### PR TITLE
graphite ingest write data in batches to coordinator

### DIFF
--- a/src/api/graphite/api.go
+++ b/src/api/graphite/api.go
@@ -20,6 +20,7 @@ import (
 	"coordinator"
 	"net"
 	"protocol"
+	"sync"
 	"time"
 
 	log "code.google.com/p/log4go"
@@ -32,8 +33,24 @@ type Server struct {
 	clusterConfig *cluster.ClusterConfiguration
 	conn          net.Listener
 	user          *cluster.ClusterAdmin
+	writeSeries   chan protocol.Series
 	shutdown      chan bool
 }
+
+// will commit a batch of series every commit_max_wait ms or every commit_capacity datapoints,
+// whichever is first
+// upto how many points/series to commit in 1 go?
+const commit_capacity = 40000
+
+// how long to wait max before flushing a commit payload
+// basically trade off the efficiency of a high commit_capacity with the expectation
+// to get your metrics stored in a short timeframe.
+const commit_max_wait = 100 * time.Millisecond
+
+// the write commit payload should get written in a timely fashion.
+// if not, the channel that feeds the committer will queue up to max_queue series, and then
+// block, creating backpressure to the client.
+const max_queue = 20000
 
 // TODO: check that database exists and create it if not
 func NewServer(config *configuration.Configuration, coord coordinator.Coordinator, clusterConfig *cluster.ClusterConfiguration) *Server {
@@ -41,6 +58,7 @@ func NewServer(config *configuration.Configuration, coord coordinator.Coordinato
 	self.listenAddress = config.GraphitePortString()
 	self.database = config.GraphiteDatabase
 	self.coordinator = coord
+	self.writeSeries = make(chan protocol.Series, max_queue)
 	self.shutdown = make(chan bool, 1)
 	self.clusterConfig = clusterConfig
 	return self
@@ -64,13 +82,12 @@ func (self *Server) ListenAndServe() {
 			return
 		}
 	}
+	go self.committer()
 	self.Serve(self.conn)
 }
 
 func (self *Server) Serve(listener net.Listener) {
-	// not really sure of the use of this shutdown channel,
-	// as all handling is done through goroutines. maybe we should use a waitgroup
-	defer func() { self.shutdown <- true }()
+	var wg sync.WaitGroup
 
 	for {
 		conn_in, err := listener.Accept()
@@ -78,8 +95,11 @@ func (self *Server) Serve(listener net.Listener) {
 			log.Error("GraphiteServer: Accept: ", err)
 			continue
 		}
-		go self.handleClient(conn_in)
+		wg.Add(1)
+		go self.handleClient(conn_in, wg)
 	}
+	wg.Wait()
+	close(self.writeSeries)
 }
 
 func (self *Server) Close() {
@@ -95,27 +115,58 @@ func (self *Server) Close() {
 	}
 }
 
-func (self *Server) writePoints(series *protocol.Series) error {
-	serie := []*protocol.Series{series}
-	err := self.coordinator.WriteSeriesData(self.user, self.database, serie)
-	if err != nil {
-		switch err.(type) {
-		case AuthorizationError:
-			// user information got stale, get a fresh one (this should happen rarely)
-			self.getAuth()
-			err = self.coordinator.WriteSeriesData(self.user, self.database, serie)
-			if err != nil {
-				log.Warn("GraphiteServer: failed to write series after getting new auth: %s\n", err.Error())
+func (self *Server) committer() {
+	defer func() { self.shutdown <- true }()
+
+	// the ingest could in theory be anything from 1 series(datapoint) every few minutes, upto millions of datapoints every second.
+	// and there might be multiple connections, each delivering a certain (not necessarily equal) fraction of the total.
+	// we want ingested points to be ingested quickly (let's say at least within 100ms), but since coordinator.WriteSeriesData
+	// has a bunch of overhead, we also want to buffer up the data, let's say
+	// up to about 1MiB of data, at 24B per record -> 43690 records, let's make it an even 40k
+
+	commit := func(commit_payload []*protocol.Series) {
+		err := self.coordinator.WriteSeriesData(self.user, self.database, commit_payload)
+		if err != nil {
+			switch err.(type) {
+			case AuthorizationError:
+				// user information got stale, get a fresh one (this should happen rarely)
+				self.getAuth()
+				err = self.coordinator.WriteSeriesData(self.user, self.database, commit_payload)
+				if err != nil {
+					log.Warn("GraphiteServer: failed to write series after getting new auth: %s\n", err.Error())
+				}
+			default:
+				log.Warn("GraphiteServer: failed write series: %s\n", err.Error())
 			}
-		default:
-			log.Warn("GraphiteServer: failed write series: %s\n", err.Error())
 		}
 	}
-	return err
+	commit_payload := make([]*protocol.Series, 0, commit_capacity)
+	timer := time.NewTimer(commit_max_wait)
+
+CommitLoop:
+	for {
+		select {
+		case serie, ok := <-self.writeSeries:
+			if len(commit_payload) == commit_capacity {
+				commit(commit_payload)
+				commit_payload = make([]*protocol.Series, 0, commit_capacity)
+				timer.Reset(commit_max_wait)
+				if !ok {
+					break CommitLoop
+				}
+			} else {
+				commit_payload = append(commit_payload, &serie)
+			}
+		case <-timer.C:
+			commit(commit_payload)
+			commit_payload = make([]*protocol.Series, 0, commit_capacity)
+		}
+	}
 }
 
-func (self *Server) handleClient(conn net.Conn) {
+func (self *Server) handleClient(conn net.Conn, wg sync.WaitGroup) {
 	defer conn.Close()
+	defer wg.Done()
 	reader := bufio.NewReader(conn)
 	for {
 		graphiteMetric := &GraphiteMetric{}
@@ -136,12 +187,11 @@ func (self *Server) handleClient(conn net.Conn) {
 			Values:         values,
 			SequenceNumber: &sn,
 		}
-		series := &protocol.Series{
+		series := protocol.Series{
 			Name:   &graphiteMetric.name,
 			Fields: []string{"value"},
 			Points: []*protocol.Point{point},
 		}
-		// little inefficient for now, later we might want to add multiple series in 1 writePoints request
-		self.writePoints(series)
+		self.writeSeries <- series
 	}
 }


### PR DESCRIPTION
should, in theory, be a lot more efficient. however this is very hard to gauge right now, since we have no instrumentation.
I did however run a bunchmark. it basically writes 1000 datapoints per "request" (i.e. 1000 lines in the graphite protocol for unique metric keys, with random values and timestamps), with 10 parallell connections, and for each it does this 100 times. and it measures how quick each connection completes.  I also looked in the corresponding logs.
every benchmark run is done with cleared wal and db directories, and a fresh log file.
i ran both the before and after, each twice, with similar results. so only one result is shown.

before (current implementation)

```
[dieter.plaetinck@dfvimeographite1 tomselleck]$ head -n 1000  generate_proto1_metrics.txt | ./tomselleck -addr :2003 -workers 10 -requests 100 -maxprocs 2
2014/04/15 19:02:28 {<nil>:2003 10 100 false false} 1000

Tom Selleck Reports:

Address to hit: :2003 (<nil>:2003)
 * 10 workers
 * 100 reqs per worker

Connects: 1000
ConnectsErrors: 0
BytesWritten: 43909000
BytesRead: 0
BytesReadErrors: 0
EmptyResponses: 1000
UnexpectedLengthResponses: 0

Breakdown by percentile:
Pctl       Best        Wrst
50%    58.362us   430.623us
60%   431.236us   498.763us
70%   498.821us   574.047us
80%   575.278us   667.932us
90%   669.011us    739.66us
95%   739.977us   755.701us
96%    757.85us   781.566us
97%   789.524us   914.632us
98%   915.604us  3.427624ms
99%  3.468484ms  4.615237ms
All    58.362us  4.615237ms

Total time: 43.932527ms
Reqs per sec: 22762.178
Avg req time: 397.22us
Median req time: 355.848us

```

the log file ends with

```
(...)
[04/15/14 19:11:19] [INFO] Opening log file /opt/influxdb/shared/data/wal/log.10001
[2014/04/15 19:11:19 EDT] [EROR] (api/graphite.(*Server).Serve:78) GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many 
[04/15/14 19:11:19] [EROR] GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many open files)
[2014/04/15 19:11:19 EDT] [EROR] (api/graphite.(*Server).Serve:78) GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many 
[04/15/14 19:11:19] [EROR] GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many open files)
[2014/04/15 19:11:19 EDT] [EROR] (api/graphite.(*Server).Serve:78) GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many 
[04/15/14 19:11:19] [EROR] GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many open files)
[2014/04/15 19:11:19 EDT] [EROR] (api/graphite.(*Server).Serve:78) GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many 
[2014/04/15 19:11:19 EDT] [EROR] (api/graphite.(*Server).Serve:78) GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many 
[2014/04/15 19:11:19 EDT] [EROR] (api/graphite.(*Server).Serve:78) GraphiteServer: Accept: %!(EXTRA *net.OpError=accept tcp [::]:2003: too many 
[04/15/14 19:11:19] [EROR] Cannot write bookmark open /opt/influxdb/shared/data/wal/bookmark.new: too many open files
panic: open /opt/influxdb/shared/data/wal/log.10001: too many open files

goroutine 145 [running]:
runtime.panic(0x85df00, 0xc210bffe40)
        /home/vagrant/bin/go/src/pkg/runtime/panic.c:266 +0xb6
wal.(*WAL).AssignSequenceNumbersAndLog(0xc210071d80, 0xc2119e9c00, 0x7f293c933ff8, 0xc2101121c0, 0x7f293c91de00, ...)
        /home/vagrant/influxdb/src/wal/wal.go:394 +0x10a
cluster.(*ShardData).Write(0xc2101121c0, 0xc2119e9c00, 0xc211428b70, 0x7f29282ffae8)
        /home/vagrant/influxdb/src/cluster/shard.go:183 +0x96
coordinator.(*CoordinatorImpl).write(0xc2100a4860, 0xc210099390, 0x8, 0xc211a9cb70, 0x1, ...)
        /home/vagrant/influxdb/src/coordinator/coordinator.go:634 +0xb2
coordinator.(*CoordinatorImpl).CommitSeriesData(0xc2100a4860, 0xc210099390, 0x8, 0xc211a9cb58, 0x1, ...)
        /home/vagrant/influxdb/src/coordinator/coordinator.go:622 +0x8a1
coordinator.(*CoordinatorImpl).WriteSeriesData(0xc2100a4860, 0x7f293c933f18, 0xc2100bc440, 0xc210099390, 0x8, ...)
        /home/vagrant/influxdb/src/coordinator/coordinator.go:462 +0x1d3
api/graphite.(*Server).writePoints(0xc2100467e0, 0xc2116e2140, 0x0, 0x0)
        /home/vagrant/influxdb/src/api/graphite/api.go:100 +0xf5
api/graphite.(*Server).handleClient(0xc2100467e0, 0x7f293c933e90, 0xc210135b28)
        /home/vagrant/influxdb/src/api/graphite/api.go:145 +0x482
created by api/graphite.(*Server).Serve
        /home/vagrant/influxdb/src/api/graphite/api.go:81 +0x175
```

with this code applied, the benchmark shows:
(note that the higher percentiles perform much worse. the total median is in the same order, but the bad performing ones drive up the average)

```
[dieter.plaetinck@dfvimeographite1 tomselleck]$ head -n 1000  generate_proto1_metrics.txt | ./tomselleck -addr :2003 -workers 10 -requests 100 -maxprocs 2
2014/04/15 18:57:18 {<nil>:2003 10 100 false false} 1000

Tom Selleck Reports:

Address to hit: :2003 (<nil>:2003)
 * 10 workers
 * 100 reqs per worker

Connects: 1000
ConnectsErrors: 0
BytesWritten: 43909000
BytesRead: 0
BytesReadErrors: 0
EmptyResponses: 1000
UnexpectedLengthResponses: 0

Breakdown by percentile:
Pctl       Best        Wrst
50%    55.122us   438.014us
60%   438.227us   498.452us
70%   499.385us   559.652us
80%   559.988us   668.483us
90%   670.838us  1.175131ms
95%2.999352913s2.999781967s
96%2.999783397s2.999955982s
97%2.999960642s3.000136881s
98%3.000152211s3.000300858s
99%3.000318443s3.000749172s
All    55.122us3.000749172s

Total time: 15.03814515s
Reqs per sec: 66.498
Avg req time: 150.364459ms
Median req time: 405.253us

```

and the log shows EOF's (but no panic like before ;-)

```
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [EROR] EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [EROR] EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [EROR] EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [INFO] Opening log file /opt/influxdb/shared/data/wal/log.1
[2014/04/15 19:15:56 EDT] [INFO] (wal.(*WAL).openLog:360) Opening log file /opt/influxdb/shared/data/wal/log.1
[04/15/14 19:15:56] [INFO] Opening index file /opt/influxdb/shared/data/wal/index.1
[2014/04/15 19:15:56 EDT] [INFO] (wal.(*WAL).openLog:374) Opening index file /opt/influxdb/shared/data/wal/index.1
[04/15/14 19:15:56] [EROR] EOF
[04/15/14 19:15:56] [EROR] EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [EROR] EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [EROR] EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [EROR] EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [EROR] EOF
[2014/04/15 19:15:56 EDT] [EROR] (api/graphite.(*Server).handleClient:175) EOF
[04/15/14 19:15:56] [EROR] EOF
```

i haven't really analyzed this much yet.  go makes it easy to add cpu and memory profiling  (see for example https://github.com/vimeo/statsdaemon/blob/master/statsdaemon.go#L553-568) so I could add that, and see what's going on. once we have a facility in the code base to track metrics i could instrument the graphite stuff and `coordinator.WriteSeriesData`
