### PR TITLE
Speed up drop database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#3541](https://github.com/influxdata/influxdb/issues/3451): Update SHOW FIELD KEYS to return the field type with the field key.
 - [#6609](https://github.com/influxdata/influxdb/pull/6609): Add support for JWT token authentication.
 - [#6559](https://github.com/influxdata/influxdb/issues/6559): Teach the http service how to enforce connection limits.
+- [#6623](https://github.com/influxdata/influxdb/pull/6623): Speed up drop database
 
 ### Bugfixes
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Drop database was closing and deleting each shard dir individually and
serially.  It would then delete the empty database dirs.

This changes drop database to close all shards in parallel and run
one `os.RemoveAll` to remove everything under the db dir which is more
efficient.

This also reworked the locking to avoid locking the `tsdb.Store` for
long periods of time.  That can cause queries and writes for other
databases to block as well.