### PR TITLE
Authorize macros

### DIFF
--- a/authorizer/macro.go
+++ b/authorizer/macro.go
@@ -1,0 +1,149 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.MacroService = (*MacroService)(nil)
+
+// MacroService wraps a influxdb.MacroService and authorizes actions
+// against it appropriately.
+type MacroService struct {
+	s influxdb.MacroService
+}
+
+// NewMacroService constructs an instance of an authorizing macro service.
+func NewMacroService(s influxdb.MacroService) *MacroService {
+	return &MacroService{
+		s: s,
+	}
+}
+
+func newMacroPermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
+	return influxdb.NewPermissionAtID(id, a, influxdb.MacrosResourceType, orgID)
+}
+
+func authorizeReadMacro(ctx context.Context, orgID, id influxdb.ID) error {
+	p, err := newMacroPermission(influxdb.ReadAction, orgID, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func authorizeWriteMacro(ctx context.Context, orgID, id influxdb.ID) error {
+	p, err := newMacroPermission(influxdb.WriteAction, orgID, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FindMacroByID checks to see if the authorizer on context has read access to the id provided.
+func (s *MacroService) FindMacroByID(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+	m, err := s.s.FindMacroByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeReadMacro(ctx, m.OrganizationID, id); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// FindMacros retrieves all macros that match the provided filter and then filters the list down to only the resources that are authorized.
+func (s *MacroService) FindMacros(ctx context.Context, filter influxdb.MacroFilter, opt ...influxdb.FindOptions) ([]*influxdb.Macro, error) {
+	// TODO: we'll likely want to push this operation into the database since fetching the whole list of data will likely be expensive.
+	ms, err := s.s.FindMacros(ctx, filter, opt...)
+	if err != nil {
+		return nil, err
+	}
+
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	macros := ms[:0]
+	for _, m := range ms {
+		err := authorizeReadMacro(ctx, m.OrganizationID, m.ID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, err
+		}
+
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+
+		macros = append(macros, m)
+	}
+
+	return macros, nil
+}
+
+// CreateMacro checks to see if the authorizer on context has write access to the global macro resource.
+func (s *MacroService) CreateMacro(ctx context.Context, m *influxdb.Macro) error {
+	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.MacrosResourceType, m.OrganizationID)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return s.s.CreateMacro(ctx, m)
+}
+
+// UpdateMacro checks to see if the authorizer on context has write access to the macro provided.
+func (s *MacroService) UpdateMacro(ctx context.Context, id influxdb.ID, upd *influxdb.MacroUpdate) (*influxdb.Macro, error) {
+	m, err := s.FindMacroByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeWriteMacro(ctx, m.OrganizationID, id); err != nil {
+		return nil, err
+	}
+
+	return s.s.UpdateMacro(ctx, id, upd)
+}
+
+// ReplaceMacro checks to see if the authorizer on context has write access to the macro provided.
+func (s *MacroService) ReplaceMacro(ctx context.Context, m *influxdb.Macro) error {
+	m, err := s.FindMacroByID(ctx, m.ID)
+	if err != nil {
+		return err
+	}
+
+	if err := authorizeWriteMacro(ctx, m.OrganizationID, m.ID); err != nil {
+		return err
+	}
+
+	return s.s.ReplaceMacro(ctx, m)
+}
+
+// DeleteMacro checks to see if the authorizer on context has write access to the macro provided.
+func (s *MacroService) DeleteMacro(ctx context.Context, id influxdb.ID) error {
+	m, err := s.FindMacroByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := authorizeWriteMacro(ctx, m.OrganizationID, id); err != nil {
+		return err
+	}
+
+	return s.s.DeleteMacro(ctx, id)
+}

--- a/authorizer/macro_test.go
+++ b/authorizer/macro_test.go
@@ -1,0 +1,654 @@
+package authorizer_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+var macroCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	cmp.Transformer("Sort", func(in []*influxdb.Macro) []*influxdb.Macro {
+		out := append([]*influxdb.Macro(nil), in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID.String() > out[j].ID.String()
+		})
+		return out
+	}),
+}
+
+func TestMacroService_FindMacroByID(t *testing.T) {
+	type fields struct {
+		MacroService influxdb.MacroService
+	}
+	type args struct {
+		permission influxdb.Permission
+		id         influxdb.ID
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access id",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacroByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             id,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.MacrosResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to access id",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacroByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             id,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.MacrosResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:orgs/000000000000000a/macros/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewMacroService(tt.fields.MacroService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			_, err := s.FindMacroByID(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestMacroService_FindMacros(t *testing.T) {
+	type fields struct {
+		MacroService influxdb.MacroService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err    error
+		macros []*influxdb.Macro
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to see all macros",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacrosF: func(ctx context.Context, filter influxdb.MacroFilter, opt ...influxdb.FindOptions) ([]*influxdb.Macro, error) {
+						return []*influxdb.Macro{
+							{
+								ID:             1,
+								OrganizationID: 10,
+							},
+							{
+								ID:             2,
+								OrganizationID: 10,
+							},
+							{
+								ID:             3,
+								OrganizationID: 11,
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.MacrosResourceType,
+					},
+				},
+			},
+			wants: wants{
+				macros: []*influxdb.Macro{
+					{
+						ID:             1,
+						OrganizationID: 10,
+					},
+					{
+						ID:             2,
+						OrganizationID: 10,
+					},
+					{
+						ID:             3,
+						OrganizationID: 11,
+					},
+				},
+			},
+		},
+		{
+			name: "authorized to access a single orgs macros",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacrosF: func(ctx context.Context, filter influxdb.MacroFilter, opt ...influxdb.FindOptions) ([]*influxdb.Macro, error) {
+						return []*influxdb.Macro{
+							{
+								ID:             1,
+								OrganizationID: 10,
+							},
+							{
+								ID:             2,
+								OrganizationID: 10,
+							},
+							{
+								ID:             3,
+								OrganizationID: 11,
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.MacrosResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				macros: []*influxdb.Macro{
+					{
+						ID:             1,
+						OrganizationID: 10,
+					},
+					{
+						ID:             2,
+						OrganizationID: 10,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewMacroService(tt.fields.MacroService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			macros, err := s.FindMacros(ctx, influxdb.MacroFilter{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+
+			if diff := cmp.Diff(macros, tt.wants.macros, macroCmpOptions...); diff != "" {
+				t.Errorf("macros are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+func TestMacroService_UpdateMacro(t *testing.T) {
+	type fields struct {
+		MacroService influxdb.MacroService
+	}
+	type args struct {
+		id          influxdb.ID
+		permissions []influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to update macro",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacroByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					UpdateMacroF: func(ctx context.Context, id influxdb.ID, upd *influxdb.MacroUpdate) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "write",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to update macro",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacroByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					UpdateMacroF: func(ctx context.Context, id influxdb.ID, upd *influxdb.MacroUpdate) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/000000000000000a/macros/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewMacroService(tt.fields.MacroService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
+
+			_, err := s.UpdateMacro(ctx, tt.args.id, &influxdb.MacroUpdate{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestMacroService_ReplaceMacro(t *testing.T) {
+	type fields struct {
+		MacroService influxdb.MacroService
+	}
+	type args struct {
+		macro       influxdb.Macro
+		permissions []influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to replace macro",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacroByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					ReplaceMacroF: func(ctx context.Context, m *influxdb.Macro) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				macro: influxdb.Macro{
+					ID:             1,
+					OrganizationID: 10,
+					Name:           "replace",
+				},
+				permissions: []influxdb.Permission{
+					{
+						Action: "write",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to replace macro",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacroByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					ReplaceMacroF: func(ctx context.Context, m *influxdb.Macro) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				macro: influxdb.Macro{
+					ID:             1,
+					OrganizationID: 10,
+				},
+				permissions: []influxdb.Permission{
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/000000000000000a/macros/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewMacroService(tt.fields.MacroService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
+
+			err := s.ReplaceMacro(ctx, &tt.args.macro)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestMacroService_DeleteMacro(t *testing.T) {
+	type fields struct {
+		MacroService influxdb.MacroService
+	}
+	type args struct {
+		id          influxdb.ID
+		permissions []influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to delete macro",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacroByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					DeleteMacroF: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "write",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to delete macro",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					FindMacroByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+						return &influxdb.Macro{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					DeleteMacroF: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.MacrosResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/000000000000000a/macros/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewMacroService(tt.fields.MacroService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
+
+			err := s.DeleteMacro(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestMacroService_CreateMacro(t *testing.T) {
+	type fields struct {
+		MacroService influxdb.MacroService
+	}
+	type args struct {
+		permission influxdb.Permission
+		orgID      influxdb.ID
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to create macro",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					CreateMacroF: func(ctx context.Context, o *influxdb.Macro) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				orgID: 10,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type:  influxdb.MacrosResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to create macro",
+			fields: fields{
+				MacroService: &mock.MacroService{
+					CreateMacroF: func(ctx context.Context, o *influxdb.Macro) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				orgID: 10,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.MacrosResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/000000000000000a/macros is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewMacroService(tt.fields.MacroService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			err := s.CreateMacro(ctx, &influxdb.Macro{OrganizationID: tt.args.orgID})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}

--- a/authz.go
+++ b/authz.go
@@ -111,6 +111,8 @@ const (
 	TelegrafsResourceType = ResourceType("telegrafs") // 6
 	// UsersResourceType gives permissions to one or more users.
 	UsersResourceType = ResourceType("users") // 7
+	// MacrosResourceType gives permission to one or more macros.
+	MacrosResourceType = ResourceType("macros") // 8
 )
 
 // AllResourceTypes is the list of all known resource types.
@@ -123,6 +125,7 @@ var AllResourceTypes = []ResourceType{
 	TasksResourceType,          // 5
 	TelegrafsResourceType,      // 6
 	UsersResourceType,          // 7
+	MacrosResourceType,         // 8
 }
 
 // OrgResourceTypes is the list of all known resource types that belong to an organization.
@@ -133,6 +136,7 @@ var OrgResourceTypes = []ResourceType{
 	TasksResourceType,      // 5
 	TelegrafsResourceType,  // 6
 	UsersResourceType,      // 7
+	MacrosResourceType,     // 8
 }
 
 // Valid checks if the resource is a member of the Resource enum.
@@ -149,7 +153,8 @@ func (t ResourceType) Valid() (err error) {
 	case TasksResourceType: // 4
 	case TelegrafsResourceType: // 5
 	case SourcesResourceType: // 6
-	case UsersResourceType: //7
+	case UsersResourceType: // 7
+	case MacrosResourceType: // 8
 	default:
 		err = ErrInvalidResourceType
 	}

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -4,7 +4,7 @@ import (
 	http "net/http"
 	"strings"
 
-	platform "github.com/influxdata/influxdb"
+	influxdb "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/authorizer"
 	"github.com/influxdata/influxdb/chronograf/server"
 	"github.com/influxdata/influxdb/query"
@@ -39,34 +39,34 @@ type APIBackend struct {
 	DeveloperMode bool
 	Logger        *zap.Logger
 
-	NewBucketService func(*platform.Source) (platform.BucketService, error)
-	NewQueryService  func(*platform.Source) (query.ProxyQueryService, error)
+	NewBucketService func(*influxdb.Source) (influxdb.BucketService, error)
+	NewQueryService  func(*influxdb.Source) (query.ProxyQueryService, error)
 
 	PointsWriter                    storage.PointsWriter
-	AuthorizationService            platform.AuthorizationService
-	BucketService                   platform.BucketService
-	SessionService                  platform.SessionService
-	UserService                     platform.UserService
-	OrganizationService             platform.OrganizationService
-	UserResourceMappingService      platform.UserResourceMappingService
-	LabelService                    platform.LabelService
-	DashboardService                platform.DashboardService
-	DashboardOperationLogService    platform.DashboardOperationLogService
-	BucketOperationLogService       platform.BucketOperationLogService
-	UserOperationLogService         platform.UserOperationLogService
-	OrganizationOperationLogService platform.OrganizationOperationLogService
-	SourceService                   platform.SourceService
-	MacroService                    platform.MacroService
-	BasicAuthService                platform.BasicAuthService
-	OnboardingService               platform.OnboardingService
+	AuthorizationService            influxdb.AuthorizationService
+	BucketService                   influxdb.BucketService
+	SessionService                  influxdb.SessionService
+	UserService                     influxdb.UserService
+	OrganizationService             influxdb.OrganizationService
+	UserResourceMappingService      influxdb.UserResourceMappingService
+	LabelService                    influxdb.LabelService
+	DashboardService                influxdb.DashboardService
+	DashboardOperationLogService    influxdb.DashboardOperationLogService
+	BucketOperationLogService       influxdb.BucketOperationLogService
+	UserOperationLogService         influxdb.UserOperationLogService
+	OrganizationOperationLogService influxdb.OrganizationOperationLogService
+	SourceService                   influxdb.SourceService
+	MacroService                    influxdb.MacroService
+	BasicAuthService                influxdb.BasicAuthService
+	OnboardingService               influxdb.OnboardingService
 	ProxyQueryService               query.ProxyQueryService
-	TaskService                     platform.TaskService
-	TelegrafService                 platform.TelegrafConfigStore
-	ScraperTargetStoreService       platform.ScraperTargetStoreService
-	SecretService                   platform.SecretService
-	LookupService                   platform.LookupService
+	TaskService                     influxdb.TaskService
+	TelegrafService                 influxdb.TelegrafConfigStore
+	ScraperTargetStoreService       influxdb.ScraperTargetStoreService
+	SecretService                   influxdb.SecretService
+	LookupService                   influxdb.LookupService
 	ChronografService               *server.Service
-	ProtoService                    platform.ProtoService
+	ProtoService                    influxdb.ProtoService
 }
 
 // NewAPIHandler constructs all api handlers beneath it and returns an APIHandler
@@ -96,7 +96,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.DashboardHandler.DashboardOperationLogService = b.DashboardOperationLogService
 
 	h.MacroHandler = NewMacroHandler()
-	h.MacroHandler.MacroService = b.MacroService
+	h.MacroHandler.MacroService = authorizer.NewMacroService(b.MacroService)
 
 	h.AuthorizationHandler = NewAuthorizationHandler(b.UserService)
 	h.AuthorizationHandler.OrganizationService = b.OrganizationService


### PR DESCRIPTION
Closes #11201

Closes part of #10814 

_Briefly describe your proposed changes:_
This PR introduces a macro service for authorizing requests.


  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
