### PR TITLE
Correct idempotency for RPs and CQs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#6065](https://github.com/influxdata/influxdb/pull/6065):  Wait for a process termination on influxdb restart @simnv
 - [#5252](https://github.com/influxdata/influxdb/issues/5252): Release tarballs contain specific attributes on '.'
 - [#5554](https://github.com/influxdata/influxdb/issues/5554): Can't run in alpine linux
+- [#6094](https://github.com/influxdata/influxdb/issues/6094): Ensure CREATE RETENTION POLICY and CREATE CONTINUOUS QUERY are idempotent in the correct way.
 
 ## v0.11.0 [2016-03-22]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -480,14 +480,6 @@ func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := s.MetaClient.SetDefaultRetentionPolicy("db0", "rp0"); err != nil {
-		t.Fatal(err)
-	}
-
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
 		&Write{data: fmt.Sprintf(`cpu value=1.0 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T01:00:00Z").UnixNano())},
@@ -503,7 +495,7 @@ func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 		&Query{
 			name:    "default rp exists",
 			command: `show retention policies ON db0`,
-			exp:     `{"results":[{"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["default","0","168h0m0s",1,false],["rp0","1h0m0s","1h0m0s",1,true]]}]}]}`,
+			exp:     `{"results":[{"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["default","0","168h0m0s",1,false],["rp0","0","168h0m0s",1,true]]}]}]}`,
 		},
 		&Query{
 			name:    "default rp",
@@ -540,10 +532,6 @@ func TestServer_Query_Multiple_Measurements(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	// Make sure we do writes for measurements that will span across shards
 	writes := []string{
@@ -590,10 +578,6 @@ func TestServer_Query_IdenticalTagValues(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	writes := []string{
 		fmt.Sprintf("cpu,t1=val1 value=1 %d", mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
@@ -646,10 +630,6 @@ func TestServer_Query_NoShards(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
 	now := now()
 
 	test := NewTest("db0", "rp0")
@@ -687,10 +667,6 @@ func TestServer_Query_NonExistent(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	now := now()
 
@@ -734,10 +710,6 @@ func TestServer_Query_Math(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db", newRetentionPolicyInfo("rp", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	now := now()
 	writes := []string{
@@ -831,10 +803,6 @@ func TestServer_Query_Count(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
 	now := now()
 
 	test := NewTest("db0", "rp0")
@@ -905,10 +873,6 @@ func TestServer_Query_Now(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
 	now := now()
 
 	test := NewTest("db0", "rp0")
@@ -961,10 +925,6 @@ func TestServer_Query_EpochPrecision(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	now := now()
 
@@ -1034,10 +994,6 @@ func TestServer_Query_Tags(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	now := now()
 
@@ -1216,10 +1172,6 @@ func TestServer_Query_Alias(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
 	writes := []string{
 		fmt.Sprintf("cpu value=1i,steps=3i %d", mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
 		fmt.Sprintf("cpu value=2i,steps=4i %d", mustParseTime(time.RFC3339Nano, "2000-01-01T00:01:00Z").UnixNano()),
@@ -1295,10 +1247,6 @@ func TestServer_Query_Common(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
 	now := now()
 
 	test := NewTest("db0", "rp0")
@@ -1372,10 +1320,6 @@ func TestServer_Query_SelectTwoPoints(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
 	now := now()
 
 	test := NewTest("db0", "rp0")
@@ -1420,10 +1364,6 @@ func TestServer_Query_SelectTwoNegativePoints(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
 	now := now()
 
 	test := NewTest("db0", "rp0")
@@ -1460,10 +1400,6 @@ func TestServer_Query_SelectRelativeTime(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	now := now()
 	yesterday := yesterday()
@@ -1510,10 +1446,6 @@ func TestServer_Query_SelectRawDerivative(t *testing.T) {
 	s := OpenServer(NewConfig())
 	defer s.Close()
 
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
-
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
 		&Write{data: fmt.Sprintf("cpu value=210 1278010021000000000\ncpu value=10 1278010022000000000")},
@@ -1555,10 +1487,6 @@ func TestServer_Query_SelectRawNonNegativeDerivative(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -1605,10 +1533,6 @@ func TestServer_Query_SelectGroupByTimeDerivative(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{
@@ -1735,10 +1659,6 @@ func TestServer_Query_SelectGroupByTimeDerivativeWithFill(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 1*time.Hour)); err != nil {
-		t.Fatal(err)
-	}
 
 	test := NewTest("db0", "rp0")
 	test.writes = Writes{

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -282,10 +282,6 @@ func (c *Client) CreateRetentionPolicy(database string, rpi *RetentionPolicyInfo
 
 	data := c.cacheData.Clone()
 
-	if rp, _ := data.RetentionPolicy(database, rpi.Name); rp != nil {
-		return rp, nil
-	}
-
 	if rpi.Duration < MinRetentionPolicyDuration && rpi.Duration != 0 {
 		return nil, ErrRetentionPolicyDurationTooLow
 	}

--- a/services/meta/client_test.go
+++ b/services/meta/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -201,43 +202,61 @@ func TestMetaClient_CreateRetentionPolicy(t *testing.T) {
 		t.Fatalf("db name wrong: %s", db.Name)
 	}
 
-	if _, err := c.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{
-		Name:     "rp0",
-		Duration: 1 * time.Hour,
-		ReplicaN: 1,
-	}); err != nil {
+	rp0 := &meta.RetentionPolicyInfo{
+		Name:               "rp0",
+		ReplicaN:           1,
+		Duration:           time.Hour,
+		ShardGroupDuration: time.Hour,
+	}
+
+	if _, err := c.CreateRetentionPolicy("db0", rp0); err != nil {
 		t.Fatal(err)
 	}
 
-	rp, err := c.RetentionPolicy("db0", "rp0")
+	actual, err := c.RetentionPolicy("db0", "rp0")
 	if err != nil {
 		t.Fatal(err)
-	} else if rp.Name != "rp0" {
-		t.Fatalf("rp name wrong: %s", rp.Name)
-	} else if rp.Duration != time.Hour {
-		t.Fatalf("rp duration wrong: %s", rp.Duration.String())
-	} else if rp.ReplicaN != 1 {
-		t.Fatalf("rp replication wrong: %d", rp.ReplicaN)
+	} else if got, exp := actual, rp0; !reflect.DeepEqual(got, exp) {
+		t.Fatalf("got %#v, expected %#v", got, exp)
 	}
 
 	// Create the same policy.  Should not error.
-	if _, err := c.CreateRetentionPolicy("db0", &meta.RetentionPolicyInfo{
-		Name:     "rp0",
-		Duration: 1 * time.Hour,
-		ReplicaN: 1,
-	}); err != nil {
+	if _, err := c.CreateRetentionPolicy("db0", rp0); err != nil {
 		t.Fatal(err)
+	} else if actual, err = c.RetentionPolicy("db0", "rp0"); err != nil {
+		t.Fatal(err)
+	} else if got, exp := actual, rp0; !reflect.DeepEqual(got, exp) {
+		t.Fatalf("got %#v, expected %#v", got, exp)
 	}
 
-	rp, err = c.RetentionPolicy("db0", "rp0")
-	if err != nil {
-		t.Fatal(err)
-	} else if rp.Name != "rp0" {
-		t.Fatalf("rp name wrong: %s", rp.Name)
-	} else if rp.Duration != time.Hour {
-		t.Fatalf("rp duration wrong: %s", rp.Duration.String())
-	} else if rp.ReplicaN != 1 {
-		t.Fatalf("rp replication wrong: %d", rp.ReplicaN)
+	// Creating the same policy, but with a different duration should
+	// result in an error.
+	rp1 := &meta.RetentionPolicyInfo{
+		Name:               rp0.Name,
+		ReplicaN:           rp0.ReplicaN,
+		Duration:           2 * rp0.Duration,
+		ShardGroupDuration: rp0.ShardGroupDuration,
+	}
+
+	if _, err := c.CreateRetentionPolicy("db0", rp1); err == nil {
+		t.Fatal("didn't get an error, but expected one")
+	} else if got, exp := err, meta.ErrRetentionPolicyExists; got.Error() != exp.Error() {
+		t.Fatalf("got error %v, expected error %v", got, exp)
+	}
+
+	// Creating the same policy, but with a different replica factor
+	// should also result in an error.
+	rp2 := &meta.RetentionPolicyInfo{
+		Name:               rp0.Name,
+		ReplicaN:           rp0.ReplicaN + 1,
+		Duration:           rp0.Duration,
+		ShardGroupDuration: rp0.ShardGroupDuration,
+	}
+
+	if _, err := c.CreateRetentionPolicy("db0", rp2); err == nil {
+		t.Fatal("didn't get an error, but expected one")
+	} else if got, exp := err, meta.ErrRetentionPolicyExists; got.Error() != exp.Error() {
+		t.Fatalf("got error %v, expected error %v", got, exp)
 	}
 }
 

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -417,8 +418,14 @@ func (data *Data) CreateContinuousQuery(database, name, query string) error {
 	}
 
 	// Ensure the name doesn't already exist.
-	for i := range di.ContinuousQueries {
-		if di.ContinuousQueries[i].Name == name {
+	for _, cq := range di.ContinuousQueries {
+		if cq.Name == name {
+			// If the query string is the same, we'll silently return,
+			// otherwise we'll assume the user might be trying to
+			// overwrite an existing CQ with a different query.
+			if strings.ToLower(cq.Query) == strings.ToLower(query) {
+				return nil
+			}
 			return ErrContinuousQueryExists
 		}
 	}


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This PR fixes a couple of bugs with how `CREATE RETENTION POLICY` and `CREATE CONTINUOUS QUERY` behaved. Currently:

```
> CREATE RETENTION POLICY rp0 ON db DURATION 1h REPLICATION 1
> CREATE RETENTION POLICY rp0 ON db DURATION 1h REPLICATION 1
> CREATE RETENTION POLICY rp0 ON db DURATION 2h REPLICATION 1
> CREATE RETENTION POLICY rp0 ON db DURATION 1h REPLICATION 2
> SHOW RETENTION POLICIES ON db
name	duration	replicaN	default
default	0		1		true
rp0	1h0m0s		1		false

>
```

i.e., the same `rp` with different duration or replication factor does not error, and it should.

```
> CREATE CONTINUOUS QUERY cq0 ON db BEGIN SELECT count(value) INTO "6_months".events FROM events GROUP BY time(10m) END
> CREATE CONTINUOUS QUERY cq0 ON db BEGIN SELECT count(value) INTO "6_months".events FROM events GROUP BY time(10m) END
ERR: continuous query already exists
>
```

i.e., the exact same query string results in an error, when really the command could be idempotent and not return an error.


New `RP` behaviour:

```
> CREATE RETENTION POLICY rp0 ON db DURATION 1h REPLICATION 1
> CREATE RETENTION POLICY rp0 ON db DURATION 2h REPLICATION 1
ERR: retention policy already exists
> CREATE RETENTION POLICY rp0 ON db DURATION 1h REPLICATION 2
ERR: retention policy already exists
> CREATE RETENTION POLICY rp0 ON db DURATION 1h REPLICATION 1
> SHOW RETENTION POLICIES ON db
name	duration	replicaN	default
default	0		1		true
rp0	1h0m0s		1		false

>
```

New `CQ` behaviour:

```
> CREATE CONTINUOUS QUERY cq0 ON db BEGIN SELECT count(value) INTO "6_months".events FROM events GROUP BY time(10m) END
> CREATE CONTINUOUS QUERY cq0 ON db BEGIN SELECT count(value) INTO "6_months".events FROM events GROUP BY time(10m) END
> CREATE CONTINUOUS QUERY cq0 ON db BEGIN select count(value) into "6_months".events from events group by time(10m) END
> CREATE CONTINUOUS QUERY cq0 ON db BEGIN select MAX(value) INTO "6_months".events FROM events GROUP BY time(10m) END
ERR: continuous query already exists
> SHOW CONTINUOUS QUERIES
name: _internal
---------------
name	query


name: db
--------
name	query
cq0	CREATE CONTINUOUS QUERY cq0 ON db BEGIN SELECT count(value) INTO db."6_months".events FROM db."default".events GROUP BY time(10m) END

>
```

Note with the `CQ` behaviour we're only checking the query string here, we're not parsing the query and attempting to check for equivalence with the existing query.
