### PR TITLE
Print error message for unknown errors in client

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -798,6 +798,8 @@ func (c *CommandLine) ExecuteQuery(query string) error {
 			err = ctx.Err()
 			if err == context.Canceled {
 				err = errors.New("aborted by user")
+			} else if err == nil {
+				err = errors.New("no data received")
 			}
 		}
 		fmt.Printf("ERR: %s\n", err)


### PR DESCRIPTION
This fixes #9277 on client side.