### PR TITLE
Fix non-compiling test

### DIFF
--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -85,7 +85,7 @@ func TestCache_CacheWriteMulti_Duplicates(t *testing.T) {
 	v5 := NewValue(time.Unix(5, 0).UTC(), 3.0)
 	values1 := Values{v3, v4, v5}
 
-	c := NewCache(0)
+	c := NewCache(0, "")
 
 	if err := c.WriteMulti(map[string][]Value{"foo": values0}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())


### PR DESCRIPTION
Signature of `NewCache` changed in PR #5758, and while that PR was in development a new test was added. This change updates the new test to use the new signature, (hopefully) fixing the build.