### PR TITLE
[tsm1] Change timestamp from time.Time to unixnano

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#5226](https://github.com/influxdata/influxdb/pull/5226): b\*1 to tsm1 shard conversion tool.
 - [#5459](https://github.com/influxdata/influxdb/pull/5459): Create `/status` endpoint for health checks.
 - [#5460](https://github.com/influxdata/influxdb/pull/5460): Prevent exponential growth in CLI history. Thanks @sczk!
+- [#5522](https://github.com/influxdata/influxdb/pull/5522): Optimize tsm1 cache to reduce memory consumption and GC scan time.
 
 ### Bugfixes
 - [#5129](https://github.com/influxdata/influxdb/pull/5129): Ensure precision flag is respected by CLI. Thanks @e-dard

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -359,3 +359,13 @@ func mustMarshalEntry(entry WALEntry) (WalEntryType, []byte) {
 
 	return entry.Type(), snappy.Encode(b, b)
 }
+
+func BenchmarkCacheFloatEntries(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cache := NewCache(10000)
+		for j := 0; j < 10000; j++ {
+			v := NewValue(time.Unix(1, 0), float64(j))
+			cache.Write("test", []Value{v})
+		}
+	}
+}

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -37,15 +37,16 @@ type Value interface {
 }
 
 func NewValue(t time.Time, value interface{}) Value {
+	un := t.UnixNano()
 	switch v := value.(type) {
 	case int64:
-		return &Int64Value{time: t, value: v}
+		return &Int64Value{unixnano: un, value: v}
 	case float64:
-		return &FloatValue{unixnano: t.UnixNano(), value: v}
+		return &FloatValue{unixnano: un, value: v}
 	case bool:
-		return &BoolValue{time: t, value: v}
+		return &BoolValue{unixnano: un, value: v}
 	case string:
-		return &StringValue{time: t, value: v}
+		return &StringValue{unixnano: un, value: v}
 	}
 	return &EmptyValue{}
 }
@@ -329,12 +330,12 @@ func DecodeFloatBlock(block []byte, a []FloatValue) ([]FloatValue, error) {
 }
 
 type BoolValue struct {
-	time  time.Time
-	value bool
+	unixnano int64
+	value    bool
 }
 
 func (b *BoolValue) Time() time.Time {
-	return b.time
+	return time.Unix(0, b.unixnano)
 }
 
 func (b *BoolValue) Size() int {
@@ -342,7 +343,7 @@ func (b *BoolValue) Size() int {
 }
 
 func (b *BoolValue) UnixNano() int64 {
-	return b.time.UnixNano()
+	return b.unixnano
 }
 
 func (b *BoolValue) Value() interface{} {
@@ -410,10 +411,10 @@ func DecodeBoolBlock(block []byte, a []BoolValue) ([]BoolValue, error) {
 		ts := dec.Read()
 		v := vdec.Read()
 		if i < len(a) {
-			a[i].time = ts
+			a[i].unixnano = ts.UnixNano()
 			a[i].value = v
 		} else {
-			a = append(a, BoolValue{ts, v})
+			a = append(a, BoolValue{ts.UnixNano(), v})
 		}
 		i++
 	}
@@ -431,12 +432,12 @@ func DecodeBoolBlock(block []byte, a []BoolValue) ([]BoolValue, error) {
 }
 
 type Int64Value struct {
-	time  time.Time
-	value int64
+	unixnano int64
+	value    int64
 }
 
 func (v *Int64Value) Time() time.Time {
-	return v.time
+	return time.Unix(0, v.unixnano)
 }
 
 func (v *Int64Value) Value() interface{} {
@@ -444,7 +445,7 @@ func (v *Int64Value) Value() interface{} {
 }
 
 func (v *Int64Value) UnixNano() int64 {
-	return v.time.UnixNano()
+	return v.unixnano
 }
 
 func (v *Int64Value) Size() int {
@@ -500,10 +501,10 @@ func DecodeInt64Block(block []byte, a []Int64Value) ([]Int64Value, error) {
 		ts := tsDec.Read()
 		v := vDec.Read()
 		if i < len(a) {
-			a[i].time = ts
+			a[i].unixnano = ts.UnixNano()
 			a[i].value = v
 		} else {
-			a = append(a, Int64Value{ts, v})
+			a = append(a, Int64Value{ts.UnixNano(), v})
 		}
 		i++
 	}
@@ -521,12 +522,12 @@ func DecodeInt64Block(block []byte, a []Int64Value) ([]Int64Value, error) {
 }
 
 type StringValue struct {
-	time  time.Time
-	value string
+	unixnano int64
+	value    string
 }
 
 func (v *StringValue) Time() time.Time {
-	return v.time
+	return time.Unix(0, v.unixnano)
 }
 
 func (v *StringValue) Value() interface{} {
@@ -534,7 +535,7 @@ func (v *StringValue) Value() interface{} {
 }
 
 func (v *StringValue) UnixNano() int64 {
-	return v.time.UnixNano()
+	return v.unixnano
 }
 
 func (v *StringValue) Size() int {
@@ -593,10 +594,10 @@ func DecodeStringBlock(block []byte, a []StringValue) ([]StringValue, error) {
 		ts := tsDec.Read()
 		v := vDec.Read()
 		if i < len(a) {
-			a[i].time = ts
+			a[i].unixnano = ts.UnixNano()
 			a[i].value = v
 		} else {
-			a = append(a, StringValue{ts, v})
+			a = append(a, StringValue{ts.UnixNano(), v})
 		}
 		i++
 	}

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -41,7 +41,7 @@ func NewValue(t time.Time, value interface{}) Value {
 	case int64:
 		return &Int64Value{time: t, value: v}
 	case float64:
-		return &FloatValue{time: t, value: v}
+		return &FloatValue{unixnano: t.UnixNano(), value: v}
 	case bool:
 		return &BoolValue{time: t, value: v}
 	case string:
@@ -222,16 +222,16 @@ func (a Values) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a Values) Less(i, j int) bool { return a[i].Time().UnixNano() < a[j].Time().UnixNano() }
 
 type FloatValue struct {
-	time  time.Time
-	value float64
+	unixnano int64
+	value    float64
 }
 
 func (f *FloatValue) Time() time.Time {
-	return f.time
+	return time.Unix(0, f.unixnano)
 }
 
 func (f *FloatValue) UnixNano() int64 {
-	return f.time.UnixNano()
+	return f.unixnano
 }
 
 func (f *FloatValue) Value() interface{} {
@@ -308,10 +308,10 @@ func DecodeFloatBlock(block []byte, a []FloatValue) ([]FloatValue, error) {
 		ts := dec.Read()
 		v := iter.Values()
 		if i < len(a) {
-			a[i].time = ts
+			a[i].unixnano = ts.UnixNano()
 			a[i].value = v
 		} else {
-			a = append(a, FloatValue{ts, v})
+			a = append(a, FloatValue{ts.UnixNano(), v})
 		}
 		i++
 	}

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -463,7 +463,6 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 
 		for j := 0; j < nvals; j++ {
 			un := int64(btou64(b[i : i+8]))
-			t := time.Unix(0, un)
 			i += 8
 
 			switch typ {
@@ -478,14 +477,14 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 				v := int64(btou64(b[i : i+8]))
 				i += 8
 				if fv, ok := values[j].(*Int64Value); ok {
-					fv.time = t
+					fv.unixnano = un
 					fv.value = v
 				}
 			case boolEntryType:
 				v := b[i]
 				i += 1
 				if fv, ok := values[j].(*BoolValue); ok {
-					fv.time = t
+					fv.unixnano = un
 					if v == 1 {
 						fv.value = true
 					} else {
@@ -502,7 +501,7 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 				v := string(b[i : i+length])
 				i += length
 				if fv, ok := values[j].(*StringValue); ok {
-					fv.time = t
+					fv.unixnano = un
 					fv.value = v
 				}
 			default:

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -462,7 +462,8 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 		}
 
 		for j := 0; j < nvals; j++ {
-			t := time.Unix(0, int64(btou64(b[i:i+8])))
+			un := int64(btou64(b[i : i+8]))
+			t := time.Unix(0, un)
 			i += 8
 
 			switch typ {
@@ -470,7 +471,7 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 				v := math.Float64frombits((btou64(b[i : i+8])))
 				i += 8
 				if fv, ok := values[j].(*FloatValue); ok {
-					fv.time = t
+					fv.unixnano = un
 					fv.value = v
 				}
 			case int64EntryType:


### PR DESCRIPTION
time.Time contains timezone `loc *Location`.
Since tsm1.Cache holds a lot of values in heap, there are many pointers in heap.
This makes GC heavy.

```
before:
$ go test -run=xxx -bench=BenchmarkCache
PASS
BenchmarkCacheFloatEntries-4         300       4019495 ns/op

after:
$ go test -run=xxx -bench=BenchmarkCache
PASS
BenchmarkCacheFloatEntries-4         500       3720449 ns/op
```

related issues:
* golang/go#14189
* #5217 

---

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)