### PR TITLE
Write path tuning

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -1432,17 +1432,14 @@ func parseNumber(val []byte) (interface{}, error) {
 }
 
 func newFieldsFromBinary(buf []byte) Fields {
-	fields := Fields{}
+	fields := make(Fields, 8)
 	var (
 		i              int
 		name, valueBuf []byte
 		value          interface{}
 		err            error
 	)
-	for {
-		if i >= len(buf) {
-			break
-		}
+	for i < len(buf) {
 
 		i, name = scanTo(buf, i, '=')
 		name = escape.Unescape(name)

--- a/models/points.go
+++ b/models/points.go
@@ -1062,14 +1062,7 @@ func escapeStringField(in string) string {
 // unescapeStringField returns a copy of in with any escaped double-quotes
 // or backslashes unescaped
 func unescapeStringField(in string) string {
-	var hasEscape bool
-	for _, b := range in {
-		if b == '\\' {
-			hasEscape = true
-		}
-	}
-
-	if !hasEscape {
+	if strings.IndexByte(in, '\\') == -1 {
 		return in
 	}
 

--- a/models/points.go
+++ b/models/points.go
@@ -1062,6 +1062,17 @@ func escapeStringField(in string) string {
 // unescapeStringField returns a copy of in with any escaped double-quotes
 // or backslashes unescaped
 func unescapeStringField(in string) string {
+	var hasEscape bool
+	for _, b := range in {
+		if b == '\\' {
+			hasEscape = true
+		}
+	}
+
+	if !hasEscape {
+		return in
+	}
+
 	var out []byte
 	i := 0
 	for {

--- a/pkg/escape/bytes.go
+++ b/pkg/escape/bytes.go
@@ -14,15 +14,7 @@ func Unescape(in []byte) []byte {
 		return nil
 	}
 
-	var hasEscape bool
-	for _, b := range in {
-		if b == '\\' {
-			hasEscape = true
-			break
-		}
-	}
-
-	if !hasEscape {
+	if bytes.IndexByte(in, '\\') == -1 {
 		return in
 	}
 

--- a/pkg/escape/bytes.go
+++ b/pkg/escape/bytes.go
@@ -10,6 +10,22 @@ func Bytes(in []byte) []byte {
 }
 
 func Unescape(in []byte) []byte {
+	if len(in) == 0 {
+		return nil
+	}
+
+	var hasEscape bool
+	for _, b := range in {
+		if b == '\\' {
+			hasEscape = true
+			break
+		}
+	}
+
+	if !hasEscape {
+		return in
+	}
+
 	i := 0
 	inLen := len(in)
 	var out []byte

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -314,9 +314,10 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 	// get the shard mutex for locally defined fields
 	for _, p := range points {
 		// see if the series should be added to the index
-		ss := s.index.Series(string(p.Key()))
+		key := string(p.Key())
+		ss := s.index.Series(key)
 		if ss == nil {
-			ss = NewSeries(string(p.Key()), p.Tags())
+			ss = NewSeries(key, p.Tags())
 			s.statMap.Add(statSeriesCreate, 1)
 		}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated

This PR has a few small optimizations for code in the write path.  It mostly avoids some allocations and reduces the time locks are held when not necessary.  Locally, I see about ~5% improvement in write throughput with `influx_stress` and fewer allocations in the profiles.