### PR TITLE
Add save query as task functionality to Data Explorer

### DIFF
--- a/ui/src/dataExplorer/components/SaveAsButton.test.tsx
+++ b/ui/src/dataExplorer/components/SaveAsButton.test.tsx
@@ -1,0 +1,31 @@
+// Libraries
+import React from 'react'
+import {shallow} from 'enzyme'
+
+// Components
+import SaveAsButton from 'src/dataExplorer/components/SaveAsButton'
+import SaveAsCellForm from 'src/dataExplorer/components/SaveAsCellForm'
+
+const setup = () => {
+  const wrapper = shallow(<SaveAsButton />)
+
+  return {wrapper}
+}
+
+describe('SaveAsButton', () => {
+  const {wrapper} = setup()
+  describe('rendering', () => {
+    it('renders', () => {
+      expect(wrapper.exists()).toBe(true)
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('save as cell form', () => {
+    it('defaults to save as cell form', () => {
+      const saveAsCellForm = wrapper.find(SaveAsCellForm)
+
+      expect(saveAsCellForm.exists()).toBe(true)
+    })
+  })
+})

--- a/ui/src/dataExplorer/components/SaveAsButton.tsx
+++ b/ui/src/dataExplorer/components/SaveAsButton.tsx
@@ -45,11 +45,11 @@ class SaveAsButton extends PureComponent<Props, State> {
           icon={IconFont.Export}
           text="Save As"
           onClick={this.handleShowOverlay}
-          color={ComponentColor.Success}
+          color={ComponentColor.Primary}
           titleText="Save your query as a Dashboard Cell or a Task"
         />
         <OverlayTechnology visible={isOverlayVisible}>
-          <OverlayContainer>
+          <OverlayContainer maxWidth={600}>
             <OverlayHeading
               title="Save As"
               onDismiss={this.handleHideOverlay}
@@ -61,6 +61,7 @@ class SaveAsButton extends PureComponent<Props, State> {
                     active={saveAsOption === SaveAsOption.Dashboard}
                     value={SaveAsOption.Dashboard}
                     onClick={this.handleSetSaveAsOption}
+                    data-test="cell-radio-button"
                   >
                     Dashboard Cell
                   </Radio.Button>
@@ -68,20 +69,28 @@ class SaveAsButton extends PureComponent<Props, State> {
                     active={saveAsOption === SaveAsOption.Task}
                     value={SaveAsOption.Task}
                     onClick={this.handleSetSaveAsOption}
+                    data-test="task-radio-button"
                   >
                     Task
                   </Radio.Button>
                 </Radio>
               </div>
-              {saveAsOption === SaveAsOption.Dashboard && (
-                <SaveAsCellForm dismiss={this.handleHideOverlay} />
-              )}
-              {saveAsOption === SaveAsOption.Task && <SaveAsTaskForm />}
+              {this.saveAsForm}
             </OverlayBody>
           </OverlayContainer>
         </OverlayTechnology>
       </>
     )
+  }
+
+  private get saveAsForm(): JSX.Element {
+    const {saveAsOption} = this.state
+
+    if (saveAsOption === SaveAsOption.Dashboard) {
+      return <SaveAsCellForm dismiss={this.handleHideOverlay} />
+    } else if (saveAsOption === SaveAsOption.Task) {
+      return <SaveAsTaskForm dismiss={this.handleHideOverlay} />
+    }
   }
 
   private handleShowOverlay = () => {

--- a/ui/src/dataExplorer/components/SaveAsTaskForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsTaskForm.tsx
@@ -1,7 +1,147 @@
-import React from 'react'
+// Libraries
+import React, {PureComponent, ChangeEvent} from 'react'
+import {connect} from 'react-redux'
+import _ from 'lodash'
 
-const SaveAsTaskForm = () => {
-  return <div>Tasks Not implemented</div>
+// Components
+import TaskForm from 'src/tasks/components/TaskForm'
+
+// Actions
+import {
+  saveNewScript,
+  setTaskOption,
+  clearTask,
+  setNewScript,
+} from 'src/tasks/actions/v2'
+
+// Types
+import {AppState, Organization} from 'src/types/v2'
+import {
+  TaskSchedule,
+  TaskOptions,
+  TaskOptionKeys,
+} from 'src/utils/taskOptionsToFluxScript'
+import {DashboardDraftQuery} from 'src/types/v2/dashboards'
+
+interface OwnProps {
+  dismiss: () => void
 }
 
-export default SaveAsTaskForm
+interface DispatchProps {
+  saveNewScript: typeof saveNewScript
+  setTaskOption: typeof setTaskOption
+  clearTask: typeof clearTask
+  setNewScript: typeof setNewScript
+}
+
+interface StateProps {
+  orgs: Organization[]
+  taskOptions: TaskOptions
+  draftQueries: DashboardDraftQuery[]
+  activeQueryIndex: number
+}
+
+type Props = StateProps & OwnProps & DispatchProps
+
+class SaveAsTaskForm extends PureComponent<Props> {
+  public componentDidMount() {
+    const {setTaskOption, setNewScript} = this.props
+
+    setTaskOption({
+      key: 'taskScheduleType',
+      value: TaskSchedule.interval,
+    })
+
+    setNewScript(this.activeScript)
+  }
+
+  public componentWillUnmount() {
+    const {clearTask} = this.props
+
+    clearTask()
+  }
+  public render() {
+    const {orgs, taskOptions, dismiss} = this.props
+
+    return (
+      <TaskForm
+        orgs={orgs}
+        taskOptions={taskOptions}
+        onChangeScheduleType={this.handleChangeScheduleType}
+        onChangeInput={this.handleChangeInput}
+        onChangeTaskOrgID={this.handleChangeTaskOrgID}
+        isInOverlay={true}
+        onSubmit={this.handleSubmit}
+        canSubmit={this.isFormValid}
+        dismiss={dismiss}
+      />
+    )
+  }
+
+  private get isFormValid(): boolean {
+    const {
+      taskOptions: {name, cron, interval},
+    } = this.props
+    const hasSchedule = !!cron || !!interval
+
+    return hasSchedule && !!name && !!this.activeScript
+  }
+
+  private get activeScript(): string {
+    const {draftQueries, activeQueryIndex} = this.props
+
+    return _.get(draftQueries, `${activeQueryIndex}.text`)
+  }
+
+  private handleSubmit = () => {
+    const {saveNewScript} = this.props
+    saveNewScript()
+  }
+
+  private handleChangeTaskOrgID = (orgID: string) => {
+    const {setTaskOption} = this.props
+
+    setTaskOption({key: 'orgID', value: orgID})
+  }
+
+  private handleChangeScheduleType = (taskScheduleType: TaskSchedule) => {
+    const {setTaskOption} = this.props
+
+    setTaskOption({key: 'taskScheduleType', value: taskScheduleType})
+  }
+
+  private handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const {setTaskOption} = this.props
+
+    const key = e.target.name as TaskOptionKeys
+    const value = e.target.value
+
+    setTaskOption({key, value})
+  }
+}
+
+const mstp = (state: AppState): StateProps => {
+  const {
+    orgs,
+    tasks,
+    timeMachines: {
+      timeMachines: {de},
+    },
+  } = state
+
+  const {draftQueries, activeQueryIndex} = de
+
+  return {orgs, taskOptions: tasks.taskOptions, draftQueries, activeQueryIndex}
+}
+
+const mdtp: DispatchProps = {
+  saveNewScript,
+  setTaskOption,
+  clearTask,
+  setNewScript,
+}
+
+export default connect<StateProps, DispatchProps>(
+  mstp,
+  mdtp
+)(SaveAsTaskForm)

--- a/ui/src/dataExplorer/components/__snapshots__/SaveAsButton.test.tsx.snap
+++ b/ui/src/dataExplorer/components/__snapshots__/SaveAsButton.test.tsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SaveAsButton rendering renders 1`] = `
+<Fragment>
+  <Button
+    active={false}
+    color="primary"
+    icon="export"
+    onClick={[Function]}
+    shape="none"
+    size="sm"
+    status="default"
+    text="Save As"
+    titleText="Save your query as a Dashboard Cell or a Task"
+    type="button"
+  />
+  <OverlayTechnology
+    visible={false}
+  >
+    <OverlayContainer
+      maxWidth={600}
+    >
+      <OverlayHeading
+        onDismiss={[Function]}
+        title="Save As"
+      />
+      <OverlayBody>
+        <div
+          className="save-as--options"
+        >
+          <Radio
+            color="primary"
+            shape="none"
+            size="sm"
+          >
+            <RadioButton
+              active={true}
+              data-test="cell-radio-button"
+              disabled={false}
+              disabledTitleText="This option is disabled"
+              onClick={[Function]}
+              value="dashboard"
+            >
+              Dashboard Cell
+            </RadioButton>
+            <RadioButton
+              active={false}
+              data-test="task-radio-button"
+              disabled={false}
+              disabledTitleText="This option is disabled"
+              onClick={[Function]}
+              value="task"
+            >
+              Task
+            </RadioButton>
+          </Radio>
+        </div>
+        <Connect(SaveAsCellForm)
+          dismiss={[Function]}
+        />
+      </OverlayBody>
+    </OverlayContainer>
+  </OverlayTechnology>
+</Fragment>
+`;

--- a/ui/src/tasks/components/TaskForm.scss
+++ b/ui/src/tasks/components/TaskForm.scss
@@ -14,7 +14,7 @@
 }
 
 .task-form--options {
-  flex: 1 0 0;
+  flex: 1 0 140px;
   padding: $ix-marg-d;
 }
 

--- a/ui/src/tasks/components/TaskForm.test.tsx
+++ b/ui/src/tasks/components/TaskForm.test.tsx
@@ -1,0 +1,38 @@
+// Libraries
+import React from 'react'
+import {shallow} from 'enzyme'
+
+// Components
+import TaskForm from 'src/tasks/components/TaskForm'
+import {Form} from 'src/clockface'
+
+// Constants
+import defaultTaskOptions from 'src/tasks/reducers/v2'
+
+const setup = (override?) => {
+  const props = {
+    orgs: [],
+    taskOptions: defaultTaskOptions,
+    onChangeScheduleType: jest.fn(),
+    onChangeInput: jest.fn(),
+    onChangeTaskOrgID: jest.fn(),
+    ...override,
+  }
+
+  const wrapper = shallow(<TaskForm {...props} />)
+
+  return {wrapper}
+}
+
+describe('TaskForm', () => {
+  describe('rendering', () => {
+    it('renders', () => {
+      const {wrapper} = setup()
+      const form = wrapper.find(Form)
+
+      expect(wrapper.exists()).toBe(true)
+      expect(form.exists()).toBe(true)
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+})

--- a/ui/src/tasks/components/TaskForm.tsx
+++ b/ui/src/tasks/components/TaskForm.tsx
@@ -11,9 +11,11 @@ import {
   Input,
   Radio,
   ButtonShape,
+  Button,
+  ComponentColor,
+  ButtonType,
 } from 'src/clockface'
 import TaskOptionsOrgDropdown from 'src/tasks/components/TasksOptionsOrgDropdown'
-import FluxEditor from 'src/shared/components/FluxEditor'
 import TaskScheduleFormField from 'src/tasks/components/TaskScheduleFormField'
 
 // Types
@@ -25,132 +27,134 @@ import {Organization} from 'src/api'
 import './TaskForm.scss'
 
 interface Props {
-  script: string
   orgs: Organization[]
   taskOptions: TaskOptions
   onChangeScheduleType: (schedule: TaskSchedule) => void
-  onChangeScript: (script: string) => void
   onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void
   onChangeTaskOrgID: (orgID: string) => void
+  isInOverlay?: boolean
+  onSubmit?: () => void
+  canSubmit?: boolean
+  dismiss?: () => void
 }
 
 interface State {
-  retryAttempts: string
   schedule: TaskSchedule
 }
 
 export default class TaskForm extends PureComponent<Props, State> {
+  public static defaultProps: Partial<Props> = {
+    isInOverlay: false,
+    onSubmit: () => {},
+    canSubmit: true,
+    dismiss: () => {},
+  }
   constructor(props) {
     super(props)
 
     this.state = {
-      retryAttempts: '1',
       schedule: props.taskOptions.taskScheduleType,
     }
   }
 
   public render() {
     const {
-      script,
       onChangeInput,
-      onChangeScript,
       onChangeTaskOrgID,
       taskOptions: {name, taskScheduleType, interval, offset, cron, orgID},
       orgs,
+      isInOverlay,
     } = this.props
 
     return (
-      <div className="task-form">
-        <div className="task-form--options">
-          <Form>
-            <Grid>
-              <Grid.Row>
-                <Grid.Column widthXS={Columns.Twelve}>
-                  <Form.Element label="Name">
-                    <Input
-                      name="name"
-                      placeholder="Name your task"
-                      onChange={onChangeInput}
-                      value={name}
-                    />
-                  </Form.Element>
-                </Grid.Column>
-                <Grid.Column widthXS={Columns.Twelve}>
-                  <Form.Element label="Owner">
-                    <TaskOptionsOrgDropdown
-                      orgs={orgs}
-                      selectedOrgID={orgID}
-                      onChangeTaskOrgID={onChangeTaskOrgID}
-                    />
-                  </Form.Element>
-                </Grid.Column>
-                <Grid.Column widthXS={Columns.Twelve}>
-                  <Form.Element label="Schedule Task">
-                    <ComponentSpacer
-                      align={Alignment.Left}
-                      stackChildren={Stack.Rows}
+      <Form>
+        <Grid>
+          <Grid.Row>
+            <Grid.Column widthXS={Columns.Twelve}>
+              <Form.Element label="Name">
+                <Input
+                  name="name"
+                  placeholder="Name your task"
+                  onChange={onChangeInput}
+                  value={name}
+                />
+              </Form.Element>
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Twelve}>
+              <Form.Element label="Owner">
+                <TaskOptionsOrgDropdown
+                  orgs={orgs}
+                  selectedOrgID={orgID}
+                  onChangeTaskOrgID={onChangeTaskOrgID}
+                />
+              </Form.Element>
+            </Grid.Column>
+            <Grid.Column>
+              <Form.Element label="Schedule Task">
+                <ComponentSpacer
+                  align={Alignment.Left}
+                  stackChildren={Stack.Rows}
+                >
+                  <Radio shape={ButtonShape.StretchToFit}>
+                    <Radio.Button
+                      id="interval"
+                      active={taskScheduleType === TaskSchedule.interval}
+                      value={TaskSchedule.interval}
+                      titleText="Interval"
+                      onClick={this.handleChangeScheduleType}
                     >
-                      <Radio shape={ButtonShape.StretchToFit}>
-                        <Radio.Button
-                          id="interval"
-                          active={taskScheduleType === TaskSchedule.interval}
-                          value={TaskSchedule.interval}
-                          titleText="Interval"
-                          onClick={this.handleChangeScheduleType}
-                        >
-                          Interval
-                        </Radio.Button>
-                        <Radio.Button
-                          id="cron"
-                          active={taskScheduleType === TaskSchedule.cron}
-                          value={TaskSchedule.cron}
-                          titleText="Cron"
-                          onClick={this.handleChangeScheduleType}
-                        >
-                          Cron
-                        </Radio.Button>
-                      </Radio>
-                      <TaskScheduleFormField
-                        onChangeInput={onChangeInput}
-                        schedule={taskScheduleType}
-                        interval={interval}
-                        offset={offset}
-                        cron={cron}
-                      />
-                    </ComponentSpacer>
-                  </Form.Element>
-                </Grid.Column>
-                <Grid.Column widthXS={Columns.Twelve}>
-                  <Form.Element label="Retry attempts">
-                    <Input
-                      name="retry"
-                      placeholder=""
-                      onChange={this.handleChangeRetry}
-                      status={ComponentStatus.Disabled}
-                      value={this.state.retryAttempts}
-                    />
-                  </Form.Element>
-                </Grid.Column>
-              </Grid.Row>
-            </Grid>
-          </Form>
-        </div>
-        <div className="task-form--editor">
-          <FluxEditor
-            script={script}
-            onChangeScript={onChangeScript}
-            visibility="visible"
-            status={{text: '', type: ''}}
-            suggestions={[]}
-          />
-        </div>
-      </div>
+                      Interval
+                    </Radio.Button>
+                    <Radio.Button
+                      id="cron"
+                      active={taskScheduleType === TaskSchedule.cron}
+                      value={TaskSchedule.cron}
+                      titleText="Cron"
+                      onClick={this.handleChangeScheduleType}
+                    >
+                      Cron
+                    </Radio.Button>
+                  </Radio>
+                </ComponentSpacer>
+              </Form.Element>
+            </Grid.Column>
+            <TaskScheduleFormField
+              onChangeInput={onChangeInput}
+              schedule={taskScheduleType}
+              interval={interval}
+              offset={offset}
+              cron={cron}
+            />
+            {isInOverlay && this.buttons}
+          </Grid.Row>
+        </Grid>
+      </Form>
     )
   }
 
-  private handleChangeRetry = (e: ChangeEvent<HTMLInputElement>): void => {
-    const retryAttempts = e.target.value
-    this.setState({retryAttempts})
+  private get buttons(): JSX.Element {
+    const {onSubmit, canSubmit, dismiss} = this.props
+    return (
+      <Grid.Column widthXS={Columns.Twelve}>
+        <Form.Footer>
+          <Button
+            text="Cancel"
+            onClick={dismiss}
+            titleText="Cancel save"
+            type={ButtonType.Button}
+          />
+          <Button
+            text={'Save as Task'}
+            color={ComponentColor.Success}
+            type={ButtonType.Submit}
+            onClick={onSubmit}
+            status={
+              canSubmit ? ComponentStatus.Default : ComponentStatus.Disabled
+            }
+          />
+        </Form.Footer>
+      </Grid.Column>
+    )
   }
 
   private handleChangeScheduleType = (schedule: TaskSchedule): void => {

--- a/ui/src/tasks/components/TaskHeader.tsx
+++ b/ui/src/tasks/components/TaskHeader.tsx
@@ -1,12 +1,13 @@
 import React, {PureComponent} from 'react'
 
 import {Page} from 'src/pageLayout'
-import {ComponentColor, Button} from 'src/clockface'
+import {ComponentColor, Button, ComponentStatus} from 'src/clockface'
 
 import 'src/tasks/components/TasksPage.scss'
 
 interface Props {
   title: string
+  canSubmit: boolean
   onCancel: () => void
   onSave: () => void
 }
@@ -27,6 +28,11 @@ export default class TaskHeader extends PureComponent<Props> {
           <Button
             color={ComponentColor.Success}
             text="Save"
+            status={
+              this.props.canSubmit
+                ? ComponentStatus.Default
+                : ComponentStatus.Disabled
+            }
             onClick={this.props.onSave}
           />
         </Page.Header.Right>

--- a/ui/src/tasks/components/TaskScheduleFormField.tsx
+++ b/ui/src/tasks/components/TaskScheduleFormField.tsx
@@ -2,10 +2,9 @@
 import React, {PureComponent, ChangeEvent} from 'react'
 
 // Components
-import {ComponentSpacer, Input, InputType} from 'src/clockface'
+import {Input, InputType, Grid, Form, Columns} from 'src/clockface'
 
 // Types
-import {Alignment} from 'src/clockface'
 import {TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
 
 interface Props {
@@ -22,31 +21,33 @@ export default class TaskScheduleFormFields extends PureComponent<Props> {
 
     return (
       <>
-        <ComponentSpacer align={Alignment.Left} stretchToFitWidth={true}>
-          <label className="task-form--form-label">
-            {schedule === TaskSchedule.interval ? 'Interval' : 'Cron'}
-          </label>
-          <Input
-            name={schedule}
-            type={InputType.Text}
-            placeholder={
-              schedule === TaskSchedule.interval ? '1d3h30s' : '0 2 * * *'
-            }
-            value={schedule === TaskSchedule.interval ? interval : cron}
-            onChange={this.props.onChangeInput}
-          />
-        </ComponentSpacer>
+        <Grid.Column widthXS={Columns.Six}>
+          <Form.Element
+            label={schedule === TaskSchedule.interval ? 'Interval' : 'Cron'}
+          >
+            <Input
+              name={schedule}
+              type={InputType.Text}
+              placeholder={
+                schedule === TaskSchedule.interval ? '1d3h30s' : '0 2 * * *'
+              }
+              value={schedule === TaskSchedule.interval ? interval : cron}
+              onChange={this.props.onChangeInput}
+            />
+          </Form.Element>
+        </Grid.Column>
 
-        <ComponentSpacer align={Alignment.Left} stretchToFitWidth={true}>
-          <label className="task-form--form-label">Offset</label>
-          <Input
-            name="offset"
-            type={InputType.Text}
-            value={offset}
-            placeholder="20m"
-            onChange={onChangeInput}
-          />
-        </ComponentSpacer>
+        <Grid.Column widthXS={Columns.Six}>
+          <Form.Element label="Offset">
+            <Input
+              name="offset"
+              type={InputType.Text}
+              value={offset}
+              placeholder="20m"
+              onChange={onChangeInput}
+            />
+          </Form.Element>
+        </Grid.Column>
       </>
     )
   }

--- a/ui/src/tasks/components/__snapshots__/TaskForm.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TaskForm.test.tsx.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TaskForm rendering renders 1`] = `
+<Form>
+  <Grid>
+    <GridRow>
+      <GridColumn
+        widthXS={12}
+      >
+        <FormElement
+          label="Name"
+        >
+          <Input
+            autoFocus={false}
+            autocomplete="off"
+            disabledTitleText="This input is disabled"
+            name="name"
+            onChange={[MockFunction]}
+            placeholder="Name your task"
+            size="sm"
+            spellCheck={false}
+            status="default"
+            titleText=""
+            value=""
+          />
+        </FormElement>
+      </GridColumn>
+      <GridColumn
+        widthXS={12}
+      >
+        <FormElement
+          label="Owner"
+        >
+          <TaskOptionsOrgDropdown
+            onChangeTaskOrgID={[MockFunction]}
+            orgs={Array []}
+          />
+        </FormElement>
+      </GridColumn>
+      <GridColumn
+        widthXS={12}
+      >
+        <FormElement
+          label="Schedule Task"
+        >
+          <ComponentSpacer
+            align="left"
+            stackChildren="rows"
+          >
+            <Radio
+              color="primary"
+              shape="stretch"
+              size="sm"
+            >
+              <RadioButton
+                active={false}
+                disabled={false}
+                disabledTitleText="This option is disabled"
+                id="interval"
+                onClick={[Function]}
+                titleText="Interval"
+                value="interval"
+              >
+                Interval
+              </RadioButton>
+              <RadioButton
+                active={false}
+                disabled={false}
+                disabledTitleText="This option is disabled"
+                id="cron"
+                onClick={[Function]}
+                titleText="Cron"
+                value="cron"
+              >
+                Cron
+              </RadioButton>
+            </Radio>
+          </ComponentSpacer>
+        </FormElement>
+      </GridColumn>
+      <TaskScheduleFormFields
+        onChangeInput={[MockFunction]}
+      />
+    </GridRow>
+  </Grid>
+</Form>
+`;

--- a/ui/src/tasks/containers/TaskEditPage.tsx
+++ b/ui/src/tasks/containers/TaskEditPage.tsx
@@ -8,7 +8,7 @@ import {connect} from 'react-redux'
 import TaskForm from 'src/tasks/components/TaskForm'
 import TaskHeader from 'src/tasks/components/TaskHeader'
 import {Page} from 'src/pageLayout'
-import {Task as TaskAPI, User, Organization} from 'src/api'
+import FluxEditor from 'src/shared/components/FluxEditor'
 
 // Actions
 import {
@@ -22,6 +22,7 @@ import {
 } from 'src/tasks/actions/v2'
 
 // Types
+import {Task as TaskAPI, User, Organization} from 'src/api'
 import {Links} from 'src/types/v2/links'
 import {State as TasksState} from 'src/tasks/reducers/v2'
 import {
@@ -88,22 +89,45 @@ class TaskPage extends PureComponent<
       <Page titleTag={`Edit ${taskOptions.name}`}>
         <TaskHeader
           title="Update Task"
+          canSubmit={this.isFormValid}
           onCancel={this.handleCancel}
           onSave={this.handleSave}
         />
         <Page.Contents fullWidth={true} scrollable={false}>
-          <TaskForm
-            orgs={orgs}
-            script={currentScript}
-            taskOptions={taskOptions}
-            onChangeScript={this.handleChangeScript}
-            onChangeScheduleType={this.handleChangeScheduleType}
-            onChangeInput={this.handleChangeInput}
-            onChangeTaskOrgID={this.handleChangeTaskOrgID}
-          />
+          <div className="task-form">
+            <div className="task-form--options">
+              <TaskForm
+                orgs={orgs}
+                canSubmit={this.isFormValid}
+                taskOptions={taskOptions}
+                onChangeInput={this.handleChangeInput}
+                onChangeScheduleType={this.handleChangeScheduleType}
+                onChangeTaskOrgID={this.handleChangeTaskOrgID}
+              />
+            </div>
+            <div className="task-form--editor">
+              <FluxEditor
+                script={currentScript}
+                onChangeScript={this.handleChangeScript}
+                visibility="visible"
+                status={{text: '', type: ''}}
+                suggestions={[]}
+              />
+            </div>
+          </div>
         </Page.Contents>
       </Page>
     )
+  }
+
+  private get isFormValid(): boolean {
+    const {
+      taskOptions: {name, cron, interval},
+      currentScript,
+    } = this.props
+
+    const hasSchedule = !!cron || !!interval
+    return hasSchedule && !!name && !!currentScript
   }
 
   private handleChangeScript = (script: string) => {

--- a/ui/src/tasks/containers/TaskPage.tsx
+++ b/ui/src/tasks/containers/TaskPage.tsx
@@ -3,11 +3,13 @@ import React, {PureComponent, ChangeEvent} from 'react'
 import {InjectedRouter} from 'react-router'
 import {connect} from 'react-redux'
 
+// components
 import TaskForm from 'src/tasks/components/TaskForm'
 import TaskHeader from 'src/tasks/components/TaskHeader'
+import FluxEditor from 'src/shared/components/FluxEditor'
 import {Page} from 'src/pageLayout'
 
-import {Links} from 'src/types/v2/links'
+// actions
 import {State as TasksState} from 'src/tasks/reducers/v2'
 import {
   setNewScript,
@@ -16,12 +18,17 @@ import {
   setTaskOption,
   clearTask,
 } from 'src/tasks/actions/v2'
+// types
+import {Links} from 'src/types/v2/links'
+import {Organization} from 'src/types/v2'
 import {
   TaskOptions,
   TaskOptionKeys,
   TaskSchedule,
 } from 'src/utils/taskOptionsToFluxScript'
-import {Organization} from 'src/types/v2'
+
+// Styles
+import 'src/tasks/components/TaskForm.scss'
 
 interface PassedInProps {
   router: InjectedRouter
@@ -67,22 +74,45 @@ class TaskPage extends PureComponent<
       <Page titleTag="Create Task">
         <TaskHeader
           title="Create Task"
+          canSubmit={this.isFormValid}
           onCancel={this.handleCancel}
           onSave={this.handleSave}
         />
         <Page.Contents fullWidth={true} scrollable={false}>
-          <TaskForm
-            orgs={orgs}
-            script={newScript}
-            taskOptions={taskOptions}
-            onChangeInput={this.handleChangeInput}
-            onChangeScheduleType={this.handleChangeScheduleType}
-            onChangeScript={this.handleChangeScript}
-            onChangeTaskOrgID={this.handleChangeTaskOrgID}
-          />
+          <div className="task-form">
+            <div className="task-form--options">
+              <TaskForm
+                orgs={orgs}
+                canSubmit={this.isFormValid}
+                taskOptions={taskOptions}
+                onChangeInput={this.handleChangeInput}
+                onChangeScheduleType={this.handleChangeScheduleType}
+                onChangeTaskOrgID={this.handleChangeTaskOrgID}
+              />
+            </div>
+            <div className="task-form--editor">
+              <FluxEditor
+                script={newScript}
+                onChangeScript={this.handleChangeScript}
+                visibility="visible"
+                status={{text: '', type: ''}}
+                suggestions={[]}
+              />
+            </div>
+          </div>
         </Page.Contents>
       </Page>
     )
+  }
+
+  private get isFormValid(): boolean {
+    const {
+      taskOptions: {name, cron, interval},
+      newScript,
+    } = this.props
+
+    const hasSchedule = !!cron || !!interval
+    return hasSchedule && !!name && !!newScript
   }
 
   private handleChangeScript = (script: string) => {

--- a/ui/src/tasks/reducers/v2/index.ts
+++ b/ui/src/tasks/reducers/v2/index.ts
@@ -18,7 +18,7 @@ export interface State {
   taskOptions: TaskOptions
 }
 
-const defaultTaskOptions: TaskOptions = {
+export const defaultTaskOptions: TaskOptions = {
   name: '',
   interval: '',
   offset: '',


### PR DESCRIPTION
Closes #10896

This PR adds the `TaskForm` component to the Save As overlay in the Data Explorer to create a new task with the active query in the explorer.

Also adds form validation, so that a task can only be saved if it has a name, a schedule (interval/cron), and a script. 

  - [x] Rebased/mergeable
  - [x] Tests pass
