### PR TITLE
Add support for multiple UDP + JSON input plugins

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -42,6 +42,16 @@ read-timeout = "5s"
   # port = 4444
   # database = ""
 
+  [[input_plugins.udp_servers]] # array of tables
+  enabled = false
+  # port = 5551
+  # database = "db1"
+
+  [[input_plugins.udp_servers]] # array of tables
+  enabled = false
+  # port = 5552
+  # database = "db2"
+
 # Raft configuration
 [raft]
 # The raft port should be open between all servers in a cluster.

--- a/src/api/udp/api.go
+++ b/src/api/udp/api.go
@@ -3,7 +3,6 @@ package udp
 import (
 	"cluster"
 	. "common"
-	"configuration"
 	"coordinator"
 	"encoding/json"
 	"net"
@@ -22,11 +21,11 @@ type Server struct {
 	shutdown      chan bool
 }
 
-func NewServer(config *configuration.Configuration, coord coordinator.Coordinator, clusterConfig *cluster.ClusterConfiguration) *Server {
+func NewServer(listenAddress string, database string, coord coordinator.Coordinator, clusterConfig *cluster.ClusterConfiguration) *Server {
 	self := &Server{}
 
-	self.listenAddress = config.UdpInputPortString()
-	self.database = config.UdpInputDatabase
+	self.listenAddress = listenAddress
+	self.database = database
 	self.coordinator = coord
 	self.shutdown = make(chan bool, 1)
 	self.clusterConfig = clusterConfig

--- a/src/configuration/configuration.go
+++ b/src/configuration/configuration.go
@@ -183,8 +183,9 @@ type WalConfig struct {
 }
 
 type InputPlugins struct {
-	Graphite GraphiteConfig `toml:"graphite"`
-	UdpInput UdpInputConfig `toml:"udp"`
+	Graphite GraphiteConfig          `toml:"graphite"`
+	UdpInput UdpInputConfig          `toml:"udp"`
+	UdpServersInput []UdpInputConfig `toml:"udp_servers"`
 }
 
 type TomlConfiguration struct {
@@ -218,6 +219,7 @@ type Configuration struct {
 	UdpInputEnabled  bool
 	UdpInputPort     int
 	UdpInputDatabase string
+	UdpServers       []UdpInputConfig
 
 	RaftServerPort               int
 	RaftTimeout                  duration
@@ -332,6 +334,7 @@ func parseTomlConfiguration(filename string) (*Configuration, error) {
 		UdpInputEnabled:  tomlConfiguration.InputPlugins.UdpInput.Enabled,
 		UdpInputPort:     tomlConfiguration.InputPlugins.UdpInput.Port,
 		UdpInputDatabase: tomlConfiguration.InputPlugins.UdpInput.Database,
+		UdpServers:       tomlConfiguration.InputPlugins.UdpServersInput,
 
 		RaftServerPort:               tomlConfiguration.Raft.Port,
 		RaftTimeout:                  tomlConfiguration.Raft.Timeout,
@@ -446,12 +449,12 @@ func (self *Configuration) GraphitePortString() string {
 	return fmt.Sprintf("%s:%d", self.BindAddress, self.GraphitePort)
 }
 
-func (self *Configuration) UdpInputPortString() string {
-	if self.UdpInputPort <= 0 {
+func (self *Configuration) UdpInputPortString(port int) string {
+	if port <= 0 {
 		return ""
 	}
 
-	return fmt.Sprintf("%s:%d", self.BindAddress, self.UdpInputPort)
+	return fmt.Sprintf("%s:%d", self.BindAddress, port)
 }
 
 func (self *Configuration) HostnameOrDetect() string {


### PR DESCRIPTION
Support comes by way of [[input_plugins.udp_servers]] in config.
A single port will map to a single database.
- Update sample config to include [[input_plugins.udp_servers]] example
- Change configuration.Configuration to hold config for array of udp servers
- Change configuration.UdpInputPortString to accept a port int
- Modify udp.NewServer to accept listenAddress string, database string
- Modify server.Server struct to hold an array of udp.Server
- Modify server.NewServer to not create any udp.Server
- Update server.ListenAndServe to check and instantiate all instances of udp.Server
