### PR TITLE
Minor fixes for build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -125,7 +125,7 @@ def create_package_fs(build_root):
         os.makedirs(os.path.join(build_root, d))
         os.chmod(os.path.join(build_root, d), 0o755)
 
-def package_scripts(build_root, config_only=False):
+def package_scripts(build_root, config_only=False, windows=False):
     """Copy the necessary scripts and configuration files to the package
     filesystem.
     """
@@ -593,10 +593,12 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                 os.makedirs(build_root)
 
                 # Copy packaging scripts to build directory
-                if platform == "windows" or static or "static_" in arch:
+                if platform == "windows":
                     # For windows and static builds, just copy
                     # binaries to root of package (no other scripts or
                     # directories)
+                    package_scripts(build_root, config_only=True, windows=True)
+                elif static or "static_" in arch:
                     package_scripts(build_root, config_only=True)
                 else:
                     create_package_fs(build_root)
@@ -836,7 +838,7 @@ def main(args):
             logging.info("{} (MD5={})".format(p.split('/')[-1:][0],
                                               generate_md5_from_file(p)))
     if orig_branch != get_current_branch():
-        logging.info("Moving back to original git branch: {}".format(args.branch))
+        logging.info("Moving back to original git branch: {}".format(orig_branch))
         run("git checkout {}".format(orig_branch))
 
     return 0


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fixes:
- Corrected an incorrect log message
- Added a `windows` flag to packaging function to bring feature-parity with Telegraf build script

