### PR TITLE
Remove max concurrent compaction limit

### DIFF
--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -235,11 +235,15 @@ func (s *Store) loadShards() error {
 	s.EngineOptions.CompactionLimiter = limiter.NewFixed(lim)
 
 	// Env var to disable throughput limiter.  This will be moved to a config option in 1.5.
+	compactionSettings := []zapcore.Field{zap.Int("max_concurrent_compactions", lim)}
 	if os.Getenv("INFLUXDB_DATA_COMPACTION_THROUGHPUT") == "" {
+		rate, burst := 48*1024*1024, 48*1024*1024
 		s.EngineOptions.CompactionThroughputLimiter = limiter.NewRate(48*1024*1024, 48*1024*1024)
+		compactionSettings = append(compactionSettings, zap.Int("throughput_bytes_per_second", rate), zap.Int("throughput_burst_bytes", burst))
 	} else {
-		s.Logger.Info("Compaction throughput limit disabled")
+		compactionSettings = append(compactionSettings, zap.String("throughput_bytes_per_second", "unlimited"), zap.String("throughput_burst", "unlimited"))
 	}
+	s.Logger.Info("Compaction settings", compactionSettings...)
 
 	log, logEnd := logger.NewOperation(s.Logger, "Open store", "tsdb_open")
 	defer logEnd()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -217,11 +217,6 @@ func (s *Store) loadShards() error {
 	if lim == 0 {
 		lim = runtime.GOMAXPROCS(0) / 2 // Default to 50% of cores for compactions
 
-		// On systems with more cores, cap at 4 to reduce disk utilization
-		if lim > 4 {
-			lim = 4
-		}
-
 		if lim < 1 {
 			lim = 1
 		}


### PR DESCRIPTION
This PR removes the maximum default limit of `4` concurrent compactions, introduced in #9204.

The idea in #9204 was to reduce IO utilisation on large systems with many cores,
and high write load. Often on these systems, disks were not scaled
appropriately to to the write volume, and while the write path could
keep up, compactions would saturate disks.

Further, in #9225 work was also done to reduce IO saturation by limiting the
compaction throughput. To some extent, both #9204 and #9225 work towards
solving the same problem.

We have recently begun to notice larger clusters suffering from
a buildup of un-compacted TSM data, because compactions are not keeping up. This is usually because they have scaled up the box for a higher write load, but the limit of 4 concurrent compactions has stayed in place. While users can
manually override the setting, it seems more user friendly if we remove
the limit by default, and set it manually in cases where compactions are
causing too much IO on larger boxes.