### PR TITLE
Treat non-reserved measurement names with underscores as normal measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#7968](https://github.com/influxdata/influxdb/issues/7968): Properly select a tag within a subquery.
 - [#8028](https://github.com/influxdata/influxdb/issues/8028): Fix panic in collectd when configured to read types DB from directory.
 - [#7880](https://github.com/influxdata/influxdb/issues/7880): Dividing aggregate functions with different outputs doesn't panic.
+- [#8044](https://github.com/influxdata/influxdb/issues/8044): Treat non-reserved measurement names with underscores as normal measurements.
 
 ## v1.2.0 [2017-01-24]
 


### PR DESCRIPTION
A measurement name that begins with an underscore and does not conflict
with one of the reserved measurement names will now be passed untouched
to the underlying shards rather than being intercepted as an empty
measurement.

A user still shouldn't rely on measurements that begin with underscores
to always be accessible, but this will prevent the most common use case
from causing unexpected behavior since we will very rarely, if ever, add
additional system sources.

Fixed #8044.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated