### PR TITLE
Don't normalize drop/delete series statements

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -1090,7 +1090,13 @@ func (e *StatementExecutor) NormalizeStatement(stmt influxql.Statement, defaultD
 				node.Database = defaultDatabase
 			}
 		case *influxql.Measurement:
-			err = e.normalizeMeasurement(node, defaultDatabase)
+			switch stmt.(type) {
+			case *influxql.DropSeriesStatement, *influxql.DeleteSeriesStatement:
+			// DB and RP not supported by these statements so don't rewrite into invalid
+			// statements
+			default:
+				err = e.normalizeMeasurement(node, defaultDatabase)
+			}
 		}
 	})
 	return

--- a/internal/meta_client.go
+++ b/internal/meta_client.go
@@ -19,7 +19,7 @@ type MetaClientMock struct {
 	CreateUserFn                        func(name, password string, admin bool) (*meta.UserInfo, error)
 
 	DatabaseFn  func(name string) *meta.DatabaseInfo
-	DatabasesFn func() ([]meta.DatabaseInfo, error)
+	DatabasesFn func() []meta.DatabaseInfo
 
 	DataFn                func() meta.Data
 	DeleteShardGroupFn    func(database string, policy string, id uint64) error
@@ -83,7 +83,7 @@ func (c *MetaClientMock) Database(name string) *meta.DatabaseInfo {
 	return c.DatabaseFn(name)
 }
 
-func (c *MetaClientMock) Databases() ([]meta.DatabaseInfo, error) {
+func (c *MetaClientMock) Databases() []meta.DatabaseInfo {
 	return c.DatabasesFn()
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

7093 causes a parse error to be returned from delete and drop
statements.  Normalizing them cause an invalid statement to be generated
which cannot be reparse if converted to a string and back.

@jsternberg 