### PR TITLE
Add AppVeyor ci config to enable continuous integration tests on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ This release removes all of the old clustering code. It operates as a standalone
 - [#6153](https://github.com/influxdata/influxdb/issues/6153): Check SHARD DURATION when recreating the same database
 - [#6178](https://github.com/influxdata/influxdb/issues/6178): Ensure SHARD DURATION is checked when recreating a retention policy
 - [#6223](https://github.com/influxdata/influxdb/issues/6223): Failure to start/run on Windows. Thanks @mvadu
+- [#6237](https://github.com/influxdata/influxdb/issues/6237): Enable continuous integration testing on Windows platform via AppVeyor. Thanks @mvadu
 
 ## v0.11.1 [2016-03-31]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,46 @@
+version: 0.{build}
+pull_requests:
+  do_not_increment_build_number: true
+branches:
+  only:
+  - master
+
+os: Windows Server 2012 R2
+
+# Custom clone folder (variables are not expanded here).
+clone_folder: c:\gopath\src\github.com\influxdata\influxdb
+
+# Environment variables
+environment:
+  #AppVeyor has go 1.6 as default go environment
+  GOROOT: C:\go
+  GOPATH: C:\gopath
+
+# Scripts that run after cloning repository
+install:
+ - set PATH=%GOROOT%\bin;%GOPATH%\bin;%PATH%
+ - echo %PATH%
+ - echo %GOPATH%
+ - cd C:\gopath\src\github.com\influxdata\influxdb
+ - go version
+ - go env
+ - go get github.com/sparrc/gdm
+ - cd C:\gopath\src\github.com\influxdata\influxdb
+ - gdm restore
+
+# To run your custom scripts instead of automatic MSBuild 
+build_script:
+ #Currently for gdm to work on Windows, we need go 1.6, but Influx is on go1.4.3, so switch the go environment
+ - set GOROOT=C:\go14
+ - set PATH=%GOROOT%\bin;%GOPATH%\bin;%PATH%
+ - echo %PATH%
+ - echo %GOPATH%
+ - go get -t -v ./...
+  
+# To run your custom scripts instead of automatic tests
+#test_script:
+ - go test -race -v ./...
+ 
+# To disable deployment
+deploy: off
+


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [X] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This PR adds AppVeyor ci config to enable continuous integration tests on Windows. Refer to #6237 for more info. InfluxData would still need to sign up and integrate with AppVeyor for this config to take effect.