### PR TITLE
rename "triple_exponential_average" -> "triple_exponential_derivative"

### DIFF
--- a/query/call_iterator.go
+++ b/query/call_iterator.go
@@ -1311,29 +1311,29 @@ func newRelativeStrengthIndexIterator(input Iterator, n int, nHold int, warmupTy
 	}
 }
 
-// newTripleExponentialAverageIterator returns an iterator for operating on a triple_exponential_moving_average() call.
-func newTripleExponentialAverageIterator(input Iterator, n int, nHold int, warmupType gota.WarmupType, opt IteratorOptions) (Iterator, error) {
+// newTripleExponentialDerivativeIterator returns an iterator for operating on a triple_exponential_moving_average() call.
+func newTripleExponentialDerivativeIterator(input Iterator, n int, nHold int, warmupType gota.WarmupType, opt IteratorOptions) (Iterator, error) {
 	switch input := input.(type) {
 	case FloatIterator:
 		createFn := func() (FloatPointAggregator, FloatPointEmitter) {
-			fn := NewTripleExponentialAverageReducer(n, nHold, warmupType)
+			fn := NewTripleExponentialDerivativeReducer(n, nHold, warmupType)
 			return fn, fn
 		}
 		return newFloatStreamFloatIterator(input, createFn, opt), nil
 	case IntegerIterator:
 		createFn := func() (IntegerPointAggregator, FloatPointEmitter) {
-			fn := NewTripleExponentialAverageReducer(n, nHold, warmupType)
+			fn := NewTripleExponentialDerivativeReducer(n, nHold, warmupType)
 			return fn, fn
 		}
 		return newIntegerStreamFloatIterator(input, createFn, opt), nil
 	case UnsignedIterator:
 		createFn := func() (UnsignedPointAggregator, FloatPointEmitter) {
-			fn := NewTripleExponentialAverageReducer(n, nHold, warmupType)
+			fn := NewTripleExponentialDerivativeReducer(n, nHold, warmupType)
 			return fn, fn
 		}
 		return newUnsignedStreamFloatIterator(input, createFn, opt), nil
 	default:
-		return nil, fmt.Errorf("unsupported triple exponential average iterator type: %T", input)
+		return nil, fmt.Errorf("unsupported triple exponential derivative iterator type: %T", input)
 	}
 }
 

--- a/query/compile.go
+++ b/query/compile.go
@@ -275,7 +275,7 @@ func (c *compiledField) compileExpr(expr influxql.Expr) error {
 			return c.compileCumulativeSum(expr.Args)
 		case "moving_average":
 			return c.compileMovingAverage(expr.Args)
-		case "exponential_moving_average", "double_exponential_moving_average", "triple_exponential_moving_average", "relative_strength_index", "triple_exponential_average":
+		case "exponential_moving_average", "double_exponential_moving_average", "triple_exponential_moving_average", "relative_strength_index", "triple_exponential_derivative":
 			return c.compileExponentialMovingAverage(expr.Name, expr.Args)
 		case "kaufmans_efficiency_ratio", "kaufmans_adaptive_moving_average":
 			return c.compileKaufmans(expr.Name, expr.Args)
@@ -589,7 +589,7 @@ func (c *compiledField) compileExponentialMovingAverage(name string, args []infl
 	if len(args) >= 3 {
 		switch arg2 := args[2].(type) {
 		case *influxql.IntegerLiteral:
-			if name == "triple_exponential_average" && arg2.Val < 1 && arg2.Val != -1 {
+			if name == "triple_exponential_derivative" && arg2.Val < 1 && arg2.Val != -1 {
 				return fmt.Errorf("%s hold period must be greater than or equal to 1", name)
 			}
 			if arg2.Val < 0 && arg2.Val != -1 {

--- a/query/functions.go
+++ b/query/functions.go
@@ -912,7 +912,7 @@ func (r *RelativeStrengthIndexReducer) Emit() []FloatPoint {
 	}
 }
 
-type TripleExponentialAverageReducer struct {
+type TripleExponentialDerivativeReducer struct {
 	trix       gota.TRIX
 	holdPeriod uint32
 	count      uint32
@@ -920,31 +920,31 @@ type TripleExponentialAverageReducer struct {
 	t          int64
 }
 
-func NewTripleExponentialAverageReducer(period int, holdPeriod int, warmupType gota.WarmupType) *TripleExponentialAverageReducer {
+func NewTripleExponentialDerivativeReducer(period int, holdPeriod int, warmupType gota.WarmupType) *TripleExponentialDerivativeReducer {
 	trix := gota.NewTRIX(period, warmupType)
 	if holdPeriod == -1 {
 		holdPeriod = trix.WarmCount()
 	}
-	return &TripleExponentialAverageReducer{
+	return &TripleExponentialDerivativeReducer{
 		trix:       *trix,
 		holdPeriod: uint32(holdPeriod),
 	}
 }
-func (r *TripleExponentialAverageReducer) AggregateFloat(p *FloatPoint) {
+func (r *TripleExponentialDerivativeReducer) AggregateFloat(p *FloatPoint) {
 	r.aggregate(p.Value, p.Time)
 }
-func (r *TripleExponentialAverageReducer) AggregateInteger(p *IntegerPoint) {
+func (r *TripleExponentialDerivativeReducer) AggregateInteger(p *IntegerPoint) {
 	r.aggregate(float64(p.Value), p.Time)
 }
-func (r *TripleExponentialAverageReducer) AggregateUnsigned(p *UnsignedPoint) {
+func (r *TripleExponentialDerivativeReducer) AggregateUnsigned(p *UnsignedPoint) {
 	r.aggregate(float64(p.Value), p.Time)
 }
-func (r *TripleExponentialAverageReducer) aggregate(v float64, t int64) {
+func (r *TripleExponentialDerivativeReducer) aggregate(v float64, t int64) {
 	r.v = r.trix.Add(v)
 	r.t = t
 	r.count++
 }
-func (r *TripleExponentialAverageReducer) Emit() []FloatPoint {
+func (r *TripleExponentialDerivativeReducer) Emit() []FloatPoint {
 	if r.count <= r.holdPeriod {
 		return nil
 	}

--- a/query/select.go
+++ b/query/select.go
@@ -253,7 +253,7 @@ func (b *exprIteratorBuilder) buildCallIterator(ctx context.Context, expr *influ
 		opt.Interval = Interval{}
 
 		return newHoltWintersIterator(input, opt, int(h.Val), int(m.Val), includeFitData, interval)
-	case "derivative", "non_negative_derivative", "difference", "non_negative_difference", "moving_average", "exponential_moving_average", "double_exponential_moving_average", "triple_exponential_moving_average", "relative_strength_index", "triple_exponential_average", "kaufmans_efficiency_ratio", "kaufmans_adaptive_moving_average", "chande_momentum_oscillator", "elapsed":
+	case "derivative", "non_negative_derivative", "difference", "non_negative_difference", "moving_average", "exponential_moving_average", "double_exponential_moving_average", "triple_exponential_moving_average", "relative_strength_index", "triple_exponential_derivative", "kaufmans_efficiency_ratio", "kaufmans_adaptive_moving_average", "chande_momentum_oscillator", "elapsed":
 		if !opt.Interval.IsZero() {
 			if opt.Ascending {
 				opt.StartTime -= int64(opt.Interval.Duration)
@@ -289,7 +289,7 @@ func (b *exprIteratorBuilder) buildCallIterator(ctx context.Context, expr *influ
 				}
 			}
 			return newMovingAverageIterator(input, int(n.Val), opt)
-		case "exponential_moving_average", "double_exponential_moving_average", "triple_exponential_moving_average", "relative_strength_index", "triple_exponential_average":
+		case "exponential_moving_average", "double_exponential_moving_average", "triple_exponential_moving_average", "relative_strength_index", "triple_exponential_derivative":
 			n := expr.Args[1].(*influxql.IntegerLiteral)
 			if n.Val > 1 && !opt.Interval.IsZero() {
 				if opt.Ascending {
@@ -320,8 +320,8 @@ func (b *exprIteratorBuilder) buildCallIterator(ctx context.Context, expr *influ
 				return newTripleExponentialMovingAverageIterator(input, int(n.Val), nHold, warmupType, opt)
 			case "relative_strength_index":
 				return newRelativeStrengthIndexIterator(input, int(n.Val), nHold, warmupType, opt)
-			case "triple_exponential_average":
-				return newTripleExponentialAverageIterator(input, int(n.Val), nHold, warmupType, opt)
+			case "triple_exponential_derivative":
+				return newTripleExponentialDerivativeIterator(input, int(n.Val), nHold, warmupType, opt)
 			}
 		case "kaufmans_efficiency_ratio", "kaufmans_adaptive_moving_average":
 			n := expr.Args[1].(*influxql.IntegerLiteral)


### PR DESCRIPTION
This renames the function `triple_exponential_average` to `triple_exponential_derivative` to more accurately reflect what it does. Ref https://github.com/influxdata/influxdb/pull/9260#issuecomment-389333924

Per the referenced discussion, instead of naming it "trix", as this is indeed what it is generally known as, I still opted for the long name due to consistency. What influx calls "average" is generally known as "sma" (simple moving average), and renaming this isn't an option, so I think consistency is more important.

@jsternberg 

###### Required for all non-trivial PRs
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
