### PR TITLE
fix(task): use formal errors during task creation

### DIFF
--- a/task/options/options.go
+++ b/task/options/options.go
@@ -85,7 +85,7 @@ func FromScript(script string) (Options, error) {
 	// pull options from the program scope
 	task, ok := scope.Lookup("task")
 	if !ok {
-		return opt, errors.New("task not defined")
+		return opt, errors.New("missing required option: 'task'")
 	}
 	optObject := task.Object()
 	nameVal, ok := optObject.Get("name")


### PR DESCRIPTION
The client expects influxdb.Error, so use them on the server.

Also clarify the message when the task option is missing.