### PR TITLE
fix host of meta address is missing

### DIFF
--- a/services/meta/service.go
+++ b/services/meta/service.go
@@ -176,7 +176,7 @@ func (s *Service) Close() error {
 
 // HTTPAddr returns the bind address for the HTTP API
 func (s *Service) HTTPAddr() string {
-	return s.httpAddr
+	return s.remoteAddr(s.httpAddr)
 }
 
 // RaftAddr returns the bind address for the Raft TCP listener


### PR DESCRIPTION
````
[metaclient] 2016/02/23 15:56:22 failure getting snapshot from :8091: Get http://:8091?index=0: dial tcp :8091: connectex: The requested address is not valid in its context.
[metaclient] 2016/02/23 15:56:23 failure getting snapshot from :8091: Get http://:8091?index=0: dial tcp :8091: connectex: The requested address is not valid in its context.
````