### PR TITLE
Persist TSI tombstones.

### DIFF
--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -433,6 +433,10 @@ type File interface {
 	// Sketches for cardinality estimation
 	MergeMeasurementsSketches(s, t estimator.Sketch) error
 
+	// Bitmap series existance.
+	SeriesIDSet() (*tsdb.SeriesIDSet, error)
+	TombstoneSeriesIDSet() (*tsdb.SeriesIDSet, error)
+
 	// Reference counting.
 	Retain()
 	Release()

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -143,7 +143,7 @@ func (i *Index) SeriesIDSet() *tsdb.SeriesIDSet {
 	seriesIDSet := tsdb.NewSeriesIDSet()
 	others := make([]*tsdb.SeriesIDSet, 0, i.PartitionN)
 	for _, p := range i.partitions {
-		others = append(others, p.seriesSet)
+		others = append(others, p.seriesIDSet)
 	}
 	seriesIDSet.Merge(others...)
 	return seriesIDSet

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -283,7 +283,7 @@ func (p *Partition) buildSeriesSet() error {
 		if err != nil {
 			return err
 		}
-		p.seriesIDSet.Diff(ss)
+		p.seriesIDSet.Merge(p.seriesIDSet, ss)
 	}
 	return nil
 }

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -51,7 +51,7 @@ type Partition struct {
 
 	// Fast series lookup of series IDs in the series file that have been present
 	// in this partition. This set tracks both insertions and deletions of a series.
-	seriesSet *tsdb.SeriesIDSet
+	seriesIDSet *tsdb.SeriesIDSet
 
 	// Compaction management
 	levels          []CompactionLevel // compaction levels
@@ -91,10 +91,10 @@ type Partition struct {
 // NewPartition returns a new instance of Partition.
 func NewPartition(sfile *tsdb.SeriesFile, path string) *Partition {
 	return &Partition{
-		closing:   make(chan struct{}),
-		path:      path,
-		sfile:     sfile,
-		seriesSet: tsdb.NewSeriesIDSet(),
+		closing:     make(chan struct{}),
+		path:        path,
+		sfile:       sfile,
+		seriesIDSet: tsdb.NewSeriesIDSet(),
 
 		// Default compaction thresholds.
 		MaxLogFileSize: DefaultMaxLogFileSize,
@@ -261,47 +261,31 @@ func (i *Partition) deleteNonManifestFiles(m *Manifest) error {
 	return nil
 }
 
-func (i *Partition) buildSeriesSet() error {
-	fs := i.retainFileSet()
+func (p *Partition) buildSeriesSet() error {
+	fs := p.retainFileSet()
 	defer fs.Release()
 
-	i.seriesSet = tsdb.NewSeriesIDSet()
+	p.seriesIDSet = tsdb.NewSeriesIDSet()
 
-	mitr := fs.MeasurementIterator()
-	if mitr == nil {
-		return nil
-	}
+	// Read series sets from files in reverse.
+	for i := len(fs.files) - 1; i >= 0; i-- {
+		f := fs.files[i]
 
-	// Iterate over each measurement.
-	for {
-		me := mitr.Next()
-		if me == nil {
-			return nil
-		}
-
-		// Iterate over each series id.
-		if err := func() error {
-			sitr := fs.MeasurementSeriesIDIterator(me.Name())
-			if sitr == nil {
-				return nil
-			}
-			defer sitr.Close()
-
-			for {
-				elem, err := sitr.Next()
-				if err != nil {
-					return err
-				} else if elem.SeriesID == 0 {
-					return nil
-				}
-
-				// Add id to series set.
-				i.seriesSet.Add(elem.SeriesID)
-			}
-		}(); err != nil {
+		// Delete anything that's been tombstoned.
+		ts, err := f.TombstoneSeriesIDSet()
+		if err != nil {
 			return err
 		}
+		p.seriesIDSet.Diff(ts)
+
+		// Add series created within the file.
+		ss, err := f.SeriesIDSet()
+		if err != nil {
+			return err
+		}
+		p.seriesIDSet.Diff(ss)
 	}
+	return nil
 }
 
 // Wait returns once outstanding compactions have finished.
@@ -589,7 +573,7 @@ func (i *Partition) createSeriesListIfNotExists(names [][]byte, tagsSlice []mode
 	// Ensure fileset cannot change during insert.
 	i.mu.RLock()
 	// Insert series into log file.
-	if err := i.activeLogFile.AddSeriesList(i.seriesSet, names, tagsSlice); err != nil {
+	if err := i.activeLogFile.AddSeriesList(i.seriesIDSet, names, tagsSlice); err != nil {
 		i.mu.RUnlock()
 		return err
 	}
@@ -610,7 +594,7 @@ func (i *Partition) DropSeries(key []byte, ts int64) error {
 		seriesID := i.sfile.SeriesID(mname, tags, nil)
 
 		// Remove from series id set.
-		i.seriesSet.Remove(seriesID)
+		i.seriesIDSet.Remove(seriesID)
 
 		// TODO(edd): this should only happen when there are no shards containing
 		// this series.


### PR DESCRIPTION
## Overview

This pull request persists existence and tombstone series id bitmaps to each `IndexFile`. Index files are listed in reverse chronological order so to rebuild the current bitmap for the whole `Index`, the index files are iterated in reverse order (chronological) and tombstone series deleted in the file and adding new ids to the set.

The series existence and tombstone bitmaps are mutually exclusive in each index file (aka a bit set in one should not be set in the other).

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass
