### PR TITLE
fix precision being case sensitive in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7650](https://github.com/influxdata/influxdb/issues/7650): Ensures that all user privileges associated with a database are removed when the database is dropped.
 - [#7659](https://github.com/influxdata/influxdb/issues/7659): Fix CLI import bug when using self-signed SSL certificates.
 - [#7698](https://github.com/influxdata/influxdb/pull/7698): CLI was caching db/rp for insert into statements.
+- [#6527](https://github.com/influxdata/influxdb/issues/6527): 0.12.2 Influx CLI client PRECISION returns "Unknown precision....
 
 
 ## v1.1.1 [unreleased]

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -394,10 +394,11 @@ func (c *CommandLine) use(cmd string) {
 
 // SetPrecision sets client precision
 func (c *CommandLine) SetPrecision(cmd string) {
-	// Remove the "precision" keyword if it exists
-	cmd = strings.TrimSpace(strings.Replace(cmd, "precision", "", -1))
 	// normalize cmd
 	cmd = strings.ToLower(cmd)
+
+	// Remove the "precision" keyword if it exists
+	cmd = strings.TrimSpace(strings.Replace(cmd, "precision", "", -1))
 
 	switch cmd {
 	case "h", "m", "s", "ms", "u", "ns":


### PR DESCRIPTION
fixes #6527 

## Before:

```
> PRECISION s
Unknown precision "precision s". Please use rfc3339, h, m, s, ms, u or ns.
```

## After:
```
> precision s
> PRECISION s
> PRECISION h
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

