### PR TITLE
Generate trace logs for a number of important InfluxDB operations

### DIFF
--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -115,7 +115,7 @@ func (cmd *Command) processDatabase(dbName, dataDir, walDir string) error {
 }
 
 func (cmd *Command) processRetentionPolicy(sfile *tsdb.SeriesFile, dbName, rpName, dataDir, walDir string) error {
-	cmd.Logger.Info("rebuilding retention policy", zap.String("db", dbName), zap.String("rp", rpName))
+	cmd.Logger.Info("rebuilding retention policy", logger.Database(dbName), logger.RetentionPolicy(rpName))
 
 	fis, err := ioutil.ReadDir(dataDir)
 	if err != nil {
@@ -142,7 +142,7 @@ func (cmd *Command) processRetentionPolicy(sfile *tsdb.SeriesFile, dbName, rpNam
 }
 
 func (cmd *Command) processShard(sfile *tsdb.SeriesFile, dbName, rpName string, shardID uint64, dataDir, walDir string) error {
-	cmd.Logger.Info("rebuilding shard", zap.String("db", dbName), zap.String("rp", rpName), zap.Uint64("shard", shardID))
+	cmd.Logger.Info("rebuilding shard", logger.Database(dbName), logger.RetentionPolicy(rpName), logger.Shard(shardID))
 
 	// Check if shard already has a TSI index.
 	indexPath := filepath.Join(dataDir, "index")

--- a/logger/fields.go
+++ b/logger/fields.go
@@ -1,0 +1,111 @@
+package logger
+
+import (
+	"time"
+
+	"github.com/influxdata/influxdb/pkg/snowflake"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	// TraceIDKey is the logging context key used for identifying unique traces.
+	TraceIDKey = "trace_id"
+
+	// OperationNameKey is the logging context key used for identifying name of an operation.
+	OperationNameKey = "op.name"
+
+	// OperationEventKey is the logging context key used for identifying a notable
+	// event during the course of an operation.
+	OperationEventKey = "op.event"
+
+	// OperationElapsedKey is the logging context key used for identifying time elapsed to finish an operation.
+	OperationElapsedKey = "op.elapsed"
+
+	// DBInstanceKey is the logging context key used for identifying name of the relevant database.
+	DBInstanceKey = "db.instance"
+
+	// DBRetentionKey is the logging context key used for identifying name of the relevant retention policy.
+	DBRetentionKey = "db.rp"
+
+	// DBShardGroupKey is the logging context key used for identifying relevant shard group.
+	DBShardGroupKey = "db.shard_group"
+
+	// DBShardIDKey is the logging context key used for identifying name of the relevant shard group.
+	DBShardIDKey = "db.shard_id"
+)
+const (
+	eventStart = "start"
+	eventEnd   = "end"
+)
+
+var (
+	gen = snowflake.New(0)
+)
+
+func nextID() string {
+	return gen.NextString()
+}
+
+// TraceID returns a field for tracking the trace identifier.
+func TraceID(id string) zapcore.Field {
+	return zap.String(TraceIDKey, id)
+}
+
+// OperationName returns a field for tracking the name of an operation.
+func OperationName(name string) zapcore.Field {
+	return zap.String(OperationNameKey, name)
+}
+
+// OperationElapsed returns a field for tracking the duration of an operation.
+func OperationElapsed(d time.Duration) zapcore.Field {
+	return zap.Duration(OperationElapsedKey, d)
+}
+
+// OperationEventStart returns a field for tracking the start of an operation.
+func OperationEventStart() zapcore.Field {
+	return zap.String(OperationEventKey, eventStart)
+}
+
+// OperationEventFinish returns a field for tracking the end of an operation.
+func OperationEventEnd() zapcore.Field {
+	return zap.String(OperationEventKey, eventEnd)
+}
+
+// Database returns a field for tracking the name of a database.
+func Database(name string) zapcore.Field {
+	return zap.String(DBInstanceKey, name)
+}
+
+// Database returns a field for tracking the name of a database.
+func RetentionPolicy(name string) zapcore.Field {
+	return zap.String(DBRetentionKey, name)
+}
+
+// ShardGroup returns a field for tracking the shard group identifier.
+func ShardGroup(id uint64) zapcore.Field {
+	return zap.Uint64(DBShardGroupKey, id)
+}
+
+// Shard returns a field for tracking the shard identifier.
+func Shard(id uint64) zapcore.Field {
+	return zap.Uint64(DBShardIDKey, id)
+}
+
+// NewOperation uses the exiting log to create a new logger with context
+// containing a trace id and the operation. Prior to returning, a standardized message
+// is logged indicating the operation has started. The returned function should be
+// called when the operation concludes in order to log a corresponding message which
+// includes an elapsed time and that the operation has ended.
+func NewOperation(log *zap.Logger, msg, name string, fields ...zapcore.Field) (*zap.Logger, func()) {
+	f := []zapcore.Field{TraceID(nextID()), OperationName(name)}
+	if len(fields) > 0 {
+		f = append(f, fields...)
+	}
+
+	now := time.Now()
+	log = log.With(f...)
+	log.Info(msg+" (start)", OperationEventStart())
+
+	return log, func() { log.Info(msg+" (end)", OperationEventEnd(), OperationElapsed(time.Since(now))) }
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -45,7 +45,7 @@ func (c *Config) New(defaultOutput io.Writer) (*zap.Logger, error) {
 		encoder,
 		zapcore.Lock(zapcore.AddSync(w)),
 		c.Level,
-	)), nil
+	), zap.Fields(zap.String("log_id", nextID()))), nil
 }
 
 func newEncoder(format string) (zapcore.Encoder, error) {

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -390,7 +390,7 @@ func (m *Monitor) createInternalStorage() {
 		}
 
 		if _, err := m.MetaClient.CreateDatabaseWithRetentionPolicy(m.storeDatabase, &spec); err != nil {
-			m.Logger.Info("Failed to create storage", zap.String("db", m.storeDatabase), zap.Error(err))
+			m.Logger.Info("Failed to create storage", logger.Database(m.storeDatabase), zap.Error(err))
 			return
 		}
 	}
