### PR TITLE
Store shard size on disk statistic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - [#6519](https://github.com/influxdata/influxdb/issues/6519): Support cast syntax for selecting a specific type.
 - [#6654](https://github.com/influxdata/influxdb/pull/6654): Add new HTTP statistics to monitoring
 
+- [#6664](https://github.com/influxdata/influxdb/pull/6664): Adds monitoring statistic for on-disk shard size.
+
 ### Bugfixes
 
 - [#6604](https://github.com/influxdata/influxdb/pull/6604): Remove old cluster code

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ const (
 	statWritePointsFail = "writePointsFail"
 	statWritePointsOK   = "writePointsOk"
 	statWriteBytes      = "writeBytes"
+	statDiskBytes       = "diskBytes"
 )
 
 var (
@@ -84,8 +86,9 @@ type Shard struct {
 
 	options EngineOptions
 
-	mu     sync.RWMutex
-	engine Engine
+	mu      sync.RWMutex
+	engine  Engine
+	closing chan struct{}
 
 	// expvar-based stats.
 	statMap *expvar.Map
@@ -116,6 +119,7 @@ func NewShard(id uint64, index *DatabaseIndex, path string, walPath string, opti
 		path:    path,
 		walPath: walPath,
 		options: options,
+		closing: make(chan struct{}),
 
 		database:        db,
 		retentionPolicy: rp,
@@ -173,6 +177,8 @@ func (s *Shard) Open() error {
 		}
 		s.logger.Printf("%s database index loaded in %s", s.path, time.Now().Sub(start))
 
+		go s.monitorSize()
+
 		return nil
 	}(); err != nil {
 		s.close()
@@ -192,6 +198,13 @@ func (s *Shard) Close() error {
 func (s *Shard) close() error {
 	if s.engine == nil {
 		return nil
+	}
+
+	// Close the closing channel at most once.
+	select {
+	case <-s.closing:
+	default:
+		close(s.closing)
 	}
 
 	// Don't leak our shard ID and series keys in the index
@@ -214,11 +227,25 @@ func (s *Shard) closed() bool {
 
 // DiskSize returns the size on disk of this shard
 func (s *Shard) DiskSize() (int64, error) {
-	stats, err := os.Stat(s.path)
+	var size int64
+	err := filepath.Walk(s.path, func(_ string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
 	if err != nil {
 		return 0, err
 	}
-	return stats.Size(), nil
+
+	err = filepath.Walk(s.walPath, func(_ string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+
+	return size, err
 }
 
 // FieldCodec returns the field encoding for a measurement.
@@ -576,6 +603,26 @@ func (s *Shard) CreateSnapshot() (string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.engine.CreateSnapshot()
+}
+
+func (s *Shard) monitorSize() {
+	t := time.NewTicker(10 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.closing:
+			return
+		case <-t.C:
+			size, err := s.DiskSize()
+			if err != nil {
+				s.logger.Printf("error collecting shard size: %v", err)
+				continue
+			}
+			sizeStat := new(expvar.Int)
+			sizeStat.Set(size)
+			s.statMap.Set(statDiskBytes, sizeStat)
+		}
+	}
 }
 
 // Shards represents a sortable list of shards.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR adds a monitoring goroutine to each shard, which will periodically emit a statistic with the current on-disk size of the shard.

@jwilder 

/cc @sparrc 