### PR TITLE
Update help and remove unused config options from the configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#5655](https://github.com/influxdata/influxdb/issues/5655): Support specifying a retention policy for the graphite service.
 - [#6820](https://github.com/influxdata/influxdb/issues/6820): Add NodeID to execution options
 - [#4532](https://github.com/influxdata/influxdb/issues/4532): Support regex selection in SHOW TAG VALUES for the key.
+- [#6889](https://github.com/influxdata/influxdb/pull/6889): Update help and remove unused config options from the configuration file.
 
 ### Bugfixes
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -28,17 +28,3 @@ This will start an interactive, single-node, that publishes the containers port 
 ```
 $ docker run -it -p 8086:8086 -p 8088:8088 influxdb
 ```
-
-## Multi-Node Cluster
-
-This will create a simple 3-node cluster.  The data is stored within the container and will be lost when the container is removed.  This is only useful for test clusters.
-
-The `HOST_IP` env variable should be your host IP if running under linux or the virtualbox VM IP if running under OSX.  On OSX, this would be something like: `$(docker-machine ip dev)` or `$(boot2docker ip)` depending on which docker tool you are using.
-
-```
-$ export HOST_IP=<your host/VM IP>
-$ docker run -it -p 8086:8086 -p 8088:8088 influxdb -hostname $HOST_IP:8088
-$ docker run -it -p 8186:8086 -p 8188:8088 influxdb -hostname $HOST_IP:8188 -join $HOST_IP:8088
-$ docker run -it -p 8286:8086 -p 8288:8088 influxdb -hostname $HOST_IP:8288 -join $HOST_IP:8088
-```
-

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -347,20 +347,19 @@ func (cmd *Command) requestInfo(request *snapshotter.Request) (*snapshotter.Resp
 func (cmd *Command) printUsage() {
 	fmt.Fprintf(cmd.Stdout, `usage: influxd backup [flags] PATH
 
-Backup downloads a snapshot of a data node and saves it to disk.
+Downloads a snapshot of a data node and saves it to disk.
 
-Options:
-  -host <host:port>
-        The host to connect to snapshot. Defaults to 127.0.0.1:8088.
-  -database <name>
-        The database to backup.
-  -retention <name>
-        Optional. The retention policy to backup.
-  -shard <id>
-        Optional. The shard id to backup. If specified, retention is required.
-  -since <2015-12-24T08:12:23>
-        Optional. Do an incremental backup since the passed in RFC3339
-        formatted time.
+	-host <host:port>
+		The host to connect to snapshot. Defaults to 127.0.0.1:8088.
+	-database <name>
+		The database to backup.
+	-retention <name>
+		Optional. The retention policy to backup.
+	-shard <id>
+		Optional. The shard id to backup. If specified, retention is required.
+	-since <2015-12-24T08:12:23>
+		Optional. Do an incremental backup since the passed in RFC3339
+		formatted time.
 
 `)
 }

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -185,7 +185,7 @@ func NewVersionCommand() *VersionCommand {
 func (cmd *VersionCommand) Run(args ...string) error {
 	// Parse flags in case -h is specified.
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	fs.Usage = func() { fmt.Fprintln(cmd.Stderr, strings.TrimSpace(versionUsage)) }
+	fs.Usage = func() { fmt.Fprintln(cmd.Stderr, versionUsage) }
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -196,8 +196,7 @@ func (cmd *VersionCommand) Run(args ...string) error {
 	return nil
 }
 
-var versionUsage = `
-usage: version
+var versionUsage = `usage: influxd version
 
-	version displays the InfluxDB version, build branch and git commit hash
+Displays the InfluxDB version, build branch and git commit hash.
 `

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -333,25 +333,24 @@ func (cmd *Command) unpackFile(tr *tar.Reader, fileName string) error {
 func (cmd *Command) printUsage() {
 	fmt.Fprintf(cmd.Stdout, `usage: influxd restore [flags] PATH
 
-Restore uses backups from the PATH to restore the metastore, databases,
+Uses backups from the PATH to restore the metastore, databases,
 retention policies, or specific shards. The InfluxDB process must not be
-running during restore.
+running during a restore.
 
-Options:
-  -metadir <path>
-        Optional. If set the metastore will be recovered to the given path.
-  -datadir <path>
-        Optional. If set the restore process will recover the specified
-        database, retention policy or shard to the given directory.
-  -database <name>
-        Optional. Required if no metadir given. Will restore the database
-        TSM files.
-  -retention <name>
-        Optional. If given, database is required. Will restore the retention policy's
-        TSM files.
-  -shard <id>
-    Optional. If given, database and retention are required. Will restore the shard's
-    TSM files.
+	-metadir <path>
+		Optional. If set the metastore will be recovered to the given path.
+	-datadir <path>
+		Optional. If set the restore process will recover the specified
+		database, retention policy or shard to the given directory.
+	-database <name>
+		Optional. Required if no metadir given. Will restore the database
+		TSM files.
+	-retention <name>
+		Optional. If given, database is required. Will restore the retention policy's
+		TSM files.
+	-shard <id>
+		Optional. If given, database and retention are required. Will restore the shard's
+		TSM files.
 
 `)
 }

--- a/cmd/influxd/run/backup_restore_test.go
+++ b/cmd/influxd/run/backup_restore_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/influxdata/influxdb/cmd/influxd/backup"
 	"github.com/influxdata/influxdb/cmd/influxd/restore"
-	"github.com/influxdata/influxdb/cmd/influxd/run"
 )
 
 func TestServer_BackupAndRestore(t *testing.T) {
@@ -59,7 +58,11 @@ func TestServer_BackupAndRestore(t *testing.T) {
 
 		// now backup
 		cmd := backup.NewCommand()
-		hostAddress, _ := run.DefaultHost(run.DefaultHostname, config.BindAddress)
+		_, port, err := net.SplitHostPort(config.BindAddress)
+		if err != nil {
+			t.Fatal(err)
+		}
+		hostAddress := net.JoinHostPort("localhost", port)
 		if err := cmd.Run("-host", hostAddress, "-database", "mydb", backupDir); err != nil {
 			t.Fatalf("error backing up: %s, hostAddress: %s", err.Error(), hostAddress)
 		}

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -95,10 +95,6 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("apply env config: %v", err)
 	}
 
-	if options.Hostname != "" {
-		config.Hostname = options.Hostname
-	}
-
 	// Validate the configuration.
 	if err := config.Validate(); err != nil {
 		return fmt.Errorf("%s. To generate a valid configuration file run `influxd config > influxdb.generated.conf`", err)
@@ -156,7 +152,8 @@ func (cmd *Command) ParseFlags(args ...string) (Options, error) {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	fs.StringVar(&options.ConfigPath, "config", "", "")
 	fs.StringVar(&options.PIDFile, "pidfile", "", "")
-	fs.StringVar(&options.Hostname, "hostname", "", "")
+	// Ignore hostname option.
+	_ = fs.String("hostname", "", "")
 	fs.StringVar(&options.CPUProfile, "cpuprofile", "", "")
 	fs.StringVar(&options.MemProfile, "memprofile", "", "")
 	fs.Usage = func() { fmt.Fprintln(cmd.Stderr, usage) }
@@ -207,24 +204,16 @@ func (cmd *Command) ParseConfig(path string) (*Config, error) {
 	return config, nil
 }
 
-var usage = `usage: run [flags]
+var usage = `usage: influxd run [flags]
 
-run starts the InfluxDB server. If this is the first time running the command
-then a new cluster will be initialized unless the -join argument is used.
+Runs the InfluxDB server.
 
         -config <path>
                           Set the path to the configuration file.
-
-        -hostname <name>
-                          Override the hostname, the 'hostname' configuration
-                          option will be overridden.
-
         -pidfile <path>
                           Write process ID to a file.
-
         -cpuprofile <path>
                           Write CPU profiling information to a file.
-
         -memprofile <path>
                           Write memory usage information to a file.
 `
@@ -233,7 +222,6 @@ then a new cluster will be initialized unless the -join argument is used.
 type Options struct {
 	ConfigPath string
 	PIDFile    string
-	Hostname   string
 	CPUProfile string
 	MemProfile string
 }

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -31,12 +31,8 @@ import (
 )
 
 const (
-	// DefaultBindAddress is the default address for raft, cluster, snapshot, etc..
+	// DefaultBindAddress is the default address for various RPC services.
 	DefaultBindAddress = ":8088"
-
-	// DefaultHostname is the default hostname used if we are unable to determine
-	// the hostname from the system
-	DefaultHostname = "localhost"
 )
 
 // Config represents the configuration format for the influxd binary.
@@ -63,12 +59,6 @@ type Config struct {
 
 	// BindAddress is the address that all TCP services use (Raft, Snapshot, Cluster, etc.)
 	BindAddress string `toml:"bind-address"`
-
-	// Hostname is the hostname portion to use when registering local
-	// addresses.  This hostname must be resolvable from other nodes.
-	Hostname string `toml:"hostname"`
-
-	Join string `toml:"join"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.

--- a/cmd/influxd/run/config_command.go
+++ b/cmd/influxd/run/config_command.go
@@ -72,7 +72,10 @@ func (cmd *PrintConfigCommand) parseConfig(path string) (*Config, error) {
 	return config, nil
 }
 
-var printConfigUsage = `usage: config
+var printConfigUsage = `usage: influxd config [flags]
 
-	config displays the default configuration
+Displays the default configuration.
+
+	-config <path>
+			Set the path to the initial configuration file.
 `

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -13,8 +13,6 @@ func TestConfig_Parse(t *testing.T) {
 	// Parse configuration.
 	var c run.Config
 	if err := c.FromToml(`
-join = "foo:123,bar:456"
-
 [meta]
 dir = "/tmp/meta"
 
@@ -96,8 +94,6 @@ enabled = true
 		t.Fatalf("unexpected subscriber enabled: %v", c.Subscriber.Enabled)
 	} else if c.ContinuousQuery.Enabled != true {
 		t.Fatalf("unexpected continuous query enabled: %v", c.ContinuousQuery.Enabled)
-	} else if exp, got := "foo:123,bar:456", c.Join; exp != got {
-		t.Fatalf("unexpected join value: got %v, exp %v", got, exp)
 	}
 }
 

--- a/services/admin/config.go
+++ b/services/admin/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	BindAddress      string `toml:"bind-address"`
 	HTTPSEnabled     bool   `toml:"https-enabled"`
 	HTTPSCertificate string `toml:"https-certificate"`
-	Version          string
+	Version          string `toml:"-"`
 }
 
 // NewConfig returns an instance of Config with defaults.

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -10,7 +10,6 @@ type Config struct {
 	AuthEnabled        bool   `toml:"auth-enabled"`
 	LogEnabled         bool   `toml:"log-enabled"`
 	WriteTracing       bool   `toml:"write-tracing"`
-	PprofEnabled       bool   `toml:"pprof-enabled"`
 	HTTPSEnabled       bool   `toml:"https-enabled"`
 	HTTPSCertificate   string `toml:"https-certificate"`
 	HTTPSPrivateKey    string `toml:"https-private-key"`

--- a/services/httpd/config_test.go
+++ b/services/httpd/config_test.go
@@ -16,7 +16,6 @@ bind-address = ":8080"
 auth-enabled = true
 log-enabled = true
 write-tracing = true
-pprof-enabled = true
 https-enabled = true
 https-certificate = "/dev/null"
 `, &c); err != nil {
@@ -34,8 +33,6 @@ https-certificate = "/dev/null"
 		t.Fatalf("unexpected log enabled: %v", c.LogEnabled)
 	} else if c.WriteTracing != true {
 		t.Fatalf("unexpected write tracing: %v", c.WriteTracing)
-	} else if c.PprofEnabled != true {
-		t.Fatalf("unexpected pprof enabled: %v", c.PprofEnabled)
 	} else if c.HTTPSEnabled != true {
 		t.Fatalf("unexpected https enabled: %v", c.HTTPSEnabled)
 	} else if c.HTTPSCertificate != "/dev/null" {

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -80,7 +80,7 @@ func NewClient(config *Config) *Client {
 		},
 		closing:             make(chan struct{}),
 		changed:             make(chan struct{}),
-		logger:              log.New(os.Stderr, "[metaclient] ", log.LstdFlags),
+		logger:              log.New(ioutil.Discard, "[metaclient] ", log.LstdFlags),
 		authCache:           make(map[string]authUser, 0),
 		path:                config.Dir,
 		retentionAutoCreate: config.RetentionAutoCreate,

--- a/services/meta/config.go
+++ b/services/meta/config.go
@@ -3,8 +3,6 @@ package meta
 import (
 	"errors"
 	"time"
-
-	"github.com/influxdata/influxdb/toml"
 )
 
 const (
@@ -25,9 +23,6 @@ type Config struct {
 	RetentionAutoCreate        bool   `toml:"retention-autocreate"`
 	DefaultRetentionPolicyName string `toml:"default-retention-policy-name"`
 	LoggingEnabled             bool   `toml:"logging-enabled"`
-	PprofEnabled               bool   `toml:"pprof-enabled"`
-
-	LeaseDuration toml.Duration `toml:"lease-duration"`
 }
 
 // NewConfig builds a new configuration with default values.
@@ -35,7 +30,6 @@ func NewConfig() *Config {
 	return &Config{
 		RetentionAutoCreate:        true,
 		DefaultRetentionPolicyName: DefaultRetentionPolicyName,
-		LeaseDuration:              toml.Duration(DefaultLeaseDuration),
 		LoggingEnabled:             DefaultLoggingEnabled,
 	}
 }


### PR DESCRIPTION
Normalize the output for the various help options so they all follow the
same format and display all relevant options.

Removing some of the unused config options from the configuration file
and updating the help documentation. Removing some remaining references
to clustering within the open source version.