### PR TITLE
Add a basic Holt-Winters algorithm to the query engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#6664](https://github.com/influxdata/influxdb/pull/6664): Adds monitoring statistic for on-disk shard size.
 - [#2926](https://github.com/influxdata/influxdb/issues/2926): Support bound parameters in the parser.
 - [#1310](https://github.com/influxdata/influxdb/issues/1310): Add https-private-key option to httpd config.
+- [#6621](https://github.com/influxdata/influxdb/pull/6621): Add Holt-Winter forecasting function.
 
 ### Bugfixes
 

--- a/influxql/functions_test.go
+++ b/influxql/functions_test.go
@@ -1,0 +1,320 @@
+package influxql_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/influxdata/influxdb/influxql"
+)
+
+func almostEqual(got, exp float64) bool {
+	return math.Abs(got-exp) < 1e-5 && !math.IsNaN(got)
+}
+
+func TestHoltWinters_AusTourists(t *testing.T) {
+	hw := influxql.NewFloatHoltWintersReducer(10, 4, false, 1)
+	// Dataset from http://www.inside-r.org/packages/cran/fpp/docs/austourists
+	austourists := []influxql.FloatPoint{
+		{Time: 1, Value: 30.052513},
+		{Time: 2, Value: 19.148496},
+		{Time: 3, Value: 25.317692},
+		{Time: 4, Value: 27.591437},
+		{Time: 5, Value: 32.076456},
+		{Time: 6, Value: 23.487961},
+		{Time: 7, Value: 28.47594},
+		{Time: 8, Value: 35.123753},
+		{Time: 9, Value: 36.838485},
+		{Time: 10, Value: 25.007017},
+		{Time: 11, Value: 30.72223},
+		{Time: 12, Value: 28.693759},
+		{Time: 13, Value: 36.640986},
+		{Time: 14, Value: 23.824609},
+		{Time: 15, Value: 29.311683},
+		{Time: 16, Value: 31.770309},
+		{Time: 17, Value: 35.177877},
+		{Time: 18, Value: 19.775244},
+		{Time: 19, Value: 29.60175},
+		{Time: 20, Value: 34.538842},
+		{Time: 21, Value: 41.273599},
+		{Time: 22, Value: 26.655862},
+		{Time: 23, Value: 28.279859},
+		{Time: 24, Value: 35.191153},
+		{Time: 25, Value: 41.727458},
+		{Time: 26, Value: 24.04185},
+		{Time: 27, Value: 32.328103},
+		{Time: 28, Value: 37.328708},
+		{Time: 29, Value: 46.213153},
+		{Time: 30, Value: 29.346326},
+		{Time: 31, Value: 36.48291},
+		{Time: 32, Value: 42.977719},
+		{Time: 33, Value: 48.901525},
+		{Time: 34, Value: 31.180221},
+		{Time: 35, Value: 37.717881},
+		{Time: 36, Value: 40.420211},
+		{Time: 37, Value: 51.206863},
+		{Time: 38, Value: 31.887228},
+		{Time: 39, Value: 40.978263},
+		{Time: 40, Value: 43.772491},
+		{Time: 41, Value: 55.558567},
+		{Time: 42, Value: 33.850915},
+		{Time: 43, Value: 42.076383},
+		{Time: 44, Value: 45.642292},
+		{Time: 45, Value: 59.76678},
+		{Time: 46, Value: 35.191877},
+		{Time: 47, Value: 44.319737},
+		{Time: 48, Value: 47.913736},
+	}
+
+	for _, p := range austourists {
+		hw.AggregateFloat(&p)
+	}
+	points := hw.Emit()
+
+	forecasted := []influxql.FloatPoint{
+		{Time: 49, Value: 57.01368875810684},
+		{Time: 50, Value: 40.190037686564295},
+		{Time: 51, Value: 54.90600903429195},
+		{Time: 52, Value: 52.61130714223962},
+		{Time: 53, Value: 59.85400578890833},
+		{Time: 54, Value: 42.21766711269367},
+		{Time: 55, Value: 57.65856066704675},
+		{Time: 56, Value: 55.26293832246274},
+		{Time: 57, Value: 62.83676840257498},
+		{Time: 58, Value: 44.34255373999999},
+	}
+
+	if exp, got := len(forecasted), len(points); exp != got {
+		t.Fatalf("unexpected number of points emitted: got %d exp %d", got, exp)
+	}
+
+	for i := range forecasted {
+		if exp, got := forecasted[i].Time, points[i].Time; got != exp {
+			t.Errorf("unexpected time on points[%d] got %v exp %v", i, got, exp)
+		}
+		if exp, got := forecasted[i].Value, points[i].Value; !almostEqual(got, exp) {
+			t.Errorf("unexpected value on points[%d] got %v exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestHoltWinters_AusTourists_Missing(t *testing.T) {
+	hw := influxql.NewFloatHoltWintersReducer(10, 4, false, 1)
+	// Dataset from http://www.inside-r.org/packages/cran/fpp/docs/austourists
+	austourists := []influxql.FloatPoint{
+		{Time: 1, Value: 30.052513},
+		{Time: 3, Value: 25.317692},
+		{Time: 4, Value: 27.591437},
+		{Time: 5, Value: 32.076456},
+		{Time: 6, Value: 23.487961},
+		{Time: 7, Value: 28.47594},
+		{Time: 9, Value: 36.838485},
+		{Time: 10, Value: 25.007017},
+		{Time: 11, Value: 30.72223},
+		{Time: 12, Value: 28.693759},
+		{Time: 13, Value: 36.640986},
+		{Time: 14, Value: 23.824609},
+		{Time: 15, Value: 29.311683},
+		{Time: 16, Value: 31.770309},
+		{Time: 17, Value: 35.177877},
+		{Time: 19, Value: 29.60175},
+		{Time: 20, Value: 34.538842},
+		{Time: 21, Value: 41.273599},
+		{Time: 22, Value: 26.655862},
+		{Time: 23, Value: 28.279859},
+		{Time: 24, Value: 35.191153},
+		{Time: 25, Value: 41.727458},
+		{Time: 26, Value: 24.04185},
+		{Time: 27, Value: 32.328103},
+		{Time: 28, Value: 37.328708},
+		{Time: 30, Value: 29.346326},
+		{Time: 31, Value: 36.48291},
+		{Time: 32, Value: 42.977719},
+		{Time: 34, Value: 31.180221},
+		{Time: 35, Value: 37.717881},
+		{Time: 36, Value: 40.420211},
+		{Time: 37, Value: 51.206863},
+		{Time: 38, Value: 31.887228},
+		{Time: 41, Value: 55.558567},
+		{Time: 42, Value: 33.850915},
+		{Time: 43, Value: 42.076383},
+		{Time: 44, Value: 45.642292},
+		{Time: 45, Value: 59.76678},
+		{Time: 46, Value: 35.191877},
+		{Time: 47, Value: 44.319737},
+		{Time: 48, Value: 47.913736},
+	}
+
+	for _, p := range austourists {
+		hw.AggregateFloat(&p)
+	}
+	points := hw.Emit()
+
+	forecasted := []influxql.FloatPoint{
+		{Time: 49, Value: 54.39825435294697},
+		{Time: 50, Value: 41.93726334513928},
+		{Time: 51, Value: 54.909838091213345},
+		{Time: 52, Value: 57.1641355392107},
+		{Time: 53, Value: 57.164128921488114},
+		{Time: 54, Value: 44.06955989656805},
+		{Time: 55, Value: 57.701724090970124},
+		{Time: 56, Value: 60.07064109901599},
+		{Time: 57, Value: 60.0706341448159},
+		{Time: 58, Value: 46.310272882941966},
+	}
+
+	if exp, got := len(forecasted), len(points); exp != got {
+		t.Fatalf("unexpected number of points emitted: got %d exp %d", got, exp)
+	}
+
+	for i := range forecasted {
+		if exp, got := forecasted[i].Time, points[i].Time; got != exp {
+			t.Errorf("unexpected time on points[%d] got %v exp %v", i, got, exp)
+		}
+		if exp, got := forecasted[i].Value, points[i].Value; !almostEqual(got, exp) {
+			t.Errorf("unexpected value on points[%d] got %v exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestHoltWinters_USPopulation(t *testing.T) {
+	series := []influxql.FloatPoint{
+		{Time: 1, Value: 3.93},
+		{Time: 2, Value: 5.31},
+		{Time: 3, Value: 7.24},
+		{Time: 4, Value: 9.64},
+		{Time: 5, Value: 12.90},
+		{Time: 6, Value: 17.10},
+		{Time: 7, Value: 23.20},
+		{Time: 8, Value: 31.40},
+		{Time: 9, Value: 39.80},
+		{Time: 10, Value: 50.20},
+		{Time: 11, Value: 62.90},
+		{Time: 12, Value: 76.00},
+		{Time: 13, Value: 92.00},
+		{Time: 14, Value: 105.70},
+		{Time: 15, Value: 122.80},
+		{Time: 16, Value: 131.70},
+		{Time: 17, Value: 151.30},
+		{Time: 18, Value: 179.30},
+		{Time: 19, Value: 203.20},
+	}
+	hw := influxql.NewFloatHoltWintersReducer(10, 0, true, 1)
+	for _, p := range series {
+		hw.AggregateFloat(&p)
+	}
+	points := hw.Emit()
+
+	forecasted := []influxql.FloatPoint{
+		{Time: 1, Value: 3.93},
+		{Time: 2, Value: 4.666229883011407},
+		{Time: 3, Value: 7.582703219729101},
+		{Time: 4, Value: 11.38750857910578},
+		{Time: 5, Value: 16.061458362866013},
+		{Time: 6, Value: 21.60339677828295},
+		{Time: 7, Value: 28.028797969563485},
+		{Time: 8, Value: 35.36898516917276},
+		{Time: 9, Value: 43.67088460608491},
+		{Time: 10, Value: 52.99725850596854},
+		{Time: 11, Value: 63.42738609386119},
+		{Time: 12, Value: 75.05818203585376},
+		{Time: 13, Value: 88.00575972021298},
+		{Time: 14, Value: 102.40746333932526},
+		{Time: 15, Value: 118.42440883475055},
+		{Time: 16, Value: 136.24459021744897},
+		{Time: 17, Value: 156.08662531118478},
+		{Time: 18, Value: 178.20423430441988},
+		{Time: 19, Value: 202.89156636951475},
+		{Time: 20, Value: 230.48951480987003},
+		{Time: 21, Value: 261.3931906116184},
+		{Time: 22, Value: 296.0607589238543},
+		{Time: 23, Value: 335.0238840597938},
+		{Time: 24, Value: 378.900077509081},
+		{Time: 25, Value: 428.40730185977736},
+		{Time: 26, Value: 484.38125346495343},
+		{Time: 27, Value: 547.7958305836579},
+		{Time: 28, Value: 619.7873945146928},
+		{Time: 29, Value: 701.6835524758332},
+	}
+
+	if exp, got := len(forecasted), len(points); exp != got {
+		t.Fatalf("unexpected number of points emitted: got %d exp %d", got, exp)
+	}
+	for i := range forecasted {
+		if exp, got := forecasted[i].Time, points[i].Time; got != exp {
+			t.Errorf("unexpected time on points[%d] got %v exp %v", i, got, exp)
+		}
+		if exp, got := forecasted[i].Value, points[i].Value; !almostEqual(got, exp) {
+			t.Errorf("unexpected value on points[%d] got %v exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestHoltWinters_USPopulation_Missing(t *testing.T) {
+	series := []influxql.FloatPoint{
+		{Time: 1, Value: 3.93},
+		{Time: 2, Value: 5.31},
+		{Time: 3, Value: 7.24},
+		{Time: 4, Value: 9.64},
+		{Time: 5, Value: 12.90},
+		{Time: 6, Value: 17.10},
+		{Time: 7, Value: 23.20},
+		{Time: 8, Value: 31.40},
+		{Time: 10, Value: 50.20},
+		{Time: 11, Value: 62.90},
+		{Time: 12, Value: 76.00},
+		{Time: 13, Value: 92.00},
+		{Time: 15, Value: 122.80},
+		{Time: 16, Value: 131.70},
+		{Time: 17, Value: 151.30},
+		{Time: 19, Value: 203.20},
+	}
+	hw := influxql.NewFloatHoltWintersReducer(10, 0, true, 1)
+	for _, p := range series {
+		hw.AggregateFloat(&p)
+	}
+	points := hw.Emit()
+
+	forecasted := []influxql.FloatPoint{
+		{Time: 1, Value: 3.93},
+		{Time: 2, Value: -0.48020223172549237},
+		{Time: 3, Value: 4.802781783666482},
+		{Time: 4, Value: 9.877595464844614},
+		{Time: 5, Value: 15.247582981982251},
+		{Time: 6, Value: 21.11408248318643},
+		{Time: 7, Value: 27.613033499005994},
+		{Time: 8, Value: 34.85894117561601},
+		{Time: 9, Value: 42.96187408308528},
+		{Time: 10, Value: 52.03593886054132},
+		{Time: 11, Value: 62.20424563556273},
+		{Time: 12, Value: 73.60229860599725},
+		{Time: 13, Value: 86.38069796377347},
+		{Time: 14, Value: 100.70760028319269},
+		{Time: 15, Value: 116.77117933639244},
+		{Time: 16, Value: 134.78222852768778},
+		{Time: 17, Value: 154.97699617972333},
+		{Time: 18, Value: 177.6203209232622},
+		{Time: 19, Value: 203.00912417351864},
+		{Time: 20, Value: 231.47631387044993},
+		{Time: 21, Value: 263.39515509958034},
+		{Time: 22, Value: 299.18416724280326},
+		{Time: 23, Value: 339.31261310834543},
+		{Time: 24, Value: 384.3066526673811},
+		{Time: 25, Value: 434.756242430451},
+		{Time: 26, Value: 491.3228711104303},
+		{Time: 27, Value: 554.748233097815},
+		{Time: 28, Value: 625.8639535249647},
+		{Time: 29, Value: 705.6024924601211},
+	}
+
+	if exp, got := len(forecasted), len(points); exp != got {
+		t.Fatalf("unexpected number of points emitted: got %d exp %d", got, exp)
+	}
+	for i := range forecasted {
+		if exp, got := forecasted[i].Time, points[i].Time; got != exp {
+			t.Errorf("unexpected time on points[%d] got %v exp %v", i, got, exp)
+		}
+		if exp, got := forecasted[i].Value, points[i].Value; !almostEqual(got, exp) {
+			t.Errorf("unexpected value on points[%d] got %v exp %v", i, got, exp)
+		}
+	}
+}

--- a/influxql/neldermead/neldermead.go
+++ b/influxql/neldermead/neldermead.go
@@ -1,0 +1,260 @@
+// This is an implementation of the Nelder-Mead optimization method
+// Based on work by Michael F. Hutt http://www.mikehutt.com/neldermead.html
+package neldermead
+
+import "math"
+
+const (
+	defaultMaxIterations = 1000
+	// reflection coefficient
+	defaultAlpha = 1.0
+	// contraction coefficient
+	defaultBeta = 0.5
+	// expansion coefficient
+	defaultGamma = 2.0
+)
+
+type Optimizer struct {
+	MaxIterations int
+	// reflection coefficient
+	Alpha,
+	// contraction coefficient
+	Beta,
+	// expansion coefficient
+	Gamma float64
+}
+
+func New() *Optimizer {
+	return &Optimizer{
+		MaxIterations: defaultMaxIterations,
+		Alpha:         defaultAlpha,
+		Beta:          defaultBeta,
+		Gamma:         defaultGamma,
+	}
+}
+
+func (o *Optimizer) Optimize(
+	objfunc func([]float64) float64,
+	start []float64,
+	epsilon,
+	scale float64,
+	constrain func([]float64),
+) (float64, []float64) {
+	n := len(start)
+
+	//holds vertices of simplex
+	v := make([][]float64, n+1)
+	for i := range v {
+		v[i] = make([]float64, n)
+	}
+
+	//value of function at each vertex
+	f := make([]float64, n+1)
+
+	//reflection - coordinates
+	vr := make([]float64, n)
+
+	//expansion - coordinates
+	ve := make([]float64, n)
+
+	//contraction - coordinates
+	vc := make([]float64, n)
+
+	//centroid - coordinates
+	vm := make([]float64, n)
+
+	// create the initial simplex
+	// assume one of the vertices is 0,0
+
+	pn := scale * (math.Sqrt(float64(n+1)) - 1 + float64(n)) / (float64(n) * math.Sqrt(2))
+	qn := scale * (math.Sqrt(float64(n+1)) - 1) / (float64(n) * math.Sqrt(2))
+
+	for i := 0; i < n; i++ {
+		v[0][i] = start[i]
+	}
+
+	for i := 1; i <= n; i++ {
+		for j := 0; j < n; j++ {
+			if i-1 == j {
+				v[i][j] = pn + start[j]
+			} else {
+				v[i][j] = qn + start[j]
+			}
+		}
+	}
+
+	if constrain != nil {
+		constrain(v[n])
+	}
+
+	// find the initial function values
+	for j := 0; j <= n; j++ {
+		f[j] = objfunc(v[j])
+	}
+
+	// begin the main loop of the minimization
+	for itr := 1; itr <= o.MaxIterations; itr++ {
+
+		// find the indexes of the largest and smallest values
+		vg := 0
+		vs := 0
+		for i := 0; i <= n; i++ {
+			if f[i] > f[vg] {
+				vg = i
+			}
+			if f[i] < f[vs] {
+				vs = i
+			}
+		}
+		// find the index of the second largest value
+		vh := vs
+		for i := 0; i <= n; i++ {
+			if f[i] > f[vh] && f[i] < f[vg] {
+				vh = i
+			}
+		}
+
+		// calculate the centroid
+		for i := 0; i <= n-1; i++ {
+			cent := 0.0
+			for m := 0; m <= n; m++ {
+				if m != vg {
+					cent += v[m][i]
+				}
+			}
+			vm[i] = cent / float64(n)
+		}
+
+		// reflect vg to new vertex vr
+		for i := 0; i <= n-1; i++ {
+			vr[i] = vm[i] + o.Alpha*(vm[i]-v[vg][i])
+		}
+		if constrain != nil {
+			constrain(vr)
+		}
+
+		// value of function at reflection point
+		fr := objfunc(vr)
+
+		if fr < f[vh] && fr >= f[vs] {
+			for i := 0; i <= n-1; i++ {
+				v[vg][i] = vr[i]
+			}
+			f[vg] = fr
+		}
+
+		// investigate a step further in this direction
+		if fr < f[vs] {
+			for i := 0; i <= n-1; i++ {
+				ve[i] = vm[i] + o.Gamma*(vr[i]-vm[i])
+			}
+			if constrain != nil {
+				constrain(ve)
+			}
+
+			// value of function at expansion point
+			fe := objfunc(ve)
+
+			// by making fe < fr as opposed to fe < f[vs],
+			// Rosenbrocks function takes 63 iterations as opposed
+			// to 64 when using double variables.
+
+			if fe < fr {
+				for i := 0; i <= n-1; i++ {
+					v[vg][i] = ve[i]
+				}
+				f[vg] = fe
+			} else {
+				for i := 0; i <= n-1; i++ {
+					v[vg][i] = vr[i]
+				}
+				f[vg] = fr
+			}
+		}
+
+		// check to see if a contraction is necessary
+		if fr >= f[vh] {
+			if fr < f[vg] && fr >= f[vh] {
+				// perform outside contraction
+				for i := 0; i <= n-1; i++ {
+					vc[i] = vm[i] + o.Beta*(vr[i]-vm[i])
+				}
+			} else {
+				// perform inside contraction
+				for i := 0; i <= n-1; i++ {
+					vc[i] = vm[i] - o.Beta*(vm[i]-v[vg][i])
+				}
+			}
+
+			if constrain != nil {
+				constrain(vc)
+			}
+
+			// value of function at contraction point
+			fc := objfunc(vc)
+
+			if fc < f[vg] {
+				for i := 0; i <= n-1; i++ {
+					v[vg][i] = vc[i]
+				}
+				f[vg] = fc
+			} else {
+				// at this point the contraction is not successful,
+				// we must halve the distance from vs to all the
+				// vertices of the simplex and then continue.
+
+				for row := 0; row <= n; row++ {
+					if row != vs {
+						for i := 0; i <= n-1; i++ {
+							v[row][i] = v[vs][i] + (v[row][i]-v[vs][i])/2.0
+						}
+					}
+				}
+
+				if constrain != nil {
+					constrain(v[vg])
+				}
+
+				f[vg] = objfunc(v[vg])
+
+				if constrain != nil {
+					constrain(v[vh])
+				}
+
+				f[vh] = objfunc(v[vh])
+			}
+		}
+
+		// test for convergence
+		fsum := 0.0
+		for i := 0; i <= n; i++ {
+			fsum += f[i]
+		}
+		favg := fsum / float64(n+1)
+		s := 0.0
+		for i := 0; i <= n; i++ {
+			s += math.Pow((f[i]-favg), 2.0) / float64(n)
+		}
+		s = math.Sqrt(s)
+		if s < epsilon {
+			break
+		}
+	}
+
+	// find the index of the smallest value
+	vs := 0
+	for i := 0; i <= n; i++ {
+		if f[i] < f[vs] {
+			vs = i
+		}
+	}
+
+	parameters := make([]float64, n)
+	for i := 0; i < n; i++ {
+		parameters[i] = v[vs][i]
+	}
+
+	min := objfunc(v[vs])
+
+	return min, parameters
+}

--- a/influxql/neldermead/neldermead_test.go
+++ b/influxql/neldermead/neldermead_test.go
@@ -1,0 +1,63 @@
+package neldermead_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/influxdata/influxdb/influxql/neldermead"
+)
+
+func round(num float64, precision float64) float64 {
+	rnum := num * math.Pow(10, precision)
+	var tnum float64
+	if rnum < 0 {
+		tnum = math.Floor(rnum - 0.5)
+	} else {
+		tnum = math.Floor(rnum + 0.5)
+	}
+	rnum = tnum / math.Pow(10, precision)
+	return rnum
+}
+
+func almostEqual(a, b, e float64) bool {
+	return math.Abs(a-b) < e
+}
+
+func Test_Optimize(t *testing.T) {
+	// 100*(b-a^2)^2 + (1-a)^2
+	//
+	// Obvious global minimum at (a,b) = (1,1)
+	//
+	// Useful visualization:
+	// https://www.wolframalpha.com/input/?i=minimize(100*(b-a%5E2)%5E2+%2B+(1-a)%5E2)
+	f := func(x []float64) float64 {
+		// a = x[0]
+		// b = x[1]
+		return 100*(x[1]-x[0]*x[0])*(x[1]-x[0]*x[0]) + (1.0-x[0])*(1.0-x[0])
+	}
+
+	constraints := func(x []float64) {
+		for i := range x {
+			x[i] = round(x[i], 5)
+		}
+	}
+
+	start := []float64{-1.2, 1.0}
+
+	opt := neldermead.New()
+	epsilon := 1e-5
+	min, parameters := opt.Optimize(f, start, epsilon, 1, constraints)
+
+	if !almostEqual(min, 0, epsilon) {
+		t.Errorf("unexpected min: got %f exp 0", min)
+	}
+
+	if !almostEqual(parameters[0], 1, 1e-2) {
+		t.Errorf("unexpected parameters[0]: got %f exp 1", parameters[0])
+	}
+
+	if !almostEqual(parameters[1], 1, 1e-2) {
+		t.Errorf("unexpected parameters[1]: got %f exp 1", parameters[1])
+	}
+
+}

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -243,6 +243,23 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions, selec
 				return nil, err
 			}
 			return NewIntervalIterator(input, opt), nil
+		case "holt_winters", "holt_winters_with_fit":
+			input, err := buildExprIterator(expr.Args[0], ic, opt, selector)
+			if err != nil {
+				return nil, err
+			}
+			h := expr.Args[1].(*IntegerLiteral)
+			m := expr.Args[2].(*IntegerLiteral)
+
+			includeFitData := "holt_winters_with_fit" == expr.Name
+
+			interval := opt.Interval.Duration
+			// Redifine interval to be unbounded to capture all aggregate results
+			opt.StartTime = MinTime
+			opt.EndTime = MaxTime
+			opt.Interval = Interval{}
+
+			return newHoltWintersIterator(input, opt, int(h.Val), int(m.Val), includeFitData, interval)
 		case "derivative", "non_negative_derivative", "difference", "moving_average", "elapsed":
 			if !opt.Interval.IsZero() {
 				if opt.Ascending {


### PR DESCRIPTION
This PR adds a basic implementation of the Holt-Winters forecasting method. Specifically the  Damped Additive Trend and Multiplicative Seasonal version. 

Holt-Winters expects the data be on a regular time intervals as such an aggregate function and group by time are always required.

The basic usage is as follows assuming you are receiving values every 1m:

```SQL
SELECT holt_winters(first(value), 10, 4) FROM mymeasurement WHERE time > now() - 1h GROUP BY time(1m)
```

The `holt_winters` method will return `10` forecasted points past the end of the selected data, for a total of 10m of data. The second argument is the seasonal value. In this example we are saying that the data is expected to have a repeating seasonal pattern every 4 data points (aka 4m). A value of 1 or less will disable seasonal evaluation, since a seasonal period repeating every 1 or fewer times has no meaning.

If you want the full fit data returned in addition to the forecasted data use `holt_winters_with_fit`

```SQL
SELECT holt_winters_with_fit(first(value), 10, 4) FROM mymeasurement WHERE time > now() - 1h GROUP BY time(1m)
```

This will return the a total of 70 points spaced 1m apart. The first 60 points represent the fitted data from the `holt_winters` method and the last 10 points are the forecasted points, which are the same 10 points returned when `holt_winters` is called.


Holt-Winters will greatly benefit being able to phase shift group by boundaries since in many cases data points and seasonal patterns may not line up exactly with our default group by boundaries.

Questions:
- Where should the `neldermead` package live? Inside `influxql` seems odd but works for now. Nelder-Mead is a numeric optimization(aka minimization) algorithm that is used by the `holt_winters` method.

TODO:
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Implement for other types beyond float64
- [x] Update `functions_test.go` to expect actual values.



