### PR TITLE
update xxhash and use Sum64String to avoid allocs

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -2,7 +2,7 @@ collectd.org e84e8af5356e7f47485bbc95c96da6dd7984a67e
 github.com/BurntSushi/toml 99064174e013895bbd9b025c31100bd1d9b590ca
 github.com/bmizerany/pat c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c
 github.com/boltdb/bolt 4b1ebc1869ad66568b313d0dc410e2be72670dda
-github.com/cespare/xxhash 4a94f899c20bc44d4f5f807cb14529e72aca99d6
+github.com/cespare/xxhash 1b6d2e40c16ba0dfce5c8eac2480ad6e7394819b
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
 github.com/dgrijalva/jwt-go 24c63f56522a87ec5339cc3567883f1039378fdb
 github.com/dgryski/go-bits 2ad8d707cc05b1815ce6ff2543bb5e8d8f9298ef

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -92,7 +92,7 @@ func (r *ring) reset() {
 // getPartition retrieves the hash ring partition associated with the provided
 // key.
 func (r *ring) getPartition(key string) *partition {
-	return r.continuum[int(xxhash.Sum64([]byte(key))%partitions)]
+	return r.continuum[int(xxhash.Sum64String(key)%partitions)]
 }
 
 // entry returns the entry for the given key.
@@ -240,7 +240,7 @@ func (p *partition) write(key string, values Values) error {
 	}
 
 	// Create a new entry using a preallocated size if we have a hint available.
-	hint, _ := p.entrySizeHints[xxhash.Sum64([]byte(key))]
+	hint, _ := p.entrySizeHints[xxhash.Sum64String(key)]
 	e, err := newEntryValues(values, hint)
 	if err != nil {
 		return err
@@ -289,7 +289,7 @@ func (p *partition) reset() {
 		// Store a hint to pre-allocate the next time we see the same entry.
 		entry.mu.RLock()
 		if cap(entry.values) > 128 { // 4 x the default entry capacity size.
-			p.entrySizeHints[xxhash.Sum64([]byte(k))] = cap(entry.values)
+			p.entrySizeHints[xxhash.Sum64String(k)] = cap(entry.values)
 		}
 		entry.mu.RUnlock()
 	}

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -63,7 +63,29 @@ func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(
 func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(256), 10000) }
 func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(256), 100000) }
 
+func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
+	vals := make([]string, keys)
+
+	// Add some keys
+	for i := 0; i < keys; i++ {
+		vals[i] = fmt.Sprintf("cpu,host=server-%d field1=value1,field2=value2,field4=value4,field5=value5,field6=value6,field7=value7,field8=value1,field9=value2,field10=value4,field11=value5,field12=value6,field13=value7", i)
+		r.add(vals[i], nil)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.getPartition(vals[i%keys])
+	}
+}
+
+func BenchmarkRing_getPartition_100(b *testing.B) { benchmarkRingGetPartition(b, MustNewRing(256), 100) }
+func BenchmarkRing_getPartition_1000(b *testing.B) {
+	benchmarkRingGetPartition(b, MustNewRing(256), 1000)
+}
+
 func benchmarkRingWrite(b *testing.B, r *ring, n int) {
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		var wg sync.WaitGroup
 		for i := 0; i < runtime.GOMAXPROCS(0); i++ {


### PR DESCRIPTION
```
± benchcmp ring_before.txt ring_after.txt
benchmark                             old ns/op     new ns/op     delta
BenchmarkRing_getPartition_100-8      108           48.1          -55.46%
BenchmarkRing_getPartition_1000-8     113           48.9          -56.73%

benchmark                             old allocs     new allocs     delta
BenchmarkRing_getPartition_100-8      1              0              -100.00%
BenchmarkRing_getPartition_1000-8     1              0              -100.00%

benchmark                             old bytes     new bytes     delta
BenchmarkRing_getPartition_100-8      192           0             -100.00%
BenchmarkRing_getPartition_1000-8     192           0             -100.00%
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
