### PR TITLE
Don't close HTTP Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - [#5842](https://github.com/influxdata/influxdb/issues/5842): Add SeriesList binary marshaling
 - [#5854](https://github.com/influxdata/influxdb/issues/5854): failures of tests in tsdb/engine/tsm1 when compiled with go master
 - [#5610](https://github.com/influxdata/influxdb/issues/5610): Write into fully-replicated cluster is not replicated across all shards
+- [#5880](https://github.com/influxdata/influxdb/issues/5880): TCP connection closed after write (regression/change from 0.9.6)
 
 ## v0.10.1 [2016-02-18]
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -385,9 +385,9 @@ func (h *Handler) serveWrite(w http.ResponseWriter, r *http.Request, user *meta.
 			resultError(w, influxql.Result{Err: err}, http.StatusBadRequest)
 			return
 		}
+		defer b.Close()
 		body = b
 	}
-	defer body.Close()
 
 	b, err := ioutil.ReadAll(body)
 	if err != nil {


### PR DESCRIPTION
This fixes a very strange edge-case we found by using Go 1.4.3 that has surfaced several times, and alluded us until now.

The security update (Go 1.4.3) changed some of the behavior around request bodies and reusing/closing connections. What this meant is that our call to `r.Body.Close()` was being interpreted as one of those "bad" scenarios, and the connection was being closed.

This should fix #5880 and several others. This will also be backported to the `0.10` branch, as closing HTTP connections with keep-alive enabled (all HTTP/1.1 connections that don't disable it) is a fairly significant regression.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
