### PR TITLE
Add Scrapers tab to Organizations page

### DIFF
--- a/ui/src/organizations/components/ScraperList.tsx
+++ b/ui/src/organizations/components/ScraperList.tsx
@@ -1,0 +1,36 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import {IndexList} from 'src/clockface'
+import ScraperRow from 'src/organizations/components/ScraperRow'
+
+// DummyData
+import {resouceOwner} from 'src/organizations/dummyData'
+
+interface Props {
+  emptyState: JSX.Element
+}
+
+export default class BucketList extends PureComponent<Props> {
+  public render() {
+    const dummyData = resouceOwner
+
+    const {emptyState} = this.props
+    return (
+      <>
+        <IndexList>
+          <IndexList.Header>
+            <IndexList.HeaderCell columnName="Name" width="50%" />
+            <IndexList.HeaderCell columnName="Bucket" width="50%" />
+          </IndexList.Header>
+          <IndexList.Body columnCount={3} emptyState={emptyState}>
+            {dummyData.map(scraper => (
+              <ScraperRow scraper={scraper} />
+            ))}
+          </IndexList.Body>
+        </IndexList>
+      </>
+    )
+  }
+}

--- a/ui/src/organizations/components/ScraperRow.tsx
+++ b/ui/src/organizations/components/ScraperRow.tsx
@@ -1,0 +1,30 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import {ComponentSize, IndexList, ConfirmationButton} from 'src/clockface'
+import {ResourceOwner} from 'src/api'
+
+interface Props {
+  scraper: ResourceOwner
+}
+
+export default class BucketRow extends PureComponent<Props> {
+  public render() {
+    return (
+      <>
+        <IndexList.Row>
+          <IndexList.Cell>name</IndexList.Cell>
+          <IndexList.Cell>bucket</IndexList.Cell>
+          <IndexList.Cell>
+            <ConfirmationButton
+              size={ComponentSize.ExtraSmall}
+              text="Delete"
+              confirmText="Confirm"
+            />
+          </IndexList.Cell>
+        </IndexList.Row>
+      </>
+    )
+  }
+}

--- a/ui/src/organizations/components/Scrapers.tsx
+++ b/ui/src/organizations/components/Scrapers.tsx
@@ -1,0 +1,45 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
+import ScraperList from 'src/organizations/components/ScraperList'
+
+import {
+  Button,
+  ComponentColor,
+  IconFont,
+  ComponentSize,
+  EmptyState,
+} from 'src/clockface'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {}
+
+@ErrorHandling
+export default class OrgOptions extends PureComponent<Props> {
+  public render() {
+    return (
+      <>
+        <TabbedPageHeader>
+          <h1>Scrapers</h1>
+          <Button
+            text="Create Bucket"
+            icon={IconFont.Plus}
+            color={ComponentColor.Primary}
+          />
+        </TabbedPageHeader>
+        <ScraperList emptyState={this.emptyState} />
+      </>
+    )
+  }
+  private get emptyState(): JSX.Element {
+    return (
+      <EmptyState size={ComponentSize.Medium}>
+        <EmptyState.Text text="No Buckets match your query" />
+      </EmptyState>
+    )
+  }
+}

--- a/ui/src/organizations/containers/OrganizationView.tsx
+++ b/ui/src/organizations/containers/OrganizationView.tsx
@@ -25,6 +25,7 @@ import Members from 'src/organizations/components/Members'
 import Buckets from 'src/organizations/components/Buckets'
 import Dashboards from 'src/organizations/components/Dashboards'
 import Tasks from 'src/organizations/components/Tasks'
+import Scrapers from 'src/organizations/components/Scrapers'
 import OrgOptions from 'src/organizations/components/OrgOptions'
 import GetOrgResources from 'src/organizations/components/GetOrgResources'
 
@@ -125,6 +126,13 @@ class OrganizationView extends PureComponent<Props> {
                     </Spinner>
                   )}
                 </GetOrgResources>
+              </TabbedPageSection>
+              <TabbedPageSection
+                id="org-view-tab--scrapers"
+                url="scrapers_tab"
+                title="Scrapers"
+              >
+                <Scrapers />
               </TabbedPageSection>
               <TabbedPageSection
                 id="org-view-tab--options"


### PR DESCRIPTION
Closes #10795 

Add scrapers tab to organizaitons page with create button and delete button to the list


<img width="1329" alt="screen shot 2019-01-10 at 4 16 16 pm" src="https://user-images.githubusercontent.com/26464594/51005318-2745b900-14f3-11e9-84db-7db20c8ebeda.png">