### PR TITLE
Update onboarding to be able to make telegraf configs

### DIFF
--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -515,3 +515,109 @@ export const authResponse = {
   },
   request: {},
 }
+
+export const setSetupParamsResponse = {
+  data: {
+    user: {
+      links: {
+        log: '/api/v2/users/033bc62520fe3000/log',
+        self: '/api/v2/users/033bc62520fe3000',
+      },
+      id: '033bc62520fe3000',
+      name: 'iris',
+    },
+    bucket: {
+      links: {
+        labels: '/api/v2/buckets/033bc62534fe3000/labels',
+        log: '/api/v2/buckets/033bc62534fe3000/log',
+        org: '/api/v2/orgs/033bc62534be3000',
+        self: '/api/v2/buckets/033bc62534fe3000',
+      },
+      id: '033bc62534fe3000',
+      organizationID: '033bc62534be3000',
+      organization: 'default',
+      name: 'defbuck',
+      retentionRules: [],
+      labels: [],
+    },
+    org: {
+      links: {
+        buckets: '/api/v2/buckets?org=default',
+        dashboards: '/api/v2/dashboards?org=default',
+        labels: '/api/v2/orgs/033bc62534be3000/labels',
+        log: '/api/v2/orgs/033bc62534be3000/log',
+        members: '/api/v2/orgs/033bc62534be3000/members',
+        secrets: '/api/v2/orgs/033bc62534be3000/secrets',
+        self: '/api/v2/orgs/033bc62534be3000',
+        tasks: '/api/v2/tasks?org=default',
+      },
+      id: '033bc62534be3000',
+      name: 'default',
+    },
+    auth: {
+      id: '033bc62534fe3001',
+      token:
+        'GSEx9BfvjlwQZfjoMgYX9rARwK2Nzc2jaiLdZso9E6X9K1ymldtQ3DwYbCqV3ClJ47sXdI1nLzsP2C1S4u76hA==',
+      status: 'active',
+      description: "iris's Token",
+      orgID: '033bc62534be3000',
+      org: 'default',
+      userID: '033bc62520fe3000',
+      user: 'iris',
+      permissions: [
+        {action: 'read', resource: 'authorizations', orgID: '033bc62534be3000'},
+        {
+          action: 'write',
+          resource: 'authorizations',
+          orgID: '033bc62534be3000',
+        },
+        {action: 'read', resource: 'buckets', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'buckets', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'dashboards', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'dashboards', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'orgs', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'orgs', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'sources', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'sources', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'tasks', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'tasks', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'telegrafs', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'telegrafs', orgID: '033bc62534be3000'},
+        {action: 'read', resource: 'users', orgID: '033bc62534be3000'},
+        {action: 'write', resource: 'users', orgID: '033bc62534be3000'},
+      ],
+      links: {
+        self: '/api/v2/authorizations/033bc62534fe3001',
+        user: '/api/v2/users/033bc62520fe3000',
+      },
+    },
+  },
+  status: 201,
+  statusText: 'Created',
+  headers: {
+    'access-control-allow-origin': 'http://localhost:9999',
+    date: 'Fri, 11 Jan 2019 22:49:33 GMT',
+    'access-control-allow-headers':
+      'Accept, Content-Type, Content-Length, Accept-Encoding, Authorization',
+    'transfer-encoding': 'chunked',
+    'access-control-allow-methods': 'POST, GET, OPTIONS, PUT, DELETE',
+    'content-type': 'application/json; charset=utf-8',
+  },
+  config: {
+    transformRequest: {},
+    transformResponse: {},
+    timeout: 0,
+    xsrfCookieName: 'XSRF-TOKEN',
+    xsrfHeaderName: 'X-XSRF-TOKEN',
+    maxContentLength: -1,
+    headers: {
+      Accept: 'application/json, text/plain, */*',
+      'Content-Type': 'application/json',
+    },
+    method: 'post',
+    data:
+      '{"username":"iris","password":"iris","org":"default","bucket":"defbuck"}',
+    url: '/api/v2/setup',
+  },
+  request: {},
+}

--- a/ui/src/onboarding/actions/dataLoaders.ts
+++ b/ui/src/onboarding/actions/dataLoaders.ts
@@ -5,8 +5,6 @@ import _ from 'lodash'
 import {
   writeLineProtocol,
   createTelegrafConfig,
-  getTelegrafConfigs,
-  updateTelegrafConfig,
 } from 'src/onboarding/apis/index'
 
 // Utils
@@ -237,11 +235,10 @@ export const createOrUpdateTelegrafConfigAsync = (authToken: string) => async (
       dataLoaders: {telegrafPlugins},
       steps: {
         setupParams: {org, bucket},
+        organizationID,
       },
     },
   } = getState()
