### PR TITLE
Converting all int types to int64 on bound parameters

### DIFF
--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2539,6 +2539,14 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 		switch v := v.(type) {
 		case float64:
 			return &NumberLiteral{Val: v}, nil
+		case int:
+			return &IntegerLiteral{Val: int64(v)}, nil
+		case int8:
+			return &IntegerLiteral{Val: int64(v)}, nil
+		case int16:
+			return &IntegerLiteral{Val: int64(v)}, nil
+		case int32:
+			return &IntegerLiteral{Val: int64(v)}, nil
 		case int64:
 			return &IntegerLiteral{Val: v}, nil
 		case string:


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

As the IntegerLiteral uses int64 internally we are unable to set
a bound parameter to any other size of integers except 64.
This patch converts any size of integer to 64 when creating an
IntegerLiteral.