### PR TITLE
Refactor the math engine to compile the query and use eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 v1.6.0 [unreleased]
 -------------------
 
+### Breaking changes
+
+-	If math is used with the same selector multiple times, it will now act as a selector rather than an aggregate. See [#9563](https://github.com/influxdata/influxdb/pull/9563) for details.
+
 ### Features
 
 -	[#9429](https://github.com/influxdata/influxdb/pull/9429): Support proxy environment variables in the influx client.

--- a/query/executor.go
+++ b/query/executor.go
@@ -152,14 +152,6 @@ func NewContextWithIterators(ctx context.Context, itr *Iterators) context.Contex
 	return context.WithValue(ctx, iteratorsContextKey, itr)
 }
 
-// tryAddAuxIteratorToContext will capture itr in the *Iterators slice, when configured
-// with a call to NewContextWithIterators.
-func tryAddAuxIteratorToContext(ctx context.Context, itr AuxIterator) {
-	if v, ok := ctx.Value(iteratorsContextKey).(*Iterators); ok {
-		*v = append(*v, itr)
-	}
-}
-
 // StatementExecutor executes a statement within the Executor.
 type StatementExecutor interface {
 	// ExecuteStatement executes a statement. Results should be sent to the

--- a/query/functions.go
+++ b/query/functions.go
@@ -31,20 +31,49 @@ func (m FieldMapper) CallType(name string, args []influxql.DataType) (influxql.D
 	return typmap.CallType(name, args)
 }
 
-type FunctionTypeMapper struct{}
+// CallTypeMapper returns the types for call iterator functions.
+// Call iterator functions are commonly implemented within the storage engine
+// so this mapper is limited to only the return values of those functions.
+type CallTypeMapper struct{}
+
+func (CallTypeMapper) MapType(measurement *influxql.Measurement, field string) influxql.DataType {
+	return influxql.Unknown
+}
+
+func (CallTypeMapper) CallType(name string, args []influxql.DataType) (influxql.DataType, error) {
+	// If the function is not implemented by the embedded field mapper, then
+	// see if we implement the function and return the type here.
+	switch name {
+	case "mean":
+		return influxql.Float, nil
+	case "count":
+		return influxql.Integer, nil
+	case "min", "max", "sum", "first", "last":
+		// TODO(jsternberg): Verify the input type.
+		return args[0], nil
+	}
+	return influxql.Unknown, nil
+}
+
+// FunctionTypeMapper handles the type mapping for all functions implemented by the
+// query engine.
+type FunctionTypeMapper struct {
+	CallTypeMapper
+}
 
 func (FunctionTypeMapper) MapType(measurement *influxql.Measurement, field string) influxql.DataType {
 	return influxql.Unknown
 }
 
-func (FunctionTypeMapper) CallType(name string, args []influxql.DataType) (influxql.DataType, error) {
-	// If the function is not implemented by the embedded field mapper, then
-	// see if we implement the function and return the type here.
+func (m FunctionTypeMapper) CallType(name string, args []influxql.DataType) (influxql.DataType, error) {
+	if typ, err := m.CallTypeMapper.CallType(name, args); typ != influxql.Unknown || err != nil {
+		return typ, err
+	}
+
+	// Handle functions implemented by the query engine.
 	switch name {
-	case "mean", "median", "integral", "stddev":
+	case "median", "integral", "stddev":
 		return influxql.Float, nil
-	case "count":
-		return influxql.Integer, nil
 	case "elapsed":
 		return influxql.Integer, nil
 	default:

--- a/query/iterator.gen.go.tmpl
+++ b/query/iterator.gen.go.tmpl
@@ -490,6 +490,95 @@ type {{$k.name}}SortedMergeHeapItem struct {
 	itr       {{$k.Name}}Iterator
 }
 
+// {{$k.name}}IteratorScanner scans the results of a {{$k.Name}}Iterator into a map.
+type {{$k.name}}IteratorScanner struct {
+	input        *buf{{$k.Name}}Iterator
+	err          error
+	keys         []string
+	defaultValue interface{}
+}
+
+// new{{$k.Name}}IteratorScanner creates a new IteratorScanner.
+func new{{$k.Name}}IteratorScanner(input {{$k.Name}}Iterator, keys []string, defaultValue interface{}) *{{$k.name}}IteratorScanner {
+	return &{{$k.name}}IteratorScanner{
+		input: newBuf{{$k.Name}}Iterator(input),
+		keys: keys,
+		defaultValue: defaultValue,
+	}
+}
+
+func (s *{{$k.name}}IteratorScanner) Peek() (int64, string, Tags) {
+	if s.err != nil {
+		return ZeroTime, "", Tags{}
+	}
+
+	p, err := s.input.peek()
+	if err != nil {
+		s.err = err
+		return ZeroTime, "", Tags{}
+	} else if p == nil {
+		return ZeroTime, "", Tags{}
+	}
+	return p.Time, p.Name, p.Tags
+}
+
+func (s *{{$k.name}}IteratorScanner) ScanAt(ts int64, name string, tags Tags, m map[string]interface{}) {
+	if s.err != nil {
+		return
+	}
+
+	p, err := s.input.Next()
+	if err != nil {
+		s.err = err
+		return
+	} else if p == nil {
+		s.useDefaults(m)
+		return
+	} else if p.Time != ts || p.Name != name || !p.Tags.Equals(&tags) {
+		s.useDefaults(m)
+		s.input.unread(p)
+		return
+	}
+
+	if k := s.keys[0]; k != "" {
+		if p.Nil {
+			if s.defaultValue != SkipDefault {
+				m[k] = s.defaultValue
+			}
+		} else {
+			m[k] = p.Value
+		}
+	}
+	for i, v := range p.Aux {
+		k := s.keys[i+1]
+		switch v.(type) {
+		case float64, int64, uint64, string, bool:
+			m[k] = v
+		default:
+			// Insert the fill value if one was specified.
+			if s.defaultValue != SkipDefault {
+				m[k] = s.defaultValue
+			}
+		}
+	}
+}
+
+func (s *{{$k.name}}IteratorScanner) useDefaults(m map[string]interface{}) {
+	if s.defaultValue == SkipDefault {
+		return
+	}
+	for _, k := range s.keys {
+    if k == "" {
+      continue
+    }
+		m[k] = s.defaultValue
+	}
+}
+
+func (s *{{$k.name}}IteratorScanner) Stats() IteratorStats { return s.input.Stats() }
+func (s *{{$k.name}}IteratorScanner) Err() error { return s.err }
+func (s *{{$k.name}}IteratorScanner) Close() error { return s.input.Close() }
+
 // {{$k.name}}ParallelIterator represents an iterator that pulls data in a separate goroutine.
 type {{$k.name}}ParallelIterator struct {
 	input   {{$k.Name}}Iterator
@@ -903,170 +992,6 @@ func (itr *{{$k.name}}CloseInterruptIterator) Next() (*{{$k.Name}}Point, error) 
 			return nil, err
 		}
 	}
-	return p, nil
-}
-
-// aux{{$k.Name}}Point represents a combination of a point and an error for the AuxIterator.
-type aux{{$k.Name}}Point struct {
-	point *{{$k.Name}}Point
-	err   error
-}
-
-// {{$k.name}}AuxIterator represents a {{$k.name}} implementation of AuxIterator.
-type {{$k.name}}AuxIterator struct {
-	input      *buf{{$k.Name}}Iterator
-	output     chan aux{{$k.Name}}Point
-	fields     *auxIteratorFields
-	background bool
-	closer     sync.Once
-}
-
-func new{{$k.Name}}AuxIterator(input {{$k.Name}}Iterator, opt IteratorOptions) *{{$k.name}}AuxIterator {
-	return &{{$k.name}}AuxIterator{
-		input:  newBuf{{$k.Name}}Iterator(input),
-		output: make(chan aux{{$k.Name}}Point, 1),
-		fields: newAuxIteratorFields(opt),
-	}
-}
-
-func (itr *{{$k.name}}AuxIterator) Background() {
-	itr.background = true
-	itr.Start()
-	go DrainIterator(itr)
-}
-
-func (itr *{{$k.name}}AuxIterator) Start()                           { go itr.stream() }
-func (itr *{{$k.name}}AuxIterator) Stats() IteratorStats             { return itr.input.Stats() }
-
-func (itr *{{$k.name}}AuxIterator) Close() error {
-	var err error
-	itr.closer.Do(func() { err = itr.input.Close() })
-	return err
-}
-
-func (itr *{{$k.name}}AuxIterator) Next() (*{{$k.Name}}Point, error) {
-	p := <-itr.output
-	return p.point, p.err
-}
-func (itr *{{$k.name}}AuxIterator) Iterator(name string, typ influxql.DataType) Iterator    { return itr.fields.iterator(name, typ) }
-
-func (itr *{{.name}}AuxIterator) stream() {
-	for {
-		// Read next point.
-		p, err := itr.input.Next()
-		if err != nil {
-			itr.output <- aux{{$k.Name}}Point{err: err}
-			itr.fields.sendError(err)
-			break
-		} else if p == nil {
-			break
-		}
-
-		// Send point to output and to each field iterator.
-		itr.output <- aux{{$k.Name}}Point{point: p}
-		if ok := itr.fields.send(p); !ok && itr.background {
-			break
-		}
-	}
-
-	close(itr.output)
-	itr.fields.close()
-}
-
-// {{$k.name}}ChanIterator represents a new instance of {{$k.name}}ChanIterator.
-type {{$k.name}}ChanIterator struct {
-	buf struct {
-		i      int
-		filled bool
-		points [2]{{$k.Name}}Point
-	}
-	err  error
-	cond *sync.Cond
-	done bool
-}
-
-func (itr *{{$k.name}}ChanIterator) Stats() IteratorStats { return IteratorStats{} }
-
-func (itr *{{$k.name}}ChanIterator) Close() error {
-	itr.cond.L.Lock()
-	// Mark the channel iterator as done and signal all waiting goroutines to start again.
-	itr.done = true
-	itr.cond.Broadcast()
-	// Do not defer the unlock so we don't create an unnecessary allocation.
-	itr.cond.L.Unlock()
-	return nil
-}
-
-func (itr *{{$k.name}}ChanIterator) setBuf(name string, tags Tags, time int64, value interface{}) bool {
-	itr.cond.L.Lock()
-	defer itr.cond.L.Unlock()
-
-	// Wait for either the iterator to be done (so we don't have to set the value)
-	// or for the buffer to have been read and ready for another write.
-	for !itr.done && itr.buf.filled {
-		itr.cond.Wait()
-	}
-
-	// Do not set the value and return false to signal that the iterator is closed.
-	// Do this after the above wait as the above for loop may have exited because
-	// the iterator was closed.
-	if itr.done {
-		return false
-	}
-
-	switch v := value.(type) {
-	case {{$k.Type}}:
-		itr.buf.points[itr.buf.i] = {{$k.Name}}Point{Name: name, Tags: tags, Time: time, Value: v}
-{{if eq $k.Name "Float"}}
-	case int64:
-		itr.buf.points[itr.buf.i] = {{$k.Name}}Point{Name: name, Tags: tags, Time: time, Value: float64(v)}
-{{end}}
-	default:
-		itr.buf.points[itr.buf.i] = {{$k.Name}}Point{Name: name, Tags: tags, Time: time, Nil: true}
-	}
-	itr.buf.filled = true
-
-	// Signal to all waiting goroutines that a new value is ready to read.
-	itr.cond.Signal()
-	return true
-}
-
-func (itr *{{$k.name}}ChanIterator) setErr(err error) {
-	itr.cond.L.Lock()
-	defer itr.cond.L.Unlock()
-	itr.err = err
-
-	// Signal to all waiting goroutines that a new value is ready to read.
-	itr.cond.Signal()
-}
-
-func (itr *{{$k.name}}ChanIterator) Next() (*{{$k.Name}}Point, error) {
-	itr.cond.L.Lock()
-	defer itr.cond.L.Unlock()
-
-	// Check for an error and return one if there.
-	if itr.err != nil {
-		return nil, itr.err
-	}
-
-	// Wait until either a value is available in the buffer or
-	// the iterator is closed.
-	for !itr.done && !itr.buf.filled {
-		itr.cond.Wait()
-	}
-
-	// Return nil once the channel is done and the buffer is empty.
-	if itr.done && !itr.buf.filled {
-		return nil, nil
-	}
-
-	// Always read from the buffer if it exists, even if the iterator
-	// is closed. This prevents the last value from being truncated by
-	// the parent iterator.
-	p := &itr.buf.points[itr.buf.i]
-	itr.buf.i = (itr.buf.i + 1) % len(itr.buf.points)
-	itr.buf.filled = false
-	itr.cond.Signal()
 	return p, nil
 }
 
@@ -1620,13 +1545,7 @@ func (itr *{{$k.name}}IteratorMapper) Next() (*{{$k.Name}}Point, error) {
 }
 
 func (itr *{{$k.name}}IteratorMapper) Stats() IteratorStats {
-	stats := IteratorStats{}
-	if cur, ok := itr.cur.(*cursor); ok {
-		for _, itr := range cur.itrs {
-			stats.Add(itr.Stats())
-		}
-	}
-	return stats
+	return itr.cur.Stats()
 }
 
 func (itr *{{$k.name}}IteratorMapper) Close() error {

--- a/query/iterator_test.go
+++ b/query/iterator_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -767,44 +766,6 @@ func TestLimitIterator_Boolean(t *testing.T) {
 
 	if !input.Closed {
 		t.Error("iterator not closed")
-	}
-}
-
-// Ensure auxiliary iterators can be created for auxilary fields.
-func TestFloatAuxIterator(t *testing.T) {
-	itr := query.NewAuxIterator(
-		&FloatIterator{Points: []query.FloatPoint{
-			{Time: 0, Value: 1, Aux: []interface{}{float64(100), float64(200)}},
-			{Time: 1, Value: 2, Aux: []interface{}{float64(500), math.NaN()}},
-		}},
-		query.IteratorOptions{Aux: []influxql.VarRef{{Val: "f0", Type: influxql.Float}, {Val: "f1", Type: influxql.Float}}},
-	)
-
-	itrs := []query.Iterator{
-		itr,
-		itr.Iterator("f0", influxql.Unknown),
-		itr.Iterator("f1", influxql.Unknown),
-		itr.Iterator("f0", influxql.Unknown),
-	}
-	itr.Start()
-
-	if a, err := Iterators(itrs).ReadAll(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	} else if !deep.Equal(a, [][]query.Point{
-		{
-			&query.FloatPoint{Time: 0, Value: 1, Aux: []interface{}{float64(100), float64(200)}},
-			&query.FloatPoint{Time: 0, Value: float64(100)},
-			&query.FloatPoint{Time: 0, Value: float64(200)},
-			&query.FloatPoint{Time: 0, Value: float64(100)},
-		},
-		{
-			&query.FloatPoint{Time: 1, Value: 2, Aux: []interface{}{float64(500), math.NaN()}},
-			&query.FloatPoint{Time: 1, Value: float64(500)},
-			&query.FloatPoint{Time: 1, Value: math.NaN()},
-			&query.FloatPoint{Time: 1, Value: float64(500)},
-		},
-	}) {
-		t.Fatalf("unexpected points: %s", spew.Sdump(a))
 	}
 }
 

--- a/query/math.go
+++ b/query/math.go
@@ -1,0 +1,47 @@
+package query
+
+import (
+	"time"
+
+	"github.com/influxdata/influxql"
+)
+
+func isMathFunction(call *influxql.Call) bool {
+	return false
+}
+
+type MathTypeMapper struct{}
+
+func (MathTypeMapper) MapType(measurement *influxql.Measurement, field string) influxql.DataType {
+	return influxql.Unknown
+}
+
+func (MathTypeMapper) CallType(name string, args []influxql.DataType) (influxql.DataType, error) {
+	// TODO(jsternberg): Put math function call types here.
+	return influxql.Unknown, nil
+}
+
+type MathValuer struct {
+	Valuer influxql.Valuer
+}
+
+func (v *MathValuer) Value(key string) (interface{}, bool) {
+	if v.Valuer != nil {
+		return v.Valuer.Value(key)
+	}
+	return nil, false
+}
+
+func (v *MathValuer) Call(name string, args []influxql.Expr) (interface{}, bool) {
+	if v, ok := v.Valuer.(influxql.CallValuer); ok {
+		return v.Call(name, args)
+	}
+	return nil, false
+}
+
+func (v *MathValuer) Zone() *time.Location {
+	if v, ok := v.Valuer.(influxql.ZoneValuer); ok {
+		return v.Zone()
+	}
+	return nil
+}

--- a/query/monitor.go
+++ b/query/monitor.go
@@ -29,14 +29,14 @@ func MonitorFromContext(ctx context.Context) Monitor {
 
 // PointLimitMonitor is a query monitor that exits when the number of points
 // emitted exceeds a threshold.
-func PointLimitMonitor(itrs Iterators, interval time.Duration, limit int) MonitorFunc {
+func PointLimitMonitor(cur Cursor, interval time.Duration, limit int) MonitorFunc {
 	return func(closing <-chan struct{}) error {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				stats := itrs.Stats()
+				stats := cur.Stats()
 				if stats.PointN >= limit {
 					return ErrMaxSelectPointsLimitExceeded(stats.PointN, limit)
 				}

--- a/query/subquery.go
+++ b/query/subquery.go
@@ -30,11 +30,10 @@ func (b *subqueryBuilder) buildAuxIterator(ctx context.Context, opt IteratorOpti
 	}
 	subOpt.Aux = auxFields
 
-	itrs, err := buildIterators(ctx, b.stmt, b.ic, subOpt)
+	cur, err := buildCursor(ctx, b.stmt, b.ic, subOpt)
 	if err != nil {
 		return nil, err
 	}
-	cur := b.buildCursor(itrs, subOpt.Ascending)
 
 	// Construct the iterators for the subquery.
 	input := NewIteratorMapper(cur, nil, indexes, subOpt)
@@ -121,11 +120,10 @@ func (b *subqueryBuilder) buildVarRefIterator(ctx context.Context, expr *influxq
 	}
 	subOpt.Aux = auxFields
 
-	itrs, err := buildIterators(ctx, b.stmt, b.ic, subOpt)
+	cur, err := buildCursor(ctx, b.stmt, b.ic, subOpt)
 	if err != nil {
 		return nil, err
 	}
-	cur := b.buildCursor(itrs, subOpt.Ascending)
 
 	// Construct the iterators for the subquery.
 	input := NewIteratorMapper(cur, driver, indexes, subOpt)
@@ -134,19 +132,4 @@ func (b *subqueryBuilder) buildVarRefIterator(ctx context.Context, expr *influxq
 		input = NewFilterIterator(input, opt.Condition, subOpt)
 	}
 	return input, nil
-}
-
-func (b *subqueryBuilder) buildCursor(itrs []Iterator, ascending bool) Cursor {
-	columnNames := b.stmt.ColumnNames()
-	columns := make([]influxql.VarRef, len(itrs))
-	for i, itr := range itrs {
-		columns[i] = influxql.VarRef{
-			Val:  columnNames[i+1],
-			Type: iteratorDataType(itr),
-		}
-	}
-
-	cur := newCursor(itrs, columns, ascending)
-	cur.omitTime = true
-	return cur
 }

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -5570,13 +5570,12 @@ func TestServer_Query_PercentileDerivative(t *testing.T) {
 		},
 	}...)
 
-	for i, query := range test.queries {
+	if err := test.init(s); err != nil {
+		t.Fatalf("test init failed: %s", err)
+	}
+
+	for _, query := range test.queries {
 		t.Run(query.name, func(t *testing.T) {
-			if i == 0 {
-				if err := test.init(s); err != nil {
-					t.Fatalf("test init failed: %s", err)
-				}
-			}
 			if query.skip {
 				t.Skipf("SKIP:: %s", query.name)
 			}
@@ -5615,13 +5614,12 @@ func TestServer_Query_UnderscoreMeasurement(t *testing.T) {
 		},
 	}...)
 
-	for i, query := range test.queries {
+	if err := test.init(s); err != nil {
+		t.Fatalf("test init failed: %s", err)
+	}
+
+	for _, query := range test.queries {
 		t.Run(query.name, func(t *testing.T) {
-			if i == 0 {
-				if err := test.init(s); err != nil {
-					t.Fatalf("test init failed: %s", err)
-				}
-			}
 			if query.skip {
 				t.Skipf("SKIP:: %s", query.name)
 			}

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1221,6 +1221,11 @@ func (a Shards) MapType(measurement, field string) influxql.DataType {
 	return typ
 }
 
+func (a Shards) CallType(name string, args []influxql.DataType) (influxql.DataType, error) {
+	typmap := query.CallTypeMapper{}
+	return typmap.CallType(name, args)
+}
+
 func (a Shards) CreateIterator(ctx context.Context, measurement *influxql.Measurement, opt query.IteratorOptions) (query.Iterator, error) {
 	switch measurement.SystemIterator {
 	case "_series":


### PR DESCRIPTION
This change makes it so that we simplify the math engine so it doesn't
use a complicated set of nested iterators. That way, we have to change
math in one fewer place.

It also greatly simplifies the query engine as now we can create the
necessary iterators, join them by time, name, and tags, and then use the
cursor interface to read them and use eval to compute the result. It
makes it so the auxiliary iterators and all of their complexity can be
removed.

This also makes use of the new eval functionality that was recently
added to the influxql package.

No math functions have been added, but the scaffolding has been included
so things like trigonometry functions are just a single commit away.

This also introduces a small breaking change. Because of the call
optimization, it is now possible to use the same selector multiple times
as a selector. So if you do this:

    SELECT max(value) * 2, max(value) / 2 FROM cpu

This will now return the timestamp of the max value rather than zero
since this query is considered to have only a single selector rather
than multiple separate selectors. If any aspect of the selector is
different, such as different selector functions or different arguments,
it will consider the selectors to be aggregates like the old behavior.

Fixes #9511.