### PR TITLE
improvements to inmem/Measurement.TagSets API

### DIFF
--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -224,7 +224,7 @@ func BenchmarkMeasurement_SeriesIDForExp_NERegex(b *testing.B) {
 func benchmarkTagSets(b *testing.B, n int, opt influxql.IteratorOptions) {
 	m := inmem.NewMeasurement("m")
 	for i := 0; i < n; i++ {
-		tags := map[string]string{"tag1":"value1", "tag2": "value2"}
+		tags := map[string]string{"tag1": "value1", "tag2": "value2"}
 		s := inmem.NewSeries([]byte(fmt.Sprintf("m,tag1=value1,tag2=value2")), models.NewTags(tags))
 		s.ID = uint64(i)
 		s.AssignShard(0)
@@ -246,7 +246,7 @@ func BenchmarkMeasurement_TagSetsNoDimensions_1000(b *testing.B) {
 }
 
 func BenchmarkMeasurement_TagSetsDimensions_1000(b *testing.B) {
-	benchmarkTagSets(b, 1000, influxql.IteratorOptions{Dimensions:[]string{"tag1", "tag2"}})
+	benchmarkTagSets(b, 1000, influxql.IteratorOptions{Dimensions: []string{"tag1", "tag2"}})
 }
 
 func BenchmarkMeasurement_TagSetsNoDimensions_100000(b *testing.B) {
@@ -254,5 +254,5 @@ func BenchmarkMeasurement_TagSetsNoDimensions_100000(b *testing.B) {
 }
 
 func BenchmarkMeasurement_TagSetsDimensions_100000(b *testing.B) {
-	benchmarkTagSets(b, 100000, influxql.IteratorOptions{Dimensions:[]string{"tag1", "tag2"}})
+	benchmarkTagSets(b, 100000, influxql.IteratorOptions{Dimensions: []string{"tag1", "tag2"}})
 }

--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -221,35 +221,38 @@ func BenchmarkMeasurement_SeriesIDForExp_NERegex(b *testing.B) {
 
 }
 
-/*
-func BenchmarkCreateSeriesIndex_1K(b *testing.B) {
-	benchmarkCreateSeriesIndex(b, genTestSeries(38, 3, 3))
-}
-
-func BenchmarkCreateSeriesIndex_100K(b *testing.B) {
-	benchmarkCreateSeriesIndex(b, genTestSeries(32, 5, 5))
-}
-
-func BenchmarkCreateSeriesIndex_1M(b *testing.B) {
-	benchmarkCreateSeriesIndex(b, genTestSeries(330, 5, 5))
-}
-
-func benchmarkCreateSeriesIndex(b *testing.B, series []*TestSeries) {
-	idxs := make([]*inmem.DatabaseIndex, 0, b.N)
-	for i := 0; i < b.N; i++ {
-		index, err := inmem.NewDatabaseIndex(fmt.Sprintf("db%d", i))
-		if err != nil {
-			b.Fatal(err)
-		}
-		idxs = append(idxs, index)
+func benchmarkTagSets(b *testing.B, n int, opt influxql.IteratorOptions) {
+	m := inmem.NewMeasurement("m")
+	for i := 0; i < n; i++ {
+		tags := map[string]string{"tag1":"value1", "tag2": "value2"}
+		s := inmem.NewSeries([]byte(fmt.Sprintf("m,tag1=value1,tag2=value2")), models.NewTags(tags))
+		s.ID = uint64(i)
+		s.AssignShard(0)
+		m.AddSeries(s)
 	}
 
+	// warm caches
+	m.TagSets(0, opt)
+
+	b.ReportAllocs()
 	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		idx := idxs[n]
-		for _, s := range series {
-			idx.CreateSeriesIndexIfNotExists(s.Measurement, s.Series, false)
-		}
+	for i := 0; i < b.N; i++ {
+		m.TagSets(0, opt)
 	}
 }
-*/
+
+func BenchmarkMeasurement_TagSetsNoDimensions_1000(b *testing.B) {
+	benchmarkTagSets(b, 1000, influxql.IteratorOptions{})
+}
+
+func BenchmarkMeasurement_TagSetsDimensions_1000(b *testing.B) {
+	benchmarkTagSets(b, 1000, influxql.IteratorOptions{Dimensions:[]string{"tag1", "tag2"}})
+}
+
+func BenchmarkMeasurement_TagSetsNoDimensions_100000(b *testing.B) {
+	benchmarkTagSets(b, 100000, influxql.IteratorOptions{})
+}
+
+func BenchmarkMeasurement_TagSetsDimensions_100000(b *testing.B) {
+	benchmarkTagSets(b, 100000, influxql.IteratorOptions{Dimensions:[]string{"tag1", "tag2"}})
+}

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -98,7 +98,6 @@ func MakeTagsKey(keys []string, tags models.Tags) []byte {
 	return b
 }
 
-
 // MeasurementFromSeriesKey returns the name of the measurement from a key that
 // contains a measurement name.
 func MeasurementFromSeriesKey(key []byte) []byte {

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -44,6 +44,61 @@ func MarshalTags(tags map[string]string) []byte {
 	return b
 }
 
+// MakeTagsKey converts a tag set to bytes for use as a lookup key.
+func MakeTagsKey(keys []string, tags models.Tags) []byte {
+	// precondition: keys is sorted
+	// precondition: models.Tags is sorted
+
+	// Empty maps marshal to empty bytes.
+	if len(keys) == 0 || len(tags) == 0 {
+		return nil
+	}
+
+	sel := make([]int, 0, len(keys))
+
+	sz := 0
+	i, j := 0, 0
+	for i < len(keys) && j < len(tags) {
+		if keys[i] < string(tags[j].Key) {
+			i++
+		} else if keys[i] > string(tags[j].Key) {
+			j++
+		} else {
+			sel = append(sel, j)
+			sz += len(keys[i]) + len(tags[j].Value)
+			i++
+			j++
+		}
+	}
+
+	if len(sel) == 0 {
+		// no tags matched the requested keys
+		return nil
+	}
+
+	sz += (len(sel) * 2) - 1 // selected tags, add separators
+
+	// Generate marshaled bytes.
+	b := make([]byte, sz)
+	buf := b
+	for _, k := range sel {
+		copy(buf, tags[k].Key)
+		buf[len(tags[k].Key)] = '|'
+		buf = buf[len(tags[k].Key)+1:]
+	}
+
+	for i, k := range sel {
+		copy(buf, tags[k].Value)
+		if i < len(sel)-1 {
+			buf[len(tags[k].Value)] = '|'
+			buf = buf[len(tags[k].Value)+1:]
+		}
+	}
+
+	return b
+}
+
+
 // MeasurementFromSeriesKey returns the name of the measurement from a key that
 // contains a measurement name.
 func MeasurementFromSeriesKey(key []byte) []byte {

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -61,6 +61,86 @@ func benchmarkMarshalTags(b *testing.B, keyN int) {
 	}
 }
 
+// Ensure tags can be marshaled into a byte slice.
+func TestMakeTagsKey(t *testing.T) {
+	for i, tt := range []struct {
+		keys   []string
+		tags   models.Tags
+		result []byte
+	}{
+		{
+			keys:   nil,
+			tags:   nil,
+			result: nil,
+		},
+		{
+			keys:   []string{"foo"},
+			tags:   models.NewTags(map[string]string{"foo": "bar"}),
+			result: []byte(`foo|bar`),
+		},
+		{
+			keys:   []string{"foo"},
+			tags:   models.NewTags(map[string]string{"baz": "battttt"}),
+			result: []byte(``),
+		},
+		{
+			keys:   []string{"baz", "foo"},
+			tags:   models.NewTags(map[string]string{"baz": "battttt"}),
+			result: []byte(`baz|battttt`),
+		},
+		{
+			keys:   []string{"baz", "foo", "zzz"},
+			tags:   models.NewTags(map[string]string{"foo": "bar"}),
+			result: []byte(`foo|bar`),
+		},
+		{
+			keys:   []string{"baz", "foo"},
+			tags:   models.NewTags(map[string]string{"foo": "bar", "baz": "battttt"}),
+			result: []byte(`baz|foo|battttt|bar`),
+		},
+		{
+			keys:   []string{"baz"},
+			tags:   models.NewTags(map[string]string{"baz": "battttt", "foo": "bar"}),
+			result: []byte(`baz|battttt`),
+		},
+	} {
+		result := tsdb.MakeTagsKey(tt.keys, tt.tags)
+		if !bytes.Equal(result, tt.result) {
+			t.Fatalf("%d. unexpected result: exp=%s, got=%s", i, tt.result, result)
+		}
+	}
+}
+
+func BenchmarkMakeTagsKey_KeyN1(b *testing.B)  { benchmarkMakeTagsKey(b, 1) }
+func BenchmarkMakeTagsKey_KeyN3(b *testing.B)  { benchmarkMakeTagsKey(b, 3) }
+func BenchmarkMakeTagsKey_KeyN5(b *testing.B)  { benchmarkMakeTagsKey(b, 5) }
+func BenchmarkMakeTagsKey_KeyN10(b *testing.B) { benchmarkMakeTagsKey(b, 10) }
+
+func makeTagsAndKeys(keyN int) ([]string, models.Tags) {
+	const keySize, valueSize = 8, 15
+
+	// Generate tag map.
+	keys := make([]string, keyN)
+	tags := make(map[string]string)
+	for i := 0; i < keyN; i++ {
+		keys[i] = fmt.Sprintf("%0*d", keySize, i)
+		tags[keys[i]] = fmt.Sprintf("%0*d", valueSize, i)
+	}
+
+	return keys, models.NewTags(tags)
+}
+
+func benchmarkMakeTagsKey(b *testing.B, keyN int) {
+	keys, tags := makeTagsAndKeys(keyN)
+
+	// Unmarshal map into byte slice.
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		tsdb.MakeTagsKey(keys, tags)
+	}
+}
+
+
 type TestSeries struct {
 	Measurement string
 	Series      *inmem.Series

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -140,7 +140,6 @@ func benchmarkMakeTagsKey(b *testing.B, keyN int) {
 	}
 }
 
-
 type TestSeries struct {
 	Measurement string
 	Series      *inmem.Series


### PR DESCRIPTION
```
benchmark                                             old ns/op     new ns/op     delta
BenchmarkMeasurement_TagSetsNoDimensions_1000-8       234054        117315        -49.88%
BenchmarkMeasurement_TagSetsDimensions_1000-8         996838        313313        -68.57%
BenchmarkMeasurement_TagSetsNoDimensions_100000-8     58940464      39452117      -33.06%
BenchmarkMeasurement_TagSetsDimensions_100000-8       175612060     70195562      -60.03%

benchmark                                             old allocs     new allocs     delta
BenchmarkMeasurement_TagSetsNoDimensions_1000-8       1026           26             -97.47%
BenchmarkMeasurement_TagSetsDimensions_1000-8         8026           2029           -74.72%
BenchmarkMeasurement_TagSetsNoDimensions_100000-8     100064         64             -99.94%
BenchmarkMeasurement_TagSetsDimensions_100000-8       800064         200067         -74.99%

benchmark                                             old bytes     new bytes     delta
BenchmarkMeasurement_TagSetsNoDimensions_1000-8       117080        69080         -41.00%
BenchmarkMeasurement_TagSetsDimensions_1000-8         549081        117176        -78.66%
BenchmarkMeasurement_TagSetsNoDimensions_100000-8     23298264      18498265      -20.60%
BenchmarkMeasurement_TagSetsDimensions_100000-8       66498276      23298360      -64.96%
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
