### PR TITLE
add leader election wait configuration.

### DIFF
--- a/src/configuration/configuration.go
+++ b/src/configuration/configuration.go
@@ -203,6 +203,7 @@ type TomlConfiguration struct {
 	ReportingDisabled bool               `toml:"reporting-disabled"`
 	Sharding          ShardingDefinition `toml:"sharding"`
 	WalConfig         WalConfig          `toml:"wal"`
+	LeaderElectionWait duration          `toml:"leader-election-wait"`
 }
 
 type Configuration struct {
@@ -234,6 +235,7 @@ type Configuration struct {
 	LogFile                      string
 	LogLevel                     string
 	BindAddress                  string
+	LeaderElectionWait           duration
 	LevelDbMaxOpenFiles          int
 	LevelDbLruCacheSize          int
 	LevelDbMaxOpenShards         int
@@ -271,7 +273,9 @@ func parseTomlConfiguration(filename string) (*Configuration, error) {
 	if err != nil {
 		return nil, err
 	}
-	tomlConfiguration := &TomlConfiguration{}
+	tomlConfiguration := &TomlConfiguration{
+		LeaderElectionWait: duration{5 * time.Second},
+	}
 	_, err = toml.Decode(string(body), tomlConfiguration)
 	if err != nil {
 		return nil, err
@@ -366,6 +370,7 @@ func parseTomlConfiguration(filename string) (*Configuration, error) {
 		PerServerWriteBufferSize:     tomlConfiguration.Cluster.WriteBufferSize,
 		ClusterMaxResponseBufferSize: tomlConfiguration.Cluster.MaxResponseBufferSize,
 		ConcurrentShardQueryLimit:    defaultConcurrentShardQueryLimit,
+		LeaderElectionWait:           tomlConfiguration.LeaderElectionWait,
 	}
 
 	config.UdpServers = append(config.UdpServers, UdpInputConfig{

--- a/src/integration/test_config_single.toml
+++ b/src/integration/test_config_single.toml
@@ -8,6 +8,7 @@
 bind-address = "0.0.0.0"
 
 reporting-disabled = true
+leader-election-wait = "0s"
 
 [logging]
 # logging level can be one of "debug", "info", "warn" or "error"

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -89,7 +89,7 @@ func (self *Server) ListenAndServe() error {
 	self.ClusterConfig.WaitForLocalServerLoaded()
 	self.writeLog.SetServerId(self.ClusterConfig.ServerId())
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(self.Config.LeaderElectionWait.Duration)
 
 	// check to make sure that the raft connection string hasn't changed
 	raftConnectionString := self.Config.RaftConnectionString()


### PR DESCRIPTION
Running DataTest always waits extra 5 seconds. This configuration improve that.

e.g ) no wait leader election.
leader-election-wait= "0s"

Also, this is useful when running single node. (I guess `leader-election-wait` is suitable name for this. but it's not, please fix correct name)
