### PR TITLE
fix nil err panic in httpd WriteResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [#9327](https://github.com/influxdata/influxdb/pull/9327): wal: update lastWriteTime behavior
 - [#9290](https://github.com/influxdata/influxdb/issues/9290): Fix regression to allow binary operations on literals.
 - [#9342](https://github.com/influxdata/influxdb/pull/9342): Fix data races in tcp.Mux and tcp.listener
+- [#9353](https://github.com/influxdata/influxdb/pull/9353): Fix panic in msgpack httpd WriteResponse error handler.
 
 ## v1.4.3 [unreleased]
 

--- a/services/httpd/response_writer.go
+++ b/services/httpd/response_writer.go
@@ -208,7 +208,7 @@ func (f *msgpackFormatter) WriteResponse(resp Response) (n int, err error) {
 	enc.WriteMapHeader(1)
 	if resp.Err != nil {
 		enc.WriteString("error")
-		enc.WriteString(err.Error())
+		enc.WriteString(resp.Err.Error())
 		return 0, nil
 	} else {
 		enc.WriteString("results")

--- a/services/httpd/response_writer_test.go
+++ b/services/httpd/response_writer_test.go
@@ -129,3 +129,28 @@ func TestResponseWriter_MessagePack(t *testing.T) {
 		t.Fatalf("unexpected output: %s != %s", have, want)
 	}
 }
+
+func TestResponseWriter_MessagePack_Error(t *testing.T) {
+	header := make(http.Header)
+	header.Set("Accept", "application/x-msgpack")
+	r := &http.Request{
+		Header: header,
+		URL:    &url.URL{},
+	}
+	w := httptest.NewRecorder()
+
+	writer := httpd.NewResponseWriter(w, r)
+	writer.WriteResponse(httpd.Response{
+		Err: fmt.Errorf("test error"),
+	})
+
+	reader := msgp.NewReader(w.Body)
+	var buf bytes.Buffer
+	if _, err := reader.WriteToJSON(&buf); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	want := fmt.Sprintf(`{"error":"test error"}`)
+	if have := strings.TrimSpace(buf.String()); have != want {
+		t.Fatalf("unexpected output: %s != %s", have, want)
+	}
+}


### PR DESCRIPTION
Got the below panic from my client when it tried to do an invalid query. The problem and fix is obvious, so putting up a PR.
```
[panic:runtime error: invalid memory address or nil pointer dereference] goroutine 25614 [running]:
runtime/debug.Stack(0xc42068b420, 0xc420108600, 0xbe91793e8d120376)
	/usr/lib/go/src/runtime/debug/stack.go:24 +0xa7
github.com/influxdata/influxdb/services/httpd.(*Handler).recovery.func1.1(0xc42068b420, 0xc420108600, 0xbe91793e8d120376, 0x55582cbe9a, 0x12f00c0, 0xc4201f8a50, 0x12a57a0, 0xc421ab27e0)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:1537 +0xcd
panic(0xccd700, 0x12dc3b0)
	/usr/lib/go/src/runtime/panic.go:491 +0x283
github.com/influxdata/influxdb/services/httpd.(*msgpackFormatter).WriteResponse(0xc421b214e0, 0x0, 0x0, 0x0, 0x12945a0, 0xc421b21580, 0x0, 0x0, 0x0)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/response_writer.go:211 +0x979
github.com/influxdata/influxdb/services/httpd.(*responseWriter).WriteResponse(0xc42068b460, 0x0, 0x0, 0x0, 0x12945a0, 0xc421b21580, 0x52, 0x52, 0x3d)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/response_writer.go:59 +0x5a
github.com/influxdata/influxdb/services/httpd.(*Handler).httpError(0xc4201f8a50, 0x7f94723b5b68, 0xc42068b460, 0xc420428ae0, 0x52, 0x190)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:1265 +0x1bd
github.com/influxdata/influxdb/services/httpd.(*Handler).serveQuery(0xc4201f8a50, 0x7f94723b5b68, 0xc42068b460, 0xc420108600, 0x0, 0x0)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:387 +0x1bd4
github.com/influxdata/influxdb/services/httpd.(*Handler).(github.com/influxdata/influxdb/services/httpd.serveQuery)-fm(0x7f94723b5b68, 0xc42068b460, 0xc420108600, 0x0, 0x0)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:136 +0x5c
github.com/influxdata/influxdb/services/httpd.authenticate.func1(0x7f94723b5b68, 0xc42068b460, 0xc420108600)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:1337 +0x7d2
net/http.HandlerFunc.ServeHTTP(0xc4202e7b40, 0x7f94723b5b68, 0xc42068b460, 0xc420108600)
	/usr/lib/go/src/net/http/server.go:1918 +0x44
github.com/influxdata/influxdb/services/httpd.(*Handler).responseWriter.func1(0x12a2ca0, 0xc421c44e60, 0xc420108600)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:1514 +0xab
net/http.HandlerFunc.ServeHTTP(0xc4202e7b60, 0x12a2ca0, 0xc421c44e60, 0xc420108600)
	/usr/lib/go/src/net/http/server.go:1918 +0x44
github.com/influxdata/influxdb/services/httpd.gzipFilter.func1(0x12a2d20, 0xc42068b440, 0xc420108600)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/gzip.go:39 +0x215
net/http.HandlerFunc.ServeHTTP(0xc4202e7b80, 0x12a2d20, 0xc42068b440, 0xc420108600)
	/usr/lib/go/src/net/http/server.go:1918 +0x44
github.com/influxdata/influxdb/services/httpd.cors.func1(0x12a2d20, 0xc42068b440, 0xc420108600)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:1459 +0x102
net/http.HandlerFunc.ServeHTTP(0xc4202e7ba0, 0x12a2d20, 0xc42068b440, 0xc420108600)
	/usr/lib/go/src/net/http/server.go:1918 +0x44
github.com/influxdata/influxdb/services/httpd.requestID.func1(0x12a2d20, 0xc42068b440, 0xc420108600)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:1490 +0x179
net/http.HandlerFunc.ServeHTTP(0xc4202e7bc0, 0x12a2d20, 0xc42068b440, 0xc420108600)
	/usr/lib/go/src/net/http/server.go:1918 +0x44
github.com/influxdata/influxdb/services/httpd.(*Handler).logging.func1(0x12a2d20, 0xc42068b420, 0xc420108600)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:1498 +0xe1
net/http.HandlerFunc.ServeHTTP(0xc4202e7be0, 0x12a2d20, 0xc42068b420, 0xc420108600)
	/usr/lib/go/src/net/http/server.go:1918 +0x44
github.com/influxdata/influxdb/services/httpd.(*Handler).recovery.func1(0x12a57a0, 0xc421ab27e0, 0xc420108600)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:1551 +0x14c
net/http.HandlerFunc.ServeHTTP(0xc4202e7c00, 0x12a57a0, 0xc421ab27e0, 0xc420108600)
	/usr/lib/go/src/net/http/server.go:1918 +0x44
github.com/bmizerany/pat.(*PatternServeMux).ServeHTTP(0xc4202e7960, 0x12a57a0, 0xc421ab27e0, 0xc420108600)
	/tmp/.gdm_26020/src/github.com/bmizerany/pat/mux.go:117 +0x15b
github.com/influxdata/influxdb/services/httpd.(*Handler).ServeHTTP(0xc4201f8a50, 0x12a57a0, 0xc421ab27e0, 0xc420108600)
	/tmp/.gdm_32513/src/github.com/influxdata/influxdb/services/httpd/handler.go:288 +0x24d
net/http.serverHandler.ServeHTTP(0xc420c90270, 0x12a57a0, 0xc421ab27e0, 0xc420108600)
	/usr/lib/go/src/net/http/server.go:2619 +0xb4
net/http.(*conn).serve(0xc4225a4280, 0x12a6de0, 0xc421920740)
	/usr/lib/go/src/net/http/server.go:1801 +0x71d
created by net/http.(*Server).Serve
	/usr/lib/go/src/net/http/server.go:2720 +0x288
```
###### Required for all non-trivial PRs
- [X] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)