### PR TITLE
fix typo in content-type header

### DIFF
--- a/src/api/http/api.go
+++ b/src/api/http/api.go
@@ -213,7 +213,7 @@ func (self *HttpServer) query(w libhttp.ResponseWriter, r *libhttp.Request) {
 	})
 
 	if statusCode != libhttp.StatusOK {
-		w.Header().Add("content-type", "text/plaing")
+		w.Header().Add("content-type", "text/plain")
 		w.WriteHeader(statusCode)
 		w.Write(body)
 	}


### PR DESCRIPTION
Small typo in the Content-Type header.
