### PR TITLE
Set the condition cursor instead of aux iterator when creating a nil condition cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6834](https://github.com/influxdata/influxdb/pull/6834): Add port to all graphite log output to help with debugging multiple endpoints
 - [#6850](https://github.com/influxdata/influxdb/pull/6850): Modify the max nanosecond time to be one nanosecond less.
 - [#6824](https://github.com/influxdata/influxdb/issues/6824): Remove systemd output redirection.
+- [#6859](https://github.com/influxdata/influxdb/issues/6859): Set the condition cursor instead of aux iterator when creating a nil condition cursor.
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1147,16 +1147,16 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, mm *tsdb.Measu
 				// If a field was requested, use a nil cursor of the requested type.
 				switch ref.Type {
 				case influxql.Float, influxql.AnyField:
-					aux[i] = &floatNilLiteralCursor{}
+					conds[i] = &floatNilLiteralCursor{}
 					continue
 				case influxql.Integer:
-					aux[i] = &integerNilLiteralCursor{}
+					conds[i] = &integerNilLiteralCursor{}
 					continue
 				case influxql.String:
-					aux[i] = &stringNilLiteralCursor{}
+					conds[i] = &stringNilLiteralCursor{}
 					continue
 				case influxql.Boolean:
-					aux[i] = &booleanNilLiteralCursor{}
+					conds[i] = &booleanNilLiteralCursor{}
 					continue
 				}
 			}


### PR DESCRIPTION
A copy/paste error had nil cursors destined for a condition cursor get
set to the auxiliary cursor instead. When the number of conditions
exceeded the number of auxiliary fields, this would result in a stack
trace in some situations. When the number of conditions was less than or
equal to the number of auxiliary fields, it means that an auxiliary
cursor may have been overwritten with a nil cursor accidentally and a
leak might have happened since it was never closed.

Fixes #6859.