### PR TITLE
Add missing QuoteIdent

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2503,7 +2503,7 @@ func (f *Field) String() string {
 	if f.Alias == "" {
 		return str
 	}
-	return fmt.Sprintf("%s AS %s", str, fmt.Sprintf(`"%s"`, f.Alias))
+	return fmt.Sprintf("%s AS %s", str, QuoteIdent(f.Alias))
 }
 
 // Sort Interface for Fields


### PR DESCRIPTION
Aliases were getting sometimes-unnecessary quotes prior to this change.