### PR TITLE
Failed imports will now alter exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#7948](https://github.com/influxdata/influxdb/pull/7948): Reduce memory allocations by reusing gzip.Writers across requests
 - [#7776](https://github.com/influxdata/influxdb/issues/7776): Add system information to /debug/vars.
 - [#7553](https://github.com/influxdata/influxdb/issues/7553): Add modulo operator to the query language.
+- [#7856](https://github.com/influxdata/influxdb/issues/7856): Failed points during an import now result in a non-zero exit code.
 
 ## v1.2.1 [2017-03-08]
 

--- a/importer/v8/importer.go
+++ b/importer/v8/importer.go
@@ -125,6 +125,17 @@ func (i *Importer) Import() error {
 		return fmt.Errorf("reading standard input: %s", err)
 	}
 
+	// If there were any failed inserts then return an error so that a non-zero
+	// exit code can be returned.
+	if i.failedInserts > 0 {
+		plural := " was"
+		if i.failedInserts > 1 {
+			plural = "s were"
+		}
+
+		return fmt.Errorf("%d point%s not inserted", i.failedInserts, plural)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #7856.

If there are any failed points during the import then the exit code for `influx` will now be `1`.