### PR TITLE
Cluster Setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - [#5666](https://github.com/influxdata/influxdb/pull/5666): Manage dependencies with gdm
 - [#5512](https://github.com/influxdata/influxdb/pull/5512): HTTP: Add config option to enable HTTP JSON write path which is now disabled by default.
 - [#5336](https://github.com/influxdata/influxdb/pull/5366): Enabled golint for influxql. @gabelev
+- [#5706](https://github.com/influxdata/influxdb/pull/5706): Cluster setup
+cleanup
 
 ### Bugfixes
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -94,9 +94,18 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("apply env config: %v", err)
 	}
 
+	// Command-line flags for -join and -hostname override the config
+	// and env variable
 	if options.Join != "" {
 		config.Meta.JoinPeers = strings.Split(options.Join, ",")
 	}
+
+	if options.Hostname != "" {
+		config.Hostname = options.Hostname
+	}
+
+	// Propogate the top-level hostname down to dependendent configs
+	config.Meta.RemoteHostname = config.Hostname
 
 	// Validate the configuration.
 	if err := config.Validate(); err != nil {
@@ -156,6 +165,7 @@ func (cmd *Command) ParseFlags(args ...string) (Options, error) {
 	fs.StringVar(&options.ConfigPath, "config", "", "")
 	fs.StringVar(&options.PIDFile, "pidfile", "", "")
 	fs.StringVar(&options.Join, "join", "", "")
+	fs.StringVar(&options.Hostname, "hostname", "", "")
 	fs.StringVar(&options.CPUProfile, "cpuprofile", "", "")
 	fs.StringVar(&options.MemProfile, "memprofile", "", "")
 	fs.Usage = func() { fmt.Fprintln(cmd.Stderr, usage) }
@@ -215,7 +225,12 @@ then a new cluster will be initialized unless the -join argument is used.
                           Set the path to the configuration file.
 
         -join <host:port>
-                          Joins the server to an existing cluster. Should be the HTTP bind address of an existing meta server
+                          Joins the server to an existing cluster. Should be
+                          the HTTP bind address of an existing meta server
+
+        -hostname <name>
+                          Override the hostname, the 'hostname' configuration
+                          option will be overridden.
 
         -pidfile <path>
                           Write process ID to a file.
@@ -232,6 +247,7 @@ type Options struct {
 	ConfigPath string
 	PIDFile    string
 	Join       string
+	Hostname   string
 	CPUProfile string
 	MemProfile string
 }

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -62,6 +62,10 @@ type Config struct {
 
 	// BindAddress is the address that all TCP services use (Raft, Snapshot, Cluster, etc.)
 	BindAddress string `toml:"bind-address"`
+
+	// Hostname is the hostname portion to use when registering local
+	// addresses.  This hostname must be resolvable from other nodes.
+	Hostname string `toml:"hostname"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -48,6 +48,10 @@ type Config struct {
 	Enabled bool   `toml:"enabled"`
 	Dir     string `toml:"dir"`
 
+	// RemoteHostname is the hostname portion to use when registering meta node
+	// addresses.  This hostname must be resolvable from other nodes.
+	RemoteHostname string
+
 	// this is deprecated. Should use the address from run/config.go
 	BindAddress string `toml:"bind-address"`
 
@@ -101,20 +105,6 @@ func (c *Config) defaultHost(addr string) string {
 		return addr
 	}
 	return address
-}
-
-// DefaultedBindAddress returns the BindAddress normalized with the
-// hosts name or "localhost" if that could not be determined.  If
-// the BindAddress already has a hostname, BindAddress is returned.
-func (c *Config) DefaultedBindAddress() string {
-	return c.defaultHost(c.BindAddress)
-}
-
-// DefaultedHTTPBindAddress returns the HTTPBindAddress normalized with the
-// hosts name or "localhost" if that could not be determined.  If
-// the HTTPBindAddress already has a hostname, HTTPBindAddress is returned.
-func (c *Config) DefaultedHTTPBindAddress() string {
-	return c.defaultHost(c.HTTPBindAddress)
 }
 
 func DefaultHost(hostname, addr string) (string, error) {

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -50,7 +50,7 @@ type Config struct {
 
 	// RemoteHostname is the hostname portion to use when registering meta node
 	// addresses.  This hostname must be resolvable from other nodes.
-	RemoteHostname string
+	RemoteHostname string `toml:"-"`
 
 	// this is deprecated. Should use the address from run/config.go
 	BindAddress string `toml:"bind-address"`
@@ -61,7 +61,7 @@ type Config struct {
 	HTTPSCertificate string `toml:"https-certificate"`
 
 	// JoinPeers if specified gives other metastore servers to join this server to the cluster
-	JoinPeers            []string      `toml:"-"`
+	JoinPeers            []string      `toml:"join"`
 	RetentionAutoCreate  bool          `toml:"retention-autocreate"`
 	ElectionTimeout      toml.Duration `toml:"election-timeout"`
 	HeartbeatTimeout     toml.Duration `toml:"heartbeat-timeout"`
@@ -89,6 +89,7 @@ func NewConfig() *Config {
 		RaftPromotionEnabled: DefaultRaftPromotionEnabled,
 		LeaseDuration:        toml.Duration(DefaultLeaseDuration),
 		LoggingEnabled:       DefaultLoggingEnabled,
+		JoinPeers:            []string{},
 	}
 }
 

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -58,13 +58,29 @@ func (data *Data) CreateDataNode(host, tcpHost string) error {
 		}
 	}
 
+	// If an existing meta node exists with the same TCPHost address,
+	// then these nodes are actually the same so re-use the existing ID
+	var existingID uint64
+	for _, n := range data.MetaNodes {
+		if n.TCPHost == tcpHost {
+			existingID = n.ID
+			break
+		}
+	}
+
+	// We didn't find an existing node, so assign it a new node ID
+	if existingID == 0 {
+		data.MaxNodeID++
+		existingID = data.MaxNodeID
+	}
+
 	// Append new node.
-	data.MaxNodeID++
 	data.DataNodes = append(data.DataNodes, NodeInfo{
-		ID:      data.MaxNodeID,
+		ID:      existingID,
 		Host:    host,
 		TCPHost: tcpHost,
 	})
+	sort.Sort(NodeInfos(data.DataNodes))
 
 	return nil
 }
@@ -151,14 +167,31 @@ func (data *Data) CreateMetaNode(httpAddr, tcpAddr string) error {
 		}
 	}
 
+	// If an existing data node exists with the same TCPHost address,
+	// then these nodes are actually the same so re-use the existing ID
+	var existingID uint64
+	for _, n := range data.DataNodes {
+		if n.TCPHost == tcpAddr {
+			existingID = n.ID
+			break
+		}
+	}
+
+	// We didn't find and existing data node ID, so assign a new ID
+	// to this meta node.
+	if existingID == 0 {
+		data.MaxNodeID++
+		existingID = data.MaxNodeID
+	}
+
 	// Append new node.
-	data.MaxNodeID++
 	data.MetaNodes = append(data.MetaNodes, NodeInfo{
-		ID:      data.MaxNodeID,
+		ID:      existingID,
 		Host:    httpAddr,
 		TCPHost: tcpAddr,
 	})
 
+	sort.Sort(NodeInfos(data.MetaNodes))
 	return nil
 }
 

--- a/services/meta/raft_state.go
+++ b/services/meta/raft_state.go
@@ -104,15 +104,6 @@ func (r *raftState) open(s *store, ln net.Listener, initializePeers []string) er
 		peers = []string{r.addr}
 	}
 
-	// If we have multiple nodes in the cluster, make sure our address is in the raft peers or
-	// we won't be able to boot into the cluster because the other peers will reject our new hostname.  This
-	// is difficult to resolve automatically because we need to have all the raft peers agree on the current members
-	// of the cluster before we can change them.
-	if len(peers) > 0 && !raft.PeerContained(peers, r.addr) {
-		r.logger.Printf("%s is not in the list of raft peers. Please ensure all nodes have the same meta nodes configured", r.addr)
-		return fmt.Errorf("peers out of sync: %v not in %v", r.addr, peers)
-	}
-
 	// Create the log store and stable store.
 	store, err := raftboltdb.NewBoltStore(filepath.Join(r.path, "raft.db"))
 	if err != nil {

--- a/services/meta/raft_state.go
+++ b/services/meta/raft_state.go
@@ -233,6 +233,24 @@ func (r *raftState) removePeer(addr string) error {
 	if !r.isLeader() {
 		return raft.ErrNotLeader
 	}
+
+	peers, err := r.peerStore.Peers()
+	if err != nil {
+		return err
+	}
+
+	var exists bool
+	for _, p := range peers {
+		if addr == p {
+			exists = true
+			break
+		}
+	}
+
+	if !exists {
+		return nil
+	}
+
 	if fut := r.raft.RemovePeer(addr); fut.Error() != nil {
 		return fut.Error()
 	}


### PR DESCRIPTION
This PR addresses most of the issues from #5673.  Specifically, it changes the following:

* Ensures node IDs are the same when a node is running both meta and data services
* Allows bind addresses where a hostname or IP is not specified to work correctly and bind to all interfaces by default. e.g. `bind-address = ":8088"` will now bind to all interfaces instead of just `localhost`.
* Fixes the top-level `hostname` config option to allow overriding all bind address hostnames.  This allows a node to advertise a different hostname than what is defined in the bind address setting.  For example, if the config is `bind-address = ":8088"` and `hostname = "influx1"`, the node will bind to all interfaces on port `8088` and remote nodes will reach this node using the address `influx1:8088`.  If a `hostname` is not specified, we default to `localhost` for backwards compatibility.  This may change to `os.Hostname()` in the future if/when #5672 is implemented.
* Adds the `-hostname` command-line option back to allow specifying both `-join` and `-hostname` as command-line flags if desired.  
* Enforces a configuration precedence and overriding ability defined as config file is overridden by env vars which are overriden by command-line flags.  These options apply in order and update the `Config` used by the services and code.
* Adds the `join` config file option back to `meta` config.  This allows join servers to be specified in a config files, via env vars, or command-line flags and ordering precedence is the same as `-hostname`.

Fixes #5669

@corylanou 