### PR TITLE
Include man pages in releng packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - [#8848](https://github.com/influxdata/influxdb/issues/8848): Prevent deadlock when doing math on the result of a subquery.
 - [#8895](https://github.com/influxdata/influxdb/issues/8895): Fix a minor memory leak in batching points in tsdb.
 - [#8900](https://github.com/influxdata/influxdb/issues/8900): Don't assume `which` is present in package post-install script.
+- [#8908](https://github.com/influxdata/influxdb/issues/8908): Fix missing man pages in new packaging output
 - [#8909](https://github.com/influxdata/influxdb/issues/8909): Fix use of `INFLUXD_OPTS` in service file
 
 ## v1.3.4 [unreleased]

--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -54,6 +54,7 @@ if [ "$OS" == "linux" ]; then
            /pkg/var/log/influxdb \
            /pkg/var/lib/influxdb \
            /pkg/usr/lib/influxdb/scripts \
+           /pkg/usr/share/man/man1 \
            /pkg/etc/influxdb \
            /pkg/etc/logrotate.d
   chmod -R 0755 /pkg
@@ -73,6 +74,9 @@ if [ "$OS" == "linux" ]; then
 
   # Copy data binaries.
   cp /ibin/* /pkg/usr/bin/
+
+  # Copy man pages.
+  cp /isrc/man/*.1.gz /pkg/usr/share/man/man1
 
   # Make tarball of files in packaging.
   BIN_GZ_NAME="/out/influxdb-oss-${VERSION}_${OS}_${ARCH}.tar.gz"

--- a/releng/packages/spec/clean_install/_install_uninstall.bash
+++ b/releng/packages/spec/clean_install/_install_uninstall.bash
@@ -18,7 +18,6 @@ Exactly one of -D or -R must be provided to indicate Debian or RPM packages.
 
 BINS=( influx influxd influx_stress influx_inspect influx_tsm )
 
-
 function testInstalled() {
   if ! command -v "$1" >/dev/null 2>&1 ; then
     >&2 echo "$1 not on \$PATH after install"
@@ -31,6 +30,19 @@ function testUninstalled() {
     >&2 echo "$1 still on \$PATH after install"
     exit 1
   fi
+}
+
+function testManpages() {
+  for p in influxd influxd-backup influxd-config influxd-restore influxd-run influxd-version \
+    influx \
+    influx_inspect \
+    influx_stress \
+    influx_tsm ; do
+    if [[ ! -r "/usr/share/man/man1/$p.1.gz" ]]; then
+      >&2 echo "No man page found for $p"
+      exit 1
+    fi
+  done
 }
 
 function testInstall() {
@@ -46,6 +58,7 @@ function testInstall() {
   for x in "${BINS[@]}"; do
     testInstalled "$x"
   done
+  testManpages
 
   if [ "$TYPE" == "deb" ]; then
     dpkg -r influxdb

--- a/releng/packages/spec/clean_install/run.bash
+++ b/releng/packages/spec/clean_install/run.bash
@@ -21,13 +21,13 @@ IS_RPM=""
 while getopts hp:DR arg; do
   case "$arg" in
     h) printHelp; exit 1;;
-    p) DATA_PKG="$OPTARG";;
+    p) PKG="$OPTARG";;
     D) IS_DEB="1";;
     R) IS_RPM="1";;
   esac
 done
 
-if [ -z "PKG" ] ; then
+if [ -z "$PKG" ] ; then
   printHelp
   exit 1
 fi

--- a/releng/source-tarball/Dockerfile
+++ b/releng/source-tarball/Dockerfile
@@ -2,10 +2,13 @@ ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine
 
 RUN apk add --no-cache \
+      asciidoc \
       bash \
       git \
       openssh-client \
-      tar
+      make \
+      tar \
+      xmlto
 
 # Build the gdm binary and then clean out /go.
 RUN go get github.com/sparrc/gdm && \

--- a/releng/source-tarball/fs/usr/local/bin/influxdb_tarball.bash
+++ b/releng/source-tarball/fs/usr/local/bin/influxdb_tarball.bash
@@ -79,6 +79,9 @@ printf 'package main
 	version = "%s"
 }' "$VERSION" > "./influxdb/cmd/influx/version.generated.go"
 
+# Prebuild the man pages so that consumers of the source tarball don't have to build it themselves.
+(cd /go/src/github.com/influxdata/influxdb/man && make build && gzip -9 ./*.1)
+
 TARBALL_NAME="influxdb-src-$SHA.tar.gz"
 (cd /go && tar czf "/out/$TARBALL_NAME" --exclude-vcs ./*) # --exclude-vcs is a GNU tar option.
 (cd /out && md5sum "$TARBALL_NAME" > "$TARBALL_NAME.md5")


### PR DESCRIPTION
The *.1.gz files are included into the source tarball, and the .deb and
.rpm files will now install the man pages when the package is installed.

Fixes #8908.
