### PR TITLE
tsm: cache: fix thread safety issue #5794.

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -79,6 +79,7 @@ const (
 
 // Cache maintains an in-memory store of Values for a set of keys.
 type Cache struct {
+	commit  sync.Mutex
 	mu      sync.RWMutex
 	store   map[string]*entry
 	dirty   map[string]*entry
@@ -168,6 +169,9 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 // Snapshot will take a snapshot of the current cache, add it to the slice of caches that
 // are being flushed, and reset the current cache with new values
 func (c *Cache) Snapshot() *Cache {
+
+	c.commit.Lock() // released by RollbackSnapshot() or CommitSnapshot()
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -228,14 +232,18 @@ func (c *Cache) UpdateStore() {
 
 // ClearSnapshot will remove the snapshot cache from the list of flushing caches and
 // adjust the size
-func (c *Cache) ClearSnapshot() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+func (c *Cache) ClearSnapshot(success bool) {
+	defer c.commit.Unlock()
 
-	c.snapshotSize = 0
-	c.snapshot = nil
+	if success {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 
-	c.updateSnapshots()
+		c.snapshotSize = 0
+		c.snapshot = nil
+
+		c.updateSnapshots()
+	}
 }
 
 // Size returns the number of point-calcuated bytes the cache currently uses.

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -198,13 +198,15 @@ func (c *Cache) Snapshot() *Cache {
 		}
 	}
 
+	snapshotBytes := c.size
+
 	// Reset the cache
 	c.store = make(map[string]*entry)
 	c.size = 0
 	c.lastSnapshot = time.Now()
 
-	c.updateMemSize(-int64(c.snapshot.Size()))
-	c.updateCachedBytes(c.snapshot.Size())
+	c.updateMemSize(-int64(snapshotBytes))
+	c.updateCachedBytes(snapshotBytes)
 	c.updateSnapshots()
 
 	return c.snapshot

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -1,0 +1,55 @@
+// +build !race
+
+package tsm1_test
+
+import (
+	"fmt"
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCacheRace(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000, "")
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(1)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		<-ch
+		s := c.Snapshot()
+		s.Deduplicate()
+		c.ClearSnapshot()
+	}()
+	close(ch)
+	wg.Wait()
+}

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -48,7 +48,7 @@ func TestCacheRace(t *testing.T) {
 		<-ch
 		s := c.Snapshot()
 		s.Deduplicate()
-		c.ClearSnapshot()
+		c.ClearSnapshot(true)
 	}()
 	close(ch)
 	wg.Wait()
@@ -103,7 +103,7 @@ func TestCacheRace2Compacters(t *testing.T) {
 			}
 			mu.Unlock()
 			s.Deduplicate()
-			c.ClearSnapshot()
+			c.ClearSnapshot(true)
 			mu.Lock()
 			defer mu.Unlock()
 			for k, _ := range myFiles {

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -53,3 +53,68 @@ func TestCacheRace(t *testing.T) {
 	close(ch)
 	wg.Wait()
 }
+
+func TestCacheRace2Compacters(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000, "")
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(1)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	fileCounter := 0
+	mapFiles := map[int]bool{}
+	mu := sync.Mutex{}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			<-ch
+			s := c.Snapshot()
+			mu.Lock()
+			mapFiles[fileCounter] = true
+			fileCounter++
+			myFiles := map[int]bool{}
+			for k, e := range mapFiles {
+				myFiles[k] = e
+			}
+			mu.Unlock()
+			s.Deduplicate()
+			c.ClearSnapshot()
+			mu.Lock()
+			defer mu.Unlock()
+			for k, _ := range myFiles {
+				if _, ok := mapFiles[k]; !ok {
+					t.Fatalf("something else deleted one of my files")
+				} else {
+					delete(mapFiles, k)
+				}
+			}
+		}()
+	}
+	close(ch)
+	wg.Wait()
+}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -228,7 +228,7 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -222,13 +222,13 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Grab snapshot, write should still fail since we're still using the memory.
-	snapshot := c.Snapshot()
+	_ = c.Snapshot()
 	if err := c.Write("bar", Values{v1}); err != ErrCacheMemoryExceeded {
 		t.Fatalf("wrong error writing key bar to cache")
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -471,7 +471,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.ClearSnapshot(snapshot)
+	e.Cache.ClearSnapshot()
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -449,6 +449,13 @@ func (e *Engine) WriteSnapshot() error {
 	// holding the engine write lock.
 	snapshot.Deduplicate()
 
+	// once we are done, we need to quickly update the snapshot's store with the dirty slice (which is now
+	// clean). We need to hold the cache write lock (rather than the snapshot write lock)
+	// since active users of the cache hold a read lock on the same object.
+	e.Cache.mu.Lock()
+	snapshot.UpdateStore()
+	e.Cache.mu.Unlock()
+
 	return e.writeSnapshotAndCommit(closedFiles, snapshot, compactor)
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -460,7 +460,13 @@ func (e *Engine) WriteSnapshot() error {
 }
 
 // writeSnapshotAndCommit will write the passed cache to a new TSM file and remove the closed WAL segments
-func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) error {
+func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) (err error) {
+
+	defer func() {
+		if err != nil {
+			e.Cache.ClearSnapshot(false)
+		}
+	}()
 	// write the new snapshot files
 	newFiles, err := compactor.WriteSnapshot(snapshot)
 	if err != nil {
@@ -478,7 +484,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.ClearSnapshot()
+	e.Cache.ClearSnapshot(true)
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)


### PR DESCRIPTION
A re-implementation of #5701 against #5789.

In addition to fixing the thread safety issue, the branch also fixes a statistics accounting issue in the implementation of #5789.