### PR TITLE
Reduce CPU usage for some compactions

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1063,6 +1063,10 @@ func (b *block) markRead(min, max int64) {
 }
 
 func (b *block) partiallyRead() bool {
+	// If readMin and readMax are still the initial values, nothing has been read.
+	if b.readMin == int64(math.MaxInt64) && b.readMax == int64(math.MinInt64) {
+		return false
+	}
 	return b.readMin != b.minTime || b.readMax != b.maxTime
 }
 


### PR DESCRIPTION
The partiallyRead func didn't account for the initial values and would
return true for blocks that had not been read at all.  This causes a
slower path during compactions that forces a block to be decoded when
it could just be merged as is without decoding.  This causes compactions
to consume more CPU and run slower at times.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
