### PR TITLE
feat(influxdb): add authorization for user actions

### DIFF
--- a/authorizer/user.go
+++ b/authorizer/user.go
@@ -1,0 +1,143 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.UserService = (*UserService)(nil)
+
+// UserService wraps a influxdb.UserService and authorizes actions
+// against it appropriately.
+type UserService struct {
+	s influxdb.UserService
+}
+
+// NewUserService constructs an instance of an authorizing user serivce.
+func NewUserService(s influxdb.UserService) *UserService {
+	return &UserService{
+		s: s,
+	}
+}
+
+func newUserPermission(a influxdb.Action, id influxdb.ID) (*influxdb.Permission, error) {
+	p := &influxdb.Permission{
+		Action: a,
+		Resource: influxdb.Resource{
+			Type: influxdb.UsersResourceType,
+			ID:   &id,
+		},
+	}
+
+	return p, p.Valid()
+}
+
+func authorizeReadUser(ctx context.Context, id influxdb.ID) error {
+	p, err := newUserPermission(influxdb.ReadAction, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func authorizeWriteUser(ctx context.Context, id influxdb.ID) error {
+	p, err := newUserPermission(influxdb.WriteAction, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FindUserByID checks to see if the authorizer on context has read access to the id provided.
+func (s *UserService) FindUserByID(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
+	if err := authorizeReadUser(ctx, id); err != nil {
+		return nil, err
+	}
+
+	return s.s.FindUserByID(ctx, id)
+}
+
+// FindUser retrieves the user and checks to see if the authorizer on context has read access to the user.
+func (s *UserService) FindUser(ctx context.Context, filter influxdb.UserFilter) (*influxdb.User, error) {
+	o, err := s.s.FindUser(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeReadUser(ctx, o.ID); err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+// FindUsers retrieves all users that match the provided filter and then filters the list down to only the resources that are authorized.
+func (s *UserService) FindUsers(ctx context.Context, filter influxdb.UserFilter, opt ...influxdb.FindOptions) ([]*influxdb.User, int, error) {
+	// TODO: we'll likely want to push this operation into the database eventually since fetching the whole list of data
+	// will likely be expensive.
+	os, _, err := s.s.FindUsers(ctx, filter, opt...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	users := os[:0]
+	for _, o := range os {
+		err := authorizeReadUser(ctx, o.ID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+
+		users = append(users, o)
+	}
+
+	return users, len(users), nil
+}
+
+// CreateUser checks to see if the authorizer on context has write access to the global users resource.
+func (s *UserService) CreateUser(ctx context.Context, o *influxdb.User) error {
+	p, err := influxdb.NewGlobalPermission(influxdb.WriteAction, influxdb.UsersResourceType)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return s.s.CreateUser(ctx, o)
+}
+
+// UpdateUser checks to see if the authorizer on context has write access to the user provided.
+func (s *UserService) UpdateUser(ctx context.Context, id influxdb.ID, upd influxdb.UserUpdate) (*influxdb.User, error) {
+	if err := authorizeWriteUser(ctx, id); err != nil {
+		return nil, err
+	}
+
+	return s.s.UpdateUser(ctx, id, upd)
+}
+
+// DeleteUser checks to see if the authorizer on context has write access to the user provided.
+func (s *UserService) DeleteUser(ctx context.Context, id influxdb.ID) error {
+	if err := authorizeWriteUser(ctx, id); err != nil {
+		return err
+	}
+
+	return s.s.DeleteUser(ctx, id)
+}

--- a/authorizer/user_test.go
+++ b/authorizer/user_test.go
@@ -1,0 +1,557 @@
+package authorizer_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+var userCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	cmp.Transformer("Sort", func(in []*influxdb.User) []*influxdb.User {
+		out := append([]*influxdb.User(nil), in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID.String() > out[j].ID.String()
+		})
+		return out
+	}),
+}
+
+func TestUserService_FindUserByID(t *testing.T) {
+	type fields struct {
+		UserService influxdb.UserService
+	}
+	type args struct {
+		permission influxdb.Permission
+		id         influxdb.ID
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access id",
+			fields: fields{
+				UserService: &mock.UserService{
+					FindUserByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
+						return &influxdb.User{
+							ID: id,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to access id",
+			fields: fields{
+				UserService: &mock.UserService{
+					FindUserByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
+						return &influxdb.User{
+							ID: id,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:users/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewUserService(tt.fields.UserService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			_, err := s.FindUserByID(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestUserService_FindUser(t *testing.T) {
+	type fields struct {
+		UserService influxdb.UserService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access user",
+			fields: fields{
+				UserService: &mock.UserService{
+					FindUserFn: func(ctx context.Context, filter influxdb.UserFilter) (*influxdb.User, error) {
+						return &influxdb.User{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to access user",
+			fields: fields{
+				UserService: &mock.UserService{
+					FindUserFn: func(ctx context.Context, filter influxdb.UserFilter) (*influxdb.User, error) {
+						return &influxdb.User{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:users/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewUserService(tt.fields.UserService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			_, err := s.FindUser(ctx, influxdb.UserFilter{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestUserService_FindUsers(t *testing.T) {
+	type fields struct {
+		UserService influxdb.UserService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err   error
+		users []*influxdb.User
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to see all users",
+			fields: fields{
+				UserService: &mock.UserService{
+					FindUsersFn: func(ctx context.Context, filter influxdb.UserFilter, opt ...influxdb.FindOptions) ([]*influxdb.User, int, error) {
+						return []*influxdb.User{
+							{
+								ID: 1,
+							},
+							{
+								ID: 2,
+							},
+							{
+								ID: 3,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+					},
+				},
+			},
+			wants: wants{
+				users: []*influxdb.User{
+					{
+						ID: 1,
+					},
+					{
+						ID: 2,
+					},
+					{
+						ID: 3,
+					},
+				},
+			},
+		},
+		{
+			name: "authorized to access a single user",
+			fields: fields{
+				UserService: &mock.UserService{
+					FindUsersFn: func(ctx context.Context, filter influxdb.UserFilter, opt ...influxdb.FindOptions) ([]*influxdb.User, int, error) {
+						return []*influxdb.User{
+							{
+								ID: 1,
+							},
+							{
+								ID: 2,
+							},
+							{
+								ID: 3,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+			},
+			wants: wants{
+				users: []*influxdb.User{
+					{
+						ID: 2,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewUserService(tt.fields.UserService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			users, _, err := s.FindUsers(ctx, influxdb.UserFilter{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+
+			if diff := cmp.Diff(users, tt.wants.users, userCmpOptions...); diff != "" {
+				t.Errorf("users are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+func TestUserService_UpdateUser(t *testing.T) {
+	type fields struct {
+		UserService influxdb.UserService
+	}
+	type args struct {
+		id         influxdb.ID
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to update user",
+			fields: fields{
+				UserService: &mock.UserService{
+					UpdateUserFn: func(ctx context.Context, id influxdb.ID, upd influxdb.UserUpdate) (*influxdb.User, error) {
+						return &influxdb.User{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to update user",
+			fields: fields{
+				UserService: &mock.UserService{
+					UpdateUserFn: func(ctx context.Context, id influxdb.ID, upd influxdb.UserUpdate) (*influxdb.User, error) {
+						return &influxdb.User{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:users/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewUserService(tt.fields.UserService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			_, err := s.UpdateUser(ctx, tt.args.id, influxdb.UserUpdate{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestUserService_DeleteUser(t *testing.T) {
+	type fields struct {
+		UserService influxdb.UserService
+	}
+	type args struct {
+		id         influxdb.ID
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to delete user",
+			fields: fields{
+				UserService: &mock.UserService{
+					DeleteUserFn: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to delete user",
+			fields: fields{
+				UserService: &mock.UserService{
+					DeleteUserFn: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:users/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewUserService(tt.fields.UserService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			err := s.DeleteUser(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestUserService_CreateUser(t *testing.T) {
+	type fields struct {
+		UserService influxdb.UserService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to create user",
+			fields: fields{
+				UserService: &mock.UserService{
+					CreateUserFn: func(ctx context.Context, o *influxdb.User) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to create user",
+			fields: fields{
+				UserService: &mock.UserService{
+					CreateUserFn: func(ctx context.Context, o *influxdb.User) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:users is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewUserService(tt.fields.UserService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			err := s.CreateUser(ctx, &influxdb.User{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}

--- a/authz.go
+++ b/authz.go
@@ -312,6 +312,16 @@ func OwnerPermissions(orgID ID) []Permission {
 	return ps
 }
 
+// MePermissions is the permission to read/write myself.
+func MePermissions(userID ID) []Permission {
+	ps := []Permission{}
+	for _, a := range actions {
+		ps = append(ps, Permission{Action: a, Resource: Resource{Type: UsersResourceType, ID: &userID}})
+	}
+
+	return ps
+}
+
 // MemberPermissions are the default permissions for those who can see a resource.
 func MemberPermissions(orgID ID) []Permission {
 	ps := []Permission{}

--- a/bolt/session.go
+++ b/bolt/session.go
@@ -110,6 +110,7 @@ func (c *Client) findSession(ctx context.Context, tx *bolt.Tx, key string) (*pla
 
 		ps = append(ps, p...)
 	}
+	ps = append(ps, platform.MePermissions(s.UserID)...)
 	s.Permissions = ps
 	return s, nil
 }

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -87,7 +87,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.OrgHandler.SecretService = b.SecretService
 
 	h.UserHandler = NewUserHandler()
-	h.UserHandler.UserService = b.UserService
+	h.UserHandler.UserService = authorizer.NewUserService(b.UserService)
 	h.UserHandler.BasicAuthService = b.BasicAuthService
 	h.UserHandler.UserOperationLogService = b.UserOperationLogService
 

--- a/testing/session.go
+++ b/testing/session.go
@@ -29,7 +29,7 @@ var sessionCmpOptions = cmp.Options{
 		})
 		return out
 	}),
-	cmpopts.IgnoreFields(platform.Session{}, "CreatedAt", "ExpiresAt"),
+	cmpopts.IgnoreFields(platform.Session{}, "CreatedAt", "ExpiresAt", "Permissions"),
 	cmpopts.EquateEmpty(),
 }
 


### PR DESCRIPTION
Closes part of #10814 

_Briefly describe your proposed changes:_
This PR introduces a user service that authorizes actions. It additionally grants users the permission to view themselves.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
