### PR TITLE
Cleanup shards and shard groups when dropping data node

### DIFF
--- a/monitor/service.go
+++ b/monitor/service.go
@@ -71,12 +71,13 @@ type Monitor struct {
 // New returns a new instance of the monitor system.
 func New(c Config) *Monitor {
 	return &Monitor{
-		done:              make(chan struct{}),
-		diagRegistrations: make(map[string]diagnostics.Client),
-		storeEnabled:      c.StoreEnabled,
-		storeDatabase:     c.StoreDatabase,
-		storeInterval:     time.Duration(c.StoreInterval),
-		Logger:            log.New(os.Stderr, "[monitor] ", log.LstdFlags),
+		done:                 make(chan struct{}),
+		diagRegistrations:    make(map[string]diagnostics.Client),
+		storeEnabled:         c.StoreEnabled,
+		storeDatabase:        c.StoreDatabase,
+		storeInterval:        time.Duration(c.StoreInterval),
+		storeRetentionPolicy: MonitorRetentionPolicy,
+		Logger:               log.New(os.Stderr, "[monitor] ", log.LstdFlags),
 	}
 }
 

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -105,47 +105,120 @@ func (data *Data) setDataNode(nodeID uint64, host, tcpHost string) error {
 	return nil
 }
 
-// DeleteDataNode removes a node from the metadata.
+// DeleteDataNode removes a node from the Meta store.
+//
+// If necessary, DeleteDataNode reassigns ownership of any shards that
+// would otherwise become orphaned by the removal of the node from the
+// cluster.
 func (data *Data) DeleteDataNode(id uint64) error {
-	// Node has to be larger than 0 to be real
-	if id == 0 {
-		return ErrNodeIDRequired
-	}
-
-	// Remove node id from all shard infos
-	for di, d := range data.Databases {
-		for ri, rp := range d.RetentionPolicies {
-			for sgi, sg := range rp.ShardGroups {
-				for si, s := range sg.Shards {
-					if s.OwnedBy(id) {
-						var owners []ShardOwner
-						for _, o := range s.Owners {
-							if o.NodeID != id {
-								owners = append(owners, o)
-							}
-						}
-						data.Databases[di].RetentionPolicies[ri].ShardGroups[sgi].Shards[si].Owners = owners
-					}
-				}
-			}
-		}
-	}
-
-	// Remove this node from the in memory nodes
 	var nodes []NodeInfo
+
+	// Remove the data node from the store's list.
 	for _, n := range data.DataNodes {
-		if n.ID == id {
-			continue
+		if n.ID != id {
+			nodes = append(nodes, n)
 		}
-		nodes = append(nodes, n)
 	}
 
 	if len(nodes) == len(data.DataNodes) {
 		return ErrNodeNotFound
 	}
-
 	data.DataNodes = nodes
+
+	// Remove node id from all shard infos
+	for di, d := range data.Databases {
+		for ri, rp := range d.RetentionPolicies {
+			for sgi, sg := range rp.ShardGroups {
+				var (
+					nodeOwnerFreqs = make(map[int]int)
+					orphanedShards []ShardInfo
+				)
+				// Look through all shards in the shard group and
+				// determine (1) if a shard no longer has any owners
+				// (orphaned); (2) if all shards in the shard group
+				// are orphaned; and (3) the number of shards in this
+				// group owned by each data node in the cluster.
+				for si, s := range sg.Shards {
+					// Track of how many shards in the group are
+					// owned by each data node in the cluster.
+					var nodeIdx = -1
+					for i, owner := range s.Owners {
+						if owner.NodeID == id {
+							nodeIdx = i
+						}
+						nodeOwnerFreqs[int(owner.NodeID)]++
+					}
+
+					if nodeIdx > -1 {
+						// Data node owns shard, so relinquish ownership
+						// and set new owners on the shard.
+						s.Owners = append(s.Owners[:nodeIdx], s.Owners[nodeIdx+1:]...)
+						data.Databases[di].RetentionPolicies[ri].ShardGroups[sgi].Shards[si].Owners = s.Owners
+					}
+
+					// Shard no longer owned. Will need reassigning
+					// an owner.
+					if len(s.Owners) == 0 {
+						orphanedShards = append(orphanedShards, s)
+					}
+				}
+
+				// Mark the shard group as deleted if it has no shards,
+				// or all of its shards are orphaned.
+				if len(sg.Shards) == 0 || len(orphanedShards) == len(sg.Shards) {
+					data.Databases[di].RetentionPolicies[ri].ShardGroups[sgi].DeletedAt = time.Now().UTC()
+					continue
+				}
+
+				// Reassign any orphaned shards. Delete the node we're
+				// dropping from the list of potential new owners.
+				delete(nodeOwnerFreqs, int(id))
+
+				for _, orphan := range orphanedShards {
+					newOwnerID, err := newShardOwner(orphan, nodeOwnerFreqs)
+					if err != nil {
+						return err
+					}
+
+					for si, s := range sg.Shards {
+						if s.ID == orphan.ID {
+							sg.Shards[si].Owners = append(sg.Shards[si].Owners, ShardOwner{NodeID: newOwnerID})
+							data.Databases[di].RetentionPolicies[ri].ShardGroups[sgi].Shards = sg.Shards
+							break
+						}
+					}
+
+				}
+			}
+		}
+	}
 	return nil
+}
+
+// newShardOwner sets the owner of the provided shard to the data node
+// that currently owns the fewest number of shards. If multiple nodes
+// own the same (fewest) number of shards, then one of those nodes
+// becomes the new shard owner.
+func newShardOwner(s ShardInfo, ownerFreqs map[int]int) (uint64, error) {
+	var (
+		minId   = -1
+		minFreq int
+	)
+
+	for id, freq := range ownerFreqs {
+		if minId == -1 || freq < minFreq {
+			minId, minFreq = int(id), freq
+		}
+	}
+
+	if minId < 0 {
+		return 0, fmt.Errorf("cannot reassign shard %d due to lack of data nodes", s.ID)
+	}
+
+	// Update the shard owner frequencies and set the new owner on the
+	// shard.
+	ownerFreqs[minId]++
+	return uint64(minId), nil
 }
 
 // MetaNode returns a node by id.
@@ -1146,7 +1219,8 @@ type ShardGroupInfo struct {
 	Shards    []ShardInfo
 }
 
-// ShardGroupInfos is a collection of ShardGroupInfo
+// ShardGroupInfos implements sort.Interface on []ShardGroupInfo, based
+// on the StartTime field.
 type ShardGroupInfos []ShardGroupInfo
 
 func (a ShardGroupInfos) Len() int           { return len(a) }
@@ -1225,7 +1299,7 @@ type ShardInfo struct {
 	Owners []ShardOwner
 }
 
-// OwnedBy returns whether the shard's owner IDs includes nodeID.
+// OwnedBy determines whether the shard's owner IDs includes nodeID.
 func (si ShardInfo) OwnedBy(nodeID uint64) bool {
 	for _, so := range si.Owners {
 		if so.NodeID == nodeID {

--- a/services/meta/data_test.go
+++ b/services/meta/data_test.go
@@ -1,0 +1,31 @@
+package meta
+
+import (
+	"reflect"
+
+	"testing"
+)
+
+func TestnewShardOwner(t *testing.T) {
+	// An error is returned if there are no data nodes available.
+	_, err := newShardOwner(ShardInfo{}, map[int]int{})
+	if err == nil {
+		t.Error("got no error, but expected one")
+	}
+
+	ownerFreqs := map[int]int{1: 15, 2: 11, 3: 12}
+	id, err := newShardOwner(ShardInfo{ID: 4}, ownerFreqs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The ID that owns the fewest shards is returned.
+	if got, exp := id, uint64(2); got != exp {
+		t.Errorf("got id %d, expected id %d", got, exp)
+	}
+
+	// The ownership frequencies are updated.
+	if got, exp := ownerFreqs, map[int]int{1: 15, 2: 12, 3: 12}; !reflect.DeepEqual(got, exp) {
+		t.Errorf("got owner frequencies %v, expected %v", got, exp)
+	}
+}

--- a/services/meta/store_fsm.go
+++ b/services/meta/store_fsm.go
@@ -581,11 +581,6 @@ func (fsm *storeFSM) applyDeleteDataNodeCommand(cmd *internal.Command) interface
 	v := ext.(*internal.DeleteDataNodeCommand)
 
 	other := fsm.data.Clone()
-	node := other.DataNode(v.GetID())
-	if node == nil {
-		return ErrNodeNotFound
-	}
-
 	if err := other.DeleteDataNode(v.GetID()); err != nil {
 		return err
 	}


### PR DESCRIPTION
Will fix #5680.

When data nodes are deleted the following will now happen:

 - if a shard only had the data node being deleted as an owner, the shard will be removed from its shard group.
 - if a shard group has no shards left, it will be marked as deleted.