### PR TITLE
Prevent a panic when aggregates are used in an inner query with a raw query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#7946](https://github.com/influxdata/influxdb/issues/7946): Fix authentication when subqueries are present.
 - [#7885](https://github.com/influxdata/influxdb/issues/7885): Fix LIMIT and OFFSET when they are used in a subquery.
 - [#7905](https://github.com/influxdata/influxdb/issues/7905): Fix ORDER BY time DESC with ordering series keys.
+- [#7966](https://github.com/influxdata/influxdb/pull/7966): Prevent a panic when aggregates are used in an inner query with a raw query.
 
 ## v1.2.0 [2017-01-24]
 

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -4740,6 +4740,14 @@ func TestServer_Query_Subqueries(t *testing.T) {
 			command: `SELECT value FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND value > 0`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",40]]}]}]}`,
 		},
+		&Query{
+			params:  url.Values{"db": []string{"db0"}},
+			command: `SELECT mean, host FROM (SELECT mean(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
+			// TODO(jsternberg): This should return the hosts for each mean()
+			// value. The query engine is currently limited in a way that
+			// doesn't allow that to work though so we have to do this.
+			exp: `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean","host"],"values":[["2000-01-01T00:00:00Z",46,null],["2000-01-01T00:00:00Z",17,null]]}]}]}`,
+		},
 	}...)
 
 	for i, query := range test.queries {

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -507,7 +507,10 @@ func (a *auxIteratorFields) iterator(name string, typ DataType) Iterator {
 func (a *auxIteratorFields) send(p Point) (ok bool) {
 	values := p.aux()
 	for i, f := range a.fields {
-		v := values[i]
+		var v interface{}
+		if i < len(values) {
+			v = values[i]
+		}
 
 		tags := p.tags()
 		tags = tags.Subset(a.dimensions)


### PR DESCRIPTION
The following types of queries will panic:

    SELECT mean, host FROM (SELECT mean(value) FROM cpu GROUP BY host)
    SELECT top(sum, host, 3) FROM (SELECT sum(value) FROM cpu GROUP BY host)

These queries _should_ work, but due to a current limitation with
aggregate functions, the aggregate functions won't return any auxiliary
fields. So even if a tag is not an auxiliary field, it is treated that
way by the query engine and this query will fail.

Fixing this properly will take a longer period of time. This fix just
prevents the panic from killing the server while we fix this for real.

Related to #7898.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated