### PR TITLE
Allow units in old time.Duration config values

### DIFF
--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -1,0 +1,41 @@
+package tsdb
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCompatDurationUnmarshalText(t *testing.T) {
+	tests := []struct {
+		in  string
+		out time.Duration
+	}{
+		{
+			"",
+			time.Duration(0)},
+		{
+			"0",
+			time.Duration(0),
+		},
+		{
+			"1",
+			1 * time.Second,
+		},
+		{
+			"150ms",
+			150 * time.Millisecond,
+		},
+		{
+			"10s",
+			10 * time.Second,
+		},
+	}
+
+	for ii, tt := range tests {
+		var x compatDuration
+		x.UnmarshalText([]byte(tt.in))
+		if time.Duration(x) != tt.out {
+			t.Errorf("[%d] compatDuration.UnmarshalText(%#v) = %v, expected %v", ii, tt.in, x, tt.out)
+		}
+	}
+}

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -159,10 +159,10 @@ func NewEngine(path string, walPath string, opt tsdb.EngineOptions) tsdb.Engine 
 		WAL:                        w,
 		RotateFileSize:             DefaultRotateFileSize,
 		MaxFileSize:                MaxDataFileSize,
-		CompactionAge:              opt.Config.IndexCompactionAge,
+		CompactionAge:              time.Duration(opt.Config.IndexCompactionAge),
 		MinCompactionFileCount:     opt.Config.IndexMinCompactionFileCount,
-		IndexCompactionFullAge:     opt.Config.IndexCompactionFullAge,
-		IndexMinCompactionInterval: opt.Config.IndexMinCompactionInterval,
+		IndexCompactionFullAge:     time.Duration(opt.Config.IndexCompactionFullAge),
+		IndexMinCompactionInterval: time.Duration(opt.Config.IndexMinCompactionInterval),
 		MaxPointsPerBlock:          DefaultMaxPointsPerBlock,
 	}
 	e.WAL.IndexWriter = e


### PR DESCRIPTION
This is a first attempt at making duration/interval time fields consistent in the config, highlighted here: #4527.

Having an unexported type (`compatDuration`) in the config definition isn't great, but it should only be temporary until all `time.Duration`-based config params can be unified to use `toml.Duration`.

Patching `toml.Duration` to detect integer values without units is also an option, though it is a much bigger change as it is used in a lot more places (not to mention the behaviour change from returning an error when no unit is set, to assuming that user wants `time.Second`).