### PR TITLE
pkg/escape: Preallocate output in Unescape

### DIFF
--- a/pkg/escape/bytes.go
+++ b/pkg/escape/bytes.go
@@ -78,7 +78,11 @@ func Unescape(in []byte) []byte {
 
 	i := 0
 	inLen := len(in)
-	var out []byte
+
+	// The output size will be no more than inLen. Preallocating the
+	// capacity of the output is faster and uses less memory than
+	// letting append() do its own (over)allocation.
+	out := make([]byte, 0, inLen)
 
 	for {
 		if i >= inLen {

--- a/pkg/escape/bytes_test.go
+++ b/pkg/escape/bytes_test.go
@@ -7,6 +7,77 @@ import (
 	"testing"
 )
 
+var result []byte
+
+func BenchmarkBytesEscapeNoEscapes(b *testing.B) {
+	buf := []byte(`no_escapes`)
+	for i := 0; i < b.N; i++ {
+		result = Bytes(buf)
+	}
+}
+
+func BenchmarkUnescapeNoEscapes(b *testing.B) {
+	buf := []byte(`no_escapes`)
+	for i := 0; i < b.N; i++ {
+		result = Unescape(buf)
+	}
+}
+
+func BenchmarkBytesEscapeMany(b *testing.B) {
+	tests := [][]byte{
+		[]byte("this is my special string"),
+		[]byte("a field w=i th == tons of escapes"),
+		[]byte("some,commas,here"),
+	}
+	for n := 0; n < b.N; n++ {
+		for _, test := range tests {
+			result = Bytes(test)
+		}
+	}
+}
+
+func BenchmarkUnescapeMany(b *testing.B) {
+	tests := [][]byte{
+		[]byte(`this\ is\ my\ special\ string`),
+		[]byte(`a\ field\ w\=i\ th\ \=\=\ tons\ of\ escapes`),
+		[]byte(`some\,commas\,here`),
+	}
+	for i := 0; i < b.N; i++ {
+		for _, test := range tests {
+			result = Unescape(test)
+		}
+	}
+}
+
+var boolResult bool
+
+func BenchmarkIsEscaped(b *testing.B) {
+	tests := [][]byte{
+		[]byte(`no_escapes`),
+		[]byte(`a\ field\ w\=i\ th\ \=\=\ tons\ of\ escapes`),
+		[]byte(`some\,commas\,here`),
+	}
+	for i := 0; i < b.N; i++ {
+		for _, test := range tests {
+			boolResult = IsEscaped(test)
+		}
+	}
+}
+
+func BenchmarkAppendUnescaped(b *testing.B) {
+	tests := [][]byte{
+		[]byte(`this\ is\ my\ special\ string`),
+		[]byte(`a\ field\ w\=i\ th\ \=\=\ tons\ of\ escapes`),
+		[]byte(`some\,commas\,here`),
+	}
+	for i := 0; i < b.N; i++ {
+		result = nil
+		for _, test := range tests {
+			result = AppendUnescaped(result, test)
+		}
+	}
+}
+
 func TestUnescape(t *testing.T) {
 	tests := []struct {
 		in  []byte


### PR DESCRIPTION
Preallocating the capacity of the output is faster and uses less memory than letting append() do its own (over)allocation. 

Benchmarking shows that this is ~42% faster than the original. The benchmark used is here: https://gist.github.com/mjs/bc3219a79d4e4a1d7848c5aaa12b3c40. The results on my machine are:

```
BenchmarkOrig-4   	20000000	        85.1 ns/op
BenchmarkNew-4    	30000000	        49.4 ns/op
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated (trivial change - not required?)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


