### PR TITLE
Return partial write error when points outside of retention policy ar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8348](https://github.com/influxdata/influxdb/pull/8348): Add max concurrent compaction limits
 - [#8366](https://github.com/influxdata/influxdb/pull/8366): Add TSI support tooling.
 - [#8350](https://github.com/influxdata/influxdb/pull/8350): Track HTTP client requests for /write and /query with /debug/requests.
-<<<<<<< 8f8ff0ec612e6e77ff618f572b302e069de8e5c3
 - [#8384](https://github.com/influxdata/influxdb/pull/8384): Write and compaction stability
 - [#7862](https://github.com/influxdata/influxdb/pull/7861): Add new profile endpoint for gathering all debug profiles and querues in single archive.
 
@@ -71,6 +70,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8343](https://github.com/influxdata/influxdb/issues/8343): Set the CSV output to an empty string for null values.
 - [#8368](https://github.com/influxdata/influxdb/issues/8368): Compaction exhausting disk resources in InfluxDB
 - [#8358](https://github.com/influxdata/influxdb/issues/8358): Small edits to the etc/config.sample.toml file.
+- [#8392](https://github.com/influxdata/influxdb/issues/8393): Points beyond retention policy scope are dropped silently
 
 ## v1.2.3 [unreleased]
 


### PR DESCRIPTION
…e dropped

Writing points outside of a retention policy range were silently dropped. They
are dropped to prevent creating a shard that will be immediately deleted.  These
dropped points were silent and did not return an error respone to the caller.

Fixes #8392

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)