### PR TITLE
Command permission fixes

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2464,7 +2464,7 @@ func (s *CreateContinuousQueryStatement) DefaultDatabase() string {
 
 // RequiredPrivileges returns the privilege required to execute a CreateContinuousQueryStatement.
 func (s *CreateContinuousQueryStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	ep := ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: ReadPrivilege}}
+	ep := ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: WritePrivilege}}
 
 	// Selecting into a database that's different from the source?
 	if s.Source.Target.Measurement.Database != "" {

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -822,7 +822,7 @@ func (s *CreateRetentionPolicyStatement) String() string {
 
 // RequiredPrivileges returns the privilege required to execute a CreateRetentionPolicyStatement.
 func (s *CreateRetentionPolicyStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
+	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: WritePrivilege}}, nil
 }
 
 // AlterRetentionPolicyStatement represents a command to alter an existing retention policy.

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2589,7 +2589,7 @@ func (s *DropMeasurementStatement) String() string {
 
 // RequiredPrivileges returns the privilege(s) required to execute a DropMeasurementStatement
 func (s *DropMeasurementStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
+	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: WritePrivilege}}, nil
 }
 
 // ShowQueriesStatement represents a command for listing all running queries.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

----

I left CHANGELOG.md unmodified as it is unclear to which target version this should go.

It is unclear whether retention policy management is only intended to be available to admin users. This PR allows creating RPs with just write privileges. If the idea is to allow RP management to admins, then the necessary fix would be also restricting the "DROP RETENTION POLICY" command to admins only.

The docs.influxdata.com documentation should also the updated as it states things like "Only admin users are allowed to work with continuous queries.".

