### PR TITLE
Prevent ReadFloatBlock from panicking when no values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - [#6720](https://github.com/influxdata/influxdb/issues/6720): Concurrent map read write panic. Thanks @arussellsaw
 - [#6727](https://github.com/influxdata/influxdb/issues/6727): queries with strings that look like dates end up with date types, not string types
 - [#6250](https://github.com/influxdata/influxdb/issues/6250): Slow startup time
+- [#6753](https://github.com/influxdata/influxdb/issues/6753): Prevent panic if there are no values.
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/engine/tsm1/file_store.gen.go
+++ b/tsdb/engine/tsm1/file_store.gen.go
@@ -25,6 +25,11 @@ func (c *KeyCursor) ReadFloatBlock(tdec *TimeDecoder, vdec *FloatDecoder, buf *[
 	tombstones := first.r.TombstoneRange(c.key)
 	values = c.filterFloatValues(tombstones, values)
 
+	// Check we have remaining values.
+	if len(values) == 0 {
+		return nil, nil
+	}
+
 	// Only one block with this key and time range so return it
 	if len(c.current) == 1 {
 		if len(values) > 0 {
@@ -154,6 +159,11 @@ func (c *KeyCursor) ReadIntegerBlock(tdec *TimeDecoder, vdec *IntegerDecoder, bu
 	// Remove any tombstones
 	tombstones := first.r.TombstoneRange(c.key)
 	values = c.filterIntegerValues(tombstones, values)
+
+	// Check we have remaining values.
+	if len(values) == 0 {
+		return nil, nil
+	}
 
 	// Only one block with this key and time range so return it
 	if len(c.current) == 1 {
@@ -285,6 +295,11 @@ func (c *KeyCursor) ReadStringBlock(tdec *TimeDecoder, vdec *StringDecoder, buf 
 	tombstones := first.r.TombstoneRange(c.key)
 	values = c.filterStringValues(tombstones, values)
 
+	// Check we have remaining values.
+	if len(values) == 0 {
+		return nil, nil
+	}
+
 	// Only one block with this key and time range so return it
 	if len(c.current) == 1 {
 		if len(values) > 0 {
@@ -414,6 +429,11 @@ func (c *KeyCursor) ReadBooleanBlock(tdec *TimeDecoder, vdec *BooleanDecoder, bu
 	// Remove any tombstones
 	tombstones := first.r.TombstoneRange(c.key)
 	values = c.filterBooleanValues(tombstones, values)
+
+	// Check we have remaining values.
+	if len(values) == 0 {
+		return nil, nil
+	}
 
 	// Only one block with this key and time range so return it
 	if len(c.current) == 1 {

--- a/tsdb/engine/tsm1/file_store.gen.go.tmpl
+++ b/tsdb/engine/tsm1/file_store.gen.go.tmpl
@@ -20,6 +20,11 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 	tombstones := first.r.TombstoneRange(c.key)
 	values = c.filter{{.Name}}Values(tombstones, values)
 
+	// Check we have remaining values.
+	if len(values) == 0 {
+		return nil, nil
+	}
+
 	// Only one block with this key and time range so return it
 	if len(c.current) == 1 {
 		if len(values) > 0 {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Possible fix for #6753.

@jwilder Let me know if this is enough; I'm not familiar with the cursor stuff.
