### PR TITLE
Reduce memory allocations in index

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -562,7 +562,7 @@ func (p *Point) MarshalJSON() ([]byte, error) {
 // MarshalString renders string representation of a Point with specified
 // precision. The default precision is nanoseconds.
 func (p *Point) MarshalString() string {
-	pt, err := models.NewPoint(p.Measurement, p.Tags, p.Fields, p.Time)
+	pt, err := models.NewPoint(p.Measurement, models.NewTags(p.Tags), p.Fields, p.Time)
 	if err != nil {
 		return "# ERROR: " + err.Error() + " " + p.Measurement
 	}

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -356,7 +356,7 @@ func NewPoint(
 		T = t[0]
 	}
 
-	pt, err := models.NewPoint(name, tags, fields, T)
+	pt, err := models.NewPoint(name, models.NewTags(tags), fields, T)
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +382,7 @@ func (p *Point) Name() string {
 
 // Tags returns the tags associated with the point
 func (p *Point) Tags() map[string]string {
-	return p.pt.Tags()
+	return p.pt.Tags().Map()
 }
 
 // Time return the timestamp for the point

--- a/cmd/influx_inspect/export.go
+++ b/cmd/influx_inspect/export.go
@@ -132,7 +132,7 @@ func (c *cmdExport) writeFiles() error {
 				for i := 0; i < reader.KeyCount(); i++ {
 					var pairs string
 					key, typ := reader.KeyAt(i)
-					values, _ := reader.ReadAll(key)
+					values, _ := reader.ReadAll(string(key))
 					measurement, field := tsm1.SeriesAndFieldFromCompositeKey(key)
 
 					for _, value := range values {

--- a/cmd/influx_inspect/report.go
+++ b/cmd/influx_inspect/report.go
@@ -78,7 +78,7 @@ func cmdReport(opts *reportOpts) {
 			totalSeries.Add([]byte(key))
 
 			if opts.detailed {
-				sep := strings.Index(key, "#!~#")
+				sep := strings.Index(string(key), "#!~#")
 				seriesKey, field := key[:sep], key[sep+4:]
 				measurement, tags, _ := models.ParseKey(seriesKey)
 
@@ -96,13 +96,13 @@ func cmdReport(opts *reportOpts) {
 				}
 				fieldCount.Add([]byte(field))
 
-				for t, v := range tags {
-					tagCount, ok := tagCardialities[t]
+				for _, t := range tags {
+					tagCount, ok := tagCardialities[string(t.Key)]
 					if !ok {
 						tagCount = hllpp.New()
-						tagCardialities[t] = tagCount
+						tagCardialities[string(t.Key)] = tagCount
 					}
-					tagCount.Add([]byte(v))
+					tagCount.Add(t.Value)
 				}
 			}
 		}

--- a/cmd/influx_inspect/tsm.go
+++ b/cmd/influx_inspect/tsm.go
@@ -121,9 +121,9 @@ func cmdDumpTsm1(opts *tsdmDumpOpts) {
 		var pos int
 		for i := 0; i < keyCount; i++ {
 			key, _ := r.KeyAt(i)
-			for _, e := range r.Entries(key) {
+			for _, e := range r.Entries(string(key)) {
 				pos++
-				split := strings.Split(key, "#!~#")
+				split := strings.Split(string(key), "#!~#")
 
 				// We dont' know know if we have fields so use an informative default
 				var measurement, field string = "UNKNOWN", "UNKNOWN"
@@ -132,7 +132,7 @@ func cmdDumpTsm1(opts *tsdmDumpOpts) {
 				measurement = split[0]
 				field = split[1]
 
-				if opts.filterKey != "" && !strings.Contains(key, opts.filterKey) {
+				if opts.filterKey != "" && !strings.Contains(string(key), opts.filterKey) {
 					continue
 				}
 				fmt.Fprintln(tw, "  "+strings.Join([]string{
@@ -160,7 +160,7 @@ func cmdDumpTsm1(opts *tsdmDumpOpts) {
 	// Start at the beginning and read every block
 	for j := 0; j < keyCount; j++ {
 		key, _ := r.KeyAt(j)
-		for _, e := range r.Entries(key) {
+		for _, e := range r.Entries(string(key)) {
 
 			f.Seek(int64(e.Offset), 0)
 			f.Read(b[:4])
@@ -172,7 +172,7 @@ func cmdDumpTsm1(opts *tsdmDumpOpts) {
 
 			blockSize += int64(e.Size)
 
-			if opts.filterKey != "" && !strings.Contains(key, opts.filterKey) {
+			if opts.filterKey != "" && !strings.Contains(string(key), opts.filterKey) {
 				i += blockSize
 				blockCount++
 				continue

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -83,7 +83,7 @@ type WritePointsRequest struct {
 // AddPoint adds a point to the WritePointRequest with field key 'value'
 func (w *WritePointsRequest) AddPoint(name string, value interface{}, timestamp time.Time, tags map[string]string) {
 	pt, err := models.NewPoint(
-		name, tags, map[string]interface{}{"value": value}, timestamp,
+		name, models.NewTags(tags), map[string]interface{}{"value": value}, timestamp,
 	)
 	if err != nil {
 		return
@@ -176,7 +176,7 @@ type WriteStatistics struct {
 func (w *PointsWriter) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "write",
-		Tags: tags,
+		Tags: models.NewTags(tags),
 		Values: map[string]interface{}{
 			statWriteReq:           atomic.LoadInt64(&w.stats.WriteReq),
 			statPointWriteReq:      atomic.LoadInt64(&w.stats.PointWriteReq),

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -818,7 +818,7 @@ func (e *StatementExecutor) executeShowStatsStatement(stmt *influxql.ShowStatsSt
 		if stmt.Module != "" && stat.Name != stmt.Module {
 			continue
 		}
-		row := &models.Row{Name: stat.Name, Tags: stat.Tags}
+		row := &models.Row{Name: stat.Name, Tags: stat.Tags.Map()}
 
 		values := make([]interface{}, 0, len(stat.Values))
 		for _, k := range stat.ValueNames() {
@@ -1055,7 +1055,7 @@ func convertRowToPoints(measurementName string, row *models.Row) ([]models.Point
 			}
 		}
 
-		p, err := models.NewPoint(measurementName, row.Tags, vals, v[timeIndex].(time.Time))
+		p, err := models.NewPoint(measurementName, models.NewTags(row.Tags), vals, v[timeIndex].(time.Time))
 		if err != nil {
 			// Drop points that can't be stored
 			continue

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -148,7 +148,7 @@ type QueryStatistics struct {
 func (e *QueryExecutor) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "queryExecutor",
-		Tags: tags,
+		Tags: models.NewTags(tags),
 		Values: map[string]interface{}{
 			statQueriesActive:          atomic.LoadInt64(&e.stats.ActiveQueries),
 			statQueriesExecuted:        atomic.LoadInt64(&e.stats.ExecutedQueries),

--- a/models/points.go
+++ b/models/points.go
@@ -139,14 +139,14 @@ func ParsePointsString(buf string) ([]Point, error) {
 }
 
 // ParseKey returns the measurement name and tags from a point.
-func ParseKey(buf string) (string, Tags, error) {
+func ParseKey(buf []byte) (string, Tags, error) {
 	// Ignore the error because scanMeasurement returns "missing fields" which we ignore
 	// when just parsing a key
-	state, i, _ := scanMeasurement([]byte(buf), 0)
+	state, i, _ := scanMeasurement(buf, 0)
 
 	var tags Tags
 	if state == tagKeyState {
-		tags = parseTags([]byte(buf))
+		tags = parseTags(buf)
 		// scanMeasurement returns the location of the comma if there are tags, strip that off
 		return string(buf[:i-1]), tags, nil
 	}
@@ -1225,39 +1225,42 @@ func (p *point) Tags() Tags {
 }
 
 func parseTags(buf []byte) Tags {
-	tags := make(map[string]string, bytes.Count(buf, []byte(",")))
+	if len(buf) == 0 {
+		return nil
+	}
+
+	pos, name := scanTo(buf, 0, ',')
+
+	// it's an empty key, so there are no tags
+	if len(name) == 0 {
+		return nil
+	}
+
+	tags := make(Tags, 0, bytes.Count(buf, []byte(",")))
 	hasEscape := bytes.IndexByte(buf, '\\') != -1
 
-	if len(buf) != 0 {
-		pos, name := scanTo(buf, 0, ',')
+	i := pos + 1
+	var key, value []byte
+	for {
+		if i >= len(buf) {
+			break
+		}
+		i, key = scanTo(buf, i, '=')
+		i, value = scanTagValue(buf, i+1)
 
-		// it's an empyt key, so there are no tags
-		if len(name) == 0 {
-			return tags
+		if len(value) == 0 {
+			continue
 		}
 
-		i := pos + 1
-		var key, value []byte
-		for {
-			if i >= len(buf) {
-				break
-			}
-			i, key = scanTo(buf, i, '=')
-			i, value = scanTagValue(buf, i+1)
-
-			if len(value) == 0 {
-				continue
-			}
-
-			if hasEscape {
-				tags[string(unescapeTag(key))] = string(unescapeTag(value))
-			} else {
-				tags[string(key)] = string(value)
-			}
-
-			i++
+		if hasEscape {
+			tags = append(tags, Tag{Key: unescapeTag(key), Value: unescapeTag(value)})
+		} else {
+			tags = append(tags, Tag{Key: key, Value: value})
 		}
+
+		i++
 	}
+
 	return tags
 }
 
@@ -1276,7 +1279,8 @@ func (p *point) SetTags(tags Tags) {
 // AddTag adds or replaces a tag value for a point
 func (p *point) AddTag(key, value string) {
 	tags := p.Tags()
-	tags[key] = value
+	tags = append(tags, Tag{Key: []byte(key), Value: []byte(value)})
+	sort.Sort(tags)
 	p.key = MakeKey([]byte(p.Name()), tags)
 }
 
@@ -1386,64 +1390,137 @@ func (p *point) UnixNano() int64 {
 	return p.Time().UnixNano()
 }
 
-// Tags represents a mapping between a Point's tag names and their
-// values.
-type Tags map[string]string
+// Tag represents a single key/value tag pair.
+type Tag struct {
+	Key   []byte
+	Value []byte
+}
+
+// Tags represents a sorted list of tags.
+type Tags []Tag
+
+// NewTags returns a new Tags from a map.
+func NewTags(m map[string]string) Tags {
+	a := make(Tags, 0, len(m))
+	for k, v := range m {
+		a = append(a, Tag{Key: []byte(k), Value: []byte(v)})
+	}
+	sort.Sort(a)
+	return a
+}
+
+func (a Tags) Len() int           { return len(a) }
+func (a Tags) Less(i, j int) bool { return bytes.Compare(a[i].Key, a[j].Key) == -1 }
+func (a Tags) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+// Get returns the value for a key.
+func (a Tags) Get(key []byte) []byte {
+	// OPTIMIZE: Use sort.Search if tagset is large.
+
+	for _, t := range a {
+		if bytes.Equal(t.Key, key) {
+			return t.Value
+		}
+	}
+	return nil
+}
+
+// GetString returns the string value for a string key.
+func (a Tags) GetString(key string) string {
+	return string(a.Get([]byte(key)))
+}
+
+// Set sets the value for a key.
+func (a *Tags) Set(key, value []byte) {
+	for _, t := range *a {
+		if bytes.Equal(t.Key, key) {
+			t.Value = value
+			return
+		}
+	}
+	*a = append(*a, Tag{Key: key, Value: value})
+	sort.Sort(*a)
+}
+
+// SetString sets the string value for a string key.
+func (a *Tags) SetString(key, value string) {
+	a.Set([]byte(key), []byte(value))
+}
+
+// Delete removes a tag by key.
+func (a *Tags) Delete(key []byte) {
+	for i, t := range *a {
+		if bytes.Equal(t.Key, key) {
+			copy((*a)[i:], (*a)[i+1:])
+			(*a)[len(*a)-1] = Tag{}
+			*a = (*a)[:len(*a)-1]
+			return
+		}
+	}
+}
+
+// Map returns a map representation of the tags.
+func (a Tags) Map() map[string]string {
+	m := make(map[string]string, len(a))
+	for _, t := range a {
+		m[string(t.Key)] = string(t.Value)
+	}
+	return m
+}
 
 // Merge merges the tags combining the two. If both define a tag with the
 // same key, the merged value overwrites the old value.
 // A new map is returned.
-func (t Tags) Merge(other map[string]string) Tags {
-	merged := make(map[string]string, len(t)+len(other))
-	for k, v := range t {
-		merged[k] = v
+func (a Tags) Merge(other map[string]string) Tags {
+	merged := make(map[string]string, len(a)+len(other))
+	for _, t := range a {
+		merged[string(t.Key)] = string(t.Value)
 	}
 	for k, v := range other {
 		merged[k] = v
 	}
-	return Tags(merged)
+	return NewTags(merged)
 }
 
 // HashKey hashes all of a tag's keys.
-func (t Tags) HashKey() []byte {
+func (a Tags) HashKey() []byte {
 	// Empty maps marshal to empty bytes.
-	if len(t) == 0 {
+	if len(a) == 0 {
 		return nil
 	}
 
-	escaped := Tags{}
-	for k, v := range t {
-		ek := escapeTag([]byte(k))
-		ev := escapeTag([]byte(v))
+	escaped := make(Tags, 0, len(a))
+	for _, t := range a {
+		ek := escapeTag(t.Key)
+		ev := escapeTag(t.Value)
 
 		if len(ev) > 0 {
-			escaped[string(ek)] = string(ev)
+			escaped = append(escaped, Tag{Key: ek, Value: ev})
 		}
 	}
 
 	// Extract keys and determine final size.
 	sz := len(escaped) + (len(escaped) * 2) // separators
-	keys := make([]string, len(escaped)+1)
-	i := 0
-	for k, v := range escaped {
-		keys[i] = k
-		i++
-		sz += len(k) + len(v)
+	keys := make([][]byte, len(escaped)+1)
+	for i, t := range escaped {
+		keys[i] = t.Key
+		sz += len(t.Key) + len(t.Value)
 	}
-	keys = keys[:i]
-	sort.Strings(keys)
+	keys = keys[:len(escaped)]
+	sort.Sort(byteSlices(keys))
+
 	// Generate marshaled bytes.
 	b := make([]byte, sz)
 	buf := b
 	idx := 0
-	for _, k := range keys {
+	for i, k := range keys {
 		buf[idx] = ','
 		idx++
 		copy(buf[idx:idx+len(k)], k)
 		idx += len(k)
 		buf[idx] = '='
 		idx++
-		v := escaped[k]
+		v := escaped[i].Value
 		copy(buf[idx:idx+len(v)], v)
 		idx += len(v)
 	}
@@ -1594,3 +1671,9 @@ func (p Fields) MarshalBinary() []byte {
 	}
 	return b
 }
+
+type byteSlices [][]byte
+
+func (a byteSlices) Len() int           { return len(a) }
+func (a byteSlices) Less(i, j int) bool { return bytes.Compare(a[i], a[j]) == -1 }
+func (a byteSlices) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -212,14 +212,13 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 
 		statistic := &Statistic{
 			Statistic: models.Statistic{
-				Tags:   make(map[string]string),
 				Values: make(map[string]interface{}),
 			},
 		}
 
 		// Add any supplied tags.
 		for k, v := range tags {
-			statistic.Tags[k] = v
+			statistic.Tags.SetString(k, v)
 		}
 
 		// Every other top-level expvar value is a map.
@@ -242,7 +241,7 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 					if err != nil {
 						return
 					}
-					statistic.Tags[t.Key] = u
+					statistic.Tags.SetString(t.Key, u)
 				})
 			case "values":
 				// string-interface map.
@@ -281,14 +280,13 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 	statistic := &Statistic{
 		Statistic: models.Statistic{
 			Name:   "runtime",
-			Tags:   make(map[string]string),
 			Values: make(map[string]interface{}),
 		},
 	}
 
 	// Add any supplied tags to Go memstats
 	for k, v := range tags {
-		statistic.Tags[k] = v
+		statistic.Tags.SetString(k, v)
 	}
 
 	var rt runtime.MemStats

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -70,7 +70,7 @@ func NewService(c Config) *Service {
 		Logger:   log.New(os.Stderr, "[collectd] ", log.LstdFlags),
 		err:      make(chan error),
 		stats:    &Statistics{},
-		statTags: map[string]string{"bind": c.BindAddress},
+		statTags: models.NewTags(map[string]string{"bind": c.BindAddress}),
 	}
 
 	return &s
@@ -360,8 +360,9 @@ func (s *Service) UnmarshalCollectd(packet *gollectd.Packet) []models.Point {
 		if packet.TypeInstance != "" {
 			tags["type_instance"] = packet.TypeInstance
 		}
-		p, err := models.NewPoint(name, tags, fields, timestamp)
+
 		// Drop invalid points
+		p, err := models.NewPoint(name, models.NewTags(tags), fields, timestamp)
 		if err != nil {
 			s.Logger.Printf("Dropping point %v: %v", name, err)
 			atomic.AddInt64(&s.stats.InvalidDroppedPoints, 1)

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -147,7 +147,7 @@ type Statistics struct {
 func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "cq",
-		Tags: tags,
+		Tags: models.NewTags(tags),
 		Values: map[string]interface{}{
 			statQueryOK:   atomic.LoadInt64(&s.stats.QueryOK),
 			statQueryFail: atomic.LoadInt64(&s.stats.QueryFail),

--- a/services/graphite/config.go
+++ b/services/graphite/config.go
@@ -116,12 +116,12 @@ func (c *Config) WithDefaults() *Config {
 
 // DefaultTags returns the config's tags.
 func (c *Config) DefaultTags() models.Tags {
-	tags := models.Tags{}
+	m := make(map[string]string, len(c.Tags))
 	for _, t := range c.Tags {
 		parts := strings.Split(t, "=")
-		tags[parts[0]] = parts[1]
+		m[parts[0]] = parts[1]
 	}
-	return tags
+	return models.NewTags(m)
 }
 
 // Validate validates the config's templates and tags.

--- a/services/graphite/parser_test.go
+++ b/services/graphite/parser_test.go
@@ -261,7 +261,7 @@ func TestFilterMatchDefault(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("miss.servers.localhost.cpu_load",
-		models.Tags{},
+		models.NewTags(map[string]string{}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -282,7 +282,7 @@ func TestFilterMatchMultipleMeasurement(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("cpu.cpu_load.10",
-		models.Tags{"host": "localhost"},
+		models.NewTags(map[string]string{"host": "localhost"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -306,7 +306,7 @@ func TestFilterMatchMultipleMeasurementSeparator(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("cpu_cpu_load_10",
-		models.Tags{"host": "localhost"},
+		models.NewTags(map[string]string{"host": "localhost"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -327,7 +327,7 @@ func TestFilterMatchSingle(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "localhost"},
+		models.NewTags(map[string]string{"host": "localhost"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -348,7 +348,7 @@ func TestParseNoMatch(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("servers.localhost.memory.VmallocChunk",
-		models.Tags{},
+		models.NewTags(map[string]string{}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -369,7 +369,7 @@ func TestFilterMatchWildcard(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "localhost"},
+		models.NewTags(map[string]string{"host": "localhost"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -392,7 +392,7 @@ func TestFilterMatchExactBeforeWildcard(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "localhost"},
+		models.NewTags(map[string]string{"host": "localhost"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -420,7 +420,7 @@ func TestFilterMatchMostLongestFilter(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "localhost", "resource": "cpu"},
+		models.NewTags(map[string]string{"host": "localhost", "resource": "cpu"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -447,7 +447,7 @@ func TestFilterMatchMultipleWildcards(t *testing.T) {
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "server01"},
+		models.NewTags(map[string]string{"host": "server01"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -462,17 +462,17 @@ func TestFilterMatchMultipleWildcards(t *testing.T) {
 }
 
 func TestParseDefaultTags(t *testing.T) {
-	p, err := graphite.NewParser([]string{"servers.localhost .host.measurement*"}, models.Tags{
+	p, err := graphite.NewParser([]string{"servers.localhost .host.measurement*"}, models.NewTags(map[string]string{
 		"region": "us-east",
 		"zone":   "1c",
 		"host":   "should not set",
-	})
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "localhost", "region": "us-east", "zone": "1c"},
+		models.NewTags(map[string]string{"host": "localhost", "region": "us-east", "zone": "1c"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -487,16 +487,16 @@ func TestParseDefaultTags(t *testing.T) {
 }
 
 func TestParseDefaultTemplateTags(t *testing.T) {
-	p, err := graphite.NewParser([]string{"servers.localhost .host.measurement* zone=1c"}, models.Tags{
+	p, err := graphite.NewParser([]string{"servers.localhost .host.measurement* zone=1c"}, models.NewTags(map[string]string{
 		"region": "us-east",
 		"host":   "should not set",
-	})
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "localhost", "region": "us-east", "zone": "1c"},
+		models.NewTags(map[string]string{"host": "localhost", "region": "us-east", "zone": "1c"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -511,16 +511,16 @@ func TestParseDefaultTemplateTags(t *testing.T) {
 }
 
 func TestParseDefaultTemplateTagsOverridGlobal(t *testing.T) {
-	p, err := graphite.NewParser([]string{"servers.localhost .host.measurement* zone=1c,region=us-east"}, models.Tags{
+	p, err := graphite.NewParser([]string{"servers.localhost .host.measurement* zone=1c,region=us-east"}, models.NewTags(map[string]string{
 		"region": "shot not be set",
 		"host":   "should not set",
-	})
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "localhost", "region": "us-east", "zone": "1c"},
+		models.NewTags(map[string]string{"host": "localhost", "region": "us-east", "zone": "1c"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 
@@ -535,16 +535,16 @@ func TestParseDefaultTemplateTagsOverridGlobal(t *testing.T) {
 }
 
 func TestParseTemplateWhitespace(t *testing.T) {
-	p, err := graphite.NewParser([]string{"servers.localhost        .host.measurement*           zone=1c"}, models.Tags{
+	p, err := graphite.NewParser([]string{"servers.localhost        .host.measurement*           zone=1c"}, models.NewTags(map[string]string{
 		"region": "us-east",
 		"host":   "should not set",
-	})
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error creating parser, got %v", err)
 	}
 
 	exp := models.MustNewPoint("cpu_load",
-		models.Tags{"host": "localhost", "region": "us-east", "zone": "1c"},
+		models.NewTags(map[string]string{"host": "localhost", "region": "us-east", "zone": "1c"}),
 		models.Fields{"value": float64(11)},
 		time.Unix(1435077219, 0))
 

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -106,7 +106,7 @@ func NewService(c Config) (*Service, error) {
 		batchTimeout:    time.Duration(d.BatchTimeout),
 		logger:          log.New(os.Stderr, fmt.Sprintf("[graphite] %s ", d.BindAddress), log.LstdFlags),
 		stats:           &Statistics{},
-		statTags:        map[string]string{"proto": d.Protocol, "bind": d.BindAddress},
+		statTags:        models.NewTags(map[string]string{"proto": d.Protocol, "bind": d.BindAddress}),
 		tcpConnections:  make(map[string]*tcpConnection),
 		done:            make(chan struct{}),
 		diagsKey:        strings.Join([]string{"graphite", d.Protocol, d.BindAddress}, ":"),

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -39,7 +39,7 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 
 			pt, _ := models.NewPoint(
 				"cpu",
-				map[string]string{},
+				models.NewTags(map[string]string{}),
 				map[string]interface{}{"value": 23.456},
 				time.Unix(now.Unix(), 0))
 
@@ -115,7 +115,7 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 
 			pt, _ := models.NewPoint(
 				"cpu",
-				map[string]string{},
+				models.NewTags(map[string]string{}),
 				map[string]interface{}{"value": 23.456},
 				time.Unix(now.Unix(), 0))
 			if database != "graphitedb" {

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -179,7 +179,7 @@ type Statistics struct {
 func (h *Handler) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "httpd",
-		Tags: tags,
+		Tags: models.NewTags(tags),
 		Values: map[string]interface{}{
 			statRequest:                      atomic.LoadInt64(&h.stats.Requests),
 			statCQRequest:                    atomic.LoadInt64(&h.stats.CQRequests),
@@ -737,24 +737,24 @@ func (h *Handler) serveExpvar(w http.ResponseWriter, r *http.Request) {
 	for _, s := range stats {
 		// Very hackily create a unique key.
 		buf := bytes.NewBufferString(s.Name)
-		if path, ok := s.Tags["path"]; ok {
+		if path := s.Tags.Get([]byte("path")); path != nil {
 			fmt.Fprintf(buf, ":%s", path)
-			if id, ok := s.Tags["id"]; ok {
+			if id := s.Tags.Get([]byte("id")); id != nil {
 				fmt.Fprintf(buf, ":%s", id)
 			}
-		} else if bind, ok := s.Tags["bind"]; ok {
-			if proto, ok := s.Tags["proto"]; ok {
+		} else if bind := s.Tags.Get([]byte("bind")); bind != nil {
+			if proto := s.Tags.Get([]byte("proto")); proto != nil {
 				fmt.Fprintf(buf, ":%s", proto)
 			}
 			fmt.Fprintf(buf, ":%s", bind)
-		} else if database, ok := s.Tags["database"]; ok {
+		} else if database := s.Tags.Get([]byte("database")); database != nil {
 			fmt.Fprintf(buf, ":%s", database)
-			if rp, ok := s.Tags["retention_policy"]; ok {
+			if rp := s.Tags.Get([]byte("retention_policy")); rp != nil {
 				fmt.Fprintf(buf, ":%s", rp)
-				if name, ok := s.Tags["name"]; ok {
+				if name := s.Tags.Get([]byte("name")); name != nil {
 					fmt.Fprintf(buf, ":%s", name)
 				}
-				if dest, ok := s.Tags["destination"]; ok {
+				if dest := s.Tags.Get([]byte("destination")); dest != nil {
 					fmt.Fprintf(buf, ":%s", dest)
 				}
 			}

--- a/services/httpd/response_writer.go
+++ b/services/httpd/response_writer.go
@@ -114,7 +114,7 @@ func (w *csvResponseWriter) WriteResponse(resp Response) (n int, err error) {
 		for _, row := range result.Series {
 			w.columns[0] = row.Name
 			if len(row.Tags) > 0 {
-				w.columns[1] = string(models.Tags(row.Tags).HashKey()[1:])
+				w.columns[1] = string(models.NewTags(row.Tags).HashKey()[1:])
 			} else {
 				w.columns[1] = ""
 			}

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -192,7 +192,7 @@ func (s *Service) Addr() net.Addr {
 
 // Statistics returns statistics for periodic monitoring.
 func (s *Service) Statistics(tags map[string]string) []models.Statistic {
-	return s.Handler.Statistics(models.Tags{"bind": s.addr}.Merge(tags))
+	return s.Handler.Statistics(models.NewTags(map[string]string{"bind": s.addr}).Merge(tags).Map())
 }
 
 // serveTCP serves the handler from the TCP listener.

--- a/services/opentsdb/handler.go
+++ b/services/opentsdb/handler.go
@@ -111,7 +111,7 @@ func (h *Handler) servePut(w http.ResponseWriter, r *http.Request) {
 			ts = time.Unix(p.Time/1000, (p.Time%1000)*1000)
 		}
 
-		pt, err := models.NewPoint(p.Metric, p.Tags, map[string]interface{}{"value": p.Value}, ts)
+		pt, err := models.NewPoint(p.Metric, models.NewTags(p.Tags), map[string]interface{}{"value": p.Value}, ts)
 		if err != nil {
 			h.Logger.Printf("Dropping point %v: %v", p.Metric, err)
 			if h.stats != nil {

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -96,7 +96,7 @@ func NewService(c Config) (*Service, error) {
 		Logger:          log.New(os.Stderr, "[opentsdb] ", log.LstdFlags),
 		LogPointErrors:  d.LogPointErrors,
 		stats:           &Statistics{},
-		statTags:        map[string]string{"bind": d.BindAddress},
+		statTags:        models.NewTags(map[string]string{"bind": d.BindAddress}),
 	}
 	return s, nil
 }
@@ -381,7 +381,7 @@ func (s *Service) handleTelnetConn(conn net.Conn) {
 		}
 		fields["value"] = fv
 
-		pt, err := models.NewPoint(measurement, tags, fields, t)
+		pt, err := models.NewPoint(measurement, models.NewTags(tags), fields, t)
 		if err != nil {
 			atomic.AddInt64(&s.stats.TelnetBadFloat, 1)
 			if s.LogPointErrors {

--- a/services/opentsdb/service_test.go
+++ b/services/opentsdb/service_test.go
@@ -39,7 +39,7 @@ func TestService_Telnet(t *testing.T) {
 		} else if !reflect.DeepEqual(points, []models.Point{
 			models.MustNewPoint(
 				"sys.cpu.user",
-				map[string]string{"host": "webserver01", "cpu": "0"},
+				models.NewTags(map[string]string{"host": "webserver01", "cpu": "0"}),
 				map[string]interface{}{"value": 42.5},
 				time.Unix(1356998400, 0),
 			),
@@ -101,7 +101,7 @@ func TestService_HTTP(t *testing.T) {
 		} else if !reflect.DeepEqual(points, []models.Point{
 			models.MustNewPoint(
 				"sys.cpu.nice",
-				map[string]string{"dc": "lga", "host": "web01"},
+				models.NewTags(map[string]string{"dc": "lga", "host": "web01"}),
 				map[string]interface{}{"value": 18.0},
 				time.Unix(1346846400, 0),
 			),

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -130,7 +130,7 @@ type Statistics struct {
 func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 	statistics := []models.Statistic{{
 		Name: "subscriber",
-		Tags: tags,
+		Tags: models.NewTags(tags),
 		Values: map[string]interface{}{
 			statPointsWritten: atomic.LoadInt64(&s.stats.PointsWritten),
 			statWriteFailures: atomic.LoadInt64(&s.stats.WriteFailures),
@@ -415,13 +415,13 @@ func (b *balancewriter) WritePoints(p *coordinator.WritePointsRequest) error {
 
 // Statistics returns statistics for periodic monitoring.
 func (b *balancewriter) Statistics(tags map[string]string) []models.Statistic {
-	tags = models.Tags(tags).Merge(b.tags)
+	tags = models.NewTags(tags).Merge(b.tags).Map()
 
 	statistics := make([]models.Statistic, len(b.stats))
 	for i := range b.stats {
 		statistics[i] = models.Statistic{
 			Name: "subscriber",
-			Tags: models.Tags(tags).Merge(map[string]string{"destination": b.stats[i].dest}),
+			Tags: models.NewTags(tags).Merge(map[string]string{"destination": b.stats[i].dest}),
 			Values: map[string]interface{}{
 				statPointsWritten: atomic.LoadInt64(&b.stats[i].pointsWritten),
 				statWriteFailures: atomic.LoadInt64(&b.stats[i].failures),

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -71,7 +71,7 @@ func NewService(c Config) *Service {
 		batcher:    tsdb.NewPointBatcher(d.BatchSize, d.BatchPending, time.Duration(d.BatchTimeout)),
 		Logger:     log.New(os.Stderr, "[udp] ", log.LstdFlags),
 		stats:      &Statistics{},
-		statTags:   map[string]string{"bind": d.BindAddress},
+		statTags:   models.NewTags(map[string]string{"bind": d.BindAddress}),
 	}
 }
 

--- a/stress/v2/stress_client/commune_test.go
+++ b/stress/v2/stress_client/commune_test.go
@@ -12,8 +12,8 @@ func TestCommunePoint(t *testing.T) {
 	if point.Name() != "write" {
 		t.Errorf("expected: write\ngot: %v", point.Name())
 	}
-	if point.Tags()["tag"] != "tagVal" {
-		t.Errorf("expected: tagVal\ngot: %v", point.Tags()["tag"])
+	if point.Tags().GetString("tag") != "tagVal" {
+		t.Errorf("expected: tagVal\ngot: %v", point.Tags().GetString("tag"))
 	}
 	if int(point.Fields()["fooField"].(float64)) != 5 {
 		t.Errorf("expected: 5\ngot: %v\n", point.Fields()["fooField"])
@@ -24,8 +24,8 @@ func TestCommunePoint(t *testing.T) {
 	if point.Name() != "write" {
 		t.Errorf("expected: write\ngot: %v", point.Name())
 	}
-	if point.Tags()["tag"] != "tagVal" {
-		t.Errorf("expected: tagVal\ngot: %v", point.Tags()["tag"])
+	if point.Tags().GetString("tag") != "tagVal" {
+		t.Errorf("expected: tagVal\ngot: %v", point.Tags().GetString("tag"))
 	}
 	if int(point.Fields()["fooField"].(float64)) != 5 {
 		t.Errorf("expected: 5\ngot: %v\n", point.Fields()["fooField"])
@@ -40,8 +40,8 @@ func TestSetCommune(t *testing.T) {
 	if pt.Name() != "write" {
 		t.Errorf("expected: write\ngot: %v", pt.Name())
 	}
-	if pt.Tags()["tag"] != "tagVal" {
-		t.Errorf("expected: tagVal\ngot: %v", pt.Tags()["tag"])
+	if pt.Tags().GetString("tag") != "tagVal" {
+		t.Errorf("expected: tagVal\ngot: %v", pt.Tags().GetString("tag"))
 	}
 	if int(pt.Fields()["fooField"].(float64)) != 5 {
 		t.Errorf("expected: 5\ngot: %v\n", pt.Fields()["fooField"])

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -171,7 +171,7 @@ type CacheStatistics struct {
 func (c *Cache) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "tsm1_cache",
-		Tags: tags,
+		Tags: models.NewTags(tags),
 		Values: map[string]interface{}{
 			statCacheMemoryBytes:    atomic.LoadInt64(&c.stats.MemSizeBytes),
 			statCacheDiskBytes:      atomic.LoadInt64(&c.stats.DiskSizeBytes),

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -44,7 +44,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	// Verify index is correct.
 	if m := index.Measurement("cpu"); m == nil {
 		t.Fatal("measurement not found")
-	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, map[string]string{"host": "A"}) {
+	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, models.NewTags(map[string]string{"host": "A"})) {
 		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
 	}
 
@@ -67,7 +67,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	// Verify index is correct.
 	if m := index.Measurement("cpu"); m == nil {
 		t.Fatal("measurement not found")
-	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, map[string]string{"host": "A"}) {
+	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, models.NewTags(map[string]string{"host": "A"})) {
 		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
 	}
 
@@ -92,9 +92,9 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	// Verify index is correct.
 	if m := index.Measurement("cpu"); m == nil {
 		t.Fatal("measurement not found")
-	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, map[string]string{"host": "A"}) {
+	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, models.NewTags(map[string]string{"host": "A"})) {
 		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
-	} else if s := m.SeriesByID(2); s.Key != "cpu,host=B" || !reflect.DeepEqual(s.Tags, map[string]string{"host": "B"}) {
+	} else if s := m.SeriesByID(2); s.Key != "cpu,host=B" || !reflect.DeepEqual(s.Tags, models.NewTags(map[string]string{"host": "B"})) {
 		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
 	}
 }
@@ -222,7 +222,7 @@ func TestEngine_CreateIterator_Cache_Ascending(t *testing.T) {
 
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", map[string]string{"host": "A"}))
+	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
 	if err := e.WritePointsString(
 		`cpu,host=A value=1.1 1000000000`,
 		`cpu,host=A value=1.2 2000000000`,
@@ -275,7 +275,7 @@ func TestEngine_CreateIterator_Cache_Descending(t *testing.T) {
 
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", map[string]string{"host": "A"}))
+	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
 	if err := e.WritePointsString(
 		`cpu,host=A value=1.1 1000000000`,
 		`cpu,host=A value=1.2 2000000000`,
@@ -328,7 +328,7 @@ func TestEngine_CreateIterator_TSM_Ascending(t *testing.T) {
 
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", map[string]string{"host": "A"}))
+	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
 	if err := e.WritePointsString(
 		`cpu,host=A value=1.1 1000000000`,
 		`cpu,host=A value=1.2 2000000000`,
@@ -382,7 +382,7 @@ func TestEngine_CreateIterator_TSM_Descending(t *testing.T) {
 
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", map[string]string{"host": "A"}))
+	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
 	if err := e.WritePointsString(
 		`cpu,host=A value=1.1 1000000000`,
 		`cpu,host=A value=1.2 2000000000`,
@@ -437,7 +437,7 @@ func TestEngine_CreateIterator_Aux(t *testing.T) {
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("F", influxql.Float, false)
-	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", map[string]string{"host": "A"}))
+	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
 	if err := e.WritePointsString(
 		`cpu,host=A value=1.1 1000000000`,
 		`cpu,host=A F=100 1000000000`,
@@ -497,7 +497,7 @@ func TestEngine_CreateIterator_Condition(t *testing.T) {
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("X", influxql.Float, false)
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("Y", influxql.Float, false)
-	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", map[string]string{"host": "A"}))
+	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
 	if err := e.WritePointsString(
 		`cpu,host=A value=1.1 1000000000`,
 		`cpu,host=A X=10 1000000000`,
@@ -663,7 +663,7 @@ func MustInitBenchmarkEngine(pointN int) *Engine {
 	// Initialize metadata.
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", map[string]string{"host": "A"}))
+	e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
 
 	// Generate time ascending points with jitterred time & value.
 	rand := rand.New(rand.NewSource(0))

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -144,7 +144,7 @@ type WALStatistics struct {
 func (l *WAL) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "tsm1_wal",
-		Tags: tags,
+		Tags: models.NewTags(tags),
 		Values: map[string]interface{}{
 			statWALOldBytes:     atomic.LoadInt64(&l.stats.OldBytes),
 			statWALCurrentBytes: atomic.LoadInt64(&l.stats.CurrentBytes),

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/influxql"
+	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/tsdb"
 )
 
@@ -182,7 +183,7 @@ func genTestSeries(mCnt, tCnt, vCnt int) []*TestSeries {
 		for _, ts := range tagSets {
 			series = append(series, &TestSeries{
 				Measurement: m,
-				Series:      tsdb.NewSeries(fmt.Sprintf("%s:%s", m, string(tsdb.MarshalTags(ts))), ts),
+				Series:      tsdb.NewSeries(fmt.Sprintf("%s:%s", m, string(tsdb.MarshalTags(ts))), models.NewTags(ts)),
 			})
 		}
 	}

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -47,7 +47,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 
 	pt := models.MustNewPoint(
 		"cpu",
-		map[string]string{"host": "server"},
+		models.Tags{{Key: []byte("host"), Value: []byte("server")}},
 		map[string]interface{}{"value": 1.0},
 		time.Unix(1, 2),
 	)
@@ -69,7 +69,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 		}
 
 		seriesTags := index.Series(string(pt.Key())).Tags
-		if len(seriesTags) != len(pt.Tags()) || pt.Tags()["host"] != seriesTags["host"] {
+		if len(seriesTags) != len(pt.Tags()) || pt.Tags().GetString("host") != seriesTags.GetString("host") {
 			t.Fatalf("tags weren't properly saved to series index: %v, %v", pt.Tags(), seriesTags)
 		}
 		if !reflect.DeepEqual(index.Measurement("cpu").TagKeys(), []string{"host"}) {
@@ -121,7 +121,7 @@ func TestMaxSeriesLimit(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		pt := models.MustNewPoint(
 			"cpu",
-			map[string]string{"host": fmt.Sprintf("server%d", i)},
+			models.Tags{{Key: []byte("host"), Value: []byte(fmt.Sprintf("server%d", i))}},
 			map[string]interface{}{"value": 1.0},
 			time.Unix(1, 2),
 		)
@@ -136,7 +136,7 @@ func TestMaxSeriesLimit(t *testing.T) {
 	// Writing one more series should exceed the series limit.
 	pt := models.MustNewPoint(
 		"cpu",
-		map[string]string{"host": "server9999"},
+		models.Tags{{Key: []byte("host"), Value: []byte("server9999")}},
 		map[string]interface{}{"value": 1.0},
 		time.Unix(1, 2),
 	)
@@ -169,7 +169,7 @@ func TestWriteTimeTag(t *testing.T) {
 
 	pt := models.MustNewPoint(
 		"cpu",
-		map[string]string{},
+		models.NewTags(map[string]string{}),
 		map[string]interface{}{"time": 1.0},
 		time.Unix(1, 2),
 	)
@@ -189,7 +189,7 @@ func TestWriteTimeTag(t *testing.T) {
 
 	pt = models.MustNewPoint(
 		"cpu",
-		map[string]string{},
+		models.NewTags(map[string]string{}),
 		map[string]interface{}{"value": 1.0, "time": 1.0},
 		time.Unix(1, 2),
 	)
@@ -230,7 +230,7 @@ func TestWriteTimeField(t *testing.T) {
 
 	pt := models.MustNewPoint(
 		"cpu",
-		map[string]string{"time": "now"},
+		models.NewTags(map[string]string{"time": "now"}),
 		map[string]interface{}{"value": 1.0},
 		time.Unix(1, 2),
 	)
@@ -270,7 +270,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 
 	pt := models.MustNewPoint(
 		"cpu",
-		map[string]string{"host": "server"},
+		models.NewTags(map[string]string{"host": "server"}),
 		map[string]interface{}{"value": 1.0},
 		time.Unix(1, 2),
 	)
@@ -282,7 +282,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 
 	pt = models.MustNewPoint(
 		"cpu",
-		map[string]string{"host": "server"},
+		models.NewTags(map[string]string{"host": "server"}),
 		map[string]interface{}{"value": 1.0, "value2": 2.0},
 		time.Unix(1, 2),
 	)
@@ -296,7 +296,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 		t.Fatalf("series wasn't in index")
 	}
 	seriesTags := index.Series(string(pt.Key())).Tags
-	if len(seriesTags) != len(pt.Tags()) || pt.Tags()["host"] != seriesTags["host"] {
+	if len(seriesTags) != len(pt.Tags()) || pt.Tags().GetString("host") != seriesTags.GetString("host") {
 		t.Fatalf("tags weren't properly saved to series index: %v, %v", pt.Tags(), seriesTags)
 	}
 	if !reflect.DeepEqual(index.Measurement("cpu").TagKeys(), []string{"host"}) {
@@ -328,7 +328,7 @@ func TestShard_Close_RemoveIndex(t *testing.T) {
 
 	pt := models.MustNewPoint(
 		"cpu",
-		map[string]string{"host": "server"},
+		models.NewTags(map[string]string{"host": "server"}),
 		map[string]interface{}{"value": 1.0},
 		time.Unix(1, 2),
 	)
@@ -521,7 +521,7 @@ func TestShard_Disabled_WriteQuery(t *testing.T) {
 
 	pt := models.MustNewPoint(
 		"cpu",
-		map[string]string{"host": "server"},
+		models.NewTags(map[string]string{"host": "server"}),
 		map[string]interface{}{"value": 1.0},
 		time.Unix(1, 2),
 	)

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -929,13 +929,13 @@ func (s *Store) TagValues(database string, cond influxql.Expr) ([]TagValues, err
 		// Loop over all keys for each series.
 		m := make(map[KeyValue]struct{}, len(ss))
 		for _, series := range ss {
-			for key, value := range series.Tags {
+			for _, t := range series.Tags {
 				if !ok {
 					// nop
-				} else if _, exists := keySet[key]; !exists {
+				} else if _, exists := keySet[string(t.Key)]; !exists {
 					continue
 				}
-				m[KeyValue{key, value}] = struct{}{}
+				m[KeyValue{string(t.Key), string(t.Value)}] = struct{}{}
 			}
 		}
 


### PR DESCRIPTION
## Overview

This commit changes the index to point to index data in the shards instead of keeping it in-memory on the heap.

_NOTE: This pull request is still missing dereferencing from the mmap when a shard is closed._

/cc @pauldix @jwilder 

## TODO
- [x] Dereference mmap on close
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

