### PR TITLE
Cache snapshotting performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7323](https://github.com/influxdata/influxdb/pull/7323): Allow add items to array config via ENV
 - [#4619](https://github.com/influxdata/influxdb/issues/4619): Support subquery execution in the query language.
 - [#7326](https://github.com/influxdata/influxdb/issues/7326): Verbose output for SSL connection errors.
+- [#7830](https://github.com/influxdata/influxdb/pull/7830): Cache snapshotting performance improvements
 
 ### Bugfixes
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -183,7 +183,8 @@ type Cache struct {
 	// Due to a bug in atomic  size needs to be the first word in the struct, as
 	// that's the only place where you're guaranteed to be 64-bit aligned on a
 	// 32 bit system. See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
-	size uint64
+	size         uint64
+	snapshotSize uint64
 
 	mu      sync.RWMutex
 	store   storer
@@ -193,7 +194,6 @@ type Cache struct {
 	// they're kept in memory while flushing so they can be queried along with the cache.
 	// they are read only and should never be modified
 	snapshot     *Cache
-	snapshotSize uint64
 	snapshotting bool
 
 	// This number is the number of pending or failed WriteSnaphot attempts since the last successful one.

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -364,9 +364,9 @@ func (c *Cache) Snapshot() (*Cache, error) {
 	snapshotSize := c.Size()
 
 	// Save the size of the snapshot on the snapshot cache
-	c.snapshot.size = snapshotSize
+	atomic.StoreUint64(&c.snapshot.size, snapshotSize)
 	// Save the size of the snapshot on the live cache
-	c.snapshotSize = snapshotSize
+	atomic.StoreUint64(&c.snapshotSize, snapshotSize)
 
 	// Reset the cache's store.
 	c.store.reset()

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -425,7 +425,7 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 		t.Fatalf("cache keys incorrect after writes, exp %v, got %v", exp, keys)
 	}
 	if err := c.Write("bar", Values{v1}); err == nil || !strings.Contains(err.Error(), "cache-max-memory-size") {
-		t.Fatalf("wrong error writing key bar to cache")
+		t.Fatalf("wrong error writing key bar to cache: %v", err)
 	}
 
 	// Grab snapshot, write should still fail since we're still using the memory.
@@ -434,7 +434,7 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 		t.Fatalf("failed to snapshot cache: %v", err)
 	}
 	if err := c.Write("bar", Values{v1}); err == nil || !strings.Contains(err.Error(), "cache-max-memory-size") {
-		t.Fatalf("wrong error writing key bar to cache")
+		t.Fatalf("wrong error writing key bar to cache: %v", err)
 	}
 
 	// Clear the snapshot and the write should now succeed.

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -17,8 +17,10 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/influxdata/influxdb/tsdb"
@@ -1282,12 +1284,17 @@ func (k *tsmKeyIterator) Close() error {
 type cacheKeyIterator struct {
 	cache *Cache
 	size  int
+	order []string
 
+	i      int
+	blocks [][]cacheBlock
+	ready  []chan struct{}
+}
+
+type cacheBlock struct {
 	k                string
-	order            []string
-	values           []Value
-	block            []byte
-	minTime, maxTime time.Time
+	minTime, maxTime int64
+	b                []byte
 	err              error
 }
 
@@ -1295,40 +1302,102 @@ type cacheKeyIterator struct {
 func NewCacheKeyIterator(cache *Cache, size int) KeyIterator {
 	keys := cache.Keys()
 
-	return &cacheKeyIterator{
-		size:  size,
-		cache: cache,
-		order: keys,
+	chans := make([]chan struct{}, len(keys))
+	for i := 0; i < len(keys); i++ {
+		chans[i] = make(chan struct{}, 1)
+	}
+
+	cki := &cacheKeyIterator{
+		i:      -1,
+		size:   size,
+		cache:  cache,
+		order:  keys,
+		ready:  chans,
+		blocks: make([][]cacheBlock, len(keys)),
+	}
+	go cki.encode()
+	return cki
+}
+
+func (c *cacheKeyIterator) encode() {
+	concurrency := runtime.NumCPU()
+	n := len(c.ready)
+
+	// Divide the keyset across each CPU
+	chunkSize := 128
+	idx := uint64(0)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		// Run one goroutine per CPU and encode a section of the key space concurrently
+		go func() {
+			for {
+				start := int(atomic.AddUint64(&idx, uint64(chunkSize))) - chunkSize
+				if start >= n {
+					break
+				}
+				end := start + chunkSize
+				if end > n {
+					end = n
+				}
+				c.encodeRange(start, end)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func (c *cacheKeyIterator) encodeRange(start, stop int) {
+	for i := start; i < stop; i++ {
+		key := c.order[i]
+		values := c.cache.values(key)
+
+		for len(values) > 0 {
+			minTime, maxTime := values[0].UnixNano(), values[len(values)-1].UnixNano()
+			var b []byte
+			var err error
+			if len(values) > c.size {
+				maxTime = values[c.size-1].UnixNano()
+				b, err = Values(values[:c.size]).Encode(nil)
+				values = values[c.size:]
+			} else {
+				b, err = Values(values).Encode(nil)
+				values = values[:0]
+			}
+			c.blocks[i] = append(c.blocks[i], cacheBlock{
+				k:       key,
+				minTime: minTime,
+				maxTime: maxTime,
+				b:       b,
+				err:     err,
+			})
+		}
+		// Notify this key is full encoded
+		c.ready[i] <- struct{}{}
 	}
 }
 
 func (c *cacheKeyIterator) Next() bool {
-	if len(c.values) > c.size {
-		c.values = c.values[c.size:]
-		return true
+	if c.i >= 0 && c.i < len(c.ready) && len(c.blocks[c.i]) > 0 {
+		c.blocks[c.i] = c.blocks[c.i][1:]
+		if len(c.blocks[c.i]) > 0 {
+			return true
+		}
 	}
+	c.i++
 
-	if len(c.order) == 0 {
+	if c.i >= len(c.order) {
 		return false
 	}
-	c.k = c.order[0]
-	c.order = c.order[1:]
-	c.values = c.cache.values(c.k)
-	return len(c.values) > 0
+
+	<-c.ready[c.i]
+	return true
 }
 
 func (c *cacheKeyIterator) Read() (string, int64, int64, []byte, error) {
-	minTime, maxTime := c.values[0].UnixNano(), c.values[len(c.values)-1].UnixNano()
-	var b []byte
-	var err error
-	if len(c.values) > c.size {
-		maxTime = c.values[c.size-1].UnixNano()
-		b, err = Values(c.values[:c.size]).Encode(nil)
-	} else {
-		b, err = Values(c.values).Encode(nil)
-	}
-
-	return c.k, minTime, maxTime, b, err
+	blk := c.blocks[c.i][0]
+	return blk.k, blk.minTime, blk.maxTime, blk.b, blk.err
 }
 
 func (c *cacheKeyIterator) Close() error {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -949,7 +949,7 @@ func (e *Engine) writeSnapshotAndCommit(closedFiles []string, snapshot *Cache) (
 
 // compactCache continually checks if the WAL cache should be written to disk.
 func (e *Engine) compactCache(quit <-chan struct{}) {
-	t := time.NewTimer(time.Second)
+	t := time.NewTicker(time.Second)
 	defer t.Stop()
 	for {
 		select {
@@ -971,7 +971,6 @@ func (e *Engine) compactCache(quit <-chan struct{}) {
 				atomic.AddInt64(&e.stats.CacheCompactionDuration, time.Since(start).Nanoseconds())
 			}
 		}
-		t.Reset(time.Second)
 	}
 }
 
@@ -989,7 +988,7 @@ func (e *Engine) ShouldCompactCache(lastWriteTime time.Time) bool {
 }
 
 func (e *Engine) compactTSMLevel(fast bool, level int, quit <-chan struct{}) {
-	t := time.NewTimer(time.Second)
+	t := time.NewTicker(time.Second)
 	defer t.Stop()
 
 	for {
@@ -1003,12 +1002,11 @@ func (e *Engine) compactTSMLevel(fast bool, level int, quit <-chan struct{}) {
 				s.Apply()
 			}
 		}
-		t.Reset(time.Second)
 	}
 }
 
 func (e *Engine) compactTSMFull(quit <-chan struct{}) {
-	t := time.NewTimer(time.Second)
+	t := time.NewTicker(time.Second)
 	defer t.Stop()
 
 	for {
@@ -1023,7 +1021,6 @@ func (e *Engine) compactTSMFull(quit <-chan struct{}) {
 			}
 
 		}
-		t.Reset(time.Second)
 	}
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR has has a few changes to improve the cache snapshotting throughput.  Under heavy write load, snapshots can start to backup.  This can cause 500 to be returned with a `cache-max-memory-size` error as well as more frequent write timeouts due to the cache being lock for a longer period of time.  

The images below are examples of 1.1 cache and heap memory size under very heavy write load (~2M/s).  They were run a c4.8xlarge (36 core/ 64 GB RAM) with both 100k series and 1M series.  

The saw tooth pattern below is the snapshots getting progressively larger and taking longer to complete.  At the peaks, write errors for `cache-max-memory-size` being exceeded could be returned depending on the configuration of the limit.  When they get larger, timeouts also start to occur when compactions kick in and use up a CPU.

![screen shot 2017-01-12 at 8 38 28 am](https://cloud.githubusercontent.com/assets/219935/21896151/8eaffa40-d8a2-11e6-91c0-40b38597c8ac.png)

Heap also continues to grow in this case:
![screen shot 2017-01-12 at 8 42 37 am](https://cloud.githubusercontent.com/assets/219935/21896292/1a308f62-d8a3-11e6-8246-e38df85bd6c0.png)

With this PR, the same write load now looks like:

![screen shot 2017-01-12 at 8 45 11 am](https://cloud.githubusercontent.com/assets/219935/21896390/794caa12-d8a3-11e6-925c-0a0021b952c9.png)

![screen shot 2017-01-12 at 8 45 41 am](https://cloud.githubusercontent.com/assets/219935/21896411/8ba5a290-d8a3-11e6-94dc-76d2f9589fe1.png)

A longer 10B point run across 1M series looks similar whereas 1.1 would start hitting 500s fairly quickly.

![screen shot 2017-01-12 at 8 47 53 am](https://cloud.githubusercontent.com/assets/219935/21896495/d4d5d58e-d8a3-11e6-85ed-d41404d5627d.png)

In both cases, the cache size stayed well under the default 1GB max memory size.  

The actual changes in this PR are the following:

* `Cache.Snapshot` was simplified to just swap the hot cache with the snapshot cache instead of iterating of very key and copy values.  This reduces lock contention with the cache is write locked.
* `CacheKeyIterator` encodes keys in parallel.  Previously, the writing of a snapshot was single thread and would iterate over each key in order and encode all the values.  This now encodes all the keys concurrently while the writer goroutine writes them out to disk in order as soon as the encoded blocks are ready.  The makes snapshotting leverage all available cores now.
* Fix cache size getting incremented to early.  If the cache limit was exceeded, the cache size counter would continue to grow with every failed write.  When the snapshot completed, it would sometimes go negative.  
* Fix an issue where compaction scheduling would sometime stop.  I'm not exactly sure how this happened locally, but the cache compactions for a shard just got stuck on a `Timer.C` channel that never fired.  This code was reusing a `Timer` incorrectly according to the docs so it has been switch to a `Ticker` instead.

With these changes, the chances of getting a `cache-max-memory-size` limit error decrease significantly.  Timeouts can still occur depending so increasing `write-timeout` may still be needed in some cases.  The timeout should occur much less frequently though.