### PR TITLE
Properly handle semi-colons as part of the main query loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugfixes
 
 - [#5152](https://github.com/influxdata/influxdb/issues/5152): Fix where filters when a tag and a filter are combined with OR.
+- [#5728](https://github.com/influxdata/influxdb/issues/5728): Properly handle semi-colons as part of the main query loop.
 
 ## v0.11.0 [unreleased]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -63,14 +63,17 @@ func MustParseExpr(s string) Expr {
 // ParseQuery parses an InfluxQL string and returns a Query AST object.
 func (p *Parser) ParseQuery() (*Query, error) {
 	var statements Statements
-	var semi bool
+	semi := true
 
 	for {
-		if tok, _, _ := p.scanIgnoreWhitespace(); tok == EOF {
+		if tok, pos, lit := p.scanIgnoreWhitespace(); tok == EOF {
 			return &Query{Statements: statements}, nil
-		} else if !semi && tok == SEMICOLON {
+		} else if tok == SEMICOLON {
 			semi = true
 		} else {
+			if !semi {
+				return nil, newParseError(tokstr(tok, lit), []string{";"}, pos)
+			}
 			p.unscan()
 			s, err := p.ParseStatement()
 			if err != nil {

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -51,6 +51,13 @@ func TestParser_ParseQuery_ParseError(t *testing.T) {
 	}
 }
 
+func TestParser_ParseQuery_NoSemicolon(t *testing.T) {
+	_, err := influxql.NewParser(strings.NewReader(`CREATE DATABASE foo CREATE DATABASE bar`)).ParseQuery()
+	if err == nil || err.Error() != `found CREATE, expected ; at line 1, char 21` {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
 // Ensure the parser can parse strings into Statement ASTs.
 func TestParser_ParseStatement(t *testing.T) {
 	// For use in various tests.


### PR DESCRIPTION
Semi-colons are now processed correctly as part of the grammar and newlines,
when used at the end of a command, will be treated as a semi-colon.

Fixes #5728.