### PR TITLE
Ensure CQ ID names can't clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#6595](https://github.com/influxdata/influxdb/issues/6595): Fix full compactions conflicting with level compactions
 - [#7081](https://github.com/influxdata/influxdb/issues/7081): Hardcode auto generated RP names to autogen
 - [#7088](https://github.com/influxdata/influxdb/pull/7088): Fix UDP pointsRx being incremented twice.
+- [#7080](https://github.com/influxdata/influxdb/pull/7080): Ensure IDs can't clash when managing Continuous Queries.
 
 ## v0.13.0 [2016-05-12]
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

I noticed this when reviewing another PR. Given database `foo:` and CQ `bar` then the ID would become `"foo::bar"`, which would clash with the case of database `foo` and CQ `:bar` --> `foo::bar`.

Instead we can use the control character for a [unit separator](https://en.wikipedia.org/wiki/C0_and_C1_control_codes#Field_separators).