### PR TITLE
Reduce allocations

### DIFF
--- a/tsdb/index/internal/file_set.go
+++ b/tsdb/index/internal/file_set.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/estimator"
+	"github.com/influxdata/influxdb/tsdb/index/tsi1"
+)
+
+// File is a mock implementation of a tsi1.File.
+type File struct {
+	Pathf                      func() string
+	Measurementf               func(name []byte) tsi1.MeasurementElem
+	MeasurementIteratorf       func() tsi1.MeasurementIterator
+	HasSeriesf                 func(name []byte, tags models.Tags) (exists, tombstoned bool)
+	Seriesf                    func(name []byte, tags models.Tags) tsi1.SeriesElem
+	SeriesNf                   func() uint64
+	TagKeyf                    func(name, key []byte) tsi1.TagKeyElem
+	TagKeyIteratorf            func(name []byte) tsi1.TagKeyIterator
+	TagValuef                  func(name, key, value []byte) tsi1.TagValueElem
+	TagValueIteratorf          func(name, key []byte) tsi1.TagValueIterator
+	SeriesIteratorf            func() tsi1.SeriesIterator
+	MeasurementSeriesIteratorf func(name []byte) tsi1.SeriesIterator
+	TagKeySeriesIteratorf      func(name, key []byte) tsi1.SeriesIterator
+	TagValueSeriesIteratorf    func(name, key, value []byte) tsi1.SeriesIterator
+	MergeSeriesSketchesf       func(s, t estimator.Sketch) error
+	MergeMeasurementsSketchesf func(s, t estimator.Sketch) error
+	Retainf                    func()
+	Releasef                   func()
+}
+
+func (f *File) Path() string                                  { return f.Pathf() }
+func (f *File) Measurement(name []byte) tsi1.MeasurementElem  { return f.Measurementf(name) }
+func (f *File) MeasurementIterator() tsi1.MeasurementIterator { return f.MeasurementIteratorf() }
+func (f *File) HasSeries(name []byte, tags models.Tags) (exists, tombstoned bool) {
+	return f.HasSeriesf(name, tags)
+}
+func (f *File) Series(name []byte, tags models.Tags) tsi1.SeriesElem { return f.Seriesf(name, tags) }
+func (f *File) SeriesN() uint64                                      { return f.SeriesNf() }
+func (f *File) TagKey(name, key []byte) tsi1.TagKeyElem              { return f.TagKeyf(name, key) }
+func (f *File) TagKeyIterator(name []byte) tsi1.TagKeyIterator       { return f.TagKeyIteratorf(name) }
+func (f *File) TagValue(name, key, value []byte) tsi1.TagValueElem {
+	return f.TagValuef(name, key, value)
+}
+func (f *File) TagValueIterator(name, key []byte) tsi1.TagValueIterator {
+	return f.TagValueIteratorf(name, key)
+}
+func (f *File) SeriesIterator() tsi1.SeriesIterator { return f.SeriesIteratorf() }
+func (f *File) MeasurementSeriesIterator(name []byte) tsi1.SeriesIterator {
+	return f.MeasurementSeriesIteratorf(name)
+}
+func (f *File) TagKeySeriesIterator(name, key []byte) tsi1.SeriesIterator {
+	return f.TagKeySeriesIteratorf(name, key)
+}
+func (f *File) TagValueSeriesIterator(name, key, value []byte) tsi1.SeriesIterator {
+	return f.TagValueSeriesIteratorf(name, key, value)
+}
+func (f *File) MergeSeriesSketches(s, t estimator.Sketch) error { return f.MergeSeriesSketchesf(s, t) }
+func (f *File) MergeMeasurementsSketches(s, t estimator.Sketch) error {
+	return f.MergeMeasurementsSketchesf(s, t)
+}
+func (f *File) Retain()  { f.Retainf() }
+func (f *File) Release() { f.Releasef() }

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -482,20 +482,16 @@ func (fs FileSet) HasSeries(name []byte, tags models.Tags) bool {
 	return false
 }
 
-// FilterNamesTags filters out any series which already exist.
+// FilterNamesTags filters out any series which already exist. It modifies the
+// provided slices of names and tags.
 func (fs FileSet) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
-	n := len(names)
-	newNames := make([][]byte, 0, n)
-	newTagsSlice := make([]models.Tags, 0, n)
-
-	for j := 0; j < n; j++ {
-		if fs.HasSeries(names[j], tagsSlice[j]) {
-			continue
+	newNames, newTagsSlice := names[:0], tagsSlice[:0]
+	for i := 0; i < len(names); i++ {
+		if !fs.HasSeries(names[i], tagsSlice[i]) {
+			newNames = append(newNames, names[i])
+			newTagsSlice = append(newTagsSlice, tagsSlice[i])
 		}
-		newNames = append(newNames, names[j])
-		newTagsSlice = append(newTagsSlice, tagsSlice[j])
 	}
-
 	return newNames, newTagsSlice
 }
 

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -544,13 +544,14 @@ func (f *LogFile) execSeriesEntry(e *LogEntry) {
 	// Generate key & series, if not exists.
 	// TODO(edd) use a pool of buffers?
 	key := AppendSeriesKey(nil, e.Name, e.Tags)
-	serie := mm.series[string(key)]
+	keyStr := string(key)
+	serie := mm.series[keyStr]
 	if serie == nil {
 		serie = &logSerie{name: e.Name, tags: e.Tags, deleted: deleted}
-		mm.series[string(key)] = serie
+		mm.series[keyStr] = serie
 	} else if deleted {
 		serie.deleted = true
-		mm.series[string(key)] = serie
+		mm.series[keyStr] = serie
 	}
 
 	// Save tags.
@@ -558,7 +559,7 @@ func (f *LogFile) execSeriesEntry(e *LogEntry) {
 		ts := mm.createTagSetIfNotExists(t.Key)
 		tv := ts.createTagValueIfNotExists(t.Value)
 
-		tv.series[string(key)] = serie
+		tv.series[keyStr] = serie
 
 		ts.tagValues[string(t.Value)] = tv
 		mm.tagSet[string(t.Key)] = ts


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

This PR contributes toward some of #7945 by reducing allocations.

 - `FilterNamesTags` was accounting for around 4% of allocations (by size). It no longer allocates.
 - `execSeriesEntry` was allocating a bunch with `string(myBuf)` calls.

Not included in this PR (because I already pushed it to `tsi`, is 21e821e5f).

@benbjohnson I added a mock `FileSet` implementation, which may come in handy.