### PR TITLE
Modify cluster.TSDBStore interface to take a slice of meta.ShardInfo

### DIFF
--- a/cluster/statement_executor_test.go
+++ b/cluster/statement_executor_test.go
@@ -244,12 +244,12 @@ func (s *TSDBStore) DeleteSeries(database string, sources []influxql.Source, con
 	return s.DeleteSeriesFn(database, sources, condition)
 }
 
-func (s *TSDBStore) IteratorCreator(shards []uint64) (influxql.IteratorCreator, error) {
+func (s *TSDBStore) IteratorCreator(shards []meta.ShardInfo) (influxql.IteratorCreator, error) {
 	// Generate iterators for each node.
 	ics := make([]influxql.IteratorCreator, 0)
 	if err := func() error {
-		for _, id := range shards {
-			ic := s.ShardIteratorCreator(id)
+		for _, shard := range shards {
+			ic := s.ShardIteratorCreator(shard.ID)
 			if ic == nil {
 				continue
 			}

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -169,7 +169,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.QueryExecutor = influxql.NewQueryExecutor()
 	s.QueryExecutor.StatementExecutor = &cluster.StatementExecutor{
 		MetaClient:        s.MetaClient,
-		TSDBStore:         s.TSDBStore,
+		TSDBStore:         cluster.LocalTSDBStore{Store: s.TSDBStore},
 		Monitor:           s.Monitor,
 		PointsWriter:      s.PointsWriter,
 		MaxSelectPointN:   c.Cluster.MaxSelectPointN,
@@ -194,7 +194,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 
 func (s *Server) appendClusterService(c cluster.Config) {
 	srv := cluster.NewService(c)
-	srv.TSDBStore = s.TSDBStore
+	srv.TSDBStore = cluster.LocalTSDBStore{Store: s.TSDBStore}
 	s.Services = append(s.Services, srv)
 	s.ClusterService = srv
 }


### PR DESCRIPTION
The tsdb package can't have a dependency on the meta package so it takes
a slice of uint64 types. The clustering implementation needs the full
ShardInfo to know the shard owners though, so a different implementation
needs to be used by clustering.

The `*tsdb.Store` type gets wrapped in the cluster package so it can
implement the `IteratorCreator` function without having a dependency on
the meta package.