### PR TITLE
Fix Cache.DeleteRange not deleting all data

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -136,6 +136,9 @@ func (e *entry) count() int {
 // filter removes all values with timestamps between min and max inclusive.
 func (e *entry) filter(min, max int64) {
 	e.mu.Lock()
+	if len(e.values) > 1 {
+		e.values = e.values.Deduplicate()
+	}
 	e.values = e.values.Exclude(min, max)
 	e.mu.Unlock()
 }

--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -241,6 +241,41 @@ func TestCache_DeleteRange_NoValues(t *testing.T) {
 	}
 }
 
+func TestCache_DeleteRange_NotSorted(t *testing.T) {
+	v0 := NewValue(1, 1.0)
+	v1 := NewValue(3, 3.0)
+	v2 := NewValue(2, 2.0)
+	values := Values{v0, v1, v2}
+	valuesSize := uint64(v0.Size() + v1.Size() + v2.Size())
+
+	c := NewCache(3*valuesSize, "")
+
+	if err := c.WriteMulti(map[string][]Value{"foo": values}); err != nil {
+		t.Fatalf("failed to write key foo to cache: %s", err.Error())
+	}
+	if n := c.Size(); n != valuesSize+3 {
+		t.Fatalf("cache size incorrect after 2 writes, exp %d, got %d", 2*valuesSize, n)
+	}
+
+	if exp, keys := [][]byte{[]byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
+		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
+	}
+
+	c.DeleteRange([][]byte{[]byte("foo")}, 1, 3)
+
+	if exp, keys := 0, len(c.Keys()); !reflect.DeepEqual(keys, exp) {
+		t.Fatalf("cache keys incorrect after delete, exp %v, got %v", exp, keys)
+	}
+
+	if got, exp := c.Size(), uint64(0); exp != got {
+		t.Fatalf("cache size incorrect after delete, exp %d, got %d", exp, got)
+	}
+
+	if got, exp := len(c.Values([]byte("foo"))), 0; got != exp {
+		t.Fatalf("cache values mismatch: got %v, exp %v", got, exp)
+	}
+}
+
 func TestCache_Cache_Delete(t *testing.T) {
 	v0 := NewValue(1, 1.0)
 	v1 := NewValue(2, 2.0)

--- a/tsdb/engine/tsm1/encoding.gen.go
+++ b/tsdb/engine/tsm1/encoding.gen.go
@@ -54,7 +54,8 @@ func (a Values) assertOrdered() {
 }
 
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
-// The Value that appears last in the slice is the one that is kept.
+// The Value that appears last in the slice is the one that is kept.  The returned
+// Values are sorted if necessary.
 func (a Values) Deduplicate() Values {
 	if len(a) <= 1 {
 		return a
@@ -86,7 +87,8 @@ func (a Values) Deduplicate() Values {
 	return a[:i+1]
 }
 
-//  Exclude returns the subset of values not in [min, max]
+// Exclude returns the subset of values not in [min, max].  The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a Values) Exclude(min, max int64) Values {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -111,7 +113,8 @@ func (a Values) Exclude(min, max int64) Values {
 	return a[:rmin]
 }
 
-// Include returns the subset values between min and max inclusive.
+// Include returns the subset values between min and max inclusive. The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a Values) Include(min, max int64) Values {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -160,7 +163,9 @@ func (a Values) search(v int64) int {
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max].
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
 func (a Values) FindRange(min, max int64) (int, int) {
 	if len(a) == 0 || min > max {
 		return -1, -1
@@ -266,7 +271,8 @@ func (a FloatValues) assertOrdered() {
 }
 
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
-// The Value that appears last in the slice is the one that is kept.
+// The Value that appears last in the slice is the one that is kept.  The returned
+// Values are sorted if necessary.
 func (a FloatValues) Deduplicate() FloatValues {
 	if len(a) <= 1 {
 		return a
@@ -298,7 +304,8 @@ func (a FloatValues) Deduplicate() FloatValues {
 	return a[:i+1]
 }
 
-//  Exclude returns the subset of values not in [min, max]
+// Exclude returns the subset of values not in [min, max].  The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a FloatValues) Exclude(min, max int64) FloatValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -323,7 +330,8 @@ func (a FloatValues) Exclude(min, max int64) FloatValues {
 	return a[:rmin]
 }
 
-// Include returns the subset values between min and max inclusive.
+// Include returns the subset values between min and max inclusive. The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a FloatValues) Include(min, max int64) FloatValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -372,7 +380,9 @@ func (a FloatValues) search(v int64) int {
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max].
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
 func (a FloatValues) FindRange(min, max int64) (int, int) {
 	if len(a) == 0 || min > max {
 		return -1, -1
@@ -522,7 +532,8 @@ func (a IntegerValues) assertOrdered() {
 }
 
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
-// The Value that appears last in the slice is the one that is kept.
+// The Value that appears last in the slice is the one that is kept.  The returned
+// Values are sorted if necessary.
 func (a IntegerValues) Deduplicate() IntegerValues {
 	if len(a) <= 1 {
 		return a
@@ -554,7 +565,8 @@ func (a IntegerValues) Deduplicate() IntegerValues {
 	return a[:i+1]
 }
 
-//  Exclude returns the subset of values not in [min, max]
+// Exclude returns the subset of values not in [min, max].  The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a IntegerValues) Exclude(min, max int64) IntegerValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -579,7 +591,8 @@ func (a IntegerValues) Exclude(min, max int64) IntegerValues {
 	return a[:rmin]
 }
 
-// Include returns the subset values between min and max inclusive.
+// Include returns the subset values between min and max inclusive. The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a IntegerValues) Include(min, max int64) IntegerValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -628,7 +641,9 @@ func (a IntegerValues) search(v int64) int {
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max].
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
 func (a IntegerValues) FindRange(min, max int64) (int, int) {
 	if len(a) == 0 || min > max {
 		return -1, -1
@@ -778,7 +793,8 @@ func (a UnsignedValues) assertOrdered() {
 }
 
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
-// The Value that appears last in the slice is the one that is kept.
+// The Value that appears last in the slice is the one that is kept.  The returned
+// Values are sorted if necessary.
 func (a UnsignedValues) Deduplicate() UnsignedValues {
 	if len(a) <= 1 {
 		return a
@@ -810,7 +826,8 @@ func (a UnsignedValues) Deduplicate() UnsignedValues {
 	return a[:i+1]
 }
 
-//  Exclude returns the subset of values not in [min, max]
+// Exclude returns the subset of values not in [min, max].  The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a UnsignedValues) Exclude(min, max int64) UnsignedValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -835,7 +852,8 @@ func (a UnsignedValues) Exclude(min, max int64) UnsignedValues {
 	return a[:rmin]
 }
 
-// Include returns the subset values between min and max inclusive.
+// Include returns the subset values between min and max inclusive. The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a UnsignedValues) Include(min, max int64) UnsignedValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -884,7 +902,9 @@ func (a UnsignedValues) search(v int64) int {
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max].
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
 func (a UnsignedValues) FindRange(min, max int64) (int, int) {
 	if len(a) == 0 || min > max {
 		return -1, -1
@@ -1034,7 +1054,8 @@ func (a StringValues) assertOrdered() {
 }
 
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
-// The Value that appears last in the slice is the one that is kept.
+// The Value that appears last in the slice is the one that is kept.  The returned
+// Values are sorted if necessary.
 func (a StringValues) Deduplicate() StringValues {
 	if len(a) <= 1 {
 		return a
@@ -1066,7 +1087,8 @@ func (a StringValues) Deduplicate() StringValues {
 	return a[:i+1]
 }
 
-//  Exclude returns the subset of values not in [min, max]
+// Exclude returns the subset of values not in [min, max].  The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a StringValues) Exclude(min, max int64) StringValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -1091,7 +1113,8 @@ func (a StringValues) Exclude(min, max int64) StringValues {
 	return a[:rmin]
 }
 
-// Include returns the subset values between min and max inclusive.
+// Include returns the subset values between min and max inclusive. The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a StringValues) Include(min, max int64) StringValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -1140,7 +1163,9 @@ func (a StringValues) search(v int64) int {
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max].
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
 func (a StringValues) FindRange(min, max int64) (int, int) {
 	if len(a) == 0 || min > max {
 		return -1, -1
@@ -1290,7 +1315,8 @@ func (a BooleanValues) assertOrdered() {
 }
 
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
-// The Value that appears last in the slice is the one that is kept.
+// The Value that appears last in the slice is the one that is kept.  The returned
+// Values are sorted if necessary.
 func (a BooleanValues) Deduplicate() BooleanValues {
 	if len(a) <= 1 {
 		return a
@@ -1322,7 +1348,8 @@ func (a BooleanValues) Deduplicate() BooleanValues {
 	return a[:i+1]
 }
 
-//  Exclude returns the subset of values not in [min, max]
+// Exclude returns the subset of values not in [min, max].  The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a BooleanValues) Exclude(min, max int64) BooleanValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -1347,7 +1374,8 @@ func (a BooleanValues) Exclude(min, max int64) BooleanValues {
 	return a[:rmin]
 }
 
-// Include returns the subset values between min and max inclusive.
+// Include returns the subset values between min and max inclusive. The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a BooleanValues) Include(min, max int64) BooleanValues {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -1396,7 +1424,9 @@ func (a BooleanValues) search(v int64) int {
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max].
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
 func (a BooleanValues) FindRange(min, max int64) (int, int) {
 	if len(a) == 0 || min > max {
 		return -1, -1

--- a/tsdb/engine/tsm1/encoding.gen.go.tmpl
+++ b/tsdb/engine/tsm1/encoding.gen.go.tmpl
@@ -51,7 +51,8 @@ func (a {{.Name}}Values) assertOrdered() {
 
 
 // Deduplicate returns a new slice with any values that have the same timestamp removed.
-// The Value that appears last in the slice is the one that is kept.
+// The Value that appears last in the slice is the one that is kept.  The returned
+// Values are sorted if necessary.
 func (a {{.Name}}Values) Deduplicate() {{.Name}}Values {
 	if len(a) <= 1 {
 		return a
@@ -83,7 +84,8 @@ func (a {{.Name}}Values) Deduplicate() {{.Name}}Values {
 	return a[:i+1]
 }
 
-//  Exclude returns the subset of values not in [min, max]
+// Exclude returns the subset of values not in [min, max].  The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a {{.Name}}Values) Exclude(min, max int64) {{.Name}}Values {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -108,7 +110,8 @@ func (a {{.Name}}Values) Exclude(min, max int64) {{.Name}}Values {
 	return a[:rmin]
 }
 
-// Include returns the subset values between min and max inclusive.
+// Include returns the subset values between min and max inclusive. The values must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a {{.Name}}Values) Include(min, max int64) {{.Name}}Values {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {
@@ -157,7 +160,9 @@ func (a {{.Name}}Values) search(v int64) int {
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max].
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
 func (a {{.Name}}Values) FindRange(min, max int64) (int, int) {
 	if len(a) == 0 || min > max {
 		return -1, -1

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -332,8 +333,8 @@ func TestShardWriteAddNewField(t *testing.T) {
 // Tests concurrently writing to the same shard with different field types which
 // can trigger a panic when the shard is snapshotted to TSM files.
 func TestShard_WritePoints_FieldConflictConcurrent(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
+	if testing.Short() || runtime.GOOS == "windows" {
+		t.Skip("Skipping on short and windows")
 	}
 	tmpDir, _ := ioutil.TempDir("", "shard_test")
 	defer os.RemoveAll(tmpDir)


### PR DESCRIPTION
This fixes a regression in the `Cache` introduced in ca40c1ad3c where
not all the values in the cache entry would be removed.  Previously,
calling `Exclude` did not require the values to be sorted.  The change
in ca40c1ad3c relies on the values being sorted so it was possible for
the wrong indexes to be returned when calling `FindRange` and leave some
data that should be deleted.

Fixes #9161

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
