### PR TITLE
Update sample config with information on logging levels

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -292,7 +292,9 @@
   # logfmt.
   # format = "auto"
 
-  # Determines which level of logs will be emitted.
+  # Determines which level of logs will be emitted. The available levels
+  # are error, warn, info, and debug. Logs that are equal to or above the
+  # specified level will be emitted.
   # level = "info"
 
   # Suppresses the logo output that is printed when the program is started.

--- a/query/query_executor.go
+++ b/query/query_executor.go
@@ -382,7 +382,7 @@ LOOP:
 
 		// Log each normalized statement.
 		if !ctx.Quiet {
-			e.Logger.Info(stmt.String())
+			e.Logger.Info("Executing query", zap.Stringer("query", stmt))
 		}
 
 		// Send any other statements to the underlying statement executor.


### PR DESCRIPTION
Update the query executor to log a message using the style guide. The
actual message is static and the query is now in a context field.