### PR TITLE
Add option to hint MADV_WILLNEED to kernel

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -116,6 +116,11 @@
   # disabled by setting it to 0.
   # max-values-per-tag = 100000
 
+  # If true, then the mmap advise value MADV_WILLNEED will be provided to the kernel with respect to
+  # TSM files. This setting has been found to be problematic on some kernels, and defaults to off.
+  # It might help users who have slow disks in some cases.
+  # tsm-use-madv-willneed = false
+
 ###
 ### [coordinator]
 ###

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -105,6 +105,12 @@ type Config struct {
 	MaxIndexLogFileSize toml.Size `toml:"max-index-log-file-size"`
 
 	TraceLoggingEnabled bool `toml:"trace-logging-enabled"`
+
+	// TSMWillNeed controls whether we hint to the kernel that we intend to
+	// page in mmap'd sections of TSM files. This setting defaults to off, as it has
+	// been found to be problematic in some cases. It may help users who have
+	// slow disks.
+	TSMWillNeed bool `toml:"tsm-use-madv-willneed"`
 }
 
 // NewConfig returns the default configuration for tsdb.
@@ -127,6 +133,7 @@ func NewConfig() Config {
 		MaxIndexLogFileSize: toml.Size(DefaultMaxIndexLogFileSize),
 
 		TraceLoggingEnabled: false,
+		TSMWillNeed:         false,
 	}
 }
 

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -15,6 +15,7 @@ func TestConfig_Parse(t *testing.T) {
 dir = "/var/lib/influxdb/data"
 wal-dir = "/var/lib/influxdb/wal"
 wal-fsync-delay = "10s"
+tsm-use-madv-willneed = true
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -31,6 +32,9 @@ wal-fsync-delay = "10s"
 	}
 	if got, exp := c.WALFsyncDelay, time.Duration(10*time.Second); time.Duration(got).Nanoseconds() != exp.Nanoseconds() {
 		t.Errorf("unexpected wal-fsync-delay:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.TSMWillNeed, true; got != exp {
+		t.Errorf("unexpected tsm-madv-willneed:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
 	}
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -211,6 +211,8 @@ func NewEngine(id uint64, idx tsdb.Index, path string, walPath string, sfile *ts
 	if opt.FileStoreObserver != nil {
 		fs.WithObserver(opt.FileStoreObserver)
 	}
+	fs.tsmMMAPWillNeed = opt.Config.TSMWillNeed
+
 	cache := NewCache(uint64(opt.Config.CacheMaxMemorySize))
 
 	c := NewCompactor()

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -27,6 +27,12 @@ func munmap(b []byte) (err error) {
 	return unix.Munmap(b)
 }
 
+// madviseWillNeed gives the kernel the mmap madvise value MADV_WILLNEED, hinting
+// that we plan on using the provided buffer in the near future.
+func madviseWillNeed(b []byte) error {
+	return madvise(b, syscall.MADV_WILLNEED)
+}
+
 func madviseDontNeed(b []byte) error {
 	return madvise(b, syscall.MADV_DONTNEED)
 }

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -121,10 +121,11 @@ func munmap(b []byte) (err error) {
 	return nil
 }
 
-func madviseDontNeed(b []byte) error {
-	// Not supported
-	return nil
-}
+// madviseWillNeed is unsupported on Windows.
+func madviseWillNeed(b []byte) error { return nil }
+
+// madviseDontNeed is unsupported on Windows.
+func madviseDontNeed(b []byte) error { return nil }
 
 func madvise(b []byte, advice int) error {
 	// Not implemented


### PR DESCRIPTION
Fixes #10117.

This PR adds a new configuration option - `tsm-use-madv-willneed` / `INFLUXDB_DATA_TSM_USE_MADV_WILLNEED`, which, when true, will hint to the kernel that we plan on sequentially reading TSM files.

This option defaults to false because we have had some issues in the past with certain kernels/operating systems. However, it may be useful to some users with slow disks.