### PR TITLE
Add WAL sync delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- [#8143](https://github.com/influxdata/influxdb/pull/8143): Add WAL sync delay
 - [#7977](https://github.com/influxdata/influxdb/issues/7977): Add chunked request processing back into the Go client v2
 - [#7974](https://github.com/influxdata/influxdb/pull/7974): Allow non-admin users to execute SHOW DATABASES.
 - [#7948](https://github.com/influxdata/influxdb/pull/7948): Reduce memory allocations by reusing gzip.Writers across requests

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -49,6 +49,12 @@
   # The directory where the TSM storage engine stores WAL files.
   wal-dir = "/var/lib/influxdb/wal"
 
+  # The amount of time that a write will wait before fsyncing.  A duration
+  # greater than 0 can be used to batch up multiple fsync calls.  This is useful for slower
+  # disks or when WAL write contention is seen.  A value of 0s fsyncs every write to the WAL.
+  # Values in the range of 0-100ms are recommended for non-SSD disks.
+  # wal-fsync-delay = "0s"
+
   # Trace logging provides more verbose output around the tsm engine. Turning
   # this on can provide more useful output for debugging tsm engine issues.
   # trace-logging-enabled = false

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -128,6 +128,7 @@ func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
 	return diagnostics.RowFromMap(map[string]interface{}{
 		"dir":                                c.Dir,
 		"wal-dir":                            c.WALDir,
+		"wal-fsync-delay":                    c.WALFsyncDelay,
 		"cache-max-memory-size":              c.CacheMaxMemorySize,
 		"cache-snapshot-memory-size":         c.CacheSnapshotMemorySize,
 		"cache-snapshot-write-cold-duration": c.CacheSnapshotWriteColdDuration,

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -53,6 +53,11 @@ type Config struct {
 	// General WAL configuration options
 	WALDir string `toml:"wal-dir"`
 
+	// WALFsyncDelay is the amount of time that a write will wait before fsyncing.  A duration
+	// greater than 0 can be used to batch up multiple fsync calls.  This is useful for slower
+	// disks or when WAL write contention is seen.  A value of 0 fsyncs every write to the WAL.
+	WALFsyncDelay toml.Duration `toml:"wal-fsync-delay"`
+
 	// Query logging
 	QueryLogEnabled bool `toml:"query-log-enabled"`
 

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -2,6 +2,7 @@ package tsdb_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/influxdata/influxdb/tsdb"
@@ -13,6 +14,7 @@ func TestConfig_Parse(t *testing.T) {
 	if _, err := toml.Decode(`
 dir = "/var/lib/influxdb/data"
 wal-dir = "/var/lib/influxdb/wal"
+wal-fsync-delay = "10s"
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -27,6 +29,10 @@ wal-dir = "/var/lib/influxdb/wal"
 	if got, exp := c.WALDir, "/var/lib/influxdb/wal"; got != exp {
 		t.Errorf("unexpected wal-dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
 	}
+	if got, exp := c.WALFsyncDelay, time.Duration(10*time.Second); time.Duration(got).Nanoseconds() != exp.Nanoseconds() {
+		t.Errorf("unexpected wal-fsync-delay:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+
 }
 
 func TestConfig_Validate_Error(t *testing.T) {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -131,6 +131,8 @@ type Engine struct {
 // NewEngine returns a new instance of Engine.
 func NewEngine(id uint64, path string, walPath string, opt tsdb.EngineOptions) tsdb.Engine {
 	w := NewWAL(walPath)
+	w.syncDelay = time.Duration(opt.Config.WALFsyncDelay)
+
 	fs := NewFileStore(path)
 	cache := NewCache(uint64(opt.Config.CacheMaxMemorySize), path)
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -914,17 +914,28 @@ func (s *Shard) monitor() {
 	defer t.Stop()
 	t2 := time.NewTicker(time.Minute)
 	defer t2.Stop()
+	var changed time.Time
+
 	for {
 		select {
 		case <-s.closing:
 			return
 		case <-t.C:
+
+			// Checking DiskSize can be expensive with a lot of shards and TSM files, only
+			// check if something has changed.
+			lm := s.LastModified()
+			if lm.Equal(changed) {
+				continue
+			}
+
 			size, err := s.DiskSize()
 			if err != nil {
 				s.logger.Info(fmt.Sprintf("Error collecting shard size: %v", err))
 				continue
 			}
 			atomic.StoreInt64(&s.stats.DiskBytes, size)
+			changed = lm
 		case <-t2.C:
 			if s.options.Config.MaxValuesPerTag == 0 {
 				continue


### PR DESCRIPTION
This is a follow up to address an issue introduced #7942 where write performance was lower due to an 100ms delay added to batch up fsyncs calls to the WAL.  This reworks it so that there is no delay by default, but multiple, concurrent fsyncs are coalesced into one.  It also adds a `wal-fsync-delay` config option that can be increased to add a delay.  The previous version also added another long running goroutine per shard.  That goroutine is removed now.

This change helps with high write load use cases, users not running on SSDs and when there are lots of small writes.

This also avoids some of the work done to collect shard stat data.  Previously, we'd `stat` the shard data and wal dirs on every collection interval (10s).  For cold shards, this these stats don't change.  When there are many shards (1000's), these thousands of syscalls can be taxing and on the system when run so frequently.

These stats are only collected now when the shard data on disk has actually changed due to a write or a compaction.

I tested this on an `m4.xlarge` w/ `sc1` volume (HDD 250 IOPS) using various workloads.

For small writes using `influx-stress insert --pps 1200 -n 100000000 -b 10`, the disk is `100%` utilized continuously and write latency is around 5.7s.

### 1.2

```
Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
xvda              0.00     0.00    0.00    0.00     0.00     0.00     0.00     0.00    0.00    0.00    0.00   0.00   0.00
xvdf              0.00    23.00    0.00   63.00     0.00   348.00    11.05     1.02   16.32    0.00   16.32  15.87 100.00
```

### New w/  `100ms` delay

Write latency improves to `1.5s` and disk util stays around 2-3%.

```
Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
xvda              0.00     1.00    0.00    8.00     0.00    36.00     9.00     0.00    0.00    0.00    0.00   0.00   0.00
xvdf              0.00    20.00    0.00   32.00     0.00   212.00    13.25     0.03    0.88    0.00    0.88   0.75   2.40
```

Testing with SSDs shows some improvement as well, but doesn't require the delay.