### PR TITLE
Fix flaky test TestServer_ConcurrentPointsWriter_Subscriber

### DIFF
--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -9158,7 +9158,10 @@ func TestServer_ConcurrentPointsWriter_Subscriber(t *testing.T) {
 	}
 	// goroutine to write points
 	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			select {
 			case <-done:
@@ -9176,6 +9179,7 @@ func TestServer_ConcurrentPointsWriter_Subscriber(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	close(done)
+	wg.Wait()
 }
 
 // Ensure time in where clause is inclusive


### PR DESCRIPTION
The LocalServer could be closed before the goroutine writing points
exited causing nil pointer panic.

Fixes #9583

###### Required for all non-trivial PRs
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
