### PR TITLE
Fix overflow in window iterator and holt winters roundTime

### DIFF
--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -23,7 +23,7 @@ const (
 
 	// MaxTime is used as the maximum time value when computing an unbounded range.
 	// This time is Jan 1, 2050 at midnight UTC.
-	MaxTime = models.MaxNanoTime
+	MaxTime = models.MaxNanoTime - 1
 )
 
 // Iterator represents a generic interface for all Iterators.

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -22,7 +22,7 @@ const (
 	MinTime = int64(0)
 
 	// MaxTime is used as the maximum time value when computing an unbounded range.
-	// This time is Jan 1, 2050 at midnight UTC.
+	// This time is 2262-04-11 23:47:16.854775806 +0000 UTC
 	MaxTime = models.MaxNanoTime - 1
 )
 


### PR DESCRIPTION
This is a patch against @e-dard's #6675. It fixes overflows in the window iterator and the holt winters round time function.