@@ -417,7 +417,7 @@ func (m *Monitor) waitUntilInterval(d time.Duration) error {
 // storeStatistics writes the statistics to an InfluxDB system.
 func (m *Monitor) storeStatistics() {
 	defer m.wg.Done()
-	m.Logger.Info("Storing statistics", zap.String("db", m.storeDatabase), zap.String("rp", m.storeRetentionPolicy), logger.DurationLiteral("interval", m.storeInterval))
+	m.Logger.Info("Storing statistics", logger.Database(m.storeDatabase), logger.RetentionPolicy(m.storeRetentionPolicy), logger.DurationLiteral("interval", m.storeInterval))
 
 	// Wait until an even interval to start recording monitor statistics.
 	// If we are interrupted before the interval for some reason, exit early.

--- a/pkg/snowflake/README.md
+++ b/pkg/snowflake/README.md
@@ -1,0 +1,38 @@
+Snowflake ID generator
+======================
+
+This is a Go implementation of [Twitter Snowflake](https://blog.twitter.com/2010/announcing-snowflake).
+
+The most useful aspect of these IDs is they are _roughly_ sortable and when generated
+at roughly the same time, should have values in close proximity to each other.
+
+IDs
+---
+
+Each id will be a 64-bit number represented, structured as follows:
+
+
+```
+6  6         5         4         3         2         1
+3210987654321098765432109876543210987654321098765432109876543210
+
+ttttttttttttttttttttttttttttttttttttttttttmmmmmmmmmmssssssssssss
+```
+
+where
+
+* s (sequence) is a 12-bit integer that increments if called multiple times for the same millisecond
+* m (machine id) is a 10-bit integer representing the server id
+* t (time) is a 42-bit integer representing the current timestamp in milliseconds
+  the number of milliseconds to have elapsed since 1491696000000 or 2017-04-09T00:00:00Z
+
+### String Encoding
+
+The 64-bit unsigned integer is base-63 encoded using the following URL-safe characters, which are ordered
+according to their ASCII value.
+
+```
+0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~
+```
+
+A binary sort of a list of encoded values will be correctly ordered according to the numerical representation. 

--- a/pkg/snowflake/gen.go
+++ b/pkg/snowflake/gen.go
@@ -1,0 +1,107 @@
+package snowflake
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	epoch        = 1491696000000
+	serverBits   = 10
+	sequenceBits = 12
+	serverShift  = sequenceBits
+	timeShift    = sequenceBits + serverBits
+	serverMax    = ^(-1 << serverBits)
+	sequenceMask = ^(-1 << sequenceBits)
+)
+
+type Generator struct {
+	rw            sync.Mutex
+	lastTimestamp uint64
+	machineID     int
+	sequence      int32
+}
+
+func New(machineID int) *Generator {
+	if machineID < 0 || machineID > serverMax {
+		panic(fmt.Errorf("invalid machine id; must be 0 ≤ id < %d", serverMax))
+	}
+	return &Generator{
+		machineID:     machineID,
+		lastTimestamp: 0,
+		sequence:      0,
+	}
+}
+
+func (g *Generator) MachineID() int {
+	return g.machineID
+}
+
+func (g *Generator) Next() uint64 {
+	t := now()
+	g.rw.Lock()
+	if t == g.lastTimestamp {
+		g.sequence = (g.sequence + 1) & sequenceMask
+		if g.sequence == 0 {
+			t = g.nextMillis()
+		}
+	} else if t < g.lastTimestamp {
+		t = g.nextMillis()
+	} else {
+		g.sequence = 0
+	}
+	g.lastTimestamp = t
+	seq := g.sequence
+	g.rw.Unlock()
+
+	tp := (t - epoch) << timeShift
+	sp := uint64(g.machineID << serverShift)
+	n := tp | sp | uint64(seq)
+
+	return n
+}
+
+func (g *Generator) NextString() string {
+	var s [11]byte
+	encode(&s, g.Next())
+	return string(s[:])
+}
+
+func (g *Generator) AppendNext(s *[11]byte) {
+	encode(s, g.Next())
+}
+
+func (g *Generator) nextMillis() uint64 {
+	t := now()
+	for t <= g.lastTimestamp {
+		time.Sleep(100 * time.Microsecond)
+		t = now()
+	}
+	return t
+}
+
+func now() uint64 { return uint64(time.Now().UnixNano() / 1e6) }
+
+var digits = [...]byte{
+	'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+	'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+	'U', 'V', 'W', 'X', 'Y', 'Z', '_', 'a', 'b', 'c',
+	'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+	'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w',
+	'x', 'y', 'z', '~'}
+
+func encode(s *[11]byte, n uint64) {
+	s[10], n = digits[n&0x3f], n>>6
+	s[9], n = digits[n&0x3f], n>>6
+	s[8], n = digits[n&0x3f], n>>6
+	s[7], n = digits[n&0x3f], n>>6
+	s[6], n = digits[n&0x3f], n>>6
+	s[5], n = digits[n&0x3f], n>>6
+	s[4], n = digits[n&0x3f], n>>6
+	s[3], n = digits[n&0x3f], n>>6
+	s[2], n = digits[n&0x3f], n>>6
+	s[1], n = digits[n&0x3f], n>>6
+	s[0] = digits[n&0x3f]
+}

--- a/pkg/snowflake/gen_test.go
+++ b/pkg/snowflake/gen_test.go
@@ -1,0 +1,68 @@
+package snowflake
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/influxdata/influxdb/pkg/testing/assert"
+)
+
+func TestEncode(t *testing.T) {
+	tests := []struct {
+		v   uint64
+		exp string
+	}{
+		{0x000, "00000000000"},
+		{0x001, "00000000001"},
+		{0x03f, "0000000000~"},
+		{0x07f, "0000000001~"},
+		{0xf07f07f07f07f07f, "F1~1~1~1~1~"},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("0x%03x→%s", test.v, test.exp), func(t *testing.T) {
+			var s [11]byte
+			encode(&s, test.v)
+			assert.Equal(t, string(s[:]), test.exp)
+		})
+	}
+}
+
+// TestSorting verifies numbers using base 63 encoding are ordered according to their numerical representation.
+func TestSorting(t *testing.T) {
+	var (
+		vals = make([]string, 1000)
+		exp  = make([]string, 1000)
+	)
+
+	for i := 0; i < len(vals); i++ {
+		var s [11]byte
+		encode(&s, uint64(i*47))
+		vals[i] = string(s[:])
+		exp[i] = string(s[:])
+	}
+
+	// randomize them
+	shuffle(len(vals), func(i, j int) {
+		vals[i], vals[j] = vals[j], vals[i]
+	})
+
+	sort.Strings(vals)
+	assert.Equal(t, vals, exp)
+}
+
+func BenchmarkEncode(b *testing.B) {
+	b.ReportAllocs()
+	var s [11]byte
+	for i := 0; i < b.N; i++ {
+		encode(&s, 100)
+	}
+}
+
+func shuffle(n int, swap func(i, j int)) {
+	for i := n - 1; i > 0; i-- {
+		j := rand.Intn(i + 1)
+		swap(i, j)
+	}
+}

