### PR TITLE
Fix help command usage string

### DIFF
--- a/cmd/influxd/help/help.go
+++ b/cmd/influxd/help/help.go
@@ -41,5 +41,5 @@ The commands are:
 
 "run" is the default command.
 
-Use "influxd help [command]" for more information about a command.
+Use "influxd [command] -help" for more information about a command.
 `


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


The information in the usage string for the `help` command about
how to get more information about a specific command was incorrect:

`influxd help [command]` does not work, but `influxd [command] --help`
does.