### PR TITLE
Refactoring 'buildtsi' command.

### DIFF
--- a/cmd/influx_inspect/help/help.go
+++ b/cmd/influx_inspect/help/help.go
@@ -34,7 +34,7 @@ The commands are:
     dumptsi              dumps low-level details about tsi1 files.
     dumptsm              dumps low-level details about tsm1 files.
     export               exports raw data from a shard to line protocol
-    inmem2tsi            generates a tsi1 index from an in-memory index shard
+    buildtsi.            generates tsi1 indexes from tsm1 data
     help                 display this help message
     report               displays a shard level report
     verify               verifies integrity of TSM files

--- a/cmd/influx_inspect/main.go
+++ b/cmd/influx_inspect/main.go
@@ -8,11 +8,11 @@ import (
 	"os"
 
 	"github.com/influxdata/influxdb/cmd"
+	"github.com/influxdata/influxdb/cmd/influx_inspect/buildtsi"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/dumptsi"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/dumptsm"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/export"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/help"
-	"github.com/influxdata/influxdb/cmd/influx_inspect/inmem2tsi"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/report"
 	"github.com/influxdata/influxdb/cmd/influx_inspect/verify"
 	_ "github.com/influxdata/influxdb/tsdb/engine"
@@ -73,10 +73,10 @@ func (m *Main) Run(args ...string) error {
 		if err := name.Run(args...); err != nil {
 			return fmt.Errorf("export: %s", err)
 		}
-	case "inmem2tsi":
-		name := inmem2tsi.NewCommand()
+	case "buildtsi":
+		name := buildtsi.NewCommand()
 		if err := name.Run(args...); err != nil {
-			return fmt.Errorf("inmem2tsi: %s", err)
+			return fmt.Errorf("buildtsi: %s", err)
 		}
 	case "report":
 		name := report.NewCommand()


### PR DESCRIPTION
## Overview

Renames the `inmem2tsi` tool to `buildtsi`. Updates to work against the entire system with database, retention policy, & shard filters.

## Usage

```sh
$ influx_inspect buildtsi -datadir ~/.influxdb/data -waldir ~/.influxdb/wal
```

```sh
$ influx_inspect buildtsi -datadir ~/.influxdb/data -waldir ~/.influxdb/wal -database db0
```

```sh
$ influx_inspect buildtsi -datadir ~/.influxdb/data -waldir ~/.influxdb/wal -database db0 -retention autogen
```

```sh
$ influx_inspect buildtsi -datadir ~/.influxdb/data -waldir ~/.influxdb/wal -database db0 -retention autogen -shard 123
```

###### Required for all non-trivial PRs
- [x] Rebased/mergable
- [x] Tests pass
- [ ] CHANGELOG.md updated
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
