### PR TITLE
Improve performance of TSI Bloom Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [#8854](https://github.com/influxdata/influxdb/pull/8854): Report the task status for a query.
 - [#8853](https://github.com/influxdata/influxdb/pull/8853): Reduce allocations, improve `readEntries` performance by simplifying loop
 - [#8830](https://github.com/influxdata/influxdb/issues/8830): Separate importer log statements to stdout and stderr.
+- [#8857](https://github.com/influxdata/influxdb/pull/8857): Improve performance of Bloom Filter in TSI index.
 
 ### Bugfixes
 

--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -26,7 +26,7 @@ type Filter struct {
 // If m is not a power of two then it is rounded to the next highest power of 2.
 func NewFilter(m uint64, k uint64) *Filter {
 	m = pow2(m)
-	return &Filter{k: k, b: make([]byte, m/8), mask: m - 1}
+	return &Filter{k: k, b: make([]byte, m>>3), mask: m - 1}
 }
 
 // NewFilterBuffer returns a new instance of a filter using a backing buffer.
@@ -60,7 +60,7 @@ func (f *Filter) Insert(v []byte) {
 	h := f.hash(v)
 	for i := uint64(0); i < f.k; i++ {
 		loc := f.location(h, i)
-		f.b[loc/8] |= 1 << (loc % 8)
+		f.b[loc>>3] |= 1 << (loc & 7)
 	}
 }
 
@@ -70,7 +70,7 @@ func (f *Filter) Contains(v []byte) bool {
 	h := f.hash(v)
 	for i := uint64(0); i < f.k; i++ {
 		loc := f.location(h, i)
-		if f.b[loc/8]&(1<<(loc%8)) == 0 {
+		if f.b[loc>>3]&(1<<(loc&7)) == 0 {
 			return false
 		}
 	}

--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -2,8 +2,9 @@ package bloom
 
 // NOTE:
 // This package implements a limited bloom filter implementation based on
-// Will Fitzgerald's bloom & bitset packages. It's implemented locally to
-// support zero-copy memory-mapped slices.
+// Will Fitzgerald's bloom & bitset packages. It uses a zero-allocation xxhash
+// implementation, rather than murmur3. It's implemented locally to support
+// zero-copy memory-mapped slices.
 //
 // This also optimizes the filter by always using a bitset size with a power of 2.
 
@@ -11,31 +12,21 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/influxdata/influxdb/pkg/pool"
-	"github.com/spaolacci/murmur3"
+	"github.com/cespare/xxhash"
 )
 
 // Filter represents a bloom filter.
 type Filter struct {
-	k        uint64
-	b        []byte
-	mask     uint64
-	hashPool *pool.Generic
+	k    uint64
+	b    []byte
+	mask uint64
 }
 
 // NewFilter returns a new instance of Filter using m bits and k hash functions.
 // If m is not a power of two then it is rounded to the next highest power of 2.
 func NewFilter(m uint64, k uint64) *Filter {
 	m = pow2(m)
-
-	return &Filter{
-		k:    k,
-		b:    make([]byte, m/8),
-		mask: m - 1,
-		hashPool: pool.NewGeneric(16, func(sz int) interface{} {
-			return murmur3.New128()
-		}),
-	}
+	return &Filter{k: k, b: make([]byte, m/8), mask: m - 1}
 }
 
 // NewFilterBuffer returns a new instance of a filter using a backing buffer.
@@ -45,15 +36,7 @@ func NewFilterBuffer(buf []byte, k uint64) (*Filter, error) {
 	if m != uint64(len(buf))*8 {
 		return nil, fmt.Errorf("bloom.Filter: buffer bit count must a power of two: %d/%d", len(buf)*8, m)
 	}
-
-	return &Filter{
-		k:    k,
-		b:    buf,
-		mask: m - 1,
-		hashPool: pool.NewGeneric(16, func(sz int) interface{} {
-			return murmur3.New128()
-		}),
-	}, nil
+	return &Filter{k: k, b: buf, mask: m - 1}, nil
 }
 
 // Len returns the number of bits used in the filter.
@@ -67,7 +50,7 @@ func (f *Filter) Bytes() []byte { return f.b }
 
 // Clone returns a copy of f.
 func (f *Filter) Clone() *Filter {
-	other := &Filter{k: f.k, b: make([]byte, len(f.b)), mask: f.mask, hashPool: f.hashPool}
+	other := &Filter{k: f.k, b: make([]byte, len(f.b)), mask: f.mask}
 	copy(other.b, f.b)
 	return other
 }
@@ -116,21 +99,22 @@ func (f *Filter) Merge(other *Filter) error {
 	return nil
 }
 
-// location returns the ith hashed location using the four base hash values.
-func (f *Filter) location(h [4]uint64, i uint64) uint {
-	return uint((h[i%2] + i*h[2+(((i+(i%2))%4)/2)]) & f.mask)
+// location returns the ith hashed location using two hash values.
+func (f *Filter) location(h [2]uint64, i uint64) uint {
+	return uint((h[0] + h[1]*i) & f.mask)
 }
 
-// hash returns a set of 4 based hashes.
-func (f *Filter) hash(data []byte) [4]uint64 {
-	h := f.hashPool.Get(0).(murmur3.Hash128)
-	defer f.hashPool.Put(h)
-	h.Reset()
-	h.Write(data)
-	v1, v2 := h.Sum128()
-	h.Write([]byte{1})
-	v3, v4 := h.Sum128()
-	return [4]uint64{v1, v2, v3, v4}
+// hash returns two 64-bit hashes based on the output of xxhash.
+func (f *Filter) hash(data []byte) [2]uint64 {
+	v1 := xxhash.Sum64(data)
+	var v2 uint64
+	if len(data) > 0 {
+		b := data[len(data)-1] // We'll put the original byte back.
+		data[len(data)-1] = byte(0)
+		v2 = xxhash.Sum64(data)
+		data[len(data)-1] = b
+	}
+	return [2]uint64{v1, v2}
 }
 
 // Estimate returns an estimated bit count and hash count given the element count and false positive rate.

--- a/pkg/bloom/bloom_test.go
+++ b/pkg/bloom/bloom_test.go
@@ -1,6 +1,7 @@
 package bloom_test
 
 import (
+	"encoding/binary"
 	"fmt"
 	"testing"
 
@@ -9,46 +10,97 @@ import (
 
 // Ensure filter can insert values and verify they exist.
 func TestFilter_InsertContains(t *testing.T) {
-	f := bloom.NewFilter(1000, 4)
+	// Short, less comprehensive test.
+	testShortFilter_InsertContains(t)
 
-	// Insert value and validate.
-	f.Insert([]byte("Bess"))
-	if !f.Contains([]byte("Bess")) {
-		t.Fatal("expected true")
+	if testing.Short() {
+		return // Just run the above short test
 	}
 
-	// Insert another value and test.
-	f.Insert([]byte("Emma"))
-	if !f.Contains([]byte("Emma")) {
-		t.Fatal("expected true")
+	// More comprehensive test for the xxhash based Bloom Filter.
+
+	// These parameters will result, for 10M entries, with a bloom filter
+	// with 0.001 false positive rate (1 in 1000 values will be incorrectly
+	// identified as being present in the set).
+	filter := bloom.NewFilter(143775876, 10)
+	v := make([]byte, 4, 4)
+	for i := 0; i < 10000000; i++ {
+		binary.BigEndian.PutUint32(v, uint32(i))
+		filter.Insert(v)
 	}
 
-	// Validate that a non-existent value doesn't exist.
-	if f.Contains([]byte("Jane")) {
-		t.Fatal("expected false")
-	}
+	// None of the values inserted should ever be considered "not possibly in
+	// the filter".
+	t.Run("100M", func(t *testing.T) {
+		for i := 0; i < 10000000; i++ {
+			binary.BigEndian.PutUint32(v, uint32(i))
+			if !filter.Contains(v) {
+				t.Fatalf("got false for value %q, expected true", v)
+			}
+		}
+
+		// If we check for 100,000,000 values that we know are not present in the
+		// filter then we might expect around 100,000 of them to be false positives.
+		var fp int
+		for i := 10000000; i < 110000000; i++ {
+			binary.BigEndian.PutUint32(v, uint32(i))
+			if filter.Contains(v) {
+				fp++
+			}
+		}
+
+		if fp > 1000000 {
+			// If we're an order of magnitude off, then it's arguable that there
+			// is a bug in the bloom filter.
+			t.Fatalf("got %d false positives which is an error rate of %f, expected error rate <=0.001", fp, float64(fp)/100000000)
+		}
+		t.Logf("Bloom false positive error rate was %f", float64(fp)/100000000)
+	})
+}
+
+func testShortFilter_InsertContains(t *testing.T) {
+	t.Run("short", func(t *testing.T) {
+		f := bloom.NewFilter(1000, 4)
+
+		// Insert value and validate.
+		f.Insert([]byte("Bess"))
+		if !f.Contains([]byte("Bess")) {
+			t.Fatal("expected true")
+		}
+
+		// Insert another value and test.
+		f.Insert([]byte("Emma"))
+		if !f.Contains([]byte("Emma")) {
+			t.Fatal("expected true")
+		}
+
+		// Validate that a non-existent value doesn't exist.
+		if f.Contains([]byte("Jane")) {
+			t.Fatal("expected false")
+		}
+	})
+}
+
+var benchCases = []struct {
+	m, k uint64
+	n    int
+}{
+	{m: 100, k: 4, n: 1000},
+	{m: 1000, k: 4, n: 1000},
+	{m: 10000, k: 4, n: 1000},
+	{m: 100000, k: 4, n: 1000},
+	{m: 100, k: 8, n: 1000},
+	{m: 1000, k: 8, n: 1000},
+	{m: 10000, k: 8, n: 1000},
+	{m: 100000, k: 8, n: 1000},
+	{m: 100, k: 20, n: 1000},
+	{m: 1000, k: 20, n: 1000},
+	{m: 10000, k: 20, n: 1000},
+	{m: 100000, k: 20, n: 1000},
 }
 
 func BenchmarkFilter_Insert(b *testing.B) {
-	cases := []struct {
-		m, k uint64
-		n    int
-	}{
-		{m: 100, k: 4, n: 1000},
-		{m: 1000, k: 4, n: 1000},
-		{m: 10000, k: 4, n: 1000},
-		{m: 100000, k: 4, n: 1000},
-		{m: 100, k: 8, n: 1000},
-		{m: 1000, k: 8, n: 1000},
-		{m: 10000, k: 8, n: 1000},
-		{m: 100000, k: 8, n: 1000},
-		{m: 100, k: 20, n: 1000},
-		{m: 1000, k: 20, n: 1000},
-		{m: 10000, k: 20, n: 1000},
-		{m: 100000, k: 20, n: 1000},
-	}
-
-	for _, c := range cases {
+	for _, c := range benchCases {
 		data := make([][]byte, 0, c.n)
 		for i := 0; i < c.n; i++ {
 			data = append(data, []byte(fmt.Sprintf("%d", i)))
@@ -63,31 +115,14 @@ func BenchmarkFilter_Insert(b *testing.B) {
 				}
 			}
 		})
+
 	}
 }
 
 var okResult bool
 
 func BenchmarkFilter_Contains(b *testing.B) {
-	cases := []struct {
-		m, k uint64
-		n    int
-	}{
-		{m: 100, k: 4, n: 1000},
-		{m: 1000, k: 4, n: 1000},
-		{m: 10000, k: 4, n: 1000},
-		{m: 100000, k: 4, n: 1000},
-		{m: 100, k: 8, n: 1000},
-		{m: 1000, k: 8, n: 1000},
-		{m: 10000, k: 8, n: 1000},
-		{m: 100000, k: 8, n: 1000},
-		{m: 100, k: 20, n: 1000},
-		{m: 1000, k: 20, n: 1000},
-		{m: 10000, k: 20, n: 1000},
-		{m: 100000, k: 20, n: 1000},
-	}
-
-	for _, c := range cases {
+	for _, c := range benchCases {
 		data := make([][]byte, 0, c.n)
 		notData := make([][]byte, 0, c.n)
 		for i := 0; i < c.n; i++ {
@@ -120,25 +155,7 @@ func BenchmarkFilter_Contains(b *testing.B) {
 }
 
 func BenchmarkFilter_Merge(b *testing.B) {
-	cases := []struct {
-		m, k uint64
-		n    int
-	}{
-		{m: 100, k: 4, n: 1000},
-		{m: 1000, k: 4, n: 1000},
-		{m: 10000, k: 4, n: 1000},
-		{m: 100000, k: 4, n: 1000},
-		{m: 100, k: 8, n: 1000},
-		{m: 1000, k: 8, n: 1000},
-		{m: 10000, k: 8, n: 1000},
-		{m: 100000, k: 8, n: 1000},
-		{m: 100, k: 20, n: 1000},
-		{m: 1000, k: 20, n: 1000},
-		{m: 10000, k: 20, n: 1000},
-		{m: 100000, k: 20, n: 1000},
-	}
-
-	for _, c := range cases {
+	for _, c := range benchCases {
 		data1 := make([][]byte, 0, c.n)
 		data2 := make([][]byte, 0, c.n)
 		for i := 0; i < c.n; i++ {

--- a/pkg/bloom/bloom_test.go
+++ b/pkg/bloom/bloom_test.go
@@ -1,6 +1,7 @@
 package bloom_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/influxdata/influxdb/pkg/bloom"
@@ -25,5 +26,142 @@ func TestFilter_InsertContains(t *testing.T) {
 	// Validate that a non-existent value doesn't exist.
 	if f.Contains([]byte("Jane")) {
 		t.Fatal("expected false")
+	}
+}
+
+func BenchmarkFilter_Insert(b *testing.B) {
+	cases := []struct {
+		m, k uint64
+		n    int
+	}{
+		{m: 100, k: 4, n: 1000},
+		{m: 1000, k: 4, n: 1000},
+		{m: 10000, k: 4, n: 1000},
+		{m: 100000, k: 4, n: 1000},
+		{m: 100, k: 8, n: 1000},
+		{m: 1000, k: 8, n: 1000},
+		{m: 10000, k: 8, n: 1000},
+		{m: 100000, k: 8, n: 1000},
+		{m: 100, k: 20, n: 1000},
+		{m: 1000, k: 20, n: 1000},
+		{m: 10000, k: 20, n: 1000},
+		{m: 100000, k: 20, n: 1000},
+	}
+
+	for _, c := range cases {
+		data := make([][]byte, 0, c.n)
+		for i := 0; i < c.n; i++ {
+			data = append(data, []byte(fmt.Sprintf("%d", i)))
+		}
+
+		filter := bloom.NewFilter(c.m, c.k)
+		b.Run(fmt.Sprintf("m=%d_k=%d_n=%d", c.m, c.k, c.n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				for _, v := range data {
+					filter.Insert(v)
+				}
+			}
+		})
+	}
+}
+
+var okResult bool
+
+func BenchmarkFilter_Contains(b *testing.B) {
+	cases := []struct {
+		m, k uint64
+		n    int
+	}{
+		{m: 100, k: 4, n: 1000},
+		{m: 1000, k: 4, n: 1000},
+		{m: 10000, k: 4, n: 1000},
+		{m: 100000, k: 4, n: 1000},
+		{m: 100, k: 8, n: 1000},
+		{m: 1000, k: 8, n: 1000},
+		{m: 10000, k: 8, n: 1000},
+		{m: 100000, k: 8, n: 1000},
+		{m: 100, k: 20, n: 1000},
+		{m: 1000, k: 20, n: 1000},
+		{m: 10000, k: 20, n: 1000},
+		{m: 100000, k: 20, n: 1000},
+	}
+
+	for _, c := range cases {
+		data := make([][]byte, 0, c.n)
+		notData := make([][]byte, 0, c.n)
+		for i := 0; i < c.n; i++ {
+			data = append(data, []byte(fmt.Sprintf("%d", i)))
+			notData = append(notData, []byte(fmt.Sprintf("%d", c.n+i)))
+		}
+
+		filter := bloom.NewFilter(c.m, c.k)
+		for _, v := range data {
+			filter.Insert(v)
+		}
+
+		b.Run(fmt.Sprintf("m=%d_k=%d_n=%d", c.m, c.k, c.n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				for _, v := range data {
+					okResult = filter.Contains(v)
+					if !okResult {
+						b.Fatalf("Filter returned negative for value %q in set", v)
+					}
+				}
+
+				// And now a bunch of values that don't exist.
+				for _, v := range notData {
+					okResult = filter.Contains(v)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkFilter_Merge(b *testing.B) {
+	cases := []struct {
+		m, k uint64
+		n    int
+	}{
+		{m: 100, k: 4, n: 1000},
+		{m: 1000, k: 4, n: 1000},
+		{m: 10000, k: 4, n: 1000},
+		{m: 100000, k: 4, n: 1000},
+		{m: 100, k: 8, n: 1000},
+		{m: 1000, k: 8, n: 1000},
+		{m: 10000, k: 8, n: 1000},
+		{m: 100000, k: 8, n: 1000},
+		{m: 100, k: 20, n: 1000},
+		{m: 1000, k: 20, n: 1000},
+		{m: 10000, k: 20, n: 1000},
+		{m: 100000, k: 20, n: 1000},
+	}
+
+	for _, c := range cases {
+		data1 := make([][]byte, 0, c.n)
+		data2 := make([][]byte, 0, c.n)
+		for i := 0; i < c.n; i++ {
+			data1 = append(data1, []byte(fmt.Sprintf("%d", i)))
+			data2 = append(data2, []byte(fmt.Sprintf("%d", c.n+i)))
+		}
+
+		filter1 := bloom.NewFilter(c.m, c.k)
+		filter2 := bloom.NewFilter(c.m, c.k)
+		for i := 0; i < c.n; i++ {
+			filter1.Insert(data1[i])
+			filter2.Insert(data2[i])
+		}
+
+		b.Run(fmt.Sprintf("m=%d_k=%d_n=%d", c.m, c.k, c.n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				other, err := bloom.NewFilterBuffer(filter1.Bytes(), filter1.K())
+				if err != nil {
+					b.Fatal(err)
+				}
+				other.Merge(filter2)
+			}
+		})
 	}
 }

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -23,8 +23,13 @@ import (
 	"github.com/uber-go/zap"
 )
 
-// IndexName is the name of the index.
-const IndexName = "tsi1"
+const (
+	// IndexName is the name of the index.
+	IndexName = "tsi1"
+
+	// Version is the current version of the TSI index.
+	Version = 1
+)
 
 // Default compaction thresholds.
 const (
@@ -95,6 +100,9 @@ type Index struct {
 	CompactionMonitorInterval time.Duration
 
 	logger zap.Logger
+
+	// Index's version.
+	version int
 }
 
 // NewIndex returns a new instance of Index.
@@ -106,9 +114,14 @@ func NewIndex() *Index {
 		MaxLogFileSize:    DefaultMaxLogFileSize,
 		CompactionEnabled: true,
 
-		logger: zap.New(zap.NullEncoder()),
+		logger:  zap.New(zap.NullEncoder()),
+		version: Version,
 	}
 }
+
+// ErrIncompatibleVersion is returned when attempting to read from an
+// incompatible tsi1 manifest file.
+var ErrIncompatibleVersion = errors.New("incompatible tsi1 index MANIFEST")
 
 func (i *Index) Type() string { return IndexName }
 
@@ -131,6 +144,11 @@ func (i *Index) Open() error {
 	if os.IsNotExist(err) {
 		m = NewManifest()
 	} else if err != nil {
+		return err
+	}
+
+	// Check to see if the MANIFEST file is compatible with the current Index.
+	if err := m.Validate(); err != nil {
 		return err
 	}
 
@@ -287,8 +305,9 @@ func (i *Index) ManifestPath() string {
 // Manifest returns a manifest for the index.
 func (i *Index) Manifest() *Manifest {
 	m := &Manifest{
-		Levels: i.levels,
-		Files:  make([]string, len(i.fileSet.files)),
+		Levels:  i.levels,
+		Files:   make([]string, len(i.fileSet.files)),
+		Version: i.version,
 	}
 
 	for j, f := range i.fileSet.files {
@@ -1221,12 +1240,16 @@ func ParseFilename(name string) (level, id int) {
 type Manifest struct {
 	Levels []CompactionLevel `json:"levels,omitempty"`
 	Files  []string          `json:"files,omitempty"`
+
+	// Version should be updated whenever the TSI format has changed.
+	Version int `json:"version,omitempty"`
 }
 
 // NewManifest returns a new instance of Manifest with default compaction levels.
 func NewManifest() *Manifest {
 	m := &Manifest{
-		Levels: make([]CompactionLevel, len(DefaultCompactionLevels)),
+		Levels:  make([]CompactionLevel, len(DefaultCompactionLevels)),
+		Version: Version,
 	}
 	copy(m.Levels, DefaultCompactionLevels[:])
 	return m
@@ -1240,6 +1263,17 @@ func (m *Manifest) HasFile(name string) bool {
 		}
 	}
 	return false
+}
+
+// Validate checks if the Manifest's version is compatible with this version
+// of the tsi1 index.
+func (m *Manifest) Validate() error {
+	// If we don't have an explicit version in the manifest file then we know
+	// it's not compatible with the latest tsi1 Index.
+	if m.Version != Version {
+		return ErrIncompatibleVersion
+	}
+	return nil
 }
 
 // ReadManifestFile reads a manifest from a file path.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated

This PR changes the hashing regime currently used in the TSI Bloom Filter (`murmur3`) to `xxhash`, and also, using the linear combination of two hashes trick, reduces the number of hashes generated per `Contains`/`Insert` call from two to one.

Further, allocations have been eradicated since `xxhash` is allocation-free. This allows us to remove the existing pool of hashers.

The overall improvement in performance is about **5x** .

### Note
Since this changes the hashing functions used to lookup the (possible) existence of series in TSI index files, any existing TSI files are no longer going to work. Anyone who has existing TSI indexes will need to remove them (which will put the shard back on the `inmem` index), and then recreate a TSI index using the `influx_inspect inmem2tsi` tool.

### Benchmarks
```
edd@work:~|⇒  benchstat old_bloom.txt new_bloom.txt  
name                                     old time/op    new time/op    delta
Filter_Insert/m=100_k=4_n=1000-24           258µs ± 3%      53µs ± 2%   -79.47%  (p=0.000 n=10+10)
Filter_Insert/m=1000_k=4_n=1000-24          257µs ± 3%      53µs ± 1%   -79.50%  (p=0.000 n=10+10)
Filter_Insert/m=10000_k=4_n=1000-24         255µs ± 4%      52µs ± 2%   -79.54%  (p=0.000 n=10+10)
Filter_Insert/m=100000_k=4_n=1000-24        260µs ± 2%      57µs ± 1%   -78.22%  (p=0.000 n=10+10)
Filter_Insert/m=100_k=8_n=1000-24           273µs ± 3%      65µs ± 2%   -76.17%  (p=0.000 n=10+10)
Filter_Insert/m=1000_k=8_n=1000-24          275µs ± 2%      65µs ± 2%   -76.27%  (p=0.000 n=10+10)
Filter_Insert/m=10000_k=8_n=1000-24         274µs ± 3%      65µs ± 2%   -76.26%  (p=0.000 n=10+10)
Filter_Insert/m=100000_k=8_n=1000-24        274µs ± 2%      66µs ± 1%   -76.05%  (p=0.000 n=10+9)
Filter_Insert/m=100_k=20_n=1000-24          314µs ± 2%     113µs ± 1%   -64.09%  (p=0.000 n=10+9)
Filter_Insert/m=1000_k=20_n=1000-24         315µs ± 2%     113µs ± 1%   -64.08%  (p=0.000 n=10+9)
Filter_Insert/m=10000_k=20_n=1000-24        311µs ± 0%     112µs ± 2%   -64.16%  (p=0.000 n=6+10)
Filter_Insert/m=100000_k=20_n=1000-24       317µs ± 2%     111µs ± 2%   -65.11%  (p=0.000 n=9+10)
Filter_Contains/m=100_k=4_n=1000-24         503µs ± 3%      76µs ± 2%   -84.84%  (p=0.000 n=10+10)
Filter_Contains/m=1000_k=4_n=1000-24        507µs ± 2%      78µs ± 1%   -84.58%  (p=0.000 n=9+10)
Filter_Contains/m=10000_k=4_n=1000-24       529µs ± 4%      80µs ± 1%   -84.90%  (p=0.000 n=10+10)
Filter_Contains/m=100000_k=4_n=1000-24      510µs ± 4%      76µs ± 2%   -85.17%  (p=0.000 n=9+10)
Filter_Contains/m=100_k=8_n=1000-24         526µs ± 4%     101µs ± 2%   -80.81%  (p=0.000 n=10+10)
Filter_Contains/m=1000_k=8_n=1000-24        524µs ± 4%     101µs ± 1%   -80.63%  (p=0.000 n=10+10)
Filter_Contains/m=10000_k=8_n=1000-24       531µs ± 5%      97µs ± 1%   -81.78%  (p=0.000 n=10+10)
Filter_Contains/m=100000_k=8_n=1000-24      536µs ± 2%      86µs ± 1%   -84.04%  (p=0.000 n=10+10)
Filter_Contains/m=100_k=20_n=1000-24        604µs ± 4%     137µs ± 2%   -77.38%  (p=0.000 n=10+10)
Filter_Contains/m=1000_k=20_n=1000-24       596µs ± 3%     136µs ± 1%   -77.23%  (p=0.000 n=10+10)
Filter_Contains/m=10000_k=20_n=1000-24      580µs ± 4%     125µs ± 0%   -78.51%  (p=0.000 n=10+8)
Filter_Contains/m=100000_k=20_n=1000-24     560µs ± 5%     107µs ± 1%   -80.82%  (p=0.000 n=10+8)
Filter_Merge/m=100_k=4_n=1000-24            411ns ± 3%     406ns ± 1%      ~     (p=0.265 n=10+9)
Filter_Merge/m=1000_k=4_n=1000-24           648ns ± 1%     604ns ± 1%    -6.79%  (p=0.000 n=10+10)
Filter_Merge/m=10000_k=4_n=1000-24         4.45µs ± 8%    3.95µs ± 6%   -11.31%  (p=0.000 n=10+10)
Filter_Merge/m=100000_k=4_n=1000-24        23.8µs ±21%    21.9µs ±17%      ~     (p=0.123 n=10+10)
Filter_Merge/m=100_k=8_n=1000-24            422ns ± 1%     411ns ± 1%    -2.50%  (p=0.000 n=9+9)
Filter_Merge/m=1000_k=8_n=1000-24           625ns ± 2%     614ns ± 1%    -1.78%  (p=0.001 n=10+10)
Filter_Merge/m=10000_k=8_n=1000-24         4.48µs ± 7%    3.78µs ± 5%   -15.57%  (p=0.000 n=10+10)
Filter_Merge/m=100000_k=8_n=1000-24        23.1µs ±20%    27.0µs ±11%   +16.76%  (p=0.002 n=10+10)
Filter_Merge/m=100_k=20_n=1000-24           421ns ± 1%     412ns ± 1%    -2.02%  (p=0.000 n=10+10)
Filter_Merge/m=1000_k=20_n=1000-24          625ns ± 2%     612ns ± 2%    -2.10%  (p=0.000 n=10+10)
Filter_Merge/m=10000_k=20_n=1000-24        3.51µs ± 3%    3.62µs ± 3%    +2.92%  (p=0.012 n=8+10)
Filter_Merge/m=100000_k=20_n=1000-24       26.4µs ±10%    27.0µs ±19%      ~     (p=0.549 n=9+10)

name                                     old alloc/op   new alloc/op   delta
Filter_Insert/m=100_k=4_n=1000-24          1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=9+10)
Filter_Insert/m=1000_k=4_n=1000-24         1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=10000_k=4_n=1000-24        1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=100000_k=4_n=1000-24       1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=100_k=8_n=1000-24          1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=1000_k=8_n=1000-24         1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=10000_k=8_n=1000-24        1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=100000_k=8_n=1000-24       1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=100_k=20_n=1000-24         1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=1000_k=20_n=1000-24        1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=10000_k=20_n=1000-24       1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Insert/m=100000_k=20_n=1000-24      1.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=100_k=4_n=1000-24        2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=1000_k=4_n=1000-24       2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=10000_k=4_n=1000-24      2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=100000_k=4_n=1000-24     2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=100_k=8_n=1000-24        2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=1000_k=8_n=1000-24       2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=10000_k=8_n=1000-24      2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=100000_k=8_n=1000-24     2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=100_k=20_n=1000-24       2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=1000_k=20_n=1000-24      2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=10000_k=20_n=1000-24     2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Contains/m=100000_k=20_n=1000-24    2.00kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Filter_Merge/m=100_k=4_n=1000-24             416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=1000_k=4_n=1000-24            416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=10000_k=4_n=1000-24           416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=100000_k=4_n=1000-24          416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=100_k=8_n=1000-24             416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=1000_k=8_n=1000-24            416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=10000_k=8_n=1000-24           416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=100000_k=8_n=1000-24          416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=100_k=20_n=1000-24            416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=1000_k=20_n=1000-24           416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=10000_k=20_n=1000-24          416B ± 0%      416B ± 0%      ~     (all equal)
Filter_Merge/m=100000_k=20_n=1000-24         416B ± 0%      416B ± 0%      ~     (all equal)
```