### PR TITLE
Do not report an error when dropping a CQ on a non-existent DB/RP

### DIFF
--- a/services/meta/client_test.go
+++ b/services/meta/client_test.go
@@ -808,9 +808,9 @@ func TestMetaClient_ContinuousQueries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Dropping a nonexistent CQ should return an error.
-	if err := c.DropContinuousQuery("db0", "not-a-cq"); err == nil {
-		t.Fatal("expected an error, got nil")
+	// Dropping a nonexistent CQ should not return an error.
+	if err := c.DropContinuousQuery("db0", "not-a-cq"); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -441,7 +441,7 @@ func (data *Data) CreateContinuousQuery(database, name, query string) error {
 func (data *Data) DropContinuousQuery(database, name string) error {
 	di := data.Database(database)
 	if di == nil {
-		return influxdb.ErrDatabaseNotFound(database)
+		return nil
 	}
 
 	for i := range di.ContinuousQueries {
@@ -450,7 +450,7 @@ func (data *Data) DropContinuousQuery(database, name string) error {
 			return nil
 		}
 	}
-	return ErrContinuousQueryNotFound
+	return nil
 }
 
 // validateURL returns an error if the URL does not have a port or uses a scheme other than UDP or HTTP.


### PR DESCRIPTION
This makes the behavior similar to other places in the DB where we
don't return an error when we try to drop an object from a non-
existent database.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

