### PR TITLE
Fix cluster hostname

### DIFF
--- a/cluster/shard_mapper.go
+++ b/cluster/shard_mapper.go
@@ -69,7 +69,7 @@ func (s *ShardMapper) dial(nodeID uint64) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := net.Dial("tcp", ni.Host)
+	conn, err := net.Dial("tcp", ni.TCPHost)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/shard_writer.go
+++ b/cluster/shard_writer.go
@@ -149,7 +149,7 @@ func (c *connFactory) dial() (net.Conn, error) {
 		return nil, fmt.Errorf("node %d does not exist", c.nodeID)
 	}
 
-	conn, err := net.DialTimeout("tcp", ni.Host, c.timeout)
+	conn, err := net.DialTimeout("tcp", ni.TCPHost, c.timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -2,6 +2,8 @@ package meta
 
 import (
 	"errors"
+	"net"
+	"os"
 	"time"
 
 	"github.com/influxdb/influxdb/toml"
@@ -44,6 +46,10 @@ type Config struct {
 	Enabled bool   `toml:"enabled"`
 	Dir     string `toml:"dir"`
 
+	// hostname used if bind addresses do not specify an IP or hostname.  We look
+	// this up once to avoid resolving it too frequently.
+	hostname string
+
 	// this is deprecated. Should use the address from run/config.go
 	BindAddress string `toml:"bind-address"`
 
@@ -67,7 +73,16 @@ type Config struct {
 
 // NewConfig builds a new configuration with default values.
 func NewConfig() *Config {
+	// Lookup our hostname and fall back to our default "localhost" if that
+	// fails for any reason.  The hostname needs to be resolvable by remote
+	// cluster nodes.
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = DefaultHostname
+	}
+
 	return &Config{
+		hostname:             hostname,
 		Enabled:              true, // enabled by default
 		BindAddress:          DefaultRaftBindAddress,
 		HTTPBindAddress:      DefaultHTTPBindAddress,
@@ -86,4 +101,30 @@ func (c *Config) Validate() error {
 		return errors.New("Meta.Dir must be specified")
 	}
 	return nil
+}
+
+func (c *Config) defaultHost(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+
+	if host == "" {
+		return net.JoinHostPort(c.hostname, port)
+	}
+	return addr
+}
+
+// DefaultedBindAddress returns the BindAddress normalized with the
+// hosts name or "localhost" if that could not be determined.  If
+// the BindAddress already has a hostname, BindAddress is returned.
+func (c *Config) DefaultedBindAddress() string {
+	return c.defaultHost(c.BindAddress)
+}
+
+// DefaultedHTTPBindAddress returns the HTTPBindAddress normalized with the
+// hosts name or "localhost" if that could not be determined.  If
+// the HTTPBindAddress already has a hostname, HTTPBindAddress is returned.
+func (c *Config) DefaultedHTTPBindAddress() string {
+	return c.defaultHost(c.HTTPBindAddress)
 }

--- a/services/meta/service.go
+++ b/services/meta/service.go
@@ -34,8 +34,8 @@ type Service struct {
 func NewService(c *Config) *Service {
 	s := &Service{
 		config:   c,
-		httpAddr: c.HTTPBindAddress,
-		raftAddr: c.BindAddress,
+		httpAddr: c.DefaultedHTTPBindAddress(),
+		raftAddr: c.DefaultedBindAddress(),
 		https:    c.HTTPSEnabled,
 		cert:     c.HTTPSCertificate,
 		err:      make(chan error),


### PR DESCRIPTION
Ensures that the HTTP and TCP address have a hostname component so that remote nodes can connect.  If an address such as `:8088` is used, we will use the hostname returned by `os.Hostname()` or `localhost` if that fails.  If a hostname is already present in the address, it will be used unchanged.  

This also fixes cluster writes and queries as well as the continual `monitor: failed to store statistics: timeout` error occurring on this branch.