### PR TITLE
fix(http): use wrapped org/bucket services only when required

### DIFF
--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -72,19 +72,17 @@ type APIBackend struct {
 // NewAPIHandler constructs all api handlers beneath it and returns an APIHandler
 func NewAPIHandler(b *APIBackend) *APIHandler {
 	h := &APIHandler{}
-	b.BucketService = authorizer.NewBucketService(b.BucketService)
-	b.OrganizationService = authorizer.NewOrgService(b.OrganizationService)
 
 	sessionBackend := NewSessionBackend(b)
 	h.SessionHandler = NewSessionHandler(sessionBackend)
 
 	h.BucketHandler = NewBucketHandler(b.UserResourceMappingService, b.LabelService, b.UserService)
-	h.BucketHandler.BucketService = b.BucketService
+	h.BucketHandler.BucketService = authorizer.NewBucketService(b.BucketService)
+	h.BucketHandler.OrganizationService = b.OrganizationService
 	h.BucketHandler.BucketOperationLogService = b.BucketOperationLogService
 
 	h.OrgHandler = NewOrgHandler(b.UserResourceMappingService, b.LabelService, b.UserService)
-	h.OrgHandler.OrganizationService = b.OrganizationService
-	h.OrgHandler.BucketService = b.BucketService
+	h.OrgHandler.OrganizationService = authorizer.NewOrgService(b.OrganizationService)
 	h.OrgHandler.OrganizationOperationLogService = b.OrganizationOperationLogService
 	h.OrgHandler.SecretService = b.SecretService
 

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -239,14 +239,15 @@ func (h *BucketHandler) handlePostBucket(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Resolve organization name to ID before create
-	o, err := h.OrganizationService.FindOrganization(ctx, platform.OrganizationFilter{Name: &req.Bucket.Organization})
-	if err != nil {
-		EncodeError(ctx, err, w)
-		return
+	if !req.Bucket.OrganizationID.Valid() {
+		// Resolve organization name to ID before create
+		o, err := h.OrganizationService.FindOrganization(ctx, platform.OrganizationFilter{Name: &req.Bucket.Organization})
+		if err != nil {
+			EncodeError(ctx, err, w)
+			return
+		}
+		req.Bucket.OrganizationID = o.ID
 	}
-
-	req.Bucket.OrganizationID = o.ID
 
 	if err := h.BucketService.CreateBucket(ctx, req.Bucket); err != nil {
 		EncodeError(ctx, err, w)

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -27,6 +27,7 @@ type BucketHandler struct {
 	UserResourceMappingService platform.UserResourceMappingService
 	LabelService               platform.LabelService
 	UserService                platform.UserService
+	OrganizationService        platform.OrganizationService
 }
 
 const (
@@ -237,6 +238,15 @@ func (h *BucketHandler) handlePostBucket(w http.ResponseWriter, r *http.Request)
 		EncodeError(ctx, err, w)
 		return
 	}
+
+	// Resolve organization name to ID before create
+	o, err := h.OrganizationService.FindOrganization(ctx, platform.OrganizationFilter{Name: &req.Bucket.Organization})
+	if err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	req.Bucket.OrganizationID = o.ID
 
 	if err := h.BucketService.CreateBucket(ctx, req.Bucket); err != nil {
 		EncodeError(ctx, err, w)

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -23,7 +23,6 @@ type OrgHandler struct {
 
 	OrganizationService             platform.OrganizationService
 	OrganizationOperationLogService platform.OrganizationOperationLogService
-	BucketService                   platform.BucketService
 	UserResourceMappingService      platform.UserResourceMappingService
 	SecretService                   platform.SecretService
 	LabelService                    platform.LabelService

--- a/http/org_test.go
+++ b/http/org_test.go
@@ -30,7 +30,6 @@ func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T)
 
 	handler := NewOrgHandler(mock.NewUserResourceMappingService(), mock.NewLabelService(), mock.NewUserService())
 	handler.OrganizationService = svc
-	handler.BucketService = svc
 	server := httptest.NewServer(handler)
 	client := OrganizationService{
 		Addr:     server.URL,

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -98,7 +98,7 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 		o, err := h.OrganizationService.FindOrganization(ctx, platform.OrganizationFilter{Name: &req.Org})
 		if err != nil {
 			logger.Info("Failed to find organization", zap.Error(err))
-			EncodeError(ctx, fmt.Errorf("organization %q not found", req.Org), w)
+			EncodeError(ctx, err, w)
 			return
 		}
 
@@ -127,10 +127,8 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 		})
 		if err != nil {
 			EncodeError(ctx, &platform.Error{
-				Code: platform.ENotFound,
-				Op:   "http/handleWrite",
-				Err:  err,
-				Msg:  fmt.Sprintf("bucket %q not found", req.Bucket),
+				Op:  "http/handleWrite",
+				Err: err,
 			}, w)
 			return
 		}


### PR DESCRIPTION
Link https://github.com/influxdata/flux/issues/875

_Briefly describe your proposed changes:_
Previously, we blanket wrapped all instances of `OrganizationService` and `BucketService` with a variation that authorized actions. This however lead to a weird situation where in order to write data to a bucket, you needed to have both read and write access to the bucket, as well as read access to an organization. This was unintuitive and wrong. Instead, we now only wrap the services for the direct action that is being performed.

We also now resolve organization names to ID in the organization http handler before we attempt to create a bucket, so that we can more easily check the that the action is authorized.

Additionally, we modified the errors returned by the write handler so that they more correctly reflect the issue that was encountered.

TODO:
- [ ] Write tests for these

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
