### PR TITLE
Fix failure on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This release removes all of the old clustering code. It operates as a standalone
 - [#6152](https://github.com/influxdata/influxdb/issues/6152): Allow SHARD DURATION to be specified in isolation when creating a database
 - [#6153](https://github.com/influxdata/influxdb/issues/6153): Check SHARD DURATION when recreating the same database
 - [#6178](https://github.com/influxdata/influxdb/issues/6178): Ensure SHARD DURATION is checked when recreating a retention policy
+- [#6223](https://github.com/influxdata/influxdb/issues/6223): Failure to start/run on Windows. Thanks @mvadu
 
 ## v0.11.1 [2016-03-31]
 

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -980,6 +980,11 @@ func snapshot(path string, data *Data) error {
 		return err
 	}
 
+	//close file handle before renaming to support Windows
+	if err = f.Close(); err != nil {
+		return err
+	}
+
 	return renameFile(tmpFile, file)
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [X] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Windows does not allow a file to be renamed while its in use. f.Sync does not close the handle. It needs to be explicitly closed before renaming. @corylanou  with https://github.com/influxdata/influxdb/commit/a961ff9ebf1c5d944ce2a8856f03519d8988d70c broke the Windows version as it removed the  f.Close()  and tried to rename.  Fixes #6223