### PR TITLE
Add Block checksum validation and "influx_inspect verify" tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#3247](https://github.com/influxdata/influxdb/issues/3247): Implement derivatives across intervals for aggregate queries.
 - [#3166](https://github.com/influxdata/influxdb/issues/3166): Sort the series keys inside of a tag set so output is deterministic.
 - [#1856](https://github.com/influxdata/influxdb/issues/1856): Add `elapsed` function that returns the time delta between subsequent points.
+- [#5502](https://github.com/influxdata/influxdb/issues/5502): Add checksum verification to TSM inspect tool
 
 ### Bugfixes
 
@@ -44,6 +45,7 @@
 - [#6257](https://github.com/influxdata/influxdb/issues/6257): CreateShardGroup was incrementing meta data index even when it was idempotent.
 - [#6223](https://github.com/influxdata/influxdb/issues/6223): Failure to start/run on Windows. Thanks @mvadu
 - [#6229](https://github.com/influxdata/influxdb/issues/6229): Fixed aggregate queries with no GROUP BY to include the end time.
+
 
 ## v0.12.0 [2016-04-05]
 ### Release Notes

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -113,6 +113,23 @@ func main() {
 		opts.dumpBlocks = opts.dumpBlocks || dumpAll || opts.filterKey != ""
 		opts.dumpIndex = opts.dumpIndex || dumpAll || opts.filterKey != ""
 		cmdDumpTsm1dev(opts)
+	case "verify":
+		var path string
+		fs := flag.NewFlagSet("verify", flag.ExitOnError)
+		fs.StringVar(&path, "dir", os.Getenv("HOME")+"/.influxdb", "Root storage path. [$HOME/.influxdb]")
+
+		fs.Usage = func() {
+			println("Usage: influx_inspect verify [options]\n\n   verifies the the checksum of shards")
+			println()
+			println("Options:")
+			fs.PrintDefaults()
+		}
+
+		if err := fs.Parse(flag.Args()[1:]); err != nil {
+			fmt.Printf("%v", err)
+			os.Exit(1)
+		}
+		cmdVerify(path)
 	default:
 		flag.Usage()
 		os.Exit(1)

--- a/cmd/influx_inspect/verify.go
+++ b/cmd/influx_inspect/verify.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+)
+
+func cmdVerify(path string) {
+	dataPath := filepath.Join(path, "data")
+
+	brokenBlocks := 0
+	totalBlocks := 0
+
+	// No need to do this in a loop
+	ext := fmt.Sprintf(".%s", tsm1.TSMFileExtension)
+
+	// Get all TSM files by walking through the data dir
+	files := []string{}
+	err := filepath.Walk(dataPath, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == ext {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 16, 8, 0, '\t', 0)
+
+	// Verify the checksums of every block in every file
+	for _, f := range files {
+		file, err := os.OpenFile(f, os.O_RDONLY, 0600)
+		if err != nil {
+			fmt.Printf("%v", err)
+			os.Exit(1)
+		}
+
+		reader, err := tsm1.NewTSMReader(file)
+		if err != nil {
+			fmt.Printf("%v", err)
+			os.Exit(1)
+		}
+
+		blockItr := reader.BlockIterator()
+		brokenFileBlocks := 0
+		count := 0
+		for blockItr.Next() {
+			totalBlocks++
+			key, _, _, checksum, buf, err := blockItr.Read()
+			if err != nil {
+				brokenBlocks++
+				fmt.Fprintf(tw, "%s: could not get checksum for key %v block %d due to error: %q\n", f, key, count, err)
+			} else if expected := crc32.ChecksumIEEE(buf); checksum != expected {
+				brokenBlocks++
+				fmt.Fprintf(tw, "%s: got %d but expected %d for key %v, block %d\n", f, checksum, expected, key, count)
+			}
+			count++
+		}
+		if brokenFileBlocks == 0 {
+			fmt.Fprintf(tw, "%s: healthy\n", f)
+		}
+	}
+
+	fmt.Fprintf(tw, "Broken Blocks: %d / %d \n", brokenBlocks, totalBlocks)
+	tw.Flush()
+}

--- a/cmd/influx_inspect/verify.go
+++ b/cmd/influx_inspect/verify.go
@@ -6,11 +6,13 @@ import (
 	"os"
 	"path/filepath"
 	"text/tabwriter"
+	"time"
 
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
 
 func cmdVerify(path string) {
+	start := time.Now()
 	dataPath := filepath.Join(path, "data")
 
 	brokenBlocks := 0
@@ -44,7 +46,10 @@ func cmdVerify(path string) {
 			os.Exit(1)
 		}
 
-		reader, err := tsm1.NewTSMReader(file)
+		reader, err := tsm1.NewTSMReaderWithOptions(tsm1.TSMReaderOptions{
+			MMAPFile: file,
+		})
+
 		if err != nil {
 			fmt.Printf("%v", err)
 			os.Exit(1)
@@ -70,6 +75,6 @@ func cmdVerify(path string) {
 		}
 	}
 
-	fmt.Fprintf(tw, "Broken Blocks: %d / %d \n", brokenBlocks, totalBlocks)
+	fmt.Fprintf(tw, "Broken Blocks: %d / %d, in %vs\n", brokenBlocks, totalBlocks, time.Since(start).Seconds())
 	tw.Flush()
 }

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -697,7 +697,7 @@ func (k *tsmKeyIterator) Next() bool {
 		if v == nil {
 			iter := k.iterators[i]
 			if iter.Next() {
-				key, minTime, maxTime, b, err := iter.Read()
+				key, minTime, maxTime, _, b, err := iter.Read()
 				if err != nil {
 					k.err = err
 				}
@@ -712,7 +712,7 @@ func (k *tsmKeyIterator) Next() bool {
 				blockKey := key
 				for iter.PeekNext() == blockKey {
 					iter.Next()
-					key, minTime, maxTime, b, err := iter.Read()
+					key, minTime, maxTime, _, b, err := iter.Read()
 					if err != nil {
 						k.err = err
 					}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -505,7 +505,7 @@ func (f *FileStore) BlockCount(path string, idx int) int {
 					return 0
 				}
 			}
-			_, _, _, block, _ := iter.Read()
+			_, _, _, _, block, _ := iter.Read()
 			return BlockCount(block)
 		}
 	}

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -581,7 +581,7 @@ func TestBlockIterator_Single(t *testing.T) {
 	var count int
 	iter := r.BlockIterator()
 	for iter.Next() {
-		key, minTime, maxTime, buf, err := iter.Read()
+		key, minTime, maxTime, _, buf, err := iter.Read()
 
 		if err != nil {
 			t.Fatalf("unexpected error creating iterator: %v", err)
@@ -646,7 +646,7 @@ func TestBlockIterator_MultipleBlocks(t *testing.T) {
 	iter := r.BlockIterator()
 	var i int
 	for iter.Next() {
-		key, minTime, maxTime, buf, err := iter.Read()
+		key, minTime, maxTime, _, buf, err := iter.Read()
 
 		if err != nil {
 			t.Fatalf("unexpected error creating iterator: %v", err)
@@ -714,7 +714,7 @@ func TestBlockIterator_Sorted(t *testing.T) {
 	iter := r.BlockIterator()
 	var lastKey string
 	for iter.Next() {
-		key, _, _, buf, err := iter.Read()
+		key, _, _, _, buf, err := iter.Read()
 
 		if key < lastKey {
 			t.Fatalf("keys not sorted: got %v, last %v", key, lastKey)
@@ -806,7 +806,7 @@ func TestCompacted_NotFull(t *testing.T) {
 		t.Fatalf("expected next, got false")
 	}
 
-	_, _, _, block, err := iter.Read()
+	_, _, _, _, block, err := iter.Read()
 	if err != nil {
 		t.Fatalf("unexpected error reading block: %v", err)
 	}
@@ -976,6 +976,7 @@ func TestTSMReader_File_Read(t *testing.T) {
 		t.Fatalf("read values count mismatch: exp %v, got %v", exp, got)
 	}
 }
+
 func BenchmarkIndirectIndex_UnmarshalBinary(b *testing.B) {
 	index := tsm1.NewDirectIndex()
 	for i := 0; i < 100000; i++ {

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -471,7 +471,7 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 
 	iter := r.BlockIterator()
 	for iter.Next() {
-		key, minTime, maxTime, b, err := iter.Read()
+		key, minTime, maxTime, _, b, err := iter.Read()
 		if err != nil {
 			t.Fatalf("unexpected error reading block: %v", err)
 		}


### PR DESCRIPTION

Fixes #5502

Output is in the form of:
```
[Broken Block] ShardID: 3    File: /Users/seif/.influxdb/data/stress/default/3/000000001-000000001.tsm   Key: cpu,host=server-23136,location=us-west#!~#value    Block: min=2006-01-02 00:00:10 +0000 UTC max=2006-01-02 00:04:10 +0000 UTC ofs=1220899 siz=82
[Broken Block] ShardID: 3    File: /Users/seif/.influxdb/data/stress/default/3/000000001-000000001.tsm   Key: cpu,host=server-48876,location=us-west#!~#value    Block: min=2006-01-02 00:00:10 +0000 UTC max=2006-01-02 00:04:10 +0000 UTC ofs=3612460 siz=82
Broken Blocks: 2 / 100000
```