### PR TITLE
Reduce cost of admin user check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#7995](https://github.com/influxdata/influxdb/issues/7995): Update liner dependency to handle docker exec.
 - [#7811](https://github.com/influxdata/influxdb/issues/7811): Kill query not killing query
 - [#7457](https://github.com/influxdata/influxdb/issues/7457): KILL QUERY should work during all phases of a query
+- [#8155](https://github.com/influxdata/influxdb/pull/8155): Simplify admin user check.
 
 ## v1.2.2 [2017-03-14]
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -72,8 +72,8 @@ type Handler struct {
 	MetaClient interface {
 		Database(name string) *meta.DatabaseInfo
 		Authenticate(username, password string) (ui *meta.UserInfo, err error)
-		Users() []meta.UserInfo
 		User(username string) (*meta.UserInfo, error)
+		AdminUserExists() bool
 	}
 
 	QueryAuthorizer interface {
@@ -964,20 +964,8 @@ func authenticate(inner func(http.ResponseWriter, *http.Request, *meta.UserInfo)
 		}
 		var user *meta.UserInfo
 
-		// Retrieve user list.
-		uis := h.MetaClient.Users()
-
-		// See if admin user exists.
-		adminExists := false
-		for i := range uis {
-			if uis[i].Admin {
-				adminExists = true
-				break
-			}
-		}
-
 		// TODO corylanou: never allow this in the future without users
-		if requireAuthentication && adminExists {
+		if requireAuthentication && h.MetaClient.AdminUserExists() {
 			creds, err := parseCredentials(r)
 			if err != nil {
 				atomic.AddInt64(&h.stats.AuthenticationFailures, 1)

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -547,13 +547,7 @@ func (c *Client) UserPrivilege(username, database string) (*influxql.Privilege, 
 func (c *Client) AdminUserExists() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-
-	for _, u := range c.cacheData.Users {
-		if u.Admin {
-			return true
-		}
-	}
-	return false
+	return c.cacheData.AdminUserExists()
 }
 
 // Authenticate returns a UserInfo if the username and password match an existing entry.

--- a/services/meta/data_test.go
+++ b/services/meta/data_test.go
@@ -110,6 +110,84 @@ func Test_Data_CreateRetentionPolicy(t *testing.T) {
 	}
 }
 
+func TestData_AdminUserExists(t *testing.T) {
+	data := meta.Data{}
+
+	// No users means no admin.
+	if data.AdminUserExists() {
+		t.Fatal("no admin user should exist")
+	}
+
+	// Add a non-admin user.
+	if err := data.CreateUser("user1", "a", false); err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := data.AdminUserExists(), false; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Add an admin user.
+	if err := data.CreateUser("admin1", "a", true); err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := data.AdminUserExists(), true; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Remove the original user
+	if err := data.DropUser("user1"); err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := data.AdminUserExists(), true; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Add another admin
+	if err := data.CreateUser("admin2", "a", true); err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := data.AdminUserExists(), true; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Revoke privileges of the first admin
+	if err := data.SetAdminPrivilege("admin1", false); err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := data.AdminUserExists(), true; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Add user1 back.
+	if err := data.CreateUser("user1", "a", false); err != nil {
+		t.Fatal(err)
+	}
+	// Revoke remaining admin.
+	if err := data.SetAdminPrivilege("admin2", false); err != nil {
+		t.Fatal(err)
+	}
+	// No longer any admins
+	if got, exp := data.AdminUserExists(), false; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Make user1 an admin
+	if err := data.SetAdminPrivilege("user1", true); err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := data.AdminUserExists(), true; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+
+	// Drop user1...
+	if err := data.DropUser("user1"); err != nil {
+		t.Fatal(err)
+	}
+	if got, exp := data.AdminUserExists(), false; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
+	}
+}
+
 func TestUserInfo_AuthorizeDatabase(t *testing.T) {
 	emptyUser := &meta.UserInfo{}
 	if !emptyUser.AuthorizeDatabase(influxql.NoPrivileges, "anydb") {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR simplifies the process of checking for the existence of an admin user when handling a query.