### PR TITLE
Mark MergeIterator as initialized

### DIFF
--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -182,6 +182,7 @@ func (itr *floatMergeIterator) Next() *FloatPoint {
 			itr.heap.items = append(itr.heap.items, item)
 		}
 		heap.Init(itr.heap)
+		itr.init = true
 	}
 
 	for {
@@ -1994,6 +1995,7 @@ func (itr *integerMergeIterator) Next() *IntegerPoint {
 			itr.heap.items = append(itr.heap.items, item)
 		}
 		heap.Init(itr.heap)
+		itr.init = true
 	}
 
 	for {
@@ -3803,6 +3805,7 @@ func (itr *stringMergeIterator) Next() *StringPoint {
 			itr.heap.items = append(itr.heap.items, item)
 		}
 		heap.Init(itr.heap)
+		itr.init = true
 	}
 
 	for {
@@ -5612,6 +5615,7 @@ func (itr *booleanMergeIterator) Next() *BooleanPoint {
 			itr.heap.items = append(itr.heap.items, item)
 		}
 		heap.Init(itr.heap)
+		itr.init = true
 	}
 
 	for {

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -179,6 +179,7 @@ func (itr *{{$k.name}}MergeIterator) Next() *{{$k.Name}}Point {
 			itr.heap.items = append(itr.heap.items, item)
 		}
 		heap.Init(itr.heap)
+		itr.init = true
 	}
 
 	for {


### PR DESCRIPTION
## Overview

This commit sets the `MergeIterator.init` flag after initialization. Previously this would generate a new heap on every call to `Next()` which caused aggregate queries to slow by ~10,000%.

Related commit: 278b0950a72857d4569247dfb122a31668b64773

/cc @jsternberg @jwilder 

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
