### PR TITLE
Fix data nodes not getting created

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -637,13 +637,17 @@ func (s *Server) initializeMetaClient() error {
 		return err
 	}
 
-	// if the node ID is > 0 then we just need to initialize the metaclient
+	// if the node ID is > 0 then we need to initialize the metaclient
 	if s.Node.ID > 0 {
 		s.MetaClient.WaitForDataChanged()
-		return nil
 	}
 
 	if s.config.Data.Enabled {
+		// If we've already created a data node for our id, we're done
+		if _, err := s.MetaClient.DataNode(s.Node.ID); err == nil {
+			return nil
+		}
+
 		n, err := s.MetaClient.CreateDataNode(s.HTTPAddr(), s.TCPAddr())
 		for err != nil {
 			log.Printf("Unable to create data node. retry in 1s: %s", err.Error())


### PR DESCRIPTION
This fixes a regression introduced in #5757 due to the node.ID getting
assigned by both the meta and data services.  When both roles are active,
the data CreateDataNode path was not getting called because a node ID was
already assigned.

This fixes the issue by seeing if a DataNode already exists for our node
ID, and if it does not, we create one.

@e-dard @dgnorton 