### PR TITLE
Only render SortBy dropdown if FieldOptions exist

### DIFF
--- a/ui/src/shared/components/view_options/TableOptions.tsx
+++ b/ui/src/shared/components/view_options/TableOptions.tsx
@@ -78,11 +78,13 @@ export class TableOptions extends Component<Props, {}> {
       <>
         <Grid.Column widthSM={Columns.Four}>
           <h4 className="view-options--header">Table Formatting</h4>
-          <SortBy
-            selected={sortBy}
-            fieldOptions={fieldOptions}
-            onChange={this.handleChangeSortBy}
-          />
+          {!!fieldOptions.length && (
+            <SortBy
+              selected={sortBy}
+              fieldOptions={fieldOptions}
+              onChange={this.handleChangeSortBy}
+            />
+          )}
           <TimeFormat
             timeFormat={timeFormat}
             onTimeFormatChange={onSetTimeFormat}


### PR DESCRIPTION
Closes #11077 

_Briefly describe your proposed changes:_
Previously, the `SortBy` dropdown was crashing when field options could not be fetched from the server.

This PR ensures that the `SortBy` dropdown is only rendered if the field options array has at least one item.

  - [x] Rebased/mergeable
  - [x] Tests pass
