### PR TITLE
Reduce allocations on Query's io.Stringer implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#6655](https://github.com/influxdata/influxdb/issues/6655): Add HTTP(s) based subscriptions.
 - [#5906](https://github.com/influxdata/influxdb/issues/5906): Dynamically update the documentation link in the admin UI.
 - [#6686](https://github.com/influxdata/influxdb/pull/6686): Optimize timestamp run-length decoding
+- [#6713](https://github.com/influxdata/influxdb/pull/6713): Reduce allocations during query parsing.
 
 ### Bugfixes
 

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/influxdata/influxdb/influxql"
 )
 
+func BenchmarkQuery_String(b *testing.B) {
+	p := influxql.NewParser(strings.NewReader(`SELECT foo AS zoo, a AS b FROM bar WHERE value > 10 AND q = 'hello'`))
+	q, _ := p.ParseStatement()
+	for i := 0; i < b.N; i++ {
+		_ = q.String()
+	}
+}
+
 // Ensure a value's data type can be retrieved.
 func TestInspectDataType(t *testing.T) {
 	for i, tt := range []struct {

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2680,15 +2680,18 @@ func (p *Parser) parseTokenMaybe(expected Token) bool {
 	return true
 }
 
+var (
+	qsReplacer = strings.NewReplacer("\n", `\n`, `\`, `\\`, `'`, `\'`)
+	qiReplacer = strings.NewReplacer("\n", `\n`, `\`, `\\`, `"`, `\"`)
+)
+
 // QuoteString returns a quoted string.
 func QuoteString(s string) string {
-	return `'` + strings.NewReplacer("\n", `\n`, `\`, `\\`, `'`, `\'`).Replace(s) + `'`
+	return `'` + qsReplacer.Replace(s) + `'`
 }
 
 // QuoteIdent returns a quoted identifier from multiple bare identifiers.
 func QuoteIdent(segments ...string) string {
-	r := strings.NewReplacer("\n", `\n`, `\`, `\\`, `"`, `\"`)
-
 	var buf bytes.Buffer
 	for i, segment := range segments {
 		needQuote := IdentNeedsQuotes(segment) ||
@@ -2698,7 +2701,7 @@ func QuoteIdent(segments ...string) string {
 			_ = buf.WriteByte('"')
 		}
 
-		_, _ = buf.WriteString(r.Replace(segment))
+		_, _ = buf.WriteString(qiReplacer.Replace(segment))
 
 		if needQuote {
 			_ = buf.WriteByte('"')


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

A query's String method can be called multiple times per query. This commit
ensures all calls to query.String share use of a strings.NewReplacer rather than allocating one per call. A `strings.Replacer` is safe for concurrent use by multiple goroutines.

This approximately halves the number of allocations for the included benchmark.

```
BenchmarkQuery_String-4         	  100000	     23209 ns/op	   51841 B/op	      98 allocs/op
```

to

```
BenchmarkQuery_String-4         	  300000	      5545 ns/op	    2304 B/op	      58 allocs/op
```