### PR TITLE
fix(services/storage): Don't serialize empty group frames

### DIFF
--- a/services/storage/group_resultset_test.go
+++ b/services/storage/group_resultset_test.go
@@ -153,13 +153,21 @@ func TestKeyMerger(t *testing.T) {
 			},
 			exp: "tag0,tag1,tag2,tag3",
 		},
+		{
+			name: "new tags,verify clear",
+			tags: []models.Tags{
+				models.ParseTags([]byte("foo,tag9=v0")),
+				models.ParseTags([]byte("foo,tag8=v0")),
+			},
+			exp: "tag8,tag9",
+		},
 	}
 
+	var km keyMerger
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var km keyMerger
-			km.setTags(tt.tags[0])
-			for _, tags := range tt.tags[1:] {
+			km.clear()
+			for _, tags := range tt.tags {
 				km.mergeTagKeys(tags)
 			}
 

--- a/services/storage/response_writer.go
+++ b/services/storage/response_writer.go
@@ -16,7 +16,7 @@ type responseWriter struct {
 
 	// current series
 	sf *ReadResponse_SeriesFrame
-	ss int
+	ss int // pointer to current series frame; used to skip writing if no points
 	sz int // estimated size in bytes for pending write
 
 	vc int // total value count

--- a/services/storage/rpc_service.go
+++ b/services/storage/rpc_service.go
@@ -155,6 +155,7 @@ func (r *rpcService) Read(req *ReadRequest, stream Storage_ReadServer) error {
 
 	return nil
 }
+
 func (r *rpcService) handleRead(ctx context.Context, req *ReadRequest, w *responseWriter) error {
 	rs, err := r.Store.Read(ctx, req)
 	if err != nil {


### PR DESCRIPTION
Group frames were being serialized when no series had points for the given time range.