### PR TITLE
Throw an error when an invalid expression is used with aux iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 
 - [#6206](https://github.com/influxdata/influxdb/issues/6206): Handle nil values from the tsm1 cursor correctly.
+- [#6248](https://github.com/influxdata/influxdb/issues/6248): Panic using incorrectly quoted "queries" field key.
 
 ## v0.12.0 [2016-04-05]
 ### Release Notes

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -2021,6 +2021,10 @@ func TestSelect_InvalidQueries(t *testing.T) {
 			q:   `SELECT 'value' FROM cpu`,
 			err: `invalid expression type: *influxql.StringLiteral`,
 		},
+		{
+			q:   `SELECT 'value', value FROM cpu`,
+			err: `invalid expression type: *influxql.StringLiteral`,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
The following query was fixed previously:

    SELECT 'value' FROM cpu

This ended up hitting the `buildExprIterator()` code path and was
handled properly. But this query:

    SELECT 'value', value FROM cpu

This took a different code path that would trigger a panic because it
triggered a panic instead of an error condition. This code path has now
been modified to trigger an error instead of a panic.

Fixes #6248.