### PR TITLE
Improve APIs to increase reuse in Enterprise

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/influxdata/influxdb/services/udp"
 	"github.com/influxdata/influxdb/tcp"
 	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/platform/storage/reads"
 	client "github.com/influxdata/usage-client/v1"
 	"go.uber.org/zap"
 
@@ -289,7 +290,7 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 	srv.Handler.BuildType = "OSS"
 	ss := storage.NewStore(s.TSDBStore, s.MetaClient)
 	srv.Handler.Store = ss
-	srv.Handler.Controller = control.NewController(ss, s.Logger)
+	srv.Handler.Controller = control.NewController(s.MetaClient, reads.NewReader(ss), s.Logger)
 
 	s.Services = append(s.Services, srv)
 }

--- a/flux/control/controller.go
+++ b/flux/control/controller.go
@@ -5,12 +5,13 @@ import (
 	"github.com/influxdata/flux/execute"
 	_ "github.com/influxdata/influxdb/flux/builtin"
 	"github.com/influxdata/influxdb/flux/functions/inputs"
-	"github.com/influxdata/influxdb/services/storage"
-	"github.com/influxdata/platform/storage/reads"
+	fstorage "github.com/influxdata/platform/query/functions/inputs/storage"
 	"go.uber.org/zap"
 )
 
-func NewController(s *storage.Store, logger *zap.Logger) *control.Controller {
+type MetaClient = inputs.MetaClient
+
+func NewController(mc MetaClient, reader fstorage.Reader, logger *zap.Logger) *control.Controller {
 	// flux
 	var (
 		concurrencyQuota = 10
@@ -25,12 +26,12 @@ func NewController(s *storage.Store, logger *zap.Logger) *control.Controller {
 		Verbose:              false,
 	}
 
-	err := inputs.InjectFromDependencies(cc.ExecutorDependencies, inputs.Dependencies{Reader: reads.NewReader(s)})
+	err := inputs.InjectFromDependencies(cc.ExecutorDependencies, inputs.Dependencies{Reader: reader})
 	if err != nil {
 		panic(err)
 	}
 
-	err = inputs.InjectBucketDependencies(cc.ExecutorDependencies, s)
+	err = inputs.InjectBucketDependencies(cc.ExecutorDependencies, mc)
 	if err != nil {
 		panic(err)
 	}

--- a/flux/functions/inputs/buckets.go
+++ b/flux/functions/inputs/buckets.go
@@ -2,12 +2,13 @@ package inputs
 
 import (
 	"fmt"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/functions/inputs"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/values"
-	"github.com/influxdata/influxdb/services/storage"
+	"github.com/influxdata/influxdb/services/meta"
 	"github.com/pkg/errors"
 )
 
@@ -63,8 +64,7 @@ func (bd *BucketsDecoder) Decode() (flux.Table, error) {
 		Type:  flux.TInt,
 	})
 
-	for _, database := range bd.deps.TSDBStore.Databases() {
-		bucket := bd.deps.MetaClient.Database(database)
+	for _, bucket := range bd.deps.Databases() {
 		rp := bucket.RetentionPolicy(bucket.DefaultRetentionPolicy)
 		b.AppendString(0, bucket.Name)
 		b.AppendString(1, "")
@@ -93,7 +93,11 @@ func createBucketsSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
 
 }
 
-type BucketDependencies *storage.Store
+type MetaClient interface {
+	Databases() []meta.DatabaseInfo
+}
+
+type BucketDependencies MetaClient
 
 func InjectBucketDependencies(depsMap execute.Dependencies, deps BucketDependencies) error {
 	if deps == nil {

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1710,7 +1710,6 @@ func (h *Handler) recovery(inner http.Handler, name string) http.Handler {
 // Store describes the behaviour of the storage packages Store type.
 type Store interface {
 	Read(ctx context.Context, req *datatypes.ReadRequest) (reads.ResultSet, error)
-	WithLogger(log *zap.Logger)
 }
 
 // Response represents a list of statement results.

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -1408,7 +1408,6 @@ func NewHandlerWithConfig(config httpd.Config) *Handler {
 	if testing.Verbose() {
 		l := logger.New(os.Stdout)
 		h.Handler.Logger = l
-		h.Handler.Store.WithLogger(l)
 	}
 
 	return h

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -208,7 +208,6 @@ func (s *Service) Close() error {
 func (s *Service) WithLogger(log *zap.Logger) {
 	s.Logger = log.With(zap.String("service", "httpd"))
 	s.Handler.Logger = s.Logger
-	s.Handler.Store.WithLogger(s.Logger)
 }
 
 // Err returns a channel for fatal errors that occur on the listener.


### PR DESCRIPTION
Various API refinements to increase reuse in Enterprise and improve testability by lowering the required dependencies to the `control.NewController` function.