### PR TITLE
Clear the start and end times for derivative calls

### DIFF
--- a/influxql/select.go
+++ b/influxql/select.go
@@ -311,8 +311,9 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 			interval := opt.DerivativeInterval()
 			isNonNegative := (expr.Name == "non_negative_derivative")
 
-			// Derivatives do not use GROUP BY intervals, so clear this option.
+			// Derivatives do not use GROUP BY intervals or time constraints, so clear these options.
 			opt.Interval = Interval{}
+			opt.StartTime, opt.EndTime = MinTime, MaxTime
 			return newDerivativeIterator(input, opt, interval, isNonNegative), nil
 		default:
 			panic(fmt.Sprintf("unsupported call: %s", expr.Name))


### PR DESCRIPTION
Derivatives rely on the underlying iterator to handle start and end
times. They do not perform them or organize points into groups. In
certain circumstances, the start time or end time that got implicitly
passed could be on an uneven interval with the first point returned by
the aggregate, which caused the entire iterator not to be read.

This fixes #5571.