### PR TITLE
Write path stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Release Notes
 
+### Breaking changes
+
+* The Shard `writePointsFail` stat has been renamed to `writePointsErr` for consistency with other stats.
+
 ### Features
 
 - [#7120](https://github.com/influxdata/influxdb/issues/7120): Add additional statistics to query executor.
@@ -10,6 +14,7 @@
 - [#7099](https://github.com/influxdata/influxdb/pull/7099): Implement text/csv content encoding for the response writer.
 - [#6992](https://github.com/influxdata/influxdb/issues/6992): Support tools for running async queries.
 - [#7136](https://github.com/influxdata/influxdb/pull/7136): Update jwt-go dependency to version 3.
+- [#7172](https://github.com/influxdata/influxdb/pull/7172): Write path stats
 
 ### Bugfixes
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -387,6 +387,7 @@ func (c *Cache) DeleteRange(keys []string, min, max int64) {
 
 		c.size -= uint64(origSize - e.size())
 	}
+	atomic.StoreInt64(&c.stats.MemSizeBytes, int64(c.size))
 }
 
 func (c *Cache) SetMaxSize(size uint64) {

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -116,6 +116,9 @@ const (
 
 	statCachedBytes         = "cachedBytes"         // counter: Total number of bytes written into snapshots.
 	statWALCompactionTimeMs = "WALCompactionTimeMs" // counter: Total number of milliseconds spent compacting snapshots
+
+	writeOK  = "writeOk"
+	writeErr = "writeErr"
 )
 
 // Cache maintains an in-memory store of Values for a set of keys.
@@ -165,6 +168,8 @@ type CacheStatistics struct {
 	CacheAgeMs          int64
 	CachedBytes         int64
 	WALCompactionTimeMs int64
+	WriteOK             int64
+	WriteErr            int64
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -193,6 +198,7 @@ func (c *Cache) Write(key string, values []Value) error {
 	newSize := c.size + uint64(addedSize)
 	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
 		c.mu.Unlock()
+		atomic.AddInt64(&c.stats.WriteErr, 1)
 		return ErrCacheMemoryExceeded
 	}
 
@@ -202,6 +208,7 @@ func (c *Cache) Write(key string, values []Value) error {
 
 	// Update the memory size stat
 	c.updateMemSize(int64(addedSize))
+	atomic.AddInt64(&c.stats.WriteOK, 1)
 
 	return nil
 }
@@ -219,6 +226,7 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 	newSize := c.size + uint64(totalSz)
 	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
 		c.mu.RUnlock()
+		atomic.AddInt64(&c.stats.WriteErr, 1)
 		return ErrCacheMemoryExceeded
 	}
 	c.mu.RUnlock()
@@ -232,6 +240,7 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 
 	// Update the memory size stat
 	c.updateMemSize(int64(totalSz))
+	atomic.AddInt64(&c.stats.WriteOK, 1)
 
 	return nil
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -693,7 +693,7 @@ func (e *Engine) DeleteMeasurement(name string, seriesKeys []string) error {
 
 // SeriesCount returns the number of series buckets on the shard.
 func (e *Engine) SeriesCount() (n int, err error) {
-	return 0, nil
+	return e.index.SeriesN(), nil
 }
 
 func (e *Engine) WriteTo(w io.Writer) (n int64, err error) { panic("not implemented") }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This PR adds some simple write path success/error counts from the shard down to the cache and WAL.  This allows someone to monitor the shard write OPS and detect when writes are failing.  If they are failing, it can be determined by drilling down to the cache or WAL write stats.

This also fixes a bug in the cache size stat where deletes would not reset the memory usage.