### PR TITLE
Remove MMAP derefencing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.3 [unreleased]
+
+### Bugfixes
+
+- [#8022](https://github.com/influxdata/influxdb/issues/8022): Segment violation in models.Tags.Get
+
 ## v1.2.2 [2017-03-14]
 
 ### Release Notes

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -444,7 +444,6 @@ func (e *Engine) LoadMetadataIndex(shardID uint64, index *tsdb.DatabaseIndex) er
 
 	// Save reference to index for iterator creation.
 	e.index = index
-	e.FileStore.dereferencer = index
 
 	if err := e.FileStore.WalkKeys(func(key []byte, typ byte) error {
 		fieldType, err := tsmFieldTypeToInfluxQLDataType(typ)
@@ -652,7 +651,7 @@ func (e *Engine) addToIndexFromKey(shardID uint64, key []byte, fieldType influxq
 	_, tags, _ := models.ParseKey(seriesKey)
 
 	s := tsdb.NewSeries(string(seriesKey), tags)
-	index.CreateSeriesIndexIfNotExists(measurement, s, false)
+	index.CreateSeriesIndexIfNotExists(measurement, s, true)
 	s.AssignShard(shardID)
 
 	return nil

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -516,13 +516,6 @@ func (t *TSMReader) BlockIterator() *BlockIterator {
 	}
 }
 
-// deref removes mmap references held by another object.
-func (t *TSMReader) deref(d dereferencer) {
-	if acc, ok := t.accessor.(*mmapAccessor); ok && acc.b != nil {
-		d.Dereference(acc.b)
-	}
-}
-
 // indirectIndex is a TSMIndex that uses a raw byte slice representation of an index.  This
 // implementation can be used for indexes that may be MMAPed into memory.
 type indirectIndex struct {

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
@@ -530,16 +529,6 @@ func (d *DatabaseIndex) DropSeries(keys []string) {
 		d.dropMeasurement(mname)
 	}
 	atomic.AddInt64(&d.stats.NumSeries, -nDeleted)
-}
-
-// Dereference removes all references to data within b and moves them to the heap.
-func (d *DatabaseIndex) Dereference(b []byte) {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	for _, s := range d.series {
-		s.Dereference(b)
-	}
 }
 
 // Measurement represents a collection of time series in a database. It also contains in-memory
@@ -1636,7 +1625,7 @@ func (s *Series) ForEachTag(fn func(models.Tag)) {
 func (s *Series) Tags() models.Tags {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.tags.Clone()
+	return s.tags
 }
 
 // CopyTags clones the tags on the series in-place,
@@ -1651,36 +1640,6 @@ func (s *Series) GetTagString(key string) string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.tags.GetString(key)
-}
-
-// Dereference removes references to a byte slice.
-func (s *Series) Dereference(b []byte) {
-	s.mu.Lock()
-
-	min := uintptr(unsafe.Pointer(&b[0]))
-	max := min + uintptr(len(b))
-
-	for i := range s.tags {
-		deref(&s.tags[i].Key, min, max)
-		deref(&s.tags[i].Value, min, max)
-	}
-
-	s.mu.Unlock()
-}
-
-func deref(v *[]byte, min, max uintptr) {
-	vv := *v
-
-	// Ignore if value is not within range.
-	ptr := uintptr(unsafe.Pointer(&vv[0]))
-	if ptr < min || ptr > max {
-		return
-	}
-
-	// Otherwise copy to the heap.
-	buf := make([]byte, len(vv))
-	copy(buf, vv)
-	*v = buf
 }
 
 // MarshalBinary encodes the object to a binary format.


### PR DESCRIPTION
This code was added to address some slow startup issues.  It is believed
to be the cause of some segfault panic's that occur at query time when
the underlying MMAP array has been unmapped.  The current structure of
code makes this change unnecessary now.

We now always clone the tags whenever we create a new series.

Fixes #8022 

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
