### PR TITLE
Make httpd logger closer to Common Log Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.0.0 [unreleased]
+
+### Release Notes
+
+### Features
+
+- [#6812](https://github.com/influxdata/influxdb/pull/6812): Make httpd logger closer to Common (& combined) Log Format.
+
+### Bugfixes
+
 ## v1.0.0-beta1 [2016-06-07]
 
 ### Release Notes

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -84,18 +84,20 @@ type Handler struct {
 
 	ContinuousQuerier continuous_querier.ContinuousQuerier
 
-	Config  *Config
-	Logger  *log.Logger
-	statMap *expvar.Map
+	Config    *Config
+	Logger    *log.Logger
+	CLFLogger *log.Logger
+	statMap   *expvar.Map
 }
 
 // NewHandler returns a new instance of handler with routes.
 func NewHandler(c Config, statMap *expvar.Map) *Handler {
 	h := &Handler{
-		mux:     pat.New(),
-		Config:  &c,
-		Logger:  log.New(os.Stderr, "[http] ", log.LstdFlags),
-		statMap: statMap,
+		mux:       pat.New(),
+		Config:    &c,
+		Logger:    log.New(os.Stderr, "[httpd] ", log.LstdFlags),
+		CLFLogger: log.New(os.Stderr, "[httpd] ", 0),
+		statMap:   statMap,
 	}
 
 	h.AddRoutes([]Route{
@@ -915,8 +917,7 @@ func (h *Handler) logging(inner http.Handler, name string) http.Handler {
 		start := time.Now()
 		l := &responseLogger{w: w}
 		inner.ServeHTTP(l, r)
-		logLine := buildLogLine(l, r, start)
-		h.Logger.Println(logLine)
+		h.CLFLogger.Println(buildLogLine(l, r, start))
 	})
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs

- [x] Tests pass
- [x] CHANGELOG.md updated

changes the httpd log lines from this:

    [httpd] 2016/06/08 14:06:39 ::1 - - [08/Jun/2016:14:06:39 +0100] POST /write?consistency=any&db=telegraf&precision=s&rp= HTTP/1.1 204 0 - InfluxDBClient d6aa01fc-2d79-11e6-8024-000000000000 2.751391ms

to this:

    [httpd] ::1 - - [08/Jun/2016:14:06:39 +0100] "POST /write?consistency=any&db=telegraf&precision=s&rp= HTTP/1.1" 204 0 "-" "InfluxDBClient" d6aa01fc-2d79-11e6-8024-000000000000 2751

So it changes a few things:

1. Remove the logger timestamp at the beginning which isn't very relevant anyways
2. adds quotes around "METHOD URI PROTOCOL", because this is part of the
common log format.
3. adds quotes around "AGENT" and "REFERRER" because this is part of the
"combined" log format.
4. Puts the response time in integer microseconds, because this is
consistent with apache's %D config mod option.

Compared with CLF, our logs now look like this:

    [httpd] %{COMMON_LOG_FORMAT} "<agent>" "<referrer>" <request_uuid> <response_time_µs>

For reference, see:
https://en.wikipedia.org/wiki/Common_Log_Format
http://httpd.apache.org/docs/current/mod/mod_log_config.html