### PR TITLE
fix tests to cope with future changes to testing.quick.Check - see #5854

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - [#5832](https://github.com/influxdata/influxdb/issues/5832): tsm: cache: need to check that snapshot has been sorted @jonseymour
 - [#5841](https://github.com/influxdata/influxdb/pull/5841): Reduce tsm allocations by converting time.Time to int64
 - [#5842](https://github.com/influxdata/influxdb/issues/5842): Add SeriesList binary marshaling
+- [#5854](https://github.com/influxdata/influxdb/issues/5854): failures of tests in tsdb/engine/tsm1 when compiled with go master
 
 ## v0.10.1 [2016-02-18]
 

--- a/tsdb/engine/tsm1/bool_test.go
+++ b/tsdb/engine/tsm1/bool_test.go
@@ -76,6 +76,10 @@ func Test_BooleanEncoder_Multi_Compressed(t *testing.T) {
 
 func Test_BooleanEncoder_Quick(t *testing.T) {
 	if err := quick.Check(func(values []bool) bool {
+		expected := values
+		if values == nil {
+			expected = []bool{}
+		}
 		// Write values to encoder.
 		enc := tsm1.NewBooleanEncoder()
 		for _, v := range values {
@@ -96,8 +100,8 @@ func Test_BooleanEncoder_Quick(t *testing.T) {
 		}
 
 		// Verify that input and output values match.
-		if !reflect.DeepEqual(values, got) {
-			t.Fatalf("mismatch:\n\nexp=%+v\n\ngot=%+v\n\n", values, got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", expected, got)
 		}
 
 		return true

--- a/tsdb/engine/tsm1/float_test.go
+++ b/tsdb/engine/tsm1/float_test.go
@@ -202,6 +202,12 @@ func TestFloatEncoder_Roundtrip_NaN(t *testing.T) {
 
 func Test_FloatEncoder_Quick(t *testing.T) {
 	quick.Check(func(values []float64) bool {
+
+		expected := values
+		if values == nil {
+			expected = []float64{}
+		}
+
 		// Write values to encoder.
 		enc := tsm1.NewFloatEncoder()
 		for _, v := range values {
@@ -225,8 +231,8 @@ func Test_FloatEncoder_Quick(t *testing.T) {
 		}
 
 		// Verify that input and output values match.
-		if !reflect.DeepEqual(values, got) {
-			t.Fatalf("mismatch:\n\nexp=%+v\n\ngot=%+v\n\n", values, got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", expected, got)
 		}
 
 		return true

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -416,6 +416,11 @@ func Test_IntegerEncoder_MinMax(t *testing.T) {
 
 func Test_IntegerEncoder_Quick(t *testing.T) {
 	quick.Check(func(values []int64) bool {
+		expected := values
+		if values == nil {
+			expected = []int64{} // is this really expected?
+		}
+
 		// Write values to encoder.
 		enc := NewIntegerEncoder()
 		for _, v := range values {
@@ -439,8 +444,8 @@ func Test_IntegerEncoder_Quick(t *testing.T) {
 		}
 
 		// Verify that input and output values match.
-		if !reflect.DeepEqual(values, got) {
-			t.Fatalf("mismatch:\n\nexp=%+v\n\ngot=%+v\n\n", values, got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", expected, got)
 		}
 
 		return true

--- a/tsdb/engine/tsm1/string_test.go
+++ b/tsdb/engine/tsm1/string_test.go
@@ -88,6 +88,10 @@ func Test_StringEncoder_Multi_Compressed(t *testing.T) {
 
 func Test_StringEncoder_Quick(t *testing.T) {
 	quick.Check(func(values []string) bool {
+		expected := values
+		if values == nil {
+			expected = []string{}
+		}
 		// Write values to encoder.
 		enc := NewStringEncoder()
 		for _, v := range values {
@@ -114,8 +118,8 @@ func Test_StringEncoder_Quick(t *testing.T) {
 		}
 
 		// Verify that input and output values match.
-		if !reflect.DeepEqual(values, got) {
-			t.Fatalf("mismatch:\n\nexp=%+v\n\ngot=%+v\n\n", values, got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", expected, got)
 		}
 
 		return true


### PR DESCRIPTION
This test case demonstrates that go master breaks the influxdb build, but go 1.6 doesn't. See #5854

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
