### PR TITLE
Mention Bot configuration

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,6 @@
+{
+  "maxReviewers": 3,
+  "fileBlacklist": ["CHANGELOG.md"],
+  "userBlacklist": ["pauldix", "toddboom"],
+  "requiredOrgs": ["influxdata"]
+}


### PR DESCRIPTION
We should only be automatically pinging people in `influxdata`, and Paul or Todd probably don't need to be bothered by `mention-bot` automatically.