### PR TITLE
Remove compaction assert that should not be there

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1158,8 +1158,6 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 }
 
 func (k *tsmKeyIterator) chunk(dst blocks) blocks {
-	k.mergedValues.assertOrdered()
-
 	for len(k.mergedValues) > k.size {
 		values := k.mergedValues[:k.size]
 		cb, err := Values(values).Encode(nil)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This assert was not removed when the issue that caused the assert
to trigger was fixed in 0f5e994.

Fixes #7121