### PR TITLE
remove duplicated code in cacheKeyIterator.encode()

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1488,25 +1488,17 @@ func (c *cacheKeyIterator) encode() {
 					minTime, maxTime := values[0].UnixNano(), values[end-1].UnixNano()
 					var b []byte
 					var err error
-					tenc.Reset()
-
-					maxTime = values[end-1].UnixNano()
 
 					switch values[0].(type) {
 					case FloatValue:
-						fenc.Reset()
 						b, err = encodeFloatBlockUsing(nil, values[:end], tenc, fenc)
 					case IntegerValue:
-						ienc.Reset()
 						b, err = encodeIntegerBlockUsing(nil, values[:end], tenc, ienc)
 					case UnsignedValue:
-						uenc.Reset()
 						b, err = encodeUnsignedBlockUsing(nil, values[:end], tenc, uenc)
 					case BooleanValue:
-						benc.Reset()
 						b, err = encodeBooleanBlockUsing(nil, values[:end], tenc, benc)
 					case StringValue:
-						senc.Reset()
 						b, err = encodeStringBlockUsing(nil, values[:end], tenc, senc)
 					default:
 						b, err = Values(values[:end]).Encode(nil)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Those encoders have been `Reset()` in `encode*BlockUsing`.