### PR TITLE
Fix DeleteSeries when multiple fields exists

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -633,21 +634,27 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 
 	// keyMap is used to see if a given key should be deleted.  seriesKey
 	// are the measurement + tagset (minus separate & field)
-	keyMap := make(map[string]int, len(seriesKeys))
+	keyMap := make(map[string]struct{}, len(seriesKeys))
 	for _, k := range seriesKeys {
-		keyMap[k] = 0
+		keyMap[k] = struct{}{}
 	}
 
 	deleteKeys := make([]string, 0, len(seriesKeys))
 	// go through the keys in the file store
 	if err := e.FileStore.WalkKeys(func(k []byte, _ byte) error {
 		seriesKey, _ := SeriesAndFieldFromCompositeKey(k)
-
 		// Keep track if we've added this key since WalkKeys can return keys
 		// we've seen before
-		if v, ok := keyMap[string(seriesKey)]; ok && v == 0 {
-			deleteKeys = append(deleteKeys, string(k))
-			keyMap[string(seriesKey)] += 1
+		key := string(k)
+		if _, ok := keyMap[string(seriesKey)]; ok {
+			i := sort.SearchStrings(deleteKeys, key)
+			if i == len(deleteKeys) {
+				deleteKeys = append(deleteKeys, key)
+			} else if key != deleteKeys[i] {
+				deleteKeys = append(deleteKeys, key)
+				copy(deleteKeys[i+1:], deleteKeys[i:])
+				deleteKeys[i] = key
+			}
 		}
 		return nil
 	}); err != nil {
@@ -658,10 +665,6 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 		return err
 	}
 
-	// reset the counts
-	for k := range keyMap {
-		keyMap[k] = 0
-	}
 	// find the keys in the cache and remove them
 	walKeys := deleteKeys[:0]
 	e.Cache.RLock()


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

The logic for determining whether a series key was already in the
the set of TSM series was too restrictive.  It allowed only the first
field of a series to be added leaving all the remaing fields.

cc @corylanou @e-dard 