### PR TITLE
Configurable precision on UDP services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#5459](https://github.com/influxdata/influxdb/pull/5459): Create `/status` endpoint for health checks.
 - [#5460](https://github.com/influxdata/influxdb/pull/5460): Prevent exponential growth in CLI history. Thanks @sczk!
 - [#5522](https://github.com/influxdata/influxdb/pull/5522): Optimize tsm1 cache to reduce memory consumption and GC scan time.
+- [#5565](https://github.com/influxdata/influxdb/pull/5565): Add configuration for time precision with UDP services. - @tpitale
 
 ### Bugfixes
 - [#5129](https://github.com/influxdata/influxdb/pull/5129): Ensure precision flag is respected by CLI. Thanks @e-dard

--- a/services/udp/config.go
+++ b/services/udp/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	BatchPending    int           `toml:"batch-pending"`
 	ReadBuffer      int           `toml:"read-buffer"`
 	BatchTimeout    toml.Duration `toml:"batch-timeout"`
-	Precision       string         `toml:"precision"`
+	Precision       string        `toml:"precision"`
 	UDPPayloadSize  int           `toml:"udp-payload-size"`
 }
 

--- a/services/udp/config.go
+++ b/services/udp/config.go
@@ -19,6 +19,9 @@ const (
 	// DefaultBatchTimeout is the default UDP batch timeout.
 	DefaultBatchTimeout = time.Second
 
+	// DefaultPrecision is the default time precision used for UDP services.
+	DefaultPrecision = "n"
+
 	// DefaultReadBuffer is the default buffer size for the UDP listener.
 	// Sets the size of the operating system's receive buffer associated with
 	// the UDP traffic. Keep in mind that the OS must be able
@@ -62,6 +65,7 @@ type Config struct {
 	BatchPending    int           `toml:"batch-pending"`
 	ReadBuffer      int           `toml:"read-buffer"`
 	BatchTimeout    toml.Duration `toml:"batch-timeout"`
+	Precision       string         `toml:"precision"`
 	UDPPayloadSize  int           `toml:"udp-payload-size"`
 }
 
@@ -80,6 +84,9 @@ func (c *Config) WithDefaults() *Config {
 	}
 	if d.BatchTimeout == 0 {
 		d.BatchTimeout = toml.Duration(DefaultBatchTimeout)
+	}
+	if d.Precision == "" {
+		d.Precision = DefaultPrecision
 	}
 	if d.ReadBuffer == 0 {
 		d.ReadBuffer = DefaultReadBuffer

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -180,7 +180,7 @@ func (s *Service) parser() {
 		case <-s.done:
 			return
 		case buf := <-s.parserChan:
-			points, err := models.ParsePoints(buf)
+			points, err := models.ParsePointsWithPrecision(buf, time.Now().UTC(), s.config.Precision)
 			if err != nil {
 				s.statMap.Add(statPointsParseFail, 1)
 				s.Logger.Printf("Failed to parse points: %s", err)


### PR DESCRIPTION
* pass configured precision string to point parsing
* add Precision configuration to UDP config
* default configured precision to match what it appears to be now (from ParsePoints)