### PR TITLE
Allow querying of system-like series

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -352,8 +352,19 @@ func (a *Sources) UnmarshalBinary(buf []byte) error {
 }
 
 // IsSystemName returns true if name is an internal system name.
-// System names are prefixed with an underscore.
-func IsSystemName(name string) bool { return strings.HasPrefix(name, "_") }
+func IsSystemName(name string) bool {
+	switch name {
+	case "_fieldKeys",
+		"_measurements",
+		"_series",
+		"_tagKey",
+		"_tagKeys",
+		"_tags":
+		return true
+	default:
+		return false
+	}
+}
 
 // SortField represents a field to sort results by.
 type SortField struct {

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -180,7 +180,7 @@ func (d *DatabaseIndex) measurementsByExpr(expr influxql.Expr) (Measurements, bo
 			// Match on name, if specified.
 			if tag.Val == "name" {
 				return d.measurementsByNameFilter(tf.Op, tf.Value, tf.Regex), true, nil
-			} else if strings.HasPrefix(tag.Val, "_") {
+			} else if influxql.IsSystemName(tag.Val) {
 				return nil, false, nil
 			}
 


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Internal system series start with an underscore prefix but
restricting this prevents users who already use an underscore
prefix in their series names.

Fixes #5870