### PR TITLE
Use int64 instead of time.Time in timestamp encoder/decoders

### DIFF
--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -268,7 +268,7 @@ func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 	tsenc := NewTimeEncoder()
 
 	for _, v := range values {
-		tsenc.Write(time.Unix(0, v.UnixNano()))
+		tsenc.Write(v.UnixNano())
 		venc.Push(v.(*FloatValue).value)
 	}
 	venc.Finish()
@@ -314,10 +314,10 @@ func DecodeFloatBlock(block []byte, tdec TimeDecoder, vdec *FloatDecoder, a *[]F
 		v := vdec.Values()
 		if i < len(*a) {
 			elem := &(*a)[i]
-			elem.unixnano = ts.UnixNano()
+			elem.unixnano = ts
 			elem.value = v
 		} else {
-			*a = append(*a, FloatValue{ts.UnixNano(), v})
+			*a = append(*a, FloatValue{ts, v})
 		}
 		i++
 	}
@@ -395,7 +395,7 @@ func encodeBooleanBlock(buf []byte, values []Value) ([]byte, error) {
 	tsenc := NewTimeEncoder()
 
 	for _, v := range values {
-		tsenc.Write(time.Unix(0, v.UnixNano()))
+		tsenc.Write(v.UnixNano())
 		venc.Write(v.(*BooleanValue).value)
 	}
 
@@ -438,10 +438,10 @@ func DecodeBooleanBlock(block []byte, tdec TimeDecoder, vdec *BooleanDecoder, a 
 		v := vdec.Read()
 		if i < len(*a) {
 			elem := &(*a)[i]
-			elem.unixnano = ts.UnixNano()
+			elem.unixnano = ts
 			elem.value = v
 		} else {
-			*a = append(*a, BooleanValue{ts.UnixNano(), v})
+			*a = append(*a, BooleanValue{ts, v})
 		}
 		i++
 	}
@@ -508,7 +508,7 @@ func encodeIntegerBlock(buf []byte, values []Value) ([]byte, error) {
 	tsEnc := NewTimeEncoder()
 	vEnc := NewIntegerEncoder()
 	for _, v := range values {
-		tsEnc.Write(time.Unix(0, v.UnixNano()))
+		tsEnc.Write(v.UnixNano())
 		vEnc.Write(v.(*IntegerValue).value)
 	}
 
@@ -550,10 +550,10 @@ func DecodeIntegerBlock(block []byte, tdec TimeDecoder, vdec *IntegerDecoder, a 
 		v := vdec.Read()
 		if i < len(*a) {
 			elem := &(*a)[i]
-			elem.unixnano = ts.UnixNano()
+			elem.unixnano = ts
 			elem.value = v
 		} else {
-			*a = append(*a, IntegerValue{ts.UnixNano(), v})
+			*a = append(*a, IntegerValue{ts, v})
 		}
 		i++
 	}
@@ -620,7 +620,7 @@ func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
 	tsEnc := NewTimeEncoder()
 	vEnc := NewStringEncoder()
 	for _, v := range values {
-		tsEnc.Write(time.Unix(0, v.UnixNano()))
+		tsEnc.Write(v.UnixNano())
 		vEnc.Write(v.(*StringValue).value)
 	}
 
@@ -664,10 +664,10 @@ func DecodeStringBlock(block []byte, tdec TimeDecoder, vdec *StringDecoder, a *[
 		v := vdec.Read()
 		if i < len(*a) {
 			elem := &(*a)[i]
-			elem.unixnano = ts.UnixNano()
+			elem.unixnano = ts
 			elem.value = v
 		} else {
-			*a = append(*a, StringValue{ts.UnixNano(), v})
+			*a = append(*a, StringValue{ts, v})
 		}
 		i++
 	}

--- a/tsdb/engine/tsm1/timestamp_test.go
+++ b/tsdb/engine/tsm1/timestamp_test.go
@@ -10,12 +10,12 @@ import (
 func Test_TimeEncoder(t *testing.T) {
 	enc := NewTimeEncoder()
 
-	x := []time.Time{}
+	x := []int64{}
 	now := time.Unix(0, 0)
-	x = append(x, now)
-	enc.Write(now)
+	x = append(x, now.UnixNano())
+	enc.Write(now.UnixNano())
 	for i := 1; i < 4; i++ {
-		x = append(x, now.Add(time.Duration(i)*time.Second))
+		x = append(x, now.Add(time.Duration(i)*time.Second).UnixNano())
 		enc.Write(x[i])
 	}
 
@@ -57,7 +57,7 @@ func Test_TimeEncoder_NoValues(t *testing.T) {
 
 func Test_TimeEncoder_One(t *testing.T) {
 	enc := NewTimeEncoder()
-	tm := time.Unix(0, 0)
+	var tm int64
 
 	enc.Write(tm)
 	b, err := enc.Bytes()
@@ -82,8 +82,8 @@ func Test_TimeEncoder_One(t *testing.T) {
 
 func Test_TimeEncoder_Two(t *testing.T) {
 	enc := NewTimeEncoder()
-	t1 := time.Unix(0, 0)
-	t2 := time.Unix(0, 1)
+	t1 := int64(0)
+	t2 := int64(1)
 	enc.Write(t1)
 	enc.Write(t2)
 
@@ -117,9 +117,9 @@ func Test_TimeEncoder_Two(t *testing.T) {
 
 func Test_TimeEncoder_Three(t *testing.T) {
 	enc := NewTimeEncoder()
-	t1 := time.Unix(0, 0)
-	t2 := time.Unix(0, 1)
-	t3 := time.Unix(0, 3)
+	t1 := int64(0)
+	t2 := int64(1)
+	t3 := int64(3)
 
 	enc.Write(t1)
 	enc.Write(t2)
@@ -163,8 +163,8 @@ func Test_TimeEncoder_Three(t *testing.T) {
 
 func Test_TimeEncoder_Large_Range(t *testing.T) {
 	enc := NewTimeEncoder()
-	t1 := time.Unix(0, 1442369134000000000)
-	t2 := time.Unix(0, 1442369135000000000)
+	t1 := int64(1442369134000000000)
+	t2 := int64(1442369135000000000)
 	enc.Write(t1)
 	enc.Write(t2)
 	b, err := enc.Bytes()
@@ -197,12 +197,12 @@ func Test_TimeEncoder_Large_Range(t *testing.T) {
 
 func Test_TimeEncoder_Uncompressed(t *testing.T) {
 	enc := NewTimeEncoder()
-	t1 := time.Unix(0, 0)
-	t2 := time.Unix(1, 0)
+	t1 := time.Unix(0, 0).UnixNano()
+	t2 := time.Unix(1, 0).UnixNano()
 
 	// about 36.5yrs in NS resolution is max range for compressed format
 	// This should cause the encoding to fallback to raw points
-	t3 := time.Unix(2, (2 << 59))
+	t3 := time.Unix(2, (2 << 59)).UnixNano()
 	enc.Write(t1)
 	enc.Write(t2)
 	enc.Write(t3)
@@ -249,9 +249,9 @@ func Test_TimeEncoder_Uncompressed(t *testing.T) {
 
 func Test_TimeEncoder_RLE(t *testing.T) {
 	enc := NewTimeEncoder()
-	var ts []time.Time
+	var ts []int64
 	for i := 0; i < 500; i++ {
-		ts = append(ts, time.Unix(int64(i), 0))
+		ts = append(ts, int64(i))
 	}
 
 	for _, v := range ts {
@@ -290,10 +290,10 @@ func Test_TimeEncoder_RLE(t *testing.T) {
 
 func Test_TimeEncoder_Reverse(t *testing.T) {
 	enc := NewTimeEncoder()
-	ts := []time.Time{
-		time.Unix(0, 3),
-		time.Unix(0, 2),
-		time.Unix(0, 0),
+	ts := []int64{
+		int64(3),
+		int64(2),
+		int64(0),
 	}
 
 	for _, v := range ts {
@@ -322,10 +322,10 @@ func Test_TimeEncoder_Reverse(t *testing.T) {
 
 func Test_TimeEncoder_220SecondDelta(t *testing.T) {
 	enc := NewTimeEncoder()
-	var ts []time.Time
+	var ts []int64
 	now := time.Now()
 	for i := 0; i < 220; i++ {
-		ts = append(ts, now.Add(time.Duration(i*60)*time.Second))
+		ts = append(ts, now.Add(time.Duration(i*60)*time.Second).UnixNano())
 	}
 
 	for _, v := range ts {
@@ -369,9 +369,9 @@ func Test_TimeEncoder_Quick(t *testing.T) {
 	quick.Check(func(values []int64) bool {
 		// Write values to encoder.
 		enc := NewTimeEncoder()
-		exp := make([]time.Time, len(values))
+		exp := make([]int64, len(values))
 		for i, v := range values {
-			exp[i] = time.Unix(0, v)
+			exp[i] = int64(v)
 			enc.Write(exp[i])
 		}
 
@@ -382,7 +382,7 @@ func Test_TimeEncoder_Quick(t *testing.T) {
 		}
 
 		// Read values out of decoder.
-		got := make([]time.Time, 0, len(values))
+		got := make([]int64, 0, len(values))
 		dec := NewTimeDecoder()
 		dec.Init(buf)
 		for dec.Next() {
@@ -403,14 +403,14 @@ func Test_TimeEncoder_Quick(t *testing.T) {
 
 func Test_TimeEncoder_RLESeconds(t *testing.T) {
 	enc := NewTimeEncoder()
-	ts := make([]time.Time, 6)
+	ts := make([]int64, 6)
 
-	ts[0] = time.Unix(0, 1444448158000000000)
-	ts[1] = time.Unix(0, 1444448168000000000)
-	ts[2] = time.Unix(0, 1444448178000000000)
-	ts[3] = time.Unix(0, 1444448188000000000)
-	ts[4] = time.Unix(0, 1444448198000000000)
-	ts[5] = time.Unix(0, 1444448208000000000)
+	ts[0] = int64(1444448158000000000)
+	ts[1] = int64(1444448168000000000)
+	ts[2] = int64(1444448178000000000)
+	ts[3] = int64(1444448188000000000)
+	ts[4] = int64(1444448198000000000)
+	ts[5] = int64(1444448208000000000)
 
 	for _, v := range ts {
 		enc.Write(v)
@@ -444,12 +444,12 @@ func Test_TimeEncoder_RLESeconds(t *testing.T) {
 
 func TestTimeEncoder_Count_Uncompressed(t *testing.T) {
 	enc := NewTimeEncoder()
-	t1 := time.Unix(0, 0)
-	t2 := time.Unix(1, 0)
+	t1 := time.Unix(0, 0).UnixNano()
+	t2 := time.Unix(1, 0).UnixNano()
 
 	// about 36.5yrs in NS resolution is max range for compressed format
 	// This should cause the encoding to fallback to raw points
-	t3 := time.Unix(2, (2 << 59))
+	t3 := time.Unix(2, (2 << 59)).UnixNano()
 	enc.Write(t1)
 	enc.Write(t2)
 	enc.Write(t3)
@@ -470,14 +470,14 @@ func TestTimeEncoder_Count_Uncompressed(t *testing.T) {
 
 func TestTimeEncoder_Count_RLE(t *testing.T) {
 	enc := NewTimeEncoder()
-	ts := make([]time.Time, 6)
+	ts := make([]int64, 6)
 
-	ts[0] = time.Unix(0, 1444448158000000000)
-	ts[1] = time.Unix(0, 1444448168000000000)
-	ts[2] = time.Unix(0, 1444448178000000000)
-	ts[3] = time.Unix(0, 1444448188000000000)
-	ts[4] = time.Unix(0, 1444448198000000000)
-	ts[5] = time.Unix(0, 1444448208000000000)
+	ts[0] = int64(1444448158000000000)
+	ts[1] = int64(1444448168000000000)
+	ts[2] = int64(1444448178000000000)
+	ts[3] = int64(1444448188000000000)
+	ts[4] = int64(1444448198000000000)
+	ts[5] = int64(1444448208000000000)
 
 	for _, v := range ts {
 		enc.Write(v)
@@ -499,9 +499,9 @@ func TestTimeEncoder_Count_RLE(t *testing.T) {
 
 func TestTimeEncoder_Count_Simple8(t *testing.T) {
 	enc := NewTimeEncoder()
-	t1 := time.Unix(0, 0)
-	t2 := time.Unix(0, 1)
-	t3 := time.Unix(0, 3)
+	t1 := int64(0)
+	t2 := int64(1)
+	t3 := int64(3)
 
 	enc.Write(t1)
 	enc.Write(t2)
@@ -527,9 +527,9 @@ func TestTimeEncoder_Count_Simple8(t *testing.T) {
 
 func BenchmarkTimeEncoder(b *testing.B) {
 	enc := NewTimeEncoder()
-	x := make([]time.Time, 1024)
+	x := make([]int64, 1024)
 	for i := 0; i < len(x); i++ {
-		x[i] = time.Now()
+		x[i] = time.Now().UnixNano()
 		enc.Write(x[i])
 	}
 
@@ -540,10 +540,10 @@ func BenchmarkTimeEncoder(b *testing.B) {
 }
 
 func BenchmarkTimeDecoder_Packed(b *testing.B) {
-	x := make([]time.Time, 1024)
+	x := make([]int64, 1024)
 	enc := NewTimeEncoder()
 	for i := 0; i < len(x); i++ {
-		x[i] = time.Now()
+		x[i] = time.Now().UnixNano()
 		enc.Write(x[i])
 	}
 	bytes, _ := enc.Bytes()
@@ -562,10 +562,10 @@ func BenchmarkTimeDecoder_Packed(b *testing.B) {
 }
 
 func BenchmarkTimeDecoder_RLE(b *testing.B) {
-	x := make([]time.Time, 1024)
+	x := make([]int64, 1024)
 	enc := NewTimeEncoder()
 	for i := 0; i < len(x); i++ {
-		x[i] = time.Unix(0, int64(i*10))
+		x[i] = int64(i * 10)
 		enc.Write(x[i])
 	}
 	bytes, _ := enc.Bytes()

--- a/tsdb/engine/tsm1/timestamp_test.go
+++ b/tsdb/engine/tsm1/timestamp_test.go
@@ -539,7 +539,7 @@ func BenchmarkTimeEncoder(b *testing.B) {
 	}
 }
 
-func BenchmarkTimeDecoder(b *testing.B) {
+func BenchmarkTimeDecoder_Packed(b *testing.B) {
 	x := make([]time.Time, 1024)
 	enc := NewTimeEncoder()
 	for i := 0; i < len(x); i++ {
@@ -550,11 +550,34 @@ func BenchmarkTimeDecoder(b *testing.B) {
 
 	b.ResetTimer()
 
+	b.StopTimer()
+	dec := NewTimeDecoder()
+	b.StartTimer()
+
 	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		dec := NewTimeDecoder()
 		dec.Init(bytes)
-		b.StartTimer()
+		for dec.Next() {
+		}
+	}
+}
+
+func BenchmarkTimeDecoder_RLE(b *testing.B) {
+	x := make([]time.Time, 1024)
+	enc := NewTimeEncoder()
+	for i := 0; i < len(x); i++ {
+		x[i] = time.Unix(0, int64(i*10))
+		enc.Write(x[i])
+	}
+	bytes, _ := enc.Bytes()
+
+	b.ResetTimer()
+
+	b.StopTimer()
+	dec := NewTimeDecoder()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		dec.Init(bytes)
 		for dec.Next() {
 		}
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated

This converts the timestamp encoder to use `int64` instead of `time.Time` to avoid a few unnecessary allocations when encoding and decoding.

```
benchmark                       old ns/op     new ns/op     delta
BenchmarkTimeEncoder            25896         25420         -1.84%
BenchmarkTimeDecoder_Packed     25791         16394         -36.44%
BenchmarkTimeDecoder_RLE        23782         7667          -67.76%

benchmark                       old allocs     new allocs     delta
BenchmarkTimeEncoder            1              1              +0.00%
BenchmarkTimeDecoder_Packed     0              0              +0.00%
BenchmarkTimeDecoder_RLE        1              0              -100.00%

benchmark                       old bytes     new bytes     delta
BenchmarkTimeEncoder            8447          8447          +0.00%
BenchmarkTimeDecoder_Packed     0             0             +0.00%
BenchmarkTimeDecoder_RLE        8192          0             -100.00%
```