### PR TITLE
misleading error trying to select from non-existent series

### DIFF
--- a/cluster/cluster_configuration.go
+++ b/cluster/cluster_configuration.go
@@ -920,7 +920,7 @@ func (self *ClusterConfiguration) getShardsToMatchQuery(querySpec *parser.QueryS
 	uniqueShards := make(map[uint32]*ShardData)
 	for _, name := range seriesNames {
 		if fs := self.MetaStore.GetFieldsForSeries(db, name); len(fs) == 0 {
-			return nil, fmt.Errorf("Couldn't look up columns for series: %s", name)
+			return nil, fmt.Errorf("Couldn't find series: %s", name)
 		}
 		space := self.getShardSpaceToMatchSeriesName(db, name)
 		if space == nil {

--- a/datastore/shard.go
+++ b/datastore/shard.go
@@ -429,7 +429,7 @@ func (self *Shard) getIterators(fields []*metastore.Field, start, end time.Time,
 func (self *Shard) getFieldsForSeries(db, series string, columns []string) ([]*metastore.Field, error) {
 	allFields := self.metaStore.GetFieldsForSeries(db, series)
 	if len(allFields) == 0 {
-		return nil, FieldLookupError{"Couldn't look up columns for series: " + series}
+		return nil, FieldLookupError{"Couldn't find series: " + series}
 	}
 	if len(columns) > 0 && columns[0] == "*" {
 		return allFields, nil

--- a/integration/continuous_queries_test.go
+++ b/integration/continuous_queries_test.go
@@ -78,5 +78,5 @@ func (self *ContinuousQueriesSuite) TestFirstBackfill(c *C) {
 
 	// check backfill_off query results
 	body, _ := self.serverProcesses[0].GetErrorBody("test_no_backfill", "select * from cqbackfill_off.10s", "root", "root", false, c)
-	c.Assert(body, Matches, "Couldn't look up columns.*")
+	c.Assert(body, Matches, "Couldn't find series.*")
 }

--- a/integration/data_test.go
+++ b/integration/data_test.go
@@ -121,6 +121,12 @@ func (self *DataTestSuite) TestDerivativeValues(c *C) {
 	c.Assert(maps[0]["derivative"], Equals, 10.0)
 }
 
+func (self *DataTestSuite) TestInvalidSeriesInSelect(c *C) {
+	client := self.server.GetClient(self.dbname, c)
+	_, err := client.Query("select value from some_invalid_series_name", "m")
+	c.Assert(err, ErrorMatches, ".*Couldn't find series: some_invalid_series_name.*")
+}
+
 // Simple case of difference function
 func (self *DataTestSuite) TestDifferenceValues(c *C) {
 	// make sure we exceed the pointBatchSize, so we force a yield to

--- a/integration/multiple_servers_test.go
+++ b/integration/multiple_servers_test.go
@@ -494,7 +494,7 @@ func (self *ServerSuite) TestDropDatabase(c *C) {
 	for _, s := range self.serverProcesses {
 		fmt.Printf("Running query against: %d\n", s.ApiPort())
 		error, _ := s.GetErrorBody("drop_db", "select * from cluster_query", "paul", "pass", true, c)
-		c.Assert(error, Matches, ".*Couldn't look up.*")
+		c.Assert(error, Matches, ".*Couldn't find series.*")
 	}
 }
 
@@ -543,7 +543,7 @@ func (self *ServerSuite) TestDropSeries(c *C) {
 		for _, s := range self.serverProcesses {
 			fmt.Printf("Running query against: %d\n", s.ApiPort())
 			error, _ := s.GetErrorBody("drop_series", "select * from cluster_query.1", "paul", "pass", true, c)
-			c.Assert(error, Matches, ".*Couldn't look up.*")
+			c.Assert(error, Matches, ".*Couldn't find series.*")
 		}
 	}
 }
@@ -1256,7 +1256,7 @@ func (self *ServerSuite) TestContinuousQueryBackfillOperations(c *C) {
 
 	// check backfill_off query results
 	body, _ := self.serverProcesses[0].GetErrorBody("test_cq", "select * from cqbackfill_off.10s", "root", "root", false, c)
-	c.Assert(body, Matches, "Couldn't look up columns for series: cqbackfill_off.10s")
+	c.Assert(body, Matches, "Couldn't find series: cqbackfill_off.10s")
 }
 
 func (self *ServerSuite) TestChangingRaftPort(c *C) {

--- a/integration/single_server_test.go
+++ b/integration/single_server_test.go
@@ -413,7 +413,7 @@ func (self *SingleServerSuite) TestUserWritePermissions(c *C) {
 	// if this test ran by itself there will be no shards to query,
 	// therefore no error will be returned
 	if err != nil {
-		c.Assert(err, ErrorMatches, ".*Couldn't look up.*")
+		c.Assert(err, ErrorMatches, ".*Couldn't find series.*")
 	} else {
 		c.Assert(actualSeries, HasLen, 0)
 	}
@@ -581,7 +581,7 @@ func (self *SingleServerSuite) TestDataResurrectionAfterRestart(c *C) {
 	c.Assert(self.server.Start(), IsNil)
 	self.server.WaitForServerToStart()
 	error, _ := self.server.GetErrorBody("db1", "select count(column0) from data_resurrection", "user", "pass", true, c)
-	c.Assert(error, Matches, ".*Couldn't look up.*")
+	c.Assert(error, Matches, ".*Couldn't find series.*")
 	series = self.server.RunQuery("list series", "s", c)
 	c.Assert(series, HasLen, 1)
 	c.Assert(series[0].Points, HasLen, 0)
@@ -759,7 +759,7 @@ func (self *SingleServerSuite) TestDbDelete(c *C) {
 	self.createUser(c)
 	// this shouldn't return any data
 	error, _ := self.server.GetErrorBody("db1", "select val1 from test_deletetions", "root", "root", true, c)
-	c.Assert(error, Matches, ".*Couldn't look up.*")
+	c.Assert(error, Matches, ".*Couldn't find series.*")
 }
 
 // test delete query


### PR DESCRIPTION
```
graphite> select * from this-series-DEFINITELY-doesnt-exist
graphite> ✘ Error: Couldn't look up columns for series: this-series-DEFINITELY-doesnt-exist
```

error should be something like "series 'this-series-DEFINITELY-doesnt-exist' not found"

<!---
@huboard:{"order":743.0,"milestone_order":778,"custom_state":""}
-->
