### PR TITLE
Add a query to verify a user's password (fixes #6837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#5499](https://github.com/influxdata/influxdb/issues/5499): Add stats and diagnostics to the TSM engine.
 - [#6959](https://github.com/influxdata/influxdb/issues/6959): Return 403 Forbidden when authentication succeeds but authorization fails.
 - [#1110](https://github.com/influxdata/influxdb/issues/1110): Support loading a folder for collectd typesdb files.
+- [#6837](https://github.com/influxdata/influxdb/issues/6837): Provides a SHOW USER WITH PASSWORD to verify a user password.
 
 ### Bugfixes
 

--- a/coordinator/meta_client.go
+++ b/coordinator/meta_client.go
@@ -9,6 +9,7 @@ import (
 
 // MetaClient is an interface for accessing meta data.
 type MetaClient interface {
+	Authenticate(username, password string) (*meta.UserInfo, error)
 	CreateContinuousQuery(database, name, query string) error
 	CreateDatabase(name string) (*meta.DatabaseInfo, error)
 	CreateDatabaseWithRetentionPolicy(name string, rpi *meta.RetentionPolicyInfo) (*meta.DatabaseInfo, error)
@@ -33,4 +34,5 @@ type MetaClient interface {
 	UserPrivilege(username, database string) (*influxql.Privilege, error)
 	UserPrivileges(username string) (map[string]influxql.Privilege, error)
 	Users() []meta.UserInfo
+	User(username string) (*meta.UserInfo, error)
 }

--- a/coordinator/meta_client_test.go
+++ b/coordinator/meta_client_test.go
@@ -9,6 +9,7 @@ import (
 
 // MetaClient is a mockable implementation of cluster.MetaClient.
 type MetaClient struct {
+	AuthenticateFn                      func(username, password string) (*meta.UserInfo, error)
 	CreateContinuousQueryFn             func(database, name, query string) error
 	CreateDatabaseFn                    func(name string) (*meta.DatabaseInfo, error)
 	CreateDatabaseWithRetentionPolicyFn func(name string, rpi *meta.RetentionPolicyInfo) (*meta.DatabaseInfo, error)
@@ -38,6 +39,7 @@ type MetaClient struct {
 	UserPrivilegeFn                     func(username, database string) (*influxql.Privilege, error)
 	UserPrivilegesFn                    func(username string) (map[string]influxql.Privilege, error)
 	UsersFn                             func() []meta.UserInfo
+	UserFn                              func(username string) (*meta.UserInfo, error)
 }
 
 func (c *MetaClient) CreateContinuousQuery(database, name, query string) error {
@@ -153,6 +155,14 @@ func (c *MetaClient) UserPrivileges(username string) (map[string]influxql.Privil
 
 func (c *MetaClient) Users() []meta.UserInfo {
 	return c.UsersFn()
+}
+
+func (c *MetaClient) User(username string) (*meta.UserInfo, error) {
+	return c.UserFn(username)
+}
+
+func (c *MetaClient) Authenticate(username, password string) (*meta.UserInfo, error) {
+	return c.AuthenticateFn(username, password)
 }
 
 // DefaultMetaClientDatabaseFn returns a single database (db0) with a retention policy.

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -144,6 +144,7 @@ func (*ShowDiagnosticsStatement) node()       {}
 func (*ShowTagKeysStatement) node()           {}
 func (*ShowTagValuesStatement) node()         {}
 func (*ShowUsersStatement) node()             {}
+func (*ShowUserStatement) node()              {}
 
 func (*BinaryExpr) node()      {}
 func (*BooleanLiteral) node()  {}
@@ -255,6 +256,7 @@ func (*ShowDiagnosticsStatement) stmt()       {}
 func (*ShowTagKeysStatement) stmt()           {}
 func (*ShowTagValuesStatement) stmt()         {}
 func (*ShowUsersStatement) stmt()             {}
+func (*ShowUserStatement) stmt()              {}
 func (*RevokeStatement) stmt()                {}
 func (*RevokeAdminStatement) stmt()           {}
 func (*SelectStatement) stmt()                {}
@@ -2838,6 +2840,35 @@ func (s *ShowUsersStatement) String() string {
 // RequiredPrivileges returns the privilege(s) required to execute a ShowUsersStatement
 func (s *ShowUsersStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
+}
+
+// ShowUserStatement represents a command for retrieving a specific user.
+type ShowUserStatement struct {
+	// Name of the user to retrieve.
+	Name string
+
+	// User's password.
+	Password string
+
+	// should the password be used to retrieve the user.
+	WithPassword bool
+}
+
+// String returns a string representation of the ShowUserStatement
+func (s *ShowUserStatement) String() string {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("SHOW USER ")
+	_, _ = buf.WriteString(QuoteIdent(s.Name))
+	if s.WithPassword {
+		_, _ = buf.WriteString(" WITH PASSWORD ")
+		_, _ = buf.WriteString("[REDACTED]")
+	}
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege(s) required to execute a ShowUserStatement
+func (s *ShowUserStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
+	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: ReadPrivilege}}, nil
 }
 
 // ShowFieldKeysStatement represents a command for listing field keys.

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1779,6 +1779,24 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SHOW USER statement
+		{
+			s: `SHOW USER testuser`,
+			stmt: &influxql.ShowUserStatement{
+				Name: "testuser",
+			},
+		},
+
+		// SHOW USER WITH PASSWORD statement
+		{
+			s: `SHOW USER testuser WITH PASSWORD 'pwd1337'`,
+			stmt: &influxql.ShowUserStatement{
+				Name:         "testuser",
+				Password:     "pwd1337",
+				WithPassword: true,
+			},
+		},
+
 		// SET PASSWORD FOR USER
 		{
 			s: `SET PASSWORD FOR testuser = 'pwd1337'`,
@@ -2248,11 +2266,14 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SHOW RETENTION POLICIES mydb`, err: `found mydb, expected ON at line 1, char 25`},
 		{s: `SHOW RETENTION POLICIES ON`, err: `found EOF, expected identifier at line 1, char 28`},
 		{s: `SHOW SHARD`, err: `found EOF, expected GROUPS at line 1, char 12`},
-		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, DIAGNOSTICS, FIELD, GRANTS, MEASUREMENTS, QUERIES, RETENTION, SERIES, SHARD, SHARDS, STATS, SUBSCRIPTIONS, TAG, USERS at line 1, char 6`},
+		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, DIAGNOSTICS, FIELD, GRANTS, MEASUREMENTS, QUERIES, RETENTION, SERIES, SHARD, SHARDS, STATS, SUBSCRIPTIONS, TAG, USER, USERS at line 1, char 6`},
 		{s: `SHOW STATS FOR`, err: `found EOF, expected string at line 1, char 16`},
 		{s: `SHOW DIAGNOSTICS FOR`, err: `found EOF, expected string at line 1, char 22`},
 		{s: `SHOW GRANTS`, err: `found EOF, expected FOR at line 1, char 13`},
 		{s: `SHOW GRANTS FOR`, err: `found EOF, expected identifier at line 1, char 17`},
+		{s: `SHOW USER`, err: `found EOF, expected identifier at line 1, char 11`},
+		{s: `SHOW USER testuser WITH`, err: `found EOF, expected PASSWORD at line 1, char 25`},
+		{s: `SHOW USER testuser WITH PASSWORD`, err: `found EOF, expected string at line 1, char 34`},
 		{s: `DROP CONTINUOUS`, err: `found EOF, expected QUERY at line 1, char 17`},
 		{s: `DROP CONTINUOUS QUERY`, err: `found EOF, expected identifier at line 1, char 23`},
 		{s: `DROP CONTINUOUS QUERY myquery`, err: `found EOF, expected ON at line 1, char 31`},

--- a/influxql/sanitize.go
+++ b/influxql/sanitize.go
@@ -8,7 +8,7 @@ import (
 var (
 	sanitizeSetPassword = regexp.MustCompile(`(?i)password\s+for[^=]*=\s+(["']?[^\s"]+["']?)`)
 
-	sanitizeCreatePassword = regexp.MustCompile(`(?i)with\s+password\s+(["']?[^\s"]+["']?)`)
+	sanitizeWithPassword = regexp.MustCompile(`(?i)with\s+password\s+(["']?[^\s"]+["']?)`)
 )
 
 // Sanitize attempts to sanitize passwords out of a raw query.
@@ -32,7 +32,7 @@ func Sanitize(query string) string {
 		query = buf.String()
 	}
 
-	if matches := sanitizeCreatePassword.FindAllStringSubmatchIndex(query, -1); matches != nil {
+	if matches := sanitizeWithPassword.FindAllStringSubmatchIndex(query, -1); matches != nil {
 		var buf bytes.Buffer
 		i := 0
 		for _, match := range matches {

--- a/influxql/sanitize_test.go
+++ b/influxql/sanitize_test.go
@@ -20,6 +20,10 @@ func TestSanitize(t *testing.T) {
 			s:    `set password for "admin" = 'admin'`,
 			stmt: `set password for "admin" = [REDACTED]`,
 		},
+		{
+			s:    `show user "admin" with password 'admin'`,
+			stmt: `show user "admin" with password [REDACTED]`,
+		},
 
 		// Common invalid statements that should still be redacted.
 		{
@@ -29,6 +33,10 @@ func TestSanitize(t *testing.T) {
 		{
 			s:    `set password for "admin" = "admin"`,
 			stmt: `set password for "admin" = [REDACTED]`,
+		},
+		{
+			s:    `show user "admin" with password "admin"`,
+			stmt: `show user "admin" with password [REDACTED]`,
 		},
 	}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated

As mentioned in https://github.com/influxdata/influxdb/issues/6837, I had already implemented something similar for my personal use, so if it can help, here is the pull request with my solution to the problem.

If you don't like the syntax, or think there is a better way to do this feature, feel free to tell me about it, I would happily try to do something better.

**Syntax proposed**

`SHOW USER "user" WITH PASSWORD 'pwd'` will return the user if the password is correct.

`SHOW USER "user"` will return the user. (might not be very useful, but I think it makes sense to have it





