### PR TITLE
client/v2: support custom dialer, not just socks proxy

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -3,6 +3,7 @@ package client // import "github.com/influxdata/influxdb/client/v2"
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -48,6 +50,10 @@ type HTTPConfig struct {
 
 	// Proxy configures the Proxy function on the HTTP client.
 	Proxy func(req *http.Request) (*url.URL, error)
+
+	// DialContext specifies the dial function for creating unencrypted TCP connections.
+	// If DialContext is nil then the transport dials using package net.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // BatchPointsConfig is the config data needed to create an instance of the BatchPoints struct.
@@ -102,7 +108,8 @@ func NewHTTPClient(conf HTTPConfig) (Client, error) {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: conf.InsecureSkipVerify,
 		},
-		Proxy: conf.Proxy,
+		Proxy:       conf.Proxy,
+		DialContext: conf.DialContext,
 	}
 	if conf.TLSConfig != nil {
 		tr.TLSClientConfig = conf.TLSConfig


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

The current HTTP Go client for InfluxDB is a bit locked down. It supports directly connecting to a remote InfluxDB server and it supports going through a SOCKS5 proxy via the `client.HTTPConfig.Proxy` config field. It however does **not** support setting a custom dialer.

A custom dialer can have much more fine grained control as to how the remote connection is established. Also, setting custom dialers is a feature of Go's `http` package via the [`http.Transport`](https://golang.org/pkg/net/http/#Transport)'s `DialContext` field, so it's something API users kind of expect to be available.

This PR just adds this additional field to the `client.HTTPConfig`, to permit configuring a different TCP dialer for the HTTP client.

---

A concrete example where this comes in handy is if we'd like to anonymize the client's IP address via the Tor network. Although the Proxy field can be abused a bit to bridge it into Tor directly, there are Go libraries that implement Go's `http` APIs and abstract all of the messy details away via the dialer construct. This PR permits InfluxDB's client to use the Tor network as a transport.

An example code of what that would look like with this PR is:

```go
package main

import (
	"fmt"
	"time"

	"github.com/cretz/bine/tor"
	"github.com/influxdata/influxdb/client/v2"
	"github.com/ipsn/go-libtor"
)

func main() {
	// Start tor with some defaults + elevated verbosity
	proxy, err := tor.Start(nil, &tor.StartConf{ProcessCreator: libtor.Creator, EnableNetwork: true})
	if err != nil {
		panic(err)
	}
	defer proxy.Close()

	// Create an InfluxDB client tunneled through the Tor network
	dialer, err := proxy.Dialer(nil, nil)
	if err != nil {
		panic(err)
	}
	client, err := client.NewHTTPClient(client.HTTPConfig{
		Addr:        "http://influx.example.com",
		DialContext: dialer.DialContext,
	})
	if err != nil {
		panic(err)
	}
	// Ping the InfluxDB server and return
	fmt.Println(client.Ping(time.Minute))
}
```