### PR TITLE
Update influxdb.service

### DIFF
--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -3,7 +3,7 @@
 [Unit]
 Description=InfluxDB is an open-source, distributed, time series database
 Documentation=https://docs.influxdata.com/influxdb/
-After=network.target
+After=network-online.target
 
 [Service]
 User=influxdb


### PR DESCRIPTION
Start influxdb.service after the network is up; otherwise, there's a chance after reboot that influxdb fails to bind and then doesn't start. For more, see [http://unix.stackexchange.com/a/126146](http://unix.stackexchange.com/a/126146)