### PR TITLE
If you're going to make a channel, make the request

### DIFF
--- a/src/cluster/cluster_server.go
+++ b/src/cluster/cluster_server.go
@@ -135,16 +135,15 @@ func (self *ClusterServer) heartbeat() {
 		self.heartbeatStarted = false
 	}()
 
-	heartbeatRequest := &protocol.Request{
-		Type:     &HEARTBEAT_TYPE,
-		Database: protocol.String(""),
-	}
 	for {
 		// this chan is buffered and in the loop on purpose. This is so
 		// that if reading a heartbeat times out, and the heartbeat then comes through
 		// later, it will be dumped into this chan and not block the protobuf client reader.
 		responseChan := make(chan *protocol.Response, 1)
-		heartbeatRequest.Id = nil
+		heartbeatRequest := &protocol.Request{
+			Type:     &HEARTBEAT_TYPE,
+			Database: protocol.String(""),
+		}
 		self.MakeRequest(heartbeatRequest, responseChan)
 		err := self.getHeartbeatResponse(responseChan)
 		if err != nil {


### PR DESCRIPTION
There is something strange going on wrt timing and stuff in heartbeats.

This _seems_ to make the problems less frequent when running the tests 
locally, but it doesn't solve the issue.

This is really here for comment.
