### PR TITLE
Change the default stats interval to 1 second instead of 10 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.4.0 [unreleased]
+
+### Bugfixes
+
+- [#8480](https://github.com/influxdata/influxdb/pull/8480): Change the default stats interval to 1 second instead of 10 seconds.
+
 ## v1.3.0 [unreleased]
 
 ### Removals

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -125,8 +125,9 @@
   # discover slow or resource intensive queries.  Setting the value to 0 disables the slow query logging.
   # log-queries-after = "0s"
 
-  # The maximum number of points a SELECT can process.  A value of 0 will make the maximum
-  # point count unlimited.
+  # The maximum number of points a SELECT can process.  A value of 0 will make
+  # the maximum point count unlimited.  This will only be checked every 10 seconds so queries will not
+  # be aborted immediately when hitting the limit.
   # max-select-point = 0
 
   # The maximum number of series a SELECT can run.  A value of 0 will make the maximum series

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -126,7 +126,7 @@
   # log-queries-after = "0s"
 
   # The maximum number of points a SELECT can process.  A value of 0 will make
-  # the maximum point count unlimited.  This will only be checked every 10 seconds so queries will not
+  # the maximum point count unlimited.  This will only be checked every second so queries will not
   # be aborted immediately when hitting the limit.
   # max-select-point = 0
 

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -14,7 +14,7 @@ import (
 )
 
 // DefaultStatsInterval is the default value for IteratorEncoder.StatsInterval.
-const DefaultStatsInterval = 10 * time.Second
+const DefaultStatsInterval = time.Second
 
 {{with $types := .}}{{range $k := $types}}
 


### PR DESCRIPTION
Update the configuration file's comment to mention the limitations of `max-select-point`.

- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary