### PR TITLE
Support chunked queries in the Go InfluxDB client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#5372](https://github.com/influxdata/influxdb/pull/5372): Faster shard loading
 - [#6148](https://github.com/influxdata/influxdb/pull/6148): Build script is now compatible with Python 3. Added ability to create detached signatures for packages. Build script now uses Python logging facility for messages.
 - [#6115](https://github.com/influxdata/influxdb/issues/6115): Support chunking query results mid-series. Limit non-chunked output.
+- [#6166](https://github.com/influxdata/influxdb/pull/6166): Teach influxdb client how to use chunked queries and use in the CLI.
 
 ### Bugfixes
 

--- a/cluster/query_executor.go
+++ b/cluster/query_executor.go
@@ -94,7 +94,7 @@ func (e *QueryExecutor) executeQuery(query *influxql.Query, database string, chu
 	var qid uint64
 	if e.QueryManager != nil {
 		var err error
-		_, closing, err = e.QueryManager.AttachQuery(&influxql.QueryParams{
+		qid, closing, err = e.QueryManager.AttachQuery(&influxql.QueryParams{
 			Query:       query,
 			Database:    database,
 			Timeout:     e.QueryTimeout,
@@ -105,6 +105,8 @@ func (e *QueryExecutor) executeQuery(query *influxql.Query, database string, chu
 			results <- &influxql.Result{Err: err}
 			return
 		}
+
+		defer e.QueryManager.KillQuery(qid)
 	}
 
 	logger := e.logger()


### PR DESCRIPTION
Modify the CLI to always use chunked queries.