### PR TITLE
Add additional statistics to query executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v1.1.0 [unreleased]
 
+### Features
+
+- [#7120](https://github.com/influxdata/influxdb/issues/7120): Add additional statistics to query executor.
+
 ### Bugfixes
 
 - [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -44,6 +44,8 @@ var (
 // Statistics for the QueryExecutor
 const (
 	statQueriesActive          = "queriesActive"   // Number of queries currently being executed
+	statQueriesExecuted        = "queriesExecuted" // Number of queries that have been executed (started).
+	statQueriesFinished        = "queriesFinished" // Number of queries that have finished.
 	statQueryExecutionDuration = "queryDurationNs" // Total (wall) time spent executing queries
 )
 
@@ -137,6 +139,8 @@ func NewQueryExecutor() *QueryExecutor {
 // QueryStatistics keeps statistics related to the QueryExecutor.
 type QueryStatistics struct {
 	ActiveQueries          int64
+	ExecutedQueries        int64
+	FinishedQueries        int64
 	QueryExecutionDuration int64
 }
 
@@ -147,6 +151,8 @@ func (e *QueryExecutor) Statistics(tags map[string]string) []models.Statistic {
 		Tags: tags,
 		Values: map[string]interface{}{
 			statQueriesActive:          atomic.LoadInt64(&e.stats.ActiveQueries),
+			statQueriesExecuted:        atomic.LoadInt64(&e.stats.ExecutedQueries),
+			statQueriesFinished:        atomic.LoadInt64(&e.stats.FinishedQueries),
 			statQueryExecutionDuration: atomic.LoadInt64(&e.stats.QueryExecutionDuration),
 		},
 	}}
@@ -176,8 +182,10 @@ func (e *QueryExecutor) executeQuery(query *Query, opt ExecutionOptions, closing
 	defer e.recover(query, results)
 
 	atomic.AddInt64(&e.stats.ActiveQueries, 1)
+	atomic.AddInt64(&e.stats.ExecutedQueries, 1)
 	defer func(start time.Time) {
 		atomic.AddInt64(&e.stats.ActiveQueries, -1)
+		atomic.AddInt64(&e.stats.FinishedQueries, 1)
 		atomic.AddInt64(&e.stats.QueryExecutionDuration, time.Since(start).Nanoseconds())
 	}(time.Now())
 


### PR DESCRIPTION
The query executor would only store the number of active queries and the
query duration so it was impossible to determine how many queries were
actually executed during that timeframe because quick queries would be
gone before the call to gather statistics was made.

This adds two new statistics so track when queries start and when
queries finish and doesn't decrement the counter so the number of
executed queries can be obtained using `derivative()` and
`difference()`.

Fixes #7120.