### PR TITLE
Fixes #5077

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#5178](https://github.com/influxdb/influxdb/pull/5178): SHOW FIELD shouldn't consider VALUES to be valid. Thanks @pires
 - [#5158](https://github.com/influxdb/influxdb/pull/5158): Fix panic when writing invalid input to the line protocol.
 - [#5264](https://github.com/influxdata/influxdb/pull/5264): Fix panic: runtime error: slice bounds out of range
+- [#5186](https://github.com/influxdata/influxdb/pull/5186): Fix database creation with retention statement parsing. Fixes [#5077](https://github.com/influxdb/influxdb/issues/5077). Thanks @pires
 
 ## v0.9.6 [2015-12-09]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1507,7 +1507,9 @@ func (p *Parser) parseCreateDatabaseStatement() (*CreateDatabaseStatement, error
 
 		// Look for "NAME"
 		var rpName string = "default" // default is default
-		if err := p.parseTokens([]Token{NAME}); err == nil {
+		if err := p.parseTokens([]Token{NAME}); err != nil {
+			p.unscan()
+		} else {
 			rpName, err = p.parseIdent()
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Throw an error if NAME is not provided when creating a database with retention, but something else is.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign CLA (if not already signed)

Fixes #5077