### PR TITLE
Fix panic in AppendSeriesKeyByID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [#7385](https://github.com/influxdata/influxdb/pull/7385): Reduce query planning allocations
 - [#7436](https://github.com/influxdata/influxdb/issues/7436): Remove accidentally added string support for the stddev call.
 - [#7161](https://github.com/influxdata/influxdb/issues/7161): Drop measurement causes cache max memory exceeded error.
+- [#7334](https://github.com/influxdata/influxdb/issues/7334): Panic with unread show series iterators during drop database
 
 ## v1.0.2 [2016-10-05]
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -598,7 +598,9 @@ func (m *Measurement) AppendSeriesKeysByID(dst []string, ids []uint64) []string 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, id := range ids {
-		dst = append(dst, m.seriesByID[id].Key)
+		if s := m.seriesByID[id]; s != nil {
+			dst = append(dst, s.Key)
+		}
 	}
 	return dst
 }

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Test comparing SeriesIDs for equality.
-func Test_SeriesIDs_Equals(t *testing.T) {
+func TestSeriesIDs_Equals(t *testing.T) {
 	ids1 := tsdb.SeriesIDs([]uint64{1, 2, 3})
 	ids2 := tsdb.SeriesIDs([]uint64{1, 2, 3})
 	ids3 := tsdb.SeriesIDs([]uint64{4, 5, 6})
@@ -25,7 +25,7 @@ func Test_SeriesIDs_Equals(t *testing.T) {
 }
 
 // Test intersecting sets of SeriesIDs.
-func Test_SeriesIDs_Intersect(t *testing.T) {
+func TestSeriesIDs_Intersect(t *testing.T) {
 	// Test swaping l & r, all branches of if-else, and exit loop when 'j < len(r)'
 	ids1 := tsdb.SeriesIDs([]uint64{1, 3, 4, 5, 6})
 	ids2 := tsdb.SeriesIDs([]uint64{1, 2, 3, 7})
@@ -48,7 +48,7 @@ func Test_SeriesIDs_Intersect(t *testing.T) {
 }
 
 // Test union sets of SeriesIDs.
-func Test_SeriesIDs_Union(t *testing.T) {
+func TestSeriesIDs_Union(t *testing.T) {
 	// Test all branches of if-else, exit loop because of 'j < len(r)', and append remainder from left.
 	ids1 := tsdb.SeriesIDs([]uint64{1, 2, 3, 7})
 	ids2 := tsdb.SeriesIDs([]uint64{1, 3, 4, 5, 6})
@@ -71,7 +71,7 @@ func Test_SeriesIDs_Union(t *testing.T) {
 }
 
 // Test removing one set of SeriesIDs from another.
-func Test_SeriesIDs_Reject(t *testing.T) {
+func TestSeriesIDs_Reject(t *testing.T) {
 	// Test all branches of if-else, exit loop because of 'j < len(r)', and append remainder from left.
 	ids1 := tsdb.SeriesIDs([]uint64{1, 2, 3, 7})
 	ids2 := tsdb.SeriesIDs([]uint64{1, 3, 4, 5, 6})
@@ -90,6 +90,32 @@ func Test_SeriesIDs_Reject(t *testing.T) {
 
 	if !exp.Equals(got) {
 		t.Fatalf("exp=%v, got=%v", exp, got)
+	}
+}
+
+func TestMeasurement_AppendSeriesKeysByID_Missing(t *testing.T) {
+	m := tsdb.NewMeasurement("cpu")
+	var dst []string
+	dst = m.AppendSeriesKeysByID(dst, []uint64{1})
+	if exp, got := 0, len(dst); exp != got {
+		t.Fatalf("series len mismatch: exp %v, got %v", exp, got)
+	}
+}
+
+func TestMeasurement_AppendSeriesKeysByID_Exists(t *testing.T) {
+	m := tsdb.NewMeasurement("cpu")
+	s := tsdb.NewSeries("cpu,host=foo", models.Tags{models.Tag{Key: []byte("host"), Value: []byte("foo")}})
+	s.ID = 1
+	m.AddSeries(s)
+
+	var dst []string
+	dst = m.AppendSeriesKeysByID(dst, []uint64{1})
+	if exp, got := 1, len(dst); exp != got {
+		t.Fatalf("series len mismatch: exp %v, got %v", exp, got)
+	}
+
+	if exp, got := "cpu,host=foo", dst[0]; exp != got {
+		t.Fatalf("series mismatch: exp %v, got %v", exp, got)
 	}
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Calling this function with a series ID that does not exist in
the measurement causes a panic.

Fixes #7334