### PR TITLE
1.3: Sort & validate TSI key value insertion.

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -927,8 +927,16 @@ func (f *LogFile) writeTagsetTo(w io.Writer, name string, info *logFileCompactIn
 		tagSetInfo := mmInfo.tagSet[k]
 		assert(tagSetInfo != nil, "tag set info not found")
 
+		// Sort tag values.
+		values := make([]string, 0, len(tag.tagValues))
+		for v := range tag.tagValues {
+			values = append(values, v)
+		}
+		sort.Strings(values)
+
 		// Add each value.
-		for v, value := range tag.tagValues {
+		for _, v := range values {
+			value := tag.tagValues[v]
 			tagValueInfo := tagSetInfo.tagValues[v]
 			sort.Sort(uint32Slice(tagValueInfo.seriesIDs))
 


### PR DESCRIPTION
Backport of https://github.com/influxdata/influxdb/pull/8995