### PR TITLE
Ensure read service regexes get optimised

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -108,12 +108,13 @@
   version = "v0.2.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/influxdata/influxql"
   packages = [
     ".",
     "internal"
   ]
-  revision = "8d2756c43bb02f5d3e505c51cf83a1ac9234c419"
+  revision = "5e999e6a81820d4450f2a1f35c5597b569258f01"
 
 [[projects]]
   branch = "master"

--- a/services/storage/predicate_influxql.go
+++ b/services/storage/predicate_influxql.go
@@ -25,7 +25,13 @@ func NodeToExpr(node *Node, remap map[string]string) (influxql.Expr, error) {
 		return nil, nil
 	}
 
-	return v.exprs[0], nil
+	// TODO(edd): It would be preferable if RewriteRegexConditions was a
+	// package level function in influxql.
+	stmt := &influxql.SelectStatement{
+		Condition: v.exprs[0],
+	}
+	stmt.RewriteRegexConditions()
+	return stmt.Condition, nil
 }
 
 type nodeToExprVisitor struct {

--- a/services/storage/predicate_test.go
+++ b/services/storage/predicate_test.go
@@ -102,6 +102,30 @@ func TestNodeToExpr(t *testing.T) {
 			e: `host = 'host1' AND region =~ /^us-west/`,
 		},
 		{
+			n: "optimisable regex",
+			r: &storage.Node{
+				NodeType: storage.NodeTypeComparisonExpression,
+				Value:    &storage.Node_Comparison_{Comparison: storage.ComparisonRegex},
+				Children: []*storage.Node{
+					{NodeType: storage.NodeTypeTagRef, Value: &storage.Node_TagRefValue{TagRefValue: "region"}},
+					{NodeType: storage.NodeTypeLiteral, Value: &storage.Node_RegexValue{RegexValue: "^us-east$"}},
+				},
+			},
+			e: `region = 'us-east'`,
+		},
+		{
+			n: "optimisable regex with or",
+			r: &storage.Node{
+				NodeType: storage.NodeTypeComparisonExpression,
+				Value:    &storage.Node_Comparison_{Comparison: storage.ComparisonRegex},
+				Children: []*storage.Node{
+					{NodeType: storage.NodeTypeTagRef, Value: &storage.Node_TagRefValue{TagRefValue: "region"}},
+					{NodeType: storage.NodeTypeLiteral, Value: &storage.Node_RegexValue{RegexValue: "^(us-east|us-west)$"}},
+				},
+			},
+			e: `region = 'us-east' OR region = 'us-west'`,
+		},
+		{
 			n: "remap _measurement -> _name",
 			r: &storage.Node{
 				NodeType: storage.NodeTypeComparisonExpression,


### PR DESCRIPTION
This fixes a bug where the read endpoint (used by flux and the prometheus read endpoint) was not calling into our regex optimisation logic.

As such, regex expressions were not getting re-written, resulting in slower read performance. 