### PR TITLE
use spaces instead of tabs for CLI column output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7659](https://github.com/influxdata/influxdb/issues/7659): Fix CLI import bug when using self-signed SSL certificates.
 - [#7698](https://github.com/influxdata/influxdb/pull/7698): CLI was caching db/rp for insert into statements.
 
+- [#7396](https://github.com/influxdata/influxdb/issues/7396): CLI should use spaces for alignment, not tabs.
 
 ## v1.1.1 [unreleased]
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -649,7 +649,7 @@ func (c *CommandLine) writeCSV(response *client.Response, w io.Writer) {
 func (c *CommandLine) writeColumns(response *client.Response, w io.Writer) {
 	// Create a tabbed writer for each result as they won't always line up
 	writer := new(tabwriter.Writer)
-	writer.Init(w, 0, 8, 1, '\t', 0)
+	writer.Init(w, 0, 8, 1, ' ', 0)
 
 	for _, result := range response.Results {
 		// Print out all messages first


### PR DESCRIPTION
fixes #7396 

## Before:
```
> select * from cpu
name: cpu
time                    region  value
----                    ------  -----
1481124828339381431             1
1481124835673705008     moscow  0.8877
1481124928405423894     america 0.9923432
```

## After:
```
> select * from cpu
name: cpu
time                region  value
----                ------  -----
1481124828339381431         1
1481124835673705008 moscow  0.8877
1481124928405423894 america 0.9923432
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
