### PR TITLE
Reduce memory usage when running queries

### DIFF
--- a/cmd/influx_inspect/dumptsm/dumptsm.go
+++ b/cmd/influx_inspect/dumptsm/dumptsm.go
@@ -110,7 +110,7 @@ func (cmd *Command) dump() error {
 		var pos int
 		for i := 0; i < keyCount; i++ {
 			key, _ := r.KeyAt(i)
-			for _, e := range r.Entries(string(key)) {
+			for _, e := range r.Entries(key) {
 				pos++
 				split := strings.Split(string(key), "#!~#")
 
@@ -146,7 +146,7 @@ func (cmd *Command) dump() error {
 	// Start at the beginning and read every block
 	for j := 0; j < keyCount; j++ {
 		key, _ := r.KeyAt(j)
-		for _, e := range r.Entries(string(key)) {
+		for _, e := range r.Entries(key) {
 
 			f.Seek(int64(e.Offset), 0)
 			f.Read(b[:4])

--- a/cmd/influx_inspect/export/export.go
+++ b/cmd/influx_inspect/export/export.go
@@ -278,7 +278,7 @@ func (cmd *Command) exportTSMFile(tsmFilePath string, w io.Writer) error {
 
 	for i := 0; i < r.KeyCount(); i++ {
 		key, _ := r.KeyAt(i)
-		values, err := r.ReadAll(string(key))
+		values, err := r.ReadAll(key)
 		if err != nil {
 			fmt.Fprintf(cmd.Stderr, "unable to read key %q in %s, skipping: %s\n", string(key), tsmFilePath, err.Error())
 			continue

--- a/cmd/influx_inspect/export/export_test.go
+++ b/cmd/influx_inspect/export/export_test.go
@@ -323,7 +323,7 @@ func writeCorpusToTSMFile(c corpus) *os.File {
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		if err := w.Write(k, c[k]); err != nil {
+		if err := w.Write([]byte(k), c[k]); err != nil {
 			panic(err)
 		}
 	}

--- a/cmd/influx_tsm/converter.go
+++ b/cmd/influx_tsm/converter.go
@@ -60,7 +60,7 @@ func (c *Converter) Process(iter KeyIterator) error {
 			}
 			keyCount = map[string]int{}
 		}
-		if err := w.Write(k, v); err != nil {
+		if err := w.Write([]byte(k), v); err != nil {
 			return err
 		}
 		keyCount[k]++

--- a/influxql/point.gen.go
+++ b/influxql/point.gen.go
@@ -22,13 +22,13 @@ type FloatPoint struct {
 	Tags Tags
 
 	Time  int64
-	Nil   bool
 	Value float64
 	Aux   []interface{}
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
 	Aggregated uint32
+	Nil        bool
 }
 
 func (v *FloatPoint) name() string { return v.Name }
@@ -233,13 +233,13 @@ type IntegerPoint struct {
 	Tags Tags
 
 	Time  int64
-	Nil   bool
 	Value int64
 	Aux   []interface{}
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
 	Aggregated uint32
+	Nil        bool
 }
 
 func (v *IntegerPoint) name() string { return v.Name }
@@ -444,13 +444,13 @@ type UnsignedPoint struct {
 	Tags Tags
 
 	Time  int64
-	Nil   bool
 	Value uint64
 	Aux   []interface{}
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
 	Aggregated uint32
+	Nil        bool
 }
 
 func (v *UnsignedPoint) name() string { return v.Name }
@@ -653,13 +653,13 @@ type StringPoint struct {
 	Tags Tags
 
 	Time  int64
-	Nil   bool
 	Value string
 	Aux   []interface{}
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
 	Aggregated uint32
+	Nil        bool
 }
 
 func (v *StringPoint) name() string { return v.Name }
@@ -864,13 +864,13 @@ type BooleanPoint struct {
 	Tags Tags
 
 	Time  int64
-	Nil   bool
 	Value bool
 	Aux   []interface{}
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
 	Aggregated uint32
+	Nil        bool
 }
 
 func (v *BooleanPoint) name() string { return v.Name }

--- a/influxql/point.gen.go.tmpl
+++ b/influxql/point.gen.go.tmpl
@@ -18,13 +18,13 @@ type {{.Name}}Point struct {
 	Tags Tags
 
 	Time  int64
-	Nil   bool
 	Value {{.Type}}
 	Aux   []interface{}
 
 	// Total number of points that were combined into this point from an aggregate.
 	// If this is zero, the point is not the result of an aggregate function.
 	Aggregated uint32
+	Nil   bool
 }
 
 func (v *{{.Name}}Point) name() string       { return v.Name }

--- a/tsdb/engine/tsm1/cache_race_test.go
+++ b/tsdb/engine/tsm1/cache_race_test.go
@@ -12,7 +12,7 @@ import (
 func TestCacheCheckConcurrentReadsAreSafe(t *testing.T) {
 	values := make(tsm1.Values, 1000)
 	timestamps := make([]int64, len(values))
-	series := make([]string, 100)
+	series := make([][]byte, 100)
 	for i := range timestamps {
 		timestamps[i] = int64(rand.Int63n(int64(len(values))))
 	}
@@ -22,7 +22,7 @@ func TestCacheCheckConcurrentReadsAreSafe(t *testing.T) {
 	}
 
 	for i := range series {
-		series[i] = fmt.Sprintf("series%d", i)
+		series[i] = []byte(fmt.Sprintf("series%d", i))
 	}
 
 	wg := sync.WaitGroup{}
@@ -34,17 +34,17 @@ func TestCacheCheckConcurrentReadsAreSafe(t *testing.T) {
 			c.Write(s, tsm1.Values{v})
 		}
 		wg.Add(3)
-		go func(s string) {
+		go func(s []byte) {
 			defer wg.Done()
 			<-ch
 			c.Values(s)
 		}(s)
-		go func(s string) {
+		go func(s []byte) {
 			defer wg.Done()
 			<-ch
 			c.Values(s)
 		}(s)
-		go func(s string) {
+		go func(s []byte) {
 			defer wg.Done()
 			<-ch
 			c.Values(s)
@@ -57,7 +57,7 @@ func TestCacheCheckConcurrentReadsAreSafe(t *testing.T) {
 func TestCacheRace(t *testing.T) {
 	values := make(tsm1.Values, 1000)
 	timestamps := make([]int64, len(values))
-	series := make([]string, 100)
+	series := make([][]byte, 100)
 	for i := range timestamps {
 		timestamps[i] = int64(rand.Int63n(int64(len(values))))
 	}
@@ -67,7 +67,7 @@ func TestCacheRace(t *testing.T) {
 	}
 
 	for i := range series {
-		series[i] = fmt.Sprintf("series%d", i)
+		series[i] = []byte(fmt.Sprintf("series%d", i))
 	}
 
 	wg := sync.WaitGroup{}
@@ -79,7 +79,7 @@ func TestCacheRace(t *testing.T) {
 			c.Write(s, tsm1.Values{v})
 		}
 		wg.Add(1)
-		go func(s string) {
+		go func(s []byte) {
 			defer wg.Done()
 			<-ch
 			c.Values(s)
@@ -122,7 +122,7 @@ func TestCacheRace(t *testing.T) {
 func TestCacheRace2Compacters(t *testing.T) {
 	values := make(tsm1.Values, 1000)
 	timestamps := make([]int64, len(values))
-	series := make([]string, 100)
+	series := make([][]byte, 100)
 	for i := range timestamps {
 		timestamps[i] = int64(rand.Int63n(int64(len(values))))
 	}
@@ -132,7 +132,7 @@ func TestCacheRace2Compacters(t *testing.T) {
 	}
 
 	for i := range series {
-		series[i] = fmt.Sprintf("series%d", i)
+		series[i] = []byte(fmt.Sprintf("series%d", i))
 	}
 
 	wg := sync.WaitGroup{}
@@ -144,7 +144,7 @@ func TestCacheRace2Compacters(t *testing.T) {
 			c.Write(s, tsm1.Values{v})
 		}
 		wg.Add(1)
-		go func(s string) {
+		go func(s []byte) {
 			defer wg.Done()
 			<-ch
 			c.Values(s)

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -1,6 +1,7 @@
 package tsm1
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -43,17 +44,17 @@ func TestCache_CacheWrite(t *testing.T) {
 
 	c := NewCache(3*valuesSize, "")
 
-	if err := c.Write("foo", values); err != nil {
+	if err := c.Write([]byte("foo"), values); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}
-	if err := c.Write("bar", values); err != nil {
+	if err := c.Write([]byte("bar"), values); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}
 	if n := c.Size(); n != 2*valuesSize {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("bar"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 }
@@ -66,11 +67,11 @@ func TestCache_CacheWrite_TypeConflict(t *testing.T) {
 
 	c := NewCache(uint64(2*valuesSize), "")
 
-	if err := c.Write("foo", values[:1]); err != nil {
+	if err := c.Write([]byte("foo"), values[:1]); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}
 
-	if err := c.Write("foo", values[1:]); err == nil {
+	if err := c.Write([]byte("foo"), values[1:]); err == nil {
 		t.Fatalf("expected field type conflict")
 	}
 
@@ -95,7 +96,7 @@ func TestCache_CacheWriteMulti(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("bar"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 }
@@ -118,8 +119,8 @@ func TestCache_WriteMulti_Stats(t *testing.T) {
 	c = NewCache(50, "")
 	c.store = ms
 
-	ms.writef = func(key string, v Values) error {
-		if key == "foo" {
+	ms.writef = func(key []byte, v Values) error {
+		if bytes.Equal(key, []byte("foo")) {
 			return errors.New("write failed")
 		}
 		return nil
@@ -160,7 +161,7 @@ func TestCache_CacheWriteMulti_TypeConflict(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", exp, got)
 	}
 
-	if exp, keys := []string{"foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 }
@@ -181,13 +182,13 @@ func TestCache_Cache_DeleteRange(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("bar"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteRange([]string{"bar"}, 2, math.MaxInt64)
+	c.DeleteRange([][]byte{[]byte("bar")}, 2, math.MaxInt64)
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("bar"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
@@ -195,11 +196,11 @@ func TestCache_Cache_DeleteRange(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", exp, got)
 	}
 
-	if got, exp := len(c.Values("bar")), 1; got != exp {
+	if got, exp := len(c.Values([]byte("bar"))), 1; got != exp {
 		t.Fatalf("cache values mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := len(c.Values("foo")), 3; got != exp {
+	if got, exp := len(c.Values([]byte("foo"))), 3; got != exp {
 		t.Fatalf("cache values mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -220,11 +221,11 @@ func TestCache_DeleteRange_NoValues(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteRange([]string{"foo"}, math.MinInt64, math.MaxInt64)
+	c.DeleteRange([][]byte{[]byte("foo")}, math.MinInt64, math.MaxInt64)
 
 	if exp, keys := 0, len(c.Keys()); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
@@ -234,7 +235,7 @@ func TestCache_DeleteRange_NoValues(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", exp, got)
 	}
 
-	if got, exp := len(c.Values("foo")), 0; got != exp {
+	if got, exp := len(c.Values([]byte("foo"))), 0; got != exp {
 		t.Fatalf("cache values mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -255,13 +256,13 @@ func TestCache_Cache_Delete(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
 	}
 
-	if exp, keys := []string{"bar", "foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("bar"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.Delete([]string{"bar"})
+	c.Delete([][]byte{[]byte("bar")})
 
-	if exp, keys := []string{"foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
@@ -269,11 +270,11 @@ func TestCache_Cache_Delete(t *testing.T) {
 		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", exp, got)
 	}
 
-	if got, exp := len(c.Values("bar")), 0; got != exp {
+	if got, exp := len(c.Values([]byte("bar"))), 0; got != exp {
 		t.Fatalf("cache values mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := len(c.Values("foo")), 3; got != exp {
+	if got, exp := len(c.Values([]byte("foo"))), 3; got != exp {
 		t.Fatalf("cache values mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -281,7 +282,7 @@ func TestCache_Cache_Delete(t *testing.T) {
 func TestCache_Cache_Delete_NonExistent(t *testing.T) {
 	c := NewCache(1024, "")
 
-	c.Delete([]string{"bar"})
+	c.Delete([][]byte{[]byte("bar")})
 
 	if got, exp := c.Size(), uint64(0); exp != got {
 		t.Fatalf("cache size incorrect exp %d, got %d", exp, got)
@@ -310,15 +311,15 @@ func TestCache_CacheWriteMulti_Duplicates(t *testing.T) {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}
 
-	if exp, keys := []string{"foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
 	expAscValues := Values{v0, v1, v3, v5}
-	if exp, got := len(expAscValues), len(c.Values("foo")); exp != got {
+	if exp, got := len(expAscValues), len(c.Values([]byte("foo"))); exp != got {
 		t.Fatalf("value count mismatch: exp: %v, got %v", exp, got)
 	}
-	if deduped := c.Values("foo"); !reflect.DeepEqual(expAscValues, deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(expAscValues, deduped) {
 		t.Fatalf("deduped ascending values for foo incorrect, exp: %v, got %v", expAscValues, deduped)
 	}
 }
@@ -331,19 +332,19 @@ func TestCache_CacheValues(t *testing.T) {
 	v4 := NewValue(4, 4.0)
 
 	c := NewCache(512, "")
-	if deduped := c.Values("no such key"); deduped != nil {
+	if deduped := c.Values([]byte("no such key")); deduped != nil {
 		t.Fatalf("Values returned for no such key")
 	}
 
-	if err := c.Write("foo", Values{v0, v1, v2, v3}); err != nil {
+	if err := c.Write([]byte("foo"), Values{v0, v1, v2, v3}); err != nil {
 		t.Fatalf("failed to write 3 values, key foo to cache: %s", err.Error())
 	}
-	if err := c.Write("foo", Values{v4}); err != nil {
+	if err := c.Write([]byte("foo"), Values{v4}); err != nil {
 		t.Fatalf("failed to write 1 value, key foo to cache: %s", err.Error())
 	}
 
 	expAscValues := Values{v3, v1, v2, v4}
-	if deduped := c.Values("foo"); !reflect.DeepEqual(expAscValues, deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(expAscValues, deduped) {
 		t.Fatalf("deduped ascending values for foo incorrect, exp: %v, got %v", expAscValues, deduped)
 	}
 }
@@ -359,7 +360,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	v7 := NewValue(2, 5.0)
 
 	c := NewCache(512, "")
-	if err := c.Write("foo", Values{v0, v1, v2, v3}); err != nil {
+	if err := c.Write([]byte("foo"), Values{v0, v1, v2, v3}); err != nil {
 		t.Fatalf("failed to write 3 values, key foo to cache: %s", err.Error())
 	}
 
@@ -370,30 +371,30 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	}
 
 	expValues := Values{v0, v1, v2, v3}
-	if deduped := snapshot.values("foo"); !reflect.DeepEqual(expValues, deduped) {
+	if deduped := snapshot.values([]byte("foo")); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("snapshotted values for foo incorrect, exp: %v, got %v", expValues, deduped)
 	}
 
 	// Ensure cache is still as expected.
-	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-snapshot values for foo incorrect, exp: %v, got %v", expValues, deduped)
 	}
 
 	// Write a new value to the cache.
-	if err := c.Write("foo", Values{v4}); err != nil {
+	if err := c.Write([]byte("foo"), Values{v4}); err != nil {
 		t.Fatalf("failed to write post-snap value, key foo to cache: %s", err.Error())
 	}
 	expValues = Values{v0, v1, v2, v3, v4}
-	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-snapshot write values for foo incorrect, exp: %v, got %v", expValues, deduped)
 	}
 
 	// Write a new, out-of-order, value to the cache.
-	if err := c.Write("foo", Values{v5}); err != nil {
+	if err := c.Write([]byte("foo"), Values{v5}); err != nil {
 		t.Fatalf("failed to write post-snap value, key foo to cache: %s", err.Error())
 	}
 	expValues = Values{v5, v0, v1, v2, v3, v4}
-	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-snapshot out-of-order write values for foo incorrect, exp: %v, got %v", expValues, deduped)
 	}
 
@@ -401,7 +402,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 	c.ClearSnapshot(true)
 
 	expValues = Values{v5, v4}
-	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-clear values for foo incorrect, exp: %v, got %v", expValues, deduped)
 	}
 
@@ -411,7 +412,7 @@ func TestCache_CacheSnapshot(t *testing.T) {
 		t.Fatalf("failed to snapshot cache: %v", err)
 	}
 
-	if err := c.Write("foo", Values{v4, v5}); err != nil {
+	if err := c.Write([]byte("foo"), Values{v4, v5}); err != nil {
 		t.Fatalf("failed to write post-snap value, key foo to cache: %s", err.Error())
 	}
 
@@ -422,12 +423,12 @@ func TestCache_CacheSnapshot(t *testing.T) {
 		t.Fatalf("failed to snapshot cache: %v", err)
 	}
 
-	if err := c.Write("foo", Values{v6, v7}); err != nil {
+	if err := c.Write([]byte("foo"), Values{v6, v7}); err != nil {
 		t.Fatalf("failed to write post-snap value, key foo to cache: %s", err.Error())
 	}
 
 	expValues = Values{v5, v7, v4, v6}
-	if deduped := c.Values("foo"); !reflect.DeepEqual(expValues, deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(expValues, deduped) {
 		t.Fatalf("post-snapshot out-of-order write values for foo incorrect, exp: %v, got %v", expValues, deduped)
 	}
 }
@@ -466,18 +467,18 @@ func TestCache_CacheEmptySnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to snapshot cache: %v", err)
 	}
-	if deduped := snapshot.values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
+	if deduped := snapshot.values([]byte("foo")); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("snapshotted values for foo incorrect, exp: %v, got %v", nil, deduped)
 	}
 
 	// Ensure cache is still as expected.
-	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshotted values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
 
 	// Clear snapshot.
 	c.ClearSnapshot(true)
-	if deduped := c.Values("foo"); !reflect.DeepEqual(Values(nil), deduped) {
+	if deduped := c.Values([]byte("foo")); !reflect.DeepEqual(Values(nil), deduped) {
 		t.Fatalf("post-snapshot-clear values for foo incorrect, exp: %v, got %v", Values(nil), deduped)
 	}
 }
@@ -488,13 +489,13 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 
 	c := NewCache(uint64(v1.Size()), "")
 
-	if err := c.Write("foo", Values{v0}); err != nil {
+	if err := c.Write([]byte("foo"), Values{v0}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}
-	if exp, keys := []string{"foo"}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+	if exp, keys := [][]byte{[]byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after writes, exp %v, got %v", exp, keys)
 	}
-	if err := c.Write("bar", Values{v1}); err == nil || !strings.Contains(err.Error(), "cache-max-memory-size") {
+	if err := c.Write([]byte("bar"), Values{v1}); err == nil || !strings.Contains(err.Error(), "cache-max-memory-size") {
 		t.Fatalf("wrong error writing key bar to cache: %v", err)
 	}
 
@@ -503,17 +504,17 @@ func TestCache_CacheWriteMemoryExceeded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to snapshot cache: %v", err)
 	}
-	if err := c.Write("bar", Values{v1}); err == nil || !strings.Contains(err.Error(), "cache-max-memory-size") {
+	if err := c.Write([]byte("bar"), Values{v1}); err == nil || !strings.Contains(err.Error(), "cache-max-memory-size") {
 		t.Fatalf("wrong error writing key bar to cache: %v", err)
 	}
 
 	// Clear the snapshot and the write should now succeed.
 	c.ClearSnapshot(true)
-	if err := c.Write("bar", Values{v1}); err != nil {
+	if err := c.Write([]byte("bar"), Values{v1}); err != nil {
 		t.Fatalf("failed to write key foo to cache: %s", err.Error())
 	}
 	expAscValues := Values{v1}
-	if deduped := c.Values("bar"); !reflect.DeepEqual(expAscValues, deduped) {
+	if deduped := c.Values([]byte("bar")); !reflect.DeepEqual(expAscValues, deduped) {
 		t.Fatalf("deduped ascending values for bar incorrect, exp: %v, got %v", expAscValues, deduped)
 	}
 }
@@ -591,13 +592,13 @@ func TestCacheLoader_LoadSingle(t *testing.T) {
 	}
 
 	// Check the cache.
-	if values := cache.Values("foo"); !reflect.DeepEqual(values, Values{p1}) {
+	if values := cache.Values([]byte("foo")); !reflect.DeepEqual(values, Values{p1}) {
 		t.Fatalf("cache key foo not as expected, got %v, exp %v", values, Values{p1})
 	}
-	if values := cache.Values("bar"); !reflect.DeepEqual(values, Values{p2}) {
+	if values := cache.Values([]byte("bar")); !reflect.DeepEqual(values, Values{p2}) {
 		t.Fatalf("cache key foo not as expected, got %v, exp %v", values, Values{p2})
 	}
-	if values := cache.Values("baz"); !reflect.DeepEqual(values, Values{p3}) {
+	if values := cache.Values([]byte("baz")); !reflect.DeepEqual(values, Values{p3}) {
 		t.Fatalf("cache key foo not as expected, got %v, exp %v", values, Values{p3})
 	}
 
@@ -614,13 +615,13 @@ func TestCacheLoader_LoadSingle(t *testing.T) {
 	}
 
 	// Check the cache.
-	if values := cache.Values("foo"); !reflect.DeepEqual(values, Values{p1}) {
+	if values := cache.Values([]byte("foo")); !reflect.DeepEqual(values, Values{p1}) {
 		t.Fatalf("cache key foo not as expected, got %v, exp %v", values, Values{p1})
 	}
-	if values := cache.Values("bar"); !reflect.DeepEqual(values, Values{p2}) {
+	if values := cache.Values([]byte("bar")); !reflect.DeepEqual(values, Values{p2}) {
 		t.Fatalf("cache key bar not as expected, got %v, exp %v", values, Values{p2})
 	}
-	if values := cache.Values("baz"); !reflect.DeepEqual(values, Values{p3}) {
+	if values := cache.Values([]byte("baz")); !reflect.DeepEqual(values, Values{p3}) {
 		t.Fatalf("cache key baz not as expected, got %v, exp %v", values, Values{p3})
 	}
 }
@@ -676,16 +677,16 @@ func TestCacheLoader_LoadDouble(t *testing.T) {
 	}
 
 	// Check the cache.
-	if values := cache.Values("foo"); !reflect.DeepEqual(values, Values{p1}) {
+	if values := cache.Values([]byte("foo")); !reflect.DeepEqual(values, Values{p1}) {
 		t.Fatalf("cache key foo not as expected, got %v, exp %v", values, Values{p1})
 	}
-	if values := cache.Values("bar"); !reflect.DeepEqual(values, Values{p2}) {
+	if values := cache.Values([]byte("bar")); !reflect.DeepEqual(values, Values{p2}) {
 		t.Fatalf("cache key bar not as expected, got %v, exp %v", values, Values{p2})
 	}
-	if values := cache.Values("baz"); !reflect.DeepEqual(values, Values{p3}) {
+	if values := cache.Values([]byte("baz")); !reflect.DeepEqual(values, Values{p3}) {
 		t.Fatalf("cache key baz not as expected, got %v, exp %v", values, Values{p3})
 	}
-	if values := cache.Values("qux"); !reflect.DeepEqual(values, Values{p4}) {
+	if values := cache.Values([]byte("qux")); !reflect.DeepEqual(values, Values{p4}) {
 		t.Fatalf("cache key qux not as expected, got %v, exp %v", values, Values{p4})
 	}
 }
@@ -719,7 +720,7 @@ func TestCacheLoader_LoadDeleted(t *testing.T) {
 	}
 
 	dentry := &DeleteRangeWALEntry{
-		Keys: []string{"foo"},
+		Keys: [][]byte{[]byte("foo")},
 		Min:  2,
 		Max:  3,
 	}
@@ -740,7 +741,7 @@ func TestCacheLoader_LoadDeleted(t *testing.T) {
 	}
 
 	// Check the cache.
-	if values := cache.Values("foo"); !reflect.DeepEqual(values, Values{p1}) {
+	if values := cache.Values([]byte("foo")); !reflect.DeepEqual(values, Values{p1}) {
 		t.Fatalf("cache key foo not as expected, got %v, exp %v", values, Values{p1})
 	}
 
@@ -752,7 +753,7 @@ func TestCacheLoader_LoadDeleted(t *testing.T) {
 	}
 
 	// Check the cache.
-	if values := cache.Values("foo"); !reflect.DeepEqual(values, Values{p1}) {
+	if values := cache.Values([]byte("foo")); !reflect.DeepEqual(values, Values{p1}) {
 		t.Fatalf("cache key foo not as expected, got %v, exp %v", values, Values{p1})
 	}
 }
@@ -787,24 +788,24 @@ func mustMarshalEntry(entry WALEntry) (WalEntryType, []byte) {
 // TestStore implements the storer interface and can be used to mock out a
 // Cache's storer implememation.
 type TestStore struct {
-	entryf       func(key string) (*entry, bool)
-	writef       func(key string, values Values) error
-	addf         func(key string, entry *entry)
-	removef      func(key string)
-	keysf        func(sorted bool) []string
-	applyf       func(f func(string, *entry) error) error
-	applySerialf func(f func(string, *entry) error) error
+	entryf       func(key []byte) (*entry, bool)
+	writef       func(key []byte, values Values) error
+	addf         func(key []byte, entry *entry)
+	removef      func(key []byte)
+	keysf        func(sorted bool) [][]byte
+	applyf       func(f func([]byte, *entry) error) error
+	applySerialf func(f func([]byte, *entry) error) error
 	resetf       func()
 }
 
 func NewTestStore() *TestStore                                      { return &TestStore{} }
-func (s *TestStore) entry(key string) (*entry, bool)                { return s.entryf(key) }
-func (s *TestStore) write(key string, values Values) error          { return s.writef(key, values) }
-func (s *TestStore) add(key string, entry *entry)                   { s.addf(key, entry) }
-func (s *TestStore) remove(key string)                              { s.removef(key) }
-func (s *TestStore) keys(sorted bool) []string                      { return s.keysf(sorted) }
-func (s *TestStore) apply(f func(string, *entry) error) error       { return s.applyf(f) }
-func (s *TestStore) applySerial(f func(string, *entry) error) error { return s.applySerialf(f) }
+func (s *TestStore) entry(key []byte) (*entry, bool)                { return s.entryf(key) }
+func (s *TestStore) write(key []byte, values Values) error          { return s.writef(key, values) }
+func (s *TestStore) add(key []byte, entry *entry)                   { s.addf(key, entry) }
+func (s *TestStore) remove(key []byte)                              { s.removef(key) }
+func (s *TestStore) keys(sorted bool) [][]byte                      { return s.keysf(sorted) }
+func (s *TestStore) apply(f func([]byte, *entry) error) error       { return s.applyf(f) }
+func (s *TestStore) applySerial(f func([]byte, *entry) error) error { return s.applySerialf(f) }
 func (s *TestStore) reset()                                         { s.resetf() }
 
 var fvSize = uint64(NewValue(1, float64(1)).Size())
@@ -818,14 +819,14 @@ func BenchmarkCacheFloatEntries(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if err := cache.Write("test", vals[i]); err != nil {
+		if err := cache.Write([]byte("test"), vals[i]); err != nil {
 			b.Fatal("err:", err, "i:", i, "N:", b.N)
 		}
 	}
 }
 
 type points struct {
-	key  string
+	key  []byte
 	vals []Value
 }
 
@@ -838,7 +839,7 @@ func BenchmarkCacheParallelFloatEntries(b *testing.B) {
 		for j := 0; j < 10; j++ {
 			v[j] = NewValue(1, float64(i+j))
 		}
-		vals[i] = points{key: fmt.Sprintf("cpu%v", rand.Intn(20)), vals: v}
+		vals[i] = points{key: []byte(fmt.Sprintf("cpu%v", rand.Intn(20))), vals: v}
 	}
 	i := int32(-1)
 	b.ResetTimer()

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -28,7 +28,7 @@ func TestCompactor_Snapshot(t *testing.T) {
 
 	c := tsm1.NewCache(0, "")
 	for k, v := range points1 {
-		if err := c.Write(k, v); err != nil {
+		if err := c.Write([]byte(k), v); err != nil {
 			t.Fatalf("failed to write key foo to cache: %s", err.Error())
 		}
 	}
@@ -73,7 +73,7 @@ func TestCompactor_Snapshot(t *testing.T) {
 	}
 
 	for _, p := range data {
-		values, err := r.ReadAll(p.key)
+		values, err := r.ReadAll([]byte(p.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -176,7 +176,7 @@ func TestCompactor_CompactFull(t *testing.T) {
 	}
 
 	for _, p := range data {
-		values, err := r.ReadAll(p.key)
+		values, err := r.ReadAll([]byte(p.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -246,7 +246,7 @@ func TestCompactor_Compact_OverlappingBlocks(t *testing.T) {
 	}
 
 	for _, p := range data {
-		values, err := r.ReadAll(p.key)
+		values, err := r.ReadAll([]byte(p.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -325,7 +325,7 @@ func TestCompactor_Compact_OverlappingBlocksMultiple(t *testing.T) {
 	}
 
 	for _, p := range data {
-		values, err := r.ReadAll(p.key)
+		values, err := r.ReadAll([]byte(p.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -414,7 +414,7 @@ func TestCompactor_CompactFull_SkipFullBlocks(t *testing.T) {
 	}
 
 	for _, p := range data {
-		values, err := r.ReadAll(p.key)
+		values, err := r.ReadAll([]byte(p.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -428,7 +428,7 @@ func TestCompactor_CompactFull_SkipFullBlocks(t *testing.T) {
 		}
 	}
 
-	if got, exp := len(r.Entries("cpu,host=A#!~#value")), 2; got != exp {
+	if got, exp := len(r.Entries([]byte("cpu,host=A#!~#value"))), 2; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -450,7 +450,7 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 	ts := tsm1.Tombstoner{
 		Path: f1,
 	}
-	ts.AddRange([]string{"cpu,host=A#!~#value"}, math.MinInt64, math.MaxInt64)
+	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, math.MinInt64, math.MaxInt64)
 
 	a3 := tsm1.NewValue(3, 1.3)
 	writes = map[string][]tsm1.Value{
@@ -513,7 +513,7 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 	}
 
 	for _, p := range data {
-		values, err := r.ReadAll(p.key)
+		values, err := r.ReadAll([]byte(p.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -527,7 +527,7 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 		}
 	}
 
-	if got, exp := len(r.Entries("cpu,host=A#!~#value")), 1; got != exp {
+	if got, exp := len(r.Entries([]byte("cpu,host=A#!~#value"))), 1; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -550,7 +550,7 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 		Path: f1,
 	}
 	// a1 should remain after compaction
-	ts.AddRange([]string{"cpu,host=A#!~#value"}, 2, math.MaxInt64)
+	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 2, math.MaxInt64)
 
 	a3 := tsm1.NewValue(3, 1.3)
 	writes = map[string][]tsm1.Value{
@@ -613,7 +613,7 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 	}
 
 	for _, p := range data {
-		values, err := r.ReadAll(p.key)
+		values, err := r.ReadAll([]byte(p.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -627,7 +627,7 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 		}
 	}
 
-	if got, exp := len(r.Entries("cpu,host=A#!~#value")), 2; got != exp {
+	if got, exp := len(r.Entries([]byte("cpu,host=A#!~#value"))), 2; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -654,8 +654,8 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 		Path: f1,
 	}
 	// a1, a3 should remain after compaction
-	ts.AddRange([]string{"cpu,host=A#!~#value"}, 2, 2)
-	ts.AddRange([]string{"cpu,host=A#!~#value"}, 4, 4)
+	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 2, 2)
+	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 4, 4)
 
 	a5 := tsm1.NewValue(5, 1.5)
 	writes = map[string][]tsm1.Value{
@@ -718,7 +718,7 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 	}
 
 	for _, p := range data {
-		values, err := r.ReadAll(p.key)
+		values, err := r.ReadAll([]byte(p.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -732,7 +732,7 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 		}
 	}
 
-	if got, exp := len(r.Entries("cpu,host=A#!~#value")), 2; got != exp {
+	if got, exp := len(r.Entries([]byte("cpu,host=A#!~#value"))), 2; got != exp {
 		t.Fatalf("block count mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -756,7 +756,7 @@ func TestCompactor_CompactFull_MaxKeys(t *testing.T) {
 		for j := 0; j < 1000; j++ {
 			values = append(values, tsm1.NewValue(int64(i*1000+j), int64(1)))
 		}
-		if err := f1.Write("cpu,host=A#!~#value", values); err != nil {
+		if err := f1.Write([]byte("cpu,host=A#!~#value"), values); err != nil {
 			t.Fatalf("write tsm f1: %v", err)
 		}
 	}
@@ -773,7 +773,7 @@ func TestCompactor_CompactFull_MaxKeys(t *testing.T) {
 	for j := lastTimeStamp; j < lastTimeStamp+1000; j++ {
 		values = append(values, tsm1.NewValue(int64(j), int64(1)))
 	}
-	if err := f2.Write("cpu,host=A#!~#value", values); err != nil {
+	if err := f2.Write([]byte("cpu,host=A#!~#value"), values); err != nil {
 		t.Fatalf("write tsm f1: %v", err)
 	}
 
@@ -847,7 +847,7 @@ func TestTSMKeyIterator_Single(t *testing.T) {
 			t.Fatalf("unexpected error decode: %v", err)
 		}
 
-		if got, exp := key, "cpu,host=A#!~#value"; got != exp {
+		if got, exp := string(key), "cpu,host=A#!~#value"; got != exp {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -907,7 +907,7 @@ func TestTSMKeyIterator_Duplicate(t *testing.T) {
 			t.Fatalf("unexpected error decode: %v", err)
 		}
 
-		if got, exp := key, "cpu,host=A#!~#value"; got != exp {
+		if got, exp := string(key), "cpu,host=A#!~#value"; got != exp {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -936,7 +936,7 @@ func TestTSMKeyIterator_MultipleKeysDeleted(t *testing.T) {
 	}
 
 	r1 := MustTSMReader(dir, 1, points1)
-	if e := r1.Delete([]string{"cpu,host=A#!~#value"}); nil != e {
+	if e := r1.Delete([][]byte{[]byte("cpu,host=A#!~#value")}); nil != e {
 		t.Fatal(e)
 	}
 
@@ -949,7 +949,7 @@ func TestTSMKeyIterator_MultipleKeysDeleted(t *testing.T) {
 	}
 
 	r2 := MustTSMReader(dir, 2, points2)
-	r2.Delete([]string{"cpu,host=A#!~#count"})
+	r2.Delete([][]byte{[]byte("cpu,host=A#!~#count")})
 
 	iter, err := tsm1.NewTSMKeyIterator(1, false, nil, r1, r2)
 	if err != nil {
@@ -975,7 +975,7 @@ func TestTSMKeyIterator_MultipleKeysDeleted(t *testing.T) {
 			t.Fatalf("unexpected error decode: %v", err)
 		}
 
-		if got, exp := key, data[0].key; got != exp {
+		if got, exp := string(key), data[0].key; got != exp {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -1038,7 +1038,7 @@ func TestCacheKeyIterator_Single(t *testing.T) {
 	c := tsm1.NewCache(0, "")
 
 	for k, v := range writes {
-		if err := c.Write(k, v); err != nil {
+		if err := c.Write([]byte(k), v); err != nil {
 			t.Fatalf("failed to write key foo to cache: %s", err.Error())
 		}
 	}
@@ -1056,7 +1056,7 @@ func TestCacheKeyIterator_Single(t *testing.T) {
 			t.Fatalf("unexpected error decode: %v", err)
 		}
 
-		if got, exp := key, "cpu,host=A#!~#value"; got != exp {
+		if got, exp := string(key), "cpu,host=A#!~#value"; got != exp {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -1086,7 +1086,7 @@ func TestCacheKeyIterator_Chunked(t *testing.T) {
 	c := tsm1.NewCache(0, "")
 
 	for k, v := range writes {
-		if err := c.Write(k, v); err != nil {
+		if err := c.Write([]byte(k), v); err != nil {
 			t.Fatalf("failed to write key foo to cache: %s", err.Error())
 		}
 	}
@@ -1105,7 +1105,7 @@ func TestCacheKeyIterator_Chunked(t *testing.T) {
 			t.Fatalf("unexpected error decode: %v", err)
 		}
 
-		if got, exp := key, "cpu,host=A#!~#value"; got != exp {
+		if got, exp := string(key), "cpu,host=A#!~#value"; got != exp {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -1136,7 +1136,7 @@ func TestCacheKeyIterator_Abort(t *testing.T) {
 	c := tsm1.NewCache(0, "")
 
 	for k, v := range writes {
-		if err := c.Write(k, v); err != nil {
+		if err := c.Write([]byte(k), v); err != nil {
 			t.Fatalf("failed to write key foo to cache: %s", err.Error())
 		}
 	}
@@ -2397,7 +2397,7 @@ func MustWriteTSM(dir string, gen int, values map[string][]tsm1.Value) string {
 	w, name := MustTSMWriter(dir, gen)
 
 	for k, v := range values {
-		if err := w.Write(k, v); err != nil {
+		if err := w.Write([]byte(k), v); err != nil {
 			panic(fmt.Sprintf("write TSM value: %v", err))
 		}
 	}

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -407,6 +407,14 @@ func DecodeFloatBlock(block []byte, a *[]FloatValue) ([]FloatValue, error) {
 		return nil, err
 	}
 
+	sz := CountTimestamps(tb)
+
+	if cap(*a) < sz {
+		*a = make([]FloatValue, sz)
+	} else {
+		*a = (*a)[:sz]
+	}
+
 	tdec := timeDecoderPool.Get(0).(*TimeDecoder)
 	vdec := floatDecoderPool.Get(0).(*FloatDecoder)
 
@@ -537,6 +545,14 @@ func DecodeBooleanBlock(block []byte, a *[]BooleanValue) ([]BooleanValue, error)
 		return nil, err
 	}
 
+	sz := CountTimestamps(tb)
+
+	if cap(*a) < sz {
+		*a = make([]BooleanValue, sz)
+	} else {
+		*a = (*a)[:sz]
+	}
+
 	tdec := timeDecoderPool.Get(0).(*TimeDecoder)
 	vdec := booleanDecoderPool.Get(0).(*BooleanDecoder)
 
@@ -653,6 +669,14 @@ func DecodeIntegerBlock(block []byte, a *[]IntegerValue) ([]IntegerValue, error)
 	tb, vb, err := unpackBlock(block)
 	if err != nil {
 		return nil, err
+	}
+
+	sz := CountTimestamps(tb)
+
+	if cap(*a) < sz {
+		*a = make([]IntegerValue, sz)
+	} else {
+		*a = (*a)[:sz]
 	}
 
 	tdec := timeDecoderPool.Get(0).(*TimeDecoder)
@@ -773,6 +797,14 @@ func DecodeUnsignedBlock(block []byte, a *[]UnsignedValue) ([]UnsignedValue, err
 		return nil, err
 	}
 
+	sz := CountTimestamps(tb)
+
+	if cap(*a) < sz {
+		*a = make([]UnsignedValue, sz)
+	} else {
+		*a = (*a)[:sz]
+	}
+
 	tdec := timeDecoderPool.Get(0).(*TimeDecoder)
 	vdec := integerDecoderPool.Get(0).(*IntegerDecoder)
 
@@ -890,6 +922,14 @@ func DecodeStringBlock(block []byte, a *[]StringValue) ([]StringValue, error) {
 	tb, vb, err := unpackBlock(block)
 	if err != nil {
 		return nil, err
+	}
+
+	sz := CountTimestamps(tb)
+
+	if cap(*a) < sz {
+		*a = make([]StringValue, sz)
+	} else {
+		*a = (*a)[:sz]
 	}
 
 	tdec := timeDecoderPool.Get(0).(*TimeDecoder)

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -136,11 +136,11 @@ func TestEngine_DeleteWALLoadMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if exp, got := 0, len(e.Cache.Values(tsm1.SeriesFieldKey("cpu,host=A", "value"))); exp != got {
+	if exp, got := 0, len(e.Cache.Values(tsm1.SeriesFieldKeyBytes("cpu,host=A", "value"))); exp != got {
 		t.Fatalf("unexpected number of values: got: %d. exp: %d", got, exp)
 	}
 
-	if exp, got := 1, len(e.Cache.Values(tsm1.SeriesFieldKey("cpu,host=B", "value"))); exp != got {
+	if exp, got := 1, len(e.Cache.Values(tsm1.SeriesFieldKeyBytes("cpu,host=B", "value"))); exp != got {
 		t.Fatalf("unexpected number of values: got: %d. exp: %d", got, exp)
 	}
 }

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -25,7 +25,7 @@ type TSMFile interface {
 	Path() string
 
 	// Read returns all the values in the block where time t resides.
-	Read(key string, t int64) ([]Value, error)
+	Read(key []byte, t int64) ([]Value, error)
 
 	// ReadAt returns all the values in the block identified by entry.
 	ReadAt(entry *IndexEntry, values []Value) ([]Value, error)
@@ -36,25 +36,25 @@ type TSMFile interface {
 	ReadBooleanBlockAt(entry *IndexEntry, values *[]BooleanValue) ([]BooleanValue, error)
 
 	// Entries returns the index entries for all blocks for the given key.
-	Entries(key string) []IndexEntry
-	ReadEntries(key string, entries *[]IndexEntry)
+	Entries(key []byte) []IndexEntry
+	ReadEntries(key []byte, entries *[]IndexEntry)
 
 	// Returns true if the TSMFile may contain a value with the specified
 	// key and time.
-	ContainsValue(key string, t int64) bool
+	ContainsValue(key []byte, t int64) bool
 
 	// Contains returns true if the file contains any values for the given
 	// key.
-	Contains(key string) bool
+	Contains(key []byte) bool
 
 	// TimeRange returns the min and max time across all keys in the file.
 	TimeRange() (int64, int64)
 
 	// TombstoneRange returns ranges of time that are deleted for the given key.
-	TombstoneRange(key string) []TimeRange
+	TombstoneRange(key []byte) []TimeRange
 
 	// KeyRange returns the min and max keys in the file.
-	KeyRange() (string, string)
+	KeyRange() ([]byte, []byte)
 
 	// KeyCount returns the number of distinct keys in the file.
 	KeyCount() int
@@ -65,13 +65,13 @@ type TSMFile interface {
 	// Type returns the block type of the values stored for the key.  Returns one of
 	// BlockFloat64, BlockInt64, BlockBoolean, BlockString.  If key does not exist,
 	// an error is returned.
-	Type(key string) (byte, error)
+	Type(key []byte) (byte, error)
 
 	// Delete removes the keys from the set of keys available in this file.
-	Delete(keys []string) error
+	Delete(keys [][]byte) error
 
 	// DeleteRange removes the values for keys between timestamps min and max.
-	DeleteRange(keys []string, min, max int64) error
+	DeleteRange(keys [][]byte, min, max int64) error
 
 	// HasTombstones returns true if file contains values that have been deleted.
 	HasTombstones() bool
@@ -149,7 +149,7 @@ type FileStat struct {
 	Size             uint32
 	LastModified     int64
 	MinTime, MaxTime int64
-	MinKey, MaxKey   string
+	MinKey, MaxKey   []byte
 }
 
 // OverlapsTimeRange returns true if the time range of the file intersect min and max.
@@ -158,13 +158,13 @@ func (f FileStat) OverlapsTimeRange(min, max int64) bool {
 }
 
 // OverlapsKeyRange returns true if the min and max keys of the file overlap the arguments min and max.
-func (f FileStat) OverlapsKeyRange(min, max string) bool {
-	return min != "" && max != "" && f.MinKey <= max && f.MaxKey >= min
+func (f FileStat) OverlapsKeyRange(min, max []byte) bool {
+	return len(min) != 0 && len(max) != 0 && bytes.Compare(f.MinKey, max) <= 0 && bytes.Compare(f.MaxKey, min) >= 0
 }
 
 // ContainsKey returns true if the min and max keys of the file overlap the arguments min and max.
-func (f FileStat) ContainsKey(key string) bool {
-	return f.MinKey >= key || key <= f.MaxKey
+func (f FileStat) ContainsKey(key []byte) bool {
+	return bytes.Compare(f.MinKey, key) >= 0 || bytes.Compare(key, f.MaxKey) <= 0
 }
 
 // NewFileStore returns a new instance of FileStore based on the given directory.
@@ -302,7 +302,7 @@ func (f *FileStore) Keys() map[string]byte {
 }
 
 // Type returns the type of values store at the block for key.
-func (f *FileStore) Type(key string) (byte, error) {
+func (f *FileStore) Type(key []byte) (byte, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
@@ -315,12 +315,12 @@ func (f *FileStore) Type(key string) (byte, error) {
 }
 
 // Delete removes the keys from the set of keys available in this file.
-func (f *FileStore) Delete(keys []string) error {
+func (f *FileStore) Delete(keys [][]byte) error {
 	return f.DeleteRange(keys, math.MinInt64, math.MaxInt64)
 }
 
 // DeleteRange removes the values for keys between timestamps min and max.
-func (f *FileStore) DeleteRange(keys []string, min, max int64) error {
+func (f *FileStore) DeleteRange(keys [][]byte, min, max int64) error {
 	if err := f.walkFiles(func(tsm TSMFile) error {
 		return tsm.DeleteRange(keys, min, max)
 	}); err != nil {
@@ -452,7 +452,7 @@ func (f *FileStore) DiskSizeBytes() int64 {
 
 // Read returns the slice of values for the given key and the given timestamp,
 // if any file matches those constraints.
-func (f *FileStore) Read(key string, t int64) ([]Value, error) {
+func (f *FileStore) Read(key []byte, t int64) ([]Value, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
@@ -476,7 +476,7 @@ func (f *FileStore) Read(key string, t int64) ([]Value, error) {
 }
 
 // KeyCursor returns a KeyCursor for key and t across the files in the FileStore.
-func (f *FileStore) KeyCursor(key string, t int64, ascending bool) *KeyCursor {
+func (f *FileStore) KeyCursor(key []byte, t int64, ascending bool) *KeyCursor {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	return newKeyCursor(f, key, t, ascending)
@@ -723,7 +723,7 @@ func (f *FileStore) walkFiles(fn func(f TSMFile) error) error {
 // locations returns the files and index blocks for a key and time.  ascending indicates
 // whether the key will be scan in ascending time order or descenging time order.
 // This function assumes the read-lock has been taken.
-func (f *FileStore) locations(key string, t int64, ascending bool) []*location {
+func (f *FileStore) locations(key []byte, t int64, ascending bool) []*location {
 	var entries []IndexEntry
 	locations := make([]*location, 0, len(f.files))
 	for _, fd := range f.files {
@@ -858,7 +858,7 @@ func ParseTSMFileName(name string) (int, int, error) {
 
 // KeyCursor allows iteration through keys in a set of files within a FileStore.
 type KeyCursor struct {
-	key string
+	key []byte
 	fs  *FileStore
 
 	// seeks is all the file locations that we need to return during iteration.
@@ -929,7 +929,7 @@ func (a ascLocations) Less(i, j int) bool {
 
 // newKeyCursor returns a new instance of KeyCursor.
 // This function assumes the read-lock has been taken.
-func newKeyCursor(fs *FileStore, key string, t int64, ascending bool) *KeyCursor {
+func newKeyCursor(fs *FileStore, key []byte, t int64, ascending bool) *KeyCursor {
 	c := &KeyCursor{
 		key:       key,
 		fs:        fs,

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -34,7 +34,7 @@ func TestFileStore_Read(t *testing.T) {
 	fs.Replace(nil, files)
 
 	// Search for an entry that exists in the second file
-	values, err := fs.Read("cpu", 1)
+	values, err := fs.Read([]byte("cpu"), 1)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestFileStore_SeekToAsc_FromStart(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
@@ -111,7 +111,7 @@ func TestFileStore_SeekToAsc_Duplicate(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
@@ -184,7 +184,7 @@ func TestFileStore_SeekToAsc_BeforeStart(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -226,7 +226,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapFloat(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -293,7 +293,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapInteger(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.IntegerValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -359,7 +359,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapUnsigned(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.UnsignedValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -425,7 +425,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapBoolean(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.BooleanValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -491,7 +491,7 @@ func TestFileStore_SeekToAsc_BeforeStart_OverlapString(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.StringValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -556,7 +556,7 @@ func TestFileStore_SeekToAsc_OverlapMinFloat(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
@@ -636,7 +636,7 @@ func TestFileStore_SeekToAsc_OverlapMinInteger(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.IntegerValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
@@ -715,7 +715,7 @@ func TestFileStore_SeekToAsc_OverlapMinUnsigned(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.UnsignedValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
@@ -794,7 +794,7 @@ func TestFileStore_SeekToAsc_OverlapMinBoolean(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.BooleanValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
@@ -873,7 +873,7 @@ func TestFileStore_SeekToAsc_OverlapMinString(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.StringValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	// Search for an entry that exists in the second file
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
@@ -951,7 +951,7 @@ func TestFileStore_SeekToAsc_Middle(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 3, true)
+	c := fs.KeyCursor([]byte("cpu"), 3, true)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1007,7 +1007,7 @@ func TestFileStore_SeekToAsc_End(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 2, true)
+	c := fs.KeyCursor([]byte("cpu"), 2, true)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1046,7 +1046,7 @@ func TestFileStore_SeekToDesc_FromStart(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 0, false)
+	c := fs.KeyCursor([]byte("cpu"), 0, false)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1085,7 +1085,7 @@ func TestFileStore_SeekToDesc_Duplicate(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 2, false)
+	c := fs.KeyCursor([]byte("cpu"), 2, false)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1144,7 +1144,7 @@ func TestFileStore_SeekToDesc_OverlapMaxFloat(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 5, false)
+	c := fs.KeyCursor([]byte("cpu"), 5, false)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1209,7 +1209,7 @@ func TestFileStore_SeekToDesc_OverlapMaxInteger(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.IntegerValue, 1000)
-	c := fs.KeyCursor("cpu", 5, false)
+	c := fs.KeyCursor([]byte("cpu"), 5, false)
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1271,7 +1271,7 @@ func TestFileStore_SeekToDesc_OverlapMaxUnsigned(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.UnsignedValue, 1000)
-	c := fs.KeyCursor("cpu", 5, false)
+	c := fs.KeyCursor([]byte("cpu"), 5, false)
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1334,7 +1334,7 @@ func TestFileStore_SeekToDesc_OverlapMaxBoolean(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.BooleanValue, 1000)
-	c := fs.KeyCursor("cpu", 5, false)
+	c := fs.KeyCursor([]byte("cpu"), 5, false)
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1397,7 +1397,7 @@ func TestFileStore_SeekToDesc_OverlapMaxString(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.StringValue, 1000)
-	c := fs.KeyCursor("cpu", 5, false)
+	c := fs.KeyCursor([]byte("cpu"), 5, false)
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1458,7 +1458,7 @@ func TestFileStore_SeekToDesc_AfterEnd(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 4, false)
+	c := fs.KeyCursor([]byte("cpu"), 4, false)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1497,7 +1497,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapFloat(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 10, false)
+	c := fs.KeyCursor([]byte("cpu"), 10, false)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1594,7 +1594,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapInteger(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.IntegerValue, 1000)
-	c := fs.KeyCursor("cpu", 11, false)
+	c := fs.KeyCursor([]byte("cpu"), 11, false)
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1671,7 +1671,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapUnsigned(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.UnsignedValue, 1000)
-	c := fs.KeyCursor("cpu", 11, false)
+	c := fs.KeyCursor([]byte("cpu"), 11, false)
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1748,7 +1748,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapBoolean(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.BooleanValue, 1000)
-	c := fs.KeyCursor("cpu", 11, false)
+	c := fs.KeyCursor([]byte("cpu"), 11, false)
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1845,7 +1845,7 @@ func TestFileStore_SeekToDesc_AfterEnd_OverlapString(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.StringValue, 1000)
-	c := fs.KeyCursor("cpu", 11, false)
+	c := fs.KeyCursor([]byte("cpu"), 11, false)
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -1945,7 +1945,7 @@ func TestFileStore_SeekToDesc_Middle(t *testing.T) {
 
 	// Search for an entry that exists in the second file
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 3, false)
+	c := fs.KeyCursor([]byte("cpu"), 3, false)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2018,7 +2018,7 @@ func TestFileStore_SeekToDesc_End(t *testing.T) {
 	fs.Replace(nil, files)
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 2, false)
+	c := fs.KeyCursor([]byte("cpu"), 2, false)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2055,12 +2055,12 @@ func TestKeyCursor_TombstoneRange(t *testing.T) {
 
 	fs.Replace(nil, files)
 
-	if err := fs.DeleteRange([]string{"cpu"}, 1, 1); err != nil {
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	expValues := []int{0, 2}
 	for _, v := range expValues {
 		values, err := c.ReadFloatBlock(&buf)
@@ -2100,12 +2100,12 @@ func TestKeyCursor_TombstoneRange_PartialFloat(t *testing.T) {
 
 	fs.Replace(nil, files)
 
-	if err := fs.DeleteRange([]string{"cpu"}, 1, 1); err != nil {
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
 	buf := make([]tsm1.FloatValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadFloatBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2144,12 +2144,12 @@ func TestKeyCursor_TombstoneRange_PartialInteger(t *testing.T) {
 
 	fs.Replace(nil, files)
 
-	if err := fs.DeleteRange([]string{"cpu"}, 1, 1); err != nil {
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
 	buf := make([]tsm1.IntegerValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadIntegerBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2188,12 +2188,12 @@ func TestKeyCursor_TombstoneRange_PartialUnsigned(t *testing.T) {
 
 	fs.Replace(nil, files)
 
-	if err := fs.DeleteRange([]string{"cpu"}, 1, 1); err != nil {
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
 	buf := make([]tsm1.UnsignedValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadUnsignedBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2232,12 +2232,12 @@ func TestKeyCursor_TombstoneRange_PartialString(t *testing.T) {
 
 	fs.Replace(nil, files)
 
-	if err := fs.DeleteRange([]string{"cpu"}, 1, 1); err != nil {
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
 	buf := make([]tsm1.StringValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadStringBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2276,12 +2276,12 @@ func TestKeyCursor_TombstoneRange_PartialBoolean(t *testing.T) {
 
 	fs.Replace(nil, files)
 
-	if err := fs.DeleteRange([]string{"cpu"}, 1, 1); err != nil {
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
 	buf := make([]tsm1.BooleanValue, 1000)
-	c := fs.KeyCursor("cpu", 0, true)
+	c := fs.KeyCursor([]byte("cpu"), 0, true)
 	values, err := c.ReadBooleanBlock(&buf)
 	if err != nil {
 		t.Fatalf("unexpected error reading values: %v", err)
@@ -2403,7 +2403,7 @@ func TestFileStore_Replace(t *testing.T) {
 	}
 
 	// Should record references to the two existing TSM files
-	cur := fs.KeyCursor("cpu", 0, true)
+	cur := fs.KeyCursor([]byte("cpu"), 0, true)
 
 	// Should move the existing files out of the way, but allow query to complete
 	if err := fs.Replace(files[:2], []string{replacement}); err != nil {
@@ -2489,7 +2489,7 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 		t.Fatalf("file count mismatch: got %v, exp %v", got, exp)
 	}
 
-	if err := fs.Delete([]string{"cpu,host=server2!~#!value"}); err != nil {
+	if err := fs.Delete([][]byte{[]byte("cpu,host=server2!~#!value")}); err != nil {
 		fatal(t, "deleting", err)
 	}
 
@@ -2528,7 +2528,7 @@ func TestFileStore_Delete(t *testing.T) {
 		t.Fatalf("key length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if err := fs.Delete([]string{"cpu,host=server2!~#!value"}); err != nil {
+	if err := fs.Delete([][]byte{[]byte("cpu,host=server2!~#!value")}); err != nil {
 		fatal(t, "deleting", err)
 	}
 
@@ -2633,7 +2633,7 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 	fs.Replace(nil, files)
 
 	// Create a tombstone
-	if err := fs.DeleteRange([]string{"cpu"}, 1, 1); err != nil {
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
@@ -2678,7 +2678,7 @@ func newFileDir(dir string, values ...keyValues) ([]string, error) {
 			return nil, err
 		}
 
-		if err := w.Write(v.key, v.values); err != nil {
+		if err := w.Write([]byte(v.key), v.values); err != nil {
 			return nil, err
 		}
 
@@ -2712,7 +2712,7 @@ func newFiles(dir string, values ...keyValues) ([]string, error) {
 			return nil, err
 		}
 
-		if err := w.Write(v.key, v.values); err != nil {
+		if err := w.Write([]byte(v.key), v.values); err != nil {
 			return nil, err
 		}
 

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -311,7 +311,6 @@ type floatAscendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []FloatValue
 		values    []FloatValue
 		pos       int
 		keyCursor *KeyCursor
@@ -327,8 +326,7 @@ func newFloatAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyCu
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]FloatValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -360,7 +358,6 @@ func (c *floatAscendingCursor) peekTSM() (t int64, v float64) {
 func (c *floatAscendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -410,7 +407,7 @@ func (c *floatAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -425,7 +422,6 @@ type floatDescendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []FloatValue
 		values    []FloatValue
 		pos       int
 		keyCursor *KeyCursor
@@ -444,8 +440,7 @@ func newFloatDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]FloatValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -480,7 +475,6 @@ func (c *floatDescendingCursor) peekTSM() (t int64, v float64) {
 func (c *floatDescendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -530,7 +524,7 @@ func (c *floatDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadFloatBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -752,7 +746,6 @@ type integerAscendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []IntegerValue
 		values    []IntegerValue
 		pos       int
 		keyCursor *KeyCursor
@@ -768,8 +761,7 @@ func newIntegerAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]IntegerValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -801,7 +793,6 @@ func (c *integerAscendingCursor) peekTSM() (t int64, v int64) {
 func (c *integerAscendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -851,7 +842,7 @@ func (c *integerAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -866,7 +857,6 @@ type integerDescendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []IntegerValue
 		values    []IntegerValue
 		pos       int
 		keyCursor *KeyCursor
@@ -885,8 +875,7 @@ func newIntegerDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]IntegerValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -921,7 +910,6 @@ func (c *integerDescendingCursor) peekTSM() (t int64, v int64) {
 func (c *integerDescendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -971,7 +959,7 @@ func (c *integerDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadIntegerBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -1193,7 +1181,6 @@ type unsignedAscendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []UnsignedValue
 		values    []UnsignedValue
 		pos       int
 		keyCursor *KeyCursor
@@ -1209,8 +1196,7 @@ func newUnsignedAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]UnsignedValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -1242,7 +1228,6 @@ func (c *unsignedAscendingCursor) peekTSM() (t int64, v uint64) {
 func (c *unsignedAscendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -1292,7 +1277,7 @@ func (c *unsignedAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -1307,7 +1292,6 @@ type unsignedDescendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []UnsignedValue
 		values    []UnsignedValue
 		pos       int
 		keyCursor *KeyCursor
@@ -1326,8 +1310,7 @@ func newUnsignedDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *K
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]UnsignedValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -1362,7 +1345,6 @@ func (c *unsignedDescendingCursor) peekTSM() (t int64, v uint64) {
 func (c *unsignedDescendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -1412,7 +1394,7 @@ func (c *unsignedDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadUnsignedBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -1634,7 +1616,6 @@ type stringAscendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []StringValue
 		values    []StringValue
 		pos       int
 		keyCursor *KeyCursor
@@ -1650,8 +1631,7 @@ func newStringAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *KeyC
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]StringValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -1683,7 +1663,6 @@ func (c *stringAscendingCursor) peekTSM() (t int64, v string) {
 func (c *stringAscendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -1733,7 +1712,7 @@ func (c *stringAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -1748,7 +1727,6 @@ type stringDescendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []StringValue
 		values    []StringValue
 		pos       int
 		keyCursor *KeyCursor
@@ -1767,8 +1745,7 @@ func newStringDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]StringValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -1803,7 +1780,6 @@ func (c *stringDescendingCursor) peekTSM() (t int64, v string) {
 func (c *stringDescendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -1853,7 +1829,7 @@ func (c *stringDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadStringBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -2075,7 +2051,6 @@ type booleanAscendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []BooleanValue
 		values    []BooleanValue
 		pos       int
 		keyCursor *KeyCursor
@@ -2091,8 +2066,7 @@ func newBooleanAscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Key
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]BooleanValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -2124,7 +2098,6 @@ func (c *booleanAscendingCursor) peekTSM() (t int64, v bool) {
 func (c *booleanAscendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -2174,7 +2147,7 @@ func (c *booleanAscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -2189,7 +2162,6 @@ type booleanDescendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []BooleanValue
 		values    []BooleanValue
 		pos       int
 		keyCursor *KeyCursor
@@ -2208,8 +2180,7 @@ func newBooleanDescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *Ke
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]BooleanValue, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -2244,7 +2215,6 @@ func (c *booleanDescendingCursor) peekTSM() (t int64, v bool) {
 func (c *booleanDescendingCursor) close() error {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -2294,7 +2264,7 @@ func (c *booleanDescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.ReadBooleanBlock(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -307,7 +307,6 @@ type {{.name}}AscendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []{{.Name}}Value
 		values    []{{.Name}}Value
 		pos       int
 		keyCursor *KeyCursor
@@ -323,8 +322,7 @@ func new{{.Name}}AscendingCursor(seek int64, cacheValues Values, tsmKeyCursor *K
 	})
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]{{.Name}}Value, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -356,7 +354,6 @@ func (c *{{.name}}AscendingCursor) peekTSM() (t int64, v {{.Type}}) {
 func (c *{{.name}}AscendingCursor) close() (error) {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -406,7 +403,7 @@ func (c *{{.name}}AscendingCursor) nextTSM() {
 	c.tsm.pos++
 	if c.tsm.pos >= len(c.tsm.values) {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}
@@ -421,7 +418,6 @@ type {{.name}}DescendingCursor struct {
 	}
 
 	tsm struct {
-		buf       []{{.Name}}Value
 		values    []{{.Name}}Value
 		pos       int
 		keyCursor *KeyCursor
@@ -440,8 +436,7 @@ func new{{.Name}}DescendingCursor(seek int64, cacheValues Values, tsmKeyCursor *
 	}
 
 	c.tsm.keyCursor = tsmKeyCursor
-	c.tsm.buf = make([]{{.Name}}Value, 10)
-	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.buf)
+	c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.values)
 	c.tsm.pos = sort.Search(len(c.tsm.values), func(i int) bool {
 		return c.tsm.values[i].UnixNano() >= seek
 	})
@@ -476,7 +471,6 @@ func (c *{{.name}}DescendingCursor) peekTSM() (t int64, v {{.Type}}) {
 func (c *{{.name}}DescendingCursor) close() (error) {
 	c.tsm.keyCursor.Close()
 	c.tsm.keyCursor = nil
-	c.tsm.buf = nil
 	c.cache.values = nil
 	c.tsm.values = nil
 	return nil
@@ -526,7 +520,7 @@ func (c *{{.name}}DescendingCursor) nextTSM() {
 	c.tsm.pos--
 	if c.tsm.pos < 0 {
 		c.tsm.keyCursor.Next()
-		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.buf)
+		c.tsm.values, _ = c.tsm.keyCursor.Read{{.Name}}Block(&c.tsm.values)
 		if len(c.tsm.values) == 0 {
 			return
 		}

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -22,7 +22,7 @@ func TestTSMReader_Type(t *testing.T) {
 	}
 
 	values := []tsm1.Value{tsm1.NewValue(0, int64(1))}
-	if err := w.Write("cpu", values); err != nil {
+	if err := w.Write([]byte("cpu"), values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 
 	}
@@ -43,7 +43,7 @@ func TestTSMReader_Type(t *testing.T) {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
 
-	typ, err := r.Type("cpu")
+	typ, err := r.Type([]byte("cpu"))
 	if err != nil {
 		fatal(t, "reading type", err)
 	}
@@ -86,7 +86,7 @@ func TestTSMReader_MMAP_ReadAll(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -112,7 +112,7 @@ func TestTSMReader_MMAP_ReadAll(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.ReadAll(d.key)
+		readValues, err := r.ReadAll([]byte(d.key))
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -166,7 +166,7 @@ func TestTSMReader_MMAP_Read(t *testing.T) {
 		},
 	}
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -192,7 +192,7 @@ func TestTSMReader_MMAP_Read(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.Read(d.key, d.values[0].UnixNano())
+		readValues, err := r.Read([]byte(d.key), d.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -247,7 +247,7 @@ func TestTSMReader_MMAP_Keys(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -273,7 +273,7 @@ func TestTSMReader_MMAP_Keys(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.Read(d.key, d.values[0].UnixNano())
+		readValues, err := r.Read([]byte(d.key), d.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -307,11 +307,11 @@ func TestTSMReader_MMAP_Tombstone(t *testing.T) {
 	}
 
 	values := []tsm1.Value{tsm1.NewValue(0, 1.0)}
-	if err := w.Write("cpu", values); err != nil {
+	if err := w.Write([]byte("cpu"), values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
-	if err := w.Write("mem", values); err != nil {
+	if err := w.Write([]byte("mem"), values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -333,7 +333,7 @@ func TestTSMReader_MMAP_Tombstone(t *testing.T) {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
 
-	if err := r.Delete([]string{"mem"}); err != nil {
+	if err := r.Delete([][]byte{[]byte("mem")}); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 
@@ -364,7 +364,7 @@ func TestTSMReader_MMAP_TombstoneRange(t *testing.T) {
 		tsm1.NewValue(2, 2.0),
 		tsm1.NewValue(3, 3.0),
 	}
-	if err := w.Write("cpu", expValues); err != nil {
+	if err := w.Write([]byte("cpu"), expValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -386,20 +386,20 @@ func TestTSMReader_MMAP_TombstoneRange(t *testing.T) {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
 
-	if err := r.DeleteRange([]string{"cpu"}, 2, math.MaxInt64); err != nil {
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, 2, math.MaxInt64); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 	defer r.Close()
 
-	if got, exp := r.ContainsValue("cpu", 1), true; got != exp {
+	if got, exp := r.ContainsValue([]byte("cpu"), 1), true; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := r.ContainsValue("cpu", 3), false; got != exp {
+	if got, exp := r.ContainsValue([]byte("cpu"), 3), false; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
-	values, err := r.ReadAll("cpu")
+	values, err := r.ReadAll([]byte("cpu"))
 	if err != nil {
 		t.Fatalf("unexpected error reading all: %v", err)
 	}
@@ -429,7 +429,7 @@ func TestTSMReader_MMAP_TombstoneOutsideTimeRange(t *testing.T) {
 		tsm1.NewValue(2, 2.0),
 		tsm1.NewValue(3, 3.0),
 	}
-	if err := w.Write("cpu", expValues); err != nil {
+	if err := w.Write([]byte("cpu"), expValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -451,20 +451,20 @@ func TestTSMReader_MMAP_TombstoneOutsideTimeRange(t *testing.T) {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
 
-	if err := r.DeleteRange([]string{"cpu"}, 0, 0); err != nil {
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, 0, 0); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 	defer r.Close()
 
-	if got, exp := r.ContainsValue("cpu", 1), true; got != exp {
+	if got, exp := r.ContainsValue([]byte("cpu"), 1), true; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := r.ContainsValue("cpu", 2), true; got != exp {
+	if got, exp := r.ContainsValue([]byte("cpu"), 2), true; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := r.ContainsValue("cpu", 3), true; got != exp {
+	if got, exp := r.ContainsValue([]byte("cpu"), 3), true; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -493,7 +493,7 @@ func TestTSMReader_MMAP_TombstoneOutsideKeyRange(t *testing.T) {
 		tsm1.NewValue(2, 2.0),
 		tsm1.NewValue(3, 3.0),
 	}
-	if err := w.Write("cpu", expValues); err != nil {
+	if err := w.Write([]byte("cpu"), expValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -515,20 +515,20 @@ func TestTSMReader_MMAP_TombstoneOutsideKeyRange(t *testing.T) {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
 
-	if err := r.DeleteRange([]string{"mem"}, 0, 3); err != nil {
+	if err := r.DeleteRange([][]byte{[]byte("mem")}, 0, 3); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 	defer r.Close()
 
-	if got, exp := r.ContainsValue("cpu", 1), true; got != exp {
+	if got, exp := r.ContainsValue([]byte("cpu"), 1), true; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := r.ContainsValue("cpu", 2), true; got != exp {
+	if got, exp := r.ContainsValue([]byte("cpu"), 2), true; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := r.ContainsValue("cpu", 3), true; got != exp {
+	if got, exp := r.ContainsValue([]byte("cpu"), 3), true; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -558,11 +558,11 @@ func TestTSMReader_MMAP_TombstoneOverlapKeyRange(t *testing.T) {
 		tsm1.NewValue(2, 2.0),
 		tsm1.NewValue(3, 3.0),
 	}
-	if err := w.Write("cpu,app=foo,host=server-0#!~#value", expValues); err != nil {
+	if err := w.Write([]byte("cpu,app=foo,host=server-0#!~#value"), expValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
-	if err := w.Write("cpu,app=foo,host=server-73379#!~#value", expValues); err != nil {
+	if err := w.Write([]byte("cpu,app=foo,host=server-73379#!~#value"), expValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -584,20 +584,20 @@ func TestTSMReader_MMAP_TombstoneOverlapKeyRange(t *testing.T) {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
 
-	if err := r.DeleteRange([]string{
-		"cpu,app=foo,host=server-0#!~#value",
-		"cpu,app=foo,host=server-73379#!~#value",
-		"cpu,app=foo,host=server-99999#!~#value"},
+	if err := r.DeleteRange([][]byte{
+		[]byte("cpu,app=foo,host=server-0#!~#value"),
+		[]byte("cpu,app=foo,host=server-73379#!~#value"),
+		[]byte("cpu,app=foo,host=server-99999#!~#value")},
 		math.MinInt64, math.MaxInt64); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 	defer r.Close()
 
-	if got, exp := r.Contains("cpu,app=foo,host=server-0#!~#value"), false; got != exp {
+	if got, exp := r.Contains([]byte("cpu,app=foo,host=server-0#!~#value")), false; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := r.Contains("cpu,app=foo,host=server-73379#!~#value"), false; got != exp {
+	if got, exp := r.Contains([]byte("cpu,app=foo,host=server-73379#!~#value")), false; got != exp {
 		t.Fatalf("ContainsValue mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -626,7 +626,7 @@ func TestTSMReader_MMAP_TombstoneFullRange(t *testing.T) {
 		tsm1.NewValue(2, 2.0),
 		tsm1.NewValue(3, 3.0),
 	}
-	if err := w.Write("cpu", expValues); err != nil {
+	if err := w.Write([]byte("cpu"), expValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -648,12 +648,12 @@ func TestTSMReader_MMAP_TombstoneFullRange(t *testing.T) {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
 
-	if err := r.DeleteRange([]string{"cpu"}, math.MinInt64, math.MaxInt64); err != nil {
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, math.MinInt64, math.MaxInt64); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 	defer r.Close()
 
-	values, err := r.ReadAll("cpu")
+	values, err := r.ReadAll([]byte("cpu"))
 	if err != nil {
 		t.Fatalf("unexpected error reading all: %v", err)
 	}
@@ -681,7 +681,7 @@ func TestTSMReader_MMAP_TombstoneMultipleRanges(t *testing.T) {
 		tsm1.NewValue(4, 4.0),
 		tsm1.NewValue(5, 5.0),
 	}
-	if err := w.Write("cpu", expValues); err != nil {
+	if err := w.Write([]byte("cpu"), expValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -704,15 +704,15 @@ func TestTSMReader_MMAP_TombstoneMultipleRanges(t *testing.T) {
 	}
 	defer r.Close()
 
-	if err := r.DeleteRange([]string{"cpu"}, 2, 2); err != nil {
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, 2, 2); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 
-	if err := r.DeleteRange([]string{"cpu"}, 4, 4); err != nil {
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, 4, 4); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 
-	values, err := r.ReadAll("cpu")
+	values, err := r.ReadAll([]byte("cpu"))
 	if err != nil {
 		t.Fatalf("unexpected error reading all: %v", err)
 	}
@@ -738,7 +738,7 @@ func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
 		tsm1.NewValue(2, 2.0),
 		tsm1.NewValue(3, 3.0),
 	}
-	if err := w.Write("cpu", cpuValues); err != nil {
+	if err := w.Write([]byte("cpu"), cpuValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -747,7 +747,7 @@ func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
 		tsm1.NewValue(2, 2.0),
 		tsm1.NewValue(30, 3.0),
 	}
-	if err := w.Write("mem", memValues); err != nil {
+	if err := w.Write([]byte("mem"), memValues); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -769,7 +769,7 @@ func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
 		t.Fatalf("unexpected error created reader: %v", err)
 	}
 
-	if err := r.DeleteRange([]string{"cpu", "mem"}, 5, math.MaxInt64); err != nil {
+	if err := r.DeleteRange([][]byte{[]byte("cpu"), []byte("mem")}, 5, math.MaxInt64); err != nil {
 		t.Fatalf("unexpected error deleting: %v", err)
 	}
 	defer r.Close()
@@ -778,11 +778,11 @@ func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
 		t.Fatalf("key count mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := len(r.TombstoneRange("cpu")), 0; got != exp {
+	if got, exp := len(r.TombstoneRange([]byte("cpu"))), 0; got != exp {
 		t.Fatalf("tombstone range mismatch: got %v, exp %v", got, exp)
 	}
 
-	values, err := r.ReadAll("cpu")
+	values, err := r.ReadAll([]byte("cpu"))
 	if err != nil {
 		t.Fatalf("unexpected error reading all: %v", err)
 	}
@@ -791,11 +791,11 @@ func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
 		t.Fatalf("values length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := len(r.TombstoneRange("mem")), 1; got != exp {
+	if got, exp := len(r.TombstoneRange([]byte("mem"))), 1; got != exp {
 		t.Fatalf("tombstone range mismatch: got %v, exp %v", got, exp)
 	}
 
-	values, err = r.ReadAll("mem")
+	values, err = r.ReadAll([]byte("mem"))
 	if err != nil {
 		t.Fatalf("unexpected error reading all: %v", err)
 	}
@@ -818,12 +818,12 @@ func TestTSMReader_MMAP_Stats(t *testing.T) {
 	}
 
 	values1 := []tsm1.Value{tsm1.NewValue(0, 1.0)}
-	if err := w.Write("cpu", values1); err != nil {
+	if err := w.Write([]byte("cpu"), values1); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
 	values2 := []tsm1.Value{tsm1.NewValue(1, 1.0)}
-	if err := w.Write("mem", values2); err != nil {
+	if err := w.Write([]byte("mem"), values2); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -847,11 +847,11 @@ func TestTSMReader_MMAP_Stats(t *testing.T) {
 	defer r.Close()
 
 	stats := r.Stats()
-	if got, exp := stats.MinKey, "cpu"; got != exp {
+	if got, exp := string(stats.MinKey), "cpu"; got != exp {
 		t.Fatalf("min key mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := stats.MaxKey, "mem"; got != exp {
+	if got, exp := string(stats.MaxKey), "mem"; got != exp {
 		t.Fatalf("max key mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -886,9 +886,9 @@ func TestTSMReader_VerifiesFileType(t *testing.T) {
 
 func TestIndirectIndex_Entries(t *testing.T) {
 	index := tsm1.NewIndexWriter()
-	index.Add("cpu", tsm1.BlockFloat64, 0, 1, 10, 100)
-	index.Add("cpu", tsm1.BlockFloat64, 2, 3, 20, 200)
-	index.Add("mem", tsm1.BlockFloat64, 0, 1, 10, 100)
+	index.Add([]byte("cpu"), tsm1.BlockFloat64, 0, 1, 10, 100)
+	index.Add([]byte("cpu"), tsm1.BlockFloat64, 2, 3, 20, 200)
+	index.Add([]byte("mem"), tsm1.BlockFloat64, 0, 1, 10, 100)
 
 	b, err := index.MarshalBinary()
 	if err != nil {
@@ -900,8 +900,8 @@ func TestIndirectIndex_Entries(t *testing.T) {
 		t.Fatalf("unexpected error unmarshaling index: %v", err)
 	}
 
-	exp := index.Entries("cpu")
-	entries := indirect.Entries("cpu")
+	exp := index.Entries([]byte("cpu"))
+	entries := indirect.Entries([]byte("cpu"))
 
 	if got, exp := len(entries), len(exp); got != exp {
 		t.Fatalf("entries length mismatch: got %v, exp %v", got, exp)
@@ -928,8 +928,8 @@ func TestIndirectIndex_Entries(t *testing.T) {
 
 func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 	index := tsm1.NewIndexWriter()
-	index.Add("cpu", tsm1.BlockFloat64, 0, 1, 10, 100)
-	index.Add("cpu", tsm1.BlockFloat64, 2, 3, 20, 200)
+	index.Add([]byte("cpu"), tsm1.BlockFloat64, 0, 1, 10, 100)
+	index.Add([]byte("cpu"), tsm1.BlockFloat64, 2, 3, 20, 200)
 
 	b, err := index.MarshalBinary()
 	if err != nil {
@@ -943,8 +943,8 @@ func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 
 	// mem has not been added to the index so we should get no entries back
 	// for both
-	exp := index.Entries("mem")
-	entries := indirect.Entries("mem")
+	exp := index.Entries([]byte("mem"))
+	entries := indirect.Entries([]byte("mem"))
 
 	if got, exp := len(entries), len(exp); got != exp && exp != 0 {
 		t.Fatalf("entries length mismatch: got %v, exp %v", got, exp)
@@ -954,7 +954,7 @@ func TestIndirectIndex_Entries_NonExistent(t *testing.T) {
 func TestIndirectIndex_MaxBlocks(t *testing.T) {
 	index := tsm1.NewIndexWriter()
 	for i := 0; i < 1<<16; i++ {
-		index.Add("cpu", tsm1.BlockFloat64, 0, 1, 10, 20)
+		index.Add([]byte("cpu"), tsm1.BlockFloat64, 0, 1, 10, 20)
 	}
 
 	if _, err := index.MarshalBinary(); err == nil {
@@ -966,7 +966,7 @@ func TestIndirectIndex_MaxBlocks(t *testing.T) {
 
 func TestIndirectIndex_Type(t *testing.T) {
 	index := tsm1.NewIndexWriter()
-	index.Add("cpu", tsm1.BlockInteger, 0, 1, 10, 20)
+	index.Add([]byte("cpu"), tsm1.BlockInteger, 0, 1, 10, 20)
 
 	b, err := index.MarshalBinary()
 	if err != nil {
@@ -978,7 +978,7 @@ func TestIndirectIndex_Type(t *testing.T) {
 		fatal(t, "unmarshal binary", err)
 	}
 
-	typ, err := ind.Type("cpu")
+	typ, err := ind.Type([]byte("cpu"))
 	if err != nil {
 		fatal(t, "reading type", err)
 	}
@@ -990,9 +990,9 @@ func TestIndirectIndex_Type(t *testing.T) {
 
 func TestIndirectIndex_Keys(t *testing.T) {
 	index := tsm1.NewIndexWriter()
-	index.Add("cpu", tsm1.BlockFloat64, 0, 1, 10, 20)
-	index.Add("mem", tsm1.BlockFloat64, 0, 1, 10, 20)
-	index.Add("cpu", tsm1.BlockFloat64, 1, 2, 20, 30)
+	index.Add([]byte("cpu"), tsm1.BlockFloat64, 0, 1, 10, 20)
+	index.Add([]byte("mem"), tsm1.BlockFloat64, 0, 1, 10, 20)
+	index.Add([]byte("cpu"), tsm1.BlockFloat64, 1, 2, 20, 30)
 
 	keys := index.Keys()
 
@@ -1002,11 +1002,11 @@ func TestIndirectIndex_Keys(t *testing.T) {
 	}
 
 	// Keys should be sorted
-	if got, exp := keys[0], "cpu"; got != exp {
+	if got, exp := string(keys[0]), "cpu"; got != exp {
 		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := keys[1], "mem"; got != exp {
+	if got, exp := string(keys[1]), "mem"; got != exp {
 		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -1022,7 +1022,7 @@ func TestBlockIterator_Single(t *testing.T) {
 	}
 
 	values := []tsm1.Value{tsm1.NewValue(0, int64(1))}
-	if err := w.Write("cpu", values); err != nil {
+	if err := w.Write([]byte("cpu"), values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 
 	}
@@ -1052,7 +1052,7 @@ func TestBlockIterator_Single(t *testing.T) {
 			t.Fatalf("unexpected error creating iterator: %v", err)
 		}
 
-		if got, exp := key, "cpu"; got != exp {
+		if got, exp := string(key), "cpu"; got != exp {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -1091,12 +1091,12 @@ func TestBlockIterator_MultipleBlocks(t *testing.T) {
 	}
 
 	values1 := []tsm1.Value{tsm1.NewValue(0, int64(1))}
-	if err := w.Write("cpu", values1); err != nil {
+	if err := w.Write([]byte("cpu"), values1); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
 	values2 := []tsm1.Value{tsm1.NewValue(1, int64(2))}
-	if err := w.Write("cpu", values2); err != nil {
+	if err := w.Write([]byte("cpu"), values2); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -1129,7 +1129,7 @@ func TestBlockIterator_MultipleBlocks(t *testing.T) {
 			t.Fatalf("unexpected error creating iterator: %v", err)
 		}
 
-		if got, exp := key, "cpu"; got != exp {
+		if got, exp := string(key), "cpu"; got != exp {
 			t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 		}
 
@@ -1177,7 +1177,7 @@ func TestBlockIterator_Sorted(t *testing.T) {
 	}
 
 	for k, v := range values {
-		if err := w.Write(k, v); err != nil {
+		if err := w.Write([]byte(k), v); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 
 		}
@@ -1207,11 +1207,11 @@ func TestBlockIterator_Sorted(t *testing.T) {
 	for iter.Next() {
 		key, _, _, _, _, buf, err := iter.Read()
 
-		if key < lastKey {
+		if string(key) < lastKey {
 			t.Fatalf("keys not sorted: got %v, last %v", key, lastKey)
 		}
 
-		lastKey = key
+		lastKey = string(key)
 
 		if err != nil {
 			t.Fatalf("unexpected error creating iterator: %v", err)
@@ -1241,7 +1241,7 @@ func TestIndirectIndex_UnmarshalBinary_BlockCountOverflow(t *testing.T) {
 	}
 
 	for i := 0; i < 3280; i++ {
-		w.Write("cpu", []tsm1.Value{tsm1.NewValue(int64(i), float64(i))})
+		w.Write([]byte("cpu"), []tsm1.Value{tsm1.NewValue(int64(i), float64(i))})
 	}
 
 	if err := w.WriteIndex(); err != nil {
@@ -1275,7 +1275,7 @@ func TestCompacted_NotFull(t *testing.T) {
 	}
 
 	values := []tsm1.Value{tsm1.NewValue(0, 1.0)}
-	if err := w.Write("cpu", values); err != nil {
+	if err := w.Write([]byte("cpu"), values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 
 	}
@@ -1345,7 +1345,7 @@ func TestTSMReader_File_ReadAll(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -1371,7 +1371,7 @@ func TestTSMReader_File_ReadAll(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.ReadAll(d.key)
+		readValues, err := r.ReadAll([]byte(d.key))
 		if err != nil {
 			t.Fatalf("unexpected error reading: %v", err)
 		}
@@ -1494,7 +1494,7 @@ func TestTSMReader_File_Read(t *testing.T) {
 		},
 	}
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -1520,7 +1520,7 @@ func TestTSMReader_File_Read(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.Read(d.key, d.values[0].UnixNano())
+		readValues, err := r.Read([]byte(d.key), d.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -1574,7 +1574,7 @@ func TestTSMReader_References(t *testing.T) {
 		},
 	}
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -1610,7 +1610,7 @@ func TestTSMReader_References(t *testing.T) {
 
 	var count int
 	for _, d := range data {
-		readValues, err := r.Read(d.key, d.values[0].UnixNano())
+		readValues, err := r.Read([]byte(d.key), d.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -1644,7 +1644,7 @@ func TestTSMReader_References(t *testing.T) {
 func BenchmarkIndirectIndex_UnmarshalBinary(b *testing.B) {
 	index := tsm1.NewIndexWriter()
 	for i := 0; i < 100000; i++ {
-		index.Add(fmt.Sprintf("cpu-%d", i), tsm1.BlockFloat64, int64(i*2), int64(i*2+1), 10, 100)
+		index.Add([]byte(fmt.Sprintf("cpu-%d", i)), tsm1.BlockFloat64, int64(i*2), int64(i*2+1), 10, 100)
 	}
 
 	bytes, err := index.MarshalBinary()

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -43,12 +43,12 @@ func TestRing_newRing(t *testing.T) {
 	}
 }
 
-var strSliceRes []string
+var strSliceRes [][]byte
 
 func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	// Add some keys
 	for i := 0; i < keys; i++ {
-		r.add(fmt.Sprintf("cpu,host=server-%d value=1", i), nil)
+		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), nil)
 	}
 
 	b.ReportAllocs()
@@ -64,11 +64,11 @@ func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(
 func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(256), 100000) }
 
 func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
-	vals := make([]string, keys)
+	vals := make([][]byte, keys)
 
 	// Add some keys
 	for i := 0; i < keys; i++ {
-		vals[i] = fmt.Sprintf("cpu,host=server-%d field1=value1,field2=value2,field4=value4,field5=value5,field6=value6,field7=value7,field8=value1,field9=value2,field10=value4,field11=value5,field12=value6,field13=value7", i)
+		vals[i] = []byte(fmt.Sprintf("cpu,host=server-%d field1=value1,field2=value2,field4=value4,field5=value5,field6=value6,field7=value7,field8=value1,field9=value2,field10=value4,field11=value5,field12=value6,field13=value7", i))
 		r.add(vals[i], nil)
 	}
 
@@ -94,7 +94,7 @@ func benchmarkRingWrite(b *testing.B, r *ring, n int) {
 			go func() {
 				defer wg.Done()
 				for j := 0; j < n; j++ {
-					if err := r.write(fmt.Sprintf("cpu,host=server-%d value=1", j), Values{}); err != nil {
+					if err := r.write([]byte(fmt.Sprintf("cpu,host=server-%d value=1", j)), Values{}); err != nil {
 						errC <- err
 					}
 				}

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -29,7 +29,7 @@ func TestTombstoner_Add(t *testing.T) {
 		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
 	}
 
-	ts.Add([]string{"foo"})
+	ts.Add([][]byte{[]byte("foo")})
 
 	entries, err = ts.ReadAll()
 	if err != nil {
@@ -57,7 +57,7 @@ func TestTombstoner_Add(t *testing.T) {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := entries[0].Key, "foo"; got != exp {
+	if got, exp := string(entries[0].Key), "foo"; got != exp {
 		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -72,7 +72,7 @@ func TestTombstoner_Add(t *testing.T) {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := entries[0].Key, "foo"; got != exp {
+	if got, exp := string(entries[0].Key), "foo"; got != exp {
 		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -93,7 +93,7 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
 
-	ts.Add([]string{})
+	ts.Add([][]byte{})
 
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}
@@ -120,7 +120,7 @@ func TestTombstoner_Delete(t *testing.T) {
 	f := MustTempFile(dir)
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
-	ts.Add([]string{"foo"})
+	ts.Add([][]byte{[]byte("foo")})
 
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}
@@ -133,8 +133,8 @@ func TestTombstoner_Delete(t *testing.T) {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := entries[0].Key, "foo"; got != exp {
-		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	if got, exp := string(entries[0].Key), "foo"; got != exp {
+		t.Fatalf("value mismatch: got %s, exp %s", got, exp)
 	}
 
 	if err := ts.Delete(); err != nil {
@@ -187,7 +187,7 @@ func TestTombstoner_ReadV1(t *testing.T) {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := entries[0].Key, "foo"; got != exp {
+	if got, exp := string(entries[0].Key), "foo"; got != exp {
 		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -202,7 +202,7 @@ func TestTombstoner_ReadV1(t *testing.T) {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := entries[0].Key, "foo"; got != exp {
+	if got, exp := string(entries[0].Key), "foo"; got != exp {
 		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
 	}
 }

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -2,6 +2,7 @@ package tsm1
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -479,7 +480,7 @@ func (l *WAL) CloseSegment() error {
 }
 
 // Delete deletes the given keys, returning the segment ID for the operation.
-func (l *WAL) Delete(keys []string) (int, error) {
+func (l *WAL) Delete(keys [][]byte) (int, error) {
 	if len(keys) == 0 {
 		return 0, nil
 	}
@@ -496,7 +497,7 @@ func (l *WAL) Delete(keys []string) (int, error) {
 
 // DeleteRange deletes the given keys within the given time range,
 // returning the segment ID for the operation.
-func (l *WAL) DeleteRange(keys []string, min, max int64) (int, error) {
+func (l *WAL) DeleteRange(keys [][]byte, min, max int64) (int, error) {
 	if len(keys) == 0 {
 		return 0, nil
 	}
@@ -877,7 +878,7 @@ func (w *WriteWALEntry) Type() WalEntryType {
 
 // DeleteWALEntry represents the deletion of multiple series.
 type DeleteWALEntry struct {
-	Keys []string
+	Keys [][]byte
 	sz   int
 }
 
@@ -889,7 +890,7 @@ func (w *DeleteWALEntry) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary deserializes the byte slice into w.
 func (w *DeleteWALEntry) UnmarshalBinary(b []byte) error {
-	w.Keys = strings.Split(string(b), "\n")
+	w.Keys = bytes.Split(b, []byte("\n"))
 	return nil
 }
 
@@ -934,7 +935,7 @@ func (w *DeleteWALEntry) Type() WalEntryType {
 
 // DeleteRangeWALEntry represents the deletion of multiple series.
 type DeleteRangeWALEntry struct {
-	Keys     []string
+	Keys     [][]byte
 	Min, Max int64
 	sz       int
 }
@@ -965,7 +966,7 @@ func (w *DeleteRangeWALEntry) UnmarshalBinary(b []byte) error {
 		if i+sz > len(b) {
 			return ErrWALCorrupt
 		}
-		w.Keys = append(w.Keys, string(b[i:i+sz]))
+		w.Keys = append(w.Keys, b[i:i+sz])
 		i += sz
 	}
 	return nil

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -216,7 +216,7 @@ func TestWALWriter_WriteDelete_Single(t *testing.T) {
 	w := tsm1.NewWALSegmentWriter(f)
 
 	entry := &tsm1.DeleteWALEntry{
-		Keys: []string{"cpu"},
+		Keys: [][]byte{[]byte("cpu")},
 	}
 
 	if err := w.Write(mustMarshalEntry(entry)); err != nil {
@@ -251,7 +251,7 @@ func TestWALWriter_WriteDelete_Single(t *testing.T) {
 		t.Fatalf("key length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := e.Keys[0], entry.Keys[0]; got != exp {
+	if got, exp := string(e.Keys[0]), string(entry.Keys[0]); got != exp {
 		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -281,7 +281,7 @@ func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
 
 	// Write the delete entry
 	deleteEntry := &tsm1.DeleteWALEntry{
-		Keys: []string{"cpu,host=A#!~value"},
+		Keys: [][]byte{[]byte("cpu,host=A#!~value")},
 	}
 
 	if err := w.Write(mustMarshalEntry(deleteEntry)); err != nil {
@@ -345,7 +345,7 @@ func TestWALWriter_WriteMultiDelete_Multiple(t *testing.T) {
 		t.Fatalf("key length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := de.Keys[0], deleteEntry.Keys[0]; got != exp {
+	if got, exp := string(de.Keys[0]), string(deleteEntry.Keys[0]); got != exp {
 		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -378,7 +378,7 @@ func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
 
 	// Write the delete entry
 	deleteEntry := &tsm1.DeleteRangeWALEntry{
-		Keys: []string{"cpu,host=A#!~value"},
+		Keys: [][]byte{[]byte("cpu,host=A#!~value")},
 		Min:  2,
 		Max:  3,
 	}
@@ -444,7 +444,7 @@ func TestWALWriter_WriteMultiDeleteRange_Multiple(t *testing.T) {
 		t.Fatalf("key length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := de.Keys[0], deleteEntry.Keys[0]; got != exp {
+	if got, exp := string(de.Keys[0]), string(deleteEntry.Keys[0]); got != exp {
 		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -522,7 +522,7 @@ func TestWAL_Delete(t *testing.T) {
 		t.Fatalf("close segment length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if _, err := w.Delete([]string{"cpu"}); err != nil {
+	if _, err := w.Delete([][]byte{[]byte("cpu")}); err != nil {
 		t.Fatalf("error writing points: %v", err)
 	}
 
@@ -641,7 +641,7 @@ func TestWriteWALSegment_UnmarshalBinary_WriteWALCorrupt(t *testing.T) {
 
 func TestWriteWALSegment_UnmarshalBinary_DeleteWALCorrupt(t *testing.T) {
 	w := &tsm1.DeleteWALEntry{
-		Keys: []string{"foo", "bar"},
+		Keys: [][]byte{[]byte("foo"), []byte("bar")},
 	}
 
 	b, err := w.MarshalBinary()
@@ -663,7 +663,7 @@ func TestWriteWALSegment_UnmarshalBinary_DeleteWALCorrupt(t *testing.T) {
 
 func TestWriteWALSegment_UnmarshalBinary_DeleteRangeWALCorrupt(t *testing.T) {
 	w := &tsm1.DeleteRangeWALEntry{
-		Keys: []string{"foo", "bar"},
+		Keys: [][]byte{[]byte("foo"), []byte("bar")},
 		Min:  1,
 		Max:  2,
 	}

--- a/tsdb/engine/tsm1/writer_test.go
+++ b/tsdb/engine/tsm1/writer_test.go
@@ -34,7 +34,7 @@ func TestTSMWriter_Write_NoValues(t *testing.T) {
 		t.Fatalf("unexpected error created writer: %v", err)
 	}
 
-	if err := w.Write("foo", []tsm1.Value{}); err != nil {
+	if err := w.Write([]byte("foo"), []tsm1.Value{}); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 	}
 
@@ -58,7 +58,7 @@ func TestTSMWriter_Write_Single(t *testing.T) {
 	}
 
 	values := []tsm1.Value{tsm1.NewValue(0, 1.0)}
-	if err := w.Write("cpu", values); err != nil {
+	if err := w.Write([]byte("cpu"), values); err != nil {
 		t.Fatalf("unexpected error writing: %v", err)
 
 	}
@@ -97,7 +97,7 @@ func TestTSMWriter_Write_Single(t *testing.T) {
 	}
 	defer r.Close()
 
-	readValues, err := r.ReadAll("cpu")
+	readValues, err := r.ReadAll([]byte("cpu"))
 	if err != nil {
 		t.Fatalf("unexpected error readin: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestTSMWriter_Write_Multiple(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -157,7 +157,7 @@ func TestTSMWriter_Write_Multiple(t *testing.T) {
 	defer r.Close()
 
 	for _, d := range data {
-		readValues, err := r.ReadAll(d.key)
+		readValues, err := r.ReadAll([]byte(d.key))
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -199,7 +199,7 @@ func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -224,7 +224,7 @@ func TestTSMWriter_Write_MultipleKeyValues(t *testing.T) {
 	defer r.Close()
 
 	for _, d := range data {
-		readValues, err := r.ReadAll(d.key)
+		readValues, err := r.ReadAll([]byte(d.key))
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -267,7 +267,7 @@ func TestTSMWriter_Write_ReverseKeys(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -292,7 +292,7 @@ func TestTSMWriter_Write_ReverseKeys(t *testing.T) {
 	defer r.Close()
 
 	for _, d := range data {
-		readValues, err := r.ReadAll(d.key)
+		readValues, err := r.ReadAll([]byte(d.key))
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -335,7 +335,7 @@ func TestTSMWriter_Write_SameKey(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -361,7 +361,7 @@ func TestTSMWriter_Write_SameKey(t *testing.T) {
 
 	values := append(data[0].values, data[1].values...)
 
-	readValues, err := r.ReadAll("cpu")
+	readValues, err := r.ReadAll([]byte("cpu"))
 	if err != nil {
 		t.Fatalf("unexpected error readin: %v", err)
 	}
@@ -404,7 +404,7 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -430,7 +430,7 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 
 	for _, values := range data {
 		// Try the first timestamp
-		readValues, err := r.Read("cpu", values.values[0].UnixNano())
+		readValues, err := r.Read([]byte("cpu"), values.values[0].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -446,7 +446,7 @@ func TestTSMWriter_Read_Multiple(t *testing.T) {
 		}
 
 		// Try the last timestamp too
-		readValues, err = r.Read("cpu", values.values[1].UnixNano())
+		readValues, err = r.Read([]byte("cpu"), values.values[1].UnixNano())
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -473,7 +473,7 @@ func TestTSMWriter_WriteBlock_Empty(t *testing.T) {
 		t.Fatalf("unexpected error creating writer: %v", err)
 	}
 
-	if err := w.WriteBlock("cpu", 0, 0, nil); err != nil {
+	if err := w.WriteBlock([]byte("cpu"), 0, 0, nil); err != nil {
 		t.Fatalf("unexpected error writing block: %v", err)
 	}
 
@@ -516,7 +516,7 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 	}
 
 	for _, d := range data {
-		if err := w.Write(d.key, d.values); err != nil {
+		if err := w.Write([]byte(d.key), d.values); err != nil {
 			t.Fatalf("unexpected error writing: %v", err)
 		}
 	}
@@ -569,7 +569,7 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error reading block: %v", err)
 		}
-		if err := w.WriteBlock(key, minTime, maxTime, b); err != nil {
+		if err := w.WriteBlock([]byte(key), minTime, maxTime, b); err != nil {
 			t.Fatalf("unexpected error writing block: %v", err)
 		}
 	}
@@ -595,7 +595,7 @@ func TestTSMWriter_WriteBlock_Multiple(t *testing.T) {
 	defer r.Close()
 
 	for _, d := range data {
-		readValues, err := r.ReadAll(d.key)
+		readValues, err := r.ReadAll([]byte(d.key))
 		if err != nil {
 			t.Fatalf("unexpected error readin: %v", err)
 		}
@@ -627,7 +627,7 @@ func TestTSMWriter_WriteBlock_MaxKey(t *testing.T) {
 		key += "a"
 	}
 
-	if err := w.WriteBlock(key, 0, 0, nil); err != tsm1.ErrMaxKeyLengthExceeded {
+	if err := w.WriteBlock([]byte(key), 0, 0, nil); err != tsm1.ErrMaxKeyLengthExceeded {
 		t.Fatalf("expected max key length error writing key: %v", err)
 	}
 }
@@ -647,7 +647,7 @@ func TestTSMWriter_Write_MaxKey(t *testing.T) {
 	for i := 0; i < 100000; i++ {
 		key += "a"
 	}
-	if err := w.Write(key, []tsm1.Value{tsm1.NewValue(0, 1.0)}); err != tsm1.ErrMaxKeyLengthExceeded {
+	if err := w.Write([]byte(key), []tsm1.Value{tsm1.NewValue(0, 1.0)}); err != tsm1.ErrMaxKeyLengthExceeded {
 		t.Fatalf("expected max key length error writing key: %v", err)
 	}
 }


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This change reduces memory usage running queries.  The bulk of the change is converting everywhere in the TSM engine that uses a `string` key to use `[]byte`.  There were lots of little allocations from converting between the two.

Some before and after memory usage querying 100M values w/ 1M series 10 times in a row.

<img width="467" alt="screen shot 2017-07-27 at 3 47 45 pm" src="https://user-images.githubusercontent.com/219935/28693636-fc61dbe6-72e2-11e7-95e4-ab6e5665ed13.png">

RSS improved about 22% with this change.  Mean query time across all runs improved about 40% (14.8s->8.8s).