### PR TITLE
Use encoder reset to save on allocs.

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -9,7 +9,7 @@ github.com/dgryski/go-bitstream 7d46cd22db7004f0cceb6f7975824b560cf0e486
 github.com/gogo/protobuf 0394392b81058a7f972029451f06e528bb18ba50
 github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380
 github.com/influxdata/usage-client 6d3895376368aa52a3a81d2a16e90f0f52371967
-github.com/jwilder/encoding ac74639f65b2180a2e5eb5ff197f0c122441aed0
+github.com/jwilder/encoding 4dada27c33277820fe35c7ee71ed34fbc9477d00
 github.com/kimor79/gollectd 61d0deeb4ffcc167b2a1baa8efd72365692811bc
 github.com/paulbellamy/ratecounter 5a11f585a31379765c190c033b6ad39956584447
 github.com/peterh/liner 8975875355a81d612fafb9f5a6037bdcc2d9b073

--- a/tsdb/engine/tsm1/timestamp.go
+++ b/tsdb/engine/tsm1/timestamp.go
@@ -73,7 +73,7 @@ func NewTimeEncoder(sz int) TimeEncoder {
 func (e *encoder) Reset() {
 	e.ts = e.ts[:0]
 	e.bytes = e.bytes[:0]
-	e.enc = simple8b.NewEncoder()
+	e.enc.Reset()
 }
 
 // Write adds a time.Time to the compressed stream.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Use `simple8b` encoder reset to save on allocs.

This appears to reduce 'backoff' (rejected writes) time during high-cardinality writes by approximately 50%. It should have knock-on benefits to all compactions.

(Note that this needs my patch on the simple8b library, which was just merged by @jwilder: https://github.com/jwilder/encoding/pull/6)