### PR TITLE
[0.10.x] Backport of cache related changes to 0.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.10.2 [unreleased]
+### Bugfixes
+- [#5719](https://github.com/influxdata/influxdb/issues/5719): Fix cache not deduplicating points
+- [#5699](https://github.com/influxdata/influxdb/issues/5699): Fix potential thread safety issue in cache @jonseymour
+- [#5832](https://github.com/influxdata/influxdb/issues/5832): tsm: cache: need to check that snapshot has been sorted @jonseymour
+- [#5857](https://github.com/influxdata/influxdb/issues/5857): panic in tsm1.Values.Deduplicate
+
+
 ## v0.10.1 [2016-02-18]
 
 ### Bugfixes

--- a/tsdb/engine/tsm1/bool_test.go
+++ b/tsdb/engine/tsm1/bool_test.go
@@ -76,6 +76,10 @@ func Test_BoolEncoder_Multi_Compressed(t *testing.T) {
 
 func Test_BoolEncoder_Quick(t *testing.T) {
 	if err := quick.Check(func(values []bool) bool {
+		expected := values
+		if values == nil {
+			expected = []bool{}
+		}
 		// Write values to encoder.
 		enc := tsm1.NewBoolEncoder()
 		for _, v := range values {
@@ -96,8 +100,8 @@ func Test_BoolEncoder_Quick(t *testing.T) {
 		}
 
 		// Verify that input and output values match.
-		if !reflect.DeepEqual(values, got) {
-			t.Fatalf("mismatch:\n\nexp=%+v\n\ngot=%+v\n\n", values, got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", expected, got)
 		}
 
 		return true

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -263,6 +263,7 @@ func (c *Cache) merged(key string) Values {
 	if c.snapshot != nil {
 		snapshotEntries := c.snapshot.store[key]
 		if snapshotEntries != nil {
+			snapshotEntries.deduplicate() // guarantee we are deduplicated
 			entries = append(entries, snapshotEntries)
 			sz += snapshotEntries.count()
 		}

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -60,6 +60,7 @@ func (e *entry) deduplicate() {
 
 // Cache maintains an in-memory store of Values for a set of keys.
 type Cache struct {
+	commit  sync.Mutex
 	mu      sync.RWMutex
 	store   map[string]*entry
 	size    uint64
@@ -128,6 +129,8 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 // Snapshot will take a snapshot of the current cache, add it to the slice of caches that
 // are being flushed, and reset the current cache with new values
 func (c *Cache) Snapshot() *Cache {
+	c.commit.Lock() // must be released by a subsequent call to ClearSnapshot.
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -166,13 +169,16 @@ func (c *Cache) Deduplicate() {
 
 // ClearSnapshot will remove the snapshot cache from the list of flushing caches and
 // adjust the size
-func (c *Cache) ClearSnapshot() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+func (c *Cache) ClearSnapshot(success bool) {
+	defer c.commit.Unlock()
 
-	c.snapshotSize = 0
-	c.snapshot = nil
+	if success {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 
+		c.snapshotSize = 0
+		c.snapshot = nil
+	}
 }
 
 // Size returns the number of point-calcuated bytes the cache currently uses.

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -68,8 +68,8 @@ type Cache struct {
 	// snapshots are the cache objects that are currently being written to tsm files
 	// they're kept in memory while flushing so they can be queried along with the cache.
 	// they are read only and should never be modified
-	snapshots     []*Cache
-	snapshotsSize uint64
+	snapshot     *Cache
+	snapshotSize uint64
 }
 
 // NewCache returns an instance of a cache which will use a maximum of maxSize bytes of memory.
@@ -88,7 +88,7 @@ func (c *Cache) Write(key string, values []Value) error {
 
 	// Enough room in the cache?
 	newSize := c.size + uint64(Values(values).Size())
-	if c.maxSize > 0 && newSize+c.snapshotsSize > c.maxSize {
+	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
 		return ErrCacheMemoryExceeded
 	}
 
@@ -109,7 +109,7 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 	// Enough room in the cache?
 	c.mu.RLock()
 	newSize := c.size + uint64(totalSz)
-	if c.maxSize > 0 && newSize+c.snapshotsSize > c.maxSize {
+	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
 		c.mu.RUnlock()
 		return ErrCacheMemoryExceeded
 	}
@@ -131,17 +131,29 @@ func (c *Cache) Snapshot() *Cache {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	snapshot := NewCache(c.maxSize)
-	snapshot.store = c.store
-	snapshot.size = c.size
+	if c.snapshot == nil {
+		c.snapshot = &Cache{
+			store: make(map[string]*entry),
+		}
+	}
 
+	// Append the current cache values to the snapshot
+	for k, e := range c.store {
+		if _, ok := c.snapshot.store[k]; ok {
+			c.snapshot.store[k].add(e.values)
+		} else {
+			c.snapshot.store[k] = e
+		}
+		c.snapshotSize += uint64(Values(e.values).Size())
+	}
+
+	// Reset the cache
 	c.store = make(map[string]*entry)
 	c.size = 0
 
-	c.snapshots = append(c.snapshots, snapshot)
-	c.snapshotsSize += snapshot.size
+	c.snapshotSize += c.snapshot.size
 
-	return snapshot
+	return c.snapshot
 }
 
 // Deduplicate sorts the snapshot before returning it. The compactor and any queries
@@ -154,17 +166,13 @@ func (c *Cache) Deduplicate() {
 
 // ClearSnapshot will remove the snapshot cache from the list of flushing caches and
 // adjust the size
-func (c *Cache) ClearSnapshot(snapshot *Cache) {
+func (c *Cache) ClearSnapshot() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for i, cache := range c.snapshots {
-		if cache == snapshot {
-			c.snapshots = append(c.snapshots[:i], c.snapshots[i+1:]...)
-			c.snapshotsSize -= snapshot.size
-			break
-		}
-	}
+	c.snapshotSize = 0
+	c.snapshot = nil
+
 }
 
 // Size returns the number of point-calcuated bytes the cache currently uses.
@@ -230,7 +238,7 @@ func (c *Cache) Delete(keys []string) {
 func (c *Cache) merged(key string) Values {
 	e := c.store[key]
 	if e == nil {
-		if len(c.snapshots) == 0 {
+		if c.snapshot == nil {
 			// No values in hot cache or snapshots.
 			return nil
 		}
@@ -242,13 +250,15 @@ func (c *Cache) merged(key string) Values {
 	// Calculate the required size of the destination buffer.
 	var entries []*entry
 	sz := 0
-	for _, s := range c.snapshots {
-		e := s.store[key]
-		if e != nil {
-			entries = append(entries, e)
-			sz += len(e.values)
+
+	if c.snapshot != nil {
+		snapshotEntries := c.snapshot.store[key]
+		if snapshotEntries != nil {
+			entries = append(entries, snapshotEntries)
+			sz += len(snapshotEntries.values)
 		}
 	}
+
 	if e != nil {
 		entries = append(entries, e)
 		sz += len(e.values)

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -1,0 +1,57 @@
+// +build !race
+
+package tsm1_test
+
+import (
+	"fmt"
+	"github.com/influxdb/influxdb/tsdb/engine/tsm1"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCheckConcurrentReadsAreSafe(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000)
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(3)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	close(ch)
+	wg.Wait()
+}

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -93,7 +93,7 @@ func TestCacheRace(t *testing.T) {
 		<-ch
 		s := c.Snapshot()
 		s.Deduplicate()
-		c.ClearSnapshot()
+		c.ClearSnapshot(true)
 	}()
 	close(ch)
 	wg.Wait()
@@ -148,7 +148,7 @@ func TestCacheRace2Compacters(t *testing.T) {
 			}
 			mu.Unlock()
 			s.Deduplicate()
-			c.ClearSnapshot()
+			c.ClearSnapshot(true)
 			mu.Lock()
 			defer mu.Unlock()
 			for k, _ := range myFiles {

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -55,3 +55,111 @@ func TestCheckConcurrentReadsAreSafe(t *testing.T) {
 	close(ch)
 	wg.Wait()
 }
+
+func TestCacheRace(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000)
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(1)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	wg.Add(1)
+	go func() {
+		wg.Done()
+		<-ch
+		s := c.Snapshot()
+		s.Deduplicate()
+		c.ClearSnapshot()
+	}()
+	close(ch)
+	wg.Wait()
+}
+
+func TestCacheRace2Compacters(t *testing.T) {
+	values := make(tsm1.Values, 1000)
+	timestamps := make([]time.Time, len(values))
+	series := make([]string, 100)
+	for i := range timestamps {
+		timestamps[i] = time.Unix(int64(rand.Int63n(int64(len(values)))), 0).UTC()
+	}
+
+	for i := range values {
+		values[i] = tsm1.NewValue(timestamps[i*len(timestamps)/len(values)], float64(i))
+	}
+
+	for i := range series {
+		series[i] = fmt.Sprintf("series%d", i)
+	}
+
+	wg := sync.WaitGroup{}
+	c := tsm1.NewCache(1000000)
+
+	ch := make(chan struct{})
+	for _, s := range series {
+		for _, v := range values {
+			c.Write(s, tsm1.Values{v})
+		}
+		wg.Add(1)
+		go func(s string) {
+			defer wg.Done()
+			<-ch
+			c.Values(s)
+		}(s)
+	}
+	fileCounter := 0
+	mapFiles := map[int]bool{}
+	mu := sync.Mutex{}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			wg.Done()
+			<-ch
+			s := c.Snapshot()
+			mu.Lock()
+			mapFiles[fileCounter] = true
+			fileCounter++
+			myFiles := map[int]bool{}
+			for k, e := range mapFiles {
+				myFiles[k] = e
+			}
+			mu.Unlock()
+			s.Deduplicate()
+			c.ClearSnapshot()
+			mu.Lock()
+			defer mu.Unlock()
+			for k, _ := range myFiles {
+				if _, ok := mapFiles[k]; !ok {
+					t.Fatalf("something else deleted one of my files")
+				} else {
+					delete(mapFiles, k)
+				}
+			}
+		}()
+	}
+	close(ch)
+	wg.Wait()
+}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -228,7 +228,7 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.ClearSnapshot()
+	c.ClearSnapshot(true)
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot, ensuring non-snapshot data untouched.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	expValues = Values{v5, v4}
 	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -199,7 +199,7 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	}
 
 	// Clear snapshot.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
@@ -222,13 +222,13 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Grab snapshot, write should still fail since we're still using the memory.
-	snapshot := c.Snapshot()
+	_ = c.Snapshot()
 	if err := c.Write("bar", Values{v1}); err != ErrCacheMemoryExceeded {
 		t.Fatalf("wrong error writing key bar to cache")
 	}
 
 	// Clear the snapshot and the write should now succeed.
-	c.ClearSnapshot(snapshot)
+	c.ClearSnapshot()
 	if err := c.Write("bar", Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -73,6 +73,41 @@ func TestCache_CacheWriteMulti(t *testing.T) {
 	}
 }
 
+// This tests writing two batches to the same series.  The first batch
+// is sorted.  The second batch is also sorted but contains duplicates.
+func TestCache_CacheWriteMulti_Duplicates(t *testing.T) {
+	v0 := NewValue(time.Unix(2, 0).UTC(), 1.0)
+	v1 := NewValue(time.Unix(3, 0).UTC(), 1.0)
+	values0 := Values{v0, v1}
+
+	v3 := NewValue(time.Unix(4, 0).UTC(), 2.0)
+	v4 := NewValue(time.Unix(5, 0).UTC(), 3.0)
+	v5 := NewValue(time.Unix(5, 0).UTC(), 3.0)
+	values1 := Values{v3, v4, v5}
+
+	c := NewCache(0)
+
+	if err := c.WriteMulti(map[string][]Value{"foo": values0}); err != nil {
+		t.Fatalf("failed to write key foo to cache: %s", err.Error())
+	}
+
+	if err := c.WriteMulti(map[string][]Value{"foo": values1}); err != nil {
+		t.Fatalf("failed to write key foo to cache: %s", err.Error())
+	}
+
+	if exp, keys := []string{"foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
+	}
+
+	expAscValues := Values{v0, v1, v3, v5}
+	if exp, got := len(expAscValues), len(c.Values("foo")); exp != got {
+		t.Fatalf("value count mismatch: exp: %v, got %v", exp, got)
+	}
+	if deduped := c.Values("foo"); !reflect.DeepEqual(expAscValues, deduped) {
+		t.Fatalf("deduped ascending values for foo incorrect, exp: %v, got %v", expAscValues, deduped)
+	}
+}
+
 func TestCache_CacheValues(t *testing.T) {
 	v0 := NewValue(time.Unix(1, 0).UTC(), 0.0)
 	v1 := NewValue(time.Unix(2, 0).UTC(), 2.0)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -438,7 +438,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.ClearSnapshot(snapshot)
+	e.Cache.ClearSnapshot()
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -420,7 +420,13 @@ func (e *Engine) WriteSnapshot() error {
 }
 
 // writeSnapshotAndCommit will write the passed cache to a new TSM file and remove the closed WAL segments
-func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) error {
+func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, compactor *Compactor) (err error) {
+
+	defer func() {
+		if err != nil {
+			e.Cache.ClearSnapshot(false)
+		}
+	}()
 	// write the new snapshot files
 	newFiles, err := compactor.WriteSnapshot(snapshot)
 	if err != nil {
@@ -438,7 +444,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache, c
 	}
 
 	// clear the snapshot from the in-memory cache, then the old WAL files
-	e.Cache.ClearSnapshot()
+	e.Cache.ClearSnapshot(true)
 
 	if err := e.WAL.Remove(closedFiles); err != nil {
 		e.logger.Printf("error removing closed wal segments: %v", err)

--- a/tsdb/engine/tsm1/float_test.go
+++ b/tsdb/engine/tsm1/float_test.go
@@ -202,6 +202,12 @@ func TestFloatEncoder_Roundtrip_NaN(t *testing.T) {
 
 func Test_FloatEncoder_Quick(t *testing.T) {
 	quick.Check(func(values []float64) bool {
+
+		expected := values
+		if values == nil {
+			expected = []float64{}
+		}
+
 		// Write values to encoder.
 		enc := tsm1.NewFloatEncoder()
 		for _, v := range values {
@@ -225,8 +231,8 @@ func Test_FloatEncoder_Quick(t *testing.T) {
 		}
 
 		// Verify that input and output values match.
-		if !reflect.DeepEqual(values, got) {
-			t.Fatalf("mismatch:\n\nexp=%+v\n\ngot=%+v\n\n", values, got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", expected, got)
 		}
 
 		return true

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -416,6 +416,11 @@ func Test_Int64Encoder_MinMax(t *testing.T) {
 
 func Test_Int64Encoder_Quick(t *testing.T) {
 	quick.Check(func(values []int64) bool {
+		expected := values
+		if values == nil {
+			expected = []int64{} // is this really expected?
+		}
+
 		// Write values to encoder.
 		enc := NewInt64Encoder()
 		for _, v := range values {
@@ -439,8 +444,8 @@ func Test_Int64Encoder_Quick(t *testing.T) {
 		}
 
 		// Verify that input and output values match.
-		if !reflect.DeepEqual(values, got) {
-			t.Fatalf("mismatch:\n\nexp=%+v\n\ngot=%+v\n\n", values, got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", expected, got)
 		}
 
 		return true

--- a/tsdb/engine/tsm1/string_test.go
+++ b/tsdb/engine/tsm1/string_test.go
@@ -88,6 +88,10 @@ func Test_StringEncoder_Multi_Compressed(t *testing.T) {
 
 func Test_StringEncoder_Quick(t *testing.T) {
 	quick.Check(func(values []string) bool {
+		expected := values
+		if values == nil {
+			expected = []string{}
+		}
 		// Write values to encoder.
 		enc := NewStringEncoder()
 		for _, v := range values {
@@ -114,8 +118,8 @@ func Test_StringEncoder_Quick(t *testing.T) {
 		}
 
 		// Verify that input and output values match.
-		if !reflect.DeepEqual(values, got) {
-			t.Fatalf("mismatch:\n\nexp=%+v\n\ngot=%+v\n\n", values, got)
+		if !reflect.DeepEqual(expected, got) {
+			t.Fatalf("mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", expected, got)
 		}
 
 		return true


### PR DESCRIPTION
This PR against 0.10.0 backports the cache related changes since 0.10.1 onto the maintenance branch. It will probably solve the problem reported in #5857.

In particular this PR includes 0.10.x version of #5719, #5701 (#5699), (#5832) and the cache statistics changes (#5758) which were brought along for the ride because it was easier to take them than to leave them.

I don't really care whether this is accepted into 0.10.x or not. I happen to need these changes myself, so the work isn't wasted. If others can benefit from the changes then they are available to anyone who is capable of creating their own build.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)