### PR TITLE
Reduce CPU usage when checking series cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#8097](https://github.com/influxdata/influxdb/pull/8097): Return query parsing errors in CSV formats.
 - [#8607](https://github.com/influxdata/influxdb/issues/8607): Fix time zone shifts when the shift happens on a time zone boundary.
 - [#8639](https://github.com/influxdata/influxdb/issues/8639): Parse time literals using the time zone in the select statement.
+- [#8694](https://github.com/influxdata/influxdb/issues/8694): Reduce CPU usage when checking series cardinality
 
 ## v1.3.3 [unreleased]
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1266,18 +1266,29 @@ func (s *Store) monitorShards() {
 				continue
 			}
 
-			// inmem shards share the same index instance so just use the first one to avoid
-			// allocating the same measurements repeatedly
-			first := shards[0]
-			names, err := first.MeasurementNamesByExpr(nil)
-			if err != nil {
-				s.Logger.Warn("cannot retrieve measurement names", zap.Error(err))
-				continue
-			}
+			var dbLock sync.Mutex
+			databases := make(map[string]struct{}, len(shards))
 
 			s.walkShards(shards, func(sh *Shard) error {
 				db := sh.database
-				id := sh.id
+
+				// Only process 1 shard from each database
+				dbLock.Lock()
+				if _, ok := databases[db]; ok {
+					dbLock.Unlock()
+					return nil
+				}
+				databases[db] = struct{}{}
+				dbLock.Unlock()
+
+				// inmem shards share the same index instance so just use the first one to avoid
+				// allocating the same measurements repeatedly
+				first := shards[0]
+				names, err := first.MeasurementNamesByExpr(nil)
+				if err != nil {
+					s.Logger.Warn("cannot retrieve measurement names", zap.Error(err))
+					return nil
+				}
 
 				for _, name := range names {
 					sh.ForEachMeasurementTagKey(name, func(k []byte) error {
@@ -1289,8 +1300,8 @@ func (s *Store) monitorShards() {
 
 						// Log at 80, 85, 90-100% levels
 						if perc == 80 || perc == 85 || perc >= 90 {
-							s.Logger.Info(fmt.Sprintf("WARN: %d%% of max-values-per-tag limit exceeded: (%d/%d), db=%s shard=%d measurement=%s tag=%s",
-								perc, n, s.EngineOptions.Config.MaxValuesPerTag, db, id, name, k))
+							s.Logger.Info(fmt.Sprintf("WARN: %d%% of max-values-per-tag limit exceeded: (%d/%d), db=%s measurement=%s tag=%s",
+								perc, n, s.EngineOptions.Config.MaxValuesPerTag, db, name, k))
 						}
 						return nil
 					})


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

The tag cardinality checks were run for all inmem shards.  Since inmem
shards share the same index, a lot of the work is redundant.  Inmem shards
also need to sort their measurmenet and tag keys which can be CPU intensive
with many shards or higher cardinality.

This changes the series cardinality monitoring to just check one shard in each database which
should lower CPU usage due to excessive sorting.  The longer term solution
is to use TSI which would not have this check or required sorting.

Fixes #8694 