### PR TITLE
Fix base64 encoding issue in stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.
 - [#7152](https://github.com/influxdata/influxdb/issues/7152): Decrement number of measurements only once when deleting the last series from a measurement.
+- [#7177](https://github.com/influxdata/influxdb/issues/7177): Fix base64 encoding issue with /debug/vars stats.
 
 ## v1.0.0 [unreleased]
 

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -176,7 +176,7 @@ type WriteStatistics struct {
 func (w *PointsWriter) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "write",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statWriteReq:           atomic.LoadInt64(&w.stats.WriteReq),
 			statPointWriteReq:      atomic.LoadInt64(&w.stats.PointWriteReq),

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -818,7 +818,7 @@ func (e *StatementExecutor) executeShowStatsStatement(stmt *influxql.ShowStatsSt
 		if stmt.Module != "" && stat.Name != stmt.Module {
 			continue
 		}
-		row := &models.Row{Name: stat.Name, Tags: stat.Tags.Map()}
+		row := &models.Row{Name: stat.Name, Tags: stat.Tags}
 
 		values := make([]interface{}, 0, len(stat.Values))
 		for _, k := range stat.ValueNames() {

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -148,7 +148,7 @@ type QueryStatistics struct {
 func (e *QueryExecutor) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "queryExecutor",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statQueriesActive:          atomic.LoadInt64(&e.stats.ActiveQueries),
 			statQueriesExecuted:        atomic.LoadInt64(&e.stats.ExecutedQueries),

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -2,6 +2,6 @@ package models
 
 type Statistic struct {
 	Name   string                 `json:"name"`
-	Tags   Tags                   `json:"tags"`
+	Tags   map[string]string      `json:"tags"`
 	Values map[string]interface{} `json:"values"`
 }

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -147,7 +147,7 @@ type Statistics struct {
 func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "cq",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statQueryOK:   atomic.LoadInt64(&s.stats.QueryOK),
 			statQueryFail: atomic.LoadInt64(&s.stats.QueryFail),

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -179,7 +179,7 @@ type Statistics struct {
 func (h *Handler) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "httpd",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statRequest:                      atomic.LoadInt64(&h.stats.Requests),
 			statCQRequest:                    atomic.LoadInt64(&h.stats.CQRequests),
@@ -742,24 +742,24 @@ func (h *Handler) serveExpvar(w http.ResponseWriter, r *http.Request) {
 	for _, s := range stats {
 		// Very hackily create a unique key.
 		buf := bytes.NewBufferString(s.Name)
-		if path := s.Tags.Get([]byte("path")); path != nil {
+		if path, ok := s.Tags["path"]; ok {
 			fmt.Fprintf(buf, ":%s", path)
-			if id := s.Tags.Get([]byte("id")); id != nil {
+			if id, ok := s.Tags["id"]; ok {
 				fmt.Fprintf(buf, ":%s", id)
 			}
-		} else if bind := s.Tags.Get([]byte("bind")); bind != nil {
-			if proto := s.Tags.Get([]byte("proto")); proto != nil {
+		} else if bind, ok := s.Tags["bind"]; ok {
+			if proto, ok := s.Tags["proto"]; ok {
 				fmt.Fprintf(buf, ":%s", proto)
 			}
 			fmt.Fprintf(buf, ":%s", bind)
-		} else if database := s.Tags.Get([]byte("database")); database != nil {
+		} else if database, ok := s.Tags["database"]; ok {
 			fmt.Fprintf(buf, ":%s", database)
-			if rp := s.Tags.Get([]byte("retention_policy")); rp != nil {
+			if rp, ok := s.Tags["retention_policy"]; ok {
 				fmt.Fprintf(buf, ":%s", rp)
-				if name := s.Tags.Get([]byte("name")); name != nil {
+				if name, ok := s.Tags["name"]; ok {
 					fmt.Fprintf(buf, ":%s", name)
 				}
-				if dest := s.Tags.Get([]byte("destination")); dest != nil {
+				if dest, ok := s.Tags["destination"]; ok {
 					fmt.Fprintf(buf, ":%s", dest)
 				}
 			}

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -130,7 +130,7 @@ type Statistics struct {
 func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 	statistics := []models.Statistic{{
 		Name: "subscriber",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statPointsWritten: atomic.LoadInt64(&s.stats.PointsWritten),
 			statWriteFailures: atomic.LoadInt64(&s.stats.WriteFailures),
@@ -415,13 +415,19 @@ func (b *balancewriter) WritePoints(p *coordinator.WritePointsRequest) error {
 
 // Statistics returns statistics for periodic monitoring.
 func (b *balancewriter) Statistics(tags map[string]string) []models.Statistic {
-	tags = models.NewTags(tags).Merge(b.tags).Map()
+	// Insert any missing default tag values.
+	for k, v := range b.tags {
+		if _, ok := tags[k]; !ok {
+			tags[k] = v
+		}
+	}
 
 	statistics := make([]models.Statistic, len(b.stats))
 	for i := range b.stats {
+		tags["destination"] = b.stats[i].dest
 		statistics[i] = models.Statistic{
 			Name: "subscriber",
-			Tags: models.NewTags(tags).Merge(map[string]string{"destination": b.stats[i].dest}),
+			Tags: tags,
 			Values: map[string]interface{}{
 				statPointsWritten: atomic.LoadInt64(&b.stats[i].pointsWritten),
 				statWriteFailures: atomic.LoadInt64(&b.stats[i].failures),

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -58,7 +58,7 @@ type Service struct {
 
 	Logger   *log.Logger
 	stats    *Statistics
-	statTags models.Tags
+	statTags map[string]string
 }
 
 // NewService returns a new instance of Service.
@@ -71,7 +71,7 @@ func NewService(c Config) *Service {
 		batcher:    tsdb.NewPointBatcher(d.BatchSize, d.BatchPending, time.Duration(d.BatchTimeout)),
 		Logger:     log.New(os.Stderr, "[udp] ", log.LstdFlags),
 		stats:      &Statistics{},
-		statTags:   models.NewTags(map[string]string{"bind": d.BindAddress}),
+		statTags:   map[string]string{"bind": d.BindAddress},
 	}
 }
 
@@ -132,9 +132,16 @@ type Statistics struct {
 
 // Statistics returns statistics for periodic monitoring.
 func (s *Service) Statistics(tags map[string]string) []models.Statistic {
+	// Insert any missing deault tag values.
+	for k, v := range s.statTags {
+		if _, ok := tags[k]; !ok {
+			tags[k] = v
+		}
+	}
+
 	return []models.Statistic{{
 		Name: "udp",
-		Tags: s.statTags,
+		Tags: tags,
 		Values: map[string]interface{}{
 			statPointsReceived:      atomic.LoadInt64(&s.stats.PointsReceived),
 			statBytesReceived:       atomic.LoadInt64(&s.stats.BytesReceived),

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -171,7 +171,7 @@ type CacheStatistics struct {
 func (c *Cache) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "tsm1_cache",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statCacheMemoryBytes:    atomic.LoadInt64(&c.stats.MemSizeBytes),
 			statCacheDiskBytes:      atomic.LoadInt64(&c.stats.DiskSizeBytes),

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -249,7 +249,7 @@ func (e *Engine) Statistics(tags map[string]string) []models.Statistic {
 	statistics := make([]models.Statistic, 0, 4)
 	statistics = append(statistics, models.Statistic{
 		Name: "tsm1_engine",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statCacheCompactions:            atomic.LoadInt64(&e.stats.CacheCompactions),
 			statCacheCompactionDuration:     atomic.LoadInt64(&e.stats.CacheCompactionDuration),

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -215,7 +215,7 @@ type FileStoreStatistics struct {
 func (f *FileStore) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "tsm1_filestore",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statFileStoreBytes: atomic.LoadInt64(&f.stats.DiskBytes),
 			statFileStoreCount: atomic.LoadInt64(&f.stats.FileCount),

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -144,7 +144,7 @@ type WALStatistics struct {
 func (l *WAL) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
 		Name: "tsm1_wal",
-		Tags: models.NewTags(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statWALOldBytes:     atomic.LoadInt64(&l.stats.OldBytes),
 			statWALCurrentBytes: atomic.LoadInt64(&l.stats.CurrentBytes),

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -55,9 +55,12 @@ type IndexStatistics struct {
 
 // Statistics returns statistics for periodic monitoring.
 func (d *DatabaseIndex) Statistics(tags map[string]string) []models.Statistic {
+	if _, ok := tags["database"]; !ok {
+		tags["database"] = d.name
+	}
 	return []models.Statistic{{
 		Name: "database",
-		Tags: models.NewTags(map[string]string{"database": d.name}).Merge(tags),
+		Tags: tags,
 		Values: map[string]interface{}{
 			statDatabaseSeries:       atomic.LoadInt64(&d.stats.NumSeries),
 			statDatabaseMeasurements: atomic.LoadInt64(&d.stats.NumMeasurements),


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated

Fixes #7177.

This PR changes the tags in `/debug/vars` to use a `map[string]string`, which ensures they're encoded correctly in the JSON response, as well as saving on some cycles by reducing the amount of sorting and hashing we are doing of various values.

It also fixes some possible bugs:

 - `opentsdb.Service.Statistics` was ignoring any passed in tags;
 -  `udp.Service.Statistics` was ignoring any passed in tags;
 - `subsriber.balancewriter.Statistics` was overwriting passed in tags with default values.

@jwilder @sparrc @corylanou 