### PR TITLE
Write path stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 ### Breaking changes
 
+* The Shard `writePointsFail` stat has been renamed to `writePointsErr` for consistency with other stats.
+
+### Features
+
+- [#7120](https://github.com/influxdata/influxdb/issues/7120): Add additional statistics to query executor.
+- [#7135](https://github.com/influxdata/influxdb/pull/7135): Support enable HTTP service over unix domain socket. Thanks @oiooj
+- [#3634](https://github.com/influxdata/influxdb/issues/3634): Support mixed duration units.
+- [#7099](https://github.com/influxdata/influxdb/pull/7099): Implement text/csv content encoding for the response writer.
+- [#6992](https://github.com/influxdata/influxdb/issues/6992): Support tools for running async queries.
+- [#7136](https://github.com/influxdata/influxdb/pull/7136): Update jwt-go dependency to version 3.
+- [#7172](https://github.com/influxdata/influxdb/pull/7172): Write path stats
+
+### Bugfixes
+
+- [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.
+- [#7152](https://github.com/influxdata/influxdb/issues/7152): Decrement number of measurements only once when deleting the last series from a measurement.
+
+## v1.0.0 [unreleased]
+
+### Breaking changes
+
 * `max-series-per-database` was added with a default of 1M but can be disabled by setting it to `0`. Existing databases with series that exceed this limit will continue to load but writes that would create new series will fail.
 * Config option `[cluster]` has been replaced with `[coordinator]`
 * Support for config options `[collectd]` and `[opentsdb]` has been removed; use `[[collectd]]` and `[[opentsdb]]` instead.

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -387,6 +387,7 @@ func (c *Cache) DeleteRange(keys []string, min, max int64) {
 
 		c.size -= uint64(origSize - e.size())
 	}
+	atomic.StoreInt64(&c.stats.MemSizeBytes, int64(c.size))
 }
 
 func (c *Cache) SetMaxSize(size uint64) {

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -116,6 +116,9 @@ const (
 
 	statCachedBytes         = "cachedBytes"         // counter: Total number of bytes written into snapshots.
 	statWALCompactionTimeMs = "WALCompactionTimeMs" // counter: Total number of milliseconds spent compacting snapshots
+
+	writeOK  = "writeOk"
+	writeErr = "writeErr"
 )
 
 // Cache maintains an in-memory store of Values for a set of keys.
@@ -165,6 +168,8 @@ type CacheStatistics struct {
 	CacheAgeMs          int64
 	CachedBytes         int64
 	WALCompactionTimeMs int64
+	WriteOK             int64
+	WriteErr            int64
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -193,6 +198,7 @@ func (c *Cache) Write(key string, values []Value) error {
 	newSize := c.size + uint64(addedSize)
 	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
 		c.mu.Unlock()
+		atomic.AddInt64(&c.stats.WriteErr, 1)
 		return ErrCacheMemoryExceeded
 	}
 
@@ -202,6 +208,7 @@ func (c *Cache) Write(key string, values []Value) error {
 
 	// Update the memory size stat
 	c.updateMemSize(int64(addedSize))
+	atomic.AddInt64(&c.stats.WriteOK, 1)
 
 	return nil
 }
@@ -219,6 +226,7 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 	newSize := c.size + uint64(totalSz)
 	if c.maxSize > 0 && newSize+c.snapshotSize > c.maxSize {
 		c.mu.RUnlock()
+		atomic.AddInt64(&c.stats.WriteErr, 1)
 		return ErrCacheMemoryExceeded
 	}
 	c.mu.RUnlock()
@@ -232,6 +240,7 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 
 	// Update the memory size stat
 	c.updateMemSize(int64(totalSz))
+	atomic.AddInt64(&c.stats.WriteOK, 1)
 
 	return nil
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -691,7 +691,7 @@ func (e *Engine) DeleteMeasurement(name string, seriesKeys []string) error {
 
 // SeriesCount returns the number of series buckets on the shard.
 func (e *Engine) SeriesCount() (n int, err error) {
-	return 0, nil
+	return e.index.SeriesN(), nil
 }
 
 func (e *Engine) WriteTo(w io.Writer) (n int64, err error) { panic("not implemented") }

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -23,13 +23,15 @@ import (
 const monitorStatInterval = 30 * time.Second
 
 const (
-	statWriteReq        = "writeReq"
-	statSeriesCreate    = "seriesCreate"
-	statFieldsCreate    = "fieldsCreate"
-	statWritePointsFail = "writePointsFail"
-	statWritePointsOK   = "writePointsOk"
-	statWriteBytes      = "writeBytes"
-	statDiskBytes       = "diskBytes"
+	statWriteReq       = "writeReq"
+	statWriteReqOK     = "writeReqOk"
+	statWriteReqErr    = "writeReqErr"
+	statSeriesCreate   = "seriesCreate"
+	statFieldsCreate   = "fieldsCreate"
+	statWritePointsErr = "writePointsErr"
+	statWritePointsOK  = "writePointsOk"
+	statWriteBytes     = "writeBytes"
+	statDiskBytes      = "diskBytes"
 )
 
 var (
@@ -162,13 +164,15 @@ func (s *Shard) SetEnabled(enabled bool) {
 
 // ShardStatistics maintains statistics for a shard.
 type ShardStatistics struct {
-	WriteReq        int64
-	SeriesCreated   int64
-	FieldsCreated   int64
-	WritePointsFail int64
-	WritePointsOK   int64
-	BytesWritten    int64
-	DiskBytes       int64
+	WriteReq       int64
+	WriteReqOK     int64
+	WriteReqErr    int64
+	SeriesCreated  int64
+	FieldsCreated  int64
+	WritePointsErr int64
+	WritePointsOK  int64
+	BytesWritten   int64
+	DiskBytes      int64
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -178,17 +182,19 @@ func (s *Shard) Statistics(tags map[string]string) []models.Statistic {
 	}
 
 	tags = s.statTags.Merge(tags)
+	seriesN, _ := s.engine.SeriesCount()
 	statistics := []models.Statistic{{
 		Name: "shard",
 		Tags: models.Tags(tags).Merge(map[string]string{"engine": s.options.EngineVersion}),
 		Values: map[string]interface{}{
-			statWriteReq:        atomic.LoadInt64(&s.stats.WriteReq),
-			statSeriesCreate:    atomic.LoadInt64(&s.stats.SeriesCreated),
-			statFieldsCreate:    atomic.LoadInt64(&s.stats.FieldsCreated),
-			statWritePointsFail: atomic.LoadInt64(&s.stats.WritePointsFail),
-			statWritePointsOK:   atomic.LoadInt64(&s.stats.WritePointsOK),
-			statWriteBytes:      atomic.LoadInt64(&s.stats.BytesWritten),
-			statDiskBytes:       atomic.LoadInt64(&s.stats.DiskBytes),
+			statWriteReq:       atomic.LoadInt64(&s.stats.WriteReq),
+			statWriteReqOK:     atomic.LoadInt64(&s.stats.WriteReqOK),
+			statWriteReqErr:    atomic.LoadInt64(&s.stats.WriteReqErr),
+			statSeriesCreate:   seriesN,
+			statWritePointsErr: atomic.LoadInt64(&s.stats.WritePointsErr),
+			statWritePointsOK:  atomic.LoadInt64(&s.stats.WritePointsOK),
+			statWriteBytes:     atomic.LoadInt64(&s.stats.BytesWritten),
+			statDiskBytes:      atomic.LoadInt64(&s.stats.DiskBytes),
 		},
 	}}
 	statistics = append(statistics, s.engine.Statistics(tags)...)
@@ -366,10 +372,12 @@ func (s *Shard) WritePoints(points []models.Point) error {
 
 	// Write to the engine.
 	if err := s.engine.WritePoints(points); err != nil {
-		atomic.AddInt64(&s.stats.WritePointsFail, 1)
+		atomic.AddInt64(&s.stats.WritePointsErr, int64(len(points)))
+		atomic.AddInt64(&s.stats.WriteReqErr, 1)
 		return fmt.Errorf("engine: %s", err)
 	}
 	atomic.AddInt64(&s.stats.WritePointsOK, int64(len(points)))
+	atomic.AddInt64(&s.stats.WriteReqOK, 1)
 
 	return nil
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR adds some simple write path success/error counts from the shard down to the cache and WAL. This allows someone to monitor the shard write OPS and detect when writes are failing. If they are failing, it can be determined by drilling down to the cache or WAL write stats.

This also fixes a bug in the cache size stat where deletes would not reset the memory usage.