### PR TITLE
Zero-alloc wrappers for strconv.Parse{Int,Float}

### DIFF
--- a/models/inline_strconv_parse.go
+++ b/models/inline_strconv_parse.go
@@ -1,0 +1,33 @@
+package models // import "github.com/influxdata/influxdb/models"
+
+import (
+	"reflect"
+	"strconv"
+	"unsafe"
+)
+
+// ParseIntBytes is a zero-alloc wrapper around strconv.ParseInt.
+func ParseIntBytes(b []byte, base int, bitSize int) (i int64, err error) {
+	s := unsafeBytesToString(b)
+	return strconv.ParseInt(s, base, bitSize)
+}
+
+// ParseFloatBytes is a zero-alloc wrapper around strconv.ParseFloat.
+func ParseFloatBytes(b []byte, bitSize int) (float64, error) {
+	s := unsafeBytesToString(b)
+	return strconv.ParseFloat(s, bitSize)
+}
+
+// unsafeBytesToString converts a []byte to a string without a heap allocation.
+//
+// It is unsafe, and is intended to prepare input to short-lived functions
+// that require strings.
+func unsafeBytesToString(in []byte) string {
+	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
+	dst := reflect.StringHeader{
+		Data: src.Data,
+		Len:  src.Len,
+	}
+	s := *(*string)(unsafe.Pointer(&dst))
+	return s
+}

