### PR TITLE
Fix vet error

### DIFF
--- a/tsdb/functions_test.go
+++ b/tsdb/functions_test.go
@@ -1028,7 +1028,7 @@ func TestGreaterThan(t *testing.T) {
 	} {
 		got := greaterThan(tt.a, tt.b)
 		if got != tt.expected {
-			t.Errorf("greaterThan failed for %#T(%[1]v) > %#T(%[2]v), got %v, expected %v.", tt.a, tt.b, got, tt.expected)
+			t.Errorf("greaterThan failed for %T(%[1]v) > %T(%[2]v), got %v, expected %v.", tt.a, tt.b, got, tt.expected)
 		}
 	}
 


### PR DESCRIPTION
Vet was failing with the following error:

```
tsdb/functions_test.go:1031: unrecognized printf flag for verb 'T': '#'
```