### PR TITLE
Add safer locking to CreateFieldIfNotExists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#6427](https://github.com/influxdata/influxdb/pull/6427): Fix setting uint config options via env vars
 - [#6458](https://github.com/influxdata/influxdb/pull/6458): Make it clear when the CLI version is unknown.
 - [#3883](https://github.com/influxdata/influxdb/issues/3883): Improve query sanitization to prevent a password leak in the logs.
+- [#6462](https://github.com/influxdata/influxdb/pull/6462): Add safer locking to CreateFieldIfNotExists
 
 ## v0.12.1 [2016-04-08]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -572,6 +572,7 @@ func (m *MeasurementFields) CreateFieldIfNotExists(name string, typ influxql.Dat
 	m.mu.RUnlock()
 
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	if f := m.fields[name]; f != nil {
 		return nil
 	}
@@ -584,7 +585,6 @@ func (m *MeasurementFields) CreateFieldIfNotExists(name string, typ influxql.Dat
 	}
 	m.fields[name] = f
 	m.Codec = NewFieldCodec(m.fields)
-	m.mu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

A deadlock can occur if the field was created while we were waiting for the lock.