### PR TITLE
Several statements were missing the DefaultDatabase method

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -594,6 +594,11 @@ func (s *DropRetentionPolicyStatement) RequiredPrivileges() (ExecutionPrivileges
 	return ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: WritePrivilege}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *DropRetentionPolicyStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // CreateUserStatement represents a command for creating a new user.
 type CreateUserStatement struct {
 	// Name of the user to be created.
@@ -704,6 +709,11 @@ func (s *GrantStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *GrantStatement) DefaultDatabase() string {
+	return s.On
+}
+
 // GrantAdminStatement represents a command for granting admin privilege.
 type GrantAdminStatement struct {
 	// Who to grant the privilege to.
@@ -802,6 +812,11 @@ func (s *RevokeStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *RevokeStatement) DefaultDatabase() string {
+	return s.On
+}
+
 // RevokeAdminStatement represents a command to revoke admin privilege from a user.
 type RevokeAdminStatement struct {
 	// Who to revoke admin privilege from.
@@ -868,6 +883,11 @@ func (s *CreateRetentionPolicyStatement) RequiredPrivileges() (ExecutionPrivileg
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *CreateRetentionPolicyStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // AlterRetentionPolicyStatement represents a command to alter an existing retention policy.
 type AlterRetentionPolicyStatement struct {
 	// Name of policy to alter.
@@ -922,6 +942,11 @@ func (s *AlterRetentionPolicyStatement) String() string {
 // RequiredPrivileges returns the privilege required to execute an AlterRetentionPolicyStatement.
 func (s *AlterRetentionPolicyStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *AlterRetentionPolicyStatement) DefaultDatabase() string {
+	return s.Database
 }
 
 // FillOption represents different options for filling aggregate windows.
@@ -2558,6 +2583,14 @@ func (s *DeleteStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: WritePrivilege}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *DeleteStatement) DefaultDatabase() string {
+	if m, ok := s.Source.(*Measurement); ok {
+		return m.Database
+	}
+	return ""
+}
+
 // ShowSeriesStatement represents a command for listing series in the database.
 type ShowSeriesStatement struct {
 	// Database to query. If blank, use the default database.
@@ -2617,6 +2650,11 @@ func (s *ShowSeriesStatement) String() string {
 // RequiredPrivileges returns the privilege required to execute a ShowSeriesStatement.
 func (s *ShowSeriesStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowSeriesStatement) DefaultDatabase() string {
+	return s.Database
 }
 
 // DropSeriesStatement represents a command for removing a series from the database.
@@ -2842,6 +2880,11 @@ func (s *DropContinuousQueryStatement) RequiredPrivileges() (ExecutionPrivileges
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: WritePrivilege}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *DropContinuousQueryStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // ShowMeasurementsStatement represents a command for listing measurements.
 type ShowMeasurementsStatement struct {
 	// Database to query. If blank, use the default database.
@@ -2906,6 +2949,11 @@ func (s *ShowMeasurementsStatement) RequiredPrivileges() (ExecutionPrivileges, e
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowMeasurementsStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // DropMeasurementStatement represents a command to drop a measurement.
 type DropMeasurementStatement struct {
 	// Name of the measurement to be dropped.
@@ -2958,6 +3006,11 @@ func (s *ShowRetentionPoliciesStatement) String() string {
 // RequiredPrivileges returns the privilege(s) required to execute a ShowRetentionPoliciesStatement
 func (s *ShowRetentionPoliciesStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowRetentionPoliciesStatement) DefaultDatabase() string {
+	return s.Database
 }
 
 // ShowStatsStatement displays statistics for a given module.
@@ -3061,6 +3114,11 @@ func (s *CreateSubscriptionStatement) RequiredPrivileges() (ExecutionPrivileges,
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *CreateSubscriptionStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // DropSubscriptionStatement represents a command to drop a subscription to the incoming data stream.
 type DropSubscriptionStatement struct {
 	Name            string
@@ -3076,6 +3134,11 @@ func (s *DropSubscriptionStatement) String() string {
 // RequiredPrivileges returns the privilege required to execute a DropSubscriptionStatement
 func (s *DropSubscriptionStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *DropSubscriptionStatement) DefaultDatabase() string {
+	return s.Database
 }
 
 // ShowSubscriptionsStatement represents a command to show a list of subscriptions.
@@ -3165,6 +3228,11 @@ func (s *ShowTagKeysStatement) RequiredPrivileges() (ExecutionPrivileges, error)
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowTagKeysStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // ShowTagValuesStatement represents a command for listing tag values.
 type ShowTagValuesStatement struct {
 	// Database to query. If blank, use the default database.
@@ -3239,6 +3307,11 @@ func (s *ShowTagValuesStatement) RequiredPrivileges() (ExecutionPrivileges, erro
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
 }
 
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowTagValuesStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // ShowUsersStatement represents a command for listing users.
 type ShowUsersStatement struct{}
 
@@ -3303,6 +3376,11 @@ func (s *ShowFieldKeysStatement) String() string {
 // RequiredPrivileges returns the privilege(s) required to execute a ShowFieldKeysStatement.
 func (s *ShowFieldKeysStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowFieldKeysStatement) DefaultDatabase() string {
+	return s.Database
 }
 
 // Fields represents a list of fields.

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -2,6 +2,7 @@ package influxql_test
 
 import (
 	"fmt"
+	"go/importer"
 	"reflect"
 	"strings"
 	"testing"
@@ -1696,6 +1697,102 @@ func TestParse_Errors(t *testing.T) {
 		bad := fmt.Sprintf(tt.tmpl, tt.bad)
 		if _, err := influxql.ParseStatement(bad); err == nil {
 			t.Fatalf("statement %q should have resulted in a parse error but did not", bad)
+		}
+	}
+}
+
+// This test checks to ensure that we have given thought to the database
+// context required for security checks.  If a new statement is added, this
+// test will fail until it is categorized into the correct bucket below.
+func Test_EnforceHasDefaultDatabase(t *testing.T) {
+	pkg, err := importer.Default().Import("github.com/influxdata/influxdb/influxql")
+	if err != nil {
+		fmt.Printf("error: %s\n", err.Error())
+		return
+	}
+	statements := []string{}
+
+	// this is a list of statements that do not have a database context
+	exemptStatements := []string{
+		"CreateDatabaseStatement",
+		"CreateUserStatement",
+		"DeleteSeriesStatement",
+		"DropDatabaseStatement",
+		"DropMeasurementStatement",
+		"DropSeriesStatement",
+		"DropShardStatement",
+		"DropUserStatement",
+		"GrantAdminStatement",
+		"KillQueryStatement",
+		"RevokeAdminStatement",
+		"SelectStatement",
+		"SetPasswordUserStatement",
+		"ShowContinuousQueriesStatement",
+		"ShowDatabasesStatement",
+		"ShowDiagnosticsStatement",
+		"ShowGrantsForUserStatement",
+		"ShowQueriesStatement",
+		"ShowShardGroupsStatement",
+		"ShowShardsStatement",
+		"ShowStatsStatement",
+		"ShowSubscriptionsStatement",
+		"ShowUsersStatement",
+	}
+
+	exists := func(stmt string) bool {
+		switch stmt {
+		// These are functions with the word statement in them, and can be ignored
+		case "Statement", "MustParseStatement", "ParseStatement", "RewriteStatement":
+			return true
+		default:
+			// check the exempt statements
+			for _, s := range exemptStatements {
+				if s == stmt {
+					return true
+				}
+			}
+			// check the statements that passed the interface test for HasDefaultDatabase
+			for _, s := range statements {
+				if s == stmt {
+					return true
+				}
+			}
+			return false
+		}
+	}
+
+	needsHasDefault := []interface{}{
+		&influxql.AlterRetentionPolicyStatement{},
+		&influxql.CreateContinuousQueryStatement{},
+		&influxql.CreateRetentionPolicyStatement{},
+		&influxql.CreateSubscriptionStatement{},
+		&influxql.DeleteStatement{},
+		&influxql.DropContinuousQueryStatement{},
+		&influxql.DropRetentionPolicyStatement{},
+		&influxql.DropSubscriptionStatement{},
+		&influxql.GrantStatement{},
+		&influxql.RevokeStatement{},
+		&influxql.ShowFieldKeysStatement{},
+		&influxql.ShowMeasurementsStatement{},
+		&influxql.ShowRetentionPoliciesStatement{},
+		&influxql.ShowSeriesStatement{},
+		&influxql.ShowTagKeysStatement{},
+		&influxql.ShowTagValuesStatement{},
+	}
+
+	for _, stmt := range needsHasDefault {
+		statements = append(statements, strings.TrimPrefix(fmt.Sprintf("%T", stmt), "*influxql."))
+		if _, ok := stmt.(influxql.HasDefaultDatabase); !ok {
+			t.Errorf("%T was expected to declare DefaultDatabase method", stmt)
+		}
+
+	}
+
+	for _, declName := range pkg.Scope().Names() {
+		if strings.HasSuffix(declName, "Statement") {
+			if !exists(declName) {
+				t.Errorf("unchecked statement %s.  please update this test to determine if this statement needs to declare 'DefaultDatabase'", declName)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Security depends on the default database context being present for some statements.  These statements were missing that check:

```
&influxql.AlterRetentionPolicyStatement{},
&influxql.CreateRetentionPolicyStatement{},
&influxql.CreateSubscriptionStatement{},
&influxql.DropContinuousQueryStatement{},
&influxql.DropRetentionPolicyStatement{},
&influxql.DropSubscriptionStatement{},
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated