### PR TITLE
Update the main Dockerfile to build influxdb from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 build
+.git

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- influxd "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The docker image created by this Dockerfile is equivalent to the
official images installed from packages, but it is built from source
instead.

It has also been updated to use the official `golang` images instead of
copying the binary from the host machine. This means the build will work
correctly on Mac OS X and not just 64-bit Linux.