### PR TITLE
fix #99. Return a separate time series

### DIFF
--- a/src/api/http/api_test.go
+++ b/src/api/http/api_test.go
@@ -110,7 +110,7 @@ func (self *MockCoordinator) ReplicateDelete(request *protocol.Request) error {
 	return nil
 }
 
-func (self *MockCoordinator) ListSeries(_ common.User, _ string) ([]*string, error) {
+func (self *MockCoordinator) ListSeries(_ common.User, _ string) ([]*protocol.Series, error) {
 	return nil, nil
 }
 

--- a/src/coordinator/interface.go
+++ b/src/coordinator/interface.go
@@ -22,7 +22,7 @@ type Coordinator interface {
 	DropDatabase(user common.User, db string) error
 	CreateDatabase(user common.User, db string, replicationFactor uint8) error
 	ListDatabases(user common.User) ([]*Database, error)
-	ListSeries(user common.User, database string) ([]*string, error)
+	ListSeries(user common.User, database string) ([]*protocol.Series, error)
 	ReplicateWrite(request *protocol.Request) error
 	ReplicateDelete(request *protocol.Request) error
 	ReplayReplication(request *protocol.Request, replicationFactor *uint8, owningServerId *uint32, lastSeenSequenceNumber *uint64)

--- a/src/coordinator/protobuf_request_handler.go
+++ b/src/coordinator/protobuf_request_handler.go
@@ -188,9 +188,12 @@ func (self *ProtobufRequestHandler) handleListSeries(request *protocol.Request, 
 		return nil
 	})
 
-	response := &protocol.Response{RequestId: request.Id, Type: &listSeriesResponse, Series: seriesFromListSeries(dbs)}
-	self.WriteResponse(conn, response)
-	response = &protocol.Response{RequestId: request.Id, Type: &endStreamResponse}
+	seriesArray := seriesFromListSeries(dbs)
+	for _, series := range seriesArray {
+		response := &protocol.Response{RequestId: request.Id, Type: &listSeriesResponse, Series: series}
+		self.WriteResponse(conn, response)
+	}
+	response := &protocol.Response{RequestId: request.Id, Type: &endStreamResponse}
 	self.WriteResponse(conn, response)
 }
 

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -41,28 +41,10 @@ func (self *QueryEngine) RunQuery(user common.User, database string, queryString
 			if err != nil {
 				return err
 			}
-			seriesName := "series"
-			points := make([]*protocol.Point, 0, len(series))
-			timestamp := time.Now().UnixNano() / 1000
-			sequenceNumber := uint64(1)
 			for _, s := range series {
-				points = append(points, &protocol.Point{
-					Timestamp:      &timestamp,
-					SequenceNumber: &sequenceNumber,
-					Values: []*protocol.FieldValue{
-						&protocol.FieldValue{
-							StringValue: s,
-						},
-					},
-				})
-			}
-			returnedSeries := &protocol.Series{
-				Name:   &seriesName,
-				Fields: []string{"name"},
-				Points: points,
-			}
-			if err := yield(returnedSeries); err != nil {
-				return err
+				if err := yield(s); err != nil {
+					return err
+				}
 			}
 			continue
 		}

--- a/src/engine/engine_test.go
+++ b/src/engine/engine_test.go
@@ -54,7 +54,7 @@ func (self *MockCoordinator) DeleteSeriesData(user common.User, database string,
 	return nil
 }
 
-func (self *MockCoordinator) ListSeries(_ common.User, _ string) ([]*string, error) {
+func (self *MockCoordinator) ListSeries(_ common.User, _ string) ([]*protocol.Series, error) {
 	return nil, nil
 }
 

--- a/src/integration/benchmark_test.go
+++ b/src/integration/benchmark_test.go
@@ -277,16 +277,13 @@ func (self *IntegrationSuite) TestSeriesListing(c *C) {
 	c.Assert(err, IsNil)
 	data := []*h.SerializedSeries{}
 	err = json.Unmarshal(bs, &data)
-	c.Assert(data, HasLen, 1)
-	series := data[0]
-	c.Assert(series.Columns, HasLen, 3)
-	points := toMap(series)
-	for _, p := range points {
-		if p["name"] == "test_series_listing" {
-			return
-		}
+	// the response should include {"name": "test_series_listing"}
+	// columns may or may not be empty as well as points
+	names := map[string]bool{}
+	for _, series := range data {
+		names[series.Name] = true
 	}
-	c.Fail()
+	c.Assert(names["test_series_listing"], Equals, true)
 }
 
 func (self *IntegrationSuite) TestArithmeticOperations(c *C) {

--- a/src/integration/server_test.go
+++ b/src/integration/server_test.go
@@ -268,8 +268,9 @@ func (self *ServerSuite) TestListSeries(c *C) {
 	self.serverProcesses[0].Post("/db/list_series/series?u=paul&p=pass", data, c)
 	for _, s := range self.serverProcesses {
 		collection := s.Query("list_series", "list series", false, c)
-		s := collection.GetSeries("series", c)
-		c.Assert(s.GetValueForPointAndColumn(0, "name", c), Equals, "cluster_query")
+		s := collection.GetSeries("cluster_query", c)
+		c.Assert(s.Columns, HasLen, 2)
+		c.Assert(s.Points, HasLen, 0)
 	}
 }
 


### PR DESCRIPTION
Previously we returned a single time series with the name "names" that
had one point per time series with the column "name" set to the time
series name. This patch changes the behavior of the server to return a
single time series with no points for each time series in the given db.
