### PR TITLE
regex: don't use exact match for case insensitive expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#7888](https://github.com/influxdata/influxdb/pull/7888): Expand query dimensions from the subquery.
 - [#7910](https://github.com/influxdata/influxdb/issues/7910): Fix EvalType when a parenthesis expression is used.
 - [#7929](https://github.com/influxdata/influxdb/issues/7929): Fix series tag iteration segfault. (#7922)
+- [#7906](https://github.com/influxdata/influxdb/issues/7906): Anchors not working as expected with case-insensitive regex
 
 ## v1.2.0 [2017-01-24]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -5543,6 +5543,12 @@ func TestServer_Query_With_EmptyTags(t *testing.T) {
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:03Z",2]]}]}]}`,
 		},
 		&Query{
+			name:    "where regex exact (case insensitive)",
+			params:  url.Values{"db": []string{"db0"}},
+			command: `select value from cpu where host =~ /(?i)^SeRvEr01$/`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2009-11-10T23:00:03Z",2]]}]}]}`,
+		},
+		&Query{
 			name:    "where regex exact (not)",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `select value from cpu where host !~ /^server01$/`,

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1369,7 +1369,7 @@ func matchExactRegex(v string) (string, bool) {
 
 	if len(re.Sub) == 3 {
 		middle := re.Sub[1]
-		if middle.Op != syntax.OpLiteral {
+		if middle.Op != syntax.OpLiteral || middle.Flags^syntax.Perl != 0 {
 			// Regex does not contain a literal op.
 			return "", false
 		}


### PR DESCRIPTION
Fixes #7906

In an attempt to reduce the overhead of using regex for exact matches,
the query parser will replace `=~ /^thing$/` with `== 'thing'`, but the
conditions being checked would ignore if any flags were set on the
expression, so `=~ /(?i)^THING$/` was replaced with `== 'THING'`, which
will fail unless the case was already exact. This change ensures that no
flags have been changed from those defaulted by the parser.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
