### PR TITLE
Implement and use zero-alloc FNV64a.

### DIFF
--- a/models/inline_fnv.go
+++ b/models/inline_fnv.go
@@ -1,0 +1,27 @@
+package models // import "github.com/influxdata/influxdb/models"
+
+// from stdlib hash/fnv/fnv.go
+const (
+	prime64  = 1099511628211
+	offset64 = 14695981039346656037
+)
+
+// InlineFNV64a is an alloc-free port of the standard library's fnv64a.
+type InlineFNV64a uint64
+
+func NewInlineFNV64a() InlineFNV64a {
+	return offset64
+}
+
+func (s *InlineFNV64a) Write(data []byte) (int, error) {
+	hash := uint64(*s)
+	for _, c := range data {
+		hash ^= uint64(c)
+		hash *= prime64
+	}
+	*s = InlineFNV64a(hash)
+	return len(data), nil
+}
+func (s *InlineFNV64a) Sum64() uint64 {
+	return uint64(*s)
+}

--- a/models/inline_fnv_test.go
+++ b/models/inline_fnv_test.go
@@ -1,0 +1,29 @@
+package models_test
+
+import (
+	"hash/fnv"
+	"testing"
+	"testing/quick"
+
+	"github.com/influxdata/influxdb/models"
+)
+
+func TestInlineFNV64aEquivalenceFuzz(t *testing.T) {
+	f := func(data []byte) bool {
+		stdlibFNV := fnv.New64a()
+		stdlibFNV.Write(data)
+		want := stdlibFNV.Sum64()
+
+		inlineFNV := models.NewInlineFNV64a()
+		inlineFNV.Write(data)
+		got := inlineFNV.Sum64()
+
+		return want == got
+	}
+	cfg := &quick.Config{
+		MaxCount: 10000,
+	}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/models/points.go
+++ b/models/points.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"math"
 	"sort"
 	"strconv"
@@ -1445,7 +1444,7 @@ func (p *point) unmarshalBinary() Fields {
 }
 
 func (p *point) HashID() uint64 {
-	h := fnv.New64a()
+	h := NewInlineFNV64a()
 	h.Write(p.key)
 	sum := h.Sum64()
 	return sum

--- a/models/rows.go
+++ b/models/rows.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"hash/fnv"
 	"sort"
 )
 
@@ -20,7 +19,7 @@ func (r *Row) SameSeries(o *Row) bool {
 
 // tagsHash returns a hash of tag key/value pairs.
 func (r *Row) tagsHash() uint64 {
-	h := fnv.New64a()
+	h := NewInlineFNV64a()
 	keys := r.tagsKeys()
 	for _, k := range keys {
 		h.Write([]byte(k))


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

+ Remove a heap alloc in (Point).HashID() and (Row).tagsHash() (According to `-gcflags -m`).
+ Direct port from the stdlib.
+ Fuzz test for equivalence to stdlib version.
+ Save one alloc per line when writing with the bulk protocol.