### PR TITLE
Ensure input services can be safely opened and closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#7470](https://github.com/influxdata/influxdb/pull/7470): Reduce map allocations when computing the TagSet of a measurement.
 - [#6894](https://github.com/influxdata/influxdb/issues/6894): Support `INFLUX_USERNAME` and `INFLUX_PASSWORD` for setting username/password in the CLI.
 - [#6896](https://github.com/influxdata/influxdb/issues/6896): Correctly read in input from a non-interactive stream for the CLI.
+- [#7463](https://github.com/influxdata/influxdb/pull/7463): Make input plugin services open/close idempotent.
 
 ### Bugfixes
 

--- a/internal/meta_client.go
+++ b/internal/meta_client.go
@@ -1,0 +1,162 @@
+package internal
+
+import (
+	"time"
+
+	"github.com/influxdata/influxdb/influxql"
+	"github.com/influxdata/influxdb/services/meta"
+)
+
+// MetaClientMock is a mockable implementation of meta.MetaClient.
+type MetaClientMock struct {
+	CloseFn                             func() error
+	CreateContinuousQueryFn             func(database, name, query string) error
+	CreateDatabaseFn                    func(name string) (*meta.DatabaseInfo, error)
+	CreateDatabaseWithRetentionPolicyFn func(name string, spec *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error)
+	CreateRetentionPolicyFn             func(database string, spec *meta.RetentionPolicySpec) (*meta.RetentionPolicyInfo, error)
+	CreateShardGroupFn                  func(database, policy string, timestamp time.Time) (*meta.ShardGroupInfo, error)
+	CreateSubscriptionFn                func(database, rp, name, mode string, destinations []string) error
+	CreateUserFn                        func(name, password string, admin bool) (*meta.UserInfo, error)
+
+	DatabaseFn  func(name string) *meta.DatabaseInfo
+	DatabasesFn func() ([]meta.DatabaseInfo, error)
+
+	DataFn                func() meta.Data
+	DeleteShardGroupFn    func(database string, policy string, id uint64) error
+	DropContinuousQueryFn func(database, name string) error
+	DropDatabaseFn        func(name string) error
+	DropRetentionPolicyFn func(database, name string) error
+	DropSubscriptionFn    func(database, rp, name string) error
+	DropShardFn           func(id uint64) error
+	DropUserFn            func(name string) error
+
+	OpenFn func() error
+
+	RetentionPolicyFn func(database, name string) (rpi *meta.RetentionPolicyInfo, err error)
+
+	SetAdminPrivilegeFn         func(username string, admin bool) error
+	SetDataFn                   func(*meta.Data) error
+	SetDefaultRetentionPolicyFn func(database, name string) error
+	SetPrivilegeFn              func(username, database string, p influxql.Privilege) error
+	ShardsByTimeRangeFn         func(sources influxql.Sources, tmin, tmax time.Time) (a []meta.ShardInfo, err error)
+	ShardOwnerFn                func(shardID uint64) (database, policy string, sgi *meta.ShardGroupInfo)
+	UpdateRetentionPolicyFn     func(database, name string, rpu *meta.RetentionPolicyUpdate) error
+	UpdateUserFn                func(name, password string) error
+	UserPrivilegeFn             func(username, database string) (*influxql.Privilege, error)
+	UserPrivilegesFn            func(username string) (map[string]influxql.Privilege, error)
+	UsersFn                     func() []meta.UserInfo
+}
+
+func (c *MetaClientMock) Close() error {
+	return c.CloseFn()
+}
+
+func (c *MetaClientMock) CreateContinuousQuery(database, name, query string) error {
+	return c.CreateContinuousQueryFn(database, name, query)
+}
+
+func (c *MetaClientMock) CreateDatabase(name string) (*meta.DatabaseInfo, error) {
+	return c.CreateDatabaseFn(name)
+}
+
+func (c *MetaClientMock) CreateDatabaseWithRetentionPolicy(name string, spec *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error) {
+	return c.CreateDatabaseWithRetentionPolicyFn(name, spec)
+}
+
+func (c *MetaClientMock) CreateRetentionPolicy(database string, spec *meta.RetentionPolicySpec) (*meta.RetentionPolicyInfo, error) {
+	return c.CreateRetentionPolicyFn(database, spec)
+}
+
+func (c *MetaClientMock) CreateShardGroup(database, policy string, timestamp time.Time) (*meta.ShardGroupInfo, error) {
+	return c.CreateShardGroupFn(database, policy, timestamp)
+}
+
+func (c *MetaClientMock) CreateSubscription(database, rp, name, mode string, destinations []string) error {
+	return c.CreateSubscriptionFn(database, rp, name, mode, destinations)
+}
+
+func (c *MetaClientMock) CreateUser(name, password string, admin bool) (*meta.UserInfo, error) {
+	return c.CreateUserFn(name, password, admin)
+}
+
+func (c *MetaClientMock) Database(name string) *meta.DatabaseInfo {
+	return c.DatabaseFn(name)
+}
+
+func (c *MetaClientMock) Databases() ([]meta.DatabaseInfo, error) {
+	return c.DatabasesFn()
+}
+
+func (c *MetaClientMock) DeleteShardGroup(database string, policy string, id uint64) error {
+	return c.DeleteShardGroup(database, policy, id)
+}
+
+func (c *MetaClientMock) DropContinuousQuery(database, name string) error {
+	return c.DropContinuousQueryFn(database, name)
+}
+
+func (c *MetaClientMock) DropDatabase(name string) error {
+	return c.DropDatabaseFn(name)
+}
+
+func (c *MetaClientMock) DropRetentionPolicy(database, name string) error {
+	return c.DropRetentionPolicyFn(database, name)
+}
+
+func (c *MetaClientMock) DropShard(id uint64) error {
+	return c.DropShardFn(id)
+}
+
+func (c *MetaClientMock) DropSubscription(database, rp, name string) error {
+	return c.DropSubscriptionFn(database, rp, name)
+}
+
+func (c *MetaClientMock) DropUser(name string) error {
+	return c.DropUserFn(name)
+}
+
+func (c *MetaClientMock) RetentionPolicy(database, name string) (rpi *meta.RetentionPolicyInfo, err error) {
+	return c.RetentionPolicyFn(database, name)
+}
+
+func (c *MetaClientMock) SetAdminPrivilege(username string, admin bool) error {
+	return c.SetAdminPrivilegeFn(username, admin)
+}
+
+func (c *MetaClientMock) SetDefaultRetentionPolicy(database, name string) error {
+	return c.SetDefaultRetentionPolicyFn(database, name)
+}
+
+func (c *MetaClientMock) SetPrivilege(username, database string, p influxql.Privilege) error {
+	return c.SetPrivilegeFn(username, database, p)
+}
+
+func (c *MetaClientMock) ShardsByTimeRange(sources influxql.Sources, tmin, tmax time.Time) (a []meta.ShardInfo, err error) {
+	return c.ShardsByTimeRangeFn(sources, tmin, tmax)
+}
+
+func (c *MetaClientMock) ShardOwner(shardID uint64) (database, policy string, sgi *meta.ShardGroupInfo) {
+	return c.ShardOwnerFn(shardID)
+}
+
+func (c *MetaClientMock) UpdateRetentionPolicy(database, name string, rpu *meta.RetentionPolicyUpdate) error {
+	return c.UpdateRetentionPolicyFn(database, name, rpu)
+}
+
+func (c *MetaClientMock) UpdateUser(name, password string) error {
+	return c.UpdateUserFn(name, password)
+}
+
+func (c *MetaClientMock) UserPrivilege(username, database string) (*influxql.Privilege, error) {
+	return c.UserPrivilegeFn(username, database)
+}
+
+func (c *MetaClientMock) UserPrivileges(username string) (map[string]influxql.Privilege, error) {
+	return c.UserPrivilegesFn(username)
+}
+
+func (c *MetaClientMock) Users() []meta.UserInfo { return c.UsersFn() }
+
+func (c *MetaClientMock) Open() error                { return c.OpenFn() }
+func (c *MetaClientMock) Data() meta.Data            { return c.DataFn() }
+func (c *MetaClientMock) SetData(d *meta.Data) error { return c.SetDataFn(d) }

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -50,11 +50,13 @@ type Service struct {
 
 	wg      sync.WaitGroup
 	err     chan error
-	stop    chan struct{}
 	conn    *net.UDPConn
 	batcher *tsdb.PointBatcher
 	typesdb gollectd.Types
 	addr    net.Addr
+
+	mu   sync.Mutex
+	done chan struct{}
 
 	// expvar-based stats.
 	stats       *Statistics
@@ -78,6 +80,14 @@ func NewService(c Config) *Service {
 
 // Open starts the service.
 func (s *Service) Open() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.closed() {
+		return nil // Already open.
+	}
+	s.done = make(chan struct{})
+
 	s.Logger.Printf("Starting collectd service")
 
 	if s.Config.BindAddress == "" {
@@ -142,7 +152,6 @@ func (s *Service) Open() error {
 			s.typesdb = typesdb
 		}
 	}
-
 	// Resolve our address.
 	addr, err := net.ResolveUDPAddr("udp", s.Config.BindAddress)
 	if err != nil {
@@ -171,8 +180,7 @@ func (s *Service) Open() error {
 	s.batcher = tsdb.NewPointBatcher(s.Config.BatchSize, s.Config.BatchPending, time.Duration(s.Config.BatchDuration))
 	s.batcher.Start()
 
-	// Create channel and wait group for signalling goroutines to stop.
-	s.stop = make(chan struct{})
+	// Create waitgroup for signalling goroutines to stop.
 	s.wg.Add(2)
 
 	// Start goroutines that process collectd packets.
@@ -184,10 +192,15 @@ func (s *Service) Open() error {
 
 // Close stops the service.
 func (s *Service) Close() error {
-	// Close the connection, and wait for the goroutine to exit.
-	if s.stop != nil {
-		close(s.stop)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed() {
+		return nil // Already closed.
 	}
+	close(s.done)
+
+	// Close the connection, and wait for the goroutine to exit.
 	if s.conn != nil {
 		s.conn.Close()
 	}
@@ -197,11 +210,28 @@ func (s *Service) Close() error {
 	s.wg.Wait()
 
 	// Release all remaining resources.
-	s.stop = nil
 	s.conn = nil
 	s.batcher = nil
 	s.Logger.Println("collectd UDP closed")
+	s.done = nil
 	return nil
+}
+
+// Closed returns true if the service is currently closed.
+func (s *Service) Closed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed()
+}
+
+func (s *Service) closed() bool {
+	select {
+	case <-s.done:
+		// Service is closing.
+		return true
+	default:
+	}
+	return s.done == nil
 }
 
 // SetLogOutput sets the writer to which all logs are written. It must not be
@@ -269,7 +299,7 @@ func (s *Service) serve() {
 
 	for {
 		select {
-		case <-s.stop:
+		case <-s.done:
 			// We closed the connection, time to go.
 			return
 		default:
@@ -310,7 +340,7 @@ func (s *Service) writePoints() {
 
 	for {
 		select {
-		case <-s.stop:
+		case <-s.done:
 			return
 		case batch := <-s.batcher.Out():
 			if err := s.PointsWriter.WritePoints(s.Config.Database, s.Config.RetentionPolicy, models.ConsistencyLevelAny, batch); err == nil {

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -49,7 +49,6 @@ type Service struct {
 	Logger       *log.Logger
 
 	wg      sync.WaitGroup
-	err     chan error
 	conn    *net.UDPConn
 	batcher *tsdb.PointBatcher
 	typesdb gollectd.Types
@@ -70,7 +69,6 @@ func NewService(c Config) *Service {
 		Config: c.WithDefaults(),
 
 		Logger:      log.New(os.Stderr, "[collectd] ", log.LstdFlags),
-		err:         make(chan error),
 		stats:       &Statistics{},
 		defaultTags: models.StatisticTags{"bind": c.BindAddress},
 	}
@@ -275,9 +273,6 @@ func (s *Service) SetTypes(types string) (err error) {
 	s.typesdb, err = gollectd.TypesDB([]byte(types))
 	return
 }
-
-// Err returns a channel for fatal errors that occur on go routines.
-func (s *Service) Err() chan error { return s.err }
 
 // Addr returns the listener's address. Returns nil if listener is closed.
 func (s *Service) Addr() net.Addr {

--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -2,18 +2,58 @@ package graphite_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/influxdata/influxdb/internal"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/graphite"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/toml"
 )
 
-func Test_ServerGraphiteTCP(t *testing.T) {
+func Test_Service_OpenClose(t *testing.T) {
+	c := graphite.Config{BindAddress: ":35422"}
+	service := NewService(&c)
+
+	// Closing a closed service is fine.
+	if err := service.GraphiteService.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Closing a closed service again is fine.
+	if err := service.GraphiteService.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := service.GraphiteService.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Opening an already open service is fine.
+	if err := service.GraphiteService.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopening a previously opened service is fine.
+	if err := service.GraphiteService.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := service.GraphiteService.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tidy up.
+	if err := service.GraphiteService.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Test_Service_TCP(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().UTC().Round(time.Second)
@@ -24,51 +64,52 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 	config.BatchTimeout = toml.Duration(time.Second)
 	config.BindAddress = ":0"
 
-	service, err := graphite.NewService(config)
-	if err != nil {
-		t.Fatalf("failed to create Graphite service: %s", err.Error())
-	}
+	service := NewService(&config)
 
 	// Allow test to wait until points are written.
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	pointsWriter := PointsWriter{
-		WritePointsFn: func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
-			defer wg.Done()
+	service.WritePointsFn = func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+		defer wg.Done()
 
-			pt, _ := models.NewPoint(
-				"cpu",
-				models.NewTags(map[string]string{}),
-				map[string]interface{}{"value": 23.456},
-				time.Unix(now.Unix(), 0))
+		pt, _ := models.NewPoint(
+			"cpu",
+			models.NewTags(map[string]string{}),
+			map[string]interface{}{"value": 23.456},
+			time.Unix(now.Unix(), 0))
 
-			if database != "graphitedb" {
-				t.Fatalf("unexpected database: %s", database)
-			} else if retentionPolicy != "" {
-				t.Fatalf("unexpected retention policy: %s", retentionPolicy)
-			} else if len(points) != 1 {
-				t.Fatalf("expected 1 point, got %d", len(points))
-			} else if points[0].String() != pt.String() {
-				t.Fatalf("expected point %v, got %v", pt.String(), points[0].String())
-			}
-			return nil
-		},
+		if database != "graphitedb" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if retentionPolicy != "" {
+			t.Fatalf("unexpected retention policy: %s", retentionPolicy)
+		} else if len(points) != 1 {
+			t.Fatalf("expected 1 point, got %d", len(points))
+		} else if points[0].String() != pt.String() {
+			t.Fatalf("expected point %v, got %v", pt.String(), points[0].String())
+		}
+		return nil
 	}
-	service.PointsWriter = &pointsWriter
-	dbCreator := DatabaseCreator{}
-	service.MetaClient = &dbCreator
 
-	if err := service.Open(); err != nil {
+	var created bool
+	service.MetaClient.CreateDatabaseWithRetentionPolicyFn = func(db string, _ *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error) {
+		if db != config.Database {
+			t.Fatalf("got %s, expected %s", db, config.Database)
+		}
+		created = true
+		return nil, nil
+	}
+
+	if err := service.GraphiteService.Open(); err != nil {
 		t.Fatalf("failed to open Graphite service: %s", err.Error())
 	}
 
-	if !dbCreator.Created {
+	if !created {
 		t.Fatalf("failed to create target database")
 	}
 
 	// Connect to the graphite endpoint we just spun up
-	_, port, _ := net.SplitHostPort(service.Addr().String())
+	_, port, _ := net.SplitHostPort(service.GraphiteService.Addr().String())
 	conn, err := net.Dial("tcp", "127.0.0.1:"+port)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +129,7 @@ func Test_ServerGraphiteTCP(t *testing.T) {
 	wg.Wait()
 }
 
-func Test_ServerGraphiteUDP(t *testing.T) {
+func Test_Service_UDP(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().UTC().Round(time.Second)
@@ -100,48 +141,49 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 	config.BindAddress = ":10000"
 	config.Protocol = "udp"
 
-	service, err := graphite.NewService(config)
-	if err != nil {
-		t.Fatalf("failed to create Graphite service: %s", err.Error())
-	}
+	service := NewService(&config)
 
 	// Allow test to wait until points are written.
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	pointsWriter := PointsWriter{
-		WritePointsFn: func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
-			defer wg.Done()
+	service.WritePointsFn = func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+		defer wg.Done()
 
-			pt, _ := models.NewPoint(
-				"cpu",
-				models.NewTags(map[string]string{}),
-				map[string]interface{}{"value": 23.456},
-				time.Unix(now.Unix(), 0))
-			if database != "graphitedb" {
-				t.Fatalf("unexpected database: %s", database)
-			} else if retentionPolicy != "" {
-				t.Fatalf("unexpected retention policy: %s", retentionPolicy)
-			} else if points[0].String() != pt.String() {
-				t.Fatalf("unexpected points: %#v", points[0].String())
-			}
-			return nil
-		},
+		pt, _ := models.NewPoint(
+			"cpu",
+			models.NewTags(map[string]string{}),
+			map[string]interface{}{"value": 23.456},
+			time.Unix(now.Unix(), 0))
+		if database != "graphitedb" {
+			t.Fatalf("unexpected database: %s", database)
+		} else if retentionPolicy != "" {
+			t.Fatalf("unexpected retention policy: %s", retentionPolicy)
+		} else if points[0].String() != pt.String() {
+			t.Fatalf("unexpected points: %#v", points[0].String())
+		}
+		return nil
 	}
-	service.PointsWriter = &pointsWriter
-	dbCreator := DatabaseCreator{}
-	service.MetaClient = &dbCreator
 
-	if err := service.Open(); err != nil {
+	var created bool
+	service.MetaClient.CreateDatabaseWithRetentionPolicyFn = func(db string, _ *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error) {
+		if db != config.Database {
+			t.Fatalf("got %s, expected %s", db, config.Database)
+		}
+		created = true
+		return nil, nil
+	}
+
+	if err := service.GraphiteService.Open(); err != nil {
 		t.Fatalf("failed to open Graphite service: %s", err.Error())
 	}
 
-	if !dbCreator.Created {
+	if !created {
 		t.Fatalf("failed to create target database")
 	}
 
 	// Connect to the graphite endpoint we just spun up
-	_, port, _ := net.SplitHostPort(service.Addr().String())
+	_, port, _ := net.SplitHostPort(service.GraphiteService.Addr().String())
 	conn, err := net.Dial("udp", "127.0.0.1:"+port)
 	if err != nil {
 		t.Fatal(err)
@@ -158,39 +200,59 @@ func Test_ServerGraphiteUDP(t *testing.T) {
 	conn.Close()
 }
 
-// PointsWriter represents a mock impl of PointsWriter.
-type PointsWriter struct {
+type Service struct {
+	GraphiteService *graphite.Service
+
+	MetaClient    *internal.MetaClientMock
 	WritePointsFn func(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
 }
 
-func (w *PointsWriter) WritePoints(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
-	return w.WritePointsFn(database, retentionPolicy, consistencyLevel, points)
+func NewService(c *graphite.Config) *Service {
+	if c == nil {
+		defaultC := graphite.NewConfig()
+		c = &defaultC
+	}
+
+	gservice, err := graphite.NewService(*c)
+	if err != nil {
+		panic(err)
+	}
+
+	service := &Service{
+		GraphiteService: gservice,
+		MetaClient:      &internal.MetaClientMock{},
+	}
+
+	service.MetaClient.CreateRetentionPolicyFn = func(string, *meta.RetentionPolicySpec) (*meta.RetentionPolicyInfo, error) {
+		return nil, nil
+	}
+
+	service.MetaClient.CreateDatabaseWithRetentionPolicyFn = func(string, *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error) {
+		return nil, nil
+	}
+
+	service.MetaClient.DatabaseFn = func(string) *meta.DatabaseInfo {
+		return nil
+	}
+
+	service.MetaClient.RetentionPolicyFn = func(string, string) (*meta.RetentionPolicyInfo, error) {
+		return nil, nil
+	}
+
+	// Set the Meta Client
+	service.GraphiteService.MetaClient = service.MetaClient
+
+	// Set the PointsWriter
+	service.GraphiteService.PointsWriter = service
+
+	if !testing.Verbose() {
+		service.GraphiteService.SetLogOutput(ioutil.Discard)
+	}
+	return service
 }
 
-type DatabaseCreator struct {
-	Created bool
-}
-
-func (d *DatabaseCreator) CreateDatabase(name string) (*meta.DatabaseInfo, error) {
-	d.Created = true
-	return nil, nil
-}
-
-func (d *DatabaseCreator) CreateRetentionPolicy(database string, spec *meta.RetentionPolicySpec) (*meta.RetentionPolicyInfo, error) {
-	return nil, nil
-}
-
-func (d *DatabaseCreator) CreateDatabaseWithRetentionPolicy(name string, spec *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error) {
-	d.Created = true
-	return nil, nil
-}
-
-func (d *DatabaseCreator) Database(name string) *meta.DatabaseInfo {
-	return nil
-}
-
-func (d *DatabaseCreator) RetentionPolicy(database, name string) (*meta.RetentionPolicyInfo, error) {
-	return nil, nil
+func (s *Service) WritePoints(database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	return s.WritePointsFn(database, retentionPolicy, consistencyLevel, points)
 }
 
 // Test Helpers

--- a/services/opentsdb/handler.go
+++ b/services/opentsdb/handler.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -138,8 +139,10 @@ func (h *Handler) servePut(w http.ResponseWriter, r *http.Request) {
 
 // chanListener represents a listener that receives connections through a channel.
 type chanListener struct {
-	addr net.Addr
-	ch   chan net.Conn
+	addr   net.Addr
+	ch     chan net.Conn
+	done   chan struct{}
+	closer sync.Once // closer ensures that Close is idempotent.
 }
 
 // newChanListener returns a new instance of chanListener.
@@ -147,20 +150,28 @@ func newChanListener(addr net.Addr) *chanListener {
 	return &chanListener{
 		addr: addr,
 		ch:   make(chan net.Conn),
+		done: make(chan struct{}),
 	}
 }
 
 func (ln *chanListener) Accept() (net.Conn, error) {
-	conn, ok := <-ln.ch
-	if !ok {
-		return nil, errors.New("network connection closed")
+	errClosed := errors.New("network connection closed")
+	select {
+	case <-ln.done:
+		return nil, errClosed
+	case conn, ok := <-ln.ch:
+		if !ok {
+			return nil, errClosed
+		}
+		return conn, nil
 	}
-	return conn, nil
 }
 
 // Close closes the connection channel.
 func (ln *chanListener) Close() error {
-	close(ln.ch)
+	ln.closer.Do(func() {
+		close(ln.done)
+	})
 	return nil
 }
 

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -49,7 +49,6 @@ type Service struct {
 	mu   sync.Mutex
 	wg   sync.WaitGroup
 	done chan struct{}
-	err  chan error
 	tls  bool
 	cert string
 
@@ -85,7 +84,6 @@ func NewService(c Config) (*Service, error) {
 	s := &Service{
 		tls:             d.TLSEnabled,
 		cert:            d.Certificate,
-		err:             make(chan error),
 		BindAddress:     d.BindAddress,
 		Database:        d.Database,
 		RetentionPolicy: d.RetentionPolicy,

--- a/services/udp/service_test.go
+++ b/services/udp/service_test.go
@@ -1,0 +1,75 @@
+package udp_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/influxdata/influxdb/internal"
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxdb/services/udp"
+)
+
+func TestService_OpenClose(t *testing.T) {
+	service := NewService(nil)
+
+	// Closing a closed service is fine.
+	if err := service.UDPService.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Closing a closed service again is fine.
+	if err := service.UDPService.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := service.UDPService.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Opening an already open service is fine.
+	if err := service.UDPService.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reopening a previously opened service is fine.
+	if err := service.UDPService.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := service.UDPService.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tidy up.
+	if err := service.UDPService.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type Service struct {
+	UDPService *udp.Service
+	MetaClient *internal.MetaClientMock
+}
+
+func NewService(c *udp.Config) *Service {
+	if c == nil {
+		defaultC := udp.NewConfig()
+		c = &defaultC
+	}
+
+	service := &Service{
+		UDPService: udp.NewService(*c),
+		MetaClient: &internal.MetaClientMock{},
+	}
+
+	service.MetaClient.CreateDatabaseFn = func(string) (*meta.DatabaseInfo, error) { return nil, nil }
+
+	// Set the Meta Client
+	service.UDPService.MetaClient = service.MetaClient
+
+	if !testing.Verbose() {
+		service.UDPService.SetLogOutput(ioutil.Discard)
+	}
+
+	return service
+}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This PR ensures that input services (`udp`, `graphite`, `opentsdb` and `collectd`) can be idempotently opened and closed.

It also fixes a goroutine leak where a listener was not being closed properly.
