### PR TITLE
fix(fs): fix proto dir permission from rw to rwx

### DIFF
--- a/fs/proto.go
+++ b/fs/proto.go
@@ -41,7 +41,7 @@ func (s *ProtoService) WithProtos(ps []*platform.Proto) {
 // Open loads the protos from the file system and sets them on the service.
 func (s *ProtoService) Open(ctx context.Context) error {
 	if _, err := os.Stat(s.Dir); os.IsNotExist(err) {
-		if err := os.Mkdir(s.Dir, 0600); err != nil {
+		if err := os.Mkdir(s.Dir, 0700); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes #11178

_Briefly describe your proposed changes:_

Directory was previous read and write but not execute.  Now, it is improved with execute!

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
