### PR TITLE
Add dumptsi path error handling.

### DIFF
--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -3,6 +3,7 @@ package tsi1
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -880,3 +881,21 @@ func (i *Index) SetFieldName(measurement []byte, name string) {}
 
 // Rebuild rebuilds an index. It's a no-op for this index.
 func (i *Index) Rebuild() {}
+
+// IsIndexDir returns true if directory contains at least one partition directory.
+func IsIndexDir(path string) (bool, error) {
+	fis, err := ioutil.ReadDir(path)
+	if err != nil {
+		return false, err
+	}
+	for _, fi := range fis {
+		if !fi.IsDir() {
+			continue
+		} else if ok, err := IsPartitionDir(filepath.Join(path, fi.Name())); err != nil {
+			return false, err
+		} else if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -1276,3 +1276,13 @@ const MaxIndexMergeCount = 2
 
 // MaxIndexFileSize is the maximum expected size of an index file.
 const MaxIndexFileSize = 4 * (1 << 30)
+
+// IsPartitionDir returns true if directory contains a MANIFEST file.
+func IsPartitionDir(path string) (bool, error) {
+	if _, err := os.Stat(filepath.Join(path, ManifestFileName)); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
This pull request adds validation to the `influx_inspect dumptsi` utility to check if a directory is an index before opening it. Previously it would assume the directory was an index and open it which would generate partitions.

This PR also moves the series iteration out of the partitions and into a single call for the index.

Fixes #9482.