### PR TITLE
Support specifying a retention policy for the graphite service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#6686](https://github.com/influxdata/influxdb/pull/6686): Optimize timestamp run-length decoding
 - [#6713](https://github.com/influxdata/influxdb/pull/6713): Reduce allocations during query parsing.
 - [#3733](https://github.com/influxdata/influxdb/issues/3733): Modify the default retention policy name and make it configurable.
+- [#5655](https://github.com/influxdata/influxdb/issues/5655): Support specifying a retention policy for the graphite service.
 
 ### Bugfixes
 

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Enabled          bool          `toml:"enabled"`
 	BindAddress      string        `toml:"bind-address"`
 	Database         string        `toml:"database"`
+	RetentionPolicy  string        `toml:"retention-policy"`
 	Protocol         string        `toml:"protocol"`
 	BatchSize        int           `toml:"batch-size"`
 	BatchPending     int           `toml:"batch-pending"`

--- a/services/graphite/config_test.go
+++ b/services/graphite/config_test.go
@@ -14,6 +14,7 @@ func TestConfig_Parse(t *testing.T) {
 	if _, err := toml.Decode(`
 bind-address = ":8080"
 database = "mydb"
+retention-policy = "myrp"
 enabled = true
 protocol = "tcp"
 batch-size=100
@@ -31,6 +32,8 @@ tags=["region=us-east"]
 		t.Fatalf("unexpected bind address: %s", c.BindAddress)
 	} else if c.Database != "mydb" {
 		t.Fatalf("unexpected database selected: %s", c.Database)
+	} else if c.RetentionPolicy != "myrp" {
+		t.Fatalf("unexpected retention policy selected: %s", c.RetentionPolicy)
 	} else if c.Enabled != true {
 		t.Fatalf("unexpected graphite enabled: %v", c.Enabled)
 	} else if c.Protocol != "tcp" {

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -176,6 +176,23 @@ func (d *DatabaseCreator) CreateDatabase(name string) (*meta.DatabaseInfo, error
 	return nil, nil
 }
 
+func (d *DatabaseCreator) CreateRetentionPolicy(database string, rpi *meta.RetentionPolicyInfo) (*meta.RetentionPolicyInfo, error) {
+	return nil, nil
+}
+
+func (d *DatabaseCreator) CreateDatabaseWithRetentionPolicy(name string, rpi *meta.RetentionPolicyInfo) (*meta.DatabaseInfo, error) {
+	d.Created = true
+	return nil, nil
+}
+
+func (d *DatabaseCreator) Database(name string) *meta.DatabaseInfo {
+	return nil
+}
+
+func (d *DatabaseCreator) RetentionPolicy(database, name string) (*meta.RetentionPolicyInfo, error) {
+	return nil, nil
+}
+
 // Test Helpers
 func errstr(err error) string {
 	if err != nil {


### PR DESCRIPTION
The graphite service will attempt to create the retention policy and use
it. If the retention policy doesn't exist, it will be created with the
default options.

Fixes #5655.