### PR TITLE
Inmem series creation improvements

### DIFF
--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -752,11 +752,6 @@ func (i *Index) DropSeriesGlobal(key []byte, ts int64) error {
 		return nil
 	}
 
-	// Series was recently created, we can't drop it.
-	if series.LastModified() >= ts {
-		return nil
-	}
-
 	// Update the tombstone sketch.
 	i.seriesTSSketch.Add([]byte(k))
 
@@ -766,7 +761,7 @@ func (i *Index) DropSeriesGlobal(key []byte, ts int64) error {
 	// Remove the measurement's reference.
 	series.Measurement.DropSeries(series)
 	// Mark the series as deleted.
-	series.Delete(ts)
+	series.Delete()
 
 	// If the measurement no longer has any series, remove it as well.
 	if !series.Measurement.HasSeries() {

--- a/tsdb/series_segment.go
+++ b/tsdb/series_segment.go
@@ -130,7 +130,7 @@ func (s *SeriesSegment) InitForWrite() (err error) {
 	} else if _, err := s.file.Seek(int64(s.size), io.SeekStart); err != nil {
 		return err
 	}
-	s.w = bufio.NewWriter(s.file)
+	s.w = bufio.NewWriterSize(s.file, 32*1024)
 
 	return nil
 }


### PR DESCRIPTION
This improves series creation throughput.

* Remove the `lastModified` time on `inmem` Series which was used for concurrent writes and deletes.  We have the series bitmaps now that works for both `inmem` and `tsi` so this is not needed.  The `time.Now()` was showing up in profiles.
* Increase the `SeriesSegment` write buffer size to 32k from 4k.  This reduces IOs and time spent while the segment is locked and waiting for flushes.
* Fix `max-series-per-database` limit checks that ended up creating series one at a time.  This now does it in bulk which is less accurate, but more efficient.  