### PR TITLE
Fix typo from a rename

### DIFF
--- a/services/graphite/errors.go
+++ b/services/graphite/errors.go
@@ -2,13 +2,13 @@ package graphite
 
 import "fmt"
 
-// An UnsupposedValueError is returned when a parsed value is not
-// supposed.
-type UnsupposedValueError struct {
+// An UnsupportedValueError is returned when a parsed value is not
+// supported.
+type UnsupportedValueError struct {
 	Field string
 	Value float64
 }
 
-func (err *UnsupposedValueError) Error() string {
+func (err *UnsupportedValueError) Error() string {
 	return fmt.Sprintf(`field "%s" value: "%v" is unsupported`, err.Field, err.Value)
 }

--- a/services/graphite/parser.go
+++ b/services/graphite/parser.go
@@ -119,7 +119,7 @@ func (p *Parser) Parse(line string) (models.Point, error) {
 	}
 
 	if math.IsNaN(v) || math.IsInf(v, 0) {
-		return nil, &UnsupposedValueError{Field: fields[0], Value: v}
+		return nil, &UnsupportedValueError{Field: fields[0], Value: v}
 	}
 
 	fieldValues := map[string]interface{}{}

--- a/services/graphite/parser_test.go
+++ b/services/graphite/parser_test.go
@@ -229,7 +229,7 @@ func TestParseNaN(t *testing.T) {
 		t.Fatalf("expected error. got nil")
 	}
 
-	if _, ok := err.(*graphite.UnsupposedValueError); !ok {
+	if _, ok := err.(*graphite.UnsupportedValueError); !ok {
 		t.Fatalf("expected *graphite.ErrUnsupportedValue, got %v", reflect.TypeOf(err))
 	}
 }

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -333,7 +333,7 @@ func (s *Service) handleLine(line string) {
 	point, err := s.parser.Parse(line)
 	if err != nil {
 		switch err := err.(type) {
-		case *UnsupposedValueError:
+		case *UnsupportedValueError:
 			// Graphite ignores NaN values with no error.
 			if math.IsNaN(err.Value) {
 				s.statMap.Add(statPointsNaNFail, 1)


### PR DESCRIPTION
Made a typo before Christmas when renaming for `golint`.

/cc @jsternberg 