### PR TITLE
Rename & log corrupt tsm files on load

### DIFF
--- a/cmd/influx_inspect/deletetsm/deletetsm.go
+++ b/cmd/influx_inspect/deletetsm/deletetsm.go
@@ -148,6 +148,5 @@ Usage: influx_inspect deletetsm [flags] path...
     -measurement NAME
             The name of the measurement to remove.
     -v
-            Enable verbose logging.
-`)
+            Enable verbose logging.`)
 }


### PR DESCRIPTION
While opening, this change updates TSM files to have a `.tsm.bad` extension if the files are corrupt.