### PR TITLE
[don't merge me] - designed to show write lock in merged() is no longer needed after #5701

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -252,25 +252,8 @@ func (c *Cache) Keys() []string {
 // Values returns a copy of all values, deduped and sorted, for the given key.
 func (c *Cache) Values(key string) Values {
 	c.mu.RLock()
-	e := c.store[key]
-	if e != nil && e.needSort {
-		// Sorting is needed, so unlock and run the merge operation with
-		// a write-lock. It is actually possible that the data will be
-		// sorted by the time the merge runs, which would mean very occasionally
-		// a write-lock will be held when only a read-lock is required.
-		c.mu.RUnlock()
-		return func() Values {
-			c.mu.Lock()
-			defer c.mu.Unlock()
-			return c.merged(key)
-		}()
-	}
-
-	// No sorting required for key, so just merge while continuing to hold read-lock.
-	return func() Values {
-		defer c.mu.RUnlock()
-		return c.merged(key)
-	}()
+	defer c.mu.RUnlock()
+	return c.merged(key)
 }
 
 // Delete will remove the keys from the cache

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -1,0 +1,57 @@
+// +build !race
+
+package tsm1_test
+
+import (
+	"fmt"
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCheckConcurrentReadsAreSafe(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000, "")
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(3)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	close(ch)
+	wg.Wait()
+}


### PR DESCRIPTION
This contains two changes that are in #5701 but does not include the other the changes.

The purpose is to demonstrate that without the other changes in #5701, taking a write lock is necessary to ensure thread safety.

The fact that the test case executes successfully after #5701, shows that the protection offered by taking the cache write lock is no longer necessary because #5701 introduces entry locks that offer the required protection.