### PR TITLE
Detect when a time literal will overflow or underflow the query engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#6294](https://github.com/influxdata/influxdb/issues/6294): Fix panic running influx_inspect info.
 - [#6382](https://github.com/influxdata/influxdb/pull/6382): Removed dead code from the old query engine.
 - [#6383](https://github.com/influxdata/influxdb/pull/6383): Recover from a panic during query execution.
+- [#3369](https://github.com/influxdata/influxdb/issues/3369): Detect when a timer literal will overflow or underflow the query engine.
 
 ## v0.12.0 [2016-04-05]
 ### Release Notes

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -3488,6 +3488,11 @@ func timeExprValue(ref Expr, lit Expr) (t time.Time, err error) {
 	if ref, ok := ref.(*VarRef); ok && strings.ToLower(ref.Val) == "time" {
 		switch lit := lit.(type) {
 		case *TimeLiteral:
+			if lit.Val.After(time.Unix(0, MaxTime)) {
+				return time.Time{}, fmt.Errorf("time %s overflows time literal", lit.Val.Format(time.RFC3339))
+			} else if lit.Val.Before(time.Unix(0, MinTime)) {
+				return time.Time{}, fmt.Errorf("time %s underflows time literal", lit.Val.Format(time.RFC3339))
+			}
 			return lit.Val, nil
 		case *DurationLiteral:
 			return time.Unix(0, int64(lit.Val)).UTC(), nil

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -837,6 +837,8 @@ func TestTimeRange(t *testing.T) {
 
 		// Invalid time expressions.
 		{expr: `time > "2000-01-01 00:00:00"`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `invalid operation: time and *influxql.VarRef are not compatible`},
+		{expr: `time > '2262-04-11 13:47:17'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `time 2262-04-11T13:47:17Z overflows time literal`},
+		{expr: `time > '1677-09-20 19:12:43'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `time 1677-09-20T19:12:43Z underflows time literal`},
 	} {
 		// Extract time range.
 		expr := MustParseExpr(tt.expr)


### PR DESCRIPTION
Fixes #3369.