### PR TITLE
Fix for lease redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - [#5182](https://github.com/influxdata/influxdb/pull/5182): Graphite: Fix an issue where the default template would be used instead of a more specific one. Thanks @flisky
 - [#5489](https://github.com/influxdata/influxdb/pull/5489): Fixes multiple issues causing tests to fail on windows. Thanks @runner-mei
+- [#5594](https://github.com/influxdata/influxdb/pull/5594): Fix missing url params on lease redirect - @oldmantaiter
 
 ## v0.10.0 [2016-02-04]
 

--- a/services/meta/handler.go
+++ b/services/meta/handler.go
@@ -309,6 +309,23 @@ func (h *handler) servePing(w http.ResponseWriter, r *http.Request) {
 
 // serveLease
 func (h *handler) serveLease(w http.ResponseWriter, r *http.Request) {
+	var name, nodeIDStr string
+	q := r.URL.Query()
+
+	// Get the requested lease name.
+	name = q.Get("name")
+	if name == "" {
+		http.Error(w, "lease name required", http.StatusBadRequest)
+		return
+	}
+
+	// Get the ID of the requesting node.
+	nodeIDStr = q.Get("nodeid")
+	if nodeIDStr == "" {
+		http.Error(w, "node ID required", http.StatusBadRequest)
+		return
+	}
+
 	// Redirect to leader if necessary.
 	leader := h.store.leaderHTTP()
 	if leader != h.s.httpAddr {
@@ -322,25 +339,11 @@ func (h *handler) serveLease(w http.ResponseWriter, r *http.Request) {
 			scheme = "https://"
 		}
 
-		leader = scheme + leader + "/lease"
+		leader = scheme + leader + "/lease?" + q.Encode()
 		http.Redirect(w, r, leader, http.StatusTemporaryRedirect)
 		return
 	}
 
-	q := r.URL.Query()
-
-	// Get the requested lease name.
-	name := q.Get("name")
-	if name == "" {
-		http.Error(w, "lease name required", http.StatusBadRequest)
-		return
-	}
-	// Get the ID of the requesting node.
-	nodeIDStr := q.Get("nodeid")
-	if name == "" {
-		http.Error(w, "node ID required", http.StatusBadRequest)
-		return
-	}
 	// Convert node ID to an int.
 	nodeID, err := strconv.ParseUint(nodeIDStr, 10, 64)
 	if err != nil {


### PR DESCRIPTION
Previously, the lease redirect was invalid causing anything relying
on a lease for execution (eg. continuous queries) to cease functioning.

The name/nodeid URL param parsing has been moved up to the top of the
handler so the options can be forwarded on to the real leader.

X-Github-Closes: #5592

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](http://influxdb.com/community/cla.html) (if not already signed)