### PR TITLE
Fix ApplyEnvOverrides when a type that implements Unmarshaler is in a slice

### DIFF
--- a/toml/toml.go
+++ b/toml/toml.go
@@ -158,6 +158,10 @@ func applyEnvOverrides(getenv func(string) string, prefix string, spec reflect.V
 		v := spec.Addr()
 		if u, ok := v.Interface().(encoding.TextUnmarshaler); ok {
 			value := getenv(prefix)
+			// Skip any fields we don't have a value to set
+			if len(value) == 0 {
+				return nil
+			}
 			return u.UnmarshalText([]byte(value))
 		}
 	}


### PR DESCRIPTION
Most parts of `ApplyEnvOverrides` will check if the value is empty
before attempting to apply the environment override. One exception is
that when a type implements Unmarshaler and it is within a slice, it
does not check that an empty value was passed.

This change fixes it so that we will not call `UnmarshalText` when the
environment variable is set to empty.

Fixes #10487.