### PR TITLE
Expose Shard.LastModified

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -49,6 +49,7 @@ type Engine interface {
 
 	// Statistics will return statistics relevant to this engine.
 	Statistics(tags map[string]string) []models.Statistic
+	LastModified() time.Time
 
 	io.WriterTo
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -827,6 +827,18 @@ func (e *Engine) SeriesCount() (n int, err error) {
 	return e.index.SeriesN(), nil
 }
 
+// LastModified returns the time when this shard was last modified
+func (e *Engine) LastModified() time.Time {
+	walTime := e.WAL.LastWriteTime()
+	fsTime := e.FileStore.LastModified()
+
+	if walTime.After(fsTime) {
+		return walTime
+	}
+
+	return fsTime
+}
+
 func (e *Engine) WriteTo(w io.Writer) (n int64, err error) { panic("not implemented") }
 
 // WriteSnapshot will snapshot the cache and write a new TSM file with its contents, releasing the snapshot when done.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -335,6 +335,14 @@ func (s *Shard) ready() error {
 	return err
 }
 
+// LastModified returns the time when this shard was last modified
+func (s *Shard) LastModified() time.Time {
+	if err := s.ready(); err != nil {
+		return time.Time{}
+	}
+	return s.engine.LastModified()
+}
+
 // DiskSize returns the size on disk of this shard
 func (s *Shard) DiskSize() (int64, error) {
 	var size int64


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This returns the LastModified time of the shard.  The LastModified
time is the wall time when a change to the shards state occurred.
It uses the WAL or FileStore to determine the max mod time.
