### PR TITLE
Use simple8b.CountBytes to avoid allocations

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -10,7 +10,7 @@ github.com/dgryski/go-bitstream 7d46cd22db7004f0cceb6f7975824b560cf0e486
 github.com/gogo/protobuf a9cd0c35b97daf74d0ebf3514c5254814b2703b4
 github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380
 github.com/influxdata/usage-client 6d3895376368aa52a3a81d2a16e90f0f52371967
-github.com/jwilder/encoding 4dada27c33277820fe35c7ee71ed34fbc9477d00
+github.com/jwilder/encoding 27894731927e49b0a9023f00312be26733744815
 github.com/paulbellamy/ratecounter 5a11f585a31379765c190c033b6ad39956584447
 github.com/peterh/liner 8975875355a81d612fafb9f5a6037bdcc2d9b073
 github.com/rakyll/statik e383bbf6b2ec1a2fb8492dfd152d945fb88919b6

--- a/tsdb/engine/tsm1/timestamp.go
+++ b/tsdb/engine/tsm1/timestamp.go
@@ -390,13 +390,8 @@ func CountTimestamps(b []byte) int {
 		return int(count)
 	case timeCompressedPackedSimple:
 		// First 9 bytes are the starting timestamp and scaling factor, skip over them
-		dec := simple8b.NewDecoder(b[9:])
-		count := 1
-		// Count the deltas
-		for dec.Next() {
-			count++
-		}
-		return count
+		count, _ := simple8b.CountBytes(b[9:])
+		return count + 1 // +1 is for the first uncompressed timestamp, starting timestamep in b[1:9]
 	default:
 		return 0
 	}


### PR DESCRIPTION
This uses a more efficient method to count the number of encoded values.  This avoids creating a `Decoder` and actually decoding all the values to count them and instead counts the values using the compressed form directly.

This should lower memory allocations and CPU usage during compactions to some degree.

Fixes #7979