### PR TITLE
#6578 - config parse issue

### DIFF
--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -140,7 +140,7 @@ func (c *Config) FromToml(input string) error {
 		log.Printf("deprecated config option %s replaced with %s; %s will not be supported in a future release\n", in, out, in)
 		return out
 	})
-	_, err := toml.Decode(input, c)
+	_, err := toml.DecodeFile(input, c)
 	return err
 }
 


### PR DESCRIPTION
https://github.com/influxdata/influxdb/commit/c6518b564fd6044652e319f33a477b28fc92f28f
introduced typo and as a result config file was not properly parsed.

c6518b564fd6044652e319f33a477b28fc92f28f was not merged with `master` branch, so PR is only for `0.13` and might be cherry-pick later.