### PR TITLE
Fix deadlock when calling `SeriesIDsAllOrByExpr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 
 - [#8755](https://github.com/influxdata/influxdb/pull/8755): Fix race condition accessing `seriesByID` map.
+- [#8766](https://github.com/influxdata/influxdb/pull/8766): Fix deadlock when calling `SeriesIDsAllOrByExpr`
 
 ## v1.3.4 [2017-08-23]
 

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -854,9 +854,9 @@ func (m *Measurement) SeriesIDsAllOrByExpr(expr influxql.Expr) (SeriesIDs, error
 	}
 
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if len(m.seriesByID) == 0 {
+	l := len(m.seriesByID)
+	m.mu.RUnlock()
+	if l == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
