### PR TITLE
Modify the default retention policy name and make it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#5906](https://github.com/influxdata/influxdb/issues/5906): Dynamically update the documentation link in the admin UI.
 - [#6686](https://github.com/influxdata/influxdb/pull/6686): Optimize timestamp run-length decoding
 - [#6713](https://github.com/influxdata/influxdb/pull/6713): Reduce allocations during query parsing.
+- [#3733](https://github.com/influxdata/influxdb/issues/3733): Modify the default retention policy name and make it configurable.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -464,7 +464,7 @@ func init() {
 			&Query{
 				name:    "show retention policies should return auto-created policy",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["default","0","168h0m0s",1,true]]}]}]}`,
+				exp:     `{"results":[{"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["autogen","0","168h0m0s",1,true]]}]}]}`,
 			},
 		},
 	}

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -527,7 +527,7 @@ func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 		&Query{
 			name:    "default rp exists",
 			command: `show retention policies ON db0`,
-			exp:     `{"results":[{"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["default","0","168h0m0s",1,false],["rp0","0","168h0m0s",1,true]]}]}]}`,
+			exp:     `{"results":[{"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["autogen","0","168h0m0s",1,false],["rp0","0","168h0m0s",1,true]]}]}]}`,
 		},
 		&Query{
 			name:    "default rp",

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -1573,16 +1573,14 @@ func (p *Parser) parseCreateDatabaseStatement() (*CreateDatabaseStatement, error
 		}
 
 		// Look for "NAME"
-		var rpName string = "default" // default is default
 		if err := p.parseTokens([]Token{NAME}); err != nil {
 			p.unscan()
 		} else {
-			rpName, err = p.parseIdent()
+			stmt.RetentionPolicyName, err = p.parseIdent()
 			if err != nil {
 				return nil, err
 			}
 		}
-		stmt.RetentionPolicyName = rpName
 	} else {
 		p.unscan()
 	}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1624,7 +1624,6 @@ func TestParser_ParseStatement(t *testing.T) {
 				RetentionPolicyCreate:      true,
 				RetentionPolicyDuration:    24 * time.Hour,
 				RetentionPolicyReplication: 1,
-				RetentionPolicyName:        "default",
 			},
 		},
 		{
@@ -1636,7 +1635,6 @@ func TestParser_ParseStatement(t *testing.T) {
 				RetentionPolicyDuration:           0,
 				RetentionPolicyReplication:        1,
 				RetentionPolicyShardGroupDuration: 30 * time.Minute,
-				RetentionPolicyName:               "default",
 			},
 		},
 		{
@@ -1647,7 +1645,6 @@ func TestParser_ParseStatement(t *testing.T) {
 				RetentionPolicyCreate:      true,
 				RetentionPolicyDuration:    24 * time.Hour,
 				RetentionPolicyReplication: 1,
-				RetentionPolicyName:        "default",
 			},
 		},
 		{
@@ -1658,7 +1655,6 @@ func TestParser_ParseStatement(t *testing.T) {
 				RetentionPolicyCreate:      true,
 				RetentionPolicyDuration:    0,
 				RetentionPolicyReplication: 2,
-				RetentionPolicyName:        "default",
 			},
 		},
 		{
@@ -1669,7 +1665,6 @@ func TestParser_ParseStatement(t *testing.T) {
 				RetentionPolicyCreate:      true,
 				RetentionPolicyDuration:    0,
 				RetentionPolicyReplication: 2,
-				RetentionPolicyName:        "default",
 			},
 		},
 		{

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -76,6 +76,7 @@ func NewClient(config *Config) *Client {
 		cacheData: &Data{
 			ClusterID: uint64(uint64(rand.Int63())),
 			Index:     1,
+			DefaultRetentionPolicyName: config.DefaultRetentionPolicyName,
 		},
 		closing:             make(chan struct{}),
 		changed:             make(chan struct{}),
@@ -196,12 +197,11 @@ func (c *Client) CreateDatabase(name string) (*DatabaseInfo, error) {
 	// create default retention policy
 	if c.retentionAutoCreate {
 		if err := data.CreateRetentionPolicy(name, &RetentionPolicyInfo{
-			Name:     "default",
 			ReplicaN: 1,
 		}); err != nil {
 			return nil, err
 		}
-		if err := data.SetDefaultRetentionPolicy(name, "default"); err != nil {
+		if err := data.SetDefaultRetentionPolicy(name, ""); err != nil {
 			return nil, err
 		}
 	}

--- a/services/meta/client_test.go
+++ b/services/meta/client_test.go
@@ -819,6 +819,7 @@ func newClient() (string, *meta.Client) {
 func newConfig() *meta.Config {
 	cfg := meta.NewConfig()
 	cfg.Dir = testTempDir(2)
+	cfg.DefaultRetentionPolicyName = "default"
 	return cfg
 }
 

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -13,15 +13,19 @@ const (
 
 	// DefaultLoggingEnabled determines if log messages are printed for the meta service
 	DefaultLoggingEnabled = true
+
+	// DefaultRetentionPolicyName is the default retention policy name.
+	DefaultRetentionPolicyName = "autogen"
 )
 
 // Config represents the meta configuration.
 type Config struct {
 	Dir string `toml:"dir"`
 
-	RetentionAutoCreate bool `toml:"retention-autocreate"`
-	LoggingEnabled      bool `toml:"logging-enabled"`
-	PprofEnabled        bool `toml:"pprof-enabled"`
+	RetentionAutoCreate        bool   `toml:"retention-autocreate"`
+	DefaultRetentionPolicyName string `toml:"default-retention-policy-name"`
+	LoggingEnabled             bool   `toml:"logging-enabled"`
+	PprofEnabled               bool   `toml:"pprof-enabled"`
 
 	LeaseDuration toml.Duration `toml:"lease-duration"`
 }
@@ -29,9 +33,10 @@ type Config struct {
 // NewConfig builds a new configuration with default values.
 func NewConfig() *Config {
 	return &Config{
-		RetentionAutoCreate: true,
-		LeaseDuration:       toml.Duration(DefaultLeaseDuration),
-		LoggingEnabled:      DefaultLoggingEnabled,
+		RetentionAutoCreate:        true,
+		DefaultRetentionPolicyName: DefaultRetentionPolicyName,
+		LeaseDuration:              toml.Duration(DefaultLeaseDuration),
+		LoggingEnabled:             DefaultLoggingEnabled,
 	}
 }
 


### PR DESCRIPTION
The default retention policy name is changed to "autogen" instead of
"default" since it ends up being ambiguous when we tell a user to check
the default retention policy, it is uncertain if we are referring to the
default retention policy (which can be changed) or the retention policy
with the name "default".

Now the automatically generated retention policy name is "autogen".

The default retention policy is now also configurable through the
configuration file so an administrator can customize what they think
should be the default.

Fixes #3733.