### PR TITLE
pkg/snowflake: reduce contention in Next calls

### DIFF
--- a/pkg/snowflake/gen.go
+++ b/pkg/snowflake/gen.go
@@ -2,7 +2,7 @@ package snowflake
 
 import (
 	"fmt"
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -10,17 +10,17 @@ const (
 	epoch        = 1491696000000
 	serverBits   = 10
 	sequenceBits = 12
+	timeBits     = 42
 	serverShift  = sequenceBits
 	timeShift    = sequenceBits + serverBits
 	serverMax    = ^(-1 << serverBits)
 	sequenceMask = ^(-1 << sequenceBits)
+	timeMask     = ^(-1 << timeBits)
 )
 
 type Generator struct {
-	rw            sync.Mutex
-	lastTimestamp uint64
-	machineID     int
-	sequence      int32
+	state   uint64
+	machine uint64
 }
 
 func New(machineID int) *Generator {
@@ -28,38 +28,50 @@ func New(machineID int) *Generator {
 		panic(fmt.Errorf("invalid machine id; must be 0 ≤ id < %d", serverMax))
 	}
 	return &Generator{
-		machineID:     machineID,
-		lastTimestamp: 0,
-		sequence:      0,
+		state:   0,
+		machine: uint64(machineID << serverShift),
 	}
 }
 
 func (g *Generator) MachineID() int {
-	return g.machineID
+	return int(g.machine >> serverShift)
 }
 
 func (g *Generator) Next() uint64 {
-	t := now()
-	g.rw.Lock()
-	if t == g.lastTimestamp {
-		g.sequence = (g.sequence + 1) & sequenceMask
-		if g.sequence == 0 {
-			t = g.nextMillis()
+	var state uint64
+
+	// we attempt 100 times to update the millisecond part of the state
+	// and increment the sequence atomically. each attempt is approx ~30ns
+	// so we spend around ~3µs total.
+	for i := 0; i < 100; i++ {
+		t := (now() - epoch) & timeMask
+		current := atomic.LoadUint64(&g.state)
+
+		// if the timestamp is right, we just need to add 1 to the sequence
+		// stored in the lowest bits.
+		if current>>timeShift&timeMask == t {
+			state = current + 1
+		} else {
+			state = t << timeShift
 		}
-	} else if t < g.lastTimestamp {
-		t = g.nextMillis()
-	} else {
-		g.sequence = 0
+
+		if atomic.CompareAndSwapUint64(&g.state, current, state) {
+			break
+		}
+
+		state = 0
 	}
-	g.lastTimestamp = t
-	seq := g.sequence
-	g.rw.Unlock()
 
-	tp := (t - epoch) << timeShift
-	sp := uint64(g.machineID << serverShift)
-	n := tp | sp | uint64(seq)
+	// since we failed 100 times, there's high contention. bail out of the
+	// loop to bound the time we'll spend in this method, and just add
+	// one to the counter. this can cause millisecond drift, but hopefully
+	// some CAS eventually succeeds and fixes the milliseconds. giving
+	// the CAS 10 attempts helps to avoid this problem.
+	if state == 0 {
+		state = atomic.AddUint64(&g.state, 1)
+	}
 
-	return n
+	return state | g.machine
 }
 
 func (g *Generator) NextString() string {
@@ -70,15 +82,6 @@ func (g *Generator) NextString() string {
 
 func (g *Generator) AppendNext(s *[11]byte) {
 	encode(s, g.Next())
-}
-
-func (g *Generator) nextMillis() uint64 {
-	t := now()
-	for t <= g.lastTimestamp {
-		time.Sleep(100 * time.Microsecond)
-		t = now()
-	}
-	return t
 }
 
 func now() uint64 { return uint64(time.Now().UnixNano() / 1e6) }


### PR DESCRIPTION
use atomics rather than mutexes to synchronize state between calls.

```
name            old time/op  new time/op  delta
Next-8           244ns ± 0%    30ns ± 2%  -87.70%  (p=0.000 n=8+7)
NextParallel-8   215µs ±60%     0µs ± 1%  -99.96%  (p=0.000 n=8+8)
```

The results for NextParallel are around ~80ns/op, but that doesn't
show up in the benchstat output.
