### PR TITLE
Fix #943: don't try to take 2 snapshots at a time

### DIFF
--- a/_vendor/raft/server.go
+++ b/_vendor/raft/server.go
@@ -1203,6 +1203,7 @@ func (s *server) TakeSnapshot() error {
 
 	state, err := s.stateMachine.Save()
 	if err != nil {
+		s.pendingSnapshot = nil
 		return err
 	}
 
@@ -1237,6 +1238,7 @@ func (s *server) saveSnapshot() error {
 
 	// Write snapshot to disk.
 	if err := s.pendingSnapshot.save(); err != nil {
+		s.pendingSnapshot = nil
 		return err
 	}
 

--- a/coordinator/raft_server.go
+++ b/coordinator/raft_server.go
@@ -331,6 +331,8 @@ const (
 )
 
 func (s *RaftServer) ForceLogCompaction() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	err := s.raftServer.TakeSnapshot()
 	if err != nil {
 		log.Error("Cannot take snapshot: %s", err)


### PR DESCRIPTION
The `TakeSnapshot()` function in _vendor/raft/server.go was failing at `s.stateMachine.Save()` and exiting without resetting `s.pendingShapshot = nil`.  That left the raft server in an invalid state.

`s.stateMachine.Save()` was failing with the error message "gob: encodeReflectValue: nil element", which comes from the `Save()` function in cluster/cluster_configuration.go.  This is a separate issue.
