### PR TITLE
top() and bottom() now returns the time for every point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8252](https://github.com/influxdata/influxdb/issues/8252): Implicitly cast null to false in binary expressions with a boolean.
 - [#8067](https://github.com/influxdata/influxdb/issues/8067): Restrict fill(none) and fill(linear) to be usable only with aggregate queries.
 - [#8065](https://github.com/influxdata/influxdb/issues/8065): Restrict top() and bottom() selectors to be used with no other functions.
+- [#8266](https://github.com/influxdata/influxdb/issues/8266): top() and bottom() now returns the time for every point.
 
 ## v1.2.3 [unreleased]
 

--- a/influxql/call_iterator.go
+++ b/influxql/call_iterator.go
@@ -786,14 +786,14 @@ func IntegerSpreadReduceSlice(a []IntegerPoint) []IntegerPoint {
 func newTopIterator(input Iterator, opt IteratorOptions, n *IntegerLiteral, tags []int) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		aggregateFn := NewFloatTopReduceSliceFunc(int(n.Val), tags, opt.Interval)
+		aggregateFn := NewFloatTopReduceSliceFunc(int(n.Val), tags, opt)
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
 			fn := NewFloatSliceFuncReducer(aggregateFn)
 			return fn, fn
 		}
 		return newFloatReduceFloatIterator(input, opt, createFn), nil
 	case IntegerIterator:
-		aggregateFn := NewIntegerTopReduceSliceFunc(int(n.Val), tags, opt.Interval)
+		aggregateFn := NewIntegerTopReduceSliceFunc(int(n.Val), tags, opt)
 		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
 			fn := NewIntegerSliceFuncReducer(aggregateFn)
 			return fn, fn
@@ -805,7 +805,7 @@ func newTopIterator(input Iterator, opt IteratorOptions, n *IntegerLiteral, tags
 }
 
 // NewFloatTopReduceSliceFunc returns the top values within a window.
-func NewFloatTopReduceSliceFunc(n int, tags []int, interval Interval) FloatReduceSliceFunc {
+func NewFloatTopReduceSliceFunc(n int, tags []int, opt IteratorOptions) FloatReduceSliceFunc {
 	return func(a []FloatPoint) []FloatPoint {
 		// Filter by tags if they exist.
 		if len(tags) > 0 {
@@ -837,13 +837,9 @@ func NewFloatTopReduceSliceFunc(n int, tags []int, interval Interval) FloatReduc
 			points = append(points, p)
 		}
 
-		// Either zero out all values or sort the points by time
-		// depending on if a time interval was given or not.
-		if !interval.IsZero() {
-			for i := range points {
-				points[i].Time = ZeroTime
-			}
-		} else {
+		// Order the points by time if an ordered output was requested.
+		// Try to keep the original ordering if possible by using a stable sort.
+		if opt.Ordered {
 			sort.Stable(floatPointsByTime(points))
 		}
 		return points
@@ -851,7 +847,7 @@ func NewFloatTopReduceSliceFunc(n int, tags []int, interval Interval) FloatReduc
 }
 
 // NewIntegerTopReduceSliceFunc returns the top values within a window.
-func NewIntegerTopReduceSliceFunc(n int, tags []int, interval Interval) IntegerReduceSliceFunc {
+func NewIntegerTopReduceSliceFunc(n int, tags []int, opt IteratorOptions) IntegerReduceSliceFunc {
 	return func(a []IntegerPoint) []IntegerPoint {
 		// Filter by tags if they exist.
 		if len(tags) > 0 {
@@ -883,13 +879,9 @@ func NewIntegerTopReduceSliceFunc(n int, tags []int, interval Interval) IntegerR
 			points = append(points, p)
 		}
 
-		// Either zero out all values or sort the points by time
-		// depending on if a time interval was given or not.
-		if !interval.IsZero() {
-			for i := range points {
-				points[i].Time = ZeroTime
-			}
-		} else {
+		// Order the points by time if an ordered output was requested.
+		// Try to keep the original ordering if possible by using a stable sort.
+		if opt.Ordered {
 			sort.Stable(integerPointsByTime(points))
 		}
 		return points
@@ -899,14 +891,14 @@ func NewIntegerTopReduceSliceFunc(n int, tags []int, interval Interval) IntegerR
 func newBottomIterator(input Iterator, opt IteratorOptions, n *IntegerLiteral, tags []int) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
-		aggregateFn := NewFloatBottomReduceSliceFunc(int(n.Val), tags, opt.Interval)
+		aggregateFn := NewFloatBottomReduceSliceFunc(int(n.Val), tags, opt)
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
 			fn := NewFloatSliceFuncReducer(aggregateFn)
 			return fn, fn
 		}
 		return newFloatReduceFloatIterator(input, opt, createFn), nil
 	case IntegerIterator:
-		aggregateFn := NewIntegerBottomReduceSliceFunc(int(n.Val), tags, opt.Interval)
+		aggregateFn := NewIntegerBottomReduceSliceFunc(int(n.Val), tags, opt)
 		createFn := func() (IntegerPointAggregator, IntegerPointEmitter) {
 			fn := NewIntegerSliceFuncReducer(aggregateFn)
 			return fn, fn
@@ -918,7 +910,7 @@ func newBottomIterator(input Iterator, opt IteratorOptions, n *IntegerLiteral, t
 }
 
 // NewFloatBottomReduceSliceFunc returns the bottom values within a window.
-func NewFloatBottomReduceSliceFunc(n int, tags []int, interval Interval) FloatReduceSliceFunc {
+func NewFloatBottomReduceSliceFunc(n int, tags []int, opt IteratorOptions) FloatReduceSliceFunc {
 	return func(a []FloatPoint) []FloatPoint {
 		// Filter by tags if they exist.
 		if len(tags) > 0 {
@@ -950,13 +942,9 @@ func NewFloatBottomReduceSliceFunc(n int, tags []int, interval Interval) FloatRe
 			points = append(points, p)
 		}
 
-		// Either zero out all values or sort the points by time
-		// depending on if a time interval was given or not.
-		if !interval.IsZero() {
-			for i := range points {
-				points[i].Time = ZeroTime
-			}
-		} else {
+		// Order the points by time if an ordered output was requested.
+		// Try to keep the original ordering if possible by using a stable sort.
+		if opt.Ordered {
 			sort.Stable(floatPointsByTime(points))
 		}
 		return points
@@ -964,7 +952,7 @@ func NewFloatBottomReduceSliceFunc(n int, tags []int, interval Interval) FloatRe
 }
 
 // NewIntegerBottomReduceSliceFunc returns the bottom values within a window.
-func NewIntegerBottomReduceSliceFunc(n int, tags []int, interval Interval) IntegerReduceSliceFunc {
+func NewIntegerBottomReduceSliceFunc(n int, tags []int, opt IteratorOptions) IntegerReduceSliceFunc {
 	return func(a []IntegerPoint) []IntegerPoint {
 		// Filter by tags if they exist.
 		if len(tags) > 0 {
@@ -996,13 +984,9 @@ func NewIntegerBottomReduceSliceFunc(n int, tags []int, interval Interval) Integ
 			points = append(points, p)
 		}
 
-		// Either zero out all values or sort the points by time
-		// depending on if a time interval was given or not.
-		if !interval.IsZero() {
-			for i := range points {
-				points[i].Time = ZeroTime
-			}
-		} else {
+		// Order the points by time if an ordered output was requested.
+		// Try to keep the original ordering if possible by using a stable sort.
+		if opt.Ordered {
 			sort.Stable(integerPointsByTime(points))
 		}
 		return points

--- a/influxql/call_iterator_test.go
+++ b/influxql/call_iterator_test.go
@@ -14,12 +14,11 @@ func TestCallIterator_Count_Float(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&FloatIterator{Points: []influxql.FloatPoint{
 			{Name: "cpu", Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-			{Name: "cpu", Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "cpu", Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Name: "cpu", Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Name: "cpu", Time: 5, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Name: "cpu", Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "cpu", Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "mem", Time: 23, Value: 10, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
@@ -27,6 +26,8 @@ func TestCallIterator_Count_Float(t *testing.T) {
 			Expr:       MustParseExpr(`count("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -34,8 +35,8 @@ func TestCallIterator_Count_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 3, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 1, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "cpu", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "mem", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
@@ -48,12 +49,11 @@ func TestCallIterator_Count_Integer(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&IntegerIterator{Points: []influxql.IntegerPoint{
 			{Name: "cpu", Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-			{Name: "cpu", Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "cpu", Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Name: "cpu", Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Name: "cpu", Time: 5, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Name: "cpu", Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "cpu", Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "mem", Time: 23, Value: 10, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
@@ -61,6 +61,8 @@ func TestCallIterator_Count_Integer(t *testing.T) {
 			Expr:       MustParseExpr(`count("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -68,8 +70,8 @@ func TestCallIterator_Count_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 3, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 1, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "cpu", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "mem", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
@@ -82,12 +84,11 @@ func TestCallIterator_Count_String(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&StringIterator{Points: []influxql.StringPoint{
 			{Name: "cpu", Time: 0, Value: "d", Tags: ParseTags("region=us-east,host=hostA")},
-			{Name: "cpu", Time: 1, Value: "c", Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "cpu", Time: 2, Value: "b", Tags: ParseTags("region=us-east,host=hostA")},
 			{Name: "cpu", Time: 1, Value: "b", Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Name: "cpu", Time: 5, Value: "e", Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Name: "cpu", Time: 1, Value: "c", Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "cpu", Time: 23, Value: "a", Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "mem", Time: 23, Value: "b", Tags: ParseTags("region=us-west,host=hostB")},
 		}},
@@ -95,6 +96,8 @@ func TestCallIterator_Count_String(t *testing.T) {
 			Expr:       MustParseExpr(`count("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -102,8 +105,8 @@ func TestCallIterator_Count_String(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 3, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 1, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "cpu", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "mem", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
@@ -116,12 +119,11 @@ func TestCallIterator_Count_Boolean(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&BooleanIterator{Points: []influxql.BooleanPoint{
 			{Name: "cpu", Time: 0, Value: true, Tags: ParseTags("region=us-east,host=hostA")},
-			{Name: "cpu", Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "cpu", Time: 2, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 			{Name: "cpu", Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Name: "cpu", Time: 5, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Name: "cpu", Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "cpu", Time: 23, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 			{Name: "mem", Time: 23, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
@@ -129,6 +131,8 @@ func TestCallIterator_Count_Boolean(t *testing.T) {
 			Expr:       MustParseExpr(`count("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -136,8 +140,8 @@ func TestCallIterator_Count_Boolean(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 3, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "cpu", Time: 5, Value: 1, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Name: "cpu", Time: 0, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "cpu", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Name: "mem", Time: 20, Value: 1, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
@@ -150,19 +154,20 @@ func TestCallIterator_Min_Float(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&FloatIterator{Points: []influxql.FloatPoint{
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 4, Value: 12, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 5, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`min("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -170,8 +175,8 @@ func TestCallIterator_Min_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Time: 1, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 4}},
-		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -183,19 +188,20 @@ func TestCallIterator_Min_Integer(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&IntegerIterator{Points: []influxql.IntegerPoint{
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 4, Value: 12, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 5, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`min("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -203,8 +209,8 @@ func TestCallIterator_Min_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Time: 1, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 4}},
-		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -216,18 +222,19 @@ func TestCallIterator_Min_Boolean(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&BooleanIterator{Points: []influxql.BooleanPoint{
 			{Time: 0, Value: true, Tags: ParseTags("region=us-east,host=hostA")},
-			{Time: 1, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 5, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`min("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -235,8 +242,8 @@ func TestCallIterator_Min_Boolean(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.BooleanPoint{Time: 2, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.BooleanPoint{Time: 1, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.BooleanPoint{Time: 5, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 1, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.BooleanPoint{Time: 23, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -248,18 +255,19 @@ func TestCallIterator_Max_Float(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&FloatIterator{Points: []influxql.FloatPoint{
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 5, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`max("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -267,8 +275,8 @@ func TestCallIterator_Max_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -280,18 +288,19 @@ func TestCallIterator_Max_Integer(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&IntegerIterator{Points: []influxql.IntegerPoint{
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 5, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`max("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -299,8 +308,8 @@ func TestCallIterator_Max_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -312,18 +321,19 @@ func TestCallIterator_Max_Boolean(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&BooleanIterator{Points: []influxql.BooleanPoint{
 			{Time: 0, Value: true, Tags: ParseTags("region=us-east,host=hostA")},
-			{Time: 1, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 5, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`max("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -331,8 +341,8 @@ func TestCallIterator_Max_Boolean(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.BooleanPoint{Time: 0, Value: true, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.BooleanPoint{Time: 1, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.BooleanPoint{Time: 5, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 1, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.BooleanPoint{Time: 23, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -344,18 +354,19 @@ func TestCallIterator_Sum_Float(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&FloatIterator{Points: []influxql.FloatPoint{
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 5, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`sum("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -363,8 +374,8 @@ func TestCallIterator_Sum_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Time: 0, Value: 35, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.FloatPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -376,18 +387,19 @@ func TestCallIterator_Sum_Integer(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&IntegerIterator{Points: []influxql.IntegerPoint{
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 5, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`sum("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -395,8 +407,8 @@ func TestCallIterator_Sum_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Time: 0, Value: 35, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 5, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 0, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -407,19 +419,20 @@ func TestCallIterator_Sum_Integer(t *testing.T) {
 func TestCallIterator_First_Float(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&FloatIterator{Points: []influxql.FloatPoint{
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 6, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`first("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -427,8 +440,8 @@ func TestCallIterator_First_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -439,19 +452,20 @@ func TestCallIterator_First_Float(t *testing.T) {
 func TestCallIterator_First_Integer(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&IntegerIterator{Points: []influxql.IntegerPoint{
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 6, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`first("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -459,8 +473,8 @@ func TestCallIterator_First_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Time: 0, Value: 15, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -471,19 +485,20 @@ func TestCallIterator_First_Integer(t *testing.T) {
 func TestCallIterator_First_String(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&StringIterator{Points: []influxql.StringPoint{
-			{Time: 1, Value: "c", Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: "b", Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 0, Value: "d", Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: "b", Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 6, Value: "e", Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: "c", Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: "a", Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`first("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -491,8 +506,8 @@ func TestCallIterator_First_String(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.StringPoint{Time: 0, Value: "d", Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.StringPoint{Time: 1, Value: "c", Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.StringPoint{Time: 6, Value: "e", Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.StringPoint{Time: 1, Value: "c", Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.StringPoint{Time: 23, Value: "a", Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -503,19 +518,20 @@ func TestCallIterator_First_String(t *testing.T) {
 func TestCallIterator_First_Boolean(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&BooleanIterator{Points: []influxql.BooleanPoint{
-			{Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 0, Value: true, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: false, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 6, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`first("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -523,8 +539,8 @@ func TestCallIterator_First_Boolean(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.BooleanPoint{Time: 0, Value: true, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.BooleanPoint{Time: 1, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.BooleanPoint{Time: 6, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 1, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.BooleanPoint{Time: 23, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -535,19 +551,20 @@ func TestCallIterator_First_Boolean(t *testing.T) {
 func TestCallIterator_Last_Float(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&FloatIterator{Points: []influxql.FloatPoint{
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 6, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`last("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -555,8 +572,8 @@ func TestCallIterator_Last_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Time: 2, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.FloatPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -567,19 +584,20 @@ func TestCallIterator_Last_Float(t *testing.T) {
 func TestCallIterator_Last_Integer(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&IntegerIterator{Points: []influxql.IntegerPoint{
-			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 6, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`last("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -587,8 +605,8 @@ func TestCallIterator_Last_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Time: 2, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 6, Value: 20, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.IntegerPoint{Time: 23, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -599,19 +617,20 @@ func TestCallIterator_Last_Integer(t *testing.T) {
 func TestCallIterator_Last_String(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&StringIterator{Points: []influxql.StringPoint{
-			{Time: 1, Value: "c", Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: "b", Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 0, Value: "d", Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: "b", Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 6, Value: "e", Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: "c", Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: "a", Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`last("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -619,8 +638,8 @@ func TestCallIterator_Last_String(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.StringPoint{Time: 2, Value: "b", Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.StringPoint{Time: 1, Value: "c", Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.StringPoint{Time: 6, Value: "e", Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.StringPoint{Time: 1, Value: "c", Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.StringPoint{Time: 23, Value: "a", Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -631,19 +650,20 @@ func TestCallIterator_Last_String(t *testing.T) {
 func TestCallIterator_Last_Boolean(t *testing.T) {
 	itr, _ := influxql.NewCallIterator(
 		&BooleanIterator{Points: []influxql.BooleanPoint{
-			{Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 2, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 0, Value: true, Tags: ParseTags("region=us-east,host=hostA")},
 			{Time: 1, Value: false, Tags: ParseTags("region=us-west,host=hostA")},
-
 			{Time: 6, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 
+			{Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 			{Time: 23, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 		}},
 		influxql.IteratorOptions{
 			Expr:       MustParseExpr(`last("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -651,8 +671,8 @@ func TestCallIterator_Last_Boolean(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.BooleanPoint{Time: 2, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 3}},
-		{&influxql.BooleanPoint{Time: 1, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.BooleanPoint{Time: 6, Value: false, Tags: ParseTags("host=hostA"), Aggregated: 1}},
+		{&influxql.BooleanPoint{Time: 1, Value: true, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 		{&influxql.BooleanPoint{Time: 23, Value: false, Tags: ParseTags("host=hostB"), Aggregated: 1}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -663,7 +683,6 @@ func TestCallIterator_Last_Boolean(t *testing.T) {
 func TestCallIterator_Mode_Float(t *testing.T) {
 	itr, _ := influxql.NewModeIterator(&FloatIterator{Points: []influxql.FloatPoint{
 		{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-		{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
 		{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 3, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
@@ -671,6 +690,8 @@ func TestCallIterator_Mode_Float(t *testing.T) {
 		{Time: 6, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 7, Value: 21, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 8, Value: 21, Tags: ParseTags("region=us-east,host=hostA")},
+
+		{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 22, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 24, Value: 25, Tags: ParseTags("region=us-west,host=hostB")},
@@ -679,6 +700,8 @@ func TestCallIterator_Mode_Float(t *testing.T) {
 			Expr:       MustParseExpr(`mode("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -686,8 +709,8 @@ func TestCallIterator_Mode_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Time: 0, Value: 10, Tags: ParseTags("host=hostA"), Aggregated: 0}},
-		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 0}},
 		{&influxql.FloatPoint{Time: 5, Value: 21, Tags: ParseTags("host=hostA"), Aggregated: 0}},
+		{&influxql.FloatPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB"), Aggregated: 0}},
 		{&influxql.FloatPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB"), Aggregated: 0}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -698,7 +721,6 @@ func TestCallIterator_Mode_Float(t *testing.T) {
 func TestCallIterator_Mode_Integer(t *testing.T) {
 	itr, _ := influxql.NewModeIterator(&IntegerIterator{Points: []influxql.IntegerPoint{
 		{Time: 0, Value: 15, Tags: ParseTags("region=us-east,host=hostA")},
-		{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 1, Value: 10, Tags: ParseTags("region=us-west,host=hostA")},
 		{Time: 2, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 3, Value: 10, Tags: ParseTags("region=us-east,host=hostA")},
@@ -706,6 +728,7 @@ func TestCallIterator_Mode_Integer(t *testing.T) {
 		{Time: 6, Value: 20, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 7, Value: 21, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 8, Value: 21, Tags: ParseTags("region=us-east,host=hostA")},
+		{Time: 1, Value: 11, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 22, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 23, Value: 8, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 24, Value: 25, Tags: ParseTags("region=us-west,host=hostB")},
@@ -714,6 +737,8 @@ func TestCallIterator_Mode_Integer(t *testing.T) {
 			Expr:       MustParseExpr(`mode("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -721,8 +746,8 @@ func TestCallIterator_Mode_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Time: 0, Value: 10, Tags: ParseTags("host=hostA")}},
-		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB")}},
 		{&influxql.IntegerPoint{Time: 5, Value: 21, Tags: ParseTags("host=hostA")}},
+		{&influxql.IntegerPoint{Time: 1, Value: 11, Tags: ParseTags("host=hostB")}},
 		{&influxql.IntegerPoint{Time: 20, Value: 8, Tags: ParseTags("host=hostB")}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -733,7 +758,6 @@ func TestCallIterator_Mode_Integer(t *testing.T) {
 func TestCallIterator_Mode_String(t *testing.T) {
 	itr, _ := influxql.NewModeIterator(&StringIterator{Points: []influxql.StringPoint{
 		{Time: 0, Value: "15", Tags: ParseTags("region=us-east,host=hostA")},
-		{Time: 1, Value: "11", Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 1, Value: "10", Tags: ParseTags("region=us-west,host=hostA")},
 		{Time: 2, Value: "10", Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 3, Value: "10", Tags: ParseTags("region=us-east,host=hostA")},
@@ -741,6 +765,8 @@ func TestCallIterator_Mode_String(t *testing.T) {
 		{Time: 6, Value: "20", Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 7, Value: "21", Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 7, Value: "21", Tags: ParseTags("region=us-east,host=hostA")},
+
+		{Time: 1, Value: "11", Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 22, Value: "8", Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 23, Value: "8", Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 24, Value: "25", Tags: ParseTags("region=us-west,host=hostB")},
@@ -749,6 +775,8 @@ func TestCallIterator_Mode_String(t *testing.T) {
 			Expr:       MustParseExpr(`mode("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -756,8 +784,8 @@ func TestCallIterator_Mode_String(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.StringPoint{Time: 0, Value: "10", Tags: ParseTags("host=hostA")}},
-		{&influxql.StringPoint{Time: 1, Value: "11", Tags: ParseTags("host=hostB")}},
 		{&influxql.StringPoint{Time: 5, Value: "21", Tags: ParseTags("host=hostA")}},
+		{&influxql.StringPoint{Time: 1, Value: "11", Tags: ParseTags("host=hostB")}},
 		{&influxql.StringPoint{Time: 20, Value: "8", Tags: ParseTags("host=hostB")}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -768,7 +796,6 @@ func TestCallIterator_Mode_String(t *testing.T) {
 func TestCallIterator_Mode_Boolean(t *testing.T) {
 	itr, _ := influxql.NewModeIterator(&BooleanIterator{Points: []influxql.BooleanPoint{
 		{Time: 0, Value: true, Tags: ParseTags("region=us-east,host=hostA")},
-		{Time: 1, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 1, Value: true, Tags: ParseTags("region=us-west,host=hostA")},
 		{Time: 2, Value: true, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 3, Value: true, Tags: ParseTags("region=us-east,host=hostA")},
@@ -776,6 +803,8 @@ func TestCallIterator_Mode_Boolean(t *testing.T) {
 		{Time: 6, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 7, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
 		{Time: 8, Value: false, Tags: ParseTags("region=us-east,host=hostA")},
+
+		{Time: 1, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 22, Value: false, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 23, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
 		{Time: 24, Value: true, Tags: ParseTags("region=us-west,host=hostB")},
@@ -784,6 +813,8 @@ func TestCallIterator_Mode_Boolean(t *testing.T) {
 			Expr:       MustParseExpr(`mode("value")`),
 			Dimensions: []string{"host"},
 			Interval:   influxql.Interval{Duration: 5 * time.Nanosecond},
+			Ordered:    true,
+			Ascending:  true,
 		},
 	)
 
@@ -791,8 +822,8 @@ func TestCallIterator_Mode_Boolean(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.BooleanPoint{Time: 0, Value: true, Tags: ParseTags("host=hostA")}},
-		{&influxql.BooleanPoint{Time: 1, Value: false, Tags: ParseTags("host=hostB")}},
 		{&influxql.BooleanPoint{Time: 5, Value: false, Tags: ParseTags("host=hostA")}},
+		{&influxql.BooleanPoint{Time: 1, Value: false, Tags: ParseTags("host=hostB")}},
 		{&influxql.BooleanPoint{Time: 20, Value: true, Tags: ParseTags("host=hostB")}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -1063,7 +1063,13 @@ type {{$k.name}}Reduce{{$v.Name}}Point struct {
 // The previous value for the dimension is passed to fn.
 func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() ([]{{$v.Name}}Point, error) {
 	// Calculate next window.
-	var startTime, endTime int64
+	var (
+		startTime, endTime int64
+		window             struct {
+			name string
+			tags string
+		}
+	)
 	for {
 		p, err := itr.input.Next()
 		if err != nil || p == nil {
@@ -1075,6 +1081,7 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() ([]{{$v.Name}}Point, e
 		// Unread the point so it can be processed.
 		itr.input.unread(p)
 		startTime, endTime = itr.opt.Window(p.Time)
+		window.name, window.tags = p.Name, p.Tags.Subset(itr.opt.Dimensions).ID()
 		break
 	}
 
@@ -1089,13 +1096,24 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() ([]{{$v.Name}}Point, e
 			break
 		} else if curr.Nil {
 			continue
+		} else if curr.Name != window.name {
+			itr.input.unread(curr)
+			break
 		}
-		tags := curr.Tags.Subset(itr.dims)
 
-		id := curr.Name
-		if len(tags.m) > 0 {
-			id += "\x00" + tags.ID()
+		// Ensure this point is within the same final window.
+		if curr.Name != window.name {
+			itr.input.unread(curr)
+			break
+		} else if tags := curr.Tags.Subset(itr.opt.Dimensions); tags.ID() != window.tags {
+			itr.input.unread(curr)
+			break
 		}
+
+		// Retrieve the tags on this point for this level of the query.
+		// This may be different than the bucket dimensions.
+		tags := curr.Tags.Subset(itr.dims)
+		id := tags.ID()
 
 		// Retrieve the aggregator for this name/tag combination or create one.
 		rp := m[id]
@@ -1112,17 +1130,18 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() ([]{{$v.Name}}Point, e
 		rp.Aggregator.Aggregate{{$k.Name}}(curr)
 	}
 
-	// Reverse sort points by name & tag.
+	// Reverse sort points by name & tag if our output is supposed to be ordered.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
-	if len(keys) > 1 {
+	if len(keys) > 1 && itr.opt.Ordered {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
 	// Assume the points are already sorted until proven otherwise.
 	sortedByTime := true
+	// Emit the points for each name & tag combination.
 	a := make([]{{$v.Name}}Point, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]

--- a/influxql/select_test.go
+++ b/influxql/select_test.go
@@ -703,11 +703,11 @@ func TestSelect_Top_NoTags_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 20}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 5}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 4}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 9 * Second, Value: 19}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 31 * Second, Value: 100}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 5 * Second, Value: 10}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 53 * Second, Value: 5}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 53 * Second, Value: 4}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -749,11 +749,11 @@ func TestSelect_Top_NoTags_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 20}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 19}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 5}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 4}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 9 * Second, Value: 19}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 31 * Second, Value: 100}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 5 * Second, Value: 10}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 53 * Second, Value: 5}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 53 * Second, Value: 4}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -799,16 +799,16 @@ func TestSelect_Top_Tags_Float(t *testing.T) {
 			&influxql.StringPoint{Name: "cpu", Time: 0 * Second, Value: "A"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 10, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Time: 0 * Second, Value: "B"},
+			&influxql.FloatPoint{Name: "cpu", Time: 5 * Second, Value: 10, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Time: 5 * Second, Value: "B"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Time: 30 * Second, Value: 100, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Time: 30 * Second, Value: "A"},
+			&influxql.FloatPoint{Name: "cpu", Time: 31 * Second, Value: 100, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Time: 31 * Second, Value: "A"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Time: 30 * Second, Value: 5, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Time: 30 * Second, Value: "B"},
+			&influxql.FloatPoint{Name: "cpu", Time: 53 * Second, Value: 5, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Time: 53 * Second, Value: "B"},
 		},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -855,16 +855,16 @@ func TestSelect_Top_Tags_Integer(t *testing.T) {
 			&influxql.StringPoint{Name: "cpu", Time: 0 * Second, Value: "A"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 10, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Time: 0 * Second, Value: "B"},
+			&influxql.IntegerPoint{Name: "cpu", Time: 5 * Second, Value: 10, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Time: 5 * Second, Value: "B"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Time: 30 * Second, Value: 100, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Time: 30 * Second, Value: "A"},
+			&influxql.IntegerPoint{Name: "cpu", Time: 31 * Second, Value: 100, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Time: 31 * Second, Value: "A"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Time: 30 * Second, Value: 5, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Time: 30 * Second, Value: "B"},
+			&influxql.IntegerPoint{Name: "cpu", Time: 53 * Second, Value: 5, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Time: 53 * Second, Value: "B"},
 		},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -907,16 +907,16 @@ func TestSelect_Top_GroupByTags_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{
-			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 0 * Second, Value: 19, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 0 * Second, Value: "A"},
+			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 9 * Second, Value: 19, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 9 * Second, Value: "A"},
 		},
 		{
 			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 0 * Second, Value: 20, Aux: []interface{}{"A"}},
 			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 0 * Second, Value: "A"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 30 * Second, Value: 100, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 30 * Second, Value: "A"},
+			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 31 * Second, Value: 100, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 31 * Second, Value: "A"},
 		},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -959,16 +959,16 @@ func TestSelect_Top_GroupByTags_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{
-			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 0 * Second, Value: 19, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 0 * Second, Value: "A"},
+			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 9 * Second, Value: 19, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 9 * Second, Value: "A"},
 		},
 		{
 			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 0 * Second, Value: 20, Aux: []interface{}{"A"}},
 			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 0 * Second, Value: "A"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 30 * Second, Value: 100, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 30 * Second, Value: "A"},
+			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 31 * Second, Value: 100, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 31 * Second, Value: "A"},
 		},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -1010,12 +1010,12 @@ func TestSelect_Bottom_NoTags_Float(t *testing.T) {
 	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 2}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 3}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 1}},
-		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 11 * Second, Value: 3}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 31 * Second, Value: 100}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 5 * Second, Value: 10}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: 1}},
+		{&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 51 * Second, Value: 2}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -1056,12 +1056,12 @@ func TestSelect_Bottom_NoTags_Integer(t *testing.T) {
 	} else if a, err := Iterators(itrs).ReadAll(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 2}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 0 * Second, Value: 3}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 30 * Second, Value: 100}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 0 * Second, Value: 10}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 1}},
-		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 30 * Second, Value: 2}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 10 * Second, Value: 2}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 11 * Second, Value: 3}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=A"), Time: 31 * Second, Value: 100}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 5 * Second, Value: 10}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 50 * Second, Value: 1}},
+		{&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("host=B"), Time: 51 * Second, Value: 2}},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
@@ -1103,20 +1103,20 @@ func TestSelect_Bottom_Tags_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{
-			&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 2, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Time: 0 * Second, Value: "A"},
+			&influxql.FloatPoint{Name: "cpu", Time: 5 * Second, Value: 10, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Time: 5 * Second, Value: "B"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 10, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Time: 0 * Second, Value: "B"},
+			&influxql.FloatPoint{Name: "cpu", Time: 10 * Second, Value: 2, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Time: 10 * Second, Value: "A"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Time: 30 * Second, Value: 1, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Time: 30 * Second, Value: "B"},
+			&influxql.FloatPoint{Name: "cpu", Time: 31 * Second, Value: 100, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Time: 31 * Second, Value: "A"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Time: 30 * Second, Value: 100, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Time: 30 * Second, Value: "A"},
+			&influxql.FloatPoint{Name: "cpu", Time: 50 * Second, Value: 1, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Time: 50 * Second, Value: "B"},
 		},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -1159,20 +1159,20 @@ func TestSelect_Bottom_Tags_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{
-			&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 2, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Time: 0 * Second, Value: "A"},
+			&influxql.IntegerPoint{Name: "cpu", Time: 5 * Second, Value: 10, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Time: 5 * Second, Value: "B"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 10, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Time: 0 * Second, Value: "B"},
+			&influxql.IntegerPoint{Name: "cpu", Time: 10 * Second, Value: 2, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Time: 10 * Second, Value: "A"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Time: 30 * Second, Value: 1, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Time: 30 * Second, Value: "B"},
+			&influxql.IntegerPoint{Name: "cpu", Time: 31 * Second, Value: 100, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Time: 31 * Second, Value: "A"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Time: 30 * Second, Value: 100, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Time: 30 * Second, Value: "A"},
+			&influxql.IntegerPoint{Name: "cpu", Time: 50 * Second, Value: 1, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Time: 50 * Second, Value: "B"},
 		},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -1215,16 +1215,16 @@ func TestSelect_Bottom_GroupByTags_Float(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{
-			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 0 * Second, Value: 2, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 0 * Second, Value: "A"},
+			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 10 * Second, Value: 2, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 10 * Second, Value: "A"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 0 * Second, Value: 3, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 0 * Second, Value: "A"},
+			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 11 * Second, Value: 3, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 11 * Second, Value: "A"},
 		},
 		{
-			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 30 * Second, Value: 1, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 30 * Second, Value: "B"},
+			&influxql.FloatPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 50 * Second, Value: 1, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 50 * Second, Value: "B"},
 		},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))
@@ -1267,16 +1267,16 @@ func TestSelect_Bottom_GroupByTags_Integer(t *testing.T) {
 		t.Fatalf("unexpected error: %s", err)
 	} else if !deep.Equal(a, [][]influxql.Point{
 		{
-			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 0 * Second, Value: 2, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 0 * Second, Value: "A"},
+			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 10 * Second, Value: 2, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=east"), Time: 10 * Second, Value: "A"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 0 * Second, Value: 3, Aux: []interface{}{"A"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 0 * Second, Value: "A"},
+			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 11 * Second, Value: 3, Aux: []interface{}{"A"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 11 * Second, Value: "A"},
 		},
 		{
-			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 30 * Second, Value: 1, Aux: []interface{}{"B"}},
-			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 30 * Second, Value: "B"},
+			&influxql.IntegerPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 50 * Second, Value: 1, Aux: []interface{}{"B"}},
+			&influxql.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 50 * Second, Value: "B"},
 		},
 	}) {
 		t.Fatalf("unexpected points: %s", spew.Sdump(a))

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -4630,19 +4630,19 @@ func TestServer_Query_TopInt(t *testing.T) {
 			name:    "top - cpu - hourly",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 1) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
-			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:00Z",4],["2000-01-01T01:00:00Z",7],["2000-01-01T02:00:00Z",9]]}]}]}`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:20Z",4],["2000-01-01T01:00:10Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
 		&Query{
 			name:    "top - cpu - 2 values hourly",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 2) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
-			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:00Z",4],["2000-01-01T00:00:00Z",3],["2000-01-01T01:00:00Z",7],["2000-01-01T01:00:00Z",6],["2000-01-01T02:00:00Z",9],["2000-01-01T02:00:00Z",7]]}]}]}`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:10Z",3],["2000-01-01T00:00:20Z",4],["2000-01-01T01:00:10Z",7],["2000-01-01T01:00:20Z",6],["2000-01-01T02:00:00Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
 		&Query{
 			name:    "top - cpu - 3 values hourly - validates that a bucket can have less than limit if no values exist in that time bucket",
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT TOP(value, 3) FROM cpu where time >= '2000-01-01T00:00:00Z' and time <= '2000-01-01T02:00:10Z' group by time(1h)`,
-			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:00Z",4],["2000-01-01T00:00:00Z",3],["2000-01-01T00:00:00Z",2],["2000-01-01T01:00:00Z",7],["2000-01-01T01:00:00Z",6],["2000-01-01T01:00:00Z",5],["2000-01-01T02:00:00Z",9],["2000-01-01T02:00:00Z",7]]}]}]}`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","top"],"values":[["2000-01-01T00:00:00Z",2],["2000-01-01T00:00:10Z",3],["2000-01-01T00:00:20Z",4],["2000-01-01T01:00:00Z",5],["2000-01-01T01:00:10Z",7],["2000-01-01T01:00:20Z",6],["2000-01-01T02:00:00Z",7],["2000-01-01T02:00:10Z",9]]}]}]}`,
 		},
 		&Query{
 			name:    "top - memory - 2 values, two tags",
@@ -4982,6 +4982,11 @@ func TestServer_Query_Subqueries(t *testing.T) {
 			params:  url.Values{"db": []string{"db0"}},
 			command: `SELECT host FROM (SELECT min(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z'`,
 			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host"],"values":[["2000-01-01T00:00:00Z","server02"],["2000-01-01T00:00:20Z","server01"]]}]}]}`,
+		},
+		&Query{
+			params:  url.Values{"db": []string{"db0"}},
+			command: `SELECT host FROM (SELECT min(usage_user) FROM cpu GROUP BY host) WHERE time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T00:00:30Z' GROUP BY host`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","tags":{"host":"server01"},"columns":["time","host"],"values":[["2000-01-01T00:00:20Z","server01"]]},{"name":"cpu","tags":{"host":"server02"},"columns":["time","host"],"values":[["2000-01-01T00:00:00Z","server02"]]}]}]}`,
 		},
 		&Query{
 			params:  url.Values{"db": []string{"db0"}},


### PR DESCRIPTION
`top()` and `bottom()` will now organize the points by time and also
keep the points original time even when a time grouping is used. At the
same time, `top()` and `bottom()` will no longer honor any fill options
that are present since they don't really make sense for these specific
functions.

This also fixes the aggregate and selectors to honor the ordered
iterator option so iterator remain ordered and to also respect the
buckets that are created by the final dimensions of the query so that
two buckets don't overlap each other within the same reducer. A test has
been added for this situation. This should clarify and encourage the use
of the ordered attribute within the query engine.

Fixes #8266.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<[influxdata/docs.influxdata.com#1103](https://github.com/influxdata/docs.influxdata.com/issues/1103)>