### PR TITLE
Support a timeout for running queries in the query manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#5939](https://github.com/influxdata/influxdb/issues/5939): Support viewing and killing running queries.
 - [#6073](https://github.com/influxdata/influxdb/pulls/6073): Iterator stats
 - [#6079](https://github.com/influxdata/influxdb/issues/6079): Limit the maximum number of concurrent queries.
+- [#6075](https://github.com/influxdata/influxdb/issues/6075): Limit the maximum running time of a query.
 
 ### Bugfixes
 

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -16,6 +16,10 @@ const (
 	// DefaultShardMapperTimeout is the default timeout set on shard mappers.
 	DefaultShardMapperTimeout = 5 * time.Second
 
+	// DefaultQueryTimeout is the default timeout for executing a query.
+	// A value of zero will have no query timeout.
+	DefaultQueryTimeout = time.Duration(0)
+
 	// DefaultMaxRemoteWriteConnections is the maximum number of open connections
 	// that will be available for remote writes to another host.
 	DefaultMaxRemoteWriteConnections = 3
@@ -33,6 +37,7 @@ type Config struct {
 	MaxRemoteWriteConnections int           `toml:"max-remote-write-connections"`
 	ShardMapperTimeout        toml.Duration `toml:"shard-mapper-timeout"`
 	MaxConcurrentQueries      int           `toml:"max-concurrent-queries"`
+	QueryTimeout              toml.Duration `toml:"query-timeout"`
 }
 
 // NewConfig returns an instance of Config with defaults.
@@ -41,6 +46,7 @@ func NewConfig() Config {
 		WriteTimeout:              toml.Duration(DefaultWriteTimeout),
 		ShardWriterTimeout:        toml.Duration(DefaultShardWriterTimeout),
 		ShardMapperTimeout:        toml.Duration(DefaultShardMapperTimeout),
+		QueryTimeout:              toml.Duration(DefaultQueryTimeout),
 		MaxRemoteWriteConnections: DefaultMaxRemoteWriteConnections,
 		MaxConcurrentQueries:      DefaultMaxConcurrentQueries,
 	}

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -164,6 +164,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.QueryExecutor.TSDBStore = s.TSDBStore
 	s.QueryExecutor.Monitor = s.Monitor
 	s.QueryExecutor.PointsWriter = s.PointsWriter
+	s.QueryExecutor.QueryTimeout = time.Duration(c.Cluster.QueryTimeout)
 	s.QueryExecutor.QueryManager = influxql.DefaultQueryManager(c.Cluster.MaxConcurrentQueries)
 	if c.Data.QueryLogEnabled {
 		s.QueryExecutor.LogOutput = os.Stderr

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -348,6 +348,9 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions) (Iter
 			if !opt.Interval.IsZero() && opt.Fill != NoFill {
 				itr = NewFillIterator(itr, expr, opt)
 			}
+			if opt.InterruptCh != nil {
+				itr = NewInterruptIterator(itr, opt.InterruptCh)
+			}
 			return itr, nil
 		}
 	case *BinaryExpr:


### PR DESCRIPTION
Include an interrupt iterator at the top level to interrupt the fill
iterator if it is producing too many points.

Fixes #6075.