### PR TITLE
Fix missing Store.Close() unlock.

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -358,6 +358,7 @@ func (s *Store) Close() error {
 	for _, sfile := range s.sfiles {
 		// Close out the series files.
 		if err := sfile.Close(); err != nil {
+			s.mu.Unlock()
 			return err
 		}
 	}


### PR DESCRIPTION
Add a missing `sync.Mutex.Unlock()` to `Store.Close()`