### PR TITLE
Implement CacheStore, a sharded map for tsm1.Cache.

### DIFF
--- a/tsdb/engine/tsm1/cache_map.go
+++ b/tsdb/engine/tsm1/cache_map.go
@@ -1,0 +1,140 @@
+package tsm1
+
+import (
+	"fmt"
+	"strings"
+)
+
+type (
+	// seriesKey is a typed string that holds the identity of a series.
+	// format: [measurement],[canonical tags]
+	// example: cpu,hostname=host0,region=us-east
+	seriesKey string
+
+	// fieldKey is a typed string that holds the identity of a field.
+	// format: [name]
+	// example: usage_user
+	fieldKey string
+)
+
+// CompositeKey stores namespaced strings that fully identify a series.
+type CompositeKey struct {
+	SeriesKey seriesKey
+	FieldKey  fieldKey
+}
+
+// NewCompositeKey makes a composite key from normal strings.
+func NewCompositeKey(l, v string) CompositeKey {
+	return CompositeKey{
+		SeriesKey: seriesKey(l),
+		FieldKey:  fieldKey(v),
+	}
+}
+
+// StringToCompositeKey is a convenience function that parses a CompositeKey
+// out of an untyped string. It assumes that the string has the following
+// format (an example):
+// "measurement_name,tag0=key0" + keyFieldSeparator + "field_name"
+// It is a utility to help migrate existing code to use the CacheStore.
+func StringToCompositeKey(s string) CompositeKey {
+	sepStart := strings.Index(s, keyFieldSeparator)
+	if sepStart == -1 {
+		panic("logic error: bad StringToCompositeKey input")
+	}
+
+	l := s[:sepStart]
+	v := s[sepStart+len(keyFieldSeparator):]
+	return NewCompositeKey(l, v)
+}
+
+// StringKey makes a plain string version of a CompositeKey. It uses the
+// magic `keyFieldSeparator` value defined elsewhere in the tsm1 code.
+func (ck CompositeKey) StringKey() string {
+	return fmt.Sprintf("%s%s%s", ck.SeriesKey, keyFieldSeparator, ck.FieldKey)
+}
+
+// CacheStore is a sharded map used for storing series data in a *tsm1.Cache.
+// It breaks away from previous tsm1.Cache designs by namespacing the keys into
+// parts, using CompositeKey, which allows for less contention on the root
+// map instance. Using this type is a speed improvement over the previous
+// map[string]*entry type that the tsm1.Cache used.
+type CacheStore map[seriesKey]*fieldData
+
+// fieldData stores field-related data. An instance of this type makes up a
+// 'shard' in a CacheStore.
+type fieldData struct {
+	// TODO(rw): explore using a lock to implement finer-grained
+	// concurrency control.
+	data map[fieldKey]*entry
+}
+
+// NewCacheStore creates a new CacheStore.
+func NewCacheStore() CacheStore {
+	return make(CacheStore)
+}
+
+// Get fetches the value associated with the CacheStore, if any. It is
+// equivalent to the one-variable form of a Go map access.
+func (cs CacheStore) Get(ck CompositeKey) *entry {
+	e, ok := cs.GetChecked(ck)
+	if ok {
+		return e
+	}
+	return nil
+}
+
+// Get fetches the value associated with the CacheStore. It is equivalent to
+// the two-variable form of a Go map access.
+func (cs CacheStore) GetChecked(ck CompositeKey) (*entry, bool) {
+	sub, ok := cs[ck.SeriesKey]
+	if sub == nil || !ok {
+		return nil, false
+	}
+	e, ok2 := sub.data[ck.FieldKey]
+	if e == nil || !ok2 {
+		return e, false
+	}
+	return e, true
+}
+
+// Put puts the given value into the CacheStore.
+func (cs CacheStore) Put(ck CompositeKey, e *entry) {
+	sub, ok := cs[ck.SeriesKey]
+	if sub == nil || !ok {
+		sub = &fieldData{data: map[fieldKey]*entry{}}
+		cs[ck.SeriesKey] = sub
+	}
+	sub.data[ck.FieldKey] = e
+}
+
+// Delete deletes the given key from the CacheStore, if applicable.
+func (cs CacheStore) Delete(ck CompositeKey) {
+	sub, ok := cs[ck.SeriesKey]
+	if sub == nil || !ok {
+		return
+	}
+	delete(sub.data, ck.FieldKey)
+	if len(sub.data) == 0 {
+		delete(cs, ck.SeriesKey)
+	}
+}
+
+// Iter iterates over (key, value) pairs in the CacheStore. It takes a
+// callback function that acts upon each (key, value) pair, and aborts if that
+// callback returns an error. It is equivalent to the two-variable range
+// statement with the normal Go map.
+func (cs CacheStore) Iter(f func(CompositeKey, *entry) error) error {
+	for seriesKey, sub := range cs {
+		for fieldKey, e := range sub.data {
+			ck := CompositeKey{
+				SeriesKey: seriesKey,
+				FieldKey:  fieldKey,
+			}
+			err := f(ck, e)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -24,7 +24,8 @@ func TestCheckConcurrentReadsAreSafe(t *testing.T) {
 	}
 
 	for i := range series {
-		series[i] = fmt.Sprintf("series%d", i)
+		k := tsm1.NewCompositeKey(fmt.Sprintf("series%d", i), "").StringKey()
+		series[i] = k
 	}
 
 	wg := sync.WaitGroup{}
@@ -69,7 +70,8 @@ func TestCacheRace(t *testing.T) {
 	}
 
 	for i := range series {
-		series[i] = fmt.Sprintf("series%d", i)
+		k := tsm1.NewCompositeKey(fmt.Sprintf("series%d", i), "").StringKey()
+		series[i] = k
 	}
 
 	wg := sync.WaitGroup{}
@@ -119,7 +121,8 @@ func TestCacheRace2Compacters(t *testing.T) {
 	}
 
 	for i := range series {
-		series[i] = fmt.Sprintf("series%d", i)
+		k := tsm1.NewCompositeKey(fmt.Sprintf("series%d", i), "").StringKey()
+		series[i] = k
 	}
 
 	wg := sync.WaitGroup{}

--- a/tsdb/engine/tsm1/cache_store_test.go
+++ b/tsdb/engine/tsm1/cache_store_test.go
@@ -1,0 +1,93 @@
+package tsm1
+
+import (
+	"fmt"
+	"testing"
+	"testing/quick"
+)
+
+// TestCacheStoreProperty_IdenticalToUnsharded verifies that the sharded
+// CacheStore type behaves identically to the simpler, unsharded
+// map[string]*entry type.
+func TestCacheStoreProperty_IdenticalToUnsharded(t *testing.T) {
+	f := func(orig map[CompositeKey][]*EmptyValue) bool {
+		// build the unsharded version to compare against:
+		gold := map[string]*entry{}
+		for ck, vv := range orig {
+			key := ck.StringKey()
+
+			for _, v := range vv {
+				existing, ok := gold[key]
+				if !ok {
+					existing = newEntry()
+					gold[key] = existing
+				}
+				existing.add([]Value{v})
+			}
+		}
+
+		// build the sharded version:
+		x := NewCacheStore()
+		for ck, vv := range orig {
+			for _, v := range vv {
+				existing := x.Get(ck)
+				if existing == nil {
+					existing = newEntry()
+					x.Put(ck, existing)
+				}
+				existing.add([]Value{v})
+			}
+		}
+
+		// check that the lengths of the sharded and unsharded map
+		// are the same:
+		l := 0
+		f := func(_ CompositeKey, _ *entry) error {
+			l++
+			return nil
+		}
+		x.Iter(f)
+		if l != len(gold) {
+			return false
+		}
+
+		// check the slice of Value objects associated with each
+		// CompositeKey by verifying pointer equality with the objects
+		// in the gold data:
+		g := func(ck CompositeKey, e *entry) error {
+			e2 := gold[ck.StringKey()]
+
+			// check that we didn't make a mistake when writing
+			// this test:
+			if e == e2 {
+				return fmt.Errorf("logic error: test is cheating by duplicating a []Value object")
+			}
+
+			// check the []Value slice has equal length:
+			if e.count() != e2.count() {
+				return fmt.Errorf("bad CacheStore storage len")
+			}
+
+			// check the pointer equality of each pair of Value
+			// objects:
+			for i := 0; i < e.count(); i++ {
+				if e.values[i] != e2.values[i] {
+					return fmt.Errorf("bad CacheStore pointer equality")
+				}
+			}
+
+			return nil
+		}
+		err := x.Iter(g)
+		if err != nil {
+			fmt.Println(err.Error())
+			return false
+		}
+
+		return true
+	}
+	cfg := &quick.Config{MaxCount: 1000}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Error(err)
+	}
+}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -338,20 +338,21 @@ func (e *Engine) LoadMetadataIndex(shardID uint64, index *tsdb.DatabaseIndex) er
 	e.Cache.RLock() // shouldn't need the lock, but just to be safe
 	defer e.Cache.RUnlock()
 
-	for key, entry := range e.Cache.Store() {
-
+	f := func(ck CompositeKey, entry *entry) error {
+		key := ck.StringKey()
 		fieldType, err := entry.values.InfluxQLType()
 		if err != nil {
 			e.logger.Printf("error getting the data type of values for key %s: %s", key, err.Error())
-			continue
+			return nil
 		}
 
 		if err := e.addToIndexFromKey(shardID, key, fieldType, index); err != nil {
 			return err
 		}
+		return nil
 	}
-
-	return nil
+	err := e.Cache.Store().Iter(f)
+	return err
 }
 
 // Backup will write a tar archive of any TSM files modified since the passed
@@ -630,12 +631,16 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 	walKeys := make([]string, 0)
 	e.Cache.RLock()
 	s := e.Cache.Store()
-	for k, _ := range s {
-		seriesKey, _ := seriesAndFieldFromCompositeKey(k)
-		if _, ok := keyMap[seriesKey]; ok {
+
+	f := func(ck CompositeKey, _ *entry) error {
+		if _, ok := keyMap[string(ck.SeriesKey)]; ok {
+			k := ck.StringKey()
 			walKeys = append(walKeys, k)
 		}
+		return nil
 	}
+	s.Iter(f)
+
 	e.Cache.RUnlock()
 
 	e.Cache.DeleteRange(walKeys, min, max)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax

This change appears to improve bulk load speed by 15% on
high-cardinality datasets, relative to influxdb 1.0.0-beta2.

Type CompositeKey separates the series key from the field key, according
to conventions present in other parts of the tsm1 codebase.

Type CacheStore implements a two-level map, where the first level is
decided by a CompositeKey's SeriesKey, and the second level is decided
by a CompositeKey's FieldKey.

No public function signatures were changed in this, however non-public
functions were altered to work with CompositeKeys instead of strings.