### PR TITLE
Allow add items to array config via ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7036](https://github.com/influxdata/influxdb/issues/7036): Switch logging to use structured logging everywhere.
 - [#3188](https://github.com/influxdata/influxdb/issues/3188): [CLI feature request] USE retention policy for queries.
 - [#7709](https://github.com/influxdata/influxdb/pull/7709): Add clear command to cli.
+- [#7323](https://github.com/influxdata/influxdb/pull/7323): Allow add items to array config via ENV
 
 ### Bugfixes
 

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -118,6 +118,9 @@ bind-address = ":8087"
 
 [[graphite]]
 protocol = "udp"
+templates = [
+  "default.* .template.in.config"
+]
 
 [[graphite]]
 protocol = "tcp"
@@ -156,6 +159,14 @@ enabled = true
 		t.Fatalf("failed to set env var: %v", err)
 	}
 
+	if err := os.Setenv("INFLUXDB_GRAPHITE_0_TEMPLATES_0", "overide.* .template.0"); err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+
+	if err := os.Setenv("INFLUXDB_GRAPHITE_1_TEMPLATES", "overide.* .template.1.1,overide.* .template.1.2"); err != nil {
+		t.Fatalf("failed to set env var: %v", err)
+	}
+
 	if err := os.Setenv("INFLUXDB_GRAPHITE_1_PROTOCOL", "udp"); err != nil {
 		t.Fatalf("failed to set env var: %v", err)
 	}
@@ -183,6 +194,14 @@ enabled = true
 
 	if c.UDPInputs[1].BindAddress != ":1234" {
 		t.Fatalf("unexpected udp bind address: %s", c.UDPInputs[1].BindAddress)
+	}
+
+	if len(c.GraphiteInputs[0].Templates) != 1 || c.GraphiteInputs[0].Templates[0] != "overide.* .template.0" {
+		t.Fatalf("unexpected graphite 0 templates: %+v", c.GraphiteInputs[0].Templates)
+	}
+
+	if len(c.GraphiteInputs[1].Templates) != 2 || c.GraphiteInputs[1].Templates[1] != "overide.* .template.1.2" {
+		t.Fatalf("unexpected graphite 1 templates: %+v", c.GraphiteInputs[1].Templates)
 	}
 
 	if c.GraphiteInputs[1].Protocol != "udp" {


### PR DESCRIPTION
Allow to create a new templates or tags configs, if there are no records
in the default config. 

Support next cases:
- Without config file:

```
$ INFLUXDB_GRAPHITE_ENABLED=true INFLUXDB_GRAPHITE_TEMPLATES="stats.* .host.measurement.cpu,system.* .host.region.measurement*" influxd config

...
[[graphite]]
  enabled = true
  bind-address = ":2003"
  database = "graphite"
  retention-policy = ""
  protocol = "tcp"
  batch-size = 5000
  batch-pending = 10
  batch-timeout = "1s"
  consistency-level = "one"
  templates = ["stats.* .host.measurement.cpu", "system.* .host.region.measurement*"]
  separator = "."
  udp-read-buffer = 0

....
```
- With specified template rule:

``` toml
[[graphite]]
  enabled = true
  templates = ["stats-config.* .host.measurement.cpu"]
```

``` bash
$ INFLUXDB_GRAPHITE_ENABLED=true INFLUXDB_GRAPHITE_0_TEMPLATES_0="stats-over.* .host.measurement.cpu" influxd config
...
[[graphite]]
  enabled = true
  bind-address = ":2003"
  database = "graphite"
  retention-policy = ""
  protocol = "tcp"
  batch-size = 5000
  batch-pending = 10
  batch-timeout = "1s"
  consistency-level = "one"
  templates = ["stats-over.* .host.measurement.cpu"]
  separator = "."
  udp-read-buffer = 0

....
```

As you see from the first example `INFLUXDB_GRAPHITE_TEMPLATES` separate rules by `,`.

Fixes: https://github.com/influxdata/influxdb/issues/6943
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
###### Required only if applicable

_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [x] Provide example syntax
