### PR TITLE
Fix WaitGroup race in TSM engine.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.
 - [#7152](https://github.com/influxdata/influxdb/issues/7152): Decrement number of measurements only once when deleting the last series from a measurement.
+- [#7149](https://github.com/influxdata/influxdb/issues/7149): Fix a waitgroup race in TSM engine.
 
 ## v1.0.0 [unreleased]
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -825,7 +825,7 @@ func (e *Engine) compactCache() {
 	defer e.wg.Done()
 	for {
 		select {
-		case <-e.done:
+		case <-e.notifyDone():
 			return
 
 		default:
@@ -865,7 +865,7 @@ func (e *Engine) compactTSMLevel(fast bool, level int) {
 
 	for {
 		select {
-		case <-e.done:
+		case <-e.notifyDone():
 			return
 
 		default:
@@ -955,7 +955,7 @@ func (e *Engine) compactTSMFull() {
 
 	for {
 		select {
-		case <-e.done:
+		case <-e.notifyDone():
 			return
 
 		default:


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated

Fixes #7149.

I'm assuming this is going into `1.1`, but I can adjust the CHANGELOG if it's going into `1.0`.

There was a race in the engine wherein If compactions were disabled and then enabled again from separate goroutines, but before the previous disabling had been cleaned up, the engine's WaitGroup would have an `Add` call happen while still blocking on the `Wait` in the first goroutine.

The fix is to simply ensure that `done` has been closed before we begin enabling compactions again.

Also, `done` I think was racy. Given it's been demonstrated in #7149 that compactions can be enabled while compactors are still running (before `Wait` has returned) then it means it's possible to receive from `done` inside, for example, `compactTSMFull` while concurrently re-assigning it in `SetCompactionsEnabled`. I've fixed that using the `notifyDone` method.

