### PR TITLE
Fix duplicate Tag Keys

### DIFF
--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -7826,9 +7826,6 @@ func TestServer_Query_ShowMeasurementExactCardinality(t *testing.T) {
 }
 
 func TestServer_Query_ShowTagKeys(t *testing.T) {
-	// TODO(benbjohnson): To be addressed in upcoming PR.
-	t.SkipNow()
-
 	t.Parallel()
 	s := OpenServer(NewConfig())
 	defer s.Close()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1230,23 +1230,20 @@ func (s *Store) TagKeys(auth query.Authorizer, shardIDs []uint64, cond influxql.
 			return nil, err
 		}
 
-		finalKeySet := make(map[string]struct{})
-		for i := range keys {
-			if len(values[i]) == 0 {
-				continue
+		// Filter final tag keys using the matching values. If a key has one or
+		// more matching values then it will be included in the final set.
+		finalKeys := keys[:0] // Use same backing array as keys to save allocation.
+		for i, k := range keys {
+			if len(values[i]) > 0 {
+				// Tag key k has one or more matching tag values.
+				finalKeys = append(finalKeys, k)
 			}
-			finalKeySet[keys[i]] = struct{}{}
-		}
-
-		finalKeys := make([]string, 0, len(finalKeySet))
-		for k := range finalKeySet {
-			finalKeys = append(finalKeys, k)
 		}
 
 		// Add to resultset.
 		results = append(results, TagKeys{
 			Measurement: string(name),
-			Keys:        keys,
+			Keys:        finalKeys,
 		})
 	}
 	return results, nil


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass

There was a bug in `SHOW TAG KEYS` where the wrong set of filtered tag keys was being appended to the result set. This wasn't showing up in the quite because the test was being skipped from recent development efforts 🤣 

This PR also optimises the building of the result set—we can simply filter the tag keys slice using another slice that shares the same backing array to save some allocations.
