### PR TITLE
Move call iterator to series level

### DIFF
--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -117,8 +117,10 @@ func (a Iterators) cast() interface{} {
 // interval.
 func NewMergeIterator(inputs []Iterator, opt IteratorOptions) Iterator {
 	inputs = Iterators(inputs).filterNonNil()
-	if len(inputs) == 0 {
+	if n := len(inputs); n == 0 {
 		return nil
+	} else if n == 1 {
+		return inputs[0]
 	}
 
 	// Aggregate functions can use a more relaxed sorting so that points


### PR DESCRIPTION
## Overview

This commit moves the `CallIterator` to wrap the individual series instead of wrapping a shard. This allows individual points to be aggregated before being merged.

This will cause a small increase in memory usuage per series but it shows a 20% decrease in query time when there are a moderate number of points per series.

## Benchmarks

Executing a `SELECT count(value) FROM cpu` across 1B points:

```
Prev:    2m15s     7.4M pt/s
New:     1m48s     9.2M pt/s
```


## TODO

- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

---

/cc @jwilder @jsternberg 
