### PR TITLE
Pre-allocate map for performance

### DIFF
--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1088,7 +1088,11 @@ func (m *Measurement) walkWhereForSeriesIds(expr influxql.Expr) (SeriesIDs, Filt
 				return nil, nil, err
 			}
 
-			filters := FilterExprs{}
+			if len(ids) == 0 {
+				return ids, nil, nil
+			}
+
+			filters := make(FilterExprs, len(ids))
 			for _, id := range ids {
 				filters[id] = expr
 			}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This PR adds an optimisation to reduce runtime overhead associated with map assignments and growing maps.

I haven't added any benchmarks but this optimisation has improved the performance of a scenario I was testing.

In the scenario 300 variations of the following queries are submitted by 5 concurrent clients to an InfluxDB instance. The test stops when all the queries complete.

```
SELECT FIRST(value) FROM cpu WHERE id='xyz' AND time > '2016-07-10T12:12:00-05:00'
SELECT FIRST(value) FROM cpu WHERE id='xyz' AND time > now() - 60d
```

Performance was reduced by 50% from around 40s to ~20s.

@jsternberg 

/cc @gunnaraasen @rossmcdonald 