### PR TITLE
postinstall script : use /etc/debian_version for debian/ubuntu detection

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -53,7 +53,7 @@ if [[ -f /etc/redhat-release ]]; then
 	install_init
 	install_chkconfig
     fi
-elif [[ -f /etc/lsb-release ]]; then
+elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
currently we use /etc/lsb-release to detect debian,

but this file is only present on ubuntu.

/etc/debian_version is installed by default by debian and ubuntu

This fix
https://github.com/influxdata/influxdb/issues/5356
