### PR TITLE
Reduce allocations with TSM queries

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -993,14 +993,18 @@ func unescapeMeasurement(in []byte) []byte {
 
 func escapeTag(in []byte) []byte {
 	for b, esc := range tagEscapeCodes {
-		in = bytes.Replace(in, []byte{b}, esc, -1)
+		if bytes.Contains(in, []byte{b}) {
+			in = bytes.Replace(in, []byte{b}, esc, -1)
+		}
 	}
 	return in
 }
 
 func unescapeTag(in []byte) []byte {
 	for b, esc := range tagEscapeCodes {
-		in = bytes.Replace(in, esc, []byte{b}, -1)
+		if bytes.Contains(in, []byte{b}) {
+			in = bytes.Replace(in, esc, []byte{b}, -1)
+		}
 	}
 	return in
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -633,11 +633,12 @@ type devTx struct {
 // Cursor returns a cursor for all cached and TSM-based data.
 func (t *devTx) Cursor(series string, fields []string, dec *tsdb.FieldCodec, ascending bool) tsdb.Cursor {
 	if len(fields) == 1 {
+		key := SeriesFieldKey(series, fields[0])
 		return &devCursor{
 			series:       series,
 			fields:       fields,
-			cache:        t.engine.Cache.Values(SeriesFieldKey(series, fields[0])),
-			tsmKeyCursor: t.engine.KeyCursor(SeriesFieldKey(series, fields[0])),
+			cache:        t.engine.Cache.Values(key),
+			tsmKeyCursor: t.engine.KeyCursor(key),
 			ascending:    ascending,
 		}
 	}
@@ -647,11 +648,12 @@ func (t *devTx) Cursor(series string, fields []string, dec *tsdb.FieldCodec, asc
 	var cursors []tsdb.Cursor
 	var cursorFields []string
 	for _, field := range fields {
+		key := SeriesFieldKey(series, field)
 		wc := &devCursor{
 			series:       series,
 			fields:       []string{field},
-			cache:        t.engine.Cache.Values(SeriesFieldKey(series, field)),
-			tsmKeyCursor: t.engine.KeyCursor(SeriesFieldKey(series, field)),
+			cache:        t.engine.Cache.Values(key),
+			tsmKeyCursor: t.engine.KeyCursor(key),
 			ascending:    ascending,
 		}
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -510,7 +510,7 @@ type location struct {
 	r     TSMFile
 	entry *IndexEntry
 
-	// Has this location been before
+	// Has this location been read before
 	read bool
 }
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -537,7 +537,6 @@ func (c *KeyCursor) init(t time.Time, ascending bool) {
 			}
 		}
 	}
-	c.buf = make([]Value, 1000)
 	c.ready = true
 }
 


### PR DESCRIPTION
This reduces memory allocations a bit when running queries against the TSM engine and may prevent some OOMs in some cases.  The bulk of the allocations are in the query engine, but the `KeyCursor` was allocating a buffer beforehand that blows the heap up with high numbers of series.  If swap is enabled, the process OS can start swapping causing performance to drastically decrease.  If a host does not have swap, the process would likely OOM on the query.   

Below are some test results from before and after this PR.  My laptop has swap and this is a basic count query on 5M series w/ ~15M points on disk. 

Before 
```
influxdb:influxdb jason$ time influx -database stress -execute "select count(value) from cpu"
name: cpu
---------
time	count
0	1.5215e+07


real	10m42.106s
user	0m0.005s
sys	0m0.020s
```

After:
```
influxdb:influxdb jason$ time influx -database stress -execute "select count(value) from cpu"
name: cpu
---------
time	count
0	1.5215e+07


real	2m29.758s
user	0m0.005s
sys	0m0.015s
```