### PR TITLE
Reduce pool size, change WAL writers default

### DIFF
--- a/tsdb/engine/tsm1/pools.go
+++ b/tsdb/engine/tsm1/pools.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	bufPool          = pool.NewBytes(1024)
+	bufPool          = pool.NewBytes(10)
 	float64ValuePool sync.Pool
 	integerValuePool sync.Pool
 	booleanValuePool sync.Pool

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"runtime"
 
 	"github.com/golang/snappy"
 	"github.com/influxdata/influxdb/models"
@@ -60,6 +61,7 @@ const (
 var (
 	ErrWALClosed  = fmt.Errorf("WAL closed")
 	ErrWALCorrupt = fmt.Errorf("corrupted WAL entry")
+	defaultWaitingWALWrites = runtime.NumCPU()
 )
 
 // Statistics gathered by the WAL.
@@ -68,7 +70,6 @@ const (
 	statWALCurrentBytes     = "currentSegmentDiskBytes"
 	statWriteOk             = "writeOk"
 	statWriteErr            = "writeErr"
-	defaultWaitingWALWrites = 10
 )
 
 type WAL struct {

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -10,13 +10,13 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-	"runtime"
 
 	"github.com/golang/snappy"
 	"github.com/influxdata/influxdb/models"
@@ -59,17 +59,17 @@ const (
 )
 
 var (
-	ErrWALClosed  = fmt.Errorf("WAL closed")
-	ErrWALCorrupt = fmt.Errorf("corrupted WAL entry")
+	ErrWALClosed            = fmt.Errorf("WAL closed")
+	ErrWALCorrupt           = fmt.Errorf("corrupted WAL entry")
 	defaultWaitingWALWrites = runtime.NumCPU()
 )
 
 // Statistics gathered by the WAL.
 const (
-	statWALOldBytes         = "oldSegmentsDiskBytes"
-	statWALCurrentBytes     = "currentSegmentDiskBytes"
-	statWriteOk             = "writeOk"
-	statWriteErr            = "writeErr"
+	statWALOldBytes     = "oldSegmentsDiskBytes"
+	statWALCurrentBytes = "currentSegmentDiskBytes"
+	statWriteOk         = "writeOk"
+	statWriteErr        = "writeErr"
 )
 
 type WAL struct {


### PR DESCRIPTION
Big pool can lead to huge memory usage in certain loads.

See #7640 for detailed discussion.