### PR TITLE
Allow services (udp, graphite, collectd and opentsdb) to select database in each metric

### DIFF
--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -354,17 +354,20 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 	for {
 		select {
 		case batch := <-batcher.Out():
-			if err := s.PointsWriter.WritePoints(&cluster.WritePointsRequest{
-				Database:         s.database,
-				RetentionPolicy:  "",
-				ConsistencyLevel: s.consistencyLevel,
-				Points:           batch,
-			}); err == nil {
-				s.statMap.Add(statBatchesTransmitted, 1)
-				s.statMap.Add(statPointsTransmitted, int64(len(batch)))
-			} else {
-				s.logger.Printf("failed to write point batch to database %q: %s", s.database, err)
-				s.statMap.Add(statBatchesTransmitFail, 1)
+			for database, points := range batch {
+				if database == "" { database = s.database }
+				if err := s.PointsWriter.WritePoints(&cluster.WritePointsRequest{
+					Database:         database,
+					RetentionPolicy:  "",
+					ConsistencyLevel: s.consistencyLevel,
+					Points:           points,
+				}); err == nil {
+					s.statMap.Add(statBatchesTransmitted, 1)
+					s.statMap.Add(statPointsTransmitted, int64(len(batch)))
+				} else {
+					s.logger.Printf("failed to write point batch to database %q: %s", s.database, err)
+					s.statMap.Add(statBatchesTransmitFail, 1)
+				}
 			}
 
 		case <-s.done:


### PR DESCRIPTION
The main goal of this PR is to allow save metrics from UDP protocol in different databases.
I have modified batcher so it scans tags looking for a "database" tag. If found, it uses it a the destionation database for this particular point.

Batcher stores points in arrays and then deliver in batchs for writting. To avoid modifying Point struct, now it stores each point inside a map of arrays, with the keys being the different databases.
Services loop over this map saving points in their databases.

This is not a final PR, is just to discuss if this approach is acceptable.

Some things to review:
 - [now batcher arrays inside the map doesn't have max size](https://github.com/influxdata/influxdb/compare/master...adrianlzt:feature/add_inline_database_support?expand=1#diff-7d232e98093c93d07e46cb25bef71172R92)
 - [when batcher is asked to flush it checks if there is something to flush measuring the length of the array. Now len() return the number of keys. Change it to scan the arrays of all keys?](https://github.com/influxdata/influxdb/compare/master...adrianlzt:feature/add_inline_database_support?expand=1#diff-7d232e98093c93d07e46cb25bef71172R108)
- performance
- fix tests

This PR will solve #5156
Also probably this one will be easy #3329