### PR TITLE
feat(http): use default prom histogram buckets

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -198,8 +198,6 @@ func (h *Handler) initMetrics() {
 		Subsystem: handlerSubsystem,
 		Name:      "request_duration_seconds",
 		Help:      "Time taken to respond to HTTP request",
-		// TODO(desa): determine what spacing these buckets should have.
-		Buckets: prometheus.ExponentialBuckets(0.001, 1.5, 25),
 	}, []string{"handler", "method", "path", "status"})
 }
 


### PR DESCRIPTION
_Briefly describe your proposed changes:_
The API response time buckets had a fairly broad range.  I'm thinking we could narrow down the range.

Old:

```
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.001"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.0015"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.0022500000000000003"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.0033750000000000004"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.005062500000000001"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.0075937500000000015"} 1
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.011390625000000001"} 1
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.017085937500000002"} 2
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.025628906250000003"} 3
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.03844335937500001"} 4
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.057665039062500006"} 5
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.08649755859375001"} 5
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.129746337890625"} 6
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.1946195068359375"} 6
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.29192926025390625"} 6
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.43789389038085935"} 6
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.656840835571289"} 6
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.9852612533569336"} 6
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="1.4778918800354004"} 7
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="2.2168378200531005"} 7
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="3.3252567300796505"} 7
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="4.987885095119475"} 7
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="7.481827642679213"} 7
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="11.222741464018819"} 7
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="16.83411219602823"} 7
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="+Inf"} 7
```

New:

```
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.005"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.01"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.025"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.05"} 0
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.1"} 1
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.25"} 1
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="0.5"} 1
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="1"} 2
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="2.5"} 2
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="5"} 2
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="10"} 2
http_api_request_duration_seconds_bucket{handler="platform",method="POST",path="/api/v2/query",status="2XX",le="+Inf"} 2
```

@desa What do you think?

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
