### PR TITLE
Ignore index size in Engine.DiskSize().

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -647,7 +647,7 @@ func (e *Engine) Statistics(tags map[string]string) []models.Statistic {
 
 // DiskSize returns the total size in bytes of all TSM and WAL segments on disk.
 func (e *Engine) DiskSize() int64 {
-	return e.FileStore.DiskSizeBytes() + e.WAL.DiskSizeBytes() + e.index.DiskSizeBytes()
+	return e.FileStore.DiskSizeBytes() + e.WAL.DiskSizeBytes()
 }
 
 // Open opens and initializes the engine.


### PR DESCRIPTION
## Overview

TSM includes index in DiskSize(), however, indexes are not copied and shouldn't be included in this method. This causes issues with `copy-shard`.