### PR TITLE
Reduce query planning allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#2792](https://github.com/influxdata/influxdb/issues/2792): Exceeding max retention policy duration gives incorrect error message
 - [#7226](https://github.com/influxdata/influxdb/issues/7226): Fix database locked up when deleting shards
 - [#7382](https://github.com/influxdata/influxdb/issues/7382): Shard stats include wal path tag so disk bytes make more sense.
+- [#7385](https://github.com/influxdata/influxdb/pull/7385): Reduce query planning allocations
 
 ## v1.0.1 [2016-09-26]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2001,7 +2001,7 @@ func walkRefs(exp Expr) []VarRef {
 	case *VarRef:
 		return []VarRef{*expr}
 	case *Call:
-		var a []VarRef
+		a := make([]VarRef, 0, len(expr.Args))
 		for _, expr := range expr.Args {
 			if ref, ok := expr.(*VarRef); ok {
 				a = append(a, *ref)
@@ -2009,9 +2009,11 @@ func walkRefs(exp Expr) []VarRef {
 		}
 		return a
 	case *BinaryExpr:
-		var ret []VarRef
-		ret = append(ret, walkRefs(expr.LHS)...)
-		ret = append(ret, walkRefs(expr.RHS)...)
+		lhs := walkRefs(expr.LHS)
+		rhs := walkRefs(expr.RHS)
+		ret := make([]VarRef, 0, len(lhs)+len(rhs))
+		ret = append(ret, lhs...)
+		ret = append(ret, rhs...)
 		return ret
 	case *ParenExpr:
 		return walkRefs(expr.Expr)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated

This PR reduces allocations during query planning.  The main change is to the `Measurement.TagSets` which was creating a lot of garbage.

The `TagSets` function was creating a lot of intermediate maps and
slices to calculate the sorted tag sets.  It first creates a map
to group tag sets with their series, it then created an equally
sized slice of the tag keys and sorted them.  Finally, it created
a new slice and added the tag sets in the original map by the ordering
of the sorted keys.  It was also recreating the tags map multiple time
creating extra garbage in the loop.

This simplifies the code to create one map for grouping and than adding
the distinct sets to a slice which is then sorted.  It also fixes the
multple tag maps getting created.

This could probably be optimized further using a ordered tree data structure.

### 1.0
```
$ influx_stress
Total Queries: 250
Average Query Response Time: 65.779923ms
```

### 1.1 master
```
$ influx_stress
Total Queries: 250
Average Query Response Time: 17.209273ms
```

cc @jsternberg 