### PR TITLE
Fix tag dereferencing panic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#7905](https://github.com/influxdata/influxdb/issues/7905): Fix ORDER BY time DESC with ordering series keys.
 - [#7966](https://github.com/influxdata/influxdb/pull/7966): Prevent a panic when aggregates are used in an inner query with a raw query.
 - [#8001](https://github.com/influxdata/influxdb/issues/8001): Map types correctly when using a regex and one of the measurements is empty.
+- [#8011](https://github.com/influxdata/influxdb/issues/8011): Fix tag dereferencing panic.
 
 ## v1.2.0 [2017-01-24]
 

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -272,7 +272,7 @@ func (d *DatabaseIndex) TagsForSeries(key string) models.Tags {
 	if ss == nil {
 		return nil
 	}
-	return ss.Tags
+	return ss.CloneTags()
 }
 
 // MeasurementsByExpr takes an expression containing only tags and returns a
@@ -1627,6 +1627,13 @@ func (s *Series) ForEachTag(fn func(models.Tag)) {
 	for _, t := range s.Tags {
 		fn(t)
 	}
+}
+
+// CloneTags returns a copy of the series tags under lock.
+func (s *Series) CloneTags() models.Tags {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Tags.Clone()
 }
 
 // Dereference removes references to a byte slice.


### PR DESCRIPTION
## Overview

Clones series tags under lock during var ref iterator creation.


## TODO
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
