### PR TITLE
fix scan tag value panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7615](https://github.com/influxdata/influxdb/issues/7615): Reject invalid subscription urls @allenpetersen
 - [#7396](https://github.com/influxdata/influxdb/issues/7396): CLI should use spaces for alignment, not tabs.
 - [#6527](https://github.com/influxdata/influxdb/issues/6527): 0.12.2 Influx CLI client PRECISION returns "Unknown precision....
+- [#7740](https://github.com/influxdata/influxdb/issues/7740): Fix parse key panic when missing tag value @oiooj
 
 ## v1.1.1 [2016-12-06]
 

--- a/models/points.go
+++ b/models/points.go
@@ -1031,6 +1031,9 @@ func scanTagValue(buf []byte, i int) (int, []byte) {
 		}
 		i++
 	}
+	if i > len(buf) {
+		return i, nil
+	}
 	return i, buf[start:i]
 }
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1976,6 +1976,12 @@ func TestParseKeyEmpty(t *testing.T) {
 	}
 }
 
+func TestParseKeyMissingValue(t *testing.T) {
+	if _, _, err := models.ParseKey([]byte("cpu,foo ")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestPoint_FieldIterator_Simple(t *testing.T) {
 
 	p, err := models.ParsePoints([]byte(`m v=42i,f=42 36`))


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

fix #7732 , I can't find a case why influxDB would crash, but indeed there is a crash risk if `i > cap(buf)`

I also reviewed `func parseTags`