### PR TITLE
Convert time.Time to int64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [#5814](https://github.com/influxdata/influxdb/issues/5814): Run CQs with the same name from different databases
 - [#5699](https://github.com/influxdata/influxdb/issues/5699): Fix potential thread safety issue in cache @jonseymour
 - [#5832](https://github.com/influxdata/influxdb/issues/5832): tsm: cache: need to check that snapshot has been sorted @jonseymour
+- [#5841](https://github.com/influxdata/influxdb/pull/5841): Reduce tsm allocations by converting time.Time to int64
 
 ## v0.10.1 [2016-02-18]
 

--- a/cmd/influx_tsm/converter_test.go
+++ b/cmd/influx_tsm/converter_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
@@ -16,7 +15,7 @@ func TestScrubValues(t *testing.T) {
 		tracker: new(tracker),
 	}
 
-	epoch := time.Unix(0, 0)
+	var epoch int64
 	simple := []tsm1.Value{tsm1.NewValue(epoch, 1.0)}
 
 	for _, tt := range []struct {

--- a/cmd/influx_tsm/tsdb/values.go
+++ b/cmd/influx_tsm/tsdb/values.go
@@ -9,18 +9,12 @@ import (
 
 // FloatValue holds float64 values
 type FloatValue struct {
-	T time.Time
+	T int64
 	V float64
 }
 
-// Time returns the time associated with the FloatValue
-func (f *FloatValue) Time() time.Time {
-	return f.T
-}
-
-// UnixNano returns the Unix time in nanoseconds associated with the FloatValue
 func (f *FloatValue) UnixNano() int64 {
-	return f.T.UnixNano()
+	return f.T
 }
 
 // Value returns the float64 value
@@ -35,28 +29,22 @@ func (f *FloatValue) Size() int {
 
 // String returns the formatted string. Implements the Stringer interface
 func (f *FloatValue) String() string {
-	return fmt.Sprintf("%v %v", f.Time(), f.Value())
+	return fmt.Sprintf("%v %v", time.Unix(0, f.T), f.Value())
 }
 
 // BoolValue holds bool values
 type BoolValue struct {
-	T time.Time
+	T int64
 	V bool
 }
 
-// Time returns the time associated with the BoolValue
-func (b *BoolValue) Time() time.Time {
-	return b.T
-}
-
-// Size returns the size of the BoolValue. It is always 9
 func (b *BoolValue) Size() int {
 	return 9
 }
 
 // UnixNano returns the Unix time in nanoseconds associated with the BoolValue
 func (b *BoolValue) UnixNano() int64 {
-	return b.T.UnixNano()
+	return b.T
 }
 
 // Value returns the boolean stored
@@ -65,29 +53,23 @@ func (b *BoolValue) Value() interface{} {
 }
 
 // String returns the formatted string. Implements the Stringer interface
-func (b *BoolValue) String() string {
-	return fmt.Sprintf("%v %v", b.Time(), b.Value())
+func (f *BoolValue) String() string {
+	return fmt.Sprintf("%v %v", time.Unix(0, f.T), f.Value())
 }
 
 // Int64Value holds int64 values
 type Int64Value struct {
-	T time.Time
+	T int64
 	V int64
 }
 
-// Time returns the time associated with the Int64Value
-func (v *Int64Value) Time() time.Time {
-	return v.T
-}
-
-// Value returns the int64 stored
 func (v *Int64Value) Value() interface{} {
 	return v.V
 }
 
 // UnixNano returns the Unix time in nanoseconds associated with the Int64Value
 func (v *Int64Value) UnixNano() int64 {
-	return v.T.UnixNano()
+	return v.T
 }
 
 // Size returns the size of the Int64Value. It is always 16
@@ -96,29 +78,23 @@ func (v *Int64Value) Size() int {
 }
 
 // String returns the formatted string. Implements the Stringer interface
-func (v *Int64Value) String() string {
-	return fmt.Sprintf("%v %v", v.Time(), v.Value())
+func (f *Int64Value) String() string {
+	return fmt.Sprintf("%v %v", time.Unix(0, f.T), f.Value())
 }
 
 // StringValue holds string values
 type StringValue struct {
-	T time.Time
+	T int64
 	V string
 }
 
-// Time returns the time associated with the StringValue
-func (v *StringValue) Time() time.Time {
-	return v.T
-}
-
-// Value returns the float stored
 func (v *StringValue) Value() interface{} {
 	return v.V
 }
 
 // UnixNano returns the Unix time in nanoseconds associated with the StringValue
 func (v *StringValue) UnixNano() int64 {
-	return v.T.UnixNano()
+	return v.T
 }
 
 // Size returns the size of the StringValue
@@ -127,8 +103,8 @@ func (v *StringValue) Size() int {
 }
 
 // String returns the formatted string. Implements the Stringer interface
-func (v *StringValue) String() string {
-	return fmt.Sprintf("%v %v", v.Time(), v.Value())
+func (f *StringValue) String() string {
+	return fmt.Sprintf("%v %v", time.Unix(0, f.T), f.Value())
 }
 
 // ConvertToValue converts the data from other engines to TSM
@@ -138,22 +114,22 @@ func ConvertToValue(k int64, v interface{}) tsm.Value {
 	switch v := v.(type) {
 	case int64:
 		value = &Int64Value{
-			T: time.Unix(0, k),
+			T: k,
 			V: v,
 		}
 	case float64:
 		value = &FloatValue{
-			T: time.Unix(0, k),
+			T: k,
 			V: v,
 		}
 	case bool:
 		value = &BoolValue{
-			T: time.Unix(0, k),
+			T: k,
 			V: v,
 		}
 	case string:
 		value = &StringValue{
-			T: time.Unix(0, k),
+			T: k,
 			V: v,
 		}
 	default:

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -4,19 +4,19 @@ package tsm1_test
 
 import (
 	"fmt"
-	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 	"math/rand"
 	"sync"
 	"testing"
-	"time"
+
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
 
 func TestCheckConcurrentReadsAreSafe(t *testing.T) {
 	values := make(tsm1.Values, 1000)
-	timestamps := make([]time.Time, len(values))
+	timestamps := make([]int64, len(values))
 	series := make([]string, 100)
 	for i := range timestamps {
-		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+		timestamps[i] = int64(rand.Int63n(int64(len(values))))
 	}
 
 	for i := range values {
@@ -58,10 +58,10 @@ func TestCheckConcurrentReadsAreSafe(t *testing.T) {
 
 func TestCacheRace(t *testing.T) {
 	values := make(tsm1.Values, 1000)
-	timestamps := make([]time.Time, len(values))
+	timestamps := make([]int64, len(values))
 	series := make([]string, 100)
 	for i := range timestamps {
-		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+		timestamps[i] = int64(rand.Int63n(int64(len(values))))
 	}
 
 	for i := range values {
@@ -101,10 +101,10 @@ func TestCacheRace(t *testing.T) {
 
 func TestCacheRace2Compacters(t *testing.T) {
 	values := make(tsm1.Values, 1000)
-	timestamps := make([]time.Time, len(values))
+	timestamps := make([]int64, len(values))
 	series := make([]string, 100)
 	for i := range timestamps {
-		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+		timestamps[i] = int64(rand.Int63n(int64(len(values))))
 	}
 
 	for i := range values {

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/golang/snappy"
 )
@@ -29,9 +28,9 @@ func TestCache_NewCache(t *testing.T) {
 }
 
 func TestCache_CacheWrite(t *testing.T) {
-	v0 := NewValue(time.Unix(1, 0).UTC(), 1.0)
-	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)
-	v2 := NewValue(time.Unix(3, 0).UTC(), 3.0)
+	v0 := NewValue(1, 1.0)
+	v1 := NewValue(2, 2.0)
+	v2 := NewValue(3, 3.0)
 	values := Values{v0, v1, v2}
 	valuesSize := uint64(v0.Size() + v1.Size() + v2.Size())
 
@@ -53,9 +52,9 @@ func TestCache_CacheWrite(t *testing.T) {
 }
 
 func TestCache_CacheWriteMulti(t *testing.T) {
-	v0 := NewValue(time.Unix(1, 0).UTC(), 1.0)
-	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)
-	v2 := NewValue(time.Unix(3, 0).UTC(), 3.0)
+	v0 := NewValue(1, 1.0)
+	v1 := NewValue(2, 2.0)
+	v2 := NewValue(3, 3.0)
 	values := Values{v0, v1, v2}
 	valuesSize := uint64(v0.Size() + v1.Size() + v2.Size())
 
@@ -76,13 +75,13 @@ func TestCache_CacheWriteMulti(t *testing.T) {
 // This tests writing two batches to the same series.  The first batch
 // is sorted.  The second batch is also sorted but contains duplicates.
 func TestCache_CacheWriteMulti_Duplicates(t *testing.T) {
-	v0 := NewValue(time.Unix(2, 0).UTC(), 1.0)
-	v1 := NewValue(time.Unix(3, 0).UTC(), 1.0)
+	v0 := NewValue(2, 1.0)
+	v1 := NewValue(3, 1.0)
 	values0 := Values{v0, v1}
 
-	v3 := NewValue(time.Unix(4, 0).UTC(), 2.0)
-	v4 := NewValue(time.Unix(5, 0).UTC(), 3.0)
-	v5 := NewValue(time.Unix(5, 0).UTC(), 3.0)
+	v3 := NewValue(4, 2.0)
+	v4 := NewValue(5, 3.0)
+	v5 := NewValue(5, 3.0)
 	values1 := Values{v3, v4, v5}
 
 	c := NewCache(0, "")
@@ -109,11 +108,11 @@ func TestCache_CacheWriteMulti_Duplicates(t *testing.T) {
 }
 
 func TestCache_CacheValues(t *testing.T) {
-	v0 := NewValue(time.Unix(1, 0).UTC(), 0.0)
-	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)
-	v2 := NewValue(time.Unix(3, 0).UTC(), 3.0)
-	v3 := NewValue(time.Unix(1, 0).UTC(), 1.0)
-	v4 := NewValue(time.Unix(4, 0).UTC(), 4.0)
+	v0 := NewValue(1, 0.0)
+	v1 := NewValue(2, 2.0)
+	v2 := NewValue(3, 3.0)
+	v3 := NewValue(1, 1.0)
+	v4 := NewValue(4, 4.0)
 
 	c := NewCache(512, "")
 	if deduped := c.Values("no such key"); deduped != nil {
@@ -134,14 +133,14 @@ func TestCache_CacheValues(t *testing.T) {
 }
 
 func TestCache_CacheSnapshot(t *testing.T) {
-	v0 := NewValue(time.Unix(2, 0).UTC(), 0.0)
-	v1 := NewValue(time.Unix(3, 0).UTC(), 2.0)
-	v2 := NewValue(time.Unix(4, 0).UTC(), 3.0)
-	v3 := NewValue(time.Unix(5, 0).UTC(), 4.0)
-	v4 := NewValue(time.Unix(6, 0).UTC(), 5.0)
-	v5 := NewValue(time.Unix(1, 0).UTC(), 5.0)
-	v6 := NewValue(time.Unix(7, 0).UTC(), 5.0)
-	v7 := NewValue(time.Unix(2, 0).UTC(), 5.0)
+	v0 := NewValue(2, 0.0)
+	v1 := NewValue(3, 2.0)
+	v2 := NewValue(4, 3.0)
+	v3 := NewValue(5, 4.0)
+	v4 := NewValue(6, 5.0)
+	v5 := NewValue(1, 5.0)
+	v6 := NewValue(7, 5.0)
+	v7 := NewValue(2, 5.0)
 
 	c := NewCache(512, "")
 	if err := c.Write("foo", Values{v0, v1, v2, v3}); err != nil {
@@ -229,8 +228,8 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 }
 
 func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
-	v0 := NewValue(time.Unix(1, 0).UTC(), 1.0)
-	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)
+	v0 := NewValue(1, 1.0)
+	v1 := NewValue(2, 2.0)
 
 	c := NewCache(uint64(v1.Size()), "")
 
@@ -269,9 +268,9 @@ func TestCacheLoader_LoadSingle(t *testing.T) {
 	f := mustTempFile(dir)
 	w := NewWALSegmentWriter(f)
 
-	p1 := NewValue(time.Unix(1, 0), 1.1)
-	p2 := NewValue(time.Unix(1, 0), int64(1))
-	p3 := NewValue(time.Unix(1, 0), true)
+	p1 := NewValue(1, 1.1)
+	p2 := NewValue(1, int64(1))
+	p3 := NewValue(1, true)
 
 	values := map[string][]Value{
 		"foo": []Value{p1},
@@ -337,10 +336,10 @@ func TestCacheLoader_LoadDouble(t *testing.T) {
 	f1, f2 := mustTempFile(dir), mustTempFile(dir)
 	w1, w2 := NewWALSegmentWriter(f1), NewWALSegmentWriter(f2)
 
-	p1 := NewValue(time.Unix(1, 0), 1.1)
-	p2 := NewValue(time.Unix(1, 0), int64(1))
-	p3 := NewValue(time.Unix(1, 0), true)
-	p4 := NewValue(time.Unix(1, 0), "string")
+	p1 := NewValue(1, 1.1)
+	p2 := NewValue(1, int64(1))
+	p3 := NewValue(1, true)
+	p4 := NewValue(1, "string")
 
 	// Write first and second segment.
 
@@ -422,7 +421,7 @@ func BenchmarkCacheFloatEntries(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		cache := NewCache(10000, "")
 		for j := 0; j < 10000; j++ {
-			v := NewValue(time.Unix(1, 0), float64(j))
+			v := NewValue(1, float64(j))
 			cache.Write("test", []Value{v})
 		}
 	}

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -16,9 +16,9 @@ func TestCompactor_Snapshot(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)
 
-	v1 := tsm1.NewValue(time.Unix(1, 0), float64(1))
-	v2 := tsm1.NewValue(time.Unix(1, 0), float64(1))
-	v3 := tsm1.NewValue(time.Unix(2, 0), float64(2))
+	v1 := tsm1.NewValue(1, float64(1))
+	v2 := tsm1.NewValue(1, float64(1))
+	v3 := tsm1.NewValue(2, float64(2))
 
 	points1 := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{v1},
@@ -83,22 +83,22 @@ func TestCompactor_CompactFull(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// write 3 TSM files with different data and one new point
-	a1 := tsm1.NewValue(time.Unix(1, 0), 1.1)
+	a1 := tsm1.NewValue(1, 1.1)
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a1},
 	}
 	f1 := MustWriteTSM(dir, 1, writes)
 
-	a2 := tsm1.NewValue(time.Unix(2, 0), 1.2)
-	b1 := tsm1.NewValue(time.Unix(1, 0), 2.1)
+	a2 := tsm1.NewValue(2, 1.2)
+	b1 := tsm1.NewValue(1, 2.1)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a2},
 		"cpu,host=B#!~#value": []tsm1.Value{b1},
 	}
 	f2 := MustWriteTSM(dir, 2, writes)
 
-	a3 := tsm1.NewValue(time.Unix(1, 0), 1.3)
-	c1 := tsm1.NewValue(time.Unix(1, 0), 3.1)
+	a3 := tsm1.NewValue(1, 1.3)
+	c1 := tsm1.NewValue(1, 3.1)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a3},
 		"cpu,host=C#!~#value": []tsm1.Value{c1},
@@ -176,20 +176,20 @@ func TestCompactor_CompactFull_SkipFullBlocks(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// write 3 TSM files with different data and one new point
-	a1 := tsm1.NewValue(time.Unix(1, 0), 1.1)
-	a2 := tsm1.NewValue(time.Unix(2, 0), 1.2)
+	a1 := tsm1.NewValue(1, 1.1)
+	a2 := tsm1.NewValue(2, 1.2)
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a1, a2},
 	}
 	f1 := MustWriteTSM(dir, 1, writes)
 
-	a3 := tsm1.NewValue(time.Unix(3, 0), 1.3)
+	a3 := tsm1.NewValue(3, 1.3)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a3},
 	}
 	f2 := MustWriteTSM(dir, 2, writes)
 
-	a4 := tsm1.NewValue(time.Unix(4, 0), 1.4)
+	a4 := tsm1.NewValue(4, 1.4)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a4},
 	}
@@ -268,7 +268,7 @@ func TestTSMKeyIterator_Single(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)
 
-	v1 := tsm1.NewValue(time.Unix(1, 0), 1.1)
+	v1 := tsm1.NewValue(1, 1.1)
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{v1},
 	}
@@ -317,8 +317,8 @@ func TestTSMKeyIterator_Chunked(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)
 
-	v0 := tsm1.NewValue(time.Unix(1, 0), 1.1)
-	v1 := tsm1.NewValue(time.Unix(2, 0), 2.1)
+	v0 := tsm1.NewValue(1, 1.1)
+	v1 := tsm1.NewValue(2, 2.1)
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{v0, v1},
 	}
@@ -372,8 +372,8 @@ func TestTSMKeyIterator_Duplicate(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)
 
-	v1 := tsm1.NewValue(time.Unix(1, 0), int64(1))
-	v2 := tsm1.NewValue(time.Unix(1, 0), int64(2))
+	v1 := tsm1.NewValue(1, int64(1))
+	v2 := tsm1.NewValue(1, int64(2))
 
 	writes1 := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{v1},
@@ -427,7 +427,7 @@ func TestTSMKeyIterator_MultipleKeysDeleted(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)
 
-	v1 := tsm1.NewValue(time.Unix(2, 0), int64(1))
+	v1 := tsm1.NewValue(2, int64(1))
 	points1 := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{v1},
 	}
@@ -437,8 +437,8 @@ func TestTSMKeyIterator_MultipleKeysDeleted(t *testing.T) {
 		t.Fatal(e)
 	}
 
-	v2 := tsm1.NewValue(time.Unix(1, 0), float64(1))
-	v3 := tsm1.NewValue(time.Unix(1, 0), float64(1))
+	v2 := tsm1.NewValue(1, float64(1))
+	v3 := tsm1.NewValue(1, float64(1))
 
 	points2 := map[string][]tsm1.Value{
 		"cpu,host=A#!~#count": []tsm1.Value{v2},
@@ -491,7 +491,7 @@ func TestTSMKeyIterator_MultipleKeysDeleted(t *testing.T) {
 }
 
 func TestCacheKeyIterator_Single(t *testing.T) {
-	v0 := tsm1.NewValue(time.Unix(1, 0).UTC(), 1.0)
+	v0 := tsm1.NewValue(1, 1.0)
 
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{v0},
@@ -538,8 +538,8 @@ func TestCacheKeyIterator_Single(t *testing.T) {
 }
 
 func TestCacheKeyIterator_Chunked(t *testing.T) {
-	v0 := tsm1.NewValue(time.Unix(1, 0).UTC(), 1.0)
-	v1 := tsm1.NewValue(time.Unix(2, 0).UTC(), 2.0)
+	v0 := tsm1.NewValue(1, 1.0)
+	v1 := tsm1.NewValue(2, 2.0)
 
 	writes := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{v0, v1},
@@ -1066,7 +1066,7 @@ func TestDefaultPlanner_Plan_CompactsMiddleSteps(t *testing.T) {
 }
 
 func assertValueEqual(t *testing.T, a, b tsm1.Value) {
-	if got, exp := a.Time(), b.Time(); !got.Equal(exp) {
+	if got, exp := a.UnixNano(), b.UnixNano(); got != exp {
 		t.Fatalf("time mismatch: got %v, exp %v", got, exp)
 	}
 	if got, exp := a.Value(), b.Value(); got != exp {
@@ -1075,7 +1075,7 @@ func assertValueEqual(t *testing.T, a, b tsm1.Value) {
 }
 
 func assertEqual(t *testing.T, a tsm1.Value, b models.Point, field string) {
-	if got, exp := a.Time(), b.Time(); !got.Equal(exp) {
+	if got, exp := a.UnixNano(), b.UnixNano(); got != exp {
 		t.Fatalf("time mismatch: got %v, exp %v", got, exp)
 	}
 	if got, exp := a.Value(), b.Fields()[field]; got != exp {

--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -37,7 +37,7 @@ func TestEncoding_FloatBlock(t *testing.T) {
 func TestEncoding_FloatBlock_ZeroTime(t *testing.T) {
 	values := make([]tsm1.Value, 3)
 	for i := 0; i < 3; i++ {
-		values[i] = tsm1.NewValue(time.Unix(0, 0), float64(i))
+		values[i] = tsm1.NewValue(0, float64(i))
 	}
 
 	b, err := tsm1.Values(values).Encode(nil)
@@ -58,11 +58,11 @@ func TestEncoding_FloatBlock_ZeroTime(t *testing.T) {
 
 func TestEncoding_FloatBlock_SimilarFloats(t *testing.T) {
 	values := make([]tsm1.Value, 5)
-	values[0] = tsm1.NewValue(time.Unix(0, 1444238178437870000), 6.00065e+06)
-	values[1] = tsm1.NewValue(time.Unix(0, 1444238185286830000), 6.000656e+06)
-	values[2] = tsm1.NewValue(time.Unix(0, 1444238188441501000), 6.000657e+06)
-	values[3] = tsm1.NewValue(time.Unix(0, 1444238195286811000), 6.000659e+06)
-	values[4] = tsm1.NewValue(time.Unix(0, 1444238198439917000), 6.000661e+06)
+	values[0] = tsm1.NewValue(1444238178437870000, 6.00065e+06)
+	values[1] = tsm1.NewValue(1444238185286830000, 6.000656e+06)
+	values[2] = tsm1.NewValue(1444238188441501000, 6.000657e+06)
+	values[3] = tsm1.NewValue(1444238195286811000, 6.000659e+06)
+	values[4] = tsm1.NewValue(1444238198439917000, 6.000661e+06)
 
 	b, err := tsm1.Values(values).Encode(nil)
 	if err != nil {
@@ -104,9 +104,8 @@ func TestEncoding_IntBlock_Basic(t *testing.T) {
 	}
 
 	for i := 0; i < len(decodedValues); i++ {
-
-		if decodedValues[i].Time() != values[i].Time() {
-			t.Fatalf("unexpected results:\n\tgot: %v\n\texp: %v\n", decodedValues[i].Time(), values[i].Time())
+		if decodedValues[i].UnixNano() != values[i].UnixNano() {
+			t.Fatalf("unexpected results:\n\tgot: %v\n\texp: %v\n", decodedValues[i].UnixNano(), values[i].UnixNano())
 		}
 
 		if decodedValues[i].Value() != values[i].Value() {
@@ -208,7 +207,7 @@ func TestEncoding_BlockType(t *testing.T) {
 
 	for _, test := range tests {
 		var values []tsm1.Value
-		values = append(values, tsm1.NewValue(time.Unix(0, 0), test.value))
+		values = append(values, tsm1.NewValue(0, test.value))
 
 		b, err := tsm1.Values(values).Encode(nil)
 		if err != nil {
@@ -244,7 +243,7 @@ func TestEncoding_Count(t *testing.T) {
 
 	for _, test := range tests {
 		var values []tsm1.Value
-		values = append(values, tsm1.NewValue(time.Unix(0, 0), test.value))
+		values = append(values, tsm1.NewValue(0, test.value))
 
 		b, err := tsm1.Values(values).Encode(nil)
 		if err != nil {
@@ -257,11 +256,11 @@ func TestEncoding_Count(t *testing.T) {
 	}
 }
 
-func getTimes(n, step int, precision time.Duration) []time.Time {
-	t := time.Now().Round(precision)
-	a := make([]time.Time, n)
+func getTimes(n, step int, precision time.Duration) []int64 {
+	t := time.Now().Round(precision).UnixNano()
+	a := make([]int64, n)
 	for i := 0; i < n; i++ {
-		a[i] = t.Add(time.Duration(i*60) * precision)
+		a[i] = t + (time.Duration(i*60) * precision).Nanoseconds()
 	}
 	return a
 }

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
@@ -17,9 +16,9 @@ func TestFileStore_Read(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -30,7 +29,7 @@ func TestFileStore_Read(t *testing.T) {
 	fs.Add(files...)
 
 	// Search for an entry that exists in the second file
-	values, err := fs.Read("cpu", time.Unix(1, 0))
+	values, err := fs.Read("cpu", 1)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -52,9 +51,9 @@ func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -65,7 +64,7 @@ func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(0, 0), true)
+	c := fs.KeyCursor("cpu", 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
@@ -89,10 +88,10 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 2.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 3.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 4.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 4.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -103,7 +102,7 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(0, 0), true)
+	c := fs.KeyCursor("cpu", 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
@@ -144,9 +143,9 @@ func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 2.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(3, 0), 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, 3.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -158,7 +157,7 @@ func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(0, 0), true)
+	c := fs.KeyCursor("cpu", 0, true)
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -181,10 +180,10 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 1.0),
-			tsm1.NewValue(time.Unix(2, 0), 2.0),
-			tsm1.NewValue(time.Unix(3, 0), 3.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(4, 0), 4.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 1.0),
+			tsm1.NewValue(2, 2.0),
+			tsm1.NewValue(3, 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(4, 4.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -196,7 +195,7 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(3, 0), true)
+	c := fs.KeyCursor("cpu", 3, true)
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -219,9 +218,9 @@ func TestFileStore_SeekToAsc_End(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -232,7 +231,7 @@ func TestFileStore_SeekToAsc_End(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(2, 0), true)
+	c := fs.KeyCursor("cpu", 2, true)
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -255,9 +254,9 @@ func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -269,7 +268,7 @@ func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(0, 0), false)
+	c := fs.KeyCursor("cpu", 0, false)
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -291,10 +290,10 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 4.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 2.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 4.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -306,7 +305,7 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(2, 0), false)
+	c := fs.KeyCursor("cpu", 2, false)
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -344,9 +343,9 @@ func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 2.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(3, 0), 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(3, 3.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -357,7 +356,7 @@ func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(4, 0), false)
+	c := fs.KeyCursor("cpu", 4, false)
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -380,11 +379,11 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 1.0)}},
 		keyValues{"cpu", []tsm1.Value{
-			tsm1.NewValue(time.Unix(2, 0), 2.0),
-			tsm1.NewValue(time.Unix(3, 0), 3.0),
-			tsm1.NewValue(time.Unix(4, 0), 4.0)},
+			tsm1.NewValue(2, 2.0),
+			tsm1.NewValue(3, 3.0),
+			tsm1.NewValue(4, 4.0)},
 		},
 	}
 
@@ -397,7 +396,7 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(3, 0), false)
+	c := fs.KeyCursor("cpu", 3, false)
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -420,9 +419,9 @@ func TestFileStore_SeekToDesc_End(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(2, 0), 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -433,7 +432,7 @@ func TestFileStore_SeekToDesc_End(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make(tsm1.FloatValues, 1000)
-	c := fs.KeyCursor("cpu", time.Unix(2, 0), false)
+	c := fs.KeyCursor("cpu", 2, false)
 	values, err := c.ReadFloatBlock(buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -457,9 +456,9 @@ func TestFileStore_Open(t *testing.T) {
 
 	// Create 3 TSM files...
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
 	_, err := newFileDir(dir, data...)
@@ -488,9 +487,9 @@ func TestFileStore_Remove(t *testing.T) {
 
 	// Create 3 TSM files...
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
 	files, err := newFileDir(dir, data...)
@@ -529,9 +528,9 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 
 	// Create 3 TSM files...
 	data := []keyValues{
-		keyValues{"cpu,host=server2!~#!value", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"mem,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu,host=server2!~#!value", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"mem,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
 	_, err := newFileDir(dir, data...)
@@ -569,9 +568,9 @@ func TestFileStore_Delete(t *testing.T) {
 
 	// Setup 3 files
 	data := []keyValues{
-		keyValues{"cpu,host=server2!~#!value", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"mem,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu,host=server2!~#!value", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"mem,host=server1!~#!value", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
 	files, err := newFiles(data...)
@@ -602,9 +601,9 @@ func TestFileStore_Stats(t *testing.T) {
 
 	// Create 3 TSM files...
 	data := []keyValues{
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
-		keyValues{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		keyValues{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
 	}
 
 	_, err := newFileDir(dir, data...)

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -216,14 +216,14 @@ func newFloatAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyCu
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]FloatValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 
 	return c
@@ -246,7 +246,7 @@ func (c *floatAscendingCursor) peekTSM() (t int64, v float64) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().(float64)
+	return item.UnixNano(), item.Value().(float64)
 }
 
 // next returns the next key/value for the cursor.
@@ -320,7 +320,7 @@ func newFloatDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekCache(); t != seek {
 		c.cache.pos--
@@ -330,7 +330,7 @@ func newFloatDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 	c.tsm.buf = make([]FloatValue, 1000)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekTSM(); t != seek {
 		c.tsm.pos--
@@ -356,7 +356,7 @@ func (c *floatDescendingCursor) peekTSM() (t int64, v float64) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().(float64)
+	return item.UnixNano(), item.Value().(float64)
 }
 
 // next returns the next key/value for the cursor.
@@ -548,14 +548,14 @@ func newIntegerAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]IntegerValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 
 	return c
@@ -578,7 +578,7 @@ func (c *integerAscendingCursor) peekTSM() (t int64, v int64) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().(int64)
+	return item.UnixNano(), item.Value().(int64)
 }
 
 // next returns the next key/value for the cursor.
@@ -652,7 +652,7 @@ func newIntegerDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekCache(); t != seek {
 		c.cache.pos--
@@ -662,7 +662,7 @@ func newIntegerDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 	c.tsm.buf = make([]IntegerValue, 1000)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekTSM(); t != seek {
 		c.tsm.pos--
@@ -688,7 +688,7 @@ func (c *integerDescendingCursor) peekTSM() (t int64, v int64) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().(int64)
+	return item.UnixNano(), item.Value().(int64)
 }
 
 // next returns the next key/value for the cursor.
@@ -880,14 +880,14 @@ func newStringAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]StringValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 
 	return c
@@ -910,7 +910,7 @@ func (c *stringAscendingCursor) peekTSM() (t int64, v string) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().(string)
+	return item.UnixNano(), item.Value().(string)
 }
 
 // next returns the next key/value for the cursor.
@@ -984,7 +984,7 @@ func newStringDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekCache(); t != seek {
 		c.cache.pos--
@@ -994,7 +994,7 @@ func newStringDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 	c.tsm.buf = make([]StringValue, 1000)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekTSM(); t != seek {
 		c.tsm.pos--
@@ -1020,7 +1020,7 @@ func (c *stringDescendingCursor) peekTSM() (t int64, v string) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().(string)
+	return item.UnixNano(), item.Value().(string)
 }
 
 // next returns the next key/value for the cursor.
@@ -1212,14 +1212,14 @@ func newBooleanAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]BooleanValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 
 	return c
@@ -1242,7 +1242,7 @@ func (c *booleanAscendingCursor) peekTSM() (t int64, v bool) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().(bool)
+	return item.UnixNano(), item.Value().(bool)
 }
 
 // next returns the next key/value for the cursor.
@@ -1316,7 +1316,7 @@ func newBooleanDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekCache(); t != seek {
 		c.cache.pos--
@@ -1326,7 +1326,7 @@ func newBooleanDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 	c.tsm.buf = make([]BooleanValue, 1000)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekTSM(); t != seek {
 		c.tsm.pos--
@@ -1352,7 +1352,7 @@ func (c *booleanDescendingCursor) peekTSM() (t int64, v bool) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().(bool)
+	return item.UnixNano(), item.Value().(bool)
 }
 
 // next returns the next key/value for the cursor.

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -212,14 +212,14 @@ func new{{.Name}}AscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *K
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]{{.Name}}Value, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 
 	return c
@@ -242,7 +242,7 @@ func (c *{{.name}}AscendingCursor) peekTSM() (t int64, v {{.Type}}) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().({{.Type}})
+	return item.UnixNano(), item.Value().({{.Type}})
 }
 
 // next returns the next key/value for the cursor.
@@ -316,7 +316,7 @@ func new{{.Name}}DescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *
 
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].Time().UnixNano() >= seek
+		return c.cache.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekCache(); t != seek {
 		c.cache.pos--
@@ -326,7 +326,7 @@ func new{{.Name}}DescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *
 	c.tsm.buf = make([]{{.Name}}Value, 1000)
 	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
-		return c.tsm.values[i].Time().UnixNano() >= seek
+		return c.tsm.values[i].UnixNano() >= seek
 	})
 	if t, _ := c.peekTSM(); t != seek {
 		c.tsm.pos--
@@ -352,7 +352,7 @@ func (c *{{.name}}DescendingCursor) peekTSM() (t int64, v {{.Type}}) {
 	}
 
 	item := c.tsm.values[c.tsm.pos]
-	return item.Time().UnixNano(), item.Value().({{.Type}})
+	return item.UnixNano(), item.Value().({{.Type}})
 }
 
 // next returns the next key/value for the cursor.

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
@@ -17,7 +16,7 @@ func TestTSMReader_Type(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	values := []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), int64(1))}
+	values := []tsm1.Value{tsm1.NewValue(0, int64(1))}
 	if err := w.Write("cpu", values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 
@@ -61,16 +60,16 @@ func TestTSMReader_MMAP_ReadAll(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"float", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), 1.0)},
+			tsm1.NewValue(1, 1.0)},
 		},
 		{"int", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), int64(1))},
+			tsm1.NewValue(1, int64(1))},
 		},
 		{"bool", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), true)},
+			tsm1.NewValue(1, true)},
 		},
 		{"string", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), "foo")},
+			tsm1.NewValue(1, "foo")},
 		},
 	}
 
@@ -142,16 +141,16 @@ func TestTSMReader_MMAP_Read(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"float", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), 1.0)},
+			tsm1.NewValue(1, 1.0)},
 		},
 		{"int", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), int64(1))},
+			tsm1.NewValue(1, int64(1))},
 		},
 		{"bool", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), true)},
+			tsm1.NewValue(1, true)},
 		},
 		{"string", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), "foo")},
+			tsm1.NewValue(1, "foo")},
 		},
 	}
 	for _, d := range data {
@@ -184,7 +183,7 @@ func TestTSMReader_MMAP_Read(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.Read(d.key, d.values[0].Time())
+		readValues, err := r.Read(d.key, d.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -222,16 +221,16 @@ func TestTSMReader_MMAP_Keys(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"float", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), 1.0)},
+			tsm1.NewValue(1, 1.0)},
 		},
 		{"int", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), int64(1))},
