### PR TITLE
Fix #1075: write timestamps in microseconds

### DIFF
--- a/api/collectd/api.go
+++ b/api/collectd/api.go
@@ -110,13 +110,13 @@ func (s *Server) HandleSocket(socket *net.UDPConn) {
 }
 
 func packetToSeries(p *collectd.Packet) []*protocol.Series {
-	// Prefer high resolution timestamp (TimeHR is 2^-30 seconds,
-	// convert to milliseconds for influxdb)
-	uts := (p.TimeHR >> 30) * 1000
+	// Prefer high resolution timestamp.  TimeHR is 2^-30 seconds, so shift
+	// right 30 to get seconds then convert to microseconds for InfluxDB
+	uts := (p.TimeHR >> 30) * 1000 * 1000
 
 	// Fallback on unix timestamp if high res is 0
 	if uts == 0 {
-		uts = p.Time * 1000
+		uts = p.Time * 1000 * 1000
 	}
 
 	// Collectd time is uint64 but influxdb expects int64

--- a/api/collectd/api_test.go
+++ b/api/collectd/api_test.go
@@ -40,7 +40,7 @@ func (cas *CollectdApiSuite) TestPacketToSeriesWithUnixTimestamp(c *C) {
 	packet := &(*packets)[0]
 	series := packetToSeries(packet)
 	timestamp := *series[0].Points[0].Timestamp
-	c.Assert(timestamp, Equals, int64(1414080767000))
+	c.Assert(timestamp, Equals, int64(1414080767000000))
 }
 
 func (cas *CollectdApiSuite) TestPacketToSeriesWithHiResTimestamp(c *C) {
@@ -61,7 +61,7 @@ func (cas *CollectdApiSuite) TestPacketToSeriesWithHiResTimestamp(c *C) {
 	packet := &(*packets)[0]
 	series := packetToSeries(packet)
 	timestamp := *series[0].Points[0].Timestamp
-	c.Assert(timestamp, Equals, int64(1414187920000))
+	c.Assert(timestamp, Equals, int64(1414187920000000))
 }
 
 // Taken from /usr/share/collectd/types.db on a Ubuntu system


### PR DESCRIPTION
Make collectd plugin write timestamps in microseconds instead of
milliseconds.
