### PR TITLE
check admin exists instead of user count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#6618](https://github.com/influxdata/influxdb/pull/6618): Optimize shard loading
 - [#6629](https://github.com/influxdata/influxdb/issues/6629): query-log-enabled in config not ignored anymore.
 - [#6607](https://github.com/influxdata/influxdb/issues/6607): SHOW TAG VALUES accepts != and !~ in WHERE clause.
+- [#6649](https://github.com/influxdata/influxdb/issues/6649): Make sure admin exists before authenticating query.
 
 ## v0.13.0 [2016-05-12]
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated

When authenticating a request, check that an admin user exists instead
of checking for len(users) > 0. This prevents getting stuck with no
admin users and being unable to create one.