### PR TITLE
WIP tsdb: Copy return value of IndexSet.MeasurementNamesByExpr

### DIFF
--- a/pkg/slices/bytes.go
+++ b/pkg/slices/bytes.go
@@ -8,3 +8,27 @@ func BytesToStrings(a [][]byte) []string {
 	}
 	return s
 }
+
+// CopyChunkedByteSlices deep-copies a [][]byte to a new [][]byte that is backed by a small number of []byte "chunks".
+func CopyChunkedByteSlices(a [][]byte, chunkSize int) [][]byte {
+	b := make([][]byte, len(a))
+	for batchBegin := 0; batchBegin < len(a); batchBegin += chunkSize {
+		batchEnd := len(a)
+		if batchEnd-batchBegin > chunkSize {
+			batchEnd = batchBegin + chunkSize
+		}
+
+		batchSize := 0
+		for j := batchBegin; j < batchEnd; j++ {
+			batchSize += len(a[j])
+		}
+		batch := make([]byte, batchSize)
+		batchOffset := 0
+		for j := batchBegin; j < batchEnd; j++ {
+			copy(batch[batchOffset:batchOffset+len(a[j])], a[j])
+			b[j] = batch[batchOffset : batchOffset+len(a[j])]
+			batchOffset += len(a[j])
+		}
+	}
+	return b
+}

--- a/pkg/slices/bytes_test.go
+++ b/pkg/slices/bytes_test.go
@@ -1,0 +1,46 @@
+package slices
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCopyChunkedByteSlices_oneChunk(t *testing.T) {
+	src := [][]byte{
+		[]byte("influx"),
+		[]byte("data"),
+	}
+
+	dst := CopyChunkedByteSlices(src, 3)
+	if !reflect.DeepEqual(src, dst) {
+		t.Errorf("destination should match source src: %v dst: %v", src, dst)
+	}
+
+	dst[0][1] = 'z'
+	if reflect.DeepEqual(src, dst) {
+		t.Error("destination should not match source")
+	}
+}
+
+func TestCopyChunkedByteSlices_multipleChunks(t *testing.T) {
+	src := [][]byte{
+		[]byte("influx"),
+		[]byte("data"),
+		[]byte("is"),
+		[]byte("the"),
+		[]byte("best"),
+		[]byte("time"),
+		[]byte("series"),
+		[]byte("database"),
+	}
+
+	dst := CopyChunkedByteSlices(src, 3)
+	if !reflect.DeepEqual(src, dst) {
+		t.Errorf("destination should match source src: %v dst: %v", src, dst)
+	}
+
+	dst[0][5] = 'z'
+	if reflect.DeepEqual(src, dst) {
+		t.Error("destination should not match source")
+	}
+}

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/bytesutil"
 	"github.com/influxdata/influxdb/pkg/estimator"
+	"github.com/influxdata/influxdb/pkg/slices"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxql"
 	"go.uber.org/zap"
@@ -1302,7 +1303,7 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.E
 			names = append(names, e)
 		}
 	}
-	return names, nil
+	return slices.CopyChunkedByteSlices(names, 1000), nil
 }
 
 func (is IndexSet) measurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {


### PR DESCRIPTION
This is a quick way to fix #10174, but the copy will cause more GC load.