### PR TITLE
Clean up shard data when dropping retention policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 - [#5666](https://github.com/influxdata/influxdb/pull/5666): Manage dependencies with gdm
 - [#5512](https://github.com/influxdata/influxdb/pull/5512): HTTP: Add config option to enable HTTP JSON write path which is now disabled by default.
 - [#5336](https://github.com/influxdata/influxdb/pull/5366): Enabled golint for influxql. @gabelev
-- [#5706](https://github.com/influxdata/influxdb/pull/5706): Cluster setup
-cleanup
+- [#5706](https://github.com/influxdata/influxdb/pull/5706): Cluster setup cleanup
+- [#5691](https://github.com/influxdata/influxdb/pull/5691): Remove associated shard data when retention policies are dropped.
 
 ### Bugfixes
 

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -412,7 +412,7 @@ func (c *Client) RetentionPolicy(database, name string) (rpi *RetentionPolicyInf
 
 	// TODO: This should not be handled here
 	if db == nil {
-		return nil, ErrDatabaseNotExists
+		return nil, influxdb.ErrDatabaseNotFound(database)
 	}
 
 	return db.RetentionPolicy(name), nil


### PR DESCRIPTION
Fixes #5653.

 - Adds methods on the `tsdb.Store` for deleting shards in a retention policy, and cleaning up said retention policy.
 - Refactors `tsdb.Store.DeleteDatabase` so that it does not require the ids of the shards within the database.
 - Wires up deleting retention policy with the query executor (for the moment).

