### PR TITLE
Replace BurntSushi library with fork on Apache license.

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,5 @@
 collectd.org e84e8af5356e7f47485bbc95c96da6dd7984a67e
-github.com/BurntSushi/toml 99064174e013895bbd9b025c31100bd1d9b590ca
+github.com/chanezon/toml a5e42e4db96f9fa382bb0e635069381bc34f3134
 github.com/bmizerany/pat c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c
 github.com/boltdb/bolt 4b1ebc1869ad66568b313d0dc410e2be72670dda
 github.com/cespare/xxhash 1b6d2e40c16ba0dfce5c8eac2480ad6e7394819b

--- a/LICENSE_OF_DEPENDENCIES.md
+++ b/LICENSE_OF_DEPENDENCIES.md
@@ -1,7 +1,7 @@
 # List
 - bootstrap 3.3.5 [MIT LICENSE](https://github.com/twbs/bootstrap/blob/master/LICENSE)
 - collectd.org [ISC LICENSE](https://github.com/collectd/go-collectd/blob/master/LICENSE)
-- github.com/BurntSushi/toml [WTFPL LICENSE](https://github.com/BurntSushi/toml/blob/master/COPYING)
+- github.com/chanezon/toml [APACHE LICENSE](https://github.com/chanezon/toml/blob/master/LICENSE.code)
 - github.com/bmizerany/pat [MIT LICENSE](https://github.com/bmizerany/pat#license)
 - github.com/boltdb/bolt [MIT LICENSE](https://github.com/boltdb/bolt/blob/master/LICENSE)
 - github.com/cespare/xxhash [MIT LICENSE](https://github.com/cespare/xxhash/blob/master/LICENSE.txt)

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/coordinator"
 	"github.com/influxdata/influxdb/monitor"
 	"github.com/influxdata/influxdb/monitor/diagnostics"

--- a/cmd/influxd/run/config_command.go
+++ b/cmd/influxd/run/config_command.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 )
 
 // PrintConfigCommand represents the command executed by "influxd config".

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/cmd/influxd/run"
 )
 

--- a/coordinator/config_test.go
+++ b/coordinator/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/coordinator"
 )
 

--- a/monitor/config_test.go
+++ b/monitor/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/monitor"
 )
 

--- a/services/collectd/config_test.go
+++ b/services/collectd/config_test.go
@@ -3,7 +3,7 @@ package collectd_test
 import (
 	"testing"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/collectd"
 )
 

--- a/services/continuous_querier/config_test.go
+++ b/services/continuous_querier/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/continuous_querier"
 )
 

--- a/services/graphite/config_test.go
+++ b/services/graphite/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/graphite"
 )
 

--- a/services/httpd/config_test.go
+++ b/services/httpd/config_test.go
@@ -3,7 +3,7 @@ package httpd_test
 import (
 	"testing"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/httpd"
 )
 

--- a/services/meta/config_test.go
+++ b/services/meta/config_test.go
@@ -3,7 +3,7 @@ package meta_test
 import (
 	"testing"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/meta"
 )
 

--- a/services/opentsdb/config_test.go
+++ b/services/opentsdb/config_test.go
@@ -3,7 +3,7 @@ package opentsdb_test
 import (
 	"testing"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/opentsdb"
 )
 

--- a/services/precreator/config_test.go
+++ b/services/precreator/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/precreator"
 )
 

--- a/services/retention/config_test.go
+++ b/services/retention/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/retention"
 )
 

--- a/services/subscriber/config_test.go
+++ b/services/subscriber/config_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/subscriber"
 )
 

--- a/services/udp/config_test.go
+++ b/services/udp/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/services/udp"
 )
 

--- a/stress/config.go
+++ b/stress/config.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 )
 
 // Config is a struct for the Stress test configuration

--- a/toml/toml_test.go
+++ b/toml/toml_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/cmd/influxd/run"
 	itoml "github.com/influxdata/influxdb/toml"
 )

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/chanezon/toml"
 	"github.com/influxdata/influxdb/tsdb"
 )
 


### PR DESCRIPTION
The BurnSushi toml library is licensed with WTFPL, which some users have issues with. This replaces it with a fork that has been relicensed under Apache2.

Fixes #8668 