### PR TITLE
Compaction fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - [#6663](https://github.com/influxdata/influxdb/issues/6663): Fixing panic in SHOW FIELD KEYS.
 - [#6624](https://github.com/influxdata/influxdb/issues/6624): Ensure clients requesting gzip encoded bodies don't receive empty body
 
+- [#6652](https://github.com/influxdata/influxdb/issues/6652): Fix panic: interface conversion: tsm1.Value is *tsm1.StringValue, not *tsm1.FloatValue
+- [#6406](https://github.com/influxdata/influxdb/issues/6406): Max index entries exceeded
+- [#6557](https://github.com/influxdata/influxdb/issues/6557): Overwriting points on large series can cause memory spikes during compactions
+
 ## v0.13.0 [2016-05-12]
 
 ### Release Notes

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,19 @@
 machine:
     services:
         - docker
+    environment:
+      GODIST: "go1.6.2.linux-amd64.tar.gz"
+    post:
+      - mkdir -p download
+      - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
+      - sudo rm -rf /usr/local/go
+      - sudo tar -C /usr/local -xzf download/$GODIST
+
 
 dependencies:
     cache_directories:
         - "~/docker"
+        - ~/download
     override:
       - ./test.sh save:
           # building the docker images can take a long time, hence caching

--- a/test.sh
+++ b/test.sh
@@ -133,7 +133,7 @@ fi
 case $ENVIRONMENT_INDEX in
     0)
         # 64 bit tests
-	# Static builds will be uploaded to S3 upon test completion
+	    # Static builds will be uploaded to S3 upon test completion
         run_test_docker Dockerfile_build_ubuntu64 test_64bit --generate --test
         rc=$?
         ;;

--- a/test.sh
+++ b/test.sh
@@ -6,10 +6,8 @@
 # Usage: ./test.sh <environment_index>
 # Corresponding environments for environment_index:
 #      0: normal 64bit tests
-#      1: tsm 64bit tests
-#      2: race enabled 64bit tests
+#      1: race enabled 64bit tests
 #      3: normal 32bit tests
-#      4: normal 64bit tests against Go 1.6
 #      save: build the docker images and save them to DOCKER_SAVE_DIR. Do not run tests.
 #      count: print the number of test environments
 #      *: to run all tests in parallel containers
@@ -29,13 +27,13 @@ DOCKER_SAVE_DIR=${DOCKER_SAVE_DIR-$HOME/docker}
 # Set default parallelism
 PARALLELISM=${PARALLELISM-1}
 # Set default timeout
-TIMEOUT=${TIMEOUT-480s}
+TIMEOUT=${TIMEOUT-960s}
 
 # Default to deleteing the container
 DOCKER_RM=${DOCKER_RM-true}
 
 # Update this value if you add a new test environment.
-ENV_COUNT=5
+ENV_COUNT=3
 
 # Default return code 0
 rc=0
@@ -138,26 +136,14 @@ case $ENVIRONMENT_INDEX in
         rc=$?
         ;;
     1)
-        # 64 bit tsm tests
-        INFLUXDB_DATA_ENGINE="tsm1"
-        run_test_docker Dockerfile_build_ubuntu64 test_64bit_tsm --generate --test
-        rc=$?
-        ;;
-    2)
         # 64 bit race tests
         GORACE="halt_on_error=1"
         run_test_docker Dockerfile_build_ubuntu64 test_64bit_race --generate --test --race
         rc=$?
         ;;
-    3)
+    2)
         # 32 bit tests
         run_test_docker Dockerfile_build_ubuntu32 test_32bit --generate --test --arch=i386
-        rc=$?
-        ;;
-    4)
-        # 64 bit tests on golang go1.6
-        GO_CHECKOUT=go1.6
-        run_test_docker Dockerfile_build_ubuntu64_git test_64bit_go1.6 --generate --test --no-vet
         rc=$?
         ;;
     "save")

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -573,16 +573,12 @@ func (c *Compactor) write(path string, iter KeyIterator) (err error) {
 		}
 
 		// Write the key and value
