### PR TITLE
Fix sorting of `first()` and `last()` calls across shards

### DIFF
--- a/influxql/call_iterator_test.go
+++ b/influxql/call_iterator_test.go
@@ -159,12 +159,12 @@ func TestCallIterator_Min_Float(t *testing.T) {
 		},
 	)
 
-	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 4},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.FloatPoint{Time: 1, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 4}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
 }
@@ -190,12 +190,12 @@ func TestCallIterator_Min_Integer(t *testing.T) {
 		},
 	)
 
-	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 4},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Time: 1, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 4}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
 }
@@ -220,12 +220,12 @@ func TestCallIterator_Max_Float(t *testing.T) {
 		},
 	)
 
-	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.FloatPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
 }
@@ -250,12 +250,12 @@ func TestCallIterator_Max_Integer(t *testing.T) {
 		},
 	)
 
-	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
 }
@@ -280,12 +280,12 @@ func TestCallIterator_Sum_Float(t *testing.T) {
 		},
 	)
 
-	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Time: 0, Value: 35, Tags: ParseTags("host=hostA"), Aggregated: 3},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.FloatPoint{Time: 0, Value: 35, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.FloatPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
 }
@@ -310,12 +310,12 @@ func TestCallIterator_Sum_Integer(t *testing.T) {
 		},
 	)
 
-	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Time: 0, Value: 35, Tags: ParseTags("host=hostA"), Aggregated: 3},
-		{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1},
-		{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1},
-		{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Time: 0, Value: 35, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.IntegerPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
 }
@@ -342,9 +342,9 @@ func TestCallIterator_First_Float(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.FloatPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
-		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
-		{&influxql.FloatPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -372,9 +372,9 @@ func TestCallIterator_First_Integer(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
-		{&influxql.IntegerPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
-		{&influxql.IntegerPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -402,9 +402,9 @@ func TestCallIterator_First_String(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.StringPoint{Time: 0, Value: "d", Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.StringPoint{Time: 0, Value: "c", Tags: ParseTags("host=hostB"), Aggregated: 1}},
-		{&influxql.StringPoint{Time: 5, Value: "e", Tags: ParseTags("host=hostA"), Aggregated: 1}},
-		{&influxql.StringPoint{Time: 20, Value: "a", Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.StringPoint{Time: 1, Value: "c", Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.StringPoint{Time: 6, Value: "e", Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.StringPoint{Time: 23, Value: "a", Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -432,9 +432,9 @@ func TestCallIterator_First_Boolean(t *testing.T) {
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
 		{&influxql.BooleanPoint{Time: 0, Value: true, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.BooleanPoint{Time: 0, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
-		{&influxql.BooleanPoint{Time: 5, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 1}},
-		{&influxql.BooleanPoint{Time: 20, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 1, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 6, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 23, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -461,10 +461,10 @@ func TestCallIterator_Last_Float(t *testing.T) {
 	)
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.FloatPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
-		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
-		{&influxql.FloatPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 2, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -491,10 +491,10 @@ func TestCallIterator_Last_Integer(t *testing.T) {
 	)
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.IntegerPoint{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
-		{&influxql.IntegerPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
-		{&influxql.IntegerPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 2, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -521,10 +521,10 @@ func TestCallIterator_Last_String(t *testing.T) {
 	)
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.StringPoint{Time: 0, Value: "b", Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.StringPoint{Time: 0, Value: "c", Tags: ParseTags("host=hostB"), Aggregated: 1}},
-		{&influxql.StringPoint{Time: 5, Value: "e", Tags: ParseTags("host=hostA"), Aggregated: 1}},
-		{&influxql.StringPoint{Time: 20, Value: "a", Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.StringPoint{Time: 2, Value: "b", Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.StringPoint{Time: 1, Value: "c", Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.StringPoint{Time: 6, Value: "e", Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.StringPoint{Time: 23, Value: "a", Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -551,10 +551,10 @@ func TestCallIterator_Last_Boolean(t *testing.T) {
 	)
 
 	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
-		{&influxql.BooleanPoint{Time: 0, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.BooleanPoint{Time: 0, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
-		{&influxql.BooleanPoint{Time: 5, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 1}},
-		{&influxql.BooleanPoint{Time: 20, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 2, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 3}},
+		{&influxql.BooleanPoint{Time: 1, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 6, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 23, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -21,6 +21,7 @@ func (r *FloatMeanReducer) Aggregate(p *FloatPoint) {
 
 func (r *FloatMeanReducer) Emit() *FloatPoint {
 	return &FloatPoint{
+		Time:       ZeroTime,
 		Value:      r.sum / float64(r.count),
 		Aggregated: r.count,
 	}
@@ -47,6 +48,7 @@ func (r *IntegerMeanReducer) Aggregate(p *IntegerPoint) {
 
 func (r *IntegerMeanReducer) Emit() *FloatPoint {
 	return &FloatPoint{
+		Time:       ZeroTime,
 		Value:      float64(r.sum) / float64(r.count),
 		Aggregated: r.count,
 	}

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -549,6 +549,27 @@ func (itr *floatFillIterator) Next() *FloatPoint {
 	return p
 }
 
+// floatIntervalIterator represents a float implementation of IntervalIterator.
+type floatIntervalIterator struct {
+	input FloatIterator
+	opt   IteratorOptions
+}
+
+func newFloatIntervalIterator(input FloatIterator, opt IteratorOptions) *floatIntervalIterator {
+	return &floatIntervalIterator{input: input, opt: opt}
+}
+
+func (itr *floatIntervalIterator) Close() error { return itr.input.Close() }
+
+func (itr *floatIntervalIterator) Next() *FloatPoint {
+	p := itr.input.Next()
+	if p == nil {
+		return p
+	}
+	p.Time, _ = itr.opt.Window(p.Time)
+	return p
+}
+
 // floatAuxIterator represents a float implementation of AuxIterator.
 type floatAuxIterator struct {
 	input  *bufFloatIterator
@@ -703,7 +724,10 @@ func (itr *floatReduceFloatIterator) reduce() []*FloatPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -792,7 +816,10 @@ func (itr *floatReduceIntegerIterator) reduce() []*IntegerPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -881,7 +908,10 @@ func (itr *floatReduceStringIterator) reduce() []*StringPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -970,7 +1000,10 @@ func (itr *floatReduceBooleanIterator) reduce() []*BooleanPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -1746,6 +1779,27 @@ func (itr *integerFillIterator) Next() *IntegerPoint {
 	return p
 }
 
+// integerIntervalIterator represents a integer implementation of IntervalIterator.
+type integerIntervalIterator struct {
+	input IntegerIterator
+	opt   IteratorOptions
+}
+
+func newIntegerIntervalIterator(input IntegerIterator, opt IteratorOptions) *integerIntervalIterator {
+	return &integerIntervalIterator{input: input, opt: opt}
+}
+
+func (itr *integerIntervalIterator) Close() error { return itr.input.Close() }
+
+func (itr *integerIntervalIterator) Next() *IntegerPoint {
+	p := itr.input.Next()
+	if p == nil {
+		return p
+	}
+	p.Time, _ = itr.opt.Window(p.Time)
+	return p
+}
+
 // integerAuxIterator represents a integer implementation of AuxIterator.
 type integerAuxIterator struct {
 	input  *bufIntegerIterator
@@ -1900,7 +1954,10 @@ func (itr *integerReduceFloatIterator) reduce() []*FloatPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -1989,7 +2046,10 @@ func (itr *integerReduceIntegerIterator) reduce() []*IntegerPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -2078,7 +2138,10 @@ func (itr *integerReduceStringIterator) reduce() []*StringPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -2167,7 +2230,10 @@ func (itr *integerReduceBooleanIterator) reduce() []*BooleanPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -2943,6 +3009,27 @@ func (itr *stringFillIterator) Next() *StringPoint {
 	return p
 }
 
+// stringIntervalIterator represents a string implementation of IntervalIterator.
+type stringIntervalIterator struct {
+	input StringIterator
+	opt   IteratorOptions
+}
+
+func newStringIntervalIterator(input StringIterator, opt IteratorOptions) *stringIntervalIterator {
+	return &stringIntervalIterator{input: input, opt: opt}
+}
+
+func (itr *stringIntervalIterator) Close() error { return itr.input.Close() }
+
+func (itr *stringIntervalIterator) Next() *StringPoint {
+	p := itr.input.Next()
+	if p == nil {
+		return p
+	}
+	p.Time, _ = itr.opt.Window(p.Time)
+	return p
+}
+
 // stringAuxIterator represents a string implementation of AuxIterator.
 type stringAuxIterator struct {
 	input  *bufStringIterator
@@ -3097,7 +3184,10 @@ func (itr *stringReduceFloatIterator) reduce() []*FloatPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -3186,7 +3276,10 @@ func (itr *stringReduceIntegerIterator) reduce() []*IntegerPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -3275,7 +3368,10 @@ func (itr *stringReduceStringIterator) reduce() []*StringPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -3364,7 +3460,10 @@ func (itr *stringReduceBooleanIterator) reduce() []*BooleanPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -4140,6 +4239,27 @@ func (itr *booleanFillIterator) Next() *BooleanPoint {
 	return p
 }
 
+// booleanIntervalIterator represents a boolean implementation of IntervalIterator.
+type booleanIntervalIterator struct {
+	input BooleanIterator
+	opt   IteratorOptions
+}
+
+func newBooleanIntervalIterator(input BooleanIterator, opt IteratorOptions) *booleanIntervalIterator {
+	return &booleanIntervalIterator{input: input, opt: opt}
+}
+
+func (itr *booleanIntervalIterator) Close() error { return itr.input.Close() }
+
+func (itr *booleanIntervalIterator) Next() *BooleanPoint {
+	p := itr.input.Next()
+	if p == nil {
+		return p
+	}
+	p.Time, _ = itr.opt.Window(p.Time)
+	return p
+}
+
 // booleanAuxIterator represents a boolean implementation of AuxIterator.
 type booleanAuxIterator struct {
 	input  *bufBooleanIterator
@@ -4294,7 +4414,10 @@ func (itr *booleanReduceFloatIterator) reduce() []*FloatPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -4383,7 +4506,10 @@ func (itr *booleanReduceIntegerIterator) reduce() []*IntegerPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -4472,7 +4598,10 @@ func (itr *booleanReduceStringIterator) reduce() []*StringPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 
@@ -4561,7 +4690,10 @@ func (itr *booleanReduceBooleanIterator) reduce() []*BooleanPoint {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -548,6 +548,27 @@ func (itr *{{$k.name}}FillIterator) Next() *{{$k.Name}}Point {
 	return p
 }
 
+// {{$k.name}}IntervalIterator represents a {{$k.name}} implementation of IntervalIterator.
+type {{$k.name}}IntervalIterator struct {
+	input {{$k.Name}}Iterator
+	opt   IteratorOptions
+}
+
+func new{{$k.Name}}IntervalIterator(input {{$k.Name}}Iterator, opt IteratorOptions) *{{$k.name}}IntervalIterator {
+	return &{{$k.name}}IntervalIterator{input: input, opt: opt}
+}
+
+func (itr *{{$k.name}}IntervalIterator) Close() error { return itr.input.Close() }
+
+func (itr *{{$k.name}}IntervalIterator) Next() *{{$k.Name}}Point {
+	p := itr.input.Next()
+	if p == nil {
+		return p
+	}
+	p.Time, _ = itr.opt.Window(p.Time)
+	return p
+}
+
 // {{$k.name}}AuxIterator represents a {{$k.name}} implementation of AuxIterator.
 type {{$k.name}}AuxIterator struct {
 	input  *buf{{$k.Name}}Iterator
@@ -704,7 +725,10 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() []*{{$v.Name}}Point {
 		p := rp.Emitter.Emit()
 		p.Name = rp.Name
 		p.Tags = rp.Tags
-		p.Time = startTime
+		// Set the points time to the interval time if the reducer didn't provide one.
+		if p.Time == ZeroTime {
+			p.Time = startTime
+		}
 		a[i] = p
 	}
 

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -206,6 +206,22 @@ func NewFillIterator(input Iterator, expr Expr, opt IteratorOptions) Iterator {
 	}
 }
 
+// NewIntervalIterator returns an iterator that sets the time on each point to the interval.
+func NewIntervalIterator(input Iterator, opt IteratorOptions) Iterator {
+	switch input := input.(type) {
+	case FloatIterator:
+		return newFloatIntervalIterator(input, opt)
+	case IntegerIterator:
+		return newIntegerIntervalIterator(input, opt)
+	case StringIterator:
+		return newStringIntervalIterator(input, opt)
+	case BooleanIterator:
+		return newBooleanIntervalIterator(input, opt)
+	default:
+		panic(fmt.Sprintf("unsupported fill iterator type: %T", input))
+	}
+}
+
 // AuxIterator represents an iterator that can split off separate auxilary iterators.
 type AuxIterator interface {
 	Iterator

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -282,17 +282,17 @@ func TestSortedMergeIterator_Float(t *testing.T) {
 		},
 		Ascending: true,
 	})
-	if a, ok := CompareFloatIterator(itr, []influxql.FloatPoint{
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 0, Value: 1},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 12, Value: 3},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 20, Value: 7},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 30, Value: 4},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 1, Value: 2},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 11, Value: 5},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 13, Value: 6},
-		{Name: "mem", Tags: ParseTags("host=A"), Time: 25, Value: 9},
-		{Name: "mem", Tags: ParseTags("host=B"), Time: 4, Value: 8},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0, Value: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 12, Value: 3}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 20, Value: 7}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30, Value: 4}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 1, Value: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 11, Value: 5}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 13, Value: 6}},
+		{&influxql.FloatPoint{Name: "mem", Tags: ParseTags("host=A"), Time: 25, Value: 9}},
+		{&influxql.FloatPoint{Name: "mem", Tags: ParseTags("host=B"), Time: 4, Value: 8}},
+	}) {
 		t.Errorf("unexpected points: %s", spew.Sdump(a))
 	}
 
@@ -327,17 +327,17 @@ func TestSortedMergeIterator_Integer(t *testing.T) {
 		},
 		Ascending: true,
 	})
-	if a, ok := CompareIntegerIterator(itr, []influxql.IntegerPoint{
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 0, Value: 1},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 12, Value: 3},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 20, Value: 7},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 30, Value: 4},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 1, Value: 2},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 11, Value: 5},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 13, Value: 6},
-		{Name: "mem", Tags: ParseTags("host=A"), Time: 25, Value: 9},
-		{Name: "mem", Tags: ParseTags("host=B"), Time: 4, Value: 8},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0, Value: 1}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 12, Value: 3}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 20, Value: 7}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30, Value: 4}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 1, Value: 2}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 11, Value: 5}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 13, Value: 6}},
+		{&influxql.IntegerPoint{Name: "mem", Tags: ParseTags("host=A"), Time: 25, Value: 9}},
+		{&influxql.IntegerPoint{Name: "mem", Tags: ParseTags("host=B"), Time: 4, Value: 8}},
+	}) {
 		t.Errorf("unexpected points: %s", spew.Sdump(a))
 	}
 
@@ -372,17 +372,17 @@ func TestSortedMergeIterator_String(t *testing.T) {
 		},
 		Ascending: true,
 	})
-	if a, ok := CompareStringIterator(itr, []influxql.StringPoint{
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 0, Value: "a"},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 12, Value: "c"},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 20, Value: "g"},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 30, Value: "d"},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 1, Value: "b"},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 11, Value: "e"},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 13, Value: "f"},
-		{Name: "mem", Tags: ParseTags("host=A"), Time: 25, Value: "i"},
-		{Name: "mem", Tags: ParseTags("host=B"), Time: 4, Value: "h"},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0, Value: "a"}},
+		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 12, Value: "c"}},
+		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 20, Value: "g"}},
+		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30, Value: "d"}},
+		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 1, Value: "b"}},
+		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 11, Value: "e"}},
+		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 13, Value: "f"}},
+		{&influxql.StringPoint{Name: "mem", Tags: ParseTags("host=A"), Time: 25, Value: "i"}},
+		{&influxql.StringPoint{Name: "mem", Tags: ParseTags("host=B"), Time: 4, Value: "h"}},
+	}) {
 		t.Errorf("unexpected points: %s", spew.Sdump(a))
 	}
 
@@ -417,17 +417,17 @@ func TestSortedMergeIterator_Boolean(t *testing.T) {
 		},
 		Ascending: true,
 	})
-	if a, ok := CompareBooleanIterator(itr, []influxql.BooleanPoint{
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 0, Value: true},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 12, Value: true},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 20, Value: true},
-		{Name: "cpu", Tags: ParseTags("host=A"), Time: 30, Value: false},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 1, Value: false},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 11, Value: true},
-		{Name: "cpu", Tags: ParseTags("host=B"), Time: 13, Value: false},
-		{Name: "mem", Tags: ParseTags("host=A"), Time: 25, Value: true},
-		{Name: "mem", Tags: ParseTags("host=B"), Time: 4, Value: true},
-	}); !ok {
+	if a := Iterators([]influxql.Iterator{itr}).ReadAll(); !deep.Equal(a, [][]influxql.Point{
+		{&influxql.BooleanPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0, Value: true}},
+		{&influxql.BooleanPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 12, Value: true}},
+		{&influxql.BooleanPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 20, Value: true}},
+		{&influxql.BooleanPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30, Value: false}},
+		{&influxql.BooleanPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 1, Value: false}},
+		{&influxql.BooleanPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 11, Value: true}},
+		{&influxql.BooleanPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 13, Value: false}},
+		{&influxql.BooleanPoint{Name: "mem", Tags: ParseTags("host=A"), Time: 25, Value: true}},
+		{&influxql.BooleanPoint{Name: "mem", Tags: ParseTags("host=B"), Time: 4, Value: true}},
+	}) {
 		t.Errorf("unexpected points: %s", spew.Sdump(a))
 	}
 
