### PR TITLE
Fix TestEngine_DisableEnableCompactions_Concurrent hang

### DIFF
--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -983,10 +983,14 @@ func TestIndex_SeriesIDSet(t *testing.T) {
 		// series for the gpu measurement...
 		for _, id := range ids {
 			contains := engine.SeriesIDSet().Contains(id)
-			if id < 4 && !contains {
-				return fmt.Errorf("bitmap does not contain ID: %d, but should", id)
-			} else if id >= 4 && contains {
-				return fmt.Errorf("bitmap still contains ID: %d after delete", id)
+			key, _ := engine.sfile.Series(id)
+			isGpu := bytes.Equal(key, []byte("gpu"))
+			isMem := bytes.Equal(key, []byte("mem"))
+
+			if (isGpu || isMem) && contains {
+				return fmt.Errorf("bitmap still contains ID: %d after delete: %s", id, string(key))
+			} else if !(isGpu || isMem) && !contains {
+				return fmt.Errorf("bitmap does not contain ID: %d, but should: %s", id, string(key))
 			}
 		}
 
@@ -997,10 +1001,14 @@ func TestIndex_SeriesIDSet(t *testing.T) {
 
 		for _, id := range ids {
 			contains := engine.SeriesIDSet().Contains(id)
-			if id < 4 && !contains {
-				return fmt.Errorf("[after re-open] bitmap does not contain ID: %d, but should", id)
-			} else if id >= 4 && contains {
-				return fmt.Errorf("[after re-open] bitmap still contains ID: %d after delete", id)
+			key, _ := engine.sfile.Series(id)
+			isGpu := bytes.Equal(key, []byte("gpu"))
+			isMem := bytes.Equal(key, []byte("mem"))
+
+			if (isGpu || isMem) && contains {
+				return fmt.Errorf("[after re-open] bitmap still contains ID: %d after delete: %s", id, string(key))
+			} else if !(isGpu || isMem) && !contains {
+				return fmt.Errorf("[after re-open] bitmap does not contain ID: %d, but should: %s", id, string(key))
 			}
 		}
 		return nil

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -74,7 +74,6 @@ func (f *SeriesFile) Close() (err error) {
 			err = e
 		}
 	}
-	f.partitions = nil
 	return err
 }
 


### PR DESCRIPTION
This test could hang due to an existing race that is still not fixed.
The snapshot and level compaction goroutines woule end up waiting on
the wrong channel to be closed so whey would never exit.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

