### PR TITLE
tsm1: ensure all written tsm files are fsynced

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1074,10 +1074,18 @@ func (c *Compactor) write(path string, iter KeyIterator, throttle bool) (err err
 		return errCompactionInProgress{err: err}
 	}
 
+	// syncingWriter ensures that whatever we wrap the above file descriptor in
+	// it will always be able to be synced by the tsm writer, since it does
+	// type assertions to attempt to sync.
+	type syncingWriter interface {
+		io.Writer
+		Sync() error
+	}
+
 	// Create the write for the new TSM file.
 	var (
 		w           TSMWriter
-		limitWriter io.Writer = fd
+		limitWriter syncingWriter = fd
 	)
 
 	if c.RateLimit != nil && throttle {


### PR DESCRIPTION
we were asserting to an *os.File in order to call Sync, but in some
cases the file handle has been wrapped, for example with limiting.
instead, assert to minimal interfaces for the functionality we need
and attempt to add some robustness in the code that creates the
writers by using a stronger interface with a Sync method.

fixes #9991