### PR TITLE
Add bound parameters map to Query object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7036](https://github.com/influxdata/influxdb/issues/7036): Switch logging to use structured logging everywhere.
 - [#3188](https://github.com/influxdata/influxdb/issues/3188): [CLI feature request] USE retention policy for queries.
 - [#7709](https://github.com/influxdata/influxdb/pull/7709): Add clear command to cli.
+- [#7688](https://github.com/influxdata/influxdb/pull/7688): Adding ability to use parameters in queries in the v2 client using the `Parameters` map in the `Query` struct.
 
 ### Bugfixes
 


### PR DESCRIPTION
Addresses #7687.  Support for bound parameters was added in #6634. However, the golang client package was not updated to support the new behaviour. This PR extends the Query object to take a list of parameters, which are POSTed to the influxdb server when the query is executed.

- [x] CHANGELOG.md updated (No, as it is a trivial change which doesn't affect the server)
- [x] Rebased/mergable
- [x] Tests pass (See below)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


## Tests
I've added a test that the parameters are encoded, (which passes).

The following tests fail when I run ` go test -v ./...`.  However, this test is also failing with a clean check-out of the master repository, so I believe it is unrelated to this PR.

FAIL	github.com/influxdata/influxdb/tsdb/engine/tsm1	21.017s

```
[tsm1] 2016/12/05 16:14:47 Snapshot for path /tmp/tsm497135727 written in 5.765042ms
--- FAIL: TestEngine_Backup (0.02s)
	engine_test.go:185: file name doesn't match:
			got: 000000002-000000001.tsm
			exp: /tmp/tsm497135727/000000001-000000001.tsm
```