### PR TITLE
Remove unused stats for expvar when the database is dropped

### DIFF
--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -2,7 +2,6 @@ package coordinator
 
 import (
 	"errors"
-	"expvar"
 	"io"
 	"log"
 	"os"
@@ -10,6 +9,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"

--- a/expvar/expvar.go
+++ b/expvar/expvar.go
@@ -1,0 +1,333 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package expvar provides a standardized interface to public variables, such
+// as operation counters in servers. It exposes these variables via HTTP at
+// /debug/vars in JSON format.
+//
+// Operations to set or modify these public variables are atomic.
+//
+// In addition to adding the HTTP handler, this package registers the
+// following variables:
+//
+//	cmdline   os.Args
+//	memstats  runtime.Memstats
+//
+// The package is sometimes only imported for the side effect of
+// registering its HTTP handler and the above variables.  To use it
+// this way, link this package into your program:
+//	import _ "expvar"
+//
+package expvar
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+)
+
+// Var is an abstract type for all exported variables.
+type Var interface {
+	String() string
+}
+
+// Int is a 64-bit integer variable that satisfies the Var interface.
+type Int struct {
+	i int64
+}
+
+func (v *Int) String() string {
+	return strconv.FormatInt(atomic.LoadInt64(&v.i), 10)
+}
+
+func (v *Int) Add(delta int64) {
+	atomic.AddInt64(&v.i, delta)
+}
+
+func (v *Int) Set(value int64) {
+	atomic.StoreInt64(&v.i, value)
+}
+
+// Float is a 64-bit float variable that satisfies the Var interface.
+type Float struct {
+	f uint64
+}
+
+func (v *Float) String() string {
+	return strconv.FormatFloat(
+		math.Float64frombits(atomic.LoadUint64(&v.f)), 'g', -1, 64)
+}
+
+// Add adds delta to v.
+func (v *Float) Add(delta float64) {
+	for {
+		cur := atomic.LoadUint64(&v.f)
+		curVal := math.Float64frombits(cur)
+		nxtVal := curVal + delta
+		nxt := math.Float64bits(nxtVal)
+		if atomic.CompareAndSwapUint64(&v.f, cur, nxt) {
+			return
+		}
+	}
+}
+
+// Set sets v to value.
+func (v *Float) Set(value float64) {
+	atomic.StoreUint64(&v.f, math.Float64bits(value))
+}
+
+// Map is a string-to-Var map variable that satisfies the Var interface.
+type Map struct {
+	mu   sync.RWMutex
+	m    map[string]Var
+	keys []string // sorted
+}
+
+// KeyValue represents a single entry in a Map.
+type KeyValue struct {
+	Key   string
+	Value Var
+}
+
+func (v *Map) String() string {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "{")
+	first := true
+	v.doLocked(func(kv KeyValue) {
+		if !first {
+			fmt.Fprintf(&b, ", ")
+		}
+		fmt.Fprintf(&b, "%q: %v", kv.Key, kv.Value)
+		first = false
+	})
+	fmt.Fprintf(&b, "}")
+	return b.String()
+}
+
+func (v *Map) Init() *Map {
+	v.m = make(map[string]Var)
+	return v
+}
+
+// updateKeys updates the sorted list of keys in v.keys.
+// must be called with v.mu held.
+func (v *Map) updateKeys() {
+	if len(v.m) == len(v.keys) {
+		// No new key.
+		return
+	}
+	v.keys = v.keys[:0]
+	for k := range v.m {
+		v.keys = append(v.keys, k)
+	}
+	sort.Strings(v.keys)
+}
+
+func (v *Map) Get(key string) Var {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.m[key]
+}
+
+func (v *Map) Set(key string, av Var) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.m[key] = av
+	v.updateKeys()
+}
+
+func (v *Map) Add(key string, delta int64) {
+	v.mu.RLock()
+	av, ok := v.m[key]
+	v.mu.RUnlock()
+	if !ok {
+		// check again under the write lock
+		v.mu.Lock()
+		av, ok = v.m[key]
+		if !ok {
+			av = new(Int)
+			v.m[key] = av
+			v.updateKeys()
+		}
+		v.mu.Unlock()
+	}
+
+	// Add to Int; ignore otherwise.
+	if iv, ok := av.(*Int); ok {
+		iv.Add(delta)
+	}
+}
+
+// AddFloat adds delta to the *Float value stored under the given map key.
+func (v *Map) AddFloat(key string, delta float64) {
+	v.mu.RLock()
+	av, ok := v.m[key]
+	v.mu.RUnlock()
+	if !ok {
+		// check again under the write lock
+		v.mu.Lock()
+		av, ok = v.m[key]
+		if !ok {
+			av = new(Float)
+			v.m[key] = av
+			v.updateKeys()
+		}
+		v.mu.Unlock()
+	}
+
+	// Add to Float; ignore otherwise.
+	if iv, ok := av.(*Float); ok {
+		iv.Add(delta)
+	}
+}
+
+// Do calls f for each entry in the map.
+// The map is locked during the iteration,
+// but existing entries may be concurrently updated.
+func (v *Map) Do(f func(KeyValue)) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	v.doLocked(f)
+}
+
+// doLocked calls f for each entry in the map.
+// v.mu must be held for reads.
+func (v *Map) doLocked(f func(KeyValue)) {
+	for _, k := range v.keys {
+		f(KeyValue{k, v.m[k]})
+	}
+}
+
+// String is a string variable, and satisfies the Var interface.
+type String struct {
+	mu sync.RWMutex
+	s  string
+}
+
+func (v *String) String() string {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return strconv.Quote(v.s)
+}
+
+func (v *String) Set(value string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.s = value
+}
+
+// Func implements Var by calling the function
+// and formatting the returned value using JSON.
+type Func func() interface{}
+
+func (f Func) String() string {
+	v, _ := json.Marshal(f())
+	return string(v)
+}
+
+// All published variables.
+var (
+	mutex   sync.RWMutex
+	vars    = make(map[string]Var)
+	varKeys []string // sorted
+)
+
+// Publish declares a named exported variable. This should be called from a
+// package's init function when it creates its Vars. If the name is already
+// registered then this will log.Panic.
+func Publish(name string, v Var) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	if _, existing := vars[name]; existing {
+		log.Panicln("Reuse of exported var name:", name)
+	}
+	vars[name] = v
+	varKeys = append(varKeys, name)
+	sort.Strings(varKeys)
+}
+
+// Get retrieves a named exported variable.
+func Get(name string) Var {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	return vars[name]
+}
+
+// Convenience functions for creating new exported variables.
+
+func NewInt(name string) *Int {
+	v := new(Int)
+	Publish(name, v)
+	return v
+}
+
+func NewFloat(name string) *Float {
+	v := new(Float)
+	Publish(name, v)
+	return v
+}
+
+func NewMap(name string) *Map {
+	v := new(Map).Init()
+	Publish(name, v)
+	return v
+}
+
+func NewString(name string) *String {
+	v := new(String)
+	Publish(name, v)
+	return v
+}
+
+// Do calls f for each exported variable.
+// The global variable map is locked during the iteration,
+// but existing entries may be concurrently updated.
+func Do(f func(KeyValue)) {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	for _, k := range varKeys {
+		f(KeyValue{k, vars[k]})
+	}
+}
+
+func expvarHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintf(w, "{\n")
+	first := true
+	Do(func(kv KeyValue) {
+		if !first {
+			fmt.Fprintf(w, ",\n")
+		}
+		first = false
+		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
+	})
+	fmt.Fprintf(w, "\n}\n")
+}
+
+func cmdline() interface{} {
+	return os.Args
+}
+
+func memstats() interface{} {
+	stats := new(runtime.MemStats)
+	runtime.ReadMemStats(stats)
+	return *stats
+}
+
+func init() {
+	http.HandleFunc("/debug/vars", expvarHandler)
+	Publish("cmdline", Func(cmdline))
+	Publish("memstats", Func(memstats))
+}

