### PR TITLE
Return time range from delete predicate func

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -55,7 +55,7 @@ type Engine interface {
 	CreateSeriesIfNotExists(key, name []byte, tags models.Tags) error
 	CreateSeriesListIfNotExists(keys, names [][]byte, tags []models.Tags) error
 	DeleteSeriesRange(itr SeriesIterator, min, max int64) error
-	DeleteSeriesRangeWithPredicate(itr SeriesIterator, min, max int64, predicate func(name []byte, tags models.Tags) bool) error
+	DeleteSeriesRangeWithPredicate(itr SeriesIterator, predicate func(name []byte, tags models.Tags) (int64, int64, bool)) error
 
 	MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error)
 	SeriesSketches() (estimator.Sketch, estimator.Sketch, error)

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -698,12 +698,12 @@ func (s *Shard) DeleteSeriesRange(itr SeriesIterator, min, max int64) error {
 
 // DeleteSeriesRangeWithPredicate deletes all values from for seriesKeys between min and max (inclusive)
 // for which predicate() returns true. If predicate() is nil, then all values in range are deleted.
-func (s *Shard) DeleteSeriesRangeWithPredicate(itr SeriesIterator, min, max int64, predicate func(name []byte, tags models.Tags) bool) error {
+func (s *Shard) DeleteSeriesRangeWithPredicate(itr SeriesIterator, predicate func(name []byte, tags models.Tags) (int64, int64, bool)) error {
 	engine, err := s.engine()
 	if err != nil {
 		return err
 	}
-	return engine.DeleteSeriesRangeWithPredicate(itr, min, max, predicate)
+	return engine.DeleteSeriesRangeWithPredicate(itr, predicate)
 }
 
 // DeleteMeasurement deletes a measurement and all underlying series.


### PR DESCRIPTION
This moves the time range to delete to be returned by the predicate
func in `DeleteSeriesRangeWithPredicate`.  It allows for a single delete
to delete different ranges of times per series instead of a single
range of time for all series.

cc @jacobmarble 