### PR TITLE
[0.11] Can't start cluster if peer hostname can't be resolved at startup

### DIFF
--- a/services/meta/store.go
+++ b/services/meta/store.go
@@ -77,11 +77,7 @@ func newStore(c *Config, httpAddr, raftAddr string) *store {
 func (s *store) open(raftln net.Listener) error {
 	s.logger.Printf("Using data dir: %v", s.path)
 
-	joinPeers, err := s.filterAddr(s.config.JoinPeers, s.httpAddr)
-	if err != nil {
-		return err
-	}
-	joinPeers = s.config.JoinPeers
+	joinPeers := s.config.JoinPeers
 
 	var initializePeers []string
 	if len(joinPeers) > 0 {


### PR DESCRIPTION
If starting InfluxDB with -join parameter and that some peer are not resolvable at InfluxDB startup, InfluxDB exit immedially:
```
node1$ influxd run -join node1:8091,node2:8091,node3:8091 -hostname $HOSTNAME
2016/03/16 14:35:41 InfluxDB starting, version 0.11.0rc1, branch 0.11, commit 441772e87782c27a679043071f7181f7928bfbb2
2016/03/16 14:35:41 Go version go1.4.3, GOMAXPROCS set to 4
2016/03/16 14:35:42 no configuration provided, using default settings
[meta] 2016/03/16 14:35:42 Starting meta service
[meta] 2016/03/16 14:35:42 Listening on HTTP: [::]:8091
[metastore] 2016/03/16 14:35:42 Using data dir: /root/.influxdb/meta
run: open server: open meta service: lookup node2: no such host
node1$
```

This is an issue with Docker cluster, the node1 container is created and start InfluxDB immedialy. Since node2 and node3 container are not yet started, node1 exit with the above error.

I've found that error comes from a call to filterAddr that try to resolve peers name. But if i'm not wrong, this call is useless, since just after we reassign another value to joinPeers.

So the PR simply remove this call to filterAddr, which solve my issue. Without this call, InfluxDB will wait to be able to contact node2 and node3, even if it can't initially resolve DNS name node2 or node3.
