### PR TITLE
Standardise CLI

### DIFF
--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -57,31 +57,31 @@ func init() {
 		RunE:  authorizationCreateF,
 	}
 
-	authorizationCreateCmd.Flags().StringVarP(&authorizationCreateFlags.org, "org", "o", "", "org name (required)")
+	authorizationCreateCmd.Flags().StringVarP(&authorizationCreateFlags.org, "org", "o", "", "The organization name (required)")
 	authorizationCreateCmd.MarkFlagRequired("org")
 
-	authorizationCreateCmd.Flags().StringVarP(&authorizationCreateFlags.user, "user", "u", "", "user name")
+	authorizationCreateCmd.Flags().StringVarP(&authorizationCreateFlags.user, "user", "u", "", "The user name")
 
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeUserPermission, "write-user", "", false, "grants the permission to perform mutative actions against organization users")
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readUserPermission, "read-user", "", false, "grants the permission to perform read actions against organization users")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeUserPermission, "write-user", "", false, "Grants the permission to perform mutative actions against organization users")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readUserPermission, "read-user", "", false, "Grants the permission to perform read actions against organization users")
 
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeBucketsPermission, "write-buckets", "", false, "grants the permission to perform mutative actions against organization buckets")
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readBucketsPermission, "read-buckets", "", false, "grants the permission to perform read actions against organization buckets")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeBucketsPermission, "write-buckets", "", false, "Grants the permission to perform mutative actions against organization buckets")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readBucketsPermission, "read-buckets", "", false, "Grants the permission to perform read actions against organization buckets")
 
-	authorizationCreateCmd.Flags().StringArrayVarP(&authorizationCreateFlags.writeBucketPermissions, "write-bucket", "", []string{}, "bucket id")
-	authorizationCreateCmd.Flags().StringArrayVarP(&authorizationCreateFlags.readBucketPermissions, "read-bucket", "", []string{}, "bucket id")
+	authorizationCreateCmd.Flags().StringArrayVarP(&authorizationCreateFlags.writeBucketPermissions, "write-bucket", "", []string{}, "The bucket id")
+	authorizationCreateCmd.Flags().StringArrayVarP(&authorizationCreateFlags.readBucketPermissions, "read-bucket", "", []string{}, "The bucket id")
 
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeTasksPermission, "write-tasks", "", false, "grants the permission to create tasks")
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readTasksPermission, "read-tasks", "", false, "grants the permission to read tasks")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeTasksPermission, "write-tasks", "", false, "Grants the permission to create tasks")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readTasksPermission, "read-tasks", "", false, "Grants the permission to read tasks")
 
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeTelegrafsPermission, "write-telegrafs", "", false, "grants the permission to create telegraf configs")
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readTelegrafsPermission, "read-telegrafs", "", false, "grants the permission to read telegraf configs")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeTelegrafsPermission, "write-telegrafs", "", false, "Grants the permission to create telegraf configs")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readTelegrafsPermission, "read-telegrafs", "", false, "Grants the permission to read telegraf configs")
 
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeOrganizationsPermission, "write-orgs", "", false, "grants the permission to create organizations")
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readOrganizationsPermission, "read-orgs", "", false, "grants the permission to read organizations")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeOrganizationsPermission, "write-orgs", "", false, "Grants the permission to create organizations")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readOrganizationsPermission, "read-orgs", "", false, "Grants the permission to read organizations")
 
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeDashboardsPermission, "write-dashboards", "", false, "grants the permission to create dashboards")
-	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readDashboardsPermission, "read-dashboards", "", false, "grants the permission to read dashboards")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.writeDashboardsPermission, "write-dashboards", "", false, "Grants the permission to create dashboards")
+	authorizationCreateCmd.Flags().BoolVarP(&authorizationCreateFlags.readDashboardsPermission, "read-dashboards", "", false, "Grants the permission to read dashboards")
 
 	authorizationCmd.AddCommand(authorizationCreateCmd)
 }
@@ -297,9 +297,9 @@ func init() {
 		RunE:  authorizationFindF,
 	}
 
