### PR TITLE
Gotos to simplify uses of the new encoder pools.

### DIFF
--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -230,7 +230,7 @@ func (f *FloatValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.value)
 }
 
-func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
+func encodeFloatBlock(buf []byte, values []Value) (b []byte, err error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
@@ -251,27 +251,27 @@ func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 	}
 	venc.Finish()
 
+	var tb, vb []byte
+
 	// Encoded timestamp values
-	tb, err := tsenc.Bytes()
+	tb, err = tsenc.Bytes()
 	if err != nil {
-		putTimeEncoder(tsenc)
-		putFloatEncoder(venc)
-		return nil, err
+		goto cleanup
 	}
 	// Encoded float values
-	vb, err := venc.Bytes()
+	vb, err = venc.Bytes()
 	if err != nil {
-		putTimeEncoder(tsenc)
-		putFloatEncoder(venc)
-		return nil, err
+		goto cleanup
 	}
 
 	// Prepend the first timestamp of the block in the first 8 bytes and the block
 	// in the next byte, followed by the block
-	b := packBlock(buf, BlockFloat64, tb, vb)
+	b = packBlock(buf, BlockFloat64, tb, vb)
+
+cleanup:
 	putTimeEncoder(tsenc)
 	putFloatEncoder(venc)
-	return b, nil
+	return
 
 }
 
