### PR TITLE
Prevent influx from panicking on connect

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -599,7 +599,8 @@ func (c *CommandLine) DatabaseToken() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if response.Error() != nil || len((*response).Results[0].Series) == 0 {
+
+	if response.Error() != nil || len(response.Results) == 0 || len(response.Results[0].Series) == 0 {
 		return "", nil
 	}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

I'm managing to trigger this panic in some circumstances. Specifically when `SHOW DIAGNOSTICS for 'registration'` is not returning anything. The JSON returned from the server is `{"results":[{}]}`

