### PR TITLE
Refactor ExecuteQuery to take options as a struct

### DIFF
--- a/coordinator/statement_executor_test.go
+++ b/coordinator/statement_executor_test.go
@@ -184,7 +184,10 @@ func DefaultQueryExecutor() *QueryExecutor {
 
 // ExecuteQuery parses query and executes against the database.
 func (e *QueryExecutor) ExecuteQuery(query, database string, chunkSize int) <-chan *influxql.Result {
-	return e.QueryExecutor.ExecuteQuery(MustParseQuery(query), database, chunkSize, false, make(chan struct{}))
+	return e.QueryExecutor.ExecuteQuery(MustParseQuery(query), influxql.ExecutionOptions{
+		Database:  database,
+		ChunkSize: chunkSize,
+	}, make(chan struct{}))
 }
 
 // TSDBStore is a mockable implementation of coordinator.TSDBStore.

--- a/influxql/internal/internal.pb.go
+++ b/influxql/internal/internal.pb.go
@@ -16,8 +16,6 @@ It has these top-level messages:
 	Measurement
 	Interval
 	IteratorStats
-	Series
-	SeriesList
 	VarRef
 */
 package influxql
@@ -431,54 +429,6 @@ func (m *IteratorStats) GetPointN() int64 {
 	return 0
 }
 
-type Series struct {
-	Name             *string  `protobuf:"bytes,1,opt,name=Name" json:"Name,omitempty"`
-	Tags             []byte   `protobuf:"bytes,2,opt,name=Tags" json:"Tags,omitempty"`
-	Aux              []uint32 `protobuf:"varint,3,rep,name=Aux" json:"Aux,omitempty"`
-	XXX_unrecognized []byte   `json:"-"`
-}
-
-func (m *Series) Reset()         { *m = Series{} }
-func (m *Series) String() string { return proto.CompactTextString(m) }
-func (*Series) ProtoMessage()    {}
-
-func (m *Series) GetName() string {
-	if m != nil && m.Name != nil {
-		return *m.Name
-	}
-	return ""
-}
-
-func (m *Series) GetTags() []byte {
-	if m != nil {
-		return m.Tags
-	}
-	return nil
-}
-
-func (m *Series) GetAux() []uint32 {
-	if m != nil {
-		return m.Aux
-	}
-	return nil
-}
-
-type SeriesList struct {
-	Items            []*Series `protobuf:"bytes,1,rep,name=Items" json:"Items,omitempty"`
-	XXX_unrecognized []byte    `json:"-"`
-}
-
-func (m *SeriesList) Reset()         { *m = SeriesList{} }
-func (m *SeriesList) String() string { return proto.CompactTextString(m) }
-func (*SeriesList) ProtoMessage()    {}
-
-func (m *SeriesList) GetItems() []*Series {
-	if m != nil {
-		return m.Items
-	}
-	return nil
-}
-
 type VarRef struct {
 	Val              *string `protobuf:"bytes,1,req,name=Val" json:"Val,omitempty"`
 	Type             *int32  `protobuf:"varint,2,opt,name=Type" json:"Type,omitempty"`
@@ -511,7 +461,5 @@ func init() {
 	proto.RegisterType((*Measurement)(nil), "influxql.Measurement")
 	proto.RegisterType((*Interval)(nil), "influxql.Interval")
 	proto.RegisterType((*IteratorStats)(nil), "influxql.IteratorStats")
-	proto.RegisterType((*Series)(nil), "influxql.Series")
-	proto.RegisterType((*SeriesList)(nil), "influxql.SeriesList")
 	proto.RegisterType((*VarRef)(nil), "influxql.VarRef")
 }

--- a/influxql/internal/internal.proto
+++ b/influxql/internal/internal.proto
@@ -66,16 +66,6 @@ message IteratorStats {
     optional int64 PointN  = 2;
 }
 
-message Series {
-    optional string Name = 1;
-    optional bytes  Tags = 2;
-    repeated uint32 Aux  = 3;
-}
-
-message SeriesList {
-    repeated Series Items = 1;
-}
-
 message VarRef {
     required string Val  = 1;
     optional int32  Type = 2;

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -750,6 +750,58 @@ func (itr *floatInterruptIterator) Next() (*FloatPoint, error) {
 	return itr.input.Next()
 }
 
+// floatCloseInterruptIterator represents a float implementation of CloseInterruptIterator.
+type floatCloseInterruptIterator struct {
+	input   FloatIterator
+	closing <-chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newFloatCloseInterruptIterator(input FloatIterator, closing <-chan struct{}) *floatCloseInterruptIterator {
+	itr := &floatCloseInterruptIterator{
+		input:   input,
+		closing: closing,
+		done:    make(chan struct{}),
+	}
+	go itr.monitor()
+	return itr
+}
+
+func (itr *floatCloseInterruptIterator) monitor() {
+	select {
+	case <-itr.closing:
+		itr.Close()
+	case <-itr.done:
+	}
+}
+
+func (itr *floatCloseInterruptIterator) Stats() IteratorStats {
+	return itr.input.Stats()
+}
+
+func (itr *floatCloseInterruptIterator) Close() error {
+	itr.once.Do(func() {
+		close(itr.done)
+		itr.input.Close()
+	})
+	return nil
+}
+
+func (itr *floatCloseInterruptIterator) Next() (*FloatPoint, error) {
+	p, err := itr.input.Next()
+	if err != nil {
+		// Check if the iterator was closed.
+		select {
+		case <-itr.done:
+			return nil, nil
+		default:
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
 // auxFloatPoint represents a combination of a point and an error for the AuxIterator.
 type auxFloatPoint struct {
 	point *FloatPoint
@@ -2756,6 +2808,58 @@ func (itr *integerInterruptIterator) Next() (*IntegerPoint, error) {
 	return itr.input.Next()
 }
 
+// integerCloseInterruptIterator represents a integer implementation of CloseInterruptIterator.
+type integerCloseInterruptIterator struct {
+	input   IntegerIterator
+	closing <-chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newIntegerCloseInterruptIterator(input IntegerIterator, closing <-chan struct{}) *integerCloseInterruptIterator {
+	itr := &integerCloseInterruptIterator{
+		input:   input,
+		closing: closing,
+		done:    make(chan struct{}),
+	}
+	go itr.monitor()
+	return itr
+}
+
+func (itr *integerCloseInterruptIterator) monitor() {
+	select {
+	case <-itr.closing:
+		itr.Close()
+	case <-itr.done:
+	}
+}
+
+func (itr *integerCloseInterruptIterator) Stats() IteratorStats {
+	return itr.input.Stats()
+}
+
+func (itr *integerCloseInterruptIterator) Close() error {
+	itr.once.Do(func() {
+		close(itr.done)
+		itr.input.Close()
+	})
+	return nil
+}
+
+func (itr *integerCloseInterruptIterator) Next() (*IntegerPoint, error) {
+	p, err := itr.input.Next()
+	if err != nil {
+		// Check if the iterator was closed.
+		select {
+		case <-itr.done:
+			return nil, nil
+		default:
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
 // auxIntegerPoint represents a combination of a point and an error for the AuxIterator.
 type auxIntegerPoint struct {
 	point *IntegerPoint
@@ -4759,6 +4863,58 @@ func (itr *stringInterruptIterator) Next() (*StringPoint, error) {
 	return itr.input.Next()
 }
 
+// stringCloseInterruptIterator represents a string implementation of CloseInterruptIterator.
+type stringCloseInterruptIterator struct {
+	input   StringIterator
+	closing <-chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newStringCloseInterruptIterator(input StringIterator, closing <-chan struct{}) *stringCloseInterruptIterator {
+	itr := &stringCloseInterruptIterator{
+		input:   input,
+		closing: closing,
+		done:    make(chan struct{}),
+	}
+	go itr.monitor()
+	return itr
+}
+
+func (itr *stringCloseInterruptIterator) monitor() {
+	select {
+	case <-itr.closing:
+		itr.Close()
+	case <-itr.done:
+	}
+}
+
+func (itr *stringCloseInterruptIterator) Stats() IteratorStats {
+	return itr.input.Stats()
+}
+
+func (itr *stringCloseInterruptIterator) Close() error {
+	itr.once.Do(func() {
+		close(itr.done)
+		itr.input.Close()
+	})
+	return nil
+}
+
+func (itr *stringCloseInterruptIterator) Next() (*StringPoint, error) {
+	p, err := itr.input.Next()
+	if err != nil {
+		// Check if the iterator was closed.
+		select {
+		case <-itr.done:
+			return nil, nil
+		default:
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
 // auxStringPoint represents a combination of a point and an error for the AuxIterator.
 type auxStringPoint struct {
 	point *StringPoint
@@ -6760,6 +6916,58 @@ func (itr *booleanInterruptIterator) Next() (*BooleanPoint, error) {
 	// Increment the counter for every point read.
 	itr.count++
 	return itr.input.Next()
+}
+
+// booleanCloseInterruptIterator represents a boolean implementation of CloseInterruptIterator.
+type booleanCloseInterruptIterator struct {
+	input   BooleanIterator
+	closing <-chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newBooleanCloseInterruptIterator(input BooleanIterator, closing <-chan struct{}) *booleanCloseInterruptIterator {
+	itr := &booleanCloseInterruptIterator{
+		input:   input,
+		closing: closing,
+		done:    make(chan struct{}),
+	}
+	go itr.monitor()
+	return itr
+}
+
+func (itr *booleanCloseInterruptIterator) monitor() {
+	select {
+	case <-itr.closing:
+		itr.Close()
+	case <-itr.done:
+	}
+}
+
+func (itr *booleanCloseInterruptIterator) Stats() IteratorStats {
+	return itr.input.Stats()
+}
+
+func (itr *booleanCloseInterruptIterator) Close() error {
+	itr.once.Do(func() {
+		close(itr.done)
+		itr.input.Close()
+	})
+	return nil
+}
+
+func (itr *booleanCloseInterruptIterator) Next() (*BooleanPoint, error) {
+	p, err := itr.input.Next()
+	if err != nil {
+		// Check if the iterator was closed.
+		select {
+		case <-itr.done:
+			return nil, nil
+		default:
+			return nil, err
+		}
+	}
+	return p, nil
 }
 
 // auxBooleanPoint represents a combination of a point and an error for the AuxIterator.

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -478,7 +478,7 @@ func (itr *{{$k.name}}ParallelIterator) monitor()  {
 	for {
 		// Read next point.
 		p, err := itr.input.Next()
-		
+
 		select {
 		case <-itr.closing:
 			return
@@ -746,6 +746,58 @@ func (itr *{{$k.name}}InterruptIterator) Next() (*{{$k.Name}}Point, error) {
 	// Increment the counter for every point read.
 	itr.count++
 	return itr.input.Next()
+}
+
+// {{$k.name}}CloseInterruptIterator represents a {{$k.name}} implementation of CloseInterruptIterator.
+type {{$k.name}}CloseInterruptIterator struct {
+	input   {{$k.Name}}Iterator
+	closing <-chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func new{{$k.Name}}CloseInterruptIterator(input {{$k.Name}}Iterator, closing <-chan struct{}) *{{$k.name}}CloseInterruptIterator {
+	itr := &{{$k.name}}CloseInterruptIterator{
+		input:   input,
+		closing: closing,
+		done:    make(chan struct{}),
+	}
+	go itr.monitor()
+	return itr
+}
+
+func (itr *{{$k.name}}CloseInterruptIterator) monitor() {
+	select {
+	case <-itr.closing:
+		itr.Close()
+	case <-itr.done:
+	}
+}
+
+func (itr *{{$k.name}}CloseInterruptIterator) Stats() IteratorStats {
+	return itr.input.Stats()
+}
+
+func (itr *{{$k.name}}CloseInterruptIterator) Close() error {
+	itr.once.Do(func() {
+		close(itr.done)
+		itr.input.Close()
+	})
+	return nil
+}
+
+func (itr *{{$k.name}}CloseInterruptIterator) Next() (*{{$k.Name}}Point, error) {
+	p, err := itr.input.Next()
+	if err != nil {
+		// Check if the iterator was closed.
+		select {
+		case <-itr.done:
+			return nil, nil
+		default:
+			return nil, err
+		}
+	}
+	return p, nil
 }
 
 // aux{{$k.Name}}Point represents a combination of a point and an error for the AuxIterator.

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -1004,30 +1004,6 @@ func TestIteratorOptions_MarshalBinary_Measurement_Regex(t *testing.T) {
 	}
 }
 
-// Ensure series list can be marshaled into and out of a binary format.
-func TestSeriesList_MarshalBinary(t *testing.T) {
-	a := []influxql.Series{
-		{Name: "cpu", Tags: ParseTags("foo=bar"), Aux: []influxql.DataType{influxql.Float, influxql.String}},
-		{Name: "mem", Aux: []influxql.DataType{influxql.Integer}},
-		{Name: "disk"},
-		{},
-	}
-
-	// Marshal to binary.
-	buf, err := influxql.SeriesList(a).MarshalBinary()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Unmarshal back to an object.
-	var other influxql.SeriesList
-	if err := other.UnmarshalBinary(buf); err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(other, influxql.SeriesList(a)) {
-		t.Fatalf("unexpected series list: %s", spew.Sdump(other))
-	}
-}
-
 // Ensure iterator can be encoded and decoded over a byte stream.
 func TestIterator_EncodeDecode(t *testing.T) {
 	var buf bytes.Buffer
@@ -1052,10 +1028,7 @@ func TestIterator_EncodeDecode(t *testing.T) {
 	}
 
 	// Decode from the buffer.
-	dec, err := influxql.NewReaderIterator(&buf, influxql.Float, itr.Stats())
-	if err != nil {
-		t.Fatal(err)
-	}
+	dec := influxql.NewReaderIterator(&buf, influxql.Float, itr.Stats())
 
 	// Initial stats should exist immediately.
 	fdec := dec.(influxql.FloatIterator)

--- a/influxql/query_executor_test.go
+++ b/influxql/query_executor_test.go
@@ -39,7 +39,7 @@ func TestQueryExecutor_AttachQuery(t *testing.T) {
 		},
 	}
 
-	discardOutput(e.ExecuteQuery(q, "mydb", 100, false, nil))
+	discardOutput(e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil))
 }
 
 func TestQueryExecutor_KillQuery(t *testing.T) {
@@ -64,12 +64,12 @@ func TestQueryExecutor_KillQuery(t *testing.T) {
 		},
 	}
 
-	results := e.ExecuteQuery(q, "mydb", 100, false, nil)
+	results := e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil)
 	q, err = influxql.ParseQuery(fmt.Sprintf("KILL QUERY %d", <-qid))
 	if err != nil {
 		t.Fatal(err)
 	}
-	discardOutput(e.ExecuteQuery(q, "mydb", 100, false, nil))
+	discardOutput(e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil))
 
 	result := <-results
 	if result.Err != influxql.ErrQueryInterrupted {
@@ -97,7 +97,7 @@ func TestQueryExecutor_Interrupt(t *testing.T) {
 	}
 
 	closing := make(chan struct{})
-	results := e.ExecuteQuery(q, "mydb", 100, false, closing)
+	results := e.ExecuteQuery(q, influxql.ExecutionOptions{}, closing)
 	close(closing)
 	result := <-results
 	if result.Err != influxql.ErrQueryInterrupted {
@@ -124,7 +124,7 @@ func TestQueryExecutor_ShowQueries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	results := e.ExecuteQuery(q, "", 100, false, nil)
+	results := e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil)
 	result := <-results
 	if len(result.Series) != 1 {
 		t.Errorf("expected %d rows, got %d", 1, len(result.Series))
@@ -154,7 +154,7 @@ func TestQueryExecutor_Limit_Timeout(t *testing.T) {
 	}
 	e.QueryTimeout = time.Nanosecond
 
-	results := e.ExecuteQuery(q, "mydb", 100, false, nil)
+	results := e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil)
 	result := <-results
 	if result.Err != influxql.ErrQueryTimeoutReached {
 		t.Errorf("unexpected error: %s", result.Err)
@@ -181,11 +181,11 @@ func TestQueryExecutor_Limit_ConcurrentQueries(t *testing.T) {
 	defer e.Close()
 
 	// Start first query and wait for it to be executing.
-	go discardOutput(e.ExecuteQuery(q, "mydb", 100, false, nil))
+	go discardOutput(e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil))
 	<-qid
 
 	// Start second query and expect for it to fail.
-	results := e.ExecuteQuery(q, "mydb", 100, false, nil)
+	results := e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil)
 
 	select {
 	case result := <-results:
@@ -219,7 +219,7 @@ func TestQueryExecutor_Close(t *testing.T) {
 		},
 	}
 
-	results := e.ExecuteQuery(q, "mydb", 100, false, nil)
+	results := e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil)
 	go func(results <-chan *influxql.Result) {
 		result := <-results
 		if result.Err != influxql.ErrQueryEngineShutdown {
@@ -240,7 +240,7 @@ func TestQueryExecutor_Close(t *testing.T) {
 		t.Error("closing the query manager did not kill the query after 100 milliseconds")
 	}
 
-	results = e.ExecuteQuery(q, "mydb", 100, false, nil)
+	results = e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil)
 	result := <-results
 	if len(result.Series) != 0 {
 		t.Errorf("expected %d rows, got %d", 0, len(result.Series))
@@ -263,7 +263,7 @@ func TestQueryExecutor_Panic(t *testing.T) {
 		},
 	}
 
-	results := e.ExecuteQuery(q, "mydb", 100, false, nil)
+	results := e.ExecuteQuery(q, influxql.ExecutionOptions{}, nil)
 	result := <-results
 	if len(result.Series) != 0 {
 		t.Errorf("expected %d rows, got %d", 0, len(result.Series))

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -334,7 +334,9 @@ func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) error {
 	defer close(closing)
 
 	// Execute the SELECT.
-	ch := s.QueryExecutor.ExecuteQuery(q, cq.Database, NoChunkingSize, false, closing)
+	ch := s.QueryExecutor.ExecuteQuery(q, influxql.ExecutionOptions{
+		Database: cq.Database,
+	}, closing)
 
 	// There is only one statement, so we will only ever receive one result
 	res, ok := <-ch

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -364,8 +364,11 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 	// Execute query.
 	w.Header().Add("Connection", "close")
 	w.Header().Add("Content-Type", "application/json")
-	readonly := r.Method == "GET"
-	results := h.QueryExecutor.ExecuteQuery(query, db, chunkSize, readonly, closing)
+	results := h.QueryExecutor.ExecuteQuery(query, influxql.ExecutionOptions{
+		Database:  db,
+		ChunkSize: chunkSize,
+		ReadOnly:  r.Method == "GET",
+	}, closing)
 
 	// if we're not chunking, this will be the in memory buffer for all results before sending to client
 	resp := Response{Results: make([]*influxql.Result, 0)}


### PR DESCRIPTION
This allows us to add additional options to ExecuteQuery without
creating parameter bloat.

Removing the unused Series structs. Their necessity was removed by a
previous commit, but the structs were not removed yet.

Add another type of interrupt iterator that monitors the interrupt
channel and calls `Close()` on the iterator when the interrupt happens.
It will primarily be used for asynchronously closing the ReaderIterator,
but it will only close the read side of the connection properly. More
work needs to be done to allow closing the write side efficiently.