### PR TITLE
Snapshot compaction improvements

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -88,7 +88,8 @@
   # compact-full-write-cold-duration = "4h"
 
   # The maximum number of concurrent full and level compactions that can run at one time.  A
-  # value of 0 results in runtime.GOMAXPROCS(0) used at runtime.  This setting does not apply
+  # value of 0 results in 50% of runtime.GOMAXPROCS(0) used at runtime.  Any number greater
+  # than 0 limits compactions to that value.  This setting does not apply
   # to cache snapshotting.
   # max-concurrent-compactions = 0
 
@@ -358,10 +359,10 @@
   # UDP Read buffer size, 0 means OS default. UDP listener will fail if set above OS max.
   # read-buffer = 0
 
-  # Multi-value plugins can be handled two ways.  
+  # Multi-value plugins can be handled two ways.
   # "split" will parse and store the multi-value plugin data into separate measurements
-  # "join" will parse and store the multi-value plugin as a single multi-value measurement.  
-  # "split" is the default behavior for backward compatability with previous versions of influxdb.  
+  # "join" will parse and store the multi-value plugin as a single multi-value measurement.
+  # "split" is the default behavior for backward compatability with previous versions of influxdb.
   # parse-multivalue-plugin = "split"
 ###
 ### [opentsdb]

--- a/pkg/limiter/fixed.go
+++ b/pkg/limiter/fixed.go
@@ -10,10 +10,27 @@ func NewFixed(limit int) Fixed {
 	return make(Fixed, limit)
 }
 
+// Idle returns true if the limiter has all its capacity is available.
+func (t Fixed) Idle() bool {
+	return len(t) == cap(t)
+}
+
+// TryTake attempts to take a token and return true if successful, otherwise returns false.
+func (t Fixed) TryTake() bool {
+	select {
+	case t <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// Take attempts to take a token and blocks until one is available.
 func (t Fixed) Take() {
 	t <- struct{}{}
 }
 
+// Release releases a token back to the limiter.
 func (t Fixed) Release() {
 	<-t
 }

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -49,7 +49,7 @@ const (
 	DefaultMaxValuesPerTag = 100000
 
 	// DefaultMaxConcurrentCompactions is the maximum number of concurrent full and level compactions
-	// that can run at one time.  A value of results in runtime.GOMAXPROCS(0) used at runtime.
+	// that can run at one time.  A value of 0 results in 50% of runtime.GOMAXPROCS(0) used at runtime.
 	DefaultMaxConcurrentCompactions = 0
 )
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -144,11 +144,13 @@ func NewEngine(id uint64, i Index, database, path string, walPath string, option
 
 // EngineOptions represents the options used to initialize the engine.
 type EngineOptions struct {
-	EngineVersion     string
-	IndexVersion      string
-	ShardID           uint64
-	InmemIndex        interface{} // shared in-memory index
-	CompactionLimiter limiter.Fixed
+	EngineVersion string
+	IndexVersion  string
+	ShardID       uint64
+	InmemIndex    interface{} // shared in-memory index
+
+	HiPriCompactionLimiter limiter.Fixed
+	LoPriCompactionLimiter limiter.Fixed
 
 	Config Config
 }

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -118,7 +118,7 @@ func (e *entry) deduplicate() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	if len(e.values) == 0 {
+	if len(e.values) <= 1 {
 		return
 	}
 	e.values = e.values.Deduplicate()

--- a/tsdb/engine/tsm1/compact.gen.go
+++ b/tsdb/engine/tsm1/compact.gen.go
@@ -6,10 +6,6 @@
 
 package tsm1
 
-import (
-	"runtime"
-)
-
 // merge combines the next set of blocks into merged blocks.
 func (k *tsmKeyIterator) mergeFloat() {
 	// No blocks left, or pending merged values, we're done
@@ -92,10 +88,6 @@ func (k *tsmKeyIterator) combineFloat(dedup bool) blocks {
 				}
 
 				k.mergedFloatValues = k.mergedFloatValues.Merge(v)
-
-				// Allow other goroutines to run
-				runtime.Gosched()
-
 			}
 		}
 
@@ -120,8 +112,6 @@ func (k *tsmKeyIterator) combineFloat(dedup bool) blocks {
 				break
 			}
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		if k.fast {
@@ -134,8 +124,6 @@ func (k *tsmKeyIterator) combineFloat(dedup bool) blocks {
 
 				chunked = append(chunked, k.blocks[i])
 				i++
-				// Allow other goroutines to run
-				runtime.Gosched()
 			}
 		}
 
@@ -170,8 +158,6 @@ func (k *tsmKeyIterator) combineFloat(dedup bool) blocks {
 
 			k.mergedFloatValues = k.mergedFloatValues.Merge(v)
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		k.blocks = k.blocks[i:]
@@ -300,10 +286,6 @@ func (k *tsmKeyIterator) combineInteger(dedup bool) blocks {
 				}
 
 				k.mergedIntegerValues = k.mergedIntegerValues.Merge(v)
-
-				// Allow other goroutines to run
-				runtime.Gosched()
-
 			}
 		}
 
@@ -328,8 +310,6 @@ func (k *tsmKeyIterator) combineInteger(dedup bool) blocks {
 				break
 			}
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		if k.fast {
@@ -342,8 +322,6 @@ func (k *tsmKeyIterator) combineInteger(dedup bool) blocks {
 
 				chunked = append(chunked, k.blocks[i])
 				i++
-				// Allow other goroutines to run
-				runtime.Gosched()
 			}
 		}
 
@@ -378,8 +356,6 @@ func (k *tsmKeyIterator) combineInteger(dedup bool) blocks {
 
 			k.mergedIntegerValues = k.mergedIntegerValues.Merge(v)
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		k.blocks = k.blocks[i:]
@@ -508,10 +484,6 @@ func (k *tsmKeyIterator) combineUnsigned(dedup bool) blocks {
 				}
 
 				k.mergedUnsignedValues = k.mergedUnsignedValues.Merge(v)
-
-				// Allow other goroutines to run
-				runtime.Gosched()
-
 			}
 		}
 
@@ -536,8 +508,6 @@ func (k *tsmKeyIterator) combineUnsigned(dedup bool) blocks {
 				break
 			}
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		if k.fast {
@@ -550,8 +520,6 @@ func (k *tsmKeyIterator) combineUnsigned(dedup bool) blocks {
 
 				chunked = append(chunked, k.blocks[i])
 				i++
-				// Allow other goroutines to run
-				runtime.Gosched()
 			}
 		}
 
@@ -586,8 +554,6 @@ func (k *tsmKeyIterator) combineUnsigned(dedup bool) blocks {
 
 			k.mergedUnsignedValues = k.mergedUnsignedValues.Merge(v)
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		k.blocks = k.blocks[i:]
@@ -716,10 +682,6 @@ func (k *tsmKeyIterator) combineString(dedup bool) blocks {
 				}
 
 				k.mergedStringValues = k.mergedStringValues.Merge(v)
-
-				// Allow other goroutines to run
-				runtime.Gosched()
-
 			}
 		}
 
