### PR TITLE
Cleanup index memory footprint counting code

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -79,7 +79,6 @@ type Engine interface {
 	DiskSize() int64
 	IsIdle() bool
 	Free() error
-	IndexBytes() (int, uintptr)
 
 	io.WriterTo
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -261,10 +261,6 @@ func NewEngine(id uint64, idx tsdb.Index, database, path string, walPath string,
 	return e
 }
 
-func (e *Engine) IndexBytes() (int, uintptr) {
-	return e.index.Bytes()
-}
-
 // Digest returns a reader for the shard's digest.
 func (e *Engine) Digest() (io.ReadCloser, int64, error) {
 	digestPath := filepath.Join(e.path, "digest.tsd")

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -60,9 +60,8 @@ type Index interface {
 	// Size of the index on disk, if applicable.
 	DiskSizeBytes() int64
 
-	// Bytes estimates the memory footprint of this Index, in bytes,
-	// and a unique reference ID to the Index instance.
-	Bytes() (int, uintptr)
+	// Bytes estimates the memory footprint of this Index, in bytes.
+	Bytes() int
 
 	// To be removed w/ tsi1.
 	SetFieldName(measurement []byte, name string)

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -79,6 +79,10 @@ func NewIndex(database string, sfile *tsdb.SeriesFile) *Index {
 	return index
 }
 
+func (i *Index) UniqueReferenceID() uintptr {
+	return uintptr(unsafe.Pointer(i))
+}
+
 // Bytes estimates the memory footprint of this Index, in bytes.
 func (i *Index) Bytes() (int, uintptr) {
 	var b int

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -84,7 +84,7 @@ func (i *Index) UniqueReferenceID() uintptr {
 }
 
 // Bytes estimates the memory footprint of this Index, in bytes.
-func (i *Index) Bytes() (int, uintptr) {
+func (i *Index) Bytes() int {
 	var b int
 	i.mu.RLock()
 	b += 24 // mu RWMutex is 24 bytes
@@ -110,7 +110,7 @@ func (i *Index) Bytes() (int, uintptr) {
 	b += int(unsafe.Sizeof(i.measurementsTSSketch)) + i.measurementsTSSketch.Bytes()
 	b += 8 // rebuildQueue Mutex is 8 bytes
 	i.mu.RUnlock()
-	return b, uintptr(unsafe.Pointer(i))
+	return b
 }
 
 func (i *Index) Type() string      { return IndexName }

--- a/tsdb/index/inmem/inmem_test.go
+++ b/tsdb/index/inmem/inmem_test.go
@@ -100,7 +100,7 @@ func TestIndex_Bytes(t *testing.T) {
 	opt := tsdb.EngineOptions{InmemIndex: inmem.NewIndex("foo", sfile.SeriesFile)}
 	si := inmem.NewShardIndex(1, "foo", "bar", tsdb.NewSeriesIDSet(), sfile.SeriesFile, opt).(*inmem.ShardIndex)
 
-	indexBaseBytes, _ := si.Bytes()
+	indexBaseBytes := si.Bytes()
 
 	name := []byte("name")
 	err := si.CreateSeriesIfNotExists(name, name, models.Tags{})
@@ -109,7 +109,7 @@ func TestIndex_Bytes(t *testing.T) {
 		t.FailNow()
 	}
 
-	indexNewBytes, _ := si.Bytes()
+	indexNewBytes := si.Bytes()
 	if indexBaseBytes >= indexNewBytes {
 		t.Errorf("index Bytes(): want >%d, got %d", indexBaseBytes, indexNewBytes)
 	}

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -132,7 +132,7 @@ func NewIndex(sfile *tsdb.SeriesFile, database string, options ...IndexOption) *
 }
 
 // Bytes estimates the memory footprint of this Index, in bytes.
-func (i *Index) Bytes() (int, uintptr) {
+func (i *Index) Bytes() int {
 	var b int
 	i.mu.RLock()
 	b += 24 // mu RWMutex is 24 bytes
@@ -151,7 +151,7 @@ func (i *Index) Bytes() (int, uintptr) {
 	b += int(unsafe.Sizeof(i.version))
 	b += int(unsafe.Sizeof(i.PartitionN))
 	i.mu.RUnlock()
-	return b, uintptr(unsafe.Pointer(i))
+	return b
 }
 
 // Database returns the name of the database the index was initialized with.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -109,6 +109,10 @@ type Index struct {
 	PartitionN uint64
 }
 
+func (i *Index) UniqueReferenceID() uintptr {
+	return uintptr(unsafe.Pointer(i))
+}
+
 // NewIndex returns a new instance of Index.
 func NewIndex(sfile *tsdb.SeriesFile, database string, options ...IndexOption) *Index {
 	idx := &Index{

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -457,10 +457,6 @@ func (s *Shard) SetCompactionsEnabled(enabled bool) {
 	engine.SetCompactionsEnabled(enabled)
 }
 
-func (s *Shard) IndexBytes() (int, uintptr) {
-	return s._engine.IndexBytes()
-}
-
 // DiskSize returns the size on disk of this shard.
 func (s *Shard) DiskSize() (int64, error) {
 	s.mu.RLock()


### PR DESCRIPTION
`IndexSet.DedupeInmemIndexes()` was written with a subtle bug, which only returned one inmem index when multiple, distinct inmem indexes existed. This change includes a regression unit test. The bug was introduced here:
https://github.com/influxdata/influxdb/commit/493c1ed0d1f103c357eb9289deba22f593fa8835#diff-c218be2666dc8c31e018b8ebca9b46ceR1067

With that out of the way, there's a much cleaner way to walk all indexes for counting their memory footprint. #9766 