### PR TITLE
Lock the zap write output to avoid race conditions when logging

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -15,7 +15,7 @@ func New(w io.Writer) *zap.Logger {
 	}
 	return zap.New(zapcore.NewCore(
 		zapcore.NewConsoleEncoder(config),
-		zapcore.AddSync(w),
+		zapcore.Lock(zapcore.AddSync(w)),
 		zapcore.DebugLevel,
 	))
 }


### PR DESCRIPTION
- [x] Rebased/mergable
- [ ] Tests pass