### PR TITLE
Remove procstat plugin from system bundles

### DIFF
--- a/ui/src/onboarding/constants/pluginConfigs.ts
+++ b/ui/src/onboarding/constants/pluginConfigs.ts
@@ -41,7 +41,6 @@ export const pluginsByBundle: PluginBundles = {
     TelegrafPluginInputMem.NameEnum.Mem,
     TelegrafPluginInputNet.NameEnum.Net,
     TelegrafPluginInputProcesses.NameEnum.Processes,
-    TelegrafPluginInputProcstat.NameEnum.Procstat,
   ],
   [BundleName.Docker]: [TelegrafPluginInputDocker.NameEnum.Docker],
   [BundleName.Kubernetes]: [TelegrafPluginInputKubernetes.NameEnum.Kubernetes],

--- a/ui/src/onboarding/reducers/dataLoaders.test.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.test.ts
@@ -33,7 +33,6 @@ import {
   netTelegrafPlugin,
   memTelegrafPlugin,
   processesTelegrafPlugin,
-  procstatTelegrafPlugin,
   systemTelegrafPlugin,
   redisTelegrafPlugin,
   token,
@@ -385,7 +384,6 @@ describe('dataLoader reducer', () => {
           netTelegrafPlugin,
           memTelegrafPlugin,
           processesTelegrafPlugin,
-          procstatTelegrafPlugin,
           systemTelegrafPlugin,
           dockerTelegrafPlugin,
         ],
@@ -490,7 +488,6 @@ describe('dataLoader reducer', () => {
         memTelegrafPlugin,
         netTelegrafPlugin,
         processesTelegrafPlugin,
-        procstatTelegrafPlugin,
       ])
     )
   })


### PR DESCRIPTION
Closes #11275

_Briefly describe your proposed changes:_
Removed procstat plugin from system bundles and updated tests

  - [x] Rebased/mergeable
  - [x] Tests pass