+			tsm1.NewValue(1, int64(1))},
 		},
 		{"bool", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), true)},
+			tsm1.NewValue(1, true)},
 		},
 		{"string", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), "foo")},
+			tsm1.NewValue(1, "foo")},
 		},
 	}
 
@@ -265,7 +264,7 @@ func TestTSMReader_MMAP_Keys(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.Read(d.key, d.values[0].Time())
+		readValues, err := r.Read(d.key, d.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -298,7 +297,7 @@ func TestTSMReader_MMAP_Tombstone(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	values := []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}
+	values := []tsm1.Value{tsm1.NewValue(0, 1.0)}
 	if err := w.Write("cpu", values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
@@ -357,12 +356,12 @@ func TestTSMReader_MMAP_Stats(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	values1 := []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}
+	values1 := []tsm1.Value{tsm1.NewValue(0, 1.0)}
 	if err := w.Write("cpu", values1); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
-	values2 := []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 1.0)}
+	values2 := []tsm1.Value{tsm1.NewValue(1, 1.0)}
 	if err := w.Write("mem", values2); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
@@ -398,11 +397,11 @@ func TestTSMReader_MMAP_Stats(t *testing.T) {
 		t.Fatalf("max key mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := stats.MinTime, values1[0].Time(); got != exp {
+	if got, exp := stats.MinTime, values1[0].UnixNano(); got != exp {
 		t.Fatalf("min time mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := stats.MaxTime, values2[0].Time(); got != exp {
+	if got, exp := stats.MaxTime, values2[0].UnixNano(); got != exp {
 		t.Fatalf("max time mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -432,9 +431,9 @@ func TestTSMReader_VerifiesFileType(t *testing.T) {
 
 func TestIndirectIndex_Entries(t *testing.T) {
 	index := tsm1.NewDirectIndex()
-	index.Add("cpu", tsm1.BlockFloat64, time.Unix(0, 0), time.Unix(1, 0), 10, 100)
-	index.Add("cpu", tsm1.BlockFloat64, time.Unix(2, 0), time.Unix(3, 0), 20, 200)
-	index.Add("mem", tsm1.BlockFloat64, time.Unix(0, 0), time.Unix(1, 0), 10, 100)
+	index.Add("cpu", tsm1.BlockFloat64, 0, 1, 10, 100)
+	index.Add("cpu", tsm1.BlockFloat64, 2, 3, 20, 200)
+	index.Add("mem", tsm1.BlockFloat64, 0, 1, 10, 100)
 
 	b, err := index.MarshalBinary()
 	if err != nil {
@@ -474,8 +473,8 @@ func TestIndirectIndex_Entries(t *testing.T) {
 
 func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 	index := tsm1.NewDirectIndex()
-	index.Add("cpu", tsm1.BlockFloat64, time.Unix(0, 0), time.Unix(1, 0), 10, 100)
-	index.Add("cpu", tsm1.BlockFloat64, time.Unix(2, 0), time.Unix(3, 0), 20, 200)
+	index.Add("cpu", tsm1.BlockFloat64, 0, 1, 10, 100)
+	index.Add("cpu", tsm1.BlockFloat64, 2, 3, 20, 200)
 
 	b, err := index.MarshalBinary()
 	if err != nil {
@@ -500,7 +499,7 @@ func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 func TestIndirectIndex_MaxBlocks(t *testing.T) {
 	index := tsm1.NewDirectIndex()
 	for i := 0; i < 1<<16; i++ {
-		index.Add("cpu", tsm1.BlockFloat64, time.Unix(0, 0), time.Unix(1, 0), 10, 20)
+		index.Add("cpu", tsm1.BlockFloat64, 0, 1, 10, 20)
 	}
 
 	if _, err := index.MarshalBinary(); err == nil {
@@ -512,7 +511,7 @@ func TestIndirectIndex_MaxBlocks(t *testing.T) {
 
 func TestIndirectIndex_Type(t *testing.T) {
 	index := tsm1.NewDirectIndex()
-	index.Add("cpu", tsm1.BlockInteger, time.Unix(0, 0), time.Unix(1, 0), 10, 20)
+	index.Add("cpu", tsm1.BlockInteger, 0, 1, 10, 20)
 
 	b, err := index.MarshalBinary()
 
@@ -533,9 +532,9 @@ func TestIndirectIndex_Type(t *testing.T) {
 
 func TestIndirectIndex_Keys(t *testing.T) {
 	index := tsm1.NewDirectIndex()
-	index.Add("cpu", tsm1.BlockFloat64, time.Unix(0, 0), time.Unix(1, 0), 10, 20)
-	index.Add("mem", tsm1.BlockFloat64, time.Unix(0, 0), time.Unix(1, 0), 10, 20)
-	index.Add("cpu", tsm1.BlockFloat64, time.Unix(1, 0), time.Unix(2, 0), 20, 30)
+	index.Add("cpu", tsm1.BlockFloat64, 0, 1, 10, 20)
+	index.Add("mem", tsm1.BlockFloat64, 0, 1, 10, 20)
+	index.Add("cpu", tsm1.BlockFloat64, 1, 2, 20, 30)
 
 	keys := index.Keys()
 
@@ -561,7 +560,7 @@ func TestBlockIterator_Single(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	values := []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), int64(1))}
+	values := []tsm1.Value{tsm1.NewValue(0, int64(1))}
 	if err := w.Write("cpu", values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 
@@ -592,11 +591,11 @@ func TestBlockIterator_Single(t *testing.T) {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
-		if got, exp := minTime, time.Unix(0, 0); got != exp {
+		if got, exp := minTime, int64(0); got != exp {
 			t.Fatalf("min time mismatch: got %v, exp %v", got, exp)
 		}
 
-		if got, exp := maxTime, time.Unix(0, 0); got != exp {
+		if got, exp := maxTime, int64(0); got != exp {
 			t.Fatalf("max time mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -619,12 +618,12 @@ func TestBlockIterator_MultipleBlocks(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	values1 := []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), int64(1))}
+	values1 := []tsm1.Value{tsm1.NewValue(0, int64(1))}
 	if err := w.Write("cpu", values1); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
-	values2 := []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), int64(2))}
+	values2 := []tsm1.Value{tsm1.NewValue(1, int64(2))}
 	if err := w.Write("cpu", values2); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
@@ -657,11 +656,11 @@ func TestBlockIterator_MultipleBlocks(t *testing.T) {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
-		if got, exp := minTime, expData[i][0].Time(); got != exp {
+		if got, exp := minTime, expData[i][0].UnixNano(); got != exp {
 			t.Fatalf("min time mismatch: got %v, exp %v", got, exp)
 		}
 
-		if got, exp := maxTime, expData[i][0].Time(); got != exp {
+		if got, exp := maxTime, expData[i][0].UnixNano(); got != exp {
 			t.Fatalf("max time mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -685,10 +684,10 @@ func TestBlockIterator_Sorted(t *testing.T) {
 	}
 
 	values := map[string][]tsm1.Value{
-		"mem":  []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), int64(1))},
-		"cpu":  []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), float64(2))},
-		"disk": []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), true)},
-		"load": []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), "string")},
+		"mem":  []tsm1.Value{tsm1.NewValue(0, int64(1))},
+		"cpu":  []tsm1.Value{tsm1.NewValue(1, float64(2))},
+		"disk": []tsm1.Value{tsm1.NewValue(1, true)},
+		"load": []tsm1.Value{tsm1.NewValue(1, "string")},
 	}
 
 	for k, v := range values {
@@ -751,7 +750,7 @@ func TestIndirectIndex_UnmarshalBinary_BlockCountOverflow(t *testing.T) {
 	}
 
 	for i := 0; i < 3280; i++ {
-		w.Write("cpu", []tsm1.Value{tsm1.NewValue(time.Unix(int64(i), 0), float64(i))})
+		w.Write("cpu", []tsm1.Value{tsm1.NewValue(int64(i), float64(i))})
 	}
 
 	if err := w.WriteIndex(); err != nil {
@@ -784,7 +783,7 @@ func TestCompacted_NotFull(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	values := []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}
+	values := []tsm1.Value{tsm1.NewValue(0, 1.0)}
 	if err := w.Write("cpu", values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 
@@ -833,16 +832,16 @@ func TestTSMReader_File_ReadAll(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"float", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), 1.0)},
+			tsm1.NewValue(1, 1.0)},
 		},
 		{"int", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), int64(1))},
+			tsm1.NewValue(1, int64(1))},
 		},
 		{"bool", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), true)},
+			tsm1.NewValue(1, true)},
 		},
 		{"string", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), "foo")},
