### PR TITLE
The attributes of a shard space should not be reverted

### DIFF
--- a/cluster/cluster_configuration.go
+++ b/cluster/cluster_configuration.go
@@ -1290,6 +1290,12 @@ func (self *ClusterConfiguration) removeShard(shard *ShardData) {
 }
 
 func (self *ClusterConfiguration) AddShardSpace(space *ShardSpace) error {
+	if space.Name != DEFAULT_SHARD_SPACE_NAME {
+		err := space.Validate(self)
+		if err != nil {
+			return err
+		}
+	}
 	self.shardLock.Lock()
 	defer self.shardLock.Unlock()
 	databaseSpaces := self.databaseShardSpaces[space.Database]

--- a/integration/single_server_test.go
+++ b/integration/single_server_test.go
@@ -740,6 +740,11 @@ func (self *SingleServerSuite) TestCreateShardSpace(c *C) {
 	spaces, err = client.GetShardSpaces()
 	c.Assert(err, IsNil)
 	c.Assert(self.hasSpace("db1", "month", spaces), Equals, true)
+	for _, s := range spaces {
+		if s.Name == "month" && s.Database == "db1" {
+			c.Assert(s.Regex, Equals, "/^the_dude_abides/")
+		}
+	}
 	shards, err := client.GetShards()
 	c.Assert(err, IsNil)
 	spaceShards := self.getShardsForSpace("month", shards.All)


### PR DESCRIPTION
`ShardSpace.compiledRegex` is not set by `ClusterConfiguration.AddShardSpace()`, so the attributes of a shard space is reverted to the default values when `ShardSpace.MatchSeries()` is called.

`ShardSpace.Validate()` should be called in `ClusterConfituration.AddShardSpace()`, shouldn't it?
