### PR TITLE
WAL replay hangs if the response wasn't received

### DIFF
--- a/src/server/server.go
+++ b/src/server/server.go
@@ -111,6 +111,7 @@ func (self *Server) ListenAndServe() error {
 		if err != nil {
 			panic(err)
 		}
+		log.Info("Connection string changed successfully")
 	}
 
 	go self.ProtobufServer.ListenAndServe()


### PR DESCRIPTION
The way the WAL works is by sequentially and synchronously sending write requests to other nodes using `ClusterServer.MakeRequest`. `MakeRequest` is inherently problematic, since it will block indefinitely waiting for the response, if the response wasn't received `MakeRequest` will never return. In the case of the WAL, that means replication will stop completely until the server is bounced.
