### PR TITLE
Add absolute time support

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1127,8 +1127,11 @@ func TimeRange(expr Expr) (min, max time.Time) {
 // Returns zero time if the expression is not a time expression.
 func timeExprValue(ref Expr, lit Expr) time.Time {
 	if ref, ok := ref.(*VarRef); ok && strings.ToLower(ref.Val) == "time" {
-		if lit, ok := lit.(*TimeLiteral); ok {
+		switch lit := lit.(type) {
+		case *TimeLiteral:
 			return lit.Val
+		case *DurationLiteral:
+			return time.Unix(0, int64(lit.Val)).UTC()
 		}
 	}
 	return time.Time{}

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -188,6 +188,9 @@ func TestTimeRange(t *testing.T) {
 		// Min/max crossover
 		{expr: `time >= "2000-01-01 00:00:00" AND time <= "1999-01-01 00:00:00"`, min: `2000-01-01 00:00:00`, max: `1999-01-01 00:00:00`},
 
+		// Absolute time
+		{expr: `time = 1388534400s`, min: `2014-01-01 00:00:00`, max: `2014-01-01 00:00:00`},
+
 		// Non-comparative expressions.
 		{expr: `time`, min: `0001-01-01 00:00:00`, max: `0001-01-01 00:00:00`},
 		{expr: `time + 2`, min: `0001-01-01 00:00:00`, max: `0001-01-01 00:00:00`},


### PR DESCRIPTION
## Overview

This pull request adds the ability to specify time by duration since epoch.
## Example

```
SELECT * FROM cpu WHERE time > 1388534400s
```
