### PR TITLE
tsm: cache: improve thread safety of Cache.Deduplicate (see #5699)

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -170,6 +170,8 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 // Snapshot will take a snapshot of the current cache, add it to the slice of caches that
 // are being flushed, and reset the current cache with new values
 func (c *Cache) Snapshot() *Cache {
+	c.commit.Lock() // must be released by a subsequent call to ClearSnapshot.
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -216,15 +218,19 @@ func (c *Cache) Deduplicate() {
 
 // ClearSnapshot will remove the snapshot cache from the list of flushing caches and
 // adjust the size
-func (c *Cache) ClearSnapshot() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+func (c *Cache) ClearSnapshot(success bool) {
+	defer c.commit.Unlock()
 
-	c.snapshotAttempts = 0
-	c.snapshotSize = 0
-	c.snapshot = nil
+	if success {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 
-	c.updateSnapshots()
+		c.snapshotAttempts = 0
+		c.snapshotSize = 0
+		c.snapshot = nil
+
+		c.updateSnapshots()
+	}
 }
 
 // Size returns the number of point-calcuated bytes the cache currently uses.

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -279,25 +279,8 @@ func (c *Cache) Keys() []string {
 // Values returns a copy of all values, deduped and sorted, for the given key.
 func (c *Cache) Values(key string) Values {
 	c.mu.RLock()
-	e := c.store[key]
-	if e != nil && e.needSort {
-		// Sorting is needed, so unlock and run the merge operation with
-		// a write-lock. It is actually possible that the data will be
-		// sorted by the time the merge runs, which would mean very occasionally
-		// a write-lock will be held when only a read-lock is required.
-		c.mu.RUnlock()
-		return func() Values {
-			c.mu.Lock()
-			defer c.mu.Unlock()
-			return c.merged(key)
-		}()
-	}
-
-	// No sorting required for key, so just merge while continuing to hold read-lock.
-	return func() Values {
-		defer c.mu.RUnlock()
-		return c.merged(key)
-	}()
+	defer c.mu.RUnlock()
+	return c.merged(key)
 }
 
 // Delete will remove the keys from the cache

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -17,6 +17,7 @@ var ErrCacheInvalidCheckpoint = fmt.Errorf("invalid checkpoint")
 
 // entry is a set of values and some metadata.
 type entry struct {
+	mu       sync.RWMutex
 	values   Values // All stored values.
 	needSort bool   // true if the values are out of order and require deduping.
 }
@@ -28,6 +29,8 @@ func newEntry() *entry {
 
 // add adds the given values to the entry.
 func (e *entry) add(values []Value) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	// See if the new values are sorted or contain duplicate timestamps
 	var prevTime int64
 	for _, v := range values {
@@ -55,11 +58,20 @@ func (e *entry) add(values []Value) {
 // deduplicate sorts and orders the entry's values. If values are already deduped and
 // and sorted, the function does no work and simply returns.
 func (e *entry) deduplicate() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	if !e.needSort || len(e.values) == 0 {
 		return
 	}
 	e.values = e.values.Deduplicate()
 	e.needSort = false
+}
+
+func (e *entry) count() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return len(e.values)
 }
 
 // Statistics gathered by the Cache.
@@ -79,6 +91,7 @@ const (
 
 // Cache maintains an in-memory store of Values for a set of keys.
 type Cache struct {
+	commit  sync.Mutex
 	mu      sync.RWMutex
 	store   map[string]*entry
 	size    uint64
@@ -186,12 +199,17 @@ func (c *Cache) Snapshot() *Cache {
 
 	// Append the current cache values to the snapshot
 	for k, e := range c.store {
+		e.mu.RLock()
 		if _, ok := c.snapshot.store[k]; ok {
 			c.snapshot.store[k].add(e.values)
 		} else {
 			c.snapshot.store[k] = e
 		}
 		c.snapshotSize += uint64(Values(e.values).Size())
+		if e.needSort {
+			c.snapshot.store[k].needSort = true
+		}
+		e.mu.RUnlock()
 	}
 
 	snapshotSize := c.size // record the number of bytes written into a snapshot
@@ -247,6 +265,9 @@ func (c *Cache) MaxSize() uint64 {
 
 // Keys returns a sorted slice of all keys under management by the cache.
 func (c *Cache) Keys() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	var a []string
 	for k, _ := range c.store {
 		a = append(a, k)
@@ -313,13 +334,13 @@ func (c *Cache) merged(key string) Values {
 		snapshotEntries := c.snapshot.store[key]
 		if snapshotEntries != nil {
 			entries = append(entries, snapshotEntries)
-			sz += len(snapshotEntries.values)
+			sz += snapshotEntries.count()
 		}
 	}
 
 	if e != nil {
 		entries = append(entries, e)
-		sz += len(e.values)
+		sz += e.count()
 	}
 
 	// Any entries? If not, return.
@@ -334,10 +355,12 @@ func (c *Cache) merged(key string) Values {
 	values := make(Values, sz)
 	n := 0
 	for _, e := range entries {
+		e.mu.RLock()
 		if !needSort && n > 0 {
 			needSort = values[n-1].UnixNano() >= e.values[0].UnixNano()
 		}
 		n += copy(values[n:], e.values)
+		e.mu.RUnlock()
 	}
 
 	if needSort {

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -55,3 +55,111 @@ func TestCheckConcurrentReadsAreSafe(t *testing.T) {
 	close(ch)
 	wg.Wait()
 }
+
+func TestCacheRace(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000, "")
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(1)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		<-ch
+		s := c.Snapshot()
+		s.Deduplicate()
+		c.ClearSnapshot()
+	}()
+	close(ch)
+	wg.Wait()
+}
+
+func TestCacheRace2Compacters(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000, "")
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(1)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	fileCounter := 0
+	mapFiles := map[int]bool{}
+	mu := sync.Mutex{}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			<-ch
+			s := c.Snapshot()
+			mu.Lock()
+			mapFiles[fileCounter] = true
+			fileCounter++
+			myFiles := map[int]bool{}
+			for k, e := range mapFiles {
+				myFiles[k] = e
+			}
+			mu.Unlock()
+			s.Deduplicate()
+			c.ClearSnapshot()
+			mu.Lock()
+			defer mu.Unlock()
+			for k, _ := range myFiles {
+				if _, ok := mapFiles[k]; !ok {
+					t.Fatalf("something else deleted one of my files")
+				} else {
+					delete(mapFiles, k)
+				}
+			}
+		}()
+	}
+	close(ch)
+	wg.Wait()
+}

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -1,0 +1,57 @@
+// +build !race
+
+package tsm1_test
+
+import (
+	"fmt"
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCheckConcurrentReadsAreSafe(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000, "")
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(3)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	close(ch)
+	wg.Wait()
+}

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -93,7 +93,7 @@ func TestCacheRace(t *testing.T) {
 		<-ch
 		s := c.Snapshot()
 		s.Deduplicate()
-		c.ClearSnapshot()
+		c.ClearSnapshot(true)
 	}()
 	close(ch)
 	wg.Wait()
@@ -148,7 +148,7 @@ func TestCacheRace2Compacters(t *testing.T) {
 			}
 			mu.Unlock()
 			s.Deduplicate()
-			c.ClearSnapshot()
+			c.ClearSnapshot(true)
 			mu.Lock()
 			defer mu.Unlock()
 			for k, _ := range myFiles {

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -228,7 +228,7 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -453,7 +453,13 @@ func (e *Engine) WriteSnapshot() error {
 }
 
 // writeSnapshotAndCommit will write the passed cache to a new TSM file and remove the closed WAL segments
-func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) error {
+func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) (err error) {
+
+	defer func() {
+		if err != nil {
+			e.Cache.ClearSnapshot(false)
+		}
+	}()
 	// write the new snapshot files
 	newFiles, err := compactor.WriteSnapshot(snapshot)
 	if err != nil {
@@ -471,7 +477,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.ClearSnapshot()
+	e.Cache.ClearSnapshot(true)
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)


### PR DESCRIPTION
Fixes #5699 

Cache.Deduplicate is designed to be execute while the caller is not holding
any locks.

The entry.deduplicate() method contains two statements:

e.values = e.values.Deduplicate()
e.needSort = false

which need to be executed in that order (as observed by all threads). However,
without a synchronization construct won't (necessarily) be executed in that order.

This fix makes a clone of each entry before performing the deduplication,
then while briefly holding the lock, updates the store with the deduplicated clones


Signed-off-by: Jon Seymour <jon@wildducktheories.com>