### PR TITLE
Optimize the mean() call by moving the calculation into the shard iterator

### DIFF
--- a/influxql/call_iterator_test.go
+++ b/influxql/call_iterator_test.go
@@ -32,11 +32,11 @@ func TestCallIterator_Count_Float(t *testing.T) {
 	)
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Name: "cpu", Time: 0, Value: 3, Tags: ParseTags("host=hostA")}},
-		{&influxql.FloatPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB")}},
-		{&influxql.FloatPoint{Name: "cpu", Time: 5, Value: 1, Tags: ParseTags("host=hostA")}},
-		{&influxql.FloatPoint{Name: "cpu", Time: 20, Value: 1, Tags: ParseTags("host=hostB")}},
-		{&influxql.FloatPoint{Name: "mem", Time: 20, Value: 1, Tags: ParseTags("host=hostB")}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 0, Value: 3, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 5, Value: 1, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "mem", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -64,11 +64,11 @@ func TestCallIterator_Count_Integer(t *testing.T) {
 	)
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 3, Tags: ParseTags("host=hostA")}},
-		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB")}},
-		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 1, Tags: ParseTags("host=hostA")}},
-		{&influxql.IntegerPoint{Name: "cpu", Time: 20, Value: 1, Tags: ParseTags("host=hostB")}},
-		{&influxql.IntegerPoint{Name: "mem", Time: 20, Value: 1, Tags: ParseTags("host=hostB")}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 3, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 1, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Name: "mem", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -96,10 +96,10 @@ func TestCallIterator_Min_Float(t *testing.T) {
 	)
 
 	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Time: 0, Value: 10, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 4},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -127,10 +127,10 @@ func TestCallIterator_Min_Integer(t *testing.T) {
 	)
 
 	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Time: 0, Value: 10, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 4},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -157,10 +157,10 @@ func TestCallIterator_Max_Float(t *testing.T) {
 	)
 
 	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Time: 0, Value: 15, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -187,10 +187,10 @@ func TestCallIterator_Max_Integer(t *testing.T) {
 	)
 
 	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Time: 0, Value: 15, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -217,10 +217,10 @@ func TestCallIterator_Sum_Float(t *testing.T) {
 	)
 
 	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Time: 0, Value: 35, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 35, Tags: ParseTags("host=hostA"), Aggregated: 3},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -247,10 +247,10 @@ func TestCallIterator_Sum_Integer(t *testing.T) {
 	)
 
 	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Time: 0, Value: 35, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 35, Tags: ParseTags("host=hostA"), Aggregated: 3},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -277,10 +277,10 @@ func TestCallIterator_First_Float(t *testing.T) {
 	)
 
 	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Time: 0, Value: 15, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -307,10 +307,10 @@ func TestCallIterator_First_Integer(t *testing.T) {
 	)
 
 	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Time: 0, Value: 15, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -337,10 +337,10 @@ func TestCallIterator_Last_Float(t *testing.T) {
 	)
 
 	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Time: 0, Value: 10, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 3},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -367,10 +367,10 @@ func TestCallIterator_Last_Integer(t *testing.T) {
 	)
 
 	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Time: 0, Value: 10, Tags: ParseTags("host=hostA")},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB")},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA")},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB")},
+		{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 3},
+		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
+		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
+		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
 	}); !ok {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}

--- a/influxql/internal/internal.pb.go
+++ b/influxql/internal/internal.pb.go
@@ -15,22 +15,25 @@ It has these top-level messages:
 package internal
 
 import proto "github.com/gogo/protobuf/proto"
+import fmt "fmt"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
+var _ = fmt.Errorf
 var _ = math.Inf
 
 type Point struct {
-	Name             *string  `protobuf:"bytes,1,req" json:"Name,omitempty"`
-	Tags             *string  `protobuf:"bytes,2,req" json:"Tags,omitempty"`
-	Time             *int64   `protobuf:"varint,3,req" json:"Time,omitempty"`
-	Nil              *bool    `protobuf:"varint,4,req" json:"Nil,omitempty"`
-	Aux              []*Aux   `protobuf:"bytes,5,rep" json:"Aux,omitempty"`
-	FloatValue       *float64 `protobuf:"fixed64,6,opt" json:"FloatValue,omitempty"`
-	IntegerValue     *int64   `protobuf:"varint,7,opt" json:"IntegerValue,omitempty"`
-	StringValue      *string  `protobuf:"bytes,8,opt" json:"StringValue,omitempty"`
-	BooleanValue     *bool    `protobuf:"varint,9,opt" json:"BooleanValue,omitempty"`
+	Name             *string  `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	Tags             *string  `protobuf:"bytes,2,req,name=Tags" json:"Tags,omitempty"`
+	Time             *int64   `protobuf:"varint,3,req,name=Time" json:"Time,omitempty"`
+	Nil              *bool    `protobuf:"varint,4,req,name=Nil" json:"Nil,omitempty"`
+	Aux              []*Aux   `protobuf:"bytes,5,rep,name=Aux" json:"Aux,omitempty"`
+	Aggregated       *uint32  `protobuf:"varint,6,opt,name=Aggregated" json:"Aggregated,omitempty"`
+	FloatValue       *float64 `protobuf:"fixed64,7,opt,name=FloatValue" json:"FloatValue,omitempty"`
+	IntegerValue     *int64   `protobuf:"varint,8,opt,name=IntegerValue" json:"IntegerValue,omitempty"`
+	StringValue      *string  `protobuf:"bytes,9,opt,name=StringValue" json:"StringValue,omitempty"`
+	BooleanValue     *bool    `protobuf:"varint,10,opt,name=BooleanValue" json:"BooleanValue,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -73,6 +76,13 @@ func (m *Point) GetAux() []*Aux {
 	return nil
 }
 
