### PR TITLE
Allow panic recovery mechanism to be disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Features
 
 - [#8426](https://github.com/influxdata/influxdb/issues/8426): Add `parse-multivalue-plugin` to allow users to choose how multivalue plugins should be handled by the collectd service.
+- [#8548](https://github.com/influxdata/influxdb/issues/8548): Allow panic recovery to be disabled when investigating server issues.
 
 ### Bugfixes
 

--- a/influxql/query_executor.go
+++ b/influxql/query_executor.go
@@ -3,7 +3,9 @@ package influxql
 import (
 	"errors"
 	"fmt"
+	"os"
 	"runtime/debug"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -36,10 +38,15 @@ var (
 
 // Statistics for the QueryExecutor
 const (
-	statQueriesActive          = "queriesActive"   // Number of queries currently being executed
+	statQueriesActive          = "queriesActive"   // Number of queries currently being executed.
 	statQueriesExecuted        = "queriesExecuted" // Number of queries that have been executed (started).
 	statQueriesFinished        = "queriesFinished" // Number of queries that have finished.
-	statQueryExecutionDuration = "queryDurationNs" // Total (wall) time spent executing queries
+	statQueryExecutionDuration = "queryDurationNs" // Total (wall) time spent executing queries.
+	statRecoveredPanics        = "recoveredPanics" // Number of panics recovered by Query Executor.
+
+	// PanicCrashEnv is the environment variable that, when set, will prevent
+	// the handler from recovering any panics.
+	PanicCrashEnv = "INFLUXDB_PANIC_CRASH"
 )
 
 // ErrDatabaseNotFound returns a database not found error for the given database name.
@@ -208,6 +215,7 @@ type QueryStatistics struct {
 	ExecutedQueries        int64
 	FinishedQueries        int64
 	QueryExecutionDuration int64
+	RecoveredPanics        int64
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -220,6 +228,7 @@ func (e *QueryExecutor) Statistics(tags map[string]string) []models.Statistic {
 			statQueriesExecuted:        atomic.LoadInt64(&e.stats.ExecutedQueries),
 			statQueriesFinished:        atomic.LoadInt64(&e.stats.FinishedQueries),
 			statQueryExecutionDuration: atomic.LoadInt64(&e.stats.QueryExecutionDuration),
+			statRecoveredPanics:        atomic.LoadInt64(&e.stats.RecoveredPanics),
 		},
 	}}
 }
@@ -392,12 +401,31 @@ LOOP:
 	}
 }
 
