### PR TITLE
Fix output duration units for SHOW QUERIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The following configuration changes in the `[data]` section may need to changed 
 - [#7053](https://github.com/influxdata/influxdb/issues/7053): Delete statement returns an error when retention policy or database is specified
 - [#7494](https://github.com/influxdata/influxdb/issues/7494): influx_inspect: export does not escape field keys.
 - [#7526](https://github.com/influxdata/influxdb/issues/7526): Truncate the version string when linking to the documentation.
+- [#7548](https://github.com/influxdata/influxdb/issues/7548): Fix output duration units for SHOW QUERIES.
 
 ## v1.0.2 [2016-10-05]
 

--- a/influxql/task_manager.go
+++ b/influxql/task_manager.go
@@ -95,15 +95,16 @@ func (t *TaskManager) executeShowQueriesStatement(q *ShowQueriesStatement) (mode
 	for id, qi := range t.queries {
 		d := now.Sub(qi.startTime)
 
-		var ds string
-		if d == 0 {
-			ds = "0s"
-		} else if d < time.Second {
-			ds = fmt.Sprintf("%du", d)
-		} else {
-			ds = (d - (d % time.Second)).String()
+		switch {
+		case d >= time.Second:
+			d = d - (d % time.Second)
+		case d >= time.Millisecond:
+			d = d - (d % time.Millisecond)
+		case d >= time.Microsecond:
+			d = d - (d % time.Microsecond)
 		}
-		values = append(values, []interface{}{id, qi.query, qi.database, ds})
+
+		values = append(values, []interface{}{id, qi.query, qi.database, d.String()})
 	}
 
 	return []*models.Row{{


### PR DESCRIPTION
The previous version was showing the microseconds unit when it was
outputting nanoseconds. Now we correctly identify which sub-second unit
to use (milliseconds, microseconds, or nanoseconds) and use the correct
unit while dividing the duration unit correctly to produce the correct
output.

Also updated to use the default duration string instead of our own
custom formatters. It turns out that the string method for
`time.Duration` does the correct thing as long as we truncate the value
first.

Fixes #7548.