### PR TITLE
Deleting from capitalized time-series doesn't work

### DIFF
--- a/src/cluster/cluster_configuration.go
+++ b/src/cluster/cluster_configuration.go
@@ -718,14 +718,6 @@ func (self *ClusterConfiguration) GetShards(querySpec *parser.QuerySpec) []*Shar
 	self.shardsByIdLock.RLock()
 	defer self.shardsByIdLock.RUnlock()
 
-	if querySpec.IsDropSeriesQuery() {
-		seriesName := querySpec.Query().DropSeriesQuery.GetTableName()
-		if seriesName[0] < FIRST_LOWER_CASE_CHARACTER {
-			return self.longTermShards
-		}
-		return self.shortTermShards
-	}
-
 	shouldQueryShortTerm, shouldQueryLongTerm := querySpec.ShouldQueryShortTermAndLongTerm()
 
 	if shouldQueryLongTerm && shouldQueryShortTerm {

--- a/src/integration/single_server_test.go
+++ b/src/integration/single_server_test.go
@@ -60,6 +60,22 @@ func (self *SingleServerSuite) TestLargeDeletes(c *C) {
 	c.Assert(data, HasLen, 0)
 }
 
+func (self *SingleServerSuite) TestDeletesFromCapitalNames(c *C) {
+	data := CreatePoints("TestLargeDeletes", 1, 1)
+	self.server.WriteData(data, c)
+	data = self.server.RunQuery("select count(column0) from TestLargeDeletes", "m", c)
+	c.Assert(data, HasLen, 1)
+	c.Assert(data[0].Points, HasLen, 1)
+	c.Assert(data[0].Points[0][1], Equals, 1.0)
+
+	query := "delete from TestLargeDeletes"
+	_ = self.server.RunQuery(query, "m", c)
+
+	// this shouldn't return any data
+	data = self.server.RunQuery("select count(column0) from TestLargeDeletes", "m", c)
+	c.Assert(data, HasLen, 0)
+}
+
 func (self *SingleServerSuite) TestSslOnly(c *C) {
 	self.server.Stop()
 	// TODO: don't hard code the path here

--- a/src/parser/query_spec.go
+++ b/src/parser/query_spec.go
@@ -81,8 +81,15 @@ func (self *QuerySpec) SeriesValuesAndColumns() map[*Value][]string {
 	}
 	if self.query.SelectQuery != nil {
 		self.seriesValuesAndColumns = self.query.SelectQuery.GetReferencedColumns()
-	} else {
+	} else if self.query.DeleteQuery != nil {
 		self.seriesValuesAndColumns = make(map[*Value][]string)
+		for _, name := range self.query.DeleteQuery.GetFromClause().Names {
+			self.seriesValuesAndColumns[name.Name] = nil
+		}
+	} else if self.query.DropSeriesQuery != nil {
+		self.seriesValuesAndColumns = make(map[*Value][]string)
+		value := &Value{Name: self.query.DropSeriesQuery.GetTableName()}
+		self.seriesValuesAndColumns[value] = nil
 	}
 	return self.seriesValuesAndColumns
 }


### PR DESCRIPTION
Steps to reproduce:
1. Insert a data point into a time-series named `Test` (note the capital letter)
2. Execute `SELECT * FROM Test` to confirm the data point got written
3. Execute `DELETE FROM Test`
4. Execute `SELECT * FROM Test` again. Notice that the point is still there.

At the same time `DROP SERIES Test` **does** work.
