### PR TITLE
Fix ARM64 build by replacing "aarch64" string with "arm64"

### DIFF
--- a/build.py
+++ b/build.py
@@ -333,6 +333,8 @@ def get_system_arch():
         arch = "amd64"
     elif arch == "386":
         arch = "i386"
+    elif arch == "aarch64":
+        arch = "arm64"
     elif 'arm' in arch:
         # Prevent uname from reporting full ARM arch (eg 'armv7l')
         arch = "arm"


### PR DESCRIPTION
This is a trivial PR that fix build.py on ARM64 architecture.

It appears as a straightforward fix to issue #7390.