### PR TITLE
Backup node.json with metastore backup

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -230,6 +230,7 @@ func (s *Server) appendSnapshotterService() {
 	srv := snapshotter.NewService()
 	srv.TSDBStore = s.TSDBStore
 	srv.MetaClient = s.MetaClient
+	srv.Node = s.Node
 	s.Services = append(s.Services, srv)
 	s.SnapshotterService = srv
 }


### PR DESCRIPTION
This updates the backup to append the `node.json` to the metastore backup file.  On restore, the two parts are split out and used accordingly. The format is changed to:
```
[8 byte magic] [8b meta len] [n meta bytes] [8b node.json len] [n node bytes]
```

The 8 byte header is basic sanity check and allows for changes to the file in the future.