### PR TITLE
Removed tabs from help text  for backup/restore

### DIFF
--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -570,7 +570,8 @@ func (cmd *Command) requestInfo(request *snapshotter.Request) (*snapshotter.Resp
 
 // printUsage prints the usage message to STDERR.
 func (cmd *Command) printUsage() {
-	fmt.Fprintf(cmd.Stdout, `Downloads a file level age-based snapshot of a data node and saves it to disk.
+	fmt.Fprintf(cmd.Stdout, `
+Downloads a file level age-based snapshot of a data node and saves it to disk.
 
 Usage: influxd backup [flags] PATH
 
@@ -585,12 +586,12 @@ Usage: influxd backup [flags] PATH
     -since <2015-12-24T08:12:23Z>
             Optional. Do an incremental backup since the passed in RFC3339
             formatted time.  Not compatible with -start or -end.
-	-start <2015-12-24T08:12:23Z>
+    -start <2015-12-24T08:12:23Z>
             All points earlier than this time stamp will be excluded from the export. Not compatible with -since.
-	-end <2015-12-24T08:12:23Z>
+    -end <2015-12-24T08:12:23Z>
             All points later than this time stamp will be excluded from the export. Not compatible with -since.
-	-portable
-	        Generate backup files in a format that is portable between different influxdb products.
+    -portable
+            Generate backup files in a format that is portable between different influxdb products.
 
 `)
 

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -541,10 +541,11 @@ func (cmd *Command) unpackTar(tarFile string) error {
 
 // printUsage prints the usage message to STDERR.
 func (cmd *Command) printUsage() {
-	fmt.Fprintf(cmd.Stdout, `Uses backups from the PATH to restore the metastore, databases,
-retention policies, or specific shards.  Default mode requires the instance to be stopped before running, and will wipe
-	all databases from the system (e.g., for disaster recovery).  The improved online and portable modes require
-    the instance to be running, and the database name used must not already exist.
+	fmt.Fprintf(cmd.Stdout, `
+Uses backups from the PATH to restore the metastore, databases, retention policies, or specific shards.
+Default mode requires the instance to be stopped before running, and will wipe all databases from the system
+(e.g., for disaster recovery).  The improved online and portable modes require the instance to be running,
+and the database name used must not already exist.
 
 Usage: influxd restore [-portable] [flags] PATH
 
@@ -564,27 +565,26 @@ Options:
     -shard <id>
             Optional. If given, -database and -retention are required. Will restore the shard's
             data.
-	-online
-	        Optional. If given, the restore will be done using the new process, detailed below.  All other arguments
-	        above should be omitted.
+    -online
+            Optional. If given, the restore will be done using the new process, detailed below.  All other arguments
+            above should be omitted.
 
 The -portable restore mode consumes files in an improved format that includes a file manifest.
 
 Options:
-	-host  <host:port>
+    -host  <host:port>
             The host to connect to and perform a snapshot of. Defaults to '127.0.0.1:8088'.
-	-db    <name>
-	        Identifies the database from the backup that will be restored.
-	-newdb <name>
-	        The name of the database into which the archived data will be imported on the target system.
-	        If not given, then the value of -db is used.  The new database name must be unique to the target system.
-	-rp    <name>
-	        Identifies the retention policy from the backup that will be restored.  Requires that -db is set.
-	-newrp <name>
-	        The name of the retention policy that will be created on the target system. Requires that -rp is set.
-	        If not given, the value of -rp is used.
-	-shard <id>
-	        Optional.  If given, -db and -rp are required.  Will restore the single shard's data.
-
+    -db    <name>
+            Identifies the database from the backup that will be restored.
+    -newdb <name>
+            The name of the database into which the archived data will be imported on the target system.
+            If not given, then the value of -db is used.  The new database name must be unique to the target system.
+    -rp    <name>
+            Identifies the retention policy from the backup that will be restored.  Requires that -db is set.
+    -newrp <name>
+            The name of the retention policy that will be created on the target system. Requires that -rp is set.
+            If not given, the value of -rp is used.
+    -shard <id>
+            Optional.  If given, -db and -rp are required.  Will restore the single shard's data.
 `)
 }


### PR DESCRIPTION
looks like a lot, just removed some tabs and fixed some bad line breaks.  