### PR TITLE
Fix series file compaction stall.

### DIFF
--- a/pkg/rhh/rhh.go
+++ b/pkg/rhh/rhh.go
@@ -244,15 +244,9 @@ func HashKey(key []byte) int64 {
 
 // HashUint64 computes a hash of an int64. Hash is always non-zero.
 func HashUint64(key uint64) int64 {
-	hash := xxhash.New()
-	binary.Write(hash, binary.BigEndian, key)
-	h := int64(hash.Sum64())
-	if h == 0 {
-		h = 1
-	} else if h < 0 {
-		h = 0 - h
-	}
-	return h
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, key)
+	return HashKey(buf)
 }
 
 // Dist returns the probe distance for a hash in a slot index.

--- a/tsdb/series_index.go
+++ b/tsdb/series_index.go
@@ -165,6 +165,13 @@ func (idx *SeriesIndex) execEntry(flag uint8, id uint64, offset int64, key []byt
 		idx.keyIDMap.Put(key, id)
 		idx.idOffsetMap[id] = offset
 
+		if id > idx.maxSeriesID {
+			idx.maxSeriesID = id
+		}
+		if offset > idx.maxOffset {
+			idx.maxOffset = offset
+		}
+
 	case SeriesEntryTombstoneFlag:
 		idx.tombstones[id] = struct{}{}
 
@@ -255,6 +262,8 @@ func (idx *SeriesIndex) Clone() *SeriesIndex {
 		count:        idx.count,
 		capacity:     idx.capacity,
 		mask:         idx.mask,
+		maxSeriesID:  idx.maxSeriesID,
+		maxOffset:    idx.maxOffset,
 		data:         idx.data,
 		keyIDData:    idx.keyIDData,
 		idOffsetData: idx.idOffsetData,


### PR DESCRIPTION
## Overview

The series file compaction previously did not snapshot the max
offset before compacting and would keep compacting until it reached
the end of segment file. This caused more entries than expected into
the RHH map and this map gets exponentially slower as it gets close
to full.

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
