### PR TITLE
Unable to query against columns with dots in their names

### DIFF
--- a/src/parser/parser_test.go
+++ b/src/parser/parser_test.go
@@ -73,6 +73,24 @@ func (self *QueryParserSuite) TestParseDeleteQueryWithEndTime(c *C) {
 	c.Assert(q.GetEndTime(), Equals, time.Unix(1389040522, 0).UTC())
 }
 
+func (self *QueryParserSuite) TestParseSelectQueryWithDotInColumnName(c *C) {
+	query := "select patient.first.name from foo"
+	queries, err := ParseQuery(query)
+	c.Assert(err, IsNil)
+
+	c.Assert(queries, HasLen, 1)
+
+	_q := queries[0]
+
+	c.Assert(_q.SelectQuery, NotNil)
+
+	q := _q.SelectQuery
+
+	for _, columns := range q.GetReferencedColumns() {
+		c.Assert(columns, DeepEquals, []string{"patient.first.name"})
+	}
+}
+
 func (self *QueryParserSuite) TestParseDropSeries(c *C) {
 	query := "drop series foobar"
 	queries, err := ParseQuery(query)

--- a/src/parser/query_api.go
+++ b/src/parser/query_api.go
@@ -158,6 +158,24 @@ func (self *SelectQuery) GetReferencedColumns() map[*Value][]string {
 		delete(mapping, name)
 	}
 
+	if len(mapping) == 0 {
+		return returnedMapping
+	}
+
+	// if `mapping` still have some mappings, then we have mistaken a
+	// column name with dots with a prefix.column, see issue #240
+	for prefix, columnNames := range mapping {
+		for _, columnName := range columnNames {
+			for table, columns := range returnedMapping {
+				if len(returnedMapping[table]) > 1 && returnedMapping[table][0] == "*" {
+					continue
+				}
+				returnedMapping[table] = append(columns, prefix+"."+columnName)
+			}
+		}
+		delete(mapping, prefix)
+	}
+
 	return returnedMapping
 }
 


### PR DESCRIPTION
There is some problem querying columns that have dots (and I guess other 'special' symbols in their names).

I've created a single point with two columns - a.1 & a.2 in a series called foo.

When I request all the data (*), I do get proper result:

curl 'http://localhost:8086/db/metrics/series?u=root&p=root&q=select+*+from+foo'

[{"name":"foo","columns":["time","sequence_number","a.1","a.2"],"points":[[1391713357450,487020001,1,2]]}]

When I request the first column (a.1) everything still looks good:

curl 'http://localhost:8086/db/metrics/series?u=root&p=root&q=select+a.1+from+foo'

[{"name":"foo","columns":["time","sequence_number","a.1"],"points":[[1391713357450,487020001,1]]}]

When I request the second column (a.2) though, unexpected stuff happens (data for a.1 is returned):

curl 'http://localhost:8086/db/metrics/series?u=root&p=root&q=select+a.2+from+foo'

[{"name":"foo","columns":["time","sequence_number","a.1"],"points":[[1391713357450,487020001,1]]}]
