### PR TITLE
 Cache metaqueries used in query builder

### DIFF
--- a/ui/src/shared/actions/v2/queryBuilder.ts
+++ b/ui/src/shared/actions/v2/queryBuilder.ts
@@ -1,8 +1,6 @@
 // APIs
 import {QueryBuilderFetcher} from 'src/shared/apis/v2/queryBuilder'
 
-import {bucketsAPI} from 'src/utils/api'
-
 // Utils
 import {
   getActiveQuerySource,
@@ -208,8 +206,8 @@ export const loadBuckets = () => async (
   dispatch(setBuilderBucketsStatus(RemoteDataState.Loading))
 
   try {
-    const {data} = await bucketsAPI.bucketsGet('')
-    const buckets = data.buckets.map(b => b.name)
+    const queryURL = getActiveQuerySource(getState()).links.query
+    const buckets = await fetcher.findBuckets(queryURL)
     const selectedBucket = getActiveQuery(getState()).builderConfig.buckets[0]
 
     dispatch(setBuilderBuckets(buckets))

--- a/ui/src/shared/actions/v2/queryBuilder.ts
+++ b/ui/src/shared/actions/v2/queryBuilder.ts
@@ -265,7 +265,15 @@ export const loadTagSelector = (index: number) => async (
     const {key} = tags[index]
 
     if (!key) {
-      dispatch(setBuilderTagKeySelection(index, keys[0]))
+      let defaultKey: string
+
+      if (index === 0 && keys.includes('_measurement')) {
+        defaultKey = '_measurement'
+      } else {
+        defaultKey = keys[0]
+      }
+
+      dispatch(setBuilderTagKeySelection(index, defaultKey))
     } else if (!keys.includes(key)) {
       // Even if the selected key didn't come back in the results, let it be
       // selected anyway

--- a/ui/src/shared/components/TagSelector.scss
+++ b/ui/src/shared/components/TagSelector.scss
@@ -37,10 +37,8 @@ button.tag-selector--remove {
 
 
 .tag-selector--empty {
-  position: absolute;
   pointer-events: none;
-  width: 100%;
-  height: 100%;
+  flex: 1 1 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -49,5 +47,5 @@ button.tag-selector--remove {
   font-size: 16px;
   text-transform: uppercase;
   text-align: center;
-  padding: $ix-marg-b + $ix-marg-a;
+  padding: 12px 12px 36px 12px;
 }


### PR DESCRIPTION
Closes #10800 

- Caches metaqueries used in the query builder. This avoids the awkward reloading when switching between different queries. Before/after:

   ![before](https://user-images.githubusercontent.com/638955/51417931-5c768a80-1b35-11e9-9652-1eb490b036fb.gif)

   ![after](https://user-images.githubusercontent.com/638955/51417932-5ed8e480-1b35-11e9-95a6-0ce0b8e27a93.gif)

- Tweaks alignment of the `TagSelector` empty state. Before/after:

   <img width="265" alt="screen shot 2019-01-18 at 2 12 29 pm" src="https://user-images.githubusercontent.com/638955/51417776-972bf300-1b34-11e9-8d94-f198b39337b0.png">

   <img width="263" alt="screen shot 2019-01-18 at 2 11 49 pm" src="https://user-images.githubusercontent.com/638955/51417782-9bf0a700-1b34-11e9-97aa-8b785ff6a495.png">


- Fixes an issue where the query builder would issue the following invalid metaquery:

  ```
  import "influxdata/influxdb/v1"

  v1.tagKeys(bucket: "a", predicate: (r) => , start: -30d)
    |> filter(fn: (r) => r._value != "_field")
    |> filter(fn: (r) =>
      r._value != "_time" and
      r._value != "_start" and
      r._value !=  "_stop" and
      r._value != "_value")
    |> distinct()
    |> limit(n: 200)
   ```

- Default first tag key selection to `_measurement` 

- Tweaks the formatting of issued metaqueries to aid in debugging