### PR TITLE
Wait for a process termination on influxdb restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [#5152](https://github.com/influxdata/influxdb/issues/5152): Fix where filters when a tag and a filter are combined with OR.
 - [#5728](https://github.com/influxdata/influxdb/issues/5728): Properly handle semi-colons as part of the main query loop.
+- [#6065](https://github.com/influxdata/influxdb/pull/6065):  Wait for a process termination on influxdb restart @simnv
 
 ## v0.11.0 [unreleased]
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -187,7 +187,14 @@ case $1 in
 
     restart)
         # Restart the daemon.
-        $0 stop && sleep 2 && $0 start
+        PID="$(pgrep -f $PIDFILE)"
+        $0 stop
+        while test ! -z $PID && test -d "/proc/$PID" &>/dev/null
+        do
+            echo "Process $PID is still running..."
+            sleep 1
+        done
+        $0 start
         ;;
 
     status)


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fixing "bind: address already in use" error in issue #6026