### PR TITLE
Reduce calls to time.Now()

### DIFF
--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -1168,8 +1168,8 @@ func NewSeries(key []byte, tags models.Tags) *Series {
 	}
 }
 
-func (s *Series) AssignShard(shardID uint64) {
-	atomic.StoreInt64(&s.lastModified, time.Now().UTC().UnixNano())
+func (s *Series) AssignShard(shardID uint64, ts int64) {
+	atomic.StoreInt64(&s.lastModified, ts)
 	if s.Assigned(shardID) {
 		return
 	}

--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/query"
@@ -214,7 +215,7 @@ func benchmarkTagSets(b *testing.B, n int, opt query.IteratorOptions) {
 		tags := map[string]string{"tag1": "value1", "tag2": "value2"}
 		s := inmem.NewSeries([]byte(fmt.Sprintf("m,tag1=value1,tag2=value2")), models.NewTags(tags))
 		s.ID = uint64(i)
-		s.AssignShard(0)
+		s.AssignShard(0, time.Now().UnixNano())
 		m.AddSeries(s)
 	}
 


### PR DESCRIPTION
These were showing up in profiles during heavy write load.

These started showing on up on `inmem` after #9084 landed.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
