### PR TITLE
Format initial logging

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -67,6 +67,10 @@ func (cmd *Command) Run(args ...string) error {
 	// Print sweet InfluxDB logo.
 	fmt.Print(logo)
 
+	// Configure default logging.
+	log.SetPrefix("[run] ")
+	log.SetFlags(log.LstdFlags)
+
 	// Set parallelism.
 	runtime.GOMAXPROCS(runtime.NumCPU())
 


### PR DESCRIPTION
Trival fix-up to logging at startup. Was:
```
2016/03/10 17:06:26 InfluxDB starting, version unknown, branch unknown, commit unknown
2016/03/10 17:06:26 Go version go1.5.2, GOMAXPROCS set to 8
2016/03/10 17:06:26 no configuration provided, using default settings
[meta] 2016/03/10 17:06:26 Starting meta service
[meta] 2016/03/10 17:06:26 Listening on HTTP: [::]:8091
[metastore] 2016/03/10 17:10:46 Using data dir: /Users/philipotoole/.influxdb/meta
```
is now: 
```
[run] 2016/03/10 17:10:46 InfluxDB starting, version unknown, branch unknown, commit unknown
[run] 2016/03/10 17:10:46 Go version go1.5.2, GOMAXPROCS set to 8
[run] 2016/03/10 17:10:46 no configuration provided, using default settings
[meta] 2016/03/10 17:10:46 Starting meta service
[meta] 2016/03/10 17:10:46 Listening on HTTP: [::]:8091
[metastore] 2016/03/10 17:10:46 Using data dir: /Users/philipotoole/.influxdb/meta
```
(The very first log messages are now formatted identically).
