### PR TITLE
Handle nil values from the tsm1 cursor correctly

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -837,7 +837,7 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, mm *tsdb.Measu
 			// Create cursor from field.
 			cur := e.buildCursor(mm.Name, seriesKey, opt.Aux[i], opt)
 			if cur != nil {
-				aux[i] = newBufCursor(cur)
+				aux[i] = newBufCursor(cur, opt.Ascending)
 				continue
 			}
 
@@ -861,7 +861,7 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, mm *tsdb.Measu
 			if cur == nil {
 				return nil, nil
 			}
-			conds[i] = newBufCursor(cur)
+			conds[i] = newBufCursor(cur, opt.Ascending)
 		}
 	}
 

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -31,11 +31,12 @@ type bufCursor struct {
 		value  interface{}
 		filled bool
 	}
+	ascending bool
 }
 
 // newBufCursor returns a bufferred wrapper for cur.
-func newBufCursor(cur cursor) *bufCursor {
-	return &bufCursor{cur: cur}
+func newBufCursor(cur cursor, ascending bool) *bufCursor {
+	return &bufCursor{cur: cur, ascending: ascending}
 }
 
 // next returns the buffer, if filled. Otherwise returns the next key/value from the cursor.
@@ -67,13 +68,16 @@ func (c *bufCursor) peek() (k int64, v interface{}) {
 func (c *bufCursor) nextAt(seek int64) interface{} {
 	for {
 		k, v := c.next()
-		if k == tsdb.EOF || k == seek {
-			return  v
-		} else if k < seek {
-			continue
+		if k != tsdb.EOF {
+			if k == seek {
+				return v
+			} else if c.ascending && k < seek {
+				continue
+			} else if !c.ascending && k > seek {
+				continue
+			}
+			c.unread(k, v)
 		}
-
-		c.unread(k, v)
 
 		// Return "nil" value for type.
 		switch c.cur.(type) {
@@ -156,8 +160,10 @@ func (itr *{{.name}}Iterator) Next() *influxql.{{.Name}}Point {
 		} else {
 			// Otherwise find lowest aux timestamp.
 			for i := range itr.aux {
-				if k, _ := itr.aux[i].peek(); k != tsdb.EOF && (seek == tsdb.EOF || k < seek) {
-					seek = k
+				if k, _ := itr.aux[i].peek(); k != tsdb.EOF {
+					if seek == tsdb.EOF || (itr.opt.Ascending && k < seek) || (!itr.opt.Ascending && k > seek) {
+						seek = k
+					}
 				}
 			}
 			itr.point.Time = seek


### PR DESCRIPTION
Send nil values from the tsm1 cursor at the end of the cursor. After the
cursor reached tsm1, the `nextAt()` call would always return the default
value rather than a nil value.

Descending also didn't work correctly because the seeking functionality
for tsm1 iterators would always act like they were ascending instead of
descending when choosing which value to select. This resulted in very
strange output from the emitter since it couldn't figure out if it was
ascending or descending.

Fixes #6206.