### PR TITLE
Authorize sources

### DIFF
--- a/authorizer/source.go
+++ b/authorizer/source.go
@@ -122,7 +122,7 @@ func (s *SourceService) CreateSource(ctx context.Context, src *influxdb.Source) 
 
 // UpdateSource checks to see if the authorizer on context has write access to the source provided.
 func (s *SourceService) UpdateSource(ctx context.Context, id influxdb.ID, upd influxdb.SourceUpdate) (*influxdb.Source, error) {
-	src, err := s.FindSourceByID(ctx, id)
+	src, err := s.s.FindSourceByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (s *SourceService) UpdateSource(ctx context.Context, id influxdb.ID, upd in
 
 // DeleteSource checks to see if the authorizer on context has write access to the source provided.
 func (s *SourceService) DeleteSource(ctx context.Context, id influxdb.ID) error {
-	m, err := s.FindSourceByID(ctx, id)
+	m, err := s.s.FindSourceByID(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/authorizer/source.go
+++ b/authorizer/source.go
@@ -1,0 +1,149 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.SourceService = (*SourceService)(nil)
+
+// SourceService wraps a influxdb.SourceService and authorizes actions
+// against it appropriately.
+type SourceService struct {
+	s influxdb.SourceService
+}
+
+// NewSourceService constructs an instance of an authorizing source service.
+func NewSourceService(s influxdb.SourceService) *SourceService {
+	return &SourceService{
+		s: s,
+	}
+}
+
+func newSourcePermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
+	return influxdb.NewPermissionAtID(id, a, influxdb.SourcesResourceType, orgID)
+}
+
+func authorizeReadSource(ctx context.Context, orgID, id influxdb.ID) error {
+	p, err := newSourcePermission(influxdb.ReadAction, orgID, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func authorizeWriteSource(ctx context.Context, orgID, id influxdb.ID) error {
+	p, err := newSourcePermission(influxdb.WriteAction, orgID, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DefaultSource checks to see if the authorizer on context has read access to the default source.
+func (s *SourceService) DefaultSource(ctx context.Context) (*influxdb.Source, error) {
+	src, err := s.s.DefaultSource(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeReadSource(ctx, src.OrganizationID, src.ID); err != nil {
+		return nil, err
+	}
+
+	return src, nil
+}
+
+// FindSourceByID checks to see if the authorizer on context has read access to the id provided.
+func (s *SourceService) FindSourceByID(ctx context.Context, id influxdb.ID) (*influxdb.Source, error) {
+	src, err := s.s.FindSourceByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeReadSource(ctx, src.OrganizationID, id); err != nil {
+		return nil, err
+	}
+
+	return src, nil
+}
+
+// FindSources retrieves all sources that match the provided options and then filters the list down to only the resources that are authorized.
+func (s *SourceService) FindSources(ctx context.Context, opts influxdb.FindOptions) ([]*influxdb.Source, int, error) {
+	// TODO: we'll likely want to push this operation into the database since fetching the whole list of data will likely be expensive.
+	ss, _, err := s.s.FindSources(ctx, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	sources := ss[:0]
+	for _, src := range ss {
+		err := authorizeReadSource(ctx, src.OrganizationID, src.ID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+
+		sources = append(sources, src)
+	}
+
+	return sources, len(sources), nil
+}
+
+// CreateSource checks to see if the authorizer on context has write access to the global source resource.
+func (s *SourceService) CreateSource(ctx context.Context, src *influxdb.Source) error {
+	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.SourcesResourceType, src.OrganizationID)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return s.s.CreateSource(ctx, src)
+}
+
+// UpdateSource checks to see if the authorizer on context has write access to the source provided.
+func (s *SourceService) UpdateSource(ctx context.Context, id influxdb.ID, upd influxdb.SourceUpdate) (*influxdb.Source, error) {
+	src, err := s.FindSourceByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeWriteSource(ctx, src.OrganizationID, id); err != nil {
+		return nil, err
+	}
+
+	return s.s.UpdateSource(ctx, id, upd)
+}
+
+// DeleteSource checks to see if the authorizer on context has write access to the source provided.
+func (s *SourceService) DeleteSource(ctx context.Context, id influxdb.ID) error {
+	m, err := s.FindSourceByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := authorizeWriteSource(ctx, m.OrganizationID, id); err != nil {
+		return err
+	}
+
+	return s.s.DeleteSource(ctx, id)
+}

--- a/authorizer/source_test.go
+++ b/authorizer/source_test.go
@@ -1,0 +1,627 @@
+package authorizer_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+var sourceCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	cmp.Transformer("Sort", func(in []*influxdb.Source) []*influxdb.Source {
+		out := append([]*influxdb.Source(nil), in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID.String() > out[j].ID.String()
+		})
+		return out
+	}),
+}
+
+func TestSourceService_DefaultSource(t *testing.T) {
+	type fields struct {
+		SourceService influxdb.SourceService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access id",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					DefaultSourceFn: func(ctx context.Context) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.SourcesResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to access id",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					DefaultSourceFn: func(ctx context.Context) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.SourcesResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:orgs/000000000000000a/sources/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewSourceService(tt.fields.SourceService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			_, err := s.DefaultSource(ctx)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestSourceService_FindSourceByID(t *testing.T) {
+	type fields struct {
+		SourceService influxdb.SourceService
+	}
+	type args struct {
+		permission influxdb.Permission
+		id         influxdb.ID
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access id",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					FindSourceByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             id,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.SourcesResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to access id",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					FindSourceByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             id,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.SourcesResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:orgs/000000000000000a/sources/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewSourceService(tt.fields.SourceService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			_, err := s.FindSourceByID(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestSourceService_FindSources(t *testing.T) {
+	type fields struct {
+		SourceService influxdb.SourceService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err     error
+		sources []*influxdb.Source
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to see all sources",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					FindSourcesFn: func(ctx context.Context, opts influxdb.FindOptions) ([]*influxdb.Source, int, error) {
+						return []*influxdb.Source{
+							{
+								ID:             1,
+								OrganizationID: 10,
+							},
+							{
+								ID:             2,
+								OrganizationID: 10,
+							},
+							{
+								ID:             3,
+								OrganizationID: 11,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.SourcesResourceType,
+					},
+				},
+			},
+			wants: wants{
+				sources: []*influxdb.Source{
+					{
+						ID:             1,
+						OrganizationID: 10,
+					},
+					{
+						ID:             2,
+						OrganizationID: 10,
+					},
+					{
+						ID:             3,
+						OrganizationID: 11,
+					},
+				},
+			},
+		},
+		{
+			name: "authorized to access a single org sources",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					FindSourcesFn: func(ctx context.Context, opts influxdb.FindOptions) ([]*influxdb.Source, int, error) {
+						return []*influxdb.Source{
+							{
+								ID:             1,
+								OrganizationID: 10,
+							},
+							{
+								ID:             2,
+								OrganizationID: 10,
+							},
+							{
+								ID:             3,
+								OrganizationID: 11,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.SourcesResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				sources: []*influxdb.Source{
+					{
+						ID:             1,
+						OrganizationID: 10,
+					},
+					{
+						ID:             2,
+						OrganizationID: 10,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewSourceService(tt.fields.SourceService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			sources, _, err := s.FindSources(ctx, influxdb.DefaultSourceFindOptions)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+
+			if diff := cmp.Diff(sources, tt.wants.sources, sourceCmpOptions...); diff != "" {
+				t.Errorf("sources are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+func TestSourceService_UpdateSource(t *testing.T) {
+	type fields struct {
+		SourceService influxdb.SourceService
+	}
+	type args struct {
+		id          influxdb.ID
+		permissions []influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to update source",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					FindSourceByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					UpdateSourceFn: func(ctx context.Context, id influxdb.ID, upd influxdb.SourceUpdate) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "write",
+						Resource: influxdb.Resource{
+							Type: influxdb.SourcesResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.SourcesResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to update source",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					FindSourceByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					UpdateSourceFn: func(ctx context.Context, id influxdb.ID, upd influxdb.SourceUpdate) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.SourcesResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/000000000000000a/sources/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewSourceService(tt.fields.SourceService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
+
+			_, err := s.UpdateSource(ctx, tt.args.id, influxdb.SourceUpdate{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestSourceService_DeleteSource(t *testing.T) {
+	type fields struct {
+		SourceService influxdb.SourceService
+	}
+	type args struct {
+		id          influxdb.ID
+		permissions []influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to delete source",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					FindSourceByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					DeleteSourceFn: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "write",
+						Resource: influxdb.Resource{
+							Type: influxdb.SourcesResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.SourcesResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to delete source",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					FindSourceByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Source, error) {
+						return &influxdb.Source{
+							ID:             1,
+							OrganizationID: 10,
+						}, nil
+					},
+					DeleteSourceFn: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.SourcesResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/000000000000000a/sources/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewSourceService(tt.fields.SourceService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
+
+			err := s.DeleteSource(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestSourceService_CreateSource(t *testing.T) {
+	type fields struct {
+		SourceService influxdb.SourceService
+	}
+	type args struct {
+		permission influxdb.Permission
+		orgID      influxdb.ID
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to create Source",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					CreateSourceFn: func(ctx context.Context, o *influxdb.Source) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				orgID: 10,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type:  influxdb.SourcesResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to create Source",
+			fields: fields{
+				SourceService: &mock.SourceService{
+					CreateSourceFn: func(ctx context.Context, o *influxdb.Source) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				orgID: 10,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.SourcesResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/000000000000000a/sources is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewSourceService(tt.fields.SourceService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			err := s.CreateSource(ctx, &influxdb.Source{OrganizationID: tt.args.orgID})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -111,7 +111,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.ScraperHandler.Logger = b.Logger.With(zap.String("handler", "scraper"))
 
 	h.SourceHandler = NewSourceHandler()
-	h.SourceHandler.SourceService = b.SourceService
+	h.SourceHandler.SourceService = authorizer.NewSourceService(b.SourceService)
 	h.SourceHandler.NewBucketService = b.NewBucketService
 	h.SourceHandler.NewQueryService = b.NewQueryService
 

--- a/source.go
+++ b/source.go
@@ -75,6 +75,9 @@ type SourceService interface {
 	DeleteSource(ctx context.Context, id ID) error
 }
 
+// DefaultSourceFindOptions are the default find options for sources
+var DefaultSourceFindOptions = FindOptions{}
+
 // SourceUpdate represents updates to a source.
 type SourceUpdate struct {
 	Name               *string     `json:"name"`


### PR DESCRIPTION
Closes #11201
Closes part of #10814

_Briefly describe your proposed changes:_
This PR introduces a source service for authorizing requests.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
