### PR TITLE
Return an error when an invalid duration literal is parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#7457](https://github.com/influxdata/influxdb/issues/7457): KILL QUERY should work during all phases of a query
 - [#8155](https://github.com/influxdata/influxdb/pull/8155): Simplify admin user check.
 - [#8118](https://github.com/influxdata/influxdb/issues/8118): Significantly improve DROP DATABASE speed.
+- [#8181](https://github.com/influxdata/influxdb/issues/8181): Return an error when an invalid duration literal is parsed.
 
 ## v1.2.2 [2017-03-14]
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2501,7 +2501,10 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 	case TRUE, FALSE:
 		return &BooleanLiteral{Val: (tok == TRUE)}, nil
 	case DURATIONVAL:
-		v, _ := ParseDuration(lit)
+		v, err := ParseDuration(lit)
+		if err != nil {
+			return nil, err
+		}
 		return &DurationLiteral{Val: v}, nil
 	case MUL:
 		wc := &Wildcard{}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -3030,6 +3030,12 @@ func TestParser_ParseExpr(t *testing.T) {
 			},
 		},
 
+		// Duration math with an invalid literal.
+		{
+			s:   `time > now() - 1y`,
+			err: `invalid duration`,
+		},
+
 		// Function call (empty)
 		{
 			s: `my_func()`,


### PR DESCRIPTION
Fixes #8181.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated