### PR TITLE
Fix panic in shard.DiskSize()

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -237,6 +237,10 @@ func (s *Shard) closed() bool {
 func (s *Shard) DiskSize() (int64, error) {
 	var size int64
 	err := filepath.Walk(s.path, func(_ string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if !fi.IsDir() {
 			size += fi.Size()
 		}
@@ -247,6 +251,10 @@ func (s *Shard) DiskSize() (int64, error) {
 	}
 
 	err = filepath.Walk(s.walPath, func(_ string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if !fi.IsDir() {
 			size += fi.Size()
 		}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

If the wal or data dir is not accessible (possibly deleted), the
`DiskSize` walk funcs could panic because they did not check the
error passed in.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x25b0ca]

goroutine 6 [running]:
panic(0x77e4a0, 0xc82000a0e0)
	/usr/local/go/src/runtime/panic.go:481 +0x3e6
github.com/influxdata/influxdb/tsdb.(*Shard).DiskSize.func1(0xc82015eed0, 0x2c, 0x0, 0x0, 0x1905640, 0xc82c296030, 0x0, 0x0)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:240 +0x3a
path/filepath.Walk(0xc82015eed0, 0x2c, 0xc82ba07c00, 0x0, 0x0)
	/usr/local/go/src/path/filepath/path.go:394 +0xa5
github.com/influxdata/influxdb/tsdb.(*Shard).DiskSize(0xc820160ea0, 0xc82006c2a0, 0x0, 0x0)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:239 +0xa4
github.com/influxdata/influxdb/tsdb.(*Shard).monitorSize(0xc820160ea0)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:624 +0x146
created by github.com/influxdata/influxdb/tsdb.(*Shard).Open.func1
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:188 +0x56f
```