### PR TITLE
Fill should fill the entire time range that is requested

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -29,8 +29,9 @@ type IntoClause struct {
 }
 
 type BasicQuery struct {
-	startTime time.Time
-	endTime   time.Time
+	startTime          time.Time
+	endTime            time.Time
+	startTimeSpecified bool
 }
 
 type SelectDeleteCommonQuery struct {
@@ -681,6 +682,7 @@ func parseSelectDeleteCommonQuery(fromClause *C.from_clause, whereCondition *C.c
 
 	if startTime != nil {
 		goQuery.startTime = *startTime
+		goQuery.startTimeSpecified = true
 	}
 
 	return goQuery, nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -101,6 +101,13 @@ func (self *QueryParserSuite) TestGetQueryString(c *C) {
 		c.Assert(actualQuery, HasLen, 1)
 		expectedQuery[0].QueryString = ""
 		actualQuery[0].QueryString = ""
+		if expectedQuery[0].DeleteQuery != nil {
+			expectedQuery[0].DeleteQuery.startTimeSpecified = false
+			actualQuery[0].DeleteQuery.startTimeSpecified = false
+		} else if expectedQuery[0].SelectQuery != nil {
+			expectedQuery[0].SelectQuery.startTimeSpecified = false
+			actualQuery[0].SelectQuery.startTimeSpecified = false
+		}
 
 		c.Assert(actualQuery[0], DeepEquals, expectedQuery[0])
 	}

--- a/parser/query_api.go
+++ b/parser/query_api.go
@@ -200,6 +200,10 @@ func (self *BasicQuery) GetStartTime() time.Time {
 	return self.startTime
 }
 
+func (self *BasicQuery) IsStartTimeSpecified() bool {
+	return self.startTimeSpecified
+}
+
 // Returns the start time of the query. Queries can only have
 // one condition of the form time > start_time
 func (self *BasicQuery) GetEndTime() time.Time {


### PR DESCRIPTION
See #117 for info on the fill function. Based on that discussion, we should be filling for the entire requested time range. If you try to graph two weeks of data and it doesn't fill at the edges and you only see a few days of data, that's bad.

So, for any query that has a `where time > ...` clause in it, make sure you fill from that time to whenever the end time is.

<!---
@huboard:{"order":80.0,"custom_state":"","milestone_order":426.0}
-->
