### PR TITLE
Use go 1.6 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ clone_folder: c:\gopath\src\github.com\influxdata\influxdb
 # Environment variables
 environment:
   #AppVeyor has go 1.6 as default go environment
-  GOROOT: C:\go
+  GOROOT: C:\go16
   GOPATH: C:\gopath
 
 # Scripts that run after cloning repository
@@ -28,10 +28,10 @@ install:
  - cd C:\gopath\src\github.com\influxdata\influxdb
  - gdm restore
 
-# To run your custom scripts instead of automatic MSBuild 
+# To run your custom scripts instead of automatic MSBuild
 build_script:
  - go get -t -v ./...
  - go test -race -v ./...
- 
+
 # To disable deployment
 deploy: off


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass


Seems the default has switched to 1.7, but we still use go 1.6.