### PR TITLE
Add a timezone component to the example backup command to make it RFC3339 compliant

### DIFF
--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -368,7 +368,7 @@ Usage: influxd backup [flags] PATH
             Optional. The retention policy to backup.
     -shard <id>
             Optional. The shard id to backup. If specified, retention is required.
-    -since <2015-12-24T08:12:23>
+    -since <2015-12-24T08:12:23Z>
             Optional. Do an incremental backup since the passed in RFC3339
             formatted time.
 

--- a/man/influxd-backup.txt
+++ b/man/influxd-backup.txt
@@ -27,7 +27,7 @@ OPTIONS
 -shard <id>::
   The shard id to backup. Optional. If specified, '-retention <name>' is required.
 
--since <2015-12-24T08:12:13>::
+-since <2015-12-24T08:12:13Z>::
   Do an incremental backup since the passed in time. The time needs to be in the RFC3339 format. Optional.
 
 SEE ALSO


### PR DESCRIPTION
Simple documentation fix on the backup command. If you don't include a timezone component to the `-since` flag you get an error like `backup: parsing time "2017-03-18T00:00" as "2006-01-02T15:04:05Z07:00": cannot parse "" as ":"`

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
- [x] Update man page when modifying a command