### PR TITLE
Don't return empty response bodies when gzip encoding requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#6650](https://github.com/influxdata/influxdb/issues/6650): Data race when dropping a database immediately after writing to it
 - [#6235](https://github.com/influxdata/influxdb/issues/6235): Fix measurement field panic in tsm1 engine.
 - [#6663](https://github.com/influxdata/influxdb/issues/6663): Fixing panic in SHOW FIELD KEYS.
+- [#6624](https://github.com/influxdata/influxdb/issues/6624): Ensure clients requesting gzip encoded bodies don't receive empty body
 
 ## v0.13.0 [2016-05-12]
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -333,7 +333,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 	// Execute query.
 	w.Header().Add("Connection", "close")
 	w.Header().Add("Content-Type", "application/json")
-	readonly := r.Method == "GET" || r.Method == "HEAD"
+	readonly := r.Method == "GET"
 	results := h.QueryExecutor.ExecuteQuery(query, db, chunkSize, readonly, closing)
 
 	// if we're not chunking, this will be the in memory buffer for all results before sending to client


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #6624 

If a client requests a gzip encoded response body and we return `http.StatusNoContent` with an empty response body some clients will be unhappy.

Instead, we'll check if the client wants a `gzip` encoded body, and when they do (and we have nothing to return), we'll instead return a minimally gzipped response body, and a `200` since the body is no longer empty.

/cc @mark-rushakoff 