### PR TITLE
Update Go version to 1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#7356](https://github.com/influxdata/influxdb/issues/7356): Use X-Forwarded-For IP address in HTTP logger if present.
 - [#7601](https://github.com/influxdata/influxdb/issues/7601): Prune data in meta store for deleted shards.
 - [#7669](https://github.com/influxdata/influxdb/issues/7669): Uncomment section headers from the default configuration file.
+- [#7684](https://github.com/influxdata/influxdb/issues/7684): Update Go version to 1.7.4.
 
 ### Bugfixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.7.3.
+InfluxDB requires Go 1.7.4.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -77,8 +77,8 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.7.3
-    gvm use go1.7.3 --default
+    gvm install go1.7.4
+    gvm use go1.7.4 --default
 
 Installing GDM
 -------------

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -11,12 +11,12 @@ To build a docker image for InfluxDB from your current checkout, run the followi
 $ ./build-docker.sh
 ```
 
-This script uses the `golang:1.7.3` image to build a fully static binary of `influxd` and then adds it to a minimal `scratch` image.
+This script uses the `golang:1.7.4` image to build a fully static binary of `influxd` and then adds it to a minimal `scratch` image.
 
 To build the image using a different version of go:
 
 ```
-$ GO_VER=1.7.3 ./build-docker.sh
+$ GO_VER=1.7.4 ./build-docker.sh
 ```
 
 Available version can be found [here](https://hub.docker.com/_/golang/).

--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -18,7 +18,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 ENV GO_ARCH 386
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -21,7 +21,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 ENV GO_ARCH amd64
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -26,7 +26,7 @@ VOLUME $PROJECT_DIR
 
 
 # Install go
-ENV GO_VERSION 1.7.3
+ENV GO_VERSION 1.7.4
 ENV GO_ARCH amd64
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -2,7 +2,7 @@
 
 set -e -x
 
-GO_VER=${GO_VER:-1.7.3}
+GO_VER=${GO_VER:-1.7.4}
 
 docker run -it -v "${GOPATH}":/gopath -v "$(pwd)":/app -e "GOPATH=/gopath" -w /app golang:$GO_VER sh -c 'CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags="-s" -o influxd ./cmd/influxd'
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
     services:
         - docker
     environment:
-      GODIST: "go1.7.3.linux-amd64.tar.gz"
+      GODIST: "go1.7.4.linux-amd64.tar.gz"
     post:
       - mkdir -p download
       - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #7684.

There is still a 32-bit Ubuntu test container running Go 1.4 [here](https://github.com/influxdata/influxdb/blob/er-go.1.7.4/Dockerfile_test_ubuntu32#L4).

@rossmcdonald what's the best way for me to get this up to 1.7.4 (or do we even need this container anymore?). I doubt there are 3rd party PPAs available for 1.7.4.
