### PR TITLE
removed parentheses to make tcp golintable

### DIFF
--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -168,7 +168,7 @@ func (mux *Mux) Listen(header byte) net.Listener {
 	return ln
 }
 
-// DefaultListener() will return a net.Listener that will pass-through any
+// DefaultListener will return a net.Listener that will pass-through any
 // connections with non-registered values for the first byte of the connection.
 // The connections returned from this listener's Accept() method will replay the
 // first byte of the connection as a short first Read().


### PR DESCRIPTION
Issue: Enable golint on the code base #4098

All required was removing parantheses trailing the method name at the start of the comment. 