### PR TITLE
Fixed evaluating arithmetic comparisons in Binary Expressions for floats

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2507,7 +2507,10 @@ func evalBinaryExpr(expr *BinaryExpr, m map[string]interface{}) interface{} {
 			return lhs != rhs
 		}
 	case float64:
-		rhs, _ := rhs.(float64)
+		rhs, ok := rhs.(float64)
+		if !ok {
+		    return nil
+		}
 		switch expr.Op {
 		case EQ:
 			return lhs == rhs


### PR DESCRIPTION
Currently there is an issue with how Binary Expressions evaluate pretty much all types, but let's focus on the case of numbers. 

At line 2491 of ast.go we have: 
func evalBinaryExpr(expr *BinaryExpr, m map[string]interface{}) interface{} {

And 4 lines below:
// Evaluate if both sides are simple types.
	switch lhs := lhs.(type) {

The culprit is that the right side is never asserted to be a simple type. Assuming a simple query:
select * from cpu_load_short where value < 5.1
select * from cpu_load_short where 5.1 > value

If value is a float, then in both cases we will fall into this scenario: 
case float64:
		rhs, _ := rhs.(float64)

In the first scenario we will get a perfectly fine result depending on what number value actually is. 
However, in the second scenario, if rhs, that being our value, is a nil, this type of a safe cast will write 0 to rhs and false to the second variable, which is ignored. Therefore, our expression evaluates to 5.1 > 0 and thus to 'true', meaning that we will receive as a result every single row with either the correct value smaller than 5.1 or with value field empty. 

I believe that this is not the expected result, therefore I have suggested a fix by not ignoring the cast information and, upon fail, returning a nil, thus preventing the rows with nils from displaying. 

Here are screenshots with an example before applying the patch:
![image](https://cloud.githubusercontent.com/assets/4009329/8092396/bb8a30a2-0fb9-11e5-9028-29bf0a2711ce.png)
![image](https://cloud.githubusercontent.com/assets/4009329/8092377/9febb168-0fb9-11e5-9323-0e64b788dffd.png)
And the incorrect result:
![image](https://cloud.githubusercontent.com/assets/4009329/8092367/914440d0-0fb9-11e5-8a17-c1f865e86d19.png)

After applying the patch:
![image](https://cloud.githubusercontent.com/assets/4009329/8092427/ec0c69d4-0fb9-11e5-81b9-0fe369ed3b55.png)
![image](https://cloud.githubusercontent.com/assets/4009329/8092429/f0380856-0fb9-11e5-9a9e-32b31077df56.png)
![image](https://cloud.githubusercontent.com/assets/4009329/8092430/f510ed3e-0fb9-11e5-9ecb-63978a55118b.png)

Moreover, same kind of check could be applied to other types, this being int64, string and bool. However, in case of bool I am not sure if the expected return for OR in case lhs is true and rhs is nil should be true or false, therefore I would prefer a comment from you, dear developers, before issuing pull requests for this and other types. 