### PR TITLE
Use bitsets to calculate series cardinality

### DIFF
--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -634,7 +634,7 @@ func testStoreCardinalityTombstoning(t *testing.T, store *Store) {
 	}
 
 	// Delete all the series for each measurement.
-	mnames, err := store.MeasurementNames(query.OpenAuthorizer, "db", nil)
+	mnames, err := store.MeasurementNames(nil, "db", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -652,9 +652,8 @@ func testStoreCardinalityTombstoning(t *testing.T, store *Store) {
 	}
 
 	// Estimated cardinality should be well within 10 of the actual cardinality.
-	// TODO(edd): this epsilon is arbitrary. How can I make it better?
-	if got, exp := cardinality, int64(10); got > exp {
-		t.Errorf("series cardinality out by %v (expected within %v), estimation was: %d", got, exp, cardinality)
+	if got, exp := int(cardinality), 10; got > exp {
+		t.Errorf("series cardinality was %v (expected within %v), expected was: %d", got, exp, 0)
 	}
 
 	// Since all the series have been deleted, all the measurements should have
@@ -665,14 +664,12 @@ func testStoreCardinalityTombstoning(t *testing.T, store *Store) {
 
 	// Estimated cardinality should be well within 2 of the actual cardinality.
 	// TODO(edd): this is totally arbitrary. How can I make it better?
-	if got, exp := cardinality, int64(2); got > exp {
-		t.Errorf("measurement cardinality out by %v (expected within %v), estimation was: %d", got, exp, cardinality)
+	if got, exp := int(cardinality), 2; got > exp {
+		t.Errorf("measurement cardinality was %v (expected within %v), expected was: %d", got, exp, 0)
 	}
 }
 
 func TestStore_Cardinality_Tombstoning(t *testing.T) {
-	t.Skip("TODO(benbjohnson): Fix once series file moved to DB")
-
 	t.Parallel()
 
 	if testing.Short() || os.Getenv("GORACE") != "" || os.Getenv("APPVEYOR") != "" {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

Prior to this, the series file was being used (more precisely, the series file index) to determine series cardinality in a database. This isn't accurate if a series file index has not been compacted for a while.

We now switch to using the bitsets of series ids that we have to maintain within each shard to determine cardinality.

The `_internal` database requests these cardinalities every 10 seconds, so I was concerned about performance of unioning these bitsets constantly, but upon benchmarking it appears that even unioning 1B spread across 100 shards would take only a millisecond or so on a laptop.