### PR TITLE
Simple8B EncodeAll incorrectly encodes 120 or 240 1s if last value is not a 1

### DIFF
--- a/pkg/encoding/simple8b/encoding.go
+++ b/pkg/encoding/simple8b/encoding.go
@@ -388,6 +388,7 @@ NEXTVALUE:
 
 		// try to pack run of 240 or 120 1s
 		if len(remaining) >= 120 {
+			// Invariant: len(a) is fixed to 120 or 240 values
 			var a []uint64
 			if len(remaining) >= 240 {
 				a = remaining[:240]
@@ -395,24 +396,31 @@ NEXTVALUE:
 				a = remaining[:120]
 			}
 
+			// search for the longest sequence of 1s in a
+			// Postcondition: k equals the index of the last 1 or -1
 			k := 0
 			for k = range a {
 				if a[k] != 1 {
+					k--
 					break
 				}
 			}
 
 			v := uint64(0)
 			switch {
-			case k >= 239:
+			case k == 239:
+				// 240 1s
 				i += 240
+
 			case k >= 119:
+				// at least 120 1s
 				v = 1 << 60
 				i += 120
 
 			default:
 				goto CODES
 			}
+
 			dst[j] = v
 			j++
 			continue

--- a/pkg/encoding/simple8b/encoding_test.go
+++ b/pkg/encoding/simple8b/encoding_test.go
@@ -123,6 +123,16 @@ func TestEncodeAll(t *testing.T) {
 			in[120] = 5
 			return in
 		}},
+		{name: "119 ones", fn: func() []uint64 {
+			in := ones(240)()
+			in[119] = 5
+			return in
+		}},
+		{name: "239 ones", fn: func() []uint64 {
+			in := ones(241)()
+			in[239] = 5
+			return in
+		}},
 	}
 
 	for _, test := range tests {

--- a/tsdb/engine/tsm1/compact.gen.go
+++ b/tsdb/engine/tsm1/compact.gen.go
@@ -1076,6 +1076,14 @@ func (k *tsmBatchKeyIterator) combineFloat(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1150,6 +1158,11 @@ func (k *tsmBatchKeyIterator) combineFloat(dedup bool) blocks {
 		if err := DecodeFloatArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block
@@ -1282,6 +1295,14 @@ func (k *tsmBatchKeyIterator) combineInteger(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1356,6 +1377,11 @@ func (k *tsmBatchKeyIterator) combineInteger(dedup bool) blocks {
 		if err := DecodeIntegerArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block
@@ -1488,6 +1514,14 @@ func (k *tsmBatchKeyIterator) combineUnsigned(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1562,6 +1596,11 @@ func (k *tsmBatchKeyIterator) combineUnsigned(dedup bool) blocks {
 		if err := DecodeUnsignedArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block
@@ -1694,6 +1733,14 @@ func (k *tsmBatchKeyIterator) combineString(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1768,6 +1815,11 @@ func (k *tsmBatchKeyIterator) combineString(dedup bool) blocks {
 		if err := DecodeStringArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block
@@ -1900,6 +1952,14 @@ func (k *tsmBatchKeyIterator) combineBoolean(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -1974,6 +2034,11 @@ func (k *tsmBatchKeyIterator) combineBoolean(dedup bool) blocks {
 		if err := DecodeBooleanArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block

--- a/tsdb/engine/tsm1/compact.gen.go.tmpl
+++ b/tsdb/engine/tsm1/compact.gen.go.tmpl
@@ -279,6 +279,14 @@ func (k *tsmBatchKeyIterator) combine{{.Name}}(dedup bool) blocks {
 					return nil
 				}
 
+				// Invariant: v.MaxTime() == k.blocks[i].maxTime
+				if k.blocks[i].maxTime != v.MaxTime() {
+					if maxTime == k.blocks[i].maxTime {
+						maxTime = v.MaxTime()
+					}
+					k.blocks[i].maxTime = v.MaxTime()
+				}
+
 				// Remove values we already read
 				v.Exclude(k.blocks[i].readMin, k.blocks[i].readMax)
 
@@ -353,6 +361,11 @@ func (k *tsmBatchKeyIterator) combine{{.Name}}(dedup bool) blocks {
 		if err := Decode{{.Name}}ArrayBlock(k.blocks[i].b, &v); err != nil {
 			k.err = err
 			return nil
+		}
+
+		// Invariant: v.MaxTime() == k.blocks[i].maxTime
+		if k.blocks[i].maxTime != v.MaxTime() {
+			k.blocks[i].maxTime = v.MaxTime()
 		}
 
 		// Apply each tombstone to the block


### PR DESCRIPTION
Resolves an encoding issue with simple8b. 

Closes #10465

For a run of 1s, if the 120th or 240th entry is not a 1, the run will be incorrectly encoded as selector 0 (240 1s) or selector 1 (120 1s), resulting in a loss of data for the 120th or 240th value.

This bug manifests itself as an infinite loop during a compaction, when the last timestamp in a block is the 120th or 240th in a run of 1s and is itself not a 1.

----

When timestamps are encoded using simple8b, they are first reduced to deltas and then a common divisor is computed. For example, take the following timestamps:

```
1:      12000
2:      13000
3:      14000
4:      15000
5..119: repeated values
120   : 133000
```

Deltas would first reduce the list to

```
1:      1000
2:      1000
3:      1000
4:      1000
5..119: 1000 repeated
120   : 2000
```

Next, a common divisor of `1000` is determined and the values scaled accordingly:

```
1:      1
2:      1
3:      1
4:      1
5..119: 1 repeated
120   : 2
```

120 values from `[1..120]` are passed to simple8b to be encoded, however, the loop to determine the run of 1s exited on the 120th, still considering it has a run of 120 values.
