### PR TITLE
Add walPath tag to shard stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#7285](https://github.com/influxdata/influxdb/issues/7285): Correctly use password-type field in Admin UI. Thanks @dandv!
 - [#2792](https://github.com/influxdata/influxdb/issues/2792): Exceeding max retention policy duration gives incorrect error message
 - [#7226](https://github.com/influxdata/influxdb/issues/7226): Fix database locked up when deleting shards
+- [#7382](https://github.com/influxdata/influxdb/issues/7382): Shard stats include wal path tag so disk bytes make more sense.
 
 ## v1.0.1 [2016-09-26]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -127,6 +127,7 @@ func NewShard(id uint64, index *DatabaseIndex, path string, walPath string, opti
 		stats: &ShardStatistics{},
 		defaultTags: models.StatisticTags{
 			"path":            path,
+			"walPath":         walPath,
 			"id":              fmt.Sprintf("%d", id),
 			"database":        db,
 			"retentionPolicy": rp,


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Without the WAL path as a tag, the diskBytes field looked like it was
reporting the size of the data directory incorrectly.

Fixes #7382.