### PR TITLE
Add additional info links to plugin forms

### DIFF
--- a/http/cur_swagger.yml
+++ b/http/cur_swagger.yml
@@ -5629,7 +5629,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/TelegrafRequestPlugin"
         - $ref: "#/components/schemas/TelegrafPluginInputNet"
-    TelegrafPluginInputNgnix:
+    TelegrafPluginInputNginx:
       type:
         object
       required:
@@ -5639,7 +5639,7 @@ components:
       properties:
         name:
           type: string
-          enum: ["ngnix"]
+          enum: ["nginx"]
         type:
           type: string
           enum: ["input"]
@@ -5647,11 +5647,11 @@ components:
           type: string
         config:
           $ref: "#/components/schemas/TelegrafPluginConfig"
-    TelegrafPluginInputNgnixRequest:
+    TelegrafPluginInputNginxRequest:
       type: object
       allOf:
         - $ref: "#/components/schemas/TelegrafRequestPlugin"
-        - $ref: "#/components/schemas/TelegrafPluginInputNgnix"
+        - $ref: "#/components/schemas/TelegrafPluginInputNginx"
     TelegrafPluginInputProcesses:
       type:
         object

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6596,7 +6596,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/TelegrafRequestPlugin"
         - $ref: "#/components/schemas/TelegrafPluginInputNet"
-    TelegrafPluginInputNgnix:
+    TelegrafPluginInputNginx:
       type:
         object
       required:
@@ -6606,7 +6606,7 @@ components:
       properties:
         name:
           type: string
-          enum: ["ngnix"]
+          enum: ["nginx"]
         type:
           type: string
           enum: ["input"]
@@ -6614,11 +6614,11 @@ components:
           type: string
         config:
           $ref: "#/components/schemas/TelegrafPluginConfig"
-    TelegrafPluginInputNgnixRequest:
+    TelegrafPluginInputNginxRequest:
       type: object
       allOf:
         - $ref: "#/components/schemas/TelegrafRequestPlugin"
-        - $ref: "#/components/schemas/TelegrafPluginInputNgnix"
+        - $ref: "#/components/schemas/TelegrafPluginInputNginx"
     TelegrafPluginInputProcesses:
       type:
         object

