### PR TITLE
return error instead of panic when type of time != float

### DIFF
--- a/src/api/http/api.go
+++ b/src/api/http/api.go
@@ -244,17 +244,22 @@ func convertToDataStoreSeries(s *SerializedSeries, precision TimePrecision) (*pr
 		for idx, field := range s.Columns {
 			value := point[idx]
 			if field == "time" {
-				_timestamp := int64(value.(float64))
-				switch precision {
-				case SecondPrecision:
-					_timestamp *= 1000
-					fallthrough
-				case MillisecondPrecision:
-					_timestamp *= 1000
-				}
+				switch value.(type) {
+					case float64:
+						_timestamp := int64(value.(float64))
+						switch precision {
+						case SecondPrecision:
+							_timestamp *= 1000
+							fallthrough
+						case MillisecondPrecision:
+							_timestamp *= 1000
+						}
 
-				timestamp = &_timestamp
-				continue
+						timestamp = &_timestamp
+						continue
+					default:
+						return nil, fmt.Errorf("time field must be float but is %T (%v)", value,value)
+				}
 			}
 
 			switch v := value.(type) {


### PR DESCRIPTION
when the time field is a string the server panics. Now a 400 is returned: "Error: time field must be float but is ..."

```
2013/11/14 23:56:26 http: panic serving 127.0.0.1:34369: interface conversion: interface is string, not float64
goroutine 14 [running]:
net/http.func·007()
    /home/vagrant/bin/go/src/pkg/net/http/server.go:1022 +0xac
api/http.convertToDataStoreSeries(0xc2001ae2c0, 0x1, 0x600, 0x6bdec0, 0xc2001c7040, ...)
    /home/vagrant/influxdb/src/api/http/api.go:247 +0x235
api/http.func·002(0xc2001536c0, 0xc20017f1b0, 0xc200191354, 0x4, 0xc2001536c0, ...)
    /home/vagrant/influxdb/src/api/http/api.go:328 +0x29d
api/http.yieldUser(0xc2001536c0, 0xc20017f1b0, 0x7f5b47fd9c20, 0xc20019134d, 0x4, ...)
    /home/vagrant/influxdb/src/api/http/api.go:479 +0x39
api/http.(*HttpServer).tryAsDbUser(0xc2000f5120, 0xc2001ae000, 0xc200152d20, 0xc2000d2d00, 0x7f5b47fd9c20, ...)
    /home/vagrant/influxdb/src/api/http/api.go:680 +0x357
api/http.(*HttpServer).writePoints(0xc2000f5120, 0xc2001ae000, 0xc200152d20, 0xc2000d2d00)
    /home/vagrant/influxdb/src/api/http/api.go:340 +0x1fb
api/http.*HttpServer.(api/http.writePoints)·fm(0xc2001ae000, 0xc200152d20, 0xc2000d2d00)
    /home/vagrant/influxdb/src/api/http/api.go:67 +0x42
api/http.func·017(0xc2001ae000, 0xc200152d20, 0xc2000d2d00)
    /home/vagrant/influxdb/src/api/http/cors.go:13 +0x17e
net/http.HandlerFunc.ServeHTTP(0xc2000d0b20, 0xc2001ae000, 0xc200152d20, 0xc2000d2d00)
    /home/vagrant/bin/go/src/pkg/net/http/server.go:1149 +0x3e
github.com/bmizerany/pat.(*PatternServeMux).ServeHTTP(0xc2000004b8, 0xc2001ae000, 0xc200152d20, 0xc2000d2d00)
    /home/vagrant/influxdb/src/github.com/bmizerany/pat/mux.go:109 +0x1a4
net/http.serverHandler.ServeHTTP(0xc20015bbe0, 0xc2001ae000, 0xc200152d20, 0xc2000d2d00)
    /home/vagrant/bin/go/src/pkg/net/http/server.go:1517 +0x16c
net/http.(*conn).serve(0xc20019b120)
    /home/vagrant/bin/go/src/pkg/net/http/server.go:1096 +0x765
created by net/http.(*Server).Serve
    /home/vagrant/bin/go/src/pkg/net/http/server.go:1564 +0x266
```
