### PR TITLE
Speed up shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#7305](https://github.com/influxdata/influxdb/pull/7305): UDP Client: Split large points. Thanks @vlasad
 - [#7115](https://github.com/influxdata/influxdb/issues/7115): Feature request: `influx inspect -export` should dump WAL files.
 - [#7388](https://github.com/influxdata/influxdb/pull/7388): Implement cumulative_sum() function.
+- [#7441](https://github.com/influxdata/influxdb/pull/7441): Speed up shutdown by closing shards concurrently.
 
 ### Bugfixes
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -229,11 +229,13 @@ func (s *Store) Close() error {
 	}
 	s.wg.Wait()
 
-	for _, sh := range s.shards {
-		if err := sh.Close(); err != nil {
-			return err
-		}
+	// Close all the shards in parallel.
+	if err := s.walkShards(s.shardsSlice(), func(sh *Shard) error {
+		return sh.Close()
+	}); err != nil {
+		return err
 	}
+
 	s.opened = false
 	s.shards = nil
 	s.databaseIndexes = nil


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

On my machine with about 20 shards, it would take 10+ seconds to shut
down InfluxDB with SIGINT. After this change, it shuts down in nearly
instantly.

(*tsdb.Store).Close was shutting down each of its shards sequentially.
Each shard's engine would signal to its compaction goroutines to quit,
and because each compaction goroutine has a hardcoded 1-second sleep in
between checks, waiting for the goroutines would often block for up to a
second.

This change closes all of the TSDB store's shards in parallel. This
means it's possible that multiple close values could error at once, but
we're still only returning the first error, consistent with previous
behavior. That being said, the return value of (\*tsdb.Store).Close is
ignored in (\*cmd/influxd/run.Server).Close anyway.