### PR TITLE
Use 'latest' alias for links to documentation

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -26,7 +26,7 @@ Though not necessary for experimentation, you may want to create a new user
 and authenticate the connection to your database.
 
 For more information please check out the
-[Admin Docs](https://docs.influxdata.com/influxdb/v0.10/administration).
+[Admin Docs](https://docs.influxdata.com/influxdb/latest/administration/).
 
 For the impatient, you can create a new admin user _bubba_ by firing off the
 [InfluxDB CLI](https://github.com/influxdata/influxdb/blob/master/cmd/influx/main.go).
@@ -70,17 +70,17 @@ func main() {
 		Username: username,
 		Password: password,
 	})
-	
+
 	if err != nil {
 	    log.Fatalln("Error: ", err)
 	}
-	
+
 	// Create a new point batch
 	bp, err := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:  MyDB,
 		Precision: "s",
 	})
-	
+
 	if err != nil {
 	    log.Fatalln("Error: ", err)
 	}
@@ -93,11 +93,11 @@ func main() {
 		"user":   46.6,
 	}
 	pt, err := client.NewPoint("cpu_usage", tags, fields, time.Now())
-	
+
 	if err != nil {
 	    log.Fatalln("Error: ", err)
 	}
-    	
+
 	bp.AddPoint(pt)
 
 	// Write the batch

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -758,7 +758,7 @@ func (c *CommandLine) help() {
         show field keys       show field key information
 
         A full list of influxql commands can be found at:
-        https://docs.influxdata.com/influxdb/v0.10/query_language/spec
+        https://docs.influxdata.com/influxdb/latest/query_language/spec/
 `)
 }
 

--- a/services/admin/assets/index.html
+++ b/services/admin/assets/index.html
@@ -34,7 +34,7 @@
                             <a href="#" data-toggle="modal" data-target="#myModal">Write Data</a>
                         </li>
                         <li>
-                            <a href="https://docs.influxdata.com/influxdb/v0.10/introduction/getting_started" target="_blank">Documentation</a>
+                            <a href="https://docs.influxdata.com/influxdb/latest/introduction/getting_started/" target="_blank">Documentation</a>
                         </li>
                     </ul>
 


### PR DESCRIPTION
Includes a fix for #6280