### PR TITLE
Fix deadlock when calling `SeriesIDsAllOrByExpr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [#8695](https://github.com/influxdata/influxdb/issues/8695): Fix merging bug on system iterators.
 - [#8699](https://github.com/influxdata/influxdb/issues/8699): Force subqueries to match the parent queries ordering.
 - [#8755](https://github.com/influxdata/influxdb/pull/8755): Fix race condition accessing `seriesByID` map.
+- [#8766](https://github.com/influxdata/influxdb/pull/8766): Fix deadlock when calling `SeriesIDsAllOrByExpr`
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -850,9 +850,9 @@ func (m *Measurement) SeriesIDsAllOrByExpr(expr influxql.Expr) (SeriesIDs, error
 	}
 
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if len(m.seriesByID) == 0 {
+	l := len(m.seriesByID)
+	m.mu.RUnlock()
+	if l == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
* `WalkWhereForSeriesIDs` may call `SeriesIDs`, which may attempt to
  upgrade from a `RLock` to a `Lock`, causing the deadlock

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
