### PR TITLE
escape non-printing characters for columnar output on cli

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -975,7 +975,7 @@ func (c *CommandLine) formatResults(result client.Result, separator string, supp
 			}
 
 			for _, vv := range v {
-				values = append(values, interfaceToString(vv))
+				values = append(values, interfaceToString(vv, c.Format == "column"))
 			}
 			rows = append(rows, strings.Join(values, separator))
 		}
@@ -983,7 +983,7 @@ func (c *CommandLine) formatResults(result client.Result, separator string, supp
 	return rows
 }
 
-func interfaceToString(v interface{}) string {
+func interfaceToString(v interface{}, escapeString bool) string {
 	switch t := v.(type) {
 	case nil:
 		return ""
@@ -994,7 +994,11 @@ func interfaceToString(v interface{}) string {
 	case float32, float64:
 		return fmt.Sprintf("%v", t)
 	default:
-		return fmt.Sprintf("%v", t)
+		if !escapeString {
+			return fmt.Sprintf("%v", t)
+		}
+		v := fmt.Sprintf("%q", t)
+		return v[1 : len(v)-1]
 	}
 }
 


### PR DESCRIPTION
This causes the influx CLI utility to escape non-printable characters when using column formatting.
My use case is that I have fields containing short binary data (binary encoded UUIDs), and I frequently run commands like `select * from foo`. I could explicitly list the columns I want to omit the binary ones, but this is cumbersome. Also seeing the escaped binary is sometimes useful for correlating data across rows.

###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [X] Tests pass
- [ ] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)