### PR TITLE
update circle-test.sh to supress false error about removing container

### DIFF
--- a/circle-test.sh
+++ b/circle-test.sh
@@ -10,6 +10,8 @@ DIR=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 cd $DIR
 
 export OUTPUT_DIR="$CIRCLE_ARTIFACTS" 
+# Don't delete the container since CircleCI doesn't have permission to do so.
+export DOCKER_RM="false"
 
 # Get number of test environments.
 count=$(./test.sh count)

--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,9 @@ PARALLELISM=${PARALLELISM-1}
 # Set default timeout
 TIMEOUT=${TIMEOUT-480s}
 
+# Default to deleteing the container
+DOCKER_RM=${DOCKER_RM-true}
+
 # Update this value if you add a new test environment.
 ENV_COUNT=6
 
@@ -69,7 +72,7 @@ function run_test_docker {
     echo "Running test in docker $name with args $@"
 
     docker run \
-         --rm \
+         --rm=$DOCKER_RM \
          -v "$DIR:/root/go/src/github.com/influxdb/influxdb" \
          -e "INFLUXDB_DATA_ENGINE=$INFLUXDB_DATA_ENGINE" \
          -e "GORACE=$GORACE" \


### PR DESCRIPTION
This just suppresses the error that CircleCI always spits out when deleting the container.
We leave `test.sh` alone so that it will still try to clean up if someone if running the script locally etc.