### PR TITLE
feat(http): add vnd.flux content-type support

### DIFF
--- a/http/cur_swagger.yml
+++ b/http/cur_swagger.yml
@@ -525,7 +525,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"            
+                $ref: "#/components/schemas/Error"
   /macros:
     get:
       tags:
@@ -2152,76 +2152,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   /query:
-    get:
-      tags:
-        - Query
-      summary: query influx with specified return formatting. The spec and query fields are mutually exclusive.
-      parameters:
-        - in: query
-          name: org
-          description: specifies the organization of the resource
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: query
-          description: query script to execute.
-          required: true
-          schema:
-            type: string
-        - in: header
-          name: Authorization
-          description: the authorization header should be in the format of `Token <key>`
-          schema:
-            type: string
-      responses:
-          '200':
-            description: query results
-            content:
-              text/csv:
-                schema:
-                  type: string
-                  example: >
-                    result,table,_start,_stop,_time,region,host,_value
-                    mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:00Z,east,A,15.43
-                    mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:20Z,east,B,59.25
-                    mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,C,52.62
-          '400':
-            description: error processing query
-            headers:
-              X-Influx-Error:
-                description: error string describing the problem
-                schema:
-                  type: string
-              X-Influx-Reference:
-                description: reference code unique to the error type
-                schema:
-                  type: integer
-            content:
-              text/csv:
-                schema:
-                  type: string
-                  example: >
-                    error,reference
-                    Failed to parse query,897
-          default:
-            description: internal server error
-            headers:
-              X-Influx-Error:
-                description: error string describing the problem
-                schema:
-                  type: string
-              X-Influx-Reference:
-                description: reference code unique to the error type
-                schema:
-                  type: integer
-            content:
-              text/csv:
-                schema:
-                  type: string
-                  example: >
-                    error,reference
-                    Failed to parse query,897
     post:
       tags:
         - Query
@@ -2243,6 +2173,7 @@ paths:
             type: string
             enum:
               - application/json
+              - application/vnd.flux
         - in: header
           name: Authorization
           description: the authorization header should be in the format of `Token <key>`
@@ -2259,6 +2190,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Query"
+            application/vnd.flux:
+              schema:
+                type: string
       responses:
           '200':
             description: query results
@@ -6188,4 +6122,4 @@ components:
         protos:
           type: array
           items:
-            $ref: "#/components/schemas/Proto"          
+            $ref: "#/components/schemas/Proto"

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -48,7 +48,6 @@ func NewFluxHandler() *FluxHandler {
 	}
 
 	h.HandlerFunc("POST", fluxPath, h.handleQuery)
-	h.HandlerFunc("GET", fluxPath, h.handleQuery)
 	h.HandlerFunc("POST", "/api/v2/query/ast", h.postFluxAST)
 	h.HandlerFunc("POST", "/api/v2/query/analyze", h.postQueryAnalyze)
 	h.HandlerFunc("POST", "/api/v2/query/spec", h.postFluxSpec)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2638,72 +2638,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   /query:
-   get:
-    tags:
-      - Query
-    summary: query influx with specified return formatting. The spec and query fields are mutually exclusive.
-    parameters:
-      - $ref: '#/components/parameters/TraceSpan'
-      - in: query
-        name: org
-        description: specifies the organization of the resource
-        required: true
-        schema:
-          type: string
-      - in: query
-        name: query
-        description: query script to execute.
-        required: true
-        schema:
-          type: string
-    responses:
-        '200':
-          description: query results
-          content:
-            text/csv:
-              schema:
-                type: string
-                example: >
-                  result,table,_start,_stop,_time,region,host,_value
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:00Z,east,A,15.43
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:20Z,east,B,59.25
-                  mean,0,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,east,C,52.62
-        '400':
-          description: error processing query
-          headers:
-            X-Influx-Error:
-              description: error string describing the problem
-              schema:
-                type: string
-            X-Influx-Reference:
-              description: reference code unique to the error type
-              schema:
-                type: integer
-          content:
-            text/csv:
-              schema:
-                type: string
-                example: >
-                  error,reference
-                  Failed to parse query,897
-        default:
-          description: internal server error
-          headers:
-            X-Influx-Error:
-              description: error string describing the problem
-              schema:
-                type: string
-            X-Influx-Reference:
-              description: reference code unique to the error type
-              schema:
-                type: integer
-          content:
-            text/csv:
-              schema:
-                type: string
-                example: >
-                  error,reference
-                  Failed to parse query,897
    post:
     tags:
       - Query
@@ -2726,6 +2660,7 @@ paths:
           type: string
           enum:
             - application/json
+            - application/vnd.flux
       - in: query
         name: org
         description: specifies the name of the organization executing the query.
@@ -2742,6 +2677,9 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/Query"
+          application/vnd.flux:
+            schema:
+              type: string
     responses:
         '200':
           description: query results


### PR DESCRIPTION
Fixes #10745

This change means that 1.x and 2.x should be in sync, and the easy way to curl a query to the server is using the `application/vnd.flux

```
curl -XPOST -sS -H 'Authorization: Token foo:pass' -H accept:application/csv -H 'content-type:application/vnd.flux' http://localhost:9999/api/v2/query -d 'from(bucket:"test") |> range(start:-1000h) |> group(columns:["_measurement"], mode:"by") |> sum()'
```