### PR TITLE
Fix create authorization command 

### DIFF
--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -138,10 +138,25 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 		return
 	}
 
-	user, err := getAuthorizedUser(r, h.UserService)
-	if err != nil {
-		EncodeError(ctx, platform.ErrUnableToCreateToken, w)
-		return
+	var user *platform.User
+	// allow the user id to be specified optionally, if it is not set
+	// we use the id from the authorizer
+	if req.UserID == nil {
+		u, err := getAuthorizedUser(r, h.UserService)
+		if err != nil {
+			EncodeError(ctx, platform.ErrUnableToCreateToken, w)
+			return
+		}
+
+		user = u
+	} else {
+		u, err := h.UserService.FindUserByID(ctx, *req.UserID)
+		if err != nil {
+			EncodeError(ctx, platform.ErrUnableToCreateToken, w)
+			return
+		}
+
+		user = u
 	}
 
 	auth := req.toPlatform(user.ID)
@@ -172,6 +187,7 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 type postAuthorizationRequest struct {
 	Status      platform.Status       `json:"status"`
 	OrgID       platform.ID           `json:"orgID"`
+	UserID      *platform.ID          `json:"userID,omitempty"`
 	Description string                `json:"description"`
 	Permissions []platform.Permission `json:"permissions"`
 }
@@ -192,6 +208,10 @@ func newPostAuthorizationRequest(a *platform.Authorization) (*postAuthorizationR
 		Description: a.Description,
 		Permissions: a.Permissions,
 		Status:      a.Status,
+	}
+
+	if a.UserID.Valid() {
+		res.UserID = &a.UserID
 	}
 
 	res.SetDefaults()

--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -164,7 +164,7 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusCreated, newAuthResponse(auth, org, user, perms)); err != nil {
-		EncodeError(ctx, err, w)
+		logEncodingError(h.Logger, r, err)
 		return
 	}
 }


### PR DESCRIPTION
Link https://github.com/influxdata/platform/pull/2185
Closes https://github.com/influxdata/influxdb/issues/10837

Briefly describe your proposed changes:
Previously, authorizations required the users id to be set explicitly on the authorization. As of #2157 the user id is retrieved off of the authorization or session used in the http request.

We now allow users to specify an explicit user when creating authorizations. If not id is provided, the user from the authorizer will be used.

Additionally, we now need to pass the organization id when creating an authorization.