### PR TITLE
Fix deadlock when running backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - [#5949](https://github.com/influxdata/influxdb/issues/5949): Return error message when improper types are used in SELECT
 - [#5963](https://github.com/influxdata/influxdb/pull/5963): Fix possible deadlock
 - [#4688](https://github.com/influxdata/influxdb/issues/4688): admin UI doesn't display results for some SHOW queries
+- [#6006](https://github.com/influxdata/influxdb/pull/6006): Fix deadlock while running backups
 
 ## v0.10.2 [2016-03-03]
 

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -91,7 +91,14 @@ func TestCacheRace(t *testing.T) {
 	go func() {
 		wg.Done()
 		<-ch
-		s := c.Snapshot()
+		s, err := c.Snapshot()
+		if err == tsm1.ErrSnapshotInProgress {
+			return
+		}
+
+		if err != nil {
+			t.Fatalf("failed to snapshot cache: %v", err)
+		}
 		s.Deduplicate()
 		c.ClearSnapshot(true)
 	}()
@@ -138,7 +145,15 @@ func TestCacheRace2Compacters(t *testing.T) {
 		go func() {
 			wg.Done()
 			<-ch
-			s := c.Snapshot()
+			s, err := c.Snapshot()
+			if err == tsm1.ErrSnapshotInProgress {
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("failed to snapshot cache: %v", err)
+			}
+
 			mu.Lock()
 			mapFiles[fileCounter] = true
 			fileCounter++

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -148,7 +148,11 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Grab snapshot, and ensure it's as expected.
-	snapshot := c.Snapshot()
+	snapshot, err := c.Snapshot()
+	if err != nil {
+		t.Fatalf("failed to snapshot cache: %v", err)
+	}
+
 	expValues := Values{v0, v1, v2, v3}
 	if deduped := snapshot.values("foo"); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("snapshotted values for foo incorrect, exp: %v, got %v", expValues, deduped)
@@ -186,7 +190,10 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	// Create another snapshot
-	snapshot = c.Snapshot()
+	snapshot, err = c.Snapshot()
+	if err != nil {
+		t.Fatalf("failed to snapshot cache: %v", err)
+	}
 
 	if err := c.Write("foo", Values{v4, v5}); err != nil {
 		t.Fatalf("failed to write post-snap value, key foo to cache: %s", err.Error())
@@ -194,7 +201,10 @@ func TestCache_CacheSnapshot(t *testing.T) {
 
 	c.ClearSnapshot(true)
 
-	snapshot = c.Snapshot()
+	snapshot, err = c.Snapshot()
+	if err != nil {
+		t.Fatalf("failed to snapshot cache: %v", err)
+	}
 
 	if err := c.Write("foo", Values{v6, v7}); err != nil {
 		t.Fatalf("failed to write post-snap value, key foo to cache: %s", err.Error())
@@ -210,7 +220,10 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	c := NewCache(512, "")
 
 	// Grab snapshot, and ensure it's as expected.
-	snapshot := c.Snapshot()
+	snapshot, err := c.Snapshot()
+	if err != nil {
+		t.Fatalf("failed to snapshot cache: %v", err)
+	}
 	if deduped := snapshot.values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("snapshotted values for foo incorrect, exp: %v, got %v", nil, deduped)
 	}
@@ -244,7 +257,10 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	}
 
 	// Grab snapshot, write should still fail since we're still using the memory.
-	_ = c.Snapshot()
+	_, err := c.Snapshot()
+	if err != nil {
+		t.Fatalf("failed to snapshot cache: %v", err)
+	}
 	if err := c.Write("bar", Values{v1}); err != ErrCacheMemoryExceeded {
 		t.Fatalf("wrong error writing key bar to cache")
 	}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -439,7 +439,10 @@ func (e *Engine) WriteSnapshot() error {
 			return nil, nil, nil, err
 		}
 
-		snapshot := e.Cache.Snapshot()
+		snapshot, err := e.Cache.Snapshot()
+		if err != nil {
+			return nil, nil, nil, err
+		}
 
 		return segments, snapshot, e.Compactor.Clone(), nil
 	}()


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

A deadlock occurs under write load if a backup is run in between the
time when a snapshot compactions has snapshotted the cache and successfully
written it to disk.  The issus is that the second snapshot call will block
on the commit lock while it is holding the engine write lock.  This causes
all writes to block as well as prevents the currently runnign snapshot
compaction from completing because it needs to acquire a read-lock.

This PR removes the commit lock and just returns an error if a snapshot is
in progress to all any locks being held to be released.  The caller can determine
whether to retry or giveup.