### PR TITLE
add support for unix socket binding service

### DIFF
--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/influxdata/influxdb/services/retention"
 	"github.com/influxdata/influxdb/services/subscriber"
 	"github.com/influxdata/influxdb/services/udp"
+	"github.com/influxdata/influxdb/services/unixsocket"
 	"github.com/influxdata/influxdb/tsdb"
 )
 
@@ -44,14 +45,15 @@ type Config struct {
 	Retention   retention.Config   `toml:"retention"`
 	Precreator  precreator.Config  `toml:"shard-precreation"`
 
-	Admin          admin.Config      `toml:"admin"`
-	Monitor        monitor.Config    `toml:"monitor"`
-	Subscriber     subscriber.Config `toml:"subscriber"`
-	HTTPD          httpd.Config      `toml:"http"`
-	GraphiteInputs []graphite.Config `toml:"graphite"`
-	CollectdInputs []collectd.Config `toml:"collectd"`
-	OpenTSDBInputs []opentsdb.Config `toml:"opentsdb"`
-	UDPInputs      []udp.Config      `toml:"udp"`
+	Admin            admin.Config        `toml:"admin"`
+	Monitor          monitor.Config      `toml:"monitor"`
+	Subscriber       subscriber.Config   `toml:"subscriber"`
+	HTTPD            httpd.Config        `toml:"http"`
+	GraphiteInputs   []graphite.Config   `toml:"graphite"`
+	CollectdInputs   []collectd.Config   `toml:"collectd"`
+	OpenTSDBInputs   []opentsdb.Config   `toml:"opentsdb"`
+	UDPInputs        []udp.Config        `toml:"udp"`
+	UnixSocketInputs []unixsocket.Config `toml:"unixsocket"`
 
 	ContinuousQuery continuous_querier.Config `toml:"continuous_queries"`
 
@@ -79,6 +81,7 @@ func NewConfig() *Config {
 	c.CollectdInputs = []collectd.Config{collectd.NewConfig()}
 	c.OpenTSDBInputs = []opentsdb.Config{opentsdb.NewConfig()}
 	c.UDPInputs = []udp.Config{udp.NewConfig()}
+	c.UnixSocketInputs = []unixsocket.Config{unixsocket.NewConfig()}
 
 	c.ContinuousQuery = continuous_querier.NewConfig()
 	c.Retention = retention.NewConfig()

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/influxdata/influxdb/services/snapshotter"
 	"github.com/influxdata/influxdb/services/subscriber"
 	"github.com/influxdata/influxdb/services/udp"
+	"github.com/influxdata/influxdb/services/unixsocket"
 	"github.com/influxdata/influxdb/tcp"
 	"github.com/influxdata/influxdb/tsdb"
 	client "github.com/influxdata/usage-client/v1"
@@ -341,6 +342,16 @@ func (s *Server) appendUDPService(c udp.Config) {
 	s.Services = append(s.Services, srv)
 }
 
+func (s *Server) appendUnixSocketService(c unixsocket.Config) {
+	if !c.Enabled {
+		return
+	}
+	srv := unixsocket.NewService(c)
+	srv.PointsWriter = s.PointsWriter
+	srv.MetaClient = s.MetaClient
+	s.Services = append(s.Services, srv)
+}
+
 func (s *Server) appendContinuousQueryService(c continuous_querier.Config) {
 	if !c.Enabled {
 		return
@@ -393,6 +404,9 @@ func (s *Server) Open() error {
 	}
 	for _, i := range s.config.UDPInputs {
 		s.appendUDPService(i)
+	}
+	for _, i := range s.config.UnixSocketInputs {
+		s.appendUnixSocketService(i)
 	}
 
 	s.Subscriber.MetaClient = s.MetaClient

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -294,6 +294,27 @@ reporting-disabled = false
   # udp-payload-size = 65536
 
 ###
+### [[unixsocket]]
+###
+### Controls the listeners for InfluxDB line protocol data via unix socket.
+###
+
+[[unixsocket]]
+  enabled = false
+  # bind-socket = ""
+  # database = "unixsocket"
+  # retention-policy = ""
+
+  # These next lines control how batching works. You should have this enabled
+  # otherwise you could get dropped metrics or poor performance. Batching
+  # will buffer points in memory if you have many coming in.
+
+  # batch-size = 1000 # will flush if this many points get buffered
+  # batch-pending = 5 # number of batches that may be pending in memory
+  # batch-timeout = "1s" # will flush at least this often even if we haven't hit buffer limit
+  # read-buffer = 0 # unix socket Read buffer size, 0 means OS default. unix socket listener will fail if set above OS max.
+
+###
 ### [continuous_queries]
 ###
 ### Controls how continuous queries are run within InfluxDB.

--- a/services/unixsocket/README.md
+++ b/services/unixsocket/README.md
@@ -1,0 +1,60 @@
+# The Unix Domain Socket Input
+
+
+## Configuration
+
+Each unix domain socket input allows the binding socket, target database, and target retention policy to be set. If the database does not exist, it will be created automatically when the input is initialized. If the retention policy is not configured, then the default retention policy for the database is used. However if the retention policy is set, the retention policy must be explicitly created. The input will not automatically create it.
+
+Each unix socket input also performs internal batching of the points it receives, as batched writes to the database are more efficient. The default _batch size_ is 1000, _pending batch_ factor is 5, with a _batch timeout_ of 1 second. This means the input will write batches of maximum size 1000, but if a batch has not reached 1000 points within 1 second of the first point being added to a batch, it will emit that batch regardless of size. The pending batch factor controls how many batches can be in memory at once, allowing the input to transmit a batch, while still building other batches.
+
+## Processing
+
+The unix socket input can receive up to 64KB per read, and splits the received data by newline. Each part is then interpreted as line-protocol encoded points, and parsed accordingly.
+
+
+## Config Examples
+
+One unix socket listener
+
+```
+# influxd.conf
+...
+[[unixsocket]]
+  enabled = true
+  bind-socket = "/var/run/influxdb.sock" # the bind socket
+  database = "telegraf" # Name of the database that will be written to
+  batch-size = 5000 # will flush if this many points get buffered
+  batch-timeout = "1s" # will flush at least this often even if the batch-size is not reached
+  batch-pending = 10 # number of batches that may be pending in memory
+  read-buffer = 0 # unix socket read buffer, 0 means to use OS default
+...
+```
+
+Multiple unix socket listeners
+
+```
+# influxd.conf
+...
+[[unixsocket]]
+  # Default unix socket for Telegraf
+  enabled = true
+  bind-socket = "/var/run/telegraf.sock" # the bind socket
+  database = "telegraf" # Name of the database that will be written to
+  batch-size = 5000 # will flush if this many points get buffered
+  batch-timeout = "1s" # will flush at least this often even if the batch-size is not reached
+  batch-pending = 10 # number of batches that may be pending in memory
+  read-buffer = 0 # unix socket read buffer size, 0 means to use OS default
+
+[[unixsocket]]
+  # High-traffic unix socket
+  enabled = true
+  bind-socket = "/var/run/mymetrics.sock" # the bind socket
+  database = "mymetrics" # Name of the database that will be written to
+  batch-size = 5000 # will flush if this many points get buffered
+  batch-timeout = "1s" # will flush at least this often even if the batch-size is not reached
+  batch-pending = 100 # number of batches that may be pending in memory
+  read-buffer = 8388608 # (8*1024*1024) unix socket read buffer size
+...
+```
+
+

--- a/services/unixsocket/config.go
+++ b/services/unixsocket/config.go
@@ -1,0 +1,94 @@
+package unixsocket
+
+import (
+	"time"
+
+	"github.com/influxdata/influxdb/toml"
+)
+
+const (
+	// DefaultBindSocket is the default binding interface if none is specified.
+	DefaultBindSocket = "/var/run/influxdb.sock"
+
+	// DefaultDatabase is the default database for unix socket traffic.
+	DefaultDatabase = "unixsocket"
+
+	// DefaultRetentionPolicy is the default retention policy used for writes.
+	DefaultRetentionPolicy = ""
+
+	// DefaultBatchSize is the default unix socket batch size.
+	DefaultBatchSize = 5000
+
+	// DefaultBatchPending is the default number of pending unix socket batches.
+	DefaultBatchPending = 10
+
+	// DefaultBatchTimeout is the default unix socket batch timeout.
+	DefaultBatchTimeout = time.Second
+
+	// DefaultPrecision is the default time precision used for unix socket services.
+	DefaultPrecision = "n"
+
+	// DefaultReadBuffer is the default buffer size for the unix socket listener.
+	// Sets the size of the operating system's receive buffer associated with
+	// the unix socket traffic. Keep in mind that the OS must be able
+	// to handle the number set here or the unix socket listener will error and exit.
+	//
+	// DefaultReadBuffer = 0 means to use the OS default, which is usually too
+	// small for high unix socket performance.
+	//
+	// Increasing OS buffer limits:
+	//     Linux:      sudo sysctl -w net.core.rmem_max=<read-buffer>
+	//     BSD/Darwin: sudo sysctl -w kern.ipc.maxsockbuf=<read-buffer>
+	DefaultReadBuffer = 0
+)
+
+// Config holds various configuration settings for the unix socket listener.
+type Config struct {
+	Enabled    bool   `toml:"enabled"`
+	BindSocket string `toml:"bind-socket"`
+
+	Database        string        `toml:"database"`
+	RetentionPolicy string        `toml:"retention-policy"`
+	BatchSize       int           `toml:"batch-size"`
+	BatchPending    int           `toml:"batch-pending"`
+	ReadBuffer      int           `toml:"read-buffer"`
+	BatchTimeout    toml.Duration `toml:"batch-timeout"`
+	Precision       string        `toml:"precision"`
+}
+
+// NewConfig returns a new instance of Config with defaults.
+func NewConfig() Config {
+	return Config{
+		BindSocket:      DefaultBindSocket,
+		Database:        DefaultDatabase,
+		RetentionPolicy: DefaultRetentionPolicy,
+		BatchSize:       DefaultBatchSize,
+		BatchPending:    DefaultBatchPending,
+		BatchTimeout:    toml.Duration(DefaultBatchTimeout),
+	}
+}
+
+// WithDefaults takes the given config and returns a new config with any required
+// default values set.
+func (c *Config) WithDefaults() *Config {
+	d := *c
+	if d.Database == "" {
+		d.Database = DefaultDatabase
+	}
+	if d.BatchSize == 0 {
+		d.BatchSize = DefaultBatchSize
+	}
+	if d.BatchPending == 0 {
+		d.BatchPending = DefaultBatchPending
+	}
+	if d.BatchTimeout == 0 {
+		d.BatchTimeout = toml.Duration(DefaultBatchTimeout)
+	}
+	if d.Precision == "" {
+		d.Precision = DefaultPrecision
+	}
+	if d.ReadBuffer == 0 {
+		d.ReadBuffer = DefaultReadBuffer
+	}
+	return &d
+}

--- a/services/unixsocket/config_test.go
+++ b/services/unixsocket/config_test.go
@@ -1,0 +1,42 @@
+package unixsocket_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/influxdata/influxdb/services/unixsocket"
+)
+
+func TestConfig_Parse(t *testing.T) {
+	// Parse configuration.
+	var c unixsocket.Config
+	if _, err := toml.Decode(`
+enabled = true
+bind-socket = "/tmp/influxdb.sock"
+database = "awesomedb"
+retention-policy = "awesomerp"
+batch-size = 100
+batch-pending = 9
+batch-timeout = "10ms"
+`, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate configuration.
+	if c.Enabled != true {
+		t.Fatalf("unexpected enabled: %v", c.Enabled)
+	} else if c.BindSocket != "/tmp/influxdb.sock" {
+		t.Fatalf("unexpected bind address: %s", c.BindSocket)
+	} else if c.Database != "awesomedb" {
+		t.Fatalf("unexpected database: %s", c.Database)
+	} else if c.RetentionPolicy != "awesomerp" {
+		t.Fatalf("unexpected retention policy: %s", c.RetentionPolicy)
+	} else if c.BatchSize != 100 {
+		t.Fatalf("unexpected batch size: %d", c.BatchSize)
+	} else if c.BatchPending != 9 {
+		t.Fatalf("unexpected batch pending: %d", c.BatchPending)
+	} else if time.Duration(c.BatchTimeout) != (10 * time.Millisecond) {
+		t.Fatalf("unexpected batch timeout: %v", c.BatchTimeout)
+	}
+}

--- a/services/unixsocket/service.go
+++ b/services/unixsocket/service.go
@@ -1,0 +1,268 @@
+package unixsocket // import "github.com/influxdata/influxdb/services/unixsocket"
+
+import (
+	"errors"
+	"io"
+	"log"
+	"net"
+	"os"
+	"path"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxdb/tsdb"
+)
+
+const (
+	// Arbitrary, testing indicated that this doesn't typically get over 10
+	parserChanLen = 1000
+
+	MAX_UNIX_SOCKET_PAYLOAD = 64 * 1024
+)
+
+// statistics gathered by the unix socket package.
+const (
+	statPointsReceived      = "pointsRx"
+	statBytesReceived       = "bytesRx"
+	statPointsParseFail     = "pointsParseFail"
+	statReadFail            = "readFail"
+	statBatchesTransmitted  = "batchesTx"
+	statPointsTransmitted   = "pointsTx"
+	statBatchesTransmitFail = "batchesTxFail"
+)
+
+//
+// Service represents here an unix socket service
+// that will listen for incoming packets
+// formatted with the inline protocol
+//
+type Service struct {
+	conn *net.UnixConn
+	addr *net.UnixAddr
+	wg   sync.WaitGroup
+	done chan struct{}
+
+	parserChan chan []byte
+	batcher    *tsdb.PointBatcher
+	config     Config
+
+	PointsWriter interface {
+		WritePoints(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+	}
+
+	MetaClient interface {
+		CreateDatabase(name string) (*meta.DatabaseInfo, error)
+	}
+
+	Logger   *log.Logger
+	stats    *Statistics
+	statTags models.Tags
+}
+
+// NewService returns a new instance of Service.
+func NewService(c Config) *Service {
+	d := *c.WithDefaults()
+	return &Service{
+		config:     d,
+		done:       make(chan struct{}),
+		parserChan: make(chan []byte, parserChanLen),
+		batcher:    tsdb.NewPointBatcher(d.BatchSize, d.BatchPending, time.Duration(d.BatchTimeout)),
+		Logger:     log.New(os.Stderr, "[unixsocket] ", log.LstdFlags),
+		stats:      &Statistics{},
+		statTags:   map[string]string{"unixsocket": d.BindSocket},
+	}
+}
+
+// Open starts the service
+func (s *Service) Open() (err error) {
+	if s.conn != nil {
+		s.conn.Close()
+	}
+
+	if s.config.BindSocket == "" {
+		return errors.New("bind socket has to be specified in config")
+	}
+	if s.config.Database == "" {
+		return errors.New("database has to be specified in config")
+	}
+
+	if _, err := s.MetaClient.CreateDatabase(s.config.Database); err != nil {
+		return errors.New("Failed to ensure target database exists")
+	}
+
+	if err := os.MkdirAll(path.Dir(s.config.BindSocket), 0777); err != nil {
+		return err
+	}
+
+	s.addr, err = net.ResolveUnixAddr("unix", s.config.BindSocket)
+	if err != nil {
+		s.Logger.Printf("Failed to resolve unix socket address %s: %s", s.config.BindSocket, err)
+		return err
+	}
+
+	s.conn, err = net.ListenUnixgram("unixgram", s.addr)
+	if err != nil {
+		s.Logger.Printf("Failed to set up unixgram listener at address %s: %s", s.addr, err)
+		return err
+	}
+
+	if s.config.ReadBuffer != 0 {
+		err = s.conn.SetReadBuffer(s.config.ReadBuffer)
+		if err != nil {
+			s.Logger.Printf("Failed to set unix socket read buffer to %d: %s",
+				s.config.ReadBuffer, err)
+			return err
+		}
+	}
+
+	s.Logger.Printf("Started listening on unix socket: %s", s.config.BindSocket)
+
+	s.wg.Add(3)
+	go s.serve()
+	go s.parser()
+	go s.writer()
+
+	return nil
+}
+
+// Statistics maintains statistics for the unix socket service.
+type Statistics struct {
+	PointsReceived      int64
+	BytesReceived       int64
+	PointsParseFail     int64
+	ReadFail            int64
+	BatchesTransmitted  int64
+	PointsTransmitted   int64
+	BatchesTransmitFail int64
+}
+
+// Statistics returns statistics for periodic monitoring.
+func (s *Service) Statistics(tags map[string]string) []models.Statistic {
+	return []models.Statistic{{
+		Name: "unixsocket",
+		Tags: s.statTags,
+		Values: map[string]interface{}{
+			statPointsReceived:      atomic.LoadInt64(&s.stats.PointsReceived),
+			statBytesReceived:       atomic.LoadInt64(&s.stats.BytesReceived),
+			statPointsParseFail:     atomic.LoadInt64(&s.stats.PointsParseFail),
+			statReadFail:            atomic.LoadInt64(&s.stats.ReadFail),
+			statBatchesTransmitted:  atomic.LoadInt64(&s.stats.BatchesTransmitted),
+			statPointsTransmitted:   atomic.LoadInt64(&s.stats.PointsTransmitted),
+			statBatchesTransmitFail: atomic.LoadInt64(&s.stats.BatchesTransmitFail),
+		},
+	}}
+}
+
+func (s *Service) writer() {
+	defer s.wg.Done()
+
+	for {
+		select {
+		case batch := <-s.batcher.Out():
+			if err := s.PointsWriter.WritePoints(s.config.Database, s.config.RetentionPolicy, models.ConsistencyLevelAny, batch); err == nil {
+				atomic.AddInt64(&s.stats.BatchesTransmitted, 1)
+				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
+			} else {
+				s.Logger.Printf("failed to write point batch to database %q: %s", s.config.Database, err)
+				atomic.AddInt64(&s.stats.BatchesTransmitFail, 1)
+			}
+
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (s *Service) serve() {
+	defer s.wg.Done()
+
+	buf := make([]byte, MAX_UNIX_SOCKET_PAYLOAD)
+	s.batcher.Start()
+	for {
+
+		select {
+		case <-s.done:
+			// We closed the connection, time to go.
+			return
+		default:
+			// Keep processing.
+			n, _, err := s.conn.ReadFromUnix(buf)
+			if err != nil {
+				if opErr, ok := err.(*net.OpError); ok && !opErr.Temporary() {
+					// Receive singal graceful
+					s.Logger.Printf("unix socket listener closed")
+					continue
+				}
+				atomic.AddInt64(&s.stats.ReadFail, 1)
+				s.Logger.Printf("Failed to read unix socket message: %s", err)
+				continue
+			}
+			atomic.AddInt64(&s.stats.BytesReceived, int64(n))
+
+			bufCopy := make([]byte, n)
+			copy(bufCopy, buf[:n])
+			s.parserChan <- bufCopy
+		}
+	}
+}
+
+func (s *Service) parser() {
+	defer s.wg.Done()
+
+	for {
+		select {
+		case <-s.done:
+			return
+		case buf := <-s.parserChan:
+			points, err := models.ParsePointsWithPrecision(buf, time.Now().UTC(), s.config.Precision)
+			if err != nil {
+				atomic.AddInt64(&s.stats.PointsParseFail, 1)
+				s.Logger.Printf("Failed to parse points: %s", err)
+				continue
+			}
+
+			for _, point := range points {
+				s.batcher.In() <- point
+			}
+			atomic.AddInt64(&s.stats.PointsReceived, int64(len(points)))
+		}
+	}
+}
+
+// Close closes the underlying listener.
+func (s *Service) Close() error {
+	if s.conn == nil {
+		return errors.New("Service already closed")
+	}
+
+	s.conn.Close()
+	s.batcher.Flush()
+	close(s.done)
+	s.wg.Wait()
+
+	// Release all remaining resources.
+	s.done = nil
+	s.conn = nil
+	err := os.Remove(s.config.BindSocket)
+	if err != nil {
+		return err
+	}
+
+	s.Logger.Print("Service closed")
+
+	return nil
+}
+
+// SetLogOutput sets the writer to which all logs are written. It must not be
+// called after Open is called.
+func (s *Service) SetLogOutput(w io.Writer) {
+	s.Logger = log.New(w, "[unixsocket] ", log.LstdFlags)
+}
+
+// Addr returns the listener's address
+func (s *Service) Addr() net.Addr {
+	return s.addr
+}


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA]

Feature Request in #7075 and #4877. I tested the code, just like the UDP service.

### start
```
[root@LT influxd]# ./influxd run

 8888888           .d888 888                   8888888b.  888888b.
   888            d88P"  888                   888  "Y88b 888  "88b
   888            888    888                   888    888 888  .88P
   888   88888b.  888888 888 888  888 888  888 888    888 8888888K.
   888   888 "88b 888    888 888  888  Y8bd8P' 888    888 888  "Y88b
   888   888  888 888    888 888  888   X88K   888    888 888    888
   888   888  888 888    888 Y88b 888 .d8""8b. 888  .d88P 888   d88P
 8888888 888  888 888    888  "Y88888 888  888 8888888P"  8888888P"

[run] 2016/08/09 14:30:03 InfluxDB starting, version unknown, branch unknown, commit unknown
[run] 2016/08/09 14:30:03 Go version go1.6.2, GOMAXPROCS set to 2
[run] 2016/08/09 14:30:03 Using configuration at: /etc/influxdb/influxdb.conf
[store] 2016/08/09 14:30:03 Using data dir: /var/lib/influxdb/data
[subscriber] 2016/08/09 14:30:03 opened service
[monitor] 2016/08/09 14:30:03 Starting monitor system
[monitor] 2016/08/09 14:30:03 'build' registered for diagnostics monitoring
[monitor] 2016/08/09 14:30:03 'runtime' registered for diagnostics monitoring
[monitor] 2016/08/09 14:30:03 'network' registered for diagnostics monitoring
[monitor] 2016/08/09 14:30:03 'system' registered for diagnostics monitoring
[shard-precreation] 2016/08/09 14:30:03 Starting precreation service with check interval of 10m0s, advance period of 30m0s
[snapshot] 2016/08/09 14:30:03 Starting snapshot service
[admin] 2016/08/09 14:30:03 Starting admin service
[admin] 2016/08/09 14:30:03 Listening on HTTP: [::]:8083
[continuous_querier] 2016/08/09 14:30:03 Starting continuous query service
[httpd] 2016/08/09 14:30:03 Starting HTTP service
[httpd] 2016/08/09 14:30:03 Authentication enabled: false
[httpd] 2016/08/09 14:30:03 Listening on HTTP: [::]:8086
[retention] 2016/08/09 14:30:03 Starting retention policy enforcement service with check interval of 30m0s
[monitor] 2016/08/09 14:30:03 Storing statistics in database '_internal' retention policy 'monitor', at interval 10s
[unixsocket] 2016/08/09 14:30:03 Started listening on unix socket: /tmp/i.sock
[run] 2016/08/09 14:30:03 Listening for signals
```

### write points example code:

```
package main

import "net"
import "time"
import "fmt"

func main() {
        addr, err := net.ResolveUnixAddr("unix", "/tmp/i.sock")
        if err != nil {
                panic(err)
        }
        c, err := net.DialUnix("unixgram", nil, addr)
        if err != nil {
                panic(err)
        }
        for {
                _, err := c.Write([]byte("cpu,host=serverA,region=us_west value=0.64\n"))
                if err != nil {
                        fmt.Println(err)
                }
                time.Sleep(1e9)
        }
}
```

### query via influx

```
[root@LT influx]# ./influx 
Visit https://enterprise.influxdata.com to register for updates, InfluxDB server management, and monitoring.
Connected to http://localhost:8086 version unknown
InfluxDB shell version: unknown
> show databases
name: databases
---------------
name
unixsocket
_internal

> use unixsocket
Using database unixsocket
> select * from cpu limit 10
name: cpu
---------
time                    host    region  value
1470725065606349352     serverA us_west 0.64
1470725066606549012     serverA us_west 0.64
1470725067606678699     serverA us_west 0.64
1470725068606809610     serverA us_west 0.64
1470725069606963202     serverA us_west 0.64
1470725070607052270     serverA us_west 0.64
1470725071607210170     serverA us_west 0.64
1470725072607312210     serverA us_west 0.64
1470725073607432441     serverA us_west 0.64
1470725074607556441     serverA us_west 0.64

```


### shutdown

```
[run] 2016/08/09 15:15:53 Signal received, initializing clean shutdown...
[run] 2016/08/09 15:15:53 Waiting for clean shutdown...
[monitor] 2016/08/09 15:15:53 shutting down monitor system
[monitor] 2016/08/09 15:15:53 terminating storage of statistics
[shard-precreation] 2016/08/09 15:15:53 Precreation service terminating
[snapshot] 2016/08/09 15:15:53 snapshot listener closed
[continuous_querier] 2016/08/09 15:15:53 continuous query service terminating
[retention] 2016/08/09 15:15:53 retention policy enforcement terminating
[unixsocket] 2016/08/09 15:15:53 unix socket listener closed
[unixsocket] 2016/08/09 15:15:53 Service closed
[subscriber] 2016/08/09 15:15:53 closed service
[run] 2016/08/09 15:15:53 server shutdown completed
```