### PR TITLE
Fixed windows "too many args to return" error

### DIFF
--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -10,5 +10,5 @@ func mmap(f *os.File, offset int64, length int) ([]byte, error) {
 }
 
 func munmap(b []byte) (err error) {
-	return nil, fmt.Errorf("munmap file not supported on windows")
+	return fmt.Errorf("munmap file not supported on windows")
 }


### PR DESCRIPTION
Building on Windows 8.1. Error of "too many arguments to return".