### PR TITLE
Replaced a panic in influxd.go with exit(1)

### DIFF
--- a/daemon/influxd.go
+++ b/daemon/influxd.go
@@ -80,7 +80,9 @@ func main() {
 	if *loadDatabaseConfig != "" {
 		err := LoadDatabaseConfig(*loadDatabaseConfig, *loadServer, *loadUser, *loadPassword)
 		if err != nil {
-			panic(err)
+			fmt.Println("There is was an error while trying to load your configuration file.")
+			fmt.Println("Check config.sample.toml (it may not exist)")
+			os.Exit(1)
 		}
 		return
 	}


### PR DESCRIPTION
When I first tried installing this, I thought my installation was broken because the current version panics if it fails to read a config file, and a config file is not included. This instead prints an error and then exits with status code 1

edit: The build will most likely fail, but it was failing when I forked it
