### PR TITLE
tsdb: observe tombstone files as well

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -208,8 +208,8 @@ type CompactionPlannerCreator func(cfg Config) interface{}
 // be sure to observe every file that is added or removed even in the presence of process death.
 type FileStoreObserver interface {
 	// FileFinishing is called before a file is renamed to it's final name.
-	FileFinishing(id uint64, path string) error
+	FileFinishing(path string) error
 
 	// FileUnlinking is called before a file is unlinked.
-	FileUnlinking(id uint64, path string) error
+	FileUnlinking(path string) error
 }

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -593,9 +593,7 @@ func TestCompactor_CompactFull_TombstonedSkipBlock(t *testing.T) {
 	}
 	f1 := MustWriteTSM(dir, 1, writes)
 
-	ts := tsm1.Tombstoner{
-		Path: f1,
-	}
+	ts := tsm1.NewTombstoner(f1, nil)
 	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, math.MinInt64, math.MaxInt64)
 
 	if err := ts.Flush(); err != nil {
@@ -697,9 +695,7 @@ func TestCompactor_CompactFull_TombstonedPartialBlock(t *testing.T) {
 	}
 	f1 := MustWriteTSM(dir, 1, writes)
 
-	ts := tsm1.Tombstoner{
-		Path: f1,
-	}
+	ts := tsm1.NewTombstoner(f1, nil)
 	// a1 should remain after compaction
 	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 2, math.MaxInt64)
 
@@ -806,9 +802,7 @@ func TestCompactor_CompactFull_TombstonedMultipleRanges(t *testing.T) {
 	}
 	f1 := MustWriteTSM(dir, 1, writes)
 
-	ts := tsm1.Tombstoner{
-		Path: f1,
-	}
+	ts := tsm1.NewTombstoner(f1, nil)
 	// a1, a3 should remain after compaction
 	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 2, 2)
 	ts.AddRange([][]byte{[]byte("cpu,host=A#!~#value")}, 4, 4)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -205,7 +205,7 @@ func NewEngine(id uint64, idx tsdb.Index, path string, walPath string, sfile *ts
 
 	fs := NewFileStore(path)
 	if opt.FileStoreObserver != nil {
-		fs.WithObserver(id, opt.FileStoreObserver)
+		fs.WithObserver(opt.FileStoreObserver)
 	}
 	cache := NewCache(uint64(opt.Config.CacheMaxMemorySize), path)
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -518,6 +518,11 @@ func (f *FileStore) Open() error {
 					return
 				}
 			}
+
+			if f.obs != nil {
+				df.WithObserver(f.id, f.obs)
+			}
+
 			readerC <- &res{r: df}
 		}(i, file)
 	}
@@ -724,6 +729,10 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 		if err != nil {
 			return err
 		}
+		if f.obs != nil {
+			tsm.WithObserver(f.id, f.obs)
+		}
+
 		updated = append(updated, tsm)
 	}
 
@@ -753,6 +762,12 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 				if f.obs != nil {
 					if err := f.obs.FileUnlinking(f.id, file.Path()); err != nil {
 						return err
+					}
+
+					for _, t := range file.TombstoneFiles() {
+						if err := f.obs.FileUnlinking(f.id, t.Path); err != nil {
+							return err
+						}
 					}
 				}
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -181,7 +181,6 @@ type FileStore struct {
 
 	currentTempDirID int
 
-	id  uint64
 	obs tsdb.FileStoreObserver
 }
 
@@ -229,8 +228,7 @@ func NewFileStore(dir string) *FileStore {
 }
 
 // WithObserver sets the observer for the file store.
