### PR TITLE
Log server error response messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#8669](https://github.com/influxdata/influxdb/pull/8669): TSI Index Migration Tool
 - [#7195](https://github.com/influxdata/influxdb/issues/7195): Support SHOW CARDINALITY queries.
 - [#8711](https://github.com/influxdata/influxdb/pull/8711): Batch up writes for monitor service
+- [#8572](https://github.com/influxdata/influxdb/pull/8572): All errors from queries or writes are available via X-InfluxDB-Error header, and 5xx error messages will be written to server logs.
 
 ### Bugfixes
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"runtime/debug"
@@ -956,14 +957,17 @@ func parseSystemDiagnostics(d *diagnostics.Diagnostics) (map[string]interface{},
 }
 
 // httpError writes an error to the client in a standard format.
-func (h *Handler) httpError(w http.ResponseWriter, error string, code int) {
+func (h *Handler) httpError(w http.ResponseWriter, errmsg string, code int) {
 	if code == http.StatusUnauthorized {
 		// If an unauthorized header will be sent back, add a WWW-Authenticate header
 		// as an authorization challenge.
 		w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=\"%s\"", h.Config.Realm))
+	} else if code/100 != 2 {
+		sz := math.Min(float64(len(errmsg)), 1024.0)
+		w.Header().Set("X-InfluxDB-Error", errmsg[:int(sz)])
 	}
 
-	response := Response{Err: errors.New(error)}
+	response := Response{Err: errors.New(errmsg)}
 	if rw, ok := w.(ResponseWriter); ok {
 		h.writeHeader(w, code)
 		rw.WriteResponse(response)
@@ -1180,6 +1184,14 @@ func (h *Handler) logging(inner http.Handler, name string) http.Handler {
 		l := &responseLogger{w: w}
 		inner.ServeHTTP(l, r)
 		h.CLFLogger.Println(buildLogLine(l, r, start))
+
+		// Log server errors.
+		if l.Status()/100 == 5 {
+			errStr := l.Header().Get("X-InfluxDB-Error")
+			if errStr != "" {
+				h.Logger.Error(fmt.Sprintf("[%d] - %q", l.Status(), errStr))
+			}
+		}
 	})
 }
 

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -40,6 +40,7 @@ func (l *responseLogger) Write(b []byte) (int, error) {
 		// Set status if WriteHeader has not been called
 		l.status = http.StatusOK
 	}
+
 	size, err := l.w.Write(b)
 	l.size += size
 	return size, err


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR provides more insight into server errors by both setting
the error on a response header, and, in the case of server errors `(5xx)`,
logging those error messages to the HTTP log, if:

```toml
[http] 
  log-enabled = true
```

So, a client error would be available via the response's `X-InfluxDB-Error` header, but wouldn't appear in the server logs. A `500` error would be in both the header and also appear in the server logs. In that case it would look something like:

```
[I] 2017-07-06T16:46:12Z Storing statistics in database '_internal' retention policy 'monitor', at interval 10s service=monitor
[I] 2017-07-06T16:46:12Z Sending usage statistics to usage.influxdata.com
[httpd] ::1 - - [06/Jul/2017:17:46:14 +0100] "POST /write?consistency=all&db=&precision=ns&rp= HTTP/1.1" 500 33 "-" "InfluxDBShell/unknown" 9fc4ecf8-626a-11e7-8001-000000000000 241
[E] 2017-07-06T16:46:14Z [500] - "some annoying error from deep within" service=httpd
```