### PR TITLE
Tighten up language. Fix list of build deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,47 @@
 InfluxDB [![Build Status](https://travis-ci.org/influxdb/influxdb.png?branch=master)](https://travis-ci.org/influxdb/influxdb)
 =========
 
-InfluxDB is an open source distributed time series database with no external dependencies. It's useful for metrics, events, and analytics with a built in HTTP API so you don't have to write any server side code to get up and running. InfluxDB is designed to answer queries in real-time. That means every data point is indexed as it comes in and is immediately available in queries that should return in < 100ms. It's designed to be scalabe, simple to install and manage, and fast to get data in and out.
+InfluxDB is an open source **distributed time series database** with **no external dependencies**. It's useful for recording metrics, events, and performing analytics.  
 
-Read an [overview of the design goals and reasons for the project](http://influxdb.org/overview/).
+It has a built-in HTTP API so you don't have to write any server side code to get up and running. 
 
-Check out the [getting started guide](http://influxdb.org/docs/) to read about how to install InfluxDB, start writing data, and issue queries in just a few minutes.
+InfluxDB is designed to be scalable, simple to install and manage, and fast to get data in and out.
 
-See the [list of libraries for different langauges](http://influxdb.org/docs/libraries/javascript.html). Or see the [HTTP API documentation to start writing a library for your favorite language](http://influxdb.org/docs/api/http.html).
+It aims to answer queries in real-time. That means every data point is indexed as it comes in and is immediately available in queries that should return in < 100ms. 
+
+## Quickstart
+
+* Understand the [design goals and motivations of the project](http://influxdb.org/overview/).
+* Follow the [getting started guide](http://influxdb.org/docs/) to find out how to install InfluxDB, start writing data, and issue queries - in just a few minutes.
+* See the [list of libraries for different langauges](http://influxdb.org/docs/libraries/javascript.html), or check out the [HTTP API documentation to start writing a library for your favorite language](http://influxdb.org/docs/api/http.html).
 
 ## Building
 
-### Mac OS
+### Mac OS X
 
-- install the build dependencies of the project `brew install protobuf bison flex leveldb go hg bzr`
-- Run `./test.sh`
+- Install the build dependencies of the project: 
 
-The second step should build the server and run the tests.
+``` shell 
+brew install protobuf bison flex leveldb go hg bzr
+```
 
-Note: if you're on Mac OS Mavericks, you might want to try to install go using `brew install go --devel`
+- Run `./test.sh`. This will build the server and run the tests.
+
+Note: If you are on Mac OS X Mavericks, you might want to try to install go using `brew install go --devel`
 
 ### Linux
 
-- You need to get go from [here](http://code.google.com/p/go/downloads/list)
-- Make sure go is on your PATH
-- If you're on a redhat based distro `sudo yum install hg bzr protobuf-compiler flex bison`
-- If you're on a debian based distro `sudo apt-get install hg bzr protobuf-compiler flex bison`
-- Run `./test.sh`
+- You need to [get Go from Google Code](http://code.google.com/p/go/downloads/list).
+- Ensure `go` is on your `PATH`.
+- If you're on a Red Hat-based distro: 
 
-The last step should build the server and run the tests.
+``` bash
+sudo yum install hg bzr protobuf-compiler flex bison
+```
+
+- If you're on a Debian-based distro:
+``` 
+sudo apt-get install mercurial bzr protobuf-compiler flex bison valgrind
+```
+
+- Run `./test.sh`. This will build the server and run the tests.


### PR DESCRIPTION
I've tried to make the language a bit more direct, in the hope of making it easier for newcomers to understand what the project is, and how to get up and running quickly. 

Valgrind is also needed as a build dep on Ubuntu, so I've added it to the list of dependencies. 
