### PR TITLE
Fix incorrect grouping when multiple aggregates are used with sparse data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The query language has been extended with a few new features:
 - [#7494](https://github.com/influxdata/influxdb/issues/7494): influx_inspect: export does not escape field keys.
 - [#7526](https://github.com/influxdata/influxdb/issues/7526): Truncate the version string when linking to the documentation.
 - [#7548](https://github.com/influxdata/influxdb/issues/7548): Fix output duration units for SHOW QUERIES.
+- [#7564](https://github.com/influxdata/influxdb/issues/7564): Fix incorrect grouping when multiple aggregates are used with sparse data.
 
 ## v1.0.2 [2016-10-05]
 

--- a/influxql/emitter.go
+++ b/influxql/emitter.go
@@ -113,14 +113,14 @@ func (e *Emitter) loadBuf() (t int64, name string, tags Tags, err error) {
 
 		// Update range values if lower and emitter is in time ascending order.
 		if e.ascending {
-			if (itrTime < t) || (itrTime == t && itrName < name) || (itrTime == t && itrName == name && itrTags.ID() < tags.ID()) {
+			if (itrName < name) || (itrName == name && itrTags.ID() < tags.ID()) || (itrName == name && itrTags.ID() == tags.ID() && itrTime < t) {
 				t, name, tags = itrTime, itrName, itrTags
 			}
 			continue
 		}
 
 		// Update range values if higher and emitter is in time descending order.
-		if (itrTime > t) || (itrTime == t && itrName > name) || (itrTime == t && itrName == name && itrTags.ID() > tags.ID()) {
+		if (itrName < name) || (itrName == name && itrTags.ID() < tags.ID()) || (itrName == name && itrTags.ID() == tags.ID() && itrTime < t) {
 			t, name, tags = itrTime, itrName, itrTags
 		}
 	}


### PR DESCRIPTION
When a query would use a grouping with two different aggregates, it was
possible for one of the aggregates to return a value from a different
series key than the second aggregate. When these series keys didn't
match, the returned grouping would be screwed up because it sorted by
time before checking for name and tags.

This did not happen when the aggregates returned values for the same
series keys because then the iterators were aligned with each other.

Backport of #7564 to 1.1.