### PR TITLE
Prevent DELETE FROM to rebuild series files for shards where nothing is deleted

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1616,7 +1616,14 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 
 	// Have we deleted all values for the series? If so, we need to remove
 	// the series from the index.
-	if len(seriesKeys) > 0 {
+	hasDeleted := false;
+	for _, k := range seriesKeys {
+			if len(k) > 0 {
+					hasDeleted = true
+					break
+			}
+	}
+	if hasDeleted {
 		buf := make([]byte, 1024) // For use when accessing series file.
 		ids := tsdb.NewSeriesIDSet()
 		measurements := make(map[string]struct{}, 1)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1618,10 +1618,10 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 	// the series from the index.
 	hasDeleted := false;
 	for _, k := range seriesKeys {
-			if len(k) > 0 {
-					hasDeleted = true
-					break
-			}
+		if len(k) > 0 {
+			hasDeleted = true
+			break
+		}
 	}
 	if hasDeleted {
 		buf := make([]byte, 1024) // For use when accessing series file.


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Queries such as 'DELETE FROM "measurement" WHERE time > someTime' will typically only affect a few shards. However, this causes all series indexes to be rebuilt as long as the series existed in the shard, but it did not care about the min/max time.

It looks like the existing if check was wrong because it just checked the length of the series array, but did not care about the series name that was set to empty in the loop above.

This PR should fix #10218, or at least partially.