### PR TITLE
Use correct variable style in influxdb.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - [#8848](https://github.com/influxdata/influxdb/issues/8848): Prevent deadlock when doing math on the result of a subquery.
 - [#8895](https://github.com/influxdata/influxdb/issues/8895): Fix a minor memory leak in batching points in tsdb.
 - [#8900](https://github.com/influxdata/influxdb/issues/8900): Don't assume `which` is present in package post-install script.
+- [#8909](https://github.com/influxdata/influxdb/issues/8909): Fix use of `INFLUXD_OPTS` in service file
 
 ## v1.3.4 [unreleased]
 

--- a/scripts/influxdb.service
+++ b/scripts/influxdb.service
@@ -10,7 +10,7 @@ User=influxdb
 Group=influxdb
 LimitNOFILE=65536
 EnvironmentFile=-/etc/default/influxdb
-ExecStart=/usr/bin/influxd -config /etc/influxdb/influxdb.conf ${INFLUXD_OPTS}
+ExecStart=/usr/bin/influxd -config /etc/influxdb/influxdb.conf $INFLUXD_OPTS
 KillMode=control-group
 Restart=on-failure
 


### PR DESCRIPTION
From the systemd.service docs:

Use "${FOO}" as part of a word, or as a word of its own, on the command
line, in which case it will be replaced by the value of the environment
variable including all whitespace it contains, resulting in a single
argument. Use "$FOO" as a separate word on the command line, in which
case it will be replaced by the value of the environment variable split
at whitespace, resulting in zero or more arguments.

- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated