### PR TITLE
add leases to meta service and client

### DIFF
--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -41,6 +41,9 @@ const (
 var (
 	// ErrServiceUnavailable is returned when the meta service is unavailable.
 	ErrServiceUnavailable = errors.New("meta service unavailable")
+
+	// ErrService is returned when the meta service returns an error.
+	ErrService = errors.New("meta service error")
 )
 
 // Client is used to execute commands on and read data from
@@ -146,7 +149,7 @@ func (c *Client) Ping(checkAllMetaServers bool) error {
 // consistent.  Any actions taken after acquiring a lease must be idempotent.
 func (c *Client) AcquireLease(name string) (l *Lease, err error) {
 	for n := 1; n < 11; n++ {
-		if l, err = c.acquireLease(name); err == ErrServiceUnavailable {
+		if l, err = c.acquireLease(name); err == ErrServiceUnavailable || err == ErrService {
 			// exponential backoff
 			d := time.Duration(math.Pow(10, float64(n))) * time.Millisecond
 			time.Sleep(d)

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -42,6 +42,7 @@ const (
 type Client struct {
 	tls    bool
 	logger *log.Logger
+	nodeID uint64
 
 	mu          sync.RWMutex
 	metaServers []string
@@ -60,8 +61,9 @@ type Client struct {
 }
 
 // NewClient returns a new *Client.
-func NewClient(metaServers []string, tls bool) *Client {
+func NewClient(nodeID uint64, metaServers []string, tls bool) *Client {
 	client := &Client{
+		nodeID:      nodeID,
 		cacheData:   &Data{},
 		metaServers: metaServers,
 		tls:         tls,
@@ -131,6 +133,54 @@ func (c *Client) Ping(checkAllMetaServers bool) error {
 	return fmt.Errorf(string(b))
 }
 
+// AcquireLease attempts to acquire the specified lease.
+// A lease is a logical concept that can be used by anything that needs to limit
+// execution to a single node.  E.g., the CQ service on all nodes may ask for
+// the "ContinuousQuery" lease. Only the node that acquires it will run CQs.
+// NOTE: Leases are not managed through the CP system and are not fully
+// consistent.  Any actions taken after acquiring a lease must be idempotent.
+func (c *Client) AcquireLease(name string) (*Lease, error) {
+	c.mu.RLock()
+	server := c.metaServers[0]
+	c.mu.RUnlock()
+	url := fmt.Sprintf("%s/lease?name=%s&nodeid=%d", c.url(server), name, c.nodeID)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusConflict:
+		err = errors.New("another node owns the lease")
+	case http.StatusBadRequest:
+		b, e := ioutil.ReadAll(resp.Body)
+		if e != nil {
+			return nil, e
+		}
+		return nil, fmt.Errorf("meta service: %s", string(b))
+	case http.StatusInternalServerError:
+		return nil, errors.New("meta service internal error")
+	default:
+		return nil, errors.New("unrecognized meta service error")
+	}
+
+	// Read lease JSON from response body.
+	b, e := ioutil.ReadAll(resp.Body)
+	if e != nil {
+		return nil, e
+	}
+	// Unmarshal JSON into a Lease.
+	l := &Lease{}
+	if e = json.Unmarshal(b, l); e != nil {
+		return nil, e
+	}
+
+	return l, err
+}
+
 func (c *Client) data() *Data {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -171,7 +221,14 @@ func (c *Client) CreateDataNode(httpAddr, tcpAddr string) (*NodeInfo, error) {
 		return nil, err
 	}
 
-	return c.DataNodeByHTTPHost(httpAddr)
+	n, err := c.DataNodeByHTTPHost(httpAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	c.nodeID = n.ID
+
+	return n, nil
 }
 
 // DataNodeByHTTPHost returns the data node with the give http bind address
@@ -728,14 +785,25 @@ func (c *Client) JoinMetaServer(httpAddr, tcpAddr string) error {
 	}
 }
 
-func (c *Client) CreateMetaNode(httpAddr, tcpAddr string) error {
+func (c *Client) CreateMetaNode(httpAddr, tcpAddr string) (*NodeInfo, error) {
 	cmd := &internal.CreateMetaNodeCommand{
 		HTTPAddr: proto.String(httpAddr),
 		TCPAddr:  proto.String(tcpAddr),
 		Rand:     proto.Uint64(uint64(rand.Int63())),
 	}
 
-	return c.retryUntilExec(internal.Command_CreateMetaNodeCommand, internal.E_CreateMetaNodeCommand_Command, cmd)
+	if err := c.retryUntilExec(internal.Command_CreateMetaNodeCommand, internal.E_CreateMetaNodeCommand_Command, cmd); err != nil {
+		return nil, err
+	}
+
+	n := c.MetaNodeByAddr(httpAddr)
+	if n == nil {
+		return nil, errors.New("new meta node not found")
+	}
+
+	c.nodeID = n.ID
+
+	return n, nil
 }
 
 func (c *Client) DeleteMetaNode(id uint64) error {

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"math"
 	"math/rand"
 	"net/http"
 	"os"
@@ -37,12 +38,17 @@ const (
 	SaltBytes = 32
 )
 
+var (
+	// ErrServiceUnavailable is returned when the meta service is unavailable.
+	ErrServiceUnavailable = errors.New("meta service unavailable")
+)
+
 // Client is used to execute commands on and read data from
 // a meta service cluster.
 type Client struct {
 	tls    bool
 	logger *log.Logger
-	nodeID uint64
+	NodeID uint64
 
 	mu          sync.RWMutex
 	metaServers []string
@@ -61,9 +67,8 @@ type Client struct {
 }
 
 // NewClient returns a new *Client.
-func NewClient(nodeID uint64, metaServers []string, tls bool) *Client {
+func NewClient(metaServers []string, tls bool) *Client {
 	client := &Client{
-		nodeID:      nodeID,
 		cacheData:   &Data{},
 		metaServers: metaServers,
 		tls:         tls,
@@ -139,11 +144,24 @@ func (c *Client) Ping(checkAllMetaServers bool) error {
 // the "ContinuousQuery" lease. Only the node that acquires it will run CQs.
 // NOTE: Leases are not managed through the CP system and are not fully
 // consistent.  Any actions taken after acquiring a lease must be idempotent.
-func (c *Client) AcquireLease(name string) (*Lease, error) {
+func (c *Client) AcquireLease(name string) (l *Lease, err error) {
+	for n := 1; n < 11; n++ {
+		if l, err = c.acquireLease(name); err == ErrServiceUnavailable {
+			// exponential backoff
+			d := time.Duration(math.Pow(10, float64(n))) * time.Millisecond
+			time.Sleep(d)
+			continue
+		}
+		break
+	}
+	return
+}
+
+func (c *Client) acquireLease(name string) (*Lease, error) {
 	c.mu.RLock()
 	server := c.metaServers[0]
 	c.mu.RUnlock()
-	url := fmt.Sprintf("%s/lease?name=%s&nodeid=%d", c.url(server), name, c.nodeID)
+	url := fmt.Sprintf("%s/lease?name=%s&nodeid=%d", c.url(server), name, c.NodeID)
 
 	resp, err := http.Get(url)
 	if err != nil {
@@ -155,6 +173,8 @@ func (c *Client) AcquireLease(name string) (*Lease, error) {
 	case http.StatusOK:
 	case http.StatusConflict:
 		err = errors.New("another node owns the lease")
+	case http.StatusServiceUnavailable:
+		return nil, ErrServiceUnavailable
 	case http.StatusBadRequest:
 		b, e := ioutil.ReadAll(resp.Body)
 		if e != nil {
@@ -226,7 +246,7 @@ func (c *Client) CreateDataNode(httpAddr, tcpAddr string) (*NodeInfo, error) {
 		return nil, err
 	}
 
-	c.nodeID = n.ID
+	c.NodeID = n.ID
 
 	return n, nil
 }
@@ -801,7 +821,7 @@ func (c *Client) CreateMetaNode(httpAddr, tcpAddr string) (*NodeInfo, error) {
 		return nil, errors.New("new meta node not found")
 	}
 
-	c.nodeID = n.ID
+	c.NodeID = n.ID
 
 	return n, nil
 }

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -35,6 +35,9 @@ const (
 	// DefaultRaftPromotionEnabled is the default for auto promoting a node to a raft node when needed
 	DefaultRaftPromotionEnabled = true
 
+	// DefaultLeaseDuration is the default duration for leases.
+	DefaultLeaseDuration = 60 * time.Second
+
 	// DefaultLoggingEnabled determines if log messages are printed for the meta service
 	DefaultLoggingEnabled = true
 )
@@ -63,6 +66,8 @@ type Config struct {
 	RaftPromotionEnabled bool          `toml:"raft-promotion-enabled"`
 	LoggingEnabled       bool          `toml:"logging-enabled"`
 	PprofEnabled         bool          `toml:"pprof-enabled"`
+
+	LeaseDuration toml.Duration `toml:"lease-duration"`
 }
 
 // NewConfig builds a new configuration with default values.
@@ -77,6 +82,7 @@ func NewConfig() *Config {
 		LeaderLeaseTimeout:   toml.Duration(DefaultLeaderLeaseTimeout),
 		CommitTimeout:        toml.Duration(DefaultCommitTimeout),
 		RaftPromotionEnabled: DefaultRaftPromotionEnabled,
+		LeaseDuration:        toml.Duration(DefaultLeaseDuration),
 		LoggingEnabled:       DefaultLoggingEnabled,
 	}
 }

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -710,7 +710,7 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 		}
 		defer s3.Close()
 
-		c1 := meta.NewClient(0, []string{s1.HTTPAddr()}, false)
+		c1 := meta.NewClient([]string{s1.HTTPAddr()}, false)
 		if err := c1.Open(); err != nil {
 			t.Fatal(err.Error())
 		}
@@ -722,7 +722,7 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 		}
 	}()
 
-	c := meta.NewClient(0, []string{s1.HTTPAddr()}, false)
+	c := meta.NewClient([]string{s1.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -774,7 +774,7 @@ func TestMetaService_CommandAgainstNonLeader(t *testing.T) {
 		defer os.RemoveAll(c.Dir)
 	}
 
-	c := meta.NewClient(0, []string{srvs[2].HTTPAddr()}, false)
+	c := meta.NewClient([]string{srvs[2].HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -820,7 +820,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 		defer os.RemoveAll(c.Dir)
 	}
 
-	c := meta.NewClient(0, []string{srvs[0].HTTPAddr(), srvs[1].HTTPAddr()}, false)
+	c := meta.NewClient([]string{srvs[0].HTTPAddr(), srvs[1].HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -879,7 +879,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 	wg.Wait()
 	time.Sleep(time.Second)
 
-	c2 := meta.NewClient(0, []string{srvs[0].HTTPAddr()}, false)
+	c2 := meta.NewClient([]string{srvs[0].HTTPAddr()}, false)
 	if err := c2.Open(); err != nil {
 		t.Fatal(err)
 	}
@@ -920,7 +920,7 @@ func TestMetaService_NameChangeSingleNode(t *testing.T) {
 	}
 	defer s.Close()
 
-	c := meta.NewClient(0, []string{s.HTTPAddr()}, false)
+	c := meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -941,7 +941,7 @@ func TestMetaService_NameChangeSingleNode(t *testing.T) {
 	}
 	defer s.Close()
 
-	c2 := meta.NewClient(0, []string{s.HTTPAddr()}, false)
+	c2 := meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c2.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -1062,7 +1062,7 @@ func TestMetaService_PersistClusterIDAfterRestart(t *testing.T) {
 	}
 	defer s.Close()
 
-	c := meta.NewClient(0, []string{s.HTTPAddr()}, false)
+	c := meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -1077,7 +1077,7 @@ func TestMetaService_PersistClusterIDAfterRestart(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	c = meta.NewClient(0, []string{s.HTTPAddr()}, false)
+	c = meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -1113,7 +1113,7 @@ func TestMetaService_Ping(t *testing.T) {
 		defer os.RemoveAll(c.Dir)
 	}
 
-	c := meta.NewClient(0, []string{srvs[0].HTTPAddr(), srvs[1].HTTPAddr()}, false)
+	c := meta.NewClient([]string{srvs[0].HTTPAddr(), srvs[1].HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -1206,7 +1206,7 @@ func newServiceAndClient() (string, *testService, *meta.Client) {
 }
 
 func newClient(s *testService) *meta.Client {
-	c := meta.NewClient(0, []string{s.HTTPAddr()}, false)
+	c := meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		panic(err)
 	}

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/services/meta"
 	"github.com/influxdb/influxdb/tcp"
+	"github.com/influxdb/influxdb/toml"
 )
 
 func TestMetaService_CreateDatabase(t *testing.T) {
@@ -709,7 +710,7 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 		}
 		defer s3.Close()
 
-		c1 := meta.NewClient([]string{s1.HTTPAddr()}, false)
+		c1 := meta.NewClient(0, []string{s1.HTTPAddr()}, false)
 		if err := c1.Open(); err != nil {
 			t.Fatal(err.Error())
 		}
@@ -721,7 +722,7 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 		}
 	}()
 
-	c := meta.NewClient([]string{s1.HTTPAddr()}, false)
+	c := meta.NewClient(0, []string{s1.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -773,7 +774,7 @@ func TestMetaService_CommandAgainstNonLeader(t *testing.T) {
 		defer os.RemoveAll(c.Dir)
 	}
 
-	c := meta.NewClient([]string{srvs[2].HTTPAddr()}, false)
+	c := meta.NewClient(0, []string{srvs[2].HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -819,7 +820,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 		defer os.RemoveAll(c.Dir)
 	}
 
-	c := meta.NewClient([]string{srvs[0].HTTPAddr(), srvs[1].HTTPAddr()}, false)
+	c := meta.NewClient(0, []string{srvs[0].HTTPAddr(), srvs[1].HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -878,7 +879,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 	wg.Wait()
 	time.Sleep(time.Second)
 
-	c2 := meta.NewClient([]string{srvs[0].HTTPAddr()}, false)
+	c2 := meta.NewClient(0, []string{srvs[0].HTTPAddr()}, false)
 	if err := c2.Open(); err != nil {
 		t.Fatal(err)
 	}
@@ -919,7 +920,7 @@ func TestMetaService_NameChangeSingleNode(t *testing.T) {
 	}
 	defer s.Close()
 
-	c := meta.NewClient([]string{s.HTTPAddr()}, false)
+	c := meta.NewClient(0, []string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -940,7 +941,7 @@ func TestMetaService_NameChangeSingleNode(t *testing.T) {
 	}
 	defer s.Close()
 
-	c2 := meta.NewClient([]string{s.HTTPAddr()}, false)
+	c2 := meta.NewClient(0, []string{s.HTTPAddr()}, false)
 	if err := c2.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -1061,7 +1062,7 @@ func TestMetaService_PersistClusterIDAfterRestart(t *testing.T) {
 	}
 	defer s.Close()
 
-	c := meta.NewClient([]string{s.HTTPAddr()}, false)
+	c := meta.NewClient(0, []string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -1076,7 +1077,7 @@ func TestMetaService_PersistClusterIDAfterRestart(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	c = meta.NewClient([]string{s.HTTPAddr()}, false)
+	c = meta.NewClient(0, []string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -1112,7 +1113,7 @@ func TestMetaService_Ping(t *testing.T) {
 		defer os.RemoveAll(c.Dir)
 	}
 
-	c := meta.NewClient([]string{srvs[0].HTTPAddr(), srvs[1].HTTPAddr()}, false)
+	c := meta.NewClient(0, []string{srvs[0].HTTPAddr(), srvs[1].HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -1136,6 +1137,60 @@ func TestMetaService_Ping(t *testing.T) {
 	}
 }
 
+func TestMetaService_AcquireLease(t *testing.T) {
+	t.Parallel()
+
+	d, s, c1 := newServiceAndClient()
+	c2 := newClient(s)
+	defer os.RemoveAll(d)
+	defer s.Close()
+	defer c1.Close()
+	defer c2.Close()
+
+	n1, err := c1.CreateDataNode("foo1:8180", "bar1:8281")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	n2, err := c2.CreateDataNode("foo2:8180", "bar2:8281")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Client 1 acquires a lease.  Should succeed.
+	l, err := c1.AcquireLease("foo")
+	if err != nil {
+		t.Fatal(err)
+	} else if l == nil {
+		t.Fatal("expected *Lease")
+	} else if l.Name != "foo" {
+		t.Fatalf("lease name wrong: %s", l.Name)
+	} else if l.Owner != n1.ID {
+		t.Fatalf("owner ID wrong. exp %d got %d", n1.ID, l.Owner)
+	}
+
+	// Client 2 attempts to acquire the same lease.  Should fail.
+	l, err = c2.AcquireLease("foo")
+	if err == nil {
+		t.Fatal("expected to fail because another node owns the lease")
+	}
+
+	// Wait for Client 1's lease to expire.
+	time.Sleep(1 * time.Second)
+
+	// Client 2 retries to acquire the lease.  Should succeed this time.
+	l, err = c2.AcquireLease("foo")
+	if err != nil {
+		t.Fatal(err)
+	} else if l == nil {
+		t.Fatal("expected *Lease")
+	} else if l.Name != "foo" {
+		t.Fatalf("lease name wrong: %s", l.Name)
+	} else if l.Owner != n2.ID {
+		t.Fatalf("owner ID wrong. exp %d got %d", n2.ID, l.Owner)
+	}
+}
+
 // newServiceAndClient returns new data directory, *Service, and *Client or panics.
 // Caller is responsible for deleting data dir and closing client.
 func newServiceAndClient() (string, *testService, *meta.Client) {
@@ -1145,12 +1200,17 @@ func newServiceAndClient() (string, *testService, *meta.Client) {
 		panic(err)
 	}
 
-	c := meta.NewClient([]string{s.HTTPAddr()}, false)
+	c := newClient(s)
+
+	return cfg.Dir, s, c
+}
+
+func newClient(s *testService) *meta.Client {
+	c := meta.NewClient(0, []string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
 		panic(err)
 	}
-
-	return cfg.Dir, s, c
+	return c
 }
 
 func newConfig() *meta.Config {
@@ -1158,6 +1218,7 @@ func newConfig() *meta.Config {
 	cfg.BindAddress = "127.0.0.1:0"
 	cfg.HTTPBindAddress = "127.0.0.1:0"
 	cfg.Dir = testTempDir(2)
+	cfg.LeaseDuration = toml.Duration(1 * time.Second)
 	return cfg
 }
 

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -85,7 +85,7 @@ func (s *store) open(raftln net.Listener) error {
 	// See if this server needs to join the raft consensus group
 	var initializePeers []string
 	if len(s.config.JoinPeers) > 0 {
-		c := NewClient(0, s.config.JoinPeers, s.config.HTTPSEnabled)
+		c := NewClient(s.config.JoinPeers, s.config.HTTPSEnabled)
 		data := c.retryUntilSnapshot(0)
 		for _, n := range data.MetaNodes {
 			initializePeers = append(initializePeers, n.TCPHost)
@@ -119,7 +119,7 @@ func (s *store) open(raftln net.Listener) error {
 	}
 
 	if len(s.config.JoinPeers) > 0 {
-		c := NewClient(0, s.config.JoinPeers, s.config.HTTPSEnabled)
+		c := NewClient(s.config.JoinPeers, s.config.HTTPSEnabled)
 		if err := c.Open(); err != nil {
 			return err
 		}

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -85,7 +85,7 @@ func (s *store) open(raftln net.Listener) error {
 	// See if this server needs to join the raft consensus group
 	var initializePeers []string
 	if len(s.config.JoinPeers) > 0 {
-		c := NewClient(s.config.JoinPeers, s.config.HTTPSEnabled)
+		c := NewClient(0, s.config.JoinPeers, s.config.HTTPSEnabled)
 		data := c.retryUntilSnapshot(0)
 		for _, n := range data.MetaNodes {
 			initializePeers = append(initializePeers, n.TCPHost)
@@ -119,7 +119,7 @@ func (s *store) open(raftln net.Listener) error {
 	}
 
 	if len(s.config.JoinPeers) > 0 {
-		c := NewClient(s.config.JoinPeers, s.config.HTTPSEnabled)
+		c := NewClient(0, s.config.JoinPeers, s.config.HTTPSEnabled)
 		if err := c.Open(); err != nil {
 			return err
 		}


### PR DESCRIPTION
- added a `/lease?name=foo&nodeid=3` endpoint to the meta service

- started modifying the `continuous_querier` service and then realized that it hasn't been rebased on `master` recently.  It's missing the CQ refactor work.  We should merge this first, rebase `meta-service` on `master`, and then update the CQ service in a separate PR.

/cc @pauldix @corylanou 