### PR TITLE
CreateShardGroup was not idempotent at the meta store level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#6206](https://github.com/influxdata/influxdb/issues/6206): Handle nil values from the tsm1 cursor correctly.
 - [#6248](https://github.com/influxdata/influxdb/issues/6248): Panic using incorrectly quoted "queries" field key.
+- [#6257](https://github.com/influxdata/influxdb/issues/6257): CreateShardGroup was incrementing meta data index even when it was idempotent.
 
 ## v0.12.0 [2016-04-05]
 ### Release Notes


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This bug was causing the index on the meta store to index for EVERY single write, and basically doubled the disk ops because of the fsync.