### PR TITLE
Enable GoLint on tsdb/internal

### DIFF
--- a/cluster/internal/data.pb.go
+++ b/cluster/internal/data.pb.go
@@ -26,9 +26,9 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 type WriteShardRequest struct {
-	ShardID          *uint64  `protobuf:"varint,1,req,name=ShardID" json:"ShardID,omitempty"`
-	Points           [][]byte `protobuf:"bytes,2,rep,name=Points" json:"Points,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	ShardID         *uint64  `protobuf:"varint,1,req,name=ShardID" json:"ShardID,omitempty"`
+	Points          [][]byte `protobuf:"bytes,2,rep,name=Points" json:"Points,omitempty"`
+	XXXUnrecognized []byte   `json:"-"`
 }
 
 func (m *WriteShardRequest) Reset()         { *m = WriteShardRequest{} }
@@ -50,9 +50,9 @@ func (m *WriteShardRequest) GetPoints() [][]byte {
 }
 
 type WriteShardResponse struct {
-	Code             *int32  `protobuf:"varint,1,req,name=Code" json:"Code,omitempty"`
-	Message          *string `protobuf:"bytes,2,opt,name=Message" json:"Message,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Code            *int32  `protobuf:"varint,1,req,name=Code" json:"Code,omitempty"`
+	Message         *string `protobuf:"bytes,2,opt,name=Message" json:"Message,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *WriteShardResponse) Reset()         { *m = WriteShardResponse{} }
@@ -74,10 +74,10 @@ func (m *WriteShardResponse) GetMessage() string {
 }
 
 type MapShardRequest struct {
-	ShardID          *uint64 `protobuf:"varint,1,req,name=ShardID" json:"ShardID,omitempty"`
-	Query            *string `protobuf:"bytes,2,req,name=Query" json:"Query,omitempty"`
-	ChunkSize        *int32  `protobuf:"varint,3,req,name=ChunkSize" json:"ChunkSize,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	ShardID         *uint64 `protobuf:"varint,1,req,name=ShardID" json:"ShardID,omitempty"`
+	Query           *string `protobuf:"bytes,2,req,name=Query" json:"Query,omitempty"`
+	ChunkSize       *int32  `protobuf:"varint,3,req,name=ChunkSize" json:"ChunkSize,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *MapShardRequest) Reset()         { *m = MapShardRequest{} }
@@ -106,12 +106,12 @@ func (m *MapShardRequest) GetChunkSize() int32 {
 }
 
 type MapShardResponse struct {
-	Code             *int32   `protobuf:"varint,1,req,name=Code" json:"Code,omitempty"`
-	Message          *string  `protobuf:"bytes,2,opt,name=Message" json:"Message,omitempty"`
-	Data             []byte   `protobuf:"bytes,3,opt,name=Data" json:"Data,omitempty"`
-	TagSets          []string `protobuf:"bytes,4,rep,name=TagSets" json:"TagSets,omitempty"`
-	Fields           []string `protobuf:"bytes,5,rep,name=Fields" json:"Fields,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	Code            *int32   `protobuf:"varint,1,req,name=Code" json:"Code,omitempty"`
+	Message         *string  `protobuf:"bytes,2,opt,name=Message" json:"Message,omitempty"`
+	Data            []byte   `protobuf:"bytes,3,opt,name=Data" json:"Data,omitempty"`
+	TagSets         []string `protobuf:"bytes,4,rep,name=TagSets" json:"TagSets,omitempty"`
+	Fields          []string `protobuf:"bytes,5,rep,name=Fields" json:"Fields,omitempty"`
+	XXXUnrecognized []byte   `json:"-"`
 }
 
 func (m *MapShardResponse) Reset()         { *m = MapShardResponse{} }

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -698,6 +698,7 @@ func (s *AlterRetentionPolicyStatement) RequiredPrivileges() ExecutionPrivileges
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}
 }
 
+// FillOption represents represents different options for aggregare windows.
 type FillOption int
 
 const (

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -698,7 +698,7 @@ func (s *AlterRetentionPolicyStatement) RequiredPrivileges() ExecutionPrivileges
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}
 }
 
