### PR TITLE
Optimize timestamp run-length decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#6621](https://github.com/influxdata/influxdb/pull/6621): Add Holt-Winter forecasting function.
 - [#6655](https://github.com/influxdata/influxdb/issues/6655): Add HTTP(s) based subscriptions.
 - [#5906](https://github.com/influxdata/influxdb/issues/5906): Dynamically update the documentation link in the admin UI.
+- [#6686](https://github.com/influxdata/influxdb/pull/6686): Optimize timestamp run-length decoding
 
 ### Bugfixes
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR switched time stamps using run-length encoding to decode without allocating a large slice of values.  Instead, it now returns them incrementally on demand.  

### Timestamp RLE decoding benchmarks
```
benchmark                      old ns/op     new ns/op     delta
BenchmarkTimeDecoder_RLE-8     6319          2339          -62.98%

benchmark                      old allocs     new allocs     delta
BenchmarkTimeDecoder_RLE-8     0              0              +0.00%

benchmark                      old bytes     new bytes     delta
BenchmarkTimeDecoder_RLE-8     0             0             +0.00%
```


### Block decoding benchmarks using RLE

```
benchmark                                       old ns/op     new ns/op     delta
BenchmarkDecodeBlock_Float_Empty-8              42530         35008         -17.69%
BenchmarkDecodeBlock_Float_EqualSize-8          39902         32206         -19.29%
BenchmarkDecodeBlock_Float_TypeSpecific-8       29570         22632         -23.46%
BenchmarkDecodeBlock_Integer_Empty-8            32222         24617         -23.60%
BenchmarkDecodeBlock_Integer_EqualSize-8        29290         21661         -26.05%
BenchmarkDecodeBlock_Integer_TypeSpecific-8     18852         11423         -39.41%
BenchmarkDecodeBlock_Boolean_Empty-8            27943         20535         -26.51%
BenchmarkDecodeBlock_Boolean_EqualSize-8        25809         18142         -29.71%
BenchmarkDecodeBlock_Boolean_TypeSpecific-8     15100         7427          -50.81%
BenchmarkDecodeBlock_String_Empty-8             95612         87524         -8.46%
BenchmarkDecodeBlock_String_EqualSize-8         92865         84970         -8.50%
BenchmarkDecodeBlock_String_TypeSpecific-8      78228         69231         -11.50%

benchmark                                       old allocs     new allocs     delta
BenchmarkDecodeBlock_Float_Empty-8              24             13             -45.83%
BenchmarkDecodeBlock_Float_EqualSize-8          23             12             -47.83%
BenchmarkDecodeBlock_Float_TypeSpecific-8       12             1              -91.67%
BenchmarkDecodeBlock_Integer_Empty-8            25             14             -44.00%
BenchmarkDecodeBlock_Integer_EqualSize-8        24             13             -45.83%
BenchmarkDecodeBlock_Integer_TypeSpecific-8     13             2              -84.62%
BenchmarkDecodeBlock_Boolean_Empty-8            24             13             -45.83%
BenchmarkDecodeBlock_Boolean_EqualSize-8        23             12             -47.83%
BenchmarkDecodeBlock_Boolean_TypeSpecific-8     12             1              -91.67%
BenchmarkDecodeBlock_String_Empty-8             1025           1014           -1.07%
BenchmarkDecodeBlock_String_EqualSize-8         1024           1013           -1.07%
BenchmarkDecodeBlock_String_TypeSpecific-8      1013           1002           -1.09%

benchmark                                       old bytes     new bytes     delta
BenchmarkDecodeBlock_Float_Empty-8              67562         51186         -24.24%
BenchmarkDecodeBlock_Float_EqualSize-8          51178         34801         -32.00%
BenchmarkDecodeBlock_Float_TypeSpecific-8       18424         2048          -88.88%
BenchmarkDecodeBlock_Integer_Empty-8            69610         53234         -23.53%
BenchmarkDecodeBlock_Integer_EqualSize-8        53226         36849         -30.77%
BenchmarkDecodeBlock_Integer_TypeSpecific-8     20472         4096          -79.99%
BenchmarkDecodeBlock_Boolean_Empty-8            67562         51186         -24.24%
BenchmarkDecodeBlock_Boolean_EqualSize-8        51177         34801         -32.00%
BenchmarkDecodeBlock_Boolean_TypeSpecific-8     18424         2048          -88.88%
BenchmarkDecodeBlock_String_Empty-8             109644        93267         -14.94%
BenchmarkDecodeBlock_String_EqualSize-8         93259         76883         -17.56%
BenchmarkDecodeBlock_String_TypeSpecific-8      44121         27745         -37.12%
```

@benbjohnson 
