### PR TITLE
Check for errors from binary.Uvarint when reading TSI logs

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -1040,7 +1040,7 @@ func (e *LogEntry) UnmarshalBinary(data []byte) error {
 	// Parse series id.
 	if len(data) < 1 {
 		return io.ErrShortBuffer
-	} else if seriesID, n = binary.Uvarint(data); n == 0 {
+	} else if seriesID, n = binary.Uvarint(data); n == 0 || n > len(data) {
 		return io.ErrShortBuffer
 	} else if n < 0 {
 		return fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
@@ -1050,7 +1050,7 @@ func (e *LogEntry) UnmarshalBinary(data []byte) error {
 	// Parse name length.
 	if len(data) < 1 {
 		return io.ErrShortBuffer
-	} else if sz, n = binary.Uvarint(data); n == 0 {
+	} else if sz, n = binary.Uvarint(data); n == 0 || n > len(data) {
 		return io.ErrShortBuffer
 	} else if n < 0 {
 		return fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
@@ -1065,7 +1065,7 @@ func (e *LogEntry) UnmarshalBinary(data []byte) error {
 	// Parse key length.
 	if len(data) < 1 {
 		return io.ErrShortBuffer
-	} else if sz, n = binary.Uvarint(data); n == 0 {
+	} else if sz, n = binary.Uvarint(data); n == 0 || n > len(data) {
 		return io.ErrShortBuffer
 	} else if n < 0 {
 		return fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
@@ -1080,7 +1080,7 @@ func (e *LogEntry) UnmarshalBinary(data []byte) error {
 	// Parse value length.
 	if len(data) < 1 {
 		return io.ErrShortBuffer
-	} else if sz, n = binary.Uvarint(data); n == 0 {
+	} else if sz, n = binary.Uvarint(data); n == 0 || n > len(data) {
 		return io.ErrShortBuffer
 	} else if n < 0 {
 		return fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -1024,18 +1024,6 @@ type LogEntry struct {
 
 // UnmarshalBinary unmarshals data into e.
 func (e *LogEntry) UnmarshalBinary(data []byte) error {
-	// Wrapper for binary.Uvarint(); returned n is > 0 else err != nil
-	uvarint := func(data []byte) (value uint64, n int, err error) {
-		if len(data) < 1 {
-			err = io.ErrShortBuffer
-		} else if value, n = binary.Uvarint(data); n == 0 || n > len(data) {
-			err = io.ErrShortBuffer
-		} else if n < 0 {
-			err = fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
-		}
-		return
-	}
-
 	var sz uint64
 	var n int
 	var seriesID uint64

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -1026,6 +1026,7 @@ type LogEntry struct {
 func (e *LogEntry) UnmarshalBinary(data []byte) error {
 	var sz uint64
 	var n int
+	var seriesID uint64
 
 	orig := data
 	start := len(data)
@@ -1039,8 +1040,11 @@ func (e *LogEntry) UnmarshalBinary(data []byte) error {
 	// Parse series id.
 	if len(data) < 1 {
 		return io.ErrShortBuffer
+	} else if seriesID, n = binary.Uvarint(data); n == 0 {
+		return io.ErrShortBuffer
+	} else if n < 0 {
+		return fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
 	}
-	seriesID, n := binary.Uvarint(data)
 	e.SeriesID, data = uint64(seriesID), data[n:]
 
 	// Parse name length.
@@ -1048,6 +1052,8 @@ func (e *LogEntry) UnmarshalBinary(data []byte) error {
 		return io.ErrShortBuffer
 	} else if sz, n = binary.Uvarint(data); n == 0 {
 		return io.ErrShortBuffer
+	} else if n < 0 {
+		return fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
 	}
 
 	// Read name data.
@@ -1061,6 +1067,8 @@ func (e *LogEntry) UnmarshalBinary(data []byte) error {
 		return io.ErrShortBuffer
 	} else if sz, n = binary.Uvarint(data); n == 0 {
 		return io.ErrShortBuffer
+	} else if n < 0 {
+		return fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
 	}
 
 	// Read key data.
@@ -1074,6 +1082,8 @@ func (e *LogEntry) UnmarshalBinary(data []byte) error {
 		return io.ErrShortBuffer
 	} else if sz, n = binary.Uvarint(data); n == 0 {
 		return io.ErrShortBuffer
+	} else if n < 0 {
+		return fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
 	}
 
 	// Read value data.

--- a/tsdb/index/tsi1/tag_block.go
+++ b/tsdb/index/tsi1/tag_block.go
@@ -346,18 +346,21 @@ func (e *TagBlockValueElem) SeriesID(i int) uint64 {
 }
 
 // SeriesIDs returns a list decoded series ids.
-func (e *TagBlockValueElem) SeriesIDs() []uint64 {
+func (e *TagBlockValueElem) SeriesIDs() ([]uint64, error) {
 	a := make([]uint64, 0, e.series.n)
 	var prev uint64
 	for data := e.series.data; len(data) > 0; {
-		delta, n := binary.Uvarint(data)
+		delta, n, err := uvarint(data)
+		if err != nil {
+			return nil, err
+		}
 		data = data[n:]
 
 		seriesID := prev + uint64(delta)
 		a = append(a, seriesID)
 		prev = seriesID
 	}
-	return a
+	return a, nil
 }
 
 // Size returns the size of the element.

--- a/tsdb/index/tsi1/tag_block_test.go
+++ b/tsdb/index/tsi1/tag_block_test.go
@@ -49,28 +49,38 @@ func TestTagBlockWriter(t *testing.T) {
 	// Verify data.
 	if e := blk.TagValueElem([]byte("region"), []byte("us-east")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{1, 2}) {
+	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !reflect.DeepEqual(a, []uint64{1, 2}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 
 	if e := blk.TagValueElem([]byte("region"), []byte("us-west")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{3}) {
+	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !reflect.DeepEqual(a, []uint64{3}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 	if e := blk.TagValueElem([]byte("host"), []byte("server0")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{1}) {
+	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !reflect.DeepEqual(a, []uint64{1}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 	if e := blk.TagValueElem([]byte("host"), []byte("server1")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{2}) {
+	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !reflect.DeepEqual(a, []uint64{2}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 	if e := blk.TagValueElem([]byte("host"), []byte("server2")); e == nil {
 		t.Fatal("expected element")
-	} else if a := e.(*tsi1.TagBlockValueElem).SeriesIDs(); !reflect.DeepEqual(a, []uint64{3}) {
+	} else if a, err := e.(*tsi1.TagBlockValueElem).SeriesIDs(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if !reflect.DeepEqual(a, []uint64{3}) {
 		t.Fatalf("unexpected series ids: %#v", a)
 	}
 }

--- a/tsdb/index/tsi1/tsi1.go
+++ b/tsdb/index/tsi1/tsi1.go
@@ -532,6 +532,19 @@ func assert(condition bool, msg string, v ...interface{}) {
 	}
 }
 
+// uvarint is a wrapper around binary.Uvarint.
+// Returns a non-nil error when binary.Uvarint returns n <= 0 or n > len(data).
+func uvarint(data []byte) (value uint64, n int, err error) {
+	if len(data) < 1 {
+		err = io.ErrShortBuffer
+	} else if value, n = binary.Uvarint(data); n == 0 || n > len(data) {
+		err = io.ErrShortBuffer
+	} else if n < 0 {
+		err = fmt.Errorf("parsing binary-encoded uint64 value failed; binary.Uvarint() returned %d", n)
+	}
+	return
+}
+
 // hexdump is a helper for dumping binary data to stderr.
 // func hexdump(data []byte) { os.Stderr.Write([]byte(hex.Dump(data))) }
 


### PR DESCRIPTION
Closes #9425

This change doesn't do anything with the CRC check because the CRC sum isn't available until after the panic likely occurs. This change does check the result of `binary.Uvarint` which is the likely source of panic.