### PR TITLE
Modify the max nanosecond time to be one nanosecond less

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - [#6771](https://github.com/influxdata/influxdb/issues/6771): Fix the point validation parser to identify and sort tags correctly.
 - [#6835](https://github.com/influxdata/influxdb/pull/6835): Include sysvinit-tools as an rpm dependency.
 - [#6834](https://github.com/influxdata/influxdb/pull/6834): Add port to all graphite log output to help with debugging multiple endpoints
+- [#6850](https://github.com/influxdata/influxdb/pull/6850): Modify the max nanosecond time to be one nanosecond less.
 
 ## v0.13.0 [2016-05-12]
 

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -23,7 +23,7 @@ const (
 
 	// MaxTime is used as the maximum time value when computing an unbounded range.
 	// This time is 2262-04-11 23:47:16.854775806 +0000 UTC
-	MaxTime = models.MaxNanoTime - 1
+	MaxTime = models.MaxNanoTime
 )
 
 // Iterator represents a generic interface for all Iterators.

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1213,7 +1213,7 @@ func TestParsePointNegativeTimestamp(t *testing.T) {
 }
 
 func TestParsePointMaxTimestamp(t *testing.T) {
-	test(t, `cpu value=1 9223372036854775807`,
+	test(t, fmt.Sprintf(`cpu value=1 %d`, models.MaxNanoTime),
 		NewTestPoint(
 			"cpu",
 			models.Tags{},

--- a/models/time.go
+++ b/models/time.go
@@ -18,9 +18,9 @@ const (
 
 	// MaxNanoTime is the maximum time that can be represented.
 	//
-	// 2262-04-11 23:47:16.854775807 +0000 UTC
+	// 2262-04-11 23:47:16.854775806 +0000 UTC
 	//
-	MaxNanoTime = int64(math.MaxInt64)
+	MaxNanoTime = int64(math.MaxInt64) - 1
 )
 
 var (

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -389,7 +389,8 @@ func (data *Data) CreateShardGroup(database, policy string, timestamp time.Time)
 	sgi.StartTime = timestamp.Truncate(rpi.ShardGroupDuration).UTC()
 	sgi.EndTime = sgi.StartTime.Add(rpi.ShardGroupDuration).UTC()
 	if sgi.EndTime.After(time.Unix(0, models.MaxNanoTime)) {
-		sgi.EndTime = time.Unix(0, models.MaxNanoTime)
+		// Shard group range is [start, end) so add one to the max time.
+		sgi.EndTime = time.Unix(0, models.MaxNanoTime+1)
 	}
 
 	data.MaxShardID++


### PR DESCRIPTION
The highest time represented by a nanosecond needs to be used for an
exclusive range, so the maximum time needs to be one less than the
possible maximum number of nanoseconds representable by an int64 so that
we don't lose a point at that one time.

Previously worked in the open source version because the timestamp used
for finding a shard would be truncated by the retention policy so the
lookup time didn't run into this edge case because it didn't rest on the
truncation boundary. Since that point didn't really belong in that shard
group and was placed there by mistake, it's best to fix this bug since
the timestamp used to create the shard group should be capable of
retrieving it.