### PR TITLE
Handle msgpack output in client

### DIFF
--- a/client/v2/client_test.go
+++ b/client/v2/client_test.go
@@ -250,7 +250,7 @@ func TestClientDownstream400WithBody_Query(t *testing.T) {
 	query := Query{}
 	_, err := c.Query(query)
 
-	expected := fmt.Sprintf(`expected json response, got "text/html", with status: %v and response body: %q`, http.StatusForbidden, err403page)
+	expected := fmt.Sprintf(`expected application/json response, got "text/html", with status: %v and response body: %q`, http.StatusForbidden, err403page)
 	if err.Error() != expected {
 		t.Errorf("unexpected error.  expected %v, actual %v", expected, err)
 	}
@@ -269,7 +269,7 @@ func TestClientDownstream400_Query(t *testing.T) {
 	query := Query{}
 	_, err := c.Query(query)
 
-	expected := fmt.Sprintf(`expected json response, got empty body, with status: %v`, http.StatusForbidden)
+	expected := fmt.Sprintf(`expected application/json response, got empty body, with status: %v`, http.StatusForbidden)
 	if err.Error() != expected {
 		t.Errorf("unexpected error.  expected %v, actual %v", expected, err)
 	}
@@ -417,7 +417,7 @@ func TestClientDownstream400WithBody_ChunkedQuery(t *testing.T) {
 	query := Query{Chunked: true}
 	_, err := c.Query(query)
 
-	expected := fmt.Sprintf(`expected json response, got "text/html", with status: %v and response body: %q`, http.StatusForbidden, err403page)
+	expected := fmt.Sprintf(`expected application/json response, got "text/html", with status: %v and response body: %q`, http.StatusForbidden, err403page)
 	if err.Error() != expected {
 		t.Errorf("unexpected error.  expected %v, actual %v", expected, err)
 	}
@@ -436,7 +436,7 @@ func TestClientDownstream400_ChunkedQuery(t *testing.T) {
 	query := Query{Chunked: true}
 	_, err := c.Query(query)
 
-	expected := fmt.Sprintf(`expected json response, got empty body, with status: %v`, http.StatusForbidden)
+	expected := fmt.Sprintf(`expected application/json response, got empty body, with status: %v`, http.StatusForbidden)
 	if err.Error() != expected {
 		t.Errorf("unexpected error.  expected %v, actual %v", expected, err)
 	}

--- a/client/v2/udp.go
+++ b/client/v2/udp.go
@@ -107,7 +107,7 @@ func (uc *udpclient) Query(q Query) (*Response, error) {
 	return nil, fmt.Errorf("Querying via UDP is not supported")
 }
 
-func (uc *udpclient) QueryAsChunk(q Query) (*ChunkedResponse, error) {
+func (uc *udpclient) QueryAsChunk(q Query) (ChunkedResponse, error) {
 	return nil, fmt.Errorf("Querying via UDP is not supported")
 }
 


### PR DESCRIPTION
This adds support for requesting JSON or msgpack encoding
in the client, and decoding msgpack format data directly.

The code was written pretty much straight through top-to-bottom
by keeping a copy of response_writer.go up and comparing
bits and pieces, and it's not been carefully tested on edge
cases or everything.

The reason I think it's worth sending in anyway is
that executing the same query both ways gets runtime
of:

	JSON: 15.855865892s
	msgpack: 6.881726139s

this is on the client side, but previous experiments with
curl suggest that using msgpack roughly *halves* wall-clock
time to respond to a request, not to mention significantly
reducing allocation load. It's even lower bandwidth
usage!

So the advantage here isn't just that the client's faster;
it's that each client using msgpack *also* reduces load on
the server. And given that the server can respond to the same
query in half as much time using msgpack, it seems to me
that quite possibly, disk access and database reads are *not*
dominating runtime in these trivial cases.

Code is probably full of typos and inadequately tested. All
I've verified is that a quick hacked-together thing that tries
to do a deep compare of two Result objects says they're
the same.

###### Required for all non-trivial PRs
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
- [ ] [InfluxData Documentation](https://github.com/influxdata/docs.influxdata.com): issue filed or pull request submitted \<link to issue or pull request\>

... I haven't done this, and probably should, but I figure first I should have this up so people can have a look at it.

Other issues: The attempt to figure out what might be an error message on the end of msgpack data we couldn't parse is probably bad. I am not sure I can do better in a sane way.
