### PR TITLE
Series should be returned in sorted order

### DIFF
--- a/common/serialize_series.go
+++ b/common/serialize_series.go
@@ -221,5 +221,6 @@ func SerializeSeries(memSeries map[string]*protocol.Series, precision TimePrecis
 			Points:  points,
 		})
 	}
+	SortSerializedSeries(serializedSeries)
 	return serializedSeries
 }

--- a/common/serialized_series.go
+++ b/common/serialized_series.go
@@ -1,9 +1,15 @@
 package common
 
+import "sort"
+
 type SerializedSeries struct {
 	Name    string          `json:"name"`
 	Columns []string        `json:"columns"`
 	Points  [][]interface{} `json:"points"`
+}
+
+func SortSerializedSeries(s []*SerializedSeries) {
+	sort.Sort(BySerializedSeriesNameAsc{s})
 }
 
 func (self *SerializedSeries) GetName() string {
@@ -16,4 +22,18 @@ func (self *SerializedSeries) GetColumns() []string {
 
 func (self *SerializedSeries) GetPoints() [][]interface{} {
 	return self.Points
+}
+
+type SerializedSeriesCollection []*SerializedSeries
+
+func (s SerializedSeriesCollection) Len() int      { return len(s) }
+func (s SerializedSeriesCollection) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+type BySerializedSeriesNameAsc struct{ SerializedSeriesCollection }
+
+func (s BySerializedSeriesNameAsc) Less(i, j int) bool {
+	if s.SerializedSeriesCollection[i] != nil && s.SerializedSeriesCollection[j] != nil {
+		return s.SerializedSeriesCollection[i].Name < s.SerializedSeriesCollection[j].Name
+	}
+	return false
 }

--- a/metastore/store.go
+++ b/metastore/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"sync"
 
 	"github.com/influxdb/influxdb/protocol"
@@ -134,6 +135,7 @@ func (self *Store) GetSeriesForDatabaseAndRegex(database string, regex *regexp.R
 			matchingSeries = append(matchingSeries, series)
 		}
 	}
+	sort.Strings(matchingSeries)
 	return matchingSeries
 }
 
@@ -148,6 +150,7 @@ func (self *Store) GetSeriesForDatabase(database string) []string {
 	for s := range databaseSeries {
 		series = append(series, s)
 	}
+	sort.Strings(series)
 	return series
 }
 


### PR DESCRIPTION
Fix #830. Tests and implementation to ensure that list series with or without a regex return in sorted order. Queries that select from a regex will return series in sorted order.
