### PR TITLE
fix restore shard bug

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -556,7 +556,7 @@ func (cmd *Command) unpackTar(tarFile string) error {
 		return fmt.Errorf("backup tarfile name incorrect format")
 	}
 
-	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.Trim(pathParts[2], "0"))
+	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.TrimPrefix(pathParts[2], "0"))
 	os.MkdirAll(shardPath, 0755)
 
 	return tarstream.Restore(f, shardPath)


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Reproduce
* operating system: CentOS release 6.7 (Final)
* version: 1.6.0 (download from official site)
* test case: Any shard that ends with "0" will restore to wrong shard.

