### PR TITLE
For writes to non replicated series the write should be synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [Issue #731](https://github.com/influxdb/influxdb/issues/731). Don't enable the udp plugin if the `enabled` option is set to false
 - [Issue #733](https://github.com/influxdb/influxdb/issues/733). Print an `INFO` message when the input plugin is disabled
 - [Issue #707](https://github.com/influxdb/influxdb/issues/707). Graphite input plugin should work payload delimited by any whitespace character
+- [Issue #734](https://github.com/influxdb/influxdb/issues/734). Don't buffer non replicated writes
 
 ## v0.7.3 [2014-06-13]
 

--- a/src/cluster/cluster_configuration.go
+++ b/src/cluster/cluster_configuration.go
@@ -36,6 +36,7 @@ type QuerySpec interface {
 
 type WAL interface {
 	AssignSequenceNumbersAndLog(request *protocol.Request, shard wal.Shard) (uint32, error)
+	AssignSequenceNumbers(request *protocol.Request) error
 	Commit(requestNumber uint32, serverId uint32) error
 	CreateCheckpoint() error
 	RecoverServerFromRequestNumber(requestNumber uint32, shardIds []uint32, yield func(request *protocol.Request, shardId uint32) error) error

--- a/src/wal/entry.go
+++ b/src/wal/entry.go
@@ -21,7 +21,8 @@ type commitEntry struct {
 }
 
 type appendEntry struct {
-	confirmation chan *confirmation
-	request      *protocol.Request
-	shardId      uint32
+	confirmation  chan *confirmation
+	request       *protocol.Request
+	shardId       uint32
+	assignSeqOnly bool
 }


### PR DESCRIPTION
Currently all writes go through the WAL even for non replicated time series/database. We should skip the wal if the write is not to be replicated. In that case the write is synchronous and it can pass/fail.
