### PR TITLE
Suppress the InfluxDB banner if the log output is not a TTY

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -94,7 +94,7 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	// Print sweet InfluxDB logo.
-	if !suppressLogo {
+	if !suppressLogo && logger.IsTerminal(cmd.Stdout) {
 		fmt.Fprint(cmd.Stdout, logo)
 	}
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -286,6 +286,7 @@
   # level = "info"
 
   # Suppresses the logo output that is printed when the program is started.
+  # The logo is always suppressed if STDOUT is not a TTY.
   # suppress-logo = false
 
 ###

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -28,7 +28,7 @@ func (c *Config) New(defaultOutput io.Writer) (*zap.Logger, error) {
 	// If the format is empty or auto, then set the format depending
 	// on whether or not a terminal is present.
 	if format == "" || format == "auto" {
-		if isTerminal(w) {
+		if IsTerminal(w) {
 			format = "console"
 		} else {
 			format = "logfmt"
@@ -71,7 +71,8 @@ func newEncoderConfig() zapcore.EncoderConfig {
 	return config
 }
 
-func isTerminal(w io.Writer) bool {
+// IsTerminal checks if w is a file and whether it is an interactive terminal session.
+func IsTerminal(w io.Writer) bool {
 	if f, ok := w.(interface {
 		Fd() uintptr
 	}); ok {


### PR DESCRIPTION
This PR removes the InfluxDB logo when output is redirected to a non-TTY device in order to strip extraneous data from log files.