### PR TITLE
Authorize organization requests.

### DIFF
--- a/authorizer/authorize.go
+++ b/authorizer/authorize.go
@@ -1,0 +1,27 @@
+package authorizer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/influxdata/influxdb"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+)
+
+// IsAllowed checks to see if an action is authorized by retrieving the authorizer
+// off of context and authorizing the action appropriately.
+func IsAllowed(ctx context.Context, p influxdb.Permission) error {
+	a, err := influxdbcontext.GetAuthorizer(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !a.Allowed(p) {
+		return &influxdb.Error{
+			Code: influxdb.EUnauthorized,
+			Msg:  fmt.Sprintf("%s is unauthorized", p),
+		}
+	}
+
+	return nil
+}

--- a/authorizer/org.go
+++ b/authorizer/org.go
@@ -1,0 +1,143 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.OrganizationService = (*OrgService)(nil)
+
+// OrgService wraps a influxdb.OrganizationService and authorizes actions
+// against it appropriately.
+type OrgService struct {
+	s influxdb.OrganizationService
+}
+
+// NewOrgService constructs an instance of an authorizing org serivce.
+func NewOrgService(s influxdb.OrganizationService) *OrgService {
+	return &OrgService{
+		s: s,
+	}
+}
+
+func newOrgPermission(a influxdb.Action, id influxdb.ID) (*influxdb.Permission, error) {
+	p := &influxdb.Permission{
+		Action: a,
+		Resource: influxdb.Resource{
+			Type: influxdb.OrgsResourceType,
+			ID:   &id,
+		},
+	}
+
+	return p, p.Valid()
+}
+
+func authorizeReadOrg(ctx context.Context, id influxdb.ID) error {
+	p, err := newOrgPermission(influxdb.ReadAction, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func authorizeWriteOrg(ctx context.Context, id influxdb.ID) error {
+	p, err := newOrgPermission(influxdb.WriteAction, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FindOrganizationByID checks to see if the authorizer on context has read access to the id provided.
+func (s *OrgService) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error) {
+	if err := authorizeReadOrg(ctx, id); err != nil {
+		return nil, err
+	}
+
+	return s.s.FindOrganizationByID(ctx, id)
+}
+
+// FindOrganization retrieves the organization and checks to see if the authorizer on context has read access to the org.
+func (s *OrgService) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+	o, err := s.s.FindOrganization(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeReadOrg(ctx, o.ID); err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+// FindOrganizations retrieves all organizations that match the provided filter and then filters the list down to only the resources that are authorized.
+func (s *OrgService) FindOrganizations(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {
+	// TODO: we'll likely want to push this operation into the database eventually since fetching the whole list of data
+	// will likely be expensive.
+	os, _, err := s.s.FindOrganizations(ctx, filter, opt...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	orgs := os[:0]
+	for _, o := range os {
+		err := authorizeReadOrg(ctx, o.ID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+
+		orgs = append(orgs, o)
+	}
+
+	return orgs, len(orgs), nil
+}
+
+// CreateOrganization checks to see if the authorizer on context has write access to the global orgs resource.
+func (s *OrgService) CreateOrganization(ctx context.Context, o *influxdb.Organization) error {
+	p, err := influxdb.NewGlobalPermission(influxdb.WriteAction, influxdb.OrgsResourceType)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return s.s.CreateOrganization(ctx, o)
+}
+
+// UpdateOrganization checks to see if the authorizer on context has write access to the organization provided.
+func (s *OrgService) UpdateOrganization(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
+	if err := authorizeWriteOrg(ctx, id); err != nil {
+		return nil, err
+	}
+
+	return s.s.UpdateOrganization(ctx, id, upd)
+}
+
+// DeleteOrganization checks to see if the authorizer on context has write access to the organization provided.
+func (s *OrgService) DeleteOrganization(ctx context.Context, id influxdb.ID) error {
+	if err := authorizeWriteOrg(ctx, id); err != nil {
+		return err
+	}
+
+	return s.s.DeleteOrganization(ctx, id)
+}

--- a/authorizer/org_test.go
+++ b/authorizer/org_test.go
@@ -1,0 +1,557 @@
+package authorizer_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+var orgCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	cmp.Transformer("Sort", func(in []*influxdb.Organization) []*influxdb.Organization {
+		out := append([]*influxdb.Organization(nil), in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID.String() > out[j].ID.String()
+		})
+		return out
+	}),
+}
+
+func TestOrgService_FindOrganizationByID(t *testing.T) {
+	type fields struct {
+		OrgService influxdb.OrganizationService
+	}
+	type args struct {
+		permission influxdb.Permission
+		id         influxdb.ID
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access id",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					FindOrganizationByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error) {
+						return &influxdb.Organization{
+							ID: id,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to access id",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					FindOrganizationByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error) {
+						return &influxdb.Organization{
+							ID: id,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:orgs/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewOrgService(tt.fields.OrgService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permission})
+
+			_, err := s.FindOrganizationByID(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestOrgService_FindOrganization(t *testing.T) {
+	type fields struct {
+		OrgService influxdb.OrganizationService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					FindOrganizationF: func(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+						return &influxdb.Organization{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to access org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					FindOrganizationF: func(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+						return &influxdb.Organization{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:orgs/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewOrgService(tt.fields.OrgService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permission})
+
+			_, err := s.FindOrganization(ctx, influxdb.OrganizationFilter{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestOrgService_FindOrganizations(t *testing.T) {
+	type fields struct {
+		OrgService influxdb.OrganizationService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err  error
+		orgs []*influxdb.Organization
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to see all orgs",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					FindOrganizationsF: func(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {
+						return []*influxdb.Organization{
+							{
+								ID: 1,
+							},
+							{
+								ID: 2,
+							},
+							{
+								ID: 3,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+					},
+				},
+			},
+			wants: wants{
+				orgs: []*influxdb.Organization{
+					{
+						ID: 1,
+					},
+					{
+						ID: 2,
+					},
+					{
+						ID: 3,
+					},
+				},
+			},
+		},
+		{
+			name: "authorized to access a single org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					FindOrganizationsF: func(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {
+						return []*influxdb.Organization{
+							{
+								ID: 1,
+							},
+							{
+								ID: 2,
+							},
+							{
+								ID: 3,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+			},
+			wants: wants{
+				orgs: []*influxdb.Organization{
+					{
+						ID: 2,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewOrgService(tt.fields.OrgService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permission})
+
+			orgs, _, err := s.FindOrganizations(ctx, influxdb.OrganizationFilter{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+
+			if diff := cmp.Diff(orgs, tt.wants.orgs, orgCmpOptions...); diff != "" {
+				t.Errorf("organizations are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+func TestOrgService_UpdateOrganization(t *testing.T) {
+	type fields struct {
+		OrgService influxdb.OrganizationService
+	}
+	type args struct {
+		id         influxdb.ID
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to update org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					UpdateOrganizationF: func(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
+						return &influxdb.Organization{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to update org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					UpdateOrganizationF: func(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
+						return &influxdb.Organization{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewOrgService(tt.fields.OrgService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permission})
+
+			_, err := s.UpdateOrganization(ctx, tt.args.id, influxdb.OrganizationUpdate{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestOrgService_DeleteOrganization(t *testing.T) {
+	type fields struct {
+		OrgService influxdb.OrganizationService
+	}
+	type args struct {
+		id         influxdb.ID
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to delete org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					DeleteOrganizationF: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to delete org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					DeleteOrganizationF: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewOrgService(tt.fields.OrgService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permission})
+
+			err := s.DeleteOrganization(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestOrgService_CreateOrganization(t *testing.T) {
+	type fields struct {
+		OrgService influxdb.OrganizationService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to create org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					CreateOrganizationF: func(ctx context.Context, o *influxdb.Organization) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to create org",
+			fields: fields{
+				OrgService: &mock.OrganizationService{
+					CreateOrganizationF: func(ctx context.Context, o *influxdb.Organization) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewOrgService(tt.fields.OrgService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permission})
+
+			err := s.CreateOrganization(ctx, &influxdb.Organization{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}

--- a/authorizer/util_test.go
+++ b/authorizer/util_test.go
@@ -1,0 +1,24 @@
+package authorizer_test
+
+import "github.com/influxdata/influxdb"
+
+// Authorizer is mock authorizer that can be used in testing.
+type Authorizer struct {
+	Permission influxdb.Permission
+}
+
+func (a *Authorizer) Allowed(p influxdb.Permission) bool {
+	return influxdb.PermissionAllowed(p, []influxdb.Permission{a.Permission})
+}
+
+func (a *Authorizer) Identifier() influxdb.ID {
+	return 1
+}
+
+func (a *Authorizer) GetUserID() influxdb.ID {
+	return 2
+}
+
+func (a *Authorizer) Kind() string {
+	return "mock"
+}

--- a/errors.go
+++ b/errors.go
@@ -17,6 +17,7 @@ const (
 	EEmptyValue       = "empty value"
 	EUnavailable      = "unavailable"
 	EForbidden        = "forbidden"
+	EUnauthorized     = "unauthorized"
 	EMethodNotAllowed = "method not allowed"
 )
 

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
 	"github.com/influxdata/influxdb/chronograf/server"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/storage"
@@ -79,7 +80,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.BucketHandler.BucketOperationLogService = b.BucketOperationLogService
 
 	h.OrgHandler = NewOrgHandler(b.UserResourceMappingService, b.LabelService, b.UserService)
-	h.OrgHandler.OrganizationService = b.OrganizationService
+	h.OrgHandler.OrganizationService = authorizer.NewOrgService(b.OrganizationService)
 	h.OrgHandler.BucketService = b.BucketService
 	h.OrgHandler.OrganizationOperationLogService = b.OrganizationOperationLogService
 	h.OrgHandler.SecretService = b.SecretService

--- a/http/errors.go
+++ b/http/errors.go
@@ -194,5 +194,6 @@ var statusCodePlatformError = map[string]int{
 	platform.ENotFound:         http.StatusNotFound,
 	platform.EUnavailable:      http.StatusServiceUnavailable,
 	platform.EForbidden:        http.StatusForbidden,
+	platform.EUnauthorized:     http.StatusForbidden,
 	platform.EMethodNotAllowed: http.StatusMethodNotAllowed,
 }

--- a/testing/util.go
+++ b/testing/util.go
@@ -8,6 +8,11 @@ import (
 
 // TODO(goller): remove opPrefix argument
 func diffPlatformErrors(name string, actual, expected error, opPrefix string, t *testing.T) {
+	ErrorsEqual(t, actual, expected)
+}
+
+// ErrorsEqual checks to see if the provided errors are equivalent.
+func ErrorsEqual(t *testing.T, actual, expected error) {
 	if expected == nil && actual == nil {
 		return
 	}


### PR DESCRIPTION
Closes part of #10814 

_Briefly describe your proposed changes:_
This PR introduces an `authorizer` package that is used to authorize service methods. It pulls the authorizer from context and uses it to authorize an action.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
