### PR TITLE
fix transform iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#6257](https://github.com/influxdata/influxdb/issues/6257): CreateShardGroup was incrementing meta data index even when it was idempotent.
 - [#6223](https://github.com/influxdata/influxdb/issues/6223): Failure to start/run on Windows. Thanks @mvadu
 - [#6229](https://github.com/influxdata/influxdb/issues/6229): Fixed aggregate queries with no GROUP BY to include the end time.
+- [#6377](https://github.com/influxdata/influxdb/issues/6377): Fix panic in transform iterator on division. @thbourlove
 
 ## v0.12.0 [2016-04-05]
 

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -822,13 +822,33 @@ func buildTransformIterator(lhs Iterator, rhs Iterator, op Token, ic IteratorCre
 			left:  newBufIntegerIterator(left),
 			right: newBufIntegerIterator(right),
 			fn: func(a *IntegerPoint, b *IntegerPoint) *FloatPoint {
+				if a == nil && b == nil {
+					return nil
+				} else if a == nil {
+					return &FloatPoint{
+						Name: b.Name,
+						Tags: b.Tags,
+						Time: b.Time,
+						Aux:  b.Aux,
+						Nil:  true,
+					}
+				} else if b == nil {
+					return &FloatPoint{
+						Name: a.Name,
+						Tags: a.Tags,
+						Time: a.Time,
+						Aux:  a.Aux,
+						Nil:  true,
+					}
+				}
+
 				p := &FloatPoint{
 					Name: a.Name,
 					Tags: a.Tags,
 					Time: a.Time,
 					Aux:  a.Aux,
 				}
-				if (a != nil && b != nil) && (!a.Nil && !b.Nil) {
+				if !a.Nil && !b.Nil {
 					p.Value = fn(a.Value, b.Value)
 				} else {
 					p.Nil = true
@@ -893,13 +913,33 @@ func buildTransformIterator(lhs Iterator, rhs Iterator, op Token, ic IteratorCre
 			left:  newBufFloatIterator(left),
 			right: newBufFloatIterator(right),
 			fn: func(a *FloatPoint, b *FloatPoint) *BooleanPoint {
+				if a == nil && b == nil {
+					return nil
+				} else if a == nil {
+					return &BooleanPoint{
+						Name: b.Name,
+						Tags: b.Tags,
+						Time: b.Time,
+						Aux:  b.Aux,
+						Nil:  true,
+					}
+				} else if b == nil {
+					return &BooleanPoint{
+						Name: a.Name,
+						Tags: a.Tags,
+						Time: a.Time,
+						Aux:  a.Aux,
+						Nil:  true,
+					}
+				}
+
 				p := &BooleanPoint{
 					Name: a.Name,
 					Tags: a.Tags,
 					Time: a.Time,
 					Aux:  a.Aux,
 				}
-				if (a != nil && b != nil) && (!a.Nil && !b.Nil) {
+				if !a.Nil && !b.Nil {
 					p.Value = fn(a.Value, b.Value)
 				} else {
 					p.Nil = true
@@ -920,13 +960,33 @@ func buildTransformIterator(lhs Iterator, rhs Iterator, op Token, ic IteratorCre
 			left:  newBufIntegerIterator(left),
 			right: newBufIntegerIterator(right),
 			fn: func(a *IntegerPoint, b *IntegerPoint) *BooleanPoint {
+				if a == nil && b == nil {
+					return nil
+				} else if a == nil {
+					return &BooleanPoint{
+						Name: b.Name,
+						Tags: b.Tags,
+						Time: b.Time,
+						Aux:  b.Aux,
+						Nil:  true,
+					}
+				} else if b == nil {
+					return &BooleanPoint{
+						Name: a.Name,
+						Tags: a.Tags,
+						Time: a.Time,
+						Aux:  a.Aux,
+						Nil:  true,
+					}
+				}
+
 				p := &BooleanPoint{
 					Name: a.Name,
 					Tags: a.Tags,
 					Time: a.Time,
 					Aux:  a.Aux,
 				}
-				if (a != nil && b != nil) && (!a.Nil && !b.Nil) {
+				if !a.Nil && !b.Nil {
 					p.Value = fn(a.Value, b.Value)
 				} else {
 					p.Nil = true


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated


##### bug
there is a bug in transform iterator. when the type of expr is `func(int64, int64) float64`, it will make influxd to be crash.

##### example

select without expr
```
> select sum(code_4xx), sum(code_5xx) from requests where time > 1460345260000000000 and time < 1460345280000000000
name: requests
--------------
time                    sum     sum_1
1460345260000000001             2825
```

select with `func(int64, int64) int64` expr
```
> select sum(code_4xx) + sum(code_5xx) from requests where time > 1460345260000000000 and time < 1460345280000000000
name: requests
--------------
time                    sum_sum
1460345260000000001
```

select with `func(int64, int64) float64` expr - crashed!
```
> select sum(code_4xx) / sum(code_5xx) from requests where time > 1460345260000000000 and time < 1460345280000000000
ERR: Get http://localhost:8086/query?chunked=true&db=sla&epoch=ns&q=select+sum%28code_4xx%29+%2F+sum%28code_5xx%29+from+requests+where+time+%3E+1460345260000000000+and+time+%3C+1460345280000000000: EOF
```

##### error log
```
[query] 2016/04/14 14:21:36 SELECT sum(code_4xx) / sum(code_5xx) FROM sla."default".requests WHERE time > 1460345260000000000 AND time < 1460345280000000000
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x705170]

goroutine 373 [running]:
github.com/influxdata/influxdb/influxql.buildTransformIterator.func2(0x0, 0xc8206a58c0, 0xc8203cf4c8)
        /home/vagrant/Develop/go/src/github.com/influxdata/influxdb/influxql/select.go:826 +0x180
github.com/influxdata/influxdb/influxql.(*integerFloatExprIterator).Next(0xc8204fdf40, 0x7f83f1c5c960)
        /home/vagrant/Develop/go/src/github.com/influxdata/influxdb/influxql/iterator.gen.go:2822 +0x7d
github.com/influxdata/influxdb/influxql.(*Emitter).readIterator(0xc8205fe980, 0x7f83f1c5c960, 0xc8204fdf40, 0x0, 0x0)
        /home/vagrant/Develop/go/src/github.com/influxdata/influxdb/influxql/emitter.go:183 +0xe8
github.com/influxdata/influxdb/influxql.(*Emitter).loadBuf(0xc8205fe980, 0xa1b203eb3d1a0000, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/vagrant/Develop/go/src/github.com/influxdata/influxdb/influxql/emitter.go:93 +0x160
github.com/influxdata/influxdb/influxql.(*Emitter).Emit(0xc8205fe980, 0x1)
        /home/vagrant/Develop/go/src/github.com/influxdata/influxdb/influxql/emitter.go:53 +0x6b
github.com/influxdata/influxdb/cluster.(*QueryExecutor).executeSelectStatement(0xc820138360, 0xc820928000, 0x2710, 0x0, 0x71, 0xc8206a46c0, 0xc8206a4720, 0x0, 0x0)
        /home/vagrant/Develop/go/src/github.com/influxdata/influxdb/cluster/query_executor.go:526 +0xe85
github.com/influxdata/influxdb/cluster.(*QueryExecutor).executeQuery(0xc820138360, 0xc8204fd120, 0xc8209ce0db, 0x3, 0x2710, 0xc8206a4720, 0xc8206a46c0)
        /home/vagrant/Develop/go/src/github.com/influxdata/influxdb/cluster/query_executor.go:146 +0xa34
created by github.com/influxdata/influxdb/cluster.(*QueryExecutor).ExecuteQuery
        /home/vagrant/Develop/go/src/github.com/influxdata/influxdb/cluster/query_executor.go:80 +0x96
```