### PR TITLE
Replace .Trim() with .TrimLeft() to avoid losing data when using legacy restore

### DIFF
--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -556,7 +556,7 @@ func (cmd *Command) unpackTar(tarFile string) error {
 		return fmt.Errorf("backup tarfile name incorrect format")
 	}
 
-	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.Trim(pathParts[2], "0"))
+	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.TrimLeft(pathParts[2], "0"))
 	os.MkdirAll(shardPath, 0755)
 
 	return tarstream.Restore(f, shardPath)


### PR DESCRIPTION
This PR fixes the issue that occurs when using the legacy restore command. If a shard is ending with one or several 0's, it will be removed and data would be restored in the wrong shard, leading to data losses when restoring.

Fixes #9962

Backup example:
```
$ ls -lh /tmp/backup
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00002.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00007.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00015.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00023.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00031.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00039.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00047.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00055.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00063.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00071.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00079.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00087.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00094.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00103.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00115.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00130.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00145.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00160.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00175.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00190.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00205.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00219.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00235.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00250.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00265.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00280.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00295.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00310.00
-rw-r--r-- 1 influxdb influxdb 1.0K Jan 10 14:04 x.autogen.00325.00
```

Before this PR, after restore:
```
$ ls -lh /var/lib/influxdb/data/x/autogen/
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 103
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 115
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 13
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 145
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 15
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 16
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 175
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 19
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 2
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 205
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 219
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 23
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 235
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 25
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 265
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 28
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 295
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 31
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 325

(missing 130, 160, 190, 250, 280, 310)
```

After this PR:
```
$ ls -lh /var/lib/influxdb/data/x/autogen/
drwxr-xr-x 81 influxdb influxdb 4.0K Jan 10 17:39 .
drwxr-xr-x  4 influxdb influxdb 4.0K Jan 10 15:23 ..
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 103
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 115
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 13
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 17:23 130
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 145
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 15
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 16
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 17:23 160
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 175
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 19
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 17:23 190
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 2
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 205
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 219
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 23
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 235
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 25
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 17:23 250
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 265
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 28
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 17:23 280
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 295
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 31
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 17:23 310
drwxr-xr-x  2 influxdb influxdb 4.0K Jan 10 14:59 325

(everything is ok)
```

###### Required for all non-trivial PRs
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

###### Required only if applicable
_You can erase any checkboxes below this note if they are not applicable to your Pull Request._
- [x] Provide example syntax
