### PR TITLE
tsm: cache: need to check that snapshot has been sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [#5753](https://github.com/influxdata/influxdb/pull/5753): Ensures that drop-type commands work correctly in a cluster
 - [#5814](https://github.com/influxdata/influxdb/issues/5814): Run CQs with the same name from different databases
 - [#5699](https://github.com/influxdata/influxdb/issues/5699): Fix potential thread safety issue in cache @jonseymour
+- [#5832](https://github.com/influxdata/influxdb/issues/5832): tsm: cache: need to check that snapshot has been sorted @jonseymour
 
 ## v0.10.1 [2016-02-18]
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -316,6 +316,7 @@ func (c *Cache) merged(key string) Values {
 	if c.snapshot != nil {
 		snapshotEntries := c.snapshot.store[key]
 		if snapshotEntries != nil {
+			snapshotEntries.deduplicate() // guarantee we are deduplicated
 			entries = append(entries, snapshotEntries)
 			sz += snapshotEntries.count()
 		}


### PR DESCRIPTION
Fixes #5832.

Previously, the code assumes that the snapshot has been sorted, but this
may not be true. So, we need to check that assumption here. If it isn't
true, the resulting slice needs to be sorted.

/cc @jwilder