### PR TITLE
Fix tests for /raft prefix

### DIFF
--- a/raft/transport_test.go
+++ b/raft/transport_test.go
@@ -51,7 +51,7 @@ func TestTransportMux_RequestVote_ErrUnsupportedScheme(t *testing.T) {
 func TestHTTPTransport_Heartbeat(t *testing.T) {
 	// Start mock HTTP server.
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if path := r.URL.Path; path != `/heartbeat` {
+		if path := r.URL.Path; path != `/raft/heartbeat` {
 			t.Fatalf("unexpected path: %q", path)
 		}
 		if term := r.FormValue("term"); term != `1` {
@@ -128,7 +128,7 @@ func TestHTTPTransport_Heartbeat_ErrConnectionRefused(t *testing.T) {
 func TestHTTPTransport_ReadFrom(t *testing.T) {
 	// Start mock HTTP server.
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if path := r.URL.Path; path != `/stream` {
+		if path := r.URL.Path; path != `/raft/stream` {
 			t.Fatalf("unexpected path: %q", path)
 		}
 		if term := r.FormValue("id"); term != `1` {
@@ -191,7 +191,7 @@ func TestHTTPTransport_ReadFrom_ErrConnectionRefused(t *testing.T) {
 func TestHTTPTransport_RequestVote(t *testing.T) {
 	// Start mock HTTP server.
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if path := r.URL.Path; path != `/vote` {
+		if path := r.URL.Path; path != `/raft/vote` {
 			t.Fatalf("unexpected path: %s", path)
 		}
 		if term := r.FormValue("term"); term != `1` {


### PR DESCRIPTION
## Overview

This pull requests fixes the tests to add `/raft` prefixes. The prefix was added before to support overlaying the raft API over the broker API.
