### PR TITLE
Re-open last WAL segment

### DIFF
--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -513,7 +513,7 @@ func (f *FileStore) Open() error {
 		}
 
 	}
-	f.lastModified = time.Unix(0, lm)
+	f.lastModified = time.Unix(0, lm).UTC()
 	close(readerC)
 
 	sort.Sort(tsmReaders(f.files))
@@ -664,7 +664,7 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 
 		// Keep track of the new mod time
 		if stat, err := fd.Stat(); err == nil {
-			if stat.ModTime().UTC().After(maxTime) {
+			if maxTime.IsZero() || stat.ModTime().UTC().After(maxTime) {
 				maxTime = stat.ModTime().UTC()
 			}
 		}

--- a/tsdb/engine/tsm1/wal_test.go
+++ b/tsdb/engine/tsm1/wal_test.go
@@ -499,7 +499,7 @@ func TestWAL_ClosedSegments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting closed segments: %v", err)
 	}
-	if got, exp := len(files), 1; got != exp {
+	if got, exp := len(files), 0; got != exp {
 		t.Fatalf("close segment length mismatch: got %v, exp %v", got, exp)
 	}
 }
@@ -541,7 +541,7 @@ func TestWAL_Delete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting closed segments: %v", err)
 	}
-	if got, exp := len(files), 1; got != exp {
+	if got, exp := len(files), 0; got != exp {
 		t.Fatalf("close segment length mismatch: got %v, exp %v", got, exp)
 	}
 }


### PR DESCRIPTION
Re-open the last wal segment instead of creating a new one.  This fixes
an issue where the last modified time of the WAL would change on
restart.  It also avoids a lot of IO file churn on restart.

Fixes #9333

###### Required for all non-trivial PRs
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
