### PR TITLE
Fix Prometheus regex parsing

### DIFF
--- a/prometheus/converters_test.go
+++ b/prometheus/converters_test.go
@@ -1,0 +1,97 @@
+package prometheus_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/influxdb/prometheus"
+	"github.com/influxdata/influxdb/prometheus/remote"
+	"github.com/influxdata/influxql"
+)
+
+func TestReadRequestToInfluxQLQuery(t *testing.T) {
+	examples := []struct {
+		name     string
+		queries  []*remote.Query
+		expQuery string
+		expError error
+	}{
+		{
+			name:     "too many queries",
+			queries:  []*remote.Query{{}, {}}, // Multiple queries
+			expError: errors.New("Prometheus read endpoint currently only supports one query at a time"),
+		},
+		{
+			name: "single condition",
+			queries: []*remote.Query{{
+				StartTimestampMs: 1,
+				EndTimestampMs:   100,
+				Matchers: []*remote.LabelMatcher{
+					{Name: "region", Value: "west", Type: remote.MatchType_EQUAL},
+				},
+			}},
+			expQuery: "SELECT f64 FROM db0.rp0._ WHERE region = 'west' AND time >= '1970-01-01T00:00:00.001Z' AND time <= '1970-01-01T00:00:00.1Z' GROUP BY *",
+		},
+		{
+			name: "multiple conditions",
+			queries: []*remote.Query{{
+				StartTimestampMs: 1,
+				EndTimestampMs:   100,
+				Matchers: []*remote.LabelMatcher{
+					{Name: "region", Value: "west", Type: remote.MatchType_EQUAL},
+					{Name: "host", Value: "serverA", Type: remote.MatchType_NOT_EQUAL},
+				},
+			}},
+			expQuery: "SELECT f64 FROM db0.rp0._ WHERE region = 'west' AND host != 'serverA' AND time >= '1970-01-01T00:00:00.001Z' AND time <= '1970-01-01T00:00:00.1Z' GROUP BY *",
+		},
+		{
+			name: "rewrite regex",
+			queries: []*remote.Query{{
+				StartTimestampMs: 1,
+				EndTimestampMs:   100,
+				Matchers: []*remote.LabelMatcher{
+					{Name: "region", Value: "c.*", Type: remote.MatchType_REGEX_MATCH},
+					{Name: "host", Value: `\d`, Type: remote.MatchType_REGEX_NO_MATCH},
+				},
+			}},
+			expQuery: `SELECT f64 FROM db0.rp0._ WHERE region =~ /c.*/ AND host !~ /\d/ AND time >= '1970-01-01T00:00:00.001Z' AND time <= '1970-01-01T00:00:00.1Z' GROUP BY *`,
+		},
+		{
+			name: "escape regex",
+			queries: []*remote.Query{{
+				StartTimestampMs: 1,
+				EndTimestampMs:   100,
+				Matchers: []*remote.LabelMatcher{
+					{Name: "test_type", Value: "a/b", Type: remote.MatchType_REGEX_MATCH},
+				},
+			}},
+			expQuery: `SELECT f64 FROM db0.rp0._ WHERE test_type =~ /a\/b/ AND time >= '1970-01-01T00:00:00.001Z' AND time <= '1970-01-01T00:00:00.1Z' GROUP BY *`,
+		},
+	}
+
+	for _, example := range examples {
+		t.Run(example.name, func(t *testing.T) {
+			readRequest := &remote.ReadRequest{Queries: example.queries}
+			query, err := prometheus.ReadRequestToInfluxQLQuery(readRequest, "db0", "rp0")
+			if !reflect.DeepEqual(err, example.expError) {
+				t.Errorf("got error %v, expected %v", err, example.expError)
+			}
+
+			var queryString string
+			if query != nil {
+				queryString = query.String()
+			}
+
+			if queryString != example.expQuery {
+				t.Errorf("got query %v, expected %v", queryString, example.expQuery)
+			}
+
+			if queryString != "" {
+				if _, err := influxql.ParseStatement(queryString); err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -615,7 +615,7 @@ func TestHandler_PromRead(t *testing.T) {
 
 	h := NewHandler(false)
 	h.StatementExecutor.ExecuteStatementFn = func(stmt influxql.Statement, ctx query.ExecutionContext) error {
-		if stmt.String() != `SELECT f64 FROM foo.._ WHERE eq = 'a' AND neq != 'b' AND regex =~ 'c' AND neqregex !~ 'd' AND time >= '1970-01-01T00:00:00.001Z' AND time <= '1970-01-01T00:00:00.002Z' GROUP BY *` {
+		if stmt.String() != `SELECT f64 FROM foo.._ WHERE eq = 'a' AND neq != 'b' AND regex =~ /c/ AND neqregex !~ /d/ AND time >= '1970-01-01T00:00:00.001Z' AND time <= '1970-01-01T00:00:00.002Z' GROUP BY *` {
 			t.Fatalf("unexpected query: %s", stmt.String())
 		} else if ctx.Database != `foo` {
 			t.Fatalf("unexpected db: %s", ctx.Database)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

Fixes #9134.

InfluxDB expects regex condition values to be `influxql.RegexLiteral`s, which have literals beginning and ending in forward slashes.

Also adds further test coverage to `ReadRequestToInfluxQLQuery`.

Only thing that might be worth checking is whether the regex values originating from Prometheus format have already escaped forward slashes or not. For example, will the following condition arrive as:

`region  =~ foo/bar` which we would then convert into `region =~ /foo\/bar/` 

or, would the condition arrive as `region =~ foo\/bar`, which we would then _incorrectly_ convert to `region =~ /foo\\/bar/`?

No `CHANGELOG` update as this will probably be back-ported.

