### PR TITLE
Fix indefinite hang in WAL.writeToLog

### DIFF
--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -246,7 +246,6 @@ func (l *WAL) scheduleSync() {
 
 	// Fsync the wal and notify all pending waiters
 	go func() {
-		defer atomic.StoreUint64(&l.syncCount, 0)
 		var timerCh <-chan time.Time
 
 		// time.NewTicker requires a > 0 delay, since 0 indicates no delay, use a closed
@@ -267,6 +266,7 @@ func (l *WAL) scheduleSync() {
 			case <-timerCh:
 				l.mu.Lock()
 				if len(l.syncWaiters) == 0 {
+					atomic.StoreUint64(&l.syncCount, 0)
 					l.mu.Unlock()
 					return
 				}
@@ -274,6 +274,7 @@ func (l *WAL) scheduleSync() {
 				l.sync()
 				l.mu.Unlock()
 			case <-l.closing:
+				atomic.StoreUint64(&l.syncCount, 0)
 				return
 			}
 		}


### PR DESCRIPTION
There was a race in the WAL writeToLog and scheduleSync which could
lead to a writing goroutine blocking indefinitely on its syncErr channel.

The issue was that the clearing of the syncCount happenend after the
wal was unlocked.  If a goroutine was able to lock, write and call scheduleSync
before the existing scheduleSync goroutine returns and ran the defer to
clear the syncCount, then a new scheduleSync goroutine would not get started again.
This left the writing goroutine blocked with nothing to signal it.

While in this state, a RLock on the engine was held.  If a Lock was requested
on the engine during this time, all future writes and queries would block waiting
on the blocked wal writer.

The fix is to move the atomic clearing of syncCount before the Lock is released so that a new scheduleSync goroutine can be started again.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
