### PR TITLE
Implement derivatives across intervals for aggregate queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#5707](https://github.com/influxdata/influxdb/issues/5707): Return a deprecated message when IF NOT EXISTS is used.
 - [#6334](https://github.com/influxdata/influxdb/pull/6334): Allow environment variables to be set per input type.
 - [#6394](https://github.com/influxdata/influxdb/pull/6394): Allow time math with integer timestamps.
+- [#3247](https://github.com/influxdata/influxdb/issues/3247): Implement derivatives across intervals for aggregate queries.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -1547,12 +1547,12 @@ cpu value=25 1278010023000000000
 		&Query{
 			name:    "calculate derivative of count with unit default (2s) group by time",
 			command: `SELECT derivative(count(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",0]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",2],["2010-07-01T18:47:02Z",0]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of count with unit 4s group by time",
 			command: `SELECT derivative(count(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",0]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",4],["2010-07-01T18:47:02Z",0]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of mean with unit default (2s) group by time",
@@ -1671,12 +1671,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of count with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(count(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-2]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",2],["2010-07-01T18:47:02Z",-2]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of count with unit 4s group by time with fill  0",
 			command: `SELECT derivative(count(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-4]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",4],["2010-07-01T18:47:02Z",-4]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of count with unit default (2s) group by time with fill previous",
@@ -1691,12 +1691,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of mean with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(mean(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-15]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",15],["2010-07-01T18:47:02Z",-15]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of mean with unit 4s group by time with fill 0",
 			command: `SELECT derivative(mean(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-30]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",30],["2010-07-01T18:47:02Z",-30]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of mean with unit default (2s) group by time with fill previous",
@@ -1711,12 +1711,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of median with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(median(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-15]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",15],["2010-07-01T18:47:02Z",-15]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of median with unit 4s group by time with fill 0",
 			command: `SELECT derivative(median(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-30]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",30],["2010-07-01T18:47:02Z",-30]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of median with unit default (2s) group by time with fill previous",
@@ -1731,12 +1731,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of sum with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(sum(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-30]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",30],["2010-07-01T18:47:02Z",-30]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of sum with unit 4s group by time with fill 0",
 			command: `SELECT derivative(sum(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-60]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",60],["2010-07-01T18:47:02Z",-60]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of sum with unit default (2s) group by time with fill previous",
@@ -1751,12 +1751,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of first with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(first(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-10]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",10],["2010-07-01T18:47:02Z",-10]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of first with unit 4s group by time with fill 0",
 			command: `SELECT derivative(first(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-20]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",20],["2010-07-01T18:47:02Z",-20]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of first with unit default (2s) group by time with fill previous",
@@ -1771,12 +1771,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of last with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(last(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-20]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",20],["2010-07-01T18:47:02Z",-20]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of last with unit 4s group by time with fill 0",
 			command: `SELECT derivative(last(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-40]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",40],["2010-07-01T18:47:02Z",-40]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of last with unit default (2s) group by time with fill previous",
@@ -1791,12 +1791,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of min with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(min(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-10]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",10],["2010-07-01T18:47:02Z",-10]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of min with unit 4s group by time with fill 0",
 			command: `SELECT derivative(min(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-20]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",20],["2010-07-01T18:47:02Z",-20]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of min with unit default (2s) group by time with fill previous",
@@ -1811,12 +1811,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of max with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(max(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-20]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",20],["2010-07-01T18:47:02Z",-20]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of max with unit 4s group by time with fill 0",
 			command: `SELECT derivative(max(value), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-40]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",40],["2010-07-01T18:47:02Z",-40]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of max with unit default (2s) group by time with fill previous",
@@ -1831,12 +1831,12 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate derivative of percentile with unit default (2s) group by time with fill 0",
 			command: `SELECT derivative(percentile(value, 50)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-10]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",10],["2010-07-01T18:47:02Z",-10]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of percentile with unit 4s group by time with fill 0",
 			command: `SELECT derivative(percentile(value, 50), 4s) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:02Z",-20]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","derivative"],"values":[["2010-07-01T18:47:00Z",20],["2010-07-01T18:47:02Z",-20]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate derivative of percentile with unit default (2s) group by time with fill previous",
@@ -1887,7 +1887,7 @@ cpu value=25 1278010023000000000
 		&Query{
 			name:    "calculate difference of count",
 			command: `SELECT difference(count(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",0]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",2],["2010-07-01T18:47:02Z",0]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of mean",
@@ -1966,7 +1966,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of count with fill 0",
 			command: `SELECT difference(count(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-2]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",2],["2010-07-01T18:47:02Z",-2]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of count with fill previous",
@@ -1976,7 +1976,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of mean with fill 0",
 			command: `SELECT difference(mean(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-15]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",15],["2010-07-01T18:47:02Z",-15]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of mean with fill previous",
@@ -1986,7 +1986,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of median with fill 0",
 			command: `SELECT difference(median(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-15]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",15],["2010-07-01T18:47:02Z",-15]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of median with fill previous",
@@ -1996,7 +1996,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of sum with fill 0",
 			command: `SELECT difference(sum(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-30]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",30],["2010-07-01T18:47:02Z",-30]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of sum with fill previous",
@@ -2006,7 +2006,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of first with fill 0",
 			command: `SELECT difference(first(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-10]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",10],["2010-07-01T18:47:02Z",-10]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of first with fill previous",
@@ -2016,7 +2016,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of last with fill 0",
 			command: `SELECT difference(last(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-20]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",20],["2010-07-01T18:47:02Z",-20]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of last with fill previous",
@@ -2026,7 +2026,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of min with fill 0",
 			command: `SELECT difference(min(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-10]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",10],["2010-07-01T18:47:02Z",-10]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of min with fill previous",
@@ -2036,7 +2036,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of max with fill 0",
 			command: `SELECT difference(max(value)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-20]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",20],["2010-07-01T18:47:02Z",-20]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of max with fill previous",
@@ -2046,7 +2046,7 @@ cpu value=20 1278010021000000000
 		&Query{
 			name:    "calculate difference of percentile with fill 0",
 			command: `SELECT difference(percentile(value, 50)) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:03' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:02Z",-10]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","difference"],"values":[["2010-07-01T18:47:00Z",10],["2010-07-01T18:47:02Z",-10]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate difference of percentile with fill previous",
@@ -2094,7 +2094,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of count",
 			command: `SELECT moving_average(count(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",2],["2010-07-01T18:47:04Z",2]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",1],["2010-07-01T18:47:02Z",2],["2010-07-01T18:47:04Z",2]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of mean",
@@ -2175,7 +2175,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of count with fill 0",
 			command: `SELECT moving_average(count(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",1],["2010-07-01T18:47:04Z",1]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",1],["2010-07-01T18:47:02Z",1],["2010-07-01T18:47:04Z",1]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of count with fill previous",
@@ -2185,7 +2185,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of mean with fill 0",
 			command: `SELECT moving_average(mean(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",6.25],["2010-07-01T18:47:04Z",16.25]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",6.25],["2010-07-01T18:47:02Z",6.25],["2010-07-01T18:47:04Z",16.25]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of mean with fill previous",
@@ -2195,7 +2195,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of median with fill 0",
 			command: `SELECT moving_average(median(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",6.25],["2010-07-01T18:47:04Z",16.25]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",6.25],["2010-07-01T18:47:02Z",6.25],["2010-07-01T18:47:04Z",16.25]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of median with fill previous",
@@ -2205,7 +2205,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of sum with fill 0",
 			command: `SELECT moving_average(sum(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",12.5],["2010-07-01T18:47:04Z",32.5]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",12.5],["2010-07-01T18:47:02Z",12.5],["2010-07-01T18:47:04Z",32.5]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of sum with fill previous",
@@ -2215,7 +2215,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of first with fill 0",
 			command: `SELECT moving_average(first(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",5],["2010-07-01T18:47:04Z",15]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",5],["2010-07-01T18:47:02Z",5],["2010-07-01T18:47:04Z",15]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of first with fill previous",
@@ -2225,7 +2225,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of last with fill 0",
 			command: `SELECT moving_average(last(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",7.5],["2010-07-01T18:47:04Z",17.5]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",7.5],["2010-07-01T18:47:02Z",7.5],["2010-07-01T18:47:04Z",17.5]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of last with fill previous",
@@ -2235,7 +2235,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of min with fill 0",
 			command: `SELECT moving_average(min(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",5],["2010-07-01T18:47:04Z",15]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",5],["2010-07-01T18:47:02Z",5],["2010-07-01T18:47:04Z",15]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of min with fill previous",
@@ -2245,7 +2245,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of max with fill 0",
 			command: `SELECT moving_average(max(value), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",7.5],["2010-07-01T18:47:04Z",17.5]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",7.5],["2010-07-01T18:47:02Z",7.5],["2010-07-01T18:47:04Z",17.5]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of max with fill previous",
@@ -2255,7 +2255,7 @@ cpu value=35 1278010025000000000
 		&Query{
 			name:    "calculate moving average of percentile with fill 0",
 			command: `SELECT moving_average(percentile(value, 50), 2) from db0.rp0.cpu where time >= '2010-07-01 18:47:00' and time <= '2010-07-01 18:47:05' group by time(2s) fill(0)`,
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:02Z",5],["2010-07-01T18:47:04Z",15]]}]}]}`,
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","moving_average"],"values":[["2010-07-01T18:47:00Z",5],["2010-07-01T18:47:02Z",5],["2010-07-01T18:47:04Z",15]]}]}]}`,
 		},
 		&Query{
 			name:    "calculate moving average of percentile with fill previous",

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -62,6 +62,168 @@ func (r *IntegerMeanReducer) Emit() []FloatPoint {
 	}}
 }
 
+// FloatDerivativeReducer calculates the derivative of the aggregated points.
+type FloatDerivativeReducer struct {
+	interval      Interval
+	prev          FloatPoint
+	curr          FloatPoint
+	isNonNegative bool
+	ascending     bool
+}
+
+// NewFloatDerivativeReducer creates a new FloatDerivativeReducer.
+func NewFloatDerivativeReducer(interval Interval, isNonNegative, ascending bool) *FloatDerivativeReducer {
+	return &FloatDerivativeReducer{
+		interval:      interval,
+		isNonNegative: isNonNegative,
+		ascending:     ascending,
+		prev:          FloatPoint{Nil: true},
+		curr:          FloatPoint{Nil: true},
+	}
+}
+
+// AggregateFloat aggregates a point into the reducer and updates the current window.
+func (r *FloatDerivativeReducer) AggregateFloat(p *FloatPoint) {
+	r.prev = r.curr
+	r.curr = *p
+}
+
+// Emit emits the derivative of the reducer at the current point.
+func (r *FloatDerivativeReducer) Emit() []FloatPoint {
+	if !r.prev.Nil {
+		// Calculate the derivative of successive points by dividing the
+		// difference of each value by the elapsed time normalized to the interval.
+		diff := r.curr.Value - r.prev.Value
+		elapsed := r.curr.Time - r.prev.Time
+		if !r.ascending {
+			elapsed = -elapsed
+		}
+
+		value := 0.0
+		if elapsed > 0 {
+			value = diff / (float64(elapsed) / float64(r.interval.Duration))
+		}
+
+		// Drop negative values for non-negative derivatives.
+		if r.isNonNegative && diff < 0 {
+			return nil
+		}
+		return []FloatPoint{{Time: r.curr.Time, Value: value}}
+	}
+	return nil
+}
+
+// IntegerDerivativeReducer calculates the derivative of the aggregated points.
+type IntegerDerivativeReducer struct {
+	interval      Interval
+	prev          IntegerPoint
+	curr          IntegerPoint
+	isNonNegative bool
+	ascending     bool
+}
+
+// NewIntegerDerivativeReducer creates a new IntegerDerivativeReducer.
+func NewIntegerDerivativeReducer(interval Interval, isNonNegative, ascending bool) *IntegerDerivativeReducer {
+	return &IntegerDerivativeReducer{
+		interval:      interval,
+		isNonNegative: isNonNegative,
+		ascending:     ascending,
+		prev:          IntegerPoint{Nil: true},
+		curr:          IntegerPoint{Nil: true},
+	}
+}
+
+// AggregateInteger aggregates a point into the reducer and updates the current window.
+func (r *IntegerDerivativeReducer) AggregateInteger(p *IntegerPoint) {
+	r.prev = r.curr
+	r.curr = *p
+}
+
+// Emit emits the derivative of the reducer at the current point.
+func (r *IntegerDerivativeReducer) Emit() []FloatPoint {
+	if !r.prev.Nil {
+		// Calculate the derivative of successive points by dividing the
+		// difference of each value by the elapsed time normalized to the interval.
+		diff := float64(r.curr.Value - r.prev.Value)
+		elapsed := r.curr.Time - r.prev.Time
+		if !r.ascending {
+			elapsed = -elapsed
+		}
+
+		value := 0.0
+		if elapsed > 0 {
+			value = diff / (float64(elapsed) / float64(r.interval.Duration))
+		}
+
+		// Drop negative values for non-negative derivatives.
+		if r.isNonNegative && diff < 0 {
+			return nil
+		}
+		return []FloatPoint{{Time: r.curr.Time, Value: value}}
+	}
+	return nil
+}
+
+// FloatDifferenceReducer calculates the derivative of the aggregated points.
+type FloatDifferenceReducer struct {
+	prev FloatPoint
+	curr FloatPoint
+}
+
+// NewFloatDifferenceReducer creates a new FloatDifferenceReducer.
+func NewFloatDifferenceReducer() *FloatDifferenceReducer {
+	return &FloatDifferenceReducer{
+		prev: FloatPoint{Nil: true},
+		curr: FloatPoint{Nil: true},
+	}
+}
+
+// AggregateFloat aggregates a point into the reducer and updates the current window.
+func (r *FloatDifferenceReducer) AggregateFloat(p *FloatPoint) {
+	r.prev = r.curr
+	r.curr = *p
+}
+
+// Emit emits the difference of the reducer at the current point.
+func (r *FloatDifferenceReducer) Emit() []FloatPoint {
+	if !r.prev.Nil {
+		// Calculate the difference of successive points.
+		value := r.curr.Value - r.prev.Value
+		return []FloatPoint{{Time: r.curr.Time, Value: value}}
+	}
+	return nil
+}
+
+// IntegerDifferenceReducer calculates the derivative of the aggregated points.
+type IntegerDifferenceReducer struct {
+	prev IntegerPoint
+	curr IntegerPoint
+}
+
+// NewIntegerDifferenceReducer creates a new IntegerDifferenceReducer.
+func NewIntegerDifferenceReducer() *IntegerDifferenceReducer {
+	return &IntegerDifferenceReducer{
+		prev: IntegerPoint{Nil: true},
+		curr: IntegerPoint{Nil: true},
+	}
+}
+
+// AggregateInteger aggregates a point into the reducer and updates the current window.
+func (r *IntegerDifferenceReducer) AggregateInteger(p *IntegerPoint) {
+	r.prev = r.curr
+	r.curr = *p
+}
+
+// Emit emits the difference of the reducer at the current point.
+func (r *IntegerDifferenceReducer) Emit() []IntegerPoint {
+	if !r.prev.Nil {
+		// Calculate the difference of successive points.
+		value := r.curr.Value - r.prev.Value
+		return []IntegerPoint{{Time: r.curr.Time, Value: value}}
+	}
+	return nil
+}
+
 // FloatMovingAverageReducer calculates the moving average of the aggregated points.
 type FloatMovingAverageReducer struct {
 	pos  int

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -466,7 +466,6 @@ type {{$k.name}}FillIterator struct {
 	startTime int64
 	endTime   int64
 	auxFields []interface{}
-	done      bool
 	opt       IteratorOptions
 
 	window struct {
@@ -487,9 +486,9 @@ func new{{$k.Name}}FillIterator(input {{$k.Name}}Iterator, expr Expr, opt Iterat
 	var startTime, endTime int64
 	if opt.Ascending {
 		startTime, _ = opt.Window(opt.StartTime)
-		_, endTime = opt.Window(opt.EndTime)
+		endTime, _ = opt.Window(opt.EndTime)
 	} else {
-		_, startTime = opt.Window(opt.EndTime)
+		startTime, _ = opt.Window(opt.EndTime)
 		endTime, _ = opt.Window(opt.StartTime)
 	}
 
@@ -511,7 +510,11 @@ func new{{$k.Name}}FillIterator(input {{$k.Name}}Iterator, expr Expr, opt Iterat
 		itr.window.name, itr.window.tags = p.Name, p.Tags
 		itr.window.time = itr.startTime
 	} else {
-		itr.window.time = itr.endTime
+		if opt.Ascending {
+			itr.window.time = itr.endTime + 1
+		} else {
+			itr.window.time = itr.endTime - 1
+		}
 	}
 	return itr
 }
@@ -527,7 +530,7 @@ func (itr *{{$k.name}}FillIterator) Next() *{{$k.Name}}Point {
 		// If we are inside of an interval, unread the point and continue below to
 		// constructing a new point.
 		if itr.opt.Ascending {
-			if itr.window.time < itr.endTime {
+			if itr.window.time <= itr.endTime {
 				itr.input.unread(p)
 				p = nil
 				break
@@ -554,7 +557,7 @@ func (itr *{{$k.name}}FillIterator) Next() *{{$k.Name}}Point {
 	}
 
 	// Check if the point is our next expected point.
-	if p == nil || p.Time > itr.window.time {
+	if p == nil || (itr.opt.Ascending && p.Time > itr.window.time) || (!itr.opt.Ascending && p.Time < itr.window.time) {
 		if p != nil {
 			itr.input.unread(p)
 		}
@@ -812,10 +815,10 @@ func (itr *{{$k.name}}ChanIterator) Next() *{{$k.Name}}Point {
 
 // {{$k.name}}Reduce{{$v.Name}}Iterator executes a reducer for every interval and buffers the result.
 type {{$k.name}}Reduce{{$v.Name}}Iterator struct {
-	input  *buf{{$k.Name}}Iterator
-	create func() ({{$k.Name}}PointAggregator, {{$v.Name}}PointEmitter)
-	opt    IteratorOptions
-	points []{{$v.Name}}Point
+	input    *buf{{$k.Name}}Iterator
+	create   func() ({{$k.Name}}PointAggregator, {{$v.Name}}PointEmitter)
+	opt      IteratorOptions
+	points   []{{$v.Name}}Point
 }
 
 // Stats returns stats from the input iterator.
@@ -913,7 +916,7 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() []{{$v.Name}}Point {
 	return a
 }
 
-// {{$k.name}}Stream{{$v.Name}}Iterator
+// {{$k.name}}Stream{{$v.Name}}Iterator streams inputs into the iterator and emits points gradually.
 type {{$k.name}}Stream{{$v.Name}}Iterator struct {
 	input  *buf{{$k.Name}}Iterator
 	create func() ({{$k.Name}}PointAggregator, {{$v.Name}}PointEmitter)
@@ -922,6 +925,7 @@ type {{$k.name}}Stream{{$v.Name}}Iterator struct {
 	points []{{$v.Name}}Point
 }
 
+// new{{$k.Name}}Stream{{$v.Name}}Iterator returns a new instance of {{$k.name}}Stream{{$v.Name}}Iterator.
 func new{{$k.Name}}Stream{{$v.Name}}Iterator(input {{$k.Name}}Iterator, createFn func() ({{$k.Name}}PointAggregator, {{$v.Name}}PointEmitter), opt IteratorOptions) *{{$k.name}}Stream{{$v.Name}}Iterator {
 	return &{{$k.name}}Stream{{$v.Name}}Iterator{
 		input:  newBuf{{$k.Name}}Iterator(input),
@@ -1239,7 +1243,6 @@ func (enc *IteratorEncoder) encode{{.Name}}Iterator(itr {{.Name}}Iterator) error
 			}
 		default:
 		}
-
 
 		// Retrieve the next point from the iterator.
 		p := itr.Next()


### PR DESCRIPTION
For aggregate queries, derivatives will now alter the start time to one
interval behind and will use that interval to find the derivative of the
first point instead of giving no value for that interval.

This does not apply to raw queries yet.

Fixes #3247. Contributes to #5943.