### PR TITLE
Cache safety fixes

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -334,21 +334,27 @@ func (c *Cache) DeleteRange(keys []string, min, max int64) {
 	defer c.mu.Unlock()
 
 	for _, k := range keys {
-		origSize := c.store[k].size()
+		// Make sure key exist in the cache, skip if it does not
+		e, ok := c.store[k]
+		if !ok {
+			continue
+		}
+
+		origSize := e.size()
 		if min == math.MinInt64 && max == math.MaxInt64 {
 			c.size -= uint64(origSize)
 			delete(c.store, k)
 			continue
 		}
 
-		c.store[k].filter(min, max)
-		if c.store[k].count() == 0 {
+		e.filter(min, max)
+		if e.count() == 0 {
 			delete(c.store, k)
 			c.size -= uint64(origSize)
 			continue
 		}
 
-		c.size -= uint64(origSize - c.store[k].size())
+		c.size -= uint64(origSize - e.size())
 	}
 }
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -268,9 +268,11 @@ func (c *Cache) Snapshot() (*Cache, error) {
 // Deduplicate sorts the snapshot before returning it. The compactor and any queries
 // coming in while it writes will need the values sorted
 func (c *Cache) Deduplicate() {
+	c.mu.RLock()
 	for _, e := range c.store {
 		e.deduplicate()
 	}
+	c.mu.RUnlock()
 }
 
 // ClearSnapshot will remove the snapshot cache from the list of flushing caches and

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -146,6 +146,7 @@ func TestCache_DeleteRange_NoValues(t *testing.T) {
 		t.Fatalf("cache values mismatch: got %v, exp %v", got, exp)
 	}
 }
+
 func TestCache_Cache_Delete(t *testing.T) {
 	v0 := NewValue(1, 1.0)
 	v1 := NewValue(2, 2.0)
@@ -182,6 +183,16 @@ func TestCache_Cache_Delete(t *testing.T) {
 
 	if got, exp := len(c.Values("foo")), 3; got != exp {
 		t.Fatalf("cache values mismatch: got %v, exp %v", got, exp)
+	}
+}
+
+func TestCache_Cache_Delete_NonExistent(t *testing.T) {
+	c := NewCache(1024, "")
+
+	c.Delete([]string{"bar"})
+
+	if got, exp := c.Size(), uint64(0); exp != got {
+		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", exp, got)
 	}
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This PR fixes a potential panic in the cache as well as a potential data race.  The first panic could occur when deletes for keys that do not exist in the cache are attempted to be deleted.  The race is related to `Deduplicate` not acquiring a read lock on the it's internal map.