### PR TITLE
Disable negative timestamps for writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Support for config options `[collectd]` and `[opentsdb]` has been removed; use `[[collectd]]` and `[[opentsdb]]` instead.
 * Config option `data-logging-enabled` within the `[data]` section, has been renamed to `trace-logging-enabled`, and defaults to `false`.
 * The keywords `IF`, `EXISTS`, and `NOT` where removed for this release.  This means you no longer need to specify `IF NOT EXISTS` for `DROP DATABASE` or `IF EXISTS` for `CREATE DATABASE`.  If these are specified, a query parse error is returned.
+* Disables writes at negative timestamps since the query engine does not support them.
 
 With this release the systemd configuration files for InfluxDB will use the system configured default for logging and will no longer write files to `/var/log/influxdb` by default. On most systems, the logs will be directed to the systemd journal and can be accessed by `journalctl -u influxdb.service`. Consult the systemd journald documentation for configuring journald.
 
@@ -123,6 +124,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7025](https://github.com/influxdata/influxdb/issues/7025): Move the CQ interval by the group by offset.
 - [#7125](https://github.com/influxdata/influxdb/pull/7125): Ensure gzip writer is closed in influx_inspect export
 - [#7127](https://github.com/influxdata/influxdb/pull/7127): Concurrent series limit
+- [#7194](https://github.com/influxdata/influxdb/issues/7194): Disable writes at negative timestamps since the query engine does not support them.
 
 ## v0.13.0 [2016-05-12]
 

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -19,7 +19,8 @@ var ErrUnknownCall = errors.New("unknown call")
 
 const (
 	// MinTime is used as the minimum time value when computing an unbounded range.
-	MinTime = int64(0)
+	// This time is 1970-01-01 00:00:00.000000000 +0000 UTC
+	MinTime = models.MinNanoTime
 
 	// MaxTime is used as the maximum time value when computing an unbounded range.
 	// This time is 2262-04-11 23:47:16.854775806 +0000 UTC

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1201,6 +1201,7 @@ func TestParsePointUnicodeString(t *testing.T) {
 }
 
 func TestParsePointNegativeTimestamp(t *testing.T) {
+	t.Skip("negative timestamps are not supported by the query engine; re-enable when negative timestamps are supported by the query engine")
 	test(t, `cpu value=1 -1`,
 		NewTestPoint(
 			"cpu",
@@ -1225,7 +1226,7 @@ func TestParsePointMaxTimestamp(t *testing.T) {
 }
 
 func TestParsePointMinTimestamp(t *testing.T) {
-	test(t, `cpu value=1 -9223372036854775808`,
+	test(t, `cpu value=1 0`,
 		NewTestPoint(
 			"cpu",
 			models.Tags{},

--- a/models/time.go
+++ b/models/time.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	// MinNanoTime is the minumum time that can be represented.
+	// MinNanoTime is the minimum time that can be represented.
 	//
-	// 1677-09-21 00:12:43.145224192 +0000 UTC
+	// 1970-01-01 00:00:00.000000000 +0000 UTC
 	//
-	MinNanoTime = int64(math.MinInt64)
+	MinNanoTime = int64(0)
 
 	// MaxNanoTime is the maximum time that can be represented.
 	//


### PR DESCRIPTION
The query engine does not support negative timestamps. Fixing that is
too big of a change and we didn't intend to support timestamps before
1970 anyway. Disabling writes so that we can improve the query engine in
the future to support negative timestamps.

Fixes #7194.