### PR TITLE
Update meta service, meta client, and httpd handler

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -520,11 +520,6 @@ func (s *Server) startServerReporting() {
 			return
 		default:
 		}
-		if err := s.MetaClient.WaitForLeader(30 * time.Second); err != nil {
-			log.Printf("no leader available for reporting: %s", err.Error())
-			time.Sleep(time.Second)
-			continue
-		}
 		s.reportServer()
 		<-time.After(24 * time.Hour)
 	}
@@ -552,7 +547,7 @@ func (s *Server) reportServer() {
 		numSeries += s
 	}
 
-	clusterID, err := s.MetaClient.ClusterID()
+	clusterID := s.MetaClient.ClusterID()
 	if err != nil {
 		log.Printf("failed to retrieve cluster ID for reporting: %s", err.Error())
 		return

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -89,7 +89,7 @@ type Monitor struct {
 	storeInterval          time.Duration
 
 	MetaClient interface {
-		ClusterID() (uint64, error)
+		ClusterID() uint64
 		CreateDatabase(name string) (*meta.DatabaseInfo, error)
 		CreateRetentionPolicy(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error)
 		SetDefaultRetentionPolicy(database, name string) error
@@ -346,7 +346,7 @@ func (m *Monitor) storeStatistics() {
 		m.storeDatabase, m.storeRetentionPolicy, m.storeInterval)
 
 	// Get cluster-level metadata. Nothing different is going to happen if errors occur.
-	clusterID, _ := m.MetaClient.ClusterID()
+	clusterID := m.MetaClient.ClusterID()
 	hostname, _ := os.Hostname()
 	clusterTags := map[string]string{
 		"clusterID": fmt.Sprintf("%d", clusterID),

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -39,7 +39,7 @@ func Test_RegisterStats(t *testing.T) {
 
 type mockMetastore struct{}
 
-func (m *mockMetastore) ClusterID() (uint64, error)                            { return 1, nil }
+func (m *mockMetastore) ClusterID() uint64                                     { return 1, nil }
 func (m *mockMetastore) IsLeader() bool                                        { return true }
 func (m *mockMetastore) SetDefaultRetentionPolicy(database, name string) error { return nil }
 func (m *mockMetastore) DropRetentionPolicy(database, name string) error       { return nil }

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -272,6 +272,21 @@ func (s *store) leaderHTTP() string {
 	return ""
 }
 
+// otherMetaServersHTTP will return the HTTP bind addresses of the other
+// meta servers in the cluster
+func (s *store) otherMetaServersHTTP() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var a []string
+	for _, n := range s.data.MetaNodes {
+		if n.TCPHost != s.raftAddr {
+			a = append(a, n.Host)
+		}
+	}
+	return a
+}
+
 // index returns the current store index.
 func (s *store) index() uint64 {
 	s.mu.RLock()


### PR DESCRIPTION
* Improve the ping endpoint so that it can optionally check for leader agreement across all meta servers
* Add Ping method to the meta client
* Fix ClusterID tests
* Remove WaitForLeader from meta client and remove unnecessary references to it

cc @corylanou @dgnorton 