### PR TITLE
Fix running multiple CQs with the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#5754](https://github.com/influxdata/influxdb/issues/5754): Adding a node as meta only results in a data node also being registered
 - [#5787](https://github.com/influxdata/influxdb/pull/5787): HTTP: Add QueryAuthorizer instance to httpd service’s handler. @chris-ramon
 - [#5753](https://github.com/influxdata/influxdb/pull/5753): ensures that drop-type commands work correctly in a cluster
+- [#5814](https://github.com/influxdata/influxdb/issues/5814): Run CQs with the same name from different databases
 
 ## v0.10.1 [2016-02-18]
 


### PR DESCRIPTION
Previously, CQs with the same name would be stored in the last run map
the same way. This caused only one of the CQs to run because after the
first one ran it would update the last run time for all CQs with the
same name.

Add the database name to the CQ ID in the last run map to differentiate
between CQs in different databases.

Fixes #5814.