### PR TITLE
Concurrent series limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7028](https://github.com/influxdata/influxdb/pull/7028): Do not run continuous queries that have no time span.
 - [#7025](https://github.com/influxdata/influxdb/issues/7025): Move the CQ interval by the group by offset.
 - [#7125](https://github.com/influxdata/influxdb/pull/7125): Ensure gzip writer is closed in influx_inspect export
+- [#7127](https://github.com/influxdata/influxdb/pull/7127): Concurrent series limit
 
 ## v0.13.0 [2016-05-12]
 

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -412,12 +412,6 @@ func (e *StatementExecutor) executeSelectStatement(stmt *influxql.SelectStatemen
 	em.OmitTime = stmt.OmitTime
 	defer em.Close()
 
-	// Calculate initial stats across all iterators.
-	stats := influxql.Iterators(itrs).Stats()
-	if e.MaxSelectSeriesN > 0 && stats.SeriesN > e.MaxSelectSeriesN {
-		return fmt.Errorf("max select series count exceeded: %d series", stats.SeriesN)
-	}
-
 	// Emit rows to the results channel.
 	var writeN int64
 	var emitted bool
@@ -505,6 +499,7 @@ func (e *StatementExecutor) createIterators(stmt *influxql.SelectStatement, ctx 
 	opt := influxql.SelectOptions{
 		InterruptCh: ctx.InterruptCh,
 		NodeID:      ctx.ExecutionOptions.NodeID,
+		MaxSeriesN:  e.MaxSelectSeriesN,
 	}
 
 	// Replace instances of "now()" with the current time, and check the resultant times.

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -22,6 +22,9 @@ type SelectOptions struct {
 	// An optional channel that, if closed, signals that the select should be
 	// interrupted.
 	InterruptCh <-chan struct{}
+
+	// Maximum number of concurrent series.
+	MaxSeriesN int
 }
 
 // Select executes stmt against ic and returns a list of iterators to stream from.

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -377,12 +377,15 @@ func (s *Store) DeleteShard(shardID uint64) error {
 }
 
 // ShardIteratorCreator returns an iterator creator for a shard.
-func (s *Store) ShardIteratorCreator(id uint64) influxql.IteratorCreator {
+func (s *Store) ShardIteratorCreator(id uint64, opt *influxql.SelectOptions) influxql.IteratorCreator {
 	sh := s.Shard(id)
 	if sh == nil {
 		return nil
 	}
-	return &shardIteratorCreator{sh: sh}
+	return &shardIteratorCreator{
+		sh:         sh,
+		maxSeriesN: opt.MaxSeriesN,
+	}
 }
 
 // DeleteDatabase will close all shards associated with a database and remove the directory and files from disk.
@@ -783,7 +786,7 @@ func (s *Store) IteratorCreator(shards []uint64, opt *influxql.SelectOptions) (i
 	ics := make([]influxql.IteratorCreator, 0)
 	if err := func() error {
 		for _, id := range shards {
-			ic := s.ShardIteratorCreator(id)
+			ic := s.ShardIteratorCreator(id, opt)
 			if ic == nil {
 				continue
 			}


### PR DESCRIPTION
## Overview

This commit fixes the `MaxSelectSeriesN` limit which was broken by the implementation of lazy iterators. The setting previously limited the total number of series but the new implementation limits the concurrent number of series being processed.

/cc @jwilder @jsternberg 

## TODO
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

