### PR TITLE
Reduce cache partitions

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -19,7 +19,7 @@ import (
 // testing, a value above the number of cores on the machine does not provide
 // any additional benefit. For now we'll set it to the number of cores on the
 // largest box we could imagine running influx.
-const ringShards = 4096
+const ringShards = 16
 
 var (
 	// ErrSnapshotInProgress is returned if a snapshot is attempted while one is already running.

--- a/tsdb/engine/tsm1/ring.go
+++ b/tsdb/engine/tsm1/ring.go
@@ -13,7 +13,7 @@ import (
 // basically defines the maximum number of partitions you can have in the ring.
 // If a smaller number of partitions are chosen when creating a ring, then
 // they're evenly spread across this many partitions in the ring.
-const partitions = 4096
+const partitions = 16
 
 // ring is a structure that maps series keys to entries.
 //

--- a/tsdb/engine/tsm1/ring_test.go
+++ b/tsdb/engine/tsm1/ring_test.go
@@ -12,8 +12,8 @@ func TestRing_newRing(t *testing.T) {
 		n         int
 		returnErr bool
 	}{
-		{n: 1}, {n: 2}, {n: 4}, {n: 8}, {n: 16}, {n: 32}, {n: 64}, {n: 128}, {n: 256},
-		{n: 0, returnErr: true}, {n: 3, returnErr: true}, {n: 512, returnErr: true},
+		{n: 1}, {n: 2}, {n: 4}, {n: 8}, {n: 16}, {n: 32, returnErr: true},
+		{n: 0, returnErr: true}, {n: 3, returnErr: true},
 	}
 
 	for i, example := range examples {

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -1025,7 +1025,7 @@ type WALSegmentWriter struct {
 // NewWALSegmentWriter returns a new WALSegmentWriter writing to w.
 func NewWALSegmentWriter(w io.WriteCloser) *WALSegmentWriter {
 	return &WALSegmentWriter{
-		bw: bufio.NewWriter(w),
+		bw: bufio.NewWriterSize(w, 16*1024),
 		w:  w,
 	}
 }


### PR DESCRIPTION
This helps with stability for higher cardinality write loads.
* Reduce cache partitions from 4096 to 16.  4096 causes big swings in HeapInUse which can OOM the processes if snapshotting gets backed up.
* Increase WAL write buffer size to 16k.  Investigating the memory spikes showed that writes to the WAL were taking several 4k IOs.  Under higher write load, this can cause disks to be saturated more quickly which can back up cache snapshotting.  With the higher partition count, the process can OOM.

###### Required for all non-trivial PRs
- [ ] Rebased/mergable
- [ ] Tests pass
- [ ] CHANGELOG.md updated
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

