### PR TITLE
Update backup flags to have long/short versions

### DIFF
--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -588,29 +588,33 @@ func (cmd *Command) requestInfo(request *snapshotter.Request) (*snapshotter.Resp
 // printUsage prints the usage message to STDERR.
 func (cmd *Command) printUsage() {
 	fmt.Fprintf(cmd.Stdout, `
-Downloads a snapshot of a data node and saves it to disk. NOTE: newer versions of influxd are 
-not compatible with older versions.  When running the backup, be sure to use the same version 
-of the influxd binary as the server that you are backing up.  
+Creates a backup copy of specified InfluxDB OSS database(s) and saves the files in an Enterprise-compatible
+format to PATH (directory where backups are saved). 
 
-Usage: influxd backup [flags] PATH
+Usage: influxd backup [options] PATH
 
     -portable
-            Generate backup files in a format that is portable between different influxdb products.
+            Required to generate backup files in a portable format that can be restored to InfluxDB OSS or InfluxDB 
+            Enterprise. Use unless the legacy backup is required.
     -host <host:port>
-            The host to connect to that will be backed up. Defaults to 127.0.0.1:8088.
+            InfluxDB OSS host to back up from. Optional. Defaults to 127.0.0.1:8088.
     -db <name>
-            The database to backup.
+            InfluxDB OSS database name to back up. Optional. If not specified, all databases are backed up when 
+            using '-portable'.
     -rp <name>
-            Optional. The retention policy to backup.
+            Retention policy to use for the backup. Optional. If not specified, all retention policies are used by 
+            default.
     -shard <id>
-            Optional. The shard id to backup. If specified, retention is required.
+            The identifier of the shard to back up. Optional. If specified, '-rp <rp_name>' is required.
     -start <2015-12-24T08:12:23Z>
-            All points earlier than this time stamp will be excluded from the export. Not compatible with -since.
+            Include all points starting with specified timestamp (RFC3339 format). 
+            Not compatible with '-since <timestamp>'.
     -end <2015-12-24T08:12:23Z>
-            All points later than this time stamp will be excluded from the export. Not compatible with -since.
+            Exclude all points after timestamp (RFC3339 format). 
+            Not compatible with '-since <timestamp>'.
     -since <2015-12-24T08:12:23Z>
-            Optional. Do an incremental backup since the passed in RFC3339
-            formatted time.  Not compatible with -start or -end.
+            Create an incremental backup of all points after the timestamp (RFC3339 format). Optional. 
+            Recommend using '-start <timestamp>' instead.
 `)
 
 }

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -146,7 +146,9 @@ func (cmd *Command) parseFlags(args []string) (err error) {
 
 	fs.StringVar(&cmd.host, "host", "localhost:8088", "")
 	fs.StringVar(&cmd.database, "database", "", "")
+	fs.StringVar(&cmd.database, "db", "", "")
 	fs.StringVar(&cmd.retentionPolicy, "retention", "", "")
+	fs.StringVar(&cmd.retentionPolicy, "rp", "", "")
 	fs.StringVar(&cmd.shardID, "shard", "", "")
 	var sinceArg string
 	var startArg string
@@ -586,28 +588,29 @@ func (cmd *Command) requestInfo(request *snapshotter.Request) (*snapshotter.Resp
 // printUsage prints the usage message to STDERR.
 func (cmd *Command) printUsage() {
 	fmt.Fprintf(cmd.Stdout, `
-Downloads a file level age-based snapshot of a data node and saves it to disk.
+Downloads a snapshot of a data node and saves it to disk. NOTE: newer versions of influxd are 
+not compatible with older versions.  When running the backup, be sure to use the same version 
+of the influxd binary as the server that you are backing up.  
 
 Usage: influxd backup [flags] PATH
 
+    -portable
+            Generate backup files in a format that is portable between different influxdb products.
     -host <host:port>
-            The host to connect to snapshot. Defaults to 127.0.0.1:8088.
-    -database <name>
+            The host to connect to that will be backed up. Defaults to 127.0.0.1:8088.
+    -db <name>
             The database to backup.
-    -retention <name>
+    -rp <name>
             Optional. The retention policy to backup.
     -shard <id>
             Optional. The shard id to backup. If specified, retention is required.
-    -since <2015-12-24T08:12:23Z>
-            Optional. Do an incremental backup since the passed in RFC3339
-            formatted time.  Not compatible with -start or -end.
     -start <2015-12-24T08:12:23Z>
             All points earlier than this time stamp will be excluded from the export. Not compatible with -since.
     -end <2015-12-24T08:12:23Z>
             All points later than this time stamp will be excluded from the export. Not compatible with -since.
-    -portable
-            Generate backup files in a format that is portable between different influxdb products.
-
+    -since <2015-12-24T08:12:23Z>
+            Optional. Do an incremental backup since the passed in RFC3339
+            formatted time.  Not compatible with -start or -end.
 `)
 
 }

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -565,52 +565,36 @@ func (cmd *Command) unpackTar(tarFile string) error {
 // printUsage prints the usage message to STDERR.
 func (cmd *Command) printUsage() {
 	fmt.Fprintf(cmd.Stdout, `
-Uses backups from the PATH to restore the metastore, databases, retention policies, or specific shards.
-The backward-compatible legacy mode requires the instance to be stopped before running, and will wipe all 
-databases from the system (e.g., for disaster recovery).  The improved online and portable modes require 
-the instance to be running, and the database name used must not already exist.
+Uses backup copies from the specified PATH to restore databases or specific shards from InfluxDB OSS
+  or InfluxDB Enterprise to an InfluxDB OSS instance.
 
-Usage: influxd restore [-portable] [flags] PATH
+Usage: influxd restore -portable [options] PATH
 
-The -portable restore mode consumes files in an improved format that includes a file manifest.
+Note: Restore using the '-portable' option consumes files in an improved Enterprise-compatible 
+  format that includes a file manifest.
 
 Options:
     -portable 
-            Required to activate portable restore mode.  
+            Required to activate the portable restore mode. If not specified, the legacy restore mode is used.
     -host  <host:port>
-            The host to connect to where the data will be restored. Defaults to '127.0.0.1:8088'.
+            InfluxDB OSS host to connect to where the data will be restored. Defaults to '127.0.0.1:8088'.
     -db    <name>
-            Identifies the database from the backup that will be restored.
+            Name of database to be restored from the backup (InfluxDB OSS or InfluxDB Enterprise)
     -newdb <name>
-            The name of the database into which the archived data will be imported on the target system.
-            If not given, then the value of -db is used.  The new database name must be unique to the target system.
+            Name of the InfluxDB OSS database into which the archived data will be imported on the target system. 
+            Optional. If not given, then the value of '-db <db_name>' is used.  The new database name must be unique 
+            to the target system.
     -rp    <name>
-            Identifies the retention policy from the backup that will be restored.  Requires that -db is set.
+            Name of retention policy from the backup that will be restored. Optional. 
+            Requires that '-db <db_name>' is specified.
     -newrp <name>
-            The name of the retention policy that will be created on the target system. Requires that -rp is set.
-            If not given, the value of -rp is used.
+            Name of the retention policy to be created on the target system. Optional. Requires that '-rp <rp_name>' 
+            is set. If not given, the '-rp <rp_name>' value is used.
     -shard <id>
-            Optional.  If given, -db and -rp are required.  Will restore the single shard's data.
-
-The legacy mode consumes files in an OSS only file format. PATH is a directory containing the backup data
-
-Options:
-    -metadir <path>
-            Optional. If set the metastore will be recovered to the given path.
-    -datadir <path>
-            Optional. If set the restore process will recover the specified
-            database, retention policy or shard to the given directory.
-    -database <name>
-            Optional. Required if no metadir given. Will restore a single database's data.
-    -retention <name>
-            Optional. If given, -database is required. Will restore the retention policy's
-            data.
-    -shard <id>
-            Optional. If given, -database and -retention are required. Will restore the shard's
-            data.
-    -online
-            Optional. If given, the restore will be done using the new process, detailed above.  Arguments -metadir
-            and -datadir are ignored.  
+            Identifier of the shard to be restored. Optional. If specified, then '-db <db_name>' and '-rp <rp_name>' are
+            required.
+    PATH
+            Path to directory containing the backup files.
 
 `)
 }

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -134,12 +134,15 @@ func (cmd *Command) parseFlags(args []string) error {
 	fs.StringVar(&cmd.host, "host", "localhost:8088", "")
 	fs.StringVar(&cmd.metadir, "metadir", "", "")
 	fs.StringVar(&cmd.datadir, "datadir", "", "")
-	fs.StringVar(&cmd.destinationDatabase, "database", "", "")
-	fs.StringVar(&cmd.restoreRetention, "retention", "", "")
+
+	fs.StringVar(&cmd.sourceDatabase, "database", "", "")
 	fs.StringVar(&cmd.sourceDatabase, "db", "", "")
 	fs.StringVar(&cmd.destinationDatabase, "newdb", "", "")
+
+	fs.StringVar(&cmd.backupRetention, "retention", "", "")
 	fs.StringVar(&cmd.backupRetention, "rp", "", "")
 	fs.StringVar(&cmd.restoreRetention, "newrp", "", "")
+
 	fs.Uint64Var(&cmd.shard, "shard", 0, "")
 	fs.BoolVar(&cmd.online, "online", false, "")
 	fs.BoolVar(&cmd.portable, "portable", false, "")
@@ -381,26 +384,6 @@ func (cmd *Command) updateMetaLegacy() error {
 	return err
 }
 
-// unpackShard will look for all backup files in the path matching this shard ID
-// and restore them to the data dir
-func (cmd *Command) unpackShard(shard uint64) error {
-	shardID := strconv.FormatUint(shard, 10)
-	// make sure the shard isn't already there so we don't clobber anything
-	restorePath := filepath.Join(cmd.datadir, cmd.destinationDatabase, cmd.restoreRetention, shardID)
-	if _, err := os.Stat(restorePath); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("shard already present: %s", restorePath)
-	}
-
-	id, err := strconv.ParseUint(shardID, 10, 64)
-	if err != nil {
-		return err
-	}
-
-	// find the shard backup files
-	pat := filepath.Join(cmd.backupFilesPath, fmt.Sprintf(backup_util.BackupFilePattern, cmd.destinationDatabase, cmd.restoreRetention, id))
-	return cmd.unpackFiles(pat + ".*")
-}
-
 func (cmd *Command) uploadShardsPortable() error {
 	for _, file := range cmd.manifestFiles {
 		if cmd.sourceDatabase == "" || cmd.sourceDatabase == file.Database {
@@ -493,13 +476,13 @@ func (cmd *Command) uploadShardsLegacy() error {
 // and restore them to the data dir
 func (cmd *Command) unpackDatabase() error {
 	// make sure the shard isn't already there so we don't clobber anything
-	restorePath := filepath.Join(cmd.datadir, cmd.destinationDatabase)
+	restorePath := filepath.Join(cmd.datadir, cmd.sourceDatabase)
 	if _, err := os.Stat(restorePath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("database already present: %s", restorePath)
 	}
 
 	// find the database backup files
-	pat := filepath.Join(cmd.backupFilesPath, cmd.destinationDatabase)
+	pat := filepath.Join(cmd.backupFilesPath, cmd.sourceDatabase)
 	return cmd.unpackFiles(pat + ".*")
 }
 
@@ -507,14 +490,34 @@ func (cmd *Command) unpackDatabase() error {
 // and restore them to the data dir
 func (cmd *Command) unpackRetention() error {
 	// make sure the shard isn't already there so we don't clobber anything
-	restorePath := filepath.Join(cmd.datadir, cmd.destinationDatabase, cmd.restoreRetention)
+	restorePath := filepath.Join(cmd.datadir, cmd.sourceDatabase, cmd.backupRetention)
 	if _, err := os.Stat(restorePath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("retention already present: %s", restorePath)
 	}
 
 	// find the retention backup files
-	pat := filepath.Join(cmd.backupFilesPath, cmd.destinationDatabase)
-	return cmd.unpackFiles(fmt.Sprintf("%s.%s.*", pat, cmd.restoreRetention))
+	pat := filepath.Join(cmd.backupFilesPath, cmd.sourceDatabase)
+	return cmd.unpackFiles(fmt.Sprintf("%s.%s.*", pat, cmd.backupRetention))
+}
+
+// unpackShard will look for all backup files in the path matching this shard ID
+// and restore them to the data dir
+func (cmd *Command) unpackShard(shard uint64) error {
+	shardID := strconv.FormatUint(shard, 10)
+	// make sure the shard isn't already there so we don't clobber anything
+	restorePath := filepath.Join(cmd.datadir, cmd.sourceDatabase, cmd.backupRetention, shardID)
+	if _, err := os.Stat(restorePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("shard already present: %s", restorePath)
+	}
+
+	id, err := strconv.ParseUint(shardID, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	// find the shard backup files
+	pat := filepath.Join(cmd.backupFilesPath, fmt.Sprintf(backup_util.BackupFilePattern, cmd.sourceDatabase, cmd.backupRetention, id))
+	return cmd.unpackFiles(pat + ".*")
 }
 
 // unpackFiles will look for backup files matching the pattern and restore them to the data dir
@@ -563,13 +566,33 @@ func (cmd *Command) unpackTar(tarFile string) error {
 func (cmd *Command) printUsage() {
 	fmt.Fprintf(cmd.Stdout, `
 Uses backups from the PATH to restore the metastore, databases, retention policies, or specific shards.
-Default mode requires the instance to be stopped before running, and will wipe all databases from the system
-(e.g., for disaster recovery).  The improved online and portable modes require the instance to be running,
-and the database name used must not already exist.
+The backward-compatible legacy mode requires the instance to be stopped before running, and will wipe all 
+databases from the system (e.g., for disaster recovery).  The improved online and portable modes require 
+the instance to be running, and the database name used must not already exist.
 
 Usage: influxd restore [-portable] [flags] PATH
 
-The default mode consumes files in an OSS only file format. PATH is a directory containing the backup data
+The -portable restore mode consumes files in an improved format that includes a file manifest.
+
+Options:
+    -portable 
+            Required to activate portable restore mode.  
+    -host  <host:port>
+            The host to connect to where the data will be restored. Defaults to '127.0.0.1:8088'.
+    -db    <name>
+            Identifies the database from the backup that will be restored.
+    -newdb <name>
+            The name of the database into which the archived data will be imported on the target system.
+            If not given, then the value of -db is used.  The new database name must be unique to the target system.
+    -rp    <name>
+            Identifies the retention policy from the backup that will be restored.  Requires that -db is set.
+    -newrp <name>
+            The name of the retention policy that will be created on the target system. Requires that -rp is set.
+            If not given, the value of -rp is used.
+    -shard <id>
+            Optional.  If given, -db and -rp are required.  Will restore the single shard's data.
+
+The legacy mode consumes files in an OSS only file format. PATH is a directory containing the backup data
 
 Options:
     -metadir <path>
@@ -586,25 +609,8 @@ Options:
             Optional. If given, -database and -retention are required. Will restore the shard's
             data.
     -online
-            Optional. If given, the restore will be done using the new process, detailed below.  All other arguments
-            above should be omitted.
+            Optional. If given, the restore will be done using the new process, detailed above.  Arguments -metadir
+            and -datadir are ignored.  
 
-The -portable restore mode consumes files in an improved format that includes a file manifest.
-
-Options:
-    -host  <host:port>
-            The host to connect to and perform a snapshot of. Defaults to '127.0.0.1:8088'.
-    -db    <name>
-            Identifies the database from the backup that will be restored.
-    -newdb <name>
-            The name of the database into which the archived data will be imported on the target system.
-            If not given, then the value of -db is used.  The new database name must be unique to the target system.
-    -rp    <name>
-            Identifies the retention policy from the backup that will be restored.  Requires that -db is set.
-    -newrp <name>
-            The name of the retention policy that will be created on the target system. Requires that -rp is set.
-            If not given, the value of -rp is used.
-    -shard <id>
-            Optional.  If given, -db and -rp are required.  Will restore the single shard's data.
 `)
 }

--- a/man/influxd-backup.txt
+++ b/man/influxd-backup.txt
@@ -3,7 +3,7 @@ influxd-backup(1)
 
 NAME
 ----
-influxd-backup - Downloads a snapshot of a data node and saves it to disk
+influxd-backup - Create a backup copy of specified database(s) and save to disk.
 
 
 SYNOPSIS
@@ -12,33 +12,33 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Downloads a snapshot of a data node and saves it to disk.
+Create a backup copy of specified InfluxDB OSS database(s) and save to disk.
 
 OPTIONS
 -------
 -portable::
-  Generate backup files in a format that is portable between different influxdb products.
+  Generate backup files in portable format that can be restored to InfluxDB OSS or InfluxDB Enterprise.
 
 -host <host:port>::
-  The host to connect to that will be backed up. Defaults to 127.0.0.1:8088.
+  InfluxDB OSS host to back up from. Optional. Defaults to 127.0.0.1:8088.
 
--db <name>::
-  The database to backup. Required.
+-db <db_name>::
+  InfluxDB OSS database name to back up. Optional. If not specified, all databases backed up with '-portable'.
 
--rp <name>::
-  The retention policy to backup. Optional.
+-rp <rp_name>::
+  Retention policy to use for the backup. Optional. If not specified, all retention policies are used by default. 
 
--shard <id>::
-  The shard id to backup. Optional. If specified, '-retention <name>' is required.
+-shard <shard_id>::
+  The identifier of the shard to back up. Optional. If specified, '-rp <rp_name>' is required.
 
--start <2015-12-24T08:12:23Z>::
-  All points earlier than this time stamp will be excluded from the export. Not compatible with -since.
+-start <timestamp>::
+  Include all points starting with specified timestamp (RFC3339 format). Not compatible with '-since <timestamp>'.
 
--end <2015-12-24T08:12:23Z>::
-  All points later than this time stamp will be excluded from the export. Not compatible with -since.
+-end <timestamp>::
+  Exclude all points after timestamp (RFC3339 format). Not compatible with -since.
 
--since <2015-12-24T08:12:13Z>::
-  Do an incremental backup since the passed in time. The time needs to be in the RFC3339 format. Optional.
+-since <timestamp>::
+  Create an incremental backup after the timestamp (RFC3339 format). Optional. Recommend using '-start <timestamp>' instead.
 
 SEE ALSO
 --------

--- a/man/influxd-backup.txt
+++ b/man/influxd-backup.txt
@@ -16,27 +16,29 @@ Downloads a snapshot of a data node and saves it to disk.
 
 OPTIONS
 -------
--host <host:port>::
-  The host to connect to and perform a snapshot of. Defaults to '127.0.0.1:8088'.
+-portable::
+  Generate backup files in a format that is portable between different influxdb products.
 
--database <name>::
+-host <host:port>::
+  The host to connect to that will be backed up. Defaults to 127.0.0.1:8088.
+
+-db <name>::
   The database to backup. Required.
 
--retention <name>::
+-rp <name>::
   The retention policy to backup. Optional.
 
 -shard <id>::
   The shard id to backup. Optional. If specified, '-retention <name>' is required.
 
--since <2015-12-24T08:12:13Z>::
-  Do an incremental backup since the passed in time. The time needs to be in the RFC3339 format. Optional.
-
 -start <2015-12-24T08:12:23Z>::
   All points earlier than this time stamp will be excluded from the export. Not compatible with -since.
+
 -end <2015-12-24T08:12:23Z>::
   All points later than this time stamp will be excluded from the export. Not compatible with -since.
--portable::
-  Generate backup files in a format that is portable between different influxdb products.
+
+-since <2015-12-24T08:12:13Z>::
+  Do an incremental backup since the passed in time. The time needs to be in the RFC3339 format. Optional.
 
 SEE ALSO
 --------

--- a/man/influxd-backup.txt
+++ b/man/influxd-backup.txt
@@ -3,21 +3,22 @@ influxd-backup(1)
 
 NAME
 ----
-influxd-backup - Create a backup copy of specified database(s) and save to disk.
-
+influxd-backup - Creates a backup copy of specified database(s) and saves to disk.
 
 SYNOPSIS
 --------
-'influxd backup' [options]
+'influxd backup' [options] PATH
 
 DESCRIPTION
 -----------
-Create a backup copy of specified InfluxDB OSS database(s) and save to disk.
+Creates a backup copy of specified InfluxDB OSS database(s) and saves to PATH (directory where backups are saved).  Use the newer `-portable` option unless legacy support is required.
+ Note: Without the '-portable' option, the legacy backup utility is used and only the metastore is backeup unless a database is specified.
+
 
 OPTIONS
 -------
 -portable::
-  Generate backup files in portable format that can be restored to InfluxDB OSS or InfluxDB Enterprise.
+  Generate backup files in portable format that can be restored to InfluxDB OSS or InfluxDB Enterprise. Optional. Use unless the legacy backup is required.
 
 -host <host:port>::
   InfluxDB OSS host to back up from. Optional. Defaults to 127.0.0.1:8088.
@@ -26,7 +27,7 @@ OPTIONS
   InfluxDB OSS database name to back up. Optional. If not specified, all databases backed up with '-portable'.
 
 -rp <rp_name>::
-  Retention policy to use for the backup. Optional. If not specified, all retention policies are used by default. 
+  Retention policy to use for the backup. Optional. If not specified, all retention policies are used by default.
 
 -shard <shard_id>::
   The identifier of the shard to back up. Optional. If specified, '-rp <rp_name>' is required.

--- a/man/influxd-backup.txt
+++ b/man/influxd-backup.txt
@@ -3,7 +3,11 @@ influxd-backup(1)
 
 NAME
 ----
-influxd-backup - Creates a backup copy of specified database(s) and saves to disk.
+influxd-backup - Creates a backup copy of specified InfluxDB OSS database(s) and saves to disk. Use this newer `-portable` option 
+  unless legacy support is required. Complete documentation on backing up and restoring, including the deprecated
+  legacy format, see:
+    https://docs.influxdata.com/influxdb/latest/administration/backup_and_restore/
+
 
 SYNOPSIS
 --------
@@ -11,20 +15,19 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Creates a backup copy of specified InfluxDB OSS database(s) and saves to PATH (directory where backups are saved).  Use the newer `-portable` option unless legacy support is required.
- Note: Without the '-portable' option, the legacy backup utility is used and only the metastore is backeup unless a database is specified.
-
+Creates a backup copy of specified InfluxDB OSS database(s) and saves the files in an Enterprise-compatible
+format to PATH (directory where backups are saved).  
 
 OPTIONS
 -------
 -portable::
-  Generate backup files in portable format that can be restored to InfluxDB OSS or InfluxDB Enterprise. Optional. Use unless the legacy backup is required.
+  Required to generate backup files in a portable format that can be restored to InfluxDB OSS or InfluxDB Enterprise. Use unless the legacy backup is required.
 
 -host <host:port>::
   InfluxDB OSS host to back up from. Optional. Defaults to 127.0.0.1:8088.
 
 -db <db_name>::
-  InfluxDB OSS database name to back up. Optional. If not specified, all databases backed up with '-portable'.
+  InfluxDB OSS database name to back up. Optional. If not specified, all databases are backed up when using '-portable'.
 
 -rp <rp_name>::
   Retention policy to use for the backup. Optional. If not specified, all retention policies are used by default.
@@ -36,10 +39,10 @@ OPTIONS
   Include all points starting with specified timestamp (RFC3339 format). Not compatible with '-since <timestamp>'.
 
 -end <timestamp>::
-  Exclude all points after timestamp (RFC3339 format). Not compatible with -since.
+  Exclude all points after timestamp (RFC3339 format). Not compatible with '-since <timestamp>'.
 
 -since <timestamp>::
-  Create an incremental backup after the timestamp (RFC3339 format). Optional. Recommend using '-start <timestamp>' instead.
+  Create an incremental backup of all points after the timestamp (RFC3339 format). Optional. Recommend using '-start <timestamp>' instead.
 
 SEE ALSO
 --------

--- a/man/influxd-restore.txt
+++ b/man/influxd-restore.txt
@@ -3,30 +3,30 @@ influxd-restore(1)
 
 NAME
 ----
-influxd-restore - Restores the metastore, databases, retention policies, or specific 
-  shards to an InfluxDB OSS instance from the specified PATH.  The backward-compatible 
-  legacy mode requires the instance to be stopped before running, and will wipe all 
-  databases from the system (e.g., for disaster recovery).  The improved '-online' and
-  '-portable' modes require the instance to be running, and the database name used must 
-  not already exist.
+influxd-restore - Restores databases or specific shards to an InfluxDB OSS instance 
+  from the specified PATH. Complete documentation 
+  for the '-portable' restore method described here, and the deprecated legacy restore format,
+  is located here:
+    https://docs.influxdata.com/influxdb/latest/administration/backup_and_restore/
 
 
 SYNOPSIS
 --------
-'influxd restore' [-portable] [options] PATH
+'influxd restore' -portable [options] PATH
 
 DESCRIPTION
 -----------
-Uses backups from the specified PATH to restore the metastore, databases, retention policies, or specific shards. 
-The InfluxDB process must not be running during a restore.
+Uses backup copies from the specified PATH to restore databases or or specific shards from InfluxDB OSS
+  or InfluxDB Enterprise to an InfluxDB OSS instance.
 
 OPTIONS
 -------
 
-Note: Restore with the '-portable' option to consume files in an improved format that includes a file manifest.
+Note: Restore using the '-portable' option consumes files in an improved Enterprise-compatible 
+  format that includes a file manifest.
 
 -portable::
-  Required to activate portable restore mode.
+  Required to activate the portable restore mode. If not specified, the legacy restore mode is used.
 
 -host <host:port>::
   InfluxDB OSS host to connect to where the data will be restored. Defaults to '127.0.0.1:8088'.
@@ -48,31 +48,8 @@ Note: Restore with the '-portable' option to consume files in an improved format
 -shard <shard_id>::
   Identifier of the shard to be restored. Optional. If specified, then '-db <db_name>' and '-rp <rp_name>' are required..
 
-
-OPTIONS (legacy mode only) 
-
-Note: The legacy mode consumes the legacy InfluxDB OSS file format only. PATH is the directory containing the backup data
-
--metadir <metadir_path>::
-  Path to the meta directory where the metastore will be restored. Required. 
-
--datadir <datadir_path>::
-  Path to the data directory where the database will be restored. Required. 
-    
--database <db_name>::
-  Name of the InfluxDB OSS database to be restored. Optional. Required if no '-metadir <metadir_path>' given. Will restore a single database's data.
-
--retention <rp_name>::
-  Name of the retention policy to be used to restore data. Optional. If specified, then '-database <db_name>' is required.
-
--shard <id>::
-  Identifier of the shard to be restored. Optional. If specified, '-database <db_name>' and '-retention <rp_name>' 
-  are required.
-
--online::
-  Uses the legacy backup format to restore InfluxDB OSS backup files created using the legacy backup utility. Optional. If specified, the restore will be done using the new process, 
-  detailed above, and the options '-metadir <metadir_path>' and '-datadir <datadir_path>' are ignored.
-
+PATH
+  Path to directory containing the backup files.
 
 SEE ALSO
 --------

--- a/man/influxd-restore.txt
+++ b/man/influxd-restore.txt
@@ -3,8 +3,8 @@ influxd-restore(1)
 
 NAME
 ----
-influxd-restore - Restores databases or specific shards to an InfluxDB OSS instance 
-  from the specified PATH. Complete documentation 
+influxd-restore - Restores databases or specific shards to an InfluxDB OSS instance
+  from the specified PATH. Complete documentation
   for the '-portable' restore method described here, and the deprecated legacy restore format,
   is located here:
     https://docs.influxdata.com/influxdb/latest/administration/backup_and_restore/
@@ -16,13 +16,13 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Uses backup copies from the specified PATH to restore databases or or specific shards from InfluxDB OSS
+Uses backup copies from the specified PATH to restore databases or specific shards from InfluxDB OSS
   or InfluxDB Enterprise to an InfluxDB OSS instance.
 
 OPTIONS
 -------
 
-Note: Restore using the '-portable' option consumes files in an improved Enterprise-compatible 
+Note: Restore using the '-portable' option consumes files in an improved Enterprise-compatible
   format that includes a file manifest.
 
 -portable::
@@ -43,10 +43,10 @@ Note: Restore using the '-portable' option consumes files in an improved Enterpr
 
 -newrp <newrp_name>::
   Name of the retention policy to be created on the target system. Optional. Requires that '-rp <rp_name>' is set.
-	  If not given, the '-rp <rp_name>' value is used.
+  If not given, the '-rp <rp_name>' value is used.
 
 -shard <shard_id>::
-  Identifier of the shard to be restored. Optional. If specified, then '-db <db_name>' and '-rp <rp_name>' are required..
+  Identifier of the shard to be restored. Optional. If specified, then '-db <db_name>' and '-rp <rp_name>' are required.
 
 PATH
   Path to directory containing the backup files.

--- a/man/influxd-restore.txt
+++ b/man/influxd-restore.txt
@@ -3,73 +3,75 @@ influxd-restore(1)
 
 NAME
 ----
-influxd-restore - Uses backups from the PATH to restore the metastore, databases, retention policies, or specific
- shards.  The backward-compatible legacy mode requires the instance to be stopped before running, and will wipe all databases from the
- system (e.g., for disaster recovery).  The improved online and portable modes require the instance to be running,
- and the database name used must not already exist.
+influxd-restore - Restores the metastore, databases, retention policies, or specific 
+  shards to an InfluxDB OSS instance from the specified PATH.  The backward-compatible 
+  legacy mode requires the instance to be stopped before running, and will wipe all 
+  databases from the system (e.g., for disaster recovery).  The improved '-online' and
+  '-portable' modes require the instance to be running, and the database name used must 
+  not already exist.
 
 
 SYNOPSIS
 --------
-'influxd restore' [-portable] [flags] PATH
+'influxd restore' [-portable] [options] PATH
 
 DESCRIPTION
 -----------
-Uses backups from the PATH to restore the metastore, databases, retention policies, or specific shards. The InfluxDB process must not be running during a restore.
+Uses backups from the specified PATH to restore the metastore, databases, retention policies, or specific shards. 
+The InfluxDB process must not be running during a restore.
 
 OPTIONS
 -------
 
-The -portable restore mode consumes files in an improved format that includes a file manifest.
+Note: Restore with the '-portable' option to consume files in an improved format that includes a file manifest.
 
-Options:
 -portable::
   Required to activate portable restore mode.
 
 -host <host:port>::
-            The host to connect to where the data will be restored. Defaults to '127.0.0.1:8088'.
+  InfluxDB OSS host to connect to where the data will be restored. Defaults to '127.0.0.1:8088'.
 
--db    <name>::
-	        Identifies the database from the backup that will be restored.
+-db <db_name>::
+  Name of database to be restored from the backup (InfluxDB OSS or InfluxDB Enterprise)
 
--newdb <name>::
-	        The name of the database into which the archived data will be imported on the target system.
-	        If not given, then the value of -db is used.  The new database name must be unique to the target system.
+-newdb <newdb_name>::
+  Name of the InfluxDB OSS database into which the archived data will be imported on the target system. Optional.
+   If not given, then the value of '-db <db_name>' is used.  The new database name must be unique to the target system.
 
--rp    <name>::
-	        Identifies the retention policy from the backup that will be restored.  Requires that -db is set.
+-rp  <rp_name>::
+  Name of retention policy from the backup that will be restored. Optional. Requires that '-db <db_name>' is specified.
 
--newrp <name>::
-	        The name of the retention policy that will be created on the target system. Requires that -rp is set.
-	        If not given, the value of -rp is used.
+-newrp <newrp_name>::
+  Name of the retention policy to be created on the target system. Optional. Requires that '-rp <rp_name>' is set.
+	  If not given, the '-rp <rp_name>' value is used.
+
+-shard <shard_id>::
+  Identifier of the shard to be restored. Optional. If specified, then '-db <db_name>' and '-rp <rp_name>' are required..
+
+
+OPTIONS (legacy mode only) 
+
+Note: The legacy mode consumes the legacy InfluxDB OSS file format only. PATH is the directory containing the backup data
+
+-metadir <metadir_path>::
+  Path to the meta directory where the metastore will be restored. Required. 
+
+-datadir <datadir_path>::
+  Path to the data directory where the database will be restored. Required. 
+    
+-database <db_name>::
+  Name of the InfluxDB OSS database to be restored. Optional. Required if no '-metadir <metadir_path>' given. Will restore a single database's data.
+
+-retention <rp_name>::
+  Name of the retention policy to be used to restore data. Optional. If specified, then '-database <db_name>' is required.
 
 -shard <id>::
-	        Optional.  If given, -db and -rp are required.  Will restore the single shard's data.
-
-
-The legacy mode consumes files in an OSS only file format. PATH is a directory containing the backup data
-
--metadir <path>::
-            Optional. If set the metastore will be recovered to the given path.
-
--datadir <path>::
-            Optional. If set the restore process will recover the specified
-            destinationDatabase, retention policy or shard to the given directory.
-
--database <name>::
-            Optional. Required if no metadir given. Will restore a single database's data.
-
--retention <name>::
-            Optional. If given, -database is required. Will restore the retention policy's
-            data.
-
--shard <id>::
-            Optional. If given, -database and -retention are required. Will restore the shard's
-            data.
+  Identifier of the shard to be restored. Optional. If specified, '-database <db_name>' and '-retention <rp_name>' 
+  are required.
 
 -online::
-	        Optional. If given, the restore will be done using the new process, detailed above.  Arguments -metadir
-            and -datadir are ignored.
+  Uses the legacy backup format to restore InfluxDB OSS backup files created using the legacy backup utility. Optional. If specified, the restore will be done using the new process, 
+  detailed above, and the options '-metadir <metadir_path>' and '-datadir <datadir_path>' are ignored.
 
 
 SEE ALSO

--- a/man/influxd-restore.txt
+++ b/man/influxd-restore.txt
@@ -4,7 +4,7 @@ influxd-restore(1)
 NAME
 ----
 influxd-restore - Uses backups from the PATH to restore the metastore, databases, retention policies, or specific
- shards.  Default mode requires the instance to be stopped before running, and will wipe all databases from the
+ shards.  The backward-compatible legacy mode requires the instance to be stopped before running, and will wipe all databases from the
  system (e.g., for disaster recovery).  The improved online and portable modes require the instance to be running,
  and the database name used must not already exist.
 
@@ -19,7 +19,35 @@ Uses backups from the PATH to restore the metastore, databases, retention polici
 
 OPTIONS
 -------
-The default mode consumes files in an OSS only file format. PATH is a directory containing the backup data
+
+The -portable restore mode consumes files in an improved format that includes a file manifest.
+
+Options:
+-portable::
+  Required to activate portable restore mode.
+
+-host <host:port>::
+            The host to connect to where the data will be restored. Defaults to '127.0.0.1:8088'.
+
+-db    <name>::
+	        Identifies the database from the backup that will be restored.
+
+-newdb <name>::
+	        The name of the database into which the archived data will be imported on the target system.
+	        If not given, then the value of -db is used.  The new database name must be unique to the target system.
+
+-rp    <name>::
+	        Identifies the retention policy from the backup that will be restored.  Requires that -db is set.
+
+-newrp <name>::
+	        The name of the retention policy that will be created on the target system. Requires that -rp is set.
+	        If not given, the value of -rp is used.
+
+-shard <id>::
+	        Optional.  If given, -db and -rp are required.  Will restore the single shard's data.
+
+
+The legacy mode consumes files in an OSS only file format. PATH is a directory containing the backup data
 
 -metadir <path>::
             Optional. If set the metastore will be recovered to the given path.
@@ -40,31 +68,9 @@ The default mode consumes files in an OSS only file format. PATH is a directory 
             data.
 
 -online::
-	        Optional. If given, the restore will be done using the new process, detailed below.  All other arguments
-	        above should be omitted.
+	        Optional. If given, the restore will be done using the new process, detailed above.  Arguments -metadir
+            and -datadir are ignored.
 
-The -portable restore mode consumes files in an improved format that includes a file manifest.
-
-Options:
--host <host:port>::
-  The host to connect to and perform a snapshot of. Defaults to '127.0.0.1:8088'.
-
--db    <name>::
-	        Identifies the database from the backup that will be restored.
-
--newdb <name>::
-	        The name of the database into which the archived data will be imported on the target system.
-	        If not given, then the value of -db is used.  The new database name must be unique to the target system.
-
--rp    <name>::
-	        Identifies the retention policy from the backup that will be restored.  Requires that -db is set.
-
--newrp <name>::
-	        The name of the retention policy that will be created on the target system. Requires that -rp is set.
-	        If not given, the value of -rp is used.
-
--shard <id>::
-	        Optional.  If given, -db and -rp are required.  Will restore the single shard's data.
 
 SEE ALSO
 --------

--- a/tests/backup_restore_test.go
+++ b/tests/backup_restore_test.go
@@ -139,7 +139,8 @@ func TestServer_BackupAndRestore(t *testing.T) {
 			t.Fatalf("error backing up: %s, hostAddress: %s", err.Error(), hostAddress)
 		}
 
-		if err := cmd.Run("-portable", "-host", hostAddress, "-database", "mydb", "-start", "1970-01-01T00:00:00.001Z", "-end", "1970-01-01T00:00:00.009Z", portableBackupDir); err != nil {
+		// also testing short-form flag here
+		if err := cmd.Run("-portable", "-host", hostAddress, "-db", "mydb", "-start", "1970-01-01T00:00:00.001Z", "-end", "1970-01-01T00:00:00.009Z", portableBackupDir); err != nil {
 			t.Fatalf("error backing up: %s, hostAddress: %s", err.Error(), hostAddress)
 		}
 


### PR DESCRIPTION
Added short- and long- form versions of -database  and -retention to  both backup and restore so that users' experience is consistent between tools (prevents some copy/paste errors)

@stevebang   will make comments on the man-pages.   Need an engineer to sign off on backup.go  and restore.go

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [X] Update man page when modifying a command
- [X] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted https://github.com/influxdata/docs.influxdata.com/pull/1536
