### PR TITLE
fix(tsdb): copy measurement names when expression is provided

### DIFF
--- a/pkg/slices/bytes.go
+++ b/pkg/slices/bytes.go
@@ -8,3 +8,30 @@ func BytesToStrings(a [][]byte) []string {
 	}
 	return s
 }
+
+// CopyChunkedByteSlices deep-copies a [][]byte to a new [][]byte that is backed by a small number of []byte "chunks".
+func CopyChunkedByteSlices(src [][]byte, chunkSize int) [][]byte {
+	dst := make([][]byte, len(src))
+
+	for chunkBegin := 0; chunkBegin < len(src); chunkBegin += chunkSize {
+		chunkEnd := len(src)
+		if chunkEnd-chunkBegin > chunkSize {
+			chunkEnd = chunkBegin + chunkSize
+		}
+
+		chunkByteSize := 0
+		for j := chunkBegin; j < chunkEnd; j++ {
+			chunkByteSize += len(src[j])
+		}
+
+		chunk := make([]byte, chunkByteSize)
+		offset := 0
+		for j := chunkBegin; j < chunkEnd; j++ {
+			copy(chunk[offset:offset+len(src[j])], src[j])
+			dst[j] = chunk[offset : offset+len(src[j]) : offset+len(src[j])]
+			offset += len(src[j])
+		}
+	}
+
+	return dst
+}

--- a/pkg/slices/bytes_test.go
+++ b/pkg/slices/bytes_test.go
@@ -1,0 +1,78 @@
+package slices
+
+import (
+	"math"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+func TestCopyChunkedByteSlices_oneChunk(t *testing.T) {
+	src := [][]byte{
+		[]byte("influx"),
+		[]byte("data"),
+	}
+
+	dst := CopyChunkedByteSlices(src, 3)
+	if !reflect.DeepEqual(src, dst) {
+		t.Errorf("destination should match source src: %v dst: %v", src, dst)
+	}
+
+	dst[0][1] = 'z'
+	if reflect.DeepEqual(src, dst) {
+		t.Error("destination should not match source")
+	}
+}
+
+func TestCopyChunkedByteSlices_multipleChunks(t *testing.T) {
+	src := [][]byte{
+		[]byte("influx"),
+		[]byte("data"),
+		[]byte("is"),
+		[]byte("the"),
+		[]byte("best"),
+		[]byte("time"),
+		[]byte("series"),
+		[]byte("database"),
+		[]byte("in"),
+		[]byte("the"),
+		[]byte("whole"),
+		[]byte("wide"),
+		[]byte("world"),
+		[]byte(":-)"),
+	}
+
+	chunkSize := 4
+	dst := CopyChunkedByteSlices(src, chunkSize)
+	if !reflect.DeepEqual(src, dst) {
+		t.Errorf("destination should match source src: %v dst: %v", src, dst)
+	}
+
+	for i := 0; i < int(math.Ceil(float64(len(src))/float64(chunkSize))); i++ {
+		thisChunkSize := chunkSize
+		if len(src)-thisChunkSize*i < thisChunkSize {
+			thisChunkSize = len(src) - thisChunkSize*i
+		}
+
+		chunk := dst[i*thisChunkSize : (i+1)*thisChunkSize]
+
+		for j := 0; j < thisChunkSize-1; j++ {
+			a := (*reflect.SliceHeader)(unsafe.Pointer(&chunk[j]))
+			b := (*reflect.SliceHeader)(unsafe.Pointer(&chunk[j+1]))
+			if b.Data-a.Data != uintptr(a.Len) {
+				t.Error("chunk elements do not appear to be adjacent, so not part of one chunk")
+			}
+			if a.Cap != a.Len {
+				t.Errorf("slice length != capacity; %d vs %d", a.Len, a.Cap)
+			}
+			if b.Cap != b.Len {
+				t.Errorf("slice length != capacity; %d vs %d", b.Len, b.Cap)
+			}
+		}
+	}
+
+	dst[0][5] = 'z'
+	if reflect.DeepEqual(src, dst) {
+		t.Error("destination should not match source")
+	}
+}

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -1297,7 +1297,11 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.E
 
 	// Return filtered list if expression exists.
 	if expr != nil {
-		return is.measurementNamesByExpr(auth, expr)
+		names, err := is.measurementNamesByExpr(auth, expr)
+		if err != nil {
+			return nil, err
+		}
+		return slices.CopyChunkedByteSlices(names, 1000), nil
 	}
 
 	itr, err := is.measurementIterator()

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/bytesutil"
 	"github.com/influxdata/influxdb/pkg/estimator"
+	"github.com/influxdata/influxdb/pkg/slices"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxql"
 	"go.uber.org/zap"
@@ -1323,7 +1324,7 @@ func (is IndexSet) MeasurementNamesByExpr(auth query.Authorizer, expr influxql.E
 			names = append(names, e)
 		}
 	}
-	return names, nil
+	return slices.CopyChunkedByteSlices(names, 1000), nil
 }
 
 func (is IndexSet) measurementNamesByExpr(auth query.Authorizer, expr influxql.Expr) ([][]byte, error) {


### PR DESCRIPTION
We already make copies when no expression is provided, because
the backing slices may go away if the shard they came from is
closed. This fixes the other spot where some backing slices
would be returned.

Backport of #10421.
Backport of #10175.