### PR TITLE
enabled golint for tsdb/internal

### DIFF
--- a/tsdb/internal/meta.pb.go
+++ b/tsdb/internal/meta.pb.go
@@ -25,16 +25,21 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// Series is a protobuf message type as set in internal/meta.proto
 type Series struct {
-	Key              *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
-	Tags             []*Tag  `protobuf:"bytes,2,rep,name=Tags" json:"Tags,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Key             *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
+	Tags            []*Tag  `protobuf:"bytes,2,rep,name=Tags" json:"Tags,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
+// Reset *Series method restores the Series protobuf message to its zero state.
 func (m *Series) Reset()         { *m = Series{} }
 func (m *Series) String() string { return proto.CompactTextString(m) }
-func (*Series) ProtoMessage()    {}
 
+// ProtoMessage *Series is implemented by generated Series protobuf messages.
+func (*Series) ProtoMessage() {}
+
+// GetKey *Series returns the protobuf Series message key.
 func (m *Series) GetKey() string {
 	if m != nil && m.Key != nil {
 		return *m.Key
@@ -42,6 +47,7 @@ func (m *Series) GetKey() string {
 	return ""
 }
 
+// GetTags *Series method returns the protobuf Series message tags
 func (m *Series) GetTags() []*Tag {
 	if m != nil {
 		return m.Tags
@@ -49,16 +55,21 @@ func (m *Series) GetTags() []*Tag {
 	return nil
 }
 
+// Tag is a protobuf message type as set in internal/meta.proto.
 type Tag struct {
-	Key              *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
-	Value            *string `protobuf:"bytes,2,req,name=Value" json:"Value,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Key             *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
+	Value           *string `protobuf:"bytes,2,req,name=Value" json:"Value,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
+// Reset *Tag method restores the Tag protobuf message to its zero state.
 func (m *Tag) Reset()         { *m = Tag{} }
 func (m *Tag) String() string { return proto.CompactTextString(m) }
-func (*Tag) ProtoMessage()    {}
 
+// ProtoMessage *Tag is implemented by generated Tag protobuf messages.
+func (*Tag) ProtoMessage() {}
+
+// GetKey *Tag returns the protobuf Tag message key.
 func (m *Tag) GetKey() string {
 	if m != nil && m.Key != nil {
 		return *m.Key
@@ -66,6 +77,7 @@ func (m *Tag) GetKey() string {
 	return ""
 }
 
+// GetValue *Tag returns the protobuf Tag Value.
 func (m *Tag) GetValue() string {
 	if m != nil && m.Value != nil {
 		return *m.Value
@@ -73,15 +85,20 @@ func (m *Tag) GetValue() string {
 	return ""
 }
 
+// MeasurementFields is a protobuf message type as set in internal/meta.proto.
 type MeasurementFields struct {
-	Fields           []*Field `protobuf:"bytes,1,rep,name=Fields" json:"Fields,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	Fields          []*Field `protobuf:"bytes,1,rep,name=Fields" json:"Fields,omitempty"`
+	XXXUnrecognized []byte   `json:"-"`
 }
 
+// Reset *MeasurementFields restores the MeasurementFields protobuf message to its zero state.
 func (m *MeasurementFields) Reset()         { *m = MeasurementFields{} }
 func (m *MeasurementFields) String() string { return proto.CompactTextString(m) }
-func (*MeasurementFields) ProtoMessage()    {}
 
+// ProtoMessage *MeasurementFields is implemented by generated MeasurementFields protobuf messages.
+func (*MeasurementFields) ProtoMessage() {}
+
+// GetFields *MeasurementFields returns the protobuf MeasurementFields fields.
 func (m *MeasurementFields) GetFields() []*Field {
 	if m != nil {
 		return m.Fields
@@ -89,17 +106,22 @@ func (m *MeasurementFields) GetFields() []*Field {
 	return nil
 }
 
+// Field is a protobuf message type as set in internal/meta.proto
 type Field struct {
-	ID               *int32  `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	Name             *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
-	Type             *int32  `protobuf:"varint,3,req,name=Type" json:"Type,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	ID              *int32  `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	Name            *string `protobuf:"bytes,2,req,name=Name" json:"Name,omitempty"`
+	Type            *int32  `protobuf:"varint,3,req,name=Type" json:"Type,omitempty"`
+	XXXUnrecognized []byte  `json:"-"`
 }
 
+// Reset *Field restores the Field protobuf message to its zero state.
 func (m *Field) Reset()         { *m = Field{} }
 func (m *Field) String() string { return proto.CompactTextString(m) }
-func (*Field) ProtoMessage()    {}
 
+// ProtoMessage *Field is implemented by generated Field protobuf messages.
+func (*Field) ProtoMessage() {}
+
+// GetID *Field returns the protobuf Field message ID.
 func (m *Field) GetID() int32 {
 	if m != nil && m.ID != nil {
 		return *m.ID
@@ -107,6 +129,7 @@ func (m *Field) GetID() int32 {
 	return 0
 }
 
+// GetName *Field returns the protobuf Field message Name.
 func (m *Field) GetName() string {
 	if m != nil && m.Name != nil {
 		return *m.Name
@@ -114,6 +137,7 @@ func (m *Field) GetName() string {
 	return ""
 }
 
+// GetType *Field returns the protobuf Field message Type.
 func (m *Field) GetType() int32 {
 	if m != nil && m.Type != nil {
 		return *m.Type


### PR DESCRIPTION
Sorry for the duplicate pull request. Enable Golint for tsdb/internal. However, when go generate is run for protobuf, it will overwrite this meta.pb.go file.