### PR TITLE
Handle nil MeasurementIterator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [#8995](https://github.com/influxdata/influxdb/pull/8995): Sort & validate TSI key value insertion.
 - [#8968](https://github.com/influxdata/influxdb/issues/8968): Make client errors more helpful on downstream errs. Thanks @darkliquid!
 - [#8984](https://github.com/influxdata/influxdb/pull/8984): EXACT and estimated CARDINALITY queries.
+- [#8893](https://github.com/influxdata/influxdb/pull/8893): Handle nil MeasurementIterator.
 
 ### Bugfixes
 

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -528,9 +528,13 @@ func (fs *FileSet) MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error) 
 		return fs.measurementNamesByExpr(expr)
 	}
 
+	itr := fs.MeasurementIterator()
+	if itr == nil {
+		return nil, nil
+	}
+
 	// Iterate over all measurements if no condition exists.
 	var names [][]byte
-	itr := fs.MeasurementIterator()
 	for e := itr.Next(); e != nil; e = itr.Next() {
 		names = append(names, e.Name())
 	}
@@ -605,8 +609,12 @@ func (fs *FileSet) measurementNamesByExpr(expr influxql.Expr) ([][]byte, error) 
 
 // measurementNamesByNameFilter returns matching measurement names in sorted order.
 func (fs *FileSet) measurementNamesByNameFilter(op influxql.Token, val string, regex *regexp.Regexp) [][]byte {
-	var names [][]byte
 	itr := fs.MeasurementIterator()
+	if itr == nil {
+		return nil
+	}
+
+	var names [][]byte
 	for e := itr.Next(); e != nil; e = itr.Next() {
 		var matched bool
 		switch op {
@@ -632,6 +640,10 @@ func (fs *FileSet) measurementNamesByTagFilter(op influxql.Token, key, val strin
 	var names [][]byte
 
 	mitr := fs.MeasurementIterator()
+	if mitr == nil {
+		return nil
+	}
+
 	for me := mitr.Next(); me != nil; me = mitr.Next() {
 		// If the operator is non-regex, only check the specified value.
 		var tagMatch bool

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -415,6 +415,10 @@ func (i *Index) MeasurementNamesByRegex(re *regexp.Regexp) ([][]byte, error) {
 	defer fs.Release()
 
 	itr := fs.MeasurementIterator()
+	if itr == nil {
+		return nil, nil
+	}
+
 	var a [][]byte
 	for e := itr.Next(); e != nil; e = itr.Next() {
 		if re.Match(e.Name()) {
@@ -1200,6 +1204,10 @@ func (itr *seriesPointIterator) Next() (*query.FloatPoint, error) {
 		// Create new series iterator, if necessary.
 		// Exit if there are no measurements remaining.
 		if itr.sitr == nil {
+			if itr.mitr == nil {
+				return nil, nil
+			}
+
 			m := itr.mitr.Next()
 			if m == nil {
 				return nil, nil


### PR DESCRIPTION
@jwilder This should fix the panic you reported along with some additional checks elsewhere.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x999995]

goroutine 45102 [running]:
github.com/influxdata/influxdb/tsdb/index/tsi1.(*FileSet).MeasurementNamesByExpr(0xc4206ea910, 0x0, 0x0, 0x0, 0xc420a99ce0, 0x42b40f, 0xd143c8, 0xc420a99cf0)
    /root/go/src/github.com/influxdata/influxdb/tsdb/index/tsi1/file_set.go:528 +0x65
github.com/influxdata/influxdb/tsdb/index/tsi1.(*Index).MeasurementNamesByExpr(0xc420a7e1e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /root/go/src/github.com/influxdata/influxdb/tsdb/index/tsi1/index.go:405 +0xb2
github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Engine).MeasurementNamesByExpr(0xc4200aac60, 0x0, 0x0, 0x0, 0x0, 0xc420a99e68, 0x0, 0xffffffffffffffff)
    /root/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/engine.go:331 +0x52
github.com/influxdata/influxdb/tsdb.(*Shard).MeasurementNamesByExpr(0xc4206861a0, 0x0, 0x0, 0xc420a99e68, 0xc420a99e38, 0xc4207aaf20, 0x0, 0x1)
    /root/go/src/github.com/influxdata/influxdb/tsdb/shard.go:745 +0x9e
github.com/influxdata/influxdb/tsdb.(*Store).MeasurementNames(0xc4205e5b80, 0xcbde71, 0x3, 0x0, 0x0, 0xc4207aaf20, 0x1, 0x1, 0x0, 0xc420a99f88)
    /root/go/src/github.com/influxdata/influxdb/tsdb/store.go:976 +0x18e
github.com/influxdata/influxdb/tests.TestConcurrentServer_ShowMeasurements.func2()
    /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:123 +0x9b
github.com/influxdata/influxdb/tests.runTest.func2(0xc42012f110, 0xc420bc49c0, 0xc4203710e0)
    /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:150 +0x7d
created by github.com/influxdata/influxdb/tests.runTest
    /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:153 +0xf5
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
