### PR TITLE
Sharded parallel tsm1.Cache map

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,6 @@
 collectd.org 9fc824c70f713ea0f058a07b49a4c563ef2a3b98
 github.com/BurntSushi/toml 99064174e013895bbd9b025c31100bd1d9b590ca
+github.com/OneOfOne/xxhash 5d931d4a2da753f31d09cb2862ffa01c44bc656b
 github.com/bmizerany/pat c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c
 github.com/boltdb/bolt 5cc10bbbc5c141029940133bb33c9e969512a698
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -5,3 +5,11 @@ type Statistic struct {
 	Tags   map[string]string      `json:"tags"`
 	Values map[string]interface{} `json:"values"`
 }
+
+func NewStatistic(name string) Statistic {
+	return Statistic{
+		Name: name,
+		Tags: make(map[string]string),
+		Values: make(map[string]interface{}),
+	}
+}

--- a/models/statistic.go
+++ b/models/statistic.go
@@ -8,8 +8,8 @@ type Statistic struct {
 
 func NewStatistic(name string) Statistic {
 	return Statistic{
-		Name: name,
-		Tags: make(map[string]string),
+		Name:   name,
+		Tags:   make(map[string]string),
 		Values: make(map[string]interface{}),
 	}
 }

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -210,9 +210,7 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 		}
 
 		statistic := &Statistic{
-			Statistic: models.Statistic{
-				Values: make(map[string]interface{}),
-			},
+			Statistic: models.NewStatistic(""),
 		}
 
 		// Add any supplied tags.
