### PR TITLE
Require fields when marshalling Point

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -1406,6 +1406,10 @@ func (p *point) StringSize() int {
 }
 
 func (p *point) MarshalBinary() ([]byte, error) {
+	if len(p.fields) == 0 {
+		return nil, ErrPointMustHaveAField
+	}
+
 	tb, err := p.time.MarshalBinary()
 	if err != nil {
 		return nil, err

--- a/models/points_internal_test.go
+++ b/models/points_internal_test.go
@@ -1,0 +1,17 @@
+package models
+
+import "testing"
+
+func TestMarshalPointNoFields(t *testing.T) {
+	points, err := ParsePointsString("m,k=v f=0i")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// It's unclear how this can ever happen, but we've observed points that were marshalled without any fields.
+	points[0].(*point).fields = []byte{}
+
+	if _, err := points[0].MarshalBinary(); err != ErrPointMustHaveAField {
+		t.Fatalf("got error %v, exp %v", err, ErrPointMustHaveAField)
+	}
+}


### PR DESCRIPTION
I haven't been able to reproduce creating a point without any fields,
but we've seen points in the wild that have been marshalled with no
fields - that is, the length header for fields is uint32(0) and a
well-formed encoded time follows.

Attempting to unmarshal points via NewPointFromBytes returns
ErrPointMustHaveAField, so it seems better to fail earlier with the same
error, rather than allowing those points to be serialized in the first
place.

- [x] Rebased/mergable
- [x] Tests pass
