### PR TITLE
Allow SHOW SERIES kill

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -811,7 +811,13 @@ func (s *Shard) CreateIterator(ctx context.Context, m *influxql.Measurement, opt
 			return nil, err
 		}
 		indexSet := IndexSet{Indexes: []Index{index}, SeriesFile: s.sfile}
-		return NewSeriesPointIterator(indexSet, opt)
+
+		itr, err := NewSeriesPointIterator(indexSet, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		return query.NewInterruptIterator(itr, opt.InterruptCh), nil
 	case "_tagKeys":
 		return NewTagKeysIterator(s, opt)
 	}


### PR DESCRIPTION
Previously, large `SHOW SERIES` queries would block until merging was complete before being interrupted. Interruption checks have been added to the iterator and the merge loop. I also tried adding interruption checks to the sort phase but it's difficult to break out of `sort.Sort()` upon interruption.