### PR TITLE
Add build script for Alpine & Linux binaries

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,11 +2,16 @@
 
 To build the commandline interface and the daemon just run ``.
 
-## Alpine
+## Make Alpine/Linux version
 
 ```
-$ docker run --rm -ti -v $(pwd):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-qnib.sh
-fatal: no tag exactly matches 'cbe96a6f5606fe473b9b4f3b7f6ea440495b5fd4'
-> go build -o ./bin/influx_v1.0.2-dirty-190_alpine
-> go build -o ./bin/influxd_v1.0.2-dirty-190_alpine
+$ make linux alpine
+docker run --rm -ti -v /Users/kniepbert/src/github.com/ChristianKniep/influxdb:/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/golang ./build-qnib.sh
+fatal: no tag exactly matches '3206dac290735d7c11a4d8ebe1c8f59d652f94bc'
+> go build -o ./bin/influx_v1.0.2-dirty-193_linux
+> go build -o ./bin/influxd_v1.0.2-dirty-193_linux
+docker run --rm -ti -v /Users/kniepbert/src/github.com/ChristianKniep/influxdb:/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-qnib.sh
+fatal: no tag exactly matches '3206dac290735d7c11a4d8ebe1c8f59d652f94bc'
+> go build -o ./bin/influx_v1.0.2-dirty-193_alpine
+> go build -o ./bin/influxd_v1.0.2-dirty-193_alpine
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -6,12 +6,18 @@ To build the commandline interface and the daemon just run ``.
 
 ```
 $ make linux alpine
-docker run --rm -ti -v /Users/kniepbert/src/github.com/ChristianKniep/influxdb:/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/golang ./build-qnib.sh
+docker run --rm -ti -v $(pwd):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/golang ./build-qnib.sh
 fatal: no tag exactly matches '3206dac290735d7c11a4d8ebe1c8f59d652f94bc'
-> go build -o ./bin/influx_v1.0.2-dirty-193_linux
-> go build -o ./bin/influxd_v1.0.2-dirty-193_linux
-docker run --rm -ti -v /Users/kniepbert/src/github.com/ChristianKniep/influxdb:/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-qnib.sh
+> go build -o ./bin/./influx_v1.0.2-dirty-194_linux
+> go build -o ./bin/./influx_inspect_v1.0.2-dirty-194_linux
+> go build -o ./bin/./influx_stress_v1.0.2-dirty-194_linux
+> go build -o ./bin/./influx_tsm_v1.0.2-dirty-194_linux
+> go build -o ./bin/./influxd_v1.0.2-dirty-194_linux
+docker run --rm -ti -v $(pwd):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-qnib.sh
 fatal: no tag exactly matches '3206dac290735d7c11a4d8ebe1c8f59d652f94bc'
