### PR TITLE
Improve performance of SHOW TAG VALUES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,8 @@
 ### Bugfixes
 
 - [#8629](https://github.com/influxdata/influxdb/pull/8629): Interrupt in progress TSM compactions
-
-## v1.3.2 [unreleased]
-
 - [#8630](https://github.com/influxdata/influxdb/pull/8630): Prevent excessive memory usage when dropping series
-
+- [#8640](https://github.com/influxdata/influxdb/issues/8640): Significantly improve performance of SHOW TAG VALUES.
 
 ## v1.3.1 [2017-07-20]
 

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -480,6 +480,11 @@ func NewConfig() *run.Config {
 	c.Data.Dir = MustTempFile()
 	c.Data.WALDir = MustTempFile()
 
+	indexVersion := os.Getenv("INFLUXDB_DATA_INDEX_VERSION")
+	if indexVersion != "" {
+		c.Data.Index = indexVersion
+	}
+
 	c.HTTPD.Enabled = true
 	c.HTTPD.BindAddress = "127.0.0.1:0"
 	c.HTTPD.LogEnabled = testing.Verbose()

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -63,6 +63,7 @@ type Engine interface {
 	// TagKeys(name []byte) ([][]byte, error)
 	HasTagKey(name, key []byte) (bool, error)
 	MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error)
+	MeasurementTagKeyValuesByExpr(name, key []byte, expr influxql.Expr) (map[string]struct{}, error)
 	ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error
 	TagKeyCardinality(name, key []byte) int
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -63,7 +63,7 @@ type Engine interface {
 	// TagKeys(name []byte) ([][]byte, error)
 	HasTagKey(name, key []byte) (bool, error)
 	MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error)
-	MeasurementTagKeyValuesByExpr(name, key []byte, expr influxql.Expr) (map[string]struct{}, error)
+	MeasurementTagKeyValuesByExpr(name []byte, key []string, expr influxql.Expr, keysSorted bool) ([][]string, error)
 	ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error
 	TagKeyCardinality(name, key []byte) int
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -348,6 +348,10 @@ func (e *Engine) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[
 	return e.index.MeasurementTagKeysByExpr(name, expr)
 }
 
+func (e *Engine) MeasurementTagKeyValuesByExpr(name, key []byte, expr influxql.Expr) (map[string]struct{}, error) {
+	return e.index.MeasurementTagKeyValuesByExpr(name, key, expr)
+}
+
 func (e *Engine) ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error {
 	return e.index.ForEachMeasurementTagKey(name, fn)
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -348,8 +348,17 @@ func (e *Engine) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[
 	return e.index.MeasurementTagKeysByExpr(name, expr)
 }
 
-func (e *Engine) MeasurementTagKeyValuesByExpr(name, key []byte, expr influxql.Expr) (map[string]struct{}, error) {
-	return e.index.MeasurementTagKeyValuesByExpr(name, key, expr)
+// MeasurementTagKeyValuesByExpr returns a set of tag values filtered by an expression.
+//
+// MeasurementTagKeyValuesByExpr relies on the provided tag keys being sorted.
+// The caller can indicate the tag keys have been sorted by setting the
+// keysSorted argument appropriately. Tag values are returned in a slice that
+// is indexible according to the sorted order of the tag keys, e.g., the values
+// for the earliest tag k will be available in index 0 of the returned values
+// slice.
+//
+func (e *Engine) MeasurementTagKeyValuesByExpr(name []byte, keys []string, expr influxql.Expr, keysSorted bool) ([][]string, error) {
+	return e.index.MeasurementTagKeyValuesByExpr(name, keys, expr, keysSorted)
 }
 
 func (e *Engine) ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error {

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -35,7 +35,8 @@ type Index interface {
 	HasTagKey(name, key []byte) (bool, error)
 	TagSets(name []byte, options influxql.IteratorOptions) ([]*influxql.TagSet, error)
 	MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error)
-	MeasurementTagKeyValuesByExpr(name, key []byte, expr influxql.Expr) (map[string]struct{}, error)
+	MeasurementTagKeyValuesByExpr(name []byte, keys []string, expr influxql.Expr, keysSorted bool) ([][]string, error)
+
 	ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error
 	TagKeyCardinality(name, key []byte) int
 

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -35,6 +35,7 @@ type Index interface {
 	HasTagKey(name, key []byte) (bool, error)
 	TagSets(name []byte, options influxql.IteratorOptions) ([]*influxql.TagSet, error)
 	MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error)
+	MeasurementTagKeyValuesByExpr(name, key []byte, expr influxql.Expr) (map[string]struct{}, error)
 	ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error
 	TagKeyCardinality(name, key []byte) int
 

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -14,11 +14,9 @@ package inmem
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"regexp"
 	"sort"
 	"sync"
-	"unsafe"
 	// "sync/atomic"
 
 	"github.com/influxdata/influxdb/influxql"
@@ -325,9 +323,9 @@ func (i *Index) MeasurementTagKeyValuesByExpr(name []byte, keys []string, expr i
 		// Iterate the tag keys we're interested in and collect values
 		// from this series, if they exist.
 		for _, t := range s.Tags() {
-			if idx, ok := keyIdxs[unsafeBytesToString(t.Key)]; ok {
+			if idx, ok := keyIdxs[string(t.Key)]; ok {
 				resultSet[idx].add(string(t.Value))
-			} else if unsafeBytesToString(t.Key) > keys[len(keys)-1] {
+			} else if string(t.Key) > keys[len(keys)-1] {
 				// The tag key is > the largest key we're interested in.
 				break
 			}
@@ -337,20 +335,6 @@ func (i *Index) MeasurementTagKeyValuesByExpr(name []byte, keys []string, expr i
 		results[i] = s.list()
 	}
 	return results, nil
-}
-
-// unsafeBytesToString converts a []byte to a string without a heap allocation.
-//
-// It is unsafe, and is intended to prepare input to short-lived functions
-// that require strings.
-func unsafeBytesToString(in []byte) string {
-	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
-	dst := reflect.StringHeader{
-		Data: src.Data,
-		Len:  src.Len,
-	}
-	s := *(*string)(unsafe.Pointer(&dst))
-	return s
 }
 
 // ForEachMeasurementTagKey iterates over all tag keys for a measurement.

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -269,6 +269,30 @@ func (i *Index) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[s
 	return mm.TagKeysByExpr(expr)
 }
 
+// MeasurementTagKeyValuesByExpr returns a set of tag values filtered by an expression.
+func (i *Index) MeasurementTagKeyValuesByExpr(name, key []byte, expr influxql.Expr) (map[string]struct{}, error) {
+	i.mu.RLock()
+	mm := i.measurements[string(name)]
+	i.mu.RUnlock()
+
+	if mm == nil {
+		return nil, nil
+	}
+
+	ids, _, _ := mm.WalkWhereForSeriesIds(expr)
+	if ids.Len() == 0 && expr == nil {
+		values := mm.TagValues(string(key))
+		x := make(map[string]struct{}, len(values))
+		for _, v := range values {
+			x[v] = struct{}{}
+		}
+		return x, nil
+	}
+
+	vals := mm.tagValuesByKeyAndSeriesID([]string{string(key)}, ids)[string(key)]
+	return vals, nil
+}
+
 // ForEachMeasurementTagKey iterates over all tag keys for a measurement.
 func (i *Index) ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error {
 	// Ensure we do not hold a lock on the index while fn executes in case fn tries

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -1465,38 +1465,9 @@ func (m *Measurement) FieldNames() []string {
 	return a
 }
 
-func (m *Measurement) tagValuesByKeyAndSeriesID(tagKeys []string, ids SeriesIDs) map[string]stringSet {
-	// If no tag keys were passed, get all tag keys for the measurement.
-	if len(tagKeys) == 0 {
-		for k := range m.seriesByTagKeyValue {
-			tagKeys = append(tagKeys, k)
-		}
-	}
+func (m *Measurement) tagValuesByKeyAndSeriesID(tagKeys []string, ids SeriesIDs) [][]string {
 
-	// Mapping between tag keys to all existing tag values.
-	tagValues := make(map[string]stringSet, 0)
-
-	// Iterate all series to collect tag values.
-	for _, id := range ids {
-		s, ok := m.seriesByID[id]
-		if !ok {
-			continue
-		}
-
-		// Iterate the tag keys we're interested in and collect values
-		// from this series, if they exist.
-		tags := s.Tags()
-		for _, tagKey := range tagKeys {
-			if tagVal := tags.GetString(tagKey); tagVal != "" {
-				if _, ok = tagValues[tagKey]; !ok {
-					tagValues[tagKey] = newStringSet()
-				}
-				tagValues[tagKey].add(tagVal)
-			}
-		}
-	}
-
-	return tagValues
+	return nil
 }
 
 func (m *Measurement) SeriesByTagKeyValue(key string) map[string]SeriesIDs {

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -1465,11 +1465,6 @@ func (m *Measurement) FieldNames() []string {
 	return a
 }
 
-func (m *Measurement) tagValuesByKeyAndSeriesID(tagKeys []string, ids SeriesIDs) [][]string {
-
-	return nil
-}
-
 func (m *Measurement) SeriesByTagKeyValue(key string) map[string]SeriesIDs {
 	m.mu.RLock()
 	ret := m.seriesByTagKeyValue[key]

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
+	"unsafe"
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
@@ -282,29 +284,62 @@ func (fs *FileSet) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (ma
 	return nil, fmt.Errorf("%#v", expr)
 }
 
-func (fs *FileSet) tagValuesByKeyAndExpr(name, key []byte, expr influxql.Expr, fieldset *tsdb.MeasurementFieldSet) (map[string]struct{}, error) {
+// tagValuesByKeyAndExpr retrieves tag values for the provided tag keys.
+//
+// tagValuesByKeyAndExpr returns sets of values for each key, indexable by the
+// position of the tag key in the keys argument.
+//
+// N.B tagValuesByKeyAndExpr relies on keys being sorted in ascending
+// lexicographic order.
+func (fs *FileSet) tagValuesByKeyAndExpr(name []byte, keys []string, expr influxql.Expr, fieldset *tsdb.MeasurementFieldSet) ([]map[string]struct{}, error) {
 	itr, err := fs.seriesByExprIterator(name, expr, fieldset.Fields(string(name)))
 	if err != nil {
 		return nil, err
 	} else if itr == nil {
 		return nil, nil
 	}
-	// Set of all tag values.
-	tagValues := make(map[string]struct{})
 
-	// Iterate all series to collect tag values.
-	for e := itr.Next(); e != nil; e = itr.Next() {
+	keyIdxs := make(map[string]int, len(keys))
+	for ki, key := range keys {
+		keyIdxs[key] = ki
 
-		// Iterate the tag keys we're interested in and collect values
-		// from this series, if they exist.
-		tags := e.Tags()
-		tagVal := tags.Get(key)
-		if _, ok := tagValues[string(tagVal)]; !ok {
-			tagValues[string(tagVal)] = struct{}{}
+		// Check that keys are in order.
+		if ki > 0 && key < keys[ki-1] {
+			return nil, fmt.Errorf("keys %v are not in ascending order", keys)
 		}
 	}
 
-	return tagValues, nil
+	resultSet := make([]map[string]struct{}, len(keys))
+	for i := 0; i < len(resultSet); i++ {
+		resultSet[i] = make(map[string]struct{})
+	}
+
+	// Iterate all series to collect tag values.
+	for e := itr.Next(); e != nil; e = itr.Next() {
+		for _, t := range e.Tags() {
+			if idx, ok := keyIdxs[unsafeBytesToString(t.Key)]; ok {
+				resultSet[idx][string(t.Value)] = struct{}{}
+			} else if unsafeBytesToString(t.Key) > keys[len(keys)-1] {
+				// The tag key is > the largest key we're interested in.
+				break
+			}
+		}
+	}
+	return resultSet, nil
+}
+
+// unsafeBytesToString converts a []byte to a string without a heap allocation.
+//
+// It is unsafe, and is intended to prepare input to short-lived functions
+// that require strings.
+func unsafeBytesToString(in []byte) string {
+	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
+	dst := reflect.StringHeader{
+		Data: src.Data,
+		Len:  src.Len,
+	}
+	s := *(*string)(unsafe.Pointer(&dst))
+	return s
 }
 
 // tagKeysByFilter will filter the tag keys for the measurement.

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -282,6 +282,31 @@ func (fs *FileSet) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (ma
 	return nil, fmt.Errorf("%#v", expr)
 }
 
+func (fs *FileSet) tagValuesByKeyAndExpr(name, key []byte, expr influxql.Expr, fieldset *tsdb.MeasurementFieldSet) (map[string]struct{}, error) {
+	itr, err := fs.seriesByExprIterator(name, expr, fieldset.Fields(string(name)))
+	if err != nil {
+		return nil, err
+	} else if itr == nil {
+		return nil, nil
+	}
+	// Set of all tag values.
+	tagValues := make(map[string]struct{})
+
+	// Iterate all series to collect tag values.
+	for e := itr.Next(); e != nil; e = itr.Next() {
+
+		// Iterate the tag keys we're interested in and collect values
+		// from this series, if they exist.
+		tags := e.Tags()
+		tagVal := tags.Get(key)
+		if _, ok := tagValues[string(tagVal)]; !ok {
+			tagValues[string(tagVal)] = struct{}{}
+		}
+	}
+
+	return tagValues, nil
+}
+
 // tagKeysByFilter will filter the tag keys for the measurement.
 func (fs *FileSet) tagKeysByFilter(name []byte, op influxql.Token, val []byte, regex *regexp.Regexp) map[string]struct{} {
 	ss := make(map[string]struct{})

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -80,7 +80,6 @@ func (fs *FileSet) MustReplace(oldFiles []File, newFile File) *FileSet {
 
 	// Ensure all old files are contiguous.
 	for j := range oldFiles {
-		println("dbg/replace", len(fs.files), "//", i, j)
 		if fs.files[i+j] != oldFiles[j] {
 			panic(fmt.Sprintf("cannot replace non-contiguous files: subset=%+v, fileset=%+v", Files(oldFiles).IDs(), Files(fs.files).IDs()))
 		}

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
 	"regexp"
-	"unsafe"
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
@@ -316,29 +314,15 @@ func (fs *FileSet) tagValuesByKeyAndExpr(name []byte, keys []string, expr influx
 	// Iterate all series to collect tag values.
 	for e := itr.Next(); e != nil; e = itr.Next() {
 		for _, t := range e.Tags() {
-			if idx, ok := keyIdxs[unsafeBytesToString(t.Key)]; ok {
+			if idx, ok := keyIdxs[string(t.Key)]; ok {
 				resultSet[idx][string(t.Value)] = struct{}{}
-			} else if unsafeBytesToString(t.Key) > keys[len(keys)-1] {
+			} else if string(t.Key) > keys[len(keys)-1] {
 				// The tag key is > the largest key we're interested in.
 				break
 			}
 		}
 	}
 	return resultSet, nil
-}
-
-// unsafeBytesToString converts a []byte to a string without a heap allocation.
-//
-// It is unsafe, and is intended to prepare input to short-lived functions
-// that require strings.
-func unsafeBytesToString(in []byte) string {
-	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
-	dst := reflect.StringHeader{
-		Data: src.Data,
-		Len:  src.Len,
-	}
-	s := *(*string)(unsafe.Pointer(&dst))
-	return s
 }
 
 // tagKeysByFilter will filter the tag keys for the measurement.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -614,21 +614,22 @@ func (i *Index) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[s
 	return fs.MeasurementTagKeysByExpr(name, expr)
 }
 
-func (i *Index) MeasurementTagKeyValuesByExpr(name, key []byte, expr influxql.Expr) (map[string]struct{}, error) {
-	fs := i.RetainFileSet()
-	defer fs.Release()
+func (i *Index) MeasurementTagKeyValuesByExpr(name []byte, key []string, expr influxql.Expr, keysSorted bool) ([][]string, error) {
+	return nil, nil
+	// fs := i.RetainFileSet()
+	// defer fs.Release()
 
-	values := make(map[string]struct{})
-	// If there is not expr, we return all tag values for the key
-	if expr == nil {
-		itr := fs.TagValueIterator(name, key)
-		for val := itr.Next(); val != nil; val = itr.Next() {
-			values[string(val.Value())] = struct{}{}
-		}
-		return values, nil
-	}
+	// values := make(map[string]struct{})
+	// // If there is not expr, we return all tag values for the key
+	// if expr == nil {
+	// 	itr := fs.TagValueIterator(name, key)
+	// 	for val := itr.Next(); val != nil; val = itr.Next() {
+	// 		values[string(val.Value())] = struct{}{}
+	// 	}
+	// 	return values, nil
+	// }
 
-	return fs.tagValuesByKeyAndExpr(name, key, expr, i.fieldset)
+	// return fs.tagValuesByKeyAndExpr(name, key, expr, i.fieldset)
 }
 
 // ForEachMeasurementSeriesByExpr iterates over all series in a measurement filtered by an expression.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -8,14 +8,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
@@ -638,7 +636,7 @@ func (i *Index) MeasurementTagKeyValuesByExpr(name []byte, keys []string, expr i
 	// fetch them all.
 	if expr == nil {
 		for ki, key := range keys {
-			itr := fs.TagValueIterator(name, unsafeStringToBytes(key))
+			itr := fs.TagValueIterator(name, []byte(key))
 			for val := itr.Next(); val != nil; val = itr.Next() {
 				results[ki] = append(results[ki], string(val.Value()))
 			}
@@ -664,21 +662,6 @@ func (i *Index) MeasurementTagKeyValuesByExpr(name []byte, keys []string, expr i
 		results[i] = values
 	}
 	return results, nil
-}
-
-// unsafeStringToBytes converts a string to a []byte without a heap allocation.
-//
-// It is unsafe, and is intended to prepare input to short-lived functions
-// that require strings.
-func unsafeStringToBytes(in string) []byte {
-	src := (*reflect.StringHeader)(unsafe.Pointer(&in))
-	len := src.Len
-
-	var b []byte
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	bh.Data = src.Data
-	bh.Len, bh.Cap = len, len
-	return b
 }
 
 // ForEachMeasurementSeriesByExpr iterates over all series in a measurement filtered by an expression.

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -8,14 +8,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
@@ -970,47 +968,21 @@ func (a TagValuesSlice) Len() int           { return len(a) }
 func (a TagValuesSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a TagValuesSlice) Less(i, j int) bool { return a[i].Measurement < a[j].Measurement }
 
-type tagValue struct {
-	mname   string
-	keyIdxs map[string]int
-	lastKey []byte
-	values  []tvSlice
+// tagValues is a temporary representation of a TagValues. Rather than allocating
+// KeyValues as we build up a TagValues object, We hold off allocating KeyValues
+// until we have merged multiple tagValues together.
+type tagValues struct {
+	name   []byte
+	keys   []string
+	values [][]string
 }
 
-type tvSlice struct {
-	data [][]byte
-}
+// Is a slice of tagValues that can be sorted by measurement.
+type tagValuesSlice []tagValues
 
-func (a tvSlice) Len() int           { return len(a.data) }
-func (a tvSlice) Swap(i, j int)      { a.data[i], a.data[j] = a.data[j], a.data[i] }
-func (a tvSlice) Less(i, j int) bool { return bytes.Compare(a.data[i], a.data[j]) == -1 }
-
-func (a *tvSlice) Insert(v []byte) {
-	var found bool
-	i := sort.Search(len(a.data), func(i int) bool {
-		cmp := bytes.Compare(a.data[i], v)
-		if cmp == 0 {
-			found = true
-		}
-		return cmp > -1
-	})
-
-	// Insert at end of slice.
-	if i == len(a.data) {
-		a.data = append(a.data, v)
-		return
-	}
-
-	// We already have this.
-	if found || bytes.Compare(a.data[i], v) == 0 {
-		return
-	}
-
-	// Insert it into slice.
-	a.data = append(a.data, nil)
-	copy(a.data[i+1:], a.data[i:])
-	a.data[i] = v
-}
+func (a tagValuesSlice) Len() int           { return len(a) }
+func (a tagValuesSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a tagValuesSlice) Less(i, j int) bool { return bytes.Compare(a[i].name, a[j].name) == -1 }
 
 // TagValues returns the tag keys and values in the given database, matching the condition.
 func (s *Store) TagValues(database string, cond influxql.Expr) ([]TagValues, error) {
@@ -1061,23 +1033,28 @@ func (s *Store) TagValues(database string, cond influxql.Expr) ([]TagValues, err
 	}
 
 	// Stores each list of TagValues for each measurement.
-	var sms map[string]tagValue
-	var maxMeasuremnts int // Hint as to lower bound on number of measurements.
+	var allResults []tagValues
+	var maxMeasurements int // Hint as to lower bound on number of measurements.
 	for _, sh := range shards {
+		// names will be sorted by MeasurementNamesByExpr.
 		names, err := sh.MeasurementNamesByExpr(measurementExpr)
 		if err != nil {
 			return nil, err
 		}
 
-		if len(names) > maxMeasuremnts {
-			maxMeasuremnts = len(names)
+		if len(names) > maxMeasurements {
+			maxMeasurements = len(names)
 		}
 
-		if sms == nil {
-			// Initialise map of tag key/values.
-			sms = make(map[string]tagValue, len(names))
+		if allResults == nil {
+			allResults = make([]tagValues, 0, len(shards)*len(names)) // Assuming all series in all shards.
 		}
 
+		// Iterate over each matching measurement in the shard. For each
+		// measurement we'll get the matching tag keys (e.g., when a WITH KEYS)
+		// statement is used, and we'll then use those to fetch all the relevant
+		// values from matching series. Series may be filtered using a WHERE
+		// filter.
 		for _, name := range names {
 			// Determine a list of keys from condition.
 			keySet, err := sh.engine.MeasurementTagKeysByExpr(name, cond)
@@ -1085,120 +1062,172 @@ func (s *Store) TagValues(database string, cond influxql.Expr) ([]TagValues, err
 				return nil, err
 			}
 
-			mname := string(name)
-
-			var (
-				tagSet tagValue
-				ok     bool
-			)
-
-			if tagSet, ok = sms[mname]; !ok {
-				tagSet = tagValue{
-					mname:   mname,
-					keyIdxs: make(map[string]int, len(keySet)),
-				}
+			if len(keySet) == 0 {
+				// No matching tag keys for this measurement
+				continue
 			}
 
-			// i will be used to track where to append values for each tag key.
-			i := len(tagSet.values)
+			result := tagValues{
+				name: name,
+				keys: make([]string, 0, len(keySet)),
+			}
+
+			// Add the keys to the tagValues and sort them.
 			for k := range keySet {
-				// If we're not already tracking this key then add a slot for
-				// its values.
-				if _, ok := tagSet.keyIdxs[k]; !ok {
-					tagSet.keyIdxs[k] = i
-					tagSet.values = append(tagSet.values, tvSlice{})
-					i++
-				}
-
-				bk := []byte(k)
-				if bytes.Compare(bk, tagSet.lastKey) == 1 {
-					tagSet.lastKey = bk
-				}
-
+				result.keys = append(result.keys, k)
 			}
+			sort.Sort(sort.StringSlice(result.keys))
 
-			// Loop over all keys for each series.
-			if err := sh.engine.ForEachMeasurementSeriesByExpr(name, filterExpr, func(tags models.Tags) error {
-				for _, t := range tags {
-					// Since tags are sorted, once we've past the last value
-					// in the the tag keys we're looking for, there is no point
-					// in continuing to look.
-					if bytes.Compare(t.Key, tagSet.lastKey) == 1 {
-						break
-					}
-
-					if _, ok := keySet[string(t.Key)]; ok {
-						tagSet.values[tagSet.keyIdxs[string(t.Key)]].Insert(t.Value)
-					}
-				}
-				return nil
-			}); err != nil {
+			// get all the tag values for each key in the keyset.
+			// Each slice in the results contains the sorted values associated
+			// associated with each tag key for the measurement from the key set.
+			if result.values, err = sh.engine.MeasurementTagKeyValuesByExpr(name, result.keys, filterExpr, true); err != nil {
 				return nil, err
 			}
-			sms[mname] = tagSet
+			allResults = append(allResults, result)
 		}
 	}
 
-	// Build out the results...
-	all := make([]TagValues, 0, len(sms))
-	sortedMs := make([]string, 0, len(sms))
-	for k := range sms {
-		sortedMs = append(sortedMs, k)
+	result := make([]TagValues, 0, maxMeasurements)
+
+	// We need to sort all results by measurement name.
+	if len(shards) > 1 {
+		sort.Sort(tagValuesSlice(allResults))
 	}
-	sort.Sort(sort.StringSlice(sortedMs))
 
-	var (
-		prevM string
-		prevK string
-		prevV []byte
-	)
-
-	for _, m := range sortedMs {
-		tagData := sms[m]
-		tagValues := TagValues{
-			Measurement: m,
-			Values:      make([]KeyValue, 0, len(tagData.keyIdxs)),
+	// The next stage is to merge the tagValue results for each shard's measurements.
+	var i, j int
+	// Used as a temporary buffer in mergeTagValues. There can be at most len(shards)
+	// instances of tagValues for a given measurement.
+	idxBuf := make([][2]int, 0, len(shards))
+	for i < len(allResults) {
+		// Gather all occurrences of the same measurement for merging.
+		for j+1 < len(allResults) && bytes.Equal(allResults[j+1].name, allResults[i].name) {
+			j++
 		}
 
-		// Sort tag keys.
-		sortedKeys := make([]string, 0, len(tagData.keyIdxs))
-		for k := range tagData.keyIdxs {
-			sortedKeys = append(sortedKeys, k)
+		// An invariant is that there can't be more than n instances of tag
+		// key value pairs for a given measurement, where n is the number of
+		// shards.
+		if got, exp := j-i+1, len(shards); got > exp {
+			return nil, fmt.Errorf("unexpected results returned engine. Got %d measurement sets for %d shards", got, exp)
 		}
-		sort.Sort(sort.StringSlice(sortedKeys))
 
-		for _, k := range sortedKeys {
-			tvIdx := tagData.keyIdxs[k] // The location of the tag value data for this key
-
-			// Sort tag values
-			// sort.Sort(tagData.values[tvIdx])
-			for _, v := range tagData.values[tvIdx].data {
-				if m != prevM || k != prevK || bytes.Compare(v, prevV) != 0 {
-					// Unique tag - let's add this one.
-					tagValues.Values = append(tagValues.Values, KeyValue{Key: k, Value: string(v)})
-				}
-				prevV = v
-				prevK = k
-				prevM = m
-			}
+		nextResult := mergeTagValues(idxBuf, allResults[i:j+1]...)
+		i = j + 1
+		if len(nextResult.Values) > 0 {
+			result = append(result, nextResult)
 		}
-		all = append(all, tagValues)
 	}
-	return all, nil
+	return result, nil
 }
 
-// unsafeBytesToString converts a []byte to a string without a heap allocation.
+// mergeTagValues merges multiple sorted sets of temporary tagValues using a
+// direct k-way merge whilst also removing duplicated entries. The result is a
+// single TagValue type.
 //
-// It is unsafe, and is intended to prepare input to short-lived functions
-// that require strings.
-func unsafeBytesToString(in []byte) string {
-	src := *(*reflect.SliceHeader)(unsafe.Pointer(&in))
-	dst := reflect.StringHeader{
-		Data: src.Data,
-		Len:  src.Len,
+// TODO(edd): a Tournament based merge (see: Knuth's TAOCP 5.4.1) might be more
+// appropriate at some point.
+//
+func mergeTagValues(valueIdxs [][2]int, tvs ...tagValues) TagValues {
+	var result TagValues
+	if len(tvs) == 0 {
+		return TagValues{}
+	} else if len(tvs) == 1 {
+		result.Measurement = string(tvs[0].name)
+		// TODO(edd): will be too small likely. Find a hint?
+		result.Values = make([]KeyValue, 0, len(tvs[0].values))
+
+		for ki, key := range tvs[0].keys {
+			for _, value := range tvs[0].values[ki] {
+				result.Values = append(result.Values, KeyValue{Key: key, Value: value})
+			}
+		}
+		return result
 	}
-	s := *(*string)(unsafe.Pointer(&dst))
-	return s
+
+	result.Measurement = string(tvs[0].name)
+
+	var maxSize int
+	for _, tv := range tvs {
+		if len(tv.values) > maxSize {
+			maxSize = len(tv.values)
+		}
+	}
+	result.Values = make([]KeyValue, 0, maxSize) // This will likely be too small but it's a start.
+
+	// Resize and reset to the number of TagValues we're merging.
+	valueIdxs = valueIdxs[:len(tvs)]
+	for i := 0; i < len(valueIdxs); i++ {
+		valueIdxs[i][0], valueIdxs[i][1] = 0, 0
+	}
+
+	var (
+		j              int
+		keyCmp, valCmp int
+	)
+
+	for {
+		// Which of the provided TagValue sets currently holds the smallest element.
+		// j is the candidate we're going to next pick for the result set.
+		j = -1
+
+		// Find the smallest element
+		for i := 0; i < len(tvs); i++ {
+			if valueIdxs[i][0] >= len(tvs[i].keys) {
+				continue // We have completely drained all tag keys and values for this shard.
+			} else if len(tvs[i].values[valueIdxs[i][0]]) == 0 {
+				// There are no tag values for these keys.
+				valueIdxs[i][0]++
+				valueIdxs[i][1] = 0
+				continue
+			} else if j == -1 {
+				// We haven't picked a best TagValues set yet. Pick this one.
+				j = i
+				continue
+			}
+
+			// It this tag key is lower than the candidate's tag key
+			keyCmp = strings.Compare(tvs[i].keys[valueIdxs[i][0]], tvs[j].keys[valueIdxs[j][0]])
+			if keyCmp == -1 {
+				j = i
+			} else if keyCmp == 0 {
+				valCmp = strings.Compare(tvs[i].values[valueIdxs[i][0]][valueIdxs[i][1]], tvs[j].values[valueIdxs[j][0]][valueIdxs[j][1]])
+				// Same tag key but this tag value is lower than the candidate.
+				if valCmp == -1 {
+					j = i
+				} else if valCmp == 0 {
+					// Duplicate tag key/value pair.... Remove and move onto
+					// the next value for shard i.
+					valueIdxs[i][1]++
+					if valueIdxs[i][1] >= len(tvs[i].values[valueIdxs[i][0]]) {
+						// Drained all these tag values, move onto next key.
+						valueIdxs[i][0]++
+						valueIdxs[i][1] = 0
+					}
+				}
+			}
+		}
+
+		// We could have drained all of the TagValue sets and be done...
+		if j == -1 {
+			break
+		}
+
+		// Append the smallest KeyValue
+		result.Values = append(result.Values, KeyValue{
+			Key:   string(tvs[j].keys[valueIdxs[j][0]]),
+			Value: tvs[j].values[valueIdxs[j][0]][valueIdxs[j][1]],
+		})
+		// Increment the indexes for the chosen TagValue.
+		valueIdxs[j][1]++
+		if valueIdxs[j][1] >= len(tvs[j].values[valueIdxs[j][0]]) {
+			// Drained all these tag values, move onto next key.
+			valueIdxs[j][0]++
+			valueIdxs[j][1] = 0
+		}
+	}
+	return result
 }
 
 func (s *Store) monitorShards() {

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1114,6 +1114,7 @@ func (s *Store) TagValues(database string, cond influxql.Expr) ([]TagValues, err
 				if bytes.Compare(bk, tagSet.lastKey) == 1 {
 					tagSet.lastKey = bk
 				}
+
 			}
 
 			// Loop over all keys for each series.

--- a/tsdb/store_internal_test.go
+++ b/tsdb/store_internal_test.go
@@ -1,0 +1,167 @@
+package tsdb
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestStore_mergeTagValues(t *testing.T) {
+	examples := []struct {
+		in  []tagValues
+		out TagValues
+	}{
+		{},
+		{in: make([]tagValues, 4), out: TagValues{Values: []KeyValue{}}},
+		{
+			in:  []tagValues{createtagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c"}})},
+			out: createTagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c"}}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c"}}),
+				createtagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c"}}),
+			},
+			out: createTagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c"}}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c"}}),
+				createtagValues("m0", map[string][]string{"host": {"server-a", "server-d", "server-e"}}),
+			},
+			out: createTagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c", "server-d", "server-e"}}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"host": {"server-a"}}),
+				createtagValues("m0", map[string][]string{}),
+				createtagValues("m0", map[string][]string{"host": {"server-a"}}),
+			},
+			out: createTagValues("m0", map[string][]string{"host": {"server-a"}}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"host": {"server-q", "server-z"}}),
+				createtagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c"}}),
+				createtagValues("m0", map[string][]string{"host": {"server-a", "server-d", "server-e"}}),
+				createtagValues("m0", map[string][]string{"host": {"server-e", "server-q", "server-z"}}),
+				createtagValues("m0", map[string][]string{"host": {"server-a"}}),
+			},
+			out: createTagValues("m0", map[string][]string{"host": {"server-a", "server-b", "server-c", "server-d", "server-e", "server-q", "server-z"}}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"a": {"0", "1"}, "host1": {"server-q", "server-z"}}),
+				createtagValues("m0", map[string][]string{"a": {"0", "2"}, "host2": {"server-a", "server-b", "server-c"}}),
+				createtagValues("m0", map[string][]string{"a": {"0", "3"}, "host3": {"server-a", "server-d", "server-e"}}),
+				createtagValues("m0", map[string][]string{"a": {"0", "4"}, "host4": {"server-e", "server-q", "server-z"}}),
+				createtagValues("m0", map[string][]string{"a": {"0", "5"}, "host5": {"server-a"}}),
+			},
+			out: createTagValues("m0", map[string][]string{
+				"a":     {"0", "1", "2", "3", "4", "5"},
+				"host1": {"server-q", "server-z"},
+				"host2": {"server-a", "server-b", "server-c"},
+				"host3": {"server-a", "server-d", "server-e"},
+				"host4": {"server-e", "server-q", "server-z"},
+				"host5": {"server-a"},
+			}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"region": {"east-1", "west-1"}, "host": {"server-a", "server-b", "server-c"}}),
+				createtagValues("m0", map[string][]string{"region": {"north-1", "west-1"}, "host": {"server-a", "server-d", "server-e"}}),
+			},
+			out: createTagValues("m0", map[string][]string{
+				"host":   {"server-a", "server-b", "server-c", "server-d", "server-e"},
+				"region": {"east-1", "north-1", "west-1"},
+			}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"region": {"east-1", "west-1"}, "host": {"server-a", "server-b", "server-c"}}),
+				createtagValues("m0", map[string][]string{"city": {"Baltimore", "Las Vegas"}}),
+			},
+			out: createTagValues("m0", map[string][]string{
+				"city":   {"Baltimore", "Las Vegas"},
+				"host":   {"server-a", "server-b", "server-c"},
+				"region": {"east-1", "west-1"},
+			}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"city": {"Baltimore", "Las Vegas"}}),
+				createtagValues("m0", map[string][]string{"region": {"east-1", "west-1"}, "host": {"server-a", "server-b", "server-c"}}),
+			},
+			out: createTagValues("m0", map[string][]string{
+				"city":   {"Baltimore", "Las Vegas"},
+				"host":   {"server-a", "server-b", "server-c"},
+				"region": {"east-1", "west-1"},
+			}),
+		},
+		{
+			in: []tagValues{
+				createtagValues("m0", map[string][]string{"region": {"east-1", "west-1"}, "host": {"server-a", "server-b", "server-c"}}),
+				createtagValues("m0", map[string][]string{}),
+			},
+			out: createTagValues("m0", map[string][]string{
+				"host":   {"server-a", "server-b", "server-c"},
+				"region": {"east-1", "west-1"},
+			}),
+		},
+	}
+
+	buf := make([][2]int, 10)
+	for i, example := range examples {
+		t.Run(fmt.Sprintf("example_%d", i+1), func(t *testing.T) {
+			if got, exp := mergeTagValues(buf, example.in...), example.out; !reflect.DeepEqual(got, exp) {
+				t.Fatalf("\ngot\n %#v\n\n expected\n %#v", got, exp)
+			}
+		})
+	}
+}
+
+// Helper to create some tagValues.
+func createtagValues(mname string, kvs map[string][]string) tagValues {
+	out := tagValues{
+		name:   []byte(mname),
+		keys:   make([]string, 0, len(kvs)),
+		values: make([][]string, len(kvs)),
+	}
+
+	for k := range kvs {
+		out.keys = append(out.keys, k)
+	}
+	sort.Sort(sort.StringSlice(out.keys))
+
+	for i, k := range out.keys {
+		values := kvs[k]
+		sort.Sort(sort.StringSlice(values))
+		out.values[i] = values
+	}
+	return out
+}
+
+// Helper to create some TagValues
+func createTagValues(mname string, kvs map[string][]string) TagValues {
+	var sz int
+	for _, v := range kvs {
+		sz += len(v)
+	}
+
+	out := TagValues{
+		Measurement: mname,
+		Values:      make([]KeyValue, 0, sz),
+	}
+
+	for tk, tvs := range kvs {
+		for _, tv := range tvs {
+			out.Values = append(out.Values, KeyValue{Key: tk, Value: tv})
+		}
+		// We have to sort the KeyValues since that's how they're provided from
+		// the Store.
+		sort.Sort(KeyValues(out.Values))
+	}
+
+	return out
+}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This PR refactors the `tsdb.Store`'s `TagValues` method to significantly improve the performance of `SHOW TAG VALUES` from that experienced in `1.3.1`.

In some cases I've observed some queries completing around 185x faster than `1.3.1`. Fixes #8640.

It works as follows:

 - For the `inmem` index we don't need to check each shard for tag values, since all shards have a copy of the same index. Therefore we just check the first shard.
 - Instead of gathering everything up into large collections and then sorting using Quicksort, we merge multiple streams of tag values together for each shard.
 - We add new methods to the `Index` for more efficiently gathering collections of tag values for tag keys.
 - Where the `SHOW TAG VALUES` doesn't include a `WHERE` clause, we skip more expensive methods that filter series, and just grab all of the appropriate series.
 - We push all the tag keys we need values for down into the index and gather all relevant values in one go, rather than repeating the process for each tag key.
 - We avoid the use of `sort.Sort` and `maps` in general.
 - We reduce wasted allocations by delaying the allocation of `KeyValue` objects, which may end up being thrown away through de-duplication anyway.
 - We leverage the invariant that tag keys are passed to the index sorted, so we can exit early from `models.Tags` iteration.
 - Where appropriate we use unsafe `string --> []byte` and `[]byte --> string` (though I'm not sure how much we're saving given the Go compiler might have kept these conversions on the stack anyway.

#### Benchmark Results

I added some benchmark. Here are the results comparing `v1.3.1` to these changes:

```
benchmark                                                                                   old ns/op      new ns/op     delta
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=1_v=100-8           93631          24872         -73.44%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=1_v=1000-8          1058656        271110        -74.39%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=10_v=100-8          1011901        242419        -76.04%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=10_v=1000-8         11425817       2741175       -76.01%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=100_v=100-8         10045286       2506089       -75.05%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=100_v=1000-8        121460151      29636546      -75.60%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=1_v=100-8          5535025        27494         -99.50%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=1_v=1000-8         57200134       277599        -99.51%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=10_v=100-8         61137967       264608        -99.57%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=10_v=1000-8        716986198      2758907       -99.62%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=100_v=100-8        644121420      2685845       -99.58%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=100_v=1000-8       7525538172     26869192      -99.64%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=1_v=100-8         46656          33858         -27.43%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=1_v=1000-8        466128         319074        -31.55%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=10_v=100-8        554105         361193        -34.82%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=10_v=1000-8       5748353        3790884       -34.05%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=100_v=100-8       5430254        3673582       -32.35%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=100_v=1000-8      61151803       40770214      -33.33%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=1_v=100-8        2968088        221329        -92.54%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=1_v=1000-8       29958242       2263208       -92.45%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=10_v=100-8       31144989       2104543       -93.24%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=10_v=1000-8      380440093      26534566      -93.03%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=100_v=100-8      359041949      24246682      -93.25%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=100_v=1000-8     4443898489     312383241     -92.97%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=1_v=100-8            92736          23104         -75.09%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=1_v=1000-8           1038086        257750        -75.17%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=10_v=100-8           1005688        227052        -77.42%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=10_v=1000-8          11498716       2689217       -76.61%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=100_v=100-8          10179007       2460154       -75.83%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=100_v=1000-8         119252644      29451575      -75.30%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=1_v=100-8           6282477        276993        -95.59%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=1_v=1000-8          65477559       3715131       -94.33%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=10_v=100-8          69200875       2740942       -96.04%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=10_v=1000-8         866964826      41253818      -95.24%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=100_v=100-8         754756036      30240493      -95.99%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=100_v=1000-8        8933943418     383221060     -95.71%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=1_v=100-8          39095          28946         -25.96%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=1_v=1000-8         527935         370338        -29.85%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=10_v=100-8         520686         337172        -35.24%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=10_v=1000-8        5671519        3657734       -35.51%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=100_v=100-8        5469111        3677777       -32.75%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=100_v=1000-8       61889900       41131446      -33.54%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=1_v=100-8         3275654        397360        -87.87%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=1_v=1000-8        32386777       4023906       -87.58%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=10_v=100-8        35536831       3915073       -88.98%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=10_v=1000-8       445130899      50358133      -88.69%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=100_v=100-8       410576229      43287794      -89.46%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=100_v=1000-8      4805356459     486141537     -89.88%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=1_v=100-8            114199         46340         -59.42%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=1_v=1000-8           1402464        470217        -66.47%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=10_v=100-8           1217745        463179        -61.96%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=10_v=1000-8          15318214       5046922       -67.05%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=100_v=100-8          12327456       4974928       -59.64%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=100_v=1000-8         167473481      54547135      -67.43%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=1_v=100-8           876073         472860        -46.03%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=1_v=1000-8          10026211       4810940       -52.02%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=10_v=100-8          9319077        4726873       -49.28%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=10_v=1000-8         118900081      50801562      -57.27%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=100_v=100-8         103685056      50633264      -51.17%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=100_v=1000-8        1218726014     502119575     -58.80%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=1_v=100-8          54435          46743         -14.13%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=1_v=1000-8         680329         551619        -18.92%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=10_v=100-8         660864         515792        -21.95%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=10_v=1000-8        7326683        5613384       -23.38%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=100_v=100-8        6432336        5149298       -19.95%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=100_v=1000-8       80600653       66508896      -17.48%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=1_v=100-8         482016         540514        +12.14%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=1_v=1000-8        5063378        5762606       +13.81%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=10_v=100-8        5164921        5375245       +4.07%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=10_v=1000-8       59156848       62785660      +6.13%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=100_v=100-8       58329304       59382389      +1.81%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=100_v=1000-8      643895491      647552903     +0.57%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=1_v=100-8             115727         46405         -59.90%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=1_v=1000-8            1440140        465606        -67.67%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=10_v=100-8            1234813        459918        -62.75%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=10_v=1000-8           15755860       4956455       -68.54%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=100_v=100-8           12596113       4898969       -61.11%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=100_v=1000-8          105677861      21834289      -79.34%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=1_v=100-8            1354048        726686        -46.33%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=1_v=1000-8           15317751       7584517       -50.49%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=10_v=100-8           14247949       7283196       -48.88%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=10_v=1000-8          176247072      81680375      -53.66%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=100_v=100-8          159042762      77424237      -51.32%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=100_v=1000-8         1357106565     453632910     -66.57%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=1_v=100-8           56688          47943         -15.43%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=1_v=1000-8          671970         539788        -19.67%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=10_v=100-8          656781         497756        -24.21%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=10_v=1000-8         7462946        5704081       -23.57%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=100_v=100-8         6674778        5291050       -20.73%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=100_v=1000-8        61318155       35040917      -42.85%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=1_v=100-8          657046         603340        -8.17%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=1_v=1000-8         7303178        7099275       -2.79%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=10_v=100-8         7221825        6556733       -9.21%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=10_v=1000-8        86004814       81364506      -5.40%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=100_v=100-8        82342911       74856378      -9.09%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=100_v=1000-8       593101145      505786539     -14.72%

benchmark                                                                                   old allocs     new allocs     delta
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=1_v=100-8           451            49             -89.14%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=1_v=1000-8          4107           52             -98.73%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=10_v=100-8          4294           283            -93.41%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=10_v=1000-8         40852          313            -99.23%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=100_v=100-8         42687          2623           -93.86%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=1_m=100_v=1000-8        408239         2923           -99.28%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=1_v=100-8          40192          53             -99.87%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=1_v=1000-8         400243         56             -99.99%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=10_v=100-8         401420         287            -99.93%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=10_v=1000-8        4001956        317            -99.99%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=100_v=100-8        4013666        2627           -99.93%
BenchmarkStore_TagValues/random_values=false_index=inmem_Filtered_s=10_m=100_v=1000-8       40019044       2927           -99.99%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=1_v=100-8         259            172            -33.59%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=1_v=1000-8        1880           999            -46.86%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=10_v=100-8        2347           1432           -38.99%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=10_v=1000-8       21129          11008          -47.90%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=100_v=100-8       22363          13609          -39.15%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=1_m=100_v=1000-8      204174         106323         -47.93%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=1_v=100-8        21088          1128           -94.65%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=1_v=1000-8       204021         10330          -94.94%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=10_v=100-8       198317         10300          -94.81%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=10_v=1000-8      2003092        101100         -94.95%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=100_v=100-8      2016907        104341         -94.83%
BenchmarkStore_TagValues/random_values=false_index=inmem_Unfiltered_s=10_m=100_v=1000-8     20018852       1010003        -94.95%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=1_v=100-8            451            49             -89.14%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=1_v=1000-8           4095           52             -98.73%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=10_v=100-8           4294           283            -93.41%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=10_v=1000-8          40735          313            -99.23%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=100_v=100-8          42675          2623           -93.85%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=1_m=100_v=1000-8         407249         2923           -99.28%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=1_v=100-8           40245          56             -99.86%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=1_v=1000-8          399516         65             -99.98%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=10_v=100-8          401843         317            -99.92%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=10_v=1000-8         3997028        407            -99.99%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=100_v=100-8         4017980        2927           -99.93%
BenchmarkStore_TagValues/random_values=true_index=inmem_Filtered_s=10_m=100_v=1000-8        39966776       3827           -99.99%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=1_v=100-8          214            149            -30.37%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=1_v=1000-8         2145           1134           -47.13%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=10_v=100-8         2222           1368           -38.43%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=10_v=1000-8        20402          10639          -47.85%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=100_v=100-8        22052          13457          -38.98%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=1_m=100_v=1000-8       205477         106966         -47.94%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=1_v=100-8         20752          1139           -94.51%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=1_v=1000-8        197353         10202          -94.83%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=10_v=100-8        205644         10938          -94.68%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=10_v=1000-8       1995154        102781         -94.85%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=100_v=100-8       2022220        107300         -94.69%
BenchmarkStore_TagValues/random_values=true_index=inmem_Unfiltered_s=10_m=100_v=1000-8      19971895       1028646        -94.85%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=1_v=100-8            483            297            -38.51%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=1_v=1000-8           4139           2103           -49.19%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=10_v=100-8           4559           2708           -40.60%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=10_v=1000-8          41115          20768          -49.49%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=100_v=100-8          45207          26744          -40.84%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=1_m=100_v=1000-8         410761         234627         -42.88%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=1_v=100-8           4512           2714           -39.85%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=1_v=1000-8          40566          20747          -48.86%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=10_v=100-8          44072          26176          -40.61%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=10_v=1000-8         404608         206506         -48.96%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=100_v=100-8         438881         260056         -40.75%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Filtered_s=10_m=100_v=1000-8        4044226        2063356        -48.98%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=1_v=100-8          280            199            -28.93%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=1_v=1000-8         2147           1151           -46.39%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=10_v=100-8         2595           1699           -34.53%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=10_v=1000-8        20633          10895          -47.20%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=100_v=100-8        24974          16276          -34.83%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=1_m=100_v=1000-8       207570         150301         -27.59%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=1_v=100-8         2516           1680           -33.23%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=1_v=1000-8        20622          11002          -46.65%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=10_v=100-8        24467          15943          -34.84%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=10_v=1000-8       204070         108431         -46.87%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=100_v=100-8       239774         156031         -34.93%
BenchmarkStore_TagValues/random_values=false_index=tsi1_Unfiltered_s=10_m=100_v=1000-8      2043644        1085043        -46.91%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=1_v=100-8             483            297            -38.51%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=1_v=1000-8            4114           2085           -49.32%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=10_v=100-8            4559           2708           -40.60%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=10_v=1000-8           41002          20660          -49.61%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=100_v=100-8           45194          26730          -40.85%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=1_m=100_v=1000-8          409598         205787         -49.76%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=1_v=100-8            4566           2717           -40.49%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=1_v=1000-8           40931          20650          -49.55%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=10_v=100-8           44609          26196          -41.28%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=10_v=1000-8          408422         205680         -49.64%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=100_v=100-8          444174         260252         -41.41%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Filtered_s=10_m=100_v=1000-8         8960142        2048274        -77.14%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=1_v=100-8           289            204            -29.41%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=1_v=1000-8          2082           1118           -46.30%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=10_v=100-8          2551           1675           -34.34%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=10_v=1000-8         20707          10932          -47.21%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=100_v=100-8         25294          16444          -34.99%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=1_m=100_v=1000-8        419928         109670         -73.88%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=1_v=100-8          2487           1651           -33.61%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=1_v=1000-8         20909          11047          -47.17%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=10_v=100-8         24703          15965          -35.37%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=10_v=1000-8        208847         109824         -47.41%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=100_v=100-8        243780         157123         -35.55%
BenchmarkStore_TagValues/random_values=true_index=tsi1_Unfiltered_s=10_m=100_v=1000-8       2066953        1087270        -47.40%
```


#### Validation

As a further step to ensure correctness I ran a script containing various `SHOW` queries against a database running `1.3.1` and then repeated for the same instance using this PR. I then compared the speed, and ensured that the results were always byte-for-byte the same using an `md5` of the output.


| Query                                                             | 1.3.1        | PR           |
| ----------------------------------------------------------------- |:------------:|:------------:|
| SHOW TAG VALUES WITH KEY = tag1                                   | 5.50s        | 0.03s       |
| SHOW TAG VALUES WITH KEY IN (tag1, tag3, tag4)                    | 2.81s        | 0.09s       |
| SHOW TAG VALUES FROM m4 WITH KEY = tag2                           | 0.08s        | 0.02s       |
| SHOW TAG VALUES FROM m4 WITH KEY = tag1 LIMIT 2                   | 0.06s        | 0.02s       |
| SHOW TAG VALUES WITH KEY IN (tag2, tag1) WHERE tag3 = 'value2'    | 0.17s        | 0.06s       |
| SHOW TAG VALUES WITH KEY IN (tag2, tag1) WHERE tag1 = 'value2'    | 0.37s        | 0.11s       |
| SHOW TAG VALUES WITH KEY IN (tag2, tag1) WHERE tag4 != 'foo'      | 1.38s        | 0.32s       |
