### PR TITLE
add chunked/chunk size as setting/options in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bugfixes
 
+- [#8119](https://github.com/influxdata/influxdb/pull/8119): Add chunked/chunk size as setting/options in cli.
 - [#8091](https://github.com/influxdata/influxdb/issues/8091): Do not increment the continuous query statistic if no query is run.
 - [#8064](https://github.com/influxdata/influxdb/issues/8064): Forbid wildcards in binary expressions.
 - [#8148](https://github.com/influxdata/influxdb/issues/8148): Fix fill(linear) when multiple series exist and there are null values.

--- a/cmd/influx/cli/cli_test.go
+++ b/cmd/influx/cli/cli_test.go
@@ -132,6 +132,77 @@ func TestSetFormat(t *testing.T) {
 	}
 }
 
+func Test_SetChunked(t *testing.T) {
+	t.Parallel()
+	c := cli.New(CLIENT_VERSION)
+	config := client.NewConfig()
+	client, _ := client.NewClient(config)
+	c.Client = client
+
+	// make sure chunked is on by default
+	if got, exp := c.Chunked, true; got != exp {
+		t.Fatalf("chunked should be on by default.  got %v, exp %v", got, exp)
+	}
+
+	// turn chunked off
+	if err := c.ParseCommand("Chunked"); err != nil {
+		t.Fatalf("setting chunked failed: err: %s", err)
+	}
+
+	if got, exp := c.Chunked, false; got != exp {
+		t.Fatalf("setting chunked failed.  got %v, exp %v", got, exp)
+	}
+
+	// turn chunked back on
+	if err := c.ParseCommand("Chunked"); err != nil {
+		t.Fatalf("setting chunked failed: err: %s", err)
+	}
+
+	if got, exp := c.Chunked, true; got != exp {
+		t.Fatalf("setting chunked failed.  got %v, exp %v", got, exp)
+	}
+}
+
+func Test_SetChunkSize(t *testing.T) {
+	t.Parallel()
+	c := cli.New(CLIENT_VERSION)
+	config := client.NewConfig()
+	client, _ := client.NewClient(config)
+	c.Client = client
+
+	// check default chunk size
+	if got, exp := c.ChunkSize, 0; got != exp {
+		t.Fatalf("unexpected chunk size.  got %d, exp %d", got, exp)
+	}
+
+	tests := []struct {
+		command string
+		exp     int
+	}{
+		{"chunk size 20", 20},
+		{"   CHunk     siZE  55    ", 55},
+		{"chunk 10", 10},
+		{"     chuNK     15", 15},
+		{"chunk size -60", 0},
+		{"chunk size 10", 10},
+		{"chunk size 0", 0},
+		{"chunk size 10", 10},
+		{"chunk size junk", 10},
+	}
+
+	for _, test := range tests {
+		if err := c.ParseCommand(test.command); err != nil {
+			t.Logf("command: %q", test.command)
+			t.Fatalf("setting chunked failed: err: %s", err)
+		}
+
+		if got, exp := c.ChunkSize, test.exp; got != exp {
+			t.Logf("command: %q", test.command)
+			t.Fatalf("unexpected chunk size.  got %d, exp %d", got, exp)
+		}
+	}
+}
+
 func TestSetWriteConsistency(t *testing.T) {
 	t.Parallel()
 	c := cli.New(CLIENT_VERSION)


### PR DESCRIPTION
While working on another PR, I noticed that `chunking` was hard coded in the CLI.  This adds options to turn chunking on/off as well setting the chunk size.

This is very useful when doing any type of scripted querying or testing.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

###### Required only if applicable
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): [PR 1055 Filed](https://github.com/influxdata/docs.influxdata.com/pull/1055)