### PR TITLE
Add ability to disable shards

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -43,6 +43,7 @@ type Engine interface {
 	SeriesCount() (n int, err error)
 	MeasurementFields(measurement string) *MeasurementFields
 	CreateSnapshot() (string, error)
+	SetEnabled(enabled bool)
 
 	// Format will return the format for the engine
 	Format() EngineFormat

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/influxdata/influxdb/tsdb"
@@ -406,17 +407,49 @@ func (c *DefaultPlanner) findGenerations() tsmGenerations {
 // Compactor merges multiple TSM files into new files or
 // writes a Cache into 1 or more TSM files
 type Compactor struct {
-	Dir    string
-	Cancel chan struct{}
-	Size   int
+	Dir  string
+	Size int
 
 	FileStore interface {
 		NextGeneration() int
 	}
+
+	mu      sync.RWMutex
+	opened  bool
+	closing chan struct{}
+}
+
+func (c *Compactor) Open() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.opened {
+		return
+	}
+
+	c.closing = make(chan struct{})
+	c.opened = true
+}
+
+func (c *Compactor) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.opened {
+		return
+	}
+	c.opened = false
+	close(c.closing)
 }
 
 // WriteSnapshot will write a Cache snapshot to a new TSM files.
 func (c *Compactor) WriteSnapshot(cache *Cache) ([]string, error) {
+	c.mu.RLock()
+	opened := c.opened
+	c.mu.RUnlock()
+
+	if !opened {
+		return nil, fmt.Errorf("snapshots disabled")
+	}
+
 	iter := NewCacheKeyIterator(cache, tsdb.DefaultMaxPointsPerBlock)
 	return c.writeNewFiles(c.FileStore.NextGeneration(), 0, iter)
 }
@@ -477,21 +510,28 @@ func (c *Compactor) compact(fast bool, tsmFiles []string) ([]string, error) {
 
 // Compact will write multiple smaller TSM files into 1 or more larger files
 func (c *Compactor) CompactFull(tsmFiles []string) ([]string, error) {
+	c.mu.RLock()
+	opened := c.opened
+	c.mu.RUnlock()
+
+	if !opened {
+		return nil, fmt.Errorf("compactions disabled")
+	}
+
 	return c.compact(false, tsmFiles)
 }
 
 // Compact will write multiple smaller TSM files into 1 or more larger files
 func (c *Compactor) CompactFast(tsmFiles []string) ([]string, error) {
-	return c.compact(true, tsmFiles)
-}
+	c.mu.RLock()
+	opened := c.opened
+	c.mu.RUnlock()
 
-// Clone will return a new compactor that can be used even if the engine is closed
-func (c *Compactor) Clone() *Compactor {
-	return &Compactor{
-		Dir:       c.Dir,
-		FileStore: c.FileStore,
-		Cancel:    c.Cancel,
+	if !opened {
+		return nil, fmt.Errorf("compactions disabled")
 	}
+
+	return c.compact(true, tsmFiles)
 }
 
 // writeNewFiles will write from the iterator into new TSM files, rotating
@@ -560,11 +600,14 @@ func (c *Compactor) write(path string, iter KeyIterator) (err error) {
 	}()
 
 	for iter.Next() {
+		c.mu.RLock()
 		select {
-		case <-c.Cancel:
+		case <-c.closing:
+			c.mu.RUnlock()
 			return fmt.Errorf("compaction aborted")
 		default:
 		}
+		c.mu.RUnlock()
 
 		// Each call to read returns the next sorted key (or the prior one if there are
 		// more values to write).  The size of values will be less than or equal to our

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -39,6 +39,17 @@ func TestCompactor_Snapshot(t *testing.T) {
 	}
 
 	files, err := compactor.WriteSnapshot(c)
+	if err == nil {
+		t.Fatalf("expected error writing snapshot: %v", err)
+	}
+	if len(files) > 0 {
+		t.Fatalf("no files should be compacted: got %v", len(files))
+
+	}
+
+	compactor.Open()
+
+	files, err = compactor.WriteSnapshot(c)
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -111,6 +122,17 @@ func TestCompactor_CompactFull(t *testing.T) {
 	}
 
 	files, err := compactor.CompactFull([]string{f1, f2, f3})
+	if err == nil {
+		t.Fatalf("expected error writing snapshot: %v", err)
+	}
+	if len(files) > 0 {
+		t.Fatalf("no files should be compacted: got %v", len(files))
+
+	}
+
+	compactor.Open()
+
+	files, err = compactor.CompactFull([]string{f1, f2, f3})
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}
@@ -199,6 +221,7 @@ func TestCompactor_CompactFull_SkipFullBlocks(t *testing.T) {
 		FileStore: &fakeFileStore{},
 		Size:      2,
 	}
+	compactor.Open()
 
 	files, err := compactor.CompactFull([]string{f1, f2, f3})
 	if err != nil {
@@ -297,6 +320,7 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 		FileStore: &fakeFileStore{},
 		Size:      2,
 	}
+	compactor.Open()
 
 	files, err := compactor.CompactFull([]string{f1, f2, f3})
 	if err != nil {
@@ -396,6 +420,7 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 		FileStore: &fakeFileStore{},
 		Size:      2,
 	}
+	compactor.Open()
 
 	files, err := compactor.CompactFull([]string{f1, f2, f3})
 	if err != nil {
@@ -500,6 +525,7 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 		FileStore: &fakeFileStore{},
 		Size:      2,
 	}
+	compactor.Open()
 
 	files, err := compactor.CompactFull([]string{f1, f2, f3})
 	if err != nil {
@@ -611,6 +637,7 @@ func TestCompactor_CompactFull_MaxKeys(t *testing.T) {
 		Dir:       dir,
 		FileStore: &fakeFileStore{},
 	}
+	compactor.Open()
 
 	// Compact both files, should get 2 files back
 	files, err := compactor.CompactFull([]string{f1Name, f2Name})

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -320,6 +320,16 @@ func (s *Store) CreateShardSnapshot(id uint64) (string, error) {
 	return sh.CreateSnapshot()
 }
 
+// SetShardEnabled enables or disables a shard for read and writes
+func (s *Store) SetShardEnabled(shardID uint64, enabled bool) error {
+	sh := s.Shard(shardID)
+	if sh == nil {
+		return ErrShardNotFound
+	}
+	sh.SetEnabled(enabled)
+	return nil
+}
+
 // DeleteShard removes a shard from disk.
 func (s *Store) DeleteShard(shardID uint64) error {
 	s.mu.Lock()


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

Disabling a shard causes all reads and writes to a query to return
and error.  This also disables compactions for the shard.

This capability is only added to the `tsdb.Store` and is not exposed anywhere else.

@corylanou 