-		err = w.WriteBlock(key, minTime, maxTime, block)
-		if err == ErrMaxBlocksExceeded {
+		if err := w.WriteBlock(key, minTime, maxTime, block); err == ErrMaxBlocksExceeded {
 			if err := w.WriteIndex(); err != nil {
 				return err
 			}
-
-			return ErrMaxBlocksExceeded
-		}
-
-		if err != nil {
+			return err
+		} else if err != nil {
 			return err
 		}
 
@@ -888,7 +884,7 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 				// Filter out only the values for overlapping block
 				v = Values(v).Include(first.minTime, first.maxTime)
 				if len(v) > 0 {
-					// Recoder that we read a subset of the block
+					// Record that we read a subset of the block
 					k.blocks[i].markRead(v[0].UnixNano(), v[len(v)-1].UnixNano())
 				}
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -640,6 +640,13 @@ type tsmKeyIterator struct {
 	blocks    blocks
 
 	buf []blocks
+
+	// mergeValues are decoded blocks that have been combined
+	mergedValues Values
+
+	// merged are encoded blocks that have been combined or used as is
+	// without decode
+	merged blocks
 }
 
 type block struct {
@@ -647,6 +654,28 @@ type block struct {
 	minTime, maxTime int64
 	b                []byte
 	tombstones       []TimeRange
+
+	// readMin, readMax are the timestamps range of values have been
+	// read and encoded from this block.
+	readMin, readMax int64
+}
+
+func (b *block) overlapsTimeRange(min, max int64) bool {
+	return b.minTime <= max && b.maxTime >= min
+}
+
+func (b *block) read() bool {
+	return b.readMin <= b.minTime && b.readMax >= b.maxTime
+}
+
+func (b *block) markRead(min, max int64) {
+	if min < b.readMin {
+		b.readMin = min
+	}
+
+	if max > b.readMax {
+		b.readMax = max
+	}
 }
 
 type blocks []*block
@@ -680,11 +709,26 @@ func NewTSMKeyIterator(size int, fast bool, readers ...*TSMReader) (KeyIterator,
 }
 
 func (k *tsmKeyIterator) Next() bool {
-	// If we still have blocks from the last read, slice off the current one
-	// and return
+	// Any merged blocks pending?
+	if len(k.merged) > 0 {
+		k.merged = k.merged[1:]
+		if len(k.merged) > 0 {
+			return true
+		}
+	}
+
+	// Any merged values pending?
+	if len(k.mergedValues) > 0 {
+		k.merge()
+		if len(k.merged) > 0 || len(k.mergedValues) > 0 {
+			return true
+		}
+	}
+
+	// If we still have blocks from the last read, merge them
 	if len(k.blocks) > 0 {
-		k.blocks = k.blocks[1:]
-		if len(k.blocks) > 0 {
+		k.merge()
+		if len(k.merged) > 0 || len(k.mergedValues) > 0 {
 			return true
 		}
 	}
@@ -702,14 +746,14 @@ func (k *tsmKeyIterator) Next() bool {
 				// This block may have ranges of time removed from it that would
 				// reduce the block min and max time.
 				tombstones := iter.r.TombstoneRange(key)
-				minTime, maxTime = k.clampTombstoneRange(tombstones, minTime, maxTime)
-
 				k.buf[i] = append(k.buf[i], &block{
 					minTime:    minTime,
 					maxTime:    maxTime,
 					key:        key,
 					b:          b,
 					tombstones: tombstones,
+					readMin:    math.MaxInt64,
+					readMax:    math.MinInt64,
 				})
 
 				blockKey := key
@@ -721,7 +765,6 @@ func (k *tsmKeyIterator) Next() bool {
 					}
 
 					tombstones := iter.r.TombstoneRange(key)
-					minTime, maxTime = k.clampTombstoneRange(tombstones, minTime, maxTime)
 
 					k.buf[i] = append(k.buf[i], &block{
 						minTime:    minTime,
@@ -729,6 +772,8 @@ func (k *tsmKeyIterator) Next() bool {
 						key:        key,
 						b:          b,
 						tombstones: tombstones,
+						readMin:    math.MaxInt64,
+						readMax:    math.MinInt64,
 					})
 				}
 			}
@@ -747,6 +792,7 @@ func (k *tsmKeyIterator) Next() bool {
 			minKey = b[0].key
 		}
 	}
+	k.key = minKey
 
 	// Now we need to find all blocks that match the min key so we can combine and dedupe
 	// the blocks if necessary
@@ -754,74 +800,112 @@ func (k *tsmKeyIterator) Next() bool {
 		if len(b) == 0 {
 			continue
 		}
-		if b[0].key == minKey {
+		if b[0].key == k.key {
 			k.blocks = append(k.blocks, b...)
 			k.buf[i] = nil
 		}
 	}
 
-	// No blocks left, we're done
 	if len(k.blocks) == 0 {
 		return false
 	}
 
-	// Only one block and no tombstoned values, just return early everything after is wasted work
-	if len(k.blocks) == 1 && len(k.blocks[0].tombstones) == 0 {
-		return true
+	k.merge()
+
+	return len(k.merged) > 0
+}
+
+// merge combines the next set of blocks into merged blocks
+func (k *tsmKeyIterator) merge() {
+	// No blocks left, or pending merged values, we're done
+	if len(k.blocks) == 0 && len(k.merged) == 0 && len(k.mergedValues) == 0 {
+		return
 	}
 
-	// If we have more than one block or any partially tombstoned blocks, we many need to dedup
-	dedup := len(k.blocks[0].tombstones) > 0
-
-	if len(k.blocks) > 1 {
+	dedup := false
+	if len(k.blocks) > 0 {
+		// If we have more than one block or any partially tombstoned blocks, we many need to dedup
 		dedup = len(k.blocks[0].tombstones) > 0
 
-		// Quickly scan each block to see if any overlap with the prior block, if they overlap then
-		// we need to dedup as there may be duplicate points now
-		for i := 1; !dedup && i < len(k.blocks); i++ {
-			if k.blocks[i].minTime <= k.blocks[i-1].maxTime || len(k.blocks[i].tombstones) > 0 {
-				dedup = true
-				break
+		if len(k.blocks) > 1 {
+			// Quickly scan each block to see if any overlap with the prior block, if they overlap then
+			// we need to dedup as there may be duplicate points now
+			for i := 1; !dedup && i < len(k.blocks); i++ {
+				if k.blocks[i].read() {
+					dedup = true
+					break
+				}
+				if k.blocks[i].minTime <= k.blocks[i-1].maxTime || len(k.blocks[i].tombstones) > 0 {
+					dedup = true
+					break
+				}
 			}
 		}
 	}
 
-	k.blocks = k.combine(dedup)
-
-	return len(k.blocks) > 0
+	k.merged = k.combine(dedup)
 }
 
 // combine returns a new set of blocks using the current blocks in the buffers.  If dedup
 // is true, all the blocks will be decoded, dedup and sorted in in order.  If dedup is false,
 // only blocks that are smaller than the chunk size will be decoded and combined.
 func (k *tsmKeyIterator) combine(dedup bool) blocks {
-	var decoded Values
 	if dedup {
-		// We have some overlapping blocks so decode all, append in order and then dedup
-		for i := 0; i < len(k.blocks); i++ {
-			v, err := DecodeBlock(k.blocks[i].b, nil)
-			if err != nil {
-				k.err = err
-				return nil
+		for len(k.mergedValues) < k.size && len(k.blocks) > 0 {
+			for len(k.blocks) > 0 && k.blocks[0].read() {
+				k.blocks = k.blocks[1:]
 			}
 
-			// Apply each tombstone to the block
-			for _, ts := range k.blocks[i].tombstones {
-				v = Values(v).Exclude(ts.Min, ts.Max)
+			if len(k.blocks) == 0 {
+				break
 			}
-			decoded = append(decoded, v...)
+			first := k.blocks[0]
 
+			// We have some overlapping blocks so decode all, append in order and then dedup
+			for i := 0; i < len(k.blocks); i++ {
+				if !k.blocks[i].overlapsTimeRange(first.minTime, first.maxTime) || k.blocks[i].read() {
+					continue
+				}
+
+				v, err := DecodeBlock(k.blocks[i].b, nil)
+				if err != nil {
+					k.err = err
+					return nil
+				}
+
+				// Remove values we already read
+				v = Values(v).Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
+
+				// Filter out only the values for overlapping block
+				v = Values(v).Include(first.minTime, first.maxTime)
+				if len(v) > 0 {
+					// Recoder that we read a subset of the block
+					k.blocks[i].markRead(v[0].UnixNano(), v[len(v)-1].UnixNano())
+				}
+
+				// Apply each tombstone to the block
+				for _, ts := range k.blocks[i].tombstones {
+					v = Values(v).Exclude(ts.Min, ts.Max)
+				}
+
+				k.mergedValues = k.mergedValues.Merge(v)
+			}
+			k.blocks = k.blocks[1:]
 		}
-		decoded = decoded.Deduplicate()
 
 		// Since we combined multiple blocks, we could have more values than we should put into
 		// a single block.  We need to chunk them up into groups and re-encode them.
-		return k.chunk(nil, decoded)
+		return k.chunk(nil)
 	} else {
 		var chunked blocks
 		var i int
 
 		for i < len(k.blocks) {
+			// skip this block if it's values were already read
+			if k.blocks[i].read() {
+				i++
+				continue
+			}
 			// If we this block is already full, just add it as is
 			if BlockCount(k.blocks[i].b) >= k.size {
 				chunked = append(chunked, k.blocks[i])
@@ -833,6 +917,12 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 
 		if k.fast {
 			for i < len(k.blocks) {
+				// skip this block if it's values were already read
+				if k.blocks[i].read() {
+					i++
+					continue
+				}
+
 				chunked = append(chunked, k.blocks[i])
 				i++
 			}
@@ -840,47 +930,48 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 
 		// If we only have 1 blocks left, just append it as is and avoid decoding/recoding
 		if i == len(k.blocks)-1 {
-			chunked = append(chunked, k.blocks[i])
+			if !k.blocks[i].read() {
+				chunked = append(chunked, k.blocks[i])
+			}
 			i++
 		}
 
 		// The remaining blocks can be combined and we know that they do not overlap and
 		// so we can just append each, sort and re-encode.
-		for i < len(k.blocks) {
+		for i < len(k.blocks) && len(k.mergedValues) < k.size {
+			if k.blocks[i].read() {
+				i++
+				continue
+			}
+
 			v, err := DecodeBlock(k.blocks[i].b, nil)
 			if err != nil {
 				k.err = err
 				return nil
 			}
 
-			decoded = append(decoded, v...)
+			// Apply each tombstone to the block
+			for _, ts := range k.blocks[i].tombstones {
+				v = Values(v).Exclude(ts.Min, ts.Max)
+			}
+
+			k.blocks[i].markRead(k.blocks[i].minTime, k.blocks[i].maxTime)
+
+			k.mergedValues = k.mergedValues.Merge(v)
 			i++
 		}
 
-		sort.Sort(Values(decoded))
-		return k.chunk(chunked, decoded)
+		k.blocks = k.blocks[i:]
+
+		return k.chunk(chunked)
 	}
 }
 
-func (k *tsmKeyIterator) chunk(dst blocks, values []Value) blocks {
-	for len(values) > k.size {
-		cb, err := Values(values[:k.size]).Encode(nil)
-		if err != nil {
-			k.err = err
-			return nil
-		}
+func (k *tsmKeyIterator) chunk(dst blocks) blocks {
+	k.mergedValues.assertOrdered()
 
-		dst = append(dst, &block{
-			minTime: values[0].UnixNano(),
-			maxTime: values[k.size-1].UnixNano(),
-			key:     k.blocks[0].key,
-			b:       cb,
-		})
-		values = values[k.size:]
-	}
-
-	// Re-encode the remaining values into the last block
-	if len(values) > 0 {
+	for len(k.mergedValues) > k.size {
+		values := k.mergedValues[:k.size]
 		cb, err := Values(values).Encode(nil)
 		if err != nil {
 			k.err = err
@@ -890,31 +981,38 @@ func (k *tsmKeyIterator) chunk(dst blocks, values []Value) blocks {
 		dst = append(dst, &block{
 			minTime: values[0].UnixNano(),
 			maxTime: values[len(values)-1].UnixNano(),
-			key:     k.blocks[0].key,
+			key:     k.key,
 			b:       cb,
 		})
+		k.mergedValues = k.mergedValues[k.size:]
+		return dst
+	}
+
+	// Re-encode the remaining values into the last block
+	if len(k.mergedValues) > 0 {
+		cb, err := Values(k.mergedValues).Encode(nil)
+		if err != nil {
+			k.err = err
+			return nil
+		}
+
+		dst = append(dst, &block{
+			minTime: k.mergedValues[0].UnixNano(),
+			maxTime: k.mergedValues[len(k.mergedValues)-1].UnixNano(),
+			key:     k.key,
+			b:       cb,
+		})
+		k.mergedValues = k.mergedValues[:0]
 	}
 	return dst
 }
 
-func (k *tsmKeyIterator) clampTombstoneRange(tombstones []TimeRange, minTime, maxTime int64) (int64, int64) {
-	for _, t := range tombstones {
-		if t.Min > minTime {
-			minTime = t.Min
-		}
-		if t.Max < maxTime {
-			maxTime = t.Max
-		}
-	}
-	return minTime, maxTime
-}
-
 func (k *tsmKeyIterator) Read() (string, int64, int64, []byte, error) {
-	if len(k.blocks) == 0 {
+	if len(k.merged) == 0 {
 		return "", 0, 0, nil, k.err
 	}
 
-	block := k.blocks[0]
+	block := k.merged[0]
 	return block.key, block.minTime, block.maxTime, block.b, k.err
 }
 

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -562,6 +562,85 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 	}
 }
 
+// Ensures that a compaction will properly rollover to a new file when the
+// max keys per blocks is exceeded
+func TestCompactor_CompactFull_MaxKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping max keys compaction test")
+	}
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+
+	// write two files where the first contains a single key with the maximum
+	// number of full blocks that can fit in a TSM file
+	f1, f1Name := MustTSMWriter(dir, 1)
+	values := make([]tsm1.Value, 1000)
+	for i := 0; i < 65535; i++ {
+		values = values[:0]
+		for j := 0; j < 1000; j++ {
+			values = append(values, tsm1.NewValue(int64(i*1000+j), float64(j)))
+		}
+		if err := f1.Write("cpu,host=A#!~#value", values); err != nil {
+			t.Fatalf("write tsm f1: %v", err)
+		}
+	}
+	if err := f1.WriteIndex(); err != nil {
+		t.Fatalf("write index f1: %v", err)
+	}
+	f1.Close()
+
+	// Write a new file with 1 block that when compacted would exceed the max
+	// blocks
+	lastTimeStamp := values[len(values)-1].UnixNano()
+	values = values[:0]
+	f2, f2Name := MustTSMWriter(dir, 2)
+	for j := lastTimeStamp; j < lastTimeStamp+1000; j++ {
+		values = append(values, tsm1.NewValue(int64(j), float64(j)))
+	}
+	if err := f2.Write("cpu,host=A#!~#value", values); err != nil {
+		t.Fatalf("write tsm f1: %v", err)
+	}
+
+	if err := f2.WriteIndex(); err != nil {
+		t.Fatalf("write index f2: %v", err)
+	}
+	f2.Close()
+
+	compactor := &tsm1.Compactor{
+		Dir:       dir,
+		FileStore: &fakeFileStore{},
+	}
+
+	// Compact both files, should get 2 files back
+	files, err := compactor.CompactFull([]string{f1Name, f2Name})
+	if err != nil {
+		t.Fatalf("unexpected error writing snapshot: %v", err)
+	}
+
+	if got, exp := len(files), 2; got != exp {
+		t.Fatalf("files length mismatch: got %v, exp %v", got, exp)
+	}
+
+	expGen, expSeq, err := tsm1.ParseTSMFileName(f2Name)
+	if err != nil {
+		t.Fatalf("unexpected error parsing file name: %v", err)
+	}
+	expSeq = expSeq + 1
+
+	gotGen, gotSeq, err := tsm1.ParseTSMFileName(files[0])
+	if err != nil {
+		t.Fatalf("unexpected error parsing file name: %v", err)
+	}
+
+	if gotGen != expGen {
+		t.Fatalf("wrong generation for new file: got %v, exp %v", gotGen, expGen)
+	}
+
+	if gotSeq != expSeq {
+		t.Fatalf("wrong sequence for new file: got %v, exp %v", gotSeq, expSeq)
+	}
+}
+
 // Tests that a single TSM file can be read and iterated over
 func TestTSMKeyIterator_Single(t *testing.T) {
 	dir := MustTempDir()
@@ -1399,7 +1478,7 @@ func MustWALSegment(dir string, entries []tsm1.WALEntry) *tsm1.WALSegmentReader 
 	return tsm1.NewWALSegmentReader(f)
 }
 
-func MustWriteTSM(dir string, gen int, values map[string][]tsm1.Value) string {
+func MustTSMWriter(dir string, gen int) (tsm1.TSMWriter, string) {
 	f := MustTempFile(dir)
 	oldName := f.Name()
 
@@ -1425,6 +1504,12 @@ func MustWriteTSM(dir string, gen int, values map[string][]tsm1.Value) string {
 		panic(fmt.Sprintf("create TSM writer: %v", err))
 	}
 
+	return w, newName
+}
+
+func MustWriteTSM(dir string, gen int, values map[string][]tsm1.Value) string {
+	w, name := MustTSMWriter(dir, gen)
+
 	for k, v := range values {
 		if err := w.Write(k, v); err != nil {
 			panic(fmt.Sprintf("write TSM value: %v", err))
@@ -1439,7 +1524,7 @@ func MustWriteTSM(dir string, gen int, values map[string][]tsm1.Value) string {
 		panic(fmt.Sprintf("write TSM close: %v", err))
 	}
 
-	return newName
+	return name
 }
 
 func MustTSMReader(dir string, gen int, values map[string][]tsm1.Value) *tsm1.TSMReader {

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -566,7 +566,7 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 // max keys per blocks is exceeded
 func TestCompactor_CompactFull_MaxKeys(t *testing.T) {
 	// This test creates a lot of data and causes timeout failures for these envs
-	if testing.Short() || os.Getenv("CIRCLECI") != "" || os.Getenv("APPVEYOR") != "" || os.Getenv("GORACE") != "" {
+	if testing.Short() || os.Getenv("CI") != "" || os.Getenv("GORACE") != "" {
 		t.Skip("Skipping max keys compaction test")
 	}
 	dir := MustTempDir()


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR re-introduces the fix for #6556 that was reverted in #6637.  The original fix could drop points during compactions as well as cause an `interface conversion` panic (#6652) in some cases.   What happened was that merged values from one series could get mixed with the values for the next series.  If the series were different types, a panic could occur.  If it was the last block to be merged, the values would be lost.  Both of these issues should be fixed now as well as the original issue of overwriting a point in a large series triggering memory spikes.

This also fixes #6406 that can occur if enough points are written into a single series to cause the TSM index to exceed the max index entries allotment. It will now handle that error and rollover to a new file.

