### PR TITLE
Make task validation errors more clear

### DIFF
--- a/task/validator.go
+++ b/task/validator.go
@@ -254,11 +254,17 @@ func validateBucket(ctx context.Context, script string, preAuth query.PreAuthori
 
 	spec, err := flux.Compile(ctx, script, time.Now())
 	if err != nil {
-		return err
+		return platform.NewError(
+			platform.WithErrorErr(err),
+			platform.WithErrorMsg("Failed to parse flux script."),
+			platform.WithErrorCode(platform.EInvalid))
 	}
 
 	if err := preAuth.PreAuthorize(ctx, spec, auth); err != nil {
-		return err
+		return platform.NewError(
+			platform.WithErrorErr(err),
+			platform.WithErrorMsg("Failed to authorize."),
+			platform.WithErrorCode(platform.EInvalid))
 	}
 
 	return nil

--- a/task/validator.go
+++ b/task/validator.go
@@ -256,7 +256,7 @@ func validateBucket(ctx context.Context, script string, preAuth query.PreAuthori
 	if err != nil {
 		return platform.NewError(
 			platform.WithErrorErr(err),
-			platform.WithErrorMsg("Failed to parse flux script."),
+			platform.WithErrorMsg("Failed to compile flux script."),
 			platform.WithErrorCode(platform.EInvalid))
 	}
 


### PR DESCRIPTION
fixes #10987

_Briefly describe your proposed changes:_
When task validation returns an error it should be of the bas model errors type so that the api can determine what status codes to return. This allows us to return the proper 400 status code when its an invalid request.