### PR TITLE
update makefile to add support for arm builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,7 +3,7 @@ SHELL = /bin/bash
 PROTOC = @PROTOC@
 GO     = @GO@
 GOROOT = @GOROOT@
-# or 386
+# or 386, arm
 arch   = amd64
 CGO_ENABLED = 1
 
@@ -15,6 +15,23 @@ cflags =
 ifeq ($(arch),386)
 	cflags = -m32
 	GOARCH = $(arch)
+endif
+
+ifneq ($(CROSS_COMPILE),)
+export CXX=$(CROSS_COMPILE)-g++
+export CC=$(CROSS_COMPILE)-gcc
+export AS=$(CROSS_COMPILE)-as
+export AR=$(CROSS_COMPILE)-ar
+export NM=$(CROSS_COMPILE)-nm
+export LD=$(CROSS_COMPILE)-ld
+export OBJDUMP=$(CROSS_COMPILE)-objdump
+export OBJCOPY=$(CROSS_COMPILE)-objcopy
+export RANLIB=$(CROSS_COMPILE)-ranlib
+export STRIP=$(CROSS_COMPILE)-strip
+export CXX_FOR_TARGET=$(CROSS_COMPILE)-g++
+export CC_FOR_TARGET=$(CROSS_COMPILE)-gcc
+GO_BUILD_OPTIONS += -ldflags="-extld=$(CC)"
+cross_flags = --host=$(arch)
 endif
 
 export GOARCH
@@ -55,7 +72,7 @@ leveldb_deps    = $(leveldb_dir)/libleveldb.a
 profile=off
 ifneq ($(profile),off)
 CGO_LDFLAGS += -ltcmalloc -lprofiler
-GO_BUILD_OPTIONS = -tags profile
+GO_BUILD_OPTIONS += -tags profile
 endif
 
 # levigo flags
@@ -81,7 +98,7 @@ ifeq ($(uname_S),Linux)
 	bash -c "cd $(snappy_dir); \
 	wget https://snappy.googlecode.com/files/$(snappy_file); \
 	tar --strip-components=1 -xvzf $(snappy_file); \
-	CFLAGS=$(cflags) CXXFLAGS=$(cflags) ./configure; \
+	CFLAGS=$(cflags) CXXFLAGS=$(cflags) ./configure $(cross_flags); \
 	$(MAKE)"
 endif
 
@@ -186,6 +203,11 @@ ifeq ($(arch),386)
 	debian_package = packages/influxdb_$(version)_i386.deb
 	rpm_args = setarch i386
 	deb_args = -a i386
+else ifeq ($(arch),arm)
+	rpm_package = packages/influxdb-$(package_version)-1.armv6hl.rpm
+	debian_package = packages/influxdb_$(version)_armhf.deb
+	rpm_args = setarch armv6hl
+	deb_args = -a armhf
 else
 	rpm_package = packages/influxdb-$(package_version)-1.x86_64.rpm
 	debian_package = packages/influxdb_$(version)_amd64.deb


### PR DESCRIPTION
I needed to update the makefile with this patch to be able to cross-compile influxdb to ARM architecture and to generate a package for the cubieboard arm board (should be the same for a raspberry pi).
