### PR TITLE
Reduce how long it takes to walk the varrefs in an expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.3.6 [unreleased]
+
+### Bugfixes
+
+- [#8770](https://github.com/influxdata/influxdb/pull/8770): Reduce how long it takes to walk the varrefs in an expression.
+
 ## v1.3.5 [2017-08-29]
 
 ### Bugfixes

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2457,29 +2457,33 @@ func walkNames(exp Expr) []string {
 
 // walkRefs will walk the Expr and return the var refs used.
 func walkRefs(exp Expr) []VarRef {
-	switch expr := exp.(type) {
-	case *VarRef:
-		return []VarRef{*expr}
-	case *Call:
-		a := make([]VarRef, 0, len(expr.Args))
-		for _, expr := range expr.Args {
-			if ref, ok := expr.(*VarRef); ok {
-				a = append(a, *ref)
+	refs := make(map[VarRef]struct{})
+	var walk func(exp Expr)
+	walk = func(exp Expr) {
+		switch expr := exp.(type) {
+		case *VarRef:
+			refs[*expr] = struct{}{}
+		case *Call:
+			for _, expr := range expr.Args {
+				if ref, ok := expr.(*VarRef); ok {
+					refs[*ref] = struct{}{}
+				}
 			}
+		case *BinaryExpr:
+			walk(expr.LHS)
+			walk(expr.RHS)
+		case *ParenExpr:
+			walk(expr.Expr)
 		}
-		return a
-	case *BinaryExpr:
-		lhs := walkRefs(expr.LHS)
-		rhs := walkRefs(expr.RHS)
-		ret := make([]VarRef, 0, len(lhs)+len(rhs))
-		ret = append(ret, lhs...)
-		ret = append(ret, rhs...)
-		return ret
-	case *ParenExpr:
-		return walkRefs(expr.Expr)
 	}
+	walk(exp)
 
-	return nil
+	// Turn the map into a slice.
+	a := make([]VarRef, 0, len(refs))
+	for ref := range refs {
+		a = append(a, ref)
+	}
+	return a
 }
 
 // ExprNames returns a list of non-"time" field names from an expression.

--- a/influxql/ast_test.go
+++ b/influxql/ast_test.go
@@ -1840,3 +1840,22 @@ func mustParseTime(s string) time.Time {
 	}
 	return t
 }
+
+// BenchmarkExprNames benchmarks how long it takes to run ExprNames.
+func BenchmarkExprNames(b *testing.B) {
+	exprs := make([]string, 100)
+	for i := range exprs {
+		exprs[i] = fmt.Sprintf("host = 'server%02d'", i)
+	}
+	condition := MustParseExpr(strings.Join(exprs, " OR "))
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		refs := influxql.ExprNames(condition)
+		if have, want := refs, []influxql.VarRef{{Val: "host"}}; !reflect.DeepEqual(have, want) {
+			b.Fatalf("unexpected expression names: have=%s want=%s", have, want)
+		}
+	}
+}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1795,20 +1795,15 @@ func (e *Engine) createTagSetIterators(ref *influxql.VarRef, name string, t *inf
 
 // createTagSetGroupIterators creates a set of iterators for a subset of a tagset's series.
 func (e *Engine) createTagSetGroupIterators(ref *influxql.VarRef, name string, seriesKeys []string, t *influxql.TagSet, filters []influxql.Expr, opt influxql.IteratorOptions) ([]influxql.Iterator, error) {
-	conditionFields := make([]influxql.VarRef, len(influxql.ExprNames(opt.Condition)))
-
 	itrs := make([]influxql.Iterator, 0, len(seriesKeys))
 	for i, seriesKey := range seriesKeys {
-		fields := 0
+		var conditionFields []influxql.VarRef
 		if filters[i] != nil {
 			// Retrieve non-time fields from this series filter and filter out tags.
-			for _, f := range influxql.ExprNames(filters[i]) {
-				conditionFields[fields] = f
-				fields++
-			}
+			conditionFields = influxql.ExprNames(filters[i])
 		}
 
-		itr, err := e.createVarRefSeriesIterator(ref, name, seriesKey, t, filters[i], conditionFields[:fields], opt)
+		itr, err := e.createVarRefSeriesIterator(ref, name, seriesKey, t, filters[i], conditionFields, opt)
 		if err != nil {
 			return itrs, err
 		} else if itr == nil {


### PR DESCRIPTION
This is used quite a bit to determine which fields are needed in a
condition. When the condition gets large, the memory usage begins to
slow it down considerably and it doesn't take care of duplicates.

Backport of #8770.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated