### PR TITLE
Use Sorted Duplicates

### DIFF
--- a/src/datastore/storage/mdb.go
+++ b/src/datastore/storage/mdb.go
@@ -72,7 +72,7 @@ func NewMDB(path string, config interface{}) (Engine, error) {
 		return MDB{}, err
 	}
 
-	dbi, err := tx.DBIOpen(nil, mdb.CREATE)
+	dbi, err := tx.DBIOpen(nil, mdb.CREATE|mdb.DUPSORT|mdb.DUPFIXED)
 	if err != nil {
 		return MDB{}, err
 	}
@@ -90,6 +90,34 @@ func NewMDB(path string, config interface{}) (Engine, error) {
 	return db, nil
 }
 
+// InfluxDB uses 24 byte keys and small values. The keys are of
+// the form SSSSttttssss
+// where SSSS is an 8 byte seriesID, tttt is an 8 byte timestamp,
+// and ssss is an 8 byte sequence number. We use MDB_DUPSORT and
+// reconstruct this as a 6 byte key with duplicate values:
+// key SSS
+// value SttttssssVVVV
+
+// Turn an InfluxDB KV pair to an internal KV pair
+func ImportKV(key, val[]byte) ([]byte, []byte) {
+	newk := key[0:6]
+	newv := make([]byte, len(key) - 6 + len(val))
+	copy(newv, key[6:])
+	if val != nil {
+		copy(newv[18:], val)
+	}
+	return newk, newv
+}
+
+// Turn an internal KV pair into an InfluxDB KV pair
+func ExportKV(key, val[]byte) ([]byte, []byte) {
+	newk := make([]byte, 24)
+	copy(newk, key)
+	copy(newk[6:], val[0:18])
+	newv := val[18:]
+	return newk, newv
+}
+
 func (db MDB) Put(key, value []byte) error {
 	return db.BatchPut([]Write{Write{key, value}})
 }
@@ -98,13 +126,14 @@ func (db MDB) BatchPut(writes []Write) error {
 	itr := db.iterator(false)
 
 	for _, w := range writes {
+		key, val := ImportKV(w.Key, w.Value)
 		if w.Value == nil {
-			itr.key, itr.value, itr.err = itr.c.Get(w.Key, mdb.SET)
-			if itr.err == nil {
+			itr.key, itr.value, itr.err = itr.c.Get(key, val, mdb.GET_RANGE)
+			if itr.err == nil && bytes.Compare(itr.key, w.Key) == 0 {
 				itr.err = itr.c.Del(0)
 			}
 		} else {
-			itr.err = itr.c.Put(w.Key, w.Value, 0)
+			itr.err = itr.c.Put(key, val, 0)
 		}
 
 		if itr.err != nil && itr.err != mdb.NotFound {
@@ -117,17 +146,19 @@ func (db MDB) BatchPut(writes []Write) error {
 }
 
 func (db MDB) Get(key []byte) ([]byte, error) {
-	tx, err := db.env.BeginTxn(nil, mdb.RDONLY)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Commit()
+	itr := db.iterator(true)
+	defer itr.Close()
 
-	v, err := tx.Get(db.db, key)
-	if err == mdb.NotFound {
+	k, v := ImportKV(key, nil)
+	k, v, err := itr.c.Get(k, v, mdb.GET_RANGE)
+	if err == nil {
+		k, v = ExportKV(k, v)
+		if bytes.Compare(k, key) == 0 {
+			return v, nil
+		}
 		return nil, nil
 	}
-	return v, err
+	return nil, err
 }
 
 func (db MDB) Del(start, finish []byte) error {
@@ -176,21 +207,46 @@ func (itr *MDBIterator) Error() error {
 }
 
 func (itr *MDBIterator) getCurrent() {
-	itr.key, itr.value, itr.err = itr.c.Get(nil, mdb.GET_CURRENT)
+	var k, v []byte
+	k, v, itr.err = itr.c.Get(nil, nil, mdb.GET_CURRENT)
+	if itr.err == nil {
+		itr.key, itr.value = ExportKV(k, v)
+	}
 	itr.setState()
 }
 
 func (itr *MDBIterator) Seek(key []byte) {
-	itr.key, itr.value, itr.err = itr.c.Get(key, mdb.SET_RANGE)
+	k, v := ImportKV(key, nil)
+	k, v, itr.err = itr.c.Get(k, v, mdb.GET_RANGE)
+	if itr.err == nil {
+		itr.key, itr.value = ExportKV(k, v)
+	} else {
+		itr.key = nil
+		itr.value = nil
+	}
 	itr.setState()
 }
 func (itr *MDBIterator) Next() {
-	itr.key, itr.value, itr.err = itr.c.Get(nil, mdb.NEXT)
+	var k, v []byte
+	k, v, itr.err = itr.c.Get(nil, nil, mdb.NEXT)
+	if itr.err == nil {
+		itr.key, itr.value = ExportKV(k, v)
+	} else {
+		itr.key = nil
+		itr.value = nil
+	}
 	itr.setState()
 }
 
 func (itr *MDBIterator) Prev() {
-	itr.key, itr.value, itr.err = itr.c.Get(nil, mdb.PREV)
+	var k, v []byte
+	k, v, itr.err = itr.c.Get(nil, nil, mdb.PREV)
+	if itr.err == nil {
+		itr.key, itr.value = ExportKV(k, v)
+	} else {
+		itr.key = nil
+		itr.value = nil
+	}
 	itr.setState()
 }
 


### PR DESCRIPTION
Saves some disk space. There are more opportunities for
optimization down this avenue. This requires a patch to gomdb https://github.com/szferi/gomdb/pull/25
and also latest LMDB rev https://gitorious.org/mdb/mdb/commit/aa89ca31b3a95f266cd2b354037466a2d950bc1f

For the scenario of 100M keys and 500K series, I got best space savings with 6 byte primary key. But if you use the full 8 byte seriesID as the primary key, then you can simply use MDB_NEXT_DUP to retrieve all the records in a series, and save the expensive Compare(RetrievedKey, EndKey) that your current code does to determine if it's reached the end. (You might see better space savings with 8 byte key, if the data set was even larger. In this data set, there weren't enough records per series to justify the overhead.) Saving 6 or 8 bytes per record is pretty good, anyway.

This code uses DUPFIXED, which assumes that all data values are the same size. If that's not true for your real data, you should omit that flag. If you can use it, it saves another 8 bytes per record.

I didn't look at how real InfluxDB data looks, so if these assumptions are totally off base, please forgive me.
