### PR TITLE
Don't return error for non-existent series file

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -970,7 +970,8 @@ func (s *Store) DeleteSeries(database string, sources []influxql.Source, conditi
 
 	sfile := s.sfiles[database]
 	if sfile == nil {
-		return fmt.Errorf("unable to locate series file for database: %q", database)
+		// No series file means nothing has been written to this DB and thus nothing to delete.
+		return nil
 	}
 	shards := s.filterShards(byDatabase(database))
 

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -140,6 +140,24 @@ func TestStore_CreateShard(t *testing.T) {
 	}
 }
 
+// Ensure the store does not return an error when delete from a non-existent db.
+func TestStore_DeleteSeries_NonExistentDB(t *testing.T) {
+	t.Parallel()
+
+	test := func(index string) {
+		s := MustOpenStore(index)
+		defer s.Close()
+
+		if err := s.DeleteSeries("db0", nil, nil, true); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) { test(index) })
+	}
+}
+
 // Ensure the store can delete an existing shard.
 func TestStore_DeleteShard(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
When dropping series, if the series file does not exists we returned
and error.  This breaks compatibility with prior versions that would
not return an error if the series do not exists.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
