### PR TITLE
Batch writes for monitor service (1.3 backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - [#8706](https://github.com/influxdata/influxdb/pull/8706): Cursor leak, resulting in an accumulation of `.tsm.tmp` files after compactions.
 - [#8713](https://github.com/influxdata/influxdb/issues/8713): Deadlock when dropping measurement and writing
 
+### Features
+
+- [#8711](https://github.com/influxdata/influxdb/pull/8711): Batch up writes for monitor service
+
 ## v1.3.3 [2017-08-10]
 
 ### Bugfixes

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -424,17 +424,26 @@ func (m *Monitor) storeStatistics() {
 				return
 			}
 
-			points := make(models.Points, 0, len(stats))
+			// Write all stats in batches
+			batch := make(models.Points, 0, 5000)
 			for _, s := range stats {
 				pt, err := models.NewPoint(s.Name, models.NewTags(s.Tags), s.Values, now)
 				if err != nil {
 					m.Logger.Info(fmt.Sprintf("Dropping point %v: %v", s.Name, err))
 					return
 				}
-				points = append(points, pt)
+				batch = append(batch, pt)
+				if len(batch) == cap(batch) {
+					m.writePoints(batch)
+					batch = batch[:0]
+
+				}
 			}
 
-			m.writePoints(points)
+			// Write the last batch
+			if len(batch) > 0 {
+				m.writePoints(batch)
+			}
 		case <-m.done:
 			m.Logger.Info(fmt.Sprintf("terminating storage of statistics"))
 			return


### PR DESCRIPTION
This is a backport of #8711, I also had to bring in the `writePoints` method that was extracted out in the monitor service of a much larger change.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated