### PR TITLE
Fix increased memory usage in cache and wal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [#8638](https://github.com/influxdata/influxdb/issues/8638): Fix `influx_inspect export` so it skips missing files.
 - [#8770](https://github.com/influxdata/influxdb/pull/8770): Reduce how long it takes to walk the varrefs in an expression.
 - [#8787](https://github.com/influxdata/influxdb/issues/8787): panic: runtime error: invalid memory address or nil pointer dereference.
+- [#8741](https://github.com/influxdata/influxdb/issues/8741): Fix increased memory usage in cache and wal readers
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -607,6 +607,7 @@ func (cl *CacheLoader) Load(cache *Cache) error {
 			if err != nil {
 				return err
 			}
+			defer f.Close()
 
 			// Log some information about the segments.
 			stat, err := os.Stat(f.Name())
@@ -614,6 +615,11 @@ func (cl *CacheLoader) Load(cache *Cache) error {
 				return err
 			}
 			cl.Logger.Info(fmt.Sprintf("reading file %s, size %d", f.Name(), stat.Size()))
+
+			// Nothing to read, skip it
+			if stat.Size() == 0 {
+				return nil
+			}
 
 			r := NewWALSegmentReader(f)
 			defer r.Close()

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -201,18 +201,23 @@ type Cache struct {
 
 	stats        *CacheStatistics
 	lastSnapshot time.Time
+
+	// A one time synchronization used to initial the cache with a store.  Since the store can allocate a
+	// a large amount memory across shards, we lazily create it.
+	initialize       atomic.Value
+	initializedCount uint32
 }
 
 // NewCache returns an instance of a cache which will use a maximum of maxSize bytes of memory.
 // Only used for engine caches, never for snapshots.
 func NewCache(maxSize uint64, path string) *Cache {
-	store, _ := newring(ringShards)
 	c := &Cache{
 		maxSize:      maxSize,
-		store:        store, // Max size for now..
+		store:        emptyStore{},
 		stats:        &CacheStatistics{},
 		lastSnapshot: time.Now(),
 	}
+	c.initialize.Store(&sync.Once{})
 	c.UpdateAge()
 	c.UpdateCompactTime(0)
 	c.updateCachedBytes(0)
@@ -253,9 +258,33 @@ func (c *Cache) Statistics(tags map[string]string) []models.Statistic {
 	}}
 }
 
+// init initializes the cache and allocates the underlying store.  Once initialized,
+// the store re-used until Freed.
+func (c *Cache) init() {
+	if !atomic.CompareAndSwapUint32(&c.initializedCount, 0, 1) {
+		return
+	}
+
+	c.mu.Lock()
+	c.store, _ = newring(ringShards)
+	c.mu.Unlock()
+}
+
+// Free releases the underlying store and memory held by the Cache.
+func (c *Cache) Free() {
+	if !atomic.CompareAndSwapUint32(&c.initializedCount, 1, 0) {
+		return
+	}
+
+	c.mu.Lock()
+	c.store = emptyStore{}
+	c.mu.Unlock()
+}
+
 // Write writes the set of values for the key to the cache. This function is goroutine-safe.
 // It returns an error if the cache will exceed its max size by adding the new values.
 func (c *Cache) Write(key []byte, values []Value) error {
+	c.init()
 	addedSize := uint64(Values(values).Size())
 
 	// Enough room in the cache?
@@ -286,6 +315,7 @@ func (c *Cache) Write(key []byte, values []Value) error {
 // values as possible.  If one key fails, the others can still succeed and an
 // error will be returned.
 func (c *Cache) WriteMulti(values map[string][]Value) error {
+	c.init()
 	var addedSize uint64
 	for _, v := range values {
 		addedSize += uint64(Values(v).Size())
@@ -332,6 +362,8 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 // Snapshot takes a snapshot of the current cache, adds it to the slice of caches that
 // are being flushed, and resets the current cache with new values.
 func (c *Cache) Snapshot() (*Cache, error) {
+	c.init()
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -394,6 +426,8 @@ func (c *Cache) Deduplicate() {
 // ClearSnapshot removes the snapshot cache from the list of flushing caches and
 // adjusts the size.
 func (c *Cache) ClearSnapshot(success bool) {
+	c.init()
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -519,6 +553,8 @@ func (c *Cache) Delete(keys [][]byte) {
 //
 // TODO(edd): Lock usage could possibly be optimised if necessary.
 func (c *Cache) DeleteRange(keys [][]byte, min, max int64) {
+	c.init()
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -710,3 +746,14 @@ func (c *Cache) updateSnapshots() {
 	atomic.StoreInt64(&c.stats.DiskSizeBytes, int64(atomic.LoadUint64(&c.snapshotSize)))
 	atomic.StoreInt64(&c.stats.SnapshotCount, int64(c.snapshotAttempts))
 }
+
+type emptyStore struct{}
+
+func (e emptyStore) entry(key []byte) *entry                        { return nil }
+func (e emptyStore) write(key []byte, values Values) error          { return nil }
+func (e emptyStore) add(key []byte, entry *entry)                   {}
+func (e emptyStore) remove(key []byte)                              {}
+func (e emptyStore) keys(sorted bool) [][]byte                      { return nil }
+func (e emptyStore) apply(f func([]byte, *entry) error) error       { return nil }
+func (e emptyStore) applySerial(f func([]byte, *entry) error) error { return nil }
+func (e emptyStore) reset()                                         {}

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -117,6 +117,7 @@ func TestCache_WriteMulti_Stats(t *testing.T) {
 
 	// Fail one of the values in the write.
 	c = NewCache(50, "")
+	c.init()
 	c.store = ms
 
 	ms.writef = func(key []byte, v Values) error {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -308,6 +308,11 @@ func (e *Engine) disableSnapshotCompactions() {
 
 	e.mu.Unlock()
 	e.snapWG.Wait()
+
+	// If the cache is empty, free up its resources as well.
+	if e.Cache.Size() == 0 {
+		e.Cache.Free()
+	}
 }
 
 // Path returns the path the engine was opened with.

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -1081,7 +1081,7 @@ func (w *WALSegmentWriter) close() error {
 // WALSegmentReader reads WAL segments.
 type WALSegmentReader struct {
 	rc    io.ReadCloser
-	r     io.Reader
+	r     *bufio.Reader
 	entry WALEntry
 	n     int64
 	err   error
@@ -1091,8 +1091,16 @@ type WALSegmentReader struct {
 func NewWALSegmentReader(r io.ReadCloser) *WALSegmentReader {
 	return &WALSegmentReader{
 		rc: r,
-		r:  bufio.NewReaderSize(r, 1024*1024),
+		r:  bufio.NewReader(r),
 	}
+}
+
+func (r *WALSegmentReader) Reset(rc io.ReadCloser) {
+	r.rc = rc
+	r.r.Reset(rc)
+	r.entry = nil
+	r.n = 0
+	r.err = nil
 }
 
 // Next indicates if there is a value to read.
@@ -1187,6 +1195,9 @@ func (r *WALSegmentReader) Error() error {
 
 // Close closes the underlying io.Reader.
 func (r *WALSegmentReader) Close() error {
+	if r.rc == nil {
+		return nil
+	}
 	return r.rc.Close()
 }
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -1198,7 +1198,9 @@ func (r *WALSegmentReader) Close() error {
 	if r.rc == nil {
 		return nil
 	}
-	return r.rc.Close()
+	err := r.rc.Close()
+	r.rc = nil
+	return err
 }
 
 // idFromFileName parses the segment file ID from its name.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

In 1.3, there were two performance improvements that appear to have increased memory usage when many shards exist.  

The cache uses more partitions to reduce lock contention, but a large number of shard causes the memory usage to be much higher.  This has been fixed to lazily create the cache store and to free it when the shard goes cold.

The wal segment reader uses a buffered reader to reduce disk IO and improve wal segment reading.  When there are a lot of shards, they are opened concurrently causing much higher memory usage.  There was also a bug where a 0 byte wal segment would still create a reader and waste memory.  This has been fixed to skip 0 byte wal segments and to re-use wal segment readers within a shard.

The screenshot below show the memory usage with 8000 shards with 1.2, 1.3 and this branch.  In this scenario, memory at rest is now lower than 1.2.  That may not be the case in general, but the high memory usage seen in 1.3 should be reduced in most cases.

<img width="469" alt="screen shot 2017-09-07 at 4 50 22 pm" src="https://user-images.githubusercontent.com/219935/30188765-77de1930-93ed-11e7-8795-fb372f6199b0.png">


Fixes #8741 