### PR TITLE
Allow value filtering on SHOW TAG VALUES

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -2182,6 +2182,21 @@ func (is IndexSet) TagValuesByKeyAndExpr(auth query.Authorizer, name []byte, key
 func (is IndexSet) tagValuesByKeyAndExpr(auth query.Authorizer, name []byte, keys []string, expr influxql.Expr) ([]map[string]struct{}, error) {
 	database := is.Database()
 
+	valueExpr := influxql.CloneExpr(expr)
+	valueExpr = influxql.Reduce(influxql.RewriteExpr(valueExpr, func(e influxql.Expr) influxql.Expr {
+		switch e := e.(type) {
+		case *influxql.BinaryExpr:
+			switch e.Op {
+			case influxql.EQ, influxql.NEQ, influxql.EQREGEX, influxql.NEQREGEX:
+				tag, ok := e.LHS.(*influxql.VarRef)
+				if !ok || tag.Val != "value" {
+					return nil
+				}
+			}
+		}
+		return e
+	}), nil)
+
 	itr, err := is.seriesByExprIterator(name, expr)
 	if err != nil {
 		return nil, err
@@ -2233,6 +2248,11 @@ func (is IndexSet) tagValuesByKeyAndExpr(auth query.Authorizer, name []byte, key
 		for i := 0; i < tagN; i++ {
 			var key, value []byte
 			key, value, buf = ReadSeriesKeyTag(buf)
+			if valueExpr != nil {
+				if !influxql.EvalBool(valueExpr, map[string]interface{}{"value": string(value)}) {
+					continue
+				}
+			}
 
 			if idx, ok := keyIdxs[string(key)]; ok {
 				resultSet[idx][string(value)] = struct{}{}


### PR DESCRIPTION
This pull request allows users to filter on the `value` field in the `SHOW TAG VALUES` command:

```
SHOW TAG VALUES WITH KEY = "mytag" WHERE "value" = 'myvalue'
```

Previously this command would return all values.
