### PR TITLE
Ensure /debug/vars tags are not base64 encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.
 - [#7152](https://github.com/influxdata/influxdb/issues/7152): Decrement number of measurements only once when deleting the last series from a measurement.
+- [#7177](https://github.com/influxdata/influxdb/issues/7177): Fix base64 encoding issue with /debug/vars tags.
 
 ## v1.0.0 [unreleased]
 
@@ -143,6 +144,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7125](https://github.com/influxdata/influxdb/pull/7125): Ensure gzip writer is closed in influx_inspect export
 - [#7127](https://github.com/influxdata/influxdb/pull/7127): Concurrent series limit
 - [#7119](https://github.com/influxdata/influxdb/pull/7119): Fix CREATE DATABASE when dealing with default values.
+
 
 ## v0.13.0 [2016-05-12]
 

--- a/models/points.go
+++ b/models/points.go
@@ -3,6 +3,7 @@ package models // import "github.com/influxdata/influxdb/models"
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -1394,6 +1395,22 @@ func (p *point) UnixNano() int64 {
 type Tag struct {
 	Key   []byte
 	Value []byte
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+//
+// When Tags are marshalled to a JSON representation it is helpful if they're
+// represented as readable strings, rather than the base64 encoded strings which
+// are emitted when encoding a []byte.
+func (t Tag) MarshalJSON() ([]byte, error) {
+	var out = struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}{
+		Key:   string(t.Key),
+		Value: string(t.Value),
+	}
+	return json.Marshal(out)
 }
 
 // Tags represents a sorted list of tags.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #7177. Please see the issue for hopefully a discussion on whether we can obviate this particular fix by using a simpler `map[string]string` over the current `[]struct{Key []byte, Value []byte}`.

I think this needs to get into `1.0` @jwilder.