### PR TITLE
Quote the empty string as an ident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Bugfixes
 
 - [#7625](https://github.com/influxdata/influxdb/issues/7625): Fix incorrect tag value in error message.
+- [#7661](https://github.com/influxdata/influxdb/pull/7661): Quote the empty string as an ident.
 
 ## v1.1.0 [2016-11-14]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2853,7 +2853,8 @@ func QuoteIdent(segments ...string) string {
 	var buf bytes.Buffer
 	for i, segment := range segments {
 		needQuote := IdentNeedsQuotes(segment) ||
-			((i < len(segments)-1) && segment != "") // not last segment && not ""
+			((i < len(segments)-1) && segment != "") || // not last segment && not ""
+			((i == 0 || i == len(segments)-1) && segment == "") // the first or last segment and an empty string
 
 		if needQuote {
 			_ = buf.WriteByte('"')

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -2806,7 +2806,7 @@ func TestQuoteIdent(t *testing.T) {
 		ident []string
 		s     string
 	}{
-		{[]string{``}, ``},
+		{[]string{``}, `""`},
 		{[]string{`select`}, `"select"`},
 		{[]string{`in-bytes`}, `"in-bytes"`},
 		{[]string{`foo`, `bar`}, `"foo".bar`},


### PR DESCRIPTION
Without this quoting, the function `max("")` turns into `max()` and will
not be reparsed correctly.

Backport of #7644.