### PR TITLE
Create dashboards for plugins in verify step

### DIFF
--- a/ui/src/dataLoaders/components/DataLoadersWizard.tsx
+++ b/ui/src/dataLoaders/components/DataLoadersWizard.tsx
@@ -28,7 +28,6 @@ import {
   removeConfigValue,
   setActiveTelegrafPlugin,
   setPluginConfiguration,
-  createOrUpdateTelegrafConfigAsync,
   addPluginBundleWithPlugins,
   removePluginBundleWithPlugins,
   setConfigArrayValue,
@@ -89,7 +88,6 @@ interface DispatchProps {
   onSetActiveTelegrafPlugin: typeof setActiveTelegrafPlugin
   onSetPluginConfiguration: typeof setPluginConfiguration
   onSetConfigArrayValue: typeof setConfigArrayValue
-  onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
   onIncrementCurrentStepIndex: typeof incrementCurrentStepIndex
   onDecrementCurrentStepIndex: typeof decrementCurrentStepIndex
   onSetCurrentStepIndex: typeof setCurrentStepIndex
@@ -150,7 +148,6 @@ class DataLoadersWizard extends PureComponent<Props> {
       onUpdateTelegrafPluginConfig,
       onAddConfigValue,
       onRemoveConfigValue,
-      onSaveTelegrafConfig,
       onAddPluginBundle,
       onRemovePluginBundle,
       notify,
@@ -191,7 +188,6 @@ class DataLoadersWizard extends PureComponent<Props> {
               onSetPluginConfiguration={onSetPluginConfiguration}
               onAddConfigValue={onAddConfigValue}
               onRemoveConfigValue={onRemoveConfigValue}
-              onSaveTelegrafConfig={onSaveTelegrafConfig}
               onAddPluginBundle={onAddPluginBundle}
               onRemovePluginBundle={onRemovePluginBundle}
               onSetConfigArrayValue={onSetConfigArrayValue}
@@ -353,7 +349,6 @@ const mdtp: DispatchProps = {
   onAddConfigValue: addConfigValue,
   onRemoveConfigValue: removeConfigValue,
   onSetActiveTelegrafPlugin: setActiveTelegrafPlugin,
-  onSaveTelegrafConfig: createOrUpdateTelegrafConfigAsync,
   onAddPluginBundle: addPluginBundleWithPlugins,
   onRemovePluginBundle: removePluginBundleWithPlugins,
   onSetPluginConfiguration: setPluginConfiguration,

--- a/ui/src/dataLoaders/components/StepSwitcher.tsx
+++ b/ui/src/dataLoaders/components/StepSwitcher.tsx
@@ -15,7 +15,6 @@ import {
   setActiveTelegrafPlugin,
   addConfigValue,
   removeConfigValue,
-  createOrUpdateTelegrafConfigAsync,
   addPluginBundleWithPlugins,
   removePluginBundleWithPlugins,
   setPluginConfiguration,
@@ -39,7 +38,6 @@ interface Props {
   buckets: Bucket[]
   dataLoaders: DataLoadersState
   currentStepIndex: number
-  onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
   onAddPluginBundle: typeof addPluginBundleWithPlugins
   onRemovePluginBundle: typeof removePluginBundleWithPlugins
   onSetConfigArrayValue: typeof setConfigArrayValue
@@ -55,7 +53,6 @@ class StepSwitcher extends PureComponent<Props> {
       onboardingStepProps,
       dataLoaders,
       onSetDataLoadersType,
-      onSaveTelegrafConfig,
       onUpdateTelegrafPluginConfig,
       onSetActiveTelegrafPlugin,
       onSetPluginConfiguration,
@@ -108,7 +105,6 @@ class StepSwitcher extends PureComponent<Props> {
             bucket={bucketName}
             username={username}
             org={org}
-            onSaveTelegrafConfig={onSaveTelegrafConfig}
             onSetActiveTelegrafPlugin={onSetActiveTelegrafPlugin}
             onSetPluginConfiguration={onSetPluginConfiguration}
             stepIndex={currentStepIndex}

--- a/ui/src/onboarding/components/verifyStep/CreateOrUpdateConfig.test.tsx
+++ b/ui/src/onboarding/components/verifyStep/CreateOrUpdateConfig.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import {shallow} from 'enzyme'
 
 // Components
-import CreateOrUpdateConfig from 'src/onboarding/components/verifyStep/CreateOrUpdateConfig'
+import {CreateOrUpdateConfig} from 'src/onboarding/components/verifyStep/CreateOrUpdateConfig'
 
 jest.mock('src/utils/api', () => require('src/onboarding/apis/mocks'))
 
@@ -12,6 +12,7 @@ const setup = async (override = {}) => {
     org: 'default',
     children: jest.fn(),
     onSaveTelegrafConfig: jest.fn(),
+    createDashboardsForPlugins: jest.fn(),
     notify: jest.fn(),
     authToken: '',
     ...override,

--- a/ui/src/onboarding/components/verifyStep/CreateOrUpdateConfig.tsx
+++ b/ui/src/onboarding/components/verifyStep/CreateOrUpdateConfig.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
 import _ from 'lodash'
 
 // Components
@@ -8,6 +9,8 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Actions
 import {createOrUpdateTelegrafConfigAsync} from 'src/onboarding/actions/dataLoaders'
+import {notify as notifyAction} from 'src/shared/actions/notifications'
+import {createDashboardsForPlugins as createDashboardsForPluginsAction} from 'src/protos/actions/'
 
 // Constants
 import {
@@ -18,20 +21,28 @@ import {
 // Types
 import {RemoteDataState, NotificationAction} from 'src/types'
 
-export interface Props {
+export interface OwnProps {
   org: string
   authToken: string
   children: () => JSX.Element
-  onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
-  notify: NotificationAction
 }
+
+export interface StateProps {}
+
+export interface DispatchProps {
+  notify: NotificationAction
+  onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
+  createDashboardsForPlugins: typeof createDashboardsForPluginsAction
+}
+
+type Props = OwnProps & StateProps & DispatchProps
 
 interface State {
   loading: RemoteDataState
 }
 
 @ErrorHandling
-class CreateOrUpdateConfig extends PureComponent<Props, State> {
+export class CreateOrUpdateConfig extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props)
 
@@ -39,13 +50,19 @@ class CreateOrUpdateConfig extends PureComponent<Props, State> {
   }
 
   public async componentDidMount() {
-    const {onSaveTelegrafConfig, authToken, notify} = this.props
+    const {
+      onSaveTelegrafConfig,
+      authToken,
+      notify,
+      createDashboardsForPlugins,
+    } = this.props
 
     this.setState({loading: RemoteDataState.Loading})
 
     try {
       await onSaveTelegrafConfig(authToken)
       notify(TelegrafConfigCreationSuccess)
+      await createDashboardsForPlugins()
 
       this.setState({loading: RemoteDataState.Done})
     } catch (error) {
@@ -61,4 +78,13 @@ class CreateOrUpdateConfig extends PureComponent<Props, State> {
   }
 }
 
-export default CreateOrUpdateConfig
+const mdtp: DispatchProps = {
+  notify: notifyAction,
+  onSaveTelegrafConfig: createOrUpdateTelegrafConfigAsync,
+  createDashboardsForPlugins: createDashboardsForPluginsAction,
+}
+
+export default connect<StateProps, DispatchProps, OwnProps>(
+  null,
+  mdtp
+)(CreateOrUpdateConfig)

--- a/ui/src/onboarding/components/verifyStep/DataStreaming.tsx
+++ b/ui/src/onboarding/components/verifyStep/DataStreaming.tsx
@@ -7,9 +7,6 @@ import TelegrafInstructions from 'src/onboarding/components/verifyStep/TelegrafI
 import CreateOrUpdateConfig from 'src/onboarding/components/verifyStep/CreateOrUpdateConfig'
 import DataListening from 'src/onboarding/components/verifyStep/DataListening'
 
-// Actions
-import {createOrUpdateTelegrafConfigAsync} from 'src/onboarding/actions/dataLoaders'
-
 // Constants
 import {StepStatus} from 'src/clockface/constants/wizard'
 
@@ -27,7 +24,6 @@ interface Props {
   stepIndex: number
   authToken: string
   onSetStepStatus: (index: number, status: StepStatus) => void
-  onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
 }
 
 @ErrorHandling
@@ -37,7 +33,6 @@ class DataStreaming extends PureComponent<Props> {
       authToken,
       org,
       configID,
-      onSaveTelegrafConfig,
       onSetStepStatus,
       bucket,
       stepIndex,
@@ -46,12 +41,7 @@ class DataStreaming extends PureComponent<Props> {
 
     return (
       <>
-        <CreateOrUpdateConfig
-          org={org}
-          notify={notify}
-          authToken={authToken}
-          onSaveTelegrafConfig={onSaveTelegrafConfig}
-        >
+        <CreateOrUpdateConfig org={org} authToken={authToken}>
           {() => (
             <TelegrafInstructions
               notify={notify}

--- a/ui/src/onboarding/components/verifyStep/VerifyDataStep.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataStep.tsx
@@ -12,7 +12,6 @@ import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar
 // Actions
 import {
   setActiveTelegrafPlugin,
-  createOrUpdateTelegrafConfigAsync,
   setPluginConfiguration,
 } from 'src/onboarding/actions/dataLoaders'
 
@@ -31,7 +30,6 @@ export interface OwnProps extends DataLoaderStepProps {
   telegrafPlugins: TelegrafPlugin[]
   onSetActiveTelegrafPlugin: typeof setActiveTelegrafPlugin
   onSetPluginConfiguration: typeof setPluginConfiguration
-  onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
   stepIndex: number
   bucket: string
   username: string
@@ -62,7 +60,6 @@ export class VerifyDataStep extends PureComponent<Props> {
       username,
       telegrafConfigID,
       type,
-      onSaveTelegrafConfig,
       onDecrementCurrentStepIndex,
       onSetStepStatus,
       stepIndex,
@@ -81,7 +78,6 @@ export class VerifyDataStep extends PureComponent<Props> {
                   notify={notify}
                   type={type}
                   telegrafConfigID={telegrafConfigID}
-                  onSaveTelegrafConfig={onSaveTelegrafConfig}
                   org={org}
                   bucket={bucket}
                   username={username}

--- a/ui/src/onboarding/components/verifyStep/VerifyDataSwitcher.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataSwitcher.tsx
@@ -6,9 +6,6 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import DataStreaming from 'src/onboarding/components/verifyStep/DataStreaming'
 import FetchAuthToken from 'src/onboarding/components/verifyStep/FetchAuthToken'
 
-// Actions
-import {createOrUpdateTelegrafConfigAsync} from 'src/onboarding/actions/dataLoaders'
-
 // Constants
 import {StepStatus} from 'src/clockface/constants/wizard'
 
@@ -25,7 +22,6 @@ interface Props {
   username: string
   stepIndex: number
   telegrafConfigID: string
-  onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
   onSetStepStatus: (index: number, status: StepStatus) => void
   onDecrementCurrentStep: () => void
   lpStatus: RemoteDataState
@@ -42,7 +38,6 @@ export class VerifyDataSwitcher extends PureComponent<Props> {
       stepIndex,
       onSetStepStatus,
       telegrafConfigID,
-      onSaveTelegrafConfig,
       notify,
       lpStatus,
     } = this.props
@@ -59,7 +54,6 @@ export class VerifyDataSwitcher extends PureComponent<Props> {
                 authToken={authToken}
                 bucket={bucket}
                 onSetStepStatus={onSetStepStatus}
-                onSaveTelegrafConfig={onSaveTelegrafConfig}
                 stepIndex={stepIndex}
               />
             )}

--- a/ui/src/protos/actions/index.ts
+++ b/ui/src/protos/actions/index.ts
@@ -12,9 +12,18 @@ import {addDashboardIDToCells} from 'src/dashboards/apis/v2/'
 
 // Actions
 import {loadDashboard} from 'src/dashboards/actions/v2/'
+import {notify} from 'src/shared/actions/notifications'
 
 // Types
 import {Proto, Dashboard} from 'src/api'
+import {GetState} from 'src/types/v2'
+import {ConfigurationState} from 'src/types/v2/dataLoaders'
+
+// Const
+import {
+  ProtoDashboardFailed,
+  ProtoDashboardCreated,
+} from 'src/shared/copy/notifications'
 
 export enum ActionTypes {
   LoadProto = 'LOAD_PROTO',
@@ -37,6 +46,7 @@ export const loadProto = (proto: Proto): LoadProtoAction => ({
 export const getProtos = () => async (dispatch: Dispatch<Action>) => {
   try {
     const {protos} = await getProtosAJAX()
+
     protos.forEach(p => {
       dispatch(loadProto(p))
     })
@@ -61,5 +71,39 @@ export const createDashFromProto = (
     })
   } catch (error) {
     console.error(error)
+  }
+}
+
+export const createDashboardsForPlugins = () => async (
+  dispatch,
+  getState: GetState
+) => {
+  await dispatch(getProtos())
+  const {
+    dataLoading: {
+      dataLoaders: {telegrafPlugins},
+      steps: {orgID},
+    },
+    protos,
+  } = getState()
+
+  const plugins = []
+
+  try {
+    telegrafPlugins.forEach(tp => {
+      if (tp.configured === ConfigurationState.Configured) {
+        if (protos[tp.name]) {
+          dispatch(createDashFromProto(protos[tp.name].id, orgID))
+          plugins.push(tp.name)
+        }
+      }
+    })
+
+    if (plugins.length) {
+      dispatch(notify(ProtoDashboardCreated(plugins)))
+    }
+  } catch (err) {
+    console.error(err)
+    dispatch(notify(ProtoDashboardFailed()))
   }
 }

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -714,3 +714,16 @@ export const fluxTimeSeriesError = (message: string): Notification => ({
   ...defaultErrorNotification,
   message: `Could not get data: ${message}`,
 })
+
+// Protos
+export const ProtoDashboardCreated = (configs: string[]): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Successfully created dashboards for telegraf plugin${
+    configs.length > 1 ? 's' : ''
+  }: ${configs.join(', ')}.`,
+})
+
+export const ProtoDashboardFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Could not create dashboards for one or more plugins`,
+})


### PR DESCRIPTION
Closes #10888 

Just prior to the verify step of the data loaders, while telegraf configuration is being saved. load protoboards in to redux, and instantiate the ones that have configured telegraf plugins. 

