### PR TITLE
fix #8638: inspect shouldn't err on missing file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#8699](https://github.com/influxdata/influxdb/issues/8699): Force subqueries to match the parent queries ordering.
 - [#8755](https://github.com/influxdata/influxdb/pull/8755): Fix race condition accessing `seriesByID` map.
 - [#8766](https://github.com/influxdata/influxdb/pull/8766): Fix deadlock when calling `SeriesIDsAllOrByExpr`
+- [#8638](https://github.com/influxdata/influxdb/issues/8638): Fix `influx_inspect export` so it skips missing files.
 
 ## v1.3.4 [unreleased]
 

--- a/cmd/influx_inspect/export/export.go
+++ b/cmd/influx_inspect/export/export.go
@@ -261,6 +261,10 @@ func (cmd *Command) writeTsmFiles(w io.Writer, files []string) error {
 func (cmd *Command) exportTSMFile(tsmFilePath string, w io.Writer) error {
 	f, err := os.Open(tsmFilePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(w, "skipped missing file: %s", tsmFilePath)
+			return nil
+		}
 		return err
 	}
 	defer f.Close()
@@ -325,6 +329,10 @@ or manually editing the exported file.
 func (cmd *Command) exportWALFile(walFilePath string, w io.Writer, warnDelete func()) error {
 	f, err := os.Open(walFilePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Fprintf(w, "skipped missing file: %s", walFilePath)
+			return nil
+		}
 		return err
 	}
 	defer f.Close()

--- a/cmd/influx_inspect/export/export_test.go
+++ b/cmd/influx_inspect/export/export_test.go
@@ -95,6 +95,12 @@ func Test_exportWALFile(t *testing.T) {
 			}
 		}
 	}
+
+	// Missing .wal file should not cause a failure.
+	var out bytes.Buffer
+	if err := newCommand().exportWALFile("file-that-does-not-exist.wal", &out, func() {}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func Test_exportTSMFile(t *testing.T) {
@@ -127,6 +133,12 @@ func Test_exportTSMFile(t *testing.T) {
 				t.Fatalf("expected line %q to be in exported output:\n%s", exp, out.String())
 			}
 		}
+	}
+
+	// Missing .tsm file should not cause a failure.
+	var out bytes.Buffer
+	if err := newCommand().exportTSMFile("file-that-does-not-exist.tsm", &out); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
`influx_inspect export` walks the data and wal directories building a list of
files to export. It then opens, reads, and exports each. If the file was
deleted between the time it was added to the list and the time the
inspect tool attempts to read it, the file is now skipped without
emitting an error.

- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated