### PR TITLE
Reduce write timeouts

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -18,7 +18,7 @@ import (
 // testing, a value above the number of cores on the machine does not provide
 // any additional benefit. For now we'll set it to the number of cores on the
 // largest box we could imagine running influx.
-const ringShards = 128
+const ringShards = 4096
 
 var (
 	// ErrSnapshotInProgress is returned if a snapshot is attempted while one is already running.

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1132,6 +1132,10 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 				}
 
 				k.mergedValues = k.mergedValues.Merge(v)
+
+				// Allow other goroutines to run
+				runtime.Gosched()
+
 			}
 			k.blocks = k.blocks[1:]
 		}
@@ -1144,6 +1148,7 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 		var i int
 
 		for i < len(k.blocks) {
+
 			// skip this block if it's values were already read
 			if k.blocks[i].read() {
 				i++
@@ -1156,6 +1161,8 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 				break
 			}
 			i++
+			// Allow other goroutines to run
+			runtime.Gosched()
 		}
 
 		if k.fast {
@@ -1168,6 +1175,8 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 
 				chunked = append(chunked, k.blocks[i])
 				i++
+				// Allow other goroutines to run
+				runtime.Gosched()
 			}
 		}
 
@@ -1202,6 +1211,8 @@ func (k *tsmKeyIterator) combine(dedup bool) blocks {
 
 			k.mergedValues = k.mergedValues.Merge(v)
 			i++
+			// Allow other goroutines to run
+			runtime.Gosched()
 		}
 
 		k.blocks = k.blocks[i:]

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1229,8 +1229,6 @@ func (e *Engine) cleanupTempTSMFiles() error {
 
 // KeyCursor returns a KeyCursor for the given key starting at time t.
 func (e *Engine) KeyCursor(key string, t int64, ascending bool) *KeyCursor {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
 	return e.FileStore.KeyCursor(key, t, ascending)
 }
 

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -13,7 +13,7 @@ import (
 // basically defines the maximum number of partitions you can have in the ring.
 // If a smaller number of partitions are chosen when creating a ring, then
 // they're evenly spread across this many partitions in the ring.
-const partitions = 256
+const partitions = 4096
 
 // ring is a structure that maps series keys to entries.
 //
@@ -92,7 +92,7 @@ func (r *ring) reset() {
 // getPartition retrieves the hash ring partition associated with the provided
 // key.
 func (r *ring) getPartition(key string) *partition {
-	return r.continuum[int(uint8(xxhash.Sum64([]byte(key))))]
+	return r.continuum[int(xxhash.Sum64([]byte(key))%partitions)]
 }
 
 // entry returns the entry for the given key.

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -64,7 +64,7 @@ var (
 	// ErrWALCorrupt is returned when reading a corrupt WAL entry.
 	ErrWALCorrupt = fmt.Errorf("corrupted WAL entry")
 
-	defaultWaitingWALWrites = runtime.NumCPU()
+	defaultWaitingWALWrites = runtime.GOMAXPROCS(0) * 2
 )
 
 // Statistics gathered by the WAL.


### PR DESCRIPTION
This PR has a few changes to reduce write timeouts which can cause `500s` via the HTTP API.

* The number of cache partitions is increased from 256 to 4096 which reduces the lock contention in `partition.write`.
* If enough compactions goroutine are running concurrently, they may tie up a CPU core for long periods of time and not allow the go runtime to schedule other goroutines.  `runtime.Gosched()` was added in a few spots during compactions where this could occur to allow write goroutines to continue.
* `FileStore` locks were modified to reduce contention while the `Engine` is locked.