-// FillOption represents represents different options for aggregare windows.
+// FillOption represents different options for aggregare windows.
 type FillOption int
 
 const (
@@ -1314,6 +1314,7 @@ func (s *SelectStatement) validateAggregates(tr targetRequirement) error {
 	return nil
 }
 
+// HasDistinct is an exported method that checks if a select statment contains DISTINCT
 func (s *SelectStatement) HasDistinct() bool {
 	// determine if we have a call named distinct
 	for _, f := range s.Fields {
@@ -1351,6 +1352,7 @@ func (s *SelectStatement) validateDistinct() error {
 	return nil
 }
 
+// HasCountDistinct is an exported method that checks if a select statment contains COUNT and DISTINCT
 func (s *SelectStatement) HasCountDistinct() bool {
 	for _, f := range s.Fields {
 		if c, ok := f.Expr.(*Call); ok {
@@ -1447,7 +1449,7 @@ func (s *SelectStatement) validateDerivative() error {
 	return nil
 }
 
-// GroupByIterval extracts the time interval, if specified.
+// GroupByInterval extracts the time interval, if specified.
 func (s *SelectStatement) GroupByInterval() (time.Duration, error) {
 	// return if we've already pulled it out
 	if s.groupByInterval != 0 {
@@ -2112,7 +2114,7 @@ func (s *ShowRetentionPoliciesStatement) RequiredPrivileges() ExecutionPrivilege
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}
 }
 
-// ShowStats statement displays statistics for a given module.
+// ShowStatsStatement displays statistics for a given module.
 type ShowStatsStatement struct {
 	// Module
 	Module string
@@ -2508,9 +2510,9 @@ func (f *Field) String() string {
 }
 
 // Sort Interface for Fields
-func (f Fields) Len() int           { return len(f) }
-func (f Fields) Less(i, j int) bool { return f[i].Name() < f[j].Name() }
-func (f Fields) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
+func (a Fields) Len() int           { return len(a) }
+func (a Fields) Less(i, j int) bool { return a[i].Name() < a[j].Name() }
+func (a Fields) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 // Dimensions represents a list of dimensions.
 type Dimensions []*Dimension
@@ -2944,7 +2946,7 @@ func TimeRange(expr Expr) (min, max time.Time) {
 	return
 }
 
-// TimeRange returns the minimum and maximum times, as epoch nano, specified by
+// TimeRangeAsEpochNano returns the minimum and maximum times, as epoch nano, specified by
 // and expression. If there is no lower bound, the start of the epoch is returned
 // for minimum. If there is no higher bound, now is returned for maximum.
 func TimeRangeAsEpochNano(expr Expr) (min, max int64) {
@@ -3571,11 +3573,12 @@ type Valuer interface {
 	Value(key string) (interface{}, bool)
 }
 
-// nowValuer returns only the value for "now()".
+// NowValuer returns only the value for "now()".
 type NowValuer struct {
 	Now time.Time
 }
 
+// Value is a method that returns the value and existence flag for a given key.
 func (v *NowValuer) Value(key string) (interface{}, bool) {
 	if key == "now()" {
 		return v.Now, true

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -510,7 +510,7 @@ func (p *Parser) parseUInt64() (uint64, error) {
 // This function assumes the DURATION token has already been consumed.
 func (p *Parser) parseDuration() (time.Duration, error) {
 	tok, pos, lit := p.scanIgnoreWhitespace()
-	if tok != DURATION_VAL && tok != INF {
+	if tok != DURATIONVAL && tok != INF {
 		return 0, newParseError(tokstr(tok, lit), []string{"duration"}, pos)
 	}
 
@@ -2307,7 +2307,7 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		return &NumberLiteral{Val: v}, nil
 	case TRUE, FALSE:
 		return &BooleanLiteral{Val: (tok == TRUE)}, nil
-	case DURATION_VAL:
+	case DURATIONVAL:
 		v, _ := ParseDuration(lit)
 		return &DurationLiteral{Val: v}, nil
 	case MUL:

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1487,7 +1487,7 @@ func (p *Parser) parseCreateDatabaseStatement() (*CreateDatabaseStatement, error
 		stmt.RetentionPolicyDuration = rpDuration
 
 		// Look for "REPLICATION"
-		var rpReplication int = 1 // default is 1
+		var rpReplication = 1 // default is 1
 		if err := p.parseTokens([]Token{REPLICATION}); err != nil {
 			p.unscan()
 		} else {
@@ -1499,7 +1499,7 @@ func (p *Parser) parseCreateDatabaseStatement() (*CreateDatabaseStatement, error
 		stmt.RetentionPolicyReplication = rpReplication
 
 		// Look for "NAME"
-		var rpName string = "default" // default is default
+		var rpName = "default" // default is default
 		if err := p.parseTokens([]Token{NAME}); err == nil {
 			rpName, err = p.parseIdent()
 			if err != nil {

--- a/influxql/result.go
+++ b/influxql/result.go
@@ -22,8 +22,8 @@ func (t *TagSet) AddFilter(key string, filter Expr) {
 	t.Filters = append(t.Filters, filter)
 }
 
-// Rows represents a list of rows that can be sorted consistently by name/tag.
 // Result represents a resultset returned from a single statement.
+// Rows represents a list of rows that can be sorted consistently by name/tag.
 type Result struct {
 	// StatementID is just the statement's position in the query. It's used
 	// to combine statement results if they're being buffered in memory.
@@ -67,6 +67,8 @@ func (r *Result) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// GetProcessor is a Method that returns processor type and index
+// based on the type of expression.
 func GetProcessor(expr Expr, startIndex int) (Processor, int) {
 	switch expr := expr.(type) {
 	case *VarRef:
@@ -91,6 +93,7 @@ func GetProcessor(expr Expr, startIndex int) (Processor, int) {
 	panic("unreachable")
 }
 
+// Processor is a prcessor type returned by GetProcessor
 type Processor func(values []interface{}) interface{}
 
 func newEchoProcessor(index int) Processor {

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -176,6 +176,7 @@ func (s *Scanner) scanString() (tok Token, pos Pos, lit string) {
 	return STRING, pos, lit
 }
 
+// ScanRegex consumes a token to find escapes
 func (s *Scanner) ScanRegex() (tok Token, pos Pos, lit string) {
 	_, pos = s.r.curr()
 
@@ -444,6 +445,7 @@ func (r *reader) curr() (ch rune, pos Pos) {
 // eof is a marker code point to signify that the reader can't read any more.
 const eof = rune(0)
 
+// ScanDelimited reads a delimited set of runes
 func ScanDelimited(r io.RuneScanner, start, end rune, escapes map[rune]rune, escapesPassThru bool) ([]byte, error) {
 	// Scan start delimiter.
 	if ch, _, err := r.ReadRune(); err != nil {

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -256,7 +256,7 @@ func (s *Scanner) scanNumber() (tok Token, pos Pos, lit string) {
 		// If the next rune is a duration unit (u,µ,ms,s) then return a duration token
 		if ch0, _ := s.r.read(); ch0 == 'u' || ch0 == 'µ' || ch0 == 's' || ch0 == 'h' || ch0 == 'd' || ch0 == 'w' {
 			_, _ = buf.WriteRune(ch0)
-			return DURATION_VAL, pos, buf.String()
+			return DURATIONVAL, pos, buf.String()
 		} else if ch0 == 'm' {
 			_, _ = buf.WriteRune(ch0)
 			if ch1, _ := s.r.read(); ch1 == 's' {
@@ -264,7 +264,7 @@ func (s *Scanner) scanNumber() (tok Token, pos Pos, lit string) {
 			} else {
 				s.r.unread()
 			}
-			return DURATION_VAL, pos, buf.String()
+			return DURATIONVAL, pos, buf.String()
 		}
 		s.r.unread()
 	}

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -95,14 +95,14 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `10.3s`, tok: influxql.NUMBER, lit: `10.3`},
 
 		// Durations
-		{s: `10u`, tok: influxql.DURATION_VAL, lit: `10u`},
-		{s: `10µ`, tok: influxql.DURATION_VAL, lit: `10µ`},
-		{s: `10ms`, tok: influxql.DURATION_VAL, lit: `10ms`},
-		{s: `-1s`, tok: influxql.DURATION_VAL, lit: `-1s`},
-		{s: `10m`, tok: influxql.DURATION_VAL, lit: `10m`},
-		{s: `10h`, tok: influxql.DURATION_VAL, lit: `10h`},
-		{s: `10d`, tok: influxql.DURATION_VAL, lit: `10d`},
-		{s: `10w`, tok: influxql.DURATION_VAL, lit: `10w`},
+		{s: `10u`, tok: influxql.DURATIONVAL, lit: `10u`},
+		{s: `10µ`, tok: influxql.DURATIONVAL, lit: `10µ`},
+		{s: `10ms`, tok: influxql.DURATIONVAL, lit: `10ms`},
+		{s: `-1s`, tok: influxql.DURATIONVAL, lit: `-1s`},
+		{s: `10m`, tok: influxql.DURATIONVAL, lit: `10m`},
+		{s: `10h`, tok: influxql.DURATIONVAL, lit: `10h`},
+		{s: `10d`, tok: influxql.DURATIONVAL, lit: `10d`},
+		{s: `10w`, tok: influxql.DURATIONVAL, lit: `10w`},
 		{s: `10x`, tok: influxql.NUMBER, lit: `10`}, // non-duration unit
 
 		// Keywords

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -95,14 +95,14 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `10.3s`, tok: influxql.NUMBER, lit: `10.3`},
 
 		// Durations
-		{s: `10u`, tok: influxql.DURATIONVAL, lit: `10u`},
-		{s: `10µ`, tok: influxql.DURATIONVAL, lit: `10µ`},
-		{s: `10ms`, tok: influxql.DURATIONVAL, lit: `10ms`},
-		{s: `-1s`, tok: influxql.DURATIONVAL, lit: `-1s`},
-		{s: `10m`, tok: influxql.DURATIONVAL, lit: `10m`},
-		{s: `10h`, tok: influxql.DURATIONVAL, lit: `10h`},
-		{s: `10d`, tok: influxql.DURATIONVAL, lit: `10d`},
-		{s: `10w`, tok: influxql.DURATIONVAL, lit: `10w`},
+		{s: `10u`, tok: influxql.DURATION_VAL, lit: `10u`},
+		{s: `10µ`, tok: influxql.DURATION_VAL, lit: `10µ`},
+		{s: `10ms`, tok: influxql.DURATION_VAL, lit: `10ms`},
+		{s: `-1s`, tok: influxql.DURATION_VAL, lit: `-1s`},
+		{s: `10m`, tok: influxql.DURATION_VAL, lit: `10m`},
+		{s: `10h`, tok: influxql.DURATION_VAL, lit: `10h`},
+		{s: `10d`, tok: influxql.DURATION_VAL, lit: `10d`},
+		{s: `10w`, tok: influxql.DURATION_VAL, lit: `10w`},
 		{s: `10x`, tok: influxql.NUMBER, lit: `10`}, // non-duration unit
 
 		// Keywords

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -16,20 +16,20 @@ const (
 
 	literalBeg
 	// IDENT and the following are IQL Literal tokens.
-	IDENT        // main
-	NUMBER       // 12345.67
-	DURATION_VAL // 13h
-	STRING       // "abc"
-	BADSTRING    // "abc
-	BADESCAPE    // \q
-	TRUE         // true
-	FALSE        // false
-	REGEX        // Regular expressions
-	BADREGEX     // `.*
-	literal_end
+	IDENT       // main
+	NUMBER      // 12345.67
+	DURATIONVAL // 13h
+	STRING      // "abc"
+	BADSTRING   // "abc
+	BADESCAPE   // \q
+	TRUE        // true
+	FALSE       // false
+	REGEX       // Regular expressions
+	BADREGEX    // `.*
+	literalEnd
 
-	operator_beg
-	// Operators
+	operatorBeg
+	// ADD and other Operators
 	ADD // +
 	SUB // -
 	MUL // *
@@ -46,7 +46,7 @@ const (
 	LTE      // <=
 	GT       // >
 	GTE      // >=
-	operator_end
+	operatorEnd
 
 	LPAREN    // (
 	RPAREN    // )
@@ -55,8 +55,8 @@ const (
 	SEMICOLON // ;
 	DOT       // .
 
-	keyword_beg
-	// Keywords
+	keywordBeg
+	// ALL and other Keywords
 	ALL
 	ALTER
 	ANY
@@ -134,7 +134,7 @@ const (
 	WHERE
 	WITH
 	WRITE
-	keyword_end
+	keywordEnd
 )
 
 var tokens = [...]string{
@@ -142,15 +142,15 @@ var tokens = [...]string{
 	EOF:     "EOF",
 	WS:      "WS",
 
-	IDENT:        "IDENT",
-	NUMBER:       "NUMBER",
-	DURATION_VAL: "DURATION_VAL",
-	STRING:       "STRING",
-	BADSTRING:    "BADSTRING",
-	BADESCAPE:    "BADESCAPE",
-	TRUE:         "TRUE",
-	FALSE:        "FALSE",
-	REGEX:        "REGEX",
+	IDENT:       "IDENT",
+	NUMBER:      "NUMBER",
+	DURATIONVAL: "DURATIONVAL",
+	STRING:      "STRING",
+	BADSTRING:   "BADSTRING",
+	BADESCAPE:   "BADESCAPE",
+	TRUE:        "TRUE",
+	FALSE:       "FALSE",
+	REGEX:       "REGEX",
 
 	ADD: "+",
 	SUB: "-",
@@ -259,7 +259,7 @@ var keywords map[string]Token
 
 func init() {
 	keywords = make(map[string]Token)
-	for tok := keyword_beg + 1; tok < keyword_end; tok++ {
+	for tok := keywordBeg + 1; tok < keywordEnd; tok++ {
 		keywords[strings.ToLower(tokens[tok])] = tok
 	}
 	for _, tok := range []Token{AND, OR} {
@@ -295,7 +295,7 @@ func (tok Token) Precedence() int {
 }
 
 // isOperator returns true for operator tokens.
-func (tok Token) isOperator() bool { return tok > operator_beg && tok < operator_end }
+func (tok Token) isOperator() bool { return tok > operatorBeg && tok < operatorEnd }
 
 // tokstr returns a literal if provided, otherwise returns the token string.
 func tokstr(tok Token, lit string) string {

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -7,14 +7,15 @@ import (
 // Token is a lexical token of the InfluxQL language.
 type Token int
 
+// These are a comprehensive list of InfluxQL language tokens.
 const (
-	// Special tokens
+	// ILLEGAL Token, EOF, WS are Special IQL tokens.
 	ILLEGAL Token = iota
 	EOF
 	WS
 
-	literal_beg
-	// Literals
+	literalBeg
+	// IDENT and the following are IQL Literal tokens.
 	IDENT        // main
 	NUMBER       // 12345.67
 	DURATION_VAL // 13h

--- a/meta/internal/meta.pb.go
+++ b/meta/internal/meta.pb.go
@@ -197,16 +197,16 @@ func (x *Command_Type) UnmarshalJSON(data []byte) error {
 }
 
 type Data struct {
-	Term             *uint64         `protobuf:"varint,1,req,name=Term" json:"Term,omitempty"`
-	Index            *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
-	ClusterID        *uint64         `protobuf:"varint,3,req,name=ClusterID" json:"ClusterID,omitempty"`
-	Nodes            []*NodeInfo     `protobuf:"bytes,4,rep,name=Nodes" json:"Nodes,omitempty"`
-	Databases        []*DatabaseInfo `protobuf:"bytes,5,rep,name=Databases" json:"Databases,omitempty"`
-	Users            []*UserInfo     `protobuf:"bytes,6,rep,name=Users" json:"Users,omitempty"`
-	MaxNodeID        *uint64         `protobuf:"varint,7,req,name=MaxNodeID" json:"MaxNodeID,omitempty"`
-	MaxShardGroupID  *uint64         `protobuf:"varint,8,req,name=MaxShardGroupID" json:"MaxShardGroupID,omitempty"`
-	MaxShardID       *uint64         `protobuf:"varint,9,req,name=MaxShardID" json:"MaxShardID,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
+	Term            *uint64         `protobuf:"varint,1,req,name=Term" json:"Term,omitempty"`
+	Index           *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
+	ClusterID       *uint64         `protobuf:"varint,3,req,name=ClusterID" json:"ClusterID,omitempty"`
+	Nodes           []*NodeInfo     `protobuf:"bytes,4,rep,name=Nodes" json:"Nodes,omitempty"`
+	Databases       []*DatabaseInfo `protobuf:"bytes,5,rep,name=Databases" json:"Databases,omitempty"`
+	Users           []*UserInfo     `protobuf:"bytes,6,rep,name=Users" json:"Users,omitempty"`
+	MaxNodeID       *uint64         `protobuf:"varint,7,req,name=MaxNodeID" json:"MaxNodeID,omitempty"`
+	MaxShardGroupID *uint64         `protobuf:"varint,8,req,name=MaxShardGroupID" json:"MaxShardGroupID,omitempty"`
+	MaxShardID      *uint64         `protobuf:"varint,9,req,name=MaxShardID" json:"MaxShardID,omitempty"`
+	XXXUnrecognized []byte          `json:"-"`
 }
 
 func (m *Data) Reset()         { *m = Data{} }
@@ -277,9 +277,9 @@ func (m *Data) GetMaxShardID() uint64 {
 }
 
 type NodeInfo struct {
-	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	Host             *string `protobuf:"bytes,2,req,name=Host" json:"Host,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	ID              *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	Host            *string `protobuf:"bytes,2,req,name=Host" json:"Host,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *NodeInfo) Reset()         { *m = NodeInfo{} }
@@ -305,7 +305,7 @@ type DatabaseInfo struct {
 	DefaultRetentionPolicy *string                `protobuf:"bytes,2,req,name=DefaultRetentionPolicy" json:"DefaultRetentionPolicy,omitempty"`
 	RetentionPolicies      []*RetentionPolicyInfo `protobuf:"bytes,3,rep,name=RetentionPolicies" json:"RetentionPolicies,omitempty"`
 	ContinuousQueries      []*ContinuousQueryInfo `protobuf:"bytes,4,rep,name=ContinuousQueries" json:"ContinuousQueries,omitempty"`
-	XXX_unrecognized       []byte                 `json:"-"`
+	XXXUnrecognized        []byte                 `json:"-"`
 }
 
 func (m *DatabaseInfo) Reset()         { *m = DatabaseInfo{} }
@@ -347,7 +347,7 @@ type RetentionPolicyInfo struct {
 	ReplicaN           *uint32             `protobuf:"varint,4,req,name=ReplicaN" json:"ReplicaN,omitempty"`
 	ShardGroups        []*ShardGroupInfo   `protobuf:"bytes,5,rep,name=ShardGroups" json:"ShardGroups,omitempty"`
 	Subscriptions      []*SubscriptionInfo `protobuf:"bytes,6,rep,name=Subscriptions" json:"Subscriptions,omitempty"`
-	XXX_unrecognized   []byte              `json:"-"`
+	XXXUnrecognized    []byte              `json:"-"`
 }
 
 func (m *RetentionPolicyInfo) Reset()         { *m = RetentionPolicyInfo{} }
@@ -397,12 +397,12 @@ func (m *RetentionPolicyInfo) GetSubscriptions() []*SubscriptionInfo {
 }
 
 type ShardGroupInfo struct {
-	ID               *uint64      `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	StartTime        *int64       `protobuf:"varint,2,req,name=StartTime" json:"StartTime,omitempty"`
-	EndTime          *int64       `protobuf:"varint,3,req,name=EndTime" json:"EndTime,omitempty"`
-	DeletedAt        *int64       `protobuf:"varint,4,req,name=DeletedAt" json:"DeletedAt,omitempty"`
-	Shards           []*ShardInfo `protobuf:"bytes,5,rep,name=Shards" json:"Shards,omitempty"`
-	XXX_unrecognized []byte       `json:"-"`
+	ID              *uint64      `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	StartTime       *int64       `protobuf:"varint,2,req,name=StartTime" json:"StartTime,omitempty"`
+	EndTime         *int64       `protobuf:"varint,3,req,name=EndTime" json:"EndTime,omitempty"`
+	DeletedAt       *int64       `protobuf:"varint,4,req,name=DeletedAt" json:"DeletedAt,omitempty"`
+	Shards          []*ShardInfo `protobuf:"bytes,5,rep,name=Shards" json:"Shards,omitempty"`
+	XXXUnrecognized []byte       `json:"-"`
 }
 
 func (m *ShardGroupInfo) Reset()         { *m = ShardGroupInfo{} }
@@ -445,10 +445,10 @@ func (m *ShardGroupInfo) GetShards() []*ShardInfo {
 }
 
 type ShardInfo struct {
-	ID               *uint64       `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	OwnerIDs         []uint64      `protobuf:"varint,2,rep,name=OwnerIDs" json:"OwnerIDs,omitempty"`
-	Owners           []*ShardOwner `protobuf:"bytes,3,rep,name=Owners" json:"Owners,omitempty"`
-	XXX_unrecognized []byte        `json:"-"`
+	ID              *uint64       `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	OwnerIDs        []uint64      `protobuf:"varint,2,rep,name=OwnerIDs" json:"OwnerIDs,omitempty"`
+	Owners          []*ShardOwner `protobuf:"bytes,3,rep,name=Owners" json:"Owners,omitempty"`
+	XXXUnrecognized []byte        `json:"-"`
 }
 
 func (m *ShardInfo) Reset()         { *m = ShardInfo{} }
@@ -477,10 +477,10 @@ func (m *ShardInfo) GetOwners() []*ShardOwner {
 }
 
 type SubscriptionInfo struct {
-	Name             *string  `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	Mode             *string  `protobuf:"bytes,2,req,name=Mode" json:"Mode,omitempty"`
-	Destinations     []string `protobuf:"bytes,3,rep,name=Destinations" json:"Destinations,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	Name            *string  `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	Mode            *string  `protobuf:"bytes,2,req,name=Mode" json:"Mode,omitempty"`
+	Destinations    []string `protobuf:"bytes,3,rep,name=Destinations" json:"Destinations,omitempty"`
+	XXXUnrecognized []byte   `json:"-"`
 }
 
 func (m *SubscriptionInfo) Reset()         { *m = SubscriptionInfo{} }
@@ -509,8 +509,8 @@ func (m *SubscriptionInfo) GetDestinations() []string {
 }
 
 type ShardOwner struct {
-	NodeID           *uint64 `protobuf:"varint,1,req,name=NodeID" json:"NodeID,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	NodeID          *uint64 `protobuf:"varint,1,req,name=NodeID" json:"NodeID,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *ShardOwner) Reset()         { *m = ShardOwner{} }
@@ -525,9 +525,9 @@ func (m *ShardOwner) GetNodeID() uint64 {
 }
 
 type ContinuousQueryInfo struct {
-	Name             *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	Query            *string `protobuf:"bytes,2,req,name=Query" json:"Query,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Name            *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	Query           *string `protobuf:"bytes,2,req,name=Query" json:"Query,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *ContinuousQueryInfo) Reset()         { *m = ContinuousQueryInfo{} }
@@ -549,11 +549,11 @@ func (m *ContinuousQueryInfo) GetQuery() string {
 }
 
 type UserInfo struct {
-	Name             *string          `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	Hash             *string          `protobuf:"bytes,2,req,name=Hash" json:"Hash,omitempty"`
-	Admin            *bool            `protobuf:"varint,3,req,name=Admin" json:"Admin,omitempty"`
-	Privileges       []*UserPrivilege `protobuf:"bytes,4,rep,name=Privileges" json:"Privileges,omitempty"`
-	XXX_unrecognized []byte           `json:"-"`
+	Name            *string          `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	Hash            *string          `protobuf:"bytes,2,req,name=Hash" json:"Hash,omitempty"`
+	Admin           *bool            `protobuf:"varint,3,req,name=Admin" json:"Admin,omitempty"`
+	Privileges      []*UserPrivilege `protobuf:"bytes,4,rep,name=Privileges" json:"Privileges,omitempty"`
+	XXXUnrecognized []byte           `json:"-"`
 }
 
 func (m *UserInfo) Reset()         { *m = UserInfo{} }
@@ -589,9 +589,9 @@ func (m *UserInfo) GetPrivileges() []*UserPrivilege {
 }
 
 type UserPrivilege struct {
-	Database         *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	Privilege        *int32  `protobuf:"varint,2,req,name=Privilege" json:"Privilege,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Database        *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	Privilege       *int32  `protobuf:"varint,2,req,name=Privilege" json:"Privilege,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *UserPrivilege) Reset()         { *m = UserPrivilege{} }
@@ -613,9 +613,9 @@ func (m *UserPrivilege) GetPrivilege() int32 {
 }
 
 type Command struct {
-	Type             *Command_Type             `protobuf:"varint,1,req,name=type,enum=internal.Command_Type" json:"type,omitempty"`
-	XXX_extensions   map[int32]proto.Extension `json:"-"`
-	XXX_unrecognized []byte                    `json:"-"`
+	Type            *Command_Type             `protobuf:"varint,1,req,name=type,enum=internal.Command_Type" json:"type,omitempty"`
+	XXX_extensions  map[int32]proto.Extension `json:"-"`
+	XXXUnrecognized []byte                    `json:"-"`
 }
 
 func (m *Command) Reset()         { *m = Command{} }
@@ -644,9 +644,9 @@ func (m *Command) GetType() Command_Type {
 }
 
 type CreateNodeCommand struct {
-	Host             *string `protobuf:"bytes,1,req,name=Host" json:"Host,omitempty"`
-	Rand             *uint64 `protobuf:"varint,2,req,name=Rand" json:"Rand,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Host            *string `protobuf:"bytes,1,req,name=Host" json:"Host,omitempty"`
+	Rand            *uint64 `protobuf:"varint,2,req,name=Rand" json:"Rand,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *CreateNodeCommand) Reset()         { *m = CreateNodeCommand{} }
@@ -676,9 +676,9 @@ var E_CreateNodeCommand_Command = &proto.ExtensionDesc{
 }
 
 type DeleteNodeCommand struct {
-	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	Force            *bool   `protobuf:"varint,2,req,name=Force" json:"Force,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	ID              *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	Force           *bool   `protobuf:"varint,2,req,name=Force" json:"Force,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *DeleteNodeCommand) Reset()         { *m = DeleteNodeCommand{} }
@@ -708,8 +708,8 @@ var E_DeleteNodeCommand_Command = &proto.ExtensionDesc{
 }
 
 type CreateDatabaseCommand struct {
-	Name             *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Name            *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *CreateDatabaseCommand) Reset()         { *m = CreateDatabaseCommand{} }
@@ -732,8 +732,8 @@ var E_CreateDatabaseCommand_Command = &proto.ExtensionDesc{
 }
 
 type DropDatabaseCommand struct {
-	Name             *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Name            *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *DropDatabaseCommand) Reset()         { *m = DropDatabaseCommand{} }
@@ -756,9 +756,9 @@ var E_DropDatabaseCommand_Command = &proto.ExtensionDesc{
 }
 
 type CreateRetentionPolicyCommand struct {
-	Database         *string              `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	RetentionPolicy  *RetentionPolicyInfo `protobuf:"bytes,2,req,name=RetentionPolicy" json:"RetentionPolicy,omitempty"`
-	XXX_unrecognized []byte               `json:"-"`
+	Database        *string              `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	RetentionPolicy *RetentionPolicyInfo `protobuf:"bytes,2,req,name=RetentionPolicy" json:"RetentionPolicy,omitempty"`
+	XXXUnrecognized []byte               `json:"-"`
 }
 
 func (m *CreateRetentionPolicyCommand) Reset()         { *m = CreateRetentionPolicyCommand{} }
@@ -788,9 +788,9 @@ var E_CreateRetentionPolicyCommand_Command = &proto.ExtensionDesc{
 }
 
 type DropRetentionPolicyCommand struct {
-	Database         *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	Name             *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Database        *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	Name            *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *DropRetentionPolicyCommand) Reset()         { *m = DropRetentionPolicyCommand{} }
@@ -820,9 +820,9 @@ var E_DropRetentionPolicyCommand_Command = &proto.ExtensionDesc{
 }
 
 type SetDefaultRetentionPolicyCommand struct {
-	Database         *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	Name             *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Database        *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	Name            *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *SetDefaultRetentionPolicyCommand) Reset()         { *m = SetDefaultRetentionPolicyCommand{} }
@@ -852,12 +852,12 @@ var E_SetDefaultRetentionPolicyCommand_Command = &proto.ExtensionDesc{
 }
 
 type UpdateRetentionPolicyCommand struct {
-	Database         *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	Name             *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
-	NewName          *string `protobuf:"bytes,3,opt,name=NewName" json:"NewName,omitempty"`
-	Duration         *int64  `protobuf:"varint,4,opt,name=Duration" json:"Duration,omitempty"`
-	ReplicaN         *uint32 `protobuf:"varint,5,opt,name=ReplicaN" json:"ReplicaN,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Database        *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	Name            *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
+	NewName         *string `protobuf:"bytes,3,opt,name=NewName" json:"NewName,omitempty"`
+	Duration        *int64  `protobuf:"varint,4,opt,name=Duration" json:"Duration,omitempty"`
+	ReplicaN        *uint32 `protobuf:"varint,5,opt,name=ReplicaN" json:"ReplicaN,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *UpdateRetentionPolicyCommand) Reset()         { *m = UpdateRetentionPolicyCommand{} }
@@ -908,10 +908,10 @@ var E_UpdateRetentionPolicyCommand_Command = &proto.ExtensionDesc{
 }
 
 type CreateShardGroupCommand struct {
-	Database         *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	Policy           *string `protobuf:"bytes,2,req,name=Policy" json:"Policy,omitempty"`
-	Timestamp        *int64  `protobuf:"varint,3,req,name=Timestamp" json:"Timestamp,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Database        *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	Policy          *string `protobuf:"bytes,2,req,name=Policy" json:"Policy,omitempty"`
+	Timestamp       *int64  `protobuf:"varint,3,req,name=Timestamp" json:"Timestamp,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *CreateShardGroupCommand) Reset()         { *m = CreateShardGroupCommand{} }
@@ -948,10 +948,10 @@ var E_CreateShardGroupCommand_Command = &proto.ExtensionDesc{
 }
 
 type DeleteShardGroupCommand struct {
-	Database         *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	Policy           *string `protobuf:"bytes,2,req,name=Policy" json:"Policy,omitempty"`
-	ShardGroupID     *uint64 `protobuf:"varint,3,req,name=ShardGroupID" json:"ShardGroupID,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Database        *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	Policy          *string `protobuf:"bytes,2,req,name=Policy" json:"Policy,omitempty"`
+	ShardGroupID    *uint64 `protobuf:"varint,3,req,name=ShardGroupID" json:"ShardGroupID,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *DeleteShardGroupCommand) Reset()         { *m = DeleteShardGroupCommand{} }
@@ -988,10 +988,10 @@ var E_DeleteShardGroupCommand_Command = &proto.ExtensionDesc{
 }
 
 type CreateContinuousQueryCommand struct {
-	Database         *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	Name             *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
-	Query            *string `protobuf:"bytes,3,req,name=Query" json:"Query,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Database        *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	Name            *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
+	Query           *string `protobuf:"bytes,3,req,name=Query" json:"Query,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *CreateContinuousQueryCommand) Reset()         { *m = CreateContinuousQueryCommand{} }
@@ -1028,9 +1028,9 @@ var E_CreateContinuousQueryCommand_Command = &proto.ExtensionDesc{
 }
 
 type DropContinuousQueryCommand struct {
-	Database         *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
-	Name             *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Database        *string `protobuf:"bytes,1,req,name=Database" json:"Database,omitempty"`
+	Name            *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *DropContinuousQueryCommand) Reset()         { *m = DropContinuousQueryCommand{} }
@@ -1060,10 +1060,10 @@ var E_DropContinuousQueryCommand_Command = &proto.ExtensionDesc{
 }
 
 type CreateUserCommand struct {
-	Name             *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	Hash             *string `protobuf:"bytes,2,req,name=Hash" json:"Hash,omitempty"`
-	Admin            *bool   `protobuf:"varint,3,req,name=Admin" json:"Admin,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Name            *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	Hash            *string `protobuf:"bytes,2,req,name=Hash" json:"Hash,omitempty"`
+	Admin           *bool   `protobuf:"varint,3,req,name=Admin" json:"Admin,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *CreateUserCommand) Reset()         { *m = CreateUserCommand{} }
@@ -1100,8 +1100,8 @@ var E_CreateUserCommand_Command = &proto.ExtensionDesc{
 }
 
 type DropUserCommand struct {
-	Name             *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Name            *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *DropUserCommand) Reset()         { *m = DropUserCommand{} }
@@ -1124,9 +1124,9 @@ var E_DropUserCommand_Command = &proto.ExtensionDesc{
 }
 
 type UpdateUserCommand struct {
-	Name             *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	Hash             *string `protobuf:"bytes,2,req,name=Hash" json:"Hash,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Name            *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	Hash            *string `protobuf:"bytes,2,req,name=Hash" json:"Hash,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *UpdateUserCommand) Reset()         { *m = UpdateUserCommand{} }
@@ -1156,10 +1156,10 @@ var E_UpdateUserCommand_Command = &proto.ExtensionDesc{
 }
 
 type SetPrivilegeCommand struct {
-	Username         *string `protobuf:"bytes,1,req,name=Username" json:"Username,omitempty"`
-	Database         *string `protobuf:"bytes,2,req,name=Database" json:"Database,omitempty"`
-	Privilege        *int32  `protobuf:"varint,3,req,name=Privilege" json:"Privilege,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Username        *string `protobuf:"bytes,1,req,name=Username" json:"Username,omitempty"`
+	Database        *string `protobuf:"bytes,2,req,name=Database" json:"Database,omitempty"`
+	Privilege       *int32  `protobuf:"varint,3,req,name=Privilege" json:"Privilege,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *SetPrivilegeCommand) Reset()         { *m = SetPrivilegeCommand{} }
@@ -1196,8 +1196,8 @@ var E_SetPrivilegeCommand_Command = &proto.ExtensionDesc{
 }
 
 type SetDataCommand struct {
-	Data             *Data  `protobuf:"bytes,1,req,name=Data" json:"Data,omitempty"`
-	XXX_unrecognized []byte `json:"-"`
+	Data            *Data  `protobuf:"bytes,1,req,name=Data" json:"Data,omitempty"`
+	XXXUnrecognized []byte `json:"-"`
 }
 
 func (m *SetDataCommand) Reset()         { *m = SetDataCommand{} }
@@ -1220,9 +1220,9 @@ var E_SetDataCommand_Command = &proto.ExtensionDesc{
 }
 
 type SetAdminPrivilegeCommand struct {
-	Username         *string `protobuf:"bytes,1,req,name=Username" json:"Username,omitempty"`
-	Admin            *bool   `protobuf:"varint,2,req,name=Admin" json:"Admin,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Username        *string `protobuf:"bytes,1,req,name=Username" json:"Username,omitempty"`
+	Admin           *bool   `protobuf:"varint,2,req,name=Admin" json:"Admin,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *SetAdminPrivilegeCommand) Reset()         { *m = SetAdminPrivilegeCommand{} }
@@ -1252,9 +1252,9 @@ var E_SetAdminPrivilegeCommand_Command = &proto.ExtensionDesc{
 }
 
 type UpdateNodeCommand struct {
-	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	Host             *string `protobuf:"bytes,2,req,name=Host" json:"Host,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	ID              *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	Host            *string `protobuf:"bytes,2,req,name=Host" json:"Host,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *UpdateNodeCommand) Reset()         { *m = UpdateNodeCommand{} }
@@ -1284,12 +1284,12 @@ var E_UpdateNodeCommand_Command = &proto.ExtensionDesc{
 }
 
 type CreateSubscriptionCommand struct {
-	Name             *string  `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	Database         *string  `protobuf:"bytes,2,req,name=Database" json:"Database,omitempty"`
-	RetentionPolicy  *string  `protobuf:"bytes,3,req,name=RetentionPolicy" json:"RetentionPolicy,omitempty"`
-	Mode             *string  `protobuf:"bytes,4,req,name=Mode" json:"Mode,omitempty"`
-	Destinations     []string `protobuf:"bytes,5,rep,name=Destinations" json:"Destinations,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	Name            *string  `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	Database        *string  `protobuf:"bytes,2,req,name=Database" json:"Database,omitempty"`
+	RetentionPolicy *string  `protobuf:"bytes,3,req,name=RetentionPolicy" json:"RetentionPolicy,omitempty"`
+	Mode            *string  `protobuf:"bytes,4,req,name=Mode" json:"Mode,omitempty"`
+	Destinations    []string `protobuf:"bytes,5,rep,name=Destinations" json:"Destinations,omitempty"`
+	XXXUnrecognized []byte   `json:"-"`
 }
 
 func (m *CreateSubscriptionCommand) Reset()         { *m = CreateSubscriptionCommand{} }
@@ -1340,10 +1340,10 @@ var E_CreateSubscriptionCommand_Command = &proto.ExtensionDesc{
 }
 
 type DropSubscriptionCommand struct {
-	Name             *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	Database         *string `protobuf:"bytes,2,req,name=Database" json:"Database,omitempty"`
-	RetentionPolicy  *string `protobuf:"bytes,3,req,name=RetentionPolicy" json:"RetentionPolicy,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Name            *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	Database        *string `protobuf:"bytes,2,req,name=Database" json:"Database,omitempty"`
+	RetentionPolicy *string `protobuf:"bytes,3,req,name=RetentionPolicy" json:"RetentionPolicy,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *DropSubscriptionCommand) Reset()         { *m = DropSubscriptionCommand{} }
@@ -1380,9 +1380,9 @@ var E_DropSubscriptionCommand_Command = &proto.ExtensionDesc{
 }
 
 type RemovePeerCommand struct {
-	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	Addr             *string `protobuf:"bytes,2,req,name=Addr" json:"Addr,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	ID              *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	Addr            *string `protobuf:"bytes,2,req,name=Addr" json:"Addr,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *RemovePeerCommand) Reset()         { *m = RemovePeerCommand{} }
@@ -1412,10 +1412,10 @@ var E_RemovePeerCommand_Command = &proto.ExtensionDesc{
 }
 
 type Response struct {
-	OK               *bool   `protobuf:"varint,1,req,name=OK" json:"OK,omitempty"`
-	Error            *string `protobuf:"bytes,2,opt,name=Error" json:"Error,omitempty"`
-	Index            *uint64 `protobuf:"varint,3,opt,name=Index" json:"Index,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	OK              *bool   `protobuf:"varint,1,req,name=OK" json:"OK,omitempty"`
+	Error           *string `protobuf:"bytes,2,opt,name=Error" json:"Error,omitempty"`
+	Index           *uint64 `protobuf:"varint,3,opt,name=Index" json:"Index,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *Response) Reset()         { *m = Response{} }
@@ -1444,9 +1444,9 @@ func (m *Response) GetIndex() uint64 {
 }
 
 type ResponseHeader struct {
-	OK               *bool   `protobuf:"varint,1,req,name=OK" json:"OK,omitempty"`
-	Error            *string `protobuf:"bytes,2,opt,name=Error" json:"Error,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	OK              *bool   `protobuf:"varint,1,req,name=OK" json:"OK,omitempty"`
+	Error           *string `protobuf:"bytes,2,opt,name=Error" json:"Error,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *ResponseHeader) Reset()         { *m = ResponseHeader{} }
@@ -1468,8 +1468,8 @@ func (m *ResponseHeader) GetError() string {
 }
 
 type ErrorResponse struct {
-	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
+	Header          *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
+	XXXUnrecognized []byte          `json:"-"`
 }
 
 func (m *ErrorResponse) Reset()         { *m = ErrorResponse{} }
@@ -1484,10 +1484,10 @@ func (m *ErrorResponse) GetHeader() *ResponseHeader {
 }
 
 type FetchDataRequest struct {
-	Index            *uint64 `protobuf:"varint,1,req,name=Index" json:"Index,omitempty"`
-	Term             *uint64 `protobuf:"varint,2,req,name=Term" json:"Term,omitempty"`
-	Blocking         *bool   `protobuf:"varint,3,opt,name=Blocking,def=0" json:"Blocking,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Index           *uint64 `protobuf:"varint,1,req,name=Index" json:"Index,omitempty"`
+	Term            *uint64 `protobuf:"varint,2,req,name=Term" json:"Term,omitempty"`
+	Blocking        *bool   `protobuf:"varint,3,opt,name=Blocking,def=0" json:"Blocking,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *FetchDataRequest) Reset()         { *m = FetchDataRequest{} }
@@ -1518,11 +1518,11 @@ func (m *FetchDataRequest) GetBlocking() bool {
 }
 
 type FetchDataResponse struct {
-	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	Index            *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
-	Term             *uint64         `protobuf:"varint,3,req,name=Term" json:"Term,omitempty"`
-	Data             []byte          `protobuf:"bytes,4,opt,name=Data" json:"Data,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
+	Header          *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
+	Index           *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
+	Term            *uint64         `protobuf:"varint,3,req,name=Term" json:"Term,omitempty"`
+	Data            []byte          `protobuf:"bytes,4,opt,name=Data" json:"Data,omitempty"`
+	XXXUnrecognized []byte          `json:"-"`
 }
 
 func (m *FetchDataResponse) Reset()         { *m = FetchDataResponse{} }
@@ -1558,8 +1558,8 @@ func (m *FetchDataResponse) GetData() []byte {
 }
 
 type JoinRequest struct {
-	Addr             *string `protobuf:"bytes,1,req,name=Addr" json:"Addr,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Addr            *string `protobuf:"bytes,1,req,name=Addr" json:"Addr,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *JoinRequest) Reset()         { *m = JoinRequest{} }
@@ -1574,11 +1574,11 @@ func (m *JoinRequest) GetAddr() string {
 }
 
 type JoinResponse struct {
-	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	EnableRaft       *bool           `protobuf:"varint,2,opt,name=EnableRaft" json:"EnableRaft,omitempty"`
-	RaftNodes        []string        `protobuf:"bytes,3,rep,name=RaftNodes" json:"RaftNodes,omitempty"`
-	NodeID           *uint64         `protobuf:"varint,4,opt,name=NodeID" json:"NodeID,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
+	Header          *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
+	EnableRaft      *bool           `protobuf:"varint,2,opt,name=EnableRaft" json:"EnableRaft,omitempty"`
+	RaftNodes       []string        `protobuf:"bytes,3,rep,name=RaftNodes" json:"RaftNodes,omitempty"`
+	NodeID          *uint64         `protobuf:"varint,4,opt,name=NodeID" json:"NodeID,omitempty"`
+	XXXUnrecognized []byte          `json:"-"`
 }
 
 func (m *JoinResponse) Reset()         { *m = JoinResponse{} }
@@ -1614,9 +1614,9 @@ func (m *JoinResponse) GetNodeID() uint64 {
 }
 
 type PromoteRaftRequest struct {
-	Addr             *string  `protobuf:"bytes,1,req,name=Addr" json:"Addr,omitempty"`
-	RaftNodes        []string `protobuf:"bytes,2,rep,name=RaftNodes" json:"RaftNodes,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	Addr            *string  `protobuf:"bytes,1,req,name=Addr" json:"Addr,omitempty"`
+	RaftNodes       []string `protobuf:"bytes,2,rep,name=RaftNodes" json:"RaftNodes,omitempty"`
+	XXXUnrecognized []byte   `json:"-"`
 }
 
 func (m *PromoteRaftRequest) Reset()         { *m = PromoteRaftRequest{} }
@@ -1638,9 +1638,9 @@ func (m *PromoteRaftRequest) GetRaftNodes() []string {
 }
 
 type PromoteRaftResponse struct {
-	Header           *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
-	Success          *bool           `protobuf:"varint,2,opt,name=Success" json:"Success,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
+	Header          *ResponseHeader `protobuf:"bytes,1,req,name=Header" json:"Header,omitempty"`
+	Success         *bool           `protobuf:"varint,2,opt,name=Success" json:"Success,omitempty"`
+	XXXUnrecognized []byte          `json:"-"`
 }
 
 func (m *PromoteRaftResponse) Reset()         { *m = PromoteRaftResponse{} }

--- a/services/copier/internal/internal.pb.go
+++ b/services/copier/internal/internal.pb.go
@@ -24,8 +24,8 @@ var _ = fmt.Errorf
 var _ = math.Inf
 
 type Request struct {
-	ShardID          *uint64 `protobuf:"varint,1,req,name=ShardID" json:"ShardID,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	ShardID         *uint64 `protobuf:"varint,1,req,name=ShardID" json:"ShardID,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *Request) Reset()         { *m = Request{} }
@@ -40,8 +40,8 @@ func (m *Request) GetShardID() uint64 {
 }
 
 type Response struct {
-	Error            *string `protobuf:"bytes,1,opt,name=Error" json:"Error,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Error           *string `protobuf:"bytes,1,opt,name=Error" json:"Error,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *Response) Reset()         { *m = Response{} }

--- a/tsdb/internal/meta.pb.go
+++ b/tsdb/internal/meta.pb.go
@@ -25,21 +25,21 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-// Series is a top level protobuf message.
+// Series is a protobuf message type as set in internal/meta.proto
 type Series struct {
 	Key             *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
 	Tags            []*Tag  `protobuf:"bytes,2,rep,name=Tags" json:"Tags,omitempty"`
 	XXXUnrecognized []byte  `json:"-"`
 }
 
-// Reset method restores a protobuf struct to its zero state.
+// Reset *Series method restores the Series protobuf message to its zero state.
 func (m *Series) Reset()         { *m = Series{} }
 func (m *Series) String() string { return proto.CompactTextString(m) }
 
-// ProtoMessage is implemented by generated protocol buffer messages.
+// ProtoMessage *Series is implemented by generated Series protobuf messages.
 func (*Series) ProtoMessage() {}
 
-// GetKey returns the protobuf message key.
+// GetKey *Series returns the protobuf Series message key.
 func (m *Series) GetKey() string {
 	if m != nil && m.Key != nil {
 		return *m.Key
@@ -47,7 +47,7 @@ func (m *Series) GetKey() string {
 	return ""
 }
 
-// GetTags method returns the protobuf message tags
+// GetTags *Series method returns the protobuf Series message tags
 func (m *Series) GetTags() []*Tag {
 	if m != nil {
 		return m.Tags
@@ -55,16 +55,21 @@ func (m *Series) GetTags() []*Tag {
 	return nil
 }
 
+// Tag is a protobuf message type as set in internal/meta.proto.
 type Tag struct {
 	Key             *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
 	Value           *string `protobuf:"bytes,2,req,name=Value" json:"Value,omitempty"`
 	XXXUnrecognized []byte  `json:"-"`
 }
 
+// Reset *Tag method restores the Tag protobuf message to its zero state.
 func (m *Tag) Reset()         { *m = Tag{} }
 func (m *Tag) String() string { return proto.CompactTextString(m) }
-func (*Tag) ProtoMessage()    {}
 
+// ProtoMessage *Tag is implemented by generated Tag protobuf messages.
+func (*Tag) ProtoMessage() {}
+
+// GetKey *Tag returns the protobuf Tag message key.
 func (m *Tag) GetKey() string {
 	if m != nil && m.Key != nil {
 		return *m.Key
@@ -72,6 +77,7 @@ func (m *Tag) GetKey() string {
 	return ""
 }
 
+// GetValue *Tag returns the protobuf Tag Value.
 func (m *Tag) GetValue() string {
 	if m != nil && m.Value != nil {
 		return *m.Value
@@ -79,15 +85,20 @@ func (m *Tag) GetValue() string {
 	return ""
 }
 
+// MeasurementFields is a protobuf message type as set in internal/meta.proto.
 type MeasurementFields struct {
 	Fields          []*Field `protobuf:"bytes,1,rep,name=Fields" json:"Fields,omitempty"`
 	XXXUnrecognized []byte   `json:"-"`
 }
 
+// Reset *MeasurementFields restores the MeasurementFields protobuf message to its zero state.
 func (m *MeasurementFields) Reset()         { *m = MeasurementFields{} }
 func (m *MeasurementFields) String() string { return proto.CompactTextString(m) }
-func (*MeasurementFields) ProtoMessage()    {}
 
+// ProtoMessage *MeasurementFields is implemented by generated MeasurementFields protobuf messages.
+func (*MeasurementFields) ProtoMessage() {}
+
+// GetFields *MeasurementFields returns the protobuf MeasurementFields fields.
 func (m *MeasurementFields) GetFields() []*Field {
 	if m != nil {
 		return m.Fields
@@ -95,6 +106,7 @@ func (m *MeasurementFields) GetFields() []*Field {
 	return nil
 }
 
+// Field is a protobuf message type as set in internal/meta.proto
 type Field struct {
 	ID              *int32  `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
 	Name            *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
@@ -102,10 +114,14 @@ type Field struct {
 	XXXUnrecognized []byte  `json:"-"`
 }
 
+// Reset *Field restores the Field protobuf message to its zero state.
 func (m *Field) Reset()         { *m = Field{} }
 func (m *Field) String() string { return proto.CompactTextString(m) }
-func (*Field) ProtoMessage()    {}
 
+// ProtoMessage *Field is implemented by generated Field protobuf messages.
+func (*Field) ProtoMessage() {}
+
+// GetID *Field returns the protobuf Field message ID.
 func (m *Field) GetID() int32 {
 	if m != nil && m.ID != nil {
 		return *m.ID
@@ -113,6 +129,7 @@ func (m *Field) GetID() int32 {
 	return 0
 }
 
+// GetName *Field returns the protobuf Field message Name.
 func (m *Field) GetName() string {
 	if m != nil && m.Name != nil {
 		return *m.Name
@@ -120,6 +137,7 @@ func (m *Field) GetName() string {
 	return ""
 }
 
+// GetType *Field returns the protobuf Field message Type.
 func (m *Field) GetType() int32 {
 	if m != nil && m.Type != nil {
 		return *m.Type

--- a/tsdb/internal/meta.pb.go
+++ b/tsdb/internal/meta.pb.go
@@ -25,16 +25,21 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// Series is a top level protobuf message.
 type Series struct {
-	Key              *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
-	Tags             []*Tag  `protobuf:"bytes,2,rep,name=Tags" json:"Tags,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Key             *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
+	Tags            []*Tag  `protobuf:"bytes,2,rep,name=Tags" json:"Tags,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
+// Reset method restores a protobuf struct to its zero state.
 func (m *Series) Reset()         { *m = Series{} }
 func (m *Series) String() string { return proto.CompactTextString(m) }
-func (*Series) ProtoMessage()    {}
 
+// ProtoMessage is implemented by generated protocol buffer messages.
+func (*Series) ProtoMessage() {}
+
+// GetKey returns the protobuf message key.
 func (m *Series) GetKey() string {
 	if m != nil && m.Key != nil {
 		return *m.Key
@@ -42,6 +47,7 @@ func (m *Series) GetKey() string {
 	return ""
 }
 
+// GetTags method returns the protobuf message tags
 func (m *Series) GetTags() []*Tag {
 	if m != nil {
 		return m.Tags
@@ -50,9 +56,9 @@ func (m *Series) GetTags() []*Tag {
 }
 
 type Tag struct {
-	Key              *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
-	Value            *string `protobuf:"bytes,2,req,name=Value" json:"Value,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Key             *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
+	Value           *string `protobuf:"bytes,2,req,name=Value" json:"Value,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *Tag) Reset()         { *m = Tag{} }
@@ -74,8 +80,8 @@ func (m *Tag) GetValue() string {
 }
 
 type MeasurementFields struct {
-	Fields           []*Field `protobuf:"bytes,1,rep,name=Fields" json:"Fields,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	Fields          []*Field `protobuf:"bytes,1,rep,name=Fields" json:"Fields,omitempty"`
+	XXXUnrecognized []byte   `json:"-"`
 }
 
 func (m *MeasurementFields) Reset()         { *m = MeasurementFields{} }
@@ -90,10 +96,10 @@ func (m *MeasurementFields) GetFields() []*Field {
 }
 
 type Field struct {
-	ID               *int32  `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	Name             *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
-	Type             *int32  `protobuf:"varint,3,req,name=Type" json:"Type,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	ID              *int32  `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	Name            *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
+	Type            *int32  `protobuf:"varint,3,req,name=Type" json:"Type,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
 func (m *Field) Reset()         { *m = Field{} }


### PR DESCRIPTION
ISSUE #4098 

I combined the clean up for influxql and tsdb/internal to enable golint on this package. BUT whenever you run go generate for protobuf, it will overwrite the meta.pb.go file and overwrite these changes to again cause golint errors. 

Ran and passed all tests. 