### PR TITLE
Dump TSM files to line protocol

### DIFF
--- a/cmd/influx_inspect/dump.go
+++ b/cmd/influx_inspect/dump.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+)
+
+func cmdDump(path string) {
+	dataPath := filepath.Join(path, "data")
+
+	// No need to do this in a loop
+	ext := fmt.Sprintf(".%s", tsm1.TSMFileExtension)
+
+	// Get all TSM files by walking through the data dir
+	files := []string{}
+	err := filepath.Walk(dataPath, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == ext {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Loop through each file and output all of the data
+	for _, f := range files {
+		file, err := os.OpenFile(f, os.O_RDONLY, 0600)
+
+		relPath, _ := filepath.Rel(dataPath, f)
+		dirs := strings.Split(relPath, string(byte(os.PathSeparator)))
+		database := dirs[0]
+		fmt.Println("Opening", f, "in database", database)
+		temp, _ := ioutil.TempDir("/tmp", "influxdb")
+
+		if err != nil {
+			fmt.Printf("%v", err)
+			os.Exit(1)
+		}
+
+		reader, err := tsm1.NewTSMReader(file)
+
+		if err != nil {
+			fmt.Printf("%v", err)
+			os.Exit(1)
+		}
+
+		filename := temp + "/" + database + ".lp"
+
+		of, _ := os.Create(filename)
+		defer of.Close()
+		w := bufio.NewWriter(of)
+
+		fmt.Println("Writing", reader.KeyCount(), "series to", filename)
+
+		for i := 0; i < reader.KeyCount(); i++ {
+			key, _ := reader.KeyAt(i)
+			values, _ := reader.ReadAll(key)
+			split := strings.Split(key, "#!~#")
+			measurement, field := split[0], split[1]
+
+			for _, value := range values {
+				pairs := field + "=" + fmt.Sprintf("%v", value.Value())
+				fmt.Fprintln(w, measurement, pairs, value.UnixNano())
+			}
+
+			w.Flush()
+		}
+	}
+}

--- a/cmd/influx_inspect/export.go
+++ b/cmd/influx_inspect/export.go
@@ -63,13 +63,26 @@ func cmdExport(path string) {
 		fmt.Println("Writing", reader.KeyCount(), "series to", filename)
 
 		for i := 0; i < reader.KeyCount(); i++ {
-			key, _ := reader.KeyAt(i)
+			var pairs string
+			key, typ := reader.KeyAt(i)
 			values, _ := reader.ReadAll(key)
 			split := strings.Split(key, "#!~#")
 			measurement, field := split[0], split[1]
 
 			for _, value := range values {
-				pairs := field + "=" + fmt.Sprintf("%v", value.Value())
+				switch typ {
+				case tsm1.BlockFloat64:
+					pairs = field + "=" + fmt.Sprintf("%v", value.Value())
+				case tsm1.BlockInteger:
+					pairs = field + "=" + fmt.Sprintf("%vi", value.Value())
+				case tsm1.BlockBoolean:
+					pairs = field + "=" + fmt.Sprintf("%v", value.Value())
+				case tsm1.BlockString:
+					pairs = field + "=" + fmt.Sprintf("\"%v\"", value.Value())
+				default:
+					pairs = field + "=" + fmt.Sprintf("%v", value.Value())
+				}
+
 				fmt.Fprintln(w, measurement, pairs, value.UnixNano())
 			}
 

--- a/cmd/influx_inspect/export.go
+++ b/cmd/influx_inspect/export.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
 
-func cmdDump(path string) {
+func cmdExport(path string) {
 	dataPath := filepath.Join(path, "data")
 
 	// No need to do this in a loop

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -129,7 +129,24 @@ func main() {
 			fmt.Printf("%v", err)
 			os.Exit(1)
 		}
-		cmdVerify(path)
+		cmdDump(path)
+	case "dump":
+		var path string
+		fs := flag.NewFlagSet("dump", flag.ExitOnError)
+		fs.StringVar(&path, "dir", os.Getenv("HOME")+"/.influxdb", "Root storage path. [$HOME/.influxdb]")
+
+		fs.Usage = func() {
+			println("Usage: influx_inspect dump [options]\n\n   dumps TSM files into InfluxDB line protocol format")
+			println()
+			println("Options:")
+			fs.PrintDefaults()
+		}
+
+		if err := fs.Parse(flag.Args()[1:]); err != nil {
+			fmt.Printf("%v", err)
+			os.Exit(1)
+		}
+		cmdDump(path)
 	default:
 		flag.Usage()
 		os.Exit(1)

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -129,14 +129,14 @@ func main() {
 			fmt.Printf("%v", err)
 			os.Exit(1)
 		}
-		cmdDump(path)
-	case "dump":
+		cmdVerify(path)
+	case "export":
 		var path string
-		fs := flag.NewFlagSet("dump", flag.ExitOnError)
+		fs := flag.NewFlagSet("export", flag.ExitOnError)
 		fs.StringVar(&path, "dir", os.Getenv("HOME")+"/.influxdb", "Root storage path. [$HOME/.influxdb]")
 
 		fs.Usage = func() {
-			println("Usage: influx_inspect dump [options]\n\n   dumps TSM files into InfluxDB line protocol format")
+			println("Usage: influx_inspect export [options]\n\n   exports TSM files into InfluxDB line protocol format")
 			println()
 			println("Options:")
 			fs.PrintDefaults()
@@ -146,7 +146,7 @@ func main() {
 			fmt.Printf("%v", err)
 			os.Exit(1)
 		}
-		cmdDump(path)
+		cmdExport(path)
 	default:
 		flag.Usage()
 		os.Exit(1)

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -216,7 +216,7 @@ func (t *TSMReader) Key(index int) (string, []IndexEntry) {
 	return t.index.Key(index)
 }
 
-// KeyAt returns the key and key typegi at position idx in the index.
+// KeyAt returns the key and key type at position idx in the index.
 func (t *TSMReader) KeyAt(idx int) (string, byte) {
 	return t.index.KeyAt(idx)
 }


### PR DESCRIPTION
This extends the `influx_inspect` tool to provide a mechanism for dumping TSM files into line protocol. Probably still needs some usability love (being able to specify an output directory, for example), but is functional as-is.

Sample output:
```
$ go install ./... && $GOPATH/bin/influx_inspect dump
Opening /Users/todd/.influxdb/data/_internal/monitor/2/000000001-000000001.tsm in database _internal
Writing 75 series to /tmp/influxdb183681029/_internal.lp
Opening /Users/todd/.influxdb/data/stress/default/1/000000004-000000003.tsm in database stress
Writing 100000 series to /tmp/influxdb179802528/stress.lp
Opening /Users/todd/.influxdb/data/stress/default/3/000000001-000000001.tsm in database stress
Writing 2 series to /tmp/influxdb653771391/stress.lp
```

- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)