### PR TITLE
Expand query dimensions from the subquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 
 - [#7877](https://github.com/influxdata/influxdb/issues/7877): Fix mapping of types when the measurement uses a regex
+- [#7888](https://github.com/influxdata/influxdb/pull/7888): Expand query dimensions from the subquery.
 
 ## v1.2.0 [2017-01-24]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -4547,13 +4547,10 @@ func FieldDimensions(sources Sources, m FieldMapper) (fields map[string]DataType
 				}
 			}
 
-			_, d, err := FieldDimensions(src.Statement.Sources, m)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			for k := range d {
-				dimensions[k] = struct{}{}
+			for _, d := range src.Statement.Dimensions {
+				if expr, ok := d.Expr.(*VarRef); ok {
+					dimensions[expr.Val] = struct{}{}
+				}
 			}
 		}
 	}

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -411,7 +411,7 @@ func TestSelectStatement_RewriteFields(t *testing.T) {
 		// Rewrite subquery
 		{
 			stmt:    `SELECT * FROM (SELECT mean(value1) FROM cpu GROUP BY host) GROUP BY *`,
-			rewrite: `SELECT mean::float FROM (SELECT mean(value1::float) FROM cpu GROUP BY host) GROUP BY host, region`,
+			rewrite: `SELECT mean::float FROM (SELECT mean(value1::float) FROM cpu GROUP BY host) GROUP BY host`,
 		},
 	}
 


### PR DESCRIPTION
During development, I, at some point, decided that the dimensions should
be expanded based on what was available rather than what was present in
the subquery. I don't really know the rationale for this because I
forgot, but it doesn't make sense or seem to be particularly useful.

Expanding dimensions now just uses the values specified in the subquery
rather than expanding to all available dimensions of the measurement in
the subquery.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes the third issue in #7875.