### PR TITLE
Fix race in (*tsm1.Cache).values

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -554,14 +554,18 @@ func (c *Cache) SetMaxSize(size uint64) {
 	c.mu.Unlock()
 }
 
-// values returns the values for the key. It doesn't lock and assumes the data is
-// already sorted. Should only be used in compact.go in the CacheKeyIterator
+// values returns the values for the key. It assumes the data is already sorted.
+// It doesn't lock the cache but it does read-lock the entry if there is one for the key.
+// values should only be used in compact.go in the CacheKeyIterator.
 func (c *Cache) values(key string) Values {
 	e, _ := c.store.entry(key)
 	if e == nil {
 		return nil
 	}
-	return e.values
+	e.mu.RLock()
+	v := e.values
+	e.mu.RUnlock()
+	return v
 }
 
 // ApplyEntryFn applies the function f to each entry in the Cache.


### PR DESCRIPTION
Without this read lock, this race would happen during a concurrent
snapshot compaction and query.

The race was observed in [this build](https://circleci.com/gh/influxdata/influxdb/14150?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) and was easy to reproduce locally with `GOMAXPROCS=1 go test -race -run=TestServer_BackupAndRestore ./cmd/influxd/run`.

- [x] Rebased/mergable
- [x] Tests pass
