### PR TITLE
Fix index inconsistency after deletes

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -179,6 +179,8 @@ func NewEngine(id uint64, idx tsdb.Index, database, path string, walPath string,
 		compactionLimiter: opt.CompactionLimiter,
 	}
 
+	fs.OnReplace = e.onFileStoreReplace
+
 	// Attach fieldset to index.
 	e.index.SetFieldSet(e.fieldset)
 
@@ -521,7 +523,7 @@ func (e *Engine) LoadMetadataIndex(shardID uint64, index tsdb.Index) error {
 			return err
 		}
 
-		if err := e.addToIndexFromKey(key, fieldType, index); err != nil {
+		if err := e.addToIndexFromKey(key, fieldType); err != nil {
 			return err
 		}
 		return nil
@@ -536,7 +538,7 @@ func (e *Engine) LoadMetadataIndex(shardID uint64, index tsdb.Index) error {
 			e.logger.Info(fmt.Sprintf("error getting the data type of values for key %s: %s", key, err.Error()))
 		}
 
-		if err := e.addToIndexFromKey([]byte(key), fieldType, index); err != nil {
+		if err := e.addToIndexFromKey([]byte(key), fieldType); err != nil {
 			return err
 		}
 		return nil
@@ -735,7 +737,7 @@ func (e *Engine) overlay(r io.Reader, basePath string, asNew bool) error {
 			return err
 		}
 
-		if err := e.addToIndexFromKey(v.key, fieldType, e.index); err != nil {
+		if err := e.addToIndexFromKey(v.key, fieldType); err != nil {
 			return err
 		}
 	}
@@ -793,7 +795,7 @@ func (e *Engine) readFileFromBackup(tr *tar.Reader, shardRelativePath string, as
 
 // addToIndexFromKey will pull the measurement name, series key, and field name from a composite key and add it to the
 // database index and measurement fields
-func (e *Engine) addToIndexFromKey(key []byte, fieldType influxql.DataType, index tsdb.Index) error {
+func (e *Engine) addToIndexFromKey(key []byte, fieldType influxql.DataType) error {
 	seriesKey, field := SeriesAndFieldFromCompositeKey(key)
 	name := tsdb.MeasurementFromSeriesKey(seriesKey)
 
@@ -1227,9 +1229,59 @@ func (e *Engine) compactTSMFull(quit <-chan struct{}) {
 				// Release the files in the compaction plan
 				e.CompactionPlan.Release(s.compactionGroups)
 			}
-
 		}
 	}
+}
+
+// onFileStoreReplace is callback handler invoked when the FileStore
+// has replaced one set of TSM files with a new set.
+func (e *Engine) onFileStoreReplace(newFiles []TSMFile) {
+	// Load any new series keys to the index
+	readers := make([]chan seriesKey, 0, len(newFiles))
+	for _, r := range newFiles {
+		ch := make(chan seriesKey, 1)
+		readers = append(readers, ch)
+
+		go func(c chan seriesKey, r TSMFile) {
+			n := r.KeyCount()
+			for i := 0; i < n; i++ {
+				key, typ := r.KeyAt(i)
+				c <- seriesKey{key, typ}
+			}
+			close(c)
+		}(ch, r)
+	}
+
+	// Merge and dedup all the series keys across each reader to reduce
+	// lock contention on the index.
+	merged := merge(readers...)
+	for v := range merged {
+		fieldType, err := tsmFieldTypeToInfluxQLDataType(v.typ)
+		if err != nil {
+			e.logger.Error(fmt.Sprintf("refresh index (1): %v", err))
+			continue
+		}
+
+		if err := e.addToIndexFromKey(v.key, fieldType); err != nil {
+			e.logger.Error(fmt.Sprintf("refresh index (2): %v", err))
+			continue
+		}
+	}
+
+	// load metadata from the Cache
+	e.Cache.ApplyEntryFn(func(key string, entry *entry) error {
+		fieldType, err := entry.values.InfluxQLType()
+		if err != nil {
+			e.logger.Error(fmt.Sprintf("refresh index (3): %v", err))
+			return nil
+		}
+
+		if err := e.addToIndexFromKey([]byte(key), fieldType); err != nil {
+			e.logger.Error(fmt.Sprintf("refresh index (4): %v", err))
+			return nil
+		}
+		return nil
+	})
 }
 
 // compactionStrategy holds the details of what to do in a compaction.

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -136,6 +136,9 @@ type FileStore struct {
 	purger *purger
 
 	currentTempDirID int
+
+	// Callback of files that are being added to the filestore
+	OnReplace func(r []TSMFile)
 }
 
 // FileStat holds information about a TSM file on disk.
@@ -544,6 +547,10 @@ func (f *FileStore) Replace(oldFiles, newFiles []string) error {
 			return err
 		}
 		updated = append(updated, tsm)
+	}
+
+	if f.OnReplace != nil {
+		f.OnReplace(updated)
 	}
 
 	f.mu.Lock()

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -895,7 +895,7 @@ func (d *indirectIndex) OverlapsTimeRange(min, max int64) bool {
 
 // OverlapsKeyRange returns true if the min and max keys of the file overlap the arguments min and max.
 func (d *indirectIndex) OverlapsKeyRange(min, max string) bool {
-	return d.minKey <= max && d.maxKey >= max
+	return d.minKey <= max && d.maxKey >= min
 }
 
 // KeyRange returns the min and max keys in the index.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes an issue where the inmem index would be inconsistent with the data stored on disk.  It also fixes a bug where deletes do not write tombstones for data that should be deleted.

The inconsistency can occur under write load to a measurement and concurrently dropping the measurement.  There is a race where the incoming writes create index entries, but the writes have not hit the cache/wal yet.  The delete completes and removes them series from the index and then the write completes and stores the data on disk.  The end result is that the data is on disk, but the index is inconsistent and is not aware that it exists within the shard.  Restarting the server causes the index to be reloaded and the data appears again.

There wasn't a good way to fix this without significantly reworking how the index and engine work together or introducing a lot of lock contention mainly to handle this cases of deletes.  I went with an approach that refreshes the index from the newly compacted files as well as what is remaining in the cache when the files are installed for use.  This resolves the issue, but there can be a brief period of time between when the the delete removes the series from the index and before the index is refreshed where series can appear missing.