### PR TITLE
Set a high default open files setting in init script.

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -70,6 +70,9 @@ pidfile=/opt/influxdb/shared/influxdb.pid
 # Configuration file
 config=/opt/$name/shared/config.toml
 
+# Maximum number of open files
+MAX_OPEN_FILES=32768
+
 # If the daemon is not there, then exit.
 [ -x $daemon ] || exit 5
 
@@ -86,6 +89,10 @@ case $1 in
         fi
         # Start the daemon.
         log_success_msg "Starting the process" "$name"
+        # Set default max open files in current shell env
+        if [ -n "$MAX_OPEN_FILES" ]; then
+            ulimit -n $MAX_OPEN_FILES
+        fi
         # Start the daemon with the help of start-stop-daemon
         # Log the message appropriately
         cd /


### PR DESCRIPTION
This commit sets 32768 as a default open file limit in current shell env and should be better than the default distributions settings (e.g. default on ubuntu 12.04 is 1024).
