### PR TITLE
Connect using CLI without HTTPS Verification

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -79,6 +80,7 @@ type Config struct {
 	UserAgent string
 	Timeout   time.Duration
 	Precision string
+	UnsafeSsl bool
 }
 
 // NewConfig will create a config to be used in connecting to the client
@@ -114,11 +116,19 @@ const (
 
 // NewClient will instantiate and return a connected client to issue commands to the server.
 func NewClient(c Config) (*Client, error) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: c.UnsafeSsl,
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
 	client := Client{
 		url:        c.URL,
 		username:   c.Username,
 		password:   c.Password,
-		httpClient: &http.Client{Timeout: c.Timeout},
+		httpClient: &http.Client{Timeout: c.Timeout, Transport: tr},
 		userAgent:  c.UserAgent,
 		precision:  c.Precision,
 	}

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -38,6 +38,7 @@ type CommandLine struct {
 	Password         string
 	Database         string
 	Ssl              bool
+	UnsafeSsl        bool
 	RetentionPolicy  string
 	ClientVersion    string
 	ServerVersion    string
@@ -270,6 +271,7 @@ func (c *CommandLine) Connect(cmd string) error {
 	config.Password = c.Password
 	config.UserAgent = "InfluxDBShell/" + c.ClientVersion
 	config.Precision = c.Precision
+	config.UnsafeSsl = c.UnsafeSsl
 	cl, err := client.NewClient(config)
 	if err != nil {
 		return fmt.Errorf("Could not create client %s", err)

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -36,6 +36,7 @@ func main() {
 	fs.StringVar(&c.Password, "password", c.Password, `Password to connect to the server.  Leaving blank will prompt for password (--password="").`)
 	fs.StringVar(&c.Database, "database", c.Database, "Database to connect to the server.")
 	fs.BoolVar(&c.Ssl, "ssl", false, "Use https for connecting to cluster.")
+	fs.BoolVar(&c.UnsafeSsl, "unsafeSsl", false, "Set this when connecting to the cluster using https and not use SSL verification.")
 	fs.StringVar(&c.Format, "format", defaultFormat, "Format specifies the format of the server responses:  json, csv, or column.")
 	fs.StringVar(&c.Precision, "precision", defaultPrecision, "Precision specifies the format of the timestamp:  rfc3339,h,m,s,ms,u or ns.")
 	fs.StringVar(&c.WriteConsistency, "consistency", "any", "Set write consistency level: any, one, quorum, or all.")
@@ -64,6 +65,8 @@ func main() {
        Username to connect to the server.
   -ssl
         Use https for requests.
+  -unsafeSsl
+        Set this when connecting to the cluster using https and not use SSL verification.
   -execute 'command'
        Execute command and quit.
   -format 'json|csv|column'


### PR DESCRIPTION
The V2 client code supports this, however, the V1 client code didn't,
and the argument to support this just had to be added to the CLI