### PR TITLE
Optimize SHOW SERIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#6290](https://github.com/influxdata/influxdb/issues/6290): Add POST /query endpoint and warning messages for using GET with write operations.
 - [#6494](https://github.com/influxdata/influxdb/issues/6494): Support booleans for min() and max().
 - [#2074](https://github.com/influxdata/influxdb/issues/2074): Support offset argument in the GROUP BY time(...) call.
+- [#6533](https://github.com/influxdata/influxdb/issues/6533): Optimize SHOW SERIES
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server_bench_test.go
+++ b/cmd/influxd/run/server_bench_test.go
@@ -3,6 +3,7 @@ package run_test
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"testing"
 )
 
@@ -44,6 +45,46 @@ func benchmarkServerQueryCount(b *testing.B, pointN int) {
 			b.Fatal(err)
 		} else if results != fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",%d]]}]}]}`, pointN) {
 			b.Fatalf("unexpected result: %s", results)
+		}
+	}
+}
+
+func BenchmarkServer_ShowSeries_1(b *testing.B) {
+	benchmarkServerShowSeries(b, 1)
+}
+
+func BenchmarkServer_ShowSeries_1K(b *testing.B) {
+	benchmarkServerShowSeries(b, 1000)
+}
+
+func BenchmarkServer_ShowSeries_100K(b *testing.B) {
+	benchmarkServerShowSeries(b, 100000)
+}
+
+func BenchmarkServer_ShowSeries_1M(b *testing.B) {
+	benchmarkServerShowSeries(b, 1000000)
+}
+
+func benchmarkServerShowSeries(b *testing.B, pointN int) {
+	s := OpenDefaultServer(NewConfig())
+	defer s.Close()
+
+	// Write data into server.
+	var buf bytes.Buffer
+	for i := 0; i < pointN; i++ {
+		fmt.Fprintf(&buf, `cpu,host=server%d value=100 %d`, i, i+1)
+		if i != pointN-1 {
+			fmt.Fprint(&buf, "\n")
+		}
+	}
+	s.MustWrite("db0", "rp0", buf.String(), nil)
+
+	// Query simple count from server.
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.QueryWithParams(`SHOW SERIES`, url.Values{"db": {"db0"}}); err != nil {
+			b.Fatal(err)
 		}
 	}
 }

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -308,6 +308,7 @@ type floatSortedMergeIterator struct {
 	opt    IteratorOptions
 	heap   floatSortedMergeHeap
 	init   bool
+	point  FloatPoint
 }
 
 // newFloatSortedMergeIterator returns an instance of floatSortedMergeIterator.
@@ -375,6 +376,8 @@ func (itr *floatSortedMergeIterator) pop() (*FloatPoint, error) {
 	item := heap.Pop(&itr.heap).(*floatSortedMergeHeapItem)
 	if item.err != nil {
 		return nil, item.err
+	} else if item.point == nil {
+		return nil, nil
 	}
 
 	// Copy the point for return.
@@ -2254,6 +2257,7 @@ type integerSortedMergeIterator struct {
 	opt    IteratorOptions
 	heap   integerSortedMergeHeap
 	init   bool
+	point  IntegerPoint
 }
 
 // newIntegerSortedMergeIterator returns an instance of integerSortedMergeIterator.
@@ -2321,6 +2325,8 @@ func (itr *integerSortedMergeIterator) pop() (*IntegerPoint, error) {
 	item := heap.Pop(&itr.heap).(*integerSortedMergeHeapItem)
 	if item.err != nil {
 		return nil, item.err
+	} else if item.point == nil {
+		return nil, nil
 	}
 
 	// Copy the point for return.
@@ -4197,6 +4203,7 @@ type stringSortedMergeIterator struct {
 	opt    IteratorOptions
 	heap   stringSortedMergeHeap
 	init   bool
+	point  StringPoint
 }
 
 // newStringSortedMergeIterator returns an instance of stringSortedMergeIterator.
@@ -4264,6 +4271,8 @@ func (itr *stringSortedMergeIterator) pop() (*StringPoint, error) {
 	item := heap.Pop(&itr.heap).(*stringSortedMergeHeapItem)
 	if item.err != nil {
 		return nil, item.err
+	} else if item.point == nil {
+		return nil, nil
 	}
 
 	// Copy the point for return.
@@ -6140,6 +6149,7 @@ type booleanSortedMergeIterator struct {
 	opt    IteratorOptions
 	heap   booleanSortedMergeHeap
 	init   bool
+	point  BooleanPoint
 }
 
 // newBooleanSortedMergeIterator returns an instance of booleanSortedMergeIterator.
@@ -6207,6 +6217,8 @@ func (itr *booleanSortedMergeIterator) pop() (*BooleanPoint, error) {
 	item := heap.Pop(&itr.heap).(*booleanSortedMergeHeapItem)
 	if item.err != nil {
 		return nil, item.err
+	} else if item.point == nil {
+		return nil, nil
 	}
 
 	// Copy the point for return.

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -307,6 +307,7 @@ type {{$k.name}}SortedMergeIterator struct {
 	opt    IteratorOptions
 	heap   {{$k.name}}SortedMergeHeap
 	init   bool
+	point  {{$k.Name}}Point
 }
 
 // new{{$k.Name}}SortedMergeIterator returns an instance of {{$k.name}}SortedMergeIterator.
@@ -374,6 +375,8 @@ func (itr *{{$k.name}}SortedMergeIterator) pop() (*{{$k.Name}}Point, error) {
 	item := heap.Pop(&itr.heap).(*{{$k.name}}SortedMergeHeapItem)
 	if item.err != nil {
 		return nil, item.err
+	} else if item.point == nil {
+		return nil, nil
 	}
 
 	// Copy the point for return.

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -102,7 +102,12 @@ func buildAuxIterators(fields Fields, ic IteratorCreator, opt IteratorOptions) (
 
 	// Filter out duplicate rows, if required.
 	if opt.Dedupe {
-		input = NewDedupeIterator(input)
+		// If there is no group by and it's a single field then fast dedupe.
+		if itr, ok := input.(FloatIterator); ok && len(fields) == 1 && len(opt.Dimensions) == 0 {
+			input = newFloatFastDedupeIterator(itr)
+		} else {
+			input = NewDedupeIterator(input)
+		}
 	}
 
 	// Apply limit & offset.

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -412,6 +412,7 @@ func (d *DatabaseIndex) Measurements() Measurements {
 		measurements = append(measurements, m)
 	}
 	d.mu.RUnlock()
+
 	return measurements
 }
 
@@ -519,6 +520,16 @@ func (m *Measurement) SeriesByID(id uint64) *Series {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.seriesByID[id]
+}
+
+// AppendSeriesKeysByID appends keys for a list of series ids to a buffer.
+func (m *Measurement) AppendSeriesKeysByID(dst []string, ids []uint64) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, id := range ids {
+		dst = append(dst, m.seriesByID[id].Key)
+	}
+	return dst
 }
 
 // SeriesKeys returns the keys of every series in this measurement


### PR DESCRIPTION
## Overview

This commit changes the `SeriesIterator` to use a heap for sorting and uses a `floatFastDedupeIterator` to avoid point encoding while deduplication.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

