### PR TITLE
Workaround for collectd problem

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -67,7 +67,7 @@ if [ -z "$FPM" ]; then
     FPM=`which fpm`
 fi
 
-GO_VERSION="go1.4.3"
+GO_VERSION="go1.5.3"
 GOPATH_INSTALL=
 BINS=(
     influxd
@@ -326,7 +326,7 @@ do
         ;;
 
     -w | --working-directory)
-	PACKAGES_ONLY="PACKAGES_ONLY"
+        PACKAGES_ONLY="PACKAGES_ONLY"
         WORKING_DIR="WORKING_DIR"
 	    shift
 	    ;;

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -299,7 +299,12 @@ func (s *Service) UnmarshalCollectd(packet *gollectd.Packet) []models.Point {
 		p, err := models.NewPoint(name, tags, fields, timestamp)
 		// Drop invalid points
 		if err != nil {
-			s.Logger.Printf("Dropping point %v: %v", name, err)
+			// I'm hitting a crash with name == nil. So I added this
+			// workaround to avoid it...
+			if &name != nil {
+				s.Logger.Printf("Dropping point %v: %v", name, err)
+			}
+			// Anyway, update the statistics of this...
 			s.statMap.Add(statDroppedPointsInvalid, 1)
 			continue
 		}


### PR DESCRIPTION
# Motivation
From some time now I had stumbled on a problem with the collectd listener, receiving some metric that crashed the whole influxdb backend due to &name == nil. My asset network runs a lot of different machines, which implies that not every collectd are on the same version number (and even not with the same plugins), although I keep them at least within the compatibility limits. I know that this may be partly responsible for the issue that I found.
In an attempt to make the code somewhat safer in this regard (I think that this multiple collectd versions situation may happen with others), I patched this workaround and had tested it for some time now (confirming that it's working properly) prior to send it as a PR.

## Commit message
This commit adds a workaround for an error found on the collectd service.go
code, where &name == nil crashed the whole influxdb backend. It also fixes a typo
on the indentation of package.sh and updates the Go version to use on package.sh
build script.