### PR TITLE
Update AppVeyor to use Go 1.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ clone_folder: c:\gopath\src\github.com\influxdata\influxdb
 
 # Environment variables
 environment:
-  GOROOT: C:\go18
+  GOROOT: C:\go19
   GOPATH: C:\gopath
 
 # Scripts that run after cloning repository


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass

Updates AppVeyor CI to use Go 1.9.