### PR TITLE
Packaging arch argument for build.py.

### DIFF
--- a/build.py
+++ b/build.py
@@ -406,7 +406,7 @@ def generate_md5_from_file(path):
             m.update(chunk)
     return m.hexdigest()
 
-def build_packages(build_output, version, nightly=False, rc=None, iteration=1):
+def build_packages(build_output, version, pkg_arch, nightly=False, rc=None, iteration=1):
     outfiles = []
     tmp_build_dir = create_temp_dir()
     try:
@@ -449,6 +449,8 @@ def build_packages(build_output, version, nightly=False, rc=None, iteration=1):
                         current_location = os.path.join(current_location, name + '.tar.gz')
                     if rc is not None:
                         package_iteration = "0.rc{}".format(rc)
+                    if pkg_arch is not None:
+                        a = pkg_arch
                     fpm_command = "fpm {} --name {} -a {} -t {} --version {} --iteration {} -C {} -p {} ".format(
                         fpm_common_args,
                         name,
@@ -490,6 +492,7 @@ def print_usage():
     print "\t --goarm=<arm version> \n\t\t- Build for specified ARM version (when building for ARM). Default value is: 6"
     print "\t --platform=<platform> \n\t\t- Build for specified platform. Acceptable values: linux, windows, darwin, or all"
     print "\t --version=<version> \n\t\t- Version information to apply to build metadata. If not specified, will be pulled from repo tag."
+    print "\t --pkgarch=<package-arch> \n\t\t- Package architecture if different from <arch>"
     print "\t --commit=<commit> \n\t\t- Use specific commit for build (currently a NOOP)."
     print "\t --branch=<branch> \n\t\t- Build from a specific branch (currently a NOOP)."
     print "\t --rc=<rc number> \n\t\t- Whether or not the build is a release candidate (affects version information)."
@@ -513,6 +516,7 @@ def main():
     commit = None
     target_platform = None
     target_arch = None
+    package_arch = None
     nightly = False
     race = False
     branch = None
@@ -548,6 +552,9 @@ def main():
         elif '--version' in arg:
             # Version to assign to this build (0.9.5, etc)
             version = arg.split("=")[1]
+        elif '--pkgarch' in arg:
+            # Package architecture if different from <arch> (armhf, etc)
+            package_arch = arg.split("=")[1]
         elif '--rc' in arg:
             # Signifies that this is a release candidate build.
             rc = arg.split("=")[1]
@@ -669,7 +676,7 @@ def main():
         if not check_path_for("fpm"):
             print "!! Cannot package without command 'fpm'. Stopping."
             return 1
-        packages = build_packages(build_output, version, nightly=nightly, rc=rc, iteration=iteration)
+        packages = build_packages(build_output, version, package_arch, nightly=nightly, rc=rc, iteration=iteration)
         # TODO(rossmcdonald): Add nice output for print_package_summary()
         # print_package_summary(packages)
         # Optionally upload to S3


### PR DESCRIPTION
Add --pkgarch option to build.py to specify the packaging architecture which can be different to GOARCH.

This belongs to #5112. For example: to build for debian on raspberry pi (Raspbian), GOARCH will be arm but the packaging architecture on debian needs to be armhf (arm hard float). The --pkgarch option is passed to fpm to specify the required architecture which is reflected in the package manifest and also in the result filename.

Example invocation to build usable packages for Raspbian:
```sh
#!/bin/bash

readonly influxdb_arch=arm
readonly influxdb_pkgarch=armhf
readonly influxdb_arm=7
readonly influxdb_platform=linux
readonly influxdb_version=0.9.6.1

./build.py --arch=$influxdb_arch \
           --pkgarch=$influxdb_pkgarch \
           --goarm=$influxdb_arm \
           --platform=$influxdb_platform \
           --version=$influxdb_version \
           --package --clean
```

Example result file:
```
influxdb_0.9.6.1-1.armhf.deb
```

Example package dump:
```sh
dpkg -I influxdb_0.9.6.1-1_armhf.deb
 new debian package, version 2.0.
 size 16736266 bytes: control archive=1621 bytes.
      54 bytes,     2 lines      conffiles
     271 bytes,    11 lines      control
     528 bytes,     9 lines      md5sums
    1400 bytes,    66 lines   *  postinst             #!/bin/bash
     919 bytes,    46 lines   *  postrm               #!/bin/bash
     631 bytes,    16 lines   *  preinst              #!/bin/bash
 Package: influxdb
 Version: 0.9.6.1-1
 License: MIT
 Vendor: InfluxData
 Architecture: armhf
 Maintainer: support@influxdb.com
 Installed-Size: 52237
 Section: default
 Priority: extra
 Homepage: https://github.com/influxdb/influxdb
 Description: Distributed time-series database.
```

I tested the changes by installing the debian package on my raspberry pi, started influxd and also ensured that invoking build.py without the --pkgarch argument results in packages with the old behaviour (arm architecture).

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergable
- [ ] Tests pass
- [X] Sign [CLA](http://influxdb.com/community/cla.html)