--- a/expvar/expvar_test.go
+++ b/expvar/expvar_test.go
@@ -1,0 +1,390 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package expvar
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"net"
+	"net/http/httptest"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// RemoveAll removes all exported variables.
+// This is for tests only.
+func RemoveAll() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	vars = make(map[string]Var)
+	varKeys = nil
+}
+
+func TestInt(t *testing.T) {
+	RemoveAll()
+	reqs := NewInt("requests")
+	if reqs.i != 0 {
+		t.Errorf("reqs.i = %v, want 0", reqs.i)
+	}
+	if reqs != Get("requests").(*Int) {
+		t.Errorf("Get() failed.")
+	}
+
+	reqs.Add(1)
+	reqs.Add(3)
+	if reqs.i != 4 {
+		t.Errorf("reqs.i = %v, want 4", reqs.i)
+	}
+
+	if s := reqs.String(); s != "4" {
+		t.Errorf("reqs.String() = %q, want \"4\"", s)
+	}
+
+	reqs.Set(-2)
+	if reqs.i != -2 {
+		t.Errorf("reqs.i = %v, want -2", reqs.i)
+	}
+}
+
+func BenchmarkIntAdd(b *testing.B) {
+	var v Int
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			v.Add(1)
+		}
+	})
+}
+
+func BenchmarkIntSet(b *testing.B) {
+	var v Int
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			v.Set(1)
+		}
+	})
+}
+
+func (v *Float) val() float64 {
+	return math.Float64frombits(atomic.LoadUint64(&v.f))
+}
+
+func TestFloat(t *testing.T) {
+	RemoveAll()
+	reqs := NewFloat("requests-float")
+	if reqs.f != 0.0 {
+		t.Errorf("reqs.f = %v, want 0", reqs.f)
+	}
+	if reqs != Get("requests-float").(*Float) {
+		t.Errorf("Get() failed.")
+	}
+
+	reqs.Add(1.5)
+	reqs.Add(1.25)
+	if v := reqs.val(); v != 2.75 {
+		t.Errorf("reqs.val() = %v, want 2.75", v)
+	}
+
+	if s := reqs.String(); s != "2.75" {
+		t.Errorf("reqs.String() = %q, want \"4.64\"", s)
+	}
+
+	reqs.Add(-2)
+	if v := reqs.val(); v != 0.75 {
+		t.Errorf("reqs.val() = %v, want 0.75", v)
+	}
+}
+
+func BenchmarkFloatAdd(b *testing.B) {
+	var f Float
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			f.Add(1.0)
+		}
+	})
+}
+
+func BenchmarkFloatSet(b *testing.B) {
+	var f Float
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			f.Set(1.0)
+		}
+	})
+}
+
+func TestString(t *testing.T) {
+	RemoveAll()
+	name := NewString("my-name")
+	if name.s != "" {
+		t.Errorf("name.s = %q, want \"\"", name.s)
+	}
+
+	name.Set("Mike")
+	if name.s != "Mike" {
+		t.Errorf("name.s = %q, want \"Mike\"", name.s)
+	}
+
+	if s := name.String(); s != "\"Mike\"" {
+		t.Errorf("reqs.String() = %q, want \"\"Mike\"\"", s)
+	}
+}
+
+func BenchmarkStringSet(b *testing.B) {
+	var s String
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			s.Set("red")
+		}
+	})
+}
+
+func TestMapCounter(t *testing.T) {
+	RemoveAll()
+	colors := NewMap("bike-shed-colors")
+
+	colors.Add("red", 1)
+	colors.Add("red", 2)
+	colors.Add("blue", 4)
+	colors.AddFloat(`green "midori"`, 4.125)
+	if x := colors.m["red"].(*Int).i; x != 3 {
+		t.Errorf("colors.m[\"red\"] = %v, want 3", x)
+	}
+	if x := colors.m["blue"].(*Int).i; x != 4 {
+		t.Errorf("colors.m[\"blue\"] = %v, want 4", x)
+	}
+	if x := colors.m[`green "midori"`].(*Float).val(); x != 4.125 {
+		t.Errorf("colors.m[`green \"midori\"] = %v, want 4.125", x)
+	}
+
+	// colors.String() should be '{"red":3, "blue":4}',
+	// though the order of red and blue could vary.
+	s := colors.String()
+	var j interface{}
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		t.Errorf("colors.String() isn't valid JSON: %v", err)
+	}
+	m, ok := j.(map[string]interface{})
+	if !ok {
+		t.Error("colors.String() didn't produce a map.")
+	}
+	red := m["red"]
+	x, ok := red.(float64)
+	if !ok {
+		t.Error("red.Kind() is not a number.")
+	}
+	if x != 3 {
+		t.Errorf("red = %v, want 3", x)
+	}
+}
+
+func BenchmarkMapSet(b *testing.B) {
+	m := new(Map).Init()
+
+	v := new(Int)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			m.Set("red", v)
+		}
+	})
+}
+
+func BenchmarkMapAddSame(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m := new(Map).Init()
+		m.Add("red", 1)
+		m.Add("red", 1)
+		m.Add("red", 1)
+		m.Add("red", 1)
+	}
+}
+
+func BenchmarkMapAddDifferent(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m := new(Map).Init()
+		m.Add("red", 1)
+		m.Add("blue", 1)
+		m.Add("green", 1)
+		m.Add("yellow", 1)
+	}
+}
+
+func TestFunc(t *testing.T) {
+	RemoveAll()
+	var x interface{} = []string{"a", "b"}
+	f := Func(func() interface{} { return x })
+	if s, exp := f.String(), `["a","b"]`; s != exp {
+		t.Errorf(`f.String() = %q, want %q`, s, exp)
+	}
+
+	x = 17
+	if s, exp := f.String(), `17`; s != exp {
+		t.Errorf(`f.String() = %q, want %q`, s, exp)
+	}
+}
+
+func TestHandler(t *testing.T) {
+	RemoveAll()
+	m := NewMap("map1")
+	m.Add("a", 1)
+	m.Add("z", 2)
+	m2 := NewMap("map2")
+	for i := 0; i < 9; i++ {
+		m2.Add(strconv.Itoa(i), int64(i))
+	}
+	rr := httptest.NewRecorder()
+	rr.Body = new(bytes.Buffer)
+	expvarHandler(rr, nil)
+	want := `{
+"map1": {"a": 1, "z": 2},
+"map2": {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8}
+}
+`
+	if got := rr.Body.String(); got != want {
+		t.Errorf("HTTP handler wrote:\n%s\nWant:\n%s", got, want)
+	}
+}
+
+func BenchmarkRealworldExpvarUsage(b *testing.B) {
+	var (
+		bytesSent Int
+		bytesRead Int
+	)
+
+	// The benchmark creates GOMAXPROCS client/server pairs.
+	// Each pair creates 4 goroutines: client reader/writer and server reader/writer.
+	// The benchmark stresses concurrent reading and writing to the same connection.
+	// Such pattern is used in net/http and net/rpc.
+
+	b.StopTimer()
+
+	P := runtime.GOMAXPROCS(0)
+	N := b.N / P
+	W := 1000
+
+	// Setup P client/server connections.
+	clients := make([]net.Conn, P)
+	servers := make([]net.Conn, P)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatalf("Listen failed: %v", err)
+	}
+	defer ln.Close()
+	done := make(chan bool)
+	go func() {
+		for p := 0; p < P; p++ {
+			s, err := ln.Accept()
+			if err != nil {
+				b.Errorf("Accept failed: %v", err)
+				return
+			}
+			servers[p] = s
+		}
+		done <- true
+	}()
+	for p := 0; p < P; p++ {
+		c, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			b.Fatalf("Dial failed: %v", err)
+		}
+		clients[p] = c
+	}
+	<-done
+
+	b.StartTimer()
+
+	var wg sync.WaitGroup
+	wg.Add(4 * P)
+	for p := 0; p < P; p++ {
+		// Client writer.
+		go func(c net.Conn) {
+			defer wg.Done()
+			var buf [1]byte
+			for i := 0; i < N; i++ {
+				v := byte(i)
+				for w := 0; w < W; w++ {
+					v *= v
+				}
+				buf[0] = v
+				n, err := c.Write(buf[:])
+				if err != nil {
+					b.Errorf("Write failed: %v", err)
+					return
+				}
+
+				bytesSent.Add(int64(n))
+			}
+		}(clients[p])
+
+		// Pipe between server reader and server writer.
+		pipe := make(chan byte, 128)
+
+		// Server reader.
+		go func(s net.Conn) {
+			defer wg.Done()
+			var buf [1]byte
+			for i := 0; i < N; i++ {
+				n, err := s.Read(buf[:])
+
+				if err != nil {
+					b.Errorf("Read failed: %v", err)
+					return
+				}
+
+				bytesRead.Add(int64(n))
+				pipe <- buf[0]
+			}
+		}(servers[p])
+
+		// Server writer.
+		go func(s net.Conn) {
+			defer wg.Done()
+			var buf [1]byte
+			for i := 0; i < N; i++ {
+				v := <-pipe
+				for w := 0; w < W; w++ {
+					v *= v
+				}
+				buf[0] = v
+				n, err := s.Write(buf[:])
+				if err != nil {
+					b.Errorf("Write failed: %v", err)
+					return
+				}
+
+				bytesSent.Add(int64(n))
+			}
+			s.Close()
+		}(servers[p])
+
+		// Client reader.
+		go func(c net.Conn) {
+			defer wg.Done()
+			var buf [1]byte
+			for i := 0; i < N; i++ {
+				n, err := c.Read(buf[:])
+
+				if err != nil {
+					b.Errorf("Read failed: %v", err)
+					return
+				}
+
+				bytesRead.Add(int64(n))
+			}
+			c.Close()
+		}(clients[p])
+	}
+	wg.Wait()
+}

