### PR TITLE
Fix length of (*tsdb.DatabaseIndex).SeriesKeys()

### DIFF
--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -74,7 +74,7 @@ func (d *DatabaseIndex) Series(key string) *Series {
 
 func (d *DatabaseIndex) SeriesKeys() []string {
 	d.mu.RLock()
-	s := make([]string, len(d.series))
+	s := make([]string, 0, len(d.series))
 	for k := range d.series {
 		s = append(s, k)
 	}


### PR DESCRIPTION

- [x] Rebased/mergable
- [x] Tests pass

Previously, it would return as many empty strings in the first half of
the slice as valid values at the end of the slice.