### PR TITLE
Allow snapshot compactions during deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [#7382](https://github.com/influxdata/influxdb/issues/7382): Shard stats include wal path tag so disk bytes make more sense.
 - [#7385](https://github.com/influxdata/influxdb/pull/7385): Reduce query planning allocations
 - [#7436](https://github.com/influxdata/influxdb/issues/7436): Remove accidentally added string support for the stddev call.
+- [#7161](https://github.com/influxdata/influxdb/issues/7161): Drop measurement causes cache max memory exceeded error.
 
 ## v1.0.2 [2016-10-05]
 
@@ -55,9 +56,6 @@
 - [#7391](https://github.com/influxdata/influxdb/issues/7391): Fix RLE integer decoding producing negative numbers
 - [#7335](https://github.com/influxdata/influxdb/pull/7335): Avoid stat syscall when planning compactions
 - [#7330](https://github.com/influxdata/influxdb/issues/7330): Subscription data loss under high write load
-- [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.
-- [#7152](https://github.com/influxdata/influxdb/issues/7152): Decrement number of measurements only once when deleting the last series from a measurement.
-- [#7161](https://github.com/influxdata/influxdb/issues/7161): Drop measurement causes cache max memory exceeded error.
 
 ## v1.0.1 [2016-09-26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@
 - [#7391](https://github.com/influxdata/influxdb/issues/7391): Fix RLE integer decoding producing negative numbers
 - [#7335](https://github.com/influxdata/influxdb/pull/7335): Avoid stat syscall when planning compactions
 - [#7330](https://github.com/influxdata/influxdb/issues/7330): Subscription data loss under high write load
+- [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.
+- [#7152](https://github.com/influxdata/influxdb/issues/7152): Decrement number of measurements only once when deleting the last series from a measurement.
+- [#7161](https://github.com/influxdata/influxdb/issues/7161): Drop measurement causes cache max memory exceeded error.
 
 ## v1.0.1 [2016-09-26]
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -526,7 +526,7 @@ func (c *Compactor) DisableSnapshots() {
 	c.mu.Unlock()
 }
 
-func (c *Compactor) EnabledSnapshots() {
+func (c *Compactor) EnableSnapshots() {
 	c.mu.Lock()
 	c.snapshotsEnabled = true
 	c.mu.Unlock()
@@ -538,7 +538,7 @@ func (c *Compactor) DisableCompactions() {
 	c.mu.Unlock()
 }
 
-func (c *Compactor) EnabledCompactions() {
+func (c *Compactor) EnableCompactions() {
 	c.mu.Lock()
 	c.compactionsEnabled = true
 	c.mu.Unlock()

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -491,41 +491,66 @@ type Compactor struct {
 		NextGeneration() int
 	}
 
-	mu      sync.RWMutex
-	opened  bool
-	closing chan struct{}
-	files   map[string]struct{}
+	mu                 sync.RWMutex
+	snapshotsEnabled   bool
+	compactionsEnabled bool
+
+	files map[string]struct{}
 }
 
 func (c *Compactor) Open() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.opened {
+	if c.snapshotsEnabled || c.compactionsEnabled {
 		return
 	}
 
-	c.closing = make(chan struct{})
-	c.opened = true
+	c.snapshotsEnabled = true
+	c.compactionsEnabled = true
 	c.files = make(map[string]struct{})
 }
 
 func (c *Compactor) Close() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if !c.opened {
+	if !(c.snapshotsEnabled || c.compactionsEnabled) {
 		return
 	}
-	c.opened = false
-	close(c.closing)
+	c.snapshotsEnabled = false
+	c.compactionsEnabled = false
+}
+
+func (c *Compactor) DisableSnapshots() {
+	c.mu.Lock()
+	c.snapshotsEnabled = false
+	c.mu.Unlock()
+}
+
+func (c *Compactor) EnabledSnapshots() {
+	c.mu.Lock()
+	c.snapshotsEnabled = true
+	c.mu.Unlock()
+}
+
+func (c *Compactor) DisableCompactions() {
+	c.mu.Lock()
+	c.compactionsEnabled = false
+	c.mu.Unlock()
+}
+
+func (c *Compactor) EnabledCompactions() {
+	c.mu.Lock()
+	c.compactionsEnabled = true
+	c.mu.Unlock()
 }
 
 // WriteSnapshot will write a Cache snapshot to a new TSM files.
 func (c *Compactor) WriteSnapshot(cache *Cache) ([]string, error) {
 	c.mu.RLock()
-	opened := c.opened
+	enabled := c.snapshotsEnabled
 	c.mu.RUnlock()
 
-	if !opened {
+	if !enabled {
 		return nil, errSnapshotsDisabled
 	}
 
@@ -534,10 +559,10 @@ func (c *Compactor) WriteSnapshot(cache *Cache) ([]string, error) {
 
 	// See if we were closed while writing a snapshot
 	c.mu.RLock()
-	opened = c.opened
+	enabled = c.snapshotsEnabled
 	c.mu.RUnlock()
 
-	if !opened {
+	if !enabled {
 		return nil, errSnapshotsDisabled
 	}
 
@@ -601,10 +626,10 @@ func (c *Compactor) compact(fast bool, tsmFiles []string) ([]string, error) {
 // Compact will write multiple smaller TSM files into 1 or more larger files
 func (c *Compactor) CompactFull(tsmFiles []string) ([]string, error) {
 	c.mu.RLock()
-	opened := c.opened
+	enabled := c.compactionsEnabled
 	c.mu.RUnlock()
 
-	if !opened {
+	if !enabled {
 		return nil, errCompactionsDisabled
 	}
 
@@ -617,10 +642,10 @@ func (c *Compactor) CompactFull(tsmFiles []string) ([]string, error) {
 
 	// See if we were closed while writing a snapshot
 	c.mu.RLock()
-	opened = c.opened
+	enabled = c.compactionsEnabled
 	c.mu.RUnlock()
 
-	if !opened {
+	if !enabled {
 		return nil, errCompactionsDisabled
 	}
 
@@ -630,10 +655,10 @@ func (c *Compactor) CompactFull(tsmFiles []string) ([]string, error) {
 // Compact will write multiple smaller TSM files into 1 or more larger files
 func (c *Compactor) CompactFast(tsmFiles []string) ([]string, error) {
 	c.mu.RLock()
-	opened := c.opened
+	enabled := c.compactionsEnabled
 	c.mu.RUnlock()
 
-	if !opened {
+	if !enabled {
 		return nil, errCompactionsDisabled
 	}
 
@@ -646,10 +671,10 @@ func (c *Compactor) CompactFast(tsmFiles []string) ([]string, error) {
 
 	// See if we were closed while writing a snapshot
 	c.mu.RLock()
-	opened = c.opened
+	enabled = c.compactionsEnabled
 	c.mu.RUnlock()
 
-	if !opened {
+	if !enabled {
 		return nil, errCompactionsDisabled
 	}
 
@@ -717,14 +742,12 @@ func (c *Compactor) write(path string, iter KeyIterator) (err error) {
 
 	for iter.Next() {
 		c.mu.RLock()
-		select {
-		case <-c.closing:
-			c.mu.RUnlock()
-			return errCompactionAborted
-		default:
-		}
+		enabled := c.snapshotsEnabled || c.compactionsEnabled
 		c.mu.RUnlock()
 
+		if !enabled {
+			return errCompactionAborted
+		}
 		// Each call to read returns the next sorted key (or the prior one if there are
 		// more values to write).  The size of values will be less than or equal to our
 		// chunk size (1000)

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -557,7 +557,7 @@ func (c *Compactor) WriteSnapshot(cache *Cache) ([]string, error) {
 	iter := NewCacheKeyIterator(cache, tsdb.DefaultMaxPointsPerBlock)
 	files, err := c.writeNewFiles(c.FileStore.NextGeneration(), 0, iter)
 
-	// See if we were closed while writing a snapshot
+	// See if we were disabled while writing a snapshot
 	c.mu.RLock()
 	enabled = c.snapshotsEnabled
 	c.mu.RUnlock()
@@ -640,7 +640,7 @@ func (c *Compactor) CompactFull(tsmFiles []string) ([]string, error) {
 
 	files, err := c.compact(false, tsmFiles)
 
-	// See if we were closed while writing a snapshot
+	// See if we were disabled while writing a snapshot
 	c.mu.RLock()
 	enabled = c.compactionsEnabled
 	c.mu.RUnlock()
@@ -669,7 +669,7 @@ func (c *Compactor) CompactFast(tsmFiles []string) ([]string, error) {
 
 	files, err := c.compact(true, tsmFiles)
 
-	// See if we were closed while writing a snapshot
+	// See if we were disabled while writing a snapshot
 	c.mu.RLock()
 	enabled = c.compactionsEnabled
 	c.mu.RUnlock()

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -58,13 +58,22 @@ const (
 
 // Engine represents a storage engine with compressed blocks.
 type Engine struct {
-	mu           sync.RWMutex
-	wg           sync.WaitGroup
-	done         chan struct{}
-	levelWorkers int
+	mu sync.RWMutex
 
-	snapDone chan struct{}
-	snapWG   sync.WaitGroup
+	// The following group of fields is used to track the state of level compactions within the
+	// Engine. The WaitGroup is used to monitor the compaction goroutines, the 'done' channel is
+	// used to signal those goroutines to shutdown. Every request to disable level compactions will
+	// call 'Wait' on 'wg', with the first goroutine to arrive (levelWorkers == 0 while holding the
+	// lock) will close the done channel and re-assign 'nil' to the variable. Re-enabling will
+	// decrease 'levelWorkers', and when it decreases to zero, level compactions will be started
+	// back up again.
+
+	wg           sync.WaitGroup // waitgroup for active level compaction goroutines
+	done         chan struct{}  // channel to signal level compactions to stop
+	levelWorkers int            // Number of "workers" that expect compactions to be in a disabled state
+
+	snapDone chan struct{}  // channel to signal snapshot compactions to stop
+	snapWG   sync.WaitGroup // waitgroup for running snapshot compactions
 
 	path         string
 	logger       *log.Logger // Logger to be used for important messages
@@ -155,16 +164,22 @@ func (e *Engine) SetEnabled(enabled bool) {
 func (e *Engine) SetCompactionsEnabled(enabled bool) {
 	if enabled {
 		e.enableSnapshotCompactions()
-		e.enableLevelCompactions(0)
+		e.enableLevelCompactions(false)
 	} else {
 		e.disableSnapshotCompactions()
-		e.disableLevelCompactions(0)
+		e.disableLevelCompactions(false)
 	}
 }
 
-func (e *Engine) enableLevelCompactions(n int) {
+// enableLevelCompactions will request that level compactions start back up again
+//
+// 'wait' signifies that a corresponding call to disableLevelCompactions(true) was made at some
+// point, and the associated task that required disabled compactions is now complete
+func (e *Engine) enableLevelCompactions(wait bool) {
 	e.mu.Lock()
-	e.levelWorkers -= n
+	if wait {
+		e.levelWorkers -= 1
+	}
 	if e.levelWorkers != 0 || e.done != nil {
 		// still waiting on more workers or already enabled
 		e.mu.Unlock()
@@ -185,10 +200,16 @@ func (e *Engine) enableLevelCompactions(n int) {
 	go func() { defer e.wg.Done(); e.compactTSMLevel(false, 3, quit) }()
 }
 
-func (e *Engine) disableLevelCompactions(n int) {
+// disableLevelCompactions will stop level compactions before returning
+//
+// If 'wait' is set to true, then a corresponding call to enableLevelCompactions(true) will be
+// required before level compactions will start back up again
+func (e *Engine) disableLevelCompactions(wait bool) {
 	e.mu.Lock()
 	old := e.levelWorkers
-	e.levelWorkers += n
+	if wait {
+		e.levelWorkers += 1
+	}
 
 	if old == 0 && e.done != nil {
 		// Prevent new compactions from starting
@@ -693,8 +714,8 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 	// so that snapshotting does not stop while writing out tombstones.  If it is stopped,
 	// and writing tombstones takes a long time, writes can get rejected due to the cache
 	// filling up.
-	e.disableLevelCompactions(1)
-	defer e.enableLevelCompactions(1)
+	e.disableLevelCompactions(true)
+	defer e.enableLevelCompactions(true)
 
 	// keyMap is used to see if a given key should be deleted.  seriesKey
 	// are the measurement + tagset (minus separate & field)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -58,13 +58,13 @@ const (
 
 // Engine represents a storage engine with compressed blocks.
 type Engine struct {
-	mu                         sync.RWMutex
-	done                       chan struct{}
-	snapshotterDone            chan struct{}
-	wg                         sync.WaitGroup
-	snapshotterWg              sync.WaitGroup
-	levelCompactionsEnabled    bool
-	snapshotCompactionsEnabled bool
+	mu           sync.RWMutex
+	wg           sync.WaitGroup
+	done         chan struct{}
+	levelWorkers int
+
+	snapDone chan struct{}
+	snapWG   sync.WaitGroup
 
 	path         string
 	logger       *log.Logger // Logger to be used for important messages
@@ -155,80 +155,87 @@ func (e *Engine) SetEnabled(enabled bool) {
 func (e *Engine) SetCompactionsEnabled(enabled bool) {
 	if enabled {
 		e.enableSnapshotCompactions()
-		e.enableLevelCompactions()
-
+		e.enableLevelCompactions(0)
 	} else {
 		e.disableSnapshotCompactions()
-		e.disableLevelCompactions()
+		e.disableLevelCompactions(0)
 	}
 }
 
-func (e *Engine) enableLevelCompactions() {
+func (e *Engine) enableLevelCompactions(n int) {
 	e.mu.Lock()
-	if e.levelCompactionsEnabled {
+	e.levelWorkers -= n
+	if e.levelWorkers != 0 || e.done != nil {
+		// still waiting on more workers or already enabled
 		e.mu.Unlock()
 		return
 	}
-	e.levelCompactionsEnabled = true
+
+	// last one to enable, start things back up
 	e.Compactor.EnableCompactions()
-	e.done = make(chan struct{})
-	e.mu.Unlock()
+	quit := make(chan struct{})
+	e.done = quit
 
 	e.wg.Add(4)
-	go e.compactTSMFull()
-	go e.compactTSMLevel(true, 1)
-	go e.compactTSMLevel(true, 2)
-	go e.compactTSMLevel(false, 3)
-}
-
-func (e *Engine) disableLevelCompactions() {
-	e.mu.Lock()
-	if !e.levelCompactionsEnabled {
-		e.mu.Unlock()
-		return
-	}
-	// Prevent new compactions from starting
-	e.levelCompactionsEnabled = false
-	e.Compactor.DisableCompactions()
 	e.mu.Unlock()
 
-	// Stop all background compaction goroutines
-	close(e.done)
+	go func() { defer e.wg.Done(); e.compactTSMFull(quit) }()
+	go func() { defer e.wg.Done(); e.compactTSMLevel(true, 1, quit) }()
+	go func() { defer e.wg.Done(); e.compactTSMLevel(true, 2, quit) }()
+	go func() { defer e.wg.Done(); e.compactTSMLevel(false, 3, quit) }()
+}
 
-	// Wait for compaction goroutines to exit
+func (e *Engine) disableLevelCompactions(n int) {
+	e.mu.Lock()
+	old := e.levelWorkers
+	e.levelWorkers += n
+
+	if old == 0 && e.done != nil {
+		// Prevent new compactions from starting
+		e.Compactor.DisableCompactions()
+
+		// Stop all background compaction goroutines
+		close(e.done)
+		e.done = nil
+	}
+
+	e.mu.Unlock()
 	e.wg.Wait()
 
-	if err := e.cleanup(); err != nil {
-		e.logger.Printf("error cleaning up temp file: %v", err)
+	if old == 0 { // first to disable should cleanup
+		if err := e.cleanup(); err != nil {
+			e.logger.Printf("error cleaning up temp file: %v", err)
+		}
 	}
 }
 
 func (e *Engine) enableSnapshotCompactions() {
 	e.mu.Lock()
-	if e.snapshotCompactionsEnabled {
+	if e.snapDone != nil {
 		e.mu.Unlock()
 		return
 	}
 
-	e.snapshotCompactionsEnabled = true
-	e.snapshotterDone = make(chan struct{})
 	e.Compactor.EnableSnapshots()
+	quit := make(chan struct{})
+	e.snapDone = quit
+	e.snapWG.Add(1)
 	e.mu.Unlock()
 
-	e.snapshotterWg.Add(1)
-	go e.compactCache()
+	go func() { defer e.snapWG.Done(); e.compactCache(quit) }()
 }
 
 func (e *Engine) disableSnapshotCompactions() {
 	e.mu.Lock()
-	if !e.snapshotCompactionsEnabled {
-		e.mu.Unlock()
-		return
+
+	if e.snapDone != nil {
+		e.Compactor.DisableSnapshots()
+		close(e.snapDone)
+		e.snapDone = nil
 	}
-	e.snapshotCompactionsEnabled = false
-	e.Compactor.DisableSnapshots()
+
 	e.mu.Unlock()
-	e.snapshotterWg.Wait()
+	e.snapWG.Wait()
 }
 
 // Path returns the path the engine was opened with.
@@ -309,8 +316,6 @@ func (e *Engine) Statistics(tags map[string]string) []models.Statistic {
 
 // Open opens and initializes the engine.
 func (e *Engine) Open() error {
-	e.done = make(chan struct{})
-
 	if err := os.MkdirAll(e.path, 0777); err != nil {
 		return err
 	}
@@ -688,8 +693,8 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 	// so that snapshotting does not stop while writing out tombstones.  If it is stopped,
 	// and writing tombstones takes a long time, writes can get rejected due to the cache
 	// filling up.
-	e.disableLevelCompactions()
-	defer e.enableLevelCompactions()
+	e.disableLevelCompactions(1)
+	defer e.enableLevelCompactions(1)
 
 	// keyMap is used to see if a given key should be deleted.  seriesKey
 	// are the measurement + tagset (minus separate & field)
@@ -860,22 +865,13 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache) (
 }
 
 // compactCache continually checks if the WAL cache should be written to disk
-func (e *Engine) compactCache() {
-	defer e.snapshotterWg.Done()
+func (e *Engine) compactCache(quit <-chan struct{}) {
 	for {
 		select {
-		case <-e.snapshotterDone:
+		case <-quit:
 			return
 
 		default:
-			e.mu.RLock()
-			enabled := e.snapshotCompactionsEnabled
-			e.mu.RUnlock()
-
-			if !enabled {
-				return
-			}
-
 			e.Cache.UpdateAge()
 			if e.ShouldCompactCache(e.WAL.LastWriteTime()) {
 				start := time.Now()
@@ -907,12 +903,10 @@ func (e *Engine) ShouldCompactCache(lastWriteTime time.Time) bool {
 		time.Now().Sub(lastWriteTime) > e.CacheFlushWriteColdDuration
 }
 
-func (e *Engine) compactTSMLevel(fast bool, level int) {
-	defer e.wg.Done()
-
+func (e *Engine) compactTSMLevel(fast bool, level int, quit <-chan struct{}) {
 	for {
 		select {
-		case <-e.done:
+		case <-quit:
 			return
 
 		default:
@@ -997,12 +991,10 @@ func (e *Engine) compactTSMLevel(fast bool, level int) {
 	}
 }
 
-func (e *Engine) compactTSMFull() {
-	defer e.wg.Done()
-
+func (e *Engine) compactTSMFull(quit <-chan struct{}) {
 	for {
 		select {
-		case <-e.done:
+		case <-quit:
 			return
 
 		default:

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -170,7 +170,7 @@ func (e *Engine) enableLevelCompactions() {
 		return
 	}
 	e.levelCompactionsEnabled = true
-	e.Compactor.EnabledCompactions()
+	e.Compactor.EnableCompactions()
 	e.done = make(chan struct{})
 	e.mu.Unlock()
 
@@ -212,7 +212,7 @@ func (e *Engine) enableSnapshotCompactions() {
 
 	e.snapshotCompactionsEnabled = true
 	e.snapshotterDone = make(chan struct{})
-	e.Compactor.EnabledSnapshots()
+	e.Compactor.EnableSnapshots()
 	e.mu.Unlock()
 
 	e.snapshotterWg.Add(1)

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -650,13 +650,16 @@ func (f *FileStore) BlockCount(path string, idx int) int {
 
 // walkFiles calls fn for every files in filestore in parallel
 func (f *FileStore) walkFiles(fn func(f TSMFile) error) error {
+	// Copy the current TSM files to prevent a slow walker from
+	// blocking other operations.
 	f.mu.RLock()
-	defer f.mu.RUnlock()
+	files := make([]TSMFile, len(f.files))
+	copy(files, f.files)
+	f.mu.RUnlock()
 
 	// struct to hold the result of opening each reader in a goroutine
-
-	errC := make(chan error, len(f.files))
-	for _, f := range f.files {
+	errC := make(chan error, len(files))
+	for _, f := range files {
 		go func(tsm TSMFile) {
 			if err := fn(tsm); err != nil {
 				errC <- fmt.Errorf("file %s: %s", tsm.Path(), err)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

If a delete takes a long time to process while writes to the
shard are occuring, it was possible for the cache to fill up
and writes to be rejected.  This occurred because we disabled
all compactions while writing tombstone file to prevent deleted
data from re-appearing after a compaction completed.

Instead, we only disable the level compactions and allow snapshot
compactions to continue.  Snapshots already handle deleted data
with the cache and wal.

Fixes #7161