### PR TITLE
Backport - Fix delete time fields creating unparseable points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#8155](https://github.com/influxdata/influxdb/pull/8155): Simplify admin user check.
 - [#8167](https://github.com/influxdata/influxdb/issues/8167): Fix a regression when math was used with selectors.
 - [#8175](https://github.com/influxdata/influxdb/issues/8175): Ensure the input for certain functions in the query engine are ordered.
+- [#8254](https://github.com/influxdata/influxdb/pull/8254): Fix delete time fields creating unparseable points
 
 ## v1.2.2 [2017-03-14]
 

--- a/models/points.go
+++ b/models/points.go
@@ -1936,7 +1936,9 @@ func (p *point) Delete() {
 	switch {
 	case p.it.end == p.it.start:
 	case p.it.end >= len(p.fields):
-		p.fields = p.fields[:p.it.start]
+		// Remove the trailing comma if there are more than one fields
+		p.fields = bytes.TrimSuffix(p.fields[:p.it.start], []byte(","))
+
 	case p.it.start == 0:
 		p.fields = p.fields[p.it.end:]
 	default:

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -2182,6 +2182,10 @@ func TestPoint_FieldIterator_Delete_Begin(t *testing.T) {
 	if !reflect.DeepEqual(got, exp) {
 		t.Fatalf("Delete failed, got %#v, exp %#v", got, exp)
 	}
+
+	if _, err = models.ParsePointsString(points[0].String()); err != nil {
+		t.Fatalf("Failed to parse point: %v", err)
+	}
 }
 
 func TestPoint_FieldIterator_Delete_Middle(t *testing.T) {
@@ -2202,6 +2206,10 @@ func TestPoint_FieldIterator_Delete_Middle(t *testing.T) {
 
 	if !reflect.DeepEqual(got, exp) {
 		t.Fatalf("Delete failed, got %#v, exp %#v", got, exp)
+	}
+
+	if _, err = models.ParsePointsString(points[0].String()); err != nil {
+		t.Fatalf("Failed to parse point: %v", err)
 	}
 }
 
@@ -2225,6 +2233,10 @@ func TestPoint_FieldIterator_Delete_End(t *testing.T) {
 	if !reflect.DeepEqual(got, exp) {
 		t.Fatalf("Delete failed, got %#v, exp %#v", got, exp)
 	}
+
+	if _, err = models.ParsePointsString(points[0].String()); err != nil {
+		t.Fatalf("Failed to parse point: %v", err)
+	}
 }
 
 func TestPoint_FieldIterator_Delete_Nothing(t *testing.T) {
@@ -2243,6 +2255,10 @@ func TestPoint_FieldIterator_Delete_Nothing(t *testing.T) {
 
 	if !reflect.DeepEqual(got, exp) {
 		t.Fatalf("Delete failed, got %#v, exp %#v", got, exp)
+	}
+
+	if _, err = models.ParsePointsString(points[0].String()); err != nil {
+		t.Fatalf("Failed to parse point: %v", err)
 	}
 }
 
@@ -2265,6 +2281,10 @@ func TestPoint_FieldIterator_Delete_Twice(t *testing.T) {
 
 	if !reflect.DeepEqual(got, exp) {
 		t.Fatalf("Delete failed, got %#v, exp %#v", got, exp)
+	}
+
+	if _, err = models.ParsePointsString(points[0].String()); err != nil {
+		t.Fatalf("Failed to parse point: %v", err)
 	}
 }
 


### PR DESCRIPTION
If a field was named time was written and was subsequently dropped,
it could leave a trailing comma in the series key causing it to fail
to be parseable in other parts of the code.

Backport #8251 
