### PR TITLE
Fix query parser when using addition and subtraction without spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [#8118](https://github.com/influxdata/influxdb/issues/8118): Significantly improve DROP DATABASE speed.
 - [#8181](https://github.com/influxdata/influxdb/issues/8181): Return an error when an invalid duration literal is parsed.
 - [#8093](https://github.com/influxdata/influxdb/issues/8093): Fix the time range when an exact timestamp is selected.
+- [#8174](https://github.com/influxdata/influxdb/issues/8174): Fix query parser when using addition and subtraction without spaces.
 
 ## v1.2.2 [2017-03-14]
 

--- a/influxql/README.md
+++ b/influxql/README.md
@@ -136,7 +136,7 @@ InfluxQL supports decimal integer literals.  Hexadecimal and octal literals are
 not currently supported.
 
 ```
-int_lit             = ( "1" … "9" ) { digit } .
+int_lit             = [ "+" | "-" ] ( "1" … "9" ) { digit } .
 ```
 
 ### Floats
@@ -144,7 +144,7 @@ int_lit             = ( "1" … "9" ) { digit } .
 InfluxQL supports floating-point literals.  Exponents are not currently supported.
 
 ```
-float_lit           = int_lit "." int_lit .
+float_lit           = [ "+" | "-" ] ( "." digit { digit } | digit { digit } "." { digit } ) .
 ```
 
 ### Strings

--- a/influxql/scanner_test.go
+++ b/influxql/scanner_test.go
@@ -87,24 +87,16 @@ func TestScanner_Scan(t *testing.T) {
 
 		// Numbers
 		{s: `100`, tok: influxql.INTEGER, lit: `100`},
-		{s: `-100`, tok: influxql.INTEGER, lit: `-100`},
 		{s: `100.23`, tok: influxql.NUMBER, lit: `100.23`},
-		{s: `+100.23`, tok: influxql.NUMBER, lit: `+100.23`},
-		{s: `-100.23`, tok: influxql.NUMBER, lit: `-100.23`},
-		{s: `-100.`, tok: influxql.NUMBER, lit: `-100`},
 		{s: `.23`, tok: influxql.NUMBER, lit: `.23`},
-		{s: `+.23`, tok: influxql.NUMBER, lit: `+.23`},
-		{s: `-.23`, tok: influxql.NUMBER, lit: `-.23`},
 		//{s: `.`, tok: influxql.ILLEGAL, lit: `.`},
-		{s: `-.`, tok: influxql.SUB, lit: ``},
-		{s: `+.`, tok: influxql.ADD, lit: ``},
 		{s: `10.3s`, tok: influxql.NUMBER, lit: `10.3`},
 
 		// Durations
 		{s: `10u`, tok: influxql.DURATIONVAL, lit: `10u`},
 		{s: `10µ`, tok: influxql.DURATIONVAL, lit: `10µ`},
 		{s: `10ms`, tok: influxql.DURATIONVAL, lit: `10ms`},
-		{s: `-1s`, tok: influxql.DURATIONVAL, lit: `-1s`},
+		{s: `1s`, tok: influxql.DURATIONVAL, lit: `1s`},
 		{s: `10m`, tok: influxql.DURATIONVAL, lit: `10m`},
 		{s: `10h`, tok: influxql.DURATIONVAL, lit: `10h`},
 		{s: `10d`, tok: influxql.DURATIONVAL, lit: `10d`},


### PR DESCRIPTION
Additionally, support unary addition and subtraction for variables,
calls, and parenthesis expressions. Doing `-value` will be the
equivalent of doing `-1 * value` now.

Fixes #8174.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated