### PR TITLE
Fix buildtsi partition key.

### DIFF
--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -207,7 +207,7 @@ func (cmd *Command) processShard(sfile *tsdb.SeriesFile, dbName, rpName string, 
 			cmd.Logger.Info("series", zap.String("name", string(name)), zap.String("tags", tags.String()))
 		}
 
-		if err := tsiIndex.CreateSeriesIfNotExists(nil, []byte(name), tags); err != nil {
+		if err := tsiIndex.CreateSeriesIfNotExists(seriesKey, []byte(name), tags); err != nil {
 			return fmt.Errorf("cannot create series: %s %s (%s)", name, tags.String(), err)
 		}
 	}
@@ -251,7 +251,7 @@ func (cmd *Command) processTSMFile(index *tsi1.Index, path string) error {
 			cmd.Logger.Info("series", zap.String("name", string(name)), zap.String("tags", tags.String()))
 		}
 
-		if err := index.CreateSeriesIfNotExists(nil, []byte(name), tags); err != nil {
+		if err := index.CreateSeriesIfNotExists(seriesKey, []byte(name), tags); err != nil {
 			return fmt.Errorf("cannot create series: %s %s (%s)", name, tags.String(), err)
 		}
 	}


### PR DESCRIPTION
Previously the TSM series key was not being passed into `CreateSeriesIfNotExists()` for `buildtsi` because the series key wasn't originally used in TSI. The series key started being used after partitioning was added but `buildtsi` was not updated.

This can affect users who rebuild TSI on hot shards since the built partition will not match newly inserted series.