### PR TITLE
shell shows error and usage when given extra parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugfixes
 
 - [#8538](https://github.com/influxdata/influxdb/pull/8538): Fix panic: runtime error: slice bounds out of range
+- [#9065](https://github.com/influxdata/influxdb/pull/9065): Refuse extra arguments to influx CLI
 
 ## v1.4.0 [unreleased]
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdata/influxdb/client"
 	"github.com/influxdata/influxdb/cmd/influx/cli"
+	"strings"
 )
 
 // These variables are populated via the Go linker.
@@ -107,6 +108,13 @@ Examples:
 `)
 	}
 	fs.Parse(os.Args[1:])
+
+	argsNotParsed := os.Args[len(os.Args)-fs.NArg():]
+	if len(argsNotParsed) > 0 {
+		fmt.Fprintf(os.Stderr, "unknown arguments: %s\n", strings.Join(argsNotParsed, " "))
+		fs.Usage()
+		os.Exit(1)
+	}
 
 	if c.ShowVersion {
 		c.Version()

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -109,7 +109,7 @@ Examples:
 	}
 	fs.Parse(os.Args[1:])
 
-	argsNotParsed := os.Args[len(os.Args)-fs.NArg():]
+	argsNotParsed := fs.Args()
 	if len(argsNotParsed) > 0 {
 		fmt.Fprintf(os.Stderr, "unknown arguments: %s\n", strings.Join(argsNotParsed, " "))
 		fs.Usage()


### PR DESCRIPTION
Fixes #8593 

When try to launch the shell with arguments the shell won't launch, instead will show an error (with the unknown args) as well as the usage.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


