### PR TITLE
Remove top-level dir config option

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -98,7 +98,7 @@ func (cmd *Command) Run(args ...string) error {
 	// If we have a node ID, ignore the join argument
 	// We are not using the reference to this node var, just checking
 	// to see if we have a node ID on disk
-	if node, _ := influxdb.LoadNode(config.Meta.Dir, config.Meta.HTTPBindAddress); node == nil || node.ID == 0 {
+	if node, _ := influxdb.LoadNode(config.Meta.Dir, []string{config.Meta.HTTPBindAddress}); node == nil || node.ID == 0 {
 		if options.Join != "" {
 			config.Meta.JoinPeers = strings.Split(options.Join, ",")
 		}

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -60,8 +60,6 @@ type Config struct {
 	// Server reporting
 	ReportingDisabled bool `toml:"reporting-disabled"`
 
-	Dir string `toml:"dir"`
-
 	// BindAddress is the address that all TCP services use (Raft, Snapshot, Cluster, etc.)
 	BindAddress string `toml:"bind-address"`
 }

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -8,9 +8,6 @@
 # Change this option to true to disable reporting.
 reporting-disabled = false
 
-# directory where server ID and cluster metaservers information will be kept
-dir = "/var/lib/influxdb"
-
 # we'll try to get the hostname automatically, but if it the os returns something
 # that isn't resolvable by other servers in the cluster, use this option to
 # manually set the hostname

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -89,7 +89,7 @@ func NewConfig() *Config {
 }
 
 func (c *Config) Validate() error {
-	if c.Enabled && c.Dir == "" {
+	if c.Dir == "" {
 		return errors.New("Meta.Dir must be specified")
 	}
 	return nil


### PR DESCRIPTION
The top-level dir config option backup/restore if it's not "meta" as well as breaks upgrades from prior releases for some users.  This PR removes it and just requires a `[meta].Dir` to always be specified.

This also fixes an issue where starting a data only node would write its local meta server address to `node.json` even when it was not running.