### PR TITLE
Fix ORDER BY time DESC with ordering series keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#7895](https://github.com/influxdata/influxdb/issues/7895): Fix incorrect math when aggregates that emit different times are used.
 - [#7946](https://github.com/influxdata/influxdb/issues/7946): Fix authentication when subqueries are present.
 - [#7885](https://github.com/influxdata/influxdb/issues/7885): Fix LIMIT and OFFSET when they are used in a subquery.
+- [#7905](https://github.com/influxdata/influxdb/issues/7905): Fix ORDER BY time DESC with ordering series keys.
 
 ## v1.2.0 [2017-01-24]
 

--- a/influxql/emitter.go
+++ b/influxql/emitter.go
@@ -126,11 +126,10 @@ func (e *Emitter) loadBuf() (t int64, name string, tags Tags, err error) {
 		}
 
 		// Update range values if higher and emitter is in time descending order.
-		if (itrName < name) || (itrName == name && itrTags.ID() < tags.ID()) || (itrName == name && itrTags.ID() == tags.ID() && itrTime < t) {
+		if (itrName > name) || (itrName == name && itrTags.ID() > tags.ID()) || (itrName == name && itrTags.ID() == tags.ID() && itrTime > t) {
 			t, name, tags = itrTime, itrName, itrTags
 		}
 	}
-
 	return
 }
 

--- a/influxql/result.go
+++ b/influxql/result.go
@@ -35,6 +35,14 @@ func (t *TagSet) Swap(i, j int) {
 	t.Filters[i], t.Filters[j] = t.Filters[j], t.Filters[i]
 }
 
+// Reverse reverses the order of series keys and filters in the TagSet.
+func (t *TagSet) Reverse() {
+	for i, j := 0, len(t.Filters)-1; i < j; i, j = i+1, j-1 {
+		t.Filters[i], t.Filters[j] = t.Filters[j], t.Filters[i]
+		t.SeriesKeys[i], t.SeriesKeys[j] = t.SeriesKeys[j], t.SeriesKeys[i]
+	}
+}
+
 // Message represents a user-facing message to be included with the result.
 type Message struct {
 	Level string `json:"level"`

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1283,6 +1283,13 @@ func (e *Engine) createCallIterator(measurement string, call *influxql.Call, opt
 		return nil, err
 	}
 
+	// Reverse the tag sets if we are ordering by descending.
+	if !opt.Ascending {
+		for _, t := range tagSets {
+			t.Reverse()
+		}
+	}
+
 	// Calculate tag sets and apply SLIMIT/SOFFSET.
 	tagSets = influxql.LimitTagSets(tagSets, opt.SLimit, opt.SOffset)
 
@@ -1334,6 +1341,13 @@ func (e *Engine) createVarRefIterator(measurement string, opt influxql.IteratorO
 	tagSets, err := mm.TagSets(e.id, opt.Dimensions, opt.Condition)
 	if err != nil {
 		return nil, err
+	}
+
+	// Reverse the tag sets if we are ordering by descending.
+	if !opt.Ascending {
+		for _, t := range tagSets {
+			t.Reverse()
+		}
 	}
 
 	// Calculate tag sets and apply SLIMIT/SOFFSET.


### PR DESCRIPTION
The order of series keys is in ascending alphabetical order, not
descending alphabetical order, when it is ordered by descending time.
This fixes the ordering so points are returned in descending order. The
emitter also had the conditions for choosing which iterator to use in
the wrong direction (which only affects aggregates with `FILL(none)`).

Fixes #7905.

- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated