### PR TITLE
Escape fields when exporting tsm/wal files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The following configuration changes in the `[data]` section may need to changed 
 - [#7482](https://github.com/influxdata/influxdb/issues/7482): Fix issue where point would be written to wrong shard.
 - [#7431](https://github.com/influxdata/influxdb/issues/7431): Remove /data/process_continuous_queries endpoint.
 - [#7053](https://github.com/influxdata/influxdb/issues/7053): Delete statement returns an error when retention policy or database is specified
+- [#7494](https://github.com/influxdata/influxdb/issues/7494): influx_inspect: export does not escape field keys.
 
 ## v1.0.2 [2016-10-05]
 

--- a/cmd/influx_inspect/export/export.go
+++ b/cmd/influx_inspect/export/export.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/escape"
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
 
@@ -271,6 +272,8 @@ func (cmd *Command) writeTsmFiles(w io.WriteCloser, files []string) error {
 			key, typ := reader.KeyAt(i)
 			values, _ := reader.ReadAll(string(key))
 			measurement, field := tsm1.SeriesAndFieldFromCompositeKey(key)
+			// measurements are stored escaped, field names are not
+			field = escape.String(field)
 
 			for _, value := range values {
 				if (value.UnixNano() < cmd.startTime) || (value.UnixNano() > cmd.endTime) {
@@ -351,6 +354,8 @@ func (cmd *Command) writeWALFiles(w io.WriteCloser, files []string, key string) 
 
 				for key, values := range t.Values {
 					measurement, field := tsm1.SeriesAndFieldFromCompositeKey([]byte(key))
+					// measurements are stored escaped, field names are not
+					field = escape.String(field)
 
 					for _, value := range values {
 						if (value.UnixNano() < cmd.startTime) || (value.UnixNano() > cmd.endTime) {


### PR DESCRIPTION
Fixes #7494 

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

### Create the scenario for spaces in measurements, tags, and fields
```
> create database foo
> use foo
Using database foo
> insert h2o\ feet,location\ field=coyote_creek level\ description="below 3 feet",something\ else="this is more stuff"
> select * from "h2o feet"
name: h2o feet
time                    level description       location field  something else
----                    -----------------       --------------  --------------
1477401458865783329     below 3 feet            coyote_creek    this is more stuff
```

### Drop and re-insert with the data from the export
```
> drop database foo
> create database foo
> insert h2o\ feet,location\ field=coyote_creek level\ description="below 3 feet" 1477401458865783329
> select * from "h2o feet"
name: h2o feet
time                    level description       location field
----                    -----------------       --------------
1477401458865783329     below 3 feet            coyote_creek

> insert h2o\ feet,location\ field=coyote_creek something\ else="this is more stuff" 1477401458865783329
> select * from "h2o feet"
name: h2o feet
time                    level description       location field  something else
----                    -----------------       --------------  --------------
1477401458865783329     below 3 feet            coyote_creek    this is more stuff
```

### Export of when it is in a tsm file:
```
# INFLUXDB EXPORT: 1677-09-20T18:12:43-06:00 - 2262-04-11T17:47:16-06:00
# DDL
CREATE DATABASE foo WITH NAME autogen
# DML
# CONTEXT-DATABASE:foo
# CONTEXT-RETENTION-POLICY:autogen
# writing tsm data
h2o\ feet,location\ field=coyote_creek level\ description="below 3 feet" 1477401458865783329
h2o\ feet,location\ field=coyote_creek something\ else="this is more stuff" 1477401458865783329
# writing wal data
```

### Export of when it is in a wal file:
```
# INFLUXDB EXPORT: 1677-09-20T18:12:43-06:00 - 2262-04-11T17:47:16-06:00
# DDL
CREATE DATABASE foo WITH NAME autogen
# DML
# CONTEXT-DATABASE:foo
# CONTEXT-RETENTION-POLICY:autogen
# writing wal data
h2o\ feet,location\ field=coyote_creek level\ description="below 3 feet" 1477401458865783329
h2o\ feet,location\ field=coyote_creek something\ else="this is more stuff" 1477401458865783329
```