### PR TITLE
Fix deadlock in DeleteSeries

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1032,14 +1032,14 @@ func (s *Store) DeleteSeries(database string, sources []influxql.Source, conditi
 	}
 
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	sfile := s.sfiles[database]
 	if sfile == nil {
+		s.mu.RUnlock()
 		// No series file means nothing has been written to this DB and thus nothing to delete.
 		return nil
 	}
 	shards := s.filterShards(byDatabase(database))
+	s.mu.RUnlock()
 
 	// Limit to 1 delete for each shard since expanding the measurement into the list
 	// of series keys can be very memory intensive if run concurrently.


### PR DESCRIPTION
The Store.Delete series held an RLock while deleting from each shard.
While deleting, the Engine uses shardSet to see if a series is fully
deleted.  The shardSet.ForEach also takes and RLock.  If a Lock is
requested between these two calls, a deadlock occurs.

To fix, we don't need to hold an RLock for the duration of the delete
in the store as each Shard handles concurrency itself and we have a
snapshot of the shards we need to access.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
