### PR TITLE
Disable max-row-limit by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v1.2.2 [2017-03-14]
+
+### Release Notes
+
+### Configuration Changes
+
+#### `[http]` Section
+
+* `max-row-limit` now defaults to `0`.  The previous default was `10000`, but due to a bug, the value in use since `1.0` was `0`.
+
+### Bugfixes
+
+- [#8050](https://github.com/influxdata/influxdb/issues/8050): influxdb & grafana, absence of data on the graphs
+
 ## v1.2.1 [2017-03-08]
 
 ### Release Notes

--- a/cmd/influxd/run/server_test.go
+++ b/cmd/influxd/run/server_test.go
@@ -5960,7 +5960,7 @@ func TestServer_Query_Chunk(t *testing.T) {
 	}
 
 	writes := make([]string, 10001) // 10,000 is the default chunking size, even when no chunking requested.
-	expectedValues := make([]string, 10000)
+	expectedValues := make([]string, len(writes))
 	for i := 0; i < len(writes); i++ {
 		writes[i] = fmt.Sprintf(`cpu value=%d %d`, i, time.Unix(0, int64(i)).UnixNano())
 		if i < len(expectedValues) {

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -240,7 +240,7 @@
   # shared-sercret = ""
 
   # The default chunk size for result sets that should be chunked.
-  # max-row-limit = 10000
+  # max-row-limit = 0
 
   # The maximum number of HTTP connections that may be open at once.  New connections that
   # would exceed this limit are dropped.  Setting this value to 0 disables the limit.

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -39,7 +39,7 @@ func NewConfig() Config {
 		PprofEnabled:      true,
 		HTTPSEnabled:      false,
 		HTTPSCertificate:  "/etc/ssl/influxdb.pem",
-		MaxRowLimit:       DefaultChunkSize,
+		MaxRowLimit:       0,
 		Realm:             DefaultRealm,
 		UnixSocketEnabled: false,
 		BindSocket:        DefaultBindSocket,


### PR DESCRIPTION
`max-row-limit` was set at 10000 since 1.0, but due to a bug it was
effectively 0 (disabled).  1.2 fixed this bug via #7368, but this
caused a breaking change w/ Grafana and any users upgrading from <1.2
who had not disabled the config manually.

This switches the default to `0` to match the prior behavior.

Fixes #8050 

Also related: https://github.com/grafana/grafana/issues/7380

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