--- a/services/collectd/service.go
+++ b/services/collectd/service.go
@@ -15,6 +15,7 @@ import (
 
 	"collectd.org/api"
 	"collectd.org/network"
+	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"
@@ -395,7 +396,7 @@ func (s *Service) writePoints() {
 			// Will attempt to create database if not yet created.
 			if err := s.createInternalStorage(); err != nil {
 				s.Logger.Info("Required database not yet created",
-					zap.String("db", s.Config.Database), zap.Error(err))
+					logger.Database(s.Config.Database), zap.Error(err))
 				continue
 			}
 
@@ -404,7 +405,7 @@ func (s *Service) writePoints() {
 				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
 			} else {
 				s.Logger.Info("Failed to write point batch to database",
-					zap.String("db", s.Config.Database), zap.Error(err))
+					logger.Database(s.Config.Database), zap.Error(err))
 				atomic.AddInt64(&s.stats.BatchesTransmitFail, 1)
 			}
 		}

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -360,13 +360,20 @@ func (s *Service) ExecuteContinuousQuery(dbi *meta.DatabaseInfo, cqi *meta.Conti
 		return false, fmt.Errorf("unable to set time range: %s", err)
 	}
 
-	var start time.Time
+	var (
+		start time.Time
+		log   = s.Logger
+	)
 	if s.loggingEnabled || s.queryStatsEnabled {
 		start = time.Now()
 	}
 
 	if s.loggingEnabled {
-		s.Logger.Info("Executing continuous query",
+		var logEnd func()
+		log, logEnd = logger.NewOperation(s.Logger, "Continuous query execution", "continuous_querier.execute")
+		defer logEnd()
+
+		log.Info("Executing continuous query",
 			zap.String("name", cq.Info.Name),
 			zap.Time("start", startTime),
 			zap.Time("end", endTime))
@@ -391,7 +398,7 @@ func (s *Service) ExecuteContinuousQuery(dbi *meta.DatabaseInfo, cqi *meta.Conti
 	}
 
 	if s.loggingEnabled {
-		s.Logger.Info("Finished continuous query",
+		log.Info("Finished continuous query",
 			zap.String("name", cq.Info.Name),
 			zap.Int64("written", written),
 			zap.Time("start", startTime),

--- a/services/graphite/service.go
+++ b/services/graphite/service.go
@@ -463,7 +463,7 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
 			} else {
 				s.logger.Info("Failed to write point batch to database",
-					zap.String("db", s.database), zap.Error(err))
+					logger.Database(s.database), zap.Error(err))
 				atomic.AddInt64(&s.stats.BatchesTransmitFail, 1)
 			}
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/monitor"
 	"github.com/influxdata/influxdb/monitor/diagnostics"
@@ -421,7 +422,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 				h.Logger.Info("Unauthorized request",
 					zap.String("user", err.User),
 					zap.Stringer("query", err.Query),
-					zap.String("db", err.Database))
+					logger.Database(err.Database))
 			}
 			h.httpError(rw, "error authorizing query: "+err.Error(), http.StatusForbidden)
 			return
@@ -981,7 +982,7 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 				h.Logger.Info("Unauthorized request",
 					zap.String("user", err.User),
 					zap.Stringer("query", err.Query),
-					zap.String("db", err.Database))
+					logger.Database(err.Database))
 			}
 			h.httpError(w, "error authorizing query: "+err.Error(), http.StatusForbidden)
 			return

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxql"
 	"go.uber.org/zap"
 
