### PR TITLE
Support the deprecated [collectd] and [opentsdb] sections temporarily

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -11,8 +11,6 @@ import (
 	"runtime"
 	"strconv"
 	"time"
-
-	"github.com/BurntSushi/toml"
 )
 
 const logo = `
@@ -202,7 +200,7 @@ func (cmd *Command) ParseConfig(path string) (*Config, error) {
 	log.Printf("Using configuration at: %s\n", path)
 
 	config := NewConfig()
-	if _, err := toml.DecodeFile(path, &config); err != nil {
+	if err := config.FromToml(path); err != nil {
 		return nil, err
 	}
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -2,14 +2,18 @@ package run
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/influxdata/influxdb/cluster"
 	"github.com/influxdata/influxdb/monitor"
 	"github.com/influxdata/influxdb/services/admin"
@@ -114,6 +118,30 @@ func NewDemoConfig() (*Config, error) {
 	c.Admin.Enabled = true
 
 	return c, nil
+}
+
+// FromTomlFile loads the config from a TOML file.
+func (c *Config) FromTomlFile(fpath string) error {
+	bs, err := ioutil.ReadFile(fpath)
+	if err != nil {
+		return err
+	}
+	return c.FromToml(string(bs))
+}
+
+// FromToml loads the config from TOML.
+func (c *Config) FromToml(input string) error {
+	// Replace collectd and opentsdb sections in the old format with the new.
+	// TODO(jsternberg): Remove for 1.0.
+	re := regexp.MustCompile(`(?m)^\s*\[(collectd|opentsdb)\]`)
+	input = re.ReplaceAllStringFunc(input, func(in string) string {
+		in = strings.TrimSpace(in)
+		out := "[" + in + "]"
+		log.Printf("deprecated config option %s replaced with %s; %s will not be supported in a future release\n", in, out, in)
+		return out
+	})
+	_, err := toml.Decode(input, c)
+	return err
 }
 
 // Validate returns an error if the config is invalid.

--- a/cmd/influxd/run/config_command.go
+++ b/cmd/influxd/run/config_command.go
@@ -66,7 +66,7 @@ func (cmd *PrintConfigCommand) parseConfig(path string) (*Config, error) {
 	}
 
 	config := NewConfig()
-	if _, err := toml.DecodeFile(path, &config); err != nil {
+	if err := config.FromToml(path); err != nil {
 		return nil, err
 	}
 	return config, nil

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -12,7 +12,7 @@ import (
 func TestConfig_Parse(t *testing.T) {
 	// Parse configuration.
 	var c run.Config
-	if _, err := toml.Decode(`
+	if err := c.FromToml(`
 join = "foo:123,bar:456"
 
 [meta]
@@ -61,7 +61,7 @@ enabled = true
 
 [continuous_queries]
 enabled = true
-`, &c); err != nil {
+`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -240,5 +240,26 @@ enabled = false
 
 	if err := c.Validate(); err == nil {
 		t.Fatalf("got nil, expected error")
+	}
+}
+
+func TestConfig_DeprecatedOptions(t *testing.T) {
+	// Parse configuration.
+	var c run.Config
+	if err := c.FromToml(`
+[collectd]
+bind-address = ":1000"
+
+[opentsdb]
+bind-address = ":2000"
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate configuration.
+	if c.CollectdInputs[0].BindAddress != ":1000" {
+		t.Fatalf("unexpected collectd bind address: %s", c.CollectdInputs[0].BindAddress)
+	} else if c.OpenTSDBInputs[0].BindAddress != ":2000" {
+		t.Fatalf("unexpected opentsdb bind address: %s", c.OpenTSDBInputs[0].BindAddress)
 	}
 }


### PR DESCRIPTION
Performs an automatic search and replace on these sections of the
configuration file so they work for the 0.13 release. Will be removed
for 1.0.