### PR TITLE
update connection settings when changing hosts in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6942](https://github.com/influxdata/influxdb/pull/6942): Fix panic: truncate the slice when merging the caches.
 - [#6708](https://github.com/influxdata/influxdb/issues/6708): Drop writes from before the retention policy time window.
 - [#6968](https://github.com/influxdata/influxdb/issues/6968): Always use the demo config when outputting a new config.
+- [#6986](https://github.com/influxdata/influxdb/pull/6986): update connection settings when changing hosts in cli.
 
 ## v0.13.0 [2016-05-12]
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -292,6 +292,13 @@ func (c *CommandLine) Connect(cmd string) error {
 		return fmt.Errorf("Failed to connect to %s\n", c.Client.Addr())
 	}
 	c.ServerVersion = v
+	// Update the command with the current connection information
+	if h, p, err := net.SplitHostPort(config.URL.Host); err == nil {
+		c.Host = h
+		if i, err := strconv.Atoi(p); err == nil {
+			c.Port = i
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Currently, if you were in the CLI and changed the connection with the command:

```
> connect localhost:8186
```

And then issued a `settings` command, the command was not remembering the new connection state and would show the original host that you connected with when you opened the session.  This fix stores the current state of the host:port back to the command so that settings will accurately show the current state.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated


