### PR TITLE
series keys are produced in ascending order

### DIFF
--- a/services/storage/series_cursor.go
+++ b/services/storage/series_cursor.go
@@ -63,6 +63,7 @@ func newIndexSeriesCursor(ctx context.Context, req *ReadRequest, shards []*tsdb.
 	opt := query.IteratorOptions{
 		Aux:        []influxql.VarRef{{Val: "key"}},
 		Authorizer: query.OpenAuthorizer,
+		Ascending:  true,
 		Ordered:    true,
 	}
 	p := &indexSeriesCursor{row: seriesRow{shards: shards}}


### PR DESCRIPTION
Series keys from TSI are produced in ascending order. Setting `Ascending` to `true` ensures the merge iterator performs an ascending comparison.