### PR TITLE
Reject invalid subscription urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,14 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 
 - [#7621](https://github.com/influxdata/influxdb/issues/7621): Expand string and boolean fields when using a wildcard with `sample()`.
 - [#7616](https://github.com/influxdata/influxdb/pull/7616): Fix chuid argument order in init script @ccasey
-- [#7656](https://github.com/influxdata/influxdb/issues/7656): Fix cross-platform backup/restore
+- [#7656](https://github.com/influxdata/influxdb/issues/7656): Fix cross-platform backup/restore @allenpetersen
 - [#7650](https://github.com/influxdata/influxdb/issues/7650): Ensures that all user privileges associated with a database are removed when the database is dropped.
 - [#7659](https://github.com/influxdata/influxdb/issues/7659): Fix CLI import bug when using self-signed SSL certificates.
 - [#7698](https://github.com/influxdata/influxdb/pull/7698): CLI was caching db/rp for insert into statements.
 - [#6527](https://github.com/influxdata/influxdb/issues/6527): 0.12.2 Influx CLI client PRECISION returns "Unknown precision....
 
 - [#7396](https://github.com/influxdata/influxdb/issues/7396): CLI should use spaces for alignment, not tabs.
+- [#7615](https://github.com/influxdata/influxdb/issues/7615): Reject invalid subscription urls @allenpetersen
 
 ## v1.1.1 [unreleased]
 

--- a/services/meta/errors.go
+++ b/services/meta/errors.go
@@ -93,6 +93,11 @@ var (
 	ErrSubscriptionNotFound = errors.New("subscription not found")
 )
 
+// ErrInvalidSubscriptionURL is returned when the destication url is invalid.
+func ErrInvalidSubscriptionURL(url string) error {
+	return fmt.Errorf("invalid subscription URL: %s", url)
+}
+
 var (
 	// ErrUserExists is returned when creating an already existing user.
 	ErrUserExists = errors.New("user already exists")

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -192,11 +192,11 @@ func (s *Service) createSubscription(se subEntry, mode string, destinations []st
 	for _, dest := range destinations {
 		u, err := url.Parse(dest)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse subscription url: %s", dest)
+			return nil, fmt.Errorf("failed to parse destination: %s", dest)
 		}
 		w, err := s.NewPointsWriter(*u)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create PointsWriter for subscription url: %s", dest)
+			return nil, fmt.Errorf("failed to create writer for destination: %s", dest)
 		}
 		writers = append(writers, w)
 		stats = append(stats, writerStats{dest: dest})
@@ -288,7 +288,7 @@ func (s *Service) updateSubs(wg *sync.WaitGroup) {
 				sub, err := s.createSubscription(se, si.Mode, si.Destinations)
 				if err != nil {
 					atomic.AddInt64(&s.stats.CreateFailures, 1)
-					s.Logger.Println(err)
+					s.Logger.Printf("Subscription creation failed for '%s' with error: %s", si.Name, err)
 					continue
 				}
 				cw := chanWriter{

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -19,8 +19,9 @@ import (
 
 // Statistics for the Subscriber service.
 const (
-	statPointsWritten = "pointsWritten"
-	statWriteFailures = "writeFailures"
+	statCreateFailures = "createFailures"
+	statPointsWritten  = "pointsWritten"
+	statWriteFailures  = "writeFailures"
 )
 
 // PointsWriter is an interface for writing points to a subscription destination.
@@ -123,8 +124,9 @@ func (s *Service) SetLogOutput(w io.Writer) {
 
 // Statistics maintains the statistics for the subscriber service.
 type Statistics struct {
-	WriteFailures int64
-	PointsWritten int64
+	CreateFailures int64
+	PointsWritten  int64
+	WriteFailures  int64
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -133,8 +135,9 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 		Name: "subscriber",
 		Tags: tags,
 		Values: map[string]interface{}{
-			statPointsWritten: atomic.LoadInt64(&s.stats.PointsWritten),
-			statWriteFailures: atomic.LoadInt64(&s.stats.WriteFailures),
+			statCreateFailures: atomic.LoadInt64(&s.stats.CreateFailures),
+			statPointsWritten:  atomic.LoadInt64(&s.stats.PointsWritten),
+			statWriteFailures:  atomic.LoadInt64(&s.stats.WriteFailures),
 		},
 	}}
 
@@ -183,20 +186,22 @@ func (s *Service) createSubscription(se subEntry, mode string, destinations []st
 	default:
 		return nil, fmt.Errorf("unknown balance mode %q", mode)
 	}
-	writers := make([]PointsWriter, len(destinations))
-	stats := make([]writerStats, len(writers))
-	for i, dest := range destinations {
+	writers := make([]PointsWriter, 0, len(destinations))
+	stats := make([]writerStats, 0, len(destinations))
+	// add only valid destinations
+	for _, dest := range destinations {
 		u, err := url.Parse(dest)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed to parse subscription url: %s", dest)
 		}
 		w, err := s.NewPointsWriter(*u)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed to create PointsWriter for subscription url: %s", dest)
 		}
-		writers[i] = w
-		stats[i].dest = dest
+		writers = append(writers, w)
+		stats = append(stats, writerStats{dest: dest})
 	}
+
 	return &balancewriter{
 		bm:      bm,
 		writers: writers,
@@ -224,10 +229,7 @@ func (s *Service) run() {
 	for {
 		select {
 		case <-s.update:
-			err := s.updateSubs(&wg)
-			if err != nil {
-				s.Logger.Println("failed to update subscriptions:", err)
-			}
+			s.updateSubs(&wg)
 		case p, ok := <-s.points:
 			if !ok {
 				// Close out all chanWriters
@@ -260,7 +262,7 @@ func (s *Service) close(wg *sync.WaitGroup) {
 	s.subs = nil
 }
 
-func (s *Service) updateSubs(wg *sync.WaitGroup) error {
+func (s *Service) updateSubs(wg *sync.WaitGroup) {
 	s.subMu.Lock()
 	defer s.subMu.Unlock()
 
@@ -285,7 +287,9 @@ func (s *Service) updateSubs(wg *sync.WaitGroup) error {
 				}
 				sub, err := s.createSubscription(se, si.Mode, si.Destinations)
 				if err != nil {
-					return err
+					atomic.AddInt64(&s.stats.CreateFailures, 1)
+					s.Logger.Println(err)
+					continue
 				}
 				cw := chanWriter{
 					writeRequests: make(chan *coordinator.WritePointsRequest, s.conf.WriteBufferSize),
@@ -318,8 +322,6 @@ func (s *Service) updateSubs(wg *sync.WaitGroup) error {
 			s.Logger.Println("deleted old subscription for", se.db, se.rp)
 		}
 	}
-
-	return nil
 }
 
 // Creates a PointsWriter from the given URL


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

The url must have a scheme of udp or tcp in addition to a port number.
CREATE SUBSCRIPTION will fail if there are invalid destinations.

Additionally Service.createSubscription will skip over any invalid
destinations on previously created subscriptions.

Fixes #7615