### PR TITLE
typo in Makefile.in 'clean' target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -140,7 +140,7 @@ build: | dependencies protobuf parser build_version_string
 
 clean:
 	rm -f daemon
-	rm -f benchmakr
+	rm -f benchmark
 	rm -rf pkg/
 	rm -rf packages/
 	rm -rf src/$(levigo_dependency)


### PR DESCRIPTION
Very minor, the clean target wasn't removing `benchmark`
