### PR TITLE
TSI Compaction Refactor

### DIFF
--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -79,6 +79,24 @@ func (f *Filter) Contains(v []byte) bool {
 	return true
 }
 
+// Merge performs an in-place union of other into f.
+// Returns an error if m or k of the filters differs.
+func (f *Filter) Merge(other *Filter) error {
+	// Ensure m & k fields match.
+	if len(f.b) != len(other.b) {
+		return fmt.Errorf("bloom.Filter.Merge(): m mismatch: %d <> %d", len(f.b), len(other.b))
+	} else if f.k != other.k {
+		return fmt.Errorf("bloom.Filter.Merge(): k mismatch: %d <> %d", f.b, other.b)
+	}
+
+	// Perform union of each byte.
+	for i := range f.b {
+		f.b[i] |= other.b[i]
+	}
+
+	return nil
+}
+
 // location returns the ith hashed location using the four base hash values.
 func (f *Filter) location(h [4]uint64, i uint64) uint {
 	return uint((h[i%2] + i*h[2+(((i+(i%2))%4)/2)]) & f.mask)

--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -1,0 +1,113 @@
+package bloom
+
+// NOTE:
+// This package implements a limited bloom filter implementation based on
+// Will Fitzgerald's bloom & bitset packages. It's implemented locally to
+// support zero-copy memory-mapped slices.
+//
+// This also optimizes the filter by always using a bitset size with a power of 2.
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/spaolacci/murmur3"
+)
+
+// Filter represents a bloom filter.
+type Filter struct {
+	k    uint64
+	b    []byte
+	mask uint64
+}
+
+// NewFilter returns a new instance of Filter using m bits and k hash functions.
+// If m is not a power of two then it is rounded to the next highest power of 2.
+func NewFilter(m uint64, k uint64) *Filter {
+	m = pow2(m)
+
+	return &Filter{
+		k:    k,
+		b:    make([]byte, m/8),
+		mask: m - 1,
+	}
+}
+
+// NewFilterBuffer returns a new instance of a filter using a backing buffer.
+// The buffer length MUST be a power of 2.
+func NewFilterBuffer(buf []byte, k uint64) (*Filter, error) {
+	m := pow2(uint64(len(buf)) * 8)
+	if m != uint64(len(buf))*8 {
+		return nil, fmt.Errorf("bloom.Filter: buffer bit count must a power of two: %d/%d", len(buf)*8, m)
+	}
+
+	return &Filter{
+		k:    k,
+		b:    buf,
+		mask: m - 1,
+	}, nil
+}
+
+// Len returns the number of bits used in the filter.
+func (f *Filter) Len() uint { return uint(len(f.b)) }
+
+// K returns the number of hash functions used in the filter.
+func (f *Filter) K() uint64 { return f.k }
+
+// Bytes returns the underlying backing slice.
+func (f *Filter) Bytes() []byte { return f.b }
+
+// Insert inserts data to the filter.
+func (f *Filter) Insert(v []byte) {
+	h := hash(v)
+	for i := uint64(0); i < f.k; i++ {
+		loc := f.location(h, i)
+		f.b[loc/8] |= 1 << (loc % 8)
+	}
+}
+
+// Contains returns true if the filter possibly contains v.
+// Returns false if the filter definitely does not contain v.
+func (f *Filter) Contains(v []byte) bool {
+	h := hash(v)
+	for i := uint64(0); i < f.k; i++ {
+		loc := f.location(h, i)
+		if f.b[loc/8]&(1<<(loc%8)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// location returns the ith hashed location using the four base hash values.
+func (f *Filter) location(h [4]uint64, i uint64) uint {
+	return uint((h[i%2] + i*h[2+(((i+(i%2))%4)/2)]) & f.mask)
+}
+
+// Estimate returns an estimated bit count and hash count given the element count and false positive rate.
+func Estimate(n uint64, p float64) (m uint64, k uint64) {
+	m = uint64(math.Ceil(-1 * float64(n) * math.Log(p) / math.Pow(math.Log(2), 2)))
+	k = uint64(math.Ceil(math.Log(2) * float64(m) / float64(n)))
+	return m, k
+}
+
+// pow2 returns the number that is the next highest power of 2.
+// Returns v if it is a power of 2.
+func pow2(v uint64) uint64 {
+	for i := uint64(8); i < 1<<62; i *= 2 {
+		if i >= v {
+			return i
+		}
+	}
+	panic("unreachable")
+}
+
+// hash returns a set of 4 based hashes.
+func hash(data []byte) [4]uint64 {
+	h := murmur3.New128()
+	h.Write(data)
+	v1, v2 := h.Sum128()
+	h.Write([]byte{1})
+	v3, v4 := h.Sum128()
+	return [4]uint64{v1, v2, v3, v4}
+}

--- a/pkg/bloom/bloom_test.go
+++ b/pkg/bloom/bloom_test.go
@@ -1,0 +1,29 @@
+package bloom_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/influxdb/pkg/bloom"
+)
+
+// Ensure filter can insert values and verify they exist.
+func TestFilter_InsertContains(t *testing.T) {
+	f := bloom.NewFilter(1000, 4)
+
+	// Insert value and validate.
+	f.Insert([]byte("Bess"))
+	if !f.Contains([]byte("Bess")) {
+		t.Fatal("expected true")
+	}
+
+	// Insert another value and test.
+	f.Insert([]byte("Emma"))
+	if !f.Contains([]byte("Emma")) {
+		t.Fatal("expected true")
+	}
+
+	// Validate that a non-existent value doesn't exist.
+	if f.Contains([]byte("Jane")) {
+		t.Fatal("expected false")
+	}
+}

--- a/tsdb/index/internal/file_set.go
+++ b/tsdb/index/internal/file_set.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/bloom"
 	"github.com/influxdata/influxdb/pkg/estimator"
 	"github.com/influxdata/influxdb/tsdb/index/tsi1"
 )
@@ -10,6 +11,8 @@ import (
 type File struct {
 	Closef                     func() error
 	Pathf                      func() string
+	IDf                        func() int
+	Levelf                     func() int
 	FilterNameTagsf            func(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags)
 	Measurementf               func(name []byte) tsi1.MeasurementElem
 	MeasurementIteratorf       func() tsi1.MeasurementIterator
@@ -28,10 +31,13 @@ type File struct {
 	MergeMeasurementsSketchesf func(s, t estimator.Sketch) error
 	Retainf                    func()
 	Releasef                   func()
+	Filterf                    func() *bloom.Filter
 }
 
 func (f *File) Close() error { return f.Closef() }
 func (f *File) Path() string { return f.Pathf() }
+func (f *File) ID() int      { return f.IDf() }
+func (f *File) Level() int   { return f.Levelf() }
 func (f *File) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
 	return f.FilterNameTagsf(names, tagsSlice)
 }
@@ -64,5 +70,6 @@ func (f *File) MergeSeriesSketches(s, t estimator.Sketch) error { return f.Merge
 func (f *File) MergeMeasurementsSketches(s, t estimator.Sketch) error {
 	return f.MergeMeasurementsSketchesf(s, t)
 }
-func (f *File) Retain()  { f.Retainf() }
-func (f *File) Release() { f.Releasef() }
+func (f *File) Retain()               { f.Retainf() }
+func (f *File) Release()              { f.Releasef() }
+func (f *File) Filter() *bloom.Filter { return f.Filterf() }

--- a/tsdb/index/internal/file_set.go
+++ b/tsdb/index/internal/file_set.go
@@ -13,7 +13,6 @@ type File struct {
 	Pathf                      func() string
 	IDf                        func() int
 	Levelf                     func() int
-	FilterNameTagsf            func(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags)
 	Measurementf               func(name []byte) tsi1.MeasurementElem
 	MeasurementIteratorf       func() tsi1.MeasurementIterator
 	HasSeriesf                 func(name []byte, tags models.Tags, buf []byte) (exists, tombstoned bool)
@@ -34,13 +33,10 @@ type File struct {
 	Filterf                    func() *bloom.Filter
 }
 
-func (f *File) Close() error { return f.Closef() }
-func (f *File) Path() string { return f.Pathf() }
-func (f *File) ID() int      { return f.IDf() }
-func (f *File) Level() int   { return f.Levelf() }
-func (f *File) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
-	return f.FilterNameTagsf(names, tagsSlice)
-}
+func (f *File) Close() error                                  { return f.Closef() }
+func (f *File) Path() string                                  { return f.Pathf() }
+func (f *File) ID() int                                       { return f.IDf() }
+func (f *File) Level() int                                    { return f.Levelf() }
 func (f *File) Measurement(name []byte) tsi1.MeasurementElem  { return f.Measurementf(name) }
 func (f *File) MeasurementIterator() tsi1.MeasurementIterator { return f.MeasurementIteratorf() }
 func (f *File) HasSeries(name []byte, tags models.Tags, buf []byte) (exists, tombstoned bool) {

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/bloom"
 	"github.com/influxdata/influxdb/pkg/bytesutil"
 	"github.com/influxdata/influxdb/pkg/estimator"
 	"github.com/influxdata/influxdb/pkg/estimator/hll"
@@ -15,7 +16,18 @@ import (
 )
 
 // FileSet represents a collection of files.
-type FileSet []File
+type FileSet struct {
+	levels  []CompactionLevel
+	files   []File
+	filters []*bloom.Filter // per-level filters
+}
+
+// NewFileSet returns a new instance of FileSet.
+func NewFileSet(levels []CompactionLevel, files []File) *FileSet {
+	fs := &FileSet{levels: levels, files: files}
+	fs.buildFilters()
+	return fs
+}
 
 // Close closes all the files in the file set.
 func (p FileSet) Close() error {
@@ -29,55 +41,55 @@ func (p FileSet) Close() error {
 }
 
 // Retain adds a reference count to all files.
-func (p FileSet) Retain() {
-	for _, f := range p {
+func (fs *FileSet) Retain() {
+	for _, f := range fs.files {
 		f.Retain()
 	}
 }
 
 // Release removes a reference count from all files.
-func (p FileSet) Release() {
-	for _, f := range p {
+func (fs *FileSet) Release() {
+	for _, f := range fs.files {
 		f.Release()
 	}
 }
 
 // MustReplace swaps a list of files for a single file and returns a new file set.
 // The caller should always guarentee that the files exist and are contiguous.
-func (p FileSet) MustReplace(oldFiles []File, newFile File) FileSet {
+func (fs *FileSet) MustReplace(oldFiles []File, newFile File) *FileSet {
 	assert(len(oldFiles) > 0, "cannot replace empty files")
 
 	// Find index of first old file.
 	var i int
-	for ; i < len(p); i++ {
-		if p[i] == oldFiles[0] {
+	for ; i < len(fs.files); i++ {
+		if fs.files[i] == oldFiles[0] {
 			break
-		} else if i == len(p)-1 {
+		} else if i == len(fs.files)-1 {
 			panic("first replacement file not found")
 		}
 	}
 
 	// Ensure all old files are contiguous.
 	for j := range oldFiles {
-		if p[i+j] != oldFiles[j] {
+		if fs.files[i+j] != oldFiles[j] {
 			panic("cannot replace non-contiguous files")
 		}
 	}
 
 	// Copy to new fileset.
-	other := make([]File, len(p)-len(oldFiles)+1)
-	copy(other[:i], p[:i])
+	other := make([]File, len(fs.files)-len(oldFiles)+1)
+	copy(other[:i], fs.files[:i])
 	other[i] = newFile
-	copy(other[i+1:], p[i+len(oldFiles):])
+	copy(other[i+1:], fs.files[i+len(oldFiles):])
 
-	return other
+	return NewFileSet(fs.levels, other)
 }
 
 // MaxID returns the highest file identifier.
-func (fs FileSet) MaxID() int {
+func (fs *FileSet) MaxID() int {
 	var max int
-	for _, f := range fs {
-		if i := ParseFileID(f.Path()); i > max {
+	for _, f := range fs.files {
+		if i := f.ID(); i > max {
 			max = i
 		}
 	}
@@ -85,9 +97,9 @@ func (fs FileSet) MaxID() int {
 }
 
 // LogFiles returns all log files from the file set.
-func (fs FileSet) LogFiles() []*LogFile {
+func (fs *FileSet) LogFiles() []*LogFile {
 	var a []*LogFile
-	for _, f := range fs {
+	for _, f := range fs.files {
 		if f, ok := f.(*LogFile); ok {
 			a = append(a, f)
 		}
@@ -96,9 +108,9 @@ func (fs FileSet) LogFiles() []*LogFile {
 }
 
 // IndexFiles returns all index files from the file set.
-func (fs FileSet) IndexFiles() []*IndexFile {
+func (fs *FileSet) IndexFiles() []*IndexFile {
 	var a []*IndexFile
-	for _, f := range fs {
+	for _, f := range fs.files {
 		if f, ok := f.(*IndexFile); ok {
 			a = append(a, f)
 		}
@@ -107,9 +119,9 @@ func (fs FileSet) IndexFiles() []*IndexFile {
 }
 
 // SeriesIterator returns an iterator over all series in the index.
-func (fs FileSet) SeriesIterator() SeriesIterator {
-	a := make([]SeriesIterator, 0, len(fs))
-	for _, f := range fs {
+func (fs *FileSet) SeriesIterator() SeriesIterator {
+	a := make([]SeriesIterator, 0, len(fs.files))
+	for _, f := range fs.files {
 		itr := f.SeriesIterator()
 		if itr == nil {
 			continue
@@ -120,8 +132,8 @@ func (fs FileSet) SeriesIterator() SeriesIterator {
 }
 
 // Measurement returns a measurement by name.
-func (fs FileSet) Measurement(name []byte) MeasurementElem {
-	for _, f := range fs {
+func (fs *FileSet) Measurement(name []byte) MeasurementElem {
+	for _, f := range fs.files {
 		if e := f.Measurement(name); e == nil {
 			continue
 		} else if e.Deleted() {
@@ -134,9 +146,9 @@ func (fs FileSet) Measurement(name []byte) MeasurementElem {
 }
 
 // MeasurementIterator returns an iterator over all measurements in the index.
-func (fs FileSet) MeasurementIterator() MeasurementIterator {
-	a := make([]MeasurementIterator, 0, len(fs))
-	for _, f := range fs {
+func (fs *FileSet) MeasurementIterator() MeasurementIterator {
+	a := make([]MeasurementIterator, 0, len(fs.files))
+	for _, f := range fs.files {
 		itr := f.MeasurementIterator()
 		if itr != nil {
 			a = append(a, itr)
@@ -147,9 +159,9 @@ func (fs FileSet) MeasurementIterator() MeasurementIterator {
 
 // MeasurementSeriesIterator returns an iterator over all non-tombstoned series
 // in the index for the provided measurement.
-func (fs FileSet) MeasurementSeriesIterator(name []byte) SeriesIterator {
-	a := make([]SeriesIterator, 0, len(fs))
-	for _, f := range fs {
+func (fs *FileSet) MeasurementSeriesIterator(name []byte) SeriesIterator {
+	a := make([]SeriesIterator, 0, len(fs.files))
+	for _, f := range fs.files {
 		itr := f.MeasurementSeriesIterator(name)
 		if itr != nil {
 			a = append(a, itr)
@@ -159,9 +171,9 @@ func (fs FileSet) MeasurementSeriesIterator(name []byte) SeriesIterator {
 }
 
 // TagKeyIterator returns an iterator over all tag keys for a measurement.
-func (fs FileSet) TagKeyIterator(name []byte) TagKeyIterator {
-	a := make([]TagKeyIterator, 0, len(fs))
-	for _, f := range fs {
+func (fs *FileSet) TagKeyIterator(name []byte) TagKeyIterator {
+	a := make([]TagKeyIterator, 0, len(fs.files))
+	for _, f := range fs.files {
 		itr := f.TagKeyIterator(name)
 		if itr != nil {
 			a = append(a, itr)
@@ -171,7 +183,7 @@ func (fs FileSet) TagKeyIterator(name []byte) TagKeyIterator {
 }
 
 // MeasurementTagKeysByExpr extracts the tag keys wanted by the expression.
-func (fs FileSet) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error) {
+func (fs *FileSet) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error) {
 	switch e := expr.(type) {
 	case *influxql.BinaryExpr:
 		switch e.Op {
@@ -231,7 +243,7 @@ func (fs FileSet) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map
 }
 
 // tagKeysByFilter will filter the tag keys for the measurement.
-func (fs FileSet) tagKeysByFilter(name []byte, op influxql.Token, val []byte, regex *regexp.Regexp) map[string]struct{} {
+func (fs *FileSet) tagKeysByFilter(name []byte, op influxql.Token, val []byte, regex *regexp.Regexp) map[string]struct{} {
 	ss := make(map[string]struct{})
 	itr := fs.TagKeyIterator(name)
 	for e := itr.Next(); e != nil; e = itr.Next() {
@@ -256,9 +268,9 @@ func (fs FileSet) tagKeysByFilter(name []byte, op influxql.Token, val []byte, re
 }
 
 // TagKeySeriesIterator returns a series iterator for all values across a single key.
-func (fs FileSet) TagKeySeriesIterator(name, key []byte) SeriesIterator {
-	a := make([]SeriesIterator, 0, len(fs))
-	for _, f := range fs {
+func (fs *FileSet) TagKeySeriesIterator(name, key []byte) SeriesIterator {
+	a := make([]SeriesIterator, 0, len(fs.files))
+	for _, f := range fs.files {
 		itr := f.TagKeySeriesIterator(name, key)
 		if itr != nil {
 			a = append(a, itr)
@@ -268,8 +280,8 @@ func (fs FileSet) TagKeySeriesIterator(name, key []byte) SeriesIterator {
 }
 
 // HasTagKey returns true if the tag key exists.
-func (fs FileSet) HasTagKey(name, key []byte) bool {
-	for _, f := range fs {
+func (fs *FileSet) HasTagKey(name, key []byte) bool {
+	for _, f := range fs.files {
 		if e := f.TagKey(name, key); e != nil {
 			return !e.Deleted()
 		}
@@ -278,8 +290,8 @@ func (fs FileSet) HasTagKey(name, key []byte) bool {
 }
 
 // HasTagValue returns true if the tag value exists.
-func (fs FileSet) HasTagValue(name, key, value []byte) bool {
-	for _, f := range fs {
+func (fs *FileSet) HasTagValue(name, key, value []byte) bool {
+	for _, f := range fs.files {
 		if e := f.TagValue(name, key, value); e != nil {
 			return !e.Deleted()
 		}
@@ -288,9 +300,9 @@ func (fs FileSet) HasTagValue(name, key, value []byte) bool {
 }
 
 // TagValueIterator returns a value iterator for a tag key.
-func (fs FileSet) TagValueIterator(name, key []byte) TagValueIterator {
-	a := make([]TagValueIterator, 0, len(fs))
-	for _, f := range fs {
+func (fs *FileSet) TagValueIterator(name, key []byte) TagValueIterator {
+	a := make([]TagValueIterator, 0, len(fs.files))
+	for _, f := range fs.files {
 		itr := f.TagValueIterator(name, key)
 		if itr != nil {
 			a = append(a, itr)
@@ -300,9 +312,9 @@ func (fs FileSet) TagValueIterator(name, key []byte) TagValueIterator {
 }
 
 // TagValueSeriesIterator returns a series iterator for a single tag value.
-func (fs FileSet) TagValueSeriesIterator(name, key, value []byte) SeriesIterator {
-	a := make([]SeriesIterator, 0, len(fs))
-	for _, f := range fs {
+func (fs *FileSet) TagValueSeriesIterator(name, key, value []byte) SeriesIterator {
+	a := make([]SeriesIterator, 0, len(fs.files))
+	for _, f := range fs.files {
 		itr := f.TagValueSeriesIterator(name, key, value)
 		if itr != nil {
 			a = append(a, itr)
@@ -313,7 +325,7 @@ func (fs FileSet) TagValueSeriesIterator(name, key, value []byte) SeriesIterator
 
 // MatchTagValueSeriesIterator returns a series iterator for tags which match value.
 // If matches is false, returns iterators which do not match value.
-func (fs FileSet) MatchTagValueSeriesIterator(name, key []byte, value *regexp.Regexp, matches bool) SeriesIterator {
+func (fs *FileSet) MatchTagValueSeriesIterator(name, key []byte, value *regexp.Regexp, matches bool) SeriesIterator {
 	matchEmpty := value.MatchString("")
 
 	if matches {
@@ -329,7 +341,7 @@ func (fs FileSet) MatchTagValueSeriesIterator(name, key []byte, value *regexp.Re
 	return FilterUndeletedSeriesIterator(fs.matchTagValueNotEqualNotEmptySeriesIterator(name, key, value))
 }
 
-func (fs FileSet) matchTagValueEqualEmptySeriesIterator(name, key []byte, value *regexp.Regexp) SeriesIterator {
+func (fs *FileSet) matchTagValueEqualEmptySeriesIterator(name, key []byte, value *regexp.Regexp) SeriesIterator {
 	vitr := fs.TagValueIterator(name, key)
 	if vitr == nil {
 		return fs.MeasurementSeriesIterator(name)
@@ -348,7 +360,7 @@ func (fs FileSet) matchTagValueEqualEmptySeriesIterator(name, key []byte, value 
 	)
 }
 
-func (fs FileSet) matchTagValueEqualNotEmptySeriesIterator(name, key []byte, value *regexp.Regexp) SeriesIterator {
+func (fs *FileSet) matchTagValueEqualNotEmptySeriesIterator(name, key []byte, value *regexp.Regexp) SeriesIterator {
 	vitr := fs.TagValueIterator(name, key)
 	if vitr == nil {
 		return nil
@@ -363,7 +375,7 @@ func (fs FileSet) matchTagValueEqualNotEmptySeriesIterator(name, key []byte, val
 	return MergeSeriesIterators(itrs...)
 }
 
-func (fs FileSet) matchTagValueNotEqualEmptySeriesIterator(name, key []byte, value *regexp.Regexp) SeriesIterator {
+func (fs *FileSet) matchTagValueNotEqualEmptySeriesIterator(name, key []byte, value *regexp.Regexp) SeriesIterator {
 	vitr := fs.TagValueIterator(name, key)
 	if vitr == nil {
 		return nil
@@ -378,7 +390,7 @@ func (fs FileSet) matchTagValueNotEqualEmptySeriesIterator(name, key []byte, val
 	return MergeSeriesIterators(itrs...)
 }
 
-func (fs FileSet) matchTagValueNotEqualNotEmptySeriesIterator(name, key []byte, value *regexp.Regexp) SeriesIterator {
+func (fs *FileSet) matchTagValueNotEqualNotEmptySeriesIterator(name, key []byte, value *regexp.Regexp) SeriesIterator {
 	vitr := fs.TagValueIterator(name, key)
 	if vitr == nil {
 		return fs.MeasurementSeriesIterator(name)
@@ -397,7 +409,7 @@ func (fs FileSet) matchTagValueNotEqualNotEmptySeriesIterator(name, key []byte, 
 	)
 }
 
-func (fs FileSet) MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
+func (fs *FileSet) MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
 	// Return filtered list if expression exists.
 	if expr != nil {
 		return fs.measurementNamesByExpr(expr)
@@ -412,7 +424,7 @@ func (fs FileSet) MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
 	return names, nil
 }
 
-func (fs FileSet) measurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
+func (fs *FileSet) measurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
 	if expr == nil {
 		return nil, nil
 	}
@@ -479,7 +491,7 @@ func (fs FileSet) measurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
 }
 
 // measurementNamesByNameFilter returns matching measurement names in sorted order.
-func (fs FileSet) measurementNamesByNameFilter(op influxql.Token, val string, regex *regexp.Regexp) [][]byte {
+func (fs *FileSet) measurementNamesByNameFilter(op influxql.Token, val string, regex *regexp.Regexp) [][]byte {
 	var names [][]byte
 	itr := fs.MeasurementIterator()
 	for e := itr.Next(); e != nil; e = itr.Next() {
@@ -503,7 +515,7 @@ func (fs FileSet) measurementNamesByNameFilter(op influxql.Token, val string, re
 	return names
 }
 
-func (fs FileSet) measurementNamesByTagFilter(op influxql.Token, key, val string, regex *regexp.Regexp) [][]byte {
+func (fs *FileSet) measurementNamesByTagFilter(op influxql.Token, key, val string, regex *regexp.Regexp) [][]byte {
 	var names [][]byte
 
 	mitr := fs.MeasurementIterator()
@@ -548,8 +560,8 @@ func (fs FileSet) measurementNamesByTagFilter(op influxql.Token, key, val string
 }
 
 // HasSeries returns true if the series exists and is not tombstoned.
-func (fs FileSet) HasSeries(name []byte, tags models.Tags, buf []byte) bool {
-	for _, f := range fs {
+func (fs *FileSet) HasSeries(name []byte, tags models.Tags, buf []byte) bool {
+	for _, f := range fs.files {
 		if exists, tombstoned := f.HasSeries(name, tags, buf); exists {
 			return !tombstoned
 		}
@@ -559,19 +571,19 @@ func (fs FileSet) HasSeries(name []byte, tags models.Tags, buf []byte) bool {
 
 // FilterNamesTags filters out any series which already exist. It modifies the
 // provided slices of names and tags.
-func (fs FileSet) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
-	for _, f := range fs {
+func (fs *FileSet) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
+	for _, f := range fs.files {
 		names, tagsSlice = f.FilterNamesTags(names, tagsSlice)
 	}
 	return names, tagsSlice
 }
 
 // SeriesSketches returns the merged series sketches for the FileSet.
-func (fs FileSet) SeriesSketches() (estimator.Sketch, estimator.Sketch, error) {
+func (fs *FileSet) SeriesSketches() (estimator.Sketch, estimator.Sketch, error) {
 	sketch, tsketch := hll.NewDefaultPlus(), hll.NewDefaultPlus()
 
 	// Iterate over all the files and merge the sketches into the result.
-	for _, f := range fs {
+	for _, f := range fs.files {
 		if err := f.MergeSeriesSketches(sketch, tsketch); err != nil {
 			return nil, nil, err
 		}
@@ -580,11 +592,11 @@ func (fs FileSet) SeriesSketches() (estimator.Sketch, estimator.Sketch, error) {
 }
 
 // MeasurementsSketches returns the merged measurement sketches for the FileSet.
-func (fs FileSet) MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error) {
+func (fs *FileSet) MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error) {
 	sketch, tsketch := hll.NewDefaultPlus(), hll.NewDefaultPlus()
 
 	// Iterate over all the files and merge the sketches into the result.
-	for _, f := range fs {
+	for _, f := range fs.files {
 		if err := f.MergeMeasurementsSketches(sketch, tsketch); err != nil {
 			return nil, nil, err
 		}
@@ -595,7 +607,7 @@ func (fs FileSet) MeasurementsSketches() (estimator.Sketch, estimator.Sketch, er
 // MeasurementSeriesByExprIterator returns a series iterator for a measurement
 // that is filtered by expr. If expr only contains time expressions then this
 // call is equivalent to MeasurementSeriesIterator().
-func (fs FileSet) MeasurementSeriesByExprIterator(name []byte, expr influxql.Expr, fieldset *tsdb.MeasurementFieldSet) (SeriesIterator, error) {
+func (fs *FileSet) MeasurementSeriesByExprIterator(name []byte, expr influxql.Expr, fieldset *tsdb.MeasurementFieldSet) (SeriesIterator, error) {
 	// Return all series for the measurement if there are no tag expressions.
 	if expr == nil || influxql.OnlyTimeExpr(expr) {
 		return fs.MeasurementSeriesIterator(name), nil
@@ -604,7 +616,7 @@ func (fs FileSet) MeasurementSeriesByExprIterator(name []byte, expr influxql.Exp
 }
 
 // MeasurementSeriesKeysByExpr returns a list of series keys matching expr.
-func (fs FileSet) MeasurementSeriesKeysByExpr(name []byte, expr influxql.Expr, fieldset *tsdb.MeasurementFieldSet) ([][]byte, error) {
+func (fs *FileSet) MeasurementSeriesKeysByExpr(name []byte, expr influxql.Expr, fieldset *tsdb.MeasurementFieldSet) ([][]byte, error) {
 	// Create iterator for all matching series.
 	itr, err := fs.MeasurementSeriesByExprIterator(name, expr, fieldset)
 	if err != nil {
@@ -627,7 +639,7 @@ func (fs FileSet) MeasurementSeriesKeysByExpr(name []byte, expr influxql.Expr, f
 	return keys, nil
 }
 
-func (fs FileSet) seriesByExprIterator(name []byte, expr influxql.Expr, mf *tsdb.MeasurementFields) (SeriesIterator, error) {
+func (fs *FileSet) seriesByExprIterator(name []byte, expr influxql.Expr, mf *tsdb.MeasurementFields) (SeriesIterator, error) {
 	switch expr := expr.(type) {
 	case *influxql.BinaryExpr:
 		switch expr.Op {
@@ -665,7 +677,7 @@ func (fs FileSet) seriesByExprIterator(name []byte, expr influxql.Expr, mf *tsdb
 }
 
 // seriesByBinaryExprIterator returns a series iterator and a filtering expression.
-func (fs FileSet) seriesByBinaryExprIterator(name []byte, n *influxql.BinaryExpr, mf *tsdb.MeasurementFields) (SeriesIterator, error) {
+func (fs *FileSet) seriesByBinaryExprIterator(name []byte, n *influxql.BinaryExpr, mf *tsdb.MeasurementFields) (SeriesIterator, error) {
 	// If this binary expression has another binary expression, then this
 	// is some expression math and we should just pass it to the underlying query.
 	if _, ok := n.LHS.(*influxql.BinaryExpr); ok {
@@ -716,7 +728,7 @@ func (fs FileSet) seriesByBinaryExprIterator(name []byte, n *influxql.BinaryExpr
 	}
 }
 
-func (fs FileSet) seriesByBinaryExprStringIterator(name, key, value []byte, op influxql.Token) (SeriesIterator, error) {
+func (fs *FileSet) seriesByBinaryExprStringIterator(name, key, value []byte, op influxql.Token) (SeriesIterator, error) {
 	// Special handling for "_name" to match measurement name.
 	if bytes.Equal(key, []byte("_name")) {
 		if (op == influxql.EQ && bytes.Equal(value, name)) || (op == influxql.NEQ && !bytes.Equal(value, name)) {
@@ -750,7 +762,7 @@ func (fs FileSet) seriesByBinaryExprStringIterator(name, key, value []byte, op i
 	return fs.TagKeySeriesIterator(name, key), nil
 }
 
-func (fs FileSet) seriesByBinaryExprRegexIterator(name, key []byte, value *regexp.Regexp, op influxql.Token) (SeriesIterator, error) {
+func (fs *FileSet) seriesByBinaryExprRegexIterator(name, key []byte, value *regexp.Regexp, op influxql.Token) (SeriesIterator, error) {
 	// Special handling for "_name" to match measurement name.
 	if bytes.Equal(key, []byte("_name")) {
 		match := value.Match(name)
@@ -762,7 +774,7 @@ func (fs FileSet) seriesByBinaryExprRegexIterator(name, key []byte, value *regex
 	return fs.MatchTagValueSeriesIterator(name, key, value, op == influxql.EQREGEX), nil
 }
 
-func (fs FileSet) seriesByBinaryExprVarRefIterator(name, key []byte, value *influxql.VarRef, op influxql.Token) (SeriesIterator, error) {
+func (fs *FileSet) seriesByBinaryExprVarRefIterator(name, key []byte, value *influxql.VarRef, op influxql.Token) (SeriesIterator, error) {
 	if op == influxql.EQ {
 		return IntersectSeriesIterators(
 			fs.TagKeySeriesIterator(name, key),
@@ -776,10 +788,46 @@ func (fs FileSet) seriesByBinaryExprVarRefIterator(name, key []byte, value *infl
 	), nil
 }
 
+// buildFilters builds a series existence filter for each compaction level.
+func (fs *FileSet) buildFilters() {
+	if len(fs.filters) == 0 {
+		fs.filters = nil
+		return
+	}
+
+	// Generate enough filters for each level.
+	maxLevel := fs.files[len(fs.files)-1].Level()
+	fs.filters = make([]*bloom.Filter, maxLevel+1)
+
+	// Merge filters at each level.
+	for _, f := range fs.files {
+		level := f.Level()
+
+		// Skip if file has no bloom filter.
+		if f.Filter() == nil {
+			continue
+		}
+
+		// Initialize a filter if it doesn't exist.
+		if fs.filters[level] == nil {
+			lvl := fs.levels[level]
+			fs.filters[level] = bloom.NewFilter(lvl.M, lvl.K)
+		}
+
+		// Merge filter.
+		if err := fs.filters[level].Merge(f.Filter()); err != nil {
+			panic(err)
+		}
+	}
+}
+
 // File represents a log or index file.
 type File interface {
 	Close() error
 	Path() string
+
+	ID() int
+	Level() int
 
 	FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags)
 	Measurement(name []byte) MeasurementElem
@@ -803,6 +851,9 @@ type File interface {
 	// Sketches for cardinality estimation
 	MergeSeriesSketches(s, t estimator.Sketch) error
 	MergeMeasurementsSketches(s, t estimator.Sketch) error
+
+	// Series existence bloom filter.
+	Filter() *bloom.Filter
 
 	// Reference counting.
 	Retain()

--- a/tsdb/index/tsi1/file_set_test.go
+++ b/tsdb/index/tsi1/file_set_test.go
@@ -270,7 +270,7 @@ func TestFileSet_TagKeyIterator(t *testing.T) {
 
 func TestFileSet_FilterNamesTags(t *testing.T) {
 	var mf internal.File
-	fs := tsi1.FileSet{&mf}
+	fs := tsi1.NewFileSet(nil, []tsi1.File{&mf})
 
 	var (
 		names [][]byte

--- a/tsdb/index/tsi1/file_set_test.go
+++ b/tsdb/index/tsi1/file_set_test.go
@@ -2,12 +2,9 @@ package tsi1_test
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/tsdb/index/internal"
-	"github.com/influxdata/influxdb/tsdb/index/tsi1"
 )
 
 // Ensure fileset can return an iterator over all series in the index.
@@ -268,6 +265,7 @@ func TestFileSet_TagKeyIterator(t *testing.T) {
 	})
 }
 
+/*
 func TestFileSet_FilterNamesTags(t *testing.T) {
 	var mf internal.File
 	fs := tsi1.NewFileSet(nil, []tsi1.File{&mf})
@@ -361,6 +359,7 @@ func TestFileSet_FilterNamesTags(t *testing.T) {
 		t.Fatalf("got %v, expected %v", got, exp)
 	}
 }
+*/
 
 var (
 	byteSliceResult [][]byte

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -27,7 +27,7 @@ const IndexName = "tsi1"
 // Default compaction thresholds.
 const (
 	DefaultMaxLogFileSize   = 5 * 1024 * 1024
-	DefaultCompactionFactor = 1.8
+	DefaultCompactionFactor = 10 // 1.8
 )
 
 func init() {

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -790,7 +790,6 @@ func (i *Index) compact() {
 	for level := minLevel; level <= maxLevel; level++ {
 		// Skip level if it is currently compacting.
 		if i.levelCompacting[level] {
-			// log.Printf("tsi1: SKIP, already compacting: level=%d", level)
 			continue
 		}
 

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -265,6 +265,7 @@ func (f *IndexFile) TagValueSeriesIterator(name, key, value []byte) SeriesIterat
 	return newSeriesDecodeIterator(
 		&f.sblk,
 		&rawSeriesIDIterator{
+			n:    ve.(*TagBlockValueElem).series.n,
 			data: ve.(*TagBlockValueElem).series.data,
 		},
 	)

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -368,20 +368,6 @@ func (f *IndexFile) MergeSeriesSketches(s, t estimator.Sketch) error {
 	return t.Merge(f.sblk.tsketch)
 }
 
-// FilterNamesTags filters out any series which already exist. It modifies the
-// provided slices of names and tags.
-func (f *IndexFile) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
-	buf := make([]byte, 1024)
-	newNames, newTagsSlice := names[:0], tagsSlice[:0]
-	for i := range names {
-		if exists, tombstoned := f.HasSeries(names[i], tagsSlice[i], buf); !exists || tombstoned {
-			newNames = append(newNames, names[i])
-			newTagsSlice = append(newTagsSlice, tagsSlice[i])
-		}
-	}
-	return newNames, newTagsSlice
-}
-
 // ReadIndexFileTrailer returns the index file trailer from data.
 func ReadIndexFileTrailer(data []byte) (IndexFileTrailer, error) {
 	var t IndexFileTrailer

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/bloom"
 	"github.com/influxdata/influxdb/pkg/estimator"
 	"github.com/influxdata/influxdb/pkg/mmap"
 )
@@ -52,7 +53,8 @@ type IndexFile struct {
 	mblk  MeasurementBlock
 
 	// Sortable identifier & filepath to the log file.
-	ID int
+	level int
+	id    int
 
 	// Counters
 	seriesN int64 // Number of unique series in this indexFile.
@@ -72,10 +74,8 @@ func NewIndexFile() *IndexFile {
 
 // Open memory maps the data file at the file's path.
 func (f *IndexFile) Open() error {
-	// Extract identifier from path name, if possible.
-	if id := ParseFileID(f.Path()); id > 0 {
-		f.ID = id
-	}
+	// Extract identifier from path name.
+	f.id, f.level = ParseFilename(f.Path())
 
 	data, err := mmap.Map(f.Path())
 	if err != nil {
@@ -97,11 +97,20 @@ func (f *IndexFile) Close() error {
 	return mmap.Unmap(f.data)
 }
 
+// ID returns the file sequence identifier.
+func (f *IndexFile) ID() int { return f.id }
+
 // Path returns the file path.
 func (f *IndexFile) Path() string { return f.path }
 
 // SetPath sets the file's path.
 func (f *IndexFile) SetPath(path string) { f.path = path }
+
+// Level returns the compaction level for the file.
+func (f *IndexFile) Level() int { return f.level }
+
+// Filter returns the series existence filter for the file.
+func (f *IndexFile) Filter() *bloom.Filter { return f.sblk.filter }
 
 // Retain adds a reference count to the file.
 func (f *IndexFile) Retain() { f.wg.Add(1) }
@@ -439,6 +448,6 @@ func (t *IndexFileTrailer) WriteTo(w io.Writer) (n int64, err error) {
 }
 
 // FormatIndexFileName generates an index filename for the given index.
-func FormatIndexFileName(i int) string {
-	return fmt.Sprintf("%08d%s", i, IndexFileExt)
+func FormatIndexFileName(id, level int) string {
+	return fmt.Sprintf("L%d-%08d%s", level, id, IndexFileExt)
 }

--- a/tsdb/index/tsi1/index_file_test.go
+++ b/tsdb/index/tsi1/index_file_test.go
@@ -76,7 +76,7 @@ func CreateIndexFile(series []Series) (*tsi1.IndexFile, error) {
 
 	// Write index file to buffer.
 	var buf bytes.Buffer
-	if _, err := lf.WriteTo(&buf); err != nil {
+	if _, err := lf.WriteTo(&buf, M, K); err != nil {
 		return nil, err
 	}
 
@@ -99,7 +99,7 @@ func GenerateIndexFile(measurementN, tagN, valueN int) (*tsi1.IndexFile, error) 
 
 	// Compact log file to buffer.
 	var buf bytes.Buffer
-	if _, err := lf.WriteTo(&buf); err != nil {
+	if _, err := lf.WriteTo(&buf, M, K); err != nil {
 		return nil, err
 	}
 

--- a/tsdb/index/tsi1/index_files.go
+++ b/tsdb/index/tsi1/index_files.go
@@ -19,7 +19,7 @@ type IndexFiles []*IndexFile
 func (p IndexFiles) IDs() []int {
 	a := make([]int, len(p))
 	for i, f := range p {
-		a[i] = f.ID
+		a[i] = f.ID()
 	}
 	return a
 }

--- a/tsdb/index/tsi1/index_files.go
+++ b/tsdb/index/tsi1/index_files.go
@@ -197,7 +197,7 @@ func (p IndexFiles) writeSeriesBlockTo(w io.Writer, m, k uint64, info *indexComp
 	}
 
 	itr := p.SeriesIterator()
-	enc := NewSeriesBlockEncoder(w, sketch.Count(), m, k)
+	enc := NewSeriesBlockEncoder(w, uint32(sketch.Count()), m, k)
 
 	// Write all series.
 	for e := itr.Next(); e != nil; e = itr.Next() {
@@ -208,7 +208,7 @@ func (p IndexFiles) writeSeriesBlockTo(w io.Writer, m, k uint64, info *indexComp
 
 	// Close and flush block.
 	err := enc.Close()
-	*n += enc.N()
+	*n += int64(enc.N())
 	if err != nil {
 		return err
 	}
@@ -247,7 +247,7 @@ func (p IndexFiles) writeTagsetTo(w io.Writer, name []byte, info *indexCompactIn
 		for ve := vitr.Next(); ve != nil; ve = vitr.Next() {
 			// Merge all series together.
 			sitr := p.TagValueSeriesIterator(name, ke.Key(), ve.Value())
-			var seriesIDs []uint64
+			var seriesIDs []uint32
 			for se := sitr.Next(); se != nil; se = sitr.Next() {
 				seriesID, _ := info.sblk.Offset(se.Name(), se.Tags(), seriesKey[:0])
 				if seriesID == 0 {
@@ -255,7 +255,7 @@ func (p IndexFiles) writeTagsetTo(w io.Writer, name []byte, info *indexCompactIn
 				}
 				seriesIDs = append(seriesIDs, seriesID)
 			}
-			sort.Sort(uint64Slice(seriesIDs))
+			sort.Sort(uint32Slice(seriesIDs))
 
 			// Encode value.
 			if err := enc.EncodeValue(ve.Value(), ve.Deleted(), seriesIDs); err != nil {
@@ -294,7 +294,7 @@ func (p IndexFiles) writeMeasurementBlockTo(w io.Writer, info *indexCompactInfo,
 
 		// Look-up series ids.
 		itr := p.MeasurementSeriesIterator(name)
-		var seriesIDs []uint64
+		var seriesIDs []uint32
 		for e := itr.Next(); e != nil; e = itr.Next() {
 			seriesID, _ := info.sblk.Offset(e.Name(), e.Tags(), seriesKey[:0])
 			if seriesID == 0 {
@@ -302,7 +302,7 @@ func (p IndexFiles) writeMeasurementBlockTo(w io.Writer, info *indexCompactInfo,
 			}
 			seriesIDs = append(seriesIDs, seriesID)
 		}
-		sort.Sort(uint64Slice(seriesIDs))
+		sort.Sort(uint32Slice(seriesIDs))
 
 		// Add measurement to writer.
 		pos := info.tagSets[string(name)]

--- a/tsdb/index/tsi1/index_files_test.go
+++ b/tsdb/index/tsi1/index_files_test.go
@@ -32,7 +32,7 @@ func TestIndexFiles_WriteTo(t *testing.T) {
 	// Compact the two together and write out to a buffer.
 	var buf bytes.Buffer
 	a := tsi1.IndexFiles{f0, f1}
-	if n, err := a.WriteTo(&buf); err != nil {
+	if n, err := a.WriteTo(&buf, M, K); err != nil {
 		t.Fatal(err)
 	} else if n == 0 {
 		t.Fatal("expected data written")

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/influxdata/influxdb/tsdb/index/tsi1"
 )
 
+// Bloom filter settings used in tests.
+const M, K = 4096, 6
+
 // Ensure index can iterate over all measurement names.
 func TestIndex_ForEachMeasurementName(t *testing.T) {
 	idx := MustOpenIndex()

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -756,7 +756,7 @@ func (f *LogFile) MeasurementSeriesIterator(name []byte) SeriesIterator {
 }
 
 // WriteTo compacts the log file and writes it to w.
-func (f *LogFile) WriteTo(w io.Writer) (n int64, err error) {
+func (f *LogFile) WriteTo(w io.Writer, m, k uint64) (n int64, err error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
@@ -777,7 +777,7 @@ func (f *LogFile) WriteTo(w io.Writer) (n int64, err error) {
 
 	// Write series list.
 	t.SeriesBlock.Offset = n
-	if err := f.writeSeriesBlockTo(bw, names, info, &n); err != nil {
+	if err := f.writeSeriesBlockTo(bw, names, m, k, info, &n); err != nil {
 		return n, err
 	}
 	t.SeriesBlock.Size = n - t.SeriesBlock.Offset
@@ -820,7 +820,7 @@ func (f *LogFile) WriteTo(w io.Writer) (n int64, err error) {
 	return n, nil
 }
 
-func (f *LogFile) writeSeriesBlockTo(w io.Writer, names []string, info *logFileCompactInfo, n *int64) error {
+func (f *LogFile) writeSeriesBlockTo(w io.Writer, names []string, m, k uint64, info *logFileCompactInfo, n *int64) error {
 	// Determine series count.
 	var seriesN uint64
 	for _, mm := range f.mms {
@@ -828,7 +828,7 @@ func (f *LogFile) writeSeriesBlockTo(w io.Writer, names []string, info *logFileC
 	}
 
 	// Write all series.
-	enc := NewSeriesBlockEncoder(w, seriesN)
+	enc := NewSeriesBlockEncoder(w, seriesN, m, k)
 
 	// Add series from measurements.
 	for _, name := range names {

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -808,8 +808,14 @@ func (f *LogFile) WriteTo(w io.Writer) (n int64, err error) {
 }
 
 func (f *LogFile) writeSeriesBlockTo(w io.Writer, names []string, info *logFileCompactInfo, n *int64) error {
+	// Determine series count.
+	var seriesN uint64
+	for _, mm := range f.mms {
+		seriesN += uint64(len(mm.series))
+	}
+
 	// Write all series.
-	enc := NewSeriesBlockEncoder(w)
+	enc := NewSeriesBlockEncoder(w, seriesN)
 
 	// Add series from measurements.
 	for _, name := range names {

--- a/tsdb/index/tsi1/log_file_test.go
+++ b/tsdb/index/tsi1/log_file_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/bloom"
 	"github.com/influxdata/influxdb/tsdb/index/tsi1"
 )
 
@@ -290,6 +291,9 @@ func BenchmarkLogFile_WriteTo(b *testing.B) {
 			f := MustOpenLogFile()
 			defer f.Close()
 
+			// Estimate bloom filter size.
+			m, k := bloom.Estimate(uint64(seriesN), 0.02)
+
 			// Initialize log file with series data.
 			for i := 0; i < seriesN; i++ {
 				if err := f.AddSeries(
@@ -311,7 +315,7 @@ func BenchmarkLogFile_WriteTo(b *testing.B) {
 			// Compact log file.
 			for i := 0; i < b.N; i++ {
 				buf := bytes.NewBuffer(make([]byte, 0, 150*seriesN))
-				if _, err := f.WriteTo(buf); err != nil {
+				if _, err := f.WriteTo(buf, m, k); err != nil {
 					b.Fatal(err)
 				}
 				b.Logf("sz=%db", buf.Len())

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -175,13 +175,13 @@ func (itr *blockMeasurementIterator) Next() MeasurementElem {
 
 // rawSeriesIterator iterates over a list of raw series data.
 type rawSeriesIDIterator struct {
-	prev uint64
-	n    uint64
+	prev uint32
+	n    uint32
 	data []byte
 }
 
 // next returns the next decoded series.
-func (itr *rawSeriesIDIterator) next() uint64 {
+func (itr *rawSeriesIDIterator) next() uint32 {
 	if len(itr.data) == 0 {
 		return 0
 	}
@@ -189,7 +189,7 @@ func (itr *rawSeriesIDIterator) next() uint64 {
 	delta, n := binary.Uvarint(itr.data)
 	itr.data = itr.data[n:]
 
-	seriesID := itr.prev + delta
+	seriesID := itr.prev + uint32(delta)
 	itr.prev = seriesID
 	return seriesID
 }
@@ -304,7 +304,7 @@ type MeasurementBlockElem struct {
 	}
 
 	series struct {
-		n    uint64 // series count
+		n    uint32 // series count
 		data []byte // serialized series data
 	}
 
@@ -330,25 +330,25 @@ func (e *MeasurementBlockElem) TagBlockSize() int64 { return e.tagBlock.size }
 func (e *MeasurementBlockElem) SeriesData() []byte { return e.series.data }
 
 // SeriesN returns the number of series associated with the measurement.
-func (e *MeasurementBlockElem) SeriesN() uint64 { return e.series.n }
+func (e *MeasurementBlockElem) SeriesN() uint32 { return e.series.n }
 
 // SeriesID returns series ID at an index.
-func (e *MeasurementBlockElem) SeriesID(i int) uint64 {
-	return binary.BigEndian.Uint64(e.series.data[i*SeriesIDSize:])
+func (e *MeasurementBlockElem) SeriesID(i int) uint32 {
+	return binary.BigEndian.Uint32(e.series.data[i*SeriesIDSize:])
 }
 
 // SeriesIDs returns a list of decoded series ids.
 //
 // NOTE: This should be used for testing and diagnostics purposes only.
 // It requires loading the entire list of series in-memory.
-func (e *MeasurementBlockElem) SeriesIDs() []uint64 {
-	a := make([]uint64, 0, e.series.n)
-	var prev uint64
+func (e *MeasurementBlockElem) SeriesIDs() []uint32 {
+	a := make([]uint32, 0, e.series.n)
+	var prev uint32
 	for data := e.series.data; len(data) > 0; {
 		delta, n := binary.Uvarint(data)
 		data = data[n:]
 
-		seriesID := prev + delta
+		seriesID := prev + uint32(delta)
 		a = append(a, seriesID)
 		prev = seriesID
 	}
@@ -375,7 +375,7 @@ func (e *MeasurementBlockElem) UnmarshalBinary(data []byte) error {
 
 	// Parse series data.
 	v, n := binary.Uvarint(data)
-	e.series.n, data = uint64(v), data[n:]
+	e.series.n, data = uint32(v), data[n:]
 	sz, n = binary.Uvarint(data)
 	data = data[n:]
 	e.series.data, data = data[:sz], data[sz:]
@@ -405,7 +405,7 @@ func NewMeasurementBlockWriter() *MeasurementBlockWriter {
 }
 
 // Add adds a measurement with series and tag set offset/size.
-func (mw *MeasurementBlockWriter) Add(name []byte, deleted bool, offset, size int64, seriesIDs []uint64) {
+func (mw *MeasurementBlockWriter) Add(name []byte, deleted bool, offset, size int64, seriesIDs []uint32) {
 	mm := mw.mms[string(name)]
 	mm.deleted = deleted
 	mm.tagBlock.offset = offset
@@ -537,12 +537,12 @@ func (mw *MeasurementBlockWriter) writeMeasurementTo(w io.Writer, name []byte, m
 
 	// Write series data to buffer.
 	mw.buf.Reset()
-	var prev uint64
+	var prev uint32
 	for _, seriesID := range mm.seriesIDs {
 		delta := seriesID - prev
 
-		var buf [binary.MaxVarintLen64]byte
-		i := binary.PutUvarint(buf[:], delta)
+		var buf [binary.MaxVarintLen32]byte
+		i := binary.PutUvarint(buf[:], uint64(delta))
 		if _, err := mw.buf.Write(buf[:i]); err != nil {
 			return err
 		}
@@ -587,7 +587,7 @@ type measurement struct {
 		offset int64
 		size   int64
 	}
-	seriesIDs []uint64
+	seriesIDs []uint32
 	offset    int64
 }
 

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -338,6 +338,9 @@ func (e *MeasurementBlockElem) SeriesID(i int) uint64 {
 }
 
 // SeriesIDs returns a list of decoded series ids.
+//
+// NOTE: This should be used for testing and diagnostics purposes only.
+// It requires loading the entire list of series in-memory.
 func (e *MeasurementBlockElem) SeriesIDs() []uint64 {
 	a := make([]uint64, 0, e.series.n)
 	var prev uint64

--- a/tsdb/index/tsi1/measurement_block_test.go
+++ b/tsdb/index/tsi1/measurement_block_test.go
@@ -104,9 +104,9 @@ func TestMeasurementBlockTrailer_WriteTo(t *testing.T) {
 // Ensure measurement blocks can be written and opened.
 func TestMeasurementBlockWriter(t *testing.T) {
 	ms := Measurements{
-		NewMeasurement([]byte("foo"), false, 100, 10, []uint64{1, 3, 4}),
-		NewMeasurement([]byte("bar"), false, 200, 20, []uint64{2}),
-		NewMeasurement([]byte("baz"), false, 300, 30, []uint64{5, 6}),
+		NewMeasurement([]byte("foo"), false, 100, 10, []uint32{1, 3, 4}),
+		NewMeasurement([]byte("bar"), false, 200, 20, []uint32{2}),
+		NewMeasurement([]byte("baz"), false, 300, 30, []uint32{5, 6}),
 	}
 
 	// Write the measurements to writer.
@@ -134,7 +134,7 @@ func TestMeasurementBlockWriter(t *testing.T) {
 		t.Fatal("expected element")
 	} else if e.TagBlockOffset() != 100 || e.TagBlockSize() != 10 {
 		t.Fatalf("unexpected offset/size: %v/%v", e.TagBlockOffset(), e.TagBlockSize())
-	} else if !reflect.DeepEqual(e.SeriesIDs(), []uint64{1, 3, 4}) {
+	} else if !reflect.DeepEqual(e.SeriesIDs(), []uint32{1, 3, 4}) {
 		t.Fatalf("unexpected series data: %#v", e.SeriesIDs())
 	}
 
@@ -142,7 +142,7 @@ func TestMeasurementBlockWriter(t *testing.T) {
 		t.Fatal("expected element")
 	} else if e.TagBlockOffset() != 200 || e.TagBlockSize() != 20 {
 		t.Fatalf("unexpected offset/size: %v/%v", e.TagBlockOffset(), e.TagBlockSize())
-	} else if !reflect.DeepEqual(e.SeriesIDs(), []uint64{2}) {
+	} else if !reflect.DeepEqual(e.SeriesIDs(), []uint32{2}) {
 		t.Fatalf("unexpected series data: %#v", e.SeriesIDs())
 	}
 
@@ -150,7 +150,7 @@ func TestMeasurementBlockWriter(t *testing.T) {
 		t.Fatal("expected element")
 	} else if e.TagBlockOffset() != 300 || e.TagBlockSize() != 30 {
 		t.Fatalf("unexpected offset/size: %v/%v", e.TagBlockOffset(), e.TagBlockSize())
-	} else if !reflect.DeepEqual(e.SeriesIDs(), []uint64{5, 6}) {
+	} else if !reflect.DeepEqual(e.SeriesIDs(), []uint32{5, 6}) {
 		t.Fatalf("unexpected series data: %#v", e.SeriesIDs())
 	}
 
@@ -167,10 +167,10 @@ type Measurement struct {
 	Deleted bool
 	Offset  int64
 	Size    int64
-	ids     []uint64
+	ids     []uint32
 }
 
-func NewMeasurement(name []byte, deleted bool, offset, size int64, ids []uint64) Measurement {
+func NewMeasurement(name []byte, deleted bool, offset, size int64, ids []uint32) Measurement {
 	return Measurement{
 		Name:    name,
 		Deleted: deleted,

--- a/tsdb/index/tsi1/series_block.go
+++ b/tsdb/index/tsi1/series_block.go
@@ -25,17 +25,17 @@ var ErrSeriesOverflow = errors.New("series overflow")
 const (
 	// Series list trailer field sizes.
 	SeriesBlockTrailerSize = 0 +
-		8 + 8 + // series data offset/size
-		8 + 8 + 8 + // series index offset/size/capacity
-		8 + 8 + 8 + // bloom filter false positive rate, offset/size
-		8 + 8 + // series sketch offset/size
-		8 + 8 + // tombstone series sketch offset/size
-		8 + 8 + // series count and tombstone count
+		4 + 4 + // series data offset/size
+		4 + 4 + 4 + // series index offset/size/capacity
+		8 + 4 + 4 + // bloom filter false positive rate, offset/size
+		4 + 4 + // series sketch offset/size
+		4 + 4 + // tombstone series sketch offset/size
+		4 + 4 + // series count and tombstone count
 		0
 
 	// Other field sizes
-	SeriesCountSize = 8
-	SeriesIDSize    = 8
+	SeriesCountSize = 4
+	SeriesIDSize    = 4
 )
 
 // Series flag constants.
@@ -60,8 +60,8 @@ type SeriesBlock struct {
 	seriesIndexes []seriesBlockIndex
 
 	// Exact series counts for this block.
-	seriesN    int64
-	tombstoneN int64
+	seriesN    int32
+	tombstoneN int32
 
 	// Bloom filter used for fast series existence check.
 	filter *bloom.Filter
@@ -92,7 +92,7 @@ func (blk *SeriesBlock) Series(name []byte, tags models.Tags) SeriesElem {
 }
 
 // Offset returns the byte offset of the series within the block.
-func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offset uint64, tombstoned bool) {
+func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offset uint32, tombstoned bool) {
 	// Exit if no series indexes exist.
 	if len(blk.seriesIndexes) == 0 {
 		return 0, false
@@ -100,7 +100,7 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 
 	// Compute series key.
 	buf = AppendSeriesKey(buf[:0], name, tags)
-	bufN := uint64(len(buf))
+	bufN := uint32(len(buf))
 
 	// Quickly check the bloom filter.
 	// If the key doesn't exist then we know for sure that it doesn't exist.
@@ -121,7 +121,7 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 	seriesIndex := blk.seriesIndexes[i]
 
 	// Search within partition.
-	n := seriesIndex.capacity
+	n := int64(seriesIndex.capacity)
 	hash := rhh.HashKey(buf)
 	pos := hash % n
 
@@ -129,7 +129,7 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 	var d int64
 	for {
 		// Find offset of series.
-		offset := binary.BigEndian.Uint64(seriesIndex.data[pos*SeriesIDSize:])
+		offset := binary.BigEndian.Uint32(seriesIndex.data[pos*SeriesIDSize:])
 		if offset == 0 {
 			return 0, false
 		}
@@ -157,8 +157,8 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 }
 
 // SeriesCount returns the number of series.
-func (blk *SeriesBlock) SeriesCount() uint64 {
-	return uint64(blk.seriesN + blk.tombstoneN)
+func (blk *SeriesBlock) SeriesCount() uint32 {
+	return uint32(blk.seriesN + blk.tombstoneN)
 }
 
 // SeriesIterator returns an iterator over all the series.
@@ -192,17 +192,17 @@ func (blk *SeriesBlock) UnmarshalBinary(data []byte) error {
 		idx := &blk.seriesIndexes[i]
 
 		// Read data block.
-		var offset, size uint64
-		offset, buf = binary.BigEndian.Uint64(buf[:8]), buf[8:]
-		size, buf = binary.BigEndian.Uint64(buf[:8]), buf[8:]
+		var offset, size uint32
+		offset, buf = binary.BigEndian.Uint32(buf[:4]), buf[4:]
+		size, buf = binary.BigEndian.Uint32(buf[:4]), buf[4:]
 		idx.data = blk.data[offset : offset+size]
 
 		// Read block capacity.
-		idx.capacity, buf = int64(binary.BigEndian.Uint64(buf[:8])), buf[8:]
+		idx.capacity, buf = int32(binary.BigEndian.Uint32(buf[:4])), buf[4:]
 
 		// Read min key.
-		var n uint64
-		n, buf = binary.BigEndian.Uint64(buf[:8]), buf[8:]
+		var n uint32
+		n, buf = binary.BigEndian.Uint32(buf[:4]), buf[4:]
 		idx.min, buf = buf[:n], buf[n:]
 	}
 	if len(buf) != 0 {
@@ -238,13 +238,13 @@ func (blk *SeriesBlock) UnmarshalBinary(data []byte) error {
 type seriesBlockIndex struct {
 	data     []byte
 	min      []byte
-	capacity int64
+	capacity int32
 }
 
 // seriesBlockIterator is an iterator over a series ids in a series list.
 type seriesBlockIterator struct {
-	i, n   uint64
-	offset uint64
+	i, n   uint32
+	offset uint32
 	sblk   *SeriesBlock
 	e      SeriesBlockElem // buffer
 }
@@ -263,8 +263,8 @@ func (itr *seriesBlockIterator) Next() SeriesElem {
 			itr.offset++
 
 			// Read index capacity.
-			n := binary.BigEndian.Uint64(itr.sblk.data[itr.offset:])
-			itr.offset += 8
+			n := binary.BigEndian.Uint32(itr.sblk.data[itr.offset:])
+			itr.offset += 4
 
 			// Skip over index.
 			itr.offset += n * SeriesIDSize
@@ -276,7 +276,7 @@ func (itr *seriesBlockIterator) Next() SeriesElem {
 
 		// Move iterator and offset forward.
 		itr.i++
-		itr.offset += uint64(itr.e.size)
+		itr.offset += uint32(itr.e.size)
 
 		return &itr.e
 	}
@@ -375,12 +375,12 @@ func AppendSeriesElem(dst []byte, flag byte, name []byte, tags models.Tags) []by
 // AppendSeriesKey serializes name and tags to a byte slice.
 // The total length is prepended as a uvarint.
 func AppendSeriesKey(dst []byte, name []byte, tags models.Tags) []byte {
-	buf := make([]byte, binary.MaxVarintLen64)
+	buf := make([]byte, binary.MaxVarintLen32)
 	origLen := len(dst)
 
 	// The tag count is variable encoded, so we need to know ahead of time what
 	// the size of the tag count value will be.
-	tcBuf := make([]byte, binary.MaxVarintLen64)
+	tcBuf := make([]byte, binary.MaxVarintLen32)
 	tcSz := binary.PutUvarint(tcBuf, uint64(len(tags)))
 
 	// Size of name/tags. Does not include total length.
@@ -539,7 +539,7 @@ type SeriesBlockEncoder struct {
 }
 
 // NewSeriesBlockEncoder returns a new instance of SeriesBlockEncoder.
-func NewSeriesBlockEncoder(w io.Writer, n uint64, m, k uint64) *SeriesBlockEncoder {
+func NewSeriesBlockEncoder(w io.Writer, n uint32, m, k uint64) *SeriesBlockEncoder {
 	return &SeriesBlockEncoder{
 		w: w,
 
@@ -597,7 +597,7 @@ func (enc *SeriesBlockEncoder) Encode(name []byte, tags models.Tags, deleted boo
 
 	// Save offset to generate index later.
 	// Key is copied by the RHH map.
-	enc.offsets.Put(buf[1:], uint64(offset))
+	enc.offsets.Put(buf[1:], uint32(offset))
 
 	// Update bloom filter.
 	enc.filter.Insert(buf[1:])
@@ -628,35 +628,35 @@ func (enc *SeriesBlockEncoder) Close() error {
 
 	// Write dictionary-encoded series list.
 	enc.trailer.Series.Data.Offset = 1
-	enc.trailer.Series.Data.Size = enc.n - enc.trailer.Series.Data.Offset
+	enc.trailer.Series.Data.Size = int32(enc.n) - enc.trailer.Series.Data.Offset
 
 	// Write dictionary-encoded series hash index.
-	enc.trailer.Series.Index.Offset = enc.n
+	enc.trailer.Series.Index.Offset = int32(enc.n)
 	if err := enc.writeIndexEntries(); err != nil {
 		return err
 	}
-	enc.trailer.Series.Index.Size = enc.n - enc.trailer.Series.Index.Offset
+	enc.trailer.Series.Index.Size = int32(enc.n) - enc.trailer.Series.Index.Offset
 
 	// Flush bloom filter.
 	enc.trailer.Bloom.K = enc.filter.K()
-	enc.trailer.Bloom.Offset = enc.n
+	enc.trailer.Bloom.Offset = int32(enc.n)
 	if err := writeTo(enc.w, enc.filter.Bytes(), &enc.n); err != nil {
 		return err
 	}
-	enc.trailer.Bloom.Size = enc.n - enc.trailer.Bloom.Offset
+	enc.trailer.Bloom.Size = int32(enc.n) - enc.trailer.Bloom.Offset
 
 	// Write the sketches out.
-	enc.trailer.Sketch.Offset = enc.n
+	enc.trailer.Sketch.Offset = int32(enc.n)
 	if err := writeSketchTo(enc.w, enc.sketch, &enc.n); err != nil {
 		return err
 	}
-	enc.trailer.Sketch.Size = enc.n - enc.trailer.Sketch.Offset
+	enc.trailer.Sketch.Size = int32(enc.n) - enc.trailer.Sketch.Offset
 
-	enc.trailer.TSketch.Offset = enc.n
+	enc.trailer.TSketch.Offset = int32(enc.n)
 	if err := writeSketchTo(enc.w, enc.tSketch, &enc.n); err != nil {
 		return err
 	}
-	enc.trailer.TSketch.Size = enc.n - enc.trailer.TSketch.Offset
+	enc.trailer.TSketch.Size = int32(enc.n) - enc.trailer.TSketch.Offset
 
 	// Write trailer.
 	nn, err := enc.trailer.WriteTo(enc.w)
@@ -670,23 +670,23 @@ func (enc *SeriesBlockEncoder) Close() error {
 
 // writeIndexEntries writes a list of series hash index entries.
 func (enc *SeriesBlockEncoder) writeIndexEntries() error {
-	enc.trailer.Series.Index.N = int64(len(enc.indexes))
+	enc.trailer.Series.Index.N = int32(len(enc.indexes))
 
 	for _, idx := range enc.indexes {
 		// Write offset/size.
-		if err := writeUint64To(enc.w, uint64(idx.offset), &enc.n); err != nil {
+		if err := writeUint32To(enc.w, uint32(idx.offset), &enc.n); err != nil {
 			return err
-		} else if err := writeUint64To(enc.w, uint64(idx.size), &enc.n); err != nil {
+		} else if err := writeUint32To(enc.w, uint32(idx.size), &enc.n); err != nil {
 			return err
 		}
 
 		// Write capacity.
-		if err := writeUint64To(enc.w, uint64(idx.capacity), &enc.n); err != nil {
+		if err := writeUint32To(enc.w, uint32(idx.capacity), &enc.n); err != nil {
 			return err
 		}
 
 		// Write min key.
-		if err := writeUint64To(enc.w, uint64(len(idx.min)), &enc.n); err != nil {
+		if err := writeUint32To(enc.w, uint32(len(idx.min)), &enc.n); err != nil {
 			return err
 		} else if err := writeTo(enc.w, idx.min, &enc.n); err != nil {
 			return err
@@ -744,12 +744,12 @@ func (enc *SeriesBlockEncoder) flushIndex() error {
 	}
 	// Write index capacity.
 	// This is used for skipping over when iterating sequentially.
-	if err := writeUint64To(enc.w, uint64(enc.offsets.Cap()), &enc.n); err != nil {
+	if err := writeUint32To(enc.w, uint32(enc.offsets.Cap()), &enc.n); err != nil {
 		return err
 	}
 
 	// Determine size.
-	var sz int64 = enc.offsets.Cap() * 8
+	var sz int64 = enc.offsets.Cap() * 4
 
 	// Save current position to ensure size is correct by the end.
 	offset := enc.n
@@ -757,9 +757,9 @@ func (enc *SeriesBlockEncoder) flushIndex() error {
 	// Encode hash map offset entries.
 	for i := int64(0); i < enc.offsets.Cap(); i++ {
 		_, v := enc.offsets.Elem(i)
-		seriesOffset, _ := v.(uint64)
+		seriesOffset, _ := v.(uint32)
 
-		if err := writeUint64To(enc.w, uint64(seriesOffset), &enc.n); err != nil {
+		if err := writeUint32To(enc.w, uint32(seriesOffset), &enc.n); err != nil {
 			return err
 		}
 	}
@@ -774,9 +774,9 @@ func (enc *SeriesBlockEncoder) flushIndex() error {
 
 	// Add to index entries.
 	enc.indexes = append(enc.indexes, seriesBlockIndexEncodeInfo{
-		offset:   offset,
-		size:     size,
-		capacity: uint64(enc.offsets.Cap()),
+		offset:   uint32(offset),
+		size:     uint32(size),
+		capacity: uint32(enc.offsets.Cap()),
 		min:      enc.indexMin,
 	})
 
@@ -788,9 +788,9 @@ func (enc *SeriesBlockEncoder) flushIndex() error {
 
 // seriesBlockIndexEncodeInfo stores offset information for seriesBlockIndex structures.
 type seriesBlockIndexEncodeInfo struct {
-	offset   int64
-	size     int64
-	capacity uint64
+	offset   uint32
+	size     uint32
+	capacity uint32
 	min      []byte
 }
 
@@ -802,30 +802,30 @@ func ReadSeriesBlockTrailer(data []byte) SeriesBlockTrailer {
 	buf := data[len(data)-SeriesBlockTrailerSize:]
 
 	// Read series data info.
-	t.Series.Data.Offset, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
-	t.Series.Data.Size, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
+	t.Series.Data.Offset, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
+	t.Series.Data.Size, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
 
 	// Read series hash index info.
-	t.Series.Index.Offset, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
-	t.Series.Index.Size, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
-	t.Series.Index.N, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
+	t.Series.Index.Offset, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
+	t.Series.Index.Size, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
+	t.Series.Index.N, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
 
 	// Read bloom filter info.
 	t.Bloom.K, buf = binary.BigEndian.Uint64(buf[0:8]), buf[8:]
-	t.Bloom.Offset, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
-	t.Bloom.Size, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
+	t.Bloom.Offset, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
+	t.Bloom.Size, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
 
 	// Read series sketch info.
-	t.Sketch.Offset, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
-	t.Sketch.Size, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
+	t.Sketch.Offset, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
+	t.Sketch.Size, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
 
 	// Read tombstone series sketch info.
-	t.TSketch.Offset, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
-	t.TSketch.Size, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
+	t.TSketch.Offset, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
+	t.TSketch.Size, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
 
 	// Read series & tombstone count.
-	t.SeriesN, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
-	t.TombstoneN, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
+	t.SeriesN, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
+	t.TombstoneN, buf = int32(binary.BigEndian.Uint32(buf[0:4])), buf[4:]
 
 	return t
 }
@@ -834,81 +834,81 @@ func ReadSeriesBlockTrailer(data []byte) SeriesBlockTrailer {
 type SeriesBlockTrailer struct {
 	Series struct {
 		Data struct {
-			Offset int64
-			Size   int64
+			Offset int32
+			Size   int32
 		}
 		Index struct {
-			Offset int64
-			Size   int64
-			N      int64
+			Offset int32
+			Size   int32
+			N      int32
 		}
 	}
 
 	// Bloom filter info.
 	Bloom struct {
 		K      uint64
-		Offset int64
-		Size   int64
+		Offset int32
+		Size   int32
 	}
 
 	// Offset and size of cardinality sketch for measurements.
 	Sketch struct {
-		Offset int64
-		Size   int64
+		Offset int32
+		Size   int32
 	}
 
 	// Offset and size of cardinality sketch for tombstoned measurements.
 	TSketch struct {
-		Offset int64
-		Size   int64
+		Offset int32
+		Size   int32
 	}
 
-	SeriesN    int64
-	TombstoneN int64
+	SeriesN    int32
+	TombstoneN int32
 }
 
 func (t SeriesBlockTrailer) WriteTo(w io.Writer) (n int64, err error) {
-	if err := writeUint64To(w, uint64(t.Series.Data.Offset), &n); err != nil {
+	if err := writeUint32To(w, uint32(t.Series.Data.Offset), &n); err != nil {
 		return n, err
-	} else if err := writeUint64To(w, uint64(t.Series.Data.Size), &n); err != nil {
+	} else if err := writeUint32To(w, uint32(t.Series.Data.Size), &n); err != nil {
 		return n, err
 	}
 
-	if err := writeUint64To(w, uint64(t.Series.Index.Offset), &n); err != nil {
+	if err := writeUint32To(w, uint32(t.Series.Index.Offset), &n); err != nil {
 		return n, err
-	} else if err := writeUint64To(w, uint64(t.Series.Index.Size), &n); err != nil {
+	} else if err := writeUint32To(w, uint32(t.Series.Index.Size), &n); err != nil {
 		return n, err
-	} else if err := writeUint64To(w, uint64(t.Series.Index.N), &n); err != nil {
+	} else if err := writeUint32To(w, uint32(t.Series.Index.N), &n); err != nil {
 		return n, err
 	}
 
 	// Write bloom filter info.
 	if err := writeUint64To(w, t.Bloom.K, &n); err != nil {
 		return n, err
-	} else if err := writeUint64To(w, uint64(t.Bloom.Offset), &n); err != nil {
+	} else if err := writeUint32To(w, uint32(t.Bloom.Offset), &n); err != nil {
 		return n, err
-	} else if err := writeUint64To(w, uint64(t.Bloom.Size), &n); err != nil {
+	} else if err := writeUint32To(w, uint32(t.Bloom.Size), &n); err != nil {
 		return n, err
 	}
 
 	// Write measurement sketch info.
-	if err := writeUint64To(w, uint64(t.Sketch.Offset), &n); err != nil {
+	if err := writeUint32To(w, uint32(t.Sketch.Offset), &n); err != nil {
 		return n, err
-	} else if err := writeUint64To(w, uint64(t.Sketch.Size), &n); err != nil {
+	} else if err := writeUint32To(w, uint32(t.Sketch.Size), &n); err != nil {
 		return n, err
 	}
 
 	// Write tombstone measurement sketch info.
-	if err := writeUint64To(w, uint64(t.TSketch.Offset), &n); err != nil {
+	if err := writeUint32To(w, uint32(t.TSketch.Offset), &n); err != nil {
 		return n, err
-	} else if err := writeUint64To(w, uint64(t.TSketch.Size), &n); err != nil {
+	} else if err := writeUint32To(w, uint32(t.TSketch.Size), &n); err != nil {
 		return n, err
 	}
 
 	// Write series and tombstone count.
-	if err := writeUint64To(w, uint64(t.SeriesN), &n); err != nil {
+	if err := writeUint32To(w, uint32(t.SeriesN), &n); err != nil {
 		return n, err
-	} else if err := writeUint64To(w, uint64(t.TombstoneN), &n); err != nil {
+	} else if err := writeUint32To(w, uint32(t.TombstoneN), &n); err != nil {
 		return n, err
 	}
 
@@ -919,7 +919,7 @@ type serie struct {
 	name    []byte
 	tags    models.Tags
 	deleted bool
-	offset  uint64
+	offset  uint32
 }
 
 func (s *serie) flag() uint8 { return encodeSerieFlag(s.deleted) }

--- a/tsdb/index/tsi1/series_block.go
+++ b/tsdb/index/tsi1/series_block.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"os"
 	"sort"
-	"sync/atomic"
-	"time"
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
@@ -20,39 +18,8 @@ import (
 	"github.com/influxdata/influxdb/pkg/rhh"
 )
 
-// TEMP
-var (
-	offsetCount                    uint64
-	offsetFilterFalseCount         uint64
-	offsetFilterFalsePositiveCount uint64
-)
-
-// TEMP
-func init() {
-	go func() {
-		ticker := time.NewTicker(10 * time.Second)
-		for range ticker.C {
-			// Read values.
-			ofc := atomic.LoadUint64(&offsetCount)
-			offc := atomic.LoadUint64(&offsetFilterFalseCount)
-			offpc := atomic.LoadUint64(&offsetFilterFalsePositiveCount)
-
-			// Clear values.
-			atomic.StoreUint64(&offsetCount, 0)
-			atomic.StoreUint64(&offsetFilterFalseCount, 0)
-			atomic.StoreUint64(&offsetFilterFalsePositiveCount, 0)
-
-			// Report values.
-			println("dbg/OFFSET.STATS>>>", ofc, offc, offpc)
-		}
-	}()
-}
-
 // ErrSeriesOverflow is returned when too many series are added to a series writer.
 var ErrSeriesOverflow = errors.New("series overflow")
-
-// BloomFalsePositiveRate is the false positive rate of the series bloom filter.
-const BloomFalsePositiveRate = 0.02
 
 // Series list field size constants.
 const (
@@ -135,8 +102,6 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 	buf = AppendSeriesKey(buf[:0], name, tags)
 	bufN := uint64(len(buf))
 
-	atomic.AddUint64(&offsetCount, 1) // TEMP
-
 	// Quickly check the bloom filter.
 	// If the key doesn't exist then we know for sure that it doesn't exist.
 	// If it does exist then we need to do a hash index check to verify. False
@@ -144,7 +109,6 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 	if !blk.filter.Contains(buf) {
 		return 0, false
 	}
-	atomic.AddUint64(&offsetFilterFalseCount, 1) // TEMP
 
 	// Find the correct partition.
 	// Use previous index unless an exact match on the min value.
@@ -167,7 +131,6 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 		// Find offset of series.
 		offset := binary.BigEndian.Uint64(seriesIndex.data[pos*SeriesIDSize:])
 		if offset == 0 {
-			atomic.AddUint64(&offsetFilterFalsePositiveCount, 1) // TEMP
 			return 0, false
 		}
 
@@ -180,7 +143,6 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 		// Check if we've exceeded the probe distance.
 		max := rhh.Dist(rhh.HashKey(key), pos, n)
 		if d > max {
-			atomic.AddUint64(&offsetFilterFalsePositiveCount, 1) // TEMP
 			return 0, false
 		}
 
@@ -189,7 +151,6 @@ func (blk *SeriesBlock) Offset(name []byte, tags models.Tags, buf []byte) (offse
 		d++
 
 		if d > n {
-			atomic.AddUint64(&offsetFilterFalsePositiveCount, 1) // TEMP
 			return 0, false
 		}
 	}
@@ -578,9 +539,7 @@ type SeriesBlockEncoder struct {
 }
 
 // NewSeriesBlockEncoder returns a new instance of SeriesBlockEncoder.
-func NewSeriesBlockEncoder(w io.Writer, n uint64) *SeriesBlockEncoder {
-	m, k := bloom.Estimate(n, BloomFalsePositiveRate)
-
+func NewSeriesBlockEncoder(w io.Writer, n uint64, m, k uint64) *SeriesBlockEncoder {
 	return &SeriesBlockEncoder{
 		w: w,
 

--- a/tsdb/index/tsi1/series_block_test.go
+++ b/tsdb/index/tsi1/series_block_test.go
@@ -56,7 +56,7 @@ func CreateSeriesBlock(a []Series) (*tsi1.SeriesBlock, error) {
 	var buf bytes.Buffer
 
 	// Create writer and sketches. Add series.
-	enc := tsi1.NewSeriesBlockEncoder(&buf, uint64(len(a)), M, K)
+	enc := tsi1.NewSeriesBlockEncoder(&buf, uint32(len(a)), M, K)
 	for i, s := range a {
 		if err := enc.Encode(s.Name, s.Tags, s.Deleted); err != nil {
 			return nil, fmt.Errorf("SeriesBlockWriter.Add(): i=%d, err=%s", i, err)

--- a/tsdb/index/tsi1/series_block_test.go
+++ b/tsdb/index/tsi1/series_block_test.go
@@ -56,7 +56,7 @@ func CreateSeriesBlock(a []Series) (*tsi1.SeriesBlock, error) {
 	var buf bytes.Buffer
 
 	// Create writer and sketches. Add series.
-	enc := tsi1.NewSeriesBlockEncoder(&buf)
+	enc := tsi1.NewSeriesBlockEncoder(&buf, uint64(len(a)))
 	for i, s := range a {
 		if err := enc.Encode(s.Name, s.Tags, s.Deleted); err != nil {
 			return nil, fmt.Errorf("SeriesBlockWriter.Add(): i=%d, err=%s", i, err)

--- a/tsdb/index/tsi1/series_block_test.go
+++ b/tsdb/index/tsi1/series_block_test.go
@@ -56,7 +56,7 @@ func CreateSeriesBlock(a []Series) (*tsi1.SeriesBlock, error) {
 	var buf bytes.Buffer
 
 	// Create writer and sketches. Add series.
-	enc := tsi1.NewSeriesBlockEncoder(&buf, uint64(len(a)))
+	enc := tsi1.NewSeriesBlockEncoder(&buf, uint64(len(a)), M, K)
 	for i, s := range a {
 		if err := enc.Encode(s.Name, s.Tags, s.Deleted); err != nil {
 			return nil, fmt.Errorf("SeriesBlockWriter.Add(): i=%d, err=%s", i, err)

--- a/tsdb/index/tsi1/tag_block_test.go
+++ b/tsdb/index/tsi1/tag_block_test.go
@@ -17,19 +17,19 @@ func TestTagBlockWriter(t *testing.T) {
 
 	if err := enc.EncodeKey([]byte("host"), false); err != nil {
 		t.Fatal(err)
-	} else if err := enc.EncodeValue([]byte("server0"), false, []uint64{1}); err != nil {
+	} else if err := enc.EncodeValue([]byte("server0"), false, []uint32{1}); err != nil {
 		t.Fatal(err)
-	} else if err := enc.EncodeValue([]byte("server1"), false, []uint64{2}); err != nil {
+	} else if err := enc.EncodeValue([]byte("server1"), false, []uint32{2}); err != nil {
 		t.Fatal(err)
-	} else if err := enc.EncodeValue([]byte("server2"), false, []uint64{3}); err != nil {
+	} else if err := enc.EncodeValue([]byte("server2"), false, []uint32{3}); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := enc.EncodeKey([]byte("region"), false); err != nil {
 		t.Fatal(err)
-	} else if err := enc.EncodeValue([]byte("us-east"), false, []uint64{1, 2}); err != nil {
+	} else if err := enc.EncodeValue([]byte("us-east"), false, []uint32{1, 2}); err != nil {
 		t.Fatal(err)
-	} else if err := enc.EncodeValue([]byte("us-west"), false, []uint64{3}); err != nil {
+	} else if err := enc.EncodeValue([]byte("us-west"), false, []uint32{3}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -49,28 +49,28 @@ func TestTagBlockWriter(t *testing.T) {
 	// Verify data.
 	if e := blk.TagValueElem([]byte("region"), []byte("us-east")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{1, 2}) {
+	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint32{1, 2}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 
 	if e := blk.TagValueElem([]byte("region"), []byte("us-west")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{3}) {
+	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint32{3}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 	if e := blk.TagValueElem([]byte("host"), []byte("server0")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{1}) {
+	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint32{1}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 	if e := blk.TagValueElem([]byte("host"), []byte("server1")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{2}) {
+	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint32{2}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 	if e := blk.TagValueElem([]byte("host"), []byte("server2")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{3}) {
+	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint32{3}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 }
@@ -105,7 +105,7 @@ func benchmarkTagBlock_SeriesN(b *testing.B, tagN, valueN int, blk **tsi1.TagBlo
 			}
 
 			for j := 0; j < valueN; j++ {
-				if err := enc.EncodeValue([]byte(fmt.Sprintf("%08d", j)), false, []uint64{1}); err != nil {
+				if err := enc.EncodeValue([]byte(fmt.Sprintf("%08d", j)), false, []uint32{1}); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/tsdb/index/tsi1/tsi1.go
+++ b/tsdb/index/tsi1/tsi1.go
@@ -720,7 +720,7 @@ func (itr *seriesExprIterator) Next() SeriesElem {
 
 // seriesIDIterator represents a iterator over a list of series ids.
 type seriesIDIterator interface {
-	next() uint64
+	next() uint32
 }
 
 // writeTo writes write v into w. Updates n.
@@ -772,6 +772,12 @@ func writeUvarintTo(w io.Writer, v uint64, n *int64) error {
 	*n += int64(nn)
 	return err
 }
+
+type uint32Slice []uint32
+
+func (a uint32Slice) Len() int           { return len(a) }
+func (a uint32Slice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a uint32Slice) Less(i, j int) bool { return a[i] < a[j] }
 
 type uint64Slice []uint64
 


### PR DESCRIPTION
## Overview

This changes the `TagBlock` & `MeasurementBlock` to store series ID lists as delta-encoded uvarints. This reduces the storage size significantly. Previously my tests were showing a 461b per series (for a 130M series dataset). Now tests are showing 225b per series (for a 430M series dataset).

The total size can still be reduced further but this is a good start.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
