### PR TITLE
Fix LIMIT and OFFSET for certain aggregate queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8065](https://github.com/influxdata/influxdb/issues/8065): Restrict top() and bottom() selectors to be used with no other functions.
 - [#8266](https://github.com/influxdata/influxdb/issues/8266): top() and bottom() now returns the time for every point.
 - [#8315](https://github.com/influxdata/influxdb/issues/8315): Remove default upper time bound on DELETE queries.
+- [#8066](https://github.com/influxdata/influxdb/issues/8066): Fix LIMIT and OFFSET for certain aggregate queries.
 
 ## v1.2.3 [unreleased]
 


### PR DESCRIPTION
When LIMIT and OFFSET were used with any functions that were not handled
directly by the query engine (anything other than count, max, min, mean,
first, or last), the input to the function would be limited instead of
receiving the full stream of values it was supposed to receive.

This also fixes a bug that caused the server to hang when LIMIT and
OFFSET were used with a selector. When using a selector, the limit and
offset should be handled before the points go to the auxiliary iterator
to be split into different iterators. Limiting happened afterwards which
caused the auxiliary iterator to hang forever.

Fixes #8066.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated