### PR TITLE
Fix tarball packaging paths

### DIFF
--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -39,6 +39,8 @@ tar x -C /go -zf /influxdb-src.tar.gz
 ln -s /go/src/github.com/influxdata/influxdb /isrc # Shorthand for influxdb source.
 SHA=$(jq -r .sha < "/isrc/.metadata.json")
 VERSION=$(jq -r .version < "/isrc/.metadata.json")
+ARCHIVE_ROOT_NAME="influxdb-${VERSION}-1"
+PKG_ROOT="/pkg/$ARCHIVE_ROOT_NAME"
 
 # Extract the respective binaries to dedicated folders.
 mkdir -p /ibin
@@ -49,34 +51,35 @@ if [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
   ####### Data packages #######
   #############################
 
-  # Create layout for packaging in /pkg.
-  mkdir -p /pkg/usr/bin \
-           /pkg/var/log/influxdb \
-           /pkg/var/lib/influxdb \
-           /pkg/usr/lib/influxdb/scripts \
-           /pkg/usr/share/man/man1 \
-           /pkg/etc/influxdb \
-           /pkg/etc/logrotate.d
+  # Create layout for packaging under $PKG_ROOT.
+  rm -rf "$PKG_ROOT"
+  mkdir -p "$PKG_ROOT/usr/bin" \
+           "$PKG_ROOT/var/log/influxdb" \
+           "$PKG_ROOT/var/lib/influxdb" \
+           "$PKG_ROOT/usr/lib/influxdb/scripts" \
+           "$PKG_ROOT/usr/share/man/man1" \
+           "$PKG_ROOT/etc/influxdb" \
+           "$PKG_ROOT/etc/logrotate.d"
   chmod -R 0755 /pkg
 
   # Copy service scripts.
-  cp /isrc/scripts/init.sh /pkg/usr/lib/influxdb/scripts/init.sh
-  chmod 0644 /pkg/usr/lib/influxdb/scripts/init.sh
-  cp /isrc/scripts/influxdb.service /pkg/usr/lib/influxdb/scripts/influxdb.service
-  chmod 0644 /pkg/usr/lib/influxdb/scripts/influxdb.service
+  cp /isrc/scripts/init.sh "$PKG_ROOT/usr/lib/influxdb/scripts/init.sh"
+  chmod 0644 "$PKG_ROOT/usr/lib/influxdb/scripts/init.sh"
+  cp /isrc/scripts/influxdb.service "$PKG_ROOT/usr/lib/influxdb/scripts/influxdb.service"
+  chmod 0644 "$PKG_ROOT/usr/lib/influxdb/scripts/influxdb.service"
 
   # Copy logrotate script.
-  cp /isrc/scripts/logrotate /pkg/etc/logrotate.d/influxdb
-  chmod 0644 /pkg/etc/logrotate.d/influxdb
+  cp /isrc/scripts/logrotate "$PKG_ROOT/etc/logrotate.d/influxdb"
+  chmod 0644 "$PKG_ROOT/etc/logrotate.d/influxdb"
 
   # Copy sample config.
-  cp /isrc/etc/config.sample.toml /pkg/etc/influxdb/influxdb.conf
+  cp /isrc/etc/config.sample.toml "$PKG_ROOT/etc/influxdb/influxdb.conf"
 
   # Copy data binaries.
-  cp /ibin/* /pkg/usr/bin/
+  cp /ibin/* "$PKG_ROOT/usr/bin/"
 
   # Copy man pages.
-  cp /isrc/man/*.1.gz /pkg/usr/share/man/man1
+  cp /isrc/man/*.1.gz "$PKG_ROOT/usr/share/man/man1"
 
   # Make tarball of files in packaging.
   BIN_GZ_NAME="/out/influxdb-${VERSION}_${OS}_${ARCH}.tar.gz"
@@ -84,6 +87,7 @@ if [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
     BIN_GZ_NAME="/out/influxdb-${VERSION}-static_${OS}_${ARCH}.tar.gz"
   fi
 
+  # Creating tarball from /pkg, NOT from $PKG_ROOT, so that influxdb-$VERSION-1 directory is present in archive.
   (cd /pkg && tar czf $BIN_GZ_NAME ./*)
 
   # don't need static install packages.
@@ -111,7 +115,7 @@ if [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
         --architecture "$ARCH" \
         --version "$VERSION" \
         --iteration 1 \
-        -C /pkg \
+        -C "$PKG_ROOT" \
         -p /out \
          | ruby -e 'puts (eval ARGF.read)[:path]' )
 
@@ -130,9 +134,13 @@ if [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
     sha256sum "$f" > "$f.sha256"
   done)
 elif [ "$OS" == "windows" ]; then
-  # Windows gets the binaries and nothing else.
-  # TODO: should Windows get the sample config files?
-  (cd /ibin && zip -9 -r "/out/influxdb-${VERSION}_${OS}_${ARCH}.zip" ./*)
+  # Windows gets the binaries and the sample config file.
+  rm -rf "$PKG_ROOT"
+  mkdir -p "$PKG_ROOT"
+  cp /ibin/*.exe "$PKG_ROOT"
+  cp /isrc/etc/config.sample.toml "$PKG_ROOT/influxdb.conf"
+
+  (cd /pkg && zip -9 -r "/out/influxdb-${VERSION}_${OS}_${ARCH}.zip" ./*)
   (cd /out && for f in *.zip; do
     md5sum "$f" > "$f.md5"
     sha256sum "$f" > "$f.sha256"

--- a/releng/raw-binaries/build.bash
+++ b/releng/raw-binaries/build.bash
@@ -4,6 +4,7 @@ function printHelp() {
   >&2 echo "USAGE: $0 -i PATH_TO_SOURCE_TARBALL -o OUTDIR
 
 Emits an archive of influxdb binaries based on the current environment's GOOS and GOARCH.
+Respects CGO_ENABLED.
 
 If the environment variable GO_NEXT is not empty, builds the binaries with the 'next' version of Go.
 "

--- a/releng/source-tarball/build.bash
+++ b/releng/source-tarball/build.bash
@@ -9,8 +9,6 @@ Emits a tarball of influxdb source code and dependencies to OUTDIR.
 
 If using -p flag, directory containing influxdb source code will be used as source of truth.
 This is helpful if you have local commits that have not been pushed.
-
-If not using -p, you must provide -S to clone over SSH.
 "
 }
 
@@ -31,7 +29,7 @@ OUTDIR=""
 INFLUXDB_GIT_MOUNT=""
 
 
-while getopts hs:b:v:o:p:S: arg; do
+while getopts hs:b:v:o:p: arg; do
   case "$arg" in
     h) printHelp; exit 1;;
     s) SHA="$OPTARG";;


### PR DESCRIPTION
The releng scripts' tarballs had paths like `./usr/bin/influx` whereas
the build.py output had `./influxdb-1.3.5-1/usr/bin/influx`. Now the
releng scripts match the build.py output.
