### PR TITLE
Fixes races/memory usage

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -347,6 +347,10 @@ func (s *Shard) close(clean bool) error {
 }
 
 func (s *Shard) IndexType() string {
+	if err := s.ready(); err != nil {
+		return ""
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.index.Type()

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -958,10 +958,14 @@ func (s *Shard) CreateSnapshot() (string, error) {
 }
 
 func (s *Shard) ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.engine.ForEachMeasurementTagKey(name, fn)
 }
 
 func (s *Shard) TagKeyCardinality(name, key []byte) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.engine.TagKeyCardinality(name, key)
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This is a follow up to #8348 that fixes data race and reduces memory allocations when monitoring shards.