### PR TITLE
Move the CQ interval by the group by offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6543](https://github.com/influxdata/influxdb/issues/6543): Fix parseFill to check for fill ident before attempting to parse an expression.
 - [#7032](https://github.com/influxdata/influxdb/pull/7032): Copy tags in influx_stress to avoid a concurrent write panic on a map.
 - [#7107](https://github.com/influxdata/influxdb/pull/7107): Limit shard concurrency
+- [#7028](https://github.com/influxdata/influxdb/pull/7028): Do not run continuous queries that have no time span.
 
 ## v0.13.0 [2016-05-12]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7032](https://github.com/influxdata/influxdb/pull/7032): Copy tags in influx_stress to avoid a concurrent write panic on a map.
 - [#7107](https://github.com/influxdata/influxdb/pull/7107): Limit shard concurrency
 - [#7028](https://github.com/influxdata/influxdb/pull/7028): Do not run continuous queries that have no time span.
+- [#7025](https://github.com/influxdata/influxdb/issues/7025): Move the CQ interval by the group by offset.
 
 ## v0.13.0 [2016-05-12]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1846,7 +1846,7 @@ func (s *SelectStatement) GroupByInterval() (time.Duration, error) {
 }
 
 // GroupByOffset extracts the time interval offset, if specified.
-func (s *SelectStatement) GroupByOffset(opt *IteratorOptions) (time.Duration, error) {
+func (s *SelectStatement) GroupByOffset() (time.Duration, error) {
 	interval, err := s.GroupByInterval()
 	if err != nil {
 		return 0, err

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -861,7 +861,7 @@ func newIteratorOptionsStmt(stmt *SelectStatement, sopt *SelectOptions) (opt Ite
 	if interval < 0 {
 		interval = 0
 	} else if interval > 0 {
-		opt.Interval.Offset, err = stmt.GroupByOffset(&opt)
+		opt.Interval.Offset, err = stmt.GroupByOffset()
 		if err != nil {
 			return opt, err
 		}

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -323,6 +323,11 @@ func (s *Service) ExecuteContinuousQuery(dbi *meta.DatabaseInfo, cqi *meta.Conti
 	// Calculate and set the time range for the query.
 	startTime := nextRun.Add(-resampleFor).Add(interval - 1).Truncate(interval)
 	endTime := now.Add(-resampleEvery).Add(interval).Truncate(interval)
+	if !endTime.After(startTime) {
+		// Exit early since there is no time interval.
+		return nil
+	}
+
 	if err := cq.q.SetTimeRange(startTime, endTime); err != nil {
 		s.Logger.Printf("error setting time range: %s\n", err)
 		return err


### PR DESCRIPTION
This will make the period selected by the CQ system work correctly for a
query with an offset.

Do not run continuous queries that have no time span

Fixes #7025.