### PR TITLE
Fix race in WALEntry.Encode and Values.Deduplicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [#8078](https://github.com/influxdata/influxdb/issues/8078): Map types correctly when selecting a field with multiple measurements where one of the measurements is empty.
 - [#8080](https://github.com/influxdata/influxdb/issues/8080): Point.UnmarshalBinary() bounds check
 - [#8085](https://github.com/influxdata/influxdb/issues/8085): panic: interface conversion: tsm1.Value is tsm1.IntegerValue, not tsm1.FloatValue.
-
+- [#8095](https://github.com/influxdata/influxdb/pull/8095): Fix race in WALEntry.Encode and Values.Deduplicate
 
 ## v1.2.0 [2017-01-24]
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -53,12 +53,12 @@ func newEntryValues(values []Value, hint int) (*entry, error) {
 	}
 
 	e := &entry{}
-	if len(values) >= hint {
-		e.values = values
+	if len(values) > hint {
+		e.values = make(Values, 0, len(values))
 	} else {
 		e.values = make(Values, 0, hint)
-		e.values = append(e.values, values...)
 	}
+	e.values = append(e.values, values...)
 
 	// No values, don't check types and ordering
 	if len(values) == 0 {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -816,11 +816,15 @@ func (e *Engine) DeleteSeriesRange(seriesKeys []string, min, max int64) error {
 
 // DeleteMeasurement deletes a measurement and all related series.
 func (e *Engine) DeleteMeasurement(name string, seriesKeys []string) error {
+	if err := e.DeleteSeries(seriesKeys); err != nil {
+		return err
+	}
+
 	e.fieldsMu.Lock()
 	delete(e.measurementFields, name)
 	e.fieldsMu.Unlock()
 
-	return e.DeleteSeries(seriesKeys)
+	return nil
 }
 
 // SeriesCount returns the number of series buckets on the shard.

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -437,6 +437,152 @@ func TestShard_WritePoints_FieldConflictConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	tmpDir, _ := ioutil.TempDir("", "shard_test")
+	defer os.RemoveAll(tmpDir)
+	tmpShard := path.Join(tmpDir, "shard")
+	tmpWal := path.Join(tmpDir, "wal")
+
+	index := tsdb.NewDatabaseIndex("db")
+	opts := tsdb.NewEngineOptions()
+	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
+
+	sh := tsdb.NewShard(1, index, tmpShard, tmpWal, opts)
+	if err := sh.Open(); err != nil {
+		t.Fatalf("error opening shard: %s", err.Error())
+	}
+	defer sh.Close()
+
+	// Spin up two goroutines that write points with different field types in reverse
+	// order concurrently.  After writing them, query them back.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		// Write 250 floats and then ints to the same field
+		points := make([]models.Point, 0, 500)
+		for i := 0; i < cap(points); i++ {
+			if i < 250 {
+				points = append(points, models.MustNewPoint(
+					"cpu",
+					models.NewTags(map[string]string{"host": "server"}),
+					map[string]interface{}{"value": 1.0},
+					time.Unix(int64(i), 0),
+				))
+			} else {
+				points = append(points, models.MustNewPoint(
+					"cpu",
+					models.NewTags(map[string]string{"host": "server"}),
+					map[string]interface{}{"value": int64(1)},
+					time.Unix(int64(i), 0),
+				))
+			}
+		}
+
+		for i := 0; i < 500; i++ {
+			if err := sh.DeleteMeasurement("cpu", []string{"cpu,host=server"}); err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			sh.WritePoints(points)
+
+			iter, err := sh.CreateIterator("cpu", influxql.IteratorOptions{
+				Expr:       influxql.MustParseExpr(`value`),
+				Aux:        []influxql.VarRef{{Val: "value"}},
+				Dimensions: []string{},
+				Ascending:  true,
+				StartTime:  influxql.MinTime,
+				EndTime:    influxql.MaxTime,
+			})
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			switch itr := iter.(type) {
+			case influxql.IntegerIterator:
+				p, err := itr.Next()
+				for p != nil && err == nil {
+					p, err = itr.Next()
+				}
+				iter.Close()
+
+			case influxql.FloatIterator:
+				p, err := itr.Next()
+				for p != nil && err == nil {
+					p, err = itr.Next()
+				}
+				iter.Close()
+
+			}
+
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// Write 250 ints and then floats to the same field
+		points := make([]models.Point, 0, 500)
+		for i := 0; i < cap(points); i++ {
+			if i < 250 {
+				points = append(points, models.MustNewPoint(
+					"cpu",
+					models.NewTags(map[string]string{"host": "server"}),
+					map[string]interface{}{"value": int64(1)},
+					time.Unix(int64(i), 0),
+				))
+			} else {
+				points = append(points, models.MustNewPoint(
+					"cpu",
+					models.NewTags(map[string]string{"host": "server"}),
+					map[string]interface{}{"value": 1.0},
+					time.Unix(int64(i), 0),
+				))
+			}
+		}
+		for i := 0; i < 500; i++ {
+			if err := sh.DeleteMeasurement("cpu", []string{"cpu,host=server"}); err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			sh.WritePoints(points)
+
+			iter, err := sh.CreateIterator("cpu", influxql.IteratorOptions{
+				Expr:       influxql.MustParseExpr(`value`),
+				Aux:        []influxql.VarRef{{Val: "value"}},
+				Dimensions: []string{},
+				Ascending:  true,
+				StartTime:  influxql.MinTime,
+				EndTime:    influxql.MaxTime,
+			})
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			switch itr := iter.(type) {
+			case influxql.IntegerIterator:
+				p, err := itr.Next()
+				for p != nil && err == nil {
+					p, err = itr.Next()
+				}
+				iter.Close()
+			case influxql.FloatIterator:
+				p, err := itr.Next()
+				for p != nil && err == nil {
+					p, err = itr.Next()
+				}
+				iter.Close()
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
 // Ensures that when a shard is closed, it removes any series meta-data
 // from the index.
 func TestShard_Close_RemoveIndex(t *testing.T) {


### PR DESCRIPTION
Under high query load, a race exists in the cache and the WAL.  Since
writes currently hit the cache first, they are availble for query before
they hit the WAL.  If the WAL is writing and accessign the Value slice
at the same time that a query is run that needs to dedup the same slice,
a race occurs.

To fix this, the cache now just copies the values instead of storing the
slice passed in.  Another way to fix this might be to have the writes go
to the wal before the cache.  I think the latter would be better, but it
introduces some larger write path issues that we'd need to also address.
e.g. if the cache was full, writes to the WAL would need to be rejected
to avoid filling the disk.

Copying the slice in the cache is simpler for now and does not appear to
dramatically affect performance.

```
WARNING: DATA RACE
Write at 0x00c420224010 by goroutine 33:
  github.com/influxdata/influxdb/tsdb/engine/tsm1.Values.Deduplicate()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/encoding.gen.go:83 +0x2ae
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*entry).deduplicate()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/cache.go:124 +0xda
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Cache).Values()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/cache.go:472 +0x647
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).buildFloatCursor()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1678 +0xf0
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).buildCursor()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1664 +0x3e2
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).createVarRefSeriesIterator()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1518 +0x37df
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).createTagSetGroupIterators()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1491 +0x2a3
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).createTagSetIterators.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1446 +0x195

Previous read at 0x00c420224010 by goroutine 15:
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*WriteWALEntry).Encode()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/wal.go:583 +0x7da
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*WAL).writeToLog()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/wal.go:328 +0x194
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*WAL).WritePoints()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/wal.go:239 +0x90
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).WritePoints()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:713 +0xcf2
  github.com/influxdata/influxdb/tsdb.(*Shard).WritePoints()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:417 +0x2cc
  github.com/influxdata/influxdb/tsdb_test.TestShard_WritePoints_FieldConflictConcurrentQuery.func2()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard_test.go:550 +0x955

Goroutine 33 (running) created at:
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).createTagSetIterators()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1447 +0x59c
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).createVarRefIterator.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1359 +0x122
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).createVarRefIterator()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1400 +0x306
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).CreateIterator()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1265 +0x6d2
  github.com/influxdata/influxdb/tsdb.(*Shard).CreateIterator()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:697 +0x111
  github.com/influxdata/influxdb/tsdb_test.TestShard_WritePoints_FieldConflictConcurrentQuery.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard_test.go:498 +0xab2

Goroutine 15 (running) created at:
  github.com/influxdata/influxdb/tsdb_test.TestShard_WritePoints_FieldConflictConcurrentQuery()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard_test.go:579 +0x8fb
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:610 +0xc9
```

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>