### PR TITLE
Speed up deletes for tsi

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -51,6 +51,7 @@ var (
 	// Static objects to prevent small allocs.
 	timeBytes              = []byte("time")
 	keyFieldSeparatorBytes = []byte(keyFieldSeparator)
+	emptyBytes             = []byte{}
 )
 
 var (
@@ -1350,7 +1351,7 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 
 			// We've found a matching key, cross it out so we do not remove it from the index.
 			if j < len(seriesKeys) && cmp == 0 {
-				seriesKeys[j] = nil
+				seriesKeys[j] = emptyBytes
 				j++
 			}
 		}

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1364,19 +1364,16 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 	if len(seriesKeys) > 0 {
 		buf := make([]byte, 1024) // For use when accessing series file.
 		ids := tsdb.NewSeriesIDSet()
+		measurements := make(map[string]struct{}, 1)
+
 		for _, k := range seriesKeys {
 			if len(k) == 0 {
 				continue // This key was wiped because it shouldn't be removed from index.
 			}
 
-			name, tags := models.ParseKey(k)
-			sid := e.sfile.SeriesID([]byte(name), tags, buf)
+			name, tags := models.ParseKeyBytes(k)
+			sid := e.sfile.SeriesID(name, tags, buf)
 			if sid == 0 {
-				continue
-			}
-
-			// This key was crossed out earlier, skip it
-			if k == nil {
 				continue
 			}
 
@@ -1398,14 +1395,20 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 				continue
 			}
 
+			measurements[string(name)] = struct{}{}
 			// Remove the series from the local index.
-			if err := e.index.DropSeries(sid, k, ts); err != nil {
+			if err := e.index.DropSeries(sid, k, false); err != nil {
 				return err
 			}
 
 			// Add the id to the set of delete ids.
 			ids.Add(sid)
+		}
 
+		for k := range measurements {
+			if err := e.index.DropMeasurementIfSeriesNotExist([]byte(k)); err != nil {
+				return err
+			}
 		}
 
 		// Remove any series IDs for our set that still exist in other shards.

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -32,7 +32,8 @@ type Index interface {
 	InitializeSeries(key, name []byte, tags models.Tags) error
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
 	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
-	DropSeries(seriesID uint64, key []byte, ts int64) error
+	DropSeries(seriesID uint64, key []byte, cascade bool) error
+	DropMeasurementIfSeriesNotExist(name []byte) error
 
 	MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error)
 	SeriesN() int64

--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -98,7 +98,7 @@ func TestIndex_MeasurementExists(t *testing.T) {
 	}
 
 	// Delete one series.
-	if err := idx.DropSeries(sid, models.MakeKey(name, tags), 0); err != nil {
+	if err := idx.DropSeries(sid, models.MakeKey(name, tags), true); err != nil {
 		t.Fatal(err)
 	}
 
@@ -117,7 +117,7 @@ func TestIndex_MeasurementExists(t *testing.T) {
 	if sid == 0 {
 		t.Fatalf("got 0 series id for %s/%v", name, tags)
 	}
-	if err := idx.DropSeries(sid, models.MakeKey(name, tags), 0); err != nil {
+	if err := idx.DropSeries(sid, models.MakeKey(name, tags), true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -605,9 +605,7 @@ func (i *Partition) createSeriesListIfNotExists(names [][]byte, tagsSlice []mode
 	return i.CheckLogFile()
 }
 
-func (i *Partition) DropSeries(seriesID uint64, ts int64) error {
-	// TODO: Use ts.
-
+func (i *Partition) DropSeries(seriesID uint64) error {
 	// Delete series from index.
 	if err := i.activeLogFile.DeleteSeriesID(seriesID); err != nil {
 		return err

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -36,8 +36,9 @@ func (s *SeriesIDSet) AddNoLock(id uint64) {
 // Contains returns true if the id exists in the set.
 func (s *SeriesIDSet) Contains(id uint64) bool {
 	s.RLock()
-	defer s.RUnlock()
-	return s.ContainsNoLock(id)
+	x := s.ContainsNoLock(id)
+	s.RUnlock()
+	return x
 }
 
 // ContainsNoLock returns true if the id exists in the set. ContainsNoLock is


### PR DESCRIPTION
This speeds up deletes by separating the series deletes from the measurement delete.  There was a lot of time spent checking if a measurement still had any series.  Since series are delete one at a time, we ended up checking the measurement N times as well.

Instead, this now deletes each series and keeps track of the measurement involved and drops those measurements (if possible), at the end.  So instead of N (drop series) + N (measurement checks), it is now N (drop series) + 1 (measurement checks)

Dropping 32m series improved from 75m to 12m.  And dropping 100m took 62m.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)