### PR TITLE
Fix build.py on Go 1.11.4

### DIFF
--- a/build.py
+++ b/build.py
@@ -537,7 +537,7 @@ def build(version=None,
             build_command += "-race "
         if len(tags) > 0:
             build_command += "-tags {} ".format(','.join(tags))
-        if "1.4" in get_go_version():
+        if get_go_version().startswith("1.4"):
             if static:
                 build_command += "-ldflags=\"-s -X main.version {} -X main.branch {} -X main.commit {}\" ".format(version,
                                                                                                                   get_current_branch(),


### PR DESCRIPTION
`build.py` does not work on Go 1.11.4, because while `"1.4" in "1.11.4"` is true, 1.11 is not 1.4, and requires the 1.5+ syntax for ldflags.

###### Required for all non-trivial PRs
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)