### PR TITLE
Support env overrides for all inputs of the same type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#6228](https://github.com/influxdata/influxdb/pull/6228): Support for multiple listeners for collectd and OpenTSDB inputs.
 - [#6292](https://github.com/influxdata/influxdb/issues/6292): Allow percentile to be used as a selector.
 - [#5707](https://github.com/influxdata/influxdb/issues/5707): Return a deprecated message when IF NOT EXISTS is used.
+- [#6334](https://github.com/influxdata/influxdb/pull/6334): Allow environment variables to be set per input type.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -175,6 +175,9 @@ func (c *Config) applyEnvOverrides(prefix string, spec reflect.Value) error {
 			// e.g. GRAPHITE_0
 			if f.Kind() == reflect.Slice || f.Kind() == reflect.Array {
 				for i := 0; i < f.Len(); i++ {
+					if err := c.applyEnvOverrides(key, f.Index(i)); err != nil {
+						return err
+					}
 					if err := c.applyEnvOverrides(fmt.Sprintf("%s_%d", key, i), f.Index(i)); err != nil {
 						return err
 					}

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -141,6 +141,8 @@ bind-address = ":2010"
 [[udp]]
 bind-address = ":4444"
 
+[[udp]]
+
 [monitoring]
 enabled = true
 
@@ -151,6 +153,10 @@ enabled = true
 	}
 
 	if err := os.Setenv("INFLUXDB_UDP_BIND_ADDRESS", ":1234"); err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+
+	if err := os.Setenv("INFLUXDB_UDP_0_BIND_ADDRESS", ":5555"); err != nil {
 		t.Fatalf("failed to set env var: %v", err)
 	}
 
@@ -170,8 +176,12 @@ enabled = true
 		t.Fatalf("failed to apply env overrides: %v", err)
 	}
 
-	if c.UDPInputs[0].BindAddress != ":4444" {
+	if c.UDPInputs[0].BindAddress != ":5555" {
 		t.Fatalf("unexpected udp bind address: %s", c.UDPInputs[0].BindAddress)
+	}
+
+	if c.UDPInputs[1].BindAddress != ":1234" {
+		t.Fatalf("unexpected udp bind address: %s", c.UDPInputs[1].BindAddress)
 	}
 
 	if c.GraphiteInputs[1].Protocol != "udp" {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Allows a default environment variable override to be specified for all config config sections that are arrays. This keeps backward compatibility for existing environment variable overrides on sections which now allow multiple services to be configured due to https://github.com/influxdata/influxdb/pull/6228 and https://github.com/influxdata/influxdb/pull/6333.

Given the following configuration for just the Graphite sections:
```
[[graphite]]
  enabled = true
  bind-address = ":2003"

[[graphite]]
  enabled = true
  bind-address = ":8085"
```

And setting the following environment variables: 

```
# Override all Graphite input's bind address setting to :1003 
INFLUXDB_GRAPHITE_BIND_ADDRESS=:1003
# Override the second Graphite input's bind address setting to :3003
INFLUXDB_GRAPHITE_1_BIND_ADDRESS=:3003
```

The current code will result in the first Graphite input using bind address `:2003` and the second Graphite input using a bind address of `:3003`.

This PR results in the first Graphite input using bind address `:1003` and the second Graphite input using a bind address of `:3003`.