### PR TITLE
Improve tsm1 cache performance

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -32,6 +32,22 @@ func newEntry() *entry {
 	return &entry{}
 }
 
+// newEntryValues returns a new instance of entry with the given values
+func newEntryValues(values []Value) *entry {
+	e := &entry{values: values}
+
+	var prevTime int64
+	for _, v := range values {
+		if v.UnixNano() <= prevTime {
+			e.needSort = true
+			break
+		}
+		prevTime = v.UnixNano()
+	}
+
+	return e
+}
+
 // add adds the given values to the entry.
 func (e *entry) add(values []Value) {
 	// See if the new values are sorted or contain duplicate timestamps
@@ -189,21 +205,20 @@ func (c *Cache) Statistics(tags map[string]string) []models.Statistic {
 }
 
 // Write writes the set of values for the key to the cache. This function is goroutine-safe.
-// It returns an error if the cache has exceeded its max size.
+// It returns an error if the cache will exceeded its max size by adding the new values.
 func (c *Cache) Write(key string, values []Value) error {
-	c.mu.Lock()
+	addedSize := uint64(Values(values).Size())
 
 	// Enough room in the cache?
-	addedSize := Values(values).Size()
-	newSize := c.size + uint64(addedSize)
-	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
+	c.mu.Lock()
+	if c.maxSize > 0 && c.size+c.snapshotSize+addedSize > c.maxSize {
 		c.mu.Unlock()
 		atomic.AddInt64(&c.stats.WriteErr, 1)
 		return ErrCacheMemoryExceeded
 	}
 
 	c.write(key, values)
-	c.size = newSize
+	c.size += addedSize
 	c.mu.Unlock()
 
 	// Update the memory size stat
@@ -214,28 +229,25 @@ func (c *Cache) Write(key string, values []Value) error {
 }
 
 // WriteMulti writes the map of keys and associated values to the cache. This function is goroutine-safe.
-// It returns an error if the cache has exceeded its max size.
+// It returns an error if the cache will exceeded its max size by adding the new values.
 func (c *Cache) WriteMulti(values map[string][]Value) error {
-	totalSz := 0
+	var totalSz uint64
 	for _, v := range values {
-		totalSz += Values(v).Size()
+		totalSz += uint64(Values(v).Size())
 	}
 
 	// Enough room in the cache?
-	c.mu.RLock()
-	newSize := c.size + uint64(totalSz)
-	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
-		c.mu.RUnlock()
+	c.mu.Lock()
+	if c.maxSize > 0 && c.snapshotSize+c.size+totalSz > c.maxSize {
+		c.mu.Unlock()
 		atomic.AddInt64(&c.stats.WriteErr, 1)
 		return ErrCacheMemoryExceeded
 	}
-	c.mu.RUnlock()
 
 	for k, v := range values {
-		c.entry(k).add(v)
+		c.write(k, v)
 	}
-	c.mu.Lock()
-	c.size += uint64(totalSz)
+	c.size += totalSz
 	c.mu.Unlock()
 
 	// Update the memory size stat
@@ -336,12 +348,12 @@ func (c *Cache) MaxSize() uint64 {
 // Keys returns a sorted slice of all keys under management by the cache.
 func (c *Cache) Keys() []string {
 	c.mu.RLock()
-	defer c.mu.RUnlock()
 
 	var a []string
 	for k, _ := range c.store {
 		a = append(a, k)
 	}
+	c.mu.RUnlock()
 	sort.Strings(a)
 	return a
 }
@@ -371,9 +383,9 @@ func (c *Cache) DeleteRange(keys []string, min, max int64) {
 			continue
 		}
 
-		origSize := e.size()
+		origSize := uint64(e.size())
 		if min == math.MinInt64 && max == math.MaxInt64 {
-			c.size -= uint64(origSize)
+			c.size -= origSize
 			delete(c.store, k)
 			continue
 		}
@@ -381,11 +393,11 @@ func (c *Cache) DeleteRange(keys []string, min, max int64) {
 		e.filter(min, max)
 		if e.count() == 0 {
 			delete(c.store, k)
-			c.size -= uint64(origSize)
+			c.size -= origSize
 			continue
 		}
 
-		c.size -= uint64(origSize - e.size())
+		c.size -= origSize - uint64(e.size())
 	}
 	atomic.StoreInt64(&c.stats.MemSizeBytes, int64(c.size))
 }
@@ -487,8 +499,8 @@ func (c *Cache) values(key string) Values {
 func (c *Cache) write(key string, values []Value) {
 	e, ok := c.store[key]
 	if !ok {
-		e = newEntry()
-		c.store[key] = e
+		c.store[key] = newEntryValues(values)
+		return
 	}
 	e.add(values)
 }

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -1,5 +1,3 @@
-// +build !race
-
 package tsm1_test
 
 import (
@@ -11,7 +9,7 @@ import (
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
 
-func TestCheckConcurrentReadsAreSafe(t *testing.T) {
+func TestCacheCheckConcurrentReadsAreSafe(t *testing.T) {
 	values := make(tsm1.Values, 1000)
 	timestamps := make([]int64, len(values))
 	series := make([]string, 100)


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Reduce the cache lock contention by widening the cache lock scope in WriteMulti, while this sounds counter intuitive it was:
* 1 x Read Lock to read the size
* 1 x Read Lock per values
* 1 x Write Lock per values on race
* 1 x Write Lock to update the size

We now have:
* 1 x Write Lock

This also reduces contention on the entries Values lock too as we have the global cache lock.

Move the calculation of the added size before taking the lock as it takes time and doesn't need the lock.

This also fixes a race in WriteMulti due to the lock not being held across the entire operation, which could cause the cache size to have an invalid value if Snapshot has been run in between the addition of the values and the size update.

Fix the cache benchmark which where benchmarking the creation of the cache not its operation and add a parallel test for more real world scenario, however this could still be improved.

Add a fast path newEntryValues values for the new case which avoids taking the values lock and all the other calculations.