### PR TITLE
Remove unused filestore reference

### DIFF
--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -859,7 +859,6 @@ func ParseTSMFileName(name string) (int, int, error) {
 // KeyCursor allows iteration through keys in a set of files within a FileStore.
 type KeyCursor struct {
 	key []byte
-	fs  *FileStore
 
 	// seeks is all the file locations that we need to return during iteration.
 	seeks []*location
@@ -932,7 +931,6 @@ func (a ascLocations) Less(i, j int) bool {
 func newKeyCursor(fs *FileStore, key []byte, t int64, ascending bool) *KeyCursor {
 	c := &KeyCursor{
 		key:       key,
-		fs:        fs,
 		seeks:     fs.locations(key, t, ascending),
 		ascending: ascending,
 	}
@@ -963,7 +961,6 @@ func (c *KeyCursor) Close() {
 
 	c.buf = nil
 	c.seeks = nil
-	c.fs = nil
 	c.current = nil
 }
 


### PR DESCRIPTION
Reduces cursor struct size from 119 bytes to 111.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
