### PR TITLE
Improve startup time of inmem index

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -28,7 +28,7 @@ type Index interface {
 	DropMeasurement(name []byte) error
 	ForEachMeasurementName(fn func(name []byte) error) error
 
-	InitializeSeries(key, name []byte, tags models.Tags) error
+	InitializeSeries(keys, names [][]byte, tags []models.Tags) error
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
 	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
 	DropSeries(seriesID uint64, key []byte, cascade bool) error

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -1155,9 +1155,9 @@ func (idx *ShardIndex) SeriesN() int64 {
 }
 
 // InitializeSeries is called during start-up.
-// This works the same as CreateSeriesIfNotExists except it ignore limit errors.
-func (idx *ShardIndex) InitializeSeries(key, name []byte, tags models.Tags) error {
-	return idx.Index.CreateSeriesListIfNotExists(idx.id, idx.seriesIDSet, [][]byte{key}, [][]byte{name}, []models.Tags{tags}, &idx.opt, true)
+// This works the same as CreateSeriesListIfNotExists except it ignore limit errors.
+func (idx *ShardIndex) InitializeSeries(keys, names [][]byte, tags []models.Tags) error {
+	return idx.Index.CreateSeriesListIfNotExists(idx.id, idx.seriesIDSet, keys, names, tags, &idx.opt, true)
 }
 
 // CreateSeriesIfNotExists creates the provided series on the index if it is not

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -554,7 +554,7 @@ func (i *Index) CreateSeriesIfNotExists(key, name []byte, tags models.Tags) erro
 }
 
 // InitializeSeries is a no-op. This only applies to the in-memory index.
-func (i *Index) InitializeSeries(key, name []byte, tags models.Tags) error {
+func (i *Index) InitializeSeries(keys, names [][]byte, tags []models.Tags) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR improves the startup time when using the `inmem` index by
ensuring that the series are created in the index and series file in
batches of 10000, rather than individually.

Fixes #9486.

Using the same dataset as #9486 with 4M series:

| release  | startup time |
| ------------- | ------------- |
|1.3.9 |   27s |
|1.4.2  |   27s |
|1.5.0rc3 |  91s | 
| PR | 20s |

So that's an improvement of `~25%` on `1.3.9`. However @jwilder @stuartcarnie I'm not set on this PR yet as we may not be able to re-use the `keys` buffer as I'm currently doing. I'm going to dig around a bit and see if it needs to be changed to allocate a new `[][]byte` for each batch rather than re-using the same one.