### PR TITLE
Track stats for number of series, measurements

### DIFF
--- a/services/copier/service_test.go
+++ b/services/copier/service_test.go
@@ -163,7 +163,7 @@ func MustOpenShard(id uint64) *Shard {
 
 	sh := &Shard{
 		Shard: tsdb.NewShard(id,
-			tsdb.NewDatabaseIndex(),
+			tsdb.NewDatabaseIndex("db"),
 			filepath.Join(path, "data"),
 			filepath.Join(path, "wal"),
 			tsdb.NewEngineOptions(),

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -33,7 +33,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	}
 
 	// Load metadata index.
-	index := tsdb.NewDatabaseIndex()
+	index := tsdb.NewDatabaseIndex("db")
 	if err := e.LoadMetadataIndex(nil, index, make(map[string]*tsdb.MeasurementFields)); err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	}
 
 	// Load metadata index.
-	index = tsdb.NewDatabaseIndex()
+	index = tsdb.NewDatabaseIndex("db")
 	if err := e.LoadMetadataIndex(nil, index, make(map[string]*tsdb.MeasurementFields)); err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	}
 
 	// Load metadata index.
-	index = tsdb.NewDatabaseIndex()
+	index = tsdb.NewDatabaseIndex("db")
 	if err := e.LoadMetadataIndex(nil, index, make(map[string]*tsdb.MeasurementFields)); err != nil {
 		t.Fatal(err)
 	}
