### PR TITLE
Avoid stat syscall when planning compactions

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -458,9 +458,8 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) []CompactionGroup {
 // findGenerations groups all the TSM files by they generation based
 // on their filename then returns the generations in descending order (newest first)
 func (c *DefaultPlanner) findGenerations() tsmGenerations {
-	generations := map[int]*tsmGeneration{}
-
 	tsmStats := c.FileStore.Stats()
+	generations := make(map[int]*tsmGeneration, len(tsmStats))
 	for _, f := range tsmStats {
 		gen, _, _ := ParseTSMFileName(f.Path)
 

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -1174,9 +1174,9 @@ func (m *mmapAccessor) readAll(key string) ([]Value, error) {
 
 func (m *mmapAccessor) path() string {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return m.f.Name()
+	path := m.f.Name()
+	m.mu.RUnlock()
+	return path
 }
 
 func (m *mmapAccessor) close() error {

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -24,11 +24,33 @@ func TestTombstoner_Add(t *testing.T) {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
 
+	stats := ts.TombstoneFiles()
+	if got, exp := len(stats), 0; got != exp {
+		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
+	}
+
 	ts.Add([]string{"foo"})
 
 	entries, err = ts.ReadAll()
 	if err != nil {
 		fatal(t, "ReadAll", err)
+	}
+
+	stats = ts.TombstoneFiles()
+	if got, exp := len(stats), 1; got != exp {
+		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if stats[0].Size == 0 {
+		t.Fatalf("got size %v, exp > 0", stats[0].Size)
+	}
+
+	if stats[0].LastModified == 0 {
+		t.Fatalf("got lastModified %v, exp > 0", stats[0].LastModified)
+	}
+
+	if stats[0].Path == "" {
+		t.Fatalf("got path %v, exp != ''", stats[0].Path)
 	}
 
 	if got, exp := len(entries), 1; got != exp {
@@ -83,6 +105,12 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
+
+	stats := ts.TombstoneFiles()
+	if got, exp := len(stats), 0; got != exp {
+		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
+	}
+
 }
 
 func TestTombstoner_Delete(t *testing.T) {
@@ -111,6 +139,11 @@ func TestTombstoner_Delete(t *testing.T) {
 
 	if err := ts.Delete(); err != nil {
 		fatal(t, "delete tombstone", err)
+	}
+
+	stats := ts.TombstoneFiles()
+	if got, exp := len(stats), 0; got != exp {
+		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
 	}
 
 	ts = &tsm1.Tombstoner{Path: f.Name()}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

When the planner runs, it needs to determine if any files have tombstones.
The code to determine if a tombstone existed involved stating the .tombstone
file.  Since the planner runs very frequently and when there are many shards, this
causes a lot of system calls that are unnecessary.

Instead, cache the results of the stats calls and only refresh them when we
haven't checked at least once or we write new tombstone data.

This also caches the results of the TSMReader.Stats call to avoid creating
garbage.