@@ -744,8 +706,6 @@ func (k *tsmKeyIterator) combineString(dedup bool) blocks {
 				break
 			}
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		if k.fast {
@@ -758,8 +718,6 @@ func (k *tsmKeyIterator) combineString(dedup bool) blocks {
 
 				chunked = append(chunked, k.blocks[i])
 				i++
-				// Allow other goroutines to run
-				runtime.Gosched()
 			}
 		}
 
@@ -794,8 +752,6 @@ func (k *tsmKeyIterator) combineString(dedup bool) blocks {
 
 			k.mergedStringValues = k.mergedStringValues.Merge(v)
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		k.blocks = k.blocks[i:]
@@ -924,10 +880,6 @@ func (k *tsmKeyIterator) combineBoolean(dedup bool) blocks {
 				}
 
 				k.mergedBooleanValues = k.mergedBooleanValues.Merge(v)
-
-				// Allow other goroutines to run
-				runtime.Gosched()
-
 			}
 		}
 
@@ -952,8 +904,6 @@ func (k *tsmKeyIterator) combineBoolean(dedup bool) blocks {
 				break
 			}
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		if k.fast {
@@ -966,8 +916,6 @@ func (k *tsmKeyIterator) combineBoolean(dedup bool) blocks {
 
 				chunked = append(chunked, k.blocks[i])
 				i++
-				// Allow other goroutines to run
-				runtime.Gosched()
 			}
 		}
 
@@ -1002,8 +950,6 @@ func (k *tsmKeyIterator) combineBoolean(dedup bool) blocks {
 
 			k.mergedBooleanValues = k.mergedBooleanValues.Merge(v)
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		k.blocks = k.blocks[i:]

--- a/tsdb/engine/tsm1/compact.gen.go.tmpl
+++ b/tsdb/engine/tsm1/compact.gen.go.tmpl
@@ -1,9 +1,5 @@
 package tsm1
 
-import (
-	"runtime"
-)
-
 {{range .}}
 
 // merge combines the next set of blocks into merged blocks.
@@ -88,10 +84,6 @@ func (k *tsmKeyIterator) combine{{.Name}}(dedup bool) blocks {
 				}
 
 				k.merged{{.Name}}Values = k.merged{{.Name}}Values.Merge(v)
-
-				// Allow other goroutines to run
-				runtime.Gosched()
-
 			}
 		}
 
@@ -116,8 +108,6 @@ func (k *tsmKeyIterator) combine{{.Name}}(dedup bool) blocks {
 				break
 			}
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		if k.fast {
@@ -130,8 +120,6 @@ func (k *tsmKeyIterator) combine{{.Name}}(dedup bool) blocks {
 
 				chunked = append(chunked, k.blocks[i])
 				i++
-				// Allow other goroutines to run
-				runtime.Gosched()
 			}
 		}
 
