### PR TITLE
Update authentication cache to work for clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#5510](https://github.com/influxdata/influxdb/pull/5510): Optimize ReducePercentile @bsideup
 - [#5557](https://github.com/influxdata/influxdb/issues/5630): Fixes panic when surrounding the select statement arguments in brackets
 - [#5628](https://github.com/influxdata/influxdb/issues/5628): Crashed the server with a bad derivative query
+- [#5532](https://github.com/influxdata/influxdb/issues/5532): user passwords not changeable in cluster
 
 ## v0.10.0 [2016-02-04]
 

--- a/services/meta/meta_test.go
+++ b/services/meta/meta_test.go
@@ -1,0 +1,7 @@
+package meta
+
+import "golang.org/x/crypto/bcrypt"
+
+func init() {
+	bcryptCost = bcrypt.MinCost
+}

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -339,10 +339,7 @@ func TestMetaService_CreateUser(t *testing.T) {
 	}
 
 	u, err = c.Authenticate("fred", "supersecure")
-	if u == nil || err != nil {
-		t.Fatalf("failed to authenticate")
-	}
-	if u.Name != "fred" {
+	if u == nil || err != nil || u.Name != "fred" {
 		t.Fatalf("failed to authenticate")
 	}
 
@@ -371,10 +368,7 @@ func TestMetaService_CreateUser(t *testing.T) {
 
 	// Auth for new password should succeed.
 	u, err = c.Authenticate("fred", "moresupersecure")
-	if u == nil || err != nil {
-		t.Fatalf("failed to authenticate")
-	}
-	if u.Name != "fred" {
+	if u == nil || err != nil || u.Name != "fred" {
 		t.Fatalf("failed to authenticate")
 	}
 
@@ -413,22 +407,6 @@ func TestMetaService_CreateUser(t *testing.T) {
 	}
 	if !u.Admin {
 		t.Fatalf("expected user to be an admin")
-	}
-
-	// Revoke privilidges from user
-	if res := c.ExecuteStatement(mustParseStatement("REVOKE ALL PRIVILEGES FROM wilma")); res.Err != nil {
-		t.Fatal(res.Err)
-	}
-
-	u, err = c.User("wilma")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if exp, got := "wilma", u.Name; exp != got {
-		t.Fatalf("unexpected user name: exp: %s got: %s", exp, got)
-	}
-	if u.Admin {
-		t.Fatalf("expected user not to be an admin")
 	}
 
 	// Revoke privilidges from user

--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -44,16 +44,8 @@ type store struct {
 	opened      bool
 	logger      *log.Logger
 
-	// Authentication cache.
-	authCache map[string]authUser
-
 	raftAddr string
 	httpAddr string
-}
-
-type authUser struct {
-	salt []byte
-	hash []byte
 }
 
 // newStore will create a new metastore with the passed in config

--- a/services/meta/store_fsm.go
+++ b/services/meta/store_fsm.go
@@ -433,7 +433,6 @@ func (fsm *storeFSM) applyDropUserCommand(cmd *internal.Command) interface{} {
 		return err
 	}
 	fsm.data = other
-	delete(fsm.authCache, v.GetName())
 	return nil
 }
 
@@ -447,7 +446,6 @@ func (fsm *storeFSM) applyUpdateUserCommand(cmd *internal.Command) interface{} {
 		return err
 	}
 	fsm.data = other
-	delete(fsm.authCache, v.GetName())
 	return nil
 }
 


### PR DESCRIPTION
Fixes #5532

This update will allow the meta clients to update their authentication caches (password changes or dropped users) when a new metadata snapshot is received.

Some things I removed:
- Duplicated test code (dropping privileges twice)
- "pluggable" hashing function type that always used `bcrypt.CompareHashAndPassword()` for validation
- unused `authCache` on the store that was never accessed

I also added a test file that will actually reduce the bcrypt work cost when the package is being tested (the comment that was there lied about already doing it)