### PR TITLE
buildtsi: Do not escape measurement names

### DIFF
--- a/models/points_test.go
+++ b/models/points_test.go
@@ -2388,6 +2388,50 @@ func TestEscapeStringField(t *testing.T) {
 	}
 }
 
+func TestParseKeyBytes(t *testing.T) {
+	testCases := []struct {
+		input        string
+		expectedName string
+		expectedTags map[string]string
+	}{
+		{input: "m,k=v", expectedName: "m", expectedTags: map[string]string{"k": "v"}},
+		{input: "m\\ q,k=v", expectedName: "m q", expectedTags: map[string]string{"k": "v"}},
+		{input: "m,k\\ q=v", expectedName: "m", expectedTags: map[string]string{"k q": "v"}},
+		{input: "m\\ q,k\\ q=v", expectedName: "m q", expectedTags: map[string]string{"k q": "v"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.input, func(t *testing.T) {
+			name, tags := models.ParseKeyBytes([]byte(testCase.input))
+			if !bytes.Equal([]byte(testCase.expectedName), name) {
+				t.Errorf("%s produced measurement %s but expected %s", testCase.input, string(name), testCase.expectedName)
+			}
+			if !tags.Equal(models.NewTags(testCase.expectedTags)) {
+				t.Errorf("%s produced tags %s but expected %s", testCase.input, tags.String(), models.NewTags(testCase.expectedTags).String())
+			}
+		})
+	}
+}
+
+func TestParseName(t *testing.T) {
+	testCases := []struct {
+		input        string
+		expectedName string
+	}{
+		{input: "m,k=v", expectedName: "m"},
+		{input: "m\\ q,k=v", expectedName: "m q"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.input, func(t *testing.T) {
+			name := models.ParseName([]byte(testCase.input))
+			if !bytes.Equal([]byte(testCase.expectedName), name) {
+				t.Errorf("%s produced measurement %s but expected %s", testCase.input, string(name), testCase.expectedName)
+			}
+		})
+	}
+}
+
 func BenchmarkEscapeStringField_Plain(b *testing.B) {
 	s := "nothing special"
 	for i := 0; i < b.N; i++ {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1193,7 +1193,7 @@ func (e *Engine) addToIndexFromKey(keys [][]byte, fieldTypes []influxql.DataType
 	for i := 0; i < len(keys); i++ {
 		// Replace tsm key format with index key format.
 		keys[i], field = SeriesAndFieldFromCompositeKey(keys[i])
-		name := tsdb.MeasurementFromSeriesKey(keys[i])
+		name := models.ParseName(keys[i])
 		mf := e.fieldset.CreateFieldsIfNotExists(name)
 		if err := mf.CreateFieldIfNotExists(field, fieldTypes[i]); err != nil {
 			return err

--- a/tsdb/meta.go
+++ b/tsdb/meta.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/pkg/escape"
 )
 
 // MarshalTags converts a tag set to bytes for use as a lookup key.
@@ -96,12 +95,4 @@ func MakeTagsKey(keys []string, tags models.Tags) []byte {
 	}
 
 	return b
-}
-
-// MeasurementFromSeriesKey returns the name of the measurement from a key that
-// contains a measurement name.
-func MeasurementFromSeriesKey(key []byte) []byte {
-	// Ignoring the error because the func returns "missing fields"
-	k, _ := models.ParseName(key)
-	return escape.Unescape(k)
 }


### PR DESCRIPTION
Backport of #9921 fixing #9904