### PR TITLE
Fix append of possible nil iterator.

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -343,7 +343,9 @@ func (f *LogFile) TagKeySeriesIDIterator(name, key []byte) tsdb.SeriesIDIterator
 		if tv.cardinality() == 0 {
 			continue
 		}
-		itrs = append(itrs, tsdb.NewSeriesIDSetIterator(tv.seriesIDSet()))
+		if itr := tsdb.NewSeriesIDSetIterator(tv.seriesIDSet()); itr != nil {
+			itrs = append(itrs, itr)
+		}
 	}
 
 	return tsdb.MergeSeriesIDIterators(itrs...)


### PR DESCRIPTION
This commit updates an iterator list to ignore `nil` iterators.
Adding a `nil` caused the `SeriesIterators.Close()` to panic.

