### PR TITLE
Add "integral" function to InfluxQL

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1840,6 +1840,20 @@ func (s *SelectStatement) validateAggregates(tr targetRequirement) error {
 				if err := s.validSampleAggr(expr); err != nil {
 					return err
 				}
+			case "integral":
+				if err := s.validSelectWithAggregate(); err != nil {
+					return err
+				}
+				if min, max, got := 1, 2, len(expr.Args); got > max || got < min {
+					return fmt.Errorf("invalid number of arguments for %s, expected at least %d but no more than %d, got %d", expr.Name, min, max, got)
+				}
+				// If a duration arg is passed, make sure it's a duration
+				if len(expr.Args) == 2 {
+					// Second must be a duration .e.g (1h)
+					if _, ok := expr.Args[1].(*DurationLiteral); !ok {
+						return errors.New("second argument must be a duration")
+					}
+				}
 			case "holt_winters", "holt_winters_with_fit":
 				if exp, got := 3, len(expr.Args); got != exp {
 					return fmt.Errorf("invalid number of arguments for %s, expected %d, got %d", expr.Name, exp, got)

--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -1295,16 +1295,17 @@ func newSampleIterator(input Iterator, opt IteratorOptions, size int) (Iterator,
 
 // newIntegralIterator returns an iterator for operating on a integral() call.
 func newIntegralIterator(input Iterator, opt IteratorOptions, interval Interval) (Iterator, error) {
+	groupByTime := !opt.Interval.IsZero()
 	switch input := input.(type) {
 	case FloatIterator:
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
-			fn := NewFloatIntegralReducer(interval)
+			fn := NewFloatIntegralReducer(interval, groupByTime)
 			return fn, fn
 		}
 		return &floatReduceFloatIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
 	case IntegerIterator:
 		createFn := func() (IntegerPointAggregator, FloatPointEmitter) {
-			fn := NewIntegerIntegralReducer(interval)
+			fn := NewIntegerIntegralReducer(interval, groupByTime)
 			return fn, fn
 		}
 		return &integerReduceFloatIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil

--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -1292,3 +1292,23 @@ func newSampleIterator(input Iterator, opt IteratorOptions, size int) (Iterator,
 		return nil, fmt.Errorf("unsupported elapsed iterator type: %T", input)
 	}
 }
+
+// newIntegralIterator returns an iterator for operating on a integral() call.
+func newIntegralIterator(input Iterator, opt IteratorOptions, interval Interval) (Iterator, error) {
+	switch input := input.(type) {
+	case FloatIterator:
+		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
+			fn := NewFloatIntegralReducer(interval)
+			return fn, fn
+		}
+		return &floatReduceFloatIterator{input: newBufFloatIterator(input), opt: opt, create: createFn}, nil
+	case IntegerIterator:
+		createFn := func() (IntegerPointAggregator, FloatPointEmitter) {
+			fn := NewIntegerIntegralReducer(interval)
+			return fn, fn
+		}
+		return &integerReduceFloatIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
+	default:
+		return nil, fmt.Errorf("unsupported integral iterator type: %T", input)
+	}
+}

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -757,3 +757,114 @@ func (r *FloatHoltWintersReducer) constrain(x []float64) {
 		x[3] = 0
 	}
 }
+
+// FloatIntegralReducer calculates the time-integral of the aggregated points.
+type FloatIntegralReducer struct {
+	count     uint32
+	interval  Interval
+	sum       float64
+	prev      FloatPoint
+	startTime int64
+}
+
+// NewFloatIntegralReducer creates a new FloatIntegralReducer.
+func NewFloatIntegralReducer(interval Interval) *FloatIntegralReducer {
+	return &FloatIntegralReducer{
+		interval: interval,
+		prev:     FloatPoint{Nil: true},
+	}
+}
+
+// AggregateFloat aggregates a point into the reducer.
+func (r *FloatIntegralReducer) AggregateFloat(p *FloatPoint) {
+
+	// If this is the first point, just save it
+	if r.prev.Nil {
+		r.startTime = p.Time
+		r.prev = *p
+		r.count++
+		return
+	}
+
+	// If this point has the same timestamp as the previous one,
+	// use it but don't add anything to the integral.  Effectively
+	// this means that we allow the curve we are integrating
+	// to have step changes in it, but who knows whether the points
+	// actually arrive in any particular order...?
+	if r.prev.Time == p.Time {
+		r.prev = *p
+		r.count++
+		return
+	}
+
+	// Normal operation: update the sum using the trapezium rule
+	elapsed := float64(p.Time-r.prev.Time) / float64(r.interval.Duration)
+	r.sum += 0.5 * (p.Value + r.prev.Value) * elapsed
+	r.prev = *p
+	r.count++
+	return
+}
+
+// Emit emits the time-integral of the aggregated points as a single point.
+func (r *FloatIntegralReducer) Emit() []FloatPoint {
+	return []FloatPoint{{
+		Time:       r.startTime,
+		Value:      r.sum,
+		Aggregated: r.count,
+	}}
+}
+
+// IntegerIntegralReducer calculates the time-integral of the aggregated points.
+type IntegerIntegralReducer struct {
+	count     uint32
+	interval  Interval
+	sum       float64
+	prev      IntegerPoint
+	startTime int64
+}
+
+// NewIntegerIntegralReducer creates a new IntegerIntegralReducer.
+func NewIntegerIntegralReducer(interval Interval) *IntegerIntegralReducer {
+	return &IntegerIntegralReducer{
+		interval: interval,
+		prev:     IntegerPoint{Nil: true},
+	}
+}
+
+// AggregateInteger aggregates a point into the reducer.
+func (r *IntegerIntegralReducer) AggregateInteger(p *IntegerPoint) {
+	// If this is the first point, just save it
+	if r.prev.Nil {
+		r.prev = *p
+		r.startTime = p.Time
+		r.count++
+		return
+	}
+
+	// If this point has the same timestamp as the previous one,
+	// use it but don't add anything to the integral.  Effectively
+	// this means that we allow the curve we are integrating
+	// to have step changes in it, but who knows whether the points
+	// actually arrive in any particular order...?
+	if r.prev.Time == p.Time {
+		r.prev = *p
+		r.count++
+		return
+	}
+
+	// Normal operation: update the sum using the trapezium rule
+	elapsed := float64(p.Time-r.prev.Time) / float64(r.interval.Duration)
+	r.sum += 0.5 * float64(p.Value+r.prev.Value) * elapsed
+	r.prev = *p
+	r.count++
+	return
+}
+
+// Emit emits the time-integral of the aggregated points as a single FLOAT point
+func (r *IntegerIntegralReducer) Emit() []FloatPoint {
+	return []FloatPoint{{
+		Time:       r.startTime,
+		Value:      r.sum,
+		Aggregated: r.count,
+	}}
+}

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -761,18 +761,18 @@ func (r *FloatHoltWintersReducer) constrain(x []float64) {
 // FloatIntegralReducer calculates the time-integral of the aggregated points.
 type FloatIntegralReducer struct {
 	groupByTime bool
-	count     uint32
-	interval  Interval
-	sum       float64
-	prev      FloatPoint
+	count       uint32
+	interval    Interval
+	sum         float64
+	prev        FloatPoint
 }
 
 // NewFloatIntegralReducer creates a new FloatIntegralReducer.
 func NewFloatIntegralReducer(interval Interval, groupByTime bool) *FloatIntegralReducer {
 	return &FloatIntegralReducer{
 		groupByTime: groupByTime,
-		interval: interval,
-		prev:     FloatPoint{Nil: true},
+		interval:    interval,
+		prev:        FloatPoint{Nil: true},
 	}
 }
 
@@ -828,18 +828,18 @@ func (r *FloatIntegralReducer) Emit() []FloatPoint {
 // IntegerIntegralReducer calculates the time-integral of the aggregated points.
 type IntegerIntegralReducer struct {
 	groupByTime bool
-	count     uint32
-	interval  Interval
-	sum       float64
-	prev      IntegerPoint
+	count       uint32
+	interval    Interval
+	sum         float64
+	prev        IntegerPoint
 }
 
 // NewIntegerIntegralReducer creates a new IntegerIntegralReducer.
 func NewIntegerIntegralReducer(interval Interval, groupByTime bool) *IntegerIntegralReducer {
 	return &IntegerIntegralReducer{
 		groupByTime: groupByTime,
-		interval: interval,
-		prev:     IntegerPoint{Nil: true},
+		interval:    interval,
+		prev:        IntegerPoint{Nil: true},
 	}
 }
 
@@ -889,5 +889,5 @@ func (r *IntegerIntegralReducer) Emit() []FloatPoint {
 			Value:      r.sum,
 			Aggregated: r.count,
 		}}
-	}	
+	}
 }

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -882,6 +882,16 @@ func (opt IteratorOptions) ElapsedInterval() Interval {
 	return Interval{Duration: time.Nanosecond}
 }
 
