### PR TITLE
parentheses value should support alias #496

### DIFF
--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -615,7 +615,11 @@ func (self *QueryEngine) executeArithmeticQuery(query *parser.SelectQuery, yield
 		case parser.ValueFunctionCall:
 			names[v.Name] = v
 		case parser.ValueExpression:
-			names["expr"+strconv.Itoa(idx)] = v
+			if v.Alias != "" {
+				names[v.Alias] = v
+			} else {
+				names["expr"+strconv.Itoa(idx)] = v
+			}
 		}
 	}
 

--- a/src/parser/parser_test.go
+++ b/src/parser/parser_test.go
@@ -930,6 +930,33 @@ func (self *QueryParserSuite) TestQueryErrorShouldHaveQueryString(c *C) {
 	c.Assert(e.queryString, Equals, query)
 }
 
+// For issue #496 - parentheses value should support alias https://github.com/influxdb/influxdb/issues/496
+func (self *QueryParserSuite) TestQueryParenthesesValueShouldSupportAlias(c *C) {
+	query := "select (1 + 2) as arithmetic_result from foo;"
+	q, err := ParseSelectQuery(query)
+
+	c.Assert(err, IsNil)
+	c.Assert(q.GetColumnNames(), HasLen, 1)
+	column := q.GetColumnNames()[0]
+	c.Assert(column.Elems, HasLen, 2)
+	c.Assert(column.Alias, Equals, "arithmetic_result")
+}
+
+func (self *QueryParserSuite) TestQueryParenthesesValueShouldSupportAliases(c *C) {
+	query := "select (1 + 2) as arithmetic_result, (3 + 4) as arithmetic_result2 from foo;"
+	q, err := ParseSelectQuery(query)
+
+	c.Assert(err, IsNil)
+	c.Assert(q.GetColumnNames(), HasLen, 2)
+	column := q.GetColumnNames()[0]
+	c.Assert(column.Elems, HasLen, 2)
+	c.Assert(column.Alias, Equals, "arithmetic_result")
+
+	column2 := q.GetColumnNames()[1]
+	c.Assert(column2.Elems, HasLen, 2)
+	c.Assert(column2.Alias, Equals, "arithmetic_result2")
+}
+
 // TODO:
 // insert into user.events.count.per_day select count(*) from user.events where time<forever group by time(1d)
 // insert into :series_name.percentiles.95 select percentile(95,value) from stats.* where time<forever group by time(1d)

--- a/src/parser/query.yacc
+++ b/src/parser/query.yacc
@@ -515,6 +515,12 @@ VALUE:
           $$ = $2;
         }
         |
+        '(' VALUE ')' AS SIMPLE_NAME
+        {
+          $$ = $2;
+          $$->alias = $5;
+        }
+        |
         FUNCTION_CALL AS SIMPLE_NAME
         {
           $$ = $1;


### PR DESCRIPTION
This patch support alias for parentheses value.

e.g)
select (1 + 2) as v from access

Currently, parentheses are mandatory.
