### PR TITLE
fix(tsm1): Fix FloatBatchDecodeAll to return empty slice an no error

### DIFF
--- a/tsdb/engine/tsm1/batch_float.go
+++ b/tsdb/engine/tsm1/batch_float.go
@@ -33,6 +33,11 @@ func FloatBatchDecodeAll(b []byte, dst []float64) ([]float64, error) {
 	// we currently just have gorilla compression.
 	br.Reset(b[1:])
 	val = br.ReadBits(64)
+	if val == uvnan {
+		// special case: there were no values to decode
+		return dst[:0], nil
+	}
+
 	dst[j] = math.Float64frombits(val)
 	j++
 

--- a/tsdb/engine/tsm1/batch_float_test.go
+++ b/tsdb/engine/tsm1/batch_float_test.go
@@ -57,6 +57,26 @@ func TestFloatBatchDecodeAll_Simple(t *testing.T) {
 	}
 }
 
+func TestFloatBatchDecodeAll_Empty(t *testing.T) {
+	s := tsm1.NewFloatEncoder()
+	s.Flush()
+
+	b, err := s.Bytes()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	buf := make([]float64, 8)
+	got, err := tsm1.FloatBatchDecodeAll(b, buf)
+	if err != nil {
+		t.Fatalf("unexpected decode error %q", err)
+	}
+
+	if exp := []float64{}; !cmp.Equal(got, exp) {
+		t.Fatalf("unexpected values -got/+exp\n%s", cmp.Diff(got, exp))
+	}
+}
+
 func TestBatchBitStreamEOF(t *testing.T) {
 	br := tsm1.NewBatchBitReader([]byte("0"))
 


### PR DESCRIPTION
FloatBatchDecodeAll behaves the same as the iterator-based float
decoder, returning an empty slice and no error when passed a buffer
with no encoded float values.

Fixes #10270