### PR TITLE
Remove flaky CLI tests

### DIFF
--- a/cmd/influx/cli/cli_test.go
+++ b/cmd/influx/cli/cli_test.go
@@ -37,26 +37,6 @@ func TestNewCLI(t *testing.T) {
 	}
 }
 
-func TestRunCLI(t *testing.T) {
-	t.Parallel()
-	ts := emptyTestServer()
-	defer ts.Close()
-
-	u, _ := url.Parse(ts.URL)
-	h, p, _ := net.SplitHostPort(u.Host)
-	c := cli.New(CLIENT_VERSION)
-	c.Host = h
-	c.Port, _ = strconv.Atoi(p)
-	c.IgnoreSignals = true
-	c.ForceTTY = true
-	go func() {
-		close(c.Quit)
-	}()
-	if err := c.Run(); err != nil {
-		t.Fatalf("Run failed with error: %s", err)
-	}
-}
-
 func TestRunCLI_ExecuteInsert(t *testing.T) {
 	t.Parallel()
 	ts := emptyTestServer()
@@ -71,26 +51,6 @@ func TestRunCLI_ExecuteInsert(t *testing.T) {
 	c.Execute = "INSERT sensor,floor=1 value=2"
 	c.IgnoreSignals = true
 	c.ForceTTY = true
-	if err := c.Run(); err != nil {
-		t.Fatalf("Run failed with error: %s", err)
-	}
-}
-
-func TestRunCLI_WithSignals(t *testing.T) {
-	t.Parallel()
-	ts := emptyTestServer()
-	defer ts.Close()
-
-	u, _ := url.Parse(ts.URL)
-	h, p, _ := net.SplitHostPort(u.Host)
-	c := cli.New(CLIENT_VERSION)
-	c.Host = h
-	c.Port, _ = strconv.Atoi(p)
-	c.IgnoreSignals = false
-	c.ForceTTY = true
-	go func() {
-		close(c.Quit)
-	}()
 	if err := c.Run(); err != nil {
 		t.Fatalf("Run failed with error: %s", err)
 	}


### PR DESCRIPTION
Deleted the two flaky test functions that don't exercise any useful behavior or valid use cases. Closes #10430 

----

The original code was racy, as the `c.Quit` channel is closed in the test here:

https://github.com/influxdata/influxdb/blob/9ac37ca459bf15572f4d6c3adfc5ad99452b3a99/cmd/influx/cli/cli_test.go#L52-L54

In addition, it will be closed if the following line results in io.EOF

https://github.com/influxdata/influxdb/blob/c5ec3a32441c56be6477c0a897ec56e1c1714d7c/cmd/influx/cli/cli.go#L259

which leads to l being set to `"exit"`, calling `ParseCommand("exit")` and finally executing the `"exit"` case in the switch statement:

https://github.com/influxdata/influxdb/blob/c5ec3a32441c56be6477c0a897ec56e1c1714d7c/cmd/influx/cli/cli.go#L284-L285