### PR TITLE
Remove react library from dependencies licences

### DIFF
--- a/LICENSE_OF_DEPENDENCIES.md
+++ b/LICENSE_OF_DEPENDENCIES.md
@@ -23,4 +23,3 @@
 - glyphicons [LICENSE](http://glyphicons.com/license/)
 - golang.org/x/crypto [BSD LICENSE](https://github.com/golang/crypto/blob/master/LICENSE)
 - jquery 2.1.4 [MIT LICENSE](https://github.com/jquery/jquery/blob/master/LICENSE.txt)
-- react 0.13.3 [BSD LICENSE](https://github.com/facebook/react/blob/master/LICENSE)


### PR DESCRIPTION
The react library was removed when the admin gui was removed;
however, a reference to the library lingered in the third
party license file.

backports influxdata/plutonium#1426