### PR TITLE
Switch meta queries to use a meta executor

### DIFF
--- a/influxql/statement_rewriter.go
+++ b/influxql/statement_rewriter.go
@@ -46,20 +46,11 @@ func rewriteShowMeasurementsStatement(stmt *ShowMeasurementsStatement) (Statemen
 	if stmt.Source != nil {
 		condition = rewriteSourcesCondition(Sources([]Source{stmt.Source}), stmt.Condition)
 	}
-
-	return &SelectStatement{
-		Fields: Fields([]*Field{
-			{Expr: &VarRef{Val: "_name"}, Alias: "name"},
-		}),
-		Sources: Sources([]Source{
-			&Measurement{Name: "_measurements"},
-		}),
+	return &ShowMeasurementsStatement{
 		Condition:  condition,
-		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
+		Offset:     stmt.Offset,
 		SortFields: stmt.SortFields,
-		OmitTime:   true,
-		Dedupe:     true,
 	}, nil
 }
 
@@ -129,18 +120,13 @@ func rewriteShowTagValuesStatement(stmt *ShowTagValuesStatement) (Statement, err
 	}
 	condition = rewriteSourcesCondition(stmt.Sources, condition)
 
-	return &SelectStatement{
-		Fields: []*Field{
-			{Expr: &VarRef{Val: "_tagKey"}, Alias: "key"},
-			{Expr: &VarRef{Val: "value"}},
-		},
-		Sources:    rewriteSources(stmt.Sources, "_tags"),
+	return &ShowTagValuesStatement{
+		Op:         stmt.Op,
+		TagKeyExpr: stmt.TagKeyExpr,
 		Condition:  condition,
-		Offset:     stmt.Offset,
-		Limit:      stmt.Limit,
 		SortFields: stmt.SortFields,
-		OmitTime:   true,
-		Dedupe:     true,
+		Limit:      stmt.Limit,
+		Offset:     stmt.Offset,
 	}, nil
 }
 
@@ -162,7 +148,6 @@ func rewriteShowTagKeysStatement(stmt *ShowTagKeysStatement) (Statement, error) 
 		OmitTime:   true,
 		Dedupe:     true,
 	}, nil
-
 }
 
 // rewriteSources rewrites sources with previous database and retention policy

--- a/influxql/statement_rewriter_test.go
+++ b/influxql/statement_rewriter_test.go
@@ -32,26 +32,6 @@ func TestRewriteStatement(t *testing.T) {
 			s:    `SELECT fieldKey, fieldType FROM mydb.myrp2._fieldKeys WHERE _name =~ /c.*/`,
 		},
 		{
-			stmt: `SHOW MEASUREMENTS`,
-			s:    `SELECT _name AS "name" FROM _measurements`,
-		},
-		{
-			stmt: `SHOW MEASUREMENTS WITH MEASUREMENT = cpu`,
-			s:    `SELECT _name AS "name" FROM _measurements WHERE _name = 'cpu'`,
-		},
-		{
-			stmt: `SHOW MEASUREMENTS WITH MEASUREMENT =~ /c.*/`,
-			s:    `SELECT _name AS "name" FROM _measurements WHERE _name =~ /c.*/`,
-		},
-		{
-			stmt: `SHOW MEASUREMENTS WHERE region = 'uswest'`,
-			s:    `SELECT _name AS "name" FROM _measurements WHERE region = 'uswest'`,
-		},
-		{
-			stmt: `SHOW MEASUREMENTS WITH MEASUREMENT = cpu WHERE region = 'uswest'`,
-			s:    `SELECT _name AS "name" FROM _measurements WHERE (_name = 'cpu') AND (region = 'uswest')`,
-		},
-		{
 			stmt: `SHOW SERIES`,
 			s:    `SELECT "key" FROM _series`,
 		},
@@ -94,30 +74,6 @@ func TestRewriteStatement(t *testing.T) {
 		{
 			stmt: `SHOW TAG KEYS FROM mydb.myrp1.cpu WHERE region = 'uswest'`,
 			s:    `SELECT tagKey FROM mydb.myrp1._tagKeys WHERE (_name = 'cpu') AND (region = 'uswest')`,
-		},
-		{
-			stmt: `SHOW TAG VALUES WITH KEY = region`,
-			s:    `SELECT _tagKey AS "key", value FROM _tags WHERE _tagKey = 'region'`,
-		},
-		{
-			stmt: `SHOW TAG VALUES FROM cpu WITH KEY = region`,
-			s:    `SELECT _tagKey AS "key", value FROM _tags WHERE (_name = 'cpu') AND (_tagKey = 'region')`,
-		},
-		{
-			stmt: `SHOW TAG VALUES FROM cpu WITH KEY IN (region, host)`,
-			s:    `SELECT _tagKey AS "key", value FROM _tags WHERE (_name = 'cpu') AND (_tagKey = 'region' OR _tagKey = 'host')`,
-		},
-		{
-			stmt: `SHOW TAG VALUES FROM mydb.myrp1.cpu WITH KEY IN (region, host)`,
-			s:    `SELECT _tagKey AS "key", value FROM mydb.myrp1._tags WHERE (_name = 'cpu') AND (_tagKey = 'region' OR _tagKey = 'host')`,
-		},
-		{
-			stmt: `SHOW TAG VALUES FROM cpu WITH KEY =~ /(region|host)/`,
-			s:    `SELECT _tagKey AS "key", value FROM _tags WHERE (_name = 'cpu') AND (_tagKey =~ /(region|host)/)`,
-		},
-		{
-			stmt: `SHOW TAG VALUES FROM mydb.myrp1.cpu WITH KEY =~ /(region|host)/`,
-			s:    `SELECT _tagKey AS "key", value FROM mydb.myrp1._tags WHERE (_name = 'cpu') AND (_tagKey =~ /(region|host)/)`,
 		},
 		{
 			stmt: `SELECT value FROM cpu`,


### PR DESCRIPTION
This way meta queries can be planned separately and not rely on looking
at specific shards.

This is a bit ugly and we likely should refactor how the
IteratorCreator's are created to begin with. It's a bit fragile since we
have to handle some meta queries through shards and some through the
database index through two separate code paths. This will work in the
interim to continue enabling fast `SHOW MEASUREMENTS` and `SHOW TAG
VALUES` queries.