### PR TITLE
feat(ui): login redirect to /me 

### DIFF
--- a/ui/src/Logout.tsx
+++ b/ui/src/Logout.tsx
@@ -22,7 +22,14 @@ export class Logout extends PureComponent<Props> {
 
   private handleSignOut = async () => {
     await logout()
-    this.props.router.push('/')
+    const {query} = this.props.location
+    let returnTo = ''
+
+    if (query && query.returnTo) {
+      returnTo = `?returnTo=${query.returnTo}`
+    }
+
+    this.props.router.push(`/signin${returnTo}`)
   }
 }
 

--- a/ui/src/Logout.tsx
+++ b/ui/src/Logout.tsx
@@ -22,7 +22,7 @@ export class Logout extends PureComponent<Props> {
 
   private handleSignOut = async () => {
     await logout()
-    this.props.router.push('/me')
+    this.props.router.push('/')
   }
 }
 

--- a/ui/src/Logout.tsx
+++ b/ui/src/Logout.tsx
@@ -22,7 +22,7 @@ export class Logout extends PureComponent<Props> {
 
   private handleSignOut = async () => {
     await logout()
-    this.props.router.push('/')
+    this.props.router.push('/me')
   }
 }
 

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -63,7 +63,10 @@ export class Signin extends PureComponent<Props, State> {
       await getMe()
     } catch (error) {
       clearInterval(this.intervalID)
-      this.props.router.push('/signin')
+      this.props.router.push({
+        pathname: '/signin',
+        state: {from: this.props.location.pathname},
+      })
     }
   }
 }

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -66,7 +66,9 @@ export class Signin extends PureComponent<Props, State> {
       const {location} = this.props
       const returnTo = location.pathname
 
-      this.props.router.push(`/signin?${returnTo}`)
+      if (!returnTo.startsWith('/signin')) {
+        this.props.router.push(`/signin?returnTo=${returnTo}`)
+      }
     }
   }
 }

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -62,13 +62,22 @@ export class Signin extends PureComponent<Props, State> {
     try {
       await getMe()
     } catch (error) {
+      const {
+        location: {pathname},
+      } = this.props
       clearInterval(this.intervalID)
-      const {location} = this.props
-      const returnTo = location.pathname
 
-      if (!returnTo.startsWith('/signin')) {
-        this.props.router.push(`/signin?returnTo=${returnTo}`)
+      if (pathname.startsWith('/signin')) {
+        return
       }
+
+      let returnTo = ''
+
+      if (pathname !== '/') {
+        returnTo = `?returnTo=${pathname}`
+      }
+
+      this.props.router.push(`/signin${returnTo}`)
     }
   }
 }

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -33,7 +33,8 @@ export class Signin extends PureComponent<Props, State> {
   }
 
   public async componentDidMount() {
-    await this.checkForLogin()
+    this.setState({loading: RemoteDataState.Done})
+    this.checkForLogin()
     this.intervalID = setInterval(this.checkForLogin, FETCH_WAIT)
   }
 
@@ -60,16 +61,12 @@ export class Signin extends PureComponent<Props, State> {
   private checkForLogin = async () => {
     try {
       await getMe()
-      this.setState({loading: RemoteDataState.Done})
     } catch (error) {
       clearInterval(this.intervalID)
       const {location} = this.props
       const returnTo = location.pathname
 
-      this.props.router.push({
-        pathname: '/signin',
-        query: {returnTo},
-      })
+      this.props.router.push(`/signin?${returnTo}`)
     }
   }
 }

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -8,6 +8,7 @@ import {getMe} from 'src/shared/apis/v2/user'
 
 // Types
 import {RemoteDataState} from 'src/types'
+import {Actions} from 'history'
 
 interface State {
   loading: RemoteDataState
@@ -63,9 +64,17 @@ export class Signin extends PureComponent<Props, State> {
       await getMe()
     } catch (error) {
       clearInterval(this.intervalID)
+      const {location} = this.props
+      let from = '/me'
+
+      // record pathname on page load pop event
+      if (location.action === Actions.POP) {
+        from = location.pathname
+      }
+
       this.props.router.push({
         pathname: '/signin',
-        state: {from: this.props.location.pathname},
+        state: {from},
       })
     }
   }

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -8,7 +8,6 @@ import {getMe} from 'src/shared/apis/v2/user'
 
 // Types
 import {RemoteDataState} from 'src/types'
