### PR TITLE
Add getter and setter for config of a BatchPoints on client

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -195,6 +195,11 @@ type BatchPoints interface {
 	// Points lists the points in the Batch.
 	Points() []*Point
 
+	// Config returns the currently configuration of this batch.
+	Config() BatchPointsConfig
+	// SetConfig sets the configuration of this batch.
+	SetConfig(config BatchPointsConfig) error
+
 	// Precision returns the currently set precision of this Batch.
 	Precision() string
 	// SetPrecision sets the precision of this batch.
@@ -253,6 +258,15 @@ func (bp *batchpoints) Points() []*Point {
 	return bp.points
 }
 
+func (bp *batchpoints) Config() BatchPointsConfig {
+	return BatchPointsConfig{
+		Precision: bp.precision,
+		Database: bp.database,
+		WriteConsistency: bp.writeConsistency,
+		RetentionPolicy: bp.retentionPolicy,
+	}
+}
+
 func (bp *batchpoints) Precision() string {
 	return bp.precision
 }
@@ -267,6 +281,13 @@ func (bp *batchpoints) WriteConsistency() string {
 
 func (bp *batchpoints) RetentionPolicy() string {
 	return bp.retentionPolicy
+}
+
+func (bp *batchpoints) SetConfig(conf BatchPointsConfig) error {
+	bp.SetDatabase(conf.Database)
+	bp.SetWriteConsistency(conf.WriteConsistency)
+	bp.SetRetentionPolicy(conf.RetentionPolicy)
+	return bp.SetPrecision(conf.Precision)
 }
 
 func (bp *batchpoints) SetPrecision(p string) error {

--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -821,16 +821,17 @@ func TestBatchPoints_SettersGetters(t *testing.T) {
 		RetentionPolicy:  "rp",
 		WriteConsistency: "wc",
 	})
-	if bp.Precision() != "ns" {
+	conf := bp.Config()
+	if bp.Precision() != "ns" || conf.Precision != "ns" {
 		t.Errorf("Expected: %s, got %s", bp.Precision(), "ns")
 	}
-	if bp.Database() != "db" {
+	if bp.Database() != "db" || conf.Database != "db" {
 		t.Errorf("Expected: %s, got %s", bp.Database(), "db")
 	}
-	if bp.RetentionPolicy() != "rp" {
+	if bp.RetentionPolicy() != "rp" || conf.RetentionPolicy != "rp" {
 		t.Errorf("Expected: %s, got %s", bp.RetentionPolicy(), "rp")
 	}
-	if bp.WriteConsistency() != "wc" {
+	if bp.WriteConsistency() != "wc" || conf.WriteConsistency != "wc" {
 		t.Errorf("Expected: %s, got %s", bp.WriteConsistency(), "wc")
 	}
 
@@ -853,6 +854,24 @@ func TestBatchPoints_SettersGetters(t *testing.T) {
 	}
 	if bp.WriteConsistency() != "wc2" {
 		t.Errorf("Expected: %s, got %s", bp.WriteConsistency(), "wc2")
+	}
+
+	err = bp.SetConfig(BatchPointsConfig{Precision: "us", Database: "db3", RetentionPolicy: "rp3", WriteConsistency: "wc3"})
+	if err != nil {
+		t.Errorf("Did not expect error: %s", err.Error())
+	}
+
+	if bp.Precision() != "us" {
+		t.Errorf("Expected: %s, got %s", bp.Precision(), "us")
+	}
+	if bp.Database() != "db3" {
+		t.Errorf("Expected: %s, got %s", bp.Database(), "db3")
+	}
+	if bp.RetentionPolicy() != "rp3" {
+		t.Errorf("Expected: %s, got %s", bp.RetentionPolicy(), "rp3")
+	}
+	if bp.WriteConsistency() != "wc3" {
+		t.Errorf("Expected: %s, got %s", bp.WriteConsistency(), "wc3")
 	}
 }
 


### PR DESCRIPTION
I am working on project that fragments one BatchPoints into multiples, so the configuration needs to be duplicated. This two functions will be useful to avoid verbose code.

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)