### PR TITLE
Cleaning up a weird statement in the statement executor

### DIFF
--- a/cluster/statement_executor.go
+++ b/cluster/statement_executor.go
@@ -774,11 +774,7 @@ func (e *StatementExecutor) NormalizeStatement(stmt influxql.Statement, defaultD
 		}
 		switch node := node.(type) {
 		case *influxql.Measurement:
-			e := e.normalizeMeasurement(node, defaultDatabase)
-			if e != nil {
-				err = e
-				return
-			}
+			err = e.normalizeMeasurement(node, defaultDatabase)
 		}
 	})
 	return


### PR DESCRIPTION
The statement used a variable from outside of the function and redefined
that variable on the same line when it was unnecessary. Cleaning up the
code so it's easier to understand.