### PR TITLE
Parallelize iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ With this release InfluxDB is moving to Go v1.6.
 - [#6533](https://github.com/influxdata/influxdb/issues/6533): Optimize SHOW SERIES
 - [#6534](https://github.com/influxdata/influxdb/pull/6534): Move to Go v1.6.2 (over Go v1.4.3)
 - [#6522](https://github.com/influxdata/influxdb/pull/6522): Dump TSM files to line protocol
+- [#6585](https://github.com/influxdata/influxdb/pull/6585): Parallelize iterators
 
 ### Bugfixes
 

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -300,7 +300,6 @@ type {{$k.name}}MergeHeapItem struct {
 	err error
 }
 
-
 // {{$k.name}}SortedMergeIterator is an iterator that sorts and merges multiple iterators into one.
 type {{$k.name}}SortedMergeIterator struct {
 	inputs []{{$k.Name}}Iterator
@@ -432,6 +431,65 @@ type {{$k.name}}SortedMergeHeapItem struct {
 	err       error
 	itr       {{$k.Name}}Iterator
 	ascending bool
+}
+
+// {{$k.name}}ParallelIterator represents an iterator that pulls data in a separate goroutine.
+type {{$k.name}}ParallelIterator struct {
+	input   {{$k.Name}}Iterator
+	ch      chan {{$k.name}}PointError
+	
+	once    sync.Once
+	closing chan struct{}
+}
+
+// new{{$k.Name}}ParallelIterator returns a new instance of {{$k.name}}ParallelIterator.
+func new{{$k.Name}}ParallelIterator(input {{$k.Name}}Iterator) *{{$k.name}}ParallelIterator {
+	itr := &{{$k.name}}ParallelIterator{
+		input:   input,
+		ch:      make(chan {{$k.name}}PointError, 1),
+		closing: make(chan struct{}), 
+	}
+	go itr.monitor()
+	return itr
+}
+
+// Stats returns stats from the underlying iterator.
+func (itr *{{$k.name}}ParallelIterator) Stats() IteratorStats { return itr.input.Stats() }
+
+// Close closes the underlying iterators.
+func (itr *{{$k.name}}ParallelIterator) Close() error {
+	itr.once.Do(func() { close(itr.closing) })
+	return itr.input.Close() 
+}
+
+// Next returns the next point from the iterator.
+func (itr *{{$k.name}}ParallelIterator) Next() (*{{$k.Name}}Point, error) {
+	v, ok := <-itr.ch
+	if !ok {
+		return nil, io.EOF
+	}
+	return v.point, v.err
+}
+
+// monitor runs in a separate goroutine and actively pulls the next point.
+func (itr *{{$k.name}}ParallelIterator) monitor()  {
+	defer close(itr.ch)
+
+	for {
+		// Read next point.
+		p, err := itr.input.Next()
+		
+		select {
+		case <-itr.closing:
+			return
+		case itr.ch <- {{$k.name}}PointError{point: p, err: err}:
+		}
+	}
+}
+
+type {{$k.name}}PointError struct {
+	point *{{$k.Name}}Point
+	err   error
 }
 
 // {{$k.name}}LimitIterator represents an iterator that limits points per group.

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -763,7 +764,7 @@ func (e *Engine) CreateIterator(opt influxql.IteratorOptions) (influxql.Iterator
 			inputs[i] = itr
 		}
 
-		return influxql.NewMergeIterator(inputs, opt), nil
+		return influxql.NewParallelMergeIterator(inputs, opt, runtime.GOMAXPROCS(0)), nil
 	}
 
 	itrs, err := e.createVarRefIterator(opt)


### PR DESCRIPTION
## Overview

This pull request adds parallel execution of aggregate `SELECT` statements. Iterators within each shard  are split using the `NewParallelMergeIterator()` function which processes iterator batches based on the number of logical cores on the system.

/cc @jwilder @toddboom 

## Results

On an AWS `c4.8xlarge` machine, performance of a simple `COUNT()` query over 1B points and 100K series drops from `1m57s` to `16.8s`. The execution of the count itself is significantly improved, however, the bottleneck on the query is now in the single-threaded planning phase for the 100K series. Parallelizing the planning phase should improve performance significantly for large numbers of series.


## TODO

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
