### PR TITLE
Fix minor config inconsistency

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -467,7 +467,7 @@
   # retention-policy = ""
   # consistency-level = "one"
   # tls-enabled = false
-  # certificate= "/etc/ssl/influxdb.pem"
+  # certificate = "/etc/ssl/influxdb.pem"
 
   # Log an error for every malformed point.
   # log-point-errors = true


### PR DESCRIPTION
Just added a space before the `=` to be consistend with the rest of the file.

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [x] Config changes: update sample config (`etc/config.sample.toml`), server `NewDemoConfig` method, and `Diagnostics` methods reporting config settings, if necessary
