### PR TITLE
Enable `golint` on the tsdb/engine/wal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#5541](https://github.com/influxdata/influxdb/pull/5541): Support for adding custom TLS Config for HTTP client.
 - [#4299](https://github.com/influxdata/influxdb/pull/4299): Reject uint64 Client.Point.Field values. Thanks @arussellsaw
+- [#5550](https://github.com/influxdata/influxdb/pull/5550): Enabled golint for tsdb/engine/wal.
 
 ### Bugfixes
 

--- a/tsdb/engine/wal/wal_test.go
+++ b/tsdb/engine/wal/wal_test.go
@@ -67,7 +67,7 @@ func TestWAL_WritePoints(t *testing.T) {
 	// ensure that we can close and re-open the log with points getting to the index
 	log.Close()
 
-	points := make([]map[string][][]byte, 0)
+	var points []map[string][][]byte
 	log.Index = &testIndexWriter{fn: func(pointsByKey map[string][][]byte, measurementFieldsToSave map[string]*tsdb.MeasurementFields, seriesToCreate []*tsdb.SeriesCreate) error {
 		points = append(points, pointsByKey)
 		return nil
@@ -169,7 +169,7 @@ func TestWAL_CorruptDataLengthSize(t *testing.T) {
 	f.Sync()
 	log.Close()
 
-	points := make([]map[string][][]byte, 0)
+	var points []map[string][][]byte
 	log.Index = &testIndexWriter{fn: func(pointsByKey map[string][][]byte, measurementFieldsToSave map[string]*tsdb.MeasurementFields, seriesToCreate []*tsdb.SeriesCreate) error {
 		points = append(points, pointsByKey)
 		return nil
@@ -248,7 +248,7 @@ func TestWAL_CorruptDataBlock(t *testing.T) {
 
 	log.Close()
 
-	points := make([]map[string][][]byte, 0)
+	var points []map[string][][]byte
 	log.Index = &testIndexWriter{fn: func(pointsByKey map[string][][]byte, measurementFieldsToSave map[string]*tsdb.MeasurementFields, seriesToCreate []*tsdb.SeriesCreate) error {
 		points = append(points, pointsByKey)
 		return nil
@@ -290,7 +290,7 @@ func TestWAL_CompactAfterTimeWithoutWrite(t *testing.T) {
 	defer log.Close()
 	defer os.RemoveAll(log.path)
 
-	points := make([]map[string][][]byte, 0)
+	var points []map[string][][]byte
 	log.Index = &testIndexWriter{fn: func(pointsByKey map[string][][]byte, measurementFieldsToSave map[string]*tsdb.MeasurementFields, seriesToCreate []*tsdb.SeriesCreate) error {
 		points = append(points, pointsByKey)
 		return nil


### PR DESCRIPTION
Cleaned up tsdb/engine/wal.go and wal_test.go to enable golint per issue #4098.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)