### PR TITLE
fix(tsi1): update units to nanoseconds

### DIFF
--- a/tsdb/tsi1/partition.go
+++ b/tsdb/tsi1/partition.go
@@ -1343,7 +1343,7 @@ func (t *partitionTracker) AddSeriesCreated(n uint64, d time.Duration) {
 		return // Nothing to record
 	}
 
-	perseries := d.Seconds() / float64(n)
+	perseries := float64(d.Nanoseconds()) / float64(n)
 	t.metrics.SeriesCreatedDuration.With(labels).Observe(perseries)
 }
 


### PR DESCRIPTION
_Briefly describe your proposed changes:_

The units for the metric `storage_series_file_index_get_duration_ns_bucket` should
be nanoseconds; previously, it was seconds.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
