### PR TITLE
fix(influxdb): change resource to resource type

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -27,7 +27,7 @@ type Authorization struct {
 // Valid ensures that the authorization is valid.
 func (a *Authorization) Valid() error {
 	for _, p := range a.Permissions {
-		if p.OrgID != a.OrgID {
+		if p.Resource.OrgID != nil && *p.Resource.OrgID != a.OrgID {
 			return &Error{
 				Msg:  fmt.Sprintf("permisson %s is not for org id %s", p, a.OrgID),
 				Code: EInvalid,

--- a/authz_test.go
+++ b/authz_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	platform "github.com/influxdata/influxdb"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
 )
 
 func TestAuthorizer_PermissionAllowed(t *testing.T) {
@@ -14,19 +15,43 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		allowed     bool
 	}{
 		{
-			name: "bad org id in permission",
+			name: "global permission",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    0,
-				ID:       IDPtr(0),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    influxdbtesting.IDPtr(1),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.WriteAction,
-					Resource: platform.BucketsResource,
-					OrgID:    1,
-					ID:       IDPtr(1),
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type: platform.BucketsResourceType,
+					},
+				},
+			},
+			allowed: true,
+		},
+		{
+			name: "bad org id in permission",
+			permission: platform.Permission{
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(0),
+					ID:    influxdbtesting.IDPtr(0),
+				},
+			},
+			permissions: []platform.Permission{
+				{
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type:  platform.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(1),
+					},
 				},
 			},
 			allowed: false,
@@ -34,17 +59,21 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		{
 			name: "bad resource id in permission",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
-				ID:       IDPtr(0),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    influxdbtesting.IDPtr(0),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.WriteAction,
-					Resource: platform.BucketsResource,
-					OrgID:    1,
-					ID:       IDPtr(1),
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type:  platform.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(1),
+					},
 				},
 			},
 			allowed: false,
@@ -52,17 +81,21 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		{
 			name: "bad resource id in permissions",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
-				ID:       IDPtr(1),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    influxdbtesting.IDPtr(1),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.WriteAction,
-					Resource: platform.BucketsResource,
-					OrgID:    1,
-					ID:       IDPtr(0),
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type:  platform.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(0),
+					},
 				},
 			},
 			allowed: false,
@@ -70,17 +103,21 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		{
 			name: "matching action resource and ID",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
-				ID:       IDPtr(1),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    influxdbtesting.IDPtr(1),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.WriteAction,
-					Resource: platform.BucketsResource,
-					OrgID:    1,
-					ID:       IDPtr(1),
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type:  platform.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(1),
+					},
 				},
 			},
 			allowed: true,
@@ -88,16 +125,20 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		{
 			name: "matching action resource with total",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
-				ID:       IDPtr(1),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    influxdbtesting.IDPtr(1),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.WriteAction,
-					Resource: platform.BucketsResource,
-					OrgID:    1,
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type:  platform.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+					},
 				},
 			},
 			allowed: true,
@@ -105,15 +146,19 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		{
 			name: "matching action resource no ID",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.WriteAction,
-					Resource: platform.BucketsResource,
-					OrgID:    1,
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type:  platform.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+					},
 				},
 			},
 			allowed: true,
@@ -121,17 +166,21 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		{
 			name: "matching action resource differing ID",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
-				ID:       IDPtr(1),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    influxdbtesting.IDPtr(1),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.WriteAction,
-					Resource: platform.BucketsResource,
-					OrgID:    1,
-					ID:       IDPtr(2),
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type:  platform.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(2),
+					},
 				},
 			},
 			allowed: false,
@@ -139,17 +188,21 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		{
 			name: "differing action same resource",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
-				ID:       IDPtr(1),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    influxdbtesting.IDPtr(1),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.ReadAction,
-					Resource: platform.BucketsResource,
-					OrgID:    1,
-					ID:       IDPtr(1),
+					Action: platform.ReadAction,
+					Resource: platform.Resource{
+						Type:  platform.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(1),
+					},
 				},
 			},
 			allowed: false,
