### PR TITLE
Fix large memory spikes in cache

### DIFF
--- a/tsdb/engine/tsm1/cache_test.go
+++ b/tsdb/engine/tsm1/cache_test.go
@@ -956,7 +956,7 @@ func BenchmarkEntry_add(b *testing.B) {
 				otherValues[i] = NewValue(1, float64(i))
 			}
 
-			entry, err := newEntryValues(values, 0) // Will use default allocation size.
+			entry, err := newEntryValues(values)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -252,7 +252,7 @@ func (p *partition) write(key []byte, values Values) (bool, error) {
 	}
 
 	// Create a new entry using a preallocated size if we have a hint available.
-	e, err := newEntryValues(values, 32)
+	e, err := newEntryValues(values)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
The cache defaulted to entry capacity size of 32.  This default
is fine for lower cardinality, but causes big spikes in InUse
heap with higher cardinalities that can OOM the process.  Since
the hints had to be removed previously due to increased memory usage,
they are now completely removed.  For lower cardinalities, we do
grow the slice, but this has a small performance penalty compared
to the large memory usage/OOMs with larger cardinalities.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)