### PR TITLE
chore: add go.mod and go.sum to list of Go sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export PATH := $(PWD)/bin/$(GOOS):$(PATH)
 
 
 # All go source files
-SOURCES := $(shell find . -name '*.go' -not -name '*_test.go')
+SOURCES := $(shell find . -name '*.go' -not -name '*_test.go') go.mod go.sum
 
 # All go source files excluding the vendored sources.
 SOURCES_NO_VENDOR := $(shell find . -path ./vendor -prune -o -name "*.go" -not -name '*_test.go' -print)


### PR DESCRIPTION
This enables workflows that use `go mod edit` commands to rely on the
Makefile correctly rebuilding the Go binaries.
