### PR TITLE
Remove MAP_POPULATE

### DIFF
--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -8,10 +8,8 @@ import (
 	"unsafe"
 )
 
-const MAP_POPULATE = 0x8000
-
 func mmap(f *os.File, offset int64, length int) ([]byte, error) {
-	mmap, err := syscall.Mmap(int(f.Fd()), 0, length, syscall.PROT_READ, syscall.MAP_SHARED|MAP_POPULATE)
+	mmap, err := syscall.Mmap(int(f.Fd()), 0, length, syscall.PROT_READ, syscall.MAP_SHARED)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This may be causing slow restart times for systems with many large TSM files.
What I believe is happening at startup in these cases is that multiple goroutines
are started to load each TSM file concurrently.  The kernel appears to serialize
mmap calls from the same process so all of the goroutines end up getting blocked
on the actual mmap system call.  MAP_POPULATE instruct the kernel to pre-fault the
page table for the files and triggers read-ahead of the pages.  For larger, 2GB files,
this makes the mmap call more expensive and slower.  When there are many of these files
and calls it is possible to fill all available memory with pagecache.  In this case,
the OS will end up pre-faulting pages from one file and have to remove pages that it just
loaded from another files causing slowness.  MAP_POPULATE may also be cause much more data
to be pre-faulted than necessary.  To load a file, we just need to scan the index at the end
of the file.  MAP_POPULATE is likely causing the whole file to be loaded when it won't actually
be accessed for a while (or at all).

Might fix issue #5311.