### PR TITLE
Compress tombstone files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [#8480](https://github.com/influxdata/influxdb/pull/8480): Change the default stats interval to 1 second instead of 10 seconds.
 - [#8466](https://github.com/influxdata/influxdb/issues/8466): illumos build broken on syscall.Mmap
 - [#8124](https://github.com/influxdata/influxdb/issues/8124): Prevent privileges on non-existent databases from being set.
+- [#8558](https://github.com/influxdata/influxdb/issues/8558): Dropping measurement used several GB disk space
 
 ## v1.3.1 [unreleased]
 


### PR DESCRIPTION
This adds a v3 tombstone format that is a gzip compressed version of the v2
format.  It reduces the size of tombstone files substantially without
having to support a more feature rich file format for tombstones.  Prior versions can still be read, but new tombstone will use the v3 format.

Testing with 1M series and dropping all of them in my local env reduced disk usage for tombstone files from 397MB to 11MB.  Each file is about 98% smaller.

### Before
```
$ du -c -h *.tombstone
 99M	000000004-000000003.tombstone
 99M	000000008-000000003.tombstone
 99M	000000011-000000002.tombstone
 99M	000000012-000000001.tombstone
397M	total
```

### After
```
$ du -c -h *.tombstone
2.8M	000000004-000000003.tombstone
2.8M	000000008-000000003.tombstone
2.8M	000000011-000000002.tombstone
2.8M	000000012-000000001.tombstone
 11M	total
```

Fixes #8558 

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)