### PR TITLE
Use DEBIAN_FRONTEND=noninteractive when using apt-get in Dockerfiles

### DIFF
--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -1,6 +1,6 @@
 FROM 32bit/ubuntu:14.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
     software-properties-common \
     wget \

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
     software-properties-common \
     wget \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
     software-properties-common \
     wget \

--- a/Dockerfile_test_ubuntu32
+++ b/Dockerfile_test_ubuntu32
@@ -1,8 +1,8 @@
 FROM 32bit/ubuntu:14.04
 
-RUN apt-get update && apt-get install -y python-software-properties software-properties-common git
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python-software-properties software-properties-common git
 RUN add-apt-repository ppa:evarlast/golang1.4
-RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-overwrite" golang-go
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-overwrite" golang-go
 
 ENV GOPATH=/root/go
 RUN mkdir -p /root/go/src/github.com/influxdata/influxdb


### PR DESCRIPTION
apt-get will attempt to use the dialog frontend by default.
When building with docker, error messages get written by debconf when
installing some packages because it tries to open the dialog frontend.

Set `DEBIAN_FRONTEND=noninteractive` to suppress these unnecessary
messages. The dialog frontend shouldn't be getting used anyway.