### PR TITLE
Removed ineffective assignments, and added checks for errors that pre…

### DIFF
--- a/cmd/influx_inspect/dumptsm/dumptsm.go
+++ b/cmd/influx_inspect/dumptsm/dumptsm.go
@@ -113,12 +113,9 @@ func (cmd *Command) dump() error {
 				pos++
 				split := strings.Split(string(key), "#!~#")
 
-				// We dont' know know if we have fields so use an informative default
-				var measurement, field string = "UNKNOWN", "UNKNOWN"
-
 				// Possible corruption? Try to read as much as we can and point to the problem.
-				measurement = split[0]
-				field = split[1]
+				measurement := split[0]
+				field := split[1]
 
 				if cmd.filterKey != "" && !strings.Contains(string(key), cmd.filterKey) {
 					continue

--- a/cmd/influx_tsm/tsdb/database.go
+++ b/cmd/influx_tsm/tsdb/database.go
@@ -172,6 +172,10 @@ func (d *Database) Shards() ([]*ShardInfo, error) {
 
 		// Process each shard
 		shards, err := rpfd.Readdirnames(-1)
+		if err != nil {
+			return nil, err
+		}
+
 		for _, sh := range shards {
 			fmt, sz, err := shardFormat(filepath.Join(d.path, rp, sh))
 			if err != nil {

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -158,7 +158,8 @@ func (cmd *Command) unpackMeta() error {
 
 	// Size of the node.json bytes
 	i += 8
-	nodeBytes := b[i:]
+	length = int(binary.BigEndian.Uint64(b[i : i+8]))
+	nodeBytes := b[i : i+length]
 
 	// Unpack into metadata.
 	var data meta.Data

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -157,7 +157,6 @@ func (cmd *Command) unpackMeta() error {
 	i += int(length)
 
 	// Size of the node.json bytes
-	length = int(binary.BigEndian.Uint64(b[i : i+8]))
 	i += 8
 	nodeBytes := b[i:]
 

--- a/coordinator/statement_executor_test.go
+++ b/coordinator/statement_executor_test.go
@@ -198,7 +198,7 @@ func NewQueryExecutor() *QueryExecutor {
 
 	var out io.Writer = &e.LogOutput
 	if testing.Verbose() {
-		out = io.MultiWriter(out, os.Stderr)
+		io.MultiWriter(out, os.Stderr)
 	}
 	e.QueryExecutor.WithLogger(zap.New(
 		zap.NewTextEncoder(),

--- a/coordinator/statement_executor_test.go
+++ b/coordinator/statement_executor_test.go
@@ -198,11 +198,11 @@ func NewQueryExecutor() *QueryExecutor {
 
 	var out io.Writer = &e.LogOutput
 	if testing.Verbose() {
-		io.MultiWriter(out, os.Stderr)
+		out = io.MultiWriter(out, os.Stderr)
 	}
 	e.QueryExecutor.WithLogger(zap.New(
 		zap.NewTextEncoder(),
-		zap.Output(os.Stderr),
+		zap.Output(zap.AddSync(out)),
 	))
 
 	return e

--- a/influxql/functions.go
+++ b/influxql/functions.go
@@ -657,7 +657,6 @@ func (r *FloatHoltWintersReducer) forecast(h int, params []float64) []float64 {
 
 	lT := params[4]
 	bT := params[5]
-	sT := 0.0
 
 	// seasonals is a ring buffer of past sT values
 	var seasonals []float64
@@ -683,6 +682,7 @@ func (r *FloatHoltWintersReducer) forecast(h int, params []float64) []float64 {
 			stm = seasonals[(t-m+so)%m]
 			stmh = seasonals[(t-m+hm+so)%m]
 		}
+		var sT float64
 		yT, lT, bT, sT = r.next(
 			params[0], // alpha
 			params[1], // beta

--- a/influxql/query_executor_test.go
+++ b/influxql/query_executor_test.go
@@ -143,7 +143,7 @@ func TestQueryExecutor_Abort(t *testing.T) {
 }
 
 func TestQueryExecutor_ShowQueries(t *testing.T) {
-	q, err := influxql.ParseQuery(`SELECT count(value) FROM cpu`)
+	_, err := influxql.ParseQuery(`SELECT count(value) FROM cpu`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestQueryExecutor_ShowQueries(t *testing.T) {
 		},
 	}
 
-	q, err = influxql.ParseQuery(`SHOW QUERIES`)
+	q, err := influxql.ParseQuery(`SHOW QUERIES`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/influxql/query_executor_test.go
+++ b/influxql/query_executor_test.go
@@ -143,11 +143,6 @@ func TestQueryExecutor_Abort(t *testing.T) {
 }
 
 func TestQueryExecutor_ShowQueries(t *testing.T) {
-	_, err := influxql.ParseQuery(`SELECT count(value) FROM cpu`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	e := NewQueryExecutor()
 	e.StatementExecutor = &StatementExecutor{
 		ExecuteStatementFn: func(stmt influxql.Statement, ctx influxql.ExecutionContext) error {

--- a/node.go
+++ b/node.go
@@ -95,7 +95,12 @@ func upgradeNodeFile(path string) error {
 		}
 		return err
 	}
+
 	err = json.Unmarshal(pb, &peers)
+	if err != nil {
+		return err
+	}
+
 	if len(peers) > 1 {
 		return fmt.Errorf("to upgrade a cluster, please contact support at influxdata")
 	}

--- a/services/graphite/parser_test.go
+++ b/services/graphite/parser_test.go
@@ -679,6 +679,9 @@ func TestApplyTemplateField(t *testing.T) {
 	}
 
 	measurement, _, field, err := p.ApplyTemplate("current.users.logged_in")
+	if err != nil {
+		t.Fatalf(err)
+	}
 
 	if measurement != "current_users" {
 		t.Errorf("Parser.ApplyTemplate unexpected result. got %s, exp %s",

--- a/services/graphite/parser_test.go
+++ b/services/graphite/parser_test.go
@@ -680,7 +680,7 @@ func TestApplyTemplateField(t *testing.T) {
 
 	measurement, _, field, err := p.ApplyTemplate("current.users.logged_in")
 	if err != nil {
-		t.Fatalf(err)
+		t.Fatal(err)
 	}
 
 	if measurement != "current_users" {

--- a/services/snapshotter/client.go
+++ b/services/snapshotter/client.go
@@ -44,7 +44,6 @@ func (c *Client) MetastoreBackup() (*meta.Data, error) {
 	length := int(binary.BigEndian.Uint64(b[i : i+8]))
 	i += 8
 	metaBytes := b[i : i+length]
-	i += int(length)
 
 	// Unpack meta data.
 	var data meta.Data

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -23,7 +23,6 @@ func NewHTTP(addr string, timeout time.Duration) (*HTTP, error) {
 // NewHTTPS returns a new HTTPS points writer with default options and HTTPS configured
 func NewHTTPS(addr string, timeout time.Duration, unsafeSsl bool, caCerts string) (*HTTP, error) {
 	tlsConfig, err := createTlsConfig(caCerts)
-
 	if err != nil {
 		return nil, err
 	}

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -24,6 +24,10 @@ func NewHTTP(addr string, timeout time.Duration) (*HTTP, error) {
 func NewHTTPS(addr string, timeout time.Duration, unsafeSsl bool, caCerts string) (*HTTP, error) {
 	tlsConfig, err := createTlsConfig(caCerts)
 
+	if err != nil {
+		return nil, err
+	}
+
 	conf := client.HTTPConfig{
 		Addr:               addr,
 		Timeout:            timeout,

--- a/stress/v2/stressql/statement/parser.go
+++ b/stress/v2/stressql/statement/parser.go
@@ -608,13 +608,13 @@ func (p *Parser) ParseFunction() (*statement.Function, error) {
 
 	fn := &statement.Function{}
 
-	tok, lit := p.scanIgnoreWhitespace()
+	_, lit := p.scanIgnoreWhitespace()
 	fn.Type = lit
 
-	tok, lit = p.scanIgnoreWhitespace()
+	_, lit = p.scanIgnoreWhitespace()
 	fn.Fn = lit
 
-	tok, lit = p.scanIgnoreWhitespace()
+	tok, lit := p.scanIgnoreWhitespace()
 	if tok != LPAREN {
 		return nil, fmt.Errorf("Error parsing Insert template function\n  Expected: LPAREN\n  Found: %v\n", lit)
 	}

--- a/tsdb/engine/tsm1/bit_reader_test.go
+++ b/tsdb/engine/tsm1/bit_reader_test.go
@@ -17,6 +17,9 @@ func TestBitStreamEOF(t *testing.T) {
 	br := tsm1.NewBitReader([]byte("0"))
 
 	b, err := br.ReadBits(8)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if b != '0' {
 		t.Error("ReadBits(8) didn't return first byte")
 	}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -845,6 +845,10 @@ func ParseTSMFileName(name string) (int, int, error) {
 	}
 
 	generation, err := strconv.ParseUint(id[:idx], 10, 32)
+	if err != nil {
+		return 0, 0, err
+	}
+
 	sequence, err := strconv.ParseUint(id[idx+1:], 10, 32)
 
 	return int(generation), int(sequence), err

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -846,12 +846,15 @@ func ParseTSMFileName(name string) (int, int, error) {
 
 	generation, err := strconv.ParseUint(id[:idx], 10, 32)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, fmt.Errorf("file %s is named incorrectly", name)
 	}
 
 	sequence, err := strconv.ParseUint(id[idx+1:], 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("file %s is named incorrectly", name)
+	}
 
-	return int(generation), int(sequence), err
+	return int(generation), int(sequence), nil
 }
 
 type KeyCursor struct {

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -153,6 +153,10 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 
 	c.Next()
 	values, err = c.ReadFloatBlock(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -533,6 +537,10 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 
 	c.Next()
 	values, err = c.ReadFloatBlock(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -608,6 +616,10 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 
 	c.Next()
 	values, err = c.ReadIntegerBlock(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -683,6 +695,10 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 
 	c.Next()
 	values, err = c.ReadBooleanBlock(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -758,6 +774,10 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 
 	c.Next()
 	values, err = c.ReadStringBlock(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	exp = nil
 	if got, exp := len(values), len(exp); got != exp {
 		t.Fatalf("value length mismatch: got %v, exp %v", got, exp)
@@ -2070,11 +2090,18 @@ func TestFileStore_Replace(t *testing.T) {
 	cur.Next()
 	buf := make([]tsm1.FloatValue, 10)
 	values, err := cur.ReadFloatBlock(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got, exp := len(values), 1; got != exp {
 		t.Fatalf("value len mismatch: got %v, exp %v", got, exp)
 	}
+
 	cur.Next()
 	values, err = cur.ReadFloatBlock(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got, exp := len(values), 1; got != exp {
 		t.Fatalf("value len mismatch: got %v, exp %v", got, exp)
 	}
@@ -2082,6 +2109,9 @@ func TestFileStore_Replace(t *testing.T) {
 	// No more blocks for this cursor
 	cur.Next()
 	values, err = cur.ReadFloatBlock(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got, exp := len(values), 0; got != exp {
 		t.Fatalf("value len mismatch: got %v, exp %v", got, exp)
 	}

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -763,6 +763,9 @@ func TestIndirectIndex_Type(t *testing.T) {
 	index.Add("cpu", tsm1.BlockInteger, 0, 1, 10, 20)
 
 	b, err := index.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ind := tsm1.NewIndirectIndex()
 	if err := ind.UnmarshalBinary(b); err != nil {

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -173,12 +173,12 @@ func TestTombstoner_ReadV1(t *testing.T) {
 
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
-	entries, err := ts.ReadAll()
+	_, err := ts.ReadAll()
 	if err != nil {
 		fatal(t, "ReadAll", err)
 	}
 
-	entries, err = ts.ReadAll()
+	entries, err := ts.ReadAll()
 	if err != nil {
 		fatal(t, "ReadAll", err)
 	}
@@ -220,12 +220,12 @@ func TestTombstoner_ReadEmptyV1(t *testing.T) {
 
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
-	entries, err := ts.ReadAll()
+	_, err := ts.ReadAll()
 	if err != nil {
 		fatal(t, "ReadAll", err)
 	}
 
-	entries, err = ts.ReadAll()
+	entries, err := ts.ReadAll()
 	if err != nil {
 		fatal(t, "ReadAll", err)
 	}


### PR DESCRIPTION
This repository had a lot of ineffective assignments and unchecked error. I added err checks and changed so that there no longer are any ineffective assignments.

```bash
gustav@Kentauren ~/g/s/g/i/influxdb (master)> ineffassign .                                                                                                                        ✔
/Users/gustav/go/src/github.com/influxdata/influxdb/cmd/influx_inspect/dumptsm/dumptsm.go:117:9: ineffectual assignment to measurement
/Users/gustav/go/src/github.com/influxdata/influxdb/cmd/influx_inspect/dumptsm/dumptsm.go:117:22: ineffectual assignment to field
/Users/gustav/go/src/github.com/influxdata/influxdb/cmd/influx_tsm/tsdb/database.go:174:11: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/cmd/influxd/restore/restore.go:160:2: ineffectual assignment to length
/Users/gustav/go/src/github.com/influxdata/influxdb/coordinator/statement_executor_test.go:201:3: ineffectual assignment to out
/Users/gustav/go/src/github.com/influxdata/influxdb/influxql/functions.go:660:2: ineffectual assignment to sT
/Users/gustav/go/src/github.com/influxdata/influxdb/influxql/query_executor_test.go:146:2: ineffectual assignment to q
/Users/gustav/go/src/github.com/influxdata/influxdb/node.go:98:2: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/services/graphite/parser_test.go:681:25: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/services/snapshotter/client.go:47:2: ineffectual assignment to i
/Users/gustav/go/src/github.com/influxdata/influxdb/services/subscriber/http.go:25:13: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/stress/v2/stressql/statement/parser.go:611:2: ineffectual assignment to tok
/Users/gustav/go/src/github.com/influxdata/influxdb/stress/v2/stressql/statement/parser.go:614:2: ineffectual assignment to tok
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/bit_reader_test.go:19:5: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store.go:847:14: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store_test.go:155:10: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store_test.go:535:10: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store_test.go:610:10: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store_test.go:685:10: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store_test.go:760:10: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store_test.go:2072:10: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store_test.go:2077:10: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/file_store_test.go:2084:10: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/reader_test.go:765:5: ineffectual assignment to err
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/tombstone_test.go:176:2: ineffectual assignment to entries
/Users/gustav/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/tombstone_test.go:223:2: ineffectual assignment to entries
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)



