### PR TITLE
Use buffer writer for wal segments

### DIFF
--- a/cmd/influx_inspect/export/export_test.go
+++ b/cmd/influx_inspect/export/export_test.go
@@ -290,6 +290,9 @@ func writeCorpusToWALFile(c corpus) *os.File {
 		panic(err)
 	}
 
+	if err := w.Flush(); err != nil {
+		panic(err)
+	}
 	// (*tsm1.WALSegmentWriter).sync isn't exported, but it only Syncs the file anyway.
 	if err := walFile.Sync(); err != nil {
 		panic(err)

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -579,6 +579,10 @@ func TestCacheLoader_LoadSingle(t *testing.T) {
 		t.Fatal("write points", err)
 	}
 
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
 	// Load the cache using the segment.
 	cache := NewCache(1024, "")
 	loader := NewCacheLoader([]string{f.Name()})
@@ -642,6 +646,9 @@ func TestCacheLoader_LoadDouble(t *testing.T) {
 		}
 		if err := w1.Write(mustMarshalEntry(entry)); err != nil {
 			t.Fatal("write points", err)
+		}
+		if err := w1.Flush(); err != nil {
+			t.Fatalf("flush error: %v", err)
 		}
 	}
 
@@ -707,6 +714,10 @@ func TestCacheLoader_LoadDeleted(t *testing.T) {
 		t.Fatal("write points", err)
 	}
 
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush error: %v", err)
+	}
+
 	dentry := &DeleteRangeWALEntry{
 		Keys: []string{"foo"},
 		Min:  2,
@@ -715,6 +726,10 @@ func TestCacheLoader_LoadDeleted(t *testing.T) {
 
 	if err := w.Write(mustMarshalEntry(dentry)); err != nil {
 		t.Fatal("write points", err)
+	}
+
+	if err := w.Flush(); err != nil {
+		t.Fatalf("flush error: %v", err)
 	}
 
 	// Load the cache using the segment.

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -37,6 +37,10 @@ func TestWALWriter_WriteMulti_Single(t *testing.T) {
 		fatal(t, "write points", err)
 	}
 
+	if err := w.Flush(); err != nil {
+		fatal(t, "flush", err)
+	}
+
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		fatal(t, "seek", err)
 	}
@@ -92,6 +96,10 @@ func TestWALWriter_WriteMulti_LargeBatch(t *testing.T) {
 
 	if err := w.Write(mustMarshalEntry(entry)); err != nil {
 		fatal(t, "write points", err)
+	}
+
+	if err := w.Flush(); err != nil {
+		fatal(t, "flush", err)
 	}
 
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
@@ -150,6 +158,9 @@ func TestWALWriter_WriteMulti_Multiple(t *testing.T) {
 
 		if err := w.Write(mustMarshalEntry(entry)); err != nil {
 			fatal(t, "write points", err)
+		}
+		if err := w.Flush(); err != nil {
+			fatal(t, "flush", err)
 		}
 	}
 
@@ -211,6 +222,10 @@ func TestWALWriter_WriteDelete_Single(t *testing.T) {
 		fatal(t, "write points", err)
 	}
 
+	if err := w.Flush(); err != nil {
+		fatal(t, "flush", err)
+	}
+
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		fatal(t, "seek", err)
 	}
@@ -259,6 +274,10 @@ func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
 		fatal(t, "write points", err)
 	}
 
+	if err := w.Flush(); err != nil {
+		fatal(t, "flush", err)
+	}
+
 	// Write the delete entry
 	deleteEntry := &tsm1.DeleteWALEntry{
 		Keys: []string{"cpu,host=A#!~value"},
@@ -266,6 +285,10 @@ func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
 
 	if err := w.Write(mustMarshalEntry(deleteEntry)); err != nil {
 		fatal(t, "write points", err)
+	}
+
+	if err := w.Flush(); err != nil {
+		fatal(t, "flush", err)
 	}
 
 	// Seek back to the beinning of the file for reading
@@ -348,6 +371,10 @@ func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
 		fatal(t, "write points", err)
 	}
 
+	if err := w.Flush(); err != nil {
+		fatal(t, "flush", err)
+	}
+
 	// Write the delete entry
 	deleteEntry := &tsm1.DeleteRangeWALEntry{
 		Keys: []string{"cpu,host=A#!~value"},
@@ -357,6 +384,10 @@ func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
 
 	if err := w.Write(mustMarshalEntry(deleteEntry)); err != nil {
 		fatal(t, "write points", err)
+	}
+
+	if err := w.Flush(); err != nil {
+		fatal(t, "flush", err)
 	}
 
 	// Seek back to the beinning of the file for reading
@@ -531,6 +562,10 @@ func TestWALWriter_Corrupt(t *testing.T) {
 	}
 	if err := w.Write(mustMarshalEntry(entry)); err != nil {
 		fatal(t, "write points", err)
+	}
+
+	if err := w.Flush(); err != nil {
+		fatal(t, "flush", err)
 	}
 
 	// Write some random bytes to the file to simulate corruption.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Writes to wal segments were not buffered which can lead to higher disk IO syscalls than necessary.  This uses a buffered writer to reduce those write syscalls.