### PR TITLE
refactor(task): look up runs more efficiently

### DIFF
--- a/task/backend/point_logwriter.go
+++ b/task/backend/point_logwriter.go
@@ -14,9 +14,9 @@ const (
 	runIDField        = "runID"
 	scheduledForField = "scheduledFor"
 	requestedAtField  = "requestedAt"
+	statusField       = "status"
 
 	taskIDTag = "taskID"
-	statusTag = "status"
 
 	// Fixed system bucket ID for task and run logs.
 	taskSystemBucketID platform.ID = 10
@@ -40,10 +40,10 @@ func NewPointLogWriter(pw PointsWriter) *PointLogWriter {
 
 func (p *PointLogWriter) UpdateRunState(ctx context.Context, rlb RunLogBase, when time.Time, status RunStatus) error {
 	tags := models.Tags{
-		models.NewTag([]byte(statusTag), []byte(status.String())),
 		models.NewTag([]byte(taskIDTag), []byte(rlb.Task.ID.String())),
 	}
-	fields := make(map[string]interface{}, 3)
+	fields := make(map[string]interface{}, 4)
+	fields[statusField] = status.String()
 	fields[runIDField] = rlb.RunID.String()
 	fields[scheduledForField] = time.Unix(rlb.RunScheduledFor, 0).UTC().Format(time.RFC3339)
 	if rlb.RequestedAt != 0 {


### PR DESCRIPTION
This switches run status from a tag to a field. This is likely a
breaking change to existing task logs.

Using a one-off local query, for 250 records, the previous approach took
around 10 seconds and the new approach is about 30 milliseconds. At 1000
records, the previous approach was roughly 110 seconds and the new
approach is around 70 milliseconds.

Closes #11099.