### PR TITLE
Fix golint bug in services/admin

### DIFF
--- a/services/admin/config_test.go
+++ b/services/admin/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/influxdata/influxdb/services/admin"
 )
 
-func TestConfig_Parse(t *testing.T) {
+func TestConfigParse(t *testing.T) {
 	// Parse configuration.
 	var c admin.Config
 	if _, err := toml.Decode(`


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
Fixes golint bug in services/admin — from what I can see, this appears to actually complete this directory:

```
~/g/s/g/i/i/s/admin git:master ❯❯❯ pwd && golint && go test .
/Users/kkirsche/go/src/github.com/influxdata/influxdb/services/admin
ok  	github.com/influxdata/influxdb/services/admin	0.029s
```

X-Ref: #4098