### PR TITLE
Add option to KILL QUERY to kill on a specific host

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -685,10 +685,20 @@ func (s *GrantAdminStatement) RequiredPrivileges() (ExecutionPrivileges, error) 
 type KillQueryStatement struct {
 	// The query to kill.
 	QueryID uint64
+
+	// The host to delegate the kill to.
+	Host string
 }
 
 func (s *KillQueryStatement) String() string {
-	return fmt.Sprintf("KILL QUERY %d", s.QueryID)
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("KILL QUERY ")
+	_, _ = buf.WriteString(strconv.FormatUint(s.QueryID, 10))
+	if s.Host != "" {
+		_, _ = buf.WriteString(" ON ")
+		_, _ = buf.WriteString(QuoteIdent(s.Host))
+	}
+	return buf.String()
 }
 
 func (s *KillQueryStatement) RequiredPrivileges() (ExecutionPrivileges, error) {

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -306,7 +306,17 @@ func (p *Parser) parseKillQueryStatement() (*KillQueryStatement, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &KillQueryStatement{QueryID: qid}, nil
+
+	var host string
+	if tok, _, _ := p.scanIgnoreWhitespace(); tok == ON {
+		host, err = p.parseIdent()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		p.unscan()
+	}
+	return &KillQueryStatement{QueryID: qid, Host: host}, nil
 }
 
 // parseCreateSubscriptionStatement parses a string and returns a CreatesubScriptionStatement.

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1129,6 +1129,15 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// KILL QUERY 4 ON localhost
+		{
+			s: `KILL QUERY 4 ON localhost`,
+			stmt: &influxql.KillQueryStatement{
+				QueryID: 4,
+				Host:    "localhost",
+			},
+		},
+
 		// SHOW RETENTION POLICIES
 		{
 			s: `SHOW RETENTION POLICIES ON mydb`,
@@ -2312,6 +2321,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `GRANT ALL PRIVILEGES TO`, err: `found EOF, expected identifier at line 1, char 25`},
 		{s: `KILL`, err: `found EOF, expected QUERY at line 1, char 6`},
 		{s: `KILL QUERY 10s`, err: `found 10s, expected integer at line 1, char 12`},
+		{s: `KILL QUERY 4 ON 'host'`, err: `found host, expected identifier at line 1, char 16`},
 		{s: `REVOKE`, err: `found EOF, expected READ, WRITE, ALL [PRIVILEGES] at line 1, char 8`},
 		{s: `REVOKE BOGUS`, err: `found BOGUS, expected READ, WRITE, ALL [PRIVILEGES] at line 1, char 8`},
 		{s: `REVOKE READ`, err: `found EOF, expected ON at line 1, char 13`},


### PR DESCRIPTION
Option only applies to clustering.