### PR TITLE
Rewrite some regex conditions to use index-compatible conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The following configuration changes in the `[data]` section may need to changed 
 - [#7496](https://github.com/influxdata/influxdb/pull/7496): Filter out series within shards that do not have data for that series.
 - [#7480](https://github.com/influxdata/influxdb/pull/7480): Improve compaction planning performance by caching tsm file stats.
 - [#7320](https://github.com/influxdata/influxdb/issues/7320): Update defaults in config for latest best practices
+- [#7495](https://github.com/influxdata/influxdb/pull/7495): Rewrite regexes of the form host = /^server-a$/ to host = 'server-a', to take advantage of the tsdb index.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/server_bench_test.go
+++ b/cmd/influxd/run/server_bench_test.go
@@ -7,25 +7,17 @@ import (
 	"testing"
 )
 
-func BenchmarkServer_Query_Count_1(b *testing.B) {
-	benchmarkServerQueryCount(b, 1)
-}
+var strResult string
 
-func BenchmarkServer_Query_Count_1K(b *testing.B) {
-	benchmarkServerQueryCount(b, 1000)
-}
-
-func BenchmarkServer_Query_Count_100K(b *testing.B) {
-	benchmarkServerQueryCount(b, 100000)
-}
-
-func BenchmarkServer_Query_Count_1M(b *testing.B) {
-	benchmarkServerQueryCount(b, 1000000)
-}
+func BenchmarkServer_Query_Count_1(b *testing.B)    { benchmarkServerQueryCount(b, 1) }
+func BenchmarkServer_Query_Count_1K(b *testing.B)   { benchmarkServerQueryCount(b, 1000) }
+func BenchmarkServer_Query_Count_100K(b *testing.B) { benchmarkServerQueryCount(b, 100000) }
+func BenchmarkServer_Query_Count_1M(b *testing.B)   { benchmarkServerQueryCount(b, 1000000) }
 
 func benchmarkServerQueryCount(b *testing.B, pointN int) {
-	s := OpenDefaultServer(NewConfig())
-	defer s.Close()
+	if _, err := benchServer.Query(`DROP MEASUREMENT cpu`); err != nil {
+		b.Fatal(err)
+	}
 
 	// Write data into server.
 	var buf bytes.Buffer
@@ -35,39 +27,92 @@ func benchmarkServerQueryCount(b *testing.B, pointN int) {
 			fmt.Fprint(&buf, "\n")
 		}
 	}
-	s.MustWrite("db0", "rp0", buf.String(), nil)
+	benchServer.MustWrite("db0", "rp0", buf.String(), nil)
 
 	// Query simple count from server.
 	b.ResetTimer()
 	b.ReportAllocs()
+	var err error
 	for i := 0; i < b.N; i++ {
-		if results, err := s.Query(`SELECT count(value) FROM db0.rp0.cpu`); err != nil {
+		if strResult, err = benchServer.Query(`SELECT count(value) FROM db0.rp0.cpu`); err != nil {
 			b.Fatal(err)
-		} else if results != fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",%d]]}]}]}`, pointN) {
-			b.Fatalf("unexpected result: %s", results)
+		} else if strResult != fmt.Sprintf(`{"results":[{"series":[{"name":"cpu","columns":["time","count"],"values":[["1970-01-01T00:00:00Z",%d]]}]}]}`, pointN) {
+			b.Fatalf("unexpected result: %s", strResult)
 		}
 	}
 }
 
-func BenchmarkServer_ShowSeries_1(b *testing.B) {
-	benchmarkServerShowSeries(b, 1)
+func BenchmarkServer_Query_Count_Where_500(b *testing.B) {
+	benchmarkServerQueryCountWhere(b, false, 500)
+}
+func BenchmarkServer_Query_Count_Where_1K(b *testing.B) {
+	benchmarkServerQueryCountWhere(b, false, 1000)
+}
+func BenchmarkServer_Query_Count_Where_10K(b *testing.B) {
+	benchmarkServerQueryCountWhere(b, false, 10000)
+}
+func BenchmarkServer_Query_Count_Where_100K(b *testing.B) {
+	benchmarkServerQueryCountWhere(b, false, 100000)
 }
 
-func BenchmarkServer_ShowSeries_1K(b *testing.B) {
-	benchmarkServerShowSeries(b, 1000)
+func BenchmarkServer_Query_Count_Where_Regex_500(b *testing.B) {
+	benchmarkServerQueryCountWhere(b, true, 500)
+}
+func BenchmarkServer_Query_Count_Where_Regex_1K(b *testing.B) {
+	benchmarkServerQueryCountWhere(b, true, 1000)
+}
+func BenchmarkServer_Query_Count_Where_Regex_10K(b *testing.B) {
+	benchmarkServerQueryCountWhere(b, true, 10000)
+}
+func BenchmarkServer_Query_Count_Where_Regex_100K(b *testing.B) {
+	benchmarkServerQueryCountWhere(b, true, 100000)
 }
 
-func BenchmarkServer_ShowSeries_100K(b *testing.B) {
-	benchmarkServerShowSeries(b, 100000)
+func benchmarkServerQueryCountWhere(b *testing.B, useRegex bool, pointN int) {
+	if _, err := benchServer.Query(`DROP MEASUREMENT cpu`); err != nil {
+		b.Fatal(err)
+	}
+
+	// Write data into server.
+	var buf bytes.Buffer
+	for i := 0; i < pointN; i++ {
+		fmt.Fprintf(&buf, `cpu,host=server-%d value=100 %d`, i, i)
+		if i != pointN-1 {
+			fmt.Fprint(&buf, "\n")
+		}
+	}
+	benchServer.MustWrite("db0", "rp0", buf.String(), nil)
+
+	// Query count from server with WHERE
+	var (
+		err       error
+		condition = `host = 'server-487'`
+	)
+
+	if useRegex {
+		condition = `host =~ /^server-487$/`
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if strResult, err = benchServer.Query(fmt.Sprintf(`SELECT count(value) FROM db0.rp0.cpu WHERE %s`, condition)); err != nil {
+			b.Fatal(err)
+		} else if strResult == `{"results":[{}]}` {
+			b.Fatal("no results")
+		}
+	}
 }
 
-func BenchmarkServer_ShowSeries_1M(b *testing.B) {
-	benchmarkServerShowSeries(b, 1000000)
-}
+func BenchmarkServer_ShowSeries_1(b *testing.B)    { benchmarkServerShowSeries(b, 1) }
+func BenchmarkServer_ShowSeries_1K(b *testing.B)   { benchmarkServerShowSeries(b, 1000) }
+func BenchmarkServer_ShowSeries_100K(b *testing.B) { benchmarkServerShowSeries(b, 100000) }
+func BenchmarkServer_ShowSeries_1M(b *testing.B)   { benchmarkServerShowSeries(b, 1000000) }
 
 func benchmarkServerShowSeries(b *testing.B, pointN int) {
-	s := OpenDefaultServer(NewConfig())
-	defer s.Close()
+	if _, err := benchServer.Query(`DROP MEASUREMENT cpu`); err != nil {
+		b.Fatal(err)
+	}
 
 	// Write data into server.
 	var buf bytes.Buffer
@@ -77,13 +122,14 @@ func benchmarkServerShowSeries(b *testing.B, pointN int) {
 			fmt.Fprint(&buf, "\n")
 		}
 	}
-	s.MustWrite("db0", "rp0", buf.String(), nil)
+	benchServer.MustWrite("db0", "rp0", buf.String(), nil)
 
 	// Query simple count from server.
 	b.ResetTimer()
 	b.ReportAllocs()
+	var err error
 	for i := 0; i < b.N; i++ {
-		if _, err := s.QueryWithParams(`SHOW SERIES`, url.Values{"db": {"db0"}}); err != nil {
+		if strResult, err = benchServer.QueryWithParams(`SHOW SERIES`, url.Values{"db": {"db0"}}); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -542,6 +542,9 @@ func (e *StatementExecutor) createIterators(stmt *influxql.SelectStatement, ctx 
 	// Remove "time" from fields list.
 	stmt.RewriteTimeFields()
 
+	// Rewrite any regex conditions that could make use of the index.
+	stmt.RewriteRegexConditions()
+
 	// Create an iterator creator based on the shards in the cluster.
 	ic, err := e.iteratorCreator(stmt, &opt)
 	if err != nil {

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1241,8 +1241,8 @@ func (s *SelectStatement) RewriteFields(ic IteratorCreator) (*SelectStatement, e
 //
 // Conditions that can currently be simplified are:
 //
-//     - host ~= /^foo$/ becomes host = 'foo'
-//     - host ~! /^foo$/ becomes host != 'foo'
+//     - host =~ /^foo$/ becomes host = 'foo'
+//     - host !~ /^foo$/ becomes host != 'foo'
 //
 // Note: if the regex contains groups, character classes, repetition or
 // similar, it's likely it won't be rewritten. In order to support rewriting

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"regexp/syntax"
 	"sort"
 	"strconv"
 	"strings"
@@ -1233,6 +1234,93 @@ func (s *SelectStatement) RewriteFields(ic IteratorCreator) (*SelectStatement, e
 	}
 
 	return other, nil
+}
+
+// RewriteRegexExprs rewrites regex conditions to make better use of the
+// database index.
+//
+// Conditions that can currently be simplified are:
+//
+//     - host ~= /^foo$/ becomes host = 'foo'
+//     - host ~! /^foo$/ becomes host != 'foo'
+//
+// Note: if the regex contains groups, character classes, repetition or
+// similar, it's likely it won't be rewritten. In order to support rewriting
+// regexes with these characters would be a lot more work.
+func (s *SelectStatement) RewriteRegexConditions() {
+	s.Condition = RewriteExpr(s.Condition, func(e Expr) Expr {
+		be, ok := e.(*BinaryExpr)
+		if !ok || (be.Op != EQREGEX && be.Op != NEQREGEX) {
+			// This expression is not a binary condition or doesn't have a
+			// regex based operator.
+			return e
+		}
+
+		// Handle regex-based condition.
+		rhs := be.RHS.(*RegexLiteral) // This must be a regex.
+
+		val, ok := matchExactRegex(rhs.Val.String())
+		if !ok {
+			// Regex didn't match.
+			return e
+		}
+
+		// Remove leading and trailing ^ and $.
+		be.RHS = &StringLiteral{Val: val}
+
+		// Update the condition operator.
+		if be.Op == EQREGEX {
+			be.Op = EQ
+		} else {
+			be.Op = NEQ
+		}
+		return be
+	})
+}
+
+// matchExactRegex matches regexes that have the following form: /^foo$/. It
+// considers /^$/ to be a matching regex.
+func matchExactRegex(v string) (string, bool) {
+	re, err := syntax.Parse(v, syntax.Perl)
+	if err != nil {
+		// Nothing we can do or log.
+		return "", false
+	}
+
+	if re.Op != syntax.OpConcat {
+		return "", false
+	}
+
+	if len(re.Sub) < 2 || len(re.Sub) > 3 {
+		// Regex has too few or too many subexpressions.
+		return "", false
+	}
+
+	start := re.Sub[0]
+	if !(start.Op == syntax.OpBeginLine || start.Op == syntax.OpBeginText) {
+		// Regex does not begin with ^
+		return "", false
+	}
+
+	end := re.Sub[len(re.Sub)-1]
+	if !(end.Op == syntax.OpEndLine || end.Op == syntax.OpEndText) {
+		// Regex does not end with $
+		return "", false
+	}
+
+	if len(re.Sub) == 3 {
+		middle := re.Sub[1]
+		if middle.Op != syntax.OpLiteral {
+			// Regex does not contain a literal op.
+			return "", false
+		}
+
+		// We can rewrite this regex.
+		return string(middle.Rune), true
+	}
+
+	// The regex /^$/
+	return "", true
 }
 
 // RewriteDistinct rewrites the expression to be a call for map/reduce to work correctly

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -2986,7 +2986,7 @@ func newAlterRetentionPolicyStatement(name string, DB string, d, sd time.Duratio
 
 // mustMarshalJSON encodes a value to JSON.
 func mustMarshalJSON(v interface{}) []byte {
-	b, err := json.Marshal(v)
+	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #7486.

This PR adds support for replacing regexes with non-regex conditions
when possible. Currently the following regexes are supported:

 - `host =~ /^server1$/` will be converted into `host = 'server1'`
 - `host !~ /^server1$/` will be converted into `host != 'server1'`

*Note*: if the regex expression contains repetition, groupings or character classes, then rewriting may not take place. For example, the condition: `name =~ /^foo.$/` will not
be rewritten as it cannot be rewritten as an exact match.

Support for some of these cases may arrive in the future.

Regexes that can be converted into simpler expression will be able to
take advantage of the tsdb index, making them significantly faster.

#### Benchmarks

The following benchmarks run a query along the lines of:
 
```
SELECT count(value) FROM cpu WHERE host = 'server1'
``` 

for the non-regex ones, and: 

```
SELECT count(value) FROM cpu WHERE host =~ /^server1$/
```

 for the regex ones.

`master` 6fd74a6a

```
BenchmarkServer_Query_Count_Where_500-4          	    1000	   1392067 ns/op	  909527 B/op	     572 allocs/op
BenchmarkServer_Query_Count_Where_1K-4           	    1000	   1349177 ns/op	  909332 B/op	     571 allocs/op
BenchmarkServer_Query_Count_Where_10K-4          	    1000	   1564794 ns/op	  908493 B/op	     569 allocs/op
BenchmarkServer_Query_Count_Where_100K-4         	    1000	   2161792 ns/op	  906965 B/op	     566 allocs/op
BenchmarkServer_Query_Count_Where_Regex_500-4    	     100	  21228299 ns/op	 1717204 B/op	     642 allocs/op
BenchmarkServer_Query_Count_Where_Regex_1K-4     	     100	  22877996 ns/op	 1717317 B/op	     642 allocs/op
BenchmarkServer_Query_Count_Where_Regex_10K-4    	      50	  20535616 ns/op	 1717303 B/op	     642 allocs/op
BenchmarkServer_Query_Count_Where_Regex_100K-4   	     100	  18272231 ns/op	 1717068 B/op	     641 allocs/op
PASS
ok  	github.com/influxdata/influxdb/cmd/influxd/run	21.132s
```

This PR produces the following results:

```
BenchmarkServer_Query_Count_Where_500-4          	    1000	   1272334 ns/op	  909657 B/op	     572 allocs/op
BenchmarkServer_Query_Count_Where_1K-4           	    1000	   1316998 ns/op	  909420 B/op	     571 allocs/op
BenchmarkServer_Query_Count_Where_10K-4          	    1000	   1770097 ns/op	  908471 B/op	     569 allocs/op
BenchmarkServer_Query_Count_Where_100K-4         	    1000	   2368152 ns/op	  906952 B/op	     566 allocs/op
BenchmarkServer_Query_Count_Where_Regex_500-4    	    1000	   2053715 ns/op	  913136 B/op	     635 allocs/op
BenchmarkServer_Query_Count_Where_Regex_1K-4     	    1000	   2823591 ns/op	  913161 B/op	     635 allocs/op
BenchmarkServer_Query_Count_Where_Regex_10K-4    	     500	   2273258 ns/op	  913110 B/op	     635 allocs/op
BenchmarkServer_Query_Count_Where_Regex_100K-4   	    1000	   2327778 ns/op	  913072 B/op	     635 allocs/op
PASS
ok  	github.com/influxdata/influxdb/cmd/influxd/run	24.178s
```

So you can see that the regexes have been rewritten and are now effectively running the same benchmarks.

##### Ratings repo

A real world query on the [ratings](github.com/jwilder/ratings) dataset:

`1.0.2`
```
⇒  time influx -database ML1M -execute "SELECT mean(rating) FROM movielens WHERE userid =~ /^48$/"
name: movielens
---------------
time	mean
0	3.068561872909699

influx -database ML1M -execute   0.00s user 0.01s system 0% cpu 1.945 total
```

`PR`
```
⇒  time influx -database ML1M -execute "SELECT mean(rating) FROM movielens WHERE userid =~ /^48$/"
name: movielens
---------------
time	mean
0	3.068561872909699

influx -database ML1M -execute   0.00s user 0.01s system 0% cpu 1.399 total
```

@jwilder @jsternberg 