### PR TITLE
cleanup import order in uuid.go

### DIFF
--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -35,10 +35,10 @@
 package uuid // import "github.com/influxdata/influxdb/uuid"
 
 import (
+	"crypto/rand"
+	"net"
 	"sync/atomic"
 	"time"
-	"net"
-	"crypto/rand"
 )
 
 // UUID - unique identifier type representing a 128 bit number


### PR DESCRIPTION
Introduced in #10005. Not sure why CircleCI didn't run against that PR.