### PR TITLE
Fix series file key/id map compaction.

### DIFF
--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -703,7 +703,7 @@ func (c *SeriesFileCompactor) insertKeyIDMap(dst []byte, capacity int64, segment
 		}
 
 		// Read key at position & hash.
-		elemKey := ReadSeriesKeyFromSegments(segments, elemOffset)
+		elemKey := ReadSeriesKeyFromSegments(segments, elemOffset+SeriesEntryHeaderSize)
 		elemHash := rhh.HashKey(elemKey)
 
 		// If the existing elem has probed less than us, then swap places with


### PR DESCRIPTION
Fixes missing series keys after series file index compaction.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
