### PR TITLE
chore(ci): Fix nightly build bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
           name: Restore Yarn package cache
           keys:
             - chronograf-npm-packages-{{ checksum "ui/package-lock.json" }}
-
       - run: make build
 
   deploy:
@@ -124,12 +123,16 @@ jobs:
           name: Restore Yarn package cache
           keys:
             - chronograf-npm-packages-{{ checksum "ui/package-lock.json" }}
-
       - setup_remote_docker
-
-      - run: |
-          docker login -u "$QUAY_USER" -p $QUAY_PASS quay.io
-          make nightly
+      - run:
+          name: "Docker Login"
+          command: docker login -u "$QUAY_USER" -p $QUAY_PASS quay.io
+      - run:
+          name: "Tag commit for goreleaser semantic versioning"
+          command: git tag v0.0.0
+      - run:
+          name: "Build nightly"
+          command: make nightly
 
 workflows:
   version: 2


### PR DESCRIPTION
The project is currently using goreleaser to manage building nightly binaries, docker images and uploads to s3.
The tool has a strict dependency on semantic versioned tags. InfluxDB history does not have a valid semantic tag causing the tool to fail. This commit creates a valid tag for the current time to allow nightly builds to continue.