-> go build -o ./bin/influx_v1.0.2-dirty-193_alpine
-> go build -o ./bin/influxd_v1.0.2-dirty-193_alpine
+> go build -o ./bin/./influx_v1.0.2-dirty-194_alpine
+> go build -o ./bin/./influx_inspect_v1.0.2-dirty-194_alpine
+> go build -o ./bin/./influx_stress_v1.0.2-dirty-194_alpine
+> go build -o ./bin/./influx_tsm_v1.0.2-dirty-194_alpine
+> go build -o ./bin/./influxd_v1.0.2-dirty-194_alpine
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -5,7 +5,7 @@ To build the commandline interface and the daemon just run ``.
 ## Alpine
 
 ```
-$ docker run --rm -ti -v $(pwd):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-in-container.sh
+$ docker run --rm -ti -v $(pwd):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-qnib.sh
 fatal: no tag exactly matches 'cbe96a6f5606fe473b9b4f3b7f6ea440495b5fd4'
 > go build -o ./bin/influx_v1.0.2-dirty-190_alpine
 > go build -o ./bin/influxd_v1.0.2-dirty-190_alpine

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,12 @@
+# Build InfluxDB
+
+To build the commandline interface and the daemon just run ``.
+
+## Alpine
+
+```
+$ docker run --rm -ti -v $(pwd):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-in-container.sh
+fatal: no tag exactly matches 'cbe96a6f5606fe473b9b4f3b7f6ea440495b5fd4'
+> go build -o ./bin/influx_v1.0.2-dirty-190_alpine
+> go build -o ./bin/influxd_v1.0.2-dirty-190_alpine
+```

--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,9 @@ tools:
 	go get github.com/kisielk/errcheck
 	go get github.com/sparrc/gdm
 
+linux:
+	docker run --rm -ti -v $(CURDIR):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/golang ./build-qnib.sh
+alpine:
+	docker run --rm -ti -v $(CURDIR):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-qnib.sh
+
 .PHONY: default,metalint,deadcode,cyclo,aligncheck,defercheck,structcheck,lint,errcheck,tools

--- a/build-in-container.sh
+++ b/build-in-container.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+## tag
+GIT_ORG_TAG=$(git describe --abbrev=0 --tags)
+git describe --exact-match --abbrev=0 > /dev/null
+if [ $? -ne 0 ];then
+    GIT_TAG="${GIT_ORG_TAG}-dirty"
+    BC_CMD=$(which bc)
+    if [ $? -ne 0 ];then
+        echo "!! Need bc command to calculate the number of commits -> proceed without..."
+    else
+        ## commit since tags
+        CNT_ALL=$(git log --oneline |wc -l)
+        CNT_COMMITS=$(echo "${CNT_ALL}-$(git log --oneline ${GIT_ORG_TAG} |wc -l)" |bc)
+        GIT_TAG="${GIT_TAG}-${CNT_COMMITS}"
+    fi
+fi
+
+## OS
+if [ -f /etc/os-release ];then
+    . /etc/os-release
+    if [ "X${ID}" != "Xalpine" ];then
+      ID=Linux
+    fi
+else
+    ID=$(uname -s)
+fi
+WDIR=$(pwd)
+if [ ! -d ${WDIR}/bin/ ];then
+    echo "No target directory (${WDIR}/bin/)... "
+    exit 1
+fi
+
+## CLI
+cd ${WDIR}/cmd/influx
+go get -d
+echo "> go build -o ${WDIR}/bin/influx_${GIT_TAG}_${ID}"
+go build -o ${WDIR}/bin/influx_${GIT_TAG}_${ID}
+
+## Server
+cd ${WDIR}/cmd/influxd
+go get -d
+echo "> go build -o ${WDIR}/bin/influxd_${GIT_TAG}_${ID}"
+go build -o ${WDIR}/bin/influxd_${GIT_TAG}_${ID}

--- a/build-in-container.sh
+++ b/build-in-container.sh
@@ -34,11 +34,11 @@ fi
 ## CLI
 cd ${WDIR}/cmd/influx
 go get -d
-echo "> go build -o ${WDIR}/bin/influx_${GIT_TAG}_${ID}"
+echo "> go build -o ./bin/influx_${GIT_TAG}_${ID}"
 go build -o ${WDIR}/bin/influx_${GIT_TAG}_${ID}
 
 ## Server
 cd ${WDIR}/cmd/influxd
 go get -d
-echo "> go build -o ${WDIR}/bin/influxd_${GIT_TAG}_${ID}"
+echo "> go build -o ./bin/influxd_${GIT_TAG}_${ID}"
 go build -o ${WDIR}/bin/influxd_${GIT_TAG}_${ID}

--- a/build-qnib.sh
+++ b/build-qnib.sh
@@ -31,14 +31,10 @@ if [ ! -d ${WDIR}/bin/ ];then
     exit 1
 fi
 ARCH=$(echo ${ID} |tr '[:upper:]' '[:lower:]')
-## CLI
-cd ${WDIR}/cmd/influx
-go get -d
-echo "> go build -o ./bin/influx_${GIT_TAG}_${ARCH}"
-go build -o ${WDIR}/bin/influx_${GIT_TAG}_${ARCH}
-
-## Server
-cd ${WDIR}/cmd/influxd
-go get -d
-echo "> go build -o ./bin/influxd_${GIT_TAG}_${ARCH}"
-go build -o ${WDIR}/bin/influxd_${GIT_TAG}_${ARCH}
+cd cmd/
+for cmd in $(find . -maxdepth 1 -mindepth 1 -type d);do
+    cd ${WDIR}/cmd/${cmd}
+    go get -d
+    echo "> go build -o ./bin/${cmd}_${GIT_TAG}_${ARCH}"
+    go build -o ${WDIR}/bin/${cmd}_${GIT_TAG}_${ARCH}
+done

--- a/build-qnib.sh
+++ b/build-qnib.sh
@@ -30,15 +30,15 @@ if [ ! -d ${WDIR}/bin/ ];then
     echo "No target directory (${WDIR}/bin/)... "
     exit 1
 fi
-
+ARCH=$(echo ${ID} |tr '[:upper:]' '[:lower:]')
 ## CLI
 cd ${WDIR}/cmd/influx
 go get -d
-echo "> go build -o ./bin/influx_${GIT_TAG}_${ID}"
-go build -o ${WDIR}/bin/influx_${GIT_TAG}_${ID}
+echo "> go build -o ./bin/influx_${GIT_TAG}_${ARCH}"
+go build -o ${WDIR}/bin/influx_${GIT_TAG}_${ARCH}
 
 ## Server
 cd ${WDIR}/cmd/influxd
 go get -d
-echo "> go build -o ./bin/influxd_${GIT_TAG}_${ID}"
-go build -o ${WDIR}/bin/influxd_${GIT_TAG}_${ID}
+echo "> go build -o ./bin/influxd_${GIT_TAG}_${ARCH}"
+go build -o ${WDIR}/bin/influxd_${GIT_TAG}_${ARCH}


### PR DESCRIPTION
I was looking for an up-to-date alpine binary and ended up createing a little build-script which uses an alpine and fedora container image to create the binaries.

Not really a critical thing... Just FYI, maybe someone finds it usefull (other than me :).

```
$ make linux alpine
docker run --rm -ti -v $(pwd):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/golang ./build-qnib.sh
fatal: no tag exactly matches '3206dac290735d7c11a4d8ebe1c8f59d652f94bc'
> go build -o ./bin/./influx_v1.0.2-dirty-194_linux
> go build -o ./bin/./influx_inspect_v1.0.2-dirty-194_linux
> go build -o ./bin/./influx_stress_v1.0.2-dirty-194_linux
> go build -o ./bin/./influx_tsm_v1.0.2-dirty-194_linux
> go build -o ./bin/./influxd_v1.0.2-dirty-194_linux
docker run --rm -ti -v $(pwd):/usr/local/src/github.com/influxdata/influxdb/ --workdir /usr/local/src/github.com/influxdata/influxdb/ qnib/alpn-go-dev ./build-qnib.sh
fatal: no tag exactly matches '3206dac290735d7c11a4d8ebe1c8f59d652f94bc'
> go build -o ./bin/./influx_v1.0.2-dirty-194_alpine
> go build -o ./bin/./influx_inspect_v1.0.2-dirty-194_alpine
> go build -o ./bin/./influx_stress_v1.0.2-dirty-194_alpine
> go build -o ./bin/./influx_tsm_v1.0.2-dirty-194_alpine
> go build -o ./bin/./influxd_v1.0.2-dirty-194_alpine
```
**EDIT**: Included all commands under `./cmd/`

To allow my build-change to use the binaries from 'the interweb', I publish them in my fork: 
e.g. https://github.com/ChristianKniep/influxdb/releases/tag/v1.0.2-dirty-195