### PR TITLE
Use replica id instead of replica name

### DIFF
--- a/cmd/influxd/create_cluster.go
+++ b/cmd/influxd/create_cluster.go
@@ -63,7 +63,7 @@ func execCreateCluster(args []string) {
 		}
 		seedUrls = append(seedUrls, u)
 
-		c := messaging.NewClient("XXX-CHANGEME-XXX")
+		c := messaging.NewClient(0) // TODO: Set replica id.
 		if err := c.Open(filepath.Join(config.Storage.Dir, messagingClientFile), seedUrls); err != nil {
 			log.Fatalf("create-cluster open client: %s", err.Error())
 		}

--- a/cmd/influxd/join_cluster.go
+++ b/cmd/influxd/join_cluster.go
@@ -83,8 +83,7 @@ func execJoinCluster(args []string) {
 		}
 
 		// Configure the Messaging Client.
-
-		c := messaging.NewClient("XXX-CHANGEME-XXX")
+		c := messaging.NewClient(0) // TODO: Set replica id.
 		if err := c.Open(filepath.Join(config.Storage.Dir, messagingClientFile), seedURLs); err != nil {
 			log.Fatalf("join-cluster open client: %s", err.Error())
 		}

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -104,7 +104,7 @@ func execRun(args []string) {
 				brokerURLs = append(brokerURLs, u)
 			}
 
-			c := messaging.NewClient("XXX-CHANGEME-XXX")
+			c := messaging.NewClient(0) // TODO: Set replica id.
 			if err := c.Open(clientFilePath, brokerURLs); err != nil {
 				log.Fatalf("Error opening Messaging Client: %s", err.Error())
 			}

