### PR TITLE
Fixed issue where compacting did not sort when blocks are unsorted and overlapping

### DIFF
--- a/tsdb/engine/tsm1/compact.gen.go
+++ b/tsdb/engine/tsm1/compact.gen.go
@@ -424,7 +424,7 @@ func (k *tsmKeyIterator) mergeUnsigned() {
 		// we need to dedup as there may be duplicate points now
 		for i := 1; !dedup && i < len(k.blocks); i++ {
 			dedup = k.blocks[i].partiallyRead() ||
-				k.blocks[i].minTime <= k.blocks[i-1].maxTime ||
+				k.blocks[i].overlapsTimeRange(k.blocks[i-1].minTime, k.blocks[i-1].maxTime) ||
 				len(k.blocks[i].tombstones) > 0
 		}
 

--- a/tsdb/engine/tsm1/compact.gen.go
+++ b/tsdb/engine/tsm1/compact.gen.go
@@ -6,12 +6,16 @@
 
 package tsm1
 
+import "sort"
+
 // merge combines the next set of blocks into merged blocks.
 func (k *tsmKeyIterator) mergeFloat() {
 	// No blocks left, or pending merged values, we're done
 	if len(k.blocks) == 0 && len(k.merged) == 0 && len(k.mergedFloatValues) == 0 {
 		return
 	}
+
+	sort.Stable(k.blocks)
 
 	dedup := len(k.mergedFloatValues) != 0
 	if len(k.blocks) > 0 && !dedup {
@@ -210,6 +214,8 @@ func (k *tsmKeyIterator) mergeInteger() {
 		return
 	}
 
+	sort.Stable(k.blocks)
+
 	dedup := len(k.mergedIntegerValues) != 0
 	if len(k.blocks) > 0 && !dedup {
 		// If we have more than one block or any partially tombstoned blocks, we many need to dedup
@@ -406,6 +412,8 @@ func (k *tsmKeyIterator) mergeUnsigned() {
 	if len(k.blocks) == 0 && len(k.merged) == 0 && len(k.mergedUnsignedValues) == 0 {
 		return
 	}
+
+	sort.Stable(k.blocks)
 
 	dedup := len(k.mergedUnsignedValues) != 0
 	if len(k.blocks) > 0 && !dedup {
@@ -604,6 +612,8 @@ func (k *tsmKeyIterator) mergeString() {
 		return
 	}
 
+	sort.Stable(k.blocks)
+
 	dedup := len(k.mergedStringValues) != 0
 	if len(k.blocks) > 0 && !dedup {
 		// If we have more than one block or any partially tombstoned blocks, we many need to dedup
@@ -800,6 +810,8 @@ func (k *tsmKeyIterator) mergeBoolean() {
 	if len(k.blocks) == 0 && len(k.merged) == 0 && len(k.mergedBooleanValues) == 0 {
 		return
 	}
+
+	sort.Stable(k.blocks)
 
 	dedup := len(k.mergedBooleanValues) != 0
 	if len(k.blocks) > 0 && !dedup {

--- a/tsdb/engine/tsm1/compact.gen.go.tmpl
+++ b/tsdb/engine/tsm1/compact.gen.go.tmpl
@@ -1,8 +1,6 @@
 package tsm1
 
-import (
-       "sort"
-)
+import "sort"
 
 {{range .}}
 
@@ -24,7 +22,7 @@ func (k *tsmKeyIterator) merge{{.Name}}() {
 		// we need to dedup as there may be duplicate points now
 		for i := 1; !dedup && i < len(k.blocks); i++ {
 			dedup = k.blocks[i].partiallyRead() ||
-			    k.blocks[i].minTime <= k.blocks[i-1].maxTime ||
+			    k.blocks[i].overlapsTimeRange(k.blocks[i-1].minTime, k.blocks[i-1].maxTime) ||
 			    len(k.blocks[i].tombstones) > 0
 		}
 


### PR DESCRIPTION
This PR fixes some issues with https://github.com/influxdata/influxdb/pull/9267.

In the case where you have both overlapping and and unsorted blocks, the previous code did not work because sort was missing. Furthermore, the template file compact.gen.go.tmpl and compact.gen.go was out of sync.

@jwilder, please review this as this is a follow-up on https://github.com/influxdata/influxdb/pull/9267.

###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [X] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)