### PR TITLE
Ensure inputs are closed on error. Add runtime GC finalizer as additional guard to close iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [#8677](https://github.com/influxdata/influxdb/issues/8677): Fix backups when snapshot is empty.
 - [#8706](https://github.com/influxdata/influxdb/pull/8706): Cursor leak, resulting in an accumulation of `.tsm.tmp` files after compactions.
 - [#8712](https://github.com/influxdata/influxdb/pull/8712): Force time expressions to use AND and improve condition parsing.
+- [#8716](https://github.com/influxdata/influxdb/pull/8716): Ensure inputs are closed on error. Add runtime GC finalizer as additional guard to close iterators
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1563,7 +1563,7 @@ func (e *Engine) CreateIterator(measurement string, opt query.IteratorOptions) (
 				if err != nil {
 					return nil, err
 				}
-				return query.Iterators(itrs).Merge(opt)
+				return newMergeGuardIterator(itrs, opt)
 			}
 		}
 
@@ -1573,14 +1573,14 @@ func (e *Engine) CreateIterator(measurement string, opt query.IteratorOptions) (
 		} else if len(inputs) == 0 {
 			return nil, nil
 		}
-		return query.Iterators(inputs).Merge(opt)
+		return newMergeGuardIterator(inputs, opt)
 	}
 
 	itrs, err := e.createVarRefIterator(measurement, opt)
 	if err != nil {
 		return nil, err
 	}
-	return query.Iterators(itrs).Merge(opt)
+	return newMergeGuardIterator(itrs, opt)
 }
 
 func (e *Engine) createCallIterator(measurement string, call *influxql.Call, opt query.IteratorOptions) ([]query.Iterator, error) {
@@ -1634,6 +1634,7 @@ func (e *Engine) createCallIterator(measurement string, call *influxql.Call, opt
 
 				itr, err := query.NewCallIterator(input, opt)
 				if err != nil {
+					query.Iterators(inputs).Close()
 					return err
 				}
 				inputs[i] = itr

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1563,7 +1563,7 @@ func (e *Engine) CreateIterator(measurement string, opt query.IteratorOptions) (
 				if err != nil {
 					return nil, err
 				}
-				return newMergeGuardIterator(itrs, opt)
+				return newMergeFinalizerIterator(itrs, opt)
 			}
 		}
 
@@ -1573,14 +1573,14 @@ func (e *Engine) CreateIterator(measurement string, opt query.IteratorOptions) (
 		} else if len(inputs) == 0 {
 			return nil, nil
 		}
-		return newMergeGuardIterator(inputs, opt)
+		return newMergeFinalizerIterator(inputs, opt)
 	}
 
 	itrs, err := e.createVarRefIterator(measurement, opt)
 	if err != nil {
 		return nil, err
 	}
-	return newMergeGuardIterator(itrs, opt)
+	return newMergeFinalizerIterator(itrs, opt)
 }
 
 func (e *Engine) createCallIterator(measurement string, call *influxql.Call, opt query.IteratorOptions) ([]query.Iterator, error) {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1758,8 +1758,6 @@ func (e *Engine) createTagSetIterators(ref *influxql.VarRef, name string, t *que
 			group.keys = t.SeriesKeys[i*n:]
 			group.filters = t.Filters[i*n:]
 		}
-
-		group.itrs = make([]query.Iterator, 0, len(group.keys))
 	}
 
 	// Read series groups in parallel.

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -8,6 +8,7 @@ package tsm1
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"sync"
 
@@ -117,6 +118,21 @@ func (c *bufCursor) nextAt(seek int64) interface{} {
 // copying the stats buffer to the iterator's stats field. This is used to
 // amortize the cost of using a mutex when updating stats.
 const statsBufferCopyIntervalN = 100
+
+type floatFinalizerIterator struct {
+	query.FloatIterator
+}
+
+func newFloatFinalizerIterator(inner query.FloatIterator) *floatFinalizerIterator {
+	itr := &floatFinalizerIterator{inner}
+	runtime.SetFinalizer(itr, (*floatFinalizerIterator).Close)
+	return itr
+}
+
+func (itr *floatFinalizerIterator) Close() error {
+	runtime.SetFinalizer(itr, nil)
+	return itr.FloatIterator.Close()
+}
 
 type floatIterator struct {
 	cur   floatCursor
@@ -527,6 +543,21 @@ func (c *floatDescendingCursor) nextTSM() {
 		}
 		c.tsm.pos = len(c.tsm.values) - 1
 	}
+}
+
+type integerFinalizerIterator struct {
+	query.IntegerIterator
+}
+
+func newIntegerFinalizerIterator(inner query.IntegerIterator) *integerFinalizerIterator {
+	itr := &integerFinalizerIterator{inner}
+	runtime.SetFinalizer(itr, (*integerFinalizerIterator).Close)
+	return itr
+}
+
+func (itr *integerFinalizerIterator) Close() error {
+	runtime.SetFinalizer(itr, nil)
+	return itr.IntegerIterator.Close()
 }
 
 type integerIterator struct {
@@ -940,6 +971,21 @@ func (c *integerDescendingCursor) nextTSM() {
 	}
 }
 
+type unsignedFinalizerIterator struct {
+	query.UnsignedIterator
+}
+
+func newUnsignedFinalizerIterator(inner query.UnsignedIterator) *unsignedFinalizerIterator {
+	itr := &unsignedFinalizerIterator{inner}
+	runtime.SetFinalizer(itr, (*unsignedFinalizerIterator).Close)
+	return itr
+}
+
+func (itr *unsignedFinalizerIterator) Close() error {
+	runtime.SetFinalizer(itr, nil)
+	return itr.UnsignedIterator.Close()
+}
+
 type unsignedIterator struct {
 	cur   unsignedCursor
 	aux   []cursorAt
@@ -1351,6 +1397,21 @@ func (c *unsignedDescendingCursor) nextTSM() {
 	}
 }
 
