### PR TITLE
Tombstone memory improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7088](https://github.com/influxdata/influxdb/pull/7088): Fix UDP pointsRx being incremented twice.
 - [#7080](https://github.com/influxdata/influxdb/pull/7080): Ensure IDs can't clash when managing Continuous Queries.
 - [#6990](https://github.com/influxdata/influxdb/issues/6990): Fix panic parsing empty key
+- [#7084](https://github.com/influxdata/influxdb/pull/7084): Tombstone memory improvements
 
 ## v0.13.0 [2016-05-12]
 

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -514,6 +514,7 @@ func (a auxIteratorFields) sendError(err error) {
 
 // DrainIterator reads all points from an iterator.
 func DrainIterator(itr Iterator) {
+	defer itr.Close()
 	switch itr := itr.(type) {
 	case FloatIterator:
 		for p, _ := itr.Next(); p != nil; p, _ = itr.Next() {
@@ -534,6 +535,7 @@ func DrainIterator(itr Iterator) {
 
 // DrainIterators reads all points from all iterators.
 func DrainIterators(itrs []Iterator) {
+	defer Iterators(itrs).Close()
 	for {
 		var hasData bool
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -185,6 +185,10 @@ func (e *Engine) SetCompactionsEnabled(enabled bool) {
 
 		// Wait for compaction goroutines to exit
 		e.wg.Wait()
+
+		if err := e.cleanup(); err != nil {
+			e.logger.Printf("error cleaning up temp file: %v", err)
+		}
 	}
 }
 
@@ -1073,6 +1077,10 @@ func (e *Engine) cleanup() error {
 		}
 	}
 
+	return e.cleanupTempTSMFiles()
+}
+
+func (e *Engine) cleanupTempTSMFiles() error {
 	files, err := filepath.Glob(filepath.Join(e.path, fmt.Sprintf("*.%s", CompactionTempExtension)))
 	if err != nil {
 		return fmt.Errorf("error getting compaction temp files: %s", err.Error())
@@ -1083,7 +1091,6 @@ func (e *Engine) cleanup() error {
 			return fmt.Errorf("error removing temp compaction files: %v", err)
 		}
 	}
-
 	return nil
 }
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -769,9 +769,8 @@ func (f *FileStore) CreateSnapshot() (string, error) {
 		}
 		// Check for tombstones and link those as well
 		for _, tf := range tsmf.TombstoneFiles() {
-			tfpath := filepath.Join(f.dir, tf.Path)
 			newpath := filepath.Join(tmpPath, filepath.Base(tf.Path))
-			if err := os.Link(tfpath, newpath); err != nil {
+			if err := os.Link(tf.Path, newpath); err != nil {
 				return "", fmt.Errorf("error creating tombstone hard link: %q", err)
 			}
 		}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -553,7 +553,7 @@ func (f *FileStore) Replace(oldFiles, newFiles []string) error {
 					}
 
 					inuse = append(inuse, file)
-					break
+					continue
 				}
 
 				if err := file.Close(); err != nil {

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -17,6 +17,7 @@ type cursor interface {
 // cursorAt provides a bufferred cursor interface.
 // This required for literal value cursors which don't have a time value.
 type cursorAt interface {
+	close() error
 	peek() (k int64, v interface{})
 	nextAt(seek int64) interface{}
 }
@@ -38,6 +39,10 @@ type bufCursor struct {
 // newBufCursor returns a bufferred wrapper for cur.
 func newBufCursor(cur cursor, ascending bool) *bufCursor {
 	return &bufCursor{cur: cur, ascending: ascending}
+}
+
+func (c *bufCursor) close() error {
+	return c.cur.close()
 }
 
 // next returns the buffer, if filled. Otherwise returns the next key/value from the cursor.
@@ -225,7 +230,18 @@ func (itr *{{.name}}Iterator) Stats() influxql.IteratorStats {
 }
 
 // Close closes the iterator.
-func (itr *{{.name}}Iterator) Close() error { return itr.cur.close() }
+func (itr *{{.name}}Iterator) Close() error {
+	for _, c := range itr.aux {
+		c.close()
+	}
+	for _, c := range itr.conds.curs {
+	    c.close()
+	}
+	if itr.cur != nil {
+		return itr.cur.close()
+	}
+	return nil
+}
 
 // {{.name}}LimitIterator
 type {{.name}}LimitIterator struct {
@@ -514,6 +530,7 @@ type {{.name}}LiteralCursor struct {
 	value {{.Type}}
 }
 
+func (c *{{.name}}LiteralCursor) close() error { return nil }
 func (c *{{.name}}LiteralCursor) peek() (t int64, v interface{}) { return tsdb.EOF, c.value }
 func (c *{{.name}}LiteralCursor) next() (t int64, v interface{}) { return tsdb.EOF, c.value }
 func (c *{{.name}}LiteralCursor) nextAt(seek int64) interface{} { return c.value }
@@ -523,6 +540,7 @@ func (c *{{.name}}LiteralCursor) nextAt(seek int64) interface{} { return c.value
 // It doesn't not have a time value so it can only be used with nextAt().
 type {{.name}}NilLiteralCursor struct {}
 
+func (c *{{.name}}NilLiteralCursor) close() error { return nil }
 func (c *{{.name}}NilLiteralCursor) peek() (t int64, v interface{}) { return tsdb.EOF, (*{{.Type}})(nil) }
 func (c *{{.name}}NilLiteralCursor) next() (t int64, v interface{}) { return tsdb.EOF, (*{{.Type}})(nil) }
 func (c *{{.name}}NilLiteralCursor) nextAt(seek int64) interface{} { return (*{{.Type}})(nil) }

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -202,27 +202,27 @@ func NewTSMReader(f *os.File) (*TSMReader, error) {
 }
 
 func (t *TSMReader) applyTombstones() error {
-	// Read any tombstone entries if the exist
-	tombstones, err := t.tombstoner.ReadAll()
-	if err != nil {
-		return fmt.Errorf("init: read tombstones: %v", err)
-	}
-
-	if len(tombstones) == 0 {
-		return nil
-	}
-
 	var cur, prev Tombstone
-	cur = tombstones[0]
-	batch := []string{cur.Key}
-	for i := 1; i < len(tombstones); i++ {
-		cur = tombstones[i]
-		prev = tombstones[i-1]
-		if prev.Min != cur.Min || prev.Max != cur.Max {
+	batch := make([]string, 0, 1024)
+
+	if err := t.tombstoner.Walk(func(ts Tombstone) error {
+		cur = ts
+		if len(batch) > 0 {
+			if prev.Min != cur.Min || prev.Max != cur.Max {
+				t.index.DeleteRange(batch, prev.Min, prev.Max)
+				batch = batch[:0]
+			}
+		}
+		batch = append(batch, ts.Key)
+
+		if len(batch) > 1024 {
 			t.index.DeleteRange(batch, prev.Min, prev.Max)
 			batch = batch[:0]
 		}
-		batch = append(batch, cur.Key)
+		prev = ts
+		return nil
+	}); err != nil {
+		return fmt.Errorf("init: read tombstones: %v", err)
 	}
 
 	if len(batch) > 0 {

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -203,7 +203,7 @@ func NewTSMReader(f *os.File) (*TSMReader, error) {
 
 func (t *TSMReader) applyTombstones() error {
 	var cur, prev Tombstone
-	batch := make([]string, 0, 1024)
+	batch := make([]string, 0, 4096)
 
 	if err := t.tombstoner.Walk(func(ts Tombstone) error {
 		cur = ts
@@ -215,7 +215,7 @@ func (t *TSMReader) applyTombstones() error {
 		}
 		batch = append(batch, ts.Key)
 
-		if len(batch) > 1024 {
+		if len(batch) > 4096 {
 			t.index.DeleteRange(batch, prev.Min, prev.Max)
 			batch = batch[:0]
 		}

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -215,7 +215,7 @@ func (t *TSMReader) applyTombstones() error {
 		}
 		batch = append(batch, ts.Key)
 
-		if len(batch) > 4096 {
+		if len(batch) >= 4096 {
 			t.index.DeleteRange(batch, prev.Min, prev.Max)
 			batch = batch[:0]
 		}

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -279,7 +279,6 @@ func (t *Tombstoner) readTombstoneV2(f *os.File, fn func(t Tombstone) error) err
 			return err
 		}
 	}
-	return nil
 }
 
 func (t *Tombstoner) tombstonePath() string {

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -11,7 +11,10 @@ import (
 	"sync"
 )
 
-const v2header = 0x1502
+const (
+	v2header     = 0x1502
+	v2headerSize = 4
+)
 
 type Tombstoner struct {
 	mu sync.Mutex
@@ -116,8 +119,7 @@ func (t *Tombstoner) Walk(fn func(t Tombstone) error) error {
 	defer f.Close()
 
 	var b [4]byte
-	_, err = f.Read(b[:])
-	if err != nil {
+	if _, err := f.Read(b[:]); err != nil {
 		// Might be a zero length file which should not exist, but
 		// an old bug allowed them to occur.  Treat it as an empty
 		// v1 tombstone file so we don't abort loading the TSM file.
@@ -221,7 +223,7 @@ func (t *Tombstoner) readTombstoneV1(f *os.File, fn func(t Tombstone) error) err
 // format is binary.
 func (t *Tombstoner) readTombstoneV2(f *os.File, fn func(t Tombstone) error) error {
 	// Skip header, already checked earlier
-	if _, err := f.Seek(4, os.SEEK_SET); err != nil {
+	if _, err := f.Seek(v2headerSize, os.SEEK_SET); err != nil {
 		return err
 	}
 	n := int64(4)

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -98,7 +98,7 @@ func (t *Tombstoner) TombstoneFiles() []FileStat {
 
 	if stat.Size() > 0 {
 		return []FileStat{FileStat{
-			Path:         stat.Name(),
+			Path:         t.tombstonePath(),
 			LastModified: stat.ModTime().UnixNano(),
 			Size:         uint32(stat.Size())}}
 	}

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -1,6 +1,7 @@
 package tsm1
 
 import (
+	"bufio"
 	"encoding/binary"
 	"io/ioutil"
 	"math"
@@ -198,19 +199,9 @@ func (t *Tombstoner) readTombstone() ([]Tombstone, error) {
 // compatibility with versions prior to 0.13.  This format is a simple newline
 // separated text file.
 func (t *Tombstoner) readTombstoneV1(f *os.File, fn func(t Tombstone) error) error {
-	var b []byte
-	var err error
-	b, err = ioutil.ReadAll(f)
-	if err != nil {
-		return err
-	}
-
-	lines := strings.TrimSpace(string(b))
-	if lines == "" {
-		return nil
-	}
-
-	for _, line := range strings.Split(string(b), "\n") {
+	r := bufio.NewScanner(f)
+	for r.Scan() {
+		line := r.Text()
 		if line == "" {
 			continue
 		}
@@ -222,7 +213,7 @@ func (t *Tombstoner) readTombstoneV1(f *os.File, fn func(t Tombstone) error) err
 			return err
 		}
 	}
-	return nil
+	return r.Err()
 }
 
 // readTombstoneV2 reads the second version of tombstone files that are capable


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR has a number of improvements to reduce memory usage, improve performance and fix bugs related to tombstone files.

* Tombstones were read into memory and then applied to TSM files.  Since we read TSM files concurrently, this could cause large memory spikes at startup.  It now loads them iteratively using a more consistent amount of memory.
* V1 tombstones also read all values into memory.  This has been changed to be more iterative.
* Deletes to TSM files are not applied concurrently which should improve deletes in the engine.
* When tombstones are loaded, batches are used to apply each tombstone instead of reading them all into memory at once.
* When tombstones were written, a bug caused the series to be add N times for each TSM files.  This cause tombstone files to be much larger than necessary and be much slower to reload.
* Some TSM cursors were not closed which could cause TSM files used during a query to and also being compacted to leak.
