### PR TITLE
Fix regex binary encoding for a measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6738](https://github.com/influxdata/influxdb/issues/6738): Time sorting broken with overwritten points
 - [#6829](https://github.com/influxdata/influxdb/issues/6829): Fix panic: runtime error: index out of range
 - [#6911](https://github.com/influxdata/influxdb/issues/6911): Fix fill(previous) when used with math operators.
+- [#6934](https://github.com/influxdata/influxdb/issues/6934): Fix regex binary encoding for a measurement.
 
 ## v0.13.0 [2016-05-12]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -3071,7 +3071,7 @@ func encodeMeasurement(mm *Measurement) *internal.Measurement {
 		IsTarget:        proto.Bool(mm.IsTarget),
 	}
 	if mm.Regex != nil {
-		pb.Regex = proto.String(mm.Regex.String())
+		pb.Regex = proto.String(mm.Regex.Val.String())
 	}
 	return pb
 }

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -999,7 +999,7 @@ func TestIteratorOptions_MarshalBinary_Measurement_Regex(t *testing.T) {
 	var other influxql.IteratorOptions
 	if err := other.UnmarshalBinary(buf); err != nil {
 		t.Fatal(err)
-	} else if v := other.Sources[0].(*influxql.Measurement).Regex.Val.String(); v != `/series.+/` {
+	} else if v := other.Sources[0].(*influxql.Measurement).Regex.Val.String(); v != `series.+` {
 		t.Fatalf("unexpected measurement regex: %s", v)
 	}
 }


### PR DESCRIPTION
Previously, it encoded the text representation of the regex literal
which included the surrounding slashes used in the query language. The
binary encoding should only include the exact string used to create the
regular expression.