### PR TITLE
Remove JSON write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#4125](https://github.com/influxdata/influxdb/pull/4125): Admin UI: Fetch and display server version on connect. Thanks @alexiri!
 - [#5602](https://github.com/influxdata/influxdb/pull/5602): Simplify cluster startup for scripting and deployment
 - [#5666](https://github.com/influxdata/influxdb/pull/5666): Manage dependencies with gdm
+- [#5512](https://github.com/influxdata/influxdb/pull/5512): HTTP: Add config option to enable HTTP JSON write path which is now disabled by default.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -340,10 +340,39 @@ func TestServer_UserCommands(t *testing.T) {
 	}
 }
 
-// Ensure the server can create a single point via json protocol and read it back.
+// Ensure the server rejects a single point via json protocol by default.
 func TestServer_Write_JSON(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig(), "")
+	defer s.Close()
+
+	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify writing JSON points returns an error.
+	now := now()
+	res, err := s.Write("", "", fmt.Sprintf(`{"database" : "db0", "retentionPolicy" : "rp0", "points": [{"measurement": "cpu", "tags": {"host": "server02"},"fields": {"value": 1.0}}],"time":"%s"} `, now.Format(time.RFC3339Nano)), nil)
+	if err == nil {
+		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", ``, res)
+	} else if exp := `JSON write protocol has been deprecated`; !strings.Contains(err.Error(), exp) {
+		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, err.Error())
+	}
+
+	// Verify no data has been written.
+	if res, err := s.Query(`SELECT * FROM db0.rp0.cpu GROUP BY *`); err != nil {
+		t.Fatal(err)
+	} else if exp := `{"results":[{}]}`; exp != res {
+		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, res)
+	}
+}
+
+// Ensure the server can create a single point via json protocol and read it back.
+func TestServer_Write_JSON_Enabled(t *testing.T) {
+	t.Parallel()
+	c := NewConfig()
+	c.HTTPD.JSONWriteEnabled = true
+	s := OpenServer(c, "")
 	defer s.Close()
 
 	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	PprofEnabled     bool   `toml:"pprof-enabled"`
 	HTTPSEnabled     bool   `toml:"https-enabled"`
 	HTTPSCertificate string `toml:"https-certificate"`
+	JSONWriteEnabled bool   `toml:"json-write-enabled"`
 }
 
 // NewConfig returns a new Config with default settings.
@@ -20,5 +21,6 @@ func NewConfig() Config {
 		LogEnabled:       true,
 		HTTPSEnabled:     false,
 		HTTPSCertificate: "/etc/ssl/influxdb.pem",
+		JSONWriteEnabled: false,
 	}
 }

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -483,7 +483,7 @@ type Handler struct {
 func NewHandler(requireAuthentication bool) *Handler {
 	statMap := influxdb.NewStatistics("httpd", "httpd", nil)
 	h := &Handler{
-		Handler: httpd.NewHandler(requireAuthentication, true, false, statMap),
+		Handler: httpd.NewHandler(requireAuthentication, true, false, false, statMap),
 	}
 	h.Handler.MetaClient = &h.MetaClient
 	h.Handler.QueryExecutor = &h.QueryExecutor

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -60,6 +60,7 @@ func NewService(c Config) *Service {
 			c.AuthEnabled,
 			c.LogEnabled,
 			c.WriteTracing,
+			c.JSONWriteEnabled,
 			statMap,
 		),
 		Logger: log.New(os.Stderr, "[httpd] ", log.LstdFlags),


### PR DESCRIPTION
This PR adds a new config option to enable the previously deprecated JSON write path, leaving the line protocol as the only write format accepted by the HTTP service by default.

The JSON write protocol can still be enabled by setting the `json-write-enabled` option in the `[httpd]` section to `true` in the config file.

The plan is to completely remove the JSON write path in v0.12.