### PR TITLE
Test InfluxDB on Go 1.11rc1

### DIFF
--- a/Dockerfile_build_ubuntu64_go1.11
+++ b/Dockerfile_build_ubuntu64_go1.11
@@ -26,7 +26,7 @@ RUN gem install fpm
 ENV GOPATH /root/go
 
 # TODO(edd) this needs to be updated to 1.11 when the branch is available.
-ENV GO_VERSION 1.10.3
+ENV GO_VERSION 1.11rc1
 
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/coordinator/meta_client_test.go
+++ b/coordinator/meta_client_test.go
@@ -160,6 +160,7 @@ func (c *MetaClient) Users() []meta.UserInfo {
 func DefaultMetaClientDatabaseFn(name string) *meta.DatabaseInfo {
 	return &meta.DatabaseInfo{
 		Name: DefaultDatabase,
+
 		DefaultRetentionPolicy: DefaultRetentionPolicy,
 	}
 }

--- a/releng/_go_versions.sh
+++ b/releng/_go_versions.sh
@@ -2,4 +2,4 @@
 # This file is meant to be sourced from other scripts.
 
 export GO_CURRENT_VERSION=1.10.3
-export GO_NEXT_VERSION=1.10.3
+export GO_NEXT_VERSION=1.11rc1

--- a/services/continuous_querier/service_test.go
+++ b/services/continuous_querier/service_test.go
@@ -784,6 +784,7 @@ func (ms *MetaClient) CreateDatabase(name, defaultRetentionPolicy string) error 
 	// Create database.
 	ms.DatabaseInfos = append(ms.DatabaseInfos, meta.DatabaseInfo{
 		Name: name,
+
 		DefaultRetentionPolicy: defaultRetentionPolicy,
 	})
 

--- a/services/retention/service_test.go
+++ b/services/retention/service_test.go
@@ -71,6 +71,7 @@ func TestService_CheckShards(t *testing.T) {
 	data := []meta.DatabaseInfo{
 		{
 			Name: "db0",
+
 			DefaultRetentionPolicy: "rp0",
 			RetentionPolicies: []meta.RetentionPolicyInfo{
 				{

--- a/services/snapshotter/service_test.go
+++ b/services/snapshotter/service_test.go
@@ -25,6 +25,7 @@ var data = meta.Data{
 	Databases: []meta.DatabaseInfo{
 		{
 			Name: "db0",
+
 			DefaultRetentionPolicy: "autogen",
 			RetentionPolicies: []meta.RetentionPolicyInfo{
 				{


### PR DESCRIPTION
This test will bring Go 1.11rc1 into the CI pipeline.