### PR TITLE
Fix default continuous query lease host (0.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Bugfixes
 
 - [#6092](https://github.com/influxdata/influxdb/issues/6092): Upgrading directly from 0.9.6.1 to 0.11.0 fails
+- [#6129](https://github.com/influxdata/influxdb/pull/6129): Fix default continuous query lease host
+
 
 ## v0.11.0 [2016-03-22]
 

--- a/services/meta/handler.go
+++ b/services/meta/handler.go
@@ -347,7 +347,7 @@ func (h *handler) serveLease(w http.ResponseWriter, r *http.Request) {
 
 	// Redirect to leader if necessary.
 	leader := h.store.leaderHTTP()
-	if leader != h.s.httpAddr {
+	if leader != h.s.remoteAddr(h.s.httpAddr) {
 		if leader == "" {
 			// No cluster leader. Client will have to try again later.
 			h.httpError(errors.New("no leader"), w, http.StatusServiceUnavailable)


### PR DESCRIPTION
## Overview 

This pull request changes the lease acquisition to add the default host to the meta http handler so that the leader address and http address will match.

/cc @jwilder 

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
