### PR TITLE
Defer unlock all write locks in inmem index.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ The following new configuration options are available.
 - [#8455](https://github.com/influxdata/influxdb/pull/8455): Check file count before attempting a TSI level compaction.
 - [#8470](https://github.com/influxdata/influxdb/issues/8470): index file fd leak in tsi branch
 - [#8468](https://github.com/influxdata/influxdb/pull/8468): Fix TSI non-contiguous compaction panic.
-
+- [#8500](https://github.com/influxdata/influxdb/issues/8500): InfluxDB goes unresponsive
 ## v1.2.4 [2017-05-08]
 
 ### Bugfixes


### PR DESCRIPTION
## Overview

Currently two write locks in `inmem` are obtained and then manually unlocked at function exit points. However, we have reports that the `inmem` index is hanging on a write lock and cannot track the issue down to anything else besides a lock that could have been left unlocked because of a panic.

This commit changes the two locks to always defer their unlocks to prevent these hangs.

Related: https://github.com/influxdata/influxdb/issues/8500


###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