-
-  const telegrafConfigsFromServer = await getTelegrafConfigs(org)
 
   let plugins = []
   telegrafPlugins.forEach(tp => {
@@ -254,14 +251,7 @@ export const createOrUpdateTelegrafConfigAsync = (authToken: string) => async (
     name: 'new config',
     agent: {collectionInterval: DEFAULT_COLLECTION_INTERVAL},
     plugins,
-  }
-
-  if (telegrafConfigsFromServer.length) {
-    const id = _.get(telegrafConfigsFromServer, '0.id', '')
-
-    await updateTelegrafConfig(id, body)
-    dispatch(setTelegrafConfigID(id))
-    return
+    organizationID,
   }
 
   const influxDB2Out = {

--- a/ui/src/onboarding/apis/index.ts
+++ b/ui/src/onboarding/apis/index.ts
@@ -5,7 +5,12 @@ import {baseAPI, setupAPI, sourcesAPI} from 'src/utils/api'
 
 // Utils
 import {telegrafsAPI, authorizationsAPI, writeAPI} from 'src/utils/api'
-import {Telegraf, WritePrecision, TelegrafRequest} from 'src/api'
+import {
+  Telegraf,
+  WritePrecision,
+  TelegrafRequest,
+  OnboardingResponse,
+} from 'src/api'
 
 import {getDeep} from 'src/utils/wrappers'
 
@@ -46,9 +51,10 @@ export interface SetupParams {
 
 export const setSetupParams = async (
   setupParams: SetupParams
-): Promise<void> => {
+): Promise<OnboardingResponse> => {
   try {
-    await setupAPI.setupPost(setupParams)
+    const result = await setupAPI.setupPost(setupParams)
+    return result.data
   } catch (error) {
     console.error("Can't set setup parameters", error)
     throw error

--- a/ui/src/onboarding/apis/mocks.ts
+++ b/ui/src/onboarding/apis/mocks.ts
@@ -2,6 +2,7 @@ import {
   getTelegrafConfigsResponse,
   authResponse,
   createTelegrafConfigResponse,
+  setSetupParamsResponse,
 } from 'mocks/dummyData'
 
 const telegrafsGet = jest.fn(() => Promise.resolve(getTelegrafConfigsResponse))
@@ -12,7 +13,7 @@ const telegrafsTelegrafIDPut = jest.fn(() =>
   Promise.resolve(createTelegrafConfigResponse)
 )
 const authorizationsGet = jest.fn(() => Promise.resolve(authResponse))
-const setupPost = jest.fn(() => Promise.resolve())
+const setupPost = jest.fn(() => Promise.resolve(setSetupParamsResponse))
 const setupGet = jest.fn(() => Promise.resolve({data: {allowed: true}}))
 
 export const telegrafsAPI = {

--- a/ui/src/onboarding/components/AdminStep.test.tsx
+++ b/ui/src/onboarding/components/AdminStep.test.tsx
@@ -11,6 +11,7 @@ import {defaultOnboardingStepProps} from 'mocks/dummyData'
 const setup = (override = {}) => {
   const props = {
     ...defaultOnboardingStepProps,
+    onSetupAdmin: jest.fn(),
     ...override,
   }
 

--- a/ui/src/onboarding/components/AdminStep.tsx
+++ b/ui/src/onboarding/components/AdminStep.tsx
@@ -17,8 +17,8 @@ import {
 import OnboardingButtons from 'src/onboarding/components/OnboardingButtons'
 import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
 
-// APIS
-import {setSetupParams, SetupParams, signin} from 'src/onboarding/apis'
+// Actions
+import {setupAdmin} from 'src/onboarding/actions/steps'
 
 // Constants
 import * as copy from 'src/shared/copy/notifications'
@@ -26,6 +26,7 @@ import * as copy from 'src/shared/copy/notifications'
 // Types
 import {StepStatus} from 'src/clockface/constants/wizard'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
+import {SetupParams} from 'src/onboarding/apis'
 
 interface State extends SetupParams {
   confirmPassword: string
@@ -33,9 +34,13 @@ interface State extends SetupParams {
   isPassMismatched: boolean
 }
 
+interface Props extends OnboardingStepProps {
+  onSetupAdmin: typeof setupAdmin
+}
+
 @ErrorHandling
-class AdminStep extends PureComponent<OnboardingStepProps, State> {
-  constructor(props: OnboardingStepProps) {
+class AdminStep extends PureComponent<Props, State> {
+  constructor(props: Props) {
     super(props)
     const {setupParams} = props
     this.state = {
@@ -253,9 +258,9 @@ class AdminStep extends PureComponent<OnboardingStepProps, State> {
     const {
       onSetStepStatus,
       currentStepIndex,
-      handleSetSetupParams,
       notify,
       onIncrementCurrentStepIndex,
+      onSetupAdmin: onSetupAdmin,
     } = this.props
 
     const {username, password, org, bucket, isAlreadySet} = this.state
@@ -274,10 +279,7 @@ class AdminStep extends PureComponent<OnboardingStepProps, State> {
     }
 
     try {
-      await setSetupParams(setupParams)
-      await signin({username, password})
-      notify(copy.SetupSuccess)
-      handleSetSetupParams(setupParams)
+      onSetupAdmin(setupParams)
       onSetStepStatus(currentStepIndex, StepStatus.Complete)
       onIncrementCurrentStepIndex()
     } catch (error) {

--- a/ui/src/onboarding/components/OnboardingStepSwitcher.tsx
+++ b/ui/src/onboarding/components/OnboardingStepSwitcher.tsx
@@ -30,6 +30,7 @@ import {
 import {SetupParams} from 'src/onboarding/apis'
 import {DataLoadersState} from 'src/types/v2/dataLoaders'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
+import {setupAdmin} from '../actions/steps'
 
 interface Props {
   onboardingStepProps: OnboardingStepProps
@@ -46,6 +47,7 @@ interface Props {
   onAddPluginBundle: typeof addPluginBundleWithPlugins
   onRemovePluginBundle: typeof removePluginBundleWithPlugins
   onSetConfigArrayValue: typeof setConfigArrayValue
+  onSetupAdmin: typeof setupAdmin
 }
 
 @ErrorHandling
@@ -66,13 +68,16 @@ class OnboardingStepSwitcher extends PureComponent<Props> {
       onAddPluginBundle,
       onRemovePluginBundle,
       onSetConfigArrayValue,
+      onSetupAdmin,
     } = this.props
 
     switch (currentStepIndex) {
       case 0:
         return <InitStep {...onboardingStepProps} />
       case 1:
-        return <AdminStep {...onboardingStepProps} />
+        return (
+          <AdminStep {...onboardingStepProps} onSetupAdmin={onSetupAdmin} />
+        )
       case 2:
         return (
           <SelectDataSourceStep

--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -15,7 +15,11 @@ import OnboardingStepSwitcher from 'src/onboarding/components/OnboardingStepSwit
 
 // Actions
 import {notify as notifyAction} from 'src/shared/actions/notifications'
-import {setSetupParams, setStepStatus} from 'src/onboarding/actions/steps'
+import {
+  setSetupParams,
+  setStepStatus,
+  setupAdmin,
+} from 'src/onboarding/actions/steps'
 
 import {
   setDataLoadersType,
@@ -83,6 +87,7 @@ interface DispatchProps {
   onSetPluginConfiguration: typeof setPluginConfiguration
   onSetConfigArrayValue: typeof setConfigArrayValue
   onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
+  onSetupAdmin: typeof setupAdmin
 }
 
 interface StateProps {
@@ -128,6 +133,7 @@ class OnboardingWizard extends PureComponent<Props> {
       setupParams,
       notify,
       onSetConfigArrayValue,
+      onSetupAdmin,
     } = this.props
 
     return (
@@ -160,6 +166,7 @@ class OnboardingWizard extends PureComponent<Props> {
               onAddPluginBundle={onAddPluginBundle}
               onRemovePluginBundle={onRemovePluginBundle}
               onSetConfigArrayValue={onSetConfigArrayValue}
+              onSetupAdmin={onSetupAdmin}
             />
           </div>
         </div>
@@ -294,6 +301,7 @@ const mdtp: DispatchProps = {
   onRemovePluginBundle: removePluginBundleWithPlugins,
   onSetPluginConfiguration: setPluginConfiguration,
   onSetConfigArrayValue: setConfigArrayValue,
+  onSetupAdmin: setupAdmin,
 }
 
 export default connect<StateProps, DispatchProps, OwnProps>(

--- a/ui/src/onboarding/reducers/steps.ts
+++ b/ui/src/onboarding/reducers/steps.ts
@@ -8,11 +8,13 @@ import {SetupParams} from 'src/onboarding/apis'
 export interface OnboardingStepsState {
   stepStatuses: StepStatus[]
   setupParams: SetupParams
+  organizationID: string
 }
 
 const INITIAL_STATE: OnboardingStepsState = {
   stepStatuses: new Array(6).fill(StepStatus.Incomplete),
   setupParams: null,
+  organizationID: '',
 }
 
 export default (
@@ -26,6 +28,8 @@ export default (
       const stepStatuses = [...state.stepStatuses]
       stepStatuses[action.payload.index] = action.payload.status
       return {...state, stepStatuses}
+    case 'SET_ORG_ID':
+      return {...state, organizationID: action.payload.organizationID}
     default:
       return state
   }


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Currently the api returns an error for get requests to the /telegrafs endpoint. Formerlly the ui would make that request to see if the config was already created to determine whether to update an existing config or create a new one. This check and update were removed until that fix is made to make onboarding work.

Additionally, we now store the organization id returned from setting up an admin since a telegraf post request now requires it.

  - [x] Rebased/mergeable
  - [x] Tests pass
