### PR TITLE
Allocation/pointer removal

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -683,13 +683,13 @@ func (c *Cache) updateMemSize(b int64) {
 
 func valueType(v Value) int {
 	switch v.(type) {
-	case *FloatValue:
+	case FloatValue:
 		return 1
-	case *IntegerValue:
+	case IntegerValue:
 		return 2
-	case *StringValue:
+	case StringValue:
 		return 3
-	case *BooleanValue:
+	case BooleanValue:
 		return 4
 	default:
 		return 0

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -100,31 +100,31 @@ type Value interface {
 func NewValue(t int64, value interface{}) Value {
 	switch v := value.(type) {
 	case int64:
-		return &IntegerValue{unixnano: t, value: v}
+		return IntegerValue{unixnano: t, value: v}
 	case float64:
-		return &FloatValue{unixnano: t, value: v}
+		return FloatValue{unixnano: t, value: v}
 	case bool:
-		return &BooleanValue{unixnano: t, value: v}
+		return BooleanValue{unixnano: t, value: v}
 	case string:
-		return &StringValue{unixnano: t, value: v}
+		return StringValue{unixnano: t, value: v}
 	}
 	return EmptyValue{}
 }
 
 func NewIntegerValue(t int64, v int64) Value {
-	return &IntegerValue{unixnano: t, value: v}
+	return IntegerValue{unixnano: t, value: v}
 }
 
 func NewFloatValue(t int64, v float64) Value {
-	return &FloatValue{unixnano: t, value: v}
+	return FloatValue{unixnano: t, value: v}
 }
 
 func NewBooleanValue(t int64, v bool) Value {
-	return &BooleanValue{unixnano: t, value: v}
+	return BooleanValue{unixnano: t, value: v}
 }
 
 func NewStringValue(t int64, v string) Value {
-	return &StringValue{unixnano: t, value: v}
+	return StringValue{unixnano: t, value: v}
 }
 
 type EmptyValue struct{}
@@ -134,11 +134,11 @@ func (e EmptyValue) Value() interface{} { return nil }
 func (e EmptyValue) Size() int          { return 0 }
 func (e EmptyValue) String() string     { return "" }
 
-func (_ EmptyValue) internalOnly()    {}
-func (_ *StringValue) internalOnly()  {}
-func (_ *IntegerValue) internalOnly() {}
-func (_ *BooleanValue) internalOnly() {}
-func (_ *FloatValue) internalOnly()   {}
+func (_ EmptyValue) internalOnly()   {}
+func (_ StringValue) internalOnly()  {}
+func (_ IntegerValue) internalOnly() {}
+func (_ BooleanValue) internalOnly() {}
+func (_ FloatValue) internalOnly()   {}
 
 // Encode converts the values to a byte slice.  If there are no values,
 // this function panics.
@@ -148,13 +148,13 @@ func (a Values) Encode(buf []byte) ([]byte, error) {
 	}
 
 	switch a[0].(type) {
-	case *FloatValue:
+	case FloatValue:
 		return encodeFloatBlock(buf, a)
-	case *IntegerValue:
+	case IntegerValue:
 		return encodeIntegerBlock(buf, a)
-	case *BooleanValue:
+	case BooleanValue:
 		return encodeBooleanBlock(buf, a)
-	case *StringValue:
+	case StringValue:
 		return encodeStringBlock(buf, a)
 	}
 
@@ -168,13 +168,13 @@ func (a Values) InfluxQLType() (influxql.DataType, error) {
 	}
 
 	switch a[0].(type) {
-	case *FloatValue:
+	case FloatValue:
 		return influxql.Float, nil
-	case *IntegerValue:
+	case IntegerValue:
 		return influxql.Integer, nil
-	case *BooleanValue:
+	case BooleanValue:
 		return influxql.Boolean, nil
-	case *StringValue:
+	case StringValue:
 		return influxql.String, nil
 	}
 
@@ -225,7 +225,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals = make([]Value, len(decoded))
 		}
 		for i := range decoded {
-			vals[i] = &decoded[i]
+			vals[i] = decoded[i]
 		}
 		return vals[:len(decoded)], err
 	case BlockInteger:
@@ -235,7 +235,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals = make([]Value, len(decoded))
 		}
 		for i := range decoded {
-			vals[i] = &decoded[i]
+			vals[i] = decoded[i]
 		}
 		return vals[:len(decoded)], err
 
@@ -246,7 +246,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals = make([]Value, len(decoded))
 		}
 		for i := range decoded {
-			vals[i] = &decoded[i]
+			vals[i] = decoded[i]
 		}
 		return vals[:len(decoded)], err
 
@@ -257,7 +257,7 @@ func DecodeBlock(block []byte, vals []Value) ([]Value, error) {
 			vals = make([]Value, len(decoded))
 		}
 		for i := range decoded {
-			vals[i] = &decoded[i]
+			vals[i] = decoded[i]
 		}
 		return vals[:len(decoded)], err
 
@@ -271,19 +271,19 @@ type FloatValue struct {
 	value    float64
 }
 
-func (f *FloatValue) UnixNano() int64 {
+func (f FloatValue) UnixNano() int64 {
 	return f.unixnano
 }
 
-func (f *FloatValue) Value() interface{} {
+func (f FloatValue) Value() interface{} {
 	return f.value
 }
 
-func (f *FloatValue) Size() int {
+func (f FloatValue) Size() int {
 	return 16
 }
 
-func (f *FloatValue) String() string {
+func (f FloatValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.value)
 }
 
@@ -306,7 +306,7 @@ func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 	err := func() error {
 		for _, v := range values {
 			tsenc.Write(v.UnixNano())
-			venc.Push(v.(*FloatValue).value)
+			venc.Push(v.(FloatValue).value)
 		}
 		venc.Finish()
 
@@ -398,19 +398,19 @@ type BooleanValue struct {
 	value    bool
 }
 
-func (b *BooleanValue) Size() int {
+func (b BooleanValue) Size() int {
 	return 9
 }
 
-func (b *BooleanValue) UnixNano() int64 {
+func (b BooleanValue) UnixNano() int64 {
 	return b.unixnano
 }
 
-func (b *BooleanValue) Value() interface{} {
+func (b BooleanValue) Value() interface{} {
 	return b.value
 }
 
-func (f *BooleanValue) String() string {
+func (f BooleanValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
@@ -430,7 +430,7 @@ func encodeBooleanBlock(buf []byte, values []Value) ([]byte, error) {
 	err := func() error {
 		for _, v := range values {
 			tsenc.Write(v.UnixNano())
-			venc.Write(v.(*BooleanValue).value)
+			venc.Write(v.(BooleanValue).value)
 		}
 
 		// Encoded timestamp values
@@ -516,19 +516,19 @@ type IntegerValue struct {
 	value    int64
 }
 
-func (v *IntegerValue) Value() interface{} {
+func (v IntegerValue) Value() interface{} {
 	return v.value
 }
 
-func (v *IntegerValue) UnixNano() int64 {
+func (v IntegerValue) UnixNano() int64 {
 	return v.unixnano
 }
 
-func (v *IntegerValue) Size() int {
+func (v IntegerValue) Size() int {
 	return 16
 }
 
-func (f *IntegerValue) String() string {
+func (f IntegerValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
@@ -540,7 +540,7 @@ func encodeIntegerBlock(buf []byte, values []Value) ([]byte, error) {
 	err := func() error {
 		for _, v := range values {
 			tsEnc.Write(v.UnixNano())
-			vEnc.Write(v.(*IntegerValue).value)
+			vEnc.Write(v.(IntegerValue).value)
 		}
 
 		// Encoded timestamp values
@@ -626,31 +626,31 @@ type StringValue struct {
 	value    string
 }
 
-func (v *StringValue) Value() interface{} {
+func (v StringValue) Value() interface{} {
 	return v.value
 }
 
-func (v *StringValue) UnixNano() int64 {
+func (v StringValue) UnixNano() int64 {
 	return v.unixnano
 }
 
-func (v *StringValue) Size() int {
+func (v StringValue) Size() int {
 	return 8 + len(v.value)
 }
 
-func (f *StringValue) String() string {
+func (f StringValue) String() string {
 	return fmt.Sprintf("%v %v", time.Unix(0, f.unixnano), f.Value())
 }
 
 func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
 	tsEnc := getTimeEncoder(len(values))
-	vEnc := getStringEncoder(len(values) * len(values[0].(*StringValue).value))
+	vEnc := getStringEncoder(len(values) * len(values[0].(StringValue).value))
 
 	var b []byte
 	err := func() error {
 		for _, v := range values {
 			tsEnc.Write(v.UnixNano())
-			vEnc.Write(v.(*StringValue).value)
+			vEnc.Write(v.(StringValue).value)
 		}
 
 		// Encoded timestamp values

--- a/tsdb/engine/tsm1/encoding_test.go
+++ b/tsdb/engine/tsm1/encoding_test.go
@@ -503,7 +503,7 @@ func TestValues_MergeFloat(t *testing.T) {
 
 func TestIntegerValues_Merge(t *testing.T) {
 	integerValue := func(t int64, f int64) tsm1.IntegerValue {
-		return *(tsm1.NewValue(t, f).(*tsm1.IntegerValue))
+		return tsm1.NewValue(t, f).(tsm1.IntegerValue)
 	}
 
 	tests := []struct {
@@ -636,7 +636,7 @@ func TestIntegerValues_Merge(t *testing.T) {
 
 func TestFloatValues_Merge(t *testing.T) {
 	floatValue := func(t int64, f float64) tsm1.FloatValue {
-		return *(tsm1.NewValue(t, f).(*tsm1.FloatValue))
+		return tsm1.NewValue(t, f).(tsm1.FloatValue)
 	}
 
 	tests := []struct {
@@ -765,7 +765,7 @@ func TestFloatValues_Merge(t *testing.T) {
 
 func TestBooleanValues_Merge(t *testing.T) {
 	booleanValue := func(t int64, f bool) tsm1.BooleanValue {
-		return *(tsm1.NewValue(t, f).(*tsm1.BooleanValue))
+		return tsm1.NewValue(t, f).(tsm1.BooleanValue)
 	}
 
 	tests := []struct {
@@ -894,7 +894,7 @@ func TestBooleanValues_Merge(t *testing.T) {
 
 func TestStringValues_Merge(t *testing.T) {
 	stringValue := func(t int64, f string) tsm1.StringValue {
-		return *(tsm1.NewValue(t, f).(*tsm1.StringValue))
+		return tsm1.NewValue(t, f).(tsm1.StringValue)
 	}
 
 	tests := []struct {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -930,12 +930,14 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache) (
 
 // compactCache continually checks if the WAL cache should be written to disk
 func (e *Engine) compactCache(quit <-chan struct{}) {
+	t := time.NewTimer(time.Second)
+	defer t.Stop()
 	for {
 		select {
 		case <-quit:
 			return
 
-		default:
+		case <-t.C:
 			e.Cache.UpdateAge()
 			if e.ShouldCompactCache(e.WAL.LastWriteTime()) {
 				start := time.Now()
@@ -950,7 +952,7 @@ func (e *Engine) compactCache(quit <-chan struct{}) {
 				atomic.AddInt64(&e.stats.CacheCompactionDuration, time.Since(start).Nanoseconds())
 			}
 		}
-		time.Sleep(time.Second)
+		t.Reset(time.Second)
 	}
 }
 
@@ -968,38 +970,41 @@ func (e *Engine) ShouldCompactCache(lastWriteTime time.Time) bool {
 }
 
 func (e *Engine) compactTSMLevel(fast bool, level int, quit <-chan struct{}) {
+	t := time.NewTimer(time.Second)
+	defer t.Stop()
+
 	for {
 		select {
 		case <-quit:
 			return
 
-		default:
+		case <-t.C:
 			s := e.levelCompactionStrategy(fast, level)
-			if s == nil {
-				time.Sleep(time.Second)
-				continue
+			if s != nil {
+				s.Apply()
 			}
-
-			s.Apply()
 		}
+		t.Reset(time.Second)
 	}
 }
 
 func (e *Engine) compactTSMFull(quit <-chan struct{}) {
+	t := time.NewTimer(time.Second)
+	defer t.Stop()
+
 	for {
 		select {
 		case <-quit:
 			return
 
-		default:
+		case <-t.C:
 			s := e.fullCompactionStrategy()
-			if s == nil {
-				time.Sleep(time.Second)
-				continue
+			if s != nil {
+				s.Apply()
 			}
 
-			s.Apply()
 		}
+		t.Reset(time.Second)
 	}
 }
 

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -343,7 +343,7 @@ func (c *floatAscendingCursor) peekCache() (t int64, v float64) {
 	}
 
 	item := c.cache.values[c.cache.pos]
-	return item.UnixNano(), item.(*FloatValue).value
+	return item.UnixNano(), item.(FloatValue).value
 }
 
 // peekTSM returns the current time/value from tsm.
@@ -463,7 +463,7 @@ func (c *floatDescendingCursor) peekCache() (t int64, v float64) {
 	}
 
 	item := c.cache.values[c.cache.pos]
-	return item.UnixNano(), item.(*FloatValue).value
+	return item.UnixNano(), item.(FloatValue).value
 }
 
 // peekTSM returns the current time/value from tsm.
@@ -786,7 +786,7 @@ func (c *integerAscendingCursor) peekCache() (t int64, v int64) {
 	}
 
 	item := c.cache.values[c.cache.pos]
-	return item.UnixNano(), item.(*IntegerValue).value
+	return item.UnixNano(), item.(IntegerValue).value
 }
 
 // peekTSM returns the current time/value from tsm.
@@ -906,7 +906,7 @@ func (c *integerDescendingCursor) peekCache() (t int64, v int64) {
 	}
 
 	item := c.cache.values[c.cache.pos]
-	return item.UnixNano(), item.(*IntegerValue).value
+	return item.UnixNano(), item.(IntegerValue).value
 }
 
 // peekTSM returns the current time/value from tsm.
@@ -1229,7 +1229,7 @@ func (c *stringAscendingCursor) peekCache() (t int64, v string) {
 	}
 
 	item := c.cache.values[c.cache.pos]
-	return item.UnixNano(), item.(*StringValue).value
+	return item.UnixNano(), item.(StringValue).value
 }
 
 // peekTSM returns the current time/value from tsm.
@@ -1349,7 +1349,7 @@ func (c *stringDescendingCursor) peekCache() (t int64, v string) {
 	}
 
 	item := c.cache.values[c.cache.pos]
-	return item.UnixNano(), item.(*StringValue).value
+	return item.UnixNano(), item.(StringValue).value
 }
 
 // peekTSM returns the current time/value from tsm.
@@ -1672,7 +1672,7 @@ func (c *booleanAscendingCursor) peekCache() (t int64, v bool) {
 	}
 
 	item := c.cache.values[c.cache.pos]
-	return item.UnixNano(), item.(*BooleanValue).value
+	return item.UnixNano(), item.(BooleanValue).value
 }
 
 // peekTSM returns the current time/value from tsm.
@@ -1792,7 +1792,7 @@ func (c *booleanDescendingCursor) peekCache() (t int64, v bool) {
 	}
 
 	item := c.cache.values[c.cache.pos]
-	return item.UnixNano(), item.(*BooleanValue).value
+	return item.UnixNano(), item.(BooleanValue).value
 }
 
 // peekTSM returns the current time/value from tsm.

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpldata
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpldata
@@ -3,28 +3,28 @@
 		"Name":"Float",
 		"name":"float",
 		"Type":"float64",
-		"ValueType":"*FloatValue",
+		"ValueType":"FloatValue",
 		"Nil":"0"
 	},
 	{
 		"Name":"Integer",
 		"name":"integer",
 		"Type":"int64",
-		"ValueType":"*IntegerValue",
+		"ValueType":"IntegerValue",
 		"Nil":"0"
 	},
 	{
 		"Name":"String",
 		"name":"string",
 		"Type":"string",
-		"ValueType":"*StringValue",
+		"ValueType":"StringValue",
 		"Nil":"\"\""
 	},
 	{
 		"Name":"Boolean",
 		"name":"boolean",
 		"Type":"bool",
-		"ValueType":"*BooleanValue",
+		"ValueType":"BooleanValue",
 		"Nil":"false"
 	}
 ]

--- a/tsdb/engine/tsm1/pools.go
+++ b/tsdb/engine/tsm1/pools.go
@@ -39,7 +39,7 @@ func getFloat64Values(size int) []Value {
 
 	for i, v := range buf {
 		if v == nil {
-			buf[i] = &FloatValue{}
+			buf[i] = FloatValue{}
 		}
 	}
 	return buf[:size]
@@ -65,7 +65,7 @@ func getIntegerValues(size int) []Value {
 
 	for i, v := range buf {
 		if v == nil {
-			buf[i] = &IntegerValue{}
+			buf[i] = IntegerValue{}
 		}
 	}
 	return buf[:size]
@@ -91,7 +91,7 @@ func getBooleanValues(size int) []Value {
 
 	for i, v := range buf {
 		if v == nil {
-			buf[i] = &BooleanValue{}
+			buf[i] = BooleanValue{}
 		}
 	}
 	return buf[:size]
@@ -117,7 +117,7 @@ func getStringValues(size int) []Value {
 
 	for i, v := range buf {
 		if v == nil {
-			buf[i] = &StringValue{}
+			buf[i] = StringValue{}
 		}
 	}
 	return buf[:size]
@@ -130,13 +130,13 @@ func putBooleanValues(buf []Value) {
 func putValue(buf []Value) {
 	if len(buf) > 0 {
 		switch buf[0].(type) {
-		case *FloatValue:
+		case FloatValue:
 			putFloat64Values(buf)
-		case *IntegerValue:
+		case IntegerValue:
 			putIntegerValues(buf)
-		case *BooleanValue:
+		case BooleanValue:
 			putBooleanValues(buf)
-		case *StringValue:
+		case StringValue:
 			putStringValues(buf)
 		}
 	}

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1893,6 +1893,17 @@ func MarshalTags(tags map[string]string) []byte {
 	return b
 }
 
+// WalkTagKeys calls fn for each tag key associated with m.  The order of the
+// keys is undefined.
+func (m *Measurement) WalkTagKeys(fn func(k string)) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for k := range m.seriesByTagKeyValue {
+		fn(k)
+	}
+}
+
 // TagKeys returns a list of the measurement's tag names.
 func (m *Measurement) TagKeys() []string {
 	m.mu.RLock()

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -853,7 +853,7 @@ func (s *Shard) monitor() {
 			}
 
 			for _, m := range s.index.Measurements() {
-				for _, k := range m.TagKeys() {
+				m.WalkTagKeys(func(k string) {
 					n := m.Cardinality(k)
 					perc := int(float64(n) / float64(s.options.Config.MaxValuesPerTag) * 100)
 					if perc > 100 {
@@ -865,7 +865,7 @@ func (s *Shard) monitor() {
 						s.logger.Printf("WARN: %d%% of max-values-per-tag limit exceeded: (%d/%d), db=%s shard=%d measurement=%s tag=%s",
 							perc, n, s.options.Config.MaxValuesPerTag, s.database, s.id, m.Name, k)
 					}
-				}
+				})
 			}
 		}
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This PR has a few changes to remove pointers and allocations.

* There are several long running goroutines that would `time.Sleep` every second.  This ends up allocating as seen by `GODEBUG=allocfreetrace=1`.  These were replaced with `time.Timer` which avoids the allocation and is more idiomatic.
* `findGenerations` is called a lot and ends up allocation quite a bit when many shards exists.  The result is usually the same because the generations do not change until a compaction completes.  This caches the result to avoid all the re-allocations.
* Converts all the `*Value` types to be non-pointers.   They don't need to be pointers since they are immutable once created.