### PR TITLE
delete redundant code in NewStore function

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -50,7 +50,6 @@ type Store struct {
 // The returned store must be initialized by calling Open before using it.
 func NewStore(path string) *Store {
 	opts := NewEngineOptions()
-	opts.Config = NewConfig()
 
 	return &Store{
 		path:          path,


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA]

The `opts.Config` has already been initialized in func `NewEngineOptions` , no need to be initialized again.

here: https://github.com/influxdata/influxdb/blob/master/tsdb/engine.go#L123 