### PR TITLE
Return the time from a percentile call on an integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Bugfixes
 
 - [#7625](https://github.com/influxdata/influxdb/issues/7625): Fix incorrect tag value in error message.
+- [#7634](https://github.com/influxdata/influxdb/issues/7634): Return the time from a percentile call on an integer.
 
 ## v1.1.0 [2016-11-14]
 ## v1.1.0 [unreleased]

--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -1120,7 +1120,7 @@ func NewIntegerPercentileReduceSliceFunc(percentile float64) IntegerReduceSliceF
 		}
 
 		sort.Sort(integerPointsByValue(a))
-		return []IntegerPoint{{Time: ZeroTime, Value: a[i].Value, Aux: a[i].Aux}}
+		return []IntegerPoint{{Time: a[i].Time, Value: a[i].Value, Aux: a[i].Aux}}
 	}
 }
 


### PR DESCRIPTION
`percentile()` is supposed to be a selector and return the time of the
point, but that only got changed when the input was a float. Updating
the integer processor to also return the time of the point rather than
the beginning of the interval.

Fixes #7634.