### PR TITLE
Fix panic: runtime error: slice bounds out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.5.0 [unreleased]
+
+### Bugfixes
+
+- [#8538](https://github.com/influxdata/influxdb/pull/8538): Fix panic: runtime error: slice bounds out of range
+
 ## v1.4.0 [unreleased]
 
 ### Breaking changes

--- a/models/points.go
+++ b/models/points.go
@@ -1064,7 +1064,7 @@ func scanLine(buf []byte, i int) (int, []byte) {
 		}
 
 		// skip past escaped characters
-		if buf[i] == '\\' {
+		if buf[i] == '\\' && i+2 < len(buf) {
 			i += 2
 			continue
 		}

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1341,6 +1341,15 @@ func TestParsePointQuotedTags(t *testing.T) {
 	)
 }
 
+func TestParsePoint_TrailingSlash(t *testing.T) {
+	_, err := models.ParsePointsString(`a v=1 0\`)
+	if err == nil {
+		t.Fatalf("ParsePoints failed: %v", err)
+	} else if !strings.Contains(err.Error(), "bad timestamp") {
+		t.Fatalf("ParsePoints unexpected error: %v", err)
+	}
+}
+
 func TestParsePointsUnbalancedQuotedTags(t *testing.T) {
 	pts, err := models.ParsePointsString("baz,mytag=\"a x=1 1441103862125\nbaz,mytag=a z=1 1441103862126")
 	if err != nil {


### PR DESCRIPTION
A trailing slash on a point can cause this.

```
$ INFLUXDB_UDP_ENABLED=true influxd
$ echo -n 'a v=1 0\' | nc -u localhost 8089
```

Fixes #8538

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
