### PR TITLE
Add a logging level to the access log

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -225,6 +225,11 @@
   # the request log to stderr.
   # access-log-path = ""
 
+  # Determines which requests should be logged. If this is set to "error", only 5xx responses will be
+  # logged to the access log or stderr if the access-log-path is empty. If set to "info", it will print
+  # everything.
+  # access-log-level = "info"
+
   # Determines whether detailed write logging is enabled.
   # write-tracing = false
 

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -1,6 +1,9 @@
 package httpd
 
-import "github.com/influxdata/influxdb/monitor/diagnostics"
+import (
+	"github.com/influxdata/influxdb/monitor/diagnostics"
+	"go.uber.org/zap/zapcore"
+)
 
 const (
 	// DefaultBindAddress is the default address to bind to.
@@ -18,23 +21,24 @@ const (
 
 // Config represents a configuration for a HTTP service.
 type Config struct {
-	Enabled            bool   `toml:"enabled"`
-	BindAddress        string `toml:"bind-address"`
-	AuthEnabled        bool   `toml:"auth-enabled"`
-	LogEnabled         bool   `toml:"log-enabled"`
-	WriteTracing       bool   `toml:"write-tracing"`
-	PprofEnabled       bool   `toml:"pprof-enabled"`
-	HTTPSEnabled       bool   `toml:"https-enabled"`
-	HTTPSCertificate   string `toml:"https-certificate"`
-	HTTPSPrivateKey    string `toml:"https-private-key"`
-	MaxRowLimit        int    `toml:"max-row-limit"`
-	MaxConnectionLimit int    `toml:"max-connection-limit"`
-	SharedSecret       string `toml:"shared-secret"`
-	Realm              string `toml:"realm"`
-	UnixSocketEnabled  bool   `toml:"unix-socket-enabled"`
-	BindSocket         string `toml:"bind-socket"`
-	MaxBodySize        int    `toml:"max-body-size"`
-	AccessLogPath      string `toml:"access-log-path"`
+	Enabled            bool          `toml:"enabled"`
+	BindAddress        string        `toml:"bind-address"`
+	AuthEnabled        bool          `toml:"auth-enabled"`
+	LogEnabled         bool          `toml:"log-enabled"`
+	WriteTracing       bool          `toml:"write-tracing"`
+	PprofEnabled       bool          `toml:"pprof-enabled"`
+	HTTPSEnabled       bool          `toml:"https-enabled"`
+	HTTPSCertificate   string        `toml:"https-certificate"`
+	HTTPSPrivateKey    string        `toml:"https-private-key"`
+	MaxRowLimit        int           `toml:"max-row-limit"`
+	MaxConnectionLimit int           `toml:"max-connection-limit"`
+	SharedSecret       string        `toml:"shared-secret"`
+	Realm              string        `toml:"realm"`
+	UnixSocketEnabled  bool          `toml:"unix-socket-enabled"`
+	BindSocket         string        `toml:"bind-socket"`
+	MaxBodySize        int           `toml:"max-body-size"`
+	AccessLogPath      string        `toml:"access-log-path"`
+	AccessLogLevel     zapcore.Level `toml:"access-log-level"`
 }
 
 // NewConfig returns a new Config with default settings.
@@ -51,6 +55,7 @@ func NewConfig() Config {
 		UnixSocketEnabled: false,
 		BindSocket:        DefaultBindSocket,
 		MaxBodySize:       DefaultMaxBodySize,
+		AccessLogLevel:    zapcore.InfoLevel,
 	}
 }
 


### PR DESCRIPTION
If set to error, it will only print 5xx responses. If set to info or
lower, it will print everything.

- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>