### PR TITLE
Fixed consistency level parameter being ignored

### DIFF
--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -181,7 +181,7 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 // WritePointsInto is a copy of WritePoints that uses a tsdb structure instead of
 // a cluster structure for information. This is to avoid a circular dependency
 func (w *PointsWriter) WritePointsInto(p *IntoWriteRequest) error {
-	return w.WritePoints(p.Database, p.RetentionPolicy, models.ConsistencyLevelAny, p.Points)
+	return w.WritePoints(p.Database, p.RetentionPolicy, models.ConsistencyLevelOne, p.Points)
 }
 
 // WritePoints writes across multiple local and remote data nodes according the consistency level.

--- a/cluster/points_writer_test.go
+++ b/cluster/points_writer_test.go
@@ -234,7 +234,7 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 		c.Open()
 		defer c.Close()
 
-		err := c.WritePoints(pr.Database, pr.RetentionPolicy, models.ConsistencyLevelAny, pr.Points)
+		err := c.WritePoints(pr.Database, pr.RetentionPolicy, models.ConsistencyLevelOne, pr.Points)
 		if err == nil && test.expErr != nil {
 			t.Errorf("PointsWriter.WritePoints(): '%s' error: got %v, exp %v", test.name, err, test.expErr)
 		}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

The http handler consistency level parameter was removed and hard-coded
to "any."  It needs to be read and passed through to the points writer.
