### PR TITLE
Add platform constant

### DIFF
--- a/platform/platform.go
+++ b/platform/platform.go
@@ -1,0 +1,3 @@
+package platform
+
+const OopsArentOnTheInfluxdbPlatformBranch = 0


### PR DESCRIPTION
This can help us make sure that consumers that want the platform branch can ensure they are on the platform branch.