### PR TITLE
Fix curl commands in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,20 +15,20 @@ If you have never written a bug report before, or if you want to brush up on you
 Test cases should be in the form of `curl` commands. For example:
 ```bash
 # create database
-curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE mydb"
+curl -X POST http://localhost:8086/query --data-urlencode "q=CREATE DATABASE mydb"
 
 # create retention policy
-curl -G http://localhost:8086/query --data-urlencode "q=CREATE RETENTION POLICY myrp ON mydb DURATION 365d REPLICATION 1 DEFAULT"
+curl -X POST http://localhost:8086/query --data-urlencode "q=CREATE RETENTION POLICY myrp ON mydb DURATION 365d REPLICATION 1 DEFAULT"
 
 # write data
-curl -X POST http://localhost:8086/write --data-urlencode "db=mydb" --data-binary "cpu,region=useast,host=server_1,service=redis value=61"
+curl -X POST http://localhost:8086/write?db=mydb --data-binary "cpu,region=useast,host=server_1,service=redis value=61"
 
 # Delete a Measurement
-curl -G http://localhost:8086/query  --data-urlencode 'db=mydb' --data-urlencode 'q=DROP MEASUREMENT cpu'
+curl -X POST http://localhost:8086/query  --data-urlencode 'db=mydb' --data-urlencode 'q=DROP MEASUREMENT cpu'
 
 # Query the Measurement
 # Bug: expected it to return no data, but data comes back.
-curl -G http://localhost:8086/query  --data-urlencode 'db=mydb' --data-urlencode 'q=SELECT * from cpu'
+curl -X POST http://localhost:8086/query  --data-urlencode 'db=mydb' --data-urlencode 'q=SELECT * from cpu'
 ```
 **If you don't include a clear test case like this, your issue may not be investigated, and may even be closed**. If writing the data is too difficult, please zip up your data directory and include a link to it in your bug report.
 


### PR DESCRIPTION
The existing curl commands are not working due to implementation has changed.
For `query` api, warning was returned:
```
{
  "results": [
    {
      "statement_id": 0,
      "messages": [
        {
          "level": "warning",
          "text": "deprecated use of 'CREATE DATABASE mydb' in a read only context, please use a POST request instead"
        }
      ]
    }
  ]
}
```

For `write` api, error was returned:
```
{"error":"database is required"}
```

- Use POST in `query` api
- Move db to query parameter in `write` api

###### Required for all non-trivial PRs
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
