### PR TITLE
Run relevant unit tests on both indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#7195](https://github.com/influxdata/influxdb/issues/7195): Support SHOW CARDINALITY queries.
 - [#8711](https://github.com/influxdata/influxdb/pull/8711): Batch up writes for monitor service
 - [#8572](https://github.com/influxdata/influxdb/pull/8572): All errors from queries or writes are available via X-InfluxDB-Error header, and 5xx error messages will be written to server logs.
+- [#8662](https://github.com/influxdata/influxdb/pull/8662): Improve test coverage across both indexes.
 
 ### Bugfixes
 

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/influxdata/influxdb/cmd/influxd/run"
@@ -472,13 +471,12 @@ func NewConfig() *run.Config {
 	c.ReportingDisabled = true
 	c.Coordinator.WriteTimeout = toml.Duration(30 * time.Second)
 	c.Meta.Dir = MustTempFile()
-
-	if !testing.Verbose() {
-		c.Meta.LoggingEnabled = false
-	}
+	c.Meta.LoggingEnabled = verboseServerLogs
 
 	c.Data.Dir = MustTempFile()
 	c.Data.WALDir = MustTempFile()
+	c.Data.QueryLogEnabled = verboseServerLogs
+	c.Data.TraceLoggingEnabled = verboseServerLogs
 
 	indexVersion := os.Getenv("INFLUXDB_DATA_INDEX_VERSION")
 	if indexVersion != "" {
@@ -487,7 +485,7 @@ func NewConfig() *run.Config {
 
 	c.HTTPD.Enabled = true
 	c.HTTPD.BindAddress = "127.0.0.1:0"
-	c.HTTPD.LogEnabled = testing.Verbose()
+	c.HTTPD.LogEnabled = verboseServerLogs
 
 	c.Monitor.StoreEnabled = false
 
@@ -724,7 +722,7 @@ func writeTestData(s Server, t *Test) error {
 
 func configureLogging(s Server) {
 	// Set the logger to discard unless verbose is on
-	if !testing.Verbose() {
+	if !verboseServerLogs {
 		s.SetLogOutput(ioutil.Discard)
 	}
 }

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -477,11 +477,7 @@ func NewConfig() *run.Config {
 	c.Data.WALDir = MustTempFile()
 	c.Data.QueryLogEnabled = verboseServerLogs
 	c.Data.TraceLoggingEnabled = verboseServerLogs
-
-	indexVersion := os.Getenv("INFLUXDB_DATA_INDEX_VERSION")
-	if indexVersion != "" {
-		c.Data.Index = indexVersion
-	}
+	c.Data.Index = indexType
 
 	c.HTTPD.Enabled = true
 	c.HTTPD.BindAddress = "127.0.0.1:0"

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -22,6 +22,9 @@ import (
 	"github.com/influxdata/influxdb/toml"
 )
 
+var verboseServerLogs bool
+var indexType string
+
 // Server represents a test wrapper for run.Server.
 type Server interface {
 	URL() string

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -40,14 +40,18 @@ func TestMain(m *testing.M) {
 		benchServer = OpenDefaultServer(c)
 
 		// Run test suite.
-		fmt.Printf("============= Running all tests for %q index =============\n", indexType)
+		if testing.Verbose() {
+			fmt.Printf("============= Running all tests for %q index =============\n", indexType)
+		}
 		if thisr := m.Run(); r == 0 {
 			r = thisr // We'll always remember the first time r is non-zero
 		}
 
 		// Cleanup
 		benchServer.Close()
-		fmt.Println()
+		if testing.Verbose() {
+			fmt.Println()
+		}
 	}
 	os.Exit(r)
 }
@@ -8413,7 +8417,7 @@ func TestServer_Query_LargeTimestamp(t *testing.T) {
 	// Open a new server with the same configuration file.
 	// This is to ensure the meta data was marshaled correctly.
 	s2 := OpenServer((s.(*LocalServer)).Config)
-	defer s2.Close()
+	defer s2.(*LocalServer).Server.Close()
 
 	for _, query := range test.queries {
 		t.Run(query.name, func(t *testing.T) {

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -66,15 +66,16 @@ func TestServer_DatabaseCommands(t *testing.T) {
 	test := tests.load(t, "database_commands")
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -90,20 +91,21 @@ func TestServer_Query_DropAndRecreateDatabase(t *testing.T) {
 	}
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -122,20 +124,21 @@ func TestServer_Query_DropDatabaseIsolated(t *testing.T) {
 	}
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -151,20 +154,21 @@ func TestServer_Query_DeleteSeries(t *testing.T) {
 	}
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -180,40 +184,42 @@ func TestServer_Query_DropAndRecreateSeries(t *testing.T) {
 	}
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 
 	// Re-write data and test again.
 	retest := tests.load(t, "drop_and_recreate_series_retest")
 
 	for i, query := range retest.queries {
-		if i == 0 {
-			if err := retest.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := retest.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -229,20 +235,21 @@ func TestServer_Query_DropSeriesFromRegex(t *testing.T) {
 	}
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -266,15 +273,16 @@ func TestServer_RetentionPolicyCommands(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -287,15 +295,16 @@ func TestServer_DatabaseRetentionPolicyAutoCreate(t *testing.T) {
 	test := tests.load(t, "retention_policy_auto_create")
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -325,15 +334,16 @@ func TestServer_ShowDatabases_NoAuth(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -400,11 +410,13 @@ func TestServer_ShowDatabases_WithAuth(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if err := query.Execute(s); err != nil {
-			t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if err := query.Execute(s); err != nil {
+				t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -490,15 +502,16 @@ func TestServer_UserCommands(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(fmt.Sprintf("command: %s - err: %s", query.command, query.Error(err)))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -728,15 +741,16 @@ func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -774,15 +788,16 @@ func TestServer_Query_Multiple_Measurements(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -825,15 +840,16 @@ func TestServer_Query_IdenticalTagValues(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -863,15 +879,16 @@ func TestServer_Query_NoShards(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -906,15 +923,16 @@ func TestServer_Query_NonExistent(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -998,15 +1016,16 @@ func TestServer_Query_Math(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1073,15 +1092,16 @@ func TestServer_Query_Count(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1118,15 +1138,16 @@ func TestServer_Query_MaxSelectSeriesN(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1171,15 +1192,16 @@ func TestServer_Query_Now(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1240,15 +1262,16 @@ func TestServer_Query_EpochPrecision(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1417,15 +1440,16 @@ func TestServer_Query_Tags(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1492,15 +1516,16 @@ func TestServer_Query_Alias(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1565,15 +1590,16 @@ func TestServer_Query_Common(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1604,20 +1630,21 @@ func TestServer_Query_SelectTwoPoints(t *testing.T) {
 	)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1641,20 +1668,21 @@ func TestServer_Query_SelectTwoNegativePoints(t *testing.T) {
 	})
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1686,20 +1714,21 @@ func TestServer_Query_SelectRelativeTime(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1728,20 +1757,21 @@ func TestServer_Query_SelectRawDerivative(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1774,20 +1804,21 @@ cpu value=20 1278010024000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -1925,20 +1956,21 @@ cpu0,host=server02 ticks=101,total=100 1278010023000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2159,20 +2191,21 @@ cpu value=20 1278010021000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2245,20 +2278,21 @@ cpu value=25 1278010023000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2379,20 +2413,21 @@ cpu value=20 1278010021000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2467,20 +2502,21 @@ cpu value=35 1278010025000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2603,20 +2639,21 @@ cpu value=35 1278010025000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2689,20 +2726,21 @@ cpu value=25 1278010023000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2823,20 +2861,21 @@ cpu value=20 1278010021000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2865,20 +2904,21 @@ events signup=t 3838400000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2907,20 +2947,21 @@ test,t=b y=3i 3000000000
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -2949,20 +2990,21 @@ func TestServer_Query_MathWithFill(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3011,20 +3053,21 @@ func TestServer_Query_MergeMany(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3068,20 +3111,21 @@ func TestServer_Query_SLimitAndSOffset(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3143,20 +3187,21 @@ func TestServer_Query_Regex(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3183,20 +3228,21 @@ func TestServer_Query_Aggregates_Int(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3223,20 +3269,21 @@ func TestServer_Query_Aggregates_IntMax(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3369,20 +3416,21 @@ func TestServer_Query_Aggregates_IntMany(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3463,20 +3511,21 @@ func TestServer_Query_Aggregates_IntMany_GroupBy(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3509,20 +3558,21 @@ func TestServer_Query_Aggregates_IntMany_OrderByDesc(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3576,20 +3626,21 @@ func TestServer_Query_Aggregates_IntOverlap(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3615,20 +3666,21 @@ func TestServer_Query_Aggregates_FloatSingle(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3755,20 +3807,21 @@ func TestServer_Query_Aggregates_FloatMany(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3821,20 +3874,21 @@ func TestServer_Query_Aggregates_FloatOverlap(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3880,20 +3934,21 @@ func TestServer_Query_Aggregates_GroupByOffset(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3933,20 +3988,21 @@ func TestServer_Query_Aggregates_Load(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -3973,20 +4029,21 @@ func TestServer_Query_Aggregates_CPU(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -4050,20 +4107,21 @@ func TestServer_Query_Aggregates_String(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -4115,21 +4173,22 @@ func TestServer_Query_Aggregates_Math(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
 
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -4444,21 +4503,22 @@ func TestServer_Query_AggregateSelectors(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
 
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -4498,21 +4558,22 @@ func TestServer_Query_ExactTimeRange(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
 
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -4576,21 +4637,22 @@ func TestServer_Query_Selectors(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
 
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -4829,21 +4891,22 @@ func TestServer_Query_TopBottomInt(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP: %s", query.name)
-			continue
-		}
+			if query.skip {
+				t.Skipf("SKIP: %s", query.name)
+			}
 
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -4896,21 +4959,22 @@ func TestServer_Query_TopBottomWriteTags(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP: %s", query.name)
-			continue
-		}
+			if query.skip {
+				t.Skipf("SKIP: %s", query.name)
+			}
 
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -4959,22 +5023,23 @@ func TestServer_Query_Aggregates_IdenticalTime(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		for n := 0; n <= query.repeat; n++ {
-			if err := query.Execute(s); err != nil {
-				t.Error(query.Error(err))
-			} else if !query.success() {
-				t.Error(query.failureMessage())
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
 			}
-		}
+			for n := 0; n <= query.repeat; n++ {
+				if err := query.Execute(s); err != nil {
+					t.Error(query.Error(err))
+				} else if !query.success() {
+					t.Error(query.failureMessage())
+				}
+			}
+		})
 	}
 }
 
@@ -5042,20 +5107,21 @@ func TestServer_Query_GroupByTimeCutoffs(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5117,20 +5183,21 @@ func TestServer_Query_MapType(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5349,20 +5416,21 @@ func TestServer_Query_SubqueryWithGroupBy(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5397,20 +5465,21 @@ func TestServer_Query_PercentileDerivative(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5441,20 +5510,21 @@ func TestServer_Query_UnderscoreMeasurement(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5560,15 +5630,16 @@ func TestServer_Write_Precision(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5669,21 +5740,22 @@ func TestServer_Query_Wildcards(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
 
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5747,20 +5819,21 @@ func TestServer_Query_WildcardExpansion(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5818,20 +5891,21 @@ func TestServer_Query_AcrossShardsAndFields(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -5885,20 +5959,21 @@ func TestServer_Query_OrderedAcrossShards(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6103,21 +6178,22 @@ func TestServer_Query_Where_Fields(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
 
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6189,20 +6265,21 @@ func TestServer_Query_Where_With_Tags(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6289,20 +6366,21 @@ func TestServer_Query_With_EmptyTags(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6403,20 +6481,21 @@ func TestServer_Query_LimitAndOffset(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6499,20 +6578,21 @@ func TestServer_Query_Fill(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6594,20 +6674,21 @@ func TestServer_Query_TimeZone(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6645,20 +6726,21 @@ func TestServer_Query_Chunk(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6768,20 +6850,21 @@ func TestServer_Query_DropAndRecreateMeasurement(t *testing.T) {
 
 	// Test that re-inserting the measurement works fine.
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 
 	test = NewTest("db0", "rp0")
@@ -6805,20 +6888,21 @@ func TestServer_Query_DropAndRecreateMeasurement(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6874,20 +6958,21 @@ func TestServer_Query_ShowQueries_Future(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -6973,20 +7058,21 @@ func TestServer_Query_ShowSeries(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -7066,20 +7152,21 @@ func TestServer_Query_ShowSeriesCardinality(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -7107,20 +7194,21 @@ func TestServer_Query_ShowStats(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -7281,20 +7369,21 @@ func TestServer_Query_ShowMeasurementCardinality(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -7428,20 +7517,21 @@ func TestServer_Query_ShowTagKeys(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -7551,20 +7641,21 @@ func TestServer_Query_ShowTagKeyCardinality(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -7614,20 +7705,21 @@ func TestServer_Query_ShowFieldKeys(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -7677,20 +7769,21 @@ func TestServer_Query_ShowFieldKeyCardinality(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -7705,20 +7798,21 @@ func TestServer_ContinuousQuery(t *testing.T) {
 
 	runTest := func(test *Test, t *testing.T) {
 		for i, query := range test.queries {
-			if i == 0 {
-				if err := test.init(s); err != nil {
-					t.Fatalf("test init failed: %s", err)
+			t.Run(query.name, func(t *testing.T) {
+				if i == 0 {
+					if err := test.init(s); err != nil {
+						t.Fatalf("test init failed: %s", err)
+					}
 				}
-			}
-			if query.skip {
-				t.Logf("SKIP:: %s", query.name)
-				continue
-			}
-			if err := query.Execute(s); err != nil {
-				t.Error(query.Error(err))
-			} else if !query.success() {
-				t.Error(query.failureMessage())
-			}
+				if query.skip {
+					t.Skipf("SKIP:: %s", query.name)
+				}
+				if err := query.Execute(s); err != nil {
+					t.Error(query.Error(err))
+				} else if !query.success() {
+					t.Error(query.failureMessage())
+				}
+			})
 		}
 	}
 
@@ -7834,20 +7928,21 @@ func TestServer_ContinuousQuery_Deadlock(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 
 	// Deadlock detector.  If the deadlock is fixed, this test should complete all the writes in ~2.5s seconds (with artifical delays
@@ -7908,20 +8003,21 @@ func TestServer_Query_EvilIdentifiers(t *testing.T) {
 	}...)
 
 	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
+		t.Run(query.name, func(t *testing.T) {
+			if i == 0 {
+				if err := test.init(s); err != nil {
+					t.Fatalf("test init failed: %s", err)
+				}
 			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8147,15 +8243,16 @@ func TestServer_Query_IntoTarget(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8204,15 +8301,16 @@ func TestServer_Query_IntoTarget_Sparse(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8256,15 +8354,16 @@ func TestServer_Query_DuplicateMeasurements(t *testing.T) {
 	}...)
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8305,15 +8404,16 @@ func TestServer_Query_LargeTimestamp(t *testing.T) {
 	defer s2.Close()
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8352,15 +8452,16 @@ func TestServer_Query_DotProduct(t *testing.T) {
 	}...)
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8491,15 +8592,16 @@ func TestServer_WhereTimeInclusive(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8546,15 +8648,16 @@ func TestServer_Query_ImplicitEndTime(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8590,15 +8693,16 @@ func TestServer_Query_Sample_Wildcard(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8648,15 +8752,16 @@ func TestServer_Query_Sample_LimitOffset(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }
 
@@ -8699,14 +8804,15 @@ func TestServer_NestedAggregateWithMathPanics(t *testing.T) {
 	}
 
 	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
+		t.Run(query.name, func(t *testing.T) {
+			if query.skip {
+				t.Skipf("SKIP:: %s", query.name)
+			}
+			if err := query.Execute(s); err != nil {
+				t.Error(query.Error(err))
+			} else if !query.success() {
+				t.Error(query.failureMessage())
+			}
+		})
 	}
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -17,9 +17,13 @@ import (
 
 // Global server used by benchmarks
 var benchServer Server
+var verboseServerLogs bool
 
 func TestMain(m *testing.M) {
+	vv := flag.Bool("vv", false, "Turn on very verbose server logging.")
 	flag.Parse()
+
+	verboseServerLogs = *vv
 
 	// Setup
 	c := NewConfig()

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -18,8 +18,6 @@ import (
 
 // Global server used by benchmarks
 var benchServer Server
-var verboseServerLogs bool
-var indexType string
 
 func TestMain(m *testing.M) {
 	vv := flag.Bool("vv", false, "Turn on very verbose server logging.")

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -116,7 +116,7 @@ func TestEngine_LoadMetadataIndex(t *testing.T) {
 
 // Ensure that deletes only sent to the WAL will clear out the data from the cache on restart
 func TestEngine_DeleteWALLoadMetadata(t *testing.T) {
-	e := MustOpenEngine()
+	e := MustOpenDefaultEngine()
 	defer e.Close()
 
 	if err := e.WritePointsString(
@@ -254,7 +254,7 @@ func TestEngine_Backup(t *testing.T) {
 func TestEngine_CreateIterator_Cache_Ascending(t *testing.T) {
 	t.Parallel()
 
-	e := MustOpenEngine()
+	e := MustOpenDefaultEngine()
 	defer e.Close()
 
 	// e.CreateMeasurement("cpu")
@@ -307,7 +307,7 @@ func TestEngine_CreateIterator_Cache_Ascending(t *testing.T) {
 func TestEngine_CreateIterator_Cache_Descending(t *testing.T) {
 	t.Parallel()
 
-	e := MustOpenEngine()
+	e := MustOpenDefaultEngine()
 	defer e.Close()
 
 	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
@@ -359,7 +359,7 @@ func TestEngine_CreateIterator_Cache_Descending(t *testing.T) {
 func TestEngine_CreateIterator_TSM_Ascending(t *testing.T) {
 	t.Parallel()
 
-	e := MustOpenEngine()
+	e := MustOpenDefaultEngine()
 	defer e.Close()
 
 	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
@@ -412,7 +412,7 @@ func TestEngine_CreateIterator_TSM_Ascending(t *testing.T) {
 func TestEngine_CreateIterator_TSM_Descending(t *testing.T) {
 	t.Parallel()
 
-	e := MustOpenEngine()
+	e := MustOpenDefaultEngine()
 	defer e.Close()
 
 	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
@@ -465,7 +465,7 @@ func TestEngine_CreateIterator_TSM_Descending(t *testing.T) {
 func TestEngine_CreateIterator_Aux(t *testing.T) {
 	t.Parallel()
 
-	e := MustOpenEngine()
+	e := MustOpenDefaultEngine()
 	defer e.Close()
 
 	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
@@ -521,7 +521,7 @@ func TestEngine_CreateIterator_Aux(t *testing.T) {
 func TestEngine_CreateIterator_Condition(t *testing.T) {
 	t.Parallel()
 
-	e := MustOpenEngine()
+	e := MustOpenDefaultEngine()
 	defer e.Close()
 
 	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
@@ -578,123 +578,103 @@ func TestEngine_CreateIterator_Condition(t *testing.T) {
 // Ensures that deleting series from TSM files with multiple fields removes all the
 /// series
 func TestEngine_DeleteSeries(t *testing.T) {
-	// Generate temporary file.
-	f, _ := ioutil.TempFile("", "tsm")
-	f.Close()
-	os.Remove(f.Name())
-	walPath := filepath.Join(f.Name(), "wal")
-	os.MkdirAll(walPath, 0777)
-	defer os.RemoveAll(f.Name())
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			// Create a few points.
+			p1 := MustParsePointString("cpu,host=A value=1.1 1000000000")
+			p2 := MustParsePointString("cpu,host=B value=1.2 2000000000")
+			p3 := MustParsePointString("cpu,host=A sum=1.3 3000000000")
 
-	// Create a few points.
-	p1 := MustParsePointString("cpu,host=A value=1.1 1000000000")
-	p2 := MustParsePointString("cpu,host=B value=1.2 2000000000")
-	p3 := MustParsePointString("cpu,host=A sum=1.3 3000000000")
+			e := NewEngine(index)
+			// mock the planner so compactions don't run during the test
+			e.CompactionPlan = &mockPlanner{}
 
-	// Write those points to the engine.
-	db := path.Base(f.Name())
-	opt := tsdb.NewEngineOptions()
-	opt.InmemIndex = inmem.NewIndex(db)
-	idx := tsdb.MustOpenIndex(1, db, filepath.Join(f.Name(), "index"), opt)
-	defer idx.Close()
-	e := tsm1.NewEngine(1, idx, db, f.Name(), walPath, opt).(*tsm1.Engine)
-	// e.LoadMetadataIndex(1, MustNewDatabaseIndex("db0")) // Initialise an index
+			if err := e.Open(); err != nil {
+				panic(err)
+			}
+			defer e.Close()
 
-	// mock the planner so compactions don't run during the test
-	e.CompactionPlan = &mockPlanner{}
+			if err := e.WritePoints([]models.Point{p1, p2, p3}); err != nil {
+				t.Fatalf("failed to write points: %s", err.Error())
+			}
+			if err := e.WriteSnapshot(); err != nil {
+				t.Fatalf("failed to snapshot: %s", err.Error())
+			}
 
-	if err := e.Open(); err != nil {
-		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
+			keys := e.FileStore.Keys()
+			if exp, got := 3, len(keys); exp != got {
+				t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
+			}
+
+			if err := e.DeleteSeriesRange([][]byte{[]byte("cpu,host=A")}, math.MinInt64, math.MaxInt64); err != nil {
+				t.Fatalf("failed to delete series: %v", err)
+			}
+
+			keys = e.FileStore.Keys()
+			if exp, got := 1, len(keys); exp != got {
+				t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
+			}
+
+			exp := "cpu,host=B#!~#value"
+			if _, ok := keys[exp]; !ok {
+				t.Fatalf("wrong series deleted: exp %v, got %v", exp, keys)
+			}
+		})
 	}
-
-	if err := e.WritePoints([]models.Point{p1, p2, p3}); err != nil {
-		t.Fatalf("failed to write points: %s", err.Error())
-	}
-	if err := e.WriteSnapshot(); err != nil {
-		t.Fatalf("failed to snapshot: %s", err.Error())
-	}
-
-	keys := e.FileStore.Keys()
-	if exp, got := 3, len(keys); exp != got {
-		t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
-	}
-
-	if err := e.DeleteSeriesRange([][]byte{[]byte("cpu,host=A")}, math.MinInt64, math.MaxInt64); err != nil {
-		t.Fatalf("failed to delete series: %v", err)
-	}
-
-	keys = e.FileStore.Keys()
-	if exp, got := 1, len(keys); exp != got {
-		t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
-	}
-
-	exp := "cpu,host=B#!~#value"
-	if _, ok := keys[exp]; !ok {
-		t.Fatalf("wrong series deleted: exp %v, got %v", exp, keys)
-	}
-
 }
 
 func TestEngine_LastModified(t *testing.T) {
-	// Generate temporary file.
-	dir, _ := ioutil.TempDir("", "tsm")
-	walPath := filepath.Join(dir, "wal")
-	os.MkdirAll(walPath, 0777)
-	defer os.RemoveAll(dir)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			// Create a few points.
+			p1 := MustParsePointString("cpu,host=A value=1.1 1000000000")
+			p2 := MustParsePointString("cpu,host=B value=1.2 2000000000")
+			p3 := MustParsePointString("cpu,host=A sum=1.3 3000000000")
 
-	// Create a few points.
-	p1 := MustParsePointString("cpu,host=A value=1.1 1000000000")
-	p2 := MustParsePointString("cpu,host=B value=1.2 2000000000")
-	p3 := MustParsePointString("cpu,host=A sum=1.3 3000000000")
+			e := NewEngine(index)
 
-	// Write those points to the engine.
-	db := path.Base(dir)
-	opt := tsdb.NewEngineOptions()
-	opt.InmemIndex = inmem.NewIndex(db)
-	idx := tsdb.MustOpenIndex(1, db, filepath.Join(dir, "index"), opt)
-	defer idx.Close()
+			// mock the planner so compactions don't run during the test
+			e.CompactionPlan = &mockPlanner{}
 
-	e := tsm1.NewEngine(1, idx, db, dir, walPath, opt).(*tsm1.Engine)
+			if lm := e.LastModified(); !lm.IsZero() {
+				t.Fatalf("expected zero time, got %v", lm.UTC())
+			}
 
-	// mock the planner so compactions don't run during the test
-	e.CompactionPlan = &mockPlanner{}
+			e.SetEnabled(false)
+			if err := e.Open(); err != nil {
+				t.Fatalf("failed to open tsm1 engine: %s", err.Error())
+			}
+			defer e.Close()
 
-	if lm := e.LastModified(); !lm.IsZero() {
-		t.Fatalf("expected zero time, got %v", lm.UTC())
-	}
+			if err := e.WritePoints([]models.Point{p1, p2, p3}); err != nil {
+				t.Fatalf("failed to write points: %s", err.Error())
+			}
 
-	e.SetEnabled(false)
-	if err := e.Open(); err != nil {
-		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
-	}
+			lm := e.LastModified()
+			if lm.IsZero() {
+				t.Fatalf("expected non-zero time, got %v", lm.UTC())
+			}
+			e.SetEnabled(true)
 
-	if err := e.WritePoints([]models.Point{p1, p2, p3}); err != nil {
-		t.Fatalf("failed to write points: %s", err.Error())
-	}
+			if err := e.WriteSnapshot(); err != nil {
+				t.Fatalf("failed to snapshot: %s", err.Error())
+			}
 
-	lm := e.LastModified()
-	if lm.IsZero() {
-		t.Fatalf("expected non-zero time, got %v", lm.UTC())
-	}
-	e.SetEnabled(true)
+			lm2 := e.LastModified()
 
-	if err := e.WriteSnapshot(); err != nil {
-		t.Fatalf("failed to snapshot: %s", err.Error())
-	}
+			if got, exp := lm.Equal(lm2), false; exp != got {
+				t.Fatalf("expected time change, got %v, exp %v", got, exp)
+			}
 
-	lm2 := e.LastModified()
+			if err := e.DeleteSeriesRange([][]byte{[]byte("cpu,host=A")}, math.MinInt64, math.MaxInt64); err != nil {
+				t.Fatalf("failed to delete series: %v", err)
+			}
 
-	if got, exp := lm.Equal(lm2), false; exp != got {
-		t.Fatalf("expected time change, got %v, exp %v", got, exp)
-	}
-
-	if err := e.DeleteSeriesRange([][]byte{[]byte("cpu,host=A")}, math.MinInt64, math.MaxInt64); err != nil {
-		t.Fatalf("failed to delete series: %v", err)
-	}
-
-	lm3 := e.LastModified()
-	if got, exp := lm2.Equal(lm3), false; exp != got {
-		t.Fatalf("expected time change, got %v, exp %v", got, exp)
+			lm3 := e.LastModified()
+			if got, exp := lm2.Equal(lm3), false; exp != got {
+				t.Fatalf("expected time change, got %v, exp %v", got, exp)
+			}
+		})
 	}
 }
 
@@ -802,120 +782,77 @@ func BenchmarkEngine_CreateIterator_Limit_1M(b *testing.B) {
 	benchmarkEngineCreateIteratorLimit(b, 1000000)
 }
 
-func BenchmarkEngine_WritePoints_10(b *testing.B) {
-	benchmarkEngine_WritePoints(b, 10)
-}
-
-func BenchmarkEngine_WritePoints_100(b *testing.B) {
-	benchmarkEngine_WritePoints(b, 100)
-}
-
-func BenchmarkEngine_WritePoints_1000(b *testing.B) {
-	benchmarkEngine_WritePoints(b, 1000)
-}
-
-func BenchmarkEngine_WritePoints_5000(b *testing.B) {
-	benchmarkEngine_WritePoints(b, 5000)
-}
-
-func benchmarkEngine_WritePoints(b *testing.B, batchSize int) {
-	e := MustOpenEngine()
-	defer e.Close()
-
-	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
-
-	pp := make([]models.Point, 0, batchSize)
-	for i := 0; i < batchSize; i++ {
-		p := MustParsePointString(fmt.Sprintf("cpu,host=%d value=1.2", i))
-		pp = append(pp, p)
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		err := e.WritePoints(pp)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkEngine_WritePoints_Parallel_1000(b *testing.B) {
-	benchmarkEngine_WritePoints(b, 1000)
-}
-
-func BenchmarkEngine_WritePoints_Parallel_5000(b *testing.B) {
-	benchmarkEngine_WritePoints_Parallel(b, 5000)
-}
-
-func BenchmarkEngine_WritePoints_Parallel_10000(b *testing.B) {
-	benchmarkEngine_WritePoints_Parallel(b, 10000)
-}
-
-func BenchmarkEngine_WritePoints_Parallel_25000(b *testing.B) {
-	benchmarkEngine_WritePoints_Parallel(b, 25000)
-}
-
-func BenchmarkEngine_WritePoints_Parallel_50000(b *testing.B) {
-	benchmarkEngine_WritePoints_Parallel(b, 50000)
-}
-
-func BenchmarkEngine_WritePoints_Parallel_75000(b *testing.B) {
-	benchmarkEngine_WritePoints_Parallel(b, 75000)
-}
-
-func BenchmarkEngine_WritePoints_Parallel_100000(b *testing.B) {
-	benchmarkEngine_WritePoints_Parallel(b, 100000)
-}
-
-func BenchmarkEngine_WritePoints_Parallel_200000(b *testing.B) {
-	benchmarkEngine_WritePoints_Parallel(b, 200000)
-}
-
-func benchmarkEngine_WritePoints_Parallel(b *testing.B, batchSize int) {
-	e := MustOpenEngine()
-	defer e.Close()
-
-	// e.Index().CreateMeasurementIndexIfNotExists("cpu")
-	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-
-		b.StopTimer()
-		cpus := runtime.GOMAXPROCS(0)
-		pp := make([]models.Point, 0, batchSize*cpus)
-		for i := 0; i < batchSize*cpus; i++ {
-			p := MustParsePointString(fmt.Sprintf("cpu,host=%d value=1.2,other=%di", i, i))
-			pp = append(pp, p)
-		}
-		b.StartTimer()
-
-		var wg sync.WaitGroup
-		errC := make(chan error)
-		for i := 0; i < cpus; i++ {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
-				from, to := i*batchSize, (i+1)*batchSize
-				err := e.WritePoints(pp[from:to])
-				if err != nil {
-					errC <- err
-					return
-				}
-			}(i)
-		}
-
-		go func() {
-			wg.Wait()
-			close(errC)
-		}()
-
-		for err := range errC {
-			if err != nil {
-				b.Error(err)
+func BenchmarkEngine_WritePoints(b *testing.B) {
+	batchSizes := []int{10, 100, 1000, 5000, 10000}
+	for _, sz := range batchSizes {
+		for _, index := range tsdb.RegisteredIndexes() {
+			e := MustOpenEngine(index)
+			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
+			pp := make([]models.Point, 0, sz)
+			for i := 0; i < sz; i++ {
+				p := MustParsePointString(fmt.Sprintf("cpu,host=%d value=1.2", i))
+				pp = append(pp, p)
 			}
+
+			b.Run(fmt.Sprintf("%s_%d", index, sz), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					err := e.WritePoints(pp)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+			e.Close()
+		}
+	}
+}
+
+func BenchmarkEngine_WritePoints_Parallel(b *testing.B) {
+	batchSizes := []int{1000, 5000, 10000, 25000, 50000, 75000, 100000, 200000}
+	for _, sz := range batchSizes {
+		for _, index := range tsdb.RegisteredIndexes() {
+			e := MustOpenEngine(index)
+			e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
+
+			cpus := runtime.GOMAXPROCS(0)
+			pp := make([]models.Point, 0, sz*cpus)
+			for i := 0; i < sz*cpus; i++ {
+				p := MustParsePointString(fmt.Sprintf("cpu,host=%d value=1.2,other=%di", i, i))
+				pp = append(pp, p)
+			}
+
+			b.Run(fmt.Sprintf("%s_%d", index, sz), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					var wg sync.WaitGroup
+					errC := make(chan error)
+					for i := 0; i < cpus; i++ {
+						wg.Add(1)
+						go func(i int) {
+							defer wg.Done()
+							from, to := i*sz, (i+1)*sz
+							err := e.WritePoints(pp[from:to])
+							if err != nil {
+								errC <- err
+								return
+							}
+						}(i)
+					}
+
+					go func() {
+						wg.Wait()
+						close(errC)
+					}()
+
+					for err := range errC {
+						if err != nil {
+							b.Error(err)
+						}
+					}
+				}
+			})
+			e.Close()
 		}
 	}
 }
@@ -932,7 +869,7 @@ func benchmarkEngineCreateIteratorLimit(b *testing.B, pointN int) {
 }
 
 func benchmarkIterator(b *testing.B, opt query.IteratorOptions, pointN int) {
-	e := MustInitBenchmarkEngine(pointN)
+	e := MustInitDefaultBenchmarkEngine(pointN)
 	b.ResetTimer()
 	b.ReportAllocs()
 
@@ -952,9 +889,10 @@ var benchmark struct {
 
 var hostNames = []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}
 
-// MustInitBenchmarkEngine creates a new engine and fills it with points.
-// Reuses previous engine if the same parameters were used.
-func MustInitBenchmarkEngine(pointN int) *Engine {
+// MustInitDefaultBenchmarkEngine creates a new engine using the default index
+// and fills it with points.  Reuses previous engine if the same parameters
+// were used.
+func MustInitDefaultBenchmarkEngine(pointN int) *Engine {
 	// Reuse engine, if available.
 	if benchmark.Engine != nil {
 		if benchmark.PointN == pointN {
@@ -971,7 +909,7 @@ func MustInitBenchmarkEngine(pointN int) *Engine {
 		panic(fmt.Sprintf("point count (%d) must be a multiple of batch size (%d)", pointN, batchSize))
 	}
 
-	e := MustOpenEngine()
+	e := MustOpenEngine(tsdb.DefaultIndex)
 
 	// Initialize metadata.
 	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
@@ -1019,7 +957,7 @@ type Engine struct {
 }
 
 // NewEngine returns a new instance of Engine at a temporary location.
-func NewEngine() *Engine {
+func NewEngine(index string) *Engine {
 	root, err := ioutil.TempDir("", "tsm1-")
 	if err != nil {
 		panic(err)
@@ -1027,7 +965,10 @@ func NewEngine() *Engine {
 
 	db := path.Base(root)
 	opt := tsdb.NewEngineOptions()
-	opt.InmemIndex = inmem.NewIndex(db)
+	opt.IndexVersion = index
+	if index == "inmem" {
+		opt.InmemIndex = inmem.NewIndex(db)
+	}
 
 	idx := tsdb.MustOpenIndex(1, db, filepath.Join(root, "data", "index"), opt)
 
@@ -1043,15 +984,22 @@ func NewEngine() *Engine {
 	}
 }
 
-// MustOpenEngine returns a new, open instance of Engine.
-func MustOpenEngine() *Engine {
-	e := NewEngine()
+// MustOpenDefaultEngine returns a new, open instance of Engine using the default
+// index. Useful when the index is not directly under test.
+func MustOpenDefaultEngine() *Engine {
+	e := NewEngine(tsdb.DefaultIndex)
 	if err := e.Open(); err != nil {
 		panic(err)
 	}
-	// if err := e.LoadMetadataIndex(1, MustNewDatabaseIndex("db")); err != nil {
-	// 	panic(err)
-	// }
+	return e
+}
+
+// MustOpenEngine returns a new, open instance of Engine.
+func MustOpenEngine(index string) *Engine {
+	e := NewEngine(index)
+	if err := e.Open(); err != nil {
+		panic(err)
+	}
 	return e
 }
 

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -601,240 +601,278 @@ func TestShard_Close_RemoveIndex(t *testing.T) {
 
 // Ensure a shard can create iterators for its underlying data.
 func TestShard_CreateIterator_Ascending(t *testing.T) {
-	sh := NewShard()
+	var sh *Shard
+	var itr query.Iterator
 
-	// Calling CreateIterator when the engine is not open will return
-	// ErrEngineClosed.
-	_, got := sh.CreateIterator("cpu", query.IteratorOptions{})
-	if exp := tsdb.ErrEngineClosed; got != exp {
-		t.Fatalf("got %v, expected %v", got, exp)
-	}
+	test := func(index string) {
+		sh = NewShard(index)
 
-	if err := sh.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer sh.Close()
+		// Calling CreateIterator when the engine is not open will return
+		// ErrEngineClosed.
+		_, got := sh.CreateIterator("cpu", query.IteratorOptions{})
+		if exp := tsdb.ErrEngineClosed; got != exp {
+			t.Fatalf("got %v, expected %v", got, exp)
+		}
 
-	sh.MustWritePointsString(`
+		if err := sh.Open(); err != nil {
+			t.Fatal(err)
+		}
+
+		sh.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
 cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 `)
 
-	// Create iterator.
-	itr, err := sh.CreateIterator("cpu", query.IteratorOptions{
-		Expr:       influxql.MustParseExpr(`value`),
-		Aux:        []influxql.VarRef{{Val: "val2"}},
-		Dimensions: []string{"host"},
-		Ascending:  true,
-		StartTime:  influxql.MinTime,
-		EndTime:    influxql.MaxTime,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	fitr := itr.(query.FloatIterator)
-	defer itr.Close()
+		// Create iterator.
+		var err error
+		itr, err = sh.CreateIterator("cpu", query.IteratorOptions{
+			Expr:       influxql.MustParseExpr(`value`),
+			Aux:        []influxql.VarRef{{Val: "val2"}},
+			Dimensions: []string{"host"},
+			Ascending:  true,
+			StartTime:  influxql.MinTime,
+			EndTime:    influxql.MaxTime,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		fitr := itr.(query.FloatIterator)
 
-	// Read values from iterator.
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(0): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{
-		Name:  "cpu",
-		Tags:  query.NewTags(map[string]string{"host": "serverA"}),
-		Time:  time.Unix(0, 0).UnixNano(),
-		Value: 100,
-		Aux:   []interface{}{(*float64)(nil)},
-	}) {
-		t.Fatalf("unexpected point(0): %s", spew.Sdump(p))
+		// Read values from iterator.
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(0): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{
+			Name:  "cpu",
+			Tags:  query.NewTags(map[string]string{"host": "serverA"}),
+			Time:  time.Unix(0, 0).UnixNano(),
+			Value: 100,
+			Aux:   []interface{}{(*float64)(nil)},
+		}) {
+			t.Fatalf("unexpected point(0): %s", spew.Sdump(p))
+		}
+
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(1): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{
+			Name:  "cpu",
+			Tags:  query.NewTags(map[string]string{"host": "serverA"}),
+			Time:  time.Unix(10, 0).UnixNano(),
+			Value: 50,
+			Aux:   []interface{}{float64(5)},
+		}) {
+			t.Fatalf("unexpected point(1): %s", spew.Sdump(p))
+		}
+
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(2): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{
+			Name:  "cpu",
+			Tags:  query.NewTags(map[string]string{"host": "serverB"}),
+			Time:  time.Unix(0, 0).UnixNano(),
+			Value: 25,
+			Aux:   []interface{}{(*float64)(nil)},
+		}) {
+			t.Fatalf("unexpected point(2): %s", spew.Sdump(p))
+		}
 	}
 
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(1): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{
-		Name:  "cpu",
-		Tags:  query.NewTags(map[string]string{"host": "serverA"}),
-		Time:  time.Unix(10, 0).UnixNano(),
-		Value: 50,
-		Aux:   []interface{}{float64(5)},
-	}) {
-		t.Fatalf("unexpected point(1): %s", spew.Sdump(p))
-	}
-
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(2): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{
-		Name:  "cpu",
-		Tags:  query.NewTags(map[string]string{"host": "serverB"}),
-		Time:  time.Unix(0, 0).UnixNano(),
-		Value: 25,
-		Aux:   []interface{}{(*float64)(nil)},
-	}) {
-		t.Fatalf("unexpected point(2): %s", spew.Sdump(p))
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
+		sh.Close()
+		itr.Close()
 	}
 }
 
 // Ensure a shard can create iterators for its underlying data.
 func TestShard_CreateIterator_Descending(t *testing.T) {
-	sh := NewShard()
+	var (
+		sh  *Shard
+		itr query.Iterator
+	)
 
-	// Calling CreateIterator when the engine is not open will return
-	// ErrEngineClosed.
-	_, got := sh.CreateIterator("cpu", query.IteratorOptions{})
-	if exp := tsdb.ErrEngineClosed; got != exp {
-		t.Fatalf("got %v, expected %v", got, exp)
-	}
+	test := func(index string) {
+		sh = NewShard(index)
 
-	if err := sh.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer sh.Close()
+		// Calling CreateIterator when the engine is not open will return
+		// ErrEngineClosed.
+		_, got := sh.CreateIterator("cpu", query.IteratorOptions{})
+		if exp := tsdb.ErrEngineClosed; got != exp {
+			t.Fatalf("got %v, expected %v", got, exp)
+		}
 
-	sh.MustWritePointsString(`
+		if err := sh.Open(); err != nil {
+			t.Fatal(err)
+		}
+
+		sh.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
 cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 `)
 
-	// Create iterator.
-	itr, err := sh.CreateIterator("cpu", query.IteratorOptions{
-		Expr:       influxql.MustParseExpr(`value`),
-		Aux:        []influxql.VarRef{{Val: "val2"}},
-		Dimensions: []string{"host"},
-		Ascending:  false,
-		StartTime:  influxql.MinTime,
-		EndTime:    influxql.MaxTime,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer itr.Close()
-	fitr := itr.(query.FloatIterator)
+		// Create iterator.
+		var err error
+		itr, err = sh.CreateIterator("cpu", query.IteratorOptions{
+			Expr:       influxql.MustParseExpr(`value`),
+			Aux:        []influxql.VarRef{{Val: "val2"}},
+			Dimensions: []string{"host"},
+			Ascending:  false,
+			StartTime:  influxql.MinTime,
+			EndTime:    influxql.MaxTime,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		fitr := itr.(query.FloatIterator)
 
-	// Read values from iterator.
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(0): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{
-		Name:  "cpu",
-		Tags:  query.NewTags(map[string]string{"host": "serverB"}),
-		Time:  time.Unix(0, 0).UnixNano(),
-		Value: 25,
-		Aux:   []interface{}{(*float64)(nil)},
-	}) {
-		t.Fatalf("unexpected point(0): %s", spew.Sdump(p))
+		// Read values from iterator.
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(0): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{
+			Name:  "cpu",
+			Tags:  query.NewTags(map[string]string{"host": "serverB"}),
+			Time:  time.Unix(0, 0).UnixNano(),
+			Value: 25,
+			Aux:   []interface{}{(*float64)(nil)},
+		}) {
+			t.Fatalf("unexpected point(0): %s", spew.Sdump(p))
+		}
+
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(1): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{
+			Name:  "cpu",
+			Tags:  query.NewTags(map[string]string{"host": "serverA"}),
+			Time:  time.Unix(10, 0).UnixNano(),
+			Value: 50,
+			Aux:   []interface{}{float64(5)},
+		}) {
+			t.Fatalf("unexpected point(1): %s", spew.Sdump(p))
+		}
+
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(2): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{
+			Name:  "cpu",
+			Tags:  query.NewTags(map[string]string{"host": "serverA"}),
+			Time:  time.Unix(0, 0).UnixNano(),
+			Value: 100,
+			Aux:   []interface{}{(*float64)(nil)},
+		}) {
+			t.Fatalf("unexpected point(2): %s", spew.Sdump(p))
+		}
 	}
 
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(1): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{
-		Name:  "cpu",
-		Tags:  query.NewTags(map[string]string{"host": "serverA"}),
-		Time:  time.Unix(10, 0).UnixNano(),
-		Value: 50,
-		Aux:   []interface{}{float64(5)},
-	}) {
-		t.Fatalf("unexpected point(1): %s", spew.Sdump(p))
-	}
-
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(2): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{
-		Name:  "cpu",
-		Tags:  query.NewTags(map[string]string{"host": "serverA"}),
-		Time:  time.Unix(0, 0).UnixNano(),
-		Value: 100,
-		Aux:   []interface{}{(*float64)(nil)},
-	}) {
-		t.Fatalf("unexpected point(2): %s", spew.Sdump(p))
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
+		sh.Close()
+		itr.Close()
 	}
 }
 
 func TestShard_Disabled_WriteQuery(t *testing.T) {
-	sh := NewShard()
-	if err := sh.Open(); err != nil {
-		t.Fatal(err)
+	var sh *Shard
+
+	test := func(index string) {
+		sh = NewShard(index)
+		if err := sh.Open(); err != nil {
+			t.Fatal(err)
+		}
+
+		sh.SetEnabled(false)
+
+		pt := models.MustNewPoint(
+			"cpu",
+			models.NewTags(map[string]string{"host": "server"}),
+			map[string]interface{}{"value": 1.0},
+			time.Unix(1, 2),
+		)
+
+		err := sh.WritePoints([]models.Point{pt})
+		if err == nil {
+			t.Fatalf("expected shard disabled error")
+		}
+		if err != tsdb.ErrShardDisabled {
+			t.Fatalf(err.Error())
+		}
+
+		_, got := sh.CreateIterator("cpu", query.IteratorOptions{})
+		if err == nil {
+			t.Fatalf("expected shard disabled error")
+		}
+		if exp := tsdb.ErrShardDisabled; got != exp {
+			t.Fatalf("got %v, expected %v", got, exp)
+		}
+
+		sh.SetEnabled(true)
+
+		err = sh.WritePoints([]models.Point{pt})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if _, err = sh.CreateIterator("cpu", query.IteratorOptions{}); err != nil {
+			t.Fatalf("unexpected error: %v", got)
+		}
 	}
-	defer sh.Close()
 
-	sh.SetEnabled(false)
-
-	pt := models.MustNewPoint(
-		"cpu",
-		models.NewTags(map[string]string{"host": "server"}),
-		map[string]interface{}{"value": 1.0},
-		time.Unix(1, 2),
-	)
-
-	err := sh.WritePoints([]models.Point{pt})
-	if err == nil {
-		t.Fatalf("expected shard disabled error")
-	}
-	if err != tsdb.ErrShardDisabled {
-		t.Fatalf(err.Error())
-	}
-
-	_, got := sh.CreateIterator("cpu", query.IteratorOptions{})
-	if err == nil {
-		t.Fatalf("expected shard disabled error")
-	}
-	if exp := tsdb.ErrShardDisabled; got != exp {
-		t.Fatalf("got %v, expected %v", got, exp)
-	}
-
-	sh.SetEnabled(true)
-
-	err = sh.WritePoints([]models.Point{pt})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if _, err = sh.CreateIterator("cpu", query.IteratorOptions{}); err != nil {
-		t.Fatalf("unexpected error: %v", got)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
+		sh.Close()
 	}
 }
 
 func TestShard_Closed_Functions(t *testing.T) {
-	sh := NewShard()
-	if err := sh.Open(); err != nil {
-		t.Fatal(err)
+	var sh *Shard
+	test := func(index string) {
+		sh = NewShard(index)
+		if err := sh.Open(); err != nil {
+			t.Fatal(err)
+		}
+
+		pt := models.MustNewPoint(
+			"cpu",
+			models.NewTags(map[string]string{"host": "server"}),
+			map[string]interface{}{"value": 1.0},
+			time.Unix(1, 2),
+		)
+
+		if err := sh.WritePoints([]models.Point{pt}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		sh.Close()
+
+		// Should not panic, just a no-op when shard is closed
+		if err := sh.ForEachMeasurementTagKey([]byte("cpu"), func(k []byte) error {
+			return nil
+		}); err != nil {
+			t.Fatalf("expected nil: got %v", err)
+		}
+
+		// Should not panic, just a no-op when shard is closed
+		if exp, got := 0, sh.TagKeyCardinality([]byte("cpu"), []byte("host")); exp != got {
+			t.Fatalf("expected nil: exp %v, got %v", exp, got)
+		}
 	}
-	defer sh.Close()
 
-	pt := models.MustNewPoint(
-		"cpu",
-		models.NewTags(map[string]string{"host": "server"}),
-		map[string]interface{}{"value": 1.0},
-		time.Unix(1, 2),
-	)
-
-	if err := sh.WritePoints([]models.Point{pt}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	sh.Close()
-
-	// Should not panic, just a no-op when shard is closed
-	if err := sh.ForEachMeasurementTagKey([]byte("cpu"), func(k []byte) error {
-		return nil
-	}); err != nil {
-		t.Fatalf("expected nil: got %v", err)
-	}
-
-	// Should not panic, just a no-op when shard is closed
-	if exp, got := 0, sh.TagKeyCardinality([]byte("cpu"), []byte("host")); exp != got {
-		t.Fatalf("expected nil: exp %v, got %v", exp, got)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
 func TestShard_FieldDimensions(t *testing.T) {
-	sh := NewShard()
+	var sh *Shard
 
-	if err := sh.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer sh.Close()
+	setup := func(index string) {
+		sh = NewShard(index)
 
-	sh.MustWritePointsString(`
+		if err := sh.Open(); err != nil {
+			t.Fatal(err)
+		}
+
+		sh.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
 cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
@@ -842,108 +880,115 @@ mem,host=serverA value=25i 0
 mem,host=serverB value=50i,val3=t 10
 _reserved,region=uswest value="foo" 0
 `)
+	}
 
-	for _, tt := range []struct {
-		sources []string
-		f       map[string]influxql.DataType
-		d       map[string]struct{}
-	}{
-		{
-			sources: []string{"cpu"},
-			f: map[string]influxql.DataType{
-				"value": influxql.Float,
-				"val2":  influxql.Float,
+	for _, index := range tsdb.RegisteredIndexes() {
+		setup(index)
+		for _, tt := range []struct {
+			sources []string
+			f       map[string]influxql.DataType
+			d       map[string]struct{}
+		}{
+			{
+				sources: []string{"cpu"},
+				f: map[string]influxql.DataType{
+					"value": influxql.Float,
+					"val2":  influxql.Float,
+				},
+				d: map[string]struct{}{
+					"host":   {},
+					"region": {},
+				},
 			},
-			d: map[string]struct{}{
-				"host":   {},
-				"region": {},
+			{
+				sources: []string{"mem"},
+				f: map[string]influxql.DataType{
+					"value": influxql.Integer,
+					"val3":  influxql.Boolean,
+				},
+				d: map[string]struct{}{
+					"host": {},
+				},
 			},
-		},
-		{
-			sources: []string{"mem"},
-			f: map[string]influxql.DataType{
-				"value": influxql.Integer,
-				"val3":  influxql.Boolean,
+			{
+				sources: []string{"cpu", "mem"},
+				f: map[string]influxql.DataType{
+					"value": influxql.Float,
+					"val2":  influxql.Float,
+					"val3":  influxql.Boolean,
+				},
+				d: map[string]struct{}{
+					"host":   {},
+					"region": {},
+				},
 			},
-			d: map[string]struct{}{
-				"host": {},
+			{
+				sources: []string{"_fieldKeys"},
+				f: map[string]influxql.DataType{
+					"fieldKey":  influxql.String,
+					"fieldType": influxql.String,
+				},
+				d: map[string]struct{}{},
 			},
-		},
-		{
-			sources: []string{"cpu", "mem"},
-			f: map[string]influxql.DataType{
-				"value": influxql.Float,
-				"val2":  influxql.Float,
-				"val3":  influxql.Boolean,
+			{
+				sources: []string{"_series"},
+				f: map[string]influxql.DataType{
+					"key": influxql.String,
+				},
+				d: map[string]struct{}{},
 			},
-			d: map[string]struct{}{
-				"host":   {},
-				"region": {},
+			{
+				sources: []string{"_tagKeys"},
+				f: map[string]influxql.DataType{
+					"tagKey": influxql.String,
+				},
+				d: map[string]struct{}{},
 			},
-		},
-		{
-			sources: []string{"_fieldKeys"},
-			f: map[string]influxql.DataType{
-				"fieldKey":  influxql.String,
-				"fieldType": influxql.String,
+			{
+				sources: []string{"_reserved"},
+				f: map[string]influxql.DataType{
+					"value": influxql.String,
+				},
+				d: map[string]struct{}{
+					"region": {},
+				},
 			},
-			d: map[string]struct{}{},
-		},
-		{
-			sources: []string{"_series"},
-			f: map[string]influxql.DataType{
-				"key": influxql.String,
+			{
+				sources: []string{"unknown"},
+				f:       map[string]influxql.DataType{},
+				d:       map[string]struct{}{},
 			},
-			d: map[string]struct{}{},
-		},
-		{
-			sources: []string{"_tagKeys"},
-			f: map[string]influxql.DataType{
-				"tagKey": influxql.String,
-			},
-			d: map[string]struct{}{},
-		},
-		{
-			sources: []string{"_reserved"},
-			f: map[string]influxql.DataType{
-				"value": influxql.String,
-			},
-			d: map[string]struct{}{
-				"region": {},
-			},
-		},
-		{
-			sources: []string{"unknown"},
-			f:       map[string]influxql.DataType{},
-			d:       map[string]struct{}{},
-		},
-	} {
-		name := strings.Join(tt.sources, ",")
-		t.Run(name, func(t *testing.T) {
-			f, d, err := sh.FieldDimensions(tt.sources)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+		} {
+			name := fmt.Sprintf("%s_%s", strings.Join(tt.sources, ","), index)
+			t.Run(name, func(t *testing.T) {
+				f, d, err := sh.FieldDimensions(tt.sources)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
 
-			if diff := cmp.Diff(tt.f, f, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("unexpected fields:\n%s", diff)
-			}
-			if diff := cmp.Diff(tt.d, d, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("unexpected dimensions:\n%s", diff)
-			}
-		})
+				if diff := cmp.Diff(tt.f, f, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected fields:\n%s", diff)
+				}
+				if diff := cmp.Diff(tt.d, d, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected dimensions:\n%s", diff)
+				}
+			})
+		}
+		sh.Close()
 	}
 }
 
 func TestShard_MapType(t *testing.T) {
-	sh := NewShard()
+	var sh *Shard
 
-	if err := sh.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer sh.Close()
+	setup := func(index string) {
+		sh = NewShard(index)
 
-	sh.MustWritePointsString(`
+		if err := sh.Open(); err != nil {
+			t.Fatal(err)
+		}
+
+		sh.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
 cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
@@ -951,449 +996,477 @@ mem,host=serverA value=25i 0
 mem,host=serverB value=50i,val3=t 10
 _reserved,region=uswest value="foo" 0
 `)
+	}
 
-	for _, tt := range []struct {
-		measurement string
-		field       string
-		typ         influxql.DataType
-	}{
-		{
-			measurement: "cpu",
-			field:       "value",
-			typ:         influxql.Float,
-		},
-		{
-			measurement: "cpu",
-			field:       "host",
-			typ:         influxql.Tag,
-		},
-		{
-			measurement: "cpu",
-			field:       "region",
-			typ:         influxql.Tag,
-		},
-		{
-			measurement: "cpu",
-			field:       "val2",
-			typ:         influxql.Float,
-		},
-		{
-			measurement: "cpu",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "mem",
-			field:       "value",
-			typ:         influxql.Integer,
-		},
-		{
-			measurement: "mem",
-			field:       "val3",
-			typ:         influxql.Boolean,
-		},
-		{
-			measurement: "mem",
-			field:       "host",
-			typ:         influxql.Tag,
-		},
-		{
-			measurement: "unknown",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "_fieldKeys",
-			field:       "fieldKey",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_fieldKeys",
-			field:       "fieldType",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_fieldKeys",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "_series",
-			field:       "key",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_series",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "_tagKeys",
-			field:       "tagKey",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_tagKeys",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "_reserved",
-			field:       "value",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_reserved",
-			field:       "region",
-			typ:         influxql.Tag,
-		},
-	} {
-		name := fmt.Sprintf("%s - %s", tt.measurement, tt.field)
-		t.Run(name, func(t *testing.T) {
-			typ := sh.MapType(tt.measurement, tt.field)
-			if have, want := typ, tt.typ; have != want {
-				t.Errorf("unexpected data type: have=%#v want=%#v", have, want)
-			}
-		})
+	for _, index := range tsdb.RegisteredIndexes() {
+		setup(index)
+		for _, tt := range []struct {
+			measurement string
+			field       string
+			typ         influxql.DataType
+		}{
+			{
+				measurement: "cpu",
+				field:       "value",
+				typ:         influxql.Float,
+			},
+			{
+				measurement: "cpu",
+				field:       "host",
+				typ:         influxql.Tag,
+			},
+			{
+				measurement: "cpu",
+				field:       "region",
+				typ:         influxql.Tag,
+			},
+			{
+				measurement: "cpu",
+				field:       "val2",
+				typ:         influxql.Float,
+			},
+			{
+				measurement: "cpu",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "mem",
+				field:       "value",
+				typ:         influxql.Integer,
+			},
+			{
+				measurement: "mem",
+				field:       "val3",
+				typ:         influxql.Boolean,
+			},
+			{
+				measurement: "mem",
+				field:       "host",
+				typ:         influxql.Tag,
+			},
+			{
+				measurement: "unknown",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "_fieldKeys",
+				field:       "fieldKey",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_fieldKeys",
+				field:       "fieldType",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_fieldKeys",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "_series",
+				field:       "key",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_series",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "_tagKeys",
+				field:       "tagKey",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_tagKeys",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "_reserved",
+				field:       "value",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_reserved",
+				field:       "region",
+				typ:         influxql.Tag,
+			},
+		} {
+			name := fmt.Sprintf("%s_%s_%s", index, tt.measurement, tt.field)
+			t.Run(name, func(t *testing.T) {
+				typ := sh.MapType(tt.measurement, tt.field)
+				if have, want := typ, tt.typ; have != want {
+					t.Errorf("unexpected data type: have=%#v want=%#v", have, want)
+				}
+			})
+		}
+		sh.Close()
 	}
 }
 
 func TestShard_MeasurementsByRegex(t *testing.T) {
-	sh := NewShard()
+	var sh *Shard
+	setup := func(index string) {
+		sh = NewShard(index)
+		if err := sh.Open(); err != nil {
+			t.Fatal(err)
+		}
 
-	if err := sh.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer sh.Close()
-
-	sh.MustWritePointsString(`
+		sh.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
 cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 mem,host=serverA value=25i 0
 mem,host=serverB value=50i,val3=t 10
 `)
+	}
 
-	for _, tt := range []struct {
-		regex        string
-		measurements []string
-	}{
-		{regex: `cpu`, measurements: []string{"cpu"}},
-		{regex: `mem`, measurements: []string{"mem"}},
-		{regex: `cpu|mem`, measurements: []string{"cpu", "mem"}},
-		{regex: `gpu`, measurements: []string{}},
-		{regex: `pu`, measurements: []string{"cpu"}},
-		{regex: `p|m`, measurements: []string{"cpu", "mem"}},
-	} {
-		t.Run(tt.regex, func(t *testing.T) {
-			re := regexp.MustCompile(tt.regex)
-			measurements := sh.MeasurementsByRegex(re)
-			sort.Strings(measurements)
-			if diff := cmp.Diff(tt.measurements, measurements, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("unexpected measurements:\n%s", diff)
-			}
-		})
+	for _, index := range tsdb.RegisteredIndexes() {
+		setup(index)
+		for _, tt := range []struct {
+			regex        string
+			measurements []string
+		}{
+			{regex: `cpu`, measurements: []string{"cpu"}},
+			{regex: `mem`, measurements: []string{"mem"}},
+			{regex: `cpu|mem`, measurements: []string{"cpu", "mem"}},
+			{regex: `gpu`, measurements: []string{}},
+			{regex: `pu`, measurements: []string{"cpu"}},
+			{regex: `p|m`, measurements: []string{"cpu", "mem"}},
+		} {
+			t.Run(index+"_"+tt.regex, func(t *testing.T) {
+				re := regexp.MustCompile(tt.regex)
+				measurements := sh.MeasurementsByRegex(re)
+				sort.Strings(measurements)
+				if diff := cmp.Diff(tt.measurements, measurements, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected measurements:\n%s", diff)
+				}
+			})
+		}
+		sh.Close()
 	}
 }
 
 func TestShards_FieldDimensions(t *testing.T) {
-	shard1 := NewShard()
+	var shard1, shard2 *Shard
 
-	if err := shard1.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer shard1.Close()
+	setup := func(index string) {
+		shard1 = NewShard(index)
+		if err := shard1.Open(); err != nil {
+			t.Fatal(err)
+		}
 
-	shard1.MustWritePointsString(`
+		shard1.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
 cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 `)
 
-	shard2 := NewShard()
+		shard2 = NewShard(index)
+		if err := shard2.Open(); err != nil {
+			t.Fatal(err)
+		}
 
-	if err := shard2.Open(); err != nil {
-		t.Fatal(err)
-	}
-
-	shard2.MustWritePointsString(`
+		shard2.MustWritePointsString(`
 mem,host=serverA value=25i 0
 mem,host=serverB value=50i,val3=t 10
 _reserved,region=uswest value="foo" 0
 `)
+	}
 
-	sh := tsdb.Shards([]*tsdb.Shard{shard1.Shard, shard2.Shard})
-	for _, tt := range []struct {
-		sources []string
-		f       map[string]influxql.DataType
-		d       map[string]struct{}
-	}{
-		{
-			sources: []string{"cpu"},
-			f: map[string]influxql.DataType{
-				"value": influxql.Float,
-				"val2":  influxql.Float,
+	for _, index := range tsdb.RegisteredIndexes() {
+		setup(index)
+		sh := tsdb.Shards([]*tsdb.Shard{shard1.Shard, shard2.Shard})
+		for _, tt := range []struct {
+			sources []string
+			f       map[string]influxql.DataType
+			d       map[string]struct{}
+		}{
+			{
+				sources: []string{"cpu"},
+				f: map[string]influxql.DataType{
+					"value": influxql.Float,
+					"val2":  influxql.Float,
+				},
+				d: map[string]struct{}{
+					"host":   {},
+					"region": {},
+				},
 			},
-			d: map[string]struct{}{
-				"host":   {},
-				"region": {},
+			{
+				sources: []string{"mem"},
+				f: map[string]influxql.DataType{
+					"value": influxql.Integer,
+					"val3":  influxql.Boolean,
+				},
+				d: map[string]struct{}{
+					"host": {},
+				},
 			},
-		},
-		{
-			sources: []string{"mem"},
-			f: map[string]influxql.DataType{
-				"value": influxql.Integer,
-				"val3":  influxql.Boolean,
+			{
+				sources: []string{"cpu", "mem"},
+				f: map[string]influxql.DataType{
+					"value": influxql.Float,
+					"val2":  influxql.Float,
+					"val3":  influxql.Boolean,
+				},
+				d: map[string]struct{}{
+					"host":   {},
+					"region": {},
+				},
 			},
-			d: map[string]struct{}{
-				"host": {},
+			{
+				sources: []string{"_fieldKeys"},
+				f: map[string]influxql.DataType{
+					"fieldKey":  influxql.String,
+					"fieldType": influxql.String,
+				},
+				d: map[string]struct{}{},
 			},
-		},
-		{
-			sources: []string{"cpu", "mem"},
-			f: map[string]influxql.DataType{
-				"value": influxql.Float,
-				"val2":  influxql.Float,
-				"val3":  influxql.Boolean,
+			{
+				sources: []string{"_series"},
+				f: map[string]influxql.DataType{
+					"key": influxql.String,
+				},
+				d: map[string]struct{}{},
 			},
-			d: map[string]struct{}{
-				"host":   {},
-				"region": {},
+			{
+				sources: []string{"_tagKeys"},
+				f: map[string]influxql.DataType{
+					"tagKey": influxql.String,
+				},
+				d: map[string]struct{}{},
 			},
-		},
-		{
-			sources: []string{"_fieldKeys"},
-			f: map[string]influxql.DataType{
-				"fieldKey":  influxql.String,
-				"fieldType": influxql.String,
+			{
+				sources: []string{"_reserved"},
+				f: map[string]influxql.DataType{
+					"value": influxql.String,
+				},
+				d: map[string]struct{}{
+					"region": {},
+				},
 			},
-			d: map[string]struct{}{},
-		},
-		{
-			sources: []string{"_series"},
-			f: map[string]influxql.DataType{
-				"key": influxql.String,
+			{
+				sources: []string{"unknown"},
+				f:       map[string]influxql.DataType{},
+				d:       map[string]struct{}{},
 			},
-			d: map[string]struct{}{},
-		},
-		{
-			sources: []string{"_tagKeys"},
-			f: map[string]influxql.DataType{
-				"tagKey": influxql.String,
-			},
-			d: map[string]struct{}{},
-		},
-		{
-			sources: []string{"_reserved"},
-			f: map[string]influxql.DataType{
-				"value": influxql.String,
-			},
-			d: map[string]struct{}{
-				"region": {},
-			},
-		},
-		{
-			sources: []string{"unknown"},
-			f:       map[string]influxql.DataType{},
-			d:       map[string]struct{}{},
-		},
-	} {
-		name := strings.Join(tt.sources, ",")
-		t.Run(name, func(t *testing.T) {
-			f, d, err := sh.FieldDimensions(tt.sources)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+		} {
+			name := fmt.Sprintf("%s_%s", index, strings.Join(tt.sources, ","))
+			t.Run(name, func(t *testing.T) {
+				f, d, err := sh.FieldDimensions(tt.sources)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
 
-			if diff := cmp.Diff(tt.f, f, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("unexpected fields:\n%s", diff)
-			}
-			if diff := cmp.Diff(tt.d, d, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("unexpected dimensions:\n%s", diff)
-			}
-		})
+				if diff := cmp.Diff(tt.f, f, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected fields:\n%s", diff)
+				}
+				if diff := cmp.Diff(tt.d, d, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected dimensions:\n%s", diff)
+				}
+			})
+		}
+		shard1.Close()
+		shard2.Close()
 	}
 }
 
 func TestShards_MapType(t *testing.T) {
-	shard1 := NewShard()
+	var shard1, shard2 *Shard
 
-	if err := shard1.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer shard1.Close()
+	setup := func(index string) {
+		shard1 = NewShard(index)
+		if err := shard1.Open(); err != nil {
+			t.Fatal(err)
+		}
 
-	shard1.MustWritePointsString(`
+		shard1.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
 cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 `)
 
-	shard2 := NewShard()
+		shard2 = NewShard(index)
+		if err := shard2.Open(); err != nil {
+			t.Fatal(err)
+		}
 
-	if err := shard2.Open(); err != nil {
-		t.Fatal(err)
-	}
-
-	shard2.MustWritePointsString(`
+		shard2.MustWritePointsString(`
 mem,host=serverA value=25i 0
 mem,host=serverB value=50i,val3=t 10
 _reserved,region=uswest value="foo" 0
 `)
+	}
 
-	sh := tsdb.Shards([]*tsdb.Shard{shard1.Shard, shard2.Shard})
-	for _, tt := range []struct {
-		measurement string
-		field       string
-		typ         influxql.DataType
-	}{
-		{
-			measurement: "cpu",
-			field:       "value",
-			typ:         influxql.Float,
-		},
-		{
-			measurement: "cpu",
-			field:       "host",
-			typ:         influxql.Tag,
-		},
-		{
-			measurement: "cpu",
-			field:       "region",
-			typ:         influxql.Tag,
-		},
-		{
-			measurement: "cpu",
-			field:       "val2",
-			typ:         influxql.Float,
-		},
-		{
-			measurement: "cpu",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "mem",
-			field:       "value",
-			typ:         influxql.Integer,
-		},
-		{
-			measurement: "mem",
-			field:       "val3",
-			typ:         influxql.Boolean,
-		},
-		{
-			measurement: "mem",
-			field:       "host",
-			typ:         influxql.Tag,
-		},
-		{
-			measurement: "unknown",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "_fieldKeys",
-			field:       "fieldKey",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_fieldKeys",
-			field:       "fieldType",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_fieldKeys",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "_series",
-			field:       "key",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_series",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "_tagKeys",
-			field:       "tagKey",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_tagKeys",
-			field:       "unknown",
-			typ:         influxql.Unknown,
-		},
-		{
-			measurement: "_reserved",
-			field:       "value",
-			typ:         influxql.String,
-		},
-		{
-			measurement: "_reserved",
-			field:       "region",
-			typ:         influxql.Tag,
-		},
-	} {
-		name := fmt.Sprintf("%s - %s", tt.measurement, tt.field)
-		t.Run(name, func(t *testing.T) {
-			typ := sh.MapType(tt.measurement, tt.field)
-			if have, want := typ, tt.typ; have != want {
-				t.Errorf("unexpected data type: have=%#v want=%#v", have, want)
-			}
-		})
+	for _, index := range tsdb.RegisteredIndexes() {
+		setup(index)
+		sh := tsdb.Shards([]*tsdb.Shard{shard1.Shard, shard2.Shard})
+		for _, tt := range []struct {
+			measurement string
+			field       string
+			typ         influxql.DataType
+		}{
+			{
+				measurement: "cpu",
+				field:       "value",
+				typ:         influxql.Float,
+			},
+			{
+				measurement: "cpu",
+				field:       "host",
+				typ:         influxql.Tag,
+			},
+			{
+				measurement: "cpu",
+				field:       "region",
+				typ:         influxql.Tag,
+			},
+			{
+				measurement: "cpu",
+				field:       "val2",
+				typ:         influxql.Float,
+			},
+			{
+				measurement: "cpu",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "mem",
+				field:       "value",
+				typ:         influxql.Integer,
+			},
+			{
+				measurement: "mem",
+				field:       "val3",
+				typ:         influxql.Boolean,
+			},
+			{
+				measurement: "mem",
+				field:       "host",
+				typ:         influxql.Tag,
+			},
+			{
+				measurement: "unknown",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "_fieldKeys",
+				field:       "fieldKey",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_fieldKeys",
+				field:       "fieldType",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_fieldKeys",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "_series",
+				field:       "key",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_series",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "_tagKeys",
+				field:       "tagKey",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_tagKeys",
+				field:       "unknown",
+				typ:         influxql.Unknown,
+			},
+			{
+				measurement: "_reserved",
+				field:       "value",
+				typ:         influxql.String,
+			},
+			{
+				measurement: "_reserved",
+				field:       "region",
+				typ:         influxql.Tag,
+			},
+		} {
+			name := fmt.Sprintf("%s_%s_%s", index, tt.measurement, tt.field)
+			t.Run(name, func(t *testing.T) {
+				typ := sh.MapType(tt.measurement, tt.field)
+				if have, want := typ, tt.typ; have != want {
+					t.Errorf("unexpected data type: have=%#v want=%#v", have, want)
+				}
+			})
+		}
+		shard1.Close()
+		shard2.Close()
 	}
 }
 
 func TestShards_MeasurementsByRegex(t *testing.T) {
-	shard1 := NewShard()
+	var shard1, shard2 *Shard
 
-	if err := shard1.Open(); err != nil {
-		t.Fatal(err)
-	}
-	defer shard1.Close()
+	setup := func(index string) {
+		shard1 = NewShard(index)
+		if err := shard1.Open(); err != nil {
+			t.Fatal(err)
+		}
 
-	shard1.MustWritePointsString(`
+		shard1.MustWritePointsString(`
 cpu,host=serverA,region=uswest value=100 0
 cpu,host=serverA,region=uswest value=50,val2=5  10
 cpu,host=serverB,region=uswest value=25  0
 `)
 
-	shard2 := NewShard()
+		shard2 = NewShard(index)
+		if err := shard2.Open(); err != nil {
+			t.Fatal(err)
+		}
 
-	if err := shard2.Open(); err != nil {
-		t.Fatal(err)
-	}
-
-	shard2.MustWritePointsString(`
+		shard2.MustWritePointsString(`
 mem,host=serverA value=25i 0
 mem,host=serverB value=50i,val3=t 10
 _reserved,region=uswest value="foo" 0
 `)
+	}
 
-	sh := tsdb.Shards([]*tsdb.Shard{shard1.Shard, shard2.Shard})
-	for _, tt := range []struct {
-		regex        string
-		measurements []string
-	}{
-		{regex: `cpu`, measurements: []string{"cpu"}},
-		{regex: `mem`, measurements: []string{"mem"}},
-		{regex: `cpu|mem`, measurements: []string{"cpu", "mem"}},
-		{regex: `gpu`, measurements: []string{}},
-		{regex: `pu`, measurements: []string{"cpu"}},
-		{regex: `p|m`, measurements: []string{"cpu", "mem"}},
-	} {
-		t.Run(tt.regex, func(t *testing.T) {
-			re := regexp.MustCompile(tt.regex)
-			measurements := sh.MeasurementsByRegex(re)
-			sort.Strings(measurements)
-			if diff := cmp.Diff(tt.measurements, measurements, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("unexpected measurements:\n%s", diff)
-			}
-		})
+	for _, index := range tsdb.RegisteredIndexes() {
+		setup(index)
+		sh := tsdb.Shards([]*tsdb.Shard{shard1.Shard, shard2.Shard})
+		for _, tt := range []struct {
+			regex        string
+			measurements []string
+		}{
+			{regex: `cpu`, measurements: []string{"cpu"}},
+			{regex: `mem`, measurements: []string{"mem"}},
+			{regex: `cpu|mem`, measurements: []string{"cpu", "mem"}},
+			{regex: `gpu`, measurements: []string{}},
+			{regex: `pu`, measurements: []string{"cpu"}},
+			{regex: `p|m`, measurements: []string{"cpu", "mem"}},
+		} {
+			t.Run(tt.regex, func(t *testing.T) {
+				re := regexp.MustCompile(tt.regex)
+				measurements := sh.MeasurementsByRegex(re)
+				sort.Strings(measurements)
+				if diff := cmp.Diff(tt.measurements, measurements, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected measurements:\n%s", diff)
+				}
+			})
+		}
+		shard1.Close()
+		shard2.Close()
 	}
 }
 
@@ -1636,7 +1709,7 @@ type Shard struct {
 }
 
 // NewShard returns a new instance of Shard with temp paths.
-func NewShard() *Shard {
+func NewShard(index string) *Shard {
 	// Create temporary path for data and WAL.
 	dir, err := ioutil.TempDir("", "influxdb-tsdb-")
 	if err != nil {
@@ -1645,8 +1718,11 @@ func NewShard() *Shard {
 
 	// Build engine options.
 	opt := tsdb.NewEngineOptions()
+	opt.IndexVersion = index
 	opt.Config.WALDir = filepath.Join(dir, "wal")
-	opt.InmemIndex = inmem.NewIndex(path.Base(dir))
+	if index == "inmem" {
+		opt.InmemIndex = inmem.NewIndex(path.Base(dir))
+	}
 
 	return &Shard{
 		Shard: tsdb.NewShard(0,

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -686,10 +686,8 @@ cpu,host=serverB,region=uswest value=25  0
 
 // Ensure a shard can create iterators for its underlying data.
 func TestShard_CreateIterator_Descending(t *testing.T) {
-	var (
-		sh  *Shard
-		itr query.Iterator
-	)
+	var sh *Shard
+	var itr query.Iterator
 
 	test := func(index string) {
 		sh = NewShard(index)

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -412,8 +412,6 @@ func TestShards_CreateIterator(t *testing.T) {
 
 // Ensure the store can backup a shard and another store can restore it.
 func TestStore_BackupRestoreShard(t *testing.T) {
-	// t.Parallel()
-
 	test := func(index string) {
 		s0, s1 := MustOpenStore(index), MustOpenStore(index)
 		defer s0.Close()
@@ -481,10 +479,11 @@ func TestStore_BackupRestoreShard(t *testing.T) {
 	}
 
 	for _, index := range tsdb.RegisteredIndexes() {
+		if index == "tsi1" {
+			t.Skip("Skipping failing test for tsi1")
+		}
+
 		t.Run(index, func(t *testing.T) {
-			if index == "tsi1" {
-				t.Skip("Skipping failing test for tsi1")
-			}
 			test(index)
 		})
 	}
@@ -531,10 +530,6 @@ func TestStore_MeasurementNames_Deduplicate(t *testing.T) {
 }
 
 func testStoreCardinalityTombstoning(t *testing.T, store *Store) {
-	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {
-		t.Skip("Skipping test in short, race and appveyor mode.")
-	}
-
 	// Generate point data to write to the shards.
 	series := genTestSeries(10, 2, 4) // 160 series
 
@@ -595,6 +590,10 @@ func testStoreCardinalityTombstoning(t *testing.T, store *Store) {
 func TestStore_Cardinality_Tombstoning(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {
+		t.Skip("Skipping test in short, race and appveyor mode.")
+	}
+
 	test := func(index string) {
 		store := NewStore()
 		store.EngineOptions.IndexVersion = index
@@ -611,10 +610,6 @@ func TestStore_Cardinality_Tombstoning(t *testing.T) {
 }
 
 func testStoreCardinalityUnique(t *testing.T, store *Store) {
-	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {
-		t.Skip("Skipping test in short, race and appveyor mode.")
-	}
-
 	// Generate point data to write to the shards.
 	series := genTestSeries(64, 5, 5) // 200,000 series
 	expCardinality := len(series)
@@ -661,6 +656,10 @@ func testStoreCardinalityUnique(t *testing.T, store *Store) {
 func TestStore_Cardinality_Unique(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {
+		t.Skip("Skipping test in short, race and appveyor mode.")
+	}
+
 	test := func(index string) {
 		store := NewStore()
 		store.EngineOptions.IndexVersion = index
@@ -680,10 +679,6 @@ func TestStore_Cardinality_Unique(t *testing.T) {
 // This test tests cardinality estimation when series data is duplicated across
 // multiple shards.
 func testStoreCardinalityDuplicates(t *testing.T, store *Store) {
-	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {
-		t.Skip("Skipping test in short, race and appveyor mode.")
-	}
-
 	// Generate point data to write to the shards.
 	series := genTestSeries(64, 5, 5) // 200,000 series.
 	expCardinality := len(series)
@@ -744,6 +739,10 @@ func testStoreCardinalityDuplicates(t *testing.T, store *Store) {
 func TestStore_Cardinality_Duplicates(t *testing.T) {
 	t.Parallel()
 
+	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {
+		t.Skip("Skipping test in short, race and appveyor mode.")
+	}
+
 	test := func(index string) {
 		store := NewStore()
 		store.EngineOptions.IndexVersion = index
@@ -763,9 +762,6 @@ func TestStore_Cardinality_Duplicates(t *testing.T) {
 // Creates a large number of series in multiple shards, which will force
 // compactions to occur.
 func testStoreCardinalityCompactions(t *testing.T, store *Store) {
-	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {
-		t.Skip("Skipping test in short, race and appveyor mode.")
-	}
 
 	// Generate point data to write to the shards.
 	series := genTestSeries(300, 5, 5) // 937,500 series
@@ -812,6 +808,10 @@ func testStoreCardinalityCompactions(t *testing.T, store *Store) {
 
 func TestStore_Cardinality_Compactions(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {
+		t.Skip("Skipping test in short, race and appveyor mode.")
+	}
 
 	test := func(index string) {
 		store := NewStore()

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -592,28 +592,22 @@ func testStoreCardinalityTombstoning(t *testing.T, store *Store) {
 	}
 }
 
-func TestStore_Cardinality_Tombstoning_Inmem(t *testing.T) {
+func TestStore_Cardinality_Tombstoning(t *testing.T) {
 	t.Parallel()
 
-	store := NewStore()
-	store.EngineOptions.Config.Index = "inmem"
-	if err := store.Open(); err != nil {
-		panic(err)
+	test := func(index string) {
+		store := NewStore()
+		store.EngineOptions.IndexVersion = index
+		if err := store.Open(); err != nil {
+			panic(err)
+		}
+		defer store.Close()
+		testStoreCardinalityTombstoning(t, store)
 	}
-	defer store.Close()
-	testStoreCardinalityTombstoning(t, store)
-}
 
-func TestStore_Cardinality_Tombstoning_TSI(t *testing.T) {
-	t.Parallel()
-
-	store := NewStore()
-	store.EngineOptions.Config.Index = "tsi1"
-	if err := store.Open(); err != nil {
-		panic(err)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
-	defer store.Close()
-	testStoreCardinalityTombstoning(t, store)
 }
 
 func testStoreCardinalityUnique(t *testing.T, store *Store) {
@@ -664,30 +658,23 @@ func testStoreCardinalityUnique(t *testing.T, store *Store) {
 	}
 }
 
-func TestStore_Cardinality_Unique_Inmem(t *testing.T) {
+func TestStore_Cardinality_Unique(t *testing.T) {
 	t.Parallel()
 
-	store := NewStore()
-	store.EngineOptions.Config.Index = "inmem"
-	store.EngineOptions.Config.MaxSeriesPerDatabase = 0
-	if err := store.Open(); err != nil {
-		panic(err)
+	test := func(index string) {
+		store := NewStore()
+		store.EngineOptions.IndexVersion = index
+		store.EngineOptions.Config.MaxSeriesPerDatabase = 0
+		if err := store.Open(); err != nil {
+			panic(err)
+		}
+		defer store.Close()
+		testStoreCardinalityUnique(t, store)
 	}
-	defer store.Close()
-	testStoreCardinalityUnique(t, store)
-}
 
-func TestStore_Cardinality_Unique_TSI1(t *testing.T) {
-	t.Parallel()
-
-	store := NewStore()
-	store.EngineOptions.Config.Index = "tsi1"
-	store.EngineOptions.Config.MaxSeriesPerDatabase = 0
-	if err := store.Open(); err != nil {
-		panic(err)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
-	defer store.Close()
-	testStoreCardinalityUnique(t, store)
 }
 
 // This test tests cardinality estimation when series data is duplicated across
@@ -754,30 +741,23 @@ func testStoreCardinalityDuplicates(t *testing.T, store *Store) {
 	}
 }
 
-func TestStore_Cardinality_Duplicates_Inmem(t *testing.T) {
+func TestStore_Cardinality_Duplicates(t *testing.T) {
 	t.Parallel()
 
-	store := NewStore()
-	store.EngineOptions.Config.Index = "inmem"
-	store.EngineOptions.Config.MaxSeriesPerDatabase = 0
-	if err := store.Open(); err != nil {
-		panic(err)
+	test := func(index string) {
+		store := NewStore()
+		store.EngineOptions.IndexVersion = index
+		store.EngineOptions.Config.MaxSeriesPerDatabase = 0
+		if err := store.Open(); err != nil {
+			panic(err)
+		}
+		defer store.Close()
+		testStoreCardinalityDuplicates(t, store)
 	}
-	defer store.Close()
-	testStoreCardinalityDuplicates(t, store)
-}
 
-func TestStore_Cardinality_Duplicates_TSI1(t *testing.T) {
-	t.Parallel()
-
-	store := NewStore()
-	store.EngineOptions.Config.Index = "tsi1"
-	store.EngineOptions.Config.MaxSeriesPerDatabase = 0
-	if err := store.Open(); err != nil {
-		panic(err)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
-	defer store.Close()
-	testStoreCardinalityDuplicates(t, store)
 }
 
 // Creates a large number of series in multiple shards, which will force
@@ -830,30 +810,23 @@ func testStoreCardinalityCompactions(t *testing.T, store *Store) {
 	}
 }
 
-func TestStore_Cardinality_Compactions_Inmem(t *testing.T) {
+func TestStore_Cardinality_Compactions(t *testing.T) {
 	t.Parallel()
 
-	store := NewStore()
-	store.EngineOptions.Config.Index = "inmem"
-	store.EngineOptions.Config.MaxSeriesPerDatabase = 0
-	if err := store.Open(); err != nil {
-		panic(err)
+	test := func(index string) {
+		store := NewStore()
+		store.EngineOptions.Config.Index = "inmem"
+		store.EngineOptions.Config.MaxSeriesPerDatabase = 0
+		if err := store.Open(); err != nil {
+			panic(err)
+		}
+		defer store.Close()
+		testStoreCardinalityCompactions(t, store)
 	}
-	defer store.Close()
-	testStoreCardinalityCompactions(t, store)
-}
 
-func TestStore_Cardinality_Compactions_TSI1(t *testing.T) {
-	t.Parallel()
-
-	store := NewStore()
-	store.EngineOptions.Config.Index = "tsi1"
-	store.EngineOptions.Config.MaxSeriesPerDatabase = 0
-	if err := store.Open(); err != nil {
-		panic(err)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
-	defer store.Close()
-	testStoreCardinalityCompactions(t, store)
 }
 
 func TestStore_TagValues(t *testing.T) {
@@ -961,9 +934,8 @@ func TestStore_TagValues(t *testing.T) {
 		}
 	}
 
-	indexes := []string{"inmem", "tsi1"}
 	for _, example := range examples {
-		for _, index := range indexes {
+		for _, index := range tsdb.RegisteredIndexes() {
 			setup(index)
 			t.Run(example.Name+"_"+index, func(t *testing.T) {
 				got, err := s.TagValues("db0", example.Expr)

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -29,69 +29,75 @@ import (
 func TestStore_DeleteRetentionPolicy(t *testing.T) {
 	t.Parallel()
 
-	s := MustOpenStore()
-	defer s.Close()
+	test := func(index string) {
+		s := MustOpenStore(index)
+		defer s.Close()
 
-	// Create a new shard and verify that it exists.
-	if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(1); sh == nil {
-		t.Fatalf("expected shard")
+		// Create a new shard and verify that it exists.
+		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(1); sh == nil {
+			t.Fatalf("expected shard")
+		}
+
+		// Create a new shard under the same retention policy,  and verify
+		// that it exists.
+		if err := s.CreateShard("db0", "rp0", 2, true); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(2); sh == nil {
+			t.Fatalf("expected shard")
+		}
+
+		// Create a new shard under a different retention policy, and
+		// verify that it exists.
+		if err := s.CreateShard("db0", "rp1", 3, true); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(3); sh == nil {
+			t.Fatalf("expected shard")
+		}
+
+		// Deleting the rp0 retention policy does not return an error.
+		if err := s.DeleteRetentionPolicy("db0", "rp0"); err != nil {
+			t.Fatal(err)
+		}
+
+		// It deletes the shards under that retention policy.
+		if sh := s.Shard(1); sh != nil {
+			t.Errorf("shard 1 was not deleted")
+		}
+
+		if sh := s.Shard(2); sh != nil {
+			t.Errorf("shard 2 was not deleted")
+		}
+
+		// It deletes the retention policy directory.
+		if got, exp := dirExists(filepath.Join(s.Path(), "db0", "rp0")), false; got != exp {
+			t.Error("directory exists, but should have been removed")
+		}
+
+		// It deletes the WAL retention policy directory.
+		if got, exp := dirExists(filepath.Join(s.EngineOptions.Config.WALDir, "db0", "rp0")), false; got != exp {
+			t.Error("directory exists, but should have been removed")
+		}
+
+		// Reopen other shard and check it still exists.
+		if err := s.Reopen(); err != nil {
+			t.Error(err)
+		} else if sh := s.Shard(3); sh == nil {
+			t.Errorf("shard 3 does not exist")
+		}
+
+		// It does not delete other retention policy directories.
+		if got, exp := dirExists(filepath.Join(s.Path(), "db0", "rp1")), true; got != exp {
+			t.Error("directory does not exist, but should")
+		}
+		if got, exp := dirExists(filepath.Join(s.EngineOptions.Config.WALDir, "db0", "rp1")), true; got != exp {
+			t.Error("directory does not exist, but should")
+		}
 	}
 
-	// Create a new shard under the same retention policy,  and verify
-	// that it exists.
-	if err := s.CreateShard("db0", "rp0", 2, true); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(2); sh == nil {
-		t.Fatalf("expected shard")
-	}
-
-	// Create a new shard under a different retention policy, and
-	// verify that it exists.
-	if err := s.CreateShard("db0", "rp1", 3, true); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(3); sh == nil {
-		t.Fatalf("expected shard")
-	}
-
-	// Deleting the rp0 retention policy does not return an error.
-	if err := s.DeleteRetentionPolicy("db0", "rp0"); err != nil {
-		t.Fatal(err)
-	}
-
-	// It deletes the shards under that retention policy.
-	if sh := s.Shard(1); sh != nil {
-		t.Errorf("shard 1 was not deleted")
-	}
-
-	if sh := s.Shard(2); sh != nil {
-		t.Errorf("shard 2 was not deleted")
-	}
-
-	// It deletes the retention policy directory.
-	if got, exp := dirExists(filepath.Join(s.Path(), "db0", "rp0")), false; got != exp {
-		t.Error("directory exists, but should have been removed")
-	}
-
-	// It deletes the WAL retention policy directory.
-	if got, exp := dirExists(filepath.Join(s.EngineOptions.Config.WALDir, "db0", "rp0")), false; got != exp {
-		t.Error("directory exists, but should have been removed")
-	}
-
-	// Reopen other shard and check it still exists.
-	if err := s.Reopen(); err != nil {
-		t.Error(err)
-	} else if sh := s.Shard(3); sh == nil {
-		t.Errorf("shard 3 does not exist")
-	}
-
-	// It does not delete other retention policy directories.
-	if got, exp := dirExists(filepath.Join(s.Path(), "db0", "rp1")), true; got != exp {
-		t.Error("directory does not exist, but should")
-	}
-	if got, exp := dirExists(filepath.Join(s.EngineOptions.Config.WALDir, "db0", "rp1")), true; got != exp {
-		t.Error("directory does not exist, but should")
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
@@ -99,30 +105,36 @@ func TestStore_DeleteRetentionPolicy(t *testing.T) {
 func TestStore_CreateShard(t *testing.T) {
 	t.Parallel()
 
-	s := MustOpenStore()
-	defer s.Close()
+	test := func(index string) {
+		s := MustOpenStore(index)
+		defer s.Close()
 
-	// Create a new shard and verify that it exists.
-	if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(1); sh == nil {
-		t.Fatalf("expected shard")
+		// Create a new shard and verify that it exists.
+		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(1); sh == nil {
+			t.Fatalf("expected shard")
+		}
+
+		// Create another shard and verify that it exists.
+		if err := s.CreateShard("db0", "rp0", 2, true); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(2); sh == nil {
+			t.Fatalf("expected shard")
+		}
+
+		// Reopen shard and recheck.
+		if err := s.Reopen(); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(1); sh == nil {
+			t.Fatalf("expected shard(1)")
+		} else if sh = s.Shard(2); sh == nil {
+			t.Fatalf("expected shard(2)")
+		}
 	}
 
-	// Create another shard and verify that it exists.
-	if err := s.CreateShard("db0", "rp0", 2, true); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(2); sh == nil {
-		t.Fatalf("expected shard")
-	}
-
-	// Reopen shard and recheck.
-	if err := s.Reopen(); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(1); sh == nil {
-		t.Fatalf("expected shard(1)")
-	} else if sh = s.Shard(2); sh == nil {
-		t.Fatalf("expected shard(2)")
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
@@ -130,21 +142,27 @@ func TestStore_CreateShard(t *testing.T) {
 func TestStore_DeleteShard(t *testing.T) {
 	t.Parallel()
 
-	s := MustOpenStore()
-	defer s.Close()
+	test := func(index string) {
+		s := MustOpenStore(index)
+		defer s.Close()
 
-	// Create a new shard and verify that it exists.
-	if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(1); sh == nil {
-		t.Fatalf("expected shard")
+		// Create a new shard and verify that it exists.
+		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(1); sh == nil {
+			t.Fatalf("expected shard")
+		}
+
+		// Reopen shard and recheck.
+		if err := s.Reopen(); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(1); sh == nil {
+			t.Fatalf("shard exists")
+		}
 	}
 
-	// Reopen shard and recheck.
-	if err := s.Reopen(); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(1); sh == nil {
-		t.Fatalf("shard exists")
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
@@ -152,58 +170,71 @@ func TestStore_DeleteShard(t *testing.T) {
 func TestStore_CreateShardSnapShot(t *testing.T) {
 	t.Parallel()
 
-	s := MustOpenStore()
-	defer s.Close()
+	test := func(index string) {
+		s := MustOpenStore(index)
+		defer s.Close()
 
-	// Create a new shard and verify that it exists.
-	if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
-		t.Fatal(err)
-	} else if sh := s.Shard(1); sh == nil {
-		t.Fatalf("expected shard")
+		// Create a new shard and verify that it exists.
+		if err := s.CreateShard("db0", "rp0", 1, true); err != nil {
+			t.Fatal(err)
+		} else if sh := s.Shard(1); sh == nil {
+			t.Fatalf("expected shard")
+		}
+
+		dir, e := s.CreateShardSnapshot(1)
+		if e != nil {
+			t.Fatal(e)
+		}
+		if dir == "" {
+			t.Fatal("empty directory name")
+		}
 	}
 
-	dir, e := s.CreateShardSnapshot(1)
-	if e != nil {
-		t.Fatal(e)
-	}
-	if dir == "" {
-		t.Fatal("empty directory name")
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
 func TestStore_Open(t *testing.T) {
 	t.Parallel()
 
-	s := NewStore()
-	defer s.Close()
+	test := func(index string) {
+		s := NewStore()
+		s.EngineOptions.IndexVersion = index
+		defer s.Close()
 
-	if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0", "2"), 0777); err != nil {
-		t.Fatal(err)
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0", "2"), 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp2", "4"), 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db1", "rp0", "1"), 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		// Store should ignore shard since it does not have a numeric name.
+		if err := s.Open(); err != nil {
+			t.Fatal(err)
+		} else if n := len(s.Databases()); n != 2 {
+			t.Fatalf("unexpected database index count: %d", n)
+		} else if n := s.ShardN(); n != 3 {
+			t.Fatalf("unexpected shard count: %d", n)
+		}
+
+		expDatabases := []string{"db0", "db1"}
+		gotDatabases := s.Databases()
+		sort.Strings(gotDatabases)
+
+		if got, exp := gotDatabases, expDatabases; !reflect.DeepEqual(got, exp) {
+			t.Fatalf("got %#v, expected %#v", got, exp)
+		}
 	}
 
-	if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp2", "4"), 0777); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.MkdirAll(filepath.Join(s.Path(), "db1", "rp0", "1"), 0777); err != nil {
-		t.Fatal(err)
-	}
-
-	// Store should ignore shard since it does not have a numeric name.
-	if err := s.Open(); err != nil {
-		t.Fatal(err)
-	} else if n := len(s.Databases()); n != 2 {
-		t.Fatalf("unexpected database index count: %d", n)
-	} else if n := s.ShardN(); n != 3 {
-		t.Fatalf("unexpected shard count: %d", n)
-	}
-
-	expDatabases := []string{"db0", "db1"}
-	gotDatabases := s.Databases()
-	sort.Strings(gotDatabases)
-
-	if got, exp := gotDatabases, expDatabases; !reflect.DeepEqual(got, exp) {
-		t.Fatalf("got %#v, expected %#v", got, exp)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
@@ -211,19 +242,26 @@ func TestStore_Open(t *testing.T) {
 func TestStore_Open_InvalidDatabaseFile(t *testing.T) {
 	t.Parallel()
 
-	s := NewStore()
-	defer s.Close()
+	test := func(index string) {
+		s := NewStore()
+		s.EngineOptions.IndexVersion = index
+		defer s.Close()
 
-	// Create a file instead of a directory for a database.
-	if _, err := os.Create(filepath.Join(s.Path(), "db0")); err != nil {
-		t.Fatal(err)
+		// Create a file instead of a directory for a database.
+		if _, err := os.Create(filepath.Join(s.Path(), "db0")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Store should ignore database since it's a file.
+		if err := s.Open(); err != nil {
+			t.Fatal(err)
+		} else if n := len(s.Databases()); n != 0 {
+			t.Fatalf("unexpected database index count: %d", n)
+		}
 	}
 
-	// Store should ignore database since it's a file.
-	if err := s.Open(); err != nil {
-		t.Fatal(err)
-	} else if n := len(s.Databases()); n != 0 {
-		t.Fatalf("unexpected database index count: %d", n)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
@@ -231,23 +269,30 @@ func TestStore_Open_InvalidDatabaseFile(t *testing.T) {
 func TestStore_Open_InvalidRetentionPolicy(t *testing.T) {
 	t.Parallel()
 
-	s := NewStore()
-	defer s.Close()
+	test := func(index string) {
+		s := NewStore()
+		s.EngineOptions.IndexVersion = index
+		defer s.Close()
 
-	// Create an RP file instead of a directory.
-	if err := os.MkdirAll(filepath.Join(s.Path(), "db0"), 0777); err != nil {
-		t.Fatal(err)
-	} else if _, err := os.Create(filepath.Join(s.Path(), "db0", "rp0")); err != nil {
-		t.Fatal(err)
+		// Create an RP file instead of a directory.
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db0"), 0777); err != nil {
+			t.Fatal(err)
+		} else if _, err := os.Create(filepath.Join(s.Path(), "db0", "rp0")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Store should ignore retention policy since it's a file, and there should
+		// be no indices created.
+		if err := s.Open(); err != nil {
+			t.Fatal(err)
+		} else if n := len(s.Databases()); n != 0 {
+			t.Log(s.Databases())
+			t.Fatalf("unexpected database index count: %d", n)
+		}
 	}
 
-	// Store should ignore retention policy since it's a file, and there should
-	// be no indices created.
-	if err := s.Open(); err != nil {
-		t.Fatal(err)
-	} else if n := len(s.Databases()); n != 0 {
-		t.Log(s.Databases())
-		t.Fatalf("unexpected database index count: %d", n)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
@@ -255,23 +300,30 @@ func TestStore_Open_InvalidRetentionPolicy(t *testing.T) {
 func TestStore_Open_InvalidShard(t *testing.T) {
 	t.Parallel()
 
-	s := NewStore()
-	defer s.Close()
+	test := func(index string) {
+		s := NewStore()
+		s.EngineOptions.IndexVersion = index
+		defer s.Close()
 
-	// Create a non-numeric shard file.
-	if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0"), 0777); err != nil {
-		t.Fatal(err)
-	} else if _, err := os.Create(filepath.Join(s.Path(), "db0", "rp0", "bad_shard")); err != nil {
-		t.Fatal(err)
+		// Create a non-numeric shard file.
+		if err := os.MkdirAll(filepath.Join(s.Path(), "db0", "rp0"), 0777); err != nil {
+			t.Fatal(err)
+		} else if _, err := os.Create(filepath.Join(s.Path(), "db0", "rp0", "bad_shard")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Store should ignore shard since it does not have a numeric name.
+		if err := s.Open(); err != nil {
+			t.Fatal(err)
+		} else if n := len(s.Databases()); n != 0 {
+			t.Fatalf("unexpected database index count: %d", n)
+		} else if n := s.ShardN(); n != 0 {
+			t.Fatalf("unexpected shard count: %d", n)
+		}
 	}
 
-	// Store should ignore shard since it does not have a numeric name.
-	if err := s.Open(); err != nil {
-		t.Fatal(err)
-	} else if n := len(s.Databases()); n != 0 {
-		t.Fatalf("unexpected database index count: %d", n)
-	} else if n := s.ShardN(); n != 0 {
-		t.Fatalf("unexpected shard count: %d", n)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
@@ -279,179 +331,202 @@ func TestStore_Open_InvalidShard(t *testing.T) {
 func TestShards_CreateIterator(t *testing.T) {
 	t.Parallel()
 
-	s := MustOpenStore()
-	defer s.Close()
+	test := func(index string) {
+		s := MustOpenStore(index)
+		defer s.Close()
 
-	// Create shard #0 with data.
-	s.MustCreateShardWithData("db0", "rp0", 0,
-		`cpu,host=serverA value=1  0`,
-		`cpu,host=serverA value=2 10`,
-		`cpu,host=serverB value=3 20`,
-	)
+		// Create shard #0 with data.
+		s.MustCreateShardWithData("db0", "rp0", 0,
+			`cpu,host=serverA value=1  0`,
+			`cpu,host=serverA value=2 10`,
+			`cpu,host=serverB value=3 20`,
+		)
 
-	// Create shard #1 with data.
-	s.MustCreateShardWithData("db0", "rp0", 1,
-		`cpu,host=serverA value=1 30`,
-		`mem,host=serverA value=2 40`, // skip: wrong source
-		`cpu,host=serverC value=3 60`,
-	)
+		// Create shard #1 with data.
+		s.MustCreateShardWithData("db0", "rp0", 1,
+			`cpu,host=serverA value=1 30`,
+			`mem,host=serverA value=2 40`, // skip: wrong source
+			`cpu,host=serverC value=3 60`,
+		)
 
-	// Retrieve shard group.
-	shards := s.ShardGroup([]uint64{0, 1})
+		// Retrieve shard group.
+		shards := s.ShardGroup([]uint64{0, 1})
 
-	// Create iterator.
-	itr, err := shards.CreateIterator("cpu", query.IteratorOptions{
-		Expr:       influxql.MustParseExpr(`value`),
-		Dimensions: []string{"host"},
-		Ascending:  true,
-		StartTime:  influxql.MinTime,
-		EndTime:    influxql.MaxTime,
-	})
-	if err != nil {
-		t.Fatal(err)
+		// Create iterator.
+		itr, err := shards.CreateIterator("cpu", query.IteratorOptions{
+			Expr:       influxql.MustParseExpr(`value`),
+			Dimensions: []string{"host"},
+			Ascending:  true,
+			StartTime:  influxql.MinTime,
+			EndTime:    influxql.MaxTime,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer itr.Close()
+		fitr := itr.(query.FloatIterator)
+
+		// Read values from iterator. The host=serverA points should come first.
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(0): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(0, 0).UnixNano(), Value: 1}) {
+			t.Fatalf("unexpected point(0): %s", spew.Sdump(p))
+		}
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(1): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(10, 0).UnixNano(), Value: 2}) {
+			t.Fatalf("unexpected point(1): %s", spew.Sdump(p))
+		}
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(2): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(30, 0).UnixNano(), Value: 1}) {
+			t.Fatalf("unexpected point(2): %s", spew.Sdump(p))
+		}
+
+		// Next the host=serverB point.
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(3): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverB"), Time: time.Unix(20, 0).UnixNano(), Value: 3}) {
+			t.Fatalf("unexpected point(3): %s", spew.Sdump(p))
+		}
+
+		// And finally the host=serverC point.
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("unexpected error(4): %s", err)
+		} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverC"), Time: time.Unix(60, 0).UnixNano(), Value: 3}) {
+			t.Fatalf("unexpected point(4): %s", spew.Sdump(p))
+		}
+
+		// Then an EOF should occur.
+		if p, err := fitr.Next(); err != nil {
+			t.Fatalf("expected eof, got error: %s", err)
+		} else if p != nil {
+			t.Fatalf("expected eof, got: %s", spew.Sdump(p))
+		}
 	}
-	defer itr.Close()
-	fitr := itr.(query.FloatIterator)
 
-	// Read values from iterator. The host=serverA points should come first.
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(0): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(0, 0).UnixNano(), Value: 1}) {
-		t.Fatalf("unexpected point(0): %s", spew.Sdump(p))
-	}
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(1): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(10, 0).UnixNano(), Value: 2}) {
-		t.Fatalf("unexpected point(1): %s", spew.Sdump(p))
-	}
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(2): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverA"), Time: time.Unix(30, 0).UnixNano(), Value: 1}) {
-		t.Fatalf("unexpected point(2): %s", spew.Sdump(p))
-	}
-
-	// Next the host=serverB point.
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(3): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverB"), Time: time.Unix(20, 0).UnixNano(), Value: 3}) {
-		t.Fatalf("unexpected point(3): %s", spew.Sdump(p))
-	}
-
-	// And finally the host=serverC point.
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("unexpected error(4): %s", err)
-	} else if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Tags: ParseTags("host=serverC"), Time: time.Unix(60, 0).UnixNano(), Value: 3}) {
-		t.Fatalf("unexpected point(4): %s", spew.Sdump(p))
-	}
-
-	// Then an EOF should occur.
-	if p, err := fitr.Next(); err != nil {
-		t.Fatalf("expected eof, got error: %s", err)
-	} else if p != nil {
-		t.Fatalf("expected eof, got: %s", spew.Sdump(p))
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
 // Ensure the store can backup a shard and another store can restore it.
 func TestStore_BackupRestoreShard(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
-	s0, s1 := MustOpenStore(), MustOpenStore()
-	defer s0.Close()
-	defer s1.Close()
+	test := func(index string) {
+		s0, s1 := MustOpenStore(index), MustOpenStore(index)
+		defer s0.Close()
+		defer s1.Close()
 
-	// Create shard with data.
-	s0.MustCreateShardWithData("db0", "rp0", 100,
-		`cpu value=1 0`,
-		`cpu value=2 10`,
-		`cpu value=3 20`,
-	)
+		// Create shard with data.
+		s0.MustCreateShardWithData("db0", "rp0", 100,
+			`cpu value=1 0`,
+			`cpu value=2 10`,
+			`cpu value=3 20`,
+		)
 
-	if err := s0.Reopen(); err != nil {
-		t.Fatal(err)
+		if err := s0.Reopen(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Backup shard to a buffer.
+		var buf bytes.Buffer
+		if err := s0.BackupShard(100, time.Time{}, &buf); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create the shard on the other store and restore from buffer.
+		if err := s1.CreateShard("db0", "rp0", 100, true); err != nil {
+			t.Fatal(err)
+		}
+		if err := s1.RestoreShard(100, &buf); err != nil {
+			t.Fatal(err)
+		}
+
+		// Read data from
+		itr, err := s0.Shard(100).CreateIterator("cpu", query.IteratorOptions{
+			Expr:      influxql.MustParseExpr(`value`),
+			Ascending: true,
+			StartTime: influxql.MinTime,
+			EndTime:   influxql.MaxTime,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		fitr := itr.(query.FloatIterator)
+
+		// Read values from iterator. The host=serverA points should come first.
+		p, e := fitr.Next()
+		if e != nil {
+			t.Fatal(e)
+		}
+		if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Time: time.Unix(0, 0).UnixNano(), Value: 1}) {
+			t.Fatalf("unexpected point(0): %s", spew.Sdump(p))
+		}
+		p, e = fitr.Next()
+		if e != nil {
+			t.Fatal(e)
+		}
+		if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Time: time.Unix(10, 0).UnixNano(), Value: 2}) {
+			t.Fatalf("unexpected point(1): %s", spew.Sdump(p))
+		}
+		p, e = fitr.Next()
+		if e != nil {
+			t.Fatal(e)
+		}
+		if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Time: time.Unix(20, 0).UnixNano(), Value: 3}) {
+			t.Fatalf("unexpected point(2): %s", spew.Sdump(p))
+		}
 	}
 
-	// Backup shard to a buffer.
-	var buf bytes.Buffer
-	if err := s0.BackupShard(100, time.Time{}, &buf); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create the shard on the other store and restore from buffer.
-	if err := s1.CreateShard("db0", "rp0", 100, true); err != nil {
-		t.Fatal(err)
-	}
-	if err := s1.RestoreShard(100, &buf); err != nil {
-		t.Fatal(err)
-	}
-
-	// Read data from
-	itr, err := s0.Shard(100).CreateIterator("cpu", query.IteratorOptions{
-		Expr:      influxql.MustParseExpr(`value`),
-		Ascending: true,
-		StartTime: influxql.MinTime,
-		EndTime:   influxql.MaxTime,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	fitr := itr.(query.FloatIterator)
-
-	// Read values from iterator. The host=serverA points should come first.
-	p, e := fitr.Next()
-	if e != nil {
-		t.Fatal(e)
-	}
-	if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Time: time.Unix(0, 0).UnixNano(), Value: 1}) {
-		t.Fatalf("unexpected point(0): %s", spew.Sdump(p))
-	}
-	p, e = fitr.Next()
-	if e != nil {
-		t.Fatal(e)
-	}
-	if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Time: time.Unix(10, 0).UnixNano(), Value: 2}) {
-		t.Fatalf("unexpected point(1): %s", spew.Sdump(p))
-	}
-	p, e = fitr.Next()
-	if e != nil {
-		t.Fatal(e)
-	}
-	if !deep.Equal(p, &query.FloatPoint{Name: "cpu", Time: time.Unix(20, 0).UnixNano(), Value: 3}) {
-		t.Fatalf("unexpected point(2): %s", spew.Sdump(p))
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			if index == "tsi1" {
+				t.Skip("Skipping failing test for tsi1")
+			}
+			test(index)
+		})
 	}
 }
 
 func TestStore_MeasurementNames_Deduplicate(t *testing.T) {
 	t.Parallel()
 
-	s := MustOpenStore()
-	defer s.Close()
+	test := func(index string) {
+		s := MustOpenStore(index)
+		defer s.Close()
 
-	// Create shard with data.
-	s.MustCreateShardWithData("db0", "rp0", 1,
-		`cpu value=1 0`,
-		`cpu value=2 10`,
-		`cpu value=3 20`,
-	)
+		// Create shard with data.
+		s.MustCreateShardWithData("db0", "rp0", 1,
+			`cpu value=1 0`,
+			`cpu value=2 10`,
+			`cpu value=3 20`,
+		)
 
-	// Create 2nd shard w/ same measurements.
-	s.MustCreateShardWithData("db0", "rp0", 2,
-		`cpu value=1 0`,
-		`cpu value=2 10`,
-		`cpu value=3 20`,
-	)
+		// Create 2nd shard w/ same measurements.
+		s.MustCreateShardWithData("db0", "rp0", 2,
+			`cpu value=1 0`,
+			`cpu value=2 10`,
+			`cpu value=3 20`,
+		)
 
-	meas, err := s.MeasurementNames("db0", nil)
-	if err != nil {
-		t.Fatalf("unexpected error with MeasurementNames: %v", err)
+		meas, err := s.MeasurementNames("db0", nil)
+		if err != nil {
+			t.Fatalf("unexpected error with MeasurementNames: %v", err)
+		}
+
+		if exp, got := 1, len(meas); exp != got {
+			t.Fatalf("measurement len mismatch: exp %v, got %v", exp, got)
+		}
+
+		if exp, got := "cpu", string(meas[0]); exp != got {
+			t.Fatalf("measurement name mismatch: exp %v, got %v", exp, got)
+		}
 	}
 
-	if exp, got := 1, len(meas); exp != got {
-		t.Fatalf("measurement len mismatch: exp %v, got %v", exp, got)
-	}
-
-	if exp, got := "cpu", string(meas[0]); exp != got {
-		t.Fatalf("measurement name mismatch: exp %v, got %v", exp, got)
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
 	}
 }
 
@@ -862,8 +937,7 @@ func TestStore_TagValues(t *testing.T) {
 
 	var s *Store
 	setup := func(index string) {
-		s = MustOpenStore()
-		s.EngineOptions.IndexVersion = index
+		s = MustOpenStore(index)
 
 		fmtStr := `cpu%[1]d,foo=a,ignoreme=nope,host=tv%[2]d,shard=s%[3]d value=1 %[4]d
 		cpu%[1]d,host=nofoo value=1 %[4]d
@@ -975,7 +1049,7 @@ func BenchmarkStoreOpen_200KSeries_100Shards(b *testing.B) { benchmarkStoreOpen(
 func benchmarkStoreOpen(b *testing.B, mCnt, tkCnt, tvCnt, pntCnt, shardCnt int) {
 	var path string
 	if err := func() error {
-		store := MustOpenStore()
+		store := MustOpenStore("inmem")
 		defer store.Store.Close()
 		path = store.Path()
 
@@ -1168,10 +1242,11 @@ func NewStore() *Store {
 	return s
 }
 
-// MustOpenStore returns a new, open Store using the default index,
+// MustOpenStore returns a new, open Store using the specified index,
 // at a temporary path.
-func MustOpenStore() *Store {
+func MustOpenStore(index string) *Store {
 	s := NewStore()
+	s.EngineOptions.IndexVersion = index
 	if err := s.Open(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass

This PR ensure that where appropriate, unit tests are run on both indexes using sub-tests. Benchmarks have also been updated in a similar way.

In terms of the `tests` package tests, I found that the test output was too noisy when using Go's verbose `-v` mode, which itself is useful for seeing the sub-test result output. Therefore I've added a new `-vv` flag for that package, if the server logs are desirable output. /cc @mark-rushakoff @aanthony1243.

Finally, regarding the `tests` package, all queries for each test will now run as sub-tests.

```
go test -v github.com/influxdata/influxdb/tests -vv
```
