### PR TITLE
Influx CLI, Notify user of failed auth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#7856](https://github.com/influxdata/influxdb/issues/7856): Failed points during an import now result in a non-zero exit code.
 - [#7821](https://github.com/influxdata/influxdb/issues/7821): Expose some configuration settings via SHOW DIAGNOSTICS
 - [#8025](https://github.com/influxdata/influxdb/issues/8025): Support single and multiline comments in InfluxQL.
+- [#8189](https://github.com/influxdata/influxdb/issues/8189): CLI `auth` command now immediately notifies users upon supplying invalid credentials.
 
 ### Bugfixes
 

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -351,6 +351,12 @@ func (c *CommandLine) SetAuth(cmd string) {
 
 	// Update the client as well
 	c.Client.SetAuth(c.ClientConfig.Username, c.ClientConfig.Password)
+
+	// Test the credentials are correct, or else notify the user.
+	response, _ := c.Client.Query(client.Query{Command: "SHOW DATABASES"})
+	if err := response.Error(); err != nil {
+		fmt.Printf("ERR: %s\n", err)
+	}
 }
 
 func (c *CommandLine) clear(cmd string) {

--- a/cmd/influx/cli/cli_test.go
+++ b/cmd/influx/cli/cli_test.go
@@ -78,8 +78,12 @@ func TestRunCLI_ExecuteInsert(t *testing.T) {
 
 func TestSetAuth(t *testing.T) {
 	t.Parallel()
+	ts := emptyTestServer()
+	defer ts.Close()
+
 	c := cli.New(CLIENT_VERSION)
-	config := client.NewConfig()
+	url, _ := url.Parse(ts.URL)
+	config := client.Config{URL: *url}
 	client, _ := client.NewClient(config)
 	c.Client = client
 	u := "userx"


### PR DESCRIPTION
When credentials are supplied to the auth command, immediately
validate them aginst the server and notify the user if
they're invalid.

Closes #7290

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)