### PR TITLE
Don't load meta data when using TSI

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -18,6 +18,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/influxdata/influxdb/tsdb/index/inmem"
+
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/estimator"
@@ -475,7 +477,13 @@ func (e *Engine) WithLogger(log zap.Logger) {
 
 // LoadMetadataIndex loads the shard metadata into memory.
 func (e *Engine) LoadMetadataIndex(shardID uint64, index tsdb.Index) error {
+	if index.Type() != inmem.IndexName {
+		// We only need to load meta data for the in memory index.
+		return nil
+	}
+
 	now := time.Now()
+	defer func() { s.logger.Info(fmt.Sprintf("%s database index loaded in %s", s.path, time.Since(now))) }()
 
 	// Save reference to index for iterator creation.
 	e.index = index

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -481,9 +481,7 @@ func (e *Engine) LoadMetadataIndex(shardID uint64, index tsdb.Index) error {
 		// We only need to load meta data for the in memory index.
 		return nil
 	}
-
 	now := time.Now()
-	defer func() { s.logger.Info(fmt.Sprintf("%s database index loaded in %s", s.path, time.Since(now))) }()
 
 	// Save reference to index for iterator creation.
 	e.index = index

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -52,6 +52,8 @@ type Index interface {
 	AssignShard(k string, shardID uint64)
 	UnassignShard(k string, shardID uint64) error
 	RemoveShard(shardID uint64)
+
+	Type() string
 }
 
 // IndexFormat represents the format for an index.

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -28,10 +28,13 @@ import (
 	"github.com/influxdata/influxdb/tsdb"
 )
 
+// IndexName is the name of this index.
+const IndexName = "inmem"
+
 func init() {
 	tsdb.NewInmemIndex = func(name string) (interface{}, error) { return NewIndex(), nil }
 
-	tsdb.RegisterIndex("inmem", func(id uint64, path string, opt tsdb.EngineOptions) tsdb.Index {
+	tsdb.RegisterIndex(IndexName, func(id uint64, path string, opt tsdb.EngineOptions) tsdb.Index {
 		return NewShardIndex(id, path, opt)
 	})
 }
@@ -66,6 +69,7 @@ func NewIndex() *Index {
 	return index
 }
 
+func (i *Index) Type() string      { return IndexName }
 func (i *Index) Open() (err error) { return nil }
 func (i *Index) Close() error      { return nil }
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -286,18 +286,15 @@ func (s *Shard) Open() error {
 			return err
 		}
 
-		// Load metadata index.
-		start := time.Now()
+		// Load metadata index for the inmem index only.
 		if err := e.LoadMetadataIndex(s.id, s.index); err != nil {
 			return err
 		}
+		s.engine = e
 
 		// TODO(benbjohnson):
 		// count := s.index.SeriesShardN(s.id)
 		// atomic.AddInt64(&s.stats.SeriesCreated, int64(count))
-
-		s.engine = e
-		s.logger.Info(fmt.Sprintf("%s database index loaded in %s", s.path, time.Since(start)))
 
 		go s.monitor()
 


### PR DESCRIPTION
Fixes #7978.

On my test instance with 38M series, `tsi` was taking around 10m to start up. With this change it starts up in less than 2 seconds.