### PR TITLE
Allow to interpolate more than one column value in continuous queries

### DIFF
--- a/src/coordinator/coordinator.go
+++ b/src/coordinator/coordinator.go
@@ -397,7 +397,7 @@ func (self *CoordinatorImpl) InterpolateValuesAndCommit(db string, series *proto
 		timestamp  int64
 	}
 	sequenceMap := make(map[sequenceKey]int)
-	r, _ := regexp.Compile(`\[.*\]`)
+	r, _ := regexp.Compile(`\[.*?\]`)
 	replaceInvalidCharacters := func(r rune) rune {
 		switch {
 		case (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):


### PR DESCRIPTION
This changes the regexp used for interpolating more than one `[<column_name>]` in the result series name.

E.g.

``` sql
select * from events into events.[user].[host];
```

Originally issue: https://github.com/influxdb/influxdb/issues/265
