### PR TITLE
Switch binaries to use posix flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 * Config option `[cluster]` has been replaced with `[coordinator]`
 * Support for config options `[collectd]` and `[opentsdb]` has been removed; use `[[collectd]]` and `[[opentsdb]]` instead.
 * Config option `data-logging-enabled` within the `[data]` section, has been renamed to `trace-logging-enabled`, and defaults to `false`.
+* Switch binaries to use posix flags.
 
-With this release the systemd configuration files for InfluxDB will use the system configured default for logging and will no longer write files to `/var/log/influxdb` by default. On most systems, the logs will be directed to the systemd journal and can be accessed by `journalctl -u influxdb.service`. Consult the systemd journald documentation for configuring journald.
+With this release, the systemd configuration files for InfluxDB will use the system configured default for logging and will no longer write files to `/var/log/influxdb` by default. On most systems, the logs will be directed to the systemd journal and can be accessed by `journalctl -u influxdb.service`. Consult the systemd journald documentation for configuring journald.
+
+With this release, the binaries will also now use posix flags instead of Go flags. Anytime you previously used one dash with a command line option, use two dashes. For example: `influxd --config /etc/influxdb/influxdb.conf`.
 
 ### Features
 
@@ -43,6 +46,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7046](https://github.com/influxdata/influxdb/pull/7046): Add tsm file export to influx_inspect tool.
 - [#7011](https://github.com/influxdata/influxdb/issues/7011): Create man pages for commands.
 - [#7050](https://github.com/influxdata/influxdb/pull/7050): Update go package library dependencies.
+- [#7052](https://github.com/influxdata/influxdb/pull/7052): Switch binaries to use posix flags.
 
 ### Bugfixes
 

--- a/Godeps
+++ b/Godeps
@@ -14,4 +14,5 @@ github.com/kimor79/gollectd 61d0deeb4ffcc167b2a1baa8efd72365692811bc
 github.com/paulbellamy/ratecounter 5a11f585a31379765c190c033b6ad39956584447
 github.com/peterh/liner 8975875355a81d612fafb9f5a6037bdcc2d9b073
 github.com/rakyll/statik 274df120e9065bdd08eb1120e0375e3dc1ae8465
+github.com/spf13/pflag 1560c1005499d61b80f865c04d39ca7505bf7f0b
 golang.org/x/crypto c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6

--- a/LICENSE_OF_DEPENDENCIES.md
+++ b/LICENSE_OF_DEPENDENCIES.md
@@ -16,6 +16,7 @@
 - github.com/paulbellamy/ratecounter [MIT LICENSE](https://github.com/paulbellamy/ratecounter/blob/master/LICENSE)
 - github.com/peterh/liner [MIT LICENSE](https://github.com/peterh/liner/blob/master/COPYING)
 - github.com/rakyll/statik [APACHE LICENSE](https://github.com/rakyll/statik/blob/master/LICENSE)
+- github.com/spf13/pflag [BSD LICENSE](https://github.com/spf13/pflag/blob/master/LICENSE)
 - glyphicons [LICENSE](http://glyphicons.com/license/)
 - golang.org/x/crypto [BSD LICENSE](https://github.com/golang/crypto/blob/master/LICENSE)
 - jquery 2.1.4 [MIT LICENSE](https://github.com/jquery/jquery/blob/master/LICENSE.txt)

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -82,7 +82,7 @@ func (c *CommandLine) Run() error {
 	// determine if they set the password flag but provided no value
 	for _, v := range os.Args {
 		v = strings.ToLower(v)
-		if (strings.HasPrefix(v, "-password") || strings.HasPrefix(v, "--password")) && c.Password == "" {
+		if strings.HasPrefix(v, "--password") && c.Password == "" {
 			promptForPassword = true
 			break
 		}

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
 	"github.com/influxdata/influxdb/client"
 	"github.com/influxdata/influxdb/cmd/influx/cli"
+	flag "github.com/spf13/pflag"
 )
 
 // These variables are populated via the Go linker.
@@ -37,19 +37,19 @@ func main() {
 	c := cli.New(version)
 
 	fs := flag.NewFlagSet("InfluxDB shell version "+version, flag.ExitOnError)
-	fs.StringVar(&c.Host, "host", client.DefaultHost, "Influxdb host to connect to.")
-	fs.IntVar(&c.Port, "port", client.DefaultPort, "Influxdb port to connect to.")
-	fs.StringVar(&c.Username, "username", c.Username, "Username to connect to the server.")
+	fs.StringVarP(&c.Host, "host", "H", client.DefaultHost, "Influxdb host to connect to.")
+	fs.IntVarP(&c.Port, "port", "p", client.DefaultPort, "Influxdb port to connect to.")
+	fs.StringVarP(&c.Username, "username", "u", c.Username, "Username to connect to the server.")
 	fs.StringVar(&c.Password, "password", c.Password, `Password to connect to the server.  Leaving blank will prompt for password (--password="").`)
-	fs.StringVar(&c.Database, "database", c.Database, "Database to connect to the server.")
+	fs.StringVarP(&c.Database, "database", "d", c.Database, "Database to connect to the server.")
 	fs.BoolVar(&c.Ssl, "ssl", false, "Use https for connecting to cluster.")
 	fs.BoolVar(&c.UnsafeSsl, "unsafeSsl", false, "Set this when connecting to the cluster using https and not use SSL verification.")
 	fs.StringVar(&c.Format, "format", defaultFormat, "Format specifies the format of the server responses:  json, csv, or column.")
 	fs.StringVar(&c.Precision, "precision", defaultPrecision, "Precision specifies the format of the timestamp:  rfc3339,h,m,s,ms,u or ns.")
 	fs.StringVar(&c.WriteConsistency, "consistency", "all", "Set write consistency level: any, one, quorum, or all.")
 	fs.BoolVar(&c.Pretty, "pretty", false, "Turns on pretty print for the json format.")
-	fs.StringVar(&c.Execute, "execute", c.Execute, "Execute command and quit.")
-	fs.BoolVar(&c.ShowVersion, "version", false, "Displays the InfluxDB version.")
+	fs.StringVarP(&c.Execute, "execute", "e", c.Execute, "Execute command and quit.")
+	fs.BoolVarP(&c.ShowVersion, "version", "v", false, "Displays the InfluxDB version.")
 	fs.BoolVar(&c.Import, "import", false, "Import a previous database.")
 	fs.IntVar(&c.PPS, "pps", defaultPPS, "How many points per second the import will allow.  By default it is zero and will not throttle importing.")
 	fs.StringVar(&c.Path, "path", "", "path to the file to import")
@@ -58,48 +58,48 @@ func main() {
 	// Define our own custom usage to print
 	fs.Usage = func() {
 		fmt.Println(`Usage of influx:
-  -version
+  -v, --version
        Display the version and exit.
-  -host 'host name'
+  -H, --host 'host name'
        Host to connect to.
-  -port 'port #'
+  -p, --port 'port #'
        Port to connect to.
-  -database 'database name'
+  -d, --database 'database name'
        Database to connect to the server.
-  -password 'password'
+  --password 'password'
       Password to connect to the server.  Leaving blank will prompt for password (--password '').
-  -username 'username'
+  -u, --username 'username'
        Username to connect to the server.
-  -ssl
+  --ssl
         Use https for requests.
-  -unsafeSsl
+  --unsafeSsl
         Set this when connecting to the cluster using https and not use SSL verification.
-  -execute 'command'
+  -e, --execute 'command'
        Execute command and quit.
-  -format 'json|csv|column'
+  --format 'json|csv|column'
        Format specifies the format of the server responses:  json, csv, or column.
-  -precision 'rfc3339|h|m|s|ms|u|ns'
+  --precision 'rfc3339|h|m|s|ms|u|ns'
        Precision specifies the format of the timestamp:  rfc3339, h, m, s, ms, u or ns.
-  -consistency 'any|one|quorum|all'
+  --consistency 'any|one|quorum|all'
        Set write consistency level: any, one, quorum, or all
-  -pretty
+  --pretty
        Turns on pretty print for the json format.
-  -import
+  --import
        Import a previous database export from file
-  -pps
+  --pps
        How many points per second the import will allow.  By default it is zero and will not throttle importing.
-  -path
+  --path
        Path to file to import
-  -compressed
+  --compressed
        Set to true if the import file is compressed
 
 Examples:
 
     # Use influx in a non-interactive mode to query the database "metrics" and pretty print json:
-    $ influx -database 'metrics' -execute 'select * from cpu' -format 'json' -pretty
+    $ influx --database 'metrics' --execute 'select * from cpu' --format 'json' --pretty
 
     # Connect to a specific database on startup and set database context:
-    $ influx -database 'metrics' -host 'localhost' -port '8086'
+    $ influx --database 'metrics' --host 'localhost' --port '8086'
 `)
 	}
 	fs.Parse(os.Args[1:])

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
 	_ "github.com/influxdata/influxdb/tsdb/engine"
+	flag "github.com/spf13/pflag"
 )
 
 func usage() {
@@ -24,6 +24,7 @@ Displays detailed information about InfluxDB data files.
 func main() {
 
 	flag.Usage = usage
+	flag.SetInterspersed(false)
 	flag.Parse()
 
 	if len(flag.Args()) == 0 {

--- a/cmd/influx_stress/README.md
+++ b/cmd/influx_stress/README.md
@@ -7,37 +7,37 @@ If you run into any issues with this tool please mention @jackzampolin when you 
 ### `influx_stress`
 This runs a basic stress test with the [default config](https://github.com/influxdata/influxdb/blob/master/stress/stress.toml) For more information on the configuration file please see the default.
 
-### `influx_stress -config someConfig.toml`
+### `influx_stress --config someConfig.toml`
 This runs the stress test with a valid configuration file located at `someConfig.tom`
 
-### `influx_stress -v2 -config someConfig.iql`
+### `influx_stress --v2 --config someConfig.iql`
 This runs the stress test with a valid `v2` configuration file. For more information about the `v2` stress test see the [v2 stress README](https://github.com/influxdata/influxdb/blob/master/stress/v2/README.md).
 
 ## Flags
 
 If flags are defined they overwrite the config from any file passed in.
 
-### `-addr` string
+### `--addr` string
 IP address and port of database where response times will persist (e.g., localhost:8086)
 
 `default` = "http://localhost:8086"
 
-### `-config` string
+### `--config` string
 The relative path to the stress test configuration file.
 
 `default` = [config](https://github.com/influxdata/influxdb/blob/master/stress/stress.toml)
 
-### `-cpuprofile` filename
+### `--cpuprofile` filename
 Writes the result of Go's cpu profile to filename
 
 `default` = no profiling
 
-### `-database` string
-Name of database on `-addr` that `influx_stress` will persist write and query response times
+### `--database` string
+Name of database on `--addr` that `influx_stress` will persist write and query response times
 
 `default` = "stress"
 
-### `-tags` value
+### `--tags` value
 A comma separated list of tags to add to write and query response times.
 
 `default` = ""

--- a/cmd/influx_stress/influx_stress.go
+++ b/cmd/influx_stress/influx_stress.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -9,11 +8,12 @@ import (
 
 	"github.com/influxdata/influxdb/stress"
 	v2 "github.com/influxdata/influxdb/stress/v2"
+	flag "github.com/spf13/pflag"
 )
 
 var (
 	useV2      = flag.Bool("v2", false, "Use version 2 of stress tool")
-	config     = flag.String("config", "", "The stress test file")
+	config     = flag.StringP("config", "c", "", "The stress test file")
 	cpuprofile = flag.String("cpuprofile", "", "Write the cpu profile to `filename`")
 	db         = flag.String("db", "", "target database within test system for write and query load")
 )

--- a/cmd/influx_tsm/main.go
+++ b/cmd/influx_tsm/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -23,6 +22,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx_tsm/b1"
 	"github.com/influxdata/influxdb/cmd/influx_tsm/bz1"
 	"github.com/influxdata/influxdb/cmd/influx_tsm/tsdb"
+	flag "github.com/spf13/pflag"
 )
 
 // ShardReader reads b* shards and converts to tsm shards
@@ -72,7 +72,7 @@ func (o *options) Parse() error {
 	fs.StringVar(&opts.BackupPath, "backup", "", "The location to backup up the current databases. Must not be within the data directory.")
 	fs.StringVar(&opts.DebugAddr, "debug", "", "If set, http debugging endpoints will be enabled on the given address")
 	fs.DurationVar(&opts.UpdateInterval, "interval", 5*time.Second, "How often status updates are printed.")
-	fs.BoolVar(&opts.Yes, "y", false, "Don't ask, just convert")
+	fs.BoolVarP(&opts.Yes, "yes", "y", false, "Don't ask, just convert")
 	fs.StringVar(&opts.CpuFile, "profile", "", "CPU Profile location")
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %v [options] <data-path> \n", os.Args[0])

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/influxdata/influxdb/services/snapshotter"
 	"github.com/influxdata/influxdb/tcp"
+	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -93,9 +93,9 @@ func (cmd *Command) Run(args ...string) error {
 func (cmd *Command) parseFlags(args []string) (retentionPolicy, shardID string, since time.Time, err error) {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.StringVar(&cmd.host, "host", "localhost:8088", "")
-	fs.StringVar(&cmd.database, "database", "", "")
-	fs.StringVar(&retentionPolicy, "retention", "", "")
+	fs.StringVarP(&cmd.host, "host", "H", "localhost:8088", "")
+	fs.StringVarP(&cmd.database, "database", "d", "", "")
+	fs.StringVarP(&retentionPolicy, "retention", "r", "", "")
 	fs.StringVar(&shardID, "shard", "", "")
 	var sinceArg string
 	fs.StringVar(&sinceArg, "since", "", "")
@@ -349,15 +349,15 @@ func (cmd *Command) printUsage() {
 
 Usage: influxd backup [flags] PATH
 
-    -host <host:port>
+    -H, --host <host:port>
             The host to connect to snapshot. Defaults to 127.0.0.1:8088.
-    -database <name>
+    -d, --database <name>
             The database to backup.
-    -retention <name>
+    -r, --retention <name>
             Optional. The retention policy to backup.
-    -shard <id>
+    --shard <id>
             Optional. The shard id to backup. If specified, retention is required.
-    -since <2015-12-24T08:12:23>
+    --since <2015-12-24T08:12:23>
             Optional. Do an incremental backup since the passed in RFC3339
             formatted time.
 

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -16,6 +15,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influxd/help"
 	"github.com/influxdata/influxdb/cmd/influxd/restore"
 	"github.com/influxdata/influxdb/cmd/influxd/run"
+	flag "github.com/spf13/pflag"
 )
 
 // These variables are populated via the Go linker.
@@ -148,14 +148,14 @@ func ParseCommandName(args []string) (string, []string) {
 	if len(args) > 0 {
 		if !strings.HasPrefix(args[0], "-") {
 			name = args[0]
-		} else if args[0] == "-h" || args[0] == "-help" || args[0] == "--help" {
+		} else if args[0] == "-h" || args[0] == "--help" {
 			// Special case -h immediately following binary name
 			name = "help"
 		}
 	}
 
 	// If command is "help" and has an argument then rewrite args to use "-h".
-	if name == "help" && len(args) > 2 && !strings.HasPrefix(args[1], "-") {
+	if name == "help" && len(args) > 1 && !strings.HasPrefix(args[1], "-") {
 		return args[1], []string{"-h"}
 	}
 

--- a/cmd/influxd/main_test.go
+++ b/cmd/influxd/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import "testing"
+
+func SliceEquals(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestParseCommandName(t *testing.T) {
+	type expected struct {
+		name string
+		args []string
+	}
+
+	tests := []struct {
+		args []string
+		exp  expected
+	}{
+		{
+		// no arguments should result in no name and no arguments
+		},
+		{
+			args: []string{"-c", "/etc/influxdb/influxdb.conf"},
+			exp: expected{
+				args: []string{"-c", "/etc/influxdb/influxdb.conf"},
+			},
+		},
+		{
+			args: []string{"run", "-c", "/etc/influxdb/influxdb.conf"},
+			exp: expected{
+				name: "run",
+				args: []string{"-c", "/etc/influxdb/influxdb.conf"},
+			},
+		},
+		{
+			args: []string{"help"},
+			exp: expected{
+				name: "help",
+			},
+		},
+		{
+			args: []string{"help", "run"},
+			exp: expected{
+				name: "run",
+				args: []string{"-h"},
+			},
+		},
+		{
+			args: []string{"--help", "config"},
+			exp: expected{
+				name: "config",
+				args: []string{"-h"},
+			},
+		},
+		{
+			args: []string{"-h", "backup"},
+			exp: expected{
+				name: "backup",
+				args: []string{"-h"},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		name, args := ParseCommandName(tt.args)
+		if name != tt.exp.name {
+			t.Errorf("%d. unexpected name. got=%s exp=%s", i, name, tt.exp.name)
+		}
+		if !SliceEquals(args, tt.exp.args) {
+			t.Errorf("%d. unexpected args. got=%s exp=%s", i, args, tt.exp.args)
+		}
+	}
+}

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,6 +17,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influxd/backup"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/services/snapshotter"
+	flag "github.com/spf13/pflag"
 )
 
 // Command represents the program execution for "influxd restore".
@@ -72,8 +72,8 @@ func (cmd *Command) parseFlags(args []string) error {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	fs.StringVar(&cmd.metadir, "metadir", "", "")
 	fs.StringVar(&cmd.datadir, "datadir", "", "")
-	fs.StringVar(&cmd.database, "database", "", "")
-	fs.StringVar(&cmd.retention, "retention", "", "")
+	fs.StringVarP(&cmd.database, "database", "d", "", "")
+	fs.StringVarP(&cmd.retention, "retention", "r", "", "")
 	fs.StringVar(&cmd.shard, "shard", "", "")
 	fs.SetOutput(cmd.Stdout)
 	fs.Usage = cmd.printUsage
@@ -92,22 +92,22 @@ func (cmd *Command) parseFlags(args []string) error {
 
 	// validate the arguments
 	if cmd.metadir == "" && cmd.database == "" {
-		return fmt.Errorf("-metadir or -database are required to restore")
+		return fmt.Errorf("--metadir or --database are required to restore")
 	}
 
 	if cmd.database != "" && cmd.datadir == "" {
-		return fmt.Errorf("-datadir is required to restore")
+		return fmt.Errorf("--datadir is required to restore")
 	}
 
 	if cmd.shard != "" {
 		if cmd.database == "" {
-			return fmt.Errorf("-database is required to restore shard")
+			return fmt.Errorf("--database is required to restore shard")
 		}
 		if cmd.retention == "" {
-			return fmt.Errorf("-retention is required to restore shard")
+			return fmt.Errorf("--retention is required to restore shard")
 		}
 	} else if cmd.retention != "" && cmd.database == "" {
-		return fmt.Errorf("-database is required to restore retention policy")
+		return fmt.Errorf("--database is required to restore retention policy")
 	}
 
 	return nil
@@ -337,18 +337,18 @@ running during a restore.
 
 Usage: influxd restore [flags] PATH
 
-    -metadir <path>
+    --metadir <path>
             Optional. If set the metastore will be recovered to the given path.
-    -datadir <path>
+    --datadir <path>
             Optional. If set the restore process will recover the specified
             database, retention policy or shard to the given directory.
-    -database <name>
+    -d, --database <name>
             Optional. Required if no metadir given. Will restore the database
             TSM files.
-    -retention <name>
+    -r, --retention <name>
             Optional. If given, database is required. Will restore the retention policy's
             TSM files.
-    -shard <id>
+    --shard <id>
             Optional. If given, database and retention are required. Will restore the shard's
             TSM files.
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,6 +10,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	flag "github.com/spf13/pflag"
 )
 
 const logo = `
@@ -150,7 +151,7 @@ func (cmd *Command) monitorServerErrors() {
 func (cmd *Command) ParseFlags(args ...string) (Options, error) {
 	var options Options
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	fs.StringVar(&options.ConfigPath, "config", "", "")
+	fs.StringVarP(&options.ConfigPath, "config", "c", "", "")
 	fs.StringVar(&options.PIDFile, "pidfile", "", "")
 	// Ignore hostname option.
 	_ = fs.String("hostname", "", "")
@@ -208,18 +209,18 @@ var usage = `Runs the InfluxDB server.
 
 Usage: influxd run [flags]
 
-    -config <path>
+    -c, --config <path>
             Set the path to the configuration file.
             This defaults to the environment variable INFLUXDB_CONFIG_PATH,
             ~/.influxdb/influxdb.conf, or /etc/influxdb/influxdb.conf if a file
             is present at any of these locations.
             Disable the automatic loading of a configuration file using
             the null device (such as /dev/null).
-    -pidfile <path>
+    --pidfile <path>
             Write process ID to a file.
-    -cpuprofile <path>
+    --cpuprofile <path>
             Write CPU profiling information to a file.
-    -memprofile <path>
+    --memprofile <path>
             Write memory usage information to a file.
 `
 

--- a/cmd/influxd/run/config_command.go
+++ b/cmd/influxd/run/config_command.go
@@ -1,12 +1,12 @@
 package run
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/BurntSushi/toml"
+	flag "github.com/spf13/pflag"
 )
 
 // PrintConfigCommand represents the command executed by "influxd config".
@@ -29,7 +29,7 @@ func NewPrintConfigCommand() *PrintConfigCommand {
 func (cmd *PrintConfigCommand) Run(args ...string) error {
 	// Parse command flags.
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
-	configPath := fs.String("config", "", "")
+	configPath := fs.StringP("config", "c", "", "")
 	fs.Usage = func() { fmt.Fprintln(cmd.Stderr, printConfigUsage) }
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -82,7 +82,7 @@ var printConfigUsage = `Displays the default configuration.
 
 Usage: influxd config [flags]
 
-    -config <path>
+    -c, --config <path>
             Set the path to the initial configuration file.
             This defaults to the environment variable INFLUXDB_CONFIG_PATH,
             ~/.influxdb/influxdb.conf, or /etc/influxdb/influxdb.conf if a file

--- a/man/influx.txt
+++ b/man/influx.txt
@@ -9,9 +9,9 @@ SYNOPSIS
 --------
 [verse]
 'influx' [options]
-'influx' -execute <command> [options]
-'influx' -import -path <path> (-compressed) [options]
-'influx' -version
+'influx' (-e | --execute) <command> [options]
+'influx' --import --path <path> (--compressed) [options]
+'influx' (-v | --version)
 
 DESCRIPTION
 -----------
@@ -27,55 +27,55 @@ The fourth form outputs the version of the command line and then immediately exi
 
 OPTIONS
 -------
--host <host>::
+-H, --host <host>::
   Host to connect to. Default is localhost.
 
--port <port>::
+-p, --port <port>::
   Port to use when connecting to the host. Default is 8086.
 
--database <database>::
+-d, --database <database>::
   Database to use when connecting to the database.
 
--username <username>::
+-u, --username <username>::
   Username to connect to the server.
 
--password <password>::
+--password <password>::
   Password to connect to the server. If left blank, this will prompt for a password.
 
--ssl:
+--ssl:
   Use https for requests.
 
--unsafeSsl::
+--unsafeSsl::
   Set this with '-ssl' to allow unsafe connections.
 
--execute <command>::
+-e, --execute <command>::
   Executes the command and exits.
 
--format <json|csv|column>::
+--format <json|csv|column>::
   Sets the format of the server responses. Default is column.
 
--precision <rfc3339|h|m|s|ms|u|ns>::
+--precision <rfc3339|h|m|s|ms|u|ns>::
   Specifies the format of the timestamp. Default is ns.
 
--consistency <any|one|quorum|all>::
+--consistency <any|one|quorum|all>::
   Set the write consistency level. Default is one.
 
--pretty::
+--pretty::
   Turns on pretty print format for the JSON format.
 
--import::
+--import::
   Import a previous database export from a file. If specified, '-path <path>' must also be specified.
 
--path <path>::
+--path <path>::
   Path to the database export file to import. Must be used with '-import'.
 
--pps <n>:
+--pps <n>:
   How many points per second the import will allow. By default, it is zero and will not throttle importing.
 
--compressed::
+--compressed::
   Set if the import file is compressed. Must be used with '-import'.
 
--version::
+-v, --version::
   Outputs the version of the influx client.
 
 include::footer.txt[]

--- a/man/influxd-backup.txt
+++ b/man/influxd-backup.txt
@@ -15,19 +15,19 @@ Downloads a snapshot of a data node and saves it to disk.
 
 OPTIONS
 -------
--host <host:port>::
+-H, --host <host:port>::
   The host to connect to and perform a snapshot of. Defaults to '127.0.0.1:8088'.
 
--database <name>::
+-d, --database <name>::
   The database to backup. Required.
 
--retention <name>::
+-r, --retention <name>::
   The retention policy to backup. Optional.
 
--shard <id>::
+--shard <id>::
   The shard id to backup. Optional. If specified, '-retention <name>' is required.
 
--since <2015-12-24T08:12:13>::
+--since <2015-12-24T08:12:13>::
   Do an incremental backup since the passed in time. The time needs to be in the RFC3339 format. Optional.
 
 SEE ALSO

--- a/man/influxd-config.txt
+++ b/man/influxd-config.txt
@@ -8,8 +8,8 @@ influxd-config - Generate configuration files for InfluxDB
 SYNOPSIS
 --------
 [verse]
-'influxd' config (-config <path>)
-'influxd config' -config /dev/null
+'influxd' config ((-c | --config) <path>)
+'influxd config' (-c | --config) /dev/null
 
 DESCRIPTION
 -----------
@@ -21,10 +21,10 @@ When using this command to regenerate a configuration file in place, be sure to 
 
 ===
 # DO NOT USE!
-$ influxd config -config influxdb.conf > influxdb.conf
+$ influxd config --config influxdb.conf > influxdb.conf
 
 # PROPER METHOD!
-$ influxd config -config influxdb.conf > influxdb.conf.tmp && \
+$ influxd config --config influxdb.conf > influxdb.conf.tmp && \
       mv influxdb.conf.tmp influxdb.conf
 ===
 
@@ -34,7 +34,7 @@ The second command version will force 'influxd config' to output the default con
 
 OPTIONS
 -------
--config <path>::
+-c, --config <path>::
   Customize the default configuration file to load. Disables automatic loading when the path is */dev/null*.
 
 include::footer.txt[]

--- a/man/influxd-restore.txt
+++ b/man/influxd-restore.txt
@@ -15,19 +15,19 @@ Uses backups from the PATH to restore the metastore, databases, retention polici
 
 OPTIONS
 -------
--metadir <path>::
+--metadir <path>::
   If set, the metastore will be recovered to the given path. Optional.
 
--datadir <path>::
+--datadir <path>::
   If set, the restore process will recover the specified database, retention policy, or shard to the given directory. Optional.
 
--database <name>::
+-d, --database <name>::
   Will restore the database TSM files. Required if no metadir is given. Optional.
 
--retention <name>::
+-r, --retention <name>::
   Will restore the retention policy's TSM files. If given, database is required. Optional.
 
--shard <id>::
+--shard <id>::
   Will restore the shard's TSM files. If given, database and retention are required. Optional.
 
 SEE ALSO

--- a/man/influxd-run.txt
+++ b/man/influxd-run.txt
@@ -8,8 +8,8 @@ influxd-run - Configure and start an InfluxDB server
 SYNOPSIS
 --------
 [verse]
-'influxd' [-config <path>] [-pidfile <path>] [-cpuprofile <path>] [-memprofile <path>]
-'influxd run' [-config <path>] [-pidfile <path>] [-cpuprofile <path>] [-memprofile <path>]
+'influxd' [(-c | --config) <path>] [--pidfile <path>] [--cpuprofile <path>] [--memprofile <path>]
+'influxd run' [(-c | --config) <path>] [--pidfile <path>] [--cpuprofile <path>] [--memprofile <path>]
 
 DESCRIPTION
 -----------
@@ -17,16 +17,16 @@ Runs the InfluxDB server.
 
 OPTIONS
 -------
--config <path>::
+-c, --config <path>::
   Sets the path to the configuration file. This defaults to the environment variable *INFLUXDB_CONFIG_PATH*, *~/.influxdb/influxdb.conf*, or */etc/influxdb/influxdb.conf* if a file is present at any of these locations. Disable the automatic loading of a configuration file by using the null device as the path (such as /dev/null on Linux or Mac OS X).
 
--pidfile <path>::
+--pidfile <path>::
   Write process ID to a file.
 
--cpuprofile <path>::
+--cpuprofile <path>::
   Write CPU profiling information to a file.
 
--memprofile <path>::
+--memprofile <path>::
   Write memory usage information to a file.
 
 include::footer.txt[]

--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -10,7 +10,7 @@ User=influxdb
 Group=influxdb
 LimitNOFILE=65536
 EnvironmentFile=-/etc/default/influxdb
-ExecStart=/usr/bin/influxd -config /etc/influxdb/influxdb.conf ${INFLUXD_OPTS}
+ExecStart=/usr/bin/influxd --config /etc/influxdb/influxdb.conf ${INFLUXD_OPTS}
 KillMode=control-group
 Restart=on-failure
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -127,8 +127,8 @@ function start() {
             --pidfile $PIDFILE \
             --exec $DAEMON \
             -- \
-            -pidfile $PIDFILE \
-            -config $CONFIG \
+            --pidfile $PIDFILE \
+            --config $CONFIG \
             $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &
     else
         local CMD="$DAEMON -pidfile $PIDFILE -config $CONFIG $INFLUXD_OPTS >>$STDOUT 2>>$STDERR &"

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -47,27 +47,27 @@ if [[ -f /etc/redhat-release ]]; then
     # RHEL-variant logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
-	install_systemd
+        install_systemd
     else
-	# Assuming sysv
-	install_init
-	install_chkconfig
+        # Assuming sysv
+        install_init
+        install_chkconfig
     fi
 elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
-	install_systemd
+        install_systemd
     else
-	# Assuming sysv
-	install_init
-	install_update_rcd
+        # Assuming sysv
+        install_init
+        install_update_rcd
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
     if [[ $ID = "amzn" ]]; then
-	# Amazon Linux logic
-	install_init
-	install_chkconfig
+        # Amazon Linux logic
+        install_init
+        install_chkconfig
     fi
 fi

--- a/scripts/post-uninstall.sh
+++ b/scripts/post-uninstall.sh
@@ -18,39 +18,39 @@ function disable_chkconfig {
 if [[ -f /etc/redhat-release ]]; then
     # RHEL-variant logic
     if [[ "$1" = "0" ]]; then
-	# InfluxDB is no longer installed, remove from init system
-	rm -f /etc/default/influxdb
-	
-	which systemctl &>/dev/null
-	if [[ $? -eq 0 ]]; then
-	    disable_systemd
-	else
-	    # Assuming sysv
-	    disable_chkconfig
-	fi
+        # InfluxDB is no longer installed, remove from init system
+        rm -f /etc/default/influxdb
+
+        which systemctl &>/dev/null
+        if [[ $? -eq 0 ]]; then
+            disable_systemd
+        else
+            # Assuming sysv
+            disable_chkconfig
+        fi
     fi
 elif [[ -f /etc/lsb-release ]]; then
     # Debian/Ubuntu logic
     if [[ "$1" != "upgrade" ]]; then
-	# Remove/purge
-	rm -f /etc/default/influxdb
-	
-	which systemctl &>/dev/null
-	if [[ $? -eq 0 ]]; then
-	    disable_systemd
-	else
-	    # Assuming sysv
-	    disable_update_rcd
-	fi
+        # Remove/purge
+        rm -f /etc/default/influxdb
+
+        which systemctl &>/dev/null
+        if [[ $? -eq 0 ]]; then
+            disable_systemd
+        else
+            # Assuming sysv
+            disable_update_rcd
+        fi
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
     if [[ $ID = "amzn" ]]; then
-	# Amazon Linux logic
-	if [[ "$1" = "0" ]]; then
-	    # InfluxDB is no longer installed, remove from init system
-	    rm -f /etc/default/influxdb
-	    disable_chkconfig
-	fi
+        # Amazon Linux logic
+        if [[ "$1" = "0" ]]; then
+            # InfluxDB is no longer installed, remove from init system
+            rm -f /etc/default/influxdb
+            disable_chkconfig
+        fi
     fi
 fi

--- a/scripts/pre-install.sh
+++ b/scripts/pre-install.sh
@@ -3,14 +3,14 @@
 if [[ -d /etc/opt/influxdb ]]; then
     # Legacy configuration found
     if [[ ! -d /etc/influxdb ]]; then
-	# New configuration does not exist, move legacy configuration to new location
-	echo -e "Please note, InfluxDB's configuration is now located at '/etc/influxdb' (previously '/etc/opt/influxdb')."
-	mv -vn /etc/opt/influxdb /etc/influxdb
+        # New configuration does not exist, move legacy configuration to new location
+        echo -e "Please note, InfluxDB's configuration is now located at '/etc/influxdb' (previously '/etc/opt/influxdb')."
+        mv -vn /etc/opt/influxdb /etc/influxdb
 
-	if [[ -f /etc/influxdb/influxdb.conf ]]; then
-	    backup_name="influxdb.conf.$(date +%s).backup"
-	    echo "A backup of your current configuration can be found at: /etc/influxdb/$backup_name"
-	    cp -a /etc/influxdb/influxdb.conf /etc/influxdb/$backup_name
-	fi
+        if [[ -f /etc/influxdb/influxdb.conf ]]; then
+            backup_name="influxdb.conf.$(date +%s).backup"
+            echo "A backup of your current configuration can be found at: /etc/influxdb/$backup_name"
+            cp -a /etc/influxdb/influxdb.conf /etc/influxdb/$backup_name
+        fi
     fi
 fi

--- a/stress/config.go
+++ b/stress/config.go
@@ -1,12 +1,12 @@
 package stress
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/BurntSushi/toml"
+	flag "github.com/spf13/pflag"
 )
 
 // Config is a struct for the Stress test configuration
@@ -118,8 +118,8 @@ func NewOutputConfig() *outputConfig {
 	var o outputConfig
 	tags := make(map[string]string)
 	o.tags = tags
-	database := flag.String("database", "stress", "name of database where the response times will persist")
-	retentionPolicy := flag.String("retention-policy", "", "name of the retention policy where the response times will persist")
+	database := flag.StringP("database", "d", "stress", "name of database where the response times will persist")
+	retentionPolicy := flag.StringP("retention-policy", "r", "", "name of the retention policy where the response times will persist")
 	address := flag.String("addr", "http://localhost:8086", "IP address and port of database where response times will persist (e.g., localhost:8086)")
 	flag.Var(&o, "tags", "A comma seperated list of tags")
 	flag.Parse()
@@ -144,4 +144,8 @@ func (t *outputConfig) Set(value string) error {
 		t.tags[tags[0]] = tags[1]
 	}
 	return nil
+}
+
+func (t *outputConfig) Type() string {
+	return "outputConfig"
 }


### PR DESCRIPTION
Updated help messages, man pages, and replaced the go flag library with
github.com/spf13/pflag for posix compatible flags. Also fixed a bug with
help pages where the command wasn't rewritten correctly. Now `influxd
help run` works correctly again.

Updated scripts to use the new flags and normalized tabs to spaces
within the bash scripts.