### PR TITLE
Expose similar Aggregate/Emit API from InfluxQL for Slice functions.

### DIFF
--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -58,30 +58,28 @@ func NewCallIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 
 // newCountIterator returns an iterator for operating on a count() call.
 func newCountIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
-	// FIXME: Wrap iterator in int-type iterator and always output int value.
-
 	switch input := input.(type) {
 	case FloatIterator:
 		createFn := func() (FloatPointAggregator, IntegerPointEmitter) {
-			fn := NewFloatFuncIntegerReducer(floatCountReduce)
+			fn := NewFloatFuncIntegerReducer(FloatCountReduce)
 			return fn, fn
 		}
 		return &floatReduceIntegerIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
 		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
-			fn := NewIntegerFuncReducer(integerCountReduce)
+			fn := NewIntegerFuncReducer(IntegerCountReduce)
 			return fn, fn
 		}
 		return &integerReduceIntegerIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	case StringIterator:
 		createFn := func() (StringPointAggregator, IntegerPointEmitter) {
-			fn := NewStringFuncIntegerReducer(stringCountReduce)
+			fn := NewStringFuncIntegerReducer(StringCountReduce)
 			return fn, fn
 		}
 		return &stringReduceIntegerIterator{input: newBufStringIterator(input), opt: opt, create: createFn}, nil
 	case BooleanIterator:
 		createFn := func() (BooleanPointAggregator, IntegerPointEmitter) {
-			fn := NewBooleanFuncIntegerReducer(booleanCountReduce)
+			fn := NewBooleanFuncIntegerReducer(BooleanCountReduce)
 			return fn, fn
 		}
 		return &booleanReduceIntegerIterator{input: newBufBooleanIterator(input), opt: opt, create: createFn}, nil
@@ -90,32 +88,32 @@ func newCountIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	}
 }
 
-// floatCountReduce returns the count of points.
-func floatCountReduce(prev *IntegerPoint, curr *FloatPoint) (int64, int64, []interface{}) {
+// FloatCountReduce returns the count of points.
+func FloatCountReduce(prev *IntegerPoint, curr *FloatPoint) (int64, int64, []interface{}) {
 	if prev == nil {
 		return ZeroTime, 1, nil
 	}
 	return ZeroTime, prev.Value + 1, nil
 }
 
-// integerCountReduce returns the count of points.
-func integerCountReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
+// IntegerCountReduce returns the count of points.
+func IntegerCountReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
 	if prev == nil {
 		return ZeroTime, 1, nil
 	}
 	return ZeroTime, prev.Value + 1, nil
 }
 
-// stringCountReduce returns the count of points.
-func stringCountReduce(prev *IntegerPoint, curr *StringPoint) (int64, int64, []interface{}) {
+// StringCountReduce returns the count of points.
+func StringCountReduce(prev *IntegerPoint, curr *StringPoint) (int64, int64, []interface{}) {
 	if prev == nil {
 		return ZeroTime, 1, nil
 	}
 	return ZeroTime, prev.Value + 1, nil
 }
 
-// booleanCountReduce returns the count of points.
-func booleanCountReduce(prev *IntegerPoint, curr *BooleanPoint) (int64, int64, []interface{}) {
+// BooleanCountReduce returns the count of points.
+func BooleanCountReduce(prev *IntegerPoint, curr *BooleanPoint) (int64, int64, []interface{}) {
 	if prev == nil {
 		return ZeroTime, 1, nil
 	}
@@ -127,13 +125,13 @@ func newMinIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
-			fn := NewFloatFuncReducer(floatMinReduce)
+			fn := NewFloatFuncReducer(FloatMinReduce)
 			return fn, fn
 		}
 		return &floatReduceFloatIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
 		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
-			fn := NewIntegerFuncReducer(integerMinReduce)
+			fn := NewIntegerFuncReducer(IntegerMinReduce)
 			return fn, fn
 		}
 		return &integerReduceIntegerIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
@@ -142,16 +140,16 @@ func newMinIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	}
 }
 
-// floatMinReduce returns the minimum value between prev & curr.
-func floatMinReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
+// FloatMinReduce returns the minimum value between prev & curr.
+func FloatMinReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
 	if prev == nil || curr.Value < prev.Value || (curr.Value == prev.Value && curr.Time < prev.Time) {
 		return curr.Time, curr.Value, curr.Aux
 	}
 	return prev.Time, prev.Value, prev.Aux
 }
 
-// integerMinReduce returns the minimum value between prev & curr.
-func integerMinReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
+// IntegerMinReduce returns the minimum value between prev & curr.
+func IntegerMinReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
 	if prev == nil || curr.Value < prev.Value || (curr.Value == prev.Value && curr.Time < prev.Time) {
 		return curr.Time, curr.Value, curr.Aux
 	}
@@ -163,13 +161,13 @@ func newMaxIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
-			fn := NewFloatFuncReducer(floatMaxReduce)
+			fn := NewFloatFuncReducer(FloatMaxReduce)
 			return fn, fn
 		}
 		return &floatReduceFloatIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
 		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
-			fn := NewIntegerFuncReducer(integerMaxReduce)
+			fn := NewIntegerFuncReducer(IntegerMaxReduce)
 			return fn, fn
 		}
 		return &integerReduceIntegerIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
@@ -178,16 +176,16 @@ func newMaxIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	}
 }
 
-// floatMaxReduce returns the maximum value between prev & curr.
-func floatMaxReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
+// FloatMaxReduce returns the maximum value between prev & curr.
+func FloatMaxReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
 	if prev == nil || curr.Value > prev.Value || (curr.Value == prev.Value && curr.Time < prev.Time) {
 		return curr.Time, curr.Value, curr.Aux
 	}
 	return prev.Time, prev.Value, prev.Aux
 }
 
-// integerMaxReduce returns the maximum value between prev & curr.
-func integerMaxReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
+// IntegerMaxReduce returns the maximum value between prev & curr.
+func IntegerMaxReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
 	if prev == nil || curr.Value > prev.Value || (curr.Value == prev.Value && curr.Time < prev.Time) {
 		return curr.Time, curr.Value, curr.Aux
 	}
@@ -199,13 +197,13 @@ func newSumIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
-			fn := NewFloatFuncReducer(floatSumReduce)
+			fn := NewFloatFuncReducer(FloatSumReduce)
 			return fn, fn
 		}
 		return &floatReduceFloatIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
 		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
-			fn := NewIntegerFuncReducer(integerSumReduce)
+			fn := NewIntegerFuncReducer(IntegerSumReduce)
 			return fn, fn
 		}
 		return &integerReduceIntegerIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
@@ -214,16 +212,16 @@ func newSumIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	}
 }
 
-// floatSumReduce returns the sum prev value & curr value.
-func floatSumReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
+// FloatSumReduce returns the sum prev value & curr value.
+func FloatSumReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
 	if prev == nil {
 		return ZeroTime, curr.Value, nil
 	}
 	return prev.Time, prev.Value + curr.Value, nil
 }
 
-// integerSumReduce returns the sum prev value & curr value.
-func integerSumReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
+// IntegerSumReduce returns the sum prev value & curr value.
+func IntegerSumReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
 	if prev == nil {
 		return ZeroTime, curr.Value, nil
 	}
@@ -235,13 +233,13 @@ func newFirstIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
-			fn := NewFloatFuncReducer(floatFirstReduce)
+			fn := NewFloatFuncReducer(FloatFirstReduce)
 			return fn, fn
 		}
 		return &floatReduceFloatIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
 		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
-			fn := NewIntegerFuncReducer(integerFirstReduce)
+			fn := NewIntegerFuncReducer(IntegerFirstReduce)
 			return fn, fn
 		}
 		return &integerReduceIntegerIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
@@ -262,16 +260,16 @@ func newFirstIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	}
 }
 
-// floatFirstReduce returns the first point sorted by time.
-func floatFirstReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
+// FloatFirstReduce returns the first point sorted by time.
+func FloatFirstReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
 	if prev == nil || curr.Time < prev.Time || (curr.Time == prev.Time && curr.Value > prev.Value) {
 		return curr.Time, curr.Value, curr.Aux
 	}
 	return prev.Time, prev.Value, prev.Aux
 }
 
-// integerFirstReduce returns the first point sorted by time.
-func integerFirstReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
+// IntegerFirstReduce returns the first point sorted by time.
+func IntegerFirstReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
 	if prev == nil || curr.Time < prev.Time || (curr.Time == prev.Time && curr.Value > prev.Value) {
 		return curr.Time, curr.Value, curr.Aux
 	}
@@ -299,13 +297,13 @@ func newLastIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
-			fn := NewFloatFuncReducer(floatLastReduce)
+			fn := NewFloatFuncReducer(FloatLastReduce)
 			return fn, fn
 		}
 		return &floatReduceFloatIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
 		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
-			fn := NewIntegerFuncReducer(integerLastReduce)
+			fn := NewIntegerFuncReducer(IntegerLastReduce)
 			return fn, fn
 		}
 		return &integerReduceIntegerIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
@@ -326,16 +324,16 @@ func newLastIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	}
 }
 
-// floatLastReduce returns the last point sorted by time.
-func floatLastReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
+// FloatLastReduce returns the last point sorted by time.
+func FloatLastReduce(prev, curr *FloatPoint) (int64, float64, []interface{}) {
 	if prev == nil || curr.Time > prev.Time || (curr.Time == prev.Time && curr.Value > prev.Value) {
 		return curr.Time, curr.Value, curr.Aux
 	}
 	return prev.Time, prev.Value, prev.Aux
 }
 
