### PR TITLE
Fix out of order blocks returned during query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6883](https://github.com/influxdata/influxdb/pull/6883): Rename dumptsmdev to dumptsm in influx_inspect.
 - [#6864](https://github.com/influxdata/influxdb/pull/6864): Allow a non-admin to call "use" for the influx cli.
 - [#6855](https://github.com/influxdata/influxdb/pull/6855): Update `stress/v2` to work with clusters, ssl, and username/password auth. Code cleanup
+- [#6738](https://github.com/influxdata/influxdb/issues/6738): Time sorting broken with overwritten points
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/engine/tsm1/file_store.gen.go.tmpl
+++ b/tsdb/engine/tsm1/file_store.gen.go.tmpl
@@ -1,5 +1,6 @@
 package tsm1
 
+
 {{range .}}
 // Read{{.Name}}Block reads the next block as a set of {{.name}} values.
 func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder, buf *[]{{.Name}}Value) ([]{{.Name}}Value, error) {
@@ -34,8 +35,21 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 	}
 
 	// Use the current block time range as our overlapping window
-	minT, maxT := values[0].UnixNano(), values[len(values)-1].UnixNano()
+	minT, maxT := first.readMin, first.readMax
+	if len(values) > 0 {
+		minT, maxT = values[0].UnixNano(), values[len(values)-1].UnixNano()
+	}
 	if c.ascending {
+		// Blocks are ordered by generation, we may have values in the past in later blocks, if so,
+		// expand the window to include the min time range to ensure values are returned in ascending
+		// order
+		for i := 1; i < len(c.current); i++ {
+			cur := c.current[i]
+			if cur.entry.MinTime < minT && !cur.read() {
+				minT = cur.entry.MinTime
+			}
+		}
+
 		// Find first block that overlaps our window
 		for i := 1; i < len(c.current); i++ {
 			cur := c.current[i]
@@ -43,7 +57,9 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				maxT = cur.entry.MaxTime
+				if cur.entry.MaxTime > maxT {
+					maxT = cur.entry.MaxTime
+				}
 				values = {{.Name}}Values(values).Include(minT, maxT)
 				break
 			}
@@ -55,6 +71,7 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 			cur := c.current[i]
 			// Skip this block if it doesn't contain points we looking for or they have already been read
 			if !cur.entry.OverlapsTimeRange(minT, maxT) || cur.read() {
+				cur.markRead(minT, maxT)
 				continue
 			}
 
@@ -74,15 +91,23 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 				// Only use values in the overlapping window
 				v = {{.Name}}Values(v).Include(minT, maxT)
 
-				if len(v) > 0 {
-					cur.markRead(v[0].UnixNano(), v[len(v)-1].UnixNano())
-				}
 				// Merge the remaing values with the existing
 				values = {{.Name}}Values(values).Merge(v)
 			}
+			cur.markRead(minT, maxT)
 		}
 
 	} else {
+		// Blocks are ordered by generation, we may have values in the past in later blocks, if so,
+		// expand the window to include the max time range to ensure values are returned in descending
+		// order
+		for i := 1; i < len(c.current); i++ {
+			cur := c.current[i]
+			if cur.entry.MaxTime > maxT && !cur.read() {
+				maxT = cur.entry.MaxTime
+			}
+		}
+
 		// Find first block that overlaps our window
 		for i := 1; i < len(c.current); i++ {
 			cur := c.current[i]
@@ -90,7 +115,9 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 				// Shrink our window so it's the intersection of the first overlapping block and the
 				// first block.  We do this to minimize the region that overlaps and needs to
 				// be merged.
-				minT = cur.entry.MinTime
+				if cur.entry.MinTime < minT {
+					minT = cur.entry.MinTime
+				}
 				values = {{.Name}}Values(values).Include(minT, maxT)
 				break
 			}
@@ -102,6 +129,7 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 			cur := c.current[i]
 			// Skip this block if it doesn't contain points we looking for or they have already been read
 			if !cur.entry.OverlapsTimeRange(minT, maxT) || cur.read() {
+				cur.markRead(minT, maxT)
 				continue
 			}
 
@@ -122,12 +150,10 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 			// don't use it again.
 			if len(v) > 0 {
 				v = {{.Name}}Values(v).Include(minT, maxT)
-
-				if len(v) > 0 {
-					cur.markRead(v[0].UnixNano(), v[len(v)-1].UnixNano())
-				}
+				// Merge the remaing values with the existing
 				values = {{.Name}}Values(v).Merge(values)
 			}
+			cur.markRead(minT, maxT)
 		}
 	}
 

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -459,6 +459,307 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 	}
 }
 
