### PR TITLE
Fix long process stalls

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -944,7 +944,7 @@ func (c *Compactor) writeNewFiles(generation, sequence int, iter KeyIterator) ([
 }
 
 func (c *Compactor) write(path string, iter KeyIterator) (err error) {
-	fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0666)
+	fd, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_EXCL|os.O_SYNC, 0666)
 	if err != nil {
 		return errCompactionInProgress{err: err}
 	}

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -20,10 +20,6 @@ func mmap(f *os.File, offset int64, length int) ([]byte, error) {
 		return nil, err
 	}
 
-	if err := unix.Madvise(mmap, syscall.MADV_RANDOM); err != nil {
-		return nil, err
-	}
-
 	return mmap, nil
 }
 

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -557,7 +557,7 @@ func (l *WAL) newSegmentFile() error {
 	}
 
 	fileName := filepath.Join(l.path, fmt.Sprintf("%s%05d.%s", WALFilePrefix, l.currentSegmentID, WALFileExtension))
-	fd, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR, 0666)
+	fd, err := os.OpenFile(fileName, os.O_CREATE|os.O_RDWR|os.O_SYNC, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes some very long stalls due to major page faults and `fsyncs` which can cause write timeouts.  #8829 inadvertently added `MADV_RANDOM` which ends up triggering lots of major page faults when a larger full compaction runs.  When the compaction accesses the memory mapped TSM files, the process is paused during the page fault.    The graph below shows what it looked like before under some workloads:

![screen shot 2017-09-22 at 4 07 48 pm](https://user-images.githubusercontent.com/219935/30825855-c4537c94-a1f1-11e7-9346-54966c8e755e.png)

Removing the `MADV_RANDOM` fixed the very large stalls, but we still had periodic timeouts where the writes were waiting for `fsyncs` to complete.  Switching the WAL and new TSM files to use `O_SYNC` causes the writes to hit disk during the actual write request and reduces the amount of data that might need to be fsync'd   This fixes the periodic write timeouts as well.

![screen shot 2017-09-25 at 1 08 33 pm](https://user-images.githubusercontent.com/219935/30826143-ae6298b0-a1f2-11e7-81f5-dfa28f8344fa.png)