### PR TITLE
Incorrect error message if using last()

### DIFF
--- a/engine/aggregator_operators.go
+++ b/engine/aggregator_operators.go
@@ -1308,7 +1308,7 @@ func (self *FirstOrLastAggregator) GetValues(state interface{}) [][]*protocol.Fi
 
 func NewFirstOrLastAggregator(name string, v *parser.Value, isFirst bool, defaultValue *parser.Value) (Aggregator, error) {
 	if len(v.Elems) != 1 {
-		return nil, common.NewQueryError(common.WrongNumberOfArguments, "function max() requires only one argument")
+		return nil, common.NewQueryError(common.WrongNumberOfArguments, fmt.Sprintf("function %s() requires exactly one argument", name))
 	}
 
 	wrappedDefaultValue, err := wrapDefaultValue(defaultValue)


### PR DESCRIPTION
If you write a query like the following 

```
 select last() from foo
```

You get a seemingly unrelated error message referring to max()

![screenshot 2014-11-04 11 11 45](https://cloud.githubusercontent.com/assets/242382/4905258/4366f6e4-644e-11e4-8d8b-dced2e038706.png)
