### PR TITLE
TSM1 Open Limiter

### DIFF
--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -162,6 +162,9 @@ type EngineOptions struct {
 	ShardID       uint64
 	InmemIndex    interface{} // shared in-memory index
 
+	// Limits the concurrent number of TSM files that can be loaded at once.
+	OpenLimiter limiter.Fixed
+
 	CompactionPlannerCreator    CompactionPlannerCreator
 	CompactionLimiter           limiter.Fixed
 	CompactionThroughputLimiter limiter.Rate

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -204,6 +204,7 @@ func NewEngine(id uint64, idx tsdb.Index, path string, walPath string, sfile *ts
 	}
 
 	fs := NewFileStore(path)
+	fs.openLimiter = opt.OpenLimiter
 	if opt.FileStoreObserver != nil {
 		fs.WithObserver(opt.FileStoreObserver)
 	}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -206,6 +206,9 @@ func (s *Store) loadShards() error {
 		err error
 	}
 
+	// Limit the number of concurrent TSM files to be opened to the number of cores.
+	s.EngineOptions.OpenLimiter = limiter.NewFixed(runtime.GOMAXPROCS(0))
+
 	// Setup a shared limiter for compactions
 	lim := s.EngineOptions.Config.MaxConcurrentCompactions
 	if lim == 0 {


### PR DESCRIPTION
## Overview

This commit restricts the number of TSM1 files that can be opened concurrently across the entire `tsdb.Store`. There is currently a limit for the number of shards that can be opened concurrently, however, this limit does not help when the number of CPU cores is higher than the number of shards. Because TSM1 files have a 2GB limit and there is no limit on the number of files per shard, extremely large shards (1TB+) can load 1,000s of files simultaneously.

### Notes

Testing on a m5.12xlarge w/ a 2.1TB dataset containing 1,084 `.tsm` files, load time was reduced by `31%` from `8m48s` to `6m2s`.