### PR TITLE
`select last() from foo` causes panic

### DIFF
--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -243,6 +243,7 @@ func (self *Coordinator) getShardsAndProcessor(querySpec *parser.QuerySpec, writ
 		}
 		writer, err = engine.NewQueryEngine(writer, q, shardIds)
 		if err != nil {
+			log.Error(err)
 			log.Info("Coordinator processor chain: %s", engine.ProcessorChain(writer))
 		}
 		return shards, writer, err

--- a/engine/processor.go
+++ b/engine/processor.go
@@ -22,6 +22,9 @@ type Processor interface {
 
 // ProcessorChain returns a string representation of the processors chained together
 func ProcessorChain(p Processor) string {
+	if p == nil {
+		return "<nil>"
+	}
 	next := p.Next()
 	if next != nil {
 		return fmt.Sprintf("%s > %s", p.Name(), ProcessorChain(next))


### PR DESCRIPTION
```
[11/11/14 15:42:57] [INFO] Start Query: db: dailymile, u: root, q: select last() from dgnorton.pace;
[11/11/14 15:42:57] [DEBG] Querying 3 shards for query
[11/11/14 15:42:57] [EROR] ********************************BUG********************************
Database: dailymile
Query: [select last() from dgnorton.pace;]
Error: runtime error: invalid memory address or nil pointer dereference. Stacktrace: goroutine 50 [running]:
github.com/influxdb/influxdb/common.RecoverFunc(0xc20802ca06, 0x9, 0xc2081c0870, 0x21, 0x0)
    /home/dgnorton/go/src/github.com/influxdb/influxdb/common/recover.go:14 +0xbb
github.com/influxdb/influxdb/engine.ProcessorChain(0x0, 0x0, 0x0, 0x0)
    /home/dgnorton/go/src/github.com/influxdb/influxdb/engine/processor.go:25 +0x4e
github.com/influxdb/influxdb/coordinator.(*Coordinator).getShardsAndProcessor(0xc2081004a0, 0xc20820e1e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /home/dgnorton/go/src/github.com/influxdb/influxdb/coordinator/coordinator.go:246 +0x303
github.com/influxdb/influxdb/coordinator.(*Coordinator).runQuerySpec(0xc2081004a0, 0xc20820e1e0, 0x7ff5a9c342f8, 0xc20802e1b0, 0x0, 0x0)
    /home/dgnorton/go/src/github.com/influxdb/influxdb/coordinator/coordinator.go:294 +0x93
github.com/influxdb/influxdb/coordinator.(*Coordinator).runSingleQuery(0xc2081004a0, 0x7ff5a9c34260, 0xc2080fbb00, 0xc20802ca06, 0x9, 0xc2081c0de0, 0x7ff5a9c342f8, 0xc20802e1b0, 0x0, 0x0)
```
