### PR TITLE
Bug fixes

### DIFF
--- a/pkg/limiter/fixed.go
+++ b/pkg/limiter/fixed.go
@@ -1,11 +1,11 @@
-package throttle
+package limiter
 
 // Fixed is a simple channel based concurrency limiter.  It uses a fixed
 // size channel to limit callers from proceeding until there is a value avalable
 // in the channel.  If all are in-use, the caller blocks until one is freed.
 type Fixed chan struct{}
 
-func New(limit int) Fixed {
+func NewFixed(limit int) Fixed {
 	return make(Fixed, limit)
 }
 

--- a/pkg/throttle/throttle.go
+++ b/pkg/throttle/throttle.go
@@ -1,0 +1,18 @@
+package throttle
+
+// Fixed is a simple channel based concurrency limiter.  It uses a fixed
+// size channel to limit callers from proceeding until there is a value avalable
+// in the channel.  If all are in-use, the caller blocks until one is freed.
+type Fixed chan struct{}
+
+func New(limit int) Fixed {
+	return make(Fixed, limit)
+}
+
+func (t Fixed) Take() {
+	t <- struct{}{}
+}
+
+func (t Fixed) Release() {
+	<-t
+}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -159,8 +159,6 @@ func (e *Engine) SetCompactionsEnabled(enabled bool) {
 		go e.compactTSMLevel(true, 1)
 		go e.compactTSMLevel(true, 2)
 		go e.compactTSMLevel(false, 3)
-
-		e.logger.Printf("compactions enabled for: %v", e.path)
 	} else {
 		e.mu.Lock()
 		if !e.compactionsEnabled {
@@ -179,8 +177,6 @@ func (e *Engine) SetCompactionsEnabled(enabled bool) {
 
 		// Wait for compaction goroutines to exit
 		e.wg.Wait()
-
-		e.logger.Printf("compactions disabled for: %v", e.path)
 	}
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -600,6 +600,12 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 		return nil
 	}
 
+	// Disable and abort running compactions so that tombstones added existing tsm
+	// files don't get removed.  This would cause deleted measurements/series to
+	// re-appear once the compaction completed.
+	e.SetCompactionsEnabled(false)
+	defer e.SetCompactionsEnabled(true)
+
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -777,7 +777,7 @@ func (e *Engine) compactCache() {
 			if e.ShouldCompactCache(e.WAL.LastWriteTime()) {
 				start := time.Now()
 				err := e.WriteSnapshot()
-				if err != nil {
+				if err != nil && err != errCompactionsDisabled {
 					e.logger.Printf("error writing snapshot: %v", err)
 					atomic.AddInt64(&e.stats.CacheCompactionErrors, 1)
 				} else {
@@ -838,7 +838,7 @@ func (e *Engine) compactTSMLevel(fast bool, level int) {
 
 					if fast {
 						files, err = e.Compactor.CompactFast(group)
-						if err != nil {
+						if err != nil && err != errCompactionsDisabled {
 							e.logger.Printf("error compacting TSM files: %v", err)
 							atomic.AddInt64(&e.stats.TSMCompactionErrors[level-1], 1)
 							time.Sleep(time.Second)
@@ -846,7 +846,7 @@ func (e *Engine) compactTSMLevel(fast bool, level int) {
 						}
 					} else {
 						files, err = e.Compactor.CompactFull(group)
-						if err != nil {
+						if err != nil && err != errCompactionsDisabled {
 							e.logger.Printf("error compacting TSM files: %v", err)
 							atomic.AddInt64(&e.stats.TSMCompactionErrors[level-1], 1)
 							time.Sleep(time.Second)
@@ -921,7 +921,7 @@ func (e *Engine) compactTSMFull() {
 					)
 					if optimize {
 						files, err = e.Compactor.CompactFast(group)
-						if err != nil {
+						if err != nil && err != errCompactionsDisabled {
 							e.logger.Printf("error compacting TSM files: %v", err)
 							atomic.AddInt64(&e.stats.TSMOptimizeCompactionErrors, 1)
 
@@ -930,7 +930,7 @@ func (e *Engine) compactTSMFull() {
 						}
 					} else {
 						files, err = e.Compactor.CompactFull(group)
-						if err != nil {
+						if err != nil && err != errCompactionsDisabled {
 							e.logger.Printf("error compacting TSM files: %v", err)
 							atomic.AddInt64(&e.stats.TSMFullCompactionErrors, 1)
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -172,6 +172,10 @@ type ShardStatistics struct {
 
 // Statistics returns statistics for periodic monitoring.
 func (s *Shard) Statistics(tags map[string]string) []models.Statistic {
+	if err := s.ready(); err != nil {
+		return nil
+	}
+
 	tags = s.statTags.Merge(tags)
 	statistics := []models.Statistic{{
 		Name: "shard",

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/pkg/throttle"
+	"github.com/influxdata/influxdb/pkg/limiter"
 )
 
 var (
@@ -146,7 +146,7 @@ func (s *Store) loadShards() error {
 		err error
 	}
 
-	t := throttle.New(runtime.GOMAXPROCS(0))
+	t := limiter.NewFixed(runtime.GOMAXPROCS(0))
 
 	resC := make(chan *res)
 	var n int
@@ -515,7 +515,7 @@ func (s *Store) walkShards(shards []*Shard, fn func(sh *Shard) error) error {
 		err error
 	}
 
-	t := throttle.New(runtime.GOMAXPROCS(0))
+	t := limiter.NewFixed(runtime.GOMAXPROCS(0))
 
 	resC := make(chan res)
 	var n int


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This PR fixes a few bugs related to writes and deletes:
* Prevent a panic in the tsm engine when stats are collected before the engine is opened.
* Abort compactions when a measurement or series is deleted.  This fixes an issues where series or measurements re-appear after deleting.
* Removed some logging around disabling compactions which was noisy
* Limits the number of in-flight writes that hold large allocations in the WAL.  When users with slower spinning disks, this allocations can cause OOMs.