### PR TITLE
[influxd] Use sync.Pool to reuse gzip.Writers across requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - [#7776](https://github.com/influxdata/influxdb/issues/7776): Add system information to /debug/vars.
+- [#7948](https://github.com/influxdata/influxdb/pull/7948): Reduce memory allocations by reusing gzip.Writers across requests
 
 ## v1.2.1 [unreleased]
 


### PR DESCRIPTION
This brings alloc_space down from ~20200M to ~10700M in a run of
`go test ./cmd/influxd/run -bench=Server -memprofile=mem.out -run='^$'`

It's hard to get stable performance numbers out of the benchmarks on my MBP, so take the following with a grain of salt: this PR makes most influxd benchmarks faster by a few %, mostly by lowering the amount of GC.

this PR (`go test ./cmd/influxd/run -bench=Server -run='^$' -benchtime=10s`):
```
BenchmarkServer_Query_Count_1-4                  	   10000	   1818724 ns/op	  128974 B/op	     513 allocs/op
BenchmarkServer_Query_Count_1K-4                 	    5000	   3693137 ns/op	  152458 B/op	     514 allocs/op
BenchmarkServer_Query_Count_100K-4               	    1000	  12607160 ns/op	 1889711 B/op	     524 allocs/op
BenchmarkServer_Query_Count_1M-4                 	     200	 117704311 ns/op	16635919 B/op	    1554 allocs/op
BenchmarkServer_Query_Count_Where_500-4          	   10000	   1809682 ns/op	   98816 B/op	     580 allocs/op
BenchmarkServer_Query_Count_Where_1K-4           	    5000	   3256780 ns/op	   98983 B/op	     580 allocs/op
BenchmarkServer_Query_Count_Where_10K-4          	    5000	   3886609 ns/op	   98320 B/op	     580 allocs/op
BenchmarkServer_Query_Count_Where_100K-4         	   10000	   2960748 ns/op	   96410 B/op	     580 allocs/op
BenchmarkServer_Query_Count_Where_Regex_500-4    	    5000	   3954818 ns/op	  103231 B/op	     661 allocs/op
BenchmarkServer_Query_Count_Where_Regex_1K-4     	    5000	   3040596 ns/op	  103395 B/op	     661 allocs/op
BenchmarkServer_Query_Count_Where_Regex_10K-4    	    5000	   3777312 ns/op	  103728 B/op	     661 allocs/op
BenchmarkServer_Query_Count_Where_Regex_100K-4   	    5000	   3171716 ns/op	  199497 B/op	    1472 allocs/op
BenchmarkServer_ShowSeries_1-4                   	     200	  87806658 ns/op	18379301 B/op	   70295 allocs/op
BenchmarkServer_ShowSeries_1K-4                  	     200	  85051824 ns/op	18310844 B/op	   69497 allocs/op
BenchmarkServer_ShowSeries_100K-4                	     100	 126484645 ns/op	27288215 B/op	   69693 allocs/op
BenchmarkServer_ShowSeries_1M-4                  	      30	 668360307 ns/op	121411739 B/op	  338035 allocs/op
```
`master` (`go test ./cmd/influxd/run -bench=Server -run='^$' -benchtime=10s`):
```
BenchmarkServer_Query_Count_1-4                  	   10000	   1904422 ns/op	  909175 B/op	     536 allocs/op
BenchmarkServer_Query_Count_1K-4                 	    5000	   3917357 ns/op	  925456 B/op	     536 allocs/op
BenchmarkServer_Query_Count_100K-4               	    1000	  17747914 ns/op	 2515462 B/op	     539 allocs/op
BenchmarkServer_Query_Count_1M-4                 	     200	 121461770 ns/op	17152968 B/op	    1565 allocs/op
BenchmarkServer_Query_Count_Where_500-4          	   10000	   2150083 ns/op	  909346 B/op	     598 allocs/op
BenchmarkServer_Query_Count_Where_1K-4           	    5000	   4037208 ns/op	  909334 B/op	     598 allocs/op
BenchmarkServer_Query_Count_Where_10K-4          	    5000	   3293030 ns/op	  909253 B/op	     598 allocs/op
BenchmarkServer_Query_Count_Where_100K-4         	    5000	   3381816 ns/op	  908965 B/op	     597 allocs/op
BenchmarkServer_Query_Count_Where_Regex_500-4    	    5000	   3767250 ns/op	  915863 B/op	     678 allocs/op
BenchmarkServer_Query_Count_Where_Regex_1K-4     	    5000	   4134308 ns/op	  915866 B/op	     678 allocs/op
BenchmarkServer_Query_Count_Where_Regex_10K-4    	    5000	   3456730 ns/op	  915869 B/op	     678 allocs/op
BenchmarkServer_Query_Count_Where_Regex_100K-4   	    3000	   3454660 ns/op	 1068348 B/op	    2030 allocs/op
BenchmarkServer_ShowSeries_1-4                   	     100	 101827312 ns/op	18836027 B/op	   69884 allocs/op
BenchmarkServer_ShowSeries_1K-4                  	     200	  83631929 ns/op	18856224 B/op	   70257 allocs/op
BenchmarkServer_ShowSeries_100K-4                	     100	 124226536 ns/op	27889449 B/op	   69344 allocs/op
BenchmarkServer_ShowSeries_1M-4                  	      30	 668649254 ns/op	121761661 B/op	  337101 allocs/op
```

###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

