### PR TITLE
Remove default upper time bound for DELETE queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8067](https://github.com/influxdata/influxdb/issues/8067): Restrict fill(none) and fill(linear) to be usable only with aggregate queries.
 - [#8065](https://github.com/influxdata/influxdb/issues/8065): Restrict top() and bottom() selectors to be used with no other functions.
 - [#8266](https://github.com/influxdata/influxdb/issues/8266): top() and bottom() now returns the time for every point.
+- [#8315](https://github.com/influxdata/influxdb/issues/8315): Remove default upper time bound on DELETE queries.
 
 ## v1.2.3 [unreleased]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -4101,7 +4101,7 @@ func TimeRange(expr Expr) (min, max time.Time, err error) {
 
 // TimeRangeAsEpochNano returns the minimum and maximum times, as epoch nano, specified by
 // an expression. If there is no lower bound, the minimum time is returned
-// for minimum. If there is no higher bound, now is returned for maximum.
+// for minimum. If there is no higher bound, the maximum time is returned.
 func TimeRangeAsEpochNano(expr Expr) (min, max int64, err error) {
 	tmin, tmax, err := TimeRange(expr)
 	if err != nil {
@@ -4114,7 +4114,7 @@ func TimeRangeAsEpochNano(expr Expr) (min, max int64, err error) {
 		min = tmin.UnixNano()
 	}
 	if tmax.IsZero() {
-		max = time.Now().UnixNano()
+		max = time.Unix(0, MaxTime).UnixNano()
 	} else {
 		max = tmax.UnixNano()
 	}


### PR DESCRIPTION
## Overview

Removes the default upper time bound for `DELETE` queries. Previously it was set to `now()` if the bound was not specified in the `WHERE` clause. Now it is set to the maximum time allowed by InfluxDB.
 
Fixes #8315, #7798.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
