### PR TITLE
handle nil *indexSeriesCursor

### DIFF
--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -79,13 +79,12 @@ func (s *Store) Read(ctx context.Context, req *ReadRequest) (*ResultSet, error) 
 	}
 
 	var cur seriesCursor
-	cur, err = newIndexSeriesCursor(ctx, req, s.TSDBStore.Shards(shardIDs))
-	if err != nil {
+	if ic, err := newIndexSeriesCursor(ctx, req, s.TSDBStore.Shards(shardIDs)); err != nil {
 		return nil, err
-	}
-
-	if cur == nil {
+	} else if ic == nil {
 		return nil, nil
+	} else {
+		cur = ic
 	}
 
 	if len(req.Grouping) > 0 {


### PR DESCRIPTION
This occurred due to incompatible TSI data between 1.3. and 1.4

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
