### PR TITLE
Move monitor.Diagnostics to its own package

### DIFF
--- a/monitor/build_info.go
+++ b/monitor/build_info.go
@@ -1,5 +1,7 @@
 package monitor
 
+import "github.com/influxdata/influxdb/monitor/diagnostics"
+
 // system captures build diagnostics
 type build struct {
 	Version string
@@ -8,7 +10,7 @@ type build struct {
 	Time    string
 }
 
-func (b *build) Diagnostics() (*Diagnostic, error) {
+func (b *build) Diagnostics() (*diagnostics.Diagnostics, error) {
 	diagnostics := map[string]interface{}{
 		"Version":    b.Version,
 		"Commit":     b.Commit,
@@ -16,5 +18,5 @@ func (b *build) Diagnostics() (*Diagnostic, error) {
 		"Build Time": b.Time,
 	}
 
-	return DiagnosticFromMap(diagnostics), nil
+	return DiagnosticsFromMap(diagnostics), nil
 }

--- a/monitor/diagnostics/diagnostics.go
+++ b/monitor/diagnostics/diagnostics.go
@@ -1,0 +1,41 @@
+package diagnostics // import "github.com/influxdata/influxdb/monitor/diagnostics"
+
+// Client is the interface modules implement if they register diagnostics with monitor.
+type Client interface {
+	Diagnostics() (*Diagnostics, error)
+}
+
+// The ClientFunc type is an adapter to allow the use of
+// ordinary functions as Diagnostics clients.
+type ClientFunc func() (*Diagnostics, error)
+
+// Diagnostics calls f().
+func (f ClientFunc) Diagnostics() (*Diagnostics, error) {
+	return f()
+}
+
+// Diagnostics represents a table of diagnostic information. The first value
+// is the name of the columns, the second is a slice of interface slices containing
+// the values for each column, by row. This information is never written to an InfluxDB
+// system and is display-only. An example showing, say, connections follows:
+//
+//     source_ip    source_port       dest_ip     dest_port
+//     182.1.0.2    2890              127.0.0.1   38901
+//     174.33.1.2   2924              127.0.0.1   38902
+type Diagnostics struct {
+	Columns []string
+	Rows    [][]interface{}
+}
+
+// NewDiagnostic initialises a new Diagnostics with the specified columns.
+func NewDiagnostics(columns []string) *Diagnostics {
+	return &Diagnostics{
+		Columns: columns,
+		Rows:    make([][]interface{}, 0),
+	}
+}
+
+// AddRow appends the provided row to the Diagnostics' rows.
+func (d *Diagnostics) AddRow(r []interface{}) {
+	d.Rows = append(d.Rows, r)
+}

--- a/monitor/go_runtime.go
+++ b/monitor/go_runtime.go
@@ -2,12 +2,14 @@ package monitor
 
 import (
 	"runtime"
+
+	"github.com/influxdata/influxdb/monitor/diagnostics"
 )
 
 // goRuntime captures Go runtime diagnostics
 type goRuntime struct{}
 
-func (g *goRuntime) Diagnostics() (*Diagnostic, error) {
+func (g *goRuntime) Diagnostics() (*diagnostics.Diagnostics, error) {
 	diagnostics := map[string]interface{}{
 		"GOARCH":     runtime.GOARCH,
 		"GOOS":       runtime.GOOS,
@@ -15,5 +17,5 @@ func (g *goRuntime) Diagnostics() (*Diagnostic, error) {
 		"version":    runtime.Version(),
 	}
 
-	return DiagnosticFromMap(diagnostics), nil
+	return DiagnosticsFromMap(diagnostics), nil
 }

--- a/monitor/network.go
+++ b/monitor/network.go
@@ -2,12 +2,14 @@ package monitor
 
 import (
 	"os"
+
+	"github.com/influxdata/influxdb/monitor/diagnostics"
 )
 
 // network captures network diagnostics
 type network struct{}
 
-func (n *network) Diagnostics() (*Diagnostic, error) {
+func (n *network) Diagnostics() (*diagnostics.Diagnostics, error) {
 	h, err := os.Hostname()
 	if err != nil {
 		return nil, err
@@ -17,5 +19,5 @@ func (n *network) Diagnostics() (*Diagnostic, error) {
 		"hostname": h,
 	}
 
-	return DiagnosticFromMap(diagnostics), nil
+	return DiagnosticsFromMap(diagnostics), nil
 }

--- a/monitor/statement_executor.go
+++ b/monitor/statement_executor.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/monitor/diagnostics"
 )
 
 // StatementExecutor translates InfluxQL queries to Monitor methods.
 type StatementExecutor struct {
 	Monitor interface {
 		Statistics(map[string]string) ([]*Statistic, error)
-		Diagnostics() (map[string]*Diagnostic, error)
+		Diagnostics() (map[string]*diagnostics.Diagnostics, error)
 	}
 }
 

--- a/monitor/system.go
+++ b/monitor/system.go
@@ -3,6 +3,8 @@ package monitor
 import (
 	"os"
 	"time"
+
+	"github.com/influxdata/influxdb/monitor/diagnostics"
 )
 
 var startTime time.Time
@@ -14,7 +16,7 @@ func init() {
 // system captures system-level diagnostics
 type system struct{}
 
-func (s *system) Diagnostics() (*Diagnostic, error) {
+func (s *system) Diagnostics() (*diagnostics.Diagnostics, error) {
 	diagnostics := map[string]interface{}{
 		"PID":         os.Getpid(),
 		"currentTime": time.Now().UTC(),
@@ -22,5 +24,5 @@ func (s *system) Diagnostics() (*Diagnostic, error) {
 		"uptime":      time.Since(startTime).String(),
 	}
 
-	return DiagnosticFromMap(diagnostics), nil
+	return DiagnosticsFromMap(diagnostics), nil
 }

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -67,6 +67,7 @@ type Service struct {
 	statMap          *expvar.Map
 	tcpConnectionsMu sync.Mutex
 	tcpConnections   map[string]*tcpConnection
+	diagsKey         string
 
 	ln      net.Listener
 	addr    net.Addr
@@ -103,6 +104,7 @@ func NewService(c Config) (*Service, error) {
 		logger:         log.New(os.Stderr, "[graphite] ", log.LstdFlags),
 		tcpConnections: make(map[string]*tcpConnection),
 		done:           make(chan struct{}),
+		diagsKey:       strings.Join([]string{"graphite", d.Protocol, d.BindAddress}, ":"),
 	}
 
 	consistencyLevel, err := cluster.ParseConsistencyLevel(d.ConsistencyLevel)
@@ -133,13 +135,12 @@ func (s *Service) Open() error {
 
 	// Configure expvar monitoring. It's OK to do this even if the service fails to open and
 	// should be done before any data could arrive for the service.
-	key := strings.Join([]string{"graphite", s.protocol, s.bindAddress}, ":")
 	tags := map[string]string{"proto": s.protocol, "bind": s.bindAddress}
-	s.statMap = influxdb.NewStatistics(key, "graphite", tags)
+	s.statMap = influxdb.NewStatistics(s.diagsKey, "graphite", tags)
 
 	// Register diagnostics if a Monitor service is available.
 	if s.Monitor != nil {
-		s.Monitor.RegisterDiagnosticsClient(key, s)
+		s.Monitor.RegisterDiagnosticsClient(s.diagsKey, s)
 	}
 
 	if _, err := s.MetaClient.CreateDatabase(s.database); err != nil {
@@ -194,6 +195,11 @@ func (s *Service) Close() error {
 	if s.batcher != nil {
 		s.batcher.Stop()
 	}
+
+	if s.Monitor != nil {
+		s.Monitor.DeregisterDiagnosticsClient(s.diagsKey)
+	}
+
 	close(s.done)
 	s.wg.Wait()
 	s.done = nil

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/cluster"
-	"github.com/influxdata/influxdb/monitor"
+	"github.com/influxdata/influxdb/monitor/diagnostics"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"
 )
@@ -76,7 +76,7 @@ type Service struct {
 	done chan struct{}
 
 	Monitor interface {
-		RegisterDiagnosticsClient(name string, client monitor.DiagsClient)
+		RegisterDiagnosticsClient(name string, client diagnostics.Client)
 		DeregisterDiagnosticsClient(name string)
 	}
 	PointsWriter interface {
@@ -374,16 +374,15 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 }
 
 // Diagnostics returns diagnostics of the graphite service.
-func (s *Service) Diagnostics() (*monitor.Diagnostic, error) {
+func (s *Service) Diagnostics() (*diagnostics.Diagnostics, error) {
 	s.tcpConnectionsMu.Lock()
 	defer s.tcpConnectionsMu.Unlock()
 
-	d := &monitor.Diagnostic{
+	d := &diagnostics.Diagnostics{
 		Columns: []string{"local", "remote", "connect time"},
 		Rows:    make([][]interface{}, 0, len(s.tcpConnections)),
 	}
 	for _, v := range s.tcpConnections {
-		_ = v
 		d.Rows = append(d.Rows, []interface{}{v.conn.LocalAddr().String(), v.conn.RemoteAddr().String(), v.connectTime})
 	}
 	return d, nil

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/monitor"
+	"github.com/influxdata/influxdb/monitor/diagnostics"
 	"github.com/influxdata/influxdb/services/meta"
 )
 
@@ -46,7 +46,7 @@ type Service struct {
 	MetaClient  metaClient
 
 	Monitor interface {
-		RegisterDiagnosticsClient(name string, client monitor.DiagsClient)
+		RegisterDiagnosticsClient(name string, client diagnostics.Client)
 		DeregisterDiagnosticsClient(name string)
 	}
 }
@@ -188,11 +188,11 @@ func (s *Service) WriteShard(shardID, ownerID uint64, points []models.Point) err
 }
 
 // Diagnostics returns diagnostic information.
-func (s *Service) Diagnostics() (*monitor.Diagnostic, error) {
+func (s *Service) Diagnostics() (*diagnostics.Diagnostics, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	d := &monitor.Diagnostic{
+	d := &diagnostics.Diagnostics{
 		Columns: []string{"node", "active", "last modified", "head", "tail"},
 		Rows:    make([][]interface{}, 0, len(s.processors)),
 	}

--- a/services/hh/service.go
+++ b/services/hh/service.go
@@ -135,6 +135,10 @@ func (s *Service) Close() error {
 		}
 	}
 
+	if s.Monitor != nil {
+		s.Monitor.DeregisterDiagnosticsClient("hh")
+	}
+
 	if s.closing != nil {
 		close(s.closing)
 	}


### PR DESCRIPTION
I was trying to create a Diagnostics Client in the tsdb package, but IIRC importing `monitor` caused an import cycle of: tsdb -> monitor -> cluster -> tsdb.

Moving Diagnostics to its own package will allow further use of diagnostics.Client without running into import cycles.