### PR TITLE
Fixing a goroutine leak in the 0.12 release candidate when using KILL QUERY

### DIFF
--- a/influxql/query_manager.go
+++ b/influxql/query_manager.go
@@ -210,7 +210,7 @@ func (qm *defaultQueryManager) AttachQuery(params *QueryParams) (uint64, <-chan 
 	}
 	qm.queries[qid] = query
 
-	go qm.waitForQuery(qid, params.Timeout, params.InterruptCh, query.monitorCh)
+	go qm.waitForQuery(qid, query.closing, params.Timeout, params.InterruptCh, query.monitorCh)
 	qm.nextID++
 	return qid, query.closing, nil
 }
@@ -222,10 +222,12 @@ func (qm *defaultQueryManager) Query(qid uint64) (*queryTask, bool) {
 	return query, ok
 }
 
-func (qm *defaultQueryManager) waitForQuery(qid uint64, timeout time.Duration, closing <-chan struct{}, monitorCh <-chan error) {
+func (qm *defaultQueryManager) waitForQuery(qid uint64, interrupt <-chan struct{}, timeout time.Duration, closing <-chan struct{}, monitorCh <-chan error) {
 	var timer <-chan time.Time
 	if timeout != 0 {
-		timer = time.After(timeout)
+		t := time.NewTimer(timeout)
+		timer = t.C
+		defer t.Stop()
 	}
 
 	select {
@@ -251,6 +253,9 @@ func (qm *defaultQueryManager) waitForQuery(qid uint64, timeout time.Duration, c
 			break
 		}
 		query.setError(ErrQueryTimeoutReached)
+	case <-interrupt:
+		// Query was manually closed so exit the select.
+		return
 	}
 	qm.KillQuery(qid)
 }


### PR DESCRIPTION
This is being fixed in master with a complete refactor of the
QueryExecutor, but that refactor won't cleanly apply to 0.12. This fix
is pretty important for ensuring that the goroutine used to monitor a
query finishes when a query is killed through `KILL QUERY`.