### PR TITLE
Prevent InfluxDB client from leaking TCP connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#6398](https://github.com/influxdata/influxdb/issues/6398): Fix CREATE RETENTION POLICY parsing so it doesn't consume tokens it shouldn't.
 - [#6413](https://github.com/influxdata/influxdb/pull/6413): Prevent goroutine leak from persistent http connections. Thanks @aaronknister.
 - [#6414](https://github.com/influxdata/influxdb/pull/6414): Send "Connection: close" header for queries.
+- [#6425](https://github.com/influxdata/influxdb/pull/6425): Close idle tcp connections in HTTP client to prevent tcp conn leak.
 
 ## v0.12.1 [2016-04-08]
 

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -123,6 +123,7 @@ func NewHTTPClient(conf HTTPConfig) (Client, error) {
 			Timeout:   conf.Timeout,
 			Transport: tr,
 		},
+		transport: tr,
 	}, nil
 }
 
@@ -172,6 +173,7 @@ func (c *client) Ping(timeout time.Duration) (time.Duration, string, error) {
 
 // Close releases the client's resources.
 func (c *client) Close() error {
+	c.transport.CloseIdleConnections()
 	return nil
 }
 
@@ -221,6 +223,7 @@ type client struct {
 	password   string
 	useragent  string
 	httpClient *http.Client
+	transport  *http.Transport
 }
 
 type udpclient struct {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] CHANGELOG.md updated

If users properly call client.Close(), then this will make sure that
established tcp connections dont continually grow when creating new http
clients.

This fixes the case where users are creating new http clients on top of
existing _valid_ connections.

This was encountered in Telegraf when we were recreating our http
clients after getting write failures that were unrelated to the actual
connection being severed (such as typos in the retention policy, see
https://github.com/influxdata/telegraf/issues/1058)