### PR TITLE
Use slash separator for filenames in tar archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [#7621](https://github.com/influxdata/influxdb/issues/7621): Expand string and boolean fields when using a wildcard with `sample()`.
 - [#7616](https://github.com/influxdata/influxdb/pull/7616): Fix chuid argument order in init script @ccasey
+- [#7656](https://github.com/influxdata/influxdb/issues/7656): Fix cross-platform backup/restore
 
 ## v1.1.1 [unreleased]
 

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -309,7 +309,8 @@ func (cmd *Command) unpackTar(tarFile string) error {
 
 // unpackFile will copy the current file from the tar archive to the data dir
 func (cmd *Command) unpackFile(tr *tar.Reader, fileName string) error {
-	fn := filepath.Join(cmd.datadir, fileName)
+	nativeFileName := filepath.FromSlash(fileName)
+	fn := filepath.Join(cmd.datadir, nativeFileName)
 	fmt.Printf("unpacking %s\n", fn)
 
 	if err := os.MkdirAll(filepath.Dir(fn), 0777); err != nil {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -540,7 +540,7 @@ func (e *Engine) Backup(w io.Writer, basePath string, since time.Time) error {
 // in their names. This should be the <db>/<retention policy>/<id> part of the path
 func (e *Engine) writeFileToBackup(f os.FileInfo, shardRelativePath, fullPath string, tw *tar.Writer) error {
 	h := &tar.Header{
-		Name:    filepath.Join(shardRelativePath, f.Name()),
+		Name:    filepath.ToSlash(filepath.Join(shardRelativePath, f.Name())),
 		ModTime: f.ModTime(),
 		Size:    f.Size(),
 		Mode:    int64(f.Mode()),
@@ -595,11 +595,13 @@ func (e *Engine) readFileFromBackup(tr *tar.Reader, shardRelativePath string) er
 		return err
 	}
 
+	nativeFileName := filepath.FromSlash(hdr.Name)
+
 	// Skip file if it does not have a matching prefix.
-	if !filepath.HasPrefix(hdr.Name, shardRelativePath) {
+	if !filepath.HasPrefix(nativeFileName, shardRelativePath) {
 		return nil
 	}
-	path, err := filepath.Rel(shardRelativePath, hdr.Name)
+	path, err := filepath.Rel(shardRelativePath, nativeFileName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [x] CHANGELOG.md updated
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

NO-OP on platforms with Unix path separator.
On Windows paths get converted to slashes before adding to archive and back to backslashes during restore.

Fixes #7656