### PR TITLE
select * from "IHS.*-*.1h" where empty(ratio) limit 1

### DIFF
--- a/engine/filtering.go
+++ b/engine/filtering.go
@@ -67,6 +67,10 @@ func matchesExpression(expr *parser.Value, fields []string, point *protocol.Poin
 	}
 
 	operator := registeredOperators[expr.Name]
+	if operator == nil {
+		return false, fmt.Errorf("Invalid boolean operator %s", expr.Name)
+	}
+
 	ok, err := operator(leftValue[0], rightValue)
 	return ok == MATCH, err
 }

--- a/integration/data_test.go
+++ b/integration/data_test.go
@@ -1780,6 +1780,20 @@ func (self *DataTestSuite) CountQueryOnSingleShard(c *C) (Fun, Fun) {
 		}
 }
 
+// issue #714
+func (self *DataTestSuite) WhereClauseWithFunction(c *C) (Fun, Fun) {
+	return func(client Client) {
+			serieses := CreatePoints("test_where_clause_with_function", 1, 1)
+			client.WriteData(serieses, c)
+		}, func(client Client) {
+			// TODO: unfortunately the way the engine is structured causes
+			// errors to be swallowed and not returned to the user. The
+			// following should be a call to RunInvalidQuery() instead of
+			// RunQuery(), since the query is invalid.
+			client.RunQuery("select column0 from test_where_clause_with_function where empty(column0)", c)
+		}
+}
+
 func (self *DataTestSuite) GroupByDay(c *C) (Fun, Fun) {
 	return func(client Client) {
 			data := `[{"points": [[4], [10], [5]], "name": "test_group_by_day", "columns": ["value"]}]`


### PR DESCRIPTION
[2014/07/04 22:24:15 IST] [EROR](common.RecoverFunc:20) *******************************_BUG**_*****************************
Database: ratios
Query: [select \* from IHS._-_.1h where empty(ratio) limit 1]
Error: runtime error: invalid memory address or nil pointer dereference. Stacktrace: goroutine 183997 [running]:
common.RecoverFunc(0xc2142147e6, 0x6, 0xc217b54d40, 0x33, 0x7fda76578eb8)
    /home/vagrant/influxdb/src/common/recover.go:14 +0xb7
runtime.panic(0x8a29e0, 0x1042b68)
    /home/vagrant/bin/go/src/pkg/runtime/panic.c:248 +0x106
engine.matchesExpression(0xc215543fa0, 0xc213634050, 0x5, 0x5, 0xc217b54dc0, ...)
    /home/vagrant/influxdb/src/engine/filtering.go:69 +0x235
engine.matches(0xc212ee5b70, 0xc213634050, 0x5, 0x5, 0xc217b54dc0, ...)
    /home/vagrant/influxdb/src/engine/filtering.go:75 +0x91
engine.Filter(0xc2185be700, 0xc213634140, 0xc213634140, 0x50, 0x450600)
    /home/vagrant/influxdb/src/engine/filtering.go:156 +0x2d4
engine.(_FilteringEngine).YieldSeries(0xc215420820, 0xc213634140, 0x7fdac6c11060)
    /home/vagrant/influxdb/src/engine/filtering_engine.go:35 +0x78
datastore.(_LevelDbShard).executeQueryForSeries(0xc213f5c900, 0xc210175e60, 0xc2134cb5e0, 0xa, 0xc2154208e0, ...)
    /home/vagrant/influxdb/src/datastore/leveldb_shard.go:319 +0x1e36
datastore.(*LevelDbShard).Query(0xc213f5c900, 0x

[2014/07/04 22:24:15 IST] [EROR](coordinator.%28*CoordinatorImpl%29.readFromResponseChannels:350) Error while executing query: Internal Error: runtime error: invalid memory address or nil pointer dereference
