### PR TITLE
Decouple Subscriber from PointsWriter

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -177,7 +177,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.PointsWriter = coordinator.NewPointsWriter()
 	s.PointsWriter.WriteTimeout = time.Duration(c.Coordinator.WriteTimeout)
 	s.PointsWriter.TSDBStore = s.TSDBStore
-	s.PointsWriter.Subscriber = s.Subscriber
+	s.PointsWriter.AddWriteSubscriber(s.Subscriber.Points())
 
 	// Initialize query executor.
 	s.QueryExecutor = influxql.NewQueryExecutor()

--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -340,7 +340,7 @@ func TestPointsWriter_WritePoints(t *testing.T) {
 		c := coordinator.NewPointsWriter()
 		c.MetaClient = ms
 		c.TSDBStore = store
-		c.Subscriber = sub
+		c.AddWriteSubscriber(sub.Points())
 		c.Node = &influxdb.Node{ID: 1}
 
 		c.Open()
@@ -416,7 +416,7 @@ func TestPointsWriter_WritePoints_Dropped(t *testing.T) {
 	c := coordinator.NewPointsWriter()
 	c.MetaClient = ms
 	c.TSDBStore = store
-	c.Subscriber = sub
+	c.AddWriteSubscriber(sub.Points())
 	c.Node = &influxdb.Node{ID: 1}
 
 	c.Open()


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This decouples the `PointsWriter` from `Subscriber` a bit by making the `PointsWriter` maintain a slice of points channels as opposed to a 1:1 reference to subscriber services channel.  When the server is wired up, `Subscriber` service is added as a subscriber.  This also allows for adding other listeners type services that want to be notified when points are written. 