### PR TITLE
Use influxdb.ShardSpace instead of cluster.ShardSpace.

### DIFF
--- a/daemon/influxd.go
+++ b/daemon/influxd.go
@@ -14,7 +14,6 @@ import (
 
 	log "code.google.com/p/log4go"
 	influxdb "github.com/influxdb/influxdb/client"
-	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/configuration"
 	"github.com/influxdb/influxdb/coordinator"
 	"github.com/influxdb/influxdb/server"
@@ -176,8 +175,8 @@ func main() {
 }
 
 type DatabaseConfig struct {
-	Database string                `json:"database"`
-	Spaces   []*cluster.ShardSpace `json:"spaces"`
+	Database string                 `json:"database"`
+	Spaces   []*influxdb.ShardSpace `json:"spaces"`
 }
 
 func LoadDatabaseConfig(fileName, server, user, password string) error {

--- a/integration/multiple_servers_test.go
+++ b/integration/multiple_servers_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	influxdb "github.com/influxdb/influxdb/client"
-	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/common"
 	. "github.com/influxdb/influxdb/integration/helpers"
 	. "launchpad.net/gocheck"
@@ -945,7 +944,7 @@ func (self *ServerSuite) TestDropShard(c *C) {
 	endSeconds := startSeconds + 3600
 	client := self.serverProcesses[0].GetClient("", c)
 	c.Assert(client.CreateDatabase("test_drop_shard"), IsNil)
-	space := &cluster.ShardSpace{Name: "test_drop", RetentionPolicy: "30d", Database: "test_drop_shard", Regex: "/^dont_drop_me_bro/"}
+	space := &influxdb.ShardSpace{Name: "test_drop", RetentionPolicy: "30d", Database: "test_drop_shard", Regex: "/^dont_drop_me_bro/"}
 	c.Assert(client.CreateShardSpace(space), IsNil)
 
 	data := fmt.Sprintf(`{

--- a/integration/remove_node_test.go
+++ b/integration/remove_node_test.go
@@ -3,7 +3,7 @@ package integration
 import (
 	"os"
 
-	"github.com/influxdb/influxdb/cluster"
+	influxdb "github.com/influxdb/influxdb/client"
 	. "github.com/influxdb/influxdb/integration/helpers"
 	. "launchpad.net/gocheck"
 )
@@ -57,11 +57,11 @@ func (self *RemoveNodeSuite) TestRemovingNode(c *C) {
 func (self *RemoveNodeSuite) TestRemovingNodeAndShards(c *C) {
 	err := os.RemoveAll("/tmp/influxdb/test")
 	c.Assert(err, IsNil)
-	s1 := NewServer("integration/test_replication_1.toml", c)
+	s1 := NewServer("integration/test_rf_1.toml", c)
 	defer s1.Stop()
 	s1.WaitForServerToStart()
 
-	s2 := NewServer("integration/test_replication_2.toml", c)
+	s2 := NewServer("integration/test_rf_2.toml", c)
 	s2.WaitForServerToStart()
 
 	client := s1.GetClient("", c)
@@ -70,7 +70,7 @@ func (self *RemoveNodeSuite) TestRemovingNodeAndShards(c *C) {
 	c.Assert(servers, HasLen, 2)
 
 	c.Assert(client.CreateDatabase("test"), IsNil)
-	space := &cluster.ShardSpace{Name: "test_space", RetentionPolicy: "1h", Database: "test", Regex: "/test_removing_node_and_shards/", ReplicationFactor: 2}
+	space := &influxdb.ShardSpace{Name: "test_space", RetentionPolicy: "1h", Database: "test", Regex: "/test_removing_node_and_shards/", ReplicationFactor: 2}
 	c.Assert(client.CreateShardSpace(space), IsNil)
 
 	series := CreatePoints("test_removing_node_and_shards", 5, 10)

--- a/integration/single_server_test.go
+++ b/integration/single_server_test.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 
 	influxdb "github.com/influxdb/influxdb/client"
-	"github.com/influxdb/influxdb/cluster"
 	. "github.com/influxdb/influxdb/integration/helpers"
 	. "launchpad.net/gocheck"
 )
@@ -725,7 +724,7 @@ func (self *SingleServerSuite) TestCreateShardSpace(c *C) {
 	c.Assert(spaces, HasLen, 1)
 	c.Assert(spaces[0].Name, Equals, "default")
 
-	space := &cluster.ShardSpace{Name: "month", RetentionPolicy: "30d", Database: "db1", Regex: "/^the_dude_abides/"}
+	space := &influxdb.ShardSpace{Name: "month", RetentionPolicy: "30d", Database: "db1", Regex: "/^the_dude_abides/"}
 	err = client.CreateShardSpace(space)
 	c.Assert(err, IsNil)
 
@@ -756,7 +755,7 @@ func (self *SingleServerSuite) getShardsForSpace(name string, shards []*influxdb
 	return filteredShards
 }
 
-func (self *SingleServerSuite) hasSpace(database, name, regex string, spaces []*cluster.ShardSpace) bool {
+func (self *SingleServerSuite) hasSpace(database, name, regex string, spaces []*influxdb.ShardSpace) bool {
 	for _, s := range spaces {
 		fmt.Printf("Checking %#v\n", s)
 		if s.Name == name && s.Database == database && s.Regex == regex {
@@ -769,7 +768,7 @@ func (self *SingleServerSuite) hasSpace(database, name, regex string, spaces []*
 func (self *SingleServerSuite) TestDropShardSpace(c *C) {
 	client := self.server.GetClient("", c)
 	spaceName := "test_drop"
-	space := &cluster.ShardSpace{Name: spaceName, RetentionPolicy: "30d", Database: "db1", Regex: "/^dont_drop_me_bro/"}
+	space := &influxdb.ShardSpace{Name: spaceName, RetentionPolicy: "30d", Database: "db1", Regex: "/^dont_drop_me_bro/"}
 	err := client.CreateShardSpace(space)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
After fd45c925, compilation of daemon/influxd.go fails:

```
/usr/bin/go build -o influxdb -tags 'hyperleveldb rocksdb' github.com/influxdb/influxdb/daemon
# github.com/influxdb/influxdb/daemon
daemon/influxd.go:209: cannot use space (type *cluster.ShardSpace) as type *influxdb.ShardSpace in function argument
```

I'm not sure this is the right fix, but use of influxdb.ShardSpace fixes the error.
