### PR TITLE
Report cmdline and memstats in /debug/vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#7271](https://github.com/influxdata/influxdb/issues/7271): Fixing typo within example configuration file. Thanks @andyfeller!
 - [#7270](https://github.com/influxdata/influxdb/issues/7270): Implement time math for lazy time literals.
+- [#7272](https://github.com/influxdata/influxdb/issues/7272): Report cmdline and memstats in /debug/vars.
 
 ## v1.0.0 [2016-09-07]
 

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -313,8 +313,6 @@ func (m *Monitor) Statistics(tags map[string]string) ([]*Statistic, error) {
 	statistics = append(statistics, statistic)
 
 	statistics = m.gatherStatistics(statistics, tags)
-	sort.Sort(Statistics(statistics))
-
 	return statistics, nil
 }
 


### PR DESCRIPTION
When we refactored expvar, the cmdline and memstats sections were not
readded to the output. This adds it back if they can be found inside of
`expvar`.

It also stops trying to sort the output of the statistics so they get
returned faster. JSON doesn't need them to be sorted and it causes
enough latency problems that sorting them hurts performance.

Fixes #7272.