### PR TITLE
Provide configurable TLS options

### DIFF
--- a/client/influxdb.go
+++ b/client/influxdb.go
@@ -118,6 +118,7 @@ type Config struct {
 	WriteConsistency string
 	UnsafeSsl        bool
 	Proxy            func(req *http.Request) (*url.URL, error)
+	TLS              *tls.Config
 }
 
 // NewConfig will create a config to be used in connecting to the client
@@ -154,9 +155,11 @@ const (
 
 // NewClient will instantiate and return a connected client to issue commands to the server.
 func NewClient(c Config) (*Client, error) {
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: c.UnsafeSsl,
+	tlsConfig := new(tls.Config)
+	if c.TLS != nil {
+		tlsConfig = c.TLS.Clone()
 	}
+	tlsConfig.InsecureSkipVerify = c.UnsafeSsl
 
 	tr := &http.Transport{
 		Proxy:           c.Proxy,

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -62,6 +62,9 @@ type Config struct {
 
 	// BindAddress is the address that all TCP services use (Raft, Snapshot, Cluster, etc.)
 	BindAddress string `toml:"bind-address"`
+
+	// TLS provides configuration options for all https endpoints.
+	TLS TLSConfig `toml:"tls"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -191,6 +191,10 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	if err := c.TLS.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cmd/influxd/run/config.go
+++ b/cmd/influxd/run/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/monitor"
 	"github.com/influxdata/influxdb/monitor/diagnostics"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/services/collectd"
 	"github.com/influxdata/influxdb/services/continuous_querier"
 	"github.com/influxdata/influxdb/services/graphite"
@@ -64,7 +65,7 @@ type Config struct {
 	BindAddress string `toml:"bind-address"`
 
 	// TLS provides configuration options for all https endpoints.
-	TLS TLSConfig `toml:"tls"`
+	TLS tlsconfig.Config `toml:"tls"`
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -64,6 +64,9 @@ enabled = true
 
 [continuous_queries]
 enabled = true
+
+[tls]
+ciphers = ["cipher"]
 `); err != nil {
 		t.Fatal(err)
 	}
@@ -97,6 +100,8 @@ enabled = true
 		t.Fatalf("unexpected subscriber enabled: %v", c.Subscriber.Enabled)
 	} else if !c.ContinuousQuery.Enabled {
 		t.Fatalf("unexpected continuous query enabled: %v", c.ContinuousQuery.Enabled)
+	} else if c.TLS.Ciphers[0] != "cipher" {
+		t.Fatalf("unexpected tls: %q", c.TLS.Ciphers)
 	}
 }
 
@@ -150,6 +155,9 @@ enabled = true
 
 [continuous_queries]
 enabled = true
+
+[tls]
+min-version = "tls1.0"
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -179,6 +187,8 @@ enabled = true
 		case "INFLUXDB_COORDINATOR_QUERY_TIMEOUT":
 			// duration type
 			return "1m"
+		case "INFLUXDB_TLS_MIN_VERSION":
+			return "tls1.2"
 		}
 		return ""
 	}
@@ -225,6 +235,10 @@ enabled = true
 
 	if c.Coordinator.QueryTimeout != influxtoml.Duration(time.Minute) {
 		t.Fatalf("unexpected query timeout: %v", c.Coordinator.QueryTimeout)
+	}
+
+	if c.TLS.MinVersion != "tls1.2" {
+		t.Fatalf("unexpected tls min version: %q", c.TLS.MinVersion)
 	}
 }
 

--- a/cmd/influxd/run/tls_config.go
+++ b/cmd/influxd/run/tls_config.go
@@ -1,0 +1,87 @@
+package run
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+)
+
+type TLSConfig struct {
+	Ciphers    []string `toml:"ciphers"`
+	MinVersion string   `toml:"min-version"`
+	MaxVersion string   `toml:"max-version"`
+}
+
+func ParseTLSConfig(config TLSConfig) (*tls.Config, error) {
+	out := new(tls.Config)
+
+	if len(config.Ciphers) > 0 {
+		for _, name := range config.Ciphers {
+			cipher, ok := ciphersMap[strings.ToUpper(name)]
+			if !ok {
+				return nil, unknownCipher(name)
+			}
+			out.CipherSuites = append(out.CipherSuites, cipher)
+		}
+	}
+
+	if config.MinVersion != "" {
+		version, ok := versionsMap[strings.ToUpper(config.MinVersion)]
+		if !ok {
+			return nil, unknownVersion(config.MinVersion)
+		}
+		out.MinVersion = version
+	}
+
+	if config.MaxVersion != "" {
+		version, ok := versionsMap[strings.ToUpper(config.MaxVersion)]
+		if !ok {
+			return nil, unknownVersion(config.MaxVersion)
+		}
+		out.MaxVersion = version
+	}
+
+	return out, nil
+}
+
+var ciphersMap = map[string]uint16{
+	"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+}
+
+func unknownCipher(name string) error {
+	// TODO(jeff): list available?
+	return fmt.Errorf("unknown cipher suite: %q", name)
+}
+
+var versionsMap = map[string]uint16{
+	"SSL3.0": tls.VersionSSL30,
+	"TLS1.0": tls.VersionTLS10,
+	"TLS1.1": tls.VersionTLS11,
+	"TLS1.2": tls.VersionTLS12,
+}
+
+func unknownVersion(name string) error {
+	// TODO(jeff): list available?
+	return fmt.Errorf("unknown tls version: %q", name)
+}

--- a/cmd/influxd/run/tls_config.go
+++ b/cmd/influxd/run/tls_config.go
@@ -12,11 +12,18 @@ type TLSConfig struct {
 	MaxVersion string   `toml:"max-version"`
 }
 
-func ParseTLSConfig(config TLSConfig) (*tls.Config, error) {
-	out := new(tls.Config)
+func (c TLSConfig) Validate() error {
+	_, err := c.Parse()
+	return err
+}
 
-	if len(config.Ciphers) > 0 {
-		for _, name := range config.Ciphers {
+func (c TLSConfig) Parse() (out *tls.Config, err error) {
+	if len(c.Ciphers) > 0 {
+		if out == nil {
+			out = new(tls.Config)
+		}
+
+		for _, name := range c.Ciphers {
 			cipher, ok := ciphersMap[strings.ToUpper(name)]
 			if !ok {
 				return nil, unknownCipher(name)
@@ -25,18 +32,26 @@ func ParseTLSConfig(config TLSConfig) (*tls.Config, error) {
 		}
 	}
 
-	if config.MinVersion != "" {
-		version, ok := versionsMap[strings.ToUpper(config.MinVersion)]
+	if c.MinVersion != "" {
+		if out == nil {
+			out = new(tls.Config)
+		}
+
+		version, ok := versionsMap[strings.ToUpper(c.MinVersion)]
 		if !ok {
-			return nil, unknownVersion(config.MinVersion)
+			return nil, unknownVersion(c.MinVersion)
 		}
 		out.MinVersion = version
 	}
 
-	if config.MaxVersion != "" {
-		version, ok := versionsMap[strings.ToUpper(config.MaxVersion)]
+	if c.MaxVersion != "" {
+		if out == nil {
+			out = new(tls.Config)
+		}
+
+		version, ok := versionsMap[strings.ToUpper(c.MaxVersion)]
 		if !ok {
-			return nil, unknownVersion(config.MaxVersion)
+			return nil, unknownVersion(c.MaxVersion)
 		}
 		out.MaxVersion = version
 	}
@@ -77,8 +92,11 @@ func unknownCipher(name string) error {
 var versionsMap = map[string]uint16{
 	"SSL3.0": tls.VersionSSL30,
 	"TLS1.0": tls.VersionTLS10,
+	"1.0":    tls.VersionTLS11,
 	"TLS1.1": tls.VersionTLS11,
+	"1.1":    tls.VersionTLS11,
 	"TLS1.2": tls.VersionTLS12,
+	"1.2":    tls.VersionTLS12,
 }
 
 func unknownVersion(name string) error {

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -534,17 +534,18 @@
 
 [tls]
   # Determines the available set of cipher suites. See https://golang.org/pkg/crypto/tls/#pkg-constants
-  # for a list of available ciphers, which depends on the version of Go. If not specified, uses
-  # the default settings from crypto/tls.
+  # for a list of available ciphers, which depends on the version of Go (use the query
+  # SHOW DIAGNOSTICS to see the version of Go used to build InfluxDB). If not specified, uses
+  # the default settings from Go's crypto/tls package.
   # ciphers = [
   #   "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
   #   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
   # ]
 
   # Minimum version of the tls protocol that will be negotiated. If not specified, uses the
-  # default settings from crypto/tls.
+  # default settings from Go's crypto/tls package.
   # min-version = "tls1.2"
 
   # Maximum version of the tls protocol that will be negotiated. If not specified, uses the
-  # default settings from crypto/tls.
+  # default settings from Go's crypto/tls package.
   # max-version = "tls1.2"

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -487,7 +487,7 @@
   # bind-address = ":8089"
   # database = "udp"
   # retention-policy = ""
- 
+
   # InfluxDB precision for timestamps on received points ("" or "n", "u", "ms", "s", "m", "h")
   # precision = ""
 
@@ -525,3 +525,26 @@
 
   # interval for how often continuous queries will be checked if they need to run
   # run-interval = "1s"
+
+###
+### [tls]
+###
+### Global configuration settings for TLS in InfluxDB.
+###
+
+[tls]
+  # Determines the available set of cipher suites. See https://golang.org/pkg/crypto/tls/#pkg-constants
+  # for a list of available ciphers, which depends on the version of Go. If not specified, uses
+  # the default settings from crypto/tls.
+  # ciphers = [
+  #   "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+  #   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+  # ]
+
+  # Minimum version of the tls protocol that will be negotiated. If not specified, uses the
+  # default settings from crypto/tls.
+  # min-version = "tls1.2"
+
+  # Maximum version of the tls protocol that will be negotiated. If not specified, uses the
+  # default settings from crypto/tls.
+  # max-version = "tls1.2"

--- a/pkg/tlsconfig/tls_config.go
+++ b/pkg/tlsconfig/tls_config.go
@@ -1,4 +1,4 @@
-package run
+package tlsconfig
 
 import (
 	"crypto/tls"
@@ -6,18 +6,22 @@ import (
 	"strings"
 )
 
-type TLSConfig struct {
+type Config struct {
 	Ciphers    []string `toml:"ciphers"`
 	MinVersion string   `toml:"min-version"`
 	MaxVersion string   `toml:"max-version"`
 }
 
-func (c TLSConfig) Validate() error {
+func NewConfig() Config {
+	return Config{}
+}
+
+func (c Config) Validate() error {
 	_, err := c.Parse()
 	return err
 }
 
-func (c TLSConfig) Parse() (out *tls.Config, err error) {
+func (c Config) Parse() (out *tls.Config, err error) {
 	if len(c.Ciphers) > 0 {
 		if out == nil {
 			out = new(tls.Config)

--- a/pkg/tlsconfig/tls_config.go
+++ b/pkg/tlsconfig/tls_config.go
@@ -3,6 +3,7 @@ package tlsconfig
 import (
 	"crypto/tls"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -89,8 +90,14 @@ var ciphersMap = map[string]uint16{
 }
 
 func unknownCipher(name string) error {
-	// TODO(jeff): list available?
-	return fmt.Errorf("unknown cipher suite: %q", name)
+	available := make([]string, 0, len(ciphersMap))
+	for name := range ciphersMap {
+		available = append(available, name)
+	}
+	sort.Strings(available)
+
+	return fmt.Errorf("unknown cipher suite: %q. available ciphers: %s",
+		name, strings.Join(available, ", "))
 }
 
 var versionsMap = map[string]uint16{
@@ -104,6 +111,18 @@ var versionsMap = map[string]uint16{
 }
 
 func unknownVersion(name string) error {
-	// TODO(jeff): list available?
-	return fmt.Errorf("unknown tls version: %q", name)
+	available := make([]string, 0, len(versionsMap))
+	for name := range versionsMap {
+		// skip the ones that just begin with a number. they may be confusing
+		// due to the duplication, and just help if the user specifies without
+		// the TLS part.
+		if name[0] == '1' {
+			continue
+		}
+		available = append(available, name)
+	}
+	sort.Strings(available)
+
+	return fmt.Errorf("unknown tls version: %q. available versions: %s",
+		name, strings.Join(available, ", "))
 }

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -1,6 +1,7 @@
 package httpd
 
 import (
+	"crypto/tls"
 	"time"
 
 	"github.com/influxdata/influxdb/monitor/diagnostics"
@@ -50,6 +51,7 @@ type Config struct {
 	MaxConcurrentWriteLimit int           `toml:"max-concurrent-write-limit"`
 	MaxEnqueuedWriteLimit   int           `toml:"max-enqueued-write-limit"`
 	EnqueuedWriteTimeout    time.Duration `toml:"enqueued-write-timeout"`
+	TLS                     *tls.Config   `toml:"-"`
 }
 
 // NewConfig returns a new Config with default settings.

--- a/services/opentsdb/config.go
+++ b/services/opentsdb/config.go
@@ -1,6 +1,7 @@
 package opentsdb
 
 import (
+	"crypto/tls"
 	"time"
 
 	"github.com/influxdata/influxdb/monitor/diagnostics"
@@ -46,6 +47,7 @@ type Config struct {
 	BatchPending     int           `toml:"batch-pending"`
 	BatchTimeout     toml.Duration `toml:"batch-timeout"`
 	LogPointErrors   bool          `toml:"log-point-errors"`
+	TLS              *tls.Config   `toml:"-"`
 }
 
 // NewConfig returns a new config for the service.

--- a/services/subscriber/config.go
+++ b/services/subscriber/config.go
@@ -1,6 +1,7 @@
 package subscriber
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"os"
@@ -42,6 +43,9 @@ type Config struct {
 
 	// The number of in-flight writes buffered in the write channel.
 	WriteBufferSize int `toml:"write-buffer-size"`
+
+	// TLS is a base tls config to use for https clients.
+	TLS *tls.Config `toml:"-"`
 }
 
 // NewConfig returns a new instance of a subscriber config.

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -348,7 +348,7 @@ func (s *Service) newPointsWriter(u url.URL) (PointsWriter, error) {
 		if s.conf.InsecureSkipVerify {
 			s.Logger.Warn("'insecure-skip-verify' is true. This will skip all certificate verifications.")
 		}
-		return NewHTTPS(u.String(), time.Duration(s.conf.HTTPTimeout), s.conf.InsecureSkipVerify, s.conf.CaCerts)
+		return NewHTTPS(u.String(), time.Duration(s.conf.HTTPTimeout), s.conf.InsecureSkipVerify, s.conf.CaCerts, s.conf.TLS)
 	default:
 		return nil, fmt.Errorf("unknown destination scheme %s", u.Scheme)
 	}


### PR DESCRIPTION
This PR allows one to specify

- Which cipher suites to use
- A minimum supported TLS version
- A maximum supported TLS version

in the config files.

Backport of #10150.