--- a/expvar/expvar_test.go
+++ b/expvar/expvar_test.go
@@ -246,7 +246,7 @@ func TestHandler(t *testing.T) {
 	}
 	rr := httptest.NewRecorder()
 	rr.Body = new(bytes.Buffer)
-	expvarHandler(rr, nil)
+	Handler(rr, nil)
 	want := `{
 "map1": {"a": 1, "z": 2},
 "map2": {"0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8}
@@ -387,4 +387,24 @@ func BenchmarkRealworldExpvarUsage(b *testing.B) {
 		}(clients[p])
 	}
 	wg.Wait()
+}
+
+func TestDoublePublish(t *testing.T) {
+	_ = NewInt("value")
+	exp := NewInt("value")
+	if got := Get("value"); got != exp {
+		t.Fatalf(`Get("value") = %q, want %q`, got, exp)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	exp := NewInt("value")
+	if got := Get("value"); got != exp {
+		t.Fatalf(`Get("value") = %q, want %q`, got, exp)
+	}
+
+	Remove("value")
+	if got, exp := Get("value"), Var(nil); got != exp {
+		t.Fatalf(`Get("value") = %q, want %q`, got, exp)
+	}
 }

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -2,7 +2,6 @@ package influxql
 
 import (
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 )
 
 var (

--- a/influxvar.go
+++ b/influxvar.go
@@ -1,8 +1,9 @@
 package influxdb
 
 import (
-	"expvar"
 	"sync"
+
+	"github.com/influxdata/influxdb/expvar"
 )
 
 var expvarMu sync.Mutex

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -45,7 +45,7 @@ For example, if you have a component called `Service`, you can statistics like s
 
 ```
 import (
-     "expvar"
+     "github.com/influxdata/influxdb/expvar"
      "github.com/influxdata/influxdb"
 )
 .

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -1,7 +1,6 @@
 package monitor // import "github.com/influxdata/influxdb/monitor"
 
 import (
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/monitor/diagnostics"
 	"github.com/influxdata/influxdb/services/meta"

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -1,7 +1,6 @@
 package collectd // import "github.com/influxdata/influxdb/services/collectd"
 
 import (
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -2,7 +2,6 @@ package continuous_querier // import "github.com/influxdata/influxdb/services/co
 
 import (
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/services/meta"
 )

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -2,7 +2,6 @@ package graphite // import "github.com/influxdata/influxdb/services/graphite"
 
 import (
 	"bufio"
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/monitor/diagnostics"
 	"github.com/influxdata/influxdb/services/meta"

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -20,6 +19,7 @@ import (
 	"github.com/bmizerany/pat"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/continuous_querier"
@@ -199,7 +199,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			pprof.Index(w, r)
 		}
 	} else if strings.HasPrefix(r.URL.Path, "/debug/vars") {
-		serveExpvar(w, r)
+		expvar.Handler(w, r)
 	} else {
 		h.mux.ServeHTTP(w, r)
 	}
@@ -633,21 +633,6 @@ func MarshalJSON(v interface{}, pretty bool) []byte {
 		return []byte(err.Error())
 	}
 	return b
-}
-
-// serveExpvar serves registered expvar information over HTTP.
-func serveExpvar(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, "{\n")
-	first := true
-	expvar.Do(func(kv expvar.KeyValue) {
-		if !first {
-			fmt.Fprintf(w, ",\n")
-		}
-		first = false
-		fmt.Fprintf(w, "%q: %s", kv.Key, kv.Value)
-	})
-	fmt.Fprintf(w, "\n}\n")
 }
 
 // h.httpError writes an error to the client in a standard format.

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -2,7 +2,6 @@ package httpd // import "github.com/influxdata/influxdb/services/httpd"
 
 import (
 	"crypto/tls"
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 )
 
 // statistics gathered by the httpd package.

