### PR TITLE
Add host name to default meta server instead of just port :8091

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - [#5949](https://github.com/influxdata/influxdb/issues/5949): Return error message when improper types are used in SELECT
 - [#5963](https://github.com/influxdata/influxdb/pull/5963): Fix possible deadlock
 - [#4688](https://github.com/influxdata/influxdb/issues/4688): admin UI doesn't display results for some SHOW queries
+- [#5848](https://github.com/influxdata/influxdb/issues/5848): Default setup of Influxd does not work in windows due to missing hostname in meta link
 
 ## v0.10.2 [2016-03-03]
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -629,7 +629,7 @@ func (s *Server) initializeMetaClient() error {
 		if s.MetaService == nil {
 			return fmt.Errorf("server not set to join existing cluster must run also as a meta node")
 		}
-		s.MetaClient.SetMetaServers([]string{s.MetaService.HTTPAddr()})
+		s.MetaClient.SetMetaServers([]string{s.MetaService.RemoteHTTPAddr()})
 		s.MetaClient.SetTLS(s.metaUseTLS)
 	} else {
 		// join this node to the cluster

--- a/services/meta/service.go
+++ b/services/meta/service.go
@@ -179,6 +179,11 @@ func (s *Service) HTTPAddr() string {
 	return s.httpAddr
 }
 
+// RemoteHTTPAddr returns the bind address for the HTTP API with host name
+func (s *Service) RemoteHTTPAddr() string {
+	return s.remoteAddr(s.httpAddr)
+}
+
 // RaftAddr returns the bind address for the Raft TCP listener
 func (s *Service) RaftAddr() string {
 	return s.raftAddr


### PR DESCRIPTION
- [Yes] CHANGELOG.md updated
- [ Yes] Rebased/mergable
- [ Yes] Tests pass
- [ Yes] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

 Windows does not like URL's without host names,getSnapshot (`Get http://:8091?index=0`) results in error ( `ConnectEx tcp: The requested address is not valid in its context.`). The fix is to add hostname to the URL. It was done while adding list of servers to meta service.

Have tested in both windows and debian Linux, no breaking changes in Linux, and now build works without a config change in windows. Fixes #5848.
