### PR TITLE
Update client README - close client resources

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -72,7 +72,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
+	defer c.Close()
+	
 	// Create a new point batch
 	bp, err := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:  MyDB,
@@ -99,6 +100,11 @@ func main() {
 	// Write the batch
 	if err := c.Write(bp); err != nil {
 		log.Fatal(err)
+	}
+	
+	// Close client resources
+	if err := c.Close(); err != nil {
+    		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
The best practice is to close used resources at the end. I've had a problem when I used this code in AWS Golang Lambda function without `c.Close()`: `socket: too many open files` - I've reached connection limit because InfluxDB connections have been still opened.

- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
- [X] Provide example syntax