-// integerLastReduce returns the last point sorted by time.
-func integerLastReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
+// IntegerLastReduce returns the last point sorted by time.
+func IntegerLastReduce(prev, curr *IntegerPoint) (int64, int64, []interface{}) {
 	if prev == nil || curr.Time > prev.Time || (curr.Time == prev.Time && curr.Value > prev.Value) {
 		return curr.Time, curr.Value, curr.Aux
 	}
@@ -362,18 +360,30 @@ func booleanLastReduce(prev, curr *BooleanPoint) (int64, bool, []interface{}) {
 func NewDistinctIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, fn: floatDistinctReduceSlice}, nil
+		createFn := func() (FloatPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewFloatSliceFuncReducer(FloatDistinctReduceSlice)
+			return fn, fn
+		}
+		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
-		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, fn: integerDistinctReduceSlice}, nil
+		createFn := func() (IntegerPointSliceAggregator, IntegerPointSliceEmitter) {
+			fn := NewIntegerSliceFuncReducer(IntegerDistinctReduceSlice)
+			return fn, fn
+		}
+		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	case StringIterator:
-		return &stringReduceSliceIterator{input: newBufStringIterator(input), opt: opt, fn: stringDistinctReduceSlice}, nil
+		createFn := func() (StringPointSliceAggregator, StringPointSliceEmitter) {
+			fn := NewStringSliceFuncReducer(StringDistinctReduceSlice)
+			return fn, fn
+		}
+		return &stringReduceSliceIterator{input: newBufStringIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported distinct iterator type: %T", input)
 	}
 }
 
