### PR TITLE
Clarify collectd directory usage in demo config

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -339,7 +339,11 @@
   # bind-address = ":25826"
   # database = "collectd"
   # retention-policy = ""
-  # typesdb = "/usr/share/collectd/types.db"
+  #
+  # The collectd service supports either scanning a directory for multiple types
+  # db files, or specifying a single db file.
+  # typesdb = "/usr/local/share/collectd"
+  #
   # security-level = "none"
   # auth-file = "/etc/collectd/auth_file"
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

Fixes #7736.

Specify the collectd array notation in the demo config for locating `types.db` files.
