### PR TITLE
add Prometheus metrics HTTP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [#9162](https://github.com/influxdata/influxdb/pull/9162): Improve inmem index startup performance for high cardinality.
 - [#8491](https://github.com/influxdata/influxdb/pull/8491): Add further tsi support for streaming/copying shards.
 - [#9181](https://github.com/influxdata/influxdb/pull/9181): Schedule a full compaction after a successful import
+- [#9218](https://github.com/influxdata/influxdb/pull/9218): Add Prometheus `/metrics` endpoint.
 
 ### Bugfixes
 

--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,6 @@
 collectd.org e84e8af5356e7f47485bbc95c96da6dd7984a67e
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
+github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/bmizerany/pat c068ca2f0aacee5ac3681d68e4d0a003b7d1fd2c
 github.com/boltdb/bolt 4b1ebc1869ad66568b313d0dc410e2be72670dda
 github.com/cespare/xxhash 1b6d2e40c16ba0dfce5c8eac2480ad6e7394819b
@@ -8,6 +9,7 @@ github.com/dgrijalva/jwt-go 24c63f56522a87ec5339cc3567883f1039378fdb
 github.com/dgryski/go-bits 2ad8d707cc05b1815ce6ff2543bb5e8d8f9298ef
 github.com/dgryski/go-bitstream 7d46cd22db7004f0cceb6f7975824b560cf0e486
 github.com/gogo/protobuf 1c2b16bc280d6635de6c52fc1471ab962dc36ec9
+github.com/golang/protobuf 1e59b77b52bf8e4b449a57e6f79f21226d571845
 github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380
 github.com/google/go-cmp 18107e6c56edb2d51f965f7d68e59404f0daee54
 github.com/influxdata/influxql c108c5fb9a432242754d18371795aa8099e73fe7
@@ -15,10 +17,15 @@ github.com/influxdata/usage-client 6d3895376368aa52a3a81d2a16e90f0f52371967
 github.com/influxdata/yamux 1f58ded512de5feabbe30b60c7d33a7a896c5f16
 github.com/influxdata/yarpc 036268cdec22b7074cd6d50cc6d7315c667063c7
 github.com/jwilder/encoding 27894731927e49b0a9023f00312be26733744815
+github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c
 github.com/opentracing/opentracing-go 1361b9cd60be79c4c3a7fa9841b3c132e40066a7
 github.com/paulbellamy/ratecounter 5a11f585a31379765c190c033b6ad39956584447
 github.com/peterh/liner 88609521dc4b6c858fd4c98b628147da928ce4ac
 github.com/philhofer/fwd 1612a298117663d7bc9a760ae20d383413859798
+github.com/prometheus/client_golang 661e31bf844dfca9aeba15f27ea8aa0d485ad212
+github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+github.com/prometheus/common 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
+github.com/prometheus/procfs a6e9df898b1336106c743392c48ee0b71f5c4efa
 github.com/retailnext/hllpp 38a7bb71b483e855d35010808143beaf05b67f9d
 github.com/spaolacci/murmur3 0d12bf811670bf6a1a63828dfbd003eded177fce
 github.com/tinylib/msgp ad0ff2e232ad2e37faf67087fb24bf8d04a8ce20

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/uuid"
 	"github.com/influxdata/influxql"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 )
 
@@ -169,6 +170,10 @@ func NewHandler(c Config) *Handler {
 		Route{ // Ping w/ status
 			"status-head",
 			"HEAD", "/status", false, true, h.serveStatus,
+		},
+		Route{
+			"prometheus-metrics",
+			"GET", "/metrics", false, true, promhttp.Handler().ServeHTTP,
 		},
 	}...)
 


### PR DESCRIPTION
This PR adds a Prometheus `http://<host:port>/metrics` endpoint. It is configured to produce the default Go metrics. Follow up PRs will add additional InfluxDB metrics.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
