### PR TITLE
Shard metadata never be expired

### DIFF
--- a/cluster/cluster_configuration.go
+++ b/cluster/cluster_configuration.go
@@ -187,7 +187,7 @@ func (self *ClusterConfiguration) PeriodicallyDropShardsWithRetentionPolicies() 
 			log.Info("Checking for shards to drop")
 			shards := self.getExpiredShards()
 			for _, s := range shards {
-				self.shardStore.DeleteShard(s.id)
+				self.DropShard(s.id, s.serverIds)
 			}
 		}
 	}()

--- a/integration/test_config_single.toml
+++ b/integration/test_config_single.toml
@@ -73,6 +73,9 @@ dir  = "/tmp/influxdb/development/raft"
 
 [storage]
 
+# The server will check this often for shards that have expired and should be cleared.
+retention-sweep-period = "1s"
+
 dir = "/tmp/influxdb/development/db"
 # How many requests to potentially buffer in memory. If the buffer gets filled then writes
 # will still be logged and once the local storage has caught up (or compacted) the writes
@@ -157,9 +160,6 @@ max-response-buffer-size = 100
 # Setting this higher will give better performance, but you'll need more memory. Setting this to 1 will ensure
 # that you don't need to buffer in memory, but you won't get the best performance.
 concurrent-shard-query-limit = 10
-
-# The server will check this often for shards that have expired and should be cleared.
-retention-sweep-period = "10000u"
 
 [wal]
 


### PR DESCRIPTION
I tried automatic shard expiration with the following database configuration:

```
[
{
  "database": "test",
  "spaces": [
    {
      "name": "everything",
      "retentionPolicy": "10m",
      "shardDuration": "1m",
      "regex": "/.*/",
      "replicationFactor": 2,
      "split": 1
    }
  ]
}
]
```

Then, old shards were successfully dropped:

```
[07/18/14 11:43:36] [INFO] DATASTORE: dropping shard /home/shugo/work/influxdb/cluster_test/1/db/shard_db_v2/00003
```

However, "GET /cluster/shards" returns dropped shards.

I guess shard metadata should be removed by updateOrRemoveShard() in all nodes, or shards should be dropped through Raft.

<!---
@huboard:{"order":767.0,"milestone_order":767.0,"custom_state":""}
-->
