### PR TITLE
[BUG FIX] Fix nil pointer dereference at /api/v1/prom/read

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1082,9 +1082,11 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 		h.httpError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
 	resp := &remote.ReadResponse{
 		Results: []*remote.QueryResult{{}},
 	}
+
 	if rs == nil {
 		respond(resp)
 		return

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1149,6 +1149,7 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 			)
 		}
 	}
+
 	respond(resp)
 }
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1076,15 +1076,14 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 		atomic.AddInt64(&h.stats.QueryRequestBytesTransmitted, int64(len(compressed)))
 	}
 
-	resp := &remote.ReadResponse{
-		Results: []*remote.QueryResult{{}},
-	}
-
 	ctx := context.Background()
 	rs, err := h.Store.Read(ctx, readRequest)
 	if err != nil {
 		h.httpError(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+	resp := &remote.ReadResponse{
+		Results: []*remote.QueryResult{{}},
 	}
 	if rs == nil {
 		respond(resp)

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1062,6 +1062,10 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 		h.httpError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if rs == nil {
+		h.httpError(w, "no result set found", http.StatusNotFound)
+		return
+	}
 	defer rs.Close()
 
 	resp := &remote.ReadResponse{


### PR DESCRIPTION
###### Required for all non-trivial PRs

- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

## Issue

While using InfluxDB I have been getting several nil pointer dereference issues when hitting the `/api/v1/prom/read` endpoint. Specifically, the error looks like this:
```
[httpd] 127.0.0.1 - - [19/Dec/2018:15:43:13 -0500] "POST /api/v1/prom/read?db=mydb HTTP/1.1" 200 0 "-" "Go-http-client/1.1" b43f30ed-03ce-11e9-8001-54e1adf55cb9 135 [panic:runtime error: invalid memory address or nil pointer dereference] goroutine 26 [running]:
runtime/debug.Stack(0xc000bf6020, 0xc00012a500, 0xbefec938560986be)
	/usr/local/go/src/runtime/debug/stack.go:24 +0xa7
github.com/influxdata/influxdb/services/httpd.(*Handler).recovery.func1.1(0xc000bf6020, 0xc00012a500, 0xbefec938560986be, 0xf4a63c64, 0x1d49060, 0xc000273100, 0x137cca0, 0xc000bfa000)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:1690 +0xcd
panic(0x107c440, 0x1d30680)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/influxdata/influxdb/services/httpd.(*Handler).servePromRead(0xc000273100, 0x7f788e492a28, 0xc000bf6060, 0xc00012a500, 0x0, 0x0)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:1065 +0x270
github.com/influxdata/influxdb/services/httpd.(*Handler).servePromRead-fm(0x7f788e492a28, 0xc000bf6060, 0xc00012a500, 0x0, 0x0)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:183 +0x5c
github.com/influxdata/influxdb/services/httpd.authenticate.func1(0x7f788e492a28, 0xc000bf6060, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:1487 +0x788
net/http.HandlerFunc.ServeHTTP(0xc00023ca20, 0x7f788e492a28, 0xc000bf6060, 0xc00012a500)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/influxdata/influxdb/services/httpd.(*Handler).responseWriter.func1(0x13787a0, 0xc000bf0050, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:1667 +0xab
net/http.HandlerFunc.ServeHTTP(0xc00023ca40, 0x13787a0, 0xc000bf0050, 0xc00012a500)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/influxdata/influxdb/services/httpd.gzipFilter.func1(0x1378820, 0xc000bf6040, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/gzip.go:39 +0x204
net/http.HandlerFunc.ServeHTTP(0xc00023ca60, 0x1378820, 0xc000bf6040, 0xc00012a500)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/influxdata/influxdb/services/httpd.cors.func1(0x1378820, 0xc000bf6040, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:1609 +0xf3
net/http.HandlerFunc.ServeHTTP(0xc00023ca80, 0x1378820, 0xc000bf6040, 0xc00012a500)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/influxdata/influxdb/services/httpd.requestID.func1(0x1378820, 0xc000bf6040, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:1640 +0x179
net/http.HandlerFunc.ServeHTTP(0xc00023caa0, 0x1378820, 0xc000bf6040, 0xc00012a500)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/influxdata/influxdb/services/httpd.(*Handler).logging.func1(0x1378820, 0xc000bf6020, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:1648 +0xdc
net/http.HandlerFunc.ServeHTTP(0xc00023cac0, 0x1378820, 0xc000bf6020, 0xc00012a500)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/influxdata/influxdb/services/httpd.(*Handler).recovery.func1(0x137cca0, 0xc000bfa000, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:1704 +0x147
net/http.HandlerFunc.ServeHTTP(0xc00023cb00, 0x137cca0, 0xc000bfa000, 0xc00012a500)
	/usr/local/go/src/net/http/server.go:1964 +0x44
github.com/influxdata/influxdb/vendor/github.com/bmizerany/pat.(*PatternServeMux).ServeHTTP(0xc000167ac0, 0x137cca0, 0xc000bfa000, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/vendor/github.com/bmizerany/pat/mux.go:117 +0x155
github.com/influxdata/influxdb/services/httpd.(*Handler).ServeHTTP(0xc000273100, 0x137cca0, 0xc000bfa000, 0xc00012a500)
	/tmp/influx/src/github.com/influxdata/influxdb/services/httpd/handler.go:381 +0x247
net/http.serverHandler.ServeHTTP(0xc00053e000, 0x137cca0, 0xc000bfa000, 0xc00012a500)
	/usr/local/go/src/net/http/server.go:2741 +0xab
net/http.(*conn).serve(0xc000be8000, 0x137e620, 0xc00030ba40)
	/usr/local/go/src/net/http/server.go:1847 +0x646
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2851 +0x2f5
```

## Error reproduction

To reproduce this error, you can run the following in one terminal:

```shell
#!/bin/bash

mkdir -p /tmp/test-influx/src/github.com/influxdata/influxdb
git clone --branch 1.8 https://github.com/influxdata/influxdb /tmp/test-influx/src/github.com/influxdata/influxdb
cd /tmp/test-influx/src/github.com/influxdata/influxdb
export GOPATH=/tmp/test-influx

## Build influxd
python build.py

## Create the config file
sudo mkdir -p /etc/influxdb
./build/influxd config > influxdb.conf
sudo mv influxdb.conf /etc/influxdb

## Start influxd
sudo ./build/influxd run
```

And in another terminal run the following script:

```shell
#!/bin/bash

mkdir -p /tmp/test-influx

export GOPATH=/tmp/test-influx

cd /tmp/test-influx

curl -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE DATABASE mydb"

curl -XPOST "http://localhost:8086/write?db=mydb" \
-d 'cpu,host=server01,region=uswest load=42 1434055562000000000'

curl -XPOST "http://localhost:8086/write?db=mydb" \
-d 'cpu,host=server02,region=uswest load=78 1434055562000000000'

curl -XPOST "http://localhost:8086/write?db=mydb" \
-d 'cpu,host=server03,region=useast load=15.4 1434055562000000000'

DEPS=( "github.com/golang/snappy" "github.com/gogo/protobuf/proto" "github.com/influxdata/influxdb/prometheus/remote" )
for dep in "${DEPS[@]}"
do
    go get $dep
done

curl https://gist.githubusercontent.com/dbellinghoven/8ee2ad3abaee6a9f842602dd7185a7b0/raw/7c14cf0f41128450d981743499f2337ff2c4b621/main.go > /tmp/test-influx/main.go

go run main.go
```

The terminal running InfluxDB should log the nil pointer dereference error shown above.

## Cause

Upon investigation, it appears that this issue is caused by the the [github.com/influxdata/influxdb/server/httpd.Handler.servePromRead](https://github.com/influxdata/influxdb/blob/master/services/httpd/handler.go#L1065) method calling `Close()` on a `nil` pointer. Specifically, when the handler attempts to read the Store [here](https://github.com/influxdata/influxdb/blob/master/services/httpd/handler.go#L1060), sometimes it can happen that the called function returns a `nil` pointer and a `nil` error, such as [here](https://github.com/influxdata/influxdb/blob/6affa7c7f59409b37b010bb8859f5675804b6258/services/storage/store.go#L138) and [here](https://github.com/influxdata/influxdb/blob/6affa7c7f59409b37b010bb8859f5675804b6258/services/storage/store.go#L145). However, the calling function does not check for the case when the returned `reads.ResultSet` and error are both `nil`. In such a case, it will continue to execute and attempt to call `Close()` on the `nil` pointer resulting in a panic when [this] (https://github.com/influxdata/influxdb/blob/master/services/httpd/handler.go#L1065) line is executed.

## Solution

With this PR, if `Store.Read()` returns a `nil` `reads.ResultSet` and error, then it will send a 404 error to the client and return. I am not sure if this is the intended outcome of such a scenario but with this fix `POST /api/v1/prom/read` will no longer panic.