### PR TITLE
Use consistent column output from the CLI for column formatted responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#7177](https://github.com/influxdata/influxdb/issues/7177): Fix base64 encoding issue with /debug/vars stats.
 - [#7196](https://github.com/influxdata/influxdb/issues/7196): Fix mmap dereferencing, fixes #7183, #7180
 - [#7013](https://github.com/influxdata/influxdb/issues/7013): Fix the dollar sign so it properly handles reserved keywords.
+- [#7297](https://github.com/influxdata/influxdb/issues/7297): Use consistent column output from the CLI for column formatted responses.
 
 ## v1.0.0 [2016-09-08]
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -645,7 +645,7 @@ func (c *CommandLine) writeColumns(response *client.Response, w io.Writer) {
 // formatResults will behave differently if you are formatting for columns or csv
 func (c *CommandLine) formatResults(result client.Result, separator string) []string {
 	rows := []string{}
-	// Create a tabbed writer for each result a they won't always line up
+	// Create a tabbed writer for each result as they won't always line up
 	for i, row := range result.Series {
 		// gather tags
 		tags := []string{}
@@ -676,15 +676,11 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 			rows = append(rows, "")
 		}
 
-		// If we are column format, we break out the name/tag to seperate lines
+		// If we are column format, we break out the name/tag to separate lines
 		if c.Format == "column" {
 			if row.Name != "" {
 				n := fmt.Sprintf("name: %s", row.Name)
 				rows = append(rows, n)
-				if len(tags) == 0 {
-					l := strings.Repeat("-", len(n))
-					rows = append(rows, l)
-				}
 			}
 			if len(tags) > 0 {
 				t := fmt.Sprintf("tags: %s", (strings.Join(tags, ", ")))
@@ -694,8 +690,8 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 
 		rows = append(rows, strings.Join(columnNames, separator))
 
-		// if format is column, break tags to their own line/format
-		if c.Format == "column" && len(tags) > 0 {
+		// if format is column, write dashes under each column
+		if c.Format == "column" {
 			lines := []string{}
 			for _, columnName := range columnNames {
 				lines = append(lines, strings.Repeat("-", len(columnName)))


### PR DESCRIPTION
There were three different outputs that could be output with columns
that were rather strange depending on if there was a name and if there
were tags with the response.

Normalized output now has the dashes always under the column names and
no dashes anywhere else for consistency.

Fixes #7297.