### PR TITLE
Remove Tags.shouldCopy, replace with forceCopy on series creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - [#7877](https://github.com/influxdata/influxdb/issues/7877): Fix mapping of types when the measurement uses a regex
 - [#7888](https://github.com/influxdata/influxdb/pull/7888): Expand query dimensions from the subquery.
 - [#7910](https://github.com/influxdata/influxdb/issues/7910): Fix EvalType when a parenthesis expression is used.
-- [#7929](https://github.com/influxdata/influxdb/issues/7929): Fix series tag iteration segfault. (#7922)
 - [#7906](https://github.com/influxdata/influxdb/issues/7906): Anchors not working as expected with case-insensitive regex
 - [#7895](https://github.com/influxdata/influxdb/issues/7895): Fix incorrect math when aggregates that emit different times are used.
 - [#7946](https://github.com/influxdata/influxdb/issues/7946): Fix authentication when subqueries are present.
@@ -13,7 +12,6 @@
 - [#7905](https://github.com/influxdata/influxdb/issues/7905): Fix ORDER BY time DESC with ordering series keys.
 - [#7966](https://github.com/influxdata/influxdb/pull/7966): Prevent a panic when aggregates are used in an inner query with a raw query.
 - [#8001](https://github.com/influxdata/influxdb/issues/8001): Map types correctly when using a regex and one of the measurements is empty.
-- [#8011](https://github.com/influxdata/influxdb/issues/8011): Fix tag dereferencing panic.
 
 ## v1.2.0 [2017-01-24]
 
@@ -44,7 +42,6 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 
 ### Bugfixes
 
-- [#7832](https://github.com/influxdata/influxdb/pull/7832): Fix memory leak when writing new series over HTTP
 - [#7786](https://github.com/influxdata/influxdb/pull/7786): Fix potential race condition in correctness of tsm1_cache memBytes statistic.
 - [#7784](https://github.com/influxdata/influxdb/pull/7784): Fix broken error return on meta client's UpdateUser and DropContinuousQuery methods.
 - [#7741](https://github.com/influxdata/influxdb/pull/7741): Fix string quoting and significantly improve performance of `influx_inspect export`.
@@ -66,6 +63,20 @@ The stress tool `influx_stress` will be removed in a subsequent release. We reco
 - [#7838](https://github.com/influxdata/influxdb/issues/7838): Ensure Subscriber service can be disabled.
 - [#7845](https://github.com/influxdata/influxdb/issues/7845): Fix race in storage engine.
 - [#7814](https://github.com/influxdata/influxdb/issues/7814): InfluxDB should do a partial write on mismatched type errors.
+
+## v1.1.3 [2017-02-17]
+
+### Bugfixes
+
+- [#8027](https://github.com/influxdata/influxdb/pull/8027): Remove Tags.shouldCopy, replace with forceCopy on series creation.
+
+## v1.1.2 [2017-02-16]
+
+### Bugfixes
+
+- [#7832](https://github.com/influxdata/influxdb/pull/7832): Fix memory leak when writing new series over HTTP
+- [#7929](https://github.com/influxdata/influxdb/issues/7929): Fix series tag iteration segfault. (#7922)
+- [#8011](https://github.com/influxdata/influxdb/issues/8011): Fix tag dereferencing panic.
 
 ## v1.1.1 [2016-12-06]
 

--- a/models/points.go
+++ b/models/points.go
@@ -1323,11 +1323,6 @@ func (p *point) Tags() Tags {
 		return p.cachedTags
 	}
 	p.cachedTags = parseTags(p.key)
-
-	for i := range p.cachedTags {
-		p.cachedTags[i].shouldCopy = true
-	}
-
 	return p.cachedTags
 }
 
@@ -1626,9 +1621,6 @@ func (p *point) Split(size int) []Point {
 type Tag struct {
 	Key   []byte
 	Value []byte
-
-	// shouldCopy returns whether or not a tag should be copied when Clone-ing
-	shouldCopy bool
 }
 
 // Clone returns a shallow copy of Tag.
@@ -1636,10 +1628,6 @@ type Tag struct {
 // Tags associated with a Point created by ParsePointsWithPrecision will hold references to the byte slice that was parsed.
 // Use Clone to create a Tag with new byte slices that do not refer to the argument to ParsePointsWithPrecision.
 func (t Tag) Clone() Tag {
-	if !t.shouldCopy {
-		return t
-	}
-
 	other := Tag{
 		Key:   make([]byte, len(t.Key)),
 		Value: make([]byte, len(t.Value)),
@@ -1674,15 +1662,6 @@ func NewTags(m map[string]string) Tags {
 func (a Tags) Clone() Tags {
 	if len(a) == 0 {
 		return nil
-	}
-
-	needsClone := false
-	for i := 0; i < len(a) && !needsClone; i++ {
-		needsClone = a[i].shouldCopy
-	}
-
-	if !needsClone {
-		return a
 	}
 
 	others := make(Tags, len(a))

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -652,7 +652,7 @@ func (e *Engine) addToIndexFromKey(shardID uint64, key []byte, fieldType influxq
 	_, tags, _ := models.ParseKey(seriesKey)
 
 	s := tsdb.NewSeries(string(seriesKey), tags)
-	index.CreateSeriesIndexIfNotExists(measurement, s)
+	index.CreateSeriesIndexIfNotExists(measurement, s, false)
 	s.AssignShard(shardID)
 
 	return nil

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -45,8 +45,8 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	// Verify index is correct.
 	if m := index.Measurement("cpu"); m == nil {
 		t.Fatal("measurement not found")
-	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, models.NewTags(map[string]string{"host": "A"})) {
-		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
+	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags(), models.NewTags(map[string]string{"host": "A"})) {
+		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags())
 	}
 
 	// write the snapshot, ensure we can close and load index from TSM
@@ -68,8 +68,8 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	// Verify index is correct.
 	if m := index.Measurement("cpu"); m == nil {
 		t.Fatal("measurement not found")
-	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, models.NewTags(map[string]string{"host": "A"})) {
-		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
+	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags(), models.NewTags(map[string]string{"host": "A"})) {
+		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags())
 	}
 
 	// Write a new point and ensure we can close and load index from TSM and WAL
@@ -93,10 +93,10 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 	// Verify index is correct.
 	if m := index.Measurement("cpu"); m == nil {
 		t.Fatal("measurement not found")
-	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags, models.NewTags(map[string]string{"host": "A"})) {
-		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
-	} else if s := m.SeriesByID(2); s.Key != "cpu,host=B" || !reflect.DeepEqual(s.Tags, models.NewTags(map[string]string{"host": "B"})) {
-		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags)
+	} else if s := m.SeriesByID(1); s.Key != "cpu,host=A" || !reflect.DeepEqual(s.Tags(), models.NewTags(map[string]string{"host": "A"})) {
+		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags())
+	} else if s := m.SeriesByID(2); s.Key != "cpu,host=B" || !reflect.DeepEqual(s.Tags(), models.NewTags(map[string]string{"host": "B"})) {
+		t.Fatalf("unexpected series: %q / %#v", s.Key, s.Tags())
 	}
 }
 
@@ -223,7 +223,7 @@ func TestEngine_CreateIterator_Cache_Ascending(t *testing.T) {
 
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
+	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})), false)
 	si.AssignShard(1)
 
 	if err := e.WritePointsString(
@@ -277,7 +277,7 @@ func TestEngine_CreateIterator_Cache_Descending(t *testing.T) {
 
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
+	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})), false)
 	si.AssignShard(1)
 
 	if err := e.WritePointsString(
@@ -331,7 +331,7 @@ func TestEngine_CreateIterator_TSM_Ascending(t *testing.T) {
 
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
+	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})), false)
 	si.AssignShard(1)
 
 	if err := e.WritePointsString(
@@ -386,7 +386,7 @@ func TestEngine_CreateIterator_TSM_Descending(t *testing.T) {
 
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
+	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})), false)
 	si.AssignShard(1)
 
 	if err := e.WritePointsString(
@@ -442,7 +442,7 @@ func TestEngine_CreateIterator_Aux(t *testing.T) {
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("F", influxql.Float, false)
-	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
+	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})), false)
 	si.AssignShard(1)
 
 	if err := e.WritePointsString(
@@ -503,7 +503,7 @@ func TestEngine_CreateIterator_Condition(t *testing.T) {
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("X", influxql.Float, false)
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("Y", influxql.Float, false)
-	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
+	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})), false)
 	si.AssignShard(1)
 
 	if err := e.WritePointsString(
@@ -893,7 +893,7 @@ func MustInitBenchmarkEngine(pointN int) *Engine {
 	// Initialize metadata.
 	e.Index().CreateMeasurementIndexIfNotExists("cpu")
 	e.MeasurementFields("cpu").CreateFieldIfNotExists("value", influxql.Float, false)
-	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})))
+	si := e.Index().CreateSeriesIndexIfNotExists("cpu", tsdb.NewSeries("cpu,host=A", models.NewTags(map[string]string{"host": "A"})), false)
 	si.AssignShard(1)
 
 	// Generate time ascending points with jitterred time & value.

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -146,7 +146,7 @@ func (d *DatabaseIndex) SeriesShardN(shardID uint64) int {
 }
 
 // CreateSeriesIndexIfNotExists adds the series for the given measurement to the index and sets its ID or returns the existing series object.
-func (d *DatabaseIndex) CreateSeriesIndexIfNotExists(measurementName string, series *Series) *Series {
+func (d *DatabaseIndex) CreateSeriesIndexIfNotExists(measurementName string, series *Series, forceCopy bool) *Series {
 	d.mu.RLock()
 	// if there is a measurement for this id, it's already been added
 	ss := d.series[series.Key]
@@ -174,7 +174,9 @@ func (d *DatabaseIndex) CreateSeriesIndexIfNotExists(measurementName string, ser
 	series.measurement = m
 
 	// Clone the tags to dereference any short-term buffers
-	series.Tags = series.Tags.Clone()
+	if forceCopy {
+		series.CopyTags()
+	}
 	d.series[series.Key] = series
 
 	m.AddSeries(series)
@@ -272,7 +274,7 @@ func (d *DatabaseIndex) TagsForSeries(key string) models.Tags {
 	if ss == nil {
 		return nil
 	}
-	return ss.CloneTags()
+	return ss.Tags()
 }
 
 // MeasurementsByExpr takes an expression containing only tags and returns a
@@ -709,7 +711,7 @@ func (m *Measurement) AddSeries(s *Series) bool {
 	}
 
 	// add this series id to the tag index on the measurement
-	for _, t := range s.Tags {
+	s.ForEachTag(func(t models.Tag) {
 		valueMap := m.seriesByTagKeyValue[string(t.Key)]
 		if valueMap == nil {
 			valueMap = make(map[string]SeriesIDs)
@@ -724,7 +726,7 @@ func (m *Measurement) AddSeries(s *Series) bool {
 			sort.Sort(ids)
 		}
 		valueMap[string(t.Value)] = ids
-	}
+	})
 
 	return true
 }
@@ -745,7 +747,7 @@ func (m *Measurement) DropSeries(series *Series) {
 
 	// remove this series id from the tag index on the measurement
 	// s.seriesByTagKeyValue is defined as map[string]map[string]SeriesIDs
-	for _, t := range series.Tags {
+	series.ForEachTag(func(t models.Tag) {
 		values := m.seriesByTagKeyValue[string(t.Key)][string(t.Value)]
 		ids := filter(values, seriesID)
 		// Check to see if we have any ids, if not, remove the key
@@ -759,7 +761,7 @@ func (m *Measurement) DropSeries(series *Series) {
 		if len(m.seriesByTagKeyValue[string(t.Key)]) == 0 {
 			delete(m.seriesByTagKeyValue, string(t.Key))
 		}
-	}
+	})
 
 	return
 }
@@ -804,8 +806,9 @@ func (m *Measurement) TagSets(shardID uint64, dimensions []string, condition inf
 
 		// Build the TagSet for this series.
 		for _, dim := range dimensions {
-			tags[dim] = s.Tags.GetString(dim)
+			tags[dim] = s.GetTagString(dim)
 		}
+
 		// Convert the TagSet to a string, so it can be added to a map allowing TagSets to be handled
 		// as a set.
 		tagsAsKey := MarshalTags(tags)
@@ -1563,7 +1566,7 @@ func (a Measurements) union(other Measurements) Measurements {
 type Series struct {
 	mu          sync.RWMutex
 	Key         string
-	Tags        models.Tags
+	tags        models.Tags
 	ID          uint64
 	measurement *Measurement
 	shardIDs    []uint64 // shards that have this series defined
@@ -1573,7 +1576,7 @@ type Series struct {
 func NewSeries(key string, tags models.Tags) *Series {
 	return &Series{
 		Key:  key,
-		Tags: tags,
+		tags: tags,
 	}
 }
 
@@ -1624,16 +1627,30 @@ func (s *Series) ShardN() int {
 func (s *Series) ForEachTag(fn func(models.Tag)) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	for _, t := range s.Tags {
+	for _, t := range s.tags {
 		fn(t)
 	}
 }
 
-// CloneTags returns a copy of the series tags under lock.
-func (s *Series) CloneTags() models.Tags {
+// Tags returns a copy of the tags under lock.
+func (s *Series) Tags() models.Tags {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.Tags.Clone()
+	return s.tags.Clone()
+}
+
+// CopyTags clones the tags on the series in-place,
+func (s *Series) CopyTags() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tags = s.tags.Clone()
+}
+
+// GetTagString returns a tag value under lock.
+func (s *Series) GetTagString(key string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.tags.GetString(key)
 }
 
 // Dereference removes references to a byte slice.
@@ -1643,9 +1660,9 @@ func (s *Series) Dereference(b []byte) {
 	min := uintptr(unsafe.Pointer(&b[0]))
 	max := min + uintptr(len(b))
 
-	for i := range s.Tags {
-		deref(&s.Tags[i].Key, min, max)
-		deref(&s.Tags[i].Value, min, max)
+	for i := range s.tags {
+		deref(&s.tags[i].Key, min, max)
+		deref(&s.tags[i].Value, min, max)
 	}
 
 	s.mu.Unlock()
@@ -1673,7 +1690,7 @@ func (s *Series) MarshalBinary() ([]byte, error) {
 
 	var pb internal.Series
 	pb.Key = &s.Key
-	for _, t := range s.Tags {
+	for _, t := range s.tags {
 		pb.Tags = append(pb.Tags, &internal.Tag{Key: proto.String(string(t.Key)), Value: proto.String(string(t.Value))})
 	}
 	return proto.Marshal(&pb)
@@ -1689,9 +1706,9 @@ func (s *Series) UnmarshalBinary(buf []byte) error {
 		return err
 	}
 	s.Key = pb.GetKey()
-	s.Tags = make(models.Tags, len(pb.Tags))
+	s.tags = make(models.Tags, len(pb.Tags))
 	for i, t := range pb.Tags {
-		s.Tags[i] = models.Tag{Key: []byte(t.GetKey()), Value: []byte(t.GetValue())}
+		s.tags[i] = models.Tag{Key: []byte(t.GetKey()), Value: []byte(t.GetValue())}
 	}
 	return nil
 }
@@ -2015,7 +2032,7 @@ func (m *Measurement) tagValuesByKeyAndSeriesID(tagKeys []string, ids SeriesIDs)
 		// Iterate the tag keys we're interested in and collect values
 		// from this series, if they exist.
 		for _, tagKey := range tagKeys {
-			if tagVal := s.Tags.GetString(tagKey); tagVal != "" {
+			if tagVal := s.GetTagString(tagKey); tagVal != "" {
 				if _, ok = tagValues[tagKey]; !ok {
 					tagValues[tagKey] = newStringSet()
 				}

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -255,7 +255,7 @@ func benchmarkCreateSeriesIndex(b *testing.B, series []*TestSeries) {
 	for n := 0; n < b.N; n++ {
 		idx := idxs[n]
 		for _, s := range series {
-			idx.CreateSeriesIndexIfNotExists(s.Measurement, s.Series)
+			idx.CreateSeriesIndexIfNotExists(s.Measurement, s.Series, false)
 		}
 	}
 }

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -585,7 +585,7 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]models.Point, 
 				continue
 			}
 
-			ss = s.index.CreateSeriesIndexIfNotExists(p.Name(), NewSeries(string(p.Key()), tags))
+			ss = s.index.CreateSeriesIndexIfNotExists(p.Name(), NewSeries(string(p.Key()), tags), true)
 			atomic.AddInt64(&s.stats.SeriesCreated, 1)
 		}
 
@@ -1481,7 +1481,7 @@ func (itr *tagValuesIterator) Next() (*influxql.FloatPoint, error) {
 		}
 
 		key := itr.buf.keys[0]
-		value := itr.buf.s.Tags.GetString(key)
+		value := itr.buf.s.GetTagString(key)
 		if value == "" {
 			itr.buf.keys = itr.buf.keys[1:]
 			continue

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -70,7 +70,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 			t.Fatalf("series wasn't in index")
 		}
 
-		seriesTags := index.Series(string(pt.Key())).Tags
+		seriesTags := index.Series(string(pt.Key())).Tags()
 		if len(seriesTags) != len(pt.Tags()) || pt.Tags().GetString("host") != seriesTags.GetString("host") {
 			t.Fatalf("tags weren't properly saved to series index: %v, %v", pt.Tags(), seriesTags)
 		}
@@ -302,8 +302,8 @@ func TestWriteTimeField(t *testing.T) {
 	series := index.Series(string(key))
 	if series == nil {
 		t.Fatal("expected series")
-	} else if len(series.Tags) != 0 {
-		t.Fatalf("unexpected number of tags: got=%v exp=%v", len(series.Tags), 0)
+	} else if len(series.Tags()) != 0 {
+		t.Fatalf("unexpected number of tags: got=%v exp=%v", len(series.Tags()), 0)
 	}
 }
 
@@ -350,7 +350,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 	if index.SeriesN() != 1 {
 		t.Fatalf("series wasn't in index")
 	}
-	seriesTags := index.Series(string(pt.Key())).Tags
+	seriesTags := index.Series(string(pt.Key())).Tags()
 	if len(seriesTags) != len(pt.Tags()) || pt.Tags().GetString("host") != seriesTags.GetString("host") {
 		t.Fatalf("tags weren't properly saved to series index: %v, %v", pt.Tags(), seriesTags)
 	}
@@ -877,7 +877,7 @@ func benchmarkWritePoints(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt int) {
 	points := []models.Point{}
 	for _, s := range series {
 		for val := 0.0; val < float64(pntCnt); val++ {
-			p := models.MustNewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
+			p := models.MustNewPoint(s.Measurement, s.Series.Tags(), map[string]interface{}{"value": val}, time.Now())
 			points = append(points, p)
 		}
 	}
@@ -918,7 +918,7 @@ func benchmarkWritePointsExistingSeries(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt
 	points := []models.Point{}
 	for _, s := range series {
 		for val := 0.0; val < float64(pntCnt); val++ {
-			p := models.MustNewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
+			p := models.MustNewPoint(s.Measurement, s.Series.Tags(), map[string]interface{}{"value": val}, time.Now())
 			points = append(points, p)
 		}
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -374,7 +374,7 @@ func benchmarkStoreOpen(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt, shardCnt int) 
 		points := []models.Point{}
 		for _, s := range series {
 			for val := 0.0; val < float64(pntCnt); val++ {
-				p := models.MustNewPoint(s.Measurement, s.Series.Tags, map[string]interface{}{"value": val}, time.Now())
+				p := models.MustNewPoint(s.Measurement, s.Series.Tags(), map[string]interface{}{"value": val}, time.Now())
 				points = append(points, p)
 			}
 		}


### PR DESCRIPTION
Previously, tags had a `shouldCopy` flag to indicate if those tags
referenced an underlying buffer and should be copied to allow GC.
Unfortunately, this prevented tags from being copied that were
created and referenced the mmap which caused segfaults.

This change removes the `shouldCopy` flag and replaces it with a
`forceCopy` argument in `CreateSeriesIfNotExists()`. This allows
the write path to indicate that tags must be cloned on insert.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
