### PR TITLE
Support bound parameters in the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#6519](https://github.com/influxdata/influxdb/issues/6519): Support cast syntax for selecting a specific type.
 - [#6654](https://github.com/influxdata/influxdb/pull/6654): Add new HTTP statistics to monitoring
 - [#6664](https://github.com/influxdata/influxdb/pull/6664): Adds monitoring statistic for on-disk shard size.
+- [#2926](https://github.com/influxdata/influxdb/issues/2926): Support bound parameters in the parser.
 
 ### Bugfixes
 

--- a/influxql/scanner.go
+++ b/influxql/scanner.go
@@ -53,6 +53,12 @@ func (s *Scanner) Scan() (tok Token, pos Pos, lit string) {
 			return s.scanNumber()
 		}
 		return DOT, pos, ""
+	case '$':
+		tok, _, lit := s.scanIdent()
+		if tok == IDENT {
+			tok = BOUNDPARAM
+		}
+		return tok, pos, lit
 	case '+', '-':
 		return s.scanNumber()
 	case '*':

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -70,6 +70,8 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `"foo\"bar\""`, tok: influxql.IDENT, lit: `foo"bar"`},
 		{s: `test"`, tok: influxql.BADSTRING, lit: "", pos: influxql.Pos{Line: 0, Char: 3}},
 		{s: `"test`, tok: influxql.BADSTRING, lit: `test`},
+		{s: `$host`, tok: influxql.BOUNDPARAM, lit: `host`},
+		{s: `$"host param"`, tok: influxql.BOUNDPARAM, lit: `host param`},
 
 		{s: `true`, tok: influxql.TRUE},
 		{s: `false`, tok: influxql.FALSE},

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -17,6 +17,7 @@ const (
 	literalBeg
 	// IDENT and the following are InfluxQL literal tokens.
 	IDENT       // main
+	BOUNDPARAM  // $param
 	NUMBER      // 12345.67
 	INTEGER     // 12345
 	DURATIONVAL // 13h


### PR DESCRIPTION
The parser can be passed a map of keys to literal values to be replaced
into the query. Parameters are preceded by a dollar sign (`$`). If a
parameter key is missing, an error is thrown by the parser.

Fixes #2926.