### PR TITLE
Check slice bounds in tsm1 to avoid panics

### DIFF
--- a/tsdb/engine/tsm1/bool.go
+++ b/tsdb/engine/tsm1/bool.go
@@ -134,10 +134,10 @@ func (e *BooleanDecoder) Next() bool {
 
 func (e *BooleanDecoder) Read() bool {
 	// Index into the byte slice
-	idx := e.i / 8
+	idx := e.i >> 3 // integer division by 8
 
 	// Bit position
-	pos := (8 - e.i%8) - 1
+	pos := 7 - (e.i & 0x7)
 
 	// The mask to select the bit
 	mask := byte(1 << uint(pos))

--- a/tsdb/engine/tsm1/bool_test.go
+++ b/tsdb/engine/tsm1/bool_test.go
@@ -113,3 +113,20 @@ func Test_BooleanEncoder_Quick(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func Test_BooleanDecoder_Corrupt(t *testing.T) {
+	cases := []string{
+		"",         // Empty
+		"\x10\x90", // Packed: invalid count
+		"\x10\x7f", // Packed: count greater than remaining bits, multiple bytes expected
+		"\x10\x01", // Packed: count greater than remaining bits, one byte expected
+	}
+
+	for _, c := range cases {
+		var dec tsm1.BooleanDecoder
+		dec.SetBytes([]byte(c))
+		if dec.Next() {
+			t.Fatalf("exp next == false, got true for case %q", c)
+		}
+	}
+}

--- a/tsdb/engine/tsm1/bool_test.go
+++ b/tsdb/engine/tsm1/bool_test.go
@@ -130,3 +130,32 @@ func Test_BooleanDecoder_Corrupt(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkBooleanDecoder_2048(b *testing.B) { benchmarkBooleanDecoder(b, 2048) }
+
+func benchmarkBooleanDecoder(b *testing.B, size int) {
+	e := tsm1.NewBooleanEncoder()
+	for i := 0; i < size; i++ {
+		e.Write(i&1 == 1)
+	}
+	bytes, err := e.Bytes()
+	if err != nil {
+		b.Fatalf("unexpected error: %v", err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var d tsm1.BooleanDecoder
+		d.SetBytes(bytes)
+
+		var n int
+		for d.Next() {
+			_ = d.Read()
+			n++
+		}
+		if n != size {
+			b.Fatalf("expected to read %d booleans, but read %d", size, n)
+		}
+	}
+}

--- a/tsdb/engine/tsm1/float.go
+++ b/tsdb/engine/tsm1/float.go
@@ -142,13 +142,19 @@ type FloatDecoder struct {
 
 // SetBytes initializes the decoder with b. Must call before calling Next().
 func (it *FloatDecoder) SetBytes(b []byte) error {
-	// first byte is the compression type.
-	// we currently just have gorilla compression.
-	it.br.Reset(b[1:])
+	var v uint64
+	if len(b) == 0 {
+		v = uvnan
+	} else {
+		// first byte is the compression type.
+		// we currently just have gorilla compression.
+		it.br.Reset(b[1:])
 
-	v, err := it.br.ReadBits(64)
-	if err != nil {
-		return err
+		var err error
+		v, err = it.br.ReadBits(64)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Reset all fields.

--- a/tsdb/engine/tsm1/float_test.go
+++ b/tsdb/engine/tsm1/float_test.go
@@ -239,6 +239,17 @@ func Test_FloatEncoder_Quick(t *testing.T) {
 	}, nil)
 }
 
+func TestFloatDecoder_Empty(t *testing.T) {
+	var dec tsm1.FloatDecoder
+	if err := dec.SetBytes([]byte{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if dec.Next() {
+		t.Fatalf("exp next == false, got true")
+	}
+}
+
 func BenchmarkFloatEncoder(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		s := tsm1.NewFloatEncoder()

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -464,6 +464,25 @@ func Test_IntegerEncoder_Quick(t *testing.T) {
 	}, nil)
 }
 
+func Test_IntegerDecoder_Corrupt(t *testing.T) {
+	cases := []string{
+		"",                     // Empty
+		"\x00abc",              // Uncompressed: less than 8 bytes
+		"\x10abc",              // Packed: less than 8 bytes
+		"\x20abc",              // RLE: less than 8 bytes
+		"\x2012345678\x90",     // RLE: valid starting value but invalid delta value
+		"\x2012345678\x01\x90", // RLE: valid starting, valid delta value, invalid repeat value
+	}
+
+	for _, c := range cases {
+		var dec IntegerDecoder
+		dec.SetBytes([]byte(c))
+		if dec.Next() {
+			t.Fatalf("exp next == false, got true")
+		}
+	}
+}
+
 func BenchmarkIntegerEncoderRLE(b *testing.B) {
 	enc := NewIntegerEncoder()
 	x := make([]int64, 1024)

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -596,10 +596,15 @@ func (d *indirectIndex) Key(idx int) (string, []IndexEntry) {
 	if idx < 0 || idx >= len(d.offsets) {
 		return "", nil
 	}
-	n, key, _ := readKey(d.b[d.offsets[idx]:])
+	n, key, err := readKey(d.b[d.offsets[idx]:])
+	if err != nil {
+		return "", nil
+	}
 
 	var entries indexEntries
-	readEntries(d.b[int(d.offsets[idx])+n:], &entries)
+	if _, err := readEntries(d.b[int(d.offsets[idx])+n:], &entries); err != nil {
+		return "", nil
+	}
 	return string(key), entries.entries
 }
 
@@ -773,6 +778,9 @@ func (d *indirectIndex) UnmarshalBinary(b []byte) error {
 
 	// Keep a reference to the actual index bytes
 	d.b = b
+	if len(b) == 0 {
+		return nil
+	}
 
 	//var minKey, maxKey []byte
 	var minTime, maxTime int64 = math.MaxInt64, 0
@@ -783,18 +791,28 @@ func (d *indirectIndex) UnmarshalBinary(b []byte) error {
 	// basically skips across the slice keeping track of the counter when we are at a key
 	// field.
 	var i int32
-	for i < int32(len(b)) {
+	iMax := int32(len(b))
+	for i < iMax {
 		d.offsets = append(d.offsets, i)
 
 		// Skip to the start of the values
 		// key length value (2) + type (1) + length of key
+		if i+2 >= iMax {
+			return fmt.Errorf("indirectIndex: not enough data for key length value")
+		}
 		i += 3 + int32(binary.BigEndian.Uint16(b[i:i+2]))
 
 		// count of index entries
+		if i+indexCountSize >= iMax {
+			return fmt.Errorf("indirectIndex: not enough data for index entries count")
+		}
 		count := int32(binary.BigEndian.Uint16(b[i : i+indexCountSize]))
 		i += indexCountSize
 
 		// Find the min time for the block
+		if i+8 >= iMax {
+			return fmt.Errorf("indirectIndex: not enough data for min time")
+		}
 		minT := int64(binary.BigEndian.Uint64(b[i : i+8]))
 		if minT < minTime {
 			minTime = minT
@@ -803,6 +821,9 @@ func (d *indirectIndex) UnmarshalBinary(b []byte) error {
 		i += (count - 1) * indexEntrySize
 
 		// Find the max time for the block
+		if i+16 >= iMax {
+			return fmt.Errorf("indirectIndex: not enough data for max time")
+		}
 		maxT := int64(binary.BigEndian.Uint64(b[i+8 : i+16]))
 		if maxT > maxTime {
 			maxTime = maxT
@@ -871,9 +892,15 @@ func (m *mmapAccessor) init() (*indirectIndex, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(m.b) < 8 {
+		return nil, fmt.Errorf("mmapAccessor: byte slice too small for indirectIndex")
+	}
 
 	indexOfsPos := len(m.b) - 8
 	indexStart := binary.BigEndian.Uint64(m.b[indexOfsPos : indexOfsPos+8])
+	if indexStart >= uint64(indexOfsPos) {
+		return nil, fmt.Errorf("mmapAccessor: invalid indexStart")
+	}
 
 	m.index = NewIndirectIndex()
 	if err := m.index.UnmarshalBinary(m.b[indexStart:indexOfsPos]); err != nil {
@@ -1106,6 +1133,10 @@ func readKey(b []byte) (n int, key []byte, err error) {
 }
 
 func readEntries(b []byte, entries *indexEntries) (n int, err error) {
+	if len(b) < 1+indexCountSize {
+		return 0, fmt.Errorf("readEntries: data too short for headers")
+	}
+
 	// 1 byte block type
 	entries.Type = b[n]
 	n++
@@ -1117,7 +1148,12 @@ func readEntries(b []byte, entries *indexEntries) (n int, err error) {
 	entries.entries = make([]IndexEntry, count)
 	for i := 0; i < count; i++ {
 		var ie IndexEntry
-		if err := ie.UnmarshalBinary(b[i*indexEntrySize+indexCountSize+indexTypeSize : i*indexEntrySize+indexCountSize+indexEntrySize+indexTypeSize]); err != nil {
+		start := i*indexEntrySize + indexCountSize + indexTypeSize
+		end := start + indexEntrySize
+		if end > len(b) {
+			return 0, fmt.Errorf("readEntries: data too short for indexEntry %d", i)
+		}
+		if err := ie.UnmarshalBinary(b[start:end]); err != nil {
 			return 0, fmt.Errorf("readEntries: unmarshal error: %v", err)
 		}
 		entries.entries[i] = ie

--- a/tsdb/engine/tsm1/string.go
+++ b/tsdb/engine/tsm1/string.go
@@ -59,9 +59,13 @@ type StringDecoder struct {
 func (e *StringDecoder) SetBytes(b []byte) error {
 	// First byte stores the encoding type, only have snappy format
 	// currently so ignore for now.
-	data, err := snappy.Decode(nil, b[1:])
-	if err != nil {
-		return fmt.Errorf("failed to decode string block: %v", err.Error())
+	var data []byte
+	if len(b) > 0 {
+		var err error
+		data, err = snappy.Decode(nil, b[1:])
+		if err != nil {
+			return fmt.Errorf("failed to decode string block: %v", err.Error())
+		}
 	}
 
 	e.b = data
@@ -73,6 +77,10 @@ func (e *StringDecoder) SetBytes(b []byte) error {
 }
 
 func (e *StringDecoder) Next() bool {
+	if e.err != nil {
+		return false
+	}
+
 	e.i += e.l
 	return e.i < len(e.b)
 }
@@ -80,11 +88,26 @@ func (e *StringDecoder) Next() bool {
 func (e *StringDecoder) Read() string {
 	// Read the length of the string
 	length, n := binary.Uvarint(e.b[e.i:])
+	if n <= 0 {
+		e.err = fmt.Errorf("StringDecoder: invalid encoded string length")
+		return ""
+	}
 
 	// The length of this string plus the length of the variable byte encoded length
 	e.l = int(length) + n
 
-	return string(e.b[e.i+n : e.i+n+int(length)])
+	lower := e.i + n
+	upper := lower + int(length)
+	if upper < lower {
+		e.err = fmt.Errorf("StringDecoder: length overflow")
+		return ""
+	}
+	if upper > len(e.b) {
+		e.err = fmt.Errorf("StringDecoder: not enough data to represent encoded string")
+		return ""
+	}
+
+	return string(e.b[lower:upper])
 }
 
 func (e *StringDecoder) Error() error {

--- a/tsdb/engine/tsm1/timestamp_test.go
+++ b/tsdb/engine/tsm1/timestamp_test.go
@@ -525,6 +525,25 @@ func TestTimeEncoder_Count_Simple8(t *testing.T) {
 	}
 }
 
+func TestTimeDecoder_Corrupt(t *testing.T) {
+	cases := []string{
+		"",                 // Empty
+		"\x10\x14",         // Packed: not enough data
+		"\x20\x00",         // RLE: not enough data for starting timestamp
+		"\x2012345678\x90", // RLE: initial timestamp but invalid uvarint encoding
+		"\x2012345678\x7f", // RLE: timestamp, RLE but invalid repeat
+		"\x00123",          // Raw: data length not multiple of 8
+	}
+
+	for _, c := range cases {
+		var dec TimeDecoder
+		dec.Init([]byte(c))
+		if dec.Next() {
+			t.Fatalf("exp next == false, got true")
+		}
+	}
+}
+
 func BenchmarkTimeEncoder(b *testing.B) {
 	enc := NewTimeEncoder()
 	x := make([]int64, 1024)


### PR DESCRIPTION
I used go-fuzz (WIP branch at https://github.com/mark-rushakoff/influxdb/tree/mr-add-gofuzz) and found a handful of panics.

These all seem to be pretty low level in the TSM1 engine, e.g.:

```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
panic(0x478920, 0xc82000a150)
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/runtime/panic.go:481 +0x3e6
github.com/influxdata/influxdb/tsdb/engine/tsm1.unpackBlock(0xa0e00a, 0x3b, 0x6c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/encoding.go:591 +0x121
github.com/influxdata/influxdb/tsdb/engine/tsm1.DecodeStringBlock(0xa0e00a, 0x3b, 0x6c, 0xc8200a0000, 0xc82003ba50, 0xc82003ba00, 0x0, 0x0, 0x0, 0x0, ...)
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/encoding.go:533 +0x332
github.com/influxdata/influxdb/tsdb/engine/tsm1.DecodeBlock(0xa0e009, 0x3c, 0x6d, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/encoding.go:176 +0x1499
github.com/influxdata/influxdb/tsdb/engine/tsm1.(*mmapAccessor).readAll(0xc82000e780, 0xc82000b0d8, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0)
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/reader.go:1020 +0x723
github.com/influxdata/influxdb/tsdb/engine/tsm1.(*TSMReader).ReadAll(0xc820014730, 0xc82000b0d8, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0)
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/reader.go:286 +0x114
github.com/influxdata/influxdb/tsdb/engine/tsm1.FuzzTSMReader(0x80e000, 0x76, 0x200000, 0x0)
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/fuzz.go:103 +0x72a
go-fuzz-dep.Main(0x574760)
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/go-fuzz-dep/main.go:49 +0x14c
main.main()
	/var/folders/ct/bl4_z3g51ks8239_r2k07v_40000gn/T/go-fuzz-build267795264/src/go.fuzz.main/main.go:10 +0x23
```

So the test case I've added may not be exactly right - I'm probably expecting no errors in places where an error is appropriate - but nonetheless the added tests in this PR reproduce several panics. It may be most appropriate to fix the panics separately and close this PR.

/cc @jwilder @benbjohnson 