### PR TITLE
fix(scraper): remove enriched type label

### DIFF
--- a/gather/metrics.go
+++ b/gather/metrics.go
@@ -37,9 +37,7 @@ func (ms MetricsSlice) Points() (models.Points, error) {
 		if err != nil {
 			return ps, err
 		}
-		if m.Type.Valid() {
-			point.AddTag("type", m.Type.String())
-		}
+
 		ps[mi] = point
 	}
 	return ps, nil
@@ -54,13 +52,12 @@ func (ms MetricsSlice) Reader() (io.Reader, error) {
 		if err != nil {
 			return nil, err
 		}
-		if m.Type.Valid() {
-			point.AddTag("type", m.Type.String())
-		}
+
 		_, err = buf.WriteString(point.String())
 		if err != nil {
 			return nil, err
 		}
+
 		if mi < len(ms)-1 && len(ms) > 1 {
 			_, err = buf.WriteString("\n")
 			if err != nil {

--- a/gather/metrics_test.go
+++ b/gather/metrics_test.go
@@ -31,6 +31,23 @@ func TestMetricsReader(t *testing.T) {
 			wants: "cpu_load_short value=0.64 1422568543702900257",
 		},
 		{
+			name: "gauge with type label produces lineprotocol with one type",
+			ms: []Metrics{
+				{
+					Name: "error_metric",
+					Tags: map[string]string{
+						"type": "gauge",
+					},
+					Fields: map[string]interface{}{
+						"value": "yes",
+					},
+					Type:      MetricTypeGauge,
+					Timestamp: time.Unix(0, 1422568543702900257),
+				},
+			},
+			wants: `error_metric,type=gauge value="yes" 1422568543702900257`,
+		},
+		{
 			name: "single regular metrics",
 			ms: []Metrics{
 				{
@@ -46,7 +63,7 @@ func TestMetricsReader(t *testing.T) {
 					Timestamp: time.Unix(0, 1422568543702900257),
 				},
 			},
-			wants: "cpu_load_short,host=server01,region=us-west,type=GAUGE value=0.64 1422568543702900257",
+			wants: "cpu_load_short,host=server01,region=us-west value=0.64 1422568543702900257",
 		},
 		{
 			name: "multiple value only",


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Scraping was enriching the tag set by adding the
prometheus data type in the tag key name, "type."

If a scraped metric already had the tag, "type," then
this would cause errors far away from problem in flux.

Co-authored-by: Kelvin Wang <sherkrainwang@gmail.com>

Closes #11054 

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
