### PR TITLE
Minor fix for legacy restore

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -440,7 +440,7 @@ func (cmd *Command) uploadShardsLegacy() error {
 	}
 
 	for _, fn := range backupFiles {
-		parts := strings.Split(fn, ".")
+		parts := strings.Split(filepath.Base(fn), ".")
 
 		if len(parts) != 4 {
 			cmd.StderrLogger.Printf("Skipping mis-named backup file: %s", fn)


### PR DESCRIPTION
Restore would fail when file paths contained extra periods.
Taking the basename of the files fixes this.

I discovered this when trying to automate a legacy backup/restore via a temporary directory. By default `mktemp` puts a period in the directory name. This causes errors of the form:

    2018/06/17 13:49:14 Restoring live from backup /tmp/tmp.Nl8QvA4Iq9/database.*
    2018/06/17 13:49:14 Skipping mis-named backup file: /tmp/tmp.Nl8QvA4Iq9/database.autogen.00167.00
    2018/06/17 13:49:14 error updating shards: strconv.ParseUint: parsing "autogen": invalid syntax
    restore: strconv.ParseUint: parsing "autogen": invalid syntax

Full disclosure: I've not written any Go code before, but the test suite still works so I don't think it broke anything. I searched through the code base and can't see any other instances of this issue.

This is only a one line fix so I guess it qualifies as a trivial PR, right?

###### Required for all non-trivial PRs
- Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- Provide example syntax
- Update man page when modifying a command
- Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
