### PR TITLE
enclose url with params

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,30 +29,30 @@ We recommend installing InfluxDB using one of the [pre-built packages](https://i
 ### Create your first database
 
 ```
-curl -XPOST 'http://localhost:8086/query' --data-urlencode "q=CREATE DATABASE mydb"
+curl -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE DATABASE mydb"
 ```
 
 ### Insert some data
 ```
-curl -XPOST 'http://localhost:8086/write?db=mydb' \
+curl -XPOST "http://localhost:8086/write?db=mydb" \
 -d 'cpu,host=server01,region=uswest load=42 1434055562000000000'
 
-curl -XPOST 'http://localhost:8086/write?db=mydb' \
+curl -XPOST "http://localhost:8086/write?db=mydb" \
 -d 'cpu,host=server02,region=uswest load=78 1434055562000000000'
 
-curl -XPOST 'http://localhost:8086/write?db=mydb' \
+curl -XPOST "http://localhost:8086/write?db=mydb" \
 -d 'cpu,host=server03,region=useast load=15.4 1434055562000000000'
 ```
 
 ### Query for the data
 ```JSON
-curl -G 'http://localhost:8086/query?pretty=true' --data-urlencode "db=mydb" \
+curl -G "http://localhost:8086/query?pretty=true" --data-urlencode "db=mydb" \
 --data-urlencode "q=SELECT * FROM cpu WHERE host='server01' AND time < now() - 1d"
 ```
 
 ### Analyze the data
 ```JSON
-curl -G 'http://localhost:8086/query?pretty=true' --data-urlencode "db=mydb" \
+curl -G "http://localhost:8086/query?pretty=true" --data-urlencode "db=mydb" \
 --data-urlencode "q=SELECT mean(load) FROM cpu WHERE region='uswest'"
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ curl -XPOST 'http://localhost:8086/write?db=mydb' \
 
 ### Query for the data
 ```JSON
-curl -G http://localhost:8086/query?pretty=true --data-urlencode "db=mydb" \
+curl -G 'http://localhost:8086/query?pretty=true' --data-urlencode "db=mydb" \
 --data-urlencode "q=SELECT * FROM cpu WHERE host='server01' AND time < now() - 1d"
 ```
 
 ### Analyze the data
 ```JSON
-curl -G http://localhost:8086/query?pretty=true --data-urlencode "db=mydb" \
+curl -G 'http://localhost:8086/query?pretty=true' --data-urlencode "db=mydb" \
 --data-urlencode "q=SELECT mean(load) FROM cpu WHERE region='uswest'"
 ```
 


### PR DESCRIPTION
```
curl -G http://localhost:8086/query?pretty=true --data-urlencode "db=mydb" \
--data-urlencode "q=SELECT * FROM cpu WHERE host='server01' AND time < now() - 1d"
```

Running this on ubuntu will get an error: 

```
curl -G http://localhost:8086/query?pretty=true --data-urlencode "db=mydb"  --data-urlencode "q=SELECT mean(load) FROM cpu WHERE region='uswest'"
No matches for wildcard “http://localhost:8086/query?pretty=true”.
fish: curl -G http://localhost:8086/query?pretty=true --data-urlencode "db=mydb"  --data-urlencode "q=SELECT mean(load) FROM cpu WHERE region='uswest'"
              ^
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
```

URL here should be enclosed with quotation marks.


---

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
