### PR TITLE
Fix leaking tmp file when large compaction aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 - [#8701](https://github.com/influxdata/influxdb/pull/8701): Fix drop measurement not dropping all data
 - [#8713](https://github.com/influxdata/influxdb/issues/8713): Deadlock when dropping measurement and writing
+- [#8726](https://github.com/influxdata/influxdb/pull/8726): Fix leaking tmp file when large compaction aborted
 
 ## v1.3.3 [unreleased]
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -866,6 +866,12 @@ func (c *Compactor) writeNewFiles(generation, sequence int, iter KeyIterator) ([
 			// planner keeps track of which files are assigned to compaction plans now.
 			return nil, err
 		} else if err != nil {
+			// Remove any tmp files we already completed
+			for _, f := range files {
+				if err := os.RemoveAll(f); err != nil {
+					return nil, err
+				}
+			}
 			// We hit an error and didn't finish the compaction.  Remove the temp file and abort.
 			if err := os.RemoveAll(fileName); err != nil {
 				return nil, err


### PR DESCRIPTION
If a large compaction was running and was aborted, it would leave
some tmp files around for files that it had fully written.  The current
active file was cleaned up, but already completed ones would not.  This
would occur when a TSM file needed to rollover due to size.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
