### PR TITLE
Replace a panic with returning an error when an unsupported call is used

### DIFF
--- a/influxql/select.go
+++ b/influxql/select.go
@@ -321,7 +321,7 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 			opt.StartTime, opt.EndTime = MinTime, MaxTime
 			return newDerivativeIterator(input, opt, interval, isNonNegative), nil
 		default:
-			panic(fmt.Sprintf("unsupported call: %s", expr.Name))
+			return nil, fmt.Errorf("unsupported call: %s", expr.Name)
 		}
 
 		if err != nil {

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -1584,3 +1584,15 @@ func TestSelect_Derivative_Integer(t *testing.T) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
 }
+
+func TestSelect_UnsupportedCall(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &FloatIterator{}, nil
+	}
+
+	_, err := influxql.Select(MustParseSelectStatement(`SELECT foobar(value) FROM cpu`), &ic, nil)
+	if err == nil || err.Error() != "unsupported call: foobar" {
+		t.Errorf("unexpected error: %s", err)
+	}
+}


### PR DESCRIPTION
Fixes #5773.