### PR TITLE
Add POST /query endpoint and warning messages for using GET with write operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [#4675](https://github.com/influxdata/influxdb/issues/4675): Allow derivative() function to be used with ORDER BY desc.
 - [#6483](https://github.com/influxdata/influxdb/pull/6483): Delete series support for TSM
 - [#6484](https://github.com/influxdata/influxdb/pull/6484): Query language support for DELETE
-
+- [#6290](https://github.com/influxdata/influxdb/issues/6290): Add POST /query endpoint and warning messages for using GET with write operations.
 
 ### Bugfixes
 
@@ -47,8 +47,8 @@
 - [#6468](https://github.com/influxdata/influxdb/issues/6468): Panic with truncated wal segments
 - [#6491](https://github.com/influxdata/influxdb/pull/6491): Fix the CLI not to enter an infinite loop when the liner has an error.
 - [#6457](https://github.com/influxdata/influxdb/issues/6457): Retention policy cleanup does not remove series
-- [#6477] (https://github.com/influxdata/influxdb/pull/6477): Don't catch SIGQUIT or SIGHUP signals.
--  [#6468](https://github.com/influxdata/influxdb/issues/6468): Panic with truncated wal segments
+- [#6477](https://github.com/influxdata/influxdb/pull/6477): Don't catch SIGQUIT or SIGHUP signals.
+- [#6468](https://github.com/influxdata/influxdb/issues/6468): Panic with truncated wal segments
 - [#6480](https://github.com/influxdata/influxdb/issues/6480): Fix SHOW statements' rewriting bug
 - [#6505](https://github.com/influxdata/influxdb/issues/6505): Add regex literal to InfluxQL spec for FROM clause.
 

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -181,7 +181,7 @@ func (c *Client) Query(q Query) (*Response, error) {
 	}
 	u.RawQuery = values.Encode()
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("POST", u.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -541,7 +541,7 @@ func (c *client) Query(q Query) (*Response, error) {
 	u := c.url
 	u.Path = "query"
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("POST", u.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/statement_executor_test.go
+++ b/cluster/statement_executor_test.go
@@ -199,7 +199,7 @@ func DefaultQueryExecutor() *QueryExecutor {
 
 // ExecuteQuery parses query and executes against the database.
 func (e *QueryExecutor) ExecuteQuery(query, database string, chunkSize int) <-chan *influxql.Result {
-	return e.QueryExecutor.ExecuteQuery(MustParseQuery(query), database, chunkSize, make(chan struct{}))
+	return e.QueryExecutor.ExecuteQuery(MustParseQuery(query), database, chunkSize, false, make(chan struct{}))
 }
 
 // TSDBStore is a mockable implementation of cluster.TSDBStore.

--- a/cmd/influxd/run/server_helpers_test.go
+++ b/cmd/influxd/run/server_helpers_test.go
@@ -143,7 +143,7 @@ func (s *Server) QueryWithParams(query string, values url.Values) (results strin
 		v, _ = url.ParseQuery(values.Encode())
 	}
 	v.Set("q", query)
-	return s.HTTPGet(s.URL() + "/query?" + v.Encode())
+	return s.HTTPPost(s.URL()+"/query?"+v.Encode(), nil)
 }
 
 // MustQueryWithParams executes a query against the server and returns the results.

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -79,6 +79,9 @@ type ExecutionContext struct {
 	// The requested maximum number of points to return in each result.
 	ChunkSize int
 
+	// If this query is being executed in a read-only context.
+	ReadOnly bool
+
 	// Hold the query executor's logger.
 	Log *log.Logger
 
@@ -158,13 +161,13 @@ func (e *QueryExecutor) SetLogOutput(w io.Writer) {
 }
 
 // ExecuteQuery executes each statement within a query.
-func (e *QueryExecutor) ExecuteQuery(query *Query, database string, chunkSize int, closing chan struct{}) <-chan *Result {
+func (e *QueryExecutor) ExecuteQuery(query *Query, database string, chunkSize int, readonly bool, closing chan struct{}) <-chan *Result {
 	results := make(chan *Result)
-	go e.executeQuery(query, database, chunkSize, closing, results)
+	go e.executeQuery(query, database, chunkSize, readonly, closing, results)
 	return results
 }
 
-func (e *QueryExecutor) executeQuery(query *Query, database string, chunkSize int, closing <-chan struct{}, results chan *Result) {
+func (e *QueryExecutor) executeQuery(query *Query, database string, chunkSize int, readonly bool, closing <-chan struct{}, results chan *Result) {
 	defer close(results)
 	defer e.recover(query, results)
 
@@ -188,6 +191,7 @@ func (e *QueryExecutor) executeQuery(query *Query, database string, chunkSize in
 		Results:     results,
 		Database:    database,
 		ChunkSize:   chunkSize,
+		ReadOnly:    readonly,
 		Log:         e.Logger,
 		InterruptCh: task.closing,
 	}
@@ -240,9 +244,15 @@ loop:
 			}
 			continue loop
 		case *KillQueryStatement:
+			var messages []*Message
+			if ctx.ReadOnly {
+				messages = append(messages, ReadOnlyWarning(stmt.String()))
+			}
+
 			err := e.executeKillQueryStatement(stmt)
 			results <- &Result{
 				StatementID: i,
+				Messages:    messages,
 				Err:         err,
 			}
 

--- a/influxql/result.go
+++ b/influxql/result.go
@@ -3,6 +3,7 @@ package influxql
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/influxdata/influxdb/models"
 )
@@ -38,6 +39,18 @@ func (t *TagSet) Swap(i, j int) {
 type Message struct {
 	Level string `json:"level"`
 	Text  string `json:"text"`
+}
+
+// ReadOnlyWarning generates a warning message that tells the user the command
+// they are using is being used for writing in a read only context.
+//
+// This is a temporary method while to be used while transitioning to read only
+// operations for issue #6290.
+func ReadOnlyWarning(stmt string) *Message {
+	return &Message{
+		Level: WarningLevel,
+		Text:  fmt.Sprintf("deprecated use of '%s' in a read only context, please use a POST request instead", stmt),
+	}
 }
 
 // Result represents a resultset returned from a single statement.

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -348,7 +348,7 @@ func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) error {
 	defer close(closing)
 
 	// Execute the SELECT.
-	ch := s.QueryExecutor.ExecuteQuery(q, cq.Database, NoChunkingSize, closing)
+	ch := s.QueryExecutor.ExecuteQuery(q, cq.Database, NoChunkingSize, false, closing)
 
 	// There is only one statement, so we will only ever receive one result
 	res, ok := <-ch


### PR DESCRIPTION
In order to follow REST a bit more carefully, all write operations
should go through a POST in the future. We still allow read operations
through either GET or POST (similar to the Graphite /render endpoint),
but write operations will trigger a returned warning as part of the JSON
response and will eventually return an error.

Fixes #6290.