### PR TITLE
Add urm scraper

### DIFF
--- a/authorizer/scraper.go
+++ b/authorizer/scraper.go
@@ -11,13 +11,15 @@ var _ influxdb.ScraperTargetStoreService = (*ScraperTargetStoreService)(nil)
 // ScraperTargetStoreService wraps a influxdb.ScraperTargetStoreService and authorizes actions
 // against it appropriately.
 type ScraperTargetStoreService struct {
+	influxdb.UserResourceMappingService
 	s influxdb.ScraperTargetStoreService
 }
 
 // NewScraperTargetStoreService constructs an instance of an authorizing scraper target store serivce.
-func NewScraperTargetStoreService(s influxdb.ScraperTargetStoreService) *ScraperTargetStoreService {
+func NewScraperTargetStoreService(s influxdb.ScraperTargetStoreService, urm influxdb.UserResourceMappingService) *ScraperTargetStoreService {
 	return &ScraperTargetStoreService{
-		s: s,
+		UserResourceMappingService: urm,
+		s:                          s,
 	}
 }
 
@@ -94,7 +96,7 @@ func (s *ScraperTargetStoreService) ListTargets(ctx context.Context) ([]influxdb
 }
 
 // AddTarget checks to see if the authorizer on context has write access to the global scraper target resource.
-func (s *ScraperTargetStoreService) AddTarget(ctx context.Context, st *influxdb.ScraperTarget) error {
+func (s *ScraperTargetStoreService) AddTarget(ctx context.Context, st *influxdb.ScraperTarget, userID influxdb.ID) error {
 	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.ScraperResourceType, st.OrgID)
 	if err != nil {
 		return err
@@ -104,11 +106,11 @@ func (s *ScraperTargetStoreService) AddTarget(ctx context.Context, st *influxdb.
 		return err
 	}
 
-	return s.s.AddTarget(ctx, st)
+	return s.s.AddTarget(ctx, st, userID)
 }
 
 // UpdateTarget checks to see if the authorizer on context has write access to the scraper target provided.
-func (s *ScraperTargetStoreService) UpdateTarget(ctx context.Context, upd *influxdb.ScraperTarget) (*influxdb.ScraperTarget, error) {
+func (s *ScraperTargetStoreService) UpdateTarget(ctx context.Context, upd *influxdb.ScraperTarget, userID influxdb.ID) (*influxdb.ScraperTarget, error) {
 	st, err := s.s.GetTargetByID(ctx, upd.ID)
 	if err != nil {
 		return nil, err
@@ -118,7 +120,7 @@ func (s *ScraperTargetStoreService) UpdateTarget(ctx context.Context, upd *influ
 		return nil, err
 	}
 
-	return s.s.UpdateTarget(ctx, upd)
+	return s.s.UpdateTarget(ctx, upd, userID)
 }
 
 // RemoveTarget checks to see if the authorizer on context has write access to the scraper target provided.

--- a/authorizer/scraper_test.go
+++ b/authorizer/scraper_test.go
@@ -104,7 +104,7 @@ func TestScraperTargetStoreService_GetTargetByID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService)
+			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService, mock.NewUserResourceMappingService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
@@ -228,7 +228,7 @@ func TestScraperTargetStoreService_ListTargets(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService)
+			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService, mock.NewUserResourceMappingService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
@@ -271,7 +271,7 @@ func TestScraperTargetStoreService_UpdateTarget(t *testing.T) {
 							OrgID: 10,
 						}, nil
 					},
-					UpdateTargetF: func(ctx context.Context, upd *influxdb.ScraperTarget) (*influxdb.ScraperTarget, error) {
+					UpdateTargetF: func(ctx context.Context, upd *influxdb.ScraperTarget, userID influxdb.ID) (*influxdb.ScraperTarget, error) {
 						return &influxdb.ScraperTarget{
 							ID:    1,
 							OrgID: 10,
@@ -312,7 +312,7 @@ func TestScraperTargetStoreService_UpdateTarget(t *testing.T) {
 							OrgID: 10,
 						}, nil
 					},
-					UpdateTargetF: func(ctx context.Context, upd *influxdb.ScraperTarget) (*influxdb.ScraperTarget, error) {
+					UpdateTargetF: func(ctx context.Context, upd *influxdb.ScraperTarget, userID influxdb.ID) (*influxdb.ScraperTarget, error) {
 						return &influxdb.ScraperTarget{
 							ID:    1,
 							OrgID: 10,
@@ -343,12 +343,12 @@ func TestScraperTargetStoreService_UpdateTarget(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService)
+			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService, mock.NewUserResourceMappingService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
 
-			_, err := s.UpdateTarget(ctx, &influxdb.ScraperTarget{ID: tt.args.id})
+			_, err := s.UpdateTarget(ctx, &influxdb.ScraperTarget{ID: tt.args.id}, influxdb.ID(1))
 			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
 		})
 	}
@@ -448,7 +448,7 @@ func TestScraperTargetStoreService_RemoveTarget(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService)
+			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService, mock.NewUserResourceMappingService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
@@ -481,7 +481,7 @@ func TestScraperTargetStoreService_AddTarget(t *testing.T) {
 			name: "authorized to create scraper",
 			fields: fields{
 				ScraperTargetStoreService: &mock.ScraperTargetStoreService{
-					AddTargetF: func(ctx context.Context, st *influxdb.ScraperTarget) error {
+					AddTargetF: func(ctx context.Context, st *influxdb.ScraperTarget, userID influxdb.ID) error {
 						return nil
 					},
 				},
@@ -504,7 +504,7 @@ func TestScraperTargetStoreService_AddTarget(t *testing.T) {
 			name: "unauthorized to create scraper",
 			fields: fields{
 				ScraperTargetStoreService: &mock.ScraperTargetStoreService{
-					AddTargetF: func(ctx context.Context, st *influxdb.ScraperTarget) error {
+					AddTargetF: func(ctx context.Context, st *influxdb.ScraperTarget, userID influxdb.ID) error {
 						return nil
 					},
 				},
@@ -530,12 +530,12 @@ func TestScraperTargetStoreService_AddTarget(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService)
+			s := authorizer.NewScraperTargetStoreService(tt.fields.ScraperTargetStoreService, mock.NewUserResourceMappingService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
 
-			err := s.AddTarget(ctx, &influxdb.ScraperTarget{OrgID: tt.args.orgID})
+			err := s.AddTarget(ctx, &influxdb.ScraperTarget{OrgID: tt.args.orgID}, influxdb.ID(1))
 			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
 		})
 	}

--- a/bolt/scraper_test.go
+++ b/bolt/scraper_test.go
@@ -21,6 +21,11 @@ func initScraperTargetStoreService(f platformtesting.TargetFields, t *testing.T)
 			t.Fatalf("failed to populate targets: %v", err)
 		}
 	}
+	for _, m := range f.UserResourceMappings {
+		if err := c.CreateUserResourceMapping(ctx, m); err != nil {
+			t.Fatalf("failed to populate user resource mapping")
+		}
+	}
 	return c, bolt.OpPrefix, func() {
 		defer closeFn()
 		for _, target := range f.Targets {
@@ -31,22 +36,6 @@ func initScraperTargetStoreService(f platformtesting.TargetFields, t *testing.T)
 	}
 }
 
-func TestScraperTargetStoreService_AddTarget(t *testing.T) {
-	platformtesting.AddTarget(initScraperTargetStoreService, t)
-}
-
-func TestScraperTargetStoreService_ListTargets(t *testing.T) {
-	platformtesting.ListTargets(initScraperTargetStoreService, t)
-}
-
-func TestScraperTargetStoreService_RemoveTarget(t *testing.T) {
-	platformtesting.RemoveTarget(initScraperTargetStoreService, t)
-}
-
-func TestScraperTargetStoreService_UpdateTarget(t *testing.T) {
-	platformtesting.UpdateTarget(initScraperTargetStoreService, t)
-}
-
-func TestScraperTargetStoreService_GetTargetByID(t *testing.T) {
-	platformtesting.GetTargetByID(initScraperTargetStoreService, t)
+func TestScraperTargetStoreService(t *testing.T) {
+	platformtesting.ScraperService(initScraperTargetStoreService, t)
 }

--- a/gather/scraper_test.go
+++ b/gather/scraper_test.go
@@ -192,6 +192,7 @@ go_memstats_gc_cpu_fraction 1.972734963012756e-05
 // and influxdb.ScraperTargetStoreService interface.
 type mockStorage struct {
 	sync.RWMutex
+	influxdb.UserResourceMappingService
 	TotalGatherJobs chan struct{}
 	Metrics         map[time.Time]Metrics
 	Targets         []influxdb.ScraperTarget
@@ -218,7 +219,7 @@ func (s *mockStorage) ListTargets(ctx context.Context) (targets []influxdb.Scrap
 	return s.Targets, nil
 }
 
-func (s *mockStorage) AddTarget(ctx context.Context, t *influxdb.ScraperTarget) error {
+func (s *mockStorage) AddTarget(ctx context.Context, t *influxdb.ScraperTarget, userID influxdb.ID) error {
 	s.Lock()
 	defer s.Unlock()
 	if s.Targets == nil {
@@ -259,7 +260,7 @@ func (s *mockStorage) GetTargetByID(ctx context.Context, id influxdb.ID) (target
 
 }
 
-func (s *mockStorage) UpdateTarget(ctx context.Context, update *influxdb.ScraperTarget) (target *influxdb.ScraperTarget, err error) {
+func (s *mockStorage) UpdateTarget(ctx context.Context, update *influxdb.ScraperTarget, userID influxdb.ID) (target *influxdb.ScraperTarget, err error) {
 	s.Lock()
 	defer s.Unlock()
 

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -112,7 +112,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.AuthorizationHandler.Logger = b.Logger.With(zap.String("handler", "auth"))
 
 	h.ScraperHandler = NewScraperHandler()
-	h.ScraperHandler.ScraperStorageService = authorizer.NewScraperTargetStoreService(b.ScraperTargetStoreService)
+	h.ScraperHandler.ScraperStorageService = authorizer.NewScraperTargetStoreService(b.ScraperTargetStoreService, b.UserResourceMappingService)
 	h.ScraperHandler.BucketService = b.BucketService
 	h.ScraperHandler.OrganizationService = b.OrganizationService
 	h.ScraperHandler.Logger = b.Logger.With(zap.String("handler", "scraper"))

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -115,6 +115,9 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.ScraperHandler.ScraperStorageService = authorizer.NewScraperTargetStoreService(b.ScraperTargetStoreService, b.UserResourceMappingService)
 	h.ScraperHandler.BucketService = b.BucketService
 	h.ScraperHandler.OrganizationService = b.OrganizationService
+	h.ScraperHandler.UserService = b.UserService
+	h.ScraperHandler.UserResourceMappingService = b.UserResourceMappingService
+	h.ScraperHandler.LabelService = b.LabelService
 	h.ScraperHandler.Logger = b.Logger.With(zap.String("handler", "scraper"))
 
 	h.SourceHandler = NewSourceHandler()

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -111,14 +111,15 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	h.AuthorizationHandler.LookupService = b.LookupService
 	h.AuthorizationHandler.Logger = b.Logger.With(zap.String("handler", "auth"))
 
-	h.ScraperHandler = NewScraperHandler()
-	h.ScraperHandler.ScraperStorageService = authorizer.NewScraperTargetStoreService(b.ScraperTargetStoreService, b.UserResourceMappingService)
-	h.ScraperHandler.BucketService = b.BucketService
-	h.ScraperHandler.OrganizationService = b.OrganizationService
-	h.ScraperHandler.UserService = b.UserService
-	h.ScraperHandler.UserResourceMappingService = b.UserResourceMappingService
-	h.ScraperHandler.LabelService = b.LabelService
-	h.ScraperHandler.Logger = b.Logger.With(zap.String("handler", "scraper"))
+	h.ScraperHandler = NewScraperHandler(
+		b.Logger.With(zap.String("handler", "scraper")),
+		b.UserService,
+		b.UserResourceMappingService,
+		b.LabelService,
+		authorizer.NewScraperTargetStoreService(b.ScraperTargetStoreService, b.UserResourceMappingService),
+		b.BucketService,
+		b.OrganizationService,
+	)
 
 	h.SourceHandler = NewSourceHandler()
 	h.SourceHandler.SourceService = authorizer.NewSourceService(b.SourceService)

--- a/http/mock/middleware.go
+++ b/http/mock/middleware.go
@@ -7,20 +7,20 @@ import (
 	platcontext "github.com/influxdata/influxdb/context"
 )
 
-// NewMiddlewareHandler create a mocked middleware handler.
-func NewMiddlewareHandler(handler http.Handler, auth influxdb.Authorizer) http.Handler {
-	return &middlewareHandler{
+// NewAuthMiddlewareHandler create a mocked middleware handler.
+func NewAuthMiddlewareHandler(handler http.Handler, auth influxdb.Authorizer) http.Handler {
+	return &authMiddlewareHandler{
 		handler: handler,
 		auth:    auth,
 	}
 }
 
-type middlewareHandler struct {
+type authMiddlewareHandler struct {
 	handler http.Handler
 	auth    influxdb.Authorizer
 }
 
-func (m *middlewareHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (m *authMiddlewareHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	r = r.WithContext(platcontext.SetAuthorizer(ctx, m.auth))
 	m.handler.ServeHTTP(w, r)

--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -36,9 +36,24 @@ const (
 )
 
 // NewScraperHandler returns a new instance of ScraperHandler.
-func NewScraperHandler() *ScraperHandler {
+func NewScraperHandler(
+	logger *zap.Logger,
+	userService influxdb.UserService,
+	userResourceMappingService influxdb.UserResourceMappingService,
+	labelService influxdb.LabelService,
+	scraperStorageService influxdb.ScraperTargetStoreService,
+	bucketService influxdb.BucketService,
+	organizationService influxdb.OrganizationService,
+) *ScraperHandler {
 	h := &ScraperHandler{
-		Router: NewRouter(),
+		Router:                     NewRouter(),
+		Logger:                     logger,
+		UserService:                userService,
+		UserResourceMappingService: userResourceMappingService,
+		LabelService:               labelService,
+		ScraperStorageService:      scraperStorageService,
+		BucketService:              bucketService,
+		OrganizationService:        organizationService,
 	}
 	h.HandlerFunc("POST", targetsPath, h.handlePostScraperTarget)
 	h.HandlerFunc("GET", targetsPath, h.handleGetScraperTargets)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1041,8 +1041,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  
-                '/macros/{macroID}':
+  '/macros/{macroID}':
     delete:
       tags:
         - Macros

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -659,6 +659,326 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  '/scrapers/{scraperTargetID}/labels':
+    get:
+      tags:
+        - ScraperTargets
+      summary: list all labels for a scraper targets
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+      responses:
+        '200':
+          description: a list of all labels for a scraper target
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  labels:
+                    $ref: "#/components/schemas/Labels"
+                  links:
+                    $ref: "#/components/schemas/Links"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags:
+        - ScraperTargets
+      summary: add a label to a scraper target
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+      requestBody:
+        description: label to add
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Label"
+      responses:
+        '200':
+          description: a list of all labels for a scraper target
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  labels:
+                    $ref: "#/components/schemas/Labels"
+                  links:
+                    $ref: "#/components/schemas/Links"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/scrapers/{scraperTargetID}/labels/{label}':
+    delete:
+      tags:
+        - ScraperTargets
+      summary: delete a label from a scraper target
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+        - in: path
+          name: label
+          schema:
+            type: string
+          required: true
+          description: the label name
+      responses:
+        '204':
+          description: delete has been accepted
+        '404':
+          description: scraper target not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    patch:
+      tags:
+        - ScraperTargets
+      summary: update a label from a scraper target
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+        - in: path
+          name: label
+          schema:
+            type: string
+          required: true
+          description: the label name
+      requestBody:
+        description: label update to apply
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Label"
+      responses:
+        '200':
+          description: updated successfully
+        '404':
+          description: scraper target not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/scrapers/{scraperTargetID}/members':
+    get:
+      tags:
+        - Users
+        - ScraperTargets
+      summary: List all users with member privileges for a scraper target
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+      responses:
+        '200':
+          description: a list of scraper target members
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceMembers"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags:
+        - Users
+        - ScraperTargets
+      summary: Add scraper target member
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+      requestBody:
+        description: user to add as member
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddResourceMemberRequestBody"
+      responses:
+        '201':
+          description: member added to scraper targets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceMember"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/scrapers/{scraperTargetID}/members/{userID}':
+    delete:
+      tags:
+        - Users
+        - ScraperTargets
+      summary: removes a member from a scraper target
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: userID
+          schema:
+            type: string
+          required: true
+          description: ID of member to remove
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+      responses:
+        '204':
+          description: member removed
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/scrapers/{scraperTargetID}/owners':
+    get:
+      tags:
+        - Users
+        - ScraperTargets
+      summary: List all owners of a scraper target
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+      responses:
+        '200':
+          description: a list of scraper target owners
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceOwners"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      tags:
+        - Users
+        - ScraperTargets
+      summary: Add scraper target owner
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+      requestBody:
+        description: user to add as owner
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddResourceMemberRequestBody"
+      responses:
+        '201':
+          description: scraper target owner added
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceOwner"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/scrapers/{scraperTargetID}/owners/{userID}':
+    delete:
+      tags:
+        - Users
+        - ScraperTargets
+      summary: removes an owner from a scraper target
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: userID
+          schema:
+            type: string
+          required: true
+          description: ID of owner to remove
+        - in: path
+          name: scraperTargetID
+          schema:
+            type: string
+          required: true
+          description: ID of the scraper target
+      responses:
+        '204':
+          description: owner removed
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /macros:
     get:
       tags:
@@ -721,7 +1041,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  '/macros/{macroID}':
+  
+                '/macros/{macroID}':
     delete:
       tags:
         - Macros

--- a/inmem/scraper_test.go
+++ b/inmem/scraper_test.go
@@ -17,25 +17,14 @@ func initScraperTargetStoreService(f platformtesting.TargetFields, t *testing.T)
 			t.Fatalf("failed to populate scraper targets")
 		}
 	}
+	for _, m := range f.UserResourceMappings {
+		if err := s.PutUserResourceMapping(ctx, m); err != nil {
+			t.Fatalf("failed to populate user resource mapping")
+		}
+	}
 	return s, OpPrefix, func() {}
 }
 
-func TestScraperTargetStoreService_AddTarget(t *testing.T) {
-	platformtesting.AddTarget(initScraperTargetStoreService, t)
-}
-
-func TestScraperTargetStoreService_ListTargets(t *testing.T) {
-	platformtesting.ListTargets(initScraperTargetStoreService, t)
-}
-
-func TestScraperTargetStoreService_RemoveTarget(t *testing.T) {
-	platformtesting.RemoveTarget(initScraperTargetStoreService, t)
-}
-
-func TestScraperTargetStoreService_UpdateTarget(t *testing.T) {
-	platformtesting.UpdateTarget(initScraperTargetStoreService, t)
-}
-
-func TestScraperTargetStoreService_GetTargetByID(t *testing.T) {
-	platformtesting.GetTargetByID(initScraperTargetStoreService, t)
+func TestScraperTargetStoreService(t *testing.T) {
+	platformtesting.ScraperService(initScraperTargetStoreService, t)
 }

--- a/mock/middle_ware.go
+++ b/mock/middle_ware.go
@@ -1,0 +1,27 @@
+package mock
+
+import (
+	"net/http"
+
+	"github.com/influxdata/influxdb"
+	platcontext "github.com/influxdata/influxdb/context"
+)
+
+// NewMiddlewareHandler create a mocked middleware handler.
+func NewMiddlewareHandler(handler http.Handler, auth influxdb.Authorizer) http.Handler {
+	return &middlewareHandler{
+		handler: handler,
+		auth:    auth,
+	}
+}
+
+type middlewareHandler struct {
+	handler http.Handler
+	auth    influxdb.Authorizer
+}
+
+func (m *middlewareHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	r = r.WithContext(platcontext.SetAuthorizer(ctx, m.auth))
+	m.handler.ServeHTTP(w, r)
+}

--- a/mock/scraper_service.go
+++ b/mock/scraper_service.go
@@ -10,11 +10,12 @@ var _ platform.ScraperTargetStoreService = &ScraperTargetStoreService{}
 
 // ScraperTargetStoreService is a mock implementation of a platform.ScraperTargetStoreService.
 type ScraperTargetStoreService struct {
+	UserResourceMappingService
 	ListTargetsF   func(ctx context.Context) ([]platform.ScraperTarget, error)
-	AddTargetF     func(ctx context.Context, t *platform.ScraperTarget) error
+	AddTargetF     func(ctx context.Context, t *platform.ScraperTarget, userID platform.ID) error
 	GetTargetByIDF func(ctx context.Context, id platform.ID) (*platform.ScraperTarget, error)
 	RemoveTargetF  func(ctx context.Context, id platform.ID) error
-	UpdateTargetF  func(ctx context.Context, t *platform.ScraperTarget) (*platform.ScraperTarget, error)
+	UpdateTargetF  func(ctx context.Context, t *platform.ScraperTarget, userID platform.ID) (*platform.ScraperTarget, error)
 }
 
 // ListTargets lists all the scraper targets.
@@ -23,8 +24,8 @@ func (s *ScraperTargetStoreService) ListTargets(ctx context.Context) ([]platform
 }
 
 // AddTarget adds a scraper target.
-func (s *ScraperTargetStoreService) AddTarget(ctx context.Context, t *platform.ScraperTarget) error {
-	return s.AddTargetF(ctx, t)
+func (s *ScraperTargetStoreService) AddTarget(ctx context.Context, t *platform.ScraperTarget, userID platform.ID) error {
+	return s.AddTargetF(ctx, t, userID)
 }
 
 // GetTargetByID retrieves a scraper target by id.
@@ -38,6 +39,6 @@ func (s *ScraperTargetStoreService) RemoveTarget(ctx context.Context, id platfor
 }
 
 // UpdateTarget updates a scraper target.
-func (s *ScraperTargetStoreService) UpdateTarget(ctx context.Context, t *platform.ScraperTarget) (*platform.ScraperTarget, error) {
-	return s.UpdateTargetF(ctx, t)
+func (s *ScraperTargetStoreService) UpdateTarget(ctx context.Context, t *platform.ScraperTarget, userID platform.ID) (*platform.ScraperTarget, error) {
+	return s.UpdateTargetF(ctx, t, userID)
 }

--- a/scraper.go
+++ b/scraper.go
@@ -28,11 +28,12 @@ type ScraperTarget struct {
 
 // ScraperTargetStoreService defines the crud service for ScraperTarget.
 type ScraperTargetStoreService interface {
+	UserResourceMappingService
 	ListTargets(ctx context.Context) ([]ScraperTarget, error)
-	AddTarget(ctx context.Context, t *ScraperTarget) error
+	AddTarget(ctx context.Context, t *ScraperTarget, userID ID) error
 	GetTargetByID(ctx context.Context, id ID) (*ScraperTarget, error)
 	RemoveTarget(ctx context.Context, id ID) error
-	UpdateTarget(ctx context.Context, t *ScraperTarget) (*ScraperTarget, error)
+	UpdateTarget(ctx context.Context, t *ScraperTarget, userID ID) (*ScraperTarget, error)
 }
 
 // ScraperTargetFilter represents a set of filter that restrict the returned results.

--- a/testing/scraper_target.go
+++ b/testing/scraper_target.go
@@ -19,8 +19,9 @@ const (
 
 // TargetFields will include the IDGenerator, and targets
 type TargetFields struct {
-	IDGenerator platform.IDGenerator
-	Targets     []*platform.ScraperTarget
+	IDGenerator          platform.IDGenerator
+	Targets              []*platform.ScraperTarget
+	UserResourceMappings []*platform.UserResourceMapping
 }
 
 var targetCmpOptions = cmp.Options{
@@ -79,11 +80,13 @@ func AddTarget(
 	t *testing.T,
 ) {
 	type args struct {
+		userID platform.ID
 		target *platform.ScraperTarget
 	}
 	type wants struct {
-		err     error
-		targets []platform.ScraperTarget
+		err                  error
+		targets              []platform.ScraperTarget
+		userResourceMappings []*platform.UserResourceMapping
 	}
 	tests := []struct {
 		name   string
@@ -94,10 +97,12 @@ func AddTarget(
 		{
 			name: "create targets with empty set",
 			fields: TargetFields{
-				IDGenerator: mock.NewIDGenerator(targetOneID, t),
-				Targets:     []*platform.ScraperTarget{},
+				IDGenerator:          mock.NewIDGenerator(targetOneID, t),
+				Targets:              []*platform.ScraperTarget{},
+				UserResourceMappings: []*platform.UserResourceMapping{},
 			},
 			args: args{
+				userID: MustIDBase16(threeID),
 				target: &platform.ScraperTarget{
 					Name:     "name1",
 					Type:     platform.PrometheusScraperType,
@@ -107,6 +112,14 @@ func AddTarget(
 				},
 			},
 			wants: wants{
+				userResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.ScraperResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+					},
+				},
 				targets: []platform.ScraperTarget{
 					{
 						Name:     "name1",
@@ -122,7 +135,8 @@ func AddTarget(
 		{
 			name: "create target with invalid org id",
 			fields: TargetFields{
-				IDGenerator: mock.NewIDGenerator(targetTwoID, t),
+				IDGenerator:          mock.NewIDGenerator(targetTwoID, t),
+				UserResourceMappings: []*platform.UserResourceMapping{},
 				Targets: []*platform.ScraperTarget{
 					{
 						Name:     "name1",
@@ -149,6 +163,7 @@ func AddTarget(
 					Msg:  "org id is invalid",
 					Op:   platform.OpAddTarget,
 				},
+				userResourceMappings: []*platform.UserResourceMapping{},
 				targets: []platform.ScraperTarget{
 					{
 						Name:     "name1",
@@ -164,7 +179,8 @@ func AddTarget(
 		{
 			name: "create target with invalid bucket id",
 			fields: TargetFields{
-				IDGenerator: mock.NewIDGenerator(targetTwoID, t),
+				IDGenerator:          mock.NewIDGenerator(targetTwoID, t),
+				UserResourceMappings: []*platform.UserResourceMapping{},
 				Targets: []*platform.ScraperTarget{
 					{
 						Name:     "name1",
@@ -191,6 +207,7 @@ func AddTarget(
 					Msg:  "bucket id is invalid",
 					Op:   platform.OpAddTarget,
 				},
+				userResourceMappings: []*platform.UserResourceMapping{},
 				targets: []platform.ScraperTarget{
 					{
 						Name:     "name1",
@@ -217,8 +234,17 @@ func AddTarget(
 						ID:       MustIDBase16(targetOneID),
 					},
 				},
+				UserResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(targetOneID),
+						ResourceType: platform.ScraperResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+					},
+				},
 			},
 			args: args{
+				userID: MustIDBase16(threeID),
 				target: &platform.ScraperTarget{
 					ID:       MustIDBase16(targetTwoID),
 					Name:     "name2",
@@ -229,6 +255,20 @@ func AddTarget(
 				},
 			},
 			wants: wants{
+				userResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: platform.ScraperResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: platform.ScraperResourceType,
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+					},
+				},
 				targets: []platform.ScraperTarget{
 					{
 						Name:     "name1",
@@ -255,7 +295,7 @@ func AddTarget(
 			s, opPrefix, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
-			err := s.AddTarget(ctx, tt.args.target)
+			err := s.AddTarget(ctx, tt.args.target, tt.args.userID)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 			defer s.RemoveTarget(ctx, tt.args.target.ID)
 
@@ -265,6 +305,16 @@ func AddTarget(
 			}
 			if diff := cmp.Diff(targets, tt.wants.targets, targetCmpOptions...); diff != "" {
 				t.Errorf("scraper targets are different -got/+want\ndiff %s", diff)
+			}
+			urms, _, err := s.FindUserResourceMappings(ctx, platform.UserResourceMappingFilter{
+				UserID:       tt.args.userID,
+				ResourceType: platform.ScraperResourceType,
+			})
+			if err != nil {
+				t.Fatalf("failed to retrieve user resource mappings: %v", err)
+			}
+			if diff := cmp.Diff(urms, tt.wants.userResourceMappings, userResourceMappingCmpOptions...); diff != "" {
+				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
 			}
 		})
 
@@ -446,11 +496,13 @@ func GetTargetByID(
 func RemoveTarget(init func(TargetFields, *testing.T) (platform.ScraperTargetStoreService, string, func()),
 	t *testing.T) {
 	type args struct {
-		ID platform.ID
+		ID     platform.ID
+		userID platform.ID
 	}
 	type wants struct {
-		err     error
-		targets []platform.ScraperTarget
+		err                  error
+		userResourceMappings []*platform.UserResourceMapping
+		targets              []platform.ScraperTarget
 	}
 	tests := []struct {
 		name   string
@@ -461,6 +513,20 @@ func RemoveTarget(init func(TargetFields, *testing.T) (platform.ScraperTargetSto
 		{
 			name: "delete targets using exist id",
 			fields: TargetFields{
+				UserResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.ScraperResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.ScraperResourceType,
+					},
+				},
 				Targets: []*platform.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetOneID),
@@ -475,9 +541,18 @@ func RemoveTarget(init func(TargetFields, *testing.T) (platform.ScraperTargetSto
 				},
 			},
 			args: args{
-				ID: MustIDBase16(targetOneID),
+				ID:     MustIDBase16(targetOneID),
+				userID: MustIDBase16(threeID),
 			},
 			wants: wants{
+				userResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.ScraperResourceType,
+					},
+				},
 				targets: []platform.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetTwoID),
@@ -490,6 +565,20 @@ func RemoveTarget(init func(TargetFields, *testing.T) (platform.ScraperTargetSto
 		{
 			name: "delete targets using id that does not exist",
 			fields: TargetFields{
+				UserResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.ScraperResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.ScraperResourceType,
+					},
+				},
 				Targets: []*platform.ScraperTarget{
 					{
 						ID:       MustIDBase16(targetOneID),
@@ -504,7 +593,8 @@ func RemoveTarget(init func(TargetFields, *testing.T) (platform.ScraperTargetSto
 				},
 			},
 			args: args{
-				ID: MustIDBase16(targetThreeID),
+				ID:     MustIDBase16(targetThreeID),
+				userID: MustIDBase16(threeID),
 			},
 			wants: wants{
 				err: &platform.Error{
@@ -522,6 +612,20 @@ func RemoveTarget(init func(TargetFields, *testing.T) (platform.ScraperTargetSto
 						ID:       MustIDBase16(targetTwoID),
 						OrgID:    MustIDBase16(orgOneID),
 						BucketID: MustIDBase16(bucketOneID),
+					},
+				},
+				userResourceMappings: []*platform.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Owner,
+						ResourceType: platform.ScraperResourceType,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						UserID:       MustIDBase16(threeID),
+						UserType:     platform.Member,
+						ResourceType: platform.ScraperResourceType,
 					},
 				},
 			},
@@ -542,6 +646,16 @@ func RemoveTarget(init func(TargetFields, *testing.T) (platform.ScraperTargetSto
 			if diff := cmp.Diff(targets, tt.wants.targets, targetCmpOptions...); diff != "" {
 				t.Errorf("targets are different -got/+want\ndiff %s", diff)
 			}
+			urms, _, err := s.FindUserResourceMappings(ctx, platform.UserResourceMappingFilter{
+				UserID:       tt.args.userID,
+				ResourceType: platform.ScraperResourceType,
+			})
+			if err != nil {
+				t.Fatalf("failed to retrieve user resource mappings: %v", err)
+			}
+			if diff := cmp.Diff(urms, tt.wants.userResourceMappings, userResourceMappingCmpOptions...); diff != "" {
+				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
+			}
 		})
 	}
 }
@@ -552,8 +666,9 @@ func UpdateTarget(
 	t *testing.T,
 ) {
 	type args struct {
-		url string
-		id  platform.ID
+		url    string
+		userID platform.ID
+		id     platform.ID
 	}
 	type wants struct {
 		err    error
@@ -669,7 +784,7 @@ func UpdateTarget(
 				URL: tt.args.url,
 			}
 
-			target, err := s.UpdateTarget(ctx, upd)
+			target, err := s.UpdateTarget(ctx, upd, tt.args.userID)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
 			if diff := cmp.Diff(target, tt.wants.target, targetCmpOptions...); diff != "" {


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/11237

_Briefly describe your proposed changes:_
add user resource mapping for scraper http endpoint.
user resource mapping become part of scraper creating transaction. 
when create the scraper, creator should become the owner.
when delete the scraper, related user resource mapping will be removed


  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
