### PR TITLE
Ensure non-interactive mode returns appropriate exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [#5449](https://github.com/influxdata/influxdb/issues/5449): panic when dropping collectd points
 - [#5455](https://github.com/influxdata/influxdb/issues/5455): panic: runtime error: slice bounds out of range when loading corrupted wal segment
 - [#5478](https://github.com/influxdata/influxdb/issues/5478): panic: interface conversion: interface is float64, not int64
+- [#5475](https://github.com/influxdata/influxdb/issues/5475): Ensure appropriate exit code returned for non-interactive use of CLI.
 
 ## v0.9.6 [2015-12-09]
 


### PR DESCRIPTION
Fixes #5475.

`ParseCommand` now returns an error, instead of a `bool`. To indicate an empty command `ErrBlankCommand` is returned. In the case of non-interactive mode, errors from `ParseCommand` will result in a non-zero exit code.

Also some refactoring to the tests to improve coverage.