### PR TITLE
Remember query from query builder

### DIFF
--- a/ui/src/shared/components/TimeMachineQueries.tsx
+++ b/ui/src/shared/components/TimeMachineQueries.tsx
@@ -114,13 +114,13 @@ class TimeMachineQueries extends PureComponent<Props> {
                 onChange={this.handleToggleIsViewingRawData}
                 size={ComponentSize.ExtraSmall}
               />
+              <CSVExportButton files={files} />
               <TimeMachineRefreshDropdown />
               <TimeRangeDropdown
                 timeRange={timeRange}
                 onSetTimeRange={onSetTimeRange}
               />
               <TimeMachineQueriesSwitcher />
-              <CSVExportButton files={files} />
               <SubmitQueryButton queryStatus={queriesState.loading} />
             </ComponentSpacer>
           </div>

--- a/ui/src/shared/reducers/v2/timeMachines.test.ts
+++ b/ui/src/shared/reducers/v2/timeMachines.test.ts
@@ -185,15 +185,11 @@ describe('timeMachineReducer', () => {
           hidden: false,
         },
         {
-          text: '',
+          text: 'bar',
           type: InfluxLanguage.Flux,
           sourceID: '',
           editMode: QueryEditMode.Builder,
-          builderConfig: {
-            buckets: [],
-            tags: [{key: '_measurement', values: []}],
-            functions: [],
-          },
+          builderConfig: {buckets: [], tags: [], functions: []},
           hidden: false,
         },
       ])

--- a/ui/src/shared/reducers/v2/timeMachines.ts
+++ b/ui/src/shared/reducers/v2/timeMachines.ts
@@ -348,8 +348,13 @@ export const timeMachineReducer = (
     case 'EDIT_ACTIVE_QUERY_WITH_BUILDER': {
       const {activeQueryIndex} = state
       const draftQueries = [...state.draftQueries]
+      const query = draftQueries[activeQueryIndex]
 
-      draftQueries[activeQueryIndex] = {...defaultViewQuery(), hidden: false}
+      draftQueries[activeQueryIndex] = {
+        ...query,
+        editMode: QueryEditMode.Builder,
+        hidden: false,
+      }
 
       return {
         ...state,


### PR DESCRIPTION
Closes #11021

When switching from query builder to editor and back, query should be
persisted

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
