### PR TITLE
Fix query compilation so multiple nested distinct calls is allowable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#9129](https://github.com/influxdata/influxdb/pull/9129): Fix delete causing too much data to disappear
 - [#9137](https://github.com/influxdata/influxdb/pull/9137): Implement FGA features on remaining meta commands.
 - [#9163](https://github.com/influxdata/influxdb/pull/9163): Fix race condition in the merge iterator close method.
+- [#9144](https://github.com/influxdata/influxdb/issues/9144): Fix query compilation so multiple nested distinct calls is allowable
 
 ## v1.4.2 [2017-11-15]
 

--- a/query/compile_test.go
+++ b/query/compile_test.go
@@ -80,6 +80,7 @@ func TestCompile_Success(t *testing.T) {
 		`SELECT max(value) FROM (SELECT value + total FROM cpu) WHERE time >= now() - 1m GROUP BY time(10s)`,
 		`SELECT value FROM cpu WHERE time >= '2000-01-01T00:00:00Z' AND time <= '2000-01-01T01:00:00Z'`,
 		`SELECT value FROM (SELECT value FROM cpu) ORDER BY time DESC`,
+		`SELECT count(distinct(value)), max(value) FROM cpu`,
 	} {
 		t.Run(tt, func(t *testing.T) {
 			stmt, err := influxql.ParseStatement(tt)
@@ -121,7 +122,6 @@ func TestCompile_Failures(t *testing.T) {
 		{s: `SELECT mean() FROM cpu`, err: `invalid number of arguments for mean, expected 1, got 0`},
 		{s: `SELECT mean(value, host) FROM cpu`, err: `invalid number of arguments for mean, expected 1, got 2`},
 		{s: `SELECT distinct(value), max(value) FROM cpu`, err: `aggregate function distinct() cannot be combined with other functions or fields`},
-		{s: `SELECT count(distinct(value)), max(value) FROM cpu`, err: `aggregate function distinct() cannot be combined with other functions or fields`},
 		{s: `SELECT count(distinct()) FROM cpu`, err: `distinct function requires at least one argument`},
 		{s: `SELECT count(distinct(value, host)) FROM cpu`, err: `distinct function can only have one argument`},
 		{s: `SELECT count(distinct(2)) FROM cpu`, err: `expected field argument in distinct()`},


### PR DESCRIPTION
When refactoring the query engine, I thought calling
`count(distinct(value))` multiple times was disallowed and so the
refactor made it so that wasn't possible.

It turns out that this pattern is allowed because since the distinct is
nested, it is aggregated anyway and can be combined with other
aggregates.

This removes the erroneously placed restriction.

Backport of #9145.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated