### PR TITLE
Return the query id assigned to a statement when running a query

### DIFF
--- a/cluster/statement_executor_test.go
+++ b/cluster/statement_executor_test.go
@@ -199,7 +199,8 @@ func DefaultQueryExecutor() *QueryExecutor {
 
 // ExecuteQuery parses query and executes against the database.
 func (e *QueryExecutor) ExecuteQuery(query, database string, chunkSize int) <-chan *influxql.Result {
-	return e.QueryExecutor.ExecuteQuery(MustParseQuery(query), database, chunkSize, false, make(chan struct{}))
+	_, results := e.QueryExecutor.ExecuteQuery(MustParseQuery(query), database, chunkSize, false, make(chan struct{}))
+	return results
 }
 
 // TSDBStore is a mockable implementation of cluster.TSDBStore.

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -334,7 +334,7 @@ func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) error {
 	defer close(closing)
 
 	// Execute the SELECT.
-	ch := s.QueryExecutor.ExecuteQuery(q, cq.Database, NoChunkingSize, false, closing)
+	_, ch := s.QueryExecutor.ExecuteQuery(q, cq.Database, NoChunkingSize, false, closing)
 
 	// There is only one statement, so we will only ever receive one result
 	res, ok := <-ch

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -318,7 +318,10 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 	w.Header().Add("Connection", "close")
 	w.Header().Add("content-type", "application/json")
 	readonly := r.Method == "GET" || r.Method == "HEAD"
-	results := h.QueryExecutor.ExecuteQuery(query, db, chunkSize, readonly, closing)
+	qid, results := h.QueryExecutor.ExecuteQuery(query, db, chunkSize, readonly, closing)
+	if qid != 0 {
+		w.Header().Add("InfluxDB-Query-ID", strconv.FormatUint(qid, 10))
+	}
 
 	// if we're not chunking, this will be the in memory buffer for all results before sending to client
 	resp := Response{Results: make([]*influxql.Result, 0)}


### PR DESCRIPTION
The query id gets returned inside of the `Influxdb-Query-Id` header as a
normal integer that can then be read by a client if it wants a way to
kill the query remotely or report the query it just created.