### PR TITLE
Add max-values-per-tag limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Release Notes
 
+### Breaking changes
+
+* `max-values-per-tag` was added with a default of 100,000, but can be disabled by setting it to `0`.  Existing measurements with tags that exceed this limit will continue to load, but writes that would cause the tags cardinality to increase will return an error.  This limit can be used to prevent high cardinality tag values from being written to a measurement.
+
 ### Features
 
 - [#7415](https://github.com/influxdata/influxdb/pull/7415): Add sample function to query language.
@@ -18,6 +22,7 @@
 - [#7115](https://github.com/influxdata/influxdb/issues/7115): Feature request: `influx inspect -export` should dump WAL files.
 - [#7388](https://github.com/influxdata/influxdb/pull/7388): Implement cumulative_sum() function.
 - [#7441](https://github.com/influxdata/influxdb/pull/7441): Speed up shutdown by closing shards concurrently.
+- [#7146](https://github.com/influxdata/influxdb/issues/7146): Add max-values-per-tag to limit high tag cardinality data
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-* `max-values-per-tag` was added with a default of 100,000, but can be disabled by setting it to `0`.  Existing measurements with tags that exceed this limit will continue to load, but writes that would cause the tags cardinality to increase will return an error.  This limit can be used to prevent high cardinality tag values from being written to a measurement.
+* `max-values-per-tag` was added with a default of 100,000, but can be disabled by setting it to `0`.  Existing measurements with tags that exceed this limit will continue to load, but writes that would cause the tags cardinality to increase will be dropped and a `partial write` error will be returned to the caller.  This limit can be used to prevent high cardinality tag values from being written to a measurement.
 
 ### Features
 

--- a/models/points.go
+++ b/models/points.go
@@ -149,6 +149,9 @@ type point struct {
 	// cached version of parsed name from key
 	cachedName string
 
+	// cached version of parsed tags
+	cachedTags Tags
+
 	it fieldIterator
 }
 
@@ -1279,7 +1282,11 @@ func (p *point) Round(d time.Duration) {
 
 // Tags returns the tag set for the point
 func (p *point) Tags() Tags {
-	return parseTags(p.key)
+	if p.cachedTags != nil {
+		return p.cachedTags
+	}
+	p.cachedTags = parseTags(p.key)
+	return p.cachedTags
 }
 
 func parseTags(buf []byte) Tags {
@@ -1332,6 +1339,7 @@ func MakeKey(name []byte, tags Tags) []byte {
 // SetTags replaces the tags for the point
 func (p *point) SetTags(tags Tags) {
 	p.key = MakeKey([]byte(p.Name()), tags)
+	p.cachedTags = tags
 }
 
 // AddTag adds or replaces a tag value for a point
@@ -1339,6 +1347,7 @@ func (p *point) AddTag(key, value string) {
 	tags := p.Tags()
 	tags = append(tags, Tag{Key: []byte(key), Value: []byte(value)})
 	sort.Sort(tags)
+	p.cachedTags = tags
 	p.key = MakeKey([]byte(p.Name()), tags)
 }
 

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -19,24 +19,25 @@ import (
 
 // statistics gathered by the httpd package.
 const (
-	statRequest                      = "req"                // Number of HTTP requests served
-	statCQRequest                    = "cqReq"              // Number of CQ-execute requests served
-	statQueryRequest                 = "queryReq"           // Number of query requests served
-	statWriteRequest                 = "writeReq"           // Number of write requests serverd
-	statPingRequest                  = "pingReq"            // Number of ping requests served
-	statStatusRequest                = "statusReq"          // Number of status requests served
-	statWriteRequestBytesReceived    = "writeReqBytes"      // Sum of all bytes in write requests
-	statQueryRequestBytesTransmitted = "queryRespBytes"     // Sum of all bytes returned in query reponses
-	statPointsWrittenOK              = "pointsWrittenOK"    // Number of points written OK
-	statPointsWrittenFail            = "pointsWrittenFail"  // Number of points that failed to be written
-	statAuthFail                     = "authFail"           // Number of authentication failures
-	statRequestDuration              = "reqDurationNs"      // Number of (wall-time) nanoseconds spent inside requests
-	statQueryRequestDuration         = "queryReqDurationNs" // Number of (wall-time) nanoseconds spent inside query requests
-	statWriteRequestDuration         = "writeReqDurationNs" // Number of (wall-time) nanoseconds spent inside write requests
-	statRequestsActive               = "reqActive"          // Number of currently active requests
-	statWriteRequestsActive          = "writeReqActive"     // Number of currently active write requests
-	statClientError                  = "clientError"        // Number of HTTP responses due to client error
-	statServerError                  = "serverError"        // Number of HTTP responses due to server error
+	statRequest                      = "req"                  // Number of HTTP requests served
+	statCQRequest                    = "cqReq"                // Number of CQ-execute requests served
+	statQueryRequest                 = "queryReq"             // Number of query requests served
+	statWriteRequest                 = "writeReq"             // Number of write requests serverd
+	statPingRequest                  = "pingReq"              // Number of ping requests served
+	statStatusRequest                = "statusReq"            // Number of status requests served
+	statWriteRequestBytesReceived    = "writeReqBytes"        // Sum of all bytes in write requests
+	statQueryRequestBytesTransmitted = "queryRespBytes"       // Sum of all bytes returned in query reponses
+	statPointsWrittenOK              = "pointsWrittenOK"      // Number of points written OK
+	statPointsWrittenDropped         = "pointsWrittenDropped" // Number of points dropped by the storage engine
+	statPointsWrittenFail            = "pointsWrittenFail"    // Number of points that failed to be written
+	statAuthFail                     = "authFail"             // Number of authentication failures
+	statRequestDuration              = "reqDurationNs"        // Number of (wall-time) nanoseconds spent inside requests
+	statQueryRequestDuration         = "queryReqDurationNs"   // Number of (wall-time) nanoseconds spent inside query requests
+	statWriteRequestDuration         = "writeReqDurationNs"   // Number of (wall-time) nanoseconds spent inside write requests
+	statRequestsActive               = "reqActive"            // Number of currently active requests
+	statWriteRequestsActive          = "writeReqActive"       // Number of currently active write requests
+	statClientError                  = "clientError"          // Number of HTTP responses due to client error
+	statServerError                  = "serverError"          // Number of HTTP responses due to server error
 )
 
 // Service manages the listener and handler for an HTTP endpoint.

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -39,6 +39,9 @@ const (
 
 	// DefaultMaxSeriesPerDatabase is the maximum number of series a node can hold per database.
 	DefaultMaxSeriesPerDatabase = 1000000
+
+	// DefaultMaxValuesPerTag is the maximum number of values a tag can have within a measurement.
+	DefaultMaxValuesPerTag = 100000
 )
 
 // Config holds the configuration for the tsbd package.
@@ -67,6 +70,11 @@ type Config struct {
 	// A value of 0 disables the limit.
 	MaxSeriesPerDatabase int `toml:"max-series-per-database"`
 
+	// MaxValuesPerTag is the maximum number of tag values a single tag key can have within
+	// a measurement.  When the limit is execeeded, writes return an error.
+	// A value of 0 disables the limit.
+	MaxValuesPerTag int `toml:"max-values-per-tag"`
+
 	TraceLoggingEnabled bool `toml:"trace-logging-enabled"`
 }
 
@@ -85,6 +93,7 @@ func NewConfig() Config {
 		CompactFullWriteColdDuration:   toml.Duration(DefaultCompactFullWriteColdDuration),
 
 		MaxSeriesPerDatabase: DefaultMaxSeriesPerDatabase,
+		MaxValuesPerTag:      DefaultMaxValuesPerTag,
 
 		TraceLoggingEnabled: false,
 	}

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -654,7 +654,16 @@ func (m *Measurement) HasSeries() bool {
 }
 
 // Cardinality returns the number of values associated with tag key
-func (m *Measurement) Cardinality(key []byte) int {
+func (m *Measurement) Cardinality(key string) int {
+	var n int
+	m.mu.RLock()
+	n = len(m.seriesByTagKeyValue[key])
+	m.mu.RUnlock()
+	return n
+}
+
+// Cardinality returns the number of values associated with tag key
+func (m *Measurement) CardinalityBytes(key []byte) int {
 	var n int
 	m.mu.RLock()
 	n = len(m.seriesByTagKeyValue[string(key)])
@@ -1839,17 +1848,6 @@ func (m *Measurement) TagKeys() []string {
 	return keys
 }
 
-func (m *Measurement) TagKeysBytes() [][]byte {
-	m.mu.RLock()
-	keys := make([][]byte, 0, len(m.seriesByTagKeyValue))
-	for k := range m.seriesByTagKeyValue {
-		keys = append(keys, []byte(k))
-	}
-	m.mu.RUnlock()
-	sort.Sort(bytesSlice(keys))
-	return keys
-}
-
 // TagValues returns all the values for the given tag key
 func (m *Measurement) TagValues(key string) []string {
 	m.mu.RLock()
@@ -2012,9 +2010,3 @@ type byTagKey []*influxql.TagSet
 func (t byTagKey) Len() int           { return len(t) }
 func (t byTagKey) Less(i, j int) bool { return bytes.Compare(t[i].Key, t[j].Key) < 0 }
 func (t byTagKey) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
-
-type bytesSlice [][]byte
-
-func (t bytesSlice) Len() int           { return len(t) }
-func (t bytesSlice) Less(i, j int) bool { return bytes.Compare(t[i], t[j]) < 0 }
-func (t bytesSlice) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -635,11 +635,31 @@ func (m *Measurement) HasTagKey(k string) bool {
 	return hasTag
 }
 
+func (m *Measurement) HasTagKeyValue(k, v []byte) bool {
+	m.mu.RLock()
+	if vals, ok := m.seriesByTagKeyValue[string(k)]; ok {
+		_, ok := vals[string(v)]
+		m.mu.RUnlock()
+		return ok
+	}
+	m.mu.RUnlock()
+	return false
+}
+
 // HasSeries returns true if there is at least 1 series under this measurement
 func (m *Measurement) HasSeries() bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return len(m.seriesByID) > 0
+}
+
+// Cardinality returns the number of values associated with tag key
+func (m *Measurement) Cardinality(key []byte) int {
+	var n int
+	m.mu.RLock()
+	n = len(m.seriesByTagKeyValue[string(key)])
+	m.mu.RUnlock()
+	return n
 }
 
 // AddSeries will add a series to the measurementIndex. Returns false if already present
@@ -1810,12 +1830,23 @@ func MarshalTags(tags map[string]string) []byte {
 // TagKeys returns a list of the measurement's tag names.
 func (m *Measurement) TagKeys() []string {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
 	keys := make([]string, 0, len(m.seriesByTagKeyValue))
 	for k := range m.seriesByTagKeyValue {
 		keys = append(keys, k)
 	}
+	m.mu.RUnlock()
 	sort.Strings(keys)
+	return keys
+}
+
+func (m *Measurement) TagKeysBytes() [][]byte {
+	m.mu.RLock()
+	keys := make([][]byte, 0, len(m.seriesByTagKeyValue))
+	for k := range m.seriesByTagKeyValue {
+		keys = append(keys, []byte(k))
+	}
+	m.mu.RUnlock()
+	sort.Sort(bytesSlice(keys))
 	return keys
 }
 
@@ -1981,3 +2012,9 @@ type byTagKey []*influxql.TagSet
 func (t byTagKey) Len() int           { return len(t) }
 func (t byTagKey) Less(i, j int) bool { return bytes.Compare(t[i].Key, t[j].Key) < 0 }
 func (t byTagKey) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+
+type bytesSlice [][]byte
+
+func (t bytesSlice) Len() int           { return len(t) }
+func (t bytesSlice) Less(i, j int) bool { return bytes.Compare(t[i], t[j]) < 0 }
+func (t bytesSlice) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -25,15 +25,16 @@ import (
 const monitorStatInterval = 30 * time.Second
 
 const (
-	statWriteReq       = "writeReq"
-	statWriteReqOK     = "writeReqOk"
-	statWriteReqErr    = "writeReqErr"
-	statSeriesCreate   = "seriesCreate"
-	statFieldsCreate   = "fieldsCreate"
-	statWritePointsErr = "writePointsErr"
-	statWritePointsOK  = "writePointsOk"
-	statWriteBytes     = "writeBytes"
-	statDiskBytes      = "diskBytes"
+	statWriteReq           = "writeReq"
+	statWriteReqOK         = "writeReqOk"
+	statWriteReqErr        = "writeReqErr"
+	statSeriesCreate       = "seriesCreate"
+	statFieldsCreate       = "fieldsCreate"
+	statWritePointsErr     = "writePointsErr"
+	statWritePointsDropped = "writePointsDropped"
+	statWritePointsOK      = "writePointsOk"
+	statWriteBytes         = "writeBytes"
+	statDiskBytes          = "diskBytes"
 )
 
 var (
@@ -81,6 +82,17 @@ func NewShardError(id uint64, err error) error {
 
 func (e ShardError) Error() string {
 	return fmt.Sprintf("[shard %d] %s", e.id, e.Err)
+}
+
+// PartialWriteErrors indicates a write request could only write a portion of the
+// requested values.
+type PartialWriteError struct {
+	Reason  string
+	Dropped int
+}
+
+func (e PartialWriteError) Error() string {
+	return fmt.Sprintf("%s dropped=%d", e.Reason, e.Dropped)
 }
 
 // Shard represents a self-contained time series database. An inverted index of
@@ -173,15 +185,16 @@ func (s *Shard) SetEnabled(enabled bool) {
 
 // ShardStatistics maintains statistics for a shard.
 type ShardStatistics struct {
-	WriteReq       int64
-	WriteReqOK     int64
-	WriteReqErr    int64
-	SeriesCreated  int64
-	FieldsCreated  int64
-	WritePointsErr int64
-	WritePointsOK  int64
-	BytesWritten   int64
-	DiskBytes      int64
+	WriteReq           int64
+	WriteReqOK         int64
+	WriteReqErr        int64
+	SeriesCreated      int64
+	FieldsCreated      int64
+	WritePointsErr     int64
+	WritePointsDropped int64
+	WritePointsOK      int64
+	BytesWritten       int64
+	DiskBytes          int64
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -196,15 +209,16 @@ func (s *Shard) Statistics(tags map[string]string) []models.Statistic {
 		Name: "shard",
 		Tags: tags,
 		Values: map[string]interface{}{
-			statWriteReq:       atomic.LoadInt64(&s.stats.WriteReq),
-			statWriteReqOK:     atomic.LoadInt64(&s.stats.WriteReqOK),
-			statWriteReqErr:    atomic.LoadInt64(&s.stats.WriteReqErr),
-			statSeriesCreate:   seriesN,
-			statFieldsCreate:   atomic.LoadInt64(&s.stats.FieldsCreated),
-			statWritePointsErr: atomic.LoadInt64(&s.stats.WritePointsErr),
-			statWritePointsOK:  atomic.LoadInt64(&s.stats.WritePointsOK),
-			statWriteBytes:     atomic.LoadInt64(&s.stats.BytesWritten),
-			statDiskBytes:      atomic.LoadInt64(&s.stats.DiskBytes),
+			statWriteReq:           atomic.LoadInt64(&s.stats.WriteReq),
+			statWriteReqOK:         atomic.LoadInt64(&s.stats.WriteReqOK),
+			statWriteReqErr:        atomic.LoadInt64(&s.stats.WriteReqErr),
+			statSeriesCreate:       seriesN,
+			statFieldsCreate:       atomic.LoadInt64(&s.stats.FieldsCreated),
+			statWritePointsErr:     atomic.LoadInt64(&s.stats.WritePointsErr),
+			statWritePointsDropped: atomic.LoadInt64(&s.stats.WritePointsDropped),
+			statWritePointsOK:      atomic.LoadInt64(&s.stats.WritePointsOK),
+			statWriteBytes:         atomic.LoadInt64(&s.stats.BytesWritten),
+			statDiskBytes:          atomic.LoadInt64(&s.stats.DiskBytes),
 		},
 	}}
 	statistics = append(statistics, s.engine.Statistics(tags)...)
@@ -370,14 +384,21 @@ func (s *Shard) WritePoints(points []models.Point) error {
 		return err
 	}
 
+	var writeError error
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	atomic.AddInt64(&s.stats.WriteReq, 1)
 
-	fieldsToCreate, err := s.validateSeriesAndFields(points)
+	points, fieldsToCreate, err := s.validateSeriesAndFields(points)
 	if err != nil {
-		return err
+		if _, ok := err.(PartialWriteError); !ok {
+			return err
+		}
+		// There was a partial write (points dropped), hold onto the error to return
+		// to the caller, but continue on writing the remaining points.
+		writeError = err
 	}
 	atomic.AddInt64(&s.stats.FieldsCreated, int64(len(fieldsToCreate)))
 
@@ -395,7 +416,7 @@ func (s *Shard) WritePoints(points []models.Point) error {
 	atomic.AddInt64(&s.stats.WritePointsOK, int64(len(points)))
 	atomic.AddInt64(&s.stats.WriteReqOK, 1)
 
-	return nil
+	return writeError
 }
 
 func (s *Shard) ContainsSeries(seriesKeys []string) (map[string]bool, error) {
@@ -466,16 +487,23 @@ func (s *Shard) createFieldsAndMeasurements(fieldsToCreate []*FieldCreate) error
 }
 
 // validateSeriesAndFields checks which series and fields are new and whose metadata should be saved and indexed
-func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, error) {
-	var fieldsToCreate []*FieldCreate
-
+func (s *Shard) validateSeriesAndFields(points []models.Point) ([]models.Point, []*FieldCreate, error) {
+	var (
+		fieldsToCreate []*FieldCreate
+		err            error
+		dropped, n     int
+		reason         string
+	)
 	if s.options.Config.MaxValuesPerTag > 0 {
-		for _, p := range points {
+		// Validate that all the new points would not exceed any limits, if so, we drop them
+		// and record why/increment counters
+		for i, p := range points {
 			tags := p.Tags()
-			// Tag value cardinality limit
 			m := s.index.Measurement(p.Name())
+
 			// Measurement doesn't exist yet, can't check the limit
 			if m != nil {
+				var dropPoint bool
 				for _, tag := range tags {
 					// If the tag value already exists, skip the limit check
 					if m.HasTagKeyValue(tag.Key, tag.Value) {
@@ -484,16 +512,29 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 
 					n := m.Cardinality(tag.Key)
 					if n >= s.options.Config.MaxValuesPerTag {
-						return nil, fmt.Errorf("max values per tag exceeded: %s, %v=%v: %d, limit %d",
-							m.Name, string(tag.Key), string(tag.Value), n, s.options.Config.MaxValuesPerTag)
+						dropPoint = true
+						reason = fmt.Sprintf("max tag value limit exceeded (%d/%d): measurement=%q tag=%q value=%q",
+							n, s.options.Config.MaxValuesPerTag, m.Name, string(tag.Key), string(tag.Key))
+						break
 					}
 				}
+				if dropPoint {
+					atomic.AddInt64(&s.stats.WritePointsDropped, 1)
+					dropped += 1
+
+					// This causes n below to not be increment allowing the point to be dropped
+					continue
+				}
 			}
+			points[n] = points[i]
+			n += 1
 		}
+		points = points[:n]
 	}
 
 	// get the shard mutex for locally defined fields
-	for _, p := range points {
+	n = 0
+	for i, p := range points {
 		// verify the tags and fields
 		tags := p.Tags()
 		if v := tags.Get(timeBytes); v != nil {
@@ -523,7 +564,11 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 		ss := s.index.SeriesBytes(p.Key())
 		if ss == nil {
 			if s.options.Config.MaxSeriesPerDatabase > 0 && s.index.SeriesN()+1 > s.options.Config.MaxSeriesPerDatabase {
-				return nil, fmt.Errorf("max series per database exceeded: %s", p.Key())
+				atomic.AddInt64(&s.stats.WritePointsDropped, 1)
+				dropped += 1
+				reason = fmt.Sprintf("db %s max series limit reached: (%d/%d)",
+					s.database, s.index.SeriesN(), s.options.Config.MaxSeriesPerDatabase)
+				continue
 			}
 
 			ss = s.index.CreateSeriesIndexIfNotExists(p.Name(), NewSeries(string(p.Key()), tags))
@@ -577,7 +622,7 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 			if f := mf.FieldBytes(iter.FieldKey()); f != nil {
 				// Field present in shard metadata, make sure there is no type conflict.
 				if f.Type != fieldType {
-					return nil, fmt.Errorf("%s: input field \"%s\" on measurement \"%s\" is type %s, already exists as type %s", ErrFieldTypeConflict, iter.FieldKey(), p.Name(), fieldType, f.Type)
+					return points, nil, fmt.Errorf("%s: input field \"%s\" on measurement \"%s\" is type %s, already exists as type %s", ErrFieldTypeConflict, iter.FieldKey(), p.Name(), fieldType, f.Type)
 				}
 
 				continue // Field is present, and it's of the same type. Nothing more to do.
@@ -585,9 +630,16 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]*FieldCreate, 
 
 			fieldsToCreate = append(fieldsToCreate, &FieldCreate{p.Name(), &Field{Name: string(iter.FieldKey()), Type: fieldType}})
 		}
+		points[n] = points[i]
+		n += 1
+	}
+	points = points[:n]
+
+	if dropped > 0 {
+		err = PartialWriteError{Reason: reason, Dropped: dropped}
 	}
 
-	return fieldsToCreate, nil
+	return points, fieldsToCreate, err
 }
 
 // SeriesCount returns the number of series buckets on the shard.
@@ -810,8 +862,8 @@ func (s *Shard) monitor() {
 
 					// Log at 80, 85, 90-100% levels
 					if perc == 80 || perc == 85 || perc >= 90 {
-						s.logger.Printf("WARN: %d%% of tag values limit reached: (%d/%d), db=%s measurement=%s tag=%s",
-							perc, n, s.options.Config.MaxValuesPerTag, s.database, m.Name, k)
+						s.logger.Printf("WARN: %d%% of tag values limit reached: (%d/%d), db=%s shard=%d measurement=%s tag=%s",
+							perc, n, s.options.Config.MaxValuesPerTag, s.database, s.id, m.Name, k)
 					}
 				}
 			}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -510,7 +510,7 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]models.Point, 
 						continue
 					}
 
-					n := m.Cardinality(tag.Key)
+					n := m.CardinalityBytes(tag.Key)
 					if n >= s.options.Config.MaxValuesPerTag {
 						dropPoint = true
 						reason = fmt.Sprintf("max tag value limit exceeded (%d/%d): measurement=%q tag=%q value=%q",
@@ -853,7 +853,7 @@ func (s *Shard) monitor() {
 			}
 
 			for _, m := range s.index.Measurements() {
-				for _, k := range m.TagKeysBytes() {
+				for _, k := range m.TagKeys() {
 					n := m.Cardinality(k)
 					perc := int(float64(n) / float64(s.options.Config.MaxValuesPerTag) * 100)
 					if perc > 100 {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR adds a `max-values-per-tag` limit with a default of `100000`.  The limit is enabled by default and can be disabled by setting it to `0`.  When the limit is set, any writes to a measurement that would cause a single tags cardinality to exceed the limit will be dropped.  The limit is soft in that it is possible to exceed it under high concurrency or if the middle of a batch of writes would exceed it.  In these cases, the writes are allowed, but subsequent writes would be dropped.  When writes are dropped, only the points that exceed a limit are dropped within the batch and the remaining points are stored.  Similarly, writing to existing series will alway be allowed since cardinality would not change.  

Since dropping points can be confusing to users, the following things occur to help alert users that writes are being dropped:

1. As the cardinality of a tag approaches 80%-100%, warning messages indicating the problem databases, measurement, tag and value are logged once a minute indicating the limit is almost met.
2. Writes return a 400, with a `partial write` error indicating the limit that was exceeded as well as the measurement and tag that caused the problem.  Additionally, the number of points that were dropped in the batch are included in the error message.
3. `writePointsDropped` stats on `shard` measurement as well as `pointsWrittenDropped` on `http` measurement are incremented when a point is dropped from a write.

Finally, this also changes the behavior of the `max-series-per-database` limit to drop points instead of rejecting the full batch.

Fixes #7146