### PR TITLE
Remove MetaServers from node.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#5557](https://github.com/influxdata/influxdb/issues/5630): Fixes panic when surrounding the select statement arguments in brackets
 - [#5628](https://github.com/influxdata/influxdb/issues/5628): Crashed the server with a bad derivative query
 - [#5532](https://github.com/influxdata/influxdb/issues/5532): user passwords not changeable in cluster
+- [#5695](https://github.com/influxdata/influxdb/pull/5695): Remove meta servers from node.json
 
 ## v0.10.0 [2016-02-04]
 

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -518,7 +518,7 @@ type Cluster struct {
 func NewCluster(size int) (*Cluster, error) {
 	c := Cluster{}
 	c.Servers = append(c.Servers, OpenServer(NewConfig(), ""))
-	metaServiceAddr := c.Servers[0].Node.MetaServers[0]
+	metaServiceAddr := c.Servers[0].MetaServers()[0]
 
 	for i := 1; i < size; i++ {
 		c.Servers = append(c.Servers, OpenServer(NewConfig(), metaServiceAddr))
@@ -548,7 +548,7 @@ func verifyCluster(c *Cluster, size int) error {
 	// grab only the meta nodes series
 	series := cl.Results[0].Series[0]
 	for i, value := range series.Values {
-		addr := c.Servers[i].Node.MetaServers[i]
+		addr := c.Servers[0].MetaServers()[0]
 		if value[0].(float64) != float64(i+1) {
 			return fmt.Errorf("expected nodeID %d, got %v", i, value[0])
 		}
@@ -594,7 +594,7 @@ func NewClusterCustom(size int, cb func(index int, config *run.Config)) (*Cluste
 	cb(0, config)
 
 	c.Servers = append(c.Servers, OpenServer(config, ""))
-	metaServiceAddr := c.Servers[0].Node.MetaServers[0]
+	metaServiceAddr := c.Servers[0].MetaServers()[0]
 
 	for i := 1; i < size; i++ {
 		config := NewConfig()

--- a/node.go
+++ b/node.go
@@ -16,15 +16,14 @@ const (
 )
 
 type Node struct {
-	path        string
-	ID          uint64
-	MetaServers []string
+	path string
+	ID   uint64
 }
 
 // LoadNode will load the node information from disk if present
-func LoadNode(path string, addrs []string) (*Node, error) {
+func LoadNode(path string) (*Node, error) {
 	// Always check to see if we are upgrading first
-	if err := upgradeNodeFile(path, addrs); err != nil {
+	if err := upgradeNodeFile(path); err != nil {
 		return nil, err
 	}
 
@@ -46,10 +45,9 @@ func LoadNode(path string, addrs []string) (*Node, error) {
 }
 
 // NewNode will return a new node
-func NewNode(path string, addrs []string) *Node {
+func NewNode(path string) *Node {
 	return &Node{
-		path:        path,
-		MetaServers: addrs,
+		path: path,
 	}
 }
 
@@ -75,26 +73,7 @@ func (n *Node) Save() error {
 	return os.Rename(tmpFile, file)
 }
 
-// AddMetaServers adds the addrs to the set of MetaServers known to this node.
-// If an addr already exists, it will not be re-added.
-func (n *Node) AddMetaServers(addrs []string) {
-	unique := map[string]struct{}{}
-	for _, addr := range n.MetaServers {
-		unique[addr] = struct{}{}
-	}
-
-	for _, addr := range addrs {
-		unique[addr] = struct{}{}
-	}
-
-	metaServers := []string{}
-	for addr := range unique {
-		metaServers = append(metaServers, addr)
-	}
-	n.MetaServers = metaServers
-}
-
-func upgradeNodeFile(path string, addrs []string) error {
+func upgradeNodeFile(path string) error {
 	oldFile := filepath.Join(path, oldNodeFile)
 	b, err := ioutil.ReadFile(oldFile)
 	if err != nil {
@@ -122,8 +101,7 @@ func upgradeNodeFile(path string, addrs []string) error {
 	}
 
 	n := &Node{
-		path:        path,
-		MetaServers: addrs,
+		path: path,
 	}
 	if n.ID, err = strconv.ParseUint(string(b), 10, 64); err != nil {
 		return err

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -1209,6 +1209,10 @@ func (c *Client) updateAuthCache() {
 	c.authCache = newCache
 }
 
+func (c *Client) MetaServers() []string {
+	return c.metaServers
+}
+
 type Peers []string
 
 func (peers Peers) Append(p ...string) Peers {

--- a/services/meta/handler.go
+++ b/services/meta/handler.go
@@ -54,7 +54,7 @@ func newHandler(c *Config, s *Service) *handler {
 		s:              s,
 		config:         c,
 		logger:         log.New(os.Stderr, "[meta-http] ", log.LstdFlags),
-		loggingEnabled: c.LoggingEnabled,
+		loggingEnabled: c.ClusterTracing,
 		closing:        make(chan struct{}),
 		leases:         NewLeases(time.Duration(c.LeaseDuration)),
 	}


### PR DESCRIPTION
This removes the MetaServers property from node.json to eliminate one
of the four places those addresses are stored on disk.  We always use
the values that come through the config (via file, env var or -join arg) to 
simplify the server bootstrapping code.

Part of work to complete #5673