### PR TITLE
Allow human-readable byte sizes in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [#8893](https://github.com/influxdata/influxdb/pull/8893): Handle nil MeasurementIterator.
 - [#8986](https://github.com/influxdata/influxdb/issues/8986): Add long-line support to client importer. Thanks @lets00!
 - [#9021](https://github.com/influxdata/influxdb/pull/9021): Update to go 1.9.2
+- [#8891](https://github.com/influxdata/influxdb/pull/8891): Allow human-readable byte sizes in config
 
 ### Bugfixes
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -71,10 +71,12 @@
 
   # CacheMaxMemorySize is the maximum size a shard's cache can
   # reach before it starts rejecting writes.
+  # Values without a size suffix (e.g. 30k, 20m, 10g) are in bytes.
   # cache-max-memory-size = 1048576000
 
   # CacheSnapshotMemorySize is the size at which the engine will
   # snapshot the cache and write it to a TSM file, freeing up memory
+  # Values without a size suffix (e.g. 30k, 20m, 10g) are in bytes.
   # cache-snapshot-memory-size = 26214400
 
   # CacheSnapshotWriteColdDuration is the length of time at

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -71,13 +71,15 @@
 
   # CacheMaxMemorySize is the maximum size a shard's cache can
   # reach before it starts rejecting writes.
-  # Values without a size suffix (e.g. 30k, 20m, 10g) are in bytes.
-  # cache-max-memory-size = 1048576000
+  # Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
+  # Vaues without a size suffix are in bytes.
+  # cache-max-memory-size = "1g"
 
   # CacheSnapshotMemorySize is the size at which the engine will
   # snapshot the cache and write it to a TSM file, freeing up memory
-  # Values without a size suffix (e.g. 30k, 20m, 10g) are in bytes.
-  # cache-snapshot-memory-size = 26214400
+  # Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
+  # Values without a size suffix are in bytes.
+  # cache-snapshot-memory-size = "25m"
 
   # CacheSnapshotWriteColdDuration is the length of time at
   # which the engine will snapshot the cache and write it to

--- a/toml/toml.go
+++ b/toml/toml.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+	"unicode"
 )
 
 // maxInt is the largest integer representable by a word (architecture dependent).
@@ -42,31 +43,54 @@ func (d Duration) MarshalText() (text []byte, err error) {
 }
 
 // Size represents a TOML parseable file size.
-// Users can specify size using "m" for megabytes and "g" for gigabytes.
-type Size int
+// Users can specify size using "k" or "K" for kibibytes, "m" or "M" for mebibytes,
+// and "g" or "G" for gibibytes. If a size suffix isn't specified then bytes are assumed.
+type Size uint64
 
 // UnmarshalText parses a byte size from text.
 func (s *Size) UnmarshalText(text []byte) error {
-	// Parse numeric portion of value.
-	length := len(string(text))
-	size, err := strconv.ParseInt(string(text[:length-1]), 10, 64)
-	if err != nil {
-		return err
+	if len(text) == 0 {
+		return fmt.Errorf("size was empty")
 	}
 
-	// Parse unit of measure ("m", "g", etc).
-	switch suffix := text[len(text)-1]; suffix {
-	case 'm':
-		size *= 1 << 20 // MB
-	case 'g':
-		size *= 1 << 30 // GB
-	default:
-		return fmt.Errorf("unknown size suffix: %c", suffix)
+	// The multiplier defaults to 1 in case the size has
+	// no suffix (and is then just raw bytes)
+	mult := int64(1)
+
+	// Preserve the original text for error messages
+	sizeText := text
+
+	// Parse unit of measure
+	suffix := text[len(sizeText)-1]
+	if !unicode.IsDigit(rune(suffix)) {
+		switch suffix {
+		case 'k', 'K':
+			mult = 1 << 10 // KiB
+		case 'm', 'M':
+			mult = 1 << 20 // MiB
+		case 'g', 'G':
+			mult = 1 << 30 // GiB
+		default:
+			return fmt.Errorf("unknown size suffix: %c", suffix)
+		}
+		sizeText = sizeText[:len(sizeText)-1]
 	}
+
+	// Parse numeric portion of value.
+	size, err := strconv.ParseInt(string(sizeText), 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid size: %s", string(text))
+	}
+
+	if maxInt/mult < size {
+		return fmt.Errorf("size would overflow the max size (%d) of an int: %s", maxInt, string(text))
+	}
+
+	size *= mult
 
 	// Check for overflow.
 	if size > maxInt {
-		return fmt.Errorf("size %d cannot be represented by an int", size)
+		return fmt.Errorf("size %d is too large", size)
 	}
 
 	*s = Size(size)

--- a/toml/toml_test.go
+++ b/toml/toml_test.go
@@ -3,6 +3,7 @@ package toml_test
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -13,13 +14,10 @@ import (
 )
 
 func TestSize_UnmarshalText(t *testing.T) {
-	// Copy this from the toml package
-	maxInt := int64(^uint(0) >> 1)
-
 	var s itoml.Size
 	for _, test := range []struct {
 		str  string
-		want int64
+		want uint64
 	}{
 		{"1", 1},
 		{"10", 10},
@@ -38,7 +36,7 @@ func TestSize_UnmarshalText(t *testing.T) {
 		{"100M", 100 << 20},
 		{"1g", 1 << 30},
 		{"1G", 1 << 30},
-		{fmt.Sprint(maxInt - 1), maxInt - 1},
+		{fmt.Sprint(uint64(math.MaxUint64) - 1), math.MaxUint64 - 1},
 	} {
 		if err := s.UnmarshalText([]byte(test.str)); err != nil {
 			t.Fatalf("unexpected error: %s", err)
@@ -49,7 +47,7 @@ func TestSize_UnmarshalText(t *testing.T) {
 	}
 
 	for _, str := range []string{
-		fmt.Sprintf("%dk", maxInt-1),
+		fmt.Sprintf("%dk", uint64(math.MaxUint64-1)),
 		"10000000000000000000g",
 		"abcdef",
 		"1KB",

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -71,8 +71,8 @@ type Config struct {
 	QueryLogEnabled bool `toml:"query-log-enabled"`
 
 	// Compaction options for tsm1 (descriptions above with defaults)
-	CacheMaxMemorySize             uint64        `toml:"cache-max-memory-size"`
-	CacheSnapshotMemorySize        uint64        `toml:"cache-snapshot-memory-size"`
+	CacheMaxMemorySize             toml.Size     `toml:"cache-max-memory-size"`
+	CacheSnapshotMemorySize        toml.Size     `toml:"cache-snapshot-memory-size"`
 	CacheSnapshotWriteColdDuration toml.Duration `toml:"cache-snapshot-write-cold-duration"`
 	CompactFullWriteColdDuration   toml.Duration `toml:"compact-full-write-cold-duration"`
 
@@ -105,8 +105,8 @@ func NewConfig() Config {
 
 		QueryLogEnabled: true,
 
-		CacheMaxMemorySize:             DefaultCacheMaxMemorySize,
-		CacheSnapshotMemorySize:        DefaultCacheSnapshotMemorySize,
+		CacheMaxMemorySize:             toml.Size(DefaultCacheMaxMemorySize),
+		CacheSnapshotMemorySize:        toml.Size(DefaultCacheSnapshotMemorySize),
 		CacheSnapshotWriteColdDuration: toml.Duration(DefaultCacheSnapshotWriteColdDuration),
 		CompactFullWriteColdDuration:   toml.Duration(DefaultCompactFullWriteColdDuration),
 

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -32,7 +32,6 @@ wal-fsync-delay = "10s"
 	if got, exp := c.WALFsyncDelay, time.Duration(10*time.Second); time.Duration(got).Nanoseconds() != exp.Nanoseconds() {
 		t.Errorf("unexpected wal-fsync-delay:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
 	}
-
 }
 
 func TestConfig_Validate_Error(t *testing.T) {
@@ -66,5 +65,73 @@ func TestConfig_Validate_Error(t *testing.T) {
 	c.Index = "tsi1"
 	if err := c.Validate(); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestConfig_ByteSizes(t *testing.T) {
+	// Parse configuration.
+	c := tsdb.NewConfig()
+	if _, err := toml.Decode(`
+dir = "/var/lib/influxdb/data"
+wal-dir = "/var/lib/influxdb/wal"
+wal-fsync-delay = "10s"
+cache-max-memory-size = 5368709120
+cache-snapshot-memory-size = 104857600
+`, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Validate(); err != nil {
+		t.Errorf("unexpected validate error: %s", err)
+	}
+
+	if got, exp := c.Dir, "/var/lib/influxdb/data"; got != exp {
+		t.Errorf("unexpected dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.WALDir, "/var/lib/influxdb/wal"; got != exp {
+		t.Errorf("unexpected wal-dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.WALFsyncDelay, time.Duration(10*time.Second); time.Duration(got).Nanoseconds() != exp.Nanoseconds() {
+		t.Errorf("unexpected wal-fsync-delay:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.CacheMaxMemorySize, uint64(5<<30); uint64(got) != exp {
+		t.Errorf("unexpected cache-max-memory-size:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.CacheSnapshotMemorySize, uint64(100<<20); uint64(got) != exp {
+		t.Errorf("unexpected cache-snapshot-memory-size:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+}
+
+func TestConfig_HumanReadableSizes(t *testing.T) {
+	// Parse configuration.
+	c := tsdb.NewConfig()
+	if _, err := toml.Decode(`
+dir = "/var/lib/influxdb/data"
+wal-dir = "/var/lib/influxdb/wal"
+wal-fsync-delay = "10s"
+cache-max-memory-size = "5g"
+cache-snapshot-memory-size = "100m"
+`, &c); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Validate(); err != nil {
+		t.Errorf("unexpected validate error: %s", err)
+	}
+
+	if got, exp := c.Dir, "/var/lib/influxdb/data"; got != exp {
+		t.Errorf("unexpected dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.WALDir, "/var/lib/influxdb/wal"; got != exp {
+		t.Errorf("unexpected wal-dir:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.WALFsyncDelay, time.Duration(10*time.Second); time.Duration(got).Nanoseconds() != exp.Nanoseconds() {
+		t.Errorf("unexpected wal-fsync-delay:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.CacheMaxMemorySize, uint64(5<<30); uint64(got) != exp {
+		t.Errorf("unexpected cache-max-memory-size:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.CacheSnapshotMemorySize, uint64(100<<20); uint64(got) != exp {
+		t.Errorf("unexpected cache-snapshot-memory-size:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
 	}
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -194,7 +194,7 @@ func NewEngine(id uint64, idx tsdb.Index, database, path string, walPath string,
 		Compactor:      c,
 		CompactionPlan: NewDefaultPlanner(fs, time.Duration(opt.Config.CompactFullWriteColdDuration)),
 
-		CacheFlushMemorySizeThreshold: opt.Config.CacheSnapshotMemorySize,
+		CacheFlushMemorySizeThreshold: uint64(opt.Config.CacheSnapshotMemorySize),
 		CacheFlushWriteColdDuration:   time.Duration(opt.Config.CacheSnapshotWriteColdDuration),
 		enableCompactionsOnOpen:       true,
 		stats:             stats,


### PR DESCRIPTION
Update support in the `toml` package for parsing human-readble byte sizes.
Supported size suffixes are "k" or "K" for kibibytes, "m" or "M" for
mebibytes, and "g" or "G" for gibibytes. If a size suffix isn't specified
then bytes are assumed.

In the config, `cache-max-memory-size` and `cache-snapshot-memory-size` are
now typed as `toml.Size` and support the new syntax.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

###### Required only if applicable
- [x] Provide example syntax
- [x] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
