### PR TITLE
Refactor TestAll test loop in data_test.go

### DIFF
--- a/integration/helpers/data_test_client.go
+++ b/integration/helpers/data_test_client.go
@@ -20,6 +20,12 @@ func (self *DataTestClient) CreateDatabase(db string, c *C) {
 	c.Assert(client.CreateDatabase(db), IsNil)
 }
 
+func (self *DataTestClient) DeleteDatabase(db string, c *C) {
+	client, err := influxdb.NewClient(&influxdb.ClientConfig{})
+	c.Assert(err, IsNil)
+	c.Assert(client.DeleteDatabase(db), IsNil)
+}
+
 func (self *DataTestClient) SetDB(db string) {
 	self.db = db
 }


### PR DESCRIPTION
Combine the three separate loops for DB creation, running setup
functions, and running tests into one loop.  Add a DB delete at the
end of each test for cleanup.

This groups output for each test together in one place.  It also has
the advantage of not running all DB creations and setup functions until
they're needed.
