### PR TITLE
Fix limit iterator with multiple sources

### DIFF
--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -407,8 +407,8 @@ func (itr *floatLimitIterator) Next() *FloatPoint {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
-			// If there's no interval and no groups then simply exit.
-			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+			// If there's no interval, no groups, and a single source then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 && len(itr.opt.Sources) == 1 {
 				return nil
 			}
 			continue
@@ -1342,8 +1342,8 @@ func (itr *integerLimitIterator) Next() *IntegerPoint {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
-			// If there's no interval and no groups then simply exit.
-			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+			// If there's no interval, no groups, and a single source then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 && len(itr.opt.Sources) == 1 {
 				return nil
 			}
 			continue
@@ -2277,8 +2277,8 @@ func (itr *stringLimitIterator) Next() *StringPoint {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
-			// If there's no interval and no groups then simply exit.
-			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+			// If there's no interval, no groups, and a single source then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 && len(itr.opt.Sources) == 1 {
 				return nil
 			}
 			continue
@@ -3212,8 +3212,8 @@ func (itr *booleanLimitIterator) Next() *BooleanPoint {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
-			// If there's no interval and no groups then simply exit.
-			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+			// If there's no interval, no groups, and a single source then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 && len(itr.opt.Sources) == 1 {
 				return nil
 			}
 			continue

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -406,8 +406,8 @@ func (itr *{{.name}}LimitIterator) Next() *{{.Name}}Point {
 
 		// Read next point if we're beyond the limit.
 		if itr.opt.Limit > 0 && (itr.n-itr.opt.Offset) > itr.opt.Limit {
-			// If there's no interval and no groups then simply exit.
-			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 {
+			// If there's no interval, no groups, and a single source then simply exit.
+			if itr.opt.Interval.IsZero() && len(itr.opt.Dimensions) == 0 && len(itr.opt.Sources) == 1 {
 				return nil
 			}
 			continue

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -514,6 +514,7 @@ func TestLimitIterator_Float(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Name: "cpu", Time: 5, Value: 3}},
+		{&influxql.FloatPoint{Name: "mem", Time: 7, Value: 8}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -540,6 +541,7 @@ func TestLimitIterator_Integer(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 3}},
+		{&influxql.IntegerPoint{Name: "mem", Time: 7, Value: 8}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -566,6 +568,7 @@ func TestLimitIterator_String(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.StringPoint{Name: "cpu", Time: 5, Value: "b"}},
+		{&influxql.StringPoint{Name: "mem", Time: 7, Value: "e"}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -592,6 +595,7 @@ func TestLimitIterator_Boolean(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.BooleanPoint{Name: "cpu", Time: 5, Value: false}},
+		{&influxql.BooleanPoint{Name: "mem", Time: 7, Value: true}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}


### PR DESCRIPTION
The limit iterator would short circuit if there were no dimensions and
all points had been read. It also needs to consider that multiple
sources will require reading the entire iterator too, so the short
circuit requires only a single source.

Fixes #5871.