### PR TITLE
Fixing aggregate queries with no GROUP BY to include the end time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#6248](https://github.com/influxdata/influxdb/issues/6248): Panic using incorrectly quoted "queries" field key.
 - [#6257](https://github.com/influxdata/influxdb/issues/6257): CreateShardGroup was incrementing meta data index even when it was idempotent.
 - [#6223](https://github.com/influxdata/influxdb/issues/6223): Failure to start/run on Windows. Thanks @mvadu
+- [#6229](https://github.com/influxdata/influxdb/issues/6229): Fixed aggregate queries with no GROUP BY to include the end time.
 
 ## v0.12.0 [2016-04-05]
 

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -1711,7 +1711,7 @@ func (itr *floatTransformIterator) Next() *FloatPoint {
 // new point if possible.
 type floatTransformFunc func(p *FloatPoint) *FloatPoint
 
-// floatReduceIterator executes a function to modify an existing point for every
+// floatBoolTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type floatBoolTransformIterator struct {
 	input FloatIterator
@@ -3521,7 +3521,7 @@ func (itr *integerTransformIterator) Next() *IntegerPoint {
 // new point if possible.
 type integerTransformFunc func(p *IntegerPoint) *IntegerPoint
 
-// integerReduceIterator executes a function to modify an existing point for every
+// integerBoolTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type integerBoolTransformIterator struct {
 	input IntegerIterator
@@ -5331,7 +5331,7 @@ func (itr *stringTransformIterator) Next() *StringPoint {
 // new point if possible.
 type stringTransformFunc func(p *StringPoint) *StringPoint
 
-// stringReduceIterator executes a function to modify an existing point for every
+// stringBoolTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type stringBoolTransformIterator struct {
 	input StringIterator
@@ -7141,7 +7141,7 @@ func (itr *booleanTransformIterator) Next() *BooleanPoint {
 // new point if possible.
 type booleanTransformFunc func(p *BooleanPoint) *BooleanPoint
 
-// booleanReduceIterator executes a function to modify an existing point for every
+// booleanBoolTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type booleanBoolTransformIterator struct {
 	input BooleanIterator

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -1047,7 +1047,7 @@ func (itr *{{$k.name}}TransformIterator) Next() *{{$k.Name}}Point {
 // new point if possible.
 type {{$k.name}}TransformFunc func(p *{{$k.Name}}Point) *{{$k.Name}}Point
 
-// {{$k.name}}ReduceIterator executes a function to modify an existing point for every
+// {{$k.name}}BoolTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.
 type {{$k.name}}BoolTransformIterator struct {
 	input {{$k.Name}}Iterator

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -734,7 +734,7 @@ func (opt IteratorOptions) SeekTime() int64 {
 // Window returns the time window [start,end) that t falls within.
 func (opt IteratorOptions) Window(t int64) (start, end int64) {
 	if opt.Interval.IsZero() {
-		return opt.StartTime, opt.EndTime
+		return opt.StartTime, opt.EndTime + 1
 	}
 
 	// Subtract the offset to the time so we calculate the correct base interval.

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -772,8 +772,8 @@ func TestIteratorOptions_Window_Default(t *testing.T) {
 	if start != 0 {
 		t.Errorf("expected start to be 0, got %d", start)
 	}
-	if end != 60 {
-		t.Errorf("expected end to be 60, got %d", end)
+	if end != 61 {
+		t.Errorf("expected end to be 61, got %d", end)
 	}
 }
 


### PR DESCRIPTION
Queries with a time constraint but no group by would not include the
final point from the underlying iterator.

Fixes #6229.