### PR TITLE
Fix partially written TSM files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ There were some important breaking changes in this release. Here's a list of the
 - [#5965](https://github.com/influxdata/influxdb/issues/5965): InfluxDB panic crashes while parsing "-" as Float
 - [#5835](https://github.com/influxdata/influxdb/issues/5835): Make CREATE USER default to IF NOT EXISTS
 - [#6042](https://github.com/influxdata/influxdb/issues/6042): CreateDatabase failure on Windows, regression from v0.11.0 RC @mvadu
+- [#5889](https://github.com/influxdata/influxdb/issues/5889): Fix writing partial TSM index when flush file fails
 
 ## v0.10.3 [2016-03-09]
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -538,7 +538,7 @@ func (c *Compactor) writeNewFiles(generation, sequence int, iter KeyIterator) ([
 	return files, nil
 }
 
-func (c *Compactor) write(path string, iter KeyIterator) error {
+func (c *Compactor) write(path string, iter KeyIterator) (err error) {
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return fmt.Errorf("%v already file exists. aborting", path)
 	}
@@ -553,7 +553,12 @@ func (c *Compactor) write(path string, iter KeyIterator) error {
 	if err != nil {
 		return err
 	}
-	defer w.Close()
+	defer func() {
+		closeErr := w.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}()
 
 	for iter.Next() {
 		select {
@@ -590,7 +595,6 @@ func (c *Compactor) write(path string, iter KeyIterator) error {
 	if err := w.WriteIndex(); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -436,6 +436,10 @@ func (f *FileStore) Replace(oldFiles, newFiles []string) error {
 		}
 	}
 
+	if err := syncDir(f.dir); err != nil {
+		return err
+	}
+
 	f.files = active
 	sort.Sort(tsmReaders(f.files))
 

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -70,6 +70,7 @@ import (
 	"hash/crc32"
 	"io"
 	"math"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -637,6 +638,12 @@ func (t *tsmWriter) WriteIndex() error {
 func (t *tsmWriter) Close() error {
 	if err := t.w.Flush(); err != nil {
 		return err
+	}
+
+	if f, ok := t.wrapped.(*os.File); ok {
+		if err := f.Sync(); err != nil {
+			return err
+		}
 	}
 
 	if c, ok := t.wrapped.(io.Closer); ok {


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes an issue where a TSM file would be partially written due to a `defer w.Close()` call swallowing an error that occurred during the `Close`.  In the case of the `TSMWriter`, `Close` flushes the underlying index buffer to disk.  If that failed, possibly due to out of disk space, the error would be hidden from the compactor and the compactor would install the file as if everything was fine.  On restart, the file could fail to load because the index may be truncated.

Fixes #5889 