+// Determines if the QueryExecutor will recover any panics or let them crash
+// the server.
+var willCrash bool
+
+func init() {
+	var err error
+	if willCrash, err = strconv.ParseBool(os.Getenv(PanicCrashEnv)); err != nil {
+		willCrash = false
+	}
+}
+
 func (e *QueryExecutor) recover(query *Query, results chan *Result) {
 	if err := recover(); err != nil {
+		atomic.AddInt64(&e.stats.RecoveredPanics, 1) // Capture the panic in _internal stats.
 		e.Logger.Error(fmt.Sprintf("%s [panic:%s] %s", query.String(), err, debug.Stack()))
 		results <- &Result{
 			StatementID: -1,
 			Err:         fmt.Errorf("%s [panic:%s]", query.String(), err),
+		}
+
+		if willCrash {
+			e.Logger.Error(fmt.Sprintf("\n\n=====\nAll goroutines now follow:"))
+			buf := debug.Stack()
+			e.Logger.Error(fmt.Sprintf("%s", buf))
+			os.Exit(1)
 		}
 	}
 }

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -19,24 +19,25 @@ import (
 
 // statistics gathered by the httpd package.
 const (
-	statRequest                      = "req"                  // Number of HTTP requests served
-	statQueryRequest                 = "queryReq"             // Number of query requests served
-	statWriteRequest                 = "writeReq"             // Number of write requests serverd
-	statPingRequest                  = "pingReq"              // Number of ping requests served
-	statStatusRequest                = "statusReq"            // Number of status requests served
-	statWriteRequestBytesReceived    = "writeReqBytes"        // Sum of all bytes in write requests
-	statQueryRequestBytesTransmitted = "queryRespBytes"       // Sum of all bytes returned in query reponses
-	statPointsWrittenOK              = "pointsWrittenOK"      // Number of points written OK
-	statPointsWrittenDropped         = "pointsWrittenDropped" // Number of points dropped by the storage engine
-	statPointsWrittenFail            = "pointsWrittenFail"    // Number of points that failed to be written
-	statAuthFail                     = "authFail"             // Number of authentication failures
-	statRequestDuration              = "reqDurationNs"        // Number of (wall-time) nanoseconds spent inside requests
-	statQueryRequestDuration         = "queryReqDurationNs"   // Number of (wall-time) nanoseconds spent inside query requests
-	statWriteRequestDuration         = "writeReqDurationNs"   // Number of (wall-time) nanoseconds spent inside write requests
-	statRequestsActive               = "reqActive"            // Number of currently active requests
-	statWriteRequestsActive          = "writeReqActive"       // Number of currently active write requests
-	statClientError                  = "clientError"          // Number of HTTP responses due to client error
-	statServerError                  = "serverError"          // Number of HTTP responses due to server error
+	statRequest                      = "req"                  // Number of HTTP requests served.
+	statQueryRequest                 = "queryReq"             // Number of query requests served.
+	statWriteRequest                 = "writeReq"             // Number of write requests serverd.
+	statPingRequest                  = "pingReq"              // Number of ping requests served.
+	statStatusRequest                = "statusReq"            // Number of status requests served.
+	statWriteRequestBytesReceived    = "writeReqBytes"        // Sum of all bytes in write requests.
+	statQueryRequestBytesTransmitted = "queryRespBytes"       // Sum of all bytes returned in query reponses.
+	statPointsWrittenOK              = "pointsWrittenOK"      // Number of points written OK.
+	statPointsWrittenDropped         = "pointsWrittenDropped" // Number of points dropped by the storage engine.
+	statPointsWrittenFail            = "pointsWrittenFail"    // Number of points that failed to be written.
+	statAuthFail                     = "authFail"             // Number of authentication failures.
+	statRequestDuration              = "reqDurationNs"        // Number of (wall-time) nanoseconds spent inside requests.
+	statQueryRequestDuration         = "queryReqDurationNs"   // Number of (wall-time) nanoseconds spent inside query requests.
+	statWriteRequestDuration         = "writeReqDurationNs"   // Number of (wall-time) nanoseconds spent inside write requests.
+	statRequestsActive               = "reqActive"            // Number of currently active requests.
+	statWriteRequestsActive          = "writeReqActive"       // Number of currently active write requests.
+	statClientError                  = "clientError"          // Number of HTTP responses due to client error.
+	statServerError                  = "serverError"          // Number of HTTP responses due to server error.
+	statRecoveredPanics              = "recoveredPanics"      // Number of panics recovered by HTTP handler.
 )
 
 // Service manages the listener and handler for an HTTP endpoint.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR adds a new environment variable `INFLUXDB_PANIC_CRASH`, which
when set to a truthy value, e.g., `true`, `TRUE`, `1`, will prevent bot the HTTP server
and the `QueryExecutor` from recovering from a panic.

When `INFLUXDB_PANIC_CRASH` is switched on, the panic will be emitted to the logs and then a further emission of the current stacktrace of all goroutines will follow.

Further, this commit adds `_internal` stats that will monitor the
occurrence of panics all the time (regardless of if `INFLUXDB_PANIC_CRASH`
has been set to `true` or not).

The recovered panic frequency can be inspected with the following
queries:

`SELECT "recoveredPanics" FROM "_internal"."monitor"."httpd";`
`SELECT "recoveredPanics" FROM "_internal"."monitor"."queryExecutor";`