### PR TITLE
Use standard merge algorithm when merging Values

### DIFF
--- a/tsdb/engine/tsm1/encoding.gen.go
+++ b/tsdb/engine/tsm1/encoding.gen.go
@@ -140,52 +140,20 @@ func (a Values) Merge(b Values) Values {
 		return append(b, a...)
 	}
 
-	for i := 0; i < len(a) && len(b) > 0; i++ {
-		av, bv := a[i].UnixNano(), b[0].UnixNano()
-		// Value in a is greater than B, we need to merge
-		if av > bv {
-			// Save value in a
-			temp := a[i]
-
-			// Overwrite a with b
-			a[i] = b[0]
-
-			// Slide all values of b down 1
-			copy(b, b[1:])
-			b = b[:len(b)-1]
-
-			var k int
-			if len(b) > 0 && av > b[len(b)-1].UnixNano() {
-				// Fast path where a is after b, we skip the search
-				k = len(b)
-			} else {
-				// See where value we save from a should be inserted in b to keep b sorted
-				k = sort.Search(len(b), func(i int) bool { return b[i].UnixNano() >= temp.UnixNano() })
-			}
-
-			if k == len(b) {
-				// Last position?
-				b = append(b, temp)
-			} else if b[k].UnixNano() != temp.UnixNano() {
-				// Save the last element, since it will get overwritten
-				last := b[len(b)-1]
-				// Somewhere in the middle of b, insert it only if it's not a duplicate
-				copy(b[k+1:], b[k:])
-				// Add the last vale to the end
-				b = append(b, last)
-				b[k] = temp
-			}
-		} else if av == bv {
-			// Value in a an b are the same, use b
-			a[i] = b[0]
-			b = b[1:]
+	out := make(Values, 0, len(a)+len(b))
+	for len(a) > 0 && len(b) > 0 {
+		if a[0].UnixNano() < b[0].UnixNano() {
+			out, a = append(out, a[0]), a[1:]
+		} else if len(b) > 0 && a[0].UnixNano() == b[0].UnixNano() {
+			a = a[1:]
+		} else {
+			out, b = append(out, b[0]), b[1:]
 		}
 	}
-
-	if len(b) > 0 {
-		return append(a, b...)
+	if len(a) > 0 {
+		return append(out, a...)
 	}
-	return a
+	return append(out, b...)
 }
 
 // Sort methods
@@ -322,52 +290,20 @@ func (a FloatValues) Merge(b FloatValues) FloatValues {
 		return append(b, a...)
 	}
 
-	for i := 0; i < len(a) && len(b) > 0; i++ {
-		av, bv := a[i].UnixNano(), b[0].UnixNano()
-		// Value in a is greater than B, we need to merge
-		if av > bv {
-			// Save value in a
-			temp := a[i]
-
-			// Overwrite a with b
-			a[i] = b[0]
-
-			// Slide all values of b down 1
-			copy(b, b[1:])
-			b = b[:len(b)-1]
-
-			var k int
-			if len(b) > 0 && av > b[len(b)-1].UnixNano() {
-				// Fast path where a is after b, we skip the search
-				k = len(b)
-			} else {
-				// See where value we save from a should be inserted in b to keep b sorted
-				k = sort.Search(len(b), func(i int) bool { return b[i].UnixNano() >= temp.UnixNano() })
-			}
-
-			if k == len(b) {
-				// Last position?
-				b = append(b, temp)
-			} else if b[k].UnixNano() != temp.UnixNano() {
-				// Save the last element, since it will get overwritten
-				last := b[len(b)-1]
-				// Somewhere in the middle of b, insert it only if it's not a duplicate
-				copy(b[k+1:], b[k:])
-				// Add the last vale to the end
-				b = append(b, last)
-				b[k] = temp
-			}
-		} else if av == bv {
-			// Value in a an b are the same, use b
-			a[i] = b[0]
-			b = b[1:]
+	out := make(FloatValues, 0, len(a)+len(b))
+	for len(a) > 0 && len(b) > 0 {
+		if a[0].UnixNano() < b[0].UnixNano() {
+			out, a = append(out, a[0]), a[1:]
+		} else if len(b) > 0 && a[0].UnixNano() == b[0].UnixNano() {
+			a = a[1:]
+		} else {
+			out, b = append(out, b[0]), b[1:]
 		}
 	}
-
-	if len(b) > 0 {
-		return append(a, b...)
+	if len(a) > 0 {
+		return append(out, a...)
 	}
-	return a
+	return append(out, b...)
 }
 
 // Sort methods
@@ -504,52 +440,20 @@ func (a IntegerValues) Merge(b IntegerValues) IntegerValues {
 		return append(b, a...)
 	}
 
-	for i := 0; i < len(a) && len(b) > 0; i++ {
-		av, bv := a[i].UnixNano(), b[0].UnixNano()
-		// Value in a is greater than B, we need to merge
-		if av > bv {
-			// Save value in a
-			temp := a[i]
-
-			// Overwrite a with b
-			a[i] = b[0]
-
-			// Slide all values of b down 1
-			copy(b, b[1:])
-			b = b[:len(b)-1]
-
-			var k int
-			if len(b) > 0 && av > b[len(b)-1].UnixNano() {
-				// Fast path where a is after b, we skip the search
-				k = len(b)
-			} else {
-				// See where value we save from a should be inserted in b to keep b sorted
-				k = sort.Search(len(b), func(i int) bool { return b[i].UnixNano() >= temp.UnixNano() })
-			}
-
-			if k == len(b) {
-				// Last position?
-				b = append(b, temp)
-			} else if b[k].UnixNano() != temp.UnixNano() {
-				// Save the last element, since it will get overwritten
-				last := b[len(b)-1]
-				// Somewhere in the middle of b, insert it only if it's not a duplicate
-				copy(b[k+1:], b[k:])
-				// Add the last vale to the end
-				b = append(b, last)
-				b[k] = temp
-			}
-		} else if av == bv {
-			// Value in a an b are the same, use b
-			a[i] = b[0]
-			b = b[1:]
+	out := make(IntegerValues, 0, len(a)+len(b))
+	for len(a) > 0 && len(b) > 0 {
+		if a[0].UnixNano() < b[0].UnixNano() {
+			out, a = append(out, a[0]), a[1:]
+		} else if len(b) > 0 && a[0].UnixNano() == b[0].UnixNano() {
+			a = a[1:]
+		} else {
+			out, b = append(out, b[0]), b[1:]
 		}
 	}
-
-	if len(b) > 0 {
-		return append(a, b...)
+	if len(a) > 0 {
+		return append(out, a...)
 	}
-	return a
+	return append(out, b...)
 }
 
 // Sort methods
@@ -686,52 +590,20 @@ func (a StringValues) Merge(b StringValues) StringValues {
 		return append(b, a...)
 	}
 
-	for i := 0; i < len(a) && len(b) > 0; i++ {
-		av, bv := a[i].UnixNano(), b[0].UnixNano()
-		// Value in a is greater than B, we need to merge
-		if av > bv {
-			// Save value in a
-			temp := a[i]
-
-			// Overwrite a with b
-			a[i] = b[0]
-
-			// Slide all values of b down 1
-			copy(b, b[1:])
-			b = b[:len(b)-1]
-
-			var k int
-			if len(b) > 0 && av > b[len(b)-1].UnixNano() {
-				// Fast path where a is after b, we skip the search
-				k = len(b)
-			} else {
-				// See where value we save from a should be inserted in b to keep b sorted
-				k = sort.Search(len(b), func(i int) bool { return b[i].UnixNano() >= temp.UnixNano() })
-			}
-
-			if k == len(b) {
-				// Last position?
-				b = append(b, temp)
-			} else if b[k].UnixNano() != temp.UnixNano() {
-				// Save the last element, since it will get overwritten
-				last := b[len(b)-1]
-				// Somewhere in the middle of b, insert it only if it's not a duplicate
-				copy(b[k+1:], b[k:])
-				// Add the last vale to the end
-				b = append(b, last)
-				b[k] = temp
-			}
-		} else if av == bv {
-			// Value in a an b are the same, use b
-			a[i] = b[0]
-			b = b[1:]
+	out := make(StringValues, 0, len(a)+len(b))
+	for len(a) > 0 && len(b) > 0 {
+		if a[0].UnixNano() < b[0].UnixNano() {
+			out, a = append(out, a[0]), a[1:]
+		} else if len(b) > 0 && a[0].UnixNano() == b[0].UnixNano() {
+			a = a[1:]
+		} else {
+			out, b = append(out, b[0]), b[1:]
 		}
 	}
-
-	if len(b) > 0 {
-		return append(a, b...)
+	if len(a) > 0 {
+		return append(out, a...)
 	}
-	return a
+	return append(out, b...)
 }
 
 // Sort methods
@@ -868,52 +740,20 @@ func (a BooleanValues) Merge(b BooleanValues) BooleanValues {
 		return append(b, a...)
 	}
 
-	for i := 0; i < len(a) && len(b) > 0; i++ {
-		av, bv := a[i].UnixNano(), b[0].UnixNano()
-		// Value in a is greater than B, we need to merge
-		if av > bv {
-			// Save value in a
-			temp := a[i]
-
-			// Overwrite a with b
-			a[i] = b[0]
-
-			// Slide all values of b down 1
-			copy(b, b[1:])
-			b = b[:len(b)-1]
-
-			var k int
-			if len(b) > 0 && av > b[len(b)-1].UnixNano() {
-				// Fast path where a is after b, we skip the search
-				k = len(b)
-			} else {
-				// See where value we save from a should be inserted in b to keep b sorted
-				k = sort.Search(len(b), func(i int) bool { return b[i].UnixNano() >= temp.UnixNano() })
-			}
-
-			if k == len(b) {
-				// Last position?
-				b = append(b, temp)
-			} else if b[k].UnixNano() != temp.UnixNano() {
-				// Save the last element, since it will get overwritten
-				last := b[len(b)-1]
-				// Somewhere in the middle of b, insert it only if it's not a duplicate
-				copy(b[k+1:], b[k:])
-				// Add the last vale to the end
-				b = append(b, last)
-				b[k] = temp
-			}
-		} else if av == bv {
-			// Value in a an b are the same, use b
-			a[i] = b[0]
-			b = b[1:]
+	out := make(BooleanValues, 0, len(a)+len(b))
+	for len(a) > 0 && len(b) > 0 {
+		if a[0].UnixNano() < b[0].UnixNano() {
+			out, a = append(out, a[0]), a[1:]
+		} else if len(b) > 0 && a[0].UnixNano() == b[0].UnixNano() {
+			a = a[1:]
+		} else {
+			out, b = append(out, b[0]), b[1:]
 		}
 	}
-
-	if len(b) > 0 {
-		return append(a, b...)
+	if len(a) > 0 {
+		return append(out, a...)
 	}
-	return a
+	return append(out, b...)
 }
 
 // Sort methods

--- a/tsdb/engine/tsm1/encoding.gen.go.tmpl
+++ b/tsdb/engine/tsm1/encoding.gen.go.tmpl
@@ -137,52 +137,20 @@ func (a {{.Name}}Values) Merge(b {{.Name}}Values) {{.Name}}Values {
 		return append(b, a...)
 	}
 
-	for i := 0; i < len(a) && len(b) > 0; i++ {
-		av, bv := a[i].UnixNano(), b[0].UnixNano()
-		// Value in a is greater than B, we need to merge
-		if av > bv {
-			// Save value in a
-			temp := a[i]
-
-			// Overwrite a with b
-			a[i] = b[0]
-
-			// Slide all values of b down 1
-			copy(b, b[1:])
-			b = b[:len(b)-1]
-
-			var k int
-			if len(b) > 0 && av > b[len(b)-1].UnixNano() {
-				// Fast path where a is after b, we skip the search
-				k = len(b)
-			} else {
-				// See where value we save from a should be inserted in b to keep b sorted
-				k = sort.Search(len(b), func(i int) bool { return b[i].UnixNano() >= temp.UnixNano() })
-			}
-
-			if k == len(b) {
-				// Last position?
-				b = append(b, temp)
-			} else if b[k].UnixNano() != temp.UnixNano() {
-				// Save the last element, since it will get overwritten
-				last := b[len(b)-1]
-				// Somewhere in the middle of b, insert it only if it's not a duplicate
-				copy(b[k+1:], b[k:])
-				// Add the last vale to the end
-				b = append(b, last)
-				b[k] = temp
-			}
-		} else if av == bv {
-			// Value in a an b are the same, use b
-			a[i] = b[0]
-			b = b[1:]
+	out := make({{.Name}}Values, 0, len(a)+len(b))
+	for len(a) > 0 && len(b) > 0 {
+		if a[0].UnixNano() < b[0].UnixNano() {
+			out, a = append(out, a[0]), a[1:]
+		} else if len(b) > 0 && a[0].UnixNano() == b[0].UnixNano() {
+			a = a[1:]
+		} else {
+			out, b = append(out, b[0]), b[1:]
 		}
 	}
-
-	if len(b) > 0 {
-		return append(a, b...)
+	if len(a) > 0 {
+		return append(out, a...)
 	}
-	return a
+	return append(out, b...)
 }
 
 // Sort methods


### PR DESCRIPTION
While investigating a runtime/GC stall, @aclements noticed that `Values.Merge` was using a sub-optimal algorithm and that a traditional merge algorithm would likely perform better in general.  He also discovered that the benchmark we were using had a bug which caused the current implementation to appear better when it was actually quite worse in all but one case.

This switches the `Values.Merge` to use a standard merge algorithm.

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkValues_Merge-8            729849        47429         -93.50%
BenchmarkValues_MergeSame-8        22544         51528         +128.57%
BenchmarkValues_MergeSimilar-8     247516        49819         -79.87%

benchmark                          old allocs     new allocs     delta
BenchmarkValues_Merge-8            1              1              +0.00%
BenchmarkValues_MergeSame-8        0              1              +Inf%
BenchmarkValues_MergeSimilar-8     1              1              +0.00%

benchmark                          old bytes     new bytes     delta
BenchmarkValues_Merge-8            32768         32768         +0.00%
BenchmarkValues_MergeSame-8        0             32768         +Inf%
BenchmarkValues_MergeSimilar-8     32768         32768         +0.00%
```