### PR TITLE
store engine start compactCache goroutine before reload wal to cache.fix issues#6109

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -145,16 +145,16 @@ func (e *Engine) Open() error {
 		return err
 	}
 
-	if err := e.reloadCache(); err != nil {
-		return err
-	}
-
 	e.wg.Add(5)
 	go e.compactCache()
 	go e.compactTSMFull()
 	go e.compactTSMLevel(true, 1)
 	go e.compactTSMLevel(true, 2)
 	go e.compactTSMLevel(false, 3)
+
+	if err := e.reloadCache(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
diff --git a/tsdb/engine/tsm1/engine.go b/tsdb/engine/tsm1/engine.go
index 82228b9..d35d961 100644
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -145,10 +145,6 @@ func (e *Engine) Open() error {
                return err
        }

-       if err := e.reloadCache(); err != nil {
-               return err
-       }
-
        e.wg.Add(5)
        go e.compactCache()
        go e.compactTSMFull()
@@ -156,6 +152,10 @@ func (e *Engine) Open() error {
        go e.compactTSMLevel(true, 2)
        go e.compactTSMLevel(false, 3)

+       if err := e.reloadCache(); err != nil {
+               return err
+       }
+
        return nil
 }
