### PR TITLE
tsdb/indx/inmem: Fix megacheck issue

### DIFF
--- a/tsdb/index/inmem/inmem_test.go
+++ b/tsdb/index/inmem/inmem_test.go
@@ -122,12 +122,3 @@ func (f *seriesFileWrapper) Close() error {
 	defer os.RemoveAll(f.Path())
 	return f.SeriesFile.Close()
 }
-
-// reopen initialises a new series file using the existing one.
-func (f *seriesFileWrapper) reopen() error {
-	if err := f.SeriesFile.Close(); err != nil {
-		return err
-	}
-	f.SeriesFile = tsdb.NewSeriesFile(f.SeriesFile.Path())
-	return nil
-}


### PR DESCRIPTION
Megacheck is pinging all of our PRs with an unused function; this fixes that.