### PR TITLE
Fix data race in *tsdb.Shard write path.

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -490,7 +490,12 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 		ss := s.index.SeriesBytes(p.Key())
 		if ss == nil {
 			key := string(p.Key())
-			if s.options.Config.MaxSeriesPerDatabase > 0 && len(s.index.series)+1 > s.options.Config.MaxSeriesPerDatabase {
+
+			s.index.mu.RLock()
+			indexSeriesLen := len(s.index.series)
+			s.index.mu.RUnlock()
+
+			if s.options.Config.MaxSeriesPerDatabase > 0 && indexSeriesLen+1 > s.options.Config.MaxSeriesPerDatabase {
 				return nil, fmt.Errorf("max series per database exceeded: %s", key)
 			}
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -490,12 +490,7 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 		ss := s.index.SeriesBytes(p.Key())
 		if ss == nil {
 			key := string(p.Key())
-
-			s.index.mu.RLock()
-			indexSeriesLen := len(s.index.series)
-			s.index.mu.RUnlock()
-
-			if s.options.Config.MaxSeriesPerDatabase > 0 && indexSeriesLen+1 > s.options.Config.MaxSeriesPerDatabase {
+			if s.options.Config.MaxSeriesPerDatabase > 0 && s.index.SeriesN()+1 > s.options.Config.MaxSeriesPerDatabase {
 				return nil, fmt.Errorf("max series per database exceeded: %s", key)
 			}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Ensure that the Shard's Index is read-locked before calculating the count of its constituent series.

The condition that consistently triggered this race condition is a database drop followed by a bulk write (which created the same database again).