### PR TITLE
Remove deprecated JSON write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - [#6012](https://github.com/influxdata/influxdb/pull/6012): Add DROP SHARD support.
+- [#6025](https://github.com/influxdata/influxdb/pull/6025): Remove deprecated JSON write path.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -341,60 +341,6 @@ func TestServer_UserCommands(t *testing.T) {
 	}
 }
 
-// Ensure the server rejects a single point via json protocol by default.
-func TestServer_Write_JSON(t *testing.T) {
-	t.Parallel()
-	s := OpenServer(NewConfig())
-	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify writing JSON points returns an error.
-	now := now()
-	res, err := s.Write("", "", fmt.Sprintf(`{"database" : "db0", "retentionPolicy" : "rp0", "points": [{"measurement": "cpu", "tags": {"host": "server02"},"fields": {"value": 1.0}}],"time":"%s"} `, now.Format(time.RFC3339Nano)), nil)
-	if err == nil {
-		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", ``, res)
-	} else if exp := `JSON write protocol has been deprecated`; !strings.Contains(err.Error(), exp) {
-		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, err.Error())
-	}
-
-	// Verify no data has been written.
-	if res, err := s.Query(`SELECT * FROM db0.rp0.cpu GROUP BY *`); err != nil {
-		t.Fatal(err)
-	} else if exp := `{"results":[{}]}`; exp != res {
-		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, res)
-	}
-}
-
-// Ensure the server can create a single point via json protocol and read it back.
-func TestServer_Write_JSON_Enabled(t *testing.T) {
-	t.Parallel()
-	c := NewConfig()
-	c.HTTPD.JSONWriteEnabled = true
-	s := OpenServer(c)
-	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
-	now := now()
-	if res, err := s.Write("", "", fmt.Sprintf(`{"database" : "db0", "retentionPolicy" : "rp0", "points": [{"measurement": "cpu", "tags": {"host": "server02"},"fields": {"value": 1.0}}],"time":"%s"} `, now.Format(time.RFC3339Nano)), nil); err != nil {
-		t.Fatal(err)
-	} else if exp := ``; exp != res {
-		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, res)
-	}
-
-	// Verify the data was written.
-	if res, err := s.Query(`SELECT * FROM db0.rp0.cpu GROUP BY *`); err != nil {
-		t.Fatal(err)
-	} else if exp := fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","tags":{"host":"server02"},"columns":["time","value"],"values":[["%s",1]]}]}]}`, now.Format(time.RFC3339Nano)); exp != res {
-		t.Fatalf("unexpected results\nexp: %s\ngot: %s\n", exp, res)
-	}
-}
-
 // Ensure the server can create a single point via line protocol with float type and read it back.
 func TestServer_Write_LineProtocol_Float(t *testing.T) {
 	t.Parallel()

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -13,7 +13,6 @@ type Config struct {
 	PprofEnabled     bool   `toml:"pprof-enabled"`
 	HTTPSEnabled     bool   `toml:"https-enabled"`
 	HTTPSCertificate string `toml:"https-certificate"`
-	JSONWriteEnabled bool   `toml:"json-write-enabled"`
 }
 
 // NewConfig returns a new Config with default settings.
@@ -24,6 +23,5 @@ func NewConfig() Config {
 		LogEnabled:       true,
 		HTTPSEnabled:     false,
 		HTTPSCertificate: "/etc/ssl/influxdb.pem",
-		JSONWriteEnabled: false,
 	}
 }

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -64,7 +64,6 @@ func NewService(c Config) *Service {
 			c.AuthEnabled,
 			c.LogEnabled,
 			c.WriteTracing,
-			c.JSONWriteEnabled,
 			statMap,
 		),
 		Logger: log.New(os.Stderr, "[httpd] ", log.LstdFlags),


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Removes the JSON write path that was deprecated in v0.11.

Also checks that writes include a valid database before decoding points and removes the check for the `precision` URL parameter, which will always default to nanoseconds if not provided.