### PR TITLE
Fix incorrect link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Bugfixes
 
-- [#9065](https://github.com/influxdata/influxdb/pull/9065): Refuse extra arguments to influx CLI
+- [#9095](https://github.com/influxdata/influxdb/pull/9095): Refuse extra arguments to influx CLI
 - [#9058](https://github.com/influxdata/influxdb/issues/9058): Fix space required after regex operator. Thanks @stop-start!
 - [#9109](https://github.com/influxdata/influxdb/issues/9109): Fix: panic: sync: WaitGroup is reused before previous Wait has returned
 - [#9163](https://github.com/influxdata/influxdb/pull/9163): Fix race condition in the merge iterator close method.


### PR DESCRIPTION
Thanks to @Luit for pointing out in #9095 that the changelog entry had the wrong link.