### PR TITLE
Optimize first/last when no group by interval is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The following configuration changes in the `[data]` section may need to changed 
 - [#7480](https://github.com/influxdata/influxdb/pull/7480): Improve compaction planning performance by caching tsm file stats.
 - [#7320](https://github.com/influxdata/influxdb/issues/7320): Update defaults in config for latest best practices
 - [#7495](https://github.com/influxdata/influxdb/pull/7495): Rewrite regexes of the form host = /^server-a$/ to host = 'server-a', to take advantage of the tsdb index.
+- [#6704](https://github.com/influxdata/influxdb/issues/6704): Optimize first/last when no group by interval is present.
 
 ### Bugfixes
 

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -629,6 +629,48 @@ func benchmarkEngineCreateIteratorCount(b *testing.B, pointN int) {
 	}, pointN)
 }
 
+func BenchmarkEngine_CreateIterator_First_1K(b *testing.B) {
+	benchmarkEngineCreateIteratorFirst(b, 1000)
+}
+func BenchmarkEngine_CreateIterator_First_100K(b *testing.B) {
+	benchmarkEngineCreateIteratorFirst(b, 100000)
+}
+func BenchmarkEngine_CreateIterator_First_1M(b *testing.B) {
+	benchmarkEngineCreateIteratorFirst(b, 1000000)
+}
+
+func benchmarkEngineCreateIteratorFirst(b *testing.B, pointN int) {
+	benchmarkIterator(b, influxql.IteratorOptions{
+		Expr:       influxql.MustParseExpr("first(value)"),
+		Sources:    []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+		Dimensions: []string{"host"},
+		Ascending:  true,
+		StartTime:  influxql.MinTime,
+		EndTime:    influxql.MaxTime,
+	}, pointN)
+}
+
+func BenchmarkEngine_CreateIterator_Last_1K(b *testing.B) {
+	benchmarkEngineCreateIteratorLast(b, 1000)
+}
+func BenchmarkEngine_CreateIterator_Last_100K(b *testing.B) {
+	benchmarkEngineCreateIteratorLast(b, 100000)
+}
+func BenchmarkEngine_CreateIterator_Last_1M(b *testing.B) {
+	benchmarkEngineCreateIteratorLast(b, 1000000)
+}
+
+func benchmarkEngineCreateIteratorLast(b *testing.B, pointN int) {
+	benchmarkIterator(b, influxql.IteratorOptions{
+		Expr:       influxql.MustParseExpr("last(value)"),
+		Sources:    []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+		Dimensions: []string{"host"},
+		Ascending:  true,
+		StartTime:  influxql.MinTime,
+		EndTime:    influxql.MaxTime,
+	}, pointN)
+}
+
 func BenchmarkEngine_CreateIterator_Limit_1K(b *testing.B) {
 	benchmarkEngineCreateIteratorLimit(b, 1000)
 }


### PR DESCRIPTION
The `first()` and `last()` functions response rate would increase linear
to the number of points even though it seems like it shouldn't. This
optimization greatly reduces the amount of time to return a response
when no `GROUP BY time(...)` clause is present in a query.

```
benchmark                                       old ns/op     new ns/op     delta
BenchmarkEngine_CreateIterator_First_1K-8       31738         28327         -10.75%
BenchmarkEngine_CreateIterator_First_100K-8     861782        72030         -91.64%
BenchmarkEngine_CreateIterator_First_1M-8       8599111       88630         -98.97%
BenchmarkEngine_CreateIterator_Last_1K-8        25177         21775         -13.51%
BenchmarkEngine_CreateIterator_Last_100K-8      828121        62467         -92.46%
BenchmarkEngine_CreateIterator_Last_1M-8        8311886       76800         -99.08%

benchmark                                       old allocs     new allocs     delta
BenchmarkEngine_CreateIterator_First_1K-8       52             62             +19.23%
BenchmarkEngine_CreateIterator_First_100K-8     68             78             +14.71%
BenchmarkEngine_CreateIterator_First_1M-8       161            171            +6.21%
BenchmarkEngine_CreateIterator_Last_1K-8        52             62             +19.23%
BenchmarkEngine_CreateIterator_Last_100K-8      68             78             +14.71%
BenchmarkEngine_CreateIterator_Last_1M-8        161            171            +6.21%

benchmark                                       old bytes     new bytes     delta
BenchmarkEngine_CreateIterator_First_1K-8       11285         12133         +7.51%
BenchmarkEngine_CreateIterator_First_100K-8     54920         55765         +1.54%
BenchmarkEngine_CreateIterator_First_1M-8       69516         70357         +1.21%
BenchmarkEngine_CreateIterator_Last_1K-8        11285         12133         +7.51%
BenchmarkEngine_CreateIterator_Last_100K-8      54919         55765         +1.54%
BenchmarkEngine_CreateIterator_Last_1M-8        69536         70357         +1.18%
```

Fixes #6704.