@@ -277,10 +275,7 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 
 	// Add Go memstats.
 	statistic := &Statistic{
-		Statistic: models.Statistic{
-			Name:   "runtime",
-			Values: make(map[string]interface{}),
-		},
+		Statistic: models.NewStatistic("runtime"),
 	}
 
 	// Add any supplied tags to Go memstats

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -122,7 +123,7 @@ const (
 type Cache struct {
 	commit  sync.Mutex
 	mu      sync.RWMutex
-	store   map[string]*entry
+	store   *CacheStoreMap
 	size    uint64
 	maxSize uint64
 
@@ -145,7 +146,7 @@ type Cache struct {
 func NewCache(maxSize uint64, path string) *Cache {
 	c := &Cache{
 		maxSize:      maxSize,
-		store:        make(map[string]*entry),
+		store:        NewCacheStoreMap(),
 		stats:        &CacheStatistics{},
 		lastSnapshot: time.Now(),
 	}
@@ -252,29 +253,24 @@ func (c *Cache) Snapshot() (*Cache, error) {
 	// If no snapshot exists, create a new one, otherwise update the existing snapshot
 	if c.snapshot == nil {
 		c.snapshot = &Cache{
-			store: make(map[string]*entry),
+			store: NewCacheStoreMap(),
 		}
 	}
 
 	// Append the current cache values to the snapshot
-	for k, e := range c.store {
-		e.mu.RLock()
-		if _, ok := c.snapshot.store[k]; ok {
-			c.snapshot.store[k].add(e.values)
-		} else {
-			c.snapshot.store[k] = e
-		}
-		c.snapshotSize += uint64(Values(e.values).Size())
-		if e.needSort {
-			c.snapshot.store[k].needSort = true
-		}
-		e.mu.RUnlock()
+
+	// this is the highest-value thing we can do on the write path, so
+	// dedicate many resources to it:
+	nWorkers := runtime.GOMAXPROCS(0) / 2
+	if nWorkers < 1 {
+		nWorkers = 1
 	}
+	c.snapshotSize += c.store.ParallelMergeInto(c.snapshot.store, nWorkers)
 
 	snapshotSize := c.size // record the number of bytes written into a snapshot
 
 	// Reset the cache
-	c.store = make(map[string]*entry)
+	c.store = NewCacheStoreMap()
 	c.size = 0
 	c.lastSnapshot = time.Now()
 
@@ -289,8 +285,12 @@ func (c *Cache) Snapshot() (*Cache, error) {
 // coming in while it writes will need the values sorted
 func (c *Cache) Deduplicate() {
 	c.mu.RLock()
-	for _, e := range c.store {
-		e.deduplicate()
+	for _, bucket := range c.store.Buckets {
+		bucket.RLock()
+		for _, e := range bucket.data {
+			e.deduplicate()
+		}
+		bucket.RUnlock()
 	}
 	c.mu.RUnlock()
 }
@@ -330,8 +330,12 @@ func (c *Cache) Keys() []string {
 	defer c.mu.RUnlock()
 
 	var a []string
-	for k, _ := range c.store {
-		a = append(a, k)
+	for _, bucket := range c.store.Buckets {
+		bucket.RLock()
+		for k := range bucket.data {
+			a = append(a, k)
+		}
+		bucket.RUnlock()
 	}
 	sort.Strings(a)
 	return a
@@ -357,7 +361,7 @@ func (c *Cache) DeleteRange(keys []string, min, max int64) {
 
 	for _, k := range keys {
 		// Make sure key exist in the cache, skip if it does not
-		e, ok := c.store[k]
+		e, ok := c.store.EntryFor(k, false)
 		if !ok {
 			continue
 		}
@@ -365,13 +369,13 @@ func (c *Cache) DeleteRange(keys []string, min, max int64) {
 		origSize := e.size()
 		if min == math.MinInt64 && max == math.MaxInt64 {
 			c.size -= uint64(origSize)
-			delete(c.store, k)
+			c.store.Delete(k)
 			continue
 		}
 
 		e.filter(min, max)
 		if e.count() == 0 {
-			delete(c.store, k)
+			c.store.Delete(k)
 			c.size -= uint64(origSize)
 			continue
 		}
@@ -391,7 +395,7 @@ func (c *Cache) SetMaxSize(size uint64) {
 // the hot source data for the key will not be changed, it is safe to call this function
 // with a read-lock taken. Otherwise it must be called with a write-lock taken.
 func (c *Cache) merged(key string) Values {
-	e := c.store[key]
+	e, _ := c.store.EntryFor(key, false)
 	if e == nil {
 		if c.snapshot == nil {
 			// No values in hot cache or snapshots.
@@ -407,7 +411,7 @@ func (c *Cache) merged(key string) Values {
 	sz := 0
 
 	if c.snapshot != nil {
-		snapshotEntries := c.snapshot.store[key]
+		snapshotEntries, _ := c.snapshot.store.EntryFor(key, false)
 		if snapshotEntries != nil {
 			snapshotEntries.deduplicate() // guarantee we are deduplicated
 			entries = append(entries, snapshotEntries)
@@ -450,7 +454,7 @@ func (c *Cache) merged(key string) Values {
 
 // Store returns the underlying cache store. This is not goroutine safe!
 // Protect access by using the Lock and Unlock functions on Cache.
-func (c *Cache) Store() map[string]*entry {
+func (c *Cache) Store() *CacheStoreMap {
 	return c.store
 }
 
@@ -465,7 +469,7 @@ func (c *Cache) RUnlock() {
 // values returns the values for the key. It doesn't lock and assumes the data is
 // already sorted. Should only be used in compact.go in the CacheKeyIterator
 func (c *Cache) values(key string) Values {
-	e := c.store[key]
+	e, _ := c.store.EntryFor(key, false)
 	if e == nil {
 		return nil
 	}
@@ -475,36 +479,14 @@ func (c *Cache) values(key string) Values {
 // write writes the set of values for the key to the cache. This function assumes
 // the lock has been taken and does not enforce the cache size limits.
 func (c *Cache) write(key string, values []Value) {
-	e, ok := c.store[key]
-	if !ok {
-		e = newEntry()
-		c.store[key] = e
-	}
+	e, _ := c.store.EntryFor(key, true)
 	e.add(values)
 }
 
 func (c *Cache) entry(key string) *entry {
-	// low-contention path: entry exists, no write operations needed:
 	c.mu.RLock()
-	e, ok := c.store[key]
+	e, _ := c.store.EntryFor(key, true)
 	c.mu.RUnlock()
-
-	if ok {
-		return e
-	}
-
-	// high-contention path: entry doesn't exist (probably), create a new
-	// one after checking again:
-	c.mu.Lock()
-
-	e, ok = c.store[key]
-	if !ok {
-		e = newEntry()
-		c.store[key] = e
-	}
-
-	c.mu.Unlock()
-
 	return e
 }
 

--- a/tsdb/engine/tsm1/cache_map.go
+++ b/tsdb/engine/tsm1/cache_map.go
@@ -1,0 +1,208 @@
+package tsm1
+
+import (
+	"math/rand"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	xxhash "github.com/OneOfOne/xxhash/native"
+)
+
+var (
+	bucketIds uint64 = 256 // must be a power of 2
+	seed      uint64
+)
+
+func init() {
+	if s := os.Getenv("CACHE_MAP_BUCKETS"); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			panic(err.Error())
+		}
+		bucketIds = uint64(n)
+	}
+	println("CACHE_MAP_BUCKETS", bucketIds)
+	seed = uint64(rand.Int63())
+	println("CACHE MAP SEED", seed)
+}
+
+// CacheStoreMap holds a sharded map from string keys to *entry objects.
+// It uses a hash function to map keys to its buckets. As much as possible, it
+// is intended to be a drop-in replacement to the plain map[string]*entry
+// which the Cache used to use.
+//
+// TODO(rw): In the future, this could shard on semantically-meaningful key
+// data. For example: map[MeasurementName]map[CanonicalTags]map[FieldName]...
+type CacheStoreMap struct {
+	Buckets []*Bucket
+}
+
+// NewCacheStoreMap creates a new CacheStoreMap with the global number of
+// buckets.
+func NewCacheStoreMap() *CacheStoreMap {
+	m := &CacheStoreMap{
+		Buckets: make([]*Bucket, bucketIds),
+	}
+	for i := range m.Buckets {
+		m.Buckets[i] = NewBucket()
+	}
+	return m
+}
+
+// BucketFor fetches the *Bucket that this key maps to.
+func (m *CacheStoreMap) BucketFor(key string) *Bucket {
+	bucketId := stringToBucketId(key)
+	return m.Buckets[bucketId]
+}
+
+func (m *CacheStoreMap) EntryFor(key string, create bool) (*entry, bool) {
+	bucket := m.BucketFor(key)
+
+	// fast path: check if this bucket has this key:
+	bucket.RLock()
+	e, ok := bucket.data[key]
+	bucket.RUnlock()
+
+	if ok {
+		return e, true
+	}
+
+	// return if the caller does not wish to create the *entry:
+	if !create {
+		return nil, false
+	}
+
+	// slow path: insert
+	e2 := newEntry()
+	bucket.Lock()
+	if bucket.data == nil {
+		bucket.Init(1)
+	}
+	e, ok = bucket.data[key]
+	if !ok {
+		e = e2
+		bucket.data[key] = e
+	}
+	bucket.Unlock()
+
+	return e, true
+}
+
+// Delete removes the given key (and its data).
+func (m *CacheStoreMap) Delete(key string) {
+	bucket := m.BucketFor(key)
+
+	bucket.Lock()
+	delete(bucket.data, key)
+	bucket.Unlock()
+}
+
+// ParallelMergeInto merges all data from the source into the destination. The
+// return value is the number of bytes (from `(models.Point).Size()`) of
+// data added to the destination object. `nWorkers` controls the parallelism.
+func (src *CacheStoreMap) ParallelMergeInto(dst *CacheStoreMap, nWorkers int) uint64 {
+	if nWorkers < 1 {
+		nWorkers = 1
+	}
+
+	var sz uint64
+	mergeJobs := make(chan [2]*Bucket, nWorkers)
+
+	// Because the hash seed is shared between CacheStoreMap instances,
+	// bucketed data can be copied over without using the hash functions.
+	// This allows embarassingly-parallel operation.
+
+	// For each bucket, create a job that merges the source bucket into
+	// the destination bucket. Process them with `nWorkers` parallelism:
+	wg := &sync.WaitGroup{}
+	for i := 0; i < nWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			for mergeJob := range mergeJobs {
+				thisSz := mergeJob[0].MergeInto(mergeJob[1])
+				atomic.AddUint64(&sz, thisSz)
+			}
+			wg.Done()
+		}()
+	}
+
+	// For each bucket, if there is any work to do, create a merge job:
+	for i := range src.Buckets {
+		if src.Buckets[i].data == nil {
+			// no source data for this bucket, skip it
+			continue
+		}
+
+		srcBucket := src.Buckets[i]
+		dstBucket := dst.Buckets[i]
+		mergeJobs <- [2]*Bucket{srcBucket, dstBucket}
+	}
+	close(mergeJobs)
+	wg.Wait()
+
+	return sz
+}
+
+// Bucket holds a 'shard' of cache map data. It is a thread-safe
+// map[string]*entry instance.
+type Bucket struct {
+	sync.RWMutex
+	data map[string]*entry
+}
+
+// NewBucket creates a new Bucket instance.
+func NewBucket() *Bucket {
+	return &Bucket{}
+}
+
+// Init initializes a Bucket with the given size hint. Using this at insertion
+// time prevents us from doing unnecessary work if we have jsut a few series.
+func (b *Bucket) Init(sizeHint int) {
+	b.data = make(map[string]*entry, sizeHint)
+}
+
+// MergeInto merges one bucket's data into another. It locks the *entry
+// instances (but not the bucket itself). This is in keeping with dropping in
+// the existing Cache logic. The return value is the number of bytes of
+// memory used by the objects added to the destination bucket.
+func (src *Bucket) MergeInto(dst *Bucket) uint64 {
+	if len(src.data) == 0 {
+		// nothing to do
+		return 0
+	}
+
+	// initialize if needed (with size hint)
+	if dst.data == nil {
+		dst.Init(len(src.data))
+	}
+
+	var sz uint64
+	for k, e := range src.data {
+		dstEntry, ok := dst.data[k]
+		if !ok {
+			// add an empty entry in the destination, because
+			// none exists:
+			dstEntry = newEntry()
+			dst.data[k] = dstEntry
+		}
+
+		// read-lock the entry and extract its data:
+		e.mu.RLock()
+		dstEntry.add(e.values)
+		needSort := e.needSort
+		sz += uint64(Values(e.values).Size())
+		e.mu.RUnlock()
+
+		if needSort {
+			dstEntry.needSort = true
+		}
+	}
+	return sz
+}
+
+// stringToBucketId computes the bucket id for the given string.
+func stringToBucketId(key string) uint64 {
+	return xxhash.ChecksumString64S(key, seed) & (bucketIds - 1)
+}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -359,17 +359,21 @@ func (e *Engine) LoadMetadataIndex(shardID uint64, index *tsdb.DatabaseIndex) er
 	e.Cache.RLock() // shouldn't need the lock, but just to be safe
 	defer e.Cache.RUnlock()
 
-	for key, entry := range e.Cache.Store() {
+	for _, bucket := range e.Cache.Store().Buckets {
+		bucket.RLock()
+		for key, entry := range bucket.data {
+			fieldType, err := entry.values.InfluxQLType()
+			if err != nil {
+				e.logger.Printf("error getting the data type of values for key %s: %s", key, err.Error())
+				continue
+			}
 
-		fieldType, err := entry.values.InfluxQLType()
-		if err != nil {
-			e.logger.Printf("error getting the data type of values for key %s: %s", key, err.Error())
-			continue
+			if err := e.addToIndexFromKey(shardID, []byte(key), fieldType, index); err != nil {
+				bucket.RUnlock()
+				return err
+			}
 		}
-
-		if err := e.addToIndexFromKey(shardID, []byte(key), fieldType, index); err != nil {
-			return err
-		}
+		bucket.RUnlock()
 	}
 
 	e.traceLogger.Printf("Meta data index for shard %d loaded in %v", shardID, time.Since(now))
@@ -665,12 +669,15 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 	// find the keys in the cache and remove them
 	walKeys := deleteKeys[:0]
 	e.Cache.RLock()
-	s := e.Cache.Store()
-	for k, _ := range s {
-		seriesKey, _ := SeriesAndFieldFromCompositeKey([]byte(k))
-		if _, ok := keyMap[string(seriesKey)]; ok {
-			walKeys = append(walKeys, k)
+	for _, bucket := range e.Cache.Store().Buckets {
+		bucket.RLock()
+		for k := range bucket.data {
+			seriesKey, _ := SeriesAndFieldFromCompositeKey([]byte(k))
+			if _, ok := keyMap[string(seriesKey)]; ok {
+				walKeys = append(walKeys, k)
+			}
 		}
+		bucket.RUnlock()
 	}
 	e.Cache.RUnlock()
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Summary

This PR introduces a sharded `map` that is almost a drop-in replacement for the `map[string]*entry` data structure used in the core of the TSM1 `*Cache`. It has the following features:

+ Less lock contention in the high-cardinality write path.
+ Parallel snapshot merging of series data (to offset the increased time when merging snapshots, apparently from iterating through multiple `map`s instead of just one).
+ No throughput change in the low-cardinality (100 series) bulk write scenario.
+ 15-25% throughput increase In the high-cardinality (1,000,000 series) bulk write scenario.

(Note that this includes the code from #7193 so that the database actually starts.)
