### PR TITLE
Enforce minimum shard duration when creating retention policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7396](https://github.com/influxdata/influxdb/issues/7396): CLI should use spaces for alignment, not tabs.
 - [#6527](https://github.com/influxdata/influxdb/issues/6527): 0.12.2 Influx CLI client PRECISION returns "Unknown precision....
 - [#7740](https://github.com/influxdata/influxdb/issues/7740): Fix parse key panic when missing tag value @oiooj
+- [#7563](https://github.com/influxdata/influxdb/issues/7563): RP should not allow `INF` or `0` as a shard duration.
 
 ## v1.1.1 [2016-12-06]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -428,6 +428,17 @@ func (p *Parser) parseCreateRetentionPolicyStatement() (*CreateRetentionPolicySt
 		if tok, pos, lit := p.scanIgnoreWhitespace(); tok != DURATION {
 			return nil, newParseError(tokstr(tok, lit), []string{"DURATION"}, pos)
 		}
+
+		// Check to see if they used the INF keyword
+		tok, pos, _ := p.scanIgnoreWhitespace()
+		if tok == INF {
+			return nil, &ParseError{
+				Message: "invalid duration INF for shard duration",
+				Pos:     pos,
+			}
+		}
+		p.unscan()
+
 		d, err := p.parseDuration()
 		if err != nil {
 			return nil, err
@@ -502,6 +513,16 @@ Loop:
 		case SHARD:
 			tok, pos, lit := p.scanIgnoreWhitespace()
 			if tok == DURATION {
+				// Check to see if they used the INF keyword
+				tok, pos, _ := p.scanIgnoreWhitespace()
+				if tok == INF {
+					return nil, &ParseError{
+						Message: "invalid duration INF for shard duration",
+						Pos:     pos,
+					}
+				}
+				p.unscan()
+
 				d, err := p.parseDuration()
 				if err != nil {
 					return nil, err

--- a/services/meta/client_test.go
+++ b/services/meta/client_test.go
@@ -85,7 +85,7 @@ func TestMetaClient_CreateDatabaseWithRetentionPolicy(t *testing.T) {
 		Name:               "rp0",
 		Duration:           &duration,
 		ReplicaN:           &replicaN,
-		ShardGroupDuration: 30 * time.Minute,
+		ShardGroupDuration: 60 * time.Minute,
 	}
 	if _, err := c.CreateDatabaseWithRetentionPolicy("db0", &spec); err != nil {
 		t.Fatal(err)
@@ -105,7 +105,7 @@ func TestMetaClient_CreateDatabaseWithRetentionPolicy(t *testing.T) {
 		t.Fatalf("rp duration wrong: %v", rp.Duration)
 	} else if rp.ReplicaN != 1 {
 		t.Fatalf("rp replication wrong: %d", rp.ReplicaN)
-	} else if rp.ShardGroupDuration != 30*time.Minute {
+	} else if rp.ShardGroupDuration != 60*time.Minute {
 		t.Fatalf("rp shard duration wrong: %v", rp.ShardGroupDuration)
 	}
 
@@ -240,8 +240,8 @@ func TestMetaClient_CreateRetentionPolicy(t *testing.T) {
 	rp0 := meta.RetentionPolicyInfo{
 		Name:               "rp0",
 		ReplicaN:           1,
-		Duration:           time.Hour,
-		ShardGroupDuration: time.Hour,
+		Duration:           2 * time.Hour,
+		ShardGroupDuration: 2 * time.Hour,
 	}
 
 	if _, err := c.CreateRetentionPolicy("db0", &meta.RetentionPolicySpec{

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1126,8 +1126,14 @@ func shardGroupDuration(d time.Duration) time.Duration {
 
 // normalisedShardDuration returns normalised shard duration based on a policy duration.
 func normalisedShardDuration(sgd, d time.Duration) time.Duration {
+	// If it is zero, it likely wasn't specified, so we default to the shard group duration
 	if sgd == 0 {
 		return shardGroupDuration(d)
+	}
+	// If it was specified, but it's less than the MinRetentionPolicyDuration, then normalize
+	// to the MinRetentionPolicyDuration
+	if sgd < MinRetentionPolicyDuration {
+		return shardGroupDuration(MinRetentionPolicyDuration)
 	}
 	return sgd
 }


### PR DESCRIPTION
Fixes #7563 

Here are examples of what the new results are when running `CREATE RETENTION POLICY` commands:

```sql
> create database foo
> CREATE RETENTION POLICY policy3 ON foo DURATION INF REPLICATION 1 SHARD DURATION 0m
> CREATE RETENTION POLICY policy4 ON foo DURATION INF REPLICATION 1 SHARD DURATION 1s
> show retention policies on foo
name    duration        shardGroupDuration      replicaN        default
----    --------        ------------------      --------        -------
autogen 0s              168h0m0s                1               true
policy3 0s              168h0m0s                1               false
policy4 0s              1h0m0s                  1               false

> CREATE RETENTION POLICY policy4 ON foo DURATION INF REPLICATION 1 SHARD DURATION INF
ERR: error parsing query: invalid duration INF for shard duration at line 1, char 82
Warning: It is possible this error is due to not setting a database.
Please set a database with the command "use <database>".
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [x] Provide example syntax

