### PR TITLE
support unix socket connection for influx CLI

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -40,6 +40,7 @@ type CommandLine struct {
 	Line             *liner.State
 	Host             string
 	Port             int
+	UnixSocket       string
 	Username         string
 	Password         string
 	Database         string
@@ -133,8 +134,8 @@ func (c *CommandLine) Run() error {
 
 	if err := c.Connect(""); err != nil {
 		return fmt.Errorf(
-			"Failed to connect to %s\nPlease check your connection settings and ensure 'influxd' is running.",
-			c.Client.Addr())
+			"Failed to connect to %s: %s\nPlease check your connection settings and ensure 'influxd' is running.",
+			c.Client.Addr(), err.Error())
 	}
 
 	// Modify precision.
@@ -305,6 +306,7 @@ func (c *CommandLine) Connect(cmd string) error {
 
 	config := client.NewConfig()
 	config.URL = u
+	config.UnixSocket = c.UnixSocket
 	config.Username = c.Username
 	config.Password = c.Password
 	config.UserAgent = "InfluxDBShell/" + c.ClientVersion
@@ -318,7 +320,7 @@ func (c *CommandLine) Connect(cmd string) error {
 
 	var v string
 	if _, v, e = c.Client.Ping(); e != nil {
-		return fmt.Errorf("Failed to connect to %s\n", c.Client.Addr())
+		return fmt.Errorf("Failed to connect to %s: %s\n", c.Client.Addr(), e.Error())
 	}
 	c.ServerVersion = v
 	// Update the command with the current connection information

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -39,6 +39,7 @@ func main() {
 	fs := flag.NewFlagSet("InfluxDB shell version "+version, flag.ExitOnError)
 	fs.StringVar(&c.Host, "host", client.DefaultHost, "Influxdb host to connect to.")
 	fs.IntVar(&c.Port, "port", client.DefaultPort, "Influxdb port to connect to.")
+	fs.StringVar(&c.UnixSocket, "socket", c.UnixSocket, "Influxdb unix socket to connect to.")
 	fs.StringVar(&c.Username, "username", c.Username, "Username to connect to the server.")
 	fs.StringVar(&c.Password, "password", c.Password, `Password to connect to the server.  Leaving blank will prompt for password (--password="").`)
 	fs.StringVar(&c.Database, "database", c.Database, "Database to connect to the server.")
@@ -64,6 +65,8 @@ func main() {
        Host to connect to.
   -port 'port #'
        Port to connect to.
+  -socket 'unix domain socket'
+       Unix socket to connect to.
   -database 'database name'
        Database to connect to the server.
   -password 'password'


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA]

How to use:

```
Sosara@MBA:~/influx$ ./influx -socket /tmp/influxdb.sock
Visit https://enterprise.influxdata.com to register for updates, InfluxDB server management, and monitoring.
Connected to /tmp/influxdb.sock version unknown
InfluxDB shell version: unknown
> show databases;
name: databases
name
----
_internal
foo

> 
```

and the default HTTP:

```
Sosara@MBA:~/influx$ ./influx 
Visit https://enterprise.influxdata.com to register for updates, InfluxDB server management, and monitoring.
Connected to http://localhost:8086 version unknown
InfluxDB shell version: unknown
> show databases;
name: databases
name
----
_internal
foo

>

```
