### PR TITLE
Add retention policy flag to CLI queries.

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -744,11 +744,12 @@ func (c *CommandLine) Insert(stmt string) error {
 // query creates a query struct to be used with the client.
 func (c *CommandLine) query(query string) client.Query {
 	return client.Query{
-		Command:   query,
-		Database:  c.Database,
-		Chunked:   c.Chunked,
-		ChunkSize: c.ChunkSize,
-		NodeID:    c.NodeID,
+		Command:         query,
+		Database:        c.Database,
+		RetentionPolicy: c.RetentionPolicy,
+		Chunked:         c.Chunked,
+		ChunkSize:       c.ChunkSize,
+		NodeID:          c.NodeID,
 	}
 }
 


### PR DESCRIPTION
Previously the CLI retention policy was not being passed to the server correctly. `SELECT` commands were working properly because they are rewritten on the client side, however, `SHOW` commands are rewritten on the server side.

Repro:

1. Insert data with different fields into retention policies "autogen" & "X"
2. Inside `influx`, execute `use mydb.X`
3. Inside `influx`, execute `SHOW FIELD KEYS`

The correct fields should show for the `X` retention policy.


Fixes https://github.com/influxdata/influxdb/issues/8589


