### PR TITLE
Fix cluster/pool release of connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [#6458](https://github.com/influxdata/influxdb/pull/6458): Make it clear when the CLI version is unknown.
 - [#3883](https://github.com/influxdata/influxdb/issues/3883): Improve query sanitization to prevent a password leak in the logs.
 - [#6462](https://github.com/influxdata/influxdb/pull/6462): Add safer locking to CreateFieldIfNotExists
+- [#6361](https://github.com/influxdata/influxdb/pull/6361): Fix cluster/pool release of connection
 
 ## v0.12.2 [2016-04-20]
 

--- a/cluster/pool.go
+++ b/cluster/pool.go
@@ -132,6 +132,7 @@ func (c *boundedPool) put(conn net.Conn) error {
 		return nil
 	default:
 		// pool is full, close passed connection
+		atomic.AddInt32(&c.total, -1)
 		return conn.Close()
 	}
 }


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This PR fix a possible resource exhaustion on connection to other node.
I can reproduce this issue on v0.11.1 and this PR fix issue. On 0.12 / master this issue should no longer exists - at least in opensource version. That why I didn't updated CHANGELOG.md.

The issue happen when a load spike cause multiple thread to create new connection on the pool. It may cause total to exceed capacity : [code of boundedPool.Get](https://github.com/influxdata/influxdb/blob/36ca49c17bca34eef1c7fc66824871e61852c285/cluster/pool.go#L88)

The later when exceeding connection are returned to the pool, they are discarded (since pool is full) but total is NOT decremented : [code of boundedPool.put](https://github.com/influxdata/influxdb/blob/36ca49c17bca34eef1c7fc66824871e61852c285/cluster/pool.go#L134)

At this point with the default value, pool have 3 working connections (== capacity) but total may be larger than this, lets say 6.

Now, if the target node goes down, connection will be marked as unusable which will closed them and remove them from pool. [code of boundedPool.MarkUnusable](https://github.com/influxdata/influxdb/blob/36ca49c17bca34eef1c7fc66824871e61852c285/cluster/pool.go#L185)

Here total is decremented, but since is was above capacity we end up with an empty pool (all connections fail/timeout since the target node is down) but total is still above 0. It will be 3 in our example.

Then from now, all call to boundedPool.Get will fail:

* The pool is empty, unable to get a already existing connection
* total = 3 which is NOT less than capacity, so it don't open a new connection