### PR TITLE
Ensure no double Rlocking occurs in IndexSet

### DIFF
--- a/tests/server_delete_test.go
+++ b/tests/server_delete_test.go
@@ -180,6 +180,10 @@ func TestServer_Insert_Delete_1515688266259660938_same_shard(t *testing.T) {
 	// Original seed was 1515688266259660938.
 	t.Parallel()
 
+	if testing.Short() || os.Getenv("GORACE") != "" {
+		t.Skip("Skipping test in short or race mode.")
+	}
+
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
 
@@ -204,6 +208,10 @@ func TestServer_Insert_Delete_1515688266259660938_same_shard(t *testing.T) {
 func TestServer_Insert_Delete_1515688266259660938(t *testing.T) {
 	// Original seed was 1515688266259660938.
 	t.Parallel()
+
+	if testing.Short() || os.Getenv("GORACE") != "" {
+		t.Skip("Skipping test in short or race mode.")
+	}
 
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()
@@ -230,6 +238,10 @@ func TestServer_Insert_Delete_1515688266259660938(t *testing.T) {
 func TestServer_Insert_Delete_1515771752164780713(t *testing.T) {
 	// Original seed was 1515771752164780713.
 	t.Parallel()
+
+	if testing.Short() || os.Getenv("GORACE") != "" {
+		t.Skip("Skipping test in short or race mode.")
+	}
 
 	s := OpenDefaultServer(NewConfig())
 	defer s.Close()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1079,9 +1079,6 @@ func (s *Store) MeasurementNames(auth query.Authorizer, database string, cond in
 		return nil, nil
 	}
 
-	release := sfile.Retain()
-	defer release()
-
 	// Build indexset.
 	is := IndexSet{Indexes: make([]Index, 0, len(shards)), SeriesFile: sfile}
 	for _, sh := range shards {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

#9308 prevents the series file from being closed when in use.

However, because the reference counting was implemented via
mutexes, it was possible to double `RLock` the series file mutex. This
allows a `Lock` to arrive in-between the two `RLock`s, (such as when
deleting the database), causing deadlock.

This PR addresses this by ensuring that from within `IndexSet`
methods, when calling other `IndexSet` methods, that they're all
unexported, and that those unexported methods never take a lock on the
series file.

Keeping series file locking in exported `IndexSet` methods only, allows
one to see any future races more easily.
