### PR TITLE
Tag TSM stats with database and retention policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#5706](https://github.com/influxdata/influxdb/pull/5706): Cluster setup cleanup
 - [#5691](https://github.com/influxdata/influxdb/pull/5691): Remove associated shard data when retention policies are dropped.
 - [#5758](https://github.com/influxdata/influxdb/pull/5758): TSM engine stats for cache, WAL, and filestore. Thanks @jonseymour
+- [#5844](https://github.com/influxdata/influxdb/pull/5844): Tag TSM engine stats with database and retention policy
 
 ### Bugfixes
 

--- a/services/copier/service_test.go
+++ b/services/copier/service_test.go
@@ -164,10 +164,8 @@ func MustOpenShard(id uint64) *Shard {
 	sh := &Shard{
 		Shard: tsdb.NewShard(id,
 			tsdb.NewDatabaseIndex("db"),
-			tsdb.ShardConfig{
-				Path:    filepath.Join(path, "data"),
-				WALPath: filepath.Join(path, "wal"),
-			},
+			filepath.Join(path, "data"),
+			filepath.Join(path, "wal"),
 			tsdb.NewEngineOptions(),
 		),
 		path: path,

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 type TSMFile interface {
@@ -124,11 +125,16 @@ func (f FileStat) ContainsKey(key string) bool {
 }
 
 func NewFileStore(dir string) *FileStore {
+	db, rp := tsdb.DecodeStorePath(dir)
 	return &FileStore{
 		dir:          dir,
 		lastModified: time.Now(),
 		Logger:       log.New(os.Stderr, "[filestore] ", log.LstdFlags),
-		statMap:      influxdb.NewStatistics("tsm1_filestore:"+dir, "tsm1_filestore", map[string]string{"path": dir}),
+		statMap: influxdb.NewStatistics(
+			"tsm1_filestore:"+dir,
+			"tsm1_filestore",
+			map[string]string{"path": dir, "database": db, "retentionPolicy": rp},
+		),
 	}
 }
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 const (
@@ -89,6 +90,7 @@ type WAL struct {
 }
 
 func NewWAL(path string) *WAL {
+	db, rp := tsdb.DecodeStorePath(path)
 	return &WAL{
 		path: path,
 
@@ -98,7 +100,11 @@ func NewWAL(path string) *WAL {
 		logger:      log.New(os.Stderr, "[tsm1wal] ", log.LstdFlags),
 		closing:     make(chan struct{}),
 
-		statMap: influxdb.NewStatistics("tsm1_wal:"+path, "tsm1_wal", map[string]string{"path": path}),
+		statMap: influxdb.NewStatistics(
+			"tsm1_wal:"+path,
+			"tsm1_wal",
+			map[string]string{"path": path, "database": db, "retentionPolicy": rp},
+		),
 	}
 }
 

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -33,7 +33,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	opts := tsdb.NewEngineOptions()
 	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
 
-	sh := tsdb.NewShard(1, index, tsdb.ShardConfig{Path: tmpShard, WALPath: tmpWal}, opts)
+	sh := tsdb.NewShard(1, index, tmpShard, tmpWal, opts)
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error opening shard: %s", err.Error())
 	}
@@ -76,7 +76,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	sh.Close()
 
 	index = tsdb.NewDatabaseIndex("db")
-	sh = tsdb.NewShard(1, index, tsdb.ShardConfig{Path: tmpShard, WALPath: tmpWal}, opts)
+	sh = tsdb.NewShard(1, index, tmpShard, tmpWal, opts)
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error opening shard: %s", err.Error())
 	}
@@ -103,7 +103,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 	opts := tsdb.NewEngineOptions()
 	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
 
-	sh := tsdb.NewShard(1, index, tsdb.ShardConfig{Path: tmpShard, WALPath: tmpWal}, opts)
+	sh := tsdb.NewShard(1, index, tmpShard, tmpWal, opts)
 	if err := sh.Open(); err != nil {
 		t.Fatalf("error opening shard: %s", err.Error())
 	}
@@ -258,7 +258,7 @@ func benchmarkWritePoints(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
 		tmpDir, _ := ioutil.TempDir("", "shard_test")
 		tmpShard := path.Join(tmpDir, "shard")
 		tmpWal := path.Join(tmpDir, "wal")
-		shard := tsdb.NewShard(1, index, tsdb.ShardConfig{Path: tmpShard, WALPath: tmpWal}, tsdb.NewEngineOptions())
+		shard := tsdb.NewShard(1, index, tmpShard, tmpWal, tsdb.NewEngineOptions())
 		shard.Open()
 
 		b.StartTimer()
@@ -294,7 +294,7 @@ func benchmarkWritePointsExistingSeries(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt
 	defer os.RemoveAll(tmpDir)
 	tmpShard := path.Join(tmpDir, "shard")
 	tmpWal := path.Join(tmpDir, "wal")
-	shard := tsdb.NewShard(1, index, tsdb.ShardConfig{Path: tmpShard, WALPath: tmpWal}, tsdb.NewEngineOptions())
+	shard := tsdb.NewShard(1, index, tmpShard, tmpWal, tsdb.NewEngineOptions())
 	shard.Open()
 	defer shard.Close()
 	chunkedWrite(shard, points)
@@ -356,10 +356,8 @@ func NewShard() *Shard {
 	return &Shard{
 		Shard: tsdb.NewShard(0,
 			tsdb.NewDatabaseIndex("db"),
-			tsdb.ShardConfig{
-				Path:    filepath.Join(path, "data"),
-				WALPath: filepath.Join(path, "wal"),
-			},
+			filepath.Join(path, "data"),
+			filepath.Join(path, "wal"),
 			opt,
 		),
 		path: path,

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -344,6 +344,7 @@ func (s *Store) Reopen() error {
 		return err
 	}
 	s.Store = tsdb.NewStore(s.Path())
+	s.EngineOptions.Config.WALDir = filepath.Join(s.Path(), "wal")
 	return s.Open()
 }
 


### PR DESCRIPTION
(This probably should have been part of #5810. Hindsight is 20/20.)

The primary intent of this changeset is to tag stats for TSM cache, WAL, and filestore with the owner database and retention policy. The database and retention policy are inferred from the path supplied to the engine component.