### PR TITLE
Update to Go 1.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.9.2.
+InfluxDB requires Go 1.10.3.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -77,8 +77,8 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.9.2
-    gvm use go1.9.2 --default
+    gvm install go1.10.3
+    gvm use go1.10.3 --default
 
 Installing Dep
 -------------
@@ -279,4 +279,4 @@ Continuous Integration testing
 -----
 InfluxDB uses CircleCI for continuous integration testing. CircleCI executes [test.sh](https://github.com/influxdata/influxdb/blob/master/test.sh), so you may do the same on your local development environment before creating a pull request.
 
-The `test.sh` script executes a test suite with 5 variants (standard 64 bit, 64 bit with race detection, 32 bit, TSI, go version 1.9.2), each executes with a different arg, 0 through 4. Unless you know differently, `./test.sh 0` is probably all you need.
+The `test.sh` script executes a test suite with 5 variants (standard 64 bit, 64 bit with race detection, 32 bit, TSI, go version 1.10.3), each executes with a different arg, 0 through 4. Unless you know differently, `./test.sh 0` is probably all you need.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.2 as builder
+FROM golang:1.10.3 as builder
 RUN go get -u github.com/golang/dep/...
 WORKDIR /go/src/github.com/influxdata/influxdb
 COPY Gopkg.toml Gopkg.lock ./

--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -22,7 +22,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.9.2
+ENV GO_VERSION 1.10.3
 ENV GO_ARCH 386
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -24,7 +24,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.9.2
+ENV GO_VERSION 1.10.3
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -27,7 +27,7 @@ VOLUME $PROJECT_DIR
 
 
 # Install go
-ENV GO_VERSION 1.9.2
+ENV GO_VERSION 1.10.3
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64_go1.11
+++ b/Dockerfile_build_ubuntu64_go1.11
@@ -24,7 +24,10 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.9.2
+
+# TODO(edd) this needs to be updated to 1.11 when the branch is available.
+ENV GO_VERSION 1.10.3
+
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_jenkins_ubuntu32
+++ b/Dockerfile_jenkins_ubuntu32
@@ -9,7 +9,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 # Install go
 ENV GOPATH /go
-ENV GO_VERSION 1.9.2
+ENV GO_VERSION 1.10.3
 ENV GO_ARCH 386
 RUN wget --no-verbose -q https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
     stage('64bit') {
       agent {
         docker {
-          image 'golang:1.9.2'
+          image 'golang:1.10.3'
         }
       }
 

--- a/cmd/influx_tools/internal/format/binary/writer_test.go
+++ b/cmd/influx_tools/internal/format/binary/writer_test.go
@@ -53,7 +53,7 @@ func TestWriter_WriteOneBucketOneSeries(t *testing.T) {
 	for i := 0; i < len(ts); i++ {
 		var ip binary.IntegerPoints
 		assertTypeValue(t, &buf, binary.IntegerPointsType, &ip)
-		assertEqual(t, ip, binary.IntegerPoints{ts[i : i+1], vs[i : i+1]})
+		assertEqual(t, ip, binary.IntegerPoints{Timestamps: ts[i : i+1], Values: vs[i : i+1]})
 	}
 
 	// series footer

--- a/releng/_go_versions.sh
+++ b/releng/_go_versions.sh
@@ -1,5 +1,5 @@
 # These are the current and "next" Go versions used to build influxdb.
 # This file is meant to be sourced from other scripts.
 
-export GO_CURRENT_VERSION=1.9.2
-export GO_NEXT_VERSION=1.9.2
+export GO_CURRENT_VERSION=1.10.3
+export GO_NEXT_VERSION=1.10.3

--- a/test.sh
+++ b/test.sh
@@ -124,8 +124,8 @@ case $ENVIRONMENT_INDEX in
         rc=$?
         ;;
     4)
-        # go1.9
-        run_test_docker Dockerfile_build_ubuntu64_go19 test_64bit --test --junit-report
+        # go1.11
+        run_test_docker Dockerfile_build_ubuntu64_go1.11 test_64bit --test --junit-report
         rc=$?
         ;;
     "count")


### PR DESCRIPTION
This PR updates the Go runtime used to 1.10.

In 289a05e I have updated the "next" version we run in tests to Go 1.11, however until that release is available I have left the actual version at 1.10.3.