### PR TITLE
Remove redundant code the from response formatter and fix CloseNotify

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -440,7 +440,12 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 	resp := Response{Results: make([]*influxql.Result, 0)}
 
 	// Status header is OK once this point is reached.
+	// Attempt to flush the header immediately so the client gets the header information
+	// and knows the query was accepted.
 	h.writeHeader(rw, http.StatusOK)
+	if w, ok := w.(http.Flusher); ok {
+		w.Flush()
+	}
 
 	// pull all results from the channel
 	rows := 0
@@ -940,6 +945,9 @@ func (w gzipResponseWriter) Write(b []byte) (int, error) {
 
 func (w gzipResponseWriter) Flush() {
 	w.Writer.(*gzip.Writer).Flush()
+	if w, ok := w.ResponseWriter.(http.Flusher); ok {
+		w.Flush()
+	}
 }
 
 func (w gzipResponseWriter) CloseNotify() <-chan bool {

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -465,7 +465,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 			n, _ := rw.WriteResponse(Response{
 				Results: []*influxql.Result{r},
 			})
-			atomic.AddInt64(&h.stats.QueryRequestBytesTransmitted, int64(n+1))
+			atomic.AddInt64(&h.stats.QueryRequestBytesTransmitted, int64(n))
 			w.(http.Flusher).Flush()
 			continue
 		}

--- a/services/httpd/response_writer.go
+++ b/services/httpd/response_writer.go
@@ -18,13 +18,15 @@ type ResponseWriter interface {
 // in the request that wraps the ResponseWriter.
 func NewResponseWriter(w http.ResponseWriter, r *http.Request) ResponseWriter {
 	pretty := r.URL.Query().Get("pretty") == "true"
+	rw := &responseWriter{ResponseWriter: w}
 	switch r.Header.Get("Accept") {
 	case "application/json":
 		fallthrough
 	default:
 		w.Header().Add("Content-Type", "application/json")
-		return &jsonResponseWriter{Pretty: pretty, ResponseWriter: w}
+		rw.formatter = &jsonFormatter{Pretty: pretty, Writer: w}
 	}
+	return rw
 }
 
 // WriteError is a convenience function for writing an error response to the ResponseWriter.
@@ -32,12 +34,41 @@ func WriteError(w ResponseWriter, err error) (int, error) {
 	return w.WriteResponse(Response{Err: err})
 }
 
-type jsonResponseWriter struct {
-	Pretty bool
+// responseWriter is an implementation of ResponseWriter.
+type responseWriter struct {
+	formatter interface {
+		WriteResponse(resp Response) (int, error)
+	}
 	http.ResponseWriter
 }
 
-func (w *jsonResponseWriter) WriteResponse(resp Response) (n int, err error) {
+// WriteResponse writes the response using the formatter.
+func (w *responseWriter) WriteResponse(resp Response) (int, error) {
+	return w.formatter.WriteResponse(resp)
+}
+
+// Flush flushes the ResponseWriter if it has a Flush() method.
+func (w *responseWriter) Flush() {
+	if w, ok := w.ResponseWriter.(http.Flusher); ok {
+		w.Flush()
+	}
+}
+
+// CloseNotify calls CloseNotify on the underlying http.ResponseWriter if it
+// exists. Otherwise, it returns a nil channel that will never notify.
+func (w *responseWriter) CloseNotify() <-chan bool {
+	if notifier, ok := w.ResponseWriter.(http.CloseNotifier); ok {
+		return notifier.CloseNotify()
+	}
+	return nil
+}
+
+type jsonFormatter struct {
+	io.Writer
+	Pretty bool
+}
+
+func (w *jsonFormatter) WriteResponse(resp Response) (n int, err error) {
 	var b []byte
 	if w.Pretty {
 		b, err = json.MarshalIndent(resp, "", "    ")
@@ -54,11 +85,4 @@ func (w *jsonResponseWriter) WriteResponse(resp Response) (n int, err error) {
 	w.Write([]byte("\n"))
 	n++
 	return n, err
-}
-
-// Flush flushes the ResponseWriter if it has a Flush() method.
-func (w *jsonResponseWriter) Flush() {
-	if w, ok := w.ResponseWriter.(http.Flusher); ok {
-		w.Flush()
-	}
 }


### PR DESCRIPTION
The query killing functionality depends on the ResponseWriter exposing a
CloseNotify method. Since we wrap the http.ResponseWriter, the new
struct does not have that method and the HTTP handler would skip past
calling that method.

Instead of duplicating `Flush()` and `CloseNotify()` for every response
formatter, we will unify all of that under a single struct and create
formatters instead.

Also, fixes a bug where the header information from a query would not be
returned until some other data was returned with it because of
buffering and another bug in the gzipResponseWriter that wouldn't flush
the actual underlying ResponseWriter.