@@ -166,8 +154,6 @@ func (k *tsmKeyIterator) combine{{.Name}}(dedup bool) blocks {
 
 			k.merged{{.Name}}Values = k.merged{{.Name}}Values.Merge(v)
 			i++
-			// Allow other goroutines to run
-			runtime.Gosched()
 		}
 
 		k.blocks = k.blocks[i:]

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -230,7 +230,7 @@ func (c *DefaultPlanner) PlanLevel(level int) []CompactionGroup {
 	// Each compaction group should run against 4 generations.  For level 1, since these
 	// can get created much more quickly, bump the grouping to 8 to keep file counts lower.
 	groupSize := 4
-	if level == 1 {
+	if level == 1 || level == 3 {
 		groupSize = 8
 	}
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -704,12 +704,16 @@ func (c *Compactor) WriteSnapshot(cache *Cache) ([]string, error) {
 		return nil, errSnapshotsDisabled
 	}
 
-	concurrency := cache.Count() / 256000
-	if concurrency < 1 {
-		concurrency = 1
-	}
-	if concurrency > 4 {
-		concurrency = 4
+	concurrency := 1
+	card := cache.Count()
+	if card >= 1024*1024 {
+		concurrency = card / 1024 * 1024
+		if concurrency < 1 {
+			concurrency = 1
+		}
+		if concurrency > 4 {
+			concurrency = 4
+		}
 	}
 	splits := cache.Split(concurrency)
 

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -1689,6 +1689,22 @@ func TestDefaultPlanner_PlanLevel_Multiple(t *testing.T) {
 			Path: "06-01.tsm1",
 			Size: 1 * 1024 * 1024,
 		},
+		tsm1.FileStat{
+			Path: "07-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "08-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "09-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "10-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
 	}
 
 	cp := tsm1.NewDefaultPlanner(
@@ -1699,8 +1715,8 @@ func TestDefaultPlanner_PlanLevel_Multiple(t *testing.T) {
 		}, tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
-	expFiles2 := []tsm1.FileStat{data[4], data[5]}
+	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]}
+	expFiles2 := []tsm1.FileStat{data[8], data[9]}
 
 	tsm := cp.PlanLevel(1)
 	if exp, got := len(expFiles1), len(tsm[0]); got != exp {

--- a/tsdb/engine/tsm1/encoding.gen.go
+++ b/tsdb/engine/tsm1/encoding.gen.go
@@ -56,7 +56,7 @@ func (a Values) assertOrdered() {
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
 // The Value that appears last in the slice is the one that is kept.
 func (a Values) Deduplicate() Values {
-	if len(a) == 0 {
+	if len(a) <= 1 {
 		return a
 	}
 
@@ -268,7 +268,7 @@ func (a FloatValues) assertOrdered() {
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
 // The Value that appears last in the slice is the one that is kept.
 func (a FloatValues) Deduplicate() FloatValues {
-	if len(a) == 0 {
+	if len(a) <= 1 {
 		return a
 	}
 
@@ -524,7 +524,7 @@ func (a IntegerValues) assertOrdered() {
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
 // The Value that appears last in the slice is the one that is kept.
 func (a IntegerValues) Deduplicate() IntegerValues {
-	if len(a) == 0 {
+	if len(a) <= 1 {
 		return a
 	}
 
@@ -780,7 +780,7 @@ func (a UnsignedValues) assertOrdered() {
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
 // The Value that appears last in the slice is the one that is kept.
 func (a UnsignedValues) Deduplicate() UnsignedValues {
-	if len(a) == 0 {
+	if len(a) <= 1 {
 		return a
 	}
 
@@ -1036,7 +1036,7 @@ func (a StringValues) assertOrdered() {
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
 // The Value that appears last in the slice is the one that is kept.
 func (a StringValues) Deduplicate() StringValues {
-	if len(a) == 0 {
+	if len(a) <= 1 {
 		return a
 	}
 
@@ -1292,7 +1292,7 @@ func (a BooleanValues) assertOrdered() {
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
 // The Value that appears last in the slice is the one that is kept.
 func (a BooleanValues) Deduplicate() BooleanValues {
-	if len(a) == 0 {
+	if len(a) <= 1 {
 		return a
 	}
 

--- a/tsdb/engine/tsm1/encoding.gen.go.tmpl
+++ b/tsdb/engine/tsm1/encoding.gen.go.tmpl
@@ -53,7 +53,7 @@ func (a {{.Name}}Values) assertOrdered() {
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
 // The Value that appears last in the slice is the one that is kept.
 func (a {{.Name}}Values) Deduplicate() {{.Name}}Values {
-	if len(a) == 0 {
+	if len(a) <= 1 {
 		return a
 	}
 

--- a/tsdb/engine/tsm1/encoding.go
+++ b/tsdb/engine/tsm1/encoding.go
@@ -359,37 +359,39 @@ func encodeFloatBlock(buf []byte, values []Value) ([]byte, error) {
 	// frame-or-reference and run length encoding.
 	tsenc := getTimeEncoder(len(values))
 
-	var b []byte
-	err := func() error {
-		for _, v := range values {
-			vv := v.(FloatValue)
-			tsenc.Write(vv.unixnano)
-			venc.Write(vv.value)
-		}
-		venc.Flush()
-
-		// Encoded timestamp values
-		tb, err := tsenc.Bytes()
-		if err != nil {
-			return err
-		}
-		// Encoded float values
-		vb, err := venc.Bytes()
-		if err != nil {
-			return err
-		}
-
-		// Prepend the first timestamp of the block in the first 8 bytes and the block
-		// in the next byte, followed by the block
-		b = packBlock(buf, BlockFloat64, tb, vb)
-
-		return nil
-	}()
+	b, err := encodeFloatBlockUsing(buf, values, tsenc, venc)
 
 	putTimeEncoder(tsenc)
 	putFloatEncoder(venc)
 
 	return b, err
+}
+
+func encodeFloatBlockUsing(buf []byte, values []Value, tsenc TimeEncoder, venc *FloatEncoder) ([]byte, error) {
+	tsenc.Reset()
+	venc.Reset()
+
+	for _, v := range values {
+		vv := v.(FloatValue)
+		tsenc.Write(vv.unixnano)
+		venc.Write(vv.value)
+	}
+	venc.Flush()
+
+	// Encoded timestamp values
+	tb, err := tsenc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	// Encoded float values
+	vb, err := venc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepend the first timestamp of the block in the first 8 bytes and the block
+	// in the next byte, followed by the block
+	return packBlock(buf, BlockFloat64, tb, vb), nil
 }
 
 // DecodeFloatBlock decodes the float block from the byte slice
@@ -499,35 +501,38 @@ func encodeBooleanBlock(buf []byte, values []Value) ([]byte, error) {
 	// Encode timestamps using an adaptive encoder
 	tsenc := getTimeEncoder(len(values))
 
-	var b []byte
-	err := func() error {
-		for _, v := range values {
-			vv := v.(BooleanValue)
-			tsenc.Write(vv.unixnano)
-			venc.Write(vv.value)
-		}
-
-		// Encoded timestamp values
-		tb, err := tsenc.Bytes()
-		if err != nil {
-			return err
-		}
-		// Encoded float values
-		vb, err := venc.Bytes()
-		if err != nil {
-			return err
-		}
-
-		// Prepend the first timestamp of the block in the first 8 bytes and the block
-		// in the next byte, followed by the block
-		b = packBlock(buf, BlockBoolean, tb, vb)
-		return nil
-	}()
+	b, err := encodeBooleanBlockUsing(buf, values, tsenc, venc)
 
 	putTimeEncoder(tsenc)
 	putBooleanEncoder(venc)
 
 	return b, err
+}
+
+func encodeBooleanBlockUsing(buf []byte, values []Value, tenc TimeEncoder, venc BooleanEncoder) ([]byte, error) {
+	tenc.Reset()
+	venc.Reset()
+
+	for _, v := range values {
+		vv := v.(BooleanValue)
+		tenc.Write(vv.unixnano)
+		venc.Write(vv.value)
+	}
+
+	// Encoded timestamp values
+	tb, err := tenc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	// Encoded float values
+	vb, err := venc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepend the first timestamp of the block in the first 8 bytes and the block
+	// in the next byte, followed by the block
+	return packBlock(buf, BlockBoolean, tb, vb), nil
 }
 
 // DecodeBooleanBlock decodes the boolean block from the byte slice
@@ -622,37 +627,40 @@ func (v IntegerValue) String() string {
 }
 
 func encodeIntegerBlock(buf []byte, values []Value) ([]byte, error) {
-	tsEnc := getTimeEncoder(len(values))
-	vEnc := getIntegerEncoder(len(values))
+	tenc := getTimeEncoder(len(values))
+	venc := getIntegerEncoder(len(values))
 
-	var b []byte
-	err := func() error {
-		for _, v := range values {
-			vv := v.(IntegerValue)
-			tsEnc.Write(vv.unixnano)
-			vEnc.Write(vv.value)
-		}
+	b, err := encodeIntegerBlockUsing(buf, values, tenc, venc)
 
-		// Encoded timestamp values
-		tb, err := tsEnc.Bytes()
-		if err != nil {
-			return err
-		}
-		// Encoded int64 values
-		vb, err := vEnc.Bytes()
-		if err != nil {
-			return err
-		}
-
-		// Prepend the first timestamp of the block in the first 8 bytes
-		b = packBlock(buf, BlockInteger, tb, vb)
-		return nil
-	}()
-
-	putTimeEncoder(tsEnc)
-	putIntegerEncoder(vEnc)
+	putTimeEncoder(tenc)
+	putIntegerEncoder(venc)
 
 	return b, err
+}
+
+func encodeIntegerBlockUsing(buf []byte, values []Value, tenc TimeEncoder, venc IntegerEncoder) ([]byte, error) {
+	tenc.Reset()
+	venc.Reset()
+
+	for _, v := range values {
+		vv := v.(IntegerValue)
+		tenc.Write(vv.unixnano)
+		venc.Write(vv.value)
+	}
+
+	// Encoded timestamp values
+	tb, err := tenc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	// Encoded int64 values
+	vb, err := venc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepend the first timestamp of the block in the first 8 bytes
+	return packBlock(buf, BlockInteger, tb, vb), nil
 }
 
 // DecodeIntegerBlock decodes the integer block from the byte slice
@@ -748,37 +756,40 @@ func (v UnsignedValue) String() string {
 }
 
 func encodeUnsignedBlock(buf []byte, values []Value) ([]byte, error) {
-	tsEnc := getTimeEncoder(len(values))
-	vEnc := getUnsignedEncoder(len(values))
+	tenc := getTimeEncoder(len(values))
+	venc := getUnsignedEncoder(len(values))
 
-	var b []byte
-	err := func() error {
-		for _, v := range values {
-			vv := v.(UnsignedValue)
-			tsEnc.Write(vv.unixnano)
-			vEnc.Write(int64(vv.value))
-		}
+	b, err := encodeUnsignedBlockUsing(buf, values, tenc, venc)
 
-		// Encoded timestamp values
-		tb, err := tsEnc.Bytes()
-		if err != nil {
-			return err
-		}
-		// Encoded int64 values
-		vb, err := vEnc.Bytes()
-		if err != nil {
-			return err
-		}
-
-		// Prepend the first timestamp of the block in the first 8 bytes
-		b = packBlock(buf, BlockUnsigned, tb, vb)
-		return nil
-	}()
-
-	putTimeEncoder(tsEnc)
-	putUnsignedEncoder(vEnc)
+	putTimeEncoder(tenc)
+	putUnsignedEncoder(venc)
 
 	return b, err
+}
+
+func encodeUnsignedBlockUsing(buf []byte, values []Value, tenc TimeEncoder, venc IntegerEncoder) ([]byte, error) {
+	tenc.Reset()
+	venc.Reset()
+
+	for _, v := range values {
+		vv := v.(UnsignedValue)
+		tenc.Write(vv.unixnano)
+		venc.Write(int64(vv.value))
+	}
+
+	// Encoded timestamp values
+	tb, err := tenc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	// Encoded int64 values
+	vb, err := venc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepend the first timestamp of the block in the first 8 bytes
+	return packBlock(buf, BlockUnsigned, tb, vb), nil
 }
 
 // DecodeUnsignedBlock decodes the unsigned integer block from the byte slice
@@ -874,38 +885,40 @@ func (v StringValue) String() string {
 }
 
 func encodeStringBlock(buf []byte, values []Value) ([]byte, error) {
-	tsEnc := getTimeEncoder(len(values))
-	vEnc := getStringEncoder(len(values) * len(values[0].(StringValue).value))
+	tenc := getTimeEncoder(len(values))
+	venc := getStringEncoder(len(values) * len(values[0].(StringValue).value))
 
-	var b []byte
-	err := func() error {
-		for _, v := range values {
-			vv := v.(StringValue)
-			tsEnc.Write(vv.unixnano)
-			vEnc.Write(vv.value)
-		}
+	b, err := encodeStringBlockUsing(buf, values, tenc, venc)
 
-		// Encoded timestamp values
-		tb, err := tsEnc.Bytes()
-		if err != nil {
-			return err
-		}
-		// Encoded string values
-		vb, err := vEnc.Bytes()
-		if err != nil {
-			return err
-		}
-
-		// Prepend the first timestamp of the block in the first 8 bytes
-		b = packBlock(buf, BlockString, tb, vb)
-
-		return nil
-	}()
-
-	putTimeEncoder(tsEnc)
-	putStringEncoder(vEnc)
+	putTimeEncoder(tenc)
+	putStringEncoder(venc)
 
 	return b, err
+}
+
+func encodeStringBlockUsing(buf []byte, values []Value, tenc TimeEncoder, venc StringEncoder) ([]byte, error) {
+	tenc.Reset()
+	venc.Reset()
+
+	for _, v := range values {
+		vv := v.(StringValue)
+		tenc.Write(vv.unixnano)
+		venc.Write(vv.value)
+	}
+
+	// Encoded timestamp values
+	tb, err := tenc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+	// Encoded string values
+	vb, err := venc.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepend the first timestamp of the block in the first 8 bytes
+	return packBlock(buf, BlockString, tb, vb), nil
 }
 
 // DecodeStringBlock decodes the string block from the byte slice

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -137,8 +137,10 @@ type Engine struct {
 
 	stats *EngineStatistics
 
-	// The limiter for concurrent compactions
-	compactionLimiter limiter.Fixed
+	// Limiters for concurrent compactions.  The low priority limiter is for level 3 and 4
+	// compactions.  The high priority is for level 1 and 2 compactions.
+	loPriCompactionLimiter limiter.Fixed
+	hiPriCompactionLimiter limiter.Fixed
 }
 
 // NewEngine returns a new instance of Engine.
@@ -176,8 +178,9 @@ func NewEngine(id uint64, idx tsdb.Index, database, path string, walPath string,
 		CacheFlushMemorySizeThreshold: opt.Config.CacheSnapshotMemorySize,
 		CacheFlushWriteColdDuration:   time.Duration(opt.Config.CacheSnapshotWriteColdDuration),
 		enableCompactionsOnOpen:       true,
-		stats:             &EngineStatistics{},
-		compactionLimiter: opt.CompactionLimiter,
+		stats: &EngineStatistics{},
+		loPriCompactionLimiter: opt.LoPriCompactionLimiter,
+		hiPriCompactionLimiter: opt.HiPriCompactionLimiter,
 	}
 
 	// Attach fieldset to index.
@@ -1346,46 +1349,33 @@ func (e *Engine) onFileStoreReplace(newFiles []TSMFile) {
 type compactionStrategy struct {
 	compactionGroups []CompactionGroup
 
-	// concurrency determines how many compactions groups will be started
-	// concurrently.  These groups may be limited by the global limiter if
-	// enabled.
-	concurrency int
 	fast        bool
 	description string
+	level       int
 
 	durationStat *int64
 	activeStat   *int64
 	successStat  *int64
 	errorStat    *int64
 
-	logger    zap.Logger
-	compactor *Compactor
-	fileStore *FileStore
-	limiter   limiter.Fixed
-	engine    *Engine
+	logger       zap.Logger
+	compactor    *Compactor
+	fileStore    *FileStore
+	loPriLimiter limiter.Fixed
+	hiPriLimiter limiter.Fixed
+
+	engine *Engine
 }
 
 // Apply concurrently compacts all the groups in a compaction strategy.
 func (s *compactionStrategy) Apply() {
 	start := time.Now()
 
-	// cap concurrent compaction groups to no more than 4 at a time.
-	concurrency := s.concurrency
-	if concurrency == 0 {
-		concurrency = 4
-	}
-
-	throttle := limiter.NewFixed(concurrency)
 	var wg sync.WaitGroup
 	for i := range s.compactionGroups {
 		wg.Add(1)
 		go func(groupNum int) {
 			defer wg.Done()
-
-			// limit concurrent compaction groups
-			throttle.Take()
-			defer throttle.Release()
-
 			s.compactGroup(groupNum)
 		}(i)
 	}
@@ -1396,10 +1386,31 @@ func (s *compactionStrategy) Apply() {
 
 // compactGroup executes the compaction strategy against a single CompactionGroup.
 func (s *compactionStrategy) compactGroup(groupNum int) {
-	// Limit concurrent compactions if we have a limiter
-	if cap(s.limiter) > 0 {
-		s.limiter.Take()
-		defer s.limiter.Release()
+	// Level 1 and 2 are high priority and have a larger slice of the pool.  If all
+	// the high priority capacity is used up, they can steal from the low priority
+	// pool as well if there is capacity.  Otherwise, it wait on the high priority
+	// limiter until an running compaction completes.  Level 3 and 4 are low priority
+	// as they are generally larger compactions and more expensive to run.  They can
+	// steal a little from the high priority limiter if there is no high priority work.
+	switch s.level {
+	case 1, 2:
+		if s.hiPriLimiter.TryTake() {
+			defer s.hiPriLimiter.Release()
+		} else if s.loPriLimiter.TryTake() {
+			defer s.loPriLimiter.Release()
+		} else {
+			s.hiPriLimiter.Take()
+			defer s.hiPriLimiter.Release()
+		}
+	default:
+		if s.loPriLimiter.TryTake() {
+			defer s.loPriLimiter.Release()
+		} else if s.hiPriLimiter.Idle() && s.hiPriLimiter.TryTake() {
+			defer s.hiPriLimiter.Release()
+		} else {
+			s.loPriLimiter.Take()
+			defer s.loPriLimiter.Release()
+		}
 	}
 
 	group := s.compactionGroups[groupNum]
@@ -1462,14 +1473,15 @@ func (e *Engine) levelCompactionStrategy(fast bool, level int) *compactionStrate
 	}
 
 	return &compactionStrategy{
-		concurrency:      4,
 		compactionGroups: compactionGroups,
 		logger:           e.logger,
 		fileStore:        e.FileStore,
 		compactor:        e.Compactor,
 		fast:             fast,
-		limiter:          e.compactionLimiter,
+		loPriLimiter:     e.loPriCompactionLimiter,
+		hiPriLimiter:     e.hiPriCompactionLimiter,
 		engine:           e,
+		level:            level,
 
 		description:  fmt.Sprintf("level %d", level),
 		activeStat:   &e.stats.TSMCompactionsActive[level-1],
@@ -1495,14 +1507,15 @@ func (e *Engine) fullCompactionStrategy() *compactionStrategy {
 	}
 
 	s := &compactionStrategy{
-		concurrency:      1,
 		compactionGroups: compactionGroups,
 		logger:           e.logger,
 		fileStore:        e.FileStore,
 		compactor:        e.Compactor,
 		fast:             optimize,
-		limiter:          e.compactionLimiter,
+		loPriLimiter:     e.loPriCompactionLimiter,
+		hiPriLimiter:     e.hiPriCompactionLimiter,
 		engine:           e,
+		level:            4,
 	}
 
 	if optimize {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -26,6 +26,7 @@ import (
 	"github.com/influxdata/influxdb/tsdb"
 	_ "github.com/influxdata/influxdb/tsdb/index"
 	"github.com/influxdata/influxdb/tsdb/index/inmem"
+	"github.com/influxdata/influxdb/tsdb/index/tsi1"
 	"github.com/uber-go/zap"
 )
 
@@ -1289,6 +1290,10 @@ func (e *Engine) compactTSMFull(quit <-chan struct{}) {
 // onFileStoreReplace is callback handler invoked when the FileStore
 // has replaced one set of TSM files with a new set.
 func (e *Engine) onFileStoreReplace(newFiles []TSMFile) {
+	if e.index.Type() == tsi1.IndexName {
+		return
+	}
+
 	// Load any new series keys to the index
 	readers := make([]chan seriesKey, 0, len(newFiles))
 	for _, r := range newFiles {

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -881,8 +881,9 @@ func TestIndirectIndex_Entries(t *testing.T) {
 	index := NewIndexWriter()
 	index.Add([]byte("cpu"), BlockFloat64, 0, 1, 10, 100)
 	index.Add([]byte("cpu"), BlockFloat64, 2, 3, 20, 200)
-	index.Add([]byte("mem"), BlockFloat64, 0, 1, 10, 100)
 	exp := index.Entries([]byte("cpu"))
+
+	index.Add([]byte("mem"), BlockFloat64, 0, 1, 10, 100)
 
 	b, err := index.MarshalBinary()
 	if err != nil {
@@ -981,26 +982,15 @@ func TestIndirectIndex_Type(t *testing.T) {
 	}
 }
 
-func TestIndirectIndex_Keys(t *testing.T) {
+func TestDirectIndex_KeyCount(t *testing.T) {
 	index := NewIndexWriter()
 	index.Add([]byte("cpu"), BlockFloat64, 0, 1, 10, 20)
 	index.Add([]byte("cpu"), BlockFloat64, 1, 2, 20, 30)
 	index.Add([]byte("mem"), BlockFloat64, 0, 1, 10, 20)
 
-	keys := index.Keys()
-
 	// 2 distinct keys
-	if got, exp := len(keys), 2; got != exp {
+	if got, exp := index.KeyCount(), 2; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
-	}
-
-	// Keys should be sorted
-	if got, exp := string(keys[0]), "cpu"; got != exp {
-		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
-	}
-
-	if got, exp := string(keys[1]), "mem"; got != exp {
-		t.Fatalf("key mismatch: got %v, exp %v", got, exp)
 	}
 }
 

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -315,16 +315,3 @@ func (p *partition) count() int {
 	return n
 
 }
-
-func (p *partition) count() int {
-	var n int
-	p.mu.RLock()
-	for _, v := range p.store {
-		if v.count() > 0 {
-			n++
-		}
-	}
-	p.mu.RUnlock()
-	return n
-
-}

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -315,3 +315,16 @@ func (p *partition) count() int {
 	return n
 
 }
+
+func (p *partition) count() int {
+	var n int
+	p.mu.RLock()
+	for _, v := range p.store {
+		if v.count() > 0 {
+			n++
+		}
+	}
+	p.mu.RUnlock()
+	return n
+
+}

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -32,15 +32,15 @@ const partitions = 4096
 // key is hashed and the first 8 bits are used as an index to the ring.
 //
 type ring struct {
-	// The unique set of partitions in the ring.
-	// len(partitions) <= len(continuum)
-	partitions []*partition
-
 	// Number of keys within the ring. This is used to provide a hint for
 	// allocating the return values in keys(). It will not be perfectly accurate
 	// since it doesn't consider adding duplicate keys, or trying to remove non-
 	// existent keys.
 	keysHint int64
+
+	// The unique set of partitions in the ring.
+	// len(partitions) <= len(continuum)
+	partitions []*partition
 }
 
 // newring returns a new ring initialised with n partitions. n must always be a

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -31,7 +31,7 @@ func TestRing_newRing(t *testing.T) {
 
 		// Check partitions distributed correctly
 		partitions := make([]*partition, 0)
-		for i, partition := range r.continuum {
+		for i, partition := range r.partitions {
 			if i == 0 || partition != partitions[len(partitions)-1] {
 				partitions = append(partitions, partition)
 			}

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -237,7 +237,7 @@ func NewIndexWriter() IndexWriter {
 
 // NewIndexWriter returns a new IndexWriter.
 func NewDiskIndexWriter(f *os.File) IndexWriter {
-	return &directIndex{fd: f, w: bufio.NewWriter(f)}
+	return &directIndex{fd: f, w: bufio.NewWriterSize(f, 1024*1024)}
 }
 
 // indexBlock represent an index information for a series within a TSM file.

--- a/tsdb/engine/tsm1/writer.go
+++ b/tsdb/engine/tsm1/writer.go
@@ -152,9 +152,6 @@ type IndexWriter interface {
 	// Entries returns all index entries for a key.
 	Entries(key []byte) []IndexEntry
 
-	// Keys returns the unique set of keys in the index.
-	Keys() [][]byte
-
 	// KeyCount returns the count of unique keys in the index.
 	KeyCount() int
 
@@ -232,7 +229,8 @@ func (e *IndexEntry) String() string {
 
 // NewIndexWriter returns a new IndexWriter.
 func NewIndexWriter() IndexWriter {
-	return &directIndex{}
+	buf := bytes.NewBuffer(make([]byte, 0, 4096))
+	return &directIndex{buf: buf, w: bufio.NewWriter(buf)}
 }
 
 // NewIndexWriter returns a new IndexWriter.
@@ -249,43 +247,48 @@ type indexBlock struct {
 // directIndex is a simple in-memory index implementation for a TSM file.  The full index
 // must fit in memory.
 type directIndex struct {
-	size   uint32
-	blocks []indexBlock
-	fd     *os.File
-	w      *bufio.Writer
+	keyCount int
+	size     uint32
+	fd       *os.File
+	buf      *bytes.Buffer
+
+	w *bufio.Writer
+
+	key          []byte
+	indexEntries *indexEntries
 }
 
 func (d *directIndex) Add(key []byte, blockType byte, minTime, maxTime int64, offset int64, size uint32) {
 	// Is this the first block being added?
-	if len(d.blocks) == 0 {
+	if len(d.key) == 0 {
 		// size of the key stored in the index
 		d.size += uint32(2 + len(key))
 		// size of the count of entries stored in the index
 		d.size += indexCountSize
 
-		d.blocks = append(d.blocks, indexBlock{
-			key: key,
-			entries: &indexEntries{
-				Type: blockType,
-				entries: []IndexEntry{IndexEntry{
-					MinTime: minTime,
-					MaxTime: maxTime,
-					Offset:  offset,
-					Size:    size,
-				}}},
+		d.key = key
+		if d.indexEntries == nil {
+			d.indexEntries = &indexEntries{}
+		}
+		d.indexEntries.Type = blockType
+		d.indexEntries.entries = append(d.indexEntries.entries, IndexEntry{
+			MinTime: minTime,
+			MaxTime: maxTime,
+			Offset:  offset,
+			Size:    size,
 		})
 
 		// size of the encoded index entry
 		d.size += indexEntrySize
+		d.keyCount++
 		return
 	}
 
-	// Find the last block so we can see if were still adding to the same series key.
-	block := d.blocks[len(d.blocks)-1]
-	cmp := bytes.Compare(block.key, key)
+	// See if were still adding to the same series key.
+	cmp := bytes.Compare(d.key, key)
 	if cmp == 0 {
 		// The last block is still this key
-		block.entries.entries = append(block.entries.entries, IndexEntry{
+		d.indexEntries.entries = append(d.indexEntries.entries, IndexEntry{
 			MinTime: minTime,
 			MaxTime: maxTime,
 			Offset:  offset,
@@ -296,9 +299,7 @@ func (d *directIndex) Add(key []byte, blockType byte, minTime, maxTime int64, of
 		d.size += indexEntrySize
 
 	} else if cmp < 0 {
-		if d.w != nil {
-			d.flush(d.w)
-		}
+		d.flush(d.w)
 		// We have a new key that is greater than the last one so we need to add
 		// a new index block section.
 
@@ -307,38 +308,31 @@ func (d *directIndex) Add(key []byte, blockType byte, minTime, maxTime int64, of
 		// size of the count of entries stored in the index
 		d.size += indexCountSize
 
-		d.blocks = append(d.blocks, indexBlock{
-			key: key,
-			entries: &indexEntries{
-				Type: blockType,
-				entries: []IndexEntry{IndexEntry{
-					MinTime: minTime,
-					MaxTime: maxTime,
-					Offset:  offset,
-					Size:    size,
-				}}},
+		d.key = key
+		d.indexEntries.Type = blockType
+		d.indexEntries.entries = append(d.indexEntries.entries, IndexEntry{
+			MinTime: minTime,
+			MaxTime: maxTime,
+			Offset:  offset,
+			Size:    size,
 		})
 
 		// size of the encoded index entry
 		d.size += indexEntrySize
+		d.keyCount++
 	} else {
 		// Keys can't be added out of order.
-		panic(fmt.Sprintf("keys must be added in sorted order: %s < %s", string(key), string(d.blocks[len(d.blocks)-1].key)))
+		panic(fmt.Sprintf("keys must be added in sorted order: %s < %s", string(key), string(d.key)))
 	}
 }
 
 func (d *directIndex) entries(key []byte) []IndexEntry {
-	if len(d.blocks) == 0 {
+	if len(d.key) == 0 {
 		return nil
 	}
 
-	if bytes.Equal(d.blocks[len(d.blocks)-1].key, key) {
-		return d.blocks[len(d.blocks)-1].entries.entries
-	}
-
-	i := sort.Search(len(d.blocks), func(i int) bool { return bytes.Compare(d.blocks[i].key, key) >= 0 })
-	if i < len(d.blocks) && bytes.Equal(d.blocks[i].key, key) {
-		return d.blocks[i].entries.entries
+	if bytes.Equal(d.key, key) {
+		return d.indexEntries.entries
 	}
 
 	return nil
@@ -358,29 +352,21 @@ func (d *directIndex) Entry(key []byte, t int64) *IndexEntry {
 	return nil
 }
 
-func (d *directIndex) Keys() [][]byte {
-	keys := make([][]byte, 0, len(d.blocks))
-	for _, v := range d.blocks {
-		keys = append(keys, v.key)
-	}
-	return keys
-}
-
 func (d *directIndex) KeyCount() int {
-	return len(d.blocks)
+	return d.keyCount
 }
 
 func (d *directIndex) WriteTo(w io.Writer) (int64, error) {
-	if d.w == nil {
-		return d.flush(w)
-	}
-
 	if _, err := d.flush(d.w); err != nil {
 		return 0, err
 	}
 
 	if err := d.w.Flush(); err != nil {
 		return 0, err
+	}
+
+	if d.fd == nil {
+		return io.Copy(w, d.buf)
 	}
 
 	if _, err := d.fd.Seek(0, io.SeekStart); err != nil {
@@ -398,50 +384,52 @@ func (d *directIndex) flush(w io.Writer) (int64, error) {
 		N   int64
 	)
 
+	if len(d.key) == 0 {
+		return 0, nil
+	}
 	// For each key, individual entries are sorted by time
-	for _, ie := range d.blocks {
-		key := ie.key
-		entries := ie.entries
+	key := d.key
+	entries := d.indexEntries
 
-		if entries.Len() > maxIndexEntries {
-			return N, fmt.Errorf("key '%s' exceeds max index entries: %d > %d", key, entries.Len(), maxIndexEntries)
-		}
-
-		if !sort.IsSorted(entries) {
-			sort.Sort(entries)
-		}
-
-		binary.BigEndian.PutUint16(buf[0:2], uint16(len(key)))
-		buf[2] = entries.Type
-		binary.BigEndian.PutUint16(buf[3:5], uint16(entries.Len()))
-
-		// Append the key length and key
-		if n, err = w.Write(buf[0:2]); err != nil {
-			return int64(n) + N, fmt.Errorf("write: writer key length error: %v", err)
-		}
-		N += int64(n)
-
-		if n, err = w.Write(key); err != nil {
-			return int64(n) + N, fmt.Errorf("write: writer key error: %v", err)
-		}
-		N += int64(n)
-
-		// Append the block type and count
-		if n, err = w.Write(buf[2:5]); err != nil {
-			return int64(n) + N, fmt.Errorf("write: writer block type and count error: %v", err)
-		}
-		N += int64(n)
-
-		// Append each index entry for all blocks for this key
-		var n64 int64
-		if n64, err = entries.WriteTo(w); err != nil {
-			return n64 + N, fmt.Errorf("write: writer entries error: %v", err)
-		}
-		N += n64
-
+	if entries.Len() > maxIndexEntries {
+		return N, fmt.Errorf("key '%s' exceeds max index entries: %d > %d", key, entries.Len(), maxIndexEntries)
 	}
 
-	d.blocks = d.blocks[:0]
+	if !sort.IsSorted(entries) {
+		sort.Sort(entries)
+	}
+
+	binary.BigEndian.PutUint16(buf[0:2], uint16(len(key)))
+	buf[2] = entries.Type
+	binary.BigEndian.PutUint16(buf[3:5], uint16(entries.Len()))
+
+	// Append the key length and key
+	if n, err = w.Write(buf[0:2]); err != nil {
+		return int64(n) + N, fmt.Errorf("write: writer key length error: %v", err)
+	}
+	N += int64(n)
+
+	if n, err = w.Write(key); err != nil {
+		return int64(n) + N, fmt.Errorf("write: writer key error: %v", err)
+	}
+	N += int64(n)
+
+	// Append the block type and count
+	if n, err = w.Write(buf[2:5]); err != nil {
+		return int64(n) + N, fmt.Errorf("write: writer block type and count error: %v", err)
+	}
+	N += int64(n)
+
+	// Append each index entry for all blocks for this key
+	var n64 int64
+	if n64, err = entries.WriteTo(w); err != nil {
+		return n64 + N, fmt.Errorf("write: writer entries error: %v", err)
+	}
+	N += n64
+
+	d.key = nil
+	d.indexEntries.Type = 0
+	d.indexEntries.entries = d.indexEntries.entries[:0]
 
 	return N, nil
 
@@ -460,14 +448,15 @@ func (d *directIndex) Size() uint32 {
 }
 
 func (d *directIndex) Close() error {
-	if d.w == nil {
-		return nil
-	}
-
 	// Flush anything remaining in the index
 	if err := d.w.Flush(); err != nil {
 		return err
 	}
+
+	if d.fd == nil {
+		return nil
+	}
+
 	if err := d.fd.Close(); err != nil {
 		return nil
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This improves TSM cache snapshot throughput for higher cardinalities.  It allows the cache to be snapshotted faster which can prevent OOMs and cache max memory errors from being hit.