### PR TITLE
Fix TSM tmp file lingering on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8368](https://github.com/influxdata/influxdb/issues/8368): Compaction exhausting disk resources in InfluxDB
 - [#8358](https://github.com/influxdata/influxdb/issues/8358): Small edits to the etc/config.sample.toml file.
 - [#8392](https://github.com/influxdata/influxdb/issues/8393): Points beyond retention policy scope are dropped silently
+- [#8387](https://github.com/influxdata/influxdb/issues/8387): Fix TSM tmp file leaked on disk
 
 ## v1.2.3 [unreleased]
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes some cases where TSM tmp files could remain on disk as well as tmp files being deleted incorrectly causing errors in the logs and compactions to be aborted.  If it occurs frequently enough, space is not reclaimed until a restart occurs.

* Running a delete or drop would disable compactions and also run `cleanup` which would delete all tmp files.  Since snapshot compactions are not disabled, any in progress one will fail causing #8387.  This could also cause failures where shard snapshots are used such as backups.
* There are some cases where a failed compaction would not remove its tmp file.  Previously, compactions could get scheduled for the same files and if both deleted the tmp file neither compaction would succeed and they would get stuck.  The recent changes to the compaction planning prevent this and remove failed tmp files due to compaction failures.

Fixes #8387