### PR TITLE
Reject uint64 Client.Point.Field values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#5460](https://github.com/influxdata/influxdb/pull/5460): Prevent exponential growth in CLI history. Thanks @sczk!
 
 ### Bugfixes
+- [#4299](https://github.com/influxdata/influxdb/pull/4299): Reject uint64 Client.Point.Field values
 - [#5129](https://github.com/influxdata/influxdb/pull/5129): Ensure precision flag is respected by CLI. Thanks @e-dard
 - [#5042](https://github.com/influxdb/influxdb/issues/5042): Count with fill(none) will drop 0 valued intervals.
 - [#4735](https://github.com/influxdb/influxdb/issues/4735): Fix panic when merging empty results.

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -196,6 +196,10 @@ func (c *Client) Write(bp BatchPoints) (*Response, error) {
 
 	var b bytes.Buffer
 	for _, p := range bp.Points {
+		err := checkPointTypes(p)
+		if err != nil {
+			return nil, err
+		}
 		if p.Raw != "" {
 			if _, err := b.WriteString(p.Raw); err != nil {
 				return nil, err
@@ -640,6 +644,19 @@ func (bp *BatchPoints) UnmarshalJSON(b []byte) error {
 // Addr provides the current url as a string of the server the client is connected to.
 func (c *Client) Addr() string {
 	return c.url.String()
+}
+
+// checkPointTypes ensures no unsupported types are submitted to influxdb, returning error if they are found.
+func checkPointTypes(p Point) error {
+	for _, v := range p.Fields {
+		switch v.(type) {
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, float32, float64, bool, string, nil:
+			return nil
+		default:
+			return fmt.Errorf("unsupported point type: %T", v)
+		}
+	}
+	return nil
 }
 
 // helper functions

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -13,6 +13,36 @@ import (
 	"github.com/influxdb/influxdb/client"
 )
 
+func BenchmarkWrite(b *testing.B) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var data client.Response
+		w.WriteHeader(http.StatusNoContent)
+		_ = json.NewEncoder(w).Encode(data)
+	}))
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL)
+	config := client.Config{URL: *u}
+	c, err := client.NewClient(config)
+	if err != nil {
+		b.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+
+	bp := client.BatchPoints{
+		Points: []client.Point{
+			{Fields: map[string]interface{}{"value": 101}}},
+	}
+	for i := 0; i < b.N; i++ {
+		r, err := c.Write(bp)
+		if err != nil {
+			b.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+		}
+		if r != nil {
+			b.Fatalf("unexpected response. expected %v, actual %v", nil, r)
+		}
+	}
+}
+
 func BenchmarkUnmarshalJSON2Tags(b *testing.B) {
 	var bp client.BatchPoints
 	data := []byte(`
@@ -543,6 +573,36 @@ func TestClient_NoTimeout(t *testing.T) {
 	_, err = c.Query(query)
 	if err != nil {
 		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+}
+
+func TestClient_WriteUint64(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var data client.Response
+		w.WriteHeader(http.StatusNoContent)
+		_ = json.NewEncoder(w).Encode(data)
+	}))
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL)
+	config := client.Config{URL: *u}
+	c, err := client.NewClient(config)
+	if err != nil {
+		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
+	}
+	bp := client.BatchPoints{
+		Points: []client.Point{
+			{
+				Fields: map[string]interface{}{"value": uint64(10)},
+			},
+		},
+	}
+	r, err := c.Write(bp)
+	if err == nil {
+		t.Fatalf("unexpected error. expected err, actual %v", err)
+	}
+	if r != nil {
+		t.Fatalf("unexpected response. expected %v, actual %v", nil, r)
 	}
 }
 


### PR DESCRIPTION
fix for issue #4249 

tested by using the example client write code from https://godoc.org/github.com/influxdb/influxdb/client#example-Client-Write
once default, once replacing the value with a uint64

go test in /client passes, same as in the root of the repo.

(apologies if i've used the below incorrectly)

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)