### PR TITLE
update influxql version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -113,7 +113,7 @@
     ".",
     "internal"
   ]
-  revision = "c661ab7db8ad858626cc7a2114e786f4e7463564"
+  revision = "a7267bff5327e316e54c54342b0bc9598753e3d5"
 
 [[projects]]
   branch = "master"
@@ -361,6 +361,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "37fc1dd54acc8029895612ba7f41e566b72cd868f8ea60ddf6b235d68de3f80b"
+  inputs-digest = "d29181544d590a3c8f971a777eb765e72e85007bc8ec5b37a97b785334b64ec2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[constraint]]
   name = "github.com/influxdata/influxql"
-  revision = "c661ab7db8ad858626cc7a2114e786f4e7463564"
+  revision = "a7267bff5327e316e54c54342b0bc9598753e3d5"
 
 [[constraint]]
   name = "github.com/mattn/go-isatty"


### PR DESCRIPTION
This PR updates the version of influxql to this commit https://github.com/influxdata/influxql/commit/a7267bff5327e316e54c54342b0bc9598753e3d5 . This fixes a bug where predicate expressions were getting parsed incorrectly.