### PR TITLE
Validate points on input

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -356,6 +356,9 @@ func (c *client) Write(bp BatchPoints) error {
 	var b bytes.Buffer
 
 	for _, p := range bp.Points() {
+		if p == nil {
+			continue
+		}
 		if _, err := b.WriteString(p.pt.PrecisionString(bp.Precision())); err != nil {
 			return err
 		}


### PR DESCRIPTION
Validate points when using Client API.   If input value is +Inf or -Inf influxdb server side will give an incorrect error (invalid boolean, or invalid number).

This PR only validates on Client side.  Server side would need a different set of changes.

Also make sure to skip any "nil" points when the client attempts a Write.

Did not update CHANGELOG.md as PR could be considered trivial.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)