### PR TITLE
Add DROP SHARD support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- [#5985](https://github.com/influxdata/influxdb/pull/5985): Add DROP SHARD support.
+
 ### Bugfixes
 
 ## v0.11.0 [unreleased]

--- a/cluster/meta_client.go
+++ b/cluster/meta_client.go
@@ -21,6 +21,7 @@ type MetaClient interface {
 	DataNodes() ([]meta.NodeInfo, error)
 	DeleteDataNode(id uint64) error
 	DeleteMetaNode(id uint64) error
+	DropShard(id uint64) error
 	DropContinuousQuery(database, name string) error
 	DropDatabase(name string) error
 	DropRetentionPolicy(database, name string) error

--- a/cluster/meta_client_test.go
+++ b/cluster/meta_client_test.go
@@ -25,6 +25,7 @@ type MetaClient struct {
 	DropDatabaseFn                      func(name string) error
 	DropRetentionPolicyFn               func(database, name string) error
 	DropSubscriptionFn                  func(database, rp, name string) error
+	DropShardFn                         func(id uint64) error
 	DropUserFn                          func(name string) error
 	MetaNodesFn                         func() ([]meta.NodeInfo, error)
 	RetentionPolicyFn                   func(database, name string) (rpi *meta.RetentionPolicyInfo, err error)
@@ -97,6 +98,10 @@ func (c *MetaClient) DropDatabase(name string) error {
 
 func (c *MetaClient) DropRetentionPolicy(database, name string) error {
 	return c.DropRetentionPolicyFn(database, name)
+}
+
+func (c *MetaClient) DropShard(id uint64) error {
+	return c.DropShardFn(id)
 }
 
 func (c *MetaClient) DropSubscription(database, rp, name string) error {

--- a/cluster/query_executor_test.go
+++ b/cluster/query_executor_test.go
@@ -193,6 +193,7 @@ type TSDBStore struct {
 	DeleteDatabaseFn                func(name string) error
 	DeleteMeasurementFn             func(database, name string) error
 	DeleteRetentionPolicyFn         func(database, name string) error
+	DeleteShardFn                   func(id uint64) error
 	DeleteSeriesFn                  func(database string, sources []influxql.Source, condition influxql.Expr) error
 	ExecuteShowFieldKeysStatementFn func(stmt *influxql.ShowFieldKeysStatement, database string) (models.Rows, error)
 	ExecuteShowTagValuesStatementFn func(stmt *influxql.ShowTagValuesStatement, database string) (models.Rows, error)
@@ -221,6 +222,10 @@ func (s *TSDBStore) DeleteMeasurement(database, name string) error {
 
 func (s *TSDBStore) DeleteRetentionPolicy(database, name string) error {
 	return s.DeleteRetentionPolicyFn(database, name)
+}
+
+func (s *TSDBStore) DeleteShard(id uint64) error {
+	return s.DeleteShardFn(id)
 }
 
 func (s *TSDBStore) DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr) error {

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -228,6 +228,8 @@ func (s *Service) executeStatement(stmt influxql.Statement, database string) err
 		return s.TSDBStore.DeleteSeries(database, t.Sources, t.Condition)
 	case *influxql.DropRetentionPolicyStatement:
 		return s.TSDBStore.DeleteRetentionPolicy(database, t.Name)
+	case *influxql.DropShardStatement:
+		return s.TSDBStore.DeleteShard(t.ID)
 	default:
 		return fmt.Errorf("%q should not be executed across a cluster", stmt.String())
 	}

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -103,6 +103,7 @@ func (*DropMeasurementStatement) node()       {}
 func (*DropRetentionPolicyStatement) node()   {}
 func (*DropSeriesStatement) node()            {}
 func (*DropServerStatement) node()            {}
+func (*DropShardStatement) node()             {}
 func (*DropSubscriptionStatement) node()      {}
 func (*DropUserStatement) node()              {}
 func (*GrantStatement) node()                 {}
@@ -214,6 +215,7 @@ func (*DropMeasurementStatement) stmt()       {}
 func (*DropRetentionPolicyStatement) stmt()   {}
 func (*DropSeriesStatement) stmt()            {}
 func (*DropServerStatement) stmt()            {}
+func (*DropShardStatement) stmt()             {}
 func (*DropSubscriptionStatement) stmt()      {}
 func (*DropUserStatement) stmt()              {}
 func (*GrantStatement) stmt()                 {}
@@ -2105,6 +2107,30 @@ func (s *DropServerStatement) String() string {
 // RequiredPrivileges returns the privilege required to execute a DropServerStatement.
 func (s *DropServerStatement) RequiredPrivileges() ExecutionPrivileges {
 	return ExecutionPrivileges{{Name: "", Privilege: AllPrivileges}}
+}
+
+// DropShardStatement represents a command for removing a shard from
+// the node.
+type DropShardStatement struct {
+	// ID of the shard to be dropped.
+	ID uint64
+
+	// Meta indicates if the server being dropped is a meta or data node
+	Meta bool
+}
+
+// String returns a string representation of the drop series statement.
+func (s *DropShardStatement) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("DROP SHARD ")
+	buf.WriteString(strconv.FormatUint(s.ID, 10))
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege required to execute a
+// DropShardStatement.
+func (s *DropShardStatement) RequiredPrivileges() ExecutionPrivileges {
+	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}
 }
 
 // ShowContinuousQueriesStatement represents a command for listing continuous queries.

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1767,7 +1767,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `CREATE CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 25`},
 		{s: `CREATE CONTINUOUS QUERY cq ON db RESAMPLE FOR 5s BEGIN SELECT mean(value) INTO cpu_mean FROM cpu GROUP BY time(10s) END`, err: `FOR duration must be >= GROUP BY time duration: must be a minimum of 10s, got 5s`},
 		{s: `CREATE CONTINUOUS QUERY cq ON db RESAMPLE EVERY 10s FOR 5s BEGIN SELECT mean(value) INTO cpu_mean FROM cpu GROUP BY time(5s) END`, err: `FOR duration must be >= GROUP BY time duration: must be a minimum of 10s, got 5s`},
-		{s: `DROP FOO`, err: `found FOO, expected SERIES, CONTINUOUS, MEASUREMENT, SERVER, SUBSCRIPTION at line 1, char 6`},
+		{s: `DROP FOO`, err: `found FOO, expected CONTINUOUS, DATA, MEASUREMENT, META, RETENTION, SERIES, SHARD, SUBSCRIPTION, USER at line 1, char 6`},
 		{s: `CREATE FOO`, err: `found FOO, expected CONTINUOUS, DATABASE, USER, RETENTION, SUBSCRIPTION at line 1, char 8`},
 		{s: `CREATE DATABASE`, err: `found EOF, expected identifier at line 1, char 17`},
 		{s: `CREATE DATABASE "testdb" WITH`, err: `found EOF, expected DURATION, REPLICATION, NAME at line 1, char 31`},

--- a/services/copier/internal/internal.pb.go
+++ b/services/copier/internal/internal.pb.go
@@ -54,3 +54,8 @@ func (m *Response) GetError() string {
 	}
 	return ""
 }
+
+func init() {
+	proto.RegisterType((*Request)(nil), "internal.Request")
+	proto.RegisterType((*Response)(nil), "internal.Response")
+}

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -715,6 +715,15 @@ func (c *Client) ShardsByTimeRange(sources influxql.Sources, tmin, tmax time.Tim
 	return a, nil
 }
 
+// DropShard deletes a shard by ID.
+func (c *Client) DropShard(id uint64) error {
+	cmd := &internal.DropShardCommand{
+		ID: proto.Uint64(id),
+	}
+
+	return c.retryUntilExec(internal.Command_DropShardCommand, internal.E_DropShardCommand_Command, cmd)
+}
+
 // CreateShardGroup creates a shard group on a database and policy for a given timestamp.
 func (c *Client) CreateShardGroup(database, policy string, timestamp time.Time) (*ShardGroupInfo, error) {
 	if sg, _ := c.data().ShardGroupByTimestamp(database, policy, timestamp); sg != nil {

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -497,6 +497,38 @@ func (data *Data) SetDefaultRetentionPolicy(database, name string) error {
 	return nil
 }
 
+// DropShard removes a shard by ID.
+func (data *Data) DropShard(id uint64) error {
+	found := -1
+	for dbidx, dbi := range data.Databases {
+		for rpidx, rpi := range dbi.RetentionPolicies {
+			for sgidx, sg := range rpi.ShardGroups {
+				for sidx, s := range sg.Shards {
+					if s.ID == id {
+						found = sidx
+						break
+					}
+				}
+
+				if found > -1 {
+					shards := sg.Shards
+					data.Databases[dbidx].RetentionPolicies[rpidx].ShardGroups[sgidx].Shards = append(shards[:found], shards[found+1:]...)
+
+					if len(shards) == 1 {
+						// We just deleted the last shard in the shard group.
+						data.Databases[dbidx].RetentionPolicies[rpidx].ShardGroups[sgidx].DeletedAt = time.Now()
+					}
+					return nil
+				}
+			}
+		}
+	}
+	// Don't return an error if the shard can't be found. This allows
+	// the command to be re-run in the case that the meta store succeeds
+	// but a data node fails (and the command need to be re-run).
+	return nil
+}
+
 // ShardGroups returns a list of all shard groups on a database and policy.
 func (data *Data) ShardGroups(database, policy string) ([]ShardGroupInfo, error) {
 	// Find retention policy.

--- a/services/meta/internal/meta.pb.go
+++ b/services/meta/internal/meta.pb.go
@@ -50,6 +50,7 @@ It has these top-level messages:
 	DeleteDataNodeCommand
 	Response
 	SetMetaNodeCommand
+	DropShardCommand
 */
 package internal
 
@@ -93,6 +94,7 @@ const (
 	Command_DeleteMetaNodeCommand            Command_Type = 27
 	Command_DeleteDataNodeCommand            Command_Type = 28
 	Command_SetMetaNodeCommand               Command_Type = 29
+	Command_DropShardCommand                 Command_Type = 30
 )
 
 var Command_Type_name = map[int32]string{
@@ -124,6 +126,7 @@ var Command_Type_name = map[int32]string{
 	27: "DeleteMetaNodeCommand",
 	28: "DeleteDataNodeCommand",
 	29: "SetMetaNodeCommand",
+	30: "DropShardCommand",
 }
 var Command_Type_value = map[string]int32{
 	"CreateNodeCommand":                1,
@@ -154,6 +157,7 @@ var Command_Type_value = map[string]int32{
 	"DeleteMetaNodeCommand":            27,
 	"DeleteDataNodeCommand":            28,
 	"SetMetaNodeCommand":               29,
+	"DropShardCommand":                 30,
 }
 
 func (x Command_Type) Enum() *Command_Type {
@@ -1657,6 +1661,30 @@ var E_SetMetaNodeCommand_Command = &proto.ExtensionDesc{
 	Tag:           "bytes,129,opt,name=command",
 }
 
+type DropShardCommand struct {
+	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *DropShardCommand) Reset()         { *m = DropShardCommand{} }
+func (m *DropShardCommand) String() string { return proto.CompactTextString(m) }
+func (*DropShardCommand) ProtoMessage()    {}
+
+func (m *DropShardCommand) GetID() uint64 {
+	if m != nil && m.ID != nil {
+		return *m.ID
+	}
+	return 0
+}
+
+var E_DropShardCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*DropShardCommand)(nil),
+	Field:         130,
+	Name:          "internal.DropShardCommand.command",
+	Tag:           "bytes,130,opt,name=command",
+}
+
 func init() {
 	proto.RegisterType((*Data)(nil), "internal.Data")
 	proto.RegisterType((*NodeInfo)(nil), "internal.NodeInfo")
@@ -1699,6 +1727,7 @@ func init() {
 	proto.RegisterType((*DeleteDataNodeCommand)(nil), "internal.DeleteDataNodeCommand")
 	proto.RegisterType((*Response)(nil), "internal.Response")
 	proto.RegisterType((*SetMetaNodeCommand)(nil), "internal.SetMetaNodeCommand")
+	proto.RegisterType((*DropShardCommand)(nil), "internal.DropShardCommand")
 	proto.RegisterEnum("internal.Command_Type", Command_Type_name, Command_Type_value)
 	proto.RegisterExtension(E_CreateNodeCommand_Command)
 	proto.RegisterExtension(E_DeleteNodeCommand_Command)
@@ -1728,4 +1757,5 @@ func init() {
 	proto.RegisterExtension(E_DeleteMetaNodeCommand_Command)
 	proto.RegisterExtension(E_DeleteDataNodeCommand_Command)
 	proto.RegisterExtension(E_SetMetaNodeCommand_Command)
+	proto.RegisterExtension(E_DropShardCommand_Command)
 }

--- a/services/meta/internal/meta.proto
+++ b/services/meta/internal/meta.proto
@@ -19,15 +19,15 @@ message Data {
 	required uint64 MaxShardGroupID = 8;
 	required uint64 MaxShardID = 9;
 
-    // added for 0.10.0
-    repeated NodeInfo DataNodes = 10;
-    repeated NodeInfo MetaNodes = 11;
+	// added for 0.10.0
+	repeated NodeInfo DataNodes = 10;
+	repeated NodeInfo MetaNodes = 11;
 }
 
 message NodeInfo {
 	required uint64 ID = 1;
 	required string Host = 2;
-    optional string TCPHost = 3;
+	optional string TCPHost = 3;
 }
 
 message DatabaseInfo {
@@ -55,9 +55,9 @@ message ShardGroupInfo {
 }
 
 message ShardInfo {
-    required uint64 ID = 1;
-    repeated uint64 OwnerIDs = 2 [deprecated=true];
-    repeated ShardOwner Owners = 3;
+	required uint64 ID = 1;
+	repeated uint64 OwnerIDs = 2 [deprecated=true];
+	repeated ShardOwner Owners = 3;
 }
 
 message SubscriptionInfo{
@@ -67,7 +67,7 @@ message SubscriptionInfo{
 }
 
 message ShardOwner {
-    required uint64 NodeID = 1;
+	required uint64 NodeID = 1;
 }
 
 message ContinuousQueryInfo {
@@ -95,9 +95,9 @@ message UserPrivilege {
 //========================================================================
 
 message Command {
-    extensions 100 to max;
+	extensions 100 to max;
 
-    enum Type {
+	enum Type {
 		CreateNodeCommand                = 1;
 		DeleteNodeCommand                = 2;
 		CreateDatabaseCommand            = 3;
@@ -126,72 +126,73 @@ message Command {
 		DeleteMetaNodeCommand            = 27;
 		DeleteDataNodeCommand            = 28;
 		SetMetaNodeCommand               = 29;
-    }
+		DropShardCommand               = 30;
+	}
 
-    required Type type = 1;
+	required Type type = 1;
 }
 
 // This isn't used in >= 0.10.0. Kept around for upgrade purposes. Instead
 // look at CreateDataNodeCommand and CreateMetaNodeCommand
 message CreateNodeCommand {
-    extend Command {
-        optional CreateNodeCommand command = 101;
-    }
+	extend Command {
+		optional CreateNodeCommand command = 101;
+	}
 	required string Host = 1;
 	required uint64 Rand = 2;
 }
 
 message DeleteNodeCommand {
-    extend Command {
-        optional DeleteNodeCommand command = 102;
-    }
+	extend Command {
+		optional DeleteNodeCommand command = 102;
+	}
 	required uint64 ID = 1;
 	required bool Force = 2;
 }
 
 message CreateDatabaseCommand {
-    extend Command {
-        optional CreateDatabaseCommand command = 103;
-    }
+	extend Command {
+		optional CreateDatabaseCommand command = 103;
+	}
 	required string Name = 1;
 	optional RetentionPolicyInfo RetentionPolicy = 2;
 }
 
 message DropDatabaseCommand {
-    extend Command {
-        optional DropDatabaseCommand command = 104;
-    }
+	extend Command {
+		optional DropDatabaseCommand command = 104;
+	}
 	required string Name = 1;
 }
 
 message CreateRetentionPolicyCommand {
-    extend Command {
-        optional CreateRetentionPolicyCommand command = 105;
-    }
+	extend Command {
+		optional CreateRetentionPolicyCommand command = 105;
+	}
 	required string Database = 1;
 	required RetentionPolicyInfo RetentionPolicy = 2;
 }
 
 message DropRetentionPolicyCommand {
-    extend Command {
-        optional DropRetentionPolicyCommand command = 106;
-    }
+	extend Command {
+		optional DropRetentionPolicyCommand command = 106;
+	}
 	required string Database = 1;
 	required string Name = 2;
 }
 
 message SetDefaultRetentionPolicyCommand {
-    extend Command {
-        optional SetDefaultRetentionPolicyCommand command = 107;
-    }
+	extend Command {
+		optional SetDefaultRetentionPolicyCommand command = 107;
+	}
 	required string Database = 1;
 	required string Name = 2;
 }
 
 message UpdateRetentionPolicyCommand {
-    extend Command {
-        optional UpdateRetentionPolicyCommand command = 108;
-    }
+	extend Command {
+		optional UpdateRetentionPolicyCommand command = 108;
+	}
 	required string Database = 1;
 	required string Name = 2;
 	optional string NewName = 3;
@@ -200,163 +201,163 @@ message UpdateRetentionPolicyCommand {
 }
 
 message CreateShardGroupCommand {
-    extend Command {
-        optional CreateShardGroupCommand command = 109;
-    }
-    required string Database = 1;
-    required string Policy = 2;
-    required int64 Timestamp = 3;
+	extend Command {
+		optional CreateShardGroupCommand command = 109;
+	}
+	required string Database = 1;
+	required string Policy = 2;
+	required int64 Timestamp = 3;
 }
 
 message DeleteShardGroupCommand {
-    extend Command {
-        optional DeleteShardGroupCommand command = 110;
-    }
-    required string Database = 1;
-    required string Policy = 2;
-    required uint64 ShardGroupID = 3;
+	extend Command {
+		optional DeleteShardGroupCommand command = 110;
+	}
+	required string Database = 1;
+	required string Policy = 2;
+	required uint64 ShardGroupID = 3;
 }
 
 message CreateContinuousQueryCommand {
-    extend Command {
-        optional CreateContinuousQueryCommand command = 111;
-    }
-    required string Database = 1;
-    required string Name = 2;
-    required string Query = 3;
+	extend Command {
+		optional CreateContinuousQueryCommand command = 111;
+	}
+	required string Database = 1;
+	required string Name = 2;
+	required string Query = 3;
 }
 
 message DropContinuousQueryCommand {
-    extend Command {
-        optional DropContinuousQueryCommand command = 112;
-    }
-    required string Database = 1;
-    required string Name = 2;
+	extend Command {
+		optional DropContinuousQueryCommand command = 112;
+	}
+	required string Database = 1;
+	required string Name = 2;
 }
 
 message CreateUserCommand {
-    extend Command {
-        optional CreateUserCommand command = 113;
-    }
-    required string Name = 1;
-    required string Hash = 2;
-    required bool Admin = 3;
+	extend Command {
+		optional CreateUserCommand command = 113;
+	}
+	required string Name = 1;
+	required string Hash = 2;
+	required bool Admin = 3;
 }
 
 message DropUserCommand {
-    extend Command {
-        optional DropUserCommand command = 114;
-    }
-    required string Name = 1;
+	extend Command {
+		optional DropUserCommand command = 114;
+	}
+	required string Name = 1;
 }
 
 message UpdateUserCommand {
-    extend Command {
-        optional UpdateUserCommand command = 115;
-    }
-    required string Name = 1;
-    required string Hash = 2;
+	extend Command {
+		optional UpdateUserCommand command = 115;
+	}
+	required string Name = 1;
+	required string Hash = 2;
 }
 
 message SetPrivilegeCommand {
-    extend Command {
-        optional SetPrivilegeCommand command = 116;
-    }
-    required string Username = 1;
-    required string Database = 2;
-    required int32 Privilege = 3;
+	extend Command {
+		optional SetPrivilegeCommand command = 116;
+	}
+	required string Username = 1;
+	required string Database = 2;
+	required int32 Privilege = 3;
 }
 
 message SetDataCommand {
-    extend Command {
-        optional SetDataCommand command = 117;
-    }
-    required Data Data = 1;
+	extend Command {
+		optional SetDataCommand command = 117;
+	}
+	required Data Data = 1;
 }
 
 message SetAdminPrivilegeCommand {
-    extend Command {
-        optional SetAdminPrivilegeCommand command = 118;
-    }
-    required string Username = 1;
-    required bool Admin = 2;
+	extend Command {
+		optional SetAdminPrivilegeCommand command = 118;
+	}
+	required string Username = 1;
+	required bool Admin = 2;
 }
 
 message UpdateNodeCommand {
-    extend Command {
-        optional UpdateNodeCommand command = 119;
-    }
-    required uint64 ID = 1;
-    required string Host = 2;
+	extend Command {
+		optional UpdateNodeCommand command = 119;
+	}
+	required uint64 ID = 1;
+	required string Host = 2;
 }
 
 message CreateSubscriptionCommand {
-    extend Command {
-        optional CreateSubscriptionCommand command = 121;
-    }
-    required string Name = 1;
-    required string Database = 2;
-    required string RetentionPolicy = 3;
-    required string Mode = 4;
-    repeated string Destinations = 5;
+	extend Command {
+		optional CreateSubscriptionCommand command = 121;
+	}
+	required string Name = 1;
+	required string Database = 2;
+	required string RetentionPolicy = 3;
+	required string Mode = 4;
+	repeated string Destinations = 5;
 
 }
 
 message DropSubscriptionCommand {
-    extend Command {
-        optional DropSubscriptionCommand command = 122;
-    }
-    required string Name = 1;
-    required string Database = 2;
-    required string RetentionPolicy = 3;
+	extend Command {
+		optional DropSubscriptionCommand command = 122;
+	}
+	required string Name = 1;
+	required string Database = 2;
+	required string RetentionPolicy = 3;
 }
 
 message RemovePeerCommand {
-    extend Command {
-        optional RemovePeerCommand command = 123;
-    }
+	extend Command {
+		optional RemovePeerCommand command = 123;
+	}
 	optional uint64 ID = 1;
 	required string Addr = 2;
 }
 
 message CreateMetaNodeCommand {
-    extend Command {
-        optional CreateMetaNodeCommand command = 124;
-    }
-    required string HTTPAddr = 1;
-    required string TCPAddr = 2;
-    required uint64 Rand = 3;
+	extend Command {
+		optional CreateMetaNodeCommand command = 124;
+	}
+	required string HTTPAddr = 1;
+	required string TCPAddr = 2;
+	required uint64 Rand = 3;
 }
 
 message CreateDataNodeCommand {
-    extend Command {
-        optional CreateDataNodeCommand command = 125;
-    }
-    required string HTTPAddr = 1;
-    required string TCPAddr = 2;
+	extend Command {
+		optional CreateDataNodeCommand command = 125;
+	}
+	required string HTTPAddr = 1;
+	required string TCPAddr = 2;
 }
 
 message UpdateDataNodeCommand {
-    extend Command {
-        optional UpdateDataNodeCommand command = 126;
-    }
-    required uint64 ID = 1;
-    required string Host = 2;
-    required string TCPHost = 3;
+	extend Command {
+		optional UpdateDataNodeCommand command = 126;
+	}
+	required uint64 ID = 1;
+	required string Host = 2;
+	required string TCPHost = 3;
 }
 
 message DeleteMetaNodeCommand {
-    extend Command {
-        optional DeleteMetaNodeCommand command = 127;
-    }
-    required uint64 ID = 1;
+	extend Command {
+		optional DeleteMetaNodeCommand command = 127;
+	}
+	required uint64 ID = 1;
 }
 
 message DeleteDataNodeCommand {
-    extend Command {
-        optional DeleteDataNodeCommand command = 128;
-    }
-    required uint64 ID = 1;
+	extend Command {
+		optional DeleteDataNodeCommand command = 128;
+	}
+	required uint64 ID = 1;
 }
 
 message Response {
@@ -368,10 +369,17 @@ message Response {
 // SetMetaNodeCommand is for the initial metanode in a cluster or
 // if the single host restarts and its hostname changes, this will update it
 message SetMetaNodeCommand {
-    extend Command {
-        optional SetMetaNodeCommand command = 129;
-    }
-    required string HTTPAddr = 1;
-    required string TCPAddr = 2;
-    required uint64 Rand = 3;
+	extend Command {
+		optional SetMetaNodeCommand command = 129;
+	}
+	required string HTTPAddr = 1;
+	required string TCPAddr = 2;
+	required uint64 Rand = 3;
+}
+
+message DropShardCommand {
+	extend Command {
+		optional DropShardCommand command = 130;
+	}
+	required uint64 ID = 1;
 }

--- a/services/meta/service_test.go
+++ b/services/meta/service_test.go
@@ -625,6 +625,85 @@ func TestMetaService_Subscriptions_Drop(t *testing.T) {
 	}
 }
 
+func TestMetaService_DropShard(t *testing.T) {
+	t.Parallel()
+
+	d, s, c := newServiceAndClient()
+	defer os.RemoveAll(d)
+	defer s.Close()
+	defer c.Close()
+
+	// Attempting to delete a shard that doesn't exist has no side
+	// effects and does not result in an error.
+	if err := c.DropShard(134); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.CreateDataNode("foo1:8180", "foo1:8181"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.CreateDataNode("foo2:8180", "foo2:8181"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := c.CreateDatabaseWithRetentionPolicy("db0", &meta.RetentionPolicyInfo{Name: "rp0", ReplicaN: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a shard group. Due to replication factor on rp0 it should
+	// have two shards.
+	tme := time.Now().Add(time.Hour)
+	sg, err := c.CreateShardGroup("db0", "rp0", tme)
+	if err != nil {
+		t.Fatal(err)
+	} else if sg == nil {
+		t.Fatalf("expected ShardGroup")
+	}
+
+	ids := c.ShardIDs()
+	if len(ids) < 2 {
+		t.Fatalf("Only %d shards, should be 2", len(ids))
+	}
+
+	// When we delete a shard, it should be removed from the shard group
+	id0 := ids[0]
+	if err := c.DropShard(id0); err != nil {
+		t.Fatal(err)
+	} else if got, exp := c.ShardIDs(), ids[1:]; !reflect.DeepEqual(got, exp) {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Since the shard group has another shard it should still be active
+	sgs, err := c.ShardGroupsByTimeRange("db0", "rp0", tme, tme)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(sgs) != 1 {
+		t.Fatalf("got %d shard groups, expected %d", len(sgs), 1)
+	}
+
+	if sgs[0].Deleted() {
+		t.Fatal("shard group has been deleted")
+	}
+
+	// Delete the last shard in the group, it should be removed from
+	// the shard group.
+	id1 := ids[1]
+	if err := c.DropShard(id1); err != nil {
+		t.Fatal(err)
+	} else if got, exp := c.ShardIDs(), []uint64(nil); !reflect.DeepEqual(got, exp) {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Since that's the last shard, the shard group should be marked as
+	// deleted.
+	if sgs, err = c.ShardGroupsByTimeRange("db0", "rp0", tme, tme); err != nil {
+		t.Fatal(err)
+	} else if len(sgs) > 0 {
+		t.Fatalf("got shard group %v, but should not have got one", sgs)
+	}
+}
+
 func TestMetaService_Shards(t *testing.T) {
 	t.Parallel()
 

--- a/tsdb/internal/meta.pb.go
+++ b/tsdb/internal/meta.pb.go
@@ -120,3 +120,10 @@ func (m *Field) GetType() int32 {
 	}
 	return 0
 }
+
+func init() {
+	proto.RegisterType((*Series)(nil), "internal.Series")
+	proto.RegisterType((*Tag)(nil), "internal.Tag")
+	proto.RegisterType((*MeasurementFields)(nil), "internal.MeasurementFields")
+	proto.RegisterType((*Field)(nil), "internal.Field")
+}


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Addresses #5935.

The new `DROP SHARD i` command takes the ID of the shard and drops it
from both the meta store, and on all data nodes. Shard data is deleted
on nodes owning the shard.

If the shard to be deleted is the last shard in the shard group,
then the shard group is marked as deleted.

Attempting to delete a shard that does not exist will not return an
error.