### PR TITLE
Update Elapsed function to return zero when only one point was aggreg…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#7066](https://github.com/influxdata/influxdb/issues/7066): Add support for secure transmission via collectd.
 - [#7554](https://github.com/influxdata/influxdb/pull/7554): update latest dependencies with Godeps.
+- [#7619](https://github.com/influxdata/influxdb/issues/7619): Update Elapsed function to return zero, when only one point was aggregated.
 
 ### Bugfixes
 

--- a/influxql/functions.gen.go
+++ b/influxql/functions.gen.go
@@ -377,6 +377,10 @@ func (r *FloatElapsedReducer) Emit() []IntegerPoint {
 		return []IntegerPoint{
 			{Time: r.curr.Time, Value: elapsed},
 		}
+	} else if !r.curr.Nil {
+		return []IntegerPoint{
+			{Time: r.curr.Time, Value: 0},
+		}
 	}
 	return nil
 }
@@ -790,6 +794,10 @@ func (r *IntegerElapsedReducer) Emit() []IntegerPoint {
 		elapsed := (r.curr.Time - r.prev.Time) / r.unitConversion
 		return []IntegerPoint{
 			{Time: r.curr.Time, Value: elapsed},
+		}
+	} else if !r.curr.Nil {
+		return []IntegerPoint{
+			{Time: r.curr.Time, Value: 0},
 		}
 	}
 	return nil
@@ -1205,6 +1213,10 @@ func (r *StringElapsedReducer) Emit() []IntegerPoint {
 		return []IntegerPoint{
 			{Time: r.curr.Time, Value: elapsed},
 		}
+	} else if !r.curr.Nil {
+		return []IntegerPoint{
+			{Time: r.curr.Time, Value: 0},
+		}
 	}
 	return nil
 }
@@ -1618,6 +1630,10 @@ func (r *BooleanElapsedReducer) Emit() []IntegerPoint {
 		elapsed := (r.curr.Time - r.prev.Time) / r.unitConversion
 		return []IntegerPoint{
 			{Time: r.curr.Time, Value: elapsed},
+		}
+	} else if !r.curr.Nil {
+		return []IntegerPoint{
+			{Time: r.curr.Time, Value: 0},
 		}
 	}
 	return nil

--- a/influxql/functions.gen.go.tmpl
+++ b/influxql/functions.gen.go.tmpl
@@ -166,6 +166,10 @@ func (r *{{$k.Name}}ElapsedReducer) Emit() []IntegerPoint {
 		return []IntegerPoint{
 			{Time: r.curr.Time, Value: elapsed},
 		}
+	} else if !r.curr.Nil {
+		return []IntegerPoint{
+			{Time: r.curr.Time, Value: 0},
+		}
 	}
 	return nil
 }

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -2645,6 +2645,90 @@ func TestSelect_Elapsed_Boolean(t *testing.T) {
 	}
 }
 
+func TestSelect_Elapsed_Float_Zero(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &FloatIterator{Points: []influxql.FloatPoint{
+			{Name: "cpu", Time: 1 * Second, Value: 20},
+		}}, nil
+	}
+
+	// Execute selection.
+	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT elapsed(value, 1s) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:00:16Z'`), &ic, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Name: "cpu", Time: 1 * Second, Value: 0}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+}
+
+func TestSelect_Elapsed_Integer_Zero(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &IntegerIterator{Points: []influxql.IntegerPoint{
+			{Name: "cpu", Time: 1 * Second, Value: 20},
+		}}, nil
+	}
+
+	// Execute selection.
+	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT elapsed(value, 1s) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:00:16Z'`), &ic, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Name: "cpu", Time: 1 * Second, Value: 0}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+}
+
+func TestSelect_Elapsed_String_Zero(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &StringIterator{Points: []influxql.StringPoint{
+			{Name: "cpu", Time: 2 * Second, Value: "a"},
+		}}, nil
+	}
+
+	// Execute selection.
+	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT elapsed(value, 1s) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:00:16Z'`), &ic, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Name: "cpu", Time: 2 * Second, Value: 0}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+}
+
+func TestSelect_Elapsed_Boolean_Zero(t *testing.T) {
+	var ic IteratorCreator
+	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {
+		return &BooleanIterator{Points: []influxql.BooleanPoint{
+			{Name: "cpu", Time: 8 * Second, Value: false},
+		}}, nil
+	}
+
+	// Execute selection.
+	itrs, err := influxql.Select(MustParseSelectStatement(`SELECT elapsed(value, 1s) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-01T00:00:16Z'`), &ic, nil)
+	if err != nil {
+		t.Fatal(err)
+	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	} else if !deep.Equal(a, [][]influxql.Point{
+		{&influxql.IntegerPoint{Name: "cpu", Time: 8 * Second, Value: 0}},
+	}) {
+		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+	}
+}
+
 func TestSelect_MovingAverage_Float(t *testing.T) {
 	var ic IteratorCreator
 	ic.CreateIteratorFn = func(opt influxql.IteratorOptions) (influxql.Iterator, error) {


### PR DESCRIPTION
Fixes #7619 

This makes it so the elapsed function returns zero when only one point was aggregated. If no points were aggregated no points are returned.


- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
