### PR TITLE
Return errors in CSV responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#8558](https://github.com/influxdata/influxdb/issues/8558): Dropping measurement used several GB disk space
 - [#8569](https://github.com/influxdata/influxdb/issues/8569): Fix the cq start and end times to use unix timestamps.
 - [#8601](https://github.com/influxdata/influxdb/pull/8601): Fixed time boundaries for continuous queries with time zones.
+- [#8097](https://github.com/influxdata/influxdb/pull/8097): Return query parsing errors in CSV formats.
 
 ## v1.3.1 [unreleased]
 

--- a/services/httpd/response_writer.go
+++ b/services/httpd/response_writer.go
@@ -103,6 +103,13 @@ type csvFormatter struct {
 
 func (w *csvFormatter) WriteResponse(resp Response) (n int, err error) {
 	csv := csv.NewWriter(w)
+	if resp.Err != nil {
+		csv.Write([]string{"error"})
+		csv.Write([]string{resp.Err.Error()})
+		csv.Flush()
+		return n, csv.Error()
+	}
+
 	for _, result := range resp.Results {
 		if result.StatementID != w.statementID {
 			// If there are no series in the result, skip past this result.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Previously, errors that happen when asking for CSV responses would be eaten; a 400 response would be sent back, but the body would be blank without any details returned to the caller. This modifies the writer to return an error if one occurred. For example:

```
$ curl -s localhost:8086/query --data-urlencode db=influx_test_db --data-urlencode "q=select * from h2o_quality limit wut" -H Accept:'text/csv'
error
"error parsing query: found wut, expected integer at line 1, char 33"
```