### PR TITLE
Adds handler for returning a profile archive

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,17 +25,19 @@ __Additional info:__ [Include gist of relevant config, logs, etc.]
 Also, if this is an issue of for performance, locking, etc the following commands are useful to create debug information for the team.
 
 ```
-curl -o block.txt "http://localhost:8086/debug/pprof/block?debug=1" 
-curl -o goroutine.txt "http://localhost:8086/debug/pprof/goroutine?debug=1" 
-curl -o heap.txt "http://localhost:8086/debug/pprof/heap?debug=1" 
-curl -o vars.txt "http://localhost:8086/debug/vars" 
+curl -o profiles.tar.gz "http://localhost:8086/debug/pprof/all?cpu=true"
+
+curl -o vars.txt "http://localhost:8086/debug/vars"
 iostat -xd 1 30 > iostat.txt
-influx -execute "show shards" > shards.txt
-influx -execute "show stats" > stats.txt
-influx -execute "show diagnostics" > diagnostics.txt
 ```
 
-Please run those if possible and link them from a [gist](http://gist.github.com).
+**Please note** It will take at least 30 seconds for the first cURL command above to return a response.
+This is because it will run a CPU profile as part of its information gathering, which takes 30 seconds to collect.
+Ideally you should run these commands when you're experiencing problems, so we can capture the state of the system at that time.
+
+If you're concerned about running a CPU profile (which only has a small, temporary impact on performance), then you can set `?cpu=false` or omit `?cpu=true` altogether.
+
+Please run those if possible and link them from a [gist](http://gist.github.com) or simply attach them as a comment to the issue.
 
 *Please note, the quickest way to fix a bug is to open a Pull Request.*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8302](https://github.com/influxdata/influxdb/pull/8302): Write throughput/concurrency improvements
 - [#8273](https://github.com/influxdata/influxdb/issues/8273): Remove the admin UI.
 - [#8327](https://github.com/influxdata/influxdb/pull/8327): Update to go1.8.1
-- [#8348](https://github.com/influxd	ata/influxdb/pull/8348): Add max concurrent compaction limits
+- [#8348](https://github.com/influxdata/influxdb/pull/8348): Add max concurrent compaction limits
 - [#8366](https://github.com/influxdata/influxdb/pull/8366): Add TSI support tooling.
 - [#8350](https://github.com/influxdata/influxdb/pull/8350): Track HTTP client requests for /write and /query with /debug/requests.
+<<<<<<< 8f8ff0ec612e6e77ff618f572b302e069de8e5c3
 - [#8384](https://github.com/influxdata/influxdb/pull/8384): Write and compaction stability
-- [#7862](https://github.com/influxdata/influxdb/pull/7861): Add new profile endpoint for gathering all debug profiles single in archive.
+- [#7862](https://github.com/influxdata/influxdb/pull/7861): Add new profile endpoint for gathering all debug profiles and querues in single archive.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,11 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8302](https://github.com/influxdata/influxdb/pull/8302): Write throughput/concurrency improvements
 - [#8273](https://github.com/influxdata/influxdb/issues/8273): Remove the admin UI.
 - [#8327](https://github.com/influxdata/influxdb/pull/8327): Update to go1.8.1
-- [#8348](https://github.com/influxdata/influxdb/pull/8348): Add max concurrent compaction limits
+- [#8348](https://github.com/influxd	ata/influxdb/pull/8348): Add max concurrent compaction limits
 - [#8366](https://github.com/influxdata/influxdb/pull/8366): Add TSI support tooling.
 - [#8350](https://github.com/influxdata/influxdb/pull/8350): Track HTTP client requests for /write and /query with /debug/requests.
 - [#8384](https://github.com/influxdata/influxdb/pull/8384): Write and compaction stability
+- [#7862](https://github.com/influxdata/influxdb/pull/7861): Add new profile endpoint for gathering all debug profiles single in archive.
 
 ### Bugfixes
 

--- a/internal/meta_client.go
+++ b/internal/meta_client.go
@@ -34,6 +34,8 @@ type MetaClientMock struct {
 
 	RetentionPolicyFn func(database, name string) (rpi *meta.RetentionPolicyInfo, err error)
 
+	AuthenticateFn           func(username, password string) (ui *meta.UserInfo, err error)
+	AdminUserExistsFn        func() bool
 	SetAdminPrivilegeFn      func(username string, admin bool) error
 	SetDataFn                func(*meta.Data) error
 	SetPrivilegeFn           func(username, database string, p influxql.Privilege) error
@@ -43,6 +45,7 @@ type MetaClientMock struct {
 	UpdateUserFn             func(name, password string) error
 	UserPrivilegeFn          func(username, database string) (*influxql.Privilege, error)
 	UserPrivilegesFn         func(username string) (map[string]influxql.Privilege, error)
+	UserFn                   func(username string) (*meta.UserInfo, error)
 	UsersFn                  func() []meta.UserInfo
 }
 
@@ -150,7 +153,13 @@ func (c *MetaClientMock) UserPrivileges(username string) (map[string]influxql.Pr
 	return c.UserPrivilegesFn(username)
 }
 
-func (c *MetaClientMock) Users() []meta.UserInfo { return c.UsersFn() }
+func (c *MetaClientMock) Authenticate(username, password string) (*meta.UserInfo, error) {
+	return c.AuthenticateFn(username, password)
+}
+func (c *MetaClientMock) AdminUserExists() bool { return c.AdminUserExistsFn() }
+
+func (c *MetaClientMock) User(username string) (*meta.UserInfo, error) { return c.UserFn(username) }
+func (c *MetaClientMock) Users() []meta.UserInfo                       { return c.UsersFn() }
 
 func (c *MetaClientMock) Open() error                { return c.OpenFn() }
 func (c *MetaClientMock) Data() meta.Data            { return c.DataFn() }

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -74,6 +74,7 @@ type Handler struct {
 
 	MetaClient interface {
 		Database(name string) *meta.DatabaseInfo
+		Databases() []meta.DatabaseInfo
 		Authenticate(username, password string) (ui *meta.UserInfo, err error)
 		User(username string) (*meta.UserInfo, error)
 		AdminUserExists() bool
@@ -251,7 +252,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("X-Influxdb-Version", h.Version)
 
 	if strings.HasPrefix(r.URL.Path, "/debug/pprof") && h.Config.PprofEnabled {
-		handleProfiles(w, r)
+		h.handleProfiles(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/debug/vars") {
 		h.serveExpvar(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/debug/requests") {

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/http/pprof"
 	"os"
 	"runtime/debug"
 	"strconv"
@@ -252,16 +251,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("X-Influxdb-Version", h.Version)
 
 	if strings.HasPrefix(r.URL.Path, "/debug/pprof") && h.Config.PprofEnabled {
-		switch r.URL.Path {
-		case "/debug/pprof/cmdline":
-			pprof.Cmdline(w, r)
-		case "/debug/pprof/profile":
-			pprof.Profile(w, r)
-		case "/debug/pprof/symbol":
-			pprof.Symbol(w, r)
-		default:
-			pprof.Index(w, r)
-		}
+		handleProfiles(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/debug/vars") {
 		h.serveExpvar(w, r)
 	} else if strings.HasPrefix(r.URL.Path, "/debug/requests") {

--- a/services/httpd/pprof.go
+++ b/services/httpd/pprof.go
@@ -1,0 +1,152 @@
+package httpd
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	httppprof "net/http/pprof"
+	"runtime/pprof"
+	"strconv"
+	"time"
+)
+
+// handleProfiles determines which profile to return to the requester.
+func handleProfiles(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/debug/pprof/cmdline":
+		httppprof.Cmdline(w, r)
+	case "/debug/pprof/profile":
+		httppprof.Profile(w, r)
+	case "/debug/pprof/symbol":
+		httppprof.Symbol(w, r)
+	case "/debug/pprof/all":
+		archiveProfiles(w, r)
+	default:
+		httppprof.Index(w, r)
+	}
+}
+
+// prof describes a profile name and a debug value, or in the case of a CPU
+// profile, the number of seconds to collect the profile for.
+type prof struct {
+	Name  string
+	Debug int64
+}
+
+// archiveProfiles collects the following profiles:
+//	- goroutine profile
+//	- heap profile
+//	- blocking profile
+//	- (optionally) CPU profile
+//
+// All profiles are added to a tar archive and then compressed, before being
+// returned to the requester as an archive file. Where profiles support debug
+// parameters, the profile is collected with debug=1. To optionally include a
+// CPU profile, the requester should provide a `cpu` query parameter, and can
+// also provide a `seconds` parameter to specify a non-default profile
+// collection time. The default CPU profile collection time is 30 seconds.
+//
+// Example request including CPU profile:
+//
+//	http://localhost:8086/debug/pprof/all?cpu=true&seconds=45
+//
+// The value after the `cpu` query parameter is not actually important, as long
+// as there is something there.
+//
+func archiveProfiles(w http.ResponseWriter, r *http.Request) {
+	var all = []*prof{
+		{Name: "goroutine", Debug: 1},
+		{Name: "block", Debug: 1},
+		{Name: "heap", Debug: 1},
+	}
+
+	// Capture a CPU profile?
+	if r.FormValue("cpu") != "" {
+		profile := &prof{Name: "cpu"}
+
+		// For a CPU profile we'll use the Debug field to indicate the number of
+		// seconds to capture the profile for.
+		profile.Debug, _ = strconv.ParseInt(r.FormValue("seconds"), 10, 64)
+		if profile.Debug <= 0 {
+			profile.Debug = 30
+		}
+		all = append([]*prof{profile}, all...) // CPU profile first.
+	}
+
+	var (
+		resp bytes.Buffer // Temporary buffer for entire archive.
+		buf  bytes.Buffer // Temporary buffer for each profile.
+	)
+
+	gz := gzip.NewWriter(&resp)
+	tw := tar.NewWriter(gz)
+	for _, profile := range all {
+		if profile.Name == "cpu" {
+			if err := pprof.StartCPUProfile(&buf); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			sleep(w, time.Duration(profile.Debug)*time.Second)
+			pprof.StopCPUProfile()
+		} else {
+			prof := pprof.Lookup(profile.Name)
+			if prof == nil {
+				http.Error(w, "unable to find profile "+profile.Name, http.StatusInternalServerError)
+				return
+			}
+
+			if err := prof.WriteTo(&buf, int(profile.Debug)); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Write the profile file's header.
+		err := tw.WriteHeader(&tar.Header{
+			Name: profile.Name + ".txt",
+			Mode: 0600,
+			Size: int64(buf.Len()),
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+		// Write the profile file's data.
+		if _, err := tw.Write(buf.Bytes()); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+		// Reset the buffer for the next profile.
+		buf.Reset()
+	}
+
+	// Close the tar writer.
+	if err := tw.Close(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	// Close the gzip writer.
+	if err := gz.Close(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	// Return the gzipped archive.
+	w.Header().Set("Content-Disposition", "attachment; filename=profiles.tar.gz")
+	w.Header().Set("Content-Type", "application/gzip")
+	io.Copy(w, &resp) // Nothing we can really do about an error at this point.
+}
+
+// Taken from net/http/pprof/pprof.go
+func sleep(w http.ResponseWriter, d time.Duration) {
+	var clientGone <-chan bool
+	if cn, ok := w.(http.CloseNotifier); ok {
+		clientGone = cn.CloseNotify()
+	}
+	select {
+	case <-time.After(d):
+	case <-clientGone:
+	}
+}

--- a/services/httpd/pprof.go
+++ b/services/httpd/pprof.go
@@ -159,7 +159,7 @@ func (h *Handler) archiveProfilesAndQueries(w http.ResponseWriter, r *http.Reque
 			for _, col := range row.Columns {
 				out = append(out, []byte(col+"\t")...)
 			}
-			out = append(out, []byte("\n")...)
+			out = append(out, '\n')
 			if _, err := tabW.Write(out); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
@@ -170,7 +170,7 @@ func (h *Handler) archiveProfilesAndQueries(w http.ResponseWriter, r *http.Reque
 				for _, v := range val {
 					out = append(out, []byte(fmt.Sprintf("%v\t", v))...)
 				}
-				out = append(out, []byte("\n")...)
+				out = append(out, '\n')
 				if _, err := tabW.Write(out); err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 				}
@@ -313,14 +313,14 @@ func (h *Handler) showStats() ([]*models.Row, error) {
 
 // joinUint64 returns a comma-delimited string of uint64 numbers.
 func joinUint64(a []uint64) string {
-	var buf bytes.Buffer
+	var buf []byte // Could take a guess at initial size here.
 	for i, x := range a {
-		buf.WriteString(strconv.FormatUint(x, 10))
-		if i < len(a)-1 {
-			buf.WriteRune(',')
+		if i != 0 {
+			buf = append(buf, ',')
 		}
+		buf = strconv.AppendUint(buf, x, 10)
 	}
-	return buf.String()
+	return string(buf)
 }
 
 // Taken from net/http/pprof/pprof.go


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated

Either @gunnaraasen or @rossmcdonald sowed the seed of this idea, so thanks to whichever one of you it was. 👍 

Currently, when debugging issues with InfluxDB, we often ask for the
following profiles and queries:

```
curl -o block.txt "http://localhost:8086/debug/pprof/block?debug=1"
curl -o goroutine.txt "http://localhost:8086/debug/pprof/goroutine?debug=1"
curl -o heap.txt "http://localhost:8086/debug/pprof/heap?debug=1"
curl -o cpu.txt "http://localhost:8086/debug/pprof/profile

influx -exectute 'SHOW SHARDS' > shards.txt
influx -exectute 'SHOW STATS' > stats.txt
influx -exectute 'SHOW DIAGNOSTICS' > diagnostics.txt
```

Collecting these can be bothersome for users, or even difficult if they're unfamiliar with `cURL` (or it's not on their system).

This commit adds a new endpoint: `/debug/pprof/all` which will return a single compressed archive of all of the above profiles and queries. The CPU profile is optional, and not returned by default. To include a CPU profile, the URL to request should be: `/debug/pprof/all?cpu=true`. It's also possible to vary the length of the CPU profile by adding a `seconds=x` parameter, where `x` defaults to `30`, if absent.

The new command for gathering profiles from users should now be:

```
curl -o profiles.tar.gz "http://localhost:8086/debug/pprof/all"
```

Or, if we need to see a CPU profile:

```
curl -o profiles.tar.gz "http://localhost:8086/debug/pprof/all?cpu=true"
```

It's important to remember that a CPU profile is a blocking operation, and by default it will take 30 seconds for the response (archive) to be returned to the user.

Finally, if the user is unfamiliar with `cURL`, they will now be able to visit `http://localhost:8086/debug/pprof/all` in a web browser, and the archive will be downloaded to their machine.

The archive contents look like:

```
⇒  tree ~/Downloads/profiles
/Users/edd/Downloads/profiles
├── block.txt
├── cpu.txt
├── diagnostics.txt
├── goroutine.txt
├── heap.txt
├── shards.txt
└── stats.txt

0 directories, 7 files
```
