### PR TITLE
build(ui): update Makefile to understand binary asset sources

### DIFF
--- a/chronograf/dist/Makefile
+++ b/chronograf/dist/Makefile
@@ -1,7 +1,7 @@
 # List any generated files here
 TARGETS = dist_gen.go
 # List any source files used to generate the targets here
-SOURCES = dist.go
+SOURCES = dist.go $(shell find ../../ui/build/)
 # List any directories that have their own Makefile here
 SUBDIRS =
 


### PR DESCRIPTION
The Makefile for the binary assets didn't understand what its sources
were. As a result the binary assets were not rebuilt when the sources
changed.
