### PR TITLE
Add shards' index types to /debug/vars

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -264,6 +264,13 @@ func (s *Shard) Statistics(tags map[string]string) []models.Statistic {
 	seriesN := engine.SeriesN()
 
 	tags = s.defaultTags.Merge(tags)
+
+	// Set the index type on the tags.  N.B this needs to be checked since it's
+	// only set when the shard is opened.
+	if indexType := s.IndexType(); indexType != "" {
+		tags["indexType"] = indexType
+	}
+
 	statistics := []models.Statistic{{
 		Name: "shard",
 		Tags: tags,


### PR DESCRIPTION
This commit adds an `indexType` key to the shard sections of the
`/debug/vars` endpoint, as well as the `_internal` shard statistics.

The tag will be reported as `"indexType": "inmem"` or `"indexType":
"tsi1"`.

Note, this will increase the cardinality of the `_internal` database.