### PR TITLE
feat(ui/onboarding): Create default scraper when Quick Start is selected

### DIFF
--- a/ui/src/logs/constants/index.ts
+++ b/ui/src/logs/constants/index.ts
@@ -11,6 +11,8 @@ export const DEFAULT_TRUNCATION = true
 
 export const LOG_VIEW_NAME = 'LOGS_PAGE'
 
+export const QUICKSTART_SCRAPER_TARGET_URL = 'http://localhost:9999/metrics'
+
 export const EMPTY_VIEW_PROPERTIES: LogViewerView = {
   columns: [],
   type: ViewType.LogViewer,

--- a/ui/src/onboarding/components/CompletionStep.test.tsx
+++ b/ui/src/onboarding/components/CompletionStep.test.tsx
@@ -11,6 +11,8 @@ import {defaultOnboardingStepProps} from 'mocks/dummyData'
 const setup = (override = {}) => {
   const props = {
     ...defaultOnboardingStepProps,
+    orgID: '',
+    bucketID: '',
     ...override,
   }
 

--- a/ui/src/onboarding/components/CompletionStep.tsx
+++ b/ui/src/onboarding/components/CompletionStep.tsx
@@ -8,8 +8,15 @@ import CompletionAdvancedButton from 'src/onboarding/components/CompletionAdvanc
 import CompletionQuickStartButton from 'src/onboarding/components/CompletionQuickStartButton'
 import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
 
+// Constants
+import {
+  QuickstartScraperCreationSuccess,
+  QuickstartScraperCreationError,
+} from 'src/shared/copy/notifications'
+
 // APIs
 import {getOrganizations, getDashboards} from 'src/organizations/apis'
+import {createScraperTarget} from 'src/onboarding/apis'
 
 // Types
 import {
@@ -21,9 +28,15 @@ import {
 } from 'src/clockface'
 import {Organization, Dashboard} from 'src/api'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
+import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/logs/constants'
+
+interface Props extends OnboardingStepProps {
+  orgID: string
+  bucketID: string
+}
 
 @ErrorHandling
-class CompletionStep extends PureComponent<OnboardingStepProps> {
+class CompletionStep extends PureComponent<Props> {
   public componentDidMount() {
     window.addEventListener('keydown', this.handleKeydown)
   }
@@ -59,7 +72,7 @@ class CompletionStep extends PureComponent<OnboardingStepProps> {
                         <ResourceFetcher<Dashboard[]> fetcher={getDashboards}>
                           {dashboards => (
                             <CompletionQuickStartButton
-                              onExit={onExit}
+                              onExit={this.handleQuickStart}
                               dashboards={dashboards}
                             />
                           )}
@@ -120,6 +133,21 @@ class CompletionStep extends PureComponent<OnboardingStepProps> {
         </div>
       </div>
     )
+  }
+
+  private handleQuickStart = async () => {
+    try {
+      await createScraperTarget(
+        QUICKSTART_SCRAPER_TARGET_URL,
+        this.props.orgID,
+        this.props.bucketID
+      )
+      this.props.notify(QuickstartScraperCreationSuccess)
+    } catch (err) {
+      this.props.notify(QuickstartScraperCreationError)
+    }
+
+    this.props.onExit()
   }
 
   private handleKeydown = (e: KeyboardEvent): void => {

--- a/ui/src/onboarding/components/OnboardingStepSwitcher.tsx
+++ b/ui/src/onboarding/components/OnboardingStepSwitcher.tsx
@@ -18,12 +18,20 @@ interface Props {
   setupParams: SetupParams
   currentStepIndex: number
   onSetupAdmin: typeof setupAdmin
+  orgID: string
+  bucketID: string
 }
 
 @ErrorHandling
 class OnboardingStepSwitcher extends PureComponent<Props> {
   public render() {
-    const {currentStepIndex, onboardingStepProps, onSetupAdmin} = this.props
+    const {
+      currentStepIndex,
+      orgID,
+      bucketID,
+      onboardingStepProps,
+      onSetupAdmin,
+    } = this.props
 
     switch (currentStepIndex) {
       case 0:
@@ -33,7 +41,13 @@ class OnboardingStepSwitcher extends PureComponent<Props> {
           <AdminStep {...onboardingStepProps} onSetupAdmin={onSetupAdmin} />
         )
       case 2:
-        return <CompletionStep {...onboardingStepProps} />
+        return (
+          <CompletionStep
+            {...onboardingStepProps}
+            orgID={orgID}
+            bucketID={bucketID}
+          />
+        )
       default:
         return <div />
     }

--- a/ui/src/onboarding/containers/OnboardingWizard.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizard.tsx
@@ -65,6 +65,8 @@ interface StateProps {
   links: Links
   stepStatuses: StepStatus[]
   setupParams: SetupParams
+  orgID: string
+  bucketID: string
 }
 
 type Props = OwnProps & StateProps & DispatchProps & WithRouterProps
@@ -80,7 +82,13 @@ class OnboardingWizard extends PureComponent<Props> {
   }
 
   public render() {
-    const {currentStepIndex, setupParams, onSetupAdmin} = this.props
+    const {
+      currentStepIndex,
+      orgID,
+      bucketID,
+      setupParams,
+      onSetupAdmin,
+    } = this.props
 
     return (
       <WizardFullScreen>
@@ -92,6 +100,8 @@ class OnboardingWizard extends PureComponent<Props> {
               onboardingStepProps={this.onboardingStepProps}
               setupParams={setupParams}
               onSetupAdmin={onSetupAdmin}
+              orgID={orgID}
+              bucketID={bucketID}
             />
           </div>
         </div>
@@ -162,11 +172,13 @@ class OnboardingWizard extends PureComponent<Props> {
 
 const mstp = ({
   links,
-  onboarding: {stepStatuses, setupParams},
+  onboarding: {stepStatuses, setupParams, orgID, bucketID},
 }: AppState): StateProps => ({
   links,
   stepStatuses,
   setupParams,
+  orgID,
+  bucketID,
 })
 
 const mdtp: DispatchProps = {

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -8,6 +8,7 @@ type NotificationExcludingMessage = Pick<
 >
 
 import {FIVE_SECONDS, TEN_SECONDS, INFINITE} from 'src/shared/constants/index'
+import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/logs/constants'
 
 const defaultErrorNotification: NotificationExcludingMessage = {
   type: 'error',
@@ -115,6 +116,16 @@ export const SigninSuccessful: Notification = {
 export const SigninError: Notification = {
   ...defaultErrorNotification,
   message: `Could not sign in`,
+}
+
+export const QuickstartScraperCreationSuccess: Notification = {
+  ...defaultSuccessNotification,
+  message: `The InfluxDB Scraper has been configured for ${QUICKSTART_SCRAPER_TARGET_URL}`,
+}
+
+export const QuickstartScraperCreationError: Notification = {
+  ...defaultErrorNotification,
+  message: `Failed to configure InfluxDB Scraper`,
 }
 
 export const TelegrafConfigCreationSuccess: Notification = {


### PR DESCRIPTION
Closes #11186

_Briefly describe your proposed changes:_
Create scraper with url of http://localhost:9999/metrics when clicking quick start in the completion step for the onboarding wizard.
Notifications for creating and error

  - [x] Rebased/mergeable
  - [ ] Tests pass
