### PR TITLE
Generating single point query from ast creates an invalid query

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -190,6 +190,13 @@ func (self *SelectQuery) GetQueryString() string {
 }
 
 func (self *SelectQuery) GetQueryStringWithTimeCondition() string {
+	// if this is a single query then it already has a time (and
+	// sequence number) condition; we don't need the extra (time < ???
+	// and time > ???) condition in the query string.
+	if self.IsSinglePointQuery() {
+		return self.GetQueryString()
+	}
+
 	return self.commonGetQueryStringWithTimes(true, true, self.startTime, self.endTime)
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -929,6 +929,14 @@ func (self *QueryParserSuite) TestParseSinglePointQuery(c *C) {
 	c.Assert(rightBoolExpression.Name, Equals, "=")
 }
 
+func (self *QueryParserSuite) TestSinglePointGetQueryString(c *C) {
+	qs := "select value from \"foo\" where (time = 999) AND (sequence_number = 1)"
+	q, err := ParseSelectQuery(qs)
+	c.Assert(err, IsNil)
+	c.Assert(q.GetQueryString(), Equals, qs)
+	c.Assert(q.GetQueryStringWithTimeCondition(), Equals, qs)
+}
+
 // TODO: test reversed order of time and sequence_number
 func (self *QueryParserSuite) TestIsSinglePointQuery(c *C) {
 	query := "select * from foo where time = 123 and sequence_number = 99"


### PR DESCRIPTION
The generated query looks like the following which is invalid:

``` sql
select * from test_single_points_with_nulls where ((time = 1410368584848890u) AND (sequence_number = 10001)) AND ((time < 1410368584848890000) AND (time > 1410368584848890000))
```
