### PR TITLE
Add time range options to influx_inspect export

### DIFF
--- a/cmd/influx_inspect/export.go
+++ b/cmd/influx_inspect/export.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
@@ -137,8 +138,8 @@ func (c *cmdExport) writeFiles() error {
 	fmt.Fprintln(w, "# DDL")
 	for key, _ := range c.files {
 		keys := strings.Split(key, string(byte(os.PathSeparator)))
-		fmt.Fprintf(w, "CREATE DATABASE %s\n", keys[0])
-		fmt.Fprintf(w, "CREATE RETENTION POLICY %s ON %s DURATION inf REPLICATION 1\n", keys[1], keys[0])
+		db, rp := influxql.QuoteIdent(keys[0]), influxql.QuoteIdent(keys[1])
+		fmt.Fprintf(w, "CREATE DATABASE %s WITH NAME %s\n", db, rp)
 	}
 
 	fmt.Fprintln(w, "# DML")

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -104,13 +104,15 @@ func main() {
 		}
 		cmdVerify(path)
 	case "export":
-		var path, out, db, rp string
+		var path, out, db, rp, start, end string
 		var compress bool
 		fs := flag.NewFlagSet("export", flag.ExitOnError)
 		fs.StringVar(&path, "dir", os.Getenv("HOME")+"/.influxdb", "Root storage path. [$HOME/.influxdb]")
 		fs.StringVar(&out, "out", os.Getenv("HOME")+"/.influxdb/export", "Destination file to export to")
 		fs.StringVar(&db, "db", "", "Optional: the database to export")
 		fs.StringVar(&rp, "rp", "", "Optional: the retention policy to export (requires db parameter to be specified)")
+		fs.StringVar(&start, "start-time", "", "Optional: the start time to export")
+		fs.StringVar(&end, "end-time", "", "Optional: the end time to export")
 		fs.BoolVar(&compress, "compress", false, "Compress the output")
 
 		fs.Usage = func() {
@@ -124,7 +126,11 @@ func main() {
 			fmt.Printf("%v", err)
 			os.Exit(1)
 		}
-		c := newCmdExport(path, out, db, rp, compress)
+		c, err := newCmdExport(path, out, db, rp, start, end, compress)
+		if err != nil {
+			fmt.Printf("%v", err)
+			os.Exit(1)
+		}
 		if err := c.run(); err != nil {
 			fmt.Println(err)
 			os.Exit(1)


### PR DESCRIPTION
Adds `-start-time` and `-end-time` options to the `influx_inspect export` tool.

cc @corylanou 