### PR TITLE
influx_tsm: ignore shard index when converting b1 shards

### DIFF
--- a/cmd/influx_tsm/b1/reader.go
+++ b/cmd/influx_tsm/b1/reader.go
@@ -93,11 +93,8 @@ func (r *Reader) Open() error {
 	if err != nil {
 		return err
 	}
-	for s, _ := range r.series {
-		if err != nil {
-			return err
-		}
 
+	for s := range r.series {
 		measurement := tsdb.MeasurementFromSeriesKey(s)
 		fields := r.fields[tsdb.MeasurementFromSeriesKey(s)]
 		if fields == nil {

--- a/cmd/influx_tsm/b1/reader.go
+++ b/cmd/influx_tsm/b1/reader.go
@@ -15,6 +15,13 @@ const DefaultChunkSize = 1000
 
 var NoFieldsFiltered uint64
 
+var excludedBuckets = map[string]bool{
+	"fields": true,
+	"meta":   true,
+	"series": true,
+	"wal":    true,
+}
+
 // Reader is used to read all data from a b1 shard.
 type Reader struct {
 	path string
@@ -27,7 +34,6 @@ type Reader struct {
 	keyBuf    string
 	valuesBuf []tsm1.Value
 
-	series map[string]*tsdb.Series
 	fields map[string]*tsdb.MeasurementFields
 	codecs map[string]*tsdb.FieldCodec
 
@@ -38,7 +44,6 @@ type Reader struct {
 func NewReader(path string) *Reader {
 	return &Reader{
 		path:   path,
-		series: make(map[string]*tsdb.Series),
 		fields: make(map[string]*tsdb.MeasurementFields),
 		codecs: make(map[string]*tsdb.FieldCodec),
 	}
@@ -71,32 +76,31 @@ func (r *Reader) Open() error {
 		return err
 	}
 
-	// Load series
-	if err := r.db.View(func(tx *bolt.Tx) error {
-		meta := tx.Bucket([]byte("series"))
-		c := meta.Cursor()
+	seriesSet := make(map[string]bool)
 
-		for k, v := c.First(); k != nil; k, v = c.Next() {
-			series := &tsdb.Series{}
-			if err := series.UnmarshalBinary(v); err != nil {
-				return err
+	// ignore series index and find all series in this shard
+	if err := r.db.View(func(tx *bolt.Tx) error {
+		tx.ForEach(func(name []byte, _ *bolt.Bucket) error {
+			key := string(name)
+			if !excludedBuckets[key] {
+				seriesSet[key] = true
 			}
-			r.series[string(k)] = series
-		}
+			return nil
+		})
 		return nil
 	}); err != nil {
 		return err
 	}
 
-	// Create cursor for each field of each series.
 	r.tx, err = r.db.Begin(false)
 	if err != nil {
 		return err
 	}
 
-	for s := range r.series {
+	// Create cursor for each field of each series.
+	for s := range seriesSet {
 		measurement := tsdb.MeasurementFromSeriesKey(s)
-		fields := r.fields[tsdb.MeasurementFromSeriesKey(s)]
+		fields := r.fields[measurement]
 		if fields == nil {
 			atomic.AddUint64(&NoFieldsFiltered, 1)
 			continue

--- a/cmd/influx_tsm/bz1/reader.go
+++ b/cmd/influx_tsm/bz1/reader.go
@@ -107,11 +107,8 @@ func (r *Reader) Open() error {
 	if err != nil {
 		return err
 	}
-	for s, _ := range r.series {
-		if err != nil {
-			return err
-		}
 
+	for s := range r.series {
 		measurement := tsdb.MeasurementFromSeriesKey(s)
 		fields := r.fields[tsdb.MeasurementFromSeriesKey(s)]
 		if fields == nil {

--- a/cmd/influx_tsm/main.go
+++ b/cmd/influx_tsm/main.go
@@ -322,12 +322,12 @@ func convertShard(si *tsdb.ShardInfo, tr *tracker) error {
 	default:
 		return fmt.Errorf("Unsupported shard format: %v", si.FormatAsString())
 	}
-	defer reader.Close()
 
 	// Open the shard, and create a converter.
 	if err := reader.Open(); err != nil {
 		return fmt.Errorf("Failed to open %v for conversion: %v", src, err)
 	}
+	defer reader.Close()
 	converter := NewConverter(dst, uint32(opts.TSMSize), tr)
 
 	// Perform the conversion.

--- a/cmd/influx_tsm/main.go
+++ b/cmd/influx_tsm/main.go
@@ -42,7 +42,7 @@ The backed-up files must be removed manually, generally after starting up the
 node again to make sure all of data has been converted correctly.
 
 To restore a backup:
-  Shut down the node, remove the converted directory, and 
+  Shut down the node, remove the converted directory, and
   copy the backed-up directory to the original location.`
 
 type options struct {
@@ -54,7 +54,6 @@ type options struct {
 	Parallel       bool
 	SkipBackup     bool
 	UpdateInterval time.Duration
-	// Quiet          bool
 }
 
 func (o *options) Parse() error {
@@ -67,7 +66,6 @@ func (o *options) Parse() error {
 	fs.BoolVar(&opts.Parallel, "parallel", false, "Perform parallel conversion. (up to GOMAXPROCS shards at once)")
 	fs.BoolVar(&opts.SkipBackup, "nobackup", false, "Disable database backups. Not recommended.")
 	fs.StringVar(&opts.BackupPath, "backup", "", "The location to backup up the current databases. Must not be within the data directoryi.")
-	// fs.BoolVar(&opts.Quiet, "quiet", false, "Suppresses the regular status updates.")
 	fs.StringVar(&opts.DebugAddr, "debug", "", "If set, http debugging endpoints will be enabled on the given address")
 	fs.DurationVar(&opts.UpdateInterval, "interval", 5*time.Second, "How often status updates are printed.")
 	fs.Usage = func() {


### PR DESCRIPTION
This series preserves the comments of #5647 and the implementation of #5665, but squashes the relevant commits together for clarity. It differs slightly from #5665 by including additional buckets in the exclusion list so as to prevent spurious `Points without fields filtered` counts in the process output.
