### PR TITLE
Remove the override of GOMAXPROCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7669](https://github.com/influxdata/influxdb/issues/7669): Uncomment section headers from the default configuration file.
 - [#7684](https://github.com/influxdata/influxdb/issues/7684): Update Go version to 1.7.4.
 - [#7036](https://github.com/influxdata/influxdb/issues/7036): Switch logging to use structured logging everywhere.
+- [#7723](https://github.com/influxdata/influxdb/pull/7723): Remove the override of GOMAXPROCS.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -68,9 +68,6 @@ func (cmd *Command) Run(args ...string) error {
 	// Print sweet InfluxDB logo.
 	fmt.Print(logo)
 
-	// Set parallelism.
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// Mark start-up in log.
 	cmd.Logger.Info(fmt.Sprintf("InfluxDB starting, version %s, branch %s, commit %s",
 		cmd.Version, cmd.Branch, cmd.Commit))


### PR DESCRIPTION
This was needed when we were on go 1.4 but hasn't been needed since go
1.5. It was kept because we weren't sure if we were going to have to
rollback to an older version of Go at that time and we kept it so we
wouldn't forget to readd it.

Now that we are on go 1.7 with go 1.4 deprecated, there is no going back
so we might as well remove this so people can set GOMAXPROCS to a custom
value using environment variables.