### PR TITLE
fix failing vet issue in test

### DIFF
--- a/models/points_test.go
+++ b/models/points_test.go
@@ -68,7 +68,7 @@ func TestPoint_AppendString(t *testing.T) {
 
 func testPoint_cube(t *testing.T, f func(p models.Point)) {
 	// heard of a table-driven test? let's make a cube-driven test...
-	tagList := []models.Tags{nil, {{[]byte("foo"), []byte("bar")}}, tags}
+	tagList := []models.Tags{nil, {models.Tag{Key: []byte("foo"), Value: []byte("bar")}}, tags}
 	fieldList := []models.Fields{{"a": 42.0}, {"a": 42, "b": "things"}, fields}
 	timeList := []time.Time{time.Time{}, time.Unix(0, 0), time.Unix(-34526, 0), time.Unix(231845, 0), time.Now()}
 


### PR DESCRIPTION
Fixing spurious go vet issue.

```
$ go vet ./...
models/points_test.go:71: github.com/influxdata/influxdb/models.Tag composite literal uses unkeyed fields
exit status 1
```

I'm running 1.7, and this may be the cause, but either way, it's a valid fix.

Self merging on green as it's a test only vet fix.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

