### PR TITLE
Backport #10549: Pass the query authorizer to subqueries

### DIFF
--- a/query/iterator.go
+++ b/query/iterator.go
@@ -798,7 +798,10 @@ func newIteratorOptionsStmt(stmt *influxql.SelectStatement, sopt SelectOptions) 
 }
 
 func newIteratorOptionsSubstatement(ctx context.Context, stmt *influxql.SelectStatement, opt IteratorOptions) (IteratorOptions, error) {
-	subOpt, err := newIteratorOptionsStmt(stmt, SelectOptions{})
+	subOpt, err := newIteratorOptionsStmt(stmt, SelectOptions{
+		Authorizer: opt.Authorizer,
+		MaxSeriesN: opt.MaxSeriesN,
+	})
 	if err != nil {
 		return IteratorOptions{}, err
 	}


### PR DESCRIPTION
The query authorizer was not being properly passed to subqueries so
rejections did not happen when a subquery was the one reading the value.
Similarly, the max series limit was not being propagated downwards
either.

The original change modified query/subquery_test.go, but the 1.5 branch
does not have the file, and appeared to be unable to compile that file
as it appeared originally; so this backport does not include the test.