### PR TITLE
Fix runtime: goroutine stack exceeds 1000000000-byte limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ With this release the systemd configuration files for InfluxDB will use the syst
 - [#7125](https://github.com/influxdata/influxdb/pull/7125): Ensure gzip writer is closed in influx_inspect export
 - [#7127](https://github.com/influxdata/influxdb/pull/7127): Concurrent series limit
 - [#7218](https://github.com/influxdata/influxdb/issues/7218): Fix alter retention policy when all options are used.
+- [#7225](https://github.com/influxdata/influxdb/issues/7225): runtime: goroutine stack exceeds 1000000000-byte limit
 
 ## v0.13.0 [2016-05-12]
 

--- a/tsdb/engine/tsm1/iterator.go
+++ b/tsdb/engine/tsm1/iterator.go
@@ -25,7 +25,7 @@ type floatCastIntegerCursor struct {
 	cursor integerCursor
 }
 
-func (c *floatCastIntegerCursor) close() error { return c.close() }
+func (c *floatCastIntegerCursor) close() error { return c.cursor.close() }
 
 func (c *floatCastIntegerCursor) next() (t int64, v interface{}) { return c.nextFloat() }
 
@@ -38,7 +38,7 @@ type integerCastFloatCursor struct {
 	cursor floatCursor
 }
 
-func (c *integerCastFloatCursor) close() error { return c.close() }
+func (c *integerCastFloatCursor) close() error { return c.cursor.close() }
 
 func (c *integerCastFloatCursor) next() (t int64, v interface{}) { return c.nextInteger() }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #7225