### PR TITLE
Fixing misspelt heading in configuration example

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -177,13 +177,13 @@ reporting-disabled = false
   # bind-socket = "/var/run/influxdb.sock"
 
 ###
-### [subsciber]
+### [subscriber]
 ###
 ### Controls the subscriptions, which can be used to fork a copy of all data
 ### received by the InfluxDB host.
 ###
 
-[subsciber]
+[subscriber]
   enabled = true
   http-timeout = "30s"
 

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -5,3 +5,11 @@ type Statistic struct {
 	Tags   map[string]string      `json:"tags"`
 	Values map[string]interface{} `json:"values"`
 }
+
+func NewStatistic(name string) Statistic {
+	return Statistic{
+		Name:   name,
+		Tags:   make(map[string]string),
+		Values: make(map[string]interface{}),
+	}
+}

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -13,3 +13,28 @@ func NewStatistic(name string) Statistic {
 		Values: make(map[string]interface{}),
 	}
 }
+
+// StatisticTags is a map that can be merged with others without causing
+// mutations to either map.
+type StatisticTags map[string]string
+
+// Merge creates a new map containing the merged contents of tags and t.
+// If both tags and the receiver map contain the same key, the value in tags
+// is used in the resulting map.
+//
+// Merge always returns a usable map.
+func (t StatisticTags) Merge(tags map[string]string) map[string]string {
+	// Add everything in tags to the result.
+	out := make(map[string]string, len(tags))
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	// Only add values from t that don't appear in tags.
+	for k, v := range t {
+		if _, ok := tags[k]; !ok {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/models/statistic_test.go
+++ b/models/statistic_test.go
@@ -1,0 +1,55 @@
+package models_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/influxdb/models"
+)
+
+func TestTags_Merge(t *testing.T) {
+	examples := []struct {
+		Base   map[string]string
+		Arg    map[string]string
+		Result map[string]string
+	}{
+		{
+			Base:   nil,
+			Arg:    nil,
+			Result: map[string]string{},
+		},
+		{
+			Base:   nil,
+			Arg:    map[string]string{"foo": "foo"},
+			Result: map[string]string{"foo": "foo"},
+		},
+		{
+			Base:   map[string]string{"foo": "foo"},
+			Arg:    nil,
+			Result: map[string]string{"foo": "foo"},
+		},
+		{
+			Base:   map[string]string{"foo": "foo"},
+			Arg:    map[string]string{"bar": "bar"},
+			Result: map[string]string{"foo": "foo", "bar": "bar"},
+		},
+		{
+			Base:   map[string]string{"foo": "foo", "bar": "bar"},
+			Arg:    map[string]string{"zoo": "zoo"},
+			Result: map[string]string{"foo": "foo", "bar": "bar", "zoo": "zoo"},
+		},
+		{
+			Base:   map[string]string{"foo": "foo", "bar": "bar"},
+			Arg:    map[string]string{"bar": "newbar"},
+			Result: map[string]string{"foo": "foo", "bar": "newbar"},
+		},
+	}
+
+	for i, example := range examples {
+		i++
+		result := models.StatisticTags(example.Base).Merge(example.Arg)
+		if got, exp := result, example.Result; !reflect.DeepEqual(got, exp) {
+			t.Errorf("[Example %d] got %#v, expected %#v", i, got, exp)
+		}
+	}
+}

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -210,9 +210,7 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 		}
 
 		statistic := &Statistic{
-			Statistic: models.Statistic{
-				Values: make(map[string]interface{}),
-			},
+			Statistic: models.NewStatistic(""),
 		}
 
 		// Add any supplied tags.
@@ -277,10 +275,7 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 
 	// Add Go memstats.
 	statistic := &Statistic{
-		Statistic: models.Statistic{
-			Name:   "runtime",
-			Values: make(map[string]interface{}),
-		},
+		Statistic: models.NewStatistic("runtime"),
 	}
 
 	// Add any supplied tags to Go memstats

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -59,9 +59,9 @@ type Service struct {
 	batcher *tsdb.PointBatcher
 	parser  *Parser
 
-	logger   *log.Logger
-	stats    *Statistics
-	statTags map[string]string
+	logger      *log.Logger
+	stats       *Statistics
+	defaultTags models.StatisticTags
 
 	tcpConnectionsMu sync.Mutex
 	tcpConnections   map[string]*tcpConnection
@@ -106,7 +106,7 @@ func NewService(c Config) (*Service, error) {
 		batchTimeout:    time.Duration(d.BatchTimeout),
 		logger:          log.New(os.Stderr, fmt.Sprintf("[graphite] %s ", d.BindAddress), log.LstdFlags),
 		stats:           &Statistics{},
-		statTags:        map[string]string{"proto": d.Protocol, "bind": d.BindAddress},
+		defaultTags:     models.StatisticTags{"proto": d.Protocol, "bind": d.BindAddress},
 		tcpConnections:  make(map[string]*tcpConnection),
 		done:            make(chan struct{}),
 		diagsKey:        strings.Join([]string{"graphite", d.Protocol, d.BindAddress}, ":"),
@@ -232,15 +232,9 @@ type Statistics struct {
 
 // Statistics returns statistics for periodic monitoring.
 func (s *Service) Statistics(tags map[string]string) []models.Statistic {
-	// Insert any missing deault tag values.
-	for k, v := range s.statTags {
-		if _, ok := tags[k]; !ok {
-			tags[k] = v
-		}
-	}
 	return []models.Statistic{{
 		Name: "graphite",
-		Tags: tags,
+		Tags: s.defaultTags.Merge(tags),
 		Values: map[string]interface{}{
 			statPointsReceived:      atomic.LoadInt64(&s.stats.PointsReceived),
 			statBytesReceived:       atomic.LoadInt64(&s.stats.BytesReceived),

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -73,8 +73,8 @@ type Service struct {
 	LogPointErrors bool
 	Logger         *log.Logger
 
-	stats    *Statistics
-	statTags map[string]string
+	stats       *Statistics
+	defaultTags models.StatisticTags
 }
 
 // NewService returns a new instance of Service.
@@ -96,7 +96,7 @@ func NewService(c Config) (*Service, error) {
 		Logger:          log.New(os.Stderr, "[opentsdb] ", log.LstdFlags),
 		LogPointErrors:  d.LogPointErrors,
 		stats:           &Statistics{},
-		statTags:        map[string]string{"bind": d.BindAddress},
+		defaultTags:     models.StatisticTags{"bind": d.BindAddress},
 	}
 	return s, nil
 }
@@ -200,16 +200,9 @@ type Statistics struct {
 
 // Statistics returns statistics for periodic monitoring.
 func (s *Service) Statistics(tags map[string]string) []models.Statistic {
-	// Insert any missing deault tag values.
-	for k, v := range s.statTags {
-		if _, ok := tags[k]; !ok {
-			tags[k] = v
-		}
-	}
-
 	return []models.Statistic{{
 		Name: "opentsdb",
-		Tags: tags,
+		Tags: s.defaultTags.Merge(tags),
 		Values: map[string]interface{}{
 			statHTTPConnectionsHandled:   atomic.LoadInt64(&s.stats.HTTPConnectionsHandled),
 			statTelnetConnectionsActive:  atomic.LoadInt64(&s.stats.ActiveTelnetConnections),

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -34,7 +34,8 @@ type DatabaseIndex struct {
 
 	name string // name of the database represented by this index
 
-	stats *IndexStatistics
+	stats       *IndexStatistics
+	defaultTags models.StatisticTags
 }
 
 // NewDatabaseIndex returns a new initialized DatabaseIndex.
@@ -44,6 +45,7 @@ func NewDatabaseIndex(name string) *DatabaseIndex {
 		series:       make(map[string]*Series),
 		name:         name,
 		stats:        &IndexStatistics{},
+		defaultTags:  models.StatisticTags{"database": name},
 	}
 }
 
@@ -55,12 +57,9 @@ type IndexStatistics struct {
 
 // Statistics returns statistics for periodic monitoring.
 func (d *DatabaseIndex) Statistics(tags map[string]string) []models.Statistic {
-	if _, ok := tags["database"]; !ok {
-		tags["database"] = d.name
-	}
 	return []models.Statistic{{
 		Name: "database",
-		Tags: tags,
+		Tags: d.defaultTags.Merge(tags),
 		Values: map[string]interface{}{
 			statDatabaseSeries:       atomic.LoadInt64(&d.stats.NumSeries),
 			statDatabaseMeasurements: atomic.LoadInt64(&d.stats.NumMeasurements),


### PR DESCRIPTION
Minor change fixing sample configuration file whose header was misspelt.  Code correctly references toml:subscriber so no functional impact