### PR TITLE
Implement command-based CLI, and start cluster-bringup

### DIFF
--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	} `toml:"storage"`
 
 	Cluster struct {
+		Dir                       string   `toml:"dir"`
 		ProtobufPort              int      `toml:"protobuf_port"`
 		ProtobufTimeout           Duration `toml:"protobuf_timeout"`
 		ProtobufHeartbeatInterval Duration `toml:"protobuf_heartbeat"`

--- a/cmd/influxd/create_cluster.go
+++ b/cmd/influxd/create_cluster.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/influxdb/influxdb/messaging"
+)
+
+// execCreateCluster runs the "create-cluster" command.
+func execCreateCluster(args []string) {
+	// Parse command flags.
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	var (
+		configPath = fs.String("config", "", "")
+		role       = fs.String("role", "combined", "")
+	)
+	fs.Usage = printCreateClusterUsage
+	fs.Parse(args)
+
+	// Parse the configuration file.
+	config, err := ParseConfigFile(*configPath)
+	if err != nil {
+		log.Fatalf("config: %s", err)
+	}
+
+	// Validate the role.
+	if *role != "combined" && *role != "broker" {
+		log.Fatal("new cluster node must be created as 'combined' or 'broker' role")
+	}
+
+	// Create the broker.
+	b := messaging.NewBroker()
+	if err := b.Open(config.Raft.Dir); err != nil {
+		log.Fatalf("broker: %s", err.Error())
+	}
+
+	// Initialize the log for the first time.
+	if err := b.Initialize(); err != nil {
+		log.Fatalf("initialize: %s", err)
+	}
+
+	// If the node is a broker and data node then create the data directory.
+	if *role == "combined" {
+		if _, err := os.Stat(config.Cluster.Dir); err == nil {
+			log.Fatal("data directory already exists")
+		}
+
+		// Now create the storage directory.
+		if err := os.MkdirAll(config.Cluster.Dir, 0744); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	log.Println("new cluster node created as", *role, "in", config.Raft.Dir)
+}
+
+func printCreateClusterUsage() {
+	log.Println(`usage: create-cluster [flags]
+
+create-cluster creates a completely new node that can act as the first node of a new
+cluster. This node must be created as a 'combined' or 'broker' node.
+
+        -role <role>
+                        Set the role to be 'combined' or 'broker'. 'broker' means it will take part
+                        in Raft Distributed Consensus. 'combined' means it take part in Raft and
+                        store time-series data. The default role is 'combined'. Any other role other
+                        than these two is invalid.
+`)
+}

--- a/cmd/influxd/join_cluster.go
+++ b/cmd/influxd/join_cluster.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"github.com/influxdb/influxdb/messaging"
+)
+
+// execJoinCluster runs the "join-cluster" command.
+func execJoinCluster(args []string) {
+	// Parse command flags.
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	var (
+		configPath  = fs.String("config", "", "")
+		role        = fs.String("role", "combined", "")
+		seedServers = fs.String("seed-servers", "", "")
+	)
+	fs.Usage = printJoinClusterUsage
+	fs.Parse(args)
+
+	// Parse configuration.
+	config, err := ParseConfigFile(*configPath)
+	if err != nil {
+		log.Fatalf("config: %s", err)
+	}
+
+	// Validate command line arguments.
+	if *seedServers == "" {
+		log.Fatal("at least one seed server must be supplied")
+	} else if *role != "combined" && *role != "broker" && *role != "data" {
+		log.Fatal("node must join as 'combined', 'broker', or 'data'")
+	}
+
+	// If joining as broker then create broker.
+	if *role == "combined" || *role == "broker" {
+		// Broker required -- but don't initialize it.
+		// Joining a cluster will do that.
+		b := messaging.NewBroker()
+		if err := b.Open(config.Raft.Dir); err != nil {
+			log.Fatalf("join: %s", err)
+		}
+	}
+
+	// If joining as a data node then create a data directory.
+	if *role == "combined" || *role == "data" {
+		// TODO: do any required data-node stuff.
+	}
+
+	log.Printf("joined cluster at %s", *seedServers)
+}
+
+func printJoinClusterUsage() {
+	log.Println(`usage: join-cluster [flags]
+
+join-cluster creates a completely new node that will attempt to join an existing cluster.
+
+        -role <role>
+                        Set the role to be 'combined', 'broker' or 'data'. broker' means it will take
+                        part in Raft Distributed Consensus. 'data' means it will store time-series data.
+                        'combined' means it will do both. The default is 'combined'. In role other than
+                        these three is invalid.
+
+        -seedservers <servers>
+                        Set the list of servers the node should contact, to join the cluster. This
+                        should be comma-delimited list of servers, in the form host:port. This option
+                        is REQUIRED.
+`)
+}

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/influxdb/influxdb"
+	"github.com/influxdb/influxdb/messaging"
+)
+
+// stateFilename represents the name of the file to store node state.
+const stateFilename = "state"
+
+// execRun runs the "run" command.
+func execRun(args []string) {
+	// Parse command flags.
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	var (
+		configPath = fs.String("config", "config.sample.toml", "")
+		pidPath    = fs.String("pidfile", "", "")
+		hostname   = fs.String("hostname", "", "")
+	)
+	fs.Usage = printRunUsage
+	fs.Parse(args)
+
+	// Write pid file.
+	if *pidPath != "" {
+		pid := strconv.Itoa(os.Getpid())
+		if err := ioutil.WriteFile(*pidPath, []byte(pid), 0644); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// Parse configuration.
+	config, err := ParseConfigFile(*configPath)
+	if err != nil {
+		log.Fatalf("config: %s", err)
+	}
+
+	// Override config properties.
+	if *hostname != "" {
+		config.Hostname = *hostname
+	}
+
+	// TODO(benbjohnson): Start admin server.
+
+	log.Print(logo)
+	if config.BindAddress == "" {
+		log.Printf("Starting Influx Server %s...", version)
+	} else {
+		log.Printf("Starting Influx Server %s bound to %s...", version, config.BindAddress)
+	}
+
+	// Bring up the node in the state as is on disk.
+	var brokerURLs []*url.URL
+
+	// Read state from disk.
+	state, err := createStateIfNotExists(filepath.Join(config.Cluster.Dir, stateFilename))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Open
+	var client influxdb.MessagingClient
+	var server *influxdb.Server
+	if state.Mode == "local" {
+		client = messaging.NewLoopbackClient()
+		log.Printf("Local messaging client created")
+		server = influxdb.NewServer(client)
+		err := server.Open(config.Storage.Dir)
+		if err != nil {
+			log.Fatalf("failed to open local Server", err.Error())
+		}
+	} else {
+		// If the Broker directory exists, open a Broker on this node.
+		if _, err := os.Stat(config.Raft.Dir); err == nil {
+			b := messaging.NewBroker()
+			if err := b.Open(config.Raft.Dir); err != nil {
+				log.Fatalf("failed to open Broker", err.Error())
+			}
+		} else {
+			log.Fatalf("failed to check for Broker directory", err.Error())
+		}
+		// If a Data directory exists, open a Data node.
+		if _, err := os.Stat(config.Storage.Dir); err == nil {
+			// Create correct client here for connecting to Broker.
+			c := messaging.NewClient("XXX-CHANGEME-XXX")
+			if err := c.Open(brokerURLs); err != nil {
+				log.Fatalf("Error opening Messaging Client: %s", err.Error())
+			}
+			defer c.Close()
+			client = c
+			log.Printf("Cluster messaging client created")
+
+			server = influxdb.NewServer(client)
+			err = server.Open(config.Storage.Dir)
+			if err != nil {
+				log.Fatalf("failed to open data Server", err.Error())
+			}
+		} else {
+			log.Fatalf("failed to check for Broker directory", err.Error())
+		}
+	}
+
+	// TODO: startProfiler()
+	// TODO: -reset-root
+
+	// Start up HTTP server with correct endpoints.
+	h := influxdb.NewHandler(server)
+	func() { log.Fatal(http.ListenAndServe(":8086", h)) }()
+
+	// Wait indefinitely.
+	<-(chan struct{})(nil)
+}
+
+func printRunUsage() {
+	log.Println(`usage: run [flags]
+
+run starts the node with any existing cluster configuration. If no cluster configuration is
+found, then the node runs in "local" mode. "Local" mode 
+
+        -config <path>
+                                Set the path to the configuration file.
+
+        -hostname <name>
+                                Override the hostname, the 'hostname' configuration option will be overridden.
+
+        -pidfile <path>
+                                Write process ID to a file.
+`)
+}
+
+// createStateIfNotExists returns the cluster state, from the file at path.
+// If no file exists at path, the default state is created, and written to the path.
+func createStateIfNotExists(path string) (*State, error) {
+	// Read state from path.
+	// If state doesn't exist then return a "local" state.
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return &State{Mode: "local"}, nil
+	} else if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Decode state from file and return.
+	s := &State{}
+	if err := json.NewDecoder(f).Decode(&s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -108,6 +108,9 @@ retention-sweep-period = "10m"
 
 [cluster]
 
+# Location for cluster state storage. For storing state persistently across restarts.
+dir = "/tmp/influxdb/development/state"
+
 # Replication happens over a TCP connection with a Protobuf protocol.
 # This port should be reachable between all servers in a cluster.
 # However, this port shouldn't be accessible from the internet.


### PR DESCRIPTION
This change adds a CLI styled after the Go tool chain, with a design
inspired by that system. It adds 4 new commands, 'run',
'create-cluster', 'join-cluster', and 'version'. Full help is also
supplied.

Local-mode 'run' is fully functional, and 'create-cluster' also works.
