### PR TITLE
make package fails with BSD sed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,7 @@ ROCKSDB_LIB = @ROCKSDB_LIB@
 # or 386, arm
 arch   = amd64
 CGO_ENABLED = 1
+sed_i = @sed_i@
 
 ifneq ($(GOROOT),)
 export GOROOT
@@ -334,10 +335,10 @@ $(binary_package): build packages
 	cp tools/benchmark/benchmark_config.sample.toml build/benchmark_config.toml
 	cp -R scripts/ build/
 	cp config.sample.toml build/config.toml
-	sed -i 's/influxdb.log/\/opt\/influxdb\/shared\/log.txt/g' build/config.toml
-	sed -i 's:${TMPDIR}/influxdb/development/db:/opt/influxdb/shared/data/db:g' build/config.toml
-	sed -i 's:${TMPDIR}/influxdb/development/raft:/opt/influxdb/shared/data/raft:g' build/config.toml
-	sed -i 's:${TMPDIR}/influxdb/development/wal:/opt/influxdb/shared/data/wal:g' build/config.toml
+	sed_i 's/influxdb.log/\/opt\/influxdb\/shared\/log.txt/g' build/config.toml
+	sed_i 's:${TMPDIR}/influxdb/development/db:/opt/influxdb/shared/data/db:g' build/config.toml
+	sed_i 's:${TMPDIR}/influxdb/development/raft:/opt/influxdb/shared/data/raft:g' build/config.toml
+	sed_i 's:${TMPDIR}/influxdb/development/wal:/opt/influxdb/shared/data/wal:g' build/config.toml
 	rm -f build/scripts/post_install.sh.bak
 	tar -czf $(binary_package) build/*
 

--- a/configure
+++ b/configure
@@ -645,8 +645,8 @@ ac_user_opts='
 enable_option_checking
 with_goroot
 with_flex
-with_rocksdb
 with_bison
+with_rocksdb
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1266,8 +1266,8 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-goroot           Set goroot to use
   --with-flex             Use flex given at that path
-  --with-rocksdb          Force building InfluxDB with rocksdb support
   --with-bison            Use bison given at that path
+  --with-rocksdb          Force building InfluxDB with rocksdb support
 
 Some influential environment variables:
   CC          C compiler command
@@ -1804,6 +1804,41 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking sed -i" >&5
+$as_echo_n "checking sed -i... " >&6; }
+  if ${ac_cv_influxdb_sed_i+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+    f=/tmp/sed_$RANDOM
+    echo -n 'version' > $f
+    if sed -i 's/version/0.1/g' $f; then
+      if test `cat $f` == "0.1"; then
+        sed_i="sed -i"
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: using sed -i" >&5
+$as_echo "using sed -i" >&6; }
+      else
+        as_fn_error $? "Invalid sed implementation detected" "$LINENO" 5
+      fi
+    elif sed -i '' 's/version/0.1/g' $f; then
+      if test `cat $f` == "0.1"; then
+        sed_i="sed -i ''"
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: using sed -i ''" >&5
+$as_echo "using sed -i ''" >&6; }
+      else
+        as_fn_error $? "Invalid sed implementation detected" "$LINENO" 5
+      fi
+    else
+      as_fn_error $? "Cannot find a sed implementation" "$LINENO" 5
+    fi
+
+fi
+
+
+
 # Extract the first word of "protoc", so it can be a program name with args.
 set dummy protoc; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -1849,10 +1884,12 @@ if test x"${PROTOC}" == x"notfound"; then
     as_fn_error $? "Please install protobuf before trying to build InfluxDB" "$LINENO" 5
 fi
 
+
 # Check whether --with-goroot was given.
 if test "${with_goroot+set}" = set; then :
   withval=$with_goroot; GOROOT=$withval
 fi
+
 
 # Extract the first word of "go", so it can be a program name with args.
 set dummy go; ac_word=$2
@@ -1898,6 +1935,7 @@ fi
 if test x"${GO}" == x"notfound"; then
     as_fn_error $? "Please install GO (or make sure it's on your path) before trying to build InfluxDB" "$LINENO" 5
 fi
+
 # Extract the first word of "gofmt", so it can be a program name with args.
 set dummy gofmt; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -1943,18 +1981,12 @@ if test x"${GOFMT}" == x"notfound"; then
     as_fn_error $? "Please install GO (or make sure it's on your path) before trying to build InfluxDB" "$LINENO" 5
 fi
 
+
 # Check whether --with-flex was given.
 if test "${with_flex+set}" = set; then :
   withval=$with_flex;
 else
   with_flex=
-fi
-
-
-
-# Check whether --with-rocksdb was given.
-if test "${with_rocksdb+set}" = set; then :
-  withval=$with_rocksdb; ROCKSDB_LIB=yes
 fi
 
 
@@ -2010,6 +2042,60 @@ if test "${with_bison+set}" = set; then :
   withval=$with_bison;
 else
   with_bison=
+fi
+
+
+if test x"${with_bison}" == x""; then
+   # Extract the first word of "bison", so it can be a program name with args.
+set dummy bison; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_with_bison+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $with_bison in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_with_bison="$with_bison" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_with_bison="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_with_bison" && ac_cv_path_with_bison=""notfound""
+  ;;
+esac
+fi
+with_bison=$ac_cv_path_with_bison
+if test -n "$with_bison"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_bison" >&5
+$as_echo "$with_bison" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+fi
+if test x"${with_bison}" == x"notfound"; then
+   as_fn_error $? "Please install bison before trying to build InfluxDB" "$LINENO" 5
+fi
+
+
+# Check whether --with-rocksdb was given.
+if test "${with_rocksdb+set}" = set; then :
+  withval=$with_rocksdb; ROCKSDB_LIB=yes
 fi
 
 
@@ -3003,52 +3089,6 @@ if test x"${ac_cv_search_clock_gettime}" != x"none required" -a x"${ac_cv_search
    LRT_LDFLAG=${ac_cv_search_clock_gettime}
 fi
 
-if test x"${with_bison}" == x""; then
-   # Extract the first word of "bison", so it can be a program name with args.
-set dummy bison; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_path_with_bison+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  case $with_bison in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_with_bison="$with_bison" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_path_with_bison="$as_dir/$ac_word$ac_exec_ext"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_path_with_bison" && ac_cv_path_with_bison=""notfound""
-  ;;
-esac
-fi
-with_bison=$ac_cv_path_with_bison
-if test -n "$with_bison"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_bison" >&5
-$as_echo "$with_bison" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-fi
-if test x"${with_bison}" == x"notfound"; then
-   as_fn_error $? "Please install bison before trying to build InfluxDB" "$LINENO" 5
-fi
 ac_config_files="$ac_config_files Makefile parser/Makefile"
 
 cat >confcache <<\_ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -8,34 +8,61 @@ AC_SUBST(with_bison)
 AC_SUBST(with_flex)
 AC_SUBST(LRT_LDFLAG)
 AC_SUBST(ROCKSDB_LIB)
+AC_SUBST(sed_i)
+
+AC_DEFUN([INFLUXDB_SED], [
+  AC_MSG_CHECKING([sed -i])
+  AC_CACHE_VAL(ac_cv_influxdb_sed_i, [
+    f=/tmp/sed_$RANDOM
+    echo -n 'version' > $f
+    if sed -i 's/version/0.1/g' $f; then
+      if test `cat $f` == "0.1"; then
+        sed_i="sed -i"
+        AC_MSG_RESULT(using sed -i)
+      else
+        AC_MSG_ERROR([Invalid sed implementation detected])
+      fi
+    elif sed -i '' 's/version/0.1/g' $f; then
+      if test `cat $f` == "0.1"; then
+        sed_i="sed -i ''"
+        AC_MSG_RESULT(using sed -i '')
+      else
+        AC_MSG_ERROR([Invalid sed implementation detected])
+      fi
+    else
+      AC_MSG_ERROR([Cannot find a sed implementation])
+    fi
+  ])
+])
+
+INFLUXDB_SED
 
 AC_PATH_PROG(PROTOC, protoc, "notfound")
 if test x"${PROTOC}" == x"notfound"; then
     AC_MSG_ERROR([Please install protobuf before trying to build InfluxDB])
 fi
+
 AC_ARG_WITH([goroot],
   [AS_HELP_STRING([--with-goroot],
     [Set goroot to use])],
   [GOROOT=$withval],
   [])
+
 AC_PATH_PROG(GO, go, "notfound", [$PATH$PATH_SEPARATOR$withval/bin$PATH_SEPARATOR])
 if test x"${GO}" == x"notfound"; then
     AC_MSG_ERROR([Please install GO (or make sure it's on your path) before trying to build InfluxDB])
 fi
+
 AC_PATH_PROG(GOFMT, gofmt, "notfound", [$PATH$PATH_SEPARATOR$withval/bin$PATH_SEPARATOR])
 if test x"${GOFMT}" == x"notfound"; then
     AC_MSG_ERROR([Please install GO (or make sure it's on your path) before trying to build InfluxDB])
 fi
+
 AC_ARG_WITH([flex],
   [AS_HELP_STRING([--with-flex],
     [Use flex given at that path])],
   [],
   [with_flex=])
-
-AC_ARG_WITH([rocksdb],
-  [AS_HELP_STRING([--with-rocksdb],
-    [Force building InfluxDB with rocksdb support])],
-  [ROCKSDB_LIB=yes])
 
 if test x"${with_flex}" == x""; then
    AC_PATH_PROG(with_flex, flex, "notfound")
@@ -48,6 +75,18 @@ AC_ARG_WITH([bison],
     [Use bison given at that path])],
   [],
   [with_bison=])
+
+if test x"${with_bison}" == x""; then
+   AC_PATH_PROG(with_bison, bison, "notfound")
+fi
+if test x"${with_bison}" == x"notfound"; then
+   AC_MSG_ERROR([Please install bison before trying to build InfluxDB])
+fi
+
+AC_ARG_WITH([rocksdb],
+  [AS_HELP_STRING([--with-rocksdb],
+    [Force building InfluxDB with rocksdb support])],
+  [ROCKSDB_LIB=yes])
 
 AC_PATH_PROG(AUTORECONF, autoreconf, "notfound")
 if test x"${AUTORECONF}" == x"notfound"; then
@@ -62,10 +101,4 @@ if test x"${ac_cv_search_clock_gettime}" != x"none required" -a x"${ac_cv_search
    LRT_LDFLAG=${ac_cv_search_clock_gettime}
 fi
 
-if test x"${with_bison}" == x""; then
-   AC_PATH_PROG(with_bison, bison, "notfound")
-fi
-if test x"${with_bison}" == x"notfound"; then
-   AC_MSG_ERROR([Please install bison before trying to build InfluxDB])
-fi
 AC_OUTPUT([Makefile parser/Makefile])


### PR DESCRIPTION
Specifically, this occurred on OS X.

```
sed -i 's/.\/admin/\/opt\/influxdb\/current\/admin/g' build/config.toml
sed: 1: "build/config.toml": undefined label 'uild/config.toml'
```

See: http://mpdaugherty.wordpress.com/2010/05/27/difference-with-sed-in-place-editing-on-mac-os-x-vs-linux/
