### PR TITLE
follow symlinks

### DIFF
--- a/scripts/post_install.sh
+++ b/scripts/post_install.sh
@@ -25,7 +25,7 @@ if ! id influxdb; then
     useradd --system -U -M influxdb
 fi
 
-chown -R influxdb:influxdb $influx_dir
+chown -R -L influxdb:influxdb $influx_dir
 chmod -R a+rX $influx_dir
 
 # only restart if the service was already running


### PR DESCRIPTION
for people that have a symlink, such as /opt/influxdb/shared/data as a link to a datadir on a different volume, this makes sure the ownership is reset there too.
otherwise you can get influxdb to panic due to incorrect permissions (happened to me)
