### PR TITLE
TSM: TSMReader.Close blocks until reads complete

### DIFF
--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -726,6 +726,7 @@ func TestEngine_CreateIterator_TSM_Ascending(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer itr.Close()
 			fitr := itr.(query.FloatIterator)
 
 			if p, err := fitr.Next(); err != nil {
@@ -783,6 +784,7 @@ func TestEngine_CreateIterator_TSM_Descending(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer itr.Close()
 			fitr := itr.(query.FloatIterator)
 
 			if p, err := fitr.Next(); err != nil {
@@ -1749,6 +1751,7 @@ func TestEngine_CreateCursor_Ascending(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer cur.Close()
 
 			fcur := cur.(tsdb.FloatBatchCursor)
 			ts, vs := fcur.Next()
@@ -1808,6 +1811,7 @@ func TestEngine_CreateCursor_Descending(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			defer cur.Close()
 
 			fcur := cur.(tsdb.FloatBatchCursor)
 			ts, vs := fcur.Next()

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -530,7 +530,10 @@ func (f *FileStore) Close() error {
 	defer f.mu.Unlock()
 
 	for _, file := range f.files {
-		file.Close()
+		err := file.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	f.lastFileStats = nil

--- a/tsdb/engine/tsm1/reader_test.go
+++ b/tsdb/engine/tsm1/reader_test.go
@@ -1828,10 +1828,6 @@ func TestTSMReader_References(t *testing.T) {
 
 	r.Ref()
 
-	if err := r.Close(); err != ErrFileInUse {
-		t.Fatalf("expected error closing reader: %v", err)
-	}
-
 	if err := r.Remove(); err != ErrFileInUse {
 		t.Fatalf("expected error removing reader: %v", err)
 	}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -31,6 +31,8 @@ var (
 	ErrShardNotFound = fmt.Errorf("shard not found")
 	// ErrStoreClosed is returned when trying to use a closed Store.
 	ErrStoreClosed = fmt.Errorf("store is closed")
+	// ErrShardDeletion is returned when trying to create a shard that is being deleted
+	ErrShardDeletion = errors.New("shard is being deleted")
 )
 
 // Statistics gathered by the store.
@@ -523,7 +525,7 @@ func (s *Store) CreateShard(database, retentionPolicy string, shardID uint64, en
 	// Shard may be undergoing a pending deletion. While the shard can be
 	// recreated, it must wait for the pending delete to finish.
 	if _, ok := s.pendingShardDeletes[shardID]; ok {
-		return fmt.Errorf("shard %d is pending deletion and cannot be created again until finished", shardID)
+		return ErrShardDeletion
 	}
 
 	// Create the db and retention policy directories if they don't exist.


### PR DESCRIPTION
Fixes #9786

`TSMReader.Close` returns an error when queries are referencing the TSM file, but `FileStore.Close` ignores the error.

In this change, `FileStore.Close` checks the error, and `TSMReader.Close` blocks, rather than returning the error. This makes it clear to the caller of `FileStore.Close` (`drop shard X` for example) that the file is safely closed, rather than requiring the caller to retry up to thousands of times when the query load is constantly high.

After this change, TSM files are always closed when `drop shard X` returns, and writing to a shard that is currently being deleted returns a partial error.