### PR TITLE
reuse cache function write

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -231,10 +231,10 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 	}
 	c.mu.RUnlock()
 
-	for k, v := range values {
-		c.entry(k).add(v)
-	}
 	c.mu.Lock()
+	for k, v := range values {
+		c.write(k, v)
+	}
 	c.size += uint64(totalSz)
 	c.mu.Unlock()
 


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

reuse cache function write in WriteMulti, make it more graceful.

func `Cache.Write` use write, why `Cache.WriteMulti` dont use it ?