### PR TITLE
"stopping server" logs not always visible

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -263,10 +263,6 @@ func (self *Server) Stop() {
 	log.Info("Stopping server")
 	self.stopped = true
 
-	log.Info("Stopping api server")
-	self.HttpApi.Close()
-	log.Info("Api server stopped")
-
 	if self.Config.GraphiteEnabled {
 		log.Info("Stopping GraphiteServer")
 		self.GraphiteApi.Close()
@@ -292,4 +288,11 @@ func (self *Server) Stop() {
 	log.Info("Stopping shard store")
 	self.shardStore.Close()
 	log.Info("shard store stopped")
+
+	// HttpApi should be the last server to be closed, otherwise
+	// server.ListenAndServe() will return causing main() to exit before
+	// the other services are properly stopped
+	log.Info("Stopping api server")
+	self.HttpApi.Close()
+	log.Info("Api server stopped")
 }


### PR DESCRIPTION
when invoking `/etc/init.d/influxdb stop`, all messages from https://github.com/influxdb/influxdb/blob/ffbe9be48a00e3e8361af0180b9237f05bb5d0a1/src/server/server.go#L212-242
should appear in the log, but this doesn't seem the case.
i suspect this is a race, the `log.Info()`'s are probably called correctly but the server exits before the records get written to the log.
I made sure to edit influxdb-daemon and to redirect all stderr/stdout to a file, so that if it panics, i would see it there (see #650), but the daemon records no stdout/stderr, implying a clean exit.

all the snippets below are the tail of a log, after calling `/etc/init.d/influxdb stop` and confirming the process is no longer running.  It seems pretty arbitrary how much of the log messages make it into the log.

```
[2014/06/19 14:22:40 EDT] [INFO] (coordinator.(*CoordinatorImpl).RunQuery:69) Start Query: db: graphite, u: graphite, q: list series
[2014/06/19 14:22:42 EDT] [INFO] (main.waitForSignals:24) Received signal: terminated
[2014/06/19 14:22:42 EDT] [INFO] (server.(*Server).Stop:216) Stopping server
[2014/06/19 14:22:42 EDT] [INFO] (server.(*Server).Stop:219) Stopping api server
```

```
[2014/06/19 14:15:50 EDT] [INFO] (server.(*Server).Stop:216) Stopping server
[2014/06/19 14:15:50 EDT] [INFO] (server.(*Server).Stop:219) Stopping api server
[2014/06/19 14:15:50 EDT] [INFO] (server.(*Server).Stop:221) Api server stopped
```

```
[2014/06/19 14:17:53 EDT] [INFO] (coordinator.(*CoordinatorImpl).RunQuery:69) Start Query: db: graphite, u: graphite, q: list series
[2014/06/19 14:17:56 EDT] [INFO] (coordinator.(*CoordinatorImpl).RunQuery:69) Start Query: db: graphite, u: graphite, q: list series
[2014/06/19 14:17:58 EDT] [INFO] (main.waitForSignals:24) Received signal: terminated
[2014/06/19 14:17:58 EDT] [INFO] (server.(*Server).Stop:216) Stopping server
[2014/06/19 14:17:58 EDT] [INFO] (server.(*Server).Stop:219) Stopping api server
[2014/06/19 14:17:58 EDT] [INFO] (api/http.(*HttpServer).Close:194) Closing http server
```