@@ -521,7 +521,7 @@ func MustOpenEngine() *Engine {
 	if err := e.Open(); err != nil {
 		panic(err)
 	}
-	if err := e.LoadMetadataIndex(nil, tsdb.NewDatabaseIndex(), make(map[string]*tsdb.MeasurementFields)); err != nil {
+	if err := e.LoadMetadataIndex(nil, tsdb.NewDatabaseIndex("db"), make(map[string]*tsdb.MeasurementFields)); err != nil {
 		panic(err)
 	}
 	return e

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -157,7 +157,7 @@ func BenchmarkCreateSeriesIndex_1M(b *testing.B) {
 func benchmarkCreateSeriesIndex(b *testing.B, series []*TestSeries) {
 	idxs := make([]*tsdb.DatabaseIndex, 0, b.N)
 	for i := 0; i < b.N; i++ {
-		idxs = append(idxs, tsdb.NewDatabaseIndex())
+		idxs = append(idxs, tsdb.NewDatabaseIndex(fmt.Sprintf("db%d", i)))
 	}
 
 	b.ResetTimer()

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -29,7 +29,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	tmpShard := path.Join(tmpDir, "shard")
 	tmpWal := path.Join(tmpDir, "wal")
 
-	index := tsdb.NewDatabaseIndex()
+	index := tsdb.NewDatabaseIndex("db")
 	opts := tsdb.NewEngineOptions()
 	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
 
@@ -75,7 +75,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	// ensure the index gets loaded after closing and opening the shard
 	sh.Close()
 
-	index = tsdb.NewDatabaseIndex()
+	index = tsdb.NewDatabaseIndex("db")
 	sh = tsdb.NewShard(1, index, tmpShard, tmpWal, opts)
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error openeing shard: %s", err.Error())
@@ -99,7 +99,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 	tmpShard := path.Join(tmpDir, "shard")
 	tmpWal := path.Join(tmpDir, "wal")
 
-	index := tsdb.NewDatabaseIndex()
+	index := tsdb.NewDatabaseIndex("db")
 	opts := tsdb.NewEngineOptions()
 	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
 
@@ -239,7 +239,7 @@ func benchmarkWritePoints(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
 	// Generate test series (measurements + unique tag sets).
 	series := genTestSeries(mCnt, tkCnt, tvCnt)
 	// Create index for the shard to use.
-	index := tsdb.NewDatabaseIndex()
+	index := tsdb.NewDatabaseIndex("db")
 	// Generate point data to write to the shard.
 	points := []models.Point{}
 	for _, s := range series {
@@ -280,7 +280,7 @@ func benchmarkWritePointsExistingSeries(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt
 	// Generate test series (measurements + unique tag sets).
 	series := genTestSeries(mCnt, tkCnt, tvCnt)
 	// Create index for the shard to use.
-	index := tsdb.NewDatabaseIndex()
+	index := tsdb.NewDatabaseIndex("db")
 	// Generate point data to write to the shard.
 	points := []models.Point{}
 	for _, s := range series {
@@ -355,7 +355,7 @@ func NewShard() *Shard {
 
 	return &Shard{
 		Shard: tsdb.NewShard(0,
-			tsdb.NewDatabaseIndex(),
+			tsdb.NewDatabaseIndex("db"),
 			filepath.Join(path, "data"),
 			filepath.Join(path, "wal"),
 			opt,

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -110,7 +110,7 @@ func (s *Store) loadIndexes() error {
 			s.Logger.Printf("Skipping database dir: %s. Not a directory", db.Name())
 			continue
 		}
-		s.databaseIndexes[db.Name()] = NewDatabaseIndex()
+		s.databaseIndexes[db.Name()] = NewDatabaseIndex(db.Name())
 	}
 	return nil
 }
@@ -252,7 +252,7 @@ func (s *Store) CreateShard(database, retentionPolicy string, shardID uint64) er
 	// create the database index if it does not exist
 	db, ok := s.databaseIndexes[database]
 	if !ok {
-		db = NewDatabaseIndex()
+		db = NewDatabaseIndex(database)
 		s.databaseIndexes[database] = db
 	}
 


### PR DESCRIPTION
Track stats for number of series, measurements

Per database: track number of series and measurements
Per measurement: track number of series

Now you can run queries like:

```
> select sum(numSeries) from _internal.."measurement" where time > now() - 30s group by time(10s), "database"
name: measurement
tags: database=_internal
time			sum
----			---
2016-02-24T00:35:30Z
2016-02-24T00:35:40Z	50
2016-02-24T00:35:50Z	50
2016-02-24T00:36:00Z	50


name: measurement
tags: database=telegraf
time			sum
----			---
2016-02-24T00:35:30Z
2016-02-24T00:35:40Z	61
2016-02-24T00:35:50Z	61
2016-02-24T00:36:00Z	61

> select * from _internal.."database" where time > now() - 30s group by "database"
name: database
tags: database=_internal
time			clusterID		database	hostname		nodeID	numMeasurements	numSeries
----			---------		--------	--------		------	---------------	---------
2016-02-24T00:36:00Z	3699771861689734216	_internal	Marks-MacBook-Pro.local	0	11		50
2016-02-24T00:36:10Z	3699771861689734216	_internal	Marks-MacBook-Pro.local	0	11		50
2016-02-24T00:36:20Z	3699771861689734216	_internal	Marks-MacBook-Pro.local	0	11		50


name: database
tags: database=telegraf
time			clusterID		database	hostname		nodeID	numMeasurements	numSeries
----			---------		--------	--------		------	---------------	---------
2016-02-24T00:36:00Z	3699771861689734216	telegraf	Marks-MacBook-Pro.local	0	14		61
2016-02-24T00:36:10Z	3699771861689734216	telegraf	Marks-MacBook-Pro.local	0	14		61
2016-02-24T00:36:20Z	3699771861689734216	telegraf	Marks-MacBook-Pro.local	0	14		61

> select "database", "measurement", top(numSeries, 10) from _internal.."measurement"  where time > now() - 10s
name: measurement
-----------------
time			database	measurement		top
2016-02-24T04:07:32Z	telegraf	influxdb_measurement	25
2016-02-24T04:07:32Z	_internal	measurement		25
2016-02-24T04:07:32Z	_internal	shard			7
2016-02-24T04:07:32Z	telegraf	influxdb_shard		7
2016-02-24T04:07:32Z	telegraf	net			6
2016-02-24T04:07:32Z	telegraf	cpu			4
2016-02-24T04:07:32Z	_internal	tsm1_wal		4
2016-02-24T04:07:32Z	telegraf	influxdb_tsm1_cache	4
2016-02-24T04:07:32Z	telegraf	influxdb_tsm1_wal	4
2016-02-24T04:07:32Z	_internal	tsm1_cache		4
```