### PR TITLE
Labels v2

### DIFF
--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -602,11 +602,6 @@ func (c *Client) deleteBucket(ctx context.Context, tx *bolt.Tx, id platform.ID) 
 		}
 	}
 
-	// if err := c.deleteLabels(ctx, tx, platform.LabelFilter{ResourceID: id}); err != nil {
-	// 	return &platform.Error{
-	// 		Err: err,
-	// 	}
-	// }
 	return nil
 }
 

--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -602,11 +602,11 @@ func (c *Client) deleteBucket(ctx context.Context, tx *bolt.Tx, id platform.ID) 
 		}
 	}
 
-	if err := c.deleteLabels(ctx, tx, platform.LabelFilter{ResourceID: id}); err != nil {
-		return &platform.Error{
-			Err: err,
-		}
-	}
+	// if err := c.deleteLabels(ctx, tx, platform.LabelFilter{ResourceID: id}); err != nil {
+	// 	return &platform.Error{
+	// 		Err: err,
+	// 	}
+	// }
 	return nil
 }
 

--- a/bolt/dashboard.go
+++ b/bolt/dashboard.go
@@ -823,12 +823,12 @@ func (c *Client) deleteDashboard(ctx context.Context, tx *bolt.Tx, id platform.I
 		}
 	}
 
-	err = c.deleteLabels(ctx, tx, platform.LabelFilter{ResourceID: id})
-	if err != nil {
-		return &platform.Error{
-			Err: err,
-		}
-	}
+	// err = c.deleteLabels(ctx, tx, platform.LabelFilter{ResourceID: id})
+	// if err != nil {
+	// 	return &platform.Error{
+	// 		Err: err,
+	// 	}
+	// }
 
 	// TODO(desa): add DeleteKeyValueLog method and use it here.
 	err = c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{

--- a/bolt/dashboard.go
+++ b/bolt/dashboard.go
@@ -823,13 +823,6 @@ func (c *Client) deleteDashboard(ctx context.Context, tx *bolt.Tx, id platform.I
 		}
 	}
 
-	// err = c.deleteLabels(ctx, tx, platform.LabelFilter{ResourceID: id})
-	// if err != nil {
-	// 	return &platform.Error{
-	// 		Err: err,
-	// 	}
-	// }
-
 	// TODO(desa): add DeleteKeyValueLog method and use it here.
 	err = c.deleteUserResourceMappings(ctx, tx, platform.UserResourceMappingFilter{
 		ResourceID:   id,

--- a/bolt/label.go
+++ b/bolt/label.go
@@ -75,21 +75,6 @@ func filterLabelsFn(filter platform.LabelFilter) func(l *platform.Label) bool {
 	}
 }
 
-// func (c *Client) findLabel(ctx context.Context, tx *bolt.Tx, resourceID platform.ID, name string) (*platform.Label, error) {
-// 	key, err := labelKey(&platform.Label{ResourceID: resourceID, Name: name})
-// 	if err != nil {
-// 		return nil, err
-// 	}
-//
-// 	l := &platform.Label{}
-// 	v := tx.Bucket(labelBucket).Get(key)
-// 	if err := json.Unmarshal(v, l); err != nil {
-// 		return nil, err
-// 	}
-//
-// 	return l, nil
-// }
-
 // FindLabels returns a list of labels that match a filter.
 func (c *Client) FindLabels(ctx context.Context, filter platform.LabelFilter, opt ...platform.FindOptions) ([]*platform.Label, error) {
 	ls := []*platform.Label{}
@@ -124,6 +109,18 @@ func (c *Client) findLabels(ctx context.Context, tx *bolt.Tx, filter platform.La
 	}
 
 	return ls, nil
+}
+
+func (c *Client) FindResourceLabels(ctx context.Context, filter platform.LabelMappingFilter) ([]*platform.Label, error) {
+	return nil, nil
+}
+
+func (c *Client) CreateLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	return nil
+}
+
+func (c *Client) DeleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	return nil
 }
 
 func (c *Client) CreateLabel(ctx context.Context, l *platform.Label) error {

--- a/bolt/label.go
+++ b/bolt/label.go
@@ -161,9 +161,10 @@ func (c *Client) FindResourceLabels(ctx context.Context, filter platform.LabelMa
 			}
 
 			l, err := c.findLabelByID(ctx, tx, id)
-			// TODO(jm): why the heck is it finding the label and returning an error?
 			if l == nil && err != nil {
-				return err
+				// TODO(jm): return error instead of continuing once orphaned mappings are fixed
+				// (see https://github.com/influxdata/influxdb/issues/11278)
+				continue
 			}
 
 			ls = append(ls, l)

--- a/bolt/label.go
+++ b/bolt/label.go
@@ -182,10 +182,17 @@ func (c *Client) FindResourceLabels(ctx context.Context, filter platform.LabelMa
 	return ls, nil
 }
 
-// func (c *Client) findResourceLabels(ctx context.Context, )
-
+// CreateLabelMapping creates a new mapping between a resource and a label.
 func (c *Client) CreateLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
-	err := c.db.Update(func(tx *bolt.Tx) error {
+	_, err := c.FindLabelByID(ctx, *m.LabelID)
+	if err != nil {
+		return &platform.Error{
+			Err: err,
+			Op:  getOp(platform.OpCreateLabel),
+		}
+	}
+
+	err = c.db.Update(func(tx *bolt.Tx) error {
 		return c.putLabelMapping(ctx, tx, m)
 	})
 
@@ -199,6 +206,7 @@ func (c *Client) CreateLabelMapping(ctx context.Context, m *platform.LabelMappin
 	return nil
 }
 
+// DeleteLabelMapping deletes a label mapping.
 func (c *Client) DeleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
 	err := c.db.Update(func(tx *bolt.Tx) error {
 		return c.deleteLabelMapping(ctx, tx, m)
@@ -229,6 +237,7 @@ func (c *Client) deleteLabelMapping(ctx context.Context, tx *bolt.Tx, m *platfor
 	return nil
 }
 
+// CreateLabel creates a new label.
 func (c *Client) CreateLabel(ctx context.Context, l *platform.Label) error {
 	err := c.db.Update(func(tx *bolt.Tx) error {
 		l.ID = c.IDGenerator.ID()
@@ -245,6 +254,7 @@ func (c *Client) CreateLabel(ctx context.Context, l *platform.Label) error {
 	return nil
 }
 
+// PutLabel creates a label from the provided struct, without generating a new ID.
 func (c *Client) PutLabel(ctx context.Context, l *platform.Label) error {
 	return c.db.Update(func(tx *bolt.Tx) error {
 		var err error

--- a/bolt/label_test.go
+++ b/bolt/label_test.go
@@ -23,6 +23,12 @@ func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.Lab
 		}
 	}
 
+	for _, m := range f.Mappings {
+		if err := c.PutLabelMapping(ctx, m); err != nil {
+			t.Fatalf("failed to populate label mappings: %v", err)
+		}
+	}
+
 	return c, bolt.OpPrefix, func() {
 		defer closeFn()
 		for _, l := range f.Labels {

--- a/bolt/label_test.go
+++ b/bolt/label_test.go
@@ -24,7 +24,7 @@ func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.Lab
 	return c, bolt.OpPrefix, func() {
 		defer closeFn()
 		for _, l := range f.Labels {
-			if err := c.DeleteLabel(ctx, *l); err != nil {
+			if err := c.DeleteLabel(ctx, l.ID); err != nil {
 				t.Logf("failed to remove label: %v", err)
 			}
 		}

--- a/bolt/label_test.go
+++ b/bolt/label_test.go
@@ -14,10 +14,12 @@ func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.Lab
 	if err != nil {
 		t.Fatalf("failed to create new bolt client: %v", err)
 	}
+	c.IDGenerator = f.IDGenerator
+
 	ctx := context.Background()
 	for _, l := range f.Labels {
-		if err := c.CreateLabel(ctx, l); err != nil {
-			t.Fatalf("failed to populate labels")
+		if err := c.PutLabel(ctx, l); err != nil {
+			t.Fatalf("failed to populate labels: %v", err)
 		}
 	}
 

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -19,6 +19,7 @@ type APIHandler struct {
 	OrgHandler           *OrgHandler
 	AuthorizationHandler *AuthorizationHandler
 	DashboardHandler     *DashboardHandler
+	LabelHandler         *LabelHandler
 	AssetHandler         *AssetHandler
 	ChronografHandler    *ChronografHandler
 	ScraperHandler       *ScraperHandler
@@ -80,6 +81,9 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.BucketHandler.BucketService = authorizer.NewBucketService(b.BucketService)
 	h.BucketHandler.OrganizationService = b.OrganizationService
 	h.BucketHandler.BucketOperationLogService = b.BucketOperationLogService
+
+	h.LabelHandler = NewLabelHandler()
+	h.LabelHandler.LabelService = b.LabelService
 
 	h.OrgHandler = NewOrgHandler(b.UserResourceMappingService, b.LabelService, b.UserService)
 	h.OrgHandler.OrganizationService = authorizer.NewOrgService(b.OrganizationService)
@@ -159,6 +163,7 @@ var apiLinks = map[string]interface{}{
 	"external": map[string]string{
 		"statusFeed": "https://www.influxdata.com/feed/json",
 	},
+	"labels": "/api/v2/labels",
 	"macros": "/api/v2/macros",
 	"me":     "/api/v2/me",
 	"orgs":   "/api/v2/orgs",
@@ -229,6 +234,11 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if strings.HasPrefix(r.URL.Path, "/api/v2/buckets") {
 		h.BucketHandler.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/api/v2/labels") {
+		h.LabelHandler.ServeHTTP(w, r)
 		return
 	}
 

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -220,7 +220,7 @@ type bucketsResponse struct {
 func newBucketsResponse(ctx context.Context, opts platform.FindOptions, f platform.BucketFilter, bs []*platform.Bucket, labelService platform.LabelService) *bucketsResponse {
 	rs := make([]*bucketResponse, 0, len(bs))
 	for _, b := range bs {
-		labels, _ := labelService.FindLabels(ctx, platform.LabelFilter{ResourceID: b.ID})
+		labels, _ := labelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: b.ID})
 		rs = append(rs, newBucketResponse(b, labels))
 	}
 	return &bucketsResponse{
@@ -305,7 +305,7 @@ func (h *BucketHandler) handleGetBucket(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{ResourceID: b.ID})
+	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: b.ID})
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return
@@ -452,7 +452,7 @@ func (h *BucketHandler) handlePatchBucket(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{ResourceID: b.ID})
+	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: b.ID})
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -71,7 +71,6 @@ func NewBucketHandler(mappingService platform.UserResourceMappingService, labelS
 	h.HandlerFunc("GET", bucketsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", bucketsIDLabelsPath, newPostLabelHandler(h.LabelService))
 	h.HandlerFunc("DELETE", bucketsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
-	h.HandlerFunc("PATCH", bucketsIDLabelsNamePath, newPatchLabelHandler(h.LabelService))
 
 	return h
 }
@@ -436,7 +435,7 @@ func decodeGetBucketsRequest(ctx context.Context, r *http.Request) (*getBucketsR
 	return req, nil
 }
 
-// handlePatchBucket is the HTTP handler for the PATH /api/v2/buckets route.
+// handlePatchBucket is the HTTP handler for the PATCH /api/v2/buckets route.
 func (h *BucketHandler) handlePatchBucket(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -31,15 +31,15 @@ type BucketHandler struct {
 }
 
 const (
-	bucketsPath             = "/api/v2/buckets"
-	bucketsIDPath           = "/api/v2/buckets/:id"
-	bucketsIDLogPath        = "/api/v2/buckets/:id/log"
-	bucketsIDMembersPath    = "/api/v2/buckets/:id/members"
-	bucketsIDMembersIDPath  = "/api/v2/buckets/:id/members/:userID"
-	bucketsIDOwnersPath     = "/api/v2/buckets/:id/owners"
-	bucketsIDOwnersIDPath   = "/api/v2/buckets/:id/owners/:userID"
-	bucketsIDLabelsPath     = "/api/v2/buckets/:id/labels"
-	bucketsIDLabelsIDPath = "/api/v2/buckets/:id/labels/:lid"
+	bucketsPath            = "/api/v2/buckets"
+	bucketsIDPath          = "/api/v2/buckets/:id"
+	bucketsIDLogPath       = "/api/v2/buckets/:id/log"
+	bucketsIDMembersPath   = "/api/v2/buckets/:id/members"
+	bucketsIDMembersIDPath = "/api/v2/buckets/:id/members/:userID"
+	bucketsIDOwnersPath    = "/api/v2/buckets/:id/owners"
+	bucketsIDOwnersIDPath  = "/api/v2/buckets/:id/owners/:userID"
+	bucketsIDLabelsPath    = "/api/v2/buckets/:id/labels"
+	bucketsIDLabelsIDPath  = "/api/v2/buckets/:id/labels/:lid"
 )
 
 // NewBucketHandler returns a new instance of BucketHandler.

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -39,7 +39,7 @@ const (
 	bucketsIDOwnersPath     = "/api/v2/buckets/:id/owners"
 	bucketsIDOwnersIDPath   = "/api/v2/buckets/:id/owners/:userID"
 	bucketsIDLabelsPath     = "/api/v2/buckets/:id/labels"
-	bucketsIDLabelsNamePath = "/api/v2/buckets/:id/labels/:name"
+	bucketsIDLabelsNamePath = "/api/v2/buckets/:id/labels/:lid"
 )
 
 // NewBucketHandler returns a new instance of BucketHandler.

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -39,7 +39,7 @@ const (
 	bucketsIDOwnersPath     = "/api/v2/buckets/:id/owners"
 	bucketsIDOwnersIDPath   = "/api/v2/buckets/:id/owners/:userID"
 	bucketsIDLabelsPath     = "/api/v2/buckets/:id/labels"
-	bucketsIDLabelsNamePath = "/api/v2/buckets/:id/labels/:lid"
+	bucketsIDLabelsIDPath = "/api/v2/buckets/:id/labels/:lid"
 )
 
 // NewBucketHandler returns a new instance of BucketHandler.
@@ -70,7 +70,7 @@ func NewBucketHandler(mappingService platform.UserResourceMappingService, labelS
 
 	h.HandlerFunc("GET", bucketsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", bucketsIDLabelsPath, newPostLabelHandler(h.LabelService))
-	h.HandlerFunc("DELETE", bucketsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
+	h.HandlerFunc("DELETE", bucketsIDLabelsIDPath, newDeleteLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -60,11 +60,11 @@ func TestService_handleGetBuckets(t *testing.T) {
 					},
 				},
 				&mock.LabelService{
-					FindLabelsFn: func(ctx context.Context, f platform.LabelFilter) ([]*platform.Label, error) {
+					FindResourceLabelsFn: func(ctx context.Context, f platform.LabelMappingFilter) ([]*platform.Label, error) {
 						labels := []*platform.Label{
 							{
-								ResourceID: f.ResourceID,
-								Name:       "label",
+								ID:   platformtesting.MustIDBase16("fc3dc670a4be9b9a"),
+								Name: "label",
 								Properties: map[string]string{
 									"color": "fff000",
 								},
@@ -102,7 +102,7 @@ func TestService_handleGetBuckets(t *testing.T) {
       "retentionRules": [{"type": "expire", "everySeconds": 2}],
 			"labels": [
         {
-          "resourceID": "0b501e7e557ab1ed",
+          "id": "fc3dc670a4be9b9a",
           "name": "label",
           "properties": {
             "color": "fff000"
@@ -123,7 +123,7 @@ func TestService_handleGetBuckets(t *testing.T) {
       "retentionRules": [{"type": "expire", "everySeconds": 86400}],
       "labels": [
         {
-          "resourceID": "c0175f0077a77005",
+          "id": "fc3dc670a4be9b9a",
           "name": "label",
           "properties": {
             "color": "fff000"

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -81,7 +81,6 @@ func NewDashboardHandler(mappingService platform.UserResourceMappingService, lab
 	h.HandlerFunc("GET", dashboardsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", dashboardsIDLabelsPath, newPostLabelHandler(h.LabelService))
 	h.HandlerFunc("DELETE", dashboardsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
-	h.HandlerFunc("PATCH", dashboardsIDLabelsNamePath, newPatchLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -41,7 +41,7 @@ const (
 	dashboardsIDOwnersPath      = "/api/v2/dashboards/:id/owners"
 	dashboardsIDOwnersIDPath    = "/api/v2/dashboards/:id/owners/:userID"
 	dashboardsIDLabelsPath      = "/api/v2/dashboards/:id/labels"
-	dashboardsIDLabelsIDPath  = "/api/v2/dashboards/:id/labels/:lid"
+	dashboardsIDLabelsIDPath    = "/api/v2/dashboards/:id/labels/:lid"
 )
 
 // NewDashboardHandler returns a new instance of DashboardHandler.

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -332,7 +332,7 @@ func newGetDashboardsResponse(ctx context.Context, dashboards []*platform.Dashbo
 
 	for _, dashboard := range dashboards {
 		if dashboard != nil {
-			labels, _ := labelService.FindLabels(ctx, platform.LabelFilter{ResourceID: dashboard.ID})
+			labels, _ := labelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: dashboard.ID})
 			res.Dashboards = append(res.Dashboards, newDashboardResponse(dashboard, labels))
 		}
 	}
@@ -390,7 +390,7 @@ func (h *DashboardHandler) handleGetDashboard(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{ResourceID: dashboard.ID})
+	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: dashboard.ID})
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return
@@ -542,7 +542,7 @@ func (h *DashboardHandler) handlePatchDashboard(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{ResourceID: dashboard.ID})
+	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: dashboard.ID})
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -41,7 +41,7 @@ const (
 	dashboardsIDOwnersPath      = "/api/v2/dashboards/:id/owners"
 	dashboardsIDOwnersIDPath    = "/api/v2/dashboards/:id/owners/:userID"
 	dashboardsIDLabelsPath      = "/api/v2/dashboards/:id/labels"
-	dashboardsIDLabelsNamePath  = "/api/v2/dashboards/:id/labels/:name"
+	dashboardsIDLabelsNamePath  = "/api/v2/dashboards/:id/labels/:lid"
 )
 
 // NewDashboardHandler returns a new instance of DashboardHandler.

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -41,7 +41,7 @@ const (
 	dashboardsIDOwnersPath      = "/api/v2/dashboards/:id/owners"
 	dashboardsIDOwnersIDPath    = "/api/v2/dashboards/:id/owners/:userID"
 	dashboardsIDLabelsPath      = "/api/v2/dashboards/:id/labels"
-	dashboardsIDLabelsNamePath  = "/api/v2/dashboards/:id/labels/:lid"
+	dashboardsIDLabelsIDPath  = "/api/v2/dashboards/:id/labels/:lid"
 )
 
 // NewDashboardHandler returns a new instance of DashboardHandler.
@@ -80,7 +80,7 @@ func NewDashboardHandler(mappingService platform.UserResourceMappingService, lab
 
 	h.HandlerFunc("GET", dashboardsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", dashboardsIDLabelsPath, newPostLabelHandler(h.LabelService))
-	h.HandlerFunc("DELETE", dashboardsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
+	h.HandlerFunc("DELETE", dashboardsIDLabelsIDPath, newDeleteLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -76,11 +76,11 @@ func TestService_handleGetDashboards(t *testing.T) {
 					},
 				},
 				&mock.LabelService{
-					FindLabelsFn: func(ctx context.Context, f platform.LabelFilter) ([]*platform.Label, error) {
+					FindResourceLabelsFn: func(ctx context.Context, f platform.LabelMappingFilter) ([]*platform.Label, error) {
 						labels := []*platform.Label{
 							{
-								ResourceID: f.ResourceID,
-								Name:       "label",
+								ID:   platformtesting.MustIDBase16("fc3dc670a4be9b9a"),
+								Name: "label",
 								Properties: map[string]string{
 									"color": "fff000",
 								},
@@ -107,7 +107,7 @@ func TestService_handleGetDashboards(t *testing.T) {
       "description": "oh hello there!",
       "labels": [
         {
-          "resourceID": "da7aba5e5d81e550",
+          "id": "fc3dc670a4be9b9a",
           "name": "label",
           "properties": {
             "color": "fff000"
@@ -148,7 +148,7 @@ func TestService_handleGetDashboards(t *testing.T) {
       "description": "",
 			"labels": [
         {
-          "resourceID": "0ca2204eca2204e0",
+          "id": "fc3dc670a4be9b9a",
           "name": "label",
           "properties": {
             "color": "fff000"
@@ -184,7 +184,7 @@ func TestService_handleGetDashboards(t *testing.T) {
 					},
 				},
 				&mock.LabelService{
-					FindLabelsFn: func(ctx context.Context, f platform.LabelFilter) ([]*platform.Label, error) {
+					FindResourceLabelsFn: func(ctx context.Context, f platform.LabelMappingFilter) ([]*platform.Label, error) {
 						return []*platform.Label{}, nil
 					},
 				},

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -231,11 +231,11 @@ func TestService_handleGetDashboards(t *testing.T) {
 					},
 				},
 				&mock.LabelService{
-					FindLabelsFn: func(ctx context.Context, f platform.LabelFilter) ([]*platform.Label, error) {
+					FindResourceLabelsFn: func(ctx context.Context, f platform.LabelMappingFilter) ([]*platform.Label, error) {
 						labels := []*platform.Label{
 							{
-								ResourceID: f.ResourceID,
-								Name:       "label",
+								ID:   platformtesting.MustIDBase16("fc3dc670a4be9b9a"),
+								Name: "label",
 								Properties: map[string]string{
 									"color": "fff000",
 								},
@@ -267,16 +267,16 @@ func TestService_handleGetDashboards(t *testing.T) {
       "meta": {
         "createdAt": "2009-11-10T23:00:00Z",
         "updatedAt": "2009-11-11T00:00:00Z"
-	  },
-	  "labels": [
-		  {
-			"resourceID": "da7aba5e5d81e550",
-			"name": "label",
-			"properties": {
-			  "color": "fff000"
-			}
-		  }
-	  ],
+    },
+    "labels": [
+      {
+        "id": "fc3dc670a4be9b9a",
+        "name": "label",
+        "properties": {
+          "color": "fff000"
+        }
+      }
+    ],
       "cells": [
         {
           "id": "da7aba5e5d81e550",

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -73,7 +73,10 @@ type postLabelRequest struct {
 
 func (b postLabelRequest) Validate() error {
 	if b.Label.Name == "" {
-		return fmt.Errorf("label requires a name")
+		return &platform.Error{
+			Code: platform.EInvalid,
+			Msg:  "label requires a name",
+		}
 	}
 	return nil
 }
@@ -81,7 +84,11 @@ func (b postLabelRequest) Validate() error {
 func decodePostLabelRequest(ctx context.Context, r *http.Request) (*postLabelRequest, error) {
 	l := &platform.Label{}
 	if err := json.NewDecoder(r.Body).Decode(l); err != nil {
-		return nil, err
+		return nil, &platform.Error{
+			Code: platform.EInvalid,
+			Msg:  "unable to decode label request",
+			Err:  err,
+		}
 	}
 
 	req := &postLabelRequest{
@@ -138,7 +145,10 @@ func decodeGetLabelRequest(ctx context.Context, r *http.Request) (*getLabelReque
 	params := httprouter.ParamsFromContext(ctx)
 	id := params.ByName("id")
 	if id == "" {
-		return nil, errors.InvalidDataf("url missing id")
+		return nil, &platform.Error{
+			Code: platform.EInvalid,
+			Msg:  "label id is not valid",
+		}
 	}
 
 	var i platform.ID

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -177,7 +177,7 @@ func newPostLabelHandler(s platform.LabelService) http.HandlerFunc {
 			return
 		}
 
-		label, err := s.FindLabelByID(ctx, req.Mapping.LabelID)
+		label, err := s.FindLabelByID(ctx, *req.Mapping.LabelID)
 		if err != nil {
 			EncodeError(ctx, err, w)
 			return
@@ -214,7 +214,7 @@ func decodePostLabelRequest(ctx context.Context, r *http.Request) (*postLabelReq
 		return nil, err
 	}
 
-	mapping.ResourceID = rid
+	mapping.ResourceID = &rid
 
 	if err := mapping.Validate(); err != nil {
 		return nil, err
@@ -305,8 +305,8 @@ func newDeleteLabelHandler(s platform.LabelService) http.HandlerFunc {
 		}
 
 		mapping := &platform.LabelMapping{
-			LabelID:    req.LabelID,
-			ResourceID: req.ResourceID,
+			LabelID:    &req.LabelID,
+			ResourceID: &req.ResourceID,
 		}
 
 		if err := s.DeleteLabelMapping(ctx, mapping); err != nil {
@@ -407,7 +407,7 @@ func (s *LabelService) CreateLabelMapping(ctx context.Context, m *platform.Label
 		return err
 	}
 
-	url, err := newURL(s.Addr, resourceIDPath(s.BasePath, m.ResourceID))
+	url, err := newURL(s.Addr, resourceIDPath(s.BasePath, *m.ResourceID))
 	if err != nil {
 		return err
 	}
@@ -469,7 +469,7 @@ func (s *LabelService) DeleteLabel(ctx context.Context, id platform.ID) error {
 }
 
 func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
-	url, err := newURL(s.Addr, labelNamePath(s.BasePath, m.ResourceID, m.LabelID))
+	url, err := newURL(s.Addr, labelNamePath(s.BasePath, *m.ResourceID, *m.LabelID))
 	if err != nil {
 		return err
 	}

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -265,7 +265,7 @@ func newPatchLabelHandler(s platform.LabelService) http.HandlerFunc {
 			return
 		}
 
-		label, err := s.UpdateLabel(ctx, req.label, req.upd)
+		label, err := s.UpdateLabel(ctx, req.label.ID, req.upd)
 		if err != nil {
 			EncodeError(ctx, err, w)
 			return
@@ -431,7 +431,7 @@ func (s *LabelService) CreateLabelMapping(ctx context.Context, m *platform.Label
 	return nil
 }
 
-func (s *LabelService) UpdateLabel(ctx context.Context, l *platform.Label, upd platform.LabelUpdate) (*platform.Label, error) {
+func (s *LabelService) UpdateLabel(ctx context.Context, id platform.ID, upd platform.LabelUpdate) (*platform.Label, error) {
 	return nil, nil
 }
 

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -45,7 +45,19 @@ func (h *LabelHandler) handlePostLabel(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *LabelHandler) handleGetLabels(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 
+	labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{})
+	if err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
+
+	err = encodeResponse(ctx, w, http.StatusOK, newLabelsResponse(labels))
+	if err != nil {
+		EncodeError(ctx, err, w)
+		return
+	}
 }
 
 // func (h *LabelHandler) handleGetLabel(w http.ResponseWriter, r *http.Request) {}

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -13,6 +13,51 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// LabelHandler represents an HTTP API handler for labels
+type LabelHandler struct {
+	*httprouter.Router
+}
+
+const (
+	labelsPath   = "/api/v2/labels"
+	labelsIDPath = "/api/v2/labels/:id"
+)
+
+// NewLabelHandler returns a new instance of LabelHandler
+func NewLabelHandler() *LabelHandler {
+	h := &LabelHandler{
+		Router: NewRouter(),
+	}
+
+	h.HandlerFunc("POST", labelsPath, h.handlePostLabel)
+	h.HandlerFunc("GET", labelsPath, h.handleGetLabels)
+
+	// h.HandlerFunc("GET", labelsIDPath, h.handleGetLabel)
+	h.HandlerFunc("PATCH", labelsIDPath, h.handlePatchLabel)
+	h.HandlerFunc("DELETE", labelsIDPath, h.handleDeleteLabel)
+
+	return h
+}
+
+func (h *LabelHandler) handlePostLabel(w http.ResponseWriter, r *http.Request) {
+
+}
+
+func (h *LabelHandler) handleGetLabels(w http.ResponseWriter, r *http.Request) {
+
+}
+
+// func (h *LabelHandler) handleGetLabel(w http.ResponseWriter, r *http.Request) {}
+
+func (h *LabelHandler) handlePatchLabel(w http.ResponseWriter, r *http.Request) {
+
+}
+
+func (h *LabelHandler) handleDeleteLabel(w http.ResponseWriter, r *http.Request) {
+
+}
+
+// LabelService connects to Influx via HTTP using tokens to manage labels
 type LabelService struct {
 	Addr               string
 	Token              string

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -163,7 +163,13 @@ func newPostLabelHandler(s plat.LabelService) http.HandlerFunc {
 			return
 		}
 
-		if err := encodeResponse(ctx, w, http.StatusCreated, newLabelResponse(&req.Mapping)); err != nil {
+		label, err := s.FindLabelByID(ctx, req.Mapping.LabelID)
+		if err != nil {
+			EncodeError(ctx, err, w)
+			return
+		}
+
+		if err := encodeResponse(ctx, w, http.StatusCreated, newLabelResponse(label)); err != nil {
 			// TODO: this can potentially result in calling w.WriteHeader multiple times, we need to pass a logger in here
 			// some how. This isn't as simple as simply passing in a logger to this function since the time that this function
 			// is called is distinct from the time that a potential logger is set.

--- a/http/label_test.go
+++ b/http/label_test.go
@@ -58,50 +58,22 @@ func TestService_handleGetLabels(t *testing.T) {
 				body: `
 {
   "links": {
-    "self": "/api/v2/labels",
+    "self": "/api/v2/labels"
   },
   "labels": [
     {
-      "links": {
-        "org": "/api/v2/orgs/50f7ba1150f7ba11",
-        "self": "/api/v2/labels/0b501e7e557ab1ed",
-        "log": "/api/v2/labels/0b501e7e557ab1ed/log",
-        "labels": "/api/v2/labels/0b501e7e557ab1ed/labels"
-      },
       "id": "0b501e7e557ab1ed",
-      "organizationID": "50f7ba1150f7ba11",
       "name": "hello",
-      "retentionRules": [{"type": "expire", "everySeconds": 2}],
-      "labels": [
-        {
-          "resourceID": "0b501e7e557ab1ed",
-          "name": "label",
-          "properties": {
-            "color": "fff000"
-          }
-        }
-      ]
+      "properties": {
+        "color": "fff000"
+      }
     },
     {
-      "links": {
-        "org": "/api/v2/orgs/7e55e118dbabb1ed",
-        "self": "/api/v2/labels/c0175f0077a77005",
-        "log": "/api/v2/labels/c0175f0077a77005/log",
-        "labels": "/api/v2/labels/c0175f0077a77005/labels"
-      },
       "id": "c0175f0077a77005",
-      "organizationID": "7e55e118dbabb1ed",
       "name": "example",
-      "retentionRules": [{"type": "expire", "everySeconds": 86400}],
-      "labels": [
-        {
-          "resourceID": "c0175f0077a77005",
-          "name": "label",
-          "properties": {
-            "color": "fff000"
-          }
-        }
-      ]
+      "properties": {
+        "color": "fff000"
+      }
     }
   ]
 }

--- a/http/label_test.go
+++ b/http/label_test.go
@@ -1,0 +1,221 @@
+package http
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/inmem"
+	platformtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestService_handleGetLabels(t *testing.T) {
+  type fields struct {
+    LabelService  platform.LabelService
+  }
+  type args struct {
+    queryParams map[string][]string
+  }
+  type wants struct {
+    statusCode  int
+    contentType string
+    body        string
+  }
+
+  tests := []struct {
+    name   string
+    fields fields
+    args   args
+    wants  wants
+  }{
+    {
+      name: "get all labels",
+      fields: fields{
+        &mock.LabelService{
+          FindLabelsFn: func(ctx context.Context, filter platform.LabelFilter, opts ...platform.FindOptions) ([]*platform.Label, int, error) {
+            return []*platform.Label{
+              {
+                ID:              platformtesting.MustIDBase16("0b501e7e557ab1ed"),
+                Name:            "hello",
+                OrganizationID:  platformtesting.MustIDBase16("50f7ba1150f7ba11"),
+                RetentionPeriod: 2 * time.Second,
+              },
+              {
+                ID:              platformtesting.MustIDBase16("c0175f0077a77005"),
+                Name:            "example",
+                OrganizationID:  platformtesting.MustIDBase16("7e55e118dbabb1ed"),
+                RetentionPeriod: 24 * time.Hour,
+              },
+            }, 2, nil
+          },
+        },
+        &mock.LabelService{
+          FindLabelsFn: func(ctx context.Context, f platform.LabelFilter) ([]*platform.Label, error) {
+            labels := []*platform.Label{
+              {
+                ResourceID: f.ResourceID,
+                Name:       "label",
+                Properties: map[string]string{
+                  "color": "fff000",
+                },
+              },
+            }
+            return labels, nil
+          },
+        },
+      },
+      args: args{
+        map[string][]string{
+          "limit": {"1"},
+        },
+      },
+      wants: wants{
+        statusCode:  http.StatusOK,
+        contentType: "application/json; charset=utf-8",
+        body: `
+{
+  "links": {
+    "self": "/api/v2/labels?descending=false&limit=1&offset=0",
+    "next": "/api/v2/labels?descending=false&limit=1&offset=1"
+  },
+  "labels": [
+    {
+      "links": {
+        "org": "/api/v2/orgs/50f7ba1150f7ba11",
+        "self": "/api/v2/labels/0b501e7e557ab1ed",
+        "log": "/api/v2/labels/0b501e7e557ab1ed/log",
+        "labels": "/api/v2/labels/0b501e7e557ab1ed/labels"
+      },
+      "id": "0b501e7e557ab1ed",
+      "organizationID": "50f7ba1150f7ba11",
+      "name": "hello",
+      "retentionRules": [{"type": "expire", "everySeconds": 2}],
+      "labels": [
+        {
+          "resourceID": "0b501e7e557ab1ed",
+          "name": "label",
+          "properties": {
+            "color": "fff000"
+          }
+        }
+      ]
+    },
+    {
+      "links": {
+        "org": "/api/v2/orgs/7e55e118dbabb1ed",
+        "self": "/api/v2/labels/c0175f0077a77005",
+        "log": "/api/v2/labels/c0175f0077a77005/log",
+        "labels": "/api/v2/labels/c0175f0077a77005/labels"
+      },
+      "id": "c0175f0077a77005",
+      "organizationID": "7e55e118dbabb1ed",
+      "name": "example",
+      "retentionRules": [{"type": "expire", "everySeconds": 86400}],
+      "labels": [
+        {
+          "resourceID": "c0175f0077a77005",
+          "name": "label",
+          "properties": {
+            "color": "fff000"
+          }
+        }
+      ]
+    }
+  ]
+}
+`,
+      },
+    },
+    {
+      name: "get all labels when there are none",
+      fields: fields{
+        &mock.LabelService{
+          FindLabelsFn: func(ctx context.Context, filter platform.LabelFilter, opts ...platform.FindOptions) ([]*platform.Label, int, error) {
+            return []*platform.Label{}, 0, nil
+          },
+        },
+        &mock.LabelService{},
+      },
+      args: args{
+        map[string][]string{
+          "limit": {"1"},
+        },
+      },
+      wants: wants{
+        statusCode:  http.StatusOK,
+        contentType: "application/json; charset=utf-8",
+        body: `
+{
+  "links": {
+    "self": "/api/v2/labels?descending=false&limit=1&offset=0"
+  },
+  "labels": []
+}`,
+      },
+    },
+  }
+
+  for _, tt := range tests {
+    t.Run(tt.name, func(t *testing.T) {
+      mappingService := mock.NewUserResourceMappingService()
+      labelService := tt.fields.LabelService
+      userService := mock.NewUserService()
+      h := NewLabelHandler(mappingService, labelService, userService)
+      h.LabelService = tt.fields.LabelService
+
+      r := httptest.NewRequest("GET", "http://any.url", nil)
+
+      qp := r.URL.Query()
+      for k, vs := range tt.args.queryParams {
+        for _, v := range vs {
+          qp.Add(k, v)
+        }
+      }
+      r.URL.RawQuery = qp.Encode()
+
+      w := httptest.NewRecorder()
+
+      h.handleGetLabels(w, r)
+
+      res := w.Result()
+      content := res.Header.Get("Content-Type")
+      body, _ := ioutil.ReadAll(res.Body)
+
+      if res.StatusCode != tt.wants.statusCode {
+        t.Errorf("%q. handleGetLabels() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+      }
+      if tt.wants.contentType != "" && content != tt.wants.contentType {
+        t.Errorf("%q. handleGetLabels() = %v, want %v", tt.name, content, tt.wants.contentType)
+      }
+      if eq, diff, err := jsonEqual(string(body), tt.wants.body); err != nil || tt.wants.body != "" && !eq {
+        t.Errorf("%q. handleGetLabels() = ***%v***", tt.name, diff)
+      }
+    })
+  }
+}
+
+func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.LabelService, string, func()) {
+	t.Helper()
+	svc := inmem.NewService()
+	svc.IDGenerator = f.IDGenerator
+
+	ctx := context.Background()
+	for _, u := range f.Users {
+		if err := svc.PutLabel(ctx, u); err != nil {
+			t.Fatalf("failed to populate labels")
+		}
+	}
+
+	handler := NewLabelHandler()
+	handler.LabelService = svc
+	server := httptest.NewServer(handler)
+	client := LabelService{
+		Addr:     server.URL,
+		OpPrefix: inmem.OpPrefix,
+	}
+
+	done := server.Close
+
+	return &client, inmem.OpPrefix, done
+}

--- a/http/label_test.go
+++ b/http/label_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	platform "github.com/influxdata/influxdb"
-	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/mock"
 	platformtesting "github.com/influxdata/influxdb/testing"
 )
@@ -129,29 +128,4 @@ func TestService_handleGetLabels(t *testing.T) {
 			}
 		})
 	}
-}
-
-func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.LabelService, string, func()) {
-	t.Helper()
-	svc := inmem.NewService()
-	svc.IDGenerator = f.IDGenerator
-
-	ctx := context.Background()
-	for _, u := range f.Labels {
-		if err := svc.PutLabel(ctx, u); err != nil {
-			t.Fatalf("failed to populate labels")
-		}
-	}
-
-	handler := NewLabelHandler()
-	handler.LabelService = svc
-	server := httptest.NewServer(handler)
-	client := LabelService{
-		Addr:     server.URL,
-		OpPrefix: inmem.OpPrefix,
-	}
-
-	done := server.Close
-
-	return &client, inmem.OpPrefix, done
 }

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -41,7 +41,7 @@ const (
 	// TODO(desa): need a way to specify which secrets to delete. this should work for now
 	organizationsIDSecretsDeletePath = "/api/v2/orgs/:id/secrets/delete"
 	organizationsIDLabelsPath        = "/api/v2/orgs/:id/labels"
-	organizationsIDLabelsNamePath    = "/api/v2/orgs/:id/labels/:lid"
+	organizationsIDLabelsIDPath    = "/api/v2/orgs/:id/labels/:lid"
 )
 
 // NewOrgHandler returns a new instance of OrgHandler.
@@ -78,7 +78,7 @@ func NewOrgHandler(mappingService platform.UserResourceMappingService,
 
 	h.HandlerFunc("GET", organizationsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", organizationsIDLabelsPath, newPostLabelHandler(h.LabelService))
-	h.HandlerFunc("DELETE", organizationsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
+	h.HandlerFunc("DELETE", organizationsIDLabelsIDPath, newDeleteLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -41,7 +41,7 @@ const (
 	// TODO(desa): need a way to specify which secrets to delete. this should work for now
 	organizationsIDSecretsDeletePath = "/api/v2/orgs/:id/secrets/delete"
 	organizationsIDLabelsPath        = "/api/v2/orgs/:id/labels"
-	organizationsIDLabelsIDPath    = "/api/v2/orgs/:id/labels/:lid"
+	organizationsIDLabelsIDPath      = "/api/v2/orgs/:id/labels/:lid"
 )
 
 // NewOrgHandler returns a new instance of OrgHandler.

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -79,7 +79,6 @@ func NewOrgHandler(mappingService platform.UserResourceMappingService,
 	h.HandlerFunc("GET", organizationsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", organizationsIDLabelsPath, newPostLabelHandler(h.LabelService))
 	h.HandlerFunc("DELETE", organizationsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
-	h.HandlerFunc("PATCH", organizationsIDLabelsNamePath, newPatchLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -41,7 +41,7 @@ const (
 	// TODO(desa): need a way to specify which secrets to delete. this should work for now
 	organizationsIDSecretsDeletePath = "/api/v2/orgs/:id/secrets/delete"
 	organizationsIDLabelsPath        = "/api/v2/orgs/:id/labels"
-	organizationsIDLabelsNamePath    = "/api/v2/orgs/:id/labels/:name"
+	organizationsIDLabelsNamePath    = "/api/v2/orgs/:id/labels/:lid"
 )
 
 // NewOrgHandler returns a new instance of OrgHandler.

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1680,6 +1680,48 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /labels:
+    post:
+      tags:
+        - Labels
+      summary: Create a label
+      requestBody:
+          description: label to create
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Label"
+      responses:
+        '201':
+          description: Added label
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Label"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    get:
+      tags:
+        - Labels
+      summary: Get all labels
+      responses:
+        '200':
+          description: all labels
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Labels"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /dashboards:
     post:
       tags:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1642,6 +1642,97 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /labels/{labelID}:
+    get:
+      tags:
+        - Labels
+      summary: Get a label
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: labelID
+          schema:
+            type: string
+          required: true
+          description: ID of label to update
+      responses:
+        '200':
+          description: a label
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Label"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+   patch:
+      tags:
+        - Labels
+      summary: Update a single label
+      requestBody:
+          description: label update
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Label"
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: labelID
+          schema:
+            type: string
+          required: true
+          description: ID of label to update
+      responses:
+        '200':
+          description: Updated label
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Label"
+        '404':
+          description: label not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+   delete:
+      tags:
+        - Labels
+      summary: Delete a label
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: labelID
+          schema:
+            type: string
+          required: true
+          description: ID of label to delete
+      responses:
+        '204':
+          description: delete has been accepted
+        '404':
+          description: label not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /dashboards:
     post:
       tags:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6987,6 +6987,9 @@ components:
     Label:
       type: object
       properties:
+        id:
+          readOnly: true
+          type: string
         name:
           type: string
         properties:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -379,46 +379,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-    patch:
-      tags:
-        - Telegrafs
-      summary: update a label from a telegraf config
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: path
-          name: telegrafID
-          schema:
-            type: string
-          required: true
-          description: ID of the telegraf config
-        - in: path
-          name: label
-          schema:
-            type: string
-          required: true
-          description: the label name
-      requestBody:
-        description: label update to apply
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Label"
-      responses:
-        '200':
-          description: updated successfully
-        '404':
-          description: telegraf config not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   '/telegrafs/{telegrafID}/members':
     get:
       tags:
@@ -1450,46 +1410,6 @@ paths:
       responses:
         '204':
           description: delete has been accepted
-        '404':
-          description: view not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    patch:
-      tags:
-        - Views
-      summary: update a label from a view
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: path
-          name: viewID
-          schema:
-            type: string
-          required: true
-          description: ID of the view
-        - in: path
-          name: label
-          schema:
-            type: string
-          required: true
-          description: the label name
-      requestBody:
-        description: label update to apply
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Label"
-      responses:
-        '200':
-          description: updated successfully
         '404':
           description: view not found
           content:
@@ -3032,46 +2952,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-    patch:
-      tags:
-        - Buckets
-      summary: update a label from a bucket
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: path
-          name: bucketID
-          schema:
-            type: string
-          required: true
-          description: ID of the bucket
-        - in: path
-          name: label
-          schema:
-            type: string
-          required: true
-          description: the label name
-      requestBody:
-        description: label update to apply
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Label"
-      responses:
-        '200':
-          description: updated successfully
-        '404':
-          description: bucket not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   '/buckets/{bucketID}/members':
     get:
       tags:
@@ -3469,46 +3349,6 @@ paths:
       responses:
         '204':
           description: delete has been accepted
-        '404':
-          description: organization not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    patch:
-      tags:
-        - Organizations
-      summary: update a label from an organization
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: path
-          name: orgID
-          schema:
-            type: string
-          required: true
-          description: ID of the organization
-        - in: path
-          name: label
-          schema:
-            type: string
-          required: true
-          description: the label name
-      requestBody:
-        description: label update to apply
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Label"
-      responses:
-        '200':
-          description: updated successfully
         '404':
           description: organization not found
           content:
@@ -4235,46 +4075,6 @@ paths:
       responses:
         '204':
           description: delete has been accepted
-        '404':
-          description: task not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-    patch:
-      tags:
-        - Tasks
-      summary: update a label from a task
-      parameters:
-        - $ref: '#/components/parameters/TraceSpan'
-        - in: path
-          name: taskID
-          schema:
-            type: string
-          required: true
-          description: ID of the task
-        - in: path
-          name: label
-          schema:
-            type: string
-          required: true
-          description: the label name
-      requestBody:
-        description: label update to apply
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Label"
-      responses:
-        '200':
-          description: updated successfully
         '404':
           description: task not found
           content:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -326,7 +326,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Label"
+              $ref: "#/components/schemas/LabelMapping"
       responses:
         '200':
           description: a list of all labels for a telegraf config
@@ -1369,7 +1369,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Label"
+              $ref: "#/components/schemas/LabelMapping"
       responses:
         '200':
           description: a list of all labels for a view
@@ -2201,7 +2201,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Label"
+              $ref: "#/components/schemas/LabelMapping"
       responses:
         '200':
           description: a list of all labels for a dashboard
@@ -3433,7 +3433,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Label"
+              $ref: "#/components/schemas/LabelMapping"
       responses:
         '200':
           description: a list of all labels for an organization
@@ -4157,7 +4157,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Label"
+              $ref: "#/components/schemas/LabelMapping"
       responses:
         '200':
           description: a list of all labels for a task

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -345,7 +345,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  '/telegrafs/{telegrafID}/labels/{label}':
+  '/telegrafs/{telegrafID}/labels/{labelID}':
     delete:
       tags:
         - Telegrafs
@@ -359,11 +359,11 @@ paths:
           required: true
           description: ID of the telegraf config
         - in: path
-          name: label
+          name: labelID
           schema:
             type: string
           required: true
-          description: the label name
+          description: the label ID
       responses:
         '204':
           description: delete has been accepted
@@ -1388,7 +1388,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  '/views/{viewID}/labels/{label}':
+  '/views/{viewID}/labels/{labelID}':
     delete:
       tags:
         - Views
@@ -1402,11 +1402,11 @@ paths:
           required: true
           description: ID of the view
         - in: path
-          name: label
+          name: labelID
           schema:
             type: string
           required: true
-          description: the label name
+          description: the label id
       responses:
         '204':
           description: delete has been accepted
@@ -1678,7 +1678,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Label"
+                $ref: "#/components/schemas/LabelUpdate"
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: path
@@ -2214,6 +2214,40 @@ paths:
                     $ref: "#/components/schemas/Labels"
                   links:
                     $ref: "#/components/schemas/Links"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/dashboards/{dashboardID}/labels/{labelID}':
+    delete:
+      tags:
+        - Dashboards
+      summary: delete a label from a dashboard
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: dashboardID
+          schema:
+            type: string
+          required: true
+          description: ID of the dashboard
+        - in: path
+          name: labelID
+          schema:
+            type: string
+          required: true
+          description: the label id to delete
+      responses:
+        '204':
+          description: delete has been accepted
+        '404':
+          description: dashboard not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           description: unexpected error
           content:
@@ -2990,7 +3024,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Label"
+              $ref: "#/components/schemas/LabelMapping"
       responses:
         '200':
           description: a list of all labels for a bucket
@@ -3009,7 +3043,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  '/buckets/{bucketID}/labels/{label}':
+  '/buckets/{bucketID}/labels/{labelID}':
     delete:
       tags:
         - Buckets
@@ -3023,11 +3057,11 @@ paths:
           required: true
           description: ID of the bucket
         - in: path
-          name: label
+          name: labelID
           schema:
             type: string
           required: true
-          description: the label name
+          description: the label id to delete
       responses:
         '204':
           description: delete has been accepted
@@ -3418,7 +3452,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  '/orgs/{orgID}/labels/{label}':
+  '/orgs/{orgID}/labels/{labelID}':
     delete:
       tags:
         - Organizations
@@ -3432,11 +3466,11 @@ paths:
           required: true
           description: ID of the organization
         - in: path
-          name: label
+          name: labelID
           schema:
             type: string
           required: true
-          description: the label name
+          description: the label id
       responses:
         '204':
           description: delete has been accepted
@@ -4144,7 +4178,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  '/tasks/{taskID}/labels/{label}':
+  '/tasks/{taskID}/labels/{labelID}':
     delete:
       tags:
         - Tasks
@@ -4158,11 +4192,11 @@ paths:
           required: true
           description: ID of the task
         - in: path
-          name: label
+          name: labelID
           schema:
             type: string
           required: true
-          description: the label name
+          description: the label id
       responses:
         '204':
           description: delete has been accepted
@@ -6996,3 +7030,15 @@ components:
           type: object
           description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example: {"color": "ffb3b3", "description": "this is a description"}
+    LabelUpdate:
+      type: object
+      properties:
+        properties:
+          type: object
+          description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
+          example: {"color": "ffb3b3", "description": "this is a description"}
+    LabelMapping:
+      type: object
+      properties:
+        labelID:
+          type: string

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1668,7 +1668,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-   patch:
+    patch:
       tags:
         - Labels
       summary: Update a single label
@@ -1706,7 +1706,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-   delete:
+    delete:
       tags:
         - Labels
       summary: Delete a label

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -47,7 +47,7 @@ const (
 	tasksIDRunsIDLogsPath  = "/api/v2/tasks/:id/runs/:rid/logs"
 	tasksIDRunsIDRetryPath = "/api/v2/tasks/:id/runs/:rid/retry"
 	tasksIDLabelsPath      = "/api/v2/tasks/:id/labels"
-	tasksIDLabelsIDPath  = "/api/v2/tasks/:id/labels/:lid"
+	tasksIDLabelsIDPath    = "/api/v2/tasks/:id/labels/:lid"
 )
 
 // NewTaskHandler returns a new instance of TaskHandler.

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -88,7 +88,6 @@ func NewTaskHandler(mappingService platform.UserResourceMappingService, labelSer
 	h.HandlerFunc("GET", tasksIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", tasksIDLabelsPath, newPostLabelHandler(h.LabelService))
 	h.HandlerFunc("DELETE", tasksIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
-	h.HandlerFunc("PATCH", tasksIDLabelsNamePath, newPatchLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -47,7 +47,7 @@ const (
 	tasksIDRunsIDLogsPath  = "/api/v2/tasks/:id/runs/:rid/logs"
 	tasksIDRunsIDRetryPath = "/api/v2/tasks/:id/runs/:rid/retry"
 	tasksIDLabelsPath      = "/api/v2/tasks/:id/labels"
-	tasksIDLabelsNamePath  = "/api/v2/tasks/:id/labels/:name"
+	tasksIDLabelsNamePath  = "/api/v2/tasks/:id/labels/:lid"
 )
 
 // NewTaskHandler returns a new instance of TaskHandler.

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -47,7 +47,7 @@ const (
 	tasksIDRunsIDLogsPath  = "/api/v2/tasks/:id/runs/:rid/logs"
 	tasksIDRunsIDRetryPath = "/api/v2/tasks/:id/runs/:rid/retry"
 	tasksIDLabelsPath      = "/api/v2/tasks/:id/labels"
-	tasksIDLabelsNamePath  = "/api/v2/tasks/:id/labels/:lid"
+	tasksIDLabelsIDPath  = "/api/v2/tasks/:id/labels/:lid"
 )
 
 // NewTaskHandler returns a new instance of TaskHandler.
@@ -87,7 +87,7 @@ func NewTaskHandler(mappingService platform.UserResourceMappingService, labelSer
 
 	h.HandlerFunc("GET", tasksIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", tasksIDLabelsPath, newPostLabelHandler(h.LabelService))
-	h.HandlerFunc("DELETE", tasksIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
+	h.HandlerFunc("DELETE", tasksIDLabelsIDPath, newDeleteLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -157,7 +157,7 @@ func newTasksResponse(ctx context.Context, ts []*platform.Task, labelService pla
 	}
 
 	for i := range ts {
-		labels, _ := labelService.FindLabels(ctx, platform.LabelFilter{ResourceID: ts[i].ID})
+		labels, _ := labelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: ts[i].ID})
 		rs.Tasks[i] = newTaskResponse(*ts[i], labels)
 	}
 	return rs
@@ -359,7 +359,7 @@ func (h *TaskHandler) handleGetTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{ResourceID: task.ID})
+	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: task.ID})
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return
@@ -408,7 +408,7 @@ func (h *TaskHandler) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{ResourceID: task.ID})
+	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: task.ID})
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/mock"
 	_ "github.com/influxdata/influxdb/query/builtin"
+	platformtesting "github.com/influxdata/influxdb/testing"
 	"github.com/julienschmidt/httprouter"
 )
 
@@ -76,11 +77,11 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 					},
 				},
 				labelService: &mock.LabelService{
-					FindLabelsFn: func(ctx context.Context, f platform.LabelFilter) ([]*platform.Label, error) {
+					FindResourceLabelsFn: func(ctx context.Context, f platform.LabelMappingFilter) ([]*platform.Label, error) {
 						labels := []*platform.Label{
 							{
-								ResourceID: f.ResourceID,
-								Name:       "label",
+								ID:   platformtesting.MustIDBase16("fc3dc670a4be9b9a"),
+								Name: "label",
 								Properties: map[string]string{
 									"color": "fff000",
 								},

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -113,7 +113,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
       "name": "task1",
 			"labels": [
         {
-          "resourceID": "0000000000000001",
+          "id": "fc3dc670a4be9b9a",
           "name": "label",
           "properties": {
             "color": "fff000"
@@ -142,7 +142,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
       "name": "task2",
 			"labels": [
         {
-          "resourceID": "0000000000000002",
+          "id": "fc3dc670a4be9b9a",
           "name": "label",
           "properties": {
             "color": "fff000"

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -74,7 +74,6 @@ func NewTelegrafHandler(
 	h.HandlerFunc("GET", telegrafsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", telegrafsIDLabelsPath, newPostLabelHandler(h.LabelService))
 	h.HandlerFunc("DELETE", telegrafsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
-	h.HandlerFunc("PATCH", telegrafsIDLabelsNamePath, newPatchLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -35,7 +35,7 @@ const (
 	telegrafsIDOwnersPath     = "/api/v2/telegrafs/:id/owners"
 	telegrafsIDOwnersIDPath   = "/api/v2/telegrafs/:id/owners/:userID"
 	telegrafsIDLabelsPath     = "/api/v2/telegrafs/:id/labels"
-	telegrafsIDLabelsNamePath = "/api/v2/telegrafs/:id/labels/:lid"
+	telegrafsIDLabelsIDPath = "/api/v2/telegrafs/:id/labels/:lid"
 )
 
 // NewTelegrafHandler returns a new instance of TelegrafHandler.
@@ -73,7 +73,7 @@ func NewTelegrafHandler(
 
 	h.HandlerFunc("GET", telegrafsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", telegrafsIDLabelsPath, newPostLabelHandler(h.LabelService))
-	h.HandlerFunc("DELETE", telegrafsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
+	h.HandlerFunc("DELETE", telegrafsIDLabelsIDPath, newDeleteLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -28,14 +28,14 @@ type TelegrafHandler struct {
 }
 
 const (
-	telegrafsPath             = "/api/v2/telegrafs"
-	telegrafsIDPath           = "/api/v2/telegrafs/:id"
-	telegrafsIDMembersPath    = "/api/v2/telegrafs/:id/members"
-	telegrafsIDMembersIDPath  = "/api/v2/telegrafs/:id/members/:userID"
-	telegrafsIDOwnersPath     = "/api/v2/telegrafs/:id/owners"
-	telegrafsIDOwnersIDPath   = "/api/v2/telegrafs/:id/owners/:userID"
-	telegrafsIDLabelsPath     = "/api/v2/telegrafs/:id/labels"
-	telegrafsIDLabelsIDPath = "/api/v2/telegrafs/:id/labels/:lid"
+	telegrafsPath            = "/api/v2/telegrafs"
+	telegrafsIDPath          = "/api/v2/telegrafs/:id"
+	telegrafsIDMembersPath   = "/api/v2/telegrafs/:id/members"
+	telegrafsIDMembersIDPath = "/api/v2/telegrafs/:id/members/:userID"
+	telegrafsIDOwnersPath    = "/api/v2/telegrafs/:id/owners"
+	telegrafsIDOwnersIDPath  = "/api/v2/telegrafs/:id/owners/:userID"
+	telegrafsIDLabelsPath    = "/api/v2/telegrafs/:id/labels"
+	telegrafsIDLabelsIDPath  = "/api/v2/telegrafs/:id/labels/:lid"
 )
 
 // NewTelegrafHandler returns a new instance of TelegrafHandler.

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -116,7 +116,7 @@ func newTelegrafResponses(ctx context.Context, tcs []*platform.TelegrafConfig, l
 		TelegrafConfigs: make([]telegrafResponse, len(tcs)),
 	}
 	for i, c := range tcs {
-		labels, _ := labelService.FindLabels(ctx, platform.LabelFilter{ResourceID: c.ID})
+		labels, _ := labelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: c.ID})
 		resp.TelegrafConfigs[i] = newTelegrafResponse(c, labels)
 	}
 	return resp
@@ -177,7 +177,7 @@ func (h *TelegrafHandler) handleGetTelegraf(w http.ResponseWriter, r *http.Reque
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(tc.TOML()))
 	case "application/json":
-		labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{ResourceID: tc.ID})
+		labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: tc.ID})
 		if err != nil {
 			EncodeError(ctx, err, w)
 			return
@@ -312,7 +312,7 @@ func (h *TelegrafHandler) handlePutTelegraf(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	labels, err := h.LabelService.FindLabels(ctx, platform.LabelFilter{ResourceID: tc.ID})
+	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: tc.ID})
 	if err != nil {
 		EncodeError(ctx, err, w)
 		return

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -35,7 +35,7 @@ const (
 	telegrafsIDOwnersPath     = "/api/v2/telegrafs/:id/owners"
 	telegrafsIDOwnersIDPath   = "/api/v2/telegrafs/:id/owners/:userID"
 	telegrafsIDLabelsPath     = "/api/v2/telegrafs/:id/labels"
-	telegrafsIDLabelsNamePath = "/api/v2/telegrafs/:id/labels/:name"
+	telegrafsIDLabelsNamePath = "/api/v2/telegrafs/:id/labels/:lid"
 )
 
 // NewTelegrafHandler returns a new instance of TelegrafHandler.

--- a/http/view_service.go
+++ b/http/view_service.go
@@ -34,7 +34,7 @@ const (
 	viewsIDOwnersPath     = "/api/v2/views/:id/owners"
 	viewsIDOwnersIDPath   = "/api/v2/views/:id/owners/:userID"
 	viewsIDLabelsPath     = "/api/v2/views/:id/labels"
-	viewsIDLabelsNamePath = "/api/v2/views/:id/labels/:name"
+	viewsIDLabelsNamePath = "/api/v2/views/:id/labels/:lid"
 )
 
 // NewViewHandler returns a new instance of ViewHandler.

--- a/http/view_service.go
+++ b/http/view_service.go
@@ -34,7 +34,7 @@ const (
 	viewsIDOwnersPath     = "/api/v2/views/:id/owners"
 	viewsIDOwnersIDPath   = "/api/v2/views/:id/owners/:userID"
 	viewsIDLabelsPath     = "/api/v2/views/:id/labels"
-	viewsIDLabelsNamePath = "/api/v2/views/:id/labels/:lid"
+	viewsIDLabelsIDPath = "/api/v2/views/:id/labels/:lid"
 )
 
 // NewViewHandler returns a new instance of ViewHandler.
@@ -65,7 +65,7 @@ func NewViewHandler(mappingService platform.UserResourceMappingService, labelSer
 
 	h.HandlerFunc("GET", viewsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", viewsIDLabelsPath, newPostLabelHandler(h.LabelService))
-	h.HandlerFunc("DELETE", viewsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
+	h.HandlerFunc("DELETE", viewsIDLabelsIDPath, newDeleteLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/view_service.go
+++ b/http/view_service.go
@@ -66,7 +66,6 @@ func NewViewHandler(mappingService platform.UserResourceMappingService, labelSer
 	h.HandlerFunc("GET", viewsIDLabelsPath, newGetLabelsHandler(h.LabelService))
 	h.HandlerFunc("POST", viewsIDLabelsPath, newPostLabelHandler(h.LabelService))
 	h.HandlerFunc("DELETE", viewsIDLabelsNamePath, newDeleteLabelHandler(h.LabelService))
-	h.HandlerFunc("PATCH", viewsIDLabelsNamePath, newPatchLabelHandler(h.LabelService))
 
 	return h
 }

--- a/http/view_service.go
+++ b/http/view_service.go
@@ -27,14 +27,14 @@ type ViewHandler struct {
 }
 
 const (
-	viewsPath             = "/api/v2/views"
-	viewsIDPath           = "/api/v2/views/:id"
-	viewsIDMembersPath    = "/api/v2/views/:id/members"
-	viewsIDMembersIDPath  = "/api/v2/views/:id/members/:userID"
-	viewsIDOwnersPath     = "/api/v2/views/:id/owners"
-	viewsIDOwnersIDPath   = "/api/v2/views/:id/owners/:userID"
-	viewsIDLabelsPath     = "/api/v2/views/:id/labels"
-	viewsIDLabelsIDPath = "/api/v2/views/:id/labels/:lid"
+	viewsPath            = "/api/v2/views"
+	viewsIDPath          = "/api/v2/views/:id"
+	viewsIDMembersPath   = "/api/v2/views/:id/members"
+	viewsIDMembersIDPath = "/api/v2/views/:id/members/:userID"
+	viewsIDOwnersPath    = "/api/v2/views/:id/owners"
+	viewsIDOwnersIDPath  = "/api/v2/views/:id/owners/:userID"
+	viewsIDLabelsPath    = "/api/v2/views/:id/labels"
+	viewsIDLabelsIDPath  = "/api/v2/views/:id/labels/:lid"
 )
 
 // NewViewHandler returns a new instance of ViewHandler.

--- a/inmem/bucket_service.go
+++ b/inmem/bucket_service.go
@@ -308,7 +308,7 @@ func (s *Service) DeleteBucket(ctx context.Context, id platform.ID) error {
 		}
 	}
 	s.bucketKV.Delete(id.String())
-	return s.deleteLabel(ctx, platform.LabelFilter{ResourceID: id})
+	// return s.deleteLabel(ctx, platform.LabelFilter{ResourceID: id})
 }
 
 // DeleteOrganizationBuckets removes all the buckets for a given org

--- a/inmem/bucket_service.go
+++ b/inmem/bucket_service.go
@@ -308,7 +308,9 @@ func (s *Service) DeleteBucket(ctx context.Context, id platform.ID) error {
 		}
 	}
 	s.bucketKV.Delete(id.String())
+
 	// return s.deleteLabel(ctx, platform.LabelFilter{ResourceID: id})
+	return nil
 }
 
 // DeleteOrganizationBuckets removes all the buckets for a given org

--- a/inmem/dashboard.go
+++ b/inmem/dashboard.go
@@ -209,13 +209,13 @@ func (s *Service) DeleteDashboard(ctx context.Context, id platform.ID) error {
 		}
 	}
 	s.dashboardKV.Delete(id.String())
-	err := s.deleteLabel(ctx, platform.LabelFilter{ResourceID: id})
-	if err != nil {
-		return &platform.Error{
-			Err: err,
-			Op:  op,
-		}
-	}
+	// err := s.deleteLabel(ctx, platform.LabelFilter{ResourceID: id})
+	// if err != nil {
+	// 	return &platform.Error{
+	// 		Err: err,
+	// 		Op:  op,
+	// 	}
+	// }
 	return nil
 }
 

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -60,104 +60,125 @@ func (s *Service) filterLabels(ctx context.Context, fn func(m *platform.Label) b
 	return labels, nil
 }
 
+func (s *Service) FindLabelByID(ctx context.Context, id platform.ID) (*platform.Label, error) {
+	return nil, nil
+}
+
 func (s *Service) FindLabels(ctx context.Context, filter platform.LabelFilter, opt ...platform.FindOptions) ([]*platform.Label, error) {
-	if filter.ResourceID.Valid() && filter.Name != "" {
-		l, err := s.FindLabelBy(ctx, filter.ResourceID, filter.Name)
-		if err != nil {
-			return nil, err
-		}
-		return []*platform.Label{l}, nil
-	}
+	return nil, nil
+}
 
-	filterFunc := func(label *platform.Label) bool {
-		return (!filter.ResourceID.Valid() || (filter.ResourceID == label.ResourceID)) &&
-			(filter.Name == "" || (filter.Name == label.Name))
-	}
-
-	labels, err := s.filterLabels(ctx, filterFunc)
-	if err != nil {
-		return nil, err
-	}
-
-	return labels, nil
+func (s *Service) FindResourceLabels(ctx context.Context, filter platform.LabelMappingFilter) ([]*platform.Label, error) {
+	// if filter.ResourceID.Valid() && filter.Name != "" {
+	// 	l, err := s.FindLabelBy(ctx, filter.ResourceID, filter.Name)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	return []*platform.Label{l}, nil
+	// }
+	//
+	// filterFunc := func(label *platform.Label) bool {
+	// 	return (!filter.ResourceID.Valid() || (filter.ResourceID == label.ResourceID)) &&
+	// 		(filter.Name == "" || (filter.Name == label.Name))
+	// }
+	//
+	// labels, err := s.filterLabels(ctx, filterFunc)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	//
+	// return labels, nil
+	return nil, nil
 }
 
 func (s *Service) CreateLabel(ctx context.Context, l *platform.Label) error {
-	label, _ := s.FindLabelBy(ctx, l.ResourceID, l.Name)
-	if label != nil {
-		return &platform.Error{
-			Code: platform.EConflict,
-			Op:   OpPrefix + platform.OpCreateLabel,
-			Msg:  fmt.Sprintf("label %s already exists", l.Name),
-		}
-	}
+	// label, _ := s.FindLabelBy(ctx, l.ResourceID, l.Name)
+	// if label != nil {
+	// 	return &platform.Error{
+	// 		Code: platform.EConflict,
+	// 		Op:   OpPrefix + platform.OpCreateLabel,
+	// 		Msg:  fmt.Sprintf("label %s already exists", l.Name),
+	// 	}
+	// }
+	//
+	// s.labelKV.Store(encodeLabelKey(l.ResourceID, l.Name), *l)
+	// return nil
+	return nil
+}
 
-	s.labelKV.Store(encodeLabelKey(l.ResourceID, l.Name), *l)
+func (s *Service) CreateLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
 	return nil
 }
 
 func (s *Service) UpdateLabel(ctx context.Context, l *platform.Label, upd platform.LabelUpdate) (*platform.Label, error) {
-	label, err := s.FindLabelBy(ctx, l.ResourceID, l.Name)
-	if err != nil {
-		return nil, &platform.Error{
-			Code: platform.ENotFound,
-			Op:   OpPrefix + platform.OpUpdateLabel,
-			Err:  err,
-		}
-	}
-
-	if label.Properties == nil {
-		label.Properties = make(map[string]string)
-	}
-
-	for k, v := range upd.Properties {
-		if v == "" {
-			delete(label.Properties, k)
-		} else {
-			label.Properties[k] = v
-		}
-	}
-
-	if err := label.Validate(); err != nil {
-		return nil, &platform.Error{
-			Code: platform.EInvalid,
-			Op:   OpPrefix + platform.OpUpdateLabel,
-			Err:  err,
-		}
-	}
-
-	s.labelKV.Store(encodeLabelKey(label.ResourceID, label.Name), *label)
-
-	return label, nil
+	// label, err := s.FindLabelBy(ctx, l.ResourceID, l.Name)
+	// if err != nil {
+	// 	return nil, &platform.Error{
+	// 		Code: platform.ENotFound,
+	// 		Op:   OpPrefix + platform.OpUpdateLabel,
+	// 		Err:  err,
+	// 	}
+	// }
+	//
+	// if label.Properties == nil {
+	// 	label.Properties = make(map[string]string)
+	// }
+	//
+	// for k, v := range upd.Properties {
+	// 	if v == "" {
+	// 		delete(label.Properties, k)
+	// 	} else {
+	// 		label.Properties[k] = v
+	// 	}
+	// }
+	//
+	// if err := label.Validate(); err != nil {
+	// 	return nil, &platform.Error{
+	// 		Code: platform.EInvalid,
+	// 		Op:   OpPrefix + platform.OpUpdateLabel,
+	// 		Err:  err,
+	// 	}
+	// }
+	//
+	// s.labelKV.Store(encodeLabelKey(label.ResourceID, label.Name), *label)
+	//
+	// return label, nil
+	return nil, nil
 }
 
 func (s *Service) PutLabel(ctx context.Context, l *platform.Label) error {
-	s.labelKV.Store(encodeLabelKey(l.ResourceID, l.Name), *l)
+	s.labelKV.Store(l.ID.String, *l)
 	return nil
 }
 
-func (s *Service) DeleteLabel(ctx context.Context, l platform.Label) error {
-	label, err := s.FindLabelBy(ctx, l.ResourceID, l.Name)
-	if label == nil && err != nil {
-		return &platform.Error{
-			Code: platform.ENotFound,
-			Op:   OpPrefix + platform.OpDeleteLabel,
-			Err:  platform.ErrLabelNotFound,
-		}
-	}
-
-	s.labelKV.Delete(encodeLabelKey(l.ResourceID, l.Name))
+func (s *Service) DeleteLabel(ctx context.Context, id platform.ID) error {
 	return nil
 }
 
-func (s *Service) deleteLabel(ctx context.Context, filter platform.LabelFilter) error {
-	labels, err := s.FindLabels(ctx, filter)
-	if labels == nil && err != nil {
-		return err
-	}
-	for _, l := range labels {
-		s.labelKV.Delete(encodeLabelKey(l.ResourceID, l.Name))
-	}
+func (s *Service) DeleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	// label, err := s.FindLabelBy(ctx, l.ResourceID, l.Name)
+	// if label == nil && err != nil {
+	// 	return &platform.Error{
+	// 		Code: platform.ENotFound,
+	// 		Op:   OpPrefix + platform.OpDeleteLabel,
+	// 		Err:  platform.ErrLabelNotFound,
+	// 	}
+	// }
+	//
+	// s.labelKV.Delete(encodeLabelKey(l.ResourceID, l.Name))
+	// return nil
+	return nil
+}
 
+func (s *Service) deleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	// labels, err := s.FindLabels(ctx, filter)
+	// if labels == nil && err != nil {
+	// 	return err
+	// }
+	// for _, l := range labels {
+	// 	s.labelKV.Delete(encodeLabelKey(l.ResourceID, l.Name))
+	// }
+	//
+	// return nil
 	return nil
 }

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -92,6 +92,7 @@ func (s *Service) FindResourceLabels(ctx context.Context, filter platform.LabelM
 }
 
 func (s *Service) CreateLabel(ctx context.Context, l *platform.Label) error {
+	l.ID = s.IDGenerator.ID()
 	// label, _ := s.FindLabelBy(ctx, l.ResourceID, l.Name)
 	// if label != nil {
 	// 	return &platform.Error{
@@ -110,7 +111,7 @@ func (s *Service) CreateLabelMapping(ctx context.Context, m *platform.LabelMappi
 	return nil
 }
 
-func (s *Service) UpdateLabel(ctx context.Context, l *platform.Label, upd platform.LabelUpdate) (*platform.Label, error) {
+func (s *Service) UpdateLabel(ctx context.Context, id platform.ID, upd platform.LabelUpdate) (*platform.Label, error) {
 	// label, err := s.FindLabelBy(ctx, l.ResourceID, l.Name)
 	// if err != nil {
 	// 	return nil, &platform.Error{

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -149,6 +149,14 @@ func (s *Service) CreateLabel(ctx context.Context, l *platform.Label) error {
 
 // CreateLabelMapping creates a mapping that associates a label to a resource.
 func (s *Service) CreateLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	_, err := s.FindLabelByID(ctx, *m.LabelID)
+	if err != nil {
+		return &platform.Error{
+			Err: err,
+			Op:  platform.OpCreateLabel,
+		}
+	}
+
 	s.labelMappingKV.Store(encodeLabelMappingKey(m), *m)
 	return nil
 }

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -122,6 +122,7 @@ func (s *Service) UpdateLabel(ctx context.Context, id platform.ID, upd platform.
 			Code: platform.ENotFound,
 			Op:   OpPrefix + platform.OpUpdateLabel,
 			Err:  err,
+			Msg:  "label not found",
 		}
 	}
 
@@ -165,6 +166,7 @@ func (s *Service) DeleteLabel(ctx context.Context, id platform.ID) error {
 			Code: platform.ENotFound,
 			Op:   OpPrefix + platform.OpDeleteLabel,
 			Err:  platform.ErrLabelNotFound,
+			Msg:  "label not found",
 		}
 	}
 

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -210,30 +210,8 @@ func (s *Service) DeleteLabel(ctx context.Context, id platform.ID) error {
 	return nil
 }
 
+// DeleteLabelMapping deletes a label mapping.
 func (s *Service) DeleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
-	// label, err := s.FindLabelBy(ctx, l.ResourceID, l.Name)
-	// if label == nil && err != nil {
-	// 	return &platform.Error{
-	// 		Code: platform.ENotFound,
-	// 		Op:   OpPrefix + platform.OpDeleteLabel,
-	// 		Err:  platform.ErrLabelNotFound,
-	// 	}
-	// }
-	//
-	// s.labelKV.Delete(encodeLabelKey(l.ResourceID, l.Name))
-	// return nil
-	return nil
-}
-
-func (s *Service) deleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
-	// labels, err := s.FindLabels(ctx, filter)
-	// if labels == nil && err != nil {
-	// 	return err
-	// }
-	// for _, l := range labels {
-	// 	s.labelKV.Delete(encodeLabelKey(l.ResourceID, l.Name))
-	// }
-	//
-	// return nil
+	s.labelMappingKV.Delete(encodeLabelMappingKey(m))
 	return nil
 }

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -3,17 +3,12 @@ package inmem
 import (
 	"context"
 	"fmt"
-	"path"
 
 	platform "github.com/influxdata/influxdb"
 )
 
-func encodeLabelKey(resourceID platform.ID, name string) string {
-	return path.Join(resourceID.String(), name)
-}
-
-func (s *Service) loadLabel(ctx context.Context, resourceID platform.ID, name string) (*platform.Label, error) {
-	i, ok := s.labelKV.Load(encodeLabelKey(resourceID, name))
+func (s *Service) loadLabel(ctx context.Context, id platform.ID) (*platform.Label, error) {
+	i, ok := s.labelKV.Load(id.String())
 	if !ok {
 		return nil, platform.ErrLabelNotFound
 	}
@@ -24,10 +19,6 @@ func (s *Service) loadLabel(ctx context.Context, resourceID platform.ID, name st
 	}
 
 	return &l, nil
-}
-
-func (s *Service) FindLabelBy(ctx context.Context, resourceID platform.ID, name string) (*platform.Label, error) {
-	return s.loadLabel(ctx, resourceID, name)
 }
 
 func (s *Service) forEachLabel(ctx context.Context, fn func(m *platform.Label) bool) error {
@@ -60,14 +51,17 @@ func (s *Service) filterLabels(ctx context.Context, fn func(m *platform.Label) b
 	return labels, nil
 }
 
+// FindLabelByID returns a single user by ID.
 func (s *Service) FindLabelByID(ctx context.Context, id platform.ID) (*platform.Label, error) {
-	return nil, nil
+	return s.loadLabel(ctx, id)
 }
 
+// FindLabels will retrieve a list of labels from storage.
 func (s *Service) FindLabels(ctx context.Context, filter platform.LabelFilter, opt ...platform.FindOptions) ([]*platform.Label, error) {
 	return nil, nil
 }
 
+// FindResourceLabels returns a list of labels that are mapped to a resource.
 func (s *Service) FindResourceLabels(ctx context.Context, filter platform.LabelMappingFilter) ([]*platform.Label, error) {
 	// if filter.ResourceID.Valid() && filter.Name != "" {
 	// 	l, err := s.FindLabelBy(ctx, filter.ResourceID, filter.Name)
@@ -91,6 +85,7 @@ func (s *Service) FindResourceLabels(ctx context.Context, filter platform.LabelM
 	return nil, nil
 }
 
+// CreateLabel creates a new label.
 func (s *Service) CreateLabel(ctx context.Context, l *platform.Label) error {
 	l.ID = s.IDGenerator.ID()
 	// label, _ := s.FindLabelBy(ctx, l.ResourceID, l.Name)
@@ -107,10 +102,12 @@ func (s *Service) CreateLabel(ctx context.Context, l *platform.Label) error {
 	return nil
 }
 
+// CreateLabelMapping creates a mapping that associates a label to a resource.
 func (s *Service) CreateLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
 	return nil
 }
 
+// UpdateLabel updates a label.
 func (s *Service) UpdateLabel(ctx context.Context, id platform.ID, upd platform.LabelUpdate) (*platform.Label, error) {
 	// label, err := s.FindLabelBy(ctx, l.ResourceID, l.Name)
 	// if err != nil {

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -11,7 +11,10 @@ import (
 func (s *Service) loadLabel(ctx context.Context, id platform.ID) (*platform.Label, error) {
 	i, ok := s.labelKV.Load(id.String())
 	if !ok {
-		return nil, platform.ErrLabelNotFound
+		return nil, &platform.Error{
+			Code: platform.ENotFound,
+			Msg:  "label not found",
+		}
 	}
 
 	l, ok := i.(platform.Label)

--- a/inmem/label_test.go
+++ b/inmem/label_test.go
@@ -18,6 +18,12 @@ func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.Lab
 		}
 	}
 
+	for _, m := range f.Mappings {
+		if err := s.CreateLabelMapping(ctx, m); err != nil {
+			t.Fatalf("failed to populate label mappings")
+		}
+	}
+
 	return s, OpPrefix, func() {}
 }
 

--- a/inmem/label_test.go
+++ b/inmem/label_test.go
@@ -10,9 +10,10 @@ import (
 
 func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.LabelService, string, func()) {
 	s := NewService()
-	ctx := context.TODO()
-	for _, m := range f.Labels {
-		if err := s.CreateLabel(ctx, m); err != nil {
+	s.IDGenerator = f.IDGenerator
+	ctx := context.Background()
+	for _, l := range f.Labels {
+		if err := s.PutLabel(ctx, l); err != nil {
 			t.Fatalf("failed to populate labels")
 		}
 	}
@@ -21,5 +22,6 @@ func initLabelService(f platformtesting.LabelFields, t *testing.T) (platform.Lab
 }
 
 func TestLabelService(t *testing.T) {
+	t.Parallel()
 	platformtesting.LabelService(initLabelService, t)
 }

--- a/inmem/service.go
+++ b/inmem/service.go
@@ -24,6 +24,7 @@ type Service struct {
 	dbrpMappingKV         sync.Map
 	userResourceMappingKV sync.Map
 	labelKV               sync.Map
+	labelMappingKV        sync.Map
 	scraperTargetKV       sync.Map
 	telegrafConfigKV      sync.Map
 	onboardingKV          sync.Map

--- a/label.go
+++ b/label.go
@@ -17,6 +17,9 @@ const (
 
 // LabelService represents a service for managing resource labels
 type LabelService interface {
+	// Returns a single label by ID.
+	FindLabelByID(ctx context.Context, id ID) (*Label, error)
+
 	// FindLabels returns a list of labels that match a filter
 	FindLabels(ctx context.Context, filter LabelFilter, opt ...FindOptions) ([]*Label, error)
 

--- a/label.go
+++ b/label.go
@@ -8,15 +8,20 @@ import (
 const ErrLabelNotFound = ChronografError("label not found")
 
 const (
-	OpFindLabels  = "FindLabels"
-	OpCreateLabel = "CreateLabel"
-	OpUpdateLabel = "UpdateLabel"
-	OpDeleteLabel = "DeleteLabel"
+	OpFindLabels    = "FindLabels"
+	OpFindLabelByID = "FindLabelByID"
+	OpCreateLabel   = "CreateLabel"
+	OpUpdateLabel   = "UpdateLabel"
+	OpDeleteLabel   = "DeleteLabel"
 )
 
+// LabelService represents a service for managing resource labels
 type LabelService interface {
 	// FindLabels returns a list of labels that match a filter
 	FindLabels(ctx context.Context, filter LabelFilter, opt ...FindOptions) ([]*Label, error)
+
+	// FindResourceLabels returns a list of labels that belong to a resource
+	FindResourceLabels(ctx context.Context, filter LabelMappingFilter) ([]*Label, error)
 
 	// CreateLabel creates a new label
 	CreateLabel(ctx context.Context, l *Label) error
@@ -25,24 +30,18 @@ type LabelService interface {
 	UpdateLabel(ctx context.Context, l *Label, upd LabelUpdate) (*Label, error)
 
 	// DeleteLabel deletes a label
-	DeleteLabel(ctx context.Context, l Label) error
+	DeleteLabel(ctx context.Context, id ID) error
 }
 
+// Label is a tag set on a resource, typically used for filtering on a UI.
 type Label struct {
-	ResourceID ID                `json:"resourceID"`
+	ID         ID                `json:"id,omitempty"`
 	Name       string            `json:"name"`
-	Properties map[string]string `json:"properties"`
+	Properties map[string]string `json:"properties,omitempty"`
 }
 
 // Validate returns an error if the label is invalid.
 func (l *Label) Validate() error {
-	if !l.ResourceID.Valid() {
-		return &Error{
-			Code: EInvalid,
-			Msg:  "resourceID is required",
-		}
-	}
-
 	if l.Name == "" {
 		return &Error{
 			Code: EInvalid,
@@ -53,13 +52,26 @@ func (l *Label) Validate() error {
 	return nil
 }
 
+// LabelMapping is used to map resource to its labels.
+// It should not be shared directly over the HTTP API.
+type LabelMapping struct {
+	LabelID    ID
+	ResourceID ID
+}
+
 // LabelUpdate represents a changeset for a label.
 // Only fields which are set are updated.
 type LabelUpdate struct {
 	Properties map[string]string `json:"properties,omitempty"`
 }
 
+// LabelFilter represents a set of filters that restrict the returned results.
 type LabelFilter struct {
+	ID   ID
+	Name string
+}
+
+// LabelMappingFilter represents a set of filters that restrict the returned results.
+type LabelMappingFilter struct {
 	ResourceID ID
-	Name       string
 }

--- a/label.go
+++ b/label.go
@@ -15,6 +15,7 @@ const (
 	OpCreateLabelMapping = "CreateLabelMapping"
 	OpUpdateLabel        = "UpdateLabel"
 	OpDeleteLabel        = "DeleteLabel"
+	OpDeleteLabelMapping = "DeleteLabelMapping"
 )
 
 // LabelService represents a service for managing resource labels

--- a/label.go
+++ b/label.go
@@ -20,7 +20,7 @@ const (
 
 // LabelService represents a service for managing resource labels
 type LabelService interface {
-	// Returns a single label by ID.
+	// FindLabelByID a single label by ID.
 	FindLabelByID(ctx context.Context, id ID) (*Label, error)
 
 	// FindLabels returns a list of labels that match a filter
@@ -67,7 +67,7 @@ func (l *Label) Validate() error {
 // LabelMapping is used to map resource to its labels.
 // It should not be shared directly over the HTTP API.
 type LabelMapping struct {
-	LabelID    *ID
+	LabelID    *ID `json:"labelID"`
 	ResourceID *ID
 }
 

--- a/label.go
+++ b/label.go
@@ -33,7 +33,7 @@ type LabelService interface {
 	CreateLabelMapping(ctx context.Context, m *LabelMapping) error
 
 	// UpdateLabel updates a label with a changeset.
-	UpdateLabel(ctx context.Context, l *Label, upd LabelUpdate) (*Label, error)
+	UpdateLabel(ctx context.Context, id ID, upd LabelUpdate) (*Label, error)
 
 	// DeleteLabel deletes a label
 	DeleteLabel(ctx context.Context, id ID) error

--- a/label.go
+++ b/label.go
@@ -8,11 +8,12 @@ import (
 const ErrLabelNotFound = ChronografError("label not found")
 
 const (
-	OpFindLabels    = "FindLabels"
-	OpFindLabelByID = "FindLabelByID"
-	OpCreateLabel   = "CreateLabel"
-	OpUpdateLabel   = "UpdateLabel"
-	OpDeleteLabel   = "DeleteLabel"
+	OpFindLabels         = "FindLabels"
+	OpFindLabelByID      = "FindLabelByID"
+	OpCreateLabel        = "CreateLabel"
+	OpCreateLabelMapping = "CreateLabelMapping"
+	OpUpdateLabel        = "UpdateLabel"
+	OpDeleteLabel        = "DeleteLabel"
 )
 
 // LabelService represents a service for managing resource labels

--- a/label.go
+++ b/label.go
@@ -10,6 +10,7 @@ const ErrLabelNotFound = ChronografError("label not found")
 const (
 	OpFindLabels         = "FindLabels"
 	OpFindLabelByID      = "FindLabelByID"
+	OpFindLabelMapping   = "FindLabelMapping"
 	OpCreateLabel        = "CreateLabel"
 	OpCreateLabelMapping = "CreateLabelMapping"
 	OpUpdateLabel        = "UpdateLabel"
@@ -65,8 +66,8 @@ func (l *Label) Validate() error {
 // LabelMapping is used to map resource to its labels.
 // It should not be shared directly over the HTTP API.
 type LabelMapping struct {
-	LabelID    ID
-	ResourceID ID
+	LabelID    *ID
+	ResourceID *ID
 }
 
 // Validate returns an error if the mapping is invalid.

--- a/label.go
+++ b/label.go
@@ -26,11 +26,17 @@ type LabelService interface {
 	// CreateLabel creates a new label
 	CreateLabel(ctx context.Context, l *Label) error
 
+	// CreateLabel maps a resource to an existing label
+	CreateLabelMapping(ctx context.Context, m *LabelMapping) error
+
 	// UpdateLabel updates a label with a changeset.
 	UpdateLabel(ctx context.Context, l *Label, upd LabelUpdate) (*Label, error)
 
 	// DeleteLabel deletes a label
 	DeleteLabel(ctx context.Context, id ID) error
+
+	// DeleteLabelMapping deletes a label mapping
+	DeleteLabelMapping(ctx context.Context, m *LabelMapping) error
 }
 
 // Label is a tag set on a resource, typically used for filtering on a UI.
@@ -57,6 +63,18 @@ func (l *Label) Validate() error {
 type LabelMapping struct {
 	LabelID    ID
 	ResourceID ID
+}
+
+// Validate returns an error if the mapping is invalid.
+func (l *LabelMapping) Validate() error {
+	if !l.ResourceID.Valid() {
+		return &Error{
+			Code: EInvalid,
+			Msg:  "resourceID is required",
+		}
+	}
+
+	return nil
 }
 
 // LabelUpdate represents a changeset for a label.

--- a/label_test.go
+++ b/label_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	platform "github.com/influxdata/influxdb"
-	platformtesting "github.com/influxdata/influxdb/testing"
 )
 
 func TestLabelValidate(t *testing.T) {
@@ -20,15 +19,12 @@ func TestLabelValidate(t *testing.T) {
 		{
 			name: "valid label",
 			fields: fields{
-				ResourceID: platformtesting.MustIDBase16("020f755c3c082000"),
-				Name:       "iot",
+				Name: "iot",
 			},
 		},
 		{
-			name: "label requires a name",
-			fields: fields{
-				ResourceID: platformtesting.MustIDBase16("020f755c3c082000"),
-			},
+			name:    "label requires a name",
+			fields:  fields{},
 			wantErr: true,
 		},
 	}

--- a/label_test.go
+++ b/label_test.go
@@ -25,13 +25,6 @@ func TestLabelValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "label requires a resourceid",
-			fields: fields{
-				Name: "iot",
-			},
-			wantErr: true,
-		},
-		{
 			name: "label requires a name",
 			fields: fields{
 				ResourceID: platformtesting.MustIDBase16("020f755c3c082000"),
@@ -42,8 +35,7 @@ func TestLabelValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := platform.Label{
-				ResourceID: tt.fields.ResourceID,
-				Name:       tt.fields.Name,
+				Name: tt.fields.Name,
 			}
 			if err := m.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("Label.Validate() error = %v, wantErr %v", err, tt.wantErr)

--- a/mock/label_service.go
+++ b/mock/label_service.go
@@ -13,8 +13,10 @@ type LabelService struct {
 	FindLabelsFn         func(context.Context, platform.LabelFilter) ([]*platform.Label, error)
 	FindResourceLabelsFn func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error)
 	CreateLabelFn        func(context.Context, *platform.Label) error
+	CreateLabelMappingFn func(context.Context, *platform.LabelMapping) error
 	UpdateLabelFn        func(context.Context, *platform.Label, platform.LabelUpdate) (*platform.Label, error)
 	DeleteLabelFn        func(context.Context, platform.ID) error
+	DeleteLabelMappingFn func(context.Context, *platform.LabelMapping) error
 }
 
 // NewLabelService returns a mock of LabelService
@@ -27,9 +29,11 @@ func NewLabelService() *LabelService {
 		FindResourceLabelsFn: func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error) {
 			return nil, nil
 		},
-		CreateLabelFn: func(context.Context, *platform.Label) error { return nil },
-		UpdateLabelFn: func(context.Context, *platform.Label, platform.LabelUpdate) (*platform.Label, error) { return nil, nil },
-		DeleteLabelFn: func(context.Context, platform.ID) error { return nil },
+		CreateLabelFn:        func(context.Context, *platform.Label) error { return nil },
+		CreateLabelMappingFn: func(context.Context, *platform.LabelMapping) error { return nil },
+		UpdateLabelFn:        func(context.Context, *platform.Label, platform.LabelUpdate) (*platform.Label, error) { return nil, nil },
+		DeleteLabelFn:        func(context.Context, platform.ID) error { return nil },
+		DeleteLabelMappingFn: func(context.Context, *platform.LabelMapping) error { return nil },
 	}
 }
 
@@ -48,6 +52,11 @@ func (s *LabelService) CreateLabel(ctx context.Context, l *platform.Label) error
 	return s.CreateLabelFn(ctx, l)
 }
 
+// CreateLabelMapping creates a new Label mapping.
+func (s *LabelService) CreateLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	return s.CreateLabelMappingFn(ctx, m)
+}
+
 // UpdateLabel updates a label.
 func (s *LabelService) UpdateLabel(ctx context.Context, l *platform.Label, upd platform.LabelUpdate) (*platform.Label, error) {
 	return s.UpdateLabelFn(ctx, l, upd)
@@ -56,4 +65,9 @@ func (s *LabelService) UpdateLabel(ctx context.Context, l *platform.Label, upd p
 // DeleteLabel removes a Label.
 func (s *LabelService) DeleteLabel(ctx context.Context, id platform.ID) error {
 	return s.DeleteLabelFn(ctx, id)
+}
+
+// DeleteLabelMapping removes a Label mapping.
+func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
+	return s.DeleteLabelMappingFn(ctx, m)
 }

--- a/mock/label_service.go
+++ b/mock/label_service.go
@@ -15,7 +15,7 @@ type LabelService struct {
 	FindResourceLabelsFn func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error)
 	CreateLabelFn        func(context.Context, *platform.Label) error
 	CreateLabelMappingFn func(context.Context, *platform.LabelMapping) error
-	UpdateLabelFn        func(context.Context, *platform.Label, platform.LabelUpdate) (*platform.Label, error)
+	UpdateLabelFn        func(context.Context, platform.ID, platform.LabelUpdate) (*platform.Label, error)
 	DeleteLabelFn        func(context.Context, platform.ID) error
 	DeleteLabelMappingFn func(context.Context, *platform.LabelMapping) error
 }
@@ -35,7 +35,7 @@ func NewLabelService() *LabelService {
 		},
 		CreateLabelFn:        func(context.Context, *platform.Label) error { return nil },
 		CreateLabelMappingFn: func(context.Context, *platform.LabelMapping) error { return nil },
-		UpdateLabelFn:        func(context.Context, *platform.Label, platform.LabelUpdate) (*platform.Label, error) { return nil, nil },
+		UpdateLabelFn:        func(context.Context, platform.ID, platform.LabelUpdate) (*platform.Label, error) { return nil, nil },
 		DeleteLabelFn:        func(context.Context, platform.ID) error { return nil },
 		DeleteLabelMappingFn: func(context.Context, *platform.LabelMapping) error { return nil },
 	}
@@ -67,8 +67,8 @@ func (s *LabelService) CreateLabelMapping(ctx context.Context, m *platform.Label
 }
 
 // UpdateLabel updates a label.
-func (s *LabelService) UpdateLabel(ctx context.Context, l *platform.Label, upd platform.LabelUpdate) (*platform.Label, error) {
-	return s.UpdateLabelFn(ctx, l, upd)
+func (s *LabelService) UpdateLabel(ctx context.Context, id platform.ID, upd platform.LabelUpdate) (*platform.Label, error) {
+	return s.UpdateLabelFn(ctx, id, upd)
 }
 
 // DeleteLabel removes a Label.

--- a/mock/label_service.go
+++ b/mock/label_service.go
@@ -10,6 +10,7 @@ var _ platform.LabelService = &LabelService{}
 
 // LabelService is a mock implementation of platform.LabelService
 type LabelService struct {
+	FindLabelByIDFn      func(ctx context.Context, id platform.ID) (*platform.Label, error)
 	FindLabelsFn         func(context.Context, platform.LabelFilter) ([]*platform.Label, error)
 	FindResourceLabelsFn func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error)
 	CreateLabelFn        func(context.Context, *platform.Label) error
@@ -23,6 +24,9 @@ type LabelService struct {
 // where its methods will return zero values.
 func NewLabelService() *LabelService {
 	return &LabelService{
+		FindLabelByIDFn: func(ctx context.Context, id platform.ID) (*platform.Label, error) {
+			return nil, nil
+		},
 		FindLabelsFn: func(context.Context, platform.LabelFilter) ([]*platform.Label, error) {
 			return nil, nil
 		},
@@ -35,6 +39,11 @@ func NewLabelService() *LabelService {
 		DeleteLabelFn:        func(context.Context, platform.ID) error { return nil },
 		DeleteLabelMappingFn: func(context.Context, *platform.LabelMapping) error { return nil },
 	}
+}
+
+// FindLabelByID finds mappings by their ID
+func (s *LabelService) FindLabelByID(ctx context.Context, id platform.ID) (*platform.Label, error) {
+	return s.FindLabelByIDFn(ctx, id)
 }
 
 // FindLabels finds mappings that match a given filter.

--- a/mock/label_service.go
+++ b/mock/label_service.go
@@ -31,7 +31,7 @@ func NewLabelService() *LabelService {
 			return nil, nil
 		},
 		FindResourceLabelsFn: func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error) {
-			return nil, nil
+			return []*platform.Label{}, nil
 		},
 		CreateLabelFn:        func(context.Context, *platform.Label) error { return nil },
 		CreateLabelMappingFn: func(context.Context, *platform.LabelMapping) error { return nil },

--- a/mock/label_service.go
+++ b/mock/label_service.go
@@ -10,10 +10,11 @@ var _ platform.LabelService = &LabelService{}
 
 // LabelService is a mock implementation of platform.LabelService
 type LabelService struct {
-	FindLabelsFn  func(context.Context, platform.LabelFilter) ([]*platform.Label, error)
-	CreateLabelFn func(context.Context, *platform.Label) error
-	UpdateLabelFn func(context.Context, *platform.Label, platform.LabelUpdate) (*platform.Label, error)
-	DeleteLabelFn func(context.Context, platform.Label) error
+	FindLabelsFn         func(context.Context, platform.LabelFilter) ([]*platform.Label, error)
+	FindResourceLabelsFn func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error)
+	CreateLabelFn        func(context.Context, *platform.Label) error
+	UpdateLabelFn        func(context.Context, *platform.Label, platform.LabelUpdate) (*platform.Label, error)
+	DeleteLabelFn        func(context.Context, platform.ID) error
 }
 
 // NewLabelService returns a mock of LabelService
@@ -23,15 +24,23 @@ func NewLabelService() *LabelService {
 		FindLabelsFn: func(context.Context, platform.LabelFilter) ([]*platform.Label, error) {
 			return nil, nil
 		},
+		FindResourceLabelsFn: func(context.Context, platform.LabelMappingFilter) ([]*platform.Label, error) {
+			return nil, nil
+		},
 		CreateLabelFn: func(context.Context, *platform.Label) error { return nil },
 		UpdateLabelFn: func(context.Context, *platform.Label, platform.LabelUpdate) (*platform.Label, error) { return nil, nil },
-		DeleteLabelFn: func(context.Context, platform.Label) error { return nil },
+		DeleteLabelFn: func(context.Context, platform.ID) error { return nil },
 	}
 }
 
 // FindLabels finds mappings that match a given filter.
 func (s *LabelService) FindLabels(ctx context.Context, filter platform.LabelFilter, opt ...platform.FindOptions) ([]*platform.Label, error) {
 	return s.FindLabelsFn(ctx, filter)
+}
+
+// FindResourceLabels finds mappings that match a given filter.
+func (s *LabelService) FindResourceLabels(ctx context.Context, filter platform.LabelMappingFilter) ([]*platform.Label, error) {
+	return s.FindResourceLabelsFn(ctx, filter)
 }
 
 // CreateLabel creates a new Label.
@@ -45,6 +54,6 @@ func (s *LabelService) UpdateLabel(ctx context.Context, l *platform.Label, upd p
 }
 
 // DeleteLabel removes a Label.
-func (s *LabelService) DeleteLabel(ctx context.Context, l platform.Label) error {
-	return s.DeleteLabelFn(ctx, l)
+func (s *LabelService) DeleteLabel(ctx context.Context, id platform.ID) error {
+	return s.DeleteLabelFn(ctx, id)
 }

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -54,14 +54,14 @@ func LabelService(
 			name: "CreateLabel",
 			fn:   CreateLabel,
 		},
-		{
-			name: "FindLabels",
-			fn:   FindLabels,
-		},
-		{
-			name: "UpdateLabel",
-			fn:   UpdateLabel,
-		},
+		// {
+		// 	name: "FindLabels",
+		// 	fn:   FindLabels,
+		// },
+		// {
+		// 	name: "UpdateLabel",
+		// 	fn:   UpdateLabel,
+		// },
 		{
 			name: "DeleteLabel",
 			fn:   DeleteLabel,
@@ -505,33 +505,33 @@ func DeleteLabel(
 				},
 			},
 		},
-		{
-			name: "deleting a non-existant label",
-			fields: LabelFields{
-				Labels: []*platform.Label{
-					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
-					},
-				},
-			},
-			args: args{
-				labelID: MustIDBase16(labelTwoID),
-			},
-			wants: wants{
-				labels: []*platform.Label{
-					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
-					},
-				},
-				err: &platform.Error{
-					Code: platform.ENotFound,
-					Op:   platform.OpDeleteLabel,
-					Msg:  "label not found",
-				},
-			},
-		},
+		// {
+		// 	name: "deleting a non-existant label",
+		// 	fields: LabelFields{
+		// 		Labels: []*platform.Label{
+		// 			{
+		// 				ID:   MustIDBase16(labelOneID),
+		// 				Name: "Tag1",
+		// 			},
+		// 		},
+		// 	},
+		// 	args: args{
+		// 		labelID: MustIDBase16(labelTwoID),
+		// 	},
+		// 	wants: wants{
+		// 		labels: []*platform.Label{
+		// 			{
+		// 				ID:   MustIDBase16(labelOneID),
+		// 				Name: "Tag1",
+		// 			},
+		// 		},
+		// 		err: &platform.Error{
+		// 			Code: platform.ENotFound,
+		// 			Op:   platform.OpDeleteLabel,
+		// 			Msg:  "label not found",
+		// 		},
+		// 	},
+		// },
 	}
 
 	for _, tt := range tests {

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -12,9 +12,8 @@ import (
 )
 
 const (
-	labelOneID   = "41a9f7288d4e2d64"
-	labelTwoID   = "b7c5355e1134b11c"
-	labelThreeID = "52ec3216eaf647e4"
+	labelOneID = "41a9f7288d4e2d64"
+	labelTwoID = "b7c5355e1134b11c"
 )
 
 var labelCmpOptions = cmp.Options{

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -54,14 +54,14 @@ func LabelService(
 			name: "CreateLabel",
 			fn:   CreateLabel,
 		},
-		// {
-		// 	name: "FindLabels",
-		// 	fn:   FindLabels,
-		// },
-		// {
-		// 	name: "UpdateLabel",
-		// 	fn:   UpdateLabel,
-		// },
+		{
+			name: "FindLabels",
+			fn:   FindLabels,
+		},
+		{
+			name: "UpdateLabel",
+			fn:   UpdateLabel,
+		},
 		{
 			name: "DeleteLabel",
 			fn:   DeleteLabel,
@@ -505,33 +505,33 @@ func DeleteLabel(
 				},
 			},
 		},
-		// {
-		// 	name: "deleting a non-existant label",
-		// 	fields: LabelFields{
-		// 		Labels: []*platform.Label{
-		// 			{
-		// 				ID:   MustIDBase16(labelOneID),
-		// 				Name: "Tag1",
-		// 			},
-		// 		},
-		// 	},
-		// 	args: args{
-		// 		labelID: MustIDBase16(labelTwoID),
-		// 	},
-		// 	wants: wants{
-		// 		labels: []*platform.Label{
-		// 			{
-		// 				ID:   MustIDBase16(labelOneID),
-		// 				Name: "Tag1",
-		// 			},
-		// 		},
-		// 		err: &platform.Error{
-		// 			Code: platform.ENotFound,
-		// 			Op:   platform.OpDeleteLabel,
-		// 			Msg:  "label not found",
-		// 		},
-		// 	},
-		// },
+		{
+			name: "deleting a non-existant label",
+			fields: LabelFields{
+				Labels: []*platform.Label{
+					{
+						ID:   MustIDBase16(labelOneID),
+						Name: "Tag1",
+					},
+				},
+			},
+			args: args{
+				labelID: MustIDBase16(labelTwoID),
+			},
+			wants: wants{
+				labels: []*platform.Label{
+					{
+						ID:   MustIDBase16(labelOneID),
+						Name: "Tag1",
+					},
+				},
+				err: &platform.Error{
+					Code: platform.ENotFound,
+					Op:   platform.OpDeleteLabel,
+					Msg:  "label not found",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	labelOneID = "41a9f7288d4e2d64"
-	labelTwoID = "b7c5355e1134b11c"
+	labelOneID   = "41a9f7288d4e2d64"
+	labelTwoID   = "b7c5355e1134b11c"
+	labelThreeID = "52ec3216eaf647e4"
 )
 
 var labelCmpOptions = cmp.Options{
@@ -95,11 +96,7 @@ func CreateLabel(
 			name: "basic create label",
 			fields: LabelFields{
 				IDGenerator: mock.NewIDGenerator(labelOneID, t),
-				Labels: []*platform.Label{
-					{
-						Name: "Tag1",
-					},
-				},
+				Labels:      []*platform.Label{},
 			},
 			args: args{
 				label: &platform.Label{
@@ -112,9 +109,7 @@ func CreateLabel(
 			wants: wants{
 				labels: []*platform.Label{
 					{
-						Name: "Tag1",
-					},
-					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag2",
 						Properties: map[string]string{
 							"color": "fff000",
@@ -123,33 +118,34 @@ func CreateLabel(
 				},
 			},
 		},
-		{
-			name: "duplicate labels fail",
-			fields: LabelFields{
-				Labels: []*platform.Label{
-					{
-						Name: "Tag1",
-					},
-				},
-			},
-			args: args{
-				label: &platform.Label{
-					Name: "Tag1",
-				},
-			},
-			wants: wants{
-				labels: []*platform.Label{
-					{
-						Name: "Tag1",
-					},
-				},
-				err: &platform.Error{
-					Code: platform.EConflict,
-					Op:   platform.OpCreateLabel,
-					Msg:  "label Tag1 already exists",
-				},
-			},
-		},
+		// {
+		// 	name: "duplicate labels fail",
+		// 	fields: LabelFields{
+		// 		IDGenerator: mock.NewIDGenerator(labelTwoID, t),
+		// 		Labels: []*platform.Label{
+		// 			{
+		// 				Name: "Tag1",
+		// 			},
+		// 		},
+		// 	},
+		// 	args: args{
+		// 		label: &platform.Label{
+		// 			Name: "Tag1",
+		// 		},
+		// 	},
+		// 	wants: wants{
+		// 		labels: []*platform.Label{
+		// 			{
+		// 				Name: "Tag1",
+		// 			},
+		// 		},
+		// 		err: &platform.Error{
+		// 			Code: platform.EConflict,
+		// 			Op:   platform.OpCreateLabel,
+		// 			Msg:  "label Tag1 already exists",
+		// 		},
+		// 	},
+		// },
 	}
 
 	for _, tt := range tests {
@@ -196,9 +192,11 @@ func FindLabels(
 			fields: LabelFields{
 				Labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 					{
+						ID:   MustIDBase16(labelTwoID),
 						Name: "Tag2",
 					},
 				},
@@ -209,9 +207,11 @@ func FindLabels(
 			wants: wants{
 				labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 					{
+						ID:   MustIDBase16(labelTwoID),
 						Name: "Tag2",
 					},
 				},
@@ -222,13 +222,12 @@ func FindLabels(
 			fields: LabelFields{
 				Labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 					{
+						ID:   MustIDBase16(labelTwoID),
 						Name: "Tag2",
-					},
-					{
-						Name: "Tag1",
 					},
 				},
 			},
@@ -240,6 +239,7 @@ func FindLabels(
 			wants: wants{
 				labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 				},
@@ -267,8 +267,8 @@ func UpdateLabel(
 	t *testing.T,
 ) {
 	type args struct {
-		label  platform.Label
-		update platform.LabelUpdate
+		labelID platform.ID
+		update  platform.LabelUpdate
 	}
 	type wants struct {
 		err    error
@@ -286,14 +286,13 @@ func UpdateLabel(
 			fields: LabelFields{
 				Labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 				},
 			},
 			args: args{
-				label: platform.Label{
-					Name: "Tag1",
-				},
+				labelID: MustIDBase16(labelOneID),
 				update: platform.LabelUpdate{
 					Properties: map[string]string{
 						"color": "fff000",
@@ -303,6 +302,7 @@ func UpdateLabel(
 			wants: wants{
 				labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 						Properties: map[string]string{
 							"color": "fff000",
@@ -316,6 +316,7 @@ func UpdateLabel(
 			fields: LabelFields{
 				Labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 						Properties: map[string]string{
 							"color":       "fff000",
@@ -325,9 +326,7 @@ func UpdateLabel(
 				},
 			},
 			args: args{
-				label: platform.Label{
-					Name: "Tag1",
-				},
+				labelID: MustIDBase16(labelOneID),
 				update: platform.LabelUpdate{
 					Properties: map[string]string{
 						"color": "abc123",
@@ -337,6 +336,7 @@ func UpdateLabel(
 			wants: wants{
 				labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 						Properties: map[string]string{
 							"color":       "abc123",
@@ -351,6 +351,7 @@ func UpdateLabel(
 			fields: LabelFields{
 				Labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 						Properties: map[string]string{
 							"color":       "fff000",
@@ -360,9 +361,7 @@ func UpdateLabel(
 				},
 			},
 			args: args{
-				label: platform.Label{
-					Name: "Tag1",
-				},
+				labelID: MustIDBase16(labelOneID),
 				update: platform.LabelUpdate{
 					Properties: map[string]string{
 						"description": "",
@@ -372,6 +371,7 @@ func UpdateLabel(
 			wants: wants{
 				labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 						Properties: map[string]string{
 							"color": "fff000",
@@ -424,9 +424,7 @@ func UpdateLabel(
 				Labels: []*platform.Label{},
 			},
 			args: args{
-				label: platform.Label{
-					Name: "Tag1",
-				},
+				labelID: MustIDBase16(labelOneID),
 				update: platform.LabelUpdate{
 					Properties: map[string]string{
 						"color": "fff000",
@@ -438,6 +436,7 @@ func UpdateLabel(
 				err: &platform.Error{
 					Code: platform.ENotFound,
 					Op:   platform.OpUpdateLabel,
+					Msg:  "label not found",
 				},
 			},
 		},
@@ -448,7 +447,7 @@ func UpdateLabel(
 			s, opPrefix, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
-			_, err := s.UpdateLabel(ctx, &tt.args.label, tt.args.update)
+			_, err := s.UpdateLabel(ctx, tt.args.labelID, tt.args.update)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
 			labels, err := s.FindLabels(ctx, platform.LabelFilter{})
@@ -467,7 +466,7 @@ func DeleteLabel(
 	t *testing.T,
 ) {
 	type args struct {
-		label platform.Label
+		labelID platform.ID
 	}
 	type wants struct {
 		err    error
@@ -485,21 +484,22 @@ func DeleteLabel(
 			fields: LabelFields{
 				Labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 					{
+						ID:   MustIDBase16(labelTwoID),
 						Name: "Tag2",
 					},
 				},
 			},
 			args: args{
-				label: platform.Label{
-					Name: "Tag1",
-				},
+				labelID: MustIDBase16(labelOneID),
 			},
 			wants: wants{
 				labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelTwoID),
 						Name: "Tag2",
 					},
 				},
@@ -510,24 +510,25 @@ func DeleteLabel(
 			fields: LabelFields{
 				Labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 				},
 			},
 			args: args{
-				label: platform.Label{
-					Name: "Tag2",
-				},
+				labelID: MustIDBase16(labelTwoID),
 			},
 			wants: wants{
 				labels: []*platform.Label{
 					{
+						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 				},
 				err: &platform.Error{
 					Code: platform.ENotFound,
 					Op:   platform.OpDeleteLabel,
+					Msg:  "label not found",
 				},
 			},
 		},
@@ -538,7 +539,7 @@ func DeleteLabel(
 			s, opPrefix, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
-			err := s.DeleteLabel(ctx, tt.args.label.ID)
+			err := s.DeleteLabel(ctx, tt.args.labelID)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
 			labels, err := s.FindLabels(ctx, platform.LabelFilter{})

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -204,8 +204,8 @@ func CreateLabelMapping(
 			},
 			args: args{
 				mapping: &platform.LabelMapping{
-					LabelID:    MustIDBase16(labelOneID),
-					ResourceID: MustIDBase16(bucketOneID),
+					LabelID:    IDPtr(MustIDBase16(labelOneID)),
+					ResourceID: IDPtr(MustIDBase16(bucketOneID)),
 				},
 				filter: platform.LabelMappingFilter{
 					ResourceID: MustIDBase16(bucketOneID),
@@ -258,7 +258,7 @@ func CreateLabelMapping(
 
 			defer s.DeleteLabelMapping(ctx, tt.args.mapping)
 
-			labels, err := s.FindResourceLabels(ctx, platform.LabelMappingFilter{})
+			labels, err := s.FindResourceLabels(ctx, tt.args.filter)
 			if err != nil {
 				t.Fatalf("failed to retrieve labels: %v", err)
 			}

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -55,6 +55,10 @@ func LabelService(
 			fn:   CreateLabel,
 		},
 		{
+			name: "CreateLabelMapping",
+			fn:   CreateLabelMapping,
+		},
+		{
 			name: "FindLabels",
 			fn:   FindLabels,
 		},
@@ -159,6 +163,102 @@ func CreateLabel(
 			defer s.DeleteLabel(ctx, tt.args.label.ID)
 
 			labels, err := s.FindLabels(ctx, platform.LabelFilter{})
+			if err != nil {
+				t.Fatalf("failed to retrieve labels: %v", err)
+			}
+			if diff := cmp.Diff(labels, tt.wants.labels, labelCmpOptions...); diff != "" {
+				t.Errorf("labels are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+func CreateLabelMapping(
+	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	t *testing.T,
+) {
+	type args struct {
+		mapping *platform.LabelMapping
+		filter  platform.LabelMappingFilter
+	}
+	type wants struct {
+		err    error
+		labels []*platform.Label
+	}
+
+	tests := []struct {
+		name   string
+		fields LabelFields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "create label mapping",
+			fields: LabelFields{
+				Labels: []*platform.Label{
+					{
+						ID:   MustIDBase16(labelOneID),
+						Name: "Tag1",
+					},
+				},
+			},
+			args: args{
+				mapping: &platform.LabelMapping{
+					LabelID:    MustIDBase16(labelOneID),
+					ResourceID: MustIDBase16(bucketOneID),
+				},
+				filter: platform.LabelMappingFilter{
+					ResourceID: MustIDBase16(bucketOneID),
+				},
+			},
+			wants: wants{
+				labels: []*platform.Label{
+					{
+						ID:   MustIDBase16(labelOneID),
+						Name: "Tag1",
+					},
+				},
+			},
+		},
+		// {
+		// 	name: "mapping to a non-existing label",
+		// 	fields: LabelFields{
+		// 		IDGenerator: mock.NewIDGenerator(labelOneID, t),
+		// 		Labels:      []*platform.Label{},
+		// 	},
+		// 	args: args{
+		// 		label: &platform.Label{
+		// 			Name: "Tag2",
+		// 			Properties: map[string]string{
+		// 				"color": "fff000",
+		// 			},
+		// 		},
+		// 	},
+		// 	wants: wants{
+		// 		labels: []*platform.Label{
+		// 			{
+		// 				ID:   MustIDBase16(labelOneID),
+		// 				Name: "Tag2",
+		// 				Properties: map[string]string{
+		// 					"color": "fff000",
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, opPrefix, done := init(tt.fields, t)
+			defer done()
+			ctx := context.Background()
+			err := s.CreateLabelMapping(ctx, tt.args.mapping)
+			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
+
+			defer s.DeleteLabelMapping(ctx, tt.args.mapping)
+
+			labels, err := s.FindResourceLabels(ctx, platform.LabelMappingFilter{})
 			if err != nil {
 				t.Fatalf("failed to retrieve labels: %v", err)
 			}


### PR DESCRIPTION
The current labels implementation is 💩. One of the biggest problems it stores a label internally as a hybrid between the label information itself, and the mapping between that and a resource; this means that resources can't share label information, and need to be updated individually. The endpoints for it are also nested on the resources they belong to, making it awkward to update/delete a label.

This PR splits the service in two:
- Firstly, we have a new set of first-class CRUD endpoints for a label, on `/api/v2/labels` and `/api/v2/labels/{labelID}`. These are used for creating/updating/deleting labels.
- The old suffix routes (e.g. `/api/v2/tasks/{taskID}/labels`) endpoints still exist, but they've been simplified. They're now only used for assigning/removing labels to/from resources.
- Requests to labelable resources will still return all of their labels in their response.

Internally, the boltdb implementation stores label information in two separate buckets; the label, and mappings between that label and other resources.