### PR TITLE
Send the "Connection: close" header for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#3369](https://github.com/influxdata/influxdb/issues/3369): Detect when a timer literal will overflow or underflow the query engine.
 - [#6398](https://github.com/influxdata/influxdb/issues/6398): Fix CREATE RETENTION POLICY parsing so it doesn't consume tokens it shouldn't.
 - [#6413](https://github.com/influxdata/influxdb/pull/6413): Prevent goroutine leak from persistent http connections. Thanks @aaronknister.
+- [#6414](https://github.com/influxdata/influxdb/pull/6414): Send "Connection: close" header for queries.
 
 ## v0.12.1 [2016-04-08]
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -293,9 +293,13 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 	// Make sure if the client disconnects we signal the query to abort
 	closing := make(chan struct{})
 	if notifier, ok := w.(http.CloseNotifier); ok {
-		notify := notifier.CloseNotify()
+		// CloseNotify() is not guaranteed to send a notification when the query
+		// is closed. Use this channel to signal that the query is finished to
+		// prevent lingering goroutines that may be stuck.
 		done := make(chan struct{})
 		defer close(done)
+
+		notify := notifier.CloseNotify()
 		go func() {
 			// Wait for either the request to finish
 			// or for the client to disconnect
@@ -310,6 +314,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 	}
 
 	// Execute query.
+	w.Header().Add("Connection", "close")
 	w.Header().Add("content-type", "application/json")
 	results := h.QueryExecutor.ExecuteQuery(query, db, chunkSize, closing)
 


### PR DESCRIPTION
CloseNotify() is not compatible with pipelining. Adding this header
prevents the client from attempting to pipeline requests.