### PR TITLE
Write throughput/concurrency improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#8194](https://github.com/influxdata/influxdb/pull/8194): Add "integral" function to InfluxQL.
 - [#7393](https://github.com/influxdata/influxdb/issues/7393): Add "non_negative_difference" function to InfluxQL.
 - [#8042](https://github.com/influxdata/influxdb/issues/8042): Add bitwise AND, OR and XOR operators to the query language.
+- [#8302](https://github.com/influxdata/influxdb/pull/8302): Write throughput/concurrency improvements
 
 ### Bugfixes
 

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -98,13 +98,15 @@ func NewPointsWriter() *PointsWriter {
 
 // ShardMapping contains a mapping of shards to points.
 type ShardMapping struct {
+	n      int
 	Points map[uint64][]models.Point  // The points associated with a shard ID
 	Shards map[uint64]*meta.ShardInfo // The shards that have been mapped, keyed by shard ID
 }
 
 // NewShardMapping creates an empty ShardMapping.
-func NewShardMapping() *ShardMapping {
+func NewShardMapping(n int) *ShardMapping {
 	return &ShardMapping{
+		n:      n,
 		Points: map[uint64][]models.Point{},
 		Shards: map[uint64]*meta.ShardInfo{},
 	}
@@ -112,6 +114,9 @@ func NewShardMapping() *ShardMapping {
 
 // MapPoint adds the point to the ShardMapping, associated with the given shardInfo.
 func (s *ShardMapping) MapPoint(shardInfo *meta.ShardInfo, p models.Point) {
+	if cap(s.Points[shardInfo.ID]) < s.n {
+		s.Points[shardInfo.ID] = make([]models.Point, 0, s.n)
+	}
 	s.Points[shardInfo.ID] = append(s.Points[shardInfo.ID], p)
 	s.Shards[shardInfo.ID] = shardInfo
 }
@@ -218,7 +223,7 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 		list = list.Append(*sg)
 	}
 
-	mapping := NewShardMapping()
+	mapping := NewShardMapping(len(wp.Points))
 	for _, p := range wp.Points {
 		sg := list.ShardGroupAt(p.Time())
 		if sg == nil {

--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -286,7 +286,7 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 
 		// copy to prevent data race
 		theTest := test
-		sm := coordinator.NewShardMapping()
+		sm := coordinator.NewShardMapping(16)
 		sm.MapPoint(
 			&meta.ShardInfo{ID: uint64(1), Owners: []meta.ShardOwner{
 				{NodeID: 1},

--- a/tsdb/engine/tsm1/pools.go
+++ b/tsdb/engine/tsm1/pools.go
@@ -1,15 +1,26 @@
 package tsm1
 
-import "github.com/influxdata/influxdb/pkg/pool"
+import "sync"
 
-var bufPool = pool.NewBytes(10)
+var bufPool sync.Pool
 
 // getBuf returns a buffer with length size from the buffer pool.
-func getBuf(size int) []byte {
-	return bufPool.Get(size)
+func getBuf(size int) *[]byte {
+	x := bufPool.Get()
+	if x == nil {
+		b := make([]byte, size)
+		return &b
+	}
+	buf := x.(*[]byte)
+	if cap(*buf) < size {
+		b := make([]byte, size)
+		return &b
+	}
+	*buf = (*buf)[:size]
+	return buf
 }
 
 // putBuf returns a buffer to the pool.
-func putBuf(buf []byte) {
+func putBuf(buf *[]byte) {
 	bufPool.Put(buf)
 }

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -382,16 +382,16 @@ func (l *WAL) writeToLog(entry WALEntry) (int, error) {
 	//defer l.limiter.Release()
 
 	// encode and compress the entry while we're not locked
-	bytes := getBuf(walEncodeBufSize)
-	defer putBuf(bytes)
+	bytes := *(getBuf(walEncodeBufSize))
+	defer putBuf(&bytes)
 
 	b, err := entry.Encode(bytes)
 	if err != nil {
 		return -1, err
 	}
 
-	encBuf := getBuf(snappy.MaxEncodedLen(len(b)))
-	defer putBuf(encBuf)
+	encBuf := *(getBuf(snappy.MaxEncodedLen(len(b))))
+	defer putBuf(&encBuf)
 	compressed := snappy.Encode(encBuf, b)
 	syncErr := make(chan error)
 
@@ -1031,8 +1031,8 @@ func NewWALSegmentReader(r io.ReadCloser) *WALSegmentReader {
 
 // Next indicates if there is a value to read.
 func (r *WALSegmentReader) Next() bool {
-	b := getBuf(defaultBufLen)
-	defer putBuf(b)
+	b := *(getBuf(defaultBufLen))
+	defer putBuf(&b)
 	var nReadOK int
 
 	// read the type and the length of the entry
@@ -1069,8 +1069,8 @@ func (r *WALSegmentReader) Next() bool {
 		r.err = err
 		return true
 	}
-	decBuf := getBuf(decLen)
-	defer putBuf(decBuf)
+	decBuf := *(getBuf(decLen))
+	defer putBuf(&decBuf)
 
 	data, err := snappy.Decode(decBuf, b[:length])
 	if err != nil {

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -233,10 +233,10 @@ func (l *WAL) Open() error {
 	return nil
 }
 
-// sync will schedule an fsync to the current wal segment and notify any
+// scheduleSync will schedule an fsync to the current wal segment and notify any
 // waiting gorutines.  If an fsync is already scheduled, subsequent calls will
 // not schedule a new fsync and will be handle by the existing scheduled fsync.
-func (l *WAL) sync() {
+func (l *WAL) scheduleSync() {
 	// If we're not the first to sync, then another goroutine is fsyncing the wal for us.
 	if !atomic.CompareAndSwapUint64(&l.syncCount, 0, 1) {
 		return
@@ -244,24 +244,48 @@ func (l *WAL) sync() {
 
 	// Fsync the wal and notify all pending waiters
 	go func() {
-		t := time.NewTimer(l.syncDelay)
-		select {
-		case <-t.C:
-			if len(l.syncWaiters) > 0 {
-				l.mu.Lock()
-				err := l.currentSegmentWriter.sync()
-				for len(l.syncWaiters) > 0 {
-					errC := <-l.syncWaiters
-					errC <- err
-				}
-				l.mu.Unlock()
-			}
-		case <-l.closing:
-			t.Stop()
-		}
+		defer atomic.StoreUint64(&l.syncCount, 0)
+		var timerCh <-chan time.Time
 
-		atomic.StoreUint64(&l.syncCount, 0)
+		// time.NewTicker requires a > 0 delay, since 0 indicates no delay, use a closed
+		// channel which will always be ready to read from.
+		if l.syncDelay == 0 {
+			// Create a RW chan and close it
+			timerChrw := make(chan time.Time)
+			close(timerChrw)
+			// Convert it to a read-only
+			timerCh = timerChrw
+		} else {
+			t := time.NewTicker(l.syncDelay)
+			defer t.Stop()
+			timerCh = t.C
+		}
+		for {
+			select {
+			case <-timerCh:
+				l.mu.Lock()
+				if len(l.syncWaiters) == 0 {
+					l.mu.Unlock()
+					return
+				}
+
+				l.sync()
+				l.mu.Unlock()
+			case <-l.closing:
+				return
+			}
+		}
 	}()
+}
+
+// sync fsyncs the current wal segments and notifies any waiters.  Callers must ensure
+// a write lock on the WAL is obtained before calling sync.
+func (l *WAL) sync() {
+	err := l.currentSegmentWriter.sync()
+	for len(l.syncWaiters) > 0 {
+		errC := <-l.syncWaiters
+		errC <- err
+	}
 }
 
 // WritePoints writes the given points to the WAL. It returns the WAL segment ID to
@@ -354,8 +378,8 @@ func (l *WAL) writeToLog(entry WALEntry) (int, error) {
 	// limit how many concurrent encodings can be in flight.  Since we can only
 	// write one at a time to disk, a slow disk can cause the allocations below
 	// to increase quickly.  If we're backed up, wait until others have completed.
-	l.limiter.Take()
-	defer l.limiter.Release()
+	//l.limiter.Take()
+	//defer l.limiter.Release()
 
 	// encode and compress the entry while we're not locked
 	bytes := getBuf(walEncodeBufSize)
@@ -369,7 +393,6 @@ func (l *WAL) writeToLog(entry WALEntry) (int, error) {
 	encBuf := getBuf(snappy.MaxEncodedLen(len(b)))
 	defer putBuf(encBuf)
 	compressed := snappy.Encode(encBuf, b)
-
 	syncErr := make(chan error)
 
 	segID, err := func() (int, error) {
@@ -393,16 +416,17 @@ func (l *WAL) writeToLog(entry WALEntry) (int, error) {
 			return -1, fmt.Errorf("error writing WAL entry: %v", err)
 		}
 
-		// Update stats for current segment size
-		atomic.StoreInt64(&l.stats.CurrentBytes, int64(l.currentSegmentWriter.size))
-
-		l.lastWriteTime = time.Now()
-
 		select {
 		case l.syncWaiters <- syncErr:
 		default:
 			return -1, fmt.Errorf("error syncing wal")
 		}
+		l.scheduleSync()
+
+		// Update stats for current segment size
+		atomic.StoreInt64(&l.stats.CurrentBytes, int64(l.currentSegmentWriter.size))
+
+		l.lastWriteTime = time.Now()
 
 		return l.currentSegmentID, nil
 
@@ -412,7 +436,6 @@ func (l *WAL) writeToLog(entry WALEntry) (int, error) {
 	}
 
 	// schedule an fsync and wait for it to complete
-	l.sync()
 	return segID, <-syncErr
 }
 
@@ -492,6 +515,7 @@ func (l *WAL) Close() error {
 		close(l.closing)
 
 		if l.currentSegmentWriter != nil {
+			l.sync()
 			l.currentSegmentWriter.close()
 			l.currentSegmentWriter = nil
 		}
@@ -514,6 +538,8 @@ func segmentFileNames(dir string) ([]string, error) {
 func (l *WAL) newSegmentFile() error {
 	l.currentSegmentID++
 	if l.currentSegmentWriter != nil {
+		l.sync()
+
 		if err := l.currentSegmentWriter.close(); err != nil {
 			return err
 		}

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -434,7 +434,7 @@ func NewTSMWriter(w io.Writer) (TSMWriter, error) {
 		blocks: map[string]*indexEntries{},
 	}
 
-	return &tsmWriter{wrapped: w, w: bufio.NewWriterSize(w, 4*1024*1024), index: index}, nil
+	return &tsmWriter{wrapped: w, w: bufio.NewWriterSize(w, 1024*1024), index: index}, nil
 }
 
 func (t *tsmWriter) writeHeader() error {

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -136,12 +136,12 @@ func (i *Index) CreateSeriesIfNotExists(shardID uint64, key, name []byte, tags m
 	i.mu.RLock()
 	// if there is a series for this id, it's already been added
 	ss := i.series[string(key)]
+	i.mu.RUnlock()
+
 	if ss != nil {
 		ss.AssignShard(shardID)
-		i.mu.RUnlock()
 		return nil
 	}
-	i.mu.RUnlock()
 
 	// get or create the measurement index
 	m := i.CreateMeasurementIndexIfNotExists(string(name))
@@ -150,8 +150,8 @@ func (i *Index) CreateSeriesIfNotExists(shardID uint64, key, name []byte, tags m
 	// Check for the series again under a write lock
 	ss = i.series[string(key)]
 	if ss != nil {
-		ss.AssignShard(shardID)
 		i.mu.Unlock()
+		ss.AssignShard(shardID)
 		return nil
 	}
 
@@ -228,9 +228,9 @@ func (i *Index) HasTagKey(name, key []byte) (bool, error) {
 // HasTagValue returns true if tag value exists.
 func (i *Index) HasTagValue(name, key, value []byte) bool {
 	i.mu.RLock()
-	defer i.mu.RUnlock()
-
 	mm := i.measurements[string(name)]
+	i.mu.RUnlock()
+
 	if mm == nil {
 		return false
 	}

--- a/tsdb/index/internal/file_set.go
+++ b/tsdb/index/internal/file_set.go
@@ -10,6 +10,7 @@ import (
 type File struct {
 	Closef                     func() error
 	Pathf                      func() string
+	FilterNameTagsf            func(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags)
 	Measurementf               func(name []byte) tsi1.MeasurementElem
 	MeasurementIteratorf       func() tsi1.MeasurementIterator
 	HasSeriesf                 func(name []byte, tags models.Tags, buf []byte) (exists, tombstoned bool)
@@ -29,8 +30,11 @@ type File struct {
 	Releasef                   func()
 }
 
-func (f *File) Close() error                                  { return f.Closef() }
-func (f *File) Path() string                                  { return f.Pathf() }
+func (f *File) Close() error { return f.Closef() }
+func (f *File) Path() string { return f.Pathf() }
+func (f *File) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
+	return f.FilterNameTagsf(names, tagsSlice)
+}
 func (f *File) Measurement(name []byte) tsi1.MeasurementElem  { return f.Measurementf(name) }
 func (f *File) MeasurementIterator() tsi1.MeasurementIterator { return f.MeasurementIteratorf() }
 func (f *File) HasSeries(name []byte, tags models.Tags, buf []byte) (exists, tombstoned bool) {

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -549,15 +549,10 @@ func (fs FileSet) HasSeries(name []byte, tags models.Tags, buf []byte) bool {
 // FilterNamesTags filters out any series which already exist. It modifies the
 // provided slices of names and tags.
 func (fs FileSet) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
-	buf := make([]byte, 1024)
-	newNames, newTagsSlice := names[:0], tagsSlice[:0]
-	for i := 0; i < len(names); i++ {
-		if !fs.HasSeries(names[i], tagsSlice[i], buf) {
-			newNames = append(newNames, names[i])
-			newTagsSlice = append(newTagsSlice, tagsSlice[i])
-		}
+	for _, f := range fs {
+		names, tagsSlice = f.FilterNamesTags(names, tagsSlice)
 	}
-	return newNames, newTagsSlice
+	return names, tagsSlice
 }
 
 // SeriesSketches returns the merged series sketches for the FileSet.
@@ -775,6 +770,7 @@ type File interface {
 	Close() error
 	Path() string
 
+	FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags)
 	Measurement(name []byte) MeasurementElem
 	MeasurementIterator() MeasurementIterator
 	HasSeries(name []byte, tags models.Tags, buf []byte) (exists, tombstoned bool)

--- a/tsdb/index/tsi1/file_set_test.go
+++ b/tsdb/index/tsi1/file_set_test.go
@@ -289,8 +289,19 @@ func TestFileSet_FilterNamesTags(t *testing.T) {
 
 	// Filter out first name/tags in arguments.
 	reset()
-	mf.HasSeriesf = func(name []byte, tags models.Tags, buf []byte) (bool, bool) {
-		return string(name) == "m1" && tags[0].String() == "{host server-1}", false
+	mf.FilterNameTagsf = func(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
+		newNames := names[:0]
+		newTags := tagsSlice[:0]
+		for i := range names {
+			name := names[i]
+			tags := tagsSlice[i]
+			if string(name) == "m1" && tags[0].String() == "{host server-1}" {
+				continue
+			}
+			newNames = append(newNames, names[i])
+			newTags = append(newTags, tagsSlice[i])
+		}
+		return newNames, newTags
 	}
 
 	gotNames, gotTags := fs.FilterNamesTags(names, tags)
@@ -303,8 +314,19 @@ func TestFileSet_FilterNamesTags(t *testing.T) {
 
 	// Filter out middle name/tags in arguments.
 	reset()
-	mf.HasSeriesf = func(name []byte, tags models.Tags, buf []byte) (bool, bool) {
-		return string(name) == "m3" && tags[0].String() == "{host server-3}", false
+	mf.FilterNameTagsf = func(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
+		newNames := names[:0]
+		newTags := tagsSlice[:0]
+		for i := range names {
+			name := names[i]
+			tags := tagsSlice[i]
+			if string(name) == "m3" && tags[0].String() == "{host server-3}" {
+				continue
+			}
+			newNames = append(newNames, names[i])
+			newTags = append(newTags, tagsSlice[i])
+		}
+		return newNames, newTags
 	}
 
 	gotNames, gotTags = fs.FilterNamesTags(names, tags)
@@ -317,10 +339,20 @@ func TestFileSet_FilterNamesTags(t *testing.T) {
 
 	// Filter out last name/tags in arguments.
 	reset()
-	mf.HasSeriesf = func(name []byte, tags models.Tags, buf []byte) (bool, bool) {
-		return string(name) == "m4" && tags[0].String() == "{host server-3}", false
+	mf.FilterNameTagsf = func(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
+		newNames := names[:0]
+		newTags := tagsSlice[:0]
+		for i := range names {
+			name := names[i]
+			tags := tagsSlice[i]
+			if string(name) == "m4" && tags[0].String() == "{host server-3}" {
+				continue
+			}
+			newNames = append(newNames, names[i])
+			newTags = append(newTags, tagsSlice[i])
+		}
+		return newNames, newTags
 	}
-
 	gotNames, gotTags = fs.FilterNamesTags(names, tags)
 	reset()
 	if got, exp := gotNames, names[:3]; !reflect.DeepEqual(got, exp) {

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -447,20 +447,15 @@ func (i *Index) CreateSeriesListIfNotExists(_, names [][]byte, tagsSlice []model
 	}
 
 	// Ensure fileset cannot change during insert.
-	i.mu.Lock()
-	defer i.mu.Unlock()
-
+	i.mu.RLock()
 	// Insert series into log file.
 	if err := i.activeLogFile.AddSeriesList(names, tagsSlice); err != nil {
+		i.mu.RUnlock()
 		return err
 	}
+	i.mu.RUnlock()
 
-	// Switch log file if necessary.
-	if err := i.checkLogFile(); err != nil {
-		return err
-	}
-
-	return nil
+	return i.CheckLogFile()
 }
 
 // InitializeSeries is a no-op. This only applies to the in-memory index.

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -349,6 +349,20 @@ func (f *IndexFile) MergeSeriesSketches(s, t estimator.Sketch) error {
 	return t.Merge(f.sblk.tsketch)
 }
 
+// FilterNamesTags filters out any series which already exist. It modifies the
+// provided slices of names and tags.
+func (f *IndexFile) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]byte, []models.Tags) {
+	buf := make([]byte, 1024)
+	newNames, newTagsSlice := names[:0], tagsSlice[:0]
+	for i := range names {
+		if exists, tombstoned := f.HasSeries(names[i], tagsSlice[i], buf); !exists || tombstoned {
+			newNames = append(newNames, names[i])
+			newTagsSlice = append(newTagsSlice, tagsSlice[i])
+		}
+	}
+	return newNames, newTagsSlice
+}
+
 // ReadIndexFileTrailer returns the index file trailer from data.
 func ReadIndexFileTrailer(data []byte) (IndexFileTrailer, error) {
 	var t IndexFileTrailer

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -1121,7 +1121,17 @@ func NewSeries(key []byte, tags models.Tags) *Series {
 }
 
 func (s *Series) AssignShard(shardID uint64) {
+	s.mu.RLock()
+	_, ok := s.shardIDs[shardID]
+	s.mu.RUnlock()
+
+	if ok {
+		return
+	}
+
 	s.mu.Lock()
+	// Skip the existence check under the write lock because we're just storing
+	// and empty struct.
 	s.shardIDs[shardID] = struct{}{}
 	s.mu.Unlock()
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This PR has a few performance improvements and bug fixes to the write path which improve overall write throughput when there are many concurrent writers.

The graphs below show the write latency and throughput changes from 1.2.3 to this PR (based off of 1.3) using batches of 5k and 10k and varying concurrent writers from 50-200 in each run.  Each of the humps is a write load of 500M values over 100k series with varying concurrency and batch sizes.  The top row is 5k batches.  Second row is 10k batches.  Left column is 1.2 and right column is this PR.  These were run a m4.16xlarge w/ 1000 IOPS SSDs using go1.8.1 and `inmem` and `tsi1` index.

For 5k batches, write throughput improved from 1.1M w/s to 2.3M w/s and latency decreased by ~50% and stayed below 500ms after the change.

For 10k batches, write throughput improved from 1.8M w/s to 2.3M w/s and latency decreased by ~30%.

The majority of the changes focus on reducing lock contention and allocations in the hot path.

The throughput was remarkably similar between `inmem` and `tsi`.  `tsi` on master hit write timeouts under higher concurrency immediately when the run started.  With this PR those, timesout were fixed as well.

### inmem

![perf](https://cloud.githubusercontent.com/assets/219935/25160540/d8ba8dae-2473-11e7-85d2-4aeb6227173d.png)

### tsi

![tsi](https://cloud.githubusercontent.com/assets/219935/25207353/2dc14dee-252b-11e7-859c-a3c5c89243c4.png)