### PR TITLE
Fix panic in IndexSet

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -24,6 +24,9 @@ const (
 	TSI1IndexName  = "tsi1"
 )
 
+// ErrIndexClosing can be returned to from an Index method if the index is currently closing.
+var ErrIndexClosing = errors.New("index is closing")
+
 type Index interface {
 	Open() error
 	Close() error

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -427,7 +427,7 @@ func (p *Partition) FieldSet() *tsdb.MeasurementFieldSet {
 func (p *Partition) RetainFileSet() (*FileSet, error) {
 	select {
 	case <-p.closing:
-		return nil, errors.New("index is closing")
+		return nil, tsdb.ErrIndexClosing
 	default:
 		p.mu.RLock()
 		defer p.mu.RUnlock()

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -424,7 +424,9 @@ func (s *Shard) Index() (Index, error) {
 	return s.index, nil
 }
 
-func (s *Shard) seriesFile() (*SeriesFile, error) {
+// SeriesFile returns a reference the underlying series file. If return an error
+// if the series file is nil.
+func (s *Shard) SeriesFile() (*SeriesFile, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if err := s.ready(); err != nil {
@@ -1339,7 +1341,7 @@ func (a Shards) createSeriesIterator(ctx context.Context, opt query.IteratorOpti
 			idxs = append(idxs, idx)
 		}
 		if sfile == nil {
-			sfile, _ = sh.seriesFile()
+			sfile, _ = sh.SeriesFile()
 		}
 	}
 
@@ -1412,7 +1414,7 @@ func (a Shards) CreateSeriesCursor(ctx context.Context, req SeriesCursorRequest,
 			idxs = append(idxs, idx)
 		}
 		if sfile == nil {
-			sfile, _ = sh.seriesFile()
+			sfile, _ = sh.SeriesFile()
 		}
 	}
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1404,10 +1404,20 @@ func (s *Store) TagKeys(auth query.Authorizer, shardIDs []uint64, cond influxql.
 		}
 
 		if is.SeriesFile == nil {
-			is.SeriesFile = shard.sfile
+			sfile, err := shard.SeriesFile()
+			if err != nil {
+				s.mu.RUnlock()
+				return nil, err
+			}
+			is.SeriesFile = sfile
 		}
 
-		is.Indexes = append(is.Indexes, shard.index)
+		index, err := shard.Index()
+		if err != nil {
+			s.mu.RUnlock()
+			return nil, err
+		}
+		is.Indexes = append(is.Indexes, index)
 	}
 	s.mu.RUnlock()
 
@@ -1560,9 +1570,21 @@ func (s *Store) TagValues(auth query.Authorizer, shardIDs []uint64, cond influxq
 		}
 
 		if is.SeriesFile == nil {
-			is.SeriesFile = shard.sfile
+			sfile, err := shard.SeriesFile()
+			if err != nil {
+				s.mu.RUnlock()
+				return nil, err
+			}
+			is.SeriesFile = sfile
 		}
-		is.Indexes = append(is.Indexes, shard.index)
+
+		index, err := shard.Index()
+		if err != nil {
+			s.mu.RUnlock()
+			return nil, err
+		}
+
+		is.Indexes = append(is.Indexes, index)
 	}
 	s.mu.RUnlock()
 	is = is.DedupeInmemIndexes()


### PR DESCRIPTION
This PR fixes a panic where a concurrent removal of a shard and meta query could cause a `nil` index to be added to the IndexSet`.

