### PR TITLE
Fixes racy locking on measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7812](https://github.com/influxdata/influxdb/issues/7812): Fix slice out of bounds panic when pruning shard groups. Thanks @vladlopes
 - [#7822](https://github.com/influxdata/influxdb/issues/7822): Drop database will delete /influxdb/data directory
 - [#7838](https://github.com/influxdata/influxdb/issues/7838): Ensure Subscriber service can be disabled.
+- [#7845](https://github.com/influxdata/influxdb/issues/7845): Fix race in storage engine.
 
 ## v1.1.1 [2016-12-06]
 
@@ -96,7 +97,7 @@ The query language has been extended with a few new features:
 - [#7442](https://github.com/influxdata/influxdb/pull/7442): Support regex on fields keys in select clause
 - [#7403](https://github.com/influxdata/influxdb/pull/7403): New `linear` fill option
 - [#7388](https://github.com/influxdata/influxdb/pull/7388): New `cumulative_sum` function
-- [#7295](https://github.com/influxdata/influxdb/pull/7295): Support `ON` for `SHOW` commands 
+- [#7295](https://github.com/influxdata/influxdb/pull/7295): Support `ON` for `SHOW` commands
 
 
 All Changes:

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -664,9 +664,13 @@ func (m *Measurement) HasSeries() bool {
 func (m *Measurement) Cardinality(key string) int {
 	var n int
 	m.mu.RLock()
-	n = len(m.seriesByTagKeyValue[key])
+	n = m.cardinality(key)
 	m.mu.RUnlock()
 	return n
+}
+
+func (m *Measurement) cardinality(key string) int {
+	return len(m.seriesByTagKeyValue[key])
 }
 
 // CardinalityBytes returns the number of values associated with the given tag key.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -896,8 +896,10 @@ func (s *Shard) monitor() {
 			}
 
 			for _, m := range s.index.Measurements() {
+				// WalkTagKeys takes an RLock on m so nothing in this function
+				// can take a lock.
 				m.WalkTagKeys(func(k string) {
-					n := m.Cardinality(k)
+					n := m.cardinality(k)
 					perc := int(float64(n) / float64(s.options.Config.MaxValuesPerTag) * 100)
 					if perc > 100 {
 						perc = 100


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [ ] Back-ported to 1.2 branch

A goroutine that takes an `RLock` must never rely on a subsequent `RLock` from completing. Doing so can cause a deadlock when another goroutine requests a `Lock` on the mutex in-between the first `RLock` and second `RLock` calls.

I think this will fix #7845.