### PR TITLE
There is no need to sort keys for snapshot

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"math"
 	"os"
-	"sort"
 	"sync"
 	"time"
 
@@ -311,7 +310,6 @@ func (c *Cache) Keys() []string {
 	for k, _ := range c.store {
 		a = append(a, k)
 	}
-	sort.Strings(a)
 	return a
 }
 

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/golang/snappy"
@@ -47,7 +48,9 @@ func TestCache_CacheWrite(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	keys := c.Keys()
+	sort.Strings(keys)
+	if exp := []string{"bar", "foo"}; !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 }
@@ -68,7 +71,9 @@ func TestCache_CacheWriteMulti(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	keys := c.Keys()
+	sort.Strings(keys)
+	if exp := []string{"bar", "foo"}; !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 }
@@ -89,13 +94,17 @@ func TestCache_Cache_DeleteRange(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	keys := c.Keys()
+	sort.Strings(keys)
+	if exp := []string{"bar", "foo"}; !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
 	c.DeleteRange([]string{"bar"}, 2, math.MaxInt64)
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	keys = c.Keys()
+	sort.Strings(keys)
+	if exp := []string{"bar", "foo"}; !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
@@ -162,7 +171,9 @@ func TestCache_Cache_Delete(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	keys := c.Keys()
+	sort.Strings(keys)
+	if exp := []string{"bar", "foo"}; !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated

It looks like there is no need to sort keys for snapshot. And this make snapshot very slow when the length of key is bigger than 10m.
