### PR TITLE
Ensure meta SHOW queries include future points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [#6683](https://github.com/influxdata/influxdb/issues/6683): Fix compaction planning re-compacting large TSM files
 - [#6693](https://github.com/influxdata/influxdb/pull/6693): Truncate the shard group end time if it exceeds MaxNanoTime.
 - [#6672](https://github.com/influxdata/influxdb/issues/6672): Accept points with trailing whitespace.
+- [#6599](https://github.com/influxdata/influxdb/issues/6599): Ensure that future points considered in SHOW queries.
 
 ## v0.13.0 [2016-05-12]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -5238,7 +5238,7 @@ func TestServer_Query_ShowQueries_Future(t *testing.T) {
 	}
 
 	writes := []string{
-		fmt.Sprintf(`cpu,host=server01 value=100 %d`, models.MaxNanoTime.UnixNano()),
+		fmt.Sprintf(`cpu,host=server01 value=100 %d`, models.MaxNanoTime),
 	}
 
 	test := NewTest("db0", "rp0")
@@ -6227,7 +6227,7 @@ func TestServer_Query_LargeTimestamp(t *testing.T) {
 	defer s.Close()
 
 	writes := []string{
-		fmt.Sprintf(`cpu value=100 %d`, models.MaxNanoTime.UnixNano()),
+		fmt.Sprintf(`cpu value=100 %d`, models.MaxNanoTime),
 	}
 
 	test := NewTest("db0", "rp0")
@@ -6238,8 +6238,8 @@ func TestServer_Query_LargeTimestamp(t *testing.T) {
 		&Query{
 			name:    `select value at max nano time`,
 			params:  url.Values{"db": []string{"db0"}},
-			command: fmt.Sprintf(`SELECT value FROM cpu WHERE time <= %d`, models.MaxNanoTime.UnixNano()),
-			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["` + models.MaxNanoTime.Format(time.RFC3339Nano) + `",100]]}]}]}`,
+			command: fmt.Sprintf(`SELECT value FROM cpu WHERE time <= %d`, models.MaxNanoTime),
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["` + time.Unix(0, models.MaxNanoTime).Format(time.RFC3339Nano) + `",100]]}]}]}`,
 		},
 	}...)
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -5225,6 +5225,78 @@ func TestServer_Query_DropAndRecreateMeasurement(t *testing.T) {
 	}
 }
 
