### PR TITLE
fix NewShardOwner to not return a current owner

### DIFF
--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -50,10 +50,10 @@ type Data struct {
 	MaxShardID      uint64
 }
 
-// NewShardOwner sets the owner of the provided shard to the data node
-// that currently owns the fewest number of shards. If multiple nodes
-// own the same (fewest) number of shards, then one of those nodes
-// becomes the new shard owner.
+// NewShardOwner returns the ID of a data node that the shard should be
+// reassigned to based on which node currently owns the fewest shards.
+// If multiple nodes own the same (fewest) number of shards, one of those
+// nodes is chosen as the new shard owner.
 func NewShardOwner(s ShardInfo, ownerFreqs map[int]int) (uint64, error) {
 	var (
 		minId   = -1
@@ -62,6 +62,11 @@ func NewShardOwner(s ShardInfo, ownerFreqs map[int]int) (uint64, error) {
 
 	for id, freq := range ownerFreqs {
 		if minId == -1 || freq < minFreq {
+			// If the node is already an owner of this shard,
+			// it's not a candidate to be the new owner.
+			if s.OwnedBy(uint64(id)) {
+				continue
+			}
 			minId, minFreq = int(id), freq
 		}
 	}

--- a/services/meta/data_internal_test.go
+++ b/services/meta/data_internal_test.go
@@ -15,19 +15,26 @@ func Test_newShardOwner(t *testing.T) {
 		t.Error("got no error, but expected one")
 	}
 
-	ownerFreqs := map[int]int{1: 15, 2: 11, 3: 12}
-	id, err := NewShardOwner(ShardInfo{ID: 4}, ownerFreqs)
+	ownerFreqs := map[int]int{1: 15, 2: 11, 3: 12, 4: 10}
+	shard := ShardInfo{
+		ID: 4,
+		Owners: []ShardOwner{
+			{NodeID: 4},
+		},
+	}
+	id, err := NewShardOwner(shard, ownerFreqs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// The ID that owns the fewest shards is returned.
+	// The ID that owns the fewest shards and is not
+	// currently an owner of this shard is returned.
 	if got, exp := id, uint64(2); got != exp {
 		t.Errorf("got id %d, expected id %d", got, exp)
 	}
 
 	// The ownership frequencies are updated.
-	if got, exp := ownerFreqs, map[int]int{1: 15, 2: 12, 3: 12}; !reflect.DeepEqual(got, exp) {
+	if got, exp := ownerFreqs, map[int]int{1: 15, 2: 12, 3: 12, 4: 10}; !reflect.DeepEqual(got, exp) {
 		t.Errorf("got owner frequencies %v, expected %v", got, exp)
 	}
 }


### PR DESCRIPTION
Fixed meta.NewShardOwner() so it wouldn't return an ID for a data node
that already owns the shard.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass