### PR TITLE
Enable casting values from a subquery

### DIFF
--- a/query/cast.go
+++ b/query/cast.go
@@ -1,58 +1,88 @@
 package query
 
-func castToFloat(v interface{}) float64 {
+import "github.com/influxdata/influxql"
+
+// castToType will coerce the underlying interface type to another
+// interface depending on the type.
+func castToType(v interface{}, typ influxql.DataType) interface{} {
+	switch typ {
+	case influxql.Float:
+		if val, ok := castToFloat(v); ok {
+			v = val
+		}
+	case influxql.Integer:
+		if val, ok := castToInteger(v); ok {
+			v = val
+		}
+	case influxql.Unsigned:
+		if val, ok := castToUnsigned(v); ok {
+			v = val
+		}
+	case influxql.String:
+		if val, ok := castToString(v); ok {
+			v = val
+		}
+	case influxql.Boolean:
+		if val, ok := castToBoolean(v); ok {
+			v = val
+		}
+	}
+	return v
+}
+
+func castToFloat(v interface{}) (float64, bool) {
 	switch v := v.(type) {
 	case float64:
-		return v
+		return v, true
 	case int64:
-		return float64(v)
+		return float64(v), true
 	case uint64:
-		return float64(v)
+		return float64(v), true
 	default:
-		return float64(0)
+		return float64(0), false
 	}
 }
 
-func castToInteger(v interface{}) int64 {
+func castToInteger(v interface{}) (int64, bool) {
 	switch v := v.(type) {
 	case float64:
-		return int64(v)
+		return int64(v), true
 	case int64:
-		return v
+		return v, true
 	case uint64:
-		return int64(v)
+		return int64(v), true
 	default:
-		return int64(0)
+		return int64(0), false
 	}
 }
 
-func castToUnsigned(v interface{}) uint64 {
+func castToUnsigned(v interface{}) (uint64, bool) {
 	switch v := v.(type) {
 	case float64:
-		return uint64(v)
+		return uint64(v), true
 	case uint64:
-		return v
+		return v, true
 	case int64:
-		return uint64(v)
+		return uint64(v), true
 	default:
-		return uint64(0)
+		return uint64(0), false
 	}
 }
 
-func castToString(v interface{}) string {
+func castToString(v interface{}) (string, bool) {
 	switch v := v.(type) {
 	case string:
-		return v
+		return v, true
 	default:
-		return ""
+		return "", false
 	}
 }
 
-func castToBoolean(v interface{}) bool {
+func castToBoolean(v interface{}) (bool, bool) {
 	switch v := v.(type) {
 	case bool:
-		return v
+		return v, true
 	default:
-		return false
+		return false, false
 	}
 }

--- a/query/iterator.gen.go.tmpl
+++ b/query/iterator.gen.go.tmpl
@@ -494,12 +494,12 @@ type {{$k.name}}SortedMergeHeapItem struct {
 type {{$k.name}}IteratorScanner struct {
 	input        *buf{{$k.Name}}Iterator
 	err          error
-	keys         []string
+	keys         []influxql.VarRef
 	defaultValue interface{}
 }
 
 // new{{$k.Name}}IteratorScanner creates a new IteratorScanner.
-func new{{$k.Name}}IteratorScanner(input {{$k.Name}}Iterator, keys []string, defaultValue interface{}) *{{$k.name}}IteratorScanner {
+func new{{$k.Name}}IteratorScanner(input {{$k.Name}}Iterator, keys []influxql.VarRef, defaultValue interface{}) *{{$k.name}}IteratorScanner {
 	return &{{$k.name}}IteratorScanner{
 		input: newBuf{{$k.Name}}Iterator(input),
 		keys: keys,
@@ -540,24 +540,24 @@ func (s *{{$k.name}}IteratorScanner) ScanAt(ts int64, name string, tags Tags, m 
 		return
 	}
 
-	if k := s.keys[0]; k != "" {
+	if k := s.keys[0]; k.Val != "" {
 		if p.Nil {
 			if s.defaultValue != SkipDefault {
-				m[k] = s.defaultValue
+				m[k.Val] = castToType(s.defaultValue, k.Type)
 			}
 		} else {
-			m[k] = p.Value
+			m[k.Val] = p.Value
 		}
 	}
 	for i, v := range p.Aux {
 		k := s.keys[i+1]
 		switch v.(type) {
 		case float64, int64, uint64, string, bool:
-			m[k] = v
+			m[k.Val] = v
 		default:
 			// Insert the fill value if one was specified.
 			if s.defaultValue != SkipDefault {
-				m[k] = s.defaultValue
+				m[k.Val] = castToType(s.defaultValue, k.Type)
 			}
 		}
 	}
@@ -568,10 +568,10 @@ func (s *{{$k.name}}IteratorScanner) useDefaults(m map[string]interface{}) {
 		return
 	}
 	for _, k := range s.keys {
-    if k == "" {
-      continue
-    }
-		m[k] = s.defaultValue
+		if k.Val == "" {
+		  continue
+		}
+		m[k.Val] = castToType(s.defaultValue, k.Type)
 	}
 }
 
@@ -846,7 +846,7 @@ CONSTRUCT:
 		case influxql.NullFill:
 			p.Nil = true
 		case influxql.NumberFill:
-			p.Value = castTo{{$k.Name}}(itr.opt.FillValue)
+			p.Value, _ = castTo{{$k.Name}}(itr.opt.FillValue)
 		case influxql.PreviousFill:
 			if !itr.prev.Nil {
 				p.Value = itr.prev.Value
@@ -1315,7 +1315,7 @@ func (itr *{{$k.name}}IteratorMapper) Next() (*{{$k.Name}}Point, error) {
 
 	if itr.driver != nil {
 	if v := itr.driver.Value(&itr.row); v != nil {
-			if v, ok := v.({{$k.Type}}); ok {
+			if v, ok := castTo{{$k.Name}}(v); ok {
 				itr.point.Value = v
 				itr.point.Nil = false
 			} else {

--- a/query/iterator.go
+++ b/query/iterator.go
@@ -426,7 +426,7 @@ type IteratorScanner interface {
 var SkipDefault = interface{}(0)
 
 // NewIteratorScanner produces an IteratorScanner for the Iterator.
-func NewIteratorScanner(input Iterator, keys []string, defaultValue interface{}) IteratorScanner {
+func NewIteratorScanner(input Iterator, keys []influxql.VarRef, defaultValue interface{}) IteratorScanner {
 	switch input := input.(type) {
 	case FloatIterator:
 		return newFloatIteratorScanner(input, keys, defaultValue)

--- a/query/iterator_mapper_test.go
+++ b/query/iterator_mapper_test.go
@@ -56,8 +56,8 @@ func TestIteratorMapper(t *testing.T) {
 		},
 	}
 	itr := query.NewIteratorMapper(cur, nil, []query.IteratorMap{
-		query.FieldMap(0),
-		query.FieldMap(1),
+		query.FieldMap{Index: 0},
+		query.FieldMap{Index: 1},
 		query.TagMap("host"),
 	}, opt)
 	if a, err := Iterators([]query.Iterator{itr}).ReadAll(); err != nil {

--- a/query/select.go
+++ b/query/select.go
@@ -12,6 +12,7 @@ import (
 
 var DefaultTypeMapper = influxql.MultiTypeMapper(
 	FunctionTypeMapper{},
+	MathTypeMapper{},
 )
 
 // SelectOptions are options that customize the select call.
@@ -582,7 +583,7 @@ func buildCursor(ctx context.Context, stmt *influxql.SelectStatement, ic Iterato
 	}
 
 	// Retrieve the refs to retrieve the auxiliary fields.
-	var auxKeys []string
+	var auxKeys []influxql.VarRef
 	if len(valueMapper.refs) > 0 {
 		opt.Aux = make([]influxql.VarRef, 0, len(valueMapper.refs))
 		for ref := range valueMapper.refs {
@@ -590,7 +591,7 @@ func buildCursor(ctx context.Context, stmt *influxql.SelectStatement, ic Iterato
 		}
 		sort.Sort(influxql.VarRefs(opt.Aux))
 
-		auxKeys = make([]string, len(opt.Aux))
+		auxKeys = make([]influxql.VarRef, len(opt.Aux))
 		for i, ref := range opt.Aux {
 			auxKeys[i] = valueMapper.symbols[ref.String()]
 		}
@@ -598,12 +599,19 @@ func buildCursor(ctx context.Context, stmt *influxql.SelectStatement, ic Iterato
 
 	// If there are no calls, then produce an auxiliary cursor.
 	if len(valueMapper.calls) == 0 {
+		// If all of the auxiliary keys are of an unknown type,
+		// do not construct the iterator and return a null cursor.
+		if !hasValidType(auxKeys) {
+			return newNullCursor(fields), nil
+		}
+
 		itr, err := buildAuxIterator(ctx, ic, stmt.Sources, opt)
 		if err != nil {
 			return nil, err
 		}
 
-		keys := []string{""}
+		// Create a slice with an empty first element.
+		keys := []influxql.VarRef{{}}
 		keys = append(keys, auxKeys...)
 
 		scanner := NewIteratorScanner(itr, keys, opt.FillValue)
@@ -625,7 +633,13 @@ func buildCursor(ctx context.Context, stmt *influxql.SelectStatement, ic Iterato
 	// Produce an iterator for every single call and create an iterator scanner
 	// associated with it.
 	scanners := make([]IteratorScanner, 0, len(valueMapper.calls))
-	for call, symbol := range valueMapper.calls {
+	for call := range valueMapper.calls {
+		driver := valueMapper.table[call]
+		if driver.Type == influxql.Unknown {
+			// The primary driver of this call is of unknown type, so skip this.
+			continue
+		}
+
 		itr, err := buildFieldIterator(ctx, call, ic, stmt.Sources, opt, selector, stmt.Target != nil)
 		if err != nil {
 			for _, s := range scanners {
@@ -634,15 +648,17 @@ func buildCursor(ctx context.Context, stmt *influxql.SelectStatement, ic Iterato
 			return nil, err
 		}
 
-		keys := make([]string, 0, len(auxKeys)+1)
-		keys = append(keys, symbol)
+		keys := make([]influxql.VarRef, 0, len(auxKeys)+1)
+		keys = append(keys, driver)
 		keys = append(keys, auxKeys...)
 
 		scanner := NewIteratorScanner(itr, keys, opt.FillValue)
 		scanners = append(scanners, scanner)
 	}
 
-	if len(scanners) == 1 {
+	if len(scanners) == 0 {
+		return newNullCursor(fields), nil
+	} else if len(scanners) == 1 {
 		return newScannerCursor(scanners[0], fields, opt), nil
 	}
 	return newMultiScannerCursor(scanners, fields, opt), nil
@@ -724,23 +740,23 @@ func buildFieldIterator(ctx context.Context, expr influxql.Expr, ic IteratorCrea
 type valueMapper struct {
 	// An index that maps a node's string output to its symbol so that all
 	// nodes with the same signature are mapped the same.
-	symbols map[string]string
+	symbols map[string]influxql.VarRef
 	// An index that maps a specific expression to a symbol. This ensures that
 	// only expressions that were mapped get symbolized.
-	table map[influxql.Expr]string
-	// A mapping of calls to their symbol.
-	calls map[*influxql.Call]string
-	// A mapping of variable references to their symbol.
-	refs map[*influxql.VarRef]string
+	table map[influxql.Expr]influxql.VarRef
+	// A collection of all of the calls in the table.
+	calls map[*influxql.Call]struct{}
+	// A collection of all of the calls in the table.
+	refs map[*influxql.VarRef]struct{}
 	i    int
 }
 
 func newValueMapper() *valueMapper {
 	return &valueMapper{
-		symbols: make(map[string]string),
-		table:   make(map[influxql.Expr]string),
-		calls:   make(map[*influxql.Call]string),
-		refs:    make(map[*influxql.VarRef]string),
+		symbols: make(map[string]influxql.VarRef),
+		table:   make(map[influxql.Expr]influxql.VarRef),
+		calls:   make(map[*influxql.Call]struct{}),
+		refs:    make(map[*influxql.VarRef]struct{}),
 	}
 }
 
@@ -763,19 +779,30 @@ func (v *valueMapper) Visit(n influxql.Node) influxql.Visitor {
 	symbol, ok := v.symbols[key]
 	if !ok {
 		// This symbol has not been assigned yet.
-		// If this is a call or expression, store the node in
-		// the appropriate index.
-		symbol = fmt.Sprintf("val%d", v.i)
+		// If this is a call or expression, mark the node
+		// as stored in the symbol table.
 		switch n := n.(type) {
 		case *influxql.Call:
 			if isMathFunction(n) {
 				return v
 			}
-			v.calls[n] = symbol
+			v.calls[n] = struct{}{}
 		case *influxql.VarRef:
-			v.refs[n] = symbol
+			v.refs[n] = struct{}{}
 		default:
 			return v
+		}
+
+		// Determine the symbol name and the symbol type.
+		symbolName := fmt.Sprintf("val%d", v.i)
+		valuer := influxql.TypeValuerEval{
+			TypeMapper: DefaultTypeMapper,
+		}
+		typ, _ := valuer.EvalType(expr)
+
+		symbol = influxql.VarRef{
+			Val:  symbolName,
+			Type: typ,
 		}
 
 		// Assign this symbol to the symbol table if it is not presently there
@@ -794,18 +821,7 @@ func (v *valueMapper) rewriteExpr(expr influxql.Expr) influxql.Expr {
 	if !ok {
 		return expr
 	}
-
-	valuer := influxql.TypeValuerEval{
-		TypeMapper: influxql.MultiTypeMapper(
-			FunctionTypeMapper{},
-			MathTypeMapper{},
-		),
-	}
-	typ, _ := valuer.EvalType(expr)
-	return &influxql.VarRef{
-		Val:  symbol,
-		Type: typ,
-	}
+	return &symbol
 }
 
 func validateTypes(stmt *influxql.SelectStatement) error {
@@ -821,4 +837,15 @@ func validateTypes(stmt *influxql.SelectStatement) error {
 		}
 	}
 	return nil
+}
+
+// hasValidType returns true if there is at least one non-unknown type
+// in the slice.
+func hasValidType(refs []influxql.VarRef) bool {
+	for _, ref := range refs {
+		if ref.Type != influxql.Unknown {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This also fixes the cursor system to abandon iterators that will not
produce meaningful results since the variables are all unknown types.

This creates a weird behavior that existed in previous releases and we
are keeping here for backwards compatibility. If a subquery referenced a
field that didn't exist in the subquery, it will return nothing. But, if
there are two subqueries and one of them has the field exist and the
other doesn't, the second will return all null values.

Fixes #9624.