### PR TITLE
Fix measurement/field filtering for flux queries

### DIFF
--- a/services/storage/predicate_influxql.go
+++ b/services/storage/predicate_influxql.go
@@ -2,7 +2,11 @@ package storage
 
 import "github.com/influxdata/influxql"
 
-var measurementRemap = map[string]string{"_measurement": "_name"}
+var measurementRemap = map[string]string{
+	"_measurement": "_name",
+	"_m":           "_name",
+	"_f":           "_field",
+}
 
 func RewriteExprRemoveFieldKeyAndValue(expr influxql.Expr) influxql.Expr {
 	return influxql.RewriteExpr(expr, func(expr influxql.Expr) influxql.Expr {


### PR DESCRIPTION
We rewrite queries for `_measurement` to `_name`, but we didn't also
rewrite `_m`. During some of the code sharing, it started being the
case that it received `_m` instead of `_measurement`. Additionally,
we need to start mapping `_f` to `_field` for the same reason.
