### PR TITLE
Remove sfile argument from IndexSet.TagSets

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2372,7 +2372,7 @@ func (e *Engine) createCallIterator(ctx context.Context, measurement string, cal
 		tagSets, err = ts.TagSets([]byte(measurement), opt)
 	} else {
 		indexSet := tsdb.IndexSet{Indexes: []tsdb.Index{e.index}, SeriesFile: e.sfile}
-		tagSets, err = indexSet.TagSets(e.sfile, []byte(measurement), opt)
+		tagSets, err = indexSet.TagSets([]byte(measurement), opt)
 	}
 
 	if err != nil {
@@ -2452,7 +2452,7 @@ func (e *Engine) createVarRefIterator(ctx context.Context, measurement string, o
 		tagSets, err = ts.TagSets([]byte(measurement), opt)
 	} else {
 		indexSet := tsdb.IndexSet{Indexes: []tsdb.Index{e.index}, SeriesFile: e.sfile}
-		tagSets, err = indexSet.TagSets(e.sfile, []byte(measurement), opt)
+		tagSets, err = indexSet.TagSets([]byte(measurement), opt)
 	}
 
 	if err != nil {
@@ -2916,7 +2916,7 @@ func (e *Engine) IteratorCost(measurement string, opt query.IteratorOptions) (qu
 
 	// Determine all of the tag sets for this query.
 	indexSet := tsdb.IndexSet{Indexes: []tsdb.Index{e.index}, SeriesFile: e.sfile}
-	tagSets, err := indexSet.TagSets(e.sfile, []byte(measurement), opt)
+	tagSets, err := indexSet.TagSets([]byte(measurement), opt)
 	if err != nil {
 		return query.IteratorCost{}, err
 	}

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -2531,7 +2531,7 @@ func (is IndexSet) MeasurementTagKeyValuesByExpr(auth query.Authorizer, name []b
 
 // TagSets returns an ordered list of tag sets for a measurement by dimension
 // and filtered by an optional conditional expression.
-func (is IndexSet) TagSets(sfile *SeriesFile, name []byte, opt query.IteratorOptions) ([]*query.TagSet, error) {
+func (is IndexSet) TagSets(name []byte, opt query.IteratorOptions) ([]*query.TagSet, error) {
 	release := is.SeriesFile.Retain()
 	defer release()
 
@@ -2582,7 +2582,7 @@ func (is IndexSet) TagSets(sfile *SeriesFile, name []byte, opt query.IteratorOpt
 		}
 
 		// Skip if the series has been tombstoned.
-		key := sfile.SeriesKey(se.SeriesID)
+		key := is.SeriesFile.SeriesKey(se.SeriesID)
 		if len(key) == 0 {
 			continue
 		}

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -523,7 +523,7 @@ func BenchmarkIndexSet_TagSets(b *testing.B) {
 				}
 			} else {
 				ts = func() ([]*query.TagSet, error) {
-					return indexSet.TagSets(idx.sfile, name, opt)
+					return indexSet.TagSets(name, opt)
 				}
 			}
 


### PR DESCRIPTION
In TagSets method IndexSet retain IndexSet.SeriesFile but query series key from the input SeriesFile.
IndexSet should retain and query the same SeriesFile.

###### Required for all non-trivial PRs
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [ ] [InfluxQL Spec](https://github.com/influxdata/influxdb/blob/master/influxql/README.md) updated
- [ ] Provide example syntax
- [ ] Update man page when modifying a command
- [ ] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>
