### PR TITLE
fix(influxdb): special case the orgs resource when generating permissions

### DIFF
--- a/authz.go
+++ b/authz.go
@@ -296,6 +296,10 @@ func OwnerPermissions(orgID ID) []Permission {
 	ps := []Permission{}
 	for _, r := range AllResourceTypes {
 		for _, a := range actions {
+			if r == OrgsResourceType {
+				ps = append(ps, Permission{Action: a, Resource: Resource{Type: r, ID: &orgID}})
+				continue
+			}
 			ps = append(ps, Permission{Action: a, Resource: Resource{Type: r, OrgID: &orgID}})
 		}
 	}
@@ -307,6 +311,10 @@ func OwnerPermissions(orgID ID) []Permission {
 func MemberPermissions(orgID ID) []Permission {
 	ps := []Permission{}
 	for _, r := range AllResourceTypes {
+		if r == OrgsResourceType {
+			ps = append(ps, Permission{Action: ReadAction, Resource: Resource{Type: r, ID: &orgID}})
+			continue
+		}
 		ps = append(ps, Permission{Action: ReadAction, Resource: Resource{Type: r, OrgID: &orgID}})
 	}
 


### PR DESCRIPTION
_Briefly describe your proposed changes:_
The set of permissions that a user was given during a session did not contain the appropriate permission to view/create resources for an organization. This PR special cases the organization permission to allow for read/create permissions for an organization.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
