### PR TITLE
Rename some of the structs and interfaces in the query package

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -70,7 +70,7 @@ type Server struct {
 	MetaClient *meta.Client
 
 	TSDBStore     *tsdb.Store
-	QueryExecutor *query.QueryExecutor
+	QueryExecutor *query.Executor
 	PointsWriter  *coordinator.PointsWriter
 	Subscriber    *subscriber.Service
 
@@ -178,7 +178,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 	s.PointsWriter.TSDBStore = s.TSDBStore
 
 	// Initialize query executor.
-	s.QueryExecutor = query.NewQueryExecutor()
+	s.QueryExecutor = query.NewExecutor()
 	s.QueryExecutor.StatementExecutor = &coordinator.StatementExecutor{
 		MetaClient:  s.MetaClient,
 		TaskManager: s.QueryExecutor.TaskManager,

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -1216,7 +1216,7 @@ func (e *StatementExecutor) writeInto(w pointsWriter, stmt *influxql.SelectState
 	// convert rows back to points. The Executors (both aggregate and raw) are complex
 	// enough that changing them to write back to the DB is going to be clumsy
 	//
-	// it might seem weird to have the write be in the QueryExecutor, but the interweaving of
+	// it might seem weird to have the write be in the Executor, but the interweaving of
 	// limitedRowWriter and ExecuteAggregate/Raw makes it ridiculously hard to make sure that the
 	// results will be the same as when queried normally.
 	name := stmt.Target.Measurement.Name

--- a/query/executor_test.go
+++ b/query/executor_test.go
@@ -21,8 +21,8 @@ func (e *StatementExecutor) ExecuteStatement(stmt influxql.Statement, ctx query.
 	return e.ExecuteStatementFn(stmt, ctx)
 }
 
-func NewQueryExecutor() *query.QueryExecutor {
-	return query.NewQueryExecutor()
+func NewQueryExecutor() *query.Executor {
+	return query.NewExecutor()
 }
 
 func TestQueryExecutor_AttachQuery(t *testing.T) {

--- a/query/monitor.go
+++ b/query/monitor.go
@@ -4,7 +4,7 @@ import "time"
 
 // PointLimitMonitor is a query monitor that exits when the number of points
 // emitted exceeds a threshold.
-func PointLimitMonitor(itrs Iterators, interval time.Duration, limit int) QueryMonitorFunc {
+func PointLimitMonitor(itrs Iterators, interval time.Duration, limit int) MonitorFunc {
 	return func(closing <-chan struct{}) error {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()

--- a/query/task_manager.go
+++ b/query/task_manager.go
@@ -54,7 +54,7 @@ type TaskManager struct {
 	Logger *zap.Logger
 
 	// Used for managing and tracking running queries.
-	queries  map[uint64]*QueryTask
+	queries  map[uint64]*Task
 	nextID   uint64
 	mu       sync.RWMutex
 	shutdown bool
@@ -65,7 +65,7 @@ func NewTaskManager() *TaskManager {
 	return &TaskManager{
 		QueryTimeout: DefaultQueryTimeout,
 		Logger:       zap.NewNop(),
-		queries:      make(map[uint64]*QueryTask),
+		queries:      make(map[uint64]*Task),
 		nextID:       1,
 	}
 }
@@ -150,7 +150,7 @@ func (t *TaskManager) queryError(qid uint64, err error) {
 // query finishes running.
 //
 // After a query finishes running, the system is free to reuse a query id.
-func (t *TaskManager) AttachQuery(q *influxql.Query, database string, interrupt <-chan struct{}) (uint64, *QueryTask, error) {
+func (t *TaskManager) AttachQuery(q *influxql.Query, database string, interrupt <-chan struct{}) (uint64, *Task, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -163,7 +163,7 @@ func (t *TaskManager) AttachQuery(q *influxql.Query, database string, interrupt 
 	}
 
 	qid := t.nextID
-	query := &QueryTask{
+	query := &Task{
 		query:     q.String(),
 		database:  database,
 		status:    RunningTask,

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -82,7 +82,7 @@ func (nullMonitor) WritePoints(models.Points) error { return nil }
 // Service manages continuous query execution.
 type Service struct {
 	MetaClient    metaClient
-	QueryExecutor *query.QueryExecutor
+	QueryExecutor *query.Executor
 	Monitor       Monitor
 	Config        *Config
 	RunInterval   time.Duration
@@ -420,7 +420,7 @@ func (s *Service) ExecuteContinuousQuery(dbi *meta.DatabaseInfo, cqi *meta.Conti
 
 // runContinuousQueryAndWriteResult will run the query against the cluster and write the results back in
 func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) *query.Result {
-	// Wrap the CQ's inner SELECT statement in a Query for the QueryExecutor.
+	// Wrap the CQ's inner SELECT statement in a Query for the Executor.
 	q := &influxql.Query{
 		Statements: influxql.Statements([]influxql.Statement{cq.q}),
 	}

--- a/services/continuous_querier/service_test.go
+++ b/services/continuous_querier/service_test.go
@@ -686,7 +686,7 @@ func NewTestService(t *testing.T) *Service {
 	s := NewService(NewConfig())
 	ms := NewMetaClient(t)
 	s.MetaClient = ms
-	s.QueryExecutor = query.NewQueryExecutor()
+	s.QueryExecutor = query.NewExecutor()
 	s.RunInterval = time.Millisecond
 
 	// Set Logger to write to dev/null so stdout isn't polluted.

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -97,7 +97,7 @@ type Handler struct {
 		AuthorizeWrite(username, database string) error
 	}
 
-	QueryExecutor *query.QueryExecutor
+	QueryExecutor *query.Executor
 
 	Monitor interface {
 		Statistics(tags map[string]string) ([]*monitor.Statistic, error)

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -922,7 +922,7 @@ func NewHandler(requireAuthentication bool) *Handler {
 	h.MetaClient = &internal.MetaClientMock{}
 
 	h.Handler.MetaClient = h.MetaClient
-	h.Handler.QueryExecutor = query.NewQueryExecutor()
+	h.Handler.QueryExecutor = query.NewExecutor()
 	h.Handler.QueryExecutor.StatementExecutor = &h.StatementExecutor
 	h.Handler.QueryAuthorizer = &h.QueryAuthorizer
 	h.Handler.PointsWriter = &h.PointsWriter


### PR DESCRIPTION
Remove the `Query` prefix from some structs and interfaces. They were
there so when the query engine was in the same package as influxql,
these would be differentiated. Now that the package name is query, the
extra prefix seems redundant.