--- a/telegraf.go
+++ b/telegraf.go
@@ -370,7 +370,7 @@ var availableInputPlugins = map[string](func() plugins.Config){
 	"mem":          func() plugins.Config { return &inputs.MemStats{} },
 	"net_response": func() plugins.Config { return &inputs.NetResponse{} },
 	"net":          func() plugins.Config { return &inputs.NetIOStats{} },
-	"ngnix":        func() plugins.Config { return &inputs.Nginx{} },
+	"nginx":        func() plugins.Config { return &inputs.Nginx{} },
 	"processes":    func() plugins.Config { return &inputs.Processes{} },
 	"procstat":     func() plugins.Config { return &inputs.Procstat{} },
 	"prometheus":   func() plugins.Config { return &inputs.Prometheus{} },

--- a/ui/src/api/api.ts
+++ b/ui/src/api/api.ts
@@ -4004,46 +4004,46 @@ export namespace TelegrafPluginInputNetResponseRequest {
 /**
  * 
  * @export
- * @interface TelegrafPluginInputNgnix
+ * @interface TelegrafPluginInputNginx
  */
-export interface TelegrafPluginInputNgnix {
+export interface TelegrafPluginInputNginx {
     /**
      * 
      * @type {string}
-     * @memberof TelegrafPluginInputNgnix
+     * @memberof TelegrafPluginInputNginx
      */
-    name: TelegrafPluginInputNgnix.NameEnum;
+    name: TelegrafPluginInputNginx.NameEnum;
     /**
      * 
      * @type {string}
-     * @memberof TelegrafPluginInputNgnix
+     * @memberof TelegrafPluginInputNginx
      */
-    type: TelegrafPluginInputNgnix.TypeEnum;
+    type: TelegrafPluginInputNginx.TypeEnum;
     /**
      * 
      * @type {string}
-     * @memberof TelegrafPluginInputNgnix
+     * @memberof TelegrafPluginInputNginx
      */
     comment?: string;
     /**
      * 
      * @type {TelegrafPluginConfig}
-     * @memberof TelegrafPluginInputNgnix
+     * @memberof TelegrafPluginInputNginx
      */
     config: TelegrafPluginConfig;
 }
 
 /**
  * @export
- * @namespace TelegrafPluginInputNgnix
+ * @namespace TelegrafPluginInputNginx
  */
-export namespace TelegrafPluginInputNgnix {
+export namespace TelegrafPluginInputNginx {
     /**
      * @export
      * @enum {string}
      */
     export enum NameEnum {
-        Ngnix = 'ngnix'
+        Nginx = 'nginx'
     }
     /**
      * @export
@@ -4057,16 +4057,16 @@ export namespace TelegrafPluginInputNgnix {
 /**
  * 
  * @export
- * @interface TelegrafPluginInputNgnixRequest
+ * @interface TelegrafPluginInputNginxRequest
  */
-export interface TelegrafPluginInputNgnixRequest extends TelegrafRequestPlugin {
+export interface TelegrafPluginInputNginxRequest extends TelegrafRequestPlugin {
 }
 
 /**
  * @export
- * @namespace TelegrafPluginInputNgnixRequest
+ * @namespace TelegrafPluginInputNginxRequest
  */
-export namespace TelegrafPluginInputNgnixRequest {
+export namespace TelegrafPluginInputNginxRequest {
 }
 
 /**

--- a/ui/src/onboarding/OnboardingWizard.scss
+++ b/ui/src/onboarding/OnboardingWizard.scss
@@ -204,6 +204,10 @@
   font-weight: 400;
   color: $g11-sidewalk;
   @include no-user-select();
+
+  a {
+    color: $c-pool;
+  }
 }
 
 /* Streaming */

--- a/ui/src/onboarding/components/configureStep/streaming/PluginConfigForm.tsx
+++ b/ui/src/onboarding/components/configureStep/streaming/PluginConfigForm.tsx
@@ -52,6 +52,15 @@ class PluginConfigForm extends PureComponent<Props> {
           <FancyScrollbar autoHide={false}>
             <div className="wizard-step--scroll-content">
               <h3 className="wizard-step--title">{_.startCase(name)}</h3>
+              <h5 className="wizard-step--sub-title">
+                For more information about this plugin, see{' '}
+                <a
+                  target="_blank"
+                  href={`https://github.com/influxdata/telegraf/tree/master/plugins/inputs/${name}`}
+                >
+                  Documentation
+                </a>
+              </h5>
               <ConfigFieldHandler
                 configFields={configFields}
                 telegrafPlugin={telegrafPlugin}

--- a/ui/src/onboarding/constants/pluginConfigs.ts
+++ b/ui/src/onboarding/constants/pluginConfigs.ts
@@ -17,7 +17,7 @@ import {
   TelegrafPluginInputMem,
   TelegrafPluginInputNet,
   TelegrafPluginInputNetResponse,
-  TelegrafPluginInputNgnix,
+  TelegrafPluginInputNginx,
   TelegrafPluginInputProcesses,
   TelegrafPluginInputProcstat,
   TelegrafPluginInputPrometheus,
@@ -45,7 +45,7 @@ export const pluginsByBundle: PluginBundles = {
   ],
   [BundleName.Docker]: [TelegrafPluginInputDocker.NameEnum.Docker],
   [BundleName.Kubernetes]: [TelegrafPluginInputKubernetes.NameEnum.Kubernetes],
-  [BundleName.Ngnix]: [TelegrafPluginInputNgnix.NameEnum.Ngnix],
+  [BundleName.Nginx]: [TelegrafPluginInputNginx.NameEnum.Nginx],
   [BundleName.Redis]: [TelegrafPluginInputRedis.NameEnum.Redis],
 }
 
@@ -153,11 +153,11 @@ export const telegrafPluginsInfo: TelegrafPluginInfo = {
       config: {},
     },
   },
-  [TelegrafPluginInputNgnix.NameEnum.Ngnix]: {
+  [TelegrafPluginInputNginx.NameEnum.Nginx]: {
     fields: null,
     defaults: {
-      name: TelegrafPluginInputNgnix.NameEnum.Ngnix,
-      type: TelegrafPluginInputNgnix.TypeEnum.Input,
+      name: TelegrafPluginInputNginx.NameEnum.Nginx,
+      type: TelegrafPluginInputNginx.TypeEnum.Input,
       config: {},
     },
   },
@@ -242,7 +242,7 @@ export const PLUGIN_OPTIONS: TelegrafPluginName[] = [
   TelegrafPluginInputMem.NameEnum.Mem,
   TelegrafPluginInputNet.NameEnum.Net,
   TelegrafPluginInputNetResponse.NameEnum.NetResponse,
-  TelegrafPluginInputNgnix.NameEnum.Ngnix,
+  TelegrafPluginInputNginx.NameEnum.Nginx,
   TelegrafPluginInputProcesses.NameEnum.Processes,
   TelegrafPluginInputProcstat.NameEnum.Procstat,
   TelegrafPluginInputPrometheus.NameEnum.Prometheus,
@@ -265,7 +265,7 @@ export const BUNDLE_LOGOS = {
   [BundleName.System]: LogoCpu,
   [BundleName.Docker]: LogoDocker,
   [BundleName.Kubernetes]: LogoKubernetes,
-  [BundleName.Ngnix]: LogoNginx,
+  [BundleName.Nginx]: LogoNginx,
   [BundleName.Redis]: LogoRedis,
 }
 
@@ -273,6 +273,6 @@ export const PLUGIN_BUNDLE_OPTIONS: BundleName[] = [
   BundleName.System,
   BundleName.Docker,
   BundleName.Kubernetes,
-  BundleName.Ngnix,
+  BundleName.Nginx,
   BundleName.Redis,
 ]

--- a/ui/src/types/v2/dataLoaders.ts
+++ b/ui/src/types/v2/dataLoaders.ts
@@ -11,7 +11,7 @@ import {
   TelegrafPluginInputMem,
   TelegrafPluginInputNet,
   TelegrafPluginInputNetResponse,
-  TelegrafPluginInputNgnix,
+  TelegrafPluginInputNginx,
   TelegrafPluginInputProcesses,
   TelegrafPluginInputProcstat,
   TelegrafPluginInputPrometheus,
@@ -94,7 +94,7 @@ export type Plugin =
   | TelegrafPluginInputMem
   | TelegrafPluginInputNet
   | TelegrafPluginInputNetResponse
-  | TelegrafPluginInputNgnix
+  | TelegrafPluginInputNginx
   | TelegrafPluginInputProcesses
   | TelegrafPluginInputProcstat
   | TelegrafPluginInputPrometheus
@@ -117,7 +117,7 @@ export enum BundleName {
   System = 'System',
   Docker = 'Docker',
   Kubernetes = 'Kubernetes',
-  Ngnix = 'NGNIX',
+  Nginx = 'NGINX',
   Redis = 'Redis',
 }
 
@@ -133,7 +133,7 @@ export type TelegrafPluginName =
   | TelegrafPluginInputMem.NameEnum.Mem
   | TelegrafPluginInputNet.NameEnum.Net
   | TelegrafPluginInputNetResponse.NameEnum.NetResponse
-  | TelegrafPluginInputNgnix.NameEnum.Ngnix
+  | TelegrafPluginInputNginx.NameEnum.Nginx
   | TelegrafPluginInputProcesses.NameEnum.Processes
   | TelegrafPluginInputProcstat.NameEnum.Procstat
   | TelegrafPluginInputPrometheus.NameEnum.Prometheus


### PR DESCRIPTION
Closes #10886

_Briefly describe your proposed changes:_
Add links on the plugin forms to telegraf plugin docs.
Additionally fix a typo. `ngnix` -> `nginx`

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
