### PR TITLE
ci: rename api-compatibility Jenkinsfile

### DIFF
--- a/api-compat.Jenkinsfile
+++ b/api-compat.Jenkinsfile
@@ -2,6 +2,7 @@ properties([disableConcurrentBuilds()])
 
 node("dind") {
     container('dind') {
+        // This method is provided by the private api-compatibility library.
         compat.test_build()
     }
 }


### PR DESCRIPTION
To get CI sorted out, we need the 2.x Jenkinsfile to have a different
name from the 1.x Jenkinsfile.