### PR TITLE
Wrap JSON decode error with meaning full data

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -576,7 +576,7 @@ func (c *client) Query(q Query) (*Response, error) {
 	}
 	// If we got a valid decode error, send that back
 	if decErr != nil {
-		return nil, decErr
+		return nil, fmt.Errorf("unable to decode json: received status code %d err: %s", resp.StatusCode, decErr)
 	}
 	// If we don't have an error in our json response, and didn't get statusOK
 	// then send back an error


### PR DESCRIPTION

I ran into an issue today when Kapacitor was upgraded but InfluxDB was not. The result was an obscure error `invalid character 'M' looking for beginning of value`. 

The cause was that the new InfluxDB client sends a `POST` request and the old server rejected it with a `405` and response body `Method not allowed`, not in JSON format.

As a result the out of context JSON decode error was returned. This PR adds context to the error so if others run into the same issue while upgrading the error contains enough information to determine the cause.