+func (m *Point) GetAggregated() uint32 {
+	if m != nil && m.Aggregated != nil {
+		return *m.Aggregated
+	}
+	return 0
+}
+
 func (m *Point) GetFloatValue() float64 {
 	if m != nil && m.FloatValue != nil {
 		return *m.FloatValue
@@ -102,11 +112,11 @@ func (m *Point) GetBooleanValue() bool {
 }
 
 type Aux struct {
-	DataType         *int32   `protobuf:"varint,1,req" json:"DataType,omitempty"`
-	FloatValue       *float64 `protobuf:"fixed64,2,opt" json:"FloatValue,omitempty"`
-	IntegerValue     *int64   `protobuf:"varint,3,opt" json:"IntegerValue,omitempty"`
-	StringValue      *string  `protobuf:"bytes,4,opt" json:"StringValue,omitempty"`
-	BooleanValue     *bool    `protobuf:"varint,5,opt" json:"BooleanValue,omitempty"`
+	DataType         *int32   `protobuf:"varint,1,req,name=DataType" json:"DataType,omitempty"`
+	FloatValue       *float64 `protobuf:"fixed64,2,opt,name=FloatValue" json:"FloatValue,omitempty"`
+	IntegerValue     *int64   `protobuf:"varint,3,opt,name=IntegerValue" json:"IntegerValue,omitempty"`
+	StringValue      *string  `protobuf:"bytes,4,opt,name=StringValue" json:"StringValue,omitempty"`
+	BooleanValue     *bool    `protobuf:"varint,5,opt,name=BooleanValue" json:"BooleanValue,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -150,4 +160,6 @@ func (m *Aux) GetBooleanValue() bool {
 }
 
 func init() {
+	proto.RegisterType((*Point)(nil), "internal.Point")
+	proto.RegisterType((*Aux)(nil), "internal.Aux")
 }

--- a/influxql/internal/internal.proto
+++ b/influxql/internal/internal.proto
@@ -1,16 +1,17 @@
 package internal;
 
 message Point {
-    required string Name = 1;
-    required string Tags = 2;
-    required int64  Time = 3;
-    required bool   Nil  = 4;
-    repeated Aux    Aux  = 5;
+    required string Name       = 1;
+    required string Tags       = 2;
+    required int64  Time       = 3;
+    required bool   Nil        = 4;
+    repeated Aux    Aux        = 5;
+    optional uint32 Aggregated = 6;
 
-    optional double FloatValue   = 6;
-    optional int64  IntegerValue = 7;
-    optional string StringValue  = 8;
-    optional bool   BooleanValue = 9;
+    optional double FloatValue   = 7;
+    optional int64  IntegerValue = 8;
+    optional string StringValue  = 9;
+    optional bool   BooleanValue = 10;
 }
 
 message Aux {

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -685,6 +685,7 @@ func (itr *floatReduceIterator) reduce() []*FloatPoint {
 		prev.Time = t
 		prev.Value = v
 		prev.Aux = aux
+		prev.Aggregated++
 	}
 
 	// Reverse sort points by name & tag.
@@ -1573,6 +1574,7 @@ func (itr *integerReduceIterator) reduce() []*IntegerPoint {
 		prev.Time = t
 		prev.Value = v
 		prev.Aux = aux
+		prev.Aggregated++
 	}
 
 	// Reverse sort points by name & tag.
@@ -2461,6 +2463,7 @@ func (itr *stringReduceIterator) reduce() []*StringPoint {
 		prev.Time = t
 		prev.Value = v
 		prev.Aux = aux
+		prev.Aggregated++
 	}
 
 	// Reverse sort points by name & tag.
@@ -3349,6 +3352,7 @@ func (itr *booleanReduceIterator) reduce() []*BooleanPoint {
 		prev.Time = t
 		prev.Value = v
 		prev.Aux = aux
+		prev.Aggregated++
 	}
 
 	// Reverse sort points by name & tag.

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -687,6 +687,7 @@ func (itr *{{.name}}ReduceIterator) reduce() []*{{.Name}}Point {
 		prev.Time = t
 		prev.Value = v
 		prev.Aux = aux
+		prev.Aggregated++
 	}
 
 	// Reverse sort points by name & tag.

--- a/influxql/point.gen.go
+++ b/influxql/point.gen.go
@@ -9,6 +9,8 @@ import (
 )
 
 // FloatPoint represents a point with a float64 value.
+// DO NOT ADD ADDITIONAL FIELDS TO THIS STRUCT.
+// See TestPoint_Fields in influxql/point_test.go for more details.
 type FloatPoint struct {
 	Name string
 	Tags Tags
@@ -17,6 +19,10 @@ type FloatPoint struct {
 	Nil   bool
 	Value float64
 	Aux   []interface{}
+
+	// Total number of points that were combined into this point from an aggregate.
+	// If this is zero, the point is not the result of an aggregate function.
+	Aggregated int
 }
 
 func (v *FloatPoint) name() string { return v.Name }
@@ -113,6 +119,8 @@ func floatPointsSortBy(points []FloatPoint, cmp func(a, b *FloatPoint) bool) *fl
 }
 
 // IntegerPoint represents a point with a int64 value.
+// DO NOT ADD ADDITIONAL FIELDS TO THIS STRUCT.
+// See TestPoint_Fields in influxql/point_test.go for more details.
 type IntegerPoint struct {
 	Name string
 	Tags Tags
@@ -121,6 +129,10 @@ type IntegerPoint struct {
 	Nil   bool
 	Value int64
 	Aux   []interface{}
+
+	// Total number of points that were combined into this point from an aggregate.
+	// If this is zero, the point is not the result of an aggregate function.
+	Aggregated int
 }
 
 func (v *IntegerPoint) name() string { return v.Name }
@@ -217,6 +229,8 @@ func integerPointsSortBy(points []IntegerPoint, cmp func(a, b *IntegerPoint) boo
 }
 
 // StringPoint represents a point with a string value.
+// DO NOT ADD ADDITIONAL FIELDS TO THIS STRUCT.
+// See TestPoint_Fields in influxql/point_test.go for more details.
 type StringPoint struct {
 	Name string
 	Tags Tags
@@ -225,6 +239,10 @@ type StringPoint struct {
 	Nil   bool
 	Value string
 	Aux   []interface{}
+
+	// Total number of points that were combined into this point from an aggregate.
+	// If this is zero, the point is not the result of an aggregate function.
+	Aggregated int
 }
 
 func (v *StringPoint) name() string { return v.Name }
@@ -321,6 +339,8 @@ func stringPointsSortBy(points []StringPoint, cmp func(a, b *StringPoint) bool) 
 }
 
 // BooleanPoint represents a point with a bool value.
+// DO NOT ADD ADDITIONAL FIELDS TO THIS STRUCT.
+// See TestPoint_Fields in influxql/point_test.go for more details.
 type BooleanPoint struct {
 	Name string
 	Tags Tags
@@ -329,6 +349,10 @@ type BooleanPoint struct {
 	Nil   bool
 	Value bool
 	Aux   []interface{}
+
+	// Total number of points that were combined into this point from an aggregate.
+	// If this is zero, the point is not the result of an aggregate function.
+	Aggregated int
 }
 
 func (v *BooleanPoint) name() string { return v.Name }

--- a/influxql/point.gen.go
+++ b/influxql/point.gen.go
@@ -22,7 +22,7 @@ type FloatPoint struct {
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
-	Aggregated int
+	Aggregated uint32
 }
 
 func (v *FloatPoint) name() string { return v.Name }
@@ -54,11 +54,12 @@ func (v *FloatPoint) Clone() *FloatPoint {
 
 func encodeFloatPoint(p *FloatPoint) *internal.Point {
 	return &internal.Point{
-		Name: proto.String(p.Name),
-		Tags: proto.String(p.Tags.ID()),
-		Time: proto.Int64(p.Time),
-		Nil:  proto.Bool(p.Nil),
-		Aux:  encodeAux(p.Aux),
+		Name:       proto.String(p.Name),
+		Tags:       proto.String(p.Tags.ID()),
+		Time:       proto.Int64(p.Time),
+		Nil:        proto.Bool(p.Nil),
+		Aux:        encodeAux(p.Aux),
+		Aggregated: proto.Uint32(p.Aggregated),
 
 		FloatValue: proto.Float64(p.Value),
 	}
@@ -66,12 +67,13 @@ func encodeFloatPoint(p *FloatPoint) *internal.Point {
 
 func decodeFloatPoint(pb *internal.Point) *FloatPoint {
 	return &FloatPoint{
-		Name:  pb.GetName(),
-		Tags:  newTagsID(pb.GetTags()),
-		Time:  pb.GetTime(),
-		Nil:   pb.GetNil(),
-		Aux:   decodeAux(pb.Aux),
-		Value: pb.GetFloatValue(),
+		Name:       pb.GetName(),
+		Tags:       newTagsID(pb.GetTags()),
+		Time:       pb.GetTime(),
+		Nil:        pb.GetNil(),
+		Aux:        decodeAux(pb.Aux),
+		Aggregated: pb.GetAggregated(),
+		Value:      pb.GetFloatValue(),
 	}
 }
 
@@ -132,7 +134,7 @@ type IntegerPoint struct {
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
-	Aggregated int
+	Aggregated uint32
 }
 
 func (v *IntegerPoint) name() string { return v.Name }
@@ -164,11 +166,12 @@ func (v *IntegerPoint) Clone() *IntegerPoint {
 
 func encodeIntegerPoint(p *IntegerPoint) *internal.Point {
 	return &internal.Point{
-		Name: proto.String(p.Name),
-		Tags: proto.String(p.Tags.ID()),
-		Time: proto.Int64(p.Time),
-		Nil:  proto.Bool(p.Nil),
-		Aux:  encodeAux(p.Aux),
+		Name:       proto.String(p.Name),
+		Tags:       proto.String(p.Tags.ID()),
+		Time:       proto.Int64(p.Time),
+		Nil:        proto.Bool(p.Nil),
+		Aux:        encodeAux(p.Aux),
+		Aggregated: proto.Uint32(p.Aggregated),
 
 		IntegerValue: proto.Int64(p.Value),
 	}
@@ -176,12 +179,13 @@ func encodeIntegerPoint(p *IntegerPoint) *internal.Point {
 
 func decodeIntegerPoint(pb *internal.Point) *IntegerPoint {
 	return &IntegerPoint{
-		Name:  pb.GetName(),
-		Tags:  newTagsID(pb.GetTags()),
-		Time:  pb.GetTime(),
-		Nil:   pb.GetNil(),
-		Aux:   decodeAux(pb.Aux),
-		Value: pb.GetIntegerValue(),
+		Name:       pb.GetName(),
+		Tags:       newTagsID(pb.GetTags()),
+		Time:       pb.GetTime(),
+		Nil:        pb.GetNil(),
+		Aux:        decodeAux(pb.Aux),
+		Aggregated: pb.GetAggregated(),
+		Value:      pb.GetIntegerValue(),
 	}
 }
 
@@ -242,7 +246,7 @@ type StringPoint struct {
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
-	Aggregated int
+	Aggregated uint32
 }
 
 func (v *StringPoint) name() string { return v.Name }
@@ -274,11 +278,12 @@ func (v *StringPoint) Clone() *StringPoint {
 
 func encodeStringPoint(p *StringPoint) *internal.Point {
 	return &internal.Point{
-		Name: proto.String(p.Name),
-		Tags: proto.String(p.Tags.ID()),
-		Time: proto.Int64(p.Time),
-		Nil:  proto.Bool(p.Nil),
-		Aux:  encodeAux(p.Aux),
+		Name:       proto.String(p.Name),
+		Tags:       proto.String(p.Tags.ID()),
+		Time:       proto.Int64(p.Time),
+		Nil:        proto.Bool(p.Nil),
+		Aux:        encodeAux(p.Aux),
+		Aggregated: proto.Uint32(p.Aggregated),
 
 		StringValue: proto.String(p.Value),
 	}
@@ -286,12 +291,13 @@ func encodeStringPoint(p *StringPoint) *internal.Point {
 
 func decodeStringPoint(pb *internal.Point) *StringPoint {
 	return &StringPoint{
-		Name:  pb.GetName(),
-		Tags:  newTagsID(pb.GetTags()),
-		Time:  pb.GetTime(),
-		Nil:   pb.GetNil(),
-		Aux:   decodeAux(pb.Aux),
-		Value: pb.GetStringValue(),
+		Name:       pb.GetName(),
+		Tags:       newTagsID(pb.GetTags()),
+		Time:       pb.GetTime(),
+		Nil:        pb.GetNil(),
+		Aux:        decodeAux(pb.Aux),
+		Aggregated: pb.GetAggregated(),
+		Value:      pb.GetStringValue(),
 	}
 }
 
@@ -352,7 +358,7 @@ type BooleanPoint struct {
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
-	Aggregated int
+	Aggregated uint32
 }
 
 func (v *BooleanPoint) name() string { return v.Name }
@@ -384,11 +390,12 @@ func (v *BooleanPoint) Clone() *BooleanPoint {
 
 func encodeBooleanPoint(p *BooleanPoint) *internal.Point {
 	return &internal.Point{
-		Name: proto.String(p.Name),
-		Tags: proto.String(p.Tags.ID()),
-		Time: proto.Int64(p.Time),
-		Nil:  proto.Bool(p.Nil),
-		Aux:  encodeAux(p.Aux),
+		Name:       proto.String(p.Name),
+		Tags:       proto.String(p.Tags.ID()),
+		Time:       proto.Int64(p.Time),
+		Nil:        proto.Bool(p.Nil),
+		Aux:        encodeAux(p.Aux),
+		Aggregated: proto.Uint32(p.Aggregated),
 
 		BooleanValue: proto.Bool(p.Value),
 	}
@@ -396,12 +403,13 @@ func encodeBooleanPoint(p *BooleanPoint) *internal.Point {
 
 func decodeBooleanPoint(pb *internal.Point) *BooleanPoint {
 	return &BooleanPoint{
-		Name:  pb.GetName(),
-		Tags:  newTagsID(pb.GetTags()),
-		Time:  pb.GetTime(),
-		Nil:   pb.GetNil(),
-		Aux:   decodeAux(pb.Aux),
-		Value: pb.GetBooleanValue(),
+		Name:       pb.GetName(),
+		Tags:       newTagsID(pb.GetTags()),
+		Time:       pb.GetTime(),
+		Nil:        pb.GetNil(),
+		Aux:        decodeAux(pb.Aux),
+		Aggregated: pb.GetAggregated(),
+		Value:      pb.GetBooleanValue(),
 	}
 }
 

--- a/influxql/point.gen.go.tmpl
+++ b/influxql/point.gen.go.tmpl
@@ -21,7 +21,7 @@ type {{.Name}}Point struct {
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
-	Aggregated int
+	Aggregated uint32
 }
 
 func (v *{{.Name}}Point) name() string       { return v.Name }
@@ -53,11 +53,12 @@ func (v *{{.Name}}Point) Clone() *{{.Name}}Point {
 
 func encode{{.Name}}Point(p *{{.Name}}Point) *internal.Point {
   return &internal.Point{
-    Name: proto.String(p.Name),
-    Tags: proto.String(p.Tags.ID()),
-    Time: proto.Int64(p.Time),
-    Nil: proto.Bool(p.Nil),
-    Aux: encodeAux(p.Aux),
+    Name:       proto.String(p.Name),
+    Tags:       proto.String(p.Tags.ID()),
+    Time:       proto.Int64(p.Time),
+    Nil:        proto.Bool(p.Nil),
+    Aux:        encodeAux(p.Aux),
+		Aggregated: proto.Uint32(p.Aggregated),
 
     {{if eq .Name "Float"}}
       FloatValue: proto.Float64(p.Value),
@@ -73,12 +74,13 @@ func encode{{.Name}}Point(p *{{.Name}}Point) *internal.Point {
 
 func decode{{.Name}}Point(pb *internal.Point) *{{.Name}}Point {
   return &{{.Name}}Point{
-    Name:  pb.GetName(),
-    Tags:  newTagsID(pb.GetTags()),
-    Time:  pb.GetTime(),
-    Nil:   pb.GetNil(),
-    Aux:   decodeAux(pb.Aux),
-    Value: pb.Get{{.Name}}Value(),
+    Name:       pb.GetName(),
+    Tags:       newTagsID(pb.GetTags()),
+    Time:       pb.GetTime(),
+    Nil:        pb.GetNil(),
+    Aux:        decodeAux(pb.Aux),
+		Aggregated: pb.GetAggregated(),
+    Value:      pb.Get{{.Name}}Value(),
   }
 }
 

--- a/influxql/point.gen.go.tmpl
+++ b/influxql/point.gen.go.tmpl
@@ -8,6 +8,8 @@ import (
 {{range .}}
 
 // {{.Name}}Point represents a point with a {{.Type}} value.
+// DO NOT ADD ADDITIONAL FIELDS TO THIS STRUCT.
+// See TestPoint_Fields in influxql/point_test.go for more details.
 type {{.Name}}Point struct {
 	Name string
 	Tags Tags
@@ -16,6 +18,10 @@ type {{.Name}}Point struct {
 	Nil   bool
 	Value {{.Type}}
 	Aux   []interface{}
+
+	// Total number of points that were combined into this point from an aggregate.
+	// If this is zero, the point is not the result of an aggregate function.
+	Aggregated int
 }
 
 func (v *{{.Name}}Point) name() string       { return v.Name }

--- a/influxql/point_test.go
+++ b/influxql/point_test.go
@@ -120,6 +120,37 @@ func TestPoint_Clone_Nil(t *testing.T) {
 	}
 }
 
+// TestPoint_Fields ensures that no additional fields are added to the point structs.
+// This struct is very sensitive and can effect performance unless handled carefully.
+// To avoid the struct becoming a dumping ground for every function that needs to store
+// miscellaneous information, this test is meant to ensure that new fields don't slip
+// into the struct.
+func TestPoint_Fields(t *testing.T) {
+	allowedFields := map[string]bool{
+		"Name":       true,
+		"Tags":       true,
+		"Time":       true,
+		"Nil":        true,
+		"Value":      true,
+		"Aux":        true,
+		"Aggregated": true,
+	}
+
+	for _, typ := range []reflect.Type{
+		reflect.TypeOf(influxql.FloatPoint{}),
+		reflect.TypeOf(influxql.IntegerPoint{}),
+		reflect.TypeOf(influxql.StringPoint{}),
+		reflect.TypeOf(influxql.BooleanPoint{}),
+	} {
+		f, ok := typ.FieldByNameFunc(func(name string) bool {
+			return !allowedFields[name]
+		})
+		if ok {
+			t.Errorf("found an unallowed field in %s: %s %s", typ, f.Name, f.Type)
+		}
+	}
+}
+
 // Ensure that tags can return a unique id.
 func TestTags_ID(t *testing.T) {
 	tags := influxql.NewTags(map[string]string{"foo": "bar", "baz": "bat"})

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -225,7 +225,7 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 			default:
 				itr, err = ic.CreateIterator(opt)
 			}
-		case "min", "max", "sum", "first", "last":
+		case "min", "max", "sum", "first", "last", "mean":
 			itr, err = ic.CreateIterator(opt)
 		case "distinct":
 			input, err := buildExprIterator(expr.Args[0].(*VarRef), ic, opt)
@@ -233,13 +233,6 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 				return nil, err
 			}
 			return NewDistinctIterator(input, opt), nil
-		case "mean":
-			// OPTIMIZE(benbjohnson): convert to map/reduce
-			input, err := buildExprIterator(expr.Args[0].(*VarRef), ic, opt)
-			if err != nil {
-				return nil, err
-			}
-			itr = newMeanIterator(input, opt)
 		case "median":
 			input, err := buildExprIterator(expr.Args[0].(*VarRef), ic, opt)
 			if err != nil {

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -36,10 +36,10 @@ func TestSelect_Min(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if a := Iterators(itrs).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10, Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100, Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -136,7 +136,7 @@ func TestSelect_Distinct_String(t *testing.T) {
 func TestSelect_Mean_Float(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
-		return &FloatIterator{Points: []influxql.FloatPoint{
+		return influxql.NewCallIterator(&FloatIterator{Points: []influxql.FloatPoint{
 			{Name: "cpu", Tags: ParseTags("region=west,host=A"), Time: 0 * Second, Value: 20},
 			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 5 * Second, Value: 10},
 			{Name: "cpu", Tags: ParseTags("region=east,host=A"), Time: 9 * Second, Value: 19},
@@ -149,7 +149,7 @@ func TestSelect_Mean_Float(t *testing.T) {
 			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 52 * Second, Value: 4},
 			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 53 * Second, Value: 4},
 			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 53 * Second, Value: 5},
-		}}, nil
+		}}, opt), nil
 	}
 
 	// Execute selection.
@@ -157,11 +157,11 @@ func TestSelect_Mean_Float(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if a := Iterators(itrs).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19.5}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2.5}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: 3.2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19.5, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10, Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2.5, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100, Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: 3.2, Aggregated: 5}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -171,7 +171,7 @@ func TestSelect_Mean_Float(t *testing.T) {
 func TestSelect_Mean_Integer(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
-		return &IntegerIterator{Points: []influxql.IntegerPoint{
+		return influxql.NewCallIterator(&IntegerIterator{Points: []influxql.IntegerPoint{
 			{Name: "cpu", Tags: ParseTags("region=west,host=A"), Time: 0 * Second, Value: 20},
 			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 5 * Second, Value: 10},
 			{Name: "cpu", Tags: ParseTags("region=east,host=A"), Time: 9 * Second, Value: 19},
@@ -184,7 +184,7 @@ func TestSelect_Mean_Integer(t *testing.T) {
 			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 52 * Second, Value: 4},
 			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 53 * Second, Value: 4},
 			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 53 * Second, Value: 5},
-		}}, nil
+		}}, opt), nil
 	}
 
 	// Execute selection.
@@ -192,11 +192,11 @@ func TestSelect_Mean_Integer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if a := Iterators(itrs).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19.5}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2.5}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: 3.2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19.5, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10, Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2.5, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100, Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: 3.2, Aggregated: 5}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -772,9 +772,9 @@ func TestSelect_Bottom_GroupByTags_Integer(t *testing.T) {
 func TestSelect_Fill_Null_Float(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
-		return &FloatIterator{Points: []influxql.FloatPoint{
+		return influxql.NewCallIterator(&FloatIterator{Points: []influxql.FloatPoint{
 			{Name: "cpu", Tags: ParseTags("host=A"), Time: 12 * Second, Value: 2},
-		}}, nil
+		}}, opt), nil
 	}
 
 	// Execute selection.
@@ -783,7 +783,7 @@ func TestSelect_Fill_Null_Float(t *testing.T) {
 		t.Fatal(err)
 	} else if a := Iterators(itrs).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Nil: true}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2, Aggregated: 1}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 20 * Second, Nil: true}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Nil: true}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 40 * Second, Nil: true}},
@@ -797,9 +797,9 @@ func TestSelect_Fill_Null_Float(t *testing.T) {
 func TestSelect_Fill_Number_Float(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
-		return &FloatIterator{Points: []influxql.FloatPoint{
+		return influxql.NewCallIterator(&FloatIterator{Points: []influxql.FloatPoint{
 			{Name: "cpu", Tags: ParseTags("host=A"), Time: 12 * Second, Value: 2},
-		}}, nil
+		}}, opt), nil
 	}
 
 	// Execute selection.
@@ -808,7 +808,7 @@ func TestSelect_Fill_Number_Float(t *testing.T) {
 		t.Fatal(err)
 	} else if a := Iterators(itrs).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 1}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2, Aggregated: 1}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 20 * Second, Value: 1}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 1}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 40 * Second, Value: 1}},
@@ -822,9 +822,9 @@ func TestSelect_Fill_Number_Float(t *testing.T) {
 func TestSelect_Fill_Previous_Float(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
-		return &FloatIterator{Points: []influxql.FloatPoint{
+		return influxql.NewCallIterator(&FloatIterator{Points: []influxql.FloatPoint{
 			{Name: "cpu", Tags: ParseTags("host=A"), Time: 12 * Second, Value: 2},
-		}}, nil
+		}}, opt), nil
 	}
 
 	// Execute selection.
@@ -833,7 +833,7 @@ func TestSelect_Fill_Previous_Float(t *testing.T) {
 		t.Fatal(err)
 	} else if a := Iterators(itrs).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Nil: true}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2, Aggregated: 1}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 20 * Second, Value: 2}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 2}},
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 40 * Second, Value: 2}},
@@ -1441,10 +1441,10 @@ func TestSelect_ParenExpr(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if a := Iterators(itrs).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10, Aggregated: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100, Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}


### PR DESCRIPTION
A new attribute has been added to points to track how many points were
used to calculate that point. This is particularly useful for finding
the mean as we can then split mean calculation into two phases: one at
the shard level and a second at the shards level.

This optimization is now used so we don't have to hold so many points in
memory while calculating the mean.