### PR TITLE
Add NPM dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project requires Go 1.11 and Go module support.
 
 Set `GO111MODULE=on` or build the project outside of your `GOPATH` for it to succeed.
 
-If you are getting an `error loading module requirements` error with `bzr executable file not found in $PATH”` on `make`, `brew install bazaar` (on macOSX) before continuing.
+If you are getting an `error loading module requirements` error with `bzr executable file not found in $PATH”` on `make`, `brew install bazaar` (on macOS) before continuing. This error will also be returned if you have not installed `npm`.  On macOS, `brew install npm` will install `npm`.
 
 For information about modules, please refer to the [wiki](https://github.com/golang/go/wiki/Modules).
 


### PR DESCRIPTION
In addition to `bzr`, `npm` is also required to build.
