### PR TITLE
Limit raw query fetch

### DIFF
--- a/tsdb/raw.go
+++ b/tsdb/raw.go
@@ -965,7 +965,10 @@ func (m *RawMapper) NextChunk() (interface{}, error) {
 			Tags:  cursor.Tags(),
 		})
 
+		// Exit if we have reached the chunk size or if we hit the LIMIT clause.
 		if len(output.Values) == m.ChunkSize {
+			return output, nil
+		} else if m.stmt.Limit > 0 && len(output.Values) >= (m.stmt.Limit+m.stmt.Offset) {
 			return output, nil
 		}
 	}


### PR DESCRIPTION
## Overview

This pull request enforces a limit on `RawMapper` so that it will not produce more values than are specified by the LIMIT clause. Previously the mapper would read up to the chunk size and the values would be limited afterward.

Fixes #4192 

/cc @toddboom @beckettsean 