### PR TITLE
tsm1 query performance improvements

### DIFF
--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -161,7 +161,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals = make([]Value, len(decoded))
 		}
 		for i := range decoded {
-			vals[i] = decoded[i]
+			vals[i] = &decoded[i]
 		}
 		return vals[:len(decoded)], err
 	case BlockInt64:
@@ -170,7 +170,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals = make([]Value, len(decoded))
 		}
 		for i := range decoded {
-			vals[i] = decoded[i]
+			vals[i] = &decoded[i]
 		}
 		return vals[:len(decoded)], err
 
@@ -180,7 +180,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals = make([]Value, len(decoded))
 		}
 		for i := range decoded {
-			vals[i] = decoded[i]
+			vals[i] = &decoded[i]
 		}
 		return vals[:len(decoded)], err
 
@@ -190,7 +190,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals = make([]Value, len(decoded))
 		}
 		for i := range decoded {
-			vals[i] = decoded[i]
+			vals[i] = &decoded[i]
 		}
 		return vals[:len(decoded)], err
 
@@ -202,7 +202,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 // Deduplicate returns a new Values slice with any values that have the same timestamp removed.
 // The Value that appears last in the slice is the one that is kept.
 func (a Values) Deduplicate() Values {
-	m := make(map[int64]Value)
+	m := make(map[int64]Value, len(a))
 	for _, val := range a {
 		m[val.UnixNano()] = val
 	}
@@ -285,7 +285,7 @@ func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 	return block, nil
 }
 
