### PR TITLE
Add influx_stress deprecation note to change log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Release Notes
 
+### Deprecations
+
+The stress tool `influx_stress` will be removed in a subsequent release. We recommend using [`influx-stress`](https://github.com/influxdata/influx-stress) as a replacement.
+
 ### Features
 
 - [#7066](https://github.com/influxdata/influxdb/issues/7066): Add support for secure transmission via collectd.


### PR DESCRIPTION
Added entry to the changelog noting that we're deprecating `influx_stress`.
