### PR TITLE
Expose AddTag method from models.Point in client.

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -302,6 +302,11 @@ func (p *Point) Name() string {
 	return p.pt.Name()
 }
 
+// AddTag adds or replaces a tag value for the point
+func (p *Point) AddTag(key, value string) {
+	p.pt.AddTag(key, value)
+}
+
 // Name returns the tags associated with the point
 func (p *Point) Tags() map[string]string {
 	return p.pt.Tags()

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -256,6 +256,25 @@ func TestClient_PointTags(t *testing.T) {
 	}
 }
 
+func TestClient_PointAddTag(t *testing.T) {
+	tags := map[string]string{"cpu": "cpu-total"}
+	fields := map[string]interface{}{"idle": 10.1, "system": 50.9, "user": 39.0}
+	p, _ := NewPoint("cpu_usage", tags, fields)
+
+	if !reflect.DeepEqual(tags, p.Tags()) {
+		t.Errorf("Error, got %v, expected %v",
+			p.Tags(), tags)
+	}
+
+	p.AddTag("hostname", "jazzhouse01")
+	tags["hostname"] = "jazzhouse01"
+
+	if !reflect.DeepEqual(tags, p.Tags()) {
+		t.Errorf("Error, got %v, expected %v",
+			p.Tags(), tags)
+	}
+}
+
 func TestClient_PointUnixNano(t *testing.T) {
 	const shortForm = "2006-Jan-02"
 	time1, _ := time.Parse(shortForm, "2013-Feb-03")


### PR DESCRIPTION
As of now it's impossible to add tags to a client.Point without resorting to something like this:

```go
	point := getPointFromSomewhere()

	tags := point.Tags()
	tags["hello"] = "hello world"

	point, _ = client.NewPoint(point.Name(), tags, point.Fields())
```
This PR adds an AddTag() method. After adding an AddTag() method it would look something like this:
```go
	point := getPointFromSomewhere()
	point.AddTag("hello", "hello world")
```
This can be useful for example when receiving a client.Point from some unknown source, and one wishes to add a tag describing the source.

Maybe we should expose more of models.Point in client..?