### PR TITLE
Add option for unicode validation.

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -67,6 +67,10 @@
   # log any sensitive data contained within a query.
   # query-log-enabled = true
 
+  # Validates incoming writes to ensure keys only have valid unicode characters.
+  # This setting will incur a small overhead because every key must be checked.
+  # validate-keys = false
+
   # Settings for the TSM engine
 
   # CacheMaxMemorySize is the maximum size a shard's cache can

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -71,6 +71,9 @@ type Config struct {
 	// disks or when WAL write contention is seen.  A value of 0 fsyncs every write to the WAL.
 	WALFsyncDelay toml.Duration `toml:"wal-fsync-delay"`
 
+	// Enables unicode validation on series keys on write.
+	ValidateKeys bool `toml:"validate-keys"`
+
 	// Query logging
 	QueryLogEnabled bool `toml:"query-log-enabled"`
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -528,6 +528,9 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]models.Point, 
 	names := make([][]byte, len(points))
 	tagsSlice := make([]models.Tags, len(points))
 
+	// Check if keys should be unicode validated.
+	validateKeys := s.options.Config.ValidateKeys
+
 	var j int
 	for i, p := range points {
 		tags := p.Tags()
@@ -539,6 +542,15 @@ func (s *Shard) validateSeriesAndFields(points []models.Point) ([]models.Point, 
 				reason = fmt.Sprintf(
 					"invalid tag key: input tag \"%s\" on measurement \"%s\" is invalid",
 					"time", string(p.Name()))
+			}
+			continue
+		}
+
+		// Drop any series with invalid unicode characters in the key.
+		if validateKeys && !models.ValidKeyTokens(string(p.Name()), tags) {
+			dropped++
+			if reason == "" {
+				reason = fmt.Sprintf("key contains invalid unicode: \"%s\"", string(p.Key()))
 			}
 			continue
 		}


### PR DESCRIPTION
## Overview

This pull request adds a `validate-keys` configuration field that requires shard writes to check for valid, printable UTF-8 characters. Points with invalid keys will be dropped and a partial write error is returned.

###### Required only if applicable

_You can erase any checkboxes below this note if they are not applicable to your Pull Request._

- [x] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary

- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
