### PR TITLE
fix(tsdb): copy measurement names when expression is provided

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -1296,7 +1296,11 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.E
 
 	// Return filtered list if expression exists.
 	if expr != nil {
-		return is.measurementNamesByExpr(auth, expr)
+		names, err := is.measurementNamesByExpr(auth, expr)
+		if err != nil {
+			return nil, err
+		}
+		return slices.CopyChunkedByteSlices(names, 1000), nil
 	}
 
 	itr, err := is.measurementIterator()


### PR DESCRIPTION
We already make copies when no expression is provided, because
the backing slices may go away if the shard they came from is
closed. This fixes the other spot where some backing slices
would be returned.
