### PR TITLE
#6563 Support Ctrl+C to cancel a running query in the Influx CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#8611](https://github.com/influxdata/influxdb/issues/8611): Respect X-Request-Id/Request-Id headers.
 - [#8572](https://github.com/influxdata/influxdb/issues/8668): InfluxDB now uses MIT licensed version of BurntSushi/toml.
 - [#8752](https://github.com/influxdata/influxdb/pull/8752): Use system cursors for measurement, series, and tag key meta queries.
+- [#6563](https://github.com/influxdata/influxdb/issues/6563): Support Ctrl+C to cancel a running query in the Influx CLI. Thanks @emluque!
 
 ### Bugfixes
 

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -180,6 +180,12 @@ func (c *Client) SetPrecision(precision string) {
 
 // Query sends a command to the server and returns the Response
 func (c *Client) Query(q Query) (*Response, error) {
+	return c.QueryContext(context.Background(), q)
+}
+
+// QueryContext sends a command to the server and returns the Response
+// It uses a context that can be cancelled by the command line client
+func (c *Client) QueryContext(ctx context.Context, q Query) (*Response, error) {
 	u := c.url
 
 	u.Path = "query"
@@ -205,6 +211,8 @@ func (c *Client) Query(q Query) (*Response, error) {
 	if c.username != "" {
 		req.SetBasicAuth(c.username, c.password)
 	}
+
+	req = req.WithContext(ctx)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/cmd/influx/cli/cli_test.go
+++ b/cmd/influx/cli/cli_test.go
@@ -76,6 +76,45 @@ func TestRunCLI_ExecuteInsert(t *testing.T) {
 	}
 }
 
+func TestRunCLI_WithSignals(t *testing.T) {
+	t.Parallel()
+	ts := emptyTestServer()
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL)
+	h, p, _ := net.SplitHostPort(u.Host)
+	c := cli.New(CLIENT_VERSION)
+	c.Host = h
+	c.Port, _ = strconv.Atoi(p)
+	c.IgnoreSignals = false
+	c.ForceTTY = true
+	go func() {
+		close(c.Quit)
+	}()
+	if err := c.Run(); err != nil {
+		t.Fatalf("Run failed with error: %s", err)
+	}
+}
+
+func TestRunCLI_ExecuteInsert_WithSignals(t *testing.T) {
+	t.Parallel()
+	ts := emptyTestServer()
+	defer ts.Close()
+
+	u, _ := url.Parse(ts.URL)
+	h, p, _ := net.SplitHostPort(u.Host)
+	c := cli.New(CLIENT_VERSION)
+	c.Host = h
+	c.Port, _ = strconv.Atoi(p)
+	c.ClientConfig.Precision = "ms"
+	c.Execute = "INSERT sensor,floor=1 value=2"
+	c.IgnoreSignals = false
+	c.ForceTTY = true
+	if err := c.Run(); err != nil {
+		t.Fatalf("Run failed with error: %s", err)
+	}
+}
+
 func TestSetAuth(t *testing.T) {
 	t.Parallel()
 	c := cli.New(CLIENT_VERSION)


### PR DESCRIPTION
Fixes #6563

Solved the issue by using context on the http request on the client.
Some common functionality between the queries with context and the ones without it was extracted to avoid code duplication.
Wrote tests for everything.

###### Required for all non-trivial PRs
- [ X] Rebased/mergable
- [ X] Tests pass
- [ ] CHANGELOG.md updated
- [ X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
