### PR TITLE
Add a global lock to coordinator.handleClusterWrite

### DIFF
--- a/src/coordinator/protobuf_request_handler.go
+++ b/src/coordinator/protobuf_request_handler.go
@@ -76,7 +76,7 @@ func (self *ProtobufRequestHandler) HandleRequest(request *protocol.Request, con
 		if err != nil {
 			switch err := err.(type) {
 			case datastore.SequenceMissingRequestsError:
-				log.Warn("Missing sequence number error: %v", err)
+				log.Warn("Missing sequence number error: Request SN: %v Last Known SN: %v", request.GetSequenceNumber(), err.LastKnownRequestSequence)
 				go self.coordinator.ReplayReplication(request, &replicationFactor, request.OwnerServerId, &err.LastKnownRequestSequence)
 				return nil
 			default:

--- a/src/datastore/leveldb_datastore.go
+++ b/src/datastore/leveldb_datastore.go
@@ -475,7 +475,9 @@ func (self *LevelDbDatastore) LogRequestAndAssignSequenceNumber(request *protoco
 			return err
 		}
 		previousSequenceNumber := self.bytesToCurrentNumber(numberBytes)
-		if previousSequenceNumber+uint64(1) != *request.SequenceNumber {
+		// Do a less than comparison because it's ok if we're just getting the same write again. As long as we haven't missed one.
+		if previousSequenceNumber+uint64(1) < *request.SequenceNumber {
+			log.Warn("MISSING REQUESTS: ", previousSequenceNumber, *request.SequenceNumber)
 			return SequenceMissingRequestsError{"Missing requests between last seen and this one.", previousSequenceNumber, *request.SequenceNumber}
 		}
 	}


### PR DESCRIPTION
This ensures that requests get sent to replicas in sequence. This is an ugly ass hack that will be removed ASAP.
