### PR TITLE
reuse ValuerEval objects

### DIFF
--- a/tsdb/engine/tsm1/iterator.gen.go
+++ b/tsdb/engine/tsm1/iterator.gen.go
@@ -196,6 +196,7 @@ type floatIterator struct {
 	statsLock sync.Mutex
 	stats     query.IteratorStats
 	statsBuf  query.IteratorStats
+	valuer    influxql.ValuerEval
 }
 
 func newFloatIterator(name string, tags query.Tags, opt query.IteratorOptions, cur floatCursor, aux []cursorAt, conds []cursorAt, condNames []string) *floatIterator {
@@ -222,6 +223,13 @@ func newFloatIterator(name string, tags query.Tags, opt query.IteratorOptions, c
 	}
 	itr.conds.names = condNames
 	itr.conds.curs = conds
+
+	itr.valuer = influxql.ValuerEval{
+		Valuer: influxql.MultiValuer(
+			query.MathValuer{},
+			influxql.MapValuer(itr.m),
+		),
+	}
 
 	return itr
 }
@@ -270,13 +278,7 @@ func (itr *floatIterator) Next() (*query.FloatPoint, error) {
 		}
 
 		// Evaluate condition, if one exists. Retry if it fails.
-		valuer := influxql.ValuerEval{
-			Valuer: influxql.MultiValuer(
-				query.MathValuer{},
-				influxql.MapValuer(itr.m),
-			),
-		}
-		if itr.opt.Condition != nil && !valuer.EvalBool(itr.opt.Condition) {
+		if itr.opt.Condition != nil && !itr.valuer.EvalBool(itr.opt.Condition) {
 			continue
 		}
 
@@ -674,6 +676,7 @@ type integerIterator struct {
 	statsLock sync.Mutex
 	stats     query.IteratorStats
 	statsBuf  query.IteratorStats
+	valuer    influxql.ValuerEval
 }
 
 func newIntegerIterator(name string, tags query.Tags, opt query.IteratorOptions, cur integerCursor, aux []cursorAt, conds []cursorAt, condNames []string) *integerIterator {
@@ -700,6 +703,13 @@ func newIntegerIterator(name string, tags query.Tags, opt query.IteratorOptions,
 	}
 	itr.conds.names = condNames
 	itr.conds.curs = conds
+
+	itr.valuer = influxql.ValuerEval{
+		Valuer: influxql.MultiValuer(
+			query.MathValuer{},
+			influxql.MapValuer(itr.m),
+		),
+	}
 
 	return itr
 }
@@ -748,13 +758,7 @@ func (itr *integerIterator) Next() (*query.IntegerPoint, error) {
 		}
 
 		// Evaluate condition, if one exists. Retry if it fails.
-		valuer := influxql.ValuerEval{
-			Valuer: influxql.MultiValuer(
-				query.MathValuer{},
-				influxql.MapValuer(itr.m),
-			),
-		}
-		if itr.opt.Condition != nil && !valuer.EvalBool(itr.opt.Condition) {
+		if itr.opt.Condition != nil && !itr.valuer.EvalBool(itr.opt.Condition) {
 			continue
 		}
 
@@ -1152,6 +1156,7 @@ type unsignedIterator struct {
 	statsLock sync.Mutex
 	stats     query.IteratorStats
 	statsBuf  query.IteratorStats
+	valuer    influxql.ValuerEval
 }
 
 func newUnsignedIterator(name string, tags query.Tags, opt query.IteratorOptions, cur unsignedCursor, aux []cursorAt, conds []cursorAt, condNames []string) *unsignedIterator {
@@ -1178,6 +1183,13 @@ func newUnsignedIterator(name string, tags query.Tags, opt query.IteratorOptions
 	}
 	itr.conds.names = condNames
 	itr.conds.curs = conds
+
+	itr.valuer = influxql.ValuerEval{
+		Valuer: influxql.MultiValuer(
+			query.MathValuer{},
+			influxql.MapValuer(itr.m),
+		),
+	}
 
 	return itr
 }
@@ -1226,13 +1238,7 @@ func (itr *unsignedIterator) Next() (*query.UnsignedPoint, error) {
 		}
 
 		// Evaluate condition, if one exists. Retry if it fails.
-		valuer := influxql.ValuerEval{
-			Valuer: influxql.MultiValuer(
-				query.MathValuer{},
-				influxql.MapValuer(itr.m),
-			),
-		}
-		if itr.opt.Condition != nil && !valuer.EvalBool(itr.opt.Condition) {
+		if itr.opt.Condition != nil && !itr.valuer.EvalBool(itr.opt.Condition) {
 			continue
 		}
 
@@ -1630,6 +1636,7 @@ type stringIterator struct {
 	statsLock sync.Mutex
 	stats     query.IteratorStats
 	statsBuf  query.IteratorStats
+	valuer    influxql.ValuerEval
 }
 
 func newStringIterator(name string, tags query.Tags, opt query.IteratorOptions, cur stringCursor, aux []cursorAt, conds []cursorAt, condNames []string) *stringIterator {
@@ -1656,6 +1663,13 @@ func newStringIterator(name string, tags query.Tags, opt query.IteratorOptions, 
 	}
 	itr.conds.names = condNames
 	itr.conds.curs = conds
+
+	itr.valuer = influxql.ValuerEval{
+		Valuer: influxql.MultiValuer(
+			query.MathValuer{},
+			influxql.MapValuer(itr.m),
+		),
+	}
 
 	return itr
 }
@@ -1704,13 +1718,7 @@ func (itr *stringIterator) Next() (*query.StringPoint, error) {
 		}
 
 		// Evaluate condition, if one exists. Retry if it fails.
-		valuer := influxql.ValuerEval{
-			Valuer: influxql.MultiValuer(
-				query.MathValuer{},
-				influxql.MapValuer(itr.m),
-			),
-		}
-		if itr.opt.Condition != nil && !valuer.EvalBool(itr.opt.Condition) {
+		if itr.opt.Condition != nil && !itr.valuer.EvalBool(itr.opt.Condition) {
 			continue
 		}
 
@@ -2108,6 +2116,7 @@ type booleanIterator struct {
 	statsLock sync.Mutex
 	stats     query.IteratorStats
 	statsBuf  query.IteratorStats
+	valuer    influxql.ValuerEval
 }
 
 func newBooleanIterator(name string, tags query.Tags, opt query.IteratorOptions, cur booleanCursor, aux []cursorAt, conds []cursorAt, condNames []string) *booleanIterator {
@@ -2134,6 +2143,13 @@ func newBooleanIterator(name string, tags query.Tags, opt query.IteratorOptions,
 	}
 	itr.conds.names = condNames
 	itr.conds.curs = conds
+
+	itr.valuer = influxql.ValuerEval{
+		Valuer: influxql.MultiValuer(
+			query.MathValuer{},
+			influxql.MapValuer(itr.m),
+		),
+	}
 
 	return itr
 }
@@ -2182,13 +2198,7 @@ func (itr *booleanIterator) Next() (*query.BooleanPoint, error) {
 		}
 
 		// Evaluate condition, if one exists. Retry if it fails.
-		valuer := influxql.ValuerEval{
-			Valuer: influxql.MultiValuer(
-				query.MathValuer{},
-				influxql.MapValuer(itr.m),
-			),
-		}
-		if itr.opt.Condition != nil && !valuer.EvalBool(itr.opt.Condition) {
+		if itr.opt.Condition != nil && !itr.valuer.EvalBool(itr.opt.Condition) {
 			continue
 		}
 

--- a/tsdb/engine/tsm1/iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/iterator.gen.go.tmpl
@@ -194,6 +194,7 @@ type {{.name}}Iterator struct {
 	statsLock sync.Mutex
 	stats     query.IteratorStats
 	statsBuf  query.IteratorStats
+	valuer    influxql.ValuerEval
 }
 
 func new{{.Name}}Iterator(name string, tags query.Tags, opt query.IteratorOptions, cur {{.name}}Cursor, aux []cursorAt, conds []cursorAt, condNames []string) *{{.name}}Iterator {
@@ -220,6 +221,13 @@ func new{{.Name}}Iterator(name string, tags query.Tags, opt query.IteratorOption
 	}
 	itr.conds.names = condNames
 	itr.conds.curs = conds
+
+	itr.valuer = influxql.ValuerEval{
+		Valuer: influxql.MultiValuer(
+			query.MathValuer{},
+			influxql.MapValuer(itr.m),
+		),
+	}
 
 	return itr
 }
@@ -268,13 +276,7 @@ func (itr *{{.name}}Iterator) Next() (*query.{{.Name}}Point, error) {
 		}
 
 		// Evaluate condition, if one exists. Retry if it fails.
-		valuer := influxql.ValuerEval{
-			Valuer: influxql.MultiValuer(
-				query.MathValuer{},
-				influxql.MapValuer(itr.m),
-			),
-		}
-		if itr.opt.Condition != nil && !valuer.EvalBool(itr.opt.Condition) {
+		if itr.opt.Condition != nil && !itr.valuer.EvalBool(itr.opt.Condition) {
 			continue
 		}
 


### PR DESCRIPTION
Scanner objects and iterators often need a ValuerEval. This
object is created, often with a function call, and has at
least one interface in it, so it allocates storage. Then it's
dropped again right away. The only part of it that might be
subject to change is usually a map. While the map's contents
change over time, the actual map doesn't change for the
lifetime of the object.

So, in both iterators and scanners, stash the ValuerEval
and continue reusing it. On a query returning a fair number
of data points, this produces a small (<5% in practice)
improvement in observed performance, visible as a significant
reduction in time spent in runtime (mallocgc, newobject,
etcetera).

The performance improvement isn't big, but it's reasonably
easy to evaluate it and establish that it's a safe change
to make.

Signed-off-by: seebs <seebs@seebs.net>

###### Required for all non-trivial PRs
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
[none apply]

Notes:
* I didn't create an issue for this, but it's a side-effect of getting curious about query-response performance and wanting to do science.
* This is mostly a thing I'm messing with in order to learn my way around the code because I had thoughts about possibly trying to reduce the number of `interface{}` being slung around.
* The performance difference is pretty small, but it is more noticeable if you use msgpack. Still pretty small.
