### PR TITLE
Fix race in DeleteDatabase

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -562,10 +562,6 @@ func (s *Store) DeleteDatabase(name string) error {
 		// no files locally, so nothing to do
 		return nil
 	}
-
-	sfile := s.sfiles[name]
-	delete(s.sfiles, name)
-
 	shards := s.filterShards(func(sh *Shard) bool {
 		return sh.database == name
 	})
@@ -585,6 +581,9 @@ func (s *Store) DeleteDatabase(name string) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	sfile := s.sfiles[name]
+	delete(s.sfiles, name)
 
 	// Close series file.
 	if sfile != nil {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

Fixes this race:
 
```
==================
WARNING: DATA RACE
Write at 0x00c42024d560 by goroutine 164:
  runtime.mapdelete_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:801 +0x0
  github.com/influxdata/influxdb/tsdb.(*Store).DeleteDatabase()
      /root/go/src/github.com/influxdata/influxdb/tsdb/store.go:567 +0x1a5
  github.com/influxdata/influxdb/tests.(*LocalServer).DropDatabase()
      /root/go/src/github.com/influxdata/influxdb/tests/server_helpers.go:334 +0xda
  github.com/influxdata/influxdb/tests.TestConcurrentServer_ShowMeasurements.func1()
      /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:128 +0xcb
  github.com/influxdata/influxdb/tests.runTest.func2()
      /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:163 +0x60

Previous read at 0x00c42024d560 by goroutine 224:
  runtime.mapaccess1_faststr()
      /usr/local/go/src/runtime/hashmap_fast.go:208 +0x0
  github.com/influxdata/influxdb/tsdb.(*Store).seriesFile()
      /root/go/src/github.com/influxdata/influxdb/tsdb/store.go:374 +0xb1
  github.com/influxdata/influxdb/tsdb.(*Store).MeasurementNames()
      /root/go/src/github.com/influxdata/influxdb/tsdb/store.go:1085 +0xde
  github.com/influxdata/influxdb/tests.TestConcurrentServer_ShowMeasurements.func2()
      /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:136 +0xee
  github.com/influxdata/influxdb/tests.runTest.func2()
      /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:163 +0x60

Goroutine 164 (running) created at:
  github.com/influxdata/influxdb/tests.runTest()
      /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:156 +0x137
  github.com/influxdata/influxdb/tests.TestConcurrentServer_ShowMeasurements()
      /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:139 +0xbb3
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c

Goroutine 224 (running) created at:
  github.com/influxdata/influxdb/tests.runTest()
      /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:156 +0x137
  github.com/influxdata/influxdb/tests.TestConcurrentServer_ShowMeasurements()
      /root/go/src/github.com/influxdata/influxdb/tests/server_concurrent_test.go:139 +0xbb3
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:746 +0x16c
==================
```