### PR TITLE
Correct godoc for SeriesFile.CreateSeriesListIfNotExists

### DIFF
--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -132,11 +132,11 @@ func (f *SeriesFile) Wait() {
 }
 
 // CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist.
-// The returned ids list returns values for new series and zero for existing series.
-func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags) (ids []uint64, err error) {
+// The returned ids slice returns IDs for every name+tags, creating new series IDs as needed.
+func (f *SeriesFile) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags) ([]uint64, error) {
 	keys := GenerateSeriesKeys(names, tagsSlice)
 	keyPartitionIDs := f.SeriesKeysPartitionIDs(keys)
-	ids = make([]uint64, len(keys))
+	ids := make([]uint64, len(keys))
 
 	var g errgroup.Group
 	for i := range f.partitions {

--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -174,7 +174,7 @@ func (p *SeriesPartition) Path() string { return p.path }
 func (p *SeriesPartition) IndexPath() string { return filepath.Join(p.path, "index") }
 
 // CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist.
-// The returned ids list returns values for new series and zero for existing series.
+// The ids parameter is modified to contain series IDs for all keys belonging to this partition.
 func (p *SeriesPartition) CreateSeriesListIfNotExists(keys [][]byte, keyPartitionIDs []int, ids []uint64) error {
 	var writeRequired bool
 	p.mu.RLock()


### PR DESCRIPTION
The existing godoc doesn't match the implementation (SeriesPartition in particular) or the way CreateSeriesListIfNotExists is used in the two places where the returned `ids` value isn't thrown away. In fact, those two usages look like they might break if current godoc were true.