### PR TITLE
Trim BOM from config file for windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6820](https://github.com/influxdata/influxdb/issues/6820): Add NodeID to execution options
 - [#4532](https://github.com/influxdata/influxdb/issues/4532): Support regex selection in SHOW TAG VALUES for the key.
 - [#6889](https://github.com/influxdata/influxdb/pull/6889): Update help and remove unused config options from the configuration file.
+- [#6900](https://github.com/influxdata/influxdb/pull/6900): Trim BOM from Windows Notepad-saved config files.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -110,12 +111,20 @@ func NewDemoConfig() (*Config, error) {
 	return c, nil
 }
 
+// trimBOM trims the Byte-Order-Marks from the beginning of the file.
+// this is for Windows compatability only.
+// see https://github.com/influxdata/telegraf/issues/1378
+func trimBOM(f []byte) []byte {
+	return bytes.TrimPrefix(f, []byte("\xef\xbb\xbf"))
+}
+
 // FromTomlFile loads the config from a TOML file.
 func (c *Config) FromTomlFile(fpath string) error {
 	bs, err := ioutil.ReadFile(fpath)
 	if err != nil {
 		return err
 	}
+	bs = trimBOM(bs)
 	return c.FromToml(string(bs))
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Default windows text editor (Notepad) adds a BOM to the beginning of the
file. This needs to be trimmed otherwise we will get an "invalid toml"
error.

see https://github.com/influxdata/telegraf/issues/1378
and http://utf8everywhere.org/#faq.boms