### PR TITLE
Unify approach to short-circuit auth

### DIFF
--- a/query/query_executor.go
+++ b/query/query_executor.go
@@ -106,6 +106,14 @@ func (a openAuthorizer) AuthorizeSeriesWrite(database string, measurement []byte
 // AuthorizeSeriesRead allows any query to execute.
 func (a openAuthorizer) AuthorizeQuery(_ string, _ *influxql.Query) error { return nil }
 
+// AuthorizerIsOpen returns true if the provided Authorizer is guaranteed to
+// authorize anything. A nil Authorizer returns true for this function, and this
+// function should be preferred over directly checking if an Authorizer is nil
+// or not.
+func AuthorizerIsOpen(a Authorizer) bool {
+	return a == nil || a == OpenAuthorizer
+}
+
 // ExecutionOptions contains the options for executing a query.
 type ExecutionOptions struct {
 	// The database the query is running against.

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -1289,7 +1289,7 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxq
 		}
 		tagMatch = false
 		// Authorization must be explicitly granted when an authorizer is present.
-		authorized = auth == nil
+		authorized = query.AuthorizerIsOpen(auth)
 
 		vitr, err := is.tagValueIterator(me, []byte(key))
 		if err != nil {
@@ -1311,7 +1311,7 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxq
 				}
 
 				tagMatch = true
-				if auth == nil {
+				if query.AuthorizerIsOpen(auth) {
 					break
 				}
 
@@ -1383,7 +1383,7 @@ func (is IndexSet) measurementNamesByTagFilter(auth query.Authorizer, op influxq
 // measurementAuthorizedSeries determines if the measurement contains a series
 // that is authorized to be read.
 func (is IndexSet) measurementAuthorizedSeries(auth query.Authorizer, name []byte) bool {
-	if auth == nil {
+	if query.AuthorizerIsOpen(auth) {
 		return true
 	}
 
@@ -1529,7 +1529,7 @@ func (is IndexSet) TagKeyHasAuthorizedSeries(auth query.Authorizer, name, tagKey
 			return false, nil
 		}
 
-		if auth == nil || auth == query.OpenAuthorizer {
+		if query.AuthorizerIsOpen(auth) {
 			return true, nil
 		}
 
@@ -2204,7 +2204,7 @@ func (is IndexSet) MeasurementTagKeyValuesByExpr(auth query.Authorizer, name []b
 			defer vitr.Close()
 
 			// If no authorizer present then return all values.
-			if auth == nil {
+			if query.AuthorizerIsOpen(auth) {
 				for {
 					val, err := vitr.Next()
 					if err != nil {

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -356,7 +356,7 @@ func (i *Index) TagKeyHasAuthorizedSeries(auth query.Authorizer, name []byte, ke
 	// and tag key.
 	var authorized bool
 	mm.SeriesByTagKeyValue(key).Range(func(_ string, sIDs seriesIDs) bool {
-		if auth == nil || auth == query.OpenAuthorizer {
+		if query.AuthorizerIsOpen(auth) {
 			authorized = true
 			return false
 		}
@@ -631,7 +631,7 @@ func (i *Index) measurementNamesByTagFilters(auth query.Authorizer, filter *TagF
 
 		tagMatch = false
 		// Authorization must be explicitly granted when an authorizer is present.
-		authorized = auth == nil
+		authorized = query.AuthorizerIsOpen(auth)
 
 		// Check the tag values belonging to the tag key for equivalence to the
 		// tag value being filtered on.
@@ -641,7 +641,7 @@ func (i *Index) measurementNamesByTagFilters(auth query.Authorizer, filter *TagF
 			}
 
 			tagMatch = true
-			if auth == nil {
+			if query.AuthorizerIsOpen(auth) {
 				return false // No need to continue checking series, there is a match.
 			}
 

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -68,7 +68,7 @@ func (m *measurement) Authorized(auth query.Authorizer) bool {
 			continue
 		}
 
-		if auth == nil || auth.AuthorizeSeriesRead(m.Database, m.NameBytes, s.Tags) {
+		if query.AuthorizerIsOpen(auth) || auth.AuthorizeSeriesRead(m.Database, m.NameBytes, s.Tags) {
 			return true
 		}
 	}
@@ -1619,7 +1619,7 @@ func (m *measurement) TagValues(auth query.Authorizer, key string) []string {
 	values := make([]string, 0, m.seriesByTagKeyValue[key].Cardinality())
 
 	m.seriesByTagKeyValue[key].RangeAll(func(k string, a seriesIDs) {
-		if auth == nil {
+		if query.AuthorizerIsOpen(auth) {
 			values = append(values, k)
 		} else {
 			for _, sid := range a {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass

We were seeing problems with `SHOW MEASUREMENTS` being slow. I inserted 20 measurements with a couple of million series and was seeing `SHOW MEASUREMENTS` taking `~600ms`. A torch graph showed we were diving into iterators that get all series and sort them for a measurement.

In the end it turned out we were not short-circuiting the FGA auth check due to a missed check on the `auth` variable. 

I have unified that approach—methods that take an `auth` should now just always call `query.AuthorizerIsOpen` to determine if an authorizer can be short-circuited.

The new time for `SHOW MEASUREMENTS` is `~800 µs`, which in this case is 600x faster 😂 

It also shows that for a couple of million series we seems to have a fixed cost of `600ms` to initialise a series id iterator. We should investigate that.