@@ -1038,16 +1038,6 @@ func FloatIterators(inputs []*FloatIterator) []influxql.Iterator {
 	return itrs
 }
 
-func CompareFloatIterator(input influxql.Iterator, expected []influxql.FloatPoint) ([]influxql.FloatPoint, bool) {
-	itr := input.(influxql.FloatIterator)
-	points := make([]influxql.FloatPoint, 0, len(expected))
-	for p := itr.Next(); p != nil; p = itr.Next() {
-		points = append(points, *p)
-	}
-	itr.Close()
-	return points, deep.Equal(points, expected)
-}
-
 // GenerateFloatIterator creates a FloatIterator with random data.
 func GenerateFloatIterator(rand *rand.Rand, valueN int) *FloatIterator {
 	const interval = 10 * time.Second
@@ -1098,16 +1088,6 @@ func IntegerIterators(inputs []*IntegerIterator) []influxql.Iterator {
 	return itrs
 }
 
-func CompareIntegerIterator(input influxql.Iterator, expected []influxql.IntegerPoint) ([]influxql.IntegerPoint, bool) {
-	itr := input.(influxql.IntegerIterator)
-	points := make([]influxql.IntegerPoint, 0, len(expected))
-	for p := itr.Next(); p != nil; p = itr.Next() {
-		points = append(points, *p)
-	}
-	itr.Close()
-	return points, deep.Equal(points, expected)
-}
-
 // Test implementation of influxql.StringIterator
 type StringIterator struct {
 	Points []influxql.StringPoint
@@ -1136,16 +1116,6 @@ func StringIterators(inputs []*StringIterator) []influxql.Iterator {
 	return itrs
 }
 
-func CompareStringIterator(input influxql.Iterator, expected []influxql.StringPoint) ([]influxql.StringPoint, bool) {
-	itr := input.(influxql.StringIterator)
-	points := make([]influxql.StringPoint, 0, len(expected))
-	for p := itr.Next(); p != nil; p = itr.Next() {
-		points = append(points, *p)
-	}
-	itr.Close()
-	return points, deep.Equal(points, expected)
-}
-
 // Test implementation of influxql.BooleanIterator
 type BooleanIterator struct {
 	Points []influxql.BooleanPoint
@@ -1172,14 +1142,4 @@ func BooleanIterators(inputs []*BooleanIterator) []influxql.Iterator {
 		itrs[i] = influxql.Iterator(inputs[i])
 	}
 	return itrs
-}
-
-func CompareBooleanIterator(input influxql.Iterator, expected []influxql.BooleanPoint) ([]influxql.BooleanPoint, bool) {
-	itr := input.(influxql.BooleanIterator)
-	points := make([]influxql.BooleanPoint, 0, len(expected))
-	for p := itr.Next(); p != nil; p = itr.Next() {
-		points = append(points, *p)
-	}
-	itr.Close()
-	return points, deep.Equal(points, expected)
 }

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -329,6 +329,9 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 				return nil, err
 			}
 
+			if expr.Name != "top" && expr.Name != "bottom" {
+				itr = NewIntervalIterator(itr, opt)
+			}
 			if !opt.Interval.IsZero() && opt.Fill != NoFill {
 				itr = NewFillIterator(itr, expr, opt)
 			}


### PR DESCRIPTION
Previously the call iterator would normalize the time to the interval
for all calls. This meant that when `first()` or `last()` was called
with no group by interval the value would be found for each shard, the
time was normalized, then it tried to find the value between the shards
(but no longer with any time data as that had already been eliminated).

This removes part of the time logic from the call iterators and makes a
new iterator `IntervalIterator` to normalize the times as they come out
of the underlying iterator.

Fixes #5890.