+			tsm1.NewValue(1, "foo")},
 		},
 	}
 
@@ -914,16 +913,16 @@ func TestTSMReader_File_Read(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"float", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), 1.0)},
+			tsm1.NewValue(1, 1.0)},
 		},
 		{"int", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), int64(1))},
+			tsm1.NewValue(1, int64(1))},
 		},
 		{"bool", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), true)},
+			tsm1.NewValue(1, true)},
 		},
 		{"string", []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), "foo")},
+			tsm1.NewValue(1, "foo")},
 		},
 	}
 	for _, d := range data {
@@ -956,7 +955,7 @@ func TestTSMReader_File_Read(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.Read(d.key, d.values[0].Time())
+		readValues, err := r.Read(d.key, d.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -980,7 +979,7 @@ func TestTSMReader_File_Read(t *testing.T) {
 func BenchmarkIndirectIndex_UnmarshalBinary(b *testing.B) {
 	index := tsm1.NewDirectIndex()
 	for i := 0; i < 100000; i++ {
-		index.Add(fmt.Sprintf("cpu-%d", i), tsm1.BlockFloat64, time.Unix(int64(i*2), 0), time.Unix(int64(i*2+1), 0), 10, 100)
+		index.Add(fmt.Sprintf("cpu-%d", i), tsm1.BlockFloat64, int64(i*2), int64(i*2+1), 10, 100)
 	}
 
 	bytes, err := index.MarshalBinary()

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -71,7 +71,7 @@ func (t *Tombstoner) TombstoneFiles() []FileStat {
 	if stat.Size() > 0 {
 		return []FileStat{FileStat{
 			Path:         stat.Name(),
-			LastModified: stat.ModTime(),
+			LastModified: stat.ModTime().UnixNano(),
 			Size:         uint32(stat.Size())}}
 	}
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -493,7 +493,7 @@ func (w *WriteWALEntry) Encode(dst []byte) ([]byte, error) {
 		n += 4
 
 		for _, vv := range v {
-			binary.BigEndian.PutUint64(dst[n:n+8], uint64(vv.Time().UnixNano()))
+			binary.BigEndian.PutUint64(dst[n:n+8], uint64(vv.UnixNano()))
 			n += 8
 
 			switch t := vv.Value().(type) {

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 
@@ -17,10 +16,10 @@ func TestWALWriter_WritePoints_Single(t *testing.T) {
 	f := MustTempFile(dir)
 	w := tsm1.NewWALSegmentWriter(f)
 
-	p1 := tsm1.NewValue(time.Unix(1, 0), 1.1)
-	p2 := tsm1.NewValue(time.Unix(1, 0), int64(1))
-	p3 := tsm1.NewValue(time.Unix(1, 0), true)
-	p4 := tsm1.NewValue(time.Unix(1, 0), "string")
+	p1 := tsm1.NewValue(1, 1.1)
+	p2 := tsm1.NewValue(1, int64(1))
+	p3 := tsm1.NewValue(1, true)
+	p4 := tsm1.NewValue(1, "string")
 
 	values := map[string][]tsm1.Value{
 		"cpu,host=A#!~#float":  []tsm1.Value{p1},
@@ -78,7 +77,7 @@ func TestWALWriter_WritePoints_LargeBatch(t *testing.T) {
 
 	var points []tsm1.Value
 	for i := 0; i < 100000; i++ {
-		points = append(points, tsm1.NewValue(time.Unix(int64(i), 0), int64(1)))
+		points = append(points, tsm1.NewValue(int64(i), int64(1)))
 	}
 
 	values := map[string][]tsm1.Value{
@@ -132,8 +131,8 @@ func TestWALWriter_WritePoints_Multiple(t *testing.T) {
 	f := MustTempFile(dir)
 	w := tsm1.NewWALSegmentWriter(f)
 
-	p1 := tsm1.NewValue(time.Unix(1, 0), int64(1))
-	p2 := tsm1.NewValue(time.Unix(1, 0), int64(2))
+	p1 := tsm1.NewValue(1, int64(1))
+	p2 := tsm1.NewValue(1, int64(2))
 
 	exp := []struct {
 		key    string
@@ -246,7 +245,7 @@ func TestWALWriter_WritePointsDelete_Multiple(t *testing.T) {
 	f := MustTempFile(dir)
 	w := tsm1.NewWALSegmentWriter(f)
 
-	p1 := tsm1.NewValue(time.Unix(1, 0), true)
+	p1 := tsm1.NewValue(1, true)
 	values := map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{p1},
 	}
@@ -346,7 +345,7 @@ func TestWAL_ClosedSegments(t *testing.T) {
 
 	if _, err := w.WritePoints(map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{
-			tsm1.NewValue(time.Unix(1, 0), 1.1),
+			tsm1.NewValue(1, 1.1),
 		},
 	}); err != nil {
 		t.Fatalf("error writing points: %v", err)
@@ -421,7 +420,7 @@ func TestWALWriter_Corrupt(t *testing.T) {
 	w := tsm1.NewWALSegmentWriter(f)
 	corruption := []byte{1, 4, 0, 0, 0}
 
-	p1 := tsm1.NewValue(time.Unix(1, 0), 1.1)
+	p1 := tsm1.NewValue(1, 1.1)
 	values := map[string][]tsm1.Value{
 		"cpu,host=A#!~#float": []tsm1.Value{p1},
 	}
@@ -471,7 +470,7 @@ func BenchmarkWALSegmentWriter(b *testing.B) {
 	points := map[string][]tsm1.Value{}
 	for i := 0; i < 5000; i++ {
 		k := "cpu,host=A#!~#value"
-		points[k] = append(points[k], tsm1.NewValue(time.Unix(int64(i), 0), 1.1))
+		points[k] = append(points[k], tsm1.NewValue(int64(i), 1.1))
 	}
 
 	dir := MustTempDir()
@@ -496,7 +495,7 @@ func BenchmarkWALSegmentReader(b *testing.B) {
 	points := map[string][]tsm1.Value{}
 	for i := 0; i < 5000; i++ {
 		k := "cpu,host=A#!~#value"
-		points[k] = append(points[k], tsm1.NewValue(time.Unix(int64(i), 0), 1.1))
+		points[k] = append(points[k], tsm1.NewValue(int64(i), 1.1))
 	}
 
 	dir := MustTempDir()

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"testing"
-	"time"
 
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
@@ -52,7 +51,7 @@ func TestTSMWriter_Write_Single(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	values := []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}
+	values := []tsm1.Value{tsm1.NewValue(0, 1.0)}
 	if err := w.Write("cpu", values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 
@@ -104,8 +103,8 @@ func TestTSMWriter_Write_Multiple(t *testing.T) {
 		key    string
 		values []tsm1.Value
 	}{
-		{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
+		{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		{"mem", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
 	}
 
 	for _, d := range data {
@@ -157,12 +156,12 @@ func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"cpu", []tsm1.Value{
-			tsm1.NewValue(time.Unix(0, 0), 1.0),
-			tsm1.NewValue(time.Unix(1, 0), 2.0)},
+			tsm1.NewValue(0, 1.0),
+			tsm1.NewValue(1, 2.0)},
 		},
 		{"mem", []tsm1.Value{
-			tsm1.NewValue(time.Unix(0, 0), 1.5),
-			tsm1.NewValue(time.Unix(1, 0), 2.5)},
+			tsm1.NewValue(0, 1.5),
+			tsm1.NewValue(1, 2.5)},
 		},
 	}
 
@@ -216,12 +215,12 @@ func TestTSMWriter_Write_ReverseKeys(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"mem", []tsm1.Value{
-			tsm1.NewValue(time.Unix(0, 0), 1.5),
-			tsm1.NewValue(time.Unix(1, 0), 2.5)},
+			tsm1.NewValue(0, 1.5),
+			tsm1.NewValue(1, 2.5)},
 		},
 		{"cpu", []tsm1.Value{
-			tsm1.NewValue(time.Unix(0, 0), 1.0),
-			tsm1.NewValue(time.Unix(1, 0), 2.0)},
+			tsm1.NewValue(0, 1.0),
+			tsm1.NewValue(1, 2.0)},
 		},
 	}
 
@@ -275,12 +274,12 @@ func TestTSMWriter_Write_SameKey(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"cpu", []tsm1.Value{
-			tsm1.NewValue(time.Unix(0, 0), 1.0),
-			tsm1.NewValue(time.Unix(1, 0), 2.0)},
+			tsm1.NewValue(0, 1.0),
+			tsm1.NewValue(1, 2.0)},
 		},
 		{"cpu", []tsm1.Value{
-			tsm1.NewValue(time.Unix(2, 0), 3.0),
-			tsm1.NewValue(time.Unix(3, 0), 4.0)},
+			tsm1.NewValue(2, 3.0),
+			tsm1.NewValue(3, 4.0)},
 		},
 	}
 
@@ -335,12 +334,12 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 		values []tsm1.Value
 	}{
 		{"cpu", []tsm1.Value{
-			tsm1.NewValue(time.Unix(0, 0), 1.0),
-			tsm1.NewValue(time.Unix(1, 0), 2.0)},
+			tsm1.NewValue(0, 1.0),
+			tsm1.NewValue(1, 2.0)},
 		},
 		{"cpu", []tsm1.Value{
-			tsm1.NewValue(time.Unix(2, 0), 3.0),
-			tsm1.NewValue(time.Unix(3, 0), 4.0)},
+			tsm1.NewValue(2, 3.0),
+			tsm1.NewValue(3, 4.0)},
 		},
 	}
 
@@ -365,7 +364,7 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 
 	for _, values := range data {
 		// Try the first timestamp
-		readValues, err := r.Read("cpu", values.values[0].Time())
+		readValues, err := r.Read("cpu", values.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -381,7 +380,7 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 		}
 
 		// Try the last timestamp too
-		readValues, err = r.Read("cpu", values.values[1].Time())
+		readValues, err = r.Read("cpu", values.values[1].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -406,7 +405,7 @@ func TestTSMWriter_WriteBlock_Empty(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	if err := w.WriteBlock("cpu", time.Unix(0, 0), time.Unix(0, 0), nil); err != nil {
+	if err := w.WriteBlock("cpu", 0, 0, nil); err != nil {
 		t.Fatalf("unexpected error writing block: %v", err)
 	}
 
@@ -431,8 +430,8 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 		key    string
 		values []tsm1.Value
 	}{
-		{"cpu", []tsm1.Value{tsm1.NewValue(time.Unix(0, 0), 1.0)}},
-		{"mem", []tsm1.Value{tsm1.NewValue(time.Unix(1, 0), 2.0)}},
+		{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		{"mem", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
This change converts all the uses of `time.Time` to `int64` within the TSM engine.  This was an idea initially presented in #5522, but didn't make sense to implement until query engine and other changes had completed.

Since we mainly using timestamps as `UnixNano` values anyways, the overhead of using a `time.Time` everywhere ends up creating a lot of garbage for GC to work though.  This change should help with GC and larger queries that process a lot of points.

A simple count query over 100M points improved from 53s to 38s with this change.  

```
$ time influx -database stress -execute "select count(value) from cpu"
name: cpu
---------
time	count
0	1e+08


real	0m52.670s
user	0m0.006s
sys	0m0.006s
```

After:

```
$ time influx -database stress -execute "select count(value) from cpu"
name: cpu
---------
time	count
0	1e+08


real	0m38.107s
user	0m0.005s
sys	0m0.006s
```

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [ ] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
