### PR TITLE
Aggregation by time interval should respect the natural boundaries of the argument

### DIFF
--- a/cluster/shard.go
+++ b/cluster/shard.go
@@ -395,7 +395,7 @@ func (self *ShardData) ShouldAggregateLocally(querySpec *parser.QuerySpec) bool 
 		}
 		return true
 	}
-	return self.shardDuration%*groupByInterval == 0
+	return (self.shardDuration%*groupByInterval == 0) && !querySpec.GroupByIrregularInterval
 }
 
 type Shards []*ShardData

--- a/cluster/shard_space.go
+++ b/cluster/shard_space.go
@@ -71,12 +71,12 @@ func (s *ShardSpace) Validate(clusterConfig *ClusterConfiguration, checkForDb bo
 		s.ReplicationFactor = DEFAULT_REPLICATION_FACTOR
 	}
 	if s.ShardDuration != "" {
-		if _, err := common.ParseTimeDuration(s.ShardDuration); err != nil {
+		if _, _, err := common.ParseTimeDuration(s.ShardDuration); err != nil {
 			return err
 		}
 	}
 	if s.RetentionPolicy != "" && s.RetentionPolicy != "inf" {
-		if _, err := common.ParseTimeDuration(s.RetentionPolicy); err != nil {
+		if _, _, err := common.ParseTimeDuration(s.RetentionPolicy); err != nil {
 			return err
 		}
 	}
@@ -121,13 +121,13 @@ func (s *ShardSpace) ParsedRetentionPeriod() time.Duration {
 	} else if s.RetentionPolicy == "inf" {
 		return time.Duration(0)
 	}
-	d, _ := common.ParseTimeDuration(s.RetentionPolicy)
+	d, _, _ := common.ParseTimeDuration(s.RetentionPolicy)
 	return time.Duration(d)
 }
 
 func (s *ShardSpace) ParsedShardDuration() time.Duration {
 	if s.ShardDuration != "" {
-		d, _ := common.ParseTimeDuration(s.ShardDuration)
+		d, _, _ := common.ParseTimeDuration(s.ShardDuration)
 		return time.Duration(d)
 	}
 	return DEFAULT_SHARD_DURATION

--- a/coordinator/raft_server.go
+++ b/coordinator/raft_server.go
@@ -273,7 +273,7 @@ func (s *RaftServer) CreateContinuousQuery(db string, query string) error {
 		return fmt.Errorf("Continuous queries with :series_name interpolation must use a regular expression in the from clause that prevents recursion")
 	}
 
-	duration, err := selectQuery.GetGroupByClause().GetGroupByTime()
+	duration, _, err := selectQuery.GetGroupByClause().GetGroupByTime()
 	if err != nil {
 		return fmt.Errorf("Couldn't get group by time for continuous query: %s", err)
 	}
@@ -497,7 +497,7 @@ func (s *RaftServer) checkContinuousQueries() {
 				continue
 			}
 
-			duration, err := query.GetGroupByClause().GetGroupByTime()
+			duration, _, err := query.GetGroupByClause().GetGroupByTime()
 			if err != nil {
 				log.Error("Couldn't get group by time for continuous query:", err)
 				continue

--- a/integration/data_test.go
+++ b/integration/data_test.go
@@ -1454,6 +1454,167 @@ func (self *DataTestSuite) TestGroupByDay(c *C) {
 	c.Assert(maps[1]["count"], Equals, 1.0)
 }
 
+func (self *DataTestSuite) TestLogicalGroupByBoundariesForWeek(c *C) {
+	tueSep30 := time.Date(2014, 9, 30, 12, 0, 0, 0, time.UTC).Unix()
+	friOct03 := time.Date(2014, 10, 3, 12, 0, 0, 0, time.UTC).Unix()
+	monOct06 := time.Date(2014, 10, 6, 12, 0, 0, 0, time.UTC).Unix()
+
+	sunSep28 := time.Date(2014, 9, 28, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+	sunOct05 := time.Date(2014, 10, 5, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+	data := fmt.Sprintf(`
+  [{
+    "name": "test_group_by_week",
+    "columns": ["value", "time"],
+    "points": [
+      [1, %d],
+      [2, %d],
+      [3, %d],
+
+      [4, %d],
+      [5, %d],
+      [6, %d],
+      [7, %d],
+
+      [8, %d],
+      [9, %d]
+    ]
+  }]`, tueSep30, tueSep30, tueSep30, friOct03, friOct03, friOct03, friOct03, monOct06, monOct06)
+
+	self.client.WriteJsonData(data, c, "s")
+	collection := self.client.RunQuery("select count(value) from test_group_by_week group by time(1w)", c)
+	c.Assert(collection, HasLen, 1)
+	maps := ToMap(collection[0])
+	c.Assert(maps, HasLen, 2)
+	c.Assert(maps[0], DeepEquals, map[string]interface{}{"time": float64(sunOct05), "count": 2.0})
+	c.Assert(maps[1], DeepEquals, map[string]interface{}{"time": float64(sunSep28), "count": 7.0})
+}
+
+func (self *DataTestSuite) TestLogicalGroupByBoundariesForMonth(c *C) {
+	aug30 := time.Date(2014, 8, 30, 12, 0, 0, 0, time.UTC).Unix()
+	aug31 := time.Date(2014, 8, 31, 12, 0, 0, 0, time.UTC).Unix()
+	sep01 := time.Date(2014, 9, 1, 12, 0, 0, 0, time.UTC).Unix()
+	sep30 := time.Date(2014, 9, 30, 12, 0, 0, 0, time.UTC).Unix()
+	oct01 := time.Date(2014, 10, 1, 12, 0, 0, 0, time.UTC).Unix()
+
+	aug := time.Date(2014, 8, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+	sep := time.Date(2014, 9, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+	oct := time.Date(2014, 10, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+
+	data := fmt.Sprintf(`
+  [{
+    "name": "test_group_by_month",
+    "columns": ["value", "time"],
+    "points": [
+      [1, %d],
+      [2, %d],
+      [3, %d],
+
+      [4, %d],
+      [5, %d],
+      [6, %d],
+      [7, %d],
+      [8, %d],
+      [9, %d],
+
+      [10, %d],
+      [11, %d]
+    ]
+  }]`, aug30, aug31, aug31, sep01, sep01, sep01, sep01, sep30, sep30, oct01, oct01)
+
+	self.client.WriteJsonData(data, c, "s")
+	collection := self.client.RunQuery("select count(value) from test_group_by_month group by time(1M)", c)
+	c.Assert(collection, HasLen, 1)
+	maps := ToMap(collection[0])
+	c.Assert(maps, HasLen, 3)
+	c.Assert(maps[0], DeepEquals, map[string]interface{}{"time": float64(oct), "count": 2.0})
+	c.Assert(maps[1], DeepEquals, map[string]interface{}{"time": float64(sep), "count": 6.0})
+	c.Assert(maps[2], DeepEquals, map[string]interface{}{"time": float64(aug), "count": 3.0})
+}
+
+func (self *DataTestSuite) TestLogicalGroupByBoundariesForMonthDuringLeapYear(c *C) {
+	jan31 := time.Date(2012, 1, 31, 12, 0, 0, 0, time.UTC).Unix()
+	feb01 := time.Date(2012, 2, 1, 12, 0, 0, 0, time.UTC).Unix()
+	feb28 := time.Date(2012, 2, 28, 12, 0, 0, 0, time.UTC).Unix()
+	feb29 := time.Date(2012, 2, 29, 12, 0, 0, 0, time.UTC).Unix()
+	mar01 := time.Date(2012, 3, 1, 12, 0, 0, 0, time.UTC).Unix()
+
+	jan := time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+	feb := time.Date(2012, 2, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+	mar := time.Date(2012, 3, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+
+	data := fmt.Sprintf(`
+  [{
+    "name": "test_group_by_month",
+    "columns": ["value", "time"],
+    "points": [
+      [1, %d],
+      [2, %d],
+      [3, %d],
+
+      [4, %d],
+      [5, %d],
+      [6, %d],
+      [7, %d],
+      [8, %d],
+      [9, %d],
+
+      [10, %d],
+      [11, %d]
+    ]
+  }]`, jan31, jan31, jan31, feb01, feb01, feb28, feb28, feb28, feb29, mar01, mar01)
+
+	self.client.WriteJsonData(data, c, "s")
+	collection := self.client.RunQuery("select count(value) from test_group_by_month group by time(1M)", c)
+	c.Assert(collection, HasLen, 1)
+	maps := ToMap(collection[0])
+	c.Assert(maps, HasLen, 3)
+	c.Assert(maps[0], DeepEquals, map[string]interface{}{"time": float64(mar), "count": 2.0})
+	c.Assert(maps[1], DeepEquals, map[string]interface{}{"time": float64(feb), "count": 6.0})
+	c.Assert(maps[2], DeepEquals, map[string]interface{}{"time": float64(jan), "count": 3.0})
+}
+
+func (self *DataTestSuite) TestLogicalGroupByBoundariesForYear(c *C) {
+	dec31of2012 := time.Date(2012, 12, 31, 12, 0, 0, 0, time.UTC).Unix()
+	jan01of2013 := time.Date(2013, 1, 1, 12, 0, 0, 0, time.UTC).Unix()
+	feb01of2013 := time.Date(2013, 2, 1, 12, 0, 0, 0, time.UTC).Unix()
+	dec31of2013 := time.Date(2013, 12, 31, 12, 0, 0, 0, time.UTC).Unix()
+	jan01of2014 := time.Date(2014, 1, 1, 12, 0, 0, 0, time.UTC).Unix()
+
+	year2012 := time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+	year2013 := time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+	year2014 := time.Date(2014, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
+
+	data := fmt.Sprintf(`
+  [{
+    "name": "test_group_by_month",
+    "columns": ["value", "time"],
+    "points": [
+      [1, %d],
+
+      [2, %d],
+      [3, %d],
+      [4, %d],
+      [5, %d],
+      [6, %d],
+      [7, %d],
+      [8, %d],
+      [9, %d],
+
+      [10, %d],
+      [11, %d]
+    ]
+  }]`, dec31of2012, jan01of2013, jan01of2013, feb01of2013, feb01of2013, feb01of2013, feb01of2013, dec31of2013, dec31of2013, jan01of2014, jan01of2014)
+
+	self.client.WriteJsonData(data, c, "s")
+	collection := self.client.RunQuery("select count(value) from test_group_by_month group by time(1Y)", c)
+	c.Assert(collection, HasLen, 1)
+	maps := ToMap(collection[0])
+	c.Assert(maps, HasLen, 3)
+	c.Assert(maps[0], DeepEquals, map[string]interface{}{"time": float64(year2014), "count": 2.0})
+	c.Assert(maps[1], DeepEquals, map[string]interface{}{"time": float64(year2013), "count": 8.0})
+	c.Assert(maps[2], DeepEquals, map[string]interface{}{"time": float64(year2012), "count": 1.0})
+}
+
 func (self *DataTestSuite) TestLimitQueryOnSingleShard(c *C) {
 	data := `[{"points": [[4], [10], [5]], "name": "test_limit_query_single_shard", "columns": ["value"]}]`
 	self.client.WriteJsonData(data, c)

--- a/parser/group_by.go
+++ b/parser/group_by.go
@@ -16,27 +16,27 @@ type GroupByClause struct {
 	Elems        []*Value
 }
 
-func (self GroupByClause) GetGroupByTime() (*time.Duration, error) {
+func (self GroupByClause) GetGroupByTime() (*time.Duration, bool, error) {
 	for _, groupBy := range self.Elems {
 		if groupBy.IsFunctionCall() && strings.ToLower(groupBy.Name) == "time" {
 			// TODO: check the number of arguments and return an error
 			if len(groupBy.Elems) != 1 {
-				return nil, common.NewQueryError(common.WrongNumberOfArguments, "time function only accepts one argument")
+				return nil, false, common.NewQueryError(common.WrongNumberOfArguments, "time function only accepts one argument")
 			}
 
 			if groupBy.Elems[0].Type != ValueDuration {
 				log.Debug("Get a time function without a duration argument %v", groupBy.Elems[0].Type)
 			}
 			arg := groupBy.Elems[0].Name
-			durationInt, err := common.ParseTimeDuration(arg)
+			durationInt, irregularInterval, err := common.ParseTimeDuration(arg)
 			if err != nil {
-				return nil, common.NewQueryError(common.InvalidArgument, fmt.Sprintf("invalid argument %s to the time function", arg))
+				return nil, false, common.NewQueryError(common.InvalidArgument, fmt.Sprintf("invalid argument %s to the time function", arg))
 			}
 			duration := time.Duration(durationInt)
-			return &duration, nil
+			return &duration, irregularInterval, nil
 		}
 	}
-	return nil, nil
+	return nil, false, nil
 }
 
 func (self *GroupByClause) GetString() string {

--- a/parser/query_api.go
+++ b/parser/query_api.go
@@ -294,7 +294,9 @@ func parseTime(value *Value) (int64, error) {
 			return t.UnixNano(), err
 		}
 
-		return common.ParseTimeDuration(value.Name)
+		duration, _, err := common.ParseTimeDuration(value.Name)
+
+		return duration, err
 	}
 
 	leftValue, err := parseTime(value.Elems[0])

--- a/parser/query_spec.go
+++ b/parser/query_spec.go
@@ -18,6 +18,7 @@ type QuerySpec struct {
 	endTime                     time.Time
 	seriesValuesAndColumns      map[*Value][]string
 	RunAgainstAllServersInShard bool
+	GroupByIrregularInterval    bool
 	groupByInterval             *time.Duration
 	groupByColumnCount          int
 }
@@ -127,7 +128,7 @@ func (self *QuerySpec) GetGroupByInterval() *time.Duration {
 		return nil
 	}
 	if self.groupByInterval == nil {
-		self.groupByInterval, _ = self.query.SelectQuery.GetGroupByClause().GetGroupByTime()
+		self.groupByInterval, self.GroupByIrregularInterval, _ = self.query.SelectQuery.GetGroupByClause().GetGroupByTime()
 	}
 	return self.groupByInterval
 }


### PR DESCRIPTION
minute, hour are straight forward. Grouping by 1d should make sure we bucket points between 00:00 UTC (midnight of consecutive days), 1w/7d should bucket points between consecutive mondays, etc. This story should deal with utc only, handling different timezones will be handled in a different issue.

<!---
@huboard:{"order":502.0,"milestone_order":387,"custom_state":""}
-->
