### PR TITLE
Don't catch SIGQUIT; safer close of Quit channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [#6462](https://github.com/influxdata/influxdb/pull/6462): Add safer locking to CreateFieldIfNotExists
 - [#6361](https://github.com/influxdata/influxdb/pull/6361): Fix cluster/pool release of connection
 - [#6470](https://github.com/influxdata/influxdb/pull/6470): Remove SHOW SERVERS & DROP SERVER support
+- [#6477] (https://github.com/influxdata/influxdb/pull/6477): Don't catch SIGQUIT or SIGHUP signals.
 
 ## v0.12.2 [2016-04-20]
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -74,9 +74,9 @@ func New(version string) *CommandLine {
 
 // Run executes the CLI
 func (c *CommandLine) Run() error {
-	// register OS signals for graceful termination
 	if !c.IgnoreSignals {
-		signal.Notify(c.osSignals, os.Kill, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
+		// register OS signals for graceful termination
+		signal.Notify(c.osSignals, syscall.SIGINT, syscall.SIGTERM)
 	}
 
 	var promptForPassword bool
@@ -182,7 +182,8 @@ func (c *CommandLine) Run() error {
 	for {
 		select {
 		case <-c.osSignals:
-			close(c.Quit)
+			c.exit()
+			return nil
 		case <-c.Quit:
 			c.exit()
 			return nil
@@ -210,7 +211,6 @@ func (c *CommandLine) ParseCommand(cmd string) error {
 	if len(tokens) > 0 {
 		switch tokens[0] {
 		case "exit", "quit":
-			// signal the program to exit
 			close(c.Quit)
 		case "gopher":
 			c.gopher()


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

A `SIGQUIT` signal should indicate to a running process that it should exit immediately, and also dump its core. This is the default behaviour for a Go program, unless the program catches the signal using `signal.Notify`. 

We were catching this signal in `influx` and then attempting to exit gracefully, which is the incorrect behaviour, especially if `influx` is stuck somewhere, or in a long running query.

Also, we were catching other signals that didn't make sense, e.g., `SIGHUP`—usually used to indicate a live configuration change, `os.Kill`—we're not even allowed to catch this.

This PR reduces the signals we catch down to `syscall.SIGINT` and `syscall.SIGTERM`. It also ensure that the `Quit` channel is closed properly.

Helps to fix #6474 