### PR TITLE
Fix memory spike when compacting overwritten points

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -640,6 +640,13 @@ type tsmKeyIterator struct {
 	blocks    blocks
 
 	buf []blocks
+
+	// mergeValues are decoded blocks that have been combined
+	mergedValues Values
+
+	// merged are encoded blocks that have been combined or used as is
+	// without decode
+	merged blocks
 }
 
 type block struct {
@@ -647,6 +654,28 @@ type block struct {
 	minTime, maxTime int64
 	b                []byte
 	tombstones       []TimeRange
+
+	// readMin, readMax are the timestamps range of values have been
+	// read and encoded from this block.
+	readMin, readMax int64
+}
+
+func (b *block) overlapsTimeRange(min, max int64) bool {
+	return b.minTime <= max && b.maxTime >= min
+}
+
+func (b *block) read() bool {
+	return b.readMin <= b.minTime && b.readMax >= b.maxTime
+}
+
+func (b *block) markRead(min, max int64) {
+	if min < b.readMin {
+		b.readMin = min
+	}
+
+	if max > b.readMax {
+		b.readMax = max
+	}
 }
 
 type blocks []*block
@@ -680,11 +709,26 @@ func NewTSMKeyIterator(size int, fast bool, readers ...*TSMReader) (KeyIterator,
 }
 
 func (k *tsmKeyIterator) Next() bool {
-	// If we still have blocks from the last read, slice off the current one
-	// and return
+	// Any merged blocks pending?
+	if len(k.merged) > 0 {
+		k.merged = k.merged[1:]
+		if len(k.merged) > 0 {
+			return true
+		}
+	}
+
+	// Any merged values pending?
+	if len(k.mergedValues) > 0 {
+		k.merge()
+		if len(k.merged) > 0 {
+			return true
+		}
+	}
+
+	// If we still have blocks from the last read, merge them
 	if len(k.blocks) > 0 {
-		k.blocks = k.blocks[1:]
-		if len(k.blocks) > 0 {
+		k.merge()
+		if len(k.merged) > 0 {
 			return true
 		}
 	}
@@ -702,14 +746,14 @@ func (k *tsmKeyIterator) Next() bool {
 				// This block may have ranges of time removed from it that would
 				// reduce the block min and max time.
 				tombstones := iter.r.TombstoneRange(key)
-				minTime, maxTime = k.clampTombstoneRange(tombstones, minTime, maxTime)
-
 				k.buf[i] = append(k.buf[i], &block{
 					minTime:    minTime,
 					maxTime:    maxTime,
 					key:        key,
 					b:          b,
 					tombstones: tombstones,
+					readMin:    math.MaxInt64,
+					readMax:    math.MinInt64,
 				})
 
 				blockKey := key
@@ -721,7 +765,6 @@ func (k *tsmKeyIterator) Next() bool {
 					}
 
 					tombstones := iter.r.TombstoneRange(key)
-					minTime, maxTime = k.clampTombstoneRange(tombstones, minTime, maxTime)
 
 					k.buf[i] = append(k.buf[i], &block{
 						minTime:    minTime,
@@ -729,6 +772,8 @@ func (k *tsmKeyIterator) Next() bool {
 						key:        key,
 						b:          b,
 						tombstones: tombstones,
+						readMin:    math.MaxInt64,
+						readMax:    math.MinInt64,
 					})
 				}
 			}
@@ -747,6 +792,7 @@ func (k *tsmKeyIterator) Next() bool {
 			minKey = b[0].key
 		}
 	}
+	k.key = minKey
 
 	// Now we need to find all blocks that match the min key so we can combine and dedupe
 	// the blocks if necessary
@@ -754,20 +800,26 @@ func (k *tsmKeyIterator) Next() bool {
 		if len(b) == 0 {
 			continue
 		}
-		if b[0].key == minKey {
+		if b[0].key == k.key {
 			k.blocks = append(k.blocks, b...)
 			k.buf[i] = nil
 		}
 	}
 
-	// No blocks left, we're done
 	if len(k.blocks) == 0 {
 		return false
 	}
 
-	// Only one block and no tombstoned values, just return early everything after is wasted work
-	if len(k.blocks) == 1 && len(k.blocks[0].tombstones) == 0 {
-		return true
+	k.merge()
+
+	return len(k.merged) > 0
+}
+
+// merge combines the next set of blocks into merged blocks
+func (k *tsmKeyIterator) merge() {
+	// No blocks left, we're done
+	if len(k.blocks) == 0 {
+		return
 	}
 
 	// If we have more than one block or any partially tombstoned blocks, we many need to dedup
@@ -779,6 +831,10 @@ func (k *tsmKeyIterator) Next() bool {
 		// Quickly scan each block to see if any overlap with the prior block, if they overlap then
 		// we need to dedup as there may be duplicate points now
 		for i := 1; !dedup && i < len(k.blocks); i++ {
+			if k.blocks[i].read() {
+				dedup = true
+				break
+			}
 			if k.blocks[i].minTime <= k.blocks[i-1].maxTime || len(k.blocks[i].tombstones) > 0 {
 				dedup = true
 				break
@@ -786,42 +842,69 @@ func (k *tsmKeyIterator) Next() bool {
 		}
 	}
 
-	k.blocks = k.combine(dedup)
-
-	return len(k.blocks) > 0
+	k.merged = k.combine(dedup)
 }
 
 // combine returns a new set of blocks using the current blocks in the buffers.  If dedup
 // is true, all the blocks will be decoded, dedup and sorted in in order.  If dedup is false,
 // only blocks that are smaller than the chunk size will be decoded and combined.
 func (k *tsmKeyIterator) combine(dedup bool) blocks {
-	var decoded Values
 	if dedup {
-		// We have some overlapping blocks so decode all, append in order and then dedup
-		for i := 0; i < len(k.blocks); i++ {
-			v, err := DecodeBlock(k.blocks[i].b, nil)
-			if err != nil {
-				k.err = err
-				return nil
+		for len(k.mergedValues) < k.size && len(k.blocks) > 0 {
+			for len(k.blocks) > 0 && k.blocks[0].read() {
+				k.blocks = k.blocks[1:]
 			}
 
-			// Apply each tombstone to the block
-			for _, ts := range k.blocks[i].tombstones {
-				v = Values(v).Exclude(ts.Min, ts.Max)
+			if len(k.blocks) == 0 {
+				break
 			}
-			decoded = append(decoded, v...)
+			first := k.blocks[0]
 
+			// We have some overlapping blocks so decode all, append in order and then dedup
+			for i := 0; i < len(k.blocks); i++ {
+				if !k.blocks[i].overlapsTimeRange(first.minTime, first.maxTime) || k.blocks[i].read() {
+					continue
+				}
+
+				v, err := DecodeBlock(k.blocks[i].b, nil)
+				if err != nil {
+					k.err = err
+					return nil
+				}
+
+				// Remove values we already read
+				v = Values(v).Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
+
+				// Filter out only the values for overlapping block
+				v = Values(v).Include(first.minTime, first.maxTime)
+				if len(v) > 0 {
+					// Recoder that we read a subset of the block
+					k.blocks[i].markRead(v[0].UnixNano(), v[len(v)-1].UnixNano())
+				}
+
+				// Apply each tombstone to the block
+				for _, ts := range k.blocks[i].tombstones {
+					v = Values(v).Exclude(ts.Min, ts.Max)
+				}
+
+				k.mergedValues = k.mergedValues.Merge(v)
+			}
+			k.blocks = k.blocks[1:]
 		}
-		decoded = decoded.Deduplicate()
 
 		// Since we combined multiple blocks, we could have more values than we should put into
 		// a single block.  We need to chunk them up into groups and re-encode them.
-		return k.chunk(nil, decoded)
+		return k.chunk(nil)
 	} else {
 		var chunked blocks
 		var i int
 
 		for i < len(k.blocks) {
+			// skip this block if it's values were already read
+			if k.blocks[i].read() {
+				i++
+				continue
+			}
 			// If we this block is already full, just add it as is
 			if BlockCount(k.blocks[i].b) >= k.size {
 				chunked = append(chunked, k.blocks[i])
@@ -833,6 +916,12 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 
 		if k.fast {
 			for i < len(k.blocks) {
+				// skip this block if it's values were already read
+				if k.blocks[i].read() {
+					i++
+					continue
+				}
+
 				chunked = append(chunked, k.blocks[i])
 				i++
 			}
@@ -840,47 +929,48 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 
 		// If we only have 1 blocks left, just append it as is and avoid decoding/recoding
 		if i == len(k.blocks)-1 {
-			chunked = append(chunked, k.blocks[i])
+			if !k.blocks[i].read() {
+				chunked = append(chunked, k.blocks[i])
+			}
 			i++
 		}
 
 		// The remaining blocks can be combined and we know that they do not overlap and
 		// so we can just append each, sort and re-encode.
-		for i < len(k.blocks) {
+		for i < len(k.blocks) && len(k.mergedValues) < k.size {
+			if k.blocks[i].read() {
+				i++
+				continue
+			}
+
 			v, err := DecodeBlock(k.blocks[i].b, nil)
 			if err != nil {
 				k.err = err
 				return nil
 			}
 
-			decoded = append(decoded, v...)
+			// Apply each tombstone to the block
+			for _, ts := range k.blocks[i].tombstones {
+				v = Values(v).Exclude(ts.Min, ts.Max)
+			}
+
+			k.blocks[i].markRead(k.blocks[i].minTime, k.blocks[i].maxTime)
+
+			k.mergedValues = k.mergedValues.Merge(v)
 			i++
 		}
 
-		sort.Sort(Values(decoded))
-		return k.chunk(chunked, decoded)
+		k.blocks = k.blocks[i:]
+
+		return k.chunk(chunked)
 	}
 }
 
-func (k *tsmKeyIterator) chunk(dst blocks, values []Value) blocks {
-	for len(values) > k.size {
-		cb, err := Values(values[:k.size]).Encode(nil)
-		if err != nil {
-			k.err = err
-			return nil
-		}
+func (k *tsmKeyIterator) chunk(dst blocks) blocks {
+	k.mergedValues.assertOrdered()
 
-		dst = append(dst, &block{
-			minTime: values[0].UnixNano(),
-			maxTime: values[k.size-1].UnixNano(),
-			key:     k.blocks[0].key,
-			b:       cb,
-		})
-		values = values[k.size:]
-	}
-
-	// Re-encode the remaining values into the last block
-	if len(values) > 0 {
+	for len(k.mergedValues) > k.size {
+		values := k.mergedValues[:k.size]
 		cb, err := Values(values).Encode(nil)
 		if err != nil {
 			k.err = err
@@ -890,31 +980,38 @@ func (k *tsmKeyIterator) chunk(dst blocks, values []Value) blocks {
 		dst = append(dst, &block{
 			minTime: values[0].UnixNano(),
 			maxTime: values[len(values)-1].UnixNano(),
-			key:     k.blocks[0].key,
+			key:     k.key,
 			b:       cb,
 		})
+		k.mergedValues = k.mergedValues[k.size:]
+		return dst
+	}
+
+	// Re-encode the remaining values into the last block
+	if len(k.mergedValues) > 0 {
+		cb, err := Values(k.mergedValues).Encode(nil)
+		if err != nil {
+			k.err = err
+			return nil
+		}
+
+		dst = append(dst, &block{
+			minTime: k.mergedValues[0].UnixNano(),
+			maxTime: k.mergedValues[len(k.mergedValues)-1].UnixNano(),
+			key:     k.key,
+			b:       cb,
+		})
+		k.mergedValues = k.mergedValues[:0]
 	}
 	return dst
 }
 
-func (k *tsmKeyIterator) clampTombstoneRange(tombstones []TimeRange, minTime, maxTime int64) (int64, int64) {
-	for _, t := range tombstones {
-		if t.Min > minTime {
-			minTime = t.Min
-		}
-		if t.Max < maxTime {
-			maxTime = t.Max
-		}
-	}
-	return minTime, maxTime
-}
-
 func (k *tsmKeyIterator) Read() (string, int64, int64, []byte, error) {
-	if len(k.blocks) == 0 {
+	if len(k.merged) == 0 {
 		return "", 0, 0, nil, k.err
 	}
 
-	block := k.blocks[0]
+	block := k.merged[0]
 	return block.key, block.minTime, block.maxTime, block.b, k.err
 }
 

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -612,19 +612,24 @@ func TestTSMKeyIterator_Single(t *testing.T) {
 
 // Tests that a single TSM file can be read and iterated over
 func TestTSMKeyIterator_Chunked(t *testing.T) {
-	t.Skip("fixme")
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)
 
 	v0 := tsm1.NewValue(1, 1.1)
-	v1 := tsm1.NewValue(2, 2.1)
 	writes := map[string][]tsm1.Value{
-		"cpu,host=A#!~#value": []tsm1.Value{v0, v1},
+		"cpu,host=A#!~#value": []tsm1.Value{v0},
 	}
 
-	r := MustTSMReader(dir, 1, writes)
+	r1 := MustTSMReader(dir, 1, writes)
 
-	iter, err := tsm1.NewTSMKeyIterator(1, false, r)
+	v1 := tsm1.NewValue(2, 2.1)
+	writes1 := map[string][]tsm1.Value{
+		"cpu,host=A#!~#value": []tsm1.Value{v1},
+	}
+
+	r2 := MustTSMReader(dir, 2, writes1)
+
+	iter, err := tsm1.NewTSMKeyIterator(2, false, r1, r2)
 	if err != nil {
 		t.Fatalf("unexpected error creating WALKeyIterator: %v", err)
 	}
@@ -646,17 +651,20 @@ func TestTSMKeyIterator_Chunked(t *testing.T) {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
-		if got, exp := len(values), len(writes); got != exp {
+		if got, exp := len(values), 2; got != exp {
 			t.Fatalf("values length mismatch: got %v, exp %v", got, exp)
 		}
 
-		for _, v := range values {
-			readValues = true
-			assertValueEqual(t, v, writes["cpu,host=A#!~#value"][chunk])
-		}
+		readValues = len(values) > 0
+		assertValueEqual(t, values[0], v0)
+		assertValueEqual(t, values[1], v1)
+
 		chunk++
 	}
 
+	if got, exp := chunk, 1; got != exp {
+		t.Fatalf("chunk count mismatch: got %v, exp %v", got, exp)
+	}
 	if !readValues {
 		t.Fatalf("failed to read any values")
 	}

--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -365,10 +365,32 @@ func TestValues_MergeFloat(t *testing.T) {
 				tsm1.NewValue(4, 4.2),
 			},
 		},
+
+		{
+			a: []tsm1.Value{
+				tsm1.NewValue(1462498658242869207, 0.0),
+				tsm1.NewValue(1462498658288956853, 1.1),
+			},
+			b: []tsm1.Value{
+				tsm1.NewValue(1462498658242870810, 0.0),
+				tsm1.NewValue(1462498658262911238, 2.2),
+				tsm1.NewValue(1462498658282415038, 4.2),
+				tsm1.NewValue(1462498658282417760, 4.2),
+			},
+			exp: []tsm1.Value{
+				tsm1.NewValue(1462498658242869207, 0.0),
+				tsm1.NewValue(1462498658242870810, 0.0),
+				tsm1.NewValue(1462498658262911238, 2.2),
+				tsm1.NewValue(1462498658282415038, 4.2),
+				tsm1.NewValue(1462498658282417760, 4.2),
+				tsm1.NewValue(1462498658288956853, 1.1),
+			},
+		},
 	}
 
 	for i, test := range tests {
 		got := tsm1.Values(test.a).Merge(test.b)
+		spew.Dump(got)
 
 		if exp, got := len(test.exp), len(got); exp != got {
 			t.Fatalf("test(%d): value length mismatch: exp %v, got %v", i, exp, got)

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -656,16 +656,28 @@ func (l *location) markRead(min, max int64) {
 	}
 }
 
-type locations []*location
+type descLocations []*location
 
 // Sort methods
-func (a locations) Len() int      { return len(a) }
-func (a locations) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a locations) Less(i, j int) bool {
+func (a descLocations) Len() int      { return len(a) }
+func (a descLocations) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a descLocations) Less(i, j int) bool {
 	if a[i].entry.MaxTime == a[j].entry.MaxTime {
 		return a[i].r.Path() < a[j].r.Path()
 	}
 	return a[i].entry.MaxTime < a[j].entry.MaxTime
+}
+
+type ascLocations []*location
+
+// Sort methods
+func (a ascLocations) Len() int      { return len(a) }
+func (a ascLocations) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ascLocations) Less(i, j int) bool {
+	if a[i].entry.MinTime == a[j].entry.MinTime {
+		return a[i].r.Path() < a[j].r.Path()
+	}
+	return a[i].entry.MinTime < a[j].entry.MinTime
 }
 
 // newKeyCursor returns a new instance of KeyCursor.
@@ -679,8 +691,10 @@ func newKeyCursor(fs *FileStore, key string, t int64, ascending bool) *KeyCursor
 	}
 	c.duplicates = c.hasOverlappingBlocks()
 
-	if !ascending {
-		sort.Sort(locations(c.seeks))
+	if ascending {
+		sort.Sort(ascLocations(c.seeks))
+	} else {
+		sort.Sort(descLocations(c.seeks))
 	}
 
 	c.seek(t)

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -247,26 +247,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 
 	exp = []tsm1.Value{
 		data[1].values[0],
-	}
-
-	if got, exp := len(values), len(exp); got != exp {
-		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, v := range exp {
-		if got, exp := values[i].Value(), v.Value(); got != exp {
-			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
-		}
-	}
-
-	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
-	if err != nil {
-		t.Fatalf("unexpected error reading values: %v", err)
-	}
-
-	exp = []tsm1.Value{
 		data[2].values[0],
+		data[3].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -332,26 +314,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 
 	exp = []tsm1.Value{
 		data[1].values[0],
-	}
-
-	if got, exp := len(values), len(exp); got != exp {
-		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, v := range exp {
-		if got, exp := values[i].Value(), v.Value(); got != exp {
-			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
-		}
-	}
-
-	c.Next()
-	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
-	if err != nil {
-		t.Fatalf("unexpected error reading values: %v", err)
-	}
-
-	exp = []tsm1.Value{
 		data[2].values[0],
+		data[3].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -417,26 +381,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 
 	exp = []tsm1.Value{
 		data[1].values[0],
-	}
-
-	if got, exp := len(values), len(exp); got != exp {
-		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, v := range exp {
-		if got, exp := values[i].Value(), v.Value(); got != exp {
-			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
-		}
-	}
-
-	c.Next()
-	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
-	if err != nil {
-		t.Fatalf("unexpected error reading values: %v", err)
-	}
-
-	exp = []tsm1.Value{
 		data[2].values[0],
+		data[3].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -502,26 +448,8 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 
 	exp = []tsm1.Value{
 		data[1].values[0],
-	}
-
-	if got, exp := len(values), len(exp); got != exp {
-		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, v := range exp {
-		if got, exp := values[i].Value(), v.Value(); got != exp {
-			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
-		}
-	}
-
-	c.Next()
-	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
-	if err != nil {
-		t.Fatalf("unexpected error reading values: %v", err)
-	}
-
-	exp = []tsm1.Value{
 		data[2].values[0],
+		data[3].values[1],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

If a large series contains a point that is overwritten, the compactor
would load the whole series into RAM during a full compaction and deduplicate
the points.  If the series was large, it could cause very large RAM spikes and OOMs.

This change reworks the compactor to merge blocks more incrementally
similar to the fix done in #6556.  It also replaces the deduplication method with
a sorted merge approache used in #6556.

To reproduce the issue, I wrote 25M points to a single series and then overwrote the first point.  When a full compaction runs, RSS spikes up quite drastically. 

There was also a bug discovered in the newly introduced `*Values.Merge` funcs where the values being merged could end up unsorted.  This is now fixed.

Fixes #6557 

Some before and after stats:

#### Before
```
$ ps -o rss,vsz $(pgrep influxd)
   RSS      VSZ
3148776 145316856
```
```
[tsm1] 2016/05/05 21:53:49 compacted full 3 files into 1 files in 48.80575863s
```

#### After
```
$ ps -o rss,vsz $(pgrep influxd)
   RSS      VSZ
 32584 145292860

```
```
[tsm1] 2016/05/05 21:48:00 compacted full 4 files into 1 files in 8.040986536s
```

After compaction completed, RSS decreased from **3.1GB** to **32MB** and compaction time decreased from **49s** to **8s**.