### PR TITLE
Allow setting the config path through an environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#3166](https://github.com/influxdata/influxdb/issues/3166): Sort the series keys inside of a tag set so output is deterministic.
 - [#1856](https://github.com/influxdata/influxdb/issues/1856): Add `elapsed` function that returns the time delta between subsequent points.
 - [#5502](https://github.com/influxdata/influxdb/issues/5502): Add checksum verification to TSM inspect tool
+- [#6444](https://github.com/influxdata/influxdb/pull/6444): Allow setting the config path through an environment variable and default config path.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/config_command.go
+++ b/cmd/influxd/run/config_command.go
@@ -36,7 +36,8 @@ func (cmd *PrintConfigCommand) Run(args ...string) error {
 	}
 
 	// Parse config from path.
-	config, err := cmd.parseConfig(*configPath)
+	opt := Options{ConfigPath: *configPath}
+	config, err := cmd.parseConfig(opt.GetConfigPath())
 	if err != nil {
 		return fmt.Errorf("parse config: %s", err)
 	}


### PR DESCRIPTION
The config path previously could only be specified through the command
line options. This made it very difficult to set a default config path
without using any option.

Now the environment variable can be set so the default configuration
path is set to a specific place, but can be overwritten using the
command line option.

The primary purpose of this is so the Docker container can have a
default configuration file, but not have to parse the command line
options to figure out if a different configuration file has been
specified while still allowing the user to only type `influxd` and have
the program start correctly.

This might also help #6392 as it would allow a default configuration
location to be included with the package by setting an environment
variable.