### PR TITLE
Low-contention path for pre-existing cache entries.

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -455,8 +455,20 @@ func (c *Cache) write(key string, values []Value) {
 }
 
 func (c *Cache) entry(key string) *entry {
-	c.mu.Lock()
+	// low-contention path: entry exists, no write operations needed:
+	c.mu.RLock()
 	e, ok := c.store[key]
+	if ok {
+		c.mu.RUnlock()
+		return e
+	}
+	c.mu.RUnlock()
+
+	// high-contention path: entry doesn't exist (probably), create a new
+	// one after checking again:
+	c.mu.Lock()
+
+	e, ok = c.store[key]
 	if !ok {
 		e = newEntry()
 		c.store[key] = e

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -458,11 +458,11 @@ func (c *Cache) entry(key string) *entry {
 	// low-contention path: entry exists, no write operations needed:
 	c.mu.RLock()
 	e, ok := c.store[key]
+	c.mu.RUnlock()
+
 	if ok {
-		c.mu.RUnlock()
 		return e
 	}
-	c.mu.RUnlock()
 
 	// high-contention path: entry doesn't exist (probably), create a new
 	// one after checking again:
@@ -473,7 +473,9 @@ func (c *Cache) entry(key string) *entry {
 		e = newEntry()
 		c.store[key] = e
 	}
+
 	c.mu.Unlock()
+
 	return e
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This change appears to increase bulk ingestion throughput by 2x-3x in
multiprocessor environments.