### PR TITLE
Use a null placeholder for NaN results

### DIFF
--- a/query/call_iterator.go
+++ b/query/call_iterator.go
@@ -846,9 +846,9 @@ func newStddevIterator(input Iterator, opt IteratorOptions) (Iterator, error) {
 
 // FloatStddevReduceSlice returns the stddev value within a window.
 func FloatStddevReduceSlice(a []FloatPoint) []FloatPoint {
-	// If there is only one point then return 0.
+	// If there is only one point then return NaN.
 	if len(a) < 2 {
-		return []FloatPoint{{Time: ZeroTime, Nil: true}}
+		return []FloatPoint{{Time: ZeroTime, Value: math.NaN()}}
 	}
 
 	// Calculate the mean.
@@ -878,9 +878,9 @@ func FloatStddevReduceSlice(a []FloatPoint) []FloatPoint {
 
 // IntegerStddevReduceSlice returns the stddev value within a window.
 func IntegerStddevReduceSlice(a []IntegerPoint) []FloatPoint {
-	// If there is only one point then return 0.
+	// If there is only one point then return NaN.
 	if len(a) < 2 {
-		return []FloatPoint{{Time: ZeroTime, Nil: true}}
+		return []FloatPoint{{Time: ZeroTime, Value: math.NaN()}}
 	}
 
 	// Calculate the mean.
@@ -904,9 +904,9 @@ func IntegerStddevReduceSlice(a []IntegerPoint) []FloatPoint {
 
 // UnsignedStddevReduceSlice returns the stddev value within a window.
 func UnsignedStddevReduceSlice(a []UnsignedPoint) []FloatPoint {
-	// If there is only one point then return 0.
+	// If there is only one point then return NaN.
 	if len(a) < 2 {
-		return []FloatPoint{{Time: ZeroTime, Nil: true}}
+		return []FloatPoint{{Time: ZeroTime, Value: math.NaN()}}
 	}
 
 	// Calculate the mean.

--- a/query/iterator_mapper.go
+++ b/query/iterator_mapper.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/influxdata/influxql"
 )
@@ -12,7 +13,15 @@ type IteratorMap interface {
 
 type FieldMap int
 
-func (i FieldMap) Value(row *Row) interface{} { return row.Values[i] }
+func (i FieldMap) Value(row *Row) interface{} {
+	v := row.Values[i]
+	if v == NullFloat {
+		// If the value is a null float, then convert it back to NaN
+		// so it is treated as a float for eval.
+		v = math.NaN()
+	}
+	return v
+}
 
 type TagMap string
 

--- a/query/select_test.go
+++ b/query/select_test.go
@@ -1389,8 +1389,8 @@ func TestSelect(t *testing.T) {
 			rows: []query.Row{
 				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{0.7071067811865476}},
 				{Time: 10 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{0.7071067811865476}},
-				{Time: 30 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{nil}},
-				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{nil}},
+				{Time: 30 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{query.NullFloat}},
+				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{query.NullFloat}},
 				{Time: 50 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{1.5811388300841898}},
 			},
 		},
@@ -1420,8 +1420,8 @@ func TestSelect(t *testing.T) {
 			rows: []query.Row{
 				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{0.7071067811865476}},
 				{Time: 10 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{0.7071067811865476}},
-				{Time: 30 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{nil}},
-				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{nil}},
+				{Time: 30 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{query.NullFloat}},
+				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{query.NullFloat}},
 				{Time: 50 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{1.5811388300841898}},
 			},
 		},
@@ -1451,8 +1451,8 @@ func TestSelect(t *testing.T) {
 			rows: []query.Row{
 				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{0.7071067811865476}},
 				{Time: 10 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{0.7071067811865476}},
-				{Time: 30 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{nil}},
-				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{nil}},
+				{Time: 30 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=A")}, Values: []interface{}{query.NullFloat}},
+				{Time: 0 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{query.NullFloat}},
 				{Time: 50 * Second, Series: query.Series{Name: "cpu", Tags: ParseTags("host=B")}, Values: []interface{}{1.5811388300841898}},
 			},
 		},


### PR DESCRIPTION
This ensures that NaN gets serialized as a null value and that it does
not get replaced with the fill value.