### PR TITLE
Ensure shared index removed when dropping database

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -278,7 +278,9 @@ func (s *Store) Close() error {
 	return nil
 }
 
-// createIndexIfNotExists returns an index for a database.
+// createIndexIfNotExists returns a shared index for a database, if the inmem
+// index is being used. If the TSI index is being used, then this method is
+// basically a no-op.
 func (s *Store) createIndexIfNotExists(name string) (interface{}, error) {
 	if idx := s.indexes[name]; idx != nil {
 		return idx, nil
@@ -480,6 +482,9 @@ func (s *Store) DeleteDatabase(name string) error {
 
 	// Remove database from store list of databases
 	delete(s.databases, name)
+
+	// Remove shared index for database if using inmem index.
+	delete(s.indexes, name)
 	s.mu.Unlock()
 
 	return nil

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -278,13 +278,7 @@ func (s *Store) Close() error {
 	return nil
 }
 
-// CreateIndexIfNotExists returns an in-memory index for a database.
-func (s *Store) CreateIndexIfNotExists(name string) (interface{}, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.createIndexIfNotExists(name)
-}
-
+// createIndexIfNotExists returns an index for a database.
 func (s *Store) createIndexIfNotExists(name string) (interface{}, error) {
 	if idx := s.indexes[name]; idx != nil {
 		return idx, nil


### PR DESCRIPTION
Fixes #8227.

When using the `inmem` index, if one drops a database, and then creates it
again, the previous index object will be reused. This includes the
previous cardinality estimation sketches, leading to inaccurate
cardinality estimations.