### PR TITLE
models: Add FieldIterator type

### DIFF
--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -117,12 +117,7 @@ func NewShardMapping() *ShardMapping {
 
 // MapPoint maps a point to shard
 func (s *ShardMapping) MapPoint(shardInfo *meta.ShardInfo, p models.Point) {
-	points, ok := s.Points[shardInfo.ID]
-	if !ok {
-		s.Points[shardInfo.ID] = []models.Point{p}
-	} else {
-		s.Points[shardInfo.ID] = append(points, p)
-	}
+	s.Points[shardInfo.ID] = append(s.Points[shardInfo.ID], p)
 	s.Shards[shardInfo.ID] = shardInfo
 }
 
@@ -270,8 +265,7 @@ func (w *PointsWriter) WritePoints(database, retentionPolicy string, consistency
 		return err
 	}
 
-	// Write each shard in it's own goroutine and return as soon
-	// as one fails.
+	// Write each shard in it's own goroutine and return as soon as one fails.
 	ch := make(chan error, len(shardMappings.Points))
 	for shardID, points := range shardMappings.Points {
 		go func(shard *meta.ShardInfo, database, retentionPolicy string, points []models.Point) {

--- a/models/inline_strconv_parse.go
+++ b/models/inline_strconv_parse.go
@@ -6,16 +6,21 @@ import (
 	"unsafe"
 )
 
-// ParseIntBytes is a zero-alloc wrapper around strconv.ParseInt.
-func ParseIntBytes(b []byte, base int, bitSize int) (i int64, err error) {
+// parseIntBytes is a zero-alloc wrapper around strconv.ParseInt.
+func parseIntBytes(b []byte, base int, bitSize int) (i int64, err error) {
 	s := unsafeBytesToString(b)
 	return strconv.ParseInt(s, base, bitSize)
 }
 
-// ParseFloatBytes is a zero-alloc wrapper around strconv.ParseFloat.
-func ParseFloatBytes(b []byte, bitSize int) (float64, error) {
+// parseFloatBytes is a zero-alloc wrapper around strconv.ParseFloat.
+func parseFloatBytes(b []byte, bitSize int) (float64, error) {
 	s := unsafeBytesToString(b)
 	return strconv.ParseFloat(s, bitSize)
+}
+
+// parseBoolBytes is a zero-alloc wrapper around strconv.ParseBool.
+func parseBoolBytes(b []byte) (bool, error) {
+	return strconv.ParseBool(unsafeBytesToString(b))
 }
 
 // unsafeBytesToString converts a []byte to a string without a heap allocation.

--- a/pkg/escape/bytes.go
+++ b/pkg/escape/bytes.go
@@ -1,12 +1,54 @@
 package escape // import "github.com/influxdata/influxdb/pkg/escape"
 
-import "bytes"
+import (
+	"bytes"
+	"strings"
+)
 
 func Bytes(in []byte) []byte {
 	for b, esc := range Codes {
 		in = bytes.Replace(in, []byte{b}, esc, -1)
 	}
 	return in
+}
+
+const escapeChars = `," =`
+
+func IsEscaped(b []byte) bool {
+	for len(b) > 0 {
+		i := bytes.IndexByte(b, '\\')
+		if i < 0 {
+			return false
+		}
+
+		if i+1 < len(b) && strings.IndexByte(escapeChars, b[i+1]) >= 0 {
+			return true
+		}
+		b = b[i+1:]
+	}
+	return false
+}
+
+func AppendUnescaped(dst, src []byte) []byte {
+	var pos int
+	for len(src) > 0 {
+		next := bytes.IndexByte(src[pos:], '\\')
+		if next < 0 || pos+next+1 >= len(src) {
+			return append(dst, src...)
+		}
+
+		if pos+next+1 < len(src) && strings.IndexByte(escapeChars, src[pos+next+1]) >= 0 {
+			if pos+next > 0 {
+				dst = append(dst, src[:pos+next]...)
+			}
+			src = src[pos+next+1:]
+			pos = 0
+		} else {
+			pos += next + 1
+		}
+	}
+
+	return dst
 }
 
 func Unescape(in []byte) []byte {

--- a/pkg/escape/bytes_test.go
+++ b/pkg/escape/bytes_test.go
@@ -1,7 +1,9 @@
 package escape
 
 import (
+	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -42,4 +44,25 @@ func TestUnescape(t *testing.T) {
 			t.Errorf("[%d] Unescape(%#v) = %#v, expected %#v", ii, string(tt.in), string(got), string(tt.out))
 		}
 	}
+}
+
+func TestAppendUnescaped(t *testing.T) {
+	cases := strings.Split(strings.TrimSpace(`
+normal
+inv\alid
+goo\"d
+sp\ ace
+\,\"\ \=
+f\\\ x
+`), "\n")
+
+	for _, c := range cases {
+		exp := Unescape([]byte(c))
+		got := AppendUnescaped(nil, []byte(c))
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("AppendUnescaped failed for %#q: got %#q, exp %#q", c, got, exp)
+		}
+	}
+
 }

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -108,18 +108,33 @@ func NewValue(t int64, value interface{}) Value {
 	case string:
 		return &StringValue{unixnano: t, value: v}
 	}
-	return &EmptyValue{}
+	return EmptyValue{}
 }
 
-type EmptyValue struct {
+func NewIntegerValue(t int64, v int64) Value {
+	return &IntegerValue{unixnano: t, value: v}
 }
 
-func (e *EmptyValue) UnixNano() int64    { return tsdb.EOF }
-func (e *EmptyValue) Value() interface{} { return nil }
-func (e *EmptyValue) Size() int          { return 0 }
-func (e *EmptyValue) String() string     { return "" }
+func NewFloatValue(t int64, v float64) Value {
+	return &FloatValue{unixnano: t, value: v}
+}
 
-func (_ *EmptyValue) internalOnly()   {}
+func NewBooleanValue(t int64, v bool) Value {
+	return &BooleanValue{unixnano: t, value: v}
+}
+
+func NewStringValue(t int64, v string) Value {
+	return &StringValue{unixnano: t, value: v}
+}
+
+type EmptyValue struct{}
+
+func (e EmptyValue) UnixNano() int64    { return tsdb.EOF }
+func (e EmptyValue) Value() interface{} { return nil }
+func (e EmptyValue) Size() int          { return 0 }
+func (e EmptyValue) String() string     { return "" }
+
+func (_ EmptyValue) internalOnly()    {}
 func (_ *StringValue) internalOnly()  {}
 func (_ *IntegerValue) internalOnly() {}
 func (_ *BooleanValue) internalOnly() {}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -564,7 +564,7 @@ func (e *Engine) addToIndexFromKey(shardID uint64, key []byte, fieldType influxq
 // WritePoints writes metadata and point data into the engine.
 // Returns an error if new points are added to an existing key.
 func (e *Engine) WritePoints(points []models.Point) error {
-	values := map[string][]Value{}
+	values := make(map[string][]Value, len(points))
 	var keyBuf []byte
 	var baseLen int
 	for _, p := range points {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -586,7 +586,7 @@ func (e *Engine) WritePoints(points []models.Point) error {
 			case models.Boolean:
 				v = NewBooleanValue(t, iter.BooleanValue())
 			default:
-				v = EmptyValue{}
+				return fmt.Errorf("unknown field type for %s: %s", string(iter.FieldKey()), p.String())
 			}
 			values[string(keyBuf)] = append(values[string(keyBuf)], v)
 		}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -818,8 +818,8 @@ func (s *Store) WriteToShard(shardID uint64, points []models.Point) error {
 	default:
 	}
 
-	sh, ok := s.shards[shardID]
-	if !ok {
+	sh := s.shards[shardID]
+	if sh == nil {
 		s.mu.RUnlock()
 		return ErrShardNotFound
 	}


### PR DESCRIPTION
The `FieldIterator` is used to scan over the fields of a point, providing information, and delaying parsing/decoding the value until it is needed.

This change uses this new type to avoid the allocation of a map for the fields which is then thrown away as soon as the points get converted into columns within the datastore.

There are also some smaller changes that would accumulate allocations over time, mostly around strings.

This should definitely be tested for correctness before being merged... The tests pass, but they might not cover all edge cases.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated