### PR TITLE
Fix deadlock in tsm1/file_store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#6283](https://github.com/influxdata/influxdb/pull/6283): Fix GROUP BY tag to produce consistent results when a series has no tags.
 - [#3773](https://github.com/influxdata/influxdb/issues/3773): Support empty tags for all WHERE equality operations.
 - [#6270](https://github.com/influxdata/influxdb/issues/6270): tsm1 query engine alloc reduction
+- [#6271](https://github.com/influxdata/influxdb/issues/6271): Fixed deadlock in tsm1 file store.
 
 ## v0.12.0 [2016-04-05]
 ### Release Notes

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -514,15 +514,14 @@ func (f *FileStore) BlockCount(path string, idx int) int {
 
 // locations returns the files and index blocks for a key and time.  ascending indicates
 // whether the key will be scan in ascending time order or descenging time order.
+// This function assumes the read-lock has been taken.
 func (f *FileStore) locations(key string, t int64, ascending bool) []location {
 	var locations []location
 
-	f.mu.RLock()
 	filesSnapshot := make([]TSMFile, len(f.files))
 	for i := range f.files {
 		filesSnapshot[i] = f.files[i]
 	}
-	f.mu.RUnlock()
 
 	var entries []IndexEntry
 	for _, fd := range filesSnapshot {
@@ -617,6 +616,7 @@ type location struct {
 }
 
 // newKeyCursor returns a new instance of KeyCursor.
+// This function assumes the read-lock has been taken.
 func newKeyCursor(fs *FileStore, key string, t int64, ascending bool) *KeyCursor {
 	c := &KeyCursor{
 		key:       key,


### PR DESCRIPTION
This fix issue #6271 

It remove the RLock from FileStore.locations.

This function is only called by newKeyCursor which itself is only called by FileStore.KeyCursor. FileStore.KeyCursor already acquire the RLock.

