### PR TITLE
models: tolerate empty field names when unpacking binary points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - [#5656](https://github.com/influxdata/influxdb/issues/5656): influx\_tsm: panic during conversion
 - [#5696](https://github.com/influxdata/influxdb/issues/5696): Do not drop the database when creating with a retention policy
 - [#5724](https://github.com/influxdata/influxdb/issues/5724): influx\_tsm doesn't close file handles properly
+- [#5664](https://github.com/influxdata/influxdb/issues/5664): panic in model.Points.scanTo #5664
+- [#5716](https://github.com/influxdata/influxdb/pull/5716): models: improve handling of points with empty field names or with no fields.
 
 ## v0.10.1 [2016-02-18]
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1772,3 +1772,17 @@ t159,label=another a=2i,value=1i 1`
 		t.Fatalf("expected 2 points, got %d", len(points))
 	}
 }
+
+func TestNewPointsWithBytesWithCorruptData(t *testing.T) {
+	corrupted := []byte{0, 0, 0, 3, 102, 111, 111, 0, 0, 0, 4, 61, 34, 65, 34, 1, 0, 0, 0, 14, 206, 86, 119, 24, 32, 72, 233, 168, 2, 148}
+	p, err := models.NewPointFromBytes(corrupted)
+	if p != nil || err == nil {
+		t.Fatalf("NewPointFromBytes: got: (%v, %v), expected: (nil, error)", p, err)
+	}
+}
+
+func TestNewPointsRejectsEmptyFieldNames(t *testing.T) {
+	if _, err := models.NewPoint("foo", nil, models.Fields{"": 1}, time.Now()); err == nil {
+		t.Fatalf("new point with empty field name. got: nil, expected: error")
+	}
+}


### PR DESCRIPTION
Prior to #5697 influx crashed with a panic if a binary point contained an empty field name. After #5697, influx entered an infinite loop in the same circumstance. With this commit, we silently elide any field with an empty field name when unmarshaling a binary point. A related PR (#5714) prevents SELECT INTO trying to create binary points with empty field names.

