### PR TITLE
chore: install gcc

### DIFF
--- a/releng/unit-tests/Dockerfile
+++ b/releng/unit-tests/Dockerfile
@@ -4,7 +4,8 @@ FROM golang:${GO_VERSION}-alpine
 RUN apk add --no-cache \
       bash \
       jq \
-      git
+      git \
+      gcc
 
 RUN go get -u github.com/jstemmer/go-junit-report && \
       mv /go/bin/go-junit-report /usr/bin/go-junit-report && \


### PR DESCRIPTION
Running OSS unit tests for the release is failing due to a missing `gcc`. 