### PR TITLE
Ensure user privileges dropped along with db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#7621](https://github.com/influxdata/influxdb/issues/7621): Expand string and boolean fields when using a wildcard with `sample()`.
 - [#7616](https://github.com/influxdata/influxdb/pull/7616): Fix chuid argument order in init script @ccasey
 - [#7656](https://github.com/influxdata/influxdb/issues/7656): Fix cross-platform backup/restore
+- [#7650](https://github.com/influxdata/influxdb/issues/7650): Ensures that all user privileges associated with a database are removed when the database is dropped.
 
 ## v1.1.1 [unreleased]
 
@@ -23,7 +24,6 @@
 - [#7625](https://github.com/influxdata/influxdb/issues/7625): Fix incorrect tag value in error message.
 
 ## v1.1.0 [2016-11-14]
-## v1.1.0 [unreleased]
 
 ### Release Notes
 

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -112,6 +112,11 @@ func (data *Data) DropDatabase(name string) error {
 	for i := range data.Databases {
 		if data.Databases[i].Name == name {
 			data.Databases = append(data.Databases[:i], data.Databases[i+1:]...)
+
+			// Remove all user privileges associated with this database.
+			for i := range data.Users {
+				delete(data.Users[i].Privileges, name)
+			}
 			break
 		}
 	}

--- a/services/meta/data_test.go
+++ b/services/meta/data_test.go
@@ -1,11 +1,67 @@
 package meta_test
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/influxdata/influxdb/influxql"
+
 	"github.com/influxdata/influxdb/services/meta"
 )
+
+func Test_Data_DropDatabase(t *testing.T) {
+	data := &meta.Data{
+		Databases: []meta.DatabaseInfo{
+			{Name: "db0"},
+			{Name: "db1"},
+			{Name: "db2"},
+			{Name: "db4"},
+			{Name: "db5"},
+		},
+		Users: []meta.UserInfo{
+			{Name: "user1", Privileges: map[string]influxql.Privilege{"db1": influxql.ReadPrivilege, "db2": influxql.ReadPrivilege}},
+			{Name: "user2", Privileges: map[string]influxql.Privilege{"db2": influxql.ReadPrivilege}},
+		},
+	}
+
+	// Dropping the first database removes it from the Data object.
+	expDbs := make([]meta.DatabaseInfo, 4)
+	copy(expDbs, data.Databases[1:])
+	if err := data.DropDatabase("db0"); err != nil {
+		t.Fatal(err)
+	} else if got, exp := data.Databases, expDbs; !reflect.DeepEqual(got, exp) {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Dropping a middle database removes it from the data object.
+	expDbs = []meta.DatabaseInfo{{Name: "db1"}, {Name: "db2"}, {Name: "db5"}}
+	if err := data.DropDatabase("db4"); err != nil {
+		t.Fatal(err)
+	} else if got, exp := data.Databases, expDbs; !reflect.DeepEqual(got, exp) {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Dropping the last database removes it from the data object.
+	expDbs = []meta.DatabaseInfo{{Name: "db1"}, {Name: "db2"}}
+	if err := data.DropDatabase("db5"); err != nil {
+		t.Fatal(err)
+	} else if got, exp := data.Databases, expDbs; !reflect.DeepEqual(got, exp) {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Dropping a database also drops all the user privileges associated with
+	// it.
+	expUsers := []meta.UserInfo{
+		{Name: "user1", Privileges: map[string]influxql.Privilege{"db1": influxql.ReadPrivilege}},
+		{Name: "user2", Privileges: map[string]influxql.Privilege{}},
+	}
+	if err := data.DropDatabase("db2"); err != nil {
+		t.Fatal(err)
+	} else if got, exp := data.Users, expUsers; !reflect.DeepEqual(got, exp) {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+}
 
 func Test_Data_CreateRetentionPolicy(t *testing.T) {
 	data := meta.Data{}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Currently user privileges associated with a database persist in the `meta.Data` object after the database is dropped. This ensures that they're removed when the database is dropped.

Fixes #7650.