### PR TITLE
Fix config file loading to read from a file

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -200,7 +200,7 @@ func (cmd *Command) ParseConfig(path string) (*Config, error) {
 	log.Printf("Using configuration at: %s\n", path)
 
 	config := NewConfig()
-	if err := config.FromToml(path); err != nil {
+	if err := config.FromTomlFile(path); err != nil {
 		return nil, err
 	}
 

--- a/cmd/influxd/run/config_command.go
+++ b/cmd/influxd/run/config_command.go
@@ -66,7 +66,7 @@ func (cmd *PrintConfigCommand) parseConfig(path string) (*Config, error) {
 	}
 
 	config := NewConfig()
-	if err := config.FromToml(path); err != nil {
+	if err := config.FromTomlFile(path); err != nil {
 		return nil, err
 	}
 	return config, nil


### PR DESCRIPTION
Accidentally used `FromToml()` when trying to read from a file path
rather than `FromTomlFile()` which will read the file and then call
`FromToml()`.

Fixes #6578.