### PR TITLE
Update to Go 1.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.10.3.
+InfluxDB requires Go 1.11.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -77,8 +77,8 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.10.3
-    gvm use go1.10.3 --default
+    gvm install go1.11
+    gvm use go1.11 --default
 
 Installing Dep
 -------------
@@ -279,4 +279,4 @@ Continuous Integration testing
 -----
 InfluxDB uses CircleCI for continuous integration testing. CircleCI executes [test.sh](https://github.com/influxdata/influxdb/blob/master/test.sh), so you may do the same on your local development environment before creating a pull request.
 
-The `test.sh` script executes a test suite with 5 variants (standard 64 bit, 64 bit with race detection, 32 bit, TSI, go version 1.10.3), each executes with a different arg, 0 through 4. Unless you know differently, `./test.sh 0` is probably all you need.
+The `test.sh` script executes a test suite with 5 variants (standard 64 bit, 64 bit with race detection, 32 bit, TSI, go version 1.11), each executes with a different arg, 0 through 4. Unless you know differently, `./test.sh 0` is probably all you need.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3 as builder
+FROM golang:1.11 as builder
 RUN go get -u github.com/golang/dep/...
 WORKDIR /go/src/github.com/influxdata/influxdb
 COPY Gopkg.toml Gopkg.lock ./

--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -22,7 +22,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.10.3
+ENV GO_VERSION 1.11
 ENV GO_ARCH 386
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -24,7 +24,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.10.3
+ENV GO_VERSION 1.11
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -27,7 +27,7 @@ VOLUME $PROJECT_DIR
 
 
 # Install go
-ENV GO_VERSION 1.10.3
+ENV GO_VERSION 1.11
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_jenkins_ubuntu32
+++ b/Dockerfile_jenkins_ubuntu32
@@ -9,7 +9,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 # Install go
 ENV GOPATH /go
-ENV GO_VERSION 1.10.3
+ENV GO_VERSION 1.11
 ENV GO_ARCH 386
 RUN wget --no-verbose -q https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_jenkins_ubuntu32
+++ b/Dockerfile_jenkins_ubuntu32
@@ -4,6 +4,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     wget \
     mercurial \
+    gcc \
     git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
     stage('64bit') {
       agent {
         docker {
-          image 'golang:1.10.3'
+          image 'golang:1.11'
         }
       }
 

--- a/releng/_go_versions.sh
+++ b/releng/_go_versions.sh
@@ -1,5 +1,5 @@
 # These are the current and "next" Go versions used to build influxdb.
 # This file is meant to be sourced from other scripts.
 
-export GO_CURRENT_VERSION=1.10.3
-export GO_NEXT_VERSION=1.11rc1
+export GO_CURRENT_VERSION=1.11
+export GO_NEXT_VERSION=1.11

--- a/services/httpd/response_writer_test.go
+++ b/services/httpd/response_writer_test.go
@@ -189,7 +189,7 @@ func TestResponseWriter_CSV_DifferentColumns(t *testing.T) {
 						Name:    "runtime",
 						Columns: []string{"GOARCH", "GOMAXPROCS", "GOOS", "version"},
 						Values: [][]interface{}{
-							{"amd64", int64(8), "darwin", "go1.10"},
+							{"amd64", int64(8), "darwin", "go1.11"},
 						},
 					},
 				},
@@ -201,7 +201,7 @@ func TestResponseWriter_CSV_DifferentColumns(t *testing.T) {
 network,,localhost
 
 name,tags,GOARCH,GOMAXPROCS,GOOS,version
-runtime,,amd64,8,darwin,go1.10
+runtime,,amd64,8,darwin,go1.11
 `; got != want {
 		t.Errorf("unexpected output:\n\ngot=%v\nwant=%s", got, want)
 	}

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@
 #      1: race enabled 64bit tests
 #      2: normal 32bit tests
 #      3: tsi build
-#      4: go 1.9
+#      4: go 1.11
 #      count: print the number of test environments
 #      *: to run all tests in parallel containers
 #


### PR DESCRIPTION
This PR updates the Go runtime used to build InfluxDB to Go 1.11.

We will continue to test the "next version of Go" using 1.11 until a 1.12 RC is available. We should really turn that test runner off until then but I don't know how to do that.