### PR TITLE
Fix panic when parsing ms durations

### DIFF
--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2686,7 +2686,7 @@ func ParseDuration(s string) (time.Duration, error) {
 			d += time.Duration(n) * time.Microsecond
 		case 'm':
 			if i+1 < len(a) && a[i+1] == 's' {
-				unit = string(a[i:2])
+				unit = string(a[i : i+2])
 				d += time.Duration(n) * time.Millisecond
 				i += 2
 				continue

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -2125,6 +2125,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SELECT count(value), value FROM foo`, err: `mixing aggregate and non-aggregate queries is not supported`},
 		{s: `SELECT count(value)/10, value FROM foo`, err: `mixing aggregate and non-aggregate queries is not supported`},
 		{s: `SELECT count(value) FROM foo group by time(1s)`, err: `aggregate functions with GROUP BY time require a WHERE time clause`},
+		{s: `SELECT count(value) FROM foo group by time(500ms)`, err: `aggregate functions with GROUP BY time require a WHERE time clause`},
 		{s: `SELECT count(value) FROM foo group by time(1s) where host = 'hosta.influxdb.org'`, err: `aggregate functions with GROUP BY time require a WHERE time clause`},
 		{s: `SELECT count(value) FROM foo group by time`, err: `time() is a function and expects at least one argument`},
 		{s: `SELECT count(value) FROM foo group by 'time'`, err: `only time and tag dimensions allowed`},


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

A query such as `SELECT count(value) FROM cpu GROUP BY time(500ms)` will panic the parser.  This only occurs if the amount for the duration literal is greater than `1` and is `ms`.

@corylanou @jsternberg 