### PR TITLE
Fix references to Go 1.6.2 in doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.6.2.
+InfluxDB requires Go 1.7.3.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -77,8 +77,8 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.6.2
-    gvm use go1.6.2 --default
+    gvm install go1.7.3
+    gvm use go1.7.3 --default
 
 Installing GDM
 -------------


### PR DESCRIPTION
Trivial change. Fixes https://github.com/influxdata/influxdb/issues/7602.