### PR TITLE
Have the server kill all queries on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#6116](https://github.com/influxdata/influxdb/pull/6116): Allow `httpd` service to be extensible for routes
 - [#6111](https://github.com/influxdata/influxdb/pull/6111): Add ability to build static assest. Improved handling of TAR and ZIP package outputs.
 - [#1825](https://github.com/influxdata/influxdb/issues/1825): Implement difference function.
+- [#6149](https://github.com/influxdata/influxdb/pull/6149): Kill running queries when server is shutdown.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -310,6 +310,10 @@ func (s *Server) Close() error {
 		s.PointsWriter.Close()
 	}
 
+	if s.QueryExecutor.QueryManager != nil {
+		s.QueryExecutor.QueryManager.Close()
+	}
+
 	// Close the TSDBStore, no more reads or writes at this point
 	if s.TSDBStore != nil {
 		s.TSDBStore.Close()


### PR DESCRIPTION
Related to #6140, but won't actually fix that problem. It will correctly
stop new queries from being started during shutdown and will send the
interrupt signal to queries during shutdown.

Since the interrupt signal is asynchronous, there isn't currently a way
to wait for the queries to complete themselves before shutting down the
engine.