### PR TITLE
Force subqueries to match the parent queries ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [#8712](https://github.com/influxdata/influxdb/pull/8712): Force time expressions to use AND and improve condition parsing.
 - [#8716](https://github.com/influxdata/influxdb/pull/8716): Ensure inputs are closed on error. Add runtime GC finalizer as additional guard to close iterators
 - [#8695](https://github.com/influxdata/influxdb/issues/8695): Fix merging bug on system iterators.
+- [#8699](https://github.com/influxdata/influxdb/issues/8699): Force subqueries to match the parent queries ordering.
 
 ## v1.3.4 [unreleased]
 

--- a/query/compile_test.go
+++ b/query/compile_test.go
@@ -79,6 +79,7 @@ func TestCompile_Success(t *testing.T) {
 		`SELECT max(derivative) FROM (SELECT derivative(mean(value)) FROM cpu) WHERE time >= now() - 1m GROUP BY time(10s)`,
 		`SELECT max(value) FROM (SELECT value + total FROM cpu) WHERE time >= now() - 1m GROUP BY time(10s)`,
 		`SELECT value FROM cpu WHERE time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T01:00:00Z'`,
+		`SELECT value FROM (SELECT value FROM cpu) ORDER BY time DESC`,
 	} {
 		t.Run(tt, func(t *testing.T) {
 			stmt, err := influxql.ParseStatement(tt)
@@ -319,6 +320,7 @@ func TestCompile_Failures(t *testing.T) {
 		{s: `SELECT min(mean) FROM (SELECT mean(value) FROM myseries GROUP BY time)`, err: `time() is a function and expects at least one argument`},
 		{s: `SELECT value FROM myseries WHERE value OR time >= now() - 1m`, err: `invalid condition expression: value`},
 		{s: `SELECT value FROM myseries WHERE time >= now() - 1m OR value`, err: `invalid condition expression: value`},
+		{s: `SELECT value FROM (SELECT value FROM cpu ORDER BY time DESC) ORDER BY time ASC`, err: `subqueries must be ordered in the same direction as the query itself`},
 	} {
 		t.Run(tt.s, func(t *testing.T) {
 			stmt, err := influxql.ParseStatement(tt.s)

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -776,6 +776,9 @@ func newIteratorOptionsSubstatement(stmt *influxql.SelectStatement, opt Iterator
 	subOpt.SLimit += opt.SLimit
 	subOpt.SOffset += opt.SOffset
 
+	// Propagate the ordering from the parent query.
+	subOpt.Ascending = opt.Ascending
+
 	// If the inner query uses a null fill option, switch it to none so we
 	// don't hit an unnecessary penalty from the fill iterator. Null values
 	// will end up getting stripped by an outer query anyway so there's no


### PR DESCRIPTION
Previously, subqueries would honor their own ordering. We never really
supported that and I have no idea if it would work since most parts in
the query engine assume that points are being delivered in only one
ordering.

Subqueries have now been modified so if a person tries to do different
ordering, they get an error when running the query. If they specify an
ordering in the top most query, that ordering gets propagated to all
subqueries.

Fixes #8699.

- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated