### PR TITLE
 runtime error: integer divide by zero.

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -74,6 +74,12 @@ protobuf_heartbeat = "200ms" # the heartbeat interval between the servers. must 
 # will be replayed from the WAL
 write-buffer-size = 10000
 
+# the maximum number of responses to buffer from remote nodes, if the
+# expected number of responses exceed this number then querying will
+# happen sequentially and the buffer size will be limited to this
+# number
+max-response-buffer-size = 100000
+
 # When queries get distributed out to shards, they go in parallel. This means that results can get buffered
 # in memory since results will come in any order, but have to be processed in the correct time order.
 # Setting this higher will give better performance, but you'll need more memory. Setting this to 1 will ensure

--- a/src/cluster/shard.go
+++ b/src/cluster/shard.go
@@ -59,38 +59,38 @@ const (
 )
 
 type ShardData struct {
-	id              uint32
-	startTime       time.Time
-	startMicro      int64
-	endMicro        int64
-	endTime         time.Time
-	wal             WAL
-	servers         []wal.Server
-	clusterServers  []*ClusterServer
-	store           LocalShardStore
-	serverIds       []uint32
-	shardType       ShardType
-	durationIsSplit bool
-	shardDuration   time.Duration
-	shardSeconds    int64
-	localServerId   uint32
-	IsLocal         bool
+	id               uint32
+	startTime        time.Time
+	startMicro       int64
+	endMicro         int64
+	endTime          time.Time
+	wal              WAL
+	servers          []wal.Server
+	clusterServers   []*ClusterServer
+	store            LocalShardStore
+	serverIds        []uint32
+	shardType        ShardType
+	durationIsSplit  bool
+	shardDuration    time.Duration
+	shardNanoseconds uint64
+	localServerId    uint32
+	IsLocal          bool
 }
 
 func NewShard(id uint32, startTime, endTime time.Time, shardType ShardType, durationIsSplit bool, wal WAL) *ShardData {
 	shardDuration := endTime.Sub(startTime)
 	return &ShardData{
-		id:              id,
-		startTime:       startTime,
-		endTime:         endTime,
-		wal:             wal,
-		startMicro:      common.TimeToMicroseconds(startTime),
-		endMicro:        common.TimeToMicroseconds(endTime),
-		serverIds:       make([]uint32, 0),
-		shardType:       shardType,
-		durationIsSplit: durationIsSplit,
-		shardDuration:   shardDuration,
-		shardSeconds:    int64(shardDuration.Seconds()),
+		id:               id,
+		startTime:        startTime,
+		endTime:          endTime,
+		wal:              wal,
+		startMicro:       common.TimeToMicroseconds(startTime),
+		endMicro:         common.TimeToMicroseconds(endTime),
+		serverIds:        make([]uint32, 0),
+		shardType:        shardType,
+		durationIsSplit:  durationIsSplit,
+		shardDuration:    shardDuration,
+		shardNanoseconds: uint64(shardDuration),
 	}
 }
 
@@ -358,7 +358,8 @@ func (self *ShardData) QueryResponseBufferSize(querySpec *parser.QuerySpec, batc
 		log.Info("BUFFER SIZE: 1000")
 		return 1000
 	}
-	tickCount := int(self.shardSeconds / int64(groupByTime.Seconds()))
+
+	tickCount := int(self.shardNanoseconds / uint64(*groupByTime))
 	if tickCount < 10 {
 		tickCount = 100
 	} else if tickCount > 1000 {

--- a/src/common/helpers.go
+++ b/src/common/helpers.go
@@ -10,6 +10,8 @@ import (
 	"unicode"
 )
 
+// Returns the parsed duration in nanoseconds, support 'u', 's', 'm',
+// 'h', 'd' and 'w' suffixes.
 func ParseTimeDuration(value string) (int64, error) {
 	parsedFloat, err := strconv.ParseFloat(value[:len(value)-1], 64)
 	if err != nil {

--- a/src/configuration/config.toml
+++ b/src/configuration/config.toml
@@ -71,6 +71,12 @@ protobuf_heartbeat = "200ms" # the heartbeat interval between the servers. must 
 # will be replayed from the WAL
 write-buffer-size = 10000
 
+# the maximum number of responses to buffer from remote nodes, if the
+# expected number of responses exceed this number then querying will
+# happen sequentially and the buffer size will be limited to this
+# number
+max-response-buffer-size = 5
+
 # When queries get distributed out to shards, they go in parallel. This means that results can get buffered
 # in memory since results will come in any order, but have to be processed in the correct time order. 
 # Setting this higher will give better performance, but you'll need more memory. Setting this to 1 will ensure 

--- a/src/configuration/configuration_test.go
+++ b/src/configuration/configuration_test.go
@@ -1,9 +1,9 @@
 package configuration
 
 import (
-	. "launchpad.net/gocheck"
 	"testing"
 	"time"
+	. "launchpad.net/gocheck"
 )
 
 // Hook up gocheck into the gotest runner.
@@ -54,6 +54,8 @@ func (self *LoadConfigurationSuite) TestConfig(c *C) {
 	c.Assert(config.WalBookmarkAfterRequests, Equals, 0)
 	c.Assert(config.WalIndexAfterRequests, Equals, 1000)
 	c.Assert(config.WalRequestsPerLogFile, Equals, 10000)
+
+	c.Assert(config.ClusterMaxResponseBufferSize, Equals, 5)
 }
 
 func (self *LoadConfigurationSuite) TestSizeParsing(c *C) {

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -247,8 +247,9 @@ func containsArithmeticOperators(query *parser.SelectQuery) bool {
 }
 
 func getTimestampFromPoint(window time.Duration, point *protocol.Point) int64 {
-	multiplier := int64(window / time.Microsecond)
-	return *point.GetTimestampInMicroseconds() / int64(multiplier) * int64(multiplier)
+	multiplier := uint64(window)
+	timestampNanoseconds := uint64(*point.GetTimestampInMicroseconds() * 1000)
+	return int64(timestampNanoseconds / multiplier * multiplier / 1000)
 }
 
 // Mapper given a point returns a group identifier as the first return

--- a/src/integration/benchmark_test.go
+++ b/src/integration/benchmark_test.go
@@ -274,6 +274,18 @@ func (self *IntegrationSuite) TestFilteringShouldNotStopIfAllPointsDontMatch(c *
 	c.Assert(serieses, HasLen, 1)
 }
 
+// issue #413
+func (self *IntegrationSuite) TestSmallGroupByIntervals(c *C) {
+	serieses := self.createPoints("test_small_group_by", 1, 1)
+	self.server.WriteData(serieses, c)
+	time.Sleep(time.Second)
+	serieses = self.server.RunQuery("select count(column0) from test_small_group_by group by time(10)", "m", c)
+	c.Assert(serieses, HasLen, 1)
+	c.Assert(serieses[0].Points, HasLen, 1)
+	c.Assert(serieses[0].Points[0], HasLen, 2)
+	c.Assert(serieses[0].Points[0][1], Equals, 1.0)
+}
+
 func (self *IntegrationSuite) TestExplainsWithPassthrough(c *C) {
 	data := `
   [{


### PR DESCRIPTION
After creating a lot of continues queries, I keep getting lots of "divide by zero" messages.

```
********************************BUG********************************
Database: tracking
Query: [SELECT MEDIAN(total) as total, MEDIAN(total_kB) as total_kB, MEDIAN(uptime) as uptime, MEDIAN(reqs) as reqs, MEDIAN(bytes_per_sec) as bytes_per_sec, MEDIAN(bytes_per_req) as bytes_per_req, MEDIAN(busy_workers) as busy_workers, MEDIAN(idle_workers) as idle_workers FROM /^project.(\d+)\.apache\.16.*/ GROUP BY time(1440) where time > 1396863886702460u and time < 1396863887702444u]
Error: runtime error: integer divide by zero. Stacktrace: goroutine 18 [running]:
common.RecoverFunc(0xc222cd7aa0, 0x8, 0xc212ff5000, 0x17b, 0x0)
        /home/vagrant/influxdb/src/common/recover.go:13 +0x106
runtime.panic(0x884c40, 0x1004a9d)
        /home/vagrant/bin/go/src/pkg/runtime/panic.c:248 +0x106
cluster.(*ShardData).QueryResponseBufferSize(0xc210134460, 0xc21064eaa0, 0x64, 0x0)
        /home/vagrant/influxdb/src/cluster/shard.go:361 +0x12d
coordinator.(*CoordinatorImpl).queryShards(0xc2100c88c0, 0xc21064eaa0, 0xc2209d20f0, 0x1, 0x1, ...)
        /home/vagrant/influxdb/src/coordinator/coordinator.go:374 +0x111
coordinator.(*CoordinatorImpl).runQuerySpec(0xc2100c88c0, 0xc21064eaa0, 0x7fc57c0a7678, 0xc22dd08fc8, 0x0, ...)
        /home/vagrant/influxdb/src/coordinator/coordinator.go:414 +0x440
coordinator.(*CoordinatorImpl).runQuery(0xc2100c88c0, 0xc21cf602c0, 0x7fc57c0a7620, 0xc2100d8000, 0xc222cd7aa0, ...)
        /home/vagrant/influxdb/src/coordinator/coordinator.go:146 +0xdb
coordinator.(*CoordinatorImpl).RunQuery(0xc2100c88c0, 0x7fc57c0a7620, 0xc2100d8000, 0xc222cd7aa0, 0x8, ...)
        /home/vagrant
```

I suspect the query doesn't return any data, hence some calculactions afterwards seem to fail. 
