### PR TITLE
Only update the changelog on 1.x branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,7 @@ pipeline {
 
       when {
         anyOf {
-          branch 'master'
-          expression { BRANCH_NAME ==~ /^\d+(.\d+)*$/ }
+          expression { BRANCH_NAME ==~ /^1(.\d+)*$/ }
         }
       }
 


### PR DESCRIPTION
Master is switching to 2.x development today, and we are not going to
continue using the changelog strategy we used in 1.x.