### PR TITLE
Highlight upgrade info for old shards

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -442,6 +442,11 @@ func (s *Server) Open() error {
 
 		// Open TSDB store.
 		if err := s.TSDBStore.Open(); err != nil {
+			// Provide helpful error if user needs to upgrade shards to
+			// tsm1.
+			if serr, ok := err.(tsdb.ShardError); ok && serr.Err == tsdb.ErrUnknownEngineFormat {
+				return influxdb.ErrUpgradeEngine
+			}
 			return fmt.Errorf("open tsdb store: %s", err)
 		}
 

--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,11 @@ var (
 
 	// ErrFieldTypeConflict is returned when a new field already exists with a different type.
 	ErrFieldTypeConflict = errors.New("field type conflict")
+
+	// ErrUpgradeEngine will be returned when it's determined that
+	// the server has encountered shards that are not in the `tsm1`
+	// format.
+	ErrUpgradeEngine = errors.New("\n\n" + upgradeMessage + "\n\n")
 )
 
 // ErrDatabaseNotFound indicates that a database operation failed on the
@@ -43,3 +48,13 @@ func IsClientError(err error) bool {
 
 	return false
 }
+
+const upgradeMessage = `*******************************************************************
+                 UNSUPPORTED SHARD FORMAT DETECTED
+
+As of version 0.11, only tsm shards are supported. Please use the
+influx_tsm tool to convert non-tsm shards.
+
+More information can be found at the documentation site:
+https://docs.influxdata.com/influxdb/v0.10/administration/upgrading
+*******************************************************************`

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -16,6 +16,11 @@ import (
 var (
 	// ErrFormatNotFound is returned when no format can be determined from a path.
 	ErrFormatNotFound = errors.New("format not found")
+
+	// ErrUnknownEngineFormat is returned when the engine format is
+	// unknown. ErrUnknownEngineFormat is currently returned if a format
+	// other than tsm1 is encountered.
+	ErrUnknownEngineFormat = errors.New("unknown engine format")
 )
 
 // Engine represents a swappable storage engine for the shard.
@@ -89,7 +94,7 @@ func NewEngine(path string, walPath string, options EngineOptions) (Engine, erro
 	if fi, err := os.Stat(path); err != nil {
 		return nil, err
 	} else if !fi.Mode().IsDir() {
-		return nil, errors.New("unknown engine type")
+		return nil, ErrUnknownEngineFormat
 	} else {
 		format = "tsm1"
 	}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -43,6 +43,25 @@ var (
 	ErrFieldUnmappedID = errors.New("field ID not mapped")
 )
 
+// A ShardError implements the error interface, and contains extra
+// context about the shard that generated the error.
+type ShardError struct {
+	id  uint64
+	Err error
+}
+
+// NewShardError returns a new ShardError.
+func NewShardError(id uint64, err error) ShardError {
+	if err == nil {
+		err = errors.New("unknown error")
+	}
+	return ShardError{id: id, Err: err}
+}
+
+func (e ShardError) Error() string {
+	return fmt.Sprintf("[shard %d] %s", e.id, e.Err)
+}
+
 // Shard represents a self-contained time series database. An inverted index of
 // the measurement and tag data is kept along with the raw time series data.
 // Data can be split across many shards. The query engine in TSDB is responsible
@@ -112,7 +131,7 @@ func (s *Shard) Open() error {
 		// Initialize underlying engine.
 		e, err := NewEngine(s.path, s.walPath, s.options)
 		if err != nil {
-			return fmt.Errorf("new engine: %s", err)
+			return err
 		}
 		s.engine = e
 
@@ -121,18 +140,18 @@ func (s *Shard) Open() error {
 
 		// Open engine.
 		if err := s.engine.Open(); err != nil {
-			return fmt.Errorf("open engine: %s", err)
+			return err
 		}
 
 		// Load metadata index.
 		if err := s.engine.LoadMetadataIndex(s, s.index, s.measurementFields); err != nil {
-			return fmt.Errorf("load metadata index: %s", err)
+			return err
 		}
 
 		return nil
 	}(); err != nil {
 		s.close()
-		return err
+		return NewShardError(s.id, err)
 	}
 
 	return nil

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -51,9 +51,9 @@ type ShardError struct {
 }
 
 // NewShardError returns a new ShardError.
-func NewShardError(id uint64, err error) ShardError {
+func NewShardError(id uint64, err error) error {
 	if err == nil {
-		err = errors.New("unknown error")
+		return nil
 	}
 	return ShardError{id: id, Err: err}
 }

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -148,7 +148,7 @@ func (s *Store) loadShards() error {
 				shard := NewShard(shardID, s.databaseIndexes[db], path, walPath, s.EngineOptions)
 				err = shard.Open()
 				if err != nil {
-					return fmt.Errorf("failed to open shard %d: %s", shardID, err)
+					return err
 				}
 
 				s.shardLocations[shardID] = &shardLocation{Database: db, RetentionPolicy: rp.Name(), Shard: shard}


### PR DESCRIPTION
Fixes #5723.

This will produce a message along the following lines:

![](https://photos-6.dropbox.com/t/2/AACUtel1X8EQeGsRnx-1YQ9uovtPsHdxCP1CSwmaSr6Ofw/12/5033766/png/32x32/3/1456336800/0/2/Screen%20Shot%202016-02-24%20at%2013.46.23.png/ENyv4gMYv8cXIAcoBw/Nrhawf6xM0Z4CPBFmluQ7FuuLD2PyCCEds0HDF_EQnY?size_mode=3&size=2048x1536)

This is an error, so the process will exit with a non-zero exit code.

@pauldix let me know if you want me to tweak the message at all.