### PR TITLE
Compaction planning fixes

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -492,10 +492,11 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) []CompactionGroup {
 // findGenerations groups all the TSM files by generation based
 // on their filename, then returns the generations in descending order (newest first).
 func (c *DefaultPlanner) findGenerations() tsmGenerations {
-	c.mu.RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	last := c.lastFindGenerations
 	lastGen := c.lastGenerations
-	c.mu.RUnlock()
 
 	if !last.IsZero() && c.FileStore.LastModified().Equal(last) {
 		return lastGen
@@ -525,10 +526,8 @@ func (c *DefaultPlanner) findGenerations() tsmGenerations {
 		sort.Sort(orderedGenerations)
 	}
 
-	c.mu.Lock()
 	c.lastFindGenerations = genTime
 	c.lastGenerations = orderedGenerations
-	c.mu.Unlock()
 
 	return orderedGenerations
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1290,10 +1290,11 @@ func (s *compactionStrategy) compactGroup(groupNum int) {
 	}()
 
 	if err != nil {
-		if err == errCompactionsDisabled || err == errCompactionInProgress {
+		_, inProgress := err.(errCompactionInProgress)
+		if err == errCompactionsDisabled || inProgress {
 			s.logger.Info(fmt.Sprintf("aborted %s compaction group (%d). %v", s.description, groupNum, err))
 
-			if err == errCompactionInProgress {
+			if _, ok := err.(errCompactionInProgress); ok {
 				time.Sleep(time.Second)
 			}
 			return

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1181,10 +1181,9 @@ func (e *Engine) compactTSMLevel(fast bool, level int, quit <-chan struct{}) {
 		case <-t.C:
 			s := e.levelCompactionStrategy(fast, level)
 			if s != nil {
-				// Release the files in the compaction plan
-				defer e.CompactionPlan.Release(s.compactionGroups)
-
 				s.Apply()
+				// Release the files in the compaction plan
+				e.CompactionPlan.Release(s.compactionGroups)
 			}
 
 		}
@@ -1203,9 +1202,9 @@ func (e *Engine) compactTSMFull(quit <-chan struct{}) {
 		case <-t.C:
 			s := e.fullCompactionStrategy()
 			if s != nil {
-				// Release the files in the compaction plan
-				defer e.CompactionPlan.Release(s.compactionGroups)
 				s.Apply()
+				// Release the files in the compaction plan
+				e.CompactionPlan.Release(s.compactionGroups)
 			}
 
 		}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes some issues related to compaction planning.
* There was a bug introduced in #8348 where planned files would not be released.
* There was a bug where failing to write snapshot would mask the file creation error.
* There was a race in `findGenerations` where it could get stuck returning no files.