### PR TITLE
fix marshaling of zero time

### DIFF
--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1248,8 +1248,16 @@ func (sgi *ShardGroupInfo) marshal() *internal.ShardGroupInfo {
 // unmarshal deserializes from a protobuf representation.
 func (sgi *ShardGroupInfo) unmarshal(pb *internal.ShardGroupInfo) {
 	sgi.ID = pb.GetID()
-	sgi.StartTime = UnmarshalTime(pb.GetStartTime())
-	sgi.EndTime = UnmarshalTime(pb.GetEndTime())
+	if i := pb.GetStartTime(); i == 0 {
+		sgi.StartTime = time.Unix(0, 0).UTC()
+	} else {
+		sgi.StartTime = UnmarshalTime(i)
+	}
+	if i := pb.GetEndTime(); i == 0 {
+		sgi.EndTime = time.Unix(0, 0).UTC()
+	} else {
+		sgi.EndTime = UnmarshalTime(i)
+	}
 	sgi.DeletedAt = UnmarshalTime(pb.GetDeletedAt())
 
 	if pb != nil && pb.TruncatedAt != nil {

--- a/services/meta/data_internal_test.go
+++ b/services/meta/data_internal_test.go
@@ -54,3 +54,36 @@ func TestShardGroupSort(t *testing.T) {
 		t.Fatal("unstable sort for ShardGroupInfos")
 	}
 }
+
+func Test_Data_RetentionPolicy_MarshalBinary(t *testing.T) {
+	zeroTime := time.Time{}
+	epoch := time.Unix(0, 0).UTC()
+
+	startTime := zeroTime
+	sgi := &ShardGroupInfo{
+		StartTime: startTime,
+	}
+	isgi := sgi.marshal()
+	sgi.unmarshal(isgi)
+	if got, exp := sgi.StartTime.UTC(), epoch.UTC(); got != exp {
+		t.Errorf("unexpected start time.  got: %s, exp: %s", got, exp)
+	}
+
+	startTime = time.Unix(0, 0)
+	endTime := startTime.Add(time.Hour * 24)
+	sgi = &ShardGroupInfo{
+		StartTime: startTime,
+		EndTime:   endTime,
+	}
+	isgi = sgi.marshal()
+	sgi.unmarshal(isgi)
+	if got, exp := sgi.StartTime.UTC(), startTime.UTC(); got != exp {
+		t.Errorf("unexpected start time.  got: %s, exp: %s", got, exp)
+	}
+	if got, exp := sgi.EndTime.UTC(), endTime.UTC(); got != exp {
+		t.Errorf("unexpected end time.  got: %s, exp: %s", got, exp)
+	}
+	if got, exp := sgi.DeletedAt.UTC(), zeroTime.UTC(); got != exp {
+		t.Errorf("unexpected DeletedAt time.  got: %s, exp: %s", got, exp)
+	}
+}


### PR DESCRIPTION
There is a very rare edge case that this will introduce.  If TruncatedAt or DeletedAt happens at epoch, when it's marshaled, it will get reset to zero time again.  The bigger fix would be to make all zero time defaults actually be epoch, but that would introduce yet another edge case likely.

This is what I came up with so far.  Let's discuss.

//cc @jwilder @joelegasse 

fixes #7689 

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
