### PR TITLE
Fix possible deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.12.0 [unreleased]
+
+### Features
+
+### Bugfixes
+
+- [#5963](https://github.com/influxdata/influxdb/pull/5963): Fix possible deadlock
+
 ## v0.11.0 [unreleased]
 
 ### Features

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -38,9 +38,6 @@ type Engine interface {
 	DeleteMeasurement(name string, seriesKeys []string) error
 	SeriesCount() (n int, err error)
 
-	// PerformMaintenance will get called periodically by the store
-	PerformMaintenance()
-
 	// Format will return the format for the engine
 	Format() EngineFormat
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -102,10 +102,6 @@ func NewEngine(path string, walPath string, opt tsdb.EngineOptions) tsdb.Engine 
 // Path returns the path the engine was opened with.
 func (e *Engine) Path() string { return e.path }
 
-// PerformMaintenance is for periodic maintenance of the store. A no-op for b1
-func (e *Engine) PerformMaintenance() {
-}
-
 // Index returns the database index.
 func (e *Engine) Index() *tsdb.DatabaseIndex {
 	e.mu.Lock()

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -306,6 +306,9 @@ func (d *DatabaseIndex) measurementsByTagFilters(filters []*TagFilter) Measureme
 
 // measurementsByRegex returns the measurements that match the regex.
 func (d *DatabaseIndex) measurementsByRegex(re *regexp.Regexp) Measurements {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	var matches Measurements
 	for _, m := range d.measurements {
 		if re.MatchString(m.Name) {

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -304,8 +304,8 @@ func (d *DatabaseIndex) measurementsByTagFilters(filters []*TagFilter) Measureme
 	return measurements
 }
 
-// measurementsByRegex returns the measurements that match the regex.
-func (d *DatabaseIndex) measurementsByRegex(re *regexp.Regexp) Measurements {
+// MeasurementsByRegex returns the measurements that match the regex.
+func (d *DatabaseIndex) MeasurementsByRegex(re *regexp.Regexp) Measurements {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -122,12 +122,6 @@ func NewShard(id uint64, index *DatabaseIndex, path string, walPath string, opti
 // Path returns the path set on the shard when it was created.
 func (s *Shard) Path() string { return s.path }
 
-// PerformMaintenance gets called periodically to have the engine perform
-// any maintenance tasks like WAL flushing and compaction
-func (s *Shard) PerformMaintenance() {
-	s.engine.PerformMaintenance()
-}
-
 // Open initializes and opens the shard's store.
 func (s *Shard) Open() error {
 	if err := func() error {

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -605,8 +605,8 @@ func (s *Store) performMaintenanceOnShard(shard *Shard) {
 // ExpandSources expands regex sources and removes duplicates.
 // NOTE: sources must be normalized (db and rp set) before calling this function.
 func (s *Store) ExpandSources(sources influxql.Sources) (influxql.Sources, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.expandSources(sources)
 }
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -595,7 +595,7 @@ func (s *Store) expandSources(sources influxql.Sources) (influxql.Sources, error
 			}
 
 			// Loop over matching measurements.
-			for _, m := range db.measurementsByRegex(src.Regex.Val) {
+			for _, m := range db.MeasurementsByRegex(src.Regex.Val) {
 				other := &influxql.Measurement{
 					Database:        src.Database,
 					RetentionPolicy: src.RetentionPolicy,


### PR DESCRIPTION
In a load test env, writes started timing out in and filling up hinted handoff queues.  The traces show a hundreds of write goroutines blocked trying to acquire the `tsdb.Store` read lock.  There were a few other goroutines stuck trying to acquire the `tsdb.Store` write lock in the periodic maintenance goroutine and during expanding sources during a query.

This change removes the maintenance goroutine because it is not used by `tsm` engine and just ends up locking the whole `tsdb.Store` periocially.  This also switches the write lock taken during expanding sources to a read lock since that code only ever reads fields on the `tsdb.Store`.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
