### PR TITLE
fix index file fd leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The following new configuration options are available.
 - [#8443](https://github.com/influxdata/influxdb/issues/8443): TSI branch has duplicate tag values.
 - [#8299](https://github.com/influxdata/influxdb/issues/8299): Out of memory when using HTTP API
 - [#8455](https://github.com/influxdata/influxdb/pull/8455): Check file count before attempting a TSI level compaction.
+- [#8470](https://github.com/influxdata/influxdb/issues/8470): index file fd leak in tsi branch
 
 ## v1.2.4 [2017-05-08]
 

--- a/tsdb/index/tsi1/series_block.go
+++ b/tsdb/index/tsi1/series_block.go
@@ -976,11 +976,11 @@ func mapIndexFileSeriesBlockFile(f *os.File) (*SeriesBlock, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	data = data[len(FileSignature):] // Skip file signature.
+	slbk_data := data[len(FileSignature):] // Skip file signature.
 
 	// Unmarshal block on top of mmap.
 	var sblk SeriesBlock
-	if err := sblk.UnmarshalBinary(data); err != nil {
+	if err := sblk.UnmarshalBinary(slbk_data); err != nil {
 		mmap.Unmap(data)
 		return nil, nil, err
 	}

--- a/tsdb/index/tsi1/series_block.go
+++ b/tsdb/index/tsi1/series_block.go
@@ -976,11 +976,11 @@ func mapIndexFileSeriesBlockFile(f *os.File) (*SeriesBlock, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	slbk_data := data[len(FileSignature):] // Skip file signature.
+	sblk_data := data[len(FileSignature):] // Skip file signature.
 
 	// Unmarshal block on top of mmap.
 	var sblk SeriesBlock
-	if err := sblk.UnmarshalBinary(slbk_data); err != nil {
+	if err := sblk.UnmarshalBinary(sblk_data); err != nil {
 		mmap.Unmap(data)
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/influxdata/influxdb/issues/8470
During index file compacting, it will be mmap twice.
First is calling `mapIndexFileSeriesBlock`, mmap the file and write index data into it, and then munmap it. After these, it will be opened as index file util being compacted into higher level file, munmap and removed from system.
The leaking is caused by the first mmap. The function `mapIndexFileSeriesBlockFile` calls `mmap`, get the data and truncates it from start which changes the address `data` points to. So, the `munmap` can't release the fd, thus, caused the fd leak.   

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

