### PR TITLE
Fix default continuous query lease host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.11.1
+
+### Bugfixes
+
+- [#6129](https://github.com/influxdata/influxdb/pull/6129): Fix default continuous query lease host
+
+
 ## v0.11.0 [2016-03-22]
 
 ### Release Notes

--- a/services/meta/handler.go
+++ b/services/meta/handler.go
@@ -347,7 +347,7 @@ func (h *handler) serveLease(w http.ResponseWriter, r *http.Request) {
 
 	// Redirect to leader if necessary.
 	leader := h.store.leaderHTTP()
-	if leader != h.s.httpAddr {
+	if leader != h.s.remoteAddr(h.s.httpAddr) {
 		if leader == "" {
 			// No cluster leader. Client will have to try again later.
 			h.httpError(errors.New("no leader"), w, http.StatusServiceUnavailable)


### PR DESCRIPTION
## Overview

This commit changes the lease acquisition to add the default host to the meta http handler so that the leader address and http address will match.

re: #5896, #6096

## TODO

- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
