### PR TITLE
Ensure correct number of tags parsed when commas used

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -1551,12 +1551,12 @@ func parseTags(buf []byte) Tags {
 		return nil
 	}
 
-	tags := make(Tags, bytes.Count(buf, []byte(",")))
-	p := 0
+	// Series keys can contain escaped commas, therefore the number of commas
+	// in a series key only gives an estimation of the upper bound on the number
+	// of tags.
+	tags := make(Tags, 0, bytes.Count(buf, []byte(",")))
 	walkTags(buf, func(key, value []byte) bool {
-		tags[p].Key = key
-		tags[p].Value = value
-		p++
+		tags = append(tags, Tag{Key: key, Value: value})
 		return true
 	})
 	return tags


### PR DESCRIPTION
Fixes #9545.

This PR fixes a parsing bug that was causing extra tags to be
generated when the incoming point contained escaped commas.

As an optimisation, the slice of tags associated with a point was
being pre-allocated using the number of commas in the series key as a hint to
the appropriate size. The hinting did not consider literal comma values in
the key though, and so it was possible for extra (empty) tag key and
value pairs to be part of the tags structure associated with a parsed
point.

The fix here is simply to pre-allocate the capacity (which is the upper bound on the maximum number of tag pairs), and then to use the slightly slower `append`, rather than index into the slice directly.

I think this will still be faster than parsing the key to determine the true number of tag pairs and then pre-allocating the slice using the index approach.

