### PR TITLE
IteratorStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#6025](https://github.com/influxdata/influxdb/pull/6025): Remove deprecated JSON write path.
 - [#5744](https://github.com/influxdata/influxdb/issues/5744): Add integer literal support to the query language.
 - [#5939](https://github.com/influxdata/influxdb/issues/5939): Support viewing and killing running queries.
+- [#6073](https://github.com/influxdata/influxdb/pulls/6073): Iterator stats
 
 ### Bugfixes
 

--- a/cluster/query_executor_test.go
+++ b/cluster/query_executor_test.go
@@ -235,8 +235,8 @@ type FloatIterator struct {
 	Points []influxql.FloatPoint
 }
 
-// Close is a no-op.
-func (itr *FloatIterator) Close() error { return nil }
+func (itr *FloatIterator) Stats() influxql.IteratorStats { return influxql.IteratorStats{} }
+func (itr *FloatIterator) Close() error                  { return nil }
 
 // Next returns the next value and shifts it off the beginning of the points slice.
 func (itr *FloatIterator) Next() *influxql.FloatPoint {

--- a/influxql/internal/internal.pb.go
+++ b/influxql/internal/internal.pb.go
@@ -15,6 +15,7 @@ It has these top-level messages:
 	Measurements
 	Measurement
 	Interval
+	IteratorStats
 	Series
 	SeriesList
 */
@@ -28,17 +29,18 @@ var _ = proto.Marshal
 var _ = math.Inf
 
 type Point struct {
-	Name             *string  `protobuf:"bytes,1,req" json:"Name,omitempty"`
-	Tags             *string  `protobuf:"bytes,2,req" json:"Tags,omitempty"`
-	Time             *int64   `protobuf:"varint,3,req" json:"Time,omitempty"`
-	Nil              *bool    `protobuf:"varint,4,req" json:"Nil,omitempty"`
-	Aux              []*Aux   `protobuf:"bytes,5,rep" json:"Aux,omitempty"`
-	Aggregated       *uint32  `protobuf:"varint,6,opt" json:"Aggregated,omitempty"`
-	FloatValue       *float64 `protobuf:"fixed64,7,opt" json:"FloatValue,omitempty"`
-	IntegerValue     *int64   `protobuf:"varint,8,opt" json:"IntegerValue,omitempty"`
-	StringValue      *string  `protobuf:"bytes,9,opt" json:"StringValue,omitempty"`
-	BooleanValue     *bool    `protobuf:"varint,10,opt" json:"BooleanValue,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
+	Name             *string        `protobuf:"bytes,1,req" json:"Name,omitempty"`
+	Tags             *string        `protobuf:"bytes,2,req" json:"Tags,omitempty"`
+	Time             *int64         `protobuf:"varint,3,req" json:"Time,omitempty"`
+	Nil              *bool          `protobuf:"varint,4,req" json:"Nil,omitempty"`
+	Aux              []*Aux         `protobuf:"bytes,5,rep" json:"Aux,omitempty"`
+	Aggregated       *uint32        `protobuf:"varint,6,opt" json:"Aggregated,omitempty"`
+	FloatValue       *float64       `protobuf:"fixed64,7,opt" json:"FloatValue,omitempty"`
+	IntegerValue     *int64         `protobuf:"varint,8,opt" json:"IntegerValue,omitempty"`
+	StringValue      *string        `protobuf:"bytes,9,opt" json:"StringValue,omitempty"`
+	BooleanValue     *bool          `protobuf:"varint,10,opt" json:"BooleanValue,omitempty"`
+	Stats            *IteratorStats `protobuf:"bytes,11,opt" json:"Stats,omitempty"`
+	XXX_unrecognized []byte         `json:"-"`
 }
 
 func (m *Point) Reset()         { *m = Point{} }
@@ -113,6 +115,13 @@ func (m *Point) GetBooleanValue() bool {
 		return *m.BooleanValue
 	}
 	return false
+}
+
+func (m *Point) GetStats() *IteratorStats {
+	if m != nil {
+		return m.Stats
+	}
+	return nil
 }
 
 type Aux struct {
@@ -383,6 +392,30 @@ func (m *Interval) GetDuration() int64 {
 func (m *Interval) GetOffset() int64 {
 	if m != nil && m.Offset != nil {
 		return *m.Offset
+	}
+	return 0
+}
+
+type IteratorStats struct {
+	SeriesN          *int64 `protobuf:"varint,1,opt" json:"SeriesN,omitempty"`
+	PointN           *int64 `protobuf:"varint,2,opt" json:"PointN,omitempty"`
+	XXX_unrecognized []byte `json:"-"`
+}
+
+func (m *IteratorStats) Reset()         { *m = IteratorStats{} }
+func (m *IteratorStats) String() string { return proto.CompactTextString(m) }
+func (*IteratorStats) ProtoMessage()    {}
+
+func (m *IteratorStats) GetSeriesN() int64 {
+	if m != nil && m.SeriesN != nil {
+		return *m.SeriesN
+	}
+	return 0
+}
+
+func (m *IteratorStats) GetPointN() int64 {
+	if m != nil && m.PointN != nil {
+		return *m.PointN
 	}
 	return 0
 }

--- a/influxql/internal/internal.proto
+++ b/influxql/internal/internal.proto
@@ -12,6 +12,8 @@ message Point {
     optional int64  IntegerValue = 8;
     optional string StringValue  = 9;
     optional bool   BooleanValue = 10;
+
+    optional IteratorStats Stats = 11;
 }
 
 message Aux {
@@ -56,6 +58,11 @@ message Measurement {
 message Interval {
     optional int64 Duration = 1;
     optional int64 Offset   = 2;
+}
+
+message IteratorStats {
+    optional int64 SeriesN = 1;
+    optional int64 PointN  = 2;
 }
 
 message Series {

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -3,14 +3,20 @@ package influxql
 import (
 	"container/heap"
 	"errors"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"sort"
 	"sync"
 	"log"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/influxdata/influxdb/influxql/internal"
 )
+
+// DefaultStatsInterval is the default value for IteratorEncoder.StatsInterval.
+const DefaultStatsInterval = 10 * time.Second
 
 {{with $types := .}}{{range $k := $types}}
 
@@ -51,6 +57,9 @@ type buf{{$k.Name}}Iterator struct {
 func newBuf{{$k.Name}}Iterator(itr {{$k.Name}}Iterator) *buf{{$k.Name}}Iterator {
 	return &buf{{$k.Name}}Iterator{itr: itr}
 }
+
+// Stats returns statistics from the input iterator.
+func (itr *buf{{$k.Name}}Iterator) Stats() IteratorStats { return itr.itr.Stats() }
 
 // Close closes the underlying iterator.
 func (itr *buf{{$k.Name}}Iterator) Close() error { return itr.itr.Close() }
@@ -137,6 +146,15 @@ func new{{$k.Name}}MergeIterator(inputs []{{$k.Name}}Iterator, opt IteratorOptio
 	heap.Init(itr.heap)
 
 	return itr
+}
+
+// Stats returns an aggregation of stats from the underlying iterators.
+func (itr *{{$k.name}}MergeIterator) Stats() IteratorStats {
+	var stats IteratorStats
+	for _, input := range itr.inputs {
+		stats.Add(input.Stats())
+	}
+	return stats
 }
 
 // Close closes the underlying iterators.
@@ -281,6 +299,15 @@ func new{{$k.Name}}SortedMergeIterator(inputs []{{$k.Name}}Iterator, opt Iterato
 	return itr
 }
 
+// Stats returns an aggregation of stats from the underlying iterators.
+func (itr *{{$k.name}}SortedMergeIterator) Stats() IteratorStats {
+	var stats IteratorStats
+	for _, input := range itr.inputs {
+		stats.Add(input.Stats())
+	}
+	return stats
+}
+
 // Close closes the underlying iterators.
 func (itr *{{$k.name}}SortedMergeIterator) Close() error {
 	for _, input := range itr.inputs {
@@ -375,6 +402,9 @@ func new{{$k.Name}}LimitIterator(input {{$k.Name}}Iterator, opt IteratorOptions)
 		opt:   opt,
 	}
 }
+
+// Stats returns stats from the underlying iterator.
+func (itr *{{$k.name}}LimitIterator) Stats() IteratorStats { return itr.input.Stats() }
 
 // Close closes the underlying iterators.
 func (itr *{{$k.name}}LimitIterator) Close() error { return itr.input.Close() }
@@ -471,6 +501,7 @@ func new{{$k.Name}}FillIterator(input {{$k.Name}}Iterator, expr Expr, opt Iterat
 	return itr
 }
 
+func (itr *{{$k.name}}FillIterator) Stats() IteratorStats { return itr.input.Stats() }
 func (itr *{{$k.name}}FillIterator) Close() error { return itr.input.Close() }
 
 func (itr *{{$k.name}}FillIterator) Next() *{{$k.Name}}Point {
@@ -558,6 +589,7 @@ func new{{$k.Name}}IntervalIterator(input {{$k.Name}}Iterator, opt IteratorOptio
 	return &{{$k.name}}IntervalIterator{input: input, opt: opt}
 }
 
+func (itr *{{$k.name}}IntervalIterator) Stats() IteratorStats { return itr.input.Stats() }
 func (itr *{{$k.name}}IntervalIterator) Close() error { return itr.input.Close() }
 
 func (itr *{{$k.name}}IntervalIterator) Next() *{{$k.Name}}Point {
@@ -625,6 +657,7 @@ func (itr *{{$k.name}}AuxIterator) Background() {
 }
 
 func (itr *{{$k.name}}AuxIterator) Start()                        { go itr.stream() }
+func (itr *{{$k.name}}AuxIterator) Stats() IteratorStats          { return itr.input.Stats() }
 func (itr *{{$k.name}}AuxIterator) Close() error                  { return itr.input.Close() }
 func (itr *{{$k.name}}AuxIterator) Next() *{{$k.Name}}Point       { return <-itr.output }
 func (itr *{{$k.name}}AuxIterator) Iterator(name string) Iterator { return itr.fields.iterator(name) }
@@ -648,10 +681,6 @@ func (itr *{{$k.name}}AuxIterator) FieldDimensions(sources Sources) (fields, dim
 }
 
 func (itr *{{$k.name}}AuxIterator) SeriesKeys(opt IteratorOptions) (SeriesList, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (itr *{{.name}}AuxIterator) ExpandSources(sources Sources) (Sources, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -684,6 +713,8 @@ type {{$k.name}}ChanIterator struct {
 	cond *sync.Cond
 	done bool
 }
+
+func (itr *{{$k.name}}ChanIterator) Stats() IteratorStats { return IteratorStats{} }
 
 func (itr *{{$k.name}}ChanIterator) Close() error {
 	itr.cond.L.Lock()
@@ -757,6 +788,9 @@ type {{$k.name}}Reduce{{$v.Name}}Iterator struct {
 	opt    IteratorOptions
 	points []{{$v.Name}}Point
 }
+
+// Stats returns stats from the input iterator.
+func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) Stats() IteratorStats { return itr.input.Stats() }
 
 // Close closes the iterator and all child iterators.
 func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) Close() error { return itr.input.Close() }
@@ -852,6 +886,12 @@ type {{$k.name}}{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}ExprIterator struct {
 	fn    {{$k.name}}{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}ExprFunc
 }
 
+func (itr *{{$k.name}}{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}ExprIterator) Stats() IteratorStats {
+	stats := itr.left.Stats()
+	stats.Add(itr.right.Stats())
+	return stats
+}
+
 func (itr *{{$k.name}}{{if ne $k.Name $v.Name}}{{$v.Name}}{{end}}ExprIterator) Close() error {
 	itr.left.Close()
 	itr.right.Close()
@@ -881,6 +921,9 @@ type {{$k.name}}TransformIterator struct {
 	fn    {{$k.name}}TransformFunc
 }
 
+// Stats returns stats from the input iterator.
+func (itr *{{$k.name}}TransformIterator) Stats() IteratorStats { return itr.input.Stats() }
+
 // Close closes the iterator and all child iterators.
 func (itr *{{$k.name}}TransformIterator) Close() error { return itr.input.Close() }
 
@@ -904,6 +947,9 @@ type {{$k.name}}BoolTransformIterator struct {
 	input {{$k.Name}}Iterator
 	fn    {{$k.name}}BoolTransformFunc
 }
+
+// Stats returns stats from the input iterator.
+func (itr *{{$k.name}}BoolTransformIterator) Stats() IteratorStats { return itr.input.Stats() }
 
 // Close closes the iterator and all child iterators.
 func (itr *{{$k.name}}BoolTransformIterator) Close() error { return itr.input.Close() }
@@ -938,6 +984,9 @@ func new{{$k.Name}}DedupeIterator(input {{$k.Name}}Iterator) *{{$k.name}}DedupeI
 		m:     make(map[string]struct{}),
 	}
 }
+
+// Stats returns stats from the input iterator.
+func (itr *{{$k.name}}DedupeIterator) Stats() IteratorStats { return itr.input.Stats() }
 
 // Close closes the iterator and all child iterators.
 func (itr *{{$k.name}}DedupeIterator) Close() error { return itr.input.Close() }
@@ -977,13 +1026,19 @@ type {{$k.name}}ReaderIterator struct {
 }
 
 // new{{$k.Name}}ReaderIterator returns a new instance of {{$k.name}}ReaderIterator.
-func new{{$k.Name}}ReaderIterator(r io.Reader, first *{{$k.Name}}Point) *{{$k.name}}ReaderIterator {
+func new{{$k.Name}}ReaderIterator(r io.Reader, first *{{$k.Name}}Point, stats IteratorStats) *{{$k.name}}ReaderIterator {
+	dec := New{{$k.Name}}PointDecoder(r)
+	dec.stats = stats
+
 	return &{{$k.name}}ReaderIterator{
 		r:     r,
-		dec:   New{{$k.Name}}PointDecoder(r),
+		dec:   dec,
 		first: first,
 	}
 }
+
+// Stats returns stats about points processed.
+func (itr *{{$k.name}}ReaderIterator) Stats() IteratorStats { return itr.dec.stats }
 
 // Close closes the underlying reader, if applicable.
 func (itr *{{$k.name}}ReaderIterator) Close() error {
@@ -1020,11 +1075,18 @@ func (itr *{{$k.name}}ReaderIterator) Next() *{{$k.Name}}Point {
 // IteratorEncoder is an encoder for encoding an iterator's points to w.
 type IteratorEncoder struct {
 	w io.Writer
+
+	// Frequency with which stats are emitted.
+	StatsInterval time.Duration
 }
 
 // NewIteratorEncoder encodes an iterator's points to w.
 func NewIteratorEncoder(w io.Writer) *IteratorEncoder {
-	return &IteratorEncoder{w: w}
+	return &IteratorEncoder{
+		w: w,
+
+		StatsInterval: DefaultStatsInterval,
+	}
 }
 
 // Encode encodes and writes all of itr's points to the underlying writer.
@@ -1046,12 +1108,31 @@ func (enc *IteratorEncoder) EncodeIterator(itr Iterator) error {
 {{range .}}
 // encode{{.Name}}Iterator encodes all points from itr to the underlying writer.
 func (enc *IteratorEncoder) encode{{.Name}}Iterator(itr {{.Name}}Iterator) error {
+	ticker := time.NewTicker(enc.StatsInterval)
+	defer ticker.Stop()
+
+	// Emit initial stats.
+	if err := enc.encodeStats(itr.Stats()); err != nil {
+		return err
+	}
+
+	// Continually stream points from the iterator into the encoder.
 	penc := New{{.Name}}PointEncoder(enc.w)
 	for {
+		// Emit stats periodically.
+		select {
+		case <-ticker.C:
+			if err := enc.encodeStats(itr.Stats()); err != nil {
+				return err
+			}
+		default:
+		}
+		
+
 		// Retrieve the next point from the iterator.
 		p := itr.Next()
 		if p == nil {
-			return nil
+			break
 		}
 
 		// Write the point to the point encoder.
@@ -1059,6 +1140,37 @@ func (enc *IteratorEncoder) encode{{.Name}}Iterator(itr {{.Name}}Iterator) error
 			return err
 		}
 	}
+
+	// Emit final stats.
+	if err := enc.encodeStats(itr.Stats()); err != nil {
+		return err
+	}
+	return nil
 }
 
-{{end}}{{end}}
+{{end}}
+
+// encode a stats object in the point stream.
+func (enc *IteratorEncoder) encodeStats(stats IteratorStats) error {
+	buf, err := proto.Marshal(&internal.Point{
+		Name: proto.String(""),
+		Tags: proto.String(""),
+		Time: proto.Int64(0),
+		Nil:  proto.Bool(false),
+
+		Stats: encodeIteratorStats(&stats),
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := binary.Write(enc.w, binary.BigEndian, uint32(len(buf))); err != nil {
+		return err
+	}
+	if _, err := enc.w.Write(buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+{{end}}

--- a/influxql/point.gen.go
+++ b/influxql/point.gen.go
@@ -170,7 +170,8 @@ func (enc *FloatPointEncoder) EncodeFloatPoint(p *FloatPoint) error {
 
 // NewFloatPointDecoder decodes FloatPoint points from a reader.
 type FloatPointDecoder struct {
-	r io.Reader
+	r     io.Reader
+	stats IteratorStats
 }
 
 // NewFloatPointDecoder returns a new instance of FloatPointDecoder that reads from r.
@@ -178,28 +179,41 @@ func NewFloatPointDecoder(r io.Reader) *FloatPointDecoder {
 	return &FloatPointDecoder{r: r}
 }
 
+// Stats returns iterator stats embedded within the stream.
+func (dec *FloatPointDecoder) Stats() IteratorStats { return dec.stats }
+
 // DecodeFloatPoint reads from the underlying reader and unmarshals into p.
 func (dec *FloatPointDecoder) DecodeFloatPoint(p *FloatPoint) error {
-	// Read length.
-	var sz uint32
-	if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
-		return err
-	}
+	for {
+		// Read length.
+		var sz uint32
+		if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
+			return err
+		}
 
-	// Read point data.
-	buf := make([]byte, sz)
-	if _, err := io.ReadFull(dec.r, buf); err != nil {
-		return err
-	}
+		// Read point data.
+		buf := make([]byte, sz)
+		if _, err := io.ReadFull(dec.r, buf); err != nil {
+			return err
+		}
 
-	// Unmarshal into point.
-	var pb internal.Point
-	if err := proto.Unmarshal(buf, &pb); err != nil {
-		return err
-	}
-	*p = *decodeFloatPoint(&pb)
+		// Unmarshal into point.
+		var pb internal.Point
+		if err := proto.Unmarshal(buf, &pb); err != nil {
+			return err
+		}
 
-	return nil
+		// If the point contains stats then read stats and retry.
+		if pb.Stats != nil {
+			dec.stats = decodeIteratorStats(pb.Stats)
+			continue
+		}
+
+		// Decode into point object.
+		*p = *decodeFloatPoint(&pb)
+
+		return nil
+	}
 }
 
 // IntegerPoint represents a point with a int64 value.
@@ -358,7 +372,8 @@ func (enc *IntegerPointEncoder) EncodeIntegerPoint(p *IntegerPoint) error {
 
 // NewIntegerPointDecoder decodes IntegerPoint points from a reader.
 type IntegerPointDecoder struct {
-	r io.Reader
+	r     io.Reader
+	stats IteratorStats
 }
 
 // NewIntegerPointDecoder returns a new instance of IntegerPointDecoder that reads from r.
@@ -366,28 +381,41 @@ func NewIntegerPointDecoder(r io.Reader) *IntegerPointDecoder {
 	return &IntegerPointDecoder{r: r}
 }
 
+// Stats returns iterator stats embedded within the stream.
+func (dec *IntegerPointDecoder) Stats() IteratorStats { return dec.stats }
+
 // DecodeIntegerPoint reads from the underlying reader and unmarshals into p.
 func (dec *IntegerPointDecoder) DecodeIntegerPoint(p *IntegerPoint) error {
-	// Read length.
-	var sz uint32
-	if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
-		return err
-	}
+	for {
+		// Read length.
+		var sz uint32
+		if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
+			return err
+		}
 
-	// Read point data.
-	buf := make([]byte, sz)
-	if _, err := io.ReadFull(dec.r, buf); err != nil {
-		return err
-	}
+		// Read point data.
+		buf := make([]byte, sz)
+		if _, err := io.ReadFull(dec.r, buf); err != nil {
+			return err
+		}
 
-	// Unmarshal into point.
-	var pb internal.Point
-	if err := proto.Unmarshal(buf, &pb); err != nil {
-		return err
-	}
-	*p = *decodeIntegerPoint(&pb)
+		// Unmarshal into point.
+		var pb internal.Point
+		if err := proto.Unmarshal(buf, &pb); err != nil {
+			return err
+		}
 
-	return nil
+		// If the point contains stats then read stats and retry.
+		if pb.Stats != nil {
+			dec.stats = decodeIteratorStats(pb.Stats)
+			continue
+		}
+
+		// Decode into point object.
+		*p = *decodeIntegerPoint(&pb)
+
+		return nil
+	}
 }
 
 // StringPoint represents a point with a string value.
@@ -546,7 +574,8 @@ func (enc *StringPointEncoder) EncodeStringPoint(p *StringPoint) error {
 
 // NewStringPointDecoder decodes StringPoint points from a reader.
 type StringPointDecoder struct {
-	r io.Reader
+	r     io.Reader
+	stats IteratorStats
 }
 
 // NewStringPointDecoder returns a new instance of StringPointDecoder that reads from r.
@@ -554,28 +583,41 @@ func NewStringPointDecoder(r io.Reader) *StringPointDecoder {
 	return &StringPointDecoder{r: r}
 }
 
+// Stats returns iterator stats embedded within the stream.
+func (dec *StringPointDecoder) Stats() IteratorStats { return dec.stats }
+
 // DecodeStringPoint reads from the underlying reader and unmarshals into p.
 func (dec *StringPointDecoder) DecodeStringPoint(p *StringPoint) error {
-	// Read length.
-	var sz uint32
-	if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
-		return err
-	}
+	for {
+		// Read length.
+		var sz uint32
+		if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
+			return err
+		}
 
-	// Read point data.
-	buf := make([]byte, sz)
-	if _, err := io.ReadFull(dec.r, buf); err != nil {
-		return err
-	}
+		// Read point data.
+		buf := make([]byte, sz)
+		if _, err := io.ReadFull(dec.r, buf); err != nil {
+			return err
+		}
 
-	// Unmarshal into point.
-	var pb internal.Point
-	if err := proto.Unmarshal(buf, &pb); err != nil {
-		return err
-	}
-	*p = *decodeStringPoint(&pb)
+		// Unmarshal into point.
+		var pb internal.Point
+		if err := proto.Unmarshal(buf, &pb); err != nil {
+			return err
+		}
 
-	return nil
+		// If the point contains stats then read stats and retry.
+		if pb.Stats != nil {
+			dec.stats = decodeIteratorStats(pb.Stats)
+			continue
+		}
+
+		// Decode into point object.
+		*p = *decodeStringPoint(&pb)
+
+		return nil
+	}
 }
 
 // BooleanPoint represents a point with a bool value.
@@ -734,7 +776,8 @@ func (enc *BooleanPointEncoder) EncodeBooleanPoint(p *BooleanPoint) error {
 
 // NewBooleanPointDecoder decodes BooleanPoint points from a reader.
 type BooleanPointDecoder struct {
-	r io.Reader
+	r     io.Reader
+	stats IteratorStats
 }
 
 // NewBooleanPointDecoder returns a new instance of BooleanPointDecoder that reads from r.
@@ -742,26 +785,39 @@ func NewBooleanPointDecoder(r io.Reader) *BooleanPointDecoder {
 	return &BooleanPointDecoder{r: r}
 }
 
+// Stats returns iterator stats embedded within the stream.
+func (dec *BooleanPointDecoder) Stats() IteratorStats { return dec.stats }
+
 // DecodeBooleanPoint reads from the underlying reader and unmarshals into p.
 func (dec *BooleanPointDecoder) DecodeBooleanPoint(p *BooleanPoint) error {
-	// Read length.
-	var sz uint32
-	if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
-		return err
-	}
+	for {
+		// Read length.
+		var sz uint32
+		if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
+			return err
+		}
 
-	// Read point data.
-	buf := make([]byte, sz)
-	if _, err := io.ReadFull(dec.r, buf); err != nil {
-		return err
-	}
+		// Read point data.
+		buf := make([]byte, sz)
+		if _, err := io.ReadFull(dec.r, buf); err != nil {
+			return err
+		}
 
-	// Unmarshal into point.
-	var pb internal.Point
-	if err := proto.Unmarshal(buf, &pb); err != nil {
-		return err
-	}
-	*p = *decodeBooleanPoint(&pb)
+		// Unmarshal into point.
+		var pb internal.Point
+		if err := proto.Unmarshal(buf, &pb); err != nil {
+			return err
+		}
 
-	return nil
+		// If the point contains stats then read stats and retry.
+		if pb.Stats != nil {
+			dec.stats = decodeIteratorStats(pb.Stats)
+			continue
+		}
+
+		// Decode into point object.
+		*p = *decodeBooleanPoint(&pb)
+
+		return nil
+	}
 }

--- a/influxql/point.gen.go.tmpl
+++ b/influxql/point.gen.go.tmpl
@@ -177,7 +177,8 @@ func (enc *{{.Name}}PointEncoder) Encode{{.Name}}Point(p *{{.Name}}Point) error 
 
 // New{{.Name}}PointDecoder decodes {{.Name}}Point points from a reader.
 type {{.Name}}PointDecoder struct {
-	r io.Reader
+	r     io.Reader
+	stats IteratorStats
 }
 
 // New{{.Name}}PointDecoder returns a new instance of {{.Name}}PointDecoder that reads from r.
@@ -185,28 +186,41 @@ func New{{.Name}}PointDecoder(r io.Reader) *{{.Name}}PointDecoder {
 	return &{{.Name}}PointDecoder{r: r}
 }
 
+// Stats returns iterator stats embedded within the stream.
+func (dec *{{.Name}}PointDecoder) Stats() IteratorStats { return dec.stats }
+
 // Decode{{.Name}}Point reads from the underlying reader and unmarshals into p.
 func (dec *{{.Name}}PointDecoder) Decode{{.Name}}Point(p *{{.Name}}Point) error {
-	// Read length.
-	var sz uint32
-	if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
-		return err
-	}
+	for {
+		// Read length.
+		var sz uint32
+		if err := binary.Read(dec.r, binary.BigEndian, &sz); err != nil {
+			return err
+		}
 
-	// Read point data.
-	buf := make([]byte, sz)
-	if _, err := io.ReadFull(dec.r, buf); err != nil {
-		return err
-	}
+		// Read point data.
+		buf := make([]byte, sz)
+		if _, err := io.ReadFull(dec.r, buf); err != nil {
+			return err
+		}
 
-	// Unmarshal into point.
-	var pb internal.Point
-	if err := proto.Unmarshal(buf, &pb); err != nil {
-		return err
-	}
-	*p = *decode{{.Name}}Point(&pb)
+		// Unmarshal into point.
+		var pb internal.Point
+		if err := proto.Unmarshal(buf, &pb); err != nil {
+			return err
+		}
 
-	return nil
+		// If the point contains stats then read stats and retry.
+		if pb.Stats != nil {
+			dec.stats = decodeIteratorStats(pb.Stats)
+			continue
+		}
+
+		// Decode into point object.
+		*p = *decode{{.Name}}Point(&pb)
+
+		return nil
+	}
 }
 
 {{end}}

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -108,6 +108,8 @@ type floatIterator struct {
 
 	m     map[string]interface{} // map used for condition evaluation
 	point influxql.FloatPoint    // reusable buffer
+
+	stats influxql.IteratorStats
 }
 
 func newFloatIterator(name string, tags influxql.Tags, opt influxql.IteratorOptions, cur floatCursor, aux []cursorAt, conds []*bufCursor, condNames []string) *floatIterator {
@@ -118,6 +120,9 @@ func newFloatIterator(name string, tags influxql.Tags, opt influxql.IteratorOpti
 		point: influxql.FloatPoint{
 			Name: name,
 			Tags: tags,
+		},
+		stats: influxql.IteratorStats{
+			SeriesN: 1,
 		},
 	}
 
@@ -177,9 +182,15 @@ func (itr *floatIterator) Next() *influxql.FloatPoint {
 			continue
 		}
 
+		// Track points returned.
+		itr.stats.PointN++
+
 		return &itr.point
 	}
 }
+
+// Stats returns stats on the points processed.
+func (itr *floatIterator) Stats() influxql.IteratorStats { return itr.stats }
 
 // Close closes the iterator.
 func (itr *floatIterator) Close() error { return nil }
@@ -440,6 +451,8 @@ type integerIterator struct {
 
 	m     map[string]interface{} // map used for condition evaluation
 	point influxql.IntegerPoint  // reusable buffer
+
+	stats influxql.IteratorStats
 }
 
 func newIntegerIterator(name string, tags influxql.Tags, opt influxql.IteratorOptions, cur integerCursor, aux []cursorAt, conds []*bufCursor, condNames []string) *integerIterator {
@@ -450,6 +463,9 @@ func newIntegerIterator(name string, tags influxql.Tags, opt influxql.IteratorOp
 		point: influxql.IntegerPoint{
 			Name: name,
 			Tags: tags,
+		},
+		stats: influxql.IteratorStats{
+			SeriesN: 1,
 		},
 	}
 
@@ -509,9 +525,15 @@ func (itr *integerIterator) Next() *influxql.IntegerPoint {
 			continue
 		}
 
+		// Track points returned.
+		itr.stats.PointN++
+
 		return &itr.point
 	}
 }
+
+// Stats returns stats on the points processed.
+func (itr *integerIterator) Stats() influxql.IteratorStats { return itr.stats }
 
 // Close closes the iterator.
 func (itr *integerIterator) Close() error { return nil }
@@ -772,6 +794,8 @@ type stringIterator struct {
 
 	m     map[string]interface{} // map used for condition evaluation
 	point influxql.StringPoint   // reusable buffer
+
+	stats influxql.IteratorStats
 }
 
 func newStringIterator(name string, tags influxql.Tags, opt influxql.IteratorOptions, cur stringCursor, aux []cursorAt, conds []*bufCursor, condNames []string) *stringIterator {
@@ -782,6 +806,9 @@ func newStringIterator(name string, tags influxql.Tags, opt influxql.IteratorOpt
 		point: influxql.StringPoint{
 			Name: name,
 			Tags: tags,
+		},
+		stats: influxql.IteratorStats{
+			SeriesN: 1,
 		},
 	}
 
@@ -841,9 +868,15 @@ func (itr *stringIterator) Next() *influxql.StringPoint {
 			continue
 		}
 
+		// Track points returned.
+		itr.stats.PointN++
+
 		return &itr.point
 	}
 }
+
+// Stats returns stats on the points processed.
+func (itr *stringIterator) Stats() influxql.IteratorStats { return itr.stats }
 
 // Close closes the iterator.
 func (itr *stringIterator) Close() error { return nil }
@@ -1104,6 +1137,8 @@ type booleanIterator struct {
 
 	m     map[string]interface{} // map used for condition evaluation
 	point influxql.BooleanPoint  // reusable buffer
+
+	stats influxql.IteratorStats
 }
 
 func newBooleanIterator(name string, tags influxql.Tags, opt influxql.IteratorOptions, cur booleanCursor, aux []cursorAt, conds []*bufCursor, condNames []string) *booleanIterator {
@@ -1114,6 +1149,9 @@ func newBooleanIterator(name string, tags influxql.Tags, opt influxql.IteratorOp
 		point: influxql.BooleanPoint{
 			Name: name,
 			Tags: tags,
+		},
+		stats: influxql.IteratorStats{
+			SeriesN: 1,
 		},
 	}
 
@@ -1173,9 +1211,15 @@ func (itr *booleanIterator) Next() *influxql.BooleanPoint {
 			continue
 		}
 
+		// Track points returned.
+		itr.stats.PointN++
+
 		return &itr.point
 	}
 }
+
+// Stats returns stats on the points processed.
+func (itr *booleanIterator) Stats() influxql.IteratorStats { return itr.stats }
 
 // Close closes the iterator.
 func (itr *booleanIterator) Close() error { return nil }

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -104,6 +104,8 @@ type {{.name}}Iterator struct {
 
 	m map[string]interface{}      // map used for condition evaluation
 	point influxql.{{.Name}}Point // reusable buffer
+
+	stats influxql.IteratorStats
 }
 
 func new{{.Name}}Iterator(name string, tags influxql.Tags, opt influxql.IteratorOptions, cur {{.name}}Cursor, aux []cursorAt, conds []*bufCursor, condNames []string) *{{.name}}Iterator {
@@ -114,6 +116,9 @@ func new{{.Name}}Iterator(name string, tags influxql.Tags, opt influxql.Iterator
 		point: influxql.{{.Name}}Point{
 			Name: name,
 			Tags: tags,
+		},
+		stats: influxql.IteratorStats{
+			SeriesN: 1,
 		},
 	}
 
@@ -173,9 +178,15 @@ func (itr *{{.name}}Iterator) Next() *influxql.{{.Name}}Point {
 			continue
 		}
 
+		// Track points returned.
+		itr.stats.PointN++
+
 		return &itr.point
 	}
 }
+
+// Stats returns stats on the points processed.
+func (itr *{{.name}}Iterator) Stats() influxql.IteratorStats { return itr.stats }
 
 // Close closes the iterator.
 func (itr *{{.name}}Iterator) Close() error { return nil }

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -936,6 +936,9 @@ func NewMeasurementIterator(sh *Shard, opt influxql.IteratorOptions) (*Measureme
 	return itr, nil
 }
 
+// Stats returns stats about the points processed.
+func (itr *MeasurementIterator) Stats() influxql.IteratorStats { return influxql.IteratorStats{} }
+
 // Close closes the iterator.
 func (itr *MeasurementIterator) Close() error { return nil }
 
@@ -999,6 +1002,9 @@ func NewSeriesIterator(sh *Shard, opt influxql.IteratorOptions) (influxql.Iterat
 		fields: opt.Aux,
 	}, nil
 }
+
+// Stats returns stats about the points processed.
+func (itr *seriesIterator) Stats() influxql.IteratorStats { return influxql.IteratorStats{} }
 
 // Close closes the iterator.
 func (itr *seriesIterator) Close() error { return nil }
@@ -1105,6 +1111,9 @@ func NewTagValuesIterator(sh *Shard, opt influxql.IteratorOptions) (influxql.Ite
 	}, nil
 }
 
+// Stats returns stats about the points processed.
+func (itr *tagValuesIterator) Stats() influxql.IteratorStats { return influxql.IteratorStats{} }
+
 // Close closes the iterator.
 func (itr *tagValuesIterator) Close() error { return nil }
 
@@ -1184,6 +1193,9 @@ type measurementKeysIterator struct {
 	}
 	fn measurementKeyFunc
 }
+
+// Stats returns stats about the points processed.
+func (itr *measurementKeysIterator) Stats() influxql.IteratorStats { return influxql.IteratorStats{} }
 
 // Close closes the iterator.
 func (itr *measurementKeysIterator) Close() error { return nil }


### PR DESCRIPTION
## Overview

This commit adds an `IteratorStats` that holds aggregate iterator processing information. A method is also added to `Iterator` to return the stats:

```go
Stats() influxql.IteratorStats
```

Most `Iterator` implementations simply call down to lower level iterators to retrieve stats and then use `IteratorStats.Add()` to merge them together.

The remote iterators will also emit their stats in the point stream upon first connection, on a given interval, and then finally once the last point has been sent.

This functionality is required for properly implementing several of the query limits as well as providing insight into the internals of the system.

## TODO

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


/cc @jsternberg @jwilder 

