### PR TITLE
Fix influx stress point writer

### DIFF
--- a/stress/basic.go
+++ b/stress/basic.go
@@ -365,7 +365,7 @@ func post(url string, datatype string, data io.Reader) (*http.Response, error) {
 func (c *BasicClient) send(b []byte) (response, error) {
 
 	t := NewTimer()
-	resp, err := post(c.Addresses[c.addrId], "application/x-www-form-urlencoded", bytes.NewBuffer(b))
+	resp, err := post(c.Addresses[c.addrId], "", bytes.NewBuffer(b))
 	t.StopTimer()
 	if err != nil {
 		return response{Timer: t}, err


### PR DESCRIPTION
It previously used the content type `application/x-www-form-urlencoded`.
When the HTTP write handler was changed to check an HTTP form parameter
in d96eef4, the body for any POST requests with that content type would
result in an empty body.