### PR TITLE
Ensure Windows builds tested with Go 1.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ clone_folder: c:\gopath\src\github.com\influxdata\influxdb
 
 # Environment variables
 environment:
-  GOROOT: C:\go17
+  GOROOT: C:\go18
   GOPATH: C:\gopath
 
 # Scripts that run after cloning repository


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated

Appveyor hadn't been updated to test with Go 1.8.