### PR TITLE
Remove series when shard rolls over

### DIFF
--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -59,6 +59,13 @@ func (s *SeriesIDSet) RemoveNoLock(id uint64) {
 	s.bitmap.Remove(uint32(id))
 }
 
+// Cardinality returns the cardinality of the SeriesIDSet.
+func (s *SeriesIDSet) Cardinality() uint64 {
+	s.RLock()
+	defer s.RUnlock()
+	return s.bitmap.GetCardinality()
+}
+
 // Merge merged the contents of others into s. The caller does not need to
 // provide s as an argument, and the contents of s will always be present in s
 // after Merge returns.
@@ -96,7 +103,8 @@ func (s *SeriesIDSet) Equals(other *SeriesIDSet) bool {
 	return s.bitmap.Equals(other.bitmap)
 }
 
-// AndNot returns the set of elements that only exist in s.
+// AndNot returns a new SeriesIDSet containing elements that were present in s,
+// but not present in other.
 func (s *SeriesIDSet) AndNot(other *SeriesIDSet) *SeriesIDSet {
 	s.RLock()
 	defer s.RUnlock()
@@ -122,7 +130,7 @@ func (s *SeriesIDSet) String() string {
 	return s.bitmap.String()
 }
 
-// Diff deletes any bits set in other.
+// Diff removes from s any elements also present in other.
 func (s *SeriesIDSet) Diff(other *SeriesIDSet) {
 	other.RLock()
 	defer other.RUnlock()

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -411,15 +411,6 @@ func (s *Shard) LastModified() time.Time {
 	return engine.LastModified()
 }
 
-// UnloadIndex removes all references to this shard from the DatabaseIndex
-func (s *Shard) UnloadIndex() {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if err := s.ready(); err != nil {
-		return
-	}
-}
-
 // Index returns a reference to the underlying index. It returns an error if
 // the index is nil.
 func (s *Shard) Index() (Index, error) {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

This PR builds on #9315  and #9316; they should be merged first.

The only commit directly relevant to this PR is https://github.com/influxdata/influxdb/commit/2bb0b79b0da6c8e4411b49b95711eb124d20462c.

Series should only be removed from the series file when they're no
longer present in any shard. This commit ensures that during a shard
rollover, the series local to the shard are checked against all other
series in the database.

Series that are no longer present in any other shards' bitsets, are then
marked as deleted in the series file.