### PR TITLE
Series creation improvements

### DIFF
--- a/pkg/mmap/mmap_unix.go
+++ b/pkg/mmap/mmap_unix.go
@@ -10,7 +10,6 @@ package mmap
 import (
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 // Map memory-maps a file.
@@ -35,11 +34,6 @@ func Map(path string, sz int64) ([]byte, error) {
 
 	data, err := syscall.Mmap(int(f.Fd()), 0, int(sz), syscall.PROT_READ, syscall.MAP_SHARED)
 	if err != nil {
-		return nil, err
-	}
-
-	if _, _, err := syscall.Syscall(syscall.SYS_MADVISE, uintptr(unsafe.Pointer(&data[0])), uintptr(len(data)), uintptr(syscall.MADV_RANDOM)); err != 0 {
-		Unmap(data)
 		return nil, err
 	}
 

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -27,6 +27,10 @@ func munmap(b []byte) (err error) {
 	return unix.Munmap(b)
 }
 
+func madviseWillNeed(b []byte) error {
+	return madvise(b, syscall.MADV_WILLNEED)
+}
+
 func madviseDontNeed(b []byte) error {
 	return madvise(b, syscall.MADV_DONTNEED)
 }

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -121,6 +121,10 @@ func munmap(b []byte) (err error) {
 	return nil
 }
 
+func madviseWillNeed(b []byte) error {
+	return nil
+}
+
 func madviseDontNeed(b []byte) error {
 	// Not supported
 	return nil

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -1374,6 +1374,10 @@ func (m *mmapAccessor) init() (*indirectIndex, error) {
 		return nil, fmt.Errorf("mmapAccessor: invalid indexStart")
 	}
 
+	// Hint to the kernal that we will be reading the file.  It would be better to hint
+	// that we will be reading the index section, but that doesn't seem to work ATM.
+	_ = madviseWillNeed(m.b)
+
 	m.index = NewIndirectIndex()
 	if err := m.index.UnmarshalBinary(m.b[indexStart:indexOfsPos]); err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes a few performance issues I was seeing with series creation.
* There was lock contention on the series file when `LogFile.execSeriesEntry` was run.  We already had the parsed series data further up the stack and `LogFile.execSeriesEntry` would need to look it up again and re-parse it.  I tacked on the parsed series data to the `LogEntry` and `execSeriesEntry` will use it if exists, otherwise fall back to looking it up in the `SeriesFile`.
* Inserting to RHH was creating lots of little allocations.  I switched it to use some temp buffers that can be re-used.
* The `mmap.Map` call `madvise(MADV_RANDOM)` which was trigger a lot of read IOPS on the series files.  I removed that and seems to reduce read IOPS.
* Loading a big TSM file was also trigger lots of read IOPS due to page faults when scanning the index.  I added a hint `madvise(MADV_WILLNEED)` that helps a bit.  I think a better solution would be to store some extra info in the TSM index to avoid scanning at load time.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
