### PR TITLE
fix(storage): Set the Type field to Tag

### DIFF
--- a/services/storage/predicate_influxql.go
+++ b/services/storage/predicate_influxql.go
@@ -139,7 +139,7 @@ func (v *nodeToExprVisitor) Visit(n *Node) NodeVisitor {
 			}
 		}
 
-		v.exprs = append(v.exprs, &influxql.VarRef{Val: ref})
+		v.exprs = append(v.exprs, &influxql.VarRef{Val: ref, Type: influxql.Tag})
 		return nil
 
 	case NodeTypeFieldRef:


### PR DESCRIPTION
Transforming an RPC predicate to InfluxQL should set the Type field to Tag, as it is explicitly set as a NodeTypeTagRef in the protobuf predicate