### PR TITLE
Support proxy environment variables in the influx client

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -113,6 +113,7 @@ type Config struct {
 	Precision        string
 	WriteConsistency string
 	UnsafeSsl        bool
+	Proxy            func(req *http.Request) (*url.URL, error)
 }
 
 // NewConfig will create a config to be used in connecting to the client
@@ -154,6 +155,7 @@ func NewClient(c Config) (*Client, error) {
 	}
 
 	tr := &http.Transport{
+		Proxy:           c.Proxy,
 		TLSClientConfig: tlsConfig,
 	}
 

--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -45,6 +45,9 @@ type HTTPConfig struct {
 	// TLSConfig allows the user to set their own TLS config for the HTTP
 	// Client. If set, this option overrides InsecureSkipVerify.
 	TLSConfig *tls.Config
+
+	// Proxy configures the Proxy function on the HTTP client.
+	Proxy func(req *http.Request) (*url.URL, error)
 }
 
 // BatchPointsConfig is the config data needed to create an instance of the BatchPoints struct.
@@ -99,6 +102,7 @@ func NewHTTPClient(conf HTTPConfig) (Client, error) {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: conf.InsecureSkipVerify,
 		},
+		Proxy: conf.Proxy,
 	}
 	if conf.TLSConfig != nil {
 		tr.TLSClientConfig = conf.TLSConfig

--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -333,6 +334,7 @@ func (c *CommandLine) Connect(cmd string) error {
 	ClientConfig := c.ClientConfig
 	ClientConfig.UserAgent = "InfluxDBShell/" + c.ClientVersion
 	ClientConfig.URL = URL
+	ClientConfig.Proxy = http.ProxyFromEnvironment
 
 	client, err := client.NewClient(ClientConfig)
 	if err != nil {

--- a/man/influx.txt
+++ b/man/influx.txt
@@ -81,4 +81,17 @@ OPTIONS
 -version::
   Outputs the version of the influx client.
 
+ENVIRONMENT
+-----------
+The environment variables can be specified in lower case or upper case. The upper case version has precedence.
+
+HTTP_PROXY [protocol://]<host>[:port]::
+  Sets the proxy server to use for HTTP.
+
+HTTPS_PROXY [protocol://]<host>[:port]::
+  Sets the proxy server to use for HTTPS. Takes precedence over HTTP_PROXY for HTTPS.
+
+NO_PROXY <comma-separated list of hosts>::
+  List of host names that shouldn't go through any proxy. If set to an asterisk \'*' only, it matches all hosts.
+
 include::footer.txt[]


### PR DESCRIPTION
This also adds support for both the v1 and v2 APIs to set the Proxy
function on the underlying http.Transport.

The functionality for proxy environment variables is provided by the
[http.ProxyFromEnvironment](https://godoc.org/net/http#ProxyFromEnvironment).

- [x] Update man page when modifying a command
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<[influxdata/docs.influxdata.com#1449](https://github.com/influxdata/docs.influxdata.com/issues/1449)\>