### PR TITLE
Fix decoding RLE integer blocks with negative deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
 - [#7226](https://github.com/influxdata/influxdb/issues/7226): Fix database locked up when deleting shards
 - [#7382](https://github.com/influxdata/influxdb/issues/7382): Shard stats include wal path tag so disk bytes make more sense.
 
+## v1.0.2 [unreleased]
+
+### Bugfixes
+
+- [#7391](https://github.com/influxdata/influxdb/issues/7391): Fix RLE integer decoding producing negative numbers
+
 ## v1.0.1 [2016-09-26]
 
 ### Bugfixes

--- a/tsdb/engine/tsm1/int.go
+++ b/tsdb/engine/tsm1/int.go
@@ -213,7 +213,7 @@ func (d *IntegerDecoder) Error() error {
 func (d *IntegerDecoder) Read() int64 {
 	switch d.encoding {
 	case intCompressedRLE:
-		return ZigZagDecode(d.rleFirst + uint64(d.i)*d.rleDelta)
+		return ZigZagDecode(d.rleFirst) + int64(d.i)*ZigZagDecode(d.rleDelta)
 	default:
 		v := ZigZagDecode(d.values[d.i])
 		// v is the delta encoded value, we need to add the prior value to get the original

--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -355,6 +355,94 @@ func Test_IntegerEncoder_CounterRLE(t *testing.T) {
 	}
 
 	if b[0]>>4 != intCompressedRLE {
+		t.Fatalf("unexpected encoding format: expected RLE, got %v", b[0]>>4)
+	}
+
+	// Should use 1 header byte, 8 byte first value, 1 var-byte for delta and 1 var-byte for
+	// count of deltas in this particular RLE.
+	if exp := 11; len(b) != exp {
+		t.Fatalf("encoded length mismatch: got %v, exp %v", len(b), exp)
+	}
+
+	var dec IntegerDecoder
+	dec.SetBytes(b)
+	i := 0
+	for dec.Next() {
+		if i > len(values) {
+			t.Fatalf("read too many values: got %v, exp %v", i, len(values))
+		}
+
+		if values[i] != dec.Read() {
+			t.Fatalf("read value %d mismatch: got %v, exp %v", i, dec.Read(), values[i])
+		}
+		i += 1
+	}
+
+	if i != len(values) {
+		t.Fatalf("failed to read enough values: got %v, exp %v", i, len(values))
+	}
+}
+
+func Test_IntegerEncoder_Descending(t *testing.T) {
+	enc := NewIntegerEncoder(16)
+	values := []int64{
+		7094, 4472, 1850,
+	}
+
+	for _, v := range values {
+		enc.Write(v)
+	}
+
+	b, err := enc.Bytes()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if b[0]>>4 != intCompressedRLE {
+		t.Fatalf("unexpected encoding format: expected simple, got %v", b[0]>>4)
+	}
+
+	// Should use 1 header byte, 8 byte first value, 1 var-byte for delta and 1 var-byte for
+	// count of deltas in this particular RLE.
+	if exp := 12; len(b) != exp {
+		t.Fatalf("encoded length mismatch: got %v, exp %v", len(b), exp)
+	}
+
+	var dec IntegerDecoder
+	dec.SetBytes(b)
+	i := 0
+	for dec.Next() {
+		if i > len(values) {
+			t.Fatalf("read too many values: got %v, exp %v", i, len(values))
+		}
+
+		if values[i] != dec.Read() {
+			t.Fatalf("read value %d mismatch: got %v, exp %v", i, dec.Read(), values[i])
+		}
+		i += 1
+	}
+
+	if i != len(values) {
+		t.Fatalf("failed to read enough values: got %v, exp %v", i, len(values))
+	}
+}
+
+func Test_IntegerEncoder_Flat(t *testing.T) {
+	enc := NewIntegerEncoder(16)
+	values := []int64{
+		1, 1, 1, 1,
+	}
+
+	for _, v := range values {
+		enc.Write(v)
+	}
+
+	b, err := enc.Bytes()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if b[0]>>4 != intCompressedRLE {
 		t.Fatalf("unexpected encoding format: expected simple, got %v", b[0]>>4)
 	}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Integer blocks that were run length encoded could produce the wrong
value when read back out because the deltas were not zig zag decoded
before scaling the final value.  If the deltas were negative, as would
be seen in a counter that decrements by a constant value, the results
would be random with some negative and positive values.

Fixes #7391

cc @e-dard 