### PR TITLE
Document UDP precision setting in config

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -487,6 +487,9 @@
   # bind-address = ":8089"
   # database = "udp"
   # retention-policy = ""
+ 
+  # InfluxDB precision for timestamps on received points ("" or "n", "u", "ms", "s", "m", "h")
+  # precision = ""
 
   # These next lines control how batching works. You should have this enabled
   # otherwise you could get dropped metrics or poor performance. Batching

--- a/services/udp/config.go
+++ b/services/udp/config.go
@@ -100,7 +100,7 @@ type Configs []Config
 // Diagnostics returns one set of diagnostics for all of the Configs.
 func (c Configs) Diagnostics() (*diagnostics.Diagnostics, error) {
 	d := &diagnostics.Diagnostics{
-		Columns: []string{"enabled", "bind-address", "database", "retention-policy", "batch-size", "batch-pending", "batch-timeout"},
+		Columns: []string{"enabled", "bind-address", "database", "retention-policy", "batch-size", "batch-pending", "batch-timeout", "precision"},
 	}
 
 	for _, cc := range c {
@@ -109,7 +109,7 @@ func (c Configs) Diagnostics() (*diagnostics.Diagnostics, error) {
 			continue
 		}
 
-		r := []interface{}{true, cc.BindAddress, cc.Database, cc.RetentionPolicy, cc.BatchSize, cc.BatchPending, cc.BatchTimeout}
+		r := []interface{}{true, cc.BindAddress, cc.Database, cc.RetentionPolicy, cc.BatchSize, cc.BatchPending, cc.BatchTimeout, cc.Precision}
 		d.AddRow(r)
 	}
 

--- a/services/udp/config_test.go
+++ b/services/udp/config_test.go
@@ -16,6 +16,7 @@ enabled = true
 bind-address = ":4444"
 database = "awesomedb"
 retention-policy = "awesomerp"
+precision = "s"
 batch-size = 100
 batch-pending = 9
 batch-timeout = "10ms"
@@ -33,6 +34,8 @@ udp-payload-size = 1500
 		t.Fatalf("unexpected database: %s", c.Database)
 	} else if c.RetentionPolicy != "awesomerp" {
 		t.Fatalf("unexpected retention policy: %s", c.RetentionPolicy)
+	} else if c.Precision != "s" {
+		t.Fatalf("unexpected precision: %s", c.Precision)
 	} else if c.BatchSize != 100 {
 		t.Fatalf("unexpected batch size: %d", c.BatchSize)
 	} else if c.BatchPending != 9 {


### PR DESCRIPTION
Backport https://github.com/influxdata/influxdb/pull/10051 to correct UDP `precision` configuration setting omission.