### PR TITLE
Fix SHOW TAG VALUES condition to not filter "name" erroneously

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1126,7 +1126,7 @@ func NewTagValuesIterator(sh *Shard, opt influxql.IteratorOptions) (influxql.Ite
 			switch e.Op {
 			case influxql.EQ, influxql.NEQ, influxql.EQREGEX, influxql.NEQREGEX:
 				tag, ok := e.LHS.(*influxql.VarRef)
-				if !ok || tag.Val == "name" || strings.HasPrefix(tag.Val, "_") {
+				if !ok || strings.HasPrefix(tag.Val, "_") {
 					return nil
 				}
 			}


### PR DESCRIPTION
Before #6038 was merged, we needed to filter "name" so that it didn't
accidentally hit the code path that used "name" to check the name of a
measurement. This was changed to "_name" to avoid a conflict with a
legitimate tag that used "name" as the key.

SHOW TAG VALUES was never modified to remove the code that filtered out
"name". This removes that line of code so a condition with "name"
doesn't get removed erroneously.

Example:

    SHOW TAG VALUES WITH KEY = host WHERE "name" = 'jsternberg'

Fixes #6581.