### PR TITLE
Fix CREATE RETENTION POLICY parsing so it doesn't consume tokens it shouldn't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [#6382](https://github.com/influxdata/influxdb/pull/6382): Removed dead code from the old query engine.
 - [#6383](https://github.com/influxdata/influxdb/pull/6383): Recover from a panic during query execution.
 - [#3369](https://github.com/influxdata/influxdb/issues/3369): Detect when a timer literal will overflow or underflow the query engine.
+- [#6398](https://github.com/influxdata/influxdb/issues/6398): Fix CREATE RETENTION POLICY parsing so it doesn't consume tokens it shouldn't.
 
 ## v0.12.1 [2016-04-08]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -413,7 +413,7 @@ func (p *Parser) parseCreateRetentionPolicyStatement() (*CreateRetentionPolicySt
 	stmt.Replication = n
 
 	// Parse optional SHARD token.
-	if tok, pos, lit := p.scanIgnoreWhitespace(); tok == SHARD {
+	if tok, _, _ := p.scanIgnoreWhitespace(); tok == SHARD {
 		if tok, pos, lit := p.scanIgnoreWhitespace(); tok != DURATION {
 			return nil, newParseError(tokstr(tok, lit), []string{"DURATION"}, pos)
 		}
@@ -422,17 +422,15 @@ func (p *Parser) parseCreateRetentionPolicyStatement() (*CreateRetentionPolicySt
 			return nil, err
 		}
 		stmt.ShardGroupDuration = d
-	} else if tok != EOF && tok != SEMICOLON && tok != DEFAULT {
-		return nil, newParseError(tokstr(tok, lit), []string{"SHARD"}, pos)
 	} else {
 		p.unscan()
 	}
 
 	// Parse optional DEFAULT token.
-	if tok, pos, lit := p.scanIgnoreWhitespace(); tok == DEFAULT {
+	if tok, _, _ := p.scanIgnoreWhitespace(); tok == DEFAULT {
 		stmt.Default = true
-	} else if tok != EOF && tok != SEMICOLON {
-		return nil, newParseError(tokstr(tok, lit), []string{"DEFAULT"}, pos)
+	} else {
+		p.unscan()
 	}
 
 	return stmt, nil

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -2090,8 +2090,6 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `CREATE RETENTION POLICY policy1 ON testdb DURATION 1h REPLICATION 3.14`, err: `found 3.14, expected integer at line 1, char 67`},
 		{s: `CREATE RETENTION POLICY policy1 ON testdb DURATION 1h REPLICATION 0`, err: `invalid value 0: must be 1 <= n <= 2147483647 at line 1, char 67`},
 		{s: `CREATE RETENTION POLICY policy1 ON testdb DURATION 1h REPLICATION bad`, err: `found bad, expected integer at line 1, char 67`},
-		{s: `CREATE RETENTION POLICY policy1 ON testdb DURATION 1h REPLICATION 1 foo`, err: `found foo, expected SHARD at line 1, char 69`},
-		{s: `CREATE RETENTION POLICY policy1 ON testdb DURATION 1h REPLICATION 1 SHARD DURATION 30m foo`, err: `found foo, expected DEFAULT at line 1, char 88`},
 		{s: `ALTER`, err: `found EOF, expected RETENTION at line 1, char 7`},
 		{s: `ALTER RETENTION`, err: `found EOF, expected POLICY at line 1, char 17`},
 		{s: `ALTER RETENTION POLICY`, err: `found EOF, expected identifier at line 1, char 24`},


### PR DESCRIPTION
The optional sections of the command consumed the semicolon token and
didn't put it back for the outer loop. The code shouldn't explicitly
check for a semicolon or EOF anyway, so these checks were removed and
the token gets unscanned if it doesn't match the optional token that the
parser is looking for.

Fixes #6398.