### PR TITLE
Correctly read in input from a non-interactive stream for the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [#5955](https://github.com/influxdata/influxdb/issues/5955): Make regex work on field and dimension keys in SELECT clause.
 - [#7470](https://github.com/influxdata/influxdb/pull/7470): Reduce map allocations when computing the TagSet of a measurement.
 - [#6894](https://github.com/influxdata/influxdb/issues/6894): Support `INFLUX_USERNAME` and `INFLUX_PASSWORD` for setting username/password in the CLI.
+- [#6896](https://github.com/influxdata/influxdb/issues/6896): Correctly read in input from a non-interactive stream for the CLI.
 
 ### Bugfixes
 

--- a/cmd/influx/cli/cli_test.go
+++ b/cmd/influx/cli/cli_test.go
@@ -48,6 +48,7 @@ func TestRunCLI(t *testing.T) {
 	c.Host = h
 	c.Port, _ = strconv.Atoi(p)
 	c.IgnoreSignals = true
+	c.ForceTTY = true
 	go func() {
 		close(c.Quit)
 	}()
@@ -69,6 +70,7 @@ func TestRunCLI_ExecuteInsert(t *testing.T) {
 	c.Precision = "ms"
 	c.Execute = "INSERT sensor,floor=1 value=2"
 	c.IgnoreSignals = true
+	c.ForceTTY = true
 	if err := c.Run(); err != nil {
 		t.Fatalf("Run failed with error: %s", err)
 	}


### PR DESCRIPTION
If you pipe in a file to the `influx` CLI, it will not try to open the
interactive line reader, but instead just send the contents of the
entire file to the server.

Fixes #6896.