### PR TITLE
Add alias support to top and bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ With this release InfluxDB is moving to Go 1.5.
 ### Features
 
 ### Bugfixes
+- [#4949](https://github.com/influxdb/influxdb/issues/4949): Fix aliases for top and bottom functions.
 - [#5042](https://github.com/influxdb/influxdb/issues/5042): Count with fill(none) will drop 0 valued intervals.
 - [#4735](https://github.com/influxdb/influxdb/issues/4735): Fix panic when merging empty results.
 - [#5016](https://github.com/influxdb/influxdb/pull/5016): Don't panic if Meta data directory not writable. Thanks @oiooj

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -954,11 +954,14 @@ func (s *SelectStatement) ColumnNames() []string {
 		case *Call:
 			if f.Name == "top" || f.Name == "bottom" {
 				if len(f.Args) == 2 {
-					columnNames = append(columnNames, f.Name)
+					columnNames = append(columnNames, field.Name())
 					continue
 				}
 				// We have a special case now where we have to add the column names for the fields TOP or BOTTOM asked for as well
-				columnNames = slices.Union(columnNames, f.Fields(), true)
+				names := f.Fields()
+				// Apply alias to first field name
+				names[0] = field.Name()
+				columnNames = slices.Union(columnNames, names, true)
 				continue
 			}
 			columnNames = append(columnNames, field.Name())


### PR DESCRIPTION
Fixes #4949

I am not sure that I implemented this with the correct behavior. Given this query what column names do you expect to be returned?

```
select top(value, id, 10) as alias_name from m
```

I made it return `alias_name, id`

See test cases for behavior to make sure we agree.
