### PR TITLE
Change interval label in TaskForm to every

### DIFF
--- a/ui/src/tasks/components/TaskForm.tsx
+++ b/ui/src/tasks/components/TaskForm.tsx
@@ -97,13 +97,13 @@ export default class TaskForm extends PureComponent<Props, State> {
                 >
                   <Radio shape={ButtonShape.StretchToFit}>
                     <Radio.Button
-                      id="interval"
+                      id="every"
                       active={taskScheduleType === TaskSchedule.interval}
                       value={TaskSchedule.interval}
-                      titleText="Interval"
+                      titleText="Every"
                       onClick={this.handleChangeScheduleType}
                     >
-                      Interval
+                      Every
                     </Radio.Button>
                     <Radio.Button
                       id="cron"

--- a/ui/src/tasks/components/TaskScheduleFormField.tsx
+++ b/ui/src/tasks/components/TaskScheduleFormField.tsx
@@ -23,7 +23,7 @@ export default class TaskScheduleFormFields extends PureComponent<Props> {
       <>
         <Grid.Column widthXS={Columns.Six}>
           <Form.Element
-            label={schedule === TaskSchedule.interval ? 'Interval' : 'Cron'}
+            label={schedule === TaskSchedule.interval ? 'Every' : 'Cron'}
           >
             <Input
               name={schedule}

--- a/ui/src/tasks/components/__snapshots__/TaskForm.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TaskForm.test.tsx.snap
@@ -56,12 +56,12 @@ exports[`TaskForm rendering renders 1`] = `
                 active={false}
                 disabled={false}
                 disabledTitleText="This option is disabled"
-                id="interval"
+                id="every"
                 onClick={[Function]}
-                titleText="Interval"
+                titleText="Every"
                 value="interval"
               >
-                Interval
+                Every
               </RadioButton>
               <RadioButton
                 active={false}


### PR DESCRIPTION
Closes #10843

This PR changes the `TaskForm` elements for the task interval to read "every" instead of "interval". Note that the app still uses the word "interval" for storing tasks in local state.

  - [x] Rebased/mergeable
  - [x] Tests pass
