### PR TITLE
allow tag keys to contain underscores

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1500,7 +1500,7 @@ func (s *Store) TagValues(auth query.Authorizer, shardIDs []uint64, cond influxq
 			switch e.Op {
 			case influxql.EQ, influxql.NEQ, influxql.EQREGEX, influxql.NEQREGEX:
 				tag, ok := e.LHS.(*influxql.VarRef)
-				if !ok || strings.HasPrefix(tag.Val, "_") {
+				if !ok || influxql.IsSystemName(tag.Val) {
 					return nil
 				}
 			}


### PR DESCRIPTION
This PR changes the `tsdb/store` to call `influxql.IsSystemName(tagKey)` instead of filtering out all tag keys that contain a leading `_`. Fixes #9522 