### PR TITLE
Fix race in Measurement index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - [#8780](https://github.com/influxdata/influxdb/issues/8780): Prevent deadlock during collectd, graphite, opentsdb, and udp shutdown.
 - [#8983](https://github.com/influxdata/influxdb/issues/8983): Remove the pidfile after the server has exited.
 - [#9005](https://github.com/influxdata/influxdb/pull/9005): Return `query.ErrQueryInterrupted` for successful read on `InterruptCh`.
+- [#8989](https://github.com/influxdata/influxdb/issues/8989): Fix race inside Measurement index.
 
 ## v1.3.4 [unreleased]
 

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -516,18 +516,20 @@ func (i *Index) measurementNamesByTagFilters(filter *TagFilter) [][]byte {
 
 		// If the operator is non-regex, only check the specified value.
 		if filter.Op == influxql.EQ || filter.Op == influxql.NEQ {
-			if _, ok := tagVals[filter.Value]; ok {
+			if tagVals.Contains(filter.Value) {
 				tagMatch = true
 			}
 		} else {
 			// Else, the operator is a regex and we have to check all tag
 			// values against the regular expression.
-			for tagVal := range tagVals {
-				if filter.Regex.MatchString(tagVal) {
+			tagVals.Range(func(k string, _ SeriesIDs) bool {
+				if filter.Regex.MatchString(k) {
 					tagMatch = true
-					continue
 				}
-			}
+				// If a tag matches then the Range over remaining tags can be
+				// ceased.
+				return !tagMatch
+			})
 		}
 
 		//


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #8989 and #8633.

Previously when issuing commands involving a regex check, walking
through the tags keys/values on a measurement, using the measurement's
index, would be racy.

This commit adds a new `TagKeyValue` type that abstracts away the
multi-layer map we were using as an inverted index from tag keys and
values to series ids. With this abstraction we can also make concurrent
access to this inverted index goroutine safe.

Finally, this commit fixes a very old bug in the index which could affect queries using a regex. Previously we would always check every tag against a regex for a measurement, even when we had found a match.