### PR TITLE
Prevent panic when dropping subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 - [#5699](https://github.com/influxdata/influxdb/issues/5699): Fix potential thread safety issue in cache @jonseymour
 - [#5832](https://github.com/influxdata/influxdb/issues/5832): tsm: cache: need to check that snapshot has been sorted @jonseymour
 - [#5857](https://github.com/influxdata/influxdb/issues/5857): panic in tsm1.Values.Deduplicate
-
+- [#5861](https://github.com/influxdata/influxdb/pull/5861): Fix panic when dropping subscription for unknown retention policy.
 
 ## v0.10.1 [2016-02-18]
 
 ### Bugfixes
+
 - [#5696](https://github.com/influxdata/influxdb/issues/5696): Do not drop the database when creating with a retention policy
 - [#5724](https://github.com/influxdata/influxdb/issues/5724): influx\_tsm doesn't close file handles properly
 - [#5606](https://github.com/influxdata/influxdb/issues/5606): TSM conversion reproducibly drops data silently

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -574,8 +574,7 @@ func (data *Data) CreateSubscription(database, rp, name, mode string, destinatio
 	rpi, err := data.RetentionPolicy(database, rp)
 	if err != nil {
 		return err
-	}
-	if rpi == nil {
+	} else if rpi == nil {
 		return influxdb.ErrRetentionPolicyNotFound(rp)
 	}
 
@@ -601,6 +600,8 @@ func (data *Data) DropSubscription(database, rp, name string) error {
 	rpi, err := data.RetentionPolicy(database, rp)
 	if err != nil {
 		return err
+	} else if rpi == nil {
+		return influxdb.ErrRetentionPolicyNotFound(rp)
 	}
 
 	for i := range rpi.Subscriptions {

--- a/services/meta/errors.go
+++ b/services/meta/errors.go
@@ -73,9 +73,6 @@ var (
 	// ErrReplicationFactorTooLow is returned when the replication factor is not in an
 	// acceptable range.
 	ErrReplicationFactorTooLow = errors.New("replication factor must be greater than 0")
-
-	// ErrRetentionPolicyNotFound is returned when an expected retention policy can't be found.
-	ErrRetentionPolicyNotFound = errors.New("retention policy not found")
 )
 
 var (

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/influxdb/influxdb"
+
 	"github.com/influxdb/influxdb/influxql"
 	"github.com/influxdb/influxdb/services/meta"
 	"github.com/influxdb/influxdb/tcp"
@@ -566,7 +568,7 @@ func TestMetaService_ContinuousQueries(t *testing.T) {
 	}
 }
 
-func TestMetaService_Subscriptions(t *testing.T) {
+func TestMetaService_Subscriptions_Create(t *testing.T) {
 	t.Parallel()
 
 	d, s, c := newServiceAndClient()
@@ -598,36 +600,128 @@ func TestMetaService_Subscriptions(t *testing.T) {
 	res := c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`))
 	if res.Err != nil {
 		t.Fatal(res.Err)
+	} else if got, exp := len(res.Series), 1; got != exp {
+		t.Fatalf("unexpected response.\n\ngot: %d series\nexp: %d\n", got, exp)
+	}
+
+	// Create another subscription.
+	if res := c.ExecuteStatement(mustParseStatement(`CREATE SUBSCRIPTION sub1 ON db0."default" DESTINATIONS ALL 'udp://example.com:6060'`)); res.Err != nil {
+		t.Fatal(res.Err)
+	}
+
+	// The subscriptions are correctly created.
+	if res = c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`)); res.Err != nil {
+		t.Fatal(res.Err)
+	}
+
+	exp := `{"series":[{"name":"db0","columns":["retention_policy","name","mode","destinations"],"values":[["default","sub0","ALL",["udp://example.com:9090"]],["default","sub1","ALL",["udp://example.com:6060"]]]}]}`
+	got := mustMarshalJSON(res)
+	if got != exp {
+		t.Fatalf("unexpected response.\n\ngot: %s\nexp: %s\n", exp, got)
+	}
+}
+
+func TestMetaService_Subscriptions_Show(t *testing.T) {
+	t.Parallel()
+
+	d, s, c := newServiceAndClient()
+	defer os.RemoveAll(d)
+	defer s.Close()
+	defer c.Close()
+
+	// Create a database to use
+	if res := c.ExecuteStatement(mustParseStatement("CREATE DATABASE db0")); res.Err != nil {
+		t.Fatal(res.Err)
+	}
+	db, err := c.Database("db0")
+	if err != nil {
+		t.Fatal(err)
+	} else if db.Name != "db0" {
+		t.Fatalf("db name wrong: %s", db.Name)
+	}
+
+	// SHOW SUBSCRIPTIONS returns no subscriptions when there are none.
+	res := c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`))
+	if res.Err != nil {
+		t.Fatal(res.Err)
+	} else if got, exp := len(res.Series), 0; got != exp {
+		t.Fatalf("got %d series, expected %d", got, exp)
+	}
+
+	// Create a subscription.
+	if res = c.ExecuteStatement(mustParseStatement(`CREATE SUBSCRIPTION sub0 ON db0."default" DESTINATIONS ALL 'udp://example.com:9090'`)); res.Err != nil {
+		t.Fatal(res.Err)
+	}
+
+	// SHOW SUBSCRIPTIONS returns the created subscription.
+	if res = c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if got, exp := len(res.Series), 1; got != exp {
+		t.Fatalf("got %d series, expected %d", got, exp)
 	}
 
 	exp := `{"series":[{"name":"db0","columns":["retention_policy","name","mode","destinations"],"values":[["default","sub0","ALL",["udp://example.com:9090"]]]}]}`
 	got := mustMarshalJSON(res)
-	if exp != got {
-		t.Fatalf("unexpected response.\n\nexp: %s\ngot: %s\n", exp, got)
+	if got != exp {
+		t.Fatalf("unexpected response.\n\ngot: %s\nexp: %s\n", got, exp)
 	}
+}
 
-	// Create a couple more subscriptions
-	if res := c.ExecuteStatement(mustParseStatement(`CREATE SUBSCRIPTION sub1 ON db0."default" DESTINATIONS ALL 'udp://example.com:6060'`)); res.Err != nil {
+func TestMetaService_Subscriptions_Drop(t *testing.T) {
+	t.Parallel()
+
+	d, s, c := newServiceAndClient()
+	defer os.RemoveAll(d)
+	defer s.Close()
+	defer c.Close()
+
+	// Create a database to use
+	if res := c.ExecuteStatement(mustParseStatement("CREATE DATABASE db0")); res.Err != nil {
 		t.Fatal(res.Err)
 	}
-	if res := c.ExecuteStatement(mustParseStatement(`CREATE SUBSCRIPTION sub2 ON db0."default" DESTINATIONS ALL 'udp://example.com:7070'`)); res.Err != nil {
+	db, err := c.Database("db0")
+	if err != nil {
+		t.Fatal(err)
+	} else if db.Name != "db0" {
+		t.Fatalf("db name wrong: %s", db.Name)
+	}
+
+	// DROP SUBSCRIPTION returns ErrSubscriptionNotFound when the
+	// subscription is unknown.
+	res := c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION foo ON db0."default"`))
+	if got, exp := res.Err, meta.ErrSubscriptionNotFound; got.Error() != exp.Error() {
+		t.Fatalf("got: %s, exp: %s", got.Error(), exp)
+	}
+
+	// Create a subscription.
+	if res = c.ExecuteStatement(mustParseStatement(`CREATE SUBSCRIPTION sub0 ON db0."default" DESTINATIONS ALL 'udp://example.com:9090'`)); res.Err != nil {
 		t.Fatal(res.Err)
 	}
 
-	// Re-create a subscription
-	if res := c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub1 ON db0."default"`)); res.Err != nil {
-		t.Fatal(res.Err)
+	// DROP SUBSCRIPTION returns an influxdb.ErrDatabaseNotFound when
+	// the database is unknown.
+	res = c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub0 ON foo."default"`))
+	if got, exp := res.Err, influxdb.ErrDatabaseNotFound("foo"); got.Error() != exp.Error() {
+		t.Fatalf("got: %s, exp: %s", got.Error(), exp)
 	}
 
-	res = c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`))
-	if res.Err != nil {
-		t.Fatal(res.Err)
+	// DROP SUBSCRIPTION returns an influxdb.ErrRetentionPolicyNotFound
+	// when the retention policy is unknown.
+	res = c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub0 ON db0."foo_policy"`))
+	if got, exp := res.Err, influxdb.ErrRetentionPolicyNotFound("foo_policy"); got.Error() != exp.Error() {
+		t.Fatalf("got: %s, exp: %s", got.Error(), exp)
 	}
 
-	exp = `{"series":[{"name":"db0","columns":["retention_policy","name","mode","destinations"],"values":[["default","sub0","ALL",["udp://example.com:9090"]],["default","sub2","ALL",["udp://example.com:7070"]]]}]}`
-	got = mustMarshalJSON(res)
-	if exp != got {
-		t.Fatalf("unexpected response.\n\nexp: %s\ngot: %s\n", exp, got)
+	// DROP SUBSCRIPTION drops the subsciption if it can find it.
+	res = c.ExecuteStatement(mustParseStatement(`DROP SUBSCRIPTION sub0 ON db0."default"`))
+	if got := res.Err; got != nil {
+		t.Fatalf("got: %v, exp: %v", got.Error(), nil)
+	}
+
+	if res = c.ExecuteStatement(mustParseStatement(`SHOW SUBSCRIPTIONS`)); res.Err != nil {
+		t.Fatal(res.Err)
+	} else if got, exp := len(res.Series), 0; got != exp {
+		t.Fatalf("got %d series, expected %d", got, exp)
 	}
 }
 


### PR DESCRIPTION
Fixes #5545.

This PR prevents a panic that occurs when attempting to add a subscription with an unknown retention policy.