### PR TITLE
Implement basic trigonometry functions

### DIFF
--- a/query/compile.go
+++ b/query/compile.go
@@ -250,8 +250,7 @@ func (c *compiledField) compileExpr(expr influxql.Expr) error {
 		return nil
 	case *influxql.Call:
 		if isMathFunction(expr) {
-			// TODO(jsternberg): Implement validation for any math functions.
-			return nil
+			return c.compileTrigFunction(expr)
 		}
 
 		// Register the function call in the list of function calls.
@@ -667,6 +666,13 @@ func (c *compiledField) compileTopBottom(call *influxql.Call) error {
 	}
 	c.global.TopBottomFunction = call.Name
 	return nil
+}
+
+func (c *compiledField) compileTrigFunction(expr *influxql.Call) error {
+	if exp, got := 1, len(expr.Args); exp != got {
+		return fmt.Errorf("invalid number of arguments for %s, expected %d, got %d", expr.Name, exp, got)
+	}
+	return c.compileExpr(expr.Args[0])
 }
 
 func (c *compiledStatement) compileDimensions(stmt *influxql.SelectStatement) error {

--- a/query/math.go
+++ b/query/math.go
@@ -1,12 +1,17 @@
 package query
 
 import (
+	"math"
 	"time"
 
 	"github.com/influxdata/influxql"
 )
 
 func isMathFunction(call *influxql.Call) bool {
+	switch call.Name {
+	case "sin", "cos", "tan":
+		return true
+	}
 	return false
 }
 
@@ -17,7 +22,10 @@ func (MathTypeMapper) MapType(measurement *influxql.Measurement, field string) i
 }
 
 func (MathTypeMapper) CallType(name string, args []influxql.DataType) (influxql.DataType, error) {
-	// TODO(jsternberg): Put math function call types here.
+	switch name {
+	case "sin", "cos", "tan":
+		return influxql.Float, nil
+	}
 	return influxql.Unknown, nil
 }
 
@@ -33,10 +41,46 @@ func (v *MathValuer) Value(key string) (interface{}, bool) {
 }
 
 func (v *MathValuer) Call(name string, args []influxql.Expr) (interface{}, bool) {
+	if len(args) == 1 {
+		switch name {
+		case "sin":
+			return v.callTrigFunction(math.Sin, args[0])
+		case "cos":
+			return v.callTrigFunction(math.Cos, args[0])
+		case "tan":
+			return v.callTrigFunction(math.Tan, args[0])
+		}
+	}
 	if v, ok := v.Valuer.(influxql.CallValuer); ok {
 		return v.Call(name, args)
 	}
 	return nil, false
+}
+
+func (v *MathValuer) callTrigFunction(fn func(x float64) float64, arg0 influxql.Expr) (interface{}, bool) {
+	var value float64
+	switch arg0 := arg0.(type) {
+	case *influxql.NumberLiteral:
+		value = arg0.Val
+	case *influxql.IntegerLiteral:
+		value = float64(arg0.Val)
+	case *influxql.VarRef:
+		if v.Valuer == nil {
+			return nil, false
+		} else if val, ok := v.Valuer.Value(arg0.Val); ok {
+			switch val := val.(type) {
+			case float64:
+				value = val
+			case int64:
+				value = float64(val)
+			}
+		} else {
+			return nil, false
+		}
+	default:
+		return nil, false
+	}
+	return fn(value), true
 }
 
 func (v *MathValuer) Zone() *time.Location {


### PR DESCRIPTION
This adds support for math functions into the query language. Math
functions are special because they are transformations and do not access
the filesystem in the same way aggregate functions do. A transformation
takes one point and always outputs one point making it more similar to
binary expressions so these math functions follow the same rules as
binary expressions.

This also supports using math literals (so you can do `sin(1)`) and the
math functions can be used anywhere such as in a field or an expression.
Both of the following are supported:

    SELECT sin(value) FROM cpu
    SELECT value FROM cpu WHERE sin(value) > 0.5

Arguments are in radians. Degrees is not supported.

Fixes #9424.

- [x] Provide example syntax
- [x] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<[influxdata/docs.influxdata.com#1457](https://github.com/influxdata/docs.influxdata.com/issues/1457)>