### PR TITLE
Reduce lock contention in engine.WritePoints

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -141,13 +141,15 @@ func (c *Cache) Snapshot() *Cache {
 	c.snapshots = append(c.snapshots, snapshot)
 	c.snapshotsSize += snapshot.size
 
-	// sort the snapshot before returning it. The compactor and any queries
-	// coming in while it writes will need the values sorted
-	for _, e := range snapshot.store {
+	return snapshot
+}
+
+// Deduplicate sorts the snapshot before returning it. The compactor and any queries
+// coming in while it writes will need the values sorted
+func (c *Cache) Deduplicate() {
+	for _, e := range c.store {
 		e.deduplicate()
 	}
-
-	return snapshot
 }
 
 // ClearSnapshot will remove the snapshot cache from the list of flushing caches and

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -411,6 +411,11 @@ func (e *Engine) WriteSnapshot() error {
 		return err
 	}
 
+	// The snapshotted cache may have duplicate points and unsorted data.  We need to deduplicate
+	// it before writing the snapshot.  This can be very expensive so it's done while we are not
+	// holding the engine write lock.
+	snapshot.Deduplicate()
+
 	return e.writeSnapshotAndCommit(closedFiles, snapshot, compactor)
 }
 


### PR DESCRIPTION
Writing the snapshot would deduplicate the snapshot points
while still holding the engine write-lock.  This can be expensive
under high load and cause writes to back up and OOM the server.

Instead, grab the snapshot under the lock and dedup it after releasing
the lock.

Possible fix for #5442