### PR TITLE
Remove extraneous newlines from the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@
 - [#9163](https://github.com/influxdata/influxdb/pull/9163): Fix race condition in the merge iterator close method.
 - [#9144](https://github.com/influxdata/influxdb/issues/9144): Fix query compilation so multiple nested distinct calls is allowable
 - [#8789](https://github.com/influxdata/influxdb/issues/8789): Fix CLI to allow quoted database names in use statement
-- [#9208](https://github.com/influxdata/influxdb/pull/9208): Updated client 4xx error message when response body length is zero. 
+- [#9208](https://github.com/influxdata/influxdb/pull/9208): Updated client 4xx error message when response body length is zero.
+- [#9230](https://github.com/influxdata/influxdb/pull/9230): Remove extraneous newlines from the log.
 
 ## v1.4.3 [unreleased]
 

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -123,7 +123,7 @@ func (s *Service) Open() error {
 			readdir = func(path string) {
 				files, err := ioutil.ReadDir(path)
 				if err != nil {
-					s.Logger.Info(fmt.Sprintf("Unable to read directory %s: %s\n", path, err))
+					s.Logger.Info(fmt.Sprintf("Unable to read directory %s: %s", path, err))
 					return
 				}
 
@@ -134,10 +134,10 @@ func (s *Service) Open() error {
 						continue
 					}
 
-					s.Logger.Info(fmt.Sprintf("Loading %s\n", fullpath))
+					s.Logger.Info(fmt.Sprintf("Loading %s", fullpath))
 					types, err := TypesDBFile(fullpath)
 					if err != nil {
-						s.Logger.Info(fmt.Sprintf("Unable to parse collectd types file: %s\n", f.Name()))
+						s.Logger.Info(fmt.Sprintf("Unable to parse collectd types file: %s", f.Name()))
 						continue
 					}
 
@@ -147,7 +147,7 @@ func (s *Service) Open() error {
 			readdir(s.Config.TypesDB)
 			s.popts.TypesDB = alltypesdb
 		} else {
-			s.Logger.Info(fmt.Sprintf("Loading %s\n", s.Config.TypesDB))
+			s.Logger.Info(fmt.Sprintf("Loading %s", s.Config.TypesDB))
 			types, err := TypesDBFile(s.Config.TypesDB)
 			if err != nil {
 				return fmt.Errorf("Open(): %s", err)

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -361,7 +361,7 @@ func (s *Service) ExecuteContinuousQuery(dbi *meta.DatabaseInfo, cqi *meta.Conti
 	}
 
 	if err := cq.q.SetTimeRange(startTime, endTime); err != nil {
-		s.Logger.Info(fmt.Sprintf("error setting time range: %s\n", err))
+		s.Logger.Info(fmt.Sprintf("error setting time range: %s", err))
 		return false, err
 	}
 
@@ -377,7 +377,7 @@ func (s *Service) ExecuteContinuousQuery(dbi *meta.DatabaseInfo, cqi *meta.Conti
 	// Do the actual processing of the query & writing of results.
 	res := s.runContinuousQueryAndWriteResult(cq)
 	if res.Err != nil {
-		s.Logger.Info(fmt.Sprintf("error: %s. running: %s\n", res.Err, cq.q.String()))
+		s.Logger.Info(fmt.Sprintf("error: %s. running: %s", res.Err, cq.q.String()))
 		return false, res.Err
 	}
 


### PR DESCRIPTION
The newlines were accidentally kept when changing the logger. They are
not necessary and mess up the log output.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated