### PR TITLE
Fix points already read from being returned more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - [#6623](https://github.com/influxdata/influxdb/pull/6623): Speed up drop database
 - [#6519](https://github.com/influxdata/influxdb/issues/6519): Support cast syntax for selecting a specific type.
 - [#6654](https://github.com/influxdata/influxdb/pull/6654): Add new HTTP statistics to monitoring
-
 - [#6664](https://github.com/influxdata/influxdb/pull/6664): Adds monitoring statistic for on-disk shard size.
 
 ### Bugfixes
@@ -27,10 +26,10 @@
 - [#6235](https://github.com/influxdata/influxdb/issues/6235): Fix measurement field panic in tsm1 engine.
 - [#6663](https://github.com/influxdata/influxdb/issues/6663): Fixing panic in SHOW FIELD KEYS.
 - [#6624](https://github.com/influxdata/influxdb/issues/6624): Ensure clients requesting gzip encoded bodies don't receive empty body
-
 - [#6652](https://github.com/influxdata/influxdb/issues/6652): Fix panic: interface conversion: tsm1.Value is *tsm1.StringValue, not *tsm1.FloatValue
 - [#6406](https://github.com/influxdata/influxdb/issues/6406): Max index entries exceeded
 - [#6557](https://github.com/influxdata/influxdb/issues/6557): Overwriting points on large series can cause memory spikes during compactions
+- [#6611](https://github.com/influxdata/influxdb/issues/6611): Queries slow down hundreds times after overwriting points
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -966,6 +966,9 @@ func (c *KeyCursor) ReadFloatBlock(tdec *TimeDecoder, vdec *FloatDecoder, buf *[
 			// Remove any tombstoned values
 			v = c.filterFloatValues(tombstones, v)
 
+			// Remove values we already read
+			v = FloatValues(v).Exclude(cur.readMin, cur.readMax)
+
 			if len(v) > 0 {
 				v = FloatValues(v).Include(first.entry.MinTime, first.entry.MaxTime)
 
@@ -985,6 +988,9 @@ func (c *KeyCursor) ReadFloatBlock(tdec *TimeDecoder, vdec *FloatDecoder, buf *[
 			}
 			// Remove any tombstoned values
 			v = c.filterFloatValues(tombstones, v)
+
+			// Remove values we already read
+			v = FloatValues(v).Exclude(cur.readMin, cur.readMax)
 
 			// If the block we decoded should have all of it's values included, mark it as read so we
 			// don't use it again.
@@ -1050,6 +1056,9 @@ func (c *KeyCursor) ReadIntegerBlock(tdec *TimeDecoder, vdec *IntegerDecoder, bu
 			// Remove any tombstoned values
 			v = c.filterIntegerValues(tombstones, v)
 
+			// Remove values we already read
+			v = IntegerValues(v).Exclude(cur.readMin, cur.readMax)
+
 			if len(v) > 0 {
 				v = IntegerValues(v).Include(first.entry.MinTime, first.entry.MaxTime)
 
@@ -1069,6 +1078,9 @@ func (c *KeyCursor) ReadIntegerBlock(tdec *TimeDecoder, vdec *IntegerDecoder, bu
 			}
 			// Remove any tombstoned values
 			v = c.filterIntegerValues(tombstones, v)
+
+			// Remove values we already read
+			v = IntegerValues(v).Exclude(cur.readMin, cur.readMax)
 
 			// If the block we decoded should have all of it's values included, mark it as read so we
 			// don't use it again.
@@ -1134,6 +1146,9 @@ func (c *KeyCursor) ReadStringBlock(tdec *TimeDecoder, vdec *StringDecoder, buf 
 			// Remove any tombstoned values
 			v = c.filterStringValues(tombstones, v)
 
+			// Remove values we already read
+			v = StringValues(v).Exclude(cur.readMin, cur.readMax)
+
 			if len(v) > 0 {
 				v = StringValues(v).Include(first.entry.MinTime, first.entry.MaxTime)
 
@@ -1153,6 +1168,9 @@ func (c *KeyCursor) ReadStringBlock(tdec *TimeDecoder, vdec *StringDecoder, buf 
 			}
 			// Remove any tombstoned values
 			v = c.filterStringValues(tombstones, v)
+
+			// Remove values we already read
+			v = StringValues(v).Exclude(cur.readMin, cur.readMax)
 
 			// If the block we decoded should have all of it's values included, mark it as read so we
 			// don't use it again.
@@ -1218,6 +1236,9 @@ func (c *KeyCursor) ReadBooleanBlock(tdec *TimeDecoder, vdec *BooleanDecoder, bu
 			// Remove any tombstoned values
 			v = c.filterBooleanValues(tombstones, v)
 
+			// Remove values we already read
+			v = BooleanValues(v).Exclude(cur.readMin, cur.readMax)
+
 			if len(v) > 0 {
 				v = BooleanValues(v).Include(first.entry.MinTime, first.entry.MaxTime)
 
@@ -1237,6 +1258,9 @@ func (c *KeyCursor) ReadBooleanBlock(tdec *TimeDecoder, vdec *BooleanDecoder, bu
 			}
 			// Remove any tombstoned values
 			v = c.filterBooleanValues(tombstones, v)
+
+			// Remove values we already read
+			v = BooleanValues(v).Exclude(cur.readMin, cur.readMax)
 
 			// If the block we decoded should have all of it's values included, mark it as read so we
 			// don't use it again.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

If there were duplicate points in multiple blocks, we would correctly
dedup the points and mark the regions of the blocks we've read.
Unfortunately, we were not excluding the already points as the cursor
moved to points in the later blocks which could cause points to be
returned more than once incorrectly.

The performance issue #6611 appears to be already fixed due to other query performance tuning.

### Perf 0.13
```
$ python /tmp/overwrite.py
==CREATING DATABASE==
==INSERTING SERIES==
* inserting 5000000 points: from 1462060800000ms - to 1462065800000ms
==QUERY==
* query: select * from test_series LIMIT 1
* result: {u'tag': u'tag0', u'value': 1, u'time': 1462060800000}
* duration: 0.0075s
==INSERTING SERIES==
* inserting 5000000 points: from 1462060800000ms - to 1462065800000ms
==QUERY==
* query: select * from test_series LIMIT 1
* result: {u'tag': u'tag0', u'value': 1, u'time': 1462060800000}
* duration: 4.0214s
==SLEEP 10s==
==QUERY==
* query: select * from test_series LIMIT 1
* result: {u'tag': u'tag0', u'value': 1, u'time': 1462060800000}
* duration: 3.1391s
==REMOVING DATABASE==
```

Note query time dropped from `0.0075s` to `3-4s`

### Perf master
```
$ python /tmp/overwrite.py
==CREATING DATABASE==
==INSERTING SERIES==
* inserting 5000000 points: from 1462060800000ms - to 1462065800000ms
==QUERY==
* query: select * from test_series LIMIT 1
* result: {u'tag': u'tag0', u'value': 1, u'time': 1462060800000}
* duration: 0.0162s
==INSERTING SERIES==
* inserting 5000000 points: from 1462060800000ms - to 1462065800000ms
==QUERY==
* query: select * from test_series LIMIT 1
* result: {u'tag': u'tag0', u'value': 1, u'time': 1462060800000}
* duration: 0.0211s
==SLEEP 10s==
==QUERY==
* query: select * from test_series LIMIT 1
* result: {u'tag': u'tag0', u'value': 1, u'time': 1462060800000}
* duration: 0.0173s
==REMOVING DATABASE==
```

Query time is unchanged.

Counting the total points in 0.13 was correct, `master` was not.  This is now fixed.

### Count master
```
> select count(value) from test_series
name: test_series
-----------------
time	count
0	5001999
```

### Count Fixed
```
> select count(value) from test_series
name: test_series
-----------------
time	count
0	5000000
```

Fixes #6611 

cc @benbjohnson 