### PR TITLE
fix descending and range queries via IFQL RPC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.4.1 [2017-11-13]
+
+### Bugfixes
+
+- [9105](https://github.com/influxdata/influxdb/pull/9105): Fix descending cursors and range queries via IFQL RPC API. 
+
 ## v1.4.0 [2017-11-13]
 
 ### Breaking changes

--- a/services/storage/store.go
+++ b/services/storage/store.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"time"
 
@@ -69,6 +70,12 @@ func (s *Store) Read(ctx context.Context, req *ReadRequest) (*ResultSet, error) 
 
 	if len(groups) == 0 {
 		return nil, nil
+	}
+
+	if req.Descending {
+		sort.Sort(sort.Reverse(meta.ShardGroupInfos(groups)))
+	} else {
+		sort.Sort(meta.ShardGroupInfos(groups))
 	}
 
 	shardIDs := make([]uint64, 0, len(groups[0].Shards)*len(groups))

--- a/tsdb/engine/tsm1/batch_cursor.gen.go.tmpl
+++ b/tsdb/engine/tsm1/batch_cursor.gen.go.tmpl
@@ -99,11 +99,6 @@ func (c *{{.name}}AscendingBatchCursor) Next() ([]int64, []{{.Type}}) {
 		if c.cache.pos < len(c.cache.values) {
 			ckey, cvalue = c.peekCache()
 
-			// No more data in cache or in TSM files.
-			if ckey == tsdb.EOF && tkey == tsdb.EOF {
-				break
-			}
-
 			var cache, tsm bool
 
 			// Both cache and tsm files have the same key, cache takes precedence.
@@ -111,7 +106,7 @@ func (c *{{.name}}AscendingBatchCursor) Next() ([]int64, []{{.Type}}) {
 				cache, tsm = true, true
 				tkey = ckey
 				tvalue = cvalue
-			} else if ckey != tsdb.EOF && (ckey < tkey || tkey == tsdb.EOF) {
+			} else if ckey < tkey || tkey == tsdb.EOF {
 				// Buffered cache key precedes that in TSM file.
 				cache = true
 				tkey = ckey
@@ -196,11 +191,13 @@ func new{{.Name}}DescendingBatchCursor(key string, seek int64, cacheValues Value
 	c := &{{.name}}DescendingBatchCursor{key: key}
 
 	c.cache.values = cacheValues
-	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
-		return c.cache.values[i].UnixNano() >= seek
-	})
 	if len(c.cache.values) > 0 {
-		if t, _ := c.peekCache(); t != seek {
+		c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
+			return c.cache.values[i].UnixNano() >= seek
+		})
+		if c.cache.pos == len(c.cache.values) {
+			c.cache.pos--
+		} else if t, _ := c.peekCache(); t != seek {
 			c.cache.pos--
 		}
 	} else {
@@ -251,11 +248,6 @@ func (c *{{.name}}DescendingBatchCursor) Next() ([]int64, []{{.Type}}) {
 		if  c.cache.pos >= 0 {
 			ckey, cvalue = c.peekCache()
 
-			// No more data in cache or in TSM files.
-			if ckey == tsdb.EOF && tkey == tsdb.EOF {
-				break
-			}
-
 			var cache, tsm bool
 
 			// Both cache and tsm files have the same key, cache takes precedence.
@@ -263,7 +255,7 @@ func (c *{{.name}}DescendingBatchCursor) Next() ([]int64, []{{.Type}}) {
 				cache, tsm = true, true
 				tkey = ckey
 				tvalue = cvalue
-			} else if ckey != tsdb.EOF && (ckey > tkey || tkey == tsdb.EOF) {
+			} else if ckey > tkey || tkey == tsdb.EOF {
 				// Buffered cache key succeeds that in TSM file.
 				cache = true
 				tkey = ckey
@@ -302,7 +294,7 @@ func (c *{{.name}}DescendingBatchCursor) peekCache() (t int64, v {{.Type}}) {
 
 // nextCache returns the next value from the cache.
 func (c *{{.name}}DescendingBatchCursor) nextCache() {
-	if c.cache.pos > 0 {
+	if c.cache.pos >= 0 {
 		c.cache.pos--
 	}
 }
@@ -344,9 +336,9 @@ func (l *{{.name}}AscendingRangeBatchCursor) Next() ([]int64, []{{.Type}}) {
 	k, v := l.{{.Name}}BatchCursor.Next()
 
 	// strip out remaining time that is outside the range
-	if len(k) > 0 && k[len(k)-1] >= l.t {
+	if len(k) > 0 && k[len(k)-1] > l.t {
 		i := len(k)-2
-		for i >= 0 && k[i] >= l.t {
+		for i >= 0 && k[i] > l.t {
 			i--
 		}
 		k = k[:i+1]
@@ -365,13 +357,13 @@ func (l *{{.name}}DescendingRangeBatchCursor) Next() ([]int64, []{{.Type}}) {
 	k, v := l.{{.Name}}BatchCursor.Next()
 
 	// strip out remaining time that is outside the range
-	if len(k) > 0 && k[0] <= l.t {
-		i := 1
-		for i < len(k) && k[i] <= l.t {
-			i++
+	if len(k) > 0 && k[len(k)-1] < l.t {
+		i := len(k)-2
+		for i >= 0 && k[i] < l.t {
+			i--
 		}
-		k = k[i:]
-		v = v[i:]
+		k = k[:i+1]
+		v = v[:i+1]
 	}
 
 	return k, v

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/deep"
 	"github.com/influxdata/influxdb/query"
@@ -378,8 +379,8 @@ func TestEngine_CreateIterator_TSM_Ascending(t *testing.T) {
 	itr, err := e.CreateIterator(context.Background(), "cpu", query.IteratorOptions{
 		Expr:       influxql.MustParseExpr(`value`),
 		Dimensions: []string{"host"},
-		StartTime:  influxql.MinTime,
-		EndTime:    influxql.MaxTime,
+		StartTime:  1000000000,
+		EndTime:    3000000000,
 		Ascending:  true,
 	})
 	if err != nil {
@@ -711,6 +712,104 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 	// even if snapshots are disabled.
 	if err := e.WriteSnapshot(); err != nil {
 		t.Fatalf("failed to snapshot: %s", err.Error())
+	}
+}
+
+// Ensure engine can create an ascending cursor for cache and tsm values.
+func TestEngine_CreateCursor_Ascending(t *testing.T) {
+	t.Parallel()
+
+	e := MustOpenDefaultEngine()
+	defer e.Close()
+
+	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
+	e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+
+	if err := e.WritePointsString(
+		`cpu,host=A value=1.1 1`,
+		`cpu,host=A value=1.2 2`,
+		`cpu,host=A value=1.3 3`,
+	); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+	e.MustWriteSnapshot()
+
+	if err := e.WritePointsString(
+		`cpu,host=A value=10.1 10`,
+		`cpu,host=A value=11.2 11`,
+		`cpu,host=A value=12.3 12`,
+	); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	cur, err := e.CreateCursor(context.Background(), &tsdb.CursorRequest{
+		Measurement: "cpu",
+		Series:      "cpu,host=A",
+		Field:       "value",
+		Ascending:   true,
+		StartTime:   2,
+		EndTime:     11,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fcur := cur.(tsdb.FloatBatchCursor)
+	ts, vs := fcur.Next()
+	if !cmp.Equal([]int64{2, 3, 10, 11}, ts) {
+		t.Fatal("unexpect timestamps")
+	}
+	if !cmp.Equal([]float64{1.2, 1.3, 10.1, 11.2}, vs) {
+		t.Fatal("unexpect timestamps")
+	}
+}
+
+// Ensure engine can create an descending cursor for tsm values.
+func TestEngine_CreateCursor_Descending(t *testing.T) {
+	t.Parallel()
+
+	e := MustOpenDefaultEngine()
+	defer e.Close()
+
+	e.MeasurementFields([]byte("cpu")).CreateFieldIfNotExists([]byte("value"), influxql.Float, false)
+	e.CreateSeriesIfNotExists([]byte("cpu,host=A"), []byte("cpu"), models.NewTags(map[string]string{"host": "A"}))
+
+	if err := e.WritePointsString(
+		`cpu,host=A value=1.1 1`,
+		`cpu,host=A value=1.2 2`,
+		`cpu,host=A value=1.3 3`,
+	); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+	e.MustWriteSnapshot()
+
+	if err := e.WritePointsString(
+		`cpu,host=A value=10.1 10`,
+		`cpu,host=A value=11.2 11`,
+		`cpu,host=A value=12.3 12`,
+	); err != nil {
+		t.Fatalf("failed to write points: %s", err.Error())
+	}
+
+	cur, err := e.CreateCursor(context.Background(), &tsdb.CursorRequest{
+		Measurement: "cpu",
+		Series:      "cpu,host=A",
+		Field:       "value",
+		Ascending:   false,
+		StartTime:   2,
+		EndTime:     11,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fcur := cur.(tsdb.FloatBatchCursor)
+	ts, vs := fcur.Next()
+	if !cmp.Equal([]int64{11, 10, 3, 2}, ts) {
+		t.Fatal("unexpect timestamps")
+	}
+	if !cmp.Equal([]float64{11.2, 10.1, 1.3, 1.2}, vs) {
+		t.Fatal("unexpect timestamps")
 	}
 }
 


### PR DESCRIPTION
* did not handle cached values correctly
* sort shards by time in either ascending or descending
  order depending on the RPC request ordering to ensure they
  are traversed in the correct order.

(cherry picked from commit 2e04e87)

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
