### PR TITLE
fix(http): fix typo in owner/member links

### DIFF
--- a/http/user_resource_mapping_service.go
+++ b/http/user_resource_mapping_service.go
@@ -41,7 +41,7 @@ type resourceUsersResponse struct {
 func newResourceUsersResponse(opts platform.FindOptions, f platform.UserResourceMappingFilter, users []*platform.User) *resourceUsersResponse {
 	rs := resourceUsersResponse{
 		Links: map[string]string{
-			"self": fmt.Sprintf("/api/v2/%ss/%s/%ss", f.ResourceType, f.ResourceID, f.UserType),
+			"self": fmt.Sprintf("/api/v2/%s/%s/%ss", f.ResourceType, f.ResourceID, f.UserType),
 		},
 		Users: make([]*resourceUserResponse, 0, len(users)),
 	}

--- a/http/user_resource_mapping_test.go
+++ b/http/user_resource_mapping_test.go
@@ -74,7 +74,7 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 				body: `
 {
   "links": {
-    "self": "/api/v2/%ss/0000000000000099/members"
+    "self": "/api/v2/%s/0000000000000099/members"
   },
   "users": [
     {
@@ -138,7 +138,7 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 				body: `
 {
   "links": {
-    "self": "/api/v2/%ss/0000000000000099/owners"
+    "self": "/api/v2/%s/0000000000000099/owners"
   },
   "users": [
     {


### PR DESCRIPTION
There was an extra s in owner links, for example:

{"links":{"self":"/api/v2/taskss/034356818538f000/owners"},"users":[]}

All of the ResourceType values in authz.go already are plural, so I am
fairly certain that the extra s was just a typo all along.