### PR TITLE
Disk utilization fixes

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -37,3 +37,4 @@ golang.org/x/crypto 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
 golang.org/x/net 9dfe39835686865bff950a07b394c12a98ddc811
 golang.org/x/sys 062cd7e4e68206d8bab9b18396626e855c992658
 golang.org/x/text a71fd10341b064c10f4a81ceac72bcf70f26ea34
+golang.org/x/time 6dc17368e09b0e8634d71cac8168d853e869a0c7

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -79,7 +79,7 @@
   # snapshot the cache and write it to a TSM file, freeing up memory
   # Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
   # Values without a size suffix are in bytes.
-  # cache-snapshot-memory-size = "256m"
+  # cache-snapshot-memory-size = "25m"
 
   # CacheSnapshotWriteColdDuration is the length of time at
   # which the engine will snapshot the cache and write it to

--- a/pkg/limiter/write_test.go
+++ b/pkg/limiter/write_test.go
@@ -1,0 +1,34 @@
+package limiter_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/pkg/limiter"
+)
+
+func TestWriter_Limited(t *testing.T) {
+	r := bytes.NewReader(bytes.Repeat([]byte{0}, 1024*1024))
+
+	limit := 512 * 1024
+	w := limiter.NewWriter(discardCloser{}, limit, 10*1024*1024)
+
+	start := time.Now()
+	n, err := io.Copy(w, r)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Error("copy error: ", err)
+	}
+
+	rate := float64(n) / elapsed.Seconds()
+	if rate > float64(limit) {
+		t.Errorf("rate limit mismath: exp %f, got %f", float64(limit), rate)
+	}
+}
+
+type discardCloser struct{}
+
+func (d discardCloser) Write(b []byte) (int, error) { return len(b), nil }
+func (d discardCloser) Close() error                { return nil }

--- a/pkg/limiter/writer.go
+++ b/pkg/limiter/writer.go
@@ -1,0 +1,83 @@
+package limiter
+
+import (
+	"context"
+	"io"
+	"os"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type Writer struct {
+	w       io.WriteCloser
+	limiter Rate
+	ctx     context.Context
+}
+
+type Rate interface {
+	WaitN(ctx context.Context, n int) error
+}
+
+func NewRate(bytesPerSec, burstLimit int) Rate {
+	limiter := rate.NewLimiter(rate.Limit(bytesPerSec), burstLimit)
+	limiter.AllowN(time.Now(), burstLimit) // spend initial burst
+	return limiter
+}
+
+// NewWriter returns a writer that implements io.Writer with rate limiting.
+// The limiter use a token bucket approach and limits the rate to bytesPerSec
+// with a maximum burst of burstLimit.
+func NewWriter(w io.WriteCloser, bytesPerSec, burstLimit int) *Writer {
+	limiter := NewRate(bytesPerSec, burstLimit)
+
+	return &Writer{
+		w:       w,
+		ctx:     context.Background(),
+		limiter: limiter,
+	}
+}
+
+// WithRate returns a Writer with the specified rate limiter.
+func NewWriterWithRate(w io.WriteCloser, limiter Rate) *Writer {
+	return &Writer{
+		w:       w,
+		ctx:     context.Background(),
+		limiter: limiter,
+	}
+}
+
+// Write writes bytes from p.
+func (s *Writer) Write(b []byte) (int, error) {
+	if s.limiter == nil {
+		return s.w.Write(b)
+	}
+
+	n, err := s.w.Write(b)
+	if err != nil {
+		return n, err
+	}
+
+	if err := s.limiter.WaitN(s.ctx, n); err != nil {
+		return n, err
+	}
+	return n, err
+}
+
+func (s *Writer) Sync() error {
+	if f, ok := s.w.(*os.File); ok {
+		return f.Sync()
+	}
+	return nil
+}
+
+func (s *Writer) Name() string {
+	if f, ok := s.w.(*os.File); ok {
+		return f.Name()
+	}
+	return ""
+}
+
+func (s *Writer) Close() error {
+	return s.w.Close()
+}

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -26,7 +26,7 @@ const (
 
 	// DefaultCacheSnapshotMemorySize is the size at which the engine will
 	// snapshot the cache and write it to a TSM file, freeing up memory
-	DefaultCacheSnapshotMemorySize = 256 * 1024 * 1024 // 256MB
+	DefaultCacheSnapshotMemorySize = 25 * 1024 * 1024 // 25MB
 
 	// DefaultCacheSnapshotWriteColdDuration is the length of time at which
 	// the engine will snapshot the cache and write it to a new TSM file if

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -156,7 +156,8 @@ type EngineOptions struct {
 	ShardID       uint64
 	InmemIndex    interface{} // shared in-memory index
 
-	CompactionLimiter limiter.Fixed
+	CompactionLimiter           limiter.Fixed
+	CompactionThroughputLimiter limiter.Rate
 
 	Config Config
 }

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -1469,6 +1469,22 @@ func TestDefaultPlanner_PlanLevel_SmallestCompactionStep(t *testing.T) {
 			Path: "08-01.tsm1",
 			Size: 1 * 1024 * 1024,
 		},
+		tsm1.FileStat{
+			Path: "09-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "10-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "11-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "12-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
 	}
 
 	cp := tsm1.NewDefaultPlanner(
@@ -1479,7 +1495,7 @@ func TestDefaultPlanner_PlanLevel_SmallestCompactionStep(t *testing.T) {
 		}, tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	expFiles := []tsm1.FileStat{data[4], data[5], data[6], data[7]}
+	expFiles := []tsm1.FileStat{data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11]}
 	tsm := cp.PlanLevel(1)
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
@@ -1534,55 +1550,6 @@ func TestDefaultPlanner_PlanLevel_SplitFile(t *testing.T) {
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3], data[4]}
 	tsm := cp.PlanLevel(3)
-	if exp, got := len(expFiles), len(tsm[0]); got != exp {
-		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, p := range expFiles {
-		if got, exp := tsm[0][i], p.Path; got != exp {
-			t.Fatalf("tsm file mismatch: got %v, exp %v", got, exp)
-		}
-	}
-}
-
-func TestDefaultPlanner_PlanLevel_IsolatedLowLevel(t *testing.T) {
-	data := []tsm1.FileStat{
-		tsm1.FileStat{
-			Path: "01-03.tsm1",
-			Size: 251 * 1024 * 1024,
-		},
-		tsm1.FileStat{
-			Path: "02-03.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-		tsm1.FileStat{
-			Path: "03-01.tsm1",
-			Size: 2 * 1024 * 1024 * 1024,
-		},
-		tsm1.FileStat{
-			Path: "04-01.tsm1",
-			Size: 10 * 1024 * 1024,
-		},
-		tsm1.FileStat{
-			Path: "05-02.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-		tsm1.FileStat{
-			Path: "06-01.tsm1",
-			Size: 1 * 1024 * 1024,
-		},
-	}
-
-	cp := tsm1.NewDefaultPlanner(
-		&fakeFileStore{
-			PathsFn: func() []tsm1.FileStat {
-				return data
-			},
-		}, tsdb.DefaultCompactFullWriteColdDuration,
-	)
-
-	expFiles := []tsm1.FileStat{data[2], data[3]}
-	tsm := cp.PlanLevel(1)
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	}
@@ -1810,8 +1777,7 @@ func TestDefaultPlanner_PlanLevel_Multiple(t *testing.T) {
 		}, tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
-	expFiles2 := []tsm1.FileStat{data[4], data[5], data[6], data[7]}
+	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]}
 
 	tsm := cp.PlanLevel(1)
 	if exp, got := len(expFiles1), len(tsm[0]); got != exp {
@@ -1820,16 +1786,6 @@ func TestDefaultPlanner_PlanLevel_Multiple(t *testing.T) {
 
 	for i, p := range expFiles1 {
 		if got, exp := tsm[0][i], p.Path; got != exp {
-			t.Fatalf("tsm file mismatch: got %v, exp %v", got, exp)
-		}
-	}
-
-	if exp, got := len(expFiles2), len(tsm[1]); got != exp {
-		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
-	}
-
-	for i, p := range expFiles2 {
-		if got, exp := tsm[1][i], p.Path; got != exp {
 			t.Fatalf("tsm file mismatch: got %v, exp %v", got, exp)
 		}
 	}
@@ -1877,6 +1833,30 @@ func TestDefaultPlanner_PlanLevel_InUse(t *testing.T) {
 			Path: "10-01.tsm1",
 			Size: 1 * 1024 * 1024,
 		},
+		tsm1.FileStat{
+			Path: "11-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "12-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "13-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "14-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "15-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "16-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
 	}
 
 	cp := tsm1.NewDefaultPlanner(
@@ -1887,8 +1867,8 @@ func TestDefaultPlanner_PlanLevel_InUse(t *testing.T) {
 		}, tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
-	expFiles2 := []tsm1.FileStat{data[4], data[5], data[6], data[7]}
+	expFiles1 := data[0:8]
+	expFiles2 := data[8:16]
 
 	tsm := cp.PlanLevel(1)
 	if exp, got := len(expFiles1), len(tsm[0]); got != exp {
@@ -2567,23 +2547,39 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 						Size: 2148728539,
 					},
 					tsm1.FileStat{
-						Path: "000000005-000000002.tsm",
-						Size: 701863692,
+						Path: "000000005-000000001.tsm",
+						Size: 2148340232,
 					},
 					tsm1.FileStat{
-						Path: "000000006-000000002.tsm",
-						Size: 701863692,
+						Path: "000000006-000000001.tsm",
+						Size: 2148356556,
 					},
 					tsm1.FileStat{
-						Path: "000000007-000000002.tsm",
-						Size: 701863692,
+						Path: "000000007-000000001.tsm",
+						Size: 167780181,
 					},
 					tsm1.FileStat{
-						Path: "000000008-000000002.tsm",
-						Size: 701863692,
+						Path: "000000008-000000001.tsm",
+						Size: 2148728539,
 					},
 					tsm1.FileStat{
 						Path: "000000009-000000002.tsm",
+						Size: 701863692,
+					},
+					tsm1.FileStat{
+						Path: "000000010-000000002.tsm",
+						Size: 701863692,
+					},
+					tsm1.FileStat{
+						Path: "000000011-000000002.tsm",
+						Size: 701863692,
+					},
+					tsm1.FileStat{
+						Path: "000000012-000000002.tsm",
+						Size: 701863692,
+					},
+					tsm1.FileStat{
+						Path: "000000013-000000002.tsm",
 						Size: 701863692,
 					},
 				}
@@ -2623,7 +2619,7 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if got, exp := len(tsm[0]), 9; got != exp {
+	if got, exp := len(tsm[0]), 13; got != exp {
 		t.Fatalf("plan length mismatch: got %v, exp %v", got, exp)
 	}
 	cp.Release(tsm)

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -1461,6 +1461,14 @@ func TestDefaultPlanner_PlanLevel_SmallestCompactionStep(t *testing.T) {
 			Path: "06-01.tsm1",
 			Size: 1 * 1024 * 1024,
 		},
+		tsm1.FileStat{
+			Path: "07-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
+		tsm1.FileStat{
+			Path: "08-01.tsm1",
+			Size: 1 * 1024 * 1024,
+		},
 	}
 
 	cp := tsm1.NewDefaultPlanner(
@@ -1471,7 +1479,7 @@ func TestDefaultPlanner_PlanLevel_SmallestCompactionStep(t *testing.T) {
 		}, tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	expFiles := []tsm1.FileStat{data[4], data[5]}
+	expFiles := []tsm1.FileStat{data[4], data[5], data[6], data[7]}
 	tsm := cp.PlanLevel(1)
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1694,7 +1694,7 @@ func (e *Engine) ShouldCompactCache(lastWriteTime time.Time) bool {
 }
 
 func (e *Engine) compact(quit <-chan struct{}) {
-	t := time.NewTicker(5 * time.Second)
+	t := time.NewTicker(10 * time.Second)
 	defer t.Stop()
 
 	for {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -190,6 +190,7 @@ func NewEngine(id uint64, idx tsdb.Index, database, path string, walPath string,
 	c := &Compactor{
 		Dir:       path,
 		FileStore: fs,
+		RateLimit: opt.CompactionThroughputLimiter,
 	}
 
 	logger := zap.NewNop()

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1695,7 +1695,7 @@ func (e *Engine) ShouldCompactCache(lastWriteTime time.Time) bool {
 }
 
 func (e *Engine) compact(quit <-chan struct{}) {
-	t := time.NewTicker(10 * time.Second)
+	t := time.NewTicker(time.Second)
 	defer t.Stop()
 
 	for {
@@ -1757,15 +1757,15 @@ func (e *Engine) compact(quit <-chan struct{}) {
 
 				switch level {
 				case 1:
-					if e.compactHiPriorityLevel(level1Groups[0], 1) {
+					if e.compactHiPriorityLevel(level1Groups[0], 1, false) {
 						level1Groups = level1Groups[1:]
 					}
 				case 2:
-					if e.compactHiPriorityLevel(level2Groups[0], 2) {
+					if e.compactHiPriorityLevel(level2Groups[0], 2, false) {
 						level2Groups = level2Groups[1:]
 					}
 				case 3:
-					if e.compactLoPriorityLevel(level3Groups[0], 3) {
+					if e.compactLoPriorityLevel(level3Groups[0], 3, true) {
 						level3Groups = level3Groups[1:]
 					}
 				case 4:
@@ -1786,8 +1786,8 @@ func (e *Engine) compact(quit <-chan struct{}) {
 
 // compactHiPriorityLevel kicks off compactions using the high priority policy. It returns
 // true if the compaction was started
-func (e *Engine) compactHiPriorityLevel(grp CompactionGroup, level int) bool {
-	s := e.levelCompactionStrategy(grp, true, level)
+func (e *Engine) compactHiPriorityLevel(grp CompactionGroup, level int, fast bool) bool {
+	s := e.levelCompactionStrategy(grp, fast, level)
 	if s == nil {
 		return false
 	}
@@ -1815,8 +1815,8 @@ func (e *Engine) compactHiPriorityLevel(grp CompactionGroup, level int) bool {
 
 // compactLoPriorityLevel kicks off compactions using the lo priority policy. It returns
 // the plans that were not able to be started
-func (e *Engine) compactLoPriorityLevel(grp CompactionGroup, level int) bool {
-	s := e.levelCompactionStrategy(grp, true, level)
+func (e *Engine) compactLoPriorityLevel(grp CompactionGroup, level int, fast bool) bool {
+	s := e.levelCompactionStrategy(grp, fast, level)
 	if s == nil {
 		return false
 	}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -187,6 +187,13 @@ func (s *Store) loadShards() error {
 
 	s.EngineOptions.CompactionLimiter = limiter.NewFixed(lim)
 
+	// Env var to disable throughput limiter.  This will be moved to a config option in 1.5.
+	if os.Getenv("INFLUXDB_DATA_COMPACTION_THROUGHPUT") == "" {
+		s.EngineOptions.CompactionThroughputLimiter = limiter.NewRate(48*1024*1024, 48*1024*1024)
+	} else {
+		s.Logger.Info("Compaction throughput limit disabled")
+	}
+
 	t := limiter.NewFixed(runtime.GOMAXPROCS(0))
 	resC := make(chan *res)
 	var n int


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This is a followup to #9206 to fix the higher disk utilization and lower write throughput in 1.4.2.  One change in #9206 was to increase the snapshot size in order to create fewer and larger level 1 TSM files.  This helped to slow down the frequency of compactions.  Unfortunately, users with many databases or lots of active shards could OOM the process each shard is consuming more memory now.

This PR reverts that fix and fixes the issue slightly differently.  
1. Snapshot concurrency is adjusted based on latency vs cardinality.
2. All TSM writing (compaction/snapshotting) is rate limited to reduce the impact of bursty snapshots and TSM fsyncs.  The WAL is not part of this change.
3. Change compaction planning to run less frequently and adjusted the criteria for plans.  Since compactions are completing roughly 2x-3x faster in 1.4 vs 1.3, we need to slow them down lot.
4.  Fixed a compaction bug where only "fast" compactions would be run.  This causes TSM files to be less compressed and bigger until a final full compaction runs. 

This is a run on c4.4xlarge w/ 10B values, 2.5m series and 5 writers.  The 1.4.2 run is only 1/5 of the way through, but the performance difference can be seen already.  You can see in 1.4.2 that there are too many compactions getting run (combined w/ other issues) which increases disk utilization and lowers write throughput.  This PR has perf that is similar or better to 1.3 in different areas.  There are significantly fewer compactions, and write throughput is ~30% better than 1.3 now.  

![metrics](https://user-images.githubusercontent.com/219935/33966283-3c9c648c-e01c-11e7-97c5-c885f83aa03c.png)

Fixes #9217 #9201