### PR TITLE
Implement both single and multiline comments in influxql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#7553](https://github.com/influxdata/influxdb/issues/7553): Add modulo operator to the query language.
 - [#7856](https://github.com/influxdata/influxdb/issues/7856): Failed points during an import now result in a non-zero exit code.
 - [#7821](https://github.com/influxdata/influxdb/issues/7821): Expose some configuration settings via SHOW DIAGNOSTICS
+- [#8025](https://github.com/influxdata/influxdb/issues/8025): Support single and multiline comments in InfluxQL.
 
 ## v1.2.2 [2017-03-14]
 

--- a/influxql/README.md
+++ b/influxql/README.md
@@ -36,6 +36,27 @@ Notation operators in order of increasing precedence:
 {}  repetition (0 to n times)
 ```
 
+## Comments
+
+Both single and multiline comments are supported. A comment is treated
+the same as whitespace by the parser.
+
+```
+-- single line comment
+/*
+    multiline comment
+*/
+```
+
+Single line comments will skip all text until the scanner hits a
+newline. Multiline comments will skip all text until the end comment
+marker is hit. Nested multiline comments are not supported so the
+following does not work:
+
+```
+/* /* this does not work */ */
+```
+
 ## Query representation
 
 ### Characters

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2686,13 +2686,15 @@ func (p *Parser) parseResample() (time.Duration, time.Duration, error) {
 // scan returns the next token from the underlying scanner.
 func (p *Parser) scan() (tok Token, pos Pos, lit string) { return p.s.Scan() }
 
-// scanIgnoreWhitespace scans the next non-whitespace token.
+// scanIgnoreWhitespace scans the next non-whitespace and non-comment token.
 func (p *Parser) scanIgnoreWhitespace() (tok Token, pos Pos, lit string) {
-	tok, pos, lit = p.scan()
-	if tok == WS {
+	for {
 		tok, pos, lit = p.scan()
+		if tok == WS || tok == COMMENT {
+			continue
+		}
+		return
 	}
-	return
 }
 
 // consumeWhitespace scans the next token if it's whitespace.

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -13,6 +13,7 @@ const (
 	ILLEGAL Token = iota
 	EOF
 	WS
+	COMMENT
 
 	literalBeg
 	// IDENT and the following are InfluxQL literal tokens.


### PR DESCRIPTION
A single line comment will read until the end of a line and is started
with `--` (just like SQL). A multiline comment is with `/* */`. You
cannot nest multiline comments.

Fixes #8025.

- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated
- [x] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [x] Provide example syntax
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted influxdata/docs.influxdata.com#1058