### PR TITLE
Add go1.9 and tsi builders to circle

### DIFF
--- a/Dockerfile_build_ubuntu64_go19
+++ b/Dockerfile_build_ubuntu64_go19
@@ -1,0 +1,38 @@
+FROM ubuntu:trusty
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    python-software-properties \
+    software-properties-common \
+    wget \
+    git \
+    mercurial \
+    make \
+    ruby \
+    ruby-dev \
+    rpm \
+    zip \
+    python \
+    python-boto \
+    asciidoc \
+    xmlto \
+    docbook-xsl
+
+RUN gem install fpm
+
+# Install go
+ENV GOPATH /root/go
+ENV GO_VERSION 1.9beta2
+ENV GO_ARCH amd64
+RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
+   tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz ; \
+   rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+ENV PATH /usr/local/go/bin:$PATH
+
+ENV PROJECT_DIR $GOPATH/src/github.com/influxdata/influxdb
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p $PROJECT_DIR
+WORKDIR $PROJECT_DIR
+
+VOLUME $PROJECT_DIR
+
+ENTRYPOINT [ "/root/go/src/github.com/influxdata/influxdb/build.py" ]

--- a/client/influxdb_test.go
+++ b/client/influxdb_test.go
@@ -539,7 +539,7 @@ func TestEpochToTime(t *testing.T) {
 		if e != nil {
 			t.Fatalf("unexpected error: expected %v, actual: %v", nil, e)
 		}
-		if tm != test.expected {
+		if !tm.Equal(test.expected) {
 			t.Fatalf("unexpected time: expected %v, actual %v", test.expected, tm)
 		}
 	}

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,7 @@
 #      1: race enabled 64bit tests
 #      2: normal 32bit tests
 #      3: tsi build
+#      4: go 1.9
 #      save: build the docker images and save them to DOCKER_SAVE_DIR. Do not run tests.
 #      count: print the number of test environments
 #      *: to run all tests in parallel containers
@@ -34,7 +35,7 @@ TIMEOUT=${TIMEOUT-960s}
 DOCKER_RM=${DOCKER_RM-true}
 
 # Update this value if you add a new test environment.
-ENV_COUNT=4
+ENV_COUNT=5
 
 # Default return code 0
 rc=0
@@ -152,7 +153,12 @@ case $ENVIRONMENT_INDEX in
         run_test_docker Dockerfile_build_ubuntu64 test_64bit --test --junit-report
         rc=$?
         ;;
-    "save")
+    4)
+        # go1.9
+        run_test_docker Dockerfile_build_ubuntu64_go19 test_64bit --test --junit-report
+        rc=$?
+        ;;
+     "save")
         # Save docker images for every Dockerfile_build* file.
         # Useful for creating an external cache.
         pids=()

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,8 @@
 # Corresponding environments for environment_index:
 #      0: normal 64bit tests
 #      1: race enabled 64bit tests
-#      3: normal 32bit tests
+#      2: normal 32bit tests
+#      3: tsi build
 #      save: build the docker images and save them to DOCKER_SAVE_DIR. Do not run tests.
 #      count: print the number of test environments
 #      *: to run all tests in parallel containers
@@ -33,7 +34,7 @@ TIMEOUT=${TIMEOUT-960s}
 DOCKER_RM=${DOCKER_RM-true}
 
 # Update this value if you add a new test environment.
-ENV_COUNT=3
+ENV_COUNT=4
 
 # Default return code 0
 rc=0
@@ -143,6 +144,12 @@ case $ENVIRONMENT_INDEX in
     2)
         # 32 bit tests
         run_test_docker Dockerfile_build_ubuntu32 test_32bit --test --junit-report --arch=i386
+        rc=$?
+        ;;
+    3)
+        # tsi
+        INFLUXDB_DATA_INDEX_VERSION="tsi1"
+        run_test_docker Dockerfile_build_ubuntu64 test_64bit --test --junit-report
         rc=$?
         ;;
     "save")


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This adds two additional builders with PR tests runs. One for running tests with `tsi` and another for building with `go1.9beta2`.  

The 1.9 build is failing with:

```
--- FAIL: TestEpochToTime (0.00s)
	influxdb_test.go:537: testing "nanoseconds"
	influxdb_test.go:543: unexpected time: expected 2017-07-21 18:27:15.383167702 +0000 UTC m=+0.060328980, actual 2017-07-21 18:27:15.383167702 +0000 UTC
```