--- a/models/inline_strconv_parse_test.go
+++ b/models/inline_strconv_parse_test.go
@@ -31,7 +31,40 @@ func TestParseIntBytesEquivalenceFuzz(t *testing.T) {
 		return pred
 	}
 	cfg := &quick.Config{
-		MaxCount: 100000,
+		MaxCount: 10000,
+	}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseIntBytesValid64bitBase10EquivalenceFuzz(t *testing.T) {
+	buf := []byte{}
+	f := func(n int64) bool {
+		buf = strconv.AppendInt(buf[:0], n, 10)
+
+		wantI, wantErr := strconv.ParseInt(string(buf), 10, 64)
+		gotI, gotErr := models.ParseIntBytes(buf, 10, 64)
+
+		pred := wantI == gotI
+
+		// error objects are heap allocated so naive equality checking
+		// won't work here. naive pointer dereferencing will panic
+		// in the case of a nil error.
+		if wantErr != nil && gotErr == nil {
+			pred = false
+		} else if wantErr == nil && gotErr != nil {
+			pred = false
+		} else if wantErr != nil && gotErr != nil {
+			if wantErr.Error() != gotErr.Error() {
+				pred = false
+			}
+		}
+
+		return pred
+	}
+	cfg := &quick.Config{
+		MaxCount: 10000,
 	}
 	if err := quick.Check(f, cfg); err != nil {
 		t.Fatal(err)
@@ -61,7 +94,40 @@ func TestParseFloatBytesEquivalenceFuzz(t *testing.T) {
 		return pred
 	}
 	cfg := &quick.Config{
-		MaxCount: 100000,
+		MaxCount: 10000,
+	}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseFloatBytesValid64bitEquivalenceFuzz(t *testing.T) {
+	buf := []byte{}
+	f := func(n float64) bool {
+		buf = strconv.AppendFloat(buf[:0], n, 'f', -1, 64)
+
+		wantI, wantErr := strconv.ParseFloat(string(buf), 64)
+		gotI, gotErr := models.ParseFloatBytes(buf, 64)
+
+		pred := wantI == gotI
+
+		// error objects are heap allocated so naive equality checking
+		// won't work here. naive pointer dereferencing will panic
+		// in the case of a nil error.
+		if wantErr != nil && gotErr == nil {
+			pred = false
+		} else if wantErr == nil && gotErr != nil {
+			pred = false
+		} else if wantErr != nil && gotErr != nil {
+			if wantErr.Error() != gotErr.Error() {
+				pred = false
+			}
+		}
+
+		return pred
+	}
+	cfg := &quick.Config{
+		MaxCount: 10000,
 	}
 	if err := quick.Check(f, cfg); err != nil {
 		t.Fatal(err)

--- a/models/inline_strconv_parse_test.go
+++ b/models/inline_strconv_parse_test.go
@@ -1,0 +1,69 @@
+package models_test
+
+import (
+	"strconv"
+	"testing"
+	"testing/quick"
+
+	"github.com/influxdata/influxdb/models"
+)
+
+func TestParseIntBytesEquivalenceFuzz(t *testing.T) {
+	f := func(b []byte, base int, bitSize int) bool {
+		wantI, wantErr := strconv.ParseInt(string(b), base, bitSize)
+		gotI, gotErr := models.ParseIntBytes(b, base, bitSize)
+
+		pred := wantI == gotI
+
+		// error objects are heap allocated so naive equality checking
+		// won't work here. naive pointer dereferencing will panic
+		// in the case of a nil error.
+		if wantErr != nil && gotErr == nil {
+			pred = false
+		} else if wantErr == nil && gotErr != nil {
+			pred = false
+		} else if wantErr != nil && gotErr != nil {
+			if wantErr.Error() != gotErr.Error() {
+				pred = false
+			}
+		}
+
+		return pred
+	}
+	cfg := &quick.Config{
+		MaxCount: 100000,
+	}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseFloatBytesEquivalenceFuzz(t *testing.T) {
+	f := func(b []byte, bitSize int) bool {
+		wantI, wantErr := strconv.ParseFloat(string(b), bitSize)
+		gotI, gotErr := models.ParseFloatBytes(b, bitSize)
+
+		pred := wantI == gotI
+
+		// error objects are heap allocated so naive equality checking
+		// won't work here. naive pointer dereferencing will panic
+		// in the case of a nil error.
+		if wantErr != nil && gotErr == nil {
+			pred = false
+		} else if wantErr == nil && gotErr != nil {
+			pred = false
+		} else if wantErr != nil && gotErr != nil {
+			if wantErr.Error() != gotErr.Error() {
+				pred = false
+			}
+		}
+
+		return pred
+	}
+	cfg := &quick.Config{
+		MaxCount: 100000,
+	}
+	if err := quick.Check(f, cfg); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/models/points.go
+++ b/models/points.go
@@ -260,7 +260,7 @@ func parsePoint(buf []byte, defaultTime time.Time, precision string) (Point, err
 		pt.time = defaultTime
 		pt.SetPrecision(precision)
 	} else {
-		ts, err := strconv.ParseInt(string(ts), 10, 64)
+		ts, err := ParseIntBytes(ts, 10, 64)
 		if err != nil {
 			return nil, err
 		}
@@ -797,14 +797,14 @@ func scanNumber(buf []byte, i int) (int, error) {
 		// Parse the int to check bounds the number of digits could be larger than the max range
 		// We subtract 1 from the index to remove the `i` from our tests
 		if len(buf[start:i-1]) >= maxInt64Digits || len(buf[start:i-1]) >= minInt64Digits {
-			if _, err := strconv.ParseInt(string(buf[start:i-1]), 10, 64); err != nil {
+			if _, err := ParseIntBytes(buf[start:i-1], 10, 64); err != nil {
 				return i, fmt.Errorf("unable to parse integer %s: %s", buf[start:i-1], err)
 			}
 		}
 	} else {
 		// Parse the float to check bounds if it's scientific or the number of digits could be larger than the max range
 		if scientific || len(buf[start:i]) >= maxFloat64Digits || len(buf[start:i]) >= minFloat64Digits {
-			if _, err := strconv.ParseFloat(string(buf[start:i]), 10); err != nil {
+			if _, err := ParseFloatBytes(buf[start:i], 10); err != nil {
 				return i, fmt.Errorf("invalid float")
 			}
 		}
@@ -1638,18 +1638,18 @@ type Fields map[string]interface{}
 func parseNumber(val []byte) (interface{}, error) {
 	if val[len(val)-1] == 'i' {
 		val = val[:len(val)-1]
-		return strconv.ParseInt(string(val), 10, 64)
+		return ParseIntBytes(val, 10, 64)
 	}
 	for i := 0; i < len(val); i++ {
 		// If there is a decimal or an N (NaN), I (Inf), parse as float
 		if val[i] == '.' || val[i] == 'N' || val[i] == 'n' || val[i] == 'I' || val[i] == 'i' || val[i] == 'e' {
-			return strconv.ParseFloat(string(val), 64)
+			return ParseFloatBytes(val, 64)
 		}
 		if val[i] < '0' && val[i] > '9' {
 			return string(val), nil
 		}
 	}
-	return strconv.ParseFloat(string(val), 64)
+	return ParseFloatBytes(val, 64)
 }
 
 func newFieldsFromBinary(buf []byte) Fields {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

+ Reduces short-lived heap allocs during value parsing.
+ Fuzz tests to verify equivalence to stdlib functions.