### PR TITLE
Backport #10549: Pass the query authorizer to subqueries

### DIFF
--- a/query/iterator.go
+++ b/query/iterator.go
@@ -687,7 +687,10 @@ func newIteratorOptionsStmt(stmt *influxql.SelectStatement, sopt SelectOptions) 
 }
 
 func newIteratorOptionsSubstatement(ctx context.Context, stmt *influxql.SelectStatement, opt IteratorOptions) (IteratorOptions, error) {
-	subOpt, err := newIteratorOptionsStmt(stmt, SelectOptions{})
+	subOpt, err := newIteratorOptionsStmt(stmt, SelectOptions{
+		Authorizer: opt.Authorizer,
+		MaxSeriesN: opt.MaxSeriesN,
+	})
 	if err != nil {
 		return IteratorOptions{}, err
 	}


### PR DESCRIPTION
The query authorizer was not being properly passed to subqueries so
rejections did not happen when a subquery was the one reading the value.
Similarly, the max series limit was not being propagated downwards
either.

This was a clean cherry-pick of #10549.