### PR TITLE
Cast number fill values for the fill iterator

### DIFF
--- a/influxql/cast.go
+++ b/influxql/cast.go
@@ -1,0 +1,41 @@
+package influxql
+
+func castToFloat(v interface{}) float64 {
+	switch v := v.(type) {
+	case float64:
+		return v
+	case int64:
+		return float64(v)
+	default:
+		return float64(0)
+	}
+}
+
+func castToInteger(v interface{}) int64 {
+	switch v := v.(type) {
+	case float64:
+		return int64(v)
+	case int64:
+		return v
+	default:
+		return int64(0)
+	}
+}
+
+func castToString(v interface{}) string {
+	switch v := v.(type) {
+	case string:
+		return v
+	default:
+		return ""
+	}
+}
+
+func castToBoolean(v interface{}) bool {
+	switch v := v.(type) {
+	case bool:
+		return v
+	default:
+		return false
+	}
+}

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -523,7 +523,7 @@ func (itr *floatFillIterator) Next() *FloatPoint {
 		case NullFill:
 			p.Nil = true
 		case NumberFill:
-			p.Value = itr.opt.FillValue.(float64)
+			p.Value = castToFloat(itr.opt.FillValue)
 		case PreviousFill:
 			if itr.prev != nil {
 				p.Value = itr.prev.Value
@@ -1411,7 +1411,7 @@ func (itr *integerFillIterator) Next() *IntegerPoint {
 		case NullFill:
 			p.Nil = true
 		case NumberFill:
-			p.Value = itr.opt.FillValue.(int64)
+			p.Value = castToInteger(itr.opt.FillValue)
 		case PreviousFill:
 			if itr.prev != nil {
 				p.Value = itr.prev.Value
@@ -2299,7 +2299,7 @@ func (itr *stringFillIterator) Next() *StringPoint {
 		case NullFill:
 			p.Nil = true
 		case NumberFill:
-			p.Value = itr.opt.FillValue.(string)
+			p.Value = castToString(itr.opt.FillValue)
 		case PreviousFill:
 			if itr.prev != nil {
 				p.Value = itr.prev.Value
@@ -3187,7 +3187,7 @@ func (itr *booleanFillIterator) Next() *BooleanPoint {
 		case NullFill:
 			p.Nil = true
 		case NumberFill:
-			p.Value = itr.opt.FillValue.(bool)
+			p.Value = castToBoolean(itr.opt.FillValue)
 		case PreviousFill:
 			if itr.prev != nil {
 				p.Value = itr.prev.Value

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -525,7 +525,7 @@ func (itr *{{.name}}FillIterator) Next() *{{.Name}}Point {
 		case NullFill:
 			p.Nil = true
 		case NumberFill:
-			p.Value = itr.opt.FillValue.({{.Type}})
+			p.Value = castTo{{.Name}}(itr.opt.FillValue)
 		case PreviousFill:
 			if itr.prev != nil {
 				p.Value = itr.prev.Value


### PR DESCRIPTION
Querying an integer field with a fill value will cause a cast error
because the underlying type is a float64 rather than an int64. Add a
function that will coerce the value to the correct type.

It may be more appropriate in the future to have the fill iterator read
the underlying iterator and cast to the appropriate type rather than
coerce the fill value to the correct type, but this solution works for
our current scenario well.