### PR TITLE
Unmap LogFile on successful open

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -50,7 +50,6 @@ type LogFile struct {
 	mu         sync.RWMutex
 	wg         sync.WaitGroup // ref count
 	id         int            // file sequence identifier
-	data       []byte         // mmap
 	file       *os.File       // writer
 	w          *bufio.Writer  // buffered writer
 	bufferSize int            // The size of the buffer used by the buffered writer
@@ -155,11 +154,11 @@ func (f *LogFile) open() error {
 	if err != nil {
 		return err
 	}
-	f.data = data
+	defer mmap.Unmap(data)
 
 	// Read log entries from mmap.
 	var n int64
-	for buf := f.data; len(buf) > 0; {
+	for buf := data; len(buf) > 0; {
 		// Read next entry. Truncate partial writes.
 		var e LogEntry
 		if err := e.UnmarshalBinary(buf); err == io.ErrShortBuffer || err == ErrLogEntryChecksumMismatch {
@@ -195,10 +194,6 @@ func (f *LogFile) Close() error {
 	if f.file != nil {
 		f.file.Close()
 		f.file = nil
-	}
-
-	if f.data != nil {
-		mmap.Unmap(f.data)
 	}
 
 	f.mms = make(logMeasurements)


### PR DESCRIPTION
Since we append to the file itself, once we have read the file in, we
can be done with the mmap'd data.

Ideally we can rework UnmarshalBinary and do away with the mmap
completely. That is future work.

For databases with lots of TSI indexes this PR could reduce RSS.