### PR TITLE
Improves existing RP checking when creating a DB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#6271](https://github.com/influxdata/influxdb/issues/6271): Fixed deadlock in tsm1 file store.
 - [#6287](https://github.com/influxdata/influxdb/issues/6287): Fix data race in Influx Client.
 - [#6252](https://github.com/influxdata/influxdb/pull/6252): Remove TSDB listener accept message @simnv
+- [#6202](https://github.com/influxdata/influxdb/pull/6202): Check default SHARD DURATION when recreating the same database.
 
 ## v0.12.0 [2016-04-05]
 ### Release Notes

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -230,6 +230,8 @@ func (c *Client) CreateDatabaseWithRetentionPolicy(name string, rpi *RetentionPo
 		// Check if the retention policy already exists. If it does and matches
 		// the desired retention policy, exit with no error.
 		if rp := db.RetentionPolicy(rpi.Name); rp != nil {
+			// Normalise ShardDuration before comparing to any existing retention policies.
+			rpi.ShardGroupDuration = normalisedShardDuration(rpi.ShardGroupDuration, rpi.Duration)
 			if rp.ReplicaN != rpi.ReplicaN || rp.Duration != rpi.Duration || rp.ShardGroupDuration != rpi.ShardGroupDuration {
 				return nil, ErrRetentionPolicyConflict
 			}

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -141,9 +141,7 @@ func (data *Data) CreateRetentionPolicy(database string, rpi *RetentionPolicyInf
 
 	// Normalise ShardDuration before comparing to any existing
 	// retention policies
-	if rpi.ShardGroupDuration == 0 {
-		rpi.ShardGroupDuration = shardGroupDuration(rpi.Duration)
-	}
+	rpi.ShardGroupDuration = normalisedShardDuration(rpi.ShardGroupDuration, rpi.Duration)
 
 	// Find database.
 	di := data.Database(database)
@@ -957,6 +955,14 @@ func shardGroupDuration(d time.Duration) time.Duration {
 		return 1 * 24 * time.Hour
 	}
 	return 1 * time.Hour
+}
+
+// normalisedShardDuration returns normalised shard duration based on a policy duration.
+func normalisedShardDuration(sgd, d time.Duration) time.Duration {
+	if sgd == 0 {
+		return shardGroupDuration(d)
+	}
+	return sgd
 }
 
 // ShardGroupInfo represents metadata about a shard group. The DeletedAt field is important


### PR DESCRIPTION
#### Details

- Currently when running an InfluxQL(`CREATE DATABASE IF NOT EXISTS xyz WITH DURATION 24h0m0s REPLICATION 1 NAME one_day_only`) to create a database which does not provide `shard duration` a default value will be set for it via:

  - [`meta.Data.CreateRetentionPolicy(...)`](https://github.com/influxdata/influxdb/blob/master/services/meta/data.go#L134) [sets](https://github.com/influxdata/influxdb/blob/master/services/meta/data.go#L145) a default value   (currently [1 hour](https://github.com/influxdata/influxdb/blob/master/services/meta/data.go#L959)).

- When re-running the same InfluxQL mentioned above, an error will occur (`retention policy conflicts with an existing policy`) when it shouldn't, based on the expected behavior of `IF NOT EXISTS` & confirmed by the [docs](https://github.com/influxdata/influxdb/blob/master/services/meta/client.go#L230):

  ```go	
// Check if the retention policy already exists. If it does and matches
// the desired retention policy, exit with no error.
```

  - So current strategy for checking retention policies does not consider the default `shard duration` value mentioned above.


- TL:DR, this PR improves the checking for existing retention policy within [`meta.Client.CreateDatabaseWithRetentionPolicy(...)`](https://github.com/influxdata/influxdb/blob/master/services/meta/client.go#L219) to consider the default `shard duration` value which is set when none is provided when creating a database.

***

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
