### PR TITLE
LIMIT seems broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,3 +268,5 @@
 ## v0.5.0-rc.4 [unreleased]
 
 ### Bugfixes
+
+- [Issue #298](https://github.com/influxdb/influxdb/issues/298). Fix limit when querying multiple shards

--- a/src/engine/limiter.go
+++ b/src/engine/limiter.go
@@ -1,0 +1,53 @@
+package engine
+
+import (
+	"protocol"
+)
+
+type Limiter struct {
+	shouldLimit bool
+	limit       int
+	limits      map[string]int
+}
+
+func NewLimiter(limit int) *Limiter {
+	return &Limiter{
+		limit:       limit,
+		limits:      map[string]int{},
+		shouldLimit: limit > 0,
+	}
+}
+
+func (self *Limiter) calculateLimitAndSlicePoints(series *protocol.Series) {
+	if self.shouldLimit {
+		// if the limit is 0, stop returning any points
+		limit := self.limitForSeries(*series.Name)
+		defer func() { self.limits[*series.Name] = limit }()
+		if limit == 0 {
+			series.Points = nil
+			return
+		}
+		limit -= len(series.Points)
+		if limit <= 0 {
+			sliceTo := len(series.Points) + limit
+			series.Points = series.Points[0:sliceTo]
+			limit = 0
+		}
+	}
+}
+
+func (self *Limiter) hitLimit(seriesName string) bool {
+	if !self.shouldLimit {
+		return false
+	}
+	return self.limitForSeries(seriesName) <= 0
+}
+
+func (self *Limiter) limitForSeries(name string) int {
+	currentLimit, ok := self.limits[name]
+	if !ok {
+		currentLimit = self.limit
+		self.limits[name] = currentLimit
+	}
+	return currentLimit
+}


### PR DESCRIPTION
vers. 0.5-rc3

```
SELECT * FROM server_disks_1 limit 1
```

This query returns 12 results instead of one in the admin interface, "LIMIT 2" gives me 24. Same happens on other series too.

Those are the returned timestamps:

1393577978000
1393459205000
1392854405000
1392249604000
1391644808000
1391040004000
1390435202000
1390406899000
1381968002000
1381363201000
1380758405000
1380153601000

Do I get one result per shard?