+type stringFinalizerIterator struct {
+	query.StringIterator
+}
+
+func newStringFinalizerIterator(inner query.StringIterator) *stringFinalizerIterator {
+	itr := &stringFinalizerIterator{inner}
+	runtime.SetFinalizer(itr, (*stringFinalizerIterator).Close)
+	return itr
+}
+
+func (itr *stringFinalizerIterator) Close() error {
+	runtime.SetFinalizer(itr, nil)
+	return itr.StringIterator.Close()
+}
+
 type stringIterator struct {
 	cur   stringCursor
 	aux   []cursorAt
@@ -1760,6 +1821,21 @@ func (c *stringDescendingCursor) nextTSM() {
 		}
 		c.tsm.pos = len(c.tsm.values) - 1
 	}
+}
+
+type booleanFinalizerIterator struct {
+	query.BooleanIterator
+}
+
+func newBooleanFinalizerIterator(inner query.BooleanIterator) *booleanFinalizerIterator {
+	itr := &booleanFinalizerIterator{inner}
+	runtime.SetFinalizer(itr, (*booleanFinalizerIterator).Close)
+	return itr
+}
+
+func (itr *booleanFinalizerIterator) Close() error {
+	runtime.SetFinalizer(itr, nil)
+	return itr.BooleanIterator.Close()
 }
 
 type booleanIterator struct {

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -3,6 +3,7 @@ package tsm1
 import (
 	"sort"
 	"fmt"
+	"runtime"
 	"sync"
 
 	"github.com/influxdata/influxdb/influxql"
@@ -113,6 +114,21 @@ func (c *bufCursor) nextAt(seek int64) interface{} {
 const statsBufferCopyIntervalN = 100
 
 {{range .}}
+
+type {{.name}}FinalizerIterator struct {
+	query.{{.Name}}Iterator
+}
+
+func new{{.Name}}FinalizerIterator(inner query.{{.Name}}Iterator) *{{.name}}FinalizerIterator {
+	itr := &{{.name}}FinalizerIterator{inner}
+	runtime.SetFinalizer(itr, (*{{.name}}FinalizerIterator).Close)
+	return itr
+}
+
+func (itr *{{.name}}FinalizerIterator) Close() error {
+	runtime.SetFinalizer(itr, nil)
+	return itr.{{.Name}}Iterator.Close()
+}
 
 type {{.name}}Iterator struct {
 	cur   {{.name}}Cursor

--- a/tsdb/engine/tsm1/iterator.go
+++ b/tsdb/engine/tsm1/iterator.go
@@ -149,9 +149,10 @@ func (c cursorsAt) close() {
 	}
 }
 
-// newMergeGuardIterator creates a new Merge iterator from the inputs. If Merge returns an error,
-// the inputs will be closed
-func newMergeGuardIterator(inputs []query.Iterator, opt query.IteratorOptions) (query.Iterator, error) {
+// newMergeFinalizerIterator creates a new Merge iterator from the inputs. If the call to Merge succeeds,
+// the resulting Iterator will be wrapped in a finalizer iterator.
+// If Merge returns an error, the inputs will be closed.
+func newMergeFinalizerIterator(inputs []query.Iterator, opt query.IteratorOptions) (query.Iterator, error) {
 	itr, err := query.Iterators(inputs).Merge(opt)
 	if err != nil {
 		query.Iterators(inputs).Close()

--- a/tsdb/engine/tsm1/iterator.go
+++ b/tsdb/engine/tsm1/iterator.go
@@ -148,3 +148,39 @@ func (c cursorsAt) close() {
 		cur.close()
 	}
 }
+
+// newMergeGuardIterator creates a new Merge iterator from the inputs. If Merge returns an error,
+// the inputs will be closed
+func newMergeGuardIterator(inputs []query.Iterator, opt query.IteratorOptions) (query.Iterator, error) {
+	itr, err := query.Iterators(inputs).Merge(opt)
+	if err != nil {
+		query.Iterators(inputs).Close()
+		return nil, err
+	}
+	return newFinalizerIterator(itr), nil
+}
+
+// newFinalizerIterator creates a new iterator that installs a runtime finalizer
+// to ensure close is eventually called if the iterator is garbage collected.
+// This additional guard attempts to protect against clients of CreateIterator not
+// correctly closing them and leaking cursors.
+func newFinalizerIterator(itr query.Iterator) query.Iterator {
+	if itr == nil {
+		return nil
+	}
+
+	switch inner := itr.(type) {
+	case query.FloatIterator:
+		return newFloatFinalizerIterator(inner)
+	case query.IntegerIterator:
+		return newIntegerFinalizerIterator(inner)
+	case query.UnsignedIterator:
+		return newUnsignedFinalizerIterator(inner)
+	case query.StringIterator:
+		return newStringFinalizerIterator(inner)
+	case query.BooleanIterator:
+		return newBooleanFinalizerIterator(inner)
+	default:
+		panic(fmt.Sprintf("unsupported finalizer iterator type: %T", itr))
+	}
+}


### PR DESCRIPTION
`newMergeGuardIterator` ensures `inputs` are closed if `Merge` returns error and wraps the returned merge iterator in `<type>FinalizerIterator`

* <type>FinalizerIterator sets a runtime finalizer and calls `Close`
  when garbage collected. This will ensure any associated cursors
  are closed and ref counts on related TSM files released
* `query.Iterators#Merge` call could return an error and the inputs
  would not be closed, causing a cursor leak, hence the `newMergeGuardIterator`

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated