### PR TITLE
Fix write path lock contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [#6121](https://github.com/influxdata/influxdb/issues/6121): Fix panic: slice index out of bounds in TSM index
 - [#6140](https://github.com/influxdata/influxdb/issues/6140): Ensure Shard engine not accessed when closed.
 - [#6110](https://github.com/influxdata/influxdb/issues/6110): Fix for 0.9 upgrade path when using RPM
+- [#6131](https://github.com/influxdata/influxdb/issues/6061): Fix write throughput regression with large number of measurments
 
 ## v0.11.0 [2016-03-22]
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1353,19 +1353,6 @@ func (s *Series) InitializeShards() {
 	s.mu.Unlock()
 }
 
-// match returns true if all tags match the series' tags.
-func (s *Series) match(tags map[string]string) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	for k, v := range tags {
-		if s.Tags[k] != v {
-			return false
-		}
-	}
-	return true
-}
-
 // SeriesIDs is a convenience type for sorting, checking equality, and doing
 // union and intersection of collections of series ids.
 type SeriesIDs []uint64

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -374,8 +374,6 @@ func (d *DatabaseIndex) DropMeasurement(name string) {
 		delete(d.series, s.Key)
 	}
 
-	m.drop()
-
 	d.statMap.Add(statDatabaseSeries, int64(-len(m.seriesByID)))
 	d.statMap.Add(statDatabaseMeasurements, -1)
 }
@@ -417,8 +415,6 @@ type Measurement struct {
 	measurement         *Measurement
 	seriesByTagKeyValue map[string]map[string]SeriesIDs // map from tag key to value to sorted set of series ids
 	seriesIDs           SeriesIDs                       // sorted list of series IDs in this measurement
-
-	statMap *expvar.Map
 }
 
 // NewMeasurement allocates and initializes a new Measurement.
@@ -431,12 +427,6 @@ func NewMeasurement(name string, idx *DatabaseIndex) *Measurement {
 		seriesByID:          make(map[uint64]*Series),
 		seriesByTagKeyValue: make(map[string]map[string]SeriesIDs),
 		seriesIDs:           make(SeriesIDs, 0),
-
-		statMap: influxdb.NewStatistics(
-			fmt.Sprintf("measurement:%s.%s", name, idx.name),
-			"measurement",
-			map[string]string{"database": idx.name, "measurement": name},
-		),
 	}
 }
 
@@ -529,7 +519,6 @@ func (m *Measurement) AddSeries(s *Series) bool {
 		valueMap[v] = ids
 	}
 
-	m.statMap.Add(statMeasurementSeries, 1)
 	return true
 }
 
@@ -577,15 +566,7 @@ func (m *Measurement) DropSeries(seriesID uint64) {
 		}
 	}
 
-	m.statMap.Add(statMeasurementSeries, -1)
-
 	return
-}
-
-// drop handles any cleanup for when a measurement is dropped.
-// Currently only cleans up stats.
-func (m *Measurement) drop() {
-	m.statMap.Add(statMeasurementSeries, int64(-len(m.seriesIDs)))
 }
 
 // filters walks the where clause of a select statement and returns a map with all series ids


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes two performance regressions in the write path.
* #5816 introduced a locking issue when creating a new statistics for a measurement.  #6131 had a script that creates 100k measurements that reproduces the issue.  This PR reverts the measurement statistics added in #5816.  If we need to track them, we'll need to find a different way to do it.  A side-effect of removing this is that shards load much faster now.
* #5372 introduced an index write lock issue when adding a shard to a series in the in-memory index.   Running the script from #6131 showed this lock contention.  This PR moves the lock to the series to avoid locking the whole index.

cc @mark-rushakoff 

Fixes #6131 