### PR TITLE
Add user authentication and authorization support for Flux HTTP requests

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -281,7 +281,8 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 	}
 	srv := httpd.NewService(c)
 	srv.Handler.MetaClient = s.MetaClient
-	srv.Handler.QueryAuthorizer = meta.NewQueryAuthorizer(s.MetaClient)
+	authorizer := meta.NewQueryAuthorizer(s.MetaClient)
+	srv.Handler.QueryAuthorizer = authorizer
 	srv.Handler.WriteAuthorizer = meta.NewWriteAuthorizer(s.MetaClient)
 	srv.Handler.QueryExecutor = s.QueryExecutor
 	srv.Handler.Monitor = s.Monitor
@@ -290,7 +291,7 @@ func (s *Server) appendHTTPDService(c httpd.Config) {
 	srv.Handler.BuildType = "OSS"
 	ss := storage.NewStore(s.TSDBStore, s.MetaClient)
 	srv.Handler.Store = ss
-	srv.Handler.Controller = control.NewController(s.MetaClient, reads.NewReader(ss), s.Logger)
+	srv.Handler.Controller = control.NewController(s.MetaClient, reads.NewReader(ss), authorizer, c.AuthEnabled, s.Logger)
 
 	s.Services = append(s.Services, srv)
 }

--- a/flux/control/controller.go
+++ b/flux/control/controller.go
@@ -10,8 +10,9 @@ import (
 )
 
 type MetaClient = inputs.MetaClient
+type Authorizer = inputs.Authorizer
 
