### PR TITLE
fix cli writeColumns output

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -608,20 +608,20 @@ func (c *CommandLine) writeCSV(response *client.Response, w io.Writer) {
 }
 
 func (c *CommandLine) writeColumns(response *client.Response, w io.Writer) {
+	// Create a tabbed writer for each result as they won't always line up
+	writer := new(tabwriter.Writer)
+	writer.Init(w, 0, 8, 1, '\t', 0)
+
 	for _, result := range response.Results {
 		// Print out all messages first
 		for _, m := range result.Messages {
 			fmt.Fprintf(w, "%s: %s.\n", m.Level, m.Text)
 		}
-
-		// Create a tabbed writer for each result as they won't always line up
-		w := new(tabwriter.Writer)
-		w.Init(os.Stdout, 0, 8, 1, '\t', 0)
 		csv := c.formatResults(result, "\t")
 		for _, r := range csv {
-			fmt.Fprintln(w, r)
+			fmt.Fprintln(writer, r)
 		}
-		w.Flush()
+		writer.Flush()
 	}
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

The old  var `w` wiil overwrite function input param `w`, and rename it to `writer`.  

