### PR TITLE
Fix broken return statements swallowing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 
 ### Bugfixes
 
+- [#7784](https://github.com/influxdata/influxdb/pull/7784): Fix broken error return on meta client's UpdateUser and DropContinuousQuery methods.
 - [#7741](https://github.com/influxdata/influxdb/pull/7741): Fix string quoting and significantly improve performance of `influx_inspect export`.
 - [#7698](https://github.com/influxdata/influxdb/pull/7698): CLI was caching db/rp for insert into statements.
 - [#7659](https://github.com/influxdata/influxdb/issues/7659): Fix CLI import bug when using self-signed SSL certificates.

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -436,7 +436,7 @@ func (c *Client) UpdateUser(name, password string) error {
 	}
 
 	if err := data.UpdateUser(name, string(hash)); err != nil {
-		return nil
+		return err
 	}
 
 	delete(c.authCache, name)
@@ -853,7 +853,7 @@ func (c *Client) DropContinuousQuery(database, name string) error {
 	data := c.cacheData.Clone()
 
 	if err := data.DropContinuousQuery(database, name); err != nil {
-		return nil
+		return err
 	}
 
 	if err := c.commit(data); err != nil {

--- a/services/meta/client_test.go
+++ b/services/meta/client_test.go
@@ -680,6 +680,19 @@ func TestMetaClient_CreateUser(t *testing.T) {
 	}
 }
 
+func TestMetaClient_UpdateUser(t *testing.T) {
+	t.Parallel()
+
+	d, c := newClient()
+	defer os.RemoveAll(d)
+	defer c.Close()
+
+	// UpdateUser that doesn't exist should return an error.
+	if err := c.UpdateUser("foo", "bar"); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
 func TestMetaClient_ContinuousQueries(t *testing.T) {
 	t.Parallel()
 
@@ -728,6 +741,11 @@ func TestMetaClient_ContinuousQueries(t *testing.T) {
 	// Drop a single CQ
 	if err := c.DropContinuousQuery("db0", "cq1"); err != nil {
 		t.Fatal(err)
+	}
+
+	// Dropping a nonexistent CQ should return an error.
+	if err := c.DropContinuousQuery("db0", "not-a-cq"); err == nil {
+		t.Fatal("expected an error, got nil")
 	}
 }
 


### PR DESCRIPTION
There was no comment on either case specifying that the `return nil`
was deliberate instead of `return err`, so I'm assuming these were
typos. I added tests to conserve the error-returning behavior.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
