### PR TITLE
Fix iterator panic in read service 

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -2179,8 +2179,9 @@ func (is IndexSet) matchTagValueEqualEmptySeriesIDIterator(name, key []byte, val
 				itr, err := is.tagValueSeriesIDIterator(name, key, e)
 				if err != nil {
 					return err
+				} else if itr != nil {
+					itrs = append(itrs, itr)
 				}
-				itrs = append(itrs, itr)
 			}
 		}
 		return nil
@@ -2222,8 +2223,9 @@ func (is IndexSet) matchTagValueEqualNotEmptySeriesIDIterator(name, key []byte, 
 			if err != nil {
 				SeriesIDIterators(itrs).Close()
 				return nil, err
+			} else if itr != nil {
+				itrs = append(itrs, itr)
 			}
-			itrs = append(itrs, itr)
 		}
 	}
 	return MergeSeriesIDIterators(itrs...), nil
@@ -2253,8 +2255,9 @@ func (is IndexSet) matchTagValueNotEqualEmptySeriesIDIterator(name, key []byte, 
 			if err != nil {
 				SeriesIDIterators(itrs).Close()
 				return nil, err
+			} else if itr != nil {
+				itrs = append(itrs, itr)
 			}
-			itrs = append(itrs, itr)
 		}
 	}
 	return MergeSeriesIDIterators(itrs...), nil
@@ -2283,8 +2286,9 @@ func (is IndexSet) matchTagValueNotEqualNotEmptySeriesIDIterator(name, key []byt
 			if err != nil {
 				SeriesIDIterators(itrs).Close()
 				return nil, err
+			} else if itr != nil {
+				itrs = append(itrs, itr)
 			}
-			itrs = append(itrs, itr)
 		}
 	}
 


### PR DESCRIPTION
Do not add `nil` values when calling `MergeSeriesIDIterators`, which will result in a panic. A `nil` value may occur when a predicate contains regular expressions.

fixes #10171 
