### PR TITLE
Reduce allocations during TSM compactions

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/influxdb/influxdb/cmd/influxd/backup"
@@ -188,8 +189,13 @@ func (cmd *Command) unpackShard(shardID string) error {
 		return fmt.Errorf("shard already present: %s", restorePath)
 	}
 
+	id, err := strconv.ParseUint(shardID, 10, 64)
+	if err != nil {
+		return err
+	}
+
 	// find the shard backup files
-	pat := filepath.Join(cmd.backupFilesPath, fmt.Sprintf(backup.BackupFilePattern, cmd.database, cmd.retention, shardID))
+	pat := filepath.Join(cmd.backupFilesPath, fmt.Sprintf(backup.BackupFilePattern, cmd.database, cmd.retention, id))
 	return cmd.unpackFiles(pat + ".*")
 }
 

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -982,6 +982,30 @@ func (a *indexEntries) MarshalBinary() (b []byte, err error) {
 	return b, nil
 }
 
+func (a *indexEntries) Write(w io.Writer) error {
+	for _, entry := range a.entries {
+		_, err := w.Write(u64tob(uint64(entry.MinTime.UnixNano())))
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(u64tob(uint64(entry.MaxTime.UnixNano())))
+		if err != nil {
+			return err
+		}
+
+		_, err = w.Write(u64tob(uint64(entry.Offset)))
+		if err != nil {
+			return err
+		}
+
+		_, err = w.Write(u32tob(entry.Size))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func readKey(b []byte) (n int, key []byte, err error) {
 	// 2 byte size of key
 	n, size := 2, int(btou16(b[:2]))

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -159,6 +159,9 @@ type TSMIndex interface {
 	// Key returns the key in the index at the given postion.
 	Key(index int) (string, []*IndexEntry)
 
+	// KeyAt returns the key in the index at the given postion.
+	KeyAt(index int) string
+
 	// KeyCount returns the count of unique keys in the index.
 	KeyCount() int
 
@@ -340,6 +343,13 @@ func (d *directIndex) Key(idx int) (string, []*IndexEntry) {
 	return k, d.blocks[k].entries
 }
 
+func (d *directIndex) KeyAt(idx int) string {
+	if idx < 0 || idx >= len(d.blocks) {
+		return ""
+	}
+	return d.Keys()[idx]
+}
+
 func (d *directIndex) KeyCount() int {
 	return len(d.blocks)
 }
@@ -409,7 +419,7 @@ func (d *directIndex) Write(w io.Writer) error {
 			return fmt.Errorf("write: writer key length error: %v", err)
 		}
 
-		_, err = w.Write([]byte(key))
+		_, err = io.WriteString(w, key)
 		if err != nil {
 			return fmt.Errorf("write: writer key error: %v", err)
 		}

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -182,6 +182,9 @@ type TSMIndex interface {
 	// UnmarshalBinary populates an index from an encoded byte slice
 	// representation of an index.
 	UnmarshalBinary(b []byte) error
+
+	// Write writes the index contents to a writer
+	Write(w io.Writer) error
 }
 
 // IndexEntry is the index information for a given block in a TSM file.
@@ -338,7 +341,7 @@ func (d *directIndex) Key(idx int) (string, []*IndexEntry) {
 }
 
 func (d *directIndex) KeyCount() int {
-	return len(d.Keys())
+	return len(d.blocks)
 }
 
 func (d *directIndex) KeyRange() (string, string) {
@@ -380,20 +383,6 @@ func (d *directIndex) addEntries(key string, entries *indexEntries) {
 }
 
 func (d *directIndex) Write(w io.Writer) error {
-	b, err := d.MarshalBinary()
-	if err != nil {
-		return fmt.Errorf("write: marshal error: %v", err)
-	}
-
-	// Write out the index bytes
-	_, err = w.Write(b)
-	if err != nil {
-		return fmt.Errorf("write: writer error: %v", err)
-	}
-	return nil
-}
-
-func (d *directIndex) MarshalBinary() ([]byte, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -404,37 +393,53 @@ func (d *directIndex) MarshalBinary() ([]byte, error) {
 	}
 	sort.Strings(keys)
 
-	// Buffer to build up the index and write in bulk
-	var b []byte
-
 	// For each key, individual entries are sorted by time
 	for _, key := range keys {
 		entries := d.blocks[key]
 
 		if entries.Len() > maxIndexEntries {
-			return nil, fmt.Errorf("key '%s' exceeds max index entries: %d > %d",
+			return fmt.Errorf("key '%s' exceeds max index entries: %d > %d",
 				key, entries.Len(), maxIndexEntries)
 		}
 		sort.Sort(entries)
 
 		// Append the key length and key
-		b = append(b, u16tob(uint16(len(key)))...)
-		b = append(b, key...)
+		_, err := w.Write(u16tob(uint16(len(key))))
+		if err != nil {
+			return fmt.Errorf("write: writer key length error: %v", err)
+		}
+
+		_, err = w.Write([]byte(key))
+		if err != nil {
+			return fmt.Errorf("write: writer key error: %v", err)
+		}
 
 		// Append the block type
-		b = append(b, entries.Type)
+		_, err = w.Write([]byte{entries.Type})
+		if err != nil {
+			return fmt.Errorf("write: writer key type error: %v", err)
+		}
 
 		// Append the index block count
-		b = append(b, u16tob(uint16(entries.Len()))...)
+		_, err = w.Write(u16tob(uint16(entries.Len())))
+		if err != nil {
+			return fmt.Errorf("write: writer block count error: %v", err)
+		}
 
 		// Append each index entry for all blocks for this key
-		eb, err := entries.MarshalBinary()
-		if err != nil {
-			return nil, err
+		if err = entries.Write(w); err != nil {
+			return fmt.Errorf("write: writer entries error: %v", err)
 		}
-		b = append(b, eb...)
 	}
-	return b, nil
+	return nil
+}
+
+func (d *directIndex) MarshalBinary() ([]byte, error) {
+	var b bytes.Buffer
+	if err := d.Write(&b); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 func (d *directIndex) UnmarshalBinary(b []byte) error {
@@ -543,20 +548,28 @@ func (t *tsmWriter) WriteBlock(key string, minTime, maxTime time.Time, block []b
 
 	checksum := crc32.ChecksumIEEE(block)
 
-	n, err := t.w.Write(append(u32tob(checksum), block...))
+	_, err := t.w.Write(u32tob(checksum))
 	if err != nil {
 		return err
 	}
+
+	n, err := t.w.Write(block)
+	if err != nil {
+		return err
+	}
+
+	// 4 byte checksum + len of block
+	blockSize := 4 + n
 
 	blockType, err := BlockType(block)
 	if err != nil {
 		return err
 	}
 	// Record this block in index
-	t.index.Add(key, blockType, minTime, maxTime, t.n, uint32(n))
+	t.index.Add(key, blockType, minTime, maxTime, t.n, uint32(blockSize))
 
-	// Increment file position pointer
-	t.n += int64(n)
+	// Increment file position pointer (checksum + block len)
+	t.n += int64(blockSize)
 
 	return nil
 }
@@ -566,23 +579,20 @@ func (t *tsmWriter) WriteBlock(key string, minTime, maxTime time.Time, block []b
 func (t *tsmWriter) WriteIndex() error {
 	indexPos := t.n
 
-	// Generate the index bytes
-	b, err := t.index.MarshalBinary()
-	if err != nil {
-		return err
-	}
-
-	// Don't write an index if we don't actually have any blocks in the file.
-	if len(b) == 0 {
+	if t.index.KeyCount() == 0 {
 		return ErrNoValues
 	}
 
-	// Write the index followed by index position
-	_, err = t.w.Write(append(b, u64tob(uint64(indexPos))...))
-	if err != nil {
+	// Write the index
+	if err := t.index.Write(t.w); err != nil {
 		return err
 	}
 
+	// Write the index index position
+	_, err := t.w.Write(u64tob(uint64(indexPos)))
+	if err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR has a few optimizations to reduce memory allocations that occur during TSM compactions.  The main changes are:
* Write the index directly to a writer instead of building a byte slice and writing the slice.  We were previously building a slice and then writing in bulk to reduce IO system calls.  A previous optimization switched the writer to use a buffered writer which makes this slice buffering unnecessary and costly.
* Avoid building a slice of sorted keys in the TSM iterator and instead just use the already sorted index as a buffer
* Resize and re-used temp buffers when encoding wal entries - not related to compactions, but showed up as a big source of allocations on the write path.
* Eliminate some allocations as side-effects.  Some calls were allocating objects due to type conversions unintentionally.

There are still a lot more places to fix but this gets most of compaction related code out of the top 10 allocation spots as seen via memory profile.
