### PR TITLE
Changes /ping route to return status code 200 instead of 204 when verbose is set

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -817,8 +817,16 @@ func (h *Handler) serveOptions(w http.ResponseWriter, r *http.Request) {
 
 // servePing returns a simple response to let the client know the server is running.
 func (h *Handler) servePing(w http.ResponseWriter, r *http.Request) {
+	verbose := r.URL.Query().Get("verbose")
 	atomic.AddInt64(&h.stats.PingRequests, 1)
-	h.writeHeader(w, http.StatusNoContent)
+
+	if verbose != "" && verbose != "0" && verbose != "false" {
+		h.writeHeader(w, http.StatusOK)
+		b, _ := json.Marshal(map[string]string{"version": h.Version})
+		w.Write(b)
+	} else {
+		h.writeHeader(w, http.StatusNoContent)
+	}
 }
 
 // serveStatus has been deprecated.


### PR DESCRIPTION
Closes #9772

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)