### PR TITLE
Prevent a panic when a query simultaneously finishes and is killed at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [#9230](https://github.com/influxdata/influxdb/pull/9230): Remove extraneous newlines from the log.
 - [#9226](https://github.com/influxdata/influxdb/issues/9226): Allow lone boolean literals in a condition expression.
 - [#9235](https://github.com/influxdata/influxdb/pull/9235): Improve performance when writes exceed `max-values-per-tag` or `max-series`.
+- [#9216](https://github.com/influxdata/influxdb/issues/9216): Prevent a panic when a query simultaneously finishes and is killed at the same time.
 
 ## v1.4.3 [unreleased]
 

--- a/query/query_executor.go
+++ b/query/query_executor.go
@@ -508,6 +508,8 @@ func (q *QueryTask) monitor(fn QueryMonitorFunc) {
 func (q *QueryTask) close() {
 	q.mu.Lock()
 	if q.status != KilledTask {
+		// Set the status to killed to prevent closing the channel twice.
+		q.status = KilledTask
 		close(q.closing)
 	}
 	q.mu.Unlock()


### PR DESCRIPTION
There is a strange race condition where a query can be killed and finish
at approximately the same time. If this happens, the query gets
retrieved by the killing task, the query gets closed by the normal
processing thread, and then the killing task attempts to kill the query
afterwards. Since the close doesn't mark the query as already killed
(since it's not killed, just merely unused), the killing thread attempts
to close the channel again.

Mark the query as killed whenever it is closed to prevent a double close
from happening. This should never cause the status to be erroneously
reported since the query status is removed from the query table within
the same lock scope.

Fixes #9216.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated