### PR TITLE
Fix two panics in the WAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [#5382](https://github.com/influxdata/influxdb/pull/5382): Fixes some escaping bugs with tag keys and values.
 - [#5349](https://github.com/influxdata/influxdb/issues/5349): Validate metadata blob for 'influxd backup'
 - [#5469](https://github.com/influxdata/influxdb/issues/5469): Conversion from bz1 to tsm doesn't work as described
+- [#5449](https://github.com/influxdata/influxdb/issues/5449): panic when dropping collectd points
 
 ## v0.9.6 [2015-12-09]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#5349](https://github.com/influxdata/influxdb/issues/5349): Validate metadata blob for 'influxd backup'
 - [#5469](https://github.com/influxdata/influxdb/issues/5469): Conversion from bz1 to tsm doesn't work as described
 - [#5449](https://github.com/influxdata/influxdb/issues/5449): panic when dropping collectd points
+- [#5455](https://github.com/influxdata/influxdb/issues/5455): panic: runtime error: slice bounds out of range when loading corrupted wal segment
 
 ## v0.9.6 [2015-12-09]
 

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -299,7 +299,7 @@ func (s *Service) UnmarshalCollectd(packet *gollectd.Packet) []models.Point {
 		p, err := models.NewPoint(name, tags, fields, timestamp)
 		// Drop invalid points
 		if err != nil {
-			s.Logger.Printf("Dropping point %v: %v", p.Name, err)
+			s.Logger.Printf("Dropping point %v: %v", name, err)
 			s.statMap.Add(statDroppedPointsInvalid, 1)
 			continue
 		}

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -493,6 +493,10 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 				}
 			case stringEntryType:
 				length := int(btou32(b[i : i+4]))
+				if i+length > int(uint32(len(b))) {
+					return fmt.Errorf("corrupted write wall entry")
+				}
+
 				i += 4
 				v := string(b[i : i+length])
 				i += length


### PR DESCRIPTION
* Fixes #5449 - a panic in collectd service when a dropped point would be logged but the actual logging statement triggered a nil pointer panic
* Fixes #5455 - a panic when loading a corrupted wal segment file where the length of a string field would cause a read past the end of the file due to a short write.  A error is returned now allowing the truncation to occur.