### PR TITLE
Allow non-admin users to execute SHOW DATABASES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ### Features
 
-- [#7776](https://github.com/influxdata/influxdb/issues/7776): Add system information to /debug/vars.
-- [#7948](https://github.com/influxdata/influxdb/pull/7948): Reduce memory allocations by reusing gzip.Writers across requests
-- [#7553](https://github.com/influxdata/influxdb/issues/7553): Add modulo operator to the query language.
 - [#7977](https://github.com/influxdata/influxdb/issues/7977): Add chunked request processing back into the Go client v2
+- [#7974](https://github.com/influxdata/influxdb/pull/7974): Allow non-admin users to execute SHOW DATABASES.
+- [#7948](https://github.com/influxdata/influxdb/pull/7948): Reduce memory allocations by reusing gzip.Writers across requests
+- [#7776](https://github.com/influxdata/influxdb/issues/7776): Add system information to /debug/vars.
+- [#7553](https://github.com/influxdata/influxdb/issues/7553): Add modulo operator to the query language.
 
 ## v1.2.1 [unreleased]
 

--- a/coordinator/statement_executor_test.go
+++ b/coordinator/statement_executor_test.go
@@ -193,6 +193,57 @@ func TestStatementExecutor_NormalizeDeleteSeries(t *testing.T) {
 	}
 }
 
+type mockAuthorizer struct {
+	AuthorizeDatabaseFn func(influxql.Privilege, string) bool
+}
+
+func (a *mockAuthorizer) AuthorizeDatabase(p influxql.Privilege, name string) bool {
+	return a.AuthorizeDatabaseFn(p, name)
+}
+
+func TestQueryExecutor_ExecuteQuery_ShowDatabases(t *testing.T) {
+	qe := influxql.NewQueryExecutor()
+	qe.StatementExecutor = &coordinator.StatementExecutor{
+		MetaClient: &internal.MetaClientMock{
+			DatabasesFn: func() []meta.DatabaseInfo {
+				return []meta.DatabaseInfo{
+					{Name: "db1"}, {Name: "db2"}, {Name: "db3"}, {Name: "db4"},
+				}
+			},
+		},
+	}
+
+	opt := influxql.ExecutionOptions{
+		Authorizer: &mockAuthorizer{
+			AuthorizeDatabaseFn: func(p influxql.Privilege, name string) bool {
+				return name == "db2" || name == "db4"
+			},
+		},
+	}
+
+	q, err := influxql.ParseQuery("SHOW DATABASES")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results := ReadAllResults(qe.ExecuteQuery(q, opt, make(chan struct{})))
+	exp := []*influxql.Result{
+		{
+			StatementID: 0,
+			Series: []*models.Row{{
+				Name:    "databases",
+				Columns: []string{"name"},
+				Values: [][]interface{}{
+					{"db2"}, {"db4"},
+				},
+			}},
+		},
+	}
+	if !reflect.DeepEqual(results, exp) {
+		t.Fatalf("unexpected results: exp %s, got %s", spew.Sdump(exp), spew.Sdump(results))
+	}
+}
+
 // QueryExecutor is a test wrapper for coordinator.QueryExecutor.
 type QueryExecutor struct {
 	*influxql.QueryExecutor

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2673,7 +2673,10 @@ func (s *ShowDatabasesStatement) String() string { return "SHOW DATABASES" }
 
 // RequiredPrivileges returns the privilege required to execute a ShowDatabasesStatement.
 func (s *ShowDatabasesStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
+	// SHOW DATABASES is one of few statements that have no required privileges.
+	// Anyone is allowed to execute it, but the returned results depend on the user's
+	// individual database permissions.
+	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: NoPrivileges}}, nil
 }
 
 // CreateContinuousQueryStatement represents a command for creating a continuous query.

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -1465,6 +1465,79 @@ func TestSelect_SubqueryPrivileges(t *testing.T) {
 	}
 }
 
+func TestShow_Privileges(t *testing.T) {
+	for _, c := range []struct {
+		stmt influxql.Statement
+		exp  influxql.ExecutionPrivileges
+	}{
+		{
+			stmt: &influxql.ShowDatabasesStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: false, Privilege: influxql.NoPrivileges}},
+		},
+		{
+			stmt: &influxql.ShowFieldKeysStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: false, Privilege: influxql.ReadPrivilege}},
+		},
+		{
+			stmt: &influxql.ShowMeasurementsStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: false, Privilege: influxql.ReadPrivilege}},
+		},
+		{
+			stmt: &influxql.ShowQueriesStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: false, Privilege: influxql.ReadPrivilege}},
+		},
+		{
+			stmt: &influxql.ShowRetentionPoliciesStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: false, Privilege: influxql.ReadPrivilege}},
+		},
+		{
+			stmt: &influxql.ShowSeriesStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: false, Privilege: influxql.ReadPrivilege}},
+		},
+		{
+			stmt: &influxql.ShowShardGroupsStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: true, Privilege: influxql.AllPrivileges}},
+		},
+		{
+			stmt: &influxql.ShowShardsStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: true, Privilege: influxql.AllPrivileges}},
+		},
+		{
+			stmt: &influxql.ShowStatsStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: true, Privilege: influxql.AllPrivileges}},
+		},
+		{
+			stmt: &influxql.ShowSubscriptionsStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: true, Privilege: influxql.AllPrivileges}},
+		},
+		{
+			stmt: &influxql.ShowDiagnosticsStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: true, Privilege: influxql.AllPrivileges}},
+		},
+		{
+			stmt: &influxql.ShowTagKeysStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: false, Privilege: influxql.ReadPrivilege}},
+		},
+		{
+			stmt: &influxql.ShowTagValuesStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: false, Privilege: influxql.ReadPrivilege}},
+		},
+		{
+			stmt: &influxql.ShowUsersStatement{},
+			exp:  influxql.ExecutionPrivileges{{Admin: true, Privilege: influxql.AllPrivileges}},
+		},
+	} {
+		got, err := c.stmt.RequiredPrivileges()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(c.exp, got) {
+			t.Errorf("exp: %v, got: %v", c.exp, got)
+		}
+	}
+}
+
 func TestSources_Names(t *testing.T) {
 	sources := influxql.Sources([]influxql.Source{
 		&influxql.Measurement{

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -390,6 +390,14 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user *meta.
 		NodeID:    nodeID,
 	}
 
+	if h.Config.AuthEnabled {
+		// The current user determines the authorized actions.
+		opts.Authorizer = user
+	} else {
+		// Auth is disabled, so allow everything.
+		opts.Authorizer = influxql.OpenAuthorizer{}
+	}
+
 	// Make sure if the client disconnects we signal the query to abort
 	var closing chan struct{}
 	if !async {

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1409,15 +1409,24 @@ func (cqi *ContinuousQueryInfo) unmarshal(pb *internal.ContinuousQueryInfo) {
 
 // UserInfo represents metadata about a user in the system.
 type UserInfo struct {
-	Name       string
-	Hash       string
-	Admin      bool
+	// User's name.
+	Name string
+
+	// Hashed password.
+	Hash string
+
+	// Whether the user is an admin, i.e. allowed to do everything.
+	Admin bool
+
+	// Map of database name to granted privilege.
 	Privileges map[string]influxql.Privilege
 }
 
-// Authorize returns true if the user is authorized and false if not.
-func (ui *UserInfo) Authorize(privilege influxql.Privilege, database string) bool {
-	if ui.Admin {
+var _ influxql.Authorizer = (*UserInfo)(nil)
+
+// AuthorizeDatabase returns true if the user is authorized for the given privilege on the given database.
+func (ui *UserInfo) AuthorizeDatabase(privilege influxql.Privilege, database string) bool {
+	if ui.Admin || privilege == influxql.NoPrivileges {
 		return true
 	}
 	p, ok := ui.Privileges[database]

--- a/services/meta/data_test.go
+++ b/services/meta/data_test.go
@@ -109,3 +109,18 @@ func Test_Data_CreateRetentionPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestUserInfo_AuthorizeDatabase(t *testing.T) {
+	emptyUser := &meta.UserInfo{}
+	if !emptyUser.AuthorizeDatabase(influxql.NoPrivileges, "anydb") {
+		t.Fatal("expected NoPrivileges to be authorized but it wasn't")
+	}
+	if emptyUser.AuthorizeDatabase(influxql.ReadPrivilege, "anydb") {
+		t.Fatal("expected ReadPrivilege to prevent authorization, but it was authorized")
+	}
+
+	adminUser := &meta.UserInfo{Admin: true}
+	if !adminUser.AuthorizeDatabase(influxql.AllPrivileges, "anydb") {
+		t.Fatalf("expected admin to be authorized but it wasn't")
+	}
+}

--- a/services/meta/query_authorizer.go
+++ b/services/meta/query_authorizer.go
@@ -82,7 +82,7 @@ func (a *QueryAuthorizer) AuthorizeQuery(u *UserInfo, query *influxql.Query, dat
 			if db == "" {
 				db = database
 			}
-			if !u.Authorize(p.Privilege, db) {
+			if !u.AuthorizeDatabase(p.Privilege, db) {
 				return &ErrAuthorize{
 					Query:    query,
 					User:     u.Name,

--- a/services/meta/write_authorizer.go
+++ b/services/meta/write_authorizer.go
@@ -19,7 +19,7 @@ func NewWriteAuthorizer(c *Client) *WriteAuthorizer {
 // AuthorizeWrite returns nil if the user has permission to write to the database.
 func (a WriteAuthorizer) AuthorizeWrite(username, database string) error {
 	u, err := a.Client.User(username)
-	if err != nil || u == nil || !u.Authorize(influxql.WritePrivilege, database) {
+	if err != nil || u == nil || !u.AuthorizeDatabase(influxql.WritePrivilege, database) {
 		return &ErrAuthorize{
 			Database: database,
 			Message:  fmt.Sprintf("%s not authorized to write to %s", username, database),


### PR DESCRIPTION
This commit introduces a new interface type, influxql.Authorizer, that
is passed as part of a statement's execution context and determines
whether the context is permitted to access a given database. In the
future, the Authorizer interface may be expanded to other resources
besides databases. In this commit, the Authorizer interface is
specifically used to determine which databases are returned when
executing SHOW DATABASES.

When HTTP authentication is enabled, the existing meta.UserInfo struct
implements Authorizer, meaning admin users can SHOW every database, and
non-admin users can SHOW only databases for which they have read and/or
write permission.

When HTTP authentication is disabled, all databases are visible through
SHOW DATABASES.

This addresses a long-standing issue where Chronograf or Grafana would
be unable to list databases if the logged-in user did not have admin
privileges.

Fixes #4785.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): https://github.com/influxdata/docs.influxdata.com/issues/1016
