### PR TITLE
fix #7068: use DefaultRetentionPolicyName from cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7043](https://github.com/influxdata/influxdb/pull/7043): Remove limiter from walkShards
 - [#5501](https://github.com/influxdata/influxdb/issues/5501): Queries against files that have just been compacted need to point to new files
 - [#6595](https://github.com/influxdata/influxdb/issues/6595): Fix full compactions conflicting with level compactions
+- [#7068](https://github.com/influxdata/influxdb/issues/7068): Use DefaultRetentionPolicyName from config
 
 ## v0.13.0 [2016-05-12]
 

--- a/coordinator/meta_client.go
+++ b/coordinator/meta_client.go
@@ -23,6 +23,7 @@ type MetaClient interface {
 	DropRetentionPolicy(database, name string) error
 	DropSubscription(database, rp, name string) error
 	DropUser(name string) error
+	RetentionAutoCreateName() string
 	RetentionPolicy(database, name string) (rpi *meta.RetentionPolicyInfo, err error)
 	SetAdminPrivilege(username string, admin bool) error
 	SetDefaultRetentionPolicy(database, name string) error

--- a/coordinator/meta_client_test.go
+++ b/coordinator/meta_client_test.go
@@ -28,6 +28,7 @@ type MetaClient struct {
 	DropShardFn                         func(id uint64) error
 	DropUserFn                          func(name string) error
 	MetaNodesFn                         func() ([]meta.NodeInfo, error)
+	RetentionAutoCreateNameFn           func() string
 	RetentionPolicyFn                   func(database, name string) (rpi *meta.RetentionPolicyInfo, err error)
 	SetAdminPrivilegeFn                 func(username string, admin bool) error
 	SetDefaultRetentionPolicyFn         func(database, name string) error
@@ -113,6 +114,10 @@ func (c *MetaClient) DropUser(name string) error {
 
 func (c *MetaClient) MetaNodes() ([]meta.NodeInfo, error) {
 	return c.MetaNodesFn()
+}
+
+func (c *MetaClient) RetentionAutoCreateName() string {
+	return c.RetentionAutoCreateNameFn()
 }
 
 func (c *MetaClient) RetentionPolicy(database, name string) (rpi *meta.RetentionPolicyInfo, err error) {

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -261,7 +261,11 @@ func (e *StatementExecutor) executeCreateDatabaseStatement(stmt *influxql.Create
 		return err
 	}
 
-	rpi := meta.NewRetentionPolicyInfo(stmt.RetentionPolicyName)
+	rpname := stmt.RetentionPolicyName
+	if rpname == "" {
+		rpname = e.MetaClient.RetentionAutoCreateName()
+	}
+	rpi := meta.NewRetentionPolicyInfo(rpname)
 	rpi.Duration = stmt.RetentionPolicyDuration
 	rpi.ReplicaN = stmt.RetentionPolicyReplication
 	rpi.ShardGroupDuration = stmt.RetentionPolicyShardGroupDuration

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -53,7 +53,8 @@ type Client struct {
 
 	path string
 
-	retentionAutoCreate bool
+	retentionAutoCreate        bool
+	defaultRetentionPolicyName string
 }
 
 type authUser struct {
@@ -68,14 +69,14 @@ func NewClient(config *Config) *Client {
 		cacheData: &Data{
 			ClusterID: uint64(rand.Int63()),
 			Index:     1,
-			DefaultRetentionPolicyName: config.DefaultRetentionPolicyName,
 		},
-		closing:             make(chan struct{}),
-		changed:             make(chan struct{}),
-		logger:              log.New(ioutil.Discard, "[metaclient] ", log.LstdFlags),
-		authCache:           make(map[string]authUser, 0),
-		path:                config.Dir,
-		retentionAutoCreate: config.RetentionAutoCreate,
+		closing:                    make(chan struct{}),
+		changed:                    make(chan struct{}),
+		logger:                     log.New(ioutil.Discard, "[metaclient] ", log.LstdFlags),
+		authCache:                  make(map[string]authUser, 0),
+		path:                       config.Dir,
+		retentionAutoCreate:        config.RetentionAutoCreate,
+		defaultRetentionPolicyName: config.DefaultRetentionPolicyName,
 	}
 }
 
@@ -189,11 +190,12 @@ func (c *Client) CreateDatabase(name string) (*DatabaseInfo, error) {
 	// create default retention policy
 	if c.retentionAutoCreate {
 		if err := data.CreateRetentionPolicy(name, &RetentionPolicyInfo{
+			Name:     c.defaultRetentionPolicyName,
 			ReplicaN: 1,
 		}); err != nil {
 			return nil, err
 		}
-		if err := data.SetDefaultRetentionPolicy(name, ""); err != nil {
+		if err := data.SetDefaultRetentionPolicy(name, c.defaultRetentionPolicyName); err != nil {
 			return nil, err
 		}
 	}
@@ -295,6 +297,11 @@ func (c *Client) CreateRetentionPolicy(database string, rpi *RetentionPolicyInfo
 	}
 
 	return rp, nil
+}
+
+// RetentionAutoCreateName returns the name used for auto generated retention policies.
+func (c *Client) RetentionAutoCreateName() string {
+	return c.defaultRetentionPolicyName
 }
 
 // RetentionPolicy returns the requested retention policy info.

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -38,8 +38,6 @@ type Data struct {
 
 	MaxShardGroupID uint64
 	MaxShardID      uint64
-
-	DefaultRetentionPolicyName string `json:"-"`
 }
 
 // NewShardOwner sets the owner of the provided shard to the data node
@@ -136,7 +134,9 @@ func (data *Data) RetentionPolicy(database, name string) (*RetentionPolicyInfo, 
 // Returns an error if name is blank or if a database does not exist.
 func (data *Data) CreateRetentionPolicy(database string, rpi *RetentionPolicyInfo) error {
 	// Validate retention policy.
-	if rpi.ReplicaN < 1 {
+	if rpi.Name == "" {
+		return ErrRetentionPolicyNameRequired
+	} else if rpi.ReplicaN < 1 {
 		return ErrReplicationFactorTooLow
 	}
 
@@ -156,18 +156,9 @@ func (data *Data) CreateRetentionPolicy(database string, rpi *RetentionPolicyInf
 		return nil
 	}
 
-	// Determine the retention policy name if it is blank.
-	rpName := rpi.Name
-	if rpName == "" {
-		if data.DefaultRetentionPolicyName == "" {
-			return ErrRetentionPolicyNameRequired
-		}
-		rpName = data.DefaultRetentionPolicyName
-	}
-
 	// Append copy of new policy.
 	rp := RetentionPolicyInfo{
-		Name:               rpName,
+		Name:               rpi.Name,
 		Duration:           rpi.Duration,
 		ReplicaN:           rpi.ReplicaN,
 		ShardGroupDuration: rpi.ShardGroupDuration,
@@ -263,10 +254,7 @@ func (data *Data) UpdateRetentionPolicy(database, name string, rpu *RetentionPol
 // SetDefaultRetentionPolicy sets the default retention policy for a database.
 func (data *Data) SetDefaultRetentionPolicy(database, name string) error {
 	if name == "" {
-		if data.DefaultRetentionPolicyName == "" {
-			return ErrRetentionPolicyNameRequired
-		}
-		name = data.DefaultRetentionPolicyName
+		return ErrRetentionPolicyNameRequired
 	}
 
 	// Find database and verify policy exists.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Use DefaultRetentionPolicyName from the config instead of passing
through meta data.