### PR TITLE
Support less granular mtime in LastModified test

### DIFF
--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1302,7 +1302,7 @@ func TestEngine_LastModified(t *testing.T) {
 			// Artificial sleep added due to filesystems caching the mod time
 			// of files.  This prevents the WAL last modified time from being
 			// returned and newer than the filestore's mod time.
-			time.Sleep(400 * time.Millisecond)
+			time.Sleep(2 * time.Second) // Covers most filesystems.
 
 			if err := e.WriteSnapshot(); err != nil {
 				t.Fatalf("failed to snapshot: %s", err.Error())


### PR DESCRIPTION
Some filesystems only have second-level `mtime` precision (`HFS+`) or 2 second level precision (`FAT32`). 

This ensures that the test passes on those filesystems.