### PR TITLE
Install autoconf in the circle build for fpm

### DIFF
--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -10,6 +10,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ruby \
     ruby-dev \
     rubygems \
+    autoconf \
+    libtool \
     build-essential \
     rpm \
     zip \

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -9,6 +9,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     make \
     ruby \
     ruby-dev \
+    autoconf \
+    libtool \
     build-essential \
     rpm \
     zip \

--- a/Dockerfile_build_ubuntu64_go19
+++ b/Dockerfile_build_ubuntu64_go19
@@ -9,6 +9,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     make \
     ruby \
     ruby-dev \
+    autoconf \
+    libtool \
     build-essential \
     rpm \
     zip \


### PR DESCRIPTION
Upstream must have changed and now autoconf isn't installed as an
implicit dependency of one of the packages anymore. Install is
explicitly so the fpm portion of the circle build works correctly.

- [x] Rebased/mergable
- [x] Tests pass