-import {Actions} from 'history'
 
 interface State {
   loading: RemoteDataState
@@ -34,8 +33,7 @@ export class Signin extends PureComponent<Props, State> {
   }
 
   public async componentDidMount() {
-    this.setState({loading: RemoteDataState.Done})
-    this.checkForLogin()
+    await this.checkForLogin()
     this.intervalID = setInterval(this.checkForLogin, FETCH_WAIT)
   }
 
@@ -62,19 +60,15 @@ export class Signin extends PureComponent<Props, State> {
   private checkForLogin = async () => {
     try {
       await getMe()
+      this.setState({loading: RemoteDataState.Done})
     } catch (error) {
       clearInterval(this.intervalID)
       const {location} = this.props
-      let from = '/me'
-
-      // record pathname on page load pop event
-      if (location.action === Actions.POP) {
-        from = location.pathname
-      }
+      const returnTo = location.pathname
 
       this.props.router.push({
         pathname: '/signin',
-        state: {from},
+        query: {returnTo},
       })
     }
   }

--- a/ui/src/me/components/LogoutButton.tsx
+++ b/ui/src/me/components/LogoutButton.tsx
@@ -12,4 +12,4 @@ const LogoutButton: SFC<WithRouterProps> = props => (
   </Link>
 )
 
-export default withRouter(LogoutButton)
+export default withRouter<{}>(LogoutButton)

--- a/ui/src/me/components/LogoutButton.tsx
+++ b/ui/src/me/components/LogoutButton.tsx
@@ -1,14 +1,15 @@
 // Libraries
 import React, {SFC} from 'react'
 import {Link} from 'react-router'
+import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Button, ComponentSize} from 'src/clockface'
 
-const LogoutButton: SFC = () => (
-  <Link to={`/logout`}>
+const LogoutButton: SFC<WithRouterProps> = props => (
+  <Link to={`/logout?returnTo=${props.location.pathname}`}>
     <Button text="Logout" size={ComponentSize.ExtraSmall} />
   </Link>
 )
 
-export default LogoutButton
+export default withRouter(LogoutButton)

--- a/ui/src/onboarding/components/SigninForm.tsx
+++ b/ui/src/onboarding/components/SigninForm.tsx
@@ -108,7 +108,7 @@ class SigninForm extends PureComponent<Props, State> {
 
     try {
       await signin({username, password})
-      this.redirectToPrevious()
+      this.handleRedirect()
     } catch (error) {
       const message = get(error, 'data.msg', '')
 
@@ -120,14 +120,14 @@ class SigninForm extends PureComponent<Props, State> {
     }
   }
 
-  private redirectToPrevious() {
+  private handleRedirect() {
     const {router} = this.props
     const {state} = this.props.location
 
     if (state && state.from) {
       router.push(state.from)
     } else {
-      router.push('/me')
+      router.push('/')
     }
   }
 }

--- a/ui/src/onboarding/components/SigninForm.tsx
+++ b/ui/src/onboarding/components/SigninForm.tsx
@@ -127,7 +127,7 @@ class SigninForm extends PureComponent<Props, State> {
     if (state && state.from) {
       router.push(state.from)
     } else {
-      router.push('/')
+      router.push('/me')
     }
   }
 }

--- a/ui/src/onboarding/components/SigninForm.tsx
+++ b/ui/src/onboarding/components/SigninForm.tsx
@@ -103,12 +103,12 @@ class SigninForm extends PureComponent<Props, State> {
   }
 
   private handleSignIn = async (): Promise<void> => {
-    const {notify, router} = this.props
+    const {notify} = this.props
     const {username, password} = this.state
 
     try {
       await signin({username, password})
-      router.push('/dashboards')
+      this.redirectToPrevious()
     } catch (error) {
       const message = get(error, 'data.msg', '')
 
@@ -117,6 +117,17 @@ class SigninForm extends PureComponent<Props, State> {
       }
 
       notify({...copy.SigninError, message})
+    }
+  }
+
+  private redirectToPrevious() {
+    const {router} = this.props
+    const {state} = this.props.location
+
+    if (state && state.from) {
+      router.push(state.from)
+    } else {
+      router.push('/me')
     }
   }
 }

--- a/ui/src/onboarding/components/SigninForm.tsx
+++ b/ui/src/onboarding/components/SigninForm.tsx
@@ -122,10 +122,10 @@ class SigninForm extends PureComponent<Props, State> {
 
   private handleRedirect() {
     const {router} = this.props
-    const {state} = this.props.location
+    const {query} = this.props.location
 
-    if (state && state.from) {
-      router.push(state.from)
+    if (query && query.returnTo) {
+      router.push(query.returnTo)
     } else {
       router.push('/me')
     }

--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -122,7 +122,7 @@ class OnboardingWizard extends PureComponent<Props> {
   private handleExit = () => {
     const {router, onCompleteSetup} = this.props
     onCompleteSetup()
-    router.push(`/`)
+    router.push(`/me`)
   }
 
   private get onboardingStepProps(): OnboardingStepProps {

--- a/ui/src/onboarding/containers/SigninPage.tsx
+++ b/ui/src/onboarding/containers/SigninPage.tsx
@@ -12,6 +12,7 @@ import SplashPage from 'src/shared/components/splash_page/SplashPage'
 import SigninForm from 'src/onboarding/components/SigninForm'
 import {Spinner} from 'src/clockface'
 import {RemoteDataState} from 'src/types'
+import Notifications from 'src/shared/components/notifications/Notifications'
 
 interface State {
   status: RemoteDataState
@@ -39,6 +40,7 @@ class SigninPage extends PureComponent<WithRouterProps, State> {
   public render() {
     return (
       <Spinner loading={this.state.status}>
+        <Notifications inPresentationMode={true} />
         <SplashPage panelWidthPixels={300}>
           <SplashPage.Panel>
             <SplashPage.Logo />

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -32,7 +32,7 @@ class SideNav extends PureComponent<Props> {
 
   public render() {
     const {isHidden, me} = this.props
-
+    const {location} = this.props
     if (isHidden) {
       return null
     }
@@ -48,7 +48,7 @@ class SideNav extends PureComponent<Props> {
         >
           <NavMenu.SubItem
             title="Logout"
-            link="/logout"
+            link={`/logout?returnTo=${location.pathname}`}
             location={location.pathname}
             highlightWhen={[]}
           />


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
-  Redirects to `/me` after signin or onboarding exit 
- Also, fixes an issue where failed sign in notifications were not being displayed until after signin.
- Changes index route to redirect to `/me` 

  - [x] Rebased/mergeable
  - [x] Tests pass
