### PR TITLE
Simplify cache snapshotting

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -87,8 +87,8 @@ type Cache struct {
 	// snapshots are the cache objects that are currently being written to tsm files
 	// they're kept in memory while flushing so they can be queried along with the cache.
 	// they are read only and should never be modified
-	snapshots     []*Cache
-	snapshotsSize uint64
+	snapshot     *Cache
+	snapshotSize uint64
 
 	statMap      *expvar.Map // nil for snapshots.
 	lastSnapshot time.Time
@@ -107,7 +107,7 @@ func NewCache(maxSize uint64, path string) *Cache {
 	c.UpdateCompactTime(0)
 	c.updateCachedBytes(0)
 	c.updateMemSize(0)
-	c.updateSnapshots()
+	c.updateSnapshot()
 	return c
 }
 
@@ -119,7 +119,7 @@ func (c *Cache) Write(key string, values []Value) error {
 	// Enough room in the cache?
 	addedSize := Values(values).Size()
 	newSize := c.size + uint64(addedSize)
-	if c.maxSize > 0 && newSize+c.snapshotsSize > c.maxSize {
+	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
 		c.mu.Unlock()
 		return ErrCacheMemoryExceeded
 	}
@@ -145,7 +145,7 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 	// Enough room in the cache?
 	c.mu.RLock()
 	newSize := c.size + uint64(totalSz)
-	if c.maxSize > 0 && newSize+c.snapshotsSize > c.maxSize {
+	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
 		c.mu.RUnlock()
 		return ErrCacheMemoryExceeded
 	}
@@ -170,23 +170,33 @@ func (c *Cache) Snapshot() *Cache {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	snapshot := &Cache{
-		store: c.store,
-		size:  c.size,
+	// If no snapshot exists, create a new one, otherwise update the existing snapshot
+	if c.snapshot == nil {
+		c.snapshot = &Cache{
+			store: make(map[string]*entry),
+		}
 	}
 
+	// Append the current cache values to the snapshot
+	for k, e := range c.store {
+		if _, ok := c.snapshot.store[k]; ok {
+			c.snapshot.store[k].add(e.values)
+		} else {
+			c.snapshot.store[k] = e
+		}
+		c.snapshotSize += uint64(Values(e.values).Size())
+	}
+
+	// Reset the cache
 	c.store = make(map[string]*entry)
 	c.size = 0
 	c.lastSnapshot = time.Now()
 
-	c.snapshots = append(c.snapshots, snapshot)
-	c.snapshotsSize += snapshot.size
+	c.updateMemSize(-int64(c.snapshot.Size()))
+	c.updateCachedBytes(c.snapshot.Size())
+	c.updateSnapshot()
 
-	c.updateMemSize(-int64(snapshot.size))
-	c.updateCachedBytes(snapshot.size)
-	c.updateSnapshots()
-
-	return snapshot
+	return c.snapshot
 }
 
 // Deduplicate sorts the snapshot before returning it. The compactor and any queries
@@ -199,19 +209,14 @@ func (c *Cache) Deduplicate() {
 
 // ClearSnapshot will remove the snapshot cache from the list of flushing caches and
 // adjust the size
-func (c *Cache) ClearSnapshot(snapshot *Cache) {
+func (c *Cache) ClearSnapshot() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for i, cache := range c.snapshots {
-		if cache == snapshot {
-			c.snapshots = append(c.snapshots[:i], c.snapshots[i+1:]...)
-			c.snapshotsSize -= snapshot.size
-			break
-		}
-	}
+	c.snapshotSize = 0
+	c.snapshot = nil
 
-	c.updateSnapshots()
+	c.updateSnapshot()
 }
 
 // Size returns the number of point-calcuated bytes the cache currently uses.
@@ -277,7 +282,7 @@ func (c *Cache) Delete(keys []string) {
 func (c *Cache) merged(key string) Values {
 	e := c.store[key]
 	if e == nil {
-		if len(c.snapshots) == 0 {
+		if c.snapshot == nil {
 			// No values in hot cache or snapshots.
 			return nil
 		}
@@ -289,13 +294,15 @@ func (c *Cache) merged(key string) Values {
 	// Calculate the required size of the destination buffer.
 	var entries []*entry
 	sz := 0
-	for _, s := range c.snapshots {
-		e := s.store[key]
-		if e != nil {
-			entries = append(entries, e)
-			sz += len(e.values)
+
+	if c.snapshot != nil {
+		snapshotEntries := c.snapshot.store[key]
+		if snapshotEntries != nil {
+			entries = append(entries, snapshotEntries)
+			sz += len(snapshotEntries.values)
 		}
 	}
+
 	if e != nil {
 		entries = append(entries, e)
 		sz += len(e.values)
@@ -454,13 +461,13 @@ func (c *Cache) updateMemSize(b int64) {
 }
 
 // Update the snapshotsCount and the diskSize levels
-func (c *Cache) updateSnapshots() {
+func (c *Cache) updateSnapshot() {
 	// Update disk stats
 	diskSizeStat := new(expvar.Int)
-	diskSizeStat.Set(int64(c.snapshotsSize))
+	diskSizeStat.Set(int64(c.snapshotSize))
 	c.statMap.Set(statCacheDiskBytes, diskSizeStat)
 
 	snapshotsStat := new(expvar.Int)
-	snapshotsStat.Set(int64(len(c.snapshots)))
+	snapshotsStat.Set(int64(1))
 	c.statMap.Set(statSnapshots, snapshotsStat)
 }

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -222,13 +222,13 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Grab snapshot, write should still fail since we're still using the memory.
-	snapshot := c.Snapshot()
+	_ = c.Snapshot()
 	if err := c.Write("bar", Values{v1}); err != ErrCacheMemoryExceeded {
 		t.Fatalf("wrong error writing key bar to cache")
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -471,7 +471,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.ClearSnapshot(snapshot)
+	e.Cache.ClearSnapshot()
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)


### PR DESCRIPTION
The Cache had support for taking multiple snapshots to support writing
multiple snapshots to TSM files concurrently.  This was in place in case snapshotting the cache happened to be a bottleneck.  In practice, this is never a bottleneck and we only
run one snappshoting goroutine continously per shard which has worked
well for all workloads.

The multiple snapshot support introduces some unhandled failure scenarios
where wal segments could be removed without writing them to TSM files.  If
a snapshot compaction fails to write due to transient disk errors, subsequent
snapshots will continue, but the failed one will not be retried.  When the
subsequent ones succeeded, all closed wal segments are removed causing data
loss.

This change simplifies the snapshotting capability to ensure that there is only
ever one snapshot.  If one fails, the next snapshot will update the existing
snapshot and retry all of old and new data.

Fixes #5686