### PR TITLE
Ensure correct shard groups created when RP has been altered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## v1.0.2 [unreleased]
 
-## Bugfixes
+### Bugfixes
 
 - [#7150](https://github.com/influxdata/influxdb/issues/7150): Do not automatically reset the shard duration when using ALTER RETENTION POLICY
+- [#5878](https://github.com/influxdata/influxdb/issues/5878): Ensure correct shard groups created when retention policy has been altered.
+
 
 ## v1.0.1 [2016-09-26]
 

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -195,10 +196,6 @@ func (w *PointsWriter) Statistics(tags map[string]string) []models.Statistic {
 // maps to a shard group or shard that does not currently exist, it will be
 // created before returning the mapping.
 func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) {
-
-	// holds the start time ranges for required shard groups
-	timeRanges := map[time.Time]*meta.ShardGroupInfo{}
-
 	rp, err := w.MetaClient.RetentionPolicy(wp.Database, wp.RetentionPolicy)
 	if err != nil {
 		return nil, err
@@ -206,44 +203,81 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 		return nil, influxdb.ErrRetentionPolicyNotFound(wp.RetentionPolicy)
 	}
 
-	// Find the minimum time for a point if the retention policy has a shard
-	// group duration. We will automatically drop any points before this time.
-	// There is a chance of a time on the edge of the shard group duration to
-	// sneak through even after it has been removed, but the circumstances are
-	// rare enough and don't matter enough that we don't account for this
-	// edge case.
+	// Holds all the shard groups and shards that are required for writes.
+	list := make(sgList, 0, 8)
 	min := time.Unix(0, models.MinNanoTime)
 	if rp.Duration > 0 {
 		min = time.Now().Add(-rp.Duration)
 	}
 
 	for _, p := range wp.Points {
-		if p.Time().Before(min) {
+		// Either the point is outside the scope of the RP, or we already have
+		// a suitable shard group for the point.
+		if p.Time().Before(min) || list.Covers(p.Time()) {
 			continue
 		}
-		timeRanges[p.Time().Truncate(rp.ShardGroupDuration)] = nil
-	}
 
-	// holds all the shard groups and shards that are required for writes
-	for t := range timeRanges {
-		sg, err := w.MetaClient.CreateShardGroup(wp.Database, wp.RetentionPolicy, t)
+		// No shard groups overlap with the point's time, so we will create
+		// a new shard group for this point.
+		sg, err := w.MetaClient.CreateShardGroup(wp.Database, wp.RetentionPolicy, p.Time())
 		if err != nil {
 			return nil, err
 		}
-		timeRanges[t] = sg
+
+		if sg == nil {
+			return nil, errors.New("nil shard group")
+		}
+		list = list.Append(*sg)
 	}
 
 	mapping := NewShardMapping()
 	for _, p := range wp.Points {
-		sg, ok := timeRanges[p.Time().Truncate(rp.ShardGroupDuration)]
-		if !ok {
+		sg := list.ShardGroupAt(p.Time())
+		if sg == nil {
+			// We didn't create a shard group because the point was outside the
+			// scope of the RP.
 			atomic.AddInt64(&w.stats.WriteDropped, 1)
 			continue
 		}
+
 		sh := sg.ShardFor(p.HashID())
 		mapping.MapPoint(&sh, p)
 	}
 	return mapping, nil
+}
+
+// sgList is a wrapper around a meta.ShardGroupInfos where we can also check
+// if a given time is covered by any of the shard groups in the list.
+type sgList meta.ShardGroupInfos
+
+func (l sgList) Covers(t time.Time) bool {
+	if len(l) == 0 {
+		return false
+	}
+	return l.ShardGroupAt(t) != nil
+}
+
+func (l sgList) ShardGroupAt(t time.Time) *meta.ShardGroupInfo {
+	// Attempt to find a shard group that could contain this point.
+	// Shard groups are sorted first according to end time, and then according
+	// to start time. Therefore, if there are multiple shard groups that match
+	// this point's time they will be preferred in this order:
+	//
+	//  - a shard group with the earliest end time;
+	//  - (assuming identical end times) the shard group with the earliest start
+	//    time.
+	idx := sort.Search(len(l), func(i int) bool { return l[i].EndTime.After(t) })
+	if idx == len(l) {
+		return nil
+	}
+	return &l[idx]
+}
+
+// Append appends a shard group to the list, and returns a sorted list.
+func (l sgList) Append(sgi meta.ShardGroupInfo) sgList {
+	next := append(l, sgi)
+	sort.Sort(meta.ShardGroupInfos(next))
+	return next
 }
 
 // WritePointsInto is a copy of WritePoints that uses a tsdb structure instead of

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1123,9 +1123,25 @@ type ShardGroupInfo struct {
 // on the StartTime field.
 type ShardGroupInfos []ShardGroupInfo
 
-func (a ShardGroupInfos) Len() int           { return len(a) }
-func (a ShardGroupInfos) Less(i, j int) bool { return a[i].StartTime.Before(a[j].StartTime) }
-func (a ShardGroupInfos) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ShardGroupInfos) Len() int      { return len(a) }
+func (a ShardGroupInfos) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a ShardGroupInfos) Less(i, j int) bool {
+	iEnd := a[i].EndTime
+	if a[i].Truncated() {
+		iEnd = a[i].TruncatedAt
+	}
+
+	jEnd := a[j].EndTime
+	if a[j].Truncated() {
+		jEnd = a[j].TruncatedAt
+	}
+
+	if iEnd.Equal(jEnd) {
+		return a[i].StartTime.Before(a[j].StartTime)
+	}
+
+	return iEnd.Before(jEnd)
+}
 
 // Contains return true if the shard group contains data for the timestamp.
 func (sgi *ShardGroupInfo) Contains(timestamp time.Time) bool {

--- a/services/meta/data_test.go
+++ b/services/meta/data_test.go
@@ -2,6 +2,8 @@ package meta
 
 import (
 	"reflect"
+	"sort"
+	"time"
 
 	"testing"
 )
@@ -27,5 +29,28 @@ func TestnewShardOwner(t *testing.T) {
 	// The ownership frequencies are updated.
 	if got, exp := ownerFreqs, map[int]int{1: 15, 2: 12, 3: 12}; !reflect.DeepEqual(got, exp) {
 		t.Errorf("got owner frequencies %v, expected %v", got, exp)
+	}
+}
+
+func TestShardGroupSort(t *testing.T) {
+	sg1 := ShardGroupInfo{
+		ID:          1,
+		StartTime:   time.Unix(1000, 0),
+		EndTime:     time.Unix(1100, 0),
+		TruncatedAt: time.Unix(1050, 0),
+	}
+
+	sg2 := ShardGroupInfo{
+		ID:        2,
+		StartTime: time.Unix(1000, 0),
+		EndTime:   time.Unix(1100, 0),
+	}
+
+	sgs := ShardGroupInfos{sg2, sg1}
+
+	sort.Sort(sgs)
+
+	if sgs[len(sgs)-1].ID != 2 {
+		t.Fatal("unstable sort for ShardGroupInfos")
 	}
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #5878.

Previously point times were truncated to the shard group duration before determining the correct shard group for the point. This meant, however, that if the shard duration of the retention policy was extended, then a new point could be truncated to a time within the boundary of a previous shard group, rather than be added to a new shard group.

This PR ensures creates shard groups based on a point's exact time, rather than truncating it, and determine which shard group a point belongs to with the following preferences:

 1. the shard group that has the earliest end time where `point_time` is also in the domain `[start_time, end_time)` for the shard group.
 2. or, in the case that multiple shard groups have equal end times, the shard group with the earliest `start_time`, subject to `point_time` falling into the domain described in (1).

@jwilder @joelegasse 

/cc @beckettsean 