### PR TITLE
Add optional pprof http endpoint immediately on startup.

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -90,6 +92,13 @@ func (cmd *Command) Run(args ...string) error {
 	if cmd.Logger, logErr = config.Logging.New(cmd.Stderr); logErr != nil {
 		// assign the default logger
 		cmd.Logger = logger.New(cmd.Stderr)
+	}
+
+	// Attempt to run pprof on :6060 before startup if debug pprof enabled.
+	if config.HTTPD.DebugPprofEnabled {
+		runtime.SetBlockProfileRate(int(1 * time.Second))
+		runtime.SetMutexProfileFraction(1)
+		go func() { http.ListenAndServe("localhost:6060", nil) }()
 	}
 
 	// Print sweet InfluxDB logo.

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -244,6 +244,10 @@
   # troubleshooting and monitoring.
   # pprof-enabled = true
 
+  # Enables a pprof endpoint that binds to localhost:6060 immediately on startup.
+  # This is only needed to debug startup issues.
+  # debug-pprof-enabled = false
+
   # Determines whether HTTPS is enabled.
   # https-enabled = false
 

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	SuppressWriteLog        bool          `toml:"suppress-write-log"`
 	WriteTracing            bool          `toml:"write-tracing"`
 	PprofEnabled            bool          `toml:"pprof-enabled"`
+	DebugPprofEnabled       bool          `toml:"debug-pprof-enabled"`
 	HTTPSEnabled            bool          `toml:"https-enabled"`
 	HTTPSCertificate        string        `toml:"https-certificate"`
 	HTTPSPrivateKey         string        `toml:"https-private-key"`
@@ -58,6 +59,7 @@ func NewConfig() Config {
 		BindAddress:           DefaultBindAddress,
 		LogEnabled:            true,
 		PprofEnabled:          true,
+		DebugPprofEnabled:     false,
 		HTTPSEnabled:          false,
 		HTTPSCertificate:      "/etc/ssl/influxdb.pem",
 		MaxRowLimit:           0,


### PR DESCRIPTION
This pull request adds `debug-pprof-enabled` which will start the default `net/http/pprof` endpoint and bind against `localhost:6060`. This will help to debug startup performance issues.

###### Required only if applicable
- [x] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
