### PR TITLE
Improve performance when writes exceed max-values-per-tag or max-series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [#9208](https://github.com/influxdata/influxdb/pull/9208): Updated client 4xx error message when response body length is zero.
 - [#9230](https://github.com/influxdata/influxdb/pull/9230): Remove extraneous newlines from the log.
 - [#9226](https://github.com/influxdata/influxdb/issues/9226): Allow lone boolean literals in a condition expression.
+- [#9235](https://github.com/influxdata/influxdb/pull/9235): Improve performance when writes exceed `max-values-per-tag` or `max-series`.
 
 ## v1.4.3 [unreleased]
 

--- a/pkg/bytesutil/bytesutil.go
+++ b/pkg/bytesutil/bytesutil.go
@@ -11,6 +11,27 @@ func Sort(a [][]byte) {
 	sort.Sort(byteSlices(a))
 }
 
+// SortDedup sorts the byte slice a and removes duplicates. The ret
+func SortDedup(a [][]byte) [][]byte {
+	if len(a) < 2 {
+		return a
+	}
+
+	Sort(a)
+
+	i, j := 0, 1
+	for j < len(a) {
+		if bytes.Compare(a[j-1], a[j]) != 0 {
+			a[i] = a[j-1]
+			i++
+		}
+		j++
+	}
+	a[i] = a[j-1]
+	i++
+	return a[:i]
+}
+
 func IsSorted(a [][]byte) bool {
 	return sort.IsSorted(byteSlices(a))
 }

--- a/pkg/bytesutil/bytesutil.go
+++ b/pkg/bytesutil/bytesutil.go
@@ -15,8 +15,32 @@ func IsSorted(a [][]byte) bool {
 	return sort.IsSorted(byteSlices(a))
 }
 
+// SearchBytes performs a binary search for x in the sorted slice a.
 func SearchBytes(a [][]byte, x []byte) int {
-	return sort.Search(len(a), func(i int) bool { return bytes.Compare(a[i], x) >= 0 })
+	// Define f(i) => bytes.Compare(a[i], x) < 0
+	// Define f(-1) == false and f(n) == true.
+	// Invariant: f(i-1) == false, f(j) == true.
+	i, j := 0, len(a)
+	for i < j {
+		h := int(uint(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		if bytes.Compare(a[h], x) < 0 {
+			i = h + 1 // preserves f(i-1) == false
+		} else {
+			j = h // preserves f(j) == true
+		}
+	}
+	// i == j, f(i-1) == false, and f(j) (= f(i)) == true  =>  answer is i.
+	return i
+}
+
+// Contains returns true if x is an element of the sorted slice a.
+func Contains(a [][]byte, x []byte) bool {
+	n := SearchBytes(a, x)
+	if n < len(a) {
+		return bytes.Compare(a[n], x) == 0
+	}
+	return false
 }
 
 // SearchBytesFixed searches a for x using a binary search.  The size of a must be a multiple of

--- a/pkg/bytesutil/bytesutil_test.go
+++ b/pkg/bytesutil/bytesutil_test.go
@@ -34,6 +34,54 @@ func TestSearchBytesFixed(t *testing.T) {
 	}
 }
 
+func TestSearchBytes(t *testing.T) {
+	in := toByteSlices("bbb", "ccc", "eee", "fff", "ggg", "hhh")
+	tests := []struct {
+		name string
+		x    string
+		exp  int
+	}{
+		{"exists first", "bbb", 0},
+		{"exists middle", "eee", 2},
+		{"exists last", "hhh", 5},
+		{"not exists last", "zzz", 6},
+		{"not exists first", "aaa", 0},
+		{"not exists mid", "ddd", 2},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := bytesutil.SearchBytes(in, []byte(test.x))
+			if got != test.exp {
+				t.Errorf("got %t, expected %t", got, test.exp)
+			}
+		})
+	}
+}
+
+func TestContains(t *testing.T) {
+	in := toByteSlices("bbb", "ccc", "eee", "fff", "ggg", "hhh")
+	tests := []struct {
+		name string
+		x    string
+		exp  bool
+	}{
+		{"exists first", "bbb", true},
+		{"exists middle", "eee", true},
+		{"exists last", "hhh", true},
+		{"not exists last", "zzz", false},
+		{"not exists first", "aaa", false},
+		{"not exists mid", "ddd", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := bytesutil.Contains(in, []byte(test.x))
+			if got != test.exp {
+				t.Errorf("got %t, expected %t", got, test.exp)
+			}
+		})
+	}
+}
+
 func TestPack_WidthOne_One(t *testing.T) {
 	a := make([]byte, 8)
 
@@ -128,5 +176,45 @@ func TestPack_WidthOne_LastFill(t *testing.T) {
 		if got, exp := a[i], v; got != exp {
 			t.Fatalf("value mismatch: a[%d] = %v, exp %v", i, got, exp)
 		}
+	}
+}
+
+func BenchmarkContains_True(b *testing.B) {
+	var in [][]byte
+	for i := 'a'; i <= 'z'; i++ {
+		in = append(in, []byte(strings.Repeat(string(i), 3)))
+	}
+	for i := 0; i < b.N; i++ {
+		bytesutil.Contains(in, []byte("xxx"))
+	}
+}
+
+func BenchmarkContains_False(b *testing.B) {
+	var in [][]byte
+	for i := 'a'; i <= 'z'; i++ {
+		in = append(in, []byte(strings.Repeat(string(i), 3)))
+	}
+	for i := 0; i < b.N; i++ {
+		bytesutil.Contains(in, []byte("a"))
+	}
+}
+
+func BenchmarkSearchBytes_Exists(b *testing.B) {
+	var in [][]byte
+	for i := 'a'; i <= 'z'; i++ {
+		in = append(in, []byte(strings.Repeat(string(i), 3)))
+	}
+	for i := 0; i < b.N; i++ {
+		bytesutil.SearchBytes(in, []byte("xxx"))
+	}
+}
+
+func BenchmarkSearchBytes_NotExits(b *testing.B) {
+	var in [][]byte
+	for i := 'a'; i <= 'z'; i++ {
+		in = append(in, []byte(strings.Repeat(string(i), 3)))
+	}
+	for i := 0; i < b.N; i++ {
+		bytesutil.SearchBytes(in, []byte("a"))
 	}
 }

--- a/pkg/bytesutil/bytesutil_test.go
+++ b/pkg/bytesutil/bytesutil_test.go
@@ -54,7 +54,7 @@ func TestSearchBytes(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := bytesutil.SearchBytes(in, []byte(test.x))
 			if got != test.exp {
-				t.Errorf("got %t, expected %t", got, test.exp)
+				t.Errorf("got %d, expected %d", got, test.exp)
 			}
 		})
 	}

