### PR TITLE
Fix stddev() call to report itself as always returning a float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.3.10 [unreleased]
+
+### Bugfixes
+
+- [#9386](https://github.com/influxdata/influxdb/issues/9386): Fix stddev() call to report itself as always returning a float.
+
 ## v1.3.9 [2018-01-19]
 
 ### Bugfixes

--- a/influxql/ast.go
+++ b/influxql/ast.go
@@ -4689,7 +4689,7 @@ func EvalType(expr Expr, sources Sources, typmap TypeMapper) DataType {
 		return typ
 	case *Call:
 		switch expr.Name {
-		case "mean", "median", "integral":
+		case "mean", "median", "integral", "stddev":
 			return Float
 		case "count":
 			return Integer


### PR DESCRIPTION
Backport of #9390.

- [x] Rebased/mergable
- [x] Tests pass
- [x] CHANGELOG.md updated