### PR TITLE
Implement cumulative_sum() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#7268](https://github.com/influxdata/influxdb/pull/7268): More man pages for the other tools we package and compress man pages fully.
 - [#7305](https://github.com/influxdata/influxdb/pull/7305): UDP Client: Split large points. Thanks @vlasad
 - [#7115](https://github.com/influxdata/influxdb/issues/7115): Feature request: `influx inspect -export` should dump WAL files.
+- [#7388](https://github.com/influxdata/influxdb/pull/7388): Implement cumulative_sum() function.
 
 ### Bugfixes
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1643,7 +1643,7 @@ func (s *SelectStatement) validateAggregates(tr targetRequirement) error {
 	for _, f := range s.Fields {
 		for _, expr := range walkFunctionCalls(f.Expr) {
 			switch expr.Name {
-			case "derivative", "non_negative_derivative", "difference", "moving_average", "elapsed":
+			case "derivative", "non_negative_derivative", "difference", "moving_average", "cumulative_sum", "elapsed":
 				if err := s.validSelectWithAggregate(); err != nil {
 					return err
 				}
@@ -1663,9 +1663,9 @@ func (s *SelectStatement) validateAggregates(tr targetRequirement) error {
 							return errors.New("elapsed requires a duration argument")
 						}
 					}
-				case "difference":
+				case "difference", "cumulative_sum":
 					if got := len(expr.Args); got != 1 {
-						return fmt.Errorf("invalid number of arguments for difference, expected 1, got %d", got)
+						return fmt.Errorf("invalid number of arguments for %s, expected 1, got %d", expr.Name, got)
 					}
 				case "moving_average":
 					if got := len(expr.Args); got != 2 {

--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -1227,6 +1227,26 @@ func newMovingAverageIterator(input Iterator, n int, opt IteratorOptions) (Itera
 	}
 }
 
+// newCumulativeSumIterator returns an iterator for operating on a cumulative_sum() call.
+func newCumulativeSumIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
+	switch input := input.(type) {
+	case FloatIterator:
+		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
+			fn := NewFloatCumulativeSumReducer()
+			return fn, fn
+		}
+		return newFloatStreamFloatIterator(input, createFn, opt), nil
+	case IntegerIterator:
+		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
+			fn := NewIntegerCumulativeSumReducer()
+			return fn, fn
+		}
+		return newIntegerStreamIntegerIterator(input, createFn, opt), nil
+	default:
+		return nil, fmt.Errorf("unsupported cumulative sum iterator type: %T", input)
+	}
+}
+
 // newHoltWintersIterator returns an iterator for operating on a elapsed() call.
 func newHoltWintersIterator(input Iterator, opt IteratorOptions, h, m int, includeFitData bool, interval time.Duration) (Iterator, error) {
 	switch input := input.(type) {

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -357,6 +357,58 @@ func (r *IntegerMovingAverageReducer) Emit() []FloatPoint {
 	}
 }
 
+// FloatCumulativeSumReducer cumulates the values from each point.
+type FloatCumulativeSumReducer struct {
+	curr FloatPoint
+}
+
+// NewFloatCumulativeSumReducer creates a new FloatCumulativeSumReducer.
+func NewFloatCumulativeSumReducer() *FloatCumulativeSumReducer {
+	return &FloatCumulativeSumReducer{
+		curr: FloatPoint{Nil: true},
+	}
+}
+
+func (r *FloatCumulativeSumReducer) AggregateFloat(p *FloatPoint) {
+	r.curr.Value += p.Value
+	r.curr.Time = p.Time
+	r.curr.Nil = false
+}
+
+func (r *FloatCumulativeSumReducer) Emit() []FloatPoint {
+	var pts []FloatPoint
+	if !r.curr.Nil {
+		pts = []FloatPoint{r.curr}
+	}
+	return pts
+}
+
+// IntegerCumulativeSumReducer cumulates the values from each point.
+type IntegerCumulativeSumReducer struct {
+	curr IntegerPoint
+}
+
+// NewIntegerCumulativeSumReducer creates a new IntegerCumulativeSumReducer.
+func NewIntegerCumulativeSumReducer() *IntegerCumulativeSumReducer {
+	return &IntegerCumulativeSumReducer{
+		curr: IntegerPoint{Nil: true},
+	}
+}
+
+func (r *IntegerCumulativeSumReducer) AggregateInteger(p *IntegerPoint) {
+	r.curr.Value += p.Value
+	r.curr.Time = p.Time
+	r.curr.Nil = false
+}
+
+func (r *IntegerCumulativeSumReducer) Emit() []IntegerPoint {
+	var pts []IntegerPoint
+	if !r.curr.Nil {
+		pts = []IntegerPoint{r.curr}
+	}
+	return pts
+}
+
 // FloatHoltWintersReducer forecasts a series into the future.
 // This is done using the Holt-Winters damped method.
 //    1. Using the series the initial values are calculated using a SSE.

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -315,6 +315,12 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions, selec
 				return newMovingAverageIterator(input, int(n.Val), opt)
 			}
 			panic(fmt.Sprintf("invalid series aggregate function: %s", expr.Name))
+		case "cumulative_sum":
+			input, err := buildExprIterator(expr.Args[0], ic, opt, selector)
+			if err != nil {
+				return nil, err
+			}
+			return newCumulativeSumIterator(input, opt)
 		default:
 			itr, err := func() (Iterator, error) {
 				switch expr.Name {

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -2734,6 +2734,114 @@ func TestSelect_MovingAverage_Integer(t *testing.T) {
 	}
 }
 
+func TestSelect_CumulativeSum_Float(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &FloatIterator{Points: []influxql.FloatPoint{
+			{Name: "cpu", Time: 0 * Second, Value: 20},
+			{Name: "cpu", Time: 4 * Second, Value: 10},
+			{Name: "cpu", Time: 8 * Second, Value: 19},
+			{Name: "cpu", Time: 12 * Second, Value: 3},
+		}}, nil
+	}
+
+	// Execute selection.
+	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT cumulative_sum(value) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:00:16Z'`), &ic, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !deep.Equal(a, [][]influxql.Point{
+		{&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 20}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 4 * Second, Value: 30}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 8 * Second, Value: 49}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 12 * Second, Value: 52}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+}
+
+func TestSelect_CumulativeSum_Integer(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &IntegerIterator{Points: []influxql.IntegerPoint{
+			{Name: "cpu", Time: 0 * Second, Value: 20},
+			{Name: "cpu", Time: 4 * Second, Value: 10},
+			{Name: "cpu", Time: 8 * Second, Value: 19},
+			{Name: "cpu", Time: 12 * Second, Value: 3},
+		}}, nil
+	}
+
+	// Execute selection.
+	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT cumulative_sum(value) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:00:16Z'`), &ic, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 20}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 4 * Second, Value: 30}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 8 * Second, Value: 49}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 12 * Second, Value: 52}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+}
+
+func TestSelect_CumulativeSum_Duplicate_Float(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &FloatIterator{Points: []influxql.FloatPoint{
+			{Name: "cpu", Time: 0 * Second, Value: 20},
+			{Name: "cpu", Time: 0 * Second, Value: 19},
+			{Name: "cpu", Time: 4 * Second, Value: 10},
+			{Name: "cpu", Time: 4 * Second, Value: 3},
+		}}, nil
+	}
+
+	// Execute selection.
+	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT cumulative_sum(value) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:00:16Z'`), &ic, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !deep.Equal(a, [][]influxql.Point{
+		{&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 20}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 39}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 4 * Second, Value: 49}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 4 * Second, Value: 52}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+}
+
+func TestSelect_CumulativeSum_Duplicate_Integer(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &IntegerIterator{Points: []influxql.IntegerPoint{
+			{Name: "cpu", Time: 0 * Second, Value: 20},
+			{Name: "cpu", Time: 0 * Second, Value: 19},
+			{Name: "cpu", Time: 4 * Second, Value: 10},
+			{Name: "cpu", Time: 4 * Second, Value: 3},
+		}}, nil
+	}
+
+	// Execute selection.
+	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT cumulative_sum(value) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:00:16Z'`), &ic, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 20}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 39}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 4 * Second, Value: 49}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 4 * Second, Value: 52}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+}
+
 func TestSelect_HoltWinters_GroupBy_Agg(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {


### PR DESCRIPTION
The `cumulative_sum()` function can be used to sum each new point and
output the current total. For the following points:

    cpu value=2 0
    cpu value=4 10
    cpu value=6 20

This would output the following points:

    > SELECT cumulative_sum(value) FROM cpu
    time    value
    ----    -----
    0       2
    10      6
    20      12

As can be seen, each new point adds to the sum of the previous point and
outputs the value with the same timestamp.

The function can also be used with an aggregate like `derivative()`.

    > SELECT cumulative_sum(mean(value) FROM cpu WHERE time >= now() - 10m GROUP BY time(1m)