### PR TITLE
Add organizationID to telegrafsRequest schema

### DIFF
--- a/http/cur_swagger.yml
+++ b/http/cur_swagger.yml
@@ -102,13 +102,6 @@ paths:
       tags:
         - Telegrafs
       summary: Create a telegraf config
-      parameters:
-          - in: query
-            name: org
-            description: specifies the organization of the resource
-            required: true
-            schema:
-              type: string
       requestBody:
         description: telegraf config to create
         required: true
@@ -5067,6 +5060,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TelegrafRequestPlugin"
+        organizationID:
+          type: string
     TelegrafRequestPlugin:
       type: object
       discriminator:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6359,6 +6359,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TelegrafRequestPlugin"
+        organizationID:
+          type: string
     TelegrafRequestPlugin:
       type: object
       discriminator:

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -438,7 +438,7 @@ export const influxDB2Plugin = {
 
 export const telegrafConfig = {
   id: telegrafConfigID,
-  orgID: '1',
+  organizationID: '1',
   name: 'in n out',
   created: '2018-11-28T18:56:48.854337-08:00',
   lastModified: '2018-11-28T18:56:48.854337-08:00',

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -4646,6 +4646,12 @@ export interface TelegrafRequest {
      * @memberof TelegrafRequest
      */
     plugins?: Array<TelegrafRequestPlugin>;
+    /**
+     * 
+     * @type {string}
+     * @memberof TelegrafRequest
+     */
+    organizationID?: string;
 }
 
 /**
@@ -12727,16 +12733,11 @@ export const TelegrafsApiAxiosParamCreator = function (configuration?: Configura
         /**
          * 
          * @summary Create a telegraf config
-         * @param {string} org specifies the organization of the resource
          * @param {TelegrafRequest} telegrafRequest telegraf config to create
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        telegrafsPost(org: string, telegrafRequest: TelegrafRequest, options: any = {}): RequestArgs {
-            // verify required parameter 'org' is not null or undefined
-            if (org === null || org === undefined) {
-                throw new RequiredError('org','Required parameter org was null or undefined when calling telegrafsPost.');
-            }
+        telegrafsPost(telegrafRequest: TelegrafRequest, options: any = {}): RequestArgs {
             // verify required parameter 'telegrafRequest' is not null or undefined
             if (telegrafRequest === null || telegrafRequest === undefined) {
                 throw new RequiredError('telegrafRequest','Required parameter telegrafRequest was null or undefined when calling telegrafsPost.');
@@ -12750,10 +12751,6 @@ export const TelegrafsApiAxiosParamCreator = function (configuration?: Configura
             const localVarRequestOptions = Object.assign({ method: 'POST' }, baseOptions, options);
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
-
-            if (org !== undefined) {
-                localVarQueryParameter['org'] = org;
-            }
 
             localVarHeaderParameter['Content-Type'] = 'application/json';
 
@@ -13097,13 +13094,12 @@ export const TelegrafsApiFp = function(configuration?: Configuration) {
         /**
          * 
          * @summary Create a telegraf config
-         * @param {string} org specifies the organization of the resource
          * @param {TelegrafRequest} telegrafRequest telegraf config to create
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        telegrafsPost(org: string, telegrafRequest: TelegrafRequest, options?: any): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Telegraf> {
-            const localVarAxiosArgs = TelegrafsApiAxiosParamCreator(configuration).telegrafsPost(org, telegrafRequest, options);
+        telegrafsPost(telegrafRequest: TelegrafRequest, options?: any): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Telegraf> {
+            const localVarAxiosArgs = TelegrafsApiAxiosParamCreator(configuration).telegrafsPost(telegrafRequest, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = Object.assign(localVarAxiosArgs.options, {url: basePath + localVarAxiosArgs.url})
                 return axios.request(axiosRequestArgs);                
@@ -13247,13 +13243,12 @@ export const TelegrafsApiFactory = function (configuration?: Configuration, base
         /**
          * 
          * @summary Create a telegraf config
-         * @param {string} org specifies the organization of the resource
          * @param {TelegrafRequest} telegrafRequest telegraf config to create
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        telegrafsPost(org: string, telegrafRequest: TelegrafRequest, options?: any) {
-            return TelegrafsApiFp(configuration).telegrafsPost(org, telegrafRequest, options)(axios, basePath);
+        telegrafsPost(telegrafRequest: TelegrafRequest, options?: any) {
+            return TelegrafsApiFp(configuration).telegrafsPost(telegrafRequest, options)(axios, basePath);
         },
         /**
          * 
@@ -13364,14 +13359,13 @@ export class TelegrafsApi extends BaseAPI {
     /**
      * 
      * @summary Create a telegraf config
-     * @param {string} org specifies the organization of the resource
      * @param {TelegrafRequest} telegrafRequest telegraf config to create
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TelegrafsApi
      */
-    public telegrafsPost(org: string, telegrafRequest: TelegrafRequest, options?: any) {
-        return TelegrafsApiFp(this.configuration).telegrafsPost(org, telegrafRequest, options)(this.axios, this.basePath);
+    public telegrafsPost(telegrafRequest: TelegrafRequest, options?: any) {
+        return TelegrafsApiFp(this.configuration).telegrafsPost(telegrafRequest, options)(this.axios, this.basePath);
     }
 
     /**

--- a/ui/src/onboarding/actions/dataLoaders.ts
+++ b/ui/src/onboarding/actions/dataLoaders.ts
@@ -30,8 +30,11 @@ import {
 } from 'src/types/v2/dataLoaders'
 import {AppState} from 'src/types/v2'
 import {RemoteDataState} from 'src/types'
-import {WritePrecision} from 'src/api'
-import {TelegrafPluginOutputInfluxDBV2} from 'src/api'
+import {
+  WritePrecision,
+  TelegrafRequest,
+  TelegrafPluginOutputInfluxDBV2,
+} from 'src/api'
 
 type GetState = () => AppState
 
@@ -320,27 +323,22 @@ export const createOrUpdateTelegrafConfigAsync = (authToken: string) => async (
     }
   })
 
-  let body = {
+  const telegrafRequest: TelegrafRequest = {
     name: 'new config',
     agent: {collectionInterval: DEFAULT_COLLECTION_INTERVAL},
+    organizationID: orgID,
     plugins,
-    orgID,
   }
 
   if (telegrafConfigsFromServer.length) {
     const id = _.get(telegrafConfigsFromServer, '0.id', '')
 
-    await updateTelegrafConfig(id, body)
+    await updateTelegrafConfig(id, telegrafRequest)
     dispatch(setTelegrafConfigID(id))
     return
   }
 
-  body = {
-    ...body,
-    plugins,
-  }
-
-  const created = await createTelegrafConfig(orgID, body)
+  const created = await createTelegrafConfig(telegrafRequest)
   dispatch(setTelegrafConfigID(created.id))
 }
 

--- a/ui/src/onboarding/apis/index.ts
+++ b/ui/src/onboarding/apis/index.ts
@@ -125,11 +125,10 @@ export const writeLineProtocol = async (
 }
 
 export const createTelegrafConfig = async (
-  org: string,
   telegrafConfig: TelegrafRequest
 ): Promise<Telegraf> => {
   try {
-    const {data} = await telegrafsAPI.telegrafsPost(org, telegrafConfig)
+    const {data} = await telegrafsAPI.telegrafsPost(telegrafConfig)
 
     return data
   } catch (error) {

--- a/ui/src/onboarding/apis/onboarding.test.ts
+++ b/ui/src/onboarding/apis/onboarding.test.ts
@@ -53,8 +53,7 @@ describe('Onboarding.Apis', () => {
 
   describe('createTelegrafConfig', () => {
     it('should return the newly created config', async () => {
-      const org = 'default'
-      const result = await createTelegrafConfig(org, telegrafConfig)
+      const result = await createTelegrafConfig(telegrafConfig)
 
       expect(result).toEqual(telegrafConfig)
     })


### PR DESCRIPTION
Add organization ID to TelegrafsRequest schema in swagger and cur_swagger,
Update generated api client, 
Update consumers of generated client to add organizationID to telegrafs POST requests, and not try to send organizationID in request parameters