### PR TITLE
Use a bounded pool for remote writes

### DIFF
--- a/cluster/config.go
+++ b/cluster/config.go
@@ -15,21 +15,27 @@ const (
 
 	// DefaultShardMapperTimeout is the default timeout set on shard mappers.
 	DefaultShardMapperTimeout = 5 * time.Second
+
+	// DefaultMaxRemoteWriteConnections is the maximum number of open connections
+	// that will be available for remote writes to another host.
+	DefaultMaxRemoteWriteConnections = 3
 )
 
 // Config represents the configuration for the clustering service.
 type Config struct {
-	ForceRemoteShardMapping bool          `toml:"force-remote-mapping"`
-	WriteTimeout            toml.Duration `toml:"write-timeout"`
-	ShardWriterTimeout      toml.Duration `toml:"shard-writer-timeout"`
-	ShardMapperTimeout      toml.Duration `toml:"shard-mapper-timeout"`
+	ForceRemoteShardMapping   bool          `toml:"force-remote-mapping"`
+	WriteTimeout              toml.Duration `toml:"write-timeout"`
+	ShardWriterTimeout        toml.Duration `toml:"shard-writer-timeout"`
+	MaxRemoteWriteConnections int           `toml:"max-remote-write-connections"`
+	ShardMapperTimeout        toml.Duration `toml:"shard-mapper-timeout"`
 }
 
 // NewConfig returns an instance of Config with defaults.
 func NewConfig() Config {
 	return Config{
-		WriteTimeout:       toml.Duration(DefaultWriteTimeout),
-		ShardWriterTimeout: toml.Duration(DefaultShardWriterTimeout),
-		ShardMapperTimeout: toml.Duration(DefaultShardMapperTimeout),
+		WriteTimeout:              toml.Duration(DefaultWriteTimeout),
+		ShardWriterTimeout:        toml.Duration(DefaultShardWriterTimeout),
+		ShardMapperTimeout:        toml.Duration(DefaultShardMapperTimeout),
+		MaxRemoteWriteConnections: DefaultMaxRemoteWriteConnections,
 	}
 }

