### PR TITLE
radix: optimize for our use case

### DIFF
--- a/pkg/radix/buffer.go
+++ b/pkg/radix/buffer.go
@@ -1,0 +1,31 @@
+package radix
+
+// bufferSize is the size of the buffer and the largest slice that can be
+// contained in it.
+const bufferSize = 4096
+
+// buffer is a type that amoritizes allocations into larger ones, handing out
+// small subslices to make copies.
+type buffer []byte
+
+// Copy returns a copy of the passed in byte slice allocated using the byte
+// slice in the buffer.
+func (b *buffer) Copy(x []byte) []byte {
+	// if we can never have enough room, just return a copy
+	if len(x) > bufferSize {
+		out := make([]byte, len(x))
+		copy(out, x)
+		return out
+	}
+
+	// if we don't have enough room, reallocate the buf first
+	if len(x) > len(*b) {
+		*b = make([]byte, bufferSize)
+	}
+
+	// create a copy and hand out a slice
+	copy(*b, x)
+	out := (*b)[:len(x):len(x)]
+	*b = (*b)[len(x):]
+	return out
+}

--- a/pkg/radix/buffer_test.go
+++ b/pkg/radix/buffer_test.go
@@ -1,0 +1,55 @@
+package radix
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+func TestBuffer(t *testing.T) {
+	var buf buffer
+
+	for i := 0; i < 1000; i++ {
+		x1 := make([]byte, rand.Intn(32)+1)
+		for j := range x1 {
+			x1[j] = byte(i + j)
+		}
+
+		x2 := buf.Copy(x1)
+		if !bytes.Equal(x2, x1) {
+			t.Fatal("bad copy")
+		}
+
+		x1[0] += 1
+		if bytes.Equal(x2, x1) {
+			t.Fatal("bad copy")
+		}
+	}
+}
+
+func TestBufferAppend(t *testing.T) {
+	var buf buffer
+	x1 := buf.Copy(make([]byte, 1))
+	x2 := buf.Copy(make([]byte, 1))
+
+	_ = append(x1, 1)
+	if x2[0] != 0 {
+		t.Fatal("append wrote past")
+	}
+}
+
+func TestBufferLarge(t *testing.T) {
+	var buf buffer
+
+	x1 := make([]byte, bufferSize+1)
+	x2 := buf.Copy(x1)
+
+	if !bytes.Equal(x1, x2) {
+		t.Fatal("bad copy")
+	}
+
+	x1[0] += 1
+	if bytes.Equal(x1, x2) {
+		t.Fatal("bad copy")
+	}
+}

--- a/pkg/radix/tree.go
+++ b/pkg/radix/tree.go
@@ -4,20 +4,16 @@ package radix
 // ability to update nodes as well as uses fixed int value type.
 
 import (
+	"bytes"
 	"sort"
-	"strings"
 	"sync"
 )
 
-// WalkFn is used when walking the tree. Takes a
-// key and value, returning if iteration should
-// be terminated.
-type WalkFn func(s string, v int) bool
-
 // leafNode is used to represent a value
 type leafNode struct {
-	key string
-	val int
+	valid bool // true if key/val are valid
+	key   []byte
+	val   int
 }
 
 // edge is used to represent an edge node
@@ -28,10 +24,10 @@ type edge struct {
 
 type node struct {
 	// leaf is used to store possible leaf
-	leaf *leafNode
+	leaf leafNode
 
 	// prefix is the common prefix we ignore
-	prefix string
+	prefix []byte
 
 	// Edges should be stored in-order for iteration.
 	// We avoid a fully materialized slice to save memory,
@@ -40,12 +36,26 @@ type node struct {
 }
 
 func (n *node) isLeaf() bool {
-	return n.leaf != nil
+	return n.leaf.valid
 }
 
 func (n *node) addEdge(e edge) {
-	n.edges = append(n.edges, e)
-	n.edges.Sort()
+	// find the insertion point with bisection
+	num := len(n.edges)
+	i, j := 0, num
+	for i < j {
+		h := int(uint(i+j) >> 1)
+		if n.edges[h].label < e.label {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+
+	// make room, copy the suffix, and insert.
+	n.edges = append(n.edges, edge{})
+	copy(n.edges[i+1:], n.edges[i:])
+	n.edges[i] = e
 }
 
 func (n *node) replaceEdge(e edge) {
@@ -61,71 +71,49 @@ func (n *node) replaceEdge(e edge) {
 }
 
 func (n *node) getEdge(label byte) *node {
-	num := len(n.edges)
-	// Use linear search for smaller arrays
-	if num < 64 {
-		for i := 0; i < num; i++ {
-			if n.edges[i].label == label {
-				return n.edges[i].node
+	// linear search for small slices
+	if len(n.edges) < 16 {
+		for _, e := range n.edges {
+			if e.label == label {
+				return e.node
 			}
 		}
-
 		return nil
 	}
 
-	idx := sort.Search(num, func(i int) bool {
-		return n.edges[i].label >= label
-	})
-	if idx < num && n.edges[idx].label == label {
-		return n.edges[idx].node
+	// binary search for larger
+	num := len(n.edges)
+	i, j := 0, num
+	for i < j {
+		h := int(uint(i+j) >> 1)
+		if n.edges[h].label < label {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	if i < num && n.edges[i].label == label {
+		return n.edges[i].node
 	}
 	return nil
 }
 
-func (n *node) delEdge(label byte) {
-	num := len(n.edges)
-	idx := sort.Search(num, func(i int) bool {
-		return n.edges[i].label >= label
-	})
-	if idx < num && n.edges[idx].label == label {
-		copy(n.edges[idx:], n.edges[idx+1:])
-		n.edges[len(n.edges)-1] = edge{}
-		n.edges = n.edges[:len(n.edges)-1]
-	}
-}
-
 type edges []edge
-
-func (e edges) Len() int {
-	return len(e)
-}
-
-func (e edges) Less(i, j int) bool {
-	return e[i].label < e[j].label
-}
-
-func (e edges) Swap(i, j int) {
-	e[i], e[j] = e[j], e[i]
-}
-
-func (e edges) Sort() {
-	sort.Sort(e)
-}
 
 // Tree implements a radix tree. This can be treated as a
 // Dictionary abstract data type. The main advantage over
 // a standard hash map is prefix-based lookups and
-// ordered iteration.  The tree is safe for concurrent access.
+// ordered iteration. The tree is safe for concurrent access.
 type Tree struct {
-	mu sync.RWMutex
-
+	mu   sync.RWMutex
 	root *node
 	size int
+	buf  buffer
 }
 
 // New returns an empty Tree
 func New() *Tree {
-	return NewFromMap(nil)
+	return &Tree{root: &node{}}
 }
 
 // NewFromMap returns a new tree containing the keys
@@ -133,54 +121,68 @@ func New() *Tree {
 func NewFromMap(m map[string]int) *Tree {
 	t := &Tree{root: &node{}}
 	for k, v := range m {
-		t.Insert(k, v)
+		t.Insert([]byte(k), v)
 	}
 	return t
 }
 
 // Len is used to return the number of elements in the tree
 func (t *Tree) Len() int {
-	return t.size
+	t.mu.RLock()
+	size := t.size
+	t.mu.RUnlock()
+
+	return size
 }
 
 // longestPrefix finds the length of the shared prefix
 // of two strings
-func longestPrefix(k1, k2 string) int {
-	max := len(k1)
-	if l := len(k2); l < max {
-		max = l
+func longestPrefix(k1, k2 []byte) int {
+	// for loops can't be inlined, but goto's can. we also use uint to help
+	// out the compiler to prove bounds checks aren't necessary on the index
+	// operations.
+
+	lk1, lk2 := uint(len(k1)), uint(len(k2))
+	i := uint(0)
+
+loop:
+	if lk1 <= i || lk2 <= i {
+		return int(i)
 	}
-	var i int
-	for i = 0; i < max; i++ {
-		if k1[i] != k2[i] {
-			break
-		}
+	if k1[i] != k2[i] {
+		return int(i)
 	}
-	return i
+	i++
+	goto loop
 }
 
 // Insert is used to add a newentry or update
 // an existing entry. Returns if inserted.
-func (t *Tree) Insert(s string, v int) (int, bool) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
+func (t *Tree) Insert(s []byte, v int) (int, bool) {
+	t.mu.RLock()
 
 	var parent *node
 	n := t.root
 	search := s
+
 	for {
 		// Handle key exhaution
 		if len(search) == 0 {
 			if n.isLeaf() {
 				old := n.leaf.val
+
+				t.mu.RUnlock()
 				return old, false
 			}
 
-			n.leaf = &leafNode{
-				key: s,
-				val: v,
+			n.leaf = leafNode{
+				key:   t.buf.Copy(s),
+				val:   v,
+				valid: true,
 			}
 			t.size++
+
+			t.mu.RUnlock()
 			return v, true
 		}
 
@@ -190,18 +192,24 @@ func (t *Tree) Insert(s string, v int) (int, bool) {
 
 		// No edge, create one
 		if n == nil {
+			newNode := &node{
+				leaf: leafNode{
+					key:   t.buf.Copy(s),
+					val:   v,
+					valid: true,
+				},
+				prefix: t.buf.Copy(search),
+			}
+
 			e := edge{
 				label: search[0],
-				node: &node{
-					leaf: &leafNode{
-						key: s,
-						val: v,
-					},
-					prefix: search,
-				},
+				node:  newNode,
 			}
+
 			parent.addEdge(e)
 			t.size++
+
+			t.mu.RUnlock()
 			return v, true
 		}
 
@@ -215,7 +223,7 @@ func (t *Tree) Insert(s string, v int) (int, bool) {
 		// Split the node
 		t.size++
 		child := &node{
-			prefix: search[:commonPrefix],
+			prefix: t.buf.Copy(search[:commonPrefix]),
 		}
 		parent.replaceEdge(edge{
 			label: search[0],
@@ -230,15 +238,18 @@ func (t *Tree) Insert(s string, v int) (int, bool) {
 		n.prefix = n.prefix[commonPrefix:]
 
 		// Create a new leaf node
-		leaf := &leafNode{
-			key: s,
-			val: v,
+		leaf := leafNode{
+			key:   t.buf.Copy(s),
+			val:   v,
+			valid: true,
 		}
 
 		// If the new key is a subset, add to to this node
 		search = search[commonPrefix:]
 		if len(search) == 0 {
 			child.leaf = leaf
+
+			t.mu.RUnlock()
 			return v, true
 		}
 
@@ -247,77 +258,19 @@ func (t *Tree) Insert(s string, v int) (int, bool) {
 			label: search[0],
 			node: &node{
 				leaf:   leaf,
-				prefix: search,
+				prefix: t.buf.Copy(search),
 			},
 		})
+
+		t.mu.RUnlock()
 		return v, true
 	}
-}
-
-// Delete is used to delete a key, returning the previous
-// value and if it was deleted
-func (t *Tree) Delete(s string) (int, bool) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	var parent *node
-	var label byte
-	n := t.root
-	search := s
-	for {
-		// Check for key exhaution
-		if len(search) == 0 {
-			if !n.isLeaf() {
-				break
-			}
-			goto DELETE
-		}
-
-		// Look for an edge
-		parent = n
-		label = search[0]
-		n = n.getEdge(label)
-		if n == nil {
-			break
-		}
-
-		// Consume the search prefix
-		if strings.HasPrefix(search, n.prefix) {
-			search = search[len(n.prefix):]
-		} else {
-			break
-		}
-	}
-	return 0, false
-
-DELETE:
-	// Delete the leaf
-	leaf := n.leaf
-	n.leaf = nil
-	t.size--
-
-	// Check if we should delete this node from the parent
-	if parent != nil && len(n.edges) == 0 {
-		parent.delEdge(label)
-	}
-
-	// Check if we should merge this node
-	if n != t.root && len(n.edges) == 1 {
-		n.mergeChild()
-	}
-
-	// Check if we should merge the parent's other child
-	if parent != nil && parent != t.root && len(parent.edges) == 1 && !parent.isLeaf() {
-		parent.mergeChild()
-	}
-
-	return leaf.val, true
 }
 
 // DeletePrefix is used to delete the subtree under a prefix
 // Returns how many nodes were deleted
 // Use this to delete large subtrees efficiently
-func (t *Tree) DeletePrefix(s string) int {
+func (t *Tree) DeletePrefix(s []byte) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -325,18 +278,18 @@ func (t *Tree) DeletePrefix(s string) int {
 }
 
 // delete does a recursive deletion
-func (t *Tree) deletePrefix(parent, n *node, prefix string) int {
+func (t *Tree) deletePrefix(parent, n *node, prefix []byte) int {
 	// Check for key exhaustion
 	if len(prefix) == 0 {
 		// Remove the leaf node
 		subTreeSize := 0
 		//recursively walk from all edges of the node to be deleted
-		recursiveWalk(n, func(s string, v int) bool {
+		recursiveWalk(n, func(s []byte, v int) bool {
 			subTreeSize++
 			return false
 		})
 		if n.isLeaf() {
-			n.leaf = nil
+			n.leaf = leafNode{}
 		}
 		n.edges = nil // deletes the entire subtree
 
@@ -351,7 +304,7 @@ func (t *Tree) deletePrefix(parent, n *node, prefix string) int {
 	// Look for an edge
 	label := prefix[0]
 	child := n.getEdge(label)
-	if child == nil || (!strings.HasPrefix(child.prefix, prefix) && !strings.HasPrefix(prefix, child.prefix)) {
+	if child == nil || (!bytes.HasPrefix(child.prefix, prefix) && !bytes.HasPrefix(prefix, child.prefix)) {
 		return 0
 	}
 
@@ -367,14 +320,17 @@ func (t *Tree) deletePrefix(parent, n *node, prefix string) int {
 func (n *node) mergeChild() {
 	e := n.edges[0]
 	child := e.node
-	n.prefix = n.prefix + child.prefix
+	prefix := make([]byte, 0, len(n.prefix)+len(child.prefix))
+	prefix = append(prefix, n.prefix...)
+	prefix = append(prefix, child.prefix...)
+	n.prefix = prefix
 	n.leaf = child.leaf
 	n.edges = child.edges
 }
 
 // Get is used to lookup a specific key, returning
 // the value and if it was found
-func (t *Tree) Get(s string) (int, bool) {
+func (t *Tree) Get(s []byte) (int, bool) {
 	t.mu.RLock()
 
 	n := t.root
@@ -396,174 +352,27 @@ func (t *Tree) Get(s string) (int, bool) {
 		}
 
 		// Consume the search prefix
-		if strings.HasPrefix(search, n.prefix) {
+		if bytes.HasPrefix(search, n.prefix) {
 			search = search[len(n.prefix):]
 		} else {
 			break
 		}
 	}
+
 	t.mu.RUnlock()
 	return 0, false
 }
 
-// LongestPrefix is like Get, but instead of an
-// exact match, it will return the longest prefix match.
-func (t *Tree) LongestPrefix(s string) (string, int, bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	var last *leafNode
-	n := t.root
-	search := s
-	for {
-		// Look for a leaf node
-		if n.isLeaf() {
-			last = n.leaf
-		}
-
-		// Check for key exhaution
-		if len(search) == 0 {
-			break
-		}
-
-		// Look for an edge
-		n = n.getEdge(search[0])
-		if n == nil {
-			break
-		}
-
-		// Consume the search prefix
-		if strings.HasPrefix(search, n.prefix) {
-			search = search[len(n.prefix):]
-		} else {
-			break
-		}
-	}
-	if last != nil {
-		return last.key, last.val, true
-	}
-	return "", 0, false
-}
-
-// Minimum is used to return the minimum value in the tree
-func (t *Tree) Minimum() (string, int, bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	n := t.root
-	for {
-		if n.isLeaf() {
-			return n.leaf.key, n.leaf.val, true
-		}
-		if len(n.edges) > 0 {
-			n = n.edges[0].node
-		} else {
-			break
-		}
-	}
-	return "", 0, false
-}
-
-// Maximum is used to return the maximum value in the tree
-func (t *Tree) Maximum() (string, int, bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	n := t.root
-	for {
-		if num := len(n.edges); num > 0 {
-			n = n.edges[num-1].node
-			continue
-		}
-		if n.isLeaf() {
-			return n.leaf.key, n.leaf.val, true
-		}
-		break
-	}
-	return "", 0, false
-}
-
-// Walk is used to walk the tree
-func (t *Tree) Walk(fn WalkFn) {
-	recursiveWalk(t.root, fn)
-}
-
-// WalkPrefix is used to walk the tree under a prefix
-func (t *Tree) WalkPrefix(prefix string, fn WalkFn) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	n := t.root
-	search := prefix
-	for {
-		// Check for key exhaution
-		if len(search) == 0 {
-			recursiveWalk(n, fn)
-			return
-		}
-
-		// Look for an edge
-		n = n.getEdge(search[0])
-		if n == nil {
-			break
-		}
-
-		// Consume the search prefix
-		if strings.HasPrefix(search, n.prefix) {
-			search = search[len(n.prefix):]
-
-		} else if strings.HasPrefix(n.prefix, search) {
-			// Child may be under our search prefix
-			recursiveWalk(n, fn)
-			return
-		} else {
-			break
-		}
-	}
-
-}
-
-// WalkPath is used to walk the tree, but only visiting nodes
-// from the root down to a given leaf. Where WalkPrefix walks
-// all the entries *under* the given prefix, this walks the
-// entries *above* the given prefix.
-func (t *Tree) WalkPath(path string, fn WalkFn) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	n := t.root
-	search := path
-	for {
-		// Visit the leaf values if any
-		if n.leaf != nil && fn(n.leaf.key, n.leaf.val) {
-			return
-		}
-
-		// Check for key exhaution
-		if len(search) == 0 {
-			return
-		}
-
-		// Look for an edge
-		n = n.getEdge(search[0])
-		if n == nil {
-			return
-		}
-
-		// Consume the search prefix
-		if strings.HasPrefix(search, n.prefix) {
-			search = search[len(n.prefix):]
-		} else {
-			break
-		}
-	}
-}
+// walkFn is used when walking the tree. Takes a
+// key and value, returning if iteration should
+// be terminated.
+type walkFn func(s []byte, v int) bool
 
 // recursiveWalk is used to do a pre-order walk of a node
 // recursively. Returns true if the walk should be aborted
-func recursiveWalk(n *node, fn WalkFn) bool {
+func recursiveWalk(n *node, fn walkFn) bool {
 	// Visit the leaf values if any
-	if n.leaf != nil && fn(n.leaf.key, n.leaf.val) {
+	if n.leaf.valid && fn(n.leaf.key, n.leaf.val) {
 		return true
 	}
 
@@ -576,12 +385,44 @@ func recursiveWalk(n *node, fn WalkFn) bool {
 	return false
 }
 
-// ToMap is used to walk the tree and convert it into a map
-func (t *Tree) ToMap() map[string]int {
-	out := make(map[string]int, t.size)
-	t.Walk(func(k string, v int) bool {
-		out[k] = v
-		return false
-	})
-	return out
+// Minimum is used to return the minimum value in the tree
+func (t *Tree) Minimum() ([]byte, int, bool) {
+	t.mu.RLock()
+
+	n := t.root
+	for {
+		if n.isLeaf() {
+			t.mu.RUnlock()
+			return n.leaf.key, n.leaf.val, true
+		}
+		if len(n.edges) > 0 {
+			n = n.edges[0].node
+		} else {
+			break
+		}
+	}
+
+	t.mu.RUnlock()
+	return nil, 0, false
+}
+
+// Maximum is used to return the maximum value in the tree
+func (t *Tree) Maximum() ([]byte, int, bool) {
+	t.mu.RLock()
+
+	n := t.root
+	for {
+		if num := len(n.edges); num > 0 {
+			n = n.edges[num-1].node
+			continue
+		}
+		if n.isLeaf() {
+			t.mu.RUnlock()
+			return n.leaf.key, n.leaf.val, true
+		}
+		break
+	}
+
+	t.mu.RUnlock()
+	return nil, 0, false
 }

--- a/pkg/radix/tree_test.go
+++ b/pkg/radix/tree_test.go
@@ -1,12 +1,26 @@
 package radix
 
 import (
-	crand "crypto/rand"
+	"crypto/rand"
 	"fmt"
 	"reflect"
-	"sort"
 	"testing"
 )
+
+// generateUUID is used to generate a random UUID
+func generateUUID() string {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Errorf("failed to read random bytes: %v", err))
+	}
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
+		buf[0:4],
+		buf[4:6],
+		buf[6:8],
+		buf[8:10],
+		buf[10:16])
+}
 
 func TestRadix(t *testing.T) {
 	var min, max string
@@ -27,32 +41,18 @@ func TestRadix(t *testing.T) {
 		t.Fatalf("bad length: %v %v", r.Len(), len(inp))
 	}
 
-	r.Walk(func(k string, v int) bool {
-		return false
-	})
-
-	for k, v := range inp {
-		out, ok := r.Get(k)
-		if !ok {
-			t.Fatalf("missing key: %v", k)
-		}
-		if out != v {
-			t.Fatalf("value mis-match: %v %v", out, v)
-		}
-	}
-
 	// Check min and max
 	outMin, _, _ := r.Minimum()
-	if outMin != min {
-		t.Fatalf("bad minimum: %v %v", outMin, min)
+	if string(outMin) != min {
+		t.Fatalf("bad minimum: %s %v", outMin, min)
 	}
 	outMax, _, _ := r.Maximum()
-	if outMax != max {
-		t.Fatalf("bad maximum: %v %v", outMax, max)
+	if string(outMax) != max {
+		t.Fatalf("bad maximum: %s %v", outMax, max)
 	}
 
 	for k, v := range inp {
-		out, ok := r.Delete(k)
+		out, ok := r.Get([]byte(k))
 		if !ok {
 			t.Fatalf("missing key: %v", k)
 		}
@@ -60,47 +60,7 @@ func TestRadix(t *testing.T) {
 			t.Fatalf("value mis-match: %v %v", out, v)
 		}
 	}
-	if r.Len() != 0 {
-		t.Fatalf("bad length: %v", r.Len())
-	}
-}
 
-func TestRoot(t *testing.T) {
-	r := New()
-	_, ok := r.Delete("")
-	if ok {
-		t.Fatalf("bad")
-	}
-	_, ok = r.Insert("", 1)
-	if !ok {
-		t.Fatalf("bad")
-	}
-	val, ok := r.Get("")
-	if !ok || val != 1 {
-		t.Fatalf("bad: %v", val)
-	}
-	val, ok = r.Delete("")
-	if !ok || val != 1 {
-		t.Fatalf("bad: %v", val)
-	}
-}
-
-func TestDelete(t *testing.T) {
-
-	r := New()
-
-	s := []string{"", "A", "AB"}
-
-	for _, ss := range s {
-		r.Insert(ss, 1)
-	}
-
-	for _, ss := range s {
-		_, ok := r.Delete(ss)
-		if !ok {
-			t.Fatalf("bad %q", ss)
-		}
-	}
 }
 
 func TestDeletePrefix(t *testing.T) {
@@ -122,220 +82,21 @@ func TestDeletePrefix(t *testing.T) {
 	for _, test := range cases {
 		r := New()
 		for _, ss := range test.inp {
-			r.Insert(ss, 1)
+			r.Insert([]byte(ss), 1)
 		}
 
-		deleted := r.DeletePrefix(test.prefix)
+		deleted := r.DeletePrefix([]byte(test.prefix))
 		if deleted != test.numDeleted {
 			t.Fatalf("Bad delete, expected %v to be deleted but got %v", test.numDeleted, deleted)
 		}
 
 		out := []string{}
-		fn := func(s string, v int) bool {
-			out = append(out, s)
+		fn := func(s []byte, v int) bool {
+			out = append(out, string(s))
 			return false
 		}
-		r.Walk(fn)
+		recursiveWalk(r.root, fn)
 
-		if !reflect.DeepEqual(out, test.out) {
-			t.Fatalf("mis-match: %v %v", out, test.out)
-		}
-	}
-}
-
-func TestLongestPrefix(t *testing.T) {
-	r := New()
-
-	keys := []string{
-		"",
-		"foo",
-		"foobar",
-		"foobarbaz",
-		"foobarbazzip",
-		"foozip",
-	}
-	for _, k := range keys {
-		r.Insert(k, 1)
-	}
-	if r.Len() != len(keys) {
-		t.Fatalf("bad len: %v %v", r.Len(), len(keys))
-	}
-
-	type exp struct {
-		inp string
-		out string
-	}
-	cases := []exp{
-		{"a", ""},
-		{"abc", ""},
-		{"fo", ""},
-		{"foo", "foo"},
-		{"foob", "foo"},
-		{"foobar", "foobar"},
-		{"foobarba", "foobar"},
-		{"foobarbaz", "foobarbaz"},
-		{"foobarbazzi", "foobarbaz"},
-		{"foobarbazzip", "foobarbazzip"},
-		{"foozi", "foo"},
-		{"foozip", "foozip"},
-		{"foozipzap", "foozip"},
-	}
-	for _, test := range cases {
-		m, _, ok := r.LongestPrefix(test.inp)
-		if !ok {
-			t.Fatalf("no match: %v", test)
-		}
-		if m != test.out {
-			t.Fatalf("mis-match: %v %v", m, test)
-		}
-	}
-}
-
-func TestWalkPrefix(t *testing.T) {
-	r := New()
-
-	keys := []string{
-		"foobar",
-		"foo/bar/baz",
-		"foo/baz/bar",
-		"foo/zip/zap",
-		"zipzap",
-	}
-	for _, k := range keys {
-		r.Insert(k, 1)
-	}
-	if r.Len() != len(keys) {
-		t.Fatalf("bad len: %v %v", r.Len(), len(keys))
-	}
-
-	type exp struct {
-		inp string
-		out []string
-	}
-	cases := []exp{
-		{
-			"f",
-			[]string{"foobar", "foo/bar/baz", "foo/baz/bar", "foo/zip/zap"},
-		},
-		{
-			"foo",
-			[]string{"foobar", "foo/bar/baz", "foo/baz/bar", "foo/zip/zap"},
-		},
-		{
-			"foob",
-			[]string{"foobar"},
-		},
-		{
-			"foo/",
-			[]string{"foo/bar/baz", "foo/baz/bar", "foo/zip/zap"},
-		},
-		{
-			"foo/b",
-			[]string{"foo/bar/baz", "foo/baz/bar"},
-		},
-		{
-			"foo/ba",
-			[]string{"foo/bar/baz", "foo/baz/bar"},
-		},
-		{
-			"foo/bar",
-			[]string{"foo/bar/baz"},
-		},
-		{
-			"foo/bar/baz",
-			[]string{"foo/bar/baz"},
-		},
-		{
-			"foo/bar/bazoo",
-			[]string{},
-		},
-		{
-			"z",
-			[]string{"zipzap"},
-		},
-	}
-
-	for _, test := range cases {
-		out := []string{}
-		fn := func(s string, v int) bool {
-			out = append(out, s)
-			return false
-		}
-		r.WalkPrefix(test.inp, fn)
-		sort.Strings(out)
-		sort.Strings(test.out)
-		if !reflect.DeepEqual(out, test.out) {
-			t.Fatalf("mis-match: %v %v", out, test.out)
-		}
-	}
-}
-
-func TestWalkPath(t *testing.T) {
-	r := New()
-
-	keys := []string{
-		"foo",
-		"foo/bar",
-		"foo/bar/baz",
-		"foo/baz/bar",
-		"foo/zip/zap",
-		"zipzap",
-	}
-	for _, k := range keys {
-		r.Insert(k, 1)
-	}
-	if r.Len() != len(keys) {
-		t.Fatalf("bad len: %v %v", r.Len(), len(keys))
-	}
-
-	type exp struct {
-		inp string
-		out []string
-	}
-	cases := []exp{
-		{
-			"f",
-			[]string{},
-		},
-		{
-			"foo",
-			[]string{"foo"},
-		},
-		{
-			"foo/",
-			[]string{"foo"},
-		},
-		{
-			"foo/ba",
-			[]string{"foo"},
-		},
-		{
-			"foo/bar",
-			[]string{"foo", "foo/bar"},
-		},
-		{
-			"foo/bar/baz",
-			[]string{"foo", "foo/bar", "foo/bar/baz"},
-		},
-		{
-			"foo/bar/bazoo",
-			[]string{"foo", "foo/bar", "foo/bar/baz"},
-		},
-		{
-			"z",
-			[]string{},
-		},
-	}
-
-	for _, test := range cases {
-		out := []string{}
-		fn := func(s string, v int) bool {
-			out = append(out, s)
-			return false
-		}
-		r.WalkPath(test.inp, fn)
-		sort.Strings(out)
-		sort.Strings(test.out)
 		if !reflect.DeepEqual(out, test.out) {
 			t.Fatalf("mis-match: %v %v", out, test.out)
 		}
@@ -344,7 +105,7 @@ func TestWalkPath(t *testing.T) {
 
 func TestInsert_Duplicate(t *testing.T) {
 	r := New()
-	vv, ok := r.Insert("cpu", 1)
+	vv, ok := r.Insert([]byte("cpu"), 1)
 	if vv != 1 {
 		t.Fatalf("value mismatch: got %v, exp %v", vv, 1)
 	}
@@ -354,7 +115,7 @@ func TestInsert_Duplicate(t *testing.T) {
 	}
 
 	// Insert a dup with a different type should fail
-	vv, ok = r.Insert("cpu", 2)
+	vv, ok = r.Insert([]byte("cpu"), 2)
 	if vv != 1 {
 		t.Fatalf("value mismatch: got %v, exp %v", vv, 1)
 	}
@@ -364,33 +125,24 @@ func TestInsert_Duplicate(t *testing.T) {
 	}
 }
 
-// generateUUID is used to generate a random UUID
-func generateUUID() string {
-	buf := make([]byte, 16)
-	if _, err := crand.Read(buf); err != nil {
-		panic(fmt.Errorf("failed to read random bytes: %v", err))
-	}
-
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
-		buf[0:4],
-		buf[4:6],
-		buf[6:8],
-		buf[8:10],
-		buf[10:16])
-}
+//
+// benchmarks
+//
 
 func BenchmarkTree_Insert(b *testing.B) {
 	t := New()
 
-	keys := make([]string, 0, 10000)
+	keys := make([][]byte, 0, 10000)
 	for i := 0; i < cap(keys); i++ {
-		k := fmt.Sprintf("cpu,host=%d", i)
+		k := []byte(fmt.Sprintf("cpu,host=%d", i))
 		if v, ok := t.Insert(k, 1); v != 1 || !ok {
 			b.Fatalf("insert failed: %v != 1 || !%v", v, ok)
 		}
 		keys = append(keys, k)
 	}
 
+	b.SetBytes(int64(len(keys)))
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	for j := 0; j < b.N; j++ {
@@ -398,6 +150,25 @@ func BenchmarkTree_Insert(b *testing.B) {
 			if v, ok := t.Insert(key, 1); v != 1 || ok {
 				b.Fatalf("insert failed: %v != 1 || !%v", v, ok)
 			}
+		}
+	}
+}
+
+func BenchmarkTree_InsertNew(b *testing.B) {
+	keys := make([][]byte, 0, 10000)
+	for i := 0; i < cap(keys); i++ {
+		k := []byte(fmt.Sprintf("cpu,host=%d", i))
+		keys = append(keys, k)
+	}
+
+	b.SetBytes(int64(len(keys)))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for j := 0; j < b.N; j++ {
+		t := New()
+		for _, key := range keys {
+			t.Insert(key, 1)
 		}
 	}
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1235,23 +1235,22 @@ func (e *Engine) WritePoints(points []models.Point) error {
 			}
 
 			keyBuf = append(keyBuf[:baseLen], iter.FieldKey()...)
-			kstr := string(keyBuf)
 
 			if e.seriesTypeMap != nil {
 				// Fast-path check to see if the field for the series already exists.
-				if v, ok := e.seriesTypeMap.Get(kstr); !ok {
+				if v, ok := e.seriesTypeMap.Get(keyBuf); !ok {
 					if typ, err := e.Type(keyBuf); err != nil {
 						// Field type is unknown, we can try to add it.
 					} else if typ != iter.Type() {
 						// Existing type is different from what was passed in, we need to drop
 						// this write and refresh the series type map.
 						seriesErr = tsdb.ErrFieldTypeConflict
-						e.seriesTypeMap.Insert(kstr, int(typ))
+						e.seriesTypeMap.Insert(keyBuf, int(typ))
 						continue
 					}
 
 					// Doesn't exsts, so try to insert
-					vv, ok := e.seriesTypeMap.Insert(kstr, int(iter.Type()))
+					vv, ok := e.seriesTypeMap.Insert(keyBuf, int(iter.Type()))
 
 					// We didn't insert and the type that exists isn't what we tried to insert, so
 					// we have a conflict and must drop this field/series.
@@ -1298,7 +1297,7 @@ func (e *Engine) WritePoints(points []models.Point) error {
 			default:
 				return fmt.Errorf("unknown field type for %s: %s", string(iter.FieldKey()), p.String())
 			}
-			values[kstr] = append(values[kstr], v)
+			values[string(keyBuf)] = append(values[string(keyBuf)], v)
 		}
 	}
 


### PR DESCRIPTION
- reduce allocations by making leaf a value type with a bool
- make longestPrefix inlineable and have no bounds checks
- delete any code for functions we don't plan to use
- operate on []byte and only copy when necessary
- inline calls to sort.Search to avoid allocations and indirections
- insert directly in the correct location for addEdge
- reduce allocations during copying with a buffer helper

results:

```
name              old time/op    new time/op     delta
Tree_Insert-8       1.10ms ± 4%     0.73ms ± 4%  -33.54%  (p=0.000 n=10+10)
Tree_InsertNew-8    3.18ms ± 2%     1.91ms ± 6%  -39.90%  (p=0.000 n=10+10)

name              old speed      new speed       delta
Tree_Insert-8     9.12MB/s ± 4%  13.72MB/s ± 4%  +50.46%  (p=0.000 n=10+10)
Tree_InsertNew-8  3.15MB/s ± 2%   5.24MB/s ± 6%  +66.42%  (p=0.000 n=10+10)

name              old alloc/op   new alloc/op    delta
Tree_InsertNew-8    1.62MB ± 0%     1.60MB ± 0%   -1.28%  (p=0.000 n=10+9)

name              old allocs/op  new allocs/op   delta
Tree_InsertNew-8     35.0k ± 0%      15.0k ± 0%  -57.04%  (p=0.000 n=10+10)
```

MB/sec in this case is 1 byte per key inserted, so it's really millions
of keys inserted per second.