### PR TITLE
Fix duplicate points returned after delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - [#8559](https://github.com/influxdata/influxdb/issues/8559): Ensure temporary TSM files get cleaned up when compaction aborted.
 - [#8500](https://github.com/influxdata/influxdb/issues/8500): InfluxDB goes unresponsive
+- [#8531](https://github.com/influxdata/influxdb/issues/8531): Duplicate points generated via INSERT after DELETE
 
 
 ## v1.3.0 [2017-06-21]

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -131,9 +131,11 @@ func (m *Measurement) SeriesIDs() SeriesIDs {
 		return s
 	}
 
+	m.sortedSeriesIDs = m.sortedSeriesIDs[:0]
 	if cap(m.sortedSeriesIDs) < len(m.seriesByID) {
 		m.sortedSeriesIDs = make(SeriesIDs, 0, len(m.seriesByID))
 	}
+
 	for k := range m.seriesByID {
 		m.sortedSeriesIDs = append(m.sortedSeriesIDs, k)
 	}
@@ -210,7 +212,7 @@ func (m *Measurement) AddSeries(s *Series) bool {
 
 	m.seriesByID[s.ID] = s
 
-	if len(m.sortedSeriesIDs) == 0 || s.ID > m.sortedSeriesIDs[len(m.sortedSeriesIDs)-1] {
+	if len(m.seriesByID) == 1 || (len(m.sortedSeriesIDs) == len(m.seriesByID)-1 && s.ID > m.sortedSeriesIDs[len(m.sortedSeriesIDs)-1]) {
 		m.sortedSeriesIDs = append(m.sortedSeriesIDs, s.ID)
 	}
 


### PR DESCRIPTION
The sortedSeriesIds slice was not getting reset to 0 which caused
the same series ids to exist in the slice more than once.  Since
the size of the slice never matched the size of the seriesID map,
it kept appendending to the slice and sorting it which cause multiple
cursor to get created for the same series.

Fixes #8531

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
