### PR TITLE
Add NodeID to execution options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#6713](https://github.com/influxdata/influxdb/pull/6713): Reduce allocations during query parsing.
 - [#3733](https://github.com/influxdata/influxdb/issues/3733): Modify the default retention policy name and make it configurable.
 - [#5655](https://github.com/influxdata/influxdb/issues/5655): Support specifying a retention policy for the graphite service.
+- [#6820](https://github.com/influxdata/influxdb/issues/6820): Add NodeID to execution options
 
 ### Bugfixes
 

--- a/coordinator/statement_executor_test.go
+++ b/coordinator/statement_executor_test.go
@@ -247,7 +247,7 @@ func (s *TSDBStore) DeleteSeries(database string, sources []influxql.Source, con
 	return s.DeleteSeriesFn(database, sources, condition)
 }
 
-func (s *TSDBStore) IteratorCreator(shards []meta.ShardInfo) (influxql.IteratorCreator, error) {
+func (s *TSDBStore) IteratorCreator(shards []meta.ShardInfo, opt *influxql.SelectOptions) (influxql.IteratorCreator, error) {
 	// Generate iterators for each node.
 	ics := make([]influxql.IteratorCreator, 0)
 	if err := func() error {

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -70,6 +70,9 @@ type ExecutionOptions struct {
 
 	// If this query is being executed in a read-only context.
 	ReadOnly bool
+
+	// Node to execute on.
+	NodeID uint64
 }
 
 // ExecutionContext contains state that the query is currently executing with.

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -15,6 +15,10 @@ type SelectOptions struct {
 	// The upper bound for a select call.
 	MaxTime time.Time
 
+	// Node to exclusively read from.
+	// If zero, all nodes are used.
+	NodeID uint64
+
 	// An optional channel that, if closed, signals that the select should be
 	// interrupted.
 	InterruptCh <-chan struct{}

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -267,6 +267,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 	}(time.Now())
 
 	pretty := r.FormValue("pretty") == "true"
+	nodeID, _ := strconv.ParseUint(r.FormValue("node_id"), 10, 64)
 
 	qp := strings.TrimSpace(r.FormValue("q"))
 	if qp == "" {
@@ -370,6 +371,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 		Database:  db,
 		ChunkSize: chunkSize,
 		ReadOnly:  r.Method == "GET",
+		NodeID:    nodeID,
 	}, closing)
 
 	// if we're not chunking, this will be the in memory buffer for all results before sending to client

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -709,7 +709,7 @@ func (s *Store) IteratorCreators() influxql.IteratorCreators {
 	return a
 }
 
-func (s *Store) IteratorCreator(shards []uint64) (influxql.IteratorCreator, error) {
+func (s *Store) IteratorCreator(shards []uint64, opt *influxql.SelectOptions) (influxql.IteratorCreator, error) {
 	// Generate iterators for each node.
 	ics := make([]influxql.IteratorCreator, 0)
 	if err := func() error {


### PR DESCRIPTION
## Overview

This pull request changes the `ExecutionOptions` and `SelectOptions` to allow a `NodeID` for specifying an exact node to query against. HTTP support is also added with a `node_id` field.

/cc @jwilder 

## TODO
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

