### PR TITLE
Add HTTP(s) Subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#2926](https://github.com/influxdata/influxdb/issues/2926): Support bound parameters in the parser.
 - [#1310](https://github.com/influxdata/influxdb/issues/1310): Add https-private-key option to httpd config.
 - [#6621](https://github.com/influxdata/influxdb/pull/6621): Add Holt-Winter forecasting function.
+- [#6655](https://github.com/influxdata/influxdb/issues/6655): Add HTTP(s) based subscriptions.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -168,6 +168,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.Subscriber.Validate(); err != nil {
+		return err
+	}
+
 	for _, g := range c.GraphiteInputs {
 		if err := g.Validate(); err != nil {
 			return fmt.Errorf("invalid graphite config: %v", err)

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -173,6 +173,18 @@ reporting-disabled = false
   max-row-limit = 10000
 
 ###
+### [subsciber]
+###
+### Controls the subscriptions, which can be used to fork a copy of all data
+### received by the InfluxDB host.
+###
+
+[subsciber]
+  enabled = true
+  http-timeout = "30s"
+
+
+###
 ### [[graphite]]
 ###
 ### Controls one or many listeners for Graphite data.

--- a/services/subscriber/config.go
+++ b/services/subscriber/config.go
@@ -1,12 +1,35 @@
 package subscriber
 
+import (
+	"errors"
+	"time"
+
+	"github.com/influxdata/influxdb/toml"
+)
+
+const (
+	DefaultHTTPTimeout = 30 * time.Second
+)
+
 // Config represents a configuration of the subscriber service.
 type Config struct {
 	// Whether to enable to Subscriber service
 	Enabled bool `toml:"enabled"`
+
+	HTTPTimeout toml.Duration `toml:"http-timeout"`
 }
 
 // NewConfig returns a new instance of a subscriber config.
 func NewConfig() Config {
-	return Config{Enabled: true}
+	return Config{
+		Enabled:     true,
+		HTTPTimeout: toml.Duration(DefaultHTTPTimeout),
+	}
+}
+
+func (c Config) Validate() error {
+	if c.HTTPTimeout <= 0 {
+		return errors.New("http-timeout must be greater than 0")
+	}
+	return nil
 }

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -13,10 +13,10 @@ type HTTP struct {
 }
 
 // NewHTTP returns a new HTTP points writer with default options.
-func NewHTTP(addr string) (*HTTP, error) {
+func NewHTTP(addr string, timeout time.Duration) (*HTTP, error) {
 	conf := client.HTTPConfig{
 		Addr:    addr,
-		Timeout: 30 * time.Second,
+		Timeout: timeout,
 	}
 	c, err := client.NewHTTPClient(conf)
 	if err != nil {

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -31,8 +31,8 @@ func (h *HTTP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
 		Database:        p.Database,
 		RetentionPolicy: p.RetentionPolicy,
 	})
-	for _, p := range p.Points {
-		bp.AddPoint(client.NewPointFrom(p))
+	for _, pt := range p.Points {
+		bp.AddPoint(client.NewPointFrom(pt))
 	}
 	err = h.c.Write(bp)
 	return

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -1,6 +1,8 @@
 package subscriber
 
 import (
+	"time"
+
 	"github.com/influxdata/influxdb/client/v2"
 	"github.com/influxdata/influxdb/coordinator"
 )
@@ -13,7 +15,8 @@ type HTTP struct {
 // NewHTTP returns a new HTTP points writer with default options.
 func NewHTTP(addr string) (*HTTP, error) {
 	conf := client.HTTPConfig{
-		Addr: addr,
+		Addr:    addr,
+		Timeout: 30 * time.Second,
 	}
 	c, err := client.NewHTTPClient(conf)
 	if err != nil {

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -1,0 +1,36 @@
+package subscriber
+
+import (
+	"github.com/influxdata/influxdb/client/v2"
+	"github.com/influxdata/influxdb/coordinator"
+)
+
+// HTTP supports writing points over HTTP using the line protocol.
+type HTTP struct {
+	c client.Client
+}
+
+// NewHTTP returns a new HTTP points writer with default options.
+func NewHTTP(addr string) (*HTTP, error) {
+	conf := client.HTTPConfig{
+		Addr: addr,
+	}
+	c, err := client.NewHTTPClient(conf)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTP{c: c}, nil
+}
+
+// WritePoints writes points over HTTP transport.
+func (h *HTTP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
+	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
+		Database:        p.Database,
+		RetentionPolicy: p.RetentionPolicy,
+	})
+	for _, p := range p.Points {
+		bp.AddPoint(client.NewPointFrom(p))
+	}
+	err = h.c.Write(bp)
+	return
+}


### PR DESCRIPTION
Adds support for the `http` and `https` protocols for subscriptions.

To use it specify a destination like so:

```
CREATE SUBSCRIPTION name ON db.rp DESTINATIONS ANY 'http://myhost.com:8086'
```

If a single HTTP based backed slows down for what ever reason all subscriptions will be effected but normal writes to InfluxDB will continue without issues. Should we isolate each of the destinations?

A config option has been added to the `[subscription]` section called `http-timeout` which specifies the client timeout when writing data to any http destination. Default is 30s

- [ ] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
