### PR TITLE
Ensure nil sketches never returned

### DIFF
--- a/pkg/estimator/hll/hll.go
+++ b/pkg/estimator/hll/hll.go
@@ -232,6 +232,10 @@ func (h *Plus) Merge(s estimator.Sketch) error {
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
 func (h *Plus) MarshalBinary() (data []byte, err error) {
+	if h == nil {
+		return nil, nil
+	}
+
 	// Marshal a version marker.
 	data = append(data, version)
 


### PR DESCRIPTION
It's possible that if `SHOW SERIES/MEASUREMENT CARDINALITY` is executed before any points are written to a database that `nil` sketches would be accessible from the Store. This is not ideal from an API consumer perspective.