### PR TITLE
Ensure retention service removes shards locally 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - [#8983](https://github.com/influxdata/influxdb/issues/8983): Remove the pidfile after the server has exited.
 - [#9005](https://github.com/influxdata/influxdb/pull/9005): Return `query.ErrQueryInterrupted` for successful read on `InterruptCh`.
 - [#8989](https://github.com/influxdata/influxdb/issues/8989): Fix race inside Measurement index.
+- [#8819](https://github.com/influxdata/influxdb/issues/8819): Ensure retention service always removes local shards.
 
 ## v1.3.4 [unreleased]
 

--- a/internal/meta_client.go
+++ b/internal/meta_client.go
@@ -32,6 +32,8 @@ type MetaClientMock struct {
 
 	OpenFn func() error
 
+	PruneShardGroupsFn func() error
+
 	RetentionPolicyFn func(database, name string) (rpi *meta.RetentionPolicyInfo, err error)
 
 	AuthenticateFn           func(username, password string) (ui meta.User, err error)
@@ -164,3 +166,5 @@ func (c *MetaClientMock) Users() []meta.UserInfo                  { return c.Use
 func (c *MetaClientMock) Open() error                { return c.OpenFn() }
 func (c *MetaClientMock) Data() meta.Data            { return c.DataFn() }
 func (c *MetaClientMock) SetData(d *meta.Data) error { return c.SetDataFn(d) }
+
+func (c *MetaClientMock) PruneShardGroups() error { return c.PruneShardGroupsFn() }

--- a/internal/tsdb_store.go
+++ b/internal/tsdb_store.go
@@ -8,7 +8,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/tsdb"
-	"go.uber.org/zap"
+	"github.com/uber-go/zap"
 )
 
 // TSDBStoreMock is a mockable implementation of tsdb.Store.

--- a/internal/tsdb_store.go
+++ b/internal/tsdb_store.go
@@ -1,0 +1,139 @@
+package internal
+
+import (
+	"io"
+	"time"
+
+	"github.com/influxdata/influxdb/influxql"
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/query"
+	"github.com/influxdata/influxdb/tsdb"
+	"go.uber.org/zap"
+)
+
+// TSDBStoreMock is a mockable implementation of tsdb.Store.
+type TSDBStoreMock struct {
+	BackupShardFn             func(id uint64, since time.Time, w io.Writer) error
+	CloseFn                   func() error
+	CreateShardFn             func(database, policy string, shardID uint64, enabled bool) error
+	CreateShardSnapshotFn     func(id uint64) (string, error)
+	DatabasesFn               func() []string
+	DeleteDatabaseFn          func(name string) error
+	DeleteMeasurementFn       func(database, name string) error
+	DeleteRetentionPolicyFn   func(database, name string) error
+	DeleteSeriesFn            func(database string, sources []influxql.Source, condition influxql.Expr) error
+	DeleteShardFn             func(id uint64) error
+	DiskSizeFn                func() (int64, error)
+	ExpandSourcesFn           func(sources influxql.Sources) (influxql.Sources, error)
+	ImportShardFn             func(id uint64, r io.Reader) error
+	MeasurementSeriesCountsFn func(database string) (measuments int, series int)
+	MeasurementsCardinalityFn func(database string) (int64, error)
+	MeasurementNamesFn        func(database string, cond influxql.Expr) ([][]byte, error)
+	OpenFn                    func() error
+	PathFn                    func() string
+	RestoreShardFn            func(id uint64, r io.Reader) error
+	SeriesCardinalityFn       func(database string) (int64, error)
+	SetShardEnabledFn         func(shardID uint64, enabled bool) error
+	ShardFn                   func(id uint64) *tsdb.Shard
+	ShardGroupFn              func(ids []uint64) tsdb.ShardGroup
+	ShardIDsFn                func() []uint64
+	ShardNFn                  func() int
+	ShardRelativePathFn       func(id uint64) (string, error)
+	ShardsFn                  func(ids []uint64) []*tsdb.Shard
+	StatisticsFn              func(tags map[string]string) []models.Statistic
+	TagValuesFn               func(auth query.Authorizer, database string, cond influxql.Expr) ([]tsdb.TagValues, error)
+	WithLoggerFn              func(log zap.Logger)
+	WriteToShardFn            func(shardID uint64, points []models.Point) error
+}
+
+func (s *TSDBStoreMock) BackupShard(id uint64, since time.Time, w io.Writer) error {
+	return s.BackupShardFn(id, since, w)
+}
+func (s *TSDBStoreMock) Close() error { return s.CloseFn() }
+func (s *TSDBStoreMock) CreateShard(database string, retentionPolicy string, shardID uint64, enabled bool) error {
+	return s.CreateShardFn(database, retentionPolicy, shardID, enabled)
+}
+func (s *TSDBStoreMock) CreateShardSnapshot(id uint64) (string, error) {
+	return s.CreateShardSnapshotFn(id)
+}
+func (s *TSDBStoreMock) Databases() []string {
+	return s.DatabasesFn()
+}
+func (s *TSDBStoreMock) DeleteDatabase(name string) error {
+	return s.DeleteDatabaseFn(name)
+}
+func (s *TSDBStoreMock) DeleteMeasurement(database string, name string) error {
+	return s.DeleteMeasurementFn(database, name)
+}
+func (s *TSDBStoreMock) DeleteRetentionPolicy(database string, name string) error {
+	return s.DeleteRetentionPolicyFn(database, name)
+}
+func (s *TSDBStoreMock) DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr) error {
+	return s.DeleteSeriesFn(database, sources, condition)
+}
+func (s *TSDBStoreMock) DeleteShard(shardID uint64) error {
+	return s.DeleteShardFn(shardID)
+}
+func (s *TSDBStoreMock) DiskSize() (int64, error) {
+	return s.DiskSizeFn()
+}
+func (s *TSDBStoreMock) ExpandSources(sources influxql.Sources) (influxql.Sources, error) {
+	return s.ExpandSourcesFn(sources)
+}
+func (s *TSDBStoreMock) ImportShard(id uint64, r io.Reader) error {
+	return s.ImportShardFn(id, r)
+}
+func (s *TSDBStoreMock) MeasurementNames(database string, cond influxql.Expr) ([][]byte, error) {
+	return s.MeasurementNamesFn(database, cond)
+}
+func (s *TSDBStoreMock) MeasurementSeriesCounts(database string) (measuments int, series int) {
+	return s.MeasurementSeriesCountsFn(database)
+}
+func (s *TSDBStoreMock) MeasurementsCardinality(database string) (int64, error) {
+	return s.MeasurementsCardinalityFn(database)
+}
+func (s *TSDBStoreMock) Open() error {
+	return s.OpenFn()
+}
+func (s *TSDBStoreMock) Path() string {
+	return s.PathFn()
+}
+func (s *TSDBStoreMock) RestoreShard(id uint64, r io.Reader) error {
+	return s.RestoreShardFn(id, r)
+}
+func (s *TSDBStoreMock) SeriesCardinality(database string) (int64, error) {
+	return s.SeriesCardinalityFn(database)
+}
+func (s *TSDBStoreMock) SetShardEnabled(shardID uint64, enabled bool) error {
+	return s.SetShardEnabledFn(shardID, enabled)
+}
+func (s *TSDBStoreMock) Shard(id uint64) *tsdb.Shard {
+	return s.ShardFn(id)
+}
+func (s *TSDBStoreMock) ShardGroup(ids []uint64) tsdb.ShardGroup {
+	return s.ShardGroupFn(ids)
+}
+func (s *TSDBStoreMock) ShardIDs() []uint64 {
+	return s.ShardIDsFn()
+}
+func (s *TSDBStoreMock) ShardN() int {
+	return s.ShardNFn()
+}
+func (s *TSDBStoreMock) ShardRelativePath(id uint64) (string, error) {
+	return s.ShardRelativePathFn(id)
+}
+func (s *TSDBStoreMock) Shards(ids []uint64) []*tsdb.Shard {
+	return s.ShardsFn(ids)
+}
+func (s *TSDBStoreMock) Statistics(tags map[string]string) []models.Statistic {
+	return s.StatisticsFn(tags)
+}
+func (s *TSDBStoreMock) TagValues(auth query.Authorizer, database string, cond influxql.Expr) ([]tsdb.TagValues, error) {
+	return s.TagValuesFn(auth, database, cond)
+}
+func (s *TSDBStoreMock) WithLogger(log zap.Logger) {
+	s.WithLoggerFn(log)
+}
+func (s *TSDBStoreMock) WriteToShard(shardID uint64, points []models.Point) error {
+	return s.WriteToShardFn(shardID, points)
+}

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -44,12 +44,10 @@ func (s *Service) Open() error {
 	}
 
 	s.logger.Info(fmt.Sprint("Starting retention policy enforcement service with check interval of ", s.config.CheckInterval))
-
 	s.done = make(chan struct{})
 
-	s.wg.Add(2)
-	go s.deleteShardGroups()
-	go s.deleteShards()
+	s.wg.Add(1)
+	go func() { defer s.wg.Done(); s.run() }()
 	return nil
 }
 
@@ -59,7 +57,7 @@ func (s *Service) Close() error {
 		return nil
 	}
 
-	s.logger.Info("retention policy enforcement terminating")
+	s.logger.Info("Retention policy enforcement service closing.")
 	close(s.done)
 
 	s.wg.Wait()
@@ -72,9 +70,7 @@ func (s *Service) WithLogger(log zap.Logger) {
 	s.logger = log.With(zap.String("service", "retention"))
 }
 
-func (s *Service) deleteShardGroups() {
-	defer s.wg.Done()
-
+func (s *Service) run() {
 	ticker := time.NewTicker(time.Duration(s.config.CheckInterval))
 	defer ticker.Stop()
 	for {
@@ -83,46 +79,26 @@ func (s *Service) deleteShardGroups() {
 			return
 
 		case <-ticker.C:
-			dbs := s.MetaClient.Databases()
-			for _, d := range dbs {
-				for _, r := range d.RetentionPolicies {
-					for _, g := range r.ExpiredShardGroups(time.Now().UTC()) {
-						if err := s.MetaClient.DeleteShardGroup(d.Name, r.Name, g.ID); err != nil {
-							s.logger.Info(fmt.Sprintf("failed to delete shard group %d from database %s, retention policy %s: %s",
-								g.ID, d.Name, r.Name, err.Error()))
-						} else {
-							s.logger.Info(fmt.Sprintf("deleted shard group %d from database %s, retention policy %s",
-								g.ID, d.Name, r.Name))
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
-func (s *Service) deleteShards() {
-	defer s.wg.Done()
-
-	ticker := time.NewTicker(time.Duration(s.config.CheckInterval))
-	defer ticker.Stop()
-	for {
-		select {
-		case <-s.done:
-			return
-
-		case <-ticker.C:
-			s.logger.Info("retention policy shard deletion check commencing")
+			s.logger.Info("Retention policy shard deletion check commencing.")
 
 			type deletionInfo struct {
 				db string
 				rp string
 			}
 			deletedShardIDs := make(map[uint64]deletionInfo, 0)
+
 			dbs := s.MetaClient.Databases()
 			for _, d := range dbs {
 				for _, r := range d.RetentionPolicies {
-					for _, g := range r.DeletedShardGroups() {
+					for _, g := range r.ExpiredShardGroups(time.Now().UTC()) {
+						if err := s.MetaClient.DeleteShardGroup(d.Name, r.Name, g.ID); err != nil {
+							s.logger.Info(fmt.Sprintf("Failed to delete shard group %d from database %s, retention policy %s: %v. Retry in %v.", g.ID, d.Name, r.Name, err, s.config.CheckInterval))
+							continue
+						}
+
+						s.logger.Info(fmt.Sprintf("Deleted shard group %d from database %s, retention policy %s.", g.ID, d.Name, r.Name))
+
+						// Store all the shard IDs that may possibly need to be removed locally.
 						for _, sh := range g.Shards {
 							deletedShardIDs[sh.ID] = deletionInfo{db: d.Name, rp: r.Name}
 						}
@@ -130,19 +106,19 @@ func (s *Service) deleteShards() {
 				}
 			}
 
+			// Remove shards if we store them locally
 			for _, id := range s.TSDBStore.ShardIDs() {
 				if info, ok := deletedShardIDs[id]; ok {
 					if err := s.TSDBStore.DeleteShard(id); err != nil {
-						s.logger.Error(fmt.Sprintf("failed to delete shard ID %d from database %s, retention policy %s: %s",
-							id, info.db, info.rp, err.Error()))
+						s.logger.Error(fmt.Sprintf("Failed to delete shard ID %d from database %s, retention policy %s: %v. Will retry in %v", id, info.db, info.rp, err, s.config.CheckInterval))
 						continue
 					}
-					s.logger.Info(fmt.Sprintf("shard ID %d from database %s, retention policy %s, deleted",
-						id, info.db, info.rp))
+					s.logger.Info(fmt.Sprintf("Shard ID %d from database %s, retention policy %s, deleted.", id, info.db, info.rp))
 				}
 			}
+
 			if err := s.MetaClient.PruneShardGroups(); err != nil {
-				s.logger.Info(fmt.Sprintf("error pruning shard groups: %s", err))
+				s.logger.Info(fmt.Sprintf("Problem pruning shard groups: %s. Will retry in %v", err, s.config.CheckInterval))
 			}
 		}
 	}

--- a/services/retention/service_test.go
+++ b/services/retention/service_test.go
@@ -2,10 +2,15 @@ package retention_test
 
 import (
 	"bytes"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/influxdata/influxdb/internal"
+	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/services/retention"
+	"github.com/influxdata/influxdb/toml"
 	"github.com/uber-go/zap"
 )
 
@@ -51,6 +56,141 @@ func TestService_OpenClose(t *testing.T) {
 	}
 }
 
+// This reproduces https://github.com/influxdata/influxdb/issues/8819
+func TestService_8819_repro(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		s, errC := testService_8819_repro(t)
+
+		if err := s.Open(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Wait for service to run.
+		if err := <-errC; err != nil {
+			t.Fatalf("%dth iteration: %v", i, err)
+		}
+	}
+}
+
+func testService_8819_repro(t *testing.T) (*Service, chan error) {
+	c := retention.NewConfig()
+	c.CheckInterval = toml.Duration(time.Millisecond)
+	s := NewService(c)
+	errC := make(chan error)
+
+	// A database and a bunch of shards
+	var mu sync.Mutex
+	shards := []uint64{3, 5, 8, 9, 11}
+	localShards := []uint64{3, 5, 8, 9, 11}
+	databases := []meta.DatabaseInfo{
+		{
+			Name: "db0",
+			RetentionPolicies: []meta.RetentionPolicyInfo{
+				{
+					Name:               "autogen",
+					Duration:           time.Millisecond,
+					ShardGroupDuration: time.Millisecond,
+					ShardGroups: []meta.ShardGroupInfo{
+						{
+							ID:        1,
+							StartTime: time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC),
+							EndTime:   time.Date(1981, 1, 1, 0, 0, 0, 0, time.UTC),
+							Shards: []meta.ShardInfo{
+								{ID: 3}, {ID: 9},
+							},
+						},
+					},
+				},
+			},
+			// TODO - add expired stuff
+		},
+	}
+
+	s.MetaClient.DatabasesFn = func() []meta.DatabaseInfo {
+		mu.Lock()
+		defer mu.Unlock()
+		return databases
+	}
+
+	s.MetaClient.DeleteShardGroupFn = func(database string, policy string, id uint64) error {
+		if database != "db0" {
+			errC <- fmt.Errorf("wrong db name: %s", database)
+		} else if policy != "autogen" {
+			errC <- fmt.Errorf("wrong rp name: %s", policy)
+		} else if id != 1 {
+			errC <- fmt.Errorf("wrong shard group id: %d", id)
+		}
+
+		// remove the associated shards (3 and 9) from the shards slice...
+		mu.Lock()
+		newShards := make([]uint64, 0, len(shards))
+		for _, sid := range shards {
+			if sid != 3 && sid != 9 {
+				newShards = append(newShards, sid)
+			}
+		}
+		shards = newShards
+		databases[0].RetentionPolicies[0].ShardGroups[0].DeletedAt = time.Now().UTC()
+		mu.Unlock()
+		return nil
+	}
+
+	s.MetaClient.PruneShardGroupsFn = func() error {
+		// When this is called all shards that have been deleted from the meta
+		// store (expired) should also have been deleted from disk.
+		// If they haven't then that indicates that shards can be removed from
+		// the meta store and there can be a race where they haven't yet been
+		// removed from the local disk and indexes. This has an impact on, for
+		// example, the max series per database limit.
+
+		mu.Lock()
+		defer mu.Unlock()
+		for _, lid := range localShards {
+			var found bool
+			for _, mid := range shards {
+				if lid == mid {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				errC <- fmt.Errorf("local shard %d present, yet it's missing from meta store. %v -- %v ", lid, shards, localShards)
+			}
+		}
+		errC <- nil
+		return nil
+	}
+
+	s.TSDBStore.ShardIDsFn = func() []uint64 {
+		mu.Lock()
+		defer mu.Unlock()
+		return localShards
+	}
+
+	s.TSDBStore.DeleteShardFn = func(id uint64) error {
+		var found bool
+		mu.Lock()
+		newShards := make([]uint64, 0, len(localShards))
+		for _, sid := range localShards {
+			if sid != id {
+				newShards = append(newShards, sid)
+			} else {
+				found = true
+			}
+		}
+		localShards = newShards
+		mu.Unlock()
+
+		if !found {
+			return fmt.Errorf("shard %d not found locally", id)
+		}
+		return nil
+	}
+
+	return s, errC
+}
+
 type Service struct {
 	MetaClient *internal.MetaClientMock
 	TSDBStore  *internal.TSDBStoreMock
@@ -66,9 +206,11 @@ func NewService(c retention.Config) *Service {
 		Service:    retention.NewService(c),
 	}
 
+	mls := zap.MultiWriteSyncer(zap.AddSync(&s.LogBuf))
+
 	l := zap.New(
 		zap.NewTextEncoder(),
-		zap.Output(zap.AddSync(&s.LogBuf)),
+		zap.Output(mls),
 	)
 	s.WithLogger(l)
 

--- a/services/retention/service_test.go
+++ b/services/retention/service_test.go
@@ -1,0 +1,78 @@
+package retention_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/influxdata/influxdb/internal"
+	"github.com/influxdata/influxdb/services/retention"
+	"github.com/uber-go/zap"
+)
+
+func TestService_OpenDisabled(t *testing.T) {
+	// Opening a disabled service should be a no-op.
+	c := retention.NewConfig()
+	c.Enabled = false
+	s := NewService(c)
+
+	if err := s.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.LogBuf.String() != "" {
+		t.Fatalf("service logged %q, didn't expect any logging", s.LogBuf.String())
+	}
+}
+
+func TestService_OpenClose(t *testing.T) {
+	// Opening a disabled service should be a no-op.
+	s := NewService(retention.NewConfig())
+
+	if err := s.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.LogBuf.String() == "" {
+		t.Fatal("service didn't log anything on open")
+	}
+
+	// Reopening is a no-op
+	if err := s.Open(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-closing is a no-op
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type Service struct {
+	MetaClient *internal.MetaClientMock
+	TSDBStore  *internal.TSDBStoreMock
+
+	LogBuf bytes.Buffer
+	*retention.Service
+}
+
+func NewService(c retention.Config) *Service {
+	s := &Service{
+		MetaClient: &internal.MetaClientMock{},
+		TSDBStore:  &internal.TSDBStoreMock{},
+		Service:    retention.NewService(c),
+	}
+
+	l := zap.New(
+		zap.NewTextEncoder(),
+		zap.Output(zap.AddSync(&s.LogBuf)),
+	)
+	s.WithLogger(l)
+
+	s.Service.MetaClient = s.MetaClient
+	s.Service.TSDBStore = s.TSDBStore
+	return s
+}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated

Fixes #8819.

As well as the main fix, this PR adds a generic `tsdb.Store` mock to the `internal` package, which can be used in other parts of the codebase. It also adds some initial testing to the Retention Service, as well as a repro test for #8819.

Previously, the process of dropping expired shards according to the retention policy duration, was managed by two independent goroutines in the retention policy service. This behaviour was introduced in #2776, at a time when there were both data and meta nodes in the OSS codebase.
The idea was that only the leader meta node would run the meta data deletions in the first goroutine, and all other nodes would run the local deletions in the second goroutine.

InfluxDB no longer operates in that way, and so we ended up with two independent goroutines that were carrying out an action that was in reality dependent on each other.

If the second goroutine (local deleter) runs before the first (meta deleter), then it may not have yet seen the meta data changes indicating which shards should be deleted. Therefore, it won't
delete any of those shards locally. Shortly after this, the first goroutine will run and remove the meta data for the shard groups.

This results in a situation where it looks like the shards have gone, e.g., according to `SHOW SHARDS` or `SHOW SERIES`, but in fact the shards remain on disk (and importantly, their series remains within the index) until the next time the second goroutine runs. By default that's another 30 minutes.

In the case where the shards to be removed would have removed the last occurrences of some series, then it's possible that if the database was already at its maximum series limit (or tag limit for that matter), no further new series can be inserted.
