### PR TITLE
Use Clockface Overlay when confirming switch from editor to builder

### DIFF
--- a/ui/src/clockface/components/overlays/Overlay.scss
+++ b/ui/src/clockface/components/overlays/Overlay.scss
@@ -4,8 +4,7 @@
 */
 
 $overlay-title-height: $chronograf-page-header-height;
-$overlay-gutter: 30px;
-$overlay-min-height: 150px;
+$overlay-gutter: $ix-marg-d;
 
 
 /*
@@ -121,6 +120,16 @@ $overlay-min-height: 150px;
 
 .overlay--body {
   padding: $overlay-gutter;
-  padding-top: 0; 
-  min-height: $overlay-min-height;
+  padding-top: 0;
+  padding-bottom: $overlay-gutter / 2;
+  color: $g13-mist;
+
+  p {
+    font-weight: 500;
+  }
+}
+
+.overlay--footer {
+  padding: $overlay-gutter 0;
+  padding-top: $overlay-gutter / 2;
 }

--- a/ui/src/clockface/components/overlays/OverlayFooter.tsx
+++ b/ui/src/clockface/components/overlays/OverlayFooter.tsx
@@ -1,0 +1,23 @@
+// Libraries
+import React, {SFC} from 'react'
+
+// Components
+import {ComponentSpacer, Stack, Alignment} from 'src/clockface'
+
+interface Props {
+  children: JSX.Element | JSX.Element[]
+}
+
+const OverlayFooter: SFC<Props> = ({children}) => (
+  <div className="overlay--footer">
+    <ComponentSpacer
+      stackChildren={Stack.Columns}
+      align={Alignment.Center}
+      stretchToFitWidth={true}
+    >
+      {children}
+    </ComponentSpacer>
+  </div>
+)
+
+export default OverlayFooter

--- a/ui/src/clockface/index.ts
+++ b/ui/src/clockface/index.ts
@@ -13,6 +13,7 @@ import OverlayTechnology from './components/overlays/OverlayTechnology'
 import OverlayContainer from './components/overlays/OverlayContainer'
 import OverlayHeading from './components/overlays/OverlayHeading'
 import OverlayBody from './components/overlays/OverlayBody'
+import OverlayFooter from './components/overlays/OverlayFooter'
 import Panel from './components/panel/Panel'
 import Radio from './components/radio_buttons/RadioButtons'
 import SlideToggle from './components/slide_toggle/SlideToggle'
@@ -86,10 +87,11 @@ export {
   MultiSelectDropdown,
   MultiInputType,
   MultipleInput,
-  OverlayTechnology,
-  OverlayContainer,
-  OverlayHeading,
   OverlayBody,
+  OverlayContainer,
+  OverlayFooter,
+  OverlayHeading,
+  OverlayTechnology,
   Panel,
   ProgressBar,
   Radio,

--- a/ui/src/shared/components/TimeMachineQueriesSwitcher.scss
+++ b/ui/src/shared/components/TimeMachineQueriesSwitcher.scss
@@ -1,0 +1,13 @@
+/*
+   Time Machine Queries Switcher
+   -----------------------------------------------------------------------------
+*/
+
+@import 'src/style/modules';
+
+.time-machine-queries-switcher--warning {
+  font-size: 15px;
+  font-weight: 500;
+  color: $g13-mist;
+  margin: 0;
+}

--- a/ui/src/shared/components/TimeMachineQueriesSwitcher.tsx
+++ b/ui/src/shared/components/TimeMachineQueriesSwitcher.tsx
@@ -3,7 +3,15 @@ import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 
 // Components
-import {Button} from 'src/clockface'
+import {
+  Button,
+  ComponentColor,
+  OverlayTechnology,
+  OverlayBody,
+  OverlayHeading,
+  OverlayContainer,
+  OverlayFooter,
+} from 'src/clockface'
 
 // Actions
 import {
@@ -17,7 +25,9 @@ import {
   getActiveQuery,
   getActiveQuerySource,
 } from 'src/shared/selectors/timeMachines'
-import {CONFIRM_LEAVE_ADVANCED_MODE} from 'src/shared/copy/v2'
+
+// Styles
+import 'src/shared/components/TimeMachineQueriesSwitcher.scss'
 
 // Types
 import {AppState, QueryEditMode, Source} from 'src/types/v2'
@@ -35,15 +45,60 @@ interface DispatchProps {
 
 type Props = StateProps & DispatchProps
 
-class TimeMachineQueriesSwitcher extends PureComponent<Props> {
+interface State {
+  isOverlayVisible: boolean
+}
+
+class TimeMachineQueriesSwitcher extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      isOverlayVisible: false,
+    }
+  }
+
   public render() {
+    const {isOverlayVisible} = this.state
+    const {onEditWithBuilder} = this.props
+
+    return (
+      <>
+        {this.button}
+        <OverlayTechnology visible={isOverlayVisible}>
+          <OverlayContainer maxWidth={400}>
+            <OverlayHeading
+              title="Are you sure?"
+              onDismiss={this.handleDismissOverlay}
+            />
+            <OverlayBody>
+              <p className="time-machine-queries-switcher--warning">
+                Switching to Query Builder mode will discard any changes you
+                have made using Flux. This cannot be recovered.
+              </p>
+            </OverlayBody>
+            <OverlayFooter>
+              <Button text="Cancel" onClick={this.handleDismissOverlay} />
+              <Button
+                color={ComponentColor.Danger}
+                text="Switch to Builder"
+                onClick={onEditWithBuilder}
+              />
+            </OverlayFooter>
+          </OverlayContainer>
+        </OverlayTechnology>
+      </>
+    )
+  }
+
+  private get button(): JSX.Element {
     const {editMode, sourceType, onEditAsFlux, onEditAsInfluxQL} = this.props
 
     if (editMode !== QueryEditMode.Builder) {
       return (
         <Button
           text="Switch to Query Builder"
-          onClick={this.handleEditWithBuilder}
+          onClick={this.handleShowOverlay}
         />
       )
     }
@@ -57,12 +112,12 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props> {
     return <Button text="Switch to Script Editor" onClick={onEditAsFlux} />
   }
 
-  private handleEditWithBuilder = (): void => {
-    const {onEditWithBuilder} = this.props
+  private handleShowOverlay = (): void => {
+    this.setState({isOverlayVisible: true})
+  }
 
-    if (window.confirm(CONFIRM_LEAVE_ADVANCED_MODE)) {
-      onEditWithBuilder()
-    }
+  private handleDismissOverlay = (): void => {
+    this.setState({isOverlayVisible: false})
   }
 }
 

--- a/ui/src/shared/components/TimeMachineQueriesSwitcher.tsx
+++ b/ui/src/shared/components/TimeMachineQueriesSwitcher.tsx
@@ -60,7 +60,6 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props, State> {
 
   public render() {
     const {isOverlayVisible} = this.state
-    const {onEditWithBuilder} = this.props
 
     return (
       <>
@@ -82,7 +81,7 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props, State> {
               <Button
                 color={ComponentColor.Danger}
                 text="Switch to Builder"
-                onClick={onEditWithBuilder}
+                onClick={this.handleConfirmSwitch}
               />
             </OverlayFooter>
           </OverlayContainer>
@@ -118,6 +117,13 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props, State> {
 
   private handleDismissOverlay = (): void => {
     this.setState({isOverlayVisible: false})
+  }
+
+  private handleConfirmSwitch = (): void => {
+    const {onEditWithBuilder} = this.props
+
+    this.handleDismissOverlay()
+    onEditWithBuilder()
   }
 }
 

--- a/ui/src/shared/copy/v2/index.ts
+++ b/ui/src/shared/copy/v2/index.ts
@@ -1,2 +1,0 @@
-export const CONFIRM_LEAVE_ADVANCED_MODE =
-  'You will lose any manual edits you have made to your query. Are you sure?'


### PR DESCRIPTION
Closes #11115 

![screen shot 2019-01-16 at 4 10 34 pm](https://user-images.githubusercontent.com/2433762/51286909-f3aed700-19a9-11e9-8693-4b8aafbdc442.png)

Use the Clockface overlay components instead of the browser dialog

  - [x] Rebased/mergeable
  - [x] Tests pass
