### PR TITLE
Use full 32bits for series IDs

### DIFF
--- a/tsdb/index/tsi1/index_test.go
+++ b/tsdb/index/tsi1/index_test.go
@@ -296,7 +296,7 @@ func TestIndex_DiskSizeBytes(t *testing.T) {
 
 	// Verify on disk size is the same in each stage.
 	// Each series stores flag(1) + series(uvarint(2)) + len(name)(1) + len(key)(1) + len(value)(1) + checksum(4).
-	expSize := int64(4 * 10)
+	expSize := int64(4 * 9)
 
 	// Each MANIFEST file is 419 bytes and there are tsi1.DefaultPartitionN of them
 	expSize += int64(tsi1.DefaultPartitionN * 419)

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -215,7 +215,7 @@ func (f *SeriesFile) SeriesIDIterator() SeriesIDIterator {
 }
 
 func (f *SeriesFile) SeriesIDPartitionID(id uint64) int {
-	return int(id & 0xFF)
+	return int((id - 1) % SeriesFilePartitionN)
 }
 
 func (f *SeriesFile) SeriesIDPartition(id uint64) *SeriesPartition {


### PR DESCRIPTION
This reworks the series ID allocation to prevent an overflow issue.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)