### PR TITLE
Remove series from index when shard is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [#6477](https://github.com/influxdata/influxdb/pull/6477): Don't catch SIGQUIT or SIGHUP signals.
 - [#6468](https://github.com/influxdata/influxdb/issues/6468): Panic with truncated wal segments
 - [#6491](https://github.com/influxdata/influxdb/pull/6491): Fix the CLI not to enter an infinite loop when the liner has an error.
+- [#6457](https://github.com/influxdata/influxdb/issues/6457): Retention policy cleanup does not remove series
 
 ## v0.12.2 [2016-04-20]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -185,6 +185,9 @@ func (s *Shard) close() error {
 		return nil
 	}
 
+	// Don't leak our shard ID and series keys in the index
+	s.index.RemoveShard(s.id)
+
 	err := s.engine.Close()
 	if err == nil {
 		s.engine = nil


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

When a shard is closed and removed due to retention policy enforcement,
the series contained in the shard would still exists in the index causing
a memory leak.  Restarting the server would cause them not to be loaded.

Fixes #6457