### PR TITLE
Don't use fmt.Errorf on random strings

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -157,7 +157,7 @@ func (c *client) Ping(timeout time.Duration) (time.Duration, string, error) {
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		var err = fmt.Errorf(string(body))
+		var err = errors.New(string(body))
 		return 0, "", err
 	}
 
@@ -407,7 +407,7 @@ func (c *client) Write(bp BatchPoints) error {
 	}
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
-		var err = fmt.Errorf(string(body))
+		var err = errors.New(string(body))
 		return err
 	}
 
@@ -471,11 +471,11 @@ type Response struct {
 // It returns nil if no errors occurred on any statements.
 func (r *Response) Error() error {
 	if r.Err != "" {
-		return fmt.Errorf(r.Err)
+		return errors.New(r.Err)
 	}
 	for _, result := range r.Results {
 		if result.Err != "" {
-			return fmt.Errorf(result.Err)
+			return errors.New(result.Err)
 		}
 	}
 	return nil


### PR DESCRIPTION
In a few places, the client was assuming that an error
string would necessarily be safe to pass as a format string.
This seems unwise.

It also seems trivial enough that I don't think it needs all the fancy overhead. I'm pretty sure that nothing is intentionally using formatting characters in things that won't have any additional arguments passed.