### PR TITLE
Fix stddev() call to report itself as always returning a float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [#9342](https://github.com/influxdata/influxdb/pull/9342): Fix data races in tcp.Mux and tcp.listener
 - [#9353](https://github.com/influxdata/influxdb/pull/9353): Fix panic in msgpack httpd WriteResponse error handler.
 - [#9335](https://github.com/influxdata/influxdb/pull/9335): Prevent race condition caused by WaitGroup re-use
+- [#9386](https://github.com/influxdata/influxdb/issues/9386): Fix stddev() call to report itself as always returning a float.
 
 ## v1.4.3 [unreleased]
 

--- a/Godeps
+++ b/Godeps
@@ -14,7 +14,7 @@ github.com/gogo/protobuf 1c2b16bc280d6635de6c52fc1471ab962dc36ec9
 github.com/golang/protobuf 1e59b77b52bf8e4b449a57e6f79f21226d571845
 github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380
 github.com/google/go-cmp 18107e6c56edb2d51f965f7d68e59404f0daee54
-github.com/influxdata/influxql 47c654dfb4cd3be546b9ed1b37b30d7ab2784ffc
+github.com/influxdata/influxql 7c0f432656229c2084ee825680ef39a2228ccdb3
 github.com/influxdata/usage-client 6d3895376368aa52a3a81d2a16e90f0f52371967
 github.com/influxdata/yamux 1f58ded512de5feabbe30b60c7d33a7a896c5f16
 github.com/influxdata/yarpc 036268cdec22b7074cd6d50cc6d7315c667063c7


### PR DESCRIPTION
Fixes #9386.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated