### PR TITLE
Delete series fixes

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -29,7 +29,7 @@ type Engine interface {
 	Close() error
 
 	SetLogOutput(io.Writer)
-	LoadMetadataIndex(shard *Shard, index *DatabaseIndex) error
+	LoadMetadataIndex(shardID uint64, index *DatabaseIndex) error
 
 	CreateIterator(opt influxql.IteratorOptions) (influxql.Iterator, error)
 	SeriesKeys(opt influxql.IteratorOptions) (influxql.SeriesList, error)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -401,6 +401,10 @@ func (e *Engine) DeleteSeries(seriesKeys []string) error {
 
 // DeleteSeriesRange removes the values between min and max (inclusive) from all series.
 func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
+	if len(seriesKeys) == 0 {
+		return nil
+	}
+
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -37,7 +37,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 
 	// Load metadata index.
 	index := tsdb.NewDatabaseIndex("db")
-	if err := e.LoadMetadataIndex(nil, index); err != nil {
+	if err := e.LoadMetadataIndex(1, index); err != nil {
 		t.Fatal(err)
 	}
 
@@ -60,7 +60,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 
 	// Load metadata index.
 	index = tsdb.NewDatabaseIndex("db")
-	if err := e.LoadMetadataIndex(nil, index); err != nil {
+	if err := e.LoadMetadataIndex(1, index); err != nil {
 		t.Fatal(err)
 	}
 
@@ -85,7 +85,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 
 	// Load metadata index.
 	index = tsdb.NewDatabaseIndex("db")
-	if err := e.LoadMetadataIndex(nil, index); err != nil {
+	if err := e.LoadMetadataIndex(1, index); err != nil {
 		t.Fatal(err)
 	}
 
@@ -693,7 +693,7 @@ func MustOpenEngine() *Engine {
 	if err := e.Open(); err != nil {
 		panic(err)
 	}
-	if err := e.LoadMetadataIndex(nil, tsdb.NewDatabaseIndex("db")); err != nil {
+	if err := e.LoadMetadataIndex(1, tsdb.NewDatabaseIndex("db")); err != nil {
 		panic(err)
 	}
 	return e

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -127,12 +127,9 @@ func (b *BlockIterator) Next() bool {
 		}
 	}
 
-	for b.n-b.i > 0 {
+	if b.n-b.i > 0 {
 		b.key, b.entries = b.r.Key(b.i)
 		b.i++
-
-		// The index blocks might have tombstone entries and could be fully deleted, filter them out
-		b.entries = b.filterTombstones(b.r.TombstoneRange(b.key), b.entries)
 
 		if len(b.entries) > 0 {
 			return true
@@ -140,29 +137,6 @@ func (b *BlockIterator) Next() bool {
 	}
 
 	return false
-}
-
-func (b *BlockIterator) filterTombstones(tombstones []TimeRange, entries []IndexEntry) []IndexEntry {
-	for _, t := range tombstones {
-		entries = b.filterEntries(entries, t.Min, t.Max)
-	}
-	return entries
-}
-
-func (b *BlockIterator) filterEntries(entries []IndexEntry, min, max int64) []IndexEntry {
-	var i int
-	for j := 0; j < len(entries); j++ {
-		// filter this block if a tombstone entry exists that fully spans the range
-		// of time of points in the block
-		if entries[j].MinTime >= min && entries[j].MaxTime <= max {
-			continue
-		}
-
-		entries[i] = entries[j]
-		i++
-	}
-
-	return entries[:i]
 }
 
 func (b *BlockIterator) Read() (string, int64, int64, uint32, []byte, error) {

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -670,8 +670,20 @@ func (d *indirectIndex) DeleteRange(keys []string, minTime, maxTime int64) {
 
 		// Is the range passed in outside the time range for this key?
 		entries := d.Entries(k)
+
+		// If multiple tombstones are saved for the same key
+		if len(entries) == 0 {
+			continue
+		}
+
 		min, max := entries[0].MinTime, entries[len(entries)-1].MaxTime
 		if minTime > max || maxTime < min {
+			continue
+		}
+
+		// Is the range passed in cover every value for the key?
+		if minTime <= min && maxTime >= max {
+			d.Delete(keys)
 			continue
 		}
 

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -217,20 +217,22 @@ func (t *Tombstoner) readTombstoneV2(f *os.File) ([]Tombstone, error) {
 	if _, err := f.Seek(4, os.SEEK_SET); err != nil {
 		return nil, err
 	}
+	n := int64(4)
 
 	fi, err := f.Stat()
 	if err != nil {
 		return nil, err
 	}
+	size := fi.Size()
 
 	tombstones := []Tombstone{}
 	var (
-		n, min, max int64
-		key         string
+		min, max int64
+		key      string
 	)
 	b := make([]byte, 4096)
 	for {
-		if n >= fi.Size() {
+		if n >= size {
 			return tombstones, nil
 		}
 
@@ -243,7 +245,6 @@ func (t *Tombstoner) readTombstoneV2(f *os.File) ([]Tombstone, error) {
 		if keyLen > len(b) {
 			b = make([]byte, keyLen)
 		}
-		n += 4
 
 		if _, err := f.Read(b[:keyLen]); err != nil {
 			return nil, err

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -36,6 +36,10 @@ func (t *Tombstoner) Add(keys []string) error {
 
 // AddRange adds all keys to the tombstone specifying only the data between min and max to be removed.
 func (t *Tombstoner) AddRange(keys []string, min, max int64) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -55,6 +55,36 @@ func TestTombstoner_Add(t *testing.T) {
 	}
 }
 
+func TestTombstoner_Add_Empty(t *testing.T) {
+	dir := MustTempDir()
+	defer func() { os.RemoveAll(dir) }()
+
+	f := MustTempFile(dir)
+	ts := &tsm1.Tombstoner{Path: f.Name()}
+
+	entries, err := ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 0; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	ts.Add([]string{})
+
+	// Use a new Tombstoner to verify values are persisted
+	ts = &tsm1.Tombstoner{Path: f.Name()}
+	entries, err = ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 0; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+}
+
 func TestTombstoner_Delete(t *testing.T) {
 	dir := MustTempDir()
 	defer func() { os.RemoveAll(dir) }()

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1807,14 +1807,13 @@ func (s stringSet) intersect(o stringSet) stringSet {
 func filter(a []uint64, v uint64) []uint64 {
 	// binary search for v
 	i := sort.Search(len(a), func(i int) bool { return a[i] >= v })
-	if i < len(a) && a[i] == v {
-		// we found it, so shift the right half down one, overwriting v's
-		// position.
-		copy(a[i:], a[i+1:])
-		return a[:len(a)-1]
-	} else {
+	if i >= len(a) || a[i] != v {
 		return a
 	}
+
+	// we found it, so shift the right half down one, overwriting v's position.
+	copy(a[i:], a[i+1:])
+	return a[:len(a)-1]
 }
 
 // MeasurementFromSeriesKey returns the name of the measurement from a key that

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -173,7 +173,7 @@ func (d *DatabaseIndex) AssignShard(k string, shardID uint64) {
 	}
 }
 
-// UnassignShard update the index to indicate that series k does not exist in
+// UnassignShard updates the index to indicate that series k does not exist in
 // the given shardID
 func (d *DatabaseIndex) UnassignShard(k string, shardID uint64) {
 	ss := d.Series(k)
@@ -182,26 +182,25 @@ func (d *DatabaseIndex) UnassignShard(k string, shardID uint64) {
 			// Remove the shard from any series
 			ss.UnassignShard(shardID)
 
-			d.mu.Lock()
-
-			// If this series not long has hards assigned, remove the series
+			// If this series no longer has shards assigned, remove the series
 			if ss.ShardN() == 0 {
 
-				// Remove the series form all measurements
-				for name, measurement := range d.measurements {
-					measurement.DropSeries(ss.id)
+				// Remove the series the measurements
+				ss.measurement.DropSeries(ss)
 
-					// If the measurement no longer has any series, remove it as well
-					if !measurement.HasSeries() {
-						d.dropMeasurement(name)
-					}
+				// If the measurement no longer has any series, remove it as well
+				if !ss.measurement.HasSeries() {
+					d.mu.Lock()
+					d.dropMeasurement(ss.measurement.Name)
+					d.mu.Unlock()
 				}
+
 				// Remove the series key from the series index
+				d.mu.Lock()
 				delete(d.series, k)
 				d.statMap.Add(statDatabaseSeries, int64(-1))
+				d.mu.Unlock()
 			}
-
-			d.mu.Unlock()
 		}
 	}
 }
@@ -454,7 +453,7 @@ func (d *DatabaseIndex) DropSeries(keys []string) {
 		if series == nil {
 			continue
 		}
-		series.measurement.DropSeries(series.id)
+		series.measurement.DropSeries(series)
 		delete(d.series, k)
 		nDeleted++
 
@@ -600,7 +599,8 @@ func (m *Measurement) AddSeries(s *Series) bool {
 }
 
 // DropSeries will remove a series from the measurementIndex.
-func (m *Measurement) DropSeries(seriesID uint64) {
+func (m *Measurement) DropSeries(series *Series) {
+	seriesID := series.id
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -609,37 +609,24 @@ func (m *Measurement) DropSeries(seriesID uint64) {
 	}
 	delete(m.seriesByID, seriesID)
 
-	var ids []uint64
-	for _, id := range m.seriesIDs {
-		if id != seriesID {
-			ids = append(ids, id)
-		}
-	}
+	ids := filter(m.seriesIDs, seriesID)
 	m.seriesIDs = ids
 
-	// remove this series id to the tag index on the measurement
+	// remove this series id from the tag index on the measurement
 	// s.seriesByTagKeyValue is defined as map[string]map[string]SeriesIDs
-	for k, v := range m.seriesByTagKeyValue {
-		values := v
-		for kk, vv := range values {
-			var ids []uint64
-			for _, id := range vv {
-				if id != seriesID {
-					ids = append(ids, id)
-				}
-			}
-			// Check to see if we have any ids, if not, remove the key
-			if len(ids) == 0 {
-				delete(values, kk)
-			} else {
-				values[kk] = ids
-			}
-		}
-		// If we have no values, then we delete the key
-		if len(values) == 0 {
-			delete(m.seriesByTagKeyValue, k)
+	for k, v := range series.Tags {
+		values := m.seriesByTagKeyValue[k][v]
+		ids := filter(values, seriesID)
+		// Check to see if we have any ids, if not, remove the key
+		if len(ids) == 0 {
+			delete(m.seriesByTagKeyValue[k], v)
 		} else {
-			m.seriesByTagKeyValue[k] = values
+			m.seriesByTagKeyValue[k][v] = ids
+		}
+
+		// If we have no values, then we delete the key
+		if len(m.seriesByTagKeyValue[k]) == 0 {
+			delete(m.seriesByTagKeyValue, k)
 		}
 	}
 
@@ -1813,6 +1800,21 @@ func (s stringSet) intersect(o stringSet) stringSet {
 		}
 	}
 	return ns
+}
+
+// filter removes v from a if it exists.  a must be sorted in ascending
+// order.
+func filter(a []uint64, v uint64) []uint64 {
+	// binary search for v
+	i := sort.Search(len(a), func(i int) bool { return a[i] >= v })
+	if i < len(a) && a[i] == v {
+		// we found it, so shift the right half down one, overwriting v's
+		// position.
+		copy(a[i:], a[i+1:])
+		return a[:len(a)-1]
+	} else {
+		return a
+	}
 }
 
 // MeasurementFromSeriesKey returns the name of the measurement from a key that

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -67,7 +67,7 @@ func NewStore(path string) *Store {
 // SetLogOutput sets the writer to which all logs are written. It must not be
 // called after Open is called.
 func (s *Store) SetLogOutput(w io.Writer) {
-	s.Logger = log.New(w, "[store]", log.LstdFlags)
+	s.Logger = log.New(w, "[store] ", log.LstdFlags)
 	s.logOutput = w
 	for _, s := range s.shards {
 		s.SetLogOutput(w)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This fixes a regression introduced in #6501 and fixes a few bugs in deleting series.  The specific issues fixes:
* Empty tombstone files could be written and would fail to be loaded if you dropped a series that didn't actually exist in a TSM file.
* Fixed some logging prefix that were missing a space
* Optimized DropSeries to be more efficient since it's called more frequently now
* Reverted filtering out index entries in the TSM block iterator (added in #6501) since it was fixing the wrong problem.
* Optimized loading and applying large numbers of tombstones
* Fixed Series not getting tagged with the shard that owns them we loading shards