### PR TITLE
Build script updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- [#5596](https://github.com/influxdata/influxdb/pull/5596): Build improvements for ARM architectures. Also removed `--goarm` and `--pkgarch` build flags.
 - [#5541](https://github.com/influxdata/influxdb/pull/5541): Client: Support for adding custom TLS Config for HTTP client.
 - [#4299](https://github.com/influxdata/influxdb/pull/4299): Client: Reject uint64 Client.Point.Field values. Thanks @arussellsaw
 - [#5550](https://github.com/influxdata/influxdb/pull/5550): Enabled golint for tsdb/engine/wal. @gabelev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,10 +139,10 @@ The binaries will be located in `$GOPATH/bin`. Please note that the InfluxDB bin
 To set the version and commit flags during the build pass the following to the **install** command:
 
 ```bash
--ldflags="-X main.version=$VERSION -X main.branch=$BRANCH -X main.commit=$COMMIT -X main.buildTime=$TIME"
+-ldflags="-X main.version=$VERSION -X main.branch=$BRANCH -X main.commit=$COMMIT"
 ```
 
-where `$VERSION` is the version, `$BRANCH` is the branch, `$COMMIT` is the git commit hash, and `$TIME` is the build timestamp.
+where `$VERSION` is the version, `$BRANCH` is the branch, and `$COMMIT` is the git commit hash.
 
 If you want to build packages, see `package.sh` help:
 ```bash

--- a/build.py
+++ b/build.py
@@ -129,7 +129,7 @@ def package_scripts(build_root):
 
 def run_generate():
     print "Running go generate to rebuild admin UI static filesystem..."
-    run("go generate services/admin")
+    run("go generate ./services/admin")
     return True
 
 ################
@@ -407,7 +407,7 @@ def build(version=None,
         if "arm" in arch:
             if arch == "armel":
                 build_command += "GOARM=5 "
-            elif arch == "armhf":
+            elif arch == "armhf" or arch == "arm":
                 build_command += "GOARM=6 "
             elif arch == "arm64":
                 build_command += "GOARM=arm64 "
@@ -465,7 +465,7 @@ def go_get(branch, update=False):
         run(get_command)
     print "Retrieving dependencies with `gdm`..."
     sys.stdout.flush()
-    run("gdm restore")
+    run("{}/bin/gdm restore".format(os.environ.get("GOPATH")))
 
 def generate_md5_from_file(path):
     m = hashlib.md5()

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -20,13 +20,16 @@ import (
 
 // These variables are populated via the Go linker.
 var (
-	version   = "0.9"
-	commit    string
-	branch    string
+	version string
+	commit  string
+	branch  string
 )
 
 func init() {
 	// If commit, branch, or build time are not set, make that clear.
+	if version == "" {
+		version = "unknown"
+	}
 	if commit == "" {
 		commit = "unknown"
 	}

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -23,7 +23,6 @@ var (
 	version   = "0.9"
 	commit    string
 	branch    string
-	buildTime string
 )
 
 func init() {
@@ -33,9 +32,6 @@ func init() {
 	}
 	if branch == "" {
 		branch = "unknown"
-	}
-	if buildTime == "" {
-		buildTime = "unknown"
 	}
 }
 
@@ -81,7 +77,6 @@ func (m *Main) Run(args ...string) error {
 		cmd.Version = version
 		cmd.Commit = commit
 		cmd.Branch = branch
-		cmd.BuildTime = buildTime
 
 		if err := cmd.Run(args...); err != nil {
 			return fmt.Errorf("run: %s", err)
@@ -193,7 +188,7 @@ func (cmd *VersionCommand) Run(args ...string) error {
 	}
 
 	// Print version info.
-	fmt.Fprintf(cmd.Stdout, "InfluxDB v%s (git: %s %s, built %s)\n", version, branch, commit, buildTime)
+	fmt.Fprintf(cmd.Stdout, "InfluxDB v%s (git: %s %s)\n", version, branch, commit)
 
 	return nil
 }

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -71,8 +71,8 @@ func (cmd *Command) Run(args ...string) error {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Mark start-up in log.
-	log.Printf("InfluxDB starting, version %s, branch %s, commit %s, built %s",
-		cmd.Version, cmd.Branch, cmd.Commit, cmd.BuildTime)
+	log.Printf("InfluxDB starting, version %s, branch %s, commit %s",
+		cmd.Version, cmd.Branch, cmd.Commit)
 	log.Printf("Go version %s, GOMAXPROCS set to %d", runtime.Version(), runtime.GOMAXPROCS(0))
 
 	// Write the PID file.


### PR DESCRIPTION
A few updates:
- Merged generalized changes from the Kapacitor build script
- Changing nightly versioning to use a tilde (`~`) over a dash (`-`), since a tilde is considered lower in value than a dash
- Adds a `--no-stash` option, which will cause the build to fail from un-committed changes
- Better handling of version tag (strips leading `v`, etc)
- Added better build and packaging logic for ARM architectures.
- Re-added Windows builds to the output.
- Removed buildTime linker flags from `influxd` to support reproducible builds.
- Removed default version string from `influxd` binary (previously set to 0.9).