### PR TITLE
Variable 'logger' collides with imported package name and incorrect usage of Println-like and Printf-like functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ v1.6.0 [2018-07-05]
 -	[#10321](https://github.com/influxdata/influxdb/pull/10321): Changes /ping route to return status code 200 instead of 204 when verbose is set.
 -	[#10300](https://github.com/influxdata/influxdb/pull/10300): Improve Compaction Performance.
 -	[#10130](https://github.com/influxdata/influxdb/pull/10130): client/v2: support custom dialer, not just socks proxy.
+-	[#10586](https://github.com/influxdata/influxdb/pull/10586): Update flux to 0.11.0.
 
 ### Bugfixes
 

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -169,11 +169,11 @@ func (cmd *Command) Close() error {
 }
 
 func (cmd *Command) monitorServerErrors() {
-	logger := log.New(cmd.Stderr, "", log.LstdFlags)
+	newLogger := log.New(cmd.Stderr, "", log.LstdFlags)
 	for {
 		select {
 		case err := <-cmd.Server.Err():
-			logger.Println(err)
+			newLogger.Println(err)
 		case <-cmd.closing:
 			return
 		}

--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -261,8 +261,7 @@ Usage: influxd run [flags]
     -cpuprofile <path>
             Write CPU profiling information to a file.
     -memprofile <path>
-            Write memory usage information to a file.
-`
+            Write memory usage information to a file.`
 
 // Options represents the command line options that can be parsed.
 type Options struct {


### PR DESCRIPTION
###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### PRS
1. Variable 'logger' collides with imported package name "github.com/influxdata/influxdb/logger"
2. Last argument of 'Fprintln' ends with redundant newline
