### PR TITLE
Speed up delete/drop statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6986](https://github.com/influxdata/influxdb/pull/6986): update connection settings when changing hosts in cli.
 - [#6965](https://github.com/influxdata/influxdb/pull/6965): Minor improvements to init script. Removes sysvinit-utils as package dependency.
 - [#6952](https://github.com/influxdata/influxdb/pull/6952): Fix compaction planning with large TSM files
+- [#6819](https://github.com/influxdata/influxdb/issues/6819): Database unresponsive after DROP MEASUREMENT
+- [#6796](https://github.com/influxdata/influxdb/issues/6796): Out of Memory Error when Dropping Measurement
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -347,17 +347,8 @@ func (s *Store) SetShardEnabled(shardID uint64, enabled bool) error {
 
 // DeleteShard removes a shard from disk.
 func (s *Store) DeleteShard(shardID uint64) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.deleteShard(shardID)
-}
-
-// deleteShard removes a shard from disk. Callers of deleteShard need
-// to handle locks appropriately.
-func (s *Store) deleteShard(shardID uint64) error {
-	// ensure shard exists
-	sh, ok := s.shards[shardID]
-	if !ok {
+	sh := s.Shard(shardID)
+	if sh == nil {
 		return nil
 	}
 
@@ -373,7 +364,10 @@ func (s *Store) deleteShard(shardID uint64) error {
 		return err
 	}
 
+	s.mu.Lock()
 	delete(s.shards, shardID)
+	s.mu.Unlock()
+
 	return nil
 }
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -473,9 +473,11 @@ func (s *Store) DeleteMeasurement(database, name string) error {
 
 	seriesKeys := m.SeriesKeys()
 
+	s.mu.RLock()
 	shards := s.filterShards(func(sh *Shard) bool {
 		return sh.database == database
 	})
+	s.mu.RUnlock()
 
 	if err := s.walkShards(shards, func(sh *Shard) error {
 		if err := sh.DeleteMeasurement(m.Name, seriesKeys); err != nil {
@@ -730,9 +732,11 @@ func (s *Store) deleteSeries(database string, seriesKeys []string, min, max int6
 		return influxql.ErrDatabaseNotFound(database)
 	}
 
+	s.mu.RLock()
 	shards := s.filterShards(func(sh *Shard) bool {
 		return sh.database == database
 	})
+	s.mu.RUnlock()
 
 	return s.walkShards(shards, func(sh *Shard) error {
 		if sh.database != database {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR speeds up drop and delete statements by converting the locks held from write locks to shorter read locks as well as processing shards in parallel.  

The write locks where problematic on the `tsdb.Store` as that essentially locks up the database to all queries and writes.  If the deletes take a long time, many things backup (writes, compactions, etc..) which can cause memory problems, lockups, and unresponsiveness.

Processing shards in parallel reduces the execution time of the operation when there are many shards on disk.

Fixes #6819 #6796