### PR TITLE
feat(ui/dataLoaders): Add new collector from collectors tab

### DIFF
--- a/ui/src/dataLoaders/components/DataLoadersWizard.tsx
+++ b/ui/src/dataLoaders/components/DataLoadersWizard.tsx
@@ -44,6 +44,7 @@ import {
   DataLoadersState,
   DataLoaderType,
   Substep,
+  DataLoaderStep,
 } from 'src/types/v2/dataLoaders'
 import {Notification, NotificationFunc} from 'src/types'
 import {AppState} from 'src/types/v2'
@@ -105,6 +106,7 @@ interface StateProps {
   currentStepIndex: number
   substep: Substep
   username: string
+  selectedBucket: string
 }
 
 type Props = OwnProps & StateProps & DispatchProps
@@ -158,7 +160,9 @@ class DataLoadersWizard extends PureComponent<Props> {
       visible,
       bucket,
       username,
+      onSetBucketInfo,
       buckets,
+      selectedBucket,
     } = this.props
 
     return (
@@ -184,6 +188,7 @@ class DataLoadersWizard extends PureComponent<Props> {
               currentStepIndex={currentStepIndex}
               onboardingStepProps={this.stepProps}
               bucketName={_.get(bucket, 'name', '')}
+              selectedBucket={selectedBucket}
               dataLoaders={dataLoaders}
               onSetDataLoadersType={onSetDataLoadersType}
               onUpdateTelegrafPluginConfig={onUpdateTelegrafPluginConfig}
@@ -195,6 +200,7 @@ class DataLoadersWizard extends PureComponent<Props> {
               onAddPluginBundle={onAddPluginBundle}
               onRemovePluginBundle={onRemovePluginBundle}
               onSetConfigArrayValue={onSetConfigArrayValue}
+              onSetBucketInfo={onSetBucketInfo}
               org={_.get(bucket, 'organization', '')}
               username={username}
               buckets={buckets}
@@ -274,7 +280,7 @@ class DataLoadersWizard extends PureComponent<Props> {
     const {onSetSubstepIndex, onSetActiveTelegrafPlugin} = this.props
 
     onSetActiveTelegrafPlugin('')
-    onSetSubstepIndex(0, 'streaming')
+    onSetSubstepIndex(DataLoaderStep.Select, 'streaming')
   }
 
   private handleClickSideBarTab = (telegrafPluginID: string) => {
@@ -291,7 +297,7 @@ class DataLoadersWizard extends PureComponent<Props> {
       0
     )
 
-    onSetSubstepIndex(1, index)
+    onSetSubstepIndex(DataLoaderStep.Configure, index)
     onSetActiveTelegrafPlugin(telegrafPluginID)
   }
 
@@ -332,7 +338,7 @@ const mstp = ({
   links,
   dataLoading: {
     dataLoaders,
-    steps: {stepStatuses, currentStep, substep},
+    steps: {stepStatuses, currentStep, substep, bucket},
   },
   me: {name},
 }: AppState): StateProps => ({
@@ -342,6 +348,7 @@ const mstp = ({
   currentStepIndex: currentStep,
   substep,
   username: name,
+  selectedBucket: bucket,
 })
 
 const mdtp: DispatchProps = {

--- a/ui/src/dataLoaders/components/StepSwitcher.tsx
+++ b/ui/src/dataLoaders/components/StepSwitcher.tsx
@@ -21,6 +21,7 @@ import {
   setPluginConfiguration,
   setConfigArrayValue,
 } from 'src/onboarding/actions/dataLoaders'
+import {setBucketInfo} from 'src/onboarding/actions/steps'
 
 // Types
 import {DataLoadersState, DataLoaderStep} from 'src/types/v2/dataLoaders'
@@ -43,8 +44,10 @@ interface Props {
   onAddPluginBundle: typeof addPluginBundleWithPlugins
   onRemovePluginBundle: typeof removePluginBundleWithPlugins
   onSetConfigArrayValue: typeof setConfigArrayValue
+  onSetBucketInfo: typeof setBucketInfo
   org: string
   username: string
+  selectedBucket: string
 }
 
 @ErrorHandling
@@ -68,6 +71,8 @@ class StepSwitcher extends PureComponent<Props> {
       username,
       org,
       buckets,
+      onSetBucketInfo,
+      selectedBucket,
     } = this.props
 
     switch (currentStepIndex) {
@@ -77,10 +82,13 @@ class StepSwitcher extends PureComponent<Props> {
             {...onboardingStepProps}
             {...dataLoaders}
             onSetDataLoadersType={onSetDataLoadersType}
+            buckets={buckets}
             bucket={bucketName}
+            selectedBucket={selectedBucket}
             onSetActiveTelegrafPlugin={onSetActiveTelegrafPlugin}
             onAddPluginBundle={onAddPluginBundle}
             onRemovePluginBundle={onRemovePluginBundle}
+            onSetBucketInfo={onSetBucketInfo}
           />
         )
       case DataLoaderStep.Configure:

--- a/ui/src/onboarding/OnboardingWizard.scss
+++ b/ui/src/onboarding/OnboardingWizard.scss
@@ -70,6 +70,11 @@
   flex: 1 0 calc(100% - 240px);
 }
 
+.wizard-step--group {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
 
 .onboarding-step {
   min-width: 100%;
@@ -122,8 +127,8 @@
 }
 
 .wizard-step--filter {
-  float:right;
-  padding-bottom: 15px;
+  align-self: flex-end;
+  margin: 20px;
 }
 
 /* Buttons */

--- a/ui/src/onboarding/apis/index.ts
+++ b/ui/src/onboarding/apis/index.ts
@@ -91,6 +91,18 @@ export const trySources = async (): Promise<boolean> => {
   }
 }
 
+export const getTelegrafConfig = async (
+  telegrafConfigID
+): Promise<Telegraf> => {
+  try {
+    const response = await telegrafsAPI.telegrafsTelegrafIDGet(telegrafConfigID)
+    return response.data
+  } catch (error) {
+    console.error(error)
+    return null
+  }
+}
+
 export const getTelegrafConfigs = async (org: string): Promise<Telegraf[]> => {
   try {
     const data = await telegrafsAPI.telegrafsGet(org)

--- a/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.test.tsx
+++ b/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.test.tsx
@@ -36,6 +36,9 @@ const setup = (override = {}) => {
     location: null,
     router: null,
     routes: [],
+    selectedBucket: '',
+    onSetBucketInfo: jest.fn(),
+    buckets: [],
     ...override,
   }
 

--- a/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.tsx
+++ b/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.tsx
@@ -17,6 +17,7 @@ import {
   addPluginBundleWithPlugins,
   removePluginBundleWithPlugins,
 } from 'src/onboarding/actions/dataLoaders'
+import {setBucketInfo} from 'src/onboarding/actions/steps'
 
 // Constants
 import {StepStatus} from 'src/clockface/constants/wizard'
@@ -28,8 +29,9 @@ import {
   DataLoaderType,
   BundleName,
 } from 'src/types/v2/dataLoaders'
+import {Bucket} from 'src/api'
 
-export interface OwnProps extends DataLoaderStepProps {
+export interface Props extends DataLoaderStepProps {
   bucket: string
   telegrafPlugins: TelegrafPlugin[]
   pluginBundles: BundleName[]
@@ -39,22 +41,13 @@ export interface OwnProps extends DataLoaderStepProps {
   onSetDataLoadersType: (type: DataLoaderType) => void
   onSetActiveTelegrafPlugin: typeof setActiveTelegrafPlugin
   onSetStepStatus: (index: number, status: StepStatus) => void
-}
-
-type Props = OwnProps
-
-interface State {
-  showStreamingSources: boolean
+  onSetBucketInfo: typeof setBucketInfo
+  buckets: Bucket[]
+  selectedBucket: string
 }
 
 @ErrorHandling
-export class SelectDataSourceStep extends PureComponent<Props, State> {
-  constructor(props: Props) {
-    super(props)
-
-    this.state = {showStreamingSources: false}
-  }
-
+export class SelectDataSourceStep extends PureComponent<Props> {
   public componentDidMount() {
     if (this.isStreaming && this.props.type !== DataLoaderType.Streaming) {
       this.props.onSetDataLoadersType(DataLoaderType.Streaming)
@@ -121,6 +114,10 @@ export class SelectDataSourceStep extends PureComponent<Props, State> {
           pluginBundles={this.props.pluginBundles}
           telegrafPlugins={this.props.telegrafPlugins}
           onTogglePluginBundle={this.handleTogglePluginBundle}
+          buckets={this.props.buckets}
+          bucket={this.props.bucket}
+          selectedBucket={this.props.selectedBucket}
+          onSelectBucket={this.handleSelectBucket}
         />
       )
     }
@@ -130,6 +127,12 @@ export class SelectDataSourceStep extends PureComponent<Props, State> {
         type={this.props.type}
       />
     )
+  }
+
+  private handleSelectBucket = (bucket: Bucket) => {
+    const {organization, organizationID, id, name} = bucket
+
+    this.props.onSetBucketInfo(organization, organizationID, name, id)
   }
 
   private get showSkip(): boolean {

--- a/ui/src/onboarding/components/selectionStep/StreamingSelector.test.tsx
+++ b/ui/src/onboarding/components/selectionStep/StreamingSelector.test.tsx
@@ -15,6 +15,10 @@ const setup = (override = {}) => {
     telegrafPlugins: [],
     pluginBundles: [],
     onTogglePluginBundle: jest.fn(),
+    buckets: [],
+    bucket: '',
+    selectedBucket: '',
+    onSelectBucket: jest.fn(),
     ...override,
   }
 

--- a/ui/src/organizations/components/Collectors.tsx
+++ b/ui/src/organizations/components/Collectors.tsx
@@ -17,42 +17,56 @@ import {
   Grid,
   Columns,
 } from 'src/clockface'
+import DataLoadersWizard from 'src/dataLoaders/components/DataLoadersWizard'
+
+// APIS
+import {
+  getTelegrafConfigTOML,
+  deleteTelegrafConfig,
+} from 'src/organizations/apis/index'
 
 // Actions
 import * as NotificationsActions from 'src/types/actions/notifications'
+import {notify} from 'src/shared/actions/notifications'
 
 // Constants
 import {getTelegrafConfigFailed} from 'src/shared/copy/v2/notifications'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {Telegraf} from 'src/api'
-import {
-  getTelegrafConfigTOML,
-  deleteTelegrafConfig,
-} from 'src/organizations/apis/index'
-import {notify} from 'src/shared/actions/notifications'
+
+// Types
+import {Telegraf, Bucket} from 'src/api'
+import {DataLoaderType, DataLoaderStep} from 'src/types/v2/dataLoaders'
+import {OverlayState} from 'src/types/v2'
 
 interface Props {
   collectors: Telegraf[]
   onChange: () => void
   notify: NotificationsActions.PublishNotificationActionCreator
   orgName: string
+  buckets: Bucket[]
+}
+
+interface State {
+  overlayState: OverlayState
 }
 
 @ErrorHandling
-export default class Collectors extends PureComponent<Props> {
+export default class Collectors extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {overlayState: OverlayState.Closed}
+  }
+
   public render() {
-    const {collectors} = this.props
+    const {collectors, buckets} = this.props
     return (
       <>
         <TabbedPageHeader>
           <h1>Telegraf Configurations</h1>
-          <Button
-            text="Create Configuration"
-            icon={IconFont.Plus}
-            color={ComponentColor.Primary}
-          />
+          {this.createButton}
         </TabbedPageHeader>
         <Grid>
           <Grid.Row>
@@ -74,9 +88,42 @@ export default class Collectors extends PureComponent<Props> {
             </Grid.Column>
           </Grid.Row>
         </Grid>
+        <DataLoadersWizard
+          visible={this.isOverlayVisible}
+          onCompleteSetup={this.handleDismissDataLoaders}
+          startingType={DataLoaderType.Streaming}
+          startingStep={DataLoaderStep.Select}
+          startingSubstep={'streaming'}
+          buckets={buckets}
+        />
       </>
     )
   }
+
+  private get isOverlayVisible(): boolean {
+    return this.state.overlayState === OverlayState.Open
+  }
+
+  private get createButton(): JSX.Element {
+    return (
+      <Button
+        text="Create Configuration"
+        icon={IconFont.Plus}
+        color={ComponentColor.Primary}
+        onClick={this.handleAddScraper}
+      />
+    )
+  }
+
+  private handleAddScraper = () => {
+    this.setState({overlayState: OverlayState.Open})
+  }
+
+  private handleDismissDataLoaders = () => {
+    this.setState({overlayState: OverlayState.Closed})
+    this.props.onChange()
+  }
+
   private get emptyState(): JSX.Element {
     const {orgName} = this.props
 
@@ -86,11 +133,7 @@ export default class Collectors extends PureComponent<Props> {
           text={`${orgName} does not own any Telegraf  Configurations , why not create one?`}
           highlightWords={['Telegraf', 'Configurations']}
         />
-        <Button
-          text="Create Configuration"
-          icon={IconFont.Plus}
-          color={ComponentColor.Primary}
-        />
+        {this.createButton}
       </EmptyState>
     )
   }

--- a/ui/src/organizations/containers/OrganizationView.tsx
+++ b/ui/src/organizations/containers/OrganizationView.tsx
@@ -165,12 +165,22 @@ class OrganizationView extends PureComponent<Props> {
                 >
                   {(collectors, loading, fetch) => (
                     <Spinner loading={loading}>
-                      <Collectors
-                        collectors={collectors}
-                        onChange={fetch}
-                        notify={notify}
-                        orgName={org.name}
-                      />
+                      <GetOrgResources<Bucket[]>
+                        organization={org}
+                        fetcher={getBuckets}
+                      >
+                        {(buckets, loading) => (
+                          <Spinner loading={loading}>
+                            <Collectors
+                              collectors={collectors}
+                              onChange={fetch}
+                              notify={notify}
+                              buckets={buckets}
+                              orgName={org.name}
+                            />
+                          </Spinner>
+                        )}
+                      </GetOrgResources>
                     </Spinner>
                   )}
                 </GetOrgResources>


### PR DESCRIPTION
Closes #11234 
Closes #11048 

_Briefly describe your proposed changes:_
Add the ability to open to the collectors section of the dataloader wizard by clicking create collector.
Fix save telegraf action so that it doesnt just update the same config over and over and you can add new configs.

  - [x] Rebased/mergeable
  - [x] Tests pass
