### PR TITLE
Use go 1.7.4 in packaging script

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -67,7 +67,7 @@ if [ -z "$FPM" ]; then
     FPM=`which fpm`
 fi
 
-GO_VERSION="go1.4.3"
+GO_VERSION="go1.7.4"
 GOPATH_INSTALL=
 BINS=(
     influxd


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

I consider this a trivial PR, but I can sign the CLA if necessary.

I was following http://www.aymerick.com/2015/10/07/influxdb-telegraf-grafana-raspberry-pi.html to build a deb of influxdb for my raspberry pi, and found that the package.sh script was using an outdated version of Go even though it appears that influxdb upgraded to Go 1.7.4 about 2 months ago ( 30bea335a494c0ce25c4caaa6030bd501f364113 ), so I updated the package.sh script to match that.