### PR TITLE
Fix race in SeriesN and CreateSeriesIfNotExists

### DIFF
--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -92,7 +92,10 @@ func (i *Index) SeriesSketches() (estimator.Sketch, estimator.Sketch, error) {
 // Since indexes are not shared across shards, the count returned by SeriesN
 // cannot be combined with other shards' counts.
 func (i *Index) SeriesN() int64 {
-	return int64(len(i.series))
+	i.mu.RLock()
+	n := int64(len(i.series))
+	i.mu.RUnlock()
+	return n
 }
 
 // Measurement returns the measurement object from the index by the name


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fixes this race:

```
==================
WARNING: DATA RACE
Write at 0x00c436c719e0 by goroutine 250:
  runtime.mapassign()
      /usr/local/go/src/runtime/hashmap.go:485 +0x0
  github.com/influxdata/influxdb/tsdb/index/inmem.(*Index).CreateSeriesIfNotExists()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/index/inmem/inmem.go:173 +0x63c
  github.com/influxdata/influxdb/tsdb/index/inmem.(*ShardIndex).CreateSeriesIfNotExists()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/index/inmem/inmem.go:819 +0x108
  github.com/influxdata/influxdb/tsdb/index/inmem.(*ShardIndex).CreateSeriesListIfNotExists()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/index/inmem/inmem.go:787 +0xe6e
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).CreateSeriesListIfNotExists()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:1032 +0xdb
  github.com/influxdata/influxdb/tsdb.(*Shard).validateSeriesAndFields()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:564 +0x8c5
  github.com/influxdata/influxdb/tsdb.(*Shard).WritePoints()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:432 +0x152
  github.com/influxdata/influxdb/tsdb.(*Store).WriteToShard()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/store.go:905 +0x129
  github.com/influxdata/influxdb/coordinator.(*PointsWriter).writeToShard()
      /Users/jason/go/src/github.com/influxdata/influxdb/coordinator/points_writer.go:350 +0x109
  github.com/influxdata/influxdb/coordinator.(*PointsWriter).WritePoints.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/coordinator/points_writer.go:307 +0xa7

Previous read at 0x00c436c719e0 by goroutine 42:
  github.com/influxdata/influxdb/tsdb/index/inmem.(*ShardIndex).SeriesN()
      <autogenerated>:11 +0x7e
  github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).SeriesN()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:344 +0x5f
  github.com/influxdata/influxdb/tsdb.(*Shard).Statistics()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/shard.go:211 +0xb8
  github.com/influxdata/influxdb/tsdb.(*Store).Statistics()
      /Users/jason/go/src/github.com/influxdata/influxdb/tsdb/store.go:119 +0xafb
  github.com/influxdata/influxdb/cmd/influxd/run.(*Server).Statistics()
      /Users/jason/go/src/github.com/influxdata/influxdb/cmd/influxd/run/server.go:215 +0x12b
  github.com/influxdata/influxdb/monitor.(*Monitor).gatherStatistics()
      /Users/jason/go/src/github.com/influxdata/influxdb/monitor/service.go:318 +0xf8
  github.com/influxdata/influxdb/monitor.(*Monitor).Statistics()
      /Users/jason/go/src/github.com/influxdata/influxdb/monitor/service.go:310 +0x1165
  github.com/influxdata/influxdb/monitor.(*Monitor).storeStatistics()
      /Users/jason/go/src/github.com/influxdata/influxdb/monitor/service.go:411 +0x594

Goroutine 250 (running) created at:
  github.com/influxdata/influxdb/coordinator.(*PointsWriter).WritePoints()
      /Users/jason/go/src/github.com/influxdata/influxdb/coordinator/points_writer.go:308 +0x431
  github.com/influxdata/influxdb/services/httpd.(*Handler).serveWrite()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:671 +0x9ea
  github.com/influxdata/influxdb/services/httpd.(*Handler).(github.com/influxdata/influxdb/services/httpd.serveWrite)-fm()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:133 +0x69
  github.com/influxdata/influxdb/services/httpd.authenticate.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:962 +0xa7d
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1942 +0x51
  github.com/influxdata/influxdb/services/httpd.(*Handler).responseWriter.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:1171 +0xc2
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1942 +0x51
  github.com/influxdata/influxdb/services/httpd.gzipFilter.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:1090 +0x1bd
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1942 +0x51
  github.com/influxdata/influxdb/services/httpd.cors.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:1145 +0x131
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1942 +0x51
  github.com/influxdata/influxdb/services/httpd.requestID.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:1155 +0x1b3
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1942 +0x51
  github.com/influxdata/influxdb/services/httpd.(*Handler).logging.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:1163 +0x143
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1942 +0x51
  github.com/influxdata/influxdb/services/httpd.(*Handler).recovery.func1()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:1188 +0x19c
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:1942 +0x51
  github.com/bmizerany/pat.(*PatternServeMux).ServeHTTP()
      /Users/jason/go/src/github.com/bmizerany/pat/mux.go:117 +0x863
  github.com/influxdata/influxdb/services/httpd.(*Handler).ServeHTTP()
      /Users/jason/go/src/github.com/influxdata/influxdb/services/httpd/handler.go:261 +0x334
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2568 +0xbc
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1825 +0x71a

Goroutine 42 (running) created at:
  github.com/influxdata/influxdb/monitor.(*Monitor).Open()
      /Users/jason/go/src/github.com/influxdata/influxdb/monitor/service.go:122 +0x401
  github.com/influxdata/influxdb/cmd/influxd/run.(*Server).Open()
      /Users/jason/go/src/github.com/influxdata/influxdb/cmd/influxd/run/server.go:426 +0x1799
  github.com/influxdata/influxdb/cmd/influxd/run.(*Command).Run()
      /Users/jason/go/src/github.com/influxdata/influxdb/cmd/influxd/run/command.go:117 +0xecd
  main.(*Main).Run()
      /Users/jason/go/src/github.com/influxdata/influxdb/cmd/influxd/main.go:89 +0x29e
  main.main()
      /Users/jason/go/src/github.com/influxdata/influxdb/cmd/influxd/main.go:46 +0xd2
==================
```