### PR TITLE
Fix for the parallel iterator

### DIFF
--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -468,7 +468,7 @@ func (itr *floatParallelIterator) Close() error {
 func (itr *floatParallelIterator) Next() (*FloatPoint, error) {
 	v, ok := <-itr.ch
 	if !ok {
-		return nil, io.EOF
+		return nil, nil
 	}
 	return v.point, v.err
 }
@@ -485,6 +485,9 @@ func (itr *floatParallelIterator) monitor() {
 		case <-itr.closing:
 			return
 		case itr.ch <- floatPointError{point: p, err: err}:
+			if p == nil || err != nil {
+				return
+			}
 		}
 	}
 }
@@ -2474,7 +2477,7 @@ func (itr *integerParallelIterator) Close() error {
 func (itr *integerParallelIterator) Next() (*IntegerPoint, error) {
 	v, ok := <-itr.ch
 	if !ok {
-		return nil, io.EOF
+		return nil, nil
 	}
 	return v.point, v.err
 }
@@ -2491,6 +2494,9 @@ func (itr *integerParallelIterator) monitor() {
 		case <-itr.closing:
 			return
 		case itr.ch <- integerPointError{point: p, err: err}:
+			if p == nil || err != nil {
+				return
+			}
 		}
 	}
 }
@@ -4477,7 +4483,7 @@ func (itr *stringParallelIterator) Close() error {
 func (itr *stringParallelIterator) Next() (*StringPoint, error) {
 	v, ok := <-itr.ch
 	if !ok {
-		return nil, io.EOF
+		return nil, nil
 	}
 	return v.point, v.err
 }
@@ -4494,6 +4500,9 @@ func (itr *stringParallelIterator) monitor() {
 		case <-itr.closing:
 			return
 		case itr.ch <- stringPointError{point: p, err: err}:
+			if p == nil || err != nil {
+				return
+			}
 		}
 	}
 }
@@ -6480,7 +6489,7 @@ func (itr *booleanParallelIterator) Close() error {
 func (itr *booleanParallelIterator) Next() (*BooleanPoint, error) {
 	v, ok := <-itr.ch
 	if !ok {
-		return nil, io.EOF
+		return nil, nil
 	}
 	return v.point, v.err
 }
@@ -6497,6 +6506,9 @@ func (itr *booleanParallelIterator) monitor() {
 		case <-itr.closing:
 			return
 		case itr.ch <- booleanPointError{point: p, err: err}:
+			if p == nil || err != nil {
+				return
+			}
 		}
 	}
 }

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -466,7 +466,7 @@ func (itr *{{$k.name}}ParallelIterator) Close() error {
 func (itr *{{$k.name}}ParallelIterator) Next() (*{{$k.Name}}Point, error) {
 	v, ok := <-itr.ch
 	if !ok {
-		return nil, io.EOF
+		return nil, nil
 	}
 	return v.point, v.err
 }
@@ -478,11 +478,14 @@ func (itr *{{$k.name}}ParallelIterator) monitor()  {
 	for {
 		// Read next point.
 		p, err := itr.input.Next()
-		
+
 		select {
 		case <-itr.closing:
 			return
 		case itr.ch <- {{$k.name}}PointError{point: p, err: err}:
+			if p == nil || err != nil {
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
The parallel iterator logic was wrong and it caused the call to `Next()`
to stall forever and for the `monitor()` goroutine to also wait forever
in a deadlock.

Fixed the logic so the `monitor()` goroutine exits when there are no
more points to read.