### PR TITLE
Sort & validate TSI key value insertion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [#8690](https://github.com/influxdata/influxdb/issues/8690): Implicitly decide on a lower limit for fill queries when none is present.
 - [#8947](https://github.com/influxdata/influxdb/pull/8947): Add `EXPLAIN ANALYZE` command, which produces a detailed execution plan of a `SELECT` statement.
 - [#8963](https://github.com/influxdata/influxdb/pull/8963): Streaming inmem2tsi conversion.
+- [#8995](https://github.com/influxdata/influxdb/pull/8995): Sort & validate TSI key value insertion. 
 
 ### Bugfixes
 

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -966,8 +966,16 @@ func (f *LogFile) writeTagsetTo(w io.Writer, name string, info *logFileCompactIn
 		tagSetInfo := mmInfo.tagSet[k]
 		assert(tagSetInfo != nil, "tag set info not found")
 
+		// Sort tag values.
+		values := make([]string, 0, len(tag.tagValues))
+		for v := range tag.tagValues {
+			values = append(values, v)
+		}
+		sort.Strings(values)
+
 		// Add each value.
-		for v, value := range tag.tagValues {
+		for _, v := range values {
+			value := tag.tagValues[v]
 			tagValueInfo := tagSetInfo.tagValues[v]
 			sort.Sort(uint32Slice(tagValueInfo.seriesIDs))
 


### PR DESCRIPTION
## Overview 

The `TagBlockEncoder` value sorting was removed at some point and the underlying input was done via a range over a map which has unpredictable sorting. This fixes the sorting and adds additional validation to ensure inputs are always ordered when compacting index files.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
