### PR TITLE
Add support for optionally logging Flux queries

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -235,6 +235,9 @@
   # Determines whether the Flux query endpoint is enabled.
   # flux-enabled = false
 
+  # Determines whether the Flux query logging is enabled.
+  # flux-log-enabled = false
+
   # The bind address used by the HTTP service.
   # bind-address = ":8086"
 

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	SuppressWriteLog        bool           `toml:"suppress-write-log"`
 	WriteTracing            bool           `toml:"write-tracing"`
 	FluxEnabled             bool           `toml:"flux-enabled"`
+	FluxLogEnabled          bool           `toml:"flux-log-enabled"`
 	PprofEnabled            bool           `toml:"pprof-enabled"`
 	DebugPprofEnabled       bool           `toml:"debug-pprof-enabled"`
 	HTTPSEnabled            bool           `toml:"https-enabled"`
@@ -66,6 +67,7 @@ func NewConfig() Config {
 	return Config{
 		Enabled:               true,
 		FluxEnabled:           false,
+		FluxLogEnabled:        false,
 		BindAddress:           DefaultBindAddress,
 		LogEnabled:            true,
 		PprofEnabled:          true,


### PR DESCRIPTION
Back port of #10996 

New configuration:

```toml
[http]
flux-log-enabled = true
```

will produce log entries similar to:

```
ts=2019-01-11T14:47:46.124347Z lvl=info msg="Executed Flux query" log_id=0CwLysq0000 service=httpd compiler_type=flux response_size=1467 query="from(bucket:\"test\") |> range(start: -5000h) |> limit(n:5)" stat_total_duration=3.949ms stat_compile_duration=3.183ms stat_queue_duration=0.026ms stat_plan_duration=0.055ms stat_requeue_duration=0.000ms stat_execute_duration=0.668ms stat_max_allocated=3200 stat_concurrency=1
```

(cherry picked from commit c47a3ea2afcc8174970daae50fc389e20175d51e)
