### PR TITLE
fix(http): ensure response body always closed

### DIFF
--- a/chronograf/influx/influx.go
+++ b/chronograf/influx/influx.go
@@ -333,12 +333,12 @@ func (c *Client) write(ctx context.Context, u *url.URL, db, rp, lp string) error
 			errChan <- err
 			return
 		}
+		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNoContent {
 			errChan <- nil
 			return
 		}
-		defer resp.Body.Close()
 
 		var response Response
 		dec := json.NewDecoder(resp.Body)

--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -609,6 +609,7 @@ func (s *AuthorizationService) FindAuthorizationByID(ctx context.Context, id pla
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -618,7 +619,6 @@ func (s *AuthorizationService) FindAuthorizationByID(ctx context.Context, id pla
 	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &b, nil
 }
@@ -663,6 +663,7 @@ func (s *AuthorizationService) FindAuthorizations(ctx context.Context, filter pl
 	if err != nil {
 		return nil, 0, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, 0, err
@@ -672,7 +673,6 @@ func (s *AuthorizationService) FindAuthorizations(ctx context.Context, filter pl
 	if err := json.NewDecoder(resp.Body).Decode(&as); err != nil {
 		return nil, 0, err
 	}
-	defer resp.Body.Close()
 
 	auths := make([]*platform.Authorization, 0, len(as.Auths))
 	for _, a := range as.Auths {
@@ -719,6 +719,7 @@ func (s *AuthorizationService) CreateAuthorization(ctx context.Context, a *platf
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// TODO(jsternberg): Should this check for a 201 explicitly?
 	if err := CheckError(resp, true); err != nil {
@@ -764,6 +765,7 @@ func (s *AuthorizationService) SetAuthorizationStatus(ctx context.Context, id pl
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return err
@@ -790,6 +792,8 @@ func (s *AuthorizationService) DeleteAuthorization(ctx context.Context, id platf
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return CheckError(resp, true)
 }
 

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -528,6 +528,7 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*pl
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -537,7 +538,6 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*pl
 	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	return br.toPlatform()
 }
 
@@ -603,6 +603,7 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketF
 	if err != nil {
 		return nil, 0, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, 0, err
@@ -612,7 +613,6 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketF
 	if err := json.NewDecoder(resp.Body).Decode(&bs); err != nil {
 		return nil, 0, err
 	}
-	defer resp.Body.Close()
 
 	buckets := make([]*platform.Bucket, 0, len(bs.Buckets))
 	for _, b := range bs.Buckets {
@@ -653,6 +653,7 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *platform.Bucket) er
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// TODO(jsternberg): Should this check for a 201 explicitly?
 	if err := CheckError(resp, true); err != nil {
@@ -700,6 +701,7 @@ func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd pl
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -709,7 +711,6 @@ func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd pl
 	if err := json.NewDecoder(resp.Body).Decode(&br); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	return br.toPlatform()
 }
 
@@ -731,6 +732,8 @@ func (s *BucketService) DeleteBucket(ctx context.Context, id platform.ID) error 
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return CheckError(resp, true)
 }
 

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -941,6 +941,7 @@ func (s *DashboardService) FindDashboardByID(ctx context.Context, id platform.ID
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -994,6 +995,7 @@ func (s *DashboardService) FindDashboards(ctx context.Context, filter platform.D
 	if err != nil {
 		return dashboards, 0, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return dashboards, 0, err
@@ -1034,6 +1036,7 @@ func (s *DashboardService) CreateDashboard(ctx context.Context, d *platform.Dash
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return err
@@ -1074,6 +1077,7 @@ func (s *DashboardService) UpdateDashboard(ctx context.Context, id platform.ID, 
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -1083,7 +1087,6 @@ func (s *DashboardService) UpdateDashboard(ctx context.Context, id platform.ID, 
 	if err := json.NewDecoder(resp.Body).Decode(&d); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 	if len(d.Cells) == 0 {
 		d.Cells = nil
 	}
@@ -1109,6 +1112,8 @@ func (s *DashboardService) DeleteDashboard(ctx context.Context, id platform.ID) 
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return CheckError(resp, true)
 }
 
@@ -1138,6 +1143,7 @@ func (s *DashboardService) AddDashboardCell(ctx context.Context, id platform.ID,
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return err
@@ -1165,6 +1171,8 @@ func (s *DashboardService) RemoveDashboardCell(ctx context.Context, dashboardID,
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return CheckError(resp, true)
 }
 
@@ -1202,6 +1210,7 @@ func (s *DashboardService) UpdateDashboardCell(ctx context.Context, dashboardID,
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -1211,7 +1220,6 @@ func (s *DashboardService) UpdateDashboardCell(ctx context.Context, dashboardID,
 	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &c, nil
 }
@@ -1237,6 +1245,7 @@ func (s *DashboardService) GetDashboardCellView(ctx context.Context, dashboardID
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -1246,7 +1255,6 @@ func (s *DashboardService) GetDashboardCellView(ctx context.Context, dashboardID
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &res.View, nil
 }
@@ -1277,6 +1285,7 @@ func (s *DashboardService) UpdateDashboardCellView(ctx context.Context, dashboar
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -1286,7 +1295,6 @@ func (s *DashboardService) UpdateDashboardCellView(ctx context.Context, dashboar
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &res.View, nil
 }
@@ -1318,6 +1326,7 @@ func (s *DashboardService) ReplaceDashboardCells(ctx context.Context, id platfor
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return err
@@ -1327,7 +1336,6 @@ func (s *DashboardService) ReplaceDashboardCells(ctx context.Context, id platfor
 	if err := json.NewDecoder(resp.Body).Decode(&cells); err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	return nil
 }

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -495,6 +495,7 @@ func (s *LabelService) FindLabelByID(ctx context.Context, id platform.ID) (*plat
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -531,6 +532,7 @@ func (s *LabelService) FindResourceLabels(ctx context.Context, filter platform.L
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp); err != nil {
 		return nil, err
@@ -570,6 +572,7 @@ func (s *LabelService) CreateLabel(ctx context.Context, l *platform.Label) error
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// TODO(jsternberg): Should this check for a 201 explicitly?
 	if err := CheckError(resp, true); err != nil {
@@ -613,6 +616,7 @@ func (s *LabelService) CreateLabelMapping(ctx context.Context, m *platform.Label
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp); err != nil {
 		return err
@@ -651,6 +655,7 @@ func (s *LabelService) UpdateLabel(ctx context.Context, id platform.ID, upd plat
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -681,6 +686,8 @@ func (s *LabelService) DeleteLabel(ctx context.Context, id platform.ID) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return CheckError(resp, true)
 }
 
@@ -701,6 +708,8 @@ func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *platform.Label
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return CheckError(resp)
 }
 

--- a/http/macro_service.go
+++ b/http/macro_service.go
@@ -385,6 +385,7 @@ func (s *MacroService) FindMacroByID(ctx context.Context, id platform.ID) (*plat
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -432,6 +433,7 @@ func (s *MacroService) FindMacros(ctx context.Context, filter platform.MacroFilt
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -476,6 +478,7 @@ func (s *MacroService) CreateMacro(ctx context.Context, m *platform.Macro) error
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return err
@@ -510,6 +513,7 @@ func (s *MacroService) UpdateMacro(ctx context.Context, id platform.ID, update *
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -519,7 +523,6 @@ func (s *MacroService) UpdateMacro(ctx context.Context, id platform.ID, update *
 	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &m, nil
 }
@@ -550,6 +553,7 @@ func (s *MacroService) ReplaceMacro(ctx context.Context, macro *platform.Macro) 
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return err
@@ -558,7 +562,6 @@ func (s *MacroService) ReplaceMacro(ctx context.Context, macro *platform.Macro) 
 	if err := json.NewDecoder(resp.Body).Decode(&macro); err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	return nil
 }
@@ -581,6 +584,8 @@ func (s *MacroService) DeleteMacro(ctx context.Context, id platform.ID) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return CheckError(resp, true)
 }
 

--- a/http/onboarding.go
+++ b/http/onboarding.go
@@ -131,10 +131,11 @@ func (s *SetupService) IsOnboarding(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer resp.Body.Close()
+
 	if err := CheckError(resp); err != nil {
 		return false, err
 	}
-	defer resp.Body.Close()
 	var ir isOnboardingResponse
 	if err := json.NewDecoder(resp.Body).Decode(&ir); err != nil {
 		return false, err

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -569,6 +569,7 @@ func (s *OrganizationService) FindOrganizations(ctx context.Context, filter plat
 	if err != nil {
 		return nil, 0, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, 0, err
@@ -614,6 +615,7 @@ func (s *OrganizationService) CreateOrganization(ctx context.Context, o *platfor
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// TODO(jsternberg): Should this check for a 201 explicitly?
 	if err := CheckError(resp, true); err != nil {
@@ -653,6 +655,7 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, id platfor
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -662,7 +665,6 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, id platfor
 	if err := json.NewDecoder(resp.Body).Decode(&o); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &o, nil
 }
@@ -685,6 +687,7 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, id platfor
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return CheckErrorStatus(http.StatusNoContent, resp, true)
 }

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -355,6 +355,7 @@ func (s *FluxQueryService) Query(ctx context.Context, r *query.Request) (flux.Re
 	if err != nil {
 		return nil, err
 	}
+	// Can't defer resp.Body.Close here because the CSV decoder depends on reading from resp.Body after this function returns.
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err

--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -227,6 +227,7 @@ func (s *ScraperService) ListTargets(ctx context.Context) ([]influxdb.ScraperTar
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
 	}
@@ -276,6 +277,7 @@ func (s *ScraperService) UpdateTarget(ctx context.Context, update *influxdb.Scra
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -284,7 +286,6 @@ func (s *ScraperService) UpdateTarget(ctx context.Context, update *influxdb.Scra
 	if err := json.NewDecoder(resp.Body).Decode(&targetResp); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &targetResp.ScraperTarget, nil
 }
@@ -330,6 +331,7 @@ func (s *ScraperService) AddTarget(ctx context.Context, target *influxdb.Scraper
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// TODO(jsternberg): Should this check for a 201 explicitly?
 	if err := CheckError(resp, true); err != nil {
@@ -362,6 +364,7 @@ func (s *ScraperService) RemoveTarget(ctx context.Context, id influxdb.ID) error
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return CheckErrorStatus(http.StatusNoContent, resp, true)
 }
@@ -384,6 +387,7 @@ func (s *ScraperService) GetTargetByID(ctx context.Context, id influxdb.ID) (*in
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -393,7 +397,6 @@ func (s *ScraperService) GetTargetByID(ctx context.Context, id influxdb.ID) (*in
 	if err := json.NewDecoder(resp.Body).Decode(&targetResp); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &targetResp.ScraperTarget, nil
 }

--- a/http/source_proxy_service.go
+++ b/http/source_proxy_service.go
@@ -89,12 +89,11 @@ func (s *SourceProxyQueryService) queryInfluxQL(ctx context.Context, w io.Writer
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)
-
 	if err != nil {
 		return 0, err
 	}
-
 	defer resp.Body.Close()
+
 	if err := CheckError(resp); err != nil {
 		return 0, err
 	}

--- a/http/source_service.go
+++ b/http/source_service.go
@@ -515,6 +515,7 @@ func (s *SourceService) FindSourceByID(ctx context.Context, id platform.ID) (*pl
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp); err != nil {
 		return nil, err
@@ -524,7 +525,6 @@ func (s *SourceService) FindSourceByID(ctx context.Context, id platform.ID) (*pl
 	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &b, nil
 }
@@ -549,6 +549,7 @@ func (s *SourceService) FindSources(ctx context.Context, opt platform.FindOption
 	if err != nil {
 		return nil, 0, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp); err != nil {
 		return nil, 0, err
@@ -558,7 +559,6 @@ func (s *SourceService) FindSources(ctx context.Context, opt platform.FindOption
 	if err := json.NewDecoder(resp.Body).Decode(&bs); err != nil {
 		return nil, 0, err
 	}
-	defer resp.Body.Close()
 
 	return bs, len(bs), nil
 }
@@ -589,6 +589,7 @@ func (s *SourceService) CreateSource(ctx context.Context, b *platform.Source) er
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// TODO(jsternberg): Should this check for a 201 explicitly?
 	if err := CheckError(resp); err != nil {
@@ -629,6 +630,7 @@ func (s *SourceService) UpdateSource(ctx context.Context, id platform.ID, upd pl
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp); err != nil {
 		return nil, err
@@ -638,7 +640,6 @@ func (s *SourceService) UpdateSource(ctx context.Context, id platform.ID, upd pl
 	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &b, nil
 }
@@ -661,6 +662,7 @@ func (s *SourceService) DeleteSource(ctx context.Context, id platform.ID) error 
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return CheckErrorStatus(http.StatusNoContent, resp)
 }

--- a/http/user_resource_mapping_service.go
+++ b/http/user_resource_mapping_service.go
@@ -271,6 +271,7 @@ func (s *UserResourceMappingService) FindUserResourceMappings(ctx context.Contex
 	if err != nil {
 		return nil, 0, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp); err != nil {
 		return nil, 0, err
@@ -309,6 +310,7 @@ func (s *UserResourceMappingService) CreateUserResourceMapping(ctx context.Conte
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// TODO(jsternberg): Should this check for a 201 explicitly?
 	if err := CheckError(resp); err != nil {
@@ -339,6 +341,8 @@ func (s *UserResourceMappingService) DeleteUserResourceMapping(ctx context.Conte
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	return CheckError(resp)
 }
 

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -435,7 +435,6 @@ func (s *UserService) FindMe(ctx context.Context, id platform.ID) (*platform.Use
 	if err != nil {
 		return nil, err
 	}
-
 	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
@@ -467,6 +466,7 @@ func (s *UserService) FindUserByID(ctx context.Context, id platform.ID) (*platfo
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -476,7 +476,6 @@ func (s *UserService) FindUserByID(ctx context.Context, id platform.ID) (*platfo
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &res.User, nil
 }
@@ -531,6 +530,7 @@ func (s *UserService) FindUsers(ctx context.Context, filter platform.UserFilter,
 	if err != nil {
 		return nil, 0, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, 0, err
@@ -571,6 +571,7 @@ func (s *UserService) CreateUser(ctx context.Context, u *platform.User) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	// TODO(jsternberg): Should this check for a 201 explicitly?
 	if err := CheckError(resp, true); err != nil {
@@ -611,6 +612,7 @@ func (s *UserService) UpdateUser(ctx context.Context, id platform.ID, upd platfo
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := CheckError(resp, true); err != nil {
 		return nil, err
@@ -620,7 +622,6 @@ func (s *UserService) UpdateUser(ctx context.Context, id platform.ID, upd platfo
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	return &res.User, nil
 }
@@ -643,6 +644,7 @@ func (s *UserService) DeleteUser(ctx context.Context, id platform.ID) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return CheckErrorStatus(http.StatusNoContent, resp, true)
 }

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -272,6 +272,7 @@ func (s *WriteService) Write(ctx context.Context, orgID, bucketID platform.ID, r
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return CheckError(resp, true)
 }


### PR DESCRIPTION
This avoids leaking resources.

Found by manually inspecting results of `git grep -A5 -F '= hc.Do'`.