### PR TITLE
Fix #7812 - Panic when pruning shard groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7740](https://github.com/influxdata/influxdb/issues/7740): Fix parse key panic when missing tag value @oiooj
 - [#7563](https://github.com/influxdata/influxdb/issues/7563): RP should not allow `INF` or `0` as a shard duration.
 - [#7585](https://github.com/influxdata/influxdb/pull/7585): Return Error instead of panic when decoding point values.
+- [#7812](https://github.com/influxdata/influxdb/issues/7812): Fix slice out of bounds panic when pruning shard groups
 
 ## v1.1.1 [2016-12-06]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7740](https://github.com/influxdata/influxdb/issues/7740): Fix parse key panic when missing tag value @oiooj
 - [#7563](https://github.com/influxdata/influxdb/issues/7563): RP should not allow `INF` or `0` as a shard duration.
 - [#7585](https://github.com/influxdata/influxdb/pull/7585): Return Error instead of panic when decoding point values.
-- [#7812](https://github.com/influxdata/influxdb/issues/7812): Fix slice out of bounds panic when pruning shard groups
+- [#7812](https://github.com/influxdata/influxdb/issues/7812): Fix slice out of bounds panic when pruning shard groups. Thanks @vladlopes
 
 ## v1.1.1 [2016-12-06]
 

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -676,15 +676,15 @@ func (c *Client) PruneShardGroups() error {
 	data := c.cacheData.Clone()
 	for i, d := range data.Databases {
 		for j, rp := range d.RetentionPolicies {
+			var remainingShardGroups []ShardGroupInfo
 			for _, sgi := range rp.ShardGroups {
 				if sgi.DeletedAt.IsZero() || !expiration.After(sgi.DeletedAt) {
+					remainingShardGroups = append(remainingShardGroups, sgi)
 					continue
 				}
-				// we are safe to delete the shard group as it's been marked deleted for the required expiration
-				s := append(rp.ShardGroups[:i], rp.ShardGroups[i+1:]...)
-				data.Databases[i].RetentionPolicies[j].ShardGroups = s
 				changed = true
 			}
+			data.Databases[i].RetentionPolicies[j].ShardGroups = remainingShardGroups
 		}
 	}
 	if changed {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [X] Tests pass
- [X] CHANGELOG.md updated

This PR fixes #7812 using this filtering trick from the [Go](https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating).

I changed the test to trigger the behavior described in the issue asserting that this change fix it.

The only problem with this solution is that we will be changing the retention policy shard groups slice every time this function is called, different from the previous one which only changed when deleting (we had performance, but no correctness).