### PR TITLE
Test that bound params generate single statement

### DIFF
--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -81,6 +81,21 @@ func TestParser_ParseQuery_NoSemicolon(t *testing.T) {
 	}
 }
 
+func TestParser_ParseBoundParameter(t *testing.T) {
+	parser := influxql.NewParser(strings.NewReader(`SELECT * FROM m WHERE t = $v`))
+	params := map[string]interface{}{
+		"v": "1; select * from m where t = v",
+	}
+	parser.SetParams(params)
+	q, err := parser.ParseQuery()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(q.Statements) != 1 {
+		t.Fatalf("bound query parameter injected a statement")
+	}
+}
+
 // Ensure the parser can parse strings into Statement ASTs.
 func TestParser_ParseStatement(t *testing.T) {
 	// For use in various tests.


### PR DESCRIPTION
Scratches an itch - I was curious about sql injection and a few days ago and noticed @mark-rushakoff answered a community question pointing to bound parameters. I wrote a test case to prove to myself that bound parameters don't parse to two statements.  

Thoughts? Reasonable test case?
