### PR TITLE
authorize user resource mapping operations

### DIFF
--- a/authorizer/urm.go
+++ b/authorizer/urm.go
@@ -1,0 +1,114 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+type OrganizationService interface {
+	FindResourceOrganizationID(ctx context.Context, rt influxdb.ResourceType, id influxdb.ID) (influxdb.ID, error)
+}
+
+type URMService struct {
+	s          influxdb.UserResourceMappingService
+	orgService OrganizationService
+}
+
+func NewURMService(orgSvc OrganizationService, s influxdb.UserResourceMappingService) *URMService {
+	return &URMService{
+		s:          s,
+		orgService: orgSvc,
+	}
+}
+
+func newURMPermission(a influxdb.Action, rt influxdb.ResourceType, orgID, id influxdb.ID) (*influxdb.Permission, error) {
+	return influxdb.NewPermissionAtID(id, a, rt, orgID)
+}
+
+func authorizeReadURM(ctx context.Context, rt influxdb.ResourceType, orgID, id influxdb.ID) error {
+	p, err := newURMPermission(influxdb.ReadAction, rt, orgID, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func authorizeWriteURM(ctx context.Context, rt influxdb.ResourceType, orgID, id influxdb.ID) error {
+	p, err := newURMPermission(influxdb.WriteAction, rt, orgID, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *URMService) FindUserResourceMappings(ctx context.Context, filter influxdb.UserResourceMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.UserResourceMapping, int, error) {
+	urms, _, err := s.s.FindUserResourceMappings(ctx, filter, opt...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	mappings := urms[:0]
+	for _, urm := range urms {
+		orgID, err := s.orgService.FindResourceOrganizationID(ctx, urm.ResourceType, urm.ResourceID)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if err := authorizeReadURM(ctx, urm.ResourceType, orgID, urm.ResourceID); err != nil {
+			continue
+		}
+
+		mappings = append(mappings, urm)
+	}
+
+	return mappings, len(mappings), nil
+}
+
+func (s *URMService) CreateUserResourceMapping(ctx context.Context, m *influxdb.UserResourceMapping) error {
+	orgID, err := s.orgService.FindResourceOrganizationID(ctx, m.ResourceType, m.ResourceID)
+	if err != nil {
+		return err
+	}
+
+	if err := authorizeWriteURM(ctx, m.ResourceType, orgID, m.ResourceID); err != nil {
+		return err
+	}
+
+	return s.s.CreateUserResourceMapping(ctx, m)
+}
+
+func (s *URMService) DeleteUserResourceMapping(ctx context.Context, resourceID influxdb.ID, userID influxdb.ID) error {
+	f := influxdb.UserResourceMappingFilter{ResourceID: resourceID, UserID: userID}
+	urms, _, err := s.s.FindUserResourceMappings(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	for _, urm := range urms {
+		orgID, err := s.orgService.FindResourceOrganizationID(ctx, urm.ResourceType, urm.ResourceID)
+		if err != nil {
+			return err
+		}
+
+		if err := authorizeWriteURM(ctx, urm.ResourceType, orgID, urm.ResourceID); err != nil {
+			return err
+		}
+
+		if err := s.s.DeleteUserResourceMapping(ctx, urm.ResourceID, urm.UserID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/authorizer/urm_test.go
+++ b/authorizer/urm_test.go
@@ -1,0 +1,258 @@
+package authorizer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+type OrgService struct {
+	OrgID influxdb.ID
+}
+
+func (s *OrgService) FindResourceOrganizationID(ctx context.Context, rt influxdb.ResourceType, id influxdb.ID) (influxdb.ID, error) {
+	return s.OrgID, nil
+}
+
+func TestURMService_FindUserResourceMappings(t *testing.T) {
+	type fields struct {
+		UserResourceMappingService influxdb.UserResourceMappingService
+		OrgService                 authorizer.OrganizationService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err  error
+		urms []*influxdb.UserResourceMapping
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to see all users",
+			fields: fields{
+				OrgService: &OrgService{OrgID: 10},
+				UserResourceMappingService: &mock.UserResourceMappingService{
+					FindMappingsFn: func(ctx context.Context, filter influxdb.UserResourceMappingFilter) ([]*influxdb.UserResourceMapping, int, error) {
+						return []*influxdb.UserResourceMapping{
+							{
+								ResourceID:   1,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+							{
+								ResourceID:   2,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+							{
+								ResourceID:   3,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				urms: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   1,
+						ResourceType: influxdb.BucketsResourceType,
+					},
+					{
+						ResourceID:   2,
+						ResourceType: influxdb.BucketsResourceType,
+					},
+					{
+						ResourceID:   3,
+						ResourceType: influxdb.BucketsResourceType,
+					},
+				},
+			},
+		},
+		{
+			name: "authorized to see all users",
+			fields: fields{
+				OrgService: &OrgService{OrgID: 10},
+				UserResourceMappingService: &mock.UserResourceMappingService{
+					FindMappingsFn: func(ctx context.Context, filter influxdb.UserResourceMappingFilter) ([]*influxdb.UserResourceMapping, int, error) {
+						return []*influxdb.UserResourceMapping{
+							{
+								ResourceID:   1,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+							{
+								ResourceID:   2,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+							{
+								ResourceID:   3,
+								ResourceType: influxdb.BucketsResourceType,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(11),
+					},
+				},
+			},
+			wants: wants{
+				urms: []*influxdb.UserResourceMapping{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewURMService(tt.fields.OrgService, tt.fields.UserResourceMappingService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			urms, _, err := s.FindUserResourceMappings(ctx, influxdb.UserResourceMappingFilter{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+
+			if diff := cmp.Diff(urms, tt.wants.urms); diff != "" {
+				t.Errorf("urms are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+func TestURMService_WriteUserResourceMapping(t *testing.T) {
+	type fields struct {
+		UserResourceMappingService influxdb.UserResourceMappingService
+		OrgService                 authorizer.OrganizationService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to write urm",
+			fields: fields{
+				OrgService: &OrgService{OrgID: 10},
+				UserResourceMappingService: &mock.UserResourceMappingService{
+					CreateMappingFn: func(ctx context.Context, m *influxdb.UserResourceMapping) error {
+						return nil
+					},
+					DeleteMappingFn: func(ctx context.Context, rid, uid influxdb.ID) error {
+						return nil
+					},
+					FindMappingsFn: func(ctx context.Context, filter influxdb.UserResourceMappingFilter) ([]*influxdb.UserResourceMapping, int, error) {
+						return []*influxdb.UserResourceMapping{
+							{
+								ResourceID:   1,
+								ResourceType: influxdb.BucketsResourceType,
+								UserID:       100,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type:  influxdb.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to write urm",
+			fields: fields{
+				OrgService: &OrgService{OrgID: 10},
+				UserResourceMappingService: &mock.UserResourceMappingService{
+					CreateMappingFn: func(ctx context.Context, m *influxdb.UserResourceMapping) error {
+						return nil
+					},
+					DeleteMappingFn: func(ctx context.Context, rid, uid influxdb.ID) error {
+						return nil
+					},
+					FindMappingsFn: func(ctx context.Context, filter influxdb.UserResourceMappingFilter) ([]*influxdb.UserResourceMapping, int, error) {
+						return []*influxdb.UserResourceMapping{
+							{
+								ResourceID:   1,
+								ResourceType: influxdb.BucketsResourceType,
+								UserID:       100,
+							},
+						}, 3, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type:  influxdb.BucketsResourceType,
+						OrgID: influxdbtesting.IDPtr(11),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:orgs/000000000000000a/buckets/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewURMService(tt.fields.OrgService, tt.fields.UserResourceMappingService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			t.Run("create urm", func(t *testing.T) {
+				err := s.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{ResourceType: influxdb.BucketsResourceType, ResourceID: 1})
+				influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+			})
+
+			t.Run("delete urm", func(t *testing.T) {
+				err := s.DeleteUserResourceMapping(ctx, 1, 100)
+				influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+			})
+
+		})
+	}
+}

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -432,6 +432,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		SecretService:                   secretSvc,
 		LookupService:                   lookupSvc,
 		ProtoService:                    protoSvc,
+		OrgLookupService:                m.boltClient,
 	}
 
 	// HTTP server

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -68,6 +68,7 @@ type APIBackend struct {
 	LookupService                   influxdb.LookupService
 	ChronografService               *server.Service
 	ProtoService                    influxdb.ProtoService
+	OrgLookupService                authorizer.OrganizationService
 }
 
 // NewAPIHandler constructs all api handlers beneath it and returns an APIHandler
@@ -76,6 +77,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 
 	sessionBackend := NewSessionBackend(b)
 	h.SessionHandler = NewSessionHandler(sessionBackend)
+	b.UserResourceMappingService = authorizer.NewURMService(b.OrgLookupService, b.UserResourceMappingService)
 
 	h.BucketHandler = NewBucketHandler(b.UserResourceMappingService, b.LabelService, b.UserService)
 	h.BucketHandler.BucketService = authorizer.NewBucketService(b.BucketService)


### PR DESCRIPTION
Closes part of #10814 

_Briefly describe your proposed changes:_
This PR wraps a user resource mapping service with some that authorizes actions against the resource type used in the mapping.

cc @leodido 

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
