### PR TITLE
Ensure client sends correct precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [#6611](https://github.com/influxdata/influxdb/issues/6611): Queries slow down hundreds times after overwriting points
 - [#6641](https://github.com/influxdata/influxdb/issues/6641): Fix read tombstones: EOF
 - [#6661](https://github.com/influxdata/influxdb/issues/6661): Disable limit optimization when using an aggregate.
+- [#6676](https://github.com/influxdata/influxdb/issues/6676): Ensures client sends correct precision when inserting points.
 
 ## v0.13.0 [2016-05-12]
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -509,7 +509,7 @@ func (c *CommandLine) Insert(stmt string) error {
 		},
 		Database:         c.Database,
 		RetentionPolicy:  c.RetentionPolicy,
-		Precision:        "n",
+		Precision:        c.Precision,
 		WriteConsistency: c.WriteConsistency,
 	})
 	if err != nil {

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -46,7 +46,7 @@ func main() {
 	fs.BoolVar(&c.UnsafeSsl, "unsafeSsl", false, "Set this when connecting to the cluster using https and not use SSL verification.")
 	fs.StringVar(&c.Format, "format", defaultFormat, "Format specifies the format of the server responses:  json, csv, or column.")
 	fs.StringVar(&c.Precision, "precision", defaultPrecision, "Precision specifies the format of the timestamp:  rfc3339,h,m,s,ms,u or ns.")
-	fs.StringVar(&c.WriteConsistency, "consistency", "any", "Set write consistency level: any, one, quorum, or all.")
+	fs.StringVar(&c.WriteConsistency, "consistency", "all", "Set write consistency level: any, one, quorum, or all.")
 	fs.BoolVar(&c.Pretty, "pretty", false, "Turns on pretty print for the json format.")
 	fs.StringVar(&c.Execute, "execute", c.Execute, "Execute command and quit.")
 	fs.BoolVar(&c.ShowVersion, "version", false, "Displays the InfluxDB version.")


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

When `precision` is changed in the client, it's not being sent through with write queries, so timestamps were always being interpreted as nanoseconds.

Fixes #6676.

Also sets default `consistency` to `all` rather than `any` (/cc @jwilder )

/cc @kostasb 