### PR TITLE
Skip backup directories created by influx_tsm

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -310,6 +310,10 @@ func (s *Store) loadIndexes() error {
 			s.Logger.Printf("Skipping database dir: %s. Not a directory", db.Name())
 			continue
 		}
+		if strings.HasSuffix(db.Name(), ".bak") {
+			s.Logger.Printf("Skipping backup directory: %s", db.Name())
+			continue
+		}
 		s.databaseIndexes[db.Name()] = NewDatabaseIndex()
 	}
 	return nil


### PR DESCRIPTION
This should correct the behavior seen in #5469. The databases and backups were getting indexed separately, but once the shards are loaded, the backup file seemed to win and took precedence. Regardless, we shouldn't have been loading the backup directories anyway.