### PR TITLE
Prevent a panic when a query simultaneously finishes and is killed at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The default value for `cache-snapshot-memory-size` has been changed from `25m` t
 - [#9201](https://github.com/influxdata/influxdb/issues/9201): Fix higher disk i/o utilization
 - [#9217](https://github.com/influxdata/influxdb/issues/9217): Fix performance decline of the 1.4 version
 - [#9226](https://github.com/influxdata/influxdb/issues/9226): Allow lone boolean literals in a condition expression.
+- [#9216](https://github.com/influxdata/influxdb/issues/9216): Prevent a panic when a query simultaneously finishes and is killed at the same time.
 
 ## v1.4.2 [2017-11-15]
 

--- a/query/query_executor.go
+++ b/query/query_executor.go
@@ -512,6 +512,8 @@ func (q *QueryTask) monitor(fn QueryMonitorFunc) {
 func (q *QueryTask) close() {
 	q.mu.Lock()
 	if q.status != KilledTask {
+		// Set the status to killed to prevent closing the channel twice.
+		q.status = KilledTask
 		close(q.closing)
 	}
 	q.mu.Unlock()


### PR DESCRIPTION
There is a strange race condition where a query can be killed and finish
at approximately the same time. If this happens, the query gets
retrieved by the killing task, the query gets closed by the normal
processing thread, and then the killing task attempts to kill the query
afterwards. Since the close doesn't mark the query as already killed
(since it's not killed, just merely unused), the killing thread attempts
to close the channel again.

Mark the query as killed whenever it is closed to prevent a double close
from happening. This should never cause the status to be erroneously
reported since the query status is removed from the query table within
the same lock scope.

Backport of #9220.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated