### PR TITLE
Don't disable snapshots when snapshot compactions are disabled

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -273,7 +273,6 @@ func (e *Engine) enableSnapshotCompactions() {
 		return
 	}
 
-	e.Compactor.EnableSnapshots()
 	quit := make(chan struct{})
 	e.snapDone = quit
 	e.snapWG.Add(1)
@@ -286,7 +285,6 @@ func (e *Engine) disableSnapshotCompactions() {
 	e.mu.Lock()
 
 	if e.snapDone != nil {
-		e.Compactor.DisableSnapshots()
 		close(e.snapDone)
 		e.snapDone = nil
 	}


### PR DESCRIPTION
Snapshot compactions can be disabled independently of snapshotting
capability.  This prevents taking backups of shards that have compactions
disabled.

This issue becomes more apparent due to #8348 disabling compactions for cold shards.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>