### PR TITLE
Optimize series key parsing on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [#6599](https://github.com/influxdata/influxdb/issues/6599): Ensure that future points considered in SHOW queries.
 - [#6720](https://github.com/influxdata/influxdb/issues/6720): Concurrent map read write panic. Thanks @arussellsaw
 - [#6727](https://github.com/influxdata/influxdb/issues/6727): queries with strings that look like dates end up with date types, not string types
+- [#6250](https://github.com/influxdata/influxdb/issues/6250): Slow startup time
 
 ## v0.13.0 [2016-05-12]
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -112,6 +112,13 @@ func BenchmarkParsePointsTagsUnSorted10(b *testing.B) {
 	}
 }
 
+func BenchmarkParseKey(b *testing.B) {
+	line := `cpu,region=us-west,host=serverA,env=prod,target=servers,zone=1c,tag1=value1,tag2=value2,tag3=value3,tag4=value4,tag5=value5`
+	for i := 0; i < b.N; i++ {
+		models.ParseKey(line)
+	}
+}
+
 // TestPoint wraps a models.Point but also makes available the raw
 // arguments to the Point.
 //

--- a/pkg/escape/strings.go
+++ b/pkg/escape/strings.go
@@ -20,6 +20,10 @@ func init() {
 }
 
 func UnescapeString(in string) string {
+	if strings.IndexByte(in, '\\') == -1 {
+		return in
+	}
+
 	for b, esc := range codesStr {
 		in = strings.Replace(in, esc, b, -1)
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This optimizes the `ParseKey` func to help speed up startup times for shards with many keys or very long keys. This should help #6250 in some cases.  `ParseKey` is called for every key when reloading the WAL and TSM file indexes.  The main change is avoiding calling the unescape funcs for tag keys and values which always returned a new string even if there was nothing escaped.  We also quickly scan the key to see if we might need to unescape anything and skip all of those calls if we don't need to.  The remaining allocation time is creating the tags map.  The tags map is really just a temporary holder to allow the tags to be indexed.  We could rework this further to avoid that map altogether and parse the key directly into the index structures.

```
benchmark               old ns/op     new ns/op     delta
BenchmarkParseKey-8     5621          2050          -63.53%

benchmark               old allocs     new allocs     delta
BenchmarkParseKey-8     25             24             -4.00%

benchmark               old bytes     new bytes     delta
BenchmarkParseKey-8     1318          1030          -21.85%
```