### PR TITLE
Faster shard loading

### DIFF
--- a/cmd/influx_tsm/tsdb/types.go
+++ b/cmd/influx_tsm/tsdb/types.go
@@ -88,11 +88,11 @@ func (s *Series) UnmarshalBinary(buf []byte) error {
 
 // MeasurementFromSeriesKey returns the Measurement name for a given series.
 func MeasurementFromSeriesKey(key string) string {
-	idx := strings.Index(key, ",")
+	idx := strings.IndexByte(key, ',')
 	if idx == -1 {
 		return key
 	}
-	return key[:strings.Index(key, ",")]
+	return key[:idx]
 }
 
 // DecodeKeyValue decodes the key and value from bytes.

--- a/models/points.go
+++ b/models/points.go
@@ -993,7 +993,7 @@ func unescapeMeasurement(in []byte) []byte {
 
 func escapeTag(in []byte) []byte {
 	for b, esc := range tagEscapeCodes {
-		if bytes.Contains(in, []byte{b}) {
+		if bytes.IndexByte(in, b) != -1 {
 			in = bytes.Replace(in, []byte{b}, esc, -1)
 		}
 	}
@@ -1002,7 +1002,7 @@ func escapeTag(in []byte) []byte {
 
 func unescapeTag(in []byte) []byte {
 	for b, esc := range tagEscapeCodes {
-		if bytes.Contains(in, []byte{b}) {
+		if bytes.IndexByte(in, b) != -1 {
 			in = bytes.Replace(in, esc, []byte{b}, -1)
 		}
 	}

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -283,12 +283,12 @@ func (c *Cache) Store() map[string]*entry {
 	return c.store
 }
 
-func (c *Cache) Lock() {
-	c.mu.Lock()
+func (c *Cache) RLock() {
+	c.mu.RLock()
 }
 
-func (c *Cache) Unlock() {
-	c.mu.Unlock()
+func (c *Cache) RUnlock() {
+	c.mu.RUnlock()
 }
 
 // values returns the values for the key. It doesn't lock and assumes the data is

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -161,16 +161,13 @@ func (e *Engine) Close() error {
 func (e *Engine) SetLogOutput(w io.Writer) {}
 
 // LoadMetadataIndex loads the shard metadata into memory.
-func (e *Engine) LoadMetadataIndex(_ *tsdb.Shard, index *tsdb.DatabaseIndex, measurementFields map[string]*tsdb.MeasurementFields) error {
+func (e *Engine) LoadMetadataIndex(sh *tsdb.Shard, index *tsdb.DatabaseIndex, measurementFields map[string]*tsdb.MeasurementFields) error {
+	start := time.Now()
 	keys := e.FileStore.Keys()
 
 	keysLoaded := make(map[string]bool)
 
-	for _, k := range keys {
-		typ, err := e.FileStore.Type(k)
-		if err != nil {
-			return err
-		}
+	for k, typ := range keys {
 		fieldType, err := tsmFieldTypeToInfluxQLDataType(typ)
 		if err != nil {
 			return err
@@ -184,8 +181,8 @@ func (e *Engine) LoadMetadataIndex(_ *tsdb.Shard, index *tsdb.DatabaseIndex, mea
 	}
 
 	// load metadata from the Cache
-	e.Cache.Lock() // shouldn't need the lock, but just to be safe
-	defer e.Cache.Unlock()
+	e.Cache.RLock() // shouldn't need the lock, but just to be safe
+	defer e.Cache.RUnlock()
 
 	for key, entry := range e.Cache.Store() {
 		if keysLoaded[key] {
@@ -194,7 +191,7 @@ func (e *Engine) LoadMetadataIndex(_ *tsdb.Shard, index *tsdb.DatabaseIndex, mea
 
 		fieldType, err := entry.values.InfluxQLType()
 		if err != nil {
-			log.Printf("error getting the data type of values for key %s: %s", key, err.Error())
+			e.logger.Printf("error getting the data type of values for key %s: %s", key, err.Error())
 			continue
 		}
 
@@ -203,6 +200,10 @@ func (e *Engine) LoadMetadataIndex(_ *tsdb.Shard, index *tsdb.DatabaseIndex, mea
 		}
 	}
 
+	// sh may be nil in tests
+	if sh != nil {
+		e.logger.Printf("%s database index loaded in %s", sh.Path(), time.Now().Sub(start))
+	}
 	return nil
 }
 
@@ -340,27 +341,29 @@ func (e *Engine) DeleteSeries(seriesKeys []string) error {
 
 	var deleteKeys []string
 	// go through the keys in the file store
-	for _, k := range e.FileStore.Keys() {
+	for k := range e.FileStore.Keys() {
 		seriesKey, _ := seriesAndFieldFromCompositeKey(k)
 		if _, ok := keyMap[seriesKey]; ok {
 			deleteKeys = append(deleteKeys, k)
 		}
 	}
-	e.FileStore.Delete(deleteKeys)
+	if err := e.FileStore.Delete(deleteKeys); err != nil {
+		return err
+	}
 
 	// find the keys in the cache and remove them
 	walKeys := make([]string, 0)
-	e.Cache.Lock()
-	defer e.Cache.Unlock()
-
+	e.Cache.RLock()
 	s := e.Cache.Store()
 	for k, _ := range s {
 		seriesKey, _ := seriesAndFieldFromCompositeKey(k)
 		if _, ok := keyMap[seriesKey]; ok {
 			walKeys = append(walKeys, k)
-			delete(s, k)
 		}
 	}
+	e.Cache.RUnlock()
+
+	e.Cache.Delete(walKeys)
 
 	// delete from the WAL
 	_, err := e.WAL.Delete(walKeys)

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -43,6 +43,12 @@ type TSMFile interface {
 	// Keys returns all keys contained in the file.
 	Keys() []string
 
+	// KeyCount returns the number of distict keys in the file.
+	KeyCount() int
+
+	// KeyAt returns the key located at index position idx
+	KeyAt(idx int) (string, byte)
+
 	// Type returns the block type of the values stored for the key.  Returns one of
 	// BlockFloat64, BlockInt64, BlockBool, BlockString.  If key does not exist,
 	// an error is returned.
@@ -170,23 +176,20 @@ func (f *FileStore) Remove(paths ...string) {
 	sort.Sort(tsmReaders(f.files))
 }
 
-func (f *FileStore) Keys() []string {
+// Keys returns all keys and types for all files
+func (f *FileStore) Keys() map[string]byte {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	uniqueKeys := map[string]struct{}{}
+	uniqueKeys := map[string]byte{}
 	for _, f := range f.files {
-		for _, key := range f.Keys() {
-			uniqueKeys[key] = struct{}{}
+		for i := 0; i < f.KeyCount(); i++ {
+			key, typ := f.KeyAt(i)
+			uniqueKeys[key] = typ
 		}
 	}
 
-	var keys []string
-	for key := range uniqueKeys {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
+	return uniqueKeys
 }
 
 func (f *FileStore) Type(key string) (byte, error) {

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -50,7 +50,7 @@ func (b *BlockIterator) PeekNext() string {
 	if len(b.entries) > 1 {
 		return b.key
 	} else if b.n-b.i > 1 {
-		key := b.r.KeyAt(b.i + 1)
+		key, _ := b.r.KeyAt(b.i + 1)
 		return key
 	}
 	return ""
@@ -193,7 +193,7 @@ func (t *TSMReader) Key(index int) (string, []*IndexEntry) {
 	return t.index.Key(index)
 }
 
-func (t *TSMReader) KeyAt(idx int) string {
+func (t *TSMReader) KeyAt(idx int) (string, byte) {
 	return t.index.KeyAt(idx)
 }
 
@@ -519,15 +519,15 @@ func (d *indirectIndex) Key(idx int) (string, []*IndexEntry) {
 	return string(key), entries.entries
 }
 
-func (d *indirectIndex) KeyAt(idx int) string {
+func (d *indirectIndex) KeyAt(idx int) (string, byte) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
 	if idx < 0 || idx >= len(d.offsets) {
-		return ""
+		return "", 0
 	}
-	_, key, _ := readKey(d.b[d.offsets[idx]:])
-	return string(key)
+	n, key, _ := readKey(d.b[d.offsets[idx]:])
+	return string(key), d.b[d.offsets[idx]+int32(n)]
 }
 
 func (d *indirectIndex) KeyCount() int {

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -160,7 +160,7 @@ type TSMIndex interface {
 	Key(index int) (string, []*IndexEntry)
 
 	// KeyAt returns the key in the index at the given postion.
-	KeyAt(index int) string
+	KeyAt(index int) (string, byte)
 
 	// KeyCount returns the count of unique keys in the index.
 	KeyCount() int
@@ -343,11 +343,14 @@ func (d *directIndex) Key(idx int) (string, []*IndexEntry) {
 	return k, d.blocks[k].entries
 }
 
-func (d *directIndex) KeyAt(idx int) string {
+func (d *directIndex) KeyAt(idx int) (string, byte) {
 	if idx < 0 || idx >= len(d.blocks) {
-		return ""
+		return "", 0
 	}
-	return d.Keys()[idx]
+	key := d.Keys()[idx]
+	entries := d.blocks[key]
+	return key, entries.Type
+
 }
 
 func (d *directIndex) KeyCount() int {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -101,9 +101,6 @@ func (s *Shard) Open() error {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
-		s.index.mu.Lock()
-		defer s.index.mu.Unlock()
-
 		// Return if the shard is already open
 		if s.engine != nil {
 			return nil
@@ -208,22 +205,18 @@ func (s *Shard) WritePoints(points []models.Point) error {
 
 	// add any new series to the in-memory index
 	if len(seriesToCreate) > 0 {
-		s.index.mu.Lock()
 		for _, ss := range seriesToCreate {
 			s.index.CreateSeriesIndexIfNotExists(ss.Measurement, ss.Series)
 		}
-		s.index.mu.Unlock()
 	}
 
 	if len(seriesToAddShardTo) > 0 {
-		s.index.mu.Lock()
 		for _, k := range seriesToAddShardTo {
-			ss := s.index.series[k]
+			ss := s.index.Series(k)
 			if ss != nil {
-				ss.shardIDs[s.id] = true
+				ss.AssignShard(s.id)
 			}
 		}
-		s.index.mu.Unlock()
 	}
 
 	// add any new fields and keep track of what needs to be saved
@@ -346,9 +339,7 @@ func (s *Shard) createFieldsAndMeasurements(fieldsToCreate []*FieldCreate) (map[
 		return nil, nil
 	}
 
-	s.index.mu.Lock()
 	s.mu.Lock()
-	defer s.index.mu.Unlock()
 	defer s.mu.Unlock()
 
 	// add fields
@@ -387,17 +378,13 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*SeriesCreate,
 	var fieldsToCreate []*FieldCreate
 	var seriesToAddShardTo []string
 
-	// get the mutex for the in memory index, which is shared across shards
-	s.index.mu.RLock()
-	defer s.index.mu.RUnlock()
-
 	// get the shard mutex for locally defined fields
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	for _, p := range points {
 		// see if the series should be added to the index
-		if ss := s.index.series[string(p.Key())]; ss == nil {
+		if ss := s.index.Series(string(p.Key())); ss == nil {
 			series := NewSeries(string(p.Key()), p.Tags())
 			seriesToCreate = append(seriesToCreate, &SeriesCreate{p.Name(), series})
 			seriesToAddShardTo = append(seriesToAddShardTo, series.Key)


### PR DESCRIPTION
This PR improves startup times for databases with many shards.  The main changes are:
* Load shards concurrently
* Avoid querying the TSM index multiple times to get keys and then types for those keys
* Avoid some unnecessary allocations
* Move the database in-memory index locking into the index type to allow shards to be loaded concurrently

Should help #5311.