### PR TITLE
Simplify cluster startup for scripting and deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#5419](https://github.com/influxdata/influxdb/pull/5419): Graphite: Support matching tags multiple times Thanks @m4ce
 - [#5598](https://github.com/influxdata/influxdb/pull/5598): Client: Add Ping to v2 client @PSUdaemon
 - [#4125](https://github.com/influxdata/influxdb/pull/4125): Admin UI: Fetch and display server version on connect. Thanks @alexiri!
+- [#5602](https://github.com/influxdata/influxdb/pull/5602): Simplify cluster startup for scripting and deployment
 
 ### Bugfixes
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/influxdata/influxdb"
 )
 
 const logo = `
@@ -95,13 +94,8 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("apply env config: %v", err)
 	}
 
-	// If we have a node ID, ignore the join argument
-	// We are not using the reference to this node var, just checking
-	// to see if we have a node ID on disk
-	if node, _ := influxdb.LoadNode(config.Meta.Dir, []string{config.Meta.HTTPBindAddress}); node == nil || node.ID == 0 {
-		if options.Join != "" {
-			config.Meta.JoinPeers = strings.Split(options.Join, ",")
-		}
+	if options.Join != "" {
+		config.Meta.JoinPeers = strings.Split(options.Join, ",")
 	}
 
 	// Validate the configuration.

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -655,7 +655,7 @@ func (s *Server) initializeMetaClient() error {
 	for {
 		n, err := s.MetaClient.CreateDataNode(s.httpAPIAddr, s.tcpAddr)
 		if err != nil {
-			println("Unable to create data node. retry...", err.Error())
+			log.Printf("Unable to create data node. retry in 1s: %s", err.Error())
 			time.Sleep(time.Second)
 			continue
 		}

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -133,6 +133,9 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 		return nil, fmt.Errorf("mkdir all: %s", err)
 	}
 
+	// 0.11 we no longer use peers.json.  Remove the file if we have one on disk.
+	os.RemoveAll(filepath.Join(c.Meta.Dir, "peers.json"))
+
 	// load the node information
 	metaAddresses := []string{nodeAddr}
 	if !c.Meta.Enabled {

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -655,17 +655,14 @@ func (s *Server) initializeMetaClient() error {
 	if err := s.MetaClient.Open(); err != nil {
 		return err
 	}
-	for {
-		n, err := s.MetaClient.CreateDataNode(s.httpAPIAddr, s.tcpAddr)
-		if err != nil {
-			log.Printf("Unable to create data node. retry in 1s: %s", err.Error())
-			time.Sleep(time.Second)
-			continue
-		}
-		s.Node.ID = n.ID
-
-		break
+	n, err := s.MetaClient.CreateDataNode(s.httpAPIAddr, s.tcpAddr)
+	for err != nil {
+		log.Printf("Unable to create data node. retry in 1s: %s", err.Error())
+		time.Sleep(time.Second)
+		n, err = s.MetaClient.CreateDataNode(s.httpAPIAddr, s.tcpAddr)
 	}
+	s.Node.ID = n.ID
+
 	metaNodes, err := s.MetaClient.MetaNodes()
 	if err != nil {
 		return err

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -843,7 +843,6 @@ func (c *Client) JoinMetaServer(httpAddr, tcpAddr string) error {
 		// Something failed, try the next node
 		currentServer++
 	}
-	return nil
 }
 
 func (c *Client) CreateMetaNode(httpAddr, tcpAddr string) (*NodeInfo, error) {

--- a/services/meta/raft_state.go
+++ b/services/meta/raft_state.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -159,6 +158,9 @@ func (r *raftState) logLeaderChanges() {
 }
 
 func (r *raftState) close() error {
+	if r == nil {
+		return nil
+	}
 	if r.closing != nil {
 		close(r.closing)
 	}
@@ -238,7 +240,7 @@ func (r *raftState) addPeer(addr string) error {
 func (r *raftState) removePeer(addr string) error {
 	// Only do this on the leader
 	if !r.isLeader() {
-		return errors.New("not the leader")
+		return raft.ErrNotLeader
 	}
 	if fut := r.raft.RemovePeer(addr); fut.Error() != nil {
 		return fut.Error()

--- a/services/meta/raft_state.go
+++ b/services/meta/raft_state.go
@@ -93,8 +93,8 @@ func (r *raftState) open(s *store, ln net.Listener, initializePeers []string) er
 		// Ensure we can always become the leader
 		config.DisableBootstrapAfterElect = false
 
-		// For single-node clusters, we can update the raft peers before we start the cluster
-		// just in case the hostname has changed.
+		// Make sure our peer address is here.  This happens with either a single node cluster
+		// or a node joining the cluster, as no one else has that information yet.
 		if !raft.PeerContained(peers, r.addr) {
 			if err := r.peerStore.SetPeers([]string{r.addr}); err != nil {
 				return err
@@ -189,7 +189,7 @@ func (r *raftState) close() error {
 
 // apply applies a serialized command to the raft log.
 func (r *raftState) apply(b []byte) error {
-	// Apply to raft log.`
+	// Apply to raft log.
 	f := r.raft.Apply(b, 0)
 	if err := f.Error(); err != nil {
 		return err

--- a/services/meta/raft_state.go
+++ b/services/meta/raft_state.go
@@ -325,14 +325,19 @@ func (l *raftLayer) Close() error { return l.ln.Close() }
 
 // peerStore is an in-memory implementation of raft.PeerStore
 type peerStore struct {
+	mu    sync.RWMutex
 	peers []string
 }
 
 func (m *peerStore) Peers() ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.peers, nil
 }
 
 func (m *peerStore) SetPeers(peers []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.peers = peers
 	return nil
 }

--- a/services/meta/service.go
+++ b/services/meta/service.go
@@ -110,9 +110,6 @@ func (s *Service) Open() error {
 
 	// Open the store
 	s.store = newStore(s.config, s.httpAddr, s.raftAddr)
-	if err := s.store.open(s.RaftListener); err != nil {
-		return err
-	}
 
 	handler := newHandler(s.config, s)
 	handler.logger = s.Logger
@@ -121,6 +118,11 @@ func (s *Service) Open() error {
 
 	// Begin listening for requests in a separate goroutine.
 	go s.serve()
+
+	if err := s.store.open(s.RaftListener); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -924,13 +924,14 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 	cfgs := make([]*meta.Config, 3)
 	srvs := make([]*testService, 3)
 	joinPeers := freePorts(len(cfgs))
+	raftPeers := freePorts(len(cfgs))
 
 	var swg sync.WaitGroup
 	swg.Add(len(cfgs))
 	for i, _ := range cfgs {
 		c := newConfig()
 		c.HTTPBindAddress = joinPeers[i]
-		c.BindAddress = "127.0.0.1:0"
+		c.BindAddress = raftPeers[i]
 		c.JoinPeers = joinPeers
 		cfgs[i] = c
 

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -788,10 +788,6 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 	cfg3.HTTPBindAddress = joinPeers[2]
 	cfg3.BindAddress = raftPeers[2]
 	defer os.RemoveAll(cfg3.Dir)
-	cfg4 := newConfig()
-	cfg4.HTTPBindAddress = joinPeers[3]
-	cfg4.BindAddress = raftPeers[3]
-	defer os.RemoveAll(cfg4.Dir)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -849,7 +845,11 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 		t.Fatalf("meta nodes wrong: %v", metaNodes)
 	}
 
-	cfg4.JoinPeers = []string{joinPeers[0], joinPeers[1], joinPeers[3]}
+	cfg4 := newConfig()
+	cfg4.HTTPBindAddress = freePort()
+	cfg4.BindAddress = freePort()
+	cfg4.JoinPeers = []string{joinPeers[0], joinPeers[1], cfg4.HTTPBindAddress}
+	defer os.RemoveAll(cfg4.Dir)
 	s4 := newService(cfg4)
 	if err := s4.Open(); err != nil {
 		t.Fatal(err.Error())

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -784,10 +784,6 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 	cfg2.HTTPBindAddress = joinPeers[1]
 	cfg2.BindAddress = raftPeers[1]
 	defer os.RemoveAll(cfg2.Dir)
-	cfg3 := newConfig()
-	cfg3.HTTPBindAddress = joinPeers[2]
-	cfg3.BindAddress = raftPeers[2]
-	defer os.RemoveAll(cfg3.Dir)
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -811,6 +807,13 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 	}()
 	defer s2.Close()
 	wg.Wait()
+
+	cfg3 := newConfig()
+	joinPeers[2] = freePort()
+	cfg3.HTTPBindAddress = joinPeers[2]
+	raftPeers[2] = freePort()
+	cfg3.BindAddress = raftPeers[2]
+	defer os.RemoveAll(cfg3.Dir)
 
 	cfg3.JoinPeers = joinPeers[0:3]
 	s3 := newService(cfg3)

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -118,21 +118,21 @@ func TestMetaService_Databases(t *testing.T) {
 	// Create two databases.
 	db, err := c.CreateDatabase("db0")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	} else if db.Name != "db0" {
 		t.Fatalf("db name wrong: %s", db.Name)
 	}
 
 	db, err = c.CreateDatabase("db1")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	} else if db.Name != "db1" {
 		t.Fatalf("db name wrong: %s", db.Name)
 	}
 
 	dbs, err := c.Databases()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	if len(dbs) != 2 {
 		t.Fatalf("expected 2 databases but got %d", len(dbs))
@@ -187,7 +187,7 @@ func TestMetaService_CreateRetentionPolicy(t *testing.T) {
 
 	db, err := c.Database("db0")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	} else if db.Name != "db0" {
 		t.Fatalf("db name wrong: %s", db.Name)
 	}
@@ -240,7 +240,7 @@ func TestMetaService_SetDefaultRetentionPolicy(t *testing.T) {
 
 	db, err := c.Database("db0")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	} else if db.Name != "db0" {
 		t.Fatalf("db name wrong: %s", db.Name)
 	}
@@ -276,7 +276,7 @@ func TestMetaService_DropRetentionPolicy(t *testing.T) {
 
 	db, err := c.Database("db0")
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	} else if db.Name != "db0" {
 		t.Fatalf("db name wrong: %s", db.Name)
 	}
@@ -669,7 +669,7 @@ func TestMetaService_Subscriptions_Drop(t *testing.T) {
 	// subscription is unknown.
 	res := c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION foo ON db0."default"`))
 	if got, exp := res.Err, meta.ErrSubscriptionNotFound; got.Error() != exp.Error() {
-		t.Fatalf("got: %s, exp: %s", got.Error(), exp)
+		t.Fatalf("got: %s, exp: %s", got, exp)
 	}
 
 	// Create a subscription.
@@ -681,20 +681,20 @@ func TestMetaService_Subscriptions_Drop(t *testing.T) {
 	// the database is unknown.
 	res = c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub0 ON foo."default"`))
 	if got, exp := res.Err, influxdb.ErrDatabaseNotFound("foo"); got.Error() != exp.Error() {
-		t.Fatalf("got: %s, exp: %s", got.Error(), exp)
+		t.Fatalf("got: %s, exp: %s", got, exp)
 	}
 
 	// DROP SUBSCRIPTION returns an influxdb.ErrRetentionPolicyNotFound
 	// when the retention policy is unknown.
 	res = c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub0 ON db0."foo_policy"`))
 	if got, exp := res.Err, influxdb.ErrRetentionPolicyNotFound("foo_policy"); got.Error() != exp.Error() {
-		t.Fatalf("got: %s, exp: %s", got.Error(), exp)
+		t.Fatalf("got: %s, exp: %s", got, exp)
 	}
 
 	// DROP SUBSCRIPTION drops the subsciption if it can find it.
 	res = c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub0 ON db0."default"`))
 	if got := res.Err; got != nil {
-		t.Fatalf("got: %s, exp: %v", got.Error(), nil)
+		t.Fatalf("got: %s, exp: %v", got, nil)
 	}
 
 	if res = c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`)); res.Err != nil {
@@ -719,7 +719,7 @@ func TestMetaService_Shards(t *testing.T) {
 	}
 
 	if _, err := c.CreateDataNode(exp.Host, exp.TCPHost); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	if _, err := c.CreateDatabase("db0"); err != nil {
@@ -792,7 +792,7 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := s1.Open(); err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		}
 	}()
 	defer s1.Close()
@@ -802,7 +802,7 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := s2.Open(); err != nil {
-			t.Fatal(err.Error())
+			t.Fatal(err)
 		}
 	}()
 	defer s2.Close()
@@ -818,13 +818,13 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 	cfg3.JoinPeers = joinPeers[0:3]
 	s3 := newService(cfg3)
 	if err := s3.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer s3.Close()
 
 	c1 := meta.NewClient(joinPeers[0:3], false)
 	if err := c1.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer c1.Close()
 
@@ -835,7 +835,7 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 
 	c := meta.NewClient([]string{s1.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer c.Close()
 
@@ -855,13 +855,13 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 	defer os.RemoveAll(cfg4.Dir)
 	s4 := newService(cfg4)
 	if err := s4.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer s4.Close()
 
 	c2 := meta.NewClient(cfg4.JoinPeers, false)
 	if err := c2.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer c2.Close()
 
@@ -894,7 +894,7 @@ func TestMetaService_CommandAgainstNonLeader(t *testing.T) {
 		go func(srv *testService) {
 			defer wg.Done()
 			if err := srv.Open(); err != nil {
-				t.Fatal(err.Error())
+				t.Fatal(err)
 			}
 		}(srvs[i])
 		defer srvs[i].Close()
@@ -905,7 +905,7 @@ func TestMetaService_CommandAgainstNonLeader(t *testing.T) {
 	for i := range cfgs {
 		c := meta.NewClient([]string{joinPeers[i]}, false)
 		if err := c.Open(); err != nil {
-			t.Fatal(err.Error())
+			t.Fatal(err)
 		}
 		defer c.Close()
 
@@ -919,7 +919,7 @@ func TestMetaService_CommandAgainstNonLeader(t *testing.T) {
 		}
 
 		if db, err := c.Database(fmt.Sprintf("foo%d", i)); db == nil || err != nil {
-			t.Fatalf("node %d: database foo wasn't created: %s", i, err.Error())
+			t.Fatalf("node %d: database foo wasn't created: %s", i, err)
 		}
 	}
 }
@@ -948,7 +948,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 			defer swg.Done()
 			if err := srv.Open(); err != nil {
 				t.Logf("opening server %d", i)
-				t.Fatal(err.Error())
+				t.Fatal(err)
 			}
 		}(i, srvs[i])
 
@@ -959,7 +959,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 
 	c := meta.NewClient(joinPeers, false)
 	if err := c.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer c.Close()
 
@@ -974,11 +974,11 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 	}
 
 	if db, err := c.Database("foo"); db == nil || err != nil {
-		t.Fatalf("database foo wasn't created: %s", err.Error())
+		t.Fatalf("database foo wasn't created: %s", err)
 	}
 
 	if err := srvs[0].Close(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	if _, err := c.CreateDatabase("bar"); err != nil {
@@ -986,14 +986,14 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 	}
 
 	if db, err := c.Database("bar"); db == nil || err != nil {
-		t.Fatalf("database bar wasn't created: %s", err.Error())
+		t.Fatalf("database bar wasn't created: %s", err)
 	}
 
 	if err := srvs[1].Close(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	if err := srvs[2].Close(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// give them a second to shut down
@@ -1027,7 +1027,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 	}
 
 	if db, err := c2.Database("bar"); db == nil || err != nil {
-		t.Fatalf("database bar wasn't created: %s", err.Error())
+		t.Fatalf("database bar wasn't created: %s", err)
 	}
 
 	if _, err := c2.CreateDatabase("asdf"); err != nil {
@@ -1035,7 +1035,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 	}
 
 	if db, err := c2.Database("asdf"); db == nil || err != nil {
-		t.Fatalf("database bar wasn't created: %s", err.Error())
+		t.Fatalf("database bar wasn't created: %s", err)
 	}
 }
 
@@ -1058,12 +1058,12 @@ func TestMetaService_NameChangeSingleNode(t *testing.T) {
 
 	c := meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer c.Close()
 
 	if _, err := c.CreateDatabase("foo"); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	s.Close()
@@ -1073,24 +1073,24 @@ func TestMetaService_NameChangeSingleNode(t *testing.T) {
 	cfg.HTTPBindAddress = "asdf" + ":" + strings.Split(s.HTTPAddr(), ":")[1]
 	s = newService(cfg)
 	if err := s.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer s.Close()
 
 	c2 := meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c2.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer c2.Close()
 
 	db, err := c2.Database("foo")
 	if db == nil || err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	nodes, err := c2.MetaNodes()
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	exp := []meta.NodeInfo{{ID: 1, Host: cfg.HTTPBindAddress, TCPHost: cfg.BindAddress}}
 
@@ -1116,7 +1116,7 @@ func TestMetaService_CreateDataNode(t *testing.T) {
 
 	n, err := c.CreateDataNode(exp.Host, exp.TCPHost)
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(n, exp) {
@@ -1125,7 +1125,7 @@ func TestMetaService_CreateDataNode(t *testing.T) {
 
 	nodes, err := c.DataNodes()
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(nodes, []meta.NodeInfo{*exp}) {
@@ -1149,7 +1149,7 @@ func TestMetaService_DropDataNode(t *testing.T) {
 
 	n, err := c.CreateDataNode(exp.Host, exp.TCPHost)
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(n, exp) {
@@ -1158,7 +1158,7 @@ func TestMetaService_DropDataNode(t *testing.T) {
 
 	nodes, err := c.DataNodes()
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(nodes, []meta.NodeInfo{*exp}) {
@@ -1166,11 +1166,11 @@ func TestMetaService_DropDataNode(t *testing.T) {
 	}
 
 	if _, err := c.CreateDatabase("foo"); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	sg, err := c.CreateShardGroup("foo", "default", time.Now())
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(sg.Shards[0].Owners, []meta.ShardOwner{{1}}) {
@@ -1178,7 +1178,7 @@ func TestMetaService_DropDataNode(t *testing.T) {
 	}
 
 	if res := c.ExecuteStatement(mustParseStatement("DROP DATA SERVER 1")); res.Err != nil {
-		t.Fatal(res.Err.Error())
+		t.Fatal(res.Err)
 	}
 
 	rp, _ := c.RetentionPolicy("foo", "default")
@@ -1200,7 +1200,7 @@ func TestMetaService_PersistClusterIDAfterRestart(t *testing.T) {
 
 	c := meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	id := c.ClusterID()
 	if id == 0 {
@@ -1210,12 +1210,12 @@ func TestMetaService_PersistClusterIDAfterRestart(t *testing.T) {
 	s.Close()
 	s = newService(cfg)
 	if err := s.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	c = meta.NewClient([]string{s.HTTPAddr()}, false)
 	if err := c.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer c.Close()
 
@@ -1245,7 +1245,7 @@ func TestMetaService_Ping(t *testing.T) {
 		go func(i int, srv *testService) {
 			defer swg.Done()
 			if err := srv.Open(); err != nil {
-				t.Fatalf("error opening server %d: %s", i, err.Error())
+				t.Fatalf("error opening server %d: %s", i, err)
 			}
 		}(i, srvs[i])
 		defer srvs[i].Close()
@@ -1255,15 +1255,15 @@ func TestMetaService_Ping(t *testing.T) {
 
 	c := meta.NewClient(joinPeers, false)
 	if err := c.Open(); err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 	defer c.Close()
 
 	if err := c.Ping(false); err != nil {
-		t.Fatalf("ping false all failed: %s", err.Error())
+		t.Fatalf("ping false all failed: %s", err)
 	}
 	if err := c.Ping(true); err != nil {
-		t.Fatalf("ping false true failed: %s", err.Error())
+		t.Fatalf("ping false true failed: %s", err)
 	}
 
 	srvs[1].Close()
@@ -1271,7 +1271,7 @@ func TestMetaService_Ping(t *testing.T) {
 	time.Sleep(time.Second)
 
 	if err := c.Ping(false); err != nil {
-		t.Fatalf("ping false some failed: %s", err.Error())
+		t.Fatalf("ping false some failed: %s", err)
 	}
 
 	if err := c.Ping(true); err == nil {
@@ -1291,12 +1291,12 @@ func TestMetaService_AcquireLease(t *testing.T) {
 
 	n1, err := c1.CreateDataNode("foo1:8180", "bar1:8281")
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	n2, err := c2.CreateDataNode("foo2:8180", "bar2:8281")
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatal(err)
 	}
 
 	// Client 1 acquires a lease.  Should succeed.

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -774,18 +774,23 @@ func TestMetaService_CreateRemoveMetaNode(t *testing.T) {
 	t.Parallel()
 
 	joinPeers := freePorts(4)
+	raftPeers := freePorts(4)
 
 	cfg1 := newConfig()
 	cfg1.HTTPBindAddress = joinPeers[0]
+	cfg1.BindAddress = raftPeers[0]
 	defer os.RemoveAll(cfg1.Dir)
 	cfg2 := newConfig()
 	cfg2.HTTPBindAddress = joinPeers[1]
+	cfg2.BindAddress = raftPeers[1]
 	defer os.RemoveAll(cfg2.Dir)
 	cfg3 := newConfig()
 	cfg3.HTTPBindAddress = joinPeers[2]
+	cfg3.BindAddress = raftPeers[2]
 	defer os.RemoveAll(cfg3.Dir)
 	cfg4 := newConfig()
 	cfg4.HTTPBindAddress = joinPeers[3]
+	cfg4.BindAddress = raftPeers[3]
 	defer os.RemoveAll(cfg4.Dir)
 
 	var wg sync.WaitGroup
@@ -1259,6 +1264,8 @@ func TestMetaService_Ping(t *testing.T) {
 	}
 
 	srvs[1].Close()
+	// give the server time to close
+	time.Sleep(time.Second)
 
 	if err := c.Ping(false); err != nil {
 		t.Fatalf("ping false some failed: %s", err.Error())

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -930,6 +930,7 @@ func TestMetaService_FailureAndRestartCluster(t *testing.T) {
 	for i, _ := range cfgs {
 		c := newConfig()
 		c.HTTPBindAddress = joinPeers[i]
+		c.BindAddress = "127.0.0.1:0"
 		c.JoinPeers = joinPeers
 		cfgs[i] = c
 

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -168,6 +168,8 @@ func (s *store) setOpen() error {
 
 // peers returns the raft peers known to this store
 func (s *store) peers() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	if s.raftState == nil {
 		return []string{s.raftAddr}
 	}

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -359,12 +359,16 @@ func (s *store) apply(b []byte) error {
 
 // join adds a new server to the metaservice and raft
 func (s *store) join(n *NodeInfo) error {
+	s.mu.RLock()
 	if s.raftState == nil {
+		s.mu.RUnlock()
 		return fmt.Errorf("store not open")
 	}
 	if err := s.raftState.addPeer(n.TCPHost); err != nil {
+		s.mu.RUnlock()
 		return err
 	}
+	s.mu.RUnlock()
 
 	return s.createMetaNode(n.Host, n.TCPHost)
 }

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -85,6 +85,9 @@ func (s *store) open(raftln net.Listener) error {
 		c := NewClient(joinPeers, s.config.HTTPSEnabled)
 		for {
 			peers := c.peers()
+			if !Peers(peers).Contains(s.raftAddr) {
+				peers = append(peers, s.raftAddr)
+			}
 			if len(s.config.JoinPeers)-len(peers) == 0 {
 				initializePeers = peers
 				break
@@ -356,6 +359,9 @@ func (s *store) apply(b []byte) error {
 
 // join adds a new server to the metaservice and raft
 func (s *store) join(n *NodeInfo) error {
+	if s.raftState == nil {
+		return fmt.Errorf("store not open")
+	}
 	if err := s.raftState.addPeer(n.TCPHost); err != nil {
 		return err
 	}

--- a/services/opentsdb/service_test.go
+++ b/services/opentsdb/service_test.go
@@ -65,11 +65,20 @@ func TestService_Telnet(t *testing.T) {
 	if err := conn.Close(); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(10 * time.Millisecond)
 
-	// Verify that the writer was called.
-	if atomic.LoadInt32(&called) == 0 {
-		t.Fatal("points writer not called")
+	tick := time.Tick(10 * time.Millisecond)
+	timeout := time.After(10 * time.Second)
+
+	for {
+		select {
+		case <-tick:
+			// Verify that the writer was called.
+			if atomic.LoadInt32(&called) > 0 {
+				return
+			}
+		case <-timeout:
+			t.Fatal("points writer not called")
+		}
 	}
 }
 


### PR DESCRIPTION
This PR will allow the specifying of the meta nodes with the `-join` argument.  It will require that you specify all current nodes for restart.  These arguments no longer need to change between restarts.

Example of starting a 3 node meta/data cluster:

```
# node 1
influxd -config ~/influx1.toml -join localhost:8191,localhost:8291,localhost8391

# node 2
influxd -config ~/influx2.toml -join localhost:8191,localhost:8291,localhost8391

# node 3
influxd -config ~/influx3.toml -join localhost:8191,localhost:8291,localhost8391
```

Will result in this server configuration:

```
> show servers
name: data_nodes
----------------
id      http_addr       tcp_addr
3       localhost:8186  localhost:8188
4       localhost:8286  localhost:8288
6       localhost:8386  localhost:8388


name: meta_nodes
----------------
id      http_addr       tcp_addr
1       localhost:8291  localhost:8288
2       localhost:8191  localhost:8188
5       localhost:8391  localhost:8388
```

This has also been tested with bringing up a cluster, and then having a new node join.   

```
# node 1
influxd -config ~/influx1.toml -join localhost:8191,localhost:8291

# node 2
influxd -config ~/influx2.toml -join localhost:8191,localhost:8291
```

Wait for the cluster to be healthy:
```
> show servers
name: data_nodes
----------------
id      http_addr       tcp_addr
3       localhost:8186  localhost:8188
4       localhost:8286  localhost:8288


name: meta_nodes
----------------
id      http_addr       tcp_addr
1       localhost:8291  localhost:8288
2       localhost:8191  localhost:8188

```

Join new node.  Notice you need to specify all nodes in the `-join` argument
```
# node 3
influxd -config ~/influx3.toml -join localhost:8191,localhost:8291,localhost8391
```

Also, to restart nodes 1 and 2, you now need to pass all three nodes.  This is typically done via scripted automation.