### PR TITLE
Open database in read only mode for influx_inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6869](https://github.com/influxdata/influxdb/issues/6869): Remove FieldCodec from tsdb package.
 - [#6882](https://github.com/influxdata/influxdb/pull/6882): Remove a double lock in the tsm1 index writer.
 - [#6883](https://github.com/influxdata/influxdb/pull/6883): Rename dumptsmdev to dumptsm in influx_inspect.
+- [#6880](https://github.com/influxdata/influxdb/pull/6880): Open database in read only mode for influx_inspect.
 
 ## v0.13.0 [2016-05-12]
 

--- a/cmd/influx_inspect/info.go
+++ b/cmd/influx_inspect/info.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -16,10 +15,11 @@ import (
 
 func cmdInfo(path string) {
 	tstore := tsdb.NewStore(filepath.Join(path, "data"))
-	tstore.Logger = log.New(ioutil.Discard, "", log.LstdFlags)
+	tstore.SetLogOutput(ioutil.Discard)
 	tstore.EngineOptions.Config.Dir = filepath.Join(path, "data")
 	tstore.EngineOptions.Config.WALLoggingEnabled = false
 	tstore.EngineOptions.Config.WALDir = filepath.Join(path, "wal")
+	tstore.EngineOptions.Mode = tsdb.ReadMode
 	if err := tstore.Open(); err != nil {
 		fmt.Printf("Failed to open dir: %v\n", err)
 		os.Exit(1)

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -110,11 +110,28 @@ func NewEngine(path string, walPath string, options EngineOptions) (Engine, erro
 	return fn(path, walPath, options), nil
 }
 
+// Mode determines the read/write mode of an engine.
+// TODO(jsternberg): Finish implementing this.
+type Mode int
+
+const (
+	// ReadMode will open the engine in a read-only mode.
+	ReadMode Mode = 1 << iota
+
+	// WriteMode will open the engine in a write-only mode.
+	WriteMode
+
+	// ReadWriteMode will open the engine in a read/write mode.
+	ReadWriteMode = ReadMode | WriteMode
+)
+
 // EngineOptions represents the options used to initialize the engine.
 type EngineOptions struct {
 	EngineVersion string
 
 	Config Config
+
+	Mode Mode
 }
 
 // NewEngineOptions returns the default options.
@@ -122,6 +139,7 @@ func NewEngineOptions() EngineOptions {
 	return EngineOptions{
 		EngineVersion: DefaultEngine,
 		Config:        NewConfig(),
+		Mode:          ReadWriteMode,
 	}
 }
 


### PR DESCRIPTION
influx_inspect would open shards and also enable compactions when it
opened the shards. Since performing compactions should not be something
the influx_inspect tool does, this adds functionality to open an engine
in a read-only mode.

In the future, we can implement more of the methods to follow the mode
that the engine is opened with. Right now, it only controls whether
compactions are enabled or not.

This also disables the internal logging from the library for
influx_inspect. It was obviously intended for this to be the case
because influx_inspect tries to override the logger, but it needed to
use `SetLogOutput` to also override subloggers in the shards.