### PR TITLE
Sort the series keys inside of a tag set so the output is deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#6334](https://github.com/influxdata/influxdb/pull/6334): Allow environment variables to be set per input type.
 - [#6394](https://github.com/influxdata/influxdb/pull/6394): Allow time math with integer timestamps.
 - [#3247](https://github.com/influxdata/influxdb/issues/3247): Implement derivatives across intervals for aggregate queries.
+- [#3166](https://github.com/influxdata/influxdb/issues/3166): Sort the series keys inside of a tag set so output is deterministic.
 
 ### Bugfixes
 

--- a/influxql/result.go
+++ b/influxql/result.go
@@ -27,6 +27,13 @@ func (t *TagSet) AddFilter(key string, filter Expr) {
 	t.Filters = append(t.Filters, filter)
 }
 
+func (t *TagSet) Len() int           { return len(t.SeriesKeys) }
+func (t *TagSet) Less(i, j int) bool { return t.SeriesKeys[i] < t.SeriesKeys[j] }
+func (t *TagSet) Swap(i, j int) {
+	t.SeriesKeys[i], t.SeriesKeys[j] = t.SeriesKeys[j], t.SeriesKeys[i]
+	t.Filters[i], t.Filters[j] = t.Filters[j], t.Filters[i]
+}
+
 // Message represents a user-facing message to be included with the result.
 type Message struct {
 	Level string `json:"level"`

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -658,6 +658,11 @@ func (m *Measurement) TagSets(dimensions []string, condition influxql.Expr) ([]*
 		tagSets[tagsAsKey] = tagSet
 	}
 
+	// Sort the series in each tag set.
+	for _, t := range tagSets {
+		sort.Sort(t)
+	}
+
 	// The TagSets have been created, as a map of TagSets. Just send
 	// the values back as a slice, sorting for consistency.
 	sortedTagSetKeys := make([]string, 0, len(tagSets))


### PR DESCRIPTION
The series keys within a tag set were previously not sorted which would
cause the output to be non-deterministic. This sorts the output series
by their keys so it has a consistent output especially when using
limits.

Fixes #3166.