### PR TITLE
Add system information to /debug/vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+## v1.3.0 [unreleased]
+
+### Features
+
+- [#7776](https://github.com/influxdata/influxdb/issues/7776): Add system information to /debug/vars.
+
+
 ## v1.2.1 [unreleased]
 
 ### Bugfixes
 
 - [#7877](https://github.com/influxdata/influxdb/issues/7877): Fix mapping of types when the measurement uses a regex
 - [#7888](https://github.com/influxdata/influxdb/pull/7888): Expand query dimensions from the subquery.
+
 
 ## v1.2.0 [2017-01-24]
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] CHANGELOG.md updated

It should fix #7776. The implementation is not very elegant, as `diagnostics.Diagnostics` is not in a format that lends itself well to being partially converted into JSON. Possibly a better solution would be to add a `json.Marshaler` implementation to each `diagnostics.Diagnostics`.

Hitting up `/debug/vars` will now should something like:

```json
{
  "system": {
    "currentTime": "2017-01-22T04:02:39.752460895Z",
    "started": "2017-01-22T04:02:38.744828465Z",
    "uptime": 1007632562
  },
  "cmdline": [
    "influxd"
  ],
....
```

The uptime of the system is shown in seconds.