### PR TITLE
Make create shard space endpoint database specific.

### DIFF
--- a/api/http/api.go
+++ b/api/http/api.go
@@ -152,7 +152,7 @@ func (self *HttpServer) Serve(listener net.Listener) {
 	self.registerEndpoint(p, "get", "/cluster/shards", self.getShards)
 	self.registerEndpoint(p, "del", "/cluster/shards/:id", self.dropShard)
 	self.registerEndpoint(p, "get", "/cluster/shard_spaces", self.getShardSpaces)
-	self.registerEndpoint(p, "post", "/cluster/shard_spaces", self.createShardSpace)
+	self.registerEndpoint(p, "post", "/cluster/shard_spaces/:db", self.createShardSpace)
 	self.registerEndpoint(p, "del", "/cluster/shard_spaces/:db/:name", self.dropShardSpace)
 	self.registerEndpoint(p, "post", "/cluster/database_configs/:db", self.configureDatabase)
 
@@ -1139,6 +1139,7 @@ func (self *HttpServer) createShardSpace(w libhttp.ResponseWriter, r *libhttp.Re
 		if err != nil {
 			return libhttp.StatusInternalServerError, err.Error()
 		}
+		space.Database = r.URL.Query().Get(":db")
 		err = space.Validate(self.clusterConfig)
 		if err != nil {
 			return libhttp.StatusBadRequest, err.Error()

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -588,8 +588,8 @@ func (self *Client) DropShardSpace(database, name string) error {
 }
 
 // Added to InfluxDB in 0.8.0
-func (self *Client) CreateShardSpace(space *ShardSpace) error {
-	url := self.getUrl(fmt.Sprintf("/cluster/shard_spaces"))
+func (self *Client) CreateShardSpace(database string, space *ShardSpace) error {
+	url := self.getUrl(fmt.Sprintf("/cluster/shard_spaces/%s", database))
 	data, err := json.Marshal(space)
 	if err != nil {
 		return err

--- a/integration/multiple_servers_test.go
+++ b/integration/multiple_servers_test.go
@@ -176,7 +176,7 @@ func (self *ServerSuite) TestShardExpiration(c *C) {
 	client := self.serverProcesses[0].GetClient("", c)
 	client.CreateDatabase("db1")
 	space := &influxdb.ShardSpace{Name: "short", RetentionPolicy: "5s", Database: "db1", Regex: "/^test_shard_expiration/"}
-	err := client.CreateShardSpace(space)
+	err := client.CreateShardSpace("db1", space)
 	c.Assert(err, IsNil)
 
 	self.serverProcesses[0].WriteData(`
@@ -1010,7 +1010,7 @@ func (self *ServerSuite) TestDropShard(c *C) {
 		s.WaitForServerToSync()
 	}
 	space := &influxdb.ShardSpace{Name: "test_drop", RetentionPolicy: "30d", Database: "test_drop_shard", Regex: "/^dont_drop_me_bro/"}
-	c.Assert(client.CreateShardSpace(space), IsNil)
+	c.Assert(client.CreateShardSpace("test_drop_shard", space), IsNil)
 
 	data := fmt.Sprintf(`{
 		"startTime":%d,

--- a/integration/remove_node_test.go
+++ b/integration/remove_node_test.go
@@ -71,7 +71,7 @@ func (self *RemoveNodeSuite) TestRemovingNodeAndShards(c *C) {
 
 	c.Assert(client.CreateDatabase("test"), IsNil)
 	space := &influxdb.ShardSpace{Name: "test_space", RetentionPolicy: "1h", Database: "test", Regex: "/test_removing_node_and_shards/", ReplicationFactor: 2}
-	c.Assert(client.CreateShardSpace(space), IsNil)
+	c.Assert(client.CreateShardSpace("test", space), IsNil)
 
 	series := CreatePoints("test_removing_node_and_shards", 5, 10)
 	client = s1.GetClient("test", c)

--- a/integration/single_server_test.go
+++ b/integration/single_server_test.go
@@ -791,8 +791,8 @@ func (self *SingleServerSuite) TestDuplicateShardsNotCreatedWhenOldShardDropped(
 
 func (self *SingleServerSuite) TestShardSpaceRegex(c *C) {
 	client := self.server.GetClient("", c)
-	space := &influxdb.ShardSpace{Name: "test_regex", RetentionPolicy: "30d", Database: "db1", Regex: "/^metric\\./"}
-	err := client.CreateShardSpace(space)
+	space := &influxdb.ShardSpace{Name: "test_regex", RetentionPolicy: "30d", Regex: "/^metric\\./"}
+	err := client.CreateShardSpace("db1", space)
 	c.Assert(err, IsNil)
 
 	self.server.WriteData(`
@@ -828,8 +828,8 @@ func (self *SingleServerSuite) TestCreateShardSpace(c *C) {
 	c.Assert(spaces, HasLen, 1)
 	c.Assert(spaces[0].Name, Equals, "default")
 
-	space := &influxdb.ShardSpace{Name: "month", RetentionPolicy: "30d", Database: "db1", Regex: "/^the_dude_abides/"}
-	err = client.CreateShardSpace(space)
+	space := &influxdb.ShardSpace{Name: "month", RetentionPolicy: "30d", Regex: "/^the_dude_abides/"}
+	err = client.CreateShardSpace("db1", space)
 	c.Assert(err, IsNil)
 
 	self.server.WriteData(`
@@ -871,8 +871,8 @@ func (self *SingleServerSuite) getSpace(database, name string, regex string, spa
 func (self *SingleServerSuite) TestDropShardSpace(c *C) {
 	client := self.server.GetClient("", c)
 	spaceName := "test_drop"
-	space := &influxdb.ShardSpace{Name: spaceName, RetentionPolicy: "30d", Database: "db1", Regex: "/^dont_drop_me_bro/"}
-	err := client.CreateShardSpace(space)
+	space := &influxdb.ShardSpace{Name: spaceName, RetentionPolicy: "30d", Regex: "/^dont_drop_me_bro/"}
+	err := client.CreateShardSpace("db1", space)
 	c.Assert(err, IsNil)
 
 	self.server.WriteData(`


### PR DESCRIPTION
Fixes #831. Shard spaces now belong to a database so the endpoint should reflect that.
