### PR TITLE
auth: update required permissions for ON clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 - [#9005](https://github.com/influxdata/influxdb/pull/9005): Return `query.ErrQueryInterrupted` for successful read on `InterruptCh`.
 - [#8989](https://github.com/influxdata/influxdb/issues/8989): Fix race inside Measurement index.
 - [#8819](https://github.com/influxdata/influxdb/issues/8819): Ensure retention service always removes local shards.
+- [#8943](https://github.com/influxdata/influxdb/pull/8943): auth: update required permissions for ON clauses
 
 ## v1.3.4 [unreleased]
 

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -2005,7 +2005,7 @@ func (s *ShowSeriesStatement) String() string {
 
 // RequiredPrivileges returns the privilege required to execute a ShowSeriesStatement.
 func (s *ShowSeriesStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+	return ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: ReadPrivilege}}, nil
 }
 
 // DefaultDatabase returns the default database from the statement.
@@ -2304,7 +2304,7 @@ func (s *DropContinuousQueryStatement) String() string {
 
 // RequiredPrivileges returns the privilege(s) required to execute a DropContinuousQueryStatement
 func (s *DropContinuousQueryStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: WritePrivilege}}, nil
+	return ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: WritePrivilege}}, nil
 }
 
 // DefaultDatabase returns the default database from the statement.
@@ -2492,7 +2492,7 @@ func (s *ShowRetentionPoliciesStatement) String() string {
 
 // RequiredPrivileges returns the privilege(s) required to execute a ShowRetentionPoliciesStatement
 func (s *ShowRetentionPoliciesStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+	return ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: ReadPrivilege}}, nil
 }
 
 // DefaultDatabase returns the default database from the statement.
@@ -2712,7 +2712,7 @@ func (s *ShowTagKeysStatement) String() string {
 
 // RequiredPrivileges returns the privilege(s) required to execute a ShowTagKeysStatement.
 func (s *ShowTagKeysStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+	return ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: ReadPrivilege}}, nil
 }
 
 // DefaultDatabase returns the default database from the statement.
@@ -2846,7 +2846,7 @@ func (s *ShowTagValuesStatement) String() string {
 
 // RequiredPrivileges returns the privilege(s) required to execute a ShowTagValuesStatement.
 func (s *ShowTagValuesStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+	return ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: ReadPrivilege}}, nil
 }
 
 // DefaultDatabase returns the default database from the statement.
@@ -3038,7 +3038,7 @@ func (s *ShowFieldKeysStatement) String() string {
 
 // RequiredPrivileges returns the privilege(s) required to execute a ShowFieldKeysStatement.
 func (s *ShowFieldKeysStatement) RequiredPrivileges() (ExecutionPrivileges, error) {
-	return ExecutionPrivileges{{Admin: false, Name: "", Privilege: ReadPrivilege}}, nil
+	return ExecutionPrivileges{{Admin: false, Name: s.Database, Privilege: ReadPrivilege}}, nil
 }
 
 // DefaultDatabase returns the default database from the statement.


### PR DESCRIPTION
Some statements had 'ON db' clauses at some point during development, but the calculated required permissions were never updated.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated