### PR TITLE
Support pre-existing request ID headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [#8711](https://github.com/influxdata/influxdb/pull/8711): Batch up writes for monitor service
 - [#8572](https://github.com/influxdata/influxdb/pull/8572): All errors from queries or writes are available via X-InfluxDB-Error header, and 5xx error messages will be written to server logs.
 - [#8662](https://github.com/influxdata/influxdb/pull/8662): Improve test coverage across both indexes.
+- [#8611](https://github.com/influxdata/influxdb/issues/8611): Respect X-Request-Id/Request-Id headers.
 
 ### Bugfixes
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Implements #8611.

Other applications or services sometimes expose a header containing a
unique ID, which can then be included in logging or response information
to allow an operator to link inter-service requests. The most common
header name used by services in the wild appears to be `X-Request-Id`,
but `Request-Id` is also used.

This commit adds support for specifying either `X-Request-Id` or
`Request-Id` headers, which will then be used by InfluxDB when logging
request information, and also in the `X-Request-Id` and `Request-Id`
response headers.

In the HTTP response, we populate both `X-Request-Id` and `Request-Id` to maintain backwards
compatibility with previous version, and to support the more common
`X-Request-Id` header name.

If both `X-Request-Id` and `Request-Id` are specified, then
`X-Request-Id` is used.

If neither header is specified, then in line with previous behaviour, we
generate a v1 UUID.