### PR TITLE
Fixes #5545

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#5594](https://github.com/influxdata/influxdb/pull/5594): Fix missing url params on lease redirect - @oldmantaiter
 - [#5376](https://github.com/influxdata/influxdb/pull/5376): Fix golint issues in models package. @nuss-justin
 - [#5535](https://github.com/influxdata/influxdb/pull/5535): Update README for referring to Collectd
+- [#5590](https://github.com/influxdata/influxdb/pull/5590): Fix panic when dropping subscription for unknown retention policy.
 
 ## v0.10.0 [2016-02-04]
 

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -574,8 +574,7 @@ func (data *Data) CreateSubscription(database, rp, name, mode string, destinatio
 	rpi, err := data.RetentionPolicy(database, rp)
 	if err != nil {
 		return err
-	}
-	if rpi == nil {
+	} else if rpi == nil {
 		return influxdb.ErrRetentionPolicyNotFound(rp)
 	}
 
@@ -601,6 +600,8 @@ func (data *Data) DropSubscription(database, rp, name string) error {
 	rpi, err := data.RetentionPolicy(database, rp)
 	if err != nil {
 		return err
+	} else if rpi == nil {
+		return influxdb.ErrRetentionPolicyNotFound(rp)
 	}
 
 	for i := range rpi.Subscriptions {

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -89,7 +89,7 @@ func (data *Data) setDataNode(nodeID uint64, host, tcpHost string) error {
 	return nil
 }
 
-// DeleteNode removes a node from the metadata.
+// DeleteDataNode removes a node from the metadata.
 func (data *Data) DeleteDataNode(id uint64) error {
 	// Node has to be larger than 0 to be real
 	if id == 0 {

--- a/services/meta/errors.go
+++ b/services/meta/errors.go
@@ -69,9 +69,6 @@ var (
 	// ErrReplicationFactorTooLow is returned when the replication factor is not in an
 	// acceptable range.
 	ErrReplicationFactorTooLow = errors.New("replication factor must be greater than 0")
-
-	// ErrRetentionPolicyNotFound is returned when an expected retention policy can't be found.
-	ErrRetentionPolicyNotFound = errors.New("retention policy not found")
 )
 
 var (

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -619,17 +619,6 @@ func TestMetaService_Subscriptions_Create(t *testing.T) {
 	if got != exp {
 		t.Fatalf("unexpected response.\n\ngot: %s\nexp: %s\n", exp, got)
 	}
-
-	// // Re-create a subscription
-	// if res := c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub1 ON db0."default"`)); res.Err != nil {
-	// 	t.Fatal(res.Err)
-	// }
-
-	// res = c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`))
-	// if res.Err != nil {
-	// 	t.Fatal(res.Err)
-	// }
-
 }
 
 func TestMetaService_Subscriptions_Show(t *testing.T) {
@@ -726,7 +715,7 @@ func TestMetaService_Subscriptions_Drop(t *testing.T) {
 	// DROP SUBSCRIPTION drops the subsciption if it can find it.
 	res = c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub0 ON db0."default"`))
 	if got := res.Err; got != nil {
-		t.Fatalf("got: %s, exp: %s", got.Error(), nil)
+		t.Fatalf("got: %s, exp: %v", got.Error(), nil)
 	}
 
 	if res = c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`)); res.Err != nil {
@@ -883,7 +872,7 @@ func TestMetaService_CommandAgainstNonLeader(t *testing.T) {
 
 	cfgs := make([]*meta.Config, 3)
 	srvs := make([]*testService, 3)
-	for i, _ := range cfgs {
+	for i := range cfgs {
 		c := newConfig()
 
 		cfgs[i] = c
@@ -926,7 +915,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 
 	cfgs := make([]*meta.Config, 3)
 	srvs := make([]*testService, 3)
-	for i, _ := range cfgs {
+	for i := range cfgs {
 		c := newConfig()
 
 		cfgs[i] = c
@@ -1208,18 +1197,18 @@ func TestMetaService_PersistClusterIDAfterRestart(t *testing.T) {
 	}
 	defer c.Close()
 
-	id_after := c.ClusterID()
-	if id_after == 0 {
+	idAfter := c.ClusterID()
+	if idAfter == 0 {
 		t.Fatal("cluster ID can't be zero")
-	} else if id_after != id {
-		t.Fatalf("cluster id not the same: %d, %d", id_after, id)
+	} else if idAfter != id {
+		t.Fatalf("cluster id not the same: %d, %d", idAfter, id)
 	}
 }
 
 func TestMetaService_Ping(t *testing.T) {
 	cfgs := make([]*meta.Config, 3)
 	srvs := make([]*testService, 3)
-	for i, _ := range cfgs {
+	for i := range cfgs {
 		c := newConfig()
 
 		cfgs[i] = c


### PR DESCRIPTION
Refactor out the `SUBSCRIPTION` tests for some better coverage and clarity. Ensure that a retention policy error will be returned if you attempt to drop a subscription on a policy that doesn't exist.

Removed `meta.ErrRetentionPolicyNotFound` since everything else uses `influxdb. ErrRetentionPolicyNotFound()`