### PR TITLE
Call storage.Group API to correctly map group mode

### DIFF
--- a/flux/functions/inputs/from.go
+++ b/flux/functions/inputs/from.go
@@ -87,7 +87,7 @@ func createFromSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execu
 			SeriesOffset:    spec.SeriesOffset,
 			Descending:      spec.Descending,
 			OrderByTime:     spec.OrderByTime,
-			GroupMode:       storage.GroupMode(spec.GroupMode),
+			GroupMode:       storage.ToGroupMode(spec.GroupMode),
 			GroupKeys:       spec.GroupKeys,
 			AggregateMethod: spec.AggregateMethod,
 		},


### PR DESCRIPTION
This fix ensures group(mode:"by") is correctly pushed down to the
storage layer.

(cherry picked from commit 881f27fe6fd43c96eff0039d75c2a6c9dad11182)
