### PR TITLE
fix(http): update scrapers endpoint

### DIFF
--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -169,11 +169,11 @@ var apiLinks = map[string]interface{}{
 		"spec":        "/api/v2/query/spec",
 		"suggestions": "/api/v2/query/suggestions",
 	},
-	"setup":          "/api/v2/setup",
-	"signin":         "/api/v2/signin",
-	"signout":        "/api/v2/signout",
-	"sources":        "/api/v2/sources",
-	"scrapertargets": "/api/v2/scrapertargets",
+	"setup":    "/api/v2/setup",
+	"signin":   "/api/v2/signin",
+	"signout":  "/api/v2/signout",
+	"sources":  "/api/v2/sources",
+	"scrapers": "/api/v2/scrapers",
 	"system": map[string]string{
 		"metrics": "/metrics",
 		"debug":   "/debug/pprof",
@@ -261,7 +261,7 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if strings.HasPrefix(r.URL.Path, "/api/v2/scrapertargets") {
+	if strings.HasPrefix(r.URL.Path, "/api/v2/scrapers") {
 		h.ScraperHandler.ServeHTTP(w, r)
 		return
 	}

--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -22,7 +22,7 @@ type ScraperHandler struct {
 }
 
 const (
-	targetPath = "/api/v2/scrapertargets"
+	targetPath = "/api/v2/scrapers"
 )
 
 // NewScraperHandler returns a new instance of ScraperHandler.
@@ -38,7 +38,7 @@ func NewScraperHandler() *ScraperHandler {
 	return h
 }
 
-// handlePostScraperTarget is HTTP handler for the POST /api/v2/scrapertargets route.
+// handlePostScraperTarget is HTTP handler for the POST /api/v2/scrapers route.
 func (h *ScraperHandler) handlePostScraperTarget(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -63,7 +63,7 @@ func (h *ScraperHandler) handlePostScraperTarget(w http.ResponseWriter, r *http.
 	}
 }
 
-// handleDeleteScraperTarget is the HTTP handler for the DELETE /api/v2/scrapertargets/:id route.
+// handleDeleteScraperTarget is the HTTP handler for the DELETE /api/v2/scrapers/:id route.
 func (h *ScraperHandler) handleDeleteScraperTarget(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -81,7 +81,7 @@ func (h *ScraperHandler) handleDeleteScraperTarget(w http.ResponseWriter, r *htt
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// handlePatchScraperTarget is the HTTP handler for the PATCH /api/v2/scrapertargets/:id route.
+// handlePatchScraperTarget is the HTTP handler for the PATCH /api/v2/scrapers/:id route.
 func (h *ScraperHandler) handlePatchScraperTarget(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -135,7 +135,7 @@ func (h *ScraperHandler) handleGetScraperTarget(w http.ResponseWriter, r *http.R
 	}
 }
 
-// handleGetScraperTargets is the HTTP handler for the GET /api/v2/scrapertargets route.
+// handleGetScraperTargets is the HTTP handler for the GET /api/v2/scrapers route.
 func (h *ScraperHandler) handleGetScraperTargets(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/http/scraper_service_test.go
+++ b/http/scraper_service_test.go
@@ -100,7 +100,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 					`
 					{
 					  "links": {
-					    "self": "/api/v2/scrapertargets"
+					    "self": "/api/v2/scrapers"
 					  },
 					  "scraper_targets": [
 					    {
@@ -113,7 +113,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 						  "type": "prometheus",
 						  "url": "www.one.url",
 						  "links": {
-						    "self": "/api/v2/scrapertargets/0000000000000111"
+						    "self": "/api/v2/scrapers/0000000000000111"
 						  }
 						},
 						{
@@ -126,7 +126,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 						  "type": "prometheus",
 						  "url": "www.two.url",
 						  "links": {
-						    "self": "/api/v2/scrapertargets/0000000000000222"
+						    "self": "/api/v2/scrapers/0000000000000222"
 						  }
                         }
 					  ]
@@ -169,7 +169,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 				body: `
                 {
                   "links": {
-                    "self": "/api/v2/scrapertargets"
+                    "self": "/api/v2/scrapers"
                   },
                   "scraper_targets": []
                 }
@@ -295,7 +295,7 @@ func TestService_handleGetScraperTarget(t *testing.T) {
 					  "orgID": "0000000000000211",
 					  "organization": "org1",
                       "links": {
-                        "self": "/api/v2/scrapertargets/%[1]s"
+                        "self": "/api/v2/scrapers/%[1]s"
                       }
                     }
                     `,
@@ -518,7 +518,7 @@ func TestService_handlePostScraperTarget(t *testing.T) {
 					  "bucket": "bucket1",
                       "bucketID": "0000000000000212",
                       "links": {
-                        "self": "/api/v2/scrapertargets/%[1]s"
+                        "self": "/api/v2/scrapers/%[1]s"
                       }
                     }
                     `,
@@ -643,7 +643,7 @@ func TestService_handlePatchScraperTarget(t *testing.T) {
 					  "bucket": "bucket1",
 					  "bucketID":"0000000000000212",
 		              "links":{
-		                "self":"/api/v2/scrapertargets/%[1]s"
+		                "self":"/api/v2/scrapers/%[1]s"
 		              }
 		            }`,
 					targetOneIDString,

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -597,7 +597,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /scrapertargets:
+  /scrapers:
     get:
       tags:
         - ScraperTargets
@@ -633,7 +633,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  '/scrapertargets/{scraperTargetID}':
+  '/scrapers/{scraperTargetID}':
     delete:
       tags:
         - ScraperTargets


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/11284

_Briefly describe your proposed changes:_
make the endpoint much simpler

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
