### PR TITLE
cleanup: remove poor usage of ',ok' with maps

### DIFF
--- a/cmd/influx_inspect/report/report.go
+++ b/cmd/influx_inspect/report/report.go
@@ -104,23 +104,23 @@ func (cmd *Command) Run(args ...string) error {
 				seriesKey, field := key[:sep], key[sep+4:]
 				measurement, tags := models.ParseKey(seriesKey)
 
-				measCount, ok := measCardinalities[measurement]
-				if !ok {
+				measCount := measCardinalities[measurement]
+				if measCount == nil {
 					measCount = hllpp.New()
 					measCardinalities[measurement] = measCount
 				}
 				measCount.Add([]byte(key))
 
-				fieldCount, ok := fieldCardinalities[measurement]
-				if !ok {
+				fieldCount := fieldCardinalities[measurement]
+				if fieldCount == nil {
 					fieldCount = hllpp.New()
 					fieldCardinalities[measurement] = fieldCount
 				}
 				fieldCount.Add([]byte(field))
 
 				for _, t := range tags {
-					tagCount, ok := tagCardinalities[string(t.Key)]
-					if !ok {
+					tagCount := tagCardinalities[string(t.Key)]
+					if tagCount == nil {
 						tagCount = hllpp.New()
 						tagCardinalities[string(t.Key)] = tagCount
 					}

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -1141,9 +1141,7 @@ func (s *SelectStatement) RewriteFields(m FieldMapper) (*SelectStatement, error)
 		for _, d := range other.Dimensions {
 			switch expr := d.Expr.(type) {
 			case *VarRef:
-				if _, ok := dimensionSet[expr.Val]; ok {
-					delete(dimensionSet, expr.Val)
-				}
+				delete(dimensionSet, expr.Val)
 			}
 		}
 	}

--- a/influxql/parse_tree.go
+++ b/influxql/parse_tree.go
@@ -21,7 +21,7 @@ func (t *ParseTree) With(fn func(*ParseTree)) {
 func (t *ParseTree) Group(tokens ...Token) *ParseTree {
 	for _, tok := range tokens {
 		// Look for the parse tree for this token.
-		if subtree, ok := t.Tokens[tok]; ok {
+		if subtree := t.Tokens[tok]; subtree != nil {
 			t = subtree
 			continue
 		}
@@ -67,12 +67,12 @@ func (t *ParseTree) Handle(tok Token, fn func(*Parser) (Statement, error)) {
 func (t *ParseTree) Parse(p *Parser) (Statement, error) {
 	for {
 		tok, pos, lit := p.ScanIgnoreWhitespace()
-		if subtree, ok := t.Tokens[tok]; ok {
+		if subtree := t.Tokens[tok]; subtree != nil {
 			t = subtree
 			continue
 		}
 
-		if stmt, ok := t.Handlers[tok]; ok {
+		if stmt := t.Handlers[tok]; stmt != nil {
 			return stmt(p)
 		}
 

--- a/influxql/parser.go
+++ b/influxql/parser.go
@@ -2638,8 +2638,8 @@ func (p *Parser) parseUnaryExpr() (Expr, error) {
 			return nil, errors.New("empty bound parameter")
 		}
 
-		v, ok := p.params[k]
-		if !ok {
+		v := p.params[k]
+		if v == nil {
 			return nil, fmt.Errorf("missing parameter: %s", k)
 		}
 

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -198,9 +198,7 @@ func (s *Service) Run(database, name string, t time.Time) error {
 			if name == "" || cq.Name == name {
 				// Remove the last run time for the CQ
 				id := fmt.Sprintf("%s%s%s", db.Name, idDelimiter, cq.Name)
-				if _, ok := s.lastRuns[id]; ok {
-					delete(s.lastRuns, id)
-				}
+				delete(s.lastRuns, id)
 			}
 		}
 	}

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -779,7 +779,7 @@ func (h *Handler) serveExpvar(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
 	first := true
-	if val, ok := diags["system"]; ok {
+	if val := diags["system"]; val != nil {
 		jv, err := parseSystemDiagnostics(val)
 		if err != nil {
 			h.httpError(w, err.Error(), http.StatusInternalServerError)

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -575,7 +575,7 @@ func TestHandler_Version(t *testing.T) {
 	for _, test := range tests {
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, MustNewRequest(test.method, test.endpoint, test.body))
-		if v, ok := w.HeaderMap["X-Influxdb-Version"]; ok {
+		if v := w.HeaderMap["X-Influxdb-Version"]; len(v) > 0 {
 			if v[0] != "0.0.0" {
 				t.Fatalf("unexpected version: %s", v)
 			}
@@ -583,7 +583,7 @@ func TestHandler_Version(t *testing.T) {
 			t.Fatalf("Header entry 'X-Influxdb-Version' not present")
 		}
 
-		if v, ok := w.HeaderMap["X-Influxdb-Build"]; ok {
+		if v := w.HeaderMap["X-Influxdb-Build"]; len(v) > 0 {
 			if v[0] != "OSS" {
 				t.Fatalf("unexpected BuildType: %s", v)
 			}

--- a/services/httpd/requests.go
+++ b/services/httpd/requests.go
@@ -47,16 +47,16 @@ func (p *RequestProfile) AddQuery(info RequestInfo) {
 func (p *RequestProfile) add(info RequestInfo, fn func(*RequestStats)) {
 	// Look for a request entry for this request.
 	p.mu.RLock()
-	st, ok := p.Requests[info]
+	st := p.Requests[info]
 	p.mu.RUnlock()
-	if ok {
+	if st != nil {
 		fn(st)
 		return
 	}
 
 	// There is no entry in the request tracker. Create one.
 	p.mu.Lock()
-	if st, ok := p.Requests[info]; ok {
+	if st := p.Requests[info]; st != nil {
 		// Something else created this entry while we were waiting for the lock.
 		p.mu.Unlock()
 		fn(st)

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1557,8 +1557,8 @@ func (leases *Leases) Acquire(name string, nodeID uint64) (*Lease, error) {
 	leases.mu.Lock()
 	defer leases.mu.Unlock()
 
-	l, ok := leases.m[name]
-	if ok {
+	l := leases.m[name]
+	if l != nil {
 		if time.Now().After(l.Expiration) || l.Owner == nodeID {
 			l.Expiration = time.Now().Add(leases.d)
 			l.Owner = nodeID

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -788,7 +788,7 @@ func mustMarshalEntry(entry WALEntry) (WalEntryType, []byte) {
 // TestStore implements the storer interface and can be used to mock out a
 // Cache's storer implememation.
 type TestStore struct {
-	entryf       func(key []byte) (*entry, bool)
+	entryf       func(key []byte) *entry
 	writef       func(key []byte, values Values) error
 	addf         func(key []byte, entry *entry)
 	removef      func(key []byte)
@@ -799,7 +799,7 @@ type TestStore struct {
 }
 
 func NewTestStore() *TestStore                                      { return &TestStore{} }
-func (s *TestStore) entry(key []byte) (*entry, bool)                { return s.entryf(key) }
+func (s *TestStore) entry(key []byte) *entry                        { return s.entryf(key) }
 func (s *TestStore) write(key []byte, values Values) error          { return s.writef(key, values) }
 func (s *TestStore) add(key []byte, entry *entry)                   { s.addf(key, entry) }
 func (s *TestStore) remove(key []byte)                              { s.removef(key) }

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -767,7 +767,7 @@ func (i *Index) assignExistingSeries(shardID uint64, keys, names [][]byte, tagsS
 	i.mu.RLock()
 	var n int
 	for j, key := range keys {
-		if ss, ok := i.series[string(key)]; !ok {
+		if ss := i.series[string(key)]; ss == nil {
 			keys[n] = keys[j]
 			names[n] = names[j]
 			tagsSlice[n] = tagsSlice[j]


### PR DESCRIPTION
There are several places in the code where comma-ok map retrieval was
being used poorly. Some were benign, like checking existence before
issuing an unconditional delete with no cleanup. Others were potentially
far more serious: assuming that if 'ok' was true, then the resulting
pointer retrieved from the map would be non-nil. `nil` is a perfectly
valid value to store in a map of pointers, and the comma-ok syntax is
meant for when membership is distinct from having a non-zero value.
There was only one or two cases that I saw that being used correctly for
maps of pointers.

This PR was inspired by an actual bug caused by poor usage: https://github.com/influxdata/influxdb/pull/8755

`ok` was true, but the pointer returned was `nil`, causing the server to panic.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated