### PR TITLE
Resolve merge conflict with #5570

### DIFF
--- a/cmd/influx_tsm/main.go
+++ b/cmd/influx_tsm/main.go
@@ -65,7 +65,7 @@ func (o *options) Parse() error {
 	fs.Uint64Var(&opts.TSMSize, "sz", maxTSMSz, "Maximum size of individual TSM files.")
 	fs.BoolVar(&opts.Parallel, "parallel", false, "Perform parallel conversion. (up to GOMAXPROCS shards at once)")
 	fs.BoolVar(&opts.SkipBackup, "nobackup", false, "Disable database backups. Not recommended.")
-	fs.StringVar(&opts.BackupPath, "backup", "", "The location to backup up the current databases. Must not be within the data directoryi.")
+	fs.StringVar(&opts.BackupPath, "backup", "", "The location to backup up the current databases. Must not be within the data directory.")
 	fs.StringVar(&opts.DebugAddr, "debug", "", "If set, http debugging endpoints will be enabled on the given address")
 	fs.DurationVar(&opts.UpdateInterval, "interval", 5*time.Second, "How often status updates are printed.")
 	fs.Usage = func() {


### PR DESCRIPTION
This change eliminates a trivial merge conflict between master and 0.10.0 by merging a trivial change (#5570) already in master into 0.10.0. The resulting commit will cleanly merge with master without spurious conflicts and does not introduce any additional unwanted changes (as can be verified with gitk 42d08c ^origin/0.10.0)
