### PR TITLE
Use --no-verbose with wget to reduce output

### DIFF
--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -24,7 +24,7 @@ RUN gem install fpm
 ENV GOPATH /root/go
 ENV GO_VERSION 1.9.2
 ENV GO_ARCH 386
-RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 ENV PATH /usr/local/go/bin:$PATH

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -26,7 +26,7 @@ RUN gem install fpm
 ENV GOPATH /root/go
 ENV GO_VERSION 1.9.2
 ENV GO_ARCH amd64
-RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 ENV PATH /usr/local/go/bin:$PATH

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -29,7 +29,7 @@ VOLUME $PROJECT_DIR
 # Install go
 ENV GO_VERSION 1.9.2
 ENV GO_ARCH amd64
-RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 

--- a/Dockerfile_build_ubuntu64_go19
+++ b/Dockerfile_build_ubuntu64_go19
@@ -26,7 +26,7 @@ RUN gem install fpm
 ENV GOPATH /root/go
 ENV GO_VERSION 1.9.2
 ENV GO_ARCH amd64
-RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 ENV PATH /usr/local/go/bin:$PATH

--- a/Dockerfile_jenkins_ubuntu32
+++ b/Dockerfile_jenkins_ubuntu32
@@ -11,7 +11,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 ENV GOPATH /go
 ENV GO_VERSION 1.9.2
 ENV GO_ARCH 386
-RUN wget -q https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+RUN wget --no-verbose -q https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH" && \
    rm /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz


### PR DESCRIPTION
The progress bar makes it hard to scroll through the output and the
progress bar information is never useful.