### PR TITLE
Implement DROP/DELETE semantics in indexes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
         - bash circle-test.sh:
             parallel: true
             # Race tests using 960s timeout
-            timeout: 960
+            timeout: 1500
 
 deployment:
   release:

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -330,8 +330,8 @@ func (e *StatementExecutor) executeDeleteSeriesStatement(stmt *influxql.DeleteSe
 	// Convert "now()" to current time.
 	stmt.Condition = influxql.Reduce(stmt.Condition, &influxql.NowValuer{Now: time.Now().UTC()})
 
-	// Locally delete the series. The series will not be removed from the index.
-	return e.TSDBStore.DeleteSeries(database, stmt.Sources, stmt.Condition, false)
+	// Locally delete the series.
+	return e.TSDBStore.DeleteSeries(database, stmt.Sources, stmt.Condition)
 }
 
 func (e *StatementExecutor) executeDropContinuousQueryStatement(q *influxql.DropContinuousQueryStatement) error {
@@ -375,7 +375,7 @@ func (e *StatementExecutor) executeDropSeriesStatement(stmt *influxql.DropSeries
 	}
 
 	// Locally drop the series.
-	return e.TSDBStore.DeleteSeries(database, stmt.Sources, stmt.Condition, true)
+	return e.TSDBStore.DeleteSeries(database, stmt.Sources, stmt.Condition)
 }
 
 func (e *StatementExecutor) executeDropShardStatement(stmt *influxql.DropShardStatement) error {
@@ -1375,7 +1375,7 @@ type TSDBStore interface {
 	DeleteDatabase(name string) error
 	DeleteMeasurement(database, name string) error
 	DeleteRetentionPolicy(database, name string) error
-	DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr, removeIndex bool) error
+	DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr) error
 	DeleteShard(id uint64) error
 
 	MeasurementNames(auth query.Authorizer, database string, cond influxql.Expr) ([][]byte, error)

