### PR TITLE
Make it clear when CLI version is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [#6419](https://github.com/influxdata/influxdb/issues/6419): Fix panic in transform iterator on division. @thbourlove
 - [#6109](https://github.com/influxdata/influxdb/issues/6109): Cache maximum memory size exceeded on startup
 - [#6427](https://github.com/influxdata/influxdb/pull/6427): Fix setting uint config options via env vars
+- [#6458](https://github.com/influxdata/influxdb/pull/6458): Make it clear when the CLI version is unknown.
 - [#3883](https://github.com/influxdata/influxdb/issues/3883): Improve query sanitization to prevent a password leak in the logs.
 
 ## v0.12.1 [2016-04-08]

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -841,7 +841,7 @@ func (c *CommandLine) gopher() {
 
 // Version prints CLI version
 func (c *CommandLine) Version() {
-	fmt.Println("InfluxDB shell " + c.ClientVersion)
+	fmt.Println("InfluxDB shell version:", c.ClientVersion)
 }
 
 func (c *CommandLine) exit() {

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -11,7 +11,7 @@ import (
 
 // These variables are populated via the Go linker.
 var (
-	version = "0.9"
+	version string
 )
 
 const (
@@ -25,6 +25,13 @@ const (
 	// by default it's 0, which means it will not throttle
 	defaultPPS = 0
 )
+
+func init() {
+	// If version is not set, make that clear.
+	if version == "" {
+		version = "unknown"
+	}
+}
 
 func main() {
 	c := cli.New(version)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This mimics the behavior of the database binary. The CLI binary, if built without setting the version, will set its version to "unknown" as opposed to "0.9".