### PR TITLE
Remove empty test file

### DIFF
--- a/cmd/influxd/run/select_test.go
+++ b/cmd/influxd/run/select_test.go
@@ -1,1 +1,0 @@
-package run_test


### PR DESCRIPTION
`influxql/select_test.go` is the right test file. `cmd/influxd/run/select_test.go` is not useful.