### PR TITLE
Fix meta.Client CreateDatabaseWithRetentionPolicy RPC command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#5695](https://github.com/influxdata/influxdb/pull/5695): Remove meta servers from node.json
 - [#5606](https://github.com/influxdata/influxdb/issues/5606): TSM conversion reproducibly drops data silently
 - [#5656](https://github.com/influxdata/influxdb/issues/5656): influx\_tsm: panic during conversion
+- [#5696](https://github.com/influxdata/influxdb/issues/5696): Do not drop the database when creating with a retention policy
 
 ## v0.10.0 [2016-02-04]
 

--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -64,9 +64,9 @@ func init() {
 				exp:     `{"results":[{}]}`,
 			},
 			&Query{
-				name:    "create database with retention duration should not error with existing database with IF NOT EXISTS",
+				name:    "create database with retention duration should error if retention policy is different with IF NOT EXISTS",
 				command: `CREATE DATABASE IF NOT EXISTS db1 WITH DURATION 24h`,
-				exp:     `{"results":[{}]}`,
+				exp:     `{"results":[{"error":"retention policy conflicts with an existing policy"}]}`,
 			},
 			&Query{
 				name:    "create database should error IF NOT EXISTS with bad retention duration",

--- a/services/meta/errors.go
+++ b/services/meta/errors.go
@@ -66,6 +66,10 @@ var (
 	ErrRetentionPolicyDurationTooLow = errors.New(fmt.Sprintf("retention policy duration must be at least %s",
 		MinRetentionPolicyDuration))
 
+	// ErrRetentionPolicyConflict is returned when creating a retention policy conflicts
+	// with an existing policy.
+	ErrRetentionPolicyConflict = errors.New("retention policy conflicts with an existing policy")
+
 	// ErrReplicationFactorTooLow is returned when the replication factor is not in an
 	// acceptable range.
 	ErrReplicationFactorTooLow = errors.New("replication factor must be greater than 0")

--- a/services/meta/internal/meta.pb.go
+++ b/services/meta/internal/meta.pb.go
@@ -174,18 +174,19 @@ func (x *Command_Type) UnmarshalJSON(data []byte) error {
 }
 
 type Data struct {
-	Term             *uint64         `protobuf:"varint,1,req,name=Term" json:"Term,omitempty"`
-	Index            *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
-	ClusterID        *uint64         `protobuf:"varint,3,req,name=ClusterID" json:"ClusterID,omitempty"`
-	Nodes            []*NodeInfo     `protobuf:"bytes,4,rep,name=Nodes" json:"Nodes,omitempty"`
-	Databases        []*DatabaseInfo `protobuf:"bytes,5,rep,name=Databases" json:"Databases,omitempty"`
-	Users            []*UserInfo     `protobuf:"bytes,6,rep,name=Users" json:"Users,omitempty"`
-	MaxNodeID        *uint64         `protobuf:"varint,7,req,name=MaxNodeID" json:"MaxNodeID,omitempty"`
-	MaxShardGroupID  *uint64         `protobuf:"varint,8,req,name=MaxShardGroupID" json:"MaxShardGroupID,omitempty"`
-	MaxShardID       *uint64         `protobuf:"varint,9,req,name=MaxShardID" json:"MaxShardID,omitempty"`
-	DataNodes        []*NodeInfo     `protobuf:"bytes,10,rep,name=DataNodes" json:"DataNodes,omitempty"`
-	MetaNodes        []*NodeInfo     `protobuf:"bytes,11,rep,name=MetaNodes" json:"MetaNodes,omitempty"`
-	XXX_unrecognized []byte          `json:"-"`
+	Term            *uint64         `protobuf:"varint,1,req,name=Term" json:"Term,omitempty"`
+	Index           *uint64         `protobuf:"varint,2,req,name=Index" json:"Index,omitempty"`
+	ClusterID       *uint64         `protobuf:"varint,3,req,name=ClusterID" json:"ClusterID,omitempty"`
+	Nodes           []*NodeInfo     `protobuf:"bytes,4,rep,name=Nodes" json:"Nodes,omitempty"`
+	Databases       []*DatabaseInfo `protobuf:"bytes,5,rep,name=Databases" json:"Databases,omitempty"`
+	Users           []*UserInfo     `protobuf:"bytes,6,rep,name=Users" json:"Users,omitempty"`
+	MaxNodeID       *uint64         `protobuf:"varint,7,req,name=MaxNodeID" json:"MaxNodeID,omitempty"`
+	MaxShardGroupID *uint64         `protobuf:"varint,8,req,name=MaxShardGroupID" json:"MaxShardGroupID,omitempty"`
+	MaxShardID      *uint64         `protobuf:"varint,9,req,name=MaxShardID" json:"MaxShardID,omitempty"`
+	// added for 0.10.0
+	DataNodes        []*NodeInfo `protobuf:"bytes,10,rep,name=DataNodes" json:"DataNodes,omitempty"`
+	MetaNodes        []*NodeInfo `protobuf:"bytes,11,rep,name=MetaNodes" json:"MetaNodes,omitempty"`
+	XXX_unrecognized []byte      `json:"-"`
 }
 
 func (m *Data) Reset()         { *m = Data{} }
@@ -644,6 +645,8 @@ func (m *Command) GetType() Command_Type {
 	return Command_CreateNodeCommand
 }
 
+// This isn't used in >= 0.10.0. Kept around for upgrade purposes. Instead
+// look at CreateDataNodeCommand and CreateMetaNodeCommand
 type CreateNodeCommand struct {
 	Host             *string `protobuf:"bytes,1,req,name=Host" json:"Host,omitempty"`
 	Rand             *uint64 `protobuf:"varint,2,req,name=Rand" json:"Rand,omitempty"`
@@ -709,8 +712,9 @@ var E_DeleteNodeCommand_Command = &proto.ExtensionDesc{
 }
 
 type CreateDatabaseCommand struct {
-	Name             *string `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Name             *string              `protobuf:"bytes,1,req,name=Name" json:"Name,omitempty"`
+	RetentionPolicy  *RetentionPolicyInfo `protobuf:"bytes,2,opt,name=RetentionPolicy" json:"RetentionPolicy,omitempty"`
+	XXX_unrecognized []byte               `json:"-"`
 }
 
 func (m *CreateDatabaseCommand) Reset()         { *m = CreateDatabaseCommand{} }
@@ -722,6 +726,13 @@ func (m *CreateDatabaseCommand) GetName() string {
 		return *m.Name
 	}
 	return ""
+}
+
+func (m *CreateDatabaseCommand) GetRetentionPolicy() *RetentionPolicyInfo {
+	if m != nil {
+		return m.RetentionPolicy
+	}
+	return nil
 }
 
 var E_CreateDatabaseCommand_Command = &proto.ExtensionDesc{
@@ -1604,6 +1615,8 @@ func (m *Response) GetIndex() uint64 {
 	return 0
 }
 
+// SetMetaNodeCommand is for the initial metanode in a cluster or
+// if the single host restarts and its hostname changes, this will update it
 type SetMetaNodeCommand struct {
 	HTTPAddr         *string `protobuf:"bytes,1,req,name=HTTPAddr" json:"HTTPAddr,omitempty"`
 	TCPAddr          *string `protobuf:"bytes,2,req,name=TCPAddr" json:"TCPAddr,omitempty"`

--- a/services/meta/internal/meta.proto
+++ b/services/meta/internal/meta.proto
@@ -120,12 +120,12 @@ message Command {
 		CreateSubscriptionCommand        = 21;
 		DropSubscriptionCommand          = 22;
 		RemovePeerCommand                = 23;
-        CreateMetaNodeCommand            = 24;
-        CreateDataNodeCommand            = 25;
-        UpdateDataNodeCommand            = 26;
-        DeleteMetaNodeCommand            = 27;
-        DeleteDataNodeCommand            = 28;
-        SetMetaNodeCommand               = 29;
+		CreateMetaNodeCommand            = 24;
+		CreateDataNodeCommand            = 25;
+		UpdateDataNodeCommand            = 26;
+		DeleteMetaNodeCommand            = 27;
+		DeleteDataNodeCommand            = 28;
+		SetMetaNodeCommand               = 29;
     }
 
     required Type type = 1;
@@ -154,6 +154,7 @@ message CreateDatabaseCommand {
         optional CreateDatabaseCommand command = 103;
     }
 	required string Name = 1;
+	optional RetentionPolicyInfo RetentionPolicy = 2;
 }
 
 message DropDatabaseCommand {
@@ -355,7 +356,7 @@ message DeleteDataNodeCommand {
     extend Command {
         optional DeleteDataNodeCommand command = 128;
     }
-    required uint64 ID = 1;    
+    required uint64 ID = 1;
 }
 
 message Response {


### PR DESCRIPTION
Previously, meta.Client would drop the default retention policy when
trying to create a database with a retention policy. The RPC has now
been modified to include the desired retention policy in the
CreateDatabase command and have it use that retention policy information
instead of the default configuration when provided.

This also lowers the number of RPC calls for
CreateDatabaseWithRetentionPolicy to only a single RPC call instead of
two.

Protections have also been included so creating a retention policy with
different parameters will return an error similar to if you tried to
modify the retention policy separately.

Fixes #5696.