### PR TITLE
Speed up DROP DATABASE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#7811](https://github.com/influxdata/influxdb/issues/7811): Kill query not killing query
 - [#7457](https://github.com/influxdata/influxdb/issues/7457): KILL QUERY should work during all phases of a query
 - [#8155](https://github.com/influxdata/influxdb/pull/8155): Simplify admin user check.
+- [#8118](https://github.com/influxdata/influxdb/issues/8118): Significantly improve DROP DATABASE speed.
 
 ## v1.2.2 [2017-03-14]
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -402,7 +402,7 @@ func (s *Store) DeleteDatabase(name string) error {
 			return nil
 		}
 
-		return sh.Close()
+		return sh.CloseFast()
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #8118.

When un-assigning shards the current behaviour is to iterate over every series and perform quite a lot of work and memory moving. This is necessary when a subset of shards within a database are removed, but when all shards in the database are to be removed (along with the database index anyway) there is no need to do this.

For a database with `800K` series, the time to `DROP  DATABASE db` is already prohibitive (almost 2 minutes):

```
⇒  time influx -database "db" -execute 'DROP DATABASE "db"'
influx -database "db" -execute 'DROP DATABASE "db"'  0.00s user 0.01s system 0% cpu 1:51.62 total
``` 

With the change in this PR we skip the step of un-assigning the shards (down to under a second):

```
⇒  time influx -database "db" -execute 'DROP DATABASE "db"'
influx -database "db" -execute 'DROP DATABASE "db"'  0.00s user 0.01s system 36% cpu 0.039 total
```



