### PR TITLE
fix panic in transform iterator on division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [#6413](https://github.com/influxdata/influxdb/pull/6413): Prevent goroutine leak from persistent http connections. Thanks @aaronknister.
 - [#6414](https://github.com/influxdata/influxdb/pull/6414): Send "Connection: close" header for queries.
 - [#6425](https://github.com/influxdata/influxdb/pull/6425): Close idle tcp connections in HTTP client to prevent tcp conn leak.
+- [#6419](https://github.com/influxdata/influxdb/issues/6419): Fix panic in transform iterator on division. @thbourlove
 
 ## v0.12.1 [2016-04-08]
 

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -840,13 +840,33 @@ func buildTransformIterator(lhs Iterator, rhs Iterator, op Token, ic IteratorCre
 			left:  newBufIntegerIterator(left),
 			right: newBufIntegerIterator(right),
 			fn: func(a *IntegerPoint, b *IntegerPoint) *FloatPoint {
+				if a == nil && b == nil {
+					return nil
+				} else if a == nil {
+					return &FloatPoint{
+						Name: b.Name,
+						Tags: b.Tags,
+						Time: b.Time,
+						Aux:  b.Aux,
+						Nil:  true,
+					}
+				} else if b == nil {
+					return &FloatPoint{
+						Name: a.Name,
+						Tags: a.Tags,
+						Time: a.Time,
+						Aux:  a.Aux,
+						Nil:  true,
+					}
+				}
+
 				p := &FloatPoint{
 					Name: a.Name,
 					Tags: a.Tags,
 					Time: a.Time,
 					Aux:  a.Aux,
 				}
-				if (a != nil && b != nil) && (!a.Nil && !b.Nil) {
+				if !a.Nil && !b.Nil {
 					p.Value = fn(a.Value, b.Value)
 				} else {
 					p.Nil = true
@@ -911,13 +931,33 @@ func buildTransformIterator(lhs Iterator, rhs Iterator, op Token, ic IteratorCre
 			left:  newBufFloatIterator(left),
 			right: newBufFloatIterator(right),
 			fn: func(a *FloatPoint, b *FloatPoint) *BooleanPoint {
+				if a == nil && b == nil {
+					return nil
+				} else if a == nil {
+					return &BooleanPoint{
+						Name: b.Name,
+						Tags: b.Tags,
+						Time: b.Time,
+						Aux:  b.Aux,
+						Nil:  true,
+					}
+				} else if b == nil {
+					return &BooleanPoint{
+						Name: a.Name,
+						Tags: a.Tags,
+						Time: a.Time,
+						Aux:  a.Aux,
+						Nil:  true,
+					}
+				}
+
 				p := &BooleanPoint{
 					Name: a.Name,
 					Tags: a.Tags,
 					Time: a.Time,
 					Aux:  a.Aux,
 				}
-				if (a != nil && b != nil) && (!a.Nil && !b.Nil) {
+				if !a.Nil && !b.Nil {
 					p.Value = fn(a.Value, b.Value)
 				} else {
 					p.Nil = true
@@ -938,13 +978,33 @@ func buildTransformIterator(lhs Iterator, rhs Iterator, op Token, ic IteratorCre
 			left:  newBufIntegerIterator(left),
 			right: newBufIntegerIterator(right),
 			fn: func(a *IntegerPoint, b *IntegerPoint) *BooleanPoint {
+				if a == nil && b == nil {
+					return nil
+				} else if a == nil {
+					return &BooleanPoint{
+						Name: b.Name,
+						Tags: b.Tags,
+						Time: b.Time,
+						Aux:  b.Aux,
+						Nil:  true,
+					}
+				} else if b == nil {
+					return &BooleanPoint{
+						Name: a.Name,
+						Tags: a.Tags,
+						Time: a.Time,
+						Aux:  a.Aux,
+						Nil:  true,
+					}
+				}
+
 				p := &BooleanPoint{
 					Name: a.Name,
 					Tags: a.Tags,
 					Time: a.Time,
 					Aux:  a.Aux,
 				}
-				if (a != nil && b != nil) && (!a.Nil && !b.Nil) {
+				if !a.Nil && !b.Nil {
 					p.Value = fn(a.Value, b.Value)
 				} else {
 					p.Nil = true


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated

if left point is nil in division expr, the influxd server would panic. Now check left point before use it. #6377 