### PR TITLE
Adding conjoined-field-names for graphite templates

### DIFF
--- a/services/graphite/parser.go
+++ b/services/graphite/parser.go
@@ -237,6 +237,9 @@ func (t *template) Apply(line string) (string, map[string]string, string, error)
 				return "", nil, "", fmt.Errorf("'field' can only be used once in each template: %q", line)
 			}
 			field = fields[i]
+		} else if tag == "field*" {
+			field = strings.Join(fields[i:], "_")
+			break			
 		} else if tag == "measurement*" {
 			measurement = append(measurement, fields[i:]...)
 			break

--- a/services/graphite/parser_test.go
+++ b/services/graphite/parser_test.go
@@ -93,6 +93,13 @@ func TestTemplateApply(t *testing.T) {
 			measurement: "cpu.load",
 			tags:        map[string]string{"zone": "us-west"},
 		},
+		{
+			test:        "conjoined fields",
+			input:       "prod.us-west.server01.cpu.util.idle.percent",
+			template:    "env.zone.host.measurement.measurement.field*",
+			measurement: "cpu.util",
+			tags:        map[string]string{"env": "prod", "zone": "us-west", "host": "server01"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I've been working on moving several of my clients away from using Graphite recently, switching to InfluxDB and Telegraf.

One of these clients has 200+ microservices all sending metrics through StatsD to Graphite, so I'm looking for a way to drop Telegraf in (running the statsd-input) as a replacement, using templates to massage the metrics into InfluxDB with tags (rather than re-build and re-deploy all of these things to support tagged metrics).

> The feature added by this PR allows a compound "field" to be derived from any number of dotted strings at the end of the template (rather than just from one). This will result in a manageable number of measurements in the InfluxDB database (one for each microservice), with fields for each metric.

Consider this example:
**Input:**: "com.company.service.helloworld.handler.hellorequest.error"
**Template**: `com.company.* measurement.measurement.measurement.measurement.field*`

The result would be:
**Measurement**: `com_company_service_helloworld`
**Field**: `handler_hellorequest_error`

I realise there is also some work required for Telegraf to support this in conjunction with "timing" metrics.

Please let me know if you think this is crazy, or worth pursuing. Also, thanks for all the work on InfluxDB and Telegraf - these are really great tools!