@@ -157,17 +210,21 @@ func TestAuthorizer_PermissionAllowed(t *testing.T) {
 		{
 			name: "same action differing resource",
 			permission: platform.Permission{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
-				ID:       IDPtr(1),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    influxdbtesting.IDPtr(1),
+				},
 			},
 			permissions: []platform.Permission{
 				{
-					Action:   platform.WriteAction,
-					Resource: platform.TasksResource,
-					OrgID:    1,
-					ID:       IDPtr(1),
+					Action: platform.WriteAction,
+					Resource: platform.Resource{
+						Type:  platform.TasksResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+						ID:    influxdbtesting.IDPtr(1),
+					},
 				},
 			},
 			allowed: false,
@@ -188,8 +245,6 @@ func TestPermission_Valid(t *testing.T) {
 	type fields struct {
 		Action   platform.Action
 		Resource platform.Resource
-		ID       *platform.ID
-		OrgID    platform.ID
 	}
 	tests := []struct {
 		name    string
@@ -199,36 +254,44 @@ func TestPermission_Valid(t *testing.T) {
 		{
 			name: "valid bucket permission with ID",
 			fields: fields{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				ID:       validID(),
-				OrgID:    1,
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					ID:    validID(),
+					OrgID: influxdbtesting.IDPtr(1),
+				},
 			},
 		},
 		{
 			name: "valid bucket permission with nil ID",
 			fields: fields{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				ID:       nil,
-				OrgID:    1,
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					ID:    nil,
+					OrgID: influxdbtesting.IDPtr(1),
+				},
 			},
 		},
 		{
 			name: "invalid bucket permission with an invalid ID",
 			fields: fields{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				ID:       func() *platform.ID { id := platform.InvalidID(); return &id }(),
-				OrgID:    1,
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					ID:    func() *platform.ID { id := platform.InvalidID(); return &id }(),
+					OrgID: influxdbtesting.IDPtr(1),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid permission without an action",
 			fields: fields{
-				Resource: platform.BucketsResource,
-				OrgID:    1,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+				},
 			},
 			wantErr: true,
 		},
@@ -236,15 +299,6 @@ func TestPermission_Valid(t *testing.T) {
 			name: "invalid permission without a resource",
 			fields: fields{
 				Action: platform.WriteAction,
-				OrgID:  1,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid permission without a valid orgID",
-			fields: fields{
-				Action: platform.WriteAction,
-				OrgID:  0,
 			},
 			wantErr: true,
 		},
@@ -254,8 +308,6 @@ func TestPermission_Valid(t *testing.T) {
 			p := &platform.Permission{
 				Action:   tt.fields.Action,
 				Resource: tt.fields.Resource,
-				ID:       tt.fields.ID,
-				OrgID:    tt.fields.OrgID,
 			}
 			if err := p.Valid(); (err != nil) != tt.wantErr {
 				t.Errorf("Permission.Valid() error = %v, wantErr %v", err, tt.wantErr)
@@ -265,20 +317,22 @@ func TestPermission_Valid(t *testing.T) {
 }
 
 func TestPermissionAllResources_Valid(t *testing.T) {
-	var resources = []platform.Resource{
-		platform.UsersResource,
-		platform.OrgsResource,
-		platform.TasksResource,
-		platform.BucketsResource,
-		platform.DashboardsResource,
-		platform.SourcesResource,
+	var resources = []platform.ResourceType{
+		platform.UsersResourceType,
+		platform.OrgsResourceType,
+		platform.TasksResourceType,
+		platform.BucketsResourceType,
+		platform.DashboardsResourceType,
+		platform.SourcesResourceType,
 	}
 
-	for _, r := range resources {
+	for _, rt := range resources {
 		p := &platform.Permission{
-			Action:   platform.WriteAction,
-			Resource: r,
-			OrgID:    1,
+			Action: platform.WriteAction,
+			Resource: platform.Resource{
+				Type: rt,
+				ID:   influxdbtesting.IDPtr(1),
+			},
 		}
 
 		if err := p.Valid(); err != nil {
@@ -295,9 +349,11 @@ func TestPermissionAllActions(t *testing.T) {
 
 	for _, a := range actions {
 		p := &platform.Permission{
-			Action:   a,
-			Resource: platform.TasksResource,
-			OrgID:    1,
+			Action: a,
+			Resource: platform.Resource{
+				Type:  platform.TasksResourceType,
+				OrgID: influxdbtesting.IDPtr(1),
+			},
 		}
 
 		if err := p.Valid(); err != nil {
@@ -310,8 +366,6 @@ func TestPermission_String(t *testing.T) {
 	type fields struct {
 		Action   platform.Action
 		Resource platform.Resource
-		OrgID    platform.ID
-		ID       *platform.ID
 		Name     *string
 	}
 	tests := []struct {
@@ -322,21 +376,46 @@ func TestPermission_String(t *testing.T) {
 		{
 			name: "valid permission with no id",
 			fields: fields{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+				},
 			},
 			want: `write:orgs/0000000000000001/buckets`,
 		},
 		{
 			name: "valid permission with an id",
 			fields: fields{
-				Action:   platform.WriteAction,
-				Resource: platform.BucketsResource,
-				OrgID:    1,
-				ID:       validID(),
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type:  platform.BucketsResourceType,
+					OrgID: influxdbtesting.IDPtr(1),
+					ID:    validID(),
+				},
 			},
 			want: `write:orgs/0000000000000001/buckets/0000000000000064`,
+		},
+		{
+			name: "valid permission with no id or org id",
+			fields: fields{
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type: platform.BucketsResourceType,
+				},
+			},
+			want: `write:buckets`,
+		},
+		{
+			name: "valid permission with no org id",
+			fields: fields{
+				Action: platform.WriteAction,
+				Resource: platform.Resource{
+					Type: platform.BucketsResourceType,
+					ID:   influxdbtesting.IDPtr(1),
+				},
+			},
+			want: `write:buckets/0000000000000001`,
 		},
 	}
 	for _, tt := range tests {
@@ -344,8 +423,6 @@ func TestPermission_String(t *testing.T) {
 			p := platform.Permission{
 				Action:   tt.fields.Action,
 				Resource: tt.fields.Resource,
-				ID:       tt.fields.ID,
-				OrgID:    tt.fields.OrgID,
 			}
 			if got := p.String(); got != tt.want {
 				t.Errorf("Permission.String() = %v, want %v", got, tt.want)
@@ -356,9 +433,5 @@ func TestPermission_String(t *testing.T) {
 
 func validID() *platform.ID {
 	id := platform.ID(100)
-	return &id
-}
-
-func IDPtr(id platform.ID) *platform.ID {
 	return &id
 }

--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -372,8 +372,8 @@ func (c *Client) PutBucket(ctx context.Context, b *platform.Bucket) error {
 
 func (c *Client) createBucketUserResourceMappings(ctx context.Context, tx *bolt.Tx, b *platform.Bucket) *platform.Error {
 	ms, err := c.findUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
-		Resource:   platform.OrgsResource,
-		ResourceID: b.OrganizationID,
+		ResourceType: platform.OrgsResourceType,
+		ResourceID:   b.OrganizationID,
 	})
 	if err != nil {
 		return &platform.Error{
@@ -383,10 +383,10 @@ func (c *Client) createBucketUserResourceMappings(ctx context.Context, tx *bolt.
 
 	for _, m := range ms {
 		if err := c.createUserResourceMapping(ctx, tx, &platform.UserResourceMapping{
-			Resource:   platform.BucketsResource,
-			ResourceID: b.ID,
-			UserID:     m.UserID,
-			UserType:   m.UserType,
+			ResourceType: platform.BucketsResourceType,
+			ResourceID:   b.ID,
+			UserID:       m.UserID,
+			UserType:     m.UserType,
 		}); err != nil {
 			return &platform.Error{
 				Err: err,
@@ -564,8 +564,8 @@ func (c *Client) deleteBucket(ctx context.Context, tx *bolt.Tx, id platform.ID) 
 		}
 	}
 	if err := c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
-		ResourceID: id,
-		Resource:   platform.BucketsResource,
+		ResourceID:   id,
+		ResourceType: platform.BucketsResourceType,
 	}); err != nil {
 		return &platform.Error{
 			Err: err,

--- a/bolt/dashboard.go
+++ b/bolt/dashboard.go
@@ -804,8 +804,8 @@ func (c *Client) deleteDashboard(ctx context.Context, tx *bolt.Tx, id platform.I
 
 	// TODO(desa): add DeleteKeyValueLog method and use it here.
 	err = c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
-		ResourceID: id,
-		Resource:   platform.DashboardsResource,
+		ResourceID:   id,
+		ResourceType: platform.DashboardsResourceType,
 	})
 	if err != nil {
 		return &platform.Error{

--- a/bolt/lookup_service.go
+++ b/bolt/lookup_service.go
@@ -9,7 +9,7 @@ import (
 var _ platform.LookupService = (*Client)(nil)
 
 // Name returns the name for the resource and ID.
-func (c *Client) Name(ctx context.Context, resource platform.Resource, id platform.ID) (string, error) {
+func (c *Client) Name(ctx context.Context, resource platform.ResourceType, id platform.ID) (string, error) {
 	if err := resource.Valid(); err != nil {
 		return "", err
 	}
@@ -19,39 +19,39 @@ func (c *Client) Name(ctx context.Context, resource platform.Resource, id platfo
 	}
 
 	switch resource {
-	case platform.TasksResource: // 5 // TODO(goller): unify task bolt storage here so we can lookup names
-	case platform.AuthorizationsResource: // 0 TODO(goller): authorizations should also have optional names
-	case platform.BucketsResource: // 1
+	case platform.TasksResourceType: // 5 // TODO(goller): unify task bolt storage here so we can lookup names
+	case platform.AuthorizationsResourceType: // 0 TODO(goller): authorizations should also have optional names
+	case platform.BucketsResourceType: // 1
 		r, err := c.FindBucketByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.DashboardsResource: // 2
+	case platform.DashboardsResourceType: // 2
 		r, err := c.FindDashboardByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.OrgsResource: // 3
+	case platform.OrgsResourceType: // 3
 		r, err := c.FindOrganizationByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.SourcesResource: // 4
+	case platform.SourcesResourceType: // 4
 		r, err := c.FindSourceByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.TelegrafsResource: // 6
+	case platform.TelegrafsResourceType: // 6
 		r, err := c.FindTelegrafConfigByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.UsersResource: // 7
+	case platform.UsersResourceType: // 7
 		r, err := c.FindUserByID(ctx, id)
 		if err != nil {
 			return "", err

--- a/bolt/lookup_service_test.go
+++ b/bolt/lookup_service_test.go
@@ -19,7 +19,6 @@ func TestClient_Name(t *testing.T) {
 	type initFn func(ctx context.Context, c *bolt.Client) error
 	type args struct {
 		resource platform.Resource
-		id       platform.ID
 		init     initFn
 	}
 	tests := []struct {
@@ -31,40 +30,49 @@ func TestClient_Name(t *testing.T) {
 		{
 			name: "error if id is invalid",
 			args: args{
-				resource: platform.DashboardsResource,
-				id:       platform.InvalidID(),
+				resource: platform.Resource{
+					Type: platform.DashboardsResourceType,
+					ID:   platformtesting.IDPtr(platform.InvalidID()),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "error if resource is invalid",
 			args: args{
-				resource: platform.Resource("invalid"),
+				resource: platform.Resource{
+					Type: platform.ResourceType("invalid"),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "authorization resource without a name returns empty string",
 			args: args{
-				resource: platform.AuthorizationsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.AuthorizationsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			want: "",
 		},
 		{
 			name: "task resource without a name returns empty string",
 			args: args{
-				resource: platform.TasksResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.TasksResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			want: "",
 		},
-
 		{
 			name: "bucket with existing id returns name",
 			args: args{
-				resource: platform.BucketsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.BucketsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *bolt.Client) error {
 					_ = s.CreateOrganization(ctx, &platform.Organization{
 						Name: "o1",
@@ -80,16 +88,20 @@ func TestClient_Name(t *testing.T) {
 		{
 			name: "bucket with non-existent id returns error",
 			args: args{
-				resource: platform.BucketsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.BucketsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "dashboard with existing id returns name",
 			args: args{
-				resource: platform.DashboardsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.DashboardsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *bolt.Client) error {
 					return s.CreateDashboard(ctx, &platform.Dashboard{
 						Name:           "dashboard1",
@@ -102,16 +114,20 @@ func TestClient_Name(t *testing.T) {
 		{
 			name: "dashboard with non-existent id returns error",
 			args: args{
-				resource: platform.DashboardsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.DashboardsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "org with existing id returns name",
 			args: args{
-				resource: platform.OrgsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.OrgsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *bolt.Client) error {
 					return s.CreateOrganization(ctx, &platform.Organization{
 						Name: "org1",
@@ -123,16 +139,20 @@ func TestClient_Name(t *testing.T) {
 		{
 			name: "org with non-existent id returns error",
 			args: args{
-				resource: platform.OrgsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.OrgsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "source with existing id returns name",
 			args: args{
-				resource: platform.SourcesResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.SourcesResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *bolt.Client) error {
 					return s.CreateSource(ctx, &platform.Source{
 						Name: "source1",
@@ -144,16 +164,20 @@ func TestClient_Name(t *testing.T) {
 		{
 			name: "source with non-existent id returns error",
 			args: args{
-				resource: platform.SourcesResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.SourcesResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "telegraf with existing id returns name",
 			args: args{
-				resource: platform.TelegrafsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.TelegrafsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *bolt.Client) error {
 					return s.CreateTelegrafConfig(ctx, &platform.TelegrafConfig{
 						OrganizationID: platformtesting.MustIDBase16("0000000000000009"),
@@ -166,16 +190,20 @@ func TestClient_Name(t *testing.T) {
 		{
 			name: "telegraf with non-existent id returns error",
 			args: args{
-				resource: platform.TelegrafsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.TelegrafsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "user with existing id returns name",
 			args: args{
-				resource: platform.UsersResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.UsersResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *bolt.Client) error {
 					return s.CreateUser(ctx, &platform.User{
 						Name: "user1",
@@ -187,8 +215,10 @@ func TestClient_Name(t *testing.T) {
 		{
 			name: "user with non-existent id returns error",
 			args: args{
-				resource: platform.UsersResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.UsersResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
@@ -208,7 +238,11 @@ func TestClient_Name(t *testing.T) {
 					t.Errorf("Service.Name() unable to initialize service: %v", err)
 				}
 			}
-			got, err := c.Name(ctx, tt.args.resource, tt.args.id)
+			id := platform.InvalidID()
+			if tt.args.resource.ID != nil {
+				id = *tt.args.resource.ID
+			}
+			got, err := c.Name(ctx, tt.args.resource.Type, id)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Service.Name() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/bolt/onboarding.go
+++ b/bolt/onboarding.go
@@ -107,10 +107,10 @@ func (c *Client) Generate(ctx context.Context, req *platform.OnboardingRequest) 
 		RetentionPeriod: time.Duration(req.RetentionPeriod) * time.Hour,
 	}
 	if err := c.CreateUserResourceMapping(ctx, &platform.UserResourceMapping{
-		Resource:   platform.OrgsResource,
-		ResourceID: o.ID,
-		UserID:     u.ID,
-		UserType:   platform.Owner,
+		ResourceType: platform.OrgsResourceType,
+		ResourceID:   o.ID,
+		UserID:       u.ID,
+		UserType:     platform.Owner,
 	}); err != nil {
 		return nil, err
 	}

--- a/bolt/telegraf.go
+++ b/bolt/telegraf.go
@@ -165,10 +165,10 @@ func (c *Client) CreateTelegrafConfig(ctx context.Context, tc *platform.Telegraf
 		}
 
 		urm := &platform.UserResourceMapping{
-			ResourceID: tc.ID,
-			UserID:     userID,
-			UserType:   platform.Owner,
-			Resource:   platform.TelegrafsResource,
+			ResourceID:   tc.ID,
+			UserID:       userID,
+			UserType:     platform.Owner,
+			ResourceType: platform.TelegrafsResourceType,
 		}
 		if err := c.createUserResourceMapping(ctx, tx, urm); err != nil {
 			return err
@@ -219,8 +219,8 @@ func (c *Client) DeleteTelegrafConfig(ctx context.Context, id platform.ID) error
 			return err
 		}
 		return c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
-			ResourceID: id,
-			Resource:   platform.TelegrafsResource,
+			ResourceID:   id,
+			ResourceType: platform.TelegrafsResourceType,
 		})
 	})
 	if err != nil {

--- a/bolt/user_resource_mapping.go
+++ b/bolt/user_resource_mapping.go
@@ -25,7 +25,7 @@ func filterMappingsFn(filter platform.UserResourceMappingFilter) func(m *platfor
 		return (!filter.UserID.Valid() || (filter.UserID == mapping.UserID)) &&
 			(!filter.ResourceID.Valid() || (filter.ResourceID == mapping.ResourceID)) &&
 			(filter.UserType == "" || (filter.UserType == mapping.UserType)) &&
-			(filter.Resource == "" || (filter.Resource == mapping.Resource))
+			(filter.ResourceType == "" || (filter.ResourceType == mapping.ResourceType))
 	}
 }
 
@@ -84,7 +84,7 @@ func (c *Client) CreateUserResourceMapping(ctx context.Context, m *platform.User
 			return err
 		}
 
-		if m.Resource == platform.OrgsResource {
+		if m.ResourceType == platform.OrgsResourceType {
 			return c.createOrgDependentMappings(ctx, tx, m)
 		}
 
@@ -125,10 +125,10 @@ func (c *Client) createOrgDependentMappings(ctx context.Context, tx *bolt.Tx, m 
 	}
 	for _, b := range bs {
 		m := &platform.UserResourceMapping{
-			Resource:   platform.BucketsResource,
-			ResourceID: b.ID,
-			UserType:   m.UserType,
-			UserID:     m.UserID,
+			ResourceType: platform.BucketsResourceType,
+			ResourceID:   b.ID,
+			UserType:     m.UserType,
+			UserID:       m.UserID,
 		}
 		if err := c.createUserResourceMapping(ctx, tx, m); err != nil {
 			return err
@@ -200,7 +200,7 @@ func (c *Client) DeleteUserResourceMapping(ctx context.Context, resourceID platf
 			return err
 		}
 
-		if m.Resource == platform.OrgsResource {
+		if m.ResourceType == platform.OrgsResourceType {
 			return c.deleteOrgDependentMappings(ctx, tx, m)
 		}
 
@@ -252,9 +252,9 @@ func (c *Client) deleteOrgDependentMappings(ctx context.Context, tx *bolt.Tx, m 
 	}
 	for _, b := range bs {
 		if err := c.deleteUserResourceMapping(ctx, tx, platform.UserResourceMappingFilter{
-			Resource:   platform.BucketsResource,
-			ResourceID: b.ID,
-			UserID:     m.UserID,
+			ResourceType: platform.BucketsResourceType,
+			ResourceID:   b.ID,
+			UserID:       m.UserID,
 		}); err != nil {
 			return err
 		}

--- a/bolt/view.go
+++ b/bolt/view.go
@@ -308,8 +308,8 @@ func (c *Client) deleteView(ctx context.Context, tx *bolt.Tx, id platform.ID) *p
 	}
 
 	if err := c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
-		ResourceID: id,
-		Resource:   platform.DashboardsResource,
+		ResourceID:   id,
+		ResourceType: platform.DashboardsResourceType,
 	}); err != nil {
 		return &platform.Error{
 			Err: err,

--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -101,7 +101,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.writeUserPermission {
-		p, err := platform.NewPermission(platform.WriteAction, platform.UsersResource, o.ID)
+		p, err := platform.NewPermission(platform.WriteAction, platform.UsersResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.readUserPermission {
-		p, err := platform.NewPermission(platform.ReadAction, platform.UsersResource, o.ID)
+		p, err := platform.NewPermission(platform.ReadAction, platform.UsersResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.writeBucketsPermission {
-		p, err := platform.NewPermission(platform.WriteAction, platform.BucketsResource, o.ID)
+		p, err := platform.NewPermission(platform.WriteAction, platform.BucketsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -125,7 +125,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.readBucketsPermission {
-		p, err := platform.NewPermission(platform.ReadAction, platform.BucketsResource, o.ID)
+		p, err := platform.NewPermission(platform.ReadAction, platform.BucketsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		p, err := platform.NewPermissionAtID(id, platform.WriteAction, platform.BucketsResource, o.ID)
+		p, err := platform.NewPermissionAtID(id, platform.WriteAction, platform.BucketsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		p, err := platform.NewPermissionAtID(id, platform.ReadAction, platform.BucketsResource, o.ID)
+		p, err := platform.NewPermissionAtID(id, platform.ReadAction, platform.BucketsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.writeTasksPermission {
-		p, err := platform.NewPermission(platform.WriteAction, platform.TasksResource, o.ID)
+		p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -168,7 +168,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.readTasksPermission {
-		p, err := platform.NewPermission(platform.ReadAction, platform.TasksResource, o.ID)
+		p, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -176,7 +176,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.writeTelegrafsPermission {
-		p, err := platform.NewPermission(platform.WriteAction, platform.TelegrafsResource, o.ID)
+		p, err := platform.NewPermission(platform.WriteAction, platform.TelegrafsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -184,7 +184,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.readTelegrafsPermission {
-		p, err := platform.NewPermission(platform.ReadAction, platform.TelegrafsResource, o.ID)
+		p, err := platform.NewPermission(platform.ReadAction, platform.TelegrafsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -192,7 +192,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.writeOrganizationsPermission {
-		p, err := platform.NewPermission(platform.WriteAction, platform.OrgsResource, o.ID)
+		p, err := platform.NewPermission(platform.WriteAction, platform.OrgsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.readOrganizationsPermission {
-		p, err := platform.NewPermission(platform.ReadAction, platform.OrgsResource, o.ID)
+		p, err := platform.NewPermission(platform.ReadAction, platform.OrgsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.writeDashboardsPermission {
-		p, err := platform.NewPermission(platform.WriteAction, platform.DashboardsResource, o.ID)
+		p, err := platform.NewPermission(platform.WriteAction, platform.DashboardsResourceType, o.ID)
 		if err != nil {
 			return err
 		}
@@ -216,7 +216,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if authorizationCreateFlags.readDashboardsPermission {
-		p, err := platform.NewPermission(platform.ReadAction, platform.DashboardsResource, o.ID)
+		p, err := platform.NewPermission(platform.ReadAction, platform.DashboardsResourceType, o.ID)
 		if err != nil {
 			return err
 		}

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -59,12 +59,12 @@ func NewBucketHandler(mappingService platform.UserResourceMappingService, labelS
 	h.HandlerFunc("PATCH", bucketsIDPath, h.handlePatchBucket)
 	h.HandlerFunc("DELETE", bucketsIDPath, h.handleDeleteBucket)
 
-	h.HandlerFunc("POST", bucketsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.BucketsResource, platform.Member))
-	h.HandlerFunc("GET", bucketsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.BucketsResource, platform.Member))
+	h.HandlerFunc("POST", bucketsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.BucketsResourceType, platform.Member))
+	h.HandlerFunc("GET", bucketsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.BucketsResourceType, platform.Member))
 	h.HandlerFunc("DELETE", bucketsIDMembersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Member))
 
-	h.HandlerFunc("POST", bucketsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.BucketsResource, platform.Owner))
-	h.HandlerFunc("GET", bucketsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.BucketsResource, platform.Owner))
+	h.HandlerFunc("POST", bucketsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.BucketsResourceType, platform.Owner))
+	h.HandlerFunc("GET", bucketsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.BucketsResourceType, platform.Owner))
 	h.HandlerFunc("DELETE", bucketsIDOwnersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Owner))
 
 	h.HandlerFunc("GET", bucketsIDLabelsPath, newGetLabelsHandler(h.LabelService))

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -71,12 +71,12 @@ func NewDashboardHandler(mappingService platform.UserResourceMappingService, lab
 	h.HandlerFunc("GET", dashboardsIDCellsIDViewPath, h.handleGetDashboardCellView)
 	h.HandlerFunc("PATCH", dashboardsIDCellsIDViewPath, h.handlePatchDashboardCellView)
 
-	h.HandlerFunc("POST", dashboardsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResource, platform.Member))
-	h.HandlerFunc("GET", dashboardsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResource, platform.Member))
+	h.HandlerFunc("POST", dashboardsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResourceType, platform.Member))
+	h.HandlerFunc("GET", dashboardsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResourceType, platform.Member))
 	h.HandlerFunc("DELETE", dashboardsIDMembersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Member))
 
-	h.HandlerFunc("POST", dashboardsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResource, platform.Owner))
-	h.HandlerFunc("GET", dashboardsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResource, platform.Owner))
+	h.HandlerFunc("POST", dashboardsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResourceType, platform.Owner))
+	h.HandlerFunc("GET", dashboardsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResourceType, platform.Owner))
 	h.HandlerFunc("DELETE", dashboardsIDOwnersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Owner))
 
 	h.HandlerFunc("GET", dashboardsIDLabelsPath, newGetLabelsHandler(h.LabelService))
@@ -241,9 +241,9 @@ func (h *DashboardHandler) handleGetDashboards(w http.ResponseWriter, r *http.Re
 
 	if req.ownerID != nil {
 		filter := platform.UserResourceMappingFilter{
-			UserID:   *req.ownerID,
-			UserType: platform.Owner,
-			Resource: platform.DashboardsResource,
+			UserID:       *req.ownerID,
+			UserType:     platform.Owner,
+			ResourceType: platform.DashboardsResourceType,
 		}
 
 		mappings, _, err := h.UserResourceMappingService.FindUserResourceMappings(ctx, filter)

--- a/http/onboarding.go
+++ b/http/onboarding.go
@@ -87,7 +87,10 @@ func newOnboardingResponse(results *platform.OnboardingResults) *onboardingRespo
 	ps := make([]permissionResponse, len(results.Auth.Permissions))
 	for i, p := range results.Auth.Permissions {
 		ps[i] = permissionResponse{
-			Permission: p,
+			Action: p.Action,
+			Resource: resourceResponse{
+				Resource: p.Resource,
+			},
 		}
 	}
 	return &onboardingResponse{

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -64,12 +64,12 @@ func NewOrgHandler(mappingService platform.UserResourceMappingService,
 	h.HandlerFunc("PATCH", organizationsIDPath, h.handlePatchOrg)
 	h.HandlerFunc("DELETE", organizationsIDPath, h.handleDeleteOrg)
 
-	h.HandlerFunc("POST", organizationsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.OrgsResource, platform.Member))
-	h.HandlerFunc("GET", organizationsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.OrgsResource, platform.Member))
+	h.HandlerFunc("POST", organizationsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.OrgsResourceType, platform.Member))
+	h.HandlerFunc("GET", organizationsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.OrgsResourceType, platform.Member))
 	h.HandlerFunc("DELETE", organizationsIDMembersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Member))
 
-	h.HandlerFunc("POST", organizationsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.OrgsResource, platform.Owner))
-	h.HandlerFunc("GET", organizationsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.OrgsResource, platform.Owner))
+	h.HandlerFunc("POST", organizationsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.OrgsResourceType, platform.Owner))
+	h.HandlerFunc("GET", organizationsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.OrgsResourceType, platform.Owner))
 	h.HandlerFunc("DELETE", organizationsIDOwnersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Owner))
 
 	h.HandlerFunc("GET", organizationsIDSecretsPath, h.handleGetSecrets)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4829,30 +4829,42 @@ components:
     Permission:
       required: [action, resource]
       properties:
-        id:
-          type: string
-          nullable: true
-          description: if id is set that is a permission for a specific resource. if it is not set it is a permission for all resources of that resource type.
-        name:
-          type: string
-          nullable: true
-          description: optional name of the resource if the resource has a name field.
         action:
           type: string
           enum:
             - read
             - write
         resource:
-          type: string
-          enum:
-            - authorizations
-            - buckets
-            - dashboards
-            - orgs
-            - sources
-            - tasks
-            - telegrafs
-            - users
+          type: object
+          required: [type]
+          properties:
+            type:
+              type: string
+              enum:
+                - authorizations
+                - buckets
+                - dashboards
+                - orgs
+                - sources
+                - tasks
+                - telegrafs
+                - users
+            id:
+              type: string
+              nullable: true
+              description: if id is set that is a permission for a specific resource. if it is not set it is a permission for all resources of that resource type.
+            name:
+              type: string
+              nullable: true
+              description: optional name of the resource if the resource has a name field.
+            orgID:
+              type: string
+              nullable: true
+              description: if orgID is set that is a permission for all resources owned my that org. if it is not set it is a permission for all resources of that resource type.
+            org:
+              type: string
+              nullable: true
+              description: optional name of the organization of the organization with orgID.
     Authorization:
       required: [orgID, permissions]
       properties:

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -71,12 +71,12 @@ func NewTaskHandler(mappingService platform.UserResourceMappingService, labelSer
 	h.HandlerFunc("GET", tasksIDLogsPath, h.handleGetLogs)
 	h.HandlerFunc("GET", tasksIDRunsIDLogsPath, h.handleGetLogs)
 
-	h.HandlerFunc("POST", tasksIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.TasksResource, platform.Member))
-	h.HandlerFunc("GET", tasksIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.TasksResource, platform.Member))
+	h.HandlerFunc("POST", tasksIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.TasksResourceType, platform.Member))
+	h.HandlerFunc("GET", tasksIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.TasksResourceType, platform.Member))
 	h.HandlerFunc("DELETE", tasksIDMembersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Member))
 
-	h.HandlerFunc("POST", tasksIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.TasksResource, platform.Owner))
-	h.HandlerFunc("GET", tasksIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.TasksResource, platform.Owner))
+	h.HandlerFunc("POST", tasksIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.TasksResourceType, platform.Owner))
+	h.HandlerFunc("GET", tasksIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.TasksResourceType, platform.Owner))
 	h.HandlerFunc("DELETE", tasksIDOwnersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Owner))
 
 	h.HandlerFunc("GET", tasksIDRunsPath, h.handleGetRuns)

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -63,12 +63,12 @@ func NewTelegrafHandler(
 	h.HandlerFunc("DELETE", telegrafsIDPath, h.handleDeleteTelegraf)
 	h.HandlerFunc("PUT", telegrafsIDPath, h.handlePutTelegraf)
 
-	h.HandlerFunc("POST", telegrafsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.TelegrafsResource, platform.Member))
-	h.HandlerFunc("GET", telegrafsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.TelegrafsResource, platform.Member))
+	h.HandlerFunc("POST", telegrafsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.TelegrafsResourceType, platform.Member))
+	h.HandlerFunc("GET", telegrafsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.TelegrafsResourceType, platform.Member))
 	h.HandlerFunc("DELETE", telegrafsIDMembersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Member))
 
-	h.HandlerFunc("POST", telegrafsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.TelegrafsResource, platform.Owner))
-	h.HandlerFunc("GET", telegrafsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.TelegrafsResource, platform.Owner))
+	h.HandlerFunc("POST", telegrafsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.TelegrafsResourceType, platform.Owner))
+	h.HandlerFunc("GET", telegrafsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.TelegrafsResourceType, platform.Owner))
 	h.HandlerFunc("DELETE", telegrafsIDOwnersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Owner))
 
 	h.HandlerFunc("GET", telegrafsIDLabelsPath, newGetLabelsHandler(h.LabelService))
@@ -221,9 +221,9 @@ func decodeTelegrafConfigFilter(ctx context.Context, r *http.Request) (*platform
 func decodeUserResourceMappingFilter(ctx context.Context, r *http.Request) (*platform.UserResourceMappingFilter, error) {
 	q := r.URL.Query()
 	f := &platform.UserResourceMappingFilter{
-		Resource: platform.TelegrafsResource,
+		ResourceType: platform.TelegrafsResourceType,
 	}
-	if idStr := q.Get("resourceId"); idStr != "" {
+	if idStr := q.Get("resourceID"); idStr != "" {
 		id, err := platform.IDFromString(idStr)
 		if err != nil {
 			return nil, err
@@ -231,7 +231,7 @@ func decodeUserResourceMappingFilter(ctx context.Context, r *http.Request) (*pla
 		f.ResourceID = *id
 	}
 
-	if idStr := q.Get("userId"); idStr != "" {
+	if idStr := q.Get("userID"); idStr != "" {
 		id, err := platform.IDFromString(idStr)
 		if err != nil {
 			return nil, err

--- a/http/user_resource_mapping_service.go
+++ b/http/user_resource_mapping_service.go
@@ -41,7 +41,7 @@ type resourceUsersResponse struct {
 func newResourceUsersResponse(opts platform.FindOptions, f platform.UserResourceMappingFilter, users []*platform.User) *resourceUsersResponse {
 	rs := resourceUsersResponse{
 		Links: map[string]string{
-			"self": fmt.Sprintf("/api/v2/%ss/%s/%ss", f.Resource, f.ResourceID, f.UserType),
+			"self": fmt.Sprintf("/api/v2/%ss/%s/%ss", f.ResourceType, f.ResourceID, f.UserType),
 		},
 		Users: make([]*resourceUserResponse, 0, len(users)),
 	}
@@ -53,7 +53,7 @@ func newResourceUsersResponse(opts platform.FindOptions, f platform.UserResource
 }
 
 // newPostMemberHandler returns a handler func for a POST to /members or /owners endpoints
-func newPostMemberHandler(s platform.UserResourceMappingService, userService platform.UserService, resourceType platform.Resource, userType platform.UserType) http.HandlerFunc {
+func newPostMemberHandler(s platform.UserResourceMappingService, userService platform.UserService, resourceType platform.ResourceType, userType platform.UserType) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -70,10 +70,10 @@ func newPostMemberHandler(s platform.UserResourceMappingService, userService pla
 		}
 
 		mapping := &platform.UserResourceMapping{
-			ResourceID: req.ResourceID,
-			Resource:   resourceType,
-			UserID:     req.MemberID,
-			UserType:   userType,
+			ResourceID:   req.ResourceID,
+			ResourceType: resourceType,
+			UserID:       req.MemberID,
+			UserType:     userType,
 		}
 
 		if err := s.CreateUserResourceMapping(ctx, mapping); err != nil {
@@ -121,7 +121,7 @@ func decodePostMemberRequest(ctx context.Context, r *http.Request) (*postMemberR
 }
 
 // newGetMembersHandler returns a handler func for a GET to /members or /owners endpoints
-func newGetMembersHandler(s platform.UserResourceMappingService, userService platform.UserService, resourceType platform.Resource, userType platform.UserType) http.HandlerFunc {
+func newGetMembersHandler(s platform.UserResourceMappingService, userService platform.UserService, resourceType platform.ResourceType, userType platform.UserType) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -132,9 +132,9 @@ func newGetMembersHandler(s platform.UserResourceMappingService, userService pla
 		}
 
 		filter := platform.UserResourceMappingFilter{
-			ResourceID: req.ResourceID,
-			Resource:   resourceType,
-			UserType:   userType,
+			ResourceID:   req.ResourceID,
+			ResourceType: resourceType,
+			UserType:     userType,
 		}
 
 		opts := platform.FindOptions{}

--- a/http/user_resource_mapping_test.go
+++ b/http/user_resource_mapping_test.go
@@ -48,16 +48,16 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 					FindMappingsFn: func(ctx context.Context, filter platform.UserResourceMappingFilter) ([]*platform.UserResourceMapping, int, error) {
 						ms := []*platform.UserResourceMapping{
 							{
-								ResourceID: filter.ResourceID,
-								Resource:   filter.Resource,
-								UserType:   filter.UserType,
-								UserID:     1,
+								ResourceID:   filter.ResourceID,
+								ResourceType: filter.ResourceType,
+								UserType:     filter.UserType,
+								UserID:       1,
 							},
 							{
-								ResourceID: filter.ResourceID,
-								Resource:   filter.Resource,
-								UserType:   filter.UserType,
-								UserID:     2,
+								ResourceID:   filter.ResourceID,
+								ResourceType: filter.ResourceType,
+								UserType:     filter.UserType,
+								UserID:       2,
 							},
 						}
 						return ms, len(ms), nil
@@ -112,16 +112,16 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 					FindMappingsFn: func(ctx context.Context, filter platform.UserResourceMappingFilter) ([]*platform.UserResourceMapping, int, error) {
 						ms := []*platform.UserResourceMapping{
 							{
-								ResourceID: filter.ResourceID,
-								Resource:   filter.Resource,
-								UserType:   filter.UserType,
-								UserID:     1,
+								ResourceID:   filter.ResourceID,
+								ResourceType: filter.ResourceType,
+								UserType:     filter.UserType,
+								UserID:       1,
 							},
 							{
-								ResourceID: filter.ResourceID,
-								Resource:   filter.Resource,
-								UserType:   filter.UserType,
-								UserID:     2,
+								ResourceID:   filter.ResourceID,
+								ResourceType: filter.ResourceType,
+								UserType:     filter.UserType,
+								UserID:       2,
 							},
 						}
 						return ms, len(ms), nil
@@ -166,14 +166,14 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		resourceTypes := []platform.Resource{
-			platform.BucketsResource,
-			platform.DashboardsResource,
-			platform.OrgsResource,
-			platform.SourcesResource,
-			platform.TasksResource,
-			platform.TelegrafsResource,
-			platform.UsersResource,
+		resourceTypes := []platform.ResourceType{
+			platform.BucketsResourceType,
+			platform.DashboardsResourceType,
+			platform.OrgsResourceType,
+			platform.SourcesResourceType,
+			platform.TasksResourceType,
+			platform.TelegrafsResourceType,
+			platform.UsersResourceType,
 		}
 
 		for _, resourceType := range resourceTypes {
@@ -311,14 +311,14 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		resourceTypes := []platform.Resource{
-			platform.BucketsResource,
-			platform.DashboardsResource,
-			platform.OrgsResource,
-			platform.SourcesResource,
-			platform.TasksResource,
-			platform.TelegrafsResource,
-			platform.UsersResource,
+		resourceTypes := []platform.ResourceType{
+			platform.BucketsResourceType,
+			platform.DashboardsResourceType,
+			platform.OrgsResourceType,
+			platform.SourcesResourceType,
+			platform.TasksResourceType,
+			platform.TelegrafsResourceType,
+			platform.UsersResourceType,
 		}
 
 		for _, resourceType := range resourceTypes {

--- a/http/view_service.go
+++ b/http/view_service.go
@@ -55,12 +55,12 @@ func NewViewHandler(mappingService platform.UserResourceMappingService, labelSer
 	h.HandlerFunc("DELETE", viewsIDPath, h.handleDeleteView)
 	h.HandlerFunc("PATCH", viewsIDPath, h.handlePatchView)
 
-	h.HandlerFunc("POST", viewsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResource, platform.Member))
-	h.HandlerFunc("GET", viewsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResource, platform.Member))
+	h.HandlerFunc("POST", viewsIDMembersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResourceType, platform.Member))
+	h.HandlerFunc("GET", viewsIDMembersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResourceType, platform.Member))
 	h.HandlerFunc("DELETE", viewsIDMembersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Member))
 
-	h.HandlerFunc("POST", viewsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResource, platform.Owner))
-	h.HandlerFunc("GET", viewsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResource, platform.Owner))
+	h.HandlerFunc("POST", viewsIDOwnersPath, newPostMemberHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResourceType, platform.Owner))
+	h.HandlerFunc("GET", viewsIDOwnersPath, newGetMembersHandler(h.UserResourceMappingService, h.UserService, platform.DashboardsResourceType, platform.Owner))
 	h.HandlerFunc("DELETE", viewsIDOwnersIDPath, newDeleteMemberHandler(h.UserResourceMappingService, platform.Owner))
 
 	h.HandlerFunc("GET", viewsIDLabelsPath, newGetLabelsHandler(h.LabelService))

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -138,7 +138,7 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 		bucket = b
 	}
 
-	p, err := platform.NewPermissionAtID(bucket.ID, platform.WriteAction, platform.BucketsResource, org.ID)
+	p, err := platform.NewPermissionAtID(bucket.ID, platform.WriteAction, platform.BucketsResourceType, org.ID)
 	if err != nil {
 		EncodeError(ctx, fmt.Errorf("could not create permission for bucket: %v", err), w)
 		return

--- a/inmem/lookup_service.go
+++ b/inmem/lookup_service.go
@@ -9,7 +9,7 @@ import (
 var _ platform.LookupService = (*Service)(nil)
 
 // Name returns the name for the resource and ID.
-func (s *Service) Name(ctx context.Context, resource platform.Resource, id platform.ID) (string, error) {
+func (s *Service) Name(ctx context.Context, resource platform.ResourceType, id platform.ID) (string, error) {
 	if err := resource.Valid(); err != nil {
 		return "", err
 	}
@@ -19,34 +19,34 @@ func (s *Service) Name(ctx context.Context, resource platform.Resource, id platf
 	}
 
 	switch resource {
-	case platform.TasksResource: // 5 // TODO(goller): unify task bolt storage here so we can lookup names
-	case platform.AuthorizationsResource: // 0 TODO(goller): authorizations should also have optional names
-	case platform.SourcesResource: // 4 TODO(goller): no inmen version of sources service: https://github.com/influxdata/platform/issues/2145
-	case platform.BucketsResource: // 1
+	case platform.TasksResourceType: // 5 // TODO(goller): unify task bolt storage here so we can lookup names
+	case platform.AuthorizationsResourceType: // 0 TODO(goller): authorizations should also have optional names
+	case platform.SourcesResourceType: // 4 TODO(goller): no inmen version of sources service: https://github.com/influxdata/platform/issues/2145
+	case platform.BucketsResourceType: // 1
 		r, err := s.FindBucketByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.DashboardsResource: // 2
+	case platform.DashboardsResourceType: // 2
 		r, err := s.FindDashboardByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.OrgsResource: // 3
+	case platform.OrgsResourceType: // 3
 		r, err := s.FindOrganizationByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.TelegrafsResource: // 6
+	case platform.TelegrafsResourceType: // 6
 		r, err := s.FindTelegrafConfigByID(ctx, id)
 		if err != nil {
 			return "", err
 		}
 		return r.Name, nil
-	case platform.UsersResource: // 7
+	case platform.UsersResourceType: // 7
 		r, err := s.FindUserByID(ctx, id)
 		if err != nil {
 			return "", err

--- a/inmem/lookup_service_test.go
+++ b/inmem/lookup_service_test.go
@@ -18,7 +18,6 @@ func TestService_Name(t *testing.T) {
 	type initFn func(ctx context.Context, s *Service) error
 	type args struct {
 		resource platform.Resource
-		id       platform.ID
 		init     initFn
 	}
 	tests := []struct {
@@ -30,47 +29,49 @@ func TestService_Name(t *testing.T) {
 		{
 			name: "error if id is invalid",
 			args: args{
-				resource: platform.DashboardsResource,
-				id:       platform.InvalidID(),
+				resource: platform.Resource{
+					Type: platform.DashboardsResourceType,
+					ID:   platformtesting.IDPtr(platform.InvalidID()),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "error if resource is invalid",
 			args: args{
-				resource: platform.Resource("invalid"),
+				resource: platform.Resource{
+					Type: platform.ResourceType("invalid"),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "authorization resource without a name returns empty string",
 			args: args{
-				resource: platform.AuthorizationsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.AuthorizationsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			want: "",
 		},
 		{
-			name: "task resource without a name returns empty string",
+			name: "task resource without a name returns an empty string",
 			args: args{
-				resource: platform.TasksResource,
-				id:       testID,
-			},
-			want: "",
-		},
-		{
-			name: "sources resource without a name returns empty string",
-			args: args{
-				resource: platform.SourcesResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.TasksResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			want: "",
 		},
 		{
 			name: "bucket with existing id returns name",
 			args: args{
-				resource: platform.BucketsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.BucketsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *Service) error {
 					_ = s.CreateOrganization(ctx, &platform.Organization{
 						Name: "o1",
@@ -86,16 +87,20 @@ func TestService_Name(t *testing.T) {
 		{
 			name: "bucket with non-existent id returns error",
 			args: args{
-				resource: platform.BucketsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.BucketsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "dashboard with existing id returns name",
 			args: args{
-				resource: platform.DashboardsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.DashboardsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *Service) error {
 					return s.CreateDashboard(ctx, &platform.Dashboard{
 						Name: "dashboard1",
@@ -107,16 +112,20 @@ func TestService_Name(t *testing.T) {
 		{
 			name: "dashboard with non-existent id returns error",
 			args: args{
-				resource: platform.DashboardsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.DashboardsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "org with existing id returns name",
 			args: args{
-				resource: platform.OrgsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.OrgsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *Service) error {
 					return s.CreateOrganization(ctx, &platform.Organization{
 						Name: "org1",
@@ -128,17 +137,20 @@ func TestService_Name(t *testing.T) {
 		{
 			name: "org with non-existent id returns error",
 			args: args{
-				resource: platform.OrgsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.OrgsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
-
 		{
 			name: "telegraf with existing id returns name",
 			args: args{
-				resource: platform.TelegrafsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.TelegrafsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *Service) error {
 					return s.CreateTelegrafConfig(ctx, &platform.TelegrafConfig{
 						OrganizationID: platformtesting.MustIDBase16("0000000000000009"),
@@ -151,16 +163,20 @@ func TestService_Name(t *testing.T) {
 		{
 			name: "telegraf with non-existent id returns error",
 			args: args{
-				resource: platform.TelegrafsResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.TelegrafsResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
 		{
 			name: "user with existing id returns name",
 			args: args{
-				resource: platform.UsersResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.UsersResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 				init: func(ctx context.Context, s *Service) error {
 					return s.CreateUser(ctx, &platform.User{
 						Name: "user1",
@@ -172,8 +188,10 @@ func TestService_Name(t *testing.T) {
 		{
 			name: "user with non-existent id returns error",
 			args: args{
-				resource: platform.UsersResource,
-				id:       testID,
+				resource: platform.Resource{
+					Type: platform.UsersResourceType,
+					ID:   platformtesting.IDPtr(testID),
+				},
 			},
 			wantErr: true,
 		},
@@ -188,7 +206,11 @@ func TestService_Name(t *testing.T) {
 					t.Errorf("Service.Name() unable to initialize service: %v", err)
 				}
 			}
-			got, err := s.Name(ctx, tt.args.resource, tt.args.id)
+			id := platform.InvalidID()
+			if tt.args.resource.ID != nil {
+				id = *tt.args.resource.ID
+			}
+			got, err := s.Name(ctx, tt.args.resource.Type, id)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Service.Name() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/inmem/telegraf.go
+++ b/inmem/telegraf.go
@@ -128,10 +128,10 @@ func (s *Service) CreateTelegrafConfig(ctx context.Context, tc *platform.Telegra
 	}
 
 	urm := &platform.UserResourceMapping{
-		ResourceID: tc.ID,
-		UserID:     userID,
-		UserType:   platform.Owner,
-		Resource:   platform.TelegrafsResource,
+		ResourceID:   tc.ID,
+		UserID:       userID,
+		UserType:     platform.Owner,
+		ResourceType: platform.TelegrafsResourceType,
 	}
 	if err := s.CreateUserResourceMapping(ctx, urm); err != nil {
 		return err
@@ -180,8 +180,8 @@ func (s *Service) DeleteTelegrafConfig(ctx context.Context, id platform.ID) erro
 	s.telegrafConfigKV.Delete(id)
 
 	err = s.deleteUserResourceMapping(ctx, platform.UserResourceMappingFilter{
-		ResourceID: id,
-		Resource:   platform.TelegrafsResource,
+		ResourceID:   id,
+		ResourceType: platform.TelegrafsResourceType,
 	})
 
 	if err != nil {

--- a/inmem/user_resource_mapping_service.go
+++ b/inmem/user_resource_mapping_service.go
@@ -73,7 +73,7 @@ func (s *Service) FindUserResourceMappings(ctx context.Context, filter platform.
 		return (!filter.UserID.Valid() || (filter.UserID == mapping.UserID)) &&
 			(!filter.ResourceID.Valid() || (filter.ResourceID == mapping.ResourceID)) &&
 			(filter.UserType == "" || (filter.UserType == mapping.UserType)) &&
-			(filter.Resource == "" || (filter.Resource == mapping.Resource))
+			(filter.ResourceType == "" || (filter.ResourceType == mapping.ResourceType))
 	}
 
 	mappings, err := s.filterUserResourceMappings(ctx, filterFunc)

--- a/lookup.go
+++ b/lookup.go
@@ -7,5 +7,5 @@ import (
 // LookupService provides field lookup for the resource and ID.
 type LookupService interface {
 	// Name returns the name for the resource and ID.
-	Name(ctx context.Context, resource Resource, id ID) (string, error)
+	Name(ctx context.Context, resource ResourceType, id ID) (string, error)
 }

--- a/mock/lookup_service.go
+++ b/mock/lookup_service.go
@@ -8,10 +8,10 @@ import (
 
 // LookupService provides field lookup for the resource and ID.
 type LookupService struct {
-	NameFn func(ctx context.Context, resource platform.Resource, id platform.ID) (string, error)
+	NameFn func(ctx context.Context, resource platform.ResourceType, id platform.ID) (string, error)
 }
 
 // Name returns the name for the resource and ID.
-func (s *LookupService) Name(ctx context.Context, resource platform.Resource, id platform.ID) (string, error) {
+func (s *LookupService) Name(ctx context.Context, resource platform.ResourceType, id platform.ID) (string, error) {
 	return s.NameFn(ctx, resource, id)
 }

--- a/query/preauthorizer.go
+++ b/query/preauthorizer.go
@@ -44,7 +44,7 @@ func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth 
 			return errors.New("bucket service returned nil bucket")
 		}
 
-		reqPerm, err := platform.NewPermissionAtID(bucket.ID, platform.ReadAction, platform.BucketsResource, bucket.OrganizationID)
+		reqPerm, err := platform.NewPermissionAtID(bucket.ID, platform.ReadAction, platform.BucketsResourceType, bucket.OrganizationID)
 		if err != nil {
 			return errors.Wrapf(err, "could not create read bucket permission")
 		}
@@ -60,7 +60,7 @@ func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth 
 			return errors.Wrapf(err, "could not find bucket %v", writeBucketFilter)
 		}
 
-		reqPerm, err := platform.NewPermissionAtID(bucket.ID, platform.WriteAction, platform.BucketsResource, bucket.OrganizationID)
+		reqPerm, err := platform.NewPermissionAtID(bucket.ID, platform.WriteAction, platform.BucketsResourceType, bucket.OrganizationID)
 		if err != nil {
 			return errors.Wrapf(err, "could not create write bucket permission")
 		}

--- a/query/preauthorizer_test.go
+++ b/query/preauthorizer_test.go
@@ -66,7 +66,7 @@ func TestPreAuthorizer_PreAuthorize(t *testing.T) {
 	}
 
 	orgID := platform.ID(1)
-	p, err := platform.NewPermissionAtID(*id, platform.ReadAction, platform.BucketsResource, orgID)
+	p, err := platform.NewPermissionAtID(*id, platform.ReadAction, platform.BucketsResourceType, orgID)
 	if err != nil {
 		t.Fatalf("Error creating read bucket permission query: %v", err)
 	}

--- a/task/validator.go
+++ b/task/validator.go
@@ -41,7 +41,7 @@ func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id platform.ID
 		return nil, err
 	}
 
-	perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResource, task.Organization)
+	perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, task.Organization)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id platform.ID
 
 func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
 	if filter.Organization != nil {
-		perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResource, *filter.Organization)
+		perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, *filter.Organization)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -71,7 +71,7 @@ func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter platform.T
 }
 
 func (ts *taskServiceValidator) CreateTask(ctx context.Context, t *platform.Task) error {
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResource, t.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, t.Organization)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id platform.ID, 
 		return nil, err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResource, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (ts *taskServiceValidator) DeleteTask(ctx context.Context, id platform.ID) 
 		return err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResource, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (ts *taskServiceValidator) DeleteTask(ctx context.Context, id platform.ID) 
 
 func (ts *taskServiceValidator) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
 	if filter.Org != nil {
-		perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResource, *filter.Org)
+		perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, *filter.Org)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -146,7 +146,7 @@ func (ts *taskServiceValidator) FindLogs(ctx context.Context, filter platform.Lo
 
 func (ts *taskServiceValidator) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
 	if filter.Org != nil {
-		perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResource, *filter.Org)
+		perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, *filter.Org)
 		if err != nil {
 			return nil, -1, err
 		}
@@ -167,7 +167,7 @@ func (ts *taskServiceValidator) FindRunByID(ctx context.Context, taskID, runID p
 		return nil, err
 	}
 
-	p, err := platform.NewPermission(platform.ReadAction, platform.TasksResource, task.Organization)
+	p, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, task.Organization)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (ts *taskServiceValidator) CancelRun(ctx context.Context, taskID, runID pla
 		return err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResource, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (ts *taskServiceValidator) RetryRun(ctx context.Context, taskID, runID plat
 		return nil, err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResource, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (ts *taskServiceValidator) ForceRun(ctx context.Context, taskID platform.ID
 		return nil, err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResource, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
 	if err != nil {
 		return nil, err
 	}

--- a/task/validator_test.go
+++ b/task/validator_test.go
@@ -205,7 +205,7 @@ from(bucket:"bad") |> range(start:-5m) |> to(bucket:"bad", org:"thing")`,
 		},
 		{
 			name: "FindTaskByID with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, err := svc.FindTaskByID(ctx, taskID)
 				return err
@@ -213,7 +213,7 @@ from(bucket:"bad") |> range(start:-5m) |> to(bucket:"bad", org:"thing")`,
 		},
 		{
 			name: "FindTasks with bad auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.OrgsResource, OrgID: taskID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &taskID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindTasks(ctx, influxdb.TaskFilter{
 					Organization: &orgID,
@@ -226,7 +226,7 @@ from(bucket:"bad") |> range(start:-5m) |> to(bucket:"bad", org:"thing")`,
 		},
 		{
 			name: "FindTasks with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindTasks(ctx, influxdb.TaskFilter{
 					Organization: &orgID,
@@ -236,7 +236,7 @@ from(bucket:"bad") |> range(start:-5m) |> to(bucket:"bad", org:"thing")`,
 		},
 		{
 			name: "FindTasks without org",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindTasks(ctx, influxdb.TaskFilter{})
 				return err
@@ -244,7 +244,7 @@ from(bucket:"bad") |> range(start:-5m) |> to(bucket:"bad", org:"thing")`,
 		},
 		{
 			name: "UpdateTask with bad auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				flux := `option task = {
  name: "my_task",
@@ -263,9 +263,9 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`
 		{
 			name: "UpdateTask with auth",
 			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{
-				influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.TasksResource, OrgID: orgID},
-				influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.BucketsResource, OrgID: r.Org.ID, ID: &r.Bucket.ID},
-				influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.BucketsResource, OrgID: r.Org.ID, ID: &r.Bucket.ID},
+				influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}},
+				influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.Resource{Type: influxdb.BucketsResourceType, OrgID: &orgID, ID: &r.Bucket.ID}},
+				influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.BucketsResourceType, OrgID: &orgID, ID: &r.Bucket.ID}},
 			}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				flux := `option task = {
@@ -281,7 +281,7 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`
 		},
 		{
 			name: "UpdateTask with bad bucket",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				flux := `option task = {
  name: "my_task",
@@ -310,7 +310,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "DeleteTask readonly auth",
-			auth: &influxdb.Authorization{Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				err := svc.DeleteTask(ctx, taskID)
 				if err == nil {
@@ -321,7 +321,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "DeleteTask with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				err := svc.DeleteTask(ctx, taskID)
 				return err
@@ -329,7 +329,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "FindLogs with bad auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.OrgsResource, OrgID: taskID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.OrgsResourceType, OrgID: &taskID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindLogs(ctx, influxdb.LogFilter{
 					Org: &orgID,
@@ -342,7 +342,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "FindLogs with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindLogs(ctx, influxdb.LogFilter{
 					Org: &orgID,
@@ -360,7 +360,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "FindRuns with bad auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.OrgsResource, OrgID: taskID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.OrgsResourceType, OrgID: &taskID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindRuns(ctx, influxdb.RunFilter{
 					Org: &orgID,
@@ -373,7 +373,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "FindRuns with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindRuns(ctx, influxdb.RunFilter{
 					Org: &orgID,
@@ -402,7 +402,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "FindRunByID with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, err := svc.FindRunByID(ctx, taskID, 10)
 				return err
@@ -410,7 +410,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "CancelRun with bad auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.OrgsResource, OrgID: taskID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.OrgsResourceType, OrgID: &taskID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				err := svc.CancelRun(ctx, 2, 10)
 				if err == nil {
@@ -421,7 +421,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "CancelRun with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				err := svc.CancelRun(ctx, 2, 10)
 				return err
@@ -429,7 +429,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "RetryRun with bad auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.OrgsResource, OrgID: taskID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.OrgsResourceType, OrgID: &taskID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, err := svc.RetryRun(ctx, 2, 10)
 				if err == nil {
@@ -440,7 +440,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "RetryRun with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, err := svc.RetryRun(ctx, 2, 10)
 				return err
@@ -448,7 +448,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "ForceRun with bad auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.OrgsResource, OrgID: taskID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.OrgsResourceType, OrgID: &taskID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, err := svc.ForceRun(ctx, 2, 10000)
 				if err == nil {
@@ -459,7 +459,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 		},
 		{
 			name: "ForceRun with auth",
-			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.TasksResource, OrgID: orgID}}},
+			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.WriteAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, err := svc.ForceRun(ctx, 2, 10000)
 				return err

--- a/testing/auth.go
+++ b/testing/auth.go
@@ -1193,19 +1193,19 @@ func DeleteAuthorization(
 
 func allUsersPermission(orgID platform.ID) []platform.Permission {
 	return []platform.Permission{
-		{Action: platform.WriteAction, Resource: platform.UsersResource, OrgID: orgID},
-		{Action: platform.ReadAction, Resource: platform.UsersResource, OrgID: orgID},
+		{Action: platform.WriteAction, Resource: platform.Resource{Type: platform.UsersResourceType, OrgID: &orgID}},
+		{Action: platform.ReadAction, Resource: platform.Resource{Type: platform.UsersResourceType, OrgID: &orgID}},
 	}
 }
 
 func createUsersPermission(orgID platform.ID) []platform.Permission {
 	return []platform.Permission{
-		{Action: platform.WriteAction, Resource: platform.UsersResource, OrgID: orgID},
+		{Action: platform.WriteAction, Resource: platform.Resource{Type: platform.UsersResourceType, OrgID: &orgID}},
 	}
 }
 
 func deleteUsersPermission(orgID platform.ID) []platform.Permission {
 	return []platform.Permission{
-		{Action: platform.WriteAction, Resource: platform.UsersResource, OrgID: orgID},
+		{Action: platform.WriteAction, Resource: platform.Resource{Type: platform.UsersResourceType, OrgID: &orgID}},
 	}
 }

--- a/testing/id.go
+++ b/testing/id.go
@@ -1,0 +1,6 @@
+package testing
+
+import "github.com/influxdata/influxdb"
+
+// IDPtr returns a pointer to an influxdb.ID.
+func IDPtr(id influxdb.ID) *influxdb.ID { return &id }

--- a/testing/telegraf.go
+++ b/testing/telegraf.go
@@ -167,10 +167,10 @@ func CreateTelegrafConfig(
 			wants: wants{
 				userResourceMapping: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 				},
 				telegrafs: []*platform.TelegrafConfig{
@@ -222,10 +222,10 @@ func CreateTelegrafConfig(
 				},
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 				},
 			},
@@ -296,16 +296,16 @@ func CreateTelegrafConfig(
 				},
 				userResourceMapping: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 				},
 			},
@@ -333,8 +333,8 @@ func CreateTelegrafConfig(
 
 			filter := platform.TelegrafConfigFilter{
 				UserResourceMappingFilter: platform.UserResourceMappingFilter{
-					UserID:   MustIDBase16(threeID),
-					Resource: platform.TelegrafsResource,
+					UserID:       MustIDBase16(threeID),
+					ResourceType: platform.TelegrafsResourceType,
 				},
 			}
 			tcs, _, err := s.FindTelegrafConfigs(ctx, filter)
@@ -346,8 +346,8 @@ func CreateTelegrafConfig(
 			}
 
 			urms, _, err := s.FindUserResourceMappings(ctx, platform.UserResourceMappingFilter{
-				UserID:   tt.args.userID,
-				Resource: platform.TelegrafsResource,
+				UserID:       tt.args.userID,
+				ResourceType: platform.TelegrafsResourceType,
 			})
 			if err != nil {
 				t.Fatalf("failed to retrieve user resource mappings: %v", err)
@@ -568,16 +568,16 @@ func FindTelegrafConfig(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -613,9 +613,9 @@ func FindTelegrafConfig(
 			args: args{
 				filter: platform.TelegrafConfigFilter{
 					UserResourceMappingFilter: platform.UserResourceMappingFilter{
-						UserID:   MustIDBase16(threeID),
-						Resource: platform.TelegrafsResource,
-						UserType: platform.Member,
+						UserID:       MustIDBase16(threeID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserType:     platform.Member,
 					},
 				},
 			},
@@ -644,16 +644,16 @@ func FindTelegrafConfig(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -689,8 +689,8 @@ func FindTelegrafConfig(
 			args: args{
 				filter: platform.TelegrafConfigFilter{
 					UserResourceMappingFilter: platform.UserResourceMappingFilter{
-						UserID:   MustIDBase16(fourID),
-						Resource: platform.TelegrafsResource,
+						UserID:       MustIDBase16(fourID),
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 			},
@@ -752,7 +752,7 @@ func FindTelegrafConfigs(
 			args: args{
 				filter: platform.TelegrafConfigFilter{
 					UserResourceMappingFilter: platform.UserResourceMappingFilter{
-						Resource: platform.TelegrafsResource,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 			},
@@ -765,16 +765,16 @@ func FindTelegrafConfigs(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -810,8 +810,8 @@ func FindTelegrafConfigs(
 			args: args{
 				filter: platform.TelegrafConfigFilter{
 					UserResourceMappingFilter: platform.UserResourceMappingFilter{
-						UserID:   MustIDBase16(threeID),
-						Resource: platform.TelegrafsResource,
+						UserID:       MustIDBase16(threeID),
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 			},
@@ -852,16 +852,16 @@ func FindTelegrafConfigs(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -897,9 +897,9 @@ func FindTelegrafConfigs(
 			args: args{
 				filter: platform.TelegrafConfigFilter{
 					UserResourceMappingFilter: platform.UserResourceMappingFilter{
-						UserID:   MustIDBase16(threeID),
-						Resource: platform.TelegrafsResource,
-						UserType: platform.Owner,
+						UserID:       MustIDBase16(threeID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserType:     platform.Owner,
 					},
 				},
 			},
@@ -923,22 +923,22 @@ func FindTelegrafConfigs(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 					{
-						ResourceID: MustIDBase16(fourID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(fourID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -1006,22 +1006,22 @@ func FindTelegrafConfigs(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 					{
-						ResourceID: MustIDBase16(fourID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(fourID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -1068,9 +1068,9 @@ func FindTelegrafConfigs(
 				filter: platform.TelegrafConfigFilter{
 					OrganizationID: idPtr(MustIDBase16(oneID)),
 					UserResourceMappingFilter: platform.UserResourceMappingFilter{
-						UserID:   MustIDBase16(threeID),
-						Resource: platform.TelegrafsResource,
-						UserType: platform.Owner,
+						UserID:       MustIDBase16(threeID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserType:     platform.Owner,
 					},
 				},
 			},
@@ -1094,16 +1094,16 @@ func FindTelegrafConfigs(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -1150,16 +1150,16 @@ func FindTelegrafConfigs(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						Resource:   platform.TelegrafsResource,
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.TelegrafsResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -1195,8 +1195,8 @@ func FindTelegrafConfigs(
 			args: args{
 				filter: platform.TelegrafConfigFilter{
 					UserResourceMappingFilter: platform.UserResourceMappingFilter{
-						UserID:   MustIDBase16(fourID),
-						Resource: platform.TelegrafsResource,
+						UserID:       MustIDBase16(fourID),
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 			},
@@ -1527,16 +1527,16 @@ func DeleteTelegrafConfig(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -1580,16 +1580,16 @@ func DeleteTelegrafConfig(
 				},
 				userResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 				telegrafConfigs: []*platform.TelegrafConfig{
@@ -1628,16 +1628,16 @@ func DeleteTelegrafConfig(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -1680,16 +1680,16 @@ func DeleteTelegrafConfig(
 				},
 				userResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 				telegrafConfigs: []*platform.TelegrafConfig{
@@ -1728,16 +1728,16 @@ func DeleteTelegrafConfig(
 			fields: TelegrafConfigFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(twoID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Member,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
@@ -1777,10 +1777,10 @@ func DeleteTelegrafConfig(
 			wants: wants{
 				userResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(oneID),
-						UserID:     MustIDBase16(threeID),
-						UserType:   platform.Owner,
-						Resource:   platform.TelegrafsResource,
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.TelegrafsResourceType,
 					},
 				},
 				telegrafConfigs: []*platform.TelegrafConfig{
@@ -1815,8 +1815,8 @@ func DeleteTelegrafConfig(
 			}
 			filter := platform.TelegrafConfigFilter{
 				UserResourceMappingFilter: platform.UserResourceMappingFilter{
-					UserID:   tt.args.userID,
-					Resource: platform.TelegrafsResource,
+					UserID:       tt.args.userID,
+					ResourceType: platform.TelegrafsResourceType,
 				},
 			}
 			tcs, n, err := s.FindTelegrafConfigs(ctx, filter)
@@ -1837,8 +1837,8 @@ func DeleteTelegrafConfig(
 			}
 
 			urms, _, err := s.FindUserResourceMappings(ctx, platform.UserResourceMappingFilter{
-				UserID:   tt.args.userID,
-				Resource: platform.TelegrafsResource,
+				UserID:       tt.args.userID,
+				ResourceType: platform.TelegrafsResourceType,
 			})
 			if err != nil {
 				t.Fatalf("failed to retrieve user resource mappings: %v", err)

--- a/testing/user_resource_mapping_service.go
+++ b/testing/user_resource_mapping_service.go
@@ -86,34 +86,34 @@ func CreateUserResourceMapping(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
 			args: args{
 				mapping: &platform.UserResourceMapping{
-					ResourceID: MustIDBase16(bucketTwoID),
-					UserID:     MustIDBase16(userTwoID),
-					UserType:   platform.Member,
-					Resource:   platform.BucketsResource,
+					ResourceID:   MustIDBase16(bucketTwoID),
+					UserID:       MustIDBase16(userTwoID),
+					UserType:     platform.Member,
+					ResourceType: platform.BucketsResourceType,
 				},
 			},
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -281,16 +281,16 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -300,16 +300,16 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -319,16 +319,16 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -340,10 +340,10 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -353,16 +353,16 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -374,10 +374,10 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -387,16 +387,16 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Owner,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Owner,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -408,10 +408,10 @@ func FindUserResourceMappings(
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Owner,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Owner,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
@@ -421,31 +421,31 @@ func FindUserResourceMappings(
 			fields: UserResourceFields{
 				UserResourceMappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketOneID),
-						UserID:     MustIDBase16(userOneID),
-						UserType:   platform.Member,
-						Resource:   platform.DashboardsResource,
+						ResourceID:   MustIDBase16(bucketOneID),
+						UserID:       MustIDBase16(userOneID),
+						UserType:     platform.Member,
+						ResourceType: platform.DashboardsResourceType,
 					},
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},
 			args: args{
 				filter: platform.UserResourceMappingFilter{
-					Resource: platform.BucketsResource,
+					ResourceType: platform.BucketsResourceType,
 				},
 			},
 			wants: wants{
 				mappings: []*platform.UserResourceMapping{
 					{
-						ResourceID: MustIDBase16(bucketTwoID),
-						UserID:     MustIDBase16(userTwoID),
-						UserType:   platform.Member,
-						Resource:   platform.BucketsResource,
+						ResourceID:   MustIDBase16(bucketTwoID),
+						UserID:       MustIDBase16(userTwoID),
+						UserType:     platform.Member,
+						ResourceType: platform.BucketsResourceType,
 					},
 				},
 			},

--- a/user_resource_mapping.go
+++ b/user_resource_mapping.go
@@ -50,10 +50,10 @@ type UserResourceMappingService interface {
 
 // UserResourceMapping represents a mapping of a resource to its user.
 type UserResourceMapping struct {
-	UserID     ID       `json:"userID"`
-	UserType   UserType `json:"userType"`
-	Resource   Resource `json:"resource"`
-	ResourceID ID       `json:"resourceID"`
+	UserID       ID           `json:"userID"`
+	UserType     UserType     `json:"userType"`
+	ResourceType ResourceType `json:"resourceType"`
+	ResourceID   ID           `json:"resourceID"`
 }
 
 // Validate reports any validation errors for the mapping.
@@ -70,7 +70,7 @@ func (m UserResourceMapping) Validate() error {
 		return err
 	}
 
-	if err := m.Resource.Valid(); err != nil {
+	if err := m.ResourceType.Valid(); err != nil {
 		return err
 	}
 
@@ -79,18 +79,18 @@ func (m UserResourceMapping) Validate() error {
 
 // UserResourceMappingFilter represents a set of filters that restrict the returned results.
 type UserResourceMappingFilter struct {
-	ResourceID ID
-	Resource   Resource
-	UserID     ID
-	UserType   UserType
+	ResourceID   ID
+	ResourceType ResourceType
+	UserID       ID
+	UserType     UserType
 }
 
 func (m *UserResourceMapping) ownerPerms() ([]Permission, error) {
 	ps := []Permission{}
 	// TODO(desa): how to grant access to specific resources.
 
-	if m.Resource == OrgsResource {
-		ps = append(ps, OperPermissions(m.ResourceID)...)
+	if m.ResourceType == OrgsResourceType {
+		ps = append(ps, OwnerPermissions(m.ResourceID)...)
 	}
 
 	return ps, nil
@@ -100,7 +100,7 @@ func (m *UserResourceMapping) memberPerms() ([]Permission, error) {
 	ps := []Permission{}
 	// TODO(desa): how to grant access to specific resources.
 
-	if m.Resource == OrgsResource {
+	if m.ResourceType == OrgsResourceType {
 		ps = append(ps, MemberPermissions(m.ResourceID)...)
 	}
 

--- a/user_resource_mapping_test.go
+++ b/user_resource_mapping_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestOwnerMappingValidate(t *testing.T) {
 	type fields struct {
-		ResourceID platform.ID
-		Resource   platform.Resource
-		UserID     platform.ID
-		UserType   platform.UserType
+		ResourceID   platform.ID
+		ResourceType platform.ResourceType
+		UserID       platform.ID
+		UserType     platform.UserType
 	}
 	tests := []struct {
 		name    string
@@ -22,36 +22,36 @@ func TestOwnerMappingValidate(t *testing.T) {
 		{
 			name: "valid mapping",
 			fields: fields{
-				UserID:     platformtesting.MustIDBase16("debac1e0deadbeef"),
-				UserType:   platform.Owner,
-				Resource:   platform.DashboardsResource,
-				ResourceID: platformtesting.MustIDBase16("020f755c3c082000"),
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				UserType:     platform.Owner,
+				ResourceType: platform.DashboardsResourceType,
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
 			},
 		},
 		{
 			name: "mapping requires a resourceid",
 			fields: fields{
-				UserID:   platformtesting.MustIDBase16("debac1e0deadbeef"),
-				UserType: platform.Owner,
-				Resource: platform.DashboardsResource,
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				UserType:     platform.Owner,
+				ResourceType: platform.DashboardsResourceType,
 			},
 			wantErr: true,
 		},
 		{
 			name: "mapping requires a userid",
 			fields: fields{
-				ResourceID: platformtesting.MustIDBase16("020f755c3c082000"),
-				UserType:   platform.Owner,
-				Resource:   platform.DashboardsResource,
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
+				UserType:     platform.Owner,
+				ResourceType: platform.DashboardsResourceType,
 			},
 			wantErr: true,
 		},
 		{
 			name: "mapping requires a usertype",
 			fields: fields{
-				ResourceID: platformtesting.MustIDBase16("020f755c3c082000"),
-				UserID:     platformtesting.MustIDBase16("debac1e0deadbeef"),
-				Resource:   platform.DashboardsResource,
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				ResourceType: platform.DashboardsResourceType,
 			},
 			wantErr: true,
 		},
@@ -67,20 +67,20 @@ func TestOwnerMappingValidate(t *testing.T) {
 		{
 			name: "the usertype provided must be valid",
 			fields: fields{
-				ResourceID: platformtesting.MustIDBase16("020f755c3c082000"),
-				UserID:     platformtesting.MustIDBase16("debac1e0deadbeef"),
-				UserType:   "foo",
-				Resource:   platform.DashboardsResource,
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				UserType:     "foo",
+				ResourceType: platform.DashboardsResourceType,
 			},
 			wantErr: true,
 		},
 		{
 			name: "the resourcetype provided must be valid",
 			fields: fields{
-				ResourceID: platformtesting.MustIDBase16("020f755c3c082000"),
-				UserID:     platformtesting.MustIDBase16("debac1e0deadbeef"),
-				UserType:   platform.Owner,
-				Resource:   "foo",
+				ResourceID:   platformtesting.MustIDBase16("020f755c3c082000"),
+				UserID:       platformtesting.MustIDBase16("debac1e0deadbeef"),
+				UserType:     platform.Owner,
+				ResourceType: "foo",
 			},
 			wantErr: true,
 		},
@@ -88,10 +88,10 @@ func TestOwnerMappingValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := platform.UserResourceMapping{
-				ResourceID: tt.fields.ResourceID,
-				Resource:   tt.fields.Resource,
-				UserID:     tt.fields.UserID,
-				UserType:   tt.fields.UserType,
+				ResourceID:   tt.fields.ResourceID,
+				ResourceType: tt.fields.ResourceType,
+				UserID:       tt.fields.UserID,
+				UserType:     tt.fields.UserType,
 			}
 			if err := m.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("OwnerMapping.Validate() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Closes #11088

_Briefly describe your proposed changes:_
This PR changes `Resource` to `ResourceType` and creates a new structure called
```go
type Resource struct {
   Type ResourceType `json:"type"`
   OrgID *ID `json:"orgID,omitempty"`
   ID *ID `json:"id,omitempty"`
}
```

It allows us to express every permission possible in the system currently in a consistent framework.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
