### PR TITLE
Do not panic when the task manager closes if a killed query is still running

### DIFF
--- a/query/query_executor.go
+++ b/query/query_executor.go
@@ -35,6 +35,9 @@ var (
 
 	// ErrQueryTimeoutLimitExceeded is an error when a query hits the max time allowed to run.
 	ErrQueryTimeoutLimitExceeded = errors.New("query-timeout limit exceeded")
+
+	// ErrAlreadyKilled is returned when attempting to kill a query that has already been killed.
+	ErrAlreadyKilled = errors.New("already killed")
 )
 
 // Statistics for the QueryExecutor
@@ -478,4 +481,25 @@ func (q *QueryTask) monitor(fn QueryMonitorFunc) {
 		case q.monitorCh <- err:
 		}
 	}
+}
+
+// close closes the query task closing channel if the query hasn't been previously killed.
+func (q *QueryTask) close() {
+	q.mu.Lock()
+	if q.status != KilledTask {
+		close(q.closing)
+	}
+	q.mu.Unlock()
+}
+
+func (q *QueryTask) kill() error {
+	q.mu.Lock()
+	if q.status == KilledTask {
+		q.mu.Unlock()
+		return ErrAlreadyKilled
+	}
+	q.status = KilledTask
+	close(q.closing)
+	q.mu.Unlock()
+	return nil
 }


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<[influxdata/docs.influxdata.com#1307](https://github.com/influxdata/docs.influxdata.com/issues/1307)\>

This prevents a channel from being closed twice when the task manager is
closed. That same check existed to make sure a panic didn't happen when
detaching a killed query, but the check was forgotten when closing the
task manager.

This also adds a new error when attempting to kill an already killed
query.

Fixes #9018.