### PR TITLE
Switch digests to use snappy compression

### DIFF
--- a/tsdb/engine/tsm1/digest.go
+++ b/tsdb/engine/tsm1/digest.go
@@ -142,6 +142,7 @@ func DigestFresh(dir string, files []string, shardLastMod time.Time) (bool, stri
 	if err != nil {
 		return false, fmt.Sprintf("Can't read digest: err=%s", err)
 	}
+	defer dr.Close()
 
 	mfest, err := dr.ReadManifest()
 	if err != nil {

--- a/tsdb/engine/tsm1/digest_reader.go
+++ b/tsdb/engine/tsm1/digest_reader.go
@@ -1,84 +1,73 @@
 package tsm1
 
 import (
-	"bufio"
-	"compress/gzip"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io"
+
+	"github.com/golang/snappy"
 )
 
 type DigestReader struct {
 	r  io.ReadCloser
-	gr *gzip.Reader
+	sr *snappy.Reader
 }
 
 func NewDigestReader(r io.ReadCloser) (*DigestReader, error) {
-	gr, err := gzip.NewReader(bufio.NewReader(r))
-	if err != nil {
-		return nil, err
-	}
-	return &DigestReader{r: r, gr: gr}, nil
+	return &DigestReader{r: r, sr: snappy.NewReader(r)}, nil
 }
 
-func (w *DigestReader) ReadManifest() (*DigestManifest, error) {
+func (r *DigestReader) ReadManifest() (*DigestManifest, error) {
 	var n uint32
 	// Read manifest length.
-	if err := binary.Read(w.gr, binary.BigEndian, &n); err != nil {
+	if err := binary.Read(r.sr, binary.BigEndian, &n); err != nil {
 		return nil, err
 	}
 
-	r := io.LimitReader(w.gr, int64(n))
+	lr := io.LimitReader(r.sr, int64(n))
 
 	m := &DigestManifest{}
-	return m, json.NewDecoder(r).Decode(m)
+	return m, json.NewDecoder(lr).Decode(m)
 }
 
-func (w *DigestReader) ReadTimeSpan() (string, *DigestTimeSpan, error) {
+func (r *DigestReader) ReadTimeSpan() (string, *DigestTimeSpan, error) {
 	var n uint16
-	if err := binary.Read(w.gr, binary.BigEndian, &n); err != nil {
+	if err := binary.Read(r.sr, binary.BigEndian, &n); err != nil {
 		return "", nil, err
 	}
 
 	b := make([]byte, n)
-	if _, err := io.ReadFull(w.gr, b); err != nil {
+	if _, err := io.ReadFull(r.sr, b); err != nil {
 		return "", nil, err
 	}
 
 	var cnt uint32
-	if err := binary.Read(w.gr, binary.BigEndian, &cnt); err != nil {
+	if err := binary.Read(r.sr, binary.BigEndian, &cnt); err != nil {
 		return "", nil, err
 	}
 
 	ts := &DigestTimeSpan{}
+	ts.Ranges = make([]DigestTimeRange, cnt)
 	for i := 0; i < int(cnt); i++ {
-		var min, max int64
-		var crc uint32
+		var buf [22]byte
 
-		if err := binary.Read(w.gr, binary.BigEndian, &min); err != nil {
+		n, err := io.ReadFull(r.sr, buf[:])
+		if err != nil {
 			return "", nil, err
+		} else if n != len(buf) {
+			return "", nil, fmt.Errorf("read %d bytes, expected %d, data %v", n, len(buf), buf[:n])
 		}
 
-		if err := binary.Read(w.gr, binary.BigEndian, &max); err != nil {
-			return "", nil, err
-		}
-
-		if err := binary.Read(w.gr, binary.BigEndian, &crc); err != nil {
-			return "", nil, err
-		}
-
-		if err := binary.Read(w.gr, binary.BigEndian, &n); err != nil {
-			return "", nil, err
-		}
-		ts.Add(min, max, int(n), crc)
+		ts.Ranges[i].Min = int64(binary.BigEndian.Uint64(buf[0:]))
+		ts.Ranges[i].Max = int64(binary.BigEndian.Uint64(buf[8:]))
+		ts.Ranges[i].CRC = binary.BigEndian.Uint32(buf[16:])
+		ts.Ranges[i].N = int(binary.BigEndian.Uint16(buf[20:]))
 	}
 
 	return string(b), ts, nil
 }
 
-func (w *DigestReader) Close() error {
-	if err := w.gr.Close(); err != nil {
-		return err
-	}
-	return w.r.Close()
+func (r *DigestReader) Close() error {
+	return r.r.Close()
 }

--- a/tsdb/engine/tsm1/digest_test.go
+++ b/tsdb/engine/tsm1/digest_test.go
@@ -347,7 +347,7 @@ func TestDigest_Manifest(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := df.Close(); err != nil {
+		if err := r.Close(); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
Some enterprise users with larger shards were seeing significant increases in CPU usage caused by reading shard digests. Profiling showed most of the time was spent decompressing the digest data. This PR improves performance of the shard digest writer and reader by switching from `gzip` to `snappy` compression, which is faster.

Local test with 13.2 GB shard (3.9 M series & 5.2 M time ranges):
```
gzip:   read in 4.5 seconds (80.7 MB digest)
snappy: read in 2.4 seconds (101.9 MB digest)
```