### PR TITLE
Fix not to reuse unfiltered expr for filterExprBySource

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -326,11 +326,14 @@ func filterExprBySource(name string, expr Expr) Expr {
 				return nil
 			}
 		}
+		return &BinaryExpr{Op: expr.Op, LHS: lhs, RHS: rhs}
 
 	case *ParenExpr:
-		if filterExprBySource(name, expr.Expr) == nil {
+		exp := filterExprBySource(name, expr.Expr)
+		if exp == nil {
 			return nil
 		}
+		return &ParenExpr{Expr: exp}
 	}
 	return expr
 }

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -64,6 +64,13 @@ func TestSelectStatement_Substatement(t *testing.T) {
 			expr: &influxql.VarRef{Val: "bb.value"},
 			sub:  `SELECT bb.value FROM bb WHERE (bb.host = "serverb" OR bb.host = "serverc") AND 1.000 = 2.000`,
 		},
+
+		// 5. 4 with different condition order
+		{
+			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM join(aa, bb) WHERE (bb.host = "serverb" OR bb.host = "serverc") AND aa.host = "servera" AND 1 = 2`,
+			expr: &influxql.VarRef{Val: "bb.value"},
+			sub:  `SELECT bb.value FROM bb WHERE (bb.host = "serverb" OR bb.host = "serverc") AND 1.000 = 2.000`,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
While trying to fix associativity issue(#1266), I found this bug.

Below test may fails on master branch.

```
// Ensure the SELECT statement can extract substatements.
func TestSelectStatement_Substatement(t *testing.T) {
    var tests = []struct {
        stmt string
        expr *influxql.VarRef
        sub  string
        err  string
    }{
        {
            stmt: `SELECT sum(aa.value) + sum(bb.value) FROM join(aa, bb) WHERE (bb.host = "serverb" OR bb.host = "serverc") AND aa.host = "servera" AND 1 = 2`,
            expr: &influxql.VarRef{Val: "bb.value"},
            sub:  `SELECT bb.value FROM bb WHERE (bb.host = "serverb" OR bb.host = "serverc") AND 1.000 = 2.000`,
        },
    }

    for i, tt := range tests {
        // Parse statement.
        stmt, err := influxql.NewParser(strings.NewReader(tt.stmt)).ParseStatement()
        if err != nil {
            t.Fatalf("invalid statement: %q: %s", tt.stmt, err)
        }

        // Extract substatement.
        sub, err := stmt.(*influxql.SelectStatement).Substatement(tt.expr)
        if err != nil {
            t.Errorf("%d. %q: unexpected error: %s", i, tt.stmt, err)
            continue
        }
        if substr := sub.String(); tt.sub != substr {
            t.Errorf("%d. %q: unexpected substatement:\n\nexp=%s\n\ngot=%s\n\n", i, tt.stmt, tt.sub, substr)
            continue
        }
    }
}
```

`return expr` in the last line of `filterExprBySource` method can return unfiltered results,
so fixing it by reconstruction using filtered elements.
