### PR TITLE
use child logger

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1625,7 +1625,7 @@ func (e *Engine) WriteSnapshot() error {
 	defer func() {
 		elapsed := time.Since(started)
 		e.Cache.UpdateCompactTime(elapsed)
-		e.logger.Info("Snapshot for path written",
+		log.Info("Snapshot for path written",
 			zap.String("path", e.path),
 			zap.Duration("duration", elapsed))
 		logEnd()


### PR DESCRIPTION
Use the child logger so the appropriate context is attached to the log entry