### PR TITLE
Use the appropriate environment variable for the wal directory

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -38,7 +38,7 @@ func NewTestRunCommand(env map[string]string) *TestRunCommand {
 			return filepath.Join(dir, "data")
 		case "INFLUXDB_META_DIR":
 			return filepath.Join(dir, "meta")
-		case "INFLUXDB_WAL_DIR":
+		case "INFLUXDB_DATA_WAL_DIR":
 			return filepath.Join(dir, "wal")
 		case "INFLUXDB_HTTP_BIND_ADDRESS":
 			return "localhost:0"


### PR DESCRIPTION
The integration test was intended to use the temporary directory for the
files that were created, but `INFLUXDB_WAL_DIR` is supposed to be
`INFLUXDB_DATA_WAL_DIR`.

- [ ] Rebased/mergable
- [ ] Tests pass