### PR TITLE
1.5: Revert "Use MADV_WILLNEED when loading TSM files"

### DIFF
--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -27,10 +27,6 @@ func munmap(b []byte) (err error) {
 	return unix.Munmap(b)
 }
 
-func madviseWillNeed(b []byte) error {
-	return madvise(b, syscall.MADV_WILLNEED)
-}
-
 func madviseDontNeed(b []byte) error {
 	return madvise(b, syscall.MADV_DONTNEED)
 }

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -121,10 +121,6 @@ func munmap(b []byte) (err error) {
 	return nil
 }
 
-func madviseWillNeed(b []byte) error {
-	return nil
-}
-
 func madviseDontNeed(b []byte) error {
 	// Not supported
 	return nil

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -1374,10 +1374,6 @@ func (m *mmapAccessor) init() (*indirectIndex, error) {
 		return nil, fmt.Errorf("mmapAccessor: invalid indexStart")
 	}
 
-	// Hint to the kernal that we will be reading the file.  It would be better to hint
-	// that we will be reading the index section, but that doesn't seem to work ATM.
-	_ = madviseWillNeed(m.b)
-
 	m.index = NewIndirectIndex()
 	if err := m.index.UnmarshalBinary(m.b[indexStart:indexOfsPos]); err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit ee270e1dd2135d91dbaf0b3adb25d9c2801b6639.