### PR TITLE
Fix bucket delete for all buckets

### DIFF
--- a/tsdb/tsm1/engine_delete_measurement.go
+++ b/tsdb/tsm1/engine_delete_measurement.go
@@ -149,6 +149,9 @@ func (e *Engine) DeleteBucket(name []byte, min, max int64) error {
 
 		// In this case the entire measurement (bucket) can be removed from the index.
 		if min == math.MinInt64 && max == math.MaxInt64 {
+			// The TSI index and Series File do not store series data in escaped form.
+			name = models.UnescapeMeasurement(name)
+
 			// Build up a set of series IDs that we need to remove from the series file.
 			set := tsdb.NewSeriesIDSet()
 			itr, err := e.index.MeasurementSeriesIDIterator(name)


### PR DESCRIPTION
If a bucket had bytes in it that would be escaped by the models
parser/package, then the index would not be correctly purged of those
series data when the bucket was dropped.

Closes #11153.

_Briefly describe your proposed changes:_

This PR ensures that when dropping a bucket or deleting from a bucket, the correct escaping happens.