### PR TITLE
Remove TimeRange function and replace with a more accurate ConditionExpr function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [#8694](https://github.com/influxdata/influxdb/issues/8694): Reduce CPU usage when checking series cardinality
 - [#8677](https://github.com/influxdata/influxdb/issues/8677): Fix backups when snapshot is empty.
 - [#8706](https://github.com/influxdata/influxdb/pull/8706): Cursor leak, resulting in an accumulation of `.tsm.tmp` files after compactions. 
+- [#8712](https://github.com/influxdata/influxdb/pull/8712): Force time expressions to use AND and improve condition parsing.
 
 ## v1.3.4 [unreleased]
 

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -538,11 +538,11 @@ func (e *StatementExecutor) createIterators(stmt *influxql.SelectStatement, ctx 
 	nowValuer := influxql.NowValuer{Now: now, Location: stmt.Location}
 	stmt = stmt.Reduce(&nowValuer)
 
-	var err error
-	opt.MinTime, opt.MaxTime, err = influxql.TimeRange(stmt.Condition, stmt.Location)
+	_, timeRange, err := influxql.ConditionExpr(stmt.Condition, &nowValuer)
 	if err != nil {
 		return nil, stmt, err
 	}
+	opt.MinTime, opt.MaxTime = timeRange.Min, timeRange.Max
 
 	if opt.MaxTime.IsZero() {
 		opt.MaxTime = time.Unix(0, influxql.MaxTime)

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -4248,28 +4248,6 @@ func HasTimeExpr(expr Expr) bool {
 	}
 }
 
-// OnlyTimeExpr returns true if the expression only has time constraints.
-func OnlyTimeExpr(expr Expr) bool {
-	if expr == nil {
-		return false
-	}
-	switch n := expr.(type) {
-	case *BinaryExpr:
-		if n.Op == AND || n.Op == OR {
-			return OnlyTimeExpr(n.LHS) && OnlyTimeExpr(n.RHS)
-		}
-		if ref, ok := n.LHS.(*VarRef); ok && strings.ToLower(ref.Val) == "time" {
-			return true
-		}
-		return false
-	case *ParenExpr:
-		// walk down the tree
-		return OnlyTimeExpr(n.Expr)
-	default:
-		return false
-	}
-}
-
 // Visitor can be called by Walk to traverse an AST hierarchy.
 // The Visit() function is called once per node.
 type Visitor interface {

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -949,46 +949,6 @@ func TestConditionExpr(t *testing.T) {
 	}
 }
 
-// Ensure that we see if a where clause has only time limitations
-func TestOnlyTimeExpr(t *testing.T) {
-	var tests = []struct {
-		stmt string
-		exp  bool
-	}{
-		{
-			stmt: `SELECT value FROM myseries WHERE value > 1`,
-			exp:  false,
-		},
-		{
-			stmt: `SELECT value FROM foo WHERE time >= '2000-01-01T00:00:05Z'`,
-			exp:  true,
-		},
-		{
-			stmt: `SELECT value FROM foo WHERE time >= '2000-01-01T00:00:05Z' AND time < '2000-01-01T00:00:05Z'`,
-			exp:  true,
-		},
-		{
-			stmt: `SELECT value FROM foo WHERE time >= '2000-01-01T00:00:05Z' AND asdf = 'bar'`,
-			exp:  false,
-		},
-		{
-			stmt: `SELECT value FROM foo WHERE asdf = 'jkl' AND (time >= '2000-01-01T00:00:05Z' AND time < '2000-01-01T00:00:05Z')`,
-			exp:  false,
-		},
-	}
-
-	for i, tt := range tests {
-		// Parse statement.
-		stmt, err := influxql.NewParser(strings.NewReader(tt.stmt)).ParseStatement()
-		if err != nil {
-			t.Fatalf("invalid statement: %q: %s", tt.stmt, err)
-		}
-		if influxql.OnlyTimeExpr(stmt.(*influxql.SelectStatement).Condition) != tt.exp {
-			t.Fatalf("%d. expected statement to return only time dimension to be %t: %s", i, tt.exp, tt.stmt)
-		}
-	}
-}
-
 // Ensure an AST node can be rewritten.
 func TestRewrite(t *testing.T) {
 	expr := MustParseExpr(`time > 1 OR foo = 2`)

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -858,81 +858,92 @@ func TestBinaryExprName(t *testing.T) {
 	}
 }
 
-// Ensure the time range of an expression can be extracted.
-func TestTimeRange(t *testing.T) {
-	for i, tt := range []struct {
-		expr          string
-		min, max, err string
-		loc           string
+func TestConditionExpr(t *testing.T) {
+	mustParseTime := func(value string) time.Time {
+		ts, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			t.Fatalf("unable to parse time: %s", err)
+		}
+		return ts
+	}
+	now := mustParseTime("2000-01-01T00:00:00Z")
+	valuer := influxql.NowValuer{Now: now}
+
+	for _, tt := range []struct {
+		s        string
+		cond     string
+		min, max time.Time
+		err      string
 	}{
-		// LHS VarRef
-		{expr: `time > '2000-01-01 00:00:00'`, min: `2000-01-01T00:00:00.000000001Z`, max: `0001-01-01T00:00:00Z`},
-		{expr: `time >= '2000-01-01 00:00:00'`, min: `2000-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`},
-		{expr: `time < '2000-01-01 00:00:00'`, min: `0001-01-01T00:00:00Z`, max: `1999-12-31T23:59:59.999999999Z`},
-		{expr: `time <= '2000-01-01 00:00:00'`, min: `0001-01-01T00:00:00Z`, max: `2000-01-01T00:00:00Z`},
-
-		// RHS VarRef
-		{expr: `'2000-01-01 00:00:00' > time`, min: `0001-01-01T00:00:00Z`, max: `1999-12-31T23:59:59.999999999Z`},
-		{expr: `'2000-01-01 00:00:00' >= time`, min: `0001-01-01T00:00:00Z`, max: `2000-01-01T00:00:00Z`},
-		{expr: `'2000-01-01 00:00:00' < time`, min: `2000-01-01T00:00:00.000000001Z`, max: `0001-01-01T00:00:00Z`},
-		{expr: `'2000-01-01 00:00:00' <= time`, min: `2000-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`},
-
-		// number literal
-		{expr: `time < 10`, min: `0001-01-01T00:00:00Z`, max: `1970-01-01T00:00:00.000000009Z`},
-
-		// Equality
-		{expr: `time = '2000-01-01 00:00:00'`, min: `2000-01-01T00:00:00Z`, max: `2000-01-01T00:00:00Z`},
-
-		// Multiple time expressions.
-		{expr: `time >= '2000-01-01 00:00:00' AND time < '2000-01-02 00:00:00'`, min: `2000-01-01T00:00:00Z`, max: `2000-01-01T23:59:59.999999999Z`},
-
-		// Min/max crossover
-		{expr: `time >= '2000-01-01 00:00:00' AND time <= '1999-01-01 00:00:00'`, min: `2000-01-01T00:00:00Z`, max: `1999-01-01T00:00:00Z`},
-
-		// Absolute time
-		{expr: `time = 1388534400s`, min: `2014-01-01T00:00:00Z`, max: `2014-01-01T00:00:00Z`},
-
-		// Non-comparative expressions.
-		{expr: `time`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`},
-		{expr: `time + 2`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`},
-		{expr: `time - '2000-01-01 00:00:00'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`},
-		{expr: `time AND '2000-01-01 00:00:00'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`},
-
-		// Invalid time expressions.
-		{expr: `time > "2000-01-01 00:00:00"`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `invalid operation: time and *influxql.VarRef are not compatible`},
-		{expr: `time > '2262-04-11 23:47:17'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `time 2262-04-11T23:47:17Z overflows time literal`},
-		{expr: `time > '1677-09-20 19:12:43'`, min: `0001-01-01T00:00:00Z`, max: `0001-01-01T00:00:00Z`, err: `time 1677-09-20T19:12:43Z underflows time literal`},
-
-		// Time zone expressions.
-		{expr: `time >= '2000-01-01'`, loc: `America/Los_Angeles`, min: `2000-01-01T00:00:00-08:00`, max: `0001-01-01T00:00:00Z`},
-		{expr: `time <= '2000-01-01'`, loc: `America/Los_Angeles`, min: `0001-01-01T00:00:00Z`, max: `2000-01-01T00:00:00-08:00`},
-		{expr: `time >= '2000-01-01 03:17:00'`, loc: `America/Los_Angeles`, min: `2000-01-01T03:17:00-08:00`, max: `0001-01-01T00:00:00Z`},
-		{expr: `time <= '2000-01-01 03:17:00'`, loc: `America/Los_Angeles`, min: `0001-01-01T00:00:00Z`, max: `2000-01-01T03:17:00-08:00`},
+		{s: `host = 'server01'`, cond: `host = 'server01'`},
+		{s: `time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T01:00:00Z'`,
+			min: mustParseTime("2000-01-01T00:00:00Z"),
+			max: mustParseTime("2000-01-01T01:00:00Z").Add(-1)},
+		{s: `host = 'server01' AND (region = 'uswest' AND time >= now() - 10m)`,
+			cond: `host = 'server01' AND (region = 'uswest')`,
+			min:  mustParseTime("1999-12-31T23:50:00Z")},
+		{s: `(host = 'server01' AND region = 'uswest') AND time >= now() - 10m`,
+			cond: `(host = 'server01' AND region = 'uswest')`,
+			min:  mustParseTime("1999-12-31T23:50:00Z")},
+		{s: `host = 'server01' AND (time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T01:00:00Z')`,
+			cond: `host = 'server01'`,
+			min:  mustParseTime("2000-01-01T00:00:00Z"),
+			max:  mustParseTime("2000-01-01T01:00:00Z").Add(-1)},
+		{s: `(time >= '2000-01-01T00:00:00Z' AND time < '2000-01-01T01:00:00Z') AND host = 'server01'`,
+			cond: `host = 'server01'`,
+			min:  mustParseTime("2000-01-01T00:00:00Z"),
+			max:  mustParseTime("2000-01-01T01:00:00Z").Add(-1)},
+		{s: `'2000-01-01T00:00:00Z' <= time AND '2000-01-01T01:00:00Z' > time`,
+			min: mustParseTime("2000-01-01T00:00:00Z"),
+			max: mustParseTime("2000-01-01T01:00:00Z").Add(-1)},
+		{s: `'2000-01-01T00:00:00Z' < time AND '2000-01-01T01:00:00Z' >= time`,
+			min: mustParseTime("2000-01-01T00:00:00Z").Add(1),
+			max: mustParseTime("2000-01-01T01:00:00Z")},
+		{s: `time = '2000-01-01T00:00:00Z'`,
+			min: mustParseTime("2000-01-01T00:00:00Z"),
+			max: mustParseTime("2000-01-01T00:00:00Z")},
+		{s: `time >= 10s`, min: mustParseTime("1970-01-01T00:00:10Z")},
+		{s: `time >= 10000000000`, min: mustParseTime("1970-01-01T00:00:10Z")},
+		{s: `time >= 10000000000.0`, min: mustParseTime("1970-01-01T00:00:10Z")},
+		{s: `time > now()`, min: now.Add(1)},
+		{s: `value`, err: `invalid condition expression: value`},
+		{s: `4`, err: `invalid condition expression: 4`},
+		{s: `time >= 'today'`, err: `invalid operation: time and *influxql.StringLiteral are not compatible`},
+		{s: `time != '2000-01-01T00:00:00Z'`, err: `invalid time comparison operator: !=`},
+		{s: `host = 'server01' OR (time >= now() - 10m AND host = 'server02')`, err: `cannot use OR with time conditions`},
+		{s: `value AND host = 'server01'`, err: `invalid condition expression: value`},
+		{s: `host = 'server01' OR (value)`, err: `invalid condition expression: value`},
+		{s: `time > '2262-04-11 23:47:17'`, err: `time 2262-04-11T23:47:17Z overflows time literal`},
+		{s: `time > '1677-09-20 19:12:43'`, err: `time 1677-09-20T19:12:43Z underflows time literal`},
 	} {
-		t.Run(tt.expr, func(t *testing.T) {
-			// Load the time zone if one was specified.
-			var loc *time.Location
-			if tt.loc != "" {
-				l, err := time.LoadLocation(tt.loc)
-				if err != nil {
-					t.Fatalf("unable to load time zone %s: %s", tt.loc, err)
+		t.Run(tt.s, func(t *testing.T) {
+			expr, err := influxql.ParseExpr(tt.s)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			cond, timeRange, err := influxql.ConditionExpr(expr, &valuer)
+			if err != nil {
+				if tt.err == "" {
+					t.Fatalf("unexpected error: %s", err)
+				} else if have, want := err.Error(), tt.err; have != want {
+					t.Fatalf("unexpected error: %s != %s", have, want)
 				}
-				loc = l
 			}
-
-			// Extract time range.
-			expr := MustParseExpr(tt.expr)
-			min, max, err := influxql.TimeRange(expr, loc)
-
-			// Compare with expected min/max.
-			if min := min.Format(time.RFC3339Nano); tt.min != min {
-				t.Fatalf("%d. %s: unexpected min:\n\nexp=%s\n\ngot=%s\n\n", i, tt.expr, tt.min, min)
+			if cond != nil {
+				if have, want := cond.String(), tt.cond; have != want {
+					t.Errorf("unexpected condition:\nhave=%s\nwant=%s", have, want)
+				}
+			} else {
+				if have, want := "", tt.cond; have != want {
+					t.Errorf("unexpected condition:\nhave=%s\nwant=%s", have, want)
+				}
 			}
-			if max := max.Format(time.RFC3339Nano); tt.max != max {
-				t.Fatalf("%d. %s: unexpected max:\n\nexp=%s\n\ngot=%s\n\n", i, tt.expr, tt.max, max)
+			if have, want := timeRange.Min, tt.min; !have.Equal(want) {
+				t.Errorf("unexpected min time:\nhave=%s\nwant=%s", have, want)
 			}
-			if (err != nil && err.Error() != tt.err) || (err == nil && tt.err != "") {
-				t.Fatalf("%d. %s: unexpected error:\n\nexp=%s\n\ngot=%s\n\n", i, tt.expr, tt.err, err)
+			if have, want := timeRange.Max, tt.max; !have.Equal(want) {
+				t.Errorf("unexpected max time:\nhave=%s\nwant=%s", have, want)
 			}
 		})
 	}
@@ -1830,11 +1841,11 @@ func (o Valuer) Value(key string) (v interface{}, ok bool) {
 
 // MustTimeRange will parse a time range. Panic on error.
 func MustTimeRange(expr influxql.Expr) (min, max time.Time) {
-	min, max, err := influxql.TimeRange(expr, nil)
+	_, timeRange, err := influxql.ConditionExpr(expr, nil)
 	if err != nil {
 		panic(err)
 	}
-	return min, max
+	return timeRange.Min, timeRange.Max
 }
 
 // mustParseTime parses an IS0-8601 string. Panic on error.

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -70,7 +70,6 @@ type Engine interface {
 
 	// InfluxQL iterators
 	MeasurementSeriesKeysByExpr(name []byte, condition influxql.Expr) ([][]byte, error)
-	ForEachMeasurementSeriesByExpr(name []byte, expr influxql.Expr, fn func(tags models.Tags) error) error
 	SeriesPointIterator(opt query.IteratorOptions) (query.Iterator, error)
 
 	// Statistics will return statistics relevant to this engine.

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -337,10 +337,6 @@ func (e *Engine) MeasurementFields(measurement []byte) *tsdb.MeasurementFields {
 	return e.fieldset.CreateFieldsIfNotExists(measurement)
 }
 
-func (e *Engine) ForEachMeasurementSeriesByExpr(name []byte, condition influxql.Expr, fn func(tags models.Tags) error) error {
-	return e.index.ForEachMeasurementSeriesByExpr(name, condition, fn)
-}
-
 func (e *Engine) HasTagKey(name, key []byte) (bool, error) {
 	return e.index.HasTagKey(name, key)
 }

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -43,7 +43,6 @@ type Index interface {
 
 	// InfluxQL system iterators
 	MeasurementSeriesKeysByExpr(name []byte, condition influxql.Expr) ([][]byte, error)
-	ForEachMeasurementSeriesByExpr(name []byte, expr influxql.Expr, fn func(tags models.Tags) error) error
 	SeriesPointIterator(opt query.IteratorOptions) (query.Iterator, error)
 
 	// Sets a shared fieldset from the engine.

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -614,23 +614,6 @@ func (i *Index) DropSeries(key []byte) error {
 	return nil
 }
 
-// ForEachMeasurementSeriesByExpr iterates over all series in a measurement filtered by an expression.
-func (i *Index) ForEachMeasurementSeriesByExpr(name []byte, expr influxql.Expr, fn func(tags models.Tags) error) error {
-	i.mu.RLock()
-	mm := i.measurements[string(name)]
-	i.mu.RUnlock()
-
-	if mm == nil {
-		return nil
-	}
-
-	if err := mm.ForEachSeriesByExpr(expr, fn); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // TagSets returns a list of tag sets.
 func (i *Index) TagSets(shardID uint64, name []byte, opt query.IteratorOptions) ([]*query.TagSet, error) {
 	i.mu.RLock()

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -276,7 +276,7 @@ func (m *Measurement) DropSeries(series *Series) {
 // filters walks the where clause of a select statement and returns a map with all series ids
 // matching the where clause and any filter expression that should be applied to each
 func (m *Measurement) filters(condition influxql.Expr) ([]uint64, map[uint64]influxql.Expr, error) {
-	if condition == nil || influxql.OnlyTimeExpr(condition) {
+	if condition == nil {
 		return m.SeriesIDs(), nil, nil
 	}
 	return m.WalkWhereForSeriesIds(condition)
@@ -555,11 +555,6 @@ func (m *Measurement) idsForExpr(n *influxql.BinaryExpr) (SeriesIDs, influxql.Ex
 			return nil, nil, fmt.Errorf("invalid expression: %s", n.String())
 		}
 		value = n.LHS
-	}
-
-	// For time literals, return all series IDs and "true" as the filter.
-	if _, ok := value.(*influxql.TimeLiteral); ok || name.Val == "time" {
-		return m.SeriesIDs(), &influxql.BooleanLiteral{Val: true}, nil
 	}
 
 	// For fields, return all series IDs from this measurement and return

--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -138,27 +138,6 @@ func TestMeasurement_TagsSet_Deadlock(t *testing.T) {
 	}
 }
 
-func TestMeasurement_ForEachSeriesByExpr_Deadlock(t *testing.T) {
-	m := inmem.NewMeasurement("foo", "cpu")
-	s1 := inmem.NewSeries([]byte("cpu,host=foo"), models.Tags{models.NewTag([]byte("host"), []byte("foo"))})
-	s1.ID = 1
-	m.AddSeries(s1)
-
-	s2 := inmem.NewSeries([]byte("cpu,host=bar"), models.Tags{models.NewTag([]byte("host"), []byte("bar"))})
-	s2.ID = 2
-	m.AddSeries(s2)
-
-	m.DropSeries(s1)
-
-	// This was deadlocking
-	m.ForEachSeriesByExpr(nil, func(tags models.Tags) error {
-		return nil
-	})
-	if got, exp := len(m.SeriesIDs()), 1; got != exp {
-		t.Fatalf("series count mismatch: got %v, exp %v", got, exp)
-	}
-}
-
 func BenchmarkMeasurement_SeriesIDForExp_EQRegex(b *testing.B) {
 	m := inmem.NewMeasurement("foo", "cpu")
 	for i := 0; i < 100000; i++ {

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -736,7 +736,7 @@ func (fs *FileSet) MeasurementsSketches() (estimator.Sketch, estimator.Sketch, e
 // call is equivalent to MeasurementSeriesIterator().
 func (fs *FileSet) MeasurementSeriesByExprIterator(name []byte, expr influxql.Expr, fieldset *tsdb.MeasurementFieldSet) (SeriesIterator, error) {
 	// Return all series for the measurement if there are no tag expressions.
-	if expr == nil || influxql.OnlyTimeExpr(expr) {
+	if expr == nil {
 		return fs.MeasurementSeriesIterator(name), nil
 	}
 	return fs.seriesByExprIterator(name, expr, fieldset.CreateFieldsIfNotExists(name))
@@ -822,11 +822,6 @@ func (fs *FileSet) seriesByBinaryExprIterator(name []byte, n *influxql.BinaryExp
 			return nil, fmt.Errorf("invalid expression: %s", n.String())
 		}
 		value = n.LHS
-	}
-
-	// For time literals, return all series and "true" as the filter.
-	if _, ok := value.(*influxql.TimeLiteral); ok || key.Val == "time" {
-		return newSeriesExprIterator(fs.MeasurementSeriesIterator(name), &influxql.BooleanLiteral{Val: true}), nil
 	}
 
 	// For fields, return all series from this measurement.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -670,27 +670,6 @@ func (i *Index) MeasurementTagKeyValuesByExpr(name []byte, keys []string, expr i
 	return results, nil
 }
 
-// ForEachMeasurementSeriesByExpr iterates over all series in a measurement filtered by an expression.
-func (i *Index) ForEachMeasurementSeriesByExpr(name []byte, condition influxql.Expr, fn func(tags models.Tags) error) error {
-	fs := i.RetainFileSet()
-	defer fs.Release()
-
-	itr, err := fs.MeasurementSeriesByExprIterator(name, condition, i.fieldset)
-	if err != nil {
-		return err
-	} else if itr == nil {
-		return nil
-	}
-
-	for e := itr.Next(); e != nil; e = itr.Next() {
-		if err := fn(e.Tags()); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // ForEachMeasurementTagKey iterates over all tag keys in a measurement.
 func (i *Index) ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error {
 	fs := i.RetainFileSet()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -829,7 +829,7 @@ func (s *Store) DeleteSeries(database string, sources []influxql.Source, conditi
 	sources = a
 
 	// Determine deletion time range.
-	_, timeRange, err := influxql.ConditionExpr(condition, nil)
+	condition, timeRange, err := influxql.ConditionExpr(condition, nil)
 	if err != nil {
 		return err
 	}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -829,9 +829,21 @@ func (s *Store) DeleteSeries(database string, sources []influxql.Source, conditi
 	sources = a
 
 	// Determine deletion time range.
-	min, max, err := influxql.TimeRangeAsEpochNano(condition)
+	_, timeRange, err := influxql.ConditionExpr(condition, nil)
 	if err != nil {
 		return err
+	}
+
+	var min, max int64
+	if !timeRange.Min.IsZero() {
+		min = timeRange.Min.UnixNano()
+	} else {
+		min = influxql.MinTime
+	}
+	if !timeRange.Max.IsZero() {
+		max = timeRange.Max.UnixNano()
+	} else {
+		max = influxql.MaxTime
 	}
 
 	s.mu.RLock()


### PR DESCRIPTION
The ConditionExpr function is more accurate because it parses the condition
and ensures that time conditions are actually used correctly. That means
that attempting to combine conditions with OR will not result in the query
silently pretending it's an AND and nested conditions work correctly so
there is only one way to read the query.

It also extracts the non-time conditions into a separate condition so we
can stop attempting to parse around the time conditions in lower layers of
the storage engine. This change does not remove those hacks, but a
following commit should be able to sanitize the condition and remove them.

- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>