### PR TITLE
Fix the implicit time range in a subquery

### DIFF
--- a/query/compile.go
+++ b/query/compile.go
@@ -878,5 +878,6 @@ func (c *compiledStatement) Prepare(shardMapper ShardMapper, sopt SelectOptions)
 		opt:     opt,
 		ic:      shards,
 		columns: columns,
+		now:     c.Options.Now,
 	}, nil
 }

--- a/query/subquery.go
+++ b/query/subquery.go
@@ -24,7 +24,7 @@ func (b *subqueryBuilder) buildAuxIterator(ctx context.Context, opt IteratorOpti
 
 	// Map the desired auxiliary fields from the substatement.
 	indexes := b.mapAuxFields(auxFields)
-	subOpt, err := newIteratorOptionsSubstatement(b.stmt, opt)
+	subOpt, err := newIteratorOptionsSubstatement(ctx, b.stmt, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (b *subqueryBuilder) buildVarRefIterator(ctx context.Context, expr *influxq
 
 	// Map the auxiliary fields to their index in the subquery.
 	indexes := b.mapAuxFields(auxFields)
-	subOpt, err := newIteratorOptionsSubstatement(b.stmt, opt)
+	subOpt, err := newIteratorOptionsSubstatement(ctx, b.stmt, opt)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The implicit time range for an interval is supposed to be now when no
end is specified. In a subquery though, the interval doesn't exist and
so it doesn't set the end time to now, but to the max time. Since the
subquery qualifies as something that should have the implicit end time
apply, this results in a query that runs slowly because it is filling in
a bunch of unasked for intervals if a fill is specified.

This hack adds the implicit end time if it sees the parent query's end
time is set to the maximum available time.

This is a temporary fix for this problem. The query compilation should
perform these time range calculations in the compilation stage and the
subqueries should use the compilation stage during execution instead of
ignoring it. That work takes a lot more effort though and is more prone
to running into unforeseen bugs.

This fix introduces a subtle, but likely rare to run into bug. If the
top level query specifies the maximum time as the end time and the
subquery has an interval, the subquery should use the end time rather
than now as the time range. With this hack, it will interpret it as an
implicit time rather than an explicit one. This is unlikely to matter
though.

Fixes #9271.