### PR TITLE
Move cluster config from raft to API.

### DIFF
--- a/api/http/api.go
+++ b/api/http/api.go
@@ -154,6 +154,7 @@ func (self *HttpServer) Serve(listener net.Listener) {
 	self.registerEndpoint(p, "get", "/interfaces", self.listInterfaces)
 
 	// cluster config endpoints
+	self.registerEndpoint(p, "get", "/cluster/configuration", self.getClusterConfiguration)
 	self.registerEndpoint(p, "get", "/cluster/servers", self.listServers)
 	self.registerEndpoint(p, "del", "/cluster/servers/:id", self.removeServers)
 	self.registerEndpoint(p, "post", "/cluster/shards", self.createShard)
@@ -1240,5 +1241,11 @@ func (self *HttpServer) migrateData(w libhttp.ResponseWriter, r *libhttp.Request
 		}()
 
 		return libhttp.StatusAccepted, nil
+	})
+}
+
+func (self *HttpServer) getClusterConfiguration(w libhttp.ResponseWriter, r *libhttp.Request) {
+	self.tryAsClusterAdmin(w, r, func(u User) (int, interface{}) {
+		return libhttp.StatusOK, self.clusterConfig.SerializableConfiguration()
 	})
 }

--- a/coordinator/raft_server.go
+++ b/coordinator/raft_server.go
@@ -541,7 +541,6 @@ func (s *RaftServer) Serve(l net.Listener) error {
 		Handler: s.router,
 	}
 
-	s.router.HandleFunc("/cluster_config", s.configHandler).Methods("GET")
 	s.router.HandleFunc("/join", s.joinHandler).Methods("POST")
 	s.router.HandleFunc("/process_command/{command_type}", s.processCommandHandler).Methods("POST")
 
@@ -672,14 +671,6 @@ func (s *RaftServer) joinHandler(w http.ResponseWriter, req *http.Request) {
 	} else {
 		http.Error(w, errors.New("Couldn't find leader of the cluster to join").Error(), http.StatusInternalServerError)
 	}
-}
-
-func (s *RaftServer) configHandler(w http.ResponseWriter, req *http.Request) {
-	js, err := json.Marshal(s.clusterConfig.GetMapForJsonSerialization())
-	if err != nil {
-		log.Error("ERROR marshalling config: ", err)
-	}
-	w.Write(js)
 }
 
 func (s *RaftServer) marshalAndDoCommandFromBody(command raft.Command, req *http.Request) (interface{}, error) {

--- a/integration/single_server_test.go
+++ b/integration/single_server_test.go
@@ -945,3 +945,24 @@ func (self *SingleServerSuite) TestSeriesShouldReturnSorted(c *C) {
 		c.Assert(s.Name, Equals, fmt.Sprintf("sort_%.3d", i+1))
 	}
 }
+
+// for issue #853 https://github.com/influxdb/influxdb/issues/853
+func (self *SingleServerSuite) TestApiReturnsClusterConfigOnlyIfAdmin(c *C) {
+	resp, err := http.Get("http://localhost:8086/cluster/configuration?u=root&p=root")
+	c.Assert(err, IsNil)
+	decoder := json.NewDecoder(resp.Body)
+	m := make(map[string]interface{})
+	err = decoder.Decode(&m)
+	c.Assert(err, IsNil)
+	c.Assert(m["Admins"], NotNil)
+	c.Assert(m["DbUsers"], NotNil)
+	c.Assert(m["Databases"], NotNil)
+	c.Assert(m["Servers"], NotNil)
+	c.Assert(m["ContinuousQueries"], NotNil)
+	c.Assert(m["MetaStore"], NotNil)
+	c.Assert(m["Shards"], NotNil)
+	c.Assert(m["DatabaseShardSpaces"], NotNil)
+
+	resp, _ = http.Get("http://localhost:8086/cluster/configuration")
+	c.Assert(resp.StatusCode, Equals, http.StatusUnauthorized)
+}


### PR DESCRIPTION
Fixes #853. Previously, there was an unprotected endpoint in raft to return the cluster config that would include user hashes. This endpoint is useful for debugging purposes so I restructured it and moved it to the API. It ensures the requesting user is a cluster admin.

Cluster config will now return all of the cluster state including servers, CQs, shards, etc.
