### PR TITLE
Ensure shards and engine are safely closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [#5479](https://github.com/influxdata/influxdb/issues/5479): Bringing up a node as a meta only node causes panic
 - [#5504](https://github.com/influxdata/influxdb/issues/5475): create retention policy on unexistant DB crash InfluxDB
 - [#5505](https://github.com/influxdata/influxdb/issues/5505): Clear authCache in meta.Client when password changes.
+- [#5244](https://github.com/influxdata/influxdb/issues/5244): panic: ensure it's safe to close engine multiple times.
 
 ## v0.9.6 [2015-12-09]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - [#5478](https://github.com/influxdata/influxdb/issues/5478): panic: interface conversion: interface is float64, not int64
 - [#5475](https://github.com/influxdata/influxdb/issues/5475): Ensure appropriate exit code returned for non-interactive use of CLI.
 - [#5479](https://github.com/influxdata/influxdb/issues/5479): Bringing up a node as a meta only node causes panic
-- [#5504](https://github.com/influxdata/influxdb/issues/5475): create retention policy on unexistant DB crash InfluxDB
+- [#5504](https://github.com/influxdata/influxdb/issues/5504): create retention policy on unexistant DB crash InfluxDB
 - [#5505](https://github.com/influxdata/influxdb/issues/5505): Clear authCache in meta.Client when password changes.
 - [#5244](https://github.com/influxdata/influxdb/issues/5244): panic: ensure it's safe to close engine multiple times.
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -141,8 +141,15 @@ func (e *Engine) Open() error {
 	return nil
 }
 
-// Close closes the engine.
+// Close closes the engine. Subsequent calls to Close are a nop.
 func (e *Engine) Close() error {
+	e.mu.RLock()
+	if e.done == nil {
+		e.mu.RUnlock()
+		return nil
+	}
+	e.mu.RUnlock()
+
 	// Shutdown goroutines and wait.
 	close(e.done)
 	e.wg.Wait()
@@ -150,6 +157,7 @@ func (e *Engine) Close() error {
 	// Lock now and close everything else down.
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	e.done = nil // Ensures that the channel will not be closed again.
 
 	if err := e.FileStore.Close(); err != nil {
 		return err

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -146,10 +146,15 @@ func (s *Shard) Close() error {
 }
 
 func (s *Shard) close() error {
-	if s.engine != nil {
-		return s.engine.Close()
+	if s.engine == nil {
+		return nil
 	}
-	return nil
+
+	err := s.engine.Close()
+	if err == nil {
+		s.engine = nil
+	}
+	return err
 }
 
 // DiskSize returns the size on disk of this shard


### PR DESCRIPTION
Hopefully fixes #5244.

I have a small query over `Engine.Close`. There are four receivers of the `done` channel. Three of them directly receive on the `done` channel and also are part of the engine's waitgroup, but one—the compactor—receives from a copy of the channel and is not in the waitgroup.

nilling the `e.done` channel after the waitgroup is done is safe for the first three, and since the compactor is using a copy of the channel, it's never going to attempt to receive from a nilled channel, so that's fine too. Just seemed a bit strange to me that the channel gets copied over to the compactor in the first place.