### PR TITLE
add clear command to cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7356](https://github.com/influxdata/influxdb/issues/7356): Use X-Forwarded-For IP address in HTTP logger if present.
 - [#7066](https://github.com/influxdata/influxdb/issues/7066): Add support for secure transmission via collectd.
 - [#7036](https://github.com/influxdata/influxdb/issues/7036): Switch logging to use structured logging everywhere.
+- [#7709](https://github.com/influxdata/influxdb/pull/7709): Add clear command to cli.
 
 ### Bugfixes
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -258,6 +258,8 @@ func (c *CommandLine) ParseCommand(cmd string) error {
 			c.use(cmd)
 		case "insert":
 			return c.Insert(cmd)
+		case "clear":
+			c.clear(cmd)
 		default:
 			return c.ExecuteQuery(cmd)
 		}
@@ -340,6 +342,34 @@ func (c *CommandLine) SetAuth(cmd string) {
 
 	// Update the client as well
 	c.Client.SetAuth(c.ClientConfig.Username, c.ClientConfig.Password)
+}
+
+func (c *CommandLine) clear(cmd string) {
+	args := strings.Split(strings.TrimSuffix(strings.TrimSpace(cmd), ";"), " ")
+	v := strings.ToLower(strings.Join(args[1:], " "))
+	switch v {
+	case "database", "db":
+		c.Database = ""
+		fmt.Println("database context cleared")
+		return
+	case "retention policy", "rp":
+		c.RetentionPolicy = ""
+		fmt.Println("retention policy context cleared")
+		return
+	default:
+		if len(args) > 1 {
+			fmt.Printf("invalid command %q.\n", v)
+		}
+		fmt.Println(`Possible commands for 'clear' are:
+    # Clear the database context
+    clear database
+    clear db
+
+    # Clear the retention policy context
+    clear retention policy
+    clear rp
+		`)
+	}
 }
 
 func (c *CommandLine) use(cmd string) {
@@ -790,6 +820,7 @@ func (c *CommandLine) help() {
         consistency <level>   sets write consistency level: any, one, quorum, or all
         history               displays command history
         settings              outputs the current settings for the shell
+        clear                 clears settings such as database or retention policy.  run 'clear' for help
         exit/quit/ctrl+d      quits the influx shell
 
         show databases        show database names


### PR DESCRIPTION
This command adds the ability to clear out settings in the cli such as database or retention policy.  It can be expanded to clear other settings if needed in the future.

This become more of an issue once we introduced the ability to set the retention policy context in https://github.com/influxdata/influxdb/pull/7708

## example usage:

```
> clear
Possible commands for 'clear' are:
    # Clear the database context
    clear database
    clear db

    # Clear the retention policy context
    clear retention policy
    clear rp
> use foo
Using database foo
> settings
Host                                                                                                            localhost:8086
Username
Database                                                                                foo
Pretty                                                                                          false
Format                                                                                          column
Write Consistency       all

> clear database
database context cleared
> settings
Host                                                                                                            localhost:8086
Username
Database
Pretty                                                                                          false
Format                                                                                          column
Write Consistency       all
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

###### Required only if applicable
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): https://github.com/influxdata/docs.influxdata.com/pull/923

