### PR TITLE
Add X-Influxdb-Build  value to HTTP response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Features
 
+- [#8574](https://github.com/influxdata/influxdb/pull/8574): Add 'X-Influxdb-Build' to http response headers so users can identify if a response is from an OSS or Enterprise service.  
+	
 - [#8426](https://github.com/influxdata/influxdb/issues/8426): Add `parse-multivalue-plugin` to allow users to choose how multivalue plugins should be handled by the collectd service.
 - [#8548](https://github.com/influxdata/influxdb/issues/8548): Allow panic recovery to be disabled when investigating server issues.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 
 ### Features
 
-- [#8574](https://github.com/influxdata/influxdb/pull/8574): Add 'X-Influxdb-Build' to http response headers so users can identify if a response is from an OSS or Enterprise service.  
-	
+- [#8574](https://github.com/influxdata/influxdb/pull/8574): Add 'X-Influxdb-Build' to http response headers so users can identify if a response is from an OSS or Enterprise service.
 - [#8426](https://github.com/influxdata/influxdb/issues/8426): Add `parse-multivalue-plugin` to allow users to choose how multivalue plugins should be handled by the collectd service.
 - [#8548](https://github.com/influxdata/influxdb/issues/8548): Allow panic recovery to be disabled when investigating server issues.
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -262,6 +262,7 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 	srv.Handler.Monitor = s.Monitor
 	srv.Handler.PointsWriter = s.PointsWriter
 	srv.Handler.Version = s.buildInfo.Version
+	srv.Handler.BuildType = "OSS"
 
 	s.Services = append(s.Services, srv)
 }

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -68,8 +68,9 @@ type Route struct {
 
 // Handler represents an HTTP handler for the InfluxDB server.
 type Handler struct {
-	mux     *pat.PatternServeMux
-	Version string
+	mux       *pat.PatternServeMux
+	Version   string
+	BuildType string
 
 	MetaClient interface {
 		Database(name string) *meta.DatabaseInfo
@@ -249,8 +250,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer atomic.AddInt64(&h.stats.ActiveRequests, -1)
 	start := time.Now()
 
-	// Add version header to all InfluxDB requests.
+	// Add version and build header to all InfluxDB requests.
 	w.Header().Add("X-Influxdb-Version", h.Version)
+	w.Header().Add("X-Influxdb-Build", h.BuildType)
 
 	if strings.HasPrefix(r.URL.Path, "/debug/pprof") && h.Config.PprofEnabled {
 		h.handleProfiles(w, r)
@@ -1150,6 +1152,7 @@ func cors(inner http.Handler) http.Handler {
 			w.Header().Set(`Access-Control-Expose-Headers`, strings.Join([]string{
 				`Date`,
 				`X-InfluxDB-Version`,
+				`X-InfluxDB-Build`,
 			}, ", "))
 		}
 

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -582,6 +582,14 @@ func TestHandler_Version(t *testing.T) {
 		} else {
 			t.Fatalf("Header entry 'X-Influxdb-Version' not present")
 		}
+
+		if v, ok := w.HeaderMap["X-Influxdb-Build"]; ok {
+			if v[0] != "OSS" {
+				t.Fatalf("unexpected BuildType: %s", v)
+			}
+		} else {
+			t.Fatalf("Header entry 'X-Influxdb-Build' not present")
+		}
 	}
 }
 
@@ -717,6 +725,7 @@ func NewHandler(requireAuthentication bool) *Handler {
 	h.Handler.QueryAuthorizer = &h.QueryAuthorizer
 	h.Handler.PointsWriter = &h.PointsWriter
 	h.Handler.Version = "0.0.0"
+	h.Handler.BuildType = "OSS"
 	return h
 }
 

--- a/stress/stress_test.go
+++ b/stress/stress_test.go
@@ -390,6 +390,7 @@ func TestBasicQueryClient_Query(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(50 * time.Millisecond)
 		w.Header().Set("X-Influxdb-Version", "x.x")
+		w.Header().Set("X-Influxdb-Build", "OSS")
 		var data client.Response
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(data)


### PR DESCRIPTION
adds a new header key/value X-Influxdb-Build that has value OSS if called from open-source build, and ENT if called from enterprise.  This commit sets the value for the OSS case, and also creates the proper flag

###### Required for all non-trivial PRs
- [X ] Rebased/mergable
- [ X] Tests pass
- [ X] CHANGELOG.md updated
- [ X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [X ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com):  https://github.com/influxdata/docs.influxdata.com/issues/1190
