### PR TITLE
Ensure gzip writer is closed in influx_inspect export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7107](https://github.com/influxdata/influxdb/pull/7107): Limit shard concurrency
 - [#7028](https://github.com/influxdata/influxdb/pull/7028): Do not run continuous queries that have no time span.
 - [#7025](https://github.com/influxdata/influxdb/issues/7025): Move the CQ interval by the group by offset.
+- [#7125](https://github.com/influxdata/influxdb/pull/7125): Ensure gzip writer is closed in influx_inspect export
 
 ## v0.13.0 [2016-05-12]
 

--- a/cmd/influx_inspect/export.go
+++ b/cmd/influx_inspect/export.go
@@ -97,6 +97,7 @@ func (c *cmdExport) writeFiles() error {
 	defer w.Close()
 	if c.compress {
 		w = gzip.NewWriter(w)
+		defer w.Close()
 	}
 
 	// Write out all the DDL


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Previously, the gzip writer may have had unflushed data when the
underlying writer was closed, and the output stream would have been
truncated early.