### PR TITLE
Update Percentile to preserve Aux fields since its a selector

### DIFF
--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -988,7 +988,7 @@ func NewFloatPercentileReduceSliceFunc(percentile float64) FloatReduceSliceFunc 
 		}
 
 		sort.Sort(floatPointsByValue(a))
-		return []FloatPoint{{Time: ZeroTime, Value: a[i].Value}}
+		return []FloatPoint{{Time: ZeroTime, Value: a[i].Value, Aux: a[i].Aux}}
 	}
 }
 
@@ -1003,7 +1003,7 @@ func NewIntegerPercentileReduceSliceFunc(percentile float64) IntegerReduceSliceF
 		}
 
 		sort.Sort(integerPointsByValue(a))
-		return []IntegerPoint{{Time: ZeroTime, Value: a[i].Value}}
+		return []IntegerPoint{{Time: ZeroTime, Value: a[i].Value, Aux: a[i].Aux}}
 	}
 }
 


### PR DESCRIPTION
Currently the InfluxQL does not allow percentile to select Aux fields but Kapacitor does, so this change helps Kapacitor use Percentile as a real selector.

See issue #6292 for making InfluxQL allow percentile with selected aux fields.

- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

