### PR TITLE
Use auth token for subscriptions

### DIFF
--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -1,39 +1,88 @@
 package subscriber
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	"time"
 
-	"github.com/influxdata/influxdb/client/v2"
 	"github.com/influxdata/influxdb/coordinator"
 )
 
 // HTTP supports writing points over HTTP using the line protocol.
 type HTTP struct {
-	c client.Client
+	url         *url.URL
+	accessToken string
+	httpClient  *http.Client
 }
 
 // NewHTTP returns a new HTTP points writer with default options.
 func NewHTTP(addr string, timeout time.Duration) (*HTTP, error) {
-	conf := client.HTTPConfig{
-		Addr:    addr,
-		Timeout: timeout,
-	}
-	c, err := client.NewHTTPClient(conf)
+	u, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("Unsupported protocol scheme: %s, your address must start with http:// or https://", u.Scheme)
 	}
-	return &HTTP{c: c}, nil
+	// Grab username from URL as token.
+	var token string
+	if u.User != nil {
+		token = u.User.Username()
+		u.User = nil
+	}
+	return &HTTP{
+		url:         u,
+		accessToken: token,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}, nil
 }
 
 // WritePoints writes points over HTTP transport.
-func (h *HTTP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
-	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
-		Database:        p.Database,
-		RetentionPolicy: p.RetentionPolicy,
-	})
-	for _, pt := range p.Points {
-		bp.AddPoint(client.NewPointFrom(pt))
+func (h *HTTP) WritePoints(p *coordinator.WritePointsRequest) error {
+	var b bytes.Buffer
+	for _, p := range p.Points {
+		if _, err := b.WriteString(p.String()); err != nil {
+			return err
+		}
+		if err := b.WriteByte('\n'); err != nil {
+			return err
+		}
 	}
-	err = h.c.Write(bp)
-	return
+
+	u := *h.url
+	u.Path = "write"
+	params := url.Values{}
+	params.Set("db", p.Database)
+	params.Set("rp", p.RetentionPolicy)
+	params.Set("precision", "ns")
+	u.RawQuery = params.Encode()
+
+	req, err := http.NewRequest("POST", u.String(), &b)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "")
+	req.Header.Set("User-Agent", "InfluxDBSubscription")
+	if h.accessToken != "" {
+		req.Header.Set("InfluxDB-Access-Token", h.accessToken)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf(string(body))
+	}
+	return nil
 }

--- a/services/subscriber/udp.go
+++ b/services/subscriber/udp.go
@@ -36,7 +36,6 @@ func (u *UDP) WritePoints(p *coordinator.WritePointsRequest) (err error) {
 		if err != nil {
 			return
 		}
-
 	}
 	return
 }


### PR DESCRIPTION
Adds a simple mechanism for using access tokens with http based subscriptions.
/cc @joelegasse 

- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated