### PR TITLE
Increase time "added" for single node test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - 1.3.3
   - 1.4beta1
 
-script: go test -v . ./messaging ./influxql
+script: go test -v ./...
 
 notifications:
   email:

--- a/raft/log_test.go
+++ b/raft/log_test.go
@@ -326,7 +326,7 @@ func NewNode() *Node {
 func NewInitNode() *Node {
 	n := NewNode()
 	n.Open()
-	go func() { n.Clock().Add(2 * n.Log.ApplyInterval) }()
+	go func() { n.Clock().Add(3 * n.Log.ApplyInterval) }()
 	if err := n.Log.Initialize(); err != nil {
 		panic("initialize: " + err.Error())
 	}


### PR DESCRIPTION
Wait()ing for the log to be applied can take 2 loops. Due to this, the
timer used to trigger the 3rd check is pushed too far into the future.
So push the clock even farther into the future.

As a result, all Travis testing can be re-enabled.
