### PR TITLE
Revert "Convert duration to string without dot and zeros"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,7 @@
 - [#8749](https://github.com/influxdata/influxdb/issues/8749): An OSS read-only user should be able to list measurements on a database
 - [#8678](https://github.com/influxdata/influxdb/issues/8678): Ensure time and tag-based condition can be used with tsi1 index when deleting.
 - [#8848](https://github.com/influxdata/influxdb/issues/8848): Prevent deadlock when doing math on the result of a subquery.
-- [#8813](https://github.com/influxdata/influxdb/issues/8813): Fix retention policy duration format
-- [#8895](https://github.com/influxdata/influxdb/issues/8895): Fix a minor memory leak in batching points in tsdb. 
+- [#8895](https://github.com/influxdata/influxdb/issues/8895): Fix a minor memory leak in batching points in tsdb.
 
 ## v1.3.4 [unreleased]
 

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -715,13 +715,7 @@ func (e *StatementExecutor) executeShowRetentionPoliciesStatement(q *influxql.Sh
 
 	row := &models.Row{Columns: []string{"name", "duration", "shardGroupDuration", "replicaN", "default"}}
 	for _, rpi := range di.RetentionPolicies {
-		row.Values = append(row.Values, []interface{}{
-			rpi.Name,
-			influxql.FormatDuration(rpi.Duration),
-			influxql.FormatDuration(rpi.ShardGroupDuration),
-			rpi.ReplicaN,
-			di.DefaultRetentionPolicy == rpi.Name,
-		})
+		row.Values = append(row.Values, []interface{}{rpi.Name, rpi.Duration.String(), rpi.ShardGroupDuration.String(), rpi.ReplicaN, di.DefaultRetentionPolicy == rpi.Name})
 	}
 	return []*models.Row{row}, nil
 }

--- a/tests/server_suite.go
+++ b/tests/server_suite.go
@@ -438,7 +438,7 @@ func init() {
 			&Query{
 				name:    "show retention policy should succeed",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","1h","1h",1,false]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","1h0m0s","1h0m0s",1,false]]}]}]}`,
 			},
 			&Query{
 				name:    "alter retention policy should succeed",
@@ -449,12 +449,12 @@ func init() {
 			&Query{
 				name:    "show retention policy should have new altered information",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h","1h",3,true]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h0m0s","1h0m0s",3,true]]}]}]}`,
 			},
 			&Query{
 				name:    "show retention policy should still show policy",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h","1h",3,true]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h0m0s","1h0m0s",3,true]]}]}]}`,
 			},
 			&Query{
 				name:    "create a second non-default retention policy",
@@ -465,7 +465,7 @@ func init() {
 			&Query{
 				name:    "show retention policy should show both",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h","1h",3,true],["rp2","1h","1h",1,false]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h0m0s","1h0m0s",3,true],["rp2","1h0m0s","1h0m0s",1,false]]}]}]}`,
 			},
 			&Query{
 				name:    "dropping non-default retention policy succeed",
@@ -488,7 +488,7 @@ func init() {
 			&Query{
 				name:    "show retention policy should show both with custom shard",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h","1h",3,true],["rp3","1h","1h",1,false]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h0m0s","1h0m0s",3,true],["rp3","1h0m0s","1h0m0s",1,false]]}]}]}`,
 			},
 			&Query{
 				name:    "dropping non-default custom shard retention policy succeed",
@@ -499,7 +499,7 @@ func init() {
 			&Query{
 				name:    "show retention policy should show just default",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h","1h",3,true]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rp0","2h0m0s","1h0m0s",3,true]]}]}]}`,
 			},
 			&Query{
 				name:    "Ensure retention policy with unacceptable retention cannot be created",
@@ -547,7 +547,7 @@ func init() {
 			&Query{
 				name:    "show retention policy: validate normalized shard group durations are working",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rpinf","0s","1w",1,false],["rpzero","1h","1h",1,false],["rponesecond","2h","1h",1,false]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["rpinf","0s","168h0m0s",1,false],["rpzero","1h0m0s","1h0m0s",1,false],["rponesecond","2h0m0s","1h0m0s",1,false]]}]}]}`,
 			},
 		},
 	}
@@ -563,7 +563,7 @@ func init() {
 			&Query{
 				name:    "show retention policies should return auto-created policy",
 				command: `SHOW RETENTION POLICIES ON db0`,
-				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["autogen","0s","1w",1,true]]}]}]}`,
+				exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["autogen","0s","168h0m0s",1,true]]}]}]}`,
 			},
 		},
 	}

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -764,7 +764,7 @@ func TestServer_Query_DefaultDBAndRP(t *testing.T) {
 		&Query{
 			name:    "default rp exists",
 			command: `show retention policies ON db0`,
-			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["autogen","0s","1w",1,false],["rp0","0s","1w",1,true]]}]}]}`,
+			exp:     `{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["autogen","0s","168h0m0s",1,false],["rp0","0s","168h0m0s",1,true]]}]}]}`,
 		},
 		&Query{
 			name:    "default rp",


### PR DESCRIPTION
Reverts influxdata/influxdb#8840

The new output makes it so the duration is not parseable with `time.ParseDuration` from the Go standard library. While this isn't necessarily a breaking change, it's in a gray enough area that the change is likely not worth it for a minor release.