### PR TITLE
cast *C.value_array from *C.struct___0 #699

### DIFF
--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -313,7 +313,7 @@ func GetGroupByClause(groupByClause *C.groupby_clause) (*GroupByClause, error) {
 		return &GroupByClause{Elems: nil}, nil
 	}
 
-	values, err := GetValueArray(groupByClause.elems)
+	values, err := GetValueArray((*C.value_array)(groupByClause.elems))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
tested with:
go version go1.2.2 linux/amd64
go version go1.3 linux/amd64
