### PR TITLE
fix show statement's rewriting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@
 - [#6468](https://github.com/influxdata/influxdb/issues/6468): Panic with truncated wal segments
 - [#6491](https://github.com/influxdata/influxdb/pull/6491): Fix the CLI not to enter an infinite loop when the liner has an error.
 - [#6457](https://github.com/influxdata/influxdb/issues/6457): Retention policy cleanup does not remove series
+- [#6477] (https://github.com/influxdata/influxdb/pull/6477): Don't catch SIGQUIT or SIGHUP signals.
+-  [#6468](https://github.com/influxdata/influxdb/issues/6468): Panic with truncated wal segments
+- [#6480](https://github.com/influxdata/influxdb/issues/6480): Fix SHOW statements' rewriting bug
 
 ## v0.12.2 [2016-04-20]
 

--- a/influxql/statement_rewriter.go
+++ b/influxql/statement_rewriter.go
@@ -25,9 +25,7 @@ func rewriteShowFieldKeysStatement(stmt *ShowFieldKeysStatement) (Statement, err
 		Fields: Fields([]*Field{
 			{Expr: &VarRef{Val: "fieldKey"}},
 		}),
-		Sources: Sources([]Source{
-			&Measurement{Name: "_fieldKeys"},
-		}),
+		Sources:    rewriteSources(stmt.Sources, "_fieldKeys"),
 		Condition:  rewriteSourcesCondition(stmt.Sources, nil),
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
@@ -74,9 +72,7 @@ func rewriteShowSeriesStatement(stmt *ShowSeriesStatement) (Statement, error) {
 		Fields: []*Field{
 			{Expr: &VarRef{Val: "key"}},
 		},
-		Sources: []Source{
-			&Measurement{Name: "_series"},
-		},
+		Sources:    rewriteSources(stmt.Sources, "_series"),
 		Condition:  rewriteSourcesCondition(stmt.Sources, stmt.Condition),
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
@@ -131,9 +127,7 @@ func rewriteShowTagValuesStatement(stmt *ShowTagValuesStatement) (Statement, err
 			{Expr: &VarRef{Val: "_tagKey"}, Alias: "key"},
 			{Expr: &VarRef{Val: "value"}},
 		},
-		Sources: []Source{
-			&Measurement{Name: "_tags"},
-		},
+		Sources:    rewriteSources(stmt.Sources, "_tags"),
 		Condition:  condition,
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
@@ -153,9 +147,7 @@ func rewriteShowTagKeysStatement(stmt *ShowTagKeysStatement) (Statement, error) 
 		Fields: []*Field{
 			{Expr: &VarRef{Val: "tagKey"}},
 		},
-		Sources: []Source{
-			&Measurement{Name: "_tagKeys"},
-		},
+		Sources:    rewriteSources(stmt.Sources, "_tagKeys"),
 		Condition:  rewriteSourcesCondition(stmt.Sources, stmt.Condition),
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
@@ -163,6 +155,28 @@ func rewriteShowTagKeysStatement(stmt *ShowTagKeysStatement) (Statement, error) 
 		OmitTime:   true,
 		Dedupe:     true,
 	}, nil
+
+}
+
+// rewriteSources rewrites sources with previous database and retention policy
+func rewriteSources(sources Sources, measurementName string) Sources {
+	newSources := Sources{}
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		mm := src.(*Measurement)
+		newSources = append(newSources,
+			&Measurement{
+				Database:        mm.Database,
+				RetentionPolicy: mm.RetentionPolicy,
+				Name:            measurementName,
+			})
+	}
+	if len(newSources) <= 0 {
+		return append(newSources, &Measurement{Name: measurementName})
+	}
+	return newSources
 }
 
 // rewriteSourcesCondition rewrites sources into `name` expressions.

--- a/influxql/statement_rewriter_test.go
+++ b/influxql/statement_rewriter_test.go
@@ -24,6 +24,14 @@ func TestRewriteStatement(t *testing.T) {
 			s:    `SELECT fieldKey FROM _fieldKeys WHERE _name =~ /c.*/`,
 		},
 		{
+			stmt: `SHOW FIELD KEYS FROM mydb.myrp2.cpu`,
+			s:    `SELECT fieldKey FROM mydb.myrp2._fieldKeys WHERE _name = 'cpu'`,
+		},
+		{
+			stmt: `SHOW FIELD KEYS FROM mydb.myrp2./c.*/`,
+			s:    `SELECT fieldKey FROM mydb.myrp2._fieldKeys WHERE _name =~ /c.*/`,
+		},
+		{
 			stmt: `SHOW MEASUREMENTS`,
 			s:    `SELECT _name AS "name" FROM _measurements`,
 		},
@@ -44,6 +52,22 @@ func TestRewriteStatement(t *testing.T) {
 			s:    `SELECT _name AS "name" FROM _measurements WHERE (_name = 'cpu') AND (region = 'uswest')`,
 		},
 		{
+			stmt: `SHOW SERIES`,
+			s:    `SELECT "key" FROM _series`,
+		},
+		{
+			stmt: `SHOW SERIES FROM cpu`,
+			s:    `SELECT "key" FROM _series WHERE _name = 'cpu'`,
+		},
+		{
+			stmt: `SHOW SERIES FROM mydb.myrp1.cpu`,
+			s:    `SELECT "key" FROM mydb.myrp1._series WHERE _name = 'cpu'`,
+		},
+		{
+			stmt: `SHOW SERIES FROM mydb.myrp1./c.*/`,
+			s:    `SELECT "key" FROM mydb.myrp1._series WHERE _name =~ /c.*/`,
+		},
+		{
 			stmt: `SHOW TAG KEYS`,
 			s:    `SELECT tagKey FROM _tagKeys`,
 		},
@@ -60,6 +84,18 @@ func TestRewriteStatement(t *testing.T) {
 			s:    `SELECT tagKey FROM _tagKeys WHERE (_name = 'cpu') AND (region = 'uswest')`,
 		},
 		{
+			stmt: `SHOW TAG KEYS FROM mydb.myrp1.cpu`,
+			s:    `SELECT tagKey FROM mydb.myrp1._tagKeys WHERE _name = 'cpu'`,
+		},
+		{
+			stmt: `SHOW TAG KEYS FROM mydb.myrp1./c.*/`,
+			s:    `SELECT tagKey FROM mydb.myrp1._tagKeys WHERE _name =~ /c.*/`,
+		},
+		{
+			stmt: `SHOW TAG KEYS FROM mydb.myrp1.cpu WHERE region = 'uswest'`,
+			s:    `SELECT tagKey FROM mydb.myrp1._tagKeys WHERE (_name = 'cpu') AND (region = 'uswest')`,
+		},
+		{
 			stmt: `SHOW TAG VALUES WITH KEY = region`,
 			s:    `SELECT _tagKey AS "key", value FROM _tags WHERE _tagKey = 'region'`,
 		},
@@ -70,6 +106,10 @@ func TestRewriteStatement(t *testing.T) {
 		{
 			stmt: `SHOW TAG VALUES FROM cpu WITH KEY IN (region, host)`,
 			s:    `SELECT _tagKey AS "key", value FROM _tags WHERE (_name = 'cpu') AND (_tagKey = 'region' OR _tagKey = 'host')`,
+		},
+		{
+			stmt: `SHOW TAG VALUES FROM mydb.myrp1.cpu WITH KEY IN (region, host)`,
+			s:    `SELECT _tagKey AS "key", value FROM mydb.myrp1._tags WHERE (_name = 'cpu') AND (_tagKey = 'region' OR _tagKey = 'host')`,
 		},
 		{
 			stmt: `SELECT value FROM cpu`,


### PR DESCRIPTION
Related Issue https://github.com/influxdata/influxdb/issues/6480

when rewriting ShowXStatement, the result statement should inherit the previous statment's  database and retention policy

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

