### PR TITLE
Cleanup Shard assignment/unassignment 

### DIFF
--- a/tests/server_delete_test.go
+++ b/tests/server_delete_test.go
@@ -180,6 +180,10 @@ func TestServer_Insert_Delete_1515688266259660938_same_shard(t *testing.T) {
 	// Original seed was 1515688266259660938.
 	t.Parallel()
 
+	if testing.Short() || os.Getenv("GORACE") != "" {
+		t.Skip("Skipping test in short or race mode.")
+	}
+
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
 
@@ -204,6 +208,10 @@ func TestServer_Insert_Delete_1515688266259660938_same_shard(t *testing.T) {
 func TestServer_Insert_Delete_1515688266259660938(t *testing.T) {
 	// Original seed was 1515688266259660938.
 	t.Parallel()
+
+	if testing.Short() || os.Getenv("GORACE") != "" {
+		t.Skip("Skipping test in short or race mode.")
+	}
 
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
@@ -230,6 +238,10 @@ func TestServer_Insert_Delete_1515688266259660938(t *testing.T) {
 func TestServer_Insert_Delete_1515771752164780713(t *testing.T) {
 	// Original seed was 1515771752164780713.
 	t.Parallel()
+
+	if testing.Short() || os.Getenv("GORACE") != "" {
+		t.Skip("Skipping test in short or race mode.")
+	}
 
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -61,9 +61,6 @@ type Index interface {
 
 	// To be removed w/ tsi1.
 	SetFieldName(measurement []byte, name string)
-	AssignShard(k string, shardID uint64)
-	UnassignShard(k string, shardID uint64, ts int64) error
-	RemoveShard(shardID uint64)
 
 	Type() string
 

--- a/tsdb/index/inmem/meta_test.go
+++ b/tsdb/index/inmem/meta_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/query"
@@ -208,7 +207,6 @@ func benchmarkTagSets(b *testing.B, n int, opt query.IteratorOptions) {
 	for i := 0; i < n; i++ {
 		tags := map[string]string{"tag1": "value1", "tag2": "value2"}
 		s := newSeries(uint64(i), m, fmt.Sprintf("m,tag1=value1,tag2=value2"), models.NewTags(tags))
-		s.AssignShard(0, time.Now().UnixNano())
 		m.AddSeries(s)
 	}
 

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -813,16 +813,8 @@ func (i *Index) RetainFileSet() (*FileSet, error) {
 	return fs, nil
 }
 
+// SetFieldName is a no-op on this index.
 func (i *Index) SetFieldName(measurement []byte, name string) {}
-func (i *Index) RemoveShard(shardID uint64)                   {}
-func (i *Index) AssignShard(k string, shardID uint64)         {}
 
-// UnassignShard removes the provided series key from the index. The naming of
-// this method stems from a legacy index logic that used to track which shards
-// owned which series.
-func (i *Index) UnassignShard(k string, _ uint64, ts int64) error {
-	// This can be called directly once inmem is gone.
-	return i.DropSeries(0, []byte(k), ts)
-}
-
+// Rebuild rebuilds an index. It's a no-op for this index.
 func (i *Index) Rebuild() {}

--- a/tsdb/index/tsi1/index_files.go
+++ b/tsdb/index/tsi1/index_files.go
@@ -73,11 +73,11 @@ func (p IndexFiles) buildSeriesIDSets() (seriesIDSet, tombstoneSeriesIDSet *tsdb
 
 		// Add tombstones and remove from old series existence set.
 		seriesIDSet.Diff(ts)
-		tombstoneSeriesIDSet.Merge(tombstoneSeriesIDSet, ts)
+		tombstoneSeriesIDSet.Merge(ts)
 
 		// Add new series and remove from old series tombstone set.
 		tombstoneSeriesIDSet.Diff(ss)
-		seriesIDSet.Merge(seriesIDSet, ss)
+		seriesIDSet.Merge(ss)
 	}
 
 	return seriesIDSet, tombstoneSeriesIDSet, nil

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -283,7 +283,7 @@ func (p *Partition) buildSeriesSet() error {
 		if err != nil {
 			return err
 		}
-		p.seriesIDSet.Merge(p.seriesIDSet, ss)
+		p.seriesIDSet.Merge(ss)
 	}
 	return nil
 }

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -336,7 +336,7 @@ func (s *Shard) Open() error {
 
 		return nil
 	}(); err != nil {
-		s.close(true)
+		s.close()
 		return NewShardError(s.id, err)
 	}
 
@@ -352,23 +352,12 @@ func (s *Shard) Open() error {
 func (s *Shard) Close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.close(true)
-}
-
-// CloseFast closes the shard without cleaning up the shard ID or any of the
-// shard's series keys from the index it belongs to.
-//
-// CloseFast can be called when the entire index is being removed, e.g., when
-// the database the shard belongs to is being dropped.
-func (s *Shard) CloseFast() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.close(false)
+	return s.close()
 }
 
 // close closes the shard an removes reference to the shard from associated
 // indexes, unless clean is false.
-func (s *Shard) close(_ bool) error {
+func (s *Shard) close() error {
 	if s._engine == nil {
 		return nil
 	}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -368,7 +368,7 @@ func (s *Shard) CloseFast() error {
 
 // close closes the shard an removes reference to the shard from associated
 // indexes, unless clean is false.
-func (s *Shard) close(clean bool) error {
+func (s *Shard) close(_ bool) error {
 	if s._engine == nil {
 		return nil
 	}
@@ -378,11 +378,6 @@ func (s *Shard) close(clean bool) error {
 	case <-s.closing:
 	default:
 		close(s.closing)
-	}
-
-	if clean {
-		// Don't leak our shard ID and series keys in the index
-		s.index.RemoveShard(s.id)
 	}
 
 	err := s._engine.Close()
@@ -434,7 +429,6 @@ func (s *Shard) UnloadIndex() {
 	if err := s.ready(); err != nil {
 		return
 	}
-	s.index.RemoveShard(s.id)
 }
 
 // Index returns a reference to the underlying index. It returns an error if

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -335,7 +335,7 @@ func (s *Store) Close() error {
 
 	// Close all the shards in parallel.
 	if err := s.walkShards(s.shardsSlice(), func(sh *Shard) error {
-		return sh.CloseFast()
+		return sh.Close()
 	}); err != nil {
 		return err
 	}
@@ -576,7 +576,7 @@ func (s *Store) DeleteDatabase(name string) error {
 			return nil
 		}
 
-		return sh.CloseFast()
+		return sh.Close()
 	}); err != nil {
 		return err
 	}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1079,9 +1079,6 @@ func (s *Store) MeasurementNames(auth query.Authorizer, database string, cond in
 		return nil, nil
 	}
 
-	release := sfile.Retain()
-	defer release()
-
 	// Build indexset.
 	is := IndexSet{Indexes: make([]Index, 0, len(shards)), SeriesFile: sfile}
 	for _, sh := range shards {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [ ] Tests pass

This PR relies on #9315. I will rebase this, once that is merged.


This PR cleans up the `inmem` index by removing all methods and data structures associated with shard assignment/unassignment.

Now that each shard-local index is maintaining a bitset of series ids, tracking the series present in the local shard's tsm engine, there is no need to track shards in the `inmem` index.

It also removes the `Shard.CloseFast` method, as all shard closes should be "fast".

