### PR TITLE
Engine race fixes

### DIFF
--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -207,6 +207,10 @@ func (m *Measurement) CardinalityBytes(key []byte) int {
 // AddSeries adds a series to the measurement's index.
 // It returns true if the series was added successfully or false if the series was already present.
 func (m *Measurement) AddSeries(s *Series) bool {
+	if s == nil {
+		return false
+	}
+
 	m.mu.RLock()
 	if m.seriesByID[s.ID] != nil {
 		m.mu.RUnlock()
@@ -286,7 +290,9 @@ func (m *Measurement) Rebuild() *Measurement {
 	// expunged.  Note: we're using SeriesIDs which returns the series in sorted order so that
 	// re-adding does not incur a sort for each series added.
 	for _, id := range m.SeriesIDs() {
-		nm.AddSeries(m.SeriesByID(id))
+		if s := m.SeriesByID(id); s != nil {
+			nm.AddSeries(s)
+		}
 	}
 	return nm
 }

--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -93,6 +93,13 @@ func TestSeriesIDs_Reject(t *testing.T) {
 	}
 }
 
+func TestMeasurement_AddSeries_Nil(t *testing.T) {
+	m := inmem.NewMeasurement("foo", "cpu")
+	if m.AddSeries(nil) {
+		t.Fatalf("AddSeries mismatch: exp false, got true")
+	}
+}
+
 func TestMeasurement_AppendSeriesKeysByID_Missing(t *testing.T) {
 	m := inmem.NewMeasurement("foo", "cpu")
 	var dst []string


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes two races in the engine.  Once occurs on the engine `WaitGroup` when `Add` is called while another goroutine is still `Wait`ing.  The other occurs when deletes occur while rebuilding the in-memory measurement index asynchronously.