### PR TITLE
Respect rp parameter in /query

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -1246,7 +1246,8 @@ func convertRowToPoints(measurementName string, row *models.Row) ([]models.Point
 }
 
 // NormalizeStatement adds a default database and policy to the measurements in statement.
-func (e *StatementExecutor) NormalizeStatement(stmt influxql.Statement, defaultDatabase string) (err error) {
+// Parameter defaultRetentionPolicy can be "".
+func (e *StatementExecutor) NormalizeStatement(stmt influxql.Statement, defaultDatabase, defaultRetentionPolicy string) (err error) {
 	influxql.WalkFunc(stmt, func(node influxql.Node) {
 		if err != nil {
 			return
@@ -1282,14 +1283,14 @@ func (e *StatementExecutor) NormalizeStatement(stmt influxql.Statement, defaultD
 				// DB and RP not supported by these statements so don't rewrite into invalid
 				// statements
 			default:
-				err = e.normalizeMeasurement(node, defaultDatabase)
+				err = e.normalizeMeasurement(node, defaultDatabase, defaultRetentionPolicy)
 			}
 		}
 	})
 	return
 }
 
-func (e *StatementExecutor) normalizeMeasurement(m *influxql.Measurement, defaultDatabase string) error {
+func (e *StatementExecutor) normalizeMeasurement(m *influxql.Measurement, defaultDatabase, defaultRetentionPolicy string) error {
 	// Targets (measurements in an INTO clause) can have blank names, which means it will be
 	// the same as the measurement name it came from in the FROM clause.
 	if !m.IsTarget && m.Name == "" && m.SystemIterator == "" && m.Regex == nil {
@@ -1314,10 +1315,13 @@ func (e *StatementExecutor) normalizeMeasurement(m *influxql.Measurement, defaul
 
 	// If no retention policy was specified, use the default.
 	if m.RetentionPolicy == "" {
-		if di.DefaultRetentionPolicy == "" {
+		if defaultRetentionPolicy != "" {
+			m.RetentionPolicy = defaultRetentionPolicy
+		} else if di.DefaultRetentionPolicy != "" {
+			m.RetentionPolicy = di.DefaultRetentionPolicy
+		} else {
 			return fmt.Errorf("default retention policy not set for: %s", di.Name)
 		}
-		m.RetentionPolicy = di.DefaultRetentionPolicy
 	}
 	return nil
 }

--- a/query/executor.go
+++ b/query/executor.go
@@ -119,6 +119,9 @@ type ExecutionOptions struct {
 	// The database the query is running against.
 	Database string
 
+	// The retention policy the query is running against.
+	RetentionPolicy string
+
 	// How to determine whether the query is allowed to execute,
 	// what resources can be returned in SHOW queries, etc.
 	Authorizer Authorizer
@@ -163,7 +166,7 @@ type StatementExecutor interface {
 type StatementNormalizer interface {
 	// NormalizeStatement adds a default database and policy to the
 	// measurements in the statement.
-	NormalizeStatement(stmt influxql.Statement, database string) error
+	NormalizeStatement(stmt influxql.Statement, database, retentionPolicy string) error
 }
 
 // Executor executes every statement in an Query.
@@ -314,7 +317,7 @@ LOOP:
 
 		// Normalize each statement if possible.
 		if normalizer, ok := e.StatementExecutor.(StatementNormalizer); ok {
-			if err := normalizer.NormalizeStatement(stmt, defaultDB); err != nil {
+			if err := normalizer.NormalizeStatement(stmt, defaultDB, opt.RetentionPolicy); err != nil {
 				if err := ctx.send(&Result{Err: err}); err == ErrQueryAborted {
 					return
 				}

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -442,10 +442,11 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 	async := r.FormValue("async") == "true"
 
 	opts := query.ExecutionOptions{
-		Database:  db,
-		ChunkSize: chunkSize,
-		ReadOnly:  r.Method == "GET",
-		NodeID:    nodeID,
+		Database:        db,
+		RetentionPolicy: r.FormValue("rp"),
+		ChunkSize:       chunkSize,
+		ReadOnly:        r.Method == "GET",
+		NodeID:          nodeID,
 	}
 
 	if h.Config.AuthEnabled {


### PR DESCRIPTION
Before this change, `/query?db=db&rp=alternate` does not respect `rp`.
Makes progress on #7973

When `rp=foo` (HTTP url param or POST form) and the queried measurement is `db.bar.m`, `bar` wins.