### PR TITLE
Limit series count in selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#6073](https://github.com/influxdata/influxdb/pulls/6073): Iterator stats
 - [#6079](https://github.com/influxdata/influxdb/issues/6079): Limit the maximum number of concurrent queries.
 - [#6075](https://github.com/influxdata/influxdb/issues/6075): Limit the maximum running time of a query.
+- [#6102](https://github.com/influxdata/influxdb/issues/6102): Limit series count in selection
 
 ### Bugfixes
 

--- a/cluster/config.go
+++ b/cluster/config.go
@@ -27,6 +27,10 @@ const (
 	// DefaultMaxConcurrentQueries is the maximum number of running queries.
 	// A value of zero will make the maximum query limit unlimited.
 	DefaultMaxConcurrentQueries = 0
+
+	// DefaultMaxSelectSeriesN is the maximum number of series a SELECT can run.
+	// A value of zero will make the maximum series count unlimited.
+	DefaultMaxSelectSeriesN = 0
 )
 
 // Config represents the configuration for the clustering service.
@@ -38,6 +42,7 @@ type Config struct {
 	ShardMapperTimeout        toml.Duration `toml:"shard-mapper-timeout"`
 	MaxConcurrentQueries      int           `toml:"max-concurrent-queries"`
 	QueryTimeout              toml.Duration `toml:"query-timeout"`
+	MaxSelectSeriesN          int           `toml:"max-select-series"`
 }
 
 // NewConfig returns an instance of Config with defaults.
@@ -49,5 +54,6 @@ func NewConfig() Config {
 		QueryTimeout:              toml.Duration(DefaultQueryTimeout),
 		MaxRemoteWriteConnections: DefaultMaxRemoteWriteConnections,
 		MaxConcurrentQueries:      DefaultMaxConcurrentQueries,
+		MaxSelectSeriesN:          DefaultMaxSelectSeriesN,
 	}
 }

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -166,6 +166,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.QueryExecutor.PointsWriter = s.PointsWriter
 	s.QueryExecutor.QueryTimeout = time.Duration(c.Cluster.QueryTimeout)
 	s.QueryExecutor.QueryManager = influxql.DefaultQueryManager(c.Cluster.MaxConcurrentQueries)
+	s.QueryExecutor.MaxSelectSeriesN = c.Cluster.MaxSelectSeriesN
 	if c.Data.QueryLogEnabled {
 		s.QueryExecutor.LogOutput = os.Stderr
 	}

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -3,6 +3,7 @@ package tsm1
 import (
 	"sort"
 	"fmt"
+	"sync"
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/tsdb"
@@ -91,6 +92,11 @@ func (c *bufCursor) nextAt(seek int64) interface{} {
 }
 
 
+// statsBufferCopyIntervalN is the number of points that are read before
+// copying the stats buffer to the iterator's stats field. This is used to
+// amortize the cost of using a mutex when updating stats. 
+const statsBufferCopyIntervalN = 100
+
 {{range .}}
 
 type {{.name}}Iterator struct {
@@ -105,7 +111,9 @@ type {{.name}}Iterator struct {
 	m map[string]interface{}      // map used for condition evaluation
 	point influxql.{{.Name}}Point // reusable buffer
 
-	stats influxql.IteratorStats
+	statsLock sync.Mutex
+	stats     influxql.IteratorStats
+	statsBuf  influxql.IteratorStats
 }
 
 func new{{.Name}}Iterator(name string, tags influxql.Tags, opt influxql.IteratorOptions, cur {{.name}}Cursor, aux []cursorAt, conds []*bufCursor, condNames []string) *{{.name}}Iterator {
@@ -117,10 +125,11 @@ func new{{.Name}}Iterator(name string, tags influxql.Tags, opt influxql.Iterator
 			Name: name,
 			Tags: tags,
 		},
-		stats: influxql.IteratorStats{
+		statsBuf: influxql.IteratorStats{
 			SeriesN: 1,
 		},
 	}
+	itr.stats = itr.statsBuf
 
 	if len(aux) > 0 {
 		itr.point.Aux = make([]interface{}, len(aux))
@@ -156,10 +165,13 @@ func (itr *{{.name}}Iterator) Next() *influxql.{{.Name}}Point {
 
 		// Exit if we have no more points or we are outside our time range.
 		if itr.point.Time == tsdb.EOF {
+			itr.copyStats()
 			return nil
 		} else if itr.opt.Ascending && itr.point.Time > itr.opt.EndTime {
+			itr.copyStats()
 			return nil
 		} else if !itr.opt.Ascending && itr.point.Time < itr.opt.StartTime {
+			itr.copyStats()
 			return nil
 		}
 
@@ -179,14 +191,28 @@ func (itr *{{.name}}Iterator) Next() *influxql.{{.Name}}Point {
 		}
 
 		// Track points returned.
-		itr.stats.PointN++
+		itr.statsBuf.PointN++
+
+		// Copy buffer to stats periodically.
+		if itr.statsBuf.PointN % statsBufferCopyIntervalN == 0 {
+			itr.copyStats()
+		}
 
 		return &itr.point
 	}
 }
 
+// copyStats copies from the itr stats buffer to the stats under lock.
+func (itr *{{.name}}Iterator) copyStats() {
+}
+
 // Stats returns stats on the points processed.
-func (itr *{{.name}}Iterator) Stats() influxql.IteratorStats { return itr.stats }
+func (itr *{{.name}}Iterator) Stats() influxql.IteratorStats {
+	itr.statsLock.Lock()
+	stats := itr.stats
+	itr.statsLock.Unlock()
+	return stats
+}
 
 // Close closes the iterator.
 func (itr *{{.name}}Iterator) Close() error { return nil }


### PR DESCRIPTION
## Overview

This pull request adds a configurable limit to the number of series that can be returned from a `SELECT` statement. The limit is checked immediately after planning and is determined by the use of iterator stats.

Fixes #6076

---

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

