### PR TITLE
remove limiter from walkShards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6819](https://github.com/influxdata/influxdb/issues/6819): Database unresponsive after DROP MEASUREMENT
 - [#6796](https://github.com/influxdata/influxdb/issues/6796): Out of Memory Error when Dropping Measurement
 - [#6946](https://github.com/influxdata/influxdb/issues/6946): Duplicate data for the same timestamp
+- [#7043](https://github.com/influxdata/influxdb/pull/7043): Remove limiter from walkShards
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -518,8 +518,6 @@ func (s *Store) walkShards(shards []*Shard, fn func(sh *Shard) error) error {
 		err error
 	}
 
-	t := limiter.NewFixed(runtime.GOMAXPROCS(0))
-
 	resC := make(chan res)
 	var n int
 
@@ -527,9 +525,6 @@ func (s *Store) walkShards(shards []*Shard, fn func(sh *Shard) error) error {
 		n++
 
 		go func(sh *Shard) {
-			t.Take()
-			defer t.Release()
-
 			if err := fn(sh); err != nil {
 				resC <- res{err: fmt.Errorf("shard %d: %s", sh.id, err)}
 				return


### PR DESCRIPTION
Fixes artificially limiting walkShards.  Bug was introduced in #7015.  We are always IO bound in these operations so we should let the scheduler do the work for us.

In effect what was happening is we were limiting in walkShards the number of concurrent drop shards we could operate on based on the CPU count.  On my local machine, with 224 local shards in a database, it was taking over 16 seconds to drop a database.  With the limiting removed, I am back down to 1s.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated