### PR TITLE
Prevent excessive memory usage when dropping series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - [#8601](https://github.com/influxdata/influxdb/pull/8601): Fixed time boundaries for continuous queries with time zones.
 - [#8097](https://github.com/influxdata/influxdb/pull/8097): Return query parsing errors in CSV formats.
 
+## v1.3.2 [unreleased]
+
+- [#8630](https://github.com/influxdata/influxdb/pull/8630): Prevent excessive memory usage when dropping series
+
 ## v1.3.1 [unreleased]
 
 ### Bugfixes


### PR DESCRIPTION
There was a change to speed up deleting and dropping measurements
that executed the deletes in parallel for all shards at once around the time 1.0 was released (#7015).

When TSI was merged in #7618, the series keys passed into `Shard.DeleteMeasurement`
were removed and were expanded lower down.  This causes memory to blow up
when a delete across many shards occurs as we now expand the set of series
keys N times (1 for each shard) instead of just once as before.  We actually didn't expand them in the old version since the in-memory index slice was passed in directly.  This isn't possible in TSI though.

While running the deletes in parallel would be ideal, there have been a number
of optimizations in the delete path that make running deletes serially pretty
good.  This change just limits the concurrency of the deletes which keeps memory
more stable.  I think we can still get back to running them concurrently, but that would involve a much larger interface change.

In my local tests, dropping 1M series in 75 shards went from `1m33s` to `3.9s` using `drop measurement`, but degraded from `2m37s` to `3m25s` when using `delete from cpu`.  Memory usage now only uses a few hundred MB instead of ballooning to several GBs.  

### Before
![screen shot 2017-07-25 at 4 57 56 pm](https://user-images.githubusercontent.com/219935/28597311-7414c4d0-715a-11e7-9cef-f3a3f6cfe223.png)

### After
![screen shot 2017-07-25 at 5 00 15 pm](https://user-images.githubusercontent.com/219935/28597398-c659699e-715a-11e7-8ccc-8f78271894bd.png)


###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

