### PR TITLE
Update influx_tsm to use a backup directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#5262](https://github.com/influxdata/influxdb/issues/5262): Fix a panic when a tag value was empty.
 - [#5382](https://github.com/influxdata/influxdb/pull/5382): Fixes some escaping bugs with tag keys and values.
 - [#5349](https://github.com/influxdata/influxdb/issues/5349): Validate metadata blob for 'influxd backup'
+- [#5469](https://github.com/influxdata/influxdb/issues/5469): Conversion from bz1 to tsm doesn't work as described
 
 ## v0.9.6 [2015-12-09]
 

--- a/cmd/influx_tsm/tracker.go
+++ b/cmd/influx_tsm/tracker.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"path/filepath"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -66,7 +65,7 @@ func (t *tracker) Run() error {
 
 				start := time.Now()
 				log.Printf("Backup of databse '%v' started", db)
-				err := backupDatabase(filepath.Join(opts.DataPath, db))
+				err := backupDatabase(db)
 				if err != nil {
 					log.Fatalf("Backup of database %v failed: %v\n", db, err)
 				}


### PR DESCRIPTION
To prevent clobbering a database that a user might have named `foo.bak`, the conversion tool will now require that the backup directory be external to the data directory.