### PR TITLE
Remove systemd output redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Release Notes
 
+With this release the systemd configuration files for InfluxDB will use the system configured default for logging and will no longer write files to `/var/log/influxdb` by default. On most systems, the logs will be directed to the systemd journal and can be accessed by `journalctl -u influxdb.service`. Consult the systemd journal documentation for configuring journald.
+
 ### Features
 
 - [#6812](https://github.com/influxdata/influxdb/pull/6812): Make httpd logger closer to Common (& combined) Log Format.
@@ -73,6 +75,7 @@
 - [#6835](https://github.com/influxdata/influxdb/pull/6835): Include sysvinit-tools as an rpm dependency.
 - [#6834](https://github.com/influxdata/influxdb/pull/6834): Add port to all graphite log output to help with debugging multiple endpoints
 - [#6850](https://github.com/influxdata/influxdb/pull/6850): Modify the max nanosecond time to be one nanosecond less.
+- [#6824](https://github.com/influxdata/influxdb/issues/6824): Remove systemd output redirection.
 
 ## v0.13.0 [2016-05-12]
 

--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -9,10 +9,8 @@ After=network-online.target
 User=influxdb
 Group=influxdb
 LimitNOFILE=65536
-Environment='STDOUT=/dev/null'
-Environment='STDERR=/var/log/influxdb/influxd.log'
 EnvironmentFile=-/etc/default/influxdb
-ExecStart=/bin/sh -c "/usr/bin/influxd -config /etc/influxdb/influxdb.conf ${INFLUXD_OPTS} >>${STDOUT} 2>>${STDERR}"
+ExecStart=/usr/bin/influxd -config /etc/influxdb/influxdb.conf ${INFLUXD_OPTS}
 KillMode=control-group
 Restart=on-failure
 


### PR DESCRIPTION
Let systemd handle the output so the journal can be used. This also
let's the user configure if the journal stores the output of this
service to a file instead of setting the location.

Fixes #6824.