### PR TITLE
Reduce allocations in query execution

### DIFF
--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -836,7 +836,11 @@ func (itr *floatReduceFloatIterator) reduce() []FloatPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -968,7 +972,11 @@ func (itr *floatReduceIntegerIterator) reduce() []IntegerPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -1100,7 +1108,11 @@ func (itr *floatReduceStringIterator) reduce() []StringPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -1232,7 +1244,11 @@ func (itr *floatReduceBooleanIterator) reduce() []BooleanPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -2271,7 +2287,11 @@ func (itr *integerReduceFloatIterator) reduce() []FloatPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -2403,7 +2423,11 @@ func (itr *integerReduceIntegerIterator) reduce() []IntegerPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -2535,7 +2559,11 @@ func (itr *integerReduceStringIterator) reduce() []StringPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -2667,7 +2695,11 @@ func (itr *integerReduceBooleanIterator) reduce() []BooleanPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -3706,7 +3738,11 @@ func (itr *stringReduceFloatIterator) reduce() []FloatPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -3838,7 +3874,11 @@ func (itr *stringReduceIntegerIterator) reduce() []IntegerPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -3970,7 +4010,11 @@ func (itr *stringReduceStringIterator) reduce() []StringPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -4102,7 +4146,11 @@ func (itr *stringReduceBooleanIterator) reduce() []BooleanPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -5141,7 +5189,11 @@ func (itr *booleanReduceFloatIterator) reduce() []FloatPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -5273,7 +5325,11 @@ func (itr *booleanReduceIntegerIterator) reduce() []IntegerPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -5405,7 +5461,11 @@ func (itr *booleanReduceStringIterator) reduce() []StringPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -5537,7 +5597,11 @@ func (itr *booleanReduceBooleanIterator) reduce() []BooleanPoint {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -685,10 +685,6 @@ func (itr *{{$k.name}}AuxIterator) SeriesKeys(opt IteratorOptions) (SeriesList, 
 	return nil, errors.New("not implemented")
 }
 
-func (itr *{{.name}}AuxIterator) ExpandSources(sources Sources) (Sources, error) {
-	return nil, errors.New("not implemented")
-}
-
 func (itr *{{.name}}AuxIterator) stream() {
 	for {
 		// Read next point.
@@ -837,7 +833,11 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() []{{$v.Name}}Point {
 			continue
 		}
 		tags := curr.Tags.Subset(itr.opt.Dimensions)
-		id := curr.Name + "\x00" + tags.ID()
+		
+		id := curr.Name
+		if len(tags.m) > 0 {
+			id += "\x00" + tags.ID()
+		}
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]

--- a/tsdb/engine/tsm1/bool.go
+++ b/tsdb/engine/tsm1/bool.go
@@ -17,12 +17,7 @@ const (
 )
 
 // BooleanEncoder encodes a series of booleans to an in-memory buffer.
-type BooleanEncoder interface {
-	Write(b bool)
-	Bytes() ([]byte, error)
-}
-
-type booleanEncoder struct {
+type BooleanEncoder struct {
 	// The encoded bytes
 	bytes []byte
 
@@ -38,10 +33,10 @@ type booleanEncoder struct {
 
 // NewBooleanEncoder returns a new instance of BooleanEncoder.
 func NewBooleanEncoder() BooleanEncoder {
-	return &booleanEncoder{}
+	return BooleanEncoder{}
 }
 
-func (e *booleanEncoder) Write(b bool) {
+func (e *BooleanEncoder) Write(b bool) {
 	// If we have filled the current byte, flush it
 	if e.i >= 8 {
 		e.flush()
@@ -60,7 +55,7 @@ func (e *booleanEncoder) Write(b bool) {
 	e.n++
 }
 
-func (e *booleanEncoder) flush() {
+func (e *BooleanEncoder) flush() {
 	// Pad remaining byte w/ 0s
 	for e.i < 8 {
 		e.b = e.b << 1
@@ -75,7 +70,7 @@ func (e *booleanEncoder) flush() {
 	}
 }
 
-func (e *booleanEncoder) Bytes() ([]byte, error) {
+func (e *BooleanEncoder) Bytes() ([]byte, error) {
 	// Ensure the current byte is flushed
 	e.flush()
 	b := make([]byte, 10+1)
@@ -92,13 +87,7 @@ func (e *booleanEncoder) Bytes() ([]byte, error) {
 }
 
 // BooleanDecoder decodes a series of booleans from an in-memory buffer.
-type BooleanDecoder interface {
-	Next() bool
-	Read() bool
-	Error() error
-}
-
-type booleanDecoder struct {
+type BooleanDecoder struct {
 	b   []byte
 	i   int
 	n   int
@@ -111,15 +100,15 @@ func NewBooleanDecoder(b []byte) BooleanDecoder {
 	// currently ignore for now.
 	b = b[1:]
 	count, n := binary.Uvarint(b)
-	return &booleanDecoder{b: b[n:], i: -1, n: int(count)}
+	return BooleanDecoder{b: b[n:], i: -1, n: int(count)}
 }
 
-func (e *booleanDecoder) Next() bool {
+func (e *BooleanDecoder) Next() bool {
 	e.i++
 	return e.i < e.n
 }
 
-func (e *booleanDecoder) Read() bool {
+func (e *BooleanDecoder) Read() bool {
 	// Index into the byte slice
 	idx := e.i / 8
 
@@ -136,6 +125,6 @@ func (e *booleanDecoder) Read() bool {
 	return v&mask == mask
 }
 
-func (e *booleanDecoder) Error() error {
+func (e *BooleanDecoder) Error() error {
 	return e.err
 }

--- a/tsdb/engine/tsm1/float.go
+++ b/tsdb/engine/tsm1/float.go
@@ -138,17 +138,17 @@ type FloatDecoder struct {
 	err error
 }
 
-func NewFloatDecoder(b []byte) (*FloatDecoder, error) {
+func NewFloatDecoder(b []byte) (FloatDecoder, error) {
 	// first byte is the compression type but we currently just have gorilla
 	// compression
 	br := bitstream.NewReader(bytes.NewReader(b[1:]))
 
 	v, err := br.ReadBits(64)
 	if err != nil {
-		return nil, err
+		return FloatDecoder{}, err
 	}
 
-	return &FloatDecoder{
+	return FloatDecoder{
 		val:   math.Float64frombits(v),
 		first: true,
 		br:    br,

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -498,9 +498,8 @@ func BenchmarkIntegerDecoderPackedSimple(b *testing.B) {
 	b.ResetTimer()
 
 	dec := NewIntegerDecoder(bytes)
-
 	for i := 0; i < b.N; i++ {
-		dec.(byteSetter).SetBytes(bytes)
+		dec.SetBytes(bytes)
 		for dec.Next() {
 		}
 	}
@@ -520,7 +519,7 @@ func BenchmarkIntegerDecoderRLE(b *testing.B) {
 	dec := NewIntegerDecoder(bytes)
 
 	for i := 0; i < b.N; i++ {
-		dec.(byteSetter).SetBytes(bytes)
+		dec.SetBytes(bytes)
 		for dec.Next() {
 		}
 	}

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -148,7 +148,8 @@ type TSMIndex interface {
 	ContainsValue(key string, timestamp int64) bool
 
 	// Entries returns all index entries for a key.
-	Entries(key string) []*IndexEntry
+	Entries(key string) []IndexEntry
+	ReadEntries(key string, entries *[]IndexEntry)
 
 	// Entry returns the index entry for the specified key and timestamp.  If no entry
 	// matches the key and timestamp, nil is returned.
@@ -158,7 +159,7 @@ type TSMIndex interface {
 	Keys() []string
 
 	// Key returns the key in the index at the given postion.
-	Key(index int) (string, []*IndexEntry)
+	Key(index int) (string, []IndexEntry)
 
 	// KeyAt returns the key in the index at the given postion.
 	KeyAt(index int) string
@@ -280,7 +281,7 @@ func (d *directIndex) Add(key string, blockType byte, minTime, maxTime int64, of
 		// size of the count of entries stored in the index
 		d.size += indexCountSize
 	}
-	entries.Append(&IndexEntry{
+	entries.entries = append(entries.entries, IndexEntry{
 		MinTime: minTime,
 		MaxTime: maxTime,
 		Offset:  offset,
@@ -291,7 +292,7 @@ func (d *directIndex) Add(key string, blockType byte, minTime, maxTime int64, of
 	d.size += indexEntrySize
 }
 
-func (d *directIndex) Entries(key string) []*IndexEntry {
+func (d *directIndex) Entries(key string) []IndexEntry {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -302,6 +303,10 @@ func (d *directIndex) Entries(key string) []*IndexEntry {
 	return d.blocks[key].entries
 }
 
+func (d *directIndex) ReadEntries(key string, entries *[]IndexEntry) {
+	*entries = d.Entries(key)
+}
+
 func (d *directIndex) Entry(key string, t int64) *IndexEntry {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
@@ -309,7 +314,7 @@ func (d *directIndex) Entry(key string, t int64) *IndexEntry {
 	entries := d.Entries(key)
 	for _, entry := range entries {
 		if entry.Contains(t) {
-			return entry
+			return &entry
 		}
 	}
 	return nil
@@ -354,7 +359,7 @@ func (d *directIndex) Keys() []string {
 	return keys
 }
 
-func (d *directIndex) Key(idx int) (string, []*IndexEntry) {
+func (d *directIndex) Key(idx int) (string, []IndexEntry) {
 	if idx < 0 || idx >= len(d.blocks) {
 		return "", nil
 	}
@@ -408,7 +413,7 @@ func (d *directIndex) addEntries(key string, entries *indexEntries) {
 		d.blocks[key] = entries
 		return
 	}
-	existing.Append(entries.entries...)
+	existing.entries = append(existing.entries, entries.entries...)
 }
 
 func (d *directIndex) Write(w io.Writer) error {
@@ -483,13 +488,14 @@ func (d *directIndex) UnmarshalBinary(b []byte) error {
 		}
 		pos += n
 
-		n, entries, err := readEntries(b[pos:])
+		var entries indexEntries
+		n, err = readEntries(b[pos:], &entries)
 		if err != nil {
 			return fmt.Errorf("readIndex: read entries error: %v", err)
 		}
 
 		pos += n
-		d.addEntries(string(key), entries)
+		d.addEntries(string(key), &entries)
 	}
 	return nil
 }


### PR DESCRIPTION
- [ ] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This pull request removes some heap objects by converting them from pointer references to non-pointers or by reusing buffers.

This reduced allocations for simple queries against high cardinality series by about a third.