### PR TITLE
critical errors don't hit stderr

### DIFF
--- a/scripts/influxdb-daemon.sh
+++ b/scripts/influxdb-daemon.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-nohup /usr/bin/influxdb "$@" > /dev/null 2>&1 &
+nohup /usr/bin/influxdb "$@" &

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -35,6 +35,10 @@ if [ $NOFILES -le 0 ]; then
     NOFILES=4096
 fi
 
+if [ "x$STDOUT" == "x" ]; then
+    STDOUT=/dev/null
+fi
+
 echo "Setting ulimit -n $NOFILES"
 if ! ulimit -n $NOFILES >/dev/null 2>&1; then
     echo -n "Cannot set the max number of open file descriptors"
@@ -109,11 +113,11 @@ case $1 in
         # Log the message appropriately
         cd /
         if which start-stop-daemon > /dev/null 2>&1; then
-            nohup start-stop-daemon --chuid influxdb:influxdb -d / --start --quiet --oknodo --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config > /dev/null 2>&1 &
+            nohup start-stop-daemon --chuid influxdb:influxdb -d / --start --quiet --oknodo --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $config >> $STDOUT 2>&1 &
         elif set | egrep '^start_daemon' > /dev/null 2>&1; then
-            start_daemon -u influxdb ${daemon}-daemon -pidfile $pidfile -config $config
+            start_daemon -u influxdb ${daemon}-daemon -pidfile $pidfile -config $config >> $STDOUT 2>&1
         else
-            sudo -u influxdb -g influxdb ${daemon}-daemon -pidfile $pidfile -config $config
+            sudo -u influxdb -g influxdb ${daemon}-daemon -pidfile $pidfile -config $config >> $STDOUT 2>&1
         fi
         log_success_msg "$name process was started"
         ;;


### PR DESCRIPTION
So I ran out of file descriptors earlier (not sure why as my limits.conf should allow enough) but I was oblivious of this fact (and the fact) that influxdb was not performing correctly because the stdout was pristine.

_log.txt_ however told a much different story; showing how it could not write shard files and read them.  Really this should be in stdout as loosing something like this due to log rotation and lots of data in the log file is :(
