### PR TITLE
fix(query): improve preauthorizer errors on unknown buckets

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -3,6 +3,7 @@ package influxdb
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -95,6 +96,26 @@ func (f BucketFilter) QueryParams() map[string][]string {
 	}
 
 	return qp
+}
+
+// String returns a human-readable string of the BucketFilter,
+// particularly useful for error messages.
+func (f BucketFilter) String() string {
+	// There should always be exactly 2 fields set, but if it's somehow more, that's fine.
+	parts := make([]string, 0, 2)
+	if f.ID != nil {
+		parts = append(parts, "Bucket ID: "+f.ID.String())
+	}
+	if f.Name != nil {
+		parts = append(parts, "Bucket Name: "+*f.Name)
+	}
+	if f.OrganizationID != nil {
+		parts = append(parts, "Org ID: "+f.OrganizationID.String())
+	}
+	if f.Organization != nil {
+		parts = append(parts, "Org Name: "+*f.Organization)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
 }
 
 // InternalBucketID returns the ID for an organization's specified internal bucket

--- a/query/preauthorizer.go
+++ b/query/preauthorizer.go
@@ -34,10 +34,10 @@ func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth 
 		return errors.Wrap(err, "could not retrieve buckets for query.Spec")
 	}
 
-	for _, readBucketItem := range readBuckets {
-		bucket, err := a.bucketService.FindBucket(ctx, readBucketItem)
+	for _, readBucketFilter := range readBuckets {
+		bucket, err := a.bucketService.FindBucket(ctx, readBucketFilter)
 		if err != nil {
-			return errors.Wrapf(err, "bucket does not exist")
+			return errors.Wrapf(err, "could not find read bucket with filter: %s", readBucketFilter)
 		}
 
 		if bucket == nil {
@@ -57,7 +57,7 @@ func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth 
 	for _, writeBucketFilter := range writeBuckets {
 		bucket, err := a.bucketService.FindBucket(ctx, writeBucketFilter)
 		if err != nil {
-			return errors.Wrapf(err, "could not find bucket %v", writeBucketFilter)
+			return errors.Wrapf(err, "could not find write bucket with filter: %s", writeBucketFilter)
 		}
 
 		reqPerm, err := platform.NewPermissionAtID(bucket.ID, platform.WriteAction, platform.BucketsResourceType, bucket.OrganizationID)


### PR DESCRIPTION
When trying to create a task that writes to an unknown bucket,
previously the error message would resemble:

could not find bucket {<nil> 0xc0000dfcc0 <nil> 0xc0000dfce0}: <not found> bucket not found

Now print something human-readable:

could not find write bucket with filter: [Bucket Name: b, Org Name: a]: <not found> bucket not found