### PR TITLE
Tolerate b1 shard index inconsistencies during TSM conversion

### DIFF
--- a/cmd/influx_tsm/b1/reader.go
+++ b/cmd/influx_tsm/b1/reader.go
@@ -211,7 +211,11 @@ func (r *Reader) Read() (string, []tsm1.Value, error) {
 
 // Close closes the reader.
 func (r *Reader) Close() error {
-	return r.tx.Rollback()
+	if r.tx != nil {
+		return r.tx.Rollback()
+	} else {
+		return nil
+	}
 }
 
 // cursor provides ordered iteration across a series.

--- a/cmd/influx_tsm/main.go
+++ b/cmd/influx_tsm/main.go
@@ -42,7 +42,7 @@ The backed-up files must be removed manually, generally after starting up the
 node again to make sure all of data has been converted correctly.
 
 To restore a backup:
-  Shut down the node, remove the converted directory, and 
+  Shut down the node, remove the converted directory, and
   copy the backed-up directory to the original location.`
 
 type options struct {
@@ -54,6 +54,7 @@ type options struct {
 	Parallel       bool
 	SkipBackup     bool
 	UpdateInterval time.Duration
+	RepairIndex    string
 	// Quiet          bool
 }
 
@@ -70,6 +71,7 @@ func (o *options) Parse() error {
 	// fs.BoolVar(&opts.Quiet, "quiet", false, "Suppresses the regular status updates.")
 	fs.StringVar(&opts.DebugAddr, "debug", "", "If set, http debugging endpoints will be enabled on the given address")
 	fs.DurationVar(&opts.UpdateInterval, "interval", 5*time.Second, "How often status updates are printed.")
+	fs.StringVar(&opts.RepairIndex, "repair-index", "fail", "Use 'repair', 'ignore' or 'fail' to repair, ignore or fail to process orphaned series.")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %v [options] <data-path> \n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "%v\n\nOptions:\n", description)
@@ -318,7 +320,9 @@ func convertShard(si *tsdb.ShardInfo, tr *tracker) error {
 	case tsdb.BZ1:
 		reader = bz1.NewReader(src)
 	case tsdb.B1:
-		reader = b1.NewReader(src)
+		b1Reader := b1.NewReader(src)
+		b1Reader.RepairIndex = opts.RepairIndex
+		reader = b1Reader
 	default:
 		return fmt.Errorf("Unsupported shard format: %v", si.FormatAsString())
 	}


### PR DESCRIPTION
These commits address data loss issues caused by a shard index inconsistency caused by a defect that was fixed (3348dab) in version 0.9.3. The data loss problem this inconsistency caused was reported with #5606. 

The changes have been tested with an instance of a 47GB database of 32 shards and 1.1B points. Prior to the fix, around 600M points (4GB) were unexpectedly dropped from the converted database. With the fix, the full 1.1B points were preserved resulting in a converted database size of 8.8GB.

Feedback is welcome about whether the list of orphaned series should be dumped to the output and whether the tracker should be used to to dump the warning messages.

Other areas of improvement might be the means that the RepairIndex configuration is associated with the b1 reader. Should I pass this as a parameter to the reader constructor or pass an reader specific options/configuration object?

A similar change should probably also be made to the bz1 reader, but I didn't have a test case I could use to verify the integrity of such a change. I am happy to extend the change to the bz1 reader if that is desired.

**It is probably worth noting that any influx database that has data that was created with a version less than 0.9.3 may be susceptible to silent data loss during TSM data conversion until this fix is applied.**

