### PR TITLE
Implement zap logging in TSI.

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -9,11 +9,13 @@ import (
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/estimator"
+	"github.com/uber-go/zap"
 )
 
 type Index interface {
 	Open() error
 	Close() error
+	WithLogger(zap.Logger)
 
 	MeasurementExists(name []byte) (bool, error)
 	MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error)

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -26,6 +26,7 @@ import (
 	"github.com/influxdata/influxdb/pkg/estimator"
 	"github.com/influxdata/influxdb/pkg/estimator/hll"
 	"github.com/influxdata/influxdb/tsdb"
+	"github.com/uber-go/zap"
 )
 
 // IndexName is the name of this index.
@@ -72,6 +73,8 @@ func NewIndex() *Index {
 func (i *Index) Type() string      { return IndexName }
 func (i *Index) Open() (err error) { return nil }
 func (i *Index) Close() error      { return nil }
+
+func (i *Index) WithLogger(zap.Logger) {}
 
 // Series returns a series by key.
 func (i *Index) Series(key []byte) (*Series, error) {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -170,6 +170,7 @@ func (s *Shard) WithLogger(log zap.Logger) {
 	s.baseLogger = log
 	if err := s.ready(); err == nil {
 		s.engine.WithLogger(s.baseLogger)
+		s.index.WithLogger(s.baseLogger)
 	}
 	s.logger = s.baseLogger.With(zap.String("service", "shard"))
 }
@@ -274,6 +275,7 @@ func (s *Shard) Open() error {
 			return err
 		}
 		s.index = idx
+		idx.WithLogger(s.baseLogger)
 
 		// Initialize underlying engine.
 		e, err := NewEngine(s.id, idx, s.path, s.walPath, s.options)


### PR DESCRIPTION
## Overview

Zap logging was implemented while TSI was being implemented so TSI still had old `log` references. This replaces the logging implementation in TSI.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