@@ -800,9 +801,9 @@ func (c *Client) PrecreateShardGroups(from, to time.Time) error {
 				// if it already exists, continue
 				if sg, _ := data.ShardGroupByTimestamp(di.Name, rp.Name, nextShardGroupTime); sg != nil {
 					c.logger.Info("Shard group already exists",
-						zap.Uint64("id", sg.ID),
-						zap.String("db", di.Name),
-						zap.String("rp", rp.Name))
+						logger.ShardGroup(sg.ID),
+						logger.Database(di.Name),
+						logger.RetentionPolicy(rp.Name))
 					continue
 				}
 				newGroup, err := createShardGroup(data, di.Name, rp.Name, nextShardGroupTime)
@@ -813,9 +814,9 @@ func (c *Client) PrecreateShardGroups(from, to time.Time) error {
 				}
 				changed = true
 				c.logger.Info("New shard group successfully precreated",
-					zap.Uint64("group_id", newGroup.ID),
-					zap.String("db", di.Name),
-					zap.String("rp", rp.Name))
+					logger.ShardGroup(newGroup.ID),
+					logger.Database(di.Name),
+					logger.RetentionPolicy(rp.Name))
 			}
 		}
 	}

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"
@@ -464,7 +465,7 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 		case batch := <-batcher.Out():
 			// Will attempt to create database if not yet created.
 			if err := s.createInternalStorage(); err != nil {
-				s.Logger.Info("Required database does not yet exist", zap.String("db", s.Database), zap.Error(err))
+				s.Logger.Info("Required database does not yet exist", logger.Database(s.Database), zap.Error(err))
 				continue
 			}
 
