### PR TITLE
Update liner dependency to handle docker exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#8091](https://github.com/influxdata/influxdb/issues/8091): Do not increment the continuous query statistic if no query is run.
 - [#8064](https://github.com/influxdata/influxdb/issues/8064): Forbid wildcards in binary expressions.
 - [#8148](https://github.com/influxdata/influxdb/issues/8148): Fix fill(linear) when multiple series exist and there are null values.
+- [#7995](https://github.com/influxdata/influxdb/issues/7995): Update liner dependency to handle docker exec.
 
 ## v1.2.2 [2017-03-14]
 

--- a/Godeps
+++ b/Godeps
@@ -12,7 +12,7 @@ github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380
 github.com/influxdata/usage-client 6d3895376368aa52a3a81d2a16e90f0f52371967
 github.com/jwilder/encoding 27894731927e49b0a9023f00312be26733744815
 github.com/paulbellamy/ratecounter 5a11f585a31379765c190c033b6ad39956584447
-github.com/peterh/liner 8975875355a81d612fafb9f5a6037bdcc2d9b073
+github.com/peterh/liner 88609521dc4b6c858fd4c98b628147da928ce4ac
 github.com/rakyll/statik e383bbf6b2ec1a2fb8492dfd152d945fb88919b6
 github.com/retailnext/hllpp 38a7bb71b483e855d35010808143beaf05b67f9d
 github.com/uber-go/atomic 74ca5ec650841aee9f289dce76e928313a37cbc6


### PR DESCRIPTION
The liner dependency now handles the scenario where the terminal width
is reported as zero. Previously, liner would panic when it tried to
divide by the width (which was zero). Now it falls back onto a dumb
prompt rather than attempting to use a smart prompt and panicking.

Fixes #7995.

- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated