### PR TITLE
Implement floor, ceil, and round functions

### DIFF
--- a/query/math.go
+++ b/query/math.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/influxdata/influxql"
@@ -8,7 +9,7 @@ import (
 
 func isMathFunction(call *influxql.Call) bool {
 	switch call.Name {
-	case "sin", "cos", "tan":
+	case "sin", "cos", "tan", "floor", "ceil", "round":
 		return true
 	}
 	return false
@@ -24,6 +25,13 @@ func (MathTypeMapper) CallType(name string, args []influxql.DataType) (influxql.
 	switch name {
 	case "sin", "cos", "tan":
 		return influxql.Float, nil
+	case "floor", "ceil", "round":
+		switch args[0] {
+		case influxql.Float, influxql.Integer, influxql.Unsigned, influxql.Unknown:
+			return args[0], nil
+		default:
+			return influxql.Unknown, fmt.Errorf("invalid argument type for first argument in %s(): %s", name, args[0])
+		}
 	}
 	return influxql.Unknown, nil
 }
@@ -46,6 +54,33 @@ func (v MathValuer) Call(name string, args []interface{}) (interface{}, bool) {
 			return v.callTrigFunction(math.Cos, arg0)
 		case "tan":
 			return v.callTrigFunction(math.Tan, arg0)
+		case "floor":
+			switch arg0 := arg0.(type) {
+			case float64:
+				return math.Floor(arg0), true
+			case int64, uint64:
+				return arg0, true
+			default:
+				return nil, true
+			}
+		case "ceil":
+			switch arg0 := arg0.(type) {
+			case float64:
+				return math.Ceil(arg0), true
+			case int64, uint64:
+				return arg0, true
+			default:
+				return nil, true
+			}
+		case "round":
+			switch arg0 := arg0.(type) {
+			case float64:
+				return round(arg0), true
+			case int64, uint64:
+				return arg0, true
+			default:
+				return nil, true
+			}
 		}
 	}
 	return nil, false
@@ -62,4 +97,12 @@ func (MathValuer) callTrigFunction(fn func(x float64) float64, arg0 interface{})
 		return nil, false
 	}
 	return fn(value), true
+}
+
+func round(x float64) float64 {
+	t := math.Trunc(x)
+	if math.Abs(x-t) >= 0.5 {
+		return t + math.Copysign(1, x)
+	}
+	return t
 }


### PR DESCRIPTION
implement  floor, ceil, round functions (listed in #5930) requested in #3691.

the functions has be implemented based on /query/math.go  as math functions. #9499
so all the (floor, ceiling, truncate) can be used anywhere such as in a field or an expression.

Example usage: 
`select load from cpu`

> name: cpu
>time                load
>1434055562000000000 42
>1434055562000000000 15.4
>1434055562000000000 78
---- 
`select floor(load) from cpu`
> name: cpu
> time                floor
> 1434055562000000000 42
> 1434055562000000000 15
> 1434055562000000000 78
---- 
`select ceil(load) from cpu
> name: cpu
> time                ceiling
> 1434055562000000000 42
> 1434055562000000000 16
> 1434055562000000000 78
---- 
`select round(load) from cpu`
> name: cpu
> time                truncate
> 1434055562000000000 42
> 1434055562000000000 15
> 1434055562000000000 78
---- 
###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
- [x] Provide example syntax
- [ ] Update man page when modifying a command