### PR TITLE
Updating documentation links to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ should return in < 100ms.
 * Understand the [design goals and motivations of the project](http://influxdb.org/docs/v0.7/introduction/overview.html).
 * Follow the [getting started guide](http://influxdb.org/docs/v0.7/introduction/getting_started.html) to find out how to install InfluxDB, start writing data, and issue queries - in just a few minutes.
 * See the
-  [list of libraries for different languages](http://influxdb.org/docs/libraries/javascript.html),
+  [list of libraries for different languages](http://influxdb.com/docs/v0.7/client_libraries/javascript.html),
   or check out the
   [HTTP API documentation to start writing a library for your favorite language](http://influxdb.org/docs/v0.7/api/reading_and_writing_data.html).
 


### PR DESCRIPTION
Documentation "stickies" to the current version, updated to 0.7 and resolved broken external libraries link.
