### PR TITLE
fix(telegrafconfigs): find by organization ID

### DIFF
--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -77,8 +77,8 @@ func getOnboardingRequest() (req *platform.OnboardingRequest) {
 	fmt.Println(promptWithColor(`Welcome to InfluxDB 2.0!`, colorYellow))
 	req.User = getInput(ui, "Please type your primary username", "")
 	req.Password = getPassword(ui)
-	req.Org = getInput(ui, "Please type your primary organization name.", "")
-	req.Bucket = getInput(ui, "Please type your primary bucket name.", "")
+	req.Org = getInput(ui, "Please type your primary organization name", "")
+	req.Bucket = getInput(ui, "Please type your primary bucket name", "")
 	for {
 		rpStr := getInput(ui, "Please type your retention period in hours (exp 168 for 1 week).\r\nOr press ENTER for infinite.", strconv.Itoa(platform.InfiniteRetention))
 		rp, err := strconv.Atoi(rpStr)

--- a/telegraf.go
+++ b/telegraf.go
@@ -15,6 +15,9 @@ import (
 // ErrTelegrafConfigInvalidOrganizationID is the error message for a missing or invalid organization ID.
 const ErrTelegrafConfigInvalidOrganizationID = "invalid organization ID"
 
+// ErrTelegrafConfigNotFound is the error message for a missing telegraf config.
+const ErrTelegrafConfigNotFound = "telegraf config not found"
+
 // ops for buckets error and buckets op logs.
 var (
 	OpFindTelegrafConfigByID = "FindTelegrafConfigByID"

--- a/testing/telegraf.go
+++ b/testing/telegraf.go
@@ -1090,6 +1090,62 @@ func FindTelegrafConfigs(
 			},
 		},
 		{
+			name: "look for organization not bound to any telegraf config",
+			fields: TelegrafConfigFields{
+				UserResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID: MustIDBase16(oneID),
+						Resource:   platform.TelegrafsResource,
+						UserID:     MustIDBase16(threeID),
+						UserType:   platform.Owner,
+					},
+					{
+						ResourceID: MustIDBase16(twoID),
+						Resource:   platform.TelegrafsResource,
+						UserID:     MustIDBase16(threeID),
+						UserType:   platform.Member,
+					},
+				},
+				TelegrafConfigs: []*platform.TelegrafConfig{
+					{
+						ID:             MustIDBase16(oneID),
+						OrganizationID: MustIDBase16(threeID),
+						Name:           "tc1",
+						Plugins: []platform.TelegrafPlugin{
+							{
+								Config: &inputs.CPUStats{},
+							},
+						},
+					},
+					{
+						ID:             MustIDBase16(twoID),
+						OrganizationID: MustIDBase16(threeID),
+						Name:           "tc2",
+						Plugins: []platform.TelegrafPlugin{
+							{
+								Comment: "comment1",
+								Config: &inputs.File{
+									Files: []string{"f1", "f2"},
+								},
+							},
+							{
+								Comment: "comment2",
+								Config:  &inputs.MemStats{},
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				filter: platform.TelegrafConfigFilter{
+					OrganizationID: idPtr(MustIDBase16(oneID)),
+				},
+			},
+			wants: wants{
+				telegrafConfigs: []*platform.TelegrafConfig{},
+			},
+		},
+		{
 			name: "find nothing",
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{


### PR DESCRIPTION
Closes #11018 


When, given an organization ID, there are not `platform.TelegrafConfig`s associated with it, the `FindTelegrafConfigs` methods should return an empty slice rather than error out.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
