### PR TITLE
Fix remote execution for partially replicated clusters

### DIFF
--- a/cluster/service.go
+++ b/cluster/service.go
@@ -187,12 +187,15 @@ func (s *Service) handleConn(conn net.Conn) {
 		case createIteratorRequestMessage:
 			s.statMap.Add(createIteratorReq, 1)
 			s.processCreateIteratorRequest(conn)
+			return
 		case fieldDimensionsRequestMessage:
 			s.statMap.Add(fieldDimensionsReq, 1)
 			s.processFieldDimensionsRequest(conn)
+			return
 		case seriesKeysRequestMessage:
 			s.statMap.Add(seriesKeysReq, 1)
 			s.processSeriesKeysRequest(conn)
+			return
 		default:
 			s.Logger.Printf("cluster service message type not found: %d", typ)
 		}

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -398,7 +398,9 @@ func drainIterator(itr Iterator) {
 // NewReaderIterator returns an iterator that streams from a reader.
 func NewReaderIterator(r io.Reader) (Iterator, error) {
 	var p Point
-	if err := NewPointDecoder(r).DecodePoint(&p); err != nil {
+	if err := NewPointDecoder(r).DecodePoint(&p); err == io.EOF {
+		return &nilFloatIterator{}, nil
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -502,8 +504,8 @@ func (a IteratorCreators) FieldDimensions(sources Sources) (fields, dimensions m
 // into a single Series by calling Combine on it.
 func (a IteratorCreators) SeriesKeys(opt IteratorOptions) (SeriesList, error) {
 	seriesMap := make(map[string]Series)
-	for _, sh := range a {
-		series, err := sh.SeriesKeys(opt)
+	for _, ic := range a {
+		series, err := ic.SeriesKeys(opt)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The RPC handler for remote queries would attempt to reuse a closed
connection for certain commands that didn't use pooling. The RPC
commands that close the connection have been fixed to not try reusing
the connection.

When creating an iterator, if there are no points to return, the points
decoder would hit an EOF that it didn't catch and would return that
error back to the client who made the request. It now properly returns
no points by using a `nilFloatIterator` if there are no points to
return.

This fixes remote execution when a cluster has nothing to return.