### PR TITLE
Remove TSI1 HLL sketches from heap.

### DIFF
--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -410,28 +410,32 @@ func (fs *FileSet) TagValueSeriesIDIterator(name, key, value []byte) (tsdb.Serie
 
 // MeasurementsSketches returns the merged measurement sketches for the FileSet.
 func (fs *FileSet) MeasurementsSketches() (estimator.Sketch, estimator.Sketch, error) {
-	sketch, tsketch := hll.NewDefaultPlus(), hll.NewDefaultPlus()
-
-	// Iterate over all the files and merge the sketches into the result.
+	sketch, tSketch := hll.NewDefaultPlus(), hll.NewDefaultPlus()
 	for _, f := range fs.files {
-		if err := f.MergeMeasurementsSketches(sketch, tsketch); err != nil {
+		if s, t, err := f.MeasurementsSketches(); err != nil {
+			return nil, nil, err
+		} else if err := sketch.Merge(s); err != nil {
+			return nil, nil, err
+		} else if err := tSketch.Merge(t); err != nil {
 			return nil, nil, err
 		}
 	}
-	return sketch, tsketch, nil
+	return sketch, tSketch, nil
 }
 
 // SeriesSketches returns the merged measurement sketches for the FileSet.
 func (fs *FileSet) SeriesSketches() (estimator.Sketch, estimator.Sketch, error) {
-	sketch, tsketch := hll.NewDefaultPlus(), hll.NewDefaultPlus()
-
-	// Iterate over all the files and merge the sketches into the result.
+	sketch, tSketch := hll.NewDefaultPlus(), hll.NewDefaultPlus()
 	for _, f := range fs.files {
-		if err := f.MergeSeriesSketches(sketch, tsketch); err != nil {
+		if s, t, err := f.SeriesSketches(); err != nil {
+			return nil, nil, err
+		} else if err := sketch.Merge(s); err != nil {
+			return nil, nil, err
+		} else if err := tSketch.Merge(t); err != nil {
 			return nil, nil, err
 		}
 	}
-	return sketch, tsketch, nil
+	return sketch, tSketch, nil
 }
 
 // File represents a log or index file.
@@ -458,8 +462,8 @@ type File interface {
 	TagValueSeriesIDSet(name, key, value []byte) (*tsdb.SeriesIDSet, error)
 
 	// Sketches for cardinality estimation
-	MergeMeasurementsSketches(s, t estimator.Sketch) error
-	MergeSeriesSketches(s, t estimator.Sketch) error
+	MeasurementsSketches() (s, t estimator.Sketch, err error)
+	SeriesSketches() (s, t estimator.Sketch, err error)
 
 	// Bitmap series existance.
 	SeriesIDSet() (*tsdb.SeriesIDSet, error)

--- a/tsdb/index/tsi1/index_file.go
+++ b/tsdb/index/tsi1/index_file.go
@@ -57,8 +57,8 @@ type IndexFile struct {
 	seriesIDSetData          []byte
 	tombstoneSeriesIDSetData []byte
 
-	// Series sketches
-	sketch, tSketch estimator.Sketch
+	// Series sketch data.
+	sketchData, tSketchData []byte
 
 	// Sortable identifier & filepath to the log file.
 	level int
@@ -75,9 +75,7 @@ type IndexFile struct {
 // NewIndexFile returns a new instance of IndexFile.
 func NewIndexFile(sfile *tsdb.SeriesFile) *IndexFile {
 	return &IndexFile{
-		sfile:   sfile,
-		sketch:  hll.NewDefaultPlus(),
-		tSketch: hll.NewDefaultPlus(),
+		sfile: sfile,
 	}
 }
 
@@ -99,8 +97,6 @@ func (f *IndexFile) bytes() int {
 	b += int(unsafe.Sizeof(f.mblk)) + f.mblk.bytes()
 	b += int(unsafe.Sizeof(f.seriesIDSetData) + unsafe.Sizeof(f.tombstoneSeriesIDSetData))
 	// Do not count contents of seriesIDSetData or tombstoneSeriesIDSetData: references f.data
-	b += int(unsafe.Sizeof(f.sketch)) + f.sketch.Bytes()
-	b += int(unsafe.Sizeof(f.tSketch)) + f.tSketch.Bytes()
 	b += int(unsafe.Sizeof(f.level) + unsafe.Sizeof(f.id))
 	b += 24 // mu RWMutex is 24 bytes
 	b += int(unsafe.Sizeof(f.compacting))
@@ -186,26 +182,15 @@ func (f *IndexFile) UnmarshalBinary(data []byte) error {
 	}
 
 	// Slice series sketch data.
-	buf := data[t.SeriesSketch.Offset : t.SeriesSketch.Offset+t.SeriesSketch.Size]
-	if err := f.sketch.UnmarshalBinary(buf); err != nil {
-		return err
-	}
-
-	buf = data[t.TombstoneSeriesSketch.Offset : t.TombstoneSeriesSketch.Offset+t.TombstoneSeriesSketch.Size]
-	if err := f.tSketch.UnmarshalBinary(buf); err != nil {
-		return err
-	}
+	f.sketchData = data[t.SeriesSketch.Offset : t.SeriesSketch.Offset+t.SeriesSketch.Size]
+	f.tSketchData = data[t.TombstoneSeriesSketch.Offset : t.TombstoneSeriesSketch.Offset+t.TombstoneSeriesSketch.Size]
 
 	// Slice series set data.
 	f.seriesIDSetData = data[t.SeriesIDSet.Offset : t.SeriesIDSet.Offset+t.SeriesIDSet.Size]
 	f.tombstoneSeriesIDSetData = data[t.TombstoneSeriesIDSet.Offset : t.TombstoneSeriesIDSet.Offset+t.TombstoneSeriesIDSet.Size]
 
-	// Slice measurement block data.
-	buf = data[t.MeasurementBlock.Offset:]
-	buf = buf[:t.MeasurementBlock.Size]
-
 	// Unmarshal measurement block.
-	if err := f.mblk.UnmarshalBinary(buf); err != nil {
+	if err := f.mblk.UnmarshalBinary(data[t.MeasurementBlock.Offset:][:t.MeasurementBlock.Size]); err != nil {
 		return err
 	}
 
@@ -397,22 +382,23 @@ func (f *IndexFile) MeasurementSeriesIDIterator(name []byte) tsdb.SeriesIDIterat
 	return f.mblk.SeriesIDIterator(name)
 }
 
-// MergeMeasurementsSketches merges the index file's measurements sketches into
-// the provided sketches.
-func (f *IndexFile) MergeMeasurementsSketches(s, t estimator.Sketch) error {
-	if err := s.Merge(f.mblk.sketch); err != nil {
-		return err
-	}
-	return t.Merge(f.mblk.tSketch)
+// MeasurementsSketches returns existence and tombstone sketches for measurements.
+func (f *IndexFile) MeasurementsSketches() (sketch, tSketch estimator.Sketch, err error) {
+	return f.mblk.Sketches()
 }
 
-// MergeSeriesSketches merges the index file's series sketches into the provided
-// sketches.
-func (f *IndexFile) MergeSeriesSketches(s, t estimator.Sketch) error {
-	if err := s.Merge(f.sketch); err != nil {
-		return err
+// SeriesSketches returns existence and tombstone sketches for series.
+func (f *IndexFile) SeriesSketches() (sketch, tSketch estimator.Sketch, err error) {
+	sketch = hll.NewDefaultPlus()
+	if err := sketch.UnmarshalBinary(f.sketchData); err != nil {
+		return nil, nil, err
 	}
-	return t.Merge(f.tSketch)
+
+	tSketch = hll.NewDefaultPlus()
+	if err := tSketch.UnmarshalBinary(f.tSketchData); err != nil {
+		return nil, nil, err
+	}
+	return sketch, tSketch, nil
 }
 
 // ReadIndexFileTrailer returns the index file trailer from data.

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -62,9 +62,6 @@ type LogFile struct {
 	size    int64            // tracks current file size
 	modTime time.Time        // tracks last time write occurred
 
-	mSketch, mTSketch estimator.Sketch // Measurement sketches
-	sSketch, sTSketch estimator.Sketch // Series sketche
-
 	// In-memory series existence/tombstone sets.
 	seriesIDSet, tombstoneSeriesIDSet *tsdb.SeriesIDSet
 
@@ -78,13 +75,9 @@ type LogFile struct {
 // NewLogFile returns a new instance of LogFile.
 func NewLogFile(sfile *tsdb.SeriesFile, path string) *LogFile {
 	return &LogFile{
-		sfile:    sfile,
-		path:     path,
-		mms:      make(logMeasurements),
-		mSketch:  hll.NewDefaultPlus(),
-		mTSketch: hll.NewDefaultPlus(),
-		sSketch:  hll.NewDefaultPlus(),
-		sTSketch: hll.NewDefaultPlus(),
+		sfile: sfile,
+		path:  path,
+		mms:   make(logMeasurements),
 
 		seriesIDSet:          tsdb.NewSeriesIDSet(),
 		tombstoneSeriesIDSet: tsdb.NewSeriesIDSet(),
@@ -105,10 +98,6 @@ func (f *LogFile) bytes() int {
 	// Do not count SeriesFile because it belongs to the code that constructed this Index.
 	b += int(unsafe.Sizeof(f.size))
 	b += int(unsafe.Sizeof(f.modTime))
-	b += int(unsafe.Sizeof(f.mSketch)) + f.mSketch.Bytes()
-	b += int(unsafe.Sizeof(f.mTSketch)) + f.mTSketch.Bytes()
-	b += int(unsafe.Sizeof(f.sSketch)) + f.sSketch.Bytes()
-	b += int(unsafe.Sizeof(f.sTSketch)) + f.sTSketch.Bytes()
 	b += int(unsafe.Sizeof(f.seriesIDSet)) + f.seriesIDSet.Bytes()
 	b += int(unsafe.Sizeof(f.tombstoneSeriesIDSet)) + f.tombstoneSeriesIDSet.Bytes()
 	b += int(unsafe.Sizeof(f.mms)) + f.mms.bytes()
@@ -643,9 +632,6 @@ func (f *LogFile) execDeleteMeasurementEntry(e *LogEntry) {
 	mm.tagSet = make(map[string]logTagKey)
 	mm.series = make(map[uint64]struct{})
 	mm.seriesSet = nil
-
-	// Update measurement tombstone sketch.
-	f.mTSketch.Add(e.Name)
 }
 
 func (f *LogFile) execDeleteTagKeyEntry(e *LogEntry) {
@@ -728,11 +714,9 @@ func (f *LogFile) execSeriesEntry(e *LogEntry) {
 
 	// Add/remove from appropriate series id sets.
 	if !deleted {
-		f.sSketch.Add(seriesKey) // Add series to sketch - key in series file format.
 		f.seriesIDSet.Add(e.SeriesID)
 		f.tombstoneSeriesIDSet.Remove(e.SeriesID)
 	} else {
-		f.sTSketch.Add(seriesKey) // Add series to tombstone sketch - key in series file format.
 		f.seriesIDSet.Remove(e.SeriesID)
 		f.tombstoneSeriesIDSet.Add(e.SeriesID)
 	}
@@ -776,9 +760,6 @@ func (f *LogFile) createMeasurementIfNotExists(name []byte) *logMeasurement {
 			series: make(map[uint64]struct{}),
 		}
 		f.mms[string(name)] = mm
-
-		// Add measurement to sketch.
-		f.mSketch.Add(name)
 	}
 	return mm
 }
@@ -846,13 +827,6 @@ func (f *LogFile) CompactTo(w io.Writer, m, k uint64, cancel <-chan struct{}) (n
 		return n, err
 	}
 
-	// Ensure block is word aligned.
-	// if offset := n % 8; offset != 0 {
-	// 	if err := writeTo(bw, make([]byte, 8-offset), &n); err != nil {
-	// 		return n, err
-	// 	}
-	// }
-
 	// Write measurement block.
 	t.MeasurementBlock.Offset = n
 	if err := f.writeMeasurementBlockTo(bw, names, info, &n); err != nil {
@@ -876,9 +850,15 @@ func (f *LogFile) CompactTo(w io.Writer, m, k uint64, cancel <-chan struct{}) (n
 	}
 	t.TombstoneSeriesIDSet.Size = n - t.TombstoneSeriesIDSet.Offset
 
-	// Write series sketches. TODO(edd): Implement WriterTo on HLL++.
+	// Build series sketches.
+	sSketch, sTSketch, err := f.seriesSketches()
+	if err != nil {
+		return n, err
+	}
+
+	// Write series sketches.
 	t.SeriesSketch.Offset = n
-	data, err := f.sSketch.MarshalBinary()
+	data, err := sSketch.MarshalBinary()
 	if err != nil {
 		return n, err
 	} else if _, err := bw.Write(data); err != nil {
@@ -888,7 +868,7 @@ func (f *LogFile) CompactTo(w io.Writer, m, k uint64, cancel <-chan struct{}) (n
 	n += t.SeriesSketch.Size
 
 	t.TombstoneSeriesSketch.Offset = n
-	if data, err = f.sTSketch.MarshalBinary(); err != nil {
+	if data, err = sTSketch.MarshalBinary(); err != nil {
 		return n, err
 	} else if _, err := bw.Write(data); err != nil {
 		return n, err
@@ -930,13 +910,6 @@ func (f *LogFile) writeTagsetTo(w io.Writer, name string, info *logFileCompactIn
 		return ErrCompactionInterrupted
 	default:
 	}
-
-	// Ensure block is word aligned.
-	// if offset := (*n) % 8; offset != 0 {
-	// 	if err := writeTo(w, make([]byte, 8-offset), n); err != nil {
-	// 		return err
-	// 	}
-	// }
 
 	enc := NewTagBlockEncoder(w)
 	var valueN int
@@ -1035,32 +1008,45 @@ type logFileMeasurementCompactInfo struct {
 	size   int64
 }
 
-// MergeMeasurementsSketches merges the measurement sketches belonging to this
-// LogFile into the provided sketches.
-//
-// MergeMeasurementsSketches is safe for concurrent use by multiple goroutines.
-func (f *LogFile) MergeMeasurementsSketches(sketch, tsketch estimator.Sketch) error {
+// MeasurementsSketches returns sketches for existing and tombstoned measurement names.
+func (f *LogFile) MeasurementsSketches() (sketch, tSketch estimator.Sketch, err error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
-
-	if err := sketch.Merge(f.mSketch); err != nil {
-		return err
-	}
-	return tsketch.Merge(f.mTSketch)
+	return f.measurementsSketches()
 }
 
-// MergeSeriesSketches merges the series sketches belonging to this
-// LogFile into the provided sketches.
-//
-// MergeSeriesSketches is safe for concurrent use by multiple goroutines.
-func (f *LogFile) MergeSeriesSketches(sketch, tsketch estimator.Sketch) error {
+func (f *LogFile) measurementsSketches() (sketch, tSketch estimator.Sketch, err error) {
+	sketch, tSketch = hll.NewDefaultPlus(), hll.NewDefaultPlus()
+	for _, mm := range f.mms {
+		if mm.deleted {
+			tSketch.Add(mm.name)
+		} else {
+			sketch.Add(mm.name)
+		}
+	}
+	return sketch, tSketch, nil
+}
+
+// SeriesSketches returns sketches for existing and tombstoned series.
+func (f *LogFile) SeriesSketches() (sketch, tSketch estimator.Sketch, err error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
+	return f.seriesSketches()
+}
 
-	if err := sketch.Merge(f.sSketch); err != nil {
-		return err
-	}
-	return tsketch.Merge(f.sTSketch)
+func (f *LogFile) seriesSketches() (sketch, tSketch estimator.Sketch, err error) {
+	sketch = hll.NewDefaultPlus()
+	f.seriesIDSet.ForEach(func(id uint64) {
+		name, keys := f.sfile.Series(id)
+		sketch.Add(models.MakeKey(name, keys))
+	})
+
+	tSketch = hll.NewDefaultPlus()
+	f.tombstoneSeriesIDSet.ForEach(func(id uint64) {
+		name, keys := f.sfile.Series(id)
+		sketch.Add(models.MakeKey(name, keys))
+	})
+	return sketch, tSketch, nil
 }
 
 // LogEntry represents a single log entry in the write-ahead log.

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -655,7 +655,6 @@ func (p *Partition) createSeriesListIfNotExists(names [][]byte, tagsSlice []mode
 
 	// Ensure fileset cannot change during insert.
 	p.mu.RLock()
-	// Insert series into log file.
 	if err := p.activeLogFile.AddSeriesList(p.seriesIDSet, names, tagsSlice); err != nil {
 		p.mu.RUnlock()
 		return err

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -191,6 +191,8 @@ func TestIndexSet_DedupeInmemIndexes(t *testing.T) {
 
 func TestIndex_Sketches(t *testing.T) {
 	checkCardinalities := func(t *testing.T, index *Index, state string, series, tseries, measurements, tmeasurements int) {
+		t.Helper()
+
 		// Get sketches and check cardinality...
 		sketch, tsketch, err := index.SeriesSketches()
 		if err != nil {
@@ -275,7 +277,14 @@ func TestIndex_Sketches(t *testing.T) {
 		}
 
 		// Check cardinalities after the delete
-		checkCardinalities(t, idx, "initial|reopen|delete", 2430, 486, 10, 2)
+		switch idx.Index.(type) {
+		case *tsi1.Index:
+			checkCardinalities(t, idx, "initial|reopen|delete", 2923, 0, 10, 2)
+		case *inmem.ShardIndex:
+			checkCardinalities(t, idx, "initial|reopen|delete", 2430, 486, 10, 2)
+		default:
+			panic("unreachable")
+		}
 
 		// Re-open step only applies to the TSI index.
 		if _, ok := idx.Index.(*tsi1.Index); ok {
@@ -285,7 +294,7 @@ func TestIndex_Sketches(t *testing.T) {
 			}
 
 			// Check cardinalities after the reopen
-			checkCardinalities(t, idx, "initial|reopen|delete|reopen", 2430, 486, 10, 2)
+			checkCardinalities(t, idx, "initial|reopen|delete|reopen", 2923, 0, 10, 2)
 		}
 		return nil
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -1040,8 +1040,14 @@ func TestStore_Sketches(t *testing.T) {
 			}
 		}
 
+		// Check cardinalities. In this case, the indexes behave differently.
+		expS, expTS, expM, expTM := 160, 0, 10, 5
+		if index == inmem.IndexName {
+			expS, expTS, expM, expTM = 160, 80, 10, 5
+		}
+
 		// Check cardinalities - tombstones should be in
-		if err := checkCardinalities(store.Store, 160, 80, 10, 5); err != nil {
+		if err := checkCardinalities(store.Store, expS, expTS, expM, expTM); err != nil {
 			return fmt.Errorf("[initial|re-open|delete] %v", err)
 		}
 
@@ -1051,12 +1057,7 @@ func TestStore_Sketches(t *testing.T) {
 		}
 
 		// Check cardinalities. In this case, the indexes behave differently.
-		//
-		// - The inmem index will report that there are 80 series and no tombstones.
-		// - The tsi1 index will report that there are 160 series and 80 tombstones.
-		//
-		// The result is the same, but the implementation differs.
-		expS, expTS, expM, expTM := 160, 80, 10, 5
+		expS, expTS, expM, expTM = 160, 0, 5, 5
 		if index == inmem.IndexName {
 			expS, expTS, expM, expTM = 80, 0, 5, 0
 		}


### PR DESCRIPTION
## Overview

This commit removes the HLL sketches on each `tsi1.LogFile` and `tsi1.IndexFile` and instead caches the data at the `tsi1.Index` level. This reduces the heap size significantly for servers with many TSI-enabled shards.

Tests using `inch` showed a reduction from `~900MB` to `~200MB` for a `638` shard server with this change. The reduction is larger if there are more compacted index files in each shard.