### PR TITLE
Support using regexes to select fields and dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#7388](https://github.com/influxdata/influxdb/pull/7388): Implement cumulative_sum() function.
 - [#7441](https://github.com/influxdata/influxdb/pull/7441): Speed up shutdown by closing shards concurrently.
 - [#7146](https://github.com/influxdata/influxdb/issues/7146): Add max-values-per-tag to limit high tag cardinality data
+- [#5955](https://github.com/influxdata/influxdb/issues/5955): Make regex work on field and dimension keys in SELECT clause.
 
 ### Bugfixes
 

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -390,6 +390,23 @@ func TestSelectStatement_RewriteFields(t *testing.T) {
 			stmt:    `SELECT mean(*) AS alias FROM cpu`,
 			rewrite: `SELECT mean(value1::float) AS alias_value1, mean(value2::integer) AS alias_value2 FROM cpu`,
 		},
+
+		// Query regex
+		{
+			stmt:    `SELECT /1/ FROM cpu`,
+			rewrite: `SELECT value1::float FROM cpu`,
+		},
+
+		{
+			stmt:    `SELECT value1 FROM cpu GROUP BY /h/`,
+			rewrite: `SELECT value1::float FROM cpu GROUP BY host`,
+		},
+
+		// Query regex
+		{
+			stmt:    `SELECT mean(/1/) FROM cpu`,
+			rewrite: `SELECT mean(value1::float) AS mean_value1 FROM cpu`,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
The functionality works the same as wildcards, but this time, you can
specify a regular expression.

One limitation is that you can't specify whether you only want to select
fields or tags. Since the regex can be changed to suit the person's
needs, I don't currently think this is an issue.

Fixes #5955.