### PR TITLE
TSM: Enforce OpenLimiter must not be nil

### DIFF
--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -3,6 +3,7 @@ package tsm1
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -464,6 +465,10 @@ func (f *FileStore) Open() error {
 	// Not loading files from disk so nothing to do
 	if f.dir == "" {
 		return nil
+	}
+
+	if f.openLimiter == nil {
+		return errors.New("cannot open FileStore without an OpenLimiter (is EngineOptions.OpenLimiter set?)")
 	}
 
 	// find the current max ID for temp directories


### PR DESCRIPTION
Enterprise was failing to start because `EngineOptions.OpenLimiter` was `nil`, and reading from a `nil` channel blocks forever.