### PR TITLE
Fix decodeTags to decode tags correctly

### DIFF
--- a/influxql/point.go
+++ b/influxql/point.go
@@ -205,11 +205,12 @@ func decodeTags(id []byte) map[string]string {
 	if len(a) == 0 {
 		return nil
 	}
+	mid := len(a) / 2
 
 	// Decode key/value tags.
 	m := make(map[string]string)
-	for i := 0; i < len(a); i += 2 {
-		m[string(a[i])] = string(a[i+1])
+	for i := 0; i < mid; i++ {
+		m[string(a[i])] = string(a[i+mid])
 	}
 	return m
 }


### PR DESCRIPTION
encodeTags would encode the tags by outputting every key followed by
every value in alphabetical order. It was supposed to output the tags in
key/value order.