### PR TITLE
Remove custom binary-conversion functions

### DIFF
--- a/cmd/influx_inspect/info.go
+++ b/cmd/influx_inspect/info.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -88,28 +87,6 @@ func countSeries(tstore *tsdb.Store) int {
 		count += cnt
 	}
 	return count
-}
-
-func btou64(b []byte) uint64 {
-	return binary.BigEndian.Uint64(b)
-}
-
-// u64tob converts a uint64 into an 8-byte slice.
-func u64tob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
-}
-
-func btou32(b []byte) uint32 {
-	return binary.BigEndian.Uint32(b)
-}
-
-// u32tob converts a uint32 into an 4-byte slice.
-func u32tob(v uint32) []byte {
-	b := make([]byte, 4)
-	binary.BigEndian.PutUint32(b, v)
-	return b
 }
 
 // ShardIDs is a collection of UINT 64 that represent shard ids.

--- a/cmd/influx_inspect/tsm.go
+++ b/cmd/influx_inspect/tsm.go
@@ -201,12 +201,12 @@ func readIndex(f *os.File) (*tsmIndex, error) {
 	// Get the min time
 	f.Seek(-20, os.SEEK_END)
 	f.Read(b)
-	minTime := time.Unix(0, int64(btou64(b)))
+	minTime := time.Unix(0, int64(binary.BigEndian.Uint64(b)))
 
 	// Get max time
 	f.Seek(-12, os.SEEK_END)
 	f.Read(b)
-	maxTime := time.Unix(0, int64(btou64(b)))
+	maxTime := time.Unix(0, int64(binary.BigEndian.Uint64(b)))
 
 	// Figure out where the index starts
 	indexStart := stat.Size() - int64(seriesCount*12+20)
@@ -356,7 +356,7 @@ func cmdDumpTsm1(opts *tsdmDumpOpts) {
 		f.Seek(int64(i), 0)
 
 		f.Read(b)
-		id := btou64(b)
+		id := binary.BigEndian.Uint64(b)
 		f.Read(b[:4])
 		length := binary.BigEndian.Uint32(b[:4])
 		buf := make([]byte, length)
@@ -364,7 +364,7 @@ func cmdDumpTsm1(opts *tsdmDumpOpts) {
 
 		blockSize += int64(len(buf)) + 12
 
-		startTime := time.Unix(0, int64(btou64(buf[:8])))
+		startTime := time.Unix(0, int64(binary.BigEndian.Uint64(buf[:8])))
 		blockType := buf[8]
 
 		encoded := buf[9:]
@@ -544,7 +544,7 @@ func cmdDumpTsm1dev(opts *tsdmDumpOpts) {
 			f.Seek(int64(e.Offset), 0)
 			f.Read(b[:4])
 
-			chksum := btou32(b[:4])
+			chksum := binary.BigEndian.Uint32(b[:4])
 
 			buf := make([]byte, e.Size-4)
 			f.Read(buf)

--- a/cmd/influx_tsm/b1/reader.go
+++ b/cmd/influx_tsm/b1/reader.go
@@ -197,7 +197,9 @@ func newCursor(tx *bolt.Tx, series string, field string, dec *tsdb.FieldCodec) *
 
 // Seek moves the cursor to a position.
 func (c cursor) SeekTo(seek int64) {
-	k, v := c.cursor.Seek(u64tob(uint64(seek)))
+	var seekBytes [8]byte
+	binary.BigEndian.PutUint64(seekBytes[:], uint64(seek))
+	k, v := c.cursor.Seek(seekBytes[:])
 	c.keyBuf, c.valBuf = tsdb.DecodeKeyValue(c.field, c.dec, k, v)
 }
 
@@ -236,13 +238,3 @@ func (a cursors) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a cursors) Less(i, j int) bool {
 	return tsm1.SeriesFieldKey(a[i].series, a[i].field) < tsm1.SeriesFieldKey(a[j].series, a[j].field)
 }
-
-// u64tob converts a uint64 into an 8-byte slice.
-func u64tob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
-}
-
-// btou64 converts an 8-byte slice to a uint64.
-func btou64(b []byte) uint64 { return binary.BigEndian.Uint64(b) }

--- a/cmd/influx_tsm/tsdb/types.go
+++ b/cmd/influx_tsm/tsdb/types.go
@@ -98,7 +98,7 @@ func MeasurementFromSeriesKey(key string) string {
 // DecodeKeyValue decodes the key and value from bytes.
 func DecodeKeyValue(field string, dec *FieldCodec, k, v []byte) (int64, interface{}) {
 	// Convert key to a timestamp.
-	key := int64(btou64(k[0:8]))
+	key := int64(binary.BigEndian.Uint64(k[0:8]))
 
 	decValue, err := dec.DecodeByName(field, v)
 	if err != nil {
@@ -106,6 +106,3 @@ func DecodeKeyValue(field string, dec *FieldCodec, k, v []byte) (int64, interfac
 	}
 	return key, decValue
 }
-
-// btou64 converts an 8-byte slice into an uint64.
-func btou64(b []byte) uint64 { return binary.BigEndian.Uint64(b) }

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -233,7 +233,7 @@ func (cmd *Command) backupMetastore() error {
 			return err
 		}
 
-		magic := btou64(binData[:8])
+		magic := binary.BigEndian.Uint64(binData[:8])
 		if magic != snapshotter.BackupMagicHeader {
 			cmd.Logger.Println("Invalid metadata blob, ensure the metadata service is running (default port 8088)")
 			return errors.New("invalid metadata received")
@@ -364,8 +364,4 @@ func retentionAndShardFromPath(path string) (retention, shard string, err error)
 	}
 
 	return a[1], a[2], nil
-}
-
-func btou64(b []byte) uint64 {
-	return binary.BigEndian.Uint64(b)
 }

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -159,20 +159,20 @@ func (cmd *Command) unpackMeta() error {
 	var i int
 
 	// Make sure the file is actually a meta store backup file
-	magic := btou64(b[:8])
+	magic := binary.BigEndian.Uint64(b[:8])
 	if magic != snapshotter.BackupMagicHeader {
 		return fmt.Errorf("invalid metadata file")
 	}
 	i += 8
 
 	// Size of the meta store bytes
-	length := int(btou64(b[i : i+8]))
+	length := int(binary.BigEndian.Uint64(b[i : i+8]))
 	i += 8
 	metaBytes := b[i : i+length]
 	i += int(length)
 
 	// Size of the node.json bytes
-	length = int(btou64(b[i : i+8]))
+	length = int(binary.BigEndian.Uint64(b[i : i+8]))
 	i += 8
 	nodeBytes := b[i:]
 
@@ -401,14 +401,3 @@ func (ln *nopListener) Close() error {
 }
 
 func (ln *nopListener) Addr() net.Addr { return &net.TCPAddr{} }
-
-// u64tob converts a uint64 into an 8-byte slice.
-func u64tob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
-}
-
-func btou64(b []byte) uint64 {
-	return binary.BigEndian.Uint64(b)
-}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -2268,7 +2268,7 @@ func TestDropSeriesStatement_String(t *testing.T) {
 
 func BenchmarkParserParseStatement(b *testing.B) {
 	b.ReportAllocs()
-	s := `SELECT field FROM "series" WHERE value > 10`
+	s := `SELECT "field" FROM "series" WHERE value > 10`
 	for i := 0; i < b.N; i++ {
 		if stmt, err := influxql.NewParser(strings.NewReader(s)).ParseStatement(); err != nil {
 			b.Fatalf("unexpected error: %s", err)

--- a/services/hh/queue.go
+++ b/services/hh/queue.go
@@ -676,11 +676,13 @@ func (l *segment) readUint64() (uint64, error) {
 	if err := l.readBytes(b); err != nil {
 		return 0, err
 	}
-	return btou64(b), nil
+	return binary.BigEndian.Uint64(b), nil
 }
 
 func (l *segment) writeUint64(sz uint64) error {
-	return l.writeBytes(u64tob(sz))
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], sz)
+	return l.writeBytes(buf[:])
 }
 
 func (l *segment) writeBytes(b []byte) error {
@@ -705,14 +707,4 @@ func (l *segment) readBytes(b []byte) error {
 		return fmt.Errorf("bad read. exp %v, got %v", 0, n)
 	}
 	return nil
-}
-
-func u64tob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
-}
-
-func btou64(b []byte) uint64 {
-	return binary.BigEndian.Uint64(b)
 }

--- a/tsdb/cursor_test.go
+++ b/tsdb/cursor_test.go
@@ -2,7 +2,6 @@ package tsdb_test
 
 import (
 	"bytes"
-	"encoding/binary"
 	"math"
 	"math/rand"
 	"reflect"
@@ -513,10 +512,3 @@ type byteSlices [][]byte
 func (a byteSlices) Len() int           { return len(a) }
 func (a byteSlices) Less(i, j int) bool { return bytes.Compare(a[i], a[j]) == -1 }
 func (a byteSlices) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-
-// u64tob converts a uint64 into an 8-byte slice.
-func u64tob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
-}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1045,10 +1045,3 @@ func mustUnmarshalJSON(b []byte, v interface{}) {
 		panic("unmarshal: " + err.Error())
 	}
 }
-
-// u64tob converts a uint64 into an 8-byte slice.
-func u64tob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
-}


### PR DESCRIPTION
I didn't like the look of one of the utility functions I came across, so I went on a mission to purge its evil ways from our codebase. It was hiding allocations...

During the purge, I came across a few places where we were encoding things in a non-optimal manner, so I cleaned them up some in an attempt to reduce allocations and copying of data.

One of the cleanups was in the TSM WAL code, which probably caused the corrupt file seen in #5455. The old code can be perused to see more detail, but the short version is that a WAL entry with lots of long strings would get truncated, but on a per-key basis. That meant that one key would be shorted space, and the next key would be written in space that should be occupied by the length-prefixed strings... nasty edge case. The fix there was to traverse the entire entry, and all of it's values, and do one large allocation of the exact size required.

I was concerned about the performance impact, although I was optimistic it would improve. Here are my local benchmarks of the changes (only the interesting/significant ones):

```
benchmark                                    old ns/op      new ns/op      delta
BenchmarkWALSegmentWriter                    1528724        786889         -48.53%
BenchmarkIndirectIndex_UnmarshalBinary       3719743        2847992        -23.44%

benchmark                           old allocs     new allocs     delta
BenchmarkWALSegmentWriter           15019          5010           -66.64%
BenchmarkQueueAppend                11             9              -18.18%

benchmark                           old bytes     new bytes     delta
BenchmarkWALSegmentWriter           496923        224383        -54.85%
BenchmarkQueueAppend                109           94            -13.76%
```