### PR TITLE
Remove error for series file when no shards exist

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1278,7 +1278,7 @@ func (a Shards) createSeriesIterator(ctx context.Context, opt query.IteratorOpti
 	}
 
 	if sfile == nil {
-		return nil, errors.New("createSeriesIterator: no series file")
+		return nil, nil
 	}
 
 	return NewSeriesPointIterator(IndexSet{Indexes: idxs, SeriesFile: sfile}, opt)


### PR DESCRIPTION
This was added to 1.5 but not `master`. Including the fix here too.

https://github.com/influxdata/influxdb/pull/9603