### PR TITLE
Optimize shard index loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bugfixes
 
 - [#6604](https://github.com/influxdata/influxdb/pull/6604): Remove old cluster code
+- [#6618](https://github.com/influxdata/influxdb/pull/6618): Optimize shard loading
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -379,6 +379,12 @@ func (e *Engine) readFileFromBackup(tr *tar.Reader, shardRelativePath string) er
 // database index and measurement fields
 func (e *Engine) addToIndexFromKey(shardID uint64, key string, fieldType influxql.DataType, index *tsdb.DatabaseIndex) error {
 	seriesKey, field := seriesAndFieldFromCompositeKey(key)
+	// Have we already indexed this series?
+	ss := index.Series(seriesKey)
+	if ss != nil {
+		return nil
+	}
+
 	measurement := tsdb.MeasurementFromSeriesKey(seriesKey)
 
 	m := index.CreateMeasurementIndexIfNotExists(measurement)
@@ -1230,9 +1236,10 @@ func tsmFieldTypeToInfluxQLDataType(typ byte) (influxql.DataType, error) {
 }
 
 func seriesAndFieldFromCompositeKey(key string) (string, string) {
-	parts := strings.Split(key, keyFieldSeparator)
-	if len(parts) != 0 {
-		return parts[0], strings.Join(parts[1:], keyFieldSeparator)
+	sep := strings.Index(key, keyFieldSeparator)
+	if sep == -1 {
+		// No field???
+		return key, ""
 	}
-	return parts[0], parts[1]
+	return key[:sep], key[sep+len(keyFieldSeparator):]
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated

On data sets with many series,  large series keys and many shards,
the cost of parsing the key and re-indexing can be high.

Loading the TSM keys into the index was being done repeatedly for
series that were already loaded into the index by an earlier TSM file.  This was
wasted worked and slows down shard loading.

Parsing the key was also innefficient and allocated a new string
slice.  This was simplified to remove that allocation.

I tested this on a dataset with two databases containing 155 and 85 shards each with ~300k series keys in each DB and keys ~250bytes in length.

#### 0.13.0 (old/new)
5:32 -> 0:32

#### master (old/new)
4:25 -> 0.33

#### master cache flushed (old/new)
5:09 -> 1:42

This should help #6250 in some cases although there may still be other bottlenecks that this data set does not bring out.