### PR TITLE
Use built-in Go 1.7 in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,17 +12,13 @@ clone_folder: c:\gopath\src\github.com\influxdata\influxdb
 
 # Environment variables
 environment:
-  #AppVeyor has go 1.6 as default go environment
-  GOROOT: C:\go16
+  GOROOT: C:\go17
   GOPATH: C:\gopath
-  GOVERSION: 1.7.1
 
 # Scripts that run after cloning repository
 install:
  - set PATH=%GOROOT%\bin;%GOPATH%\bin;%PATH%
  - rmdir c:\go /s /q
- - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.zip
- - 7z x go%GOVERSION%.windows-amd64.zip -y -oC:\ > NUL
  - echo %PATH%
  - echo %GOPATH%
  - cd C:\gopath\src\github.com\influxdata\influxdb


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

See available versions of Go at
https://www.appveyor.com/docs/installed-software/#go