### PR TITLE
Add series existence check in tsi1.

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -27,6 +27,7 @@ github.com/prometheus/client_model 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
 github.com/prometheus/common 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
 github.com/prometheus/procfs a6e9df898b1336106c743392c48ee0b71f5c4efa
 github.com/retailnext/hllpp 38a7bb71b483e855d35010808143beaf05b67f9d
+github.com/RoaringBitmap/roaring cefad6e4f79d4fa5d1d758ff937dde300641ccfa
 github.com/spaolacci/murmur3 0d12bf811670bf6a1a63828dfbd003eded177fce
 github.com/tinylib/msgp ad0ff2e232ad2e37faf67087fb24bf8d04a8ce20
 github.com/xlab/treeprint 06dfc6fa17cdde904617990a0c2d89e3e332dbb3

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -164,11 +164,10 @@ func (i *Index) MeasurementIterator() (tsdb.MeasurementIterator, error) {
 // CreateSeriesIfNotExists adds the series for the given measurement to the
 // index and sets its ID or returns the existing series object
 func (i *Index) CreateSeriesIfNotExists(shardID uint64, key, name []byte, tags models.Tags, opt *tsdb.EngineOptions, ignoreLimits bool) error {
-	seriesIDs, err := i.sfile.CreateSeriesListIfNotExists([][]byte{name}, []models.Tags{tags}, nil)
-	if err != nil {
+	if _, err := i.sfile.CreateSeriesListIfNotExists([][]byte{name}, []models.Tags{tags}, nil); err != nil {
 		return err
 	}
-	seriesID := seriesIDs[0]
+	seriesID := i.sfile.SeriesID(name, tags, nil)
 
 	i.mu.RLock()
 	// if there is a series for this id, it's already been added

--- a/tsdb/index/tsi1/series_set.go
+++ b/tsdb/index/tsi1/series_set.go
@@ -1,0 +1,30 @@
+package tsi1
+
+import (
+	"sync"
+
+	"github.com/RoaringBitmap/roaring"
+)
+
+// SeriesSet represents a lockable bitmap of series ids.
+type SeriesSet struct {
+	sync.RWMutex
+	bitmap *roaring.Bitmap
+}
+
+// NewSeriesSet returns a new instance of SeriesSet.
+func NewSeriesSet() *SeriesSet {
+	return &SeriesSet{
+		bitmap: roaring.NewBitmap(),
+	}
+}
+
+// Add adds the series id to the set.
+func (s *SeriesSet) Add(id uint64) {
+	s.bitmap.Add(uint32(id))
+}
+
+// Contains returns true if the id exists in the set.
+func (s *SeriesSet) Contains(id uint64) bool {
+	return s.bitmap.Contains(uint32(id))
+}

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -150,7 +150,8 @@ func (f *SeriesFile) Path() string { return f.path }
 // Path returns the path to the series index.
 func (f *SeriesFile) IndexPath() string { return filepath.Join(f.path, "index") }
 
-// CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist. Returns the offset of the series.
+// CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist.
+// The returned ids list returns values for new series and zero for existing series.
 func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags, buf []byte) (ids []uint64, err error) {
 	f.mu.RLock()
 	ids, ok := f.index.FindIDListByNameTags(f.segments, names, tagsSlice, buf)
@@ -175,7 +176,7 @@ func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []mod
 
 	for i := range names {
 		// Skip series that have already been created.
-		if id := ids[i]; id != 0 {
+		if ids[i] != 0 {
 			continue
 		}
 


### PR DESCRIPTION
## Overview

This adds `SeriesSet` to `Partition` to provide an existence check within the TSI index itself.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
