### PR TITLE
Remove unused WAL configuration variables/fields

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -147,9 +147,6 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 
 	// Copy TSDB configuration.
 	s.TSDBStore.EngineOptions.EngineVersion = c.Data.Engine
-	s.TSDBStore.EngineOptions.MaxWALSize = c.Data.MaxWALSize
-	s.TSDBStore.EngineOptions.WALFlushInterval = time.Duration(c.Data.WALFlushInterval)
-	s.TSDBStore.EngineOptions.WALPartitionFlushDelay = time.Duration(c.Data.WALPartitionFlushDelay)
 
 	// Create the Subscriber service
 	s.Subscriber = subscriber.NewService(c.Subscriber)

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -69,36 +69,10 @@ reporting-disabled = false
 
   dir = "/var/lib/influxdb/data"
 
-  # The following WAL settings are for the b1 storage engine used in 0.9.2. They won't
-  # apply to any new shards created after upgrading to a version > 0.9.3.
-  max-wal-size = 104857600 # Maximum size the WAL can reach before a flush. Defaults to 100MB.
-  wal-flush-interval = "10m" # Maximum time data can sit in WAL before a flush.
-  wal-partition-flush-delay = "2s" # The delay time between each WAL partition being flushed.
-
   # These are the WAL settings for the storage engine >= 0.9.3
   wal-dir = "/var/lib/influxdb/wal"
   wal-logging-enabled = true
   data-logging-enabled = true
-
-  # When a series in the WAL in-memory cache reaches this size in bytes it is marked as ready to
-  # flush to the index
-  # wal-ready-series-size = 25600
-
-  # Flush and compact a partition once this ratio of series are over the ready size
-  # wal-compaction-threshold = 0.6
-
-  # Force a flush and compaction if any series in a partition gets above this size in bytes
-  # wal-max-series-size = 2097152
-
-  # Force a flush of all series and full compaction if there have been no writes in this
-  # amount of time. This is useful for ensuring that shards that are cold for writes don't
-  # keep a bunch of data cached in memory and in the WAL.
-  # wal-flush-cold-interval = "10m"
-
-  # Force a partition to flush its largest series if it reaches this approximate size in
-  # bytes. Remember there are 5 partitions so you'll need at least 5x this amount of memory.
-  # The more memory you have, the bigger this can be.
-  # wal-partition-size-threshold = 20971520
 
   # Whether queries should be logged before execution. Very useful for troubleshooting, but will
   # log any sensitive data contained within a query.

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -12,39 +12,7 @@ const (
 	// DefaultEngine is the default engine for new shards
 	DefaultEngine = "tsm1"
 
-	// DefaultMaxWALSize is the default size of the WAL before it is flushed.
-	DefaultMaxWALSize = 100 * 1024 * 1024 // 100MB
-
-	// DefaultWALFlushInterval is the frequency the WAL will get flushed if
-	// it doesn't reach its size threshold.
-	DefaultWALFlushInterval = 10 * time.Minute
-
-	// DefaultWALPartitionFlushDelay is the sleep time between WAL partition flushes.
-	DefaultWALPartitionFlushDelay = 2 * time.Second
-
 	// tsdb/engine/wal configuration options
-
-	// DefaultReadySeriesSize of 32KB specifies when a series is eligible to be flushed
-	DefaultReadySeriesSize = 30 * 1024
-
-	// DefaultCompactionThreshold flush and compact a partition once this ratio of keys are over the flush size
-	DefaultCompactionThreshold = 0.5
-
-	// DefaultMaxSeriesSize specifies the size at which a series will be forced to flush
-	DefaultMaxSeriesSize = 1024 * 1024
-
-	// DefaultFlushColdInterval specifies how long after a partition has been cold
-	// for writes that a full flush and compaction are forced
-	DefaultFlushColdInterval = 5 * time.Second
-
-	// DefaultPartitionSizeThreshold specifies when a partition gets to this size in
-	// memory, we should slow down writes until it gets a chance to compact.
-	// This will force clients to get backpressure if they're writing too fast. We need
-	// this because the WAL can take writes much faster than the index. So eventually
-	// we'll need to create backpressure, otherwise we'll fill up the memory and die.
-	// This number multiplied by the parition count is roughly the max possible memory
-	// size for the in-memory WAL cache.
-	DefaultPartitionSizeThreshold = 50 * 1024 * 1024 // 50MB
 
 	// Default settings for TSM
 
@@ -75,19 +43,9 @@ type Config struct {
 	Dir    string `toml:"dir"`
 	Engine string `toml:"engine"`
 
-	// WAL config options for b1 (introduced in 0.9.2)
-	MaxWALSize             int           `toml:"max-wal-size"`
-	WALFlushInterval       toml.Duration `toml:"wal-flush-interval"`
-	WALPartitionFlushDelay toml.Duration `toml:"wal-partition-flush-delay"`
-
-	// WAL configuration options for bz1 (introduced in 0.9.3)
-	WALDir                    string        `toml:"wal-dir"`
-	WALLoggingEnabled         bool          `toml:"wal-logging-enabled"`
-	WALReadySeriesSize        int           `toml:"wal-ready-series-size"`
-	WALCompactionThreshold    float64       `toml:"wal-compaction-threshold"`
-	WALMaxSeriesSize          int           `toml:"wal-max-series-size"`
-	WALFlushColdInterval      toml.Duration `toml:"wal-flush-cold-interval"`
-	WALPartitionSizeThreshold uint64        `toml:"wal-partition-size-threshold"`
+	// General WAL configuration options
+	WALDir            string `toml:"wal-dir"`
+	WALLoggingEnabled bool   `toml:"wal-logging-enabled"`
 
 	// Query logging
 	QueryLogEnabled bool `toml:"query-log-enabled"`
@@ -105,17 +63,9 @@ type Config struct {
 // NewConfig returns the default configuration for tsdb.
 func NewConfig() Config {
 	return Config{
-		Engine:                 DefaultEngine,
-		MaxWALSize:             DefaultMaxWALSize,
-		WALFlushInterval:       toml.Duration(DefaultWALFlushInterval),
-		WALPartitionFlushDelay: toml.Duration(DefaultWALPartitionFlushDelay),
+		Engine: DefaultEngine,
 
-		WALLoggingEnabled:         true,
-		WALReadySeriesSize:        DefaultReadySeriesSize,
-		WALCompactionThreshold:    DefaultCompactionThreshold,
-		WALMaxSeriesSize:          DefaultMaxSeriesSize,
-		WALFlushColdInterval:      toml.Duration(DefaultFlushColdInterval),
-		WALPartitionSizeThreshold: DefaultPartitionSizeThreshold,
+		WALLoggingEnabled: true,
 
 		QueryLogEnabled: true,
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -107,10 +107,7 @@ func NewEngine(path string, walPath string, options EngineOptions) (Engine, erro
 
 // EngineOptions represents the options used to initialize the engine.
 type EngineOptions struct {
-	EngineVersion          string
-	MaxWALSize             int
-	WALFlushInterval       time.Duration
-	WALPartitionFlushDelay time.Duration
+	EngineVersion string
 
 	Config Config
 }
@@ -118,11 +115,8 @@ type EngineOptions struct {
 // NewEngineOptions returns the default options.
 func NewEngineOptions() EngineOptions {
 	return EngineOptions{
-		EngineVersion:          DefaultEngine,
-		MaxWALSize:             DefaultMaxWALSize,
-		WALFlushInterval:       DefaultWALFlushInterval,
-		WALPartitionFlushDelay: DefaultWALPartitionFlushDelay,
-		Config:                 NewConfig(),
+		EngineVersion: DefaultEngine,
+		Config:        NewConfig(),
 	}
 }
 


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

These were all b1/bz1 settings that no longer have any effect:

- {Default,}MaxWALSize
- {Default,}WALFlushInterval
- {Default,}WALPartitionFlushDelay
- {Default,WAL}ReadySeriesSize
- {Default,WAL}CompactionThreshold
- {Default,WAL}MaxSeriesSize
- {Default,WAL}FlushColdInterval
- {Default,WAL}PartitionSizeThreshold