### PR TITLE
Backup continue on errors

### DIFF
--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -382,6 +382,7 @@ func (cmd *Command) backupResponsePaths(response *snapshotter.Response) error {
 		err = cmd.backupShard(db, rp, id)
 
 		if err != nil && !cmd.continueOnError {
+			cmd.StderrLogger.Printf("error (%s) when backing up db: %s, rp %s, shard %s. continuing backup on remaining shards", err, db, rp, id )
 			return err
 		}
 	}

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -619,7 +619,7 @@ Usage: influxd backup [options] PATH
             Create an incremental backup of all points after the timestamp (RFC3339 format). Optional. 
             Recommend using '-start <timestamp>' instead.
     -skip-errors 
-            optional flag to continue backing up the remaining shards when the current shard fails to backup. 
+            Optional flag to continue backing up the remaining shards when the current shard fails to backup. 
 `)
 
 }

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -58,6 +58,7 @@ type Command struct {
 	portable         bool
 	manifest         backup_util.Manifest
 	portableFileBase string
+	continueOnError  bool
 
 	BackupFiles []string
 }
@@ -157,6 +158,7 @@ func (cmd *Command) parseFlags(args []string) (err error) {
 	fs.StringVar(&startArg, "start", "", "")
 	fs.StringVar(&endArg, "end", "", "")
 	fs.BoolVar(&cmd.portable, "portable", false, "")
+	fs.BoolVar(&cmd.continueOnError, "skip-errors", false, "")
 
 	fs.SetOutput(cmd.Stderr)
 	fs.Usage = cmd.printUsage
@@ -251,12 +253,12 @@ func (cmd *Command) backupShard(db, rp, sid string) error {
 
 	// TODO: verify shard backup data
 	err = cmd.downloadAndVerify(req, shardArchivePath, nil)
+	if err != nil {
+		os.Remove(shardArchivePath)
+		return err
+	}
 	if !cmd.portable {
 		cmd.BackupFiles = append(cmd.BackupFiles, shardArchivePath)
-	}
-
-	if err != nil {
-		return err
 	}
 
 	if cmd.portable {
@@ -379,7 +381,7 @@ func (cmd *Command) backupResponsePaths(response *snapshotter.Response) error {
 
 		err = cmd.backupShard(db, rp, id)
 
-		if err != nil {
+		if err != nil && !cmd.continueOnError {
 			return err
 		}
 	}
@@ -615,6 +617,8 @@ Usage: influxd backup [options] PATH
     -since <2015-12-24T08:12:23Z>
             Create an incremental backup of all points after the timestamp (RFC3339 format). Optional. 
             Recommend using '-start <timestamp>' instead.
+    -skip-errors 
+            optional flag to continue backing up the remaining shards when the current shard fails to backup. 
 `)
 
 }

--- a/cmd/influxd/backup/backup.go
+++ b/cmd/influxd/backup/backup.go
@@ -382,7 +382,7 @@ func (cmd *Command) backupResponsePaths(response *snapshotter.Response) error {
 		err = cmd.backupShard(db, rp, id)
 
 		if err != nil && !cmd.continueOnError {
-			cmd.StderrLogger.Printf("error (%s) when backing up db: %s, rp %s, shard %s. continuing backup on remaining shards", err, db, rp, id )
+			cmd.StderrLogger.Printf("error (%s) when backing up db: %s, rp %s, shard %s. continuing backup on remaining shards", err, db, rp, id)
 			return err
 		}
 	}

--- a/man/influxd-backup.txt
+++ b/man/influxd-backup.txt
@@ -3,7 +3,7 @@ influxd-backup(1)
 
 NAME
 ----
-influxd-backup - Creates a backup copy of specified InfluxDB OSS database(s) and saves to disk. Use this newer `-portable` option 
+influxd-backup - Creates a backup copy of specified InfluxDB OSS database(s) and saves to disk. Use this newer `-portable` option
   unless legacy support is required. Complete documentation on backing up and restoring, including the deprecated
   legacy format, see:
     https://docs.influxdata.com/influxdb/latest/administration/backup_and_restore/
@@ -16,7 +16,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Creates a backup copy of specified InfluxDB OSS database(s) and saves the files in an Enterprise-compatible
-format to PATH (directory where backups are saved).  
+format to PATH (directory where backups are saved).
 
 OPTIONS
 -------
@@ -43,6 +43,9 @@ OPTIONS
 
 -since <timestamp>::
   Create an incremental backup of all points after the timestamp (RFC3339 format). Optional. Recommend using '-start <timestamp>' instead.
+
+-skip-errors::
+  Optional flag to continue backing up the remaining shards when the current shard fails to backup.
 
 SEE ALSO
 --------


### PR DESCRIPTION
there are some edge cases where a shard backup fails on a live backup if it is deleted by a retention policy 
after the shard is identified, but before the download starts.  This fix allows the backup process to continue, even with failures so that empty/deleted shards are ignored.  

Adds a new flag : 
`# influxd backup -portable -skip-errors -db telegraf /tmp/backup`

if skip-errors is set, then errors will be skipped as described above.  The default for skip-errors is false, maintaining backward compatability.  

docs PR:  https://github.com/influxdata/docs.influxdata.com/pull/1844