### PR TITLE
Add more stats for httpd, query executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#5419](https://github.com/influxdata/influxdb/pull/5419): Graphite: Support matching tags multiple times Thanks @m4ce
 - [#5598](https://github.com/influxdata/influxdb/pull/5598): Client: Add Ping to v2 client @PSUdaemon
 - [#4125](https://github.com/influxdata/influxdb/pull/4125): Admin UI: Fetch and display server version on connect. Thanks @alexiri!
+- [#5681](https://github.com/influxdata/influxdb/pull/5681): Stats: Add durations, number currently active to httpd and query executor
 - [#5602](https://github.com/influxdata/influxdb/pull/5602): Simplify cluster startup for scripting and deployment
 - [#5666](https://github.com/influxdata/influxdb/pull/5666): Manage dependencies with gdm
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -164,6 +164,8 @@ func (h *Handler) SetRoutes(routes []route) {
 // ServeHTTP responds to HTTP request to the handler.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.statMap.Add(statRequest, 1)
+	h.statMap.Add(statRequestsActive, 1)
+	start := time.Now()
 
 	// FIXME(benbjohnson): Add pprof enabled flag.
 	if strings.HasPrefix(r.URL.Path, "/debug/pprof") {
@@ -182,6 +184,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		h.mux.ServeHTTP(w, r)
 	}
+
+	h.statMap.Add(statRequestsActive, -1)
+	h.statMap.Add(statRequestDuration, time.Since(start).Nanoseconds())
 }
 
 func (h *Handler) serveProcessContinuousQueries(w http.ResponseWriter, r *http.Request, user *meta.UserInfo) {
@@ -228,6 +233,9 @@ func (h *Handler) serveProcessContinuousQueries(w http.ResponseWriter, r *http.R
 // serveQuery parses an incoming query and, if valid, executes the query.
 func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.UserInfo) {
 	h.statMap.Add(statQueryRequest, 1)
+	defer func(start time.Time) {
+		h.statMap.Add(statQueryRequestDuration, time.Since(start).Nanoseconds())
+	}(time.Now())
 
 	q := r.URL.Query()
 	pretty := q.Get("pretty") == "true"
@@ -363,6 +371,9 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 
 func (h *Handler) serveWrite(w http.ResponseWriter, r *http.Request, user *meta.UserInfo) {
 	h.statMap.Add(statWriteRequest, 1)
+	defer func(start time.Time) {
+		h.statMap.Add(statWriteRequestDuration, time.Since(start).Nanoseconds())
+	}(time.Now())
 
 	// Handle gzip decoding of the body
 	body := r.Body

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -16,17 +16,21 @@ import (
 
 // statistics gathered by the httpd package.
 const (
-	statRequest                      = "req"               // Number of HTTP requests served
-	statCQRequest                    = "cqReq"             // Number of CQ-execute requests served
-	statQueryRequest                 = "queryReq"          // Number of query requests served
-	statWriteRequest                 = "writeReq"          // Number of write requests serverd
-	statPingRequest                  = "pingReq"           // Number of ping requests served
-	statStatusRequest                = "statusReq"         // Number of status requests served
-	statWriteRequestBytesReceived    = "writeReqBytes"     // Sum of all bytes in write requests
-	statQueryRequestBytesTransmitted = "queryRespBytes"    // Sum of all bytes returned in query reponses
-	statPointsWrittenOK              = "pointsWrittenOK"   // Number of points written OK
-	statPointsWrittenFail            = "pointsWrittenFail" // Number of points that failed to be written
-	statAuthFail                     = "authFail"          // Number of authentication failures
+	statRequest                      = "req"                // Number of HTTP requests served
+	statCQRequest                    = "cqReq"              // Number of CQ-execute requests served
+	statQueryRequest                 = "queryReq"           // Number of query requests served
+	statWriteRequest                 = "writeReq"           // Number of write requests serverd
+	statPingRequest                  = "pingReq"            // Number of ping requests served
+	statStatusRequest                = "statusReq"          // Number of status requests served
+	statWriteRequestBytesReceived    = "writeReqBytes"      // Sum of all bytes in write requests
+	statQueryRequestBytesTransmitted = "queryRespBytes"     // Sum of all bytes returned in query reponses
+	statPointsWrittenOK              = "pointsWrittenOK"    // Number of points written OK
+	statPointsWrittenFail            = "pointsWrittenFail"  // Number of points that failed to be written
+	statAuthFail                     = "authFail"           // Number of authentication failures
+	statRequestDuration              = "reqDurationNs"      // Number of (wall-time) nanoseconds spent inside requests
+	statQueryRequestDuration         = "queryReqDurationNs" // Number of (wall-time) nanoseconds spent inside query requests
+	statWriteRequestDuration         = "writeReqDurationNs" // Number of (wall-time) nanoseconds spent inside write requests
+	statRequestsActive               = "reqActive"          // Number of currently active requests
 )
 
 // Service manages the listener and handler for an HTTP endpoint.


### PR DESCRIPTION
Four new stats in httpd:

* `queryReqDurationNs`: time spent inside GET /query
* `writeReqDurationNs`: time spent inside POST /write
* `reqDurationNs`: time spent handling any HTTP request
* `reqActive`: number of currently active HTTP requests


Two new stats in query executor:

* `queryDurationNs`: time spent executing queries
* `queriesActive`: number of currently active/executing queries