### PR TITLE
Turn the ExecutionContext into a context.Context

### DIFF
--- a/query/compile.go
+++ b/query/compile.go
@@ -874,10 +874,11 @@ func (c *compiledStatement) Prepare(shardMapper ShardMapper, sopt SelectOptions)
 
 	columns := stmt.ColumnNames()
 	return &preparedStatement{
-		stmt:    stmt,
-		opt:     opt,
-		ic:      shards,
-		columns: columns,
-		now:     c.Options.Now,
+		stmt:      stmt,
+		opt:       opt,
+		ic:        shards,
+		columns:   columns,
+		maxPointN: sopt.MaxPointN,
+		now:       c.Options.Now,
 	}, nil
 }

--- a/query/execution_context.go
+++ b/query/execution_context.go
@@ -1,0 +1,113 @@
+package query
+
+import (
+	"context"
+	"sync"
+)
+
+// ExecutionContext contains state that the query is currently executing with.
+type ExecutionContext struct {
+	context.Context
+
+	// The statement ID of the executing query.
+	statementID int
+
+	// The query ID of the executing query.
+	QueryID uint64
+
+	// The query task information available to the StatementExecutor.
+	task *Task
+
+	// Output channel where results and errors should be sent.
+	Results chan *Result
+
+	// Options used to start this query.
+	ExecutionOptions
+
+	mu   sync.RWMutex
+	done chan struct{}
+	err  error
+}
+
+func (ctx *ExecutionContext) watch() {
+	ctx.done = make(chan struct{})
+	if ctx.err != nil {
+		close(ctx.done)
+		return
+	}
+
+	go func() {
+		defer close(ctx.done)
+
+		var taskCtx <-chan struct{}
+		if ctx.task != nil {
+			taskCtx = ctx.task.closing
+		}
+
+		select {
+		case <-taskCtx:
+			ctx.err = ctx.task.Error()
+			if ctx.err == nil {
+				ctx.err = ErrQueryInterrupted
+			}
+		case <-ctx.AbortCh:
+			ctx.err = ErrQueryAborted
+		case <-ctx.Context.Done():
+			ctx.err = ctx.Context.Err()
+		}
+	}()
+}
+
+func (ctx *ExecutionContext) Done() <-chan struct{} {
+	ctx.mu.RLock()
+	if ctx.done != nil {
+		defer ctx.mu.RUnlock()
+		return ctx.done
+	}
+	ctx.mu.RUnlock()
+
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	if ctx.done == nil {
+		ctx.watch()
+	}
+	return ctx.done
+}
+
+func (ctx *ExecutionContext) Err() error {
+	ctx.mu.RLock()
+	defer ctx.mu.RUnlock()
+	return ctx.err
+}
+
+func (ctx *ExecutionContext) Value(key interface{}) interface{} {
+	switch key {
+	case monitorContextKey:
+		return ctx.task
+	}
+	return ctx.Context.Value(key)
+}
+
+// send sends a Result to the Results channel and will exit if the query has
+// been aborted.
+func (ctx *ExecutionContext) send(result *Result) error {
+	result.StatementID = ctx.statementID
+	select {
+	case <-ctx.AbortCh:
+		return ErrQueryAborted
+	case ctx.Results <- result:
+	}
+	return nil
+}
+
+// Send sends a Result to the Results channel and will exit if the query has
+// been interrupted or aborted.
+func (ctx *ExecutionContext) Send(result *Result) error {
+	result.StatementID = ctx.statementID
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case ctx.Results <- result:
+	}
+	return nil
+}

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -791,7 +791,6 @@ func newIteratorOptionsStmt(stmt *influxql.SelectStatement, sopt SelectOptions) 
 	opt.Limit, opt.Offset = stmt.Limit, stmt.Offset
 	opt.SLimit, opt.SOffset = stmt.SLimit, stmt.SOffset
 	opt.MaxSeriesN = sopt.MaxSeriesN
-	opt.InterruptCh = sopt.InterruptCh
 	opt.Authorizer = sopt.Authorizer
 
 	return opt, nil

--- a/query/monitor.go
+++ b/query/monitor.go
@@ -1,6 +1,31 @@
 package query
 
-import "time"
+import (
+	"context"
+	"time"
+)
+
+// MonitorFunc is a function that will be called to check if a query
+// is currently healthy. If the query needs to be interrupted for some reason,
+// the error should be returned by this function.
+type MonitorFunc func(<-chan struct{}) error
+
+// Monitor monitors the status of a query and returns whether the query should
+// be aborted with an error.
+type Monitor interface {
+	// Monitor starts a new goroutine that will monitor a query. The function
+	// will be passed in a channel to signal when the query has been finished
+	// normally. If the function returns with an error and the query is still
+	// running, the query will be terminated.
+	Monitor(fn MonitorFunc)
+}
+
+// MonitorFromContext returns a Monitor embedded within the Context
+// if one exists.
+func MonitorFromContext(ctx context.Context) Monitor {
+	v, _ := ctx.Value(monitorContextKey).(Monitor)
+	return v
+}
 
 // PointLimitMonitor is a query monitor that exits when the number of points
 // emitted exceeds a threshold.

--- a/query/monitor_test.go
+++ b/query/monitor_test.go
@@ -1,0 +1,57 @@
+package query_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/query"
+	"github.com/influxdata/influxql"
+)
+
+func TestPointLimitMonitor(t *testing.T) {
+	t.Parallel()
+
+	stmt := MustParseSelectStatement(`SELECT mean(value) FROM cpu`)
+
+	// Create a new task manager so we can use the query task as a monitor.
+	taskManager := query.NewTaskManager()
+	ctx, detach, err := taskManager.AttachQuery(&influxql.Query{
+		Statements: []influxql.Statement{stmt},
+	}, query.ExecutionOptions{}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	defer detach()
+
+	shardMapper := ShardMapper{
+		MapShardsFn: func(sources influxql.Sources, t influxql.TimeRange) query.ShardGroup {
+			return &ShardGroup{
+				CreateIteratorFn: func(ctx context.Context, m *influxql.Measurement, opt query.IteratorOptions) (query.Iterator, error) {
+					return &FloatIterator{
+						Points: []query.FloatPoint{
+							{Name: "cpu", Value: 35},
+						},
+						Context: ctx,
+						Delay:   2 * time.Second,
+						stats: query.IteratorStats{
+							PointN: 10,
+						},
+					}, nil
+				},
+				Fields: map[string]influxql.DataType{
+					"value": influxql.Float,
+				},
+			}
+		},
+	}
+
+	itrs, _, err := query.Select(ctx, stmt, &shardMapper, query.SelectOptions{
+		MaxPointN: 1,
+	})
+	if _, err := Iterators(itrs).ReadAll(); err == nil {
+		t.Fatalf("expected an error")
+	} else if got, want := err.Error(), "max-select-point limit exceeed: (10/1)"; got != want {
+		t.Fatalf("unexpected error: got=%v want=%v", got, want)
+	}
+}


### PR DESCRIPTION
Along with modifying ExecutionContext to be a context and have the
TaskManager return the context itself, this also creates a Monitor
interface and exposes the Monitor through the Context. This way, we can
access the monitor from within the query.Select method and keep all of
the limits inside of the query package instead of leaking them into the
statement executor.

An eventual goal is to remove the InterruptCh from the IteratorOptions
and use the Context instead, but for now, we'll just assign the done
channel from the Context to the IteratorOptions so at least they refer
to the same channel.