### PR TITLE
Remove empty scraper verify step and data loaders progress bar 

### DIFF
--- a/ui/src/onboarding/actions/steps.ts
+++ b/ui/src/onboarding/actions/steps.ts
@@ -1,12 +1,8 @@
-// Constants
-import {StepStatus} from 'src/clockface/constants/wizard'
-
 // Types
 import {Substep} from 'src/types/v2/dataLoaders'
 
 export type Action =
   | SetBucketInfo
-  | SetStepStatus
   | SetBucketID
   | IncrementCurrentStepIndex
   | DecrementCurrentStepIndex
@@ -77,22 +73,6 @@ export const setBucketInfo = (
 ): SetBucketInfo => ({
   type: 'SET_BUCKET_INFO',
   payload: {org, orgID, bucket, bucketID},
-})
-
-interface SetStepStatus {
-  type: 'SET_STEP_STATUS'
-  payload: {index: number; status: StepStatus}
-}
-
-export const setStepStatus = (
-  index: number,
-  status: StepStatus
-): SetStepStatus => ({
-  type: 'SET_STEP_STATUS',
-  payload: {
-    index,
-    status,
-  },
 })
 
 interface SetBucketID {

--- a/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.test.tsx
+++ b/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.test.tsx
@@ -12,11 +12,7 @@ import {ComponentStatus} from 'src/clockface'
 import {DataLoaderType} from 'src/types/v2/dataLoaders'
 
 // Dummy Data
-import {
-  defaultOnboardingStepProps,
-  telegrafPlugin,
-  cpuTelegrafPlugin,
-} from 'mocks/dummyData'
+import {defaultOnboardingStepProps, cpuTelegrafPlugin} from 'mocks/dummyData'
 import OnboardingButtons from 'src/onboarding/components/OnboardingButtons'
 
 const setup = (override = {}) => {
@@ -30,7 +26,6 @@ const setup = (override = {}) => {
     onRemovePluginBundle: jest.fn(),
     onSetDataLoadersType: jest.fn(),
     onSetActiveTelegrafPlugin: jest.fn(),
-    onSetStepStatus: jest.fn(),
     currentStepIndex: 2,
     substep: undefined,
     location: null,
@@ -57,29 +52,6 @@ describe('Onboarding.Components.SelectionStep.SelectDataSourceStep', () => {
       expect(onboardingButtons.prop('nextButtonStatus')).toBe(
         ComponentStatus.Disabled
       )
-    })
-  })
-
-  describe('skip info', () => {
-    it('does not render if telegraf no plugins are selected', () => {
-      const wrapper = setup()
-      const onboardingButtons = wrapper.find(OnboardingButtons)
-
-      expect(onboardingButtons.prop('showSkip')).toBe(false)
-    })
-
-    it('renders if telegraf plugins are selected', () => {
-      const wrapper = setup({telegrafPlugins: [cpuTelegrafPlugin]})
-      const onboardingButtons = wrapper.find(OnboardingButtons)
-
-      expect(onboardingButtons.prop('showSkip')).toBe(true)
-    })
-
-    it('does not render if any telegraf plugins is incomplete', () => {
-      const wrapper = setup({telegrafPlugins: [telegrafPlugin]})
-      const onboardingButtons = wrapper.find(OnboardingButtons)
-
-      expect(onboardingButtons.prop('showSkip')).toBe(false)
     })
   })
 

--- a/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.tsx
+++ b/ui/src/onboarding/components/selectionStep/SelectDataSourceStep.tsx
@@ -19,9 +19,6 @@ import {
 } from 'src/onboarding/actions/dataLoaders'
 import {setBucketInfo} from 'src/onboarding/actions/steps'
 
-// Constants
-import {StepStatus} from 'src/clockface/constants/wizard'
-
 // Types
 import {DataLoaderStepProps} from 'src/dataLoaders/components/DataLoadersWizard'
 import {
@@ -40,7 +37,6 @@ export interface Props extends DataLoaderStepProps {
   onRemovePluginBundle: typeof removePluginBundleWithPlugins
   onSetDataLoadersType: (type: DataLoaderType) => void
   onSetActiveTelegrafPlugin: typeof setActiveTelegrafPlugin
-  onSetStepStatus: (index: number, status: StepStatus) => void
   onSetBucketInfo: typeof setBucketInfo
   buckets: Bucket[]
   selectedBucket: string
@@ -71,11 +67,8 @@ export class SelectDataSourceStep extends PureComponent<Props> {
           </div>
           <OnboardingButtons
             onClickBack={this.handleClickBack}
-            onClickSkip={this.jumpToCompletionStep}
-            skipButtonText={'Skip to Complete'}
             autoFocusNext={true}
             nextButtonStatus={this.nextButtonStatus}
-            showSkip={this.showSkip}
           />
         </Form>
       </div>
@@ -135,22 +128,6 @@ export class SelectDataSourceStep extends PureComponent<Props> {
     this.props.onSetBucketInfo(organization, organizationID, name, id)
   }
 
-  private get showSkip(): boolean {
-    const {telegrafPlugins} = this.props
-    if (telegrafPlugins.length < 1) {
-      return false
-    }
-
-    return telegrafPlugins.every(plugin => plugin.configured === 'configured')
-  }
-
-  private jumpToCompletionStep = () => {
-    const {onSetCurrentStepIndex, stepStatuses} = this.props
-
-    this.handleSetStepStatus()
-    onSetCurrentStepIndex(stepStatuses.length - 2)
-  }
-
   private handleClickNext = () => {
     const {
       currentStepIndex,
@@ -165,8 +142,6 @@ export class SelectDataSourceStep extends PureComponent<Props> {
       return
     }
 
-    this.handleSetStepStatus()
-
     if (this.isStreaming) {
       const name = _.get(telegrafPlugins, '0.name', '')
       onSetActiveTelegrafPlugin(name)
@@ -178,10 +153,10 @@ export class SelectDataSourceStep extends PureComponent<Props> {
   }
 
   private handleClickBack = () => {
-    const {currentStepIndex, onSetCurrentStepIndex} = this.props
+    const {currentStepIndex, onSetSubstepIndex} = this.props
 
     if (this.isStreaming) {
-      onSetCurrentStepIndex(+currentStepIndex)
+      onSetSubstepIndex(+currentStepIndex, 0)
       return
     }
 
@@ -206,19 +181,6 @@ export class SelectDataSourceStep extends PureComponent<Props> {
     }
 
     this.props.onAddPluginBundle(bundle)
-  }
-
-  private handleSetStepStatus = () => {
-    const {onSetStepStatus, currentStepIndex} = this.props
-
-    if (
-      this.props.type === DataLoaderType.Streaming &&
-      !this.props.telegrafPlugins.length
-    ) {
-      onSetStepStatus(currentStepIndex, StepStatus.Incomplete)
-    } else if (this.props.type) {
-      onSetStepStatus(currentStepIndex, StepStatus.Complete)
-    }
   }
 
   private get isStreaming(): boolean {

--- a/ui/src/onboarding/components/verifyStep/DataListening.test.tsx
+++ b/ui/src/onboarding/components/verifyStep/DataListening.test.tsx
@@ -11,7 +11,6 @@ const setup = (override = {}) => {
   const props = {
     bucket: 'defbuck',
     stepIndex: 4,
-    onSetStepStatus: jest.fn(),
     ...override,
   }
 

--- a/ui/src/onboarding/components/verifyStep/DataListening.tsx
+++ b/ui/src/onboarding/components/verifyStep/DataListening.tsx
@@ -17,16 +17,11 @@ import ConnectionInformation, {
   LoadingState,
 } from 'src/onboarding/components/verifyStep/ConnectionInformation'
 
-// Constants
-import {StepStatus} from 'src/clockface/constants/wizard'
-
 // Types
 import {InfluxLanguage} from 'src/types/v2/dashboards'
 
 export interface Props {
   bucket: string
-  stepIndex: number
-  onSetStepStatus: (index: number, status: StepStatus) => void
 }
 
 interface State {
@@ -117,7 +112,7 @@ class DataListening extends PureComponent<Props, State> {
   }
 
   private checkForData = async (): Promise<void> => {
-    const {bucket, onSetStepStatus, stepIndex} = this.props
+    const {bucket} = this.props
     const {secondsLeft} = this.state
     const script = `from(bucket: "${bucket}")
       |> range(start: -1m)`
@@ -135,19 +130,16 @@ class DataListening extends PureComponent<Props, State> {
       timePassed = Number(new Date()) - this.startTime
     } catch (err) {
       this.setState({loading: LoadingState.Error})
-      onSetStepStatus(stepIndex, StepStatus.Incomplete)
       return
     }
 
     if (rowCount > 1) {
       this.setState({loading: LoadingState.Done})
-      onSetStepStatus(stepIndex, StepStatus.Complete)
       return
     }
 
     if (timePassed >= MINUTE || secondsLeft <= 0) {
       this.setState({loading: LoadingState.NotFound})
-      onSetStepStatus(stepIndex, StepStatus.Incomplete)
       return
     }
     this.intervalID = setTimeout(this.checkForData, FETCH_WAIT)

--- a/ui/src/onboarding/components/verifyStep/DataStreaming.tsx
+++ b/ui/src/onboarding/components/verifyStep/DataStreaming.tsx
@@ -10,9 +10,6 @@ import DataListening from 'src/onboarding/components/verifyStep/DataListening'
 // Actions
 import {createOrUpdateTelegrafConfigAsync} from 'src/onboarding/actions/dataLoaders'
 
-// Constants
-import {StepStatus} from 'src/clockface/constants/wizard'
-
 // Decorator
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -24,9 +21,7 @@ interface Props {
   bucket: string
   org: string
   configID: string
-  stepIndex: number
   authToken: string
-  onSetStepStatus: (index: number, status: StepStatus) => void
   onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
 }
 
@@ -38,9 +33,7 @@ class DataStreaming extends PureComponent<Props> {
       org,
       configID,
       onSaveTelegrafConfig,
-      onSetStepStatus,
       bucket,
-      stepIndex,
       notify,
     } = this.props
 
@@ -61,11 +54,7 @@ class DataStreaming extends PureComponent<Props> {
           )}
         </CreateOrUpdateConfig>
 
-        <DataListening
-          bucket={bucket}
-          stepIndex={stepIndex}
-          onSetStepStatus={onSetStepStatus}
-        />
+        <DataListening bucket={bucket} />
       </>
     )
   }

--- a/ui/src/onboarding/components/verifyStep/VerifyDataStep.test.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataStep.test.tsx
@@ -5,7 +5,6 @@ import {shallow} from 'enzyme'
 // Components
 import {VerifyDataStep} from 'src/onboarding/components/verifyStep/VerifyDataStep'
 import VerifyDataSwitcher from 'src/onboarding/components/verifyStep/VerifyDataSwitcher'
-import OnboardingButtons from 'src/onboarding/components/OnboardingButtons'
 
 // Types
 import {DataLoaderType} from 'src/types/v2/dataLoaders'
@@ -43,11 +42,9 @@ const setup = (override = {}) => {
 describe('Onboarding.Components.VerifyStep.VerifyDataStep', () => {
   it('renders', () => {
     const {wrapper} = setup()
-    const onboardingButtons = wrapper.find(OnboardingButtons)
     const switcher = wrapper.find(VerifyDataSwitcher)
 
     expect(wrapper.exists()).toBe(true)
-    expect(onboardingButtons.prop('showSkip')).toBe(true)
     expect(switcher.exists()).toBe(true)
   })
 })

--- a/ui/src/onboarding/components/verifyStep/VerifyDataStep.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataStep.tsx
@@ -20,7 +20,6 @@ import {
 import {DataLoaderType, TelegrafPlugin} from 'src/types/v2/dataLoaders'
 import {Form} from 'src/clockface'
 import {NotificationAction, RemoteDataState} from 'src/types'
-import {StepStatus} from 'src/clockface/constants/wizard'
 import {AppState} from 'src/types/v2'
 import {DataLoaderStepProps} from 'src/dataLoaders/components/DataLoadersWizard'
 
@@ -64,8 +63,6 @@ export class VerifyDataStep extends PureComponent<Props> {
       type,
       onSaveTelegrafConfig,
       onDecrementCurrentStepIndex,
-      onSetStepStatus,
-      stepIndex,
       notify,
       lpStatus,
       org,
@@ -85,8 +82,6 @@ export class VerifyDataStep extends PureComponent<Props> {
                   org={org}
                   bucket={bucket}
                   username={username}
-                  onSetStepStatus={onSetStepStatus}
-                  stepIndex={stepIndex}
                   onDecrementCurrentStep={onDecrementCurrentStepIndex}
                   lpStatus={lpStatus}
                 />
@@ -95,9 +90,6 @@ export class VerifyDataStep extends PureComponent<Props> {
           </div>
           <OnboardingButtons
             onClickBack={this.handleDecrementStep}
-            onClickSkip={this.jumpToCompletionStep}
-            skipButtonText={'Skip'}
-            showSkip={true}
             nextButtonText={'Finish'}
           />
         </Form>
@@ -116,18 +108,7 @@ export class VerifyDataStep extends PureComponent<Props> {
   }
 
   private handleIncrementStep = () => {
-    const {onSetStepStatus, type, lpStatus, onExit} = this.props
-    const {currentStepIndex} = this.props
-
-    if (
-      type === DataLoaderType.LineProtocol &&
-      lpStatus === RemoteDataState.Error
-    ) {
-      onSetStepStatus(currentStepIndex, StepStatus.Error)
-    } else {
-      onSetStepStatus(currentStepIndex, StepStatus.Complete)
-    }
-
+    const {onExit} = this.props
     onExit()
   }
 
@@ -148,12 +129,6 @@ export class VerifyDataStep extends PureComponent<Props> {
       onDecrementCurrentStepIndex()
       onSetActiveTelegrafPlugin('')
     }
-  }
-
-  private jumpToCompletionStep = () => {
-    const {onSetCurrentStepIndex, stepStatuses} = this.props
-
-    onSetCurrentStepIndex(stepStatuses.length - 1)
   }
 }
 

--- a/ui/src/onboarding/components/verifyStep/VerifyDataSwitcher.test.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataSwitcher.test.tsx
@@ -20,7 +20,6 @@ const setup = (override = {}) => {
     telegrafConfigID: '',
     onSaveTelegrafConfig: jest.fn(),
     stepIndex: 4,
-    onSetStepStatus: jest.fn(),
     onDecrementCurrentStep: jest.fn(),
     lpStatus: RemoteDataState.NotStarted,
     ...override,

--- a/ui/src/onboarding/components/verifyStep/VerifyDataSwitcher.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataSwitcher.tsx
@@ -9,9 +9,6 @@ import FetchAuthToken from 'src/onboarding/components/verifyStep/FetchAuthToken'
 // Actions
 import {createOrUpdateTelegrafConfigAsync} from 'src/onboarding/actions/dataLoaders'
 
-// Constants
-import {StepStatus} from 'src/clockface/constants/wizard'
-
 // Types
 import {DataLoaderType} from 'src/types/v2/dataLoaders'
 import {NotificationAction, RemoteDataState} from 'src/types'
@@ -23,10 +20,8 @@ interface Props {
   org: string
   bucket: string
   username: string
-  stepIndex: number
   telegrafConfigID: string
   onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
-  onSetStepStatus: (index: number, status: StepStatus) => void
   onDecrementCurrentStep: () => void
   lpStatus: RemoteDataState
 }
@@ -39,8 +34,6 @@ export class VerifyDataSwitcher extends PureComponent<Props> {
       bucket,
       username,
       type,
-      stepIndex,
-      onSetStepStatus,
       telegrafConfigID,
       onSaveTelegrafConfig,
       notify,
@@ -58,9 +51,7 @@ export class VerifyDataSwitcher extends PureComponent<Props> {
                 configID={telegrafConfigID}
                 authToken={authToken}
                 bucket={bucket}
-                onSetStepStatus={onSetStepStatus}
                 onSaveTelegrafConfig={onSaveTelegrafConfig}
-                stepIndex={stepIndex}
               />
             )}
           </FetchAuthToken>

--- a/ui/src/onboarding/reducers/steps.ts
+++ b/ui/src/onboarding/reducers/steps.ts
@@ -1,6 +1,3 @@
-// Constants
-import {StepStatus} from 'src/clockface/constants/wizard'
-
 // Types
 import {Action} from 'src/onboarding/actions/steps'
 import {Substep} from 'src/types/v2/dataLoaders'
@@ -8,7 +5,6 @@ import {Substep} from 'src/types/v2/dataLoaders'
 export interface DataLoadersStepsState {
   currentStep: number
   substep?: Substep
-  stepStatuses: StepStatus[]
   orgID: string
   bucketID: string
   org: string
@@ -16,7 +12,6 @@ export interface DataLoadersStepsState {
 }
 
 const INITIAL_STATE: DataLoadersStepsState = {
-  stepStatuses: new Array(3).fill(StepStatus.Incomplete),
   org: '',
   bucket: '',
   orgID: '',
@@ -45,10 +40,6 @@ export default (
       }
     case 'SET_BUCKET_INFO':
       return {...state, ...action.payload}
-    case 'SET_STEP_STATUS':
-      const stepStatuses = [...state.stepStatuses]
-      stepStatuses[action.payload.index] = action.payload.status
-      return {...state, stepStatuses}
     case 'SET_BUCKET_ID':
       return {...state, bucketID: action.payload.bucketID}
     default:


### PR DESCRIPTION
Closes #11048 

_Briefly describe your proposed changes:_
Clicking next on the scraper configure step closes the wizard rather than taking you to an empty verify step.
Remove progress bar from dataloaders wizard which allowed for the removal of step statuses.
Fix issue with not being able to click back on streaming selection step.

  - [x] Rebased/mergeable
  - [ ] Tests pass