### PR TITLE
Add support for secret key authentication to manage influxdb locally.

### DIFF
--- a/cmd/influxd/config.go
+++ b/cmd/influxd/config.go
@@ -165,6 +165,7 @@ type Config struct {
 	ReportingDisabled bool   `toml:"reporting-disabled"`
 	Version           string `toml:"-"`
 	InfluxDBVersion   string `toml:"-"`
+	SecretFile        string `toml:"secret-file"`
 
 	Initialization Initialization `toml:"initialization"`
 

--- a/cmd/influxd/run.go
+++ b/cmd/influxd/run.go
@@ -301,6 +301,11 @@ func (cmd *RunCommand) CheckConfig() {
 	if cmd.config.Data.Enabled && cmd.config.Data.Dir == "" {
 		log.Fatal("Data.Dir must be specified.  To generate a valid configuration file run `influxd config > influxdb.generated.conf`.")
 	}
+	if cmd.config.SecretFile != "" {
+		if _, err := os.Stat(cmd.config.SecretFile); err != nil {
+			log.Fatalf("Problem while loading secret file: %s.", err)
+		}
+	}
 }
 
 func (cmd *RunCommand) Open(config *Config, join string) *Node {
@@ -337,6 +342,11 @@ func (cmd *RunCommand) Open(config *Config, join string) *Node {
 		cmd.node.DataNode = s
 		s.SetAuthenticationEnabled(cmd.config.Authentication.Enabled)
 		log.Printf("authentication enabled: %v\n", cmd.config.Authentication.Enabled)
+
+		if cmd.config.SecretFile != "" {
+			s.SecretFile = cmd.config.SecretFile
+			log.Printf("Secret file: %s\n", cmd.config.SecretFile)
+		}
 
 		// Enable retention policy enforcement if requested.
 		if cmd.config.Data.RetentionCheckEnabled {

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -17,6 +17,10 @@ port = 8086
 # Change this option to true to disable reporting.
 reporting-disabled = false
 
+# File containing administration secret you can use this file as an way to run
+# administration commands via localhost. Useful for automation tools
+#secret-file = "/path/to/the/file"
+
 # Controls settings for initial start-up. Once a node is successfully started,
 # these settings are ignored.  If a node is started with the -join flag,
 # these settings are ignored.


### PR DESCRIPTION
As described in https://github.com/influxdb/influxdb/issues/2278, I added the support for the secret file. 

Some feedback more than welcome. 

Also I will need some hints how to write the tests for this feature.