### PR TITLE
Fix string fields w/ trailing slashes

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -1038,8 +1038,8 @@ func scanFieldValue(buf []byte, i int) (int, []byte) {
 	start := i
 	quoted := false
 	for i < len(buf) {
-		// Only escape char for a field value is a double-quote
-		if buf[i] == '\\' && i+1 < len(buf) && buf[i+1] == '"' {
+		// Only escape char for a field value is a double-quote and backslash
+		if buf[i] == '\\' && i+1 < len(buf) && (buf[i+1] == '"' || buf[i+1] == '\\') {
 			i += 2
 			continue
 		}

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1086,6 +1086,21 @@ func TestParsePointWithStringWithCommas(t *testing.T) {
 			},
 			time.Unix(1, 0)),
 	)
+
+	// string w/ trailing escape chars
+	test(t, `cpu,host=serverA,region=us-east str="foo\\",str2="bar" 1000000000`,
+		NewTestPoint(
+			"cpu",
+			models.NewTags(map[string]string{
+				"host":   "serverA",
+				"region": "us-east",
+			}),
+			models.Fields{
+				"str":  "foo\\", // trailing escape char
+				"str2": "bar",
+			},
+			time.Unix(1, 0)),
+	)
 }
 
 func TestParsePointQuotedMeasurement(t *testing.T) {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated

A string field w/ a trailing slash before the quote would parse incorrectly
because the quote would be seen as escaped.  We have to treat \\ as an
escape sequence within strings in order to handle this.

@e-dard 