### PR TITLE
This restores the old time range behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - [#8694](https://github.com/influxdata/influxdb/issues/8694): Reduce CPU usage when checking series cardinality
 - [#8677](https://github.com/influxdata/influxdb/issues/8677): Fix backups when snapshot is empty.
 - [#8706](https://github.com/influxdata/influxdb/pull/8706): Cursor leak, resulting in an accumulation of `.tsm.tmp` files after compactions.
-- [#8712](https://github.com/influxdata/influxdb/pull/8712): Force time expressions to use AND and improve condition parsing.
+- [#8712](https://github.com/influxdata/influxdb/pull/8712): Improve condition parsing.
 - [#8716](https://github.com/influxdata/influxdb/pull/8716): Ensure inputs are closed on error. Add runtime GC finalizer as additional guard to close iterators
 - [#8695](https://github.com/influxdata/influxdb/issues/8695): Fix merging bug on system iterators.
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -4828,11 +4828,8 @@ func ConditionExpr(cond Expr, valuer Valuer) (Expr, TimeRange, error) {
 				return nil, TimeRange{}, err
 			}
 
-			// If either of the two expressions has a time range and we are combining
-			// them with OR, return an error since this isn't allowed.
-			if cond.Op == OR && !(lhsTime.IsZero() && rhsTime.IsZero()) {
-				return nil, TimeRange{}, errors.New("cannot use OR with time conditions")
-			}
+			// Always intersect the time range even if it makes no sense.
+			// There is no such thing as using OR with a time range.
 			timeRange := lhsTime.Intersect(rhsTime)
 
 			// Combine the left and right expression.

--- a/query/compile_test.go
+++ b/query/compile_test.go
@@ -145,7 +145,8 @@ func TestCompile_Failures(t *testing.T) {
 		{s: `SELECT bottom(value, 2.5) FROM cpu`, err: `expected integer as last argument in bottom(), found 2.500`},
 		{s: `SELECT bottom(value, -1) FROM cpu`, err: `limit (-1) in bottom function must be at least 1`},
 		{s: `SELECT bottom(value, 3) FROM cpu LIMIT 2`, err: `limit (3) in bottom function can not be larger than the LIMIT (2) in the select statement`},
-		{s: `SELECT value FROM cpu WHERE time >= now() - 10m OR time < now() - 5m`, err: `cannot use OR with time conditions`},
+		// TODO(jsternberg): This query is wrong, but we cannot enforce this because of previous behavior: https://github.com/influxdata/influxdb/pull/8771
+		//{s: `SELECT value FROM cpu WHERE time >= now() - 10m OR time < now() - 5m`, err: `cannot use OR with time conditions`},
 		{s: `SELECT value FROM cpu WHERE value`, err: `invalid condition expression: value`},
 		{s: `SELECT count(value), * FROM cpu`, err: `mixing aggregate and non-aggregate queries is not supported`},
 		{s: `SELECT max(*), host FROM cpu`, err: `mixing aggregate and non-aggregate queries is not supported`},


### PR DESCRIPTION
All time ranges are combined with AND regardless of context and
regardless of whether it makes any logical sense.

That was the previous behavior and, unfortunately, a lot of people rely
on it.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

This change modifies the changelog for #8712.