### PR TITLE
Packaging and Build Updates

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -63,4 +63,11 @@ elif [[ -f /etc/debian_version ]]; then
 	install_init
 	install_update_rcd
     fi
+elif [[ -f /etc/os-release ]]; then
+    source /etc/os-release
+    if [[ $ID = "amzn" ]]; then
+	# Amazon Linux logic
+	install_init
+	install_chkconfig
+    fi
 fi

--- a/scripts/post-uninstall.sh
+++ b/scripts/post-uninstall.sh
@@ -43,4 +43,14 @@ elif [[ -f /etc/lsb-release ]]; then
 	    disable_update_rcd
 	fi
     fi
+elif [[ -f /etc/os-release ]]; then
+    source /etc/os-release
+    if [[ $ID = "amzn" ]]; then
+	# Amazon Linux logic
+	if [[ "$1" = "0" ]]; then
+	    # InfluxDB is no longer installed, remove from init system
+	    rm -f /etc/default/influxdb
+	    disable_chkconfig
+	fi
+    fi
 fi


### PR DESCRIPTION
Updates to build script:
- Added ability to specify an S3 bucket path (`--bucket=bucket/folder1/folder2`, etc)
- Added package iteration to tar and zip outputs (in case of a pre-release)
- Modified build script to be more generic, so that updates to other TICK components are more streamlined
- Structured influxdb-specific content at the top of file for easier porting of features between other TICK-stack build scripts
- Removed `zip` as a valid package output
- Restructured `tar` package output to be a little more user-friendly (base directory is `influxdb-{VERSION}`, instead of the root packaging structure)

Updates to packaging:
- Added installation support for Amazon Linux
