### PR TITLE
Added option to follow redirects and use last URL in redirect path.

### DIFF
--- a/client/v2/udp.go
+++ b/client/v2/udp.go
@@ -110,3 +110,8 @@ func (uc *udpclient) Query(q Query) (*Response, error) {
 func (uc *udpclient) Ping(timeout time.Duration) (time.Duration, string, error) {
 	return 0, "", nil
 }
+
+// This is a noop function which should never be called.
+func (uc *udpclient) CheckHTTPRedirect() (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
This is code to address https://github.com/influxdata/telegraf/issues/2191
For redirects and puts/posts they are not followed. This PR creates an option 'InsecureFollowRedirect' which is triggered will have an initial GET done and the redirect will be followed and the URL for the last redirect will be placed in the connection.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