--- a/tsdb/index/inmem/inmem_test.go
+++ b/tsdb/index/inmem/inmem_test.go
@@ -21,9 +21,9 @@ func createData(lo, hi int) (keys, names [][]byte, tags []models.Tags) {
 }
 
 func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesExceeded(b *testing.B) {
-	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo")}
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo", nil)}
 	opt.Config.MaxValuesPerTag = 10
-	si := inmem.NewShardIndex(1, "foo", "bar", opt)
+	si := inmem.NewShardIndex(1, "foo", "bar", nil, opt)
 	si.Open()
 	keys, names, tags := createData(0, 10)
 	si.CreateSeriesListIfNotExists(keys, names, tags)
@@ -37,9 +37,9 @@ func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesExceeded(b *testin
 }
 
 func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesNotExceeded(b *testing.B) {
-	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo")}
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo", nil)}
 	opt.Config.MaxValuesPerTag = 100000
-	si := inmem.NewShardIndex(1, "foo", "bar", opt)
+	si := inmem.NewShardIndex(1, "foo", "bar", nil, opt)
 	si.Open()
 	keys, names, tags := createData(0, 10)
 	si.CreateSeriesListIfNotExists(keys, names, tags)
@@ -53,8 +53,8 @@ func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesNotExceeded(b *tes
 }
 
 func BenchmarkShardIndex_CreateSeriesListIfNotExists_NoMaxValues(b *testing.B) {
-	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo")}
-	si := inmem.NewShardIndex(1, "foo", "bar", opt)
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo", nil)}
+	si := inmem.NewShardIndex(1, "foo", "bar", nil, opt)
 	si.Open()
 	keys, names, tags := createData(0, 10)
 	si.CreateSeriesListIfNotExists(keys, names, tags)
@@ -68,10 +68,10 @@ func BenchmarkShardIndex_CreateSeriesListIfNotExists_NoMaxValues(b *testing.B) {
 }
 
 func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxSeriesExceeded(b *testing.B) {
-	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo")}
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo", nil)}
 	opt.Config.MaxValuesPerTag = 0
 	opt.Config.MaxSeriesPerDatabase = 10
-	si := inmem.NewShardIndex(1, "foo", "bar", opt)
+	si := inmem.NewShardIndex(1, "foo", "bar", nil, opt)
 	si.Open()
 	keys, names, tags := createData(0, 10)
 	si.CreateSeriesListIfNotExists(keys, names, tags)

--- a/tsdb/index/inmem/inmem_test.go
+++ b/tsdb/index/inmem/inmem_test.go
@@ -1,0 +1,85 @@
+package inmem_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/tsdb/index/inmem"
+)
+
+func createData(lo, hi int) (keys, names [][]byte, tags []models.Tags) {
+	for i := lo; i < hi; i++ {
+		keys = append(keys, []byte(fmt.Sprintf("m0,tag0=t%d", i)))
+		names = append(names, []byte("m0"))
+		var t models.Tags
+		t.Set([]byte("tag0"), []byte(fmt.Sprintf("%d", i)))
+		tags = append(tags, t)
+	}
+	return
+}
+
+func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesExceeded(b *testing.B) {
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo")}
+	opt.Config.MaxValuesPerTag = 10
+	si := inmem.NewShardIndex(1, "foo", "bar", opt)
+	si.Open()
+	keys, names, tags := createData(0, 10)
+	si.CreateSeriesListIfNotExists(keys, names, tags)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	keys, names, tags = createData(9, 5010)
+	for i := 0; i < b.N; i++ {
+		si.CreateSeriesListIfNotExists(keys, names, tags)
+	}
+}
+
+func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesNotExceeded(b *testing.B) {
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo")}
+	opt.Config.MaxValuesPerTag = 100000
+	si := inmem.NewShardIndex(1, "foo", "bar", opt)
+	si.Open()
+	keys, names, tags := createData(0, 10)
+	si.CreateSeriesListIfNotExists(keys, names, tags)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	keys, names, tags = createData(9, 5010)
+	for i := 0; i < b.N; i++ {
+		si.CreateSeriesListIfNotExists(keys, names, tags)
+	}
+}
+
+func BenchmarkShardIndex_CreateSeriesListIfNotExists_NoMaxValues(b *testing.B) {
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo")}
+	si := inmem.NewShardIndex(1, "foo", "bar", opt)
+	si.Open()
+	keys, names, tags := createData(0, 10)
+	si.CreateSeriesListIfNotExists(keys, names, tags)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	keys, names, tags = createData(9, 5010)
+	for i := 0; i < b.N; i++ {
+		si.CreateSeriesListIfNotExists(keys, names, tags)
+	}
+}
+
+func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxSeriesExceeded(b *testing.B) {
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo")}
+	opt.Config.MaxValuesPerTag = 0
+	opt.Config.MaxSeriesPerDatabase = 10
+	si := inmem.NewShardIndex(1, "foo", "bar", opt)
+	si.Open()
+	keys, names, tags := createData(0, 10)
+	si.CreateSeriesListIfNotExists(keys, names, tags)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	keys, names, tags = createData(9, 5010)
+	for i := 0; i < b.N; i++ {
+		si.CreateSeriesListIfNotExists(keys, names, tags)
+	}
+}


### PR DESCRIPTION
```
benchmark                                                                  old ns/op     new ns/op     delta
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesExceeded-8        6175374       2714158       -56.05%
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesNotExceeded-8     344502        326312        -5.28%
BenchmarkShardIndex_CreateSeriesListIfNotExists_NoMaxValues-8              346734        329961        -4.84%
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxSeriesExceeded-8        2414945       1996223       -17.34%

benchmark                                                                  old allocs     new allocs     delta
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesExceeded-8        45377          128            -99.72%
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesNotExceeded-8     33             20             -39.39%
BenchmarkShardIndex_CreateSeriesListIfNotExists_NoMaxValues-8              33             20             -39.39%
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxSeriesExceeded-8        15219          71             -99.53%

benchmark                                                                  old bytes     new bytes     delta
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesExceeded-8        1354539       480114        -64.56%
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxValuesNotExceeded-8     2101          1261          -39.98%
BenchmarkShardIndex_CreateSeriesListIfNotExists_NoMaxValues-8              2100          1261          -39.95%
BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxSeriesExceeded-8        707247        477737        -32.45%
```

----

Additional improvements to bytesutil packages

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkContains_True-8            67.0          41.8          -37.61%
BenchmarkContains_False-8           73.2          47.6          -34.97%
BenchmarkSearchBytes_Exists-8       51.5          34.3          -33.40%
BenchmarkSearchBytes_NotExits-8     57.7          39.8          -31.02%
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated