### PR TITLE
Refactor the subquery code and fix outer condition queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8266](https://github.com/influxdata/influxdb/issues/8266): top() and bottom() now returns the time for every point.
 - [#8315](https://github.com/influxdata/influxdb/issues/8315): Remove default upper time bound on DELETE queries.
 - [#8066](https://github.com/influxdata/influxdb/issues/8066): Fix LIMIT and OFFSET for certain aggregate queries.
+- [#8045](https://github.com/influxdata/influxdb/issues/8045): Refactor the subquery code and fix outer condition queries.
 
 ## v1.2.3 [unreleased]
 

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -1503,6 +1503,70 @@ type {{$k.name}}DedupeIterator struct {
 	m     map[string]struct{} // lookup of points already sent
 }
 
+type {{$k.name}}IteratorMapper struct {
+	e         *Emitter
+	buf       []interface{}
+	driver    IteratorMap   // which iterator to use for the primary value, can be nil
+	fields    []IteratorMap // which iterator to use for an aux field
+	point     {{$k.Name}}Point
+}
+
+func new{{$k.Name}}IteratorMapper(itrs []Iterator, driver IteratorMap, fields []IteratorMap, opt IteratorOptions) *{{$k.name}}IteratorMapper {
+	e := NewEmitter(itrs, opt.Ascending, 0)
+	e.OmitTime = true
+	return &{{$k.name}}IteratorMapper{
+		e:         e,
+		buf:       make([]interface{}, len(itrs)),
+		driver:    driver,
+		fields:    fields,
+		point:  {{$k.Name}}Point{
+			Aux: make([]interface{}, len(fields)),
+		},
+	}
+}
+
+func (itr *{{$k.name}}IteratorMapper) Next() (*{{$k.Name}}Point, error) {
+	t, name, tags, err := itr.e.loadBuf()
+	if err != nil || t == ZeroTime {
+		return nil, err
+	}
+	itr.point.Time = t
+	itr.point.Name = name
+	itr.point.Tags = tags
+
+	itr.e.readInto(t, name, tags, itr.buf)
+	if itr.driver != nil {
+	if v := itr.driver.Value(tags, itr.buf); v != nil {
+			if v, ok := v.({{$k.Type}}); ok {
+				itr.point.Value = v
+				itr.point.Nil = false
+			} else {
+				itr.point.Value = {{$k.Nil}}
+				itr.point.Nil = true
+			}
+		} else {
+			itr.point.Value = {{$k.Nil}}
+			itr.point.Nil = true
+		}
+	}
+	for i, f := range itr.fields {
+		itr.point.Aux[i] = f.Value(tags, itr.buf)
+	}
+	return &itr.point, nil
+}
+
+func (itr *{{$k.name}}IteratorMapper) Stats() IteratorStats {
+	stats := IteratorStats{}
+	for _, itr := range itr.e.itrs {
+		stats.Add(itr.Stats())
+	}
+	return stats
+}
+
+func (itr *{{$k.name}}IteratorMapper) Close() error {
+	return itr.e.Close()
+}
+
 type {{$k.name}}FilterIterator struct {
 	input {{$k.Name}}Iterator
 	cond  Expr

--- a/influxql/iterator_mapper_test.go
+++ b/influxql/iterator_mapper_test.go
@@ -31,7 +31,7 @@ func TestIteratorMapper(t *testing.T) {
 			{Val: "val2", Type: influxql.String},
 		},
 	}
-	itr := influxql.NewIteratorMapper(inputs, []influxql.IteratorMap{
+	itr := influxql.NewIteratorMapper(inputs, nil, []influxql.IteratorMap{
 		influxql.FieldMap(0),
 		influxql.FieldMap(1),
 		influxql.TagMap("host"),

--- a/influxql/subquery.go
+++ b/influxql/subquery.go
@@ -1,0 +1,129 @@
+package influxql
+
+type subqueryBuilder struct {
+	ic   IteratorCreator
+	stmt *SelectStatement
+}
+
+// buildAuxIterator constructs an auxiliary Iterator from a subquery.
+func (b *subqueryBuilder) buildAuxIterator(opt IteratorOptions) (Iterator, error) {
+	// Retrieve a list of fields needed for conditions.
+	auxFields := opt.Aux
+	conds := ExprNames(opt.Condition)
+	if len(conds) > 0 {
+		auxFields = make([]VarRef, len(opt.Aux)+len(conds))
+		copy(auxFields, opt.Aux)
+		copy(auxFields[len(opt.Aux):], conds)
+	}
+
+	// Map the desired auxiliary fields from the substatement.
+	indexes := b.mapAuxFields(auxFields)
+	subOpt, err := newIteratorOptionsSubstatement(b.stmt, opt)
+	if err != nil {
+		return nil, err
+	}
+	subOpt.Aux = auxFields
+
+	itrs, err := buildIterators(b.stmt, b.ic, subOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct the iterators for the subquery.
+	input := NewIteratorMapper(itrs, nil, indexes, subOpt)
+	// If there is a condition, filter it now.
+	if opt.Condition != nil {
+		input = NewFilterIterator(input, opt.Condition, subOpt)
+	}
+	return input, nil
+}
+
+func (b *subqueryBuilder) mapAuxFields(auxFields []VarRef) []IteratorMap {
+	indexes := make([]IteratorMap, len(auxFields))
+	for i, name := range auxFields {
+		m := b.mapAuxField(&name)
+		if m == nil {
+			// If this field doesn't map to anything, use the NullMap so it
+			// shows up as null.
+			m = NullMap{}
+		}
+		indexes[i] = m
+	}
+	return indexes
+}
+
+func (b *subqueryBuilder) mapAuxField(name *VarRef) IteratorMap {
+	offset := 0
+	for i, f := range b.stmt.Fields {
+		if f.Name() == name.Val {
+			return FieldMap(i + offset)
+		} else if call, ok := f.Expr.(*Call); ok && (call.Name == "top" || call.Name == "bottom") {
+			// We may match one of the arguments in "top" or "bottom".
+			if len(call.Args) > 2 {
+				for j, arg := range call.Args[1 : len(call.Args)-1] {
+					if arg, ok := arg.(*VarRef); ok && arg.Val == name.Val {
+						return FieldMap(i + j + 1)
+					}
+				}
+				// Increment the offset so we have the correct index for later fields.
+				offset += len(call.Args) - 2
+			}
+		}
+	}
+
+	// Unable to find this in the list of fields.
+	// Look within the dimensions and create a field if we find it.
+	for _, d := range b.stmt.Dimensions {
+		if d, ok := d.Expr.(*VarRef); ok && name.Val == d.Val {
+			return TagMap(d.Val)
+		}
+	}
+
+	// Unable to find any matches.
+	return nil
+}
+
+func (b *subqueryBuilder) buildVarRefIterator(expr *VarRef, opt IteratorOptions) (Iterator, error) {
+	// Look for the field or tag that is driving this query.
+	driver := b.mapAuxField(expr)
+	if driver == nil {
+		// Exit immediately if there is no driver. If there is no driver, there
+		// are no results. Period.
+		return nil, nil
+	}
+
+	// Determine necessary auxiliary fields for this query.
+	auxFields := opt.Aux
+	conds := ExprNames(opt.Condition)
+	if len(conds) > 0 && len(opt.Aux) > 0 {
+		// Combine the auxiliary fields requested with the ones in the condition.
+		auxFields = make([]VarRef, len(opt.Aux)+len(conds))
+		copy(auxFields, opt.Aux)
+		copy(auxFields[len(opt.Aux):], conds)
+	} else if len(conds) > 0 {
+		// Set the auxiliary fields to what is in the condition since we have
+		// requested none in the query itself.
+		auxFields = conds
+	}
+
+	// Map the auxiliary fields to their index in the subquery.
+	indexes := b.mapAuxFields(auxFields)
+	subOpt, err := newIteratorOptionsSubstatement(b.stmt, opt)
+	if err != nil {
+		return nil, err
+	}
+	subOpt.Aux = auxFields
+
+	itrs, err := buildIterators(b.stmt, b.ic, subOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct the iterators for the subquery.
+	input := NewIteratorMapper(itrs, driver, indexes, subOpt)
+	// If there is a condition, filter it now.
+	if opt.Condition != nil {
+		input = NewFilterIterator(input, opt.Condition, subOpt)
+	}
+	return input, nil
+}

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -5011,7 +5011,7 @@ func TestServer_Query_Subqueries(t *testing.T) {
 		&Query{
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT host FROM (SELECT mean(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
-			exp:     `{"results":[{"statement_id":0}]}`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host"],"values":[["2000-01-01T00:00:00Z","server01"],["2000-01-01T00:00:00Z","server02"]]}]}]}`,
 		},
 		&Query{
 			params:  url.Values{"db": []string{"db0"}},
@@ -5067,6 +5067,21 @@ func TestServer_Query_Subqueries(t *testing.T) {
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT value FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND value > 0`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","value"],"values":[["2000-01-01T00:00:00Z",40]]}]}]}`,
+		},
+		&Query{
+			params:  url.Values{"db": []string{"db0"}},
+			command: `SELECT max FROM (SELECT max(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND host = 'server01'`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","max"],"values":[["2000-01-01T00:00:00Z",70]]}]}]}`,
+		},
+		&Query{
+			params:  url.Values{"db": []string{"db0"}},
+			command: `SELECT mean(value) FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND value > 0`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",40]]}]}]}`,
+		},
+		&Query{
+			params:  url.Values{"db": []string{"db0"}},
+			command: `SELECT mean(value) FROM (SELECT max(usage_user), usage_user - usage_system AS value FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' AND host =~ /server/`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","mean"],"values":[["2000-01-01T00:00:00Z",-2]]}]}]}`,
 		},
 	}...)
 


### PR DESCRIPTION
This change refactors the subquery code into a separate builder class to
help allow for more reuse and make the functions smaller and easier to
read.

The previous function that handled most of the code was too big and
impossible to reason through.

This also goes and replaces the complicated logic of aggregates that had
a subquery source with the simpler IteratorMapper. I think the overhead
from the IteratorMapper will be more, but I also believe that the actual
code is simpler and more robust to produce more accurate answers. It
might be a future project to optimize that section of code, but I don't
have any actual numbers for the efficiency of one method and I believe
accuracy and code clarity may be more important at the moment since I am
otherwise incapable of reading my own code.

Fixes #8045.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated