### PR TITLE
Remove FieldCodec from tsdb package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6850](https://github.com/influxdata/influxdb/pull/6850): Modify the max nanosecond time to be one nanosecond less.
 - [#6824](https://github.com/influxdata/influxdb/issues/6824): Remove systemd output redirection.
 - [#6859](https://github.com/influxdata/influxdb/issues/6859): Set the condition cursor instead of aux iterator when creating a nil condition cursor.
+- [#6869](https://github.com/influxdata/influxdb/issues/6869): Remove FieldCodec from tsdb package.
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1,14 +1,12 @@
 package tsdb
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -298,17 +296,6 @@ func (s *Shard) DiskSize() (int64, error) {
 	})
 
 	return size, err
-}
-
-// FieldCodec returns the field encoding for a measurement.
-// TODO: this is temporarily exported to make tx.go work. When the query engine gets refactored
-// into the tsdb package this should be removed. No one outside tsdb should know the underlying field encoding scheme.
-func (s *Shard) FieldCodec(measurementName string) *FieldCodec {
-	m := s.engine.MeasurementFields(measurementName)
-	if m == nil {
-		return NewFieldCodec(nil)
-	}
-	return m.Codec
 }
 
 // FieldCreate holds information for a field to create on a measurement
@@ -691,7 +678,6 @@ type MeasurementFields struct {
 	mu sync.RWMutex
 
 	fields map[string]*Field
-	Codec  *FieldCodec
 }
 
 func NewMeasurementFields() *MeasurementFields {
@@ -759,7 +745,6 @@ func (m *MeasurementFields) CreateFieldIfNotExists(name string, typ influxql.Dat
 		Type: typ,
 	}
 	m.fields[name] = f
-	m.Codec = NewFieldCodec(m.fields)
 
 	return nil
 }
@@ -787,268 +772,6 @@ type Field struct {
 	ID   uint8             `json:"id,omitempty"`
 	Name string            `json:"name,omitempty"`
 	Type influxql.DataType `json:"type,omitempty"`
-}
-
-// FieldCodec provides encoding and decoding functionality for the fields of a given
-// Measurement. It is a distinct type to avoid locking writes on this node while
-// potentially long-running queries are executing.
-//
-// It is not affected by changes to the Measurement object after codec creation.
-// TODO: this shouldn't be exported. nothing outside the shard should know about field encodings.
-//       However, this is here until tx.go and the engine get refactored into tsdb.
-type FieldCodec struct {
-	fieldsByID   map[uint8]*Field
-	fieldsByName map[string]*Field
-}
-
-// NewFieldCodec returns a FieldCodec for the given Measurement. Must be called with
-// a RLock that protects the Measurement.
-func NewFieldCodec(fields map[string]*Field) *FieldCodec {
-	fieldsByID := make(map[uint8]*Field, len(fields))
-	fieldsByName := make(map[string]*Field, len(fields))
-	for _, f := range fields {
-		fieldsByID[f.ID] = f
-		fieldsByName[f.Name] = f
-	}
-	return &FieldCodec{fieldsByID: fieldsByID, fieldsByName: fieldsByName}
-}
-
-// EncodeFields converts a map of values with string keys to a byte slice of field
-// IDs and values.
-//
-// If a field exists in the codec, but its type is different, an error is returned. If
-// a field is not present in the codec, the system panics.
-func (f *FieldCodec) EncodeFields(values map[string]interface{}) ([]byte, error) {
-	// Allocate byte slice
-	b := make([]byte, 0, 10)
-
-	for k, v := range values {
-		field := f.fieldsByName[k]
-		if field == nil {
-			panic(fmt.Sprintf("field does not exist for %s", k))
-		} else if influxql.InspectDataType(v) != field.Type {
-			return nil, fmt.Errorf("field \"%s\" is type %T, mapped as type %s", k, v, field.Type)
-		}
-
-		var buf []byte
-
-		switch field.Type {
-		case influxql.Float:
-			value := v.(float64)
-			buf = make([]byte, 9)
-			binary.BigEndian.PutUint64(buf[1:9], math.Float64bits(value))
-		case influxql.Integer:
-			var value uint64
-			switch v.(type) {
-			case int:
-				value = uint64(v.(int))
-			case int32:
-				value = uint64(v.(int32))
-			case int64:
-				value = uint64(v.(int64))
-			default:
-				panic(fmt.Sprintf("invalid integer type: %T", v))
-			}
-			buf = make([]byte, 9)
-			binary.BigEndian.PutUint64(buf[1:9], value)
-		case influxql.Boolean:
-			value := v.(bool)
-
-			// Only 1 byte need for a boolean.
-			buf = make([]byte, 2)
-			if value {
-				buf[1] = byte(1)
-			}
-		case influxql.String:
-			value := v.(string)
-			if len(value) > maxStringLength {
-				value = value[:maxStringLength]
-			}
-			// Make a buffer for field ID (1 bytes), the string length (2 bytes), and the string.
-			buf = make([]byte, len(value)+3)
-
-			// Set the string length, then copy the string itself.
-			binary.BigEndian.PutUint16(buf[1:3], uint16(len(value)))
-			for i, c := range []byte(value) {
-				buf[i+3] = byte(c)
-			}
-		default:
-			panic(fmt.Sprintf("unsupported value type during encode fields: %T", v))
-		}
-
-		// Always set the field ID as the leading byte.
-		buf[0] = field.ID
-
-		// Append temp buffer to the end.
-		b = append(b, buf...)
-	}
-
-	return b, nil
-}
-
-// FieldIDByName returns the ID of the field with the given name s.
-// TODO: this shouldn't be exported. remove when tx.go and engine.go get refactored into tsdb
-func (f *FieldCodec) FieldIDByName(s string) (uint8, error) {
-	fi := f.fieldsByName[s]
-	if fi == nil {
-		return 0, ErrFieldNotFound
-	}
-	return fi.ID, nil
-}
-
-// DecodeFields decodes a byte slice into a set of field ids and values.
-func (f *FieldCodec) DecodeFields(b []byte) (map[uint8]interface{}, error) {
-	if len(b) == 0 {
-		return nil, nil
-	}
-
-	// Create a map to hold the decoded data.
-	values := make(map[uint8]interface{}, 0)
-
-	for {
-		if len(b) < 1 {
-			// No more bytes.
-			break
-		}
-
-		// First byte is the field identifier.
-		fieldID := b[0]
-		field := f.fieldsByID[fieldID]
-		if field == nil {
-			// See note in DecodeByID() regarding field-mapping failures.
-			return nil, ErrFieldUnmappedID
-		}
-
-		var value interface{}
-		switch field.Type {
-		case influxql.Float:
-			value = math.Float64frombits(binary.BigEndian.Uint64(b[1:9]))
-			// Move bytes forward.
-			b = b[9:]
-		case influxql.Integer:
-			value = int64(binary.BigEndian.Uint64(b[1:9]))
-			// Move bytes forward.
-			b = b[9:]
-		case influxql.Boolean:
-			if b[1] == 1 {
-				value = true
-			} else {
-				value = false
-			}
-			// Move bytes forward.
-			b = b[2:]
-		case influxql.String:
-			size := binary.BigEndian.Uint16(b[1:3])
-			value = string(b[3 : size+3])
-			// Move bytes forward.
-			b = b[size+3:]
-		default:
-			panic(fmt.Sprintf("unsupported value type during decode fields: %T", f.fieldsByID[fieldID]))
-		}
-
-		values[fieldID] = value
-
-	}
-
-	return values, nil
-}
-
-// DecodeFieldsWithNames decodes a byte slice into a set of field names and values
-// TODO: shouldn't be exported. refactor engine
-func (f *FieldCodec) DecodeFieldsWithNames(b []byte) (map[string]interface{}, error) {
-	fields, err := f.DecodeFields(b)
-	if err != nil {
-		return nil, err
-	}
-	m := make(map[string]interface{})
-	for id, v := range fields {
-		field := f.fieldsByID[id]
-		if field != nil {
-			m[field.Name] = v
-		}
-	}
-	return m, nil
-}
-
-// DecodeByID scans a byte slice for a field with the given ID, converts it to its
-// expected type, and return that value.
-// TODO: shouldn't be exported. refactor engine
-func (f *FieldCodec) DecodeByID(targetID uint8, b []byte) (interface{}, error) {
-	if len(b) == 0 {
-		return 0, ErrFieldNotFound
-	}
-
-	for {
-		if len(b) < 1 {
-			// No more bytes.
-			break
-		}
-		field, ok := f.fieldsByID[b[0]]
-		if !ok {
-			// This can happen, though is very unlikely. If this node receives encoded data, to be written
-			// to disk, and is queried for that data before its metastore is updated, there will be no field
-			// mapping for the data during decode. All this can happen because data is encoded by the node
-			// that first received the write request, not the node that actually writes the data to disk.
-			// So if this happens, the read must be aborted.
-			return 0, ErrFieldUnmappedID
-		}
-
-		var value interface{}
-		switch field.Type {
-		case influxql.Float:
-			// Move bytes forward.
-			value = math.Float64frombits(binary.BigEndian.Uint64(b[1:9]))
-			b = b[9:]
-		case influxql.Integer:
-			value = int64(binary.BigEndian.Uint64(b[1:9]))
-			b = b[9:]
-		case influxql.Boolean:
-			if b[1] == 1 {
-				value = true
-			} else {
-				value = false
-			}
-			// Move bytes forward.
-			b = b[2:]
-		case influxql.String:
-			size := binary.BigEndian.Uint16(b[1:3])
-			value = string(b[3 : 3+size])
-			// Move bytes forward.
-			b = b[size+3:]
-		default:
-			panic(fmt.Sprintf("unsupported value type during decode by id: %T", field.Type))
-		}
-
-		if field.ID == targetID {
-			return value, nil
-		}
-	}
-
-	return 0, ErrFieldNotFound
-}
-
-// DecodeByName scans a byte slice for a field with the given name, converts it to its
-// expected type, and return that value.
-func (f *FieldCodec) DecodeByName(name string, b []byte) (interface{}, error) {
-	fi := f.FieldByName(name)
-	if fi == nil {
-		return 0, ErrFieldNotFound
-	}
-	return f.DecodeByID(fi.ID, b)
-}
-
-// Fields returns a unsorted list of the codecs fields.
-func (f *FieldCodec) Fields() []*Field {
-	a := make([]*Field, 0, len(f.fieldsByID))
-	for _, f := range f.fieldsByID {
-		a = append(a, f)
-	}
-	return a
-}
-
-// FieldByName returns the field by its name. It will return a nil if not found
-func (f *FieldCodec) FieldByName(name string) *Field {
-	return f.fieldsByName[name]
 }
 
 // shardIteratorCreator creates iterators for a local shard.


### PR DESCRIPTION
Updated `influx_inspect` to use the `FieldDimensions` method instead
(more reliable anyway). The `influx_tsm` program used its own vendored
copy of `FieldCodec` so it is not affected by this change. `FieldCodec`
was only used for the `b1` and `bz1` engines which were removed in 0.12,
but the code that created the field codec was never removed. This
limited the maximum number of fields to 255 even though that restriction
was removed with the `tsm1` engine.

Fixes #6869.