### PR TITLE
Filter iterators as high up a possible

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -1629,7 +1629,7 @@ func (is IndexSet) measurementSeriesIDIterator(name []byte) (SeriesIDIterator, e
 			a = append(a, itr)
 		}
 	}
-	return FilterUndeletedSeriesIDIterator(is.SeriesFile, MergeSeriesIDIterators(a...)), nil
+	return MergeSeriesIDIterators(a...), nil
 }
 
 // ForEachMeasurementTagKey iterates over all tag keys in a measurement and applies
@@ -1700,7 +1700,7 @@ func (is IndexSet) tagKeySeriesIDIterator(name, key []byte) (SeriesIDIterator, e
 			a = append(a, itr)
 		}
 	}
-	return FilterUndeletedSeriesIDIterator(is.SeriesFile, MergeSeriesIDIterators(a...)), nil
+	return MergeSeriesIDIterators(a...), nil
 }
 
 // TagValueSeriesIDIterator returns a series iterator for a single tag value.
@@ -1724,7 +1724,7 @@ func (is IndexSet) tagValueSeriesIDIterator(name, key, value []byte) (SeriesIDIt
 			a = append(a, itr)
 		}
 	}
-	return FilterUndeletedSeriesIDIterator(is.SeriesFile, MergeSeriesIDIterators(a...)), nil
+	return MergeSeriesIDIterators(a...), nil
 }
 
 // MeasurementSeriesByExprIterator returns a series iterator for a measurement
@@ -1751,7 +1751,7 @@ func (is IndexSet) measurementSeriesByExprIterator(name []byte, expr influxql.Ex
 	if err != nil {
 		return nil, err
 	}
-	return FilterUndeletedSeriesIDIterator(is.SeriesFile, itr), nil
+	return itr, nil
 }
 
 // MeasurementSeriesKeysByExpr returns a list of series keys matching expr.

--- a/tsdb/meta_test.go
+++ b/tsdb/meta_test.go
@@ -168,7 +168,7 @@ type TagValGenerator struct {
 }
 
 func NewTagValGenerator(tagKey string, nVals int) *TagValGenerator {
-	tvg := &TagValGenerator{Key: tagKey}
+	tvg := &TagValGenerator{Key: tagKey, Vals: make([]string, 0, nVals)}
 	for i := 0; i < nVals; i++ {
 		tvg.Vals = append(tvg.Vals, fmt.Sprintf("tagValue%d", i))
 	}
@@ -200,7 +200,7 @@ type TagSetGenerator struct {
 }
 
 func NewTagSetGenerator(nSets int, nTagVals ...int) *TagSetGenerator {
-	tsg := &TagSetGenerator{}
+	tsg := &TagSetGenerator{TagVals: make([]*TagValGenerator, 0, nSets)}
 	for i := 0; i < nSets; i++ {
 		nVals := nTagVals[0]
 		if i < len(nTagVals) {


### PR DESCRIPTION
Previously we were filtering iterators at a very low level, which meant we were filtering series that would have been merged out by higher iterators anyway.

Filtering is expensive because it involves locking on the series file partitions, which has a fixed cost of ~35ns per seriesID checked. For millions of series that can expensive at planning time.

This PR moves the filtering to as high a level as possible.