### PR TITLE
Ensure pprof-enabled config option is respected

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -81,9 +81,6 @@ func (cmd *Command) Run(args ...string) error {
 		return fmt.Errorf("write pid file: %s", err)
 	}
 
-	// Turn on block profiling to debug stuck databases
-	runtime.SetBlockProfileRate(int(1 * time.Second))
-
 	// Parse config
 	config, err := cmd.ParseConfig(options.GetConfigPath())
 	if err != nil {
@@ -98,6 +95,11 @@ func (cmd *Command) Run(args ...string) error {
 	// Validate the configuration.
 	if err := config.Validate(); err != nil {
 		return fmt.Errorf("%s. To generate a valid configuration file run `influxd config > influxdb.generated.conf`", err)
+	}
+
+	if config.HTTPD.PprofEnabled {
+		// Turn on block profiling to debug stuck databases
+		runtime.SetBlockProfileRate(int(1 * time.Second))
 	}
 
 	// Create server from config and start it.

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	AuthEnabled        bool   `toml:"auth-enabled"`
 	LogEnabled         bool   `toml:"log-enabled"`
 	WriteTracing       bool   `toml:"write-tracing"`
+	PprofEnabled       bool   `toml:"pprof-enabled"`
 	HTTPSEnabled       bool   `toml:"https-enabled"`
 	HTTPSCertificate   string `toml:"https-certificate"`
 	HTTPSPrivateKey    string `toml:"https-private-key"`
@@ -35,6 +36,7 @@ func NewConfig() Config {
 		Enabled:           true,
 		BindAddress:       DefaultBindAddress,
 		LogEnabled:        true,
+		PprofEnabled:      true,
 		HTTPSEnabled:      false,
 		HTTPSCertificate:  "/etc/ssl/influxdb.pem",
 		MaxRowLimit:       DefaultChunkSize,

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -244,8 +244,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Add version header to all InfluxDB requests.
 	w.Header().Add("X-Influxdb-Version", h.Version)
 
-	// FIXME(benbjohnson): Add pprof enabled flag.
-	if strings.HasPrefix(r.URL.Path, "/debug/pprof") {
+	if strings.HasPrefix(r.URL.Path, "/debug/pprof") && h.Config.PprofEnabled {
 		switch r.URL.Path {
 		case "/debug/pprof/cmdline":
 			pprof.Cmdline(w, r)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR ensures we respect the `pprof-enabled` config, field, and sets it to be enabled by default. If users wish, they can disable the profiling endpoints by setting `pprof-enabled = false`; they will still be able to use the profiling cli flags in that case.

Looks like this cleans up one of your `FIXME`s @benbjohnson. 

/cc @jwilder this is the other part we need for Pu.