### PR TITLE
Fix removing series from index

### DIFF
--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/bytesutil"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
@@ -130,6 +131,11 @@ func (m *Measurement) SeriesKeysByID(ids SeriesIDs) [][]byte {
 		}
 		keys = append(keys, []byte(s.Key))
 	}
+
+	if !bytesutil.IsSorted(keys) {
+		bytesutil.Sort(keys)
+	}
+
 	return keys
 }
 
@@ -144,6 +150,11 @@ func (m *Measurement) SeriesKeys() [][]byte {
 		}
 		keys = append(keys, []byte(s.Key))
 	}
+
+	if !bytesutil.IsSorted(keys) {
+		bytesutil.Sort(keys)
+	}
+
 	return keys
 }
 


### PR DESCRIPTION
The loop to check if a series still exists in a TSM file was wrong
in that it 1) exited early after one iteration and 2) had an off
by one error that causes the wrong series to be marked as existing.

This fixes both of these cases which can cause the index to become
inconsistent with the data stored on disk.

This is a follow up fix related to #9173 and only applies to changes in master/1.5.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>