### PR TITLE
Improve performance of buildtsi tool / series creation

### DIFF
--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -279,14 +279,14 @@ func (cmd *Command) processShard(sfile *tsdb.SeriesFile, dbName, rpName string, 
 
 	for _, key := range cache.Keys() {
 		seriesKey, _ := tsm1.SeriesAndFieldFromCompositeKey(key)
-		name, tags := models.ParseKey(seriesKey)
+		name, tags := models.ParseKeyBytes(seriesKey)
 
 		if cmd.Verbose {
 			cmd.Logger.Info("Series", zap.String("name", string(name)), zap.String("tags", tags.String()))
 		}
 
 		keysBatch = append(keysBatch, seriesKey)
-		namesBatch = append(namesBatch, []byte(name))
+		namesBatch = append(namesBatch, name)
 		tagsBatch = append(tagsBatch, tags)
 
 		// Flush batch?
@@ -347,14 +347,14 @@ func (cmd *Command) processTSMFile(index *tsi1.Index, path string) error {
 	for i := 0; i < r.KeyCount(); i++ {
 		key, _ := r.KeyAt(i)
 		seriesKey, _ := tsm1.SeriesAndFieldFromCompositeKey(key)
-		name, tags := models.ParseKey(seriesKey)
+		name, tags := models.ParseKeyBytes(seriesKey)
 
 		if cmd.Verbose {
 			cmd.Logger.Info("Series", zap.String("name", string(name)), zap.String("tags", tags.String()))
 		}
 
 		keysBatch = append(keysBatch, seriesKey)
-		namesBatch = append(namesBatch, []byte(name))
+		namesBatch = append(namesBatch, name)
 		tagsBatch = append(tagsBatch, tags)
 
 		// Flush batch?

--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -232,8 +232,13 @@ func (cmd *Command) processShard(sfile *tsdb.SeriesFile, dbName, rpName string, 
 	}
 
 	// Open TSI index in temporary path.
-	tsiIndex := tsi1.NewIndex(sfile, dbName, tsi1.WithPath(tmpPath), tsi1.WithMaximumLogFileSize(cmd.maxLogFileSize))
+	tsiIndex := tsi1.NewIndex(sfile, dbName,
+		tsi1.WithPath(tmpPath),
+		tsi1.WithMaximumLogFileSize(cmd.maxLogFileSize),
+		tsi1.DisableFsync())
+
 	tsiIndex.WithLogger(cmd.Logger)
+
 	cmd.Logger.Info("Opening tsi index in temporary location", zap.String("path", tmpPath))
 	if err := tsiIndex.Open(); err != nil {
 		return err

--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 
@@ -61,7 +64,46 @@ func (cmd *Command) Run(args ...string) error {
 	}
 	cmd.Logger = logger.New(cmd.Stderr)
 
+	finish := startProfiles()
+	defer finish()
 	return cmd.run(*dataDir, *walDir)
+}
+
+func startProfiles() func() {
+	runtime.MemProfileRate = 100 // Sample 1% of allocations.
+
+	paths := []string{"/tmp/buildtsi.mem.pprof", "/tmp/buildtsi.cpu.pprof"}
+	var files []*os.File
+	for _, pth := range paths {
+		f, err := os.Create(pth)
+		if err != nil {
+			log.Fatalf("memprofile: %v", err)
+		}
+		log.Printf("writing profile to: %s\n", pth)
+		files = append(files, f)
+
+	}
+
+	closeFn := func() {
+		// Write the memory profile
+		if err := pprof.Lookup("heap").WriteTo(files[0], 0); err != nil {
+			panic(err)
+		}
+
+		// Stop the CPU profile.
+		pprof.StopCPUProfile()
+
+		for _, fd := range files {
+			if err := fd.Close(); err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	if err := pprof.StartCPUProfile(files[1]); err != nil {
+		panic(err)
+	}
+	return closeFn
 }
 
 func (cmd *Command) run(dataDir, walDir string) error {

--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -240,7 +240,11 @@ func (cmd *Command) processShard(sfile *tsdb.SeriesFile, dbName, rpName string, 
 	tsiIndex := tsi1.NewIndex(sfile, dbName,
 		tsi1.WithPath(tmpPath),
 		tsi1.WithMaximumLogFileSize(cmd.maxLogFileSize),
-		tsi1.DisableFsync())
+		tsi1.DisableFsync(),
+		// Each new series entry in a log file is ~12 bytes so this should
+		// roughly equate to one flush to the file for every batch.
+		tsi1.WithLogFileBufferSize(12*cmd.batchSize),
+	)
 
 	tsiIndex.WithLogger(cmd.Logger)
 

--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -6,12 +6,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
-	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -73,47 +71,49 @@ func (cmd *Command) Run(args ...string) error {
 	}
 	cmd.Logger = logger.New(cmd.Stderr)
 
-	finish := startProfiles()
-	defer finish()
+	// Uncomment for profiling
+	// finish := startProfiles()
+	// defer finish()
+
 	return cmd.run(*dataDir, *walDir)
 }
 
-func startProfiles() func() {
-	runtime.MemProfileRate = 100 // Sample 1% of allocations.
+// func startProfiles() func() {
+// 	runtime.MemProfileRate = 100 // Sample 1% of allocations.
 
-	paths := []string{"/tmp/buildtsi.mem.pprof", "/tmp/buildtsi.cpu.pprof"}
-	var files []*os.File
-	for _, pth := range paths {
-		f, err := os.Create(pth)
-		if err != nil {
-			log.Fatalf("memprofile: %v", err)
-		}
-		log.Printf("writing profile to: %s\n", pth)
-		files = append(files, f)
+// 	paths := []string{"/tmp/buildtsi.mem.pprof", "/tmp/buildtsi.cpu.pprof"}
+// 	var files []*os.File
+// 	for _, pth := range paths {
+// 		f, err := os.Create(pth)
+// 		if err != nil {
+// 			log.Fatalf("memprofile: %v", err)
+// 		}
+// 		log.Printf("writing profile to: %s\n", pth)
+// 		files = append(files, f)
 
-	}
+// 	}
 
-	closeFn := func() {
-		// Write the memory profile
-		if err := pprof.Lookup("heap").WriteTo(files[0], 0); err != nil {
-			panic(err)
-		}
+// 	closeFn := func() {
+// 		// Write the memory profile
+// 		if err := pprof.Lookup("heap").WriteTo(files[0], 0); err != nil {
+// 			panic(err)
+// 		}
 
-		// Stop the CPU profile.
-		pprof.StopCPUProfile()
+// 		// Stop the CPU profile.
+// 		pprof.StopCPUProfile()
 
-		for _, fd := range files {
-			if err := fd.Close(); err != nil {
-				panic(err)
-			}
-		}
-	}
+// 		for _, fd := range files {
+// 			if err := fd.Close(); err != nil {
+// 				panic(err)
+// 			}
+// 		}
+// 	}
 
-	if err := pprof.StartCPUProfile(files[1]); err != nil {
-		panic(err)
-	}
-	return closeFn
-}
+// 	if err := pprof.StartCPUProfile(files[1]); err != nil {
+// 		panic(err)
+// 	}
+// 	return closeFn
+// }
 
 func (cmd *Command) run(dataDir, walDir string) error {
 	// Verify the user actually wants to run as root.

--- a/models/points.go
+++ b/models/points.go
@@ -1587,7 +1587,6 @@ func parseTags(buf []byte, dst Tags) Tags {
 	var i int
 	walkTags(buf, func(key, value []byte) bool {
 		dst[i].Key, dst[i].Value = key, value
-		// tags = append(tags, Tag{Key: key, Value: value})
 		i++
 		return true
 	})

--- a/models/points.go
+++ b/models/points.go
@@ -1573,11 +1573,14 @@ func parseTags(buf []byte, dst Tags) Tags {
 	}
 
 	n := bytes.Count(buf, []byte(","))
-	if len(dst) < n {
+	if cap(dst) < n {
 		dst = make(Tags, n)
+	} else {
+		dst = dst[:n]
 	}
 
-	if dst == nil { // Ensure existing behaviour.
+	// Ensure existing behaviour when point has no tags and nil slice passed in.
+	if dst == nil {
 		dst = Tags{}
 	}
 

--- a/models/points.go
+++ b/models/points.go
@@ -278,14 +278,17 @@ func ParseKey(buf []byte) (string, Tags) {
 }
 
 func ParseKeyBytes(buf []byte) ([]byte, Tags) {
+	return ParseKeyBytesWithTags(buf, nil)
+}
+
+func ParseKeyBytesWithTags(buf []byte, tags Tags) ([]byte, Tags) {
 	// Ignore the error because scanMeasurement returns "missing fields" which we ignore
 	// when just parsing a key
 	state, i, _ := scanMeasurement(buf, 0)
 
 	var name []byte
-	var tags Tags
 	if state == tagKeyState {
-		tags = parseTags(buf)
+		tags = parseTags(buf, tags)
 		// scanMeasurement returns the location of the comma if there are tags, strip that off
 		name = buf[:i-1]
 	} else {
@@ -295,7 +298,7 @@ func ParseKeyBytes(buf []byte) ([]byte, Tags) {
 }
 
 func ParseTags(buf []byte) Tags {
-	return parseTags(buf)
+	return parseTags(buf, nil)
 }
 
 func ParseName(buf []byte) []byte {
@@ -1476,7 +1479,7 @@ func (p *point) Tags() Tags {
 	if p.cachedTags != nil {
 		return p.cachedTags
 	}
-	p.cachedTags = parseTags(p.key)
+	p.cachedTags = parseTags(p.key, nil)
 	return p.cachedTags
 }
 
@@ -1562,20 +1565,33 @@ func walkFields(buf []byte, fn func(key, value []byte) bool) {
 	}
 }
 
-func parseTags(buf []byte) Tags {
+// parseTags parses buf into the provided destination tags, returning destination
+// Tags, which may have a different length and capacity.
+func parseTags(buf []byte, dst Tags) Tags {
 	if len(buf) == 0 {
 		return nil
+	}
+
+	n := bytes.Count(buf, []byte(","))
+	if len(dst) < n {
+		dst = make(Tags, n)
+	}
+
+	if dst == nil { // Ensure existing behaviour.
+		dst = Tags{}
 	}
 
 	// Series keys can contain escaped commas, therefore the number of commas
 	// in a series key only gives an estimation of the upper bound on the number
 	// of tags.
-	tags := make(Tags, 0, bytes.Count(buf, []byte(",")))
+	var i int
 	walkTags(buf, func(key, value []byte) bool {
-		tags = append(tags, Tag{Key: key, Value: value})
+		dst[i].Key, dst[i].Value = key, value
+		// tags = append(tags, Tag{Key: key, Value: value})
+		i++
 		return true
 	})
-	return tags
+	return dst[:i]
 }
 
 // MakeKey creates a key for a set of tags.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -86,6 +86,15 @@ var WithMaximumLogFileSize = func(size int64) IndexOption {
 	}
 }
 
+// DisableFsync disables flushing and syncing of underlying files. Primarily this
+// impacts the LogFiles. This option can be set when working with the index in
+// an offline manner, for cases where a hard failure can be overcome by re-running the tooling.
+var DisableFsync = func() IndexOption {
+	return func(i *Index) {
+		i.disableFsync = true
+	}
+}
+
 // Index represents a collection of layered index files and WAL.
 type Index struct {
 	mu         sync.RWMutex
@@ -96,6 +105,7 @@ type Index struct {
 	path               string      // Root directory of the index partitions.
 	disableCompactions bool        // Initially disables compactions on the index.
 	maxLogFileSize     int64       // Maximum size of a LogFile before it's compacted.
+	disableFsync       bool        // Disables flushing buffers and fsyning files. Used when working with indexes offline.
 	logger             *zap.Logger // Index's logger.
 
 	// The following must be set when initializing an Index.
@@ -206,6 +216,7 @@ func (i *Index) Open() error {
 	for j := 0; j < len(i.partitions); j++ {
 		p := NewPartition(i.sfile, filepath.Join(i.path, fmt.Sprint(j)))
 		p.MaxLogFileSize = i.maxLogFileSize
+		p.nosync = i.disableFsync
 		p.logger = i.logger.With(zap.String("tsi1_partition", fmt.Sprint(j+1)))
 		i.partitions[j] = p
 	}

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -101,6 +101,11 @@ var DisableFsync = func() IndexOption {
 // be appropriate to set this.
 var WithLogFileBufferSize = func(sz int) IndexOption {
 	return func(i *Index) {
+		if sz > 1<<17 { // 128K
+			sz = 1 << 17
+		} else if sz < 1<<12 {
+			sz = 1 << 12 // 4K (runtime default)
+		}
 		i.logfileBufferSize = sz
 	}
 }

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -799,8 +799,8 @@ func (f *LogFile) CompactTo(w io.Writer, m, k uint64, cancel <-chan struct{}) (n
 	default:
 	}
 
-	// Wrap in bufferred writer.
-	bw := bufio.NewWriter(w)
+	// Wrap in bufferred writer with a buffer equivalent to the LogFile size.
+	bw := bufio.NewWriterSize(w, 1<<17) // 128K
 
 	// Setup compaction offset tracking data.
 	var t IndexFileTrailer

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -70,6 +70,7 @@ type Partition struct {
 	// Log file compaction thresholds.
 	MaxLogFileSize int64
 	nosync         bool // when true, flushing and syncing of LogFile will be disabled.
+	logbufferSize  int  // the LogFile's buffer is set to this value.
 
 	// Frequency of compaction checks.
 	compactionInterrupt chan struct{}
@@ -92,7 +93,6 @@ func NewPartition(sfile *tsdb.SeriesFile, path string) *Partition {
 		sfile:       sfile,
 		seriesIDSet: tsdb.NewSeriesIDSet(),
 
-		// Default compaction thresholds.
 		MaxLogFileSize: tsdb.DefaultMaxIndexLogFileSize,
 
 		// compactionEnabled: true,
@@ -249,6 +249,7 @@ func (p *Partition) Open() error {
 func (p *Partition) openLogFile(path string) (*LogFile, error) {
 	f := NewLogFile(p.sfile, path)
 	f.nosync = p.nosync
+	f.bufferSize = p.logbufferSize
 
 	if err := f.Open(); err != nil {
 		return nil, err

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -69,6 +69,7 @@ type Partition struct {
 
 	// Log file compaction thresholds.
 	MaxLogFileSize int64
+	nosync         bool // when true, flushing and syncing of LogFile will be disabled.
 
 	// Frequency of compaction checks.
 	compactionInterrupt chan struct{}
@@ -247,6 +248,8 @@ func (p *Partition) Open() error {
 // openLogFile opens a log file and appends it to the index.
 func (p *Partition) openLogFile(path string) (*LogFile, error) {
 	f := NewLogFile(p.sfile, path)
+	f.nosync = p.nosync
+
 	if err := f.Open(); err != nil {
 		return nil, err
 	}

--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -135,10 +135,19 @@ func (s *SeriesIDSet) AndNot(other *SeriesIDSet) *SeriesIDSet {
 	return &SeriesIDSet{bitmap: roaring.AndNot(s.bitmap, other.bitmap)}
 }
 
-// ForEach calls f for each id in the set.
+// ForEach calls f for each id in the set. The function is applied to the IDs
+// in ascending order.
 func (s *SeriesIDSet) ForEach(f func(id uint64)) {
 	s.RLock()
 	defer s.RUnlock()
+	itr := s.bitmap.Iterator()
+	for itr.HasNext() {
+		f(uint64(itr.Next()))
+	}
+}
+
+// ForEachNoLock calls f for each id in the set without taking a lock.
+func (s *SeriesIDSet) ForEachNoLock(f func(id uint64)) {
 	itr := s.bitmap.Iterator()
 	for itr.HasNext() {
 		f(uint64(itr.Next()))
@@ -159,6 +168,20 @@ func (s *SeriesIDSet) Diff(other *SeriesIDSet) {
 	s.Lock()
 	defer s.Unlock()
 	s.bitmap = roaring.AndNot(s.bitmap, other.bitmap)
+}
+
+// Clone returns a new SeriesIDSet with a deep copy of the underlying bitmap.
+func (s *SeriesIDSet) Clone() *SeriesIDSet {
+	s.RLock()
+	defer s.RUnlock()
+	return s.CloneNoLock()
+}
+
+// CloneNoLock calls Clone without taking a lock.
+func (s *SeriesIDSet) CloneNoLock() *SeriesIDSet {
+	new := NewSeriesIDSet()
+	new.bitmap = s.bitmap.Clone()
+	return new
 }
 
 // Iterator returns an iterator to the underlying bitmap.


### PR DESCRIPTION
Fixes #10019 

This PR significantly improves the performance of `influx_inspect buildtsi`. It makes building a TSI index around 4-10 times faster than 1.5.3, and 17–46 times faster than current `master`. 😃 

#### New tool features

 - Shards will be processed concurrently (adjustable with `-c`);
 - Series batch size configurable. This is an "expert" option, and users should typically stick with the default value, which is 10,000; and
 - Much. More. Fasterer.

#### Test data

I wrote 100,000,000 series with inch across 25 shards.

  - 4 measurements
  - 5 tag keys

```
inch -b 10000 -c 5 -t 10,10,10,100,1000 -f 1 -m 4 -p 1 -start-time '2018-07-02T00:00:00Z' -time 100h  -v
```

#### TLDR Results

These results show the time taken to build the TSI index with a pre-existing series file. Most of the performance boost comes from changes to how the index is built so I focussed on that results-wise:

| Description | master time | PR time| time Δ  | master series/s | PR series/s | series/s Δ |
| ---: | :---: | :---: | :---: | :---: | :---: | :---: |
| single shard (4M series) |  8m 15s | 28s | ~94% |  9K  | ~143K  | ~94% |
| 25 shards (100M series) |  ~200 min | 4m 20s | ~98% |  ~8.3K  | ~﻿384K  | ~98% |

N.B these results were against `master`. 1.5.3 might not be _as bad_ as the master results because it doesn't contain #9982, which hurts `buildtsi` performance. 

#### Breakdown

There are some other useful commits in the set, but these are the ones that made the most difference:

 - f6facb5 and 2c40e80: we have to flush buffers and syncing files on every write to a `LogFile` for durability reasons. However, we don't need to do this for offline tooling since in the worst-case failure, we can just re-run the tool. Let's turn that off! 
 - 10a45f3: rather than reading series one at a time out of a TSM file, we can read a batch and then send them all at once to be written to the index. 10,000 is a good, empirically determined, default batch size.
 - f78ff85: A `LogEntry` is 11-12 bytes per series. If you write a batch of 10,000 new series that's going to involve three fsyncs. By making the buffer configurable for the `buildtsi` tool we can reduce the frequency of these syscalls.
 - 4792ba4: We maintain inverted indexes for `measurement_name -> all_series_with_name` amd `tag_key_value -> all_series_with_tag_key_value`. Rather than storing the sets of series ids for these indexes in maps, we use bitmaps. This reduces their size and improves performance when we need to pull them out in order. This will significantly help with TSI query planning too. Note: bitsets have a non-trivial cost for low cardinality sets (`~1000 ns` and `~15` allocs),  so we don't always use them.
 - 0bf0180: re-use tag containers... This one I need some scrutiny on. I'm almost certain that it is OK to do this for the offline tooling, but please take a close look @benbjohnson @stuartcarnie.... It made a massive improvement: `~37s -> ~28s`.
 - a85e951 concurrent shard index building. This will help for machines with many cores. How it helps with machines with fewer than 8 OS-threads is unclear because the series file and index already use multiple cores during insertion anyway.


#### Todo 

 I want to abstract a bunch of the "when to use bitsets and when not to" into the `tsdb.SeriesIDSet`. I will do that in a future PR.

