### PR TITLE
fix(tsm1): Avoid searching index if key outside index bounds

### DIFF
--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -839,6 +839,10 @@ func (d *indirectIndex) searchOffset(key []byte) int {
 // search returns the byte position of key in the index.  If key is not
 // in the index, len(index) is returned.
 func (d *indirectIndex) search(key []byte) int {
+	if !d.ContainsKey(key) {
+		return len(d.b)
+	}
+
 	// We use a binary search across our indirect offsets (pointers to all the keys
 	// in the index slice).
 	i := bytesutil.SearchBytesFixed(d.offsets, 4, func(x []byte) bool {


### PR DESCRIPTION
This improvement avoids performing a binary search on the index by
first checking the key against the lower and upper bounds. Particularly
useful for multiple, fully-compacted TSM files.
