### PR TITLE
Show organization names in task api actions

### DIFF
--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -130,7 +130,8 @@ func taskCreateF(cmd *cobra.Command, args []string) {
 			w.Flush()
 		}
 
-		t.Organization = orgs[0].ID
+		t.OrganizationID = orgs[0].ID
+		t.Organization = orgs[0].Name
 	}
 
 	if taskCreateFlags.orgID != "" {
@@ -139,7 +140,7 @@ func taskCreateF(cmd *cobra.Command, args []string) {
 			fmt.Printf("error parsing organization id: %v\n", err)
 			os.Exit(1)
 		}
-		t.Organization = *id
+		t.OrganizationID = *id
 	}
 
 	if err := s.CreateTask(context.Background(), t); err != nil {
@@ -151,18 +152,20 @@ func taskCreateF(cmd *cobra.Command, args []string) {
 	w.WriteHeaders(
 		"ID",
 		"Name",
+		"OrganizationID",
 		"Organization",
 		"Status",
 		"Every",
 		"Cron",
 	)
 	w.Write(map[string]interface{}{
-		"ID":           t.ID.String(),
-		"Name":         t.Name,
-		"Organization": t.Organization.String(),
-		"Status":       t.Status,
-		"Every":        t.Every,
-		"Cron":         t.Cron,
+		"ID":             t.ID.String(),
+		"Name":           t.Name,
+		"OrganizationID": t.OrganizationID.String(),
+		"Organization":   t.Organization,
+		"Status":         t.Status,
+		"Every":          t.Every,
+		"Cron":           t.Cron,
 	})
 	w.Flush()
 }
@@ -252,6 +255,7 @@ func taskFindF(cmd *cobra.Command, args []string) {
 	w.WriteHeaders(
 		"ID",
 		"Name",
+		"OrganizationID",
 		"Organization",
 		"Status",
 		"Every",
@@ -259,12 +263,13 @@ func taskFindF(cmd *cobra.Command, args []string) {
 	)
 	for _, t := range tasks {
 		w.Write(map[string]interface{}{
-			"ID":           t.ID.String(),
-			"Name":         t.Name,
-			"Organization": t.Organization.String(),
-			"Status":       t.Status,
-			"Every":        t.Every,
-			"Cron":         t.Cron,
+			"ID":             t.ID.String(),
+			"Name":           t.Name,
+			"OrganizationID": t.OrganizationID.String(),
+			"Organization":   t.Organization,
+			"Status":         t.Status,
+			"Every":          t.Every,
+			"Cron":           t.Cron,
 		})
 	}
 	w.Flush()
@@ -328,18 +333,20 @@ func taskUpdateF(cmd *cobra.Command, args []string) {
 	w.WriteHeaders(
 		"ID",
 		"Name",
+		"OrganizationID",
 		"Organization",
 		"Status",
 		"Every",
 		"Cron",
 	)
 	w.Write(map[string]interface{}{
-		"ID":           t.ID.String(),
-		"Name":         t.Name,
-		"Organization": t.Organization.String(),
-		"Status":       t.Status,
-		"Every":        t.Every,
-		"Cron":         t.Cron,
+		"ID":             t.ID.String(),
+		"Name":           t.Name,
+		"OrganizationID": t.OrganizationID.String(),
+		"Organization":   t.Organization,
+		"Status":         t.Status,
+		"Every":          t.Every,
+		"Cron":           t.Cron,
 	})
 	w.Flush()
 }
@@ -393,18 +400,20 @@ func taskDeleteF(cmd *cobra.Command, args []string) {
 	w.WriteHeaders(
 		"ID",
 		"Name",
+		"OrganizationID",
 		"Organization",
 		"Status",
 		"Every",
 		"Cron",
 	)
 	w.Write(map[string]interface{}{
-		"ID":           t.ID.String(),
-		"Name":         t.Name,
-		"Organization": t.Organization.String(),
-		"Status":       t.Status,
-		"Every":        t.Every,
-		"Cron":         t.Cron,
+		"ID":             t.ID.String(),
+		"Name":           t.Name,
+		"OrganizationID": t.OrganizationID.String(),
+		"Organization":   t.Organization,
+		"Status":         t.Status,
+		"Every":          t.Every,
+		"Cron":           t.Cron,
 	})
 	w.Flush()
 }

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -121,6 +121,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.TaskHandler = NewTaskHandler(b.UserResourceMappingService, b.LabelService, b.Logger, b.UserService)
 	h.TaskHandler.TaskService = b.TaskService
 	h.TaskHandler.AuthorizationService = b.AuthorizationService
+	h.TaskHandler.OrganizationService = b.OrganizationService
 	h.TaskHandler.UserResourceMappingService = b.UserResourceMappingService
 
 	h.TelegrafHandler = NewTelegrafHandler(

--- a/http/router.go
+++ b/http/router.go
@@ -13,7 +13,7 @@ func NewRouter() *httprouter.Router {
 	router := httprouter.New()
 	router.NotFound = http.HandlerFunc(notFoundHandler)
 	router.MethodNotAllowed = http.HandlerFunc(methodNotAllowedHandler)
-	// router.PanicHandler = panicHandler
+	router.PanicHandler = panicHandler
 	return router
 }
 

--- a/http/router.go
+++ b/http/router.go
@@ -13,7 +13,7 @@ func NewRouter() *httprouter.Router {
 	router := httprouter.New()
 	router.NotFound = http.HandlerFunc(notFoundHandler)
 	router.MethodNotAllowed = http.HandlerFunc(methodNotAllowedHandler)
-	router.PanicHandler = panicHandler
+	// router.PanicHandler = panicHandler
 	return router
 }
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5151,7 +5151,7 @@ components:
         orgID:
           description: The ID of the organization that owns this Task.
           type: string
-        organization:
+        org:
           description: The organization that owns this Task.
           type: string
         name:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5151,6 +5151,9 @@ components:
         orgID:
           description: The ID of the organization that owns this Task.
           type: string
+        organization:
+          description: The organization that owns this Task.
+          type: string
         name:
           description: A description of the task.
           type: string

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -120,7 +120,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
         }
       ],
       "orgID": "0000000000000001",
-      "organization": "test",
+      "org": "test",
       "status": "",
       "flux": "",
       "owner": {
@@ -149,7 +149,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
         }
       ],
 	  "orgID": "0000000000000002",
-	  "organization": "test",
+	  "org": "test",
       "status": "",
       "flux": "",
       "owner": {
@@ -247,7 +247,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
   "name": "task1",
   "labels": [],
   "orgID": "0000000000000001",
-  "organization": "test",
+  "org": "test",
   "status": "",
   "flux": "",
   "owner": {

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -18,6 +18,25 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+func mockOrgService() platform.OrganizationService {
+	return &mock.OrganizationService{
+		FindOrganizationByIDF: func(ctx context.Context, id platform.ID) (*platform.Organization, error) {
+			return &platform.Organization{ID: id, Name: "test"}, nil
+		},
+		FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
+			org := &platform.Organization{}
+			if filter.Name != nil {
+				org.Name = *filter.Name
+			}
+			if filter.ID != nil {
+				org.ID = *filter.ID
+			}
+
+			return org, nil
+		},
+	}
+}
+
 func TestTaskHandler_handleGetTasks(t *testing.T) {
 	type fields struct {
 		taskService  platform.TaskService
@@ -41,16 +60,16 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 					FindTasksFn: func(ctx context.Context, f platform.TaskFilter) ([]*platform.Task, int, error) {
 						tasks := []*platform.Task{
 							{
-								ID:           1,
-								Name:         "task1",
-								Organization: 1,
-								Owner:        platform.User{ID: 1, Name: "user1"},
+								ID:             1,
+								Name:           "task1",
+								OrganizationID: 1,
+								Owner:          platform.User{ID: 1, Name: "user1"},
 							},
 							{
-								ID:           2,
-								Name:         "task2",
-								Organization: 2,
-								Owner:        platform.User{ID: 2, Name: "user2"},
+								ID:             2,
+								Name:           "task2",
+								OrganizationID: 2,
+								Owner:          platform.User{ID: 2, Name: "user2"},
 							},
 						}
 						return tasks, len(tasks), nil
@@ -101,6 +120,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
         }
       ],
       "orgID": "0000000000000001",
+      "organization": "test",
       "status": "",
       "flux": "",
       "owner": {
@@ -128,7 +148,8 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
           }
         }
       ],
-      "orgID": "0000000000000002",
+	  "orgID": "0000000000000002",
+	  "organization": "test",
       "status": "",
       "flux": "",
       "owner": {
@@ -148,6 +169,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			h := NewTaskHandler(mock.NewUserResourceMappingService(), mock.NewLabelService(), logger.New(os.Stdout), mock.NewUserService())
+			h.OrganizationService = mockOrgService()
 			h.TaskService = tt.fields.taskService
 			h.LabelService = tt.fields.labelService
 			h.handleGetTasks(w, r)
@@ -192,8 +214,8 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
 			name: "create task",
 			args: args{
 				task: platform.Task{
-					Name:         "task1",
-					Organization: 1,
+					Name:           "task1",
+					OrganizationID: 1,
 					Owner: platform.User{
 						ID:   1,
 						Name: "user1",
@@ -225,6 +247,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
   "name": "task1",
   "labels": [],
   "orgID": "0000000000000001",
+  "organization": "test",
   "status": "",
   "flux": "",
   "owner": {
@@ -251,6 +274,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			h := NewTaskHandler(mock.NewUserResourceMappingService(), mock.NewLabelService(), logger.New(os.Stdout), mock.NewUserService())
+			h.OrganizationService = mockOrgService()
 			h.TaskService = tt.fields.taskService
 			h.handlePostTask(w, r)
 
@@ -355,6 +379,7 @@ func TestTaskHandler_handleGetRun(t *testing.T) {
 				}))
 			w := httptest.NewRecorder()
 			h := NewTaskHandler(mock.NewUserResourceMappingService(), mock.NewLabelService(), logger.New(os.Stdout), mock.NewUserService())
+			h.OrganizationService = mockOrgService()
 			h.TaskService = tt.fields.taskService
 			h.handleGetRun(w, r)
 
@@ -463,6 +488,7 @@ func TestTaskHandler_handleGetRuns(t *testing.T) {
 				}))
 			w := httptest.NewRecorder()
 			h := NewTaskHandler(mock.NewUserResourceMappingService(), mock.NewLabelService(), logger.New(os.Stdout), mock.NewUserService())
+			h.OrganizationService = mockOrgService()
 			h.TaskService = tt.fields.taskService
 			h.handleGetRuns(w, r)
 

--- a/http/task_test.go
+++ b/http/task_test.go
@@ -31,6 +31,22 @@ func httpTaskServiceFactory(t *testing.T) (*servicetest.System, context.CancelFu
 	h := http.NewAuthenticationHandler()
 	h.AuthorizationService = i
 	th := http.NewTaskHandler(mock.NewUserResourceMappingService(), mock.NewLabelService(), zaptest.NewLogger(t), mock.NewUserService())
+	th.OrganizationService = &mock.OrganizationService{
+		FindOrganizationByIDF: func(ctx context.Context, id platform.ID) (*platform.Organization, error) {
+			return &platform.Organization{ID: id, Name: "test"}, nil
+		},
+		FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
+			org := &platform.Organization{}
+			if filter.Name != nil {
+				org.Name = *filter.Name
+			}
+			if filter.ID != nil {
+				org.ID = *filter.ID
+			}
+
+			return org, nil
+		},
+	}
 	th.TaskService = backingTS
 	th.AuthorizationService = i
 	h.Handler = th

--- a/task.go
+++ b/task.go
@@ -23,7 +23,7 @@ const (
 type Task struct {
 	ID              ID     `json:"id,omitempty"`
 	OrganizationID  ID     `json:"orgID"`
-	Organization    string `json:"organization"`
+	Organization    string `json:"org"`
 	Name            string `json:"name"`
 	Status          string `json:"status"`
 	Owner           User   `json:"owner"`

--- a/task.go
+++ b/task.go
@@ -22,7 +22,8 @@ const (
 // Task is a task. 🎊
 type Task struct {
 	ID              ID     `json:"id,omitempty"`
-	Organization    ID     `json:"orgID"`
+	OrganizationID  ID     `json:"orgID"`
+	Organization    string `json:"organization"`
 	Name            string `json:"name"`
 	Status          string `json:"status"`
 	Owner           User   `json:"owner"`

--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -83,7 +83,7 @@ func (p pAdapter) CreateTask(ctx context.Context, t *platform.Task) error {
 	}
 
 	req := backend.CreateTaskRequest{
-		Org:           t.Organization,
+		Org:           t.OrganizationID,
 		User:          t.Owner.ID,
 		Script:        t.Flux,
 		ScheduleAfter: scheduleAfter,
@@ -141,7 +141,7 @@ func (p pAdapter) UpdateTask(ctx context.Context, id platform.ID, upd platform.T
 		return nil, err
 	}
 	task.Owner.ID = t.User
-	task.Organization = t.Org
+	task.OrganizationID = t.Org
 
 	return task, nil
 }
@@ -233,9 +233,9 @@ func toPlatformTask(t backend.StoreTask, m *backend.StoreTaskMeta) (*platform.Ta
 	}
 
 	pt := &platform.Task{
-		ID:           t.ID,
-		Organization: t.Org,
-		Name:         t.Name,
+		ID:             t.ID,
+		OrganizationID: t.Org,
+		Name:           t.Name,
 		Owner: platform.User{
 			ID:   t.User,
 			Name: "", // TODO(mr): how to get owner name?

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -112,7 +112,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	userID := idGen.ID()
 
 	// Create a task.
-	task := &platform.Task{Organization: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
+	task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
 	if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
 		t.Fatal(err)
 	}
@@ -150,8 +150,8 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	found["FindTasks with User filter"] = fs[0]
 
 	for fn, f := range found {
-		if f.Organization != orgID {
-			t.Fatalf("%s: wrong organization returned; want %s, got %s", fn, orgID.String(), f.Organization.String())
+		if f.OrganizationID != orgID {
+			t.Fatalf("%s: wrong organization returned; want %s, got %s", fn, orgID.String(), f.OrganizationID.String())
 		}
 		if f.Owner.ID != userID {
 			t.Fatalf("%s: wrong user returned; want %s, got %s", fn, userID.String(), f.Owner.ID.String())
@@ -248,7 +248,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 func testMetaUpdate(t *testing.T, sys *System) {
 	orgID, userID, _ := creds(t, sys)
 
-	task := &platform.Task{Organization: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
+	task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
 	if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 
 		// Script is set to run every minute. The platform adapter is currently hardcoded to schedule after "now",
 		// which makes timing of runs somewhat difficult.
-		task := &platform.Task{Organization: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
+		task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
 		if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
 			t.Fatal(err)
 		}
@@ -423,7 +423,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 
 		// Script is set to run every minute. The platform adapter is currently hardcoded to schedule after "now",
 		// which makes timing of runs somewhat difficult.
-		task := &platform.Task{Organization: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
+		task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
 		if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
 			t.Fatal(err)
 		}
@@ -514,7 +514,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 	t.Run("ForceRun", func(t *testing.T) {
 		t.Parallel()
 
-		task := &platform.Task{Organization: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
+		task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
 		if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
 			t.Fatal(err)
 		}
@@ -555,7 +555,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 	t.Run("FindLogs", func(t *testing.T) {
 		t.Parallel()
 
-		task := &platform.Task{Organization: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
+		task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
 		if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
 			t.Fatal(err)
 		}
@@ -791,9 +791,9 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 	// Start adding tasks.
 	for i := 0; i < numTasks; i++ {
 		taskCh <- &platform.Task{
-			Organization: orgID,
-			Owner:        platform.User{ID: userID},
-			Flux:         fmt.Sprintf(scriptFmt, i),
+			OrganizationID: orgID,
+			Owner:          platform.User{ID: userID},
+			Flux:           fmt.Sprintf(scriptFmt, i),
 		}
 	}
 

--- a/task/validator.go
+++ b/task/validator.go
@@ -41,7 +41,7 @@ func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id platform.ID
 		return nil, err
 	}
 
-	perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, task.Organization)
+	perm, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, task.OrganizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter platform.T
 }
 
 func (ts *taskServiceValidator) CreateTask(ctx context.Context, t *platform.Task) error {
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, t.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, t.OrganizationID)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id platform.ID, 
 		return nil, err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.OrganizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (ts *taskServiceValidator) DeleteTask(ctx context.Context, id platform.ID) 
 		return err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.OrganizationID)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (ts *taskServiceValidator) FindRunByID(ctx context.Context, taskID, runID p
 		return nil, err
 	}
 
-	p, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, task.Organization)
+	p, err := platform.NewPermission(platform.ReadAction, platform.TasksResourceType, task.OrganizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (ts *taskServiceValidator) CancelRun(ctx context.Context, taskID, runID pla
 		return err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.OrganizationID)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (ts *taskServiceValidator) RetryRun(ctx context.Context, taskID, runID plat
 		return nil, err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.OrganizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (ts *taskServiceValidator) ForceRun(ctx context.Context, taskID platform.ID
 		return nil, err
 	}
 
-	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.Organization)
+	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, task.OrganizationID)
 	if err != nil {
 		return nil, err
 	}

--- a/task/validator_test.go
+++ b/task/validator_test.go
@@ -32,7 +32,7 @@ func TestOnboardingValidation(t *testing.T) {
 	ctx := pctx.SetAuthorizer(context.Background(), r.Auth)
 
 	err = validator.CreateTask(ctx, &influxdb.Task{
-		Organization: r.Org.ID,
+		OrganizationID: r.Org.ID,
 		Flux: `option task = {
  name: "my_task",
  every: 1s,
@@ -46,10 +46,10 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`,
 
 func mockTaskService() influxdb.TaskService {
 	task := influxdb.Task{
-		ID:           influxdb.ID(2),
-		Organization: influxdb.ID(1),
-		Name:         "cows",
-		Owner:        influxdb.User{ID: influxdb.ID(3), Name: "farmer"},
+		ID:             influxdb.ID(2),
+		OrganizationID: influxdb.ID(1),
+		Name:           "cows",
+		Owner:          influxdb.User{ID: influxdb.ID(3), Name: "farmer"},
 		Flux: `option task = {
  name: "my_task",
  every: 1s,
@@ -136,9 +136,9 @@ func TestValidations(t *testing.T) {
 			name: "create failure",
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				err := svc.CreateTask(ctx, &influxdb.Task{
-					Organization: r.Org.ID,
-					Name:         "cows",
-					Owner:        influxdb.User{ID: influxdb.ID(2), Name: "farmer"},
+					OrganizationID: r.Org.ID,
+					Name:           "cows",
+					Owner:          influxdb.User{ID: influxdb.ID(2), Name: "farmer"},
 					Flux: `option task = {
  name: "my_task",
  every: 1s,
@@ -158,9 +158,9 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`,
 			auth: r.Auth,
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				err := svc.CreateTask(ctx, &influxdb.Task{
-					Organization: r.Org.ID,
-					Name:         "cows",
-					Owner:        *r.User,
+					OrganizationID: r.Org.ID,
+					Name:           "cows",
+					Owner:          *r.User,
 					Flux: `option task = {
  name: "my_task",
  every: 1s,
@@ -176,9 +176,9 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`,
 			auth: r.Auth,
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				err := svc.CreateTask(ctx, &influxdb.Task{
-					Organization: r.Org.ID,
-					Name:         "cows",
-					Owner:        *r.User,
+					OrganizationID: r.Org.ID,
+					Name:           "cows",
+					Owner:          *r.User,
 					Flux: `option task = {
  name: "my_task",
  every: 1s,


### PR DESCRIPTION
Closes #10876 

_Briefly describe your proposed changes:_
Actions on resources under an organization show the org id as well as the name. This should bring the tasks resource inline with the rest of the resources in the same category. It also grants the advantage of allowing the api to accept org name instead of org id when creating a task.
