### PR TITLE
Forbid wildcards in binary expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bugfixes
 
 - [#8091](https://github.com/influxdata/influxdb/issues/8091): Do not increment the continuous query statistic if no query is run.
+- [#8064](https://github.com/influxdata/influxdb/issues/8064): Forbid wildcards in binary expressions.
 
 ## v1.2.2 [2017-03-14]
 

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -326,6 +326,7 @@ func TestSelectStatement_RewriteFields(t *testing.T) {
 	var tests = []struct {
 		stmt    string
 		rewrite string
+		err     string
 	}{
 		// No wildcards
 		{
@@ -462,6 +463,35 @@ func TestSelectStatement_RewriteFields(t *testing.T) {
 			stmt:    `SELECT * FROM (SELECT mean(value1) FROM cpu GROUP BY host) GROUP BY *`,
 			rewrite: `SELECT mean::float FROM (SELECT mean(value1::float) FROM cpu GROUP BY host) GROUP BY host`,
 		},
+
+		// Invalid queries that can't be rewritten should return an error (to
+		// avoid a panic in the query engine)
+		{
+			stmt: `SELECT count(*) / 2 FROM cpu`,
+			err:  `unsupported expression with wildcard: count(*) / 2`,
+		},
+
+		{
+			stmt: `SELECT * / 2 FROM (SELECT count(*) FROM cpu)`,
+			err:  `unsupported expression with wildcard: * / 2`,
+		},
+
+		{
+			stmt: `SELECT count(/value/) / 2 FROM cpu`,
+			err:  `unsupported expression with regex field: count(/value/) / 2`,
+		},
+
+		// This one should be possible though since there's no wildcard in the
+		// binary expression.
+		{
+			stmt:    `SELECT value1 + value2, * FROM cpu`,
+			rewrite: `SELECT value1::float + value2::integer, host::tag, region::tag, value1::float, value2::integer FROM cpu`,
+		},
+
+		{
+			stmt:    `SELECT value1 + value2, /value/ FROM cpu`,
+			rewrite: `SELECT value1::float + value2::integer, value1::float, value2::integer FROM cpu`,
+		},
 	}
 
 	for i, tt := range tests {
@@ -496,12 +526,20 @@ func TestSelectStatement_RewriteFields(t *testing.T) {
 
 		// Rewrite statement.
 		rw, err := stmt.(*influxql.SelectStatement).RewriteFields(&ic)
-		if err != nil {
-			t.Errorf("%d. %q: error: %s", i, tt.stmt, err)
-		} else if rw == nil {
-			t.Errorf("%d. %q: unexpected nil statement", i, tt.stmt)
-		} else if rw := rw.String(); tt.rewrite != rw {
-			t.Errorf("%d. %q: unexpected rewrite:\n\nexp=%s\n\ngot=%s\n\n", i, tt.stmt, tt.rewrite, rw)
+		if tt.err != "" {
+			if err != nil && err.Error() != tt.err {
+				t.Errorf("%d. %q: unexpected error: %s != %s", i, tt.stmt, err.Error(), tt.err)
+			} else if err == nil {
+				t.Errorf("%d. %q: expected error", i, tt.stmt)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%d. %q: error: %s", i, tt.stmt, err)
+			} else if rw == nil && tt.err == "" {
+				t.Errorf("%d. %q: unexpected nil statement", i, tt.stmt)
+			} else if rw := rw.String(); tt.rewrite != rw {
+				t.Errorf("%d. %q: unexpected rewrite:\n\nexp=%s\n\ngot=%s\n\n", i, tt.stmt, tt.rewrite, rw)
+			}
 		}
 	}
 }


### PR DESCRIPTION
When rewriting fields, wildcards within binary expressions were skipped.
This now throws an error whenever it finds a wildcard within a binary
expression in order to prevent the panic that occurs.

Fixes #8064.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted influxdata/docs.influxdata.com#1064