### PR TITLE
Add recent server logs to `/pprof/all` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#9218](https://github.com/influxdata/influxdb/pull/9218): Add Prometheus `/metrics` endpoint.
 - [#9213](https://github.com/influxdata/influxdb/pull/9213): Add ability to generate shard digests.
 - [#9184](https://github.com/influxdata/influxdb/pull/9184): Allow setting the node id in the influx cli program.
+- [#9366](https://github.com/influxdata/influxdb/pull/9366): Include server logs in `all` profile archive.
 
 ### Bugfixes
 

--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -62,10 +62,10 @@ type Main struct {
 // NewMain return a new instance of Main.
 func NewMain() *Main {
 	return &Main{
-		Logger: logger.New(os.Stderr),
+		Logger: logger.New(logger.Stderr),
 		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Stdout: logger.Stdout,
+		Stderr: logger.Stderr,
 	}
 }
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/influxdata/influxdb/logger"
 	"go.uber.org/zap"
 )
 
@@ -56,8 +57,8 @@ func NewCommand() *Command {
 		closing: make(chan struct{}),
 		Closed:  make(chan struct{}),
 		Stdin:   os.Stdin,
-		Stdout:  os.Stdout,
-		Stderr:  os.Stderr,
+		Stdout:  logger.Stdout,
+		Stderr:  logger.Stderr,
 		Logger:  zap.NewNop(),
 	}
 }

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -26,17 +26,16 @@ import (
 	"github.com/influxdata/influxdb/services/precreator"
 	"github.com/influxdata/influxdb/services/retention"
 	"github.com/influxdata/influxdb/services/snapshotter"
+	"github.com/influxdata/influxdb/services/storage"
 	"github.com/influxdata/influxdb/services/subscriber"
 	"github.com/influxdata/influxdb/services/udp"
 	"github.com/influxdata/influxdb/tcp"
 	"github.com/influxdata/influxdb/tsdb"
-	client "github.com/influxdata/usage-client/v1"
-	"go.uber.org/zap"
-
-	// Initialize the engine & index packages
-	"github.com/influxdata/influxdb/services/storage"
+	// Import engine and index.
 	_ "github.com/influxdata/influxdb/tsdb/engine"
 	_ "github.com/influxdata/influxdb/tsdb/index"
+	client "github.com/influxdata/usage-client/v1"
+	"go.uber.org/zap"
 )
 
 var startTime time.Time

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,12 +2,36 @@ package logger
 
 import (
 	"io"
+	"os"
 	"time"
 
+	"github.com/influxdata/influxdb/pkg/bytesutil"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
+// LoggingBuffer maintains a globally available buffer of the most recent logs.
+// It is injected into the server within the influxd main package, and is
+// currently accessed by the custom profiling archive generated using the
+// /debug/pprof/all URL.
+var LoggingBuffer *bytesutil.CircularBuffer
+
+// Stderr should be used whenever any package is logging to os.Stderr. This
+// package ensures that any writes to this writer are duplicated to the logging
+// buffer defined above.
+var Stderr io.Writer
+
+// Stdout is similar to Stderr.
+var Stdout io.Writer
+
+func init() {
+	// Initialize LoggingBuffer with 2MB size.
+	LoggingBuffer = bytesutil.NewCircularBuffer(1 << 21)
+	Stderr = io.MultiWriter(LoggingBuffer, os.Stderr)
+	Stdout = io.MultiWriter(LoggingBuffer, os.Stdout)
+}
+
+// New initializes a new Logger.
 func New(w io.Writer) *zap.Logger {
 	config := zap.NewProductionEncoderConfig()
 	config.EncodeTime = func(ts time.Time, encoder zapcore.PrimitiveArrayEncoder) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,8 +1,10 @@
 package logger
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/influxdata/influxdb/pkg/bytesutil"
@@ -25,8 +27,18 @@ var Stderr io.Writer
 var Stdout io.Writer
 
 func init() {
+	size := 1 << 21
+	env := os.Getenv("INFLUXDB_PRIVATE_LOG_BUFFER_SIZE")
+	if env != "" {
+		if n, err := strconv.ParseInt(env, 10, 64); err != nil {
+			fmt.Printf("Unable to parse %q as logging buffer size.\n", env)
+		} else {
+			size = int(n)
+		}
+	}
+
 	// Initialize LoggingBuffer with 2MB size.
-	LoggingBuffer = bytesutil.NewCircularBuffer(1 << 21)
+	LoggingBuffer = bytesutil.NewCircularBuffer(size)
 	Stderr = io.MultiWriter(LoggingBuffer, os.Stderr)
 	Stdout = io.MultiWriter(LoggingBuffer, os.Stdout)
 }

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/monitor"
 	"github.com/influxdata/influxdb/monitor/diagnostics"
@@ -121,7 +122,7 @@ func NewHandler(c Config) *Handler {
 		mux:            pat.New(),
 		Config:         &c,
 		Logger:         zap.NewNop(),
-		CLFLogger:      log.New(os.Stderr, "[httpd] ", 0),
+		CLFLogger:      log.New(logger.Stderr, "[httpd] ", 0),
 		stats:          &Statistics{},
 		requestTracker: NewRequestTracker(),
 	}

--- a/tcp/mux.go
+++ b/tcp/mux.go
@@ -7,9 +7,10 @@ import (
 	"io"
 	"log"
 	"net"
-	"os"
 	"sync"
 	"time"
+
+	"github.com/influxdata/influxdb/logger"
 )
 
 const (
@@ -59,7 +60,7 @@ func NewMux() *Mux {
 	return &Mux{
 		m:       make(map[byte]*listener),
 		Timeout: DefaultTimeout,
-		Logger:  log.New(os.Stderr, "[tcp] ", log.LstdFlags),
+		Logger:  log.New(logger.Stderr, "[tcp] ", log.LstdFlags),
 	}
 }
 


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated

This PR adds recent server logs to the `/debug/pprof/all` profiling endpoint. This has two advantages:

  1) It makes it easier to investigate user issues because the logs can often contain useful information.
  2) The logs are taken as the last step in the profile gathering stage, which means they correlate well to the time period the profiles were captured over. Sometimes we're sent profiling data and logs that are from different time periods, making it hard to understand what's going on.

A circular buffer is used to maintain a fixed size of logging data at all times. By default, `2MB` of logs will be made available in the profile archive. Calls to the profiling endpoint copy this buffer and write it out to an `influxdb.log` file.

In order to ensure we capture all logs within this buffer, `os.Stderr` and `os.Stdout` are swapped throughout the program for `logger.Stderr` and `logger.Stdout`, which are actually multi-writers, teeing all data to the circular buffer and the respective original locations.