### PR TITLE
Return error if database is not found when calling (c *Client) Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [#5478](https://github.com/influxdata/influxdb/issues/5478): panic: interface conversion: interface is float64, not int64
 - [#5475](https://github.com/influxdata/influxdb/issues/5475): Ensure appropriate exit code returned for non-interactive use of CLI.
 - [#5479](https://github.com/influxdata/influxdb/issues/5479): Bringing up a node as a meta only node causes panic
+- [#5504](https://github.com/influxdata/influxdb/issues/5475): create retention policy on unexistant DB crash InfluxDB
 
 ## v0.9.6 [2015-12-09]
 

--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -378,6 +378,12 @@ func init() {
 				command: `DROP RETENTION POLICY rp1 ON mydatabase`,
 				exp:     `{"results":[{"error":"database not found: mydatabase"}]}`,
 			},
+			&Query{
+				name:    "Ensure retention policy for non existing db is not created",
+				command: `CREATE RETENTION POLICY rp0 ON nodb DURATION 1h REPLICATION 1`,
+				exp:     `{"results":[{"error":"database not found: nodb"}]}`,
+				once:    true,
+			},
 		},
 	}
 

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -305,6 +305,8 @@ func (c *Client) Database(name string) (*DatabaseInfo, error) {
 		}
 	}
 
+	// Can't throw ErrDatabaseNotExists here since it would require some major
+	// work around catching the error when needed. Should be revisited.
 	return nil, nil
 }
 
@@ -401,6 +403,11 @@ func (c *Client) RetentionPolicy(database, name string) (rpi *RetentionPolicyInf
 	db, err := c.Database(database)
 	if err != nil {
 		return nil, err
+	}
+
+	// TODO: This should not be handled here
+	if db == nil {
+		return nil, ErrDatabaseNotExists
 	}
 
 	return db.RetentionPolicy(name), nil

--- a/services/meta/errors.go
+++ b/services/meta/errors.go
@@ -39,6 +39,9 @@ var (
 	// ErrDatabaseExists is returned when creating an already existing database.
 	ErrDatabaseExists = errors.New("database already exists")
 
+	// ErrDatabaseNotExists is returned when operating on a not existing database.
+	ErrDatabaseNotExists = errors.New("database does not exist")
+
 	// ErrDatabaseNameRequired is returned when creating a database without a name.
 	ErrDatabaseNameRequired = errors.New("database name required")
 )


### PR DESCRIPTION
Instead of returning nil, nil in case of no DB being found return
errors.New("Database '%s' does not exist", name)
Fixes #5504