### PR TITLE
Fix mmap dereferencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.
 - [#7152](https://github.com/influxdata/influxdb/issues/7152): Decrement number of measurements only once when deleting the last series from a measurement.
 - [#7177](https://github.com/influxdata/influxdb/issues/7177): Fix base64 encoding issue with /debug/vars stats.
+- [#7196](https://github.com/influxdata/influxdb/ssues/7196): Fix mmap dereferencing, fixes #7183, #7180
 
 ## v1.0.0 [unreleased]
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -442,8 +442,11 @@ func (f *FileStore) Close() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	for _, f := range f.files {
-		f.Close()
+	for _, file := range f.files {
+		if f.dereferencer != nil {
+			file.deref(f.dereferencer)
+		}
+		file.Close()
 	}
 
 	f.files = nil

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -491,7 +491,7 @@ func (t *TSMReader) BlockIterator() *BlockIterator {
 
 // deref removes mmap references held by another object.
 func (t *TSMReader) deref(d dereferencer) {
-	if acc, ok := t.accessor.(*mmapAccessor); ok {
+	if acc, ok := t.accessor.(*mmapAccessor); ok && acc.b != nil {
 		d.Dereference(acc.b)
 	}
 }

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1504,9 +1504,9 @@ func (s *Series) Dereference(b []byte) {
 	min := uintptr(unsafe.Pointer(&b[0]))
 	max := min + uintptr(len(b))
 
-	for _, t := range s.Tags {
-		deref(&t.Key, min, max)
-		deref(&t.Value, min, max)
+	for i := range s.Tags {
+		deref(&s.Tags[i].Key, min, max)
+		deref(&s.Tags[i].Value, min, max)
 	}
 
 	s.mu.Unlock()


### PR DESCRIPTION
## Overview

Adds a missing dereference call to `Close()` as well as fixes a tag copy issue.

Fixes #7183, #7180

/cc @jwilder 

## TODO

- [x] Rebased/mergable
- [x] Tests pass

