### PR TITLE
typo: databse -> database

### DIFF
--- a/cmd/influx_tsm/tracker.go
+++ b/cmd/influx_tsm/tracker.go
@@ -64,7 +64,7 @@ func (t *tracker) Run() error {
 				defer t.wg.Done()
 
 				start := time.Now()
-				log.Printf("Backup of databse '%v' started", db)
+				log.Printf("Backup of database '%v' started", db)
 				err := backupDatabase(db)
 				if err != nil {
 					log.Fatalf("Backup of database %v failed: %v\n", db, err)


### PR DESCRIPTION
Fixes a small typo in one of the messages emitted by influx_tsm during the backup phase.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>