### PR TITLE
tsdb: prevent fields with empty names being written by SELECT INTO 

### DIFF
--- a/tsdb/into.go
+++ b/tsdb/into.go
@@ -17,8 +17,10 @@ func convertRowToPoints(measurementName string, row *models.Row) ([]models.Point
 	for i, c := range row.Columns {
 		if c == "time" {
 			timeIndex = i
-		} else {
+		} else if c != "" {
 			fieldIndexes[c] = i
+		} else {
+			return nil, errors.New("error converting rows to points - empty field name encountered")
 		}
 	}
 


### PR DESCRIPTION
Currently, if one tries to run a SELECT INTO statement with a query whose
result set has an empty column names influx will panic (#5644, #5697) or enter an
infinite loop (#5712).

An example of a query which causes this problem is

    select count(value)/60 into cpu_hour from cpu group by time(1h)

It doesn't seem sane to create points with fields containing empty names,
so for now, return an error rather doing something we know is going
to cause a problem down the track.

A better alternative might be to assign/generate default names to such columns.

Signed-off-b: Jon Seymour <jon@wildducktheories.com>