### PR TITLE
SHOW TAG KEYS with high cardinality and many shards 

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -65,10 +65,10 @@ type Engine interface {
 	ForEachMeasurementName(fn func(name []byte) error) error
 	DeleteMeasurement(name []byte) error
 
-	// TagKeys(name []byte) ([][]byte, error)
 	HasTagKey(name, key []byte) (bool, error)
 	MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error)
 	MeasurementTagKeyValuesByExpr(auth query.Authorizer, name []byte, key []string, expr influxql.Expr, keysSorted bool) ([][]string, error)
+	TagKeyHasAuthorizedSeries(auth query.Authorizer, name []byte, key string) bool
 	ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error
 	TagKeyCardinality(name, key []byte) int
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -391,6 +391,12 @@ func (e *Engine) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[
 	return e.index.MeasurementTagKeysByExpr(name, expr)
 }
 
+// TagKeyHasAuthorizedSeries determines if there exist authorized series for the
+// provided measurement name and tag key.
+func (e *Engine) TagKeyHasAuthorizedSeries(auth query.Authorizer, name []byte, key string) bool {
+	return e.index.TagKeyHasAuthorizedSeries(auth, name, key)
+}
+
 // MeasurementTagKeyValuesByExpr returns a set of tag values filtered by an expression.
 //
 // MeasurementTagKeyValuesByExpr relies on the provided tag keys being sorted.

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -37,6 +37,7 @@ type Index interface {
 	TagSets(name []byte, options query.IteratorOptions) ([]*query.TagSet, error)
 	MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error)
 	MeasurementTagKeyValuesByExpr(auth query.Authorizer, name []byte, keys []string, expr influxql.Expr, keysSorted bool) ([][]string, error)
+	TagKeyHasAuthorizedSeries(auth query.Authorizer, name []byte, key string) bool
 
 	ForEachMeasurementTagKey(name []byte, fn func(key []byte) error) error
 	TagKeyCardinality(name, key []byte) int

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -1351,15 +1351,15 @@ func (t *TagKeyValue) LoadByte(value []byte) SeriesIDs {
 // TagKeyValue is a no-op.
 //
 // If f returns false then iteration over any remaining keys or values will cease.
-func (t *TagKeyValue) Range(f func(k string, a SeriesIDs) bool) {
+func (t *TagKeyValue) Range(f func(tagValue string, a SeriesIDs) bool) {
 	if t == nil {
 		return
 	}
 
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	for k, a := range t.valueIDs {
-		if !f(k, a) {
+	for tagValue, a := range t.valueIDs {
+		if !f(tagValue, a) {
 			return
 		}
 	}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -776,6 +776,16 @@ func (s *Shard) MeasurementSeriesKeysByExpr(name []byte, expr influxql.Expr) ([]
 	return engine.MeasurementSeriesKeysByExpr(name, expr)
 }
 
+// TagKeyHasAuthorizedSeries determines if there exists an authorised series on
+// the provided measurement with the provided tag key.
+func (s *Shard) TagKeyHasAuthorizedSeries(auth query.Authorizer, name []byte, key string) bool {
+	engine, err := s.engine()
+	if err != nil {
+		return false
+	}
+	return engine.TagKeyHasAuthorizedSeries(auth, name, key)
+}
+
 // MeasurementTagKeysByExpr returns all the tag keys for the provided expression.
 func (s *Shard) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[string]struct{}, error) {
 	engine, err := s.engine()


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

Fixes #9125.

This PR fixes a performance issue where `SHOW TAG KEYS` on a system using the `tsi1` index and many shards / high cardinality would become very expensive. This was due to the way with checked for filtered tag values. Filtered tag values would exist is you did a query like `SHOW TAG KEYS WHERE "region" = 'west'`. In the case where no `WHERE` clause is present we were actually retrieving all tag values, rather than retrieving none at all. The latter would obviously be preferable from a performance perspective.

This PR adds a fix for this by adding a new method on the engine that lets you determine if there exists an authorised series for a given measurement and tag key, without having to instantiate the expensive `TagValueSeriesIterator` iterator, and without having to materialise millions of tag values. We short-circuit where appropriate to speed up performance.

### Benchmark

For a database with 3M series across 500 shards using `tsi1`:

```
// v1.4.2
$ edd@work:~|⇒  time influx -database stress -execute 'show tag keys'               
name: m0
tagKey
------
tag0
tag1
tag2
tag3
tag4
tag5
tag6
influx -database stress -execute 'show tag keys'  0.01s user 0.00s system 0% cpu 15.548 total
```

**15.5** seconds.


```
// This PR
edd@work:~|⇒  time influx -database stress -execute 'show tag keys'
name: m0
tagKey
------
tag0
tag1
tag2
tag3
tag4
tag5
tag6
influx -database stress -execute 'show tag keys'  0.00s user 0.01s system 24% cpu 0.021 total
```

**0.021** seconds.

