### PR TITLE
Return a deprecated message when IF NOT EXISTS is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#6263](https://github.com/influxdata/influxdb/pull/6263): Reduce UDP Service allocation size.
 - [#6228](https://github.com/influxdata/influxdb/pull/6228): Support for multiple listeners for collectd and OpenTSDB inputs.
 - [#6292](https://github.com/influxdata/influxdb/issues/6292): Allow percentile to be used as a selector.
+- [#5707](https://github.com/influxdata/influxdb/issues/5707): Return a deprecated message when IF NOT EXISTS is used.
 
 ### Bugfixes
 

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -387,22 +387,31 @@ func (c *Client) Ping() (time.Duration, string, error) {
 
 // Structs
 
+// Message represents a user message.
+type Message struct {
+	Level string `json:"level,omitempty"`
+	Text  string `json:"text,omitempty"`
+}
+
 // Result represents a resultset returned from a single statement.
 type Result struct {
-	Series []models.Row
-	Err    error
+	Series   []models.Row
+	Messages []*Message
+	Err      error
 }
 
 // MarshalJSON encodes the result into JSON.
 func (r *Result) MarshalJSON() ([]byte, error) {
 	// Define a struct that outputs "error" as a string.
 	var o struct {
-		Series []models.Row `json:"series,omitempty"`
-		Err    string       `json:"error,omitempty"`
+		Series   []models.Row `json:"series,omitempty"`
+		Messages []*Message   `json:"messages,omitempty"`
+		Err      string       `json:"error,omitempty"`
 	}
 
 	// Copy fields to output struct.
 	o.Series = r.Series
+	o.Messages = r.Messages
 	if r.Err != nil {
 		o.Err = r.Err.Error()
 	}
@@ -413,8 +422,9 @@ func (r *Result) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON decodes the data into the Result struct
 func (r *Result) UnmarshalJSON(b []byte) error {
 	var o struct {
-		Series []models.Row `json:"series,omitempty"`
-		Err    string       `json:"error,omitempty"`
+		Series   []models.Row `json:"series,omitempty"`
+		Messages []*Message   `json:"messages,omitempty"`
+		Err      string       `json:"error,omitempty"`
 	}
 
 	dec := json.NewDecoder(bytes.NewBuffer(b))
@@ -424,6 +434,7 @@ func (r *Result) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	r.Series = o.Series
+	r.Messages = o.Messages
 	if o.Err != "" {
 		r.Err = errors.New(o.Err)
 	}

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -516,10 +516,17 @@ func (r *Response) Error() error {
 	return nil
 }
 
+// Message represents a user message.
+type Message struct {
+	Level string
+	Text  string
+}
+
 // Result represents a resultset returned from a single statement.
 type Result struct {
-	Series []models.Row
-	Err    string `json:"error,omitempty"`
+	Series   []models.Row
+	Messages []*Message
+	Err      string `json:"error,omitempty"`
 }
 
 func (uc *udpclient) Query(q Query) (*Response, error) {

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -609,7 +609,12 @@ func (c *CommandLine) writeCSV(response *client.Response, w io.Writer) {
 
 func (c *CommandLine) writeColumns(response *client.Response, w io.Writer) {
 	for _, result := range response.Results {
-		// Create a tabbed writer for each result a they won't always line up
+		// Print out all messages first
+		for _, m := range result.Messages {
+			fmt.Fprintf(w, "%s: %s.\n", m.Level, m.Text)
+		}
+
+		// Create a tabbed writer for each result as they won't always line up
 		w := new(tabwriter.Writer)
 		w.Init(os.Stdout, 0, 8, 1, '\t', 0)
 		csv := c.formatResults(result, "\t")

--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -56,12 +56,12 @@ func init() {
 			&Query{
 				name:    "create database should not error with existing database with IF NOT EXISTS",
 				command: `CREATE DATABASE IF NOT EXISTS db0`,
-				exp:     `{"results":[{}]}`,
+				exp:     `{"results":[{"messages":[{"level":"warning","text":"IF NOT EXISTS is deprecated as of v0.13.0 and will be removed in v1.0"}]}]}`,
 			},
 			&Query{
 				name:    "create database should create non-existing database with IF NOT EXISTS",
 				command: `CREATE DATABASE IF NOT EXISTS db1`,
-				exp:     `{"results":[{}]}`,
+				exp:     `{"results":[{"messages":[{"level":"warning","text":"IF NOT EXISTS is deprecated as of v0.13.0 and will be removed in v1.0"}]}]}`,
 			},
 			&Query{
 				name:    "create database with retention duration should error if retention policy is different with IF NOT EXISTS",

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -79,6 +79,9 @@ type ExecutionContext struct {
 	// The requested maximum number of points to return in each result.
 	ChunkSize int
 
+	// Hold the query executor's logger.
+	Log *log.Logger
+
 	// A channel that is closed when the query is interrupted.
 	InterruptCh <-chan struct{}
 }
@@ -176,6 +179,7 @@ func (e *QueryExecutor) executeQuery(query *Query, database string, chunkSize in
 		Results:     results,
 		Database:    database,
 		ChunkSize:   chunkSize,
+		Log:         logger,
 		InterruptCh: task.closing,
 	}
 

--- a/influxql/result.go
+++ b/influxql/result.go
@@ -7,6 +7,11 @@ import (
 	"github.com/influxdata/influxdb/models"
 )
 
+const (
+	// WarningLevel is the message level for a warning.
+	WarningLevel = "warning"
+)
+
 // TagSet is a fundamental concept within the query system. It represents a composite series,
 // composed of multiple individual series that share a set of tag attributes.
 type TagSet struct {
@@ -22,6 +27,12 @@ func (t *TagSet) AddFilter(key string, filter Expr) {
 	t.Filters = append(t.Filters, filter)
 }
 
+// Message represents a user-facing message to be included with the result.
+type Message struct {
+	Level string `json:"level"`
+	Text  string `json:"text"`
+}
+
 // Result represents a resultset returned from a single statement.
 // Rows represents a list of rows that can be sorted consistently by name/tag.
 type Result struct {
@@ -29,6 +40,7 @@ type Result struct {
 	// to combine statement results if they're being buffered in memory.
 	StatementID int `json:"-"`
 	Series      models.Rows
+	Messages    []*Message
 	Err         error
 }
 
@@ -36,12 +48,14 @@ type Result struct {
 func (r *Result) MarshalJSON() ([]byte, error) {
 	// Define a struct that outputs "error" as a string.
 	var o struct {
-		Series []*models.Row `json:"series,omitempty"`
-		Err    string        `json:"error,omitempty"`
+		Series   []*models.Row `json:"series,omitempty"`
+		Messages []*Message    `json:"messages,omitempty"`
+		Err      string        `json:"error,omitempty"`
 	}
 
 	// Copy fields to output struct.
 	o.Series = r.Series
+	o.Messages = r.Messages
 	if r.Err != nil {
 		o.Err = r.Err.Error()
 	}
@@ -52,8 +66,9 @@ func (r *Result) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON decodes the data into the Result struct
 func (r *Result) UnmarshalJSON(b []byte) error {
 	var o struct {
-		Series []*models.Row `json:"series,omitempty"`
-		Err    string        `json:"error,omitempty"`
+		Series   []*models.Row `json:"series,omitempty"`
+		Messages []*Message    `json:"messages,omitempty"`
+		Err      string        `json:"error,omitempty"`
 	}
 
 	err := json.Unmarshal(b, &o)
@@ -61,6 +76,7 @@ func (r *Result) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	r.Series = o.Series
+	r.Messages = o.Messages
 	if o.Err != "" {
 		r.Err = errors.New(o.Err)
 	}

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -379,6 +379,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 			// Append remaining rows as new rows.
 			r.Series = r.Series[rowsMerged:]
 			cr.Series = append(cr.Series, r.Series...)
+			cr.Messages = append(cr.Messages, r.Messages...)
 		} else {
 			resp.Results = append(resp.Results, r)
 		}


### PR DESCRIPTION
The deprecated message is now attached to a new attribute returned with
the results. This message can then be read by clients to warn a user
about upcoming changes to the query engine.

The `influx` client has already been modified to read this message and
print it out for every format except CSV.

The first warning message is a deprecated message about removing `IF NOT
EXISTS` from `CREATE DATABASE`.

Fixes #5707.