### PR TITLE
Implement value-transform functions such as sin() and abs().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#7393](https://github.com/influxdata/influxdb/issues/7393): Add "non_negative_difference" function to InfluxQL.
 - [#8042](https://github.com/influxdata/influxdb/issues/8042): Add bitwise AND, OR and XOR operators to the query language.
 - [#8302](https://github.com/influxdata/influxdb/pull/8302): Write throughput/concurrency improvements
+- [#659](https://github.com/influxdata/influxdb/issues/659): Add value-transform functions to the query language (abs, sin, cos, tan, asin, acos, atan, log, log10, exp, sqrt, rad2deg, deg2rad, pow, ceiling, floor, round)
 
 ### Bugfixes
 

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -1237,6 +1237,56 @@ func TestEvalType(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: `rounding float to integer`,
+			in:   `round(value)`,
+			typ:  influxql.Integer,
+			data: EvalFixture{
+				"cpu": map[string]influxql.DataType{
+					"value": influxql.Float,
+				},
+			},
+		},
+		{
+			name: `sin(integer) returns float`,
+			in:   `sin(value)`,
+			typ:  influxql.Float,
+			data: EvalFixture{
+				"cpu": map[string]influxql.DataType{
+					"value": influxql.Integer,
+				},
+			},
+		},
+		{
+			name: `pow(integer, 4) returns integer`,
+			in:   `pow(value, 4)`,
+			typ:  influxql.Integer,
+			data: EvalFixture{
+				"cpu": map[string]influxql.DataType{
+					"value": influxql.Integer,
+				},
+			},
+		},
+		{
+			name: `pow(integer, -2) returns float`,
+			in:   `pow(value, -2)`,
+			typ:  influxql.Float,
+			data: EvalFixture{
+				"cpu": map[string]influxql.DataType{
+					"value": influxql.Integer,
+				},
+			},
+		},
+		{
+			name: `pow(integer, 2.2) returns float`,
+			in:   `pow(value, 2.2)`,
+			typ:  influxql.Float,
+			data: EvalFixture{
+				"cpu": map[string]influxql.DataType{
+					"value": influxql.Integer,
+				},
+			},
+		},
 	} {
 		sources := make([]influxql.Source, 0, len(tt.data))
 		for src := range tt.data {


### PR DESCRIPTION
This adds 17 "value transforms" to InfluxQL, where these are defined as functions which operate on the value of one datapoint at a time, leaving the timestamp unaffected.

The full list of functions added is: `abs`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `log`, `log10`, `exp`, `sqrt`, `rad2deg`, `deg2rad`, `pow`, `ceiling`, `floor`, `round`.

All of these work for float and integer datatypes.  You get integer points back where possible (e.g. `round(my_float)` or `abs(my_int)`), otherwise you get float points.

Internally, they are called via the Auxiliary Value route rather than as standard Calls (which are basically for aggregators, selectors and other things which don't necessarily return a new value for each input point).  This means that they play nicely with multi-field queries, selectors, nesting and subqueries; the following queries on the standard dataset all produce the expected results:

```
SELECT water_level, 3 * abs(water_level - 100.4) AS fred FROM h2o_feet LIMIT 3

SELECT max(water_level), sqrt(abs(water_level)) FROM h2o_feet

SELECT -4 * abs(fred) FROM (SELECT mean(water_level) AS fred FROM h2o_feet)

SELECT mean(*) FROM (SELECT abs(water_level) FROM h2o_feet)
```

More unit tests are required, but implementing the tests seems to be harder than implementing the code, particularly for more complex queries like the ones above.  Any pointers or examples welcome.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Provide example syntax
- [x] [InfluxData Documentation] https://github.com/influxdata/docs.influxdata.com/pull/1097
