### PR TITLE
Compaction limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8302](https://github.com/influxdata/influxdb/pull/8302): Write throughput/concurrency improvements
 - [#8273](https://github.com/influxdata/influxdb/issues/8273): Remove the admin UI.
 - [#8327](https://github.com/influxdata/influxdb/pull/8327): Update to go1.8.1
+- [#8348](https://github.com/influxdata/influxdb/pull/8348): Add max concurrent compaction limits
 
 ### Bugfixes
 
@@ -54,6 +55,8 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8315](https://github.com/influxdata/influxdb/issues/8315): Remove default upper time bound on DELETE queries.
 - [#8066](https://github.com/influxdata/influxdb/issues/8066): Fix LIMIT and OFFSET for certain aggregate queries.
 - [#8045](https://github.com/influxdata/influxdb/issues/8045): Refactor the subquery code and fix outer condition queries.
+- [#7425](https://github.com/influxdata/influxdb/issues/7425): Fix compaction aborted log messages
+- [#8123](https://github.com/influxdata/influxdb/issues/8123): TSM compaction does not remove .tmp on error
 
 ## v1.2.3 [unreleased]
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -89,6 +89,11 @@
   # write or delete
   # compact-full-write-cold-duration = "4h"
 
+  # The maximum number of concurrent full and level compactions that can run at one time.  A
+  # value of 0 results in runtime.GOMAXPROCS(0) used at runtime.  This setting does not apply
+  # to cache snapshotting.
+  # max-concurrent-compactions = 0
+
   # The maximum series allowed per database before writes are dropped.  This limit can prevent
   # high cardinality issues at the database level.  This limit can be disabled by setting it to
   # 0.

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -74,6 +74,7 @@ type Engine interface {
 	// Statistics will return statistics relevant to this engine.
 	Statistics(tags map[string]string) []models.Statistic
 	LastModified() time.Time
+	DiskSize() int64
 	IsIdle() bool
 
 	io.WriterTo

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -31,6 +31,8 @@ type Engine interface {
 	Open() error
 	Close() error
 	SetEnabled(enabled bool)
+	SetCompactionsEnabled(enabled bool)
+
 	WithLogger(zap.Logger)
 
 	LoadMetadataIndex(shardID uint64, index Index) error
@@ -72,6 +74,7 @@ type Engine interface {
 	// Statistics will return statistics relevant to this engine.
 	Statistics(tags map[string]string) []models.Statistic
 	LastModified() time.Time
+	IsIdle() bool
 
 	io.WriterTo
 }

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/estimator"
+	"github.com/influxdata/influxdb/pkg/limiter"
 	"github.com/uber-go/zap"
 )
 
@@ -136,10 +137,11 @@ func NewEngine(id uint64, i Index, path string, walPath string, options EngineOp
 
 // EngineOptions represents the options used to initialize the engine.
 type EngineOptions struct {
-	EngineVersion string
-	IndexVersion  string
-	ShardID       uint64
-	InmemIndex    interface{} // shared in-memory index
+	EngineVersion     string
+	IndexVersion      string
+	ShardID           uint64
+	InmemIndex        interface{} // shared in-memory index
+	CompactionLimiter limiter.Fixed
 
 	Config Config
 }

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -260,7 +260,7 @@ func (c *Cache) Write(key string, values []Value) error {
 
 	// Enough room in the cache?
 	limit := c.maxSize
-	n := c.Size() + atomic.LoadUint64(&c.snapshotSize) + addedSize
+	n := c.Size() + addedSize
 
 	if limit > 0 && n > limit {
 		atomic.AddInt64(&c.stats.WriteErr, 1)
@@ -293,7 +293,7 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 
 	// Enough room in the cache?
 	limit := c.maxSize // maxSize is safe for reading without a lock.
-	n := c.Size() + atomic.LoadUint64(&c.snapshotSize) + addedSize
+	n := c.Size() + addedSize
 	if limit > 0 && n > limit {
 		atomic.AddInt64(&c.stats.WriteErr, 1)
 		return ErrCacheMemorySizeLimitExceeded(n, limit)
@@ -416,7 +416,7 @@ func (c *Cache) ClearSnapshot(success bool) {
 
 // Size returns the number of point-calcuated bytes the cache currently uses.
 func (c *Cache) Size() uint64 {
-	return atomic.LoadUint64(&c.size)
+	return atomic.LoadUint64(&c.size) + atomic.LoadUint64(&c.snapshotSize)
 }
 
 // increaseSize increases size by delta.

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -448,7 +448,7 @@ func TestCache_Snapshot_Stats(t *testing.T) {
 	}
 
 	// Store size should have been reset.
-	if got, exp := c.Size(), uint64(0); got != exp {
+	if got, exp := c.Size(), uint64(16); got != exp {
 		t.Fatalf("got %v, expected %v", got, exp)
 	}
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -54,6 +54,7 @@ type CompactionPlanner interface {
 	PlanLevel(level int) []CompactionGroup
 	PlanOptimize() []CompactionGroup
 	Release(group []CompactionGroup)
+	FullyCompacted() bool
 }
 
 // DefaultPlanner implements CompactionPlanner using a strategy to roll up
@@ -142,6 +143,12 @@ func (t *tsmGeneration) hasTombstones() bool {
 		}
 	}
 	return false
+}
+
+// FullyCompacted returns true if the shard is fully compacted.
+func (c *DefaultPlanner) FullyCompacted() bool {
+	gens := c.findGenerations()
+	return len(gens) <= 1 && !gens.hasTombstones()
 }
 
 // PlanLevel returns a set of TSM files to rewrite for a specific level.

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 )
 
@@ -1090,8 +1091,8 @@ func TestCacheKeyIterator_Chunked(t *testing.T) {
 }
 
 func TestDefaultPlanner_Plan_Min(t *testing.T) {
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return []tsm1.FileStat{
 					tsm1.FileStat{
@@ -1108,8 +1109,8 @@ func TestDefaultPlanner_Plan_Min(t *testing.T) {
 					},
 				}
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	tsm := cp.Plan(time.Now())
 	if exp, got := 0, len(tsm); got != exp {
@@ -1151,13 +1152,13 @@ func TestDefaultPlanner_Plan_CombineSequence(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
 	tsm := cp.Plan(time.Now())
@@ -1213,13 +1214,11 @@ func TestDefaultPlanner_Plan_MultipleGroups(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
-			PathsFn: func() []tsm1.FileStat {
-				return data
-			},
+	cp := tsm1.NewDefaultPlanner(&fakeFileStore{
+		PathsFn: func() []tsm1.FileStat {
+			return data
 		},
-	}
+	}, tsdb.DefaultCompactFullWriteColdDuration)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3],
 		data[4], data[5], data[6], data[7]}
@@ -1280,13 +1279,13 @@ func TestDefaultPlanner_PlanLevel_SmallestCompactionStep(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{data[4], data[5]}
 	tsm := cp.PlanLevel(1)
@@ -1333,13 +1332,13 @@ func TestDefaultPlanner_PlanLevel_SplitFile(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3], data[4]}
 	tsm := cp.PlanLevel(3)
@@ -1382,13 +1381,13 @@ func TestDefaultPlanner_PlanLevel_IsolatedLowLevel(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{data[2], data[3]}
 	tsm := cp.PlanLevel(1)
@@ -1435,13 +1434,13 @@ func TestDefaultPlanner_PlanLevel_IsolatedHighLevel(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{}
 	tsm := cp.PlanLevel(3)
@@ -1478,13 +1477,13 @@ func TestDefaultPlanner_PlanLevel3_MinFiles(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{}
 	tsm := cp.PlanLevel(3)
@@ -1510,13 +1509,13 @@ func TestDefaultPlanner_PlanLevel2_MinFiles(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{}
 	tsm := cp.PlanLevel(2)
@@ -1554,13 +1553,13 @@ func TestDefaultPlanner_PlanLevel_Tombstone(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1]}
 	tsm := cp.PlanLevel(3)
@@ -1603,13 +1602,13 @@ func TestDefaultPlanner_PlanLevel_Multiple(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
 	expFiles2 := []tsm1.FileStat{data[4], data[5]}
@@ -1652,13 +1651,13 @@ func TestDefaultPlanner_PlanOptimize_NoLevel4(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{}
 	tsm := cp.PlanOptimize()
@@ -1695,13 +1694,13 @@ func TestDefaultPlanner_PlanOptimize_Level4(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
 	tsm := cp.PlanOptimize()
@@ -1760,13 +1759,13 @@ func TestDefaultPlanner_PlanOptimize_Multiple(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
 	expFiles2 := []tsm1.FileStat{data[5], data[6], data[7], data[8]}
@@ -1813,13 +1812,13 @@ func TestDefaultPlanner_PlanOptimize_Optimized(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{}
 	tsm := cp.PlanOptimize()
@@ -1845,13 +1844,13 @@ func TestDefaultPlanner_PlanOptimize_Tombstones(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2]}
 	tsm := cp.PlanOptimize()
@@ -1897,14 +1896,14 @@ func TestDefaultPlanner_Plan_FullOnCold(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
 		},
-		CompactFullWriteColdDuration: time.Nanosecond,
-	}
+		time.Nanosecond,
+	)
 
 	tsm := cp.Plan(time.Now().Add(-time.Second))
 	if exp, got := len(data), len(tsm[0]); got != exp {
@@ -1932,13 +1931,13 @@ func TestDefaultPlanner_Plan_SkipMaxSizeFiles(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	tsm := cp.Plan(time.Now())
 	if exp, got := 0, len(tsm); got != exp {
@@ -1975,15 +1974,13 @@ func TestDefaultPlanner_Plan_SkipPlanningAfterFull(t *testing.T) {
 		blockCount: 1000,
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore:                    fs,
-		CompactFullWriteColdDuration: time.Nanosecond,
-	}
-
+	cp := tsm1.NewDefaultPlanner(fs, time.Nanosecond)
+	plan := cp.Plan(time.Now().Add(-time.Second))
 	// first verify that our test set would return files
-	if exp, got := 4, len(cp.Plan(time.Now().Add(-time.Second))[0]); got != exp {
+	if exp, got := 4, len(plan[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	}
+	cp.Release(plan)
 
 	// skip planning if all files are over the limit
 	over := []tsm1.FileStat{
@@ -2017,14 +2014,18 @@ func TestDefaultPlanner_Plan_SkipPlanningAfterFull(t *testing.T) {
 	}
 
 	cp.FileStore = overFs
-	if exp, got := 0, len(cp.Plan(time.Now().Add(-time.Second))); got != exp {
+	plan = cp.Plan(time.Now().Add(-time.Second))
+	if exp, got := 0, len(plan); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	}
+	cp.Release(plan)
 
+	plan = cp.PlanOptimize()
 	// ensure the optimize planner would pick this up
-	if exp, got := 1, len(cp.PlanOptimize()); got != exp {
+	if exp, got := 1, len(plan); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	}
+	cp.Release(plan)
 
 	cp.FileStore = fs
 	// ensure that it will plan if last modified has changed
@@ -2082,15 +2083,14 @@ func TestDefaultPlanner_Plan_TwoGenLevel3(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			blockCount: 1000,
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
 		},
-		CompactFullWriteColdDuration: time.Hour,
-	}
+		time.Hour)
 
 	tsm := cp.Plan(time.Now().Add(-24 * time.Hour))
 	if exp, got := 1, len(tsm); got != exp {
@@ -2127,15 +2127,17 @@ func TestDefaultPlanner_Plan_NotFullOverMaxsize(t *testing.T) {
 		blockCount: 100,
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore:                    fs,
-		CompactFullWriteColdDuration: time.Nanosecond,
-	}
+	cp := tsm1.NewDefaultPlanner(
+		fs,
+		time.Nanosecond,
+	)
 
+	plan := cp.Plan(time.Now().Add(-time.Second))
 	// first verify that our test set would return files
-	if exp, got := 4, len(cp.Plan(time.Now().Add(-time.Second))[0]); got != exp {
+	if exp, got := 4, len(plan[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	}
+	cp.Release(plan)
 
 	// skip planning if all files are over the limit
 	over := []tsm1.FileStat{
@@ -2188,13 +2190,13 @@ func TestDefaultPlanner_Plan_CompactsMiddleSteps(t *testing.T) {
 		},
 	}
 
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return data
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
 	tsm := cp.Plan(time.Now())
@@ -2210,8 +2212,8 @@ func TestDefaultPlanner_Plan_CompactsMiddleSteps(t *testing.T) {
 }
 
 func TestDefaultPlanner_Plan_LargeSets(t *testing.T) {
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return []tsm1.FileStat{
 					tsm1.FileStat{
@@ -2236,8 +2238,8 @@ func TestDefaultPlanner_Plan_LargeSets(t *testing.T) {
 					},
 				}
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	tsm := cp.Plan(time.Now())
 	if exp, got := 0, len(tsm); got != exp {
@@ -2246,8 +2248,8 @@ func TestDefaultPlanner_Plan_LargeSets(t *testing.T) {
 }
 
 func TestDefaultPlanner_Plan_LargeGeneration(t *testing.T) {
-	cp := &tsm1.DefaultPlanner{
-		FileStore: &fakeFileStore{
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
 			PathsFn: func() []tsm1.FileStat {
 				return []tsm1.FileStat{
 					tsm1.FileStat{
@@ -2272,8 +2274,8 @@ func TestDefaultPlanner_Plan_LargeGeneration(t *testing.T) {
 					},
 				}
 			},
-		},
-	}
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
 
 	tsm := cp.Plan(time.Now())
 	if exp, got := 0, len(tsm); got != exp {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -430,6 +430,11 @@ func (e *Engine) Statistics(tags map[string]string) []models.Statistic {
 	return statistics
 }
 
+// DiskSize returns the total size in bytes of all TSM and WAL segments on disk.
+func (e *Engine) DiskSize() int64 {
+	return e.FileStore.DiskSizeBytes() + e.WAL.DiskSizeBytes()
+}
+
 // Open opens and initializes the engine.
 func (e *Engine) Open() error {
 	if err := os.MkdirAll(e.path, 0777); err != nil {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -245,6 +245,7 @@ func (e *Engine) disableLevelCompactions(wait bool) {
 		e.levelWorkers += 1
 	}
 
+	var cleanup bool
 	if old == 0 && e.done != nil {
 		// Prevent new compactions from starting
 		e.Compactor.DisableCompactions()
@@ -252,12 +253,13 @@ func (e *Engine) disableLevelCompactions(wait bool) {
 		// Stop all background compaction goroutines
 		close(e.done)
 		e.done = nil
+		cleanup = true
 	}
 
 	e.mu.Unlock()
 	e.wg.Wait()
 
-	if old == 0 { // first to disable should cleanup
+	if cleanup { // first to disable should cleanup
 		if err := e.cleanup(); err != nil {
 			e.logger.Info(fmt.Sprintf("error cleaning up temp file: %v", err))
 		}

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1059,6 +1059,7 @@ type mockPlanner struct{}
 func (m *mockPlanner) Plan(lastWrite time.Time) []tsm1.CompactionGroup { return nil }
 func (m *mockPlanner) PlanLevel(level int) []tsm1.CompactionGroup      { return nil }
 func (m *mockPlanner) PlanOptimize() []tsm1.CompactionGroup            { return nil }
+func (m *mockPlanner) Release(groups []tsm1.CompactionGroup)           {}
 
 // ParseTags returns an instance of Tags for a comma-delimited list of key/values.
 func ParseTags(s string) influxql.Tags {

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1060,6 +1060,7 @@ func (m *mockPlanner) Plan(lastWrite time.Time) []tsm1.CompactionGroup { return 
 func (m *mockPlanner) PlanLevel(level int) []tsm1.CompactionGroup      { return nil }
 func (m *mockPlanner) PlanOptimize() []tsm1.CompactionGroup            { return nil }
 func (m *mockPlanner) Release(groups []tsm1.CompactionGroup)           {}
+func (m *mockPlanner) FullyCompacted() bool                            { return false }
 
 // ParseTags returns an instance of Tags for a comma-delimited list of key/values.
 func ParseTags(s string) influxql.Tags {

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -465,6 +465,11 @@ func (t *TSMReader) Size() uint32 {
 func (t *TSMReader) LastModified() int64 {
 	t.mu.RLock()
 	lm := t.lastModified
+	for _, ts := range t.tombstoner.TombstoneFiles() {
+		if ts.LastModified > lm {
+			lm = ts.LastModified
+		}
+	}
 	t.mu.RUnlock()
 	return lm
 }

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -375,6 +375,10 @@ func (l *WAL) LastWriteTime() time.Time {
 	return l.lastWriteTime
 }
 
+func (l *WAL) DiskSizeBytes() int64 {
+	return atomic.LoadInt64(&l.stats.OldBytes) + atomic.LoadInt64(&l.stats.CurrentBytes)
+}
+
 func (l *WAL) writeToLog(entry WALEntry) (int, error) {
 	// limit how many concurrent encodings can be in flight.  Since we can only
 	// write one at a time to disk, a slow disk can cause the allocations below

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -287,12 +287,9 @@ func (m *Measurement) ForEachSeriesByExpr(condition influxql.Expr, fn func(tags 
 		return err
 	}
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	// Iterate over each series.
 	for _, id := range ids {
-		s := m.seriesByID[id]
+		s := m.SeriesByID(id)
 		if err := fn(s.Tags()); err != nil {
 			return err
 		}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -208,15 +208,7 @@ func (s *Shard) Statistics(tags map[string]string) []models.Statistic {
 
 	// Refresh our disk size stat
 	_, _ = s.DiskSize()
-
-	// TODO(edd): Should statSeriesCreate be the current number of series in the
-	// shard, or the total number of series ever created?
-	sSketch, tSketch, err := s.engine.SeriesSketches()
-	seriesN := int64(sSketch.Count() - tSketch.Count())
-	if err != nil {
-		s.logger.Error("cannot compute series sketch", zap.Error(err))
-		seriesN = 0
-	}
+	seriesN := s.engine.SeriesN()
 
 	tags = s.defaultTags.Merge(tags)
 	statistics := []models.Statistic{{

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -158,6 +158,13 @@ func (s *Store) loadShards() error {
 
 	t := limiter.NewFixed(runtime.GOMAXPROCS(0))
 
+	// Setup a shared limiter for compactions
+	lim := s.EngineOptions.Config.MaxConcurrentCompactions
+	if lim == 0 {
+		lim = runtime.GOMAXPROCS(0)
+	}
+	s.EngineOptions.CompactionLimiter = limiter.NewFixed(lim)
+
 	resC := make(chan *res)
 	var n int
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -224,6 +224,9 @@ func (s *Store) loadShards() error {
 
 					// Open engine.
 					shard := NewShard(shardID, path, walPath, opt)
+
+					// Disable compactions, writes and queries until all shards are loaded
+					shard.EnableOnOpen = false
 					shard.WithLogger(s.baseLogger)
 
 					err = shard.Open()
@@ -251,6 +254,12 @@ func (s *Store) loadShards() error {
 		s.databases[res.s.database] = struct{}{}
 	}
 	close(resC)
+
+	// Enable all shards
+	for _, sh := range s.shards {
+		sh.SetEnabled(true)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This change adds a new limit to control how many concurrent full/level compactions can run at one time.  It also stops background compaction goroutines for cold shards.

* `max-concurrent-compactions` can be set to limit the number of full and level compactions that run concurrently.  This limit does not apply to snapshot compactions as they must run to avoid filling the cache.  A value of `0`, default, sets the limit to `runtime.GOMAXPROCS(0)`.  Any value greater than 0 will limit compactions to that number.  Compactions that are scheduled to run when the limit is met, will block until one completes.  This limit can be used to throttle CPU usage due to many concurrent compactions.
* The startup process has changed to disable compactions until all shards have opened.  Previously, a shard would start compactions as soon as it was opened even if other shards were still opening.  This could slow down startup due to many compactions kicking in and consuming CPU/IO while other shards are loading.
* Shards have about 5 goroutines used for level/full compactions.  When there are thousands of shards, the number of goroutines can be high.  While this hasn't been an issue per-se, it is inefficient considering most of these goroutines are not doing anything once a shard goes cold and is fully compacted.  These goroutines are now stopped once the shard goes cold and they are restarted after new writes/deletes to the shard occur.
* Compaction planning runs independently for each level.  Sometimes the planning can assign the same file to different plans.  This was handled by the `Compactor` which would keep track of which files are currently being compacted.  If a duplicate file was seen, the second compaction would be aborted leading to messages as seen in #7425.  The planner was updated to keep track of what files have been assigned to plans to prevent plans being returned with overlapping files.  #7425 should not occur now, but the safeguards in the `Compactor` are still in place.
* There was bug where `tmp` files would not be cleaned up when an error occurred during a compaction.  These are now removed.
* `monitor` goroutine per shard has been removed and handled by a single goroutine for all shards on the store.
* `Cache.Size` didn't include the snapshot size which cause the size to be misreported.

Fixes #7425 #8276 #8123