### PR TITLE
Fix sporadic write failures with influx_stress

### DIFF
--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -139,11 +139,11 @@ func (d *DatabaseIndex) CreateSeriesIndexIfNotExists(measurementName string, ser
 
 	series.measurement = m
 	d.series[series.Key] = series
-	d.mu.Unlock()
 
 	m.AddSeries(series)
 
 	d.statMap.Add(statDatabaseSeries, 1)
+	d.mu.Unlock()
 
 	return series
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

This Unlock was moved in ff14472 which seems to create a lock contention situation
sometimes under high write load.  This contention causes writes to
fail with timeouts.