### PR TITLE
Switch backup to use shard.Snapshot

### DIFF
--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -273,6 +273,16 @@ func (cmd *Command) downloadAndVerify(req *snapshotter.Request, path string, val
 		}
 	}
 
+	f, err := os.Stat(tmppath)
+	if err != nil {
+		return err
+	}
+
+	// There was nothing downloaded, don't create an empty backup file.
+	if f.Size() == 0 {
+		return os.Remove(tmppath)
+	}
+
 	// Rename temporary file to final path.
 	if err := os.Rename(tmppath, path); err != nil {
 		return fmt.Errorf("rename: %s", err)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This switch the backup shard call to use the shard Snapshot that
internally creates a snapshot by hardlinking all of the TSM and
tombstone files instead.  This reduces the time that the FileStore
is locked and will allow for larger shards to be backup more easily.

@corylanou 