### PR TITLE
Request should support multiple time series

### DIFF
--- a/src/api/graphite/api.go
+++ b/src/api/graphite/api.go
@@ -15,13 +15,14 @@ package graphite
 import (
 	"bufio"
 	"cluster"
-	log "code.google.com/p/log4go"
 	. "common"
 	"configuration"
 	"coordinator"
 	"net"
 	"protocol"
 	"time"
+
+	log "code.google.com/p/log4go"
 )
 
 type Server struct {
@@ -95,13 +96,14 @@ func (self *Server) Close() {
 }
 
 func (self *Server) writePoints(series *protocol.Series) error {
-	err := self.coordinator.WriteSeriesData(self.user, self.database, series)
+	serie := []*protocol.Series{series}
+	err := self.coordinator.WriteSeriesData(self.user, self.database, serie)
 	if err != nil {
 		switch err.(type) {
 		case AuthorizationError:
 			// user information got stale, get a fresh one (this should happen rarely)
 			self.getAuth()
-			err = self.coordinator.WriteSeriesData(self.user, self.database, series)
+			err = self.coordinator.WriteSeriesData(self.user, self.database, serie)
 			if err != nil {
 				log.Warn("GraphiteServer: failed to write series after getting new auth: %s\n", err.Error())
 			}

--- a/src/api/http/api.go
+++ b/src/api/http/api.go
@@ -331,6 +331,7 @@ func (self *HttpServer) writePoints(w libhttp.ResponseWriter, r *libhttp.Request
 		}
 
 		// convert the wire format to the internal representation of the time series
+		dataStoreSeries := make([]*protocol.Series, 0, len(serializedSeries))
 		for _, s := range serializedSeries {
 			if len(s.Points) == 0 {
 				continue
@@ -341,12 +342,15 @@ func (self *HttpServer) writePoints(w libhttp.ResponseWriter, r *libhttp.Request
 				return libhttp.StatusBadRequest, err.Error()
 			}
 
-			err = self.coordinator.WriteSeriesData(user, db, series)
-
-			if err != nil {
-				return errorToStatusCode(err), err.Error()
-			}
+			dataStoreSeries = append(dataStoreSeries, series)
 		}
+
+		err = self.coordinator.WriteSeriesData(user, db, dataStoreSeries)
+
+		if err != nil {
+			return errorToStatusCode(err), err.Error()
+		}
+
 		return libhttp.StatusOK, nil
 	})
 }

--- a/src/api/http/api_test.go
+++ b/src/api/http/api_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	. "launchpad.net/gocheck"
 	"net"
 	libhttp "net/http"
 	"net/url"
@@ -17,6 +16,7 @@ import (
 	"protocol"
 	"testing"
 	"time"
+	. "launchpad.net/gocheck"
 )
 
 // Hook up gocheck into the gotest runner.
@@ -101,8 +101,8 @@ type MockCoordinator struct {
 	returnedError     error
 }
 
-func (self *MockCoordinator) WriteSeriesData(_ User, db string, series *protocol.Series) error {
-	self.series = append(self.series, series)
+func (self *MockCoordinator) WriteSeriesData(_ User, db string, series []*protocol.Series) error {
+	self.series = append(self.series, series...)
 	return nil
 }
 

--- a/src/cluster/shard.go
+++ b/src/cluster/shard.go
@@ -190,7 +190,7 @@ func (self *ShardData) Write(request *p.Request) error {
 	}
 	for _, server := range self.clusterServers {
 		// we have to create a new reqeust object because the ID gets assigned on each server.
-		requestWithoutId := &p.Request{Type: request.Type, Database: request.Database, Series: request.Series, ShardId: &self.id, RequestNumber: request.RequestNumber}
+		requestWithoutId := &p.Request{Type: request.Type, Database: request.Database, MultiSeries: request.MultiSeries, ShardId: &self.id, RequestNumber: request.RequestNumber}
 		server.BufferWrite(requestWithoutId)
 	}
 	return nil

--- a/src/coordinator/client_server_test.go
+++ b/src/coordinator/client_server_test.go
@@ -3,10 +3,10 @@ package coordinator
 import (
 	"encoding/binary"
 	"fmt"
-	. "launchpad.net/gocheck"
 	"net"
 	"protocol"
 	"time"
+	. "launchpad.net/gocheck"
 )
 
 type ClientServerSuite struct{}
@@ -54,7 +54,7 @@ func (self *ClientServerSuite) TestClientCanMakeRequests(c *C) {
 	id := uint32(1)
 	database := "pauldb"
 	proxyWrite := protocol.Request_WRITE
-	request := &protocol.Request{Id: &id, Type: &proxyWrite, Database: &database, Series: series}
+	request := &protocol.Request{Id: &id, Type: &proxyWrite, Database: &database, MultiSeries: []*protocol.Series{series}}
 
 	time.Sleep(time.Second * 1)
 	err := protobufClient.MakeRequest(request, responseStream)

--- a/src/coordinator/coordinator_test.go
+++ b/src/coordinator/coordinator_test.go
@@ -629,7 +629,7 @@ func (self *CoordinatorSuite) TestCheckReadAccess(c *C) {
 	user := &MockUser{
 		dbCannotWrite: map[string]bool{"foo": true},
 	}
-	err := coordinator.WriteSeriesData(user, "foo", series)
+	err := coordinator.WriteSeriesData(user, "foo", []*protocol.Series{series})
 	c.Assert(err, ErrorMatches, ".*Insufficient permission.*")
 }
 

--- a/src/coordinator/interface.go
+++ b/src/coordinator/interface.go
@@ -16,7 +16,7 @@ type Coordinator interface {
 	//      for all the data points that are returned
 	//   4. The end of a time series is signaled by returning a series with no data points
 	//   5. TODO: Aggregation on the nodes
-	WriteSeriesData(user common.User, db string, series *protocol.Series) error
+	WriteSeriesData(user common.User, db string, series []*protocol.Series) error
 	DropDatabase(user common.User, db string) error
 	CreateDatabase(user common.User, db string, replicationFactor uint8) error
 	ForceCompaction(user common.User) error

--- a/src/datastore/leveldb_shard_datastore.go
+++ b/src/datastore/leveldb_shard_datastore.go
@@ -161,7 +161,13 @@ func (self *LevelDbShardDatastore) Write(request *protocol.Request) error {
 		return err
 	}
 	defer self.ReturnShard(*request.ShardId)
-	return shardDb.Write(*request.Database, request.Series)
+	for _, s := range request.MultiSeries {
+		err := shardDb.Write(*request.Database, s)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (self *LevelDbShardDatastore) BufferWrite(request *protocol.Request) {

--- a/src/protocol/protocol.proto
+++ b/src/protocol/protocol.proto
@@ -35,9 +35,9 @@ message Request {
   optional uint32 id = 1;
   required Type type = 2;
   required string database = 3;
-  optional Series series = 4;
   // only write and delete requests get sequenceNumbers assigned. These are used to
   // ensure that the receiving server is up to date
+  repeated Series multi_series = 4;
   optional uint64 sequence_number = 5;
   optional uint32 shard_id = 6;
   optional string query = 7;


### PR DESCRIPTION
It's more efficient to send multiple time series over the network when replicating data and when storing the data in leveldb.
