### PR TITLE
Simplify loops

### DIFF
--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -523,7 +523,7 @@ func TestBufferedPointsWriter(t *testing.T) {
 	reset()
 
 	// Test writing points one at a time.
-	for i, _ := range r.Points {
+	for i := range r.Points {
 		if err := w.WritePointsInto(&coordinator.IntoWriteRequest{
 			Database:        db,
 			RetentionPolicy: rp,

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -871,7 +871,7 @@ func (data *Data) importOneDB(other Data, backupDBName, restoreDBName, backupRPN
 		for j, sgImport := range rpImport.ShardGroups {
 			data.MaxShardGroupID++
 			rpImport.ShardGroups[j].ID = data.MaxShardGroupID
-			for k, _ := range sgImport.Shards {
+			for k := range sgImport.Shards {
 				data.MaxShardID++
 				shardIDMap[sgImport.Shards[k].ID] = data.MaxShardID
 				sgImport.Shards[k].ID = data.MaxShardID

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -394,14 +394,14 @@ func TestEngine_Export(t *testing.T) {
 	}
 
 	// TEST 1: did we get any extra files not found in the store?
-	for k, _ := range fileData {
+	for k := range fileData {
 		if _, ok := fileNames[k]; !ok {
 			t.Errorf("exported a file not in the store: %s", k)
 		}
 	}
 
 	// TEST 2: did we miss any files that the store had?
-	for k, _ := range fileNames {
+	for k := range fileNames {
 		if _, ok := fileData[k]; !ok {
 			t.Errorf("failed to export a file from the store: %s", k)
 		}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -930,7 +930,7 @@ func (s *Store) Databases() []string {
 	defer s.mu.RUnlock()
 
 	databases := make([]string, 0, len(s.databases))
-	for k, _ := range s.databases {
+	for k := range s.databases {
 		databases = append(databases, k)
 	}
 	return databases


### PR DESCRIPTION
`megacheck` was [recently updated](https://github.com/dominikh/go-tools/commit/7ca3f547f9335a25653ffb1b68a21ed576ae1854) to simplify some loops. This PR fixes the cases in the repo that could be simplified in this way.