### PR TITLE
Fix cluster admin listing

### DIFF
--- a/src/api/http/api.go
+++ b/src/api/http/api.go
@@ -552,7 +552,7 @@ type UpdateClusterAdminUser struct {
 }
 
 type ApiUser struct {
-	Name string `json:"username"`
+	Name string `json:"name"`
 }
 
 type UserDetail struct {


### PR DESCRIPTION
Listing cluster admins still returns a list where a 'username' field is used instead of 'user' field. This fix should not affect anything else than that presentation.
