### PR TITLE
(WIP) add cluster meta executor

### DIFF
--- a/cluster/internal/data.pb.go
+++ b/cluster/internal/data.pb.go
@@ -13,6 +13,8 @@ It has these top-level messages:
 	WriteShardResponse
 	MapShardRequest
 	MapShardResponse
+	ExecuteStatementRequest
+	ExecuteStatementResponse
 */
 package internal
 
@@ -151,4 +153,61 @@ func (m *MapShardResponse) GetFields() []string {
 		return m.Fields
 	}
 	return nil
+}
+
+type ExecuteStatementRequest struct {
+	Statement        *string `protobuf:"bytes,1,req,name=Statement" json:"Statement,omitempty"`
+	Database         *string `protobuf:"bytes,2,req,name=Database" json:"Database,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *ExecuteStatementRequest) Reset()         { *m = ExecuteStatementRequest{} }
+func (m *ExecuteStatementRequest) String() string { return proto.CompactTextString(m) }
+func (*ExecuteStatementRequest) ProtoMessage()    {}
+
+func (m *ExecuteStatementRequest) GetStatement() string {
+	if m != nil && m.Statement != nil {
+		return *m.Statement
+	}
+	return ""
+}
+
+func (m *ExecuteStatementRequest) GetDatabase() string {
+	if m != nil && m.Database != nil {
+		return *m.Database
+	}
+	return ""
+}
+
+type ExecuteStatementResponse struct {
+	Code             *int32  `protobuf:"varint,1,req,name=Code" json:"Code,omitempty"`
+	Message          *string `protobuf:"bytes,2,opt,name=Message" json:"Message,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *ExecuteStatementResponse) Reset()         { *m = ExecuteStatementResponse{} }
+func (m *ExecuteStatementResponse) String() string { return proto.CompactTextString(m) }
+func (*ExecuteStatementResponse) ProtoMessage()    {}
+
+func (m *ExecuteStatementResponse) GetCode() int32 {
+	if m != nil && m.Code != nil {
+		return *m.Code
+	}
+	return 0
+}
+
+func (m *ExecuteStatementResponse) GetMessage() string {
+	if m != nil && m.Message != nil {
+		return *m.Message
+	}
+	return ""
+}
+
+func init() {
+	proto.RegisterType((*WriteShardRequest)(nil), "internal.WriteShardRequest")
+	proto.RegisterType((*WriteShardResponse)(nil), "internal.WriteShardResponse")
+	proto.RegisterType((*MapShardRequest)(nil), "internal.MapShardRequest")
+	proto.RegisterType((*MapShardResponse)(nil), "internal.MapShardResponse")
+	proto.RegisterType((*ExecuteStatementRequest)(nil), "internal.ExecuteStatementRequest")
+	proto.RegisterType((*ExecuteStatementResponse)(nil), "internal.ExecuteStatementResponse")
 }

--- a/cluster/internal/data.proto
+++ b/cluster/internal/data.proto
@@ -23,3 +23,13 @@ message MapShardResponse {
     repeated string TagSets = 4;
     repeated string Fields = 5;
 }
+
+message ExecuteStatementRequest {
+    required string Statement = 1;
+    required string Database = 2;
+}
+
+message ExecuteStatementResponse {
+    required int32 Code = 1;
+    optional string Message = 2;
+}

--- a/cluster/meta_executor.go
+++ b/cluster/meta_executor.go
@@ -1,0 +1,153 @@
+package cluster
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/influxql"
+	"github.com/influxdata/influxdb/services/meta"
+)
+
+// MetaExecutor executes meta queries on all data nodes.
+type MetaExecutor struct {
+	mu             sync.RWMutex
+	timeout        time.Duration
+	pool           *clientPool
+	maxConnections int
+	Logger         *log.Logger
+	Node           *influxdb.Node
+
+	MetaClient interface {
+		DataNode(id uint64) (ni *meta.NodeInfo, err error)
+		DataNodes() ([]meta.NodeInfo, error)
+	}
+}
+
+// NewMetaExecutor returns a new initialized *MetaExecutor.
+func NewMetaExecutor() *MetaExecutor {
+	return &MetaExecutor{
+		timeout:        DefaultWriteTimeout,
+		pool:           newClientPool(),
+		maxConnections: 1000,
+		Logger:         log.New(os.Stderr, "[meta-executor] ", log.LstdFlags),
+	}
+}
+
+// ExecuteStatement executes a single InfluxQL statement on all nodes in the cluster concurrently.
+func (m *MetaExecutor) ExecuteStatement(stmt influxql.Statement, database string) error {
+	println("MetaExecutor.ExecuteStatement start")
+	defer println("MetaExecutor.ExecuteStatement end")
+	// Get a list of all nodes the query needs to be executed on.
+	nodes, err := m.MetaClient.DataNodes()
+	if err != nil {
+		return err
+	}
+
+	// Start a goroutine to execute the statement on each of the remote nodes.
+	var wg sync.WaitGroup
+	wg.Add(len(nodes))
+	errs := make(chan error)
+	defer close(errs)
+
+	for _, node := range nodes {
+		go func() {
+			defer wg.Done()
+			if err := m.executeOnNode(stmt, database, &node); err != nil {
+				errs <- err
+			}
+		}()
+	}
+
+	// Wait on all nodes to execute the statement and respond.
+	wg.Wait()
+
+	select {
+	case err = <-errs:
+		return err
+	default:
+		return nil
+	}
+}
+
+// executeOnNode executes a single InfluxQL statement on a single node.
+func (m *MetaExecutor) executeOnNode(stmt influxql.Statement, database string, node *meta.NodeInfo) error {
+	println("MetaExecutor.executeOnNode start")
+	defer println("MetaExecutor.executeOnNode end")
+	// Executing statement on the local node?
+	//if node.ID == m.Node.ID {
+	//	panic("fix me !!!!!!!!!!!!!!!!!!!")
+	//}
+
+	// We're executing on a remote node so establish a connection.
+	c, err := m.dial(node.ID)
+	if err != nil {
+		return err
+	}
+
+	conn, ok := c.(*pooledConn)
+	if !ok {
+		panic("wrong connection type in MetaExecutor")
+	}
+	// Return connection to pool by "closing" it.
+	defer func(conn net.Conn) { conn.Close() }(conn)
+
+	// Build RPC request.
+	var request ExecuteStatementRequest
+	request.SetStatement(stmt.String())
+	request.SetDatabase(database)
+
+	// Marshal into protocol buffer.
+	buf, err := request.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	// Send request.
+	conn.SetWriteDeadline(time.Now().Add(m.timeout))
+	if err := WriteTLV(conn, executeStatementRequestMessage, buf); err != nil {
+		conn.MarkUnusable()
+		return err
+	}
+
+	// Read the response.
+	conn.SetReadDeadline(time.Now().Add(m.timeout))
+	_, buf, err = ReadTLV(conn)
+	if err != nil {
+		conn.MarkUnusable()
+		return err
+	}
+
+	// Unmarshal response.
+	var response ExecuteStatementResponse
+	if err := response.UnmarshalBinary(buf); err != nil {
+		return err
+	}
+
+	if response.Code() != 0 {
+		return fmt.Errorf("error code %d: %s", response.Code(), response.Message())
+	}
+
+	return nil
+}
+
+// dial returns a connection to a single node in the cluster.
+func (m *MetaExecutor) dial(nodeID uint64) (net.Conn, error) {
+	// If we don't have a connection pool for that addr yet, create one
+	_, ok := m.pool.getPool(nodeID)
+	if !ok {
+		factory := &connFactory{nodeID: nodeID, clientPool: m.pool, timeout: m.timeout}
+		factory.metaClient = m.MetaClient
+
+		p, err := NewBoundedPool(1, m.maxConnections, m.timeout, factory.dial)
+		if err != nil {
+			return nil, err
+		}
+		m.pool.setPool(nodeID, p)
+	}
+	return m.pool.conn(nodeID)
+}

--- a/cluster/meta_executor.go
+++ b/cluster/meta_executor.go
@@ -55,12 +55,12 @@ func (m *MetaExecutor) ExecuteStatement(stmt influxql.Statement, database string
 	defer close(errs)
 
 	for _, node := range nodes {
-		go func() {
+		go func(node meta.NodeInfo) {
 			defer wg.Done()
 			if err := m.executeOnNode(stmt, database, &node); err != nil {
 				errs <- err
 			}
-		}()
+		}(node)
 	}
 
 	// Wait on all nodes to execute the statement and respond.
@@ -84,6 +84,7 @@ func (m *MetaExecutor) executeOnNode(stmt influxql.Statement, database string, n
 	//}
 
 	// We're executing on a remote node so establish a connection.
+	fmt.Printf("dialing: %v\n", node)
 	c, err := m.dial(node.ID)
 	if err != nil {
 		return err

--- a/cluster/meta_writer.go
+++ b/cluster/meta_writer.go
@@ -29,13 +29,5 @@ func NewMetaWriter() *MetaWriter {
 func (m *MetaWriter) DropDatabase(name string) error {
 	println("MetaWriter.DropDatabase start")
 	defer println("MetaWriter.DropDatabase end")
-	dbi, err := m.MetaClient.Database(name)
-	if err != nil {
-		return err
-	} else if dbi == nil {
-		return nil
-	}
-
-	// Remove the database from the local store
 	return m.TSDBStore.DeleteDatabase(name)
 }

--- a/cluster/meta_writer.go
+++ b/cluster/meta_writer.go
@@ -1,0 +1,41 @@
+package cluster
+
+import (
+	"log"
+	"os"
+
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxdb/tsdb"
+)
+
+// MetaWriter writes meta query changes to the local tsdb store.
+type MetaWriter struct {
+	TSDBStore *tsdb.Store
+	Logger    *log.Logger
+
+	MetaClient interface {
+		Database(name string) (*meta.DatabaseInfo, error)
+	}
+}
+
+// NewMetaWriter returns a new initialized *MetaWriter.
+func NewMetaWriter() *MetaWriter {
+	return &MetaWriter{
+		Logger: log.New(os.Stderr, "[meta-writer] ", log.LstdFlags),
+	}
+}
+
+// DropDatabase closes and deletes all local files for the database.
+func (m *MetaWriter) DropDatabase(name string) error {
+	println("MetaWriter.DropDatabase start")
+	defer println("MetaWriter.DropDatabase end")
+	dbi, err := m.MetaClient.Database(name)
+	if err != nil {
+		return err
+	} else if dbi == nil {
+		return nil
+	}
+
+	// Remove the database from the local store
+	return m.TSDBStore.DeleteDatabase(name)
+}

--- a/cluster/rpc.go
+++ b/cluster/rpc.go
@@ -219,3 +219,65 @@ func (w *WriteShardResponse) UnmarshalBinary(buf []byte) error {
 	}
 	return nil
 }
+
+// ExecuteStatementRequest represents the a request to execute a statement on a node.
+type ExecuteStatementRequest struct {
+	pb internal.ExecuteStatementRequest
+}
+
+// Statement returns the InfluxQL statement.
+func (r *ExecuteStatementRequest) Statement() string { return r.pb.GetStatement() }
+
+// SetStatement sets the InfluxQL statement.
+func (r *ExecuteStatementRequest) SetStatement(statement string) {
+	r.pb.Statement = proto.String(statement)
+}
+
+// Database returns the database name.
+func (r *ExecuteStatementRequest) Database() string { return r.pb.GetDatabase() }
+
+// SetDatabase sets the database name.
+func (r *ExecuteStatementRequest) SetDatabase(database string) { r.pb.Database = proto.String(database) }
+
+// MarshalBinary encodes the object to a binary format.
+func (m *ExecuteStatementRequest) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(&m.pb)
+}
+
+// UnmarshalBinary populates ExecuteStatementRequest from a binary format.
+func (m *ExecuteStatementRequest) UnmarshalBinary(buf []byte) error {
+	if err := proto.Unmarshal(buf, &m.pb); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ExecuteStatementResponse represents the response returned from a remote ExecuteStatementRequest call.
+type ExecuteStatementResponse struct {
+	pb internal.WriteShardResponse
+}
+
+// Code returns the response code.
+func (w *ExecuteStatementResponse) Code() int { return int(w.pb.GetCode()) }
+
+// SetCode sets the Code
+func (w *ExecuteStatementResponse) SetCode(code int) { w.pb.Code = proto.Int32(int32(code)) }
+
+// Message returns the repsonse message.
+func (w *ExecuteStatementResponse) Message() string { return w.pb.GetMessage() }
+
+// SetMessage sets the Message
+func (w *ExecuteStatementResponse) SetMessage(message string) { w.pb.Message = &message }
+
+// MarshalBinary encodes the object to a binary format.
+func (m *ExecuteStatementResponse) MarshalBinary() ([]byte, error) {
+	return proto.Marshal(&m.pb)
+}
+
+// UnmarshalBinary populates ExecuteStatementResponse from a binary format.
+func (m *ExecuteStatementResponse) UnmarshalBinary(buf []byte) error {
+	if err := proto.Unmarshal(buf, &m.pb); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"
@@ -48,8 +49,12 @@ type Service struct {
 	TSDBStore interface {
 		CreateShard(database, policy string, shardID uint64) error
 		WriteToShard(shardID uint64, points []models.Point) error
+		DeleteDatabase(name string, shardIDs []uint64) error
+		DeleteMeasurement(database, name string) error
 		// CreateMapper(shardID uint64, stmt influxql.Statement, chunkSize int) (tsdb.Mapper, error)
 	}
+
+	MetaWriter *MetaWriter
 
 	Logger  *log.Logger
 	statMap *expvar.Map
@@ -174,10 +179,44 @@ func (s *Service) handleConn(conn net.Conn) {
 					}
 				}
 			*/
+		case executeStatementRequestMessage:
+			err := s.processExecuteStatementRequest(buf)
+			if err != nil {
+				s.Logger.Printf("process execute statement error: %s", err)
+			}
+			s.writeShardResponse(conn, err)
 		default:
 			s.Logger.Printf("cluster service message type not found: %d", typ)
 		}
 	}
+}
+
+func (s *Service) processExecuteStatementRequest(buf []byte) error {
+	println("cluster.Service.processExecuteStatementRequest start")
+	defer println("cluster.Service.processExecuteStatementRequest end")
+	// Unmarshal the request.
+	var req ExecuteStatementRequest
+	if err := req.UnmarshalBinary(buf); err != nil {
+		return err
+	}
+
+	// Parse the InfluxQL statement.
+	stmt, err := influxql.ParseStatement(req.Statement())
+	if err != nil {
+		return err
+	}
+
+	return s.executeStatement(stmt)
+}
+
+func (s *Service) executeStatement(stmt influxql.Statement) error {
+	switch t := stmt.(type) {
+	case *influxql.DropDatabaseStatement:
+		s.MetaWriter.DropDatabase(t.Name)
+	default:
+		panic("statement not implemented")
+	}
+	return nil
 }
 
 func (s *Service) processWriteShardRequest(buf []byte) error {

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -49,9 +49,8 @@ type Service struct {
 	TSDBStore interface {
 		CreateShard(database, policy string, shardID uint64) error
 		WriteToShard(shardID uint64, points []models.Point) error
-		DeleteDatabase(name string, shardIDs []uint64) error
+		DeleteDatabase(name string) error
 		DeleteMeasurement(database, name string) error
-		// CreateMapper(shardID uint64, stmt influxql.Statement, chunkSize int) (tsdb.Mapper, error)
 	}
 
 	MetaWriter *MetaWriter

--- a/cluster/service_test.go
+++ b/cluster/service_test.go
@@ -23,11 +23,13 @@ func (m *metaClient) DataNode(nodeID uint64) (*meta.NodeInfo, error) {
 }
 
 type testService struct {
-	nodeID          uint64
-	ln              net.Listener
-	muxln           net.Listener
-	writeShardFunc  func(shardID uint64, points []models.Point) error
-	createShardFunc func(database, policy string, shardID uint64) error
+	nodeID                uint64
+	ln                    net.Listener
+	muxln                 net.Listener
+	writeShardFunc        func(shardID uint64, points []models.Point) error
+	createShardFunc       func(database, policy string, shardID uint64) error
+	deleteDatabaseFunc    func(database string) error
+	deleteMeasurementFunc func(database, name string) error
 }
 
 func newTestWriteService(f func(shardID uint64, points []models.Point) error) testService {
@@ -66,6 +68,14 @@ func (t testService) WriteToShard(shardID uint64, points []models.Point) error {
 
 func (t testService) CreateShard(database, policy string, shardID uint64) error {
 	return t.createShardFunc(database, policy, shardID)
+}
+
+func (t testService) DeleteDatabase(database string) error {
+	return t.deleteDatabaseFunc(database)
+}
+
+func (t testService) DeleteMeasurement(database, name string) error {
+	return t.deleteMeasurementFunc(database, name)
 }
 
 func writeShardSuccess(shardID uint64, points []models.Point) error {

--- a/cluster/shard_writer.go
+++ b/cluster/shard_writer.go
@@ -14,6 +14,8 @@ const (
 	writeShardResponseMessage
 	mapShardRequestMessage
 	mapShardResponseMessage
+	executeStatementRequestMessage
+	executeStatementResponseMessage
 )
 
 // ShardWriter writes a set of points to a shard.

--- a/cluster/shard_writer_test.go
+++ b/cluster/shard_writer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/influxdb/toml"
 )
 
-// Ensure the shard writer can successful write a single request.
+// Ensure the shard writer can successfully write a single request.
 func TestShardWriter_WriteShard_Success(t *testing.T) {
 	ts := newTestWriteService(writeShardSuccess)
 	s := cluster.NewService(cluster.Config{})

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -219,12 +219,17 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 		s.PointsWriter.Subscriber = s.Subscriber
 		s.PointsWriter.Node = s.Node
 
+		// Initialize meta executor.
+		metaExecutor := cluster.NewMetaExecutor()
+		metaExecutor.MetaClient = s.MetaClient
+
 		// Initialize query executor.
 		s.QueryExecutor = cluster.NewQueryExecutor()
 		s.QueryExecutor.MetaClient = s.MetaClient
 		s.QueryExecutor.TSDBStore = s.TSDBStore
 		s.QueryExecutor.Monitor = s.Monitor
 		s.QueryExecutor.PointsWriter = s.PointsWriter
+		s.QueryExecutor.MetaExecutor = metaExecutor
 		if c.Data.QueryLogEnabled {
 			s.QueryExecutor.LogOutput = os.Stderr
 		}
@@ -244,6 +249,9 @@ func (s *Server) appendClusterService(c cluster.Config) {
 	srv := cluster.NewService(c)
 	srv.TSDBStore = s.TSDBStore
 	srv.MetaClient = s.MetaClient
+	srv.MetaWriter = cluster.NewMetaWriter()
+	srv.MetaWriter.TSDBStore = s.TSDBStore
+	srv.MetaWriter.MetaClient = s.MetaClient
 	s.Services = append(s.Services, srv)
 	s.ClusterService = srv
 }


### PR DESCRIPTION
This PR adds `cluster.MetaExecutor` which distributes InfluxQL meta statements to all data nodes in the cluster for execution.  For example, when `DROP DATABASE foo` is executed, it goes through the following flow:
* HTTP API receives query
* HTTP API passes query to `cluster.QueryExecutor`
* `cluster.QueryExecutor` tells `meta.Client` to delete the database
* `cluster.QueryExecutor` tells `cluster.MetaExecutor` to execute the statement
* `cluster.MetaExecutor` creates an `executeStatementRequestMessage` RPC command which is sent to `cluster.Service` on all data nodes
* `cluster.Service` dispatches command to `cluster.Service.processExecuteStatementRequest`
* `cluster.Service.processExecuteStatementRequest` unmarshals the request, parses the statement, and passes it to `cluster.Service.executeStatement`
* `cluster.Service.executeStatement` switches on the statement type and calls `cluster.MetaWriter.DropDatabase`
* `cluster.MetaWriter.DropDatabase` calls `tsdb.Store.DeleteDatabase`

Errors propagate back from each node through RPC to the node that executed the statement on the cluster and that node returns failure if any node fails to execute.