### PR TITLE
WIP - Restore fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#6148](https://github.com/influxdata/influxdb/pull/6148): Build script is now compatible with Python 3. Added ability to create detached signatures for packages. Build script now uses Python logging facility for messages.
 - [#6115](https://github.com/influxdata/influxdb/issues/6115): Support chunking query results mid-series. Limit non-chunked output.
 - [#6166](https://github.com/influxdata/influxdb/pull/6166): Teach influxdb client how to use chunked queries and use in the CLI.
+- [#6158](https://github.com/influxdata/influxdb/pull/6158): Update influxd to detect an upgrade from `0.11` to `0.12`.  Minor restore bug fixes.
 
 ### Bugfixes
 

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -170,7 +170,7 @@ func (cmd *Command) unpackMeta() error {
 
 	// Copy meta config and remove peers so it starts in single mode.
 	c := cmd.MetaConfig
-	c.LoggingEnabled = false
+	c.Dir = cmd.metadir
 
 	// Create the meta dir
 	if os.MkdirAll(c.Dir, 0700); err != nil {
@@ -193,6 +193,16 @@ func (cmd *Command) unpackMeta() error {
 	if err := client.SetData(&data); err != nil {
 		return fmt.Errorf("set data: %s", err)
 	}
+
+	// remove the raft.db file if it exists
+	err = os.Remove(filepath.Join(cmd.metadir, "raft.db"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
 	return nil
 }
 

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -203,6 +203,15 @@ func (cmd *Command) unpackMeta() error {
 		return err
 	}
 
+	// remove the node.json file if it exists
+	err = os.Remove(filepath.Join(cmd.metadir, "node.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
 	return nil
 }
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -115,6 +115,13 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 		}
 	}
 
+	// Check to see if there is a raft db, if so, error out with a message
+	// to downgrade, export, and then import the meta data
+	raftFile := filepath.Join(c.Meta.Dir, "raft.db")
+	if _, err := os.Stat(raftFile); err == nil {
+		return nil, fmt.Errorf("detected %s.  either downgrade and export your meta data to import before continuing, or delete the file to start fresh", raftFile)
+	}
+
 	// In 0.10.0 bind-address got moved to the top level. Check
 	// The old location to keep things backwards compatible
 	bind := c.BindAddress

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -91,14 +91,6 @@ func (c *Client) Open() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Check to see if there is a raft db, if so, error out with a message
-	// to downgrade, export, and then import the meta data
-
-	raftFile := filepath.Join(c.path, "raft.db")
-	if _, err := os.Stat(raftFile); err == nil {
-		return fmt.Errorf("detected %s.  either downgrade and export your meta data to import before continuing, or delete the file to start fresh", raftFile)
-	}
-
 	// Try to load from disk
 	if err := c.Load(); err != nil {
 		return err

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -975,7 +975,7 @@ func snapshot(path string, data *Data) error {
 		return err
 	}
 
-	if err = f.Close(); nil != err {
+	if err = f.Sync(); err != nil {
 		return err
 	}
 

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -90,6 +90,15 @@ func NewClient(config *Config) *Client {
 func (c *Client) Open() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// Check to see if there is a raft db, if so, error out with a message
+	// to downgrade, export, and then import the meta data
+
+	raftFile := filepath.Join(c.path, "raft.db")
+	if _, err := os.Stat(raftFile); err == nil {
+		return fmt.Errorf("detected %s.  either downgrade and export your meta data to import before continuing, or delete the file to start fresh", raftFile)
+	}
+
 	// Try to load from disk
 	if err := c.Load(); err != nil {
 		return err


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [ ] Docs webpages updated

This PR addresses the upgrading of a single node from `0.11` to `0.12`.  In `0.11`, the meta store information was stored in `raft.db` via the raft services.  In `0.12`, the meta store information is now stored in `meta.db` which is a binary protobuf file.

If you are upgrading from from `0.11` to `0.12`, the following steps need to be taken:

NOTE: This process will remove the `raft.db` and `node.json` files.  It is recommended you backup the entire directory structure in case of a failure during the upgrade.

1) While still running `0.11`, export your meta data with a command like:

```sh
influxd backup <backup directory>
```

2) Upgrade the `influxd` binary from `0.11` to `0.12`.  Do not start the service yet.

3) Restore the meta store with the following command:

```sh
influxd restore -metadir=<meta directory> <backup directory>
```

4) Start the service and confirm the meta data is present.