### PR TITLE
auth command with leading spaces will be written to history

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -200,7 +200,7 @@ func (c *CommandLine) mainLoop() error {
 				c.exit()
 				return e
 			}
-			if err := c.ParseCommand(l); err != ErrBlankCommand && !strings.HasPrefix(l, "auth") {
+			if err := c.ParseCommand(l); err != ErrBlankCommand && !strings.HasPrefix(strings.TrimSpace(l), "auth") {
 				c.Line.AppendHistory(l)
 				c.saveHistory()
 			}

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -715,7 +715,7 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 			}
 			rows = append(rows, strings.Join(values, separator))
 		}
-		// Outout a line separator if in column format
+		// Output a line separator if in column format
 		if c.Format == "column" {
 			rows = append(rows, "")
 		}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Noticed that `auth` command will be prevented to write into history file. 
However it doesn't prevent if the `auth` command has leading spaces.