+// Tests that blocks with a lower min time in later files are not returned
+// more than once causing unsorted results
+func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 1.0), tsm1.NewValue(3, 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.0), tsm1.NewValue(4, 4.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 0.0), tsm1.NewValue(1, 1.1)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.2)}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	buf := make([]tsm1.FloatValue, 1000)
+	c := fs.KeyCursor("cpu", 0, true)
+	// Search for an entry that exists in the second file
+	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := []tsm1.Value{
+		data[2].values[0],
+		data[2].values[1],
+		data[3].values[0],
+		data[0].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	exp = nil
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+}
+
+// Tests that blocks with a lower min time in later files are not returned
+// more than once causing unsorted results
+func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, int64(1)), tsm1.NewValue(3, int64(3))}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, int64(2)), tsm1.NewValue(4, int64(4))}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, int64(0)), tsm1.NewValue(1, int64(10))}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, int64(5))}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	buf := make([]tsm1.IntegerValue, 1000)
+	c := fs.KeyCursor("cpu", 0, true)
+	// Search for an entry that exists in the second file
+	values, err := c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := []tsm1.Value{
+		data[2].values[0],
+		data[2].values[1],
+		data[3].values[0],
+		data[0].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	exp = nil
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+}
+
+// Tests that blocks with a lower min time in later files are not returned
+// more than once causing unsorted results
+func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, true), tsm1.NewValue(3, true)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, true), tsm1.NewValue(4, true)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, true), tsm1.NewValue(1, false)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, false)}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	buf := make([]tsm1.BooleanValue, 1000)
+	c := fs.KeyCursor("cpu", 0, true)
+	// Search for an entry that exists in the second file
+	values, err := c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := []tsm1.Value{
+		data[2].values[0],
+		data[2].values[1],
+		data[3].values[0],
+		data[0].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	exp = nil
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+}
+
+// Tests that blocks with a lower min time in later files are not returned
+// more than once causing unsorted results
+func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, "1.0"), tsm1.NewValue(3, "3.0")}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, "2.0"), tsm1.NewValue(4, "4.0")}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, "0.0"), tsm1.NewValue(1, "1.1")}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, "2.2")}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	buf := make([]tsm1.StringValue, 1000)
+	c := fs.KeyCursor("cpu", 0, true)
+	// Search for an entry that exists in the second file
+	values, err := c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := []tsm1.Value{
+		data[2].values[0],
+		data[2].values[1],
+		data[3].values[0],
+		data[0].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	// Check that calling Next will dedupe points
+	c.Next()
+	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[1].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	exp = nil
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+}
+
 func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)
@@ -487,16 +788,34 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
 
-	exp := data[0]
-	if got, exp := len(values), len(exp.values); got != exp {
+	exp := []tsm1.Value{data[0].values[2]}
+	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
 
-	for i, v := range exp.values {
+	for i, v := range exp {
 		if got, exp := values[i].Value(), v.Value(); got != exp {
 			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
 		}
 	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{data[1].values[0]}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
 }
 
 func TestFileStore_SeekToAsc_End(t *testing.T) {
@@ -632,7 +951,260 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
 		}
 	}
+}
 
