### PR TITLE
Fix race condition in the merge iterator close method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bugfixes
 
 - [#9036](https://github.com/influxdata/influxdb/issues/9036): Add 'influx_inspect inmem2tsi' command.
-
+- [#9163](https://github.com/influxdata/influxdb/pull/9163): Fix race condition in the merge iterator close method.
 
 ## v1.3.7 [2017-10-26]
 

--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -1,4 +1,4 @@
-FROM ioft/i386-ubuntu:14.04
+FROM ioft/i386-ubuntu:xenial
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
@@ -9,6 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     make \
     ruby \
     ruby-dev \
+    build-essential \
     rpm \
     zip \
     python \

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
@@ -9,6 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     make \
     ruby \
     ruby-dev \
+    build-essential \
     rpm \
     zip \
     python \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python-software-properties \
@@ -9,6 +9,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     make \
     ruby \
     ruby-dev \
+    build-essential \
     rpm \
     zip \
     python \

--- a/influxql/iterator.gen.go
+++ b/influxql/iterator.gen.go
@@ -117,6 +117,9 @@ type floatMergeIterator struct {
 	heap   *floatMergeHeap
 	init   bool
 
+	closed bool
+	mu     sync.RWMutex
+
 	// Current iterator and window.
 	curr   *floatMergeHeapItem
 	window struct {
@@ -160,17 +163,27 @@ func (itr *floatMergeIterator) Stats() IteratorStats {
 
 // Close closes the underlying iterators.
 func (itr *floatMergeIterator) Close() error {
+	itr.mu.Lock()
+	defer itr.mu.Unlock()
+
 	for _, input := range itr.inputs {
 		input.Close()
 	}
 	itr.curr = nil
 	itr.inputs = nil
 	itr.heap.items = nil
+	itr.closed = true
 	return nil
 }
 
 // Next returns the next point from the iterator.
 func (itr *floatMergeIterator) Next() (*FloatPoint, error) {
+	itr.mu.RLock()
+	defer itr.mu.RUnlock()
+	if itr.closed {
+		return nil, nil
+	}
+
 	// Initialize the heap. This needs to be done lazily on the first call to this iterator
 	// so that iterator initialization done through the Select() call returns quickly.
 	// Queries can only be interrupted after the Select() call completes so any operations
@@ -3045,6 +3058,9 @@ type integerMergeIterator struct {
 	heap   *integerMergeHeap
 	init   bool
 
+	closed bool
+	mu     sync.RWMutex
+
 	// Current iterator and window.
 	curr   *integerMergeHeapItem
 	window struct {
@@ -3088,17 +3104,27 @@ func (itr *integerMergeIterator) Stats() IteratorStats {
 
 // Close closes the underlying iterators.
 func (itr *integerMergeIterator) Close() error {
+	itr.mu.Lock()
+	defer itr.mu.Unlock()
+
 	for _, input := range itr.inputs {
 		input.Close()
 	}
 	itr.curr = nil
 	itr.inputs = nil
 	itr.heap.items = nil
+	itr.closed = true
 	return nil
 }
 
 // Next returns the next point from the iterator.
 func (itr *integerMergeIterator) Next() (*IntegerPoint, error) {
+	itr.mu.RLock()
+	defer itr.mu.RUnlock()
+	if itr.closed {
+		return nil, nil
+	}
+
 	// Initialize the heap. This needs to be done lazily on the first call to this iterator
 	// so that iterator initialization done through the Select() call returns quickly.
 	// Queries can only be interrupted after the Select() call completes so any operations
@@ -5970,6 +5996,9 @@ type stringMergeIterator struct {
 	heap   *stringMergeHeap
 	init   bool
 
+	closed bool
+	mu     sync.RWMutex
+
 	// Current iterator and window.
 	curr   *stringMergeHeapItem
 	window struct {
@@ -6013,17 +6042,27 @@ func (itr *stringMergeIterator) Stats() IteratorStats {
 
 // Close closes the underlying iterators.
 func (itr *stringMergeIterator) Close() error {
+	itr.mu.Lock()
+	defer itr.mu.Unlock()
+
 	for _, input := range itr.inputs {
 		input.Close()
 	}
 	itr.curr = nil
 	itr.inputs = nil
 	itr.heap.items = nil
+	itr.closed = true
 	return nil
 }
 
 // Next returns the next point from the iterator.
 func (itr *stringMergeIterator) Next() (*StringPoint, error) {
+	itr.mu.RLock()
+	defer itr.mu.RUnlock()
+	if itr.closed {
+		return nil, nil
+	}
+
 	// Initialize the heap. This needs to be done lazily on the first call to this iterator
 	// so that iterator initialization done through the Select() call returns quickly.
 	// Queries can only be interrupted after the Select() call completes so any operations
@@ -8881,6 +8920,9 @@ type booleanMergeIterator struct {
 	heap   *booleanMergeHeap
 	init   bool
 
+	closed bool
+	mu     sync.RWMutex
+
 	// Current iterator and window.
 	curr   *booleanMergeHeapItem
 	window struct {
@@ -8924,17 +8966,27 @@ func (itr *booleanMergeIterator) Stats() IteratorStats {
 
 // Close closes the underlying iterators.
 func (itr *booleanMergeIterator) Close() error {
+	itr.mu.Lock()
+	defer itr.mu.Unlock()
+
 	for _, input := range itr.inputs {
 		input.Close()
 	}
 	itr.curr = nil
 	itr.inputs = nil
 	itr.heap.items = nil
+	itr.closed = true
 	return nil
 }
 
 // Next returns the next point from the iterator.
 func (itr *booleanMergeIterator) Next() (*BooleanPoint, error) {
+	itr.mu.RLock()
+	defer itr.mu.RUnlock()
+	if itr.closed {
+		return nil, nil
+	}
+
 	// Initialize the heap. This needs to be done lazily on the first call to this iterator
 	// so that iterator initialization done through the Select() call returns quickly.
 	// Queries can only be interrupted after the Select() call completes so any operations

--- a/influxql/iterator.gen.go.tmpl
+++ b/influxql/iterator.gen.go.tmpl
@@ -114,6 +114,9 @@ type {{$k.name}}MergeIterator struct {
 	heap   *{{$k.name}}MergeHeap
 	init   bool
 
+	closed bool
+	mu     sync.RWMutex
+
 	// Current iterator and window.
 	curr   *{{$k.name}}MergeHeapItem
 	window struct {
@@ -157,17 +160,27 @@ func (itr *{{$k.name}}MergeIterator) Stats() IteratorStats {
 
 // Close closes the underlying iterators.
 func (itr *{{$k.name}}MergeIterator) Close() error {
+	itr.mu.Lock()
+	defer itr.mu.Unlock()
+
 	for _, input := range itr.inputs {
 		input.Close()
 	}
 	itr.curr = nil
 	itr.inputs = nil
 	itr.heap.items = nil
+	itr.closed = true
 	return nil
 }
 
 // Next returns the next point from the iterator.
 func (itr *{{$k.name}}MergeIterator) Next() (*{{$k.Name}}Point, error) {
+	itr.mu.RLock()
+	defer itr.mu.RUnlock()
+	if itr.closed {
+		return nil, nil
+	}
+
 	// Initialize the heap. This needs to be done lazily on the first call to this iterator
 	// so that iterator initialization done through the Select() call returns quickly.
 	// Queries can only be interrupted after the Select() call completes so any operations

--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -129,9 +129,10 @@ func newFloatFinalizerIterator(inner influxql.FloatIterator, logger zap.Logger) 
 }
 
 func (itr *floatFinalizerIterator) closeGC() {
-	runtime.SetFinalizer(itr, nil)
-	itr.logger.Error("FloatIterator finalized by GC")
-	itr.Close()
+	go func() {
+		itr.logger.Error("FloatIterator finalized by GC")
+		itr.Close()
+	}()
 }
 
 func (itr *floatFinalizerIterator) Close() error {
@@ -588,9 +589,10 @@ func newIntegerFinalizerIterator(inner influxql.IntegerIterator, logger zap.Logg
 }
 
 func (itr *integerFinalizerIterator) closeGC() {
-	runtime.SetFinalizer(itr, nil)
-	itr.logger.Error("IntegerIterator finalized by GC")
-	itr.Close()
+	go func() {
+		itr.logger.Error("IntegerIterator finalized by GC")
+		itr.Close()
+	}()
 }
 
 func (itr *integerFinalizerIterator) Close() error {
@@ -1047,9 +1049,10 @@ func newStringFinalizerIterator(inner influxql.StringIterator, logger zap.Logger
 }
 
 func (itr *stringFinalizerIterator) closeGC() {
-	runtime.SetFinalizer(itr, nil)
-	itr.logger.Error("StringIterator finalized by GC")
-	itr.Close()
+	go func() {
+		itr.logger.Error("StringIterator finalized by GC")
+		itr.Close()
+	}()
 }
 
 func (itr *stringFinalizerIterator) Close() error {
@@ -1506,9 +1509,10 @@ func newBooleanFinalizerIterator(inner influxql.BooleanIterator, logger zap.Logg
 }
 
 func (itr *booleanFinalizerIterator) closeGC() {
-	runtime.SetFinalizer(itr, nil)
-	itr.logger.Error("BooleanIterator finalized by GC")
-	itr.Close()
+	go func() {
+		itr.logger.Error("BooleanIterator finalized by GC")
+		itr.Close()
+	}()
 }
 
 func (itr *booleanFinalizerIterator) Close() error {

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -125,9 +125,10 @@ func new{{.Name}}FinalizerIterator(inner influxql.{{.Name}}Iterator, logger zap.
 }
 
 func (itr *{{.name}}FinalizerIterator) closeGC() {
-	runtime.SetFinalizer(itr, nil)
-	itr.logger.Error("{{.Name}}Iterator finalized by GC")
-	itr.Close()
+	go func() {
+		itr.logger.Error("{{.Name}}Iterator finalized by GC")
+		itr.Close()
+	}()
 }
 
 func (itr *{{.name}}FinalizerIterator) Close() error {

--- a/tsdb/engine/tsm1/iterator_test.go
+++ b/tsdb/engine/tsm1/iterator_test.go
@@ -1,0 +1,113 @@
+package tsm1
+
+import (
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/influxql"
+	"github.com/uber-go/zap"
+)
+
+type testFinalizerIterator struct {
+	OnClose func()
+}
+
+func (itr *testFinalizerIterator) Next() (*influxql.FloatPoint, error) {
+	return nil, nil
+}
+
+func (itr *testFinalizerIterator) Close() error {
+	// Act as if this is a slow finalizer and ensure that it doesn't block
+	// the finalizer background thread.
+	itr.OnClose()
+	return nil
+}
+
+func (itr *testFinalizerIterator) Stats() influxql.IteratorStats {
+	return influxql.IteratorStats{}
+}
+
+func TestFinalizerIterator(t *testing.T) {
+	var (
+		step1 = make(chan struct{})
+		step2 = make(chan struct{})
+		step3 = make(chan struct{})
+	)
+
+	l := zap.New(zap.NewTextEncoder(), zap.Output(os.Stderr))
+	done := make(chan struct{})
+	func() {
+		itr := &testFinalizerIterator{
+			OnClose: func() {
+				// Simulate a slow closing iterator by waiting for the done channel
+				// to be closed. The done channel is closed by a later finalizer.
+				close(step1)
+				<-done
+				close(step3)
+			},
+		}
+		newFinalizerIterator(itr, l)
+	}()
+
+	for i := 0; i < 100; i++ {
+		runtime.GC()
+	}
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	select {
+	case <-timer.C:
+		t.Fatal("The finalizer for the iterator did not run")
+		close(done)
+	case <-step1:
+		// The finalizer has successfully run, but should not have completed yet.
+		timer.Stop()
+	}
+
+	select {
+	case <-step3:
+		t.Fatal("The finalizer should not have finished yet")
+	default:
+	}
+
+	// Use a fake value that will be collected by the garbage collector and have
+	// the finalizer close the channel. This finalizer should run after the iterator's
+	// finalizer.
+	value := func() int {
+		foo := &struct {
+			value int
+		}{value: 1}
+		runtime.SetFinalizer(foo, func(value interface{}) {
+			close(done)
+			close(step2)
+		})
+		return foo.value + 2
+	}()
+	if value < 2 {
+		t.Log("This should never be output")
+	}
+
+	for i := 0; i < 100; i++ {
+		runtime.GC()
+	}
+
+	timer.Reset(100 * time.Millisecond)
+	select {
+	case <-timer.C:
+		t.Fatal("The second finalizer did not run")
+	case <-step2:
+		// The finalizer has successfully run and should have
+		// closed the done channel.
+		timer.Stop()
+	}
+
+	// Wait for step3 to finish where the closed value should be set.
+	timer.Reset(100 * time.Millisecond)
+	select {
+	case <-timer.C:
+		t.Fatal("The iterator was not finalized")
+	case <-step3:
+		timer.Stop()
+	}
+}


### PR DESCRIPTION
If the close happens when next is being called, it can result in a race
condition where the current iterator gets set to nil after the initial
check.

This also fixes the finalizer so it runs the close method in a goroutine
instead of running it by itself. This is because all finalizers run on
the same goroutine so a close that takes a long time can cause a backup
for all finalizers. This also removes the redundant call to
`runtime.SetFinalizer` from the finalizer itself because a finalizer,
when called, has already cleared itself.

Backport of #9163.

- [x] Rebased/mergable
- [ ] Tests pass
- [x] CHANGELOG.md updated