### PR TITLE
Bind to random port in service open/close tests

### DIFF
--- a/services/graphite/service_test.go
+++ b/services/graphite/service_test.go
@@ -16,7 +16,9 @@ import (
 )
 
 func Test_Service_OpenClose(t *testing.T) {
-	c := Config{BindAddress: ":35422"}
+	// Let the OS assign a random port since we are only opening and closing the service,
+	// not actually connecting to it.
+	c := Config{BindAddress: "127.0.0.1:0"}
 	service := NewTestService(&c)
 
 	// Closing a closed service is fine.

--- a/services/opentsdb/service_test.go
+++ b/services/opentsdb/service_test.go
@@ -20,7 +20,9 @@ import (
 )
 
 func Test_Service_OpenClose(t *testing.T) {
-	service := NewTestService("db0", "127.0.0.1:45362")
+	// Let the OS assign a random port since we are only opening and closing the service,
+	// not actually connecting to it.
+	service := NewTestService("db0", "127.0.0.1:0")
 
 	// Closing a closed service is fine.
 	if err := service.Service.Close(); err != nil {


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass

These tests have been flaky on Circle in the past due to those specific
ports being in use. Binding to port 0 will pick a random, available
port.