### PR TITLE
query non-local shard with time range

### DIFF
--- a/cluster/shard.go
+++ b/cluster/shard.go
@@ -507,7 +507,7 @@ func (self *ShardData) HandleDestructiveQuery(querySpec *parser.QuerySpec, reque
 }
 
 func (self *ShardData) createRequest(querySpec *parser.QuerySpec) *p.Request {
-	queryString := querySpec.GetQueryString()
+	queryString := querySpec.GetQueryStringWithTimeCondition()
 	user := querySpec.User()
 	userName := user.GetName()
 	database := querySpec.Database()


### PR DESCRIPTION
on delegating query to remote server, queryString needs to be querySpec.GetQueryStringWithTimeCondition()
## sample data

``` json
[
   {
      "name": "hello",
      "columns": [
         "time",
         "value"
      ],
      "points": [
         [
            6000,
            10
         ],
         [
            5000,
            20
         ],
         [
            4000,
            30
         ],
         [
            3000,
            20
         ],
         [
            2000,
            10
         ],
         [
            1000,
            0
         ]
      ]
   }
]
```
## query to local server

```
select * from hello where time>4s
```

server returns 3 points
## query to non-local server

```
select * from hello where time>4s
```

server returns 6(all) points
