### PR TITLE
Remove error for series file when no shards exist

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1267,7 +1267,7 @@ func (a Shards) createSeriesIterator(ctx context.Context, opt query.IteratorOpti
 	}
 
 	if sfile == nil {
-		return nil, errors.New("createSeriesIterator: no series file")
+		return nil, nil
 	}
 
 	return NewSeriesPointIterator(IndexSet{Indexes: idxs, SeriesFile: sfile}, opt)


### PR DESCRIPTION
A `nil` iterator should be returned on an empty shard set.