### PR TITLE
Add organization to dashboards

### DIFF
--- a/bolt/lookup_service_test.go
+++ b/bolt/lookup_service_test.go
@@ -92,7 +92,8 @@ func TestClient_Name(t *testing.T) {
 				id:       testID,
 				init: func(ctx context.Context, s *bolt.Client) error {
 					return s.CreateDashboard(ctx, &platform.Dashboard{
-						Name: "dashboard1",
+						Name:           "dashboard1",
+						OrganizationID: 1,
 					})
 				},
 			},

--- a/dashboard.go
+++ b/dashboard.go
@@ -2,6 +2,7 @@ package influxdb
 
 import (
 	"context"
+	"net/url"
 	"sort"
 	"time"
 )
@@ -67,11 +68,12 @@ type DashboardService interface {
 
 // Dashboard represents all visual and query data for a dashboard.
 type Dashboard struct {
-	ID          ID            `json:"id,omitempty"`
-	Name        string        `json:"name"`
-	Description string        `json:"description"`
-	Cells       []*Cell       `json:"cells"`
-	Meta        DashboardMeta `json:"meta"`
+	ID             ID            `json:"id,omitempty"`
+	OrganizationID ID            `json:"organizationID,omitempty"`
+	Name           string        `json:"name"`
+	Description    string        `json:"description"`
+	Cells          []*Cell       `json:"cells"`
+	Meta           DashboardMeta `json:"meta"`
 }
 
 // DashboardMeta contains meta information about dashboards
@@ -121,7 +123,25 @@ type Cell struct {
 
 // DashboardFilter is a filter for dashboards.
 type DashboardFilter struct {
-	IDs []*ID
+	IDs            []*ID
+	OrganizationID *ID
+	Organization   *string
+}
+
+// QueryParams turns a dashboard filter into query params
+func (f DashboardFilter) QueryParams() url.Values {
+	qp := url.Values{}
+	for _, id := range f.IDs {
+		if id != nil {
+			qp.Add("id", id.String())
+		}
+	}
+
+	if f.OrganizationID != nil {
+		qp.Add("orgID", f.OrganizationID.String())
+	}
+
+	return qp
 }
 
 // DashboardUpdate is the patch structure for a dashboard.

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
 
@@ -87,10 +88,11 @@ func NewDashboardHandler(mappingService platform.UserResourceMappingService, lab
 }
 
 type dashboardLinks struct {
-	Self   string `json:"self"`
-	Cells  string `json:"cells"`
-	Log    string `json:"log"`
-	Labels string `json:"labels"`
+	Self         string `json:"self"`
+	Cells        string `json:"cells"`
+	Log          string `json:"log"`
+	Labels       string `json:"labels"`
+	Organization string `json:"org"`
 }
 
 type dashboardResponse struct {
@@ -109,20 +111,22 @@ func (d dashboardResponse) toPlatform() *platform.Dashboard {
 		cells[i] = d.Cells[i].toPlatform()
 	}
 	return &platform.Dashboard{
-		ID:    d.ID,
-		Name:  d.Name,
-		Meta:  d.Meta,
-		Cells: cells,
+		ID:             d.ID,
+		OrganizationID: d.OrganizationID,
+		Name:           d.Name,
+		Meta:           d.Meta,
+		Cells:          cells,
 	}
 }
 
 func newDashboardResponse(d *platform.Dashboard, labels []*platform.Label) dashboardResponse {
 	res := dashboardResponse{
 		Links: dashboardLinks{
-			Self:   fmt.Sprintf("/api/v2/dashboards/%s", d.ID),
-			Cells:  fmt.Sprintf("/api/v2/dashboards/%s/cells", d.ID),
-			Log:    fmt.Sprintf("/api/v2/dashboards/%s/log", d.ID),
-			Labels: fmt.Sprintf("/api/v2/dashboards/%s/labels", d.ID),
+			Self:         fmt.Sprintf("/api/v2/dashboards/%s", d.ID),
+			Cells:        fmt.Sprintf("/api/v2/dashboards/%s/cells", d.ID),
+			Log:          fmt.Sprintf("/api/v2/dashboards/%s/log", d.ID),
+			Labels:       fmt.Sprintf("/api/v2/dashboards/%s/labels", d.ID),
+			Organization: fmt.Sprintf("/api/v2/orgs/%s", d.OrganizationID),
 		},
 		Dashboard: *d,
 		Labels:    []platform.Label{},
@@ -255,7 +259,7 @@ func (h *DashboardHandler) handleGetDashboards(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if err := encodeResponse(ctx, w, http.StatusOK, newGetDashboardsResponse(ctx, dashboards, h.LabelService)); err != nil {
+	if err := encodeResponse(ctx, w, http.StatusOK, newGetDashboardsResponse(ctx, dashboards, req.filter, h.LabelService)); err != nil {
 		logEncodingError(h.Logger, r, err)
 		return
 	}
@@ -280,11 +284,19 @@ func decodeGetDashboardsRequest(ctx context.Context, r *http.Request) (*getDashb
 			}
 			req.filter.IDs = append(req.filter.IDs, &i)
 		}
-	} else if owner := qp.Get("owner"); owner != "" {
+	} else if ownerID := qp.Get("ownerID"); ownerID != "" {
 		req.ownerID = &initialID
-		if err := req.ownerID.DecodeFromString(owner); err != nil {
+		if err := req.ownerID.DecodeFromString(ownerID); err != nil {
 			return nil, err
 		}
+	} else if orgID := qp.Get("orgID"); orgID != "" {
+		id := platform.InvalidID()
+		if err := id.DecodeFromString(orgID); err != nil {
+			return nil, err
+		}
+		req.filter.OrganizationID = &id
+	} else if org := qp.Get("org"); org != "" {
+		req.filter.Organization = &org
 	}
 
 	req.opts = platform.DefaultDashboardFindOptions
@@ -313,10 +325,28 @@ func (d getDashboardsResponse) toPlatform() []*platform.Dashboard {
 	return res
 }
 
-func newGetDashboardsResponse(ctx context.Context, dashboards []*platform.Dashboard, labelService platform.LabelService) getDashboardsResponse {
+func newGetDashboardsResponse(ctx context.Context, dashboards []*platform.Dashboard, filter platform.DashboardFilter, labelService platform.LabelService) getDashboardsResponse {
+	qp := url.Values{}
+	for _, id := range filter.IDs {
+		qp.Add("id", id.String())
+	}
+
+	if filter.OrganizationID != nil {
+		qp.Add("orgID", filter.OrganizationID.String())
+	}
+
+	if filter.Organization != nil {
+		qp.Add("org", *filter.Organization)
+	}
+
+	self := "/api/v2/dashboards"
+	if len(qp) > 0 {
+		self = self + "?" + qp.Encode()
+	}
+
 	res := getDashboardsResponse{
 		Links: getDashboardsLinks{
-			Self: "/api/v2/dashboards",
+			Self: self,
 		},
 		Dashboards: make([]dashboardResponse, 0, len(dashboards)),
 	}
@@ -961,6 +991,9 @@ func (s *DashboardService) FindDashboards(ctx context.Context, filter platform.D
 	qp.Add("sortBy", opts.SortBy)
 	for _, id := range filter.IDs {
 		qp.Add("id", id.String())
+	}
+	if filter.OrganizationID != nil {
+		qp.Add("orgID", filter.OrganizationID.String())
 	}
 	url.RawQuery = qp.Encode()
 

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -45,9 +45,10 @@ func TestService_handleGetDashboards(t *testing.T) {
 					FindDashboardsF: func(ctx context.Context, filter platform.DashboardFilter, opts platform.FindOptions) ([]*platform.Dashboard, int, error) {
 						return []*platform.Dashboard{
 							{
-								ID:          platformtesting.MustIDBase16("da7aba5e5d81e550"),
-								Name:        "hello",
-								Description: "oh hello there!",
+								ID:             platformtesting.MustIDBase16("da7aba5e5d81e550"),
+								OrganizationID: 1,
+								Name:           "hello",
+								Description:    "oh hello there!",
 								Meta: platform.DashboardMeta{
 									CreatedAt: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 									UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
@@ -63,7 +64,8 @@ func TestService_handleGetDashboards(t *testing.T) {
 								},
 							},
 							{
-								ID: platformtesting.MustIDBase16("0ca2204eca2204e0"),
+								ID:             platformtesting.MustIDBase16("0ca2204eca2204e0"),
+								OrganizationID: 1,
 								Meta: platform.DashboardMeta{
 									CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
 									UpdatedAt: time.Date(2012, time.November, 10, 24, 0, 0, 0, time.UTC),
@@ -100,6 +102,7 @@ func TestService_handleGetDashboards(t *testing.T) {
   "dashboards": [
     {
       "id": "da7aba5e5d81e550",
+      "organizationID": "0000000000000001",
       "name": "hello",
       "description": "oh hello there!",
       "labels": [
@@ -130,6 +133,7 @@ func TestService_handleGetDashboards(t *testing.T) {
       ],
       "links": {
         "self": "/api/v2/dashboards/da7aba5e5d81e550",
+        "org": "/api/v2/orgs/0000000000000001",
         "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
         "log": "/api/v2/dashboards/da7aba5e5d81e550/log",
         "labels": "/api/v2/dashboards/da7aba5e5d81e550/labels"
@@ -137,6 +141,7 @@ func TestService_handleGetDashboards(t *testing.T) {
     },
     {
       "id": "0ca2204eca2204e0",
+      "organizationID": "0000000000000001",
       "name": "example",
       "description": "",
 			"labels": [
@@ -155,6 +160,7 @@ func TestService_handleGetDashboards(t *testing.T) {
       "cells": [],
       "links": {
         "self": "/api/v2/dashboards/0ca2204eca2204e0",
+        "org": "/api/v2/orgs/0000000000000001",
         "log": "/api/v2/dashboards/0ca2204eca2204e0/log",
         "cells": "/api/v2/dashboards/0ca2204eca2204e0/cells",
         "labels": "/api/v2/dashboards/0ca2204eca2204e0/labels"
@@ -259,7 +265,8 @@ func TestService_handleGetDashboard(t *testing.T) {
 					FindDashboardByIDF: func(ctx context.Context, id platform.ID) (*platform.Dashboard, error) {
 						if id == platformtesting.MustIDBase16("020f755c3c082000") {
 							return &platform.Dashboard{
-								ID: platformtesting.MustIDBase16("020f755c3c082000"),
+								ID:             platformtesting.MustIDBase16("020f755c3c082000"),
+								OrganizationID: 1,
 								Meta: platform.DashboardMeta{
 									CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
 									UpdatedAt: time.Date(2012, time.November, 10, 24, 0, 0, 0, time.UTC),
@@ -290,6 +297,7 @@ func TestService_handleGetDashboard(t *testing.T) {
 				body: `
 {
   "id": "020f755c3c082000",
+  "organizationID": "0000000000000001",
   "name": "hello",
   "description": "",
   "labels": [],
@@ -312,6 +320,7 @@ func TestService_handleGetDashboard(t *testing.T) {
   ],
   "links": {
     "self": "/api/v2/dashboards/020f755c3c082000",
+		"org": "/api/v2/orgs/0000000000000001",
     "log": "/api/v2/dashboards/020f755c3c082000/log",
     "cells": "/api/v2/dashboards/020f755c3c082000/cells",
     "labels": "/api/v2/dashboards/020f755c3c082000/labels"
@@ -417,9 +426,10 @@ func TestService_handlePostDashboard(t *testing.T) {
 			},
 			args: args{
 				dashboard: &platform.Dashboard{
-					ID:          platformtesting.MustIDBase16("020f755c3c082000"),
-					Name:        "hello",
-					Description: "howdy there",
+					ID:             platformtesting.MustIDBase16("020f755c3c082000"),
+					OrganizationID: 1,
+					Name:           "hello",
+					Description:    "howdy there",
 					Cells: []*platform.Cell{
 						{
 							ID: platformtesting.MustIDBase16("da7aba5e5d81e550"),
@@ -437,6 +447,7 @@ func TestService_handlePostDashboard(t *testing.T) {
 				body: `
 {
   "id": "020f755c3c082000",
+  "organizationID": "0000000000000001",
   "name": "hello",
   "description": "howdy there",
   "labels": [],
@@ -459,6 +470,7 @@ func TestService_handlePostDashboard(t *testing.T) {
   ],
   "links": {
     "self": "/api/v2/dashboards/020f755c3c082000",
+		"org": "/api/v2/orgs/0000000000000001",
     "log": "/api/v2/dashboards/020f755c3c082000/log",
     "cells": "/api/v2/dashboards/020f755c3c082000/cells",
     "labels": "/api/v2/dashboards/020f755c3c082000/labels"
@@ -632,8 +644,9 @@ func TestService_handlePatchDashboard(t *testing.T) {
 					UpdateDashboardF: func(ctx context.Context, id platform.ID, upd platform.DashboardUpdate) (*platform.Dashboard, error) {
 						if id == platformtesting.MustIDBase16("020f755c3c082000") {
 							d := &platform.Dashboard{
-								ID:   platformtesting.MustIDBase16("020f755c3c082000"),
-								Name: "hello",
+								ID:             platformtesting.MustIDBase16("020f755c3c082000"),
+								OrganizationID: 1,
+								Name:           "hello",
 								Meta: platform.DashboardMeta{
 									CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
 									UpdatedAt: time.Date(2012, time.November, 10, 25, 0, 0, 0, time.UTC),
@@ -670,6 +683,7 @@ func TestService_handlePatchDashboard(t *testing.T) {
 				body: `
 {
   "id": "020f755c3c082000",
+	"organizationID": "0000000000000001",
   "name": "example",
   "description": "",
   "labels": [],
@@ -692,6 +706,7 @@ func TestService_handlePatchDashboard(t *testing.T) {
   ],
   "links": {
     "self": "/api/v2/dashboards/020f755c3c082000",
+    "org": "/api/v2/orgs/0000000000000001",
     "log": "/api/v2/dashboards/020f755c3c082000/log",
     "cells": "/api/v2/dashboards/020f755c3c082000/cells",
     "labels": "/api/v2/dashboards/020f755c3c082000/labels"

--- a/http/proto.go
+++ b/http/proto.go
@@ -156,7 +156,8 @@ func (h *ProtoHandler) handlePostProtosDashboards(w http.ResponseWriter, r *http
 		return
 	}
 
-	if err := encodeResponse(ctx, w, http.StatusCreated, newGetDashboardsResponse(ctx, ds, h.LabelService)); err != nil {
+	filter := platform.DashboardFilter{OrganizationID: &req.OrganizationID}
+	if err := encodeResponse(ctx, w, http.StatusCreated, newGetDashboardsResponse(ctx, ds, filter, h.LabelService)); err != nil {
 		logEncodingError(h.Logger, r, err)
 		return
 	}

--- a/http/proto_test.go
+++ b/http/proto_test.go
@@ -94,9 +94,10 @@ func TestProtoHandler(t *testing.T) {
 					CreateDashboardsFromProtoFn: func(ctx context.Context, protoID, orgID platform.ID) ([]*platform.Dashboard, error) {
 						return []*platform.Dashboard{
 							{
-								ID:          platformtesting.MustIDBase16("da7aba5e5d81e550"),
-								Name:        "hello",
-								Description: "oh hello there!",
+								ID:             platformtesting.MustIDBase16("da7aba5e5d81e550"),
+								OrganizationID: orgID,
+								Name:           "hello",
+								Description:    "oh hello there!",
 								Meta: platform.DashboardMeta{
 									CreatedAt: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 									UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
@@ -112,7 +113,8 @@ func TestProtoHandler(t *testing.T) {
 								},
 							},
 							{
-								ID: platformtesting.MustIDBase16("0ca2204eca2204e0"),
+								ID:             platformtesting.MustIDBase16("0ca2204eca2204e0"),
+								OrganizationID: orgID,
 								Meta: platform.DashboardMeta{
 									CreatedAt: time.Date(2012, time.November, 10, 23, 0, 0, 0, time.UTC),
 									UpdatedAt: time.Date(2012, time.November, 10, 24, 0, 0, 0, time.UTC),
@@ -127,7 +129,7 @@ func TestProtoHandler(t *testing.T) {
 				method:   "POST",
 				endpoint: "/api/v2/protos/0000000000000001/dashboards",
 				body: &createProtoResourcesRequest{
-					OrganizationID: 100,
+					OrganizationID: 1,
 				},
 			},
 			wants: wants{
@@ -152,12 +154,14 @@ func TestProtoHandler(t *testing.T) {
 		      ],
 		      "description": "oh hello there!",
 		      "id": "da7aba5e5d81e550",
+					"organizationID": "0000000000000001",
 		      "labels": [
 		      ],
 		      "links": {
 		        "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
 		        "labels": "/api/v2/dashboards/da7aba5e5d81e550/labels",
 		        "log": "/api/v2/dashboards/da7aba5e5d81e550/log",
+		        "org": "/api/v2/orgs/0000000000000001",
 		        "self": "/api/v2/dashboards/da7aba5e5d81e550"
 		      },
 		      "meta": {
@@ -171,12 +175,14 @@ func TestProtoHandler(t *testing.T) {
 		      ],
 		      "description": "",
 		      "id": "0ca2204eca2204e0",
+					"organizationID": "0000000000000001",
 		      "labels": [
 		      ],
 		      "links": {
 		        "cells": "/api/v2/dashboards/0ca2204eca2204e0/cells",
 		        "labels": "/api/v2/dashboards/0ca2204eca2204e0/labels",
 		        "log": "/api/v2/dashboards/0ca2204eca2204e0/log",
+		        "org": "/api/v2/orgs/0000000000000001",
 		        "self": "/api/v2/dashboards/0ca2204eca2204e0"
 		      },
 		      "meta": {
@@ -187,7 +193,7 @@ func TestProtoHandler(t *testing.T) {
 		    }
 		  ],
 		  "links": {
-		    "self": "/api/v2/dashboards"
+		    "self": "/api/v2/dashboards?orgID=0000000000000001"
 		  }
 		}
 		`,

--- a/testing/dashboards.go
+++ b/testing/dashboards.go
@@ -128,26 +128,30 @@ func CreateDashboard(
 				NowFn: func() time.Time { return time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC) },
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 				},
 			},
 			args: args{
 				dashboard: &platform.Dashboard{
-					ID:   MustIDBase16(dashTwoID),
-					Name: "dashboard2",
+					ID:             MustIDBase16(dashTwoID),
+					OrganizationID: 1,
+					Name:           "dashboard2",
 				},
 			},
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "dashboard2",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
 						Meta: platform.DashboardMeta{
 							CreatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
@@ -167,25 +171,29 @@ func CreateDashboard(
 				NowFn: func() time.Time { return time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC) },
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 				},
 			},
 			args: args{
 				dashboard: &platform.Dashboard{
-					Name: "dashboard2",
+					OrganizationID: 1,
+					Name:           "dashboard2",
 				},
 			},
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "dashboard2",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
 						Meta: platform.DashboardMeta{
 							CreatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
@@ -248,8 +256,9 @@ func AddDashboardCell(
 				NowFn: func() time.Time { return time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC) },
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 				},
 				Views: []*platform.View{
@@ -269,7 +278,8 @@ func AddDashboardCell(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID: MustIDBase16(dashOneID),
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -294,8 +304,9 @@ func AddDashboardCell(
 				},
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 				},
 				Views: []*platform.View{
@@ -313,7 +324,8 @@ func AddDashboardCell(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID: MustIDBase16(dashOneID),
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -338,8 +350,9 @@ func AddDashboardCell(
 				},
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 				},
 				Views: []*platform.View{
@@ -362,8 +375,9 @@ func AddDashboardCell(
 				},
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 				},
 			},
@@ -415,12 +429,14 @@ func FindDashboardByID(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "dashboard2",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
 					},
 				},
 			},
@@ -429,8 +445,9 @@ func FindDashboardByID(
 			},
 			wants: wants{
 				dashboard: &platform.Dashboard{
-					ID:   MustIDBase16(dashTwoID),
-					Name: "dashboard2",
+					ID:             MustIDBase16(dashTwoID),
+					OrganizationID: 1,
+					Name:           "dashboard2",
 				},
 			},
 		},
@@ -439,12 +456,14 @@ func FindDashboardByID(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "dashboard2",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
 					},
 				},
 			},
@@ -483,8 +502,9 @@ func FindDashboards(
 	t *testing.T,
 ) {
 	type args struct {
-		IDs         []*platform.ID
-		findOptions platform.FindOptions
+		IDs            []*platform.ID
+		organizationID *platform.ID
+		findOptions    platform.FindOptions
 	}
 
 	type wants struct {
@@ -502,12 +522,14 @@ func FindDashboards(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "abc",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "xyz",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
 					},
 				},
 			},
@@ -517,12 +539,59 @@ func FindDashboards(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "abc",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "xyz",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
+					},
+				},
+			},
+		},
+		{
+			name: "find all dashboards by org 10",
+			fields: DashboardFields{
+				Dashboards: []*platform.Dashboard{
+					{
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
+					},
+					{
+						ID:             2,
+						OrganizationID: 10,
+						Name:           "hello",
+					},
+					{
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
+					},
+					{
+						ID:             3,
+						OrganizationID: 10,
+						Name:           "world",
+					},
+				},
+			},
+			args: args{
+				findOptions:    platform.DefaultDashboardFindOptions,
+				organizationID: idPtr(10),
+			},
+			wants: wants{
+				dashboards: []*platform.Dashboard{
+					{
+						ID:             2,
+						OrganizationID: 10,
+						Name:           "hello",
+					},
+					{
+						ID:             3,
+						OrganizationID: 10,
+						Name:           "world",
 					},
 				},
 			},
@@ -532,14 +601,16 @@ func FindDashboards(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID: MustIDBase16(dashOneID),
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							CreatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
 						Name: "abc",
 					},
 					{
-						ID: MustIDBase16(dashTwoID),
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							CreatedAt: time.Date(2004, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -555,15 +626,17 @@ func FindDashboards(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "xyz",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
 						Meta: platform.DashboardMeta{
 							CreatedAt: time.Date(2004, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
 					},
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "abc",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
 						Meta: platform.DashboardMeta{
 							CreatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -576,14 +649,16 @@ func FindDashboards(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID: MustIDBase16(dashOneID),
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
 						Name: "abc",
 					},
 					{
-						ID: MustIDBase16(dashTwoID),
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2010, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -599,14 +674,16 @@ func FindDashboards(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID: MustIDBase16(dashOneID),
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
 						Name: "abc",
 					},
 					{
-						ID: MustIDBase16(dashTwoID),
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2010, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -620,12 +697,14 @@ func FindDashboards(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "abc",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "xyz",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
 					},
 				},
 			},
@@ -638,8 +717,9 @@ func FindDashboards(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "xyz",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
 					},
 				},
 			},
@@ -649,12 +729,14 @@ func FindDashboards(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "abc",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "xyz",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
 					},
 				},
 			},
@@ -668,12 +750,14 @@ func FindDashboards(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "abc",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "xyz",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
 					},
 				},
 			},
@@ -683,12 +767,14 @@ func FindDashboards(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "abc",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "abc",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "xyz",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "xyz",
 					},
 				},
 			},
@@ -713,6 +799,10 @@ func FindDashboards(
 			filter := platform.DashboardFilter{}
 			if tt.args.IDs != nil {
 				filter.IDs = tt.args.IDs
+			}
+
+			if tt.args.organizationID != nil {
+				filter.OrganizationID = tt.args.organizationID
 			}
 
 			dashboards, _, err := s.FindDashboards(ctx, filter, tt.args.findOptions)
@@ -749,12 +839,14 @@ func DeleteDashboard(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						Name: "A",
-						ID:   MustIDBase16(dashOneID),
+						Name:           "A",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 					},
 					{
-						Name: "B",
-						ID:   MustIDBase16(dashTwoID),
+						Name:           "B",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
 					},
 				},
 			},
@@ -764,8 +856,9 @@ func DeleteDashboard(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						Name: "B",
-						ID:   MustIDBase16(dashTwoID),
+						Name:           "B",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
 					},
 				},
 			},
@@ -775,12 +868,14 @@ func DeleteDashboard(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						Name: "A",
-						ID:   MustIDBase16(dashOneID),
+						Name:           "A",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 					},
 					{
-						Name: "B",
-						ID:   MustIDBase16(dashTwoID),
+						Name:           "B",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
 					},
 				},
 			},
@@ -795,12 +890,14 @@ func DeleteDashboard(
 				},
 				dashboards: []*platform.Dashboard{
 					{
-						Name: "A",
-						ID:   MustIDBase16(dashOneID),
+						Name:           "A",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 					},
 					{
-						Name: "B",
-						ID:   MustIDBase16(dashTwoID),
+						Name:           "B",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
 					},
 				},
 			},
@@ -854,12 +951,14 @@ func UpdateDashboard(
 				NowFn: func() time.Time { return time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC) },
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "dashboard2",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
 					},
 				},
 			},
@@ -869,7 +968,8 @@ func UpdateDashboard(
 			},
 			wants: wants{
 				dashboard: &platform.Dashboard{
-					ID: MustIDBase16(dashOneID),
+					ID:             MustIDBase16(dashOneID),
+					OrganizationID: 1,
 					Meta: platform.DashboardMeta{
 						UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 					},
@@ -883,12 +983,14 @@ func UpdateDashboard(
 				NowFn: func() time.Time { return time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC) },
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "dashboard2",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
 					},
 				},
 			},
@@ -898,9 +1000,10 @@ func UpdateDashboard(
 			},
 			wants: wants{
 				dashboard: &platform.Dashboard{
-					ID:          MustIDBase16(dashOneID),
-					Name:        "dashboard1",
-					Description: "changed",
+					ID:             MustIDBase16(dashOneID),
+					OrganizationID: 1,
+					Name:           "dashboard1",
+					Description:    "changed",
 					Meta: platform.DashboardMeta{
 						UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 					},
@@ -913,12 +1016,14 @@ func UpdateDashboard(
 				NowFn: func() time.Time { return time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC) },
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "dashboard2",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
 					},
 				},
 			},
@@ -929,9 +1034,10 @@ func UpdateDashboard(
 			},
 			wants: wants{
 				dashboard: &platform.Dashboard{
-					ID:          MustIDBase16(dashOneID),
-					Name:        "changed",
-					Description: "changed",
+					ID:             MustIDBase16(dashOneID),
+					OrganizationID: 1,
+					Name:           "changed",
+					Description:    "changed",
 					Meta: platform.DashboardMeta{
 						UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 					},
@@ -944,12 +1050,14 @@ func UpdateDashboard(
 				NowFn: func() time.Time { return time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC) },
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 					},
 					{
-						ID:   MustIDBase16(dashTwoID),
-						Name: "dashboard2",
+						ID:             MustIDBase16(dashTwoID),
+						OrganizationID: 1,
+						Name:           "dashboard2",
 					},
 				},
 			},
@@ -1023,8 +1131,9 @@ func RemoveDashboardCell(
 				},
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1050,7 +1159,8 @@ func RemoveDashboardCell(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID: MustIDBase16(dashOneID),
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -1119,8 +1229,9 @@ func UpdateDashboardCell(
 				},
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1142,7 +1253,8 @@ func UpdateDashboardCell(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID: MustIDBase16(dashOneID),
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -1171,8 +1283,9 @@ func UpdateDashboardCell(
 				},
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1192,8 +1305,9 @@ func UpdateDashboardCell(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1222,8 +1336,9 @@ func UpdateDashboardCell(
 				},
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1245,8 +1360,9 @@ func UpdateDashboardCell(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1330,8 +1446,9 @@ func ReplaceDashboardCells(
 				},
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1359,8 +1476,9 @@ func ReplaceDashboardCells(
 			wants: wants{
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Meta: platform.DashboardMeta{
 							UpdatedAt: time.Date(2009, time.November, 10, 24, 0, 0, 0, time.UTC),
 						},
@@ -1396,8 +1514,9 @@ func ReplaceDashboardCells(
 				},
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1427,8 +1546,9 @@ func ReplaceDashboardCells(
 				},
 				dashboards: []*platform.Dashboard{
 					{
-						ID:   MustIDBase16(dashOneID),
-						Name: "dashboard1",
+						ID:             MustIDBase16(dashOneID),
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: MustIDBase16(dashTwoID),
@@ -1486,8 +1606,9 @@ func GetDashboardCellView(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   1,
-						Name: "dashboard1",
+						ID:             1,
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: 100,
@@ -1514,8 +1635,9 @@ func GetDashboardCellView(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   1,
-						Name: "dashboard1",
+						ID:             1,
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: 100,
@@ -1581,8 +1703,9 @@ func UpdateDashboardCellView(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   1,
-						Name: "dashboard1",
+						ID:             1,
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: 100,
@@ -1611,8 +1734,9 @@ func UpdateDashboardCellView(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   1,
-						Name: "dashboard1",
+						ID:             1,
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: 100,
@@ -1646,8 +1770,9 @@ func UpdateDashboardCellView(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   1,
-						Name: "dashboard1",
+						ID:             1,
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: 100,
@@ -1683,8 +1808,9 @@ func UpdateDashboardCellView(
 			fields: DashboardFields{
 				Dashboards: []*platform.Dashboard{
 					{
-						ID:   1,
-						Name: "dashboard1",
+						ID:             1,
+						OrganizationID: 1,
+						Name:           "dashboard1",
 						Cells: []*platform.Cell{
 							{
 								ID: 100,


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/10778

This PR adds `OrganizationID` to dashboards supports filtering by organization id via the API.