### PR TITLE
Fix a panic when a tag value was empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#5186](https://github.com/influxdata/influxdb/pull/5186): Fix database creation with retention statement parsing. Fixes [#5077](https://github.com/influxdb/influxdb/issues/5077). Thanks @pires
 - [#5193](https://github.com/influxdata/influxdb/issues/5193): Missing data a minute before current time. Comes back later.
 - [#5350](https://github.com/influxdata/influxdb/issues/5350): 'influxd backup' should create backup directory
+- [#5262](https://github.com/influxdata/influxdb/issues/5262): Fix a panic when a tag value was empty.
 
 ## v0.9.6 [2015-12-09]
 

--- a/models/points.go
+++ b/models/points.go
@@ -455,7 +455,7 @@ func scanTagsKey(buf []byte, i int) (int, error) {
 // scanTagsValue scans each character in a tag value.
 func scanTagsValue(buf []byte, i int) (int, int, error) {
 	// Tag value cannot be empty.
-	if buf[i] == ',' || buf[i] == ' ' {
+	if i >= len(buf) || buf[i] == ',' || buf[i] == ' ' {
 		// cpu,tag={',', ' '}
 		return -1, i, fmt.Errorf("missing tag value")
 	}

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -253,6 +253,7 @@ func TestParsePointMissingTagValue(t *testing.T) {
 	examples := []string{
 		`cpu,host`,
 		`cpu,host,`,
+		`cpu,host=`,
 		`cpu,host value=1i`,
 		`cpu,host=serverA,region value=1i`,
 		`cpu,host=serverA,region= value=1i`,


### PR DESCRIPTION
A panic would happen if you wrote the following:
    cpu,host=

There was a missing bounds check when scanning the tag value.

Fixes #5262.