+func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, 1.0), tsm1.NewValue(3, 3.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.0), tsm1.NewValue(4, 4.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 0.0), tsm1.NewValue(1, 1.1)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, 2.2)}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	// Search for an entry that exists in the second file
+	buf := make([]tsm1.FloatValue, 1000)
+	c := fs.KeyCursor("cpu", 5, false)
+	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+		data[1].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+	exp = []tsm1.Value{
+
+		data[2].values[0],
+		data[2].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, int64(1)), tsm1.NewValue(3, int64(3))}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, int64(2)), tsm1.NewValue(4, int64(4))}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, int64(0)), tsm1.NewValue(1, int64(10))}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, int64(5))}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	// Search for an entry that exists in the second file
+	buf := make([]tsm1.IntegerValue, 1000)
+	c := fs.KeyCursor("cpu", 5, false)
+	values, err := c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+		data[1].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+	exp = []tsm1.Value{
+		data[2].values[0],
+		data[2].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, true), tsm1.NewValue(3, true)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, true), tsm1.NewValue(4, true)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, true), tsm1.NewValue(1, false)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, false)}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	// Search for an entry that exists in the second file
+	buf := make([]tsm1.BooleanValue, 1000)
+	c := fs.KeyCursor("cpu", 5, false)
+	values, err := c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+		data[1].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+	exp = []tsm1.Value{
+		data[2].values[0],
+		data[2].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(1, "1.0"), tsm1.NewValue(3, "3.0")}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, "2.0"), tsm1.NewValue(4, "4.0")}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, "0.0"), tsm1.NewValue(1, "1.1")}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(2, "2.2")}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	fs.Add(files...)
+
+	// Search for an entry that exists in the second file
+	buf := make([]tsm1.StringValue, 1000)
+	c := fs.KeyCursor("cpu", 5, false)
+	values, err := c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp := []tsm1.Value{
+		data[3].values[0],
+		data[0].values[1],
+		data[1].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+	exp = []tsm1.Value{
+		data[2].values[0],
+		data[2].values[1],
+	}
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
 }
 
 func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
@@ -791,37 +1363,17 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make([]tsm1.IntegerValue, 1000)
-	c := fs.KeyCursor("cpu", 8, false)
+	c := fs.KeyCursor("cpu", 11, false)
 	values, err := c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
 
 	exp := []tsm1.Value{
+		data[3].values[0],
 		data[0].values[0],
 		data[0].values[1],
 		data[3].values[1],
-	}
-
-	if got, exp := len(values), len(exp); got != exp {
-		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, v := range exp {
-		if got, exp := values[i].Value(), v.Value(); got != exp {
-			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
-		}
-	}
-
-	c.Next()
-	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
-
-	if err != nil {
-		t.Fatalf("unexpected error reading values: %v", err)
-	}
-
-	exp = []tsm1.Value{
-		data[3].values[0],
 	}
 
 	if got, exp := len(values), len(exp); got != exp {
@@ -888,7 +1440,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make([]tsm1.BooleanValue, 1000)
-	c := fs.KeyCursor("cpu", 8, false)
+	c := fs.KeyCursor("cpu", 11, false)
 	values, err := c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -985,7 +1537,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 	fs.Add(files...)
 
 	buf := make([]tsm1.StringValue, 1000)
-	c := fs.KeyCursor("cpu", 8, false)
+	c := fs.KeyCursor("cpu", 11, false)
 	values, err := c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1091,15 +1643,50 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
 
-	exp := data[1]
-	if got, exp := len(values), len(exp.values); got != exp {
+	exp := []tsm1.Value{
+		data[1].values[0],
+		data[1].values[1],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
 
-	for i, v := range exp.values {
+	for i, v := range exp {
 		if got, exp := values[i].Value(), v.Value(); got != exp {
 			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
 		}
+	}
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	exp = []tsm1.Value{
+		data[0].values[0],
+	}
+
+	if got, exp := len(values), len(exp); got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range exp {
+		if got, exp := values[i].Value(), v.Value(); got != exp {
+			t.Fatalf("read value mismatch(%d): got %v, exp %v", i, got, exp)
+		}
+	}
+
+	c.Next()
+	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error reading values: %v", err)
+	}
+
+	if got, exp := len(values), 0; got != exp {
+		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
 	}
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

If there were blocks in later TSM files that were for overwritten
points or writes into the past, they could be returned more than
once or out of order causing the cursor values to be unsorted.

One effect of this is that graphs in graphana would render with
the line going all over the place in spots.

This might also cause duplicate data to be returned.

Fixes #6738