### PR TITLE
Fix #1004. Querying for data outside of existing shards should return an empty response.

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -275,7 +275,7 @@ func (self *Coordinator) runQuerySpec(querySpec *parser.QuerySpec, p engine.Proc
 	}
 
 	if len(shards) == 0 {
-		return fmt.Errorf("Couldn't look up columns")
+		return processor.Close()
 	}
 
 	shardConcurrentLimit := self.config.ConcurrentShardQueryLimit


### PR DESCRIPTION
<!---
@huboard:{"order":748.0,"milestone_order":1023,"custom_state":""}
-->