+// IntegralInterval returns the time interval for the integral function.
+func (opt IteratorOptions) IntegralInterval() Interval {
+	// Use the interval on the integral() call, if specified.
+	if expr, ok := opt.Expr.(*Call); ok && len(expr.Args) == 2 {
+		return Interval{Duration: expr.Args[1].(*DurationLiteral).Val}
+	}
+
+	return Interval{Duration: time.Second}
+}
+
 // MarshalBinary encodes opt into a binary format.
 func (opt *IteratorOptions) MarshalBinary() ([]byte, error) {
 	return proto.Marshal(encodeIteratorOptions(opt))

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -940,6 +940,15 @@ func TestIteratorOptions_ElapsedInterval_Call(t *testing.T) {
 	}
 }
 
+func TestIteratorOptions_IntegralInterval_Default(t *testing.T) {
+	opt := influxql.IteratorOptions{}
+	expected := influxql.Interval{Duration: time.Second}
+	actual := opt.IntegralInterval()
+	if actual != expected {
+		t.Errorf("expected default integral interval to be %v, got %v", expected, actual)
+	}
+}
+
 // Ensure iterator options can be marshaled to and from a binary format.
 func TestIteratorOptions_MarshalBinary(t *testing.T) {
 	opt := &influxql.IteratorOptions{

--- a/influxql/select.go
+++ b/influxql/select.go
@@ -279,7 +279,7 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions, selec
 			opt.Interval = Interval{}
 
 			return newHoltWintersIterator(input, opt, int(h.Val), int(m.Val), includeFitData, interval)
-		case "derivative", "non_negative_derivative", "difference", "moving_average", "elapsed":
+		case "derivative", "non_negative_derivative", "difference", "moving_average", "elapsed", "integral":
 			if !opt.Interval.IsZero() {
 				if opt.Ascending {
 					opt.StartTime -= int64(opt.Interval.Duration)
@@ -301,6 +301,9 @@ func buildExprIterator(expr Expr, ic IteratorCreator, opt IteratorOptions, selec
 			case "elapsed":
 				interval := opt.ElapsedInterval()
 				return newElapsedIterator(input, opt, interval)
+			case "integral":
+				interval := opt.IntegralInterval()
+				return newIntegralIterator(input, opt, interval)
 			case "difference":
 				return newDifferenceIterator(input, opt)
 			case "moving_average":

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -2686,8 +2686,8 @@ func TestSelect_Integral_Float_GroupByTime(t *testing.T) {
 	}
 
 	expected := [][]influxql.Point{
-		{&influxql.FloatPoint{Name: "cpu", Time: 0, Value: 5*15, Aggregated: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Time: 20 * Second, Value: -5*10, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 0, Value: 5 * 15, Aggregated: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Time: 20 * Second, Value: -5 * 10, Aggregated: 2}},
 	}
 	CheckPoints(t, &ic, `SELECT integral(value) FROM cpu WHERE time > 0s AND time < 60s GROUP BY time(20s)`, expected)
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

###### Required only if applicable
- [x] Provide example syntax

I'll open a pull request against the documentation repository, but essentially this is an aggregator function which returns a single value for the "area under the curve".  

You can optionally specify a time interval argument which determines the units of the returned values.  This defaults to one second, so

    SELECT integral(value) from power_in_watts

will return the energy in units of watt-seconds, whereas

    SELECT integral(value, 1h) from power_in_watts

will return the energy in watt-hours.

I think the only potentially contentious/confusing thing is the behaviour at the "edges" of a time period.  As for other InfluxQL functions, we only analyse the datapoints within the specified period (or group-by interval).   This means that the integral does not include the time between the start of the interval and the first datapoint, nor the time between the last datapoint and the end of the interval.  

This will lead to slight inconsistencies, such as a set of daily integral values not quite adding up to the corresponding weekly integral.  The only way to solve that would be to look outside the time period being analysed to find the neighbouring points, so that we can interpolate the curve to the edges of the period, but I don't see a mechanism for doing that.  It could be potentially very expensive, as you might have to search forwards and back through all time in case there were points to use.

We already have some slight inconsistencies of a similar nature - for example the `derivative` function doesn't produce a value for the first point in each interval (for the same reason) so a set of derivative series calculated for each day doesn't quite match the result of analysing the whole week at once.

I propose that we just explain the above limitation in the documentation for now.


