### PR TITLE
Fix deadlock in Measurement.SeriesIDsAllOrByExpr

### DIFF
--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -841,17 +841,16 @@ func expandExprWithValues(expr influxql.Expr, keys []string, tagExprs []tagExpr,
 // SeriesIDsAllOrByExpr walks an expressions for matching series IDs
 // or, if no expressions is given, returns all series IDs for the measurement.
 func (m *Measurement) SeriesIDsAllOrByExpr(expr influxql.Expr) (SeriesIDs, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.seriesIDsAllOrByExpr(expr)
-}
-
-func (m *Measurement) seriesIDsAllOrByExpr(expr influxql.Expr) (SeriesIDs, error) {
 	// If no expression given or the measurement has no series,
 	// we can take just return the ids or nil accordingly.
 	if expr == nil {
 		return m.SeriesIDs(), nil
-	} else if len(m.seriesByID) == 0 {
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.seriesByID) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
SeriesIDsAllOrByExpr took a RLock and ended up calling SeriesIDs
which can take a Lock causing a deadlock.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
