### PR TITLE
Investigate possible performance bug with limit 1 queries with where clause

### DIFF
--- a/datastore/shard.go
+++ b/datastore/shard.go
@@ -208,6 +208,8 @@ func (self *Shard) executeQueryForSeries(querySpec *parser.QuerySpec, name strin
 				if err != nil {
 					log.Error("Error while processing data: %v", err)
 					return err
+				} else {
+					return nil
 				}
 			}
 			seriesOutgoing = &protocol.Series{Name: protocol.String(name), Fields: columns, Points: make([]*protocol.Point, 0, self.pointBatchSize)}


### PR DESCRIPTION
This blog post: http://www.ryandaigle.com/a/time-series-db-design-with-influx mentions getting a performance increase on a query like this:

``` sql
select value
  from gateway.account.sample
  where account_key = 'abc123'
  limit 1

-- and this gives same result, but much better performance
select value
  from gateway.account.sample
  where time > now() - 2d
    and account_key = 'abc123'
  limit 1
```

This is on a series that has hundreds of thousands of points. This looks to me like the range scan is still going through after the limit has already been hit.

We need to look into this and ensure that once the limit is hit, the scan stops.
