### PR TITLE
enable HTTP service over unix domain socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - [#7120](https://github.com/influxdata/influxdb/issues/7120): Add additional statistics to query executor.
+- [#7135](https://github.com/influxdata/influxdb/pull/7135): Support enable HTTP service over unix domain socket. Thanks @oiooj
 
 ### Bugfixes
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -173,6 +173,9 @@ reporting-disabled = false
   max-row-limit = 10000
   realm = "InfluxDB"
 
+  unix-socket-enabled = false # enable http service over unix domain socket
+  # bind-socket = "/var/run/influxdb.sock"
+
 ###
 ### [subsciber]
 ###

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -6,6 +6,9 @@ const (
 
 	// DefaultRealm is the default realm sent back when issuing a basic auth challenge.
 	DefaultRealm = "InfluxDB"
+
+	// DefaultBindSocket is the default unix socket to bind to.
+	DefaultBindSocket = "/var/run/influxdb.sock"
 )
 
 // Config represents a configuration for a HTTP service.
@@ -22,17 +25,21 @@ type Config struct {
 	MaxConnectionLimit int    `toml:"max-connection-limit"`
 	SharedSecret       string `toml:"shared-secret"`
 	Realm              string `toml:"realm"`
+	UnixSocketEnabled  bool   `toml:"unix-socket-enabled"`
+	BindSocket         string `toml:"bind-socket"`
 }
 
 // NewConfig returns a new Config with default settings.
 func NewConfig() Config {
 	return Config{
-		Enabled:          true,
-		BindAddress:      DefaultBindAddress,
-		LogEnabled:       true,
-		HTTPSEnabled:     false,
-		HTTPSCertificate: "/etc/ssl/influxdb.pem",
-		MaxRowLimit:      DefaultChunkSize,
-		Realm:            DefaultRealm,
+		Enabled:           true,
+		BindAddress:       DefaultBindAddress,
+		LogEnabled:        true,
+		HTTPSEnabled:      false,
+		HTTPSCertificate:  "/etc/ssl/influxdb.pem",
+		MaxRowLimit:       DefaultChunkSize,
+		Realm:             DefaultRealm,
+		UnixSocketEnabled: false,
+		BindSocket:        DefaultBindSocket,
 	}
 }

--- a/services/httpd/config_test.go
+++ b/services/httpd/config_test.go
@@ -18,6 +18,8 @@ log-enabled = true
 write-tracing = true
 https-enabled = true
 https-certificate = "/dev/null"
+unix-socket-enabled = true
+bind-socket = "/var/run/influxdb.sock"
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -37,6 +39,10 @@ https-certificate = "/dev/null"
 		t.Fatalf("unexpected https enabled: %v", c.HTTPSEnabled)
 	} else if c.HTTPSCertificate != "/dev/null" {
 		t.Fatalf("unexpected https certificate: %v", c.HTTPSCertificate)
+	} else if c.UnixSocketEnabled != true {
+		t.Fatalf("unexpected unix socket enabled: %v", c.UnixSocketEnabled)
+	} else if c.BindSocket != "/var/run/influxdb.sock" {
+		t.Fatalf("unexpected bind unix socket: %v", c.BindSocket)
 	}
 }
 

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -8,7 +8,10 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
+	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/influxdata/influxdb/models"
@@ -46,6 +49,10 @@ type Service struct {
 	limit int
 	err   chan error
 
+	unixSocket         bool
+	bindSocket         string
+	unixSocketListener net.Listener
+
 	Handler *Handler
 
 	Logger *log.Logger
@@ -54,14 +61,16 @@ type Service struct {
 // NewService returns a new instance of Service.
 func NewService(c Config) *Service {
 	s := &Service{
-		addr:    c.BindAddress,
-		https:   c.HTTPSEnabled,
-		cert:    c.HTTPSCertificate,
-		key:     c.HTTPSPrivateKey,
-		limit:   c.MaxConnectionLimit,
-		err:     make(chan error),
-		Handler: NewHandler(c),
-		Logger:  log.New(os.Stderr, "[httpd] ", log.LstdFlags),
+		addr:       c.BindAddress,
+		https:      c.HTTPSEnabled,
+		cert:       c.HTTPSCertificate,
+		key:        c.HTTPSPrivateKey,
+		limit:      c.MaxConnectionLimit,
+		err:        make(chan error),
+		unixSocket: c.UnixSocketEnabled,
+		bindSocket: c.BindSocket,
+		Handler:    NewHandler(c),
+		Logger:     log.New(os.Stderr, "[httpd] ", log.LstdFlags),
 	}
 	if s.key == "" {
 		s.key = s.cert
@@ -101,6 +110,29 @@ func (s *Service) Open() error {
 		s.ln = listener
 	}
 
+	// Open unix socket listener.
+	if s.unixSocket {
+		if runtime.GOOS == "windows" {
+			return fmt.Errorf("unable to use unix socket on windows")
+		}
+		if err := os.MkdirAll(path.Dir(s.bindSocket), 0777); err != nil {
+			return err
+		}
+		if err := syscall.Unlink(s.bindSocket); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+
+		listener, err := net.Listen("unix", s.bindSocket)
+		if err != nil {
+			return err
+		}
+
+		s.Logger.Println("Listening on unix socket:", listener.Addr().String())
+		s.unixSocketListener = listener
+
+		go s.serveUnixSocket()
+	}
+
 	// Enforce a connection limit if one has been given.
 	if s.limit > 0 {
 		s.ln = LimitListener(s.ln, s.limit)
@@ -120,14 +152,21 @@ func (s *Service) Open() error {
 	}
 
 	// Begin listening for requests in a separate goroutine.
-	go s.serve()
+	go s.serveTCP()
 	return nil
 }
 
 // Close closes the underlying listener.
 func (s *Service) Close() error {
 	if s.ln != nil {
-		return s.ln.Close()
+		if err := s.ln.Close(); err != nil {
+			return err
+		}
+	}
+	if s.unixSocketListener != nil {
+		if err := s.unixSocketListener.Close(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -156,11 +195,21 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 	return s.Handler.Statistics(models.Tags{"bind": s.addr}.Merge(tags))
 }
 
+// serveTCP serves the handler from the TCP listener.
+func (s *Service) serveTCP() {
+	s.serve(s.ln)
+}
+
+// serveUnixSocket serves the handler from the unix socket listener.
+func (s *Service) serveUnixSocket() {
+	s.serve(s.unixSocketListener)
+}
+
 // serve serves the handler from the listener.
-func (s *Service) serve() {
+func (s *Service) serve(listener net.Listener) {
 	// The listener was closed so exit
 	// See https://github.com/golang/go/issues/4373
-	err := http.Serve(s.ln, s.Handler)
+	err := http.Serve(listener, s.Handler)
 	if err != nil && !strings.Contains(err.Error(), "closed") {
 		s.err <- fmt.Errorf("listener failed: addr=%s, err=%s", s.Addr(), err)
 	}


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA]

Feature Request in #7075 and #4877. Now you can use the http service over TCP and unix domain socket.

### config

```
[http]
  enabled = true
  bind-address = ":8086"
  auth-enabled = false
  log-enabled = true
  write-tracing = false
  pprof-enabled = false
  https-enabled = false
  https-certificate = "/etc/ssl/influxdb.pem"
  ### Use a separate private key location.
  # https-private-key = ""
  max-row-limit = 10000
  realm = "InfluxDB"

  unix-socket-enabled = true # enable http service over unix domain socket
  bind-socket = "/var/run/influxdb.sock"
```

### start

```
.....

[snapshot] 2016/08/10 14:30:42 Starting snapshot service
[admin] 2016/08/10 14:30:42 Starting admin service
[admin] 2016/08/10 14:30:42 Listening on HTTP: [::]:8083
[continuous_querier] 2016/08/10 14:30:42 Starting continuous query service
[httpd] 2016/08/10 14:30:42 Starting HTTP service
[httpd] 2016/08/10 14:30:42 Authentication enabled: false
[httpd] 2016/08/10 14:30:42 Listening on HTTP: [::]:8086
[httpd] 2016/08/10 14:30:42 Listening on unix socket: /tmp/test.sock
[retention] 2016/08/10 14:30:42 Starting retention policy enforcement service with check interval of 30m0s
[monitor] 2016/08/10 14:30:42 Storing statistics in database '_internal' retention policy 'monitor', at interval 10s
[run] 2016/08/10 14:30:42 Listening for signals

```

### simple client

```

package main

import (
        "fmt"
        "io/ioutil"
        "net"
        "net/http"
        "net/url"
)

var sock = "/tmp/test.sock"

// all your client.Get or client.Post calls has to be a valid url (http://xxxx.xxx/path not unix://...),
// the domain name doesn't matter since it won't be used in connecting.
const URL = "http://test/"

func unixsocketDial(proto, addr string) (conn net.Conn, err error) {
        return net.Dial("unix", sock)
}

func main() {
        tr := &http.Transport{
                Dial: unixsocketDial,
        }

        client := &http.Client{Transport: tr}

        q := url.Values{}
        q.Set("db", "unixsocket")
        q.Set("q", "SELECT value FROM cpu WHERE region='us_west' LIMIT 10")

        req, err := http.NewRequest("GET", URL+"query?"+q.Encode(), nil)
        req.Header.Add("Content-Type", "application/json;charset=UTF-8")
        resp, err := client.Do(req)
        if err != nil {
                panic(err)
        }

        defer resp.Body.Close()

        body, err := ioutil.ReadAll(resp.Body)
        fmt.Println(string(body))
}
```
### result

```
[root@LT test-unix-socket-client]# go run http-over-unixsocket.go               
{"results":[{"series":[{"name":"cpu","columns":["time","value"],"values":[["2016-08-09T06:44:25.606349352Z",0.64],["2016-08-09T06:44:26.606549012Z",0.64],["2016-08-09T06:44:27.606678699Z",0.64],["2016-08-09T06:44:28.60680961Z",0.64],["2016-08-09T06:44:29.606963202Z",0.64],["2016-08-09T06:44:30.60705227Z",0.64],["2016-08-09T06:44:31.60721017Z",0.64],["2016-08-09T06:44:32.60731221Z",0.64],["2016-08-09T06:44:33.607432441Z",0.64],["2016-08-09T06:44:34.607556441Z",0.64]]}]}]}
```