### PR TITLE
Ensure safe access to Shard engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#6092](https://github.com/influxdata/influxdb/issues/6092): Upgrading directly from 0.9.6.1 to 0.11.0 fails
 - [#6061](https://github.com/influxdata/influxdb/issues/6061): [0.12 / master] POST to /write does not write points if request has header 'Content-Type: application/x-www-form-urlencoded'
 - [#6121](https://github.com/influxdata/influxdb/issues/6121): Fix panic: slice index out of bounds in TSM index
+- [#6140](https://github.com/influxdata/influxdb/issues/6140): Ensure Shard engine not accessed when closed.
 
 ## v0.11.0 [2016-03-22]
 


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fixes #6140.

This PR ensures that it's not possible to access a shard's underlying engine once it has been closed. It also synchronises access to the underlying engine to prevent potential data races on `Shard.engine`.

@benbjohnson @jwilder I'd appreciate your thoughts here since I'm not sure if this is going to be adding undue bottlenecks. The alternative would be to never `nil` `s.engine` and let the underlying `tsm1/Engine` return errors when it's accessed after it's been closed.

/cc @jsternberg 