### PR TITLE
Fix Issue#6042, #6030 CreateDatabase failure on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ There were some important breaking changes in this release. Here's a list of the
 - [#6006](https://github.com/influxdata/influxdb/pull/6006): Fix deadlock while running backups
 - [#5965](https://github.com/influxdata/influxdb/issues/5965): InfluxDB panic crashes while parsing "-" as Float
 - [#5835](https://github.com/influxdata/influxdb/issues/5835): Make CREATE USER default to IF NOT EXISTS
+- [#6042](https://github.com/influxdata/influxdb/issues/6042): CreateDatabase failure on Windows, regression from v0.11.0 RC @mvadu
 
 ## v0.10.3 [2016-03-09]
 

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -983,7 +983,7 @@ func snapshot(path string, data *Data) error {
 		return err
 	}
 
-	return os.Rename(tmpFile, file)
+	return renameFile(tmpFile, file)
 }
 
 // Load will save the current meta data from disk

--- a/services/meta/file_unix.go
+++ b/services/meta/file_unix.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package meta
+
+import "os"
+
+// renameFile will rename the source to target using os function.
+func renameFile(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}

--- a/services/meta/file_windows.go
+++ b/services/meta/file_windows.go
@@ -1,0 +1,16 @@
+// +build windows
+
+package meta
+
+import "os"
+
+// renameFile will rename the source to target using os function. If target exists it will be removed before renaming.
+func renameFile(oldpath, newpath string) error {
+	if _, err := os.Stat(newpath); err == nil {
+		if err = os.Remove(newpath); nil != err {
+			return err
+		}
+	}
+
+	return os.Rename(oldpath, newpath)
+}


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [X] Rebased/mergable
- [X] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Commit [27cfaa4](https://github.com/influxdata/influxdb/commit/27cfaa4b7a517364556cdd1a7225cab513784bc6#diff-1ab852c12e0bcdadffcaabf579a32345)  introduced a regression in `meta/client.go`, which made `CreateDatabase` calls to fail on windows. Root cause is the `[os.Rename](https://github.com/influxdata/influxdb/blob/27cfaa4b7a517364556cdd1a7225cab513784bc6/services/meta/client.go#L898)` in `func (c *Client) Snapshot()`. In Windows this fails when the file already exists. Fix is to remove the old file, and store the new file.

Fixes #6042, #6030 