### PR TITLE
Remove "Verbose" option from controller.Config

### DIFF
--- a/flux/control/controller.go
+++ b/flux/control/controller.go
@@ -23,7 +23,6 @@ func NewController(mc MetaClient, reader fstorage.Reader, logger *zap.Logger) *c
 		ConcurrencyQuota:     concurrencyQuota,
 		MemoryBytesQuota:     int64(memoryBytesQuota),
 		Logger:               logger,
-		Verbose:              false,
 	}
 
 	err := inputs.InjectFromDependencies(cc.ExecutorDependencies, inputs.Dependencies{Reader: reader, MetaClient: mc})


### PR DESCRIPTION
The flux controller will use the log level of the logger to log queries and plans instead.

