### PR TITLE
Fix parseFill to check for fill ident before attempting to parse an expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7080](https://github.com/influxdata/influxdb/pull/7080): Ensure IDs can't clash when managing Continuous Queries.
 - [#6990](https://github.com/influxdata/influxdb/issues/6990): Fix panic parsing empty key
 - [#7084](https://github.com/influxdata/influxdb/pull/7084): Tombstone memory improvements
+- [#6543](https://github.com/influxdata/influxdb/issues/6543): Fix parseFill to check for fill ident before attempting to parse an expression.
 
 ## v0.13.0 [2016-05-12]
 

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -2152,6 +2152,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SELECT count(foo + sum(bar)) FROM cpu`, err: `expected field argument in count()`},
 		{s: `SELECT (count(foo + sum(bar))) FROM cpu`, err: `expected field argument in count()`},
 		{s: `SELECT sum(value) + count(foo + sum(bar)) FROM cpu`, err: `binary expressions cannot mix aggregates and raw fields`},
+		{s: `SELECT mean(value) FROM cpu FILL + value`, err: `fill must be a function call`},
 		// See issues https://github.com/influxdata/influxdb/issues/1647
 		// and https://github.com/influxdata/influxdb/issues/4404
 		//{s: `DELETE`, err: `found EOF, expected FROM at line 1, char 8`},


### PR DESCRIPTION
The previous parseFill would try to parse an expression and only unscan
one token when it failed. This caused it to not put back the correct
number of tokens with some expression.

Now it has been modified to check for the fill ident ahead of time and
then use ParseExpr() to parse the call. If the expression fails to parse
into a call, it will send an error instead of trying to continue with an
invalid parser state.

Fixes #6543.