### PR TITLE
Fix queries against compacted files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6796](https://github.com/influxdata/influxdb/issues/6796): Out of Memory Error when Dropping Measurement
 - [#6946](https://github.com/influxdata/influxdb/issues/6946): Duplicate data for the same timestamp
 - [#7043](https://github.com/influxdata/influxdb/pull/7043): Remove limiter from walkShards
+- [#5501](https://github.com/influxdata/influxdb/issues/5501): Queries against files that have just been compacted need to point to new files
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -91,7 +91,7 @@ type TSMFile interface {
 	// Remove deletes the file from the filesystem
 	Remove() error
 
-	// Returns true if the file is current in use by queries
+	// Returns true if the file is currently in use by queries
 	InUse() bool
 
 	// Ref records that this file is actively in use
@@ -530,7 +530,7 @@ func (f *FileStore) Replace(oldFiles, newFiles []string) error {
 			if remove == file.Path() {
 				keep = false
 
-				// If queries running against this file, then we need to move it out of the
+				// If queries are running against this file, then we need to move it out of the
 				// way and let them complete.  We'll then delete the original file to avoid
 				// blocking callers upstream.  If the process crashes, the temp file is
 				// cleaned up at startup automatically.

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -84,8 +84,21 @@ type TSMFile interface {
 	// Size returns the size of the file on disk in bytes.
 	Size() uint32
 
+	// Rename renames the existing TSM file to a new name and replaces the mmap backing slice using the new
+	// file name.  Index and Reader state are not re-initialized.
+	Rename(path string) error
+
 	// Remove deletes the file from the filesystem
 	Remove() error
+
+	// Returns true if the file is current in use by queries
+	InUse() bool
+
+	// Ref records that this file is actively in use
+	Ref()
+
+	// Unref records that this file is no longer in user
+	Unref()
 
 	// Stats returns summary information about the TSM file.
 	Stats() FileStat
@@ -115,7 +128,8 @@ type FileStore struct {
 	logOutput    io.Writer   // Writer to be logger and traceLogger if active.
 	traceLogging bool
 
-	stats *FileStoreStatistics
+	stats  *FileStoreStatistics
+	purger *purger
 
 	currentTempDirID int
 }
@@ -142,13 +156,18 @@ func (f FileStat) ContainsKey(key string) bool {
 }
 
 func NewFileStore(dir string) *FileStore {
+	logger := log.New(os.Stderr, "[filestore] ", log.LstdFlags)
 	return &FileStore{
 		dir:          dir,
 		lastModified: time.Now(),
-		logger:       log.New(os.Stderr, "[filestore] ", log.LstdFlags),
+		logger:       logger,
 		traceLogger:  log.New(ioutil.Discard, "[filestore] ", log.LstdFlags),
 		logOutput:    os.Stderr,
 		stats:        &FileStoreStatistics{},
+		purger: &purger{
+			files:  map[string]TSMFile{},
+			logger: logger,
+		},
 	}
 }
 
@@ -504,12 +523,43 @@ func (f *FileStore) Replace(oldFiles, newFiles []string) error {
 	}
 
 	// We need to prune our set of active files now
-	var active []TSMFile
+	var active, inuse []TSMFile
 	for _, file := range updated {
 		keep := true
 		for _, remove := range oldFiles {
 			if remove == file.Path() {
 				keep = false
+
+				// If queries running against this file, then we need to move it out of the
+				// way and let them complete.  We'll then delete the original file to avoid
+				// blocking callers upstream.  If the process crashes, the temp file is
+				// cleaned up at startup automatically.
+				if file.InUse() {
+					// Copy all the tombstones related to this TSM file
+					var deletes []string
+					for _, t := range file.TombstoneFiles() {
+						deletes = append(deletes, t.Path)
+					}
+					deletes = append(deletes, file.Path())
+
+					// Rename the TSM file used by this reader
+					tempPath := file.Path() + ".tmp"
+					if err := file.Rename(tempPath); err != nil {
+						return err
+					}
+
+					// Remove the old file and tombstones.  We can't use the normal TSMReader.Remove()
+					// because it now refers to our temp file which we can't remove.
+					for _, f := range deletes {
+						if err := os.RemoveAll(f); err != nil {
+							return err
+						}
+					}
+
+					inuse = append(inuse, file)
+					break
+				}
+
 				if err := file.Close(); err != nil {
 					return err
 				}
@@ -529,6 +579,9 @@ func (f *FileStore) Replace(oldFiles, newFiles []string) error {
 	if err := syncDir(f.dir); err != nil {
 		return err
 	}
+
+	// Tell the purger about our in-use files we need to remove
+	f.purger.add(inuse)
 
 	f.files = active
 	sort.Sort(tsmReaders(f.files))
@@ -738,6 +791,9 @@ type KeyCursor struct {
 	// If this is true, we need to scan the duplicate blocks and dedup the points
 	// as query time until they are compacted.
 	duplicates bool
+
+	// The distinct set of TSM files references by the cursor
+	refs map[string]TSMFile
 }
 
 type location struct {
@@ -793,6 +849,7 @@ func newKeyCursor(fs *FileStore, key string, t int64, ascending bool) *KeyCursor
 		fs:        fs,
 		seeks:     fs.locations(key, t, ascending),
 		ascending: ascending,
+		refs:      map[string]TSMFile{},
 	}
 	c.duplicates = c.hasOverlappingBlocks()
 
@@ -802,12 +859,25 @@ func newKeyCursor(fs *FileStore, key string, t int64, ascending bool) *KeyCursor
 		sort.Sort(descLocations(c.seeks))
 	}
 
+	// Determine the distinct set of TSM files in use and mark then as in-use
+	for _, f := range c.seeks {
+		if _, ok := c.refs[f.r.Path()]; !ok {
+			f.r.Ref()
+			c.refs[f.r.Path()] = f.r
+		}
+	}
+
 	c.seek(t)
 	return c
 }
 
 // Close removes all references on the cursor.
 func (c *KeyCursor) Close() {
+	// Remove all of our in-use references since we're done
+	for _, f := range c.refs {
+		f.Unref()
+	}
+
 	c.buf = nil
 	c.seeks = nil
 	c.fs = nil
@@ -992,6 +1062,62 @@ func (c *KeyCursor) filterBooleanValues(tombstones []TimeRange, values BooleanVa
 		values = values.Exclude(t.Min, t.Max)
 	}
 	return values
+}
+
+type purger struct {
+	mu      sync.RWMutex
+	files   map[string]TSMFile
+	running bool
+
+	logger *log.Logger
+}
+
+func (p *purger) add(files []TSMFile) {
+	p.mu.Lock()
+	for _, f := range files {
+		p.files[f.Path()] = f
+	}
+	p.mu.Unlock()
+	p.purge()
+}
+
+func (p *purger) purge() {
+	p.mu.Lock()
+	if p.running {
+		p.mu.Unlock()
+		return
+	}
+	p.running = true
+	p.mu.Unlock()
+
+	go func() {
+		for {
+			p.mu.Lock()
+			for k, v := range p.files {
+				if !v.InUse() {
+					if err := v.Close(); err != nil {
+						p.logger.Printf("purge: close file: %v", err)
+						continue
+					}
+
+					if err := v.Remove(); err != nil {
+						p.logger.Printf("purge: remove file: %v", err)
+						continue
+					}
+					delete(p.files, k)
+				}
+			}
+
+			if len(p.files) == 0 {
+				p.running = false
+				p.mu.Unlock()
+				return
+			}
+
+			p.mu.Unlock()
+			time.Sleep(time.Second)
+		}
+	}()
 }
 
 type tsmReaders []TSMFile

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -381,6 +381,7 @@ func (c *floatAscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -493,6 +494,7 @@ func (c *floatDescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1
@@ -791,6 +793,7 @@ func (c *integerAscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -903,6 +906,7 @@ func (c *integerDescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1
@@ -1201,6 +1205,7 @@ func (c *stringAscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -1313,6 +1318,7 @@ func (c *stringDescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1
@@ -1611,6 +1617,7 @@ func (c *booleanAscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -1723,6 +1730,7 @@ func (c *booleanDescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -16,6 +16,7 @@ import (
 )
 
 type cursor interface {
+	close() error
 	next() (t int64, v interface{})
 }
 
@@ -228,7 +229,7 @@ func (itr *floatIterator) Stats() influxql.IteratorStats {
 }
 
 // Close closes the iterator.
-func (itr *floatIterator) Close() error { return nil }
+func (itr *floatIterator) Close() error { return itr.cur.close() }
 
 // floatLimitIterator
 type floatLimitIterator struct {
@@ -335,6 +336,12 @@ func (c *floatAscendingCursor) peekTSM() (t int64, v float64) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *floatAscendingCursor) close() error {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *floatAscendingCursor) next() (int64, interface{}) { return c.nextFloat() }
 
@@ -381,7 +388,6 @@ func (c *floatAscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -448,6 +454,12 @@ func (c *floatDescendingCursor) peekTSM() (t int64, v float64) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *floatDescendingCursor) close() error {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *floatDescendingCursor) next() (int64, interface{}) { return c.nextFloat() }
 
@@ -494,7 +506,6 @@ func (c *floatDescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1
@@ -640,7 +651,7 @@ func (itr *integerIterator) Stats() influxql.IteratorStats {
 }
 
 // Close closes the iterator.
-func (itr *integerIterator) Close() error { return nil }
+func (itr *integerIterator) Close() error { return itr.cur.close() }
 
 // integerLimitIterator
 type integerLimitIterator struct {
@@ -747,6 +758,12 @@ func (c *integerAscendingCursor) peekTSM() (t int64, v int64) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *integerAscendingCursor) close() error {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *integerAscendingCursor) next() (int64, interface{}) { return c.nextInteger() }
 
@@ -793,7 +810,6 @@ func (c *integerAscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -860,6 +876,12 @@ func (c *integerDescendingCursor) peekTSM() (t int64, v int64) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *integerDescendingCursor) close() error {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *integerDescendingCursor) next() (int64, interface{}) { return c.nextInteger() }
 
@@ -906,7 +928,6 @@ func (c *integerDescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1
@@ -1052,7 +1073,7 @@ func (itr *stringIterator) Stats() influxql.IteratorStats {
 }
 
 // Close closes the iterator.
-func (itr *stringIterator) Close() error { return nil }
+func (itr *stringIterator) Close() error { return itr.cur.close() }
 
 // stringLimitIterator
 type stringLimitIterator struct {
@@ -1159,6 +1180,12 @@ func (c *stringAscendingCursor) peekTSM() (t int64, v string) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *stringAscendingCursor) close() error {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *stringAscendingCursor) next() (int64, interface{}) { return c.nextString() }
 
@@ -1205,7 +1232,6 @@ func (c *stringAscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -1272,6 +1298,12 @@ func (c *stringDescendingCursor) peekTSM() (t int64, v string) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *stringDescendingCursor) close() error {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *stringDescendingCursor) next() (int64, interface{}) { return c.nextString() }
 
@@ -1318,7 +1350,6 @@ func (c *stringDescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1
@@ -1464,7 +1495,7 @@ func (itr *booleanIterator) Stats() influxql.IteratorStats {
 }
 
 // Close closes the iterator.
-func (itr *booleanIterator) Close() error { return nil }
+func (itr *booleanIterator) Close() error { return itr.cur.close() }
 
 // booleanLimitIterator
 type booleanLimitIterator struct {
@@ -1571,6 +1602,12 @@ func (c *booleanAscendingCursor) peekTSM() (t int64, v bool) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *booleanAscendingCursor) close() error {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *booleanAscendingCursor) next() (int64, interface{}) { return c.nextBoolean() }
 
@@ -1617,7 +1654,6 @@ func (c *booleanAscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -1684,6 +1720,12 @@ func (c *booleanDescendingCursor) peekTSM() (t int64, v bool) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *booleanDescendingCursor) close() error {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *booleanDescendingCursor) next() (int64, interface{}) { return c.nextBoolean() }
 
@@ -1730,7 +1772,6 @@ func (c *booleanDescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -10,6 +10,7 @@ import (
 )
 
 type cursor interface {
+	close() error
 	next() (t int64, v interface{})
 }
 
@@ -224,7 +225,7 @@ func (itr *{{.name}}Iterator) Stats() influxql.IteratorStats {
 }
 
 // Close closes the iterator.
-func (itr *{{.name}}Iterator) Close() error { return nil }
+func (itr *{{.name}}Iterator) Close() error { return itr.cur.close() }
 
 // {{.name}}LimitIterator
 type {{.name}}LimitIterator struct {
@@ -331,6 +332,12 @@ func (c *{{.name}}AscendingCursor) peekTSM() (t int64, v {{.Type}}) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *{{.name}}AscendingCursor) close() (error) {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *{{.name}}AscendingCursor) next() (int64, interface{}) { return c.next{{.Name}}() }
 
@@ -377,7 +384,6 @@ func (c *{{.name}}AscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -444,6 +450,12 @@ func (c *{{.name}}DescendingCursor) peekTSM() (t int64, v {{.Type}}) {
 	return item.UnixNano(), item.value
 }
 
+// close closes the cursor and any dependent cursors.
+func (c *{{.name}}DescendingCursor) close() (error) {
+	c.tsm.keyCursor.Close()
+	return nil
+}
+
 // next returns the next key/value for the cursor.
 func (c *{{.name}}DescendingCursor) next() (int64, interface{}) { return c.next{{.Name}}() }
 
@@ -490,7 +502,6 @@ func (c *{{.name}}DescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
-			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -377,6 +377,7 @@ func (c *{{.name}}AscendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = 0
@@ -489,6 +490,7 @@ func (c *{{.name}}DescendingCursor) nextTSM() {
 		c.tsm.keyCursor.Next()
 		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
 		if len(c.tsm.values) == 0 {
+			c.tsm.keyCursor.Close()
 			return
 		}
 		c.tsm.pos = len(c.tsm.values) - 1

--- a/tsdb/engine/tsm1/iterator.go
+++ b/tsdb/engine/tsm1/iterator.go
@@ -25,6 +25,8 @@ type floatCastIntegerCursor struct {
 	cursor integerCursor
 }
 
+func (c *floatCastIntegerCursor) close() error { return c.close() }
+
 func (c *floatCastIntegerCursor) next() (t int64, v interface{}) { return c.nextFloat() }
 
 func (c *floatCastIntegerCursor) nextFloat() (int64, float64) {
@@ -35,6 +37,8 @@ func (c *floatCastIntegerCursor) nextFloat() (int64, float64) {
 type integerCastFloatCursor struct {
 	cursor floatCursor
 }
+
+func (c *integerCastFloatCursor) close() error { return c.close() }
 
 func (c *integerCastFloatCursor) next() (t int64, v interface{}) { return c.nextInteger() }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This fixes #5501 and #6925 so that running queries against files that are also being compacted does not cause the query to end abruptly.  This usually looks like large chunks of data just disappearing and then re-appearing the next time the query runs.  In grafana, a graph could look like the third image in #6925.  Queries should now be consistent as of the time they are executed with respect data on disk regardless if files are compacted.

To fix this, this PR uses a reference counting approach where queries register their usage of a TSM file and remove that reference when finished.  In the `FileStore`, if a TSM file is replaced, but is still in use, it is moved aside to allow the query to complete and then periodically the file is checked to see if it can be removed.  The new files being installed will be use by any future queries after `Replace` returns.

In order to not complicate or block compactions, the existing file is renamed to a temp file and the live file is removed.  The `TSMReader` then re-MMAPs this new file, using it's existing index and tombstone state.  This approach performs well in local testing and should also work on windows.  In the event of a crash, the moved aside files are cleaned up as part of startup like other temp files managed by the engine.

Fixes #5501 
Fixes #6925 

cc @benbjohnson 