### PR TITLE
influx_tsm: don't defer reader.Close() until after Open()

### DIFF
--- a/cmd/influx_tsm/b1/reader.go
+++ b/cmd/influx_tsm/b1/reader.go
@@ -93,11 +93,8 @@ func (r *Reader) Open() error {
 	if err != nil {
 		return err
 	}
-	for s, _ := range r.series {
-		if err != nil {
-			return err
-		}
 
+	for s := range r.series {
 		measurement := tsdb.MeasurementFromSeriesKey(s)
 		fields := r.fields[tsdb.MeasurementFromSeriesKey(s)]
 		if fields == nil {

--- a/cmd/influx_tsm/bz1/reader.go
+++ b/cmd/influx_tsm/bz1/reader.go
@@ -107,11 +107,8 @@ func (r *Reader) Open() error {
 	if err != nil {
 		return err
 	}
-	for s, _ := range r.series {
-		if err != nil {
-			return err
-		}
 
+	for s := range r.series {
 		measurement := tsdb.MeasurementFromSeriesKey(s)
 		fields := r.fields[tsdb.MeasurementFromSeriesKey(s)]
 		if fields == nil {

--- a/cmd/influx_tsm/main.go
+++ b/cmd/influx_tsm/main.go
@@ -322,12 +322,12 @@ func convertShard(si *tsdb.ShardInfo, tr *tracker) error {
 	default:
 		return fmt.Errorf("Unsupported shard format: %v", si.FormatAsString())
 	}
-	defer reader.Close()
 
 	// Open the shard, and create a converter.
 	if err := reader.Open(); err != nil {
 		return fmt.Errorf("Failed to open %v for conversion: %v", src, err)
 	}
+	defer reader.Close()
 	converter := NewConverter(dst, uint32(opts.TSMSize), tr)
 
 	// Perform the conversion.


### PR DESCRIPTION
Fixes #5656

/cc @jwilder 