### PR TITLE
Improve TSM1 cache performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7684](https://github.com/influxdata/influxdb/issues/7684): Update Go version to 1.7.4.
 - [#7036](https://github.com/influxdata/influxdb/issues/7036): Switch logging to use structured logging everywhere.
 - [#7723](https://github.com/influxdata/influxdb/pull/7723): Remove the override of GOMAXPROCS.
+- [#7633](https://github.com/influxdata/influxdb/pull/7633): improve write performance significantly.
 
 ### Bugfixes
 

--- a/Godeps
+++ b/Godeps
@@ -2,7 +2,7 @@ collectd.org e84e8af5356e7f47485bbc95c96da6dd7984a67e
 github.com/BurntSushi/toml 99064174e013895bbd9b025c31100bd1d9b590ca
 github.com/bmizerany/pat c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c
 github.com/boltdb/bolt 4b1ebc1869ad66568b313d0dc410e2be72670dda
-github.com/cespare/xxhash 1ce10610a70c8da08278fbe935f2feafd6d9074d
+github.com/cespare/xxhash 4a94f899c20bc44d4f5f807cb14529e72aca99d6
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/dgrijalva/jwt-go 24c63f56522a87ec5339cc3567883f1039378fdb
 github.com/dgryski/go-bits 2ad8d707cc05b1815ce6ff2543bb5e8d8f9298ef

--- a/Godeps
+++ b/Godeps
@@ -2,6 +2,7 @@ collectd.org e84e8af5356e7f47485bbc95c96da6dd7984a67e
 github.com/BurntSushi/toml 99064174e013895bbd9b025c31100bd1d9b590ca
 github.com/bmizerany/pat c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c
 github.com/boltdb/bolt 4b1ebc1869ad66568b313d0dc410e2be72670dda
+github.com/cespare/xxhash 1ce10610a70c8da08278fbe935f2feafd6d9074d
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/dgrijalva/jwt-go 24c63f56522a87ec5339cc3567883f1039378fdb
 github.com/dgryski/go-bits 2ad8d707cc05b1815ce6ff2543bb5e8d8f9298ef

--- a/LICENSE_OF_DEPENDENCIES.md
+++ b/LICENSE_OF_DEPENDENCIES.md
@@ -4,6 +4,7 @@
 - github.com/BurntSushi/toml [WTFPL LICENSE](https://github.com/BurntSushi/toml/blob/master/COPYING)
 - github.com/bmizerany/pat [MIT LICENSE](https://github.com/bmizerany/pat#license)
 - github.com/boltdb/bolt [MIT LICENSE](https://github.com/boltdb/bolt/blob/master/LICENSE)
+- github.com/cespare/xxhash [MIT LICENSE](https://github.com/cespare/xxhash/blob/master/LICENSE.txt)
 - github.com/davecgh/go-spew/spew [ISC LICENSE](https://github.com/davecgh/go-spew/blob/master/LICENSE)
 - github.com/dgrijalva/jwt-go [MIT LICENSE](https://github.com/dgrijalva/jwt-go/blob/master/LICENSE)
 - github.com/dgryski/go-bits [MIT LICENSE](https://github.com/dgryski/go-bits/blob/master/LICENSE)

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -613,14 +613,10 @@ func (c *Cache) values(key string) Values {
 	return e.values
 }
 
+// ApplyEntryFn applies the function f to each entry in the Cache.
+// ApplyEntryFn calls f on each entry in turn, within the same goroutine.
+// It is safe for use by multiple goroutines.
 func (c *Cache) ApplyEntryFn(f func(key string, entry *entry) error) error {
-	c.mu.RLock()
-	store := c.store
-	c.mu.RUnlock()
-	return store.apply(f)
-}
-
-func (c *Cache) ApplySerialEntryFn(f func(key string, entry *entry) error) error {
 	c.mu.RLock()
 	store := c.store
 	c.mu.RUnlock()

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -741,3 +741,30 @@ func BenchmarkCacheParallelFloatEntries(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkEntry_add(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			b.StopTimer()
+			values := make([]Value, 10)
+			for i := 0; i < 10; i++ {
+				values[i] = NewValue(int64(i+1), float64(i))
+			}
+
+			otherValues := make([]Value, 10)
+			for i := 0; i < 10; i++ {
+				otherValues[i] = NewValue(1, float64(i))
+			}
+
+			entry, err := newEntryValues(values)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.StartTimer()
+			if err := entry.add(otherValues); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -746,17 +746,17 @@ func BenchmarkEntry_add(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			b.StopTimer()
-			values := make([]Value, 10)
+			values := make([]Value, 100)
 			for i := 0; i < 10; i++ {
 				values[i] = NewValue(int64(i+1), float64(i))
 			}
 
-			otherValues := make([]Value, 10)
+			otherValues := make([]Value, 100)
 			for i := 0; i < 10; i++ {
 				otherValues[i] = NewValue(1, float64(i))
 			}
 
-			entry, err := newEntryValues(values)
+			entry, err := newEntryValues(values, 0) // Will use default allocation size.
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -85,7 +85,7 @@ func TestCache_CacheWriteMulti(t *testing.T) {
 	values := Values{v0, v1, v2}
 	valuesSize := uint64(v0.Size() + v1.Size() + v2.Size())
 
-	c := NewCache(3*valuesSize, "")
+	c := NewCache(30*valuesSize, "")
 
 	if err := c.WriteMulti(map[string][]Value{"foo": values, "bar": values}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
@@ -128,7 +128,7 @@ func TestCache_Cache_DeleteRange(t *testing.T) {
 	values := Values{v0, v1, v2}
 	valuesSize := uint64(v0.Size() + v1.Size() + v2.Size())
 
-	c := NewCache(3*valuesSize, "")
+	c := NewCache(30*valuesSize, "")
 
 	if err := c.WriteMulti(map[string][]Value{"foo": values, "bar": values}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
@@ -202,7 +202,7 @@ func TestCache_Cache_Delete(t *testing.T) {
 	values := Values{v0, v1, v2}
 	valuesSize := uint64(v0.Size() + v1.Size() + v2.Size())
 
-	c := NewCache(3*valuesSize, "")
+	c := NewCache(30*valuesSize, "")
 
 	if err := c.WriteMulti(map[string][]Value{"foo": values, "bar": values}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
@@ -719,7 +719,7 @@ type points struct {
 
 func BenchmarkCacheParallelFloatEntries(b *testing.B) {
 	c := b.N * runtime.GOMAXPROCS(0)
-	cache := NewCache(uint64(c)*fvSize, "")
+	cache := NewCache(uint64(c)*fvSize*10, "")
 	vals := make([]points, c)
 	for i := 0; i < c; i++ {
 		v := make([]Value, 10)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -785,7 +785,7 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 	walKeys := deleteKeys[:0]
 
 	// ApplySerialEntryFn cannot return an error in this invocation.
-	_ = e.Cache.ApplySerialEntryFn(func(k string, _ *entry) error {
+	_ = e.Cache.ApplyEntryFn(func(k string, _ *entry) error {
 		seriesKey, _ := SeriesAndFieldFromCompositeKey([]byte(k))
 		if _, ok := keyMap[string(seriesKey)]; ok {
 			walKeys = append(walKeys, k)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -784,8 +784,8 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 	// find the keys in the cache and remove them
 	walKeys := deleteKeys[:0]
 
-	// ApplyEntryFn cannot return an error in this invocation.
-	_ = e.Cache.ApplyEntryFn(func(k string, _ *entry) error {
+	// ApplySerialEntryFn cannot return an error in this invocation.
+	_ = e.Cache.ApplySerialEntryFn(func(k string, _ *entry) error {
 		seriesKey, _ := SeriesAndFieldFromCompositeKey([]byte(k))
 		if _, ok := keyMap[string(seriesKey)]; ok {
 			walKeys = append(walKeys, k)

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -742,9 +742,11 @@ func BenchmarkEngine_CreateIterator_Limit_1M(b *testing.B) {
 func BenchmarkEngine_WritePoints_10(b *testing.B) {
 	benchmarkEngine_WritePoints(b, 10)
 }
+
 func BenchmarkEngine_WritePoints_100(b *testing.B) {
 	benchmarkEngine_WritePoints(b, 100)
 }
+
 func BenchmarkEngine_WritePoints_1000(b *testing.B) {
 	benchmarkEngine_WritePoints(b, 1000)
 }

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -1,0 +1,218 @@
+package tsm1
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cespare/xxhash"
+)
+
+// partitions is the number of partitions we used in the ring's continuum. It
+// basically defines the maximum number of partitions you can have in the ring.
+// If a smaller number of partitions are chosen when creating a ring, then
+// they're evenly spread across this many partitions in the ring.
+const partitions = 256
+
+// ring is a structure that maps series keys to entries.
+//
+// ring is implemented as a crude hash ring, in so much that you can have
+// variable numbers of members in the ring, and the appropriate member for a
+// given series key can always consistently be found. Unlike a true hash ring
+// though, this ring is not resizeable—there must be at most 256 members in the
+// ring, and the number of members must always be a power of 2.
+//
+// ring works as follows: Each member of the ring contains a single store, which
+// contains a map of series keys to entries. A ring always has 256 partitions,
+// and a member takes up one or more of these partitions (depending on how many
+// members are specified to be in the ring)
+//
+// To determine the partition that a series key should be added to, the series
+// key is hashed and the first 8 bits are used as an index to the ring.
+//
+type ring struct {
+	partitions []*partition // The unique set of partitions in the ring.
+	continuum  []*partition // A mapping of parition to location on the ring continuum.
+
+	// Number of entries held within the ring. This is used to provide a
+	// hint for allocating a []string to return all keys. It will not be
+	// perfectly accurate since it doesn't consider adding duplicate keys,
+	// or trying to remove non-existent keys.
+	entryN int64
+}
+
+func newring(n int) (*ring, error) {
+	if n <= 0 || n > partitions {
+		return nil, fmt.Errorf("invalid number of paritions: %d", n)
+	}
+
+	r := ring{
+		continuum: make([]*partition, partitions), // maximum number of partitions.
+	}
+
+	// The trick here is to map N partitions to all points on the continuum,
+	// such that the first eight bits of a given hash will map directly to one
+	// of the N partitions.
+	for i := 0; i < len(r.continuum); i++ {
+		if (i == 0 || i%(partitions/n) == 0) && len(r.partitions) < n {
+			r.partitions = append(r.partitions, &partition{
+				store:          make(map[string]*entry),
+				entrySizeHints: make(map[uint64]int),
+			})
+		}
+		r.continuum[i] = r.partitions[len(r.partitions)-1]
+	}
+	return &r, nil
+}
+
+// getPartition retrieves the hash ring partition associated with the provided
+// key.
+func (r *ring) getPartition(key string) *partition {
+	return r.continuum[int(uint8(xxhash.Sum64([]byte(key))))]
+}
+
+// entry returns the entry for the given key.
+// entry is safe for use by multiple goroutines.
+func (r *ring) entry(key string) (*entry, bool) {
+	return r.getPartition(key).entry(key)
+}
+
+// write writes values to the entry in the ring's partition associated with key.
+// If no entry exists for the key then one will be created.
+// write is safe for use by multiple goroutines.
+func (r *ring) write(key string, values Values) error {
+	return r.getPartition(key).write(key, values)
+}
+
+// add adds an entry to the ring.
+func (r *ring) add(key string, entry *entry) {
+	r.getPartition(key).add(key, entry)
+	atomic.AddInt64(&r.entryN, 1)
+}
+
+// remove deletes the entry for the given key.
+// remove is safe for use by multiple goroutines.
+func (r *ring) remove(key string) {
+	r.getPartition(key).remove(key)
+	if r.entryN > 0 {
+		atomic.AddInt64(&r.entryN, -1)
+	}
+}
+
+// keys returns all the keys from all partitions in the hash ring. The returned
+// keys will be in order if sorted is true.
+func (r *ring) keys(sorted bool) []string {
+	keys := make([]string, 0, atomic.LoadInt64(&r.entryN))
+	for _, p := range r.partitions {
+		keys = append(keys, p.keys()...)
+	}
+
+	if sorted {
+		sort.Strings(keys)
+	}
+	return keys
+}
+
+// apply applies the provided function to every entry in the ring under a read
+// lock. The provided function will be called with each key and the
+// corresponding entry. The first error encountered will be returned, if any.
+func (r *ring) apply(f func(string, *entry) error) error {
+
+	var (
+		wg  sync.WaitGroup
+		res = make(chan error, len(r.partitions))
+	)
+
+	for _, p := range r.partitions {
+		wg.Add(1)
+
+		go func(p *partition) {
+			defer wg.Done()
+
+			p.mu.RLock()
+			for k, e := range p.store {
+				if err := f(k, e); err != nil {
+					res <- err
+					p.mu.RUnlock()
+					return
+				}
+			}
+			p.mu.RUnlock()
+		}(p)
+	}
+
+	go func() {
+		wg.Wait()
+		close(res)
+	}()
+
+	// Collect results.
+	for err := range res {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type partition struct {
+	mu    sync.RWMutex
+	store map[string]*entry
+}
+
+// entry returns the partition's entry for the provided key.
+// It's safe for use by multiple goroutines.
+func (p *partition) entry(key string) (*entry, bool) {
+	p.mu.RLock()
+	e, ok := p.store[key]
+	p.mu.RUnlock()
+	return e, ok
+}
+
+// write writes the values to the entry in the partition, creating the entry
+// if it does not exist.
+// write is safe for use by multiple goroutines.
+func (p *partition) write(key string, values Values) error {
+	p.mu.RLock()
+	e, ok := p.store[key]
+	p.mu.RUnlock()
+	if ok {
+		return e.add(values)
+	}
+
+	e, err := newEntryValues(values)
+	if err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	p.store[key] = e
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *partition) add(key string, entry *entry) {
+	p.mu.Lock()
+	p.store[key] = entry
+	p.mu.Unlock()
+}
+
+// remove deletes the entry associated with the provided key.
+// remove is safe for use by multiple goroutines.
+func (p *partition) remove(key string) {
+	p.mu.Lock()
+	delete(p.store, key)
+	p.mu.Unlock()
+}
+
+// keys returns an unsorted slice of the keys in the partition.
+func (p *partition) keys() []string {
+	p.mu.RLock()
+	keys := make([]string, 0, len(p.store))
+	for k, _ := range p.store {
+		keys = append(keys, k)
+	}
+	p.mu.RUnlock()
+	return keys
+}

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -32,16 +32,27 @@ const partitions = 256
 // key is hashed and the first 8 bits are used as an index to the ring.
 //
 type ring struct {
-	partitions []*partition // The unique set of partitions in the ring.
-	continuum  []*partition // A mapping of parition to location on the ring continuum.
+	// The unique set of partitions in the ring.
+	// len(partitions) <= len(continuum)
+	partitions []*partition
 
-	// Number of entries held within the ring. This is used to provide a
-	// hint for allocating a []string to return all keys. It will not be
-	// perfectly accurate since it doesn't consider adding duplicate keys,
-	// or trying to remove non-existent keys.
-	entryN int64
+	// A mapping of partition to location on the ring continuum. This is used
+	// to lookup a partition.
+	continuum []*partition
+
+	// Number of keys within the ring. This is used to provide a hint for
+	// allocating the return values in keys(). It will not be perfectly accurate
+	// since it doesn't consider adding duplicate keys, or trying to remove non-
+	// existent keys.
+	keysHint int64
 }
 
+// newring returns a new ring initialised with n partitions. n must always be a
+// power of 2, and for performance reasons should be larger than the number of
+// cores on the host. The supported set of values for n is:
+//
+//     {1, 2, 4, 8, 16, 32, 64, 128, 256}.
+//
 func newring(n int) (*ring, error) {
 	if n <= 0 || n > partitions {
 		return nil, fmt.Errorf("invalid number of paritions: %d", n)
@@ -66,6 +77,17 @@ func newring(n int) (*ring, error) {
 	return &r, nil
 }
 
+// reset resets the ring so it can be reused. Before removing references to entries
+// within each partition it gathers sizing information to provide hints when
+// reallocating entries in partition maps.
+//
+// reset is not safe for use by multiple goroutines.
+func (r *ring) reset() {
+	for _, partition := range r.partitions {
+		partition.reset()
+	}
+}
+
 // getPartition retrieves the hash ring partition associated with the provided
 // key.
 func (r *ring) getPartition(key string) *partition {
@@ -88,22 +110,22 @@ func (r *ring) write(key string, values Values) error {
 // add adds an entry to the ring.
 func (r *ring) add(key string, entry *entry) {
 	r.getPartition(key).add(key, entry)
-	atomic.AddInt64(&r.entryN, 1)
+	atomic.AddInt64(&r.keysHint, 1)
 }
 
 // remove deletes the entry for the given key.
 // remove is safe for use by multiple goroutines.
 func (r *ring) remove(key string) {
 	r.getPartition(key).remove(key)
-	if r.entryN > 0 {
-		atomic.AddInt64(&r.entryN, -1)
+	if r.keysHint > 0 {
+		atomic.AddInt64(&r.keysHint, -1)
 	}
 }
 
 // keys returns all the keys from all partitions in the hash ring. The returned
 // keys will be in order if sorted is true.
 func (r *ring) keys(sorted bool) []string {
-	keys := make([]string, 0, atomic.LoadInt64(&r.entryN))
+	keys := make([]string, 0, atomic.LoadInt64(&r.keysHint))
 	for _, p := range r.partitions {
 		keys = append(keys, p.keys()...)
 	}
@@ -117,6 +139,7 @@ func (r *ring) keys(sorted bool) []string {
 // apply applies the provided function to every entry in the ring under a read
 // lock. The provided function will be called with each key and the
 // corresponding entry. The first error encountered will be returned, if any.
+// apply is safe for use by multiple goroutines.
 func (r *ring) apply(f func(string, *entry) error) error {
 
 	var (
@@ -156,9 +179,16 @@ func (r *ring) apply(f func(string, *entry) error) error {
 	return nil
 }
 
+// partition provides safe access to a map of series keys to entries.
 type partition struct {
 	mu    sync.RWMutex
 	store map[string]*entry
+
+	// entrySizeHints stores hints for appropriate sizes to pre-allocate the
+	// []Values in an entry. entrySizeHints will only contain hints for entries
+	// that were present prior to the most recent snapshot, preventing unbounded
+	// growth over time.
+	entrySizeHints map[uint64]int
 }
 
 // entry returns the partition's entry for the provided key.
@@ -178,10 +208,16 @@ func (p *partition) write(key string, values Values) error {
 	e, ok := p.store[key]
 	p.mu.RUnlock()
 	if ok {
+		// Hot path.
 		return e.add(values)
 	}
 
-	e, err := newEntryValues(values)
+	// Create a new entry using a preallocated size if we have a hint available.
+	p.mu.RLock()
+	hint, _ := p.entrySizeHints[xxhash.Sum64([]byte(key))]
+	p.mu.RUnlock()
+
+	e, err := newEntryValues(values, hint)
 	if err != nil {
 		return err
 	}
@@ -192,6 +228,7 @@ func (p *partition) write(key string, values Values) error {
 	return nil
 }
 
+// add adds a new entry for key to the partition.
 func (p *partition) add(key string, entry *entry) {
 	p.mu.Lock()
 	p.store[key] = entry
@@ -215,4 +252,24 @@ func (p *partition) keys() []string {
 	}
 	p.mu.RUnlock()
 	return keys
+}
+
+// reset resets the partition by reinitialising the store. reset returns hints
+// about sizes that the entries within the store could be reallocated with.
+func (p *partition) reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Collect the allocated sizes of values for each entry in the store.
+	p.entrySizeHints = make(map[uint64]int)
+	for k, entry := range p.store {
+		// If the capacity is large then there are many values in the entry.
+		// Store a hint to pre-allocate the next time we see the same entry.
+		if cap(entry.values) > 128 { // 4 x the default entry capacity size.
+			p.entrySizeHints[xxhash.Sum64([]byte(k))] = cap(entry.values)
+		}
+	}
+
+	// Reset the store.
+	p.store = make(map[string]*entry, len(p.store))
 }

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -1,0 +1,34 @@
+package tsm1
+
+import (
+	"fmt"
+	"testing"
+)
+
+var strSliceRes []string
+
+func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
+	// Add some keys
+	for i := 0; i < keys; i++ {
+		r.add(fmt.Sprintf("cpu,host=server-%d value=1", i), nil)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		strSliceRes = r.keys(false)
+	}
+}
+
+func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(256), 100) }
+func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(256), 1000) }
+func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(256), 10000) }
+func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(256), 100000) }
+
+func MustNewRing(n int) *ring {
+	r, err := newring(n)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -2,8 +2,46 @@ package tsm1
 
 import (
 	"fmt"
+	"runtime"
+	"sync"
 	"testing"
 )
+
+func TestRing_newRing(t *testing.T) {
+	examples := []struct {
+		n         int
+		returnErr bool
+	}{
+		{n: 1}, {n: 2}, {n: 4}, {n: 8}, {n: 16}, {n: 32}, {n: 64}, {n: 128}, {n: 256},
+		{n: 0, returnErr: true}, {n: 3, returnErr: true}, {n: 512, returnErr: true},
+	}
+
+	for i, example := range examples {
+		r, err := newring(example.n)
+		if err != nil {
+			if example.returnErr {
+				continue // expecting an error.
+			}
+			t.Fatal(err)
+		}
+
+		if got, exp := len(r.partitions), example.n; got != exp {
+			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
+		}
+
+		// Check partitions distributed correctly
+		partitions := make([]*partition, 0)
+		for i, partition := range r.continuum {
+			if i == 0 || partition != partitions[len(partitions)-1] {
+				partitions = append(partitions, partition)
+			}
+		}
+
+		if got, exp := len(partitions), example.n; got != exp {
+			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
+		}
+	}
+}
 
 var strSliceRes []string
 
@@ -24,6 +62,45 @@ func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(
 func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(256), 1000) }
 func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(256), 10000) }
 func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(256), 100000) }
+
+func benchmarkRingWrite(b *testing.B, r *ring, n int) {
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+		for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < n; j++ {
+					if err := r.write(fmt.Sprintf("cpu,host=server-%d value=1", j), Values{}); err != nil {
+						b.Fatal(err)
+					}
+				}
+			}()
+			wg.Wait()
+		}
+	}
+}
+
+func BenchmarkRing_write_1_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(1), 100) }
+func BenchmarkRing_write_1_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(1), 1000) }
+func BenchmarkRing_write_1_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(1), 10000) }
+func BenchmarkRing_write_1_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(1), 100000) }
+func BenchmarkRing_write_4_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(4), 100) }
+func BenchmarkRing_write_4_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(4), 1000) }
+func BenchmarkRing_write_4_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(4), 10000) }
+func BenchmarkRing_write_4_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(4), 100000) }
+func BenchmarkRing_write_32_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(32), 100) }
+func BenchmarkRing_write_32_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(32), 1000) }
+func BenchmarkRing_write_32_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(32), 10000) }
+func BenchmarkRing_write_32_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(32), 100000) }
+func BenchmarkRing_write_128_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(128), 100) }
+func BenchmarkRing_write_128_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(128), 1000) }
+func BenchmarkRing_write_128_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(128), 10000) }
+func BenchmarkRing_write_128_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
+func BenchmarkRing_write_256_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(256), 100) }
+func BenchmarkRing_write_256_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(256), 1000) }
+func BenchmarkRing_write_256_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(256), 10000) }
+func BenchmarkRing_write_256_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
 
 func MustNewRing(n int) *ring {
 	r, err := newring(n)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR optimises the TSM1 cache, improving write performance under load by up to 70% from `1.1`.

It works by using a simple (crude, really) Hash Ring, which allows any series key to be consistently mapped to a partition in the ring. Each partition contains a map of series keys to TSM1 entries, and manages safe access to that map. Entries are distributed uniformly between a small (currently fixed to 128) partitions.

Since each partition manages access to the entries that map to it, contention over the entire cache is minimised, and restricted to cases when keys that map to the same partition as each other need to operate on the cache.

Further, currently the cache is essentially re-allocated and re-build after a snapshot is taken, which is expensive. This PR adds some logic that keeps track of how entries within the cache are currently allocated as _hints_, and uses these hints to pre-allocate the cache after a snapshot, so that subsequent additions of entries do not result in new allocations within the cache data-structure.

##### Performance

I've been mainly testing performance on a `c4.8xlarge` AWS instance, firing a combined `1.8 M writes/sec` at the instance using `influx-stress`. Specifically:

```
# host 1
$ influx-stress insert -n 30000000 --pps 900000 --host http://influxdb:8086

# host 2
$ influx-stress insert -n 30000000 --pps 900000 --host http://influxdb:8086
```
In total 600M points are written.

 - Write Throughput InfluxDB 1.1 RC1: *1,082,621 writes/sec*
 - Write Throughput er-cache: *1,682,816 writes/sec*

This is a typical run, where the points have a single value. The case where there are multiple points have a similar difference.  



