### PR TITLE
Remove accidentally added string support for the stddev call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [#7226](https://github.com/influxdata/influxdb/issues/7226): Fix database locked up when deleting shards
 - [#7382](https://github.com/influxdata/influxdb/issues/7382): Shard stats include wal path tag so disk bytes make more sense.
 - [#7385](https://github.com/influxdata/influxdb/pull/7385): Reduce query planning allocations
+- [#7436](https://github.com/influxdata/influxdb/issues/7436): Remove accidentally added string support for the stddev call.
 
 ## v1.0.2 [2016-10-05]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1167,9 +1167,7 @@ func (s *SelectStatement) RewriteFields(ic IteratorCreator) (*SelectStatement, e
 				switch call.Name {
 				case "count", "first", "last", "distinct", "elapsed", "mode":
 					supportedTypes[String] = struct{}{}
-					supportedTypes[Boolean] = struct{}{}
-				case "stddev":
-					supportedTypes[String] = struct{}{}
+					fallthrough
 				case "min", "max":
 					supportedTypes[Boolean] = struct{}{}
 				}

--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -677,12 +677,6 @@ func newStddevIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 			return fn, fn
 		}
 		return &integerReduceFloatIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
-	case StringIterator:
-		createFn := func() (StringPointAggregator, StringPointEmitter) {
-			fn := NewStringSliceFuncReducer(StringStddevReduceSlice)
-			return fn, fn
-		}
-		return &stringReduceStringIterator{input: newBufStringIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported stddev iterator type: %T", input)
 	}
@@ -744,11 +738,6 @@ func IntegerStddevReduceSlice(a []IntegerPoint) []FloatPoint {
 		Time:  ZeroTime,
 		Value: math.Sqrt(variance / float64(count-1)),
 	}}
-}
-
-// StringStddevReduceSlice always returns "".
-func StringStddevReduceSlice(a []StringPoint) []StringPoint {
-	return []StringPoint{{Time: ZeroTime, Value: ""}}
 }
 
 // newSpreadIterator returns an iterator for operating on a spread() call.

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -1320,43 +1320,6 @@ func TestSelect_Stddev_Integer(t *testing.T) {
 	}
 }
 
-// Ensure a SELECT stddev() query can be executed.
-func TestSelect_Stddev_String(t *testing.T) {
-	var ic IteratorCreator
-	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
-		return &StringIterator{Points: []influxql.StringPoint{
-			{Name: "cpu", Tags: ParseTags("region=west,host=A"), Time: 0 * Second, Value: "a"},
-			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 5 * Second, Value: "b"},
-			{Name: "cpu", Tags: ParseTags("region=east,host=A"), Time: 9 * Second, Value: "c"},
-			{Name: "cpu", Tags: ParseTags("region=east,host=A"), Time: 10 * Second, Value: "d"},
-			{Name: "cpu", Tags: ParseTags("region=west,host=A"), Time: 11 * Second, Value: "e"},
-			{Name: "cpu", Tags: ParseTags("region=west,host=A"), Time: 31 * Second, Value: "f"},
-
-			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 50 * Second, Value: "g"},
-			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 51 * Second, Value: "h"},
-			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 52 * Second, Value: "i"},
-			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 53 * Second, Value: "j"},
-			{Name: "cpu", Tags: ParseTags("region=west,host=B"), Time: 53 * Second, Value: "k"},
-		}}, nil
-	}
-
-	// Execute selection.
-	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT stddev(value) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-02T00:00:00Z' GROUP BY time(10s), host fill(none)`), &ic, nil)
-	if err != nil {
-		t.Fatal(err)
-	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: ""}},
-		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: ""}},
-		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: ""}},
-		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: ""}},
-		{&influxql.StringPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: ""}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
-	}
-}
-
 // Ensure a SELECT spread() query can be executed.
 func TestSelect_Spread_Float(t *testing.T) {
 	var ic IteratorCreator


### PR DESCRIPTION
Strings would always return an empty string and stddev is meaningless
when it comes to strings. This removes that functionality so strings
don't automatically get picked up when using a wildcard.

Fixes #7436.