@@ -473,7 +474,7 @@ func (s *Service) processBatches(batcher *tsdb.PointBatcher) {
 				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
 			} else {
 				s.Logger.Info("Failed to write point batch to database",
-					zap.String("db", s.Database), zap.Error(err))
+					logger.Database(s.Database), zap.Error(err))
 				atomic.AddInt64(&s.stats.BatchesTransmitFail, 1)
 			}
 		}

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/coordinator"
+	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/monitor"
 	"github.com/influxdata/influxdb/services/meta"
@@ -315,8 +316,8 @@ func (s *Service) updateSubs(wg *sync.WaitGroup) {
 				}
 				s.subs[se] = cw
 				s.Logger.Info("Added new subscription",
-					zap.String("db", se.db),
-					zap.String("rp", se.rp))
+					logger.Database(se.db),
+					logger.RetentionPolicy(se.rp))
 			}
 		}
 	}
@@ -330,8 +331,8 @@ func (s *Service) updateSubs(wg *sync.WaitGroup) {
 			// Remove it from the set
 			delete(s.subs, se)
 			s.Logger.Info("Deleted old subscription",
-				zap.String("db", se.db),
-				zap.String("rp", se.rp))
+				logger.Database(se.db),
+				logger.RetentionPolicy(se.rp))
 		}
 	}
 }

--- a/services/udp/service.go
+++ b/services/udp/service.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"
@@ -161,7 +162,7 @@ func (s *Service) writer() {
 			// Will attempt to create database if not yet created.
 			if err := s.createInternalStorage(); err != nil {
 				s.Logger.Info("Required database does not yet exist",
-					zap.String("db", s.config.Database), zap.Error(err))
+					logger.Database(s.config.Database), zap.Error(err))
 				continue
 			}
 
@@ -170,7 +171,7 @@ func (s *Service) writer() {
 				atomic.AddInt64(&s.stats.PointsTransmitted, int64(len(batch)))
 			} else {
 				s.Logger.Info("Failed to write point batch to database",
-					zap.String("db", s.config.Database), zap.Error(err))
+					logger.Database(s.config.Database), zap.Error(err))
 				atomic.AddInt64(&s.stats.BatchesTransmitFail, 1)
 			}
 

--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
+	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/rhh"
 	"go.uber.org/zap"
@@ -258,10 +258,8 @@ func (p *SeriesPartition) CreateSeriesListIfNotExists(keys [][]byte, keyPartitio
 	// Check if we've crossed the compaction threshold.
 	if p.compactionsEnabled() && !p.compacting && p.CompactThreshold != 0 && p.index.InMemCount() >= uint64(p.CompactThreshold) {
 		p.compacting = true
-		logger := p.Logger.With(zap.String("path", p.path))
-		logger.Info("beginning series partition compaction")
+		log, logEnd := logger.NewOperation(p.Logger, "Series partition compaction", "series_partition.compaction", zap.String("path", p.path))
 
-		startTime := time.Now()
 		p.wg.Add(1)
 		go func() {
 			defer p.wg.Done()
@@ -269,10 +267,10 @@ func (p *SeriesPartition) CreateSeriesListIfNotExists(keys [][]byte, keyPartitio
 			compactor := NewSeriesPartitionCompactor()
 			compactor.cancel = p.closing
 			if err := compactor.Compact(p); err != nil {
-				logger.With(zap.Error(err)).Error("series partition compaction failed")
+				log.Error("series partition compaction failed", zap.Error(err))
 			}
 
-			logger.With(zap.Duration("elapsed", time.Since(startTime))).Info("completed series partition compaction")
+			logEnd()
 
 			// Clear compaction flag.
 			p.mu.Lock()


### PR DESCRIPTION
### Notes

Traces create a child logger with additional context that is used to log any subsequent events during the trace. Specifically

* `op.name` is a unique identifier for the operation. We can filter on all operations of a specific name. An example of an `op.name` might be `tsm1.compact_group`
* `op.event` currently has two values `start` or `end` indicating the start or end of an operation
    * for example, you can grep by values in `op.name` AND `op.event` to find all starting operation logs
* Traces begin and end with a consistent log entry
    * traces begin with a friendly description of the operation, like **TSM compaction** and the `op.event` context
    * Traces end with the same description of the operation, like **TSM compaction**
* `trace_id` is a unique identifier used for a specific instance of a trace and can be used to correlate all related log events
* `log_id` is added to _every_ log entry for a single execution of the `influxd` process, allowing all log entries for a single run to be easily identified. There are also other ways a log file could be split by a single execution, however, the consistent `log_id` will make it easier when searching log aggregations services.
* `op.elapsed` is the amount of time the operation was spent executing and is logged with ending trace entry
* a few consistent context keys have been established when logging related events
    * `db.instance` identifies the name of the database 
    * `db.rp` identifies the name of the retention policy
    * `db.shard_id` identifies the id of the shard
    * `db.shard_group` identifies the shard group identifier

### Tooling

There are a number of tools for processing and filtering log files in JSON or logfmt

* [hutils](https://blog.heroku.com/hutils-explore-your-structured-data-logs) from heroku are designed to work with logfmt
* influxlog – WIP will be our tool to quickly report on various interesting metrics and / or conditions
    * this will go hand-in-hand with all the usual text filtering
* [lnav](http://lnav.org) – useful for watching and filtering files real-time


### Operations

* tsdb.Open traces all events related to the initial opening of the `tsdb.Store`
    * `op.name` : `tsdb.open`
* retention policy shard deletions
    * `op.name` : `retention.delete_check`
* all TSM compaction strategies
    * `op.name` : `tsm.compact_group`
    * `strategy` : `(level|full)`
    * `level` : `[1,3]`
    * `optimize` : `(true|false)`
* series file compactions
    * `op.name` : `series_partition.compaction`
* continuous query execution (if logging enabled)
    * `op.name` : `continuous_querier.execute`
* TSI log file compaction
    * `op.name` : `index.tsi.compact_log_file`
* TSI level compaction
    * `op.name` : `index.tsi.compact_to_level`

----

Some examples of related trace log entries in `logfmt`:

```
ts=2018-02-21T20:22:06.293163Z lvl=info msg="Cache snapshot (start)" log_id=06QW8yAl000 engine=tsm1 trace_id=06QWKbqG000 op.name=cache.snapshot op.event=start
ts=2018-02-21T20:22:06.373734Z lvl=info msg="Snapshot for path written" log_id=06QW8yAl000 engine=tsm1 path=/Users/stuartcarnie/.influxdb/data/bar/autogen/438 duration=80.582ms
ts=2018-02-21T20:22:06.373775Z lvl=info msg="Cache snapshot (end)" log_id=06QW8yAl000 engine=tsm1 trace_id=06QWKbqG000 op.name=cache.snapshot op.event=end op.elapsed=80ms
ts=2018-02-21T20:22:09.292390Z lvl=info msg="Cache snapshot (start)" log_id=06QW8yAl000 engine=tsm1 trace_id=06QWKnZ0000 op.name=cache.snapshot op.event=start
ts=2018-02-21T20:22:09.375122Z lvl=info msg="Snapshot for path written" log_id=06QW8yAl000 engine=tsm1 path=/Users/stuartcarnie/.influxdb/data/bar/autogen/438 duration=82.744ms
ts=2018-02-21T20:22:09.375169Z lvl=info msg="Cache snapshot (end)" log_id=06QW8yAl000 engine=tsm1 trace_id=06QWKnZ0000 op.name=cache.snapshot op.event=end op.elapsed=82ms
ts=2018-02-21T20:22:12.292417Z lvl=info msg="Cache snapshot (start)" log_id=06QW8yAl000 engine=tsm1 trace_id=06QWKzH0000 op.name=cache.snapshot op.event=start
ts=2018-02-21T20:22:12.371576Z lvl=info msg="Snapshot for path written" log_id=06QW8yAl000 engine=tsm1 path=/Users/stuartcarnie/.influxdb/data/bar/autogen/438 duration=79.174ms
ts=2018-02-21T20:22:12.371621Z lvl=info msg="Cache snapshot (end)" log_id=06QW8yAl000 engine=tsm1 trace_id=06QWKzH0000 op.name=cache.snapshot op.event=end op.elapsed=79ms
ts=2018-02-21T20:22:13.292489Z lvl=info msg="TSM compaction (start)" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group op.event=start
ts=2018-02-21T20:22:13.292571Z lvl=info msg="Beginning compaction" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group files=8
ts=2018-02-21T20:22:13.292618Z lvl=info msg="Compacting file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=0 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000122-000000001.tsm
ts=2018-02-21T20:22:13.292653Z lvl=info msg="Compacting file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=1 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000123-000000001.tsm
ts=2018-02-21T20:22:13.292670Z lvl=info msg="Compacting file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=2 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000124-000000001.tsm
ts=2018-02-21T20:22:13.292685Z lvl=info msg="Compacting file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=3 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000125-000000001.tsm
ts=2018-02-21T20:22:13.292700Z lvl=info msg="Compacting file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=4 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000126-000000001.tsm
ts=2018-02-21T20:22:13.292727Z lvl=info msg="Compacting file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=5 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000127-000000001.tsm
ts=2018-02-21T20:22:13.292755Z lvl=info msg="Compacting file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=6 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000128-000000001.tsm
ts=2018-02-21T20:22:13.292773Z lvl=info msg="Compacting file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=7 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000129-000000001.tsm
ts=2018-02-21T20:22:14.262006Z lvl=info msg="Compacted file" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group index=0 file=/Users/stuartcarnie/.influxdb/data/bar/autogen/438/000000129-000000002.tsm.tmp
ts=2018-02-21T20:22:14.262060Z lvl=info msg="Finished compacting files" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group groups=8 files=1 duration=969.583ms
ts=2018-02-21T20:22:14.262078Z lvl=info msg="TSM compaction (end)" log_id=06QW8yAl000 engine=tsm1 level=1 strategy=level trace_id=06QWL2B0000 op.name=tsm1.compact_group op.event=end op.elapsed=969ms
ts=2018-02-21T20:22:15.292772Z lvl=info msg="Cache snapshot (start)" log_id=06QW8yAl000 engine=tsm1 trace_id=06QWL9~0000 op.name=cache.snapshot op.event=start
ts=2018-02-21T20:22:15.394407Z lvl=info msg="Snapshot for path written" log_id=06QW8yAl000 engine=tsm1 path=/Users/stuartcarnie/.influxdb/data/bar/autogen/438 duration=101.658ms
ts=2018-02-21T20:22:15.394459Z lvl=info msg="Cache snapshot (end)" log_id=06QW8yAl000 engine=tsm1 trace_id=06QWL9~0000 op.name=cache.snapshot op.event=end op.elapsed=101ms
```