### PR TITLE
fix: cursor leak when cur == nil and aux or conds is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [#8639](https://github.com/influxdata/influxdb/issues/8639): Parse time literals using the time zone in the select statement.
 - [#8694](https://github.com/influxdata/influxdb/issues/8694): Reduce CPU usage when checking series cardinality
 - [#8677](https://github.com/influxdata/influxdb/issues/8677): Fix backups when snapshot is empty.
+- [#8706](https://github.com/influxdata/influxdb/pull/8706): Cursor leak, resulting in an accumulation of `.tsm.tmp` files after compactions. 
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1972,6 +1972,8 @@ func (e *Engine) createVarRefSeriesIterator(ref *influxql.VarRef, name string, s
 
 	// If the field doesn't exist then don't build an iterator.
 	if cur == nil {
+		cursorsAt(aux).close()
+		cursorsAt(conds).close()
 		return nil, nil
 	}
 

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -239,13 +239,9 @@ func (itr *floatIterator) Stats() influxql.IteratorStats {
 
 // Close closes the iterator.
 func (itr *floatIterator) Close() error {
-	for _, c := range itr.aux {
-		c.close()
-	}
+	cursorsAt(itr.aux).close()
 	itr.aux = nil
-	for _, c := range itr.conds.curs {
-		c.close()
-	}
+	cursorsAt(itr.conds.curs).close()
 	itr.conds.curs = nil
 	if itr.cur != nil {
 		err := itr.cur.close()
@@ -654,13 +650,9 @@ func (itr *integerIterator) Stats() influxql.IteratorStats {
 
 // Close closes the iterator.
 func (itr *integerIterator) Close() error {
-	for _, c := range itr.aux {
-		c.close()
-	}
+	cursorsAt(itr.aux).close()
 	itr.aux = nil
-	for _, c := range itr.conds.curs {
-		c.close()
-	}
+	cursorsAt(itr.conds.curs).close()
 	itr.conds.curs = nil
 	if itr.cur != nil {
 		err := itr.cur.close()
@@ -1069,13 +1061,9 @@ func (itr *unsignedIterator) Stats() influxql.IteratorStats {
 
 // Close closes the iterator.
 func (itr *unsignedIterator) Close() error {
-	for _, c := range itr.aux {
-		c.close()
-	}
+	cursorsAt(itr.aux).close()
 	itr.aux = nil
-	for _, c := range itr.conds.curs {
-		c.close()
-	}
+	cursorsAt(itr.conds.curs).close()
 	itr.conds.curs = nil
 	if itr.cur != nil {
 		err := itr.cur.close()
@@ -1484,13 +1472,9 @@ func (itr *stringIterator) Stats() influxql.IteratorStats {
 
 // Close closes the iterator.
 func (itr *stringIterator) Close() error {
-	for _, c := range itr.aux {
-		c.close()
-	}
+	cursorsAt(itr.aux).close()
 	itr.aux = nil
-	for _, c := range itr.conds.curs {
-		c.close()
-	}
+	cursorsAt(itr.conds.curs).close()
 	itr.conds.curs = nil
 	if itr.cur != nil {
 		err := itr.cur.close()
@@ -1899,13 +1883,9 @@ func (itr *booleanIterator) Stats() influxql.IteratorStats {
 
 // Close closes the iterator.
 func (itr *booleanIterator) Close() error {
-	for _, c := range itr.aux {
-		c.close()
-	}
+	cursorsAt(itr.aux).close()
 	itr.aux = nil
-	for _, c := range itr.conds.curs {
-		c.close()
-	}
+	cursorsAt(itr.conds.curs).close()
 	itr.conds.curs = nil
 	if itr.cur != nil {
 		err := itr.cur.close()

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -235,13 +235,9 @@ func (itr *{{.name}}Iterator) Stats() influxql.IteratorStats {
 
 // Close closes the iterator.
 func (itr *{{.name}}Iterator) Close() error {
-	for _, c := range itr.aux {
-		c.close()
-	}
+    cursorsAt(itr.aux).close()
 	itr.aux = nil
-	for _, c := range itr.conds.curs {
-	    c.close()
-	}
+	cursorsAt(itr.conds.curs).close()
 	itr.conds.curs = nil
 	if itr.cur != nil {
 		err := itr.cur.close()

--- a/tsdb/engine/tsm1/iterator.go
+++ b/tsdb/engine/tsm1/iterator.go
@@ -140,3 +140,11 @@ func (c *stringSliceCursor) nextString() (int64, string) {
 	c.values = c.values[1:]
 	return 0, value
 }
+
+type cursorsAt []cursorAt
+
+func (c cursorsAt) close() {
+	for _, cur := range c {
+		cur.close()
+	}
+}


### PR DESCRIPTION
* symptom would be locked `.tsm` files resulting in an accumulation of `.tsm.tmp` files after a compaction

Scenarios

* aggregate queries that included fields in the `where` condition, where the aggregate field does not exist for all shards. example `select count(*) where some_field = 0` in which case `conds` cursors will leak
* selectors that include additional fields and the field in the selector does not exist across all shards, like `select first(foo), v0 from m0 limit 10`, in which case `aux` cursors will leak

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated