### PR TITLE
WIP for support selecting tag keys

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -149,6 +149,7 @@ func (*SortField) node()       {}
 func (SortFields) node()       {}
 func (Sources) node()          {}
 func (*StringLiteral) node()   {}
+func (*TagRef) node()          {}
 func (*Target) node()          {}
 func (*TimeLiteral) node()     {}
 func (*VarRef) node()          {}
@@ -261,6 +262,7 @@ func (*NumberLiteral) expr()   {}
 func (*ParenExpr) expr()       {}
 func (*RegexLiteral) expr()    {}
 func (*StringLiteral) expr()   {}
+func (*TagRef) expr()          {}
 func (*TimeLiteral) expr()     {}
 func (*VarRef) expr()          {}
 func (*Wildcard) expr()        {}
@@ -2993,6 +2995,16 @@ type VarRef struct {
 // String returns a string representation of the variable reference.
 func (r *VarRef) String() string {
 	return QuoteIdent(r.Val)
+}
+
+// TagRef represents a reference to a tag.
+type TagRef struct {
+	Val string
+}
+
+// String returns a string representation of the tag reference.
+func (r *TagRef) String() string {
+	return "@" + QuoteIdent(r.Val)
 }
 
 // Call represents a function call.

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2847,6 +2847,8 @@ func (f *Field) Name() string {
 	case *ParenExpr:
 		f := Field{Expr: expr.Expr}
 		return f.Name()
+	case *TagRef:
+		return expr.Val
 	case *VarRef:
 		return expr.Val
 	}
@@ -3315,6 +3317,8 @@ func CloneExpr(expr Expr) Expr {
 		return &RegexLiteral{Val: expr.Val}
 	case *StringLiteral:
 		return &StringLiteral{Val: expr.Val}
+	case *TagRef:
+		return &TagRef{Val: expr.Val}
 	case *TimeLiteral:
 		return &TimeLiteral{Val: expr.Val}
 	case *VarRef:

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -929,14 +929,14 @@ func decodeIteratorOptions(pb *internal.IteratorOptions) (*IteratorOptions, erro
 // selectInfo represents an object that stores info about select fields.
 type selectInfo struct {
 	calls map[*Call]struct{}
-	refs  map[*VarRef]struct{}
+	refs  map[interface{}]struct{}
 }
 
 // newSelectInfo creates a object with call and var ref info from stmt.
 func newSelectInfo(stmt *SelectStatement) *selectInfo {
 	info := &selectInfo{
 		calls: make(map[*Call]struct{}),
-		refs:  make(map[*VarRef]struct{}),
+		refs:  make(map[interface{}]struct{}),
 	}
 	Walk(info, stmt.Fields)
 	return info
@@ -948,6 +948,9 @@ func (v *selectInfo) Visit(n Node) Visitor {
 		v.calls[n] = struct{}{}
 		return nil
 	case *VarRef:
+		v.refs[n] = struct{}{}
+		return nil
+	case *TagRef:
 		v.refs[n] = struct{}{}
 		return nil
 	}

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2329,6 +2329,8 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 
 		// Parse it as a VarRef.
 		return p.parseVarRef()
+	case TAGREF:
+		return &TagRef{Val: lit}, nil
 	case DISTINCT:
 		// If the next immediate token is a left parentheses, parse as function call.
 		// Otherwise parse as a Distinct expression.

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -41,6 +41,9 @@ func (s *Scanner) Scan() (tok Token, pos Pos, lit string) {
 	switch ch0 {
 	case eof:
 		return EOF, pos, ""
+	case '@':
+		_, pos, lit := s.scanIdent()
+		return TAGREF, pos, lit
 	case '"':
 		s.r.unread()
 		return s.scanIdent()

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -40,7 +40,12 @@ func Select(stmt *SelectStatement, ic IteratorCreator, sopt *SelectOptions) ([]I
 	// Determine auxiliary fields to be selected.
 	opt.Aux = make([]string, 0, len(info.refs))
 	for ref := range info.refs {
-		opt.Aux = append(opt.Aux, ref.Val)
+		switch ref := ref.(type) {
+		case *VarRef:
+			opt.Aux = append(opt.Aux, ref.Val)
+		case *TagRef:
+			opt.Aux = append(opt.Aux, ref.Value())
+		}
 	}
 	sort.Strings(opt.Aux)
 

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -116,6 +116,8 @@ func buildAuxIterators(fields Fields, ic IteratorCreator, opt IteratorOptions) (
 			switch expr := expr.(type) {
 			case *VarRef:
 				itrs[i] = aitr.Iterator(expr.Val)
+			case *TagRef:
+				itrs[i] = aitr.Iterator("@" + expr.Val)
 			case *BinaryExpr:
 				itr, err := buildExprIterator(expr, aitr, opt)
 				if err != nil {

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -17,6 +17,7 @@ const (
 	literalBeg
 	// IDENT and the following are InfluxQL literal tokens.
 	IDENT       // main
+	TAGREF      // @main
 	NUMBER      // 12345.67
 	INTEGER     // 12345
 	DURATIONVAL // 13h


### PR DESCRIPTION
A potential solution for #4630. Allows the `@` sigil to be used to refer to a tag specifically.