### PR TITLE
Minor Build Updates

### DIFF
--- a/build.py
+++ b/build.py
@@ -531,6 +531,10 @@ def build_packages(build_output, version, nightly=False, rc=None, iteration=1):
                     package_build_root = build_root
                     current_location = build_output[platform][arch]
 
+                    if rc is not None:
+                        # Set iteration to 0 since it's a release candidate
+                        package_iteration = "0.rc{}".format(rc)
+
                     if package_type in ['zip', 'tar']:
                         # For tars and zips, start the packaging one folder above
                         # the build root (to include the package name)
@@ -551,10 +555,6 @@ def build_packages(build_output, version, nightly=False, rc=None, iteration=1):
                         current_location = os.path.join(current_location, name + '.tar.gz')
                     elif package_type == 'zip':
                         current_location = os.path.join(current_location, name + '.zip')
-
-                    if rc is not None:
-                        # Set iteration to 0 since it's a release candidate
-                        package_iteration = "0.rc{}".format(rc)
 
                     fpm_command = "fpm {} --name {} -a {} -t {} --version {} --iteration {} -C {} -p {} ".format(
                         fpm_common_args,

--- a/build.py
+++ b/build.py
@@ -377,7 +377,8 @@ def build(version=None,
           rc=None,
           race=False,
           clean=False,
-          outdir="."):
+          outdir=".",
+          tags=[]):
     print ""
     print "-------------------------"
     print ""
@@ -391,6 +392,8 @@ def build(version=None,
     print "- arch: {}".format(arch)
     print "- nightly? {}".format(str(nightly).lower())
     print "- race enabled? {}".format(str(race).lower())
+    if len(tags) > 0:
+        print "- build tags: {}".format(','.join(tags))
     print ""
 
     if not os.path.exists(outdir):
@@ -434,6 +437,8 @@ def build(version=None,
             build_command += "go build -o {} ".format(os.path.join(outdir, b))
         if race:
             build_command += "-race "
+        if len(tags) > 0:
+            build_command += "-tags {} ".format(','.join(tags))
         go_version = get_go_version()
         if "1.4" in go_version:
             build_command += "-ldflags=\"-X main.version {} -X main.branch {} -X main.commit {}\" ".format(version,
@@ -622,6 +627,7 @@ def print_package_summary(packages):
 
 def main():
     global debug
+    global PACKAGE_NAME
 
     # Command-line arguments
     outdir = "build"
@@ -646,6 +652,7 @@ def main():
     upload_bucket = None
     generate = False
     no_stash = False
+    build_tags = []
 
     for arg in sys.argv[1:]:
         if '--outdir' in arg:
@@ -713,6 +720,12 @@ def main():
             no_stash = True
         elif '--generate' in arg:
             generate = True
+        elif '--build-tags' in arg:
+            for t in arg.split("=")[1].split(","):
+                build_tags.append(t)
+        elif '--name' in arg:
+            # Change the output package name
+            PACKAGE_NAME = arg.split("=")[1]
         elif '--debug' in arg:
             print "[DEBUG] Using debug output"
             debug = True
@@ -808,7 +821,8 @@ def main():
                      rc=rc,
                      race=race,
                      clean=clean,
-                     outdir=od):
+                     outdir=od,
+                     tags=build_tags):
                 return 1
             build_output.get(platform).update( { arch : od } )
 

--- a/test.sh
+++ b/test.sh
@@ -131,30 +131,30 @@ fi
 case $ENVIRONMENT_INDEX in
     0)
         # 64 bit tests
-        run_test_docker Dockerfile_build_ubuntu64 test_64bit --debug --test
+        run_test_docker Dockerfile_build_ubuntu64 test_64bit --debug --generate --test
         rc=$?
         ;;
     1)
         # 64 bit tsm tests
         INFLUXDB_DATA_ENGINE="tsm1"
-        run_test_docker Dockerfile_build_ubuntu64 test_64bit_tsm --debug --test
+        run_test_docker Dockerfile_build_ubuntu64 test_64bit_tsm --debug --generate --test
         rc=$?
         ;;
     2)
         # 64 bit race tests
         GORACE="halt_on_error=1"
-        run_test_docker Dockerfile_build_ubuntu64 test_64bit_race --debug --test --race
+        run_test_docker Dockerfile_build_ubuntu64 test_64bit_race --debug --generate --test --race
         rc=$?
         ;;
     3)
         # 32 bit tests
-        run_test_docker Dockerfile_build_ubuntu32 test_32bit --debug --test
+        run_test_docker Dockerfile_build_ubuntu32 test_32bit --debug --generate --test
         rc=$?
         ;;
     4)
         # 64 bit tests on golang go1.6
         GO_CHECKOUT=go1.6
-        run_test_docker Dockerfile_build_ubuntu64_git test_64bit_go1.6 --debug --test --no-vet
+        run_test_docker Dockerfile_build_ubuntu64_git test_64bit_go1.6 --debug --generate --test --no-vet
         rc=$?
         ;;
     "save")


### PR DESCRIPTION
- Added `--generate` call to circle tests to identify outdated static assets
- Changed `GOARM` value from `arm64` to `7`
- Switched order of 'generate' and 'get' commands
- Fixed bug where release candidate wasn't applied to tar or zip output
- Adds a `--build-tags=<tag1>[,<tag2>...]` flag for including build flags
- Adds a `--name=<package name>` flag to control the name of the produced package