### PR TITLE
Fix duplicate data returned in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6952](https://github.com/influxdata/influxdb/pull/6952): Fix compaction planning with large TSM files
 - [#6819](https://github.com/influxdata/influxdb/issues/6819): Database unresponsive after DROP MEASUREMENT
 - [#6796](https://github.com/influxdata/influxdb/issues/6796): Out of Memory Error when Dropping Measurement
+- [#6946](https://github.com/influxdata/influxdb/issues/6946): Duplicate data for the same timestamp
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -147,6 +147,13 @@ func (d *DatabaseIndex) CreateSeriesIndexIfNotExists(measurementName string, ser
 	m := d.CreateMeasurementIndexIfNotExists(measurementName)
 
 	d.mu.Lock()
+	// Check for the series again under a write lock
+	ss = d.series[series.Key]
+	if ss != nil {
+		d.mu.Unlock()
+		return ss
+	}
+
 	// set the in memory ID for query processing on this shard
 	series.id = d.lastID + 1
 	d.lastID++

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -542,6 +542,10 @@ func (s *Shard) createSystemIterator(opt influxql.IteratorOptions) (influxql.Ite
 
 // FieldDimensions returns unique sets of fields and dimensions across a list of sources.
 func (s *Shard) FieldDimensions(sources influxql.Sources) (fields map[string]influxql.DataType, dimensions map[string]struct{}, err error) {
+	if err := s.ready(); err != nil {
+		return nil, nil, err
+	}
+
 	if influxql.Sources(sources).HasSystemSource() {
 		// Only support a single system source.
 		if len(sources) > 1 {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This fixes a race in the meta index for adding series to measurements that can cause duplicate data to be returned at query time.  The issue was that the series would get added more than once to a measurement because we did not check for the series under a write lock after releasing the read lock.

This also fixes a panic in `Shard.FieldDimensions` that happened while testing this fix.

Fixes #6946