### PR TITLE
Perform a proper exit for the reportServer goroutine

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -345,14 +345,17 @@ func (s *Server) Close() error {
 
 // startServerReporting starts periodic server reporting.
 func (s *Server) startServerReporting() {
+	s.reportServer()
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-s.closing:
 			return
-		default:
+		case <-ticker.C:
+			s.reportServer()
 		}
-		s.reportServer()
-		<-time.After(24 * time.Hour)
 	}
 }
 


### PR DESCRIPTION
Previously, the goroutine would block for 24 hours and would only check
every 24 hours if the server was closed. Since this never happened, the
goroutine would just be abruptly killed when the main process ended
(since nobody waited for this goroutine to end).

Updating the code to exit when the server is closed immediately and
switching the timer to a ticker instance that can be stopped.