### PR TITLE
Fix the dollar sign so it properly handles reserved keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - [#1834](https://github.com/influxdata/influxdb/issues/1834): Drop time when used as a tag or field key.
 - [#7152](https://github.com/influxdata/influxdb/issues/7152): Decrement number of measurements only once when deleting the last series from a measurement.
 - [#7177](https://github.com/influxdata/influxdb/issues/7177): Fix base64 encoding issue with /debug/vars stats.
-- [#7196](https://github.com/influxdata/influxdb/ssues/7196): Fix mmap dereferencing, fixes #7183, #7180
+- [#7196](https://github.com/influxdata/influxdb/issues/7196): Fix mmap dereferencing, fixes #7183, #7180
+- [#7013](https://github.com/influxdata/influxdb/issues/7013): Fix the dollar sign so it properly handles reserved keywords.
 
 ## v1.0.0 [unreleased]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2409,9 +2409,14 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		}
 		return &RegexLiteral{Val: re}, nil
 	case BOUNDPARAM:
-		v, ok := p.params[lit]
+		k := strings.TrimPrefix(lit, "$")
+		if len(k) == 0 {
+			return nil, errors.New("empty bound parameter")
+		}
+
+		v, ok := p.params[k]
 		if !ok {
-			return nil, fmt.Errorf("missing parameter: %s", lit)
+			return nil, fmt.Errorf("missing parameter: %s", k)
 		}
 
 		switch v := v.(type) {

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -2308,6 +2308,8 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SET PASSWORD FOR dejan`, err: `found EOF, expected = at line 1, char 24`},
 		{s: `SET PASSWORD FOR dejan =`, err: `found EOF, expected string at line 1, char 25`},
 		{s: `SET PASSWORD FOR dejan = bla`, err: `found bla, expected string at line 1, char 26`},
+		{s: `$SHOW$DATABASES`, err: `found $SHOW, expected SELECT, DELETE, SHOW, CREATE, DROP, GRANT, REVOKE, ALTER, SET, KILL at line 1, char 1`},
+		{s: `SELECT * FROM cpu WHERE "tagkey" = $$`, err: `empty bound parameter`},
 	}
 
 	for i, tt := range tests {

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -70,8 +70,8 @@ func TestScanner_Scan(t *testing.T) {
 		{s: `"foo\"bar\""`, tok: influxql.IDENT, lit: `foo"bar"`},
 		{s: `test"`, tok: influxql.BADSTRING, lit: "", pos: influxql.Pos{Line: 0, Char: 3}},
 		{s: `"test`, tok: influxql.BADSTRING, lit: `test`},
-		{s: `$host`, tok: influxql.BOUNDPARAM, lit: `host`},
-		{s: `$"host param"`, tok: influxql.BOUNDPARAM, lit: `host param`},
+		{s: `$host`, tok: influxql.BOUNDPARAM, lit: `$host`},
+		{s: `$"host param"`, tok: influxql.BOUNDPARAM, lit: `$host param`},
 
 		{s: `true`, tok: influxql.TRUE},
 		{s: `false`, tok: influxql.FALSE},


### PR DESCRIPTION
The dollar sign would sometimes be accepted as whitespace if it was
immediately followed by a reserved keyword or an invalid character. It
now reads these properly as a bound parameter rather than ignoring the
dollar sign.

Fixes #7013.