### PR TITLE
Backport: Fix panic in ForEachMeasurementTagKey

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -973,14 +973,18 @@ func (s *Shard) CreateSnapshot() (string, error) {
 }
 
 func (s *Shard) ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if err := s.ready(); err != nil {
+		return nil
+	}
+
 	return s.engine.ForEachMeasurementTagKey(name, fn)
 }
 
 func (s *Shard) TagKeyCardinality(name, key []byte) int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	if err := s.ready(); err != nil {
+		return 0
+	}
+
 	return s.engine.TagKeyCardinality(name, key)
 }
 


### PR DESCRIPTION
Back ports #8487 

If a shard was closed, ForEachMeasurementTagKey and TagKeyCardinality
would panic because the engine was nil.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
