### PR TITLE
Fix possible deadlock when queries and delete series run concurrently

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -686,8 +686,8 @@ func (s *Store) ExpandSources(sources influxql.Sources) (influxql.Sources, error
 
 // IteratorCreators returns a set of all local shards as iterator creators.
 func (s *Store) IteratorCreators() influxql.IteratorCreators {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	a := make(influxql.IteratorCreators, 0, len(s.shards))
 	for _, sh := range s.shards {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated

This locks showed up in a deadlocked systems running queries and
delete series across a large dataset.  Queries should not need to
lock the `tsdb.Store` for writes so this change switch the `Lock` to an `RLock`.

cc @benbjohnson 