### PR TITLE
Meta node only fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [#5664](https://github.com/influxdata/influxdb/issues/5664): panic in model.Points.scanTo #5664
 - [#5716](https://github.com/influxdata/influxdb/pull/5716): models: improve handling of points with empty field names or with no fields.
 - [#5719](https://github.com/influxdata/influxdb/issues/5719): Fix cache not deduplicating points
+- [#5754](https://github.com/influxdata/influxdb/issues/5754): Adding a node as meta only results in a data node also being registered
 
 ## v0.10.1 [2016-02-18]
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -94,6 +94,11 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("apply env config: %v", err)
 	}
 
+	// Propogate the top-level join options down to the meta config
+	if config.Join != "" {
+		config.Meta.JoinPeers = strings.Split(config.Join, ",")
+	}
+
 	// Command-line flags for -join and -hostname override the config
 	// and env variable
 	if options.Join != "" {

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -66,6 +66,8 @@ type Config struct {
 	// Hostname is the hostname portion to use when registering local
 	// addresses.  This hostname must be resolvable from other nodes.
 	Hostname string `toml:"hostname"`
+
+	Join string `toml:"join"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -142,13 +142,24 @@ func (c *Config) Validate() error {
 	if !c.Meta.Enabled && !c.Data.Enabled {
 		return errors.New("either Meta, Data, or both must be enabled")
 	}
-	if err := c.Meta.Validate(); err != nil {
-		return err
+
+	if c.Meta.Enabled {
+		if err := c.Meta.Validate(); err != nil {
+			return err
+		}
+
+		// If the config is for a meta-only node, we can't store monitor stats
+		// locally.
+		if c.Monitor.StoreEnabled && !c.Data.Enabled {
+			return fmt.Errorf("monitor storage can not be enabled on meta only nodes")
+		}
 	}
-	if err := c.Data.Validate(); err != nil {
-		return err
-	}
+
 	if c.Data.Enabled {
+		if err := c.Data.Validate(); err != nil {
+			return err
+		}
+
 		if err := c.HintedHandoff.Validate(); err != nil {
 			return err
 		}

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -82,7 +82,7 @@ enabled = true
 	} else if c.ContinuousQuery.Enabled != true {
 		t.Fatalf("unexpected continuous query enabled: %v", c.ContinuousQuery.Enabled)
 	} else if exp, got := "foo:123,bar:456", c.Join; exp != got {
-		t.Fatalf("unexpected join value: exp %v, got %v", exp, got)
+		t.Fatalf("unexpected join value: got %v, exp %v", got, exp)
 	}
 }
 
@@ -163,7 +163,7 @@ enabled = false
 	}
 
 	if e := c.Validate(); e == nil {
-		t.Fatalf("expected error, got nil")
+		t.Fatalf("got nil, expected error")
 	}
 }
 
@@ -183,6 +183,6 @@ enabled = false
 	}
 
 	if err := c.Validate(); err == nil {
-		t.Fatalf("expected error, got nil")
+		t.Fatalf("got nil, expected error")
 	}
 }

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -13,6 +13,8 @@ func TestConfig_Parse(t *testing.T) {
 	// Parse configuration.
 	var c run.Config
 	if _, err := toml.Decode(`
+join = "foo:123,bar:456"
+
 [meta]
 dir = "/tmp/meta"
 
@@ -79,6 +81,8 @@ enabled = true
 		t.Fatalf("unexpected subscriber enabled: %v", c.Subscriber.Enabled)
 	} else if c.ContinuousQuery.Enabled != true {
 		t.Fatalf("unexpected continuous query enabled: %v", c.ContinuousQuery.Enabled)
+	} else if exp, got := "foo:123,bar:456", c.Join; exp != got {
+		t.Fatalf("unexpected join value: exp %v, got %v", exp, got)
 	}
 }
 

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -166,3 +166,23 @@ enabled = false
 		t.Fatalf("expected error, got nil")
 	}
 }
+
+func TestConfig_ValidateMonitorStore_MetaOnly(t *testing.T) {
+	c := run.NewConfig()
+	if _, err := toml.Decode(`
+[monitor]
+store-enabled = true
+
+[meta]
+dir = "foo"
+
+[data]
+enabled = false
+`, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Validate(); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -187,6 +187,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	if c.Meta.Enabled {
 		s.MetaService = meta.NewService(c.Meta)
 		s.MetaService.Version = s.buildInfo.Version
+		s.MetaService.Node = s.Node
 	}
 
 	if c.Data.Enabled {
@@ -642,16 +643,18 @@ func (s *Server) initializeMetaClient() error {
 		return nil
 	}
 
-	n, err := s.MetaClient.CreateDataNode(s.HTTPAddr(), s.TCPAddr())
-	for err != nil {
-		log.Printf("Unable to create data node. retry in 1s: %s", err.Error())
-		time.Sleep(time.Second)
-		n, err = s.MetaClient.CreateDataNode(s.HTTPAddr(), s.TCPAddr())
-	}
-	s.Node.ID = n.ID
+	if s.config.Data.Enabled {
+		n, err := s.MetaClient.CreateDataNode(s.HTTPAddr(), s.TCPAddr())
+		for err != nil {
+			log.Printf("Unable to create data node. retry in 1s: %s", err.Error())
+			time.Sleep(time.Second)
+			n, err = s.MetaClient.CreateDataNode(s.HTTPAddr(), s.TCPAddr())
+		}
+		s.Node.ID = n.ID
 
-	if err := s.Node.Save(); err != nil {
-		return err
+		if err := s.Node.Save(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -838,8 +838,7 @@ func (c *Client) JoinMetaServer(httpAddr, tcpAddr string) (*NodeInfo, error) {
 		// Successfully joined
 		if resp.StatusCode == http.StatusOK {
 			defer resp.Body.Close()
-			dec := json.NewDecoder(resp.Body)
-			if err := dec.Decode(&node); err != nil {
+			if err := json.NewDecoder(resp.Body).Decode(&node); err != nil {
 				return nil, err
 			}
 			break

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -61,7 +61,7 @@ type Config struct {
 	HTTPSCertificate string `toml:"https-certificate"`
 
 	// JoinPeers if specified gives other metastore servers to join this server to the cluster
-	JoinPeers            []string      `toml:"join"`
+	JoinPeers            []string      `toml:"-"`
 	RetentionAutoCreate  bool          `toml:"retention-autocreate"`
 	ElectionTimeout      toml.Duration `toml:"election-timeout"`
 	HeartbeatTimeout     toml.Duration `toml:"heartbeat-timeout"`

--- a/services/meta/handler.go
+++ b/services/meta/handler.go
@@ -166,8 +166,7 @@ func (h *handler) serveExec(w http.ResponseWriter, r *http.Request) {
 
 		// Return the node with newly assigned ID as json
 		w.Header().Add("Content-Type", "application/json")
-		enc := json.NewEncoder(w)
-		if err := enc.Encode(node); err != nil {
+		if err := json.NewEncoder(w).Encode(node); err != nil {
 			h.httpError(err, w, http.StatusInternalServerError)
 		}
 

--- a/services/meta/service.go
+++ b/services/meta/service.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/influxdata/influxdb"
 )
 
 const (
@@ -31,6 +33,8 @@ type Service struct {
 	err      chan error
 	Logger   *log.Logger
 	store    *store
+
+	Node *influxdb.Node
 }
 
 // NewService returns a new instance of Service.
@@ -112,6 +116,7 @@ func (s *Service) Open() error {
 
 	// Open the store.  The addresses passed in are remotely accessible.
 	s.store = newStore(s.config, s.remoteAddr(s.httpAddr), s.remoteAddr(s.raftAddr))
+	s.store.node = s.Node
 
 	handler := newHandler(s.config, s)
 	handler.logger = s.Logger

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -1330,7 +1330,11 @@ func newService(cfg *meta.Config) *testService {
 	// Multiplex listener.
 	mux := tcp.NewMux()
 
+	if err != nil {
+		panic(err)
+	}
 	s := meta.NewService(cfg)
+	s.Node = influxdb.NewNode(cfg.Dir)
 	s.RaftListener = mux.Listen(meta.MuxHeader)
 
 	go mux.Serve(ln)


### PR DESCRIPTION
This fixes some issues that come up with creating meta-only nodes.

1. Monitor service defaults to storing statistics in the `_internal` database.  A meta-only node can't store anything itself so for now that config option has to be disabled.  The server will report that as a configuration error for now.
2. A data node was always getting created in the meta store regardless of whether the role of the node was actually a data node.  We now create the appropriate nodes based on the services that are enabled.
3. The `join` config file option was incorrectly exposed under the `[meta]` section as a string slice.  This has been revert and it's now a top-level string that matches the env var and `-join` flag (e.g.  `join = 'host1:8091,host2:9091"`).

Fixes #5754