### PR TITLE
Fix wait reused while disabling compactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [#9065](https://github.com/influxdata/influxdb/pull/9065): Refuse extra arguments to influx CLI
 - [#9058](https://github.com/influxdata/influxdb/issues/9058): Fix space required after regex operator. Thanks @stop-start!
+- [#9109](https://github.com/influxdata/influxdb/issues/9109): Fix: panic: sync: WaitGroup is reused before previous Wait has returned
 
 ## v1.4.2 [2017-11-15]
 


### PR DESCRIPTION
This fixes the re-use of the `WaitGroup` while one goroutine is still `Wait`ing when disabling compactions.  Unfortunately, I have not found a simpler way to implement this that still maintains the same behavior as the current code.  The tests do reproduce the panic reliably and these changes prevent the panic from occurring. 

Fixes #9109 

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)