### PR TITLE
Use random port in PID file test

### DIFF
--- a/cmd/influxd/run/command_test.go
+++ b/cmd/influxd/run/command_test.go
@@ -20,6 +20,14 @@ func TestCommand_PIDFile(t *testing.T) {
 	pidFile := filepath.Join(tmpdir, "influxdb.pid")
 
 	cmd := run.NewCommand()
+	cmd.Getenv = func(key string) string {
+		switch key {
+		case "INFLUXDB_BIND_ADDRESS", "INFLUXDB_HTTP_BIND_ADDRESS":
+			return "127.0.0.1:0"
+		default:
+			return os.Getenv(key)
+		}
+	}
 	if err := cmd.Run("-pidfile", pidFile); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

If you have InfluxDB running locally with default settings then `TestCommand_PIDFile` will always fail due to a port clash.

This PR assigns a random port when running the test.