-func (f *FileStore) WithObserver(id uint64, obs tsdb.FileStoreObserver) {
-	f.id = id
+func (f *FileStore) WithObserver(obs tsdb.FileStoreObserver) {
 	f.obs = obs
 }
 
@@ -520,7 +518,7 @@ func (f *FileStore) Open() error {
 			}
 
 			if f.obs != nil {
-				df.WithObserver(f.id, f.obs)
+				df.WithObserver(f.obs)
 			}
 
 			readerC <- &res{r: df}
@@ -699,7 +697,7 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 
 		// give the observer a chance to process the file first.
 		if f.obs != nil {
-			if err := f.obs.FileFinishing(f.id, file); err != nil {
+			if err := f.obs.FileFinishing(file); err != nil {
 				return err
 			}
 		}
@@ -730,7 +728,7 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 			return err
 		}
 		if f.obs != nil {
-			tsm.WithObserver(f.id, f.obs)
+			tsm.WithObserver(f.obs)
 		}
 
 		updated = append(updated, tsm)
@@ -760,12 +758,12 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 
 				// give the observer a chance to process the file first.
 				if f.obs != nil {
-					if err := f.obs.FileUnlinking(f.id, file.Path()); err != nil {
+					if err := f.obs.FileUnlinking(file.Path()); err != nil {
 						return err
 					}
 
 					for _, t := range file.TombstoneFiles() {
-						if err := f.obs.FileUnlinking(f.id, t.Path); err != nil {
+						if err := f.obs.FileUnlinking(t.Path); err != nil {
 							return err
 						}
 					}

--- a/tsdb/engine/tsm1/file_store_observer.go
+++ b/tsdb/engine/tsm1/file_store_observer.go
@@ -1,0 +1,6 @@
+package tsm1
+
+type noFileStoreObserver struct{}
+
+func (noFileStoreObserver) FileFinishing(path string) error { return nil }
+func (noFileStoreObserver) FileUnlinking(path string) error { return nil }

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -2750,26 +2750,26 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 }
 
 type mockObserver struct {
-	fileFinishing func(id uint64, path string) error
-	fileUnlinking func(id uint64, path string) error
+	fileFinishing func(path string) error
+	fileUnlinking func(path string) error
 }
 
-func (m mockObserver) FileFinishing(id uint64, path string) error {
-	return m.fileFinishing(id, path)
+func (m mockObserver) FileFinishing(path string) error {
+	return m.fileFinishing(path)
 }
 
-func (m mockObserver) FileUnlinking(id uint64, path string) error {
-	return m.fileUnlinking(id, path)
+func (m mockObserver) FileUnlinking(path string) error {
+	return m.fileUnlinking(path)
 }
 
 func TestFileStore_Observer(t *testing.T) {
 	var finishes, unlinks []string
 	m := mockObserver{
-		fileFinishing: func(id uint64, path string) error {
+		fileFinishing: func(path string) error {
 			finishes = append(finishes, path)
 			return nil
 		},
-		fileUnlinking: func(id uint64, path string) error {
+		fileUnlinking: func(path string) error {
 			unlinks = append(unlinks, path)
 			return nil
 		},
@@ -2790,7 +2790,7 @@ func TestFileStore_Observer(t *testing.T) {
 	dir := MustTempDir()
 	defer os.RemoveAll(dir)
 	fs := tsm1.NewFileStore(dir)
-	fs.WithObserver(0, m)
+	fs.WithObserver(m)
 
 	// Setup 3 files
 	data := []keyValues{

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -2749,6 +2749,110 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 	}
 }
 
+type mockObserver struct {
+	fileFinishing func(id uint64, path string) error
+	fileUnlinking func(id uint64, path string) error
+}
+
+func (m mockObserver) FileFinishing(id uint64, path string) error {
+	return m.fileFinishing(id, path)
+}
+
+func (m mockObserver) FileUnlinking(id uint64, path string) error {
+	return m.fileUnlinking(id, path)
+}
+
+func TestFileStore_Observer(t *testing.T) {
+	var finishes, unlinks []string
+	m := mockObserver{
+		fileFinishing: func(id uint64, path string) error {
+			finishes = append(finishes, path)
+			return nil
+		},
+		fileUnlinking: func(id uint64, path string) error {
+			unlinks = append(unlinks, path)
+			return nil
+		},
+	}
+
+	check := func(results []string, expect ...string) {
+		t.Helper()
+		if len(results) != len(expect) {
+			t.Fatalf("wrong number of results: %d results != %d expected", len(results), len(expect))
+		}
+		for i, ex := range expect {
+			if got := filepath.Base(results[i]); got != ex {
+				t.Fatalf("unexpected result: got %q != expected %q", got, ex)
+			}
+		}
+	}
+
+	dir := MustTempDir()
+	defer os.RemoveAll(dir)
+	fs := tsm1.NewFileStore(dir)
+	fs.WithObserver(0, m)
+
+	// Setup 3 files
+	data := []keyValues{
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0), tsm1.NewValue(1, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(10, 2.0)}},
+		keyValues{"cpu", []tsm1.Value{tsm1.NewValue(20, 3.0)}},
+	}
+
+	files, err := newFiles(dir, data...)
+	if err != nil {
+		t.Fatalf("unexpected error creating files: %v", err)
+	}
+
+	if err := fs.Replace(nil, files); err != nil {
+		t.Fatalf("error replacing: %v", err)
+	}
+
+	// Create a tombstone
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 10, 10); err != nil {
+		t.Fatalf("unexpected error delete range: %v", err)
+	}
+
+	// Check that we observed finishes correctly
+	check(finishes,
+		"000000001-000000001.tsm",
+		"000000002-000000001.tsm",
+		"000000003-000000001.tsm",
+		"000000002-000000001.tombstone.tmp",
+	)
+	check(unlinks)
+	unlinks, finishes = nil, nil
+
+	// remove files including a tombstone
+	if err := fs.Replace(files[1:3], nil); err != nil {
+		t.Fatal("error replacing")
+	}
+
+	// Check that we observed unlinks correctly
+	check(finishes)
+	check(unlinks,
+		"000000002-000000001.tsm",
+		"000000002-000000001.tombstone",
+		"000000003-000000001.tsm",
+	)
+	unlinks, finishes = nil, nil
+
+	// add a tombstone for the first file multiple times.
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 0, 0); err != nil {
+		t.Fatalf("unexpected error delete range: %v", err)
+	}
+	if err := fs.DeleteRange([][]byte{[]byte("cpu")}, 1, 1); err != nil {
+		t.Fatalf("unexpected error delete range: %v", err)
+	}
+
+	check(finishes,
+		"000000001-000000001.tombstone.tmp",
+		"000000001-000000001.tombstone.tmp",
+	)
+	check(unlinks)
+	unlinks, finishes = nil, nil
+}
+
 func newFileDir(dir string, values ...keyValues) ([]string, error) {
 	var files []string
 

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -258,8 +258,7 @@ func NewTSMReader(f *os.File) (*TSMReader, error) {
 }
 
 // WithObserver sets the observer for the TSM reader.
-func (t *TSMReader) WithObserver(id uint64, obs tsdb.FileStoreObserver) {
-	t.tombstoner.id = id
+func (t *TSMReader) WithObserver(obs tsdb.FileStoreObserver) {
 	t.tombstoner.obs = obs
 }
 

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 
 	"github.com/influxdata/influxdb/pkg/bytesutil"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 // ErrFileInUse is returned when attempting to remove or close a TSM file that is still being used.
@@ -244,13 +245,22 @@ func NewTSMReader(f *os.File) (*TSMReader, error) {
 	}
 
 	t.index = index
-	t.tombstoner = &Tombstoner{Path: t.Path(), FilterFn: index.ContainsKey}
+	t.tombstoner = &Tombstoner{
+		Path:     t.Path(),
+		FilterFn: index.ContainsKey,
+	}
 
 	if err := t.applyTombstones(); err != nil {
 		return nil, err
 	}
 
 	return t, nil
+}
+
+// WithObserver sets the observer for the TSM reader.
+func (t *TSMReader) WithObserver(id uint64, obs tsdb.FileStoreObserver) {
+	t.tombstoner.id = id
+	t.tombstoner.obs = obs
 }
 
 func (t *TSMReader) applyTombstones() error {

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -245,10 +245,7 @@ func NewTSMReader(f *os.File) (*TSMReader, error) {
 	}
 
 	t.index = index
-	t.tombstoner = &Tombstoner{
-		Path:     t.Path(),
-		FilterFn: index.ContainsKey,
-	}
+	t.tombstoner = NewTombstoner(t.Path(), index.ContainsKey)
 
 	if err := t.applyTombstones(); err != nil {
 		return nil, err
@@ -259,7 +256,7 @@ func NewTSMReader(f *os.File) (*TSMReader, error) {
 
 // WithObserver sets the observer for the TSM reader.
 func (t *TSMReader) WithObserver(obs tsdb.FileStoreObserver) {
-	t.tombstoner.obs = obs
+	t.tombstoner.WithObserver(obs)
 }
 
 func (t *TSMReader) applyTombstones() error {

--- a/tsdb/engine/tsm1/tombstone.go
+++ b/tsdb/engine/tsm1/tombstone.go
@@ -53,7 +53,7 @@ type Tombstoner struct {
 	tmp               [8]byte
 	lastAppliedOffset int64
 
-	id  uint64
+	// Optional observer for when tombstone files are written.
 	obs tsdb.FileStoreObserver
 }
 
@@ -369,7 +369,7 @@ func (t *Tombstoner) commit() error {
 	t.pendingFile.Close()
 
 	if t.obs != nil {
-		if err := t.obs.FileFinishing(t.id, tmpFilename); err != nil {
+		if err := t.obs.FileFinishing(tmpFilename); err != nil {
 			return err
 		}
 	}

--- a/tsdb/engine/tsm1/tombstone_test.go
+++ b/tsdb/engine/tsm1/tombstone_test.go
@@ -14,7 +14,7 @@ func TestTombstoner_Add(t *testing.T) {
 	defer func() { os.RemoveAll(dir) }()
 
 	f := MustTempFile(dir)
-	ts := &tsm1.Tombstoner{Path: f.Name()}
+	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	entries := mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
@@ -59,7 +59,7 @@ func TestTombstoner_Add(t *testing.T) {
 	}
 
 	// Use a new Tombstoner to verify values are persisted
-	ts = &tsm1.Tombstoner{Path: f.Name()}
+	ts = tsm1.NewTombstoner(f.Name(), nil)
 	entries = mustReadAll(ts)
 	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
@@ -75,7 +75,7 @@ func TestTombstoner_Add_LargeKey(t *testing.T) {
 	defer func() { os.RemoveAll(dir) }()
 
 	f := MustTempFile(dir)
-	ts := &tsm1.Tombstoner{Path: f.Name()}
+	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	entries := mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
@@ -121,7 +121,7 @@ func TestTombstoner_Add_LargeKey(t *testing.T) {
 	}
 
 	// Use a new Tombstoner to verify values are persisted
-	ts = &tsm1.Tombstoner{Path: f.Name()}
+	ts = tsm1.NewTombstoner(f.Name(), nil)
 	entries = mustReadAll(ts)
 	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
@@ -137,7 +137,7 @@ func TestTombstoner_Add_Multiple(t *testing.T) {
 	defer func() { os.RemoveAll(dir) }()
 
 	f := MustTempFile(dir)
-	ts := &tsm1.Tombstoner{Path: f.Name()}
+	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	entries := mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
@@ -192,7 +192,7 @@ func TestTombstoner_Add_Multiple(t *testing.T) {
 	}
 
 	// Use a new Tombstoner to verify values are persisted
-	ts = &tsm1.Tombstoner{Path: f.Name()}
+	ts = tsm1.NewTombstoner(f.Name(), nil)
 	entries = mustReadAll(ts)
 	if got, exp := len(entries), 2; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
@@ -213,7 +213,7 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 	defer func() { os.RemoveAll(dir) }()
 
 	f := MustTempFile(dir)
-	ts := &tsm1.Tombstoner{Path: f.Name()}
+	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	entries := mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
@@ -227,7 +227,7 @@ func TestTombstoner_Add_Empty(t *testing.T) {
 	}
 
 	// Use a new Tombstoner to verify values are persisted
-	ts = &tsm1.Tombstoner{Path: f.Name()}
+	ts = tsm1.NewTombstoner(f.Name(), nil)
 	entries = mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
@@ -245,7 +245,7 @@ func TestTombstoner_Delete(t *testing.T) {
 	defer func() { os.RemoveAll(dir) }()
 
 	f := MustTempFile(dir)
-	ts := &tsm1.Tombstoner{Path: f.Name()}
+	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	ts.Add([][]byte{[]byte("foo")})
 
@@ -254,7 +254,7 @@ func TestTombstoner_Delete(t *testing.T) {
 	}
 
 	// Use a new Tombstoner to verify values are persisted
-	ts = &tsm1.Tombstoner{Path: f.Name()}
+	ts = tsm1.NewTombstoner(f.Name(), nil)
 	entries := mustReadAll(ts)
 	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
@@ -273,7 +273,7 @@ func TestTombstoner_Delete(t *testing.T) {
 		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
 	}
 
-	ts = &tsm1.Tombstoner{Path: f.Name()}
+	ts = tsm1.NewTombstoner(f.Name(), nil)
 	entries = mustReadAll(ts)
 	if got, exp := len(entries), 0; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
@@ -294,7 +294,7 @@ func TestTombstoner_ReadV1(t *testing.T) {
 		t.Fatalf("rename tombstone failed: %v", err)
 	}
 
-	ts := &tsm1.Tombstoner{Path: f.Name()}
+	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	// Read once
 	_ = mustReadAll(ts)
@@ -311,7 +311,7 @@ func TestTombstoner_ReadV1(t *testing.T) {
 	}
 
 	// Use a new Tombstoner to verify values are persisted
-	ts = &tsm1.Tombstoner{Path: f.Name()}
+	ts = tsm1.NewTombstoner(f.Name(), nil)
 	entries = mustReadAll(ts)
 	if got, exp := len(entries), 1; got != exp {
 		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
@@ -333,7 +333,7 @@ func TestTombstoner_ReadEmptyV1(t *testing.T) {
 		t.Fatalf("rename tombstone failed: %v", err)
 	}
 
-	ts := &tsm1.Tombstoner{Path: f.Name()}
+	ts := tsm1.NewTombstoner(f.Name(), nil)
 
 	_ = mustReadAll(ts)
 


### PR DESCRIPTION
I worry that I have tangled myself into a mess with the `WithObserver` pattern in order to avoid a mandatory, optional, parameter everywhere. It seems fragile to future changes in that one must consider if upon any opening of a TSMFile, if it may generate a tombstone. Open to suggestions.