### PR TITLE
Add capability to force a full compaction

### DIFF
--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
@@ -9,6 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     make \
     ruby \
     ruby-dev \
+    build-essential \
     rpm \
     zip \
     python \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
@@ -9,6 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     make \
     ruby \
     ruby-dev \
+    build-essential \
     rpm \
     zip \
     python \

--- a/Dockerfile_build_ubuntu64_go19
+++ b/Dockerfile_build_ubuntu64_go19
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
@@ -9,6 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     make \
     ruby \
     ruby-dev \
+    build-essential \
     rpm \
     zip \
     python \

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -34,6 +34,7 @@ type Engine interface {
 	Close() error
 	SetEnabled(enabled bool)
 	SetCompactionsEnabled(enabled bool)
+	ScheduleFullCompaction() error
 
 	WithLogger(*zap.Logger)
 

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2462,6 +2462,104 @@ func TestDefaultPlanner_Plan_LargeGeneration(t *testing.T) {
 	}
 }
 
+func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
+	cp := tsm1.NewDefaultPlanner(
+		&fakeFileStore{
+			PathsFn: func() []tsm1.FileStat {
+				return []tsm1.FileStat{
+					tsm1.FileStat{
+						Path: "000000001-000000001.tsm",
+						Size: 2148340232,
+					},
+					tsm1.FileStat{
+						Path: "000000002-000000001.tsm",
+						Size: 2148356556,
+					},
+					tsm1.FileStat{
+						Path: "000000003-000000001.tsm",
+						Size: 167780181,
+					},
+					tsm1.FileStat{
+						Path: "000000004-000000001.tsm",
+						Size: 2148728539,
+					},
+					tsm1.FileStat{
+						Path: "000000005-000000002.tsm",
+						Size: 701863692,
+					},
+					tsm1.FileStat{
+						Path: "000000006-000000002.tsm",
+						Size: 701863692,
+					},
+					tsm1.FileStat{
+						Path: "000000007-000000002.tsm",
+						Size: 701863692,
+					},
+					tsm1.FileStat{
+						Path: "000000008-000000002.tsm",
+						Size: 701863692,
+					},
+					tsm1.FileStat{
+						Path: "000000009-000000002.tsm",
+						Size: 701863692,
+					},
+				}
+			},
+		}, tsdb.DefaultCompactFullWriteColdDuration,
+	)
+
+	tsm := cp.PlanLevel(1)
+	if exp, got := 1, len(tsm); got != exp {
+		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
+	}
+	cp.Release(tsm)
+
+	tsm = cp.PlanLevel(2)
+	if exp, got := 1, len(tsm); got != exp {
+		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
+	}
+	cp.Release(tsm)
+
+	cp.ForceFull()
+
+	// Level plans should not return any plans
+	tsm = cp.PlanLevel(1)
+	if exp, got := 0, len(tsm); got != exp {
+		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
+	}
+	cp.Release(tsm)
+
+	tsm = cp.PlanLevel(2)
+	if exp, got := 0, len(tsm); got != exp {
+		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
+	}
+	cp.Release(tsm)
+
+	tsm = cp.Plan(time.Now())
+	if exp, got := 1, len(tsm); got != exp {
+		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := len(tsm[0]), 9; got != exp {
+		t.Fatalf("plan length mismatch: got %v, exp %v", got, exp)
+	}
+	cp.Release(tsm)
+
+	// Level plans should return plans now that Plan has been called
+	tsm = cp.PlanLevel(1)
+	if exp, got := 1, len(tsm); got != exp {
+		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
+	}
+	cp.Release(tsm)
+
+	tsm = cp.PlanLevel(2)
+	if exp, got := 1, len(tsm); got != exp {
+		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
+	}
+	cp.Release(tsm)
+
+}
+
 func assertValueEqual(t *testing.T, a, b tsm1.Value) {
 	if got, exp := a.UnixNano(), b.UnixNano(); got != exp {
 		t.Fatalf("time mismatch: got %v, exp %v", got, exp)

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1173,6 +1173,7 @@ func (m *mockPlanner) PlanLevel(level int) []tsm1.CompactionGroup      { return 
 func (m *mockPlanner) PlanOptimize() []tsm1.CompactionGroup            { return nil }
 func (m *mockPlanner) Release(groups []tsm1.CompactionGroup)           {}
 func (m *mockPlanner) FullyCompacted() bool                            { return false }
+func (m *mockPlanner) ForceFull()                                      {}
 
 // ParseTags returns an instance of Tags for a comma-delimited list of key/values.
 func ParseTags(s string) query.Tags {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -191,6 +191,15 @@ func (s *Shard) SetEnabled(enabled bool) {
 	s.mu.Unlock()
 }
 
+// ScheduleFullCompaction forces a full compaction to be schedule on the shard.
+func (s *Shard) ScheduleFullCompaction() error {
+	engine, err := s.engine()
+	if err != nil {
+		return err
+	}
+	return engine.ScheduleFullCompaction()
+}
+
 // ID returns the shards ID.
 func (s *Shard) ID() uint64 {
 	return s.id


### PR DESCRIPTION
This adds the capability to the engine to force a full compaction
to be scheduled.  When called, it snapshots any data in the cache,
aborts running compactions and prevents level plans from returning
level plans.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)