### PR TITLE
Support mixed duration units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#7120](https://github.com/influxdata/influxdb/issues/7120): Add additional statistics to query executor.
 - [#7135](https://github.com/influxdata/influxdb/pull/7135): Support enable HTTP service over unix domain socket. Thanks @oiooj
+- [#3634](https://github.com/influxdata/influxdb/issues/3634): Support mixed duration units.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -31,7 +31,7 @@ func init() {
 			&Query{
 				name:    "create database should error with bad name",
 				command: `CREATE DATABASE 0xdb0`,
-				exp:     `{"error":"error parsing query: found 0, expected identifier at line 1, char 17"}`,
+				exp:     `{"error":"error parsing query: found 0xdb0, expected identifier at line 1, char 17"}`,
 			},
 			&Query{
 				name:    "create database with retention duration should error with bad retention duration",

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -330,7 +330,7 @@ func TestServer_UserCommands(t *testing.T) {
 			&Query{
 				name:    "bad create user request",
 				command: `CREATE USER 0xBAD WITH PASSWORD pwd1337`,
-				exp:     `{"error":"error parsing query: found 0, expected identifier at line 1, char 13"}`,
+				exp:     `{"error":"error parsing query: found 0xBAD, expected identifier at line 1, char 13"}`,
 			},
 			&Query{
 				name:    "bad create user request, no name",

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -770,7 +770,6 @@ func TestTimeRange(t *testing.T) {
 
 		// number literal
 		{expr: `time < 10`, min: `0001-01-01T00:00:00Z`, max: `1970-01-01T00:00:00.000000009Z`},
-		{expr: `time < 10i`, min: `0001-01-01T00:00:00Z`, max: `1970-01-01T00:00:00.000000009Z`},
 
 		// Equality
 		{expr: `time = '2000-01-01 00:00:00'`, min: `2000-01-01T00:00:00Z`, max: `2000-01-01T00:00:00.000000001Z`},

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2567,6 +2567,9 @@ func (p *Parser) consumeWhitespace() {
 func (p *Parser) unscan() { p.s.Unscan() }
 
 // ParseDuration parses a time duration from a string.
+// This is needed instead of time.ParseDuration because this will support
+// the full syntax that InfluxQL supports for specifying durations
+// including weeks and days.
 func ParseDuration(s string) (time.Duration, error) {
 	// Return an error if the string is blank or one character
 	if len(s) < 2 {
@@ -2576,41 +2579,66 @@ func ParseDuration(s string) (time.Duration, error) {
 	// Split string into individual runes.
 	a := split(s)
 
-	// Extract the unit of measure.
-	// If the last two characters are "ms" then parse as milliseconds.
-	// Otherwise just use the last character as the unit of measure.
-	var num, uom string
-	if len(s) > 2 && s[len(s)-2:] == "ms" {
-		num, uom = string(a[:len(a)-2]), "ms"
-	} else {
-		num, uom = string(a[:len(a)-1]), string(a[len(a)-1:])
+	// Start with a zero duration.
+	var d time.Duration
+	i := 0
+
+	// Check for a negative.
+	isNegative := false
+	if a[i] == '-' {
+		isNegative = true
+		i++
 	}
 
-	// Parse the numeric part.
-	n, err := strconv.ParseInt(num, 10, 64)
-	if err != nil {
-		return 0, ErrInvalidDuration
-	}
+	// Parsing loop.
+	for i < len(a) {
+		// Find the number portion.
+		start := i
+		for ; i < len(a) && isDigit(a[i]); i++ {
+			// Scan for the digits.
+		}
 
-	// Multiply by the unit of measure.
-	switch uom {
-	case "u", "µ":
-		return time.Duration(n) * time.Microsecond, nil
-	case "ms":
-		return time.Duration(n) * time.Millisecond, nil
-	case "s":
-		return time.Duration(n) * time.Second, nil
-	case "m":
-		return time.Duration(n) * time.Minute, nil
-	case "h":
-		return time.Duration(n) * time.Hour, nil
-	case "d":
-		return time.Duration(n) * 24 * time.Hour, nil
-	case "w":
-		return time.Duration(n) * 7 * 24 * time.Hour, nil
-	default:
-		return 0, ErrInvalidDuration
+		// Check if we reached the end of the string prematurely.
+		if i >= len(a) || i == start {
+			return 0, ErrInvalidDuration
+		}
+
+		// Parse the numeric part.
+		n, err := strconv.ParseInt(string(a[start:i]), 10, 64)
+		if err != nil {
+			return 0, ErrInvalidDuration
+		}
+
+		// Extract the unit of measure.
+		// If the last two characters are "ms" then parse as milliseconds.
+		// Otherwise just use the last character as the unit of measure.
+		switch a[i] {
+		case 'u', 'µ':
+			d += time.Duration(n) * time.Microsecond
+		case 'm':
+			if i+1 < len(a) && a[i+1] == 's' {
+				d += time.Duration(n) * time.Millisecond
+				i += 2
+				continue
+			}
+			d += time.Duration(n) * time.Minute
+		case 's':
+			d += time.Duration(n) * time.Second
+		case 'h':
+			d += time.Duration(n) * time.Hour
+		case 'd':
+			d += time.Duration(n) * 24 * time.Hour
+		case 'w':
+			d += time.Duration(n) * 7 * 24 * time.Hour
+		default:
+			return 0, ErrInvalidDuration
+		}
+		i++
 	}
+	if isNegative {
+		d = -d
+	}
+	return d, nil
 }
 
 // FormatDuration formats a duration to a string.

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -2546,6 +2546,10 @@ func TestParseDuration(t *testing.T) {
 		{s: `2h`, d: 2 * time.Hour},
 		{s: `2d`, d: 2 * 24 * time.Hour},
 		{s: `2w`, d: 2 * 7 * 24 * time.Hour},
+		{s: `1h30m`, d: time.Hour + 30*time.Minute},
+		{s: `30ms3000u`, d: 30*time.Millisecond + 3000*time.Microsecond},
+		{s: `-5s`, d: -5 * time.Second},
+		{s: `-5m30s`, d: -5*time.Minute - 30*time.Second},
 
 		{s: ``, err: "invalid duration"},
 		{s: `3`, err: "invalid duration"},

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -263,21 +263,32 @@ func (s *Scanner) scanNumber() (tok Token, pos Pos, lit string) {
 
 	// Read as a duration or integer if it doesn't have a fractional part.
 	if !isDecimal {
-		// If the next rune is a duration unit (u,µ,ms,s) then return a duration token
-		if ch0, _ := s.r.read(); ch0 == 'u' || ch0 == 'µ' || ch0 == 's' || ch0 == 'h' || ch0 == 'd' || ch0 == 'w' {
+		// If the next rune is a letter then this is a duration token.
+		if ch0, _ := s.r.read(); isLetter(ch0) || ch0 == 'µ' {
 			_, _ = buf.WriteRune(ch0)
-			return DURATIONVAL, pos, buf.String()
-		} else if ch0 == 'm' {
-			_, _ = buf.WriteRune(ch0)
-			if ch1, _ := s.r.read(); ch1 == 's' {
+			for {
+				ch1, _ := s.r.read()
+				if !isLetter(ch1) && ch1 != 'µ' {
+					s.r.unread()
+					break
+				}
 				_, _ = buf.WriteRune(ch1)
-			} else {
-				s.r.unread()
+			}
+
+			// Continue reading digits and letters as part of this token.
+			for {
+				if ch0, _ := s.r.read(); isLetter(ch0) || ch0 == 'µ' || isDigit(ch0) {
+					_, _ = buf.WriteRune(ch0)
+				} else {
+					s.r.unread()
+					break
+				}
 			}
 			return DURATIONVAL, pos, buf.String()
+		} else {
+			s.r.unread()
+			return INTEGER, pos, buf.String()
 		}
-		s.r.unread()
-		return INTEGER, pos, buf.String()
 	}
 	return NUMBER, pos, buf.String()
 }

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -108,7 +108,7 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `10h`, tok: influxql.DURATIONVAL, lit: `10h`},
 		{s: `10d`, tok: influxql.DURATIONVAL, lit: `10d`},
 		{s: `10w`, tok: influxql.DURATIONVAL, lit: `10w`},
-		{s: `10x`, tok: influxql.INTEGER, lit: `10`}, // non-duration unit
+		{s: `10x`, tok: influxql.DURATIONVAL, lit: `10x`}, // non-duration unit, but scanned as a duration value
 
 		// Keywords
 		{s: `ALL`, tok: influxql.ALL},


### PR DESCRIPTION
It is now possible to use a mixed duration unit like `1h30m`. The
duration units can be in whatever order as long as they are connected to
each other.

There is a change to the scanner. A token such as `10x` will be scanned
as a duration literal, but will then fail to parse as an invalid
duration. This should not be a breaking change as there is no situation
where `10m10` was a valid order of tokens for the parser.

Fixes #3634.