### PR TITLE
Add golang.org/x/sys to Godeps

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -18,3 +18,4 @@ github.com/spaolacci/murmur3 0d12bf811670bf6a1a63828dfbd003eded177fce
 github.com/uber-go/atomic 74ca5ec650841aee9f289dce76e928313a37cbc6
 github.com/uber-go/zap fbae0281ffd546fa6d1959fec6075ac5da7fb577
 golang.org/x/crypto 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
+golang.org/x/sys 90796e5a05ce440b41c768bd9af257005e470461


### PR DESCRIPTION
This dependency appears to only be used when building for Solaris (mmap
dependency). It looks like this wasn't caught earlier due to gdm using
the current build tags to determine which files to process when saving
dependencies.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
