### PR TITLE
fix(bolt): create user mapping after bucket is created

### DIFF
--- a/bolt/onboarding.go
+++ b/bolt/onboarding.go
@@ -106,15 +106,16 @@ func (c *Client) Generate(ctx context.Context, req *platform.OnboardingRequest) 
 		OrganizationID:  o.ID,
 		RetentionPeriod: time.Duration(req.RetentionPeriod) * time.Hour,
 	}
+	if err = c.CreateBucket(ctx, bucket); err != nil {
+		return nil, err
+	}
+
 	if err := c.CreateUserResourceMapping(ctx, &platform.UserResourceMapping{
 		ResourceType: platform.OrgsResourceType,
 		ResourceID:   o.ID,
 		UserID:       u.ID,
 		UserType:     platform.Owner,
 	}); err != nil {
-		return nil, err
-	}
-	if err = c.CreateBucket(ctx, bucket); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
When adding a org owner, the `UserResourceMappingService` add the owner to org's buckets:

https://github.com/influxdata/influxdb/blob/02cc100b4f56eaefabc521eba96fb1c12e5b75f1/bolt/user_resource_mapping.go#L81-L93

https://github.com/influxdata/influxdb/blob/02cc100b4f56eaefabc521eba96fb1c12e5b75f1/bolt/user_resource_mapping.go#L120-L140

---

_Briefly describe your proposed changes:_
In `OnboardingService.Generate` , Add a org owner after the org's bucket is created.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
