### PR TITLE
Optimize models.MakeKey

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -64,6 +64,9 @@ type Point interface {
 	// Tags returns the tag set for the point.
 	Tags() Tags
 
+	// ForEachTag iterates over each tag invoking fn.  If fn return false, iteration stops.
+	ForEachTag(fn func(k, v []byte) bool)
+
 	// AddTag adds or replaces a tag value for a point.
 	AddTag(key, value string)
 
@@ -1473,6 +1476,10 @@ func (p *point) Tags() Tags {
 	}
 	p.cachedTags = parseTags(p.key)
 	return p.cachedTags
+}
+
+func (p *point) ForEachTag(fn func(k, v []byte) bool) {
+	walkTags(p.key, fn)
 }
 
 func (p *point) HasTag(tag []byte) bool {

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -2388,6 +2388,18 @@ func BenchmarkParseTags(b *testing.B) {
 	}
 }
 
+func BenchmarkMakeKey(b *testing.B) {
+	name := []byte("cpu")
+	tags := models.NewTags(map[string]string{
+		"host":   "server01",
+		"region": "us-west2",
+		"zone":   "a",
+	})
+	for i := 0; i < b.N; i++ {
+		models.MakeKey(name, tags)
+	}
+}
+
 func init() {
 	// Force uint support to be enabled for testing.
 	models.EnableUintSupport()


### PR DESCRIPTION
Optimizes `models.MakeKey` this was showing up in some profiles for writes.

```
benchcmp /tmp/old.txt /tmp/new.txt
benchmark              old ns/op     new ns/op     delta
BenchmarkMakeKey-8     1139          177           -84.46%

benchmark              old allocs     new allocs     delta
BenchmarkMakeKey-8     7              2              -71.43%

benchmark              old bytes     new bytes     delta
BenchmarkMakeKey-8     272           96            -64.71%
```