### PR TITLE
mutex lock around measurement field map access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [#6693](https://github.com/influxdata/influxdb/pull/6693): Truncate the shard group end time if it exceeds MaxNanoTime.
 - [#6672](https://github.com/influxdata/influxdb/issues/6672): Accept points with trailing whitespace.
 - [#6599](https://github.com/influxdata/influxdb/issues/6599): Ensure that future points considered in SHOW queries.
+- [#6720](https://github.com/influxdata/influxdb/issues/6720): Concurrent map read write panic. Thanks @arussellsaw
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -164,24 +164,25 @@ func (s *Shard) Open() error {
 		if err != nil {
 			return err
 		}
-		s.engine = e
 
 		// Set log output on the engine.
-		s.engine.SetLogOutput(s.LogOutput)
+		e.SetLogOutput(s.LogOutput)
 
 		// Open engine.
-		if err := s.engine.Open(); err != nil {
+		if err := e.Open(); err != nil {
 			return err
 		}
 
 		// Load metadata index.
 		start := time.Now()
-		if err := s.engine.LoadMetadataIndex(s.id, s.index); err != nil {
+		if err := e.LoadMetadataIndex(s.id, s.index); err != nil {
 			return err
 		}
 
 		count := s.index.SeriesShardN(s.id)
 		s.statMap.Add(statSeriesCreate, int64(count))
+
+		s.engine = e
 
 		s.logger.Printf("%s database index loaded in %s", s.path, time.Now().Sub(start))
 


### PR DESCRIPTION
fix for https://github.com/influxdata/influxdb/issues/6720
CLA is signed

