### PR TITLE
Hitting open files limit causes influxdb to create shards in loop

### DIFF
--- a/datastore/shard_datastore.go
+++ b/datastore/shard_datastore.go
@@ -185,6 +185,7 @@ func (self *ShardDatastore) GetOrCreateShard(id uint32) (cluster.LocalShardDb, e
 
 	se, err := init.Initialize(dbDir, c)
 	if err != nil {
+		os.RemoveAll(dbDir)
 		return nil, err
 	}
 

--- a/datastore/shard_datastore_test.go
+++ b/datastore/shard_datastore_test.go
@@ -1,9 +1,14 @@
 package datastore
 
 import (
+	"errors"
 	"os"
+	"path"
 
 	"github.com/influxdb/influxdb/configuration"
+	"github.com/influxdb/influxdb/datastore/storage"
+	"github.com/influxdb/influxdb/metastore"
+
 	. "launchpad.net/gocheck"
 )
 
@@ -38,4 +43,56 @@ func (self *ShardDatastoreSuite) TestWillEnforceMaxOpenShards(c *C) {
 	c.Assert(shard.IsClosed(), Equals, false)
 	store.ReturnShard(uint32(2))
 	c.Assert(shard.IsClosed(), Equals, true)
+}
+
+type mockDB struct{}
+
+func (m mockDB) Name() string { return "mockdb" }
+
+func (m mockDB) Path() string { return "" }
+
+func (m mockDB) Put(key, value []byte) error { return nil }
+
+func (m mockDB) Get(key []byte) ([]byte, error) { return []byte{}, nil }
+
+func (m mockDB) BatchPut(writes []storage.Write) error { return nil }
+
+func (m mockDB) Del(first, last []byte) error { return nil }
+
+func (m mockDB) Iterator() storage.Iterator { return nil }
+
+func (m mockDB) Compact() {}
+
+func (m mockDB) Close() {}
+
+func NewMockDB(path string, config interface{}) (storage.Engine, error) {
+	return nil, errors.New("some error")
+}
+
+type mockDBConfig struct{}
+
+func NewMockDBConfig() interface{} {
+	return &mockDBConfig{}
+}
+
+func (self *ShardDatastoreSuite) TestGetOrCreateShardDeletesFilesOnError(c *C) {
+	// Register our mockDB so that ShardData will create & use it instead
+	// of a real one (i.e., leveldb, rocksdb, etc.).
+	err := storage.RegisterEngine("mockdb", storage.Initializer{NewMockDBConfig, NewMockDB})
+	c.Assert(err, IsNil)
+
+	config := &configuration.Configuration{
+		DataDir:              TEST_DATASTORE_SHARD_DIR,
+		StorageMaxOpenShards: 100,
+		StorageDefaultEngine: "mockdb",
+	}
+
+	sd, err := NewShardDatastore(config, metastore.NewStore())
+	c.Assert(err, IsNil)
+
+	s, err := sd.GetOrCreateShard(999)
+	c.Assert(err, NotNil)
+	c.Assert(s, IsNil)
+	_, err = os.Stat(path.Join(TEST_DATASTORE_SHARD_DIR, "shard_db_v2/00999"))
+	c.Assert(os.IsNotExist(err), Equals, true)
 }

--- a/datastore/storage/hyperleveldb.go
+++ b/datastore/storage/hyperleveldb.go
@@ -14,10 +14,13 @@ import (
 const HYPERLEVELDB_NAME = "hyperleveldb"
 
 func init() {
-	registerEngine(HYPERLEVELDB_NAME, Initializer{
+	err := RegisterEngine(HYPERLEVELDB_NAME, Initializer{
 		NewHyperlevelDBConfig,
 		NewHyperlevelDB,
 	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 type HyperlevelDBConfiguration struct {

--- a/datastore/storage/leveldb.go
+++ b/datastore/storage/leveldb.go
@@ -12,10 +12,13 @@ import (
 const LEVELDB_NAME = "leveldb"
 
 func init() {
-	registerEngine(LEVELDB_NAME, Initializer{
+	err := RegisterEngine(LEVELDB_NAME, Initializer{
 		NewLevelDBConfig,
 		NewLevelDB,
 	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 type LevelDbConfiguration struct {

--- a/datastore/storage/mdb.go
+++ b/datastore/storage/mdb.go
@@ -12,10 +12,13 @@ import (
 const MDB_NAME = "lmdb"
 
 func init() {
-	registerEngine(MDB_NAME, Initializer{
+	err := RegisterEngine(MDB_NAME, Initializer{
 		NewMDBConfiguration,
 		NewMDB,
 	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 type MDBConfiguration struct {

--- a/datastore/storage/registry.go
+++ b/datastore/storage/registry.go
@@ -31,11 +31,12 @@ func wrapInitializer(initializer Initializer) Initializer {
 	return init
 }
 
-func registerEngine(name string, init Initializer) {
+func RegisterEngine(name string, init Initializer) error {
 	if _, ok := engineRegistry[name]; ok {
-		panic(fmt.Errorf("Engine '%s' already exists", name))
+		return fmt.Errorf("Engine '%s' already exists", name)
 	}
 	engineRegistry[name] = wrapInitializer(init)
+	return nil
 }
 
 func GetInitializer(name string) (Initializer, error) {

--- a/datastore/storage/rocksdb.go
+++ b/datastore/storage/rocksdb.go
@@ -15,10 +15,13 @@ import (
 const ROCKSDB_NAME = "rocksdb"
 
 func init() {
-	registerEngine(ROCKSDB_NAME, Initializer{
+	err := RegisterEngine(ROCKSDB_NAME, Initializer{
 		NewRocksDBConfig,
 		NewRocksDB,
 	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 type RocksDBConfiguration struct {


### PR DESCRIPTION
Default install on Debian, 0.8.3, no tuning done except changing data dir path.

After InfluxDB hit the open files limit it started to create new shards in the loop, and of course could not write data, resulting in creation of few thousand dirs. 
It should either:
- exit, so if it is monitored user can notice before wondering why there is no stats from last shard
- close old/least used shards

Logs:

```
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).GetShardToWriteToBySeriesAndTime:796) No matching shards for write at time 1413064200000000u, creating...
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).createShards:827) createShards for space long_term: start: Tue Oct 7 02:00:00 +0200 CEST 2014. end: Thu Nov 6 01:00:00 +0100 CET 2014
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/datastore.(*ShardDatastore).GetOrCreateShard:162) DATASTORE: opening or creating shard /var/lib/influxdb/db/shard_db_v2/04960
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).AddShards:1029) AddShards: error setting local store: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04960/type: too many open files)
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*RaftServer).doOrProxyCommandOnce:169) Cannot run command &coordinator.CreateShardsCommand{Shards:[]*cluster.NewShardData{(*cluster.NewShardData)(0xc20983ba40)}, SpaceName:""}. open /var/lib/influxdb/db/shard_db_v2/04960/type: too many open files
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*RaftServer).CreateShards:749) RAFT: CreateShards: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04960/type: too many open files)
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*CoordinatorImpl).InterpolateValuesAndCommit:626) Couldn't write data for continuous query: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04960/type: too many open files)
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).GetShardToWriteToBySeriesAndTime:796) No matching shards for write at time 1413064200000000u, creating...
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).createShards:827) createShards for space long_term: start: Tue Oct 7 02:00:00 +0200 CEST 2014. end: Thu Nov 6 01:00:00 +0100 CET 2014
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/datastore.(*ShardDatastore).GetOrCreateShard:162) DATASTORE: opening or creating shard /var/lib/influxdb/db/shard_db_v2/04961
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).AddShards:1029) AddShards: error setting local store: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04961/type: too many open files)
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*RaftServer).doOrProxyCommandOnce:169) Cannot run command &coordinator.CreateShardsCommand{Shards:[]*cluster.NewShardData{(*cluster.NewShardData)(0xc208edaee0)}, SpaceName:""}. open /var/lib/influxdb/db/shard_db_v2/04961/type: too many open files
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*RaftServer).CreateShards:749) RAFT: CreateShards: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04961/type: too many open files)
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*CoordinatorImpl).InterpolateValuesAndCommit:626) Couldn't write data for continuous query: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04961/type: too many open files)
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).GetShardToWriteToBySeriesAndTime:796) No matching shards for write at time 1413064200000000u, creating...
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).createShards:827) createShards for space long_term: start: Tue Oct 7 02:00:00 +0200 CEST 2014. end: Thu Nov 6 01:00:00 +0100 CET 2014
[2014/10/12 00:00:01 CEST] [INFO] (github.com/influxdb/influxdb/datastore.(*ShardDatastore).GetOrCreateShard:162) DATASTORE: opening or creating shard /var/lib/influxdb/db/shard_db_v2/04962
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/cluster.(*ClusterConfiguration).AddShards:1029) AddShards: error setting local store: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04962/type: too many open files)
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*RaftServer).doOrProxyCommandOnce:169) Cannot run command &coordinator.CreateShardsCommand{Shards:[]*cluster.NewShardData{(*cluster.NewShardData)(0xc20a3684d0)}, SpaceName:""}. open /var/lib/influxdb/db/shard_db_v2/04962/type: too many open files
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*RaftServer).CreateShards:749) RAFT: CreateShards: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04962/type: too many open files)
[2014/10/12 00:00:01 CEST] [EROR] (github.com/influxdb/influxdb/coordinator.(*CoordinatorImpl).InterpolateValuesAndCommit:626) Couldn't write data for continuous query: %!(EXTRA *os.PathError=open /var/lib/influxdb/db/shard_db_v2/04962/type: too many open files)
```
