### PR TITLE
Use the Accept header for determining the Content-Type instead of Content-Type

### DIFF
--- a/services/httpd/response_writer.go
+++ b/services/httpd/response_writer.go
@@ -14,11 +14,11 @@ type ResponseWriter interface {
 	http.ResponseWriter
 }
 
-// NewResponseWriter creates a new ResponseWriter based on the Content-Type of the request
-// that wraps the ResponseWriter.
+// NewResponseWriter creates a new ResponseWriter based on the Accept header
+// in the request that wraps the ResponseWriter.
 func NewResponseWriter(w http.ResponseWriter, r *http.Request) ResponseWriter {
 	pretty := r.URL.Query().Get("pretty") == "true"
-	switch r.Header.Get("Content-Type") {
+	switch r.Header.Get("Accept") {
 	case "application/json":
 		fallthrough
 	default:


### PR DESCRIPTION
The `Content-Type` header is meant to say what the content type of the
request is supposed to be and `Accept` is used to ask for a specific
content type. I messed this up and used `Content-Type` instead of
`Accept`. This works with `GET` requests accidentally, but `POST`
requests stop working.