### PR TITLE
Make template parsing more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#8495](https://github.com/influxdata/influxdb/pull/8495): Improve CLI connection warnings
 - [#9084](https://github.com/influxdata/influxdb/pull/9084): Handle high cardinality deletes in TSM engine
 - [#9162](https://github.com/influxdata/influxdb/pull/9162): Improve inmem index startup performance for high cardinality.
+- [#9165]: Allow fancier parsing for Graphite-protocol templates.
 
 ### Bugfixes
 


### PR DESCRIPTION
A system we work with likes to send values with names like
	h1.Interface_xe0.in
	h1.Interface_xe0.out
	h1.Interface_bge0.in
	h1.Interface_bge0.out

We can parse these as "host.measurement.field", but then we have
measurements with names like "Interface_xe0" or "Interface_bge0".
In fact, in our current data set, that's over 1000 distinct
measurements.

This patch introduces a "subfield" functionality for templates.
In the new functionality, the template is:
	host.(_,measurement_interface).field
This results in all the measurements being named "Interface",
and having tags of
	{host: h1, interface: xe0}
	{host: h1, interface: bge0}
along with the expected set of fields.

The parsing is slightly complicated because of the existing
expectation that specifying a separator doesn't change how things
are split, only how they are rejoined when joining multiple
matching tags.

This patch also makes the '*' functionality generic, allowing
it to be used with arbitrary names, not just 'measurement' and
'field'. It also moves the check for more than one greedy name
into the initial template parse, since it's detectable at that
point, and the corresponding test is moved. The test for
multiple specifications of 'field' is dropped, because that
actually works perfectly well, and is just like a more selective
form of 'field*'.

Signed-off-by: seebs <seebs@markleygroup.com>

###### Required for all non-trivial PRs
- [*] Rebased/mergable
- [*] Tests pass
- [*] CHANGELOG.md updated
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

(The CLA will probably take a bit to percolate to people who have authority, but I don't anticipate them objecting.)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [*] Provide example syntax
- [*] Update man page when modifying a command
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>

(Does "updated README.md" count, or do I need a separate issue for that?)