+func TestServer_Query_ShowQueries_Future(t *testing.T) {
+	t.Parallel()
+	s := OpenServer(NewConfig())
+	defer s.Close()
+
+	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.MetaClient.SetDefaultRetentionPolicy("db0", "rp0"); err != nil {
+		t.Fatal(err)
+	}
+
+	writes := []string{
+		fmt.Sprintf(`cpu,host=server01 value=100 %d`, models.MaxNanoTime.UnixNano()),
+	}
+
+	test := NewTest("db0", "rp0")
+	test.writes = Writes{
+		&Write{data: strings.Join(writes, "\n")},
+	}
+
+	test.addQueries([]*Query{
+		&Query{
+			name:    `show measurements`,
+			command: "SHOW MEASUREMENTS",
+			exp:     `{"results":[{"series":[{"name":"measurements","columns":["name"],"values":[["cpu"]]}]}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
+		&Query{
+			name:    `show series`,
+			command: "SHOW SERIES",
+			exp:     `{"results":[{"series":[{"columns":["key"],"values":[["cpu,host=server01"]]}]}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
+		&Query{
+			name:    `show tag keys`,
+			command: "SHOW TAG KEYS FROM cpu",
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["tagKey"],"values":[["host"]]}]}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
+		&Query{
+			name:    `show tag values`,
+			command: "SHOW TAG VALUES WITH KEY = \"host\"",
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["key","value"],"values":[["host","server01"]]}]}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
+		&Query{
+			name:    `show field keys`,
+			command: "SHOW FIELD KEYS",
+			exp:     `{"results":[{"series":[{"name":"cpu","columns":["fieldKey","fieldType"],"values":[["value","float"]]}]}]}`,
+			params:  url.Values{"db": []string{"db0"}},
+		},
+	}...)
+
+	for i, query := range test.queries {
+		if i == 0 {
+			if err := test.init(s); err != nil {
+				t.Fatalf("test init failed: %s", err)
+			}
+		}
+		if query.skip {
+			t.Logf("SKIP:: %s", query.name)
+			continue
+		}
+		if err := query.Execute(s); err != nil {
+			t.Error(query.Error(err))
+		} else if !query.success() {
+			t.Error(query.failureMessage())
+		}
+	}
+}
+
 func TestServer_Query_ShowSeries(t *testing.T) {
 	t.Parallel()
 	s := OpenServer(NewConfig())

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -425,7 +425,7 @@ func (e *StatementExecutor) executeSelectStatement(stmt *influxql.SelectStatemen
 		// to the maximum possible value, to ensure that data where all points
 		// are in the future are returned.
 		if influxql.Sources(stmt.Sources).HasSystemSource() {
-			opt.MaxTime = time.Unix(0, models.MaxNanoTime.UnixNano())
+			opt.MaxTime = time.Unix(0, influxql.MaxTime).UTC()
 		} else {
 			opt.MaxTime = now
 		}

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -420,7 +420,15 @@ func (e *StatementExecutor) executeSelectStatement(stmt *influxql.SelectStatemen
 	}
 
 	if opt.MaxTime.IsZero() {
-		opt.MaxTime = now
+		// In the case that we're executing a meta query where the user cannot
+		// specify a time condition, then we expand the default max time
+		// to the maximum possible value, to ensure that data where all points
+		// are in the future are returned.
+		if influxql.Sources(stmt.Sources).HasSystemSource() {
+			opt.MaxTime = time.Unix(0, models.MaxNanoTime.UnixNano())
+		} else {
+			opt.MaxTime = now
+		}
 	}
 	if opt.MinTime.IsZero() {
 		opt.MinTime = time.Unix(0, 0)

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -742,7 +742,7 @@ func TestTimeRange(t *testing.T) {
 
 		// Invalid time expressions.
 		{expr: `time > "2000-01-01 00:00:00"`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `invalid operation: time and *influxql.VarRef are not compatible`},
-		{expr: `time > '2262-04-11 13:47:17'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `time 2262-04-11T13:47:17Z overflows time literal`},
+		{expr: `time > '2262-04-11 23:47:17'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `time 2262-04-11T23:47:17Z overflows time literal`},
 		{expr: `time > '1677-09-20 19:12:43'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `time 1677-09-20T19:12:43Z underflows time literal`},
 	} {
 		// Extract time range.

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -23,7 +23,7 @@ const (
 
 	// MaxTime is used as the maximum time value when computing an unbounded range.
 	// This time is Jan 1, 2050 at midnight UTC.
-	MaxTime = models.MaxNanoTime
+	MaxTime = models.MaxNanoTime - 1
 )
 
 // Iterator represents a generic interface for all Iterators.

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/influxdb/models"
+
 	"github.com/gogo/protobuf/proto"
 	internal "github.com/influxdata/influxdb/influxql/internal"
 )
@@ -21,7 +23,7 @@ const (
 
 	// MaxTime is used as the maximum time value when computing an unbounded range.
 	// This time is Jan 1, 2050 at midnight UTC.
-	MaxTime = int64(2524608000000000000)
+	MaxTime = models.MaxNanoTime
 )
 
 // Iterator represents a generic interface for all Iterators.

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -22,7 +22,7 @@ const (
 	MinTime = int64(0)
 
 	// MaxTime is used as the maximum time value when computing an unbounded range.
-	// This time is Jan 1, 2050 at midnight UTC.
+	// This time is 2262-04-11 23:47:16.854775806 +0000 UTC
 	MaxTime = models.MaxNanoTime - 1
 )
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1195,19 +1195,19 @@ func TestParsePointMaxTimestamp(t *testing.T) {
 			models.Fields{
 				"value": 1.0,
 			},
-			time.Unix(0, int64(1<<63-1))),
+			time.Unix(0, models.MaxNanoTime)),
 	)
 }
 
 func TestParsePointMinTimestamp(t *testing.T) {
-	test(t, `cpu value=1 -9223372036854775807`,
+	test(t, `cpu value=1 -9223372036854775808`,
 		NewTestPoint(
 			"cpu",
 			models.Tags{},
 			models.Fields{
 				"value": 1.0,
 			},
-			time.Unix(0, -int64(1<<63-1))),
+			time.Unix(0, models.MinNanoTime)),
 	)
 }
 

--- a/models/time.go
+++ b/models/time.go
@@ -9,14 +9,26 @@ import (
 	"time"
 )
 
+const (
+	// MinNanoTime is the minumum time that can be represented.
+	//
+	// 1677-09-21 00:12:43.145224192 +0000 UTC
+	//
+	MinNanoTime = int64(math.MinInt64)
+
+	// MaxNanoTime is the maximum time that can be represented.
+	//
+	// 2262-04-11 23:47:16.854775807 +0000 UTC
+	//
+	MaxNanoTime = int64(math.MaxInt64)
+)
+
 var (
-	// MaxNanoTime is the maximum time that can be represented via int64 nanoseconds since the epoch.
-	MaxNanoTime = time.Unix(0, math.MaxInt64).UTC()
-	// MinNanoTime is the minumum time that can be represented via int64 nanoseconds since the epoch.
-	MinNanoTime = time.Unix(0, math.MinInt64).UTC()
+	minNanoTime = time.Unix(0, MinNanoTime).UTC()
+	maxNanoTime = time.Unix(0, MaxNanoTime).UTC()
 
 	// ErrTimeOutOfRange gets returned when time is out of the representable range using int64 nanoseconds since the epoch.
-	ErrTimeOutOfRange = fmt.Errorf("time outside range %s - %s", MinNanoTime, MaxNanoTime)
+	ErrTimeOutOfRange = fmt.Errorf("time outside range %d - %d", MinNanoTime, MaxNanoTime)
 )
 
 // SafeCalcTime safely calculates the time given. Will return error if the time is outside the
@@ -24,7 +36,8 @@ var (
 func SafeCalcTime(timestamp int64, precision string) (time.Time, error) {
 	mult := GetPrecisionMultiplier(precision)
 	if t, ok := safeSignedMult(timestamp, mult); ok {
-		return time.Unix(0, t).UTC(), nil
+		tme := time.Unix(0, t).UTC()
+		return tme, CheckTime(tme)
 	}
 
 	return time.Time{}, ErrTimeOutOfRange
@@ -32,7 +45,7 @@ func SafeCalcTime(timestamp int64, precision string) (time.Time, error) {
 
 // CheckTime checks that a time is within the safe range.
 func CheckTime(t time.Time) error {
-	if t.Before(MinNanoTime) || t.After(MaxNanoTime) {
+	if t.Before(minNanoTime) || t.After(maxNanoTime) {
 		return ErrTimeOutOfRange
 	}
 	return nil
@@ -43,7 +56,7 @@ func safeSignedMult(a, b int64) (int64, bool) {
 	if a == 0 || b == 0 || a == 1 || b == 1 {
 		return a * b, true
 	}
-	if a == math.MinInt64 || b == math.MaxInt64 {
+	if a == MinNanoTime || b == MaxNanoTime {
 		return 0, false
 	}
 	c := a * b

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -372,8 +372,8 @@ func (data *Data) CreateShardGroup(database, policy string, timestamp time.Time)
 	sgi.ID = data.MaxShardGroupID
 	sgi.StartTime = timestamp.Truncate(rpi.ShardGroupDuration).UTC()
 	sgi.EndTime = sgi.StartTime.Add(rpi.ShardGroupDuration).UTC()
-	if sgi.EndTime.After(models.MaxNanoTime) {
-		sgi.EndTime = models.MaxNanoTime
+	if sgi.EndTime.After(time.Unix(0, models.MaxNanoTime)) {
+		sgi.EndTime = time.Unix(0, models.MaxNanoTime)
 	}
 
 	data.MaxShardID++


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #6599.

If a series only contained points in the future, then none of the `SHOW` queries would return anything. This was because the `SHOW` queries were using the default time range (up to `now()`) and the user is unable to specify a time clause to remedy that.

`SHOW` queries will now include a max time of `influxql.MaxTime`.

This PR also fixes the line-protocol parser to verify if the timestamp provided by the client is within the acceptable time period.