### PR TITLE
Validate retention policy names

### DIFF
--- a/cmd/influxd/run/server_suite_test.go
+++ b/cmd/influxd/run/server_suite_test.go
@@ -29,9 +29,20 @@ func init() {
 				once:    true,
 			},
 			&Query{
-				name:    "create database should error with bad name",
+				name:    "create database with retention policy should fail with invalid name",
+				command: `CREATE DATABASE db1 WITH NAME "."`,
+				exp:     `{"results":[{"statement_id":0,"error":"invalid name"}]}`,
+				once:    true,
+			},
+			&Query{
+				name:    "create database should error with some unquoted names",
 				command: `CREATE DATABASE 0xdb0`,
 				exp:     `{"error":"error parsing query: found 0xdb0, expected identifier at line 1, char 17"}`,
+			},
+			&Query{
+				name:    "create database should error with invalid characters",
+				command: `CREATE DATABASE "."`,
+				exp:     `{"results":[{"statement_id":0,"error":"invalid name"}]}`,
 			},
 			&Query{
 				name:    "create database with retention duration should error with bad retention duration",
@@ -367,6 +378,12 @@ func init() {
 	tests["retention_policy_commands"] = Test{
 		db: "db0",
 		queries: []*Query{
+			&Query{
+				name:    "create retention policy with invalid name should return an error",
+				command: `CREATE RETENTION POLICY "." ON db0 DURATION 1d REPLICATION 1`,
+				exp:     `{"results":[{"statement_id":0,"error":"invalid name"}]}`,
+				once:    true,
+			},
 			&Query{
 				name:    "create retention policy should succeed",
 				command: `CREATE RETENTION POLICY rp0 ON db0 DURATION 1h REPLICATION 1`,

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -255,6 +255,14 @@ func (e *StatementExecutor) executeCreateDatabaseStatement(stmt *influxql.Create
 		return err
 	}
 
+	// If we're doing, for example, CREATE DATABASE "db" WITH DURATION 1d then
+	// the name will not yet be set. We only need to validate non-empty
+	// retention policy names, such as in the statement:
+	// 	CREATE DATABASE "db" WITH DURATION 1d NAME "xyz"
+	if stmt.RetentionPolicyName != "" && !meta.ValidName(stmt.RetentionPolicyName) {
+		return meta.ErrInvalidName
+	}
+
 	spec := meta.RetentionPolicySpec{
 		Name:               stmt.RetentionPolicyName,
 		Duration:           stmt.RetentionPolicyDuration,


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] Backport to 1.2

Only 2207365 needs to be reviewed in this PR.

#7865 should be merged first as this branches off of that to ensure compatibility all round. Fixes an extra case from #7822 which was not caught in the fix in #7829.

Also adds some test coverage for all the cases.