### PR TITLE
Correct stress/v2 tests to not depend on $GOPATH

### DIFF
--- a/stress/v2/stressql/parser_test.go
+++ b/stress/v2/stressql/parser_test.go
@@ -1,18 +1,10 @@
 package stressql
 
-import (
-	"fmt"
-	"os"
-	"testing"
-)
+import "testing"
 
 // Pulls the default configFile and makes sure it parses
 func TestParseStatements(t *testing.T) {
-	gopath := os.Getenv("GOPATH")
-	if gopath == "" {
-		t.Error("$GOPATH not set")
-	}
-	stmts, err := ParseStatements(fmt.Sprintf("%v/src/github.com/influxdata/influxdb/stress/v2/file.iql", gopath))
+	stmts, err := ParseStatements("../file.iql")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
The test assumed that you were working within a single directory
$GOPATH. `go test` actually sets the current directory to the directory
of the package being tested, so the relative path to the test file could
be used instead.

/cc @jackzampolin 