### PR TITLE
fix(influx_tools): Use Array cursor types

### DIFF
--- a/cmd/influx_tools/internal/format/binary/reader_test.go
+++ b/cmd/influx_tools/internal/format/binary/reader_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/influxdata/influxdb/cmd/influx_tools/internal/format/binary"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
 )
 
@@ -373,14 +374,15 @@ type floatCursor struct {
 func (c *floatCursor) Close()     {}
 func (c *floatCursor) Err() error { return nil }
 
-func (c *floatCursor) Next() (keys []int64, values []float64) {
+func (c *floatCursor) Next() *tsdb.FloatArray {
 	if c.c > len(c.keys) {
 		c.c = len(c.keys)
 	}
 
-	k, v := c.keys[:c.c], c.vals[:c.c]
+	var a tsdb.FloatArray
+	a.Timestamps, a.Values = c.keys[:c.c], c.vals[:c.c]
 	c.keys, c.vals = c.keys[c.c:], c.vals[c.c:]
-	return k, v
+	return &a
 }
 
 type unsignedCursor struct {
@@ -392,14 +394,15 @@ type unsignedCursor struct {
 func (c *unsignedCursor) Close()     {}
 func (c *unsignedCursor) Err() error { return nil }
 
-func (c *unsignedCursor) Next() (keys []int64, values []uint64) {
+func (c *unsignedCursor) Next() *tsdb.UnsignedArray {
 	if c.c > len(c.keys) {
 		c.c = len(c.keys)
 	}
 
-	k, v := c.keys[:c.c], c.vals[:c.c]
+	var a tsdb.UnsignedArray
+	a.Timestamps, a.Values = c.keys[:c.c], c.vals[:c.c]
 	c.keys, c.vals = c.keys[c.c:], c.vals[c.c:]
-	return k, v
+	return &a
 }
 
 type booleanCursor struct {
@@ -411,14 +414,15 @@ type booleanCursor struct {
 func (c *booleanCursor) Close()     {}
 func (c *booleanCursor) Err() error { return nil }
 
-func (c *booleanCursor) Next() (keys []int64, values []bool) {
+func (c *booleanCursor) Next() *tsdb.BooleanArray {
 	if c.c > len(c.keys) {
 		c.c = len(c.keys)
 	}
 
-	k, v := c.keys[:c.c], c.vals[:c.c]
+	var a tsdb.BooleanArray
+	a.Timestamps, a.Values = c.keys[:c.c], c.vals[:c.c]
 	c.keys, c.vals = c.keys[c.c:], c.vals[c.c:]
-	return k, v
+	return &a
 }
 
 type stringCursor struct {
@@ -430,14 +434,15 @@ type stringCursor struct {
 func (c *stringCursor) Close()     {}
 func (c *stringCursor) Err() error { return nil }
 
-func (c *stringCursor) Next() (keys []int64, values []string) {
+func (c *stringCursor) Next() *tsdb.StringArray {
 	if c.c > len(c.keys) {
 		c.c = len(c.keys)
 	}
 
-	k, v := c.keys[:c.c], c.vals[:c.c]
+	var a tsdb.StringArray
+	a.Timestamps, a.Values = c.keys[:c.c], c.vals[:c.c]
 	c.keys, c.vals = c.keys[c.c:], c.vals[c.c:]
-	return k, v
+	return &a
 }
 
 func assertNil(t *testing.T, got interface{}) {

--- a/cmd/influx_tools/internal/format/binary/writer.go
+++ b/cmd/influx_tools/internal/format/binary/writer.go
@@ -221,7 +221,7 @@ func (bw *bucketWriter) EndSeries() {
 	bw.w.state = writeSeries
 }
 
-func (bw *bucketWriter) WriteIntegerCursor(cur tsdb.IntegerBatchCursor) {
+func (bw *bucketWriter) WriteIntegerCursor(cur tsdb.IntegerArrayCursor) {
 	if bw.hasErr() {
 		return
 	}
@@ -236,19 +236,19 @@ func (bw *bucketWriter) WriteIntegerCursor(cur tsdb.IntegerBatchCursor) {
 
 	var msg IntegerPoints
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 
-		bw.n += len(ts)
-		msg.Timestamps = ts
-		msg.Values = vs
+		bw.n += a.Len()
+		msg.Timestamps = a.Timestamps
+		msg.Values = a.Values
 		bw.w.writeTypeMessage(IntegerPointsType, &msg)
 	}
 }
 
-func (bw *bucketWriter) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
+func (bw *bucketWriter) WriteFloatCursor(cur tsdb.FloatArrayCursor) {
 	if bw.hasErr() {
 		return
 	}
@@ -263,19 +263,19 @@ func (bw *bucketWriter) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
 
 	var msg FloatPoints
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 
-		bw.n += len(ts)
-		msg.Timestamps = ts
-		msg.Values = vs
+		bw.n += a.Len()
+		msg.Timestamps = a.Timestamps
+		msg.Values = a.Values
 		bw.w.writeTypeMessage(FloatPointsType, &msg)
 	}
 }
 
-func (bw *bucketWriter) WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor) {
+func (bw *bucketWriter) WriteUnsignedCursor(cur tsdb.UnsignedArrayCursor) {
 	if bw.hasErr() {
 		return
 	}
@@ -290,19 +290,19 @@ func (bw *bucketWriter) WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor) {
 
 	var msg UnsignedPoints
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 
-		bw.n += len(ts)
-		msg.Timestamps = ts
-		msg.Values = vs
+		bw.n += a.Len()
+		msg.Timestamps = a.Timestamps
+		msg.Values = a.Values
 		bw.w.writeTypeMessage(UnsignedPointsType, &msg)
 	}
 }
 
-func (bw *bucketWriter) WriteBooleanCursor(cur tsdb.BooleanBatchCursor) {
+func (bw *bucketWriter) WriteBooleanCursor(cur tsdb.BooleanArrayCursor) {
 	if bw.hasErr() {
 		return
 	}
@@ -317,19 +317,19 @@ func (bw *bucketWriter) WriteBooleanCursor(cur tsdb.BooleanBatchCursor) {
 
 	var msg BooleanPoints
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 
-		bw.n += len(ts)
-		msg.Timestamps = ts
-		msg.Values = vs
+		bw.n += a.Len()
+		msg.Timestamps = a.Timestamps
+		msg.Values = a.Values
 		bw.w.writeTypeMessage(BooleanPointsType, &msg)
 	}
 }
 
-func (bw *bucketWriter) WriteStringCursor(cur tsdb.StringBatchCursor) {
+func (bw *bucketWriter) WriteStringCursor(cur tsdb.StringArrayCursor) {
 	if bw.hasErr() {
 		return
 	}
@@ -344,14 +344,14 @@ func (bw *bucketWriter) WriteStringCursor(cur tsdb.StringBatchCursor) {
 
 	var msg StringPoints
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 
-		bw.n += len(ts)
-		msg.Timestamps = ts
-		msg.Values = vs
+		bw.n += a.Len()
+		msg.Timestamps = a.Timestamps
+		msg.Values = a.Values
 		bw.w.writeTypeMessage(StringPointsType, &msg)
 	}
 }

--- a/cmd/influx_tools/internal/format/binary/writer_test.go
+++ b/cmd/influx_tools/internal/format/binary/writer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx_tools/internal/format/binary"
 	"github.com/influxdata/influxdb/cmd/influx_tools/internal/tlv"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
 )
 
@@ -74,14 +75,15 @@ type intCursor struct {
 func (c *intCursor) Close()     {}
 func (c *intCursor) Err() error { return nil }
 
-func (c *intCursor) Next() (keys []int64, values []int64) {
+func (c *intCursor) Next() *tsdb.IntegerArray {
 	if c.c > len(c.keys) {
 		c.c = len(c.keys)
 	}
 
-	k, v := c.keys[:c.c], c.vals[:c.c]
+	var a tsdb.IntegerArray
+	a.Timestamps, a.Values = c.keys[:c.c], c.vals[:c.c]
 	c.keys, c.vals = c.keys[c.c:], c.vals[c.c:]
-	return k, v
+	return &a
 }
 
 func assertEqual(t *testing.T, got, exp interface{}) {

--- a/cmd/influx_tools/internal/format/conflictwriter.go
+++ b/cmd/influx_tools/internal/format/conflictwriter.go
@@ -120,7 +120,7 @@ func (bw *aggregateBucketWriter) conflictState(other influxql.DataType) {
 	}
 }
 
-func (bw *aggregateBucketWriter) WriteIntegerCursor(cur tsdb.IntegerBatchCursor) {
+func (bw *aggregateBucketWriter) WriteIntegerCursor(cur tsdb.IntegerArrayCursor) {
 	if bw.typ == influxql.Integer {
 		bw.w.WriteIntegerCursor(cur)
 	} else {
@@ -129,7 +129,7 @@ func (bw *aggregateBucketWriter) WriteIntegerCursor(cur tsdb.IntegerBatchCursor)
 	}
 }
 
-func (bw *aggregateBucketWriter) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
+func (bw *aggregateBucketWriter) WriteFloatCursor(cur tsdb.FloatArrayCursor) {
 	if bw.typ == influxql.Float {
 		bw.w.WriteFloatCursor(cur)
 	} else {
@@ -138,7 +138,7 @@ func (bw *aggregateBucketWriter) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
 	}
 }
 
-func (bw *aggregateBucketWriter) WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor) {
+func (bw *aggregateBucketWriter) WriteUnsignedCursor(cur tsdb.UnsignedArrayCursor) {
 	if bw.typ == influxql.Unsigned {
 		bw.w.WriteUnsignedCursor(cur)
 	} else {
@@ -147,7 +147,7 @@ func (bw *aggregateBucketWriter) WriteUnsignedCursor(cur tsdb.UnsignedBatchCurso
 	}
 }
 
-func (bw *aggregateBucketWriter) WriteBooleanCursor(cur tsdb.BooleanBatchCursor) {
+func (bw *aggregateBucketWriter) WriteBooleanCursor(cur tsdb.BooleanArrayCursor) {
 	if bw.typ == influxql.Boolean {
 		bw.w.WriteBooleanCursor(cur)
 	} else {
@@ -156,7 +156,7 @@ func (bw *aggregateBucketWriter) WriteBooleanCursor(cur tsdb.BooleanBatchCursor)
 	}
 }
 
-func (bw *aggregateBucketWriter) WriteStringCursor(cur tsdb.StringBatchCursor) {
+func (bw *aggregateBucketWriter) WriteStringCursor(cur tsdb.StringArrayCursor) {
 	if bw.typ == influxql.String {
 		bw.w.WriteStringCursor(cur)
 	} else {

--- a/cmd/influx_tools/internal/format/line/writer.go
+++ b/cmd/influx_tools/internal/format/line/writer.go
@@ -51,24 +51,24 @@ func (w *Writer) BeginSeries(name, field []byte, typ influxql.DataType, tags mod
 
 func (w *Writer) EndSeries() {}
 
-func (w *Writer) WriteIntegerCursor(cur tsdb.IntegerBatchCursor) {
+func (w *Writer) WriteIntegerCursor(cur tsdb.IntegerArrayCursor) {
 	if w.err != nil {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:len(w.key)] // Re-slice buf to be "<series_key> <field>=".
 
-			buf = strconv.AppendInt(buf, vs[i], 10)
+			buf = strconv.AppendInt(buf, a.Values[i], 10)
 			buf = append(buf, 'i')
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return
@@ -77,23 +77,23 @@ func (w *Writer) WriteIntegerCursor(cur tsdb.IntegerBatchCursor) {
 	}
 }
 
-func (w *Writer) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
+func (w *Writer) WriteFloatCursor(cur tsdb.FloatArrayCursor) {
 	if w.err != nil {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:len(w.key)] // Re-slice buf to be "<series_key> <field>=".
 
-			buf = strconv.AppendFloat(buf, vs[i], 'g', -1, 64)
+			buf = strconv.AppendFloat(buf, a.Values[i], 'g', -1, 64)
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return
@@ -102,24 +102,24 @@ func (w *Writer) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
 	}
 }
 
-func (w *Writer) WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor) {
+func (w *Writer) WriteUnsignedCursor(cur tsdb.UnsignedArrayCursor) {
 	if w.err != nil {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:len(w.key)] // Re-slice buf to be "<series_key> <field>=".
 
-			buf = strconv.AppendUint(buf, vs[i], 10)
+			buf = strconv.AppendUint(buf, a.Values[i], 10)
 			buf = append(buf, 'u')
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return
@@ -128,23 +128,23 @@ func (w *Writer) WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor) {
 	}
 }
 
-func (w *Writer) WriteBooleanCursor(cur tsdb.BooleanBatchCursor) {
+func (w *Writer) WriteBooleanCursor(cur tsdb.BooleanArrayCursor) {
 	if w.err != nil {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:len(w.key)] // Re-slice buf to be "<series_key> <field>=".
 
-			buf = strconv.AppendBool(buf, vs[i])
+			buf = strconv.AppendBool(buf, a.Values[i])
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return
@@ -153,25 +153,25 @@ func (w *Writer) WriteBooleanCursor(cur tsdb.BooleanBatchCursor) {
 	}
 }
 
-func (w *Writer) WriteStringCursor(cur tsdb.StringBatchCursor) {
+func (w *Writer) WriteStringCursor(cur tsdb.StringArrayCursor) {
 	if w.err != nil {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:len(w.key)] // Re-slice buf to be "<series_key> <field>=".
 
 			buf = append(buf, '"')
-			buf = append(buf, models.EscapeStringField(vs[i])...)
+			buf = append(buf, models.EscapeStringField(a.Values[i])...)
 			buf = append(buf, '"')
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return

--- a/cmd/influx_tools/internal/format/text/writer.go
+++ b/cmd/influx_tools/internal/format/text/writer.go
@@ -61,24 +61,24 @@ func (w *Writer) BeginSeries(name, field []byte, typ influxql.DataType, tags mod
 
 func (w *Writer) EndSeries() {}
 
-func (w *Writer) WriteIntegerCursor(cur tsdb.IntegerBatchCursor) {
+func (w *Writer) WriteIntegerCursor(cur tsdb.IntegerArrayCursor) {
 	if w.err != nil || w.m == Series {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:0]
 
-			buf = strconv.AppendInt(buf, vs[i], 10)
+			buf = strconv.AppendInt(buf, a.Values[i], 10)
 			buf = append(buf, 'i')
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return
@@ -87,23 +87,23 @@ func (w *Writer) WriteIntegerCursor(cur tsdb.IntegerBatchCursor) {
 	}
 }
 
-func (w *Writer) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
+func (w *Writer) WriteFloatCursor(cur tsdb.FloatArrayCursor) {
 	if w.err != nil || w.m == Series {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:0]
 
-			buf = strconv.AppendFloat(buf, vs[i], 'g', -1, 64)
+			buf = strconv.AppendFloat(buf, a.Values[i], 'g', -1, 64)
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return
@@ -112,24 +112,24 @@ func (w *Writer) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
 	}
 }
 
-func (w *Writer) WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor) {
+func (w *Writer) WriteUnsignedCursor(cur tsdb.UnsignedArrayCursor) {
 	if w.err != nil || w.m == Series {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:0]
 
-			buf = strconv.AppendUint(buf, vs[i], 10)
+			buf = strconv.AppendUint(buf, a.Values[i], 10)
 			buf = append(buf, 'u')
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return
@@ -138,23 +138,23 @@ func (w *Writer) WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor) {
 	}
 }
 
-func (w *Writer) WriteBooleanCursor(cur tsdb.BooleanBatchCursor) {
+func (w *Writer) WriteBooleanCursor(cur tsdb.BooleanArrayCursor) {
 	if w.err != nil || w.m == Series {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:0]
 
-			buf = strconv.AppendBool(buf, vs[i])
+			buf = strconv.AppendBool(buf, a.Values[i])
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return
@@ -163,25 +163,25 @@ func (w *Writer) WriteBooleanCursor(cur tsdb.BooleanBatchCursor) {
 	}
 }
 
-func (w *Writer) WriteStringCursor(cur tsdb.StringBatchCursor) {
+func (w *Writer) WriteStringCursor(cur tsdb.StringArrayCursor) {
 	if w.err != nil || w.m == Series {
 		return
 	}
 
 	buf := w.key
 	for {
-		ts, vs := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
-		for i := range ts {
+		for i := range a.Timestamps {
 			buf = buf[:0]
 
 			buf = append(buf, '"')
-			buf = append(buf, models.EscapeStringField(vs[i])...)
+			buf = append(buf, models.EscapeStringField(a.Values[i])...)
 			buf = append(buf, '"')
 			buf = append(buf, ' ')
-			buf = strconv.AppendInt(buf, ts[i], 10)
+			buf = strconv.AppendInt(buf, a.Timestamps[i], 10)
 			buf = append(buf, '\n')
 			if _, w.err = w.w.Write(buf); w.err != nil {
 				return

--- a/cmd/influx_tools/internal/format/writer.go
+++ b/cmd/influx_tools/internal/format/writer.go
@@ -28,11 +28,11 @@ type BucketWriter interface {
 	BeginSeries(name, field []byte, typ influxql.DataType, tags models.Tags)
 	EndSeries()
 
-	WriteIntegerCursor(cur tsdb.IntegerBatchCursor)
-	WriteFloatCursor(cur tsdb.FloatBatchCursor)
-	WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor)
-	WriteBooleanCursor(cur tsdb.BooleanBatchCursor)
-	WriteStringCursor(cur tsdb.StringBatchCursor)
+	WriteIntegerCursor(cur tsdb.IntegerArrayCursor)
+	WriteFloatCursor(cur tsdb.FloatArrayCursor)
+	WriteUnsignedCursor(cur tsdb.UnsignedArrayCursor)
+	WriteBooleanCursor(cur tsdb.BooleanArrayCursor)
+	WriteStringCursor(cur tsdb.StringArrayCursor)
 	Close() error
 }
 
@@ -53,15 +53,15 @@ func WriteBucket(w Writer, start, end int64, rs *storage.ResultSet) error {
 		for ci.Next() {
 			cur := ci.Cursor()
 			switch c := cur.(type) {
-			case tsdb.IntegerBatchCursor:
+			case tsdb.IntegerArrayCursor:
 				bw.WriteIntegerCursor(c)
-			case tsdb.FloatBatchCursor:
+			case tsdb.FloatArrayCursor:
 				bw.WriteFloatCursor(c)
-			case tsdb.UnsignedBatchCursor:
+			case tsdb.UnsignedArrayCursor:
 				bw.WriteUnsignedCursor(c)
-			case tsdb.BooleanBatchCursor:
+			case tsdb.BooleanArrayCursor:
 				bw.WriteBooleanCursor(c)
-			case tsdb.StringBatchCursor:
+			case tsdb.StringArrayCursor:
 				bw.WriteStringCursor(c)
 			case nil:
 				// no data for series key + field combination in this shard
@@ -95,61 +95,61 @@ func (w *devNull) EndSeries()                                                   
 func (w *devNull) Err() error   { return nil }
 func (w *devNull) Close() error { return nil }
 
-func (w *devNull) WriteIntegerCursor(cur tsdb.IntegerBatchCursor) {
+func (w *devNull) WriteIntegerCursor(cur tsdb.IntegerArrayCursor) {
 	if !w.r {
 		return
 	}
 	for {
-		ts, _ := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 	}
 }
 
-func (w *devNull) WriteFloatCursor(cur tsdb.FloatBatchCursor) {
+func (w *devNull) WriteFloatCursor(cur tsdb.FloatArrayCursor) {
 	if !w.r {
 		return
 	}
 	for {
-		ts, _ := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 	}
 }
 
-func (w *devNull) WriteUnsignedCursor(cur tsdb.UnsignedBatchCursor) {
+func (w *devNull) WriteUnsignedCursor(cur tsdb.UnsignedArrayCursor) {
 	if !w.r {
 		return
 	}
 	for {
-		ts, _ := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 	}
 }
 
-func (w *devNull) WriteBooleanCursor(cur tsdb.BooleanBatchCursor) {
+func (w *devNull) WriteBooleanCursor(cur tsdb.BooleanArrayCursor) {
 	if !w.r {
 		return
 	}
 	for {
-		ts, _ := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 	}
 }
 
-func (w *devNull) WriteStringCursor(cur tsdb.StringBatchCursor) {
+func (w *devNull) WriteStringCursor(cur tsdb.StringArrayCursor) {
 	if !w.r {
 		return
 	}
 	for {
-		ts, _ := cur.Next()
-		if len(ts) == 0 {
+		a := cur.Next()
+		if a.Len() == 0 {
 			break
 		}
 	}


### PR DESCRIPTION
A recent change for the columnar work changed the default cursor types used by the storage read service. This service is used by the `influx_tools export` command and required updating to utilize the new types.