### PR TITLE
Fix unit test so filterExprBySource fix is tested

### DIFF
--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -67,9 +67,9 @@ func TestSelectStatement_Substatement(t *testing.T) {
 
 		// 5. 4 with different condition order
 		{
-			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM join(aa, bb) WHERE (bb.host = "serverb" OR bb.host = "serverc") AND aa.host = "servera" AND 1 = 2`,
+			stmt: `SELECT sum(aa.value) + sum(bb.value) FROM join(aa, bb) WHERE ((bb.host = "serverb" OR bb.host = "serverc") AND aa.host = "servera") AND 1 = 2`,
 			expr: &influxql.VarRef{Val: "bb.value"},
-			sub:  `SELECT bb.value FROM bb WHERE (bb.host = "serverb" OR bb.host = "serverc") AND 1.000 = 2.000`,
+			sub:  `SELECT bb.value FROM bb WHERE ((bb.host = "serverb" OR bb.host = "serverc")) AND 1.000 = 2.000`,
 		},
 	}
 


### PR DESCRIPTION
The change introduced by:

```
https://github.com/influxdb/influxdb/pull/1269
```

was not actually being tested.
