### PR TITLE
Return the correct auxiliary values for top/bottom

### DIFF
--- a/query/functions.go
+++ b/query/functions.go
@@ -1337,11 +1337,14 @@ func (r *FloatTopReducer) AggregateFloat(p *FloatPoint) {
 		if !r.h.cmp(&r.h.points[0], p) {
 			return
 		}
-		r.h.points[0] = *p
+		p.CopyTo(&r.h.points[0])
 		heap.Fix(r.h, 0)
 		return
 	}
-	heap.Push(r.h, *p)
+
+	var clone FloatPoint
+	p.CopyTo(&clone)
+	heap.Push(r.h, clone)
 }
 
 func (r *FloatTopReducer) Emit() []FloatPoint {
@@ -1380,11 +1383,14 @@ func (r *IntegerTopReducer) AggregateInteger(p *IntegerPoint) {
 		if !r.h.cmp(&r.h.points[0], p) {
 			return
 		}
-		r.h.points[0] = *p
+		p.CopyTo(&r.h.points[0])
 		heap.Fix(r.h, 0)
 		return
 	}
-	heap.Push(r.h, *p)
+
+	var clone IntegerPoint
+	p.CopyTo(&clone)
+	heap.Push(r.h, clone)
 }
 
 func (r *IntegerTopReducer) Emit() []IntegerPoint {
@@ -1423,11 +1429,14 @@ func (r *UnsignedTopReducer) AggregateUnsigned(p *UnsignedPoint) {
 		if !r.h.cmp(&r.h.points[0], p) {
 			return
 		}
-		r.h.points[0] = *p
+		p.CopyTo(&r.h.points[0])
 		heap.Fix(r.h, 0)
 		return
 	}
-	heap.Push(r.h, *p)
+
+	var clone UnsignedPoint
+	p.CopyTo(&clone)
+	heap.Push(r.h, clone)
 }
 
 func (r *UnsignedTopReducer) Emit() []UnsignedPoint {
@@ -1466,11 +1475,14 @@ func (r *FloatBottomReducer) AggregateFloat(p *FloatPoint) {
 		if !r.h.cmp(&r.h.points[0], p) {
 			return
 		}
-		r.h.points[0] = *p
+		p.CopyTo(&r.h.points[0])
 		heap.Fix(r.h, 0)
 		return
 	}
-	heap.Push(r.h, *p)
+
+	var clone FloatPoint
+	p.CopyTo(&clone)
+	heap.Push(r.h, clone)
 }
 
 func (r *FloatBottomReducer) Emit() []FloatPoint {
@@ -1509,11 +1521,14 @@ func (r *IntegerBottomReducer) AggregateInteger(p *IntegerPoint) {
 		if !r.h.cmp(&r.h.points[0], p) {
 			return
 		}
-		r.h.points[0] = *p
+		p.CopyTo(&r.h.points[0])
 		heap.Fix(r.h, 0)
 		return
 	}
-	heap.Push(r.h, *p)
+
+	var clone IntegerPoint
+	p.CopyTo(&clone)
+	heap.Push(r.h, clone)
 }
 
 func (r *IntegerBottomReducer) Emit() []IntegerPoint {
@@ -1552,11 +1567,14 @@ func (r *UnsignedBottomReducer) AggregateUnsigned(p *UnsignedPoint) {
 		if !r.h.cmp(&r.h.points[0], p) {
 			return
 		}
-		r.h.points[0] = *p
+		p.CopyTo(&r.h.points[0])
 		heap.Fix(r.h, 0)
 		return
 	}
-	heap.Push(r.h, *p)
+
+	var clone UnsignedPoint
+	p.CopyTo(&clone)
+	heap.Push(r.h, clone)
 }
 
 func (r *UnsignedBottomReducer) Emit() []UnsignedPoint {

--- a/query/point.gen.go
+++ b/query/point.gen.go
@@ -61,9 +61,13 @@ func (v *FloatPoint) Clone() *FloatPoint {
 
 // CopyTo makes a deep copy into the point.
 func (v *FloatPoint) CopyTo(other *FloatPoint) {
-	*other = *v
+	other.Name, other.Tags = v.Name, v.Tags
+	other.Time = v.Time
+	other.Value, other.Nil = v.Value, v.Nil
 	if v.Aux != nil {
-		other.Aux = make([]interface{}, len(v.Aux))
+		if len(other.Aux) != len(v.Aux) {
+			other.Aux = make([]interface{}, len(v.Aux))
+		}
 		copy(other.Aux, v.Aux)
 	}
 }
@@ -282,9 +286,13 @@ func (v *IntegerPoint) Clone() *IntegerPoint {
 
 // CopyTo makes a deep copy into the point.
 func (v *IntegerPoint) CopyTo(other *IntegerPoint) {
-	*other = *v
+	other.Name, other.Tags = v.Name, v.Tags
+	other.Time = v.Time
+	other.Value, other.Nil = v.Value, v.Nil
 	if v.Aux != nil {
-		other.Aux = make([]interface{}, len(v.Aux))
+		if len(other.Aux) != len(v.Aux) {
+			other.Aux = make([]interface{}, len(v.Aux))
+		}
 		copy(other.Aux, v.Aux)
 	}
 }
@@ -503,9 +511,13 @@ func (v *UnsignedPoint) Clone() *UnsignedPoint {
 
 // CopyTo makes a deep copy into the point.
 func (v *UnsignedPoint) CopyTo(other *UnsignedPoint) {
-	*other = *v
+	other.Name, other.Tags = v.Name, v.Tags
+	other.Time = v.Time
+	other.Value, other.Nil = v.Value, v.Nil
 	if v.Aux != nil {
-		other.Aux = make([]interface{}, len(v.Aux))
+		if len(other.Aux) != len(v.Aux) {
+			other.Aux = make([]interface{}, len(v.Aux))
+		}
 		copy(other.Aux, v.Aux)
 	}
 }
@@ -722,9 +734,13 @@ func (v *StringPoint) Clone() *StringPoint {
 
 // CopyTo makes a deep copy into the point.
 func (v *StringPoint) CopyTo(other *StringPoint) {
-	*other = *v
+	other.Name, other.Tags = v.Name, v.Tags
+	other.Time = v.Time
+	other.Value, other.Nil = v.Value, v.Nil
 	if v.Aux != nil {
-		other.Aux = make([]interface{}, len(v.Aux))
+		if len(other.Aux) != len(v.Aux) {
+			other.Aux = make([]interface{}, len(v.Aux))
+		}
 		copy(other.Aux, v.Aux)
 	}
 }
@@ -943,9 +959,13 @@ func (v *BooleanPoint) Clone() *BooleanPoint {
 
 // CopyTo makes a deep copy into the point.
 func (v *BooleanPoint) CopyTo(other *BooleanPoint) {
-	*other = *v
+	other.Name, other.Tags = v.Name, v.Tags
+	other.Time = v.Time
+	other.Value, other.Nil = v.Value, v.Nil
 	if v.Aux != nil {
-		other.Aux = make([]interface{}, len(v.Aux))
+		if len(other.Aux) != len(v.Aux) {
+			other.Aux = make([]interface{}, len(v.Aux))
+		}
 		copy(other.Aux, v.Aux)
 	}
 }

--- a/query/point.gen.go.tmpl
+++ b/query/point.gen.go.tmpl
@@ -57,9 +57,13 @@ func (v *{{.Name}}Point) Clone() *{{.Name}}Point {
 
 // CopyTo makes a deep copy into the point.
 func (v *{{.Name}}Point) CopyTo(other *{{.Name}}Point) {
-	*other = *v
+	other.Name, other.Tags = v.Name, v.Tags
+	other.Time = v.Time
+	other.Value, other.Nil = v.Value, v.Nil
 	if v.Aux != nil {
-		other.Aux = make([]interface{}, len(v.Aux))
+		if len(other.Aux) != len(v.Aux) {
+			other.Aux = make([]interface{}, len(v.Aux))
+		}
 		copy(other.Aux, v.Aux)
 	}
 }

--- a/query/select_test.go
+++ b/query/select_test.go
@@ -22,6 +22,7 @@ func TestSelect(t *testing.T) {
 		name   string
 		q      string
 		typ    influxql.DataType
+		fields map[string]influxql.DataType
 		expr   string
 		itrs   []query.Iterator
 		points [][]query.Point
@@ -891,6 +892,93 @@ func TestSelect(t *testing.T) {
 			},
 		},
 		{
+			name: "Top_AuxFields_Float",
+			q:    `SELECT top(p1, 2), p2, p3 FROM cpu`,
+			fields: map[string]influxql.DataType{
+				"p1": influxql.Float,
+				"p2": influxql.Float,
+				"p3": influxql.String,
+			},
+			itrs: []query.Iterator{
+				&FloatIterator{Points: []query.FloatPoint{
+					{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{float64(2), "aaa"}},
+					{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{float64(3), "bbb"}},
+					{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{float64(4), "ccc"}},
+					{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{float64(5), "ddd"}},
+				}},
+			},
+			points: [][]query.Point{
+				{
+					&query.FloatPoint{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{float64(4), "ccc"}},
+					&query.FloatPoint{Name: "cpu", Time: 2 * Second, Value: 4},
+					&query.StringPoint{Name: "cpu", Time: 2 * Second, Value: "ccc"},
+				},
+				{
+					&query.FloatPoint{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{float64(5), "ddd"}},
+					&query.FloatPoint{Name: "cpu", Time: 3 * Second, Value: 5},
+					&query.StringPoint{Name: "cpu", Time: 3 * Second, Value: "ddd"},
+				},
+			},
+		},
+		{
+			name: "Top_AuxFields_Integer",
+			q:    `SELECT top(p1, 2), p2, p3 FROM cpu`,
+			fields: map[string]influxql.DataType{
+				"p1": influxql.Integer,
+				"p2": influxql.Integer,
+				"p3": influxql.String,
+			},
+			itrs: []query.Iterator{
+				&IntegerIterator{Points: []query.IntegerPoint{
+					{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{int64(2), "aaa"}},
+					{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{int64(3), "bbb"}},
+					{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{int64(4), "ccc"}},
+					{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{int64(5), "ddd"}},
+				}},
+			},
+			points: [][]query.Point{
+				{
+					&query.IntegerPoint{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{int64(4), "ccc"}},
+					&query.IntegerPoint{Name: "cpu", Time: 2 * Second, Value: 4},
+					&query.StringPoint{Name: "cpu", Time: 2 * Second, Value: "ccc"},
+				},
+				{
+					&query.IntegerPoint{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{int64(5), "ddd"}},
+					&query.IntegerPoint{Name: "cpu", Time: 3 * Second, Value: 5},
+					&query.StringPoint{Name: "cpu", Time: 3 * Second, Value: "ddd"},
+				},
+			},
+		},
+		{
+			name: "Top_AuxFields_Unsigned",
+			q:    `SELECT top(p1, 2), p2, p3 FROM cpu`,
+			fields: map[string]influxql.DataType{
+				"p1": influxql.Unsigned,
+				"p2": influxql.Unsigned,
+				"p3": influxql.String,
+			},
+			itrs: []query.Iterator{
+				&UnsignedIterator{Points: []query.UnsignedPoint{
+					{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{uint64(2), "aaa"}},
+					{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{uint64(3), "bbb"}},
+					{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{uint64(4), "ccc"}},
+					{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{uint64(5), "ddd"}},
+				}},
+			},
+			points: [][]query.Point{
+				{
+					&query.UnsignedPoint{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{uint64(4), "ccc"}},
+					&query.UnsignedPoint{Name: "cpu", Time: 2 * Second, Value: 4},
+					&query.StringPoint{Name: "cpu", Time: 2 * Second, Value: "ccc"},
+				},
+				{
+					&query.UnsignedPoint{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{uint64(5), "ddd"}},
+					&query.UnsignedPoint{Name: "cpu", Time: 3 * Second, Value: 5},
+					&query.StringPoint{Name: "cpu", Time: 3 * Second, Value: "ddd"},
+				},
+			},
+		},
+		{
 			name: "Bottom_NoTags_Float",
 			q:    `SELECT bottom(value::float, 2) FROM cpu WHERE time >= '1970-01-01T00:00:00Z' AND time < '1970-01-02T00:00:00Z' GROUP BY time(30s), host fill(none)`,
 			typ:  influxql.Float,
@@ -1227,6 +1315,93 @@ func TestSelect(t *testing.T) {
 				{
 					&query.UnsignedPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 50 * Second, Value: 1, Aux: []interface{}{"B"}},
 					&query.StringPoint{Name: "cpu", Tags: ParseTags("region=west"), Time: 50 * Second, Value: "B"},
+				},
+			},
+		},
+		{
+			name: "Bottom_AuxFields_Float",
+			q:    `SELECT bottom(p1, 2), p2, p3 FROM cpu`,
+			fields: map[string]influxql.DataType{
+				"p1": influxql.Float,
+				"p2": influxql.Float,
+				"p3": influxql.String,
+			},
+			itrs: []query.Iterator{
+				&FloatIterator{Points: []query.FloatPoint{
+					{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{float64(2), "aaa"}},
+					{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{float64(3), "bbb"}},
+					{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{float64(4), "ccc"}},
+					{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{float64(5), "ddd"}},
+				}},
+			},
+			points: [][]query.Point{
+				{
+					&query.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{float64(2), "aaa"}},
+					&query.FloatPoint{Name: "cpu", Time: 0 * Second, Value: 2},
+					&query.StringPoint{Name: "cpu", Time: 0 * Second, Value: "aaa"},
+				},
+				{
+					&query.FloatPoint{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{float64(3), "bbb"}},
+					&query.FloatPoint{Name: "cpu", Time: 1 * Second, Value: 3},
+					&query.StringPoint{Name: "cpu", Time: 1 * Second, Value: "bbb"},
+				},
+			},
+		},
+		{
+			name: "Bottom_AuxFields_Integer",
+			q:    `SELECT bottom(p1, 2), p2, p3 FROM cpu`,
+			fields: map[string]influxql.DataType{
+				"p1": influxql.Integer,
+				"p2": influxql.Integer,
+				"p3": influxql.String,
+			},
+			itrs: []query.Iterator{
+				&IntegerIterator{Points: []query.IntegerPoint{
+					{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{int64(2), "aaa"}},
+					{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{int64(3), "bbb"}},
+					{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{int64(4), "ccc"}},
+					{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{int64(5), "ddd"}},
+				}},
+			},
+			points: [][]query.Point{
+				{
+					&query.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{int64(2), "aaa"}},
+					&query.IntegerPoint{Name: "cpu", Time: 0 * Second, Value: 2},
+					&query.StringPoint{Name: "cpu", Time: 0 * Second, Value: "aaa"},
+				},
+				{
+					&query.IntegerPoint{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{int64(3), "bbb"}},
+					&query.IntegerPoint{Name: "cpu", Time: 1 * Second, Value: 3},
+					&query.StringPoint{Name: "cpu", Time: 1 * Second, Value: "bbb"},
+				},
+			},
+		},
+		{
+			name: "Bottom_AuxFields_Unsigned",
+			q:    `SELECT bottom(p1, 2), p2, p3 FROM cpu`,
+			fields: map[string]influxql.DataType{
+				"p1": influxql.Unsigned,
+				"p2": influxql.Unsigned,
+				"p3": influxql.String,
+			},
+			itrs: []query.Iterator{
+				&UnsignedIterator{Points: []query.UnsignedPoint{
+					{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{uint64(2), "aaa"}},
+					{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{uint64(3), "bbb"}},
+					{Name: "cpu", Time: 2 * Second, Value: 3, Aux: []interface{}{uint64(4), "ccc"}},
+					{Name: "cpu", Time: 3 * Second, Value: 4, Aux: []interface{}{uint64(5), "ddd"}},
+				}},
+			},
+			points: [][]query.Point{
+				{
+					&query.UnsignedPoint{Name: "cpu", Time: 0 * Second, Value: 1, Aux: []interface{}{uint64(2), "aaa"}},
+					&query.UnsignedPoint{Name: "cpu", Time: 0 * Second, Value: 2},
+					&query.StringPoint{Name: "cpu", Time: 0 * Second, Value: "aaa"},
+				},
+				{
+					&query.UnsignedPoint{Name: "cpu", Time: 1 * Second, Value: 2, Aux: []interface{}{uint64(3), "bbb"}},
+					&query.UnsignedPoint{Name: "cpu", Time: 1 * Second, Value: 3},
+					&query.StringPoint{Name: "cpu", Time: 1 * Second, Value: "bbb"},
 				},
 			},
 		},
@@ -2783,10 +2958,14 @@ func TestSelect(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			shardMapper := ShardMapper{
 				MapShardsFn: func(sources influxql.Sources, _ influxql.TimeRange) query.ShardGroup {
+					var fields map[string]influxql.DataType
+					if tt.typ != influxql.Unknown {
+						fields = map[string]influxql.DataType{"value": tt.typ}
+					} else {
+						fields = tt.fields
+					}
 					return &ShardGroup{
-						Fields: map[string]influxql.DataType{
-							"value": tt.typ,
-						},
+						Fields:     fields,
 						Dimensions: []string{"host", "region"},
 						CreateIteratorFn: func(ctx context.Context, m *influxql.Measurement, opt query.IteratorOptions) (query.Iterator, error) {
 							if m.Name != "cpu" {


### PR DESCRIPTION
When `top()` or `bottom()` were used and selected auxiliary values, they
would return the wrong values that would be equal to the last point
selected. This is because the aggregators saved the memory address of
the auxiliary fields instead of copying them over. Since the same
auxiliary fields memory location is used for every value returned by the
storage engine, this resulted in the values being incorrect because they
were overwritten with incorrect values.

This fixes that so the auxiliary fields are copied out when they are
saved rather than only the memory location.

Backport of #9858.