### PR TITLE
Fix MeasurementHasSeries returning incorrect value

### DIFF
--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -224,14 +224,15 @@ func (f *IndexFile) MeasurementHasSeries(ss *tsdb.SeriesIDSet, name []byte) (ok 
 		return false
 	}
 
+	var exists bool
 	e.ForEachSeriesID(func(id uint64) error {
 		if ss.Contains(id) {
-			ok = true
+			exists = true
 			return errors.New("done")
 		}
 		return nil
 	})
-	return ok
+	return exists
 }
 
 // TagValueIterator returns a value iterator for a tag key and a flag

--- a/tsdb/index/tsi1/index_file_test.go
+++ b/tsdb/index/tsi1/index_file_test.go
@@ -49,6 +49,26 @@ func TestGenerateIndexFile(t *testing.T) {
 	}
 }
 
+// Ensure a MeasurementHashSeries returns false when all series are tombstoned.
+func TestIndexFile_MeasurementHasSeries_Tombstoned(t *testing.T) {
+	sfile := MustOpenSeriesFile()
+	defer sfile.Close()
+
+	f, err := CreateIndexFile(sfile.SeriesFile, []Series{
+		{Name: []byte("cpu"), Tags: models.NewTags(map[string]string{"region": "east"})},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate all series are tombstoned
+	ss := tsdb.NewSeriesIDSet()
+
+	if f.MeasurementHasSeries(ss, []byte("cpu")) {
+		t.Fatalf("MeasurementHasSeries got true, exp false")
+	}
+}
+
 func BenchmarkIndexFile_TagValueSeries(b *testing.B) {
 	b.Run("M=1,K=2,V=3", func(b *testing.B) {
 		sfile := MustOpenSeriesFile()


### PR DESCRIPTION
If all the series in a measurement were tombstones, MeasurementHasSeries
would return true because the ok var was re-used from a prior check
earlier in the func.  This caused it to be true all the time unless
the measurment was actually tombstoned.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)