### PR TITLE
test(influxdb): testing table generation and transformations

### DIFF
--- a/query/querytest/reader.go
+++ b/query/querytest/reader.go
@@ -1,0 +1,83 @@
+package querytest
+
+import (
+	"context"
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
+	"github.com/influxdata/influxdb/storage/reads"
+)
+
+func ReaderTestHelper(
+	t *testing.T,
+	start execute.Time,
+	stop execute.Time,
+	addTransformations func(d execute.Dataset, c execute.TableBuilderCache, s execute.Source) error,
+	data []*Table,
+	want []*executetest.Table,
+) {
+	t.Helper()
+
+	if start > stop {
+		t.Fatal("invalid bounds, start > stop")
+	}
+
+	for _, tbl := range data {
+		if err := tbl.Check(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	bounds := execute.Bounds{
+		Start: start,
+		Stop:  stop,
+	}
+	now := stop
+
+	store, err := NewStore(data, bounds)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id := executetest.RandomDatasetID()
+	d := executetest.NewDataset(id)
+	c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
+	c.SetTriggerSpec(flux.DefaultTrigger)
+	s := influxdb.NewSource(
+		id,
+		reads.NewReader(store),
+		influxdb.ReadSpec{PointsLimit: math.MaxInt64},
+		bounds,
+		execute.Window{
+			Period: execute.Duration(stop - start),
+			Every:  execute.Duration(stop - start),
+		},
+		now)
+
+	err = addTransformations(d, c, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.Run(context.Background())
+	got, err := executetest.TablesFromCache(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	executetest.NormalizeTables(got)
+	executetest.NormalizeTables(want)
+
+	sort.Sort(executetest.SortedTables(got))
+	sort.Sort(executetest.SortedTables(want))
+
+	if !cmp.Equal(want, got) {
+		t.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(want, got))
+	}
+}

--- a/query/querytest/storage.go
+++ b/query/querytest/storage.go
@@ -1,0 +1,286 @@
+package querytest
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/values"
+	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
+	"github.com/influxdata/influxdb/storage/reads"
+	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+)
+
+type mockStore struct {
+	cur    reads.SeriesCursor
+	bounds execute.Bounds
+}
+
+func NewStore(data []*Table, queryBounds execute.Bounds) (*mockStore, error) {
+	ms := &mockStore{
+		cur: &tableCursor{
+			data: data,
+		},
+		bounds: queryBounds,
+	}
+	return ms, nil
+}
+
+func (ms *mockStore) Read(ctx context.Context, req *datatypes.ReadRequest) (reads.ResultSet, error) {
+	req.TimestampRange = datatypes.TimestampRange{
+		Start: int64(ms.bounds.Start),
+		End:   int64(ms.bounds.Stop),
+	}
+	return reads.NewResultSet(ctx, req, ms.cur), nil
+}
+
+// No grouping gets pushed down to storage, so, this method should never be called.
+// Group push down is specified directly into the request, but we hard code it without it in querytest/reader/ReaderTestHelper.
+func (*mockStore) GroupRead(ctx context.Context, req *datatypes.ReadRequest) (reads.GroupResultSet, error) {
+	panic("mockStore is not designed for GroupRead")
+}
+
+func (*mockStore) GetSource(rs influxdb.ReadSpec) (proto.Message, error) {
+	return &mockMsg{}, nil
+}
+
+type mockMsg struct{}
+
+func (m *mockMsg) Reset() {
+	*m = mockMsg{}
+}
+
+func (*mockMsg) String() string {
+	return "mockMsg()"
+}
+
+func (*mockMsg) ProtoMessage() {
+}
+
+// ----- Cursors
+
+type tableCursor struct {
+	data []*Table
+	i    int
+}
+
+func (tc *tableCursor) Close()     {}
+func (tc *tableCursor) Err() error { return nil }
+
+func (tc *tableCursor) Next() *reads.SeriesRow {
+	if tc.i >= len(tc.data) {
+		return nil
+	}
+
+	tbl := tc.data[tc.i]
+
+	sr := &reads.SeriesRow{}
+	sr.Name = []byte(tbl.Measurement)
+	sr.Field = tbl.Field
+
+	// add _measurement and _field to tags
+	key := []byte("_measurement")
+	value := sr.Name
+	sr.Tags.Set(key, value)
+	key = []byte("_field")
+	value = []byte(sr.Field)
+	sr.Tags.Set(key, value)
+
+	// add other tags
+	for j, l := range tbl.TagLabels {
+		key := []byte(l)
+		value := []byte(tbl.TagValues[j])
+		sr.Tags.Set(key, value)
+	}
+
+	sr.SeriesTags = sr.Tags.Clone()
+
+	itr := &cursorIterator{}
+	bc := &baseCursor{data: tbl}
+	switch tbl.ValueType {
+	case flux.TBool:
+		itr.c = &boolCursor{bc}
+	case flux.TInt:
+		itr.c = &intCursor{bc}
+	case flux.TUInt:
+		itr.c = &uintCursor{bc}
+	case flux.TFloat:
+		itr.c = &floatCursor{bc}
+	case flux.TString:
+		itr.c = &stringCursor{bc}
+	case flux.TTime:
+		itr.c = &intCursor{bc}
+	}
+
+	sr.Query = append(sr.Query, itr)
+
+	tc.i++
+	return sr
+}
+
+type baseCursor struct {
+	data *Table
+	done bool
+}
+
+func (*baseCursor) Stats() cursors.CursorStats {
+	return cursors.CursorStats{}
+}
+
+func (*baseCursor) Close() {}
+
+func (*baseCursor) Err() error {
+	return nil
+}
+
+func (bc *baseCursor) more() bool {
+	if bc.done {
+		return false
+	}
+	bc.done = true
+	return true
+}
+
+type cursorIterator struct {
+	c    cursors.Cursor
+	stop bool
+}
+
+func (*cursorIterator) Stats() cursors.CursorStats {
+	return cursors.CursorStats{}
+}
+
+func (ci *cursorIterator) Next(ctx context.Context, r *cursors.CursorRequest) (cursors.Cursor, error) {
+	if ci.stop {
+		return nil, nil
+	}
+	ci.stop = true
+	return ci.c, nil
+}
+
+type intCursor struct {
+	*baseCursor
+}
+
+func (c *intCursor) Next() *cursors.IntegerArray {
+	if c.more() {
+		return &cursors.IntegerArray{
+			Timestamps: extractTimes(c.data),
+			Values:     extractIntValues(c.data),
+		}
+	}
+	return &cursors.IntegerArray{}
+}
+
+type uintCursor struct {
+	*baseCursor
+}
+
+func (c *uintCursor) Next() *cursors.UnsignedArray {
+	if c.more() {
+		return &cursors.UnsignedArray{
+			Timestamps: extractTimes(c.data),
+			Values:     extractUIntValues(c.data),
+		}
+	}
+	return &cursors.UnsignedArray{}
+}
+
+type floatCursor struct {
+	*baseCursor
+}
+
+func (c *floatCursor) Next() *cursors.FloatArray {
+	if c.more() {
+		return &cursors.FloatArray{
+			Timestamps: extractTimes(c.data),
+			Values:     extractFloatValues(c.data),
+		}
+	}
+	return &cursors.FloatArray{}
+}
+
+type boolCursor struct {
+	*baseCursor
+}
+
+func (c *boolCursor) Next() *cursors.BooleanArray {
+	if c.more() {
+		return &cursors.BooleanArray{
+			Timestamps: extractTimes(c.data),
+			Values:     extractBoolValues(c.data),
+		}
+	}
+	return &cursors.BooleanArray{}
+}
+
+type stringCursor struct {
+	*baseCursor
+}
+
+func (c *stringCursor) Next() *cursors.StringArray {
+	if c.more() {
+		return &cursors.StringArray{
+			Timestamps: extractTimes(c.data),
+			Values:     extractStringValues(c.data),
+		}
+	}
+
+	return &cursors.StringArray{}
+}
+
+func extractTimes(data *Table) []int64 {
+	s := make([]int64, 0, len(data.Rows))
+	for _, row := range data.Rows {
+		s = append(s, int64(row.time))
+	}
+	return s
+}
+
+func extractIntValues(data *Table) []int64 {
+	s := make([]int64, 0, len(data.Rows))
+	for _, row := range data.Rows {
+		var v int64
+		if ts, ok := row.value.(values.Time); ok {
+			v = int64(ts)
+		} else {
+			v = row.value.(int64)
+		}
+		s = append(s, v)
+	}
+	return s
+}
+
+func extractUIntValues(data *Table) []uint64 {
+	s := make([]uint64, 0, len(data.Rows))
+	for _, row := range data.Rows {
+		s = append(s, row.value.(uint64))
+	}
+	return s
+}
+
+func extractFloatValues(data *Table) []float64 {
+	s := make([]float64, 0, len(data.Rows))
+	for _, row := range data.Rows {
+		s = append(s, row.value.(float64))
+	}
+	return s
+}
+
+func extractBoolValues(data *Table) []bool {
+	s := make([]bool, 0, len(data.Rows))
+	for _, row := range data.Rows {
+		s = append(s, row.value.(bool))
+	}
+	return s
+}
+
+func extractStringValues(data *Table) []string {
+	s := make([]string, 0, len(data.Rows))
+	for _, row := range data.Rows {
+		s = append(s, row.value.(string))
+	}
+	return s
+}

--- a/query/querytest/table.go
+++ b/query/querytest/table.go
@@ -1,0 +1,33 @@
+package querytest
+
+import (
+	"fmt"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+)
+
+type Table struct {
+	Measurement string
+	Field       string
+	ValueType   flux.ColType
+	TagLabels   []string
+	TagValues   []string
+	Rows        []*Row
+}
+
+func (t *Table) Check() error {
+	if len(t.TagValues) != len(t.TagLabels) {
+		return fmt.Errorf("tag values and labels must have same length")
+	}
+	return nil
+}
+
+type Row struct {
+	time  execute.Time
+	value interface{}
+}
+
+func R(time execute.Time, value interface{}) *Row {
+	return &Row{time: time, value: value}
+}

--- a/query/reads_test.go
+++ b/query/reads_test.go
@@ -1,0 +1,160 @@
+package query_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/influxdb/query/querytest"
+)
+
+func TestReadAndTransform(t *testing.T) {
+	start := execute.Time(0)
+	stop := execute.Time(20)
+
+	testCases := []struct {
+		name  string
+		addTs func(d execute.Dataset, c execute.TableBuilderCache, s execute.Source) error
+		data  []*querytest.Table
+		want  []*executetest.Table
+	}{
+		{
+			name: "limit",
+			addTs: func(d execute.Dataset, c execute.TableBuilderCache, s execute.Source) error {
+				limit := universe.NewLimitTransformation(d, c, &universe.LimitProcedureSpec{N: 2})
+				s.AddTransformation(limit)
+				return nil
+			},
+			data: []*querytest.Table{
+				{
+					Measurement: "m1",
+					Field:       "f1",
+					ValueType:   flux.TFloat,
+					Rows: []*querytest.Row{
+						querytest.R(execute.Time(1), 1.0),
+						querytest.R(execute.Time(2), 3.0),
+						querytest.R(execute.Time(11), 5.0),
+						querytest.R(execute.Time(12), 7.0),
+					},
+				},
+				{
+					Measurement: "m1",
+					Field:       "f2",
+					ValueType:   flux.TFloat,
+					Rows: []*querytest.Row{
+						querytest.R(execute.Time(1), 2.0),
+						querytest.R(execute.Time(2), 4.0),
+						querytest.R(execute.Time(11), 6.0),
+						querytest.R(execute.Time(12), 8.0),
+					},
+				},
+			},
+			want: []*executetest.Table{
+				{
+					KeyCols: []string{"_start", "_stop", "_field", "_measurement"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "_field", Type: flux.TString},
+						{Label: "_measurement", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(0), execute.Time(20), execute.Time(1), 1.0, "f1", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(2), 3.0, "f1", "m1"},
+					},
+				},
+				{
+					KeyCols: []string{"_start", "_stop", "_field", "_measurement"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "_field", Type: flux.TString},
+						{Label: "_measurement", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(0), execute.Time(20), execute.Time(1), 2.0, "f2", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(2), 4.0, "f2", "m1"},
+					},
+				},
+			},
+		},
+		{
+			name: "group",
+			addTs: func(d execute.Dataset, c execute.TableBuilderCache, s execute.Source) error {
+				group := universe.NewGroupTransformation(d, c, &universe.GroupProcedureSpec{
+					GroupMode: flux.GroupModeBy,
+					GroupKeys: []string{"_measurement"},
+				})
+				s.AddTransformation(group)
+				return nil
+			},
+			data: []*querytest.Table{
+				{
+					Measurement: "m1",
+					Field:       "f1",
+					ValueType:   flux.TFloat,
+					Rows: []*querytest.Row{
+						querytest.R(execute.Time(1), 1.0),
+						querytest.R(execute.Time(2), 3.0),
+						querytest.R(execute.Time(11), 5.0),
+						querytest.R(execute.Time(12), 7.0),
+					},
+				},
+				{
+					Measurement: "m1",
+					Field:       "f2",
+					ValueType:   flux.TFloat,
+					Rows: []*querytest.Row{
+						querytest.R(execute.Time(1), 2.0),
+						querytest.R(execute.Time(2), 4.0),
+						querytest.R(execute.Time(11), 6.0),
+						querytest.R(execute.Time(12), 8.0),
+					},
+				},
+			},
+			want: []*executetest.Table{
+				{
+					KeyCols: []string{"_measurement"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "_field", Type: flux.TString},
+						{Label: "_measurement", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(0), execute.Time(20), execute.Time(1), 1.0, "f1", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(2), 3.0, "f1", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(11), 5.0, "f1", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(12), 7.0, "f1", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(1), 2.0, "f2", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(2), 4.0, "f2", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(11), 6.0, "f2", "m1"},
+						{execute.Time(0), execute.Time(20), execute.Time(12), 8.0, "f2", "m1"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			querytest.ReaderTestHelper(
+				t,
+				start,
+				stop,
+				tc.addTs,
+				tc.data,
+				tc.want,
+			)
+		})
+	}
+}


### PR DESCRIPTION
Tests for cursor and table generation.

This tests uses the `reads.Reader` by mocking `Store` and cursors to return test-specific data.

At the moment I am not checking table keys, but only data.  
I cannot get any data, because, when the transformation starts processing, it tries to add columns that already exist, because they are part of the group key.  
If I remove the group key from the input data, then I get a panic because a point must have at least 2 tags.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
