### PR TITLE
Add option write-log-enabled

### DIFF
--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	BindAddress        string `toml:"bind-address"`
 	AuthEnabled        bool   `toml:"auth-enabled"`
 	LogEnabled         bool   `toml:"log-enabled"`
+	WriteLogEnabled    bool   `toml:"write-log-enabled"`
 	WriteTracing       bool   `toml:"write-tracing"`
 	PprofEnabled       bool   `toml:"pprof-enabled"`
 	HTTPSEnabled       bool   `toml:"https-enabled"`
@@ -36,6 +37,7 @@ func NewConfig() Config {
 		Enabled:           true,
 		BindAddress:       DefaultBindAddress,
 		LogEnabled:        true,
+		WriteLogEnabled:   true,
 		PprofEnabled:      true,
 		HTTPSEnabled:      false,
 		HTTPSCertificate:  "/etc/ssl/influxdb.pem",

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -127,7 +127,7 @@ func NewHandler(c Config) *Handler {
 		},
 		Route{
 			"write", // Data-ingest route.
-			"POST", "/write", true, true, h.serveWrite,
+			"POST", "/write", true, c.WriteLogEnabled, h.serveWrite,
 		},
 		Route{ // Ping
 			"ping",


### PR DESCRIPTION
For investigating (slow) queries (f.e. their timings, number, when and so on) I need to log-enabled=true, but massive writes overflood the influx log.

I propose this additional flag write-log-enabled=false to selectively turn off write logs.

```
[http]
  log-enabled = true
  write-log-enabled = false
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
- [x] Provide example syntax
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
