### PR TITLE
Fix the inherited interval for derivative and others

### DIFF
--- a/query/compile.go
+++ b/query/compile.go
@@ -455,7 +455,7 @@ func (c *compiledField) compileDerivative(args []influxql.Expr, isNonNegative bo
 		}
 		return c.compileNestedExpr(arg0)
 	default:
-		if !c.global.Interval.IsZero() {
+		if !c.global.Interval.IsZero() && !c.global.InheritedInterval {
 			return fmt.Errorf("aggregate function required inside the call to %s", name)
 		}
 		return c.compileSymbol(name, arg0)
@@ -488,7 +488,7 @@ func (c *compiledField) compileElapsed(args []influxql.Expr) error {
 		}
 		return c.compileNestedExpr(arg0)
 	default:
-		if !c.global.Interval.IsZero() {
+		if !c.global.Interval.IsZero() && !c.global.InheritedInterval {
 			return fmt.Errorf("aggregate function required inside the call to elapsed")
 		}
 		return c.compileSymbol("elapsed", arg0)
@@ -514,7 +514,7 @@ func (c *compiledField) compileDifference(args []influxql.Expr, isNonNegative bo
 		}
 		return c.compileNestedExpr(arg0)
 	default:
-		if !c.global.Interval.IsZero() {
+		if !c.global.Interval.IsZero() && !c.global.InheritedInterval {
 			return fmt.Errorf("aggregate function required inside the call to %s", name)
 		}
 		return c.compileSymbol(name, arg0)
@@ -535,7 +535,7 @@ func (c *compiledField) compileCumulativeSum(args []influxql.Expr) error {
 		}
 		return c.compileNestedExpr(arg0)
 	default:
-		if !c.global.Interval.IsZero() {
+		if !c.global.Interval.IsZero() && !c.global.InheritedInterval {
 			return fmt.Errorf("aggregate function required inside the call to cumulative_sum")
 		}
 		return c.compileSymbol("cumulative_sum", arg0)
@@ -565,7 +565,7 @@ func (c *compiledField) compileMovingAverage(args []influxql.Expr) error {
 		}
 		return c.compileNestedExpr(arg0)
 	default:
-		if !c.global.Interval.IsZero() {
+		if !c.global.Interval.IsZero() && !c.global.InheritedInterval {
 			return fmt.Errorf("aggregate function required inside the call to moving_average")
 		}
 		return c.compileSymbol("moving_average", arg0)
@@ -622,7 +622,7 @@ func (c *compiledField) compileExponentialMovingAverage(name string, args []infl
 		}
 		return c.compileExpr(arg0)
 	default:
-		if !c.global.Interval.IsZero() {
+		if !c.global.Interval.IsZero() && !c.global.InheritedInterval {
 			return fmt.Errorf("aggregate function required inside the call to %s", name)
 		}
 		return c.compileSymbol(name, arg0)
@@ -663,7 +663,7 @@ func (c *compiledField) compileKaufmans(name string, args []influxql.Expr) error
 		}
 		return c.compileExpr(arg0)
 	default:
-		if !c.global.Interval.IsZero() {
+		if !c.global.Interval.IsZero() && !c.global.InheritedInterval {
 			return fmt.Errorf("aggregate function required inside the call to %s", name)
 		}
 		return c.compileSymbol(name, arg0)
@@ -717,7 +717,7 @@ func (c *compiledField) compileChandeMomentumOscillator(args []influxql.Expr) er
 		}
 		return c.compileExpr(arg0)
 	default:
-		if !c.global.Interval.IsZero() {
+		if !c.global.Interval.IsZero() && !c.global.InheritedInterval {
 			return fmt.Errorf("aggregate function required inside the call to chande_momentum_oscillator")
 		}
 		return c.compileSymbol("chande_momentum_oscillator", arg0)

--- a/query/compile_test.go
+++ b/query/compile_test.go
@@ -109,6 +109,7 @@ func TestCompile_Success(t *testing.T) {
 		`SELECT log10(value) FROM cpu`,
 		`SELECT sin(value) - sin(1.3) FROM cpu`,
 		`SELECT value FROM cpu WHERE sin(value) > 0.5`,
+		`SELECT sum("out")/sum("in") FROM (SELECT derivative("out") AS "out", derivative("in") AS "in" FROM "m0" WHERE time >= now() - 5m GROUP BY "index") GROUP BY time(1m) fill(none)`,
 	} {
 		t.Run(tt, func(t *testing.T) {
 			stmt, err := influxql.ParseStatement(tt)


### PR DESCRIPTION
The compiler was too strict. The inherited interval from an outer query
should not have caused the inner query to fail because inherited
intervals are only implicitly passed to inner queries that support group
by time functionality. Since the inner query with a derivative doesn't
support grouping by time and the inner query itself doesn't specify a
time, the outer query shouldn't have invalidated the inner query.

Backport of #10246.