-func NewController(mc MetaClient, reader fstorage.Reader, logger *zap.Logger) *control.Controller {
+func NewController(mc MetaClient, reader fstorage.Reader, auth Authorizer, authEnabled bool, logger *zap.Logger) *control.Controller {
 	// flux
 	var (
 		concurrencyQuota = 10
@@ -25,12 +26,12 @@ func NewController(mc MetaClient, reader fstorage.Reader, logger *zap.Logger) *c
 		Logger:               logger,
 	}
 
-	err := inputs.InjectFromDependencies(cc.ExecutorDependencies, inputs.Dependencies{Reader: reader, MetaClient: mc})
+	err := inputs.InjectFromDependencies(cc.ExecutorDependencies, inputs.Dependencies{Reader: reader, MetaClient: mc, Authorizer: auth, AuthEnabled: authEnabled})
 	if err != nil {
 		panic(err)
 	}
 
-	err = inputs.InjectBucketDependencies(cc.ExecutorDependencies, mc)
+	err = inputs.InjectBucketDependencies(cc.ExecutorDependencies, inputs.BucketDependencies{MetaClient: mc, Authorizer: auth, AuthEnabled: authEnabled})
 	if err != nil {
 		panic(err)
 	}

--- a/flux/functions/inputs/buckets.go
+++ b/flux/functions/inputs/buckets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxql"
 	"github.com/pkg/errors"
 )
 
@@ -20,6 +21,7 @@ func init() {
 type BucketsDecoder struct {
 	deps  BucketDependencies
 	alloc *memory.Allocator
+	user  meta.User
 }
 
 func (bd *BucketsDecoder) Connect() error {
@@ -65,14 +67,28 @@ func (bd *BucketsDecoder) Decode() (flux.Table, error) {
 		Type:  flux.TInt,
 	})
 
-	for _, bucket := range bd.deps.Databases() {
-		rp := bucket.RetentionPolicy(bucket.DefaultRetentionPolicy)
-		b.AppendString(0, bucket.Name)
-		b.AppendString(1, "")
-		b.AppendString(2, "influxdb")
-		b.AppendString(3, "")
-		b.AppendString(4, rp.Name)
-		b.AppendInt(5, rp.Duration.Nanoseconds())
+	var hasAccess func(db string) bool
+	if bd.user == nil {
+		hasAccess = func(db string) bool {
+			return true
+		}
+	} else {
+		hasAccess = func(db string) bool {
+			return bd.deps.Authorizer.AuthorizeDatabase(bd.user, influxql.ReadPrivilege, db) == nil ||
+				bd.deps.Authorizer.AuthorizeDatabase(bd.user, influxql.WritePrivilege, db) == nil
+		}
+	}
+
+	for _, bucket := range bd.deps.MetaClient.Databases() {
+		if hasAccess(bucket.Name) {
+			rp := bucket.RetentionPolicy(bucket.DefaultRetentionPolicy)
+			b.AppendString(0, bucket.Name)
+			b.AppendString(1, "")
+			b.AppendString(2, "influxdb")
+			b.AppendString(3, "")
+			b.AppendString(4, rp.Name)
+			b.AppendInt(5, rp.Duration.Nanoseconds())
+		}
 	}
 
 	return b.Table()
@@ -88,7 +104,15 @@ func createBucketsSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
 	// so there's no need to inject custom dependencies for buckets()
 	deps := a.Dependencies()[inputs.BucketsKind].(BucketDependencies)
 
-	bd := &BucketsDecoder{deps: deps, alloc: a.Allocator()}
+	var user meta.User
+	if deps.AuthEnabled {
+		user = meta.UserFromContext(a.Context())
+		if user == nil {
+			return nil, errors.New("createBucketsSource: no user")
+		}
+	}
+
+	bd := &BucketsDecoder{deps: deps, alloc: a.Allocator(), user: user}
 
 	return inputs.CreateSourceFromDecoder(bd, dsid, a)
 
@@ -99,11 +123,25 @@ type MetaClient interface {
 	Database(name string) *meta.DatabaseInfo
 }
 
-type BucketDependencies MetaClient
+type BucketDependencies struct {
+	MetaClient  MetaClient
+	Authorizer  Authorizer
+	AuthEnabled bool
+}
+
+func (d BucketDependencies) Validate() error {
+	if d.MetaClient == nil {
+		return errors.New("validate BucketDependencies: missing MetaClient")
+	}
+	if d.AuthEnabled && d.Authorizer == nil {
+		return errors.New("validate BucketDependencies: missing Authorizer")
+	}
+	return nil
+}
 
 func InjectBucketDependencies(depsMap execute.Dependencies, deps BucketDependencies) error {
-	if deps == nil {
-		return errors.New("bucket store dependency")
+	if err := deps.Validate(); err != nil {
+		return err
 	}
 	depsMap[inputs.BucketsKind] = deps
 	return nil

--- a/services/meta/context.go
+++ b/services/meta/context.go
@@ -1,0 +1,22 @@
+package meta
+
+import (
+	"context"
+)
+
+type key int
+
+const (
+	userKey key = iota
+)
+
+// NewContextWithUser returns a new context with user added.
+func NewContextWithUser(ctx context.Context, user User) context.Context {
+	return context.WithValue(ctx, userKey, user)
+}
+
+// UserFromContext returns the User associated with ctx or nil if no user has been assigned.
+func UserFromContext(ctx context.Context) User {
+	l, _ := ctx.Value(userKey).(User)
+	return l
+}

--- a/services/meta/query_authorizer.go
+++ b/services/meta/query_authorizer.go
@@ -51,6 +51,24 @@ func (a *QueryAuthorizer) AuthorizeQuery(u User, query *influxql.Query, database
 	return u.AuthorizeQuery(database, query)
 }
 
+func (a *QueryAuthorizer) AuthorizeDatabase(u User, priv influxql.Privilege, database string) error {
+	if u == nil {
+		return &ErrAuthorize{
+			Database: database,
+			Message:  "no user provided",
+		}
+	}
+
+	if !u.AuthorizeDatabase(priv, database) {
+		return &ErrAuthorize{
+			Database: database,
+			Message:  fmt.Sprintf("user %q, requires %s for database %q", u.ID(), priv.String(), database),
+		}
+	}
+
+	return nil
+}
+
 func (u *UserInfo) AuthorizeQuery(database string, query *influxql.Query) error {
 
 	// Admin privilege allows the user to execute all statements.


### PR DESCRIPTION
* Add `AuthorizeDatabase` API to `QueryAuthorizer` to verify a user has appropriate access to the specified database
* Update `serveFluxQuery` handler, adding a `meta.User` parameter, which triggers the Flux API requires a user when auth is enabled
* update Flux `createFromSource` and `createBucketsSource` dependencies to require `Authorizer` when auth is enabled in configuration
* update `createFromSource` verify read permissions for each bucket specified in a Flux query
* update `BucketsDecoder`, which implements the `buckets()` Flux function, to limit the displayed buckets to those the user has read or write permissions to. This replicates the behavior of the `SHOW DATABASES` InfluxQL command
* add unit tests to verify authentication is required for Flux HTTP requests when auth is enabled in configuration
