### PR TITLE
Speed up drops/deletes and startup

### DIFF
--- a/tsdb/engine/tsm1/file_store_internal_test.go
+++ b/tsdb/engine/tsm1/file_store_internal_test.go
@@ -1,0 +1,249 @@
+package tsm1
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestMergeSeriesKey_Single(t *testing.T) {
+	a := make(chan seriesKey, 5)
+	for i := 0; i < cap(a); i++ {
+		a <- seriesKey{key: []byte(fmt.Sprintf("%d", i))}
+	}
+
+	merged := merge(a)
+	close(a)
+
+	exp := []string{"0", "1", "2", "3", "4"}
+	for v := range merged {
+		if got, exp := v, exp[0]; !bytes.Equal(got.key, []byte(exp)) {
+			t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+		}
+		exp = exp[1:]
+	}
+
+	if len(exp) > 0 {
+		t.Fatalf("missed values: %v", exp)
+	}
+}
+
+func TestMergeSeriesKey_Nil(t *testing.T) {
+	merged := merge(nil)
+
+	for v := range merged {
+		t.Fatalf("value mismatch: got %v, exp nil", v)
+	}
+
+	merged = merge(nil, nil)
+	for v := range merged {
+		t.Fatalf("value mismatch: got %v, exp nil", v)
+	}
+
+}
+
+func TestMergeSeriesKey_Duplicates(t *testing.T) {
+	a := make(chan seriesKey, 5)
+	b := make(chan seriesKey, 5)
+
+	for i := 0; i < cap(a); i++ {
+		a <- seriesKey{key: []byte(fmt.Sprintf("%d", i))}
+		b <- seriesKey{key: []byte(fmt.Sprintf("%d", i))}
+	}
+
+	merged := merge(a, b)
+	close(a)
+	close(b)
+
+	exp := []string{"0", "1", "2", "3", "4"}
+	for v := range merged {
+		if len(exp) == 0 {
+			t.Fatalf("more values than expected: got %v", v)
+		}
+
+		if got, exp := v, exp[0]; !bytes.Equal(got.key, []byte(exp)) {
+			t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+		}
+
+		exp = exp[1:]
+	}
+
+	if len(exp) > 0 {
+		t.Fatalf("missed values: %v", exp)
+	}
+}
+
+func TestMergeSeriesKey_Alternating(t *testing.T) {
+	a := make(chan seriesKey, 2)
+	b := make(chan seriesKey, 2)
+
+	for i := 0; i < cap(a); i++ {
+		a <- seriesKey{key: []byte(fmt.Sprintf("%d", i*2))}
+		b <- seriesKey{key: []byte(fmt.Sprintf("%d", i*2+1))}
+	}
+
+	merged := merge(a, b)
+	close(a)
+	close(b)
+
+	exp := []string{"0", "1", "2", "3"}
+	for v := range merged {
+		if len(exp) == 0 {
+			t.Fatalf("more values than expected: got %v", v)
+		}
+
+		if got, exp := v, exp[0]; !bytes.Equal(got.key, []byte(exp)) {
+			t.Fatalf("value mismatch: got %v, exp %v", string(got.key), exp)
+		}
+		exp = exp[1:]
+	}
+
+	if len(exp) > 0 {
+		t.Fatalf("missed values: %v", exp)
+	}
+}
+
+func TestMergeSeriesKey_AlternatingDuplicates(t *testing.T) {
+	a := make(chan seriesKey, 2)
+	b := make(chan seriesKey, 2)
+	c := make(chan seriesKey, 2)
+
+	for i := 0; i < cap(a); i++ {
+		a <- seriesKey{key: []byte(fmt.Sprintf("%d", i*2))}
+		b <- seriesKey{key: []byte(fmt.Sprintf("%d", i*2+1))}
+		c <- seriesKey{key: []byte(fmt.Sprintf("%d", i*2))}
+	}
+
+	merged := merge(a, b, c)
+	close(a)
+	close(b)
+	close(c)
+
+	exp := []string{"0", "1", "2", "3"}
+	for v := range merged {
+		if len(exp) == 0 {
+			t.Fatalf("more values than expected: got %v", v)
+		}
+
+		if got, exp := v, exp[0]; !bytes.Equal(got.key, []byte(exp)) {
+			t.Fatalf("value mismatch: got %v, exp %v", string(got.key), exp)
+		}
+		exp = exp[1:]
+	}
+
+	if len(exp) > 0 {
+		t.Fatalf("missed values: %v", exp)
+	}
+}
+
+func TestMergeSeriesKey_Unbuffered(t *testing.T) {
+	a := make(chan seriesKey)
+	b := make(chan seriesKey)
+
+	go func() {
+		for i := 0; i < 2; i++ {
+			a <- seriesKey{key: []byte(fmt.Sprintf("%d", i*2))}
+		}
+		close(a)
+	}()
+
+	go func() {
+		for i := 0; i < 2; i++ {
+			b <- seriesKey{key: []byte(fmt.Sprintf("%d", i*2+1))}
+		}
+		close(b)
+	}()
+
+	merged := merge(a, b)
+
+	exp := []string{"0", "1", "2", "3"}
+	for v := range merged {
+		if len(exp) == 0 {
+			t.Fatalf("more values than expected: got %v", v)
+		}
+
+		if got, exp := v, exp[0]; !bytes.Equal(got.key, []byte(exp)) {
+			t.Fatalf("value mismatch: got %v, exp %v", string(got.key), exp)
+		}
+		exp = exp[1:]
+	}
+
+	if len(exp) > 0 {
+		t.Fatalf("missed values: %v", exp)
+	}
+}
+
+func TestMergeSeriesKey_OneEmpty(t *testing.T) {
+	a := make(chan seriesKey)
+	b := make(chan seriesKey)
+
+	go func() {
+		for i := 0; i < 2; i++ {
+			a <- seriesKey{key: []byte(fmt.Sprintf("%d", i*2))}
+		}
+		close(a)
+	}()
+
+	close(b)
+	merged := merge(a, b)
+
+	exp := []string{"0", "2"}
+	for v := range merged {
+		if len(exp) == 0 {
+			t.Fatalf("more values than expected: got %v", v)
+		}
+
+		if got, exp := v, exp[0]; !bytes.Equal(got.key, []byte(exp)) {
+			t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+		}
+		exp = exp[1:]
+	}
+
+	if len(exp) > 0 {
+		t.Fatalf("missed values: %v", exp)
+	}
+}
+
+func TestMergeSeriesKey_Overlapping(t *testing.T) {
+	a := make(chan seriesKey)
+	b := make(chan seriesKey)
+	c := make(chan seriesKey)
+
+	go func() {
+		for i := 0; i < 3; i++ {
+			a <- seriesKey{key: []byte(fmt.Sprintf("%d", i))}
+		}
+		close(a)
+	}()
+
+	go func() {
+		for i := 4; i < 7; i++ {
+			b <- seriesKey{key: []byte(fmt.Sprintf("%d", i))}
+		}
+		close(b)
+	}()
+
+	go func() {
+		for i := 0; i < 9; i++ {
+			c <- seriesKey{key: []byte(fmt.Sprintf("%d", i))}
+		}
+		close(c)
+	}()
+	merged := merge(a, b, c)
+
+	exp := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8"}
+	for v := range merged {
+		if len(exp) == 0 {
+			t.Fatalf("more values than expected: got %v", v)
+		}
+
+		if got, exp := v, exp[0]; !bytes.Equal(got.key, []byte(exp)) {
+			t.Fatalf("value mismatch: got %v, exp %v", string(got.key), exp)
+		}
+		exp = exp[1:]
+	}
+
+	if len(exp) > 0 {
+		t.Fatalf("missed values: %v", exp)
+	}
+}

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -710,21 +710,23 @@ func (d *indirectIndex) Key(idx int) (string, byte, []IndexEntry) {
 // KeyAt returns the key in the index at the given position.
 func (d *indirectIndex) KeyAt(idx int) ([]byte, byte) {
 	d.mu.RLock()
-	defer d.mu.RUnlock()
 
 	if idx < 0 || idx >= len(d.offsets) {
+		d.mu.RUnlock()
 		return nil, 0
 	}
 	n, key, _ := readKey(d.b[d.offsets[idx]:])
-	return key, d.b[d.offsets[idx]+int32(n)]
+	typ := d.b[d.offsets[idx]+int32(n)]
+	d.mu.RUnlock()
+	return key, typ
 }
 
 // KeyCount returns the count of unique keys in the index.
 func (d *indirectIndex) KeyCount() int {
 	d.mu.RLock()
-	defer d.mu.RUnlock()
-
-	return len(d.offsets)
+	n := len(d.offsets)
+	d.mu.RUnlock()
+	return n
 }
 
 // Delete removes the given keys from the index.

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -501,6 +501,7 @@ func (s *Store) DeleteMeasurement(database, name string) error {
 	}
 
 	seriesKeys := m.SeriesKeys()
+	sort.Strings(seriesKeys)
 
 	s.mu.RLock()
 	shards := s.filterShards(func(sh *Shard) bool {
@@ -753,6 +754,10 @@ func (s *Store) deleteSeries(database string, seriesKeys []string, min, max int6
 	db := s.databaseIndexes[database]
 	if db == nil {
 		return influxql.ErrDatabaseNotFound(database)
+	}
+
+	if !sort.StringsAreSorted(seriesKeys) {
+		sort.Strings(seriesKeys)
 	}
 
 	s.mu.RLock()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -734,11 +734,11 @@ func (s *Store) DeleteSeries(database string, sources []influxql.Source, conditi
 			}
 		} else {
 			// No WHERE clause so get all series IDs for this measurement.
-			ids = m.seriesIDs
+			ids = m.SeriesIDs()
 		}
 
 		for _, id := range ids {
-			seriesKeys = append(seriesKeys, m.seriesByID[id].Key)
+			seriesKeys = append(seriesKeys, m.SeriesByID(id).Key)
 		}
 	}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated

This PR speeds up all drop and deletes statements as well as startup times.  The drops and delete statements were slow due to cleaning up the in-memory index as well as some inefficient code paths in the TSM tombstoning path.

* Deleting series keys using `FileStore.Walk` which iterated over every key in every TSM file sequentially.  It spent a lot of time and memory deduplicating keys and converting them to the underlying series keys.  This was switch to leverage the already sorted TSM file indexes to merge and iterate over them in parallel.  
* A side effect of optimizing `FileStore.Walk` is that it is also used at startup to reload the index.  This now reduces the number of keys that are parsed across all files.  I noticed ~50% speedup with my dataset, but did not experiment with other datasets.  It's possible the _optimize_ compactions may be able to be removed in the future if this change keeps start times consistent.
* Writing tombstone files did not buffer writes.  When deleting many series keys, a lot of IO time due to small writes would slow the writes down.  This now uses a buffered writer.
* Deleting a retention policy or `delete series` used a slower code path that needed to remove series ids from the in-memory measurement index.  There is a sorted slice of series IDs that was constantly maintained and cause memory to be continuously re-copied.  Keeping this sorted during large bulk deletes was too slow.  Instead, we create the sorted slice on-demand the first time it's requested by a query.  Deletes now just delete from a map which is much faster.
* Deleting keys in various parts of the TSM engine used some intermediate maps.  This created garbage and high memory usage.  These were switched to use approaches that leveraged the already sorted series keys to avoid the intermediate allocations.

Some benchmarks from testing w/ a dataset of 5M series in some unoptimized TSM files (e.g the keys were repeated across many big TSM files).  I test the same dataset w/ 1.2.2 and this branch:

### Drop retention policy
Before **10m35s**, after **7s**

### Drop measurement
Before **25m6s**, after **29s**

Delete series and drop database (also optimized further in #8179) had similar speedups. 