### PR TITLE
TSI/SeriesFile Compaction Disabling

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1206,6 +1206,11 @@ func (e *Engine) DeleteSeriesRange(itr tsdb.SeriesIterator, min, max int64) erro
 			// filling up.
 			e.disableLevelCompactions(true)
 			defer e.enableLevelCompactions(true)
+
+			e.sfile.DisableCompactions()
+			defer e.sfile.EnableCompactions()
+			e.sfile.Wait()
+
 			disableOnce = true
 		}
 

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -168,7 +168,6 @@ func (i *Index) Open() error {
 	for j := 0; j < len(i.partitions); j++ {
 		p := NewPartition(i.sfile, filepath.Join(i.path, fmt.Sprint(j)))
 		p.Database = i.database
-		p.compactionsDisabled = i.disableCompactions
 		p.logger = i.logger.With(zap.String("partition", fmt.Sprint(j+1)))
 		i.partitions[j] = p
 	}
@@ -214,6 +213,18 @@ func (i *Index) Compact() {
 	defer i.mu.Unlock()
 	for _, p := range i.partitions {
 		p.Compact()
+	}
+}
+
+func (i *Index) EnableCompactions() {
+	for _, p := range i.partitions {
+		p.EnableCompactions()
+	}
+}
+
+func (i *Index) DisableCompactions() {
+	for _, p := range i.partitions {
+		p.DisableCompactions()
 	}
 }
 

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -111,6 +111,26 @@ func (f *SeriesFile) Retain() func() {
 	return nop
 }
 
+// EnableCompactions allows compactions to run.
+func (f *SeriesFile) EnableCompactions() {
+	for _, p := range f.partitions {
+		p.EnableCompactions()
+	}
+}
+
+// DisableCompactions prevents new compactions from running.
+func (f *SeriesFile) DisableCompactions() {
+	for _, p := range f.partitions {
+		p.DisableCompactions()
+	}
+}
+
+// Wait waits for all Retains to be released.
+func (f *SeriesFile) Wait() {
+	f.refs.Lock()
+	defer f.refs.Unlock()
+}
+
 // CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist.
 // The returned ids list returns values for new series and zero for existing series.
 func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags, buf []byte) (ids []uint64, err error) {


### PR DESCRIPTION
This adds the capability to disable TSI and SeriesFile compactions.  Disabling them prevents new compactions from starting, but does not end any in-progress.  This fixes deleting w/ TSI where a TSI/SeriesFile compaction would run while deleting causing deleted data to re-appear.

This also disables the compactions (like TSM) when deleting series.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)