### PR TITLE
fix method Fields() for models.point is not concurrency-safe

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/influxdata/influxdb/pkg/escape"
@@ -36,6 +37,9 @@ var (
 
 	// ErrInvalidPoint is returned when a point cannot be parsed correctly.
 	ErrInvalidPoint = errors.New("point is invalid")
+
+	// ErrConcurrentParsingPoint is returned when multiple goroutines are parsing same point
+	ErrConcurrentParsingPoint = errors.New("point is parsing by multiple goroutines")
 )
 
 const (
@@ -195,6 +199,9 @@ type point struct {
 
 	// cached version of parsed fields from data
 	cachedFields map[string]interface{}
+
+	// point fields is being parsed or has been parsed when touched > 0
+	touched uint32
 
 	// cached version of parsed name from key
 	cachedName string
@@ -1503,6 +1510,9 @@ func (p *point) AddTag(key, value string) {
 func (p *point) Fields() (Fields, error) {
 	if p.cachedFields != nil {
 		return p.cachedFields, nil
+	}
+	if !atomic.CompareAndSwapUint32(&p.touched, 0, 1) {
+		return nil, ErrConcurrentParsingPoint
 	}
 	cf, err := p.unmarshalBinary()
 	if err != nil {


### PR DESCRIPTION
I met panic "panic: runtime error: slice bounds out of range" when using method Fields() for client.Point.

panic: runtime error: slice bounds out of range

goroutine 149 [running]:
vendor/github.com/influxdata/influxdb/client/v2.(*Point).Fields.func1(0xc4224635e0)
	mygopath/src/vendor/github.com/influxdata/influxdb/client/v2/client.go:350 +0xc7
panic(0x87e7e0, 0xcccf90)
	mygopath/src/runtime/panic.go:489 +0x2cf
vendor/github.com/influxdata/influxdb/models.(*point).unmarshalBinary.func1(0xc42246cff0)
	mygopath/src/vendor/github.com/influxdata/influxdb/models/points.go:1674 +0x32f
panic(0x87e7e0, 0xcccf90)
	myGOROOTpath/src/runtime/panic.go:489 +0x2cf
vendor/github.com/influxdata/influxdb/models.(*point).StringValue(0xc42246cff0, 0x0, 0x0)
	mygopath/src/vendor/github.com/influxdata/influxdb/models/points.go:2116 +0xbb
vendor/github.com/influxdata/influxdb/models.(*point).unmarshalBinary(0xc42246cff0, 0x0, 0x0, 0x0)
	mygopath/src/vendor/github.com/influxdata/influxdb/models/points.go:1697 +0x788
vendor/github.com/influxdata/influxdb/models.(*point).Fields(0xc42246cff0, 0x905810, 0xc4224635e0, 0x3)
	mygopath/src/vendor/github.com/influxdata/influxdb/models/points.go:1507 +0x3c
vendor/github.com/influxdata/influxdb/client/v2.(*Point).Fields(0xc4224635e0, 0x0, 0x0, 0x0)
	mygopath/src/vendor/github.com/influxdata/influxdb/client/v2/client.go:353 +0x78`

Fields() for client.Point will call Fields() for struct models.point, but method Fields() for struct models.point is concurrency-unsafe if multiple goroutines are parsing one point.
This pr is to avoid point is parsed by multiple goroutines. If mulitple goroutines are parsing point fields, only one goroutine can parse point fields successfully, and others will get an error: ErrConcurrentParsingPoint