### PR TITLE
tsm: cache: add a test that demonstrates a race condition.

### DIFF
--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -1,0 +1,55 @@
+// +build !race
+
+package tsm1_test
+
+import (
+	"fmt"
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCacheRace(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000, "")
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(1)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		<-ch
+		s := c.Snapshot()
+		s.Deduplicate()
+		c.ClearSnapshot()
+	}()
+	close(ch)
+	wg.Wait()
+}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -222,13 +222,13 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Grab snapshot, write should still fail since we're still using the memory.
-	snapshot := c.Snapshot()
+	_ = c.Snapshot()
 	if err := c.Write("bar", Values{v1}); err != ErrCacheMemoryExceeded {
 		t.Fatalf("wrong error writing key bar to cache")
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -471,7 +471,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.ClearSnapshot(snapshot)
+	e.Cache.ClearSnapshot()
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)


### PR DESCRIPTION
This a rebase of the test in #5701 that demonstrates that #5789 still subject to the issue addressed by #5701. 

I have kept the test case PR separate from the fix since the fix hasn't been accepted, but there is no reason why the test itself should not be.

To run the test, do:

   cd tsdb/engine/tsm1

Then run:

   GORACE=history=1000 go test -race cache_race_test.go