--- a/services/opentsdb/handler.go
+++ b/services/opentsdb/handler.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
-	"expvar"
 	"io"
 	"log"
 	"net"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/models"
 )
 

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
-	"expvar"
 	"io"
 	"log"
 	"net"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -2,7 +2,6 @@ package subscriber // import "github.com/influxdata/influxdb/services/subscriber
 
 import (
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/coordinator"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/services/meta"
 )
 

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -2,7 +2,6 @@ package udp // import "github.com/influxdata/influxdb/services/udp"
 
 import (
 	"errors"
-	"expvar"
 	"io"
 	"log"
 	"net"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"

--- a/stress/stress_test_server/server.go
+++ b/stress/stress_test_server/server.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-	"expvar"
 	"fmt"
-	"github.com/paulbellamy/ratecounter"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/influxdata/influxdb/expvar"
+	"github.com/paulbellamy/ratecounter"
 )
 
 var (

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -1,7 +1,6 @@
 package tsm1
 
 import (
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/tsdb"
 )
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/tsdb"
@@ -240,8 +241,11 @@ func (e *Engine) Close() error {
 
 	if err := e.FileStore.Close(); err != nil {
 		return err
+	} else if err := e.WAL.Close(); err != nil {
+		return err
 	}
-	return e.WAL.Close()
+	expvar.Remove("tsm1_cache:" + e.path)
+	return nil
 }
 
 // SetLogOutput sets the logger used for all messages. It must not be called

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -386,6 +386,7 @@ func (f *FileStore) Close() error {
 	}
 
 	f.files = nil
+	expvar.Remove("tsm1_filestore:" + f.dir)
 	return nil
 }
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -1,7 +1,6 @@
 package tsm1
 
 import (
-	"expvar"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/tsdb"
 )
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -3,7 +3,6 @@ package tsm1
 import (
 	"encoding/binary"
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/tsdb"
 )
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -389,6 +389,7 @@ func (l *WAL) Close() error {
 		l.currentSegmentWriter = nil
 	}
 
