### PR TITLE
Teach the CQ runner how to deal with a resample interval higher than the query interval

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2019,6 +2019,23 @@ func (s *CreateContinuousQueryStatement) RequiredPrivileges() ExecutionPrivilege
 	return ep
 }
 
+func (s *CreateContinuousQueryStatement) validate() error {
+	interval, err := s.Source.GroupByInterval()
+	if err != nil {
+		return err
+	}
+
+	if s.ResampleFor != 0 {
+		if s.ResampleEvery != 0 && s.ResampleEvery > interval {
+			interval = s.ResampleEvery
+		}
+		if interval > s.ResampleFor {
+			return fmt.Errorf("FOR duration must be >= GROUP BY time duration: must be a minimum of %s, got %s", FormatDuration(interval), FormatDuration(s.ResampleFor))
+		}
+	}
+	return nil
+}
+
 // DropContinuousQueryStatement represents a command for removing a continuous query.
 type DropContinuousQueryStatement struct {
 	Name     string

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1443,6 +1443,10 @@ func (p *Parser) parseCreateContinuousQueryStatement() (*CreateContinuousQuerySt
 		return nil, newParseError(tokstr(tok, lit), []string{"END"}, pos)
 	}
 
+	if err := stmt.validate(); err != nil {
+		return nil, err
+	}
+
 	return stmt, nil
 }
 

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1764,6 +1764,8 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `DROP CONTINUOUS QUERY myquery ON`, err: `found EOF, expected identifier at line 1, char 34`},
 		{s: `CREATE CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 19`},
 		{s: `CREATE CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 25`},
+		{s: `CREATE CONTINUOUS QUERY cq ON db RESAMPLE FOR 5s BEGIN SELECT mean(value) INTO cpu_mean FROM cpu GROUP BY time(10s) END`, err: `FOR duration must be >= GROUP BY time duration: must be a minimum of 10s, got 5s`},
+		{s: `CREATE CONTINUOUS QUERY cq ON db RESAMPLE EVERY 10s FOR 5s BEGIN SELECT mean(value) INTO cpu_mean FROM cpu GROUP BY time(5s) END`, err: `FOR duration must be >= GROUP BY time duration: must be a minimum of 10s, got 5s`},
 		{s: `DROP FOO`, err: `found FOO, expected SERIES, CONTINUOUS, MEASUREMENT, SERVER, SUBSCRIPTION at line 1, char 6`},
 		{s: `CREATE FOO`, err: `found FOO, expected CONTINUOUS, DATABASE, USER, RETENTION, SUBSCRIPTION at line 1, char 8`},
 		{s: `CREATE DATABASE`, err: `found EOF, expected identifier at line 1, char 17`},

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -283,8 +283,16 @@ func (s *Service) ExecuteContinuousQuery(dbi *meta.DatabaseInfo, cqi *meta.Conti
 	resampleFor := interval
 	if cq.Resample.For != 0 {
 		resampleFor = cq.Resample.For
+	} else if interval < resampleEvery {
+		resampleFor = resampleEvery
 	}
 	oldestTime := nextRun.Add(-resampleFor)
+
+	// If the resample interval is greater than the interval of the query, use the
+	// query interval instead.
+	if interval < resampleEvery {
+		resampleEvery = interval
+	}
 
 	// Calculate and set the time range for the query. Go from most recent to least.
 	startTime := now.Add(-resampleEvery).Truncate(interval)


### PR DESCRIPTION
Previously if you issued a CQ with a resample interval higher than the
query interval, such as the following:

    CREATE CONTINUOUS QUERY cq ON db
        RESAMPLE EVERY 4m
        BEGIN
            SELECT mean(value) INTO cpu_mean FROM cpu GROUP BY time(2m)
        END

This would result in strange behavior because the FOR value defaulted to
the GROUP BY interval and the minimum time passing before a CQ ran was
also the resample interval, so it wouldn't run the appropriate intervals
even if you set the resample duration to a higher value.

This tweaks the CQ runner to set the minimum interval before a bucket
becomes capable of running to the lower of the query interval or the
resample interval instead of always using the resample interval.

It also sets the default resample duration to be the higher value of the
query interval or the resample interval so the above query gets a
default of 4m instead of 2m and will execute 2 queries every 4 minutes.

If you manually set the resample duration to a lower value than the
resample interval, the old behavior will still happen and should be
considered an error.

Fixes #5286.