### PR TITLE
fixes a memory leak when NewReaderIterator creates a nilFloatIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,13 @@
 - [#8607](https://github.com/influxdata/influxdb/issues/8607): Fix time zone shifts when the shift happens on a time zone boundary.
 - [#8639](https://github.com/influxdata/influxdb/issues/8639): Parse time literals using the time zone in the select statement.
 
-## v1.3.2 [unreleased]
+## v1.3.3 [unreleased]
+
+### Bugfixes
+
+- [#8681](https://github.com/influxdata/influxdb/pull/8681): Resolves a memory leak when NewReaderIterator creates a nilFloatIterator, the reader is not closed
+
+## v1.3.2 [2017-08-04]
 
 ### Bugfixes
 

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -626,7 +626,7 @@ func NewReaderIterator(r io.Reader, typ DataType, stats IteratorStats) Iterator 
 	case Boolean:
 		return newBooleanReaderIterator(r, stats)
 	default:
-		return &nilFloatIterator{}
+		return &nilFloatReaderIterator{r: r}
 	}
 }
 
@@ -1232,6 +1232,19 @@ type nilFloatIterator struct{}
 func (*nilFloatIterator) Stats() IteratorStats       { return IteratorStats{} }
 func (*nilFloatIterator) Close() error               { return nil }
 func (*nilFloatIterator) Next() (*FloatPoint, error) { return nil, nil }
+
+type nilFloatReaderIterator struct {
+	r io.Reader
+}
+
+func (*nilFloatReaderIterator) Stats() IteratorStats { return IteratorStats{} }
+func (itr *nilFloatReaderIterator) Close() error {
+	if r, ok := itr.r.(io.ReadCloser); ok {
+		return r.Close()
+	}
+	return nil
+}
+func (*nilFloatReaderIterator) Next() (*FloatPoint, error) { return nil, nil }
 
 // integerFloatTransformIterator executes a function to modify an existing point for every
 // output of the input iterator.

--- a/influxql/iterator.go
+++ b/influxql/iterator.go
@@ -1240,6 +1240,7 @@ type nilFloatReaderIterator struct {
 func (*nilFloatReaderIterator) Stats() IteratorStats { return IteratorStats{} }
 func (itr *nilFloatReaderIterator) Close() error {
 	if r, ok := itr.r.(io.ReadCloser); ok {
+		itr.r = nil
 		return r.Close()
 	}
 	return nil


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
