### PR TITLE
Adds mutex profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#8548](https://github.com/influxdata/influxdb/issues/8548): Allow panic recovery to be disabled when investigating server issues.
 - [#8525](https://github.com/influxdata/influxdb/issues/8525): Support http pipelining for /query endpoint.
 - [#8652](https://github.com/influxdata/influxdb/pull/8652): Reduce allocations when reading data
+- [#8592](https://github.com/influxdata/influxdb/pull/8592): Mutex profiles are now available.
 
 ### Bugfixes
 
@@ -87,7 +88,7 @@ The following new configuration options are available.
 
 ### Features
 
-- [#8512](https://github.com/influxdata/influxdb/pull/8512): Switch to LogLog-Beta Cardinality estimation 
+- [#8512](https://github.com/influxdata/influxdb/pull/8512): Switch to LogLog-Beta Cardinality estimation
 - [#8143](https://github.com/influxdata/influxdb/pull/8143): Add WAL sync delay
 - [#7977](https://github.com/influxdata/influxdb/issues/7977): Add chunked request processing back into the Go client v2
 - [#7974](https://github.com/influxdata/influxdb/pull/7974): Allow non-admin users to execute SHOW DATABASES.

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -96,8 +96,9 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	if config.HTTPD.PprofEnabled {
-		// Turn on block profiling to debug stuck databases
+		// Turn on block and mutex profiling.
 		runtime.SetBlockProfileRate(int(1 * time.Second))
+		runtime.SetMutexProfileFraction(1) // Collect every sample
 	}
 
 	// Create server from config and start it.

--- a/services/httpd/pprof.go
+++ b/services/httpd/pprof.go
@@ -44,6 +44,7 @@ type prof struct {
 //	- goroutine profile
 //	- heap profile
 //	- blocking profile
+//	- mutex profile
 //	- (optionally) CPU profile
 //
 // It also collects the following query results:
@@ -70,6 +71,7 @@ func (h *Handler) archiveProfilesAndQueries(w http.ResponseWriter, r *http.Reque
 	var allProfs = []*prof{
 		{Name: "goroutine", Debug: 1},
 		{Name: "block", Debug: 1},
+		{Name: "mutex", Debug: 1},
 		{Name: "heap", Debug: 1},
 	}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Mutex profiles are now available via the:

  - /debug/pprof/mutex
  - /debug/pprof/all

endpoints.

