### PR TITLE
Implement FGA on SHOW COMMANDS

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -742,7 +742,7 @@ func (e *StatementExecutor) executeShowMeasurementsStatement(q *influxql.ShowMea
 		return ErrDatabaseNameRequired
 	}
 
-	names, err := e.TSDBStore.MeasurementNames(q.Database, q.Condition)
+	names, err := e.TSDBStore.MeasurementNames(ctx.Authorizer, q.Database, q.Condition)
 	if err != nil || len(names) == 0 {
 		return ctx.Send(&query.Result{
 			StatementID: ctx.StatementID,
@@ -1378,7 +1378,7 @@ type TSDBStore interface {
 	DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr) error
 	DeleteShard(id uint64) error
 
-	MeasurementNames(database string, cond influxql.Expr) ([][]byte, error)
+	MeasurementNames(auth query.Authorizer, database string, cond influxql.Expr) ([][]byte, error)
 	TagKeys(auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagKeys, error)
 	TagValues(auth query.Authorizer, shardIDs []uint64, cond influxql.Expr) ([]tsdb.TagValues, error)
 

--- a/coordinator/statement_executor_test.go
+++ b/coordinator/statement_executor_test.go
@@ -280,7 +280,7 @@ func NewQueryExecutor() *QueryExecutor {
 		return nil
 	}
 
-	e.TSDBStore.MeasurementNamesFn = func(database string, cond influxql.Expr) ([][]byte, error) {
+	e.TSDBStore.MeasurementNamesFn = func(auth query.Authorizer, database string, cond influxql.Expr) ([][]byte, error) {
 		return nil, nil
 	}
 

--- a/internal/authorizer.go
+++ b/internal/authorizer.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxql"
+)
+
+// AuthorizerMock is a mockable implementation of a query.Authorizer.
+type AuthorizerMock struct {
+	AuthorizeDatabaseFn    func(influxql.Privilege, string) bool
+	AuthorizeQueryFn       func(database string, query *influxql.Query) error
+	AuthorizeSeriesReadFn  func(database string, measurement []byte, tags models.Tags) bool
+	AuthorizeSeriesWriteFn func(database string, measurement []byte, tags models.Tags) bool
+}
+
+// AuthorizeDatabase determines if the provided privilege is sufficient to
+// authorise access to the database.
+func (a *AuthorizerMock) AuthorizeDatabase(p influxql.Privilege, name string) bool {
+	return a.AuthorizeDatabaseFn(p, name)
+}
+
+// AuthorizeQuery determins if the query can be executed against the provided
+// database.
+func (a *AuthorizerMock) AuthorizeQuery(database string, query *influxql.Query) error {
+	return a.AuthorizeQueryFn(database, query)
+}
+
+// AuthorizeSeriesRead determines if the series comprising measurement and tags
+// can be read on the provided database.
+func (a *AuthorizerMock) AuthorizeSeriesRead(database string, measurement []byte, tags models.Tags) bool {
+	return a.AuthorizeSeriesReadFn(database, measurement, tags)
+}
+
+// AuthorizeSeriesWrite determines if the series comprising measurement and tags
+// can be written to, on the provided database.
+func (a *AuthorizerMock) AuthorizeSeriesWrite(database string, measurement []byte, tags models.Tags) bool {
+	return a.AuthorizeSeriesWriteFn(database, measurement, tags)
+}

--- a/internal/tsdb_store.go
+++ b/internal/tsdb_store.go
@@ -28,7 +28,7 @@ type TSDBStoreMock struct {
 	ImportShardFn             func(id uint64, r io.Reader) error
 	MeasurementSeriesCountsFn func(database string) (measuments int, series int)
 	MeasurementsCardinalityFn func(database string) (int64, error)
-	MeasurementNamesFn        func(database string, cond influxql.Expr) ([][]byte, error)
+	MeasurementNamesFn        func(auth query.Authorizer, database string, cond influxql.Expr) ([][]byte, error)
 	OpenFn                    func() error
 	PathFn                    func() string
 	RestoreShardFn            func(id uint64, r io.Reader) error
@@ -84,8 +84,8 @@ func (s *TSDBStoreMock) ExpandSources(sources influxql.Sources) (influxql.Source
 func (s *TSDBStoreMock) ImportShard(id uint64, r io.Reader) error {
 	return s.ImportShardFn(id, r)
 }
-func (s *TSDBStoreMock) MeasurementNames(database string, cond influxql.Expr) ([][]byte, error) {
-	return s.MeasurementNamesFn(database, cond)
+func (s *TSDBStoreMock) MeasurementNames(auth query.Authorizer, database string, cond influxql.Expr) ([][]byte, error) {
+	return s.MeasurementNamesFn(auth, database, cond)
 }
 func (s *TSDBStoreMock) MeasurementSeriesCounts(database string) (measuments int, series int) {
 	return s.MeasurementSeriesCountsFn(database)

--- a/pkg/slices/bytes.go
+++ b/pkg/slices/bytes.go
@@ -1,0 +1,10 @@
+package slices
+
+// BytesToStrings converts a slice of []byte into a slice of strings.
+func BytesToStrings(a [][]byte) []string {
+	s := make([]string, 0, len(a))
+	for _, v := range a {
+		s = append(s, string(v))
+	}
+	return s
+}

--- a/pkg/slices/strings.go
+++ b/pkg/slices/strings.go
@@ -39,3 +39,12 @@ func ExistsIgnoreCase(set []string, find string) bool {
 	}
 	return false
 }
+
+// StringsToBytes converts a variable number of strings into a slice of []byte.
+func StringsToBytes(s ...string) [][]byte {
+	a := make([][]byte, 0, len(s))
+	for _, v := range s {
+		a = append(a, []byte(v))
+	}
+	return a
+}

--- a/query/query_executor.go
+++ b/query/query_executor.go
@@ -68,7 +68,7 @@ func ErrMaxConcurrentQueriesLimitExceeded(n, limit int) error {
 	return fmt.Errorf("max-concurrent-queries limit exceeded(%d, %d)", n, limit)
 }
 
-// Authorizer reports whether certain operations are authorized.
+// Authorizer determines if certain operations are authorized.
 type Authorizer interface {
 	// AuthorizeDatabase indicates whether the given Privilege is authorized on the database with the given name.
 	AuthorizeDatabase(p influxql.Privilege, name string) bool
@@ -85,22 +85,26 @@ type Authorizer interface {
 
 // OpenAuthorizer is the Authorizer used when authorization is disabled.
 // It allows all operations.
-type OpenAuthorizer struct{}
+type openAuthorizer struct{}
 
-var _ Authorizer = OpenAuthorizer{}
+// OpenAuthorizer can be shared by all goroutines.
+var OpenAuthorizer = openAuthorizer{}
 
 // AuthorizeDatabase returns true to allow any operation on a database.
-func (_ OpenAuthorizer) AuthorizeDatabase(influxql.Privilege, string) bool { return true }
+func (a openAuthorizer) AuthorizeDatabase(influxql.Privilege, string) bool { return true }
 
-func (_ OpenAuthorizer) AuthorizeSeriesRead(database string, measurement []byte, tags models.Tags) bool {
+// AuthorizeSeriesRead allows accesss to any series.
+func (a openAuthorizer) AuthorizeSeriesRead(database string, measurement []byte, tags models.Tags) bool {
 	return true
 }
 
-func (_ OpenAuthorizer) AuthorizeSeriesWrite(database string, measurement []byte, tags models.Tags) bool {
+// AuthorizeSeriesWrite allows accesss to any series.
+func (a openAuthorizer) AuthorizeSeriesWrite(database string, measurement []byte, tags models.Tags) bool {
 	return true
 }
 
-func (_ OpenAuthorizer) AuthorizeQuery(_ string, _ *influxql.Query) error { return nil }
+// AuthorizeSeriesRead allows any query to execute.
+func (a openAuthorizer) AuthorizeQuery(_ string, _ *influxql.Query) error { return nil }
 
 // ExecutionOptions contains the options for executing a query.
 type ExecutionOptions struct {

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -418,7 +418,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 		opts.Authorizer = user
 	} else {
 		// Auth is disabled, so allow everything.
-		opts.Authorizer = query.OpenAuthorizer{}
+		opts.Authorizer = query.OpenAuthorizer
 	}
 
 	// Make sure if the client disconnects we signal the query to abort
@@ -960,7 +960,7 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 		opts.Authorizer = user
 	} else {
 		// Auth is disabled, so allow everything.
-		opts.Authorizer = query.OpenAuthorizer{}
+		opts.Authorizer = query.OpenAuthorizer
 	}
 
 	// Make sure if the client disconnects we signal the query to abort

--- a/services/storage/series_cursor.go
+++ b/services/storage/series_cursor.go
@@ -55,7 +55,7 @@ type indexSeriesCursor struct {
 func newIndexSeriesCursor(ctx context.Context, req *ReadRequest, shards []*tsdb.Shard) (*indexSeriesCursor, error) {
 	opt := query.IteratorOptions{
 		Aux:        []influxql.VarRef{{Val: "key"}},
-		Authorizer: query.OpenAuthorizer{},
+		Authorizer: query.OpenAuthorizer,
 		Ordered:    true,
 	}
 	p := &indexSeriesCursor{row: seriesRow{shards: shards}}

--- a/tests/server_concurrent_test.go
+++ b/tests/server_concurrent_test.go
@@ -133,7 +133,7 @@ func TestConcurrentServer_ShowMeasurements(t *testing.T) {
 		if !ok {
 			t.Fatal("Not a local server")
 		}
-		srv.TSDBStore.MeasurementNames("db0", nil)
+		srv.TSDBStore.MeasurementNames(query.OpenAuthorizer, "db0", nil)
 	}
 
 	runTest(10*time.Second, f1, f2)

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -59,7 +59,7 @@ type Engine interface {
 	SeriesN() int64
 
 	MeasurementExists(name []byte) (bool, error)
-	MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error)
+	MeasurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error)
 	MeasurementNamesByRegex(re *regexp.Regexp) ([][]byte, error)
 	MeasurementFields(measurement []byte) *MeasurementFields
 	ForEachMeasurementName(fn func(name []byte) error) error

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -370,8 +370,8 @@ func (e *Engine) MeasurementExists(name []byte) (bool, error) {
 	return e.index.MeasurementExists(name)
 }
 
-func (e *Engine) MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
-	return e.index.MeasurementNamesByExpr(expr)
+func (e *Engine) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
+	return e.index.MeasurementNamesByExpr(auth, expr)
 }
 
 func (e *Engine) MeasurementNamesByRegex(re *regexp.Regexp) ([][]byte, error) {

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -19,7 +19,7 @@ type Index interface {
 	WithLogger(*zap.Logger)
 
 	MeasurementExists(name []byte) (bool, error)
-	MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error)
+	MeasurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error)
 	MeasurementNamesByRegex(re *regexp.Regexp) ([][]byte, error)
 	DropMeasurement(name []byte) error
 	ForEachMeasurementName(fn func(name []byte) error) error

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -392,24 +392,26 @@ func (i *Index) TagsForSeries(key string) (models.Tags, error) {
 
 // MeasurementNamesByExpr takes an expression containing only tags and returns a
 // list of matching meaurement names.
-func (i *Index) MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
+func (i *Index) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
 	// Return all measurement names if no expression is provided.
 	if expr == nil {
 		a := make([][]byte, 0, len(i.measurements))
-		for name := range i.measurements {
-			a = append(a, []byte(name))
+		for _, m := range i.measurements {
+			if m.Authorized(auth) {
+				a = append(a, m.name)
+			}
 		}
 		bytesutil.Sort(a)
 		return a, nil
 	}
 
-	return i.measurementNamesByExpr(expr)
+	return i.measurementNamesByExpr(auth, expr)
 }
 
-func (i *Index) measurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
+func (i *Index) measurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
 	if expr == nil {
 		return nil, nil
 	}
@@ -444,19 +446,19 @@ func (i *Index) measurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
 
 			// Match on name, if specified.
 			if tag.Val == "_name" {
-				return i.measurementNamesByNameFilter(tf.Op, tf.Value, tf.Regex), nil
+				return i.measurementNamesByNameFilter(auth, tf.Op, tf.Value, tf.Regex), nil
 			} else if influxql.IsSystemName(tag.Val) {
 				return nil, nil
 			}
 
-			return i.measurementNamesByTagFilters(tf), nil
+			return i.measurementNamesByTagFilters(auth, tf), nil
 		case influxql.OR, influxql.AND:
-			lhs, err := i.measurementNamesByExpr(e.LHS)
+			lhs, err := i.measurementNamesByExpr(auth, e.LHS)
 			if err != nil {
 				return nil, err
 			}
 
-			rhs, err := i.measurementNamesByExpr(e.RHS)
+			rhs, err := i.measurementNamesByExpr(auth, e.RHS)
 			if err != nil {
 				return nil, err
 			}
@@ -469,13 +471,13 @@ func (i *Index) measurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
 			return nil, fmt.Errorf("invalid tag comparison operator")
 		}
 	case *influxql.ParenExpr:
-		return i.measurementNamesByExpr(e.Expr)
+		return i.measurementNamesByExpr(auth, e.Expr)
 	}
 	return nil, fmt.Errorf("%#v", expr)
 }
 
 // measurementNamesByNameFilter returns the sorted measurements matching a name.
-func (i *Index) measurementNamesByNameFilter(op influxql.Token, val string, regex *regexp.Regexp) [][]byte {
+func (i *Index) measurementNamesByNameFilter(auth query.Authorizer, op influxql.Token, val string, regex *regexp.Regexp) [][]byte {
 	var names [][]byte
 	for _, m := range i.measurements {
 		var matched bool
@@ -490,17 +492,16 @@ func (i *Index) measurementNamesByNameFilter(op influxql.Token, val string, rege
 			matched = !regex.MatchString(m.Name)
 		}
 
-		if !matched {
-			continue
+		if matched && m.Authorized(auth) {
+			names = append(names, m.name)
 		}
-		names = append(names, []byte(m.Name))
 	}
 	bytesutil.Sort(names)
 	return names
 }
 
 // measurementNamesByTagFilters returns the sorted measurements matching the filters on tag values.
-func (i *Index) measurementNamesByTagFilters(filter *TagFilter) [][]byte {
+func (i *Index) measurementNamesByTagFilters(auth query.Authorizer, filter *TagFilter) [][]byte {
 	// Build a list of measurements matching the filters.
 	var names [][]byte
 	var tagMatch bool
@@ -541,9 +542,8 @@ func (i *Index) measurementNamesByTagFilters(filter *TagFilter) [][]byte {
 		//     True   |       False     |      False
 		//     False  |       True      |      False
 		//     False  |       False     |      True
-		if tagMatch == (filter.Op == influxql.EQ || filter.Op == influxql.EQREGEX) {
+		if tagMatch == (filter.Op == influxql.EQ || filter.Op == influxql.EQREGEX) && m.Authorized(auth) {
 			names = append(names, []byte(m.Name))
-			continue
 		}
 	}
 

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -12,7 +12,6 @@ shared index format to the new per-shard format.
 package inmem
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"regexp"
@@ -392,7 +391,7 @@ func (i *Index) TagsForSeries(key string) (models.Tags, error) {
 }
 
 // MeasurementNamesByExpr takes an expression containing only tags and returns a
-// list of matching meaurement names.
+// list of matching measurement names.
 func (i *Index) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
@@ -508,13 +507,9 @@ func (i *Index) measurementNamesByTagFilters(auth query.Authorizer, filter *TagF
 	var tagMatch bool
 	var authorized bool
 
-	// valEqual determins if the provided []byte is equal to the tag value
-	// to be filtered on.
-	valEqual := func(b []byte) bool {
-		if filter.Op == influxql.EQ || filter.Op == influxql.NEQ {
-			return bytes.Equal([]byte(filter.Value), b)
-		}
-		return filter.Regex.Match(b)
+	valEqual := filter.Regex.MatchString
+	if filter.Op == influxql.EQ || filter.Op == influxql.NEQ {
+		valEqual = func(s string) bool { return filter.Value == s }
 	}
 
 	// Iterate through all measurements in the database.
@@ -525,36 +520,35 @@ func (i *Index) measurementNamesByTagFilters(auth query.Authorizer, filter *TagF
 		}
 
 		tagMatch = false
-		authorized = true
-		if auth != nil {
-			authorized = false // Authorization must be explicitly granted.
-		}
+		// Authorization must be explicitly granted when an authorizer is present.
+		authorized = auth == nil
 
 		// Check the tag values belonging to the tag key for equivalence to the
 		// tag value being filtered on.
 		tagVals.Range(func(tv string, seriesIDs SeriesIDs) bool {
-			if valEqual([]byte(tv)) {
-				tagMatch = true
-				if auth == nil {
-					return false // No need to continue checking series.
-				}
+			if !valEqual(tv) {
+				return true // No match. Keep checking.
+			}
 
-				// Is there a series with this matching tag value that is
-				// authorized to be read?
-				for _, sid := range seriesIDs {
-					if s := m.SeriesByID(sid); s != nil && auth.AuthorizeSeriesRead(i.database, m.name, s.Tags()) {
-						// The Range call can return early as a matching
-						// tag value with an authorized series has been found.
-						authorized = true
-						return false
-					}
+			tagMatch = true
+			if auth == nil {
+				return false // No need to continue checking series, there is a match.
+			}
+
+			// Is there a series with this matching tag value that is
+			// authorized to be read?
+			for _, sid := range seriesIDs {
+				if s := m.SeriesByID(sid); s != nil && auth.AuthorizeSeriesRead(i.database, m.name, s.Tags()) {
+					// The Range call can return early as a matching
+					// tag value with an authorized series has been found.
+					authorized = true
+					return false
 				}
 			}
 
-			// Either this tag value doesn't match the required filter, or the
-			// tag value does match but doesn't have any authorized series.
-			// Keep checking tag values.
-			return true
+			// The matching tag value doesn't have any authorized series.
+			// Check for other matching tag values if this is a regex check.
+			return filter.Op == influxql.EQREGEX
 		})
 
 		// For negation operators, to determine if the measurement is authorized,
@@ -841,7 +835,7 @@ func (i *Index) RemoveShard(shardID uint64) {
 	}
 }
 
-// assignExistingSeries assigns the existings series to shardID and returns the series, names and tags that
+// assignExistingSeries assigns the existing series to shardID and returns the series, names and tags that
 // do not exists yet.
 func (i *Index) assignExistingSeries(shardID uint64, keys, names [][]byte, tagsSlice []models.Tags) ([][]byte, [][]byte, []models.Tags) {
 	i.mu.RLock()
@@ -950,7 +944,7 @@ func (idx *ShardIndex) CreateSeriesListIfNotExists(keys, names [][]byte, tagsSli
 	return nil
 }
 
-// InitializeSeries is called during startup.
+// InitializeSeries is called during start-up.
 // This works the same as CreateSeriesIfNotExists except it ignore limit errors.
 func (i *ShardIndex) InitializeSeries(key, name []byte, tags models.Tags) error {
 	return i.Index.CreateSeriesIfNotExists(i.id, key, name, tags, &i.opt, true)

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -52,6 +52,28 @@ func NewMeasurement(database, name string) *Measurement {
 	}
 }
 
+// Authorized determines if this Measurement is authorized to be read, according
+// to the provided Authorizer. A measurement is authorized to be read if at
+// least one series from the measurement is authorized to be read.
+func (m *Measurement) Authorized(auth query.Authorizer) bool {
+	if auth == nil {
+		return true
+	}
+
+	// Note(edd): the cost of this check scales linearly with the number of series
+	// belonging to a measurement, which means it may become expensive when there
+	// are large numbers of series on a measurement.
+	//
+	// In the future we might want to push the set of series down into the
+	// authorizer, but that will require an API change.
+	for _, s := range m.SeriesByIDMap() {
+		if auth.AuthorizeSeriesRead(m.database, m.name, s.tags) {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Measurement) HasField(name string) bool {
 	m.mu.RLock()
 	_, hasField := m.fieldNames[name]

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -303,7 +303,7 @@ func (m *Measurement) Rebuild() *Measurement {
 	m.mu.RUnlock()
 
 	// Re-add each series to allow the measurement indexes to get re-created.  If there were
-	// deletes, the existing measurment may have references to deleted series that need to be
+	// deletes, the existing measurement may have references to deleted series that need to be
 	// expunged.  Note: we're NOT using SeriesIDs which returns the series in sorted order because
 	// we need to do this under a write lock to prevent races.  The series are added in sorted
 	// order to prevent resorting them again after they are all re-added.

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -67,9 +67,10 @@ func (fs *FileSet) Release() {
 // Filters do not need to be rebuilt because log files have no bloom filter.
 func (fs *FileSet) PrependLogFile(f *LogFile) *FileSet {
 	return &FileSet{
-		levels:  fs.levels,
-		files:   append([]File{f}, fs.files...),
-		filters: fs.filters,
+		database: fs.database,
+		levels:   fs.levels,
+		files:    append([]File{f}, fs.files...),
+		filters:  fs.filters,
 	}
 }
 
@@ -113,9 +114,10 @@ func (fs *FileSet) MustReplace(oldFiles []File, newFile File) *FileSet {
 
 	// Build new fileset and rebuild changed filters.
 	newFS := &FileSet{
-		levels:  fs.levels,
-		files:   other,
-		filters: filters,
+		levels:   fs.levels,
+		files:    other,
+		filters:  filters,
+		database: fs.database,
 	}
 	if err := newFS.buildFilters(); err != nil {
 		panic("cannot build file set: " + err.Error())

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -715,7 +715,7 @@ func (fs *FileSet) measurementNamesByTagFilter(auth query.Authorizer, op influxq
 		}
 
 		// For negation operators, to determine if the measurement is authorized,
-		// an authorized series belonging to the measurement must located.
+		// an authorized series belonging to the measurement must be located.
 		// Then, the measurement can be added iff !tagMatch && authorized.
 		if op == influxql.NEQ || op == influxql.NEQREGEX && !tagMatch {
 			authorized = fs.measurementAuthorizedSeries(auth, me.Name())
@@ -729,7 +729,6 @@ func (fs *FileSet) measurementNamesByTagFilter(auth query.Authorizer, op influxq
 		//     False  |       False     |      True
 		if tagMatch == (op == influxql.EQ || op == influxql.EQREGEX) && authorized {
 			names = append(names, me.Name())
-			continue
 		}
 	}
 

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -400,11 +400,11 @@ func (i *Index) MeasurementExists(name []byte) (bool, error) {
 	return m != nil && !m.Deleted(), nil
 }
 
-func (i *Index) MeasurementNamesByExpr(expr influxql.Expr) ([][]byte, error) {
+func (i *Index) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {
 	fs := i.RetainFileSet()
 	defer fs.Release()
 
-	names, err := fs.MeasurementNamesByExpr(expr)
+	names, err := fs.MeasurementNamesByExpr(auth, expr)
 
 	// Clone byte slices since they will be used after the fileset is released.
 	return bytesutil.CloneSlice(names), err

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -1239,6 +1239,14 @@ func (itr *seriesPointIterator) Next() (*query.FloatPoint, error) {
 			continue
 		}
 
+		// TODO(edd): It seems to me like this authorisation check should be
+		// further down in the index. At this point we're going to be filtering
+		// series that have already been materialised in the LogFiles and
+		// IndexFiles.
+		if itr.opt.Authorizer != nil && !itr.opt.Authorizer.AuthorizeSeriesRead(itr.fs.database, e.Name(), e.Tags()) {
+			continue
+		}
+
 		// Convert to a key.
 		key := string(models.MakeKey(e.Name(), e.Tags()))
 

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -139,7 +139,7 @@ func TestIndex_MeasurementNamesByExpr(t *testing.T) {
 	// Retrieve measurements by expression
 	idx.Run(t, func(t *testing.T) {
 		t.Run("EQ", func(t *testing.T) {
-			names, err := idx.MeasurementNamesByExpr(influxql.MustParseExpr(`region = 'west'`))
+			names, err := idx.MeasurementNamesByExpr(nil, influxql.MustParseExpr(`region = 'west'`))
 			if err != nil {
 				t.Fatal(err)
 			} else if !reflect.DeepEqual(names, [][]byte{[]byte("cpu"), []byte("mem")}) {
@@ -148,7 +148,7 @@ func TestIndex_MeasurementNamesByExpr(t *testing.T) {
 		})
 
 		t.Run("NEQ", func(t *testing.T) {
-			names, err := idx.MeasurementNamesByExpr(influxql.MustParseExpr(`region != 'east'`))
+			names, err := idx.MeasurementNamesByExpr(nil, influxql.MustParseExpr(`region != 'east'`))
 			if err != nil {
 				t.Fatal(err)
 			} else if !reflect.DeepEqual(names, [][]byte{[]byte("disk"), []byte("mem")}) {
@@ -157,7 +157,7 @@ func TestIndex_MeasurementNamesByExpr(t *testing.T) {
 		})
 
 		t.Run("EQREGEX", func(t *testing.T) {
-			names, err := idx.MeasurementNamesByExpr(influxql.MustParseExpr(`region =~ /east|west/`))
+			names, err := idx.MeasurementNamesByExpr(nil, influxql.MustParseExpr(`region =~ /east|west/`))
 			if err != nil {
 				t.Fatal(err)
 			} else if !reflect.DeepEqual(names, [][]byte{[]byte("cpu"), []byte("mem")}) {
@@ -166,7 +166,7 @@ func TestIndex_MeasurementNamesByExpr(t *testing.T) {
 		})
 
 		t.Run("NEQREGEX", func(t *testing.T) {
-			names, err := idx.MeasurementNamesByExpr(influxql.MustParseExpr(`country !~ /^u/`))
+			names, err := idx.MeasurementNamesByExpr(nil, influxql.MustParseExpr(`country !~ /^u/`))
 			if err != nil {
 				t.Fatal(err)
 			} else if !reflect.DeepEqual(names, [][]byte{[]byte("cpu"), []byte("disk")}) {

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -244,11 +244,11 @@ func ReadMeasurementBlockTrailer(data []byte) (MeasurementBlockTrailer, error) {
 	t.HashIndex.Offset, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
 	t.HashIndex.Size, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
 
-	// Read measurment sketch info.
+	// Read measurement sketch info.
 	t.Sketch.Offset, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
 	t.Sketch.Size, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
 
-	// Read tombstone measurment sketch info.
+	// Read tombstone measurement sketch info.
 	t.TSketch.Offset, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
 	t.TSketch.Size, buf = int64(binary.BigEndian.Uint64(buf[0:8])), buf[8:]
 

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -7,11 +7,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/influxdata/influxdb/tsdb/index/inmem"
-
 	"github.com/influxdata/influxdb/internal"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/slices"
 	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/tsdb/index/inmem"
 	"github.com/influxdata/influxql"
 )
 
@@ -47,20 +47,20 @@ func TestIndex_MeasurementNamesByExpr(t *testing.T) {
 
 	// These examples should be run without any auth.
 	examples := []example{
-		{name: "all", expected: StringsToBytes("cpu", "disk", "gpu", "mem", "pci")},
-		{name: "EQ", expr: influxql.MustParseExpr(`region = 'west'`), expected: StringsToBytes("cpu", "mem")},
-		{name: "NEQ", expr: influxql.MustParseExpr(`region != 'west'`), expected: StringsToBytes("gpu", "pci")},
-		{name: "EQREGEX", expr: influxql.MustParseExpr(`region =~ /.*st/`), expected: StringsToBytes("cpu", "gpu", "mem", "pci")},
-		{name: "NEQREGEX", expr: influxql.MustParseExpr(`region !~ /.*est/`), expected: StringsToBytes("gpu", "pci")},
+		{name: "all", expected: slices.StringsToBytes("cpu", "disk", "gpu", "mem", "pci")},
+		{name: "EQ", expr: influxql.MustParseExpr(`region = 'west'`), expected: slices.StringsToBytes("cpu", "mem")},
+		{name: "NEQ", expr: influxql.MustParseExpr(`region != 'west'`), expected: slices.StringsToBytes("gpu", "pci")},
+		{name: "EQREGEX", expr: influxql.MustParseExpr(`region =~ /.*st/`), expected: slices.StringsToBytes("cpu", "gpu", "mem", "pci")},
+		{name: "NEQREGEX", expr: influxql.MustParseExpr(`region !~ /.*est/`), expected: slices.StringsToBytes("gpu", "pci")},
 	}
 
 	// These examples should be run with the authorizer.
 	authExamples := []example{
-		{name: "all", expected: StringsToBytes("cpu", "gpu", "mem")},
-		{name: "EQ", expr: influxql.MustParseExpr(`region = 'west'`), expected: StringsToBytes("mem")},
-		{name: "NEQ", expr: influxql.MustParseExpr(`region != 'west'`), expected: StringsToBytes("gpu")},
-		{name: "EQREGEX", expr: influxql.MustParseExpr(`region =~ /.*st/`), expected: StringsToBytes("cpu", "gpu", "mem")},
-		{name: "NEQREGEX", expr: influxql.MustParseExpr(`region !~ /.*est/`), expected: StringsToBytes("gpu")},
+		{name: "all", expected: slices.StringsToBytes("cpu", "gpu", "mem")},
+		{name: "EQ", expr: influxql.MustParseExpr(`region = 'west'`), expected: slices.StringsToBytes("mem")},
+		{name: "NEQ", expr: influxql.MustParseExpr(`region != 'west'`), expected: slices.StringsToBytes("gpu")},
+		{name: "EQREGEX", expr: influxql.MustParseExpr(`region =~ /.*st/`), expected: slices.StringsToBytes("cpu", "gpu", "mem")},
+		{name: "NEQREGEX", expr: influxql.MustParseExpr(`region !~ /.*est/`), expected: slices.StringsToBytes("gpu")},
 	}
 
 	for _, idx := range tsdb.RegisteredIndexes() {
@@ -72,7 +72,7 @@ func TestIndex_MeasurementNamesByExpr(t *testing.T) {
 						if err != nil {
 							t.Fatal(err)
 						} else if !reflect.DeepEqual(names, example.expected) {
-							t.Fatalf("got names: %v, expected %v", BytesToStrings(names), BytesToStrings(example.expected))
+							t.Fatalf("got names: %v, expected %v", slices.BytesToStrings(names), slices.BytesToStrings(example.expected))
 						}
 					})
 				}
@@ -85,29 +85,13 @@ func TestIndex_MeasurementNamesByExpr(t *testing.T) {
 						if err != nil {
 							t.Fatal(err)
 						} else if !reflect.DeepEqual(names, example.expected) {
-							t.Fatalf("got names: %v, expected %v", BytesToStrings(names), BytesToStrings(example.expected))
+							t.Fatalf("got names: %v, expected %v", slices.BytesToStrings(names), slices.BytesToStrings(example.expected))
 						}
 					})
 				}
 			})
 		})
 	}
-}
-
-func StringsToBytes(s ...string) [][]byte {
-	a := make([][]byte, 0, len(s))
-	for _, v := range s {
-		a = append(a, []byte(v))
-	}
-	return a
-}
-
-func BytesToStrings(a [][]byte) []string {
-	s := make([]string, 0, len(a))
-	for _, v := range a {
-		s = append(s, string(v))
-	}
-	return s
 }
 
 type Index struct {

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -1,0 +1,137 @@
+package tsdb_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/influxdb/tsdb/index/inmem"
+
+	"github.com/influxdata/influxdb/internal"
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxql"
+)
+
+func TestIndex_MeasurementNamesByExpr(t *testing.T) {
+	// Setup indexes
+	indexes := map[string]*Index{}
+	for _, name := range tsdb.RegisteredIndexes() {
+		idx := NewIndex(name)
+		idx.AddSeries("cpu", map[string]string{"region": "east"})
+		idx.AddSeries("cpu", map[string]string{"region": "west", "secret": "foo"})
+		idx.AddSeries("disk", map[string]string{"secret": "foo"})
+		idx.AddSeries("mem", map[string]string{"region": "west"})
+		idx.AddSeries("gpu", map[string]string{"region": "east"})
+		idx.AddSeries("pci", map[string]string{"region": "east", "secret": "foo"})
+		indexes[name] = idx
+	}
+
+	authorizer := &internal.AuthorizerMock{
+		AuthorizeSeriesReadFn: func(database string, measurement []byte, tags models.Tags) bool {
+			if tags.GetString("secret") != "" {
+				t.Logf("Rejecting series db=%s, m=%s, tags=%v", database, measurement, tags)
+				return false
+			}
+			return true
+		},
+	}
+
+	type example struct {
+		name     string
+		expr     influxql.Expr
+		expected [][]byte
+	}
+
+	// These examples should be run without any auth.
+	examples := []example{
+		{name: "all", expected: StringsToBytes("cpu", "disk", "gpu", "mem", "pci")},
+		{name: "EQ", expr: influxql.MustParseExpr(`region = 'west'`), expected: StringsToBytes("cpu", "mem")},
+		{name: "NEQ", expr: influxql.MustParseExpr(`region != 'west'`), expected: StringsToBytes("gpu", "pci")},
+		{name: "EQREGEX", expr: influxql.MustParseExpr(`region =~ /.*st/`), expected: StringsToBytes("cpu", "gpu", "mem", "pci")},
+		{name: "NEQREGEX", expr: influxql.MustParseExpr(`region !~ /.*est/`), expected: StringsToBytes("gpu", "pci")},
+	}
+
+	// These examples should be run with the authorizer.
+	authExamples := []example{
+		{name: "all", expected: StringsToBytes("cpu", "gpu", "mem")},
+		{name: "EQ", expr: influxql.MustParseExpr(`region = 'west'`), expected: StringsToBytes("mem")},
+		{name: "NEQ", expr: influxql.MustParseExpr(`region != 'west'`), expected: StringsToBytes("gpu")},
+		{name: "EQREGEX", expr: influxql.MustParseExpr(`region =~ /.*st/`), expected: StringsToBytes("cpu", "gpu", "mem")},
+		{name: "NEQREGEX", expr: influxql.MustParseExpr(`region !~ /.*est/`), expected: StringsToBytes("gpu")},
+	}
+
+	for _, idx := range tsdb.RegisteredIndexes() {
+		t.Run(idx, func(t *testing.T) {
+			t.Run("no authorization", func(t *testing.T) {
+				for _, example := range examples {
+					t.Run(example.name, func(t *testing.T) {
+						names, err := indexes[idx].MeasurementNamesByExpr(nil, example.expr)
+						if err != nil {
+							t.Fatal(err)
+						} else if !reflect.DeepEqual(names, example.expected) {
+							t.Fatalf("got names: %v, expected %v", BytesToStrings(names), BytesToStrings(example.expected))
+						}
+					})
+				}
+			})
+
+			t.Run("with authorization", func(t *testing.T) {
+				for _, example := range authExamples {
+					t.Run(example.name, func(t *testing.T) {
+						names, err := indexes[idx].MeasurementNamesByExpr(authorizer, example.expr)
+						if err != nil {
+							t.Fatal(err)
+						} else if !reflect.DeepEqual(names, example.expected) {
+							t.Fatalf("got names: %v, expected %v", BytesToStrings(names), BytesToStrings(example.expected))
+						}
+					})
+				}
+			})
+		})
+	}
+}
+
+func StringsToBytes(s ...string) [][]byte {
+	a := make([][]byte, 0, len(s))
+	for _, v := range s {
+		a = append(a, []byte(v))
+	}
+	return a
+}
+
+func BytesToStrings(a [][]byte) []string {
+	s := make([]string, 0, len(a))
+	for _, v := range a {
+		s = append(s, string(v))
+	}
+	return s
+}
+
+type Index struct {
+	tsdb.Index
+}
+
+func NewIndex(index string) *Index {
+	opts := tsdb.NewEngineOptions()
+	opts.IndexVersion = index
+
+	if index == inmem.IndexName {
+		opts.InmemIndex = inmem.NewIndex("db0")
+	}
+
+	path, err := ioutil.TempDir("", "influxdb-tsdb")
+	if err != nil {
+		panic(err)
+	}
+	idx := &Index{Index: tsdb.MustOpenIndex(0, "db0", filepath.Join(path, "index"), opts)}
+	return idx
+}
+
+func (idx *Index) AddSeries(name string, tags map[string]string) error {
+	t := models.NewTags(tags)
+	key := fmt.Sprintf("%s,%s", name, t.HashKey())
+	return idx.CreateSeriesIfNotExists([]byte(key), []byte(name), t)
+}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -741,12 +741,12 @@ func (s *Shard) MeasurementsSketches() (estimator.Sketch, estimator.Sketch, erro
 
 // MeasurementNamesByExpr returns names of measurements matching the condition.
 // If cond is nil then all measurement names are returned.
-func (s *Shard) MeasurementNamesByExpr(cond influxql.Expr) ([][]byte, error) {
+func (s *Shard) MeasurementNamesByExpr(auth query.Authorizer, cond influxql.Expr) ([][]byte, error) {
 	engine, err := s.engine()
 	if err != nil {
 		return nil, err
 	}
-	return engine.MeasurementNamesByExpr(cond)
+	return engine.MeasurementNamesByExpr(auth, cond)
 }
 
 // MeasurementNamesByRegex returns names of measurements matching the regular expression.
@@ -1595,7 +1595,9 @@ func NewFieldKeysIterator(engine Engine, opt query.IteratorOptions) (query.Itera
 	itr := &fieldKeysIterator{engine: engine}
 
 	// Retrieve measurements from shard. Filter if condition specified.
-	names, err := engine.MeasurementNamesByExpr(opt.Condition)
+	//
+	// FGA is currently not supported when retrieving field keys.
+	names, err := engine.MeasurementNamesByExpr(query.OpenAuthorizer, opt.Condition)
 	if err != nil {
 		return nil, err
 	}
@@ -1685,7 +1687,7 @@ type measurementKeyFunc func(name []byte) ([][]byte, error)
 
 func newMeasurementKeysIterator(engine Engine, fn measurementKeyFunc, opt query.IteratorOptions) (*measurementKeysIterator, error) {
 	itr := &measurementKeysIterator{fn: fn}
-	names, err := engine.MeasurementNamesByExpr(opt.Condition)
+	names, err := engine.MeasurementNamesByExpr(opt.Authorizer, opt.Condition)
 	if err != nil {
 		return nil, err
 	}

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -1,6 +1,7 @@
 package tsdb_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -13,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/influxdata/influxdb/internal"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
@@ -769,6 +772,105 @@ cpu,host=serverB,region=uswest value=25  0
 
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) { test(index) })
+		sh.Close()
+		itr.Close()
+	}
+}
+
+func TestShard_CreateIterator_Series_Auth(t *testing.T) {
+	var sh *Shard
+	var itr query.Iterator
+
+	type variant struct {
+		name string
+		m    *influxql.Measurement
+		aux  []influxql.VarRef
+	}
+
+	examples := []variant{
+		{
+			name: "use_index",
+			m:    &influxql.Measurement{Name: "cpu"},
+			aux:  []influxql.VarRef{{Val: "_seriesKey", Type: influxql.String}},
+		},
+		{
+			name: "use_cursors",
+			m:    &influxql.Measurement{Name: "cpu", SystemIterator: "_series"},
+			aux:  []influxql.VarRef{{Val: "key", Type: influxql.String}},
+		},
+	}
+
+	test := func(index string, v variant) error {
+		sh = MustNewOpenShard(index)
+		sh.MustWritePointsString(`
+cpu,host=serverA,region=uswest value=100 0
+cpu,host=serverA,region=uswest value=50,val2=5  10
+cpu,host=serverB,region=uswest value=25  0
+cpu,secret=foo value=100 0
+`)
+
+		seriesAuthorizer := &internal.AuthorizerMock{
+			AuthorizeSeriesReadFn: func(database string, measurement []byte, tags models.Tags) bool {
+				if database == "" || !bytes.Equal(measurement, []byte("cpu")) || tags.GetString("secret") != "" {
+					t.Logf("Rejecting series db=%s, m=%s, tags=%v", database, measurement, tags)
+					return false
+				}
+				return true
+			},
+		}
+
+		// Create iterator for case where we use cursors (e.g., where time
+		// included in a SHOW SERIES query).
+		var err error
+		itr, err = sh.CreateIterator(context.Background(), v.m, query.IteratorOptions{
+			Aux:        v.aux,
+			Ascending:  true,
+			StartTime:  influxql.MinTime,
+			EndTime:    influxql.MaxTime,
+			Authorizer: seriesAuthorizer,
+		})
+		if err != nil {
+			return err
+		}
+
+		if itr == nil {
+			return fmt.Errorf("iterator is nil")
+		}
+
+		fitr := itr.(query.FloatIterator)
+		defer fitr.Close()
+		var expCount = 2
+		var gotCount int
+		for {
+			f, err := fitr.Next()
+			if err != nil {
+				return err
+			}
+
+			if f == nil {
+				break
+			}
+
+			if got := f.Aux[0].(string); strings.Contains(got, "secret") {
+				return fmt.Errorf("got a series %q that should be filtered", got)
+			}
+			gotCount++
+		}
+
+		if gotCount != expCount {
+			return fmt.Errorf("got %d series, expected %d", gotCount, expCount)
+		}
+		return nil
+	}
+
+	for _, index := range tsdb.RegisteredIndexes() {
+		for _, example := range examples {
+			t.Run(index+"_"+example.name, func(t *testing.T) {
+				if err := test(index, example); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
 		sh.Close()
 		itr.Close()
 	}
@@ -1562,6 +1664,15 @@ func NewShard(index string) *Shard {
 		),
 		path: dir,
 	}
+}
+
+// MustNewOpenShard creates and opens a shard with the provided index.
+func MustNewOpenShard(index string) *Shard {
+	sh := NewShard(index)
+	if err := sh.Open(); err != nil {
+		panic(err)
+	}
+	return sh
 }
 
 // Close closes the shard and removes all underlying data.

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -998,7 +998,7 @@ func TestStore_Measurements_Auth(t *testing.T) {
 		var gotNames int
 		for _, name := range names {
 			if string(name) == "mem" {
-				return fmt.Errorf("got measurment %q but it should be filtered.", name)
+				return fmt.Errorf("got measurement %q but it should be filtered.", name)
 			}
 			gotNames++
 		}
@@ -1054,7 +1054,7 @@ func TestStore_TagKeys_Auth(t *testing.T) {
 		var gotKeys int
 		for _, tk := range keys {
 			if got, exp := tk.Measurement, "cpu"; got != exp {
-				return fmt.Errorf("got measurment %q, expected %q", got, exp)
+				return fmt.Errorf("got measurement %q, expected %q", got, exp)
 			}
 
 			for _, key := range tk.Keys {
@@ -1121,7 +1121,7 @@ func TestStore_TagValues_Auth(t *testing.T) {
 		var gotValues int
 		for _, tv := range values {
 			if got, exp := tv.Measurement, "cpu"; got != exp {
-				return fmt.Errorf("got measurment %q, expected %q", got, exp)
+				return fmt.Errorf("got measurement %q, expected %q", got, exp)
 			}
 
 			for _, v := range tv.Values {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated

This PR does the following:

   - Fix bug in `tsi1` where database names were not propagating properly. This would have been a problem for FGA.
   - Implement FGA on the `SeriesPointIterator`. This will be needed by `SHOW SERIES`, and I suspect `ifql`.
   - Add test coverage for FGA when using `SHOW TAG KEYS` and `SHOW TAG VALUES`. It looks like FGA was working on them even after the recent `SHOW` command refactor.
  - Implement FGA on `SHOW MEASUREMENTS` now that `SHOW MEASUREMENTS` is using its own command, rather than a `SelectStatement`.
  - Fix a bug in `tsi1` where negation operations on tags would not return the correct values.
  - Add significant test coverage for FGA on `SHOW MEASUREMENTS`.