### PR TITLE
Show disk usage reduction factor post-compression

### DIFF
--- a/cmd/influx_tsm/converter.go
+++ b/cmd/influx_tsm/converter.go
@@ -16,6 +16,7 @@ var (
 	PointsWritten   uint64
 	PointsRead      uint64
 	TsmFilesCreated uint64
+	TsmBytesWritten int64
 )
 
 type KeyIterator interface {
@@ -71,6 +72,8 @@ func (c *Converter) Process(iter KeyIterator) error {
 			if err := w.WriteIndex(); err != nil && err != tsm1.ErrNoValues {
 				return err
 			}
+			atomic.AddInt64(&TsmBytesWritten, int64(w.Size()))
+
 			if err := w.Close(); err != nil {
 				return err
 			}
@@ -82,6 +85,8 @@ func (c *Converter) Process(iter KeyIterator) error {
 		if err := w.WriteIndex(); err != nil && err != tsm1.ErrNoValues {
 			return err
 		}
+		atomic.AddInt64(&TsmBytesWritten, int64(w.Size()))
+
 		if err := w.Close(); err != nil {
 			return err
 		}

--- a/cmd/influx_tsm/main.go
+++ b/cmd/influx_tsm/main.go
@@ -201,16 +201,21 @@ func main() {
 	pg.Wait()
 
 	// Dump stats.
+	preSize := tsdb.ShardInfos(shards).Size()
+	postSize := TsmBytesWritten
 	fmt.Printf("\nSummary statistics\n========================================\n")
-	fmt.Printf("Databases converted:              %d\n", len(tsdb.ShardInfos(shards).Databases()))
-	fmt.Printf("Shards converted:                 %d\n", len(shards))
-	fmt.Printf("TSM files created:                %d\n", TsmFilesCreated)
-	fmt.Printf("Points read:                      %d\n", PointsRead)
-	fmt.Printf("Points written:                   %d\n", PointsWritten)
-	fmt.Printf("NaN filtered:                     %d\n", NanFiltered)
-	fmt.Printf("Inf filtered:                     %d\n", InfFiltered)
-	fmt.Printf("Points without fields filtered:   %d\n", b1.NoFieldsFiltered+bz1.NoFieldsFiltered)
-	fmt.Printf("Total conversion time:            %v\n", time.Now().Sub(conversionStart))
+	fmt.Printf("Databases converted:                 %d\n", len(tsdb.ShardInfos(shards).Databases()))
+	fmt.Printf("Shards converted:                    %d\n", len(shards))
+	fmt.Printf("TSM files created:                   %d\n", TsmFilesCreated)
+	fmt.Printf("Points read:                         %d\n", PointsRead)
+	fmt.Printf("Points written:                      %d\n", PointsWritten)
+	fmt.Printf("NaN filtered:                        %d\n", NanFiltered)
+	fmt.Printf("Inf filtered:                        %d\n", InfFiltered)
+	fmt.Printf("Points without fields filtered:      %d\n", b1.NoFieldsFiltered+bz1.NoFieldsFiltered)
+	fmt.Printf("Disk usage pre-conversion (bytes):   %d\n", preSize)
+	fmt.Printf("Disk usage post-conversion (bytes):  %d\n", postSize)
+	fmt.Printf("Reduction factor:                    %d%%\n", (100*preSize-postSize)/preSize)
+	fmt.Printf("Total conversion time:               %v\n", time.Now().Sub(conversionStart))
 	fmt.Println()
 }
 

--- a/cmd/influx_tsm/main.go
+++ b/cmd/influx_tsm/main.go
@@ -215,6 +215,7 @@ func main() {
 	fmt.Printf("Disk usage pre-conversion (bytes):   %d\n", preSize)
 	fmt.Printf("Disk usage post-conversion (bytes):  %d\n", postSize)
 	fmt.Printf("Reduction factor:                    %d%%\n", (100*preSize-postSize)/preSize)
+	fmt.Printf("Bytes per TSM point:                 %.2f\n", float64(postSize)/float64(PointsWritten))
 	fmt.Printf("Total conversion time:               %v\n", time.Now().Sub(conversionStart))
 	fmt.Println()
 }

--- a/cmd/influx_tsm/tsdb/database.go
+++ b/cmd/influx_tsm/tsdb/database.go
@@ -95,6 +95,15 @@ func (s ShardInfos) FilterFormat(fmt EngineFormat) ShardInfos {
 	return a
 }
 
+// Size returns the space on disk consumed by the shards.
+func (s ShardInfos) Size() int64 {
+	var sz int64
+	for _, si := range s {
+		sz += si.Size
+	}
+	return sz
+}
+
 // ExclusiveDatabases returns a copy of the ShardInfo, with shards associated
 // with the given databases present. If the given set is empty, all databases
 // are returned.


### PR DESCRIPTION
```
Summary statistics
========================================
Databases converted:                 1
Shards converted:                    9
TSM files created:                   9
Points read:                         5488922
Points written:                      5488922
NaN filtered:                        0
Inf filtered:                        0
Points without fields filtered:      0
Disk usage pre-conversion (bytes):   252182528
Disk usage post-conversion (bytes):  4808331
Reduction factor:                    99%
Total conversion time:               8.058645003s
```