### PR TITLE
Fix panic in ForEachMeasurementTagKey

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -973,14 +973,18 @@ func (s *Shard) CreateSnapshot() (string, error) {
 }
 
 func (s *Shard) ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if err := s.ready(); err != nil {
+		return nil
+	}
+
 	return s.engine.ForEachMeasurementTagKey(name, fn)
 }
 
 func (s *Shard) TagKeyCardinality(name, key []byte) int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if err := s.ready(); err != nil {
+		return 0
+	}
+
 	return s.engine.TagKeyCardinality(name, key)
 }
 


### PR DESCRIPTION
If a shard was closed, ForEachMeasurementTagKey and TagKeyCardinality
would panic because the engine was nil.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fixes #8473