### PR TITLE
Fixes #9645: wrong result after gap in data for integral()

### DIFF
--- a/query/functions.go
+++ b/query/functions.go
@@ -1605,6 +1605,7 @@ func (r *FloatIntegralReducer) AggregateFloat(p *FloatPoint) {
 			r.window.end, r.window.start = r.opt.Window(p.Time)
 		}
 		r.sum = 0.0
+		r.prev = *p
 	}
 
 	// Normal operation: update the sum using the trapezium rule


### PR DESCRIPTION
This fixes a bug for integral() when interpolating data after a gap in data. The commit simply sets the previous point correctly. 