### PR TITLE
Allow setting the node id in the influx cli program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [#9181](https://github.com/influxdata/influxdb/pull/9181): Schedule a full compaction after a successful import
 - [#9218](https://github.com/influxdata/influxdb/pull/9218): Add Prometheus `/metrics` endpoint.
 - [#9213](https://github.com/influxdata/influxdb/pull/9213): Add ability to generate shard digests.
+- [#9184](https://github.com/influxdata/influxdb/pull/9184): Allow setting the node id in the influx cli program.
 
 ### Bugfixes
 

--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -48,6 +48,15 @@ type Query struct {
 	//
 	// Chunked must be set to true for this option to be used.
 	ChunkSize int
+
+	// NodeID sets the data node to use for the query results. This option only
+	// has any effect in the enterprise version of the software where there can be
+	// more than one data node and is primarily useful for analyzing differences in
+	// data. The default behavior is to automatically select the appropriate data
+	// nodes to retrieve all of the data. On a database where the number of data nodes
+	// is greater than the replication factor, it is expected that setting this option
+	// will only retrieve partial data.
+	NodeID int
 }
 
 // ParseConnectionString will parse a string to create a valid connection URL
@@ -197,6 +206,9 @@ func (c *Client) QueryContext(ctx context.Context, q Query) (*Response, error) {
 		if q.ChunkSize > 0 {
 			values.Set("chunk_size", strconv.Itoa(q.ChunkSize))
 		}
+	}
+	if q.NodeID > 0 {
+		values.Set("node_id", strconv.Itoa(q.NodeID))
 	}
 	if c.precision != "" {
 		values.Set("epoch", c.precision)

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -50,6 +50,7 @@ type CommandLine struct {
 	Import          bool
 	Chunked         bool
 	ChunkSize       int
+	NodeID          int
 	Quit            chan struct{}
 	IgnoreSignals   bool // Ignore signals normally caught by this process (used primarily for testing)
 	ForceTTY        bool // Force the CLI to act as if it were connected to a TTY
@@ -284,6 +285,8 @@ func (c *CommandLine) ParseCommand(cmd string) error {
 			}
 		case "use":
 			c.use(cmd)
+		case "node":
+			c.node(cmd)
 		case "insert":
 			return c.Insert(cmd)
 		case "clear":
@@ -513,6 +516,26 @@ func (c *CommandLine) retentionPolicyExists(db, rp string) bool {
 	return true
 }
 
+func (c *CommandLine) node(cmd string) {
+	args := strings.Split(strings.TrimSuffix(strings.TrimSpace(cmd), ";"), " ")
+	if len(args) != 2 {
+		fmt.Println("Improper number of arguments for 'node' command, requires exactly one.")
+		return
+	}
+
+	if args[1] == "clear" {
+		c.NodeID = 0
+		return
+	}
+
+	id, err := strconv.Atoi(args[1])
+	if err != nil {
+		fmt.Printf("Unable to parse node id from %s. Must be an integer or 'clear'.\n", args[1])
+		return
+	}
+	c.NodeID = id
+}
+
 // SetChunkSize sets the chunk size
 // 0 sets it back to the default
 func (c *CommandLine) SetChunkSize(cmd string) {
@@ -711,6 +734,7 @@ func (c *CommandLine) query(query string) client.Query {
 		Database:  c.Database,
 		Chunked:   c.Chunked,
 		ChunkSize: c.ChunkSize,
+		NodeID:    c.NodeID,
 	}
 }
 

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -51,6 +51,7 @@ func main() {
 	fs.StringVar(&c.ClientConfig.Precision, "precision", defaultPrecision, "Precision specifies the format of the timestamp:  rfc3339,h,m,s,ms,u or ns.")
 	fs.StringVar(&c.ClientConfig.WriteConsistency, "consistency", "all", "Set write consistency level: any, one, quorum, or all.")
 	fs.BoolVar(&c.Pretty, "pretty", false, "Turns on pretty print for the json format.")
+	fs.IntVar(&c.NodeID, "node", 0, "Specify the node that data should be retrieved from (enterprise only).")
 	fs.StringVar(&c.Execute, "execute", c.Execute, "Execute command and quit.")
 	fs.BoolVar(&c.ShowVersion, "version", false, "Displays the InfluxDB version.")
 	fs.BoolVar(&c.Import, "import", false, "Import a previous database.")

--- a/man/influx.txt
+++ b/man/influx.txt
@@ -63,6 +63,9 @@ OPTIONS
 -pretty::
   Turns on pretty print format for the JSON format.
 
+-node <n>::
+  Specifies the data node that should be queried for data. This option is only valid on enterprise clusters.
+
 -import::
   Import a previous database export from a file. If specified, '-path <path>' must also be specified.
 


### PR DESCRIPTION
The string `node <n>` can be used to specify which data node the data
should be retrieved from. This uses the `node_id=X` query parameter that
is supported, but wasn't exposed anywhere in the client library.

We use this feature enough internally when attempting to find
inconsistencies or network errors that it is easier if this is just
supported. Otherwise, I continue having to recompile the CLI program
every time I need to do this.

To clear a previously set node, you can use `node 0` or `node clear`.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [x] Update man page when modifying a command