### PR TITLE
Disable cache max memory size when reloading the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [#6414](https://github.com/influxdata/influxdb/pull/6414): Send "Connection: close" header for queries.
 - [#6425](https://github.com/influxdata/influxdb/pull/6425): Close idle tcp connections in HTTP client to prevent tcp conn leak.
 - [#6419](https://github.com/influxdata/influxdb/issues/6419): Fix panic in transform iterator on division. @thbourlove
+- [#6109](https://github.com/influxdata/influxdb/issues/6109): Cache maximum memory size exceeded on startup
 
 ## v0.12.1 [2016-04-08]
 

--- a/stress/stress_test.go
+++ b/stress/stress_test.go
@@ -54,7 +54,8 @@ func TestTimer_Elapsed(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	tmr.StopTimer()
 	e := tmr.Elapsed()
-	if time.Duration(2*time.Second) > e || e > time.Duration(3*time.Second) {
+
+	if time.Duration(1990*time.Millisecond) > e || e > time.Duration(3*time.Second) {
 		t.Errorf("expected around %s got %s", time.Duration(2*time.Second), e)
 	}
 }

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -306,6 +306,12 @@ func (c *Cache) Delete(keys []string) {
 	}
 }
 
+func (c *Cache) SetMaxSize(size uint64) {
+	c.mu.Lock()
+	c.maxSize = size
+	c.mu.Unlock()
+}
+
 // merged returns a copy of hot and snapshot values. The copy will be merged, deduped, and
 // sorted. It assumes all necessary locks have been taken. If the caller knows that the
 // the hot source data for the key will not be changed, it is safe to call this function

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -659,6 +659,14 @@ func (e *Engine) reloadCache() error {
 		return err
 	}
 
+	limit := e.Cache.MaxSize()
+	defer func() {
+		e.Cache.SetMaxSize(limit)
+	}()
+
+	// Disable the max size during loading
+	e.Cache.SetMaxSize(0)
+
 	loader := NewCacheLoader(files)
 	if err := loader.Load(e.Cache); err != nil {
 		return err


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

The cache max memory size is an approximate size and can prevent a
shard from loading at startup.  This change disable the max size
at startup to prevent this problem and sets the limt back after
reloading.

Fixes #6109