-	authorizationFindCmd.Flags().StringVarP(&authorizationFindFlags.user, "user", "u", "", "user")
-	authorizationFindCmd.Flags().StringVarP(&authorizationFindFlags.userID, "user-id", "", "", "user ID")
-	authorizationFindCmd.Flags().StringVarP(&authorizationFindFlags.id, "id", "i", "", "authorization ID")
+	authorizationFindCmd.Flags().StringVarP(&authorizationFindFlags.user, "user", "u", "", "The user")
+	authorizationFindCmd.Flags().StringVarP(&authorizationFindFlags.userID, "user-id", "", "", "The user ID")
+	authorizationFindCmd.Flags().StringVarP(&authorizationFindFlags.id, "id", "i", "", "The authorization ID")
 
 	authorizationCmd.AddCommand(authorizationFindCmd)
 }
@@ -398,7 +398,7 @@ func init() {
 		RunE:  authorizationDeleteF,
 	}
 
-	authorizationDeleteCmd.Flags().StringVarP(&authorizationDeleteFlags.id, "id", "i", "", "authorization id (required)")
+	authorizationDeleteCmd.Flags().StringVarP(&authorizationDeleteFlags.id, "id", "i", "", "The authorization ID (required)")
 	authorizationDeleteCmd.MarkFlagRequired("id")
 
 	authorizationCmd.AddCommand(authorizationDeleteCmd)
@@ -463,11 +463,11 @@ var authorizationActiveFlags AuthorizationActiveFlags
 func init() {
 	authorizationActiveCmd := &cobra.Command{
 		Use:   "active",
-		Short: "active authorization",
+		Short: "Active authorization",
 		RunE:  authorizationActiveF,
 	}
 
-	authorizationActiveCmd.Flags().StringVarP(&authorizationActiveFlags.id, "id", "i", "", "authorization id (required)")
+	authorizationActiveCmd.Flags().StringVarP(&authorizationActiveFlags.id, "id", "i", "", "The authorization ID (required)")
 	authorizationActiveCmd.MarkFlagRequired("id")
 
 	authorizationCmd.AddCommand(authorizationActiveCmd)
@@ -532,11 +532,11 @@ var authorizationInactiveFlags AuthorizationInactiveFlags
 func init() {
 	authorizationInactiveCmd := &cobra.Command{
 		Use:   "inactive",
-		Short: "inactive authorization",
+		Short: "Inactive authorization",
 		RunE:  authorizationInactiveF,
 	}
 
-	authorizationInactiveCmd.Flags().StringVarP(&authorizationInactiveFlags.id, "id", "i", "", "authorization id (required)")
+	authorizationInactiveCmd.Flags().StringVarP(&authorizationInactiveFlags.id, "id", "i", "", "The authorization ID (required)")
 	authorizationInactiveCmd.MarkFlagRequired("id")
 
 	authorizationCmd.AddCommand(authorizationInactiveCmd)

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -17,7 +17,7 @@ import (
 // Bucket Command
 var bucketCmd = &cobra.Command{
 	Use:   "bucket",
-	Short: "bucket related commands",
+	Short: "Bucket management commands",
 	Run:   bucketF,
 }
 
@@ -42,10 +42,10 @@ func init() {
 		Run:   bucketCreateF,
 	}
 
-	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.name, "name", "n", "", "name of bucket that will be created")
-	bucketCreateCmd.Flags().DurationVarP(&bucketCreateFlags.retention, "retention", "r", 0, "duration in nanoseconds data will live in bucket")
-	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.org, "org", "o", "", "name of the organization that owns the bucket")
-	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.orgID, "org-id", "", "", "id of the organization that owns the bucket")
+	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.name, "name", "n", "", "Name of bucket that will be created")
+	bucketCreateCmd.Flags().DurationVarP(&bucketCreateFlags.retention, "retention", "r", 0, "Duration in nanoseconds data will live in bucket")
+	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.org, "org", "o", "", "Name of the organization that owns the bucket")
+	bucketCreateCmd.Flags().StringVarP(&bucketCreateFlags.orgID, "org-id", "", "", "The ID of the organization that owns the bucket")
 	bucketCreateCmd.MarkFlagRequired("name")
 
 	bucketCmd.AddCommand(bucketCreateCmd)
