### PR TITLE
udp json listener

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -35,6 +35,11 @@ read-timeout = "5s"
   enabled = false
   # port = 2003
   # database = ""  # store graphite data in this database
+  
+  [input_plugins.udp]
+  enabled = true
+  port = 4444
+  database = "test"
 
 # Raft configuration
 [raft]

--- a/src/api/udp/api.go
+++ b/src/api/udp/api.go
@@ -1,0 +1,104 @@
+package udp
+
+import (
+  "cluster"
+  log "code.google.com/p/log4go"
+  . "common"
+  "configuration"
+  "coordinator"
+  "net"
+  "encoding/json"
+  "protocol"
+)
+
+type Server struct {
+  listenAddress string
+  database      string
+  coordinator   coordinator.Coordinator
+  clusterConfig *cluster.ClusterConfiguration
+  conn          *net.UDPConn
+  user          *cluster.ClusterAdmin
+  shutdown      chan bool
+}
+
+func NewServer(config *configuration.Configuration, coord coordinator.Coordinator, clusterConfig *cluster.ClusterConfiguration) *Server {
+  self := &Server{}
+  
+  self.listenAddress = config.UdpInputPortString()
+  self.database = config.UdpInputDatabase
+  self.coordinator = coord
+  self.shutdown = make(chan bool, 1)
+  self.clusterConfig = clusterConfig
+  
+  return self
+}
+
+func (self *Server) getAuth() {
+  // just use any (the first) of the list of admins.
+  names := self.clusterConfig.GetClusterAdmins()
+  self.user = self.clusterConfig.GetClusterAdmin(names[0])
+}
+
+
+func (self *Server) ListenAndServe() {
+  var err error
+  
+  self.getAuth()
+  
+  addr, err := net.ResolveUDPAddr("udp4", self.listenAddress)
+  if err != nil {
+    log.Error("UDPServer: ResolveUDPAddr: ", err)
+    return
+  }
+
+  
+  if self.listenAddress != "" {
+    self.conn, err = net.ListenUDP("udp", addr)
+    if err != nil {
+      log.Error("UDPServer: Listen: ", err)
+      return
+    }
+  }
+  defer self.conn.Close()
+  self.HandleSocket(self.conn)
+}
+
+func (self *Server) HandleSocket(socket *net.UDPConn) {
+  buffer := make([]byte, 2048)
+  
+  for {
+    n, _, err := socket.ReadFromUDP(buffer)
+    if err != nil || n == 0 {
+      log.Error("UDP ReadFromUDP error: %s", err)
+      continue
+    }
+    
+    serializedSeries := []*SerializedSeries{}
+    err = json.Unmarshal(buffer[0:n], &serializedSeries)
+    if err != nil {
+      log.Error("UDP json error: %s", err)
+      continue
+    }
+    
+    for _, s := range serializedSeries {
+      if len(s.Points) == 0 {
+        continue
+      }
+
+      series, err := ConvertToDataStoreSeries(s, SecondPrecision)
+      if err != nil {
+        log.Error("UDP cannot convert received data: %s", err)
+        continue
+      }
+      
+      serie := []*protocol.Series{series}
+      err = self.coordinator.WriteSeriesData(self.user, "test", serie)
+      if err != nil {
+        log.Error("UDP cannot write data: %s", err)
+        continue
+      }
+    }
+
+  }
+  
+}

--- a/src/configuration/configuration.go
+++ b/src/configuration/configuration.go
@@ -72,6 +72,11 @@ type GraphiteConfig struct {
 	Port     int
 	Database string
 }
+type UdpInputConfig struct {
+	Enabled  bool
+	Port     int
+	Database string
+}
 
 type RaftConfig struct {
 	Port    int
@@ -171,6 +176,7 @@ type WalConfig struct {
 
 type InputPlugins struct {
 	Graphite GraphiteConfig `toml:"graphite"`
+	UdpInput UdpInputConfig `toml:"udp"`
 }
 
 type TomlConfiguration struct {
@@ -195,9 +201,15 @@ type Configuration struct {
 	ApiHttpCertPath              string
 	ApiHttpPort                  int
 	ApiReadTimeout               time.Duration
+	
 	GraphiteEnabled              bool
 	GraphitePort                 int
 	GraphiteDatabase             string
+	
+	UdpInputEnabled 						 bool
+	UdpInputPort								 int
+	UdpInputDatabase 						 string
+	
 	RaftServerPort               int
 	RaftTimeout                  duration
 	SeedServers                  []string
@@ -300,9 +312,15 @@ func parseTomlConfiguration(filename string) (*Configuration, error) {
 		ApiHttpCertPath:              tomlConfiguration.HttpApi.SslCertPath,
 		ApiHttpSslPort:               tomlConfiguration.HttpApi.SslPort,
 		ApiReadTimeout:               apiReadTimeout,
+		
 		GraphiteEnabled:              tomlConfiguration.InputPlugins.Graphite.Enabled,
 		GraphitePort:                 tomlConfiguration.InputPlugins.Graphite.Port,
 		GraphiteDatabase:             tomlConfiguration.InputPlugins.Graphite.Database,
+		
+		UdpInputEnabled:              tomlConfiguration.InputPlugins.UdpInput.Enabled,
+		UdpInputPort:                 tomlConfiguration.InputPlugins.UdpInput.Port,
+		UdpInputDatabase:             tomlConfiguration.InputPlugins.UdpInput.Database,
+		
 		RaftServerPort:               tomlConfiguration.Raft.Port,
 		RaftTimeout:                  tomlConfiguration.Raft.Timeout,
 		RaftDir:                      tomlConfiguration.Raft.Dir,
@@ -408,6 +426,18 @@ func (self *Configuration) GraphitePortString() string {
 	}
 
 	return fmt.Sprintf("%s:%d", self.BindAddress, self.GraphitePort)
+}
+
+func (self *Configuration) UdpInputPortString() string {
+	if self.UdpInputPort <= 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("%s:%d", self.BindAddress, self.UdpInputPort)
+}
+
+func (self *Configuration) ProtobufPortString() string {
+	return fmt.Sprintf("%s:%d", self.BindAddress, self.ProtobufPort)
 }
 
 func (self *Configuration) HostnameOrDetect() string {


### PR DESCRIPTION
(This is not ready to be merged as is)

I want something lighter than http for sending data to my influxdb and since my influxdb server and the producer are both on the same host I started with this simple listener which take UDP packets in with the standard json used for the http listener.

I want to know if this could be merged before working more on it (it may be simple but since I don't know much of go so it took me some time to even reach that point), it should works for simple use cases:
- I don't care about lost packets (looks like this can still happen even on loopback interfaces if packets are sent too quickly)
- packets misorder should not be an issue
- I think there is no limit on datagram size on loopback interface but I cant' find any evidence of this, does anyone know ?

So far this works but there is no config part and I still need a way to tell in which series the data will be written (currently hardcoded).

So.. what do you think ? Could it be merged ? (if I add the missing part namely the config and a way to tell which serie to write to)

(This interface is only meant to write data, obviously)
