### PR TITLE
return query.ErrQueryInterrupted for read on InterruptCh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - [#8822](https://github.com/influxdata/influxdb/issues/8822): Fix data dropped incorrectly during compaction
 - [#8780](https://github.com/influxdata/influxdb/issues/8780): Prevent deadlock during collectd, graphite, opentsdb, and udp shutdown.
 - [#8983](https://github.com/influxdata/influxdb/issues/8983): Remove the pidfile after the server has exited.
+- [#9005](https://github.com/influxdata/influxdb/pull/9005): Return `query.ErrQueryInterrupted` for successful read on `InterruptCh`.
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1770,7 +1770,7 @@ func (e *Engine) createCallIterator(ctx context.Context, measurement string, cal
 			select {
 			case <-opt.InterruptCh:
 				query.Iterators(itrs).Close()
-				return err
+				return query.ErrQueryInterrupted
 			default:
 			}
 
@@ -1973,7 +1973,7 @@ func (e *Engine) createTagSetGroupIterators(ctx context.Context, ref *influxql.V
 		select {
 		case <-opt.InterruptCh:
 			query.Iterators(itrs).Close()
-			return nil, err
+			return nil, query.ErrQueryInterrupted
 		default:
 		}
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1260,7 +1260,7 @@ func (a Shards) CreateIterator(ctx context.Context, measurement string, opt quer
 		select {
 		case <-opt.InterruptCh:
 			query.Iterators(itrs).Close()
-			return nil, err
+			return nil, query.ErrQueryInterrupted
 		default:
 		}
 


### PR DESCRIPTION
Some reads on the `InterruptCh` channel were not returning `ErrQueryInterrupted`

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