@@ -143,10 +143,10 @@ func init() {
 		Run:   bucketFindF,
 	}
 
-	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.name, "name", "n", "", "bucket name")
-	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.id, "id", "i", "", "bucket ID")
-	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.orgID, "org-id", "", "", "bucket organization ID")
-	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.org, "org", "o", "", "bucket organization name")
+	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.name, "name", "n", "", "The bucket name")
+	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.id, "id", "i", "", "The bucket ID")
+	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.orgID, "org-id", "", "", "The bucket organization ID")
+	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.org, "org", "o", "", "The bucket organization name")
 
 	bucketCmd.AddCommand(bucketFindCmd)
 }
@@ -233,9 +233,9 @@ func init() {
 		Run:   bucketUpdateF,
 	}
 
-	bucketUpdateCmd.Flags().StringVarP(&bucketUpdateFlags.id, "id", "i", "", "bucket ID (required)")
-	bucketUpdateCmd.Flags().StringVarP(&bucketUpdateFlags.name, "name", "n", "", "new bucket name")
-	bucketUpdateCmd.Flags().DurationVarP(&bucketUpdateFlags.retention, "retention", "r", 0, "new duration data will live in bucket")
+	bucketUpdateCmd.Flags().StringVarP(&bucketUpdateFlags.id, "id", "i", "", "The bucket ID (required)")
+	bucketUpdateCmd.Flags().StringVarP(&bucketUpdateFlags.name, "name", "n", "", "New bucket name")
+	bucketUpdateCmd.Flags().DurationVarP(&bucketUpdateFlags.retention, "retention", "r", 0, "New duration data will live in bucket")
 	bucketUpdateCmd.MarkFlagRequired("id")
 
 	bucketCmd.AddCommand(bucketUpdateCmd)
@@ -345,7 +345,7 @@ func init() {
 		Run:   bucketDeleteF,
 	}
 
-	bucketDeleteCmd.Flags().StringVarP(&bucketDeleteFlags.id, "id", "i", "", "bucket id (required)")
+	bucketDeleteCmd.Flags().StringVarP(&bucketDeleteFlags.id, "id", "i", "", "The bucket ID (required)")
 	bucketDeleteCmd.MarkFlagRequired("id")
 
 	bucketCmd.AddCommand(bucketDeleteCmd)

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -80,10 +80,23 @@ func init() {
 	}
 
 	influxCmd.PersistentFlags().BoolVar(&flags.local, "local", false, "Run commands locally against the filesystem")
+
+	// Override help on all the commands tree
+	walk(influxCmd, func(c *cobra.Command) {
+		c.Flags().BoolP("help", "h", false, fmt.Sprintf("Help for the %s command ", c.Name()))
+	})
 }
 
 func influxF(cmd *cobra.Command, args []string) {
 	cmd.Usage()
+}
+
+// walk calls f for c and all of its children.
+func walk(c *cobra.Command, f func(*cobra.Command)) {
+	f(c)
+	for _, c := range c.Commands() {
+		walk(c, f)
+	}
 }
 
 // Execute executes the influx command

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -17,7 +17,7 @@ import (
 var organizationCmd = &cobra.Command{
 	Use:     "org",
 	Aliases: []string{"organization"},
-	Short:   "Organization related commands",
+	Short:   "Organization management commands",
 	Run:     organizationF,
 }
 
@@ -39,7 +39,7 @@ func init() {
 		Run:   organizationCreateF,
 	}
 
-	organizationCreateCmd.Flags().StringVarP(&organizationCreateFlags.name, "name", "n", "", "name of organization that will be created")
+	organizationCreateCmd.Flags().StringVarP(&organizationCreateFlags.name, "name", "n", "", "The name of organization that will be created")
 	organizationCreateCmd.MarkFlagRequired("name")
 
 	organizationCmd.AddCommand(organizationCreateCmd)
@@ -109,8 +109,8 @@ func init() {
 		Run:   organizationFindF,
 	}
 
-	organizationFindCmd.Flags().StringVarP(&organizationFindFlags.name, "name", "n", "", "organization name")
-	organizationFindCmd.Flags().StringVarP(&organizationFindFlags.id, "id", "i", "", "organization id")
+	organizationFindCmd.Flags().StringVarP(&organizationFindFlags.name, "name", "n", "", "The organization name")
+	organizationFindCmd.Flags().StringVarP(&organizationFindFlags.id, "id", "i", "", "The organization ID")
 
 	organizationCmd.AddCommand(organizationFindCmd)
 }
