### PR TITLE
Fix mapping of types when the measurement uses a regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.1 [unreleased]
+
+### Bugfixes
+
+- [#7877](https://github.com/influxdata/influxdb/issues/7877): Fix mapping of types when the measurement uses a regex
+
 ## v1.2.0 [2017-01-24]
 
 ### Release Notes
@@ -5,7 +11,6 @@
 ### Deprecations
 
 The stress tool `influx_stress` will be removed in a subsequent release. We recommend using [`influx-stress`](https://github.com/influxdata/influx-stress) as a replacement.
-
 
 ### Features
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -2959,6 +2959,12 @@ func TestServer_Query_Regex(t *testing.T) {
 			command: `SELECT * FROM db0../cpu[13]/ GROUP BY *`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","tags":{"host":"server01"},"columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
 		},
+		&Query{
+			name:    "map field type with a regex source",
+			command: `SELECT value FROM /cpu[13]/`,
+			params:  url.Values{"db": []string{"db0"}},
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu1","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",10]]},{"name":"cpu3","columns":["time","value"],"values":[["2015-02-28T01:03:36.703820946Z",30]]}]}]}`,
+		},
 	}...)
 
 	for i, query := range test.queries {

--- a/coordinator/shard_mapper.go
+++ b/coordinator/shard_mapper.go
@@ -134,7 +134,22 @@ func (a *LocalShardMapping) MapType(m *influxql.Measurement, field string) influ
 	if sg == nil {
 		return influxql.Unknown
 	}
-	return sg.MapType(m.Name, field)
+
+	var names []string
+	if m.Regex != nil {
+		names = sg.MeasurementsByRegex(m.Regex.Val)
+	} else {
+		names = []string{m.Name}
+	}
+
+	var typ influxql.DataType
+	for _, name := range names {
+		t := sg.MapType(name, field)
+		if typ == influxql.Unknown || t < typ {
+			typ = t
+		}
+	}
+	return typ
 }
 
 func (a *LocalShardMapping) CreateIterator(m *influxql.Measurement, opt influxql.IteratorOptions) (influxql.Iterator, error) {


### PR DESCRIPTION
With the new shard mapper implementation, regexes were just ignored so
it attempted to look up the field type inside of a measurement with no
name (which cannot possibly exist) so it would think the field didn't
exist and map it as the unknown type.

- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated

Fixes #7877.