### PR TITLE
Fix EvalType when a parenthesis expression is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#7877](https://github.com/influxdata/influxdb/issues/7877): Fix mapping of types when the measurement uses a regex
 - [#7888](https://github.com/influxdata/influxdb/pull/7888): Expand query dimensions from the subquery.
+- [#7910](https://github.com/influxdata/influxdb/issues/7910): Fix EvalType when a parenthesis expression is used.
 
 ## v1.2.0 [2017-01-24]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -4490,7 +4490,7 @@ func EvalType(expr Expr, sources Sources, typmap TypeMapper) DataType {
 			return EvalType(expr.Args[0], sources, typmap)
 		}
 	case *ParenExpr:
-		return EvalType(expr, sources, typmap)
+		return EvalType(expr.Expr, sources, typmap)
 	case *NumberLiteral:
 		return Float
 	case *IntegerLiteral:

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -1136,6 +1136,16 @@ func TestEvalType(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: `value inside a parenthesis`,
+			in:   `(value)`,
+			typ:  influxql.Float,
+			data: EvalFixture{
+				"cpu": map[string]influxql.DataType{
+					"value": influxql.Float,
+				},
+			},
+		},
 	} {
 		sources := make([]influxql.Source, 0, len(tt.data))
 		for src := range tt.data {


### PR DESCRIPTION
Backport #7916.