### PR TITLE
local vs. cluster meta queries for data nodes

### DIFF
--- a/services/meta/META_QUERIES_DESIGN.md
+++ b/services/meta/META_QUERIES_DESIGN.md
@@ -42,6 +42,12 @@ can be answered by the local cache.
 nodes to have them return all series stored in their local shards.  Series
 keys are not known to the meta store so a distributed query must run.
 
+* Local vs. Cluster Query - The `SHOW SERIES` meta query should have two 
+versions; one which returns all series in the queried database, and another
+which returns only the series located on the specified node. Presumably the
+meta queries which execute against data nodes should have a `NODE` clause
+to allow direct inquiry of that node's data, not the entire cluster.
+
 * Update Meta Data Only - The `DROP CONTINUOUS QUERY` statement can execute
 directly on the meta nodes and delete the continuos queries stored in the meta
 data.  When continuous queries execute, the worker node consults the meta 

--- a/services/meta/META_QUERIES_DESIGN.md
+++ b/services/meta/META_QUERIES_DESIGN.md
@@ -45,7 +45,7 @@ keys are not known to the meta store so a distributed query must run.
 * Local vs. Cluster Query - The `SHOW SERIES` meta query should have two 
 versions; one which returns all series in the queried database, and another
 which returns only the series located on the specified node. Presumably the
-meta queries which execute against data nodes should have a `NODE` clause
+meta queries which execute against data nodes should have a `SERVER =` clause
 to allow direct inquiry of that node's data, not the entire cluster.
 
 * Update Meta Data Only - The `DROP CONTINUOUS QUERY` statement can execute


### PR DESCRIPTION
It can be very useful to know what series, measurements, tags, or fields are actually present on a given node as opposed to throughout the cluster. The support team advocates that there be a way to query local information only. E.g.

`SHOW SERIES` lists all the series in the target database across the cluster.
`SHOW SERIES WITH SERVER = 12` would only show those series that exist on server id 12

The syntax of the second command is definitely up for grabs, but that proposal introduces no new keywords. The value passed would be the ID from `SHOW SERVERS`. It could easily be extended with regex: `SHOW SERIES WITH SERVER =~ /[12,13,14]/`