### PR TITLE
Support the ON syntax in SHOW TAG VALUES

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -857,11 +857,11 @@ func (e *StatementExecutor) executeShowSubscriptionsStatement(stmt *influxql.Sho
 }
 
 func (e *StatementExecutor) executeShowTagValues(q *influxql.ShowTagValuesStatement, ctx *influxql.ExecutionContext) error {
-	if ctx.Database == "" {
+	if q.Database == "" {
 		return ErrDatabaseNameRequired
 	}
 
-	tagValues, err := e.TSDBStore.TagValues(ctx.Database, q.Condition)
+	tagValues, err := e.TSDBStore.TagValues(q.Database, q.Condition)
 	if err != nil {
 		ctx.Results <- &influxql.Result{
 			StatementID: ctx.StatementID,
@@ -1086,6 +1086,10 @@ func (e *StatementExecutor) NormalizeStatement(stmt influxql.Statement, defaultD
 				node.Database = defaultDatabase
 			}
 		case *influxql.ShowMeasurementsStatement:
+			if node.Database == "" {
+				node.Database = defaultDatabase
+			}
+		case *influxql.ShowTagValuesStatement:
 			if node.Database == "" {
 				node.Database = defaultDatabase
 			}

--- a/influxql/statement_rewriter.go
+++ b/influxql/statement_rewriter.go
@@ -122,6 +122,7 @@ func rewriteShowTagValuesStatement(stmt *ShowTagValuesStatement) (Statement, err
 	condition = rewriteSourcesCondition(stmt.Sources, condition)
 
 	return &ShowTagValuesStatement{
+		Database:   stmt.Database,
 		Op:         stmt.Op,
 		TagKeyExpr: stmt.TagKeyExpr,
 		Condition:  condition,


### PR DESCRIPTION
The parser was updated previously in #7295 and the functionality was
supposed to be there, but the wiring in the query engine for that to
happen was never written.

Fixes #7552.