### PR TITLE
Bind RPC to localhost by default, add to sample config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 The admin UI is removed and unusable in this release. The `[admin]` configuration section will be ignored.
 
+### Configuration Changes
+
+* The top-level config `bind-address` now defaults to `localhost:8088`.
+  The previous default was just `:8088`, causing the backup and restore port to be bound on all available interfaces (i.e. including interfaces on the public internet).
+
 ### Features
 
 - [#8143](https://github.com/influxdata/influxdb/pull/8143): Add WAL sync delay
@@ -38,6 +43,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8064](https://github.com/influxdata/influxdb/issues/8064): Forbid wildcards in binary expressions.
 - [#8148](https://github.com/influxdata/influxdb/issues/8148): Fix fill(linear) when multiple series exist and there are null values.
 - [#7995](https://github.com/influxdata/influxdb/issues/7995): Update liner dependency to handle docker exec.
+- [#7835](https://github.com/influxdata/influxdb/pull/7835): Bind backup and restore port to localhost by default
 - [#7811](https://github.com/influxdata/influxdb/issues/7811): Kill query not killing query
 - [#7457](https://github.com/influxdata/influxdb/issues/7457): KILL QUERY should work during all phases of a query
 - [#8155](https://github.com/influxdata/influxdb/pull/8155): Simplify admin user check.

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// DefaultBindAddress is the default address for various RPC services.
-	DefaultBindAddress = ":8088"
+	DefaultBindAddress = "127.0.0.1:8088"
 )
 
 // Config represents the configuration format for the influxd binary.

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -2,7 +2,7 @@
 
 # The values in this file override the default values used by the system if
 # a config option is not specified. The commented out lines are the configuration
-# field and the default value used. Uncommentting a line and changing the value
+# field and the default value used. Uncommenting a line and changing the value
 # will change the value used at runtime when the process is restarted.
 
 # Once every 24 hours InfluxDB will report usage data to usage.influxdata.com
@@ -11,10 +11,8 @@
 # Change this option to true to disable reporting.
 # reporting-disabled = false
 
-# we'll try to get the hostname automatically, but if it the os returns something
-# that isn't resolvable by other servers in the cluster, use this option to
-# manually set the hostname
-# hostname = "localhost"
+# Bind address to use for the RPC service for backup and restore.
+# bind-address = "127.0.0.1:8088"
 
 ###
 ### [meta]
@@ -123,7 +121,7 @@
   # can help prevent run away queries.  Setting the value to 0 disables the limit.
   # query-timeout = "0s"
 
-  # The the time threshold when a query will be logged as a slow query.  This limit can be set to help
+  # The time threshold when a query will be logged as a slow query.  This limit can be set to help
   # discover slow or resource intensive queries.  Setting the value to 0 disables the slow query logging.
   # log-queries-after = "0s"
 
@@ -135,7 +133,7 @@
   # count unlimited.
   # max-select-series = 0
 
-  # The maxium number of group by time bucket a SELECt can create.  A value of zero will max the maximum
+  # The maxium number of group by time bucket a SELECT can create.  A value of zero will max the maximum
   # number of buckets unlimited.
   # max-select-buckets = 0
 


### PR DESCRIPTION
Bind the RPC port to localhost by default so it is not potentially exposed to the public internet.

Add toplevel `bind-address` to the sample config because it was missing, and fix a couple typos in the config.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
