### PR TITLE
Speedup shutdown for high cardinality databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#7457](https://github.com/influxdata/influxdb/issues/7457): KILL QUERY should work during all phases of a query
 - [#8155](https://github.com/influxdata/influxdb/pull/8155): Simplify admin user check.
 - [#8118](https://github.com/influxdata/influxdb/issues/8118): Significantly improve DROP DATABASE speed.
+- [#8171](https://github.com/influxdata/influxdb/issues/8171): Significantly improve shutdown speed for high cardinality databases.
 
 ## v1.2.2 [2017-03-14]
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -227,7 +227,7 @@ func (s *Store) Close() error {
 
 	// Close all the shards in parallel.
 	if err := s.walkShards(s.shardsSlice(), func(sh *Shard) error {
-		return sh.Close()
+		return sh.CloseFast()
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated

Fixes #8171.

The current system [times out](https://github.com/influxdata/influxdb/blob/master/cmd/influxd/main.go#L108) after 30 seconds if the system has not gracefully shutdown before then.

For databases with a large number of series sometimes this hard limit is often triggered because it's very expensive to remove all of the series from the index. Of course, there is not actually a need to carefully remove all the series from the index, because we're shutting down the entire system.

Much like #6623 we can just close the shards and move on.

For `v1.2.1` running on a 36 core box with 400K series:

```
vice=retention
[I] 2017-03-21T13:08:55Z Listening for signals
[I] 2017-03-21T13:08:55Z Storing statistics in database '_internal' retention policy 'monitor', at interval 10s service=monitor
[I] 2017-03-21T13:08:55Z Sending usage statistics to usage.influxdata.com
^C[I] 2017-03-21T13:09:02Z Signal received, initializing clean shutdown...
[I] 2017-03-21T13:09:02Z Waiting for clean shutdown...
[I] 2017-03-21T13:09:02Z shutting down monitor system service=monitor
[I] 2017-03-21T13:09:02Z snapshot listener closed service=snapshot
[I] 2017-03-21T13:09:02Z terminating storage of statistics service=monitor
[I] 2017-03-21T13:09:02Z Precreation service terminating service=shard-precreation
[I] 2017-03-21T13:09:02Z continuous query service terminating service=continuous_querier
[I] 2017-03-21T13:09:02Z retention policy enforcement terminating service=retention
[I] 2017-03-21T13:09:32Z time limit reached, initializing hard shutdown
ubuntu@ip-172-30-2-55:~$
```

Will now shutdown in under a second:

```
[I] 2017-03-21T13:13:18Z Listening on HTTP:[::]:8086 service=httpd
[I] 2017-03-21T13:13:18Z Starting retention policy enforcement service with check interval of 30m0s service=retention
[I] 2017-03-21T13:13:18Z Listening for signals
[I] 2017-03-21T13:13:18Z Sending usage statistics to usage.influxdata.com
^C[I] 2017-03-21T13:13:23Z Signal received, initializing clean shutdown...
[I] 2017-03-21T13:13:23Z Waiting for clean shutdown...
[I] 2017-03-21T13:13:23Z shutting down monitor system service=monitor
[I] 2017-03-21T13:13:23Z terminating storage of statistics service=monitor
[I] 2017-03-21T13:13:23Z Precreation service terminating service=shard-precreation
[I] 2017-03-21T13:13:23Z snapshot listener closed service=snapshot
[I] 2017-03-21T13:13:23Z continuous query service terminating service=continuous_querier
[I] 2017-03-21T13:13:23Z retention policy enforcement terminating service=retention
[I] 2017-03-21T13:13:23Z closed service service=subscriber
[I] 2017-03-21T13:13:23Z server shutdown completed
ubuntu@ip-172-30-2-55:~$
```