-// floatDistinctReduceSlice returns the distinct value within a window.
-func floatDistinctReduceSlice(a []FloatPoint, opt *reduceOptions) []FloatPoint {
+// FloatDistinctReduceSlice returns the distinct value within a window.
+func FloatDistinctReduceSlice(a []FloatPoint, opt *ReduceOptions) []FloatPoint {
 	m := make(map[float64]FloatPoint)
 	for _, p := range a {
 		if _, ok := m[p.Value]; !ok {
@@ -389,8 +399,8 @@ func floatDistinctReduceSlice(a []FloatPoint, opt *reduceOptions) []FloatPoint {
 	return points
 }
 
-// integerDistinctReduceSlice returns the distinct value within a window.
-func integerDistinctReduceSlice(a []IntegerPoint, opt *reduceOptions) []IntegerPoint {
+// IntegerDistinctReduceSlice returns the distinct value within a window.
+func IntegerDistinctReduceSlice(a []IntegerPoint, opt *ReduceOptions) []IntegerPoint {
 	m := make(map[int64]IntegerPoint)
 	for _, p := range a {
 		if _, ok := m[p.Value]; !ok {
@@ -406,8 +416,8 @@ func integerDistinctReduceSlice(a []IntegerPoint, opt *reduceOptions) []IntegerP
 	return points
 }
 
-// stringDistinctReduceSlice returns the distinct value within a window.
-func stringDistinctReduceSlice(a []StringPoint, opt *reduceOptions) []StringPoint {
+// StringDistinctReduceSlice returns the distinct value within a window.
+func StringDistinctReduceSlice(a []StringPoint, opt *ReduceOptions) []StringPoint {
 	m := make(map[string]StringPoint)
 	for _, p := range a {
 		if _, ok := m[p.Value]; !ok {
@@ -447,18 +457,26 @@ func newMeanIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 func newMedianIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, fn: floatMedianReduceSlice}, nil
+		createFn := func() (FloatPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewFloatSliceFuncReducer(FloatMedianReduceSlice)
+			return fn, fn
+		}
+		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
-		return &integerReduceSliceFloatIterator{input: newBufIntegerIterator(input), opt: opt, fn: integerMedianReduceSlice}, nil
+		createFn := func() (IntegerPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewIntegerSliceFloatFuncReducer(IntegerMedianReduceSlice)
+			return fn, fn
+		}
+		return &integerReduceSliceFloatIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported median iterator type: %T", input)
 	}
 }
 
-// floatMedianReduceSlice returns the median value within a window.
-func floatMedianReduceSlice(a []FloatPoint, opt *reduceOptions) []FloatPoint {
+// FloatMedianReduceSlice returns the median value within a window.
+func FloatMedianReduceSlice(a []FloatPoint, opt *ReduceOptions) []FloatPoint {
 	if len(a) == 1 {
-		return []FloatPoint{{Time: opt.startTime, Value: a[0].Value}}
+		return []FloatPoint{{Time: opt.StartTime, Value: a[0].Value}}
 	}
 
 	// OPTIMIZE(benbjohnson): Use getSortedRange() from v0.9.5.1.
@@ -468,15 +486,15 @@ func floatMedianReduceSlice(a []FloatPoint, opt *reduceOptions) []FloatPoint {
 	sort.Sort(floatPointsByValue(a))
 	if len(a)%2 == 0 {
 		lo, hi := a[len(a)/2-1], a[(len(a)/2)]
-		return []FloatPoint{{Time: opt.startTime, Value: lo.Value + (hi.Value-lo.Value)/2}}
+		return []FloatPoint{{Time: opt.StartTime, Value: lo.Value + (hi.Value-lo.Value)/2}}
 	}
-	return []FloatPoint{{Time: opt.startTime, Value: a[len(a)/2].Value}}
+	return []FloatPoint{{Time: opt.StartTime, Value: a[len(a)/2].Value}}
 }
 
-// integerMedianReduceSlice returns the median value within a window.
-func integerMedianReduceSlice(a []IntegerPoint, opt *reduceOptions) []FloatPoint {
+// IntegerMedianReduceSlice returns the median value within a window.
+func IntegerMedianReduceSlice(a []IntegerPoint, opt *ReduceOptions) []FloatPoint {
 	if len(a) == 1 {
-		return []FloatPoint{{Time: opt.startTime, Value: float64(a[0].Value)}}
+		return []FloatPoint{{Time: opt.StartTime, Value: float64(a[0].Value)}}
 	}
 
 	// OPTIMIZE(benbjohnson): Use getSortedRange() from v0.9.5.1.
@@ -486,30 +504,42 @@ func integerMedianReduceSlice(a []IntegerPoint, opt *reduceOptions) []FloatPoint
 	sort.Sort(integerPointsByValue(a))
 	if len(a)%2 == 0 {
 		lo, hi := a[len(a)/2-1], a[(len(a)/2)]
-		return []FloatPoint{{Time: opt.startTime, Value: float64(lo.Value) + float64(hi.Value-lo.Value)/2}}
+		return []FloatPoint{{Time: opt.StartTime, Value: float64(lo.Value) + float64(hi.Value-lo.Value)/2}}
 	}
-	return []FloatPoint{{Time: opt.startTime, Value: float64(a[len(a)/2].Value)}}
+	return []FloatPoint{{Time: opt.StartTime, Value: float64(a[len(a)/2].Value)}}
 }
 
 // newStddevIterator returns an iterator for operating on a stddev() call.
 func newStddevIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, fn: floatStddevReduceSlice}, nil
+		createFn := func() (FloatPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewFloatSliceFuncReducer(FloatStddevReduceSlice)
+			return fn, fn
+		}
+		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
-		return &integerReduceSliceFloatIterator{input: newBufIntegerIterator(input), opt: opt, fn: integerStddevReduceSlice}, nil
+		createFn := func() (IntegerPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewIntegerSliceFloatFuncReducer(IntegerStddevReduceSlice)
+			return fn, fn
+		}
+		return &integerReduceSliceFloatIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	case StringIterator:
-		return &stringReduceSliceIterator{input: newBufStringIterator(input), opt: opt, fn: stringStddevReduceSlice}, nil
+		createFn := func() (StringPointSliceAggregator, StringPointSliceEmitter) {
+			fn := NewStringSliceFuncReducer(StringStddevReduceSlice)
+			return fn, fn
+		}
+		return &stringReduceSliceIterator{input: newBufStringIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported stddev iterator type: %T", input)
 	}
 }
 
-// floatStddevReduceSlice returns the stddev value within a window.
-func floatStddevReduceSlice(a []FloatPoint, opt *reduceOptions) []FloatPoint {
+// FloatStddevReduceSlice returns the stddev value within a window.
+func FloatStddevReduceSlice(a []FloatPoint, opt *ReduceOptions) []FloatPoint {
 	// If there is only one point then return 0.
 	if len(a) < 2 {
-		return []FloatPoint{{Time: opt.startTime, Nil: true}}
+		return []FloatPoint{{Time: opt.StartTime, Nil: true}}
 	}
 
 	// Calculate the mean.
@@ -532,16 +562,16 @@ func floatStddevReduceSlice(a []FloatPoint, opt *reduceOptions) []FloatPoint {
 		variance += math.Pow(p.Value-mean, 2)
 	}
 	return []FloatPoint{{
-		Time:  opt.startTime,
+		Time:  opt.StartTime,
 		Value: math.Sqrt(variance / float64(count-1)),
 	}}
 }
 
-// integerStddevReduceSlice returns the stddev value within a window.
-func integerStddevReduceSlice(a []IntegerPoint, opt *reduceOptions) []FloatPoint {
+// IntegerStddevReduceSlice returns the stddev value within a window.
+func IntegerStddevReduceSlice(a []IntegerPoint, opt *ReduceOptions) []FloatPoint {
 	// If there is only one point then return 0.
 	if len(a) < 2 {
-		return []FloatPoint{{Time: opt.startTime, Nil: true}}
+		return []FloatPoint{{Time: opt.StartTime, Nil: true}}
 	}
 
 	// Calculate the mean.
@@ -558,41 +588,49 @@ func integerStddevReduceSlice(a []IntegerPoint, opt *reduceOptions) []FloatPoint
 		variance += math.Pow(float64(p.Value)-mean, 2)
 	}
 	return []FloatPoint{{
-		Time:  opt.startTime,
+		Time:  opt.StartTime,
 		Value: math.Sqrt(variance / float64(count-1)),
 	}}
 }
 
-// stringStddevReduceSlice always returns "".
-func stringStddevReduceSlice(a []StringPoint, opt *reduceOptions) []StringPoint {
-	return []StringPoint{{Time: opt.startTime, Value: ""}}
+// StringStddevReduceSlice always returns "".
+func StringStddevReduceSlice(a []StringPoint, opt *ReduceOptions) []StringPoint {
+	return []StringPoint{{Time: opt.StartTime, Value: ""}}
 }
 
 // newSpreadIterator returns an iterator for operating on a spread() call.
 func newSpreadIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, fn: floatSpreadReduceSlice}, nil
+		createFn := func() (FloatPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewFloatSliceFuncReducer(FloatSpreadReduceSlice)
+			return fn, fn
+		}
+		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
-		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, fn: integerSpreadReduceSlice}, nil
+		createFn := func() (IntegerPointSliceAggregator, IntegerPointSliceEmitter) {
+			fn := NewIntegerSliceFuncReducer(IntegerSpreadReduceSlice)
+			return fn, fn
+		}
+		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported spread iterator type: %T", input)
 	}
 }
 
-// floatSpreadReduceSlice returns the spread value within a window.
-func floatSpreadReduceSlice(a []FloatPoint, opt *reduceOptions) []FloatPoint {
+// FloatSpreadReduceSlice returns the spread value within a window.
+func FloatSpreadReduceSlice(a []FloatPoint, opt *ReduceOptions) []FloatPoint {
 	// Find min & max values.
 	min, max := a[0].Value, a[0].Value
 	for _, p := range a[1:] {
 		min = math.Min(min, p.Value)
 		max = math.Max(max, p.Value)
 	}
-	return []FloatPoint{{Time: opt.startTime, Value: max - min}}
+	return []FloatPoint{{Time: opt.StartTime, Value: max - min}}
 }
 
-// integerSpreadReduceSlice returns the spread value within a window.
-func integerSpreadReduceSlice(a []IntegerPoint, opt *reduceOptions) []IntegerPoint {
+// IntegerSpreadReduceSlice returns the spread value within a window.
+func IntegerSpreadReduceSlice(a []IntegerPoint, opt *ReduceOptions) []IntegerPoint {
 	// Find min & max values.
 	min, max := a[0].Value, a[0].Value
 	for _, p := range a[1:] {
@@ -603,26 +641,34 @@ func integerSpreadReduceSlice(a []IntegerPoint, opt *reduceOptions) []IntegerPoi
 			max = p.Value
 		}
 	}
-	return []IntegerPoint{{Time: opt.startTime, Value: max - min}}
+	return []IntegerPoint{{Time: opt.StartTime, Value: max - min}}
 }
 
 // newTopIterator returns an iterator for operating on a top() call.
 func newTopIterator(input Iterator, opt IteratorOptions, n *NumberLiteral, tags []int) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, fn: newFloatTopReduceSliceFunc(int(n.Val), tags, opt.Interval)}, nil
+		createFn := func() (FloatPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewFloatSliceFuncReducer(NewFloatTopReduceSliceFunc(int(n.Val), tags, opt.Interval))
+			return fn, fn
+		}
+		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
-		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, fn: newIntegerTopReduceSliceFunc(int(n.Val), tags, opt.Interval)}, nil
+		createFn := func() (IntegerPointSliceAggregator, IntegerPointSliceEmitter) {
+			fn := NewIntegerSliceFuncReducer(NewIntegerTopReduceSliceFunc(int(n.Val), tags, opt.Interval))
+			return fn, fn
+		}
+		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported top iterator type: %T", input)
 	}
 }
 
 // newFloatTopReduceSliceFunc returns the top values within a window.
-func newFloatTopReduceSliceFunc(n int, tags []int, interval Interval) floatReduceSliceFunc {
-	return func(a []FloatPoint, opt *reduceOptions) []FloatPoint {
+func NewFloatTopReduceSliceFunc(n int, tags []int, interval Interval) FloatReduceSliceFunc {
+	return func(a []FloatPoint, opt *ReduceOptions) []FloatPoint {
 		// Filter by tags if they exist.
-		if tags != nil {
+		if len(tags) > 0 {
 			a = filterFloatByUniqueTags(a, tags, func(cur, p *FloatPoint) bool {
 				return p.Value > cur.Value || (p.Value == cur.Value && p.Time < cur.Time)
 			})
@@ -655,7 +701,7 @@ func newFloatTopReduceSliceFunc(n int, tags []int, interval Interval) floatReduc
 		// depending on if a time interval was given or not.
 		if !interval.IsZero() {
 			for i := range points {
-				points[i].Time = opt.startTime
+				points[i].Time = opt.StartTime
 			}
 		} else {
 			sort.Stable(floatPointsByTime(points))
@@ -664,11 +710,11 @@ func newFloatTopReduceSliceFunc(n int, tags []int, interval Interval) floatReduc
 	}
 }
 
-// newIntegerTopReduceSliceFunc returns the top values within a window.
-func newIntegerTopReduceSliceFunc(n int, tags []int, interval Interval) integerReduceSliceFunc {
-	return func(a []IntegerPoint, opt *reduceOptions) []IntegerPoint {
+// NewIntegerTopReduceSliceFunc returns the top values within a window.
+func NewIntegerTopReduceSliceFunc(n int, tags []int, interval Interval) IntegerReduceSliceFunc {
+	return func(a []IntegerPoint, opt *ReduceOptions) []IntegerPoint {
 		// Filter by tags if they exist.
-		if tags != nil {
+		if len(tags) > 0 {
 			a = filterIntegerByUniqueTags(a, tags, func(cur, p *IntegerPoint) bool {
 				return p.Value > cur.Value || (p.Value == cur.Value && p.Time < cur.Time)
 			})
@@ -701,7 +747,7 @@ func newIntegerTopReduceSliceFunc(n int, tags []int, interval Interval) integerR
 		// depending on if a time interval was given or not.
 		if !interval.IsZero() {
 			for i := range points {
-				points[i].Time = opt.startTime
+				points[i].Time = opt.StartTime
 			}
 		} else {
 			sort.Stable(integerPointsByTime(points))
@@ -714,19 +760,27 @@ func newIntegerTopReduceSliceFunc(n int, tags []int, interval Interval) integerR
 func newBottomIterator(input Iterator, opt IteratorOptions, n *NumberLiteral, tags []int) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, fn: newFloatBottomReduceSliceFunc(int(n.Val), tags, opt.Interval)}, nil
+		createFn := func() (FloatPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewFloatSliceFuncReducer(NewFloatBottomReduceSliceFunc(int(n.Val), tags, opt.Interval))
+			return fn, fn
+		}
+		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
-		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, fn: newIntegerBottomReduceSliceFunc(int(n.Val), tags, opt.Interval)}, nil
+		createFn := func() (IntegerPointSliceAggregator, IntegerPointSliceEmitter) {
+			fn := NewIntegerSliceFuncReducer(NewIntegerBottomReduceSliceFunc(int(n.Val), tags, opt.Interval))
+			return fn, fn
+		}
+		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	default:
-		return nil, fmt.Errorf("unsupported bottom iterator type: %T", input)
+		return nil, fmt.Errorf("unsupported top iterator type: %T", input)
 	}
 }
 
-// newFloatBottomReduceSliceFunc returns the bottom values within a window.
-func newFloatBottomReduceSliceFunc(n int, tags []int, interval Interval) floatReduceSliceFunc {
-	return func(a []FloatPoint, opt *reduceOptions) []FloatPoint {
+// NewFloatBottomReduceSliceFunc returns the bottom values within a window.
+func NewFloatBottomReduceSliceFunc(n int, tags []int, interval Interval) FloatReduceSliceFunc {
+	return func(a []FloatPoint, opt *ReduceOptions) []FloatPoint {
 		// Filter by tags if they exist.
-		if tags != nil {
+		if len(tags) > 0 {
 			a = filterFloatByUniqueTags(a, tags, func(cur, p *FloatPoint) bool {
 				return p.Value < cur.Value || (p.Value == cur.Value && p.Time < cur.Time)
 			})
@@ -759,7 +813,7 @@ func newFloatBottomReduceSliceFunc(n int, tags []int, interval Interval) floatRe
 		// depending on if a time interval was given or not.
 		if !interval.IsZero() {
 			for i := range points {
-				points[i].Time = opt.startTime
+				points[i].Time = opt.StartTime
 			}
 		} else {
 			sort.Stable(floatPointsByTime(points))
@@ -768,11 +822,11 @@ func newFloatBottomReduceSliceFunc(n int, tags []int, interval Interval) floatRe
 	}
 }
 
-// newIntegerBottomReduceSliceFunc returns the bottom values within a window.
-func newIntegerBottomReduceSliceFunc(n int, tags []int, interval Interval) integerReduceSliceFunc {
-	return func(a []IntegerPoint, opt *reduceOptions) []IntegerPoint {
+// NewIntegerBottomReduceSliceFunc returns the bottom values within a window.
+func NewIntegerBottomReduceSliceFunc(n int, tags []int, interval Interval) IntegerReduceSliceFunc {
+	return func(a []IntegerPoint, opt *ReduceOptions) []IntegerPoint {
 		// Filter by tags if they exist.
-		if tags != nil {
+		if len(tags) > 0 {
 			a = filterIntegerByUniqueTags(a, tags, func(cur, p *IntegerPoint) bool {
 				return p.Value < cur.Value || (p.Value == cur.Value && p.Time < cur.Time)
 			})
@@ -805,7 +859,7 @@ func newIntegerBottomReduceSliceFunc(n int, tags []int, interval Interval) integ
 		// depending on if a time interval was given or not.
 		if !interval.IsZero() {
 			for i := range points {
-				points[i].Time = opt.startTime
+				points[i].Time = opt.StartTime
 			}
 		} else {
 			sort.Stable(integerPointsByTime(points))
@@ -874,36 +928,44 @@ func filterIntegerByUniqueTags(a []IntegerPoint, tags []int, cmpFunc func(cur, p
 	return points
 }
 
-// newPercentileIterator returns an iterator for operating on a percentile() call.
+// NewPercentileIterator returns an iterator for operating on a percentile() call.
 func newPercentileIterator(input Iterator, opt IteratorOptions, percentile float64) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, fn: newFloatPercentileReduceSliceFunc(percentile)}, nil
+		createFn := func() (FloatPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewFloatSliceFuncReducer(NewFloatPercentileReduceSliceFunc(percentile))
+			return fn, fn
+		}
+		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
-		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, fn: newIntegerPercentileReduceSliceFunc(percentile)}, nil
+		createFn := func() (IntegerPointSliceAggregator, IntegerPointSliceEmitter) {
+			fn := NewIntegerSliceFuncReducer(NewIntegerPercentileReduceSliceFunc(percentile))
+			return fn, fn
+		}
+		return &integerReduceSliceIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported percentile iterator type: %T", input)
 	}
 }
 
-// newFloatPercentileReduceSliceFunc returns the percentile value within a window.
-func newFloatPercentileReduceSliceFunc(percentile float64) floatReduceSliceFunc {
-	return func(a []FloatPoint, opt *reduceOptions) []FloatPoint {
+// NewFloatPercentileReduceSliceFunc returns the percentile value within a window.
+func NewFloatPercentileReduceSliceFunc(percentile float64) FloatReduceSliceFunc {
+	return func(a []FloatPoint, opt *ReduceOptions) []FloatPoint {
 		length := len(a)
 		i := int(math.Floor(float64(length)*percentile/100.0+0.5)) - 1
 
 		if i < 0 || i >= length {
-			return []FloatPoint{{Time: opt.startTime, Nil: true}}
+			return []FloatPoint{{Time: opt.StartTime, Nil: true}}
 		}
 
 		sort.Sort(floatPointsByValue(a))
-		return []FloatPoint{{Time: opt.startTime, Value: a[i].Value}}
+		return []FloatPoint{{Time: opt.StartTime, Value: a[i].Value}}
 	}
 }
 
-// newIntegerPercentileReduceSliceFunc returns the percentile value within a window.
-func newIntegerPercentileReduceSliceFunc(percentile float64) integerReduceSliceFunc {
-	return func(a []IntegerPoint, opt *reduceOptions) []IntegerPoint {
+// NewIntegerPercentileReduceSliceFunc returns the percentile value within a window.
+func NewIntegerPercentileReduceSliceFunc(percentile float64) IntegerReduceSliceFunc {
+	return func(a []IntegerPoint, opt *ReduceOptions) []IntegerPoint {
 		length := len(a)
 		i := int(math.Floor(float64(length)*percentile/100.0+0.5)) - 1
 
@@ -912,7 +974,7 @@ func newIntegerPercentileReduceSliceFunc(percentile float64) integerReduceSliceF
 		}
 
 		sort.Sort(integerPointsByValue(a))
-		return []IntegerPoint{{Time: opt.startTime, Value: a[i].Value}}
+		return []IntegerPoint{{Time: opt.StartTime, Value: a[i].Value}}
 	}
 }
 
@@ -920,19 +982,27 @@ func newIntegerPercentileReduceSliceFunc(percentile float64) integerReduceSliceF
 func newDerivativeIterator(input Iterator, opt IteratorOptions, interval Interval, isNonNegative bool) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, fn: newFloatDerivativeReduceSliceFunc(interval, isNonNegative)}, nil
+		createFn := func() (FloatPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewFloatSliceFuncReducer(NewFloatDerivativeReduceSliceFunc(interval, isNonNegative))
+			return fn, fn
+		}
+		return &floatReduceSliceIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
-		return &integerReduceSliceFloatIterator{input: newBufIntegerIterator(input), opt: opt, fn: newIntegerDerivativeReduceSliceFunc(interval, isNonNegative)}, nil
+		createFn := func() (IntegerPointSliceAggregator, FloatPointSliceEmitter) {
+			fn := NewIntegerSliceFloatFuncReducer(NewIntegerDerivativeReduceSliceFunc(interval, isNonNegative))
+			return fn, fn
+		}
+		return &integerReduceSliceFloatIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported derivative iterator type: %T", input)
 	}
 }
 
-// newFloatDerivativeReduceSliceFunc returns the derivative value within a window.
-func newFloatDerivativeReduceSliceFunc(interval Interval, isNonNegative bool) floatReduceSliceFunc {
+// NewFloatDerivativeReduceSliceFunc returns the derivative value within a window.
+func NewFloatDerivativeReduceSliceFunc(interval Interval, isNonNegative bool) FloatReduceSliceFunc {
 	prev := FloatPoint{Time: -1}
 
-	return func(a []FloatPoint, opt *reduceOptions) []FloatPoint {
+	return func(a []FloatPoint, opt *ReduceOptions) []FloatPoint {
 		if len(a) == 0 {
 			return a
 		} else if len(a) == 1 {
@@ -970,11 +1040,11 @@ func newFloatDerivativeReduceSliceFunc(interval Interval, isNonNegative bool) fl
 	}
 }
 
-// newIntegerDerivativeReduceSliceFunc returns the derivative value within a window.
-func newIntegerDerivativeReduceSliceFunc(interval Interval, isNonNegative bool) integerReduceSliceFloatFunc {
+// NewIntegerDerivativeReduceSliceFunc returns the derivative value within a window.
+func NewIntegerDerivativeReduceSliceFunc(interval Interval, isNonNegative bool) IntegerReduceSliceFloatFunc {
 	prev := IntegerPoint{Time: -1}
 
-	return func(a []IntegerPoint, opt *reduceOptions) []FloatPoint {
+	return func(a []IntegerPoint, opt *ReduceOptions) []FloatPoint {
 		if len(a) == 0 {
 			return []FloatPoint{}
 		} else if len(a) == 1 {
@@ -1016,7 +1086,7 @@ func newIntegerDerivativeReduceSliceFunc(interval Interval, isNonNegative bool) 
 // This iterator receives an integer iterator but produces a float iterator.
 type integerReduceSliceFloatIterator struct {
 	input  *bufIntegerIterator
-	fn     integerReduceSliceFloatFunc
+	create func() (IntegerPointSliceAggregator, FloatPointSliceEmitter)
 	opt    IteratorOptions
 	points []FloatPoint
 }
@@ -1046,9 +1116,8 @@ func (itr *integerReduceSliceFloatIterator) reduce() []FloatPoint {
 	// Calculate next window.
 	startTime, endTime := itr.opt.Window(itr.input.peekTime())
 
-	var reduceOptions = reduceOptions{
-		startTime: startTime,
-		endTime:   endTime,
+	var reduceOptions = ReduceOptions{
+		StartTime: startTime,
 	}
 
 	// Group points by name and tagset.
@@ -1077,7 +1146,9 @@ func (itr *integerReduceSliceFloatIterator) reduce() []FloatPoint {
 	// Reduce each set into a set of values.
 	results := make(map[string][]FloatPoint)
 	for key, g := range groups {
-		a := itr.fn(g.points, &reduceOptions)
+		aggregator, emitter := itr.create()
+		aggregator.AggregateSlice(g.points)
+		a := emitter.Emit(&reduceOptions)
 		if len(a) == 0 {
 			continue
 		}
@@ -1107,6 +1178,3 @@ func (itr *integerReduceSliceFloatIterator) reduce() []FloatPoint {
 
 	return a
 }
-
-// integerReduceSliceFloatFunc is the function called by a IntegerPoint slice reducer that emits FloatPoint.
-type integerReduceSliceFloatFunc func(a []IntegerPoint, opt *reduceOptions) []FloatPoint

--- a/influxql/functions.gen.go
+++ b/influxql/functions.gen.go
@@ -16,6 +16,17 @@ type FloatPointEmitter interface {
 	Emit() *FloatPoint
 }
 
+// FloatPointSliceAggregator aggregates a slice of to produce a slice of points.
+type FloatPointSliceAggregator interface {
+	Aggregate(a FloatPoint)
+	AggregateSlice(a []FloatPoint)
+}
+
+// FloatPointSliceEmitter produces a slice of points from an aggregate.
+type FloatPointSliceEmitter interface {
+	Emit(opt *ReduceOptions) []FloatPoint
+}
+
 // FloatReduceFunc is the function called by a FloatPoint reducer.
 type FloatReduceFunc func(prev *FloatPoint, curr *FloatPoint) (t int64, v float64, aux []interface{})
 
@@ -41,6 +52,30 @@ func (r *FloatFuncReducer) Aggregate(p *FloatPoint) {
 
 func (r *FloatFuncReducer) Emit() *FloatPoint {
 	return r.prev
+}
+
+// FloatReduceSliceFunc is the function called by a FloatPoint slice reducer.
+type FloatReduceSliceFunc func(a []FloatPoint, opt *ReduceOptions) []FloatPoint
+
+type FloatSliceFuncReducer struct {
+	slice []FloatPoint
+	fn    FloatReduceSliceFunc
+}
+
+func NewFloatSliceFuncReducer(fn FloatReduceSliceFunc) *FloatSliceFuncReducer {
+	return &FloatSliceFuncReducer{fn: fn}
+}
+
+func (r *FloatSliceFuncReducer) Aggregate(a FloatPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *FloatSliceFuncReducer) AggregateSlice(a []FloatPoint) {
+	r.slice = a
+}
+
+func (r *FloatSliceFuncReducer) Emit(opt *ReduceOptions) []FloatPoint {
+	return r.fn(r.slice, opt)
 }
 
 // FloatReduceIntegerFunc is the function called by a FloatPoint reducer.
@@ -70,6 +105,30 @@ func (r *FloatFuncIntegerReducer) Emit() *IntegerPoint {
 	return r.prev
 }
 
+// FloatReduceSliceFunc is the function called by a FloatPoint slice reducer.
+type FloatReduceSliceIntegerFunc func(a []FloatPoint, opt *ReduceOptions) []IntegerPoint
+
+type FloatSliceFuncIntegerReducer struct {
+	slice []FloatPoint
+	fn    FloatReduceSliceIntegerFunc
+}
+
+func NewFloatSliceFuncIntegerReducer(fn FloatReduceSliceIntegerFunc) *FloatSliceFuncIntegerReducer {
+	return &FloatSliceFuncIntegerReducer{fn: fn}
+}
+
+func (r *FloatSliceFuncIntegerReducer) Aggregate(a FloatPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *FloatSliceFuncIntegerReducer) AggregateSlice(a []FloatPoint) {
+	r.slice = a
+}
+
+func (r *FloatSliceFuncIntegerReducer) Emit(opt *ReduceOptions) []IntegerPoint {
+	return r.fn(r.slice, opt)
+}
+
 // FloatReduceStringFunc is the function called by a FloatPoint reducer.
 type FloatReduceStringFunc func(prev *StringPoint, curr *FloatPoint) (t int64, v string, aux []interface{})
 
@@ -95,6 +154,30 @@ func (r *FloatFuncStringReducer) Aggregate(p *FloatPoint) {
 
 func (r *FloatFuncStringReducer) Emit() *StringPoint {
 	return r.prev
+}
+
+// FloatReduceSliceFunc is the function called by a FloatPoint slice reducer.
+type FloatReduceSliceStringFunc func(a []FloatPoint, opt *ReduceOptions) []StringPoint
+
+type FloatSliceFuncStringReducer struct {
+	slice []FloatPoint
+	fn    FloatReduceSliceStringFunc
+}
+
+func NewFloatSliceFuncStringReducer(fn FloatReduceSliceStringFunc) *FloatSliceFuncStringReducer {
+	return &FloatSliceFuncStringReducer{fn: fn}
+}
+
+func (r *FloatSliceFuncStringReducer) Aggregate(a FloatPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *FloatSliceFuncStringReducer) AggregateSlice(a []FloatPoint) {
+	r.slice = a
+}
+
+func (r *FloatSliceFuncStringReducer) Emit(opt *ReduceOptions) []StringPoint {
+	return r.fn(r.slice, opt)
 }
 
 // FloatReduceBooleanFunc is the function called by a FloatPoint reducer.
@@ -124,6 +207,30 @@ func (r *FloatFuncBooleanReducer) Emit() *BooleanPoint {
 	return r.prev
 }
 
+// FloatReduceSliceFunc is the function called by a FloatPoint slice reducer.
+type FloatReduceSliceBooleanFunc func(a []FloatPoint, opt *ReduceOptions) []BooleanPoint
+
+type FloatSliceFuncBooleanReducer struct {
+	slice []FloatPoint
+	fn    FloatReduceSliceBooleanFunc
+}
+
+func NewFloatSliceFuncBooleanReducer(fn FloatReduceSliceBooleanFunc) *FloatSliceFuncBooleanReducer {
+	return &FloatSliceFuncBooleanReducer{fn: fn}
+}
+
+func (r *FloatSliceFuncBooleanReducer) Aggregate(a FloatPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *FloatSliceFuncBooleanReducer) AggregateSlice(a []FloatPoint) {
+	r.slice = a
+}
+
+func (r *FloatSliceFuncBooleanReducer) Emit(opt *ReduceOptions) []BooleanPoint {
+	return r.fn(r.slice, opt)
+}
+
 // IntegerPointAggregator aggregates points to produce a single point.
 type IntegerPointAggregator interface {
 	Aggregate(p *IntegerPoint)
@@ -132,6 +239,17 @@ type IntegerPointAggregator interface {
 // IntegerPointEmitter produces a single point from an aggregate.
 type IntegerPointEmitter interface {
 	Emit() *IntegerPoint
+}
+
+// IntegerPointSliceAggregator aggregates a slice of to produce a slice of points.
+type IntegerPointSliceAggregator interface {
+	Aggregate(a IntegerPoint)
+	AggregateSlice(a []IntegerPoint)
+}
+
+// IntegerPointSliceEmitter produces a slice of points from an aggregate.
+type IntegerPointSliceEmitter interface {
+	Emit(opt *ReduceOptions) []IntegerPoint
 }
 
 // IntegerReduceFloatFunc is the function called by a IntegerPoint reducer.
@@ -161,6 +279,30 @@ func (r *IntegerFuncFloatReducer) Emit() *FloatPoint {
 	return r.prev
 }
 
+// IntegerReduceSliceFunc is the function called by a IntegerPoint slice reducer.
+type IntegerReduceSliceFloatFunc func(a []IntegerPoint, opt *ReduceOptions) []FloatPoint
+
+type IntegerSliceFuncFloatReducer struct {
+	slice []IntegerPoint
+	fn    IntegerReduceSliceFloatFunc
+}
+
+func NewIntegerSliceFuncFloatReducer(fn IntegerReduceSliceFloatFunc) *IntegerSliceFuncFloatReducer {
+	return &IntegerSliceFuncFloatReducer{fn: fn}
+}
+
+func (r *IntegerSliceFuncFloatReducer) Aggregate(a IntegerPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *IntegerSliceFuncFloatReducer) AggregateSlice(a []IntegerPoint) {
+	r.slice = a
+}
+
+func (r *IntegerSliceFuncFloatReducer) Emit(opt *ReduceOptions) []FloatPoint {
+	return r.fn(r.slice, opt)
+}
+
 // IntegerReduceFunc is the function called by a IntegerPoint reducer.
 type IntegerReduceFunc func(prev *IntegerPoint, curr *IntegerPoint) (t int64, v int64, aux []interface{})
 
@@ -186,6 +328,30 @@ func (r *IntegerFuncReducer) Aggregate(p *IntegerPoint) {
 
 func (r *IntegerFuncReducer) Emit() *IntegerPoint {
 	return r.prev
+}
+
+// IntegerReduceSliceFunc is the function called by a IntegerPoint slice reducer.
+type IntegerReduceSliceFunc func(a []IntegerPoint, opt *ReduceOptions) []IntegerPoint
+
+type IntegerSliceFuncReducer struct {
+	slice []IntegerPoint
+	fn    IntegerReduceSliceFunc
+}
+
+func NewIntegerSliceFuncReducer(fn IntegerReduceSliceFunc) *IntegerSliceFuncReducer {
+	return &IntegerSliceFuncReducer{fn: fn}
+}
+
+func (r *IntegerSliceFuncReducer) Aggregate(a IntegerPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *IntegerSliceFuncReducer) AggregateSlice(a []IntegerPoint) {
+	r.slice = a
+}
+
+func (r *IntegerSliceFuncReducer) Emit(opt *ReduceOptions) []IntegerPoint {
+	return r.fn(r.slice, opt)
 }
 
 // IntegerReduceStringFunc is the function called by a IntegerPoint reducer.
@@ -215,6 +381,30 @@ func (r *IntegerFuncStringReducer) Emit() *StringPoint {
 	return r.prev
 }
 
+// IntegerReduceSliceFunc is the function called by a IntegerPoint slice reducer.
+type IntegerReduceSliceStringFunc func(a []IntegerPoint, opt *ReduceOptions) []StringPoint
+
+type IntegerSliceFuncStringReducer struct {
+	slice []IntegerPoint
+	fn    IntegerReduceSliceStringFunc
+}
+
+func NewIntegerSliceFuncStringReducer(fn IntegerReduceSliceStringFunc) *IntegerSliceFuncStringReducer {
+	return &IntegerSliceFuncStringReducer{fn: fn}
+}
+
+func (r *IntegerSliceFuncStringReducer) Aggregate(a IntegerPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *IntegerSliceFuncStringReducer) AggregateSlice(a []IntegerPoint) {
+	r.slice = a
+}
+
+func (r *IntegerSliceFuncStringReducer) Emit(opt *ReduceOptions) []StringPoint {
+	return r.fn(r.slice, opt)
+}
+
 // IntegerReduceBooleanFunc is the function called by a IntegerPoint reducer.
 type IntegerReduceBooleanFunc func(prev *BooleanPoint, curr *IntegerPoint) (t int64, v bool, aux []interface{})
 
@@ -242,6 +432,30 @@ func (r *IntegerFuncBooleanReducer) Emit() *BooleanPoint {
 	return r.prev
 }
 
+// IntegerReduceSliceFunc is the function called by a IntegerPoint slice reducer.
+type IntegerReduceSliceBooleanFunc func(a []IntegerPoint, opt *ReduceOptions) []BooleanPoint
+
+type IntegerSliceFuncBooleanReducer struct {
+	slice []IntegerPoint
+	fn    IntegerReduceSliceBooleanFunc
+}
+
+func NewIntegerSliceFuncBooleanReducer(fn IntegerReduceSliceBooleanFunc) *IntegerSliceFuncBooleanReducer {
+	return &IntegerSliceFuncBooleanReducer{fn: fn}
+}
+
+func (r *IntegerSliceFuncBooleanReducer) Aggregate(a IntegerPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *IntegerSliceFuncBooleanReducer) AggregateSlice(a []IntegerPoint) {
+	r.slice = a
+}
+
+func (r *IntegerSliceFuncBooleanReducer) Emit(opt *ReduceOptions) []BooleanPoint {
+	return r.fn(r.slice, opt)
+}
+
 // StringPointAggregator aggregates points to produce a single point.
 type StringPointAggregator interface {
 	Aggregate(p *StringPoint)
@@ -250,6 +464,17 @@ type StringPointAggregator interface {
 // StringPointEmitter produces a single point from an aggregate.
 type StringPointEmitter interface {
 	Emit() *StringPoint
+}
+
+// StringPointSliceAggregator aggregates a slice of to produce a slice of points.
+type StringPointSliceAggregator interface {
+	Aggregate(a StringPoint)
+	AggregateSlice(a []StringPoint)
+}
+
+// StringPointSliceEmitter produces a slice of points from an aggregate.
+type StringPointSliceEmitter interface {
+	Emit(opt *ReduceOptions) []StringPoint
 }
 
 // StringReduceFloatFunc is the function called by a StringPoint reducer.
@@ -279,6 +504,30 @@ func (r *StringFuncFloatReducer) Emit() *FloatPoint {
 	return r.prev
 }
 
+// StringReduceSliceFunc is the function called by a StringPoint slice reducer.
+type StringReduceSliceFloatFunc func(a []StringPoint, opt *ReduceOptions) []FloatPoint
+
+type StringSliceFuncFloatReducer struct {
+	slice []StringPoint
+	fn    StringReduceSliceFloatFunc
+}
+
+func NewStringSliceFuncFloatReducer(fn StringReduceSliceFloatFunc) *StringSliceFuncFloatReducer {
+	return &StringSliceFuncFloatReducer{fn: fn}
+}
+
+func (r *StringSliceFuncFloatReducer) Aggregate(a StringPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *StringSliceFuncFloatReducer) AggregateSlice(a []StringPoint) {
+	r.slice = a
+}
+
+func (r *StringSliceFuncFloatReducer) Emit(opt *ReduceOptions) []FloatPoint {
+	return r.fn(r.slice, opt)
+}
+
 // StringReduceIntegerFunc is the function called by a StringPoint reducer.
 type StringReduceIntegerFunc func(prev *IntegerPoint, curr *StringPoint) (t int64, v int64, aux []interface{})
 
@@ -304,6 +553,30 @@ func (r *StringFuncIntegerReducer) Aggregate(p *StringPoint) {
 
 func (r *StringFuncIntegerReducer) Emit() *IntegerPoint {
 	return r.prev
+}
+
+// StringReduceSliceFunc is the function called by a StringPoint slice reducer.
+type StringReduceSliceIntegerFunc func(a []StringPoint, opt *ReduceOptions) []IntegerPoint
+
+type StringSliceFuncIntegerReducer struct {
+	slice []StringPoint
+	fn    StringReduceSliceIntegerFunc
+}
+
+func NewStringSliceFuncIntegerReducer(fn StringReduceSliceIntegerFunc) *StringSliceFuncIntegerReducer {
+	return &StringSliceFuncIntegerReducer{fn: fn}
+}
+
+func (r *StringSliceFuncIntegerReducer) Aggregate(a StringPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *StringSliceFuncIntegerReducer) AggregateSlice(a []StringPoint) {
+	r.slice = a
+}
+
+func (r *StringSliceFuncIntegerReducer) Emit(opt *ReduceOptions) []IntegerPoint {
+	return r.fn(r.slice, opt)
 }
 
 // StringReduceFunc is the function called by a StringPoint reducer.
@@ -333,6 +606,30 @@ func (r *StringFuncReducer) Emit() *StringPoint {
 	return r.prev
 }
 
+// StringReduceSliceFunc is the function called by a StringPoint slice reducer.
+type StringReduceSliceFunc func(a []StringPoint, opt *ReduceOptions) []StringPoint
+
+type StringSliceFuncReducer struct {
+	slice []StringPoint
+	fn    StringReduceSliceFunc
+}
+
+func NewStringSliceFuncReducer(fn StringReduceSliceFunc) *StringSliceFuncReducer {
+	return &StringSliceFuncReducer{fn: fn}
+}
+
+func (r *StringSliceFuncReducer) Aggregate(a StringPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *StringSliceFuncReducer) AggregateSlice(a []StringPoint) {
+	r.slice = a
+}
+
+func (r *StringSliceFuncReducer) Emit(opt *ReduceOptions) []StringPoint {
+	return r.fn(r.slice, opt)
+}
+
 // StringReduceBooleanFunc is the function called by a StringPoint reducer.
 type StringReduceBooleanFunc func(prev *BooleanPoint, curr *StringPoint) (t int64, v bool, aux []interface{})
 
@@ -360,6 +657,30 @@ func (r *StringFuncBooleanReducer) Emit() *BooleanPoint {
 	return r.prev
 }
 
+// StringReduceSliceFunc is the function called by a StringPoint slice reducer.
+type StringReduceSliceBooleanFunc func(a []StringPoint, opt *ReduceOptions) []BooleanPoint
+
+type StringSliceFuncBooleanReducer struct {
+	slice []StringPoint
+	fn    StringReduceSliceBooleanFunc
+}
+
+func NewStringSliceFuncBooleanReducer(fn StringReduceSliceBooleanFunc) *StringSliceFuncBooleanReducer {
+	return &StringSliceFuncBooleanReducer{fn: fn}
+}
+
+func (r *StringSliceFuncBooleanReducer) Aggregate(a StringPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *StringSliceFuncBooleanReducer) AggregateSlice(a []StringPoint) {
+	r.slice = a
+}
+
+func (r *StringSliceFuncBooleanReducer) Emit(opt *ReduceOptions) []BooleanPoint {
+	return r.fn(r.slice, opt)
+}
+
 // BooleanPointAggregator aggregates points to produce a single point.
 type BooleanPointAggregator interface {
 	Aggregate(p *BooleanPoint)
@@ -368,6 +689,17 @@ type BooleanPointAggregator interface {
 // BooleanPointEmitter produces a single point from an aggregate.
 type BooleanPointEmitter interface {
 	Emit() *BooleanPoint
+}
+
+// BooleanPointSliceAggregator aggregates a slice of to produce a slice of points.
+type BooleanPointSliceAggregator interface {
+	Aggregate(a BooleanPoint)
+	AggregateSlice(a []BooleanPoint)
+}
+
+// BooleanPointSliceEmitter produces a slice of points from an aggregate.
+type BooleanPointSliceEmitter interface {
+	Emit(opt *ReduceOptions) []BooleanPoint
 }
 
 // BooleanReduceFloatFunc is the function called by a BooleanPoint reducer.
@@ -397,6 +729,30 @@ func (r *BooleanFuncFloatReducer) Emit() *FloatPoint {
 	return r.prev
 }
 
+// BooleanReduceSliceFunc is the function called by a BooleanPoint slice reducer.
+type BooleanReduceSliceFloatFunc func(a []BooleanPoint, opt *ReduceOptions) []FloatPoint
+
+type BooleanSliceFuncFloatReducer struct {
+	slice []BooleanPoint
+	fn    BooleanReduceSliceFloatFunc
+}
+
+func NewBooleanSliceFuncFloatReducer(fn BooleanReduceSliceFloatFunc) *BooleanSliceFuncFloatReducer {
+	return &BooleanSliceFuncFloatReducer{fn: fn}
+}
+
+func (r *BooleanSliceFuncFloatReducer) Aggregate(a BooleanPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *BooleanSliceFuncFloatReducer) AggregateSlice(a []BooleanPoint) {
+	r.slice = a
+}
+
+func (r *BooleanSliceFuncFloatReducer) Emit(opt *ReduceOptions) []FloatPoint {
+	return r.fn(r.slice, opt)
+}
+
 // BooleanReduceIntegerFunc is the function called by a BooleanPoint reducer.
 type BooleanReduceIntegerFunc func(prev *IntegerPoint, curr *BooleanPoint) (t int64, v int64, aux []interface{})
 
@@ -422,6 +778,30 @@ func (r *BooleanFuncIntegerReducer) Aggregate(p *BooleanPoint) {
 
 func (r *BooleanFuncIntegerReducer) Emit() *IntegerPoint {
 	return r.prev
+}
+
+// BooleanReduceSliceFunc is the function called by a BooleanPoint slice reducer.
+type BooleanReduceSliceIntegerFunc func(a []BooleanPoint, opt *ReduceOptions) []IntegerPoint
+
+type BooleanSliceFuncIntegerReducer struct {
+	slice []BooleanPoint
+	fn    BooleanReduceSliceIntegerFunc
+}
+
+func NewBooleanSliceFuncIntegerReducer(fn BooleanReduceSliceIntegerFunc) *BooleanSliceFuncIntegerReducer {
+	return &BooleanSliceFuncIntegerReducer{fn: fn}
+}
+
+func (r *BooleanSliceFuncIntegerReducer) Aggregate(a BooleanPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *BooleanSliceFuncIntegerReducer) AggregateSlice(a []BooleanPoint) {
+	r.slice = a
+}
+
+func (r *BooleanSliceFuncIntegerReducer) Emit(opt *ReduceOptions) []IntegerPoint {
+	return r.fn(r.slice, opt)
 }
 
 // BooleanReduceStringFunc is the function called by a BooleanPoint reducer.
@@ -451,6 +831,30 @@ func (r *BooleanFuncStringReducer) Emit() *StringPoint {
 	return r.prev
 }
 
+// BooleanReduceSliceFunc is the function called by a BooleanPoint slice reducer.
+type BooleanReduceSliceStringFunc func(a []BooleanPoint, opt *ReduceOptions) []StringPoint
+
+type BooleanSliceFuncStringReducer struct {
+	slice []BooleanPoint
+	fn    BooleanReduceSliceStringFunc
+}
+
+func NewBooleanSliceFuncStringReducer(fn BooleanReduceSliceStringFunc) *BooleanSliceFuncStringReducer {
+	return &BooleanSliceFuncStringReducer{fn: fn}
+}
+
+func (r *BooleanSliceFuncStringReducer) Aggregate(a BooleanPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *BooleanSliceFuncStringReducer) AggregateSlice(a []BooleanPoint) {
+	r.slice = a
+}
+
+func (r *BooleanSliceFuncStringReducer) Emit(opt *ReduceOptions) []StringPoint {
+	return r.fn(r.slice, opt)
+}
+
 // BooleanReduceFunc is the function called by a BooleanPoint reducer.
 type BooleanReduceFunc func(prev *BooleanPoint, curr *BooleanPoint) (t int64, v bool, aux []interface{})
 
@@ -476,4 +880,28 @@ func (r *BooleanFuncReducer) Aggregate(p *BooleanPoint) {
 
 func (r *BooleanFuncReducer) Emit() *BooleanPoint {
 	return r.prev
+}
+
+// BooleanReduceSliceFunc is the function called by a BooleanPoint slice reducer.
+type BooleanReduceSliceFunc func(a []BooleanPoint, opt *ReduceOptions) []BooleanPoint
+
+type BooleanSliceFuncReducer struct {
+	slice []BooleanPoint
+	fn    BooleanReduceSliceFunc
+}
+
+func NewBooleanSliceFuncReducer(fn BooleanReduceSliceFunc) *BooleanSliceFuncReducer {
+	return &BooleanSliceFuncReducer{fn: fn}
+}
+
+func (r *BooleanSliceFuncReducer) Aggregate(a BooleanPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *BooleanSliceFuncReducer) AggregateSlice(a []BooleanPoint) {
+	r.slice = a
+}
+
+func (r *BooleanSliceFuncReducer) Emit(opt *ReduceOptions) []BooleanPoint {
+	return r.fn(r.slice, opt)
 }

--- a/influxql/functions.gen.go.tmpl
+++ b/influxql/functions.gen.go.tmpl
@@ -12,6 +12,18 @@ type {{$k.Name}}PointEmitter interface {
 	Emit() *{{$k.Name}}Point
 }
 
+// {{.Name}}PointSliceAggregator aggregates a slice of to produce a slice of points.
+type {{.Name}}PointSliceAggregator interface {
+	Aggregate(a {{.Name}}Point)
+	AggregateSlice(a []{{.Name}}Point)
+}
+
+// {{.Name}}PointSliceEmitter produces a slice of points from an aggregate.
+type {{.Name}}PointSliceEmitter interface {
+	Emit(opt *ReduceOptions) []{{.Name}}Point
+}
+
+
 {{range $v := $types}}
 
 // {{$k.Name}}Reduce{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Func is the function called by a {{$k.Name}}Point reducer.
@@ -39,5 +51,30 @@ func (r *{{$k.Name}}Func{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer) Aggr
 
 func (r *{{$k.Name}}Func{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer) Emit() *{{$v.Name}}Point {
 	return r.prev
+}
+
+
+// {{$k.Name}}ReduceSliceFunc is the function called by a {{$k.Name}}Point slice reducer.
+type {{$k.Name}}ReduceSlice{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Func func(a []{{$k.Name}}Point, opt *ReduceOptions) []{{$v.Name}}Point
+
+type {{$k.Name}}SliceFunc{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer struct {
+	slice []{{$k.Name}}Point
+	fn    {{$k.Name}}ReduceSlice{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Func
+}
+
+func New{{$k.Name}}SliceFunc{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer(fn {{$k.Name}}ReduceSlice{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Func) *{{$k.Name}}SliceFunc{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer {
+	return &{{$k.Name}}SliceFunc{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer{fn: fn}
+}
+
+func (r *{{$k.Name}}SliceFunc{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer) Aggregate(a {{$k.Name}}Point) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *{{$k.Name}}SliceFunc{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer) AggregateSlice(a []{{$k.Name}}Point) {
+	r.slice = a
+}
+
+func (r *{{$k.Name}}SliceFunc{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}Reducer) Emit(opt *ReduceOptions) []{{$v.Name}}Point {
+    return r.fn(r.slice, opt)
 }
 {{end}}{{end}}{{end}}

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -51,3 +51,27 @@ func (r *IntegerMeanReducer) Emit() *FloatPoint {
 		Aggregated: r.count,
 	}
 }
+
+type IntegerSliceFloatFuncReducer struct {
+	slice []IntegerPoint
+	fn    IntegerReduceSliceFloatFunc
+}
+
+// NewIntegerDerivativeReducer returns the derivative value within a window.
+func NewIntegerSliceFloatFuncReducer(fn IntegerReduceSliceFloatFunc) *IntegerSliceFloatFuncReducer {
+	return &IntegerSliceFloatFuncReducer{
+		fn: fn,
+	}
+}
+
+func (r *IntegerSliceFloatFuncReducer) Aggregate(a IntegerPoint) {
+	r.slice = append(r.slice, a)
+}
+
+func (r *IntegerSliceFloatFuncReducer) AggregateSlice(a []IntegerPoint) {
+	r.slice = a
+}
+
+func (r *IntegerSliceFloatFuncReducer) Emit(opt *ReduceOptions) []FloatPoint {
+	return r.fn(r.slice, opt)
+}

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -980,7 +980,7 @@ func (itr *floatReduceBooleanIterator) reduce() []*BooleanPoint {
 // floatReduceSliceIterator executes a reducer on all points in a window and buffers the result.
 type floatReduceSliceIterator struct {
 	input  *bufFloatIterator
-	fn     floatReduceSliceFunc
+	create func() (FloatPointSliceAggregator, FloatPointSliceEmitter)
 	opt    IteratorOptions
 	points []FloatPoint
 }
@@ -1010,9 +1010,8 @@ func (itr *floatReduceSliceIterator) reduce() []FloatPoint {
 	// Calculate next window.
 	startTime, endTime := itr.opt.Window(itr.input.peekTime())
 
-	var reduceOptions = reduceOptions{
-		startTime: startTime,
-		endTime:   endTime,
+	var reduceOptions = ReduceOptions{
+		StartTime: startTime,
 	}
 
 	// Group points by name and tagset.
@@ -1043,7 +1042,9 @@ func (itr *floatReduceSliceIterator) reduce() []FloatPoint {
 	// Reduce each set into a set of values.
 	results := make(map[string][]FloatPoint)
 	for key, g := range groups {
-		a := itr.fn(g.points, &reduceOptions)
+		aggregator, emitter := itr.create()
+		aggregator.AggregateSlice(g.points)
+		a := emitter.Emit(&reduceOptions)
 		if len(a) == 0 {
 			continue
 		}
@@ -1074,10 +1075,7 @@ func (itr *floatReduceSliceIterator) reduce() []FloatPoint {
 	return a
 }
 
-// floatReduceSliceFunc is the function called by a FloatPoint slice reducer.
-type floatReduceSliceFunc func(a []FloatPoint, opt *reduceOptions) []FloatPoint
-
-// floatReduceIterator executes a function to modify an existing point for every
+// floatTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type floatTransformIterator struct {
 	input FloatIterator
@@ -2177,7 +2175,7 @@ func (itr *integerReduceBooleanIterator) reduce() []*BooleanPoint {
 // integerReduceSliceIterator executes a reducer on all points in a window and buffers the result.
 type integerReduceSliceIterator struct {
 	input  *bufIntegerIterator
-	fn     integerReduceSliceFunc
+	create func() (IntegerPointSliceAggregator, IntegerPointSliceEmitter)
 	opt    IteratorOptions
 	points []IntegerPoint
 }
@@ -2207,9 +2205,8 @@ func (itr *integerReduceSliceIterator) reduce() []IntegerPoint {
 	// Calculate next window.
 	startTime, endTime := itr.opt.Window(itr.input.peekTime())
 
-	var reduceOptions = reduceOptions{
-		startTime: startTime,
-		endTime:   endTime,
+	var reduceOptions = ReduceOptions{
+		StartTime: startTime,
 	}
 
 	// Group points by name and tagset.
@@ -2240,7 +2237,9 @@ func (itr *integerReduceSliceIterator) reduce() []IntegerPoint {
 	// Reduce each set into a set of values.
 	results := make(map[string][]IntegerPoint)
 	for key, g := range groups {
-		a := itr.fn(g.points, &reduceOptions)
+		aggregator, emitter := itr.create()
+		aggregator.AggregateSlice(g.points)
+		a := emitter.Emit(&reduceOptions)
 		if len(a) == 0 {
 			continue
 		}
@@ -2271,10 +2270,7 @@ func (itr *integerReduceSliceIterator) reduce() []IntegerPoint {
 	return a
 }
 
-// integerReduceSliceFunc is the function called by a IntegerPoint slice reducer.
-type integerReduceSliceFunc func(a []IntegerPoint, opt *reduceOptions) []IntegerPoint
-
-// integerReduceIterator executes a function to modify an existing point for every
+// integerTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type integerTransformIterator struct {
 	input IntegerIterator
@@ -3374,7 +3370,7 @@ func (itr *stringReduceBooleanIterator) reduce() []*BooleanPoint {
 // stringReduceSliceIterator executes a reducer on all points in a window and buffers the result.
 type stringReduceSliceIterator struct {
 	input  *bufStringIterator
-	fn     stringReduceSliceFunc
+	create func() (StringPointSliceAggregator, StringPointSliceEmitter)
 	opt    IteratorOptions
 	points []StringPoint
 }
@@ -3404,9 +3400,8 @@ func (itr *stringReduceSliceIterator) reduce() []StringPoint {
 	// Calculate next window.
 	startTime, endTime := itr.opt.Window(itr.input.peekTime())
 
-	var reduceOptions = reduceOptions{
-		startTime: startTime,
-		endTime:   endTime,
+	var reduceOptions = ReduceOptions{
+		StartTime: startTime,
 	}
 
 	// Group points by name and tagset.
@@ -3437,7 +3432,9 @@ func (itr *stringReduceSliceIterator) reduce() []StringPoint {
 	// Reduce each set into a set of values.
 	results := make(map[string][]StringPoint)
 	for key, g := range groups {
-		a := itr.fn(g.points, &reduceOptions)
+		aggregator, emitter := itr.create()
+		aggregator.AggregateSlice(g.points)
+		a := emitter.Emit(&reduceOptions)
 		if len(a) == 0 {
 			continue
 		}
@@ -3468,10 +3465,7 @@ func (itr *stringReduceSliceIterator) reduce() []StringPoint {
 	return a
 }
 
-// stringReduceSliceFunc is the function called by a StringPoint slice reducer.
-type stringReduceSliceFunc func(a []StringPoint, opt *reduceOptions) []StringPoint
-
-// stringReduceIterator executes a function to modify an existing point for every
+// stringTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type stringTransformIterator struct {
 	input StringIterator
@@ -4571,7 +4565,7 @@ func (itr *booleanReduceBooleanIterator) reduce() []*BooleanPoint {
 // booleanReduceSliceIterator executes a reducer on all points in a window and buffers the result.
 type booleanReduceSliceIterator struct {
 	input  *bufBooleanIterator
-	fn     booleanReduceSliceFunc
+	create func() (BooleanPointSliceAggregator, BooleanPointSliceEmitter)
 	opt    IteratorOptions
 	points []BooleanPoint
 }
@@ -4601,9 +4595,8 @@ func (itr *booleanReduceSliceIterator) reduce() []BooleanPoint {
 	// Calculate next window.
 	startTime, endTime := itr.opt.Window(itr.input.peekTime())
 
-	var reduceOptions = reduceOptions{
-		startTime: startTime,
-		endTime:   endTime,
+	var reduceOptions = ReduceOptions{
+		StartTime: startTime,
 	}
 
 	// Group points by name and tagset.
@@ -4634,7 +4627,9 @@ func (itr *booleanReduceSliceIterator) reduce() []BooleanPoint {
 	// Reduce each set into a set of values.
 	results := make(map[string][]BooleanPoint)
 	for key, g := range groups {
-		a := itr.fn(g.points, &reduceOptions)
+		aggregator, emitter := itr.create()
+		aggregator.AggregateSlice(g.points)
+		a := emitter.Emit(&reduceOptions)
 		if len(a) == 0 {
 			continue
 		}
@@ -4665,10 +4660,7 @@ func (itr *booleanReduceSliceIterator) reduce() []BooleanPoint {
 	return a
 }
 
-// booleanReduceSliceFunc is the function called by a BooleanPoint slice reducer.
-type booleanReduceSliceFunc func(a []BooleanPoint, opt *reduceOptions) []BooleanPoint
-
-// booleanReduceIterator executes a function to modify an existing point for every
+// booleanTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type booleanTransformIterator struct {
 	input BooleanIterator

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -715,7 +715,7 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() []*{{$v.Name}}Point {
 // {{$k.name}}ReduceSliceIterator executes a reducer on all points in a window and buffers the result.
 type {{$k.name}}ReduceSliceIterator struct {
 	input  *buf{{$k.Name}}Iterator
-	fn     {{$k.name}}ReduceSliceFunc
+    create func() ({{$k.Name}}PointSliceAggregator, {{$k.Name}}PointSliceEmitter)
 	opt    IteratorOptions
 	points []{{$k.Name}}Point
 }
@@ -745,9 +745,8 @@ func (itr *{{$k.name}}ReduceSliceIterator) reduce() []{{$k.Name}}Point {
 	// Calculate next window.
 	startTime, endTime := itr.opt.Window(itr.input.peekTime())
 
-	var reduceOptions = reduceOptions{
-		startTime: startTime,
-		endTime:   endTime,
+	var reduceOptions = ReduceOptions{
+		StartTime: startTime,
 	}
 
 	// Group points by name and tagset.
@@ -778,7 +777,9 @@ func (itr *{{$k.name}}ReduceSliceIterator) reduce() []{{$k.Name}}Point {
 	// Reduce each set into a set of values.
 	results := make(map[string][]{{$k.Name}}Point)
 	for key, g := range groups {
-		a := itr.fn(g.points, &reduceOptions)
+		aggregator, emitter := itr.create()
+		aggregator.AggregateSlice(g.points)
+		a := emitter.Emit(&reduceOptions)
 		if len(a) == 0 {
 			continue
 		}
@@ -809,10 +810,7 @@ func (itr *{{$k.name}}ReduceSliceIterator) reduce() []{{$k.Name}}Point {
 	return a
 }
 
-// {{$k.name}}ReduceSliceFunc is the function called by a {{$k.Name}}Point slice reducer.
-type {{$k.name}}ReduceSliceFunc func(a []{{$k.Name}}Point, opt *reduceOptions) []{{$k.Name}}Point
-
-// {{$k.name}}ReduceIterator executes a function to modify an existing point for every
+// {{$k.name}}TransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type {{$k.name}}TransformIterator struct {
 	input {{$k.Name}}Iterator

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -941,15 +941,35 @@ func decodeInterval(pb *internal.Interval) Interval {
 }
 
 // reduceOptions represents options for performing reductions on windows of points.
-type reduceOptions struct {
-	startTime int64
-	endTime   int64
+type ReduceOptions struct {
+	StartTime int64
 }
 
 type nilFloatIterator struct{}
 
 func (*nilFloatIterator) Close() error      { return nil }
 func (*nilFloatIterator) Next() *FloatPoint { return nil }
+
+type integerFloatCastIterator struct {
+	input IntegerIterator
+}
+
+func (itr *integerFloatCastIterator) Close() error { return itr.input.Close() }
+func (itr *integerFloatCastIterator) Next() *FloatPoint {
+	p := itr.input.Next()
+	if p == nil {
+		return nil
+	}
+
+	return &FloatPoint{
+		Name:  p.Name,
+		Tags:  p.Tags,
+		Time:  p.Time,
+		Nil:   p.Nil,
+		Value: float64(p.Value),
+		Aux:   p.Aux,
+	}
+}
 
 // integerFloatTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
@@ -974,24 +994,3 @@ func (itr *integerFloatTransformIterator) Next() *FloatPoint {
 // The point passed in may be modified and returned rather than allocating a
 // new point if possible.
 type integerFloatTransformFunc func(p *IntegerPoint) *FloatPoint
-
-type integerFloatCastIterator struct {
-	input IntegerIterator
-}
-
-func (itr *integerFloatCastIterator) Close() error { return itr.input.Close() }
-func (itr *integerFloatCastIterator) Next() *FloatPoint {
-	p := itr.input.Next()
-	if p == nil {
-		return nil
-	}
-
-	return &FloatPoint{
-		Name:  p.Name,
-		Tags:  p.Tags,
-		Time:  p.Time,
-		Nil:   p.Nil,
-		Value: float64(p.Value),
-		Aux:   p.Aux,
-	}
-}


### PR DESCRIPTION
The change does effectively the same as the previous refactor the reduce function but for the slice typed functions. Names get a little long and hard to read but I think it still clear what it going on. 

The reason for even implementing these types is so that the state is stored on a reducer and the iterators become stateless. The statelessness of an iterator made composing various combination of int/float/etc simple. See the related Kapacitor PR https://github.com/influxdata/kapacitor/pull/280

Q: The derivative function uses a local prev value that is supposed to carry over from window to window, but that was not isolated by group, now since a new reducer is created each time it is lost entirely. A custom reducer should fix it, but wondering if I should implement per group or leave it how it was. Relevant line https://github.com/influxdata/influxdb/blob/master/influxql/call_iterator.go#L933

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

