### PR TITLE
fix TestMetaClient_CreateDatabaseIfNotExists fail on the windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This release removes all of the old clustering code. It operates as a standalone
 
 ### Bugfixes
 
+- [#6212](https://github.com/influxdata/influxdb/pull/6212): Fix TestMetaClient_CreateDatabaseIfNotExists fail on the windows.
 - [#5152](https://github.com/influxdata/influxdb/issues/5152): Fix where filters when a tag and a filter are combined with OR.
 - [#5728](https://github.com/influxdata/influxdb/issues/5728): Properly handle semi-colons as part of the main query loop.
 - [#6065](https://github.com/influxdata/influxdb/pull/6065):  Wait for a process termination on influxdb restart @simnv

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -979,6 +979,7 @@ func snapshot(path string, data *Data) error {
 	if err = f.Sync(); err != nil {
 		return err
 	}
+	f.Close() // must close file before rename file.
 
 	return renameFile(tmpFile, file)
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

````
=== RUN   TestMetaClient_CreateDatabaseIfNotExists
--- FAIL: TestMetaClient_CreateDatabaseIfNotExists (0.40s)
panic: rename C:\Users\meifakun\AppData\Local\Temp\meta_test.newClient270200807\meta.dbtmp C:\Users\meifakun\AppData\Local\Temp\meta_test.newClient270200807\meta.db: The process cannot access the file because it is being used by another process. [recovered]
        panic: rename C:\Users\meifakun\AppData\Local\Temp\meta_test.newClient270200807\meta.dbtmp C:\Users\meifakun\AppData\Local\Temp\meta_test.newClient270200807\meta.db: The process cannot access the file because it is being used by another process.

goroutine 5 [running]:
panic(0x81b940, 0xc08200ba40)
        d:/tools/go_amd64/src/runtime/panic.go:464 +0x3f4
testing.tRunner.func1(0xc08205a090)
        d:/tools/go_amd64/src/testing/testing.go:467 +0x199
panic(0x81b940, 0xc08200ba40)
        d:/tools/go_amd64/src/runtime/panic.go:426 +0x4f7
github.com/influxdata/influxdb/services/meta_test.newClient(0x0, 0x0, 0x0)
        D:/developing/go/influxdb/src/github.com/influxdata/influxdb/services/meta/client_test.go:781 +0x96
github.com/influxdata/influxdb/services/meta_test.TestMetaClient_CreateDatabaseIfNotExists(0xc08205a090)
        D:/developing/go/influxdb/src/github.com/influxdata/influxdb/services/meta/client_test.go:56 +0x4c
testing.tRunner(0xc08205a090, 0xafba78)
        d:/tools/go_amd64/src/testing/testing.go:473 +0x9f
created by testing.RunTests
        d:/tools/go_amd64/src/testing/testing.go:582 +0x899
exit status 2
FAIL    github.com/influxdata/influxdb/services/meta    1.752s
````