### PR TITLE
Support INFLUX_USERNAME and INFLUX_PASSWORD for setting username/password in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#7146](https://github.com/influxdata/influxdb/issues/7146): Add max-values-per-tag to limit high tag cardinality data
 - [#5955](https://github.com/influxdata/influxdb/issues/5955): Make regex work on field and dimension keys in SELECT clause.
 - [#7470](https://github.com/influxdata/influxdb/pull/7470): Reduce map allocations when computing the TagSet of a measurement.
+- [#6894](https://github.com/influxdata/influxdb/issues/6894): Support `INFLUX_USERNAME` and `INFLUX_PASSWORD` for setting username/password in the CLI.
 
 ### Bugfixes
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -102,6 +102,15 @@ func (c *CommandLine) Run() error {
 		}
 	}
 
+	// Read environment variables for username/password.
+	if c.Username == "" {
+		c.Username = os.Getenv("INFLUX_USERNAME")
+	}
+	// If we prompted for a password, always use the entered password.
+	if !promptForPassword && c.Password == "" {
+		c.Password = os.Getenv("INFLUX_PASSWORD")
+	}
+
 	if err := c.Connect(""); err != nil {
 		return fmt.Errorf(
 			"Failed to connect to %s\nPlease check your connection settings and ensure 'influxd' is running.",


### PR DESCRIPTION
Fixes #6894.