### PR TITLE
Add func to get str desc of Processor chain

### DIFF
--- a/api/http/series_writer.go
+++ b/api/http/series_writer.go
@@ -3,6 +3,7 @@ package http
 // This implements the SeriesWriter interface for use with the API
 
 import (
+	"github.com/influxdb/influxdb/engine"
 	"github.com/influxdb/influxdb/protocol"
 )
 
@@ -28,4 +29,8 @@ func (self *SeriesWriter) Close() error {
 
 func (self *SeriesWriter) Name() string {
 	return "SeriesWriter"
+}
+
+func (self *SeriesWriter) Next() engine.Processor {
+	return nil
 }

--- a/cluster/nil_processor.go
+++ b/cluster/nil_processor.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 
+	"github.com/influxdb/influxdb/engine"
 	"github.com/influxdb/influxdb/protocol"
 )
 
@@ -17,5 +18,9 @@ func (np NilProcessor) Yield(s *protocol.Series) (bool, error) {
 }
 
 func (np NilProcessor) Close() error {
+	return nil
+}
+
+func (np NilProcessor) Next() engine.Processor {
 	return nil
 }

--- a/cluster/response_channel_processor.go
+++ b/cluster/response_channel_processor.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"code.google.com/p/log4go"
+	"github.com/influxdb/influxdb/engine"
 	"github.com/influxdb/influxdb/protocol"
 )
 
