### PR TITLE
SHOW CARDINALITY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#8652](https://github.com/influxdata/influxdb/pull/8652): Reduce allocations when reading data
 - [#8592](https://github.com/influxdata/influxdb/pull/8592): Mutex profiles are now available.
 - [#8669](https://github.com/influxdata/influxdb/pull/8669): TSI Index Migration Tool
+- [#7195](https://github.com/influxdata/influxdb/issues/7195): Support SHOW CARDINALITY queries.
 
 ### Bugfixes
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -153,6 +153,7 @@ func (*ShowRetentionPoliciesStatement) node() {}
 func (*ShowMeasurementsStatement) node()      {}
 func (*ShowQueriesStatement) node()           {}
 func (*ShowSeriesStatement) node()            {}
+func (*ShowSeriesCardinalityStatement) node() {}
 func (*ShowShardGroupsStatement) node()       {}
 func (*ShowShardsStatement) node()            {}
 func (*ShowStatsStatement) node()             {}
@@ -268,6 +269,7 @@ func (*ShowMeasurementsStatement) stmt()      {}
 func (*ShowQueriesStatement) stmt()           {}
 func (*ShowRetentionPoliciesStatement) stmt() {}
 func (*ShowSeriesStatement) stmt()            {}
+func (*ShowSeriesCardinalityStatement) stmt() {}
 func (*ShowShardGroupsStatement) stmt()       {}
 func (*ShowShardsStatement) stmt()            {}
 func (*ShowStatsStatement) stmt()             {}
@@ -2757,6 +2759,47 @@ func (s *DropShardStatement) String() string {
 // DropShardStatement.
 func (s *DropShardStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
+}
+
+// ShowSeriesCardinalityStatement represents a command for listing series cardinality.
+type ShowSeriesCardinalityStatement struct {
+	// Database to query. If blank, use the default database.
+	// The database can also be specified per source in the Sources.
+	Database string
+
+	// Measurement(s) the series are listed for.
+	Sources Sources
+
+	// An expression evaluated on a series name or tag.
+	Condition Expr
+
+	// Expressions used for grouping the selection.
+	Dimensions Dimensions
+}
+
+// String returns a string representation of the show continuous queries statement.
+func (s *ShowSeriesCardinalityStatement) String() string {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("SHOW SERIES CARDINALITY")
+
+	if s.Database != "" {
+		_, _ = buf.WriteString(" ON ")
+		_, _ = buf.WriteString(QuoteIdent(s.Database))
+	}
+	if s.Sources != nil {
+		_, _ = buf.WriteString(" FROM ")
+		_, _ = buf.WriteString(s.Sources.String())
+	}
+	if s.Condition != nil {
+		_, _ = buf.WriteString(" WHERE ")
+		_, _ = buf.WriteString(s.Condition.String())
+	}
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege required to execute a ShowSeriesCardinalityStatement.
+func (s *ShowSeriesCardinalityStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
+	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
 }
 
 // ShowContinuousQueriesStatement represents a command for listing continuous queries.

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -121,47 +121,51 @@ type Node interface {
 func (*Query) node()     {}
 func (Statements) node() {}
 
-func (*AlterRetentionPolicyStatement) node()  {}
-func (*CreateContinuousQueryStatement) node() {}
-func (*CreateDatabaseStatement) node()        {}
-func (*CreateRetentionPolicyStatement) node() {}
-func (*CreateSubscriptionStatement) node()    {}
-func (*CreateUserStatement) node()            {}
-func (*Distinct) node()                       {}
-func (*DeleteSeriesStatement) node()          {}
-func (*DeleteStatement) node()                {}
-func (*DropContinuousQueryStatement) node()   {}
-func (*DropDatabaseStatement) node()          {}
-func (*DropMeasurementStatement) node()       {}
-func (*DropRetentionPolicyStatement) node()   {}
-func (*DropSeriesStatement) node()            {}
-func (*DropShardStatement) node()             {}
-func (*DropSubscriptionStatement) node()      {}
-func (*DropUserStatement) node()              {}
-func (*GrantStatement) node()                 {}
-func (*GrantAdminStatement) node()            {}
-func (*KillQueryStatement) node()             {}
-func (*RevokeStatement) node()                {}
-func (*RevokeAdminStatement) node()           {}
-func (*SelectStatement) node()                {}
-func (*SetPasswordUserStatement) node()       {}
-func (*ShowContinuousQueriesStatement) node() {}
-func (*ShowGrantsForUserStatement) node()     {}
-func (*ShowDatabasesStatement) node()         {}
-func (*ShowFieldKeysStatement) node()         {}
-func (*ShowRetentionPoliciesStatement) node() {}
-func (*ShowMeasurementsStatement) node()      {}
-func (*ShowQueriesStatement) node()           {}
-func (*ShowSeriesStatement) node()            {}
-func (*ShowSeriesCardinalityStatement) node() {}
-func (*ShowShardGroupsStatement) node()       {}
-func (*ShowShardsStatement) node()            {}
-func (*ShowStatsStatement) node()             {}
-func (*ShowSubscriptionsStatement) node()     {}
-func (*ShowDiagnosticsStatement) node()       {}
-func (*ShowTagKeysStatement) node()           {}
-func (*ShowTagValuesStatement) node()         {}
-func (*ShowUsersStatement) node()             {}
+func (*AlterRetentionPolicyStatement) node()       {}
+func (*CreateContinuousQueryStatement) node()      {}
+func (*CreateDatabaseStatement) node()             {}
+func (*CreateRetentionPolicyStatement) node()      {}
+func (*CreateSubscriptionStatement) node()         {}
+func (*CreateUserStatement) node()                 {}
+func (*Distinct) node()                            {}
+func (*DeleteSeriesStatement) node()               {}
+func (*DeleteStatement) node()                     {}
+func (*DropContinuousQueryStatement) node()        {}
+func (*DropDatabaseStatement) node()               {}
+func (*DropMeasurementStatement) node()            {}
+func (*DropRetentionPolicyStatement) node()        {}
+func (*DropSeriesStatement) node()                 {}
+func (*DropShardStatement) node()                  {}
+func (*DropSubscriptionStatement) node()           {}
+func (*DropUserStatement) node()                   {}
+func (*GrantStatement) node()                      {}
+func (*GrantAdminStatement) node()                 {}
+func (*KillQueryStatement) node()                  {}
+func (*RevokeStatement) node()                     {}
+func (*RevokeAdminStatement) node()                {}
+func (*SelectStatement) node()                     {}
+func (*SetPasswordUserStatement) node()            {}
+func (*ShowContinuousQueriesStatement) node()      {}
+func (*ShowGrantsForUserStatement) node()          {}
+func (*ShowDatabasesStatement) node()              {}
+func (*ShowFieldKeyCardinalityStatement) node()    {}
+func (*ShowFieldKeysStatement) node()              {}
+func (*ShowRetentionPoliciesStatement) node()      {}
+func (*ShowMeasurementCardinalityStatement) node() {}
+func (*ShowMeasurementsStatement) node()           {}
+func (*ShowQueriesStatement) node()                {}
+func (*ShowSeriesStatement) node()                 {}
+func (*ShowSeriesCardinalityStatement) node()      {}
+func (*ShowShardGroupsStatement) node()            {}
+func (*ShowShardsStatement) node()                 {}
+func (*ShowStatsStatement) node()                  {}
+func (*ShowSubscriptionsStatement) node()          {}
+func (*ShowDiagnosticsStatement) node()            {}
+func (*ShowTagKeyCardinalityStatement) node()      {}
+func (*ShowTagKeysStatement) node()                {}
+func (*ShowTagValuesCardinalityStatement) node()   {}
+func (*ShowTagValuesStatement) node()              {}
+func (*ShowUsersStatement) node()                  {}
 
 func (*BinaryExpr) node()      {}
 func (*BooleanLiteral) node()  {}
@@ -243,46 +247,50 @@ type ExecutionPrivilege struct {
 // ExecutionPrivileges is a list of privileges required to execute a statement.
 type ExecutionPrivileges []ExecutionPrivilege
 
-func (*AlterRetentionPolicyStatement) stmt()  {}
-func (*CreateContinuousQueryStatement) stmt() {}
-func (*CreateDatabaseStatement) stmt()        {}
-func (*CreateRetentionPolicyStatement) stmt() {}
-func (*CreateSubscriptionStatement) stmt()    {}
-func (*CreateUserStatement) stmt()            {}
-func (*DeleteSeriesStatement) stmt()          {}
-func (*DeleteStatement) stmt()                {}
-func (*DropContinuousQueryStatement) stmt()   {}
-func (*DropDatabaseStatement) stmt()          {}
-func (*DropMeasurementStatement) stmt()       {}
-func (*DropRetentionPolicyStatement) stmt()   {}
-func (*DropSeriesStatement) stmt()            {}
-func (*DropSubscriptionStatement) stmt()      {}
-func (*DropUserStatement) stmt()              {}
-func (*GrantStatement) stmt()                 {}
-func (*GrantAdminStatement) stmt()            {}
-func (*KillQueryStatement) stmt()             {}
-func (*ShowContinuousQueriesStatement) stmt() {}
-func (*ShowGrantsForUserStatement) stmt()     {}
-func (*ShowDatabasesStatement) stmt()         {}
-func (*ShowFieldKeysStatement) stmt()         {}
-func (*ShowMeasurementsStatement) stmt()      {}
-func (*ShowQueriesStatement) stmt()           {}
-func (*ShowRetentionPoliciesStatement) stmt() {}
-func (*ShowSeriesStatement) stmt()            {}
-func (*ShowSeriesCardinalityStatement) stmt() {}
-func (*ShowShardGroupsStatement) stmt()       {}
-func (*ShowShardsStatement) stmt()            {}
-func (*ShowStatsStatement) stmt()             {}
-func (*DropShardStatement) stmt()             {}
-func (*ShowSubscriptionsStatement) stmt()     {}
-func (*ShowDiagnosticsStatement) stmt()       {}
-func (*ShowTagKeysStatement) stmt()           {}
-func (*ShowTagValuesStatement) stmt()         {}
-func (*ShowUsersStatement) stmt()             {}
-func (*RevokeStatement) stmt()                {}
-func (*RevokeAdminStatement) stmt()           {}
-func (*SelectStatement) stmt()                {}
-func (*SetPasswordUserStatement) stmt()       {}
+func (*AlterRetentionPolicyStatement) stmt()       {}
+func (*CreateContinuousQueryStatement) stmt()      {}
+func (*CreateDatabaseStatement) stmt()             {}
+func (*CreateRetentionPolicyStatement) stmt()      {}
+func (*CreateSubscriptionStatement) stmt()         {}
+func (*CreateUserStatement) stmt()                 {}
+func (*DeleteSeriesStatement) stmt()               {}
+func (*DeleteStatement) stmt()                     {}
+func (*DropContinuousQueryStatement) stmt()        {}
+func (*DropDatabaseStatement) stmt()               {}
+func (*DropMeasurementStatement) stmt()            {}
+func (*DropRetentionPolicyStatement) stmt()        {}
+func (*DropSeriesStatement) stmt()                 {}
+func (*DropSubscriptionStatement) stmt()           {}
+func (*DropUserStatement) stmt()                   {}
+func (*GrantStatement) stmt()                      {}
+func (*GrantAdminStatement) stmt()                 {}
+func (*KillQueryStatement) stmt()                  {}
+func (*ShowContinuousQueriesStatement) stmt()      {}
+func (*ShowGrantsForUserStatement) stmt()          {}
+func (*ShowDatabasesStatement) stmt()              {}
+func (*ShowFieldKeyCardinalityStatement) stmt()    {}
+func (*ShowFieldKeysStatement) stmt()              {}
+func (*ShowMeasurementCardinalityStatement) stmt() {}
+func (*ShowMeasurementsStatement) stmt()           {}
+func (*ShowQueriesStatement) stmt()                {}
+func (*ShowRetentionPoliciesStatement) stmt()      {}
+func (*ShowSeriesStatement) stmt()                 {}
+func (*ShowSeriesCardinalityStatement) stmt()      {}
+func (*ShowShardGroupsStatement) stmt()            {}
+func (*ShowShardsStatement) stmt()                 {}
+func (*ShowStatsStatement) stmt()                  {}
+func (*DropShardStatement) stmt()                  {}
+func (*ShowSubscriptionsStatement) stmt()          {}
+func (*ShowDiagnosticsStatement) stmt()            {}
+func (*ShowTagKeyCardinalityStatement) stmt()      {}
+func (*ShowTagKeysStatement) stmt()                {}
+func (*ShowTagValuesCardinalityStatement) stmt()   {}
+func (*ShowTagValuesStatement) stmt()              {}
+func (*ShowUsersStatement) stmt()                  {}
+func (*RevokeStatement) stmt()                     {}
+func (*RevokeAdminStatement) stmt()                {}
+func (*SelectStatement) stmt()                     {}
+func (*SetPasswordUserStatement) stmt()            {}
 
 // Expr represents an expression that can be evaluated to a value.
 type Expr interface {
@@ -2775,6 +2783,8 @@ type ShowSeriesCardinalityStatement struct {
 
 	// Expressions used for grouping the selection.
 	Dimensions Dimensions
+
+	Limit, Offset int
 }
 
 // String returns a string representation of the show continuous queries statement.
@@ -2794,12 +2804,28 @@ func (s *ShowSeriesCardinalityStatement) String() string {
 		_, _ = buf.WriteString(" WHERE ")
 		_, _ = buf.WriteString(s.Condition.String())
 	}
+	if len(s.Dimensions) > 0 {
+		_, _ = buf.WriteString(" GROUP BY ")
+		_, _ = buf.WriteString(s.Dimensions.String())
+	}
+	if s.Limit > 0 {
+		_, _ = fmt.Fprintf(&buf, " LIMIT %d", s.Limit)
+	}
+	if s.Offset > 0 {
+		_, _ = buf.WriteString(" OFFSET ")
+		_, _ = buf.WriteString(strconv.Itoa(s.Offset))
+	}
 	return buf.String()
 }
 
 // RequiredPrivileges returns the privilege required to execute a ShowSeriesCardinalityStatement.
 func (s *ShowSeriesCardinalityStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowSeriesCardinalityStatement) DefaultDatabase() string {
+	return s.Database
 }
 
 // ShowContinuousQueriesStatement represents a command for listing continuous queries.
@@ -2944,6 +2970,56 @@ func (s *DropContinuousQueryStatement) RequiredPrivileges() (ExecutionPrivileges
 
 // DefaultDatabase returns the default database from the statement.
 func (s *DropContinuousQueryStatement) DefaultDatabase() string {
+	return s.Database
+}
+
+// ShowMeasurementCardinalityStatement represents a command for listing measurement cardinality.
+type ShowMeasurementCardinalityStatement struct {
+	Database      string
+	Sources       Sources
+	Condition     Expr
+	Dimensions    Dimensions
+	Limit, Offset int
+}
+
+// String returns a string representation of the statement.
+func (s *ShowMeasurementCardinalityStatement) String() string {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("SHOW MEASUREMENT CARDINALITY")
+
+	if s.Database != "" {
+		_, _ = buf.WriteString(" ON ")
+		_, _ = buf.WriteString(QuoteIdent(s.Database))
+	}
+	if s.Sources != nil {
+		_, _ = buf.WriteString(" FROM ")
+		_, _ = buf.WriteString(s.Sources.String())
+	}
+	if s.Condition != nil {
+		_, _ = buf.WriteString(" WHERE ")
+		_, _ = buf.WriteString(s.Condition.String())
+	}
+	if len(s.Dimensions) > 0 {
+		_, _ = buf.WriteString(" GROUP BY ")
+		_, _ = buf.WriteString(s.Dimensions.String())
+	}
+	if s.Limit > 0 {
+		_, _ = fmt.Fprintf(&buf, " LIMIT %d", s.Limit)
+	}
+	if s.Offset > 0 {
+		_, _ = buf.WriteString(" OFFSET ")
+		_, _ = buf.WriteString(strconv.Itoa(s.Offset))
+	}
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege required to execute a ShowMeasurementCardinalityStatement.
+func (s *ShowMeasurementCardinalityStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
+	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowMeasurementCardinalityStatement) DefaultDatabase() string {
 	return s.Database
 }
 
@@ -3295,6 +3371,56 @@ func (s *ShowTagKeysStatement) DefaultDatabase() string {
 	return s.Database
 }
 
+// ShowTagKeyCardinalityStatement represents a command for listing tag key cardinality.
+type ShowTagKeyCardinalityStatement struct {
+	Database      string
+	Sources       Sources
+	Condition     Expr
+	Dimensions    Dimensions
+	Limit, Offset int
+}
+
+// String returns a string representation of the statement.
+func (s *ShowTagKeyCardinalityStatement) String() string {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("SHOW TAG KEY CARDINALITY")
+
+	if s.Database != "" {
+		_, _ = buf.WriteString(" ON ")
+		_, _ = buf.WriteString(QuoteIdent(s.Database))
+	}
+	if s.Sources != nil {
+		_, _ = buf.WriteString(" FROM ")
+		_, _ = buf.WriteString(s.Sources.String())
+	}
+	if s.Condition != nil {
+		_, _ = buf.WriteString(" WHERE ")
+		_, _ = buf.WriteString(s.Condition.String())
+	}
+	if len(s.Dimensions) > 0 {
+		_, _ = buf.WriteString(" GROUP BY ")
+		_, _ = buf.WriteString(s.Dimensions.String())
+	}
+	if s.Limit > 0 {
+		_, _ = fmt.Fprintf(&buf, " LIMIT %d", s.Limit)
+	}
+	if s.Offset > 0 {
+		_, _ = buf.WriteString(" OFFSET ")
+		_, _ = buf.WriteString(strconv.Itoa(s.Offset))
+	}
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege required to execute a ShowTagKeyCardinalityStatement.
+func (s *ShowTagKeyCardinalityStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
+	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowTagKeyCardinalityStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // ShowTagValuesStatement represents a command for listing tag values.
 type ShowTagValuesStatement struct {
 	// Database to query. If blank, use the default database.
@@ -3374,6 +3500,66 @@ func (s *ShowTagValuesStatement) DefaultDatabase() string {
 	return s.Database
 }
 
+// ShowTagValuesCardinalityStatement represents a command for listing tag value cardinality.
+type ShowTagValuesCardinalityStatement struct {
+	Database      string
+	Sources       Sources
+	Op            Token
+	TagKeyExpr    Literal
+	Condition     Expr
+	Dimensions    Dimensions
+	Limit, Offset int
+}
+
+// String returns a string representation of the statement.
+func (s *ShowTagValuesCardinalityStatement) String() string {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("SHOW TAG VALUES CARDINALITY")
+
+	if s.Database != "" {
+		_, _ = buf.WriteString(" ON ")
+		_, _ = buf.WriteString(QuoteIdent(s.Database))
+	}
+	if s.Sources != nil {
+		_, _ = buf.WriteString(" FROM ")
+		_, _ = buf.WriteString(s.Sources.String())
+	}
+	_, _ = buf.WriteString(" WITH KEY ")
+	_, _ = buf.WriteString(s.Op.String())
+	_, _ = buf.WriteString(" ")
+	if lit, ok := s.TagKeyExpr.(*StringLiteral); ok {
+		_, _ = buf.WriteString(QuoteIdent(lit.Val))
+	} else {
+		_, _ = buf.WriteString(s.TagKeyExpr.String())
+	}
+	if s.Condition != nil {
+		_, _ = buf.WriteString(" WHERE ")
+		_, _ = buf.WriteString(s.Condition.String())
+	}
+	if len(s.Dimensions) > 0 {
+		_, _ = buf.WriteString(" GROUP BY ")
+		_, _ = buf.WriteString(s.Dimensions.String())
+	}
+	if s.Limit > 0 {
+		_, _ = fmt.Fprintf(&buf, " LIMIT %d", s.Limit)
+	}
+	if s.Offset > 0 {
+		_, _ = buf.WriteString(" OFFSET ")
+		_, _ = buf.WriteString(strconv.Itoa(s.Offset))
+	}
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege required to execute a ShowTagValuesCardinalityStatement.
+func (s *ShowTagValuesCardinalityStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
+	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowTagValuesCardinalityStatement) DefaultDatabase() string {
+	return s.Database
+}
+
 // ShowUsersStatement represents a command for listing users.
 type ShowUsersStatement struct{}
 
@@ -3385,6 +3571,56 @@ func (s *ShowUsersStatement) String() string {
 // RequiredPrivileges returns the privilege(s) required to execute a ShowUsersStatement
 func (s *ShowUsersStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
 	return ExecutionPrivileges{{Admin: true, Name: "", Privilege: AllPrivileges}}, nil
+}
+
+// ShowFieldKeyCardinalityStatement represents a command for listing field key cardinality.
+type ShowFieldKeyCardinalityStatement struct {
+	Database      string
+	Sources       Sources
+	Condition     Expr
+	Dimensions    Dimensions
+	Limit, Offset int
+}
+
+// String returns a string representation of the statement.
+func (s *ShowFieldKeyCardinalityStatement) String() string {
+	var buf bytes.Buffer
+	_, _ = buf.WriteString("SHOW FIELD KEY CARDINALITY")
+
+	if s.Database != "" {
+		_, _ = buf.WriteString(" ON ")
+		_, _ = buf.WriteString(QuoteIdent(s.Database))
+	}
+	if s.Sources != nil {
+		_, _ = buf.WriteString(" FROM ")
+		_, _ = buf.WriteString(s.Sources.String())
+	}
+	if s.Condition != nil {
+		_, _ = buf.WriteString(" WHERE ")
+		_, _ = buf.WriteString(s.Condition.String())
+	}
+	if len(s.Dimensions) > 0 {
+		_, _ = buf.WriteString(" GROUP BY ")
+		_, _ = buf.WriteString(s.Dimensions.String())
+	}
+	if s.Limit > 0 {
+		_, _ = fmt.Fprintf(&buf, " LIMIT %d", s.Limit)
+	}
+	if s.Offset > 0 {
+		_, _ = buf.WriteString(" OFFSET ")
+		_, _ = buf.WriteString(strconv.Itoa(s.Offset))
+	}
+	return buf.String()
+}
+
+// RequiredPrivileges returns the privilege required to execute a ShowFieldKeyCardinalityStatement.
+func (s *ShowFieldKeyCardinalityStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
+	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+}
+
+// DefaultDatabase returns the default database from the statement.
+func (s *ShowFieldKeyCardinalityStatement) DefaultDatabase() string {
+	return s.Database
 }
 
 // ShowFieldKeysStatement represents a command for listing field keys.
@@ -4275,7 +4511,23 @@ func Walk(v Visitor, node Node) {
 		Walk(v, n.Condition)
 		Walk(v, n.SortFields)
 
+	case *ShowFieldKeyCardinalityStatement:
+		Walk(v, n.Sources)
+		Walk(v, n.Condition)
+
 	case *ShowSeriesStatement:
+		Walk(v, n.Sources)
+		Walk(v, n.Condition)
+
+	case *ShowSeriesCardinalityStatement:
+		Walk(v, n.Sources)
+		Walk(v, n.Condition)
+
+	case *ShowMeasurementCardinalityStatement:
+		Walk(v, n.Sources)
+		Walk(v, n.Condition)
+
+	case *ShowTagKeyCardinalityStatement:
 		Walk(v, n.Sources)
 		Walk(v, n.Condition)
 
@@ -4283,6 +4535,10 @@ func Walk(v Visitor, node Node) {
 		Walk(v, n.Sources)
 		Walk(v, n.Condition)
 		Walk(v, n.SortFields)
+
+	case *ShowTagValuesCardinalityStatement:
+		Walk(v, n.Sources)
+		Walk(v, n.Condition)
 
 	case *ShowTagValuesStatement:
 		Walk(v, n.Sources)

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -1790,11 +1790,16 @@ func Test_EnforceHasDefaultDatabase(t *testing.T) {
 		&influxql.GrantStatement{},
 		&influxql.RevokeStatement{},
 		&influxql.ShowFieldKeysStatement{},
+		&influxql.ShowFieldKeyCardinalityStatement{},
+		&influxql.ShowMeasurementCardinalityStatement{},
 		&influxql.ShowMeasurementsStatement{},
 		&influxql.ShowRetentionPoliciesStatement{},
 		&influxql.ShowSeriesStatement{},
+		&influxql.ShowSeriesCardinalityStatement{},
 		&influxql.ShowTagKeysStatement{},
+		&influxql.ShowTagKeyCardinalityStatement{},
 		&influxql.ShowTagValuesStatement{},
+		&influxql.ShowTagValuesCardinalityStatement{},
 	}
 
 	for _, stmt := range needsHasDefault {

--- a/influxql/parse_tree.go
+++ b/influxql/parse_tree.go
@@ -114,11 +114,21 @@ func init() {
 		show.Handle(DIAGNOSTICS, func(p *Parser) (Statement, error) {
 			return p.parseShowDiagnosticsStatement()
 		})
-		show.Group(FIELD).Handle(KEYS, func(p *Parser) (Statement, error) {
-			return p.parseShowFieldKeysStatement()
+		show.Group(FIELD).With(func(field *ParseTree) {
+			field.Handle(KEY, func(p *Parser) (Statement, error) {
+				return p.parseShowFieldKeyStatement()
+			})
+			field.Handle(KEYS, func(p *Parser) (Statement, error) {
+				return p.parseShowFieldKeysStatement()
+			})
 		})
 		show.Group(GRANTS).Handle(FOR, func(p *Parser) (Statement, error) {
 			return p.parseGrantsForUserStatement()
+		})
+		show.Group(MEASUREMENT).With(func(measurement *ParseTree) {
+			measurement.Handle(CARDINALITY, func(p *Parser) (Statement, error) {
+				return p.parseShowMeasurementCardinalityStatement()
+			})
 		})
 		show.Handle(MEASUREMENTS, func(p *Parser) (Statement, error) {
 			return p.parseShowMeasurementsStatement()
@@ -145,6 +155,11 @@ func init() {
 			return p.parseShowSubscriptionsStatement()
 		})
 		show.Group(TAG).With(func(tag *ParseTree) {
+			tag.Group(KEY).With(func(key *ParseTree) {
+				key.Handle(CARDINALITY, func(p *Parser) (Statement, error) {
+					return p.parseShowTagKeyCardinalityStatement()
+				})
+			})
 			tag.Handle(KEYS, func(p *Parser) (Statement, error) {
 				return p.parseShowTagKeysStatement()
 			})

--- a/influxql/parse_tree.go
+++ b/influxql/parse_tree.go
@@ -125,10 +125,8 @@ func init() {
 		show.Group(GRANTS).Handle(FOR, func(p *Parser) (Statement, error) {
 			return p.parseGrantsForUserStatement()
 		})
-		show.Group(MEASUREMENT).With(func(measurement *ParseTree) {
-			measurement.Handle(CARDINALITY, func(p *Parser) (Statement, error) {
-				return p.parseShowMeasurementCardinalityStatement()
-			})
+		show.Group(MEASUREMENT).Handle(CARDINALITY, func(p *Parser) (Statement, error) {
+			return p.parseShowMeasurementCardinalityStatement()
 		})
 		show.Handle(MEASUREMENTS, func(p *Parser) (Statement, error) {
 			return p.parseShowMeasurementsStatement()
@@ -155,10 +153,8 @@ func init() {
 			return p.parseShowSubscriptionsStatement()
 		})
 		show.Group(TAG).With(func(tag *ParseTree) {
-			tag.Group(KEY).With(func(key *ParseTree) {
-				key.Handle(CARDINALITY, func(p *Parser) (Statement, error) {
-					return p.parseShowTagKeyCardinalityStatement()
-				})
+			tag.Group(KEY).Handle(CARDINALITY, func(p *Parser) (Statement, error) {
+				return p.parseShowTagKeyCardinalityStatement()
 			})
 			tag.Handle(KEYS, func(p *Parser) (Statement, error) {
 				return p.parseShowTagKeysStatement()

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -900,16 +900,16 @@ func (p *Parser) parseDeleteStatement() (Statement, error) {
 	return stmt, nil
 }
 
-// parseShowSeriesStatement parses a string and returns a ShowSeriesStatement.
+// parseShowSeriesStatement parses a string and returns a Statement.
 // This function assumes the "SHOW SERIES" tokens have already been consumed.
 func (p *Parser) parseShowSeriesStatement() (Statement, error) {
 	stmt := &ShowSeriesStatement{}
 	var err error
 
-	if tok, _, _ := p.scanIgnoreWhitespace(); tok == CARDINALITY {
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == CARDINALITY {
 		return p.parseShowSeriesCardinalityStatement()
 	}
-	p.unscan()
+	p.Unscan()
 
 	// Parse optional ON clause.
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == ON {
@@ -956,48 +956,91 @@ func (p *Parser) parseShowSeriesStatement() (Statement, error) {
 
 // This function assumes the "SHOW SERIES CARDINALITY" tokens have already been consumed.
 func (p *Parser) parseShowSeriesCardinalityStatement() (Statement, error) {
+	var err error
 	stmt := &ShowSeriesCardinalityStatement{}
 
 	// Parse optional ON clause.
-	if tok, _, _ := p.scanIgnoreWhitespace(); tok == ON {
-		database, err := p.parseIdent()
-		if err != nil {
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == ON {
+		if stmt.Database, err = p.ParseIdent(); err != nil {
 			return nil, err
 		}
-		stmt.Database = database
 	} else {
-		p.unscan()
+		p.Unscan()
 	}
 
 	// Parse optional FROM.
-	if tok, _, _ := p.scanIgnoreWhitespace(); tok == FROM {
-		sources, err := p.parseSources(false)
-		if err != nil {
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == FROM {
+		if stmt.Sources, err = p.parseSources(false); err != nil {
 			return nil, err
 		}
-		stmt.Sources = sources
 	} else {
-		p.unscan()
+		p.Unscan()
 	}
 
 	// Parse condition: "WHERE EXPR".
-	condition, err := p.parseCondition()
-	if err != nil {
+	if stmt.Condition, err = p.parseCondition(); err != nil {
 		return nil, err
 	}
-	stmt.Condition = condition
 
 	// Parse dimensions: "GROUP BY DIMENSION+".
-	dimensions, err := p.parseDimensions()
-	if err != nil {
+	if stmt.Dimensions, err = p.parseDimensions(); err != nil {
 		return nil, err
 	}
-	stmt.Dimensions = dimensions
+
+	// Parse limit & offset: "LIMIT <n>", "OFFSET <n>".
+	if stmt.Limit, err = p.ParseOptionalTokenAndInt(LIMIT); err != nil {
+		return nil, err
+	} else if stmt.Offset, err = p.ParseOptionalTokenAndInt(OFFSET); err != nil {
+		return nil, err
+	}
 
 	return stmt, nil
 }
 
-// parseShowMeasurementsStatement parses a string and returns a ShowSeriesStatement.
+// This function assumes the "SHOW MEASUREMENT CARDINALITY" tokens have already been consumed.
+func (p *Parser) parseShowMeasurementCardinalityStatement() (Statement, error) {
+	stmt := &ShowMeasurementCardinalityStatement{}
+
+	// Parse optional ON clause.
+	var err error
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == ON {
+		if stmt.Database, err = p.ParseIdent(); err != nil {
+			return nil, err
+		}
+	} else {
+		p.Unscan()
+	}
+
+	// Parse optional FROM.
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == FROM {
+		if stmt.Sources, err = p.parseSources(false); err != nil {
+			return nil, err
+		}
+	} else {
+		p.Unscan()
+	}
+
+	// Parse condition: "WHERE EXPR".
+	if stmt.Condition, err = p.parseCondition(); err != nil {
+		return nil, err
+	}
+
+	// Parse dimensions: "GROUP BY DIMENSION+".
+	if stmt.Dimensions, err = p.parseDimensions(); err != nil {
+		return nil, err
+	}
+
+	// Parse limit & offset: "LIMIT <n>", "OFFSET <n>".
+	if stmt.Limit, err = p.ParseOptionalTokenAndInt(LIMIT); err != nil {
+		return nil, err
+	} else if stmt.Offset, err = p.ParseOptionalTokenAndInt(OFFSET); err != nil {
+		return nil, err
+	}
+
+	return stmt, nil
+}
+
+// parseShowMeasurementsStatement parses a string and returns a Statement.
 // This function assumes the "SHOW MEASUREMENTS" tokens have already been consumed.
 func (p *Parser) parseShowMeasurementsStatement() (*ShowMeasurementsStatement, error) {
 	stmt := &ShowMeasurementsStatement{}
@@ -1086,7 +1129,59 @@ func (p *Parser) parseShowRetentionPoliciesStatement() (*ShowRetentionPoliciesSt
 	return stmt, nil
 }
 
-// parseShowTagKeysStatement parses a string and returns a ShowSeriesStatement.
+// parseShowTagKeyStatement parses a string and returns a Statement.
+// This function assumes the "SHOW TAG KEY" tokens have already been consumed.
+func (p *Parser) parseShowTagKeyStatement() (Statement, error) {
+	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != CARDINALITY {
+		return nil, newParseError(tokstr(tok, lit), []string{"CARDINALITY"}, pos)
+	}
+	return p.parseShowTagKeyCardinalityStatement()
+}
+
+// This function assumes the "SHOW TAG KEY CARDINALITY" tokens have already been consumed.
+func (p *Parser) parseShowTagKeyCardinalityStatement() (Statement, error) {
+	var err error
+	stmt := &ShowTagKeyCardinalityStatement{}
+
+	// Parse optional ON clause.
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == ON {
+		if stmt.Database, err = p.ParseIdent(); err != nil {
+			return nil, err
+		}
+	} else {
+		p.Unscan()
+	}
+
+	// Parse optional FROM.
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == FROM {
+		if stmt.Sources, err = p.parseSources(false); err != nil {
+			return nil, err
+		}
+	} else {
+		p.Unscan()
+	}
+
+	// Parse condition: "WHERE EXPR".
+	if stmt.Condition, err = p.parseCondition(); err != nil {
+		return nil, err
+	}
+
+	// Parse dimensions: "GROUP BY DIMENSION+".
+	if stmt.Dimensions, err = p.parseDimensions(); err != nil {
+		return nil, err
+	}
+
+	// Parse limit & offset: "LIMIT <n>", "OFFSET <n>".
+	if stmt.Limit, err = p.ParseOptionalTokenAndInt(LIMIT); err != nil {
+		return nil, err
+	} else if stmt.Offset, err = p.ParseOptionalTokenAndInt(OFFSET); err != nil {
+		return nil, err
+	}
+
+	return stmt, nil
+}
+
+// parseShowTagKeysStatement parses a string and returns a Statement.
 // This function assumes the "SHOW TAG KEYS" tokens have already been consumed.
 func (p *Parser) parseShowTagKeysStatement() (*ShowTagKeysStatement, error) {
 	stmt := &ShowTagKeysStatement{}
@@ -1145,11 +1240,16 @@ func (p *Parser) parseShowTagKeysStatement() (*ShowTagKeysStatement, error) {
 	return stmt, nil
 }
 
-// parseShowTagValuesStatement parses a string and returns a ShowSeriesStatement.
+// parseShowTagValuesStatement parses a string and returns a Statement.
 // This function assumes the "SHOW TAG VALUES" tokens have already been consumed.
-func (p *Parser) parseShowTagValuesStatement() (*ShowTagValuesStatement, error) {
+func (p *Parser) parseShowTagValuesStatement() (Statement, error) {
 	stmt := &ShowTagValuesStatement{}
 	var err error
+
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == CARDINALITY {
+		return p.parseShowTagValuesCardinalityStatement()
+	}
+	p.Unscan()
 
 	// Parse optional ON clause.
 	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == ON {
@@ -1193,6 +1293,54 @@ func (p *Parser) parseShowTagValuesStatement() (*ShowTagValuesStatement, error) 
 
 	// Parse offset: "OFFSET <n>".
 	if stmt.Offset, err = p.ParseOptionalTokenAndInt(OFFSET); err != nil {
+		return nil, err
+	}
+
+	return stmt, nil
+}
+
+// This function assumes the "SHOW TAG VALUES CARDINALITY" tokens have already been consumed.
+func (p *Parser) parseShowTagValuesCardinalityStatement() (Statement, error) {
+	var err error
+	stmt := &ShowTagValuesCardinalityStatement{}
+
+	// Parse optional ON clause.
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == ON {
+		if stmt.Database, err = p.ParseIdent(); err != nil {
+			return nil, err
+		}
+	} else {
+		p.Unscan()
+	}
+
+	// Parse optional FROM.
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == FROM {
+		if stmt.Sources, err = p.parseSources(false); err != nil {
+			return nil, err
+		}
+	} else {
+		p.Unscan()
+	}
+
+	// Parse required WITH KEY.
+	if stmt.Op, stmt.TagKeyExpr, err = p.parseTagKeyExpr(); err != nil {
+		return nil, err
+	}
+
+	// Parse condition: "WHERE EXPR".
+	if stmt.Condition, err = p.parseCondition(); err != nil {
+		return nil, err
+	}
+
+	// Parse dimensions: "GROUP BY DIMENSION+".
+	if stmt.Dimensions, err = p.parseDimensions(); err != nil {
+		return nil, err
+	}
+
+	// Parse limit & offset: "LIMIT <n>", "OFFSET <n>".
+	if stmt.Limit, err = p.ParseOptionalTokenAndInt(LIMIT); err != nil {
+		return nil, err
+	} else if stmt.Offset, err = p.ParseOptionalTokenAndInt(OFFSET); err != nil {
 		return nil, err
 	}
 
@@ -1261,7 +1409,59 @@ func (p *Parser) parseShowSubscriptionsStatement() (*ShowSubscriptionsStatement,
 	return stmt, nil
 }
 
-// parseShowFieldKeysStatement parses a string and returns a ShowSeriesStatement.
+// parseShowFieldKeyStatement parses a string and returns a Statement.
+// This function assumes the "SHOW FIELD KEY" tokens have already been consumed.
+func (p *Parser) parseShowFieldKeyStatement() (Statement, error) {
+	if tok, pos, lit := p.ScanIgnoreWhitespace(); tok != CARDINALITY {
+		return nil, newParseError(tokstr(tok, lit), []string{"CARDINALITY"}, pos)
+	}
+	return p.parseShowFieldKeyCardinalityStatement()
+}
+
+// This function assumes the "SHOW FIELD KEY CARDINALITY" tokens have already been consumed.
+func (p *Parser) parseShowFieldKeyCardinalityStatement() (Statement, error) {
+	var err error
+	stmt := &ShowFieldKeyCardinalityStatement{}
+
+	// Parse optional ON clause.
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == ON {
+		if stmt.Database, err = p.ParseIdent(); err != nil {
+			return nil, err
+		}
+	} else {
+		p.Unscan()
+	}
+
+	// Parse optional FROM.
+	if tok, _, _ := p.ScanIgnoreWhitespace(); tok == FROM {
+		if stmt.Sources, err = p.parseSources(false); err != nil {
+			return nil, err
+		}
+	} else {
+		p.Unscan()
+	}
+
+	// Parse condition: "WHERE EXPR".
+	if stmt.Condition, err = p.parseCondition(); err != nil {
+		return nil, err
+	}
+
+	// Parse dimensions: "GROUP BY DIMENSION+".
+	if stmt.Dimensions, err = p.parseDimensions(); err != nil {
+		return nil, err
+	}
+
+	// Parse limit & offset: "LIMIT <n>", "OFFSET <n>".
+	if stmt.Limit, err = p.ParseOptionalTokenAndInt(LIMIT); err != nil {
+		return nil, err
+	} else if stmt.Offset, err = p.ParseOptionalTokenAndInt(OFFSET); err != nil {
+		return nil, err
+	}
+
+	return stmt, nil
+}
+
+// parseShowFieldKeysStatement parses a string and returns a Statement.
 // This function assumes the "SHOW FIELD KEYS" tokens have already been consumed.
 func (p *Parser) parseShowFieldKeysStatement() (*ShowFieldKeysStatement, error) {
 	stmt := &ShowFieldKeysStatement{}

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1529,6 +1529,12 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SHOW SERIES CARDINALITY statement
+		{
+			s:    `SHOW SERIES CARDINALITY`,
+			stmt: &influxql.ShowSeriesCardinalityStatement{},
+		},
+
 		// SHOW MEASUREMENTS WHERE with ORDER BY and LIMIT
 		{
 			skip: true,

--- a/influxql/parser_test.go
+++ b/influxql/parser_test.go
@@ -1535,6 +1535,59 @@ func TestParser_ParseStatement(t *testing.T) {
 			stmt: &influxql.ShowSeriesCardinalityStatement{},
 		},
 
+		// SHOW SERIES CARDINALITY FROM cpu
+		{
+			s: `SHOW SERIES CARDINALITY FROM cpu`,
+			stmt: &influxql.ShowSeriesCardinalityStatement{
+				Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+			},
+		},
+
+		// SHOW SERIES CARDINALITY ON db0
+		{
+			s: `SHOW SERIES CARDINALITY ON db0`,
+			stmt: &influxql.ShowSeriesCardinalityStatement{
+				Database: "db0",
+			},
+		},
+
+		// SHOW SERIES CARDINALITY FROM /<regex>/
+		{
+			s: `SHOW SERIES CARDINALITY FROM /[cg]pu/`,
+			stmt: &influxql.ShowSeriesCardinalityStatement{
+				Sources: []influxql.Source{
+					&influxql.Measurement{
+						Regex: &influxql.RegexLiteral{Val: regexp.MustCompile(`[cg]pu`)},
+					},
+				},
+			},
+		},
+
+		// SHOW SERIES CARDINALITY with OFFSET 0
+		{
+			s:    `SHOW SERIES CARDINALITY OFFSET 0`,
+			stmt: &influxql.ShowSeriesCardinalityStatement{Offset: 0},
+		},
+
+		// SHOW SERIES CARDINALITY with LIMIT 2 OFFSET 0
+		{
+			s:    `SHOW SERIES CARDINALITY LIMIT 2 OFFSET 0`,
+			stmt: &influxql.ShowSeriesCardinalityStatement{Offset: 0, Limit: 2},
+		},
+
+		// SHOW SERIES CARDINALITY WHERE with ORDER BY and LIMIT
+		{
+			s: `SHOW SERIES CARDINALITY WHERE region = 'order by desc' LIMIT 10`,
+			stmt: &influxql.ShowSeriesCardinalityStatement{
+				Condition: &influxql.BinaryExpr{
+					Op:  influxql.EQ,
+					LHS: &influxql.VarRef{Val: "region"},
+					RHS: &influxql.StringLiteral{Val: "order by desc"},
+				},
+				Limit: 10,
+			},
+		},
+
 		// SHOW MEASUREMENTS WHERE with ORDER BY and LIMIT
 		{
 			skip: true,
@@ -1580,6 +1633,65 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 
+		// SHOW MEASUREMENT CARDINALITY statement
+		{
+			s:    `SHOW MEASUREMENT CARDINALITY`,
+			stmt: &influxql.ShowMeasurementCardinalityStatement{},
+		},
+
+		// SHOW MEASUREMENT CARDINALITY FROM cpu
+		{
+			s: `SHOW MEASUREMENT CARDINALITY FROM cpu`,
+			stmt: &influxql.ShowMeasurementCardinalityStatement{
+				Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+			},
+		},
+
+		// SHOW MEASUREMENT CARDINALITY ON db0
+		{
+			s: `SHOW MEASUREMENT CARDINALITY ON db0`,
+			stmt: &influxql.ShowMeasurementCardinalityStatement{
+				Database: "db0",
+			},
+		},
+
+		// SHOW MEASUREMENT CARDINALITY FROM /<regex>/
+		{
+			s: `SHOW MEASUREMENT CARDINALITY FROM /[cg]pu/`,
+			stmt: &influxql.ShowMeasurementCardinalityStatement{
+				Sources: []influxql.Source{
+					&influxql.Measurement{
+						Regex: &influxql.RegexLiteral{Val: regexp.MustCompile(`[cg]pu`)},
+					},
+				},
+			},
+		},
+
+		// SHOW MEASUREMENT CARDINALITY with OFFSET 0
+		{
+			s:    `SHOW MEASUREMENT CARDINALITY OFFSET 0`,
+			stmt: &influxql.ShowMeasurementCardinalityStatement{Offset: 0},
+		},
+
+		// SHOW MEASUREMENT CARDINALITY with LIMIT 2 OFFSET 0
+		{
+			s:    `SHOW MEASUREMENT CARDINALITY LIMIT 2 OFFSET 0`,
+			stmt: &influxql.ShowMeasurementCardinalityStatement{Offset: 0, Limit: 2},
+		},
+
+		// SHOW MEASUREMENT CARDINALITY WHERE with ORDER BY and LIMIT
+		{
+			s: `SHOW MEASUREMENT CARDINALITY WHERE region = 'order by desc' LIMIT 10`,
+			stmt: &influxql.ShowMeasurementCardinalityStatement{
+				Condition: &influxql.BinaryExpr{
+					Op:  influxql.EQ,
+					LHS: &influxql.VarRef{Val: "region"},
+					RHS: &influxql.StringLiteral{Val: "order by desc"},
+				},
+				Limit: 10,
+			},
+		},
+
 		// SHOW QUERIES
 		{
 			s:    `SHOW QUERIES`,
@@ -1614,6 +1726,65 @@ func TestParser_ParseStatement(t *testing.T) {
 			s: `SHOW RETENTION POLICIES ON db0`,
 			stmt: &influxql.ShowRetentionPoliciesStatement{
 				Database: "db0",
+			},
+		},
+
+		// SHOW TAG KEY CARDINALITY statement
+		{
+			s:    `SHOW TAG KEY CARDINALITY`,
+			stmt: &influxql.ShowTagKeyCardinalityStatement{},
+		},
+
+		// SHOW TAG KEY CARDINALITY FROM cpu
+		{
+			s: `SHOW TAG KEY CARDINALITY FROM cpu`,
+			stmt: &influxql.ShowTagKeyCardinalityStatement{
+				Sources: []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+			},
+		},
+
+		// SHOW TAG KEY CARDINALITY ON db0
+		{
+			s: `SHOW TAG KEY CARDINALITY ON db0`,
+			stmt: &influxql.ShowTagKeyCardinalityStatement{
+				Database: "db0",
+			},
+		},
+
+		// SHOW TAG KEY CARDINALITY FROM /<regex>/
+		{
+			s: `SHOW TAG KEY CARDINALITY FROM /[cg]pu/`,
+			stmt: &influxql.ShowTagKeyCardinalityStatement{
+				Sources: []influxql.Source{
+					&influxql.Measurement{
+						Regex: &influxql.RegexLiteral{Val: regexp.MustCompile(`[cg]pu`)},
+					},
+				},
+			},
+		},
+
+		// SHOW TAG KEY CARDINALITY with OFFSET 0
+		{
+			s:    `SHOW TAG KEY CARDINALITY OFFSET 0`,
+			stmt: &influxql.ShowTagKeyCardinalityStatement{Offset: 0},
+		},
+
+		// SHOW TAG KEY CARDINALITY with LIMIT 2 OFFSET 0
+		{
+			s:    `SHOW TAG KEY CARDINALITY LIMIT 2 OFFSET 0`,
+			stmt: &influxql.ShowTagKeyCardinalityStatement{Offset: 0, Limit: 2},
+		},
+
+		// SHOW TAG KEY CARDINALITY WHERE with ORDER BY and LIMIT
+		{
+			s: `SHOW TAG KEY CARDINALITY WHERE region = 'order by desc' LIMIT 10`,
+			stmt: &influxql.ShowTagKeyCardinalityStatement{
+				Condition: &influxql.BinaryExpr{
+					Op:  influxql.EQ,
+					LHS: &influxql.VarRef{Val: "region"},
+					RHS: &influxql.StringLiteral{Val: "order by desc"},
+				},
+				Limit: 10,
 			},
 		},
 
@@ -1843,6 +2014,85 @@ func TestParser_ParseStatement(t *testing.T) {
 				Database:   "db0",
 				Op:         influxql.EQ,
 				TagKeyExpr: &influxql.StringLiteral{Val: "host"},
+			},
+		},
+
+		// SHOW TAG VALUES CARDINALITY statement
+		{
+			s: `SHOW TAG VALUES CARDINALITY WITH KEY = host`,
+			stmt: &influxql.ShowTagValuesCardinalityStatement{
+				Op:         influxql.EQ,
+				TagKeyExpr: &influxql.StringLiteral{Val: "host"},
+			},
+		},
+
+		// SHOW TAG VALUES CARDINALITY FROM cpu
+		{
+			s: `SHOW TAG VALUES CARDINALITY FROM cpu WITH KEY =  host`,
+			stmt: &influxql.ShowTagValuesCardinalityStatement{
+				Sources:    []influxql.Source{&influxql.Measurement{Name: "cpu"}},
+				Op:         influxql.EQ,
+				TagKeyExpr: &influxql.StringLiteral{Val: "host"},
+			},
+		},
+
+		// SHOW TAG VALUES CARDINALITY ON db0
+		{
+			s: `SHOW TAG VALUES CARDINALITY ON db0 WITH KEY = host`,
+			stmt: &influxql.ShowTagValuesCardinalityStatement{
+				Database:   "db0",
+				Op:         influxql.EQ,
+				TagKeyExpr: &influxql.StringLiteral{Val: "host"},
+			},
+		},
+
+		// SHOW TAG VALUES CARDINALITY FROM /<regex>/
+		{
+			s: `SHOW TAG VALUES CARDINALITY FROM /[cg]pu/ WITH KEY = host`,
+			stmt: &influxql.ShowTagValuesCardinalityStatement{
+				Sources: []influxql.Source{
+					&influxql.Measurement{
+						Regex: &influxql.RegexLiteral{Val: regexp.MustCompile(`[cg]pu`)},
+					},
+				},
+				Op:         influxql.EQ,
+				TagKeyExpr: &influxql.StringLiteral{Val: "host"},
+			},
+		},
+
+		// SHOW TAG VALUES CARDINALITY with OFFSET 0
+		{
+			s: `SHOW TAG VALUES CARDINALITY WITH KEY = host OFFSET 0`,
+			stmt: &influxql.ShowTagValuesCardinalityStatement{
+				Op:         influxql.EQ,
+				TagKeyExpr: &influxql.StringLiteral{Val: "host"},
+				Offset:     0,
+			},
+		},
+
+		// SHOW TAG VALUES CARDINALITY with LIMIT 2 OFFSET 0
+		{
+			s: `SHOW TAG VALUES CARDINALITY WITH KEY = host LIMIT 2 OFFSET 0`,
+			stmt: &influxql.ShowTagValuesCardinalityStatement{
+				Op:         influxql.EQ,
+				TagKeyExpr: &influxql.StringLiteral{Val: "host"},
+				Offset:     0,
+				Limit:      2,
+			},
+		},
+
+		// SHOW TAG VALUES CARDINALITY WHERE with ORDER BY and LIMIT
+		{
+			s: `SHOW TAG VALUES CARDINALITY WITH KEY = host WHERE region = 'order by desc' LIMIT 10`,
+			stmt: &influxql.ShowTagValuesCardinalityStatement{
+				Op:         influxql.EQ,
+				TagKeyExpr: &influxql.StringLiteral{Val: "host"},
+				Condition: &influxql.BinaryExpr{
+					Op:  influxql.EQ,
+					LHS: &influxql.VarRef{Val: "region"},
+					RHS: &influxql.StringLiteral{Val: "order by desc"},
+				},
+				Limit: 10,
 			},
 		},
 
@@ -2709,7 +2959,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{s: `SHOW RETENTION ON`, err: `found ON, expected POLICIES at line 1, char 16`},
 		{s: `SHOW RETENTION POLICIES ON`, err: `found EOF, expected identifier at line 1, char 28`},
 		{s: `SHOW SHARD`, err: `found EOF, expected GROUPS at line 1, char 12`},
-		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, DIAGNOSTICS, FIELD, GRANTS, MEASUREMENTS, QUERIES, RETENTION, SERIES, SHARD, SHARDS, STATS, SUBSCRIPTIONS, TAG, USERS at line 1, char 6`},
+		{s: `SHOW FOO`, err: `found FOO, expected CONTINUOUS, DATABASES, DIAGNOSTICS, FIELD, GRANTS, MEASUREMENT, MEASUREMENTS, QUERIES, RETENTION, SERIES, SHARD, SHARDS, STATS, SUBSCRIPTIONS, TAG, USERS at line 1, char 6`},
 		{s: `SHOW STATS FOR`, err: `found EOF, expected string at line 1, char 16`},
 		{s: `SHOW DIAGNOSTICS FOR`, err: `found EOF, expected string at line 1, char 22`},
 		{s: `SHOW GRANTS`, err: `found EOF, expected FOR at line 1, char 13`},

--- a/influxql/point.go
+++ b/influxql/point.go
@@ -112,6 +112,20 @@ func (t *Tags) Keys() []string {
 	return a
 }
 
+// Values returns a sorted list of all values on the tag.
+func (t *Tags) Values() []string {
+	if t == nil {
+		return nil
+	}
+
+	var a []string
+	for _, v := range t.m {
+		a = append(a, v)
+	}
+	sort.Strings(a)
+	return a
+}
+
 // Value returns the value for a given key.
 func (t *Tags) Value(k string) string {
 	if t == nil {

--- a/influxql/point.go
+++ b/influxql/point.go
@@ -118,7 +118,7 @@ func (t *Tags) Values() []string {
 		return nil
 	}
 
-	var a []string
+	a := make([]string, 0, len(t.m))
 	for _, v := range t.m {
 		a = append(a, v)
 	}

--- a/influxql/statement_rewriter.go
+++ b/influxql/statement_rewriter.go
@@ -84,8 +84,6 @@ func rewriteShowFieldKeyCardinalityStatement(stmt *ShowFieldKeyCardinalityStatem
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
 		OmitTime:   true,
-		Dedupe:     true,
-		IsRawQuery: true,
 	}, nil
 }
 
@@ -142,8 +140,6 @@ func rewriteShowMeasurementCardinalityStatement(stmt *ShowMeasurementCardinality
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
 		OmitTime:   true,
-		Dedupe:     true,
-		IsRawQuery: true,
 	}, nil
 }
 
@@ -191,8 +187,6 @@ func rewriteShowSeriesCardinalityStatement(stmt *ShowSeriesCardinalityStatement)
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
 		OmitTime:   true,
-		Dedupe:     true,
-		IsRawQuery: true,
 	}, nil
 }
 
@@ -326,8 +320,6 @@ func rewriteShowTagValuesCardinalityStatement(stmt *ShowTagValuesCardinalityStat
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
 		OmitTime:   true,
-		Dedupe:     true,
-		IsRawQuery: true,
 	}, nil
 }
 
@@ -386,8 +378,6 @@ func rewriteShowTagKeyCardinalityStatement(stmt *ShowTagKeyCardinalityStatement)
 		Offset:     stmt.Offset,
 		Limit:      stmt.Limit,
 		OmitTime:   true,
-		Dedupe:     true,
-		IsRawQuery: true,
 	}, nil
 }
 

--- a/influxql/token.go
+++ b/influxql/token.go
@@ -72,6 +72,7 @@ const (
 	ASC
 	BEGIN
 	BY
+	CARDINALITY
 	CREATE
 	CONTINUOUS
 	DATABASE
@@ -192,6 +193,7 @@ var tokens = [...]string{
 	ASC:           "ASC",
 	BEGIN:         "BEGIN",
 	BY:            "BY",
+	CARDINALITY:   "CARDINALITY",
 	CREATE:        "CREATE",
 	CONTINUOUS:    "CONTINUOUS",
 	DATABASE:      "DATABASE",

--- a/models/points.go
+++ b/models/points.go
@@ -1826,6 +1826,30 @@ func NewTags(m map[string]string) Tags {
 	return a
 }
 
+// Keys returns the list of keys for a tag set.
+func (a Tags) Keys() []string {
+	if len(a) == 0 {
+		return nil
+	}
+	keys := make([]string, len(a))
+	for i, tag := range a {
+		keys[i] = string(tag.Key)
+	}
+	return keys
+}
+
+// Values returns the list of values for a tag set.
+func (a Tags) Values() []string {
+	if len(a) == 0 {
+		return nil
+	}
+	values := make([]string, len(a))
+	for i, tag := range a {
+		values[i] = string(tag.Value)
+	}
+	return values
+}
+
 // String returns the string representation of the tags.
 func (a Tags) String() string {
 	var buf bytes.Buffer

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1899,7 +1899,7 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, name string, s
 		conditionFields = varRefSliceRemove(conditionFields, "_tagKey")
 
 		// Remove _tagKey conditional references from iterator.
-		itrOpt.Condition = influxql.RewriteExpr(itrOpt.Condition, func(expr influxql.Expr) influxql.Expr {
+		itrOpt.Condition = influxql.RewriteExpr(influxql.CloneExpr(itrOpt.Condition), func(expr influxql.Expr) influxql.Expr {
 			switch expr := expr.(type) {
 			case *influxql.BinaryExpr:
 				if ref, ok := expr.LHS.(*influxql.VarRef); ok && ref.Val == "_tagKey" {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1857,7 +1857,7 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, name string, s
 		for i, ref := range opt.Aux {
 			// Create cursor from field if a tag wasn't requested.
 			if ref.Type != influxql.Tag {
-				cur := e.buildCursor(name, seriesKey, &ref, opt)
+				cur := e.buildCursor(name, seriesKey, tfs, &ref, opt)
 				if cur != nil {
 					aux[i] = newBufCursor(cur, opt.Ascending)
 					continue
@@ -1893,6 +1893,26 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, name string, s
 		}
 	}
 
+	// Remove _tagKey condition field.
+	// We can't seach on it because we can't join it to _tagValue based on time.
+	if varRefSliceContains(conditionFields, "_tagKey") {
+		conditionFields = varRefSliceRemove(conditionFields, "_tagKey")
+
+		// Remove _tagKey conditional references from iterator.
+		itrOpt.Condition = influxql.RewriteExpr(itrOpt.Condition, func(expr influxql.Expr) influxql.Expr {
+			switch expr := expr.(type) {
+			case *influxql.BinaryExpr:
+				if ref, ok := expr.LHS.(*influxql.VarRef); ok && ref.Val == "_tagKey" {
+					return &influxql.BooleanLiteral{Val: true}
+				}
+				if ref, ok := expr.RHS.(*influxql.VarRef); ok && ref.Val == "_tagKey" {
+					return &influxql.BooleanLiteral{Val: true}
+				}
+			}
+			return expr
+		})
+	}
+
 	// Build conditional field cursors.
 	// If a conditional field doesn't exist then ignore the series.
 	var conds []cursorAt
@@ -1901,7 +1921,7 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, name string, s
 		for i, ref := range conditionFields {
 			// Create cursor from field if a tag wasn't requested.
 			if ref.Type != influxql.Tag {
-				cur := e.buildCursor(name, seriesKey, &ref, opt)
+				cur := e.buildCursor(name, seriesKey, tfs, &ref, opt)
 				if cur != nil {
 					conds[i] = newBufCursor(cur, opt.Ascending)
 					continue
@@ -1948,11 +1968,16 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, name string, s
 	}
 
 	// Build main cursor.
-	cur := e.buildCursor(name, seriesKey, ref, opt)
+	cur := e.buildCursor(name, seriesKey, tfs, ref, opt)
 
 	// If the field doesn't exist then don't build an iterator.
 	if cur == nil {
 		return nil, nil
+	}
+
+	// Remove measurement name if we are selecting the name.
+	if ref.Val == "_name" {
+		name = ""
 	}
 
 	switch cur := cur.(type) {
@@ -1972,11 +1997,28 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, name string, s
 }
 
 // buildCursor creates an untyped cursor for a field.
-func (e *Engine) buildCursor(measurement, seriesKey string, ref *influxql.VarRef, opt influxql.IteratorOptions) cursor {
+func (e *Engine) buildCursor(measurement, seriesKey string, tags models.Tags, ref *influxql.VarRef, opt influxql.IteratorOptions) cursor {
+	// Check if this is a system field cursor.
+	switch ref.Val {
+	case "_name":
+		return &stringSliceCursor{values: []string{measurement}}
+	case "_tagKey":
+		return &stringSliceCursor{values: tags.Keys()}
+	case "_tagValue":
+		return &stringSliceCursor{values: matchTagValues(tags, opt.Condition)}
+	case "_seriesKey":
+		return &stringSliceCursor{values: []string{seriesKey}}
+	}
+
 	// Look up fields for measurement.
 	mf := e.fieldset.Fields(measurement)
 	if mf == nil {
 		return nil
+	}
+
+	// Check for system field for field keys.
+	if ref.Val == "_fieldKey" {
+		return &stringSliceCursor{values: mf.FieldKeys()}
 	}
 
 	// Find individual field.
@@ -2035,6 +2077,28 @@ func (e *Engine) buildCursor(measurement, seriesKey string, ref *influxql.VarRef
 	default:
 		panic("unreachable")
 	}
+}
+
+func matchTagValues(tags models.Tags, condition influxql.Expr) []string {
+	if condition == nil {
+		return tags.Values()
+	}
+
+	// Populate map with tag values.
+	data := map[string]interface{}{}
+	for _, tag := range tags {
+		data[string(tag.Key)] = string(tag.Value)
+	}
+
+	// Match against each specific tag.
+	var values []string
+	for _, tag := range tags {
+		data["_tagKey"] = string(tag.Key)
+		if influxql.EvalBool(condition, data) {
+			values = append(values, string(tag.Value))
+		}
+	}
+	return values
 }
 
 // buildFloatCursor creates a cursor for a float field.
@@ -2153,4 +2217,27 @@ func readDir(root, rel string) ([]string, error) {
 		paths = append(paths, children...)
 	}
 	return paths, nil
+}
+
+func varRefSliceContains(a []influxql.VarRef, v string) bool {
+	for _, ref := range a {
+		if ref.Val == v {
+			return true
+		}
+	}
+	return false
+}
+
+func varRefSliceRemove(a []influxql.VarRef, v string) []influxql.VarRef {
+	if !varRefSliceContains(a, v) {
+		return a
+	}
+
+	other := make([]influxql.VarRef, 0, len(a))
+	for _, ref := range a {
+		if ref.Val != v {
+			other = append(other, ref)
+		}
+	}
+	return other
 }

--- a/tsdb/engine/tsm1/iterator.go
+++ b/tsdb/engine/tsm1/iterator.go
@@ -121,3 +121,22 @@ var (
 	nilStringLiteralValueCursor   cursorAt = &literalValueCursor{value: (*string)(nil)}
 	nilBooleanLiteralValueCursor  cursorAt = &literalValueCursor{value: (*bool)(nil)}
 )
+
+// stringSliceCursor is a cursor that outputs a slice of string values.
+type stringSliceCursor struct {
+	values []string
+}
+
+func (c *stringSliceCursor) close() error { return nil }
+
+func (c *stringSliceCursor) next() (int64, interface{}) { return c.nextString() }
+
+func (c *stringSliceCursor) nextString() (int64, string) {
+	if len(c.values) == 0 {
+		return tsdb.EOF, ""
+	}
+
+	value := c.values[0]
+	c.values = c.values[1:]
+	return 0, value
+}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -848,6 +848,11 @@ func (s *Shard) MeasurementsByRegex(re *regexp.Regexp) []string {
 
 // MapType returns the data type for the field within the measurement.
 func (s *Shard) MapType(measurement, field string) influxql.DataType {
+	switch field {
+	case "_name", "_tagKey", "_tagValue", "_seriesKey":
+		return influxql.String
+	}
+
 	// Process system measurements.
 	if strings.HasPrefix(measurement, "_") {
 		switch measurement {
@@ -1146,6 +1151,18 @@ type MeasurementFields struct {
 // NewMeasurementFields returns an initialised *MeasurementFields value.
 func NewMeasurementFields() *MeasurementFields {
 	return &MeasurementFields{fields: make(map[string]*Field)}
+}
+
+func (m *MeasurementFields) FieldKeys() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	a := make([]string, 0, len(m.fields))
+	for key := range m.fields {
+		a = append(a, key)
+	}
+	sort.Strings(a)
+	return a
 }
 
 // MarshalBinary encodes the object to a binary format.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -736,7 +736,7 @@ func (s *Shard) CreateIterator(measurement string, opt influxql.IteratorOptions)
 	return s.engine.CreateIterator(measurement, opt)
 }
 
-// createSystemIterator returns an iterator for a system source.
+// createSystemIterator returns an iterator for a field of system source.
 func (s *Shard) createSystemIterator(measurement string, opt influxql.IteratorOptions) (influxql.Iterator, bool, error) {
 	switch measurement {
 	case "_fieldKeys":
@@ -748,8 +748,9 @@ func (s *Shard) createSystemIterator(measurement string, opt influxql.IteratorOp
 	case "_tagKeys":
 		itr, err := NewTagKeysIterator(s, opt)
 		return itr, true, err
+	default:
+		return nil, false, nil
 	}
-	return nil, false, nil
 }
 
 // createSeriesIterator returns a new instance of SeriesIterator.


### PR DESCRIPTION
## Overview

This pull request adds `SHOW CARDINALITY` functionality for `SERIES`, `MEASUREMENT`, `TAG KEY`, `TAG VALUES`, and `FIELD`.

```
SHOW SERIES CARDINALITY
SHOW SERIES CARDINALITY FROM "<measurement>"
SHOW SERIES CARDINALITY WHERE "<key>" = '<value>'
SHOW SERIES CARDINALITY FROM "<measurement>" WHERE "<key>" = '<value>'
SHOW MEASUREMENT CARDINALITY
SHOW TAG KEY CARDINALITY
SHOW TAG KEY CARDINALITY FROM "<measurement>"
SHOW FIELD KEY CARDINALITY 
SHOW FIELD KEY CARDINALITY FROM "<measurement>"
SHOW TAG VALUES CARDINALITY WITH KEY = '<tag key>'
SHOW TAG VALUES CARDINALITY FROM "<measurement>" WITH KEY = '<tag key>'
```


## System iterators

I refactored the system iterators to treat them like normal data streams. Now you can read the following fields from a series:

- `_name`
- `_seriesKey`
- `_tagKey`
- `_tagValue`
- `_fieldKey`

The new `SHOW CARDINALITY` commands are rewritten to use these fields.

The refactor is largely a good thing but there are a couple trade offs that I'll mention here:

- Points are grouped by measurement in the query engine so `SHOW SERIES CARDINALITY` will always group by measurement.

- `VALUE` is not a reserved word so the statement is `SHOW TAG VALUES CARDINALITY`. I think that making `VALUE` a reserved word will break a lot of queries.

---

Fixes #7195.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
