### PR TITLE
Handle high cardinality deletes in TSM engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * The default logging format has been changed. See [#9055](https://github.com/influxdata/influxdb/pull/9055) for details.
 
+### Features
+
+- [#9088](https://github.com/influxdata/influxdb/pull/9084): Handle high cardinality deletes in TSM engine
+
 ### Bugfixes
 
 - [#8538](https://github.com/influxdata/influxdb/pull/8538): Fix panic: runtime error: slice bounds out of range

--- a/cmd/influxd/run/command_test.go
+++ b/cmd/influxd/run/command_test.go
@@ -19,6 +19,11 @@ func TestCommand_PIDFile(t *testing.T) {
 
 	pidFile := filepath.Join(tmpdir, "influxdb.pid")
 
+	// Override the default data/wal dir so it doesn't look in ~/.influxdb which
+	// might have junk not related to this test.
+	os.Setenv("INFLUXDB_DATA_DIR", tmpdir)
+	os.Setenv("INFLUXDB_DATA_WAL_DIR", tmpdir)
+
 	cmd := run.NewCommand()
 	cmd.Getenv = func(key string) string {
 		switch key {

--- a/models/points.go
+++ b/models/points.go
@@ -263,6 +263,11 @@ func ParsePointsString(buf string) ([]Point, error) {
 // NOTE: to minimize heap allocations, the returned Tags will refer to subslices of buf.
 // This can have the unintended effect preventing buf from being garbage collected.
 func ParseKey(buf []byte) (string, Tags) {
+	meas, tags := ParseKeyBytes(buf)
+	return string(meas), tags
+}
+
+func ParseKeyBytes(buf []byte) ([]byte, Tags) {
 	// Ignore the error because scanMeasurement returns "missing fields" which we ignore
 	// when just parsing a key
 	state, i, _ := scanMeasurement(buf, 0)
@@ -271,9 +276,9 @@ func ParseKey(buf []byte) (string, Tags) {
 	if state == tagKeyState {
 		tags = parseTags(buf)
 		// scanMeasurement returns the location of the comma if there are tags, strip that off
-		return string(buf[:i-1]), tags
+		return buf[:i-1], tags
 	}
-	return string(buf[:i]), tags
+	return buf[:i], tags
 }
 
 func ParseTags(buf []byte) (Tags, error) {

--- a/pkg/bytesutil/bytesutil.go
+++ b/pkg/bytesutil/bytesutil.go
@@ -112,6 +112,11 @@ func CloneSlice(a [][]byte) [][]byte {
 func Pack(a []byte, width int, val byte) []byte {
 	var i, j, iStart, jStart, end int
 
+	fill := make([]byte, width)
+	for i := 0; i < len(fill); i++ {
+		fill[i] = val
+	}
+
 	// Skip the first run that won't move
 	for ; i < len(a) && a[i] != val; i += width {
 	}
@@ -134,13 +139,10 @@ func Pack(a []byte, width int, val byte) []byte {
 		}
 
 		// Move the non-gap over the section to remove.
-		copy(a[iStart:], a[jStart:j])
+		copy(a[end:], a[jStart:j])
 		i = iStart + len(a[jStart:j])
-		for k := i; k < j; k++ {
-			a[k] = val
-		}
-
-		end = i
+		end += j - jStart
+		i = j
 	}
 
 	return a[:end]

--- a/pkg/bytesutil/bytesutil.go
+++ b/pkg/bytesutil/bytesutil.go
@@ -107,6 +107,45 @@ func CloneSlice(a [][]byte) [][]byte {
 	return other
 }
 
+// Pack converts a sparse array to a dense one.  It removes sections of a containing
+// runs of val of length width.  The returned value is a subslice of a.
+func Pack(a []byte, width int, val byte) []byte {
+	var i, j, iStart, jStart, end int
+
+	// Skip the first run that won't move
+	for ; i < len(a) && a[i] != val; i += width {
+	}
+	end = i
+
+	for i < len(a) {
+		// Find the next gap to remove
+		iStart = i
+		for i < len(a) && a[i] == val {
+			i += width
+		}
+
+		// Find the next non-gap to keep
+		jStart = i
+		for j = i; j < len(a) && a[j] != val; j += width {
+		}
+
+		if jStart == len(a) {
+			break
+		}
+
+		// Move the non-gap over the section to remove.
+		copy(a[iStart:], a[jStart:j])
+		i = iStart + len(a[jStart:j])
+		for k := i; k < j; k++ {
+			a[k] = val
+		}
+
+		end = i
+	}
+
+	return a[:end]
+}
+
 type byteSlices [][]byte
 
 func (a byteSlices) Len() int           { return len(a) }

--- a/pkg/bytesutil/bytesutil_test.go
+++ b/pkg/bytesutil/bytesutil_test.go
@@ -106,3 +106,27 @@ func TestPack_WidthOne_Last(t *testing.T) {
 		}
 	}
 }
+
+func TestPack_WidthOne_LastFill(t *testing.T) {
+	a := make([]byte, 8)
+
+	a[0] = 255
+	a[1] = 255
+	a[2] = 2
+	a[3] = 2
+	a[4] = 2
+	a[5] = 2
+	a[6] = 2
+	a[7] = 2
+
+	a = bytesutil.Pack(a, 2, 255)
+	if got, exp := len(a), 6; got != exp {
+		t.Fatalf("len mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range []byte{2, 2, 2, 2, 2, 2} {
+		if got, exp := a[i], v; got != exp {
+			t.Fatalf("value mismatch: a[%d] = %v, exp %v", i, got, exp)
+		}
+	}
+}

--- a/pkg/bytesutil/bytesutil_test.go
+++ b/pkg/bytesutil/bytesutil_test.go
@@ -33,3 +33,76 @@ func TestSearchBytesFixed(t *testing.T) {
 		t.Fatalf("index mismatch: exp %v, got %v", exp, got)
 	}
 }
+
+func TestPack_WidthOne_One(t *testing.T) {
+	a := make([]byte, 8)
+
+	a[4] = 1
+
+	a = bytesutil.Pack(a, 1, 0)
+	if got, exp := len(a), 1; got != exp {
+		t.Fatalf("len mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range []byte{1} {
+		if got, exp := a[i], v; got != exp {
+			t.Fatalf("value mismatch: a[%d] = %v, exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestPack_WidthOne_Two(t *testing.T) {
+	a := make([]byte, 8)
+
+	a[4] = 1
+	a[6] = 2
+
+	a = bytesutil.Pack(a, 1, 0)
+	if got, exp := len(a), 2; got != exp {
+		t.Fatalf("len mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range []byte{1, 2} {
+		if got, exp := a[i], v; got != exp {
+			t.Fatalf("value mismatch: a[%d] = %v, exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestPack_WidthTwo_Two(t *testing.T) {
+	a := make([]byte, 8)
+
+	a[2] = 1
+	a[3] = 1
+	a[6] = 2
+	a[7] = 2
+
+	a = bytesutil.Pack(a, 2, 0)
+	if got, exp := len(a), 4; got != exp {
+		t.Fatalf("len mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range []byte{1, 1, 2, 2} {
+		if got, exp := a[i], v; got != exp {
+			t.Fatalf("value mismatch: a[%d] = %v, exp %v", i, got, exp)
+		}
+	}
+}
+
+func TestPack_WidthOne_Last(t *testing.T) {
+	a := make([]byte, 8)
+
+	a[6] = 2
+	a[7] = 2
+
+	a = bytesutil.Pack(a, 2, 255)
+	if got, exp := len(a), 8; got != exp {
+		t.Fatalf("len mismatch: got %v, exp %v", got, exp)
+	}
+
+	for i, v := range []byte{0, 0, 0, 0, 0, 0, 2, 2} {
+		if got, exp := a[i], v; got != exp {
+			t.Fatalf("value mismatch: a[%d] = %v, exp %v", i, got, exp)
+		}
+	}
+}

--- a/test.sh
+++ b/test.sh
@@ -90,7 +90,7 @@ function build_docker_image {
     local imagename=$2
 
     echo "Building docker image $imagename"
-    exit_if_fail docker build -f "$dockerfile" -t "$imagename" .
+    exit_if_fail docker build --rm=$DOCKER_RM -f "$dockerfile" -t "$imagename" .
 }
 
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -72,6 +72,7 @@ type Engine interface {
 	TagKeyCardinality(name, key []byte) int
 
 	// InfluxQL iterators
+	MeasurementSeriesKeysByExprIterator(name []byte, expr influxql.Expr) (SeriesIterator, error)
 	MeasurementSeriesKeysByExpr(name []byte, condition influxql.Expr) ([][]byte, error)
 	SeriesPointIterator(opt query.IteratorOptions) (query.Iterator, error)
 

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -51,7 +51,7 @@ type Engine interface {
 
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
 	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
-	DeleteSeriesRange(keys [][]byte, min, max int64) error
+	DeleteSeriesRange(itr SeriesIterator, min, max int64) error
 
 	SeriesSketches() (estimator.Sketch, estimator.Sketch, error)
 	MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error)

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -461,6 +461,10 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 	}
 	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, math.MinInt64, math.MaxInt64)
 
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing tombstone: %v", err)
+	}
+
 	a3 := tsm1.NewValue(3, 1.3)
 	writes = map[string][]tsm1.Value{
 		"cpu,host=A#!~#value": []tsm1.Value{a3},
@@ -562,6 +566,10 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 	}
 	// a1 should remain after compaction
 	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 2, math.MaxInt64)
+
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing tombstone: %v", err)
+	}
 
 	a3 := tsm1.NewValue(3, 1.3)
 	writes = map[string][]tsm1.Value{
@@ -669,6 +677,10 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 	// a1, a3 should remain after compaction
 	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 2, 2)
 	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 4, 4)
+
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing tombstone: %v", err)
+	}
 
 	a5 := tsm1.NewValue(5, 1.5)
 	writes = map[string][]tsm1.Value{

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -30,6 +30,7 @@ import (
 	"github.com/influxdata/influxdb/tsdb"
 	_ "github.com/influxdata/influxdb/tsdb/index"
 	"github.com/influxdata/influxdb/tsdb/index/inmem"
+	"github.com/influxdata/influxdb/tsdb/index/tsi1"
 	"github.com/influxdata/influxql"
 	"go.uber.org/zap"
 )
@@ -936,6 +937,13 @@ func (e *Engine) WritePoints(points []models.Point) error {
 // DeleteSeriesRange removes the values between min and max (inclusive) from all series
 func (e *Engine) DeleteSeriesRange(itr tsdb.SeriesIterator, min, max int64) error {
 	var disableOnce bool
+
+	// Ensure that the index does not compact away the measurement or series we're
+	// going to delete before we're done with them.
+	if tsiIndex, ok := e.index.(*tsi1.Index); ok {
+		fs := tsiIndex.RetainFileSet()
+		defer fs.Release()
+	}
 
 	var sz int
 	batch := make([][]byte, 0, 10000)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -974,6 +974,14 @@ func (e *Engine) DeleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 		bytesutil.Sort(seriesKeys)
 	}
 
+	// Min and max time in the engine are slightly different from the query language values.
+	if min == influxql.MinTime {
+		min = math.MinInt64
+	}
+	if max == influxql.MaxTime {
+		max = math.MaxInt64
+	}
+
 	// Disable and abort running compactions so that tombstones added existing tsm
 	// files don't get removed.  This would cause deleted measurements/series to
 	// re-appear once the compaction completed.  We only disable the level compactions

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1157,6 +1157,10 @@ func (e *Engine) ForEachMeasurementName(fn func(name []byte) error) error {
 	return e.index.ForEachMeasurementName(fn)
 }
 
+func (e *Engine) MeasurementSeriesKeysByExprIterator(name []byte, expr influxql.Expr) (tsdb.SeriesIterator, error) {
+	return e.index.MeasurementSeriesKeysByExprIterator(name, expr)
+}
+
 // MeasurementSeriesKeysByExpr returns a list of series keys matching expr.
 func (e *Engine) MeasurementSeriesKeysByExpr(name []byte, expr influxql.Expr) ([][]byte, error) {
 	return e.index.MeasurementSeriesKeysByExpr(name, expr)

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -470,6 +470,10 @@ func (t *TSMReader) DeleteRange(keys [][]byte, minTime, maxTime int64) error {
 		return err
 	}
 
+	if err := t.tombstoner.Flush(); err != nil {
+		return err
+	}
+
 	t.index.DeleteRange(keys, minTime, maxTime)
 	return nil
 }
@@ -477,6 +481,10 @@ func (t *TSMReader) DeleteRange(keys [][]byte, minTime, maxTime int64) error {
 // Delete deletes blocks indicated by keys.
 func (t *TSMReader) Delete(keys [][]byte) error {
 	if err := t.tombstoner.Add(keys); err != nil {
+		return err
+	}
+
+	if err := t.tombstoner.Flush(); err != nil {
 		return err
 	}
 

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -124,6 +124,12 @@ func (t *Tombstoner) Flush() error {
 	return nil
 }
 
+func (t *Tombstoner) Rollback() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.rollback()
+}
+
 // ReadAll returns all the tombstones in the Tombstoner's directory.
 func (t *Tombstoner) ReadAll() ([]Tombstone, error) {
 	t.mu.RLock()

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -303,7 +303,7 @@ func (t *Tombstoner) prepareV4() error {
 	f.Close()
 
 	var b [8]byte
-	bw := bufio.NewWriterSize(tmp, 1024*1024)
+	bw := bufio.NewWriterSize(tmp, 64*1024)
 
 	// Write the header only if the file is new
 	if os.IsNotExist(err) {

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -15,11 +15,7 @@ func TestTombstoner_Add(t *testing.T) {
 	f := MustTempFile(dir)
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
-	entries, err := ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries := mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -35,11 +31,7 @@ func TestTombstoner_Add(t *testing.T) {
 		t.Fatalf("unexpected error flushing tombstone: %v", err)
 	}
 
-	entries, err = ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries = mustReadAll(ts)
 	stats = ts.TombstoneFiles()
 	if got, exp := len(stats), 1; got != exp {
 		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
@@ -67,11 +59,7 @@ func TestTombstoner_Add(t *testing.T) {
 
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}
-	entries, err = ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries = mustReadAll(ts)
 	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -88,11 +76,7 @@ func TestTombstoner_Add_Multiple(t *testing.T) {
 	f := MustTempFile(dir)
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
-	entries, err := ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries := mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -114,11 +98,7 @@ func TestTombstoner_Add_Multiple(t *testing.T) {
 		t.Fatalf("unexpected error flushing tombstone: %v", err)
 	}
 
-	entries, err = ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries = mustReadAll(ts)
 	stats = ts.TombstoneFiles()
 	if got, exp := len(stats), 1; got != exp {
 		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
@@ -150,11 +130,7 @@ func TestTombstoner_Add_Multiple(t *testing.T) {
 
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}
-	entries, err = ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries = mustReadAll(ts)
 	if got, exp := len(entries), 2; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -176,11 +152,7 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 	f := MustTempFile(dir)
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
-	entries, err := ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries := mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -193,11 +165,7 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}
-	entries, err = ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries = mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -224,11 +192,7 @@ func TestTombstoner_Delete(t *testing.T) {
 
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}
-	entries, err := ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries := mustReadAll(ts)
 	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -247,11 +211,7 @@ func TestTombstoner_Delete(t *testing.T) {
 	}
 
 	ts = &tsm1.Tombstoner{Path: f.Name()}
-	entries, err = ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries = mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -273,15 +233,11 @@ func TestTombstoner_ReadV1(t *testing.T) {
 
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
-	_, err := ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
+	// Read once
+	_ = mustReadAll(ts)
 
-	entries, err := ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
+	// Read again
+	entries := mustReadAll(ts)
 
 	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
@@ -293,11 +249,7 @@ func TestTombstoner_ReadV1(t *testing.T) {
 
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}
-	entries, err = ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries = mustReadAll(ts)
 	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
@@ -320,17 +272,27 @@ func TestTombstoner_ReadEmptyV1(t *testing.T) {
 
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
-	_, err := ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
+	_ = mustReadAll(ts)
 
-	entries, err := ts.ReadAll()
-	if err != nil {
-		fatal(t, "ReadAll", err)
-	}
-
+	entries := mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
 	}
+}
+
+func mustReadAll(t *tsm1.Tombstoner) []tsm1.Tombstone {
+	var tombstones []tsm1.Tombstone
+	if err := t.Walk(func(t tsm1.Tombstone) error {
+		b := make([]byte, len(t.Key))
+		copy(b, t.Key)
+		tombstones = append(tombstones, tsm1.Tombstone{
+			Min: t.Min,
+			Max: t.Max,
+			Key: b,
+		})
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+	return tombstones
 }

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -31,6 +31,10 @@ func TestTombstoner_Add(t *testing.T) {
 
 	ts.Add([][]byte{[]byte("foo")})
 
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing tombstone: %v", err)
+	}
+
 	entries, err = ts.ReadAll()
 	if err != nil {
 		fatal(t, "ReadAll", err)
@@ -95,6 +99,10 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 
 	ts.Add([][]byte{})
 
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing tombstone: %v", err)
+	}
+
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}
 	entries, err = ts.ReadAll()
@@ -121,6 +129,10 @@ func TestTombstoner_Delete(t *testing.T) {
 	ts := &tsm1.Tombstoner{Path: f.Name()}
 
 	ts.Add([][]byte{[]byte("foo")})
+
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing: %v", err)
+	}
 
 	// Use a new Tombstoner to verify values are persisted
 	ts = &tsm1.Tombstoner{Path: f.Name()}

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -81,6 +81,94 @@ func TestTombstoner_Add(t *testing.T) {
 	}
 }
 
+func TestTombstoner_Add_Multiple(t *testing.T) {
+	dir := MustTempDir()
+	defer func() { os.RemoveAll(dir) }()
+
+	f := MustTempFile(dir)
+	ts := &tsm1.Tombstoner{Path: f.Name()}
+
+	entries, err := ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 0; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	stats := ts.TombstoneFiles()
+	if got, exp := len(stats), 0; got != exp {
+		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
+	}
+
+	ts.Add([][]byte{[]byte("foo")})
+
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing tombstone: %v", err)
+	}
+
+	ts.Add([][]byte{[]byte("bar")})
+
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing tombstone: %v", err)
+	}
+
+	entries, err = ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	stats = ts.TombstoneFiles()
+	if got, exp := len(stats), 1; got != exp {
+		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if stats[0].Size == 0 {
+		t.Fatalf("got size %v, exp > 0", stats[0].Size)
+	}
+
+	if stats[0].LastModified == 0 {
+		t.Fatalf("got lastModified %v, exp > 0", stats[0].LastModified)
+	}
+
+	if stats[0].Path == "" {
+		t.Fatalf("got path %v, exp != ''", stats[0].Path)
+	}
+
+	if got, exp := len(entries), 2; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := string(entries[0].Key), "foo"; got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := string(entries[1].Key), "bar"; got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+
+	// Use a new Tombstoner to verify values are persisted
+	ts = &tsm1.Tombstoner{Path: f.Name()}
+	entries, err = ts.ReadAll()
+	if err != nil {
+		fatal(t, "ReadAll", err)
+	}
+
+	if got, exp := len(entries), 2; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := string(entries[0].Key), "foo"; got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := string(entries[1].Key), "bar"; got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+
+}
+
 func TestTombstoner_Add_Empty(t *testing.T) {
 	dir := MustTempDir()
 	defer func() { os.RemoveAll(dir) }()

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -27,7 +27,7 @@ type Index interface {
 	InitializeSeries(key, name []byte, tags models.Tags) error
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
 	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
-	DropSeries(key []byte) error
+	DropSeries(key []byte, ts int64) error
 
 	SeriesSketches() (estimator.Sketch, estimator.Sketch, error)
 	MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error)
@@ -55,7 +55,7 @@ type Index interface {
 	// To be removed w/ tsi1.
 	SetFieldName(measurement []byte, name string)
 	AssignShard(k string, shardID uint64)
-	UnassignShard(k string, shardID uint64) error
+	UnassignShard(k string, shardID uint64, ts int64) error
 	RemoveShard(shardID uint64)
 
 	Type() string

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -42,6 +42,7 @@ type Index interface {
 	TagKeyCardinality(name, key []byte) int
 
 	// InfluxQL system iterators
+	MeasurementSeriesKeysByExprIterator(name []byte, condition influxql.Expr) (SeriesIterator, error)
 	MeasurementSeriesKeysByExpr(name []byte, condition influxql.Expr) ([][]byte, error)
 	SeriesPointIterator(opt query.IteratorOptions) (query.Iterator, error)
 
@@ -60,6 +61,21 @@ type Index interface {
 	Type() string
 
 	Rebuild()
+}
+
+// SeriesElem represents a generic series element.
+type SeriesElem interface {
+	Name() []byte
+	Tags() models.Tags
+	Deleted() bool
+
+	// InfluxQL expression associated with series during filtering.
+	Expr() influxql.Expr
+}
+
+// SeriesIterator represents a iterator over a list of series.
+type SeriesIterator interface {
+	Next() SeriesElem
 }
 
 // IndexFormat represents the format for an index.

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -685,7 +685,7 @@ func (i *Index) MeasurementSeriesKeysByExprIterator(name []byte, condition influ
 	if err != nil {
 		return nil, err
 	}
-	return &seriesIterator{keys: keys}, nil
+	return &seriesIterator{keys: keys}, err
 }
 
 func (i *Index) MeasurementSeriesKeysByExpr(name []byte, condition influxql.Expr) ([][]byte, error) {

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -1027,9 +1027,11 @@ var errMaxSeriesPerDatabaseExceeded = errors.New("max series per database exceed
 
 type seriesIterator struct {
 	keys [][]byte
+	elem series
 }
 
 type series struct {
+	tsdb.SeriesElem
 	name    []byte
 	tags    models.Tags
 	deleted bool
@@ -1044,8 +1046,10 @@ func (itr *seriesIterator) Next() tsdb.SeriesElem {
 	if len(itr.keys) == 0 {
 		return nil
 	}
+
 	name, tags := models.ParseKeyBytes(itr.keys[0])
-	s := series{name: name, tags: tags}
+	itr.elem.name = name
+	itr.elem.tags = tags
 	itr.keys = itr.keys[1:]
-	return s
+	return &itr.elem
 }

--- a/tsdb/index/internal/file_set.go
+++ b/tsdb/index/internal/file_set.go
@@ -4,6 +4,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/bloom"
 	"github.com/influxdata/influxdb/pkg/estimator"
+	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/index/tsi1"
 )
 
@@ -16,16 +17,16 @@ type File struct {
 	Measurementf               func(name []byte) tsi1.MeasurementElem
 	MeasurementIteratorf       func() tsi1.MeasurementIterator
 	HasSeriesf                 func(name []byte, tags models.Tags, buf []byte) (exists, tombstoned bool)
-	Seriesf                    func(name []byte, tags models.Tags) tsi1.SeriesElem
+	Seriesf                    func(name []byte, tags models.Tags) tsdb.SeriesElem
 	SeriesNf                   func() uint64
 	TagKeyf                    func(name, key []byte) tsi1.TagKeyElem
 	TagKeyIteratorf            func(name []byte) tsi1.TagKeyIterator
 	TagValuef                  func(name, key, value []byte) tsi1.TagValueElem
 	TagValueIteratorf          func(name, key []byte) tsi1.TagValueIterator
-	SeriesIteratorf            func() tsi1.SeriesIterator
-	MeasurementSeriesIteratorf func(name []byte) tsi1.SeriesIterator
-	TagKeySeriesIteratorf      func(name, key []byte) tsi1.SeriesIterator
-	TagValueSeriesIteratorf    func(name, key, value []byte) tsi1.SeriesIterator
+	SeriesIteratorf            func() tsdb.SeriesIterator
+	MeasurementSeriesIteratorf func(name []byte) tsdb.SeriesIterator
+	TagKeySeriesIteratorf      func(name, key []byte) tsdb.SeriesIterator
+	TagValueSeriesIteratorf    func(name, key, value []byte) tsdb.SeriesIterator
 	MergeSeriesSketchesf       func(s, t estimator.Sketch) error
 	MergeMeasurementsSketchesf func(s, t estimator.Sketch) error
 	Retainf                    func()
@@ -42,7 +43,7 @@ func (f *File) MeasurementIterator() tsi1.MeasurementIterator { return f.Measure
 func (f *File) HasSeries(name []byte, tags models.Tags, buf []byte) (exists, tombstoned bool) {
 	return f.HasSeriesf(name, tags, buf)
 }
-func (f *File) Series(name []byte, tags models.Tags) tsi1.SeriesElem { return f.Seriesf(name, tags) }
+func (f *File) Series(name []byte, tags models.Tags) tsdb.SeriesElem { return f.Seriesf(name, tags) }
 func (f *File) SeriesN() uint64                                      { return f.SeriesNf() }
 func (f *File) TagKey(name, key []byte) tsi1.TagKeyElem              { return f.TagKeyf(name, key) }
 func (f *File) TagKeyIterator(name []byte) tsi1.TagKeyIterator       { return f.TagKeyIteratorf(name) }
@@ -52,14 +53,14 @@ func (f *File) TagValue(name, key, value []byte) tsi1.TagValueElem {
 func (f *File) TagValueIterator(name, key []byte) tsi1.TagValueIterator {
 	return f.TagValueIteratorf(name, key)
 }
-func (f *File) SeriesIterator() tsi1.SeriesIterator { return f.SeriesIteratorf() }
-func (f *File) MeasurementSeriesIterator(name []byte) tsi1.SeriesIterator {
+func (f *File) SeriesIterator() tsdb.SeriesIterator { return f.SeriesIteratorf() }
+func (f *File) MeasurementSeriesIterator(name []byte) tsdb.SeriesIterator {
 	return f.MeasurementSeriesIteratorf(name)
 }
-func (f *File) TagKeySeriesIterator(name, key []byte) tsi1.SeriesIterator {
+func (f *File) TagKeySeriesIterator(name, key []byte) tsdb.SeriesIterator {
 	return f.TagKeySeriesIteratorf(name, key)
 }
-func (f *File) TagValueSeriesIterator(name, key, value []byte) tsi1.SeriesIterator {
+func (f *File) TagValueSeriesIterator(name, key, value []byte) tsdb.SeriesIterator {
 	return f.TagValueSeriesIteratorf(name, key, value)
 }
 func (f *File) MergeSeriesSketches(s, t estimator.Sketch) error { return f.MergeSeriesSketchesf(s, t) }

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -559,7 +559,7 @@ func (i *Index) CreateSeriesIfNotExists(key, name []byte, tags models.Tags) erro
 	return nil
 }
 
-func (i *Index) DropSeries(key []byte) error {
+func (i *Index) DropSeries(key []byte, ts int64) error {
 	if err := func() error {
 		i.mu.RLock()
 		defer i.mu.RUnlock()
@@ -879,9 +879,9 @@ func (i *Index) SetFieldName(measurement []byte, name string) {}
 func (i *Index) RemoveShard(shardID uint64)                   {}
 func (i *Index) AssignShard(k string, shardID uint64)         {}
 
-func (i *Index) UnassignShard(k string, shardID uint64) error {
+func (i *Index) UnassignShard(k string, shardID uint64, ts int64) error {
 	// This can be called directly once inmem is gone.
-	return i.DropSeries([]byte(k))
+	return i.DropSeries([]byte(k), ts)
 }
 
 // SeriesPointIterator returns an influxql iterator over all series.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -732,6 +732,19 @@ func (i *Index) TagKeyCardinality(name, key []byte) int {
 	return 0
 }
 
+func (i *Index) MeasurementSeriesKeysByExprIterator(name []byte, condition influxql.Expr) (tsdb.SeriesIterator, error) {
+	fs := i.RetainFileSet()
+	defer fs.Release()
+
+	itr, err := fs.MeasurementSeriesByExprIterator(name, condition, i.fieldset)
+	if err != nil {
+		return nil, err
+	} else if itr == nil {
+		return nil, nil
+	}
+	return itr, err
+}
+
 // MeasurementSeriesKeysByExpr returns a list of series keys matching expr.
 func (i *Index) MeasurementSeriesKeysByExpr(name []byte, expr influxql.Expr) ([][]byte, error) {
 	fs := i.RetainFileSet()
@@ -1170,7 +1183,7 @@ type seriesPointIterator struct {
 	fs       *FileSet
 	fieldset *tsdb.MeasurementFieldSet
 	mitr     MeasurementIterator
-	sitr     SeriesIterator
+	sitr     tsdb.SeriesIterator
 	opt      query.IteratorOptions
 
 	point query.FloatPoint // reusable point

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -575,11 +575,8 @@ func (i *Index) DropSeries(key []byte, ts int64) error {
 		fs := i.retainFileSet()
 		defer fs.Release()
 
-		// Check if that was the last series for the measurement in the entire index.
-		itr := fs.MeasurementSeriesIterator(mname)
-		if itr == nil {
-			return nil
-		} else if e := itr.Next(); e != nil {
+		mm := fs.Measurement(mname)
+		if mm == nil || mm.HasSeries() {
 			return nil
 		}
 

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/influxdb/pkg/bloom"
 	"github.com/influxdata/influxdb/pkg/estimator"
 	"github.com/influxdata/influxdb/pkg/mmap"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 // IndexFileVersion is the current TSI1 index file version.
@@ -233,7 +234,7 @@ func (f *IndexFile) TagValueIterator(name, key []byte) TagValueIterator {
 
 // TagKeySeriesIterator returns a series iterator for a tag key and a flag
 // indicating if a tombstone exists on the measurement or key.
-func (f *IndexFile) TagKeySeriesIterator(name, key []byte) SeriesIterator {
+func (f *IndexFile) TagKeySeriesIterator(name, key []byte) tsdb.SeriesIterator {
 	tblk := f.tblks[string(name)]
 	if tblk == nil {
 		return nil
@@ -247,7 +248,7 @@ func (f *IndexFile) TagKeySeriesIterator(name, key []byte) SeriesIterator {
 
 	// Merge all value series iterators together.
 	vitr := ke.TagValueIterator()
-	var itrs []SeriesIterator
+	var itrs []tsdb.SeriesIterator
 	for ve := vitr.Next(); ve != nil; ve = vitr.Next() {
 		sitr := &rawSeriesIDIterator{data: ve.(*TagBlockValueElem).series.data}
 		itrs = append(itrs, newSeriesDecodeIterator(&f.sblk, sitr))
@@ -258,7 +259,7 @@ func (f *IndexFile) TagKeySeriesIterator(name, key []byte) SeriesIterator {
 
 // TagValueSeriesIterator returns a series iterator for a tag value and a flag
 // indicating if a tombstone exists on the measurement, key, or value.
-func (f *IndexFile) TagValueSeriesIterator(name, key, value []byte) SeriesIterator {
+func (f *IndexFile) TagValueSeriesIterator(name, key, value []byte) tsdb.SeriesIterator {
 	tblk := f.tblks[string(name)]
 	if tblk == nil {
 		return nil
@@ -305,7 +306,7 @@ func (f *IndexFile) HasSeries(name []byte, tags models.Tags, buf []byte) (exists
 
 // Series returns the series and a flag indicating if the series has been
 // tombstoned by the measurement.
-func (f *IndexFile) Series(name []byte, tags models.Tags) SeriesElem {
+func (f *IndexFile) Series(name []byte, tags models.Tags) tsdb.SeriesElem {
 	return f.sblk.Series(name, tags)
 }
 
@@ -333,7 +334,7 @@ func (f *IndexFile) TagKeyIterator(name []byte) TagKeyIterator {
 }
 
 // MeasurementSeriesIterator returns an iterator over a measurement's series.
-func (f *IndexFile) MeasurementSeriesIterator(name []byte) SeriesIterator {
+func (f *IndexFile) MeasurementSeriesIterator(name []byte) tsdb.SeriesIterator {
 	return &seriesDecodeIterator{
 		itr:  f.mblk.seriesIDIterator(name),
 		sblk: &f.sblk,
@@ -355,7 +356,7 @@ func (f *IndexFile) SeriesN() uint64 {
 }
 
 // SeriesIterator returns an iterator over all series.
-func (f *IndexFile) SeriesIterator() SeriesIterator {
+func (f *IndexFile) SeriesIterator() tsdb.SeriesIterator {
 	return f.sblk.SeriesIterator()
 }
 

--- a/tsdb/index/tsi1/index_files.go
+++ b/tsdb/index/tsi1/index_files.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/influxdb/pkg/bytesutil"
 	"github.com/influxdata/influxdb/pkg/estimator/hll"
 	"github.com/influxdata/influxdb/pkg/mmap"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 // IndexFiles represents a layered set of index files.
@@ -90,8 +91,8 @@ func (p *IndexFiles) TagKeyIterator(name []byte) (TagKeyIterator, error) {
 }
 
 // SeriesIterator returns an iterator that merges series across all files.
-func (p IndexFiles) SeriesIterator() SeriesIterator {
-	a := make([]SeriesIterator, 0, len(p))
+func (p IndexFiles) SeriesIterator() tsdb.SeriesIterator {
+	a := make([]tsdb.SeriesIterator, 0, len(p))
 	for _, f := range p {
 		itr := f.SeriesIterator()
 		if itr == nil {
@@ -103,8 +104,8 @@ func (p IndexFiles) SeriesIterator() SeriesIterator {
 }
 
 // MeasurementSeriesIterator returns an iterator that merges series across all files.
-func (p IndexFiles) MeasurementSeriesIterator(name []byte) SeriesIterator {
-	a := make([]SeriesIterator, 0, len(p))
+func (p IndexFiles) MeasurementSeriesIterator(name []byte) tsdb.SeriesIterator {
+	a := make([]tsdb.SeriesIterator, 0, len(p))
 	for _, f := range p {
 		itr := f.MeasurementSeriesIterator(name)
 		if itr == nil {
@@ -116,8 +117,8 @@ func (p IndexFiles) MeasurementSeriesIterator(name []byte) SeriesIterator {
 }
 
 // TagValueSeriesIterator returns an iterator that merges series across all files.
-func (p IndexFiles) TagValueSeriesIterator(name, key, value []byte) SeriesIterator {
-	a := make([]SeriesIterator, 0, len(p))
+func (p IndexFiles) TagValueSeriesIterator(name, key, value []byte) tsdb.SeriesIterator {
+	a := make([]tsdb.SeriesIterator, 0, len(p))
 	for i := range p {
 		itr := p[i].TagValueSeriesIterator(name, key, value)
 		if itr != nil {

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -93,7 +93,7 @@ func TestIndex_MeasurementExists(t *testing.T) {
 	})
 
 	// Delete one series.
-	if err := idx.DropSeries(models.MakeKey([]byte("cpu"), models.NewTags(map[string]string{"region": "east"}))); err != nil {
+	if err := idx.DropSeries(models.MakeKey([]byte("cpu"), models.NewTags(map[string]string{"region": "east"})), 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -107,7 +107,7 @@ func TestIndex_MeasurementExists(t *testing.T) {
 	})
 
 	// Delete second series.
-	if err := idx.DropSeries(models.MakeKey([]byte("cpu"), models.NewTags(map[string]string{"region": "west"}))); err != nil {
+	if err := idx.DropSeries(models.MakeKey([]byte("cpu"), models.NewTags(map[string]string{"region": "west"})), 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -1290,6 +1290,17 @@ type logMeasurement struct {
 
 func (m *logMeasurement) Name() []byte  { return m.name }
 func (m *logMeasurement) Deleted() bool { return m.deleted }
+func (m *logMeasurement) HasSeries() bool {
+	if m.deleted {
+		return false
+	}
+	for _, v := range m.series {
+		if !v.deleted {
+			return true
+		}
+	}
+	return false
+}
 
 func (m *logMeasurement) createTagSetIfNotExists(key []byte) logTagKey {
 	ts, ok := m.tagSet[string(key)]

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/pkg/estimator/hll"
+	"github.com/influxdata/influxdb/tsdb"
 
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/bloom"
@@ -246,7 +247,7 @@ func (f *LogFile) DeleteMeasurement(name []byte) error {
 }
 
 // TagKeySeriesIterator returns a series iterator for a tag key.
-func (f *LogFile) TagKeySeriesIterator(name, key []byte) SeriesIterator {
+func (f *LogFile) TagKeySeriesIterator(name, key []byte) tsdb.SeriesIterator {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
@@ -261,7 +262,7 @@ func (f *LogFile) TagKeySeriesIterator(name, key []byte) SeriesIterator {
 	}
 
 	// Combine iterators across all tag keys.
-	itrs := make([]SeriesIterator, 0, len(tk.tagValues))
+	itrs := make([]tsdb.SeriesIterator, 0, len(tk.tagValues))
 	for _, tv := range tk.tagValues {
 		if len(tv.series) == 0 {
 			continue
@@ -361,7 +362,7 @@ func (f *LogFile) DeleteTagKey(name, key []byte) error {
 }
 
 // TagValueSeriesIterator returns a series iterator for a tag value.
-func (f *LogFile) TagValueSeriesIterator(name, key, value []byte) SeriesIterator {
+func (f *LogFile) TagValueSeriesIterator(name, key, value []byte) tsdb.SeriesIterator {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
@@ -562,12 +563,12 @@ func (f *LogFile) FilterNamesTags(names [][]byte, tagsSlice []models.Tags) ([][]
 }
 
 // Series returns a series by name/tags.
-func (f *LogFile) Series(name []byte, tags models.Tags) SeriesElem {
+func (f *LogFile) Series(name []byte, tags models.Tags) tsdb.SeriesElem {
 	return f.SeriesWithBuffer(name, tags, nil)
 }
 
 // SeriesWithBuffer returns a series by name/tags.
-func (f *LogFile) SeriesWithBuffer(name []byte, tags models.Tags, buf []byte) SeriesElem {
+func (f *LogFile) SeriesWithBuffer(name []byte, tags models.Tags, buf []byte) tsdb.SeriesElem {
 	key := AppendSeriesKey(buf[:0], name, tags)
 
 	f.mu.RLock()
@@ -704,7 +705,7 @@ func (f *LogFile) execSeriesEntry(e *LogEntry) {
 }
 
 // SeriesIterator returns an iterator over all series in the log file.
-func (f *LogFile) SeriesIterator() SeriesIterator {
+func (f *LogFile) SeriesIterator() tsdb.SeriesIterator {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
@@ -783,7 +784,7 @@ func (f *LogFile) MeasurementIterator() MeasurementIterator {
 }
 
 // MeasurementSeriesIterator returns an iterator over all series for a measurement.
-func (f *LogFile) MeasurementSeriesIterator(name []byte) SeriesIterator {
+func (f *LogFile) MeasurementSeriesIterator(name []byte) tsdb.SeriesIterator {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
@@ -1451,7 +1452,7 @@ func newLogSeriesIterator(m map[string]*logSerie) *logSeriesIterator {
 }
 
 // Next returns the next element in the iterator.
-func (itr *logSeriesIterator) Next() (e SeriesElem) {
+func (itr *logSeriesIterator) Next() (e tsdb.SeriesElem) {
 	if len(itr.series) == 0 {
 		return nil
 	}

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -337,6 +337,8 @@ func (e *MeasurementBlockElem) SeriesID(i int) uint32 {
 	return binary.BigEndian.Uint32(e.series.data[i*SeriesIDSize:])
 }
 
+func (e *MeasurementBlockElem) HasSeries() bool { return e.series.n > 0 }
+
 // SeriesIDs returns a list of decoded series ids.
 //
 // NOTE: This should be used for testing and diagnostics purposes only.

--- a/tsdb/index/tsi1/series_block.go
+++ b/tsdb/index/tsi1/series_block.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/influxdb/pkg/estimator/hll"
 	"github.com/influxdata/influxdb/pkg/mmap"
 	"github.com/influxdata/influxdb/pkg/rhh"
+	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
 )
 
@@ -80,7 +81,7 @@ func (blk *SeriesBlock) HasSeries(name []byte, tags models.Tags, buf []byte) (ex
 }
 
 // Series returns a series element.
-func (blk *SeriesBlock) Series(name []byte, tags models.Tags) SeriesElem {
+func (blk *SeriesBlock) Series(name []byte, tags models.Tags) tsdb.SeriesElem {
 	offset, _ := blk.Offset(name, tags, nil)
 	if offset == 0 {
 		return nil
@@ -162,7 +163,7 @@ func (blk *SeriesBlock) SeriesCount() uint32 {
 }
 
 // SeriesIterator returns an iterator over all the series.
-func (blk *SeriesBlock) SeriesIterator() SeriesIterator {
+func (blk *SeriesBlock) SeriesIterator() tsdb.SeriesIterator {
 	return &seriesBlockIterator{
 		n:      blk.SeriesCount(),
 		offset: 1,
@@ -250,7 +251,7 @@ type seriesBlockIterator struct {
 }
 
 // Next returns the next series element.
-func (itr *seriesBlockIterator) Next() SeriesElem {
+func (itr *seriesBlockIterator) Next() tsdb.SeriesElem {
 	for {
 		// Exit if at the end.
 		if itr.i == itr.n {
@@ -295,7 +296,7 @@ func newSeriesDecodeIterator(sblk *SeriesBlock, itr seriesIDIterator) *seriesDec
 }
 
 // Next returns the next series element.
-func (itr *seriesDecodeIterator) Next() SeriesElem {
+func (itr *seriesDecodeIterator) Next() tsdb.SeriesElem {
 	// Read next series id.
 	id := itr.itr.next()
 	if id == 0 {

--- a/tsdb/index/tsi1/tsi1.go
+++ b/tsdb/index/tsi1/tsi1.go
@@ -21,6 +21,7 @@ const LoadFactor = 80
 type MeasurementElem interface {
 	Name() []byte
 	Deleted() bool
+	HasSeries() bool
 }
 
 // MeasurementElems represents a list of MeasurementElem.
@@ -113,6 +114,15 @@ func (p measurementMergeElem) Deleted() bool {
 		return false
 	}
 	return p[0].Deleted()
+}
+
+func (p measurementMergeElem) HasSeries() bool {
+	for _, v := range p {
+		if v.HasSeries() {
+			return true
+		}
+	}
+	return false
 }
 
 // filterUndeletedMeasurementIterator returns all measurements which are not deleted.

--- a/tsdb/index/tsi1/tsi1.go
+++ b/tsdb/index/tsi1/tsi1.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/query"
+	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
 )
 
@@ -341,18 +342,8 @@ func (p tagValueMergeElem) Deleted() bool {
 	return p[0].Deleted()
 }
 
-// SeriesElem represents a generic series element.
-type SeriesElem interface {
-	Name() []byte
-	Tags() models.Tags
-	Deleted() bool
-
-	// InfluxQL expression associated with series during filtering.
-	Expr() influxql.Expr
-}
-
 // SeriesElemKey encodes e as a series key.
-func SeriesElemKey(e SeriesElem) []byte {
+func SeriesElemKey(e tsdb.SeriesElem) []byte {
 	name, tags := e.Name(), e.Tags()
 
 	// TODO: Precompute allocation size.
@@ -370,7 +361,7 @@ func SeriesElemKey(e SeriesElem) []byte {
 }
 
 // CompareSeriesElem returns -1 if a < b, 1 if a > b, and 0 if equal.
-func CompareSeriesElem(a, b SeriesElem) int {
+func CompareSeriesElem(a, b tsdb.SeriesElem) int {
 	if cmp := bytes.Compare(a.Name(), b.Name()); cmp != 0 {
 		return cmp
 	}
@@ -389,15 +380,10 @@ func (e *seriesElem) Tags() models.Tags   { return e.tags }
 func (e *seriesElem) Deleted() bool       { return e.deleted }
 func (e *seriesElem) Expr() influxql.Expr { return nil }
 
-// SeriesIterator represents a iterator over a list of series.
-type SeriesIterator interface {
-	Next() SeriesElem
-}
-
 // MergeSeriesIterators returns an iterator that merges a set of iterators.
 // Iterators that are first in the list take precendence and a deletion by those
 // early iterators will invalidate elements by later iterators.
-func MergeSeriesIterators(itrs ...SeriesIterator) SeriesIterator {
+func MergeSeriesIterators(itrs ...tsdb.SeriesIterator) tsdb.SeriesIterator {
 	if n := len(itrs); n == 0 {
 		return nil
 	} else if n == 1 {
@@ -405,22 +391,22 @@ func MergeSeriesIterators(itrs ...SeriesIterator) SeriesIterator {
 	}
 
 	return &seriesMergeIterator{
-		buf:  make([]SeriesElem, len(itrs)),
+		buf:  make([]tsdb.SeriesElem, len(itrs)),
 		itrs: itrs,
 	}
 }
 
 // seriesMergeIterator is an iterator that merges multiple iterators together.
 type seriesMergeIterator struct {
-	buf  []SeriesElem
-	itrs []SeriesIterator
+	buf  []tsdb.SeriesElem
+	itrs []tsdb.SeriesIterator
 }
 
 // Next returns the element with the next lowest name/tags across the iterators.
 //
 // If multiple iterators contain the same name/tags then the first is returned
 // and the remaining ones are skipped.
-func (itr *seriesMergeIterator) Next() SeriesElem {
+func (itr *seriesMergeIterator) Next() tsdb.SeriesElem {
 	// Find next lowest name/tags amongst the buffers.
 	var name []byte
 	var tags models.Tags
@@ -452,7 +438,7 @@ func (itr *seriesMergeIterator) Next() SeriesElem {
 	}
 
 	// Refill buffer.
-	var e SeriesElem
+	var e tsdb.SeriesElem
 	for i, buf := range itr.buf {
 		if buf == nil || !bytes.Equal(buf.Name(), name) || models.CompareTags(buf.Tags(), tags) != 0 {
 			continue
@@ -472,23 +458,23 @@ func (itr *seriesMergeIterator) Next() SeriesElem {
 // IntersectSeriesIterators returns an iterator that only returns series which
 // occur in both iterators. If both series have associated expressions then
 // they are combined together.
-func IntersectSeriesIterators(itr0, itr1 SeriesIterator) SeriesIterator {
+func IntersectSeriesIterators(itr0, itr1 tsdb.SeriesIterator) tsdb.SeriesIterator {
 	if itr0 == nil || itr1 == nil {
 		return nil
 	}
 
-	return &seriesIntersectIterator{itrs: [2]SeriesIterator{itr0, itr1}}
+	return &seriesIntersectIterator{itrs: [2]tsdb.SeriesIterator{itr0, itr1}}
 }
 
 // seriesIntersectIterator is an iterator that merges two iterators together.
 type seriesIntersectIterator struct {
 	e    seriesExprElem
-	buf  [2]SeriesElem
-	itrs [2]SeriesIterator
+	buf  [2]tsdb.SeriesElem
+	itrs [2]tsdb.SeriesIterator
 }
 
 // Next returns the next element which occurs in both iterators.
-func (itr *seriesIntersectIterator) Next() (e SeriesElem) {
+func (itr *seriesIntersectIterator) Next() (e tsdb.SeriesElem) {
 	for {
 		// Fill buffers.
 		if itr.buf[0] == nil {
@@ -538,7 +524,7 @@ func (itr *seriesIntersectIterator) Next() (e SeriesElem) {
 // UnionSeriesIterators returns an iterator that returns series from both
 // both iterators. If both series have associated expressions then they are
 // combined together.
-func UnionSeriesIterators(itr0, itr1 SeriesIterator) SeriesIterator {
+func UnionSeriesIterators(itr0, itr1 tsdb.SeriesIterator) tsdb.SeriesIterator {
 	// Return other iterator if either one is nil.
 	if itr0 == nil {
 		return itr1
@@ -546,18 +532,18 @@ func UnionSeriesIterators(itr0, itr1 SeriesIterator) SeriesIterator {
 		return itr0
 	}
 
-	return &seriesUnionIterator{itrs: [2]SeriesIterator{itr0, itr1}}
+	return &seriesUnionIterator{itrs: [2]tsdb.SeriesIterator{itr0, itr1}}
 }
 
 // seriesUnionIterator is an iterator that unions two iterators together.
 type seriesUnionIterator struct {
 	e    seriesExprElem
-	buf  [2]SeriesElem
-	itrs [2]SeriesIterator
+	buf  [2]tsdb.SeriesElem
+	itrs [2]tsdb.SeriesIterator
 }
 
 // Next returns the next element which occurs in both iterators.
-func (itr *seriesUnionIterator) Next() (e SeriesElem) {
+func (itr *seriesUnionIterator) Next() (e tsdb.SeriesElem) {
 	// Fill buffers.
 	if itr.buf[0] == nil {
 		itr.buf[0] = itr.itrs[0].Next()
@@ -606,23 +592,23 @@ func (itr *seriesUnionIterator) Next() (e SeriesElem) {
 
 // DifferenceSeriesIterators returns an iterator that only returns series which
 // occur the first iterator but not the second iterator.
-func DifferenceSeriesIterators(itr0, itr1 SeriesIterator) SeriesIterator {
+func DifferenceSeriesIterators(itr0, itr1 tsdb.SeriesIterator) tsdb.SeriesIterator {
 	if itr0 != nil && itr1 == nil {
 		return itr0
 	} else if itr0 == nil {
 		return nil
 	}
-	return &seriesDifferenceIterator{itrs: [2]SeriesIterator{itr0, itr1}}
+	return &seriesDifferenceIterator{itrs: [2]tsdb.SeriesIterator{itr0, itr1}}
 }
 
 // seriesDifferenceIterator is an iterator that merges two iterators together.
 type seriesDifferenceIterator struct {
-	buf  [2]SeriesElem
-	itrs [2]SeriesIterator
+	buf  [2]tsdb.SeriesElem
+	itrs [2]tsdb.SeriesIterator
 }
 
 // Next returns the next element which occurs only in the first iterator.
-func (itr *seriesDifferenceIterator) Next() (e SeriesElem) {
+func (itr *seriesDifferenceIterator) Next() (e tsdb.SeriesElem) {
 	for {
 		// Fill buffers.
 		if itr.buf[0] == nil {
@@ -658,18 +644,18 @@ func (itr *seriesDifferenceIterator) Next() (e SeriesElem) {
 
 // filterUndeletedSeriesIterator returns all series which are not deleted.
 type filterUndeletedSeriesIterator struct {
-	itr SeriesIterator
+	itr tsdb.SeriesIterator
 }
 
 // FilterUndeletedSeriesIterator returns an iterator which filters all deleted series.
-func FilterUndeletedSeriesIterator(itr SeriesIterator) SeriesIterator {
+func FilterUndeletedSeriesIterator(itr tsdb.SeriesIterator) tsdb.SeriesIterator {
 	if itr == nil {
 		return nil
 	}
 	return &filterUndeletedSeriesIterator{itr: itr}
 }
 
-func (itr *filterUndeletedSeriesIterator) Next() SeriesElem {
+func (itr *filterUndeletedSeriesIterator) Next() tsdb.SeriesElem {
 	for {
 		e := itr.itr.Next()
 		if e == nil {
@@ -683,7 +669,7 @@ func (itr *filterUndeletedSeriesIterator) Next() SeriesElem {
 
 // seriesExprElem holds a series and its associated filter expression.
 type seriesExprElem struct {
-	SeriesElem
+	tsdb.SeriesElem
 	expr influxql.Expr
 }
 
@@ -692,12 +678,12 @@ func (e *seriesExprElem) Expr() influxql.Expr { return e.expr }
 
 // seriesExprIterator is an iterator that attaches an associated expression.
 type seriesExprIterator struct {
-	itr SeriesIterator
+	itr tsdb.SeriesIterator
 	e   seriesExprElem
 }
 
 // newSeriesExprIterator returns a new instance of seriesExprIterator.
-func newSeriesExprIterator(itr SeriesIterator, expr influxql.Expr) SeriesIterator {
+func newSeriesExprIterator(itr tsdb.SeriesIterator, expr influxql.Expr) tsdb.SeriesIterator {
 	if itr == nil {
 		return nil
 	}
@@ -711,7 +697,7 @@ func newSeriesExprIterator(itr SeriesIterator, expr influxql.Expr) SeriesIterato
 }
 
 // Next returns the next element in the iterator.
-func (itr *seriesExprIterator) Next() SeriesElem {
+func (itr *seriesExprIterator) Next() tsdb.SeriesElem {
 	itr.e.SeriesElem = itr.itr.Next()
 	if itr.e.SeriesElem == nil {
 		return nil

--- a/tsdb/index/tsi1/tsi1_test.go
+++ b/tsdb/index/tsi1/tsi1_test.go
@@ -202,12 +202,15 @@ func TestMergeSeriesIterators(t *testing.T) {
 
 // MeasurementElem represents a test implementation of tsi1.MeasurementElem.
 type MeasurementElem struct {
-	name    []byte
-	deleted bool
+	name      []byte
+	deleted   bool
+	hasSeries bool
 }
 
-func (e *MeasurementElem) Name() []byte                        { return e.name }
-func (e *MeasurementElem) Deleted() bool                       { return e.deleted }
+func (e *MeasurementElem) Name() []byte    { return e.name }
+func (e *MeasurementElem) Deleted() bool   { return e.deleted }
+func (e *MeasurementElem) HasSeries() bool { return e.hasSeries }
+
 func (e *MeasurementElem) TagKeyIterator() tsi1.TagKeyIterator { return nil }
 
 // MeasurementIterator represents an iterator over a slice of measurements.

--- a/tsdb/index/tsi1/tsi1_test.go
+++ b/tsdb/index/tsi1/tsi1_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/index/tsi1"
 	"github.com/influxdata/influxql"
 )
@@ -255,7 +256,7 @@ type TagValueElem struct {
 
 func (e *TagValueElem) Value() []byte                       { return e.value }
 func (e *TagValueElem) Deleted() bool                       { return e.deleted }
-func (e *TagValueElem) SeriesIterator() tsi1.SeriesIterator { return nil }
+func (e *TagValueElem) SeriesIterator() tsdb.SeriesIterator { return nil }
 
 // TagValueIterator represents an iterator over a slice of tag values.
 type TagValueIterator struct {
@@ -290,7 +291,7 @@ type SeriesIterator struct {
 }
 
 // Next returns the next element in the iterator.
-func (itr *SeriesIterator) Next() (e tsi1.SeriesElem) {
+func (itr *SeriesIterator) Next() (e tsdb.SeriesElem) {
 	if len(itr.Elems) == 0 {
 		return nil
 	}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -686,18 +685,13 @@ func (s *Shard) createFieldsAndMeasurements(fieldsToCreate []*FieldCreate) error
 	return nil
 }
 
-// DeleteSeries deletes a list of series.
-func (s *Shard) DeleteSeries(seriesKeys [][]byte) error {
-	return s.DeleteSeriesRange(seriesKeys, math.MinInt64, math.MaxInt64)
-}
-
 // DeleteSeriesRange deletes all values from for seriesKeys between min and max (inclusive)
-func (s *Shard) DeleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
+func (s *Shard) DeleteSeriesRange(itr SeriesIterator, min, max int64) error {
 	engine, err := s.engine()
 	if err != nil {
 		return err
 	}
-	return engine.DeleteSeriesRange(seriesKeys, min, max)
+	return engine.DeleteSeriesRange(itr, min, max)
 }
 
 // DeleteMeasurement deletes a measurement and all underlying series.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -755,6 +755,14 @@ func (s *Shard) MeasurementNamesByRegex(re *regexp.Regexp) ([][]byte, error) {
 	return engine.MeasurementNamesByRegex(re)
 }
 
+func (s *Shard) MeasurementSeriesKeysByExprIterator(name []byte, expr influxql.Expr) (SeriesIterator, error) {
+	engine, err := s.engine()
+	if err != nil {
+		return nil, err
+	}
+	return engine.MeasurementSeriesKeysByExprIterator(name, expr)
+}
+
 // MeasurementSeriesKeysByExpr returns a list of series keys from the shard
 // matching expr.
 func (s *Shard) MeasurementSeriesKeysByExpr(name []byte, expr influxql.Expr) ([][]byte, error) {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This PR has a number of changes to reduce memory usage in the TSM engine for deletes that could lead to OOMs.  This required reworking how deletes are processed altogether.  

The initial version of the deletes in the engine took a slice of all the series keys to be deleted and then processed those keys. This worked fine for smaller cardinality deletes, but is problematic for higher cardinalities as well as when the data set grows across many TSM files.  

The main problems addressed are:

* The creation of the large slice of series keys has been switched to use an iterator approach.
* The `Engine.DeleteSeriesRange` needed to create several intermediate slices and maps that were at least as big as the original series keys passed in.  These slices and maps are used to track the field-less series keys (passed in), to the actual series keys stored in TSM (with fields).
* Writing tombstones required reading in the existing tombstones on disk and adding new ones to the set and re-writing them out (#5503).  This makes deleting smaller batches of writes very expensive.  This has been fixed via a new tombstone format and interfaces to write and commit them in batches that avoids the previous problems.
* Deletes and writes to the same series could leave the index in an inconsistent state because concurrent writes could be adding series to the index while a delete removes it unknowingly.  A temporary fix in 1.3 was to re-add all the series keys after compactions completes.   This is unworkable with higher cardinalities and is handled better in this PR.
* Determining whether a series and measurement needs to be removed from the index was expensive.  It previously worked by applying the deletes, and then calling `containsSeries` which determined if any data exists for the series in the engine.  If nothing existed, the entries were removed from the index as well.  This was racy and memory intensive and has been reworked to use smaller, re-usable batches.

The graphs below are a before and after deleting 8M series from `inmem` in a single shard with about 20 large TSM files that are not fully compacted.  The first graphs shows a fairly large spike that is correlated w/ the number of series and TSM files to write tombstones.  The seconds still uses a bit too much memory (still looking into), but the large spike is gone. 

## Inmem Deleting 8M series Before/After
![screen shot 2017-11-08 at 10 59 35 am](https://user-images.githubusercontent.com/219935/32566665-dcf185ce-c475-11e7-81bd-a417e0967012.png) ![screen shot 2017-11-08 at 11 12 00 am](https://user-images.githubusercontent.com/219935/32566682-e9095f44-c475-11e7-8499-a91bd9e3b2a9.png)

## TSI Deleting 32M series Before/After
![screen shot 2017-11-09 at 6 58 05 am](https://user-images.githubusercontent.com/219935/32618122-0a56d87a-c534-11e7-913a-c4e59a80a8f3.png)
![screen shot 2017-11-08 at 8 36 35 pm](https://user-images.githubusercontent.com/219935/32618142-1869aae6-c534-11e7-8971-52a0a67e2db8.png)

Master ran for 12+hrs and I eventually killed it.  This change completed in 17m, but I should be able to improve that further.