### PR TITLE
tsdb/index: Add Bytes() methods

### DIFF
--- a/pkg/estimator/hll/hll.go
+++ b/pkg/estimator/hll/hll.go
@@ -102,7 +102,7 @@ func NewPlus(p uint8) (*Plus, error) {
 	return hll, nil
 }
 
-// Bytes returns an estimate of the memory footprint of this instance of Plus, in bytes.
+// Bytes estimates the memory footprint of this Plus, in bytes.
 func (h *Plus) Bytes() int {
 	var b int
 	b += len(h.tmpSet) * 4
@@ -124,17 +124,8 @@ func NewDefaultPlus() *Plus {
 	return p
 }
 
-// MustNewPlus returns a new Plus with precision p. Panic on error.
-func MustNewPlus(p uint8) *Plus {
-	hll, err := NewPlus(p)
-	if err != nil {
-		panic(err)
-	}
-	return hll
-}
-
 // Clone returns a deep copy of h.
-func (h *Plus) Clone() *Plus {
+func (h *Plus) Clone() estimator.Sketch {
 	var hll = &Plus{
 		hash:       h.hash,
 		p:          h.p,

--- a/pkg/estimator/hll/hll_test.go
+++ b/pkg/estimator/hll/hll_test.go
@@ -26,7 +26,7 @@ func toByte(v uint64) []byte {
 	return buf[:]
 }
 
-func TestHLLPP_Bytes(t *testing.T) {
+func TestPlus_Bytes(t *testing.T) {
 	testCases := []struct {
 		p      uint8
 		normal bool
@@ -70,7 +70,7 @@ func TestHLLPP_Bytes(t *testing.T) {
 	}
 }
 
-func TestHLLPP_Add_NoSparse(t *testing.T) {
+func TestPlus_Add_NoSparse(t *testing.T) {
 	h := NewTestPlus(16)
 	h.toNormal()
 
@@ -111,7 +111,7 @@ func TestHLLPP_Add_NoSparse(t *testing.T) {
 	}
 }
 
-func TestHLLPPPrecision_NoSparse(t *testing.T) {
+func TestPlusPrecision_NoSparse(t *testing.T) {
 	h := NewTestPlus(4)
 	h.toNormal()
 
@@ -134,7 +134,7 @@ func TestHLLPPPrecision_NoSparse(t *testing.T) {
 	}
 }
 
-func TestHLLPP_toNormal(t *testing.T) {
+func TestPlus_toNormal(t *testing.T) {
 	h := NewTestPlus(16)
 	h.Add(toByte(0x00010fffffffffff))
 	h.toNormal()
@@ -176,7 +176,7 @@ func TestHLLPP_toNormal(t *testing.T) {
 	}
 }
 
-func TestHLLPPCount(t *testing.T) {
+func TestPlusCount(t *testing.T) {
 	h := NewTestPlus(16)
 
 	n := h.Count()
@@ -211,7 +211,7 @@ func TestHLLPPCount(t *testing.T) {
 	}
 }
 
-func TestHLLPP_Merge_Error(t *testing.T) {
+func TestPlus_Merge_Error(t *testing.T) {
 	h := NewTestPlus(16)
 	h2 := NewTestPlus(10)
 
@@ -311,7 +311,7 @@ func TestHLL_Merge_Normal(t *testing.T) {
 	}
 }
 
-func TestHLLPP_Merge(t *testing.T) {
+func TestPlus_Merge(t *testing.T) {
 	h := NewTestPlus(16)
 
 	k1 := uint64(0xf000017000000000)
@@ -404,7 +404,7 @@ func TestHLLPP_Merge(t *testing.T) {
 	}
 }
 
-func TestHLLPP_EncodeDecode(t *testing.T) {
+func TestPlus_EncodeDecode(t *testing.T) {
 	h := NewTestPlus(8)
 	i, r := h.decodeHash(h.encodeHash(0xffffff8000000000))
 	if i != 0xff {
@@ -447,7 +447,7 @@ func TestHLLPP_EncodeDecode(t *testing.T) {
 	}
 }
 
-func TestHLLPP_Error(t *testing.T) {
+func TestPlus_Error(t *testing.T) {
 	_, err := NewPlus(3)
 	if err == nil {
 		t.Error("precision 3 should return error")
@@ -464,7 +464,7 @@ func TestHLLPP_Error(t *testing.T) {
 	}
 }
 
-func TestHLLPP_Marshal_Unmarshal_Sparse(t *testing.T) {
+func TestPlus_Marshal_Unmarshal_Sparse(t *testing.T) {
 	h, _ := NewPlus(4)
 	h.sparse = true
 	h.tmpSet = map[uint32]struct{}{26: struct{}{}, 40: struct{}{}}
@@ -497,7 +497,7 @@ func TestHLLPP_Marshal_Unmarshal_Sparse(t *testing.T) {
 	}
 }
 
-func TestHLLPP_Marshal_Unmarshal_Dense(t *testing.T) {
+func TestPlus_Marshal_Unmarshal_Dense(t *testing.T) {
 	h, _ := NewPlus(4)
 	h.sparse = false
 
@@ -531,7 +531,7 @@ func TestHLLPP_Marshal_Unmarshal_Dense(t *testing.T) {
 
 // Tests that a sketch can be serialised / unserialised and keep an accurate
 // cardinality estimate.
-func TestHLLPP_Marshal_Unmarshal_Count(t *testing.T) {
+func TestPlus_Marshal_Unmarshal_Count(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test in short mode")
 	}
@@ -596,7 +596,10 @@ func TestHLLPP_Marshal_Unmarshal_Count(t *testing.T) {
 }
 
 func NewTestPlus(p uint8) *Plus {
-	h, _ := NewPlus(p)
+	h, err := NewPlus(p)
+	if err != nil {
+		panic(err)
+	}
 	h.hash = nopHash
 	return h
 }

--- a/pkg/estimator/sketch.go
+++ b/pkg/estimator/sketch.go
@@ -13,6 +13,12 @@ type Sketch interface {
 	// Merge merges another sketch into this one.
 	Merge(s Sketch) error
 
+	// Bytes estimates the memory footprint of the sketch, in bytes.
+	Bytes() int
+
+	// Clone returns a deep copy of the sketch.
+	Clone() Sketch
+
 	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
 }

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -60,6 +60,9 @@ type Index interface {
 	// Size of the index on disk, if applicable.
 	DiskSizeBytes() int64
 
+	// Bytes estimates the memory footprint of this Index, in bytes.
+	Bytes() int
+
 	// To be removed w/ tsi1.
 	SetFieldName(measurement []byte, name string)
 

--- a/tsdb/index/inmem/inmem_test.go
+++ b/tsdb/index/inmem/inmem_test.go
@@ -94,6 +94,26 @@ func BenchmarkShardIndex_CreateSeriesListIfNotExists_MaxSeriesExceeded(b *testin
 	}
 }
 
+func TestIndex_Bytes(t *testing.T) {
+	sfile := mustOpenSeriesFile()
+	defer sfile.Close()
+	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo", sfile.SeriesFile)}
+	si := inmem.NewShardIndex(1, "foo", "bar", tsdb.NewSeriesIDSet(), sfile.SeriesFile, opt).(*inmem.ShardIndex)
+
+	indexBaseBytes := si.Bytes()
+
+	name := []byte("name")
+	err := si.CreateSeriesIfNotExists(name, name, models.Tags{})
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	if indexBaseBytes >= si.Bytes() {
+		t.Errorf("index Bytes(): want >%d, got %d", indexBaseBytes, si.Bytes())
+	}
+}
+
 // seriesFileWrapper is a test wrapper for tsdb.seriesFileWrapper.
 type seriesFileWrapper struct {
 	*tsdb.SeriesFile

--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"sync"
+	"unsafe"
 
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/bytesutil"
@@ -49,6 +50,40 @@ func newMeasurement(database, name string) *measurement {
 		seriesByID:          make(map[uint64]*series),
 		seriesByTagKeyValue: make(map[string]*tagKeyValue),
 	}
+}
+
+// bytes estimates the memory footprint of this measurement, in bytes.
+func (m *measurement) bytes() int {
+	var b int
+	m.mu.RLock()
+	b += int(unsafe.Sizeof(m.Database)) + len(m.Database)
+	b += int(unsafe.Sizeof(m.Name)) + len(m.Name)
+	if m.NameBytes != nil {
+		b += int(unsafe.Sizeof(m.NameBytes)) + cap(m.NameBytes)
+	}
+	b += 24 // 24 bytes for m.mu RWMutex
+	b += int(unsafe.Sizeof(m.fieldNames))
+	for fieldName := range m.fieldNames {
+		b += int(unsafe.Sizeof(fieldName)) + len(fieldName)
+	}
+	b += int(unsafe.Sizeof(m.seriesByID))
+	for k, v := range m.seriesByID {
+		b += int(unsafe.Sizeof(k))
+		b += int(unsafe.Sizeof(v))
+		// Do not count footprint of each series, to avoid double-counting in Index.bytes().
+	}
+	b += int(unsafe.Sizeof(m.seriesByTagKeyValue))
+	for k, v := range m.seriesByTagKeyValue {
+		b += int(unsafe.Sizeof(k)) + len(k)
+		b += int(unsafe.Sizeof(v)) + v.bytes()
+	}
+	b += int(unsafe.Sizeof(m.sortedSeriesIDs))
+	for _, seriesID := range m.sortedSeriesIDs {
+		b += int(unsafe.Sizeof(seriesID))
+	}
+	b += int(unsafe.Sizeof(m.dirty))
+	m.mu.RUnlock()
+	return b
 }
 
 // Authorized determines if this Measurement is authorized to be read, according
@@ -989,6 +1024,22 @@ func newSeries(id uint64, m *measurement, key string, tags models.Tags) *series 
 	}
 }
 
+// bytes estimates the memory footprint of this series, in bytes.
+func (s *series) bytes() int {
+	var b int
+	s.mu.RLock()
+	b += 24 // RWMutex uses 24 bytes
+	b += int(unsafe.Sizeof(s.deleted) + unsafe.Sizeof(s.ID))
+	// Do not count s.Measurement to prevent double-counting in Index.Bytes.
+	b += int(unsafe.Sizeof(s.Key)) + len(s.Key)
+	for _, tag := range s.Tags {
+		b += int(unsafe.Sizeof(tag)) + cap(tag.Key) + cap(tag.Value)
+	}
+	b += int(unsafe.Sizeof(s.Tags))
+	s.mu.RUnlock()
+	return b
+}
+
 // Delete marks this series as deleted.  A deleted series should not be returned for queries.
 func (s *series) Delete() {
 	s.mu.Lock()
@@ -1006,11 +1057,25 @@ func (s *series) Deleted() bool {
 
 // TagKeyValue provides goroutine-safe concurrent access to the set of series
 // ids mapping to a set of tag values.
-//
-// TODO(edd): This could possibly be replaced by a sync.Map once we use Go 1.9.
 type tagKeyValue struct {
 	mu      sync.RWMutex
 	entries map[string]*tagKeyValueEntry
+}
+
+// bytes estimates the memory footprint of this tagKeyValue, in bytes.
+func (t *tagKeyValue) bytes() int {
+	var b int
+	t.mu.RLock()
+	b += 24 // RWMutex is 24 bytes
+	b += int(unsafe.Sizeof(t.entries))
+	for k, v := range t.entries {
+		b += int(unsafe.Sizeof(k)) + len(k)
+		b += len(v.m) * 8 // uint64
+		b += cap(v.a) * 8 // uint64
+		b += int(unsafe.Sizeof(v) + unsafe.Sizeof(*v))
+	}
+	t.mu.RUnlock()
+	return b
 }
 
 // NewTagKeyValue initialises a new TagKeyValue.

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -86,7 +86,8 @@ func (f *LogFile) bytes() int {
 	b += 16 // wg WaitGroup is 16 bytes
 	b += int(unsafe.Sizeof(f.id))
 	// Do not include f.data because it is mmap'd
-	b += int(unsafe.Sizeof(f.w)) + f.w.Size()
+	// TODO(jacobmarble): Uncomment when we are using go >= 1.10.0
+	//b += int(unsafe.Sizeof(f.w)) + f.w.Size()
 	b += int(unsafe.Sizeof(f.buf)) + cap(f.buf)
 	b += int(unsafe.Sizeof(f.keyBuf)) + cap(f.keyBuf)
 	// Do not count SeriesFile because it belongs to the code that constructed this Index.

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/bloom"
@@ -76,6 +77,30 @@ func NewLogFile(sfile *tsdb.SeriesFile, path string) *LogFile {
 		seriesIDSet:          tsdb.NewSeriesIDSet(),
 		tombstoneSeriesIDSet: tsdb.NewSeriesIDSet(),
 	}
+}
+
+// bytes estimates the memory footprint of this LogFile, in bytes.
+func (f *LogFile) bytes() int {
+	var b int
+	b += 24 // mu RWMutex is 24 bytes
+	b += 16 // wg WaitGroup is 16 bytes
+	b += int(unsafe.Sizeof(f.id))
+	// Do not include f.data because it is mmap'd
+	b += int(unsafe.Sizeof(f.w)) + f.w.Size()
+	b += int(unsafe.Sizeof(f.buf)) + cap(f.buf)
+	b += int(unsafe.Sizeof(f.keyBuf)) + cap(f.keyBuf)
+	// Do not count SeriesFile because it belongs to the code that constructed this Index.
+	b += int(unsafe.Sizeof(f.size))
+	b += int(unsafe.Sizeof(f.modTime))
+	b += int(unsafe.Sizeof(f.mSketch)) + f.mSketch.Bytes()
+	b += int(unsafe.Sizeof(f.mTSketch)) + f.mTSketch.Bytes()
+	b += int(unsafe.Sizeof(f.sSketch)) + f.sSketch.Bytes()
+	b += int(unsafe.Sizeof(f.sTSketch)) + f.sTSketch.Bytes()
+	b += int(unsafe.Sizeof(f.seriesIDSet)) + f.seriesIDSet.Bytes()
+	b += int(unsafe.Sizeof(f.tombstoneSeriesIDSet)) + f.tombstoneSeriesIDSet.Bytes()
+	b += int(unsafe.Sizeof(f.mms)) + f.mms.bytes()
+	b += int(unsafe.Sizeof(f.path)) + len(f.path)
+	return b
 }
 
 // Open reads the log from a file and validates all the checksums.
@@ -1138,11 +1163,35 @@ func appendLogEntry(dst []byte, e *LogEntry) []byte {
 // logMeasurements represents a map of measurement names to measurements.
 type logMeasurements map[string]*logMeasurement
 
+// bytes estimates the memory footprint of this logMeasurements, in bytes.
+func (mms *logMeasurements) bytes() int {
+	var b int
+	for k, v := range *mms {
+		b += len(k)
+		b += v.bytes()
+	}
+	b += int(unsafe.Sizeof(*mms))
+	return b
+}
+
 type logMeasurement struct {
 	name    []byte
 	tagSet  map[string]logTagKey
 	deleted bool
 	series  map[uint64]struct{}
+}
+
+// bytes estimates the memory footprint of this logMeasurement, in bytes.
+func (mm *logMeasurement) bytes() int {
+	var b int
+	b += cap(mm.name)
+	for k, v := range mm.tagSet {
+		b += len(k)
+		b += v.bytes()
+	}
+	b += len(mm.series) * 8
+	b += int(unsafe.Sizeof(*mm))
+	return b
 }
 
 func (mm *logMeasurement) seriesIDs() []uint64 {
@@ -1202,6 +1251,18 @@ type logTagKey struct {
 	tagValues map[string]logTagValue
 }
 
+// bytes estimates the memory footprint of this logTagKey, in bytes.
+func (tk *logTagKey) bytes() int {
+	var b int
+	b += cap(tk.name)
+	for k, v := range tk.tagValues {
+		b += len(k)
+		b += v.bytes()
+	}
+	b += int(unsafe.Sizeof(*tk))
+	return b
+}
+
 func (tk *logTagKey) Key() []byte   { return tk.name }
 func (tk *logTagKey) Deleted() bool { return tk.deleted }
 
@@ -1232,6 +1293,15 @@ type logTagValue struct {
 	name    []byte
 	deleted bool
 	series  map[uint64]struct{}
+}
+
+// bytes estimates the memory footprint of this logTagValue, in bytes.
+func (tv *logTagValue) bytes() int {
+	var b int
+	b += cap(tv.name)
+	b += len(tv.series) * 8
+	b += int(unsafe.Sizeof(*tv))
+	return b
 }
 
 func (tv *logTagValue) seriesIDs() []uint64 {

--- a/tsdb/index/tsi1/measurement_block.go
+++ b/tsdb/index/tsi1/measurement_block.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"sort"
+	"unsafe"
 
 	"github.com/influxdata/influxdb/pkg/estimator"
 	"github.com/influxdata/influxdb/pkg/estimator/hll"
@@ -59,6 +60,16 @@ type MeasurementBlock struct {
 	sketch, tSketch estimator.Sketch
 
 	version int // block version
+}
+
+// bytes estimates the memory footprint of this MeasurementBlock, in bytes.
+func (blk *MeasurementBlock) bytes() int {
+	var b int
+	// Do not count contents of blk.data or blk.hashData because they reference into an external []byte
+	b += blk.sketch.Bytes()
+	b += blk.tSketch.Bytes()
+	b += int(unsafe.Sizeof(*blk))
+	return b
 }
 
 // Version returns the encoding version parsed from the data.

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"io"
 	"sync"
+	"unsafe"
 
 	"github.com/RoaringBitmap/roaring"
 )
@@ -18,6 +19,16 @@ func NewSeriesIDSet() *SeriesIDSet {
 	return &SeriesIDSet{
 		bitmap: roaring.NewBitmap(),
 	}
+}
+
+// Bytes estimates the memory footprint of this SeriesIDSet, in bytes.
+func (s *SeriesIDSet) Bytes() int {
+	var b int
+	s.RLock()
+	b += 24 // mu RWMutex is 24 bytes
+	b += int(unsafe.Sizeof(s.bitmap)) + int(s.bitmap.GetSizeInBytes())
+	s.RUnlock()
+	return b
 }
 
 // Add adds the series id to the set.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -1450,7 +1450,7 @@ func (m *MeasurementFields) bytes() int {
 	b += int(unsafe.Sizeof(m.fields))
 	for k, v := range m.fields {
 		b += int(unsafe.Sizeof(k)) + len(k)
-		b += int(unsafe.Sizeof(v) + unsafe.Sizeof(*v)) + len(v.Name)
+		b += int(unsafe.Sizeof(v)+unsafe.Sizeof(*v)) + len(v.Name)
 	}
 	m.mu.RUnlock()
 	return b
@@ -1565,6 +1565,7 @@ func (m *MeasurementFields) Clone() *MeasurementFields {
 		fields: fields,
 	}
 }
+
 // MeasurementFieldSet represents a collection of fields by measurement.
 // This safe for concurrent use.
 type MeasurementFieldSet struct {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/influxdata/influxdb/models"
@@ -1441,6 +1442,20 @@ func (m *MeasurementFields) FieldKeys() []string {
 	return a
 }
 
+// bytes estimates the memory footprint of this MeasurementFields, in bytes.
+func (m *MeasurementFields) bytes() int {
+	var b int
+	m.mu.RLock()
+	b += 24 // mu RWMutex is 24 bytes
+	b += int(unsafe.Sizeof(m.fields))
+	for k, v := range m.fields {
+		b += int(unsafe.Sizeof(k)) + len(k)
+		b += int(unsafe.Sizeof(v) + unsafe.Sizeof(*v)) + len(v.Name)
+	}
+	m.mu.RUnlock()
+	return b
+}
+
 // CreateFieldIfNotExists creates a new field with an autoincrementing ID.
 // Returns an error if 255 fields have already been created on the measurement or
 // the fields already exists with a different type.
@@ -1550,7 +1565,6 @@ func (m *MeasurementFields) Clone() *MeasurementFields {
 		fields: fields,
 	}
 }
-
 // MeasurementFieldSet represents a collection of fields by measurement.
 // This safe for concurrent use.
 type MeasurementFieldSet struct {
@@ -1571,6 +1585,21 @@ func NewMeasurementFieldSet(path string) (*MeasurementFieldSet, error) {
 	// If there is a load error, return the error and an empty set so
 	// it can be rebuild manually.
 	return fs, fs.load()
+}
+
+// Bytes estimates the memory footprint of this MeasurementFieldSet, in bytes.
+func (fs *MeasurementFieldSet) Bytes() int {
+	var b int
+	fs.mu.RLock()
+	b += 24 // mu RWMutex is 24 bytes
+	for k, v := range fs.fields {
+		b += int(unsafe.Sizeof(k)) + len(k)
+		b += int(unsafe.Sizeof(v)) + v.bytes()
+	}
+	b += int(unsafe.Sizeof(fs.fields))
+	b += int(unsafe.Sizeof(fs.path)) + len(fs.path)
+	fs.mu.RUnlock()
+	return b
 }
 
 // Fields returns fields for a measurement by name.


### PR DESCRIPTION
Provides internal API to make progress on #9766 

Memory counting is a bit complicated because `go vet` does not allow copying instances of `sync.Mutex` and similar data structures, and `unsafe.Sizeof` violates that check. To work around this, there is a lot of field-by-field counting in this change, but I tried to consistently comment exceptions and count fields in the order they are presented in each struct.