### PR TITLE
Drop NaN values when writing back points

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -47,7 +47,9 @@ type StatementExecutor struct {
 	Monitor *monitor.Monitor
 
 	// Used for rewriting points back into system for SELECT INTO statements.
-	PointsWriter pointsWriter
+	PointsWriter interface {
+		WritePointsInto(*IntoWriteRequest) error
+	}
 
 	// Select statement limits
 	MaxSelectPointN   int
@@ -571,10 +573,11 @@ func (e *StatementExecutor) executeSelectStatement(stmt *influxql.SelectStatemen
 
 		// Write points back into system for INTO statements.
 		if stmt.Target != nil {
-			if err := e.writeInto(pointsWriter, stmt, row); err != nil {
+			n, err := e.writeInto(pointsWriter, stmt, row)
+			if err != nil {
 				return err
 			}
-			writeN += int64(len(row.Values))
+			writeN += n
 			continue
 		}
 
@@ -1185,9 +1188,9 @@ func (w *BufferedPointsWriter) Len() int { return len(w.buf) }
 // Cap returns the capacity (in points) of the buffer.
 func (w *BufferedPointsWriter) Cap() int { return cap(w.buf) }
 
-func (e *StatementExecutor) writeInto(w pointsWriter, stmt *influxql.SelectStatement, row *models.Row) error {
+func (e *StatementExecutor) writeInto(w pointsWriter, stmt *influxql.SelectStatement, row *models.Row) (n int64, err error) {
 	if stmt.Target.Measurement.Database == "" {
-		return errNoDatabaseInTarget
+		return 0, errNoDatabaseInTarget
 	}
 
 	// It might seem a bit weird that this is where we do this, since we will have to
@@ -1204,7 +1207,7 @@ func (e *StatementExecutor) writeInto(w pointsWriter, stmt *influxql.SelectState
 
 	points, err := convertRowToPoints(name, row)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if err := w.WritePointsInto(&IntoWriteRequest{
@@ -1212,10 +1215,10 @@ func (e *StatementExecutor) writeInto(w pointsWriter, stmt *influxql.SelectState
 		RetentionPolicy: stmt.Target.Measurement.RetentionPolicy,
 		Points:          points,
 	}); err != nil {
-		return err
+		return 0, err
 	}
 
-	return nil
+	return int64(len(points)), nil
 }
 
 var errNoDatabaseInTarget = errors.New("no database in target")
@@ -1242,7 +1245,11 @@ func convertRowToPoints(measurementName string, row *models.Row) ([]models.Point
 		vals := make(map[string]interface{})
 		for fieldName, fieldIndex := range fieldIndexes {
 			val := v[fieldIndex]
-			if val != nil {
+			// Check specifically for nil or a NullFloat. This is because
+			// the NullFloat represents float numbers that don't have an internal representation
+			// (like NaN) that cannot be written back, but will not equal nil so there will be
+			// an attempt to write them if we do not check for it.
+			if val != nil && val != query.NullFloat {
 				vals[fieldName] = v[fieldIndex]
 			}
 		}


### PR DESCRIPTION
When an NaN value was computed, it would be written back incorrectly as
a string type instead of being omitted. This happened very rarely in the
case that `stddev()` of a single value was computed and only when it was
being done on a new shard.

This correctly drops the value. The reason this wasn't correctly dropped
previously is because NaN values are represented as a `(*float64)(nil)`
which does not equal `nil` so the writeback system thought it was a
non-nil point, but the writer encoded it as a string.

In addition to the above, this also fixes the point writer to report the
number of points actually written rather than the number of points
desired to be written. Previously, if there was an error writing a point
for some reason, the point would be silently dropped, but still recorded
as a point that had been written. Now it reports the number of points
that were written and omits the ones that were dropped.