### PR TITLE
Fix TSM1 panic on reader error.

### DIFF
--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -547,6 +547,8 @@ func (f *FileStore) Open() error {
 					readerC <- &res{r: df, err: fmt.Errorf("cannot rename corrupt file %s: %v", file.Name(), e)}
 					return
 				}
+				readerC <- &res{r: df, err: fmt.Errorf("cannot read corrupt file %s: %v", file.Name(), err)}
+				return
 			}
 
 			df.WithObserver(f.obs)


### PR DESCRIPTION
This commit fixes an error check so that a `nil` TSM reader does
not cause a panic. Fixes #10244.