### PR TITLE
tsdb: add shard number to the observer

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -208,8 +208,8 @@ type CompactionPlannerCreator func(cfg Config) interface{}
 // be sure to observe every file that is added or removed even in the presence of process death.
 type FileStoreObserver interface {
 	// FileFinishing is called before a file is renamed to it's final name.
-	FileFinishing(path string) error
+	FileFinishing(id uint64, path string) error
 
 	// FileUnlinking is called before a file is unlinked.
-	FileUnlinking(path string) error
+	FileUnlinking(id uint64, path string) error
 }

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -205,7 +205,7 @@ func NewEngine(id uint64, idx tsdb.Index, path string, walPath string, sfile *ts
 
 	fs := NewFileStore(path)
 	if opt.FileStoreObserver != nil {
-		fs.WithObserver(opt.FileStoreObserver)
+		fs.WithObserver(id, opt.FileStoreObserver)
 	}
 	cache := NewCache(uint64(opt.Config.CacheMaxMemorySize), path)
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -181,6 +181,7 @@ type FileStore struct {
 
 	currentTempDirID int
 
+	id  uint64
 	obs tsdb.FileStoreObserver
 }
 
@@ -228,7 +229,8 @@ func NewFileStore(dir string) *FileStore {
 }
 
 // WithObserver sets the observer for the file store.
-func (f *FileStore) WithObserver(obs tsdb.FileStoreObserver) {
+func (f *FileStore) WithObserver(id uint64, obs tsdb.FileStoreObserver) {
+	f.id = id
 	f.obs = obs
 }
 
@@ -692,7 +694,7 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 
 		// give the observer a chance to process the file first.
 		if f.obs != nil {
-			if err := f.obs.FileFinishing(file); err != nil {
+			if err := f.obs.FileFinishing(f.id, file); err != nil {
 				return err
 			}
 		}
@@ -749,7 +751,7 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 
 				// give the observer a chance to process the file first.
 				if f.obs != nil {
-					if err := f.obs.FileUnlinking(file.Path()); err != nil {
+					if err := f.obs.FileUnlinking(f.id, file.Path()); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
an observer may want to know what shard the file is part of. this
way, they don't have to rely on brittle file path parsing.
