### PR TITLE
Check file count before attempting a TSI level compaction.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ The following new configuration options are available.
 - [#7957](https://github.com/influxdata/influxdb/issues/7957): URL query parameter credentials take priority over Authentication header.
 - [#8443](https://github.com/influxdata/influxdb/issues/8443): TSI branch has duplicate tag values.
 - [#8299](https://github.com/influxdata/influxdb/issues/8299): Out of memory when using HTTP API
-
+- [#8455](https://github.com/influxdata/influxdb/pull/8455): Check file count before attempting a TSI level compaction.
 
 ## v1.2.4 [2017-05-08]
 

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -805,7 +805,11 @@ func (i *Index) compact() {
 		}
 
 		// Collect files for the level.
+		// Skip if we don't have enough files in the level.
 		files := fs.IndexFilesByLevel(level)
+		if len(files) < 2 {
+			continue
+		}
 
 		// Calculate total size. Skip level if it doesn't meet min size of next level.
 		var size int64


### PR DESCRIPTION
## Overview

This check was previously in a different section of code which was lost during a refactor to the new compaction strategy. The compaction planning now makes a check to ensure at least two files are available for compaction in a level.

Fixes #8451.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
