### PR TITLE
Flux group(mode:"by") does not push down correct operation to storage layer

### DIFF
--- a/flux/functions/inputs/from.go
+++ b/flux/functions/inputs/from.go
@@ -75,7 +75,7 @@ func createFromSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execu
 			SeriesOffset:    spec.SeriesOffset,
 			Descending:      spec.Descending,
 			OrderByTime:     spec.OrderByTime,
-			GroupMode:       storage.GroupMode(spec.GroupMode),
+			GroupMode:       storage.ToGroupMode(spec.GroupMode),
 			GroupKeys:       spec.GroupKeys,
 			AggregateMethod: spec.AggregateMethod,
 		},


### PR DESCRIPTION
This fix ensures group(mode:"by") is correctly pushed down to the
storage layer.