### PR TITLE
Implement continuous query backfill

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -557,11 +557,16 @@ func (s *SetPasswordUserStatement) RequiredPrivileges() ExecutionPrivileges {
 type BackfillStatement struct {
 	QueryName string
 	Database  string
+	From      Expr
 	Until     Expr
 }
 
 func (b *BackfillStatement) String() string {
-	return fmt.Sprintf("BACKFILL %s ON %s UNTIL %s", b.QueryName, b.Database, b.Until.String())
+	untilstr := ""
+	if b.Until != nil {
+		untilstr = fmt.Sprintf(" UNTIL %s", b.Until.String())
+	}
+	return fmt.Sprintf("BACKFILL %s ON %s FROM %s%s", b.QueryName, b.Database, b.From.String(), untilstr)
 }
 
 func (b *BackfillStatement) RequiredPrivileges() ExecutionPrivileges {

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -82,6 +82,7 @@ func (Statements) node() {}
 
 func (*AlterDatabaseRenameStatement) node()   {}
 func (*AlterRetentionPolicyStatement) node()  {}
+func (*BackfillStatement) node()              {}
 func (*CreateContinuousQueryStatement) node() {}
 func (*CreateDatabaseStatement) node()        {}
 func (*CreateRetentionPolicyStatement) node() {}
@@ -191,6 +192,7 @@ type ExecutionPrivileges []ExecutionPrivilege
 
 func (*AlterDatabaseRenameStatement) stmt()   {}
 func (*AlterRetentionPolicyStatement) stmt()  {}
+func (*BackfillStatement) stmt()              {}
 func (*CreateContinuousQueryStatement) stmt() {}
 func (*CreateDatabaseStatement) stmt()        {}
 func (*CreateRetentionPolicyStatement) stmt() {}
@@ -550,6 +552,26 @@ func (s *SetPasswordUserStatement) String() string {
 // RequiredPrivileges returns the privilege required to execute a SetPasswordUserStatement.
 func (s *SetPasswordUserStatement) RequiredPrivileges() ExecutionPrivileges {
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}
+}
+
+type BackfillStatement struct {
+	QueryName string
+	Database  string
+	Until     Expr
+}
+
+func (b *BackfillStatement) String() string {
+	return fmt.Sprintf("BACKFILL %s ON %s UNTIL %s", b.QueryName, b.Database, b.Until.String())
+}
+
+func (b *BackfillStatement) RequiredPrivileges() ExecutionPrivileges {
+	return []ExecutionPrivilege{
+		{
+			Admin:     false,
+			Name:      b.Database,
+			Privilege: WritePrivilege,
+		},
+	}
 }
 
 // RevokeStatement represents a command to revoke a privilege from a user.

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -305,10 +305,9 @@ func (p *Parser) parseBackfillStatement() (*BackfillStatement, error) {
 
 	// Get the UNTIL keyword. This is optional, so if we see EOF, just ignore it.
 	tok, pos, lit = p.scanIgnoreWhitespace()
-	if tok == EOF {
+	if tok != UNTIL {
+		p.unscan()
 		return stmt, nil
-	} else if tok != UNTIL {
-		return nil, newParseError(tokstr(tok, lit), []string{"UNTIL"}, pos)
 	}
 
 	expr, err = p.ParseExpr()

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -291,13 +291,27 @@ func (p *Parser) parseBackfillStatement() (*BackfillStatement, error) {
 	}
 	stmt.Database = ident
 
-	// get the UNTIL keywork
+	// get the FROM keyword
 	tok, pos, lit = p.scanIgnoreWhitespace()
-	if tok != UNTIL {
-		return nil, newParseError(tokstr(tok, lit), []string{"UNTIL"}, pos)
+	if tok != FROM {
+		return nil, newParseError(tokstr(tok, lit), []string{"FROM"}, pos)
 	}
 
 	expr, err := p.ParseExpr()
+	if err != nil {
+		return nil, err
+	}
+	stmt.From = expr
+
+	// Get the UNTIL keyword. This is optional, so if we see EOF, just ignore it.
+	tok, pos, lit = p.scanIgnoreWhitespace()
+	if tok == EOF {
+		return stmt, nil
+	} else if tok != UNTIL {
+		return nil, newParseError(tokstr(tok, lit), []string{"UNTIL"}, pos)
+	}
+
+	expr, err = p.ParseExpr()
 	if err != nil {
 		return nil, err
 	}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1457,10 +1457,10 @@ func TestParser_ParseStatement(t *testing.T) {
 		},
 
 		// Errors
-		{s: ``, err: `found EOF, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 1`},
+		{s: ``, err: `found EOF, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET, BACKFILL at line 1, char 1`},
 		{s: `SELECT`, err: `found EOF, expected identifier, string, number, bool at line 1, char 8`},
 		{s: `SELECT time FROM myseries`, err: `at least 1 non-time field must be queried`},
-		{s: `blah blah`, err: `found blah, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET at line 1, char 1`},
+		{s: `blah blah`, err: `found blah, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET, BACKFILL at line 1, char 1`},
 		{s: `SELECT field1 X`, err: `found X, expected FROM at line 1, char 15`},
 		{s: `SELECT field1 FROM "series" WHERE X +;`, err: `found ;, expected identifier, string, number, bool at line 1, char 38`},
 		{s: `SELECT field1 FROM myseries GROUP`, err: `found EOF, expected BY at line 1, char 35`},

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -61,6 +61,7 @@ const (
 	AS
 	ASC
 	BEGIN
+	BACKFILL
 	BY
 	CREATE
 	CONTINUOUS
@@ -121,6 +122,7 @@ const (
 	SOFFSET
 	TAG
 	TO
+	UNTIL
 	USER
 	USERS
 	VALUES
@@ -173,6 +175,7 @@ var tokens = [...]string{
 	ALTER:        "ALTER",
 	AS:           "AS",
 	ASC:          "ASC",
+	BACKFILL:     "BACKFILL",
 	BEGIN:        "BEGIN",
 	BY:           "BY",
 	CREATE:       "CREATE",
@@ -234,6 +237,7 @@ var tokens = [...]string{
 	DIAGNOSTICS:  "DIAGNOSTICS",
 	TAG:          "TAG",
 	TO:           "TO",
+	UNTIL:        "UNTIL",
 	USER:         "USER",
 	USERS:        "USERS",
 	VALUES:       "VALUES",


### PR DESCRIPTION
The syntax for this feature is `BACKFILL cqname ON database UNTIL
timeliteral`

This will fill in the continuous query from now until the time
literal. The time literal can be an expression such as `now() - 10d`