### PR TITLE
Series Map

### DIFF
--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -279,6 +279,9 @@ func (i *Partition) Close() error {
 	return nil
 }
 
+// Path returns the path to the partition.
+func (i *Partition) Path() string { return i.path }
+
 // NextSequence returns the next file identifier.
 func (i *Partition) NextSequence() int {
 	i.mu.Lock()

--- a/tsdb/index/tsi1/partition_test.go
+++ b/tsdb/index/tsi1/partition_test.go
@@ -40,7 +40,7 @@ func TestPartition_Open(t *testing.T) {
 		t.Run(fmt.Sprintf("incompatible index version: %d", v), func(t *testing.T) {
 			p = NewPartition()
 			// Manually create a MANIFEST file for an incompatible index version.
-			mpath := filepath.Join(p.Path, tsi1.ManifestFileName)
+			mpath := filepath.Join(p.Path(), tsi1.ManifestFileName)
 			m := tsi1.NewManifest()
 			m.Levels = nil
 			m.Version = v // Set example MANIFEST version.
@@ -82,9 +82,7 @@ type Partition struct {
 
 // NewPartition returns a new instance of Partition at a temporary path.
 func NewPartition() *Partition {
-	p := &Partition{Partition: tsi1.NewPartition()}
-	p.Path = MustTempDir()
-	return p
+	return &Partition{Partition: tsi1.NewPartition(MustTempDir())}
 }
 
 // MustOpenPartition returns a new, open index. Panic on error.
@@ -98,7 +96,7 @@ func MustOpenPartition() *Partition {
 
 // Close closes and removes the index directory.
 func (p *Partition) Close() error {
-	defer os.RemoveAll(p.Path)
+	defer os.RemoveAll(p.Path())
 	return p.Partition.Close()
 }
 
@@ -108,8 +106,7 @@ func (p *Partition) Reopen() error {
 		return err
 	}
 
-	path := p.Path
-	p.Partition = tsi1.NewPartition()
-	p.Path = path
+	path := p.Path()
+	p.Partition = tsi1.NewPartition(path)
 	return p.Open()
 }

--- a/tsdb/index/tsi1/series_file.go
+++ b/tsdb/index/tsi1/series_file.go
@@ -37,7 +37,7 @@ const MaxSeriesFileHashSize = (1048576 * LoadFactor) / 100
 
 // SeriesMapThreshold is the number of series to hold in the in-memory series map
 // before compacting and rebuilding the on-disk map.
-const SeriesMapThreshold = 100000
+const SeriesMapThreshold = 300000
 
 // SeriesFile represents the section of the index that holds series data.
 type SeriesFile struct {


### PR DESCRIPTION
This includes an RHH implementation of an on-disk series map. Currently this rebuilds the entire map after going past a threshold for a given number of series.

This currently blocks inserts (which is obviously bad) and I started doing a background compaction but realized that it might make more sense to create incremental maps instead.

Also, there was a bug in the partition loading that was causing partitions not to load. I'll add a comment inline.
