### PR TITLE
Initial implementation of explain plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#8572](https://github.com/influxdata/influxdb/issues/8668): InfluxDB now uses MIT licensed version of BurntSushi/toml.
 - [#8752](https://github.com/influxdata/influxdb/pull/8752): Use system cursors for measurement, series, and tag key meta queries.
 - [#6563](https://github.com/influxdata/influxdb/issues/6563): Support Ctrl+C to cancel a running query in the Influx CLI. Thanks @emluque!
+- [#8776](https://github.com/influxdata/influxdb/pull/8776): Initial implementation of explain plan.
 
 ### Bugfixes
 

--- a/coordinator/statement_executor_test.go
+++ b/coordinator/statement_executor_test.go
@@ -385,6 +385,7 @@ type MockShard struct {
 	Measurements      []string
 	FieldDimensionsFn func(measurements []string) (fields map[string]influxql.DataType, dimensions map[string]struct{}, err error)
 	CreateIteratorFn  func(m string, opt query.IteratorOptions) (query.Iterator, error)
+	IteratorCostFn    func(m string, opt query.IteratorOptions) (query.IteratorCost, error)
 	ExpandSourcesFn   func(sources influxql.Sources) (influxql.Sources, error)
 }
 
@@ -418,6 +419,10 @@ func (sh *MockShard) MapType(measurement, field string) influxql.DataType {
 
 func (sh *MockShard) CreateIterator(measurement string, opt query.IteratorOptions) (query.Iterator, error) {
 	return sh.CreateIteratorFn(measurement, opt)
+}
+
+func (sh *MockShard) IteratorCost(measurement string, opt query.IteratorOptions) (query.IteratorCost, error) {
+	return sh.IteratorCostFn(measurement, opt)
 }
 
 func (sh *MockShard) ExpandSources(sources influxql.Sources) (influxql.Sources, error) {

--- a/query/explain.go
+++ b/query/explain.go
@@ -1,0 +1,84 @@
+package query
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/influxdata/influxdb/influxql"
+)
+
+func (p *preparedStatement) Explain() (string, error) {
+	// Determine the cost of all iterators created as part of this plan.
+	ic := &explainIteratorCreator{ic: p.ic}
+	p.ic = ic
+	itrs, _, err := p.Select()
+	p.ic = ic.ic
+
+	if err != nil {
+		return "", err
+	}
+	Iterators(itrs).Close()
+
+	var buf bytes.Buffer
+	for i, node := range ic.nodes {
+		if i > 0 {
+			buf.WriteString("\n")
+		}
+
+		expr := "<nil>"
+		if node.Expr != nil {
+			expr = node.Expr.String()
+		}
+		fmt.Fprintf(&buf, "EXPRESSION: %s\n", expr)
+		if len(node.Aux) != 0 {
+			refs := make([]string, len(node.Aux))
+			for i, ref := range node.Aux {
+				refs[i] = ref.String()
+			}
+			fmt.Fprintf(&buf, "AUXILIARY FIELDS: %s\n", strings.Join(refs, ", "))
+		}
+		fmt.Fprintf(&buf, "NUMBER OF SHARDS: %d\n", node.Cost.NumShards)
+		fmt.Fprintf(&buf, "NUMBER OF SERIES: %d\n", node.Cost.NumSeries)
+		fmt.Fprintf(&buf, "NUMBER OF FILES: %d\n", node.Cost.NumFiles)
+		fmt.Fprintf(&buf, "NUMBER OF BLOCKS: %d\n", node.Cost.BlocksRead)
+		fmt.Fprintf(&buf, "SIZE OF BLOCKS: %d\n", node.Cost.BlockSize)
+	}
+	return buf.String(), nil
+}
+
+type planNode struct {
+	Expr influxql.Expr
+	Aux  []influxql.VarRef
+	Cost IteratorCost
+}
+
+type explainIteratorCreator struct {
+	ic interface {
+		IteratorCreator
+		io.Closer
+	}
+	nodes []planNode
+}
+
+func (e *explainIteratorCreator) CreateIterator(m *influxql.Measurement, opt IteratorOptions) (Iterator, error) {
+	cost, err := e.ic.IteratorCost(m, opt)
+	if err != nil {
+		return nil, err
+	}
+	e.nodes = append(e.nodes, planNode{
+		Expr: opt.Expr,
+		Aux:  opt.Aux,
+		Cost: cost,
+	})
+	return &nilFloatIterator{}, nil
+}
+
+func (e *explainIteratorCreator) IteratorCost(m *influxql.Measurement, opt IteratorOptions) (IteratorCost, error) {
+	return e.ic.IteratorCost(m, opt)
+}
+
+func (e *explainIteratorCreator) Close() error {
+	return e.ic.Close()
+}

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -625,6 +625,9 @@ func NewReaderIterator(r io.Reader, typ influxql.DataType, stats IteratorStats) 
 type IteratorCreator interface {
 	// Creates a simple iterator for use in an InfluxQL query.
 	CreateIterator(source *influxql.Measurement, opt IteratorOptions) (Iterator, error)
+
+	// Determines the potential cost for creating an iterator.
+	IteratorCost(source *influxql.Measurement, opt IteratorOptions) (IteratorCost, error)
 }
 
 // IteratorOptions is an object passed to CreateIterator to specify creation options.
@@ -1338,6 +1341,40 @@ func decodeIteratorStats(pb *internal.IteratorStats) IteratorStats {
 	return IteratorStats{
 		SeriesN: int(pb.GetSeriesN()),
 		PointN:  int(pb.GetPointN()),
+	}
+}
+
+// IteratorCost contains statistics retrieved for explaining what potential
+// cost may be incurred by instantiating an iterator.
+type IteratorCost struct {
+	// The total number of shards that are touched by this query.
+	NumShards int64
+
+	// The total number of non-unique series that are accessed by this query.
+	// This number matches the number of cursors created by the query since
+	// one cursor is created for every series.
+	NumSeries int64
+
+	// The total number of non-unique files that may be accessed by this query.
+	// This will count the number of files accessed by each series so files
+	// will likely be double counted.
+	NumFiles int64
+
+	// The number of blocks that had the potential to be accessed.
+	BlocksRead int64
+
+	// The amount of data that can be potentially read.
+	BlockSize int64
+}
+
+// Combine combines the results of two IteratorCost structures into one.
+func (c IteratorCost) Combine(other IteratorCost) IteratorCost {
+	return IteratorCost{
+		NumShards:  c.NumShards + other.NumShards,
+		NumSeries:  c.NumSeries + other.NumSeries,
+		NumFiles:   c.NumFiles + other.NumFiles,
+		BlocksRead: c.BlocksRead + other.BlocksRead,
+		BlockSize:  c.BlockSize + other.BlockSize,
 	}
 }
 

--- a/query/select.go
+++ b/query/select.go
@@ -56,6 +56,9 @@ type PreparedStatement interface {
 	// Select creates the Iterators that will be used to read the query.
 	Select() ([]Iterator, []string, error)
 
+	// Explain outputs the explain plan for this statement.
+	Explain() (string, error)
+
 	// Close closes the resources associated with this prepared statement.
 	// This must be called as the mapped shards may hold open resources such
 	// as network connections.

--- a/query/select_test.go
+++ b/query/select_test.go
@@ -2785,6 +2785,10 @@ func (sh *ShardGroup) CreateIterator(m *influxql.Measurement, opt query.Iterator
 	return sh.CreateIteratorFn(m, opt)
 }
 
+func (sh *ShardGroup) IteratorCost(m *influxql.Measurement, opt query.IteratorOptions) (query.IteratorCost, error) {
+	return query.IteratorCost{}, nil
+}
+
 func (sh *ShardGroup) FieldDimensions(m *influxql.Measurement) (fields map[string]influxql.DataType, dimensions map[string]struct{}, err error) {
 	fields = make(map[string]influxql.DataType)
 	dimensions = make(map[string]struct{})

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -44,6 +44,7 @@ type Engine interface {
 	Import(r io.Reader, basePath string) error
 
 	CreateIterator(measurement string, opt query.IteratorOptions) (query.Iterator, error)
+	IteratorCost(measurement string, opt query.IteratorOptions) (query.IteratorCost, error)
 	WritePoints(points []models.Point) error
 
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	"github.com/influxdata/influxdb/influxql"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/estimator"
+	"github.com/influxdata/influxdb/pkg/limiter"
 	"github.com/influxdata/influxdb/query"
 	internal "github.com/influxdata/influxdb/tsdb/internal"
 	"github.com/uber-go/zap"
@@ -776,6 +778,14 @@ func (s *Shard) createSeriesIterator(opt query.IteratorOptions) (query.Iterator,
 	return s.engine.SeriesPointIterator(opt)
 }
 
+// IteratorCost returns the estimated cost of constructing and reading an iterator.
+func (s *Shard) IteratorCost(measurement string, opt query.IteratorOptions) (query.IteratorCost, error) {
+	if err := s.ready(); err != nil {
+		return query.IteratorCost{}, err
+	}
+	return s.engine.IteratorCost(measurement, opt)
+}
+
 // FieldDimensions returns unique sets of fields and dimensions across a list of sources.
 func (s *Shard) FieldDimensions(measurements []string) (fields map[string]influxql.DataType, dimensions map[string]struct{}, err error) {
 	if err := s.ready(); err != nil {
@@ -1008,6 +1018,7 @@ type ShardGroup interface {
 	FieldDimensions(measurements []string) (fields map[string]influxql.DataType, dimensions map[string]struct{}, err error)
 	MapType(measurement, field string) influxql.DataType
 	CreateIterator(measurement string, opt query.IteratorOptions) (query.Iterator, error)
+	IteratorCost(measurement string, opt query.IteratorOptions) (query.IteratorCost, error)
 	ExpandSources(sources influxql.Sources) (influxql.Sources, error)
 }
 
@@ -1104,6 +1115,46 @@ func (a Shards) CreateIterator(measurement string, opt query.IteratorOptions) (q
 		}
 	}
 	return query.Iterators(itrs).Merge(opt)
+}
+
+func (a Shards) IteratorCost(measurement string, opt query.IteratorOptions) (query.IteratorCost, error) {
+	var costs query.IteratorCost
+	var costerr error
+	var mu sync.RWMutex
+
+	limit := limiter.NewFixed(runtime.GOMAXPROCS(0))
+	var wg sync.WaitGroup
+	for _, sh := range a {
+		limit.Take()
+		wg.Add(1)
+
+		mu.RLock()
+		if costerr != nil {
+			mu.RUnlock()
+			break
+		}
+		mu.RUnlock()
+
+		go func(sh *Shard) {
+			defer limit.Release()
+			defer wg.Done()
+
+			cost, err := sh.IteratorCost(measurement, opt)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				if costerr == nil {
+					costerr = err
+				}
+				return
+			}
+			costs = costs.Combine(cost)
+		}(sh)
+	}
+	wg.Wait()
+	return costs, costerr
 }
 
 func (a Shards) ExpandSources(sources influxql.Sources) (influxql.Sources, error) {


### PR DESCRIPTION
It prints the statistics of each iterator that will access the storage
engine. For each access of the storage engine, it will print the number
of shards that will potentially be accessed, the number of files that
may be accessed, the number of series that will be created, the number
of blocks, and the size of those blocks.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<[influxdata/docs.influxdata.com#1256](https://github.com/influxdata/docs.influxdata.com/issues/1256)>