### PR TITLE
Fix ORDER BY desc so it doesn't skip values

### DIFF
--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -338,7 +338,7 @@ func newFloatDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]FloatValue, 1000)
+	c.tsm.buf = make([]FloatValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
@@ -418,7 +418,7 @@ func (c *floatDescendingCursor) nextTSM() {
 		if len(c.tsm.values) == 0 {
 			return
 		}
-		c.tsm.pos = 0
+		c.tsm.pos = len(c.tsm.values) - 1
 	}
 }
 
@@ -681,7 +681,7 @@ func newIntegerDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]IntegerValue, 1000)
+	c.tsm.buf = make([]IntegerValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
@@ -761,7 +761,7 @@ func (c *integerDescendingCursor) nextTSM() {
 		if len(c.tsm.values) == 0 {
 			return
 		}
-		c.tsm.pos = 0
+		c.tsm.pos = len(c.tsm.values) - 1
 	}
 }
 
@@ -1024,7 +1024,7 @@ func newStringDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]StringValue, 1000)
+	c.tsm.buf = make([]StringValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
@@ -1104,7 +1104,7 @@ func (c *stringDescendingCursor) nextTSM() {
 		if len(c.tsm.values) == 0 {
 			return
 		}
-		c.tsm.pos = 0
+		c.tsm.pos = len(c.tsm.values) - 1
 	}
 }
 
@@ -1367,7 +1367,7 @@ func newBooleanDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]BooleanValue, 1000)
+	c.tsm.buf = make([]BooleanValue, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
@@ -1447,7 +1447,7 @@ func (c *booleanDescendingCursor) nextTSM() {
 		if len(c.tsm.values) == 0 {
 			return
 		}
-		c.tsm.pos = 0
+		c.tsm.pos = len(c.tsm.values) - 1
 	}
 }
 

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -334,7 +334,7 @@ func new{{.Name}}DescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]{{.Name}}Value, 1000)
+	c.tsm.buf = make([]{{.Name}}Value, 10)
 	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
@@ -414,7 +414,7 @@ func (c *{{.name}}DescendingCursor) nextTSM() {
 		if len(c.tsm.values) == 0 {
 			return
 		}
-		c.tsm.pos = 0
+		c.tsm.pos = len(c.tsm.values) - 1
 	}
 }
 


### PR DESCRIPTION
After reading the initial buffer, ORDER BY desc would read the next
block into the buffer and only read the first element. It's because the
code that was copied from the ascending cursor wasn't modified correctly
to set the position to the last element in the buffer.

The buffer size has also been lowered from 1000 to 10 to match with the
ascending cursor for performance with limit queries.

Fixes #6055.