### PR TITLE
TSM Bug Fixes/Go 1.4.3

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -7,7 +7,7 @@ if [ $fmtcount -gt 0 ]; then
 fi
 
 # Due to the way composites work, vet will fail for some of our tests so we ignore it
-vetcount=`go tool vet --composites=false ./ 2>&1  | wc -l`
+vetcount=`go tool vet -composites=true ./ 2>&1  | wc -l`
 if [ $vetcount -gt 0 ]; then
     echo "Some files aren't passing vet heuristics, please run 'go vet ./...' to see the errors it flags and correct your source code before committing"
     exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## v0.10.0 [unreleased]
 
-With this release InfluxDB is moving to Go 1.5.
-
 ### Features
 - [#5183](https://github.com/influxdb/influxdb/pull/5183): CLI confirms database exists when USE executed. Thanks @pires
 - [#5201](https://github.com/influxdb/influxdb/pull/5201): Allow max UDP buffer size to be configurable. Thanks @sebito91

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ With this release InfluxDB is moving to Go 1.5.
 - [#5158](https://github.com/influxdb/influxdb/pull/5158): Fix panic when writing invalid input to the line protocol.
 - [#5264](https://github.com/influxdata/influxdb/pull/5264): Fix panic: runtime error: slice bounds out of range
 - [#5186](https://github.com/influxdata/influxdb/pull/5186): Fix database creation with retention statement parsing. Fixes [#5077](https://github.com/influxdb/influxdb/issues/5077). Thanks @pires
+- [#5193](https://github.com/influxdata/influxdb/issues/5193): Missing data a minute before current time. Comes back later.
 
 ## v0.9.6 [2015-12-09]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.5.2 or greater.
+InfluxDB requires Go 1.4.3.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -77,8 +77,8 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.5.2
-    gvm use go1.5.2 --default
+    gvm install go1.4.3
+    gvm use go1.4.3 --default
 
 Revision Control Systems
 -------------

--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -18,7 +18,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.5.2
+ENV GO_VERSION 1.4.3
 ENV GO_ARCH 386
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -16,9 +16,9 @@ RUN apt-get update && apt-get install -y \
 
 RUN gem install fpm
 
-# Install go1.5+
+# Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.5.2
+ENV GO_VERSION 1.4.3
 ENV GO_ARCH amd64
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -25,8 +25,8 @@ RUN mkdir -p $PROJECT_DIR
 VOLUME $PROJECT_DIR
 
 
-# Install go1.5+
-ENV GO_VERSION 1.5.2
+# Install go
+ENV GO_VERSION 1.4.3
 ENV GO_ARCH amd64
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \

--- a/Dockerfile_test_ubuntu32
+++ b/Dockerfile_test_ubuntu32
@@ -1,7 +1,7 @@
 FROM 32bit/ubuntu:14.04
 
 RUN apt-get update && apt-get install -y python-software-properties software-properties-common git
-RUN add-apt-repository ppa:evarlast/golang1.5
+RUN add-apt-repository ppa:evarlast/golang1.4
 RUN apt-get update && apt-get install -y -o Dpkg::Options::="--force-overwrite" golang-go
 
 ENV GOPATH=/root/go

--- a/build.py
+++ b/build.py
@@ -234,8 +234,11 @@ def upload_packages(packages, nightly=False):
     print ""
 
 def run_tests(race, parallel, timeout, no_vet):
-    get_command = "go get -d -t ./..."
     print "Retrieving Go dependencies...",
+    get_command = "go get -d -t ./..."
+    sys.stdout.flush()
+    run(get_command)
+    get_command = "go get golang.org/x/tools/cmd/vet"
     sys.stdout.flush()
     run(get_command)
     print "done."
@@ -254,7 +257,7 @@ def run_tests(race, parallel, timeout, no_vet):
         print err
         return False
     if not no_vet:
-        p = subprocess.Popen(["go", "tool", "vet", "-composites=false", "./"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(["go", "tool", "vet", "-composites=true", "./"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         if len(out) > 0 or len(err) > 0:
             print "Go vet failed. Please run 'go vet ./...' and fix any errors."
@@ -493,7 +496,7 @@ def print_usage():
     print "\t --commit=<commit> \n\t\t- Use specific commit for build (currently a NOOP)."
     print "\t --branch=<branch> \n\t\t- Build from a specific branch (currently a NOOP)."
     print "\t --rc=<rc number> \n\t\t- Whether or not the build is a release candidate (affects version information)."
-    print "\t --iteration=<iteration number> \n\t\t- The iteration to display on the package output (defaults to 0 for RC's, and 1 otherwise)."    
+    print "\t --iteration=<iteration number> \n\t\t- The iteration to display on the package output (defaults to 0 for RC's, and 1 otherwise)."
     print "\t --race \n\t\t- Whether the produced build should have race detection enabled."
     print "\t --package \n\t\t- Whether the produced builds should be packaged for the target platform(s)."
     print "\t --nightly \n\t\t- Whether the produced build is a nightly (affects version information)."

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -45,13 +45,6 @@ reporting-disabled = false
 [data]
   dir = "/var/lib/influxdb/data"
 
-  # Controls the storage engine used for new shards. Engines available are b1,
-  # bz1, and tsm1. b1 was the original default engine from 0.9.0 to 0.9.2. bz1
-  # has been the default engine since 0.9.3. tsm1 was introduced in 0.9.5 and is
-  # currently EXPERIMENTAL. Consequently, data written into the tsm1 engine may
-  # need to be wiped between upgrades.
-  # engine ="bz1"
-
   # The following WAL settings are for the b1 storage engine used in 0.9.2. They won't
   # apply to any new shards created after upgrading to a version > 0.9.3.
   max-wal-size = 104857600 # Maximum size the WAL can reach before a flush. Defaults to 100MB.
@@ -152,7 +145,7 @@ reporting-disabled = false
 ###
 
 [cluster]
-  shard-writer-timeout = "5s" # The time within which a remote shard must respond to a write request. 
+  shard-writer-timeout = "5s" # The time within which a remote shard must respond to a write request.
   write-timeout = "10s" # The time within which a write request must complete on the cluster.
 
 ###
@@ -330,7 +323,7 @@ reporting-disabled = false
   # batch-pending = 5 # number of batches that may be pending in memory
   # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
   # read-buffer = 0 # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
- 
+
   # set the expected UDP payload size; lower values tend to yield better performance, default is max UDP size 65536
   # udp-payload-size = 65536
 

--- a/package.sh
+++ b/package.sh
@@ -67,7 +67,7 @@ if [ -z "$FPM" ]; then
     FPM=`which fpm`
 fi
 
-GO_VERSION="go1.5.2"
+GO_VERSION="go1.4.3"
 GOPATH_INSTALL=
 BINS=(
     influxd

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -3,8 +3,6 @@ package tsdb
 import (
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"time"
 
 	"github.com/influxdb/influxdb/toml"
@@ -12,7 +10,7 @@ import (
 
 const (
 	// DefaultEngine is the default engine for new shards
-	DefaultEngine = "bz1"
+	DefaultEngine = "tsm1"
 
 	// DefaultMaxWALSize is the default size of the WAL before it is flushed.
 	DefaultMaxWALSize = 100 * 1024 * 1024 // 100MB
@@ -104,14 +102,8 @@ type Config struct {
 }
 
 func NewConfig() Config {
-	defaultEngine := DefaultEngine
-	if engine := os.Getenv("INFLUXDB_DATA_ENGINE"); engine != "" {
-		log.Println("TSDB engine selected via environment variable:", engine)
-		defaultEngine = engine
-	}
-
 	return Config{
-		Engine:                 defaultEngine,
+		Engine:                 DefaultEngine,
 		MaxWALSize:             DefaultMaxWALSize,
 		WALFlushInterval:       toml.Duration(DefaultWALFlushInterval),
 		WALPartitionFlushDelay: toml.Duration(DefaultWALPartitionFlushDelay),

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -815,7 +815,6 @@ func (c *devCursor) nextTSM() (int64, interface{}) {
 		if c.tsmPos >= len(c.tsmValues) {
 			c.tsmValues, _ = c.tsmKeyCursor.Next(c.ascending)
 			if len(c.tsmValues) == 0 {
-				c.tsmKeyCursor.Close()
 				return tsdb.EOF, nil
 			}
 			c.tsmPos = 0
@@ -826,7 +825,6 @@ func (c *devCursor) nextTSM() (int64, interface{}) {
 		if c.tsmPos < 0 {
 			c.tsmValues, _ = c.tsmKeyCursor.Next(c.ascending)
 			if len(c.tsmValues) == 0 {
-				c.tsmKeyCursor.Close()
 				return tsdb.EOF, nil
 			}
 			c.tsmPos = len(c.tsmValues) - 1

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Ensure an engine containing cached values responds correctly to queries.
-func TestDevEngine_QueryCache_Ascending(t *testing.T) {
+func TestEngine_QueryCache_Ascending(t *testing.T) {
 	// Generate temporary file.
 	f, _ := ioutil.TempFile("", "tsm")
 	f.Close()
@@ -32,7 +32,7 @@ func TestDevEngine_QueryCache_Ascending(t *testing.T) {
 	p3 := parsePoint("cpu,host=A value=1.3 3000000000")
 
 	// Write those points to the engine.
-	e := NewDevEngine(f.Name(), walPath, tsdb.NewEngineOptions())
+	e := NewEngine(f.Name(), walPath, tsdb.NewEngineOptions())
 	if err := e.Open(); err != nil {
 		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
 	}
@@ -41,7 +41,7 @@ func TestDevEngine_QueryCache_Ascending(t *testing.T) {
 	}
 
 	// Start a query transactions and get a cursor.
-	tx := devTx{engine: e.(*DevEngine)}
+	tx := tx{engine: e.(*Engine)}
 	ascCursor := tx.Cursor("cpu,host=A", []string{"value"}, nil, true)
 
 	k, v := ascCursor.SeekTo(1)
@@ -76,7 +76,7 @@ func TestDevEngine_QueryCache_Ascending(t *testing.T) {
 }
 
 // Ensure an engine containing cached values responds correctly to queries.
-func TestDevEngine_QueryTSM_Ascending(t *testing.T) {
+func TestEngine_QueryTSM_Ascending(t *testing.T) {
 	fs := NewFileStore("")
 
 	// Setup 3 files
@@ -133,7 +133,7 @@ func TestDevEngine_QueryTSM_Ascending(t *testing.T) {
 }
 
 // Ensure an engine containing cached values responds correctly to queries.
-func TestDevEngine_QueryCache_Descending(t *testing.T) {
+func TestEngine_QueryCache_Descending(t *testing.T) {
 	// Generate temporary file.
 	f, _ := ioutil.TempFile("", "tsm")
 	f.Close()
@@ -148,7 +148,7 @@ func TestDevEngine_QueryCache_Descending(t *testing.T) {
 	p3 := parsePoint("cpu,host=A value=1.3 3000000000")
 
 	// Write those points to the engine.
-	e := NewDevEngine(f.Name(), walPath, tsdb.NewEngineOptions())
+	e := NewEngine(f.Name(), walPath, tsdb.NewEngineOptions())
 	if err := e.Open(); err != nil {
 		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
 	}
@@ -157,7 +157,7 @@ func TestDevEngine_QueryCache_Descending(t *testing.T) {
 	}
 
 	// Start a query transactions and get a cursor.
-	tx := devTx{engine: e.(*DevEngine)}
+	tx := tx{engine: e.(*Engine)}
 	descCursor := tx.Cursor("cpu,host=A", []string{"value"}, nil, false)
 
 	k, v := descCursor.SeekTo(4000000000)
@@ -177,7 +177,7 @@ func TestDevEngine_QueryCache_Descending(t *testing.T) {
 }
 
 // Ensure an engine containing cached values responds correctly to queries.
-func TestDevEngine_QueryTSM_Descending(t *testing.T) {
+func TestEngine_QueryTSM_Descending(t *testing.T) {
 	fs := NewFileStore("")
 
 	// Setup 3 files
@@ -218,7 +218,7 @@ func TestDevEngine_QueryTSM_Descending(t *testing.T) {
 	}
 }
 
-func TestDevEngine_LoadMetadataIndex(t *testing.T) {
+func TestEngine_LoadMetadataIndex(t *testing.T) {
 	// Generate temporary file.
 	f, _ := ioutil.TempFile("", "tsm")
 	f.Close()
@@ -232,7 +232,7 @@ func TestDevEngine_LoadMetadataIndex(t *testing.T) {
 	p2 := parsePoint("cpu,host=B value=1.2 2000000000")
 
 	// Write those points to the engine.
-	e := NewDevEngine(f.Name(), walPath, tsdb.NewEngineOptions()).(*DevEngine)
+	e := NewEngine(f.Name(), walPath, tsdb.NewEngineOptions()).(*Engine)
 	if err := e.Open(); err != nil {
 		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
 	}
@@ -317,7 +317,7 @@ func TestDevEngine_LoadMetadataIndex(t *testing.T) {
 }
 
 // Ensure that deletes only sent to the WAL will clear out the data from the cache on restart
-func TestDevEngine_DeleteWALLoadMetadata(t *testing.T) {
+func TestEngine_DeleteWALLoadMetadata(t *testing.T) {
 	// Generate temporary file.
 	f, _ := ioutil.TempFile("", "tsm")
 	f.Close()
@@ -331,7 +331,7 @@ func TestDevEngine_DeleteWALLoadMetadata(t *testing.T) {
 	p2 := parsePoint("cpu,host=B value=1.2 2000000000")
 
 	// Write those points to the engine.
-	e := NewDevEngine(f.Name(), walPath, tsdb.NewEngineOptions()).(*DevEngine)
+	e := NewEngine(f.Name(), walPath, tsdb.NewEngineOptions()).(*Engine)
 	if err := e.Open(); err != nil {
 		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
 	}
@@ -347,7 +347,7 @@ func TestDevEngine_DeleteWALLoadMetadata(t *testing.T) {
 		t.Fatalf("error closing: %s", err.Error())
 	}
 
-	e = NewDevEngine(f.Name(), walPath, tsdb.NewEngineOptions()).(*DevEngine)
+	e = NewEngine(f.Name(), walPath, tsdb.NewEngineOptions()).(*Engine)
 	if err := e.Open(); err != nil {
 		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
 	}
@@ -362,7 +362,7 @@ func TestDevEngine_DeleteWALLoadMetadata(t *testing.T) {
 }
 
 // Ensure that the engine will backup any TSM files created since the passed in time
-func TestDevEngine_Backup(t *testing.T) {
+func TestEngine_Backup(t *testing.T) {
 	// Generate temporary file.
 	f, _ := ioutil.TempFile("", "tsm")
 	f.Close()
@@ -377,7 +377,7 @@ func TestDevEngine_Backup(t *testing.T) {
 	p3 := parsePoint("cpu,host=C value=1.3 3000000000")
 
 	// Write those points to the engine.
-	e := NewDevEngine(f.Name(), walPath, tsdb.NewEngineOptions()).(*DevEngine)
+	e := NewEngine(f.Name(), walPath, tsdb.NewEngineOptions()).(*Engine)
 
 	// mock the planner so compactions don't run during the test
 	e.CompactionPlan = &mockPlanner{}


### PR DESCRIPTION
This PR fixes #5193 #5283 and #5217 .

#5193 was caused by the tsm cursor getting closed prematurely causing future seeks to return no data.
#5283 appears to be a go 1.5.2 related bug as switching back to 1.4.3 did not produce the same panic.
#5217 is related to the performance degradation from using go 1.5.2.  This PR switches the builds to 1.4.3.

This also changes the default storage engine to `tsm1` and removes the ability to configure other engines.  Existing `b1` and `bz1` shards will load and work as is, but should to be converted to `tsm1` at some point using the migration tool.