### PR TITLE
Improvement on `run.NewServer` related to `meta.QueryAuthorizer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [#5716](https://github.com/influxdata/influxdb/pull/5716): models: improve handling of points with empty field names or with no fields.
 - [#5719](https://github.com/influxdata/influxdb/issues/5719): Fix cache not deduplicating points
 - [#5754](https://github.com/influxdata/influxdb/issues/5754): Adding a node as meta only results in a data node also being registered
+- [#5787](https://github.com/influxdata/influxdb/pull/5787): HTTP: Add QueryAuthorizer instance to httpd service’s handler. @chris-ramon
 
 ## v0.10.1 [2016-02-18]
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -289,6 +289,7 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 	}
 	srv := httpd.NewService(c)
 	srv.Handler.MetaClient = s.MetaClient
+	srv.Handler.QueryAuthorizer = meta.NewQueryAuthorizer(s.MetaClient)
 	srv.Handler.QueryExecutor = s.QueryExecutor
 	srv.Handler.PointsWriter = s.PointsWriter
 	srv.Handler.Version = s.buildInfo.Version

--- a/services/meta/query_authorizer.go
+++ b/services/meta/query_authorizer.go
@@ -10,6 +10,12 @@ type QueryAuthorizer struct {
 	Client *Client
 }
 
+func NewQueryAuthorizer(c *Client) *QueryAuthorizer {
+	return &QueryAuthorizer{
+		Client: c,
+	}
+}
+
 // AuthorizeQuery authorizes u to execute q on database.
 // Database can be "" for queries that do not require a database.
 // If no user is provided it will return an error unless the query's first statement is to create


### PR DESCRIPTION
##### Details:

- Commit: e3b4b71c introduced the type [`meta.QueryAuthorizer`](https://github.com/influxdata/influxdb/blob/master/services/meta/query_authorizer.go#L9) which is a field of [`httpd.Handler`](https://github.com/influxdata/influxdb/blob/master/services/httpd/handler.go#L67) and is used on [`httpd/handler.go`](https://github.com/influxdata/influxdb/blob/master/services/httpd/handler.go#L275) to validate authorization, like so:

```go
if h.requireAuthentication {
	if err := h.QueryAuthorizer.AuthorizeQuery(user, query, db); err != nil {
		if err, ok := err.(meta.ErrAuthorize); ok {
			h.Logger.Printf("unauthorized request | user: %q | query: %q | database %q\n", err.User, err.Query.String(), err.Database)
		}
		httpError(w, "error authorizing query: "+err.Error(), pretty, http.StatusUnauthorized)
		return
	}
}
```
- When [`run.NewServer`](https://github.com/influxdata/influxdb/blob/master/cmd/influxd/run/server.go#L108) wires all the services; and it [creates](https://github.com/influxdata/influxdb/blob/master/cmd/influxd/run/server.go#L286) new instance of `httpd.Service`, it does not set `*Handler.QueryAuthorizer` (due some reason I might be missing? cc/ @benbjohnson) - due this, performing http requests against [`run.Server`](https://github.com/influxdata/influxdb/blob/master/cmd/influxd/run/server.go#L51) will throw a run time error: `invalid memory address or nil pointer dereference`, because `*Handler.QueryAuthorizer` is `nil`.

- This PR updates `run.Server.appendHTTPDService` to set that missing `QueryAuthorizer` explained above.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/)