### PR TITLE
Make logging output location more programmatically configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- [#6213](https://github.com/influxdata/influxdb/pull/6213): Make logging output location more programmatically configurable.
 - [#6237](https://github.com/influxdata/influxdb/issues/6237): Enable continuous integration testing on Windows platform via AppVeyor. Thanks @mvadu
 - [#6263](https://github.com/influxdata/influxdb/pull/6263): Reduce UDP Service allocation size.
 - [#6228](https://github.com/influxdata/influxdb/pull/6228): Support for multiple listeners for collectd and OpenTSDB inputs.

--- a/cluster/points_writer.go
+++ b/cluster/points_writer.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"errors"
 	"expvar"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -138,6 +139,12 @@ func (w *PointsWriter) Close() error {
 		w.subPoints = nil
 	}
 	return nil
+}
+
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (w *PointsWriter) SetLogOutput(lw io.Writer) {
+	w.Logger = log.New(lw, "[write] ", log.LstdFlags)
 }
 
 // MapShards maps the points contained in wp to a ShardMapping.  If a point

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -92,9 +92,10 @@ func (s *Service) Open() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[cluster] ", log.LstdFlags)
 }
 
 // serve accepts connections from the listener and handles them.

--- a/cluster/statement_executor_test.go
+++ b/cluster/statement_executor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"log"
 	"os"
 	"reflect"
 	"testing"
@@ -180,10 +181,11 @@ func NewQueryExecutor() *QueryExecutor {
 	}
 	e.QueryExecutor.StatementExecutor = e.StatementExecutor
 
-	e.QueryExecutor.LogOutput = &e.LogOutput
+	var out io.Writer = &e.LogOutput
 	if testing.Verbose() {
-		e.QueryExecutor.LogOutput = io.MultiWriter(e.QueryExecutor.LogOutput, os.Stderr)
+		out = io.MultiWriter(out, os.Stderr)
 	}
+	e.QueryExecutor.Logger = log.New(out, "[query] ", log.LstdFlags)
 
 	return e
 }

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -183,7 +182,7 @@ func (cmd *Command) unpackMeta() error {
 	}
 
 	client := meta.NewClient(c)
-	client.SetLogger(log.New(ioutil.Discard, "", 0))
+	client.SetLogOutput(ioutil.Discard)
 	if err := client.Open(); err != nil {
 		return err
 	}

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -244,18 +244,22 @@ func (s *Server) Open() error {
 	s.appendAdminService(s.config.Admin)
 	s.appendContinuousQueryService(s.config.ContinuousQuery)
 	s.appendHTTPDService(s.config.HTTPD)
-	s.appendCollectdService(s.config.Collectd)
-	if err := s.appendOpenTSDBService(s.config.OpenTSDB); err != nil {
-		return nil, err
-	}
-	for _, g := range s.config.UDPs {
-		s.appendUDPService(g)
-	}
 	s.appendRetentionPolicyService(s.config.Retention)
-	for _, g := range s.config.Graphites {
-		if err := s.appendGraphiteService(g); err != nil {
-			return nil, err
+	for _, i := range s.config.GraphiteInputs {
+		if err := s.appendGraphiteService(i); err != nil {
+			return err
 		}
+	}
+	for _, i := range s.config.CollectdInputs {
+		s.appendCollectdService(i)
+	}
+	for _, i := range s.config.OpenTSDBInputs {
+		if err := s.appendOpenTSDBService(i); err != nil {
+			return err
+		}
+	}
+	for _, i := range s.config.UDPInputs {
+		s.appendUDPService(i)
 	}
 
 	s.Subscriber.MetaClient = s.MetaClient

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -183,7 +183,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.QueryExecutor.QueryTimeout = time.Duration(c.Cluster.QueryTimeout)
 	s.QueryExecutor.MaxConcurrentQueries = c.Cluster.MaxConcurrentQueries
 	if c.Data.QueryLogEnabled {
-		s.QueryExecutor.LogOutput = os.Stderr
+		s.QueryExecutor.Logger = log.New(os.Stderr, "[query] ", log.LstdFlags)
 	}
 
 	// Initialize the monitor

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -52,6 +52,8 @@ type Server struct {
 	BindAddress string
 	Listener    net.Listener
 
+	Logger *log.Logger
+
 	MetaClient *meta.Client
 
 	TSDBStore     *tsdb.Store
@@ -132,6 +134,8 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 		closing:   make(chan struct{}),
 
 		BindAddress: bind,
+
+		Logger: log.New(os.Stderr, "", log.LstdFlags),
 
 		MetaClient: meta.NewClient(c.Meta),
 
@@ -358,7 +362,7 @@ func (s *Server) startServerReporting() {
 func (s *Server) reportServer() {
 	dis, err := s.MetaClient.Databases()
 	if err != nil {
-		log.Printf("failed to retrieve databases for reporting: %s", err.Error())
+		s.Logger.Printf("failed to retrieve databases for reporting: %s", err.Error())
 		return
 	}
 	numDatabases := len(dis)
@@ -382,7 +386,7 @@ func (s *Server) reportServer() {
 
 	clusterID := s.MetaClient.ClusterID()
 	if err != nil {
-		log.Printf("failed to retrieve cluster ID for reporting: %s", err.Error())
+		s.Logger.Printf("failed to retrieve cluster ID for reporting: %s", err.Error())
 		return
 	}
 
@@ -405,7 +409,7 @@ func (s *Server) reportServer() {
 		},
 	}
 
-	log.Printf("Sending anonymous usage statistics to m.influxdb.com")
+	s.Logger.Printf("Sending anonymous usage statistics to m.influxdb.com")
 
 	go cl.Save(usage)
 }

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -152,7 +152,8 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 		httpUseTLS:  c.HTTPD.HTTPSEnabled,
 		tcpAddr:     bind,
 
-		config: c,
+		config:    c,
+		logOutput: os.Stderr,
 	}
 
 	if err := s.MetaClient.Open(); err != nil {

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"math"
 	"net/http"
 	"net/url"
@@ -480,19 +479,7 @@ func writeTestData(s *Server, t *Test) error {
 func configureLogging(s *Server) {
 	// Set the logger to discard unless verbose is on
 	if !testing.Verbose() {
-		type logSetter interface {
-			SetLogger(*log.Logger)
-		}
-		nullLogger := log.New(ioutil.Discard, "", 0)
-		s.TSDBStore.Logger = nullLogger
-		s.Monitor.SetLogger(nullLogger)
-		s.QueryExecutor.Logger = log.New(ioutil.Discard, "[query] ", log.LstdFlags)
-		s.Subscriber.SetLogger(nullLogger)
-		for _, service := range s.Services {
-			if service, ok := service.(logSetter); ok {
-				service.SetLogger(nullLogger)
-			}
-		}
+		s.SetLogOutput(ioutil.Discard)
 	}
 }
 

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -486,7 +486,7 @@ func configureLogging(s *Server) {
 		nullLogger := log.New(ioutil.Discard, "", 0)
 		s.TSDBStore.Logger = nullLogger
 		s.Monitor.SetLogger(nullLogger)
-		s.QueryExecutor.LogOutput = ioutil.Discard
+		s.QueryExecutor.Logger = log.New(ioutil.Discard, "[query] ", log.LstdFlags)
 		s.Subscriber.SetLogger(nullLogger)
 		for _, service := range s.Services {
 			if service, ok := service.(logSetter); ok {

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"sync"
@@ -144,6 +145,12 @@ func (e *QueryExecutor) Close() error {
 	}
 	e.queries = nil
 	return nil
+}
+
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (e *QueryExecutor) SetLogOutput(w io.Writer) {
+	e.Logger = log.New(w, "[query] ", log.LstdFlags)
 }
 
 // ExecuteQuery executes each statement within a query.

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -177,7 +177,7 @@ func (e *QueryExecutor) executeQuery(query *Query, database string, chunkSize in
 		Results:     results,
 		Database:    database,
 		ChunkSize:   chunkSize,
-		Log:         logger,
+		Log:         e.Logger,
 		InterruptCh: task.closing,
 	}
 

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -3,6 +3,7 @@ package monitor // import "github.com/influxdata/influxdb/monitor"
 import (
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"runtime"
@@ -116,9 +117,10 @@ func (m *Monitor) Close() {
 	m.done = nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (m *Monitor) SetLogger(l *log.Logger) {
-	m.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (m *Monitor) SetLogOutput(w io.Writer) {
+	m.Logger = log.New(w, "[monitor] ", log.LstdFlags)
 }
 
 // RegisterDiagnosticsClient registers a diagnostics client with the given name and tags.

--- a/services/admin/service.go
+++ b/services/admin/service.go
@@ -3,6 +3,7 @@ package admin // import "github.com/influxdata/influxdb/services/admin"
 import (
 	"crypto/tls"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -81,9 +82,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.logger = log.New(w, "[admin] ", log.LstdFlags)
 }
 
 // Err returns a channel for fatal errors that occur on the listener.

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -3,6 +3,7 @@ package collectd // import "github.com/influxdata/influxdb/services/collectd"
 import (
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -167,9 +168,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[collectd] ", log.LstdFlags)
 }
 
 // SetTypes sets collectd types db.

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -127,9 +128,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[continuous_querier] ", log.LstdFlags)
 }
 
 // Run runs the specified continuous query, or all CQs if none is specified.

--- a/services/copier/service.go
+++ b/services/copier/service.go
@@ -61,9 +61,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[copier] ", log.LstdFlags)
 }
 
 // Err returns a channel for fatal out-of-band errors.

--- a/services/copier/service_test.go
+++ b/services/copier/service_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func NewService() *Service {
 	s.Service.TSDBStore = &s.TSDBStore
 
 	if !testing.Verbose() {
-		s.SetLogger(log.New(ioutil.Discard, "", 0))
+		s.SetLogOutput(ioutil.Discard)
 	}
 	return s
 }

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"net"
@@ -200,9 +201,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.logger = log.New(w, "[graphite] ", log.LstdFlags)
 }
 
 // Addr returns the address the Service binds to.

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -133,6 +133,7 @@ func (s *Service) Close() error {
 // SetLogger sets the internal logger to the logger passed in.
 func (s *Service) SetLogger(l *log.Logger) {
 	s.Logger = l
+	s.Handler.Logger = l
 }
 
 // Err returns a channel for fatal errors that occur on the listener.

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -130,8 +131,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	l := log.New(w, "[httpd]", log.LstdFlags)
 	s.Logger = l
 	s.Handler.Logger = l
 }

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -957,10 +957,12 @@ func (c *Client) MarshalBinary() ([]byte, error) {
 	return c.cacheData.MarshalBinary()
 }
 
-func (c *Client) SetLogger(l *log.Logger) {
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (c *Client) SetLogOutput(w io.Writer) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.logger = l
+	c.logger = log.New(w, "[metaclient] ", log.LstdFlags)
 }
 
 func (c *Client) updateAuthCache() {

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -177,8 +177,11 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) { s.Logger = l }
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[opentsdb] ", log.LstdFlags)
+}
 
 // Err returns a channel for fatal errors that occur on the listener.
 func (s *Service) Err() <-chan error { return s.err }

--- a/services/precreator/service.go
+++ b/services/precreator/service.go
@@ -1,6 +1,7 @@
 package precreator // import "github.com/influxdata/influxdb/services/precreator"
 
 import (
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -33,9 +34,10 @@ func NewService(c Config) (*Service, error) {
 	return &s, nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[shard-precreation] ", log.LstdFlags)
 }
 
 // Open starts the precreation service.

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -1,6 +1,7 @@
 package retention // import "github.com/influxdata/influxdb/services/retention"
 
 import (
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -54,9 +55,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.logger = log.New(w, "[retention] ", log.LstdFlags)
 }
 
 func (s *Service) deleteShardGroups() {

--- a/services/snapshotter/service.go
+++ b/services/snapshotter/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -71,9 +72,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[snapshot] ", log.LstdFlags)
 }
 
 // Err returns a channel for fatal out-of-band errors.

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -3,6 +3,7 @@ package subscriber // import "github.com/influxdata/influxdb/services/subscriber
 import (
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -108,9 +109,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[subscriber] ", log.LstdFlags)
 }
 
 func (s *Service) waitForMetaUpdates() {

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -3,6 +3,7 @@ package udp // import "github.com/influxdata/influxdb/services/udp"
 import (
 	"errors"
 	"expvar"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -214,9 +215,10 @@ func (s *Service) Close() error {
 	return nil
 }
 
-// SetLogger sets the internal logger to the logger passed in.
-func (s *Service) SetLogger(l *log.Logger) {
-	s.Logger = l
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[udp] ", log.LstdFlags)
 }
 
 // Addr returns the listener's address

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -3,6 +3,7 @@ package tsm1
 import (
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"sort"
@@ -468,6 +469,12 @@ func (cl *CacheLoader) Load(cache *Cache) error {
 		}
 	}
 	return nil
+}
+
+// SetLogOutput sets the logger used for all messages. It must not be called
+// after the Open method has been called.
+func (cl *CacheLoader) SetLogOutput(w io.Writer) {
+	cl.Logger = log.New(w, "[cacheloader] ", log.LstdFlags)
 }
 
 // Updates the age statistic

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -79,7 +79,6 @@ func NewEngine(path string, walPath string, opt tsdb.EngineOptions) tsdb.Engine 
 
 	e := &Engine{
 		path:              path,
-		logger:            log.New(os.Stderr, "[tsm1] ", log.LstdFlags),
 		measurementFields: make(map[string]*tsdb.MeasurementFields),
 
 		WAL:   w,
@@ -96,6 +95,7 @@ func NewEngine(path string, walPath string, opt tsdb.EngineOptions) tsdb.Engine 
 		CacheFlushMemorySizeThreshold: opt.Config.CacheSnapshotMemorySize,
 		CacheFlushWriteColdDuration:   time.Duration(opt.Config.CacheSnapshotWriteColdDuration),
 	}
+	e.SetLogOutput(os.Stderr)
 
 	return e
 }
@@ -195,7 +195,10 @@ func (e *Engine) Close() error {
 }
 
 // SetLogOutput is a no-op.
-func (e *Engine) SetLogOutput(w io.Writer) {}
+func (e *Engine) SetLogOutput(w io.Writer) {
+	e.logger = log.New(w, "[tsm1] ", log.LstdFlags)
+	e.WAL.SetLogOutput(w)
+}
 
 // LoadMetadataIndex loads the shard metadata into memory.
 func (e *Engine) LoadMetadataIndex(sh *tsdb.Shard, index *tsdb.DatabaseIndex) error {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -194,7 +194,8 @@ func (e *Engine) Close() error {
 	return e.WAL.Close()
 }
 
-// SetLogOutput is a no-op.
+// SetLogOutput sets the logger used for all messages. It must not be called
+// after the Open method has been called.
 func (e *Engine) SetLogOutput(w io.Writer) {
 	e.logger = log.New(w, "[tsm1] ", log.LstdFlags)
 	e.WAL.SetLogOutput(w)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -200,6 +200,7 @@ func (e *Engine) Close() error {
 func (e *Engine) SetLogOutput(w io.Writer) {
 	e.logger = log.New(w, "[tsm1] ", log.LstdFlags)
 	e.WAL.SetLogOutput(w)
+	e.FileStore.SetLogOutput(w)
 	e.logOutput = w
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -37,8 +37,9 @@ type Engine struct {
 	done chan struct{}
 	wg   sync.WaitGroup
 
-	path   string
-	logger *log.Logger
+	path      string
+	logger    *log.Logger
+	logOutput io.Writer
 
 	// TODO(benbjohnson): Index needs to be moved entirely into engine.
 	index             *tsdb.DatabaseIndex
@@ -199,6 +200,7 @@ func (e *Engine) Close() error {
 func (e *Engine) SetLogOutput(w io.Writer) {
 	e.logger = log.New(w, "[tsm1] ", log.LstdFlags)
 	e.WAL.SetLogOutput(w)
+	e.logOutput = w
 }
 
 // LoadMetadataIndex loads the shard metadata into memory.
@@ -664,6 +666,7 @@ func (e *Engine) reloadCache() error {
 	}
 
 	loader := NewCacheLoader(files)
+	loader.SetLogOutput(e.logOutput)
 	if err := loader.Load(e.Cache); err != nil {
 		return err
 	}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -3,6 +3,7 @@ package tsm1
 import (
 	"expvar"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -143,6 +144,12 @@ func NewFileStore(dir string) *FileStore {
 			map[string]string{"path": dir, "database": db, "retentionPolicy": rp},
 		),
 	}
+}
+
+// SetLogOutput sets the logger used for all messages. It must not be called
+// after the Open method has been called.
+func (f *FileStore) SetLogOutput(w io.Writer) {
+	f.Logger = log.New(w, "[filestore] ", log.LstdFlags)
 }
 
 // Returns the number of TSM files currently loaded

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -91,12 +91,13 @@ type WAL struct {
 
 func NewWAL(path string) *WAL {
 	db, rp := tsdb.DecodeStorePath(path)
-	w := &WAL{
+	return &WAL{
 		path: path,
 
 		// these options should be overriden by any options in the config
 		LogOutput:   os.Stderr,
 		SegmentSize: DefaultSegmentSize,
+		logger:      log.New(os.Stderr, "[tsm1wal] ", log.LstdFlags),
 		closing:     make(chan struct{}),
 
 		statMap: influxdb.NewStatistics(
@@ -105,8 +106,6 @@ func NewWAL(path string) *WAL {
 			map[string]string{"path": path, "database": db, "retentionPolicy": rp},
 		),
 	}
-	w.SetLogOutput(os.Stderr)
-	return w
 }
 
 // SetLogOutput sets the location that logs are written to.

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -108,7 +108,8 @@ func NewWAL(path string) *WAL {
 	}
 }
 
-// SetLogOutput sets the location that logs are written to.
+// SetLogOutput sets the location that logs are written to. It must not be
+// called after the Open method has been called.
 func (l *WAL) SetLogOutput(w io.Writer) {
 	l.logger = log.New(w, "[tsm1wal] ", log.LstdFlags)
 }

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -91,13 +91,12 @@ type WAL struct {
 
 func NewWAL(path string) *WAL {
 	db, rp := tsdb.DecodeStorePath(path)
-	return &WAL{
+	w := &WAL{
 		path: path,
 
 		// these options should be overriden by any options in the config
 		LogOutput:   os.Stderr,
 		SegmentSize: DefaultSegmentSize,
-		logger:      log.New(os.Stderr, "[tsm1wal] ", log.LstdFlags),
 		closing:     make(chan struct{}),
 
 		statMap: influxdb.NewStatistics(
@@ -106,6 +105,13 @@ func NewWAL(path string) *WAL {
 			map[string]string{"path": path, "database": db, "retentionPolicy": rp},
 		),
 	}
+	w.SetLogOutput(os.Stderr)
+	return w
+}
+
+// SetLogOutput sets the location that logs are written to.
+func (l *WAL) SetLogOutput(w io.Writer) {
+	l.logger = log.New(w, "[tsm1wal] ", log.LstdFlags)
 }
 
 // Path returns the path the log was initialized with.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -121,6 +121,14 @@ func NewShard(id uint64, index *DatabaseIndex, path string, walPath string, opti
 	}
 }
 
+// SetLogOutput sets the writer to which log output will be written.
+func (s *Shard) SetLogOutput(w io.Writer) {
+	s.LogOutput = w
+	if s.engine != nil {
+		s.engine.SetLogOutput(w)
+	}
+}
+
 // Path returns the path set on the shard when it was created.
 func (s *Shard) Path() string { return s.path }
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -121,10 +121,11 @@ func NewShard(id uint64, index *DatabaseIndex, path string, walPath string, opti
 	}
 }
 
-// SetLogOutput sets the writer to which log output will be written.
+// SetLogOutput sets the writer to which log output will be written. It must
+// not be called after the Open method has been called.
 func (s *Shard) SetLogOutput(w io.Writer) {
 	s.LogOutput = w
-	if s.engine != nil {
+	if !s.closed() {
 		s.engine.SetLogOutput(w)
 	}
 }

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -64,7 +64,8 @@ func NewStore(path string) *Store {
 	}
 }
 
-// SetLogOutput sets the writer to which underlying database logs will go.
+// SetLogOutput sets the writer to which underlying database logs will go. It
+// must not be called after the Open method has been called.
 func (s *Store) SetLogOutput(w io.Writer) {
 	s.logOutput = w
 	for _, s := range s.shards {

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -64,9 +64,10 @@ func NewStore(path string) *Store {
 	}
 }
 
-// SetLogOutput sets the writer to which underlying database logs will go. It
-// must not be called after the Open method has been called.
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
 func (s *Store) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[store]", log.LstdFlags)
 	s.logOutput = w
 	for _, s := range s.shards {
 		s.SetLogOutput(w)


### PR DESCRIPTION
###### Overview

This PR includes various improvements to make InfluxDB's logging output location more programmatically configurable in general. This feature is only important for users who embed InfluxDB into their Go programs, and was already half-supported. This change just improves the existing feature.

For an in-depth example of why this change is important, please see the description of https://github.com/sourcegraph/appdash/pull/131

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
