### PR TITLE
Add `CREATE USER IF NOT EXISTS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#5598](https://github.com/influxdata/influxdb/pull/5598): Client: Add Ping to v2 client @PSUdaemon
 - [#4125](https://github.com/influxdata/influxdb/pull/4125): Admin UI: Fetch and display server version on connect. Thanks @alexiri!
 - [#5602](https://github.com/influxdata/influxdb/pull/5602): Simplify cluster startup for scripting and deployment
+- [#5360](https://github.com/influxdata/influxdb/pull/5360): Support IF NOT EXISTS for CREATE USER
 
 ### Bugfixes
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -470,12 +470,18 @@ type CreateUserStatement struct {
 
 	// User's admin privilege.
 	Admin bool
+
+	// Whether to return without error if the user already exists.
+	IfNotExists bool
 }
 
 // String returns a string representation of the create user statement.
 func (s *CreateUserStatement) String() string {
 	var buf bytes.Buffer
 	_, _ = buf.WriteString("CREATE USER ")
+	if s.IfNotExists {
+		_, _ = buf.WriteString("IF NOT EXISTS ")
+	}
 	_, _ = buf.WriteString(QuoteIdent(s.Name))
 	_, _ = buf.WriteString(" WITH PASSWORD ")
 	_, _ = buf.WriteString("[REDACTED]")

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1334,8 +1334,9 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `CREATE USER testuser WITH PASSWORD 'pwd1337'`,
 			stmt: &influxql.CreateUserStatement{
-				Name:     "testuser",
-				Password: "pwd1337",
+				Name:        "testuser",
+				IfNotExists: false,
+				Password:    "pwd1337",
 			},
 		},
 
@@ -1343,9 +1344,20 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `CREATE USER testuser WITH PASSWORD 'pwd1337' WITH ALL PRIVILEGES`,
 			stmt: &influxql.CreateUserStatement{
-				Name:     "testuser",
-				Password: "pwd1337",
-				Admin:    true,
+				Name:        "testuser",
+				IfNotExists: false,
+				Password:    "pwd1337",
+				Admin:       true,
+			},
+		},
+
+		// CREATE USER IF NOT EXISTS statement
+		{
+			s: `CREATE USER IF NOT EXISTS testuser WITH PASSWORD 'pwd1337'`,
+			stmt: &influxql.CreateUserStatement{
+				Name:        "testuser",
+				IfNotExists: true,
+				Password:    "pwd1337",
 			},
 		},
 

--- a/services/meta/statement_executor.go
+++ b/services/meta/statement_executor.go
@@ -198,6 +198,9 @@ func (e *StatementExecutor) executeDropServerStatement(q *influxql.DropServerSta
 
 func (e *StatementExecutor) executeCreateUserStatement(q *influxql.CreateUserStatement) *influxql.Result {
 	_, err := e.Store.CreateUser(q.Name, q.Password, q.Admin)
+	if err == ErrUserExists && q.IfNotExists {
+		err = nil
+	}
 	return &influxql.Result{Err: err}
 }
 


### PR DESCRIPTION
Refactor `IF NOT EXISTS` parsing to `Parser.parseIfNotExists`.

I needed this to completely automate creation of users on InfluxDB hosts using Ansible.

I signed the CLA as me@mmalecki.com.