### PR TITLE
Expand string and boolean fields when using a wildcard with sample()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bugfixes
 
+- [#7621](https://github.com/influxdata/influxdb/issues/7621): Expand string and boolean fields when using a wildcard with `sample()`.
 
 ## v1.1.0 [unreleased]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1178,7 +1178,7 @@ func (s *SelectStatement) RewriteFields(ic IteratorCreator) (*SelectStatement, e
 
 				// Add additional types for certain functions.
 				switch call.Name {
-				case "count", "first", "last", "distinct", "elapsed", "mode":
+				case "count", "first", "last", "distinct", "elapsed", "mode", "sample":
 					supportedTypes[String] = struct{}{}
 					fallthrough
 				case "min", "max":

--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -1276,18 +1276,18 @@ func newSampleIterator(input Iterator, opt IteratorOptions, size int) (Iterator,
 			return fn, fn
 		}
 		return &integerReduceIntegerIterator{input: newBufIntegerIterator(input), opt: opt, create: createFn}, nil
-	case BooleanIterator:
-		createFn := func() (BooleanPointAggregator, BooleanPointEmitter) {
-			fn := NewBooleanSampleReducer(size)
-			return fn, fn
-		}
-		return &booleanReduceBooleanIterator{input: newBufBooleanIterator(input), opt: opt, create: createFn}, nil
 	case StringIterator:
 		createFn := func() (StringPointAggregator, StringPointEmitter) {
 			fn := NewStringSampleReducer(size)
 			return fn, fn
 		}
 		return &stringReduceStringIterator{input: newBufStringIterator(input), opt: opt, create: createFn}, nil
+	case BooleanIterator:
+		createFn := func() (BooleanPointAggregator, BooleanPointEmitter) {
+			fn := NewBooleanSampleReducer(size)
+			return fn, fn
+		}
+		return &booleanReduceBooleanIterator{input: newBufBooleanIterator(input), opt: opt, create: createFn}, nil
 	default:
 		return nil, fmt.Errorf("unsupported elapsed iterator type: %T", input)
 	}


### PR DESCRIPTION
Fixes #7621.