### PR TITLE
feat #6679: add series limit config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Support for config options `[collectd]` and `[opentsdb]` has been removed; use `[[collectd]]` and `[[opentsdb]]` instead.
 * Config option `data-logging-enabled` within the `[data]` section, has been renamed to `trace-logging-enabled`, and defaults to `false`.
 * The keywords `IF`, `EXISTS`, and `NOT` where removed for this release.  This means you no longer need to specify `IF NOT EXISTS` for `DROP DATABASE` or `IF EXISTS` for `CREATE DATABASE`.
+* `max-series-per-database` was added with a default of 1M but can be disabled by setting it to `0`.
 
 With this release the systemd configuration files for InfluxDB will use the system configured default for logging and will no longer write files to `/var/log/influxdb` by default. On most systems, the logs will be directed to the systemd journal and can be accessed by `journalctl -u influxdb.service`. Consult the systemd journald documentation for configuring journald.
 
@@ -46,6 +47,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7050](https://github.com/influxdata/influxdb/pull/7050): Update go package library dependencies.
 - [#5750](https://github.com/influxdata/influxdb/issues/5750): Support wildcards in aggregate functions.
 - [#7605](https://github.com/influxdata/influxdb/issues/7605): Remove IF EXISTS/IF NOT EXISTS from influxql language.
+- [#7095](https://github.com/influxdata/influxdb/pull/7095): Add MaxSeriesPerDatabase config setting.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 ## v1.0.0 [unreleased]
 
+### Breaking changes
+
+* `max-series-per-database` was added with a default of 1M but can be disabled by setting it to `0`. Existing databases with series that exceed this limit will continue to load but writes that would create new series will fail.
+
 ### Release Notes
 
 * Config option `[cluster]` has been replaced with `[coordinator]`
 * Support for config options `[collectd]` and `[opentsdb]` has been removed; use `[[collectd]]` and `[[opentsdb]]` instead.
 * Config option `data-logging-enabled` within the `[data]` section, has been renamed to `trace-logging-enabled`, and defaults to `false`.
 * The keywords `IF`, `EXISTS`, and `NOT` where removed for this release.  This means you no longer need to specify `IF NOT EXISTS` for `DROP DATABASE` or `IF EXISTS` for `CREATE DATABASE`.
-* `max-series-per-database` was added with a default of 1M but can be disabled by setting it to `0`.
 
 With this release the systemd configuration files for InfluxDB will use the system configured default for logging and will no longer write files to `/var/log/influxdb` by default. On most systems, the logs will be directed to the systemd journal and can be accessed by `journalctl -u influxdb.service`. Consult the systemd journald documentation for configuring journald.
 

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -36,6 +36,9 @@ const (
 	// DefaultMaxPointsPerBlock is the maximum number of points in an encoded
 	// block in a TSM file
 	DefaultMaxPointsPerBlock = 1000
+
+	// DefaultMaxSeriesPerDatabase is the maximum number of series a node can hold per database.
+	DefaultMaxSeriesPerDatabase = 1000000
 )
 
 // Config holds the configuration for the tsbd package.
@@ -57,6 +60,13 @@ type Config struct {
 	CompactFullWriteColdDuration   toml.Duration `toml:"compact-full-write-cold-duration"`
 	MaxPointsPerBlock              int           `toml:"max-points-per-block"`
 
+	// Limits
+
+	// MaxSeriesPerDatabase is the maximum number of series a node can hold per database.
+	// When this limit is exceeded, writes return a 'max series per database exceeded' error.
+	// A value of 0 disables the limit.
+	MaxSeriesPerDatabase int `toml:"max-series-per-database"`
+
 	TraceLoggingEnabled bool `toml:"trace-logging-enabled"`
 }
 
@@ -73,6 +83,8 @@ func NewConfig() Config {
 		CacheSnapshotMemorySize:        DefaultCacheSnapshotMemorySize,
 		CacheSnapshotWriteColdDuration: toml.Duration(DefaultCacheSnapshotWriteColdDuration),
 		CompactFullWriteColdDuration:   toml.Duration(DefaultCompactFullWriteColdDuration),
+
+		MaxSeriesPerDatabase: DefaultMaxSeriesPerDatabase,
 
 		TraceLoggingEnabled: false,
 	}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -451,6 +451,10 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 		key := string(p.Key())
 		ss := s.index.Series(key)
 		if ss == nil {
+			if s.options.Config.MaxSeriesPerDatabase > 0 && len(s.index.series)+1 > s.options.Config.MaxSeriesPerDatabase {
+				return nil, fmt.Errorf("max series per database exceeded: %s", key)
+			}
+
 			ss = NewSeries(key, p.Tags())
 			atomic.AddInt64(&s.stats.SeriesCreated, 1)
 		}


### PR DESCRIPTION
This PR adds a configurable limit on the number of series per database.

/cc @jwilder 

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

