### PR TITLE
Speed up time encoding/decoding

### DIFF
--- a/tsdb/engine/tsm1/int_test.go
+++ b/tsdb/engine/tsm1/int_test.go
@@ -597,6 +597,10 @@ func BenchmarkIntegerEncoderPackedSimple(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		enc.Bytes()
+		enc.Reset()
+		for i := 0; i < len(x); i++ {
+			enc.Write(x[i])
+		}
 	}
 }
 

--- a/tsdb/engine/tsm1/timestamp_test.go
+++ b/tsdb/engine/tsm1/timestamp_test.go
@@ -555,6 +555,10 @@ func BenchmarkTimeEncoder(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		enc.Bytes()
+		enc.Reset()
+		for i := 0; i < len(x); i++ {
+			enc.Write(x[i])
+		}
 	}
 }
 
@@ -569,10 +573,7 @@ func BenchmarkTimeDecoder_Packed(b *testing.B) {
 
 	b.ResetTimer()
 
-	b.StopTimer()
 	var dec TimeDecoder
-	b.StartTimer()
-
 	for i := 0; i < b.N; i++ {
 		dec.Init(bytes)
 		for dec.Next() {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This speeds up time encoding and decoding by skipping the divisor
scaling if scaling by 1.  Since division and multiplication are expensive
cpu and scaling by 1 has no effect, this just slows encoding and decoding
down.

This should improve compaction times somewhat since time encoding is used by all types.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkTimeEncoder-8            33930         19271         -43.20%
BenchmarkTimeDecoder_Packed-8     9819          8339          -15.07%
BenchmarkTimeDecoder_RLE-8        2331          2288          -1.84%
```