### PR TITLE
Added additional variable to fulfil NewUDPClient function requirement…

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -230,7 +230,7 @@ The **InfluxDB** client also supports writing over UDP.
 ```go
 func WriteUDP() {
 	// Make client
-	c := client.NewUDPClient("localhost:8089")
+	c, _ := client.NewUDPClient("localhost:8089")
 
 	// Create a new point batch
 	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{

--- a/client/README.md
+++ b/client/README.md
@@ -230,8 +230,11 @@ The **InfluxDB** client also supports writing over UDP.
 ```go
 func WriteUDP() {
 	// Make client
-	c, _ := client.NewUDPClient("localhost:8089")
-
+	c, err := client.NewUDPClient("localhost:8089")
+	if err != nil {
+		panic(err.Error())
+	}
+	
 	// Create a new point batch
 	bp, _ := client.NewBatchPoints(client.BatchPointsConfig{
 		Precision: "s",


### PR DESCRIPTION
Hi, 

Added additional variable to fulfill ```NewUDPClient``` function requirement (there was one instead of 2) and it caused multiple-value ```client.NewUDPClient()``` in single-value context error

According to function definition in udp.go (client/v2/udp.go), function is returning two values (client and error): 
```golang 
func NewUDPClient(conf UDPConfig) (Client, error)
```

Please verify.
Thanks!