### PR TITLE
redact passwords before saving history in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bugfixes
 
+- [#8190](https://github.com/influxdata/influxdb/issues/8190): History file should redact passwords before saving to history.
 - [#8122](https://github.com/influxdata/influxdb/pull/8122): Suppress headers in output for influx cli when they are the same.
 - [#8119](https://github.com/influxdata/influxdb/pull/8119): Add chunked/chunk size as setting/options in cli.
 - [#8091](https://github.com/influxdata/influxdb/issues/8091): Do not increment the continuous query statistic if no query is run.

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -224,6 +224,7 @@ func (c *CommandLine) mainLoop() error {
 				return e
 			}
 			if err := c.ParseCommand(l); err != ErrBlankCommand && !strings.HasPrefix(strings.TrimSpace(l), "auth") {
+				l = influxql.Sanitize(l)
 				c.Line.AppendHistory(l)
 				c.saveHistory()
 			}


### PR DESCRIPTION
fixes #8190 

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