-func DecodeFloatBlock(block []byte, a []*FloatValue) ([]*FloatValue, error) {
+func DecodeFloatBlock(block []byte, a []FloatValue) ([]FloatValue, error) {
 	// Block type is the next block, make sure we actually have a float block
 	blockType := block[0]
 	if blockType != BlockFloat64 {
@@ -307,11 +307,11 @@ func DecodeFloatBlock(block []byte, a []*FloatValue) ([]*FloatValue, error) {
 	for dec.Next() && iter.Next() {
 		ts := dec.Read()
 		v := iter.Values()
-		if i < len(a) && a[i] != nil {
+		if i < len(a) {
 			a[i].time = ts
 			a[i].value = v
 		} else {
-			a = append(a, &FloatValue{ts, v})
+			a = append(a, FloatValue{ts, v})
 		}
 		i++
 	}
@@ -390,7 +390,7 @@ func encodeBoolBlock(buf []byte, values []Value) ([]byte, error) {
 	return block, nil
 }
 
-func DecodeBoolBlock(block []byte, a []*BoolValue) ([]*BoolValue, error) {
+func DecodeBoolBlock(block []byte, a []BoolValue) ([]BoolValue, error) {
 	// Block type is the next block, make sure we actually have a float block
 	blockType := block[0]
 	if blockType != BlockBool {
@@ -409,11 +409,11 @@ func DecodeBoolBlock(block []byte, a []*BoolValue) ([]*BoolValue, error) {
 	for dec.Next() && vdec.Next() {
 		ts := dec.Read()
 		v := vdec.Read()
-		if i < len(a) && a[i] != nil {
+		if i < len(a) {
 			a[i].time = ts
 			a[i].value = v
 		} else {
-			a = append(a, &BoolValue{ts, v})
+			a = append(a, BoolValue{ts, v})
 		}
 		i++
 	}
@@ -479,7 +479,7 @@ func encodeInt64Block(buf []byte, values []Value) ([]byte, error) {
 	return append(block, packBlock(tb, vb)...), nil
 }
 
-func DecodeInt64Block(block []byte, a []*Int64Value) ([]*Int64Value, error) {
+func DecodeInt64Block(block []byte, a []Int64Value) ([]Int64Value, error) {
 	blockType := block[0]
 	if blockType != BlockInt64 {
 		return nil, fmt.Errorf("invalid block type: exp %d, got %d", BlockInt64, blockType)
@@ -499,11 +499,11 @@ func DecodeInt64Block(block []byte, a []*Int64Value) ([]*Int64Value, error) {
 	for tsDec.Next() && vDec.Next() {
 		ts := tsDec.Read()
 		v := vDec.Read()
-		if i < len(a) && a[i] != nil {
+		if i < len(a) {
 			a[i].time = ts
 			a[i].value = v
 		} else {
-			a = append(a, &Int64Value{ts, v})
+			a = append(a, Int64Value{ts, v})
 		}
 		i++
 	}
@@ -569,7 +569,7 @@ func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
 	return append(block, packBlock(tb, vb)...), nil
 }
 
-func DecodeStringBlock(block []byte, a []*StringValue) ([]*StringValue, error) {
+func DecodeStringBlock(block []byte, a []StringValue) ([]StringValue, error) {
 	blockType := block[0]
 	if blockType != BlockString {
 		return nil, fmt.Errorf("invalid block type: exp %d, got %d", BlockString, blockType)
@@ -592,11 +592,11 @@ func DecodeStringBlock(block []byte, a []*StringValue) ([]*StringValue, error) {
 	for tsDec.Next() && vDec.Next() {
 		ts := tsDec.Read()
 		v := vDec.Read()
-		if i < len(a) && a[i] != nil {
+		if i < len(a) {
 			a[i].time = ts
 			a[i].value = v
 		} else {
-			a = append(a, &StringValue{ts, v})
+			a = append(a, StringValue{ts, v})
 		}
 		i++
 	}

--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -325,10 +325,7 @@ func BenchmarkDecodeBlock_Float_TypeSpecific(b *testing.B) {
 		b.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues := make([]*tsm1.FloatValue, len(values))
-	for i := 0; i < len(decodedValues); i++ {
-		decodedValues[i] = &tsm1.FloatValue{}
-	}
+	decodedValues := make([]tsm1.FloatValue, len(values))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err = tsm1.DecodeFloatBlock(bytes, decodedValues)
@@ -397,10 +394,7 @@ func BenchmarkDecodeBlock_Int64_TypeSpecific(b *testing.B) {
 		b.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues := make([]*tsm1.Int64Value, len(values))
-	for i := 0; i < len(decodedValues); i++ {
-		decodedValues[i] = &tsm1.Int64Value{}
-	}
+	decodedValues := make([]tsm1.Int64Value, len(values))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err = tsm1.DecodeInt64Block(bytes, decodedValues)
@@ -469,10 +463,7 @@ func BenchmarkDecodeBlock_Bool_TypeSpecific(b *testing.B) {
 		b.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues := make([]*tsm1.BoolValue, len(values))
-	for i := 0; i < len(decodedValues); i++ {
-		decodedValues[i] = &tsm1.BoolValue{}
-	}
+	decodedValues := make([]tsm1.BoolValue, len(values))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err = tsm1.DecodeBoolBlock(bytes, decodedValues)
@@ -541,10 +532,7 @@ func BenchmarkDecodeBlock_String_TypeSpecific(b *testing.B) {
 		b.Fatalf("unexpected error: %v", err)
 	}
 
-	decodedValues := make([]*tsm1.StringValue, len(values))
-	for i := 0; i < len(decodedValues); i++ {
-		decodedValues[i] = &tsm1.StringValue{}
-	}
+	decodedValues := make([]tsm1.StringValue, len(values))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, err = tsm1.DecodeStringBlock(bytes, decodedValues)


### PR DESCRIPTION
## Overview

This pull request fixes two query engine performance issues:

1. `DecodeFloatBlock()` decodes into a `[]FloatValue` instead of `[]*FloatValue`. This reduces the number of allocations significantly during decoding.

2. Reads all `MapInput` objects for a point at once instead of reseeking for each field. This was causing massive allocations for multi-field queries with `tsm1` because of how seeks work.


## Results

Running a query with multiple `mean()` calls over a `1h` time period and bucketed by minute previously took over `5m` to run. With this PR fix it takes `10s`.