### PR TITLE
Reduce allocations in models.(*Point)

### DIFF
--- a/models/flat_tags.go
+++ b/models/flat_tags.go
@@ -1,0 +1,71 @@
+package models
+
+import (
+	"bytes"
+	"sync"
+)
+
+// flatTagsPool is used to encourage reuse of flatTags instances.
+var flatTagsPool = &sync.Pool{
+	New: func() interface{} {
+		return &flatTags{Data: []flatTag{}}
+	},
+}
+
+// flatTagsGetFromPool gets a ready-to-use flatTags instance from the pool.
+func flatTagsGetFromPool() *flatTags {
+	return flatTagsPool.Get().(*flatTags)
+}
+
+// flatTagsPutIntoPool resets a flatTags instance and puts it into its pool.
+func flatTagsPutIntoPool(x *flatTags) {
+	x.Data = x.Data[:0]
+	flatTagsPool.Put(x)
+}
+
+// flatTag holds a basic pair of byte slices.
+type flatTag struct {
+	Key, Val []byte
+}
+
+// flatTags holds a slice of flatTag instances. It is a lower-overhead
+// alternative to map[string]string that is used elsewhere in this package.
+type flatTags struct {
+	Data []flatTag
+}
+
+// Len helps implement sort.Interface.
+func (a *flatTags) Len() int { return len(a.Data) }
+
+// Swap helps implement sort.Interface.
+func (a *flatTags) Swap(i, j int) { a.Data[i], a.Data[j] = a.Data[j], a.Data[i] }
+
+// Less helps implement sort.Interface.
+func (a *flatTags) Less(i, j int) bool {
+	return bytes.Compare(a.Data[i].Key, a.Data[j].Key) < 0
+}
+
+// Get accesses the i'th element.
+func (a *flatTags) Get(i int) ([]byte, []byte) {
+	x := a.Data[i]
+	return x.Key, x.Val
+}
+
+// InsertionSort is an in-place zero-overhead sort. It should be used instead
+// of sort.Sort, to avoid heap allocations. It is less efficient for larger
+// sets of items.
+func (a *flatTags) InsertionSort() {
+	for i := 1; i < len(a.Data); i++ {
+		for j := i; j > 0 && a.Less(j, j-1); j-- {
+			a.Swap(j, j-1)
+		}
+	}
+}
+
+// Append appends a new key, value pair to this flatTags instance.
+func (a *flatTags) Append(k, v []byte) {
+	a.Data = append(a.Data, flatTag{
+		Key: k,
+		Val: v,
+	})
+}

--- a/models/flat_tags.go
+++ b/models/flat_tags.go
@@ -20,6 +20,7 @@ func flatTagsGetFromPool() *flatTags {
 // flatTagsPutIntoPool resets a flatTags instance and puts it into its pool.
 func flatTagsPutIntoPool(x *flatTags) {
 	x.Data = x.Data[:0]
+	x.Sorted = true
 	flatTagsPool.Put(x)
 }
 
@@ -31,6 +32,7 @@ type flatTag struct {
 // flatTags holds a slice of flatTag instances. It is a lower-overhead
 // alternative to map[string]string that is used elsewhere in this package.
 type flatTags struct {
+	Sorted bool
 	Data []flatTag
 }
 
@@ -51,6 +53,12 @@ func (a *flatTags) Get(i int) ([]byte, []byte) {
 	return x.Key, x.Val
 }
 
+// IsSorted is a simple predicate. Use it to skip unnecessary calls to
+// InsertionSort.
+func (a *flatTags) IsSorted() bool {
+	return a.Sorted
+}
+
 // InsertionSort is an in-place zero-overhead sort. It should be used instead
 // of sort.Sort, to avoid heap allocations. It is less efficient for larger
 // sets of items.
@@ -60,6 +68,7 @@ func (a *flatTags) InsertionSort() {
 			a.Swap(j, j-1)
 		}
 	}
+	a.Sorted = true
 }
 
 // Append appends a new key, value pair to this flatTags instance.
@@ -68,4 +77,9 @@ func (a *flatTags) Append(k, v []byte) {
 		Key: k,
 		Val: v,
 	})
+	if a.Sorted && len(a.Data) >= 2 {
+		i := len(a.Data) - 2
+		j := len(a.Data) - 1
+		a.Sorted = a.Less(i, j)
+	}
 }

--- a/models/flat_tags.go
+++ b/models/flat_tags.go
@@ -33,7 +33,7 @@ type flatTag struct {
 // alternative to map[string]string that is used elsewhere in this package.
 type flatTags struct {
 	Sorted bool
-	Data []flatTag
+	Data   []flatTag
 }
 
 // Len helps implement sort.Interface.

--- a/models/flat_tags_test.go
+++ b/models/flat_tags_test.go
@@ -7,17 +7,24 @@ import (
 )
 
 func TestFlatTagsInsertionSort(t *testing.T) {
-	f := func(fts flatTags) bool {
+	f := func(generated []flatTag) bool {
 		// set up the expected key data:
 		gold := []string{}
-		for i := 0; i < fts.Len(); i++ {
-			k, _ := fts.Get(i)
-			gold = append(gold, string(k))
+		for _, ft := range generated {
+			gold = append(gold, string(ft.Key))
 		}
 		sort.Strings(gold)
 
+		// set up the container:
+		fts := &flatTags{}
+		for _, ft := range generated {
+			fts.Append(ft.Key, ft.Val)
+		}
+
 		// perform the work:
-		fts.InsertionSort()
+		if !fts.IsSorted() {
+			fts.InsertionSort()
+		}
 
 		// set up the got key data:
 		got := []string{}

--- a/models/flat_tags_test.go
+++ b/models/flat_tags_test.go
@@ -1,0 +1,47 @@
+package models
+
+import (
+	"sort"
+	"testing"
+	"testing/quick"
+)
+
+func TestFlatTagsInsertionSort(t *testing.T) {
+	f := func(fts flatTags) bool {
+		// set up the expected key data:
+		gold := []string{}
+		for i := 0; i < fts.Len(); i++ {
+			k, _ := fts.Get(i)
+			gold = append(gold, string(k))
+		}
+		sort.Strings(gold)
+
+		// perform the work:
+		fts.InsertionSort()
+
+		// set up the got key data:
+		got := []string{}
+		for i := 0; i < fts.Len(); i++ {
+			k, _ := fts.Get(i)
+			got = append(got, string(k))
+		}
+
+		// check that what we want matches what we got:
+		if len(gold) != len(got) {
+			return false
+		}
+		for i := range gold {
+			if gold[i] != got[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	cfg := quick.Config{
+		MaxCount: 1000,
+	}
+	if err := quick.Check(f, &cfg); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/models/points.go
+++ b/models/points.go
@@ -1448,7 +1448,7 @@ func (t Tags) HashKey() []byte {
 	b := make([]byte, sz)
 	buf := b
 	idx := 0
-	for i := 0; i < escaped.Len() ;i++ {
+	for i := 0; i < escaped.Len(); i++ {
 		k, v := escaped.Get(i)
 		buf[idx] = ','
 		idx++

--- a/models/points.go
+++ b/models/points.go
@@ -1029,6 +1029,11 @@ func scanFieldValue(buf []byte, i int) (int, []byte) {
 
 func escapeMeasurement(in []byte) []byte {
 	for _, x := range measurementEscapeCodes {
+		// This check avoids the "always make a copy" behavior of
+		// `bytes.Replace`:
+		if bytes.Count(in, x.unescaped) == 0 {
+			continue
+		}
 		in = bytes.Replace(in, x.unescaped, x.escaped, -1)
 	}
 	return in
@@ -1036,6 +1041,11 @@ func escapeMeasurement(in []byte) []byte {
 
 func unescapeMeasurement(in []byte) []byte {
 	for _, x := range measurementEscapeCodes {
+		// This check avoids the "always make a copy" behavior of
+		// `bytes.Replace`:
+		if bytes.Count(in, x.escaped) == 0 {
+			continue
+		}
 		in = bytes.Replace(in, x.escaped, x.unescaped, -1)
 	}
 	return in
@@ -1059,6 +1069,11 @@ func unescapeTag(in []byte) []byte {
 	}
 
 	for _, x := range tagEscapeCodes {
+		// This check avoids the "always make a copy" behavior of
+		// `bytes.Replace`:
+		if bytes.Count(in, x.escaped) == 0 {
+			continue
+		}
 		in = bytes.Replace(in, x.escaped, x.unescaped, -1)
 	}
 	return in

--- a/models/points.go
+++ b/models/points.go
@@ -16,15 +16,19 @@ import (
 )
 
 var (
-	measurementEscapeCodes = map[byte][]byte{
-		',': []byte(`\,`),
-		' ': []byte(`\ `),
+	measurementEscapeCodes = []struct {
+		unescaped, escaped []byte
+	}{
+		{[]byte(`,`), []byte(`\,`)},
+		{[]byte(` `), []byte(`\ `)},
 	}
 
-	tagEscapeCodes = map[byte][]byte{
-		',': []byte(`\,`),
-		' ': []byte(`\ `),
-		'=': []byte(`\=`),
+	tagEscapeCodes = []struct {
+		unescaped, escaped []byte
+	}{
+		{[]byte(`,`), []byte(`\,`)},
+		{[]byte(` `), []byte(`\ `)},
+		{[]byte(`=`), []byte(`\=`)},
 	}
 
 	ErrPointMustHaveAField  = errors.New("point without fields is unsupported")
@@ -1022,24 +1026,22 @@ func scanFieldValue(buf []byte, i int) (int, []byte) {
 }
 
 func escapeMeasurement(in []byte) []byte {
-	for b, esc := range measurementEscapeCodes {
-		in = bytes.Replace(in, []byte{b}, esc, -1)
+	for _, x := range measurementEscapeCodes {
+		in = bytes.Replace(in, x.unescaped, x.escaped, -1)
 	}
 	return in
 }
 
 func unescapeMeasurement(in []byte) []byte {
-	for b, esc := range measurementEscapeCodes {
-		in = bytes.Replace(in, esc, []byte{b}, -1)
+	for _, x := range measurementEscapeCodes {
+		in = bytes.Replace(in, x.escaped, x.unescaped, -1)
 	}
 	return in
 }
 
 func escapeTag(in []byte) []byte {
-	for b, esc := range tagEscapeCodes {
-		if bytes.IndexByte(in, b) != -1 {
-			in = bytes.Replace(in, []byte{b}, esc, -1)
-		}
+	for _, x := range tagEscapeCodes {
+		in = bytes.Replace(in, x.unescaped, x.escaped, -1)
 	}
 	return in
 }
@@ -1049,10 +1051,8 @@ func unescapeTag(in []byte) []byte {
 		return in
 	}
 
-	for b, esc := range tagEscapeCodes {
-		if bytes.IndexByte(in, b) != -1 {
-			in = bytes.Replace(in, esc, []byte{b}, -1)
-		}
+	for _, x := range tagEscapeCodes {
+		in = bytes.Replace(in, x.escaped, x.unescaped, -1)
 	}
 	return in
 }

--- a/models/points.go
+++ b/models/points.go
@@ -253,7 +253,9 @@ func parsePoint(buf []byte, defaultTime time.Time, precision string) (Point, err
 		pt.time = defaultTime
 		pt.SetPrecision(precision)
 	} else {
-		ts, err := strconv.ParseInt(string(ts), 10, 64)
+		// Use unsafeBytesToString here because a plain `string`
+		// conversion escapes to the heap (as of Go 1.6):
+		ts, err := strconv.ParseInt(unsafeBytesToString(ts), 10, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -36,77 +36,77 @@ func BenchmarkMarshal(b *testing.B) {
 }
 
 func BenchmarkParsePointNoTags(b *testing.B) {
-	line := `cpu value=1i 1000000000`
+	line := []byte(`cpu value=1i 1000000000`)
 	for i := 0; i < b.N; i++ {
-		models.ParsePoints([]byte(line))
+		models.ParsePoints(line)
 		b.SetBytes(int64(len(line)))
 	}
 }
 
 func BenchmarkParsePointWithPrecisionN(b *testing.B) {
-	line := `cpu value=1i 1000000000`
+	line := []byte(`cpu value=1i 1000000000`)
 	defaultTime := time.Now().UTC()
 	for i := 0; i < b.N; i++ {
-		models.ParsePointsWithPrecision([]byte(line), defaultTime, "n")
+		models.ParsePointsWithPrecision(line, defaultTime, "n")
 		b.SetBytes(int64(len(line)))
 	}
 }
 
 func BenchmarkParsePointWithPrecisionU(b *testing.B) {
-	line := `cpu value=1i 1000000000`
+	line := []byte(`cpu value=1i 1000000000`)
 	defaultTime := time.Now().UTC()
 	for i := 0; i < b.N; i++ {
-		models.ParsePointsWithPrecision([]byte(line), defaultTime, "u")
+		models.ParsePointsWithPrecision(line, defaultTime, "u")
 		b.SetBytes(int64(len(line)))
 	}
 }
 
 func BenchmarkParsePointsTagsSorted2(b *testing.B) {
-	line := `cpu,host=serverA,region=us-west value=1i 1000000000`
+	line := []byte(`cpu,host=serverA,region=us-west value=1i 1000000000`)
 	for i := 0; i < b.N; i++ {
-		models.ParsePoints([]byte(line))
+		models.ParsePoints(line)
 		b.SetBytes(int64(len(line)))
 	}
 }
 
 func BenchmarkParsePointsTagsSorted5(b *testing.B) {
-	line := `cpu,env=prod,host=serverA,region=us-west,target=servers,zone=1c value=1i 1000000000`
+	line := []byte(`cpu,env=prod,host=serverA,region=us-west,target=servers,zone=1c value=1i 1000000000`)
 	for i := 0; i < b.N; i++ {
-		models.ParsePoints([]byte(line))
+		models.ParsePoints(line)
 		b.SetBytes(int64(len(line)))
 	}
 }
 
 func BenchmarkParsePointsTagsSorted10(b *testing.B) {
-	line := `cpu,env=prod,host=serverA,region=us-west,tag1=value1,tag2=value2,tag3=value3,tag4=value4,tag5=value5,target=servers,zone=1c value=1i 1000000000`
+	line := []byte(`cpu,env=prod,host=serverA,region=us-west,tag1=value1,tag2=value2,tag3=value3,tag4=value4,tag5=value5,target=servers,zone=1c value=1i 1000000000`)
 	for i := 0; i < b.N; i++ {
-		models.ParsePoints([]byte(line))
+		models.ParsePoints(line)
 		b.SetBytes(int64(len(line)))
 	}
 }
 
 func BenchmarkParsePointsTagsUnSorted2(b *testing.B) {
-	line := `cpu,region=us-west,host=serverA value=1i 1000000000`
+	line := []byte(`cpu,region=us-west,host=serverA value=1i 1000000000`)
 	for i := 0; i < b.N; i++ {
-		pt, _ := models.ParsePoints([]byte(line))
+		pt, _ := models.ParsePoints(line)
 		b.SetBytes(int64(len(line)))
 		pt[0].Key()
 	}
 }
 
 func BenchmarkParsePointsTagsUnSorted5(b *testing.B) {
-	line := `cpu,region=us-west,host=serverA,env=prod,target=servers,zone=1c value=1i 1000000000`
+	line := []byte(`cpu,region=us-west,host=serverA,env=prod,target=servers,zone=1c value=1i 1000000000`)
 	for i := 0; i < b.N; i++ {
-		pt, _ := models.ParsePoints([]byte(line))
+		pt, _ := models.ParsePoints(line)
 		b.SetBytes(int64(len(line)))
 		pt[0].Key()
 	}
 }
 
 func BenchmarkParsePointsTagsUnSorted10(b *testing.B) {
-	line := `cpu,region=us-west,host=serverA,env=prod,target=servers,zone=1c,tag1=value1,tag2=value2,tag3=value3,tag4=value4,tag5=value5 value=1i 1000000000`
+	line := []byte(`cpu,region=us-west,host=serverA,env=prod,target=servers,zone=1c,tag1=value1,tag2=value2,tag3=value3,tag4=value4,tag5=value5 value=1i 1000000000`)
 	for i := 0; i < b.N; i++ {
-		pt, _ := models.ParsePoints([]byte(line))
+		pt, _ := models.ParsePoints(line)
 		b.SetBytes(int64(len(line)))
 		pt[0].Key()
 	}

--- a/models/simple_unsafe.go
+++ b/models/simple_unsafe.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// unsafeBytesToString converts a []byte to a string without a heap allocation.
+//
+// It is unsafe, and is intended to prepare input to short-lived functions
+// that require strings.
+func unsafeBytesToString(in []byte) string {
+	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
+	dst := reflect.StringHeader{
+		Data: src.Data,
+		Len:  src.Len,
+	}
+	s := *(*string)(unsafe.Pointer(&dst))
+	return s
+}

--- a/models/simple_unsafe.go
+++ b/models/simple_unsafe.go
@@ -18,3 +18,18 @@ func unsafeBytesToString(in []byte) string {
 	s := *(*string)(unsafe.Pointer(&dst))
 	return s
 }
+
+// unsafeStringToBytes converts a string to a []byte without a heap allocation.
+//
+// It is unsafe, and is intended to prepare input to short-lived functions
+// that require byte slices.
+func unsafeStringToBytes(in string) []byte {
+	src := *(*reflect.StringHeader)(unsafe.Pointer(&in))
+	dst := reflect.SliceHeader{
+		Data: src.Data,
+		Len:  src.Len,
+		Cap:  src.Len,
+	}
+	s := *(*[]byte)(unsafe.Pointer(&dst))
+	return s
+}

--- a/models/simple_unsafe_test.go
+++ b/models/simple_unsafe_test.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+	"testing/quick"
+)
+
+const letters = "abcdefghijklmnopqrstuvwxyz"
+
+func TestUnsafeBytesToString_16(t *testing.T) {
+	f := func(buf []byte) bool {
+		gotString := unsafeBytesToString(buf)
+		gotBuf := []byte(gotString)
+
+		return bytes.Equal(buf, gotBuf)
+	}
+
+	cfg := quick.Config{
+		MaxCount: 1000,
+	}
+	if err := quick.Check(f, &cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func BenchmarkUnsafeBytesToString_16(b *testing.B) {
+	buf := make([]byte, 16)
+	for i := range buf {
+		buf[i] = letters[rand.Intn(len(letters))]
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		unsafeBytesToString(buf)
+	}
+}

--- a/models/simple_unsafe_test.go
+++ b/models/simple_unsafe_test.go
@@ -9,7 +9,7 @@ import (
 
 const letters = "abcdefghijklmnopqrstuvwxyz"
 
-func TestUnsafeBytesToString_16(t *testing.T) {
+func TestUnsafeBytesToString(t *testing.T) {
 	f := func(buf []byte) bool {
 		gotString := unsafeBytesToString(buf)
 		gotBuf := []byte(gotString)
@@ -34,5 +34,34 @@ func BenchmarkUnsafeBytesToString_16(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		unsafeBytesToString(buf)
+	}
+}
+
+func TestUnsafeStringToBytes(t *testing.T) {
+	f := func(s string) bool {
+		gotBuf := unsafeStringToBytes(s)
+		gotString := string(gotBuf)
+
+		return s == gotString
+	}
+
+	cfg := quick.Config{
+		MaxCount: 1000,
+	}
+	if err := quick.Check(f, &cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func BenchmarkUnsafeStringToBytes_16(b *testing.B) {
+	buf := make([]byte, 16)
+	for i := range buf {
+		buf[i] = letters[rand.Intn(len(letters))]
+	}
+	s := string(buf)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		unsafeStringToBytes(s)
 	}
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [*] Rebased/mergable
- [*] Tests pass
- [*] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Summary

This PR reduces GC pressure by reducing allocations during various `models.(*Point)` operations.
It does not change any public function signatures.

###### Changes

+ Use `flatTags` instead of `map[string]string` as a bookeeping data structure during `models.(*Point).HashKey`. This includes tests and a global pool.
+ Implement `[]byte -> string` and `string -> []byte` casts, and use them (carefully) in cases where the Go compiler fails to keep the value on the stack.
+ Use a slice of struct to store escape codes, not a map (due to iteration speed differences).

###### `models` Benchmarks before and after

```
After:
BenchmarkMarshal-4                       2000000              1520 ns/op              64 B/op          1 allocs/op
BenchmarkParsePointNoTags-4              5000000               686 ns/op          33.50 MB/s         160 B/op          2 allocs/op*
BenchmarkParsePointWithPrecisionN-4      5000000               665 ns/op          34.54 MB/s         160 B/op          2 allocs/op*
BenchmarkParsePointWithPrecisionU-4      5000000               681 ns/op          33.77 MB/s         160 B/op          2 allocs/op*
BenchmarkParsePointsTagsSorted2-4        3000000              1023 ns/op          49.84 MB/s         160 B/op          2 allocs/op*
BenchmarkParsePointsTagsSorted5-4        2000000              1311 ns/op          63.28 MB/s         160 B/op          2 allocs/op*
BenchmarkParsePointsTagsSorted10-4       1000000              2019 ns/op          70.82 MB/s         160 B/op          2 allocs/op*
BenchmarkParsePointsTagsUnSorted2-4      2000000              1220 ns/op          41.77 MB/s         192 B/op          3 allocs/op*
BenchmarkParsePointsTagsUnSorted5-4      2000000              1862 ns/op          44.56 MB/s         224 B/op          3 allocs/op*
BenchmarkParsePointsTagsUnSorted10-4     1000000              3304 ns/op          43.28 MB/s         288 B/op          3 allocs/op*
BenchmarkParseKey-4                      1000000              2829 ns/op            1030 B/op         24 allocs/op

Before:
BenchmarkMarshal-4                       1000000              3289 ns/op             560 B/op         13 allocs/op
BenchmarkParsePointNoTags-4              3000000               791 ns/op          29.07 MB/s         208 B/op          4 allocs/op
BenchmarkParsePointWithPrecisionN-4      5000000               779 ns/op          29.50 MB/s         208 B/op          4 allocs/op
BenchmarkParsePointWithPrecisionU-4      5000000               775 ns/op          29.66 MB/s         208 B/op          4 allocs/op
BenchmarkParsePointsTagsSorted2-4        3000000              1087 ns/op          46.91 MB/s         240 B/op          4 allocs/op
BenchmarkParsePointsTagsSorted5-4        2000000              1446 ns/op          57.39 MB/s         272 B/op          4 allocs/op
BenchmarkParsePointsTagsSorted10-4       1000000              2284 ns/op          62.59 MB/s         320 B/op          4 allocs/op
BenchmarkParsePointsTagsUnSorted2-4      2000000              1393 ns/op          36.59 MB/s         272 B/op          5 allocs/op
BenchmarkParsePointsTagsUnSorted5-4      1000000              2143 ns/op          38.72 MB/s         336 B/op          5 allocs/op
BenchmarkParsePointsTagsUnSorted10-4     1000000              3669 ns/op          38.97 MB/s         448 B/op          5 allocs/op
BenchmarkParseKey-4                      1000000              2818 ns/op            1030 B/op         24 allocs/op

[*] The benchmarks were updated to remove one spurious heap allocation per iteration.
```
