### PR TITLE
Fix loading huge series into RAM when points are overwritten

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -92,7 +92,7 @@ func (e *entry) count() int {
 // filter removes all values between min and max inclusive
 func (e *entry) filter(min, max int64) {
 	e.mu.Lock()
-	e.values = e.values.Filter(min, max)
+	e.values = e.values.Exclude(min, max)
 	e.mu.Unlock()
 }
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -807,7 +807,7 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 
 			// Apply each tombstone to the block
 			for _, ts := range k.blocks[i].tombstones {
-				v = Values(v).Filter(ts.Min, ts.Max)
+				v = Values(v).Exclude(ts.Min, ts.Max)
 			}
 			decoded = append(decoded, v...)
 

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -116,7 +116,6 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 
 	exp := []tsm1.Value{
 		data[1].values[0],
-		data[3].values[0],
 	}
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -135,6 +134,21 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
 
+	exp = []tsm1.Value{
+		data[3].values[0],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -213,10 +227,48 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[1].values[0],
-		data[2].values[0],
-		data[3].values[1],
 	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[2].values[0],
+	}
+
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
@@ -261,10 +313,47 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[1].values[0],
-		data[2].values[0],
-		data[3].values[1],
 	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[2].values[0],
+	}
+
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
@@ -309,10 +398,47 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[1].values[0],
-		data[2].values[0],
-		data[3].values[1],
 	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[2].values[0],
+	}
+
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
@@ -357,10 +483,47 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 	exp := []tsm1.Value{
 		data[3].values[0],
 		data[0].values[1],
-		data[1].values[0],
-		data[2].values[0],
-		data[3].values[1],
 	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[2].values[0],
+	}
+
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
@@ -516,7 +679,6 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
 	exp := []tsm1.Value{
-		data[1].values[0],
 		data[3].values[0],
 	}
 	if got, exp := len(values), len(exp); got != exp {
@@ -528,6 +690,25 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
 		}
 	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
 }
 
 func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
@@ -573,7 +754,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 	defer os.RemoveAll(dir)
 	fs := tsm1.NewFileStore(dir)
 
-	// Setup 3 files
+	// Setup 4 files
 	data := []keyValues{
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(8, 0.0), tsm1.NewValue(9, 1.0)}},
 		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.0)}},
@@ -589,16 +770,13 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 8, false)
+	c := fs.KeyCursor("cpu", 10, false)
 	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
 
 	exp := []tsm1.Value{
-		data[1].values[0],
-		data[3].values[0],
-		data[3].values[1],
 		data[0].values[0],
 		data[0].values[1],
 	}
@@ -611,6 +789,60 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 		if got, exp := values[i].Value(), v.Value(); got != exp {
 			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
 		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[3].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	if got, exp := len(values), 0; got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
 }
 
@@ -642,9 +874,6 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 	}
 
 	exp := []tsm1.Value{
-		data[1].values[0],
-		data[3].values[0],
-		data[3].values[1],
 		data[0].values[0],
 		data[0].values[1],
 	}
@@ -657,6 +886,60 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 		if got, exp := values[i].Value(), v.Value(); got != exp {
 			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
 		}
+	}
+
+	c.Next()
+	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[3].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	if got, exp := len(values), 0; got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
 }
 
@@ -688,9 +971,6 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 	}
 
 	exp := []tsm1.Value{
-		data[1].values[0],
-		data[3].values[0],
-		data[3].values[1],
 		data[0].values[0],
 		data[0].values[1],
 	}
@@ -703,6 +983,60 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 		if got, exp := values[i].Value(), v.Value(); got != exp {
 			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
 		}
+	}
+
+	c.Next()
+	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[3].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	if got, exp := len(values), 0; got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
 }
 
@@ -734,9 +1068,6 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 	}
 
 	exp := []tsm1.Value{
-		data[1].values[0],
-		data[3].values[0],
-		data[3].values[1],
 		data[0].values[0],
 		data[0].values[1],
 	}
@@ -749,6 +1080,60 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 		if got, exp := values[i].Value(), v.Value(); got != exp {
 			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
 		}
+	}
+
+	c.Next()
+	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[3].values[0],
+		data[3].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	if got, exp := len(values), 0; got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
 }
 

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -1024,7 +1024,7 @@ func (m *mmapAccessor) readAll(key string) ([]Value, error) {
 
 		// Filter out any values that were deleted
 		for _, t := range tombstones {
-			temp = Values(temp).Filter(t.Min, t.Max)
+			temp = Values(temp).Exclude(t.Min, t.Max)
 		}
 
 		values = append(values, temp...)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated

In some query scenarios, if there are a lot of points on disk for the same series spread across many blocks in TSM files and a point is overwritten near the beginning of the shard's time range, the full series could be loaded into RAM triggering OOMs and huge allocations.  I believe this same problem exists in the compactor, but this PR only fixes the query path.  A separate fix will be needed for compactions.

The issue was that the `KeyCursor` code that handles overwriting points had a simple implementation that just deduped the whole series in this case.  This falls over when the series is quite large.

Instead, the `KeyCursor` has been changed to only decode blocks with updated points.  It then keeps track of what section of the blocks have been read so they are not re-read when the later points are decoded.

Since the points in a block are always sorted, the code was also changed to remove the `Deduplicate` calls since they end up reallocating the slice (as well as creating an equally sized `map`).  Instead, we do a sorted merge and re-use the slice as much as we can.

To reproduce this issue, I wrote 50M points to a single series and overwrote the first point a few times until the TSM file blocks were in the state that this issue surfaced.  Then I ran a `select count(value) from cpu` query to could every point in the series.

Some before and after system stats:

#### Before

```
$time influx -database stress -execute "select count(value) from cpu"
name: cpu
---------
time	count
0	50000000


real	0m39.994s
user	0m0.004s
sys	0m0.006s

```

```
$ ps -o rss,vsz,pid $(pgrep influxd)
   RSS      VSZ   PID
5960276 573563196 20644
```

#### After

```
$ time influx -database stress -execute "select count(value) from cpu"
name: cpu
---------
time	count
0	50000000

real	0m11.352s
user	0m0.004s
sys	0m0.006s
```

```
$ ps -o rss,vsz,pid $(pgrep influxd)
   RSS      VSZ   PID
137428 573564744 20907
```

Query time reduced from **40s** to **11.3s** and RSS from **6GB** to **137MB**.