### PR TITLE
Use block size and file size before skipping a file during compactions

### DIFF
--- a/cmd/influx_inspect/tsm.go
+++ b/cmd/influx_inspect/tsm.go
@@ -549,7 +549,7 @@ func cmdDumpTsm1dev(opts *tsdmDumpOpts) {
 			buf := make([]byte, e.Size-4)
 			f.Read(buf)
 
-			blockSize += int64(len(buf)) + 4
+			blockSize += int64(e.Size)
 
 			blockType := buf[0]
 
@@ -584,7 +584,7 @@ func cmdDumpTsm1dev(opts *tsdmDumpOpts) {
 			blockStats.size(len(buf))
 
 			if opts.filterKey != "" && !strings.Contains(key, opts.filterKey) {
-				i += (4 + int64(e.Size))
+				i += blockSize
 				blockCount++
 				continue
 			}
@@ -601,7 +601,7 @@ func cmdDumpTsm1dev(opts *tsdmDumpOpts) {
 				fmt.Sprintf("%d/%d", len(ts), len(values)),
 			}, "\t"))
 
-			i += (4 + int64(e.Size))
+			i += blockSize
 			blockCount++
 		}
 	}

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -584,6 +584,35 @@ func TestFileStore_Delete(t *testing.T) {
 	}
 }
 
+func TestFileStore_Stats(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+
+	// Create 3 TSM files...
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+	}
+
+	_, err := newFileDir(dir, data...)
+	if err != nil {
+		fatal(t, "creating test files", err)
+	}
+
+	fs := tsm1.NewFileStore(dir)
+	if err := fs.Open(); err != nil {
+		fatal(t, "opening file store", err)
+	}
+	defer fs.Close()
+
+	stats := fs.Stats()
+	if got, exp := len(stats), 3; got != exp {
+		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
+	}
+
+}
+
 func newFileDir(dir string, values ...keyValues) ([]string, error) {
 	var files []string
 


### PR DESCRIPTION
This fixes an issue where multiple maximally sized TSM files would accumulate even though their blocks are not yet full.  This could happen with datasets with very large keys or large numbers of keys (10M).  It would show up as a dataset that grows very large and after 24hrs (when full compaction kicks in), the data size would drop considerably.  

This change now also looks at the first block to see if it's full in addition to the total file size before skipping it.  If the block is not full, we'll include the file for compaction with others to keep trying to fill the blocks.