### PR TITLE
httpd/meta: use open auth when unrestricted

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -475,8 +475,12 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 	}
 
 	if h.Config.AuthEnabled {
-		// The current user determines the authorized actions.
-		opts.Authorizer = user
+		if user != nil && user.AuthorizeUnrestricted() {
+			opts.Authorizer = query.OpenAuthorizer
+		} else {
+			// The current user determines the authorized actions.
+			opts.Authorizer = user
+		}
 	} else {
 		// Auth is disabled, so allow everything.
 		opts.Authorizer = query.OpenAuthorizer

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1579,6 +1579,7 @@ type UserInfo struct {
 type User interface {
 	query.Authorizer
 	ID() string
+	AuthorizeUnrestricted() bool
 }
 
 func (u *UserInfo) ID() string {
@@ -1602,6 +1603,11 @@ func (u *UserInfo) AuthorizeSeriesRead(database string, measurement []byte, tags
 // AuthorizeSeriesWrite is used to limit access per-series (enterprise only)
 func (u *UserInfo) AuthorizeSeriesWrite(database string, measurement []byte, tags models.Tags) bool {
 	return true
+}
+
+// AuthorizeUnrestricted allows admins to shortcut access checks.
+func (u *UserInfo) AuthorizeUnrestricted() bool {
+	return u.Admin
 }
 
 // clone returns a deep copy of si.


### PR DESCRIPTION
This changes adds additional auth shortcutting, primarily for enterprise
usecases with simple FGA setups. OSS users won't see any changes.