### PR TITLE
Rename json organizationID to orgID across API

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -20,7 +20,7 @@ const InfiniteRetention = 0
 // Bucket is a bucket. 🎉
 type Bucket struct {
 	ID                  ID            `json:"id,omitempty"`
-	OrganizationID      ID            `json:"organizationID,omitempty"`
+	OrganizationID      ID            `json:"orgID,omitempty"`
 	Organization        string        `json:"organization,omitempty"`
 	Name                string        `json:"name"`
 	RetentionPolicyName string        `json:"rp,omitempty"` // This to support v1 sources

--- a/dashboard.go
+++ b/dashboard.go
@@ -69,7 +69,7 @@ type DashboardService interface {
 // Dashboard represents all visual and query data for a dashboard.
 type Dashboard struct {
 	ID             ID            `json:"id,omitempty"`
-	OrganizationID ID            `json:"organizationID,omitempty"`
+	OrganizationID ID            `json:"orgID,omitempty"`
 	Name           string        `json:"name"`
 	Description    string        `json:"description"`
 	Cells          []*Cell       `json:"cells"`

--- a/http/cur_swagger.yml
+++ b/http/cur_swagger.yml
@@ -3900,7 +3900,7 @@ components:
           type: string
         rp:
           type: string
-        organizationID:
+        orgID:
           type: string
         retentionRules:
           type: array
@@ -4075,7 +4075,7 @@ components:
           type: string
     TaskCreateRequest:
       properties:
-        organizationID:
+        orgID:
           description: The ID of the organization that owns this Task.
           type: string
         status:
@@ -4088,7 +4088,7 @@ components:
         flux:
           description: The Flux script to run for this task.
           type: string
-      required: [organizationID, flux]
+      required: [orgID, flux]
     TaskUpdateRequest:
       properties:
         status:
@@ -4107,7 +4107,7 @@ components:
         id:
           readOnly: true
           type: string
-        organizationID:
+        orgID:
           description: The ID of the organization that owns this Task.
           type: string
         name:

--- a/http/cur_swagger.yml
+++ b/http/cur_swagger.yml
@@ -1016,13 +1016,6 @@ paths:
       tags:
         - Dashboards
       summary: Create a dashboard
-      parameters:
-          - in: query
-            name: org
-            description: specifies the organization of the resource
-            required: true
-            schema:
-              type: string
       requestBody:
           description: dashboard to create
           required: true
@@ -4964,6 +4957,9 @@ components:
         id:
           readOnly: true
           type: string
+        orgID:
+          type: string
+          description: id of organization that owns dashboard
         name:
           type: string
           description: user-facing name of the dashboard
@@ -5008,7 +5004,7 @@ components:
               type: string
         id:
           type: string
-        organizationID:
+        orgID:
           type: string
         name:
           type: string

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -102,7 +102,7 @@ func TestService_handleGetDashboards(t *testing.T) {
   "dashboards": [
     {
       "id": "da7aba5e5d81e550",
-      "organizationID": "0000000000000001",
+      "orgID": "0000000000000001",
       "name": "hello",
       "description": "oh hello there!",
       "labels": [
@@ -143,7 +143,7 @@ func TestService_handleGetDashboards(t *testing.T) {
     },
     {
       "id": "0ca2204eca2204e0",
-      "organizationID": "0000000000000001",
+      "orgID": "0000000000000001",
       "name": "example",
       "description": "",
 			"labels": [
@@ -301,7 +301,7 @@ func TestService_handleGetDashboard(t *testing.T) {
 				body: `
 {
   "id": "020f755c3c082000",
-  "organizationID": "0000000000000001",
+  "orgID": "0000000000000001",
   "name": "hello",
   "description": "",
   "labels": [],
@@ -453,7 +453,7 @@ func TestService_handlePostDashboard(t *testing.T) {
 				body: `
 {
   "id": "020f755c3c082000",
-  "organizationID": "0000000000000001",
+  "orgID": "0000000000000001",
   "name": "hello",
   "description": "howdy there",
   "labels": [],
@@ -691,7 +691,7 @@ func TestService_handlePatchDashboard(t *testing.T) {
 				body: `
 {
   "id": "020f755c3c082000",
-	"organizationID": "0000000000000001",
+	"orgID": "0000000000000001",
   "name": "example",
   "description": "",
   "labels": [],

--- a/http/proto.go
+++ b/http/proto.go
@@ -121,7 +121,7 @@ func (h *ProtoHandler) handleGetProtos(w http.ResponseWriter, r *http.Request) {
 
 type createProtoResourcesRequest struct {
 	ProtoID        platform.ID `json:"-"`
-	OrganizationID platform.ID `json:"organizationID"`
+	OrganizationID platform.ID `json:"orgID"`
 }
 
 // Decode turns an http request into a createProtoResourceRequest.

--- a/http/proto_test.go
+++ b/http/proto_test.go
@@ -154,7 +154,7 @@ func TestProtoHandler(t *testing.T) {
 		      ],
 		      "description": "oh hello there!",
 		      "id": "da7aba5e5d81e550",
-					"organizationID": "0000000000000001",
+					"orgID": "0000000000000001",
 		      "labels": [
 		      ],
 		      "links": {
@@ -177,7 +177,7 @@ func TestProtoHandler(t *testing.T) {
 		      ],
 		      "description": "",
 		      "id": "0ca2204eca2204e0",
-					"organizationID": "0000000000000001",
+					"orgID": "0000000000000001",
 		      "labels": [
 		      ],
 		      "links": {

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -661,7 +661,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"              
+                $ref: "#/components/schemas/Error"
   /macros:
     get:
       tags:
@@ -4946,7 +4946,7 @@ components:
           type: string
         name:
           type: string
-        organizationID:
+        orgID:
           type: string
         organization:
           type: string
@@ -5161,7 +5161,7 @@ components:
         id:
           readOnly: true
           type: string
-        organizationID:
+        orgID:
           description: The ID of the organization that owns this Task.
           type: string
         name:
@@ -6152,7 +6152,7 @@ components:
             type: string
     CreateProtoResourcesRequest:
       properties:
-        organizationID:
+        orgID:
           type: string
     Proto:
       properties:
@@ -6196,7 +6196,7 @@ components:
         id:
           readOnly: true
           type: string
-        organizationID:
+        orgID:
           type: string
           description: id of the organization that owns the dashboard
         name:
@@ -6237,7 +6237,7 @@ components:
               type: string
         id:
           type: string
-        organizationID:
+        orgID:
           type: string
         default:
           type: boolean

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6196,6 +6196,9 @@ components:
         id:
           readOnly: true
           type: string
+        organizationID:
+          type: string
+          description: id of the organization that owns the dashboard
         name:
           type: string
           description: user-facing name of the dashboard

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -100,7 +100,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
           }
         }
       ],
-      "organizationID": "0000000000000001",
+      "orgID": "0000000000000001",
       "status": "",
       "flux": "",
       "owner": {
@@ -128,7 +128,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
           }
         }
       ],
-      "organizationID": "0000000000000002",
+      "orgID": "0000000000000002",
       "status": "",
       "flux": "",
       "owner": {
@@ -224,7 +224,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
   "id": "0000000000000001",
   "name": "task1",
   "labels": [],
-  "organizationID": "0000000000000001",
+  "orgID": "0000000000000001",
   "status": "",
   "flux": "",
   "owner": {

--- a/source.go
+++ b/source.go
@@ -24,7 +24,7 @@ const (
 // TODO(desa): do sources belong
 type Source struct {
 	ID                 ID         `json:"id,string,omitempty"`          // ID is the unique ID of the source
-	OrganizationID     ID         `json:"organizationID"`               // OrganizationID is the organization ID that resource belongs to
+	OrganizationID     ID         `json:"orgID"`                        // OrganizationID is the organization ID that resource belongs to
 	Default            bool       `json:"default"`                      // Default specifies the default source for the application
 	Name               string     `json:"name"`                         // Name is the user-defined name for the source
 	Type               SourceType `json:"type,omitempty"`               // Type specifies which kinds of source (enterprise vs oss vs 2.0)

--- a/task.go
+++ b/task.go
@@ -22,7 +22,7 @@ const (
 // Task is a task. 🎊
 type Task struct {
 	ID              ID     `json:"id,omitempty"`
-	Organization    ID     `json:"organizationID"`
+	Organization    ID     `json:"orgID"`
 	Name            string `json:"name"`
 	Status          string `json:"status"`
 	Owner           User   `json:"owner"`

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -25,6 +25,7 @@ import {
   TelegrafPluginInputDocker,
   Task as TaskApi,
   Label,
+  Organization,
 } from 'src/api'
 
 export const links: Links = {
@@ -203,6 +204,7 @@ export const template: Template = {
 
 export const dashboard: Dashboard = {
   id: '1',
+  orgID: '02ee9e2a29d73000',
   cells: [],
   name: 'd1',
   links: {
@@ -239,6 +241,7 @@ export const dashboardWithLabels: Dashboard = {
   id: '1',
   cells: [],
   name: 'd1',
+  orgID: '02ee9e2a29d73000',
   links: {
     self: 'self/link',
     cells: 'cells/link',
@@ -263,33 +266,35 @@ export const cell: Cell = {
   },
 }
 
+export const orgs: Organization[] = [
+  {
+    links: {
+      buckets: '/api/v2/buckets?org=RadicalOrganization',
+      dashboards: '/api/v2/dashboards?org=RadicalOrganization',
+      self: '/api/v2/orgs/02ee9e2a29d73000',
+      tasks: '/api/v2/tasks?org=RadicalOrganization',
+    },
+    id: '02ee9e2a29d73000',
+    name: 'RadicalOrganization',
+  },
+]
+
 export const tasks: Task[] = [
   {
     id: '02ef9deff2141000',
-    organizationID: '02ee9e2a29d73000',
+    orgID: '02ee9e2a29d73000',
     name: 'pasdlak',
     status: TaskApi.StatusEnum.Active,
     owner: {id: '02ee9e2a19d73000', name: ''},
     flux:
       'option task = {\n  name: "pasdlak",\n  cron: "2 0 * * *"\n}\nfrom(bucket: "inbucket") \n|> range(start: -1h)',
     cron: '2 0 * * *',
-    organization: {
-      links: {
-        buckets: '/api/v2/buckets?org=RadicalOrganization',
-        dashboards: '/api/v2/dashboards?org=RadicalOrganization',
-        log: '/api/v2/orgs/02ee9e2a29d73000/log',
-        members: '/api/v2/orgs/02ee9e2a29d73000/members',
-        self: '/api/v2/orgs/02ee9e2a29d73000',
-        tasks: '/api/v2/tasks?org=RadicalOrganization',
-      },
-      id: '02ee9e2a29d73000',
-      name: 'RadicalOrganization',
-    },
+    organization: orgs[0],
     labels: [],
   },
   {
     id: '02f12c50dba72000',
-    organizationID: '02ee9e2a29d73000',
+    orgID: '02ee9e2a29d73000',
     name: 'somename',
     status: TaskApi.StatusEnum.Active,
     owner: {id: '02ee9e2a19d73000', name: ''},
@@ -300,8 +305,6 @@ export const tasks: Task[] = [
       links: {
         buckets: '/api/v2/buckets?org=RadicalOrganization',
         dashboards: '/api/v2/dashboards?org=RadicalOrganization',
-        log: '/api/v2/orgs/02ee9e2a29d73000/log',
-        members: '/api/v2/orgs/02ee9e2a29d73000/members',
         self: '/api/v2/orgs/02ee9e2a29d73000',
         tasks: '/api/v2/tasks?org=RadicalOrganization',
       },
@@ -435,6 +438,7 @@ export const influxDB2Plugin = {
 
 export const telegrafConfig = {
   id: telegrafConfigID,
+  orgID: '1',
   name: 'in n out',
   created: '2018-11-28T18:56:48.854337-08:00',
   lastModified: '2018-11-28T18:56:48.854337-08:00',
@@ -534,7 +538,7 @@ export const setSetupParamsResponse = {
         self: '/api/v2/buckets/033bc62534fe3000',
       },
       id: '033bc62534fe3000',
-      organizationID: '033bc62534be3000',
+      orgID: '033bc62534be3000',
       organization: 'default',
       name: 'defbuck',
       retentionRules: [],

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -343,7 +343,7 @@ export interface Bucket {
      * @type {string}
      * @memberof Bucket
      */
-    organizationID?: string;
+    orgID?: string;
     /**
      * rules to expire or retain data.  No rules means data never expires.
      * @type {Array<BucketRetentionRules>}
@@ -2532,7 +2532,7 @@ export interface Source {
      * @type {string}
      * @memberof Source
      */
-    organizationID?: string;
+    orgID?: string;
     /**
      * 
      * @type {string}
@@ -2701,7 +2701,7 @@ export interface Task {
      * @type {string}
      * @memberof Task
      */
-    organizationID?: string;
+    orgID?: string;
     /**
      * A description of the task.
      * @type {string}
@@ -2790,7 +2790,7 @@ export interface TaskCreateRequest {
      * @type {string}
      * @memberof TaskCreateRequest
      */
-    organizationID: string;
+    orgID: string;
     /**
      * Starting state of the task. 'inactive' tasks are not run until they are updated to 'active'
      * @type {string}

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -613,6 +613,12 @@ export interface Dashboard {
      */
     id?: string;
     /**
+     * id of organization that owns dashboard
+     * @type {string}
+     * @memberof Dashboard
+     */
+    orgID?: string;
+    /**
      * user-facing name of the dashboard
      * @type {string}
      * @memberof Dashboard
@@ -7696,16 +7702,11 @@ export const DashboardsApiAxiosParamCreator = function (configuration?: Configur
         /**
          * 
          * @summary Create a dashboard
-         * @param {string} org specifies the organization of the resource
          * @param {Dashboard} dashboard dashboard to create
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        dashboardsPost(org: string, dashboard: Dashboard, options: any = {}): RequestArgs {
-            // verify required parameter 'org' is not null or undefined
-            if (org === null || org === undefined) {
-                throw new RequiredError('org','Required parameter org was null or undefined when calling dashboardsPost.');
-            }
+        dashboardsPost(dashboard: Dashboard, options: any = {}): RequestArgs {
             // verify required parameter 'dashboard' is not null or undefined
             if (dashboard === null || dashboard === undefined) {
                 throw new RequiredError('dashboard','Required parameter dashboard was null or undefined when calling dashboardsPost.');
@@ -7719,10 +7720,6 @@ export const DashboardsApiAxiosParamCreator = function (configuration?: Configur
             const localVarRequestOptions = Object.assign({ method: 'POST' }, baseOptions, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
-
-            if (org !== undefined) {
-                localVarQueryParameter['org'] = org;
-            }
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
@@ -8036,13 +8033,12 @@ export const DashboardsApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary Create a dashboard
-         * @param {string} org specifies the organization of the resource
          * @param {Dashboard} dashboard dashboard to create
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        dashboardsPost(org: string, dashboard: Dashboard, options?: any): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Dashboard> {
-            const localVarAxiosArgs = DashboardsApiAxiosParamCreator(configuration).dashboardsPost(org, dashboard, options);
+        dashboardsPost(dashboard: Dashboard, options?: any): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Dashboard> {
+            const localVarAxiosArgs = DashboardsApiAxiosParamCreator(configuration).dashboardsPost(dashboard, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = Object.assign(localVarAxiosArgs.options, {url: basePath + localVarAxiosArgs.url})
                 return axios.request(axiosRequestArgs);                
@@ -8270,13 +8266,12 @@ export const DashboardsApiFactory = function (configuration?: Configuration, bas
         /**
          * 
          * @summary Create a dashboard
-         * @param {string} org specifies the organization of the resource
          * @param {Dashboard} dashboard dashboard to create
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        dashboardsPost(org: string, dashboard: Dashboard, options?: any) {
-            return DashboardsApiFp(configuration).dashboardsPost(org, dashboard, options)(axios, basePath);
+        dashboardsPost(dashboard: Dashboard, options?: any) {
+            return DashboardsApiFp(configuration).dashboardsPost(dashboard, options)(axios, basePath);
         },
     };
 };
@@ -8539,14 +8534,13 @@ export class DashboardsApi extends BaseAPI {
     /**
      * 
      * @summary Create a dashboard
-     * @param {string} org specifies the organization of the resource
      * @param {Dashboard} dashboard dashboard to create
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DashboardsApi
      */
-    public dashboardsPost(org: string, dashboard: Dashboard, options?: any) {
-        return DashboardsApiFp(this.configuration).dashboardsPost(org, dashboard, options)(this.axios, this.basePath);
+    public dashboardsPost(dashboard: Dashboard, options?: any) {
+        return DashboardsApiFp(this.configuration).dashboardsPost(dashboard, options)(this.axios, this.basePath);
     }
 
 }

--- a/ui/src/dashboards/apis/v2/index.ts
+++ b/ui/src/dashboards/apis/v2/index.ts
@@ -47,7 +47,7 @@ export const getDashboard = async (id: string): Promise<Dashboard> => {
 export const createDashboard = async (
   dashboard: Partial<Dashboard>
 ): Promise<Dashboard> => {
-  const {data} = await dashboardsAPI.dashboardsPost('', dashboard)
+  const {data} = await dashboardsAPI.dashboardsPost(dashboard)
   return {...data, cells: addDashboardIDToCells(data.cells, data.id)}
 }
 

--- a/ui/src/dashboards/components/dashboard_index/Contents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Contents.tsx
@@ -9,11 +9,12 @@ import Table from 'src/dashboards/components/dashboard_index/Table'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Dashboard} from 'src/types/v2'
+import {Dashboard, Organization} from 'src/types/v2'
 import {Notification} from 'src/types/notifications'
 
 interface Props {
   dashboards: Dashboard[]
+  orgs: Organization[]
   defaultDashboardLink: string
   onSetDefaultDashboard: (dashboardLink: string) => void
   onCreateDashboard: () => void
@@ -39,6 +40,7 @@ export default class DashboardsIndexContents extends Component<Props> {
       onUpdateDashboard,
       onEditLabels,
       searchTerm,
+      orgs,
     } = this.props
 
     return (
@@ -54,6 +56,7 @@ export default class DashboardsIndexContents extends Component<Props> {
           onSetDefaultDashboard={onSetDefaultDashboard}
           onUpdateDashboard={onUpdateDashboard}
           onEditLabels={onEditLabels}
+          orgs={orgs}
         />
       </div>
     )

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -50,7 +50,7 @@ import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants/index'
 // Types
 import {Notification} from 'src/types/notifications'
 import {DashboardFile} from 'src/types/v2/dashboards'
-import {Links, Cell, Dashboard, AppState} from 'src/types/v2'
+import {Links, Cell, Dashboard, AppState, Organization} from 'src/types/v2'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -70,6 +70,7 @@ interface DispatchProps {
 interface StateProps {
   links: Links
   dashboards: Dashboard[]
+  orgs: Organization[]
 }
 
 interface OwnProps {
@@ -106,7 +107,7 @@ class DashboardIndex extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {dashboards, notify, links, handleUpdateDashboard} = this.props
+    const {dashboards, notify, links, handleUpdateDashboard, orgs} = this.props
     const {searchTerm} = this.state
 
     return (
@@ -133,6 +134,7 @@ class DashboardIndex extends PureComponent<Props, State> {
           <Page.Contents fullWidth={false} scrollable={true}>
             <DashboardsContents
               dashboards={dashboards}
+              orgs={orgs}
               onSetDefaultDashboard={this.handleSetDefaultDashboard}
               defaultDashboardLink={links.defaultDashboard}
               onDeleteDashboard={this.handleDeleteDashboard}
@@ -167,11 +169,12 @@ class DashboardIndex extends PureComponent<Props, State> {
   }
 
   private handleCreateDashboard = async (): Promise<void> => {
-    const {router, notify} = this.props
+    const {router, notify, orgs} = this.props
     try {
       const newDashboard = {
         name: DEFAULT_DASHBOARD_NAME,
         cells: [],
+        orgID: orgs[0].id,
       }
       const data = await createDashboard(newDashboard)
       router.push(`/dashboards/${data.id}`)
@@ -183,12 +186,13 @@ class DashboardIndex extends PureComponent<Props, State> {
   private handleCloneDashboard = async (
     dashboard: Dashboard
   ): Promise<void> => {
-    const {router, notify} = this.props
+    const {router, notify, orgs} = this.props
     const name = `${dashboard.name} (clone)`
     try {
       const data = await createDashboard({
         ...dashboard,
         name,
+        orgID: orgs[0].id,
       })
       router.push(`/dashboards/${data.id}`)
     } catch (error) {
@@ -296,9 +300,10 @@ class DashboardIndex extends PureComponent<Props, State> {
 }
 
 const mstp = (state: AppState): StateProps => {
-  const {dashboards, links} = state
+  const {dashboards, links, orgs} = state
 
   return {
+    orgs,
     dashboards,
     links,
   }

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -18,7 +18,7 @@ import SortingHat from 'src/shared/components/sorting_hat/SortingHat'
 
 // Types
 import {Sort} from 'src/clockface'
-import {Dashboard} from 'src/types/v2'
+import {Dashboard, Organization} from 'src/types/v2'
 
 interface Props {
   searchTerm: string
@@ -31,6 +31,7 @@ interface Props {
   onUpdateDashboard: (dashboard: Dashboard) => void
   onSetDefaultDashboard: (dashboardLink: string) => void
   onEditLabels: (dashboard: Dashboard) => void
+  orgs: Organization[]
 }
 
 interface DatedDashboard extends Dashboard {
@@ -106,6 +107,7 @@ class DashboardsTable extends PureComponent<Props & WithRouterProps, State> {
       onDeleteDashboard,
       onUpdateDashboard,
       onEditLabels,
+      orgs,
     } = this.props
 
     const {sortKey, sortDirection} = this.state
@@ -125,6 +127,7 @@ class DashboardsTable extends PureComponent<Props & WithRouterProps, State> {
               onDeleteDashboard={onDeleteDashboard}
               onUpdateDashboard={onUpdateDashboard}
               onEditLabels={onEditLabels}
+              orgs={orgs}
             />
           )}
         </SortingHat>

--- a/ui/src/dashboards/components/dashboard_index/TableRow.test.tsx
+++ b/ui/src/dashboards/components/dashboard_index/TableRow.test.tsx
@@ -7,11 +7,12 @@ import TableRow from 'src/dashboards/components/dashboard_index/TableRow'
 import {Label} from 'src/clockface'
 
 // Dummy Data
-import {dashboardWithLabels, dashboard} from 'mocks/dummyData'
+import {dashboardWithLabels, dashboard, orgs} from 'mocks/dummyData'
 
 const setup = (override = {}) => {
   const props = {
     dashboard,
+    orgs,
     onDeleteDashboard: jest.fn(),
     onCloneDashboard: jest.fn(),
     onExportDashboard: jest.fn(),

--- a/ui/src/dashboards/components/dashboard_index/TableRow.tsx
+++ b/ui/src/dashboards/components/dashboard_index/TableRow.tsx
@@ -17,7 +17,7 @@ import {
 import EditableDescription from 'src/shared/components/editable_description/EditableDescription'
 
 // Types
-import {Dashboard} from 'src/types/v2'
+import {Dashboard, Organization} from 'src/types/v2'
 import {Alignment} from 'src/clockface'
 import moment from 'moment'
 
@@ -29,6 +29,7 @@ import {
 
 interface Props {
   dashboard: Dashboard
+  orgs: Organization[]
   onDeleteDashboard: (dashboard: Dashboard) => void
   onCloneDashboard: (dashboard: Dashboard) => void
   onExportDashboard: (dashboard: Dashboard) => void
@@ -65,7 +66,7 @@ export default class DashboardsIndexTableRow extends PureComponent<Props> {
             />
           </ComponentSpacer>
         </IndexList.Cell>
-        <IndexList.Cell>Owner does not come back from API</IndexList.Cell>
+        <IndexList.Cell>{this.ownerName}</IndexList.Cell>
         {this.lastModifiedCell}
         <IndexList.Cell alignment={Alignment.Right} revealOnHover={true}>
           <ComponentSpacer align={Alignment.Left} stackChildren={Stack.Columns}>
@@ -144,6 +145,12 @@ export default class DashboardsIndexTableRow extends PureComponent<Props> {
     const {dashboard} = this.props
 
     return dashboard.name || DEFAULT_DASHBOARD_NAME
+  }
+
+  private get ownerName(): string {
+    const {dashboard, orgs} = this.props
+    const ownerOrg = orgs.find(o => o.id === dashboard.orgID)
+    return ownerOrg.name
   }
 
   private get nameClassName(): string {

--- a/ui/src/dashboards/components/dashboard_index/TableRows.tsx
+++ b/ui/src/dashboards/components/dashboard_index/TableRows.tsx
@@ -5,7 +5,7 @@ import React, {PureComponent} from 'react'
 import TableRow from 'src/dashboards/components/dashboard_index/TableRow'
 
 // Types
-import {Dashboard} from 'src/types/v2'
+import {Dashboard, Organization} from 'src/types/v2'
 
 interface Props {
   dashboards: Dashboard[]
@@ -14,6 +14,7 @@ interface Props {
   onExportDashboard: (dashboard: Dashboard) => void
   onUpdateDashboard: (dashboard: Dashboard) => void
   onEditLabels: (dashboard: Dashboard) => void
+  orgs: Organization[]
 }
 
 export default class DashboardsIndexTableRows extends PureComponent<Props> {
@@ -25,6 +26,7 @@ export default class DashboardsIndexTableRows extends PureComponent<Props> {
       onDeleteDashboard,
       onUpdateDashboard,
       onEditLabels,
+      orgs,
     } = this.props
 
     return dashboards.map(d => (
@@ -36,6 +38,7 @@ export default class DashboardsIndexTableRows extends PureComponent<Props> {
         onDeleteDashboard={onDeleteDashboard}
         onUpdateDashboard={onUpdateDashboard}
         onEditLabels={onEditLabels}
+        orgs={orgs}
       />
     ))
   }

--- a/ui/src/dataExplorer/components/DashboardsDropdown.tsx
+++ b/ui/src/dataExplorer/components/DashboardsDropdown.tsx
@@ -58,7 +58,7 @@ class DashboardsDropdown extends PureComponent<Props> {
   }
 
   private get dividerItem(): JSX.Element {
-    return <MultiSelectDropdown.Divider />
+    return <MultiSelectDropdown.Divider key={0} />
   }
 }
 export default DashboardsDropdown

--- a/ui/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -28,7 +28,7 @@ import {createDashboard} from 'src/dashboards/apis/v2'
 import {notify} from 'src/shared/actions/notifications'
 
 // types
-import {AppState, Dashboard, View} from 'src/types/v2'
+import {AppState, Dashboard, View, Organization} from 'src/types/v2'
 import {
   DashboardTemplate,
   DEFAULT_DASHBOARD_NAME,
@@ -45,6 +45,7 @@ interface State {
 interface StateProps {
   dashboards: Dashboard[]
   view: View
+  orgs: Organization[]
 }
 
 interface DispatchProps {
@@ -187,9 +188,10 @@ class SaveAsCellForm extends PureComponent<Props, State> {
     dashboardName: string,
     view: View
   ): Promise<void> => {
-    const {onCreateCellWithView} = this.props
+    const {onCreateCellWithView, orgs} = this.props
     try {
       const newDashboard = {
+        orgID: orgs[0].id,
         name: dashboardName || DEFAULT_DASHBOARD_NAME,
         cells: [],
       }
@@ -232,13 +234,14 @@ class SaveAsCellForm extends PureComponent<Props, State> {
 
 const mstp = (state: AppState): StateProps => {
   const {
+    orgs,
     dashboards,
     timeMachines: {
       timeMachines: {de},
     },
   } = state
   const {view} = de
-  return {dashboards, view}
+  return {dashboards, view, orgs}
 }
 
 const mdtp: DispatchProps = {

--- a/ui/src/logs/utils/logQuery.test.ts
+++ b/ui/src/logs/utils/logQuery.test.ts
@@ -22,7 +22,7 @@ describe('Logs.LogQuery', () => {
     config = buildTableQueryConfig({
       id: '1',
       organization: 'default',
-      organizationID: '1',
+      orgID: '1',
       name: 'telegraf',
       rp: 'autogen',
       retentionRules: [],

--- a/ui/src/logs/utils/v1/queryBuilder.test.ts
+++ b/ui/src/logs/utils/v1/queryBuilder.test.ts
@@ -15,7 +15,7 @@ describe('Logs.V1.queryBuilder', () => {
     config = buildTableQueryConfig({
       id: '1',
       organization: 'default',
-      organizationID: '1',
+      orgID: '1',
       name: 'telegraf',
       rp: 'autogen',
       retentionRules: [],

--- a/ui/src/logs/utils/v2/queryBuilder.test.ts
+++ b/ui/src/logs/utils/v2/queryBuilder.test.ts
@@ -15,7 +15,7 @@ describe('Logs.V2.queryBuilder', () => {
     config = buildTableQueryConfig({
       id: '1',
       organization: 'default',
-      organizationID: '1',
+      orgID: '1',
       name: 'telegraf',
       rp: 'autogen',
       retentionRules: [],

--- a/ui/src/onboarding/actions/dataLoaders.ts
+++ b/ui/src/onboarding/actions/dataLoaders.ts
@@ -295,12 +295,12 @@ export const createOrUpdateTelegrafConfigAsync = (authToken: string) => async (
       dataLoaders: {telegrafPlugins},
       steps: {
         setupParams: {org, bucket},
-        organizationID,
+        orgID,
       },
     },
   } = getState()
 
-  const telegrafConfigsFromServer = await getTelegrafConfigs(organizationID)
+  const telegrafConfigsFromServer = await getTelegrafConfigs(orgID)
 
   const influxDB2Out = {
     name: TelegrafPluginOutputInfluxDBV2.NameEnum.InfluxdbV2,
@@ -324,7 +324,7 @@ export const createOrUpdateTelegrafConfigAsync = (authToken: string) => async (
     name: 'new config',
     agent: {collectionInterval: DEFAULT_COLLECTION_INTERVAL},
     plugins,
-    organizationID,
+    orgID,
   }
 
   if (telegrafConfigsFromServer.length) {
@@ -340,7 +340,7 @@ export const createOrUpdateTelegrafConfigAsync = (authToken: string) => async (
     plugins,
   }
 
-  const created = await createTelegrafConfig(org, body)
+  const created = await createTelegrafConfig(orgID, body)
   dispatch(setTelegrafConfigID(created.id))
 }
 

--- a/ui/src/onboarding/actions/steps.ts
+++ b/ui/src/onboarding/actions/steps.ts
@@ -42,21 +42,21 @@ export const setStepStatus = (
 
 interface SetOrganizationID {
   type: 'SET_ORG_ID'
-  payload: {organizationID}
+  payload: {orgID: string}
 }
 
-const setOrganizationID = organizationID => ({
+const setOrganizationID = (orgID: string) => ({
   type: 'SET_ORG_ID',
-  payload: {organizationID},
+  payload: {orgID},
 })
 
 export const setupAdmin = (setupParams: SetupParams) => async dispatch => {
   try {
     dispatch(setSetupParams(setupParams))
     const onboardingResponse = await setSetupParamsAJAX(setupParams)
-    const {id: organizationID} = onboardingResponse.org
+    const {id: orgID} = onboardingResponse.org
 
-    dispatch(setOrganizationID(organizationID))
+    dispatch(setOrganizationID(orgID))
 
     await signinAJAX({
       username: setupParams.username,

--- a/ui/src/onboarding/reducers/steps.ts
+++ b/ui/src/onboarding/reducers/steps.ts
@@ -8,13 +8,13 @@ import {SetupParams} from 'src/onboarding/apis'
 export interface OnboardingStepsState {
   stepStatuses: StepStatus[]
   setupParams: SetupParams
-  organizationID: string
+  orgID: string
 }
 
 const INITIAL_STATE: OnboardingStepsState = {
   stepStatuses: new Array(6).fill(StepStatus.Incomplete),
   setupParams: null,
-  organizationID: '',
+  orgID: '',
 }
 
 export default (
@@ -29,7 +29,7 @@ export default (
       stepStatuses[action.payload.index] = action.payload.status
       return {...state, stepStatuses}
     case 'SET_ORG_ID':
-      return {...state, organizationID: action.payload.organizationID}
+      return {...state, orgID: action.payload.orgID}
     default:
       return state
   }

--- a/ui/src/organizations/components/CreateBucketOverlay.tsx
+++ b/ui/src/organizations/components/CreateBucketOverlay.tsx
@@ -107,12 +107,12 @@ export default class BucketOverlay extends PureComponent<Props, State> {
 
   private handleCreateBucket = (): void => {
     const {onCreateBucket, org} = this.props
-    const organizationID = org.id
+    const orgID = org.id
     const organization = org.name
 
     const bucket = {
       ...this.state.bucket,
-      organizationID,
+      orgID,
       organization,
     }
 

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -209,7 +209,7 @@ export const populateTasks = () => async (
     const tasks = await getUserTasks(user)
 
     const mappedTasks = tasks.map(task => {
-      const org = orgs.find(org => org.id === task.organizationID)
+      const org = orgs.find(org => org.id === task.orgID)
 
       return {
         ...task,
@@ -232,7 +232,7 @@ export const selectTaskByID = (id: string) => async (
     const {orgs} = getState()
 
     const task = await getTask(id)
-    const org = orgs.find(org => org.id === task.organizationID)
+    const org = orgs.find(org => org.id === task.orgID)
 
     return dispatch(setCurrentTask({...task, organization: org}))
   } catch (e) {

--- a/ui/src/tasks/api/v2/index.ts
+++ b/ui/src/tasks/api/v2/index.ts
@@ -2,10 +2,10 @@ import {Task} from 'src/api'
 import {taskAPI} from 'src/utils/api'
 
 export const submitNewTask = async (
-  organizationID: string,
+  orgID: string,
   flux: string
 ): Promise<Task> => {
-  const {data} = await taskAPI.tasksPost({organizationID, flux})
+  const {data} = await taskAPI.tasksPost({orgID, flux})
 
   return data
 }

--- a/ui/src/tasks/components/__snapshots__/TaskRow.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TaskRow.test.tsx.snap
@@ -83,19 +83,17 @@ from(bucket: \\"inbucket\\")
             "id": "02ef9deff2141000",
             "labels": Array [],
             "name": "pasdlak",
+            "orgID": "02ee9e2a29d73000",
             "organization": Object {
               "id": "02ee9e2a29d73000",
               "links": Object {
                 "buckets": "/api/v2/buckets?org=RadicalOrganization",
                 "dashboards": "/api/v2/dashboards?org=RadicalOrganization",
-                "log": "/api/v2/orgs/02ee9e2a29d73000/log",
-                "members": "/api/v2/orgs/02ee9e2a29d73000/members",
                 "self": "/api/v2/orgs/02ee9e2a29d73000",
                 "tasks": "/api/v2/tasks?org=RadicalOrganization",
               },
               "name": "RadicalOrganization",
             },
-            "organizationID": "02ee9e2a29d73000",
             "owner": Object {
               "id": "02ee9e2a19d73000",
               "name": "",

--- a/ui/src/tasks/components/__snapshots__/TasksList.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TasksList.test.tsx.snap
@@ -65,19 +65,17 @@ from(bucket: \\"inbucket\\")
             "id": "02ef9deff2141000",
             "labels": Array [],
             "name": "pasdlak",
+            "orgID": "02ee9e2a29d73000",
             "organization": Object {
               "id": "02ee9e2a29d73000",
               "links": Object {
                 "buckets": "/api/v2/buckets?org=RadicalOrganization",
                 "dashboards": "/api/v2/dashboards?org=RadicalOrganization",
-                "log": "/api/v2/orgs/02ee9e2a29d73000/log",
-                "members": "/api/v2/orgs/02ee9e2a29d73000/members",
                 "self": "/api/v2/orgs/02ee9e2a29d73000",
                 "tasks": "/api/v2/tasks?org=RadicalOrganization",
               },
               "name": "RadicalOrganization",
             },
-            "organizationID": "02ee9e2a29d73000",
             "owner": Object {
               "id": "02ee9e2a19d73000",
               "name": "",
@@ -112,19 +110,17 @@ from(bucket: \\"inbucket\\")
               },
             ],
             "name": "somename",
+            "orgID": "02ee9e2a29d73000",
             "organization": Object {
               "id": "02ee9e2a29d73000",
               "links": Object {
                 "buckets": "/api/v2/buckets?org=RadicalOrganization",
                 "dashboards": "/api/v2/dashboards?org=RadicalOrganization",
-                "log": "/api/v2/orgs/02ee9e2a29d73000/log",
-                "members": "/api/v2/orgs/02ee9e2a29d73000/members",
                 "self": "/api/v2/orgs/02ee9e2a29d73000",
                 "tasks": "/api/v2/tasks?org=RadicalOrganization",
               },
               "name": "RadicalOrganization",
             },
-            "organizationID": "02ee9e2a29d73000",
             "owner": Object {
               "id": "02ee9e2a19d73000",
               "name": "",

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -166,7 +166,7 @@ class TasksPage extends PureComponent<Props, State> {
       }
       let orgIDFilter = true
       if (dropdownOrgID && dropdownOrgID !== allOrganizationsID) {
-        orgIDFilter = t.organizationID === dropdownOrgID
+        orgIDFilter = t.orgID === dropdownOrgID
       }
       return searchTermFilter && activeFilter && orgIDFilter
     })

--- a/ui/src/tasks/containers/__snapshots__/TasksPage.test.tsx.snap
+++ b/ui/src/tasks/containers/__snapshots__/TasksPage.test.tsx.snap
@@ -65,19 +65,17 @@ from(bucket: \\"inbucket\\")
             "id": "02ef9deff2141000",
             "labels": Array [],
             "name": "pasdlak",
+            "orgID": "02ee9e2a29d73000",
             "organization": Object {
               "id": "02ee9e2a29d73000",
               "links": Object {
                 "buckets": "/api/v2/buckets?org=RadicalOrganization",
                 "dashboards": "/api/v2/dashboards?org=RadicalOrganization",
-                "log": "/api/v2/orgs/02ee9e2a29d73000/log",
-                "members": "/api/v2/orgs/02ee9e2a29d73000/members",
                 "self": "/api/v2/orgs/02ee9e2a29d73000",
                 "tasks": "/api/v2/tasks?org=RadicalOrganization",
               },
               "name": "RadicalOrganization",
             },
-            "organizationID": "02ee9e2a29d73000",
             "owner": Object {
               "id": "02ee9e2a19d73000",
               "name": "",
@@ -112,19 +110,17 @@ from(bucket: \\"inbucket\\")
               },
             ],
             "name": "somename",
+            "orgID": "02ee9e2a29d73000",
             "organization": Object {
               "id": "02ee9e2a29d73000",
               "links": Object {
                 "buckets": "/api/v2/buckets?org=RadicalOrganization",
                 "dashboards": "/api/v2/dashboards?org=RadicalOrganization",
-                "log": "/api/v2/orgs/02ee9e2a29d73000/log",
-                "members": "/api/v2/orgs/02ee9e2a29d73000/members",
                 "self": "/api/v2/orgs/02ee9e2a29d73000",
                 "tasks": "/api/v2/tasks?org=RadicalOrganization",
               },
               "name": "RadicalOrganization",
             },
-            "organizationID": "02ee9e2a29d73000",
             "owner": Object {
               "id": "02ee9e2a19d73000",
               "name": "",

--- a/ui/src/tasks/dummyData.ts
+++ b/ui/src/tasks/dummyData.ts
@@ -3,7 +3,7 @@ import {Task} from 'src/api'
 export const dummyTasks: Task[] = [
   {
     id: '02ef9deff2141000',
-    organizationID: '02ee9e2a29d73000',
+    orgID: '02ee9e2a29d73000',
     name: 'pasdlak',
     status: Task.StatusEnum.Active,
     owner: null,
@@ -13,7 +13,7 @@ export const dummyTasks: Task[] = [
   },
   {
     id: '02f12c50dba72000',
-    organizationID: '02ee9e2a29d73000',
+    orgID: '02ee9e2a29d73000',
     name: 'somename',
     status: Task.StatusEnum.Active,
     owner: null,

--- a/ui/src/tasks/reducers/v2/index.ts
+++ b/ui/src/tasks/reducers/v2/index.ts
@@ -47,7 +47,7 @@ export default (state: State = defaultState, action: Action): State => {
         newScript: '',
       }
     case 'SET_ALL_TASK_OPTIONS':
-      const {name, every, cron, organizationID, offset} = action.payload
+      const {name, every, cron, orgID, offset} = action.payload
       let taskScheduleType = TaskSchedule.interval
       if (cron) {
         taskScheduleType = TaskSchedule.cron
@@ -60,7 +60,7 @@ export default (state: State = defaultState, action: Action): State => {
           name,
           cron,
           interval: every,
-          orgID: organizationID,
+          orgID,
           taskScheduleType,
           offset,
         },

--- a/ui/src/types/v2/buckets.ts
+++ b/ui/src/types/v2/buckets.ts
@@ -2,7 +2,7 @@ export interface Bucket {
   id: string
   name: string
   organization: string
-  organizationID: string
+  orgID: string
   rp?: string
   retentionRules: RetentionRule[]
   links: BucketLinks

--- a/ui/src/types/v2/tasks.ts
+++ b/ui/src/types/v2/tasks.ts
@@ -1,5 +1,4 @@
-import {Organization} from 'src/types/v2/orgs'
-import {Task as TaskAPI} from 'src/api'
+import {Task as TaskAPI, Organization} from 'src/api'
 
 export interface Task extends TaskAPI {
   organization: Organization


### PR DESCRIPTION
_Briefly describe your proposed changes:_
This PR uses the `json` struct tag `orgID` instead of `organizationID` universally across the application.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
