### PR TITLE
GetLeaderRaftConnectString returns consistent result

### DIFF
--- a/api/http/api.go
+++ b/api/http/api.go
@@ -986,21 +986,20 @@ func (self *HttpServer) listServers(w libhttp.ResponseWriter, r *libhttp.Request
 		servers := self.clusterConfig.Servers()
 		serverMaps := make([]map[string]interface{}, len(servers), len(servers))
 
-		//FIXME: GetLeaderConnectString is not consistent yet when called on different server.
-		leaderConnectString, _ := self.raftServer.GetLeaderConnectString()
+		leaderRaftConnectString, _ := self.raftServer.GetLeaderRaftConnectString()
 		leaderRaftName := self.raftServer.GetLeaderRaftName()
 		for i, s := range servers {
 			serverMaps[i] = map[string]interface{}{
 				"id": s.Id,
-				"protobufConnectString": s.ProtobufConnectionString,
-				"isUp":                  s.IsUp(), //FIXME: IsUp is not consistent
-				"raftName":              s.RaftName,
-				"state":                 s.State,
-				"stateName":             s.GetStateName(),
-				"raftConnectionString":  s.RaftConnectionString,
-				"leaderRaftName":        leaderRaftName,
-				"leaderConnectString":   leaderConnectString,
-				"isLeader":              self.raftServer.IsLeaderByRaftName(s.RaftName)}
+				"protobufConnectString":   s.ProtobufConnectionString,
+				"isUp":                    s.IsUp(), //FIXME: IsUp is not consistent
+				"raftName":                s.RaftName,
+				"state":                   s.State,
+				"stateName":               s.GetStateName(),
+				"raftConnectionString":    s.RaftConnectionString,
+				"leaderRaftName":          leaderRaftName,
+				"leaderRaftConnectString": leaderRaftConnectString,
+				"isLeader":                self.raftServer.IsLeaderByRaftName(s.RaftName)}
 		}
 		return libhttp.StatusOK, serverMaps
 	})

--- a/coordinator/raft_server.go
+++ b/coordinator/raft_server.go
@@ -124,8 +124,15 @@ func (s *RaftServer) IsLeaderByRaftName(name string) bool {
 	return s.raftServer.Leader() == name
 }
 
-func (s *RaftServer) GetLeaderConnectString() (string, bool) {
-	return s.leaderConnectString()
+/**
+* return a consistant leader raft connection string when called on all living nodes include leader.
+ */
+func (s *RaftServer) GetLeaderRaftConnectString() (string, bool) {
+	if s.IsLeaderByRaftName(s.name) {
+		return s.config.RaftConnectionString(), true
+	} else {
+		return s.leaderConnectString()
+	}
 }
 
 func (s *RaftServer) leaderConnectString() (string, bool) {


### PR DESCRIPTION
return a consistant leader raft connection string when called on all living nodes include leader.