@@ -342,7 +342,7 @@ func (f *BooleanValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
-func encodeBooleanBlock(buf []byte, values []Value) ([]byte, error) {
+func encodeBooleanBlock(buf []byte, values []Value) (b []byte, err error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
@@ -359,27 +359,27 @@ func encodeBooleanBlock(buf []byte, values []Value) ([]byte, error) {
 		venc.Write(v.(*BooleanValue).value)
 	}
 
+	var tb, vb []byte
+
 	// Encoded timestamp values
-	tb, err := tsenc.Bytes()
+	tb, err = tsenc.Bytes()
 	if err != nil {
-		putTimeEncoder(tsenc)
-		putBooleanEncoder(venc)
-		return nil, err
+		goto cleanup
 	}
 	// Encoded float values
-	vb, err := venc.Bytes()
+	vb, err = venc.Bytes()
 	if err != nil {
-		putTimeEncoder(tsenc)
-		putBooleanEncoder(venc)
-		return nil, err
+		goto cleanup
 	}
 
 	// Prepend the first timestamp of the block in the first 8 bytes and the block
 	// in the next byte, followed by the block
-	b := packBlock(buf, BlockBoolean, tb, vb)
+	b = packBlock(buf, BlockBoolean, tb, vb)
+
+cleanup:
 	putTimeEncoder(tsenc)
 	putBooleanEncoder(venc)
-	return b, nil
+	return
 }
 
 func DecodeBooleanBlock(block []byte, tdec *TimeDecoder, vdec *BooleanDecoder, a *[]BooleanValue) ([]BooleanValue, error) {
@@ -447,7 +447,7 @@ func (f *IntegerValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
-func encodeIntegerBlock(buf []byte, values []Value) ([]byte, error) {
+func encodeIntegerBlock(buf []byte, values []Value) (b []byte, err error) {
 	tsEnc := getTimeEncoder(len(values))
 	vEnc := getIntegerEncoder(len(values))
 
@@ -456,26 +456,26 @@ func encodeIntegerBlock(buf []byte, values []Value) ([]byte, error) {
 		vEnc.Write(v.(*IntegerValue).value)
 	}
 
+	var tb, vb []byte
+
 	// Encoded timestamp values
-	tb, err := tsEnc.Bytes()
+	tb, err = tsEnc.Bytes()
 	if err != nil {
-		putTimeEncoder(tsEnc)
-		putIntegerEncoder(vEnc)
-		return nil, err
+		goto cleanup
 	}
 	// Encoded int64 values
-	vb, err := vEnc.Bytes()
+	vb, err = vEnc.Bytes()
 	if err != nil {
-		putTimeEncoder(tsEnc)
-		putIntegerEncoder(vEnc)
-		return nil, err
+		goto cleanup
 	}
 
 	// Prepend the first timestamp of the block in the first 8 bytes
-	b := packBlock(buf, BlockInteger, tb, vb)
+	b = packBlock(buf, BlockInteger, tb, vb)
+
+cleanup:
 	putTimeEncoder(tsEnc)
 	putIntegerEncoder(vEnc)
-	return b, nil
+	return
 }
 
 func DecodeIntegerBlock(block []byte, tdec *TimeDecoder, vdec *IntegerDecoder, a *[]IntegerValue) ([]IntegerValue, error) {
@@ -544,7 +544,7 @@ func (f *StringValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
-func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
+func encodeStringBlock(buf []byte, values []Value) (b []byte, err error) {
 	tsEnc := getTimeEncoder(len(values))
 	vEnc := getStringEncoder(len(values) * len(values[0].(*StringValue).value))
 
@@ -553,26 +553,26 @@ func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
 		vEnc.Write(v.(*StringValue).value)
 	}
 
+	var tb, vb []byte
+
 	// Encoded timestamp values
-	tb, err := tsEnc.Bytes()
+	tb, err = tsEnc.Bytes()
 	if err != nil {
-		putTimeEncoder(tsEnc)
-		putStringEncoder(vEnc)
-		return nil, err
+		goto cleanup
 	}
 	// Encoded string values
-	vb, err := vEnc.Bytes()
+	vb, err = vEnc.Bytes()
 	if err != nil {
-		putTimeEncoder(tsEnc)
-		putStringEncoder(vEnc)
-		return nil, err
+		goto cleanup
 	}
 
 	// Prepend the first timestamp of the block in the first 8 bytes
-	b := packBlock(buf, BlockString, tb, vb)
+	b = packBlock(buf, BlockString, tb, vb)
+
+cleanup:
 	putTimeEncoder(tsEnc)
 	putStringEncoder(vEnc)
-	return b, nil
+	return
 }
 
 func DecodeStringBlock(block []byte, tdec *TimeDecoder, vdec *StringDecoder, a *[]StringValue) ([]StringValue, error) {

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -230,7 +230,7 @@ func (f *FloatValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.value)
 }
 
-func encodeFloatBlock(buf []byte, values []Value) (b []byte, err error) {
+func encodeFloatBlock(buf []byte, values []Value) ([]byte, err error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
@@ -251,7 +251,8 @@ func encodeFloatBlock(buf []byte, values []Value) (b []byte, err error) {
 	}
 	venc.Finish()
 
-	var tb, vb []byte
+	var err error
+	var b, tb, vb []byte
 
 	// Encoded timestamp values
 	tb, err = tsenc.Bytes()
@@ -271,7 +272,7 @@ func encodeFloatBlock(buf []byte, values []Value) (b []byte, err error) {
 cleanup:
 	putTimeEncoder(tsenc)
 	putFloatEncoder(venc)
-	return
+	return b, err
 
 }
 
@@ -342,7 +343,7 @@ func (f *BooleanValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
-func encodeBooleanBlock(buf []byte, values []Value) (b []byte, err error) {
+func encodeBooleanBlock(buf []byte, values []Value) ([]byte, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
@@ -359,7 +360,8 @@ func encodeBooleanBlock(buf []byte, values []Value) (b []byte, err error) {
 		venc.Write(v.(*BooleanValue).value)
 	}
 
-	var tb, vb []byte
+	var err error
+	var b, tb, vb []byte
 
 	// Encoded timestamp values
 	tb, err = tsenc.Bytes()
@@ -379,7 +381,7 @@ func encodeBooleanBlock(buf []byte, values []Value) (b []byte, err error) {
 cleanup:
 	putTimeEncoder(tsenc)
 	putBooleanEncoder(venc)
-	return
+	return b, err
 }
 
 func DecodeBooleanBlock(block []byte, tdec *TimeDecoder, vdec *BooleanDecoder, a *[]BooleanValue) ([]BooleanValue, error) {
@@ -447,7 +449,7 @@ func (f *IntegerValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
-func encodeIntegerBlock(buf []byte, values []Value) (b []byte, err error) {
+func encodeIntegerBlock(buf []byte, values []Value) ([]byte, error) {
 	tsEnc := getTimeEncoder(len(values))
 	vEnc := getIntegerEncoder(len(values))
 
@@ -456,7 +458,8 @@ func encodeIntegerBlock(buf []byte, values []Value) (b []byte, err error) {
 		vEnc.Write(v.(*IntegerValue).value)
 	}
 
-	var tb, vb []byte
+	var err error
+	var b, tb, vb []byte
 
 	// Encoded timestamp values
 	tb, err = tsEnc.Bytes()
@@ -475,7 +478,7 @@ func encodeIntegerBlock(buf []byte, values []Value) (b []byte, err error) {
 cleanup:
 	putTimeEncoder(tsEnc)
 	putIntegerEncoder(vEnc)
-	return
+	return b, err
 }
 
 func DecodeIntegerBlock(block []byte, tdec *TimeDecoder, vdec *IntegerDecoder, a *[]IntegerValue) ([]IntegerValue, error) {
@@ -544,7 +547,7 @@ func (f *StringValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
-func encodeStringBlock(buf []byte, values []Value) (b []byte, err error) {
+func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
 	tsEnc := getTimeEncoder(len(values))
 	vEnc := getStringEncoder(len(values) * len(values[0].(*StringValue).value))
 
@@ -553,7 +556,8 @@ func encodeStringBlock(buf []byte, values []Value) (b []byte, err error) {
 		vEnc.Write(v.(*StringValue).value)
 	}
 
-	var tb, vb []byte
+	var err error
+	var b, tb, vb []byte
 
 	// Encoded timestamp values
 	tb, err = tsEnc.Bytes()
@@ -572,7 +576,7 @@ func encodeStringBlock(buf []byte, values []Value) (b []byte, err error) {
 cleanup:
 	putTimeEncoder(tsEnc)
 	putStringEncoder(vEnc)
-	return
+	return b, err
 }
 
 func DecodeStringBlock(block []byte, tdec *TimeDecoder, vdec *StringDecoder, a *[]StringValue) ([]StringValue, error) {

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -230,7 +230,7 @@ func (f *FloatValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.value)
 }
 
-func encodeFloatBlock(buf []byte, values []Value) ([]byte, err error) {
+func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

After delving into the encoding code yesterday, I'd like to make this change for maintainability. It reduces the number of code paths that have to be correct in order to reclaim resources. Put another way, this uses `goto` as a cheap `defer`.