### PR TITLE
Optimize Point.NewPointFromBytes

### DIFF
--- a/models/points_test.go
+++ b/models/points_test.go
@@ -131,6 +131,25 @@ func BenchmarkNewPoint(b *testing.B) {
 	}
 }
 
+func BenchmarkNewPointFromBinary(b *testing.B) {
+	pts, err := models.ParsePointsString("cpu value1=1.0,value2=1.0,value3=3.0,value4=4,value5=\"five\" 1000000000")
+	if err != nil {
+		b.Fatalf("unexpected error ParsePointsString: %v", err)
+	}
+
+	bytes, err := pts[0].MarshalBinary()
+	if err != nil {
+		b.Fatalf("unexpected error MarshalBinary: %v", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, err := models.NewPointFromBytes(bytes)
+		if err != nil {
+			b.Fatalf("unexpected error NewPointsFromBytes: %v", err)
+		}
+	}
+}
+
 func BenchmarkParsePointNoTags5000(b *testing.B) {
 	var batch [5000]string
 	for i := 0; i < len(batch); i++ {


### PR DESCRIPTION
There was a check to ensure that fields exists when unmarshalBinary
is called.  This created a map and other garbage just to see if any
fields exist and then was thrown away.  The amount of garbage created is
proportional to the number of fields too.  The benchmark below uses 5 fields.

This changes it to use a FieldIterator that does not allocate as
much as the other method.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkNewPointFromBinary-8     1310          457           -65.11%

benchmark                         old allocs     new allocs     delta
BenchmarkNewPointFromBinary-8     14             1              -92.86%

benchmark                         old bytes     new bytes     delta
BenchmarkNewPointFromBinary-8     672           240           -64.29%
```

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
