### PR TITLE
suppress headers in output for influx when they are the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bugfixes
 
+- [#8122](https://github.com/influxdata/influxdb/pull/8122): Suppress headers in output for influx cli when they are the same.
 - [#8119](https://github.com/influxdata/influxdb/pull/8119): Add chunked/chunk size as setting/options in cli.
 - [#8091](https://github.com/influxdata/influxdb/issues/8091): Do not increment the continuous query statistic if no query is run.
 - [#8064](https://github.com/influxdata/influxdb/issues/8064): Forbid wildcards in binary expressions.

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -31,6 +31,10 @@ import (
 // ErrBlankCommand is returned when a parsed command is empty.
 var ErrBlankCommand = errors.New("empty input")
 
+// DefaultChunkSize is the default number of results to return
+// per response if chunked responses are turned on
+const DefaultChunkSize = 10000
+
 // CommandLine holds CLI configuration and state.
 type CommandLine struct {
 	Line            *liner.State

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,10 +31,6 @@ import (
 
 // ErrBlankCommand is returned when a parsed command is empty.
 var ErrBlankCommand = errors.New("empty input")
-
-// DefaultChunkSize is the default number of results to return
-// per response if chunked responses are turned on
-const DefaultChunkSize = 10000
 
 // CommandLine holds CLI configuration and state.
 type CommandLine struct {
@@ -777,16 +774,41 @@ func (c *CommandLine) writeJSON(response *client.Response, w io.Writer) {
 	fmt.Fprintln(w, string(data))
 }
 
+func tagsEqual(prev, current map[string]string) bool {
+	return reflect.DeepEqual(prev, current)
+}
+
+func columnsEqual(prev, current []string) bool {
+	return reflect.DeepEqual(prev, current)
+}
+
+func headersEqual(prev, current models.Row) bool {
+	if prev.Name != current.Name {
+		return false
+	}
+	return tagsEqual(prev.Tags, current.Tags) && columnsEqual(prev.Columns, current.Columns)
+}
+
 func (c *CommandLine) writeCSV(response *client.Response, w io.Writer) {
 	csvw := csv.NewWriter(w)
+	var previousHeaders models.Row
 	for _, result := range response.Results {
+		suppressHeaders := len(result.Series) > 0 && headersEqual(previousHeaders, result.Series[0])
+		if !suppressHeaders && len(result.Series) > 0 {
+			previousHeaders = models.Row{
+				Name:    result.Series[0].Name,
+				Tags:    result.Series[0].Tags,
+				Columns: result.Series[0].Columns,
+			}
+		}
+
 		// Create a tabbed writer for each result as they won't always line up
-		rows := c.formatResults(result, "\t")
+		rows := c.formatResults(result, "\t", suppressHeaders)
 		for _, r := range rows {
 			csvw.Write(strings.Split(r, "\t"))
 		}
-		csvw.Flush()
 	}
+	csvw.Flush()
 }
 
 func (c *CommandLine) writeColumns(response *client.Response, w io.Writer) {
@@ -794,21 +816,40 @@ func (c *CommandLine) writeColumns(response *client.Response, w io.Writer) {
 	writer := new(tabwriter.Writer)
 	writer.Init(w, 0, 8, 1, ' ', 0)
 
-	for _, result := range response.Results {
+	var previousHeaders models.Row
+	for i, result := range response.Results {
 		// Print out all messages first
 		for _, m := range result.Messages {
 			fmt.Fprintf(w, "%s: %s.\n", m.Level, m.Text)
 		}
-		csv := c.formatResults(result, "\t")
-		for _, r := range csv {
+		// Check to see if the headers are the same as the previous row.  If so, suppress them in the output
+		suppressHeaders := len(result.Series) > 0 && headersEqual(previousHeaders, result.Series[0])
+		if !suppressHeaders && len(result.Series) > 0 {
+			previousHeaders = models.Row{
+				Name:    result.Series[0].Name,
+				Tags:    result.Series[0].Tags,
+				Columns: result.Series[0].Columns,
+			}
+		}
+
+		// If we are suppressing headers, don't output the extra line return. If we
+		// aren't suppressing headers, then we put out line returns between results
+		// (not before the first result, and not after the last result).
+		if !suppressHeaders && i > 0 {
+			fmt.Fprintln(writer, "")
+		}
+
+		rows := c.formatResults(result, "\t", suppressHeaders)
+		for _, r := range rows {
 			fmt.Fprintln(writer, r)
 		}
-		writer.Flush()
+
 	}
+	writer.Flush()
 }
 
 // formatResults will behave differently if you are formatting for columns or csv
-func (c *CommandLine) formatResults(result client.Result, separator string) []string {
+func (c *CommandLine) formatResults(result client.Result, separator string, suppressHeaders bool) []string {
 	rows := []string{}
 	// Create a tabbed writer for each result as they won't always line up
 	for i, row := range result.Series {
@@ -835,12 +876,12 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 		columnNames = append(columnNames, row.Columns...)
 
 		// Output a line separator if we have more than one set or results and format is column
-		if i > 0 && c.Format == "column" {
+		if i > 0 && c.Format == "column" && !suppressHeaders {
 			rows = append(rows, "")
 		}
 
 		// If we are column format, we break out the name/tag to separate lines
-		if c.Format == "column" {
+		if c.Format == "column" && !suppressHeaders {
 			if row.Name != "" {
 				n := fmt.Sprintf("name: %s", row.Name)
 				rows = append(rows, n)
@@ -851,10 +892,12 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 			}
 		}
 
-		rows = append(rows, strings.Join(columnNames, separator))
+		if !suppressHeaders {
+			rows = append(rows, strings.Join(columnNames, separator))
+		}
 
 		// if format is column, write dashes under each column
-		if c.Format == "column" {
+		if c.Format == "column" && !suppressHeaders {
 			lines := []string{}
 			for _, columnName := range columnNames {
 				lines = append(lines, strings.Repeat("-", len(columnName)))
@@ -877,10 +920,6 @@ func (c *CommandLine) formatResults(result client.Result, separator string) []st
 				values = append(values, interfaceToString(vv))
 			}
 			rows = append(rows, strings.Join(values, separator))
-		}
-		// Output a line separator if in column format
-		if c.Format == "column" {
-			rows = append(rows, "")
 		}
 	}
 	return rows


### PR DESCRIPTION
If you encountered a chunked result while processing the results of a query, you would get the headers inserted for no reason. This PR suppresses the header when they are the same so as to not inflate the output.  This is very useful when doing queries and grabbing a line count for adhoc testing, not to mention it created issues with csv layouts.

There is no good way to add testing for this without a larger refactor, so I've done extensive scenario adhoc testing.  I'll list those below, but if you are reviewing this PR, the most important thing to look for is any scenarios I might of missed.

## CSV Output

### Before Change
```
> select * from m2
name,time,area,cpu,mem,region,val
m2,1489160933298193430,,,,west,8
m2,1489160955106239552,north,99.8,123254,,
m2,1489160980553494642,south,98.8,123525,,
m2,1489160999872615861,east,97.8,123523,,
m2,1489161005520282539,east,97.8,123522,,
name,time,area,cpu,mem,region,val
m2,1489161007072346588,east,97.8,123521,,
m2,1489161024602161179,east,97.8,123520,,
```

### After Change
```
> select * from m2
name,time,area,cpu,mem,region,val
m2,1489160933298193430,,,,west,8
m2,1489160955106239552,north,99.8,123254,,
m2,1489160980553494642,south,98.8,123525,,
m2,1489160999872615861,east,97.8,123523,,
m2,1489161005520282539,east,97.8,123522,,
m2,1489161007072346588,east,97.8,123521,,
m2,1489161024602161179,east,97.8,123520,,
```

## Column Output

### Before Change
```
> select * from m2
name: m2
time                area  cpu  mem    region val
----                ----  ---  ---    ------ ---
1489160933298193430                   west   8
1489160955106239552 north 99.8 123254
1489160980553494642 south 98.8 123525
1489160999872615861 east  97.8 123523
1489161005520282539 east  97.8 123522

name: m2
time                area cpu  mem    region val
----                ---- ---  ---    ------ ---
1489161007072346588 east 97.8 123521
1489161024602161179 east 97.8 123520

```

### After Change
```
> select * from m2
name: m2
time                area  cpu  mem    region val
----                ----  ---  ---    ------ ---
1489160933298193430                   west   8
1489160955106239552 north 99.8 123254
1489160980553494642 south 98.8 123525
1489160999872615861 east  97.8 123523
1489161005520282539 east  97.8 123522
1489161007072346588 east  97.8 123521
1489161024602161179 east  97.8 123520
```

## Multiple Measurement + Chunked

### Before Change
```
> select * from m2
name: m2
time                area  cpu  mem    region val
----                ----  ---  ---    ------ ---
1489160933298193430                   west   8
1489160955106239552 north 99.8 123254
1489160980553494642 south 98.8 123525
1489160999872615861 east  97.8 123523
1489161005520282539 east  97.8 123522

name: m2
time                area cpu  mem    region val
----                ---- ---  ---    ------ ---
1489161007072346588 east 97.8 123521
1489161024602161179 east 97.8 123520

> select * from /m*/
name: m1
time                area cpu field mem region val
----                ---- --- ----- --- ------ ---
1489160894168214149                    east   1
1489160896124618043                    east   2
1489160897460385000                    east   3
1489160898924532600                    east   4
1489160900644363008                    east   5

name: m1
time                area cpu field mem region val
----                ---- --- ----- --- ------ ---
1489160907827927527                    west   6
1489160910315118036                    west   7

name: m2
time                area  cpu  field mem    region val
----                ----  ---  ----- ---    ------ ---
1489160933298193430                         west   8
1489160955106239552 north 99.8       123254
1489160980553494642 south 98.8       123525
1489160999872615861 east  97.8       123523
1489161005520282539 east  97.8       123522

name: m2
time                area cpu  field mem    region val
----                ---- ---  ----- ---    ------ ---
1489161007072346588 east 97.8       123521
1489161024602161179 east 97.8       123520

name: m3
time                area cpu field mem region val
----                ---- --- ----- --- ------ ---
1489161208341811442          0
```

### After Change
```
> select * from /m*/
name: m1
time                area cpu field mem region val
----                ---- --- ----- --- ------ ---
1489160894168214149                    east   1
1489160896124618043                    east   2
1489160897460385000                    east   3
1489160898924532600                    east   4
1489160900644363008                    east   5
1489160907827927527                    west   6
1489160910315118036                    west   7

name: m2
time                area  cpu  field mem    region val
----                ----  ---  ----- ---    ------ ---
1489160933298193430                         west   8
1489160955106239552 north 99.8       123254
1489160980553494642 south 98.8       123525
1489160999872615861 east  97.8       123523
1489161005520282539 east  97.8       123522
1489161007072346588 east  97.8       123521
1489161024602161179 east  97.8       123520

name: m3
time                area cpu field mem region val
----                ---- --- ----- --- ------ ---
1489161208341811442          0
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