+	expvar.Remove("tsm1_wal:" + l.path)
 	return nil
 }
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1,13 +1,13 @@
 package tsdb
 
 import (
-	"expvar"
 	"fmt"
 	"regexp"
 	"sort"
 	"sync"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/escape"

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -2,7 +2,6 @@ package tsdb
 
 import (
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"log"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	internal "github.com/influxdata/influxdb/tsdb/internal"

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -248,6 +248,7 @@ func (s *Shard) close() error {
 	if err == nil {
 		s.engine = nil
 	}
+	expvar.Remove(fmt.Sprintf("shard:%s:%d", s.path, s.id))
 	return err
 }
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/influxdb/expvar"
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 )
@@ -371,6 +372,7 @@ func (s *Store) ShardIteratorCreator(id uint64) influxql.IteratorCreator {
 func (s *Store) DeleteDatabase(name string) error {
 	type resp struct {
 		shardID uint64
+		path    string
 		err     error
 	}
 
@@ -385,7 +387,7 @@ func (s *Store) DeleteDatabase(name string) error {
 			go func() {
 				defer wg.Done()
 				err := sh.Close()
-				responses <- resp{shardID, err}
+				responses <- resp{shardID, sh.path, err}
 			}()
 		}
 	}
@@ -412,6 +414,7 @@ func (s *Store) DeleteDatabase(name string) error {
 	}
 
 	delete(s.databaseIndexes, name)
+	expvar.Remove("database:" + name)
 	return nil
 }
 


### PR DESCRIPTION
This change switches to using a custom version of the expvar package that
allows removing previously published variables. While this works in a limited
number of cases, it is very error prone and we should consider switching to an
alternate solution as soon as we can. It is very difficult to manage the
statistics in a global variable like expvar and it limits the number of
different metrics we can create to begin with.

This has only been modified to remove the dead databases and shards. We can
continue applying this hotfix to other sections too, but this solution is only
for making a minimal viable product for 1.0 in case we can't do a proper
solution before then.

Fixes #6507.