@@ -171,8 +171,8 @@ func init() {
 		Run:   organizationUpdateF,
 	}
 
-	organizationUpdateCmd.Flags().StringVarP(&organizationUpdateFlags.id, "id", "i", "", "organization ID (required)")
-	organizationUpdateCmd.Flags().StringVarP(&organizationUpdateFlags.name, "name", "n", "", "organization name")
+	organizationUpdateCmd.Flags().StringVarP(&organizationUpdateFlags.id, "id", "i", "", "The organization ID (required)")
+	organizationUpdateCmd.Flags().StringVarP(&organizationUpdateFlags.name, "name", "n", "", "The organization name")
 	organizationUpdateCmd.MarkFlagRequired("id")
 
 	organizationCmd.AddCommand(organizationUpdateCmd)
@@ -214,7 +214,7 @@ func organizationUpdateF(cmd *cobra.Command, args []string) {
 	w.Flush()
 }
 
-// Delete command
+// OrganizationDeleteFlags contains the flag of the org delete command
 type OrganizationDeleteFlags struct {
 	id string
 }
@@ -267,7 +267,7 @@ func init() {
 		Run:   organizationDeleteF,
 	}
 
-	organizationDeleteCmd.Flags().StringVarP(&organizationDeleteFlags.id, "id", "i", "", "organization id (required)")
+	organizationDeleteCmd.Flags().StringVarP(&organizationDeleteFlags.id, "id", "i", "", "The organization ID (required)")
 	organizationDeleteCmd.MarkFlagRequired("id")
 
 	organizationCmd.AddCommand(organizationDeleteCmd)
@@ -276,7 +276,7 @@ func init() {
 // Member management
 var organizationMembersCmd = &cobra.Command{
 	Use:   "members",
-	Short: "organization membership commands",
+	Short: "Organization membership commands",
 	Run:   organizationF,
 }
 
@@ -363,8 +363,8 @@ func init() {
 		Run:   organizationMembersListF,
 	}
 
-	organizationMembersListCmd.Flags().StringVarP(&organizationMembersListFlags.id, "id", "i", "", "organization id")
-	organizationMembersListCmd.Flags().StringVarP(&organizationMembersListFlags.name, "name", "n", "", "organization name")
+	organizationMembersListCmd.Flags().StringVarP(&organizationMembersListFlags.id, "id", "i", "", "The organization ID")
+	organizationMembersListCmd.Flags().StringVarP(&organizationMembersListFlags.name, "name", "n", "", "The organization name")
 
 	organizationMembersCmd.AddCommand(organizationMembersListCmd)
 }
@@ -450,9 +450,9 @@ func init() {
 		Run:   organizationMembersAddF,
 	}
 
-	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.id, "id", "i", "", "organization id")
-	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.name, "name", "n", "", "organization name")
-	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.memberId, "member", "o", "", "member id")
+	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.id, "id", "i", "", "The organization ID")
+	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.name, "name", "n", "", "The organization name")
+	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.memberId, "member", "o", "", "The member ID")
 	organizationMembersAddCmd.MarkFlagRequired("member")
 
 	organizationMembersCmd.AddCommand(organizationMembersAddCmd)
@@ -533,9 +533,9 @@ func init() {
 		Run:   organizationMembersRemoveF,
 	}
 
