### PR TITLE
Encode durations as a string so they are more user-friendly

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -13,6 +13,9 @@ func New(w io.Writer) *zap.Logger {
 	config.EncodeTime = func(ts time.Time, encoder zapcore.PrimitiveArrayEncoder) {
 		encoder.AppendString(ts.UTC().Format(time.RFC3339))
 	}
+	config.EncodeDuration = func(d time.Duration, encoder zapcore.PrimitiveArrayEncoder) {
+		encoder.AppendString(d.String())
+	}
 	return zap.New(zapcore.NewCore(
 		zapcore.NewConsoleEncoder(config),
 		zapcore.Lock(zapcore.AddSync(w)),


### PR DESCRIPTION
- [x] Rebased/mergable
- [x] Tests pass