--- a/internal/tsdb_store.go
+++ b/internal/tsdb_store.go
@@ -23,7 +23,7 @@ type TSDBStoreMock struct {
 	DeleteDatabaseFn          func(name string) error
 	DeleteMeasurementFn       func(database, name string) error
 	DeleteRetentionPolicyFn   func(database, name string) error
-	DeleteSeriesFn            func(database string, sources []influxql.Source, condition influxql.Expr, removeIndex bool) error
+	DeleteSeriesFn            func(database string, sources []influxql.Source, condition influxql.Expr) error
 	DeleteShardFn             func(id uint64) error
 	DiskSizeFn                func() (int64, error)
 	ExpandSourcesFn           func(sources influxql.Sources) (influxql.Sources, error)
@@ -77,8 +77,8 @@ func (s *TSDBStoreMock) DeleteMeasurement(database string, name string) error {
 func (s *TSDBStoreMock) DeleteRetentionPolicy(database string, name string) error {
 	return s.DeleteRetentionPolicyFn(database, name)
 }
-func (s *TSDBStoreMock) DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr, removeIndex bool) error {
-	return s.DeleteSeriesFn(database, sources, condition, removeIndex)
+func (s *TSDBStoreMock) DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr) error {
+	return s.DeleteSeriesFn(database, sources, condition)
 }
 func (s *TSDBStoreMock) DeleteShard(shardID uint64) error {
 	return s.DeleteShardFn(shardID)

--- a/tests/server_delete_test.go
+++ b/tests/server_delete_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -113,6 +114,11 @@ func setupCommands(s *LocalServer, tracker *SeriesTracker) []Command {
 // and a database's series file.
 func TestServer_DELETE_DROP_SERIES_DROP_MEASUREMENT(t *testing.T) {
 	t.Parallel()
+
+	if testing.Short() || os.Getenv("GORACE") != "" {
+		t.Skip("Skipping test in short or race mode.")
+	}
+
 	N := 5000
 	shardN := 10
 	r := rand.New(rand.NewSource(seed))

--- a/tests/server_delete_test.go
+++ b/tests/server_delete_test.go
@@ -1,0 +1,459 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/influxdata/influxdb/models"
+)
+
+var db = "db0"
+var rp = "rp0"
+
+// Makes it easy to debug times by emitting rfc formatted strings instead
+// of numbers.
+var tme = func(t int64) string {
+	// return time.Unix(0, t).UTC().String()
+	return fmt.Sprint(t) // Just emit the number
+}
+
+type Command func() (string, error)
+
+func setupCommands(s *LocalServer, tracker *SeriesTracker) []Command {
+	var measurementN = 10
+	var seriesN = 100
+	var commands []Command
+
+	r := rand.New(rand.NewSource(seed))
+
+	// Command for inserting some series data.
+	commands = append(commands, func() (string, error) {
+		name := fmt.Sprintf("m%d", r.Intn(measurementN))
+		tags := models.NewTags(map[string]string{fmt.Sprintf("s%d", r.Intn(seriesN)): "a"})
+
+		tracker.Lock()
+		pt := tracker.AddSeries(name, tags)
+		_, err := s.Write(db, rp, pt, nil)
+		if err != nil {
+			return "", err
+		}
+
+		defer tracker.Unlock()
+		return fmt.Sprintf("INSERT %s", pt), tracker.Verify()
+	})
+
+	// Command for dropping an entire measurement.
+	commands = append(commands, func() (string, error) {
+		name := fmt.Sprintf("m%d", r.Intn(measurementN))
+
+		tracker.Lock()
+		tracker.DeleteMeasurement(name)
+		query := fmt.Sprintf("DROP MEASUREMENT %s", name)
+		_, err := s.QueryWithParams(query, url.Values{"db": []string{"db0"}})
+		if err != nil {
+			return "", err
+		}
+
+		defer tracker.Unlock()
+		return query, tracker.Verify()
+	})
+
+	// Command for dropping a single series.
+	commands = append(commands, func() (string, error) {
+		name := fmt.Sprintf("m%d", r.Intn(measurementN))
+		tagKey := fmt.Sprintf("s%d", r.Intn(seriesN))
+		tags := models.NewTags(map[string]string{tagKey: "a"})
+
+		tracker.Lock()
+		tracker.DropSeries(name, tags)
+		query := fmt.Sprintf("DROP SERIES FROM %q WHERE %q = 'a'", name, tagKey)
+		_, err := s.QueryWithParams(query, url.Values{"db": []string{"db0"}})
+		if err != nil {
+			return "", err
+		}
+
+		defer tracker.Unlock()
+		return query, tracker.Verify()
+	})
+
+	// Command for dropping a single series.
+	commands = append(commands, func() (string, error) {
+		name := fmt.Sprintf("m%d", r.Intn(measurementN))
+
+		tracker.Lock()
+		min, max := tracker.DeleteRandomRange(name)
+		query := fmt.Sprintf("DELETE FROM %q WHERE time >= %d AND time <= %d ", name, min, max)
+		_, err := s.QueryWithParams(query, url.Values{"db": []string{"db0"}})
+		if err != nil {
+			return "", err
+		}
+
+		defer tracker.Unlock()
+		query = fmt.Sprintf("DELETE FROM %q WHERE time >= %s AND time <= %s ", name, tme(min), tme(max))
+		return query, tracker.Verify()
+	})
+
+	return commands
+}
+
+// TestServer_Delete_Series sets up a concurrent collection of clients that continuously
+// write data and delete series, measurements and shards.
+//
+// The purpose of this test is to provide a randomised, highly concurrent test
+// to shake out bugs involving the interactions between shards, their indexes,
+// and a database's series file.
+func TestServer_DELETE_DROP_SERIES_DROP_MEASUREMENT(t *testing.T) {
+	t.Parallel()
+	N := 5000
+	shardN := 10
+	r := rand.New(rand.NewSource(seed))
+	t.Logf("***** Seed set to %d *****\n", seed)
+
+	if testing.Short() {
+		t.Skip("Skipping in short mode")
+	}
+
+	s := OpenDefaultServer(NewConfig())
+	defer s.Close()
+
+	if _, ok := s.(*RemoteServer); ok {
+		t.Skip("Skipping. Not implemented on remote server")
+	}
+
+	localServer := s.(*LocalServer)
+
+	// First initialize some writes such that we end up with 10 shards.
+	// The first point refers to 1970-01-01 00:00:00.01 +0000 UTC and each subsequent
+	// point is 7 days into the future.
+	queries := make([]string, 0, N)
+	data := make([]string, 0, shardN)
+	for i := int64(0); i < int64(cap(data)); i++ {
+		query := fmt.Sprintf(`a val=1 %d`, 10000000+(int64(time.Hour)*24*7*i))
+		queries = append(queries, fmt.Sprintf("INSERT %s", query))
+		data = append(data, query)
+	}
+
+	if _, err := s.Write(db, rp, strings.Join(data, "\n"), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := NewSeriesTracker(r, localServer, db, rp)
+	commands := setupCommands(localServer, tracker)
+	for i := 0; i < N; i++ {
+		query, err := commands[r.Intn(len(commands))]()
+		queries = append(queries, query)
+		if err != nil {
+			emit := queries
+			if len(queries) > 100 {
+				emit = queries[len(queries)-100:]
+			}
+			t.Logf("Emitting last 100 queries of %d total:\n%s\n", len(queries), strings.Join(emit, "\n"))
+			t.Logf("Current points in Series Tracker index:\n%s\n", tracker.DumpPoints())
+			t.Fatal(err)
+		}
+	}
+}
+
+// SeriesTracker is a lockable tracker of which shards should own which series.
+type SeriesTracker struct {
+	sync.RWMutex
+	r *rand.Rand
+
+	// The testing server
+	server *LocalServer
+
+	// series maps a series key to a value that determines which shards own the
+	// series.
+	series map[string]uint64
+
+	// seriesPoints maps a series key to all the times that the series is written.
+	seriesPoints map[string][]int64
+
+	// measurements maps a measurement name to a value that determines which
+	// shards own the measurement.
+	measurements map[string]uint64
+
+	// measurementsSeries maps which series keys belong to which measurement.
+	measurementsSeries map[string]map[string]struct{}
+
+	// shardTimeRanges maintains the time ranges that a shard spans
+	shardTimeRanges map[uint64][2]int64
+	shardIDs        []uint64
+}
+
+func NewSeriesTracker(r *rand.Rand, server *LocalServer, db, rp string) *SeriesTracker {
+	tracker := &SeriesTracker{
+		r:                  r,
+		series:             make(map[string]uint64),
+		seriesPoints:       make(map[string][]int64),
+		measurements:       make(map[string]uint64),
+		measurementsSeries: make(map[string]map[string]struct{}),
+		shardTimeRanges:    make(map[uint64][2]int64),
+		server:             server,
+	}
+
+	data := server.MetaClient.Data()
+
+	sgs, err := data.ShardGroups(db, rp)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, sg := range sgs {
+		tracker.shardTimeRanges[sg.ID] = [2]int64{sg.StartTime.UnixNano(), sg.EndTime.UnixNano()}
+		tracker.shardIDs = append(tracker.shardIDs, sg.ID)
+	}
+
+	// Add initial series
+	for i, sid := range tracker.shardIDs {
+		// Map the shard to the series.
+		tracker.series["a"] = tracker.series["a"] | (1 << sid)
+		// Map the shard to the measurement.
+		tracker.measurements["a"] = tracker.measurements["a"] | (1 << sid)
+		// Map the timstamp of the point in this shard to the series.
+		tracker.seriesPoints["a"] = append(tracker.seriesPoints["a"], 10000000+(int64(time.Hour)*24*7*int64(i)))
+	}
+	// Map initial series to measurement.
+	tracker.measurementsSeries["a"] = map[string]struct{}{"a": struct{}{}}
+	return tracker
+}
+
+// AddSeries writes a point for the provided series to the provided shard. The
+// exact time of the point is randomised within all the shards' boundaries.
+// The point string is returned, to be inserted into the server.
+func (s *SeriesTracker) AddSeries(name string, tags models.Tags) string {
+	// generate a random shard and time within it.
+	time, shard := s.randomTime()
+
+	pt, err := models.NewPoint(name, tags, models.Fields{"v": 1.0}, time)
+	if err != nil {
+		panic(err)
+	}
+
+	key := string(pt.Key())
+	s.series[key] = s.series[key] | (1 << shard)
+	s.seriesPoints[key] = append(s.seriesPoints[key], time.UnixNano())
+
+	// Update measurement map
+	s.measurements[name] = s.measurements[name] | (1 << shard)
+
+	// Update measurement -> series mapping
+	if _, ok := s.measurementsSeries[name]; !ok {
+		s.measurementsSeries[name] = map[string]struct{}{string(key): struct{}{}}
+	} else {
+		s.measurementsSeries[name][string(key)] = struct{}{}
+	}
+	return pt.String()
+}
+
+// DeleteMeasurement deletes all series associated with the provided measurement
+// from the tracker.
+func (s *SeriesTracker) DeleteMeasurement(name string) {
+	// Delete from shard -> measurement mapping
+	delete(s.measurements, name)
+
+	// Get any series associated with measurement, and delete them.
+	series := s.measurementsSeries[name]
+
+	// Remove all series associated with this measurement.
+	for key := range series {
+		delete(s.series, key)
+		delete(s.seriesPoints, key)
+	}
+	delete(s.measurementsSeries, name)
+}
+
+// DropSeries deletes a specific series, removing any measurements if no series
+// are owned by them any longer.
+func (s *SeriesTracker) DropSeries(name string, tags models.Tags) {
+	pt, err := models.NewPoint(name, tags, models.Fields{"v": 1.0}, time.Now())
+	if err != nil {
+		panic(err)
+	}
+
+	key := string(pt.Key())
+	_, ok := s.series[key]
+	if ok {
+		s.cleanupSeries(name, key) // Remove all series data.
+	}
+}
+
+// cleanupSeries removes any traces of series that no longer have any point
+// data.
+func (s *SeriesTracker) cleanupSeries(name, key string) {
+	// Remove series references
+	delete(s.series, key)
+	delete(s.measurementsSeries[name], key)
+	delete(s.seriesPoints, key)
+
+	// Check if that was the last series for a measurement
+	if len(s.measurementsSeries[name]) == 0 {
+		delete(s.measurementsSeries, name) // Remove the measurement
+		delete(s.measurements, name)
+	}
+}
+
+// DeleteRandomRange deletes all series data within a random time range for the
+// provided measurement.
+func (s *SeriesTracker) DeleteRandomRange(name string) (int64, int64) {
+	t1, _ := s.randomTime()
+	t2, _ := s.randomTime()
+	min, max := t1.UnixNano(), t2.UnixNano()
+	if t2.Before(t1) {
+		min, max = t2.UnixNano(), t1.UnixNano()
+	}
+	if min > max {
+		panic(fmt.Sprintf("min time %d > max %d", min, max))
+	}
+	// Get all the series associated with this measurement.
+	series := s.measurementsSeries[name]
+	if len(series) == 0 {
+		// Nothing to do
+		return min, max
+	}
+
+	// For each series, check for, and remove, any points that fall within the
+	// time range.
+	var seriesToDelete []string
+	for serie := range series {
+		points := s.seriesPoints[serie]
+		sort.Sort(sortedInt64(points))
+
+		// Find min and max index that fall in range.
+		var minIdx, maxIdx = -1, -1
+		for i, p := range points {
+			if minIdx == -1 && p >= min {
+				minIdx = i
+			}
+			if p <= max {
+				maxIdx = i
+			}
+		}
+
+		// If either the minIdx or maxIdx are not set, then none of the points
+		// fall in that boundary of the domain.
+		if minIdx == -1 || maxIdx == -1 {
+			continue
+		}
+
+		// Cut those points from the series points slice.
+		s.seriesPoints[serie] = append(points[:minIdx], points[maxIdx+1:]...)
+
+		// Was that the last point for the series?
+		if len(s.seriesPoints[serie]) == 0 {
+			seriesToDelete = append(seriesToDelete, serie)
+		}
+	}
+
+	// Cleanup any removed series/measurements.
+	for _, key := range seriesToDelete {
+		s.cleanupSeries(name, key)
+	}
+
+	return min, max
+}
+
+// randomTime generates a random time to insert a point, such that it will fall
+// within one of the shards' time boundaries.
+func (s *SeriesTracker) randomTime() (time.Time, uint64) {
+	// Pick a random shard
+	id := s.shardIDs[s.r.Intn(len(s.shardIDs))]
+
+	// Get min and max time range of the shard.
+	min, max := s.shardTimeRanges[id][0], s.shardTimeRanges[id][1]
+	if min >= max {
+		panic(fmt.Sprintf("min %d >= max %d", min, max))
+	}
+	tme := s.r.Int63n(max-min) + min // Will result in a range [min, max)
+	if tme < min || tme >= max {
+		panic(fmt.Sprintf("generated time %d is out of bounds [%d, %d)", tme, min, max))
+	}
+	return time.Unix(0, tme), id
+}
+
+// Verify verifies that the server's view of the index/series file matches the
+// series tracker's.
+func (s *SeriesTracker) Verify() error {
+	res, err := s.server.QueryWithParams("SHOW SERIES", url.Values{"db": []string{"db0"}})
+	if err != nil {
+		return err
+	}
+
+	// Get all series...
+	var results struct {
+		Results []struct {
+			Series []struct {
+				Values [][]string `json:"values"`
+			} `json:"series"`
+		} `json:"results"`
+	}
+
+	if err := json.Unmarshal([]byte(res), &results); err != nil {
+		return err
+	}
+
+	var gotSeries []string
+	for _, ser := range results.Results {
+		for _, values := range ser.Series {
+			for _, v := range values.Values {
+				gotSeries = append(gotSeries, v[0])
+			}
+		}
+	}
+	// series are returned sorted by name then tag key then tag value, which is
+	// not the same as lexicographic order.
+	sort.Strings(gotSeries)
+
+	expectedSeries := make([]string, 0, len(s.series))
+	for series := range s.series {
+		expectedSeries = append(expectedSeries, series)
+	}
+	sort.Strings(expectedSeries)
+
+	if !reflect.DeepEqual(gotSeries, expectedSeries) {
+		return fmt.Errorf("verification failed:\ngot series: %v\nexpected series: %v\ndifference: %s", gotSeries, expectedSeries, cmp.Diff(gotSeries, expectedSeries))
+	}
+	return nil
+}
+
+// DumpPoints returns all the series points.
+func (s *SeriesTracker) DumpPoints() string {
+	keys := make([]string, 0, len(s.seriesPoints))
+	for key := range s.seriesPoints {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for i, key := range keys {
+		// We skip key "a" as it's just there to initialise the shards.
+		if key == "a" {
+			continue
+		}
+
+		points := s.seriesPoints[key]
+		sort.Sort(sortedInt64(points))
+
+		pointStr := make([]string, 0, len(points))
+		for _, p := range points {
+			pointStr = append(pointStr, tme(p))
+		}
+		keys[i] = fmt.Sprintf("%s: %v", key, pointStr)
+	}
+	return strings.Join(keys, "\n")
+}
+
+type sortedInt64 []int64
+
+func (a sortedInt64) Len() int           { return len(a) }
+func (a sortedInt64) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a sortedInt64) Less(i, j int) bool { return a[i] < a[j] }

--- a/tests/server_helpers.go
+++ b/tests/server_helpers.go
@@ -27,6 +27,7 @@ import (
 var verboseServerLogs bool
 var indexType string
 var cleanupData bool
+var seed int64
 
 // Server represents a test wrapper for run.Server.
 type Server interface {

--- a/tests/server_suite.go
+++ b/tests/server_suite.go
@@ -256,6 +256,18 @@ func init() {
 				exp:     `{"results":[{"statement_id":0,"series":[{"name":"cpu","columns":["time","host","region","val"],"values":[["2000-01-01T00:00:00Z","serverA","uswest",23.2]]}]}]}`,
 				params:  url.Values{"db": []string{"db1"}},
 			},
+			&Query{
+				name:    "Delete remaining instances of series",
+				command: `DELETE FROM cpu WHERE time < '2000-01-04T00:00:00Z'`,
+				exp:     `{"results":[{"statement_id":0}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
+			&Query{
+				name:    "Show series should now be empty",
+				command: `SHOW SERIES`,
+				exp:     `{"results":[{"statement_id":0}]}`,
+				params:  url.Values{"db": []string{"db0"}},
+			},
 		},
 	}
 

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,7 +25,14 @@ var benchServer Server
 func TestMain(m *testing.M) {
 	flag.BoolVar(&verboseServerLogs, "vv", false, "Turn on very verbose server logging.")
 	flag.BoolVar(&cleanupData, "clean", true, "Clean up test data on disk.")
+	flag.Int64Var(&seed, "seed", 0, "Set specific seed controlling randomness.")
 	flag.Parse()
+
+	// Set random seed if not explicitly set.
+	if seed == 0 {
+		seed = time.Now().UnixNano()
+	}
+	rand.Seed(seed)
 
 	var r int
 	for _, indexType = range tsdb.RegisteredIndexes() {

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -81,6 +81,11 @@ type Engine interface {
 	io.WriterTo
 }
 
+// SeriesIDSets provides access to the total set of series IDs
+type SeriesIDSets interface {
+	ForEach(f func(ids *SeriesIDSet)) error
+}
+
 // EngineFormat represents the format for an engine.
 type EngineFormat int
 
@@ -150,7 +155,8 @@ type EngineOptions struct {
 	CompactionLimiter           limiter.Fixed
 	CompactionThroughputLimiter limiter.Rate
 
-	Config Config
+	Config       Config
+	SeriesIDSets SeriesIDSets
 }
 
 // NewEngineOptions returns the default options.

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -54,7 +54,7 @@ type Engine interface {
 
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
 	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
-	DeleteSeriesRange(itr SeriesIterator, min, max int64, removeIndex bool) error
+	DeleteSeriesRange(itr SeriesIterator, min, max int64) error
 
 	MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error)
 	SeriesN() int64

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1365,6 +1365,10 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 		buf := make([]byte, 1024) // For use when accessing series file.
 		ids := tsdb.NewSeriesIDSet()
 		for _, k := range seriesKeys {
+			if len(k) == 0 {
+				continue // This key was wiped because it shouldn't be removed from index.
+			}
+
 			name, tags := models.ParseKey(k)
 			sid := e.sfile.SeriesID([]byte(name), tags, buf)
 			if sid == 0 {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1399,7 +1399,7 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 			}
 
 			// Remove the series from the local index.
-			if err := e.index.DropSeries(k, ts); err != nil {
+			if err := e.index.DropSeries(sid, k, ts); err != nil {
 				return err
 			}
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1372,7 +1372,7 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 			name, tags := models.ParseKey(k)
 			sid := e.sfile.SeriesID([]byte(name), tags, buf)
 			if sid == 0 {
-				return fmt.Errorf("unable to find id for series key %q during deletion", k)
+				continue
 			}
 
 			// This key was crossed out earlier, skip it

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1368,7 +1368,7 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 			name, tags := models.ParseKey(k)
 			sid := e.sfile.SeriesID([]byte(name), tags, buf)
 			if sid == 0 {
-				return fmt.Errorf("unable to find id for series key %s during deletion", k)
+				return fmt.Errorf("unable to find id for series key %q during deletion", k)
 			}
 			id := (sid << 32) | e.id
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -178,6 +178,9 @@ type Engine struct {
 	compactionLimiter limiter.Fixed
 
 	scheduler *scheduler
+
+	// provides access to the total set of series IDs
+	seriesIDSets tsdb.SeriesIDSets
 }
 
 // NewEngine returns a new instance of Engine.
@@ -219,6 +222,7 @@ func NewEngine(id uint64, idx tsdb.Index, database, path string, walPath string,
 		stats:             stats,
 		compactionLimiter: opt.CompactionLimiter,
 		scheduler:         newScheduler(stats, opt.CompactionLimiter.Capacity()),
+		seriesIDSets:      opt.SeriesIDSets,
 	}
 
 	if e.traceLogging {
@@ -1359,7 +1363,15 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 	// the series from the index.
 	if len(seriesKeys) > 0 {
 		buf := make([]byte, 1024) // For use when accessing series file.
+		ids := tsdb.NewSeriesIDSet()
 		for _, k := range seriesKeys {
+			name, tags := models.ParseKey(k)
+			sid := e.sfile.SeriesID([]byte(name), tags, buf)
+			if sid == 0 {
+				return fmt.Errorf("unable to find id for series key %s during deletion", k)
+			}
+			id := (sid << 32) | e.id
+
 			// This key was crossed out earlier, skip it
 			if k == nil {
 				continue
@@ -1379,30 +1391,38 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 				i++
 			}
 
-			// Some cache values still exists, leave the series in the index.
 			if hasCacheValues {
 				continue
 			}
 
-			// Remove the series from the series file and index.
-
-			// TODO(edd): we need to first check with all other shards if it's
-			// OK to tombstone the series in the series file.
-			//
-			// Further, in the case of the inmem index, we should only remove
-			// the series from the index if we also tombstone it in the series
-			// file.
-			name, tags := models.ParseKey(k)
-			sid := e.sfile.SeriesID([]byte(name), tags, buf)
-			if sid == 0 {
-				return fmt.Errorf("unable to find id for series key %s during deletion", k)
-			}
-
 			// Remove the series from the index for this shard
-			id := (sid << 32) | e.id
 			if err := e.index.UnassignShard(string(k), id, ts); err != nil {
 				return err
 			}
+
+			// Add the id to the set of delete ids.
+			ids.Add(sid)
+
+		}
+
+		// Remove any series IDs for our set that still exist in other shards.
+		// We cannot remove these from the series file yet.
+		if err := e.seriesIDSets.ForEach(func(s *tsdb.SeriesIDSet) {
+			ids = ids.AndNot(s)
+		}); err != nil {
+			return err
+		}
+
+		// Remove the remaining ids from the series file as they no longer exist
+		// in any shard.
+		var err error
+		ids.ForEach(func(id uint64) {
+			if err1 := e.sfile.DeleteSeriesID(id); err1 != nil {
+				err = err1
+			}
+		})
+		if err != nil {
+			return err
 		}
 	}
 

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1817,13 +1817,15 @@ func NewEngine(index string) (*Engine, error) {
 	if err = sfile.Open(); err != nil {
 		return nil, err
 	}
-	seriesIDs := tsdb.NewSeriesIDSet()
 
 	opt := tsdb.NewEngineOptions()
 	opt.IndexVersion = index
 	if index == "inmem" {
 		opt.InmemIndex = inmem.NewIndex(db, sfile)
 	}
+	// Initialise series id sets. Need to do this as it's normally done at the
+	// store level.
+	seriesIDs := tsdb.NewSeriesIDSet()
 	opt.SeriesIDSets = seriesIDSets([]*tsdb.SeriesIDSet{seriesIDs})
 
 	idxPath := filepath.Join(dbPath, "index")

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1159,27 +1159,9 @@ func TestEngine_DeleteSeriesRange(t *testing.T) {
 				t.Fatalf("series mismatch: got %s, exp %s", got, exp)
 			}
 
-			if got, exp := tags, models.NewTags(map[string]string{"host": "0"}); !got.Equal(exp) {
-				t.Fatalf("series mismatch: got %s, exp %s", got, exp)
+			if !tags.Equal(models.NewTags(map[string]string{"host": "0"})) && !tags.Equal(models.NewTags(map[string]string{"host": "B"})) {
+				t.Fatalf(`series mismatch: got %s, exp either "host=0" or "host=B"`, tags)
 			}
-
-			if elem, err = iter.Next(); err != nil {
-				t.Fatal(err)
-			}
-			if elem.SeriesID == 0 {
-				t.Fatalf("series index mismatch: EOF, exp 2 series")
-			}
-
-			// Lookup series.
-			name, tags = e.sfile.Series(elem.SeriesID)
-			if got, exp := name, []byte("cpu"); !bytes.Equal(got, exp) {
-				t.Fatalf("series mismatch: got %s, exp %s", got, exp)
-			}
-
-			if got, exp := tags, models.NewTags(map[string]string{"host": "B"}); !got.Equal(exp) {
-				t.Fatalf("series mismatch: got %s, exp %s", got, exp)
-			}
-
 			iter.Close()
 
 			// Deleting remaining series should remove them from the series.

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1817,15 +1817,16 @@ func NewEngine(index string) (*Engine, error) {
 	if err = sfile.Open(); err != nil {
 		return nil, err
 	}
+	seriesIDs := tsdb.NewSeriesIDSet()
 
 	opt := tsdb.NewEngineOptions()
 	opt.IndexVersion = index
 	if index == "inmem" {
 		opt.InmemIndex = inmem.NewIndex(db, sfile)
 	}
+	opt.SeriesIDSets = seriesIDSets([]*tsdb.SeriesIDSet{seriesIDs})
 
 	idxPath := filepath.Join(dbPath, "index")
-	seriesIDs := tsdb.NewSeriesIDSet()
 	idx := tsdb.MustOpenIndex(1, db, idxPath, seriesIDs, sfile, opt)
 
 	tsm1Engine := tsm1.NewEngine(1, idx, db, filepath.Join(root, "data"), filepath.Join(root, "wal"), sfile, opt).(*tsm1.Engine)
@@ -2052,4 +2053,13 @@ func (itr *seriesIterator) Next() (tsdb.SeriesElem, error) {
 	s := series{name: name, tags: tags}
 	itr.keys = itr.keys[1:]
 	return s, nil
+}
+
+type seriesIDSets []*tsdb.SeriesIDSet
+
+func (a seriesIDSets) ForEach(f func(ids *tsdb.SeriesIDSet)) error {
+	for _, v := range a {
+		f(v)
+	}
+	return nil
 }

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -2170,7 +2170,7 @@ func (is IndexSet) MeasurementTagKeyValuesByExpr(auth query.Authorizer, name []b
 				if err != nil {
 					return nil, err
 				} else if sitr == nil {
-					break
+					continue
 				}
 				defer sitr.Close()
 

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -32,7 +32,7 @@ type Index interface {
 	InitializeSeries(key, name []byte, tags models.Tags) error
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
 	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
-	DropSeries(key []byte, ts int64) error
+	DropSeries(seriesID uint64, key []byte, ts int64) error
 
 	MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error)
 	SeriesN() int64

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -1050,6 +1050,7 @@ func (idx *ShardIndex) UnassignShard(key string, id uint64, ts int64) error {
 	// TODO(edd): temporarily munging series id and shard id into same value,
 	// to test prototype without having to change Index API.
 	sid, shardID := id>>32, id&0xFFFFFFFF
+
 	idx.seriesIDSet.Remove(sid)
 	return idx.Index.UnassignShard(key, shardID, ts)
 }

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -1065,14 +1065,9 @@ type ShardIndex struct {
 	opt tsdb.EngineOptions
 }
 
-// DropSeries removes the provided series id from the local bitset tracking
-// series. It then checks the database-wide series file, and if the series id has
-// been deleted, it removes the series from the global in-memory index.
-func (idx *ShardIndex) DropSeries(key []byte, ts int64) error {
-	// TODO(edd): Make this more efficient by passing in the series id.
-	name, tags := models.ParseKey(key)
-	seriesID := idx.sfile.SeriesID([]byte(name), tags, nil)
-
+// DropSeries removes the provided series id from the local bitset that tracks
+// series in this shard only.
+func (idx *ShardIndex) DropSeries(seriesID uint64, _ []byte, ts int64) error {
 	// Remove from shard-local bitset if it exists.
 	idx.seriesIDSet.Lock()
 	if idx.seriesIDSet.ContainsNoLock(seriesID) {

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -323,6 +323,8 @@ func (m *measurement) Rebuild() *measurement {
 
 	for _, id := range m.sortedSeriesIDs {
 		if s := m.seriesByID[id]; s != nil {
+			// Explicitly set the new measurement on the series.
+			s.Measurement = nm
 			nm.AddSeries(s)
 		}
 	}
@@ -1238,11 +1240,9 @@ func (s *series) AssignShard(shardID uint64, ts int64) {
 
 func (s *series) UnassignShard(shardID uint64, ts int64) {
 	s.mu.Lock()
-	fmt.Println(s.shardIDs)
 	if s.LastModified() < ts {
 		delete(s.shardIDs, shardID)
 	}
-	fmt.Println(s.shardIDs)
 	s.mu.Unlock()
 }
 
@@ -1266,7 +1266,6 @@ func (s *series) ShardN() int {
 
 // Delete marks this series as deleted.  A deleted series should not be returned for queries.
 func (s *series) Delete(ts int64) {
-	fmt.Println("Marking series ", s.Key, "as deleted")
 	s.mu.Lock()
 	if s.LastModified() < ts {
 		s.deleted = true

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -1238,9 +1238,11 @@ func (s *series) AssignShard(shardID uint64, ts int64) {
 
 func (s *series) UnassignShard(shardID uint64, ts int64) {
 	s.mu.Lock()
+	fmt.Println(s.shardIDs)
 	if s.LastModified() < ts {
 		delete(s.shardIDs, shardID)
 	}
+	fmt.Println(s.shardIDs)
 	s.mu.Unlock()
 }
 
@@ -1264,6 +1266,7 @@ func (s *series) ShardN() int {
 
 // Delete marks this series as deleted.  A deleted series should not be returned for queries.
 func (s *series) Delete(ts int64) {
+	fmt.Println("Marking series ", s.Key, "as deleted")
 	s.mu.Lock()
 	if s.LastModified() < ts {
 		s.deleted = true

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -418,6 +418,7 @@ type File interface {
 
 	Measurement(name []byte) MeasurementElem
 	MeasurementIterator() MeasurementIterator
+	MeasurementHasSeries(ss *tsdb.SeriesIDSet, name []byte) bool
 
 	TagKey(name, key []byte) TagKeyElem
 	TagKeyIterator(name []byte) TagKeyIterator

--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -433,6 +433,10 @@ type File interface {
 	// Sketches for cardinality estimation
 	MergeMeasurementsSketches(s, t estimator.Sketch) error
 
+	// Bitmap series existance.
+	SeriesIDSet() (*tsdb.SeriesIDSet, error)
+	TombstoneSeriesIDSet() (*tsdb.SeriesIDSet, error)
+
 	// Reference counting.
 	Retain()
 	Release()

--- a/tsdb/index/tsi1/file_set_test.go
+++ b/tsdb/index/tsi1/file_set_test.go
@@ -12,10 +12,7 @@ import (
 
 // Ensure fileset can return an iterator over all series in the index.
 func TestFileSet_SeriesIDIterator(t *testing.T) {
-	sfile := MustOpenSeriesFile()
-	defer sfile.Close()
-
-	idx := MustOpenIndex(sfile.SeriesFile, 1)
+	idx := MustOpenIndex(1)
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -84,10 +81,7 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 
 // Ensure fileset can return an iterator over all series for one measurement.
 func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
-	sfile := MustOpenSeriesFile()
-	defer sfile.Close()
-
-	idx := MustOpenIndex(sfile.SeriesFile, 1)
+	idx := MustOpenIndex(1)
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -153,10 +147,7 @@ func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
 
 // Ensure fileset can return an iterator over all measurements for the index.
 func TestFileSet_MeasurementIterator(t *testing.T) {
-	sfile := MustOpenSeriesFile()
-	defer sfile.Close()
-
-	idx := MustOpenIndex(sfile.SeriesFile, 1)
+	idx := MustOpenIndex(1)
 	defer idx.Close()
 
 	// Create initial set of series.
@@ -180,12 +171,16 @@ func TestFileSet_MeasurementIterator(t *testing.T) {
 			t.Fatal("expected iterator")
 		}
 
-		if e := itr.Next(); string(e.Name()) != `cpu` {
-			t.Fatalf("unexpected measurement: %s", e.Name())
-		} else if e := itr.Next(); string(e.Name()) != `mem` {
-			t.Fatalf("unexpected measurement: %s", e.Name())
-		} else if e := itr.Next(); e != nil {
-			t.Fatalf("expected nil measurement: %s", e.Name())
+		expectedNames := []string{"cpu", "mem", ""} // Empty string implies end
+		for _, name := range expectedNames {
+			e := itr.Next()
+			if name == "" && e != nil {
+				t.Errorf("got measurement %s, expected nil measurement", e.Name())
+			} else if e == nil && name != "" {
+				t.Errorf("got nil measurement, expected %s", name)
+			} else if e != nil && string(e.Name()) != name {
+				t.Errorf("got measurement %s, expected %s", e.Name(), name)
+			}
 		}
 	})
 
@@ -210,24 +205,23 @@ func TestFileSet_MeasurementIterator(t *testing.T) {
 			t.Fatal("expected iterator")
 		}
 
-		if e := itr.Next(); string(e.Name()) != `cpu` {
-			t.Fatalf("unexpected measurement: %s", e.Name())
-		} else if e := itr.Next(); string(e.Name()) != `disk` {
-			t.Fatalf("unexpected measurement: %s", e.Name())
-		} else if e := itr.Next(); string(e.Name()) != `mem` {
-			t.Fatalf("unexpected measurement: %s", e.Name())
-		} else if e := itr.Next(); e != nil {
-			t.Fatalf("expected nil measurement: %s", e.Name())
+		expectedNames := []string{"cpu", "disk", "mem", ""} // Empty string implies end
+		for _, name := range expectedNames {
+			e := itr.Next()
+			if name == "" && e != nil {
+				t.Errorf("got measurement %s, expected nil measurement", e.Name())
+			} else if e == nil && name != "" {
+				t.Errorf("got nil measurement, expected %s", name)
+			} else if e != nil && string(e.Name()) != name {
+				t.Errorf("got measurement %s, expected %s", e.Name(), name)
+			}
 		}
 	})
 }
 
 // Ensure fileset can return an iterator over all keys for one measurement.
 func TestFileSet_TagKeyIterator(t *testing.T) {
-	sfile := MustOpenSeriesFile()
-	defer sfile.Close()
-
-	idx := MustOpenIndex(sfile.SeriesFile, 1)
+	idx := MustOpenIndex(1)
 	defer idx.Close()
 
 	// Create initial set of series.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -143,7 +143,7 @@ func (i *Index) SeriesIDSet() *tsdb.SeriesIDSet {
 	seriesIDSet := tsdb.NewSeriesIDSet()
 	others := make([]*tsdb.SeriesIDSet, 0, i.PartitionN)
 	for _, p := range i.partitions {
-		others = append(others, p.seriesSet)
+		others = append(others, p.seriesIDSet)
 	}
 	seriesIDSet.Merge(others...)
 	return seriesIDSet

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -536,14 +536,14 @@ func (i *Index) InitializeSeries(key, name []byte, tags models.Tags) error {
 }
 
 // DropSeries drops the provided series from the index.
-func (i *Index) DropSeries(key []byte, ts int64) error {
-	// Extract measurement name.
-	name, _ := models.ParseKeyBytes(key)
-
+func (i *Index) DropSeries(seriesID uint64, key []byte, ts int64) error {
 	// Remove from partition.
-	if err := i.partition(key).DropSeries(key, ts); err != nil {
+	if err := i.partition(key).DropSeries(seriesID, ts); err != nil {
 		return err
 	}
+
+	// Extract measurement name.
+	name, _ := models.ParseKeyBytes(key)
 
 	// Check if that was the last series for the measurement in the entire index.
 	if ok, err := i.MeasurementHasSeries(name); err != nil {
@@ -820,9 +820,9 @@ func (i *Index) AssignShard(k string, shardID uint64)         {}
 // UnassignShard removes the provided series key from the index. The naming of
 // this method stems from a legacy index logic that used to track which shards
 // owned which series.
-func (i *Index) UnassignShard(k string, id uint64, ts int64) error {
+func (i *Index) UnassignShard(k string, _ uint64, ts int64) error {
 	// This can be called directly once inmem is gone.
-	return i.DropSeries([]byte(k), ts)
+	return i.DropSeries(0, []byte(k), ts)
 }
 
 func (i *Index) Rebuild() {}

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -143,6 +143,7 @@ func (i *Index) SeriesIDSet() *tsdb.SeriesIDSet {
 	seriesIDSet := tsdb.NewSeriesIDSet()
 	others := make([]*tsdb.SeriesIDSet, 0, i.PartitionN)
 	for _, p := range i.partitions {
+		fmt.Printf("Partition %s: bitset to merge is %v\n", p.id, p.seriesSet)
 		others = append(others, p.seriesSet)
 	}
 	seriesIDSet.Merge(others...)
@@ -480,7 +481,7 @@ func (i *Index) CreateSeriesListIfNotExists(_ [][]byte, names [][]byte, tagsSlic
 
 	// Determine partition for series using each series key.
 	buf := make([]byte, 2048)
-	for k, _ := range names {
+	for k := range names {
 		buf = tsdb.AppendSeriesKey(buf[:0], names[k], tagsSlice[k])
 
 		pidx := i.partitionIdx(buf)

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -217,6 +217,23 @@ func (f *IndexFile) MeasurementN() (n uint64) {
 	return n
 }
 
+// MeasurementHasSeries returns true if a measurement has any non-tombstoned series.
+func (f *IndexFile) MeasurementHasSeries(ss *tsdb.SeriesIDSet, name []byte) (ok bool) {
+	e, ok := f.mblk.Elem(name)
+	if !ok {
+		return false
+	}
+
+	e.ForEachSeriesID(func(id uint64) error {
+		if ss.Contains(id) {
+			ok = true
+			return errors.New("done")
+		}
+		return nil
+	})
+	return ok
+}
+
 // TagValueIterator returns a value iterator for a tag key and a flag
 // indicating if a tombstone exists on the measurement or key.
 func (f *IndexFile) TagValueIterator(name, key []byte) TagValueIterator {

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -113,6 +113,10 @@ func TestIndex_MeasurementExists(t *testing.T) {
 
 	// Delete second series.
 	tags.Set([]byte("region"), []byte("west"))
+	sid = idx.Index.SeriesFile().SeriesID(name, tags, nil)
+	if sid == 0 {
+		t.Fatalf("got 0 series id for %s/%v", name, tags)
+	}
 	if err := idx.DropSeries(sid, models.MakeKey(name, tags), 0); err != nil {
 		t.Fatal(err)
 	}

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -91,8 +91,14 @@ func TestIndex_MeasurementExists(t *testing.T) {
 		}
 	})
 
+	name, tags := []byte("cpu"), models.NewTags(map[string]string{"region": "east"})
+	sid := idx.Index.SeriesFile().SeriesID(name, tags, nil)
+	if sid == 0 {
+		t.Fatalf("got 0 series id for %s/%v", name, tags)
+	}
+
 	// Delete one series.
-	if err := idx.DropSeries(models.MakeKey([]byte("cpu"), models.NewTags(map[string]string{"region": "east"})), 0); err != nil {
+	if err := idx.DropSeries(sid, models.MakeKey(name, tags), 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -106,7 +112,8 @@ func TestIndex_MeasurementExists(t *testing.T) {
 	})
 
 	// Delete second series.
-	if err := idx.DropSeries(models.MakeKey([]byte("cpu"), models.NewTags(map[string]string{"region": "west"})), 0); err != nil {
+	tags.Set([]byte("region"), []byte("west"))
+	if err := idx.DropSeries(sid, models.MakeKey(name, tags), 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -233,6 +233,22 @@ func (f *LogFile) Measurement(name []byte) MeasurementElem {
 	return mm
 }
 
+func (f *LogFile) MeasurementHasSeries(ss *tsdb.SeriesIDSet, name []byte) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	mm, ok := f.mms[string(name)]
+	if !ok {
+		return false
+	}
+	for id := range mm.series {
+		if ss.Contains(id) {
+			return true
+		}
+	}
+	return false
+}
+
 // MeasurementNames returns an ordered list of measurement names.
 func (f *LogFile) MeasurementNames() []string {
 	f.mu.RLock()

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -350,16 +350,26 @@ func (e *MeasurementBlockElem) HasSeries() bool { return e.series.n > 0 }
 // It requires loading the entire list of series in-memory.
 func (e *MeasurementBlockElem) SeriesIDs() []uint64 {
 	a := make([]uint64, 0, e.series.n)
+	e.ForEachSeriesID(func(id uint64) error {
+		a = append(a, id)
+		return nil
+	})
+	return a
+}
+
+func (e *MeasurementBlockElem) ForEachSeriesID(fn func(uint64) error) error {
 	var prev uint64
 	for data := e.series.data; len(data) > 0; {
 		delta, n := binary.Uvarint(data)
 		data = data[n:]
 
 		seriesID := prev + uint64(delta)
-		a = append(a, seriesID)
+		if err := fn(seriesID); err != nil {
+			return err
+		}
 		prev = seriesID
 	}
-	return a
+	return nil
 }
 
 // Size returns the size of the element.

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -283,7 +283,7 @@ func (p *Partition) buildSeriesSet() error {
 		if err != nil {
 			return err
 		}
-		p.seriesIDSet.Diff(ss)
+		p.seriesIDSet.Merge(p.seriesIDSet, ss)
 	}
 	return nil
 }

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -583,6 +583,13 @@ func (i *Partition) DropMeasurement(name []byte) error {
 // createSeriesListIfNotExists creates a list of series if they doesn't exist in
 // bulk.
 func (i *Partition) createSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags) error {
+	// Is there anything to do? The partition may have been sent an empty batch.
+	if len(names) == 0 {
+		return nil
+	} else if len(names) != len(tagsSlice) {
+		return fmt.Errorf("uneven batch, partition %s sent %d names and %d tags", i.id, len(names), len(tagsSlice))
+	}
+
 	// Maintain reference count on files in file set.
 	fs, err := i.RetainFileSet()
 	if err != nil {

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -51,7 +51,7 @@ type Partition struct {
 
 	// Fast series lookup of series IDs in the series file that have been present
 	// in this partition. This set tracks both insertions and deletions of a series.
-	seriesSet *tsdb.SeriesIDSet
+	seriesIDSet *tsdb.SeriesIDSet
 
 	// Compaction management
 	levels          []CompactionLevel // compaction levels
@@ -91,10 +91,10 @@ type Partition struct {
 // NewPartition returns a new instance of Partition.
 func NewPartition(sfile *tsdb.SeriesFile, path string) *Partition {
 	return &Partition{
-		closing:   make(chan struct{}),
-		path:      path,
-		sfile:     sfile,
-		seriesSet: tsdb.NewSeriesIDSet(),
+		closing:     make(chan struct{}),
+		path:        path,
+		sfile:       sfile,
+		seriesIDSet: tsdb.NewSeriesIDSet(),
 
 		// Default compaction thresholds.
 		MaxLogFileSize: DefaultMaxLogFileSize,
@@ -261,52 +261,31 @@ func (i *Partition) deleteNonManifestFiles(m *Manifest) error {
 	return nil
 }
 
-func (i *Partition) buildSeriesSet() error {
-	fs := i.retainFileSet()
+func (p *Partition) buildSeriesSet() error {
+	fs := p.retainFileSet()
 	defer fs.Release()
 
-	i.seriesSet = tsdb.NewSeriesIDSet()
+	p.seriesIDSet = tsdb.NewSeriesIDSet()
 
-	mitr := fs.MeasurementIterator()
-	if mitr == nil {
-		return nil
-	}
+	// Read series sets from files in reverse.
+	for i := len(fs.files) - 1; i >= 0; i-- {
+		f := fs.files[i]
 
-	// Iterate over each measurement.
-	for {
-		me := mitr.Next()
-		if me == nil {
-			return nil
-		}
-
-		// Iterate over each series id.
-		if err := func() error {
-			sitr := fs.MeasurementSeriesIDIterator(me.Name())
-			if sitr == nil {
-				return nil
-			}
-			defer sitr.Close()
-
-			for {
-				elem, err := sitr.Next()
-				if err != nil {
-					return err
-				} else if elem.SeriesID == 0 {
-					return nil
-				}
-
-				if i.sfile.IsDeleted(elem.SeriesID) {
-					continue
-				}
-
-				// Add id to series set.
-				i.seriesSet.Add(elem.SeriesID)
-			}
-		}(); err != nil {
+		// Delete anything that's been tombstoned.
+		ts, err := f.TombstoneSeriesIDSet()
+		if err != nil {
 			return err
 		}
-		p.seriesIDSet.Merge(p.seriesIDSet, ss)
+		p.seriesIDSet.Diff(ts)
+
+		// Add series created within the file.
+		ss, err := f.SeriesIDSet()
+		if err != nil {
+			return err
+		}
+		p.seriesIDSet.Diff(ss)
 	}
+	return nil
 }
 
 // Wait returns once outstanding compactions have finished.
@@ -601,7 +580,7 @@ func (i *Partition) createSeriesListIfNotExists(names [][]byte, tagsSlice []mode
 	// Ensure fileset cannot change during insert.
 	i.mu.RLock()
 	// Insert series into log file.
-	if err := i.activeLogFile.AddSeriesList(i.seriesSet, names, tagsSlice); err != nil {
+	if err := i.activeLogFile.AddSeriesList(i.seriesIDSet, names, tagsSlice); err != nil {
 		i.mu.RUnlock()
 		return err
 	}
@@ -624,7 +603,7 @@ func (i *Partition) DropSeries(key []byte, ts int64) error {
 		}
 
 		// Remove from series id set.
-		i.seriesSet.Remove(seriesID)
+		i.seriesIDSet.Remove(seriesID)
 
 		return nil
 	}(); err != nil {

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -611,6 +611,9 @@ func (i *Partition) DropSeries(key []byte, ts int64) error {
 
 		name, tags := models.ParseKeyBytes(key)
 		seriesID := i.sfile.SeriesID(name, tags, nil)
+		if seriesID == 0 {
+			return fmt.Errorf("[partition %s] no series id for key %q when attempting index drop", i.id, string(key))
+		}
 
 		// Remove from series id set.
 		i.seriesSet.Remove(seriesID)

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -305,6 +305,7 @@ func (i *Partition) buildSeriesSet() error {
 		}(); err != nil {
 			return err
 		}
+		p.seriesIDSet.Merge(p.seriesIDSet, ss)
 	}
 }
 

--- a/tsdb/index/tsi1/tsi1_test.go
+++ b/tsdb/index/tsi1/tsi1_test.go
@@ -310,3 +310,12 @@ func (f *SeriesFile) Close() error {
 	defer os.RemoveAll(f.Path())
 	return f.SeriesFile.Close()
 }
+
+// Reopen initialises a new series file using the existing one.
+func (f *SeriesFile) Reopen() error {
+	if err := f.SeriesFile.Close(); err != nil {
+		return err
+	}
+	f.SeriesFile = tsdb.NewSeriesFile(f.SeriesFile.Path())
+	return nil
+}

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -1,6 +1,7 @@
 package tsdb
 
 import (
+	"io"
 	"sync"
 
 	"github.com/RoaringBitmap/roaring"
@@ -109,4 +110,28 @@ func (s *SeriesIDSet) String() string {
 	s.RLock()
 	defer s.RUnlock()
 	return s.bitmap.String()
+}
+
+// Diff deletes any bits set in other.
+func (s *SeriesIDSet) Diff(other *SeriesIDSet) {
+	other.RLock()
+	defer other.RUnlock()
+
+	s.Lock()
+	defer s.Unlock()
+	s.bitmap = roaring.AndNot(s.bitmap, other.bitmap)
+}
+
+// UnmarshalBinary unmarshals data into the set.
+func (s *SeriesIDSet) UnmarshalBinary(data []byte) error {
+	s.Lock()
+	defer s.Unlock()
+	return s.bitmap.UnmarshalBinary(data)
+}
+
+// WriteTo writes the set to w.
+func (s *SeriesIDSet) WriteTo(w io.Writer) (int64, error) {
+	s.RLock()
+	defer s.RUnlock()
+	return s.bitmap.WriteTo(w)
 }

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -71,3 +71,29 @@ func (s *SeriesIDSet) Merge(others ...*SeriesIDSet) {
 	defer s.Unlock()
 	s.bitmap = roaring.FastOr(bms...)
 }
+
+// AndNot returns the set of elements that only exist in s.
+func (s *SeriesIDSet) AndNot(other *SeriesIDSet) *SeriesIDSet {
+	s.RLock()
+	defer s.RUnlock()
+	other.RLock()
+	defer other.RUnlock()
+
+	return &SeriesIDSet{bitmap: roaring.AndNot(s.bitmap, other.bitmap)}
+}
+
+// ForEach calls f for each id in the set.
+func (s *SeriesIDSet) ForEach(f func(id uint64)) {
+	s.RLock()
+	defer s.RUnlock()
+	itr := s.bitmap.Iterator()
+	for itr.HasNext() {
+		f(uint64(itr.Next()))
+	}
+}
+
+func (s *SeriesIDSet) String() string {
+	s.RLock()
+	defer s.RUnlock()
+	return s.bitmap.String()
+}

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -72,6 +72,19 @@ func (s *SeriesIDSet) Merge(others ...*SeriesIDSet) {
 	s.bitmap = roaring.FastOr(bms...)
 }
 
+// Equals returns true if other and s are the same set of ids.
+func (s *SeriesIDSet) Equals(other *SeriesIDSet) bool {
+	if s == other {
+		return true
+	}
+
+	s.RLock()
+	defer s.RUnlock()
+	other.RLock()
+	other.RUnlock()
+	return s.bitmap.Equals(other.bitmap)
+}
+
 // AndNot returns the set of elements that only exist in s.
 func (s *SeriesIDSet) AndNot(other *SeriesIDSet) *SeriesIDSet {
 	s.RLock()

--- a/tsdb/series_set_test.go
+++ b/tsdb/series_set_test.go
@@ -1,0 +1,221 @@
+package tsdb
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSeriesIDSet_AndNot(t *testing.T) {
+	examples := [][3][]uint64{
+		[3][]uint64{
+			{1, 10, 20, 30},
+			{10, 12, 13, 14, 20},
+			{1, 30},
+		},
+		[3][]uint64{
+			{},
+			{10},
+			{},
+		},
+		[3][]uint64{
+			{1, 10, 20, 30},
+			{1, 10, 20, 30},
+			{},
+		},
+		[3][]uint64{
+			{1, 10},
+			{1, 10, 100},
+			{},
+		},
+		[3][]uint64{
+			{1, 10},
+			{},
+			{1, 10},
+		},
+	}
+
+	for i, example := range examples {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			// Build sets.
+			a, b := NewSeriesIDSet(), NewSeriesIDSet()
+			for _, v := range example[0] {
+				a.Add(v)
+			}
+			for _, v := range example[1] {
+				b.Add(v)
+			}
+
+			expected := NewSeriesIDSet()
+			for _, v := range example[2] {
+				expected.Add(v)
+			}
+
+			got := a.AndNot(b)
+			if got.String() != expected.String() {
+				t.Fatalf("got %s, expected %s", got.String(), expected.String())
+			}
+		})
+	}
+
+}
+
+var resultUint64 uint64
+var resultBool bool
+
+// Contains should be typically a constant time lookup. Example results on a laptop:
+//
+// BenchmarkSeriesIDSet_Contains/1-4 			20000000	        68.5 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Contains/2-4 			20000000	        70.8 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Contains/10-4         	20000000	        70.3 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Contains/100-4        	20000000	        71.3 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Contains/1000-4       	20000000	        80.5 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Contains/10000-4      	20000000	        67.3 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Contains/100000-4     	20000000	        73.1 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Contains/1000000-4    	20000000	        77.3 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Contains/10000000-4   	20000000	        75.3 ns/op	       0 B/op	       0 allocs/op
+func BenchmarkSeriesIDSet_Contains(b *testing.B) {
+	cardinalities := []uint64{1, 2, 10, 100, 1000, 10000, 100000, 1000000, 10000000}
+
+	for _, cardinality := range cardinalities {
+		// Setup...
+		set := NewSeriesIDSet()
+		for i := uint64(0); i < cardinality; i++ {
+			set.Add(i)
+		}
+
+		lookup := cardinality / 2
+		b.Run(fmt.Sprint(cardinality), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				resultBool = set.Contains(lookup)
+			}
+		})
+	}
+}
+
+var set *SeriesIDSet
+
+// Adding to a larger bitset shouldn't be significantly more expensive than adding
+// to a smaller one. This benchmark adds a value to different cardinality sets.
+//
+// Example results from a laptop:
+// BenchmarkSeriesIDSet_Add/1-4 	 		1000000	      1053 ns/op	      48 B/op	       2 allocs/op
+// BenchmarkSeriesIDSet_Add/2-4 	 		5000000	       303 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Add/10-4         	5000000	       348 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Add/100-4        	5000000	       373 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Add/1000-4       	5000000	       342 ns/op	       0 B/op	       0 allocs/op
+//
+//
+func BenchmarkSeriesIDSet_AddMore(b *testing.B) {
+	cardinalities := []uint64{1, 2, 10, 100, 1000, 10000, 100000, 1000000, 10000000}
+
+	for _, cardinality := range cardinalities {
+		// Setup...
+		set = NewSeriesIDSet()
+		for i := uint64(0); i < cardinality-1; i++ {
+			set.Add(i)
+		}
+
+		b.Run(fmt.Sprint(cardinality), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				// Add next value
+				set.Add(cardinality)
+
+				b.StopTimer()
+				set.Remove(cardinality)
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+// Add benchmarks the cost of adding the same element to a set versus the
+// cost of checking if it exists before adding it.
+//
+// Typical benchmarks from a laptop:
+//
+// BenchmarkSeriesIDSet_Add/cardinality_1000000_add_same-4         			20000000	        89.5 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Add/cardinality_1000000_check_add_global_lock-4     30000000	        56.9 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Add/cardinality_1000000_check_add_multi_lock-4      20000000	        75.7 ns/op	       0 B/op	       0 allocs/op
+//
+func BenchmarkSeriesIDSet_Add(b *testing.B) {
+	// Setup...
+	set = NewSeriesIDSet()
+	for i := uint64(0); i < 1000000; i++ {
+		set.Add(i)
+	}
+	lookup := uint64(300032)
+
+	// Add the same value over and over.
+	b.Run(fmt.Sprint("cardinality_1000000_add_same"), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			set.Add(lookup)
+		}
+	})
+
+	// Check if the value exists before adding it. Subsequent repeats of the code
+	// will result in contains checks.
+	b.Run(fmt.Sprint("cardinality_1000000_check_add_global_lock"), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			set.Lock()
+			if !set.ContainsNoLock(lookup) {
+				set.AddNoLock(lookup)
+			}
+			set.Unlock()
+		}
+	})
+
+	// Check if the value exists before adding it under two locks.
+	b.Run(fmt.Sprint("cardinality_1000000_check_add_multi_lock"), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if !set.Contains(lookup) {
+				set.Add(lookup)
+			}
+		}
+	})
+}
+
+// Remove benchmarks the cost of removing the same element in a set versus the
+// cost of checking if it exists before removing it.
+//
+// Typical benchmarks from a laptop:
+//
+// BenchmarkSeriesIDSet_Remove/cardinality_1000000_remove_same-4         		20000000	        99.1 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Remove/cardinality_1000000_check_remove_global_lock-4   20000000	        57.7 ns/op	       0 B/op	       0 allocs/op
+// BenchmarkSeriesIDSet_Remove/cardinality_1000000_check_remove_multi_lock-4    20000000	        80.1 ns/op	       0 B/op	       0 allocs/op
+//
+func BenchmarkSeriesIDSet_Remove(b *testing.B) {
+	// Setup...
+	set = NewSeriesIDSet()
+	for i := uint64(0); i < 1000000; i++ {
+		set.Add(i)
+	}
+	lookup := uint64(300032)
+
+	// Remove the same value over and over.
+	b.Run(fmt.Sprint("cardinality_1000000_remove_same"), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			set.Remove(lookup)
+		}
+	})
+
+	// Check if the value exists before adding it. Subsequent repeats of the code
+	// will result in contains checks.
+	b.Run(fmt.Sprint("cardinality_1000000_check_remove_global_lock"), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			set.Lock()
+			if set.ContainsNoLock(lookup) {
+				set.RemoveNoLock(lookup)
+			}
+			set.Unlock()
+		}
+	})
+
+	// Check if the value exists before adding it under two locks.
+	b.Run(fmt.Sprint("cardinality_1000000_check_remove_multi_lock"), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if set.Contains(lookup) {
+				set.Remove(lookup)
+			}
+		}
+	})
+}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -719,12 +719,12 @@ func (s *Shard) createFieldsAndMeasurements(fieldsToCreate []*FieldCreate) error
 }
 
 // DeleteSeriesRange deletes all values from for seriesKeys between min and max (inclusive)
-func (s *Shard) DeleteSeriesRange(itr SeriesIterator, min, max int64, removeIndex bool) error {
+func (s *Shard) DeleteSeriesRange(itr SeriesIterator, min, max int64) error {
 	engine, err := s.engine()
 	if err != nil {
 		return err
 	}
-	return engine.DeleteSeriesRange(itr, min, max, removeIndex)
+	return engine.DeleteSeriesRange(itr, min, max)
 }
 
 // DeleteMeasurement deletes a measurement and all underlying series.

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -365,6 +365,7 @@ func TestShard_WritePoints_FieldConflictConcurrent(t *testing.T) {
 	opts := tsdb.NewEngineOptions()
 	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
 	opts.InmemIndex = inmem.NewIndex(path.Base(tmpDir), sfile.SeriesFile)
+	opts.SeriesIDSets = seriesIDSets([]*tsdb.SeriesIDSet{})
 
 	sh := tsdb.NewShard(1, tmpShard, tmpWal, sfile.SeriesFile, opts)
 	if err := sh.Open(); err != nil {
@@ -452,6 +453,7 @@ func TestShard_WritePoints_FieldConflictConcurrentQuery(t *testing.T) {
 	opts := tsdb.NewEngineOptions()
 	opts.Config.WALDir = filepath.Join(tmpDir, "wal")
 	opts.InmemIndex = inmem.NewIndex(path.Base(tmpDir), sfile.SeriesFile)
+	opts.SeriesIDSets = seriesIDSets([]*tsdb.SeriesIDSet{})
 
 	sh := tsdb.NewShard(1, tmpShard, tmpWal, sfile.SeriesFile, opts)
 	if err := sh.Open(); err != nil {
@@ -1923,4 +1925,13 @@ func (itr *seriesIterator) Next() (tsdb.SeriesElem, error) {
 	s := series{name: name, tags: tags}
 	itr.keys = itr.keys[1:]
 	return s, nil
+}
+
+type seriesIDSets []*tsdb.SeriesIDSet
+
+func (a seriesIDSets) ForEach(f func(ids *tsdb.SeriesIDSet)) error {
+	for _, v := range a {
+		f(v)
+	}
+	return nil
 }

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -937,7 +937,7 @@ func (s *Store) ShardRelativePath(id uint64) (string, error) {
 
 // DeleteSeries loops through the local shards and deletes the series data for
 // the passed in series keys.
-func (s *Store) DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr, removeIndex bool) error {
+func (s *Store) DeleteSeries(database string, sources []influxql.Source, condition influxql.Expr) error {
 	// Expand regex expressions in the FROM clause.
 	a, err := s.ExpandSources(sources)
 	if err != nil {
@@ -1015,7 +1015,7 @@ func (s *Store) DeleteSeries(database string, sources []influxql.Source, conditi
 				continue
 			}
 			defer itr.Close()
-			if err := sh.DeleteSeriesRange(NewSeriesIteratorAdapter(sfile, itr), min, max, removeIndex); err != nil {
+			if err := sh.DeleteSeriesRange(NewSeriesIteratorAdapter(sfile, itr), min, max); err != nil {
 				return err
 			}
 

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -148,7 +148,7 @@ func TestStore_DeleteSeries_NonExistentDB(t *testing.T) {
 		s := MustOpenStore(index)
 		defer s.Close()
 
-		if err := s.DeleteSeries("db0", nil, nil, true); err != nil {
+		if err := s.DeleteSeries("db0", nil, nil); err != nil {
 			t.Fatal(err.Error())
 		}
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -1267,7 +1267,7 @@ func TestStore_TagValues_Auth(t *testing.T) {
 		}
 
 		if gotValues != expValues {
-			return fmt.Errorf("got %d tags, but expected %d", gotValues, expValues)
+			return fmt.Errorf("got %d values, but expected %d", gotValues, expValues)
 		}
 		return nil
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -579,7 +579,7 @@ func testStoreCardinalityTombstoning(t *testing.T, store *Store) {
 	}
 
 	for _, name := range mnames {
-		if err := store.DeleteSeries("db", []influxql.Source{&influxql.Measurement{Name: string(name)}}, nil, true); err != nil {
+		if err := store.DeleteSeries("db", []influxql.Source{&influxql.Measurement{Name: string(name)}}, nil); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1038,7 +1038,7 @@ func TestStore_Measurements_Auth(t *testing.T) {
 			return err
 		}
 
-		if err := s.DeleteSeries("db0", nil, cond, true); err != nil {
+		if err := s.DeleteSeries("db0", nil, cond); err != nil {
 			return err
 		}
 
@@ -1130,7 +1130,7 @@ func TestStore_TagKeys_Auth(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err := s.DeleteSeries("db0", nil, cond, true); err != nil {
+		if err := s.DeleteSeries("db0", nil, cond); err != nil {
 			return err
 		}
 
@@ -1233,7 +1233,7 @@ func TestStore_TagValues_Auth(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err := s.DeleteSeries("db0", nil, cond, true); err != nil {
+		if err := s.DeleteSeries("db0", nil, cond); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass

This PR addresses #9299.

This PR implements the correct `DROP`/`DELETE` semantics in both the `tsi1` and `inmem` indexes. These semantics are:

 - When deleting series data using the `DROP` keyword, all series data for all time periods is removed from both the `tsm` engine and the index.
 - When deleting series data using the `DELETE` keyword, series data is removed from the `tsm` data in the relevant shards. Further, if the deleted `tsm` data contained the only remaining occurrences of data (across _any_ shard) for a given series, then that series is also removed from the index.

As discussed in more detail in #9299, the two indexes behave differently, requiring a different implementation for each. The `inmem` index is shared across all shards, while the `tsi1` index is shard-local.

For the `inmem` shard, a compressed bitmap has been introduced to track all the series IDs present in the shard only (which are a subset of the series IDs in the `inmem` index). When a series is removed, every shard that contains that series data removes the associated series ID from its bitset. In the case of a `DELETE` command, if no shard's have the series in their bitsets, then the series is removed from the `inmem` index.

For the `tsi1` index we maintain a local bitset in each index. This makes determining if any shards contain series data more performant.

This PR also makes some improvements to testing around `DELETE`/`DROP`. It introduces a new randomised test with a custom index. Random operations on a real InfluxDB server and executed, and after each operation, Influx's series set is compared to the test's own index using `SHOW SERIES`.

During development the test identified a couple of bugs, and repro cases were put into their own tests.

