### PR TITLE
Alter MODE to work on all datatypes and return multiple values

### DIFF
--- a/src/engine/aggregator.go
+++ b/src/engine/aggregator.go
@@ -886,11 +886,11 @@ func (self *ModeAggregator) GetValues(state interface{}) [][]*protocol.FieldValu
 	}
 	sort.Ints(counts)
 
-	// move this to a state param
 	returnValues := [][]*protocol.FieldValue{}
 	
 	last := 0
 	for i := len(counts); i > 0; i-- {
+		// counts can contain duplicates, but we only want to append each count-set once
 		count := counts[i - 1]
 		if count == last {
 			continue
@@ -909,6 +909,7 @@ func (self *ModeAggregator) GetValues(state interface{}) [][]*protocol.FieldValu
 					returnValues = append(returnValues, []*protocol.FieldValue{&protocol.FieldValue{DoubleValue: &v}})
 			}
 		}
+		// size is really "minimum size"
 		if len(returnValues) >= self.size {
 			break
 		}		


### PR DESCRIPTION
This alteration allows MODE to be used to get, for example, the "10 most common strings" in a dataset.

I've never written in Go before, so if I've made some silly choices let me know!

I assume it needs some tests attached, although I'm not sure how to write these.
