### PR TITLE
Optimize remote writes

### DIFF
--- a/cluster/service.go
+++ b/cluster/service.go
@@ -188,7 +188,7 @@ func (s *Service) processWriteShardRequest(buf []byte) error {
 
 	points := req.Points()
 	s.statMap.Add(writeShardPointsReq, int64(len(points)))
-	err := s.TSDBStore.WriteToShard(req.ShardID(), req.Points())
+	err := s.TSDBStore.WriteToShard(req.ShardID(), points)
 
 	// We may have received a write for a shard that we don't have locally because the
 	// sending node may have just created the shard (via the metastore) and the write
@@ -211,7 +211,7 @@ func (s *Service) processWriteShardRequest(buf []byte) error {
 		if err != nil {
 			return err
 		}
-		return s.TSDBStore.WriteToShard(req.ShardID(), req.Points())
+		return s.TSDBStore.WriteToShard(req.ShardID(), points)
 	}
 
 	if err != nil {

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -26,17 +26,19 @@ func newEntry() *entry {
 func (e *entry) add(values []Value) {
 	// if there are existing values make sure they're all less than the first of
 	// the new values being added
-	l := len(e.values)
-	if l != 0 {
+	if len(e.values) == 0 {
+		e.values = values
+	} else {
+		l := len(e.values)
 		lastValTime := e.values[l-1].UnixNano()
 		if lastValTime >= values[0].UnixNano() {
 			e.needSort = true
 		}
+		e.values = append(e.values, values...)
 	}
-	e.values = append(e.values, values...)
 
 	// if there's only one value, we know it's sorted
-	if len(values) <= 1 {
+	if len(values) <= 1 || e.needSort {
 		return
 	}
 


### PR DESCRIPTION
This PR fixes some performance issues with the remote write path (used via cluster writes and hinted handoff).

* Switch remote write marshaling to use a faster method to avoid parsing the line protocol format again on the remote side.
* Avoid parsing the points multiple times on the receiving node.  The monitoring stats were inadvertently parsing the points again.
* Optimize the Cache entry.add a bit to reduce lock contention with adding points.

These changes help remote cluster writes keep up with the coordinating node and avoid queuing them to hinted handoff.