### PR TITLE
Fix large field keys preventing snapshot compactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The admin UI is removed and unusable in this release. The `[admin]` configuratio
 - [#8358](https://github.com/influxdata/influxdb/issues/8358): Small edits to the etc/config.sample.toml file.
 - [#8392](https://github.com/influxdata/influxdb/issues/8393): Points beyond retention policy scope are dropped silently
 - [#8387](https://github.com/influxdata/influxdb/issues/8387): Fix TSM tmp file leaked on disk
+- [#8417](https://github.com/influxdata/influxdb/issues/8417): Fix large field keys preventing snapshot compactions
 
 
 ## v1.2.4 [2017-05-08]

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -455,13 +455,13 @@ func (t *tsmWriter) writeHeader() error {
 
 // Write writes a new block containing key and values.
 func (t *tsmWriter) Write(key string, values Values) error {
+	if len(key) > maxKeyLength {
+		return ErrMaxKeyLengthExceeded
+	}
+
 	// Nothing to write
 	if len(values) == 0 {
 		return nil
-	}
-
-	if len(key) > maxKeyLength {
-		return ErrMaxKeyLengthExceeded
 	}
 
 	// Write header only after we have some data to write.
@@ -507,6 +507,10 @@ func (t *tsmWriter) Write(key string, values Values) error {
 // exceeds max entries for a given key, ErrMaxBlocksExceeded is returned.  This indicates
 // that the index is now full for this key and no future writes to this key will succeed.
 func (t *tsmWriter) WriteBlock(key string, minTime, maxTime int64, block []byte) error {
+	if len(key) > maxKeyLength {
+		return ErrMaxKeyLengthExceeded
+	}
+
 	// Nothing to write
 	if len(block) == 0 {
 		return nil

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -612,6 +612,26 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 	}
 }
 
+func TestTSMWriter_WriteBlock_MaxKey(t *testing.T) {
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	f := MustTempFile(dir)
+
+	w, err := tsm1.NewTSMWriter(f)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	var key string
+	for i := 0; i < 100000; i++ {
+		key += "a"
+	}
+
+	if err := w.WriteBlock(key, 0, 0, nil); err != tsm1.ErrMaxKeyLengthExceeded {
+		t.Fatalf("expected max key length error writing key: %v", err)
+	}
+}
+
 func TestTSMWriter_Write_MaxKey(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes an issue where a very large field key would be accepted during a write, but would subsequently fail when snapshotting the key to TSM.  The issue was that series key validation only looked at the measurement + tagset for the max key length.  The actual series key includes the field name and an internal tsm value.  If a write with a very large field key was sent, it would pass this validation and be written to a tsm file.  When the tsm file was loaded, it would fail to load because the actual key size overflow the 2 bytes allocated for storing the key length.

This fixes the validation to fail the writes early on so the client receives a 400/partial write error.  It also fixes the bug in the tsm writer to prevent writing keys that are too large.  This was check in `WriteValues`, but not `WriteBlock` by mistake.

Fixes #8417