### PR TITLE
Use decoder pools

### DIFF
--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -1095,7 +1095,7 @@ func BenchmarkDecodeBlock_Float_TypeSpecific(b *testing.B) {
 	decodedValues := make([]tsm1.FloatValue, len(values))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = tsm1.DecodeFloatBlock(bytes, &tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &decodedValues)
+		_, err = tsm1.DecodeFloatBlock(bytes, &decodedValues)
 		if err != nil {
 			b.Fatalf("unexpected error decoding block: %v", err)
 		}
@@ -1164,7 +1164,7 @@ func BenchmarkDecodeBlock_Integer_TypeSpecific(b *testing.B) {
 	decodedValues := make([]tsm1.IntegerValue, len(values))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = tsm1.DecodeIntegerBlock(bytes, &tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &decodedValues)
+		_, err = tsm1.DecodeIntegerBlock(bytes, &decodedValues)
 		if err != nil {
 			b.Fatalf("unexpected error decoding block: %v", err)
 		}
@@ -1233,7 +1233,7 @@ func BenchmarkDecodeBlock_Boolean_TypeSpecific(b *testing.B) {
 	decodedValues := make([]tsm1.BooleanValue, len(values))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = tsm1.DecodeBooleanBlock(bytes, &tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &decodedValues)
+		_, err = tsm1.DecodeBooleanBlock(bytes, &decodedValues)
 		if err != nil {
 			b.Fatalf("unexpected error decoding block: %v", err)
 		}
@@ -1302,7 +1302,7 @@ func BenchmarkDecodeBlock_String_TypeSpecific(b *testing.B) {
 	decodedValues := make([]tsm1.StringValue, len(values))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err = tsm1.DecodeStringBlock(bytes, &tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &decodedValues)
+		_, err = tsm1.DecodeStringBlock(bytes, &decodedValues)
 		if err != nil {
 			b.Fatalf("unexpected error decoding block: %v", err)
 		}

--- a/tsdb/engine/tsm1/file_store.gen.go
+++ b/tsdb/engine/tsm1/file_store.gen.go
@@ -7,7 +7,7 @@
 package tsm1
 
 // ReadFloatBlock reads the next block as a set of float values.
-func (c *KeyCursor) ReadFloatBlock(tdec *TimeDecoder, vdec *FloatDecoder, buf *[]FloatValue) ([]FloatValue, error) {
+func (c *KeyCursor) ReadFloatBlock(buf *[]FloatValue) ([]FloatValue, error) {
 	// No matching blocks to decode
 	if len(c.current) == 0 {
 		return nil, nil
@@ -16,7 +16,7 @@ func (c *KeyCursor) ReadFloatBlock(tdec *TimeDecoder, vdec *FloatDecoder, buf *[
 	// First block is the oldest block containing the points we're searching for.
 	first := c.current[0]
 	*buf = (*buf)[:0]
-	values, err := first.r.ReadFloatBlockAt(&first.entry, tdec, vdec, buf)
+	values, err := first.r.ReadFloatBlockAt(&first.entry, buf)
 
 	// Remove values we already read
 	values = FloatValues(values).Exclude(first.readMin, first.readMax)
@@ -81,7 +81,7 @@ func (c *KeyCursor) ReadFloatBlock(tdec *TimeDecoder, vdec *FloatDecoder, buf *[
 
 			tombstones := cur.r.TombstoneRange(c.key)
 			var a []FloatValue
-			v, err := cur.r.ReadFloatBlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.ReadFloatBlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}
@@ -140,7 +140,7 @@ func (c *KeyCursor) ReadFloatBlock(tdec *TimeDecoder, vdec *FloatDecoder, buf *[
 			tombstones := cur.r.TombstoneRange(c.key)
 
 			var a []FloatValue
-			v, err := cur.r.ReadFloatBlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.ReadFloatBlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}
@@ -167,7 +167,7 @@ func (c *KeyCursor) ReadFloatBlock(tdec *TimeDecoder, vdec *FloatDecoder, buf *[
 }
 
 // ReadIntegerBlock reads the next block as a set of integer values.
-func (c *KeyCursor) ReadIntegerBlock(tdec *TimeDecoder, vdec *IntegerDecoder, buf *[]IntegerValue) ([]IntegerValue, error) {
+func (c *KeyCursor) ReadIntegerBlock(buf *[]IntegerValue) ([]IntegerValue, error) {
 	// No matching blocks to decode
 	if len(c.current) == 0 {
 		return nil, nil
@@ -176,7 +176,7 @@ func (c *KeyCursor) ReadIntegerBlock(tdec *TimeDecoder, vdec *IntegerDecoder, bu
 	// First block is the oldest block containing the points we're searching for.
 	first := c.current[0]
 	*buf = (*buf)[:0]
-	values, err := first.r.ReadIntegerBlockAt(&first.entry, tdec, vdec, buf)
+	values, err := first.r.ReadIntegerBlockAt(&first.entry, buf)
 
 	// Remove values we already read
 	values = IntegerValues(values).Exclude(first.readMin, first.readMax)
@@ -241,7 +241,7 @@ func (c *KeyCursor) ReadIntegerBlock(tdec *TimeDecoder, vdec *IntegerDecoder, bu
 
 			tombstones := cur.r.TombstoneRange(c.key)
 			var a []IntegerValue
-			v, err := cur.r.ReadIntegerBlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.ReadIntegerBlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}
@@ -300,7 +300,7 @@ func (c *KeyCursor) ReadIntegerBlock(tdec *TimeDecoder, vdec *IntegerDecoder, bu
 			tombstones := cur.r.TombstoneRange(c.key)
 
 			var a []IntegerValue
-			v, err := cur.r.ReadIntegerBlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.ReadIntegerBlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}
@@ -327,7 +327,7 @@ func (c *KeyCursor) ReadIntegerBlock(tdec *TimeDecoder, vdec *IntegerDecoder, bu
 }
 
 // ReadStringBlock reads the next block as a set of string values.
-func (c *KeyCursor) ReadStringBlock(tdec *TimeDecoder, vdec *StringDecoder, buf *[]StringValue) ([]StringValue, error) {
+func (c *KeyCursor) ReadStringBlock(buf *[]StringValue) ([]StringValue, error) {
 	// No matching blocks to decode
 	if len(c.current) == 0 {
 		return nil, nil
@@ -336,7 +336,7 @@ func (c *KeyCursor) ReadStringBlock(tdec *TimeDecoder, vdec *StringDecoder, buf 
 	// First block is the oldest block containing the points we're searching for.
 	first := c.current[0]
 	*buf = (*buf)[:0]
-	values, err := first.r.ReadStringBlockAt(&first.entry, tdec, vdec, buf)
+	values, err := first.r.ReadStringBlockAt(&first.entry, buf)
 
 	// Remove values we already read
 	values = StringValues(values).Exclude(first.readMin, first.readMax)
@@ -401,7 +401,7 @@ func (c *KeyCursor) ReadStringBlock(tdec *TimeDecoder, vdec *StringDecoder, buf 
 
 			tombstones := cur.r.TombstoneRange(c.key)
 			var a []StringValue
-			v, err := cur.r.ReadStringBlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.ReadStringBlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}
@@ -460,7 +460,7 @@ func (c *KeyCursor) ReadStringBlock(tdec *TimeDecoder, vdec *StringDecoder, buf 
 			tombstones := cur.r.TombstoneRange(c.key)
 
 			var a []StringValue
-			v, err := cur.r.ReadStringBlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.ReadStringBlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}
@@ -487,7 +487,7 @@ func (c *KeyCursor) ReadStringBlock(tdec *TimeDecoder, vdec *StringDecoder, buf 
 }
 
 // ReadBooleanBlock reads the next block as a set of boolean values.
-func (c *KeyCursor) ReadBooleanBlock(tdec *TimeDecoder, vdec *BooleanDecoder, buf *[]BooleanValue) ([]BooleanValue, error) {
+func (c *KeyCursor) ReadBooleanBlock(buf *[]BooleanValue) ([]BooleanValue, error) {
 	// No matching blocks to decode
 	if len(c.current) == 0 {
 		return nil, nil
@@ -496,7 +496,7 @@ func (c *KeyCursor) ReadBooleanBlock(tdec *TimeDecoder, vdec *BooleanDecoder, bu
 	// First block is the oldest block containing the points we're searching for.
 	first := c.current[0]
 	*buf = (*buf)[:0]
-	values, err := first.r.ReadBooleanBlockAt(&first.entry, tdec, vdec, buf)
+	values, err := first.r.ReadBooleanBlockAt(&first.entry, buf)
 
 	// Remove values we already read
 	values = BooleanValues(values).Exclude(first.readMin, first.readMax)
@@ -561,7 +561,7 @@ func (c *KeyCursor) ReadBooleanBlock(tdec *TimeDecoder, vdec *BooleanDecoder, bu
 
 			tombstones := cur.r.TombstoneRange(c.key)
 			var a []BooleanValue
-			v, err := cur.r.ReadBooleanBlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.ReadBooleanBlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}
@@ -620,7 +620,7 @@ func (c *KeyCursor) ReadBooleanBlock(tdec *TimeDecoder, vdec *BooleanDecoder, bu
 			tombstones := cur.r.TombstoneRange(c.key)
 
 			var a []BooleanValue
-			v, err := cur.r.ReadBooleanBlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.ReadBooleanBlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}

--- a/tsdb/engine/tsm1/file_store.gen.go.tmpl
+++ b/tsdb/engine/tsm1/file_store.gen.go.tmpl
@@ -3,7 +3,7 @@ package tsm1
 
 {{range .}}
 // Read{{.Name}}Block reads the next block as a set of {{.name}} values.
-func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder, buf *[]{{.Name}}Value) ([]{{.Name}}Value, error) {
+func (c *KeyCursor) Read{{.Name}}Block(buf *[]{{.Name}}Value) ([]{{.Name}}Value, error) {
 	// No matching blocks to decode
 	if len(c.current) == 0 {
 		return nil, nil
@@ -12,7 +12,7 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 	// First block is the oldest block containing the points we're searching for.
 	first := c.current[0]
 	*buf = (*buf)[:0]
-	values, err := first.r.Read{{.Name}}BlockAt(&first.entry, tdec, vdec, buf)
+	values, err := first.r.Read{{.Name}}BlockAt(&first.entry, buf)
 
 	// Remove values we already read
 	values = {{.Name}}Values(values).Exclude(first.readMin, first.readMax)
@@ -77,7 +77,7 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 
 			tombstones := cur.r.TombstoneRange(c.key)
 			var a []{{.Name}}Value
-			v, err := cur.r.Read{{.Name}}BlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.Read{{.Name}}BlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}
@@ -136,7 +136,7 @@ func (c *KeyCursor) Read{{.Name}}Block(tdec *TimeDecoder, vdec *{{.Name}}Decoder
 			tombstones := cur.r.TombstoneRange(c.key)
 
 			var a []{{.Name}}Value
-			v, err := cur.r.Read{{.Name}}BlockAt(&cur.entry, tdec, vdec, &a)
+			v, err := cur.r.Read{{.Name}}BlockAt(&cur.entry, &a)
 			if err != nil {
 				return nil, err
 			}

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -70,7 +70,7 @@ func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
 	// Search for an entry that exists in the second file
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
 	// Search for an entry that exists in the second file
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 
 	// Check that calling Next will dedupe points
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -178,7 +178,7 @@ func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -287,7 +287,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -308,7 +308,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err = c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -353,7 +353,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err = c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -419,7 +419,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -440,7 +440,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err = c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -485,7 +485,7 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
 	// Search for an entry that exists in the second file
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -509,7 +509,7 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 
 	// Check that calling Next will dedupe points
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -529,7 +529,7 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -561,7 +561,7 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
 	// Search for an entry that exists in the second file
-	values, err := c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -585,7 +585,7 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 
 	// Check that calling Next will dedupe points
 	c.Next()
-	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err = c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -604,7 +604,7 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err = c.ReadIntegerBlock(&buf)
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -636,7 +636,7 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
 	// Search for an entry that exists in the second file
-	values, err := c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -660,7 +660,7 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 
 	// Check that calling Next will dedupe points
 	c.Next()
-	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err = c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -679,7 +679,7 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err = c.ReadBooleanBlock(&buf)
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -711,7 +711,7 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
 	// Search for an entry that exists in the second file
-	values, err := c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -735,7 +735,7 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 
 	// Check that calling Next will dedupe points
 	c.Next()
-	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err = c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -754,7 +754,7 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err = c.ReadStringBlock(&buf)
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -784,7 +784,7 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 3, true)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -801,7 +801,7 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -840,7 +840,7 @@ func TestFileStore_SeekToAsc_End(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 2, true)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -879,7 +879,7 @@ func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 0, false)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -918,7 +918,7 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 2, false)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -936,7 +936,7 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -977,7 +977,7 @@ func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 5, false)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -998,7 +998,7 @@ func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1042,7 +1042,7 @@ func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor("cpu", 5, false)
-	values, err := c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1063,7 +1063,7 @@ func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err = c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1105,7 +1105,7 @@ func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor("cpu", 5, false)
-	values, err := c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1126,7 +1126,7 @@ func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err = c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1168,7 +1168,7 @@ func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor("cpu", 5, false)
-	values, err := c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1189,7 +1189,7 @@ func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err = c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1229,7 +1229,7 @@ func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 4, false)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1268,7 +1268,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 10, false)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1289,7 +1289,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1311,7 +1311,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1332,7 +1332,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1365,7 +1365,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor("cpu", 11, false)
-	values, err := c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1388,7 +1388,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err = c.ReadIntegerBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1409,7 +1409,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err = c.ReadIntegerBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1442,7 +1442,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor("cpu", 11, false)
-	values, err := c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1463,7 +1463,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err = c.ReadBooleanBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1485,7 +1485,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err = c.ReadBooleanBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1506,7 +1506,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err = c.ReadBooleanBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1539,7 +1539,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor("cpu", 11, false)
-	values, err := c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1560,7 +1560,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err = c.ReadStringBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1582,7 +1582,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err = c.ReadStringBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1603,7 +1603,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err = c.ReadStringBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1639,7 +1639,7 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 3, false)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1659,7 +1659,7 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 		}
 	}
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1680,7 +1680,7 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 	}
 
 	c.Next()
-	values, err = c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err = c.ReadFloatBlock(&buf)
 
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1712,7 +1712,7 @@ func TestFileStore_SeekToDesc_End(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 2, false)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1756,7 +1756,7 @@ func TestKeyCursor_TombstoneRange(t *testing.T) {
 	c := fs.KeyCursor("cpu", 0, true)
 	expValues := []int{0, 2}
 	for _, v := range expValues {
-		values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+		values, err := c.ReadFloatBlock(&buf)
 		if err != nil {
 			t.Fatalf("unexpected error reading values: %v", err)
 		}
@@ -1799,7 +1799,7 @@ func TestKeyCursor_TombstoneRange_PartialFloat(t *testing.T) {
 
 	buf := make([]tsm1.FloatValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadFloatBlock(&tsm1.TimeDecoder{}, &tsm1.FloatDecoder{}, &buf)
+	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1843,7 +1843,7 @@ func TestKeyCursor_TombstoneRange_PartialInteger(t *testing.T) {
 
 	buf := make([]tsm1.IntegerValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadIntegerBlock(&tsm1.TimeDecoder{}, &tsm1.IntegerDecoder{}, &buf)
+	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1887,7 +1887,7 @@ func TestKeyCursor_TombstoneRange_PartialString(t *testing.T) {
 
 	buf := make([]tsm1.StringValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadStringBlock(&tsm1.TimeDecoder{}, &tsm1.StringDecoder{}, &buf)
+	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -1931,7 +1931,7 @@ func TestKeyCursor_TombstoneRange_PartialBoolean(t *testing.T) {
 
 	buf := make([]tsm1.BooleanValue, 1000)
 	c := fs.KeyCursor("cpu", 0, true)
-	values, err := c.ReadBooleanBlock(&tsm1.TimeDecoder{}, &tsm1.BooleanDecoder{}, &buf)
+	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -2064,23 +2064,21 @@ func TestFileStore_Replace(t *testing.T) {
 	}
 
 	// There should be two blocks (1 in each file)
-	tdec := &tsm1.TimeDecoder{}
-	vdec := &tsm1.FloatDecoder{}
 	cur.Next()
 	buf := make([]tsm1.FloatValue, 10)
-	values, err := cur.ReadFloatBlock(tdec, vdec, &buf)
+	values, err := cur.ReadFloatBlock(&buf)
 	if got, exp := len(values), 1; got != exp {
 		t.Fatalf("value len mismatch: got %v, exp %v", got, exp)
 	}
 	cur.Next()
-	values, err = cur.ReadFloatBlock(tdec, vdec, &buf)
+	values, err = cur.ReadFloatBlock(&buf)
 	if got, exp := len(values), 1; got != exp {
 		t.Fatalf("value len mismatch: got %v, exp %v", got, exp)
 	}
 
 	// No more blocks for this cursor
 	cur.Next()
-	values, err = cur.ReadFloatBlock(tdec, vdec, &buf)
+	values, err = cur.ReadFloatBlock(&buf)
 	if got, exp := len(values), 0; got != exp {
 		t.Fatalf("value len mismatch: got %v, exp %v", got, exp)
 	}

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -311,8 +311,6 @@ type floatAscendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      FloatDecoder
 		buf       []FloatValue
 		values    []FloatValue
 		pos       int
@@ -330,7 +328,7 @@ func newFloatAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyCu
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]FloatValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -412,7 +410,7 @@ func (c *floatAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -427,8 +425,6 @@ type floatDescendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      FloatDecoder
 		buf       []FloatValue
 		values    []FloatValue
 		pos       int
@@ -449,7 +445,7 @@ func newFloatDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]FloatValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -534,7 +530,7 @@ func (c *floatDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -758,8 +754,6 @@ type integerAscendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      IntegerDecoder
 		buf       []IntegerValue
 		values    []IntegerValue
 		pos       int
@@ -777,7 +771,7 @@ func newIntegerAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]IntegerValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -859,7 +853,7 @@ func (c *integerAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -874,8 +868,6 @@ type integerDescendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      IntegerDecoder
 		buf       []IntegerValue
 		values    []IntegerValue
 		pos       int
@@ -896,7 +888,7 @@ func newIntegerDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]IntegerValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -981,7 +973,7 @@ func (c *integerDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -1205,8 +1197,6 @@ type stringAscendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      StringDecoder
 		buf       []StringValue
 		values    []StringValue
 		pos       int
@@ -1224,7 +1214,7 @@ func newStringAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]StringValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -1306,7 +1296,7 @@ func (c *stringAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -1321,8 +1311,6 @@ type stringDescendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      StringDecoder
 		buf       []StringValue
 		values    []StringValue
 		pos       int
@@ -1343,7 +1331,7 @@ func newStringDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]StringValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -1428,7 +1416,7 @@ func (c *stringDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -1652,8 +1640,6 @@ type booleanAscendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      BooleanDecoder
 		buf       []BooleanValue
 		values    []BooleanValue
 		pos       int
@@ -1671,7 +1657,7 @@ func newBooleanAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]BooleanValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -1753,7 +1739,7 @@ func (c *booleanAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -1768,8 +1754,6 @@ type booleanDescendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      BooleanDecoder
 		buf       []BooleanValue
 		values    []BooleanValue
 		pos       int
@@ -1790,7 +1774,7 @@ func newBooleanDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]BooleanValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -1875,7 +1859,7 @@ func (c *booleanDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -307,8 +307,6 @@ type {{.name}}AscendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      {{.Name}}Decoder
 		buf       []{{.Name}}Value
 		values    []{{.Name}}Value
 		pos       int
@@ -326,7 +324,7 @@ func new{{.Name}}AscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *K
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]{{.Name}}Value, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -408,7 +406,7 @@ func (c *{{.name}}AscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -423,8 +421,6 @@ type {{.name}}DescendingCursor struct {
 	}
 
 	tsm struct {
-		tdec      TimeDecoder
-		vdec      {{.Name}}Decoder
 		buf       []{{.Name}}Value
 		values    []{{.Name}}Value
 		pos       int
@@ -445,7 +441,7 @@ func new{{.Name}}DescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *
 
 	c.tsm.keyCursor = tsmKeyCursor
 	c.tsm.buf = make([]{{.Name}}Value, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.buf)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -530,7 +526,7 @@ func (c *{{.name}}DescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.tdec, &c.tsm.vdec, &c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.buf)
 		if len(c.tsm.values) == 0 {
 			return
 		}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR creates a set of long-lived decoder pools that are re-used during compactions and queries.  Some decoders are expensive to create.  On the query side, series iterators created decoders and re-used them throughout the query to avoid recreating them all the time.  For larger queries, memory usage was higher because there were two decoders per series.   These are now removed from the iterators and re-used from a shared pool resulting in lower memory usage for some queries.

During compactions, decoders were created for every block that was decoded causing a lot of garbage.  These are now re-used from the pool.

This also has a small change to the cache to reduce the time the cache read lock is held when constructing a series iterator. 

Counting 100M points across 2.5M series:

### Before 

```
$ time influx -database stress -execute "select count(n) from ctr"
name: ctr
time   	count
----   	-----
0      	100000000


real   	2m26.890s
user   	0m0.004s
sys    	0m0.015s
```

### After
```
$ time influx -database stress -execute "select count(n) from ctr"
name: ctr
time   	count
----   	-----
0      	100000000


real   	0m31.552s
user   	0m0.005s
sys    	0m0.014s
```

### Heap Profile

This is the heap profile while those two queries ran.

![screen shot 2016-10-03 at 12 25 24 pm](https://cloud.githubusercontent.com/assets/219935/19048667/8db36f06-8964-11e6-8157-7cddef07fdb4.png)