### PR TITLE
Implement Continuous Queries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -148,7 +148,7 @@ ifneq ($(only),)
 	GOTEST_OPTS = -gocheck.f $(only)
 endif
 ifneq ($(verbose),off)
-	GOTEST_OPTS += -v -gocheck.v
+	GOTEST_OPTS += -v -gocheck.v -gocheck.vv
 endif
 
 test: test_dependencies parser

--- a/src/coordinator/command.go
+++ b/src/coordinator/command.go
@@ -3,6 +3,7 @@ package coordinator
 import (
 	log "code.google.com/p/log4go"
 	"github.com/goraft/raft"
+	"time"
 )
 
 var internalRaftCommands map[string]raft.Command
@@ -17,9 +18,68 @@ func init() {
 		&SaveDbUserCommand{},
 		&SaveClusterAdminCommand{},
 		&ChangeDbUserPassword{},
+		&CreateContinuousQueryCommand{},
+		&DeleteContinuousQueryCommand{},
+		&SetContinuousQueryTimestampCommand{},
 	} {
 		internalRaftCommands[command.CommandName()] = command
 	}
+}
+
+type SetContinuousQueryTimestampCommand struct {
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func NewSetContinuousQueryTimestampCommand(timestamp time.Time) *SetContinuousQueryTimestampCommand {
+	return &SetContinuousQueryTimestampCommand{timestamp}
+}
+
+func (c *SetContinuousQueryTimestampCommand) CommandName() string {
+	return "set_cq_ts"
+}
+
+func (c *SetContinuousQueryTimestampCommand) Apply(server raft.Server) (interface{}, error) {
+	config := server.Context().(*ClusterConfiguration)
+	err := config.SetContinuousQueryTimestamp(c.Timestamp)
+	return nil, err
+}
+
+type CreateContinuousQueryCommand struct {
+	Database string `json:"database"`
+	Query    string `json:"query"`
+}
+
+func NewCreateContinuousQueryCommand(database string, query string) *CreateContinuousQueryCommand {
+	return &CreateContinuousQueryCommand{database, query}
+}
+
+func (c *CreateContinuousQueryCommand) CommandName() string {
+	return "create_cq"
+}
+
+func (c *CreateContinuousQueryCommand) Apply(server raft.Server) (interface{}, error) {
+	config := server.Context().(*ClusterConfiguration)
+	err := config.CreateContinuousQuery(c.Database, c.Query)
+	return nil, err
+}
+
+type DeleteContinuousQueryCommand struct {
+	Database string `json:"database"`
+	Id       uint32 `json:"id"`
+}
+
+func NewDeleteContinuousQueryCommand(database string, id uint32) *DeleteContinuousQueryCommand {
+	return &DeleteContinuousQueryCommand{database, id}
+}
+
+func (c *DeleteContinuousQueryCommand) CommandName() string {
+	return "delete_cq"
+}
+
+func (c *DeleteContinuousQueryCommand) Apply(server raft.Server) (interface{}, error) {
+	config := server.Context().(*ClusterConfiguration)
+	err := config.DeleteContinuousQuery(c.Database, c.Id)
+	return nil, err
 }
 
 type DropDatabaseCommand struct {

--- a/src/coordinator/interface.go
+++ b/src/coordinator/interface.go
@@ -28,6 +28,9 @@ type Coordinator interface {
 	ReplicateDelete(request *protocol.Request) error
 	ReplayReplication(request *protocol.Request, replicationFactor *uint8, owningServerId *uint32, lastSeenSequenceNumber *uint64)
 	GetLastSequenceNumber(replicationFactor uint8, ownerServerId, originatingServerId uint32) (uint64, error)
+	DeleteContinuousQuery(user common.User, db string, id uint32) error
+	CreateContinuousQuery(user common.User, db string, query string) error
+	ListContinuousQueries(user common.User, db string) ([]*protocol.Series, error)
 }
 
 type UserManager interface {
@@ -61,6 +64,8 @@ type UserManager interface {
 type ClusterConsensus interface {
 	CreateDatabase(name string, replicationFactor uint8) error
 	DropDatabase(name string) error
+	CreateContinuousQuery(db string, query string) error
+	DeleteContinuousQuery(db string, id uint32) error
 	SaveClusterAdminUser(u *clusterAdmin) error
 	SaveDbUser(user *dbUser) error
 	ChangeDbUserPassword(db, username string, hash []byte) error
@@ -77,9 +82,12 @@ type ClusterConsensus interface {
 		  delete all of the data that they no longer have to keep from the ring
 	*/
 	ActivateServer(server *ClusterServer) error
+
 	// Efficient method to have a potential server take the place of a running (or downed)
 	// server. The replacement must have a state of "Potential" for this to work.
 	ReplaceServer(oldServer *ClusterServer, replacement *ClusterServer) error
+
+	AssignEngineAndCoordinator(engine queryRunner, coordinator *CoordinatorImpl) error
 
 	// When a cluster is turned on for the first time.
 	CreateRootUser() error

--- a/src/parser/frees.c
+++ b/src/parser/frees.c
@@ -99,6 +99,11 @@ free_select_query (select_query *q)
     free_groupby_clause(q->group_by);
   }
 
+  if (q->into_clause) {
+    free_value(q->into_clause->target);
+    free(q->into_clause);
+  }
+
   if (q->from_clause) {
     // free the from clause
     free_from_clause(q->from_clause);
@@ -139,6 +144,10 @@ close_query (query *q)
   if (q->drop_series_query) {
     free_drop_series_query(q->drop_series_query);
     free(q->drop_series_query);
+  }
+
+  if (q->drop_query) {
+    free(q->drop_query);
   }
 
   if (q->delete_query) {

--- a/src/parser/query.lex
+++ b/src/parser/query.lex
@@ -28,6 +28,8 @@ static int yycolumn = 1;
 "merge"                   { return MERGE; }
 "list"                    { return LIST; }
 "series"                  { return SERIES; }
+"continuous query"        { return CONTINUOUS_QUERY; }
+"continuous queries"      { return CONTINUOUS_QUERIES; }
 "inner"                   { return INNER; }
 "join"                    { return JOIN; }
 "from"                    { BEGIN(FROM_CLAUSE); return FROM; }
@@ -57,7 +59,8 @@ static int yycolumn = 1;
 "as"                      { return AS; }
 "select"                  { return SELECT; }
 "delete"                  { return DELETE; }
-"drop series"                    { return DROP_SERIES; }
+"drop series"             { return DROP_SERIES; }
+"drop"                    { return DROP; }
 "limit"                   { BEGIN(INITIAL); return LIMIT; }
 "order"                   { BEGIN(INITIAL); return ORDER; }
 "asc"                     { return ASC; }
@@ -65,6 +68,7 @@ static int yycolumn = 1;
 "desc"                    { return DESC; }
 "group"                   { BEGIN(INITIAL); return GROUP; }
 "by"                      { return BY; }
+"into"                    { return INTO; }
 "("                       { yylval->character = *yytext; return *yytext; }
 ")"                       { yylval->character = *yytext; return *yytext; }
 "+"                       { yylval->character = *yytext; return *yytext; }
@@ -90,7 +94,7 @@ static int yycolumn = 1;
 
 [a-zA-Z0-9_]*     { yylval->string = strdup(yytext); return SIMPLE_NAME; }
 
-[a-zA-Z0-9_][a-zA-Z0-9._-]*   { yylval->string = strdup(yytext); return TABLE_NAME; }
+[:a-zA-Z0-9_][a-zA-Z0-9._-]*   { yylval->string = strdup(yytext); return TABLE_NAME; }
 
 \'[^\']*\'                    {
   yytext[yyleng-1] = '\0';

--- a/src/parser/query_types.h
+++ b/src/parser/query_types.h
@@ -75,9 +75,14 @@ typedef struct {
 } from_clause;
 
 typedef struct {
+  value *target;
+} into_clause;
+
+typedef struct {
   value_array *c;
   from_clause *from_clause;
   groupby_clause *group_by;
+  into_clause *into_clause;
   condition *where_condition;
   int limit;
   char ascending;
@@ -94,10 +99,16 @@ typedef struct {
 } drop_series_query;
 
 typedef struct {
+  int id;
+} drop_query;
+
+typedef struct {
   select_query *select_query;
   delete_query *delete_query;
   drop_series_query *drop_series_query;
+  drop_query *drop_query;
   char list_series_query;
+  char list_continuous_queries_query;
   error *error;
 } query;
 

--- a/src/parser/test_memory_leaks.sh
+++ b/src/parser/test_memory_leaks.sh
@@ -45,6 +45,16 @@ int main(int argc, char **argv) {
   q = parse_query("select * from foobar limit");
   close_query(&q);
 
+  // test continuous queries
+  q = parse_query("select * from foo into bar;");
+  close_query(&q);
+
+  q = parse_query("list continuous queries;");
+  close_query(&q);
+
+  q = parse_query("drop continuous query 5;");
+  close_query(&q);
+
   return 0;
 }
 EOF

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -41,6 +41,7 @@ func NewServer(config *configuration.Configuration) (*Server, error) {
 		return nil, err
 	}
 
+	raftServer.AssignEngineAndCoordinator(eng, coord)
 	httpApi := http.NewHttpServer(config.ApiHttpPortString(), config.AdminAssetsDir, eng, coord, coord)
 	adminServer := admin.NewHttpServer(config.AdminAssetsDir, config.AdminHttpPortString())
 


### PR DESCRIPTION
Users should be able to specify queries that run constantly on the cluster that feed into another time series. Here are a few examples:

``` sql
select percentile(value, 95) 
from /stats\.*/
group by time(5m) 
into :series_name.percentiles.5m.95

select count(type) 
from events 
group by time(10m), type 
into events.count_per_type.10m
```

There should be a REST endpoint that returns which continuous queries are running on the cluster. There should be a DELETE endpoint to terminate a continuous query.
