### PR TITLE
Fix panic in readTombstoneV4

### DIFF
--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -604,7 +604,7 @@ func (t *Tombstoner) readTombstoneV4(f *os.File, fn func(t Tombstone) error) err
 				}
 
 				keyLen := int(binary.BigEndian.Uint32(b[:4]))
-				if keyLen > len(b)+16 {
+				if keyLen+16 > len(b) {
 					b = make([]byte, keyLen+16)
 				}
 

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -1,6 +1,7 @@
 package tsm1_test
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -65,6 +66,68 @@ func TestTombstoner_Add(t *testing.T) {
 	}
 
 	if got, exp := string(entries[0].Key), "foo"; got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+}
+
+func TestTombstoner_Add_LargeKey(t *testing.T) {
+	dir := MustTempDir()
+	defer func() { os.RemoveAll(dir) }()
+
+	f := MustTempFile(dir)
+	ts := &tsm1.Tombstoner{Path: f.Name()}
+
+	entries := mustReadAll(ts)
+	if got, exp := len(entries), 0; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	stats := ts.TombstoneFiles()
+	if got, exp := len(stats), 0; got != exp {
+		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
+	}
+
+	key := bytes.Repeat([]byte{'a'}, 4096)
+	ts.Add([][]byte{key})
+
+	if err := ts.Flush(); err != nil {
+		t.Fatalf("unexpected error flushing tombstone: %v", err)
+	}
+
+	entries = mustReadAll(ts)
+	stats = ts.TombstoneFiles()
+	if got, exp := len(stats), 1; got != exp {
+		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if stats[0].Size == 0 {
+		t.Fatalf("got size %v, exp > 0", stats[0].Size)
+	}
+
+	if stats[0].LastModified == 0 {
+		t.Fatalf("got lastModified %v, exp > 0", stats[0].LastModified)
+	}
+
+	if stats[0].Path == "" {
+		t.Fatalf("got path %v, exp != ''", stats[0].Path)
+	}
+
+	if got, exp := len(entries), 1; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := string(entries[0].Key), string(key); got != exp {
+		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
+	}
+
+	// Use a new Tombstoner to verify values are persisted
+	ts = &tsm1.Tombstoner{Path: f.Name()}
+	entries = mustReadAll(ts)
+	if got, exp := len(entries), 1; got != exp {
+		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
+	}
+
+	if got, exp := string(entries[0].Key), string(key); got != exp {
 		t.Fatalf("value mismatch: got %v, exp %v", got, exp)
 	}
 }


### PR DESCRIPTION
The length check was backwards so if a series key was longer than
4096 bytes, it would cause a slice out of bounds panic.

```
--- FAIL: TestTombstoner_Add_LargeKey (0.00s)
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

goroutine 5 [running]:
testing.tRunner.func1(0xc4201960f0)
	/usr/local/go/src/testing/testing.go:742 +0x29d
panic(0x16e9460, 0x1ba6340)
	/usr/local/go/src/runtime/panic.go:505 +0x229
github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Tombstoner).readTombstoneV4.func1(0xc420108dc0, 0xc420087b48, 0xc420087b20, 0xc420087b30, 0xc420087ae8, 0xc420087af0, 0xc420087ca0, 0xc420073b28, 0x102c1c4)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/tombstone.go:619 +0x591
github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Tombstoner).readTombstoneV4(0xc4200ecea0, 0xc42000e140, 0xc420087ca0, 0x0, 0x0)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/tombstone.go:639 +0x436
github.com/influxdata/influxdb/tsdb/engine/tsm1.(*Tombstoner).Walk(0xc4200ecea0, 0xc420073ca0, 0x0, 0x0)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/tombstone.go:234 +0x283
github.com/influxdata/influxdb/tsdb/engine/tsm1_test.mustReadAll(0xc4200ecea0, 0x0, 0x0, 0x1)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/tombstone_test.go:348 +0x60
github.com/influxdata/influxdb/tsdb/engine/tsm1_test.TestTombstoner_Add_LargeKey(0xc4201960f0)
	/Users/jason/go/src/github.com/influxdata/influxdb/tsdb/engine/tsm1/tombstone_test.go:97 +0x284
testing.tRunner(0xc4201960f0, 0x17c9aa0)
	/usr/local/go/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:824 +0x2e0
```


