### PR TITLE
tsdb/SeriesFile: remove unused function param

### DIFF
--- a/cmd/influx-tools/importer/series_writer.go
+++ b/cmd/influx-tools/importer/series_writer.go
@@ -75,7 +75,7 @@ type seriesFileAdapter struct {
 }
 
 func (s *seriesFileAdapter) CreateSeriesListIfNotExists(keys [][]byte, names [][]byte, tagsSlice []models.Tags) (err error) {
-	_, err = s.sf.CreateSeriesListIfNotExists(names, tagsSlice, s.buf[:0])
+	_, err = s.sf.CreateSeriesListIfNotExists(names, tagsSlice)
 	return err
 }
 

--- a/cmd/influx_inspect/verify/seriesfile/verify_test.go
+++ b/cmd/influx_inspect/verify/seriesfile/verify_test.go
@@ -97,7 +97,7 @@ func NewTest(t *testing.T) *Test {
 			tagsSlice = append(tagsSlice, nil)
 		}
 
-		_, err := seriesFile.CreateSeriesListIfNotExists(names, tagsSlice, nil)
+		_, err := seriesFile.CreateSeriesListIfNotExists(names, tagsSlice)
 		if err != nil {
 			return err
 		}

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -183,7 +183,7 @@ func (i *Index) MeasurementIterator() (tsdb.MeasurementIterator, error) {
 // CreateSeriesListIfNotExists adds the series for the given measurement to the
 // index and sets its ID or returns the existing series object
 func (i *Index) CreateSeriesListIfNotExists(seriesIDSet *tsdb.SeriesIDSet, keys, names [][]byte, tagsSlice []models.Tags, opt *tsdb.EngineOptions, ignoreLimits bool) error {
-	seriesIDs, err := i.sfile.CreateSeriesListIfNotExists(names, tagsSlice, nil)
+	seriesIDs, err := i.sfile.CreateSeriesListIfNotExists(names, tagsSlice)
 	if err != nil {
 		return err
 	}

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -486,9 +486,7 @@ func (f *LogFile) DeleteTagValue(name, key, value []byte) error {
 
 // AddSeriesList adds a list of series to the log file in bulk.
 func (f *LogFile) AddSeriesList(seriesSet *tsdb.SeriesIDSet, names [][]byte, tagsSlice []models.Tags) error {
-	buf := make([]byte, 2048)
-
-	seriesIDs, err := f.sfile.CreateSeriesListIfNotExists(names, tagsSlice, buf[:0])
+	seriesIDs, err := f.sfile.CreateSeriesListIfNotExists(names, tagsSlice)
 	if err != nil {
 		return err
 	}

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -133,7 +133,7 @@ func (f *SeriesFile) Wait() {
 
 // CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist.
 // The returned ids list returns values for new series and zero for existing series.
-func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags, buf []byte) (ids []uint64, err error) {
+func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags) (ids []uint64, err error) {
 	keys := GenerateSeriesKeys(names, tagsSlice)
 	keyPartitionIDs := f.SeriesKeysPartitionIDs(keys)
 	ids = make([]uint64, len(keys))

--- a/tsdb/series_file_test.go
+++ b/tsdb/series_file_test.go
@@ -22,7 +22,7 @@ func TestSeriesFile_Series(t *testing.T) {
 		{Name: []byte("mem"), Tags: models.NewTags(map[string]string{"region": "east"})},
 	}
 	for _, s := range series {
-		if _, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte(s.Name)}, []models.Tags{s.Tags}, nil); err != nil {
+		if _, err := sfile.CreateSeriesListIfNotExists([][]byte{[]byte(s.Name)}, []models.Tags{s.Tags}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -61,7 +61,7 @@ func TestSeriesFileCompactor(t *testing.T) {
 		names = append(names, []byte(fmt.Sprintf("m%d", i)))
 		tagsSlice = append(tagsSlice, models.NewTags(map[string]string{"foo": "bar"}))
 	}
-	if _, err := sfile.CreateSeriesListIfNotExists(names, tagsSlice, nil); err != nil {
+	if _, err := sfile.CreateSeriesListIfNotExists(names, tagsSlice); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Just noticed an unused param, pretty simple.