### PR TITLE
Fix panic in AST rewriter when (*SelectStatement).Condition == nil

### DIFF
--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -4300,7 +4300,15 @@ func Rewrite(r Rewriter, node Node) Node {
 		n.Fields = Rewrite(r, n.Fields).(Fields)
 		n.Dimensions = Rewrite(r, n.Dimensions).(Dimensions)
 		n.Sources = Rewrite(r, n.Sources).(Sources)
-		n.Condition = Rewrite(r, n.Condition).(Expr)
+
+		// Rewrite may return nil. Nil does not satisfy the Expr
+		// interface. We only assert the rewritten result to be an
+		// Expr if it is not nil:
+		if cond := Rewrite(r, n.Condition); cond != nil {
+			n.Condition = cond.(Expr)
+		} else {
+			n.Condition = nil
+		}
 
 	case *SubQuery:
 		n.Statement = Rewrite(r, n.Statement).(*SelectStatement)


### PR DESCRIPTION
The AST rewriter tries to assert `nil` to be an `influxql.Expr` and thus causes a panic. This patch checks that the field is not `nil` before running the rewriter.