### PR TITLE
Log information about index version during startup

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -366,18 +366,21 @@ func (s *Shard) close() error {
 	return err
 }
 
+// IndexType returns the index version being used for this shard.
+//
+// IndexType returns the empty string if it is called before the shard is opened,
+// since it is only that point that the underlying index type is known.
 func (s *Shard) IndexType() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if err := s.ready(); err != nil {
+	if s._engine == nil || s.index == nil { // Shard not open yet.
 		return ""
 	}
-
 	return s.index.Type()
 }
 
 // ready determines if the Shard is ready for queries or writes.
-// It returns nil if ready, otherwise ErrShardClosed or ErrShardDiabled
+// It returns nil if ready, otherwise ErrShardClosed or ErrShardDisabled
 func (s *Shard) ready() error {
 	var err error
 	if s._engine == nil {

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -322,7 +322,7 @@ func (s *Store) loadShards() error {
 					}
 
 					resC <- &res{s: shard}
-					log.Info("Opened shard", zap.String("path", path), zap.Duration("duration", time.Since(start)))
+					log.Info("Opened shard", zap.String("index_version", shard.IndexType()), zap.String("path", path), zap.Duration("duration", time.Since(start)))
 				}(db.Name(), rp.Name(), sh.Name())
 			}
 		}


### PR DESCRIPTION
Contributes to #9707.

This PR adds two new useful things to the logs:

 1) During startup the index type in use for a shard will be logged when the shard is opened, using the `index_version` key. The two types available are: `{"inmem", "tsi1"}`.
 2) The TSDB store will track all the different index types for all shards within all databases. Then, it will determine if there exist shards within a database that are running differing indexes, and log the frequency of each index type as a warning.

An example of the new logs (including a database with mixed index types) is as follows:

```
...
...
2018-04-25T12:56:53.953773Z	info	Opened shard	{"log_id": "07gDtm50000", "service": "store", "trace_id": "07gDtmVW000", "op_name": "tsdb_open", "index_version": "tsi1", "path": "/Users/edd/.influxdb/data/_internal/monitor/1", "duration": "27.234ms"}
2018-04-25T12:56:53.955287Z	info	Opened shard	{"log_id": "07gDtm50000", "service": "store", "trace_id": "07gDtmVW000", "op_name": "tsdb_open", "index_version": "tsi1", "path": "/Users/edd/.influxdb/data/fooo/autogen/8", "duration": "20.021ms"}
2018-04-25T12:56:54.144353Z	info	Opened shard	{"log_id": "07gDtm50000", "service": "store", "trace_id": "07gDtmVW000", "op_name": "tsdb_open", "index_version": "inmem", "path": "/Users/edd/.influxdb/data/_internal/monitor/7", "duration": "253.250ms"}
2018-04-25T12:56:54.319992Z	info	Opened shard	{"log_id": "07gDtm50000", "service": "store", "trace_id": "07gDtmVW000", "op_name": "tsdb_open", "index_version": "inmem", "path": "/Users/edd/.influxdb/data/_internal/monitor/6", "duration": "428.724ms"}
2018-04-25T12:56:54.320059Z	warn	Mixed shard index types	{"log_id": "07gDtm50000", "service": "store", "inmem_count": 2, "tsi1_count": 1, "db_instance": "_internal"}
2018-04-25T12:56:54.320250Z	info	Open store (end)	{"log_id": "07gDtm50000", "service": "store", "trace_id": "07gDtmVW000", "op_name": "tsdb_open", "op_event": "end", "op_elapsed": "433.798ms"}
2018-04-25T12:56:54.320277Z	info	Opened service	{"log_id": "07gDtm50000", "service": "subscriber"}
2018-04-25T12:56:54.320285Z	info	Starting monitor service	{"log_id": "07gDtm50000", "service": "monitor"}
2018-04-25T12:56:54.320292Z	info	Registered diagnostics client	{"log_id": "07gDtm50000", "service": "monitor", "name": "build"}
...
...
```