### PR TITLE
clientv2 - QueryCtx()

### DIFF
--- a/client/v2/udp.go
+++ b/client/v2/udp.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -104,6 +105,10 @@ func (uc *udpclient) Write(bp BatchPoints) error {
 }
 
 func (uc *udpclient) Query(q Query) (*Response, error) {
+	return nil, fmt.Errorf("Querying via UDP is not supported")
+}
+
+func (uc *udpclient) QueryCtx(ctx context.Context, q Query) (*Response, error) {
 	return nil, fmt.Errorf("Querying via UDP is not supported")
 }
 

--- a/client/v2/udp.go
+++ b/client/v2/udp.go
@@ -105,15 +105,15 @@ func (uc *udpclient) Write(bp BatchPoints) error {
 }
 
 func (uc *udpclient) Query(q Query) (*Response, error) {
-	return nil, fmt.Errorf("Querying via UDP is not supported")
+	return nil, fmt.Errorf("querying via UDP is not supported")
 }
 
 func (uc *udpclient) QueryCtx(ctx context.Context, q Query) (*Response, error) {
-	return nil, fmt.Errorf("Querying via UDP is not supported")
+	return nil, fmt.Errorf("querying via UDP is not supported")
 }
 
 func (uc *udpclient) QueryAsChunk(q Query) (*ChunkedResponse, error) {
-	return nil, fmt.Errorf("Querying via UDP is not supported")
+	return nil, fmt.Errorf("querying via UDP is not supported")
 }
 
 func (uc *udpclient) Ping(timeout time.Duration) (time.Duration, string, error) {


### PR DESCRIPTION
A simple modification allowing to pass a context to the clientv2 when performing queries. This is most helpful when a client launches thru a reverse proxy a long read and closes the connection before the batch is finished.

Dummy example:
```golang
func readHandler(w http.ResponseWriter, r *http.Request) {
	// snappy decode
	// [...]
	// protobuff unmarshall
	// [...]

	// spawn our influx client
	influx, err := influxdb.New("http://<host>:8086", database, user, password)
	if err != nil {
		fmt.Println(err)
		if r.Context().Err() == nil {
			http.Error(w, fmt.Sprintf("can't spawn InfluxDB controller: %v", err),
				http.StatusInternalServerError)
		}
		return
	}
	defer func() {
		if err = influx.Close(); err != nil {
			fmt.Println(err)
		}
	}()

	// Build & perform request
	// [...]
	resp, err := influx.QueryCtx(r.Context(), req)
	if err != nil {
		fmt.Println("read query to influxdb failed:", err)
		if r.Context().Err() == nil {
			http.Error(w, fmt.Sprintf("read query to influxdb failed: %v", err),
				http.StatusInternalServerError)
		}
		return
	}
	// [...]

	// protobuff marshal
	// [...]
	// snappy encode
	// [...]
}
```

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

~I did not signed it, but this is a trivial PR :)~

###### Required only if applicable
- [x] Provide example syntax
