### PR TITLE
initial stab at coming up with a different default password

### DIFF
--- a/src/coordinator/raft_server.go
+++ b/src/coordinator/raft_server.go
@@ -217,9 +217,13 @@ func (s *RaftServer) CreateRootUser() error {
 	} else {
 		initRootPassword := checkAltRootPassword
 	}
-	hash, _ := hashPassword(initRootPassword)
-	u.changePassword(string(hash))
-	return s.SaveClusterAdminUser(u)
+	hash, err := hashPassword(initRootPassword)
+	if err != nil {
+		return err
+	} else {
+		u.changePassword(string(hash))
+		return s.SaveClusterAdminUser(u)
+	}
 }
 
 func (s *RaftServer) SetContinuousQueryTimestamp(timestamp time.Time) error {


### PR DESCRIPTION
First uber-naive stab at a way to init a cluster with a different root password. This is not optimal but it should make automation of installations much easier. This is for things like Chef and Puppet. Right now it's difficult to a case where you want to automate changing the root password. Given the following situation:
- install
- start cluster

Now you have two operations you need to complete:
- change root password
- add new user/database/admin user

Using chef as the example, let's assume you store a node attribute somewhere that says "yes I changed this password". During initial bootstraps, if the run fails, that node's state doesn't get saved. Now you can't get back "in" to the cluster because maybe the password changed but the rest of the initial run failed.

Also saving node state doesn't really work with Chef-solo.

The idea here is that when you start up for the first time, you can set an env var that will override the "root" password. I'm still getting the build chain up and going but I wanted to float this out there as an idea first via PR. This way the root password is a known state when the cluster is initialized and immediately usable as opposed to having to deal with changing it after the fact and having the window of a known password out there.
