### PR TITLE
Performance optimization for testcode

### DIFF
--- a/stress/basic.go
+++ b/stress/basic.go
@@ -93,14 +93,14 @@ func typeArr(a []string) []interface{} {
 		var t string
 		switch ty {
 		case "float64":
-			t = fmt.Sprintf("%v", rand.Intn(1000))
+			t = fmt.Sprintf("%v", time.Now().Nanosecond() % 1000)
 		case "int":
-			t = fmt.Sprintf("%vi", rand.Intn(1000))
+			t = fmt.Sprintf("%vi", time.Now().Nanosecond() % 1000)
 		case "bool":
-			b := rand.Intn(2) == 1
+			b := time.Now().Nanosecond() % 2 == 1
 			t = fmt.Sprintf("%t", b)
 		default:
-			t = fmt.Sprintf("%v", rand.Intn(1000))
+			t = fmt.Sprintf("%v", time.Now().Nanosecond() % 1000)
 		}
 		i[j] = t
 	}

--- a/stress/basic.go
+++ b/stress/basic.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"sync"
 	"time"


### PR DESCRIPTION
first, show my flame graph Captured in the pressure measurement phase in the test server. 
![image](https://user-images.githubusercontent.com/2619009/39983751-5a37fc68-578b-11e8-9107-6a0c7aca2cf6.png)

40% of cpu detected waiting on sync.(*Mutex), can only run up to 800% cpu usage, the pressure on influxdb is only 20w/s points.
so may be it necessary to optimize. 

show my stress test config file. 
```
[provision]
  [provision.basic]
    enabled = true
    address = "xxxx:xxxx"
    database = "xxxx"
    reset_database = false

[write]
  [write.point_generator]
    [write.point_generator.basic]
      point_count = 1000
      series_count = 1000000
      tick = "10s"
      jitter = true
      precision = "s"
      measurement = "cpu"
      start_date = "2009-Jan-02"
      [[write.point_generator.basic.tag]]
        key = "host"
        value = "server"
      [[write.point_generator.basic.tag]]
        key = "location"
        value = "us-west"
      [[write.point_generator.basic.field]]
        key = "value"
        value = "float64" # supported types: float64, int, bool
      [[write.point_generator.basic.field]]
        key = "test_filed_int"
        value = "int" # supported types: float64, int, bool
      [[write.point_generator.basic.field]]
        key = "test_filed_bool"
        value = "bool" # supported types: float64, int, bool

  [write.influx_client]
    [write.influx_client.basic]
      enabled = true
      addresses = ["xxxx:xxxx"] 
      database = "stress"
      precision = "s"
      batch_size = 10000
      batch_interval = "0s"
      concurrency = 100
      ssl = false
      format = "line_http" 
      retention-policy = "xxxx"
```
test server:   kernel: Linux 3.10.0 redhat7
cpu count: 64

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
