### PR TITLE
Include the query task status in the QueryInfo struct

### DIFF
--- a/query/task_manager.go
+++ b/query/task_manager.go
@@ -1,6 +1,8 @@
 package query
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -20,7 +22,7 @@ type TaskStatus int
 
 const (
 	// RunningTask is set when the task is running.
-	RunningTask TaskStatus = iota
+	RunningTask TaskStatus = iota + 1
 
 	// KilledTask is set when the task is killed, but resources are still
 	// being used.
@@ -33,8 +35,27 @@ func (t TaskStatus) String() string {
 		return "running"
 	case KilledTask:
 		return "killed"
+	default:
+		return "unknown"
 	}
-	panic(fmt.Sprintf("unknown task status: %d", int(t)))
+}
+
+func (t TaskStatus) MarshalJSON() ([]byte, error) {
+	s := t.String()
+	return json.Marshal(s)
+}
+
+func (t *TaskStatus) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("running")) {
+		*t = RunningTask
+	} else if bytes.Equal(data, []byte("killed")) {
+		*t = KilledTask
+	} else if bytes.Equal(data, []byte("unknown")) {
+		*t = TaskStatus(0)
+	} else {
+		return fmt.Errorf("unknown task status: %s", string(data))
+	}
+	return nil
 }
 
 // TaskManager takes care of all aspects related to managing running queries.
@@ -228,6 +249,7 @@ type QueryInfo struct {
 	Query    string        `json:"query"`
 	Database string        `json:"database"`
 	Duration time.Duration `json:"duration"`
+	Status   TaskStatus    `json:"status"`
 }
 
 // Queries returns a list of all running queries with information about them.
@@ -243,6 +265,7 @@ func (t *TaskManager) Queries() []QueryInfo {
 			Query:    qi.query,
 			Database: qi.database,
 			Duration: now.Sub(qi.startTime),
+			Status:   qi.status,
 		})
 	}
 	return queries


### PR DESCRIPTION
Previously, the task manager was modified to keep the query status so it
could track which queries were running and which ones were killed.
In those previous versions, we removed a task from the process table
as soon as it was killed and did not remove it after it had finished
executing. This meant there could be zombie goroutines running in the
background that were impossible to see.

When the task manager was updated to track the task status, we forgot to
expose the status in the public interface so consumers could see the
task status.

Backport of #9778.