### PR TITLE
boolean attribute in where clause

### DIFF
--- a/src/engine/filtering.go
+++ b/src/engine/filtering.go
@@ -19,6 +19,9 @@ func getExpressionValue(values []*parser.Value, fields []string, point *protocol
 		case parser.ValueInt:
 			value, _ := strconv.ParseInt(value.Name, 10, 64)
 			fieldValues = append(fieldValues, &protocol.FieldValue{Int64Value: &value})
+		case parser.ValueBool:
+			value, _ := strconv.ParseBool(value.Name)
+			fieldValues = append(fieldValues, &protocol.FieldValue{BoolValue: &value})
 		case parser.ValueString, parser.ValueRegex:
 			fieldValues = append(fieldValues, &protocol.FieldValue{StringValue: &value.Name})
 

--- a/src/integration/benchmark_test.go
+++ b/src/integration/benchmark_test.go
@@ -1587,6 +1587,27 @@ func (self *IntegrationSuite) TestSinglePointSelectWithNullValues(c *C) {
 	}
 }
 
+func (self *IntegrationSuite) TestBooleanColumnsWorkWithWhereQuery(c *C) {
+	err := self.server.WriteData(`
+[
+  {
+    "name": "test_boolean_columns_where",
+    "columns": ["a"],
+    "points":[[true], [false], [true]]
+  }
+]`)
+	c.Assert(err, IsNil)
+
+	bs, err := self.server.RunQuery("select count(a) from test_boolean_columns_where where a = true", "m")
+	c.Assert(err, IsNil)
+	data := []*SerializedSeries{}
+	err = json.Unmarshal(bs, &data)
+	c.Assert(err, IsNil)
+	c.Assert(data, HasLen, 1)
+	c.Assert(data[0].Points, HasLen, 1)
+	c.Assert(data[0].Points[0][1], Equals, 2.0)
+}
+
 func (self *IntegrationSuite) TestColumnsWithOnlySomeValuesWorkWithWhereQuery(c *C) {
 	err := self.server.WriteData(`
 [

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -26,6 +26,7 @@ type ValueType int
 const (
 	ValueRegex        ValueType = C.VALUE_REGEX
 	ValueInt                    = C.VALUE_INT
+	ValueBool                   = C.VALUE_BOOLEAN
 	ValueFloat                  = C.VALUE_FLOAT
 	ValueString                 = C.VALUE_STRING
 	ValueIntoName               = C.VALUE_INTO_NAME

--- a/src/parser/query.lex
+++ b/src/parser/query.lex
@@ -93,6 +93,8 @@ static int yycolumn = 1;
 
 [0-9]*\.[0-9]+|[0-9]+\.[0-9]*                       { yylval->string = strdup(yytext); return FLOAT_VALUE; }
 
+true|false                                          { yylval->string = strdup(yytext); return BOOLEAN_VALUE; }
+
 [a-zA-Z0-9_]*                                       { yylval->string = strdup(yytext); return SIMPLE_NAME; }
 
 [a-zA-Z0-9_][a-zA-Z0-9._-]*                         { yylval->string = strdup(yytext); return TABLE_NAME; }

--- a/src/parser/query.yacc
+++ b/src/parser/query.yacc
@@ -75,7 +75,7 @@ value *create_expression_value(char *operator, size_t size, ...) {
 
 // define types of tokens (terminals)
 %token          SELECT DELETE FROM WHERE EQUAL GROUP BY LIMIT ORDER ASC DESC MERGE INNER JOIN AS LIST SERIES INTO CONTINUOUS_QUERIES CONTINUOUS_QUERY DROP DROP_SERIES EXPLAIN
-%token <string> STRING_VALUE INT_VALUE FLOAT_VALUE TABLE_NAME SIMPLE_NAME INTO_NAME REGEX_OP
+%token <string> STRING_VALUE INT_VALUE FLOAT_VALUE BOOLEAN_VALUE TABLE_NAME SIMPLE_NAME INTO_NAME REGEX_OP
 %token <string>  NEGATION_REGEX_OP REGEX_STRING INSENSITIVE_REGEX_STRING DURATION
 
 // define the precedence of these operators
@@ -433,6 +433,11 @@ VALUE:
         FLOAT_VALUE
         {
           $$ = create_value($1, VALUE_FLOAT, FALSE, NULL);
+        }
+        |
+        BOOLEAN_VALUE
+        {
+          $$ = create_value($1, VALUE_BOOLEAN, FALSE, NULL);
         }
         |
         DURATION_VALUE

--- a/src/parser/query_types.h
+++ b/src/parser/query_types.h
@@ -23,6 +23,7 @@ typedef struct value_t {
     VALUE_REGEX,
     VALUE_INT,
     VALUE_FLOAT,
+    VALUE_BOOLEAN,
     VALUE_STRING,
     VALUE_INTO_NAME,
     VALUE_TABLE_NAME,


### PR DESCRIPTION
This query never returns for us:

> select identifier, signed_in from events where signed_in limit 10;

Removing the WHERE clause we get an immediate result:

> select identifier, signed_in from events limit 10;

I get this in the log file (log level: info) of the server receiving the query (we have a cluster of three machines):

```
********************************BUG********************************
Database: tonne
Query: [select identifier, signed_in from events where signed_in limit 10;]
Error: runtime error: index out of range. Stacktrace: goroutine 45 [running]:
coordinator.recoverFunc(0xc210047c66, 0x5, 0xc21053f5f0, 0x42)
    /home/vagrant/influxdb/src/coordinator/coordinator.go:342 +0x106
runtime.panic(0x883480, 0x1001917)
    /home/vagrant/bin/go/src/pkg/runtime/panic.c:248 +0x106
parser.getTime(0xc2117903c0, 0xc211790300, 0x0, 0x0, 0x101a500, ...)
    /home/vagrant/influxdb/src/parser/query_api.go:384 +0xa7c
parser.parseSelectDeleteCommonQuery(0xc21053f5f0, 0x42, 0x7ff1e8015650, 0x7ff1e8015380, 0xc20fe86fc0, ...)
    /home/vagrant/influxdb/src/parser/parser.go:591 +0x1cf
parser.parseSelectQuery(0xc21053f5f0, 0x42, 0x7ff1e8013640, 0x0, 0x0, ...)
    /home/vagrant/influxdb/src/parser/parser.go:620 +0x73
parser.ParseQuery(0xc21053f5f0, 0x42, 0x0, 0x0, 0x0, ...)
    /home/vagrant/influxdb/src/parser/parser.go:529 +0x579
coordinator.(*CoordinatorImpl).RunQuery(0xc2100a4900, 0x7ff1ed6e96e0, 0xc210071b00, 0xc210047c66, 0x5, ...)
    /home/vagrant/influxdb/src/coordinator/coordinator.go:85 +0x196
api/http.func·004(0x7ff1ed6e96e0, 0xc210071b00, 0x7c66e0, 0xc211265730
```

I use the web interface, InfluxDB 0.5.1, Debian Wheezy, Amd64 architecture.
