### PR TITLE
Add option to disable WAL

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -155,6 +155,7 @@ type EngineOptions struct {
 
 	CompactionLimiter           limiter.Fixed
 	CompactionThroughputLimiter limiter.Rate
+	WALEnabled                  bool
 
 	Config       Config
 	SeriesIDSets SeriesIDSets
@@ -166,6 +167,7 @@ func NewEngineOptions() EngineOptions {
 		EngineVersion: DefaultEngine,
 		IndexVersion:  DefaultIndex,
 		Config:        NewConfig(),
+		WALEnabled:    true,
 	}
 }
 


### PR DESCRIPTION
This adds an internal option (not exposed via config) to disable the WAL
when using the TSM engine directly.
