### PR TITLE
Go 1.10 omits Content-Type header if server response has no body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [#9163](https://github.com/influxdata/influxdb/pull/9163): Fix race condition in the merge iterator close method.
 - [#9144](https://github.com/influxdata/influxdb/issues/9144): Fix query compilation so multiple nested distinct calls is allowable
 - [#8789](https://github.com/influxdata/influxdb/issues/8789): Fix CLI to allow quoted database names in use statement
+- [#9208](https://github.com/influxdata/influxdb/pull/9208): Updated client 4xx error message when response body length is zero. 
 
 ## v1.4.3 [unreleased]
 

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -534,7 +534,7 @@ func (c *client) Query(q Query) (*Response, error) {
 		// like downstream serving a large file
 		body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1024))
 		if err != nil || len(body) == 0 {
-			return nil, fmt.Errorf("expected json response, got %q, with status: %v", cType, resp.StatusCode)
+			return nil, fmt.Errorf("expected json response, got empty body, with status: %v", resp.StatusCode)
 		}
 
 		return nil, fmt.Errorf("expected json response, got %q, with status: %v and response body: %q", cType, resp.StatusCode, body)

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -240,7 +240,7 @@ func TestClientDownstream400_Query(t *testing.T) {
 	query := Query{}
 	_, err := c.Query(query)
 
-	expected := fmt.Sprintf(`expected json response, got "text/plain", with status: %v`, http.StatusForbidden)
+	expected := fmt.Sprintf(`expected json response, got empty body, with status: %v`, http.StatusForbidden)
 	if err.Error() != expected {
 		t.Errorf("unexpected error.  expected %v, actual %v", expected, err)
 	}
@@ -407,7 +407,7 @@ func TestClientDownstream400_ChunkedQuery(t *testing.T) {
 	query := Query{Chunked: true}
 	_, err := c.Query(query)
 
-	expected := fmt.Sprintf(`expected json response, got "text/plain", with status: %v`, http.StatusForbidden)
+	expected := fmt.Sprintf(`expected json response, got empty body, with status: %v`, http.StatusForbidden)
 	if err.Error() != expected {
 		t.Errorf("unexpected error.  expected %v, actual %v", expected, err)
 	}


### PR DESCRIPTION
Update error response to exclude `Content-Type` if body length is 0

https://tip.golang.org/doc/go1.10#net/http

> The content-serving handlers also now omit the `Content-Type` header
when serving zero-length content.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
