### PR TITLE
Extract coordinator.Permissions

### DIFF
--- a/src/cluster/user.go
+++ b/src/cluster/user.go
@@ -88,6 +88,10 @@ func (self *ClusterAdmin) IsClusterAdmin() bool {
 	return true
 }
 
+func (self *ClusterAdmin) IsDbAdmin(_ string) bool {
+	return true
+}
+
 func (self *ClusterAdmin) HasWriteAccess(_ string) bool {
 	return true
 }

--- a/src/cluster/user_test.go
+++ b/src/cluster/user_test.go
@@ -26,6 +26,7 @@ func (self *UserSuite) SetUpSuite(c *C) {
 func (self *UserSuite) TestProperties(c *C) {
 	u := ClusterAdmin{CommonUser{Name: "root"}}
 	c.Assert(u.IsClusterAdmin(), Equals, true)
+	c.Assert(u.IsDbAdmin("db"), Equals, true)
 	c.Assert(u.GetName(), Equals, "root")
 	hash, err := HashPassword("foobar")
 	c.Assert(err, IsNil)

--- a/src/coordinator/permissions.go
+++ b/src/coordinator/permissions.go
@@ -1,0 +1,159 @@
+package coordinator
+
+import (
+	"common"
+)
+
+type Permissions struct{}
+
+func (self *Permissions) AuthorizeDeleteQuery(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permission to write to %s", db)
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeDropSeries(user common.User, db string, seriesName string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) && !user.HasWriteAccess(seriesName) {
+		return false, common.NewAuthorizationError("Insufficient permissions to drop series")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeCreateContinuousQuery(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to create continuous query")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeDeleteContinuousQuery(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to delete continuous query")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeListContinuousQueries(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to list continuous queries")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeCreateDatabase(user common.User) (ok bool, err common.AuthorizationError) {
+	if !user.IsClusterAdmin() {
+		return false, common.NewAuthorizationError("Insufficient permissions to create database")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeListDatabases(user common.User) (ok bool, err common.AuthorizationError) {
+	if !user.IsClusterAdmin() {
+		return false, common.NewAuthorizationError("Insufficient permissions to list databases")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeDropDatabase(user common.User) (ok bool, err common.AuthorizationError) {
+	if !user.IsClusterAdmin() {
+		return false, common.NewAuthorizationError("Insufficient permissions to drop database")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeListClusterAdmins(user common.User) (ok bool, err common.AuthorizationError) {
+	if !user.IsClusterAdmin() {
+		return false, common.NewAuthorizationError("Insufficient permissions to list cluster admins")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeCreateClusterAdmin(user common.User) (ok bool, err common.AuthorizationError) {
+	if !user.IsClusterAdmin() {
+		return false, common.NewAuthorizationError("Insufficient permissions to create cluster admin")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeDeleteClusterAdmin(user common.User) (ok bool, err common.AuthorizationError) {
+	if !user.IsClusterAdmin() {
+		return false, common.NewAuthorizationError("Insufficient permissions to delete cluster admin")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeChangeClusterAdminPassword(user common.User) (ok bool, err common.AuthorizationError) {
+	if !user.IsClusterAdmin() {
+		return false, common.NewAuthorizationError("Insufficient permissions to change cluster admin password")
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeCreateDbUser(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to create db user on %s", db)
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeDeleteDbUser(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to delete db user on %s", db)
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeListDbUsers(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to list db users on %s", db)
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeGetDbUser(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to get db user on %s", db)
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeChangeDbUserPassword(user common.User, db string, targetUsername string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) && !(user.GetDb() == db && user.GetName() == targetUsername) {
+		return false, common.NewAuthorizationError("Insufficient permissions to change db user password for %s on %s", targetUsername, db)
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeChangeDbUserPermissions(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to change db user permissions on %s", db)
+	}
+
+	return true, ""
+}
+
+func (self *Permissions) AuthorizeGrantDbUserAdmin(user common.User, db string) (ok bool, err common.AuthorizationError) {
+	if !user.IsDbAdmin(db) {
+		return false, common.NewAuthorizationError("Insufficient permissions to grant db user admin privileges on %s", db)
+	}
+
+	return true, ""
+}

--- a/src/coordinator/permissions_test.go
+++ b/src/coordinator/permissions_test.go
@@ -1,0 +1,357 @@
+package coordinator
+
+import (
+	"cluster"
+	"common"
+	. "launchpad.net/gocheck"
+)
+
+type PermissionsSuite struct {
+	permissions  Permissions
+	commonUser   *cluster.CommonUser
+	dbAdmin      *cluster.DbUser
+	clusterAdmin *cluster.ClusterAdmin
+}
+
+var _ = Suite(&PermissionsSuite{})
+
+func (self *PermissionsSuite) SetUpSuite(c *C) {
+	self.permissions = Permissions{}
+	self.commonUser = &cluster.CommonUser{"common_user", "", false, "common_user"}
+	self.dbAdmin = &cluster.DbUser{cluster.CommonUser{"db_admin", "", false, "db_admin"}, "db", nil, nil, true}
+	self.clusterAdmin = &cluster.ClusterAdmin{cluster.CommonUser{"root", "", false, "root"}}
+}
+
+func (self *PermissionsSuite) TestAuthorizeDeleteQuery(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permission to write to db")
+
+	ok, err = self.permissions.AuthorizeDeleteQuery(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeDeleteQuery(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeDeleteQuery(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeDropSeries(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to drop series")
+
+	ok, err = self.permissions.AuthorizeDropSeries(self.commonUser, "db", "series")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeDropSeries(self.dbAdmin, "db", "series")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeDropSeries(self.clusterAdmin, "db", "series")
+	c.Assert(ok, Equals, true)
+
+	// TODO: assert user with write access is authorized to drop series
+}
+
+func (self *PermissionsSuite) TestAuthorizeCreateContinuousQuery(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to create continuous query")
+
+	ok, err = self.permissions.AuthorizeCreateContinuousQuery(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeCreateContinuousQuery(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeCreateContinuousQuery(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeDeleteContinuousQuery(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to delete continuous query")
+
+	ok, err = self.permissions.AuthorizeDeleteContinuousQuery(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeDeleteContinuousQuery(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeDeleteContinuousQuery(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeListContinuousQueries(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to list continuous queries")
+
+	ok, err = self.permissions.AuthorizeListContinuousQueries(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeListContinuousQueries(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeListContinuousQueries(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeCreateDatabase(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to create database")
+
+	ok, err = self.permissions.AuthorizeCreateDatabase(self.commonUser)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeCreateDatabase(self.dbAdmin)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeCreateDatabase(self.clusterAdmin)
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeListDatabases(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to list databases")
+
+	ok, err = self.permissions.AuthorizeListDatabases(self.commonUser)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeListDatabases(self.dbAdmin)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeListDatabases(self.clusterAdmin)
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeDropDatabase(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to drop database")
+
+	ok, err = self.permissions.AuthorizeDropDatabase(self.commonUser)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeDropDatabase(self.dbAdmin)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeDropDatabase(self.clusterAdmin)
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeListClusterAdmins(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to list cluster admins")
+
+	ok, err = self.permissions.AuthorizeListClusterAdmins(self.commonUser)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeListClusterAdmins(self.dbAdmin)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeListClusterAdmins(self.clusterAdmin)
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeCreateClusterAdmin(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to create cluster admin")
+
+	ok, err = self.permissions.AuthorizeCreateClusterAdmin(self.commonUser)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeCreateClusterAdmin(self.dbAdmin)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeCreateClusterAdmin(self.clusterAdmin)
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeDeleteClusterAdmin(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to delete cluster admin")
+
+	ok, err = self.permissions.AuthorizeDeleteClusterAdmin(self.commonUser)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeDeleteClusterAdmin(self.dbAdmin)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeDeleteClusterAdmin(self.clusterAdmin)
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeChangeClusterAdminPassword(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to change cluster admin password")
+
+	ok, err = self.permissions.AuthorizeChangeClusterAdminPassword(self.commonUser)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeChangeClusterAdminPassword(self.dbAdmin)
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeChangeClusterAdminPassword(self.clusterAdmin)
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeCreateDbUser(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to create db user on db")
+
+	ok, err = self.permissions.AuthorizeCreateDbUser(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeCreateDbUser(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeCreateDbUser(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeDeleteDbUser(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to delete db user on db")
+
+	ok, err = self.permissions.AuthorizeDeleteDbUser(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeDeleteDbUser(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeDeleteDbUser(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeListDbUsers(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to list db users on db")
+
+	ok, err = self.permissions.AuthorizeListDbUsers(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeListDbUsers(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeListDbUsers(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeGetDbUser(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to get db user on db")
+
+	ok, err = self.permissions.AuthorizeGetDbUser(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeGetDbUser(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeGetDbUser(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeChangeDbUserPassword(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to change db user password for someone on db")
+
+	ok, err = self.permissions.AuthorizeChangeDbUserPassword(self.commonUser, "db", "someone")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeChangeDbUserPassword(self.dbAdmin, "db", "someone")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeChangeDbUserPassword(self.clusterAdmin, "db", "someone")
+	c.Assert(ok, Equals, true)
+
+	// TODO: test non-admin db user can change own password
+}
+
+func (self *PermissionsSuite) TestAuthorizeChangeDbUserPermissions(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to change db user permissions on db")
+
+	ok, err = self.permissions.AuthorizeChangeDbUserPermissions(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeChangeDbUserPermissions(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeChangeDbUserPermissions(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}
+
+func (self *PermissionsSuite) TestAuthorizeGrantDbUserAdmin(c *C) {
+	var ok bool
+	var err common.AuthorizationError
+
+	authErr := common.NewAuthorizationError("Insufficient permissions to grant db user admin privileges on db")
+
+	ok, err = self.permissions.AuthorizeGrantDbUserAdmin(self.commonUser, "db")
+	c.Assert(ok, Equals, false)
+	c.Assert(err, Equals, authErr)
+
+	ok, _ = self.permissions.AuthorizeGrantDbUserAdmin(self.dbAdmin, "db")
+	c.Assert(ok, Equals, true)
+
+	ok, _ = self.permissions.AuthorizeGrantDbUserAdmin(self.clusterAdmin, "db")
+	c.Assert(ok, Equals, true)
+}


### PR DESCRIPTION
All ClusterAdmins now qualify as DbAdmins too.

I think the discussion in Issue #313 is indicative of a smell that the coordinator object shouldn't directly contain the logic about deciding whether a user has permissions to perform a particular operation -- hence extracting a permissions object that is lightweight for now, but should be flexible enough to have finer-grained permissions in the future if desired.

I added a TODO to a couple of the tests that I added, where it wasn't extremely obvious to me what the extra logic was doing. It will probably be trivial to address for anyone who's more familiar with user roles and permissions of InfluxDB.

Also, I'm having trouble running the `./configure --with-flex=/usr/local/Cellar/flex/2.5.37/bin/flex --with-bison=/usr/local/Cellar/bison/3.0.2/bin/bison && make` command as recommended in the dev guide (I'm on OSX 10.9.2). It's possible I may have broken some tests outside the coordinator package, although I don't expect that to be the case.
