### PR TITLE
Mitigate timing attack to identify valid username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 
 ### Bugfixes
 
+- [#7755](https://github.com/influxdata/influxdb/pull/7755): Mitigate timing attack to identify valid username
 - [#7741](https://github.com/influxdata/influxdb/pull/7741): Fix string quoting and significantly improve performance of `influx_inspect export`.
 - [#7698](https://github.com/influxdata/influxdb/pull/7698): CLI was caching db/rp for insert into statements.
 - [#7659](https://github.com/influxdata/influxdb/issues/7659): Fix CLI import bug when using self-signed SSL certificates.


### PR DESCRIPTION
Refer to https://cwe.mitre.org/data/definitions/208.html for details on
this common weakness.

Prior to this change, a locally running influxd instance would respond
to a query with an invalid username in about 14ms, but would take about
93ms to respond when the username was valid but the password was
incorrect. Now, both valid and invalid usernames take about 93ms.

Likewise, the newly added benchmark for an invalid username now takes
about the same time as the benchmark for a valid username with an
invalid password. Prior to this change, the invalid username benchmark
ran in about 0.004% of the invalid password time.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
