### PR TITLE
DROP SHARD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- [#6012](https://github.com/influxdata/influxdb/pull/6012): Add DROP SHARD support.
+
 ### Bugfixes
 
 ## v0.11.0 [unreleased]

--- a/cluster/meta_client.go
+++ b/cluster/meta_client.go
@@ -17,6 +17,7 @@ type MetaClient interface {
 	CreateUser(name, password string, admin bool) (*meta.UserInfo, error)
 	Database(name string) (*meta.DatabaseInfo, error)
 	Databases() ([]meta.DatabaseInfo, error)
+	DropShard(id uint64) error
 	DropContinuousQuery(database, name string) error
 	DropDatabase(name string) error
 	DropRetentionPolicy(database, name string) error

--- a/cluster/meta_client_test.go
+++ b/cluster/meta_client_test.go
@@ -25,6 +25,7 @@ type MetaClient struct {
 	DropDatabaseFn                      func(name string) error
 	DropRetentionPolicyFn               func(database, name string) error
 	DropSubscriptionFn                  func(database, rp, name string) error
+	DropShardFn                         func(id uint64) error
 	DropUserFn                          func(name string) error
 	MetaNodesFn                         func() ([]meta.NodeInfo, error)
 	RetentionPolicyFn                   func(database, name string) (rpi *meta.RetentionPolicyInfo, err error)
@@ -53,6 +54,9 @@ func (c *MetaClient) CreateDatabaseWithRetentionPolicy(name string, rpi *meta.Re
 
 func (c *MetaClient) CreateRetentionPolicy(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error) {
 	return c.CreateRetentionPolicyFn(database, rpi)
+}
+func (c *MetaClient) DropShard(id uint64) error {
+	return c.DropShardFn(id)
 }
 
 func (c *MetaClient) CreateSubscription(database, rp, name, mode string, destinations []string) error {

--- a/cluster/query_executor.go
+++ b/cluster/query_executor.go
@@ -320,6 +320,16 @@ func (e *QueryExecutor) executeDropSeriesStatement(stmt *influxql.DropSeriesStat
 	return e.TSDBStore.DeleteSeries(database, stmt.Sources, stmt.Condition)
 }
 
+func (e *QueryExecutor) executeDropShardStatement(stmt *influxql.DropShardStatement) error {
+	// Remove the shard reference from the Meta Store.
+	if err := e.MetaClient.DropShard(stmt.ID); err != nil {
+		return err
+	}
+
+	// Locally delete the shard.
+	return e.TSDBStore.DeleteShard(stmt.ID)
+}
+
 func (e *QueryExecutor) executeDropRetentionPolicyStatement(stmt *influxql.DropRetentionPolicyStatement) error {
 	if err := e.MetaClient.DropRetentionPolicy(stmt.Database, stmt.Name); err != nil {
 		return err
@@ -877,6 +887,7 @@ type TSDBStore interface {
 	DeleteMeasurement(database, name string) error
 	DeleteRetentionPolicy(database, name string) error
 	DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr) error
+	DeleteShard(id uint64) error
 	ExecuteShowFieldKeysStatement(stmt *influxql.ShowFieldKeysStatement, database string) (models.Rows, error)
 	ExecuteShowTagValuesStatement(stmt *influxql.ShowTagValuesStatement, database string) (models.Rows, error)
 	ExpandSources(sources influxql.Sources) (influxql.Sources, error)

--- a/cluster/query_executor_test.go
+++ b/cluster/query_executor_test.go
@@ -124,6 +124,7 @@ type TSDBStore struct {
 	DeleteDatabaseFn                func(name string) error
 	DeleteMeasurementFn             func(database, name string) error
 	DeleteRetentionPolicyFn         func(database, name string) error
+	DeleteShardFn                   func(id uint64) error
 	DeleteSeriesFn                  func(database string, sources []influxql.Source, condition influxql.Expr) error
 	ExecuteShowFieldKeysStatementFn func(stmt *influxql.ShowFieldKeysStatement, database string) (models.Rows, error)
 	ExecuteShowTagValuesStatementFn func(stmt *influxql.ShowTagValuesStatement, database string) (models.Rows, error)
@@ -152,6 +153,10 @@ func (s *TSDBStore) DeleteMeasurement(database, name string) error {
 
 func (s *TSDBStore) DeleteRetentionPolicy(database, name string) error {
 	return s.DeleteRetentionPolicyFn(database, name)
+}
+
+func (s *TSDBStore) DeleteShard(id uint64) error {
+	return s.DeleteShardFn(id)
 }
 
 func (s *TSDBStore) DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr) error {

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -240,6 +240,8 @@ func (s *Service) executeStatement(stmt influxql.Statement, database string) err
 		return s.TSDBStore.DeleteSeries(database, t.Sources, t.Condition)
 	case *influxql.DropRetentionPolicyStatement:
 		return s.TSDBStore.DeleteRetentionPolicy(database, t.Name)
+	case *influxql.DropShardStatement:
+		return s.TSDBStore.DeleteShard(t.ID)
 	default:
 		return fmt.Errorf("%q should not be executed across a cluster", stmt.String())
 	}

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -103,6 +103,7 @@ func (*DropMeasurementStatement) node()       {}
 func (*DropRetentionPolicyStatement) node()   {}
 func (*DropSeriesStatement) node()            {}
 func (*DropServerStatement) node()            {}
+func (*DropShardStatement) node()             {}
 func (*DropSubscriptionStatement) node()      {}
 func (*DropUserStatement) node()              {}
 func (*GrantStatement) node()                 {}
@@ -229,6 +230,7 @@ func (*ShowSeriesStatement) stmt()            {}
 func (*ShowShardGroupsStatement) stmt()       {}
 func (*ShowShardsStatement) stmt()            {}
 func (*ShowStatsStatement) stmt()             {}
+func (*DropShardStatement) stmt()             {}
 func (*ShowSubscriptionsStatement) stmt()     {}
 func (*ShowDiagnosticsStatement) stmt()       {}
 func (*ShowTagKeysStatement) stmt()           {}
@@ -2132,6 +2134,30 @@ func (s *DropServerStatement) String() string {
 // RequiredPrivileges returns the privilege required to execute a DropServerStatement.
 func (s *DropServerStatement) RequiredPrivileges() ExecutionPrivileges {
 	return ExecutionPrivileges{{Name: "", Privilege: AllPrivileges}}
+}
+
+// DropShardStatement represents a command for removing a shard from
+// the node.
+type DropShardStatement struct {
+	// ID of the shard to be dropped.
+	ID uint64
+
+	// Meta indicates if the server being dropped is a meta or data node
+	Meta bool
+}
+
+// String returns a string representation of the drop series statement.
+func (s *DropShardStatement) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("DROP SHARD ")
+	buf.WriteString(strconv.FormatUint(s.ID, 10))
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege required to execute a
+// DropShardStatement.
+func (s *DropShardStatement) RequiredPrivileges() ExecutionPrivileges {
+	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}
 }
 
 // ShowContinuousQueriesStatement represents a command for listing continuous queries.

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1755,7 +1755,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `CREATE CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 25`},
 		{s: `CREATE CONTINUOUS QUERY cq ON db RESAMPLE FOR 5s BEGIN SELECT mean(value) INTO cpu_mean FROM cpu GROUP BY time(10s) END`, err: `FOR duration must be >= GROUP BY time duration: must be a minimum of 10s, got 5s`},
 		{s: `CREATE CONTINUOUS QUERY cq ON db RESAMPLE EVERY 10s FOR 5s BEGIN SELECT mean(value) INTO cpu_mean FROM cpu GROUP BY time(5s) END`, err: `FOR duration must be >= GROUP BY time duration: must be a minimum of 10s, got 5s`},
-		{s: `DROP FOO`, err: `found FOO, expected SERIES, CONTINUOUS, MEASUREMENT, SERVER, SUBSCRIPTION at line 1, char 6`},
+		{s: `DROP FOO`, err: `found FOO, expected CONTINUOUS, DATA, MEASUREMENT, META, RETENTION, SERIES, SHARD, SUBSCRIPTION, USER at line 1, char 6`},
 		{s: `CREATE FOO`, err: `found FOO, expected CONTINUOUS, DATABASE, USER, RETENTION, SUBSCRIPTION at line 1, char 8`},
 		{s: `CREATE DATABASE`, err: `found EOF, expected identifier at line 1, char 17`},
 		{s: `CREATE DATABASE "testdb" WITH`, err: `found EOF, expected DURATION, REPLICATION, NAME at line 1, char 31`},

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -683,6 +683,16 @@ func (c *Client) ShardsByTimeRange(sources influxql.Sources, tmin, tmax time.Tim
 	return a, nil
 }
 
+// DropShard deletes a shard by ID.
+func (c *Client) DropShard(id uint64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	data := c.cacheData.Clone()
+	data.DropShard(id)
+	return c.commit(data)
+}
+
 // CreateShardGroup creates a shard group on a database and policy for a given timestamp.
 func (c *Client) CreateShardGroup(database, policy string, timestamp time.Time) (*ShardGroupInfo, error) {
 	c.mu.Lock()

--- a/services/meta/internal/meta.pb.go
+++ b/services/meta/internal/meta.pb.go
@@ -50,6 +50,7 @@ It has these top-level messages:
 	DeleteDataNodeCommand
 	Response
 	SetMetaNodeCommand
+	DropShardCommand
 */
 package internal
 
@@ -93,6 +94,7 @@ const (
 	Command_DeleteMetaNodeCommand            Command_Type = 27
 	Command_DeleteDataNodeCommand            Command_Type = 28
 	Command_SetMetaNodeCommand               Command_Type = 29
+	Command_DropShardCommand                 Command_Type = 30
 )
 
 var Command_Type_name = map[int32]string{
@@ -124,6 +126,7 @@ var Command_Type_name = map[int32]string{
 	27: "DeleteMetaNodeCommand",
 	28: "DeleteDataNodeCommand",
 	29: "SetMetaNodeCommand",
+	30: "DropShardCommand",
 }
 var Command_Type_value = map[string]int32{
 	"CreateNodeCommand":                1,
@@ -154,6 +157,7 @@ var Command_Type_value = map[string]int32{
 	"DeleteMetaNodeCommand":            27,
 	"DeleteDataNodeCommand":            28,
 	"SetMetaNodeCommand":               29,
+	"DropShardCommand":                 30,
 }
 
 func (x Command_Type) Enum() *Command_Type {
@@ -1657,6 +1661,30 @@ var E_SetMetaNodeCommand_Command = &proto.ExtensionDesc{
 	Tag:           "bytes,129,opt,name=command",
 }
 
+type DropShardCommand struct {
+	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *DropShardCommand) Reset()         { *m = DropShardCommand{} }
+func (m *DropShardCommand) String() string { return proto.CompactTextString(m) }
+func (*DropShardCommand) ProtoMessage()    {}
+
+func (m *DropShardCommand) GetID() uint64 {
+	if m != nil && m.ID != nil {
+		return *m.ID
+	}
+	return 0
+}
+
+var E_DropShardCommand_Command = &proto.ExtensionDesc{
+	ExtendedType:  (*Command)(nil),
+	ExtensionType: (*DropShardCommand)(nil),
+	Field:         130,
+	Name:          "internal.DropShardCommand.command",
+	Tag:           "bytes,130,opt,name=command",
+}
+
 func init() {
 	proto.RegisterType((*Data)(nil), "internal.Data")
 	proto.RegisterType((*NodeInfo)(nil), "internal.NodeInfo")
@@ -1699,6 +1727,7 @@ func init() {
 	proto.RegisterType((*DeleteDataNodeCommand)(nil), "internal.DeleteDataNodeCommand")
 	proto.RegisterType((*Response)(nil), "internal.Response")
 	proto.RegisterType((*SetMetaNodeCommand)(nil), "internal.SetMetaNodeCommand")
+	proto.RegisterType((*DropShardCommand)(nil), "internal.DropShardCommand")
 	proto.RegisterEnum("internal.Command_Type", Command_Type_name, Command_Type_value)
 	proto.RegisterExtension(E_CreateNodeCommand_Command)
 	proto.RegisterExtension(E_DeleteNodeCommand_Command)
@@ -1728,4 +1757,5 @@ func init() {
 	proto.RegisterExtension(E_DeleteMetaNodeCommand_Command)
 	proto.RegisterExtension(E_DeleteDataNodeCommand_Command)
 	proto.RegisterExtension(E_SetMetaNodeCommand_Command)
+	proto.RegisterExtension(E_DropShardCommand_Command)
 }

--- a/services/meta/internal/meta.proto
+++ b/services/meta/internal/meta.proto
@@ -19,15 +19,15 @@ message Data {
 	required uint64 MaxShardGroupID = 8;
 	required uint64 MaxShardID = 9;
 
-    // added for 0.10.0
-    repeated NodeInfo DataNodes = 10;
-    repeated NodeInfo MetaNodes = 11;
+	// added for 0.10.0
+	repeated NodeInfo DataNodes = 10;
+	repeated NodeInfo MetaNodes = 11;
 }
 
 message NodeInfo {
 	required uint64 ID = 1;
 	required string Host = 2;
-    optional string TCPHost = 3;
+	optional string TCPHost = 3;
 }
 
 message DatabaseInfo {
@@ -55,9 +55,9 @@ message ShardGroupInfo {
 }
 
 message ShardInfo {
-    required uint64 ID = 1;
-    repeated uint64 OwnerIDs = 2 [deprecated=true];
-    repeated ShardOwner Owners = 3;
+	required uint64 ID = 1;
+	repeated uint64 OwnerIDs = 2 [deprecated=true];
+	repeated ShardOwner Owners = 3;
 }
 
 message SubscriptionInfo{
@@ -67,7 +67,7 @@ message SubscriptionInfo{
 }
 
 message ShardOwner {
-    required uint64 NodeID = 1;
+	required uint64 NodeID = 1;
 }
 
 message ContinuousQueryInfo {
@@ -95,9 +95,9 @@ message UserPrivilege {
 //========================================================================
 
 message Command {
-    extensions 100 to max;
+	extensions 100 to max;
 
-    enum Type {
+	enum Type {
 		CreateNodeCommand                = 1;
 		DeleteNodeCommand                = 2;
 		CreateDatabaseCommand            = 3;
@@ -126,72 +126,73 @@ message Command {
 		DeleteMetaNodeCommand            = 27;
 		DeleteDataNodeCommand            = 28;
 		SetMetaNodeCommand               = 29;
-    }
+		DropShardCommand                 = 30;
+	}
 
-    required Type type = 1;
+	required Type type = 1;
 }
 
 // This isn't used in >= 0.10.0. Kept around for upgrade purposes. Instead
 // look at CreateDataNodeCommand and CreateMetaNodeCommand
 message CreateNodeCommand {
-    extend Command {
-        optional CreateNodeCommand command = 101;
-    }
+	extend Command {
+		optional CreateNodeCommand command = 101;
+	}
 	required string Host = 1;
 	required uint64 Rand = 2;
 }
 
 message DeleteNodeCommand {
-    extend Command {
-        optional DeleteNodeCommand command = 102;
-    }
+	extend Command {
+		optional DeleteNodeCommand command = 102;
+	}
 	required uint64 ID = 1;
 	required bool Force = 2;
 }
 
 message CreateDatabaseCommand {
-    extend Command {
-        optional CreateDatabaseCommand command = 103;
-    }
+	extend Command {
+		optional CreateDatabaseCommand command = 103;
+	}
 	required string Name = 1;
 	optional RetentionPolicyInfo RetentionPolicy = 2;
 }
 
 message DropDatabaseCommand {
-    extend Command {
-        optional DropDatabaseCommand command = 104;
-    }
+	extend Command {
+		optional DropDatabaseCommand command = 104;
+	}
 	required string Name = 1;
 }
 
 message CreateRetentionPolicyCommand {
-    extend Command {
-        optional CreateRetentionPolicyCommand command = 105;
-    }
+	extend Command {
+		optional CreateRetentionPolicyCommand command = 105;
+	}
 	required string Database = 1;
 	required RetentionPolicyInfo RetentionPolicy = 2;
 }
 
 message DropRetentionPolicyCommand {
-    extend Command {
-        optional DropRetentionPolicyCommand command = 106;
-    }
+	extend Command {
+		optional DropRetentionPolicyCommand command = 106;
+	}
 	required string Database = 1;
 	required string Name = 2;
 }
 
 message SetDefaultRetentionPolicyCommand {
-    extend Command {
-        optional SetDefaultRetentionPolicyCommand command = 107;
-    }
+	extend Command {
+		optional SetDefaultRetentionPolicyCommand command = 107;
+	}
 	required string Database = 1;
 	required string Name = 2;
 }
 
 message UpdateRetentionPolicyCommand {
-    extend Command {
-        optional UpdateRetentionPolicyCommand command = 108;
-    }
+	extend Command {
+		optional UpdateRetentionPolicyCommand command = 108;
+	}
 	required string Database = 1;
 	required string Name = 2;
 	optional string NewName = 3;
@@ -200,163 +201,163 @@ message UpdateRetentionPolicyCommand {
 }
 
 message CreateShardGroupCommand {
-    extend Command {
-        optional CreateShardGroupCommand command = 109;
-    }
-    required string Database = 1;
-    required string Policy = 2;
-    required int64 Timestamp = 3;
+	extend Command {
+		optional CreateShardGroupCommand command = 109;
+	}
+	required string Database = 1;
+	required string Policy = 2;
+	required int64 Timestamp = 3;
 }
 
 message DeleteShardGroupCommand {
-    extend Command {
-        optional DeleteShardGroupCommand command = 110;
-    }
-    required string Database = 1;
-    required string Policy = 2;
-    required uint64 ShardGroupID = 3;
+	extend Command {
+		optional DeleteShardGroupCommand command = 110;
+	}
+	required string Database = 1;
+	required string Policy = 2;
+	required uint64 ShardGroupID = 3;
 }
 
 message CreateContinuousQueryCommand {
-    extend Command {
-        optional CreateContinuousQueryCommand command = 111;
-    }
-    required string Database = 1;
-    required string Name = 2;
-    required string Query = 3;
+	extend Command {
+		optional CreateContinuousQueryCommand command = 111;
+	}
+	required string Database = 1;
+	required string Name = 2;
+	required string Query = 3;
 }
 
 message DropContinuousQueryCommand {
-    extend Command {
-        optional DropContinuousQueryCommand command = 112;
-    }
-    required string Database = 1;
-    required string Name = 2;
+	extend Command {
+		optional DropContinuousQueryCommand command = 112;
+	}
+	required string Database = 1;
+	required string Name = 2;
 }
 
 message CreateUserCommand {
-    extend Command {
-        optional CreateUserCommand command = 113;
-    }
-    required string Name = 1;
-    required string Hash = 2;
-    required bool Admin = 3;
+	extend Command {
+		optional CreateUserCommand command = 113;
+	}
+	required string Name = 1;
+	required string Hash = 2;
+	required bool Admin = 3;
 }
 
 message DropUserCommand {
-    extend Command {
-        optional DropUserCommand command = 114;
-    }
-    required string Name = 1;
+	extend Command {
+		optional DropUserCommand command = 114;
+	}
+	required string Name = 1;
 }
 
 message UpdateUserCommand {
-    extend Command {
-        optional UpdateUserCommand command = 115;
-    }
-    required string Name = 1;
-    required string Hash = 2;
+	extend Command {
+		optional UpdateUserCommand command = 115;
+	}
+	required string Name = 1;
+	required string Hash = 2;
 }
 
 message SetPrivilegeCommand {
-    extend Command {
-        optional SetPrivilegeCommand command = 116;
-    }
-    required string Username = 1;
-    required string Database = 2;
-    required int32 Privilege = 3;
+	extend Command {
+		optional SetPrivilegeCommand command = 116;
+	}
+	required string Username = 1;
+	required string Database = 2;
+	required int32 Privilege = 3;
 }
 
 message SetDataCommand {
-    extend Command {
-        optional SetDataCommand command = 117;
-    }
-    required Data Data = 1;
+	extend Command {
+		optional SetDataCommand command = 117;
+	}
+	required Data Data = 1;
 }
 
 message SetAdminPrivilegeCommand {
-    extend Command {
-        optional SetAdminPrivilegeCommand command = 118;
-    }
-    required string Username = 1;
-    required bool Admin = 2;
+	extend Command {
+		optional SetAdminPrivilegeCommand command = 118;
+	}
+	required string Username = 1;
+	required bool Admin = 2;
 }
 
 message UpdateNodeCommand {
-    extend Command {
-        optional UpdateNodeCommand command = 119;
-    }
-    required uint64 ID = 1;
-    required string Host = 2;
+	extend Command {
+		optional UpdateNodeCommand command = 119;
+	}
+	required uint64 ID = 1;
+	required string Host = 2;
 }
 
 message CreateSubscriptionCommand {
-    extend Command {
-        optional CreateSubscriptionCommand command = 121;
-    }
-    required string Name = 1;
-    required string Database = 2;
-    required string RetentionPolicy = 3;
-    required string Mode = 4;
-    repeated string Destinations = 5;
+	extend Command {
+		optional CreateSubscriptionCommand command = 121;
+	}
+	required string Name = 1;
+	required string Database = 2;
+	required string RetentionPolicy = 3;
+	required string Mode = 4;
+	repeated string Destinations = 5;
 
 }
 
 message DropSubscriptionCommand {
-    extend Command {
-        optional DropSubscriptionCommand command = 122;
-    }
-    required string Name = 1;
-    required string Database = 2;
-    required string RetentionPolicy = 3;
+	extend Command {
+		optional DropSubscriptionCommand command = 122;
+	}
+	required string Name = 1;
+	required string Database = 2;
+	required string RetentionPolicy = 3;
 }
 
 message RemovePeerCommand {
-    extend Command {
-        optional RemovePeerCommand command = 123;
-    }
+	extend Command {
+		optional RemovePeerCommand command = 123;
+	}
 	optional uint64 ID = 1;
 	required string Addr = 2;
 }
 
 message CreateMetaNodeCommand {
-    extend Command {
-        optional CreateMetaNodeCommand command = 124;
-    }
-    required string HTTPAddr = 1;
-    required string TCPAddr = 2;
-    required uint64 Rand = 3;
+	extend Command {
+		optional CreateMetaNodeCommand command = 124;
+	}
+	required string HTTPAddr = 1;
+	required string TCPAddr = 2;
+	required uint64 Rand = 3;
 }
 
 message CreateDataNodeCommand {
-    extend Command {
-        optional CreateDataNodeCommand command = 125;
-    }
-    required string HTTPAddr = 1;
-    required string TCPAddr = 2;
+	extend Command {
+		optional CreateDataNodeCommand command = 125;
+	}
+	required string HTTPAddr = 1;
+	required string TCPAddr = 2;
 }
 
 message UpdateDataNodeCommand {
-    extend Command {
-        optional UpdateDataNodeCommand command = 126;
-    }
-    required uint64 ID = 1;
-    required string Host = 2;
-    required string TCPHost = 3;
+	extend Command {
+		optional UpdateDataNodeCommand command = 126;
+	}
+	required uint64 ID = 1;
+	required string Host = 2;
+	required string TCPHost = 3;
 }
 
 message DeleteMetaNodeCommand {
-    extend Command {
-        optional DeleteMetaNodeCommand command = 127;
-    }
-    required uint64 ID = 1;
+	extend Command {
+		optional DeleteMetaNodeCommand command = 127;
+	}
+	required uint64 ID = 1;
 }
 
 message DeleteDataNodeCommand {
-    extend Command {
-        optional DeleteDataNodeCommand command = 128;
-    }
-    required uint64 ID = 1;
+	extend Command {
+		optional DeleteDataNodeCommand command = 128;
+	}
+	required uint64 ID = 1;
 }
 
 message Response {
@@ -368,10 +369,17 @@ message Response {
 // SetMetaNodeCommand is for the initial metanode in a cluster or
 // if the single host restarts and its hostname changes, this will update it
 message SetMetaNodeCommand {
-    extend Command {
-        optional SetMetaNodeCommand command = 129;
-    }
-    required string HTTPAddr = 1;
-    required string TCPAddr = 2;
-    required uint64 Rand = 3;
+	extend Command {
+		optional SetMetaNodeCommand command = 129;
+	}
+	required string HTTPAddr = 1;
+	required string TCPAddr = 2;
+	required uint64 Rand = 3;
+}
+
+message DropShardCommand {
+	extend Command {
+		optional DropShardCommand command = 130;
+	}
+	required uint64 ID = 1;
 }


### PR DESCRIPTION
Addresses #5935.

The DROP SHARD command takes the ID of the shard and drops it
from both the meta store, and the data node. Shard data is deleted
on the node.

If the shard to be deleted is the last shard in the shard group,
then the shard group is marked as deleted.

Attempting to delete a shard that does not exist will _not_ return an
error.

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)