### PR TITLE
fix ClusterID generation bug

### DIFF
--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -66,7 +66,7 @@ type authUser struct {
 func NewClient(config *Config) *Client {
 	return &Client{
 		cacheData: &Data{
-			ClusterID: uint64(uint64(rand.Int63())),
+			ClusterID: uint64(rand.Int63()),
 			Index:     1,
 			DefaultRetentionPolicyName: config.DefaultRetentionPolicyName,
 		},


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA]

Why convert to uint64 twice? Maybe just a little bug

