### PR TITLE
Add https-private-key option to httpd config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#6654](https://github.com/influxdata/influxdb/pull/6654): Add new HTTP statistics to monitoring
 - [#6664](https://github.com/influxdata/influxdb/pull/6664): Adds monitoring statistic for on-disk shard size.
 - [#2926](https://github.com/influxdata/influxdb/issues/2926): Support bound parameters in the parser.
+- [#1310](https://github.com/influxdata/influxdb/issues/1310): Add https-private-key option to httpd config.
 
 ### Bugfixes
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -168,6 +168,8 @@ reporting-disabled = false
   pprof-enabled = false
   https-enabled = false
   https-certificate = "/etc/ssl/influxdb.pem"
+  ### Use a separate private key location.
+  # https-private-key = ""
   max-row-limit = 10000
 
 ###

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	PprofEnabled       bool   `toml:"pprof-enabled"`
 	HTTPSEnabled       bool   `toml:"https-enabled"`
 	HTTPSCertificate   string `toml:"https-certificate"`
+	HTTPSPrivateKey    string `toml:"https-private-key"`
 	MaxRowLimit        int    `toml:"max-row-limit"`
 	MaxConnectionLimit int    `toml:"max-connection-limit"`
 	SharedSecret       string `toml:"shared-secret"`

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	addr  string
 	https bool
 	cert  string
+	key   string
 	limit int
 	err   chan error
 
@@ -64,10 +65,14 @@ func NewService(c Config) *Service {
 		addr:    c.BindAddress,
 		https:   c.HTTPSEnabled,
 		cert:    c.HTTPSCertificate,
+		key:     c.HTTPSPrivateKey,
 		limit:   c.MaxConnectionLimit,
 		err:     make(chan error),
 		Handler: NewHandler(c, statMap),
 		Logger:  log.New(os.Stderr, "[httpd] ", log.LstdFlags),
+	}
+	if s.key == "" {
+		s.key = s.cert
 	}
 	s.Handler.Logger = s.Logger
 	return s
@@ -80,7 +85,7 @@ func (s *Service) Open() error {
 
 	// Open listener.
 	if s.https {
-		cert, err := tls.LoadX509KeyPair(s.cert, s.cert)
+		cert, err := tls.LoadX509KeyPair(s.cert, s.key)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The HTTPS configuration for the httpd service only had an option to
specify the certificate file and the same file would be used for both
the certificate and private key file (they could be concatenated
together).

This adds an additional option to specify the files differently from
each other while still allowing the previous behavior. If only
`https-certificate` is specified, the httpd service will try to load the
private key from the `https-certificate` file. If a separate
`https-private-key` file is specified, the private key will be loaded
from there instead.

Fixes #1310.