### PR TITLE
tsm: ensure that snapshot writes are eventually retried/released, even if WriteSnapshot fails

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -55,7 +55,7 @@ func (e *entry) add(values []Value) {
 // deduplicate sorts and orders the entry's values. If values are already deduped and
 // and sorted, the function does no work and simply returns.
 func (e *entry) deduplicate() {
-	if !e.needSort || len(e.values) == 0 {
+	if !e.needSort || len(e.values) <= 1 {
 		return
 	}
 	e.values = e.values.Deduplicate()
@@ -81,6 +81,7 @@ const (
 type Cache struct {
 	mu      sync.RWMutex
 	store   map[string]*entry
+	dirty   map[string]*entry
 	size    uint64
 	maxSize uint64
 
@@ -173,6 +174,15 @@ func (c *Cache) Snapshot() *Cache {
 	snapshot := &Cache{
 		store: c.store,
 		size:  c.size,
+		dirty: make(map[string]*entry),
+	}
+
+	for k, e := range c.store {
+		if e.needSort {
+			snapshot.dirty[k] = &entry{needSort: true, values: e.values}
+		} else {
+			snapshot.dirty[k] = e
+		}
 	}
 
 	c.store = make(map[string]*entry)
@@ -192,9 +202,15 @@ func (c *Cache) Snapshot() *Cache {
 // Deduplicate sorts the snapshot before returning it. The compactor and any queries
 // coming in while it writes will need the values sorted
 func (c *Cache) Deduplicate() {
-	for _, e := range c.store {
+	for _, e := range c.dirty {
 		e.deduplicate()
 	}
+}
+
+// This method must be called while holding the write lock of the cache that
+// create this snapshot.
+func (c *Cache) UpdateStore() {
+	c.store, c.dirty = c.dirty, nil
 }
 
 // ClearSnapshot will remove the snapshot cache from the list of flushing caches and

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -166,8 +166,11 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 }
 
 // Snapshot will take a snapshot of the current cache, add it to the slice of caches that
-// are being flushed, and reset the current cache with new values
-func (c *Cache) Snapshot() *Cache {
+// are being flushed, and reset the current cache with new values.
+//
+// Every call to this method must be matched with exactly one corresponding call to either
+// CommitSnapshot() or RollbackSnapshot().
+func (c *Cache) PrepareSnapshot() *Cache {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -213,9 +216,14 @@ func (c *Cache) UpdateStore() {
 	c.store, c.dirty = c.dirty, nil
 }
 
-// ClearSnapshot will remove the snapshot cache from the list of flushing caches and
-// adjust the size
-func (c *Cache) ClearSnapshot(snapshot *Cache) {
+// RollbackSnapshot rolls back a previously prepared snapshot.
+func (c *Cache) RollbackSnapshot(snapshot *Cache) {
+	// TBD: replace placeholder with true implementation.
+}
+
+// CommitSnapshot will remove the snapshot cache from the list of flushing caches and
+// adjust the size of the list.
+func (c *Cache) CommitSnapshot(snapshot *Cache) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -91,6 +91,7 @@ type Cache struct {
 	// they are read only and should never be modified
 	snapshots     []*Cache
 	snapshotsSize uint64
+	files         []string
 
 	statMap      *expvar.Map // nil for snapshots.
 	lastSnapshot time.Time
@@ -166,12 +167,37 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 	return nil
 }
 
-// Snapshot will take a snapshot of the current cache, add it to the slice of caches that
-// are being flushed, and reset the current cache with new values.
+// Answers the names WAL segment files which are captured by the snapshot. The contents
+// of the specified files and the receiving snapshot should be identical.
+func (c *Cache) Files() []string {
+	return c.files
+}
+
+// Filter the specified list of files to exclude any file already referenced
+// by an existing snapshot
+func (c *Cache) newFiles(files []string) []string {
+	filtered := []string{}
+	existing := map[string]bool{}
+	for _, s := range c.snapshots {
+		for _, f := range s.files {
+			existing[f] = true
+		}
+	}
+	for _, f := range files {
+		if !existing[f] {
+			filtered = append(filtered, f)
+		}
+	}
+	return filtered
+}
+
+// PrepareSnapshots accepts a list of the closed files and prepares a new snapshot corresponding
+// to the changes in newly closed files that were not captured by previous snapshots. It returns a slice
+// containing references to every snapshot that has not yet been successfully committed.
 //
 // Every call to this method must be matched with exactly one corresponding call to either
-// CommitSnapshot() or RollbackSnapshot().
-func (c *Cache) PrepareSnapshot() *Cache {
+// CommitSnapshots() or RollbackSnapshots().
+func (c *Cache) PrepareSnapshots(files []string) []*Cache {
 
 	c.commit.Lock() // released by RollbackSnapshot() or CommitSnapshot()
 
@@ -182,6 +208,7 @@ func (c *Cache) PrepareSnapshot() *Cache {
 		store: c.store,
 		size:  c.size,
 		dirty: make(map[string]*entry),
+		files: c.newFiles(files),
 	}
 
 	for k, e := range c.store {
@@ -203,7 +230,10 @@ func (c *Cache) PrepareSnapshot() *Cache {
 	c.updateCachedBytes(snapshot.size)
 	c.updateSnapshots()
 
-	return snapshot
+	clone := make([]*Cache, len(c.snapshots))
+	copy(clone, c.snapshots)
+
+	return clone
 }
 
 // Deduplicate sorts the snapshot before returning it. The compactor and any queries
@@ -224,13 +254,29 @@ func (c *Cache) UpdateStore() {
 //
 // We leave the snapshots slice untouched because we need to use it to resolve
 // queries that hit the WAL segments.
-func (c *Cache) RollbackSnapshot() {
+// RollbackSnapshot rolls back a previously prepared snapshot by resetting
+// the
+
+func (c *Cache) RollbackSnapshots(incomplete []*Cache) {
 	defer c.commit.Unlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.snapshots = make([]*Cache, 0, len(incomplete)) // not strictly necessary since we expect incomplete[i] != nil for at least one i.
+	c.snapshotsSize = 0
+
+	// remove any snapshots that have been nil'd
+	for _, s := range incomplete {
+		if s != nil {
+			c.snapshots = append(c.snapshots, s)
+			c.snapshotsSize += s.Size()
+		}
+	}
 }
 
 // CommitSnapshot commits a previously prepared snapshot by reset the snapshots array
 // and releasing the commit lock.
-func (c *Cache) CommitSnapshot() {
+func (c *Cache) CommitSnapshots() {
 	defer c.commit.Unlock()
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -46,9 +46,9 @@ func TestCacheRace(t *testing.T) {
 	go func() {
 		wg.Done()
 		<-ch
-		s := c.PrepareSnapshot()
-		s.Deduplicate()
-		c.CommitSnapshot()
+		s := c.PrepareSnapshots([]string{"wal"})
+		s[len(s)-1].Deduplicate()
+		c.CommitSnapshots()
 	}()
 	close(ch)
 	wg.Wait()

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -46,9 +46,9 @@ func TestCacheRace(t *testing.T) {
 	go func() {
 		wg.Done()
 		<-ch
-		s := c.Snapshot()
+		s := c.PrepareSnapshot()
 		s.Deduplicate()
-		c.ClearSnapshot(s)
+		c.CommitSnapshot(s)
 	}()
 	close(ch)
 	wg.Wait()

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -1,0 +1,55 @@
+// +build !race
+
+package tsm1_test
+
+import (
+	"fmt"
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCacheRace(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000, "")
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(1)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		<-ch
+		s := c.Snapshot()
+		s.Deduplicate()
+		c.ClearSnapshot(s)
+	}()
+	close(ch)
+	wg.Wait()
+}

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -48,7 +48,7 @@ func TestCacheRace(t *testing.T) {
 		<-ch
 		s := c.PrepareSnapshot()
 		s.Deduplicate()
-		c.CommitSnapshot(s)
+		c.CommitSnapshot()
 	}()
 	close(ch)
 	wg.Wait()

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -147,7 +147,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Grab snapshot, and ensure it's as expected.
-	snapshot := c.Snapshot()
+	snapshot := c.PrepareSnapshot()
 	expValues := Values{v0, v1, v2, v3}
 	if deduped := snapshot.values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("snapshotted values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.ClearSnapshot(snapshot)
+	c.CommitSnapshot(snapshot)
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -188,7 +188,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	c := NewCache(512, "")
 
 	// Grab snapshot, and ensure it's as expected.
-	snapshot := c.Snapshot()
+	snapshot := c.PrepareSnapshot()
 	if deduped := snapshot.values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("snapshotted values for foo incorrect, exp: %v, got %v", nil, deduped)
 	}
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.ClearSnapshot(snapshot)
+	c.CommitSnapshot(snapshot)
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -222,13 +222,13 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Grab snapshot, write should still fail since we're still using the memory.
-	snapshot := c.Snapshot()
+	snapshot := c.PrepareSnapshot()
 	if err := c.Write("bar", Values{v1}); err != ErrCacheMemoryExceeded {
 		t.Fatalf("wrong error writing key bar to cache")
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.ClearSnapshot(snapshot)
+	c.CommitSnapshot(snapshot)
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.CommitSnapshot(snapshot)
+	c.CommitSnapshot()
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.CommitSnapshot(snapshot)
+	c.CommitSnapshot()
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -222,13 +222,13 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Grab snapshot, write should still fail since we're still using the memory.
-	snapshot := c.PrepareSnapshot()
+	_ = c.PrepareSnapshot()
 	if err := c.Write("bar", Values{v1}); err != ErrCacheMemoryExceeded {
 		t.Fatalf("wrong error writing key bar to cache")
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.CommitSnapshot(snapshot)
+	c.CommitSnapshot()
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -410,7 +410,6 @@ func (e *Engine) WriteTo(w io.Writer) (n int64, err error) { panic("not implemen
 func (e *Engine) WriteSnapshot() error {
 	// Lock and grab the cache snapshot along with all the closed WAL
 	// filenames associated with the snapshot
-
 	var started *time.Time
 
 	defer func() {
@@ -419,7 +418,7 @@ func (e *Engine) WriteSnapshot() error {
 		}
 	}()
 
-	closedFiles, snapshot, compactor, err := func() ([]string, *Cache, *Compactor, error) {
+	snapshots, compactor, err := func() ([]*Cache, *Compactor, error) {
 		e.mu.Lock()
 		defer e.mu.Unlock()
 
@@ -427,17 +426,17 @@ func (e *Engine) WriteSnapshot() error {
 		started = &now
 
 		if err := e.WAL.CloseSegment(); err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 
 		segments, err := e.WAL.ClosedSegments()
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 
-		snapshot := e.Cache.PrepareSnapshot()
+		snapshots := e.Cache.PrepareSnapshots(segments)
 
-		return segments, snapshot, e.Compactor.Clone(), nil
+		return snapshots, e.Compactor.Clone(), nil
 	}()
 
 	if err != nil {
@@ -447,6 +446,10 @@ func (e *Engine) WriteSnapshot() error {
 	// The snapshotted cache may have duplicate points and unsorted data.  We need to deduplicate
 	// it before writing the snapshot.  This can be very expensive so it's done while we are not
 	// holding the engine write lock.
+	//
+	// We only need to deduplicate the last snapshot, since any earlier snapshots would have
+	// been deduplicated when they were taken.
+	snapshot := snapshots[len(snapshots)-1]
 	snapshot.Deduplicate()
 
 	// once we are done, we need to quickly update the snapshot's store with the dirty slice (which is now
@@ -456,39 +459,63 @@ func (e *Engine) WriteSnapshot() error {
 	snapshot.UpdateStore()
 	e.Cache.mu.Unlock()
 
-	return e.writeSnapshotAndCommit(closedFiles, snapshot, compactor)
+	return e.writeSnapshotsAndCommit(snapshots, compactor)
 }
 
-// writeSnapshotAndCommit will write the passed cache to a new TSM file and remove the closed WAL segments
-func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) (err error) {
+// writeSnapshotsAndCommit will write the passed snapshots to new TSM files,
+// remove the corresponding closed WAL segments and commit the snapshot to the cache.
+//
+// Any snapshot not successfully written will be returned to the cache with RollbackSnapshots.
+func (e *Engine) writeSnapshotsAndCommit(snapshots []*Cache, compactor *Compactor) (err error) {
+
+	// ensure that any snapshot that was not completely written in returned
+	// to the cache
 	defer func() {
 		if err != nil {
-			e.Cache.RollbackSnapshot()
+
+			// at least one snapshot failed to write - rollback it
+			// and all remaining snapshots
+
+			e.Cache.RollbackSnapshots(snapshots)
 		}
 	}()
 
-	// write the new snapshot files
-	newFiles, err := compactor.WriteSnapshot(snapshot)
-	if err != nil {
-		e.logger.Printf("error writing snapshot from compactor: %v", err)
-		return err
-	}
+	for i, snapshot := range snapshots {
 
-	e.mu.RLock()
-	defer e.mu.RUnlock()
+		if closedFiles, err := func(snapshot *Cache) ([]string, error) {
+			// write the new snapshot files
+			newFiles, err := compactor.WriteSnapshot(snapshot)
+			if err != nil {
+				e.logger.Printf("error writing snapshot from compactor: %v", err)
+				return nil, err
+			}
+			e.mu.RLock()
+			defer e.mu.RUnlock()
 
-	// update the file store with these new files
-	if err := e.FileStore.Replace(nil, newFiles); err != nil {
-		e.logger.Printf("error adding new TSM files from snapshot: %v", err)
-		return err
+			// update the file store with these new files
+			if err := e.FileStore.Replace(nil, newFiles); err != nil {
+				e.logger.Printf("error adding new TSM files from snapshot: %v", err)
+				return nil, err
+			}
+
+			return snapshot.Files(), nil
+
+		}(snapshot); err != nil {
+			return err
+		} else if err := e.WAL.Remove(closedFiles); err != nil {
+
+			// TBD: isn't this really an error - don't we risk causing out of order
+			// writes if we leave WAL segments hanging around?
+
+			e.logger.Printf("error removing closed wal segments: %v", err)
+		}
+
+		// success! - mark the snapshot as completely written so that rollback will remove it
+		snapshots[i] = nil
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.CommitSnapshot()
-
-	if err := e.WAL.Remove(closedFiles); err != nil {
-		e.logger.Printf("error removing closed wal segments: %v", err)
-	}
+	e.Cache.CommitSnapshots()
 
 	return nil
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -460,7 +460,13 @@ func (e *Engine) WriteSnapshot() error {
 }
 
 // writeSnapshotAndCommit will write the passed cache to a new TSM file and remove the closed WAL segments
-func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) error {
+func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) (err error) {
+	defer func() {
+		if err != nil {
+			e.Cache.RollbackSnapshot(snapshot)
+		}
+	}()
+
 	// write the new snapshot files
 	newFiles, err := compactor.WriteSnapshot(snapshot)
 	if err != nil {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -449,6 +449,13 @@ func (e *Engine) WriteSnapshot() error {
 	// holding the engine write lock.
 	snapshot.Deduplicate()
 
+	// once we are done, we need to quickly update the snapshot's store with the dirty slice (which is now
+	// clean). We need to hold the cache write lock (rather than the snapshot write lock)
+	// since active users of the cache hold a read lock on the same object.
+	e.Cache.mu.Lock()
+	snapshot.UpdateStore()
+	e.Cache.mu.Unlock()
+
 	return e.writeSnapshotAndCommit(closedFiles, snapshot, compactor)
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -463,7 +463,7 @@ func (e *Engine) WriteSnapshot() error {
 func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) (err error) {
 	defer func() {
 		if err != nil {
-			e.Cache.RollbackSnapshot(snapshot)
+			e.Cache.RollbackSnapshot()
 		}
 	}()
 
@@ -484,7 +484,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.CommitSnapshot(snapshot)
+	e.Cache.CommitSnapshot()
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -435,7 +435,7 @@ func (e *Engine) WriteSnapshot() error {
 			return nil, nil, nil, err
 		}
 
-		snapshot := e.Cache.Snapshot()
+		snapshot := e.Cache.PrepareSnapshot()
 
 		return segments, snapshot, e.Compactor.Clone(), nil
 	}()
@@ -478,7 +478,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.ClearSnapshot(snapshot)
+	e.Cache.CommitSnapshot(snapshot)
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)


### PR DESCRIPTION
This is my attempt to fix the code review issue I identified in #5686.

The controversial aspect of this fix may be the introduction of a commit lock that ensures that
at most one thread is writing a snapshot for a given shard at a given time. I think the lock 
is justified because reasoning about concurrent execution of these code paths seems fraught with
danger. Of course, if there are contrary opinions, lets discuss.
