### PR TITLE
Remove dimensions from field wildcards

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -973,38 +973,38 @@ func (s *SelectStatement) RewriteWildcards(ic IteratorCreator) (*SelectStatement
 	other := s.Clone()
 
 	// Rewrite all wildcard query fields
-	rwFields := make(Fields, 0, len(s.Fields))
-	for _, f := range s.Fields {
-		switch f.Expr.(type) {
-		case *Wildcard:
-			for _, name := range fields {
-				rwFields = append(rwFields, &Field{Expr: &VarRef{Val: name}})
+	if hasFieldWildcard {
+		// Allocate a slice assuming there is exactly one wildcard for efficiency.
+		rwFields := make(Fields, 0, len(s.Fields)+len(fields)-1)
+		for _, f := range s.Fields {
+			switch f.Expr.(type) {
+			case *Wildcard:
+				for _, name := range fields {
+					rwFields = append(rwFields, &Field{Expr: &VarRef{Val: name}})
+				}
+			default:
+				rwFields = append(rwFields, f)
 			}
-		default:
-			rwFields = append(rwFields, f)
 		}
+		other.Fields = rwFields
 	}
-	other.Fields = rwFields
 
 	// Rewrite all wildcard GROUP BY fields
-	rwDimensions := make(Dimensions, 0, len(s.Dimensions))
-	for _, d := range s.Dimensions {
-		switch d.Expr.(type) {
-		case *Wildcard:
-			for _, name := range dimensions {
-				rwDimensions = append(rwDimensions, &Dimension{Expr: &VarRef{Val: name}})
+	if hasDimensionWildcard {
+		// Allocate a slice assuming there is exactly one wildcard for efficiency.
+		rwDimensions := make(Dimensions, 0, len(s.Dimensions)+len(dimensions)-1)
+		for _, d := range s.Dimensions {
+			switch d.Expr.(type) {
+			case *Wildcard:
+				for _, name := range dimensions {
+					rwDimensions = append(rwDimensions, &Dimension{Expr: &VarRef{Val: name}})
+				}
+			default:
+				rwDimensions = append(rwDimensions, d)
 			}
-		default:
-			rwDimensions = append(rwDimensions, d)
 		}
+		other.Dimensions = rwDimensions
 	}
-
-	if hasFieldWildcard && !hasDimensionWildcard {
-		for _, name := range dimensions {
-			rwDimensions = append(rwDimensions, &Dimension{Expr: &VarRef{Val: name}})
-		}
-	}
-	other.Dimensions = rwDimensions
 
 	return other, nil
 }

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -356,16 +356,22 @@ func TestSelectStatement_RewriteWildcards(t *testing.T) {
 		// Parser fundamentally prohibits multiple query sources
 
 		// Query wildcard with explicit
-		// {
-		//	stmt:    `SELECT *,value1 FROM cpu`,
-		//		rewrite: `SELECT value1, value2, value1 FROM cpu`,
-		//	},
+		{
+			stmt:    `SELECT *,value1 FROM cpu`,
+			rewrite: `SELECT host, region, value1, value2, value1 FROM cpu`,
+		},
 
 		// Query multiple wildcards
-		//	{
-		//			stmt:    `SELECT *,* FROM cpu`,
-		//			rewrite: `SELECT value1,value2,value1,value2 FROM cpu`,
-		//  },
+		{
+			stmt:    `SELECT *,* FROM cpu`,
+			rewrite: `SELECT host, region, value1, value2, host, region, value1, value2 FROM cpu`,
+		},
+
+		// Query wildcards with group by
+		{
+			stmt:    `SELECT * FROM cpu GROUP BY host`,
+			rewrite: `SELECT region, value1, value2 FROM cpu GROUP BY host`,
+		},
 
 		// No GROUP BY wildcards
 		{


### PR DESCRIPTION
When a wildcard is specified for the field but not the dimensions, the
dimensions get added to the list of fields as part of
`RewriteWildcards()`.

But when a dimension was given with no wildcard, the dimension didn't
get removed from the wildcard in the fields section. This teaches the
rewriter to disclude dimensions explicitly included from being expanded
as a field. Now this statement when a measurement has one tag named host
and a field named value:

    SELECT * FROM cpu GROUP BY host

Would expand to this:

    SELECT value FROM cpu GROUP BY host

Instead of this:

    SELECT host, value FROM cpu GROUP BY host

If you want the latter behavior, you can include it like this:

    SELECT host, * FROM cpu GROUP BY host

Fixes #5770.