### PR TITLE
Fix data deleted outside of time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - [#8909](https://github.com/influxdata/influxdb/issues/8909): Fix use of `INFLUXD_OPTS` in service file
 - [#8952](https://github.com/influxdata/influxdb/issues/8952): Fix WAL panic: runtime error: makeslice: cap out of range
 - [#8975](https://github.com/influxdata/influxdb/pull/8975): Copy returned bytes from TSI meta functions.
+- [#7797](https://github.com/influxdata/influxdb/issues/7706): Fix data deleted outside of time range
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -834,7 +834,7 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) {
 	}
 
 	tombstones := map[string][]TimeRange{}
-	for _, k := range keys {
+	for i, k := range keys {
 		// Is the range passed in outside the time range for this key?
 		entries := d.Entries(k)
 
@@ -850,7 +850,7 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) {
 
 		// Is the range passed in cover every value for the key?
 		if minTime <= min && maxTime >= max {
-			d.Delete(keys)
+			d.Delete(keys[i : i+1])
 			continue
 		}
 

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -656,6 +656,79 @@ func TestTSMReader_MMAP_TombstoneFullRange(t *testing.T) {
 	}
 }
 
+func TestTSMReader_MMAP_TombstoneFullRangeMultiple(t *testing.T) {
+	dir := mustTempDir()
+	defer os.RemoveAll(dir)
+	f := mustTempFile(dir)
+	defer f.Close()
+
+	w, err := NewTSMWriter(f)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	expValues := []Value{
+		NewValue(1, 1.0),
+		NewValue(2, 2.0),
+		NewValue(3, 3.0),
+	}
+	if err := w.Write([]byte("cpu"), expValues); err != nil {
+		t.Fatalf("unexpected error writing: %v", err)
+	}
+
+	expValues1 := []Value{
+		NewValue(3, 1.0),
+		NewValue(4, 2.0),
+		NewValue(5, 3.0),
+	}
+
+	if err := w.Write([]byte("mem"), expValues1); err != nil {
+		t.Fatalf("unexpected error writing: %v", err)
+	}
+
+	if err := w.WriteIndex(); err != nil {
+		t.Fatalf("unexpected error writing index: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpected error closing: %v", err)
+	}
+
+	f, err = os.Open(f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error open file: %v", err)
+	}
+
+	r, err := NewTSMReader(f)
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+	defer r.Close()
+
+	if err := r.DeleteRange([][]byte{[]byte("mem"), []byte("cpu")}, 0, 3); err != nil {
+		t.Fatalf("unexpected error deleting: %v", err)
+	}
+
+	// Make sure everything is deleted
+	values, err := r.ReadAll([]byte("cpu"))
+	if err != nil {
+		t.Fatalf("unexpected error reading all: %v", err)
+	}
+
+	if got, exp := len(values), 0; got != exp {
+		t.Fatalf("values length mismatch: got %v, exp %v", got, exp)
+	}
+
+	values, err = r.ReadAll([]byte("mem"))
+	if err != nil {
+		t.Fatalf("unexpected error reading all: %v", err)
+	}
+
+	if got, exp := len(values), 2; got != exp {
+		t.Fatalf("values length mismatch: got %v, exp %v", got, exp)
+	}
+}
+
 func TestTSMReader_MMAP_TombstoneMultipleRanges(t *testing.T) {
 	dir := mustTempDir()
 	defer os.RemoveAll(dir)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes a case where data outside of the time range specified in a delete was deleted incorrectly.   

Steps to repro:

```
> insert cpu value=1 0
> insert cpu value=1 1
> insert cpu value=1 2
> insert cpu value1=1 2
> insert cpu value1=1 3
> insert cpu value1=1 4
> select * from cpu
name: cpu
time value value1
---- ----- ------
0    1
1    1
2    1     1
3          1
4          1
> delete from cpu where time >= 0 and time <= 2
> select * from cpu
>
```

With this fix, it works correctly now:

```
> insert cpu value=1 0
> insert cpu value=1 1
> insert cpu value=1 2
> insert cpu value1=1 2
> insert cpu value1=1 3
> insert cpu value1=1 4
> delete from cpu where time >= 0 and time <= 2
> select * from cpu
name: cpu
time value value1
---- ----- ------
3          1
4          1
```

The issue was that if an earlier series (as seen by `DeleteRange`) was fully deleted, a faster path delete case was called with all series instead of the one.

Fixes #7706

