### PR TITLE
Use timer for mux timeout

### DIFF
--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -103,9 +103,12 @@ func (mux *Mux) handleConn(conn net.Conn) {
 	}
 
 	// Send connection to handler.  The handler is responsible for closing the connection.
+	timer := time.NewTimer(mux.Timeout)
+	defer timer.Stop()
+
 	select {
 	case handler.c <- conn:
-	case <-time.After(mux.Timeout):
+	case <-timer.C:
 		conn.Close()
 		mux.Logger.Printf("tcp.Mux: handler not ready: %d. Connection from %s closed", typ[0], conn.RemoteAddr())
 		return


### PR DESCRIPTION
## Overview

This commit changes the timeout for `mux.Mux.handleConn()` to use `time.Timer` instead of `time.After()` so that the channel can be closed immediately once the connection is handed off.

/cc @jwilder

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


