### PR TITLE
Fix read tombstones: EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [#6406](https://github.com/influxdata/influxdb/issues/6406): Max index entries exceeded
 - [#6557](https://github.com/influxdata/influxdb/issues/6557): Overwriting points on large series can cause memory spikes during compactions
 - [#6611](https://github.com/influxdata/influxdb/issues/6611): Queries slow down hundreds times after overwriting points
+- [#6641](https://github.com/influxdata/influxdb/issues/6641): Fix read tombstones: EOF
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -173,3 +173,31 @@ func TestTombstoner_ReadV1(t *testing.T) {
 		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
 	}
 }
+
+func TestTombstoner_ReadEmptyV1(t *testing.T) {
+	dir := MustTempDir()
+	defer func() { os.RemoveAll(dir) }()
+
+	f := MustTempFile(dir)
+	f.Close()
+
+	if err := os.Rename(f.Name(), f.Name()+".tombstone"); err != nil {
+		t.Fatalf("rename tombstone failed: %v", err)
+	}
+
+	ts := &tsm1.Tombstoner{Path: f.Name()}
+
+	entries, err := ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	entries, err = ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 0; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Due to an bug in TSM tombstone files, it was possible to create
empty tombstone files.  At startup, the TSM file would error out
and not load the TSM file.

Instead, treat it as an empty v1 file so the TSM file can load
correctly.

Fixes #6641