### PR TITLE
Change default time boundaries for raw queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The following configuration changes in the `[data]` section may need to changed 
 - [#7320](https://github.com/influxdata/influxdb/issues/7320): Update defaults in config for latest best practices
 - [#7495](https://github.com/influxdata/influxdb/pull/7495): Rewrite regexes of the form host = /^server-a$/ to host = 'server-a', to take advantage of the tsdb index.
 - [#6704](https://github.com/influxdata/influxdb/issues/6704): Optimize first/last when no group by interval is present.
+- [#4461](https://github.com/influxdata/influxdb/issues/4461): Change default time boundaries for raw queries.
 
 ### Bugfixes
 

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -529,7 +529,13 @@ func (e *StatementExecutor) createIterators(stmt *influxql.SelectStatement, ctx 
 		if influxql.Sources(stmt.Sources).HasSystemSource() {
 			opt.MaxTime = time.Unix(0, influxql.MaxTime).UTC()
 		} else {
-			opt.MaxTime = now
+			if interval, err := stmt.GroupByInterval(); err != nil {
+				return nil, stmt, err
+			} else if interval > 0 {
+				opt.MaxTime = now
+			} else {
+				opt.MaxTime = time.Unix(0, influxql.MaxTime).UTC()
+			}
 		}
 	}
 	if opt.MinTime.IsZero() {


### PR DESCRIPTION
Changes the default time boundaries for raw queries so raw queries will
range until the end of time. Aggregate queries continue to have their
default end time be `now()`.

Fixes #4461.