### PR TITLE
Do not drop on the floor small buffers

### DIFF
--- a/tsdb/engine/tsm1/pools.go
+++ b/tsdb/engine/tsm1/pools.go
@@ -13,6 +13,7 @@ func getBuf(size int) *[]byte {
 	}
 	buf := x.(*[]byte)
 	if cap(*buf) < size {
+		bufPool.Put(x)
 		b := make([]byte, size)
 		return &b
 	}


### PR DESCRIPTION
Currently if a buffer from the buffer is too small to satisfy its request then we simply drop it and allocate a new one.

This change puts it back in the pool and then allocates a new one.

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
