### PR TITLE
Implicitly cast null to false in binary expressions with a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [#8177](https://github.com/influxdata/influxdb/issues/8177): Fix racy integration test.
 - [#8230](https://github.com/influxdata/influxdb/issues/8230): Prevent overflowing or underflowing during window computation.
 - [#8058](https://github.com/influxdata/influxdb/pull/8058): Enabled golint for admin, httpd, subscriber, udp. @karlding
+- [#8252](https://github.com/influxdata/influxdb/issues/8252): Implicitly cast null to false in binary expressions with a boolean.
 
 ## v1.2.3 [unreleased]
 

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -1136,7 +1136,7 @@ func TestEval(t *testing.T) {
 		// String literals.
 		{in: `'foo' = 'bar'`, out: false},
 		{in: `'foo' = 'foo'`, out: true},
-		{in: `'' = 4`, out: false},
+		{in: `'' = 4`, out: nil},
 
 		// Regex literals.
 		{in: `'foo' =~ /f.*/`, out: true},
@@ -1148,9 +1148,12 @@ func TestEval(t *testing.T) {
 		{in: `foo`, out: "bar", data: map[string]interface{}{"foo": "bar"}},
 		{in: `foo = 'bar'`, out: true, data: map[string]interface{}{"foo": "bar"}},
 		{in: `foo = 'bar'`, out: nil, data: map[string]interface{}{"foo": nil}},
+		{in: `'bar' = foo`, out: nil, data: map[string]interface{}{"foo": nil}},
 		{in: `foo <> 'bar'`, out: true, data: map[string]interface{}{"foo": "xxx"}},
 		{in: `foo =~ /b.*/`, out: true, data: map[string]interface{}{"foo": "bar"}},
 		{in: `foo !~ /b.*/`, out: false, data: map[string]interface{}{"foo": "bar"}},
+		{in: `foo > 2 OR bar > 3`, out: true, data: map[string]interface{}{"foo": float64(4)}},
+		{in: `foo > 2 OR bar > 3`, out: true, data: map[string]interface{}{"bar": float64(4)}},
 	} {
 		// Evaluate expression.
 		out := influxql.Eval(MustParseExpr(tt.in), tt.data)


### PR DESCRIPTION
Also more consistently treat a binary expression with strings so it
produces the same value no matter the direction of the expression.

Fixes #8252.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>