### PR TITLE
Performance improvements to MakeKey and HashKey APIs

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -16,16 +16,21 @@ import (
 	"github.com/influxdata/influxdb/pkg/escape"
 )
 
+type escapeSet struct {
+	k   [1]byte
+	esc [2]byte
+}
+
 var (
-	measurementEscapeCodes = map[byte][]byte{
-		',': []byte(`\,`),
-		' ': []byte(`\ `),
+	measurementEscapeCodes = [...]escapeSet{
+		{k: [1]byte{','}, esc: [2]byte{'\\', ','}},
+		{k: [1]byte{' '}, esc: [2]byte{'\\', ' '}},
 	}
 
-	tagEscapeCodes = map[byte][]byte{
-		',': []byte(`\,`),
-		' ': []byte(`\ `),
-		'=': []byte(`\=`),
+	tagEscapeCodes = [...]escapeSet{
+		{k: [1]byte{','}, esc: [2]byte{'\\', ','}},
+		{k: [1]byte{' '}, esc: [2]byte{'\\', ' '}},
+		{k: [1]byte{'='}, esc: [2]byte{'\\', '='}},
 	}
 
 	// ErrPointMustHaveAField is returned when operating on a point that does not have any fields.
@@ -1199,23 +1204,33 @@ func scanFieldValue(buf []byte, i int) (int, []byte) {
 }
 
 func EscapeMeasurement(in []byte) []byte {
-	for b, esc := range measurementEscapeCodes {
-		in = bytes.Replace(in, []byte{b}, esc, -1)
+	for _, c := range measurementEscapeCodes {
+		if bytes.IndexByte(in, c.k[0]) != -1 {
+			in = bytes.Replace(in, c.k[:], c.esc[:], -1)
+		}
 	}
 	return in
 }
 
 func unescapeMeasurement(in []byte) []byte {
-	for b, esc := range measurementEscapeCodes {
-		in = bytes.Replace(in, esc, []byte{b}, -1)
+	if bytes.IndexByte(in, '\\') == -1 {
+		return in
+	}
+
+	for i := range measurementEscapeCodes {
+		c := &measurementEscapeCodes[i]
+		if bytes.IndexByte(in, c.k[0]) != -1 {
+			in = bytes.Replace(in, c.esc[:], c.k[:], -1)
+		}
 	}
 	return in
 }
 
 func escapeTag(in []byte) []byte {
-	for b, esc := range tagEscapeCodes {
-		if bytes.IndexByte(in, b) != -1 {
-			in = bytes.Replace(in, []byte{b}, esc, -1)
+	for i := range tagEscapeCodes {
+		c := &tagEscapeCodes[i]
+		if bytes.IndexByte(in, c.k[0]) != -1 {
+			in = bytes.Replace(in, c.k[:], c.esc[:], -1)
 		}
 	}
 	return in
@@ -1226,9 +1241,10 @@ func unescapeTag(in []byte) []byte {
 		return in
 	}
 
-	for b, esc := range tagEscapeCodes {
-		if bytes.IndexByte(in, b) != -1 {
-			in = bytes.Replace(in, esc, []byte{b}, -1)
+	for i := range tagEscapeCodes {
+		c := &tagEscapeCodes[i]
+		if bytes.IndexByte(in, c.k[0]) != -1 {
+			in = bytes.Replace(in, c.esc[:], c.k[:], -1)
 		}
 	}
 	return in
@@ -1541,9 +1557,16 @@ func parseTags(buf []byte) Tags {
 
 // MakeKey creates a key for a set of tags.
 func MakeKey(name []byte, tags Tags) []byte {
+	return AppendMakeKey(nil, name, tags)
+}
+
+// AppendMakeKey appends the key derived from name and tags to dst and returns the extended buffer.
+func AppendMakeKey(dst []byte, name []byte, tags Tags) []byte {
 	// unescape the name and then re-escape it to avoid double escaping.
 	// The key should always be stored in escaped form.
-	return append(EscapeMeasurement(unescapeMeasurement(name)), tags.HashKey()...)
+	dst = append(dst, EscapeMeasurement(unescapeMeasurement(name))...)
+	dst = tags.AppendHashKey(dst)
+	return dst
 }
 
 // SetTags replaces the tags for the point.
@@ -1911,8 +1934,8 @@ func (a Tags) String() string {
 // for data structures or delimiters for example.
 func (a Tags) Size() int {
 	var total int
-	for _, t := range a {
-		total += t.Size()
+	for i := range a {
+		total += a[i].Size()
 	}
 	return total
 }
@@ -2045,42 +2068,78 @@ func (a Tags) Merge(other map[string]string) Tags {
 
 // HashKey hashes all of a tag's keys.
 func (a Tags) HashKey() []byte {
+	return a.AppendHashKey(nil)
+}
+
+func (a Tags) needsEscape() bool {
+	for i := range a {
+		t := &a[i]
+		for j := range tagEscapeCodes {
+			c := &tagEscapeCodes[j]
+			if bytes.IndexByte(t.Key, c.k[0]) != -1 || bytes.IndexByte(t.Value, c.k[0]) != -1 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// AppendHashKey appends the result of hashing all of a tag's keys and values to dst and returns the extended buffer.
+func (a Tags) AppendHashKey(dst []byte) []byte {
 	// Empty maps marshal to empty bytes.
 	if len(a) == 0 {
-		return nil
+		return dst
 	}
 
 	// Type invariant: Tags are sorted
 
-	escaped := make(Tags, 0, len(a))
 	sz := 0
-	for _, t := range a {
-		ek := escapeTag(t.Key)
-		ev := escapeTag(t.Value)
-
-		if len(ev) > 0 {
-			escaped = append(escaped, Tag{Key: ek, Value: ev})
-			sz += len(ek) + len(ev)
+	var escaped Tags
+	if a.needsEscape() {
+		var tmp [20]Tag
+		if len(a) < len(tmp) {
+			escaped = tmp[:len(a)]
+		} else {
+			escaped = make(Tags, len(a))
 		}
+
+		for i := range a {
+			t := &a[i]
+			nt := &escaped[i]
+			nt.Key = escapeTag(t.Key)
+			nt.Value = escapeTag(t.Value)
+			sz += len(nt.Key) + len(nt.Value)
+		}
+	} else {
+		sz = a.Size()
+		escaped = a
 	}
 
 	sz += len(escaped) + (len(escaped) * 2) // separators
 
 	// Generate marshaled bytes.
-	b := make([]byte, sz)
-	buf := b
+	if cap(dst)-len(dst) < sz {
+		nd := make([]byte, len(dst), len(dst)+sz)
+		copy(nd, dst)
+		dst = nd
+	}
+	buf := dst[len(dst) : len(dst)+sz]
 	idx := 0
-	for _, k := range escaped {
+	for i := range escaped {
+		k := &escaped[i]
+		if len(k.Value) == 0 {
+			continue
+		}
 		buf[idx] = ','
 		idx++
-		copy(buf[idx:idx+len(k.Key)], k.Key)
+		copy(buf[idx:], k.Key)
 		idx += len(k.Key)
 		buf[idx] = '='
 		idx++
-		copy(buf[idx:idx+len(k.Value)], k.Value)
+		copy(buf[idx:], k.Value)
 		idx += len(k.Value)
 	}
-	return b[:idx]
+	return dst[:len(dst)+idx]
 }
 
 // CopyTags returns a shallow copy of tags.

--- a/models/points.go
+++ b/models/points.go
@@ -69,6 +69,9 @@ type Point interface {
 	// Tags returns the tag set for the point.
 	Tags() Tags
 
+	// ForEachTag iterates over each tag invoking fn.  If fn return false, iteration stops.
+	ForEachTag(fn func(k, v []byte) bool)
+
 	// AddTag adds or replaces a tag value for a point.
 	AddTag(key, value string)
 
@@ -1459,6 +1462,10 @@ func (p *point) Tags() Tags {
 	}
 	p.cachedTags = parseTags(p.key)
 	return p.cachedTags
+}
+
+func (p *point) ForEachTag(fn func(k, v []byte) bool) {
+	walkTags(p.key, fn)
 }
 
 func (p *point) HasTag(tag []byte) bool {

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -2388,6 +2388,78 @@ func BenchmarkParseTags(b *testing.B) {
 	}
 }
 
+func BenchmarkEscapeMeasurement(b *testing.B) {
+	benchmarks := []struct {
+		m []byte
+	}{
+		{[]byte("this_is_a_test")},
+		{[]byte("this,is,a,test")},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(string(bm.m), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				models.EscapeMeasurement(bm.m)
+			}
+		})
+	}
+}
+
+func makeTags(key, val string, n int) models.Tags {
+	tags := make(models.Tags, n)
+	for i := range tags {
+		tags[i].Key = []byte(fmt.Sprintf("%s%03d", key, i))
+		tags[i].Value = []byte(fmt.Sprintf("%s%03d", val, i))
+	}
+	return tags
+}
+
+func BenchmarkTags_HashKey(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		t    models.Tags
+	}{
+		{"5 tags-no esc", makeTags("tag_foo", "val_bar", 5)},
+		{"25 tags-no esc", makeTags("tag_foo", "val_bar", 25)},
+		{"5 tags-esc", makeTags("tag foo", "val bar", 5)},
+		{"25 tags-esc", makeTags("tag foo", "val bar", 25)},
+	}
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				bm.t.HashKey()
+			}
+		})
+	}
+}
+
+func BenchmarkMakeKey(b *testing.B) {
+	benchmarks := []struct {
+		m []byte
+		t models.Tags
+	}{
+		{[]byte("this_is_a_test"), nil},
+		{[]byte("this,is,a,test"), nil},
+		{[]byte(`this\ is\ a\ test`), nil},
+
+		{[]byte("this_is_a_test"), makeTags("tag_foo", "val_bar", 8)},
+		{[]byte("this,is,a,test"), makeTags("tag_foo", "val_bar", 8)},
+		{[]byte("this_is_a_test"), makeTags("tag_foo", "val bar", 8)},
+		{[]byte("this,is,a,test"), makeTags("tag_foo", "val bar", 8)},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(string(bm.m), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				models.MakeKey(bm.m, bm.t)
+			}
+		})
+	}
+}
+
 func init() {
 	// Force uint support to be enabled for testing.
 	models.EnableUintSupport()


### PR DESCRIPTION
```
name                                old time/op    new time/op    delta
EscapeMeasurement/this_is_a_test-8     142ns ± 3%      17ns ± 4%   -87.93%  (p=0.008 n=5+5)
EscapeMeasurement/this,is,a,test-8     195ns ± 1%     101ns ± 4%   -48.05%  (p=0.008 n=5+5)
Tags_HashKey/5_tags-no_esc-8          1.04µs ± 2%    0.25µs ±14%   -75.78%  (p=0.008 n=5+5)
Tags_HashKey/25_tags-no_esc-8         4.85µs ± 2%    1.00µs ± 4%   -79.27%  (p=0.008 n=5+5)
Tags_HashKey/5_tags-esc-8             1.79µs ±11%    0.82µs ± 1%   -53.86%  (p=0.008 n=5+5)
Tags_HashKey/25_tags-esc-8            8.02µs ± 0%    4.14µs ± 0%   -48.34%  (p=0.016 n=4+5)
MakeKey/this_is_a_test-8               327ns ± 1%      73ns ± 1%   -77.70%  (p=0.016 n=5+4)
MakeKey/this,is,a,test-8               392ns ± 3%     163ns ± 3%   -58.48%  (p=0.008 n=5+5)
MakeKey/this\_is\_a\_test-8            458ns ± 2%     293ns ± 3%   -35.97%  (p=0.008 n=5+5)
MakeKey/this_is_a_test#01-8           2.04µs ± 1%    0.40µs ± 0%   -80.50%  (p=0.016 n=5+4)
MakeKey/this,is,a,test#01-8           2.12µs ± 1%    0.50µs ± 1%   -76.33%  (p=0.008 n=5+5)
MakeKey/this_is_a_test#02-8           2.60µs ± 2%    0.94µs ± 2%   -63.75%  (p=0.008 n=5+5)
MakeKey/this,is,a,test#02-8           2.64µs ± 1%    1.03µs ± 3%   -60.84%  (p=0.008 n=5+5)

name                                old alloc/op   new alloc/op   delta
EscapeMeasurement/this_is_a_test-8     32.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
EscapeMeasurement/this,is,a,test-8     62.0B ± 0%     32.0B ± 0%      ~     (p=0.079 n=4+5)
Tags_HashKey/5_tags-no_esc-8            368B ± 0%      128B ± 0%   -65.22%  (p=0.008 n=5+5)
Tags_HashKey/25_tags-no_esc-8         1.86kB ± 0%    0.58kB ± 0%   -68.97%  (p=0.008 n=5+5)
Tags_HashKey/5_tags-esc-8               528B ± 0%      288B ± 0%   -45.45%  (p=0.008 n=5+5)
Tags_HashKey/25_tags-esc-8            2.72kB ± 0%    2.72kB ± 0%      ~     (all equal)
MakeKey/this_is_a_test-8               64.0B ± 0%     16.0B ± 0%   -75.00%  (p=0.008 n=5+5)
MakeKey/this,is,a,test-8               93.4B ± 1%     64.0B ± 0%   -31.48%  (p=0.008 n=5+5)
MakeKey/this\_is\_a\_test-8            95.6B ± 1%     80.0B ± 0%   -16.32%  (p=0.008 n=5+5)
MakeKey/this_is_a_test#01-8             832B ± 0%      224B ± 0%   -73.08%  (p=0.008 n=5+5)
MakeKey/this,is,a,test#01-8             878B ± 0%      272B ± 0%   -69.01%  (p=0.008 n=5+5)
MakeKey/this_is_a_test#02-8             976B ± 0%      352B ± 0%   -63.93%  (p=0.008 n=5+5)
MakeKey/this,is,a,test#02-8           1.01kB ± 0%    0.42kB ± 0%   -58.65%  (p=0.008 n=5+5)

name                                old allocs/op  new allocs/op  delta
EscapeMeasurement/this_is_a_test-8      2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
EscapeMeasurement/this,is,a,test-8      2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)
Tags_HashKey/5_tags-no_esc-8            2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)
Tags_HashKey/25_tags-no_esc-8           2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.008 n=5+5)
Tags_HashKey/5_tags-esc-8               12.0 ± 0%      11.0 ± 0%    -8.33%  (p=0.008 n=5+5)
Tags_HashKey/25_tags-esc-8              52.0 ± 0%      52.0 ± 0%      ~     (all equal)
MakeKey/this_is_a_test-8                4.00 ± 0%      1.00 ± 0%   -75.00%  (p=0.008 n=5+5)
MakeKey/this,is,a,test-8                4.00 ± 0%      2.00 ± 0%   -50.00%  (p=0.008 n=5+5)
MakeKey/this\_is\_a\_test-8             4.00 ± 0%      3.00 ± 0%   -25.00%  (p=0.008 n=5+5)
MakeKey/this_is_a_test#01-8             7.00 ± 0%      2.00 ± 0%   -71.43%  (p=0.008 n=5+5)
MakeKey/this,is,a,test#01-8             7.00 ± 0%      3.00 ± 0%   -57.14%  (p=0.008 n=5+5)
MakeKey/this_is_a_test#02-8             15.0 ± 0%      10.0 ± 0%   -33.33%  (p=0.008 n=5+5)
MakeKey/this,is,a,test#02-8             15.0 ± 0%      11.0 ± 0%   -26.67%  (p=0.008 n=5+5)
```