### PR TITLE
Client failover to meta commands when stdin is empty in non-interactive mode

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -90,7 +90,10 @@ func (c *CommandLine) Run() error {
 		if err != nil {
 			return err
 		}
-		return c.ExecuteQuery(string(cmd))
+		if string(cmd) != "" {
+			return c.ExecuteQuery(string(cmd))
+		}
+		// no stdin, switch back to meta commands
 	}
 
 	if !c.IgnoreSignals {


### PR DESCRIPTION
resolves #7575

