### PR TITLE
Allow 'null' to be supplied as fill value

### DIFF
--- a/engine/aggregator.go
+++ b/engine/aggregator.go
@@ -82,6 +82,11 @@ func wrapDefaultValue(defaultValue *parser.Value) (*protocol.FieldValue, error) 
 		v, _ := strconv.Atoi(defaultValue.Name)
 		value := int64(v)
 		return &protocol.FieldValue{Int64Value: &value}, nil
+	case parser.ValueSimpleName:
+		if defaultValue.Name != "null" {
+			return nil, fmt.Errorf("Unsupported fill value %s", defaultValue.Name)
+		}
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("Unknown type %s", defaultValue.Type)
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -569,6 +569,7 @@ func (self *QueryParserSuite) TestParseSelectWithGroupByFillWithZero(c *C) {
 
 	groupBy := q.GetGroupByClause()
 	c.Assert(groupBy.FillWithZero, Equals, true)
+	c.Assert(groupBy.FillValue.Name, Equals, "0")
 	c.Assert(groupBy.Elems, HasLen, 2)
 	c.Assert(groupBy.Elems[0].IsFunctionCall(), Equals, false)
 	c.Assert(groupBy.Elems[0].Name, Equals, "user_email")


### PR DESCRIPTION
Add to unit tests to test fill, including new "null" support.

Fix #713.

<!---
@huboard:{"order":76.0,"custom_state":""}
-->
