### PR TITLE
Expired shard's directory no longer getting deleted since 0.8.4?

### DIFF
--- a/cluster/shard_space.go
+++ b/cluster/shard_space.go
@@ -33,6 +33,8 @@ const (
 	DEFAULT_RETENTION_POLICY_DURATION = 0
 )
 
+const InfiniteRetention = time.Duration(0)
+
 func NewShardSpace(database, name string) *ShardSpace {
 	s := &ShardSpace{
 		Database: database,
@@ -119,7 +121,7 @@ func (s *ShardSpace) ParsedRetentionPeriod() time.Duration {
 	if s.RetentionPolicy == "" {
 		return DEFAULT_RETENTION_POLICY_DURATION
 	} else if s.RetentionPolicy == "inf" {
-		return time.Duration(0)
+		return InfiniteRetention
 	}
 	d, _ := common.ParseTimeDuration(s.RetentionPolicy)
 	return time.Duration(d)

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -507,19 +507,30 @@ func (self *Coordinator) CommitSeriesData(db string, serieses []*protocol.Series
 		// TODO: this isn't needed anymore
 		series.SortPointsTimeDescending()
 
+		sn := series.GetName()
+		// use regular for loop since we update the iteration index `i' as
+		// we batch points that have the same timestamp
 		for i := 0; i < len(series.Points); {
 			if len(series.GetName()) == 0 {
 				return fmt.Errorf("Series name cannot be empty")
 			}
 
-			shard, err := self.clusterConfiguration.GetShardToWriteToBySeriesAndTime(db, series.GetName(), series.Points[i].GetTimestamp())
+			ts := series.Points[i].GetTimestamp()
+			shard, err := self.clusterConfiguration.GetShardToWriteToBySeriesAndTime(db, sn, ts)
 			if err != nil {
 				return err
 			}
+			log.Fine("GetShardToWriteToBySeriesAndTime(%s, %s, %d) = (%s, %v)", db, sn, ts, shard, err)
 			firstIndex := i
-			timestamp := series.Points[i].GetTimestamp()
-			for ; i < len(series.Points) && series.Points[i].GetTimestamp() == timestamp; i++ {
+			for ; i < len(series.Points) && series.Points[i].GetTimestamp() == ts; i++ {
 				// add all points with the same timestamp
+			}
+
+			// if shard == nil, then the points shouldn't be writte. This
+			// will happen if the points had timestamps earlier than the
+			// retention period
+			if shard == nil {
+				continue
 			}
 			newSeries := &protocol.Series{Name: series.Name, Fields: series.Fields, Points: series.Points[firstIndex:i:i]}
 


### PR DESCRIPTION
Since we upgraded from 0.8.3 to 0.8.4 (and subsequently to 0.8.5), it looks like InfluxDB no longer deletes the directories containing expired shards' data. This is the log output from around the latest shard rollover which took place today at 01:00 CET:

```
Oct 30 00:32:30 influx influxdb[13368]: [10/30/14 00:32:30] [INFO] Checking for shards to drop
Oct 30 00:40:19 influx influxdb[13368]: [10/30/14 00:40:19] [INFO] Checking for shards to drop
Oct 30 00:50:19 influx influxdb[13368]: [10/30/14 00:50:19] [INFO] Checking for shards to drop
Oct 30 01:00:00 influx influxdb[13368]: [10/30/14 01:00:00] [INFO] No matching shards for write at time 1414627200000000u, creating...
Oct 30 01:00:00 influx influxdb[13368]: [10/30/14 01:00:00] [INFO] createShards for space default: start: Thu Oct 30 01:00:00 +0100 CET 2014. end: Fri Oct 31 01:00:00 +0100 CET 2014
Oct 30 01:00:01 influx influxdb[13368]: [10/30/14 01:00:01] [INFO] DATASTORE: opening or creating shard /var/influxdb/db/shard_db_v2/00066
Oct 30 01:00:01 influx influxdb[13368]: [10/30/14 01:00:01] [INFO] Adding shard to default: 66 - start: Thu Oct 30 01:00:00 +0100 CET 2014 (1414627200). end: Fri Oct 31 01:00:00 +0100 CET 2014 (1414713600). isLocal: true. servers: [1]
Oct 30 01:02:15 influx influxdb[13368]: [10/30/14 01:02:15] [INFO] Checking for shards to drop
Oct 30 01:10:19 influx influxdb[13368]: [10/30/14 01:10:19] [INFO] Checking for shards to drop
Oct 30 01:20:19 influx influxdb[13368]: [10/30/14 01:20:19] [INFO] Checking for shards to drop
```

At this time, older shard number 61 expired and was actually removed from the configuration (i.e. it's no longer visible in the admin GUI), but as opposed to the behavior we had in 0.8.3, the directory containing the RocksDB data didn't get removed.
