### PR TITLE
Reduce lock contention when snapshotting

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -83,7 +83,7 @@ func (e *entry) add(values []Value) error {
 		return nil // Nothing to do.
 	}
 
-	// Are any of the new values out of order or the wrong type?
+	// Are any of the new values the wrong type?
 	for _, v := range values {
 		if e.vtype != valueType(v) {
 			return tsdb.ErrFieldTypeConflict

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -746,12 +746,12 @@ func BenchmarkEntry_add(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			b.StopTimer()
-			values := make([]Value, 100)
+			values := make([]Value, 10)
 			for i := 0; i < 10; i++ {
 				values[i] = NewValue(int64(i+1), float64(i))
 			}
 
-			otherValues := make([]Value, 100)
+			otherValues := make([]Value, 10)
 			for i := 0; i < 10; i++ {
 				otherValues[i] = NewValue(1, float64(i))
 			}

--- a/tsdb/engine/tsm1/encoding.gen.go
+++ b/tsdb/engine/tsm1/encoding.gen.go
@@ -59,6 +59,20 @@ func (a Values) Deduplicate() Values {
 	if len(a) == 0 {
 		return a
 	}
+
+	// See if we're already sorted and deduped
+	var needSort bool
+	for i := 1; i < len(a); i++ {
+		if a[i-1].UnixNano() >= a[i].UnixNano() {
+			needSort = true
+			break
+		}
+	}
+
+	if !needSort {
+		return a
+	}
+
 	sort.Stable(a)
 	var i int
 	for j := 1; j < len(a); j++ {
@@ -115,13 +129,8 @@ func (a Values) Merge(b Values) Values {
 	// Normally, both a and b should not contain duplicates.  Due to a bug in older versions, it's
 	// possible stored blocks might contain duplicate values.  Remove them if they exists before
 	// merging.
-	if !a.ordered() {
-		a = a.Deduplicate()
-	}
-
-	if !b.ordered() {
-		b = b.Deduplicate()
-	}
+	a = a.Deduplicate()
+	b = b.Deduplicate()
 
 	if a[len(a)-1].UnixNano() < b[0].UnixNano() {
 		return append(a, b...)
@@ -232,6 +241,20 @@ func (a FloatValues) Deduplicate() FloatValues {
 	if len(a) == 0 {
 		return a
 	}
+
+	// See if we're already sorted and deduped
+	var needSort bool
+	for i := 1; i < len(a); i++ {
+		if a[i-1].UnixNano() >= a[i].UnixNano() {
+			needSort = true
+			break
+		}
+	}
+
+	if !needSort {
+		return a
+	}
+
 	sort.Stable(a)
 	var i int
 	for j := 1; j < len(a); j++ {
@@ -288,13 +311,8 @@ func (a FloatValues) Merge(b FloatValues) FloatValues {
 	// Normally, both a and b should not contain duplicates.  Due to a bug in older versions, it's
 	// possible stored blocks might contain duplicate values.  Remove them if they exists before
 	// merging.
-	if !a.ordered() {
-		a = a.Deduplicate()
-	}
-
-	if !b.ordered() {
-		b = b.Deduplicate()
-	}
+	a = a.Deduplicate()
+	b = b.Deduplicate()
 
 	if a[len(a)-1].UnixNano() < b[0].UnixNano() {
 		return append(a, b...)
@@ -405,6 +423,20 @@ func (a IntegerValues) Deduplicate() IntegerValues {
 	if len(a) == 0 {
 		return a
 	}
+
+	// See if we're already sorted and deduped
+	var needSort bool
+	for i := 1; i < len(a); i++ {
+		if a[i-1].UnixNano() >= a[i].UnixNano() {
+			needSort = true
+			break
+		}
+	}
+
+	if !needSort {
+		return a
+	}
+
 	sort.Stable(a)
 	var i int
 	for j := 1; j < len(a); j++ {
@@ -461,13 +493,8 @@ func (a IntegerValues) Merge(b IntegerValues) IntegerValues {
 	// Normally, both a and b should not contain duplicates.  Due to a bug in older versions, it's
 	// possible stored blocks might contain duplicate values.  Remove them if they exists before
 	// merging.
-	if !a.ordered() {
-		a = a.Deduplicate()
-	}
-
-	if !b.ordered() {
-		b = b.Deduplicate()
-	}
+	a = a.Deduplicate()
+	b = b.Deduplicate()
 
 	if a[len(a)-1].UnixNano() < b[0].UnixNano() {
 		return append(a, b...)
@@ -578,6 +605,20 @@ func (a StringValues) Deduplicate() StringValues {
 	if len(a) == 0 {
 		return a
 	}
+
+	// See if we're already sorted and deduped
+	var needSort bool
+	for i := 1; i < len(a); i++ {
+		if a[i-1].UnixNano() >= a[i].UnixNano() {
+			needSort = true
+			break
+		}
+	}
+
+	if !needSort {
+		return a
+	}
+
 	sort.Stable(a)
 	var i int
 	for j := 1; j < len(a); j++ {
@@ -634,13 +675,8 @@ func (a StringValues) Merge(b StringValues) StringValues {
 	// Normally, both a and b should not contain duplicates.  Due to a bug in older versions, it's
 	// possible stored blocks might contain duplicate values.  Remove them if they exists before
 	// merging.
-	if !a.ordered() {
-		a = a.Deduplicate()
-	}
-
-	if !b.ordered() {
-		b = b.Deduplicate()
-	}
+	a = a.Deduplicate()
+	b = b.Deduplicate()
 
 	if a[len(a)-1].UnixNano() < b[0].UnixNano() {
 		return append(a, b...)
@@ -751,6 +787,20 @@ func (a BooleanValues) Deduplicate() BooleanValues {
 	if len(a) == 0 {
 		return a
 	}
+
+	// See if we're already sorted and deduped
+	var needSort bool
+	for i := 1; i < len(a); i++ {
+		if a[i-1].UnixNano() >= a[i].UnixNano() {
+			needSort = true
+			break
+		}
+	}
+
+	if !needSort {
+		return a
+	}
+
 	sort.Stable(a)
 	var i int
 	for j := 1; j < len(a); j++ {
@@ -807,13 +857,8 @@ func (a BooleanValues) Merge(b BooleanValues) BooleanValues {
 	// Normally, both a and b should not contain duplicates.  Due to a bug in older versions, it's
 	// possible stored blocks might contain duplicate values.  Remove them if they exists before
 	// merging.
-	if !a.ordered() {
-		a = a.Deduplicate()
-	}
-
-	if !b.ordered() {
-		b = b.Deduplicate()
-	}
+	a = a.Deduplicate()
+	b = b.Deduplicate()
 
 	if a[len(a)-1].UnixNano() < b[0].UnixNano() {
 		return append(a, b...)

--- a/tsdb/engine/tsm1/encoding.gen.go.tmpl
+++ b/tsdb/engine/tsm1/encoding.gen.go.tmpl
@@ -56,6 +56,20 @@ func (a {{.Name}}Values) Deduplicate() {{.Name}}Values {
 	if len(a) == 0 {
 		return a
 	}
+
+	// See if we're already sorted and deduped
+	var needSort bool
+	for i := 1; i < len(a); i++ {
+		if a[i-1].UnixNano() >= a[i].UnixNano() {
+			needSort = true
+			break
+		}
+	}
+
+	if !needSort {
+		return a
+	}
+
 	sort.Stable(a)
 	var i int
 	for j := 1; j < len(a); j++ {
@@ -112,13 +126,8 @@ func (a {{.Name}}Values) Merge(b {{.Name}}Values) {{.Name}}Values {
 	// Normally, both a and b should not contain duplicates.  Due to a bug in older versions, it's
 	// possible stored blocks might contain duplicate values.  Remove them if they exists before
 	// merging.
-	if !a.ordered() {
-		a = a.Deduplicate()
-	}
-
-	if !b.ordered() {
-		b = b.Deduplicate()
-	}
+	a = a.Deduplicate()
+	b = b.Deduplicate()
 
 	if a[len(a)-1].UnixNano() < b[0].UnixNano() {
 		return append(a, b...)

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -305,8 +305,9 @@ func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 	var b []byte
 	err := func() error {
 		for _, v := range values {
-			tsenc.Write(v.UnixNano())
-			venc.Push(v.(FloatValue).value)
+			vv := v.(FloatValue)
+			tsenc.Write(vv.unixnano)
+			venc.Push(vv.value)
 		}
 		venc.Finish()
 
@@ -429,8 +430,9 @@ func encodeBooleanBlock(buf []byte, values []Value) ([]byte, error) {
 	var b []byte
 	err := func() error {
 		for _, v := range values {
-			tsenc.Write(v.UnixNano())
-			venc.Write(v.(BooleanValue).value)
+			vv := v.(BooleanValue)
+			tsenc.Write(vv.unixnano)
+			venc.Write(vv.value)
 		}
 
 		// Encoded timestamp values
@@ -539,8 +541,9 @@ func encodeIntegerBlock(buf []byte, values []Value) ([]byte, error) {
 	var b []byte
 	err := func() error {
 		for _, v := range values {
-			tsEnc.Write(v.UnixNano())
-			vEnc.Write(v.(IntegerValue).value)
+			vv := v.(IntegerValue)
+			tsEnc.Write(vv.unixnano)
+			vEnc.Write(vv.value)
 		}
 
 		// Encoded timestamp values
@@ -649,8 +652,9 @@ func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
 	var b []byte
 	err := func() error {
 		for _, v := range values {
-			tsEnc.Write(v.UnixNano())
-			vEnc.Write(v.(StringValue).value)
+			vv := v.(StringValue)
+			tsEnc.Write(vv.unixnano)
+			vEnc.Write(vv.value)
 		}
 
 		// Encoded timestamp values

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -287,9 +287,11 @@ func (p *partition) reset() {
 	for k, entry := range p.store {
 		// If the capacity is large then there are many values in the entry.
 		// Store a hint to pre-allocate the next time we see the same entry.
+		entry.mu.RLock()
 		if cap(entry.values) > 128 { // 4 x the default entry capacity size.
 			p.entrySizeHints[xxhash.Sum64([]byte(k))] = cap(entry.values)
 		}
+		entry.mu.RUnlock()
 	}
 
 	// Reset the store.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This reduces some lock contention in the write path when snapshots are running.  This doesn't prevent write timeouts from ever occurring, but does seem to reduce their occurrences.

