### PR TITLE
Should be able to disable admin API

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -14,6 +14,7 @@ file   = "influxdb.log"         # stdout to log to standard out
 
 # Configure the admin server
 [admin]
+enabled = true                  # whether to enable the admin api or not
 port   = 8083
 assets = "./admin"
 

--- a/src/configuration/config.toml
+++ b/src/configuration/config.toml
@@ -12,6 +12,7 @@ file   = "influxdb.log"
 
 # Configure the admin server
 [admin]
+enabled = false
 port   = 8083
 assets = "./admin"
 

--- a/src/configuration/configuration.go
+++ b/src/configuration/configuration.go
@@ -10,8 +10,9 @@ import (
 )
 
 type AdminConfig struct {
-	Port   int
-	Assets string
+	Enabled bool
+	Port    int
+	Assets  string
 }
 
 type ApiConfig struct {
@@ -38,29 +39,30 @@ type LoggingConfig struct {
 }
 
 type TomlConfiguration struct {
-	Admin    AdminConfig
-	Api      ApiConfig
-	Raft     RaftConfig
-	Storage  StorageConfig
-	Cluster  ClusterConfig
-	Logging  LoggingConfig
-	Hostname string
+	Admin       AdminConfig
+	Api         ApiConfig
+	Raft        RaftConfig
+	Storage     StorageConfig
+	Cluster     ClusterConfig
+	Logging     LoggingConfig
+	Hostname    string
 	BindAddress string `toml:"bind-address"`
 }
 
 type Configuration struct {
-	AdminHttpPort  int
-	AdminAssetsDir string
-	ApiHttpPort    int
-	RaftServerPort int
-	SeedServers    []string
-	DataDir        string
-	RaftDir        string
-	ProtobufPort   int
-	Hostname       string
-	LogFile        string
-	LogLevel       string
-	BindAddress 	 string
+	AdminApiEnabled bool
+	AdminHttpPort   int
+	AdminAssetsDir  string
+	ApiHttpPort     int
+	RaftServerPort  int
+	SeedServers     []string
+	DataDir         string
+	RaftDir         string
+	ProtobufPort    int
+	Hostname        string
+	LogFile         string
+	LogLevel        string
+	BindAddress     string
 }
 
 func LoadConfiguration(fileName string) *Configuration {
@@ -84,18 +86,19 @@ func parseTomlConfiguration(filename string) (*Configuration, error) {
 	}
 
 	config := &Configuration{
-		AdminHttpPort:  tomlConfiguration.Admin.Port,
-		AdminAssetsDir: tomlConfiguration.Admin.Assets,
-		ApiHttpPort:    tomlConfiguration.Api.Port,
-		RaftServerPort: tomlConfiguration.Raft.Port,
-		RaftDir:        tomlConfiguration.Raft.Dir,
-		ProtobufPort:   tomlConfiguration.Cluster.ProtobufPort,
-		SeedServers:    tomlConfiguration.Cluster.SeedServers,
-		DataDir:        tomlConfiguration.Storage.Dir,
-		LogFile:        tomlConfiguration.Logging.File,
-		LogLevel:       tomlConfiguration.Logging.Level,
-		Hostname:       tomlConfiguration.Hostname,
-		BindAddress:    tomlConfiguration.BindAddress,
+		AdminApiEnabled: tomlConfiguration.Admin.Enabled,
+		AdminHttpPort:   tomlConfiguration.Admin.Port,
+		AdminAssetsDir:  tomlConfiguration.Admin.Assets,
+		ApiHttpPort:     tomlConfiguration.Api.Port,
+		RaftServerPort:  tomlConfiguration.Raft.Port,
+		RaftDir:         tomlConfiguration.Raft.Dir,
+		ProtobufPort:    tomlConfiguration.Cluster.ProtobufPort,
+		SeedServers:     tomlConfiguration.Cluster.SeedServers,
+		DataDir:         tomlConfiguration.Storage.Dir,
+		LogFile:         tomlConfiguration.Logging.File,
+		LogLevel:        tomlConfiguration.Logging.Level,
+		Hostname:        tomlConfiguration.Hostname,
+		BindAddress:     tomlConfiguration.BindAddress,
 	}
 
 	return config, nil

--- a/src/configuration/configuration_test.go
+++ b/src/configuration/configuration_test.go
@@ -21,6 +21,7 @@ func (self *LoadConfigurationSuite) TestConfig(c *C) {
 	c.Assert(config.LogFile, Equals, "influxdb.log")
 	c.Assert(config.LogLevel, Equals, "info")
 
+	c.Assert(config.AdminApiEnabled, Equals, false)
 	c.Assert(config.AdminAssetsDir, Equals, "./admin")
 	c.Assert(config.AdminHttpPort, Equals, 8083)
 

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -70,8 +70,12 @@ func (self *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
-	log.Info("Starting admin interface on port %d", self.Config.AdminHttpPort)
-	go self.AdminServer.ListenAndServe()
+	if !self.Config.AdminApiEnabled {
+		log.Info("Admin interface is disabled")
+	} else {
+		log.Info("Starting admin interface on port %d", self.Config.AdminHttpPort)
+		go self.AdminServer.ListenAndServe()
+	}
 	log.Info("Starting Http Api server on port %d", self.Config.ApiHttpPort)
 	self.HttpApi.ListenAndServe()
 	return nil


### PR DESCRIPTION
is there a way to completely disable the admin interface ?
if not is there a way to bind it to a specific ip address ?
