### PR TITLE
Fixes #8787

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [#8766](https://github.com/influxdata/influxdb/pull/8766): Fix deadlock when calling `SeriesIDsAllOrByExpr`
 - [#8638](https://github.com/influxdata/influxdb/issues/8638): Fix `influx_inspect export` so it skips missing files.
 - [#8770](https://github.com/influxdata/influxdb/pull/8770): Reduce how long it takes to walk the varrefs in an expression.
+- [#8787](https://github.com/influxdata/influxdb/issues/8787): panic: runtime error: invalid memory address or nil pointer dereference.
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -112,7 +112,6 @@ type Shard struct {
 	path    string
 	walPath string
 	id      uint64
-	wg      sync.WaitGroup
 
 	database        string
 	retentionPolicy string
@@ -350,11 +349,10 @@ func (s *Shard) close(clean bool) error {
 	default:
 		close(s.closing)
 	}
-	s.wg.Wait()
 
 	if clean {
 		// Don't leak our shard ID and series keys in the index
-		s.UnloadIndex()
+		s.unloadIndex()
 	}
 
 	err := s.engine.Close()
@@ -403,6 +401,13 @@ func (s *Shard) LastModified() time.Time {
 
 // UnloadIndex removes all references to this shard from the DatabaseIndex
 func (s *Shard) UnloadIndex() {
+	if err := s.ready(); err != nil {
+		return
+	}
+	s.unloadIndex()
+}
+
+func (s *Shard) unloadIndex() {
 	s.index.RemoveShard(s.id)
 }
 


### PR DESCRIPTION
Exported `UnloadIndex` API checks `ready` state

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
