### PR TITLE
add the ability for retention policy context in cli with use command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7356](https://github.com/influxdata/influxdb/issues/7356): Use X-Forwarded-For IP address in HTTP logger if present.
 - [#7066](https://github.com/influxdata/influxdb/issues/7066): Add support for secure transmission via collectd.
 - [#7036](https://github.com/influxdata/influxdb/issues/7036): Switch logging to use structured logging everywhere.
+- [#3188](https://github.com/influxdata/influxdb/issues/3188): [CLI feature request] USE retention policy for queries.
 
 ### Bugfixes
 

--- a/cmd/influx/cli/parser.go
+++ b/cmd/influx/cli/parser.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+)
+
+func parseDatabaseAndRetentionPolicy(stmt []byte) (string, string, error) {
+	var db, rp []byte
+	var quoted bool
+	var seperatorCount int
+
+	stmt = bytes.TrimSpace(stmt)
+
+	for _, b := range stmt {
+		if b == '"' {
+			quoted = !quoted
+			continue
+		}
+		if b == '.' && !quoted {
+			seperatorCount++
+			if seperatorCount > 1 {
+				return "", "", fmt.Errorf("unable to parse database and retention policy from %s", string(stmt))
+			}
+			continue
+		}
+		if seperatorCount == 1 {
+			rp = append(rp, b)
+			continue
+		}
+		db = append(db, b)
+	}
+	return string(db), string(rp), nil
+}

--- a/cmd/influx/cli/parser_internal_test.go
+++ b/cmd/influx/cli/parser_internal_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+)
+
+func Test_parseDatabaseAndretentionPolicy(t *testing.T) {
+	tests := []struct {
+		stmt string
+		db   string
+		rp   string
+		err  error
+	}{
+		{
+			stmt: `foo`,
+			db:   "foo",
+		},
+		{
+			stmt: `"foo.bar"`,
+			db:   "foo.bar",
+		},
+		{
+			stmt: `"foo.bar".`,
+			db:   "foo.bar",
+		},
+		{
+			stmt: `."foo.bar"`,
+			rp:   "foo.bar",
+		},
+		{
+			stmt: `foo.bar`,
+			db:   "foo",
+			rp:   "bar",
+		},
+		{
+			stmt: `"foo".bar`,
+			db:   "foo",
+			rp:   "bar",
+		},
+		{
+			stmt: `"foo"."bar"`,
+			db:   "foo",
+			rp:   "bar",
+		},
+		{
+			stmt: `"foo.bin"."bar"`,
+			db:   "foo.bin",
+			rp:   "bar",
+		},
+		{
+			stmt: `"foo.bin"."bar.baz...."`,
+			db:   "foo.bin",
+			rp:   "bar.baz....",
+		},
+		{
+			stmt: `  "foo.bin"."bar.baz...."  `,
+			db:   "foo.bin",
+			rp:   "bar.baz....",
+		},
+
+		{
+			stmt: `"foo.bin"."bar".boom`,
+			err:  errors.New("foo"),
+		},
+		{
+			stmt: "foo.bar.",
+			err:  errors.New("foo"),
+		},
+	}
+
+	for _, test := range tests {
+		db, rp, err := parseDatabaseAndRetentionPolicy([]byte(test.stmt))
+		if err != nil && test.err == nil {
+			t.Errorf("unexpected error: got %s", err)
+			continue
+		}
+		if test.err != nil && err == nil {
+			t.Errorf("expected err: got: nil, exp: %s", test.err)
+			continue
+		}
+		if db != test.db {
+			t.Errorf("unexpected database: got: %s, exp: %s", db, test.db)
+		}
+		if rp != test.rp {
+			t.Errorf("unexpected retention policy: got: %s, exp: %s", rp, test.rp)
+		}
+	}
+
+}


### PR DESCRIPTION
fixes #3188 

## example usage:

```sql
> create database foo
> show retention policies on foo
name    duration shardGroupDuration replicaN default
----    -------- ------------------ -------- -------
autogen 0s       168h0m0s           1        true

> create retention policy bar on foo duration 1h replication 1
> show retention policies on foo
name    duration shardGroupDuration replicaN default
----    -------- ------------------ -------- -------
autogen 0s       168h0m0s           1        true
bar     1h0m0s   1h0m0s             1        false

> use foo
Using database foo
> insert cpu,context=foo value=1
> select * from cpu
name: cpu
time                context value
----                ------- -----
1482248174482948380 foo     1

> use foo.bar
Using database foo
Using retention policy bar
> insert cpu,context=bar value=2
> select * from cpu
name: cpu
time                context value
----                ------- -----
1482248211927258844 bar     2

> settings
Setting           Value
--------          --------
Host              localhost:8086
Username
Database          foo
RetentionPolicy   bar
Pretty            false
Format            column
Write Consistency all

```
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): https://github.com/influxdata/docs.influxdata.com/pull/923

