### PR TITLE
Optimize WAL segment reading

### DIFF
--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -743,31 +743,28 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 
 		switch typ {
 		case float64EntryType:
+			if i+16*nvals > len(b) {
+				return ErrWALCorrupt
+			}
+
 			values := make([]Value, 0, nvals)
 			for j := 0; j < nvals; j++ {
-				if i+16 > len(b) {
-					return ErrWALCorrupt
-				}
-
 				un := int64(binary.BigEndian.Uint64(b[i : i+8]))
 				i += 8
-
 				v := math.Float64frombits((binary.BigEndian.Uint64(b[i : i+8])))
 				i += 8
-
 				values = append(values, NewFloatValue(un, v))
 			}
 			w.Values[k] = values
 		case integerEntryType:
+			if i+16*nvals > len(b) {
+				return ErrWALCorrupt
+			}
+
 			values := make([]Value, 0, nvals)
 			for j := 0; j < nvals; j++ {
-				if i+16 > len(b) {
-					return ErrWALCorrupt
-				}
-
 				un := int64(binary.BigEndian.Uint64(b[i : i+8]))
 				i += 8
-
 				v := int64(binary.BigEndian.Uint64(b[i : i+8]))
 				i += 8
 				values = append(values, NewIntegerValue(un, v))
@@ -775,12 +772,12 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 			w.Values[k] = values
 
 		case booleanEntryType:
+			if i+9*nvals > len(b) {
+				return ErrWALCorrupt
+			}
+
 			values := make([]Value, 0, nvals)
 			for j := 0; j < nvals; j++ {
-				if i+9 > len(b) {
-					return ErrWALCorrupt
-				}
-
 				un := int64(binary.BigEndian.Uint64(b[i : i+8]))
 				i += 8
 
@@ -805,7 +802,7 @@ func (w *WriteWALEntry) UnmarshalBinary(b []byte) error {
 				i += 8
 
 				length := int(binary.BigEndian.Uint32(b[i : i+4]))
-				if i+length > int(uint32(len(b))) {
+				if i+length > len(b) {
 					return ErrWALCorrupt
 				}
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -1,6 +1,7 @@
 package tsm1
 
 import (
+	"bufio"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -973,7 +974,8 @@ func (w *WALSegmentWriter) close() error {
 
 // WALSegmentReader reads WAL segments.
 type WALSegmentReader struct {
-	r     io.ReadCloser
+	rc    io.ReadCloser
+	r     io.Reader
 	entry WALEntry
 	n     int64
 	err   error
@@ -982,7 +984,8 @@ type WALSegmentReader struct {
 // NewWALSegmentReader returns a new WALSegmentReader reading from r.
 func NewWALSegmentReader(r io.ReadCloser) *WALSegmentReader {
 	return &WALSegmentReader{
-		r: r,
+		rc: r,
+		r:  bufio.NewReaderSize(r, 1024*1024),
 	}
 }
 
@@ -1080,7 +1083,7 @@ func (r *WALSegmentReader) Error() error {
 
 // Close closes the underlying io.Reader.
 func (r *WALSegmentReader) Close() error {
-	return r.r.Close()
+	return r.rc.Close()
 }
 
 // idFromFileName parses the segment file ID from its name.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Reading WAL segments generates a lot of garbage and was doing some things inefficiently.  This change improves reading segments a bit.  

These changes help a little, but most of the garbage (and time) is still dominated by `tsm1.Value` interface and conversion when re-creating the type specific values to be added back to the `tsm1.Cache`.  Fixing that is a bit more complicated.

```
benchmark                       old ns/op     new ns/op     delta
BenchmarkWALSegmentReader-8     40012977      23665143      -40.86%

benchmark                       old allocs     new allocs     delta
BenchmarkWALSegmentReader-8     1000500        500601         -49.96%

benchmark                       old bytes     new bytes     delta
BenchmarkWALSegmentReader-8     24236300      16236804      -33.01%
```