### PR TITLE
Added option to write HTTP request logs to separate file

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -217,6 +217,10 @@
   # Determines whether HTTP request logging is enabled.
   # log-enabled = true
 
+  # Specifies whether HTTP request logging is written to the specified path when enabled.
+  # If influxd is unable to access the specified path, it will log an error and fall back to stderr.
+  # access-log-path = ""
+
   # Determines whether detailed write logging is enabled.
   # write-tracing = false
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -217,8 +217,12 @@
   # Determines whether HTTP request logging is enabled.
   # log-enabled = true
 
-  # Specifies whether HTTP request logging is written to the specified path when enabled.
-  # If influxd is unable to access the specified path, it will log an error and fall back to stderr.
+  # When HTTP request logging is enabled, this option specifies the path where
+  # log entries should be written. If unspecified, the default is to write to stderr, which
+  # intermingles HTTP logs with internal InfluxDB logging.
+  #
+  # If influxd is unable to access the specified path, it will log an error and fall back to writing
+  # the request log to stderr.
   # access-log-path = ""
 
   # Determines whether detailed write logging is enabled.

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	UnixSocketEnabled  bool   `toml:"unix-socket-enabled"`
 	BindSocket         string `toml:"bind-socket"`
 	MaxBodySize        int    `toml:"max-body-size"`
+	AccessLogPath      string `toml:"access-log-path"`
 }
 
 // NewConfig returns a new Config with default settings.
@@ -67,5 +68,6 @@ func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
 		"https-enabled":        c.HTTPSEnabled,
 		"max-row-limit":        c.MaxRowLimit,
 		"max-connection-limit": c.MaxConnectionLimit,
+		"access-log-path":      c.AccessLogPath,
 	}), nil
 }

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -110,6 +110,7 @@ type Handler struct {
 	Config    *Config
 	Logger    *zap.Logger
 	CLFLogger *log.Logger
+	accessLog *os.File
 	stats     *Statistics
 
 	requestTracker *RequestTracker
@@ -178,6 +179,31 @@ func NewHandler(c Config) *Handler {
 	}...)
 
 	return h
+}
+
+func (h *Handler) Open() {
+	if h.Config.LogEnabled {
+		path := "stderr"
+
+		if h.Config.AccessLogPath != "" {
+			f, err := os.OpenFile(h.Config.AccessLogPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+			if err != nil {
+				h.Logger.Error("unable to open access log, falling back to stderr", zap.Error(err), zap.String("path", h.Config.AccessLogPath))
+				return
+			}
+			h.CLFLogger = log.New(f, "", 0) // [httpd] prefix stripped when logging to a file
+			h.accessLog = f
+			path = h.Config.AccessLogPath
+		}
+		h.Logger.Info("opened HTTP access log", zap.String("path", path))
+	}
+}
+
+func (h *Handler) Close() {
+	if h.accessLog != nil {
+		h.accessLog.Close()
+		h.accessLog = nil
+	}
 }
 
 // Statistics maintains statistics for the httpd service.

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -89,6 +89,8 @@ func (s *Service) Open() error {
 	s.Logger.Info("Starting HTTP service")
 	s.Logger.Info(fmt.Sprint("Authentication enabled:", s.Handler.Config.AuthEnabled))
 
+	s.Handler.Open()
+
 	// Open listener.
 	if s.https {
 		cert, err := tls.LoadX509KeyPair(s.cert, s.key)
@@ -163,6 +165,8 @@ func (s *Service) Open() error {
 
 // Close closes the underlying listener.
 func (s *Service) Close() error {
+	s.Handler.Close()
+
 	if s.ln != nil {
 		if err := s.ln.Close(); err != nil {
 			return err


### PR DESCRIPTION
Added a new option for the `[http]` service configuration to redirect request logging to a separate file, to address part of #9438

> Add a way to split out HTTP logs into a separate access log.

The new key is as follows

```
[http]
  # When HTTP request logging is enabled, this option specifies the path where 
  # log entries should be written. If unspecified, the default is to write to stderr, which
  # intermingles HTTP logs with internal InfluxDB logging.
  #
  # If influxd is unable to access the specified path, it will log an error and fall back to writing
  # the request log to stderr.
  # access-log-path = ""
```

**NOTES:** 

* when request logging is redirected to a file, the `[httpd] ` prefix is stripped, so access log parsing tools like [lnav](https://lnav.org) can render them without additional modification.
* to rotate the log file, use the `copytruncate` method of `logrotate` or similar to leave the original file in place.