--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -334,6 +334,10 @@ func (w *PointsWriter) writeToShard(shard *meta.ShardInfo, database, retentionPo
 				// The remote write failed so queue it via hinted handoff
 				w.statMap.Add(statWritePointReqHH, int64(len(points)))
 				hherr := w.HintedHandoff.WriteShard(shardID, owner.NodeID, points)
+				if hherr != nil {
+					ch <- &AsyncWriteResult{owner, hherr}
+					return
+				}
 
 				// If the write consistency level is ANY, then a successful hinted handoff can
 				// be considered a successful write so send nil to the response channel

--- a/cluster/pool.go
+++ b/cluster/pool.go
@@ -1,0 +1,188 @@
+package cluster
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"gopkg.in/fatih/pool.v2"
+)
+
+// boundedPool implements the Pool interface based on buffered channels.
+type boundedPool struct {
+	// storage for our net.Conn connections
+	mu    sync.Mutex
+	conns chan net.Conn
+
+	timeout time.Duration
+	total   int32
+	// net.Conn generator
+	factory Factory
+}
+
+// Factory is a function to create new connections.
+type Factory func() (net.Conn, error)
+
+// NewBoundedPool returns a new pool based on buffered channels with an initial
+// capacity, maximum capacity and timeout to wait for a connection from the pool.
+// Factory is used when initial capacity is
+// greater than zero to fill the pool. A zero initialCap doesn't fill the Pool
+// until a new Get() is called. During a Get(), If there is no new connection
+// available in the pool and total connections is less than the max, a new connection
+// will be created via the Factory() method.  Othewise, the call will block until
+// a connection is available or the timeout is reached.
+func NewBoundedPool(initialCap, maxCap int, timeout time.Duration, factory Factory) (pool.Pool, error) {
+	if initialCap < 0 || maxCap <= 0 || initialCap > maxCap {
+		return nil, errors.New("invalid capacity settings")
+	}
+
+	c := &boundedPool{
+		conns:   make(chan net.Conn, maxCap),
+		factory: factory,
+		timeout: timeout,
+	}
+
+	// create initial connections, if something goes wrong,
+	// just close the pool error out.
+	for i := 0; i < initialCap; i++ {
+		conn, err := factory()
+		if err != nil {
+			c.Close()
+			return nil, fmt.Errorf("factory is not able to fill the pool: %s", err)
+		}
+		c.conns <- conn
+		atomic.AddInt32(&c.total, 1)
+	}
+
+	return c, nil
+}
+
+func (c *boundedPool) getConns() chan net.Conn {
+	c.mu.Lock()
+	conns := c.conns
+	c.mu.Unlock()
+	return conns
+}
+
+// Get implements the Pool interfaces Get() method. If there is no new
+// connection available in the pool, a new connection will be created via the
+// Factory() method.
+func (c *boundedPool) Get() (net.Conn, error) {
+	conns := c.getConns()
+	if conns == nil {
+		return nil, pool.ErrClosed
+	}
+
+	// Try and grab a connection from the pool
+	select {
+	case conn := <-conns:
+		if conn == nil {
+			return nil, pool.ErrClosed
+		}
+		return c.wrapConn(conn), nil
+	default:
+		// Could not get connection, can we create a new one?
+		if atomic.LoadInt32(&c.total) < int32(cap(conns)) {
+			conn, err := c.factory()
+			if err != nil {
+				return nil, err
+			}
+			atomic.AddInt32(&c.total, 1)
+
+			return c.wrapConn(conn), nil
+		}
+	}
+
+	// The pool was empty and we couldn't create a new one to
+	// retry until one is free or we timeout
+	select {
+	case conn := <-conns:
+		if conn == nil {
+			return nil, pool.ErrClosed
+		}
+		return c.wrapConn(conn), nil
+	case <-time.After(c.timeout):
+		return nil, fmt.Errorf("timed out waiting for free connection")
+	}
+
+}
+
+// put puts the connection back to the pool. If the pool is full or closed,
+// conn is simply closed. A nil conn will be rejected.
+func (c *boundedPool) put(conn net.Conn) error {
+	if conn == nil {
+		return errors.New("connection is nil. rejecting")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.conns == nil {
+		// pool is closed, close passed connection
+		return conn.Close()
+	}
+
+	// put the resource back into the pool. If the pool is full, this will
+	// block and the default case will be executed.
+	select {
+	case c.conns <- conn:
+		return nil
+	default:
+		// pool is full, close passed connection
+		return conn.Close()
+	}
+}
+
+func (c *boundedPool) Close() {
+	c.mu.Lock()
+	conns := c.conns
+	c.conns = nil
+	c.factory = nil
+	c.mu.Unlock()
+
+	if conns == nil {
+		return
+	}
+
+	close(conns)
+	for conn := range conns {
+		conn.Close()
+	}
+}
+
+func (c *boundedPool) Len() int { return len(c.getConns()) }
+
+// newConn wraps a standard net.Conn to a poolConn net.Conn.
+func (c *boundedPool) wrapConn(conn net.Conn) net.Conn {
+	p := &pooledConn{c: c}
+	p.Conn = conn
+	return p
+}
+
+// pooledConn is a wrapper around net.Conn to modify the the behavior of
+// net.Conn's Close() method.
+type pooledConn struct {
+	net.Conn
+	c        *boundedPool
+	unusable bool
+}
+
+// Close() puts the given connects back to the pool instead of closing it.
+func (p pooledConn) Close() error {
+	if p.unusable {
+		if p.Conn != nil {
+			return p.Conn.Close()
+		}
+		return nil
+	}
+	return p.c.put(p.Conn)
+}
+
+// MarkUnusable() marks the connection not usable any more, to let the pool close it instead of returning it to pool.
+func (p *pooledConn) MarkUnusable() {
+	p.unusable = true
+	atomic.AddInt32(&p.c.total, -1)
+}

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -87,6 +87,11 @@ func writeShardFail(shardID uint64, points []models.Point) error {
 	return fmt.Errorf("failed to write")
 }
 
+func writeShardSlow(shardID uint64, points []models.Point) error {
+	time.Sleep(1 * time.Second)
+	return nil
+}
+
 var responses = make(chan *serviceResponse, 1024)
 
 func (testService) ResponseN(n int) ([]*serviceResponse, error) {

--- a/cluster/shard_writer_test.go
+++ b/cluster/shard_writer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdb/influxdb/cluster"
 	"github.com/influxdb/influxdb/models"
+	"github.com/influxdb/influxdb/toml"
 )
 
 // Ensure the shard writer can successful write a single request.
@@ -22,7 +23,7 @@ func TestShardWriter_WriteShard_Success(t *testing.T) {
 	defer s.Close()
 	defer ts.Close()
 
-	w := cluster.NewShardWriter(time.Minute)
+	w := cluster.NewShardWriter(time.Minute, 1)
 	w.MetaClient = &metaClient{host: ts.ln.Addr().String()}
 
 	// Build a single point.
@@ -69,7 +70,7 @@ func TestShardWriter_WriteShard_Multiple(t *testing.T) {
 	defer s.Close()
 	defer ts.Close()
 
-	w := cluster.NewShardWriter(time.Minute)
+	w := cluster.NewShardWriter(time.Minute, 1)
 	w.MetaClient = &metaClient{host: ts.ln.Addr().String()}
 
 	// Build a single point.
@@ -118,7 +119,7 @@ func TestShardWriter_WriteShard_Error(t *testing.T) {
 	defer s.Close()
 	defer ts.Close()
 
-	w := cluster.NewShardWriter(time.Minute)
+	w := cluster.NewShardWriter(time.Minute, 1)
 	w.MetaClient = &metaClient{host: ts.ln.Addr().String()}
 	now := time.Now()
 
@@ -146,7 +147,7 @@ func TestShardWriter_Write_ErrDialTimeout(t *testing.T) {
 	defer s.Close()
 	defer ts.Close()
 
-	w := cluster.NewShardWriter(time.Nanosecond)
+	w := cluster.NewShardWriter(time.Nanosecond, 1)
 	w.MetaClient = &metaClient{host: ts.ln.Addr().String()}
 	now := time.Now()
 
@@ -169,7 +170,7 @@ func TestShardWriter_Write_ErrReadTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := cluster.NewShardWriter(time.Millisecond)
+	w := cluster.NewShardWriter(time.Millisecond, 1)
 	w.MetaClient = &metaClient{host: ln.Addr().String()}
 	now := time.Now()
 
@@ -182,5 +183,37 @@ func TestShardWriter_Write_ErrReadTimeout(t *testing.T) {
 
 	if err := w.WriteShard(shardID, ownerID, points); err == nil || !strings.Contains(err.Error(), "i/o timeout") {
 		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+// Ensure the shard writer returns an error when we can't get a connection.
+func TestShardWriter_Write_PoolMax(t *testing.T) {
+	ts := newTestWriteService(writeShardSlow)
+	s := cluster.NewService(cluster.Config{
+		ShardWriterTimeout: toml.Duration(100 * time.Millisecond),
+	})
+	s.Listener = ts.muxln
+	s.TSDBStore = ts
+	if err := s.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	defer ts.Close()
+
+	w := cluster.NewShardWriter(100*time.Millisecond, 1)
+	w.MetaClient = &metaClient{host: ts.ln.Addr().String()}
+	now := time.Now()
+
+	shardID := uint64(1)
+	ownerID := uint64(2)
+	var points []models.Point
+	points = append(points, models.MustNewPoint(
+		"cpu", models.Tags{"host": "server01"}, map[string]interface{}{"value": int64(100)}, now,
+	))
+
+	go w.WriteShard(shardID, ownerID, points)
+	time.Sleep(time.Millisecond)
+	if err := w.WriteShard(shardID, ownerID, points); err == nil || err.Error() != "timed out waiting for free connection" {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -185,7 +185,8 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 		s.QueryExecutor.QueryLogEnabled = c.Data.QueryLogEnabled
 
 		// Set the shard writer
-		s.ShardWriter = cluster.NewShardWriter(time.Duration(c.Cluster.ShardWriterTimeout))
+		s.ShardWriter = cluster.NewShardWriter(time.Duration(c.Cluster.ShardWriterTimeout),
+			c.Cluster.MaxRemoteWriteConnections)
 
 		// Create the hinted handoff service
 		s.HintedHandoff = hh.NewService(c.HintedHandoff, s.ShardWriter, s.MetaClient)


### PR DESCRIPTION
Under highly conncurrent write load, the coordinating node would
create a connection to any other node that is part of the replica
group.  Since each connection can be expensive, OOM sitations could
occur because there was no bounds on the number of new connections
that would be created.  If writes on a remote node were slow, connections
could pile up an exacerbate the problem.

This switches the pool to be bounded and has a checkout that is blocking
with a timeout.  If a connection is available, it's returned immediately.
If the pool still has room for more connections, it will create one if needed.

Otherwise, the call will block until a connection becomes available or
the timeout expires.  In the case of a timeout, it is propogated back up
to the PointsWriter that determine what do return to the client.

Fixes #5442 