-	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.id, "id", "i", "", "organization id")
-	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.name, "name", "n", "", "organization name")
-	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.memberId, "member", "o", "", "member id")
+	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.id, "id", "i", "", "The organization ID")
+	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.name, "name", "n", "", "The organization name")
+	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.memberId, "member", "o", "", "The member ID")
 	organizationMembersRemoveCmd.MarkFlagRequired("member")
 
 	organizationMembersCmd.AddCommand(organizationMembersRemoveCmd)

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -13,9 +13,9 @@ import (
 
 var queryCmd = &cobra.Command{
 	Use:   "query [query literal or @/path/to/query.flux]",
-	Short: "Execute an Flux query",
+	Short: "Execute a Flux query",
 	Long: `Execute a literal Flux query provided as a string,
-		or execute a literal Flux query contained in a file by specifying the file prefixed with an @ sign.`,
+or execute a literal Flux query contained in a file by specifying the file prefixed with an @ sign.`,
 	Args: cobra.ExactArgs(1),
 	Run:  fluxQueryF,
 }
@@ -25,7 +25,7 @@ var queryFlags struct {
 }
 
 func init() {
-	queryCmd.PersistentFlags().StringVar(&queryFlags.OrgID, "org-id", "", "Organization ID")
+	queryCmd.PersistentFlags().StringVar(&queryFlags.OrgID, "org-id", "", "The organization ID")
 	viper.BindEnv("ORG_ID")
 	if h := viper.GetString("ORG_ID"); h != "" {
 		queryFlags.OrgID = h

--- a/cmd/influx/repl.go
+++ b/cmd/influx/repl.go
@@ -27,13 +27,13 @@ var replFlags struct {
 }
 
 func init() {
-	replCmd.PersistentFlags().StringVar(&replFlags.OrgID, "org-id", "", "ID of organization to query")
+	replCmd.PersistentFlags().StringVar(&replFlags.OrgID, "org-id", "", "The ID of organization to query")
 	viper.BindEnv("ORG_ID")
 	if h := viper.GetString("ORG_ID"); h != "" {
 		replFlags.OrgID = h
 	}
 
-	replCmd.PersistentFlags().StringVarP(&replFlags.Org, "org", "o", "", "name of the organization")
+	replCmd.PersistentFlags().StringVarP(&replFlags.Org, "org", "o", "", "The name of the organization")
 	viper.BindEnv("ORG")
 	if h := viper.GetString("ORG"); h != "" {
 		replFlags.Org = h

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -15,7 +15,7 @@ import (
 // task Command
 var taskCmd = &cobra.Command{
 	Use:   "task",
-	Short: "task related commands",
+	Short: "Task management commands",
 	Run:   taskF,
 }
 
@@ -30,7 +30,7 @@ func taskF(cmd *cobra.Command, args []string) {
 
 var logCmd = &cobra.Command{
 	Use:   "log",
-	Short: "log related commands",
+	Short: "Log related commands",
 	Run:   logF,
 }
 
@@ -40,7 +40,7 @@ func logF(cmd *cobra.Command, args []string) {
 
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "run related commands",
+	Short: "Run related commands",
 	Run:   runF,
 }
 

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -36,8 +36,8 @@ func init() {
 		Run:   userUpdateF,
 	}
 
-	userUpdateCmd.Flags().StringVarP(&userUpdateFlags.id, "id", "i", "", "user id (required)")
-	userUpdateCmd.Flags().StringVarP(&userUpdateFlags.name, "name", "n", "", "user name")
+	userUpdateCmd.Flags().StringVarP(&userUpdateFlags.id, "id", "i", "", "The user ID (required)")
+	userUpdateCmd.Flags().StringVarP(&userUpdateFlags.name, "name", "n", "", "The user name")
 	userUpdateCmd.MarkFlagRequired("id")
 
 	userCmd.AddCommand(userUpdateCmd)
@@ -133,7 +133,7 @@ func init() {
 		Run:   userCreateF,
 	}
 
-	userCreateCmd.Flags().StringVarP(&userCreateFlags.name, "name", "n", "", "user name (required)")
+	userCreateCmd.Flags().StringVarP(&userCreateFlags.name, "name", "n", "", "The user name (required)")
 	userCreateCmd.MarkFlagRequired("name")
 
 	userCmd.AddCommand(userCreateCmd)
@@ -182,8 +182,8 @@ func init() {
 		Run:   userFindF,
 	}
 
-	userFindCmd.Flags().StringVarP(&userFindFlags.id, "id", "i", "", "user ID")
-	userFindCmd.Flags().StringVarP(&userFindFlags.name, "name", "n", "", "user name")
+	userFindCmd.Flags().StringVarP(&userFindFlags.id, "id", "i", "", "The user ID")
+	userFindCmd.Flags().StringVarP(&userFindFlags.name, "name", "n", "", "The user name")
 
 	userCmd.AddCommand(userFindCmd)
 }
@@ -242,7 +242,7 @@ func init() {
 		Run:   userDeleteF,
 	}
 
-	userDeleteCmd.Flags().StringVarP(&userDeleteFlags.id, "id", "i", "", "user id (required)")
+	userDeleteCmd.Flags().StringVarP(&userDeleteFlags.id, "id", "i", "", "The user ID (required)")
 	userDeleteCmd.MarkFlagRequired("id")
 
 	userCmd.AddCommand(userDeleteCmd)

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -18,9 +18,9 @@ import (
 
 var writeCmd = &cobra.Command{
 	Use:   "write line protocol or @/path/to/points.txt",
-	Short: "Write points to influxdb",
-	Long: `Write a single line of line protocol to influx db,
-		or add an entire file specified with an @ prefix`,
+	Short: "Write points to InfluxDB",
+	Long: `Write a single line of line protocol to InfluxDB,
+or add an entire file specified with an @ prefix.`,
 	Args: cobra.ExactArgs(1),
 	RunE: fluxWriteF,
 }
@@ -34,31 +34,31 @@ var writeFlags struct {
 }
 
 func init() {
-	writeCmd.PersistentFlags().StringVar(&writeFlags.OrgID, "org-id", "", "id of the organization that owns the bucket")
+	writeCmd.PersistentFlags().StringVar(&writeFlags.OrgID, "org-id", "", "The ID of the organization that owns the bucket")
 	viper.BindEnv("ORG_ID")
 	if h := viper.GetString("ORG_ID"); h != "" {
 		writeFlags.OrgID = h
 	}
 
-	writeCmd.PersistentFlags().StringVarP(&writeFlags.Org, "org", "o", "", "name of the organization that owns the bucket")
+	writeCmd.PersistentFlags().StringVarP(&writeFlags.Org, "org", "o", "", "The name of the organization that owns the bucket")
 	viper.BindEnv("ORG")
 	if h := viper.GetString("ORG"); h != "" {
 		writeFlags.Org = h
 	}
 
-	writeCmd.PersistentFlags().StringVar(&writeFlags.BucketID, "bucket-id", "", "ID of destination bucket")
+	writeCmd.PersistentFlags().StringVar(&writeFlags.BucketID, "bucket-id", "", "The ID of destination bucket")
 	viper.BindEnv("BUCKET_ID")
 	if h := viper.GetString("BUCKET_ID"); h != "" {
 		writeFlags.BucketID = h
 	}
 
-	writeCmd.PersistentFlags().StringVarP(&writeFlags.Bucket, "bucket", "b", "", "name of destination bucket")
+	writeCmd.PersistentFlags().StringVarP(&writeFlags.Bucket, "bucket", "b", "", "The name of destination bucket")
 	viper.BindEnv("BUCKET_NAME")
 	if h := viper.GetString("BUCKET_NAME"); h != "" {
 		writeFlags.Bucket = h
 	}
 
-	writeCmd.PersistentFlags().StringVarP(&writeFlags.Precision, "precision", "p", "ns", "precision of the timestamps of the lines")
+	writeCmd.PersistentFlags().StringVarP(&writeFlags.Precision, "precision", "p", "ns", "Precision of the timestamps of the lines")
 	viper.BindEnv("PRECISION")
 	if p := viper.GetString("PRECISION"); p != "" {
 		writeFlags.Precision = p


### PR DESCRIPTION
Closes #10995 

This PR represents an attempt to standardise our CLI as suggested by @edd in the referred issue.

Rules

- ID always completely uppercase
- Custom help message for all commands and subcommands, starting with an uppercase word too
- Commands short (and long) descriptions starting with an uppercase word
- Flags descritions starting with an uppercase 

---

  - [ ] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
