### PR TITLE
Fix panic: runtime error: slice bounds out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 - [#9065](https://github.com/influxdata/influxdb/pull/9065): Refuse extra arguments to influx CLI
 
+## v1.4.2 [unreleased]
+
+### Bugfixes
+
+- [#9117](https://github.com/influxdata/influxdb/pull/9117): Fix panic: runtime error: slice bounds out of range
+
 ## v1.4.1 [2017-11-13]
 
 ### Bugfixes

--- a/tsdb/engine/tsm1/encoding.gen.go
+++ b/tsdb/engine/tsm1/encoding.gen.go
@@ -162,7 +162,7 @@ func (a Values) search(v int64) int {
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max].
 func (a Values) FindRange(min, max int64) (int, int) {
-	if len(a) == 0 {
+	if len(a) == 0 || min > max {
 		return -1, -1
 	}
 
@@ -374,7 +374,7 @@ func (a FloatValues) search(v int64) int {
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max].
 func (a FloatValues) FindRange(min, max int64) (int, int) {
-	if len(a) == 0 {
+	if len(a) == 0 || min > max {
 		return -1, -1
 	}
 
@@ -630,7 +630,7 @@ func (a IntegerValues) search(v int64) int {
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max].
 func (a IntegerValues) FindRange(min, max int64) (int, int) {
-	if len(a) == 0 {
+	if len(a) == 0 || min > max {
 		return -1, -1
 	}
 
@@ -886,7 +886,7 @@ func (a UnsignedValues) search(v int64) int {
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max].
 func (a UnsignedValues) FindRange(min, max int64) (int, int) {
-	if len(a) == 0 {
+	if len(a) == 0 || min > max {
 		return -1, -1
 	}
 
@@ -1142,7 +1142,7 @@ func (a StringValues) search(v int64) int {
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max].
 func (a StringValues) FindRange(min, max int64) (int, int) {
-	if len(a) == 0 {
+	if len(a) == 0 || min > max {
 		return -1, -1
 	}
 
@@ -1398,7 +1398,7 @@ func (a BooleanValues) search(v int64) int {
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max].
 func (a BooleanValues) FindRange(min, max int64) (int, int) {
-	if len(a) == 0 {
+	if len(a) == 0 || min > max {
 		return -1, -1
 	}
 

--- a/tsdb/engine/tsm1/encoding.gen.go.tmpl
+++ b/tsdb/engine/tsm1/encoding.gen.go.tmpl
@@ -159,7 +159,7 @@ func (a {{.Name}}Values) search(v int64) int {
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max].
 func (a {{.Name}}Values) FindRange(min, max int64) (int, int) {
-	if len(a) == 0 {
+	if len(a) == 0 || min > max {
 		return -1, -1
 	}
 

--- a/tsdb/engine/tsm1/encoding.gen_test.go
+++ b/tsdb/engine/tsm1/encoding.gen_test.go
@@ -74,6 +74,7 @@ func TestIntegerValues_Exclude(t *testing.T) {
 		min, max int64
 		exp      []int64
 	}{
+		{"excl bad range", 18, 11, []int64{10, 12, 14, 16, 18}},
 		{"excl none-lo", 0, 9, []int64{10, 12, 14, 16, 18}},
 		{"excl none-hi", 19, 30, []int64{10, 12, 14, 16, 18}},
 		{"excl first", 0, 10, []int64{12, 14, 16, 18}},


### PR DESCRIPTION
This fixes a regression in 1.4 introduced in ca40c1ad3c where a delete with an invalid time range could end up either causing a panic or duplicate data in the blocks.  I discovered this trying to reproduce #9116, which I have not been able to reproduce yet.  This fix _may_ fix that as well.  This does not occur in 1.3.

For both of these, star the server with `INFLUXDB_DATA_CACHE_SNAPSHOT_WRITE_COLD_DURATION=1s influxd`


To reproduce the panic:

A delete where the min and max times are backwards causes a panic in `Exclude`.

```
#!/bin/bash

influx -execute "drop database test; create database test"

curl -v "http://localhost:8086/write?db=test" --data-binary 'cpu value=1 0
cpu value=1 1
cpu value=1 2
cpu value=1 3
cpu value=1 4
cpu value=1 5
cpu value=1 6
cpu value=1 7
cpu value=1 8
cpu value=1 9
cpu value=1 10
cpu value=1 11
mem value=1 1
zzz value=1 2
aaa value=1 3'

echo "Waiting 2 seconds for snapshot"
sleep 2

echo "All data is there"
influx -database test -execute "select * from /.*/"

echo "Delete cpu series by exact times"
influx -database test -execute "delete from cpu where time >= 10 and time <= 1;"


echo "Waiting for compaction"
sleep 2
echo "All series lexicographically after aaa are gone"

influx -database test -execute "select * from /.*/"
```

The server crashes with:
```
panic: runtime error: slice bounds out of range

goroutine 4248 [running]:
github.com/influxdata/influxdb/tsdb/engine/tsm1.FloatValues.Exclude(0xc42031e000, 0xc, 0xc, 0xa, 0x1, 0xc42031e000, 0xc, 0xc)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/encoding.gen.go:317 +0x1c8
github.com/influxdata/influxdb/tsdb/engine/tsm1.(*tsmKeyIterator).combineFloat(0xc4204d31e0, 0xc4202ba101, 0x8, 0xc4207457d0, 0x10452d4)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/compact.gen.go:87 +0x430
github.com/influxdata/influxdb/tsdb/engine/tsm1.(*tsmKeyIterator).mergeFloat(0xc4204d31e0)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/compact.gen.go:31 +0x14e
```

To reproduce the duplicate data:
```
#!/bin/bash

influx -execute "drop database test; create database test"

curl -v "http://localhost:8086/write?db=test" --data-binary 'cpu value=1 0
cpu value=1 1
cpu value=1 2
cpu value=1 3
cpu value=1 4
cpu value=1 5
cpu value=1 6
cpu value=1 7
cpu value=1 8
cpu value=1 9
cpu value=1 10
cpu value=1 11
mem value=1 1
zzz value=1 2
aaa value=1 3'

echo "Waiting 2 seconds for snapshot"
sleep 2

echo "All data is there"
influx -database test -execute "select * from /.*/"

echo "Delete cpu series by exact times"
influx -database test -execute "delete from cpu where time >= 0 and time <= 0; delete from cpu where time >= 2 and time <= 4; delete from cpu where time >= 6 and time <= 8; delete from cpu where time >= 10 and time <= 1;"

echo "Waiting for compaction"
sleep 2
echo "All series lexicographically after aaa are gone"

influx -database test -execute "select * from /.*/"
```

This causes the CPU series to have duplicate data after a compaction:
```
name: cpu
time value
---- -----
1    1
5    1
9    1
5    1
9    1
10   1
11   1
```

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)