### PR TITLE
Feat(adminui)/advanced data collection step

### DIFF
--- a/ui/src/onboarding/components/AdminStep.tsx
+++ b/ui/src/onboarding/components/AdminStep.tsx
@@ -298,12 +298,12 @@ class AdminStep extends PureComponent<Props, State> {
     }
 
     try {
-      onSetupAdmin(setupParams)
-      onSetStepStatus(currentStepIndex, StepStatus.Complete)
-      onIncrementCurrentStepIndex()
+      await onSetupAdmin(setupParams)
     } catch (error) {
       notify(copy.SetupError)
     }
+    onSetStepStatus(currentStepIndex, StepStatus.Complete)
+    onIncrementCurrentStepIndex()
   }
 }
 

--- a/ui/src/onboarding/components/CompletionAdvancedButton.tsx
+++ b/ui/src/onboarding/components/CompletionAdvancedButton.tsx
@@ -34,10 +34,7 @@ class CompletionAdvancedButton extends PureComponent<Props> {
     const {router, orgs, onExit} = this.props
     const id = _.get(orgs, '0.id', null)
     if (id) {
-      router.push({
-        pathname: `/organizations/${id}/buckets_tab`,
-        state: {openDataLoaderOverlay: true},
-      })
+      router.push(`/organizations/${id}/buckets_tab?openDataLoaderOverlay=true`)
     } else {
       onExit()
     }

--- a/ui/src/onboarding/components/CompletionAdvancedButton.tsx
+++ b/ui/src/onboarding/components/CompletionAdvancedButton.tsx
@@ -34,7 +34,10 @@ class CompletionAdvancedButton extends PureComponent<Props> {
     const {router, orgs, onExit} = this.props
     const id = _.get(orgs, '0.id', null)
     if (id) {
-      router.push(`/organizations/${id}/buckets_tab`)
+      router.push({
+        pathname: `/organizations/${id}/buckets_tab`,
+        state: {openDataLoaderOverlay: true},
+      })
     } else {
       onExit()
     }

--- a/ui/src/onboarding/components/CompletionAdvancedButton.tsx
+++ b/ui/src/onboarding/components/CompletionAdvancedButton.tsx
@@ -32,7 +32,7 @@ class CompletionAdvancedButton extends PureComponent<Props> {
 
   private handleAdvanced = (): void => {
     const {router, orgs, onExit} = this.props
-    const id = _.get(orgs, '[0].id', null)
+    const id = _.get(orgs, '0.id', null)
     if (id) {
       router.push(`/organizations/${id}/buckets_tab`)
     } else {

--- a/ui/src/organizations/components/BucketList.tsx
+++ b/ui/src/organizations/components/BucketList.tsx
@@ -32,7 +32,7 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
 
     const openDataLoaderOverlay = _.get(
       this,
-      'props.location.state.openDataLoaderOverlay',
+      'props.location.query.openDataLoaderOverlay',
       false
     )
     const firstBucketID = _.get(this, 'props.buckets.0.id', null)
@@ -41,11 +41,7 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
     this.state = {
       bucketID,
       bucketOverlayState: OverlayState.Closed,
-      dataLoadersOverlayState: _.get(
-        this,
-        'props.location.state.openDataLoaderOverlay',
-        false
-      )
+      dataLoadersOverlayState: openDataLoaderOverlay
         ? OverlayState.Open
         : OverlayState.Closed,
     }

--- a/ui/src/organizations/components/BucketList.tsx
+++ b/ui/src/organizations/components/BucketList.tsx
@@ -1,5 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+import _ from 'lodash'
 
 // Components
 import UpdateBucketOverlay from 'src/organizations/components/UpdateBucketOverlay'
@@ -24,14 +26,28 @@ interface State {
   dataLoadersOverlayState: OverlayState
 }
 
-export default class BucketList extends PureComponent<Props, State> {
+class BucketList extends PureComponent<Props & WithRouterProps, State> {
   constructor(props) {
     super(props)
 
+    const openDataLoaderOverlay = _.get(
+      this,
+      'props.location.state.openDataLoaderOverlay',
+      false
+    )
+    const firstBucketID = _.get(this, 'props.buckets.0.id', null)
+    const bucketID = openDataLoaderOverlay ? firstBucketID : null
+
     this.state = {
-      bucketID: null,
+      bucketID,
       bucketOverlayState: OverlayState.Closed,
-      dataLoadersOverlayState: OverlayState.Closed,
+      dataLoadersOverlayState: _.get(
+        this,
+        'props.location.state.openDataLoaderOverlay',
+        false
+      )
+        ? OverlayState.Open
+        : OverlayState.Closed,
     }
   }
 
@@ -119,3 +135,5 @@ export default class BucketList extends PureComponent<Props, State> {
     this.setState({bucketOverlayState: OverlayState.Closed})
   }
 }
+
+export default withRouter<Props>(BucketList)

--- a/ui/src/shared/components/resource_fetcher/ResourceFetcher.tsx
+++ b/ui/src/shared/components/resource_fetcher/ResourceFetcher.tsx
@@ -28,7 +28,13 @@ export default class ResourceFetcher<T> extends PureComponent<
 
   public async componentDidMount() {
     const {fetcher} = this.props
-    const resources = await fetcher()
+    let resources
+    try {
+      resources = await fetcher()
+    } catch (error) {
+      console.error(error)
+    }
+
     this.setState({resources, loading: RemoteDataState.Done})
   }
 


### PR DESCRIPTION
Closes #11060

This PR sets the "Advanced" button in the onboarding to open the Data Loaders overlay in the buckets tab of the organizations page.

Also, this PR changes the "Next" behavior on the admin setup step of onboarding to wait for the admin setup API call to finish before going to the Completion step. This is so that the Completion step will have a bucket to add Data Loaders to when the user clicks the Advanced option.

  - [x] Rebased/mergeable
  - [ ] Tests pass
