### PR TITLE
Remove sysvinit-tools as an RPM package dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6708](https://github.com/influxdata/influxdb/issues/6708): Drop writes from before the retention policy time window.
 - [#6968](https://github.com/influxdata/influxdb/issues/6968): Always use the demo config when outputting a new config.
 - [#6986](https://github.com/influxdata/influxdb/pull/6986): update connection settings when changing hosts in cli.
+- [#6965](https://github.com/influxdata/influxdb/pull/6965): Minor improvements to init script. Removes sysvinit-utils as package dependency.
 
 ## v0.13.0 [2016-05-12]
 

--- a/build.py
+++ b/build.py
@@ -689,7 +689,7 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                             package_build_root,
                             current_location)
                         if package_type == "rpm":
-                            fpm_command += "--depends coreutils --depends sysvinit-tools --rpm-posttrans {}".format(POSTINST_SCRIPT)
+                            fpm_command += "--depends coreutils --rpm-posttrans {}".format(POSTINST_SCRIPT)
                         out = run(fpm_command, shell=True)
                         matches = re.search(':path=>"(.*)"', out)
                         outfile = None


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR reverts https://github.com/influxdata/influxdb/pull/6835, which added sysvinit-tools as an RPM dependency.

/cc @jsternberg 