### PR TITLE
Update HTTP headers in meta service's httpd

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -195,6 +195,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 
 	if c.Meta.Enabled {
 		s.MetaService = meta.NewService(c.Meta)
+		s.MetaService.Version = s.buildInfo.Version
 	}
 
 	if c.Data.Enabled {

--- a/services/meta/handler.go
+++ b/services/meta/handler.go
@@ -24,8 +24,7 @@ import (
 
 // handler represents an HTTP handler for the meta service.
 type handler struct {
-	config  *Config
-	Version string
+	config *Config
 
 	logger         *log.Logger
 	loggingEnabled bool // Log every HTTP access.
@@ -422,7 +421,7 @@ func gzipFilter(inner http.Handler) http.Handler {
 // and adds the X-INFLUXBD-VERSION header to outgoing responses.
 func versionHeader(inner http.Handler, h *handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("X-InfluxDB-Version", h.Version)
+		w.Header().Add("X-InfluxDB-Version", h.s.Version)
 		inner.ServeHTTP(w, r)
 	})
 }

--- a/services/meta/handler.go
+++ b/services/meta/handler.go
@@ -254,6 +254,7 @@ func (h *handler) serveSnapshot(w http.ResponseWriter, r *http.Request) {
 			h.httpError(err, w, http.StatusInternalServerError)
 			return
 		}
+		w.Header().Add("Content-Type", "application/octet-stream")
 		w.Write(b)
 		return
 	case <-w.(http.CloseNotifier).CloseNotify():
@@ -312,6 +313,7 @@ func (h *handler) servePing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) servePeers(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(h.store.peers()); err != nil {
 		h.httpError(err, w, http.StatusInternalServerError)
@@ -380,7 +382,7 @@ func (h *handler) serveLease(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}
 	// Write the lease data.
-	w.Header().Add("content-type", "application/json")
+	w.Header().Add("Content-Type", "application/json")
 	w.Write(b)
 	return
 }

--- a/services/meta/service.go
+++ b/services/meta/service.go
@@ -19,6 +19,8 @@ const (
 type Service struct {
 	RaftListener net.Listener
 
+	Version string
+
 	config   *Config
 	handler  *handler
 	ln       net.Listener


### PR DESCRIPTION
The Version for X-Influxdb-Version was previously not being set, and now it is.

Also added a couple missing Content-Type headers.