### PR TITLE
Add TSI support tooling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8273](https://github.com/influxdata/influxdb/issues/8273): Remove the admin UI.
 - [#8327](https://github.com/influxdata/influxdb/pull/8327): Update to go1.8.1
 - [#8348](https://github.com/influxdata/influxdb/pull/8348): Add max concurrent compaction limits
+- [#8366](https://github.com/influxdata/influxdb/pull/8366): Add TSI support tooling.
 
 ### Bugfixes
 

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/influxdata/influxdb/cmd"
+	"github.com/influxdata/influxdb/cmd/influx_inspect/dumptsi"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/dumptsm"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/export"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/help"
@@ -52,6 +53,11 @@ func (m *Main) Run(args ...string) error {
 	case "", "help":
 		if err := help.NewCommand().Run(args...); err != nil {
 			return fmt.Errorf("help: %s", err)
+		}
+	case "dumptsi":
+		name := dumptsi.NewCommand()
+		if err := name.Run(args...); err != nil {
+			return fmt.Errorf("dumptsi: %s", err)
 		}
 	case "dumptsmdev":
 		fmt.Fprintf(m.Stderr, "warning: dumptsmdev is deprecated, use dumptsm instead.\n")

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -17,6 +17,17 @@ import (
 // FileSet represents a collection of files.
 type FileSet []File
 
+// Close closes all the files in the file set.
+func (p FileSet) Close() error {
+	var err error
+	for _, f := range p {
+		if e := f.Close(); e != nil && err == nil {
+			err = e
+		}
+	}
+	return err
+}
+
 // Retain adds a reference count to all files.
 func (p FileSet) Retain() {
 	for _, f := range p {

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -83,6 +83,7 @@ type Index struct {
 	CompactionFactor float64
 
 	// Frequency of compaction checks.
+	CompactionEnabled         bool
 	CompactionMonitorInterval time.Duration
 }
 
@@ -92,8 +93,9 @@ func NewIndex() *Index {
 		closing: make(chan struct{}),
 
 		// Default compaction thresholds.
-		MaxLogFileSize:   DefaultMaxLogFileSize,
-		CompactionFactor: DefaultCompactionFactor,
+		MaxLogFileSize:    DefaultMaxLogFileSize,
+		CompactionEnabled: true,
+		CompactionFactor:  DefaultCompactionFactor,
 	}
 }
 
@@ -753,6 +755,10 @@ func (i *Index) Compact() {
 
 // compact compacts continguous groups of files that are not currently compacting.
 func (i *Index) compact() {
+	if !i.CompactionEnabled {
+		return
+	}
+
 	fs := i.retainFileSet()
 	defer fs.Release()
 

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -195,6 +195,15 @@ func (f *IndexFile) Measurement(name []byte) MeasurementElem {
 	return &e
 }
 
+// MeasurementN returns the number of measurements in the file.
+func (f *IndexFile) MeasurementN() (n uint64) {
+	mitr := f.mblk.Iterator()
+	for me := mitr.Next(); me != nil; me = mitr.Next() {
+		n++
+	}
+	return n
+}
+
 // TagValueIterator returns a value iterator for a tag key and a flag
 // indicating if a tombstone exists on the measurement or key.
 func (f *IndexFile) TagValueIterator(name, key []byte) TagValueIterator {

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -372,6 +372,35 @@ func (f *LogFile) TagValueSeriesIterator(name, key, value []byte) SeriesIterator
 	return newLogSeriesIterator(tv.series)
 }
 
+// MeasurementN returns the total number of measurements.
+func (f *LogFile) MeasurementN() (n uint64) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return uint64(len(f.mms))
+}
+
+// TagKeyN returns the total number of keys.
+func (f *LogFile) TagKeyN() (n uint64) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, mm := range f.mms {
+		n += uint64(len(mm.tagSet))
+	}
+	return n
+}
+
+// TagValueN returns the total number of values.
+func (f *LogFile) TagValueN() (n uint64) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	for _, mm := range f.mms {
+		for _, k := range mm.tagSet {
+			n += uint64(len(k.tagValues))
+		}
+	}
+	return n
+}
+
 // DeleteTagValue adds a tombstone for a tag value to the log file.
 func (f *LogFile) DeleteTagValue(name, key, value []byte) error {
 	f.mu.Lock()

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -321,6 +321,12 @@ func (e *MeasurementBlockElem) TagBlockOffset() int64 { return e.tagBlock.offset
 // TagBlockSize returns the size of the measurement's tag block.
 func (e *MeasurementBlockElem) TagBlockSize() int64 { return e.tagBlock.size }
 
+// SeriesData returns the raw series data.
+func (e *MeasurementBlockElem) SeriesData() []byte { return e.series.data }
+
+// SeriesN returns the number of series associated with the measurement.
+func (e *MeasurementBlockElem) SeriesN() uint64 { return e.series.n }
+
 // SeriesID returns series ID at an index.
 func (e *MeasurementBlockElem) SeriesID(i int) uint64 {
 	return binary.BigEndian.Uint64(e.series.data[i*SeriesIDSize:])
@@ -334,6 +340,9 @@ func (e *MeasurementBlockElem) SeriesIDs() []uint64 {
 	}
 	return a
 }
+
+// Size returns the size of the element.
+func (e *MeasurementBlockElem) Size() int { return e.size }
 
 // UnmarshalBinary unmarshals data into e.
 func (e *MeasurementBlockElem) UnmarshalBinary(data []byte) error {

--- a/tsdb/index/tsi1/tag_block.go
+++ b/tsdb/index/tsi1/tag_block.go
@@ -316,6 +316,9 @@ func (e *TagBlockValueElem) Value() []byte { return e.value }
 // SeriesN returns the series count.
 func (e *TagBlockValueElem) SeriesN() uint64 { return e.series.n }
 
+// SeriesData returns the raw series data.
+func (e *TagBlockValueElem) SeriesData() []byte { return e.series.data }
+
 // SeriesID returns series ID at an index.
 func (e *TagBlockValueElem) SeriesID(i int) uint64 {
 	return binary.BigEndian.Uint64(e.series.data[i*SeriesIDSize:])
@@ -329,6 +332,9 @@ func (e *TagBlockValueElem) SeriesIDs() []uint64 {
 	}
 	return a
 }
+
+// Size returns the size of the element.
+func (e *TagBlockValueElem) Size() int { return e.size }
 
 // unmarshal unmarshals buf into e.
 func (e *TagBlockValueElem) unmarshal(buf []byte) {


### PR DESCRIPTION
## Overview

Added a `dumptsi` command to `influx_inspect`. It provides the ability to inspect a whole index or a subset of files.

```
Dumps low-level details about tsi1 files.

Usage: influx_inspect dumptsi [flags] path...

    -series
            Dump raw series data
    -measurements
            Dump raw measurement data
    -tag-keys
            Dump raw tag keys
    -tag-values
            Dump raw tag values
    -tag-value-series
            Dump raw series for each tag value
    -measurement-filter REGEXP
            Filters data by measurement regular expression
    -tag-key-filter REGEXP
            Filters data by tag key regular expression
    -tag-value-filter REGEXP
            Filters data by tag value regular expression

If no flags are specified then summary stats are provided for each file.
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
