### PR TITLE
Fix data being dropped during compactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - [#8952](https://github.com/influxdata/influxdb/issues/8952): Fix WAL panic: runtime error: makeslice: cap out of range
 - [#8975](https://github.com/influxdata/influxdb/pull/8975): Copy returned bytes from TSI meta functions.
 - [#7797](https://github.com/influxdata/influxdb/issues/7706): Fix data deleted outside of time range
+- [#8822](https://github.com/influxdata/influxdb/issues/8822): Fix data dropped incorrectly during compaction
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"runtime"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -646,6 +647,10 @@ type TimeRange struct {
 	Min, Max int64
 }
 
+func (t TimeRange) Overlaps(min, max int64) bool {
+	return t.Min <= max && t.Max >= min
+}
+
 // NewIndirectIndex returns a new indirect index.
 func NewIndirectIndex() *indirectIndex {
 	return &indirectIndex{
@@ -870,7 +875,59 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) {
 			continue
 		}
 
-		tombstones[string(k)] = append(tombstones[string(k)], TimeRange{minTime, maxTime})
+		d.mu.RLock()
+		existing := d.tombstones[string(k)]
+		d.mu.RUnlock()
+
+		// Append the new tombonstes to the existing ones
+		newTs := append(existing, append(tombstones[string(k)], TimeRange{minTime, maxTime})...)
+		fn := func(i, j int) bool {
+			a, b := newTs[i], newTs[j]
+			if a.Min == b.Min {
+				return a.Max <= b.Max
+			}
+			return a.Min < b.Min
+		}
+
+		// Sort the updated tombstones if necessary
+		if len(newTs) > 1 && !sort.SliceIsSorted(newTs, fn) {
+			sort.Slice(newTs, fn)
+		}
+
+		tombstones[string(k)] = newTs
+
+		// We need to see if all the tombstones end up deleting the entire series.  This
+		// could happen if their is one tombstore with min,max time spanning all the block
+		// time ranges or from multiple smaller tombstones the delete segments.  To detect
+		// this cases, we use a window starting at the first tombstone and grow it be each
+		// tombstone that is immediately adjacent to the current window or if it overlaps.
+		// If there are any gaps, we abort.
+		minTs, maxTs := newTs[0].Min, newTs[0].Max
+		for j := 1; j < len(newTs); j++ {
+			prevTs := newTs[j-1]
+			ts := newTs[j]
+
+			// Make sure all the tombstone line up for a continuous range.  We don't
+			// want to have two small deletes on each edges end up causing us to
+			// remove the full key.
+			if prevTs.Max != ts.Min-1 && !prevTs.Overlaps(ts.Min, ts.Max) {
+				minTs, maxTs = int64(math.MaxInt64), int64(math.MinInt64)
+				break
+			}
+
+			if ts.Min < minTs {
+				minTs = ts.Min
+			}
+			if ts.Max > maxTs {
+				maxTs = ts.Max
+			}
+		}
+
+		// If we have a fully deleted series, delete it all of it.
+		if minTs <= min && maxTs >= max {
+			d.Delete(keys[i : i+1])
+			continue
+		}
 	}
 
 	if len(tombstones) == 0 {
@@ -879,7 +936,7 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) {
 
 	d.mu.Lock()
 	for k, v := range tombstones {
-		d.tombstones[k] = append(d.tombstones[k], v...)
+		d.tombstones[k] = v
 	}
 	d.mu.Unlock()
 }

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -788,6 +788,127 @@ func TestTSMReader_MMAP_TombstoneMultipleRanges(t *testing.T) {
 	}
 }
 
+func TestTSMReader_MMAP_TombstoneMultipleRangesFull(t *testing.T) {
+	dir := mustTempDir()
+	defer os.RemoveAll(dir)
+	f := mustTempFile(dir)
+	defer f.Close()
+
+	w, err := NewTSMWriter(f)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	expValues := []Value{
+		NewValue(1, 1.0),
+		NewValue(2, 2.0),
+	}
+	if err := w.Write([]byte("cpu"), expValues); err != nil {
+		t.Fatalf("unexpected error writing: %v", err)
+	}
+
+	if err := w.WriteIndex(); err != nil {
+		t.Fatalf("unexpected error writing index: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpected error closing: %v", err)
+	}
+
+	f, err = os.Open(f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error open file: %v", err)
+	}
+
+	r, err := NewTSMReader(f)
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+	defer r.Close()
+
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
+		t.Fatalf("unexpected error deleting: %v", err)
+	}
+
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, 2, 2); err != nil {
+		t.Fatalf("unexpected error deleting: %v", err)
+	}
+
+	if got, exp := r.KeyCount(), 0; got != exp {
+		t.Fatalf("key count mismatch: got %v, exp %v", got, exp)
+	}
+
+	values, err := r.ReadAll([]byte("cpu"))
+	if err != nil {
+		t.Fatalf("unexpected error reading all: %v", err)
+	}
+
+	if got, exp := len(values), 0; got != exp {
+		t.Fatalf("values length mismatch: got %v, exp %v", got, exp)
+	}
+}
+
+func TestTSMReader_MMAP_TombstoneMultipleRangesNoOverlap(t *testing.T) {
+	dir := mustTempDir()
+	defer os.RemoveAll(dir)
+	f := mustTempFile(dir)
+	defer f.Close()
+
+	w, err := NewTSMWriter(f)
+	if err != nil {
+		t.Fatalf("unexpected error creating writer: %v", err)
+	}
+
+	expValues := []Value{
+		NewValue(1, 1.0),
+		NewValue(2, 2.0),
+		NewValue(3, 2.0),
+	}
+	if err := w.Write([]byte("cpu"), expValues); err != nil {
+		t.Fatalf("unexpected error writing: %v", err)
+	}
+
+	if err := w.WriteIndex(); err != nil {
+		t.Fatalf("unexpected error writing index: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpected error closing: %v", err)
+	}
+
+	f, err = os.Open(f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error open file: %v", err)
+	}
+
+	r, err := NewTSMReader(f)
+	if err != nil {
+		t.Fatalf("unexpected error created reader: %v", err)
+	}
+	defer r.Close()
+
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
+		t.Fatalf("unexpected error deleting: %v", err)
+	}
+
+	if err := r.DeleteRange([][]byte{[]byte("cpu")}, 3, 3); err != nil {
+		t.Fatalf("unexpected error deleting: %v", err)
+	}
+
+	if got, exp := r.KeyCount(), 1; got != exp {
+		t.Fatalf("key count mismatch: got %v, exp %v", got, exp)
+	}
+
+	values, err := r.ReadAll([]byte("cpu"))
+	if err != nil {
+		t.Fatalf("unexpected error reading all: %v", err)
+	}
+
+	if got, exp := len(values), 1; got != exp {
+		t.Fatalf("values length mismatch: got %v, exp %v", got, exp)
+	}
+}
+
 func TestTSMReader_MMAP_TombstoneOutsideRange(t *testing.T) {
 	dir := mustTempDir()
 	defer os.RemoveAll(dir)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This fixes #8822 and #8937.  

If multiple tombstones exists for a series that ended up causing the
full data to be deleted, the blocks were not removed from the offsets
in the TSM index.  This causes the TSMReader to report that a key exist
but does not have any data which should never happen.

During a compaction, every key should have at least one value.  Since
this invariant was broken, the compaction aborted early and ends up
dropping all series keys that are lexigraphically greater than where
the breakage occured.  This would cause data to be dropped during the
compaction.


To repro this in a live server you can run the following script:

First start the server with:
```
INFLUXDB_DATA_CACHE_SNAPSHOT_WRITE_COLD_DURATION=1s influxd
```

Then run:

```bash
#!/bin/bash

influx -execute "drop database test; create database test"

curl -v "http://localhost:8086/write?db=test" --data-binary 'cpu value=1 0
cpu value=1 1
mem value=1 1
zzz value=1 2
aaa value=1 3'

echo "Waiting 2 seconds for snapshot"
sleep 2

echo "All data is there"
influx -database test -execute "select * from /.*/"

echo "Delete cpu series by exact times"
influx -database test -execute "delete from cpu where time >= 0 and time <= 0; delete from cpu where time >= 1 and time <= 1;"

echo "Waiting for compaction"
sleep 2
echo "All series lexicographically after aaa are gone"

influx -database test -execute "select * from /.*/"
```

This fixes a potential bug where the BlockIterator would skip blocks
if the underlying TSMReader had deletes on it concurrently.  This
could possibly occur due to changes in 91eb9de that now use the
existing TSMReaders from the FileStore instead of creating new ones
during compaction.