### PR TITLE
Fix time zone shifts when the shift happens on a time zone boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#8569](https://github.com/influxdata/influxdb/issues/8569): Fix the cq start and end times to use unix timestamps.
 - [#8601](https://github.com/influxdata/influxdb/pull/8601): Fixed time boundaries for continuous queries with time zones.
 - [#8097](https://github.com/influxdata/influxdb/pull/8097): Return query parsing errors in CSV formats.
+- [#8607](https://github.com/influxdata/influxdb/issues/8607): Fix time zone shifts when the shift happens on a time zone boundary.
 
 ## v1.3.1 [unreleased]
 

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -726,7 +726,7 @@ func (itr *floatFillIterator) Next() (*FloatPoint, error) {
 	// Check to see if we have passed over an offset change and adjust the time
 	// to account for this new offset.
 	if itr.opt.Location != nil {
-		if _, offset := itr.opt.Zone(itr.window.time); offset != itr.window.offset {
+		if _, offset := itr.opt.Zone(itr.window.time - 1); offset != itr.window.offset {
 			diff := itr.window.offset - offset
 			if abs(diff) < int64(itr.opt.Interval.Duration) {
 				itr.window.time += diff
@@ -4073,7 +4073,7 @@ func (itr *integerFillIterator) Next() (*IntegerPoint, error) {
 	// Check to see if we have passed over an offset change and adjust the time
 	// to account for this new offset.
 	if itr.opt.Location != nil {
-		if _, offset := itr.opt.Zone(itr.window.time); offset != itr.window.offset {
+		if _, offset := itr.opt.Zone(itr.window.time - 1); offset != itr.window.offset {
 			diff := itr.window.offset - offset
 			if abs(diff) < int64(itr.opt.Interval.Duration) {
 				itr.window.time += diff
@@ -7403,7 +7403,7 @@ func (itr *unsignedFillIterator) Next() (*UnsignedPoint, error) {
 	// Check to see if we have passed over an offset change and adjust the time
 	// to account for this new offset.
 	if itr.opt.Location != nil {
-		if _, offset := itr.opt.Zone(itr.window.time); offset != itr.window.offset {
+		if _, offset := itr.opt.Zone(itr.window.time - 1); offset != itr.window.offset {
 			diff := itr.window.offset - offset
 			if abs(diff) < int64(itr.opt.Interval.Duration) {
 				itr.window.time += diff
@@ -10733,7 +10733,7 @@ func (itr *stringFillIterator) Next() (*StringPoint, error) {
 	// Check to see if we have passed over an offset change and adjust the time
 	// to account for this new offset.
 	if itr.opt.Location != nil {
-		if _, offset := itr.opt.Zone(itr.window.time); offset != itr.window.offset {
+		if _, offset := itr.opt.Zone(itr.window.time - 1); offset != itr.window.offset {
 			diff := itr.window.offset - offset
 			if abs(diff) < int64(itr.opt.Interval.Duration) {
 				itr.window.time += diff
@@ -14063,7 +14063,7 @@ func (itr *booleanFillIterator) Next() (*BooleanPoint, error) {
 	// Check to see if we have passed over an offset change and adjust the time
 	// to account for this new offset.
 	if itr.opt.Location != nil {
-		if _, offset := itr.opt.Zone(itr.window.time); offset != itr.window.offset {
+		if _, offset := itr.opt.Zone(itr.window.time - 1); offset != itr.window.offset {
 			diff := itr.window.offset - offset
 			if abs(diff) < int64(itr.opt.Interval.Duration) {
 				itr.window.time += diff

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -727,7 +727,7 @@ func (itr *{{$k.name}}FillIterator) Next() (*{{$k.Name}}Point, error) {
 	// Check to see if we have passed over an offset change and adjust the time
 	// to account for this new offset.
 	if itr.opt.Location != nil {
-		if _, offset := itr.opt.Zone(itr.window.time); offset != itr.window.offset {
+		if _, offset := itr.opt.Zone(itr.window.time - 1); offset != itr.window.offset {
 			diff := itr.window.offset - offset
 			if abs(diff) < int64(itr.opt.Interval.Duration) {
 				itr.window.time += diff

--- a/influxql/iterator_test.go
+++ b/influxql/iterator_test.go
@@ -705,235 +705,224 @@ func TestLimitIterator(t *testing.T) {
 	}
 }
 
-func TestFillIterator_DST_Start_GroupByDay_Ascending(t *testing.T) {
-	start := time.Date(2000, 4, 1, 0, 0, 0, 0, LosAngeles)
-	end := time.Date(2000, 4, 5, 0, 0, 0, 0, LosAngeles).Add(-time.Nanosecond)
-	itr := influxql.NewFillIterator(
-		&FloatIterator{Points: []influxql.FloatPoint{{Time: start.UnixNano(), Value: 0}}},
-		nil,
-		influxql.IteratorOptions{
-			StartTime: start.UnixNano(),
-			EndTime:   end.UnixNano(),
-			Interval: influxql.Interval{
-				Duration: 24 * time.Hour,
+func TestFillIterator_DST(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		start, end time.Time
+		points     []time.Duration
+		opt        influxql.IteratorOptions
+	}{
+		{
+			name:  "Start_GroupByDay_Ascending",
+			start: mustParseTime("2000-04-01T00:00:00-08:00"),
+			end:   mustParseTime("2000-04-05T00:00:00-07:00"),
+			points: []time.Duration{
+				24 * time.Hour,
+				47 * time.Hour,
+				71 * time.Hour,
 			},
-			Location:  LosAngeles,
-			Ascending: true,
-		},
-	)
-
-	if a, err := (Iterators{itr}).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: start.UnixNano(), Value: 0}},
-		{&influxql.FloatPoint{Time: start.Add(24 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(47 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(71 * time.Hour).UnixNano(), Nil: true}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
-	}
-}
-
-func TestFillIterator_DST_Start_GroupByDay_Descending(t *testing.T) {
-	start := time.Date(2000, 4, 1, 0, 0, 0, 0, LosAngeles)
-	end := time.Date(2000, 4, 5, 0, 0, 0, 0, LosAngeles).Add(-time.Nanosecond)
-	itr := influxql.NewFillIterator(
-		&FloatIterator{Points: []influxql.FloatPoint{{Time: start.UnixNano(), Value: 0}}},
-		nil,
-		influxql.IteratorOptions{
-			StartTime: start.UnixNano(),
-			EndTime:   end.UnixNano(),
-			Interval: influxql.Interval{
-				Duration: 24 * time.Hour,
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 24 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: true,
 			},
-			Location:  LosAngeles,
-			Ascending: false,
 		},
-	)
-
-	if a, err := (Iterators{itr}).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: start.Add(71 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(47 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(24 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.UnixNano(), Value: 0}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
-	}
-}
-
-func TestFillIterator_DST_Start_GroupByHour_Ascending(t *testing.T) {
-	start := time.Date(2000, 4, 2, 0, 0, 0, 0, LosAngeles)
-	end := start.Add(4*time.Hour - time.Nanosecond)
-	itr := influxql.NewFillIterator(
-		&FloatIterator{Points: []influxql.FloatPoint{{Time: start.UnixNano(), Value: 0}}},
-		nil,
-		influxql.IteratorOptions{
-			StartTime: start.UnixNano(),
-			EndTime:   end.UnixNano(),
-			Interval: influxql.Interval{
-				Duration: time.Hour,
+		{
+			name:  "Start_GroupByDay_Descending",
+			start: mustParseTime("2000-04-01T00:00:00-08:00"),
+			end:   mustParseTime("2000-04-05T00:00:00-07:00"),
+			points: []time.Duration{
+				71 * time.Hour,
+				47 * time.Hour,
+				24 * time.Hour,
 			},
-			Location:  LosAngeles,
-			Ascending: true,
-		},
-	)
-
-	if a, err := (Iterators{itr}).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: start.UnixNano(), Value: 0}},
-		{&influxql.FloatPoint{Time: start.Add(1 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(2 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(3 * time.Hour).UnixNano(), Nil: true}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
-	}
-}
-
-func TestFillIterator_DST_Start_GroupByHour_Descending(t *testing.T) {
-	start := time.Date(2000, 4, 2, 0, 0, 0, 0, LosAngeles)
-	end := start.Add(4*time.Hour - time.Nanosecond)
-	itr := influxql.NewFillIterator(
-		&FloatIterator{Points: []influxql.FloatPoint{{Time: start.UnixNano(), Value: 0}}},
-		nil,
-		influxql.IteratorOptions{
-			StartTime: start.UnixNano(),
-			EndTime:   end.UnixNano(),
-			Interval: influxql.Interval{
-				Duration: time.Hour,
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 24 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: false,
 			},
-			Location:  LosAngeles,
-			Ascending: false,
 		},
-	)
-
-	if a, err := (Iterators{itr}).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: start.Add(3 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(2 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(1 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.UnixNano(), Value: 0}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
-	}
-}
-
-func TestFillIterator_DST_End_GroupByDay_Ascending(t *testing.T) {
-	start := time.Date(2000, 10, 28, 0, 0, 0, 0, LosAngeles)
-	end := time.Date(2000, 11, 1, 0, 0, 0, 0, LosAngeles).Add(-time.Nanosecond)
-	itr := influxql.NewFillIterator(
-		&FloatIterator{Points: []influxql.FloatPoint{{Time: start.UnixNano(), Value: 0}}},
-		nil,
-		influxql.IteratorOptions{
-			StartTime: start.UnixNano(),
-			EndTime:   end.UnixNano(),
-			Interval: influxql.Interval{
-				Duration: 24 * time.Hour,
+		{
+			name:  "Start_GroupByHour_Ascending",
+			start: mustParseTime("2000-04-02T00:00:00-08:00"),
+			end:   mustParseTime("2000-04-02T05:00:00-07:00"),
+			points: []time.Duration{
+				1 * time.Hour,
+				2 * time.Hour,
+				3 * time.Hour,
 			},
-			Location:  LosAngeles,
-			Ascending: true,
-		},
-	)
-
-	if a, err := (Iterators{itr}).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: start.UnixNano(), Value: 0}},
-		{&influxql.FloatPoint{Time: start.Add(24 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(49 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(73 * time.Hour).UnixNano(), Nil: true}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
-	}
-}
-
-func TestFillIterator_DST_End_GroupByDay_Descending(t *testing.T) {
-	start := time.Date(2000, 10, 28, 0, 0, 0, 0, LosAngeles)
-	end := time.Date(2000, 11, 1, 0, 0, 0, 0, LosAngeles).Add(-time.Nanosecond)
-	itr := influxql.NewFillIterator(
-		&FloatIterator{Points: []influxql.FloatPoint{{Time: start.UnixNano(), Value: 0}}},
-		nil,
-		influxql.IteratorOptions{
-			StartTime: start.UnixNano(),
-			EndTime:   end.UnixNano(),
-			Interval: influxql.Interval{
-				Duration: 24 * time.Hour,
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 1 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: true,
 			},
-			Location:  LosAngeles,
-			Ascending: false,
 		},
-	)
-
-	if a, err := (Iterators{itr}).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: start.Add(73 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(49 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(24 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.UnixNano(), Value: 0}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
-	}
-}
-
-func TestFillIterator_DST_End_GroupByHour_Ascending(t *testing.T) {
-	start := time.Date(2000, 10, 29, 0, 0, 0, 0, LosAngeles)
-	end := start.Add(4*time.Hour - time.Nanosecond)
-	itr := influxql.NewFillIterator(
-		&FloatIterator{Points: []influxql.FloatPoint{{Time: start.UnixNano(), Value: 0}}},
-		nil,
-		influxql.IteratorOptions{
-			StartTime: start.UnixNano(),
-			EndTime:   end.UnixNano(),
-			Interval: influxql.Interval{
-				Duration: time.Hour,
+		{
+			name:  "Start_GroupByHour_Descending",
+			start: mustParseTime("2000-04-02T00:00:00-08:00"),
+			end:   mustParseTime("2000-04-02T05:00:00-07:00"),
+			points: []time.Duration{
+				3 * time.Hour,
+				2 * time.Hour,
+				1 * time.Hour,
 			},
-			Location:  LosAngeles,
-			Ascending: true,
-		},
-	)
-
-	if a, err := (Iterators{itr}).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: start.UnixNano(), Value: 0}},
-		{&influxql.FloatPoint{Time: start.Add(1 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(2 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(3 * time.Hour).UnixNano(), Nil: true}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
-	}
-}
-
-func TestFillIterator_DST_End_GroupByHour_Descending(t *testing.T) {
-	start := time.Date(2000, 10, 29, 0, 0, 0, 0, LosAngeles)
-	end := start.Add(4*time.Hour - time.Nanosecond)
-	itr := influxql.NewFillIterator(
-		&FloatIterator{Points: []influxql.FloatPoint{{Time: start.UnixNano(), Value: 0}}},
-		nil,
-		influxql.IteratorOptions{
-			StartTime: start.UnixNano(),
-			EndTime:   end.UnixNano(),
-			Interval: influxql.Interval{
-				Duration: time.Hour,
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 1 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: false,
 			},
-			Location:  LosAngeles,
-			Ascending: false,
 		},
-	)
+		{
+			name:  "Start_GroupBy2Hour_Ascending",
+			start: mustParseTime("2000-04-02T00:00:00-08:00"),
+			end:   mustParseTime("2000-04-02T07:00:00-07:00"),
+			points: []time.Duration{
+				2 * time.Hour,
+				3 * time.Hour,
+				5 * time.Hour,
+			},
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 2 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: true,
+			},
+		},
+		{
+			name:  "Start_GroupBy2Hour_Descending",
+			start: mustParseTime("2000-04-02T00:00:00-08:00"),
+			end:   mustParseTime("2000-04-02T07:00:00-07:00"),
+			points: []time.Duration{
+				5 * time.Hour,
+				3 * time.Hour,
+				2 * time.Hour,
+			},
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 2 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: false,
+			},
+		},
+		{
+			name:  "End_GroupByDay_Ascending",
+			start: mustParseTime("2000-10-28T00:00:00-07:00"),
+			end:   mustParseTime("2000-11-01T00:00:00-08:00"),
+			points: []time.Duration{
+				24 * time.Hour,
+				49 * time.Hour,
+				73 * time.Hour,
+			},
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 24 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: true,
+			},
+		},
+		{
+			name:  "End_GroupByDay_Descending",
+			start: mustParseTime("2000-10-28T00:00:00-07:00"),
+			end:   mustParseTime("2000-11-01T00:00:00-08:00"),
+			points: []time.Duration{
+				73 * time.Hour,
+				49 * time.Hour,
+				24 * time.Hour,
+			},
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 24 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: false,
+			},
+		},
+		{
+			name:  "End_GroupByHour_Ascending",
+			start: mustParseTime("2000-10-29T00:00:00-07:00"),
+			end:   mustParseTime("2000-10-29T03:00:00-08:00"),
+			points: []time.Duration{
+				1 * time.Hour,
+				2 * time.Hour,
+				3 * time.Hour,
+			},
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 1 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: true,
+			},
+		},
+		{
+			name:  "End_GroupByHour_Descending",
+			start: mustParseTime("2000-10-29T00:00:00-07:00"),
+			end:   mustParseTime("2000-10-29T03:00:00-08:00"),
+			points: []time.Duration{
+				3 * time.Hour,
+				2 * time.Hour,
+				1 * time.Hour,
+			},
+			opt: influxql.IteratorOptions{
+				Interval: influxql.Interval{
+					Duration: 1 * time.Hour,
+				},
+				Location:  LosAngeles,
+				Ascending: false,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			opt := tt.opt
+			opt.StartTime = tt.start.UnixNano()
+			opt.EndTime = tt.end.UnixNano() - 1
 
-	if a, err := (Iterators{itr}).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]influxql.Point{
-		{&influxql.FloatPoint{Time: start.Add(3 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(2 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.Add(1 * time.Hour).UnixNano(), Nil: true}},
-		{&influxql.FloatPoint{Time: start.UnixNano(), Value: 0}},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
+			points := make([][]influxql.Point, 0, len(tt.points)+1)
+			if opt.Ascending {
+				points = append(points, []influxql.Point{
+					&influxql.FloatPoint{
+						Time: tt.start.UnixNano(),
+					},
+				})
+			}
+			for _, d := range tt.points {
+				points = append(points, []influxql.Point{
+					&influxql.FloatPoint{
+						Time: tt.start.Add(d).UnixNano(),
+						Nil:  true,
+					},
+				})
+			}
+			if !opt.Ascending {
+				points = append(points, []influxql.Point{
+					&influxql.FloatPoint{
+						Time: tt.start.UnixNano(),
+					},
+				})
+			}
+			itr := influxql.NewFillIterator(
+				&FloatIterator{Points: []influxql.FloatPoint{{Time: tt.start.UnixNano(), Value: 0}}},
+				nil,
+				opt,
+			)
+
+			if a, err := (Iterators{itr}).ReadAll(); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			} else if !deep.Equal(a, points) {
+				t.Fatalf("unexpected points: %s", spew.Sdump(a))
+			}
+		})
 	}
 }
 
@@ -1047,23 +1036,99 @@ func TestIteratorOptions_Window_Default(t *testing.T) {
 }
 
 func TestIteratorOptions_Window_Location(t *testing.T) {
-	now := time.Date(2000, 4, 2, 12, 14, 15, 0, LosAngeles)
-	opt := influxql.IteratorOptions{
-		Location: LosAngeles,
-		Interval: influxql.Interval{
-			Duration: 24 * time.Hour,
+	for _, tt := range []struct {
+		now        time.Time
+		start, end time.Time
+		interval   time.Duration
+	}{
+		{
+			now:      mustParseTime("2000-04-02T12:14:15-07:00"),
+			start:    mustParseTime("2000-04-02T00:00:00-08:00"),
+			end:      mustParseTime("2000-04-03T00:00:00-07:00"),
+			interval: 24 * time.Hour,
 		},
-	}
-
-	start, end := opt.Window(now.UnixNano())
-	if exp := time.Date(2000, 4, 2, 0, 0, 0, 0, LosAngeles).UnixNano(); start != exp {
-		t.Errorf("expected start to be %d, got %d", exp, start)
-	}
-	if exp := time.Date(2000, 4, 3, 0, 0, 0, 0, LosAngeles).UnixNano(); end != exp {
-		t.Errorf("expected end to be %d, got %d", exp, end)
-	}
-	if got, exp := time.Duration(end-start), 23*time.Hour; got != exp {
-		t.Errorf("expected duration to be %s, got %s", exp, got)
+		{
+			now:      mustParseTime("2000-04-02T01:17:12-08:00"),
+			start:    mustParseTime("2000-04-02T00:00:00-08:00"),
+			end:      mustParseTime("2000-04-03T00:00:00-07:00"),
+			interval: 24 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-04-02T01:14:15-08:00"),
+			start:    mustParseTime("2000-04-02T00:00:00-08:00"),
+			end:      mustParseTime("2000-04-02T03:00:00-07:00"),
+			interval: 2 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-04-02T03:17:12-07:00"),
+			start:    mustParseTime("2000-04-02T03:00:00-07:00"),
+			end:      mustParseTime("2000-04-02T04:00:00-07:00"),
+			interval: 2 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-04-02T01:14:15-08:00"),
+			start:    mustParseTime("2000-04-02T01:00:00-08:00"),
+			end:      mustParseTime("2000-04-02T03:00:00-07:00"),
+			interval: 1 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-04-02T03:17:12-07:00"),
+			start:    mustParseTime("2000-04-02T03:00:00-07:00"),
+			end:      mustParseTime("2000-04-02T04:00:00-07:00"),
+			interval: 1 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-10-29T12:14:15-08:00"),
+			start:    mustParseTime("2000-10-29T00:00:00-07:00"),
+			end:      mustParseTime("2000-10-30T00:00:00-08:00"),
+			interval: 24 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-10-29T01:17:12-07:00"),
+			start:    mustParseTime("2000-10-29T00:00:00-07:00"),
+			end:      mustParseTime("2000-10-30T00:00:00-08:00"),
+			interval: 24 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-10-29T01:14:15-07:00"),
+			start:    mustParseTime("2000-10-29T00:00:00-07:00"),
+			end:      mustParseTime("2000-10-29T02:00:00-08:00"),
+			interval: 2 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-10-29T03:17:12-08:00"),
+			start:    mustParseTime("2000-10-29T02:00:00-08:00"),
+			end:      mustParseTime("2000-10-29T04:00:00-08:00"),
+			interval: 2 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-10-29T01:14:15-07:00"),
+			start:    mustParseTime("2000-10-29T01:00:00-07:00"),
+			end:      mustParseTime("2000-10-29T01:00:00-08:00"),
+			interval: 1 * time.Hour,
+		},
+		{
+			now:      mustParseTime("2000-10-29T02:17:12-07:00"),
+			start:    mustParseTime("2000-10-29T02:00:00-07:00"),
+			end:      mustParseTime("2000-10-29T03:00:00-07:00"),
+			interval: 1 * time.Hour,
+		},
+	} {
+		t.Run(fmt.Sprintf("%s/%s", tt.now, tt.interval), func(t *testing.T) {
+			opt := influxql.IteratorOptions{
+				Location: LosAngeles,
+				Interval: influxql.Interval{
+					Duration: tt.interval,
+				},
+			}
+			start, end := opt.Window(tt.now.UnixNano())
+			if have, want := time.Unix(0, start).In(LosAngeles), tt.start; !have.Equal(want) {
+				t.Errorf("unexpected start time: %s != %s", have, want)
+			}
+			if have, want := time.Unix(0, end).In(LosAngeles), tt.end; !have.Equal(want) {
+				t.Errorf("unexpected end time: %s != %s", have, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
When a time zone shift happened at the edge of a time bucket, the logic
was incorrect. When we added an hour to the day with a time grouping of
2 hours, we took the hour away from the previous bucket instead of the
next bucket so the first bucket of the day would be from midnight to 1
AM and the second bucket would include 1 AM to 4 AM (2 AM to 3 AM does
not exist when shifting forwards). The correct buckets should have been
12 AM to 2 AM for the first bucket of the day and 3 AM to 4 AM for the
second (since 2 AM to 3 AM does not exist).

This also modifies the tests to use table tests and sub tests.

Fixes #8607.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated