### PR TITLE
Prevent default policy panic.

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -270,14 +270,14 @@ func (e *StatementExecutor) executeCreateRetentionPolicyStatement(stmt *influxql
 	}
 
 	// Create new retention policy.
-	rp, err := e.MetaClient.CreateRetentionPolicy(stmt.Database, &spec)
+	_, err := e.MetaClient.CreateRetentionPolicy(stmt.Database, &spec)
 	if err != nil {
 		return err
 	}
 
 	// If requested, set new policy as the default.
 	if stmt.Default {
-		if err := e.MetaClient.SetDefaultRetentionPolicy(stmt.Database, rp.Name); err != nil {
+		if err := e.MetaClient.SetDefaultRetentionPolicy(stmt.Database, stmt.Name); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes panic that can occur while creating a retention policy where
the Client.CreateRetentionPolicy() can return a nil RP & error.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