--- a/messaging/broker_test.go
+++ b/messaging/broker_test.go
@@ -47,12 +47,12 @@ func TestBroker_Publish(t *testing.T) {
 	defer b.Close()
 
 	// Create a new named replica.
-	if err := b.CreateReplica("node0"); err != nil {
+	if err := b.CreateReplica(2000); err != nil {
 		t.Fatalf("create replica: %s", err)
 	}
 
 	// Subscribe replica to a topic.
-	if err := b.Subscribe("node0", 20); err != nil {
+	if err := b.Subscribe(2000, 20); err != nil {
 		t.Fatalf("subscribe: %s", err)
 	}
 
@@ -70,7 +70,7 @@ func TestBroker_Publish(t *testing.T) {
 	// Read message from the replica.
 	var buf bytes.Buffer
 	go func() {
-		if _, err := b.Replica("node0").WriteTo(&buf); err != nil {
+		if _, err := b.Replica(2000).WriteTo(&buf); err != nil {
 			t.Fatalf("write to: %s", err)
 		}
 	}()
@@ -94,7 +94,7 @@ func TestBroker_Publish(t *testing.T) {
 	}
 
 	// Unsubscribe replica from the topic.
-	if err := b.Unsubscribe("node0", 20); err != nil {
+	if err := b.Unsubscribe(2000, 20); err != nil {
 		t.Fatalf("unsubscribe: %s", err)
 	}
 
@@ -121,8 +121,8 @@ func TestBroker_CreateReplica_ErrReplicaExists(t *testing.T) {
 	defer b.Close()
 
 	// Create a replica twice.
-	b.CreateReplica("node0")
-	if err := b.CreateReplica("node0"); err != messaging.ErrReplicaExists {
+	b.CreateReplica(2000)
+	if err := b.CreateReplica(2000); err != messaging.ErrReplicaExists {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -133,7 +133,7 @@ func TestBroker_DeleteReplica(t *testing.T) {
 	defer b.Close()
 
 	// Create a new named replica.
-	if err := b.CreateReplica("node0"); err != nil {
+	if err := b.CreateReplica(2000); err != nil {
 		t.Fatalf("create replica: %s", err)
 	}
 
@@ -141,7 +141,7 @@ func TestBroker_DeleteReplica(t *testing.T) {
 	var buf bytes.Buffer
 	var closed bool
 	go func() {
-		if _, err := b.Replica("node0").WriteTo(&buf); err != nil {
+		if _, err := b.Replica(2000).WriteTo(&buf); err != nil {
 			t.Fatalf("write to: %s", err)
 		}
 		closed = true
@@ -149,7 +149,7 @@ func TestBroker_DeleteReplica(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Delete the replica.
-	if err := b.DeleteReplica("node0"); err != nil {
+	if err := b.DeleteReplica(2000); err != nil {
 		t.Fatalf("delete replica: %s", err)
 	}
 	time.Sleep(10 * time.Millisecond)
@@ -160,7 +160,7 @@ func TestBroker_DeleteReplica(t *testing.T) {
 	}
 
 	// Ensure the replica no longer exists.
-	if r := b.Replica("node0"); r != nil {
+	if r := b.Replica(2000); r != nil {
 		t.Fatal("replica still exists")
 	}
 }
@@ -169,7 +169,7 @@ func TestBroker_DeleteReplica(t *testing.T) {
 func TestBroker_DeleteReplica_ErrReplicaNotFound(t *testing.T) {
 	b := NewBroker()
 	defer b.Close()
-	if err := b.DeleteReplica("no_such_replica"); err != messaging.ErrReplicaNotFound {
+	if err := b.DeleteReplica(0); err != messaging.ErrReplicaNotFound {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -178,8 +178,8 @@ func TestBroker_DeleteReplica_ErrReplicaNotFound(t *testing.T) {
 func TestBroker_Subscribe_ErrReplicaNotFound(t *testing.T) {
 	b := NewBroker()
 	defer b.Close()
-	b.CreateReplica("bar")
-	if err := b.Subscribe("foo", 20); err != messaging.ErrReplicaNotFound {
+	b.CreateReplica(2000)
+	if err := b.Subscribe(3000, 20); err != messaging.ErrReplicaNotFound {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }
@@ -188,7 +188,7 @@ func TestBroker_Subscribe_ErrReplicaNotFound(t *testing.T) {
 func TestBroker_Unsubscribe_ErrReplicaNotFound(t *testing.T) {
 	b := NewBroker()
 	defer b.Close()
-	if err := b.Unsubscribe("foo", 20); err != messaging.ErrReplicaNotFound {
+	if err := b.Unsubscribe(0, 20); err != messaging.ErrReplicaNotFound {
 		t.Fatalf("unexpected error: %s", err)
 	}
 }

--- a/messaging/errors.go
+++ b/messaging/errors.go
@@ -24,8 +24,8 @@ var (
 	// ErrReplicaNotFound is returned when referencing a replica that doesn't exist.
 	ErrReplicaNotFound = errors.New("replica not found")
 
-	// ErrReplicaNameRequired is returned when finding a replica without a name.
-	ErrReplicaNameRequired = errors.New("replica name required")
+	// ErrReplicaRequired is returned when finding a replica without an id.
+	ErrReplicaRequired = errors.New("replica required")
 
 	// errReplicaUnavailable is returned when writing bytes to a replica when
 	// there is no writer attached to the replica.

--- a/messaging/handler.go
+++ b/messaging/handler.go
@@ -51,15 +51,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // connects the requestor as the replica's writer.
 func (h *Handler) stream(w http.ResponseWriter, r *http.Request) {
-	// Retrieve the replica name.
-	name := r.URL.Query().Get("name")
-	if name == "" {
-		h.error(w, ErrReplicaNameRequired, http.StatusBadRequest)
+	// Read the replica ID.
+	var replicaID uint64
+	if n, err := strconv.ParseUint(r.URL.Query().Get("replicaID"), 10, 64); err != nil {
+		h.error(w, ErrReplicaRequired, http.StatusBadRequest)
 		return
+	} else {
+		replicaID = uint64(n)
 	}
 
 	// Find the replica on the broker.
-	replica := h.broker.Replica(name)
+	replica := h.broker.Replica(replicaID)
 	if replica == nil {
 		h.error(w, ErrReplicaNotFound, http.StatusNotFound)
 		return
@@ -83,7 +85,7 @@ func (h *Handler) publish(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Read the topic ID.
-	if n, err := strconv.ParseUint(r.URL.Query().Get("topicID"), 10, 32); err != nil {
+	if n, err := strconv.ParseUint(r.URL.Query().Get("topicID"), 10, 64); err != nil {
 		h.error(w, ErrTopicRequired, http.StatusBadRequest)
 		return
 	} else {

--- a/server_test.go
+++ b/server_test.go
@@ -374,7 +374,6 @@ func TestServer_WriteSeries(t *testing.T) {
 
 	// Write series with one point to the database.
 	timestamp := mustParseTime("2000-01-01T00:00:00Z")
-
 	name := "cpu_load"
 	tags := map[string]string{"host": "servera.influx.com", "region": "uswest"}
 	values := map[string]interface{}{"value": 23.2}
@@ -384,6 +383,7 @@ func TestServer_WriteSeries(t *testing.T) {
 	}
 
 	t.Skip("pending")
+
 	// TODO: Execute a query and record all series found.
 	// q := mustParseQuery(`select myval from cpu_load`)
 	// if err := db.ExecuteQuery(q); err != nil {

--- a/shard.go
+++ b/shard.go
@@ -61,7 +61,7 @@ func (s *Shard) close() error {
 	return s.store.Close()
 }
 
-// write writes series data to a shard.
+// writeSeries writes series data to a shard.
 func (s *Shard) writeSeries(overwrite bool, data []byte) error {
 	id, timestamp, values, err := unmarshalPoint(data)
 	if err != nil {
@@ -71,8 +71,7 @@ func (s *Shard) writeSeries(overwrite bool, data []byte) error {
 	// TODO: make this work
 	fmt.Println("writeSeries: ", id, timestamp, values)
 	return s.store.Update(func(tx *bolt.Tx) error {
-		// TODO
-		return nil
+		return nil // TODO
 	})
 }
 


### PR DESCRIPTION
## Overview

This pull request changes the `messaging` package to use an `uint64` replica id instead of a `string` replica name. This is more consistent with the indices that are generated in the `raft` package.
