### PR TITLE
Use preferred go1.4.3 for docker images too.

### DIFF
--- a/build-docker.sh
+++ b/build-docker.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-GO_VER=${GO_VER:-1.5}
+GO_VER=${GO_VER:-1.4.3}
 
 docker run -it -v "${GOPATH}":/gopath -v "$(pwd)":/app -e "GOPATH=/gopath" -w /app golang:$GO_VER sh -c 'CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags="-s" -o influxd ./cmd/influxd'
 


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Some people (e.g. me!) use builder-docker.sh to create docker images.

I got burnt by the go 1.5 performance issue because I didn't override
the default GO_VER variable.

This change sets the default to the same as used in the main build.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>