### PR TITLE
Support true time series query cancellation

### DIFF
--- a/ui/src/onboarding/components/verifyStep/DataListening.tsx
+++ b/ui/src/onboarding/components/verifyStep/DataListening.tsx
@@ -130,7 +130,7 @@ class DataListening extends PureComponent<Props, State> {
         '/api/v2/query',
         script,
         InfluxLanguage.Flux
-      )
+      ).promise
       rowCount = response.rowCount
       timePassed = Number(new Date()) - this.startTime
     } catch (err) {

--- a/ui/src/shared/actions/v2/queryBuilder.ts
+++ b/ui/src/shared/actions/v2/queryBuilder.ts
@@ -1,8 +1,5 @@
 // APIs
-import {
-  QueryBuilderFetcher,
-  CancellationError,
-} from 'src/shared/apis/v2/queryBuilder'
+import {QueryBuilderFetcher} from 'src/shared/apis/v2/queryBuilder'
 
 import {bucketsAPI} from 'src/utils/api'
 
@@ -17,6 +14,7 @@ import {
 import {Dispatch} from 'redux-thunk'
 import {GetState} from 'src/types/v2'
 import {RemoteDataState} from 'src/types'
+import {CancellationError} from 'src/types/promises'
 
 const fetcher = new QueryBuilderFetcher()
 

--- a/ui/src/types/promises.ts
+++ b/ui/src/types/promises.ts
@@ -2,3 +2,5 @@ export interface WrappedCancelablePromise<T> {
   promise: Promise<T>
   cancel: () => void
 }
+
+export class CancellationError extends Error {}

--- a/ui/src/utils/restartable.test.ts
+++ b/ui/src/utils/restartable.test.ts
@@ -1,4 +1,5 @@
-import {restartable, CancellationError} from 'src/utils/restartable'
+import {restartable} from 'src/utils/restartable'
+import {CancellationError} from 'src/types/promises'
 
 describe('restartable', () => {
   test('with three concurrent promises', async () => {

--- a/ui/src/utils/restartable.ts
+++ b/ui/src/utils/restartable.ts
@@ -1,6 +1,6 @@
 import Deferred from 'src/utils/Deferred'
 
-export class CancellationError extends Error {}
+import {CancellationError} from 'src/types/promises'
 
 // `restartable` is a utility that wraps promise-returning functions so that
 // concurrent calls resolve successfully exactly once, and with the most


### PR DESCRIPTION
Previously, outdated queries in the `TimeSeries` and `QueryBuilderFetcher` would run to completion even though their results were ignored.

Now, pending but outdated queries will be truly canceled via `XmlHttpRequest#abort`. This frees up server and network resources.

Closes #10801