### PR TITLE
Ensure tmp files cleaned up when compaction disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@
 - [#8466](https://github.com/influxdata/influxdb/issues/8466): illumos build broken on syscall.Mmap
 - [#8124](https://github.com/influxdata/influxdb/issues/8124): Prevent privileges on non-existent databases from being set.
 
-## v1.3.0 [unreleased]
+## v1.3.1 [unreleased]
+
+### Bugfixes
+
+- [#8559](https://github.com/influxdata/influxdb/issues/8559): Ensure temporary TSM files get cleaned up when compaction aborted.
+
+
+## v1.3.0 [2017-06-21]
 
 ### Release Notes
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -748,6 +748,11 @@ func (c *Compactor) CompactFull(tsmFiles []string) ([]string, error) {
 	c.mu.RUnlock()
 
 	if !enabled {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if err := c.cleanupDisabledCompaction(tsmFiles); err != nil {
+			return nil, err
+		}
 		return nil, errCompactionsDisabled
 	}
 
@@ -777,11 +782,34 @@ func (c *Compactor) CompactFast(tsmFiles []string) ([]string, error) {
 	c.mu.RUnlock()
 
 	if !enabled {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if err := c.cleanupDisabledCompaction(tsmFiles); err != nil {
+			return nil, err
+		}
 		return nil, errCompactionsDisabled
 	}
 
 	return files, err
 
+}
+
+// cleanupDisabledCompaction is responsible for cleaning up a compaction that
+// was started, but then abandoned before the temporary files were dealt with.
+func (c *Compactor) cleanupDisabledCompaction(tsmFiles []string) error {
+	for _, f := range tsmFiles {
+		files, err := filepath.Glob(filepath.Join(filepath.Dir(f), fmt.Sprintf("*.%s", CompactionTempExtension)))
+		if err != nil {
+			return fmt.Errorf("error cleaning up compaction temp files: %s", err.Error())
+		}
+
+		for _, f := range files {
+			if err := os.Remove(f); err != nil {
+				return fmt.Errorf("error removing temp compaction file: %v", err)
+			}
+		}
+	}
+	return nil
 }
 
 // writeNewFiles writes from the iterator into new TSM files, rotating


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fix for #8559. 

#8559 occurs most commonly in testing when compactions that are in-progress are interrupted by the removal of data. `DROP MEASUREMENT` tends to trigger the issue. The interruption leaves `.tsm.tmp` files within shard directories.

Whilst we do have compaction logic to deal with interruptions, the current logic works by attempting to create `.tsm.tmp` files and, when that fails due to the file already existing, assume that another compaction is in progress. The latter compaction then bails out and complains that a `.tsm.tmp` file already exists (really it's assuming that another compaction goroutine is currently taking care of the compaction).

In two specific points in the compaction logic it's possible to trigger the situation where the `.tsm.tmp` files are left around but other compaction goroutines should _not_ treat this as an on-going compaction. In these cases we remove the `tsm.tmp` files.