### PR TITLE
Remove a few short-lived string allocs.

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -61,7 +61,6 @@ var (
 var (
 	// Static objects to prevent small allocs.
 	staticTimeByteSlice = []byte("time")
-	staticTimeString    = "time"
 )
 
 // A ShardError implements the error interface, and contains extra
@@ -478,9 +477,9 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 		}
 
 		fields := p.Fields()
-		if _, ok := fields[staticTimeString]; ok {
+		if _, ok := fields["time"]; ok {
 			s.logger.Printf("dropping field 'time' from '%s'\n", p.PrecisionString(""))
-			delete(fields, staticTimeString)
+			delete(fields, "time")
 
 			if len(fields) == 0 {
 				continue

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -60,7 +60,7 @@ var (
 
 var (
 	// Static objects to prevent small allocs.
-	staticTimeByteSlice = []byte("time")
+	timeTag = []byte("time")
 )
 
 // A ShardError implements the error interface, and contains extra
@@ -470,9 +470,9 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 	for _, p := range points {
 		// verify the tags and fields
 		tags := p.Tags()
-		if v := tags.Get(staticTimeByteSlice); v != nil {
+		if v := tags.Get(timeTag); v != nil {
 			s.logger.Printf("dropping tag 'time' from '%s'\n", p.PrecisionString(""))
-			tags.Delete(staticTimeByteSlice)
+			tags.Delete(timeTag)
 			p.SetTags(tags)
 		}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

(*tsdb.Shard).validateSeriesAndFields uses fewer string allocs in some hot spots.