### PR TITLE
Prepare for Go 1.9 math/bits package.

### DIFF
--- a/pkg/bits/bits.go
+++ b/pkg/bits/bits.go
@@ -1,0 +1,19 @@
+// +build !go1.9
+
+package bits
+
+import (
+	"github.com/dgryski/go-bits"
+)
+
+// LeadingZeros64 counts leading zeroes.
+var LeadingZeros64 = bits.Clz
+
+// TrailingZeros64 counts trailing zeroes.
+var TrailingZeros64 = bits.Ctz
+
+// LeadingZeros32 uses a 64-bit clz implementation and
+// reduces the result by 32, to get a clz for a word.
+func LeadingZeros32(x uint32) uint64 {
+	return bits.Clz(uint64(x)) - 32
+}

--- a/pkg/bits/bits_1.9.go
+++ b/pkg/bits/bits_1.9.go
@@ -1,0 +1,25 @@
+// +build go1.9
+
+package bits
+
+import (
+	"math/bits"
+)
+
+// LeadingZeros64 returns the number of leading zero bits in x; the result is
+// 64 for x == 0.
+func LeadingZeros64(x uint64) uint64 {
+	return uint64(bits.LeadingZeros64(x))
+}
+
+// LeadingZeros32 returns the number of leading zero bits in x; the result is
+// 32 for x == 0.
+func LeadingZeros32(x uint32) uint64 {
+	return uint64(bits.LeadingZeros32(x))
+}
+
+// TrailingZeros64 returns the number of trailing zero bits in x; the result is
+// 64 for x == 0.
+func TrailingZeros64(x uint64) uint64 {
+	return uint64(bits.TrailingZeros64(x))
+}

--- a/tsdb/engine/tsm1/float.go
+++ b/tsdb/engine/tsm1/float.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/dgryski/go-bits"
 	"github.com/dgryski/go-bitstream"
+	"github.com/influxdata/influxdb/pkg/bits"
 )
 
 const (
@@ -110,8 +110,8 @@ func (s *FloatEncoder) Write(v float64) {
 	} else {
 		s.bw.WriteBit(bitstream.One)
 
-		leading := bits.Clz(vDelta)
-		trailing := bits.Ctz(vDelta)
+		leading := uint64(bits.LeadingZeros64(vDelta))
+		trailing := uint64(bits.TrailingZeros64(vDelta))
 
 		// Clamp number of leading zeros to avoid overflow when encoding
 		leading &= 0x1F


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

**Note** Should not be merged until we decide to move to Go 1.9.

This PR replaces the `github.com/dgryksi/go-bits` dependency with the standard library `math/bits` package.