### PR TITLE
make client/v2/BatchPoints precision match models/Points

### DIFF
--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -520,16 +520,57 @@ func TestBatchPoints_PrecisionError(t *testing.T) {
 	}
 }
 
+func TestBatchPoints_PrecisionSetterGetter(t *testing.T) {
+	precisionTestCases := [][]string{
+		{"ns"},
+		{"u", "us", "µs", "µ"},
+		{"ms"},
+		{"s"},
+		{"m"},
+		{"h"},
+	}
+
+	for _, testCase := range precisionTestCases {
+		expected := testCase[0]
+
+		for _, alias := range testCase {
+			bp, err := NewBatchPoints(BatchPointsConfig{
+				Precision: alias,
+			})
+			if err != nil {
+				t.Errorf("Alias %q: Did not expect error: %s", alias, err.Error())
+			}
+			if bp.Precision() != expected {
+				t.Errorf("Alias %q: expected: %s, got %s", alias, expected, bp.Precision())
+			}
+
+			err = bp.SetPrecision(alias)
+			if err != nil {
+				t.Errorf("Alias %q: Did not expect error: %s", alias, err.Error())
+			}
+
+			if bp.Precision() != expected {
+				t.Errorf("Alias %q: Expected: %s, got %s", alias, expected, bp.Precision())
+			}
+		}
+	}
+
+	bp, err := NewBatchPoints(BatchPointsConfig{})
+	if err != nil {
+		t.Errorf("Did not expect error: %s", err.Error())
+	}
+
+	if bp.Precision() != "ns" {
+		t.Errorf("Expected %s, got %s", "ns", bp.Precision())
+	}
+}
+
 func TestBatchPoints_SettersGetters(t *testing.T) {
 	bp, _ := NewBatchPoints(BatchPointsConfig{
-		Precision:        "ns",
 		Database:         "db",
 		RetentionPolicy:  "rp",
 		WriteConsistency: "wc",
 	})
-	if bp.Precision() != "ns" {
-		t.Errorf("Expected: %s, got %s", bp.Precision(), "ns")
-	}
 	if bp.Database() != "db" {
 		t.Errorf("Expected: %s, got %s", bp.Database(), "db")
 	}
@@ -543,14 +584,7 @@ func TestBatchPoints_SettersGetters(t *testing.T) {
 	bp.SetDatabase("db2")
 	bp.SetRetentionPolicy("rp2")
 	bp.SetWriteConsistency("wc2")
-	err := bp.SetPrecision("s")
-	if err != nil {
-		t.Errorf("Did not expect error: %s", err.Error())
-	}
 
-	if bp.Precision() != "s" {
-		t.Errorf("Expected: %s, got %s", bp.Precision(), "s")
-	}
 	if bp.Database() != "db2" {
 		t.Errorf("Expected: %s, got %s", bp.Database(), "db2")
 	}


### PR DESCRIPTION
Currently client/v2/BatchPoints enforces precisions that are valid golang time.Duration units (ns, us, ms, s, m, or h). Furthermore, it will accept a precision string like "0s" (since "10s" is a valid time.Duration). However, models/Points.PrecisionString, which is ultimately used by the client to generate the line protocol data for writing points, requires one of ns, u, ms, s, m, or h. Otherwise it silently ignores the precision and generates a nanosecond precision timestamp. The two sets of units are the same except for microseconds (us vs u).

I swapped out the calls to `time.ParseDuration` in favor of explicitly checking for the valid values. It now accepts "u" (seemingly the definitive unit name for microseconds) as well as "us" (since some code might use the client with this value, even though it doesn't work correctly). I threw in "µ" and "µs" since these are valid elsewhere in the API. I moved tests of NewBatchPoints and BatchPoints.SetPrecision to a separate, exhaustive, test.

- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/)
