### PR TITLE
Fix TSM UnmarshalBinary panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [#6094](https://github.com/influxdata/influxdb/issues/6094): Ensure CREATE RETENTION POLICY and CREATE CONTINUOUS QUERY are idempotent in the correct way.
 - [#6092](https://github.com/influxdata/influxdb/issues/6092): Upgrading directly from 0.9.6.1 to 0.11.0 fails
 - [#6061](https://github.com/influxdata/influxdb/issues/6061): [0.12 / master] POST to /write does not write points if request has header 'Content-Type: application/x-www-form-urlencoded'
+- [#6121](https://github.com/influxdata/influxdb/issues/6121): Fix panic: slice index out of bounds in TSM index
 
 ## v0.11.0 [2016-03-22]
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1791,3 +1791,18 @@ func TestNewPointsRejectsEmptyFieldNames(t *testing.T) {
 		t.Fatalf("new point with empty field name. got: nil, expected: error")
 	}
 }
+
+func TestNewPointsRejectsMaxKey(t *testing.T) {
+	var key string
+	for i := 0; i < 65536; i++ {
+		key += "a"
+	}
+
+	if _, err := models.NewPoint(key, nil, models.Fields{"value": 1}, time.Now()); err == nil {
+		t.Fatalf("new point with max key. got: nil, expected: error")
+	}
+
+	if _, err := models.ParsePointsString(fmt.Sprintf("%v value=1", key)); err == nil {
+		t.Fatalf("parse point with max key. got: nil, expected: error")
+	}
+}

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -94,11 +94,15 @@ const (
 
 	// Max number of blocks for a given key that can exist in a single file
 	maxIndexEntries = (1 << (indexCountSize * 8)) - 1
+
+	// max length of a key in an index entry (measurement + tags)
+	maxKeyLength = (1 << (2 * 8)) - 1
 )
 
 var (
-	ErrNoValues  = fmt.Errorf("no values written")
-	ErrTSMClosed = fmt.Errorf("tsm file closed")
+	ErrNoValues             = fmt.Errorf("no values written")
+	ErrTSMClosed            = fmt.Errorf("tsm file closed")
+	ErrMaxKeyLengthExceeded = fmt.Errorf("max key length exceeded")
 )
 
 // TSMWriter writes TSM formatted key and values.
@@ -540,6 +544,10 @@ func (t *tsmWriter) Write(key string, values Values) error {
 	// Nothing to write
 	if len(values) == 0 {
 		return nil
+	}
+
+	if len(key) > maxKeyLength {
+		return ErrMaxKeyLengthExceeded
 	}
 
 	// Write header only after we have some data to write.

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -3,6 +3,7 @@ package tsm1_test
 import (
 	"bytes"
 	"encoding/binary"
+	"os"
 	"testing"
 
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
@@ -508,5 +509,25 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 				t.Fatalf("read value mismatch(%d): got %v, exp %d", i, readValues[i].Value(), v.Value())
 			}
 		}
+	}
+}
+
+func TestTSMWriter_Write_MaxKey(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	f := MustTempFile(dir)
+	defer f.Close()
+
+	w, err := tsm1.NewTSMWriter(f)
+	if err != nil {
+		t.Fatalf("unexpected error created writer: %v", err)
+	}
+
+	var key string
+	for i := 0; i < 100000; i++ {
+		key += "a"
+	}
+	if err := w.Write(key, []tsm1.Value{tsm1.NewValue(0, 1.0)}); err != tsm1.ErrMaxKeyLengthExceeded {
+		t.Fatalf("expected max key length error writing key: %v", err)
 	}
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

If writing points ended up creating a key (measurement + tag sets) that was larger than 65535 bytes, it could overflow the length bytes in the the TSM index causing a panic when opening the file:

```
panic: runtime error: slice bounds out of range

goroutine 71 [running]:
github.com/influxdb/influxdb/tsdb/engine/tsm1.(*indirectIndex).UnmarshalBinary(0xc222850f00, 0x7f715
abea3c9, 0x7efa2a, 0x7efa32, 0x0, 0x0)
        /tmp/tmp.n7AHL1nb9U/src/github.com/influxdb/influxdb/tsdb/engine/tsm1/reader.go:639 +0x45f
```

I was able to reproduce this panic in a test by writing a key of 100k bytes.

This PR checks for that condition in the TSM writer so that an error is returned if a large key is written.  It also adds validation to `models.Point` to prevent creating a point that would exceed the max key length.

May fix #6121 #6022 #6054 #5202