### PR TITLE
Close the query shard group after the iterators are created

### DIFF
--- a/coordinator/shard_mapper.go
+++ b/coordinator/shard_mapper.go
@@ -181,8 +181,9 @@ func (a *LocalShardMapping) CreateIterator(m *influxql.Measurement, opt query.It
 	return sg.CreateIterator(m.Name, opt)
 }
 
-// Close does nothing for a LocalShardMapping.
+// Close clears out the list of mapped shards.
 func (a *LocalShardMapping) Close() error {
+	a.ShardMap = nil
 	return nil
 }
 


### PR DESCRIPTION
Now, the prepared statement keeps the open resource and closing the open
resource created from `Prepare` is the responsibility of the prepared
statement.

This also nils out the local shard mapping after it is closed to prevent
it from being used after it is closed.

- [x] Rebased/mergable
- [x] Tests pass