### PR TITLE
hll: skip recalc of sparseSet if tmpSet is empty

### DIFF
--- a/pkg/estimator/hll/hll.go
+++ b/pkg/estimator/hll/hll.go
@@ -306,6 +306,9 @@ func (h *Plus) UnmarshalBinary(data []byte) error {
 }
 
 func (h *Plus) mergeSparse() {
+	if len(h.tmpSet) == 0 {
+		return
+	}
 	keys := make(uint64Slice, 0, len(h.tmpSet))
 	for k := range h.tmpSet {
 		keys = append(keys, k)

--- a/pkg/estimator/hll/hll_test.go
+++ b/pkg/estimator/hll/hll_test.go
@@ -164,6 +164,20 @@ func TestHLLPPCount(t *testing.T) {
 	if n != 5 {
 		t.Error(n)
 	}
+
+	// not mutated, still returns correct count
+	n = h.Count()
+	if n != 5 {
+		t.Error(n)
+	}
+
+	h.Add(toByte(0x00060fffffffffff))
+
+	// mutated
+	n = h.Count()
+	if n != 6 {
+		t.Error(n)
+	}
 }
 
 func TestHLLPP_Merge_Error(t *testing.T) {


### PR DESCRIPTION
```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkSet_Count/set_size_1000-8        38095         28.3          -99.93%
BenchmarkSet_Count/set_size_5000-8        152052        30.1          -99.98%
BenchmarkSet_Count/set_size_10000-8       50953         54978         +7.90%
BenchmarkSet_Count/set_size_50000-8       32495         31222         -3.92%
BenchmarkSet_Count/set_size_1000000-8     32603         30800         -5.53%

benchmark                                 old allocs     new allocs     delta
BenchmarkSet_Count/set_size_1000-8        4              0              -100.00%
BenchmarkSet_Count/set_size_5000-8        4              0              -100.00%
BenchmarkSet_Count/set_size_10000-8       0              0              +0.00%
BenchmarkSet_Count/set_size_50000-8       0              0              +0.00%
BenchmarkSet_Count/set_size_1000000-8     0              0              +0.00%

benchmark                                 old bytes     new bytes     delta
BenchmarkSet_Count/set_size_1000-8        16496         0             -100.00%
BenchmarkSet_Count/set_size_5000-8        16497         0             -100.00%
BenchmarkSet_Count/set_size_10000-8       0             0             +0.00%
BenchmarkSet_Count/set_size_50000-8       0             0             +0.00%
BenchmarkSet_Count/set_size_1000000-8     0             0             +0.00%
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

