### PR TITLE
fixed missing queryString assignment

### DIFF
--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -556,6 +556,7 @@ func ParseQuery(query string) ([]*Query, error) {
 			lastLine:    int(q.error.last_line),
 			lastColumn:  int(q.error.last_column) - 1,
 			errorString: str,
+			queryString: query,
 		}
 	}
 

--- a/src/parser/parser_test.go
+++ b/src/parser/parser_test.go
@@ -911,6 +911,13 @@ func (self *QueryParserSuite) TestParseColumnWithPeriodOrDash(c *C) {
 	c.Assert(column.Alias, Equals, "count-column-a.foo")
 }
 
+func (self *QueryParserSuite) TestQueryErrorShouldHaveQueryString(c *C) {
+	query := "select ! from foo;"
+	_, err := ParseSelectQuery(query)
+	e, _ := err.(*QueryError)
+	c.Assert(e.queryString, Equals, query)
+}
+
 // TODO:
 // insert into user.events.count.per_day select count(*) from user.events where time<forever group by time(1d)
 // insert into :series_name.percentiles.95 select percentile(95,value) from stats.* where time<forever group by time(1d)


### PR DESCRIPTION
I've noticed http api returns strange error message when I send wrong query.

```
syntax error, unexpected ')'

        ^
```

this pull request improve it.