@@ -33,4 +34,8 @@ func (p *ResponseChannelProcessor) Close() error {
 
 func (p *ResponseChannelProcessor) Name() string {
 	return "ResponseChannelProcessor"
+}
+
+func (p *ResponseChannelProcessor) Next() engine.Processor {
+	return nil
 }

--- a/cluster/shard.go
+++ b/cluster/shard.go
@@ -311,7 +311,6 @@ func (self *ShardData) Query(querySpec *parser.QuerySpec, response chan<- *p.Res
 			log.Error("Error while creating engine: %s", err)
 			return
 		}
-
 		shard, err := self.store.GetOrCreateShard(self.id)
 		if err != nil {
 			response <- &p.Response{
@@ -322,6 +321,9 @@ func (self *ShardData) Query(querySpec *parser.QuerySpec, response chan<- *p.Res
 			return
 		}
 		defer self.store.ReturnShard(self.id)
+
+		log.Info("Processor chain:  %s\n", engine.ProcessorChain(processor))
+
 		err = shard.Query(querySpec, processor)
 		// if we call Close() in case of an error it will mask the error
 		if err != nil {

--- a/cluster/shard_id_inserter.go
+++ b/cluster/shard_id_inserter.go
@@ -29,3 +29,6 @@ func (sip ShardIdInserterProcessor) Close() error {
 func (sip ShardIdInserterProcessor) Name() string {
 	return fmt.Sprintf("ShardIdInserterProcessor (%d)", sip.id)
 }
+func (sip ShardIdInserterProcessor) Next() engine.Processor {
+	return sip.next
+}

--- a/coordinator/continuous_query_writer.go
+++ b/coordinator/continuous_query_writer.go
@@ -4,6 +4,7 @@ package coordinator
 // queries to write their output back into the db
 
 import (
+	"github.com/influxdb/influxdb/engine"
 	"github.com/influxdb/influxdb/parser"
 	"github.com/influxdb/influxdb/protocol"
 )
@@ -47,4 +48,8 @@ func (self *ContinuousQueryWriter) Close() error {
 
 func (self *ContinuousQueryWriter) Name() string {
 	return "ContinuousQueryWriter"
+}
+
+func (self *ContinuousQueryWriter) Next() engine.Processor {
+	return nil
 }

--- a/engine/aggregator_engine.go
+++ b/engine/aggregator_engine.go
@@ -43,7 +43,7 @@ type AggregatorEngine struct {
 }
 
 func (self *AggregatorEngine) Name() string {
-	return "Aggregator Engine"
+	return "AggregatorEngine"
 }
 
 func (self *AggregatorEngine) Close() error {
@@ -328,6 +328,10 @@ func (self *AggregatorEngine) getValuesForGroup(table string, group []*protocol.
 
 func (self *AggregatorEngine) init(query *parser.SelectQuery) error {
 	return nil
+}
+
+func (self *AggregatorEngine) Next() Processor {
+	return self.next
 }
 
 func NewAggregatorEngine(query *parser.SelectQuery, next Processor) (*AggregatorEngine, error) {

--- a/engine/arithmetic_engine.go
+++ b/engine/arithmetic_engine.go
@@ -78,3 +78,7 @@ func (self *ArithmeticEngine) Close() error {
 func (self *ArithmeticEngine) Name() string {
 	return "Arithmetic Engine"
 }
+
+func (self *ArithmeticEngine) Next() Processor {
+	return self.next
+}

--- a/engine/common_merge_engine.go
+++ b/engine/common_merge_engine.go
@@ -47,3 +47,7 @@ func (cme *CommonMergeEngine) Yield(s *protocol.Series) (bool, error) {
 func (cme *CommonMergeEngine) Name() string {
 	return "CommonMergeEngine"
 }
+
+func (self *CommonMergeEngine) Next() Processor {
+	return self.next
+}

--- a/engine/filtering_engine.go
+++ b/engine/filtering_engine.go
@@ -40,3 +40,7 @@ func (self *FilteringEngine) Close() error {
 func (self *FilteringEngine) Name() string {
 	return self.processor.Name()
 }
+
+func (self *FilteringEngine) Next() Processor {
+	return self.processor.Next()
+}

--- a/engine/join_engine.go
+++ b/engine/join_engine.go
@@ -85,3 +85,7 @@ func (je *JoinEngine) Yield(s *protocol.Series) (bool, error) {
 	}
 	return true, nil
 }
+
+func (self *JoinEngine) Next() Processor {
+	return self.next
+}

--- a/engine/merge_engine.go
+++ b/engine/merge_engine.go
@@ -32,3 +32,7 @@ func (me *MergeEngine) Close() error {
 func (me *MergeEngine) Name() string {
 	return "MergeEngine"
 }
+
+func (self *MergeEngine) Next() Processor {
+	return self.next
+}

--- a/engine/passthrough_engine.go
+++ b/engine/passthrough_engine.go
@@ -87,3 +87,7 @@ func (self *Passthrough) Close() error {
 func (self *Passthrough) Name() string {
 	return "PassthroughEngine"
 }
+
+func (self *Passthrough) Next() Processor {
+	return self.next
+}

--- a/engine/processor.go
+++ b/engine/processor.go
@@ -1,6 +1,10 @@
 package engine
 
-import "github.com/influxdb/influxdb/protocol"
+import (
+	"fmt"
+
+	"github.com/influxdb/influxdb/protocol"
+)
 
 // Passed to a shard (local datastore or whatever) that gets yielded points from series.
 type Processor interface {
@@ -10,7 +14,17 @@ type Processor interface {
 	// needed.
 	Yield(s *protocol.Series) (bool, error)
 	Name() string
+	Next() Processor
 
 	// Flush any data that could be in the queue
 	Close() error
+}
+
+// ProcessorChain returns a string representation of the processors chained together
+func ProcessorChain(p Processor) string {
+	next := p.Next()
+	if next != nil {
+		return fmt.Sprintf("%s > %s", p.Name(), ProcessorChain(next))
+	}
+	return p.Name()
 }


### PR DESCRIPTION
@jvshahid  I added this while debugging an issue.  If you think it might be useful, merge it in...otherwise just delete the branch.

It logs a line similar to the following for each query:

[INFO] Processor chain:  Aggregator Engine > PassthroughEngine > ShardIdInserterProcessor (3) > ResponseChannelProcessor
