### PR TITLE
Fix compaction logic on infrequent cache snapshots

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1971,7 +1971,7 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 			level1Groups := e.CompactionPlan.PlanLevel(1)
 			level2Groups := e.CompactionPlan.PlanLevel(2)
 			level3Groups := e.CompactionPlan.PlanLevel(3)
-			level4Groups := e.CompactionPlan.Plan(e.FileStore.LastModified())
+			level4Groups := e.CompactionPlan.Plan(e.LastModified())
 			atomic.StoreInt64(&e.stats.TSMOptimizeCompactionsQueue, int64(len(level4Groups)))
 
 			// If no full compactions are need, see if an optimize is needed


### PR DESCRIPTION
This change fixes #10511 that manifests when a shard is considered cold
faster than its cache is snapshotted. This can happen if WAL is enabled
because previously the code only considered the last modification of
compacted tsm1 files. Instead Engine.LastModified() also takes the WAL
into account if necessary.

#### Testing
I haven't added a test to prevent regressions because I couldn't find a test that calls this code path and checks when a compaction is triggered (especially a full compaction). For that reason I've done some manual tests:
1. Generate default configuration: `$ influxd config > influxdb.conf`
2. Modify parameters: `sed -i -e 's/cache-snapshot-memory-size = .*/cache-snapshot-memory-size = "24k"/' -e 's/compact-full-write-cold-duration = ".*"/compact-full-write-cold-duration = "30s"/' influxdb.conf` (this gives me a cache compaction once per minute for the `_internal` database; tweak values as needed, but make sure that mentioned situation can arise)
3. Start InfluxDB: `$ influxd -config influxdb.conf`

By default InfluxDB will start filling `_internal` and without this change, I'm seeing full compactions 30s after the cache has been compacted. This is exactly the behavior I've described in #10511. After applying this commit it's compacting as documented (level 1 / 2 / etc.).

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)