### PR TITLE
Fix GROUP BY for small intervals and implicit times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - [#4472](https://github.com/influxdb/influxdb/issues/4472): Fix 'too many points in GROUP BY interval' error
 - [#4475](https://github.com/influxdb/influxdb/issues/4475): Fix SHOW TAG VALUES error message.
 - [#4486](https://github.com/influxdb/influxdb/pull/4486): Fix missing comments for runner package
+- [#4481](https://github.com/influxdb/influxdb/issues/4481): GROUP BY on intervals < 1ms makes too many buckets
 - [#4497](https://github.com/influxdb/influxdb/pull/4497): Fix sequence in meta proto
 
 ## v0.9.4 [2015-09-14]

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -3169,6 +3169,53 @@ func TestServer_Query_GroupByTimeCutoffs(t *testing.T) {
 	}
 }
 
+// Test for bug #4481 GROUP BY on intervals < 1ms makes too many buckets
+func TestServer_Query_GroupBySmallInterval(t *testing.T) {
+	t.Parallel()
+	s := OpenServer(NewConfig(), "")
+	defer s.Close()
+
+	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MetaStore.SetDefaultRetentionPolicy("db0", "rp0"); err != nil {
+		t.Fatal(err)
+	}
+
+	writes := []string{
+		fmt.Sprintf(`cpu value=1i %d`, time.Now().UnixNano()),
+	}
+	test := NewTest("db0", "rp0")
+	test.write = strings.Join(writes, "\n")
+
+	test.addQueries([]*Query{
+		&Query{
+			name:    "group by with small interval - this query should return 2 buckets",
+			params:  url.Values{"db": []string{"db0"}},
+			command: `SELECT MEAN(value) FROM cpu where time >= now() - 1u group by time(1u)`,
+			exp:     `"values":\[\["\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d*)?Z",null\],\["\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d*)?Z",null\]\]`,
+			pattern: true,
+		},
+	}...)
+
+	for i, query := range test.queries {
+		if i == 0 {
+			if err := test.init(s); err != nil {
+				t.Fatalf("test init failed: %s", err)
+			}
+		}
+		if query.skip {
+			t.Logf("SKIP:: %s", query.name)
+			continue
+		}
+		if err := query.Execute(s); err != nil {
+			t.Error(query.Error(err))
+		} else if !query.success() {
+			t.Error(query.failureMessage())
+		}
+	}
+}
+
 func TestServer_Write_Precision(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig(), "")

--- a/tsdb/query_executor.go
+++ b/tsdb/query_executor.go
@@ -242,11 +242,22 @@ func (q *QueryExecutor) PlanSelect(stmt *influxql.SelectStatement, chunkSize int
 	// Replace instances of "now()" with the current time, and check the resultant times.
 	stmt.Condition = influxql.Reduce(stmt.Condition, &influxql.NowValuer{Now: now})
 	tmin, tmax := influxql.TimeRange(stmt.Condition)
+	explicitTimeRange := true
 	if tmax.IsZero() {
 		tmax = now
+		explicitTimeRange = false
 	}
 	if tmin.IsZero() {
 		tmin = time.Unix(0, 0)
+		explicitTimeRange = false
+	}
+
+	// for queries with small group by interval set time range if it wasn't explicit
+	if !explicitTimeRange {
+		interval, err := stmt.GroupByInterval()
+		if err == nil && interval < time.Second {
+			stmt.SetTimeRange(tmin, tmax)
+		}
 	}
 
 	for _, src := range stmt.Sources {


### PR DESCRIPTION
Implicit ending time range for group by was calculated later than
starting range. This caused too many buckets for small intervals.
The fix is to set explicit time range for such cases, but triggers
reparsing of the query.

Fixes #4481