### PR TITLE
Remove double read-lock in meta client

### DIFF
--- a/services/continuous_querier/service_test.go
+++ b/services/continuous_querier/service_test.go
@@ -173,10 +173,10 @@ func TestContinuousQueryService_ResampleOptions(t *testing.T) {
 
 func TestContinuousQueryService_EveryHigherThanInterval(t *testing.T) {
 	s := NewTestService(t)
-	ms := NewMetaStore(t)
+	ms := NewMetaClient(t)
 	ms.CreateDatabase("db", "")
 	ms.CreateContinuousQuery("db", "cq", `CREATE CONTINUOUS QUERY cq ON db RESAMPLE EVERY 1m BEGIN SELECT mean(value) INTO cpu_mean FROM cpu GROUP BY time(30s) END`)
-	s.MetaStore = ms
+	s.MetaClient = ms
 
 	// Set RunInterval high so we can trigger using Run method.
 	s.RunInterval = 10 * time.Minute

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -398,9 +398,6 @@ func (c *Client) CreateRetentionPolicy(database string, rpi *RetentionPolicyInfo
 
 // RetentionPolicy returns the requested retention policy info.
 func (c *Client) RetentionPolicy(database, name string) (rpi *RetentionPolicyInfo, err error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	db, err := c.Database(database)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a possible fix for #5437.

`meta.Client.RetentionPolicy` acquired a read-lock and
then called `Database` which called `data()` which acquired a read-lock again.
If a write lock was taken between these two read-locks (likely by Authenticate),
the write-lock would block, and the second read-lock would also block
causing a dead-lock.

@dgnorton @corylanou 

