### PR TITLE
add authorized authorization service

### DIFF
--- a/authorizer/auth.go
+++ b/authorizer/auth.go
@@ -1,0 +1,163 @@
+package authorizer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.AuthorizationService = (*AuthorizationService)(nil)
+
+// AuthorizationService wraps a influxdb.AuthorizationService and authorizes actions
+// against it appropriately.
+type AuthorizationService struct {
+	s influxdb.AuthorizationService
+}
+
+// NewAuthorizationService constructs an instance of an authorizing authorization serivce.
+func NewAuthorizationService(s influxdb.AuthorizationService) *AuthorizationService {
+	return &AuthorizationService{
+		s: s,
+	}
+}
+
+func newAuthorizationPermission(a influxdb.Action, id influxdb.ID) (*influxdb.Permission, error) {
+	p := &influxdb.Permission{
+		Action: a,
+		Resource: influxdb.Resource{
+			Type: influxdb.UsersResourceType,
+			ID:   &id,
+		},
+	}
+	return p, p.Valid()
+}
+
+func authorizeReadAuthorization(ctx context.Context, id influxdb.ID) error {
+	p, err := newAuthorizationPermission(influxdb.ReadAction, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func authorizeWriteAuthorization(ctx context.Context, id influxdb.ID) error {
+	p, err := newAuthorizationPermission(influxdb.WriteAction, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FindAuthorizationByID checks to see if the authorizer on context has read access to the id provided.
+func (s *AuthorizationService) FindAuthorizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Authorization, error) {
+	a, err := s.s.FindAuthorizationByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeReadAuthorization(ctx, a.UserID); err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+// FindAuthorization retrieves the authorization and checks to see if the authorizer on context has read access to the authorization.
+func (s *AuthorizationService) FindAuthorizationByToken(ctx context.Context, t string) (*influxdb.Authorization, error) {
+	a, err := s.s.FindAuthorizationByToken(ctx, t)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeReadAuthorization(ctx, a.UserID); err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+// FindAuthorizations retrieves all authorizations that match the provided filter and then filters the list down to only the resources that are authorized.
+func (s *AuthorizationService) FindAuthorizations(ctx context.Context, filter influxdb.AuthorizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Authorization, int, error) {
+	// TODO: we'll likely want to push this operation into the database eventually since fetching the whole list of data
+	// will likely be expensive.
+	as, _, err := s.s.FindAuthorizations(ctx, filter, opt...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	authorizations := as[:0]
+	for _, a := range as {
+		err := authorizeReadAuthorization(ctx, a.UserID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, 0, err
+		}
+
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+
+		authorizations = append(authorizations, a)
+	}
+
+	return authorizations, len(authorizations), nil
+}
+
+// CreateAuthorization checks to see if the authorizer on context has write access to the global authorizations resource.
+func (s *AuthorizationService) CreateAuthorization(ctx context.Context, a *influxdb.Authorization) error {
+	if err := authorizeWriteAuthorization(ctx, a.UserID); err != nil {
+		return err
+	}
+
+	for _, p := range a.Permissions {
+		if err := IsAllowed(ctx, p); err != nil {
+			return &influxdb.Error{
+				Err:  err,
+				Msg:  fmt.Sprintf("cannot create authorization with permission %s", p),
+				Code: influxdb.EForbidden,
+			}
+		}
+	}
+
+	return s.s.CreateAuthorization(ctx, a)
+}
+
+// SetAuthorizationStatus checks to see if the authorizer on context has write access to the authorization provided.
+func (s *AuthorizationService) SetAuthorizationStatus(ctx context.Context, id influxdb.ID, st influxdb.Status) error {
+	a, err := s.s.FindAuthorizationByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := authorizeWriteAuthorization(ctx, a.UserID); err != nil {
+		return err
+	}
+
+	return s.s.SetAuthorizationStatus(ctx, id, st)
+}
+
+// DeleteAuthorization checks to see if the authorizer on context has write access to the authorization provided.
+func (s *AuthorizationService) DeleteAuthorization(ctx context.Context, id influxdb.ID) error {
+	a, err := s.s.FindAuthorizationByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := authorizeWriteAuthorization(ctx, a.UserID); err != nil {
+		return err
+	}
+
+	return s.s.DeleteAuthorization(ctx, id)
+}

--- a/authorizer/auth_test.go
+++ b/authorizer/auth_test.go
@@ -1,0 +1,272 @@
+package authorizer_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+var authorizationCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	cmp.Transformer("Sort", func(in []*influxdb.Authorization) []*influxdb.Authorization {
+		out := append([]*influxdb.Authorization(nil), in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID.String() > out[j].ID.String()
+		})
+		return out
+	}),
+}
+
+func TestAuthorizationService_ReadAuthorization(t *testing.T) {
+	type fields struct {
+		AuthorizationService influxdb.AuthorizationService
+	}
+	type args struct {
+		permission influxdb.Permission
+		id         influxdb.ID
+	}
+	type wants struct {
+		err            error
+		authorizations []*influxdb.Authorization
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access id",
+			fields: fields{
+				AuthorizationService: &mock.AuthorizationService{
+					FindAuthorizationByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Authorization, error) {
+						return &influxdb.Authorization{
+							ID:     id,
+							UserID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: nil,
+				authorizations: []*influxdb.Authorization{
+					{
+						ID:     10,
+						UserID: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "unauthorized to access id",
+			fields: fields{
+				AuthorizationService: &mock.AuthorizationService{
+					FindAuthorizationByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Authorization, error) {
+						return &influxdb.Authorization{
+							ID:     id,
+							UserID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.BucketsResourceType,
+						ID:   influxdbtesting.IDPtr(20),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:users/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+				authorizations: []*influxdb.Authorization{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mock.AuthorizationService{}
+			m.FindAuthorizationByIDFn = func(ctx context.Context, id influxdb.ID) (*influxdb.Authorization, error) {
+				return &influxdb.Authorization{
+					ID:     id,
+					UserID: 1,
+				}, nil
+			}
+			m.FindAuthorizationByTokenFn = func(ctx context.Context, t string) (*influxdb.Authorization, error) {
+				return &influxdb.Authorization{
+					ID:     10,
+					UserID: 1,
+				}, nil
+			}
+			m.FindAuthorizationsFn = func(ctx context.Context, filter influxdb.AuthorizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Authorization, int, error) {
+				return []*influxdb.Authorization{
+					{
+						ID:     10,
+						UserID: 1,
+					},
+				}, 1, nil
+			}
+			s := authorizer.NewAuthorizationService(m)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			t.Run("find authorization by id", func(t *testing.T) {
+				_, err := s.FindAuthorizationByID(ctx, 10)
+				influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+			})
+			t.Run("find authorization by token", func(t *testing.T) {
+				_, err := s.FindAuthorizationByToken(ctx, "10")
+				influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+			})
+
+			t.Run("find authorizations", func(t *testing.T) {
+				as, _, err := s.FindAuthorizations(ctx, influxdb.AuthorizationFilter{})
+				influxdbtesting.ErrorsEqual(t, err, nil)
+
+				if diff := cmp.Diff(as, tt.wants.authorizations, authorizationCmpOptions...); diff != "" {
+					t.Errorf("authorizations are different -got/+want\ndiff %s", diff)
+				}
+			})
+
+		})
+	}
+}
+
+func TestAuthorizationService_WriteAuthorization(t *testing.T) {
+	type fields struct {
+		AuthorizationService influxdb.AuthorizationService
+	}
+	type args struct {
+		permission influxdb.Permission
+		userID     influxdb.ID
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to create authorization",
+			fields: fields{
+				AuthorizationService: &mock.AuthorizationService{
+					CreateAuthorizationFn: func(ctx context.Context, b *influxdb.Authorization) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				userID: 1,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to create authorization",
+			fields: fields{
+				AuthorizationService: &mock.AuthorizationService{
+					CreateAuthorizationFn: func(ctx context.Context, b *influxdb.Authorization) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				userID: 1,
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.UsersResourceType,
+						ID:   influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:users/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mock.AuthorizationService{}
+			m.FindAuthorizationByIDFn = func(ctx context.Context, id influxdb.ID) (*influxdb.Authorization, error) {
+				return &influxdb.Authorization{
+					ID:     id,
+					UserID: 1,
+				}, nil
+			}
+			m.CreateAuthorizationFn = func(ctx context.Context, a *influxdb.Authorization) error {
+				return nil
+			}
+			m.DeleteAuthorizationFn = func(ctx context.Context, id influxdb.ID) error {
+				return nil
+			}
+			m.SetAuthorizationStatusFn = func(ctx context.Context, id influxdb.ID, s influxdb.Status) error {
+				return nil
+			}
+			s := authorizer.NewAuthorizationService(m)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			t.Run("create authorization", func(t *testing.T) {
+				err := s.CreateAuthorization(ctx, &influxdb.Authorization{UserID: tt.args.userID})
+				influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+			})
+
+			t.Run("set authorization status", func(t *testing.T) {
+				err := s.SetAuthorizationStatus(ctx, 10, influxdb.Active)
+				influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+			})
+
+			t.Run("delete authorization", func(t *testing.T) {
+				err := s.DeleteAuthorization(ctx, 10)
+				influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+			})
+
+		})
+	}
+}

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -100,7 +100,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 
 	h.AuthorizationHandler = NewAuthorizationHandler(b.UserService)
 	h.AuthorizationHandler.OrganizationService = b.OrganizationService
-	h.AuthorizationHandler.AuthorizationService = b.AuthorizationService
+	h.AuthorizationHandler.AuthorizationService = authorizer.NewAuthorizationService(b.AuthorizationService)
 	h.AuthorizationHandler.LookupService = b.LookupService
 	h.AuthorizationHandler.Logger = b.Logger.With(zap.String("handler", "auth"))
 


### PR DESCRIPTION
Closes part of #10814

_Briefly describe your proposed changes:_
This PR introduces an authorized authorization service.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
