### PR TITLE
Fix cardinality estimation error

### DIFF
--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -384,7 +384,6 @@ func (i *Index) availableThreads() int {
 
 // updateMeasurementSketches rebuilds the cached measurement sketches.
 func (i *Index) updateMeasurementSketches() error {
-	i.mSketch, i.mTSketch = hll.NewDefaultPlus(), hll.NewDefaultPlus()
 	for j := 0; j < int(i.PartitionN); j++ {
 		if s, t, err := i.partitions[j].MeasurementsSketches(); err != nil {
 			return err
@@ -399,7 +398,6 @@ func (i *Index) updateMeasurementSketches() error {
 
 // updateSeriesSketches rebuilds the cached series sketches.
 func (i *Index) updateSeriesSketches() error {
-	i.sSketch, i.sTSketch = hll.NewDefaultPlus(), hll.NewDefaultPlus()
 	for j := 0; j < int(i.PartitionN); j++ {
 		if s, t, err := i.partitions[j].SeriesSketches(); err != nil {
 			return err

--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -1051,7 +1051,7 @@ func (f *LogFile) seriesSketches() (sketch, tSketch estimator.Sketch, err error)
 	tSketch = hll.NewDefaultPlus()
 	f.tombstoneSeriesIDSet.ForEach(func(id uint64) {
 		name, keys := f.sfile.Series(id)
-		sketch.Add(models.MakeKey(name, keys))
+		tSketch.Add(models.MakeKey(name, keys))
 	})
 	return sketch, tSketch, nil
 }

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -278,14 +278,7 @@ func TestIndex_Sketches(t *testing.T) {
 		}
 
 		// Check cardinalities after the delete
-		switch idx.Index.(type) {
-		case *tsi1.Index:
-			checkCardinalities(t, idx, "initial|reopen|delete", 2923, 0, 10, 2)
-		case *inmem.ShardIndex:
-			checkCardinalities(t, idx, "initial|reopen|delete", 2430, 486, 10, 2)
-		default:
-			panic("unreachable")
-		}
+		checkCardinalities(t, idx, "initial|reopen|delete", 2430, 486, 10, 2)
 
 		// Re-open step only applies to the TSI index.
 		if _, ok := idx.Index.(*tsi1.Index); ok {
@@ -295,7 +288,7 @@ func TestIndex_Sketches(t *testing.T) {
 			}
 
 			// Check cardinalities after the reopen
-			checkCardinalities(t, idx, "initial|reopen|delete|reopen", 2923, 0, 10, 2)
+			checkCardinalities(t, idx, "initial|reopen|delete|reopen", 2430, 486, 10, 2)
 		}
 		return nil
 	}

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -1279,7 +1279,7 @@ func TestStore_Sketches(t *testing.T) {
 		}
 
 		// Check cardinalities. In this case, the indexes behave differently.
-		expS, expTS, expM, expTM := 160, 0, 10, 5
+		expS, expTS, expM, expTM := 160, 80, 10, 5
 		if index == inmem.IndexName {
 			expS, expTS, expM, expTM = 160, 80, 10, 5
 		}
@@ -1295,7 +1295,7 @@ func TestStore_Sketches(t *testing.T) {
 		}
 
 		// Check cardinalities. In this case, the indexes behave differently.
-		expS, expTS, expM, expTM = 160, 0, 5, 5
+		expS, expTS, expM, expTM = 80, 80, 5, 5
 		if index == inmem.IndexName {
 			expS, expTS, expM, expTM = 80, 0, 5, 0
 		}


### PR DESCRIPTION
This PR fixes an error in the TSI index with estimating the cardinality of series recently added and then removed.

It also resolves some erroneous assertions in tests. 