### PR TITLE
Bump jwt-go to 2.7.0

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -4,7 +4,7 @@ github.com/bmizerany/pat c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c
 github.com/boltdb/bolt 4b1ebc1869ad66568b313d0dc410e2be72670dda
 github.com/cespare/xxhash 4a94f899c20bc44d4f5f807cb14529e72aca99d6
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
-github.com/dgrijalva/jwt-go 24c63f56522a87ec5339cc3567883f1039378fdb
+github.com/dgrijalva/jwt-go 268038b363c7a8d7306b8e35bf77a1fde4b0c402
 github.com/dgryski/go-bits 2ad8d707cc05b1815ce6ff2543bb5e8d8f9298ef
 github.com/dgryski/go-bitstream 7d46cd22db7004f0cceb6f7975824b560cf0e486
 github.com/gogo/protobuf a9cd0c35b97daf74d0ebf3514c5254814b2703b4

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -937,21 +937,14 @@ func authenticate(inner func(http.ResponseWriter, *http.Request, *meta.UserInfo)
 					return
 				}
 
-				claims, ok := token.Claims.(jwt.MapClaims)
-				if !ok {
-					h.httpError(w, "problem authenticating token", http.StatusInternalServerError)
-					h.Logger.Info("Could not assert JWT token claims as jwt.MapClaims")
-					return
-				}
-
 				// Make sure an expiration was set on the token.
-				if exp, ok := claims["exp"].(float64); !ok || exp <= 0.0 {
+				if exp, ok := token.Claims["exp"].(float64); !ok || exp <= 0.0 {
 					h.httpError(w, "token expiration required", http.StatusUnauthorized)
 					return
 				}
 
 				// Get the username from the token.
-				username, ok := claims["username"].(string)
+				username, ok := token.Claims["username"].(string)
 				if !ok {
 					h.httpError(w, "username in token must be a string", http.StatusUnauthorized)
 					return

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -194,13 +194,13 @@ func TestHandler_Query_Auth(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("unexpected status: %d: %s", w.Code, w.Body.String())
-	} else if !strings.Contains(w.Body.String(), `{"error":"Token is expired`) {
+	} else if !strings.Contains(w.Body.String(), `{"error":"token is expired`) {
 		t.Fatalf("unexpected body: %s", w.Body.String())
 	}
 
 	// Test handler with JWT token that has no expiration set.
 	token, _ := MustJWTToken("user1", h.Config.SharedSecret, false)
-	delete(token.Claims.(jwt.MapClaims), "exp")
+	delete(token.Claims, "exp")
 	signedToken, err := token.SignedString([]byte(h.Config.SharedSecret))
 	if err != nil {
 		t.Fatal(err)
@@ -725,11 +725,11 @@ func NewResultChan(results ...*influxql.Result) <-chan *influxql.Result {
 // MustJWTToken returns a new JWT token and signed string or panics trying.
 func MustJWTToken(username, secret string, expired bool) (*jwt.Token, string) {
 	token := jwt.New(jwt.GetSigningMethod("HS512"))
-	token.Claims.(jwt.MapClaims)["username"] = username
+	token.Claims["username"] = username
 	if expired {
-		token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(-time.Second).Unix()
+		token.Claims["exp"] = time.Now().Add(-time.Second).Unix()
 	} else {
-		token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Minute * 10).Unix()
+		token.Claims["exp"] = time.Now().Add(time.Minute * 10).Unix()
 	}
 	signed, err := token.SignedString([]byte(secret))
 	if err != nil {


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This patch was written by @guillemj for Debian. (thanks to him!) I have modified it to also fix tests.

We had to write the patch because we don't have an older version of jwt-go in Debian.