### PR TITLE
CLI was caching db/rp for insert into statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7656](https://github.com/influxdata/influxdb/issues/7656): Fix cross-platform backup/restore
 - [#7650](https://github.com/influxdata/influxdb/issues/7650): Ensures that all user privileges associated with a database are removed when the database is dropped.
 - [#7659](https://github.com/influxdata/influxdb/issues/7659): Fix CLI import bug when using self-signed SSL certificates.
+- [#7698](https://github.com/influxdata/influxdb/pull/7698): CLI was caching db/rp for insert into statements.
 
 
 ## v1.1.1 [unreleased]

--- a/cmd/influx/cli/cli_internal_test.go
+++ b/cmd/influx/cli/cli_internal_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import "testing"
+
+func TestParseCommand_InsertInto(t *testing.T) {
+	t.Parallel()
+
+	c := CommandLine{}
+
+	tests := []struct {
+		cmd, db, rp string
+	}{
+		{
+			cmd: `INSERT INTO test cpu,host=serverA,region=us-west value=1.0`,
+			db:  "",
+			rp:  "test",
+		},
+		{
+			cmd: ` INSERT INTO .test cpu,host=serverA,region=us-west value=1.0`,
+			db:  "",
+			rp:  "test",
+		},
+		{
+			cmd: `INSERT INTO   "test test" cpu,host=serverA,region=us-west value=1.0`,
+			db:  "",
+			rp:  "test test",
+		},
+		{
+			cmd: `Insert iNTO test.test cpu,host=serverA,region=us-west value=1.0`,
+			db:  "test",
+			rp:  "test",
+		},
+		{
+			cmd: `insert into "test test" cpu,host=serverA,region=us-west value=1.0`,
+			db:  "",
+			rp:  "test test",
+		},
+		{
+			cmd: `insert into "d b"."test test" cpu,host=serverA,region=us-west value=1.0`,
+			db:  "d b",
+			rp:  "test test",
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("command: %s", test.cmd)
+		bp, err := c.parseInsert(test.cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bp.Database != test.db {
+			t.Fatalf(`Command "insert into" db parsing failed, expected: %q, actual: %q`, test.db, bp.Database)
+		}
+		if bp.RetentionPolicy != test.rp {
+			t.Fatalf(`Command "insert into" rp parsing failed, expected: %q, actual: %q`, test.rp, bp.RetentionPolicy)
+		}
+	}
+}

--- a/cmd/influx/cli/cli_test.go
+++ b/cmd/influx/cli/cli_test.go
@@ -411,67 +411,6 @@ func TestParseCommand_Insert(t *testing.T) {
 	}
 }
 
-func TestParseCommand_InsertInto(t *testing.T) {
-	t.Parallel()
-	ts := emptyTestServer()
-	defer ts.Close()
-
-	u, _ := url.Parse(ts.URL)
-	config := client.Config{URL: *u}
-	c, err := client.NewClient(config)
-	if err != nil {
-		t.Fatalf("unexpected error.  expected %v, actual %v", nil, err)
-	}
-	m := cli.CommandLine{Client: c}
-
-	tests := []struct {
-		cmd, db, rp string
-	}{
-		{
-			cmd: `INSERT INTO test cpu,host=serverA,region=us-west value=1.0`,
-			db:  "",
-			rp:  "test",
-		},
-		{
-			cmd: ` INSERT INTO .test cpu,host=serverA,region=us-west value=1.0`,
-			db:  "",
-			rp:  "test",
-		},
-		{
-			cmd: `INSERT INTO   "test test" cpu,host=serverA,region=us-west value=1.0`,
-			db:  "",
-			rp:  "test test",
-		},
-		{
-			cmd: `Insert iNTO test.test cpu,host=serverA,region=us-west value=1.0`,
-			db:  "test",
-			rp:  "test",
-		},
-		{
-			cmd: `insert into "test test" cpu,host=serverA,region=us-west value=1.0`,
-			db:  "test",
-			rp:  "test test",
-		},
-		{
-			cmd: `insert into "d b"."test test" cpu,host=serverA,region=us-west value=1.0`,
-			db:  "d b",
-			rp:  "test test",
-		},
-	}
-
-	for _, test := range tests {
-		if err := m.ParseCommand(test.cmd); err != nil {
-			t.Fatalf(`Got error %v for command %q, expected nil.`, err, test.cmd)
-		}
-		if m.Database != test.db {
-			t.Fatalf(`Command "insert into" db parsing failed, expected: %q, actual: %q`, test.db, m.Database)
-		}
-		if m.RetentionPolicy != test.rp {
-			t.Fatalf(`Command "insert into" rp parsing failed, expected: %q, actual: %q`, test.rp, m.RetentionPolicy)
-		}
-	}
-}
-
 func TestParseCommand_History(t *testing.T) {
 	t.Parallel()
 	c := cli.CommandLine{Line: liner.NewLiner()}


### PR DESCRIPTION
## Before:

```sql
> create database foo
> use foo
Using database foo
> insert cpu value=1
> insert into badrp mem value=100
Using retention policy badrp
ERR: {"error":"retention policy not found: badrp"}

> insert cpu value=2
ERR: {"error":"retention policy not found: badrp"}
```

## After:
```
> create database foo
> use foo
Using database foo
> insert cpu value=1
> insert into badrp mem value=100
ERR: {"error":"retention policy not found: badrp"}

> insert cpu value=2
> insert into autogen mem value=100
> select * from cpu
name: cpu
time                value
----                -----
1481123342516456239 1
1481123351091949866 2

> select * from mem
name: mem
time                value
----                -----
1481123368541597661 100
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): https://github.com/influxdata/docs.influxdata.com/pull/914