### PR TITLE
Use test_rf_{1,2}.toml instead of test_replication_{1,2}.toml

### DIFF
--- a/integration/remove_node_test.go
+++ b/integration/remove_node_test.go
@@ -57,11 +57,11 @@ func (self *RemoveNodeSuite) TestRemovingNode(c *C) {
 func (self *RemoveNodeSuite) TestRemovingNodeAndShards(c *C) {
 	err := os.RemoveAll("/tmp/influxdb/test")
 	c.Assert(err, IsNil)
-	s1 := NewServer("integration/test_replication_1.toml", c)
+	s1 := NewServer("integration/test_rf_1.toml", c)
 	defer s1.Stop()
 	s1.WaitForServerToStart()
 
-	s2 := NewServer("integration/test_replication_2.toml", c)
+	s2 := NewServer("integration/test_rf_2.toml", c)
 	s2.WaitForServerToStart()
 
 	client := s1.GetClient("", c)


### PR DESCRIPTION
In #760, uncommitted config files are used in integration/remove_node_test.go.  Sorry.
