### PR TITLE
make pattern for regex_string token less character-hungry

### DIFF
--- a/src/parser/query.lex
+++ b/src/parser/query.lex
@@ -61,8 +61,8 @@ static int yycolumn = 1;
 
 [0-9]*\.[0-9]+|[0-9]+\.[0-9]* { yylval->string = strdup(yytext); return FLOAT_VALUE; }
 
-\/.+\/                    { yytext[strlen(yytext)-1]='\0';yylval->string=strdup(yytext+1);return REGEX_STRING; }
-\/.+\/i                   { yytext[strlen(yytext)-2]='\0';yylval->string=strdup(yytext+1);return INSENSITIVE_REGEX_STRING; }
+\/[^/]+\/                    { yytext[strlen(yytext)-1]='\0';yylval->string=strdup(yytext+1);return REGEX_STRING; }
+\/[^/]+\/i                   { yytext[strlen(yytext)-2]='\0';yylval->string=strdup(yytext+1);return INSENSITIVE_REGEX_STRING; }
 
 [a-zA-Z0-9_]*     { yylval->string = strdup(yytext); return SIMPLE_NAME; }
 


### PR DESCRIPTION
I think this fixes queries with two regexes, like so:

```
select * from /.../ where x =~ /.../
```

The lexer would previously extract one big regex from the first to the last '/' character.

A problem that still remains is this:

```
select a/2, b/2 from x
ERROR: Error at 841508205:2713675. syntax error, unexpected REGEX_STRING, expecting FROM
```

Don't know how to fix that yet.
