### PR TITLE
Fix bug with incorrect ABS results for negative integer values 

### DIFF
--- a/query/iterator.go
+++ b/query/iterator.go
@@ -1307,10 +1307,8 @@ func (p reverseStringSlice) Less(i, j int) bool { return p[i] > p[j] }
 func (p reverseStringSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 func abs(v int64) int64 {
-	if v < 0 {
-		return -v
-	}
-	return v
+	sign := v >> 63
+	return (v ^ sign) - sign
 }
 
 // IteratorEncoder is an encoder for encoding an iterator's points to w.

--- a/query/math.go
+++ b/query/math.go
@@ -98,7 +98,10 @@ func (v MathValuer) Call(name string, args []interface{}) (interface{}, bool) {
 			switch arg0 := arg0.(type) {
 			case float64:
 				return math.Abs(arg0), true
-			case int64, uint64:
+			case int64:
+				sign := arg0 >> 63
+				return (arg0 ^ sign) - sign, true
+			case uint64:
 				return arg0, true
 			default:
 				return nil, true

--- a/query/math_test.go
+++ b/query/math_test.go
@@ -144,7 +144,7 @@ func TestMathValuer_Call(t *testing.T) {
 		{s: `abs(f)`, values: values{"f": float64(2)}, exp: float64(2)},
 		{s: `abs(f)`, values: values{"f": float64(-2)}, exp: float64(2)},
 		{s: `abs(i)`, values: values{"i": int64(2)}, exp: int64(2)},
-		{s: `abs(i)`, values: values{"i": int64(-2)}, exp: int64(-2)},
+		{s: `abs(i)`, values: values{"i": int64(-2)}, exp: int64(2)},
 		{s: `abs(u)`, values: values{"u": uint64(2)}, exp: uint64(2)},
 		{s: `sin(f)`, values: values{"f": math.Pi / 2}, exp: math.Sin(math.Pi / 2)},
 		{s: `sin(i)`, values: values{"i": int64(2)}, exp: math.Sin(2)},

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -572,8 +572,6 @@ func zone(ts time.Time) int64 {
 }
 
 func abs(v int64) int64 {
-	if v < 0 {
-		return -v
-	}
-	return v
+	sign := v >> 63
+	return (v ^ sign) - sign
 }


### PR DESCRIPTION
Added inline bit-shift absolute value for int64 type as per:
http://cavaliercoder.com/blog/optimized-abs-for-int64-in-go.html
Updated implementations in Iterator and the continuous query service

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)