### PR TITLE
graphite api: add support for sending metrics over UDP

### DIFF
--- a/src/configuration/configuration.go
+++ b/src/configuration/configuration.go
@@ -68,9 +68,10 @@ type ApiConfig struct {
 }
 
 type GraphiteConfig struct {
-	Enabled  bool
-	Port     int
-	Database string
+	Enabled    bool
+	Port       int
+	Database   string
+	UdpEnabled bool    `toml:"udp_enabled"`
 }
 type UdpInputConfig struct {
 	Enabled  bool
@@ -202,9 +203,10 @@ type Configuration struct {
 	ApiHttpPort     int
 	ApiReadTimeout  time.Duration
 
-	GraphiteEnabled  bool
-	GraphitePort     int
-	GraphiteDatabase string
+	GraphiteEnabled    bool
+	GraphitePort       int
+	GraphiteDatabase   string
+	GraphiteUdpEnabled bool
 
 	UdpInputEnabled  bool
 	UdpInputPort     int
@@ -314,9 +316,10 @@ func parseTomlConfiguration(filename string) (*Configuration, error) {
 		ApiHttpSslPort:  tomlConfiguration.HttpApi.SslPort,
 		ApiReadTimeout:  apiReadTimeout,
 
-		GraphiteEnabled:  tomlConfiguration.InputPlugins.Graphite.Enabled,
-		GraphitePort:     tomlConfiguration.InputPlugins.Graphite.Port,
-		GraphiteDatabase: tomlConfiguration.InputPlugins.Graphite.Database,
+		GraphiteEnabled:    tomlConfiguration.InputPlugins.Graphite.Enabled,
+		GraphitePort:       tomlConfiguration.InputPlugins.Graphite.Port,
+		GraphiteDatabase:   tomlConfiguration.InputPlugins.Graphite.Database,
+		GraphiteUdpEnabled: tomlConfiguration.InputPlugins.Graphite.UdpEnabled,
 
 		UdpInputEnabled:  tomlConfiguration.InputPlugins.UdpInput.Enabled,
 		UdpInputPort:     tomlConfiguration.InputPlugins.UdpInput.Port,

--- a/src/integration/test_config1.toml
+++ b/src/integration/test_config1.toml
@@ -28,6 +28,7 @@ ssl-cert = "./cert.pem"
   enabled = true
   port = 60513
   database = "graphite_db"  # store graphite data in this database
+  udp_enabled = true
 
   [input_plugins.udp]
   enabled = true


### PR DESCRIPTION
There already exists an API for sending metrics to InfluxDB over TCP using
Graphite plaintext protocol. Sometimes it is more convenient to send metrics
over UDP, so adding that support for the Graphite as well. For now at least,
using the same port for UDP traffic than for TCP to make configuration really
simple.

UDP listener is disabled by default, but can be turned on by setting udp_enabled
to true in graphite plugin configuration.

There are already quite a few libraries and other solutions supporting Graphite UDP API, so this makes starting use of InfluxDB easier. One particular case where this is useful is when using StatsD as it natively supports using Graphite as the metrics backend, but it uses UDP to send metrics. This change should make InfluxDB a drop-in replacement for Graphite as StatsD backend.
