### PR TITLE
Ensure ErrFieldTypeConflict value returned

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,18 +6,9 @@ import (
 	"strings"
 )
 
-var (
-	// ErrFieldsRequired is returned when a point does not any fields.
-	ErrFieldsRequired = errors.New("fields required")
-
-	// ErrFieldTypeConflict is returned when a new field already exists with a different type.
-	ErrFieldTypeConflict = errors.New("field type conflict")
-
-	// ErrUpgradeEngine will be returned when it's determined that
-	// the server has encountered shards that are not in the `tsm1`
-	// format.
-	ErrUpgradeEngine = errors.New("\n\n" + upgradeMessage + "\n\n")
-)
+// ErrFieldTypeConflict is returned when a new field already exists with a
+// different type.
+var ErrFieldTypeConflict = errors.New("field type conflict")
 
 // ErrDatabaseNotFound indicates that a database operation failed on the
 // specified database because the specified database does not exist.
@@ -35,14 +26,7 @@ func IsClientError(err error) bool {
 		return false
 	}
 
-	if err == ErrFieldsRequired {
-		return true
-	}
-	if err == ErrFieldTypeConflict {
-		return true
-	}
-
-	if strings.Contains(err.Error(), ErrFieldTypeConflict.Error()) {
+	if strings.HasPrefix(err.Error(), ErrFieldTypeConflict.Error()) {
 		return true
 	}
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -504,7 +504,7 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 			if f := mf.Field(name); f != nil {
 				// Field present in shard metadata, make sure there is no type conflict.
 				if f.Type != influxql.InspectDataType(value) {
-					return nil, fmt.Errorf("field type conflict: input field \"%s\" on measurement \"%s\" is type %T, already exists as type %s", name, p.Name(), value, f.Type)
+					return nil, fmt.Errorf("%s: input field \"%s\" on measurement \"%s\" is type %T, already exists as type %s", ErrFieldTypeConflict, name, p.Name(), value, f.Type)
 				}
 
 				continue // Field is present, and it's of the same type. Nothing more to do.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

Tidy up some unused errors, and ensure that we always return an error prefixed with the contents of `ErrFieldTypeConflict` when there are conflicting field types.
