### PR TITLE
Misc alpha polish

### DIFF
--- a/ui/src/shared/components/TimeMachineQueryTab.scss
+++ b/ui/src/shared/components/TimeMachineQueryTab.scss
@@ -4,7 +4,7 @@
   background: $g2-kevlar;
   border-radius: 5px 5px 0 0;
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
   color: $g10-wolf;
   font-weight: 700;
@@ -29,14 +29,22 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  flex: 1 1 0;
 }
 
-.time-machine-query-tab--close {
-  margin-left: 10px;
+.time-machine-query-tab--close, .time-machine-query-tab--hide {
   margin-bottom: 2px;
   color: $g7-graphite;
 
   &:hover {
     color: $g16-pearl;
   }
+}
+
+.time-machine-query-tab--hide {
+  margin-right: 8px;
+}
+
+.time-machine-query-tab--close {
+  margin-left: 8px;
 }

--- a/ui/src/shared/components/TimeMachineQueryTab.tsx
+++ b/ui/src/shared/components/TimeMachineQueryTab.tsx
@@ -69,6 +69,7 @@ class TimeMachineQueryTab extends PureComponent<Props, State> {
             className={`time-machine-query-tab ${activeClass}`}
             onClick={this.handleSetActive}
           >
+            {this.showHideButton}
             <TimeMachineQueryTabName
               isActive={isActive}
               name={query.name}
@@ -78,7 +79,6 @@ class TimeMachineQueryTab extends PureComponent<Props, State> {
               onEdit={this.handleEditName}
               onCancelEdit={this.handleCancelEditName}
             />
-            {this.showHideButton}
             {this.removeButton}
           </div>
         </RightClick.Trigger>
@@ -151,7 +151,7 @@ class TimeMachineQueryTab extends PureComponent<Props, State> {
 
     return (
       <div
-        className="time-machine-query-tab--close"
+        className="time-machine-query-tab--hide"
         onClick={this.handleToggleView}
       >
         <span className={`icon ${icon}`} />

--- a/ui/src/shared/reducers/v2/timeMachines.test.ts
+++ b/ui/src/shared/reducers/v2/timeMachines.test.ts
@@ -177,7 +177,7 @@ describe('timeMachineReducer', () => {
       expect(nextState.activeQueryIndex).toEqual(1)
       expect(nextState.draftQueries).toEqual([
         {
-          text: 'foo',
+          text: '',
           type: InfluxLanguage.Flux,
           sourceID: '',
           editMode: QueryEditMode.Builder,
@@ -185,7 +185,7 @@ describe('timeMachineReducer', () => {
           hidden: false,
         },
         {
-          text: 'bar',
+          text: '',
           type: InfluxLanguage.Flux,
           sourceID: '',
           editMode: QueryEditMode.Builder,

--- a/ui/src/shared/reducers/v2/timeMachines.ts
+++ b/ui/src/shared/reducers/v2/timeMachines.ts
@@ -346,20 +346,14 @@ export const timeMachineReducer = (
     }
 
     case 'EDIT_ACTIVE_QUERY_WITH_BUILDER': {
-      const {activeQueryIndex} = state
-      const draftQueries = [...state.draftQueries]
-      const query = draftQueries[activeQueryIndex]
+      return produce(state, draftState => {
+        const query = draftState.draftQueries[draftState.activeQueryIndex]
 
-      draftQueries[activeQueryIndex] = {
-        ...query,
-        editMode: QueryEditMode.Builder,
-        hidden: false,
-      }
+        query.editMode = QueryEditMode.Builder
+        query.hidden = false
 
-      return {
-        ...state,
-        draftQueries,
-      }
+        buildAndSubmitAllQueries(draftState)
+      })
     }
 
     case 'EDIT_ACTIVE_QUERY_AS_FLUX': {

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -35,6 +35,7 @@ import {getDeep} from 'src/utils/wrappers'
 import {
   taskOptionsToFluxScript,
   TaskOptionKeys,
+  TaskOptions,
 } from 'src/utils/taskOptionsToFluxScript'
 
 export type Action =
@@ -318,18 +319,15 @@ export const updateScript = () => async (dispatch, getState: GetStateFunc) => {
   }
 }
 
-export const saveNewScript = () => async (
-  dispatch,
-  getState: GetStateFunc
-): Promise<void> => {
+export const saveNewScript = (
+  script: string,
+  taskOptions: TaskOptions
+) => async (dispatch, getState: GetStateFunc): Promise<void> => {
   try {
-    const {
-      orgs,
-      tasks: {newScript: script, taskOptions},
-    } = await getState()
+    const {orgs} = await getState()
 
     const fluxTaskOptions = taskOptionsToFluxScript(taskOptions)
-    const scriptWithOptions = `${fluxTaskOptions}\n${script}`
+    const scriptWithOptions = `${fluxTaskOptions}\n\n${script}`
 
     let org = orgs.find(org => {
       return org.id === taskOptions.orgID

--- a/ui/src/tasks/containers/TaskPage.tsx
+++ b/ui/src/tasks/containers/TaskPage.tsx
@@ -124,7 +124,9 @@ class TaskPage extends PureComponent<
   }
 
   private handleSave = () => {
-    this.props.saveNewScript()
+    const {newScript, taskOptions} = this.props
+
+    this.props.saveNewScript(newScript, taskOptions)
   }
 
   private handleCancel = () => {


### PR DESCRIPTION
Closes #11228

- Fixes an issue where saving a query in the DE as a task would fail with a 400 error (the script was using variables that didn't exist)
- Moves the visibility icon to the left of the name in each query tab in the DE
- Fixes an issue where the query builder and graph were out of sync after switching from script mode to query builder mode