### PR TITLE
Authorize secrets

### DIFF
--- a/authorizer/secret.go
+++ b/authorizer/secret.go
@@ -1,0 +1,142 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.SecretService = (*SecretService)(nil)
+
+// SecretService wraps a influxdb.SecretService and authorizes actions
+// against it appropriately.
+type SecretService struct {
+	s influxdb.SecretService
+}
+
+// NewSecretService constructs an instance of an authorizing secret serivce.
+func NewSecretService(s influxdb.SecretService) *SecretService {
+	return &SecretService{
+		s: s,
+	}
+}
+
+func newSecretPermission(a influxdb.Action, orgID influxdb.ID) (*influxdb.Permission, error) {
+	return influxdb.NewPermission(a, influxdb.SecretsResourceType, orgID)
+}
+
+func authorizeReadSecret(ctx context.Context, orgID influxdb.ID) error {
+	p, err := newSecretPermission(influxdb.ReadAction, orgID)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func authorizeWriteSecret(ctx context.Context, orgID influxdb.ID) error {
+	p, err := newSecretPermission(influxdb.WriteAction, orgID)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LoadSecret checks to see if the authorizer on context has read access to the secret key provided.
+func (s *SecretService) LoadSecret(ctx context.Context, orgID influxdb.ID, key string) (string, error) {
+	secret, err := s.s.LoadSecret(ctx, orgID, key)
+	if err != nil {
+		return "", err
+	}
+
+	if err := authorizeReadSecret(ctx, orgID); err != nil {
+		return "", err
+	}
+
+	return secret, nil
+}
+
+// GetSecretKeys checks to see if the authorizer on context has read access to all the secrets belonging to orgID.
+func (s *SecretService) GetSecretKeys(ctx context.Context, orgID influxdb.ID) ([]string, error) {
+	secrets, err := s.s.GetSecretKeys(ctx, orgID)
+	if err != nil {
+		return []string{}, err
+	}
+
+	if err := authorizeReadSecret(ctx, orgID); err != nil {
+		return []string{}, err
+	}
+
+	return secrets, nil
+}
+
+// PutSecret checks to see if the authorizer on context has write access to the secret key provided.
+func (s *SecretService) PutSecret(ctx context.Context, orgID influxdb.ID, key string, val string) error {
+	if err := authorizeWriteSecret(ctx, orgID); err != nil {
+		return err
+	}
+
+	err := s.s.PutSecret(ctx, orgID, key, val)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PutSecrets checks to see if the authorizer on context has read and write access to the secret keys provided.
+func (s *SecretService) PutSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
+	// PutSecrets operates on intersection betwen m and keys beloging to orgID.
+	// We need to have read access to those secrets since it deletes the secrets (within the intersection) that have not be overridden.
+	if err := authorizeReadSecret(ctx, orgID); err != nil {
+		return err
+	}
+
+	if err := authorizeWriteSecret(ctx, orgID); err != nil {
+		return err
+	}
+
+	err := s.s.PutSecrets(ctx, orgID, m)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PatchSecrets checks to see if the authorizer on context has write access to the secret keys provided.
+func (s *SecretService) PatchSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
+	if err := authorizeWriteSecret(ctx, orgID); err != nil {
+		return err
+	}
+
+	err := s.s.PatchSecrets(ctx, orgID, m)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteSecret checks to see if the authorizer on context has write access to the secret keys provided.
+func (s *SecretService) DeleteSecret(ctx context.Context, orgID influxdb.ID, keys ...string) error {
+	if err := authorizeWriteSecret(ctx, orgID); err != nil {
+		return err
+	}
+
+	err := s.s.DeleteSecret(ctx, orgID, keys...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/authorizer/secret.go
+++ b/authorizer/secret.go
@@ -53,12 +53,12 @@ func authorizeWriteSecret(ctx context.Context, orgID influxdb.ID) error {
 
 // LoadSecret checks to see if the authorizer on context has read access to the secret key provided.
 func (s *SecretService) LoadSecret(ctx context.Context, orgID influxdb.ID, key string) (string, error) {
-	secret, err := s.s.LoadSecret(ctx, orgID, key)
-	if err != nil {
+	if err := authorizeReadSecret(ctx, orgID); err != nil {
 		return "", err
 	}
 
-	if err := authorizeReadSecret(ctx, orgID); err != nil {
+	secret, err := s.s.LoadSecret(ctx, orgID, key)
+	if err != nil {
 		return "", err
 	}
 
@@ -67,12 +67,12 @@ func (s *SecretService) LoadSecret(ctx context.Context, orgID influxdb.ID, key s
 
 // GetSecretKeys checks to see if the authorizer on context has read access to all the secrets belonging to orgID.
 func (s *SecretService) GetSecretKeys(ctx context.Context, orgID influxdb.ID) ([]string, error) {
-	secrets, err := s.s.GetSecretKeys(ctx, orgID)
-	if err != nil {
+	if err := authorizeReadSecret(ctx, orgID); err != nil {
 		return []string{}, err
 	}
 
-	if err := authorizeReadSecret(ctx, orgID); err != nil {
+	secrets, err := s.s.GetSecretKeys(ctx, orgID)
+	if err != nil {
 		return []string{}, err
 	}
 

--- a/authorizer/secret_test.go
+++ b/authorizer/secret_test.go
@@ -1,0 +1,279 @@
+package authorizer_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+var secretCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+}
+
+func TestSecretService_LoadSecret(t *testing.T) {
+	type fields struct {
+		SecretService influxdb.SecretService
+	}
+	type args struct {
+		permission influxdb.Permission
+		org        influxdb.ID
+		key        string
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access secret within org",
+			fields: fields{
+				SecretService: &mock.SecretService{
+					LoadSecretFn: func(ctx context.Context, orgID influxdb.ID, k string) (string, error) {
+						if k == "key" {
+							return "val", nil
+						}
+						return "", &influxdb.Error{
+							Code: influxdb.ENotFound,
+							Msg:  influxdb.ErrSecretNotFound,
+						}
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.SecretsResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+				key: "key",
+				org: influxdb.ID(10),
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "cannot access not existing secret",
+			fields: fields{
+				SecretService: &mock.SecretService{
+					LoadSecretFn: func(ctx context.Context, orgID influxdb.ID, k string) (string, error) {
+						if k == "key" {
+							return "val", nil
+						}
+						return "", &influxdb.Error{
+							Code: influxdb.ENotFound,
+							Msg:  influxdb.ErrSecretNotFound,
+						}
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.SecretsResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+				key: "not existing",
+				org: influxdb.ID(10),
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Msg:  influxdb.ErrSecretNotFound,
+				},
+			},
+		},
+		{
+			name: "unauthorized to access secret within org",
+			fields: fields{
+				SecretService: &mock.SecretService{
+					LoadSecretFn: func(ctx context.Context, orgID influxdb.ID, k string) (string, error) {
+						if k == "key" {
+							return "val", nil
+						}
+						return "", &influxdb.Error{
+							Code: influxdb.ENotFound,
+							Msg:  influxdb.ErrSecretNotFound,
+						}
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.SecretsResourceType,
+						ID:   influxdbtesting.IDPtr(10),
+					},
+				},
+				org: influxdb.ID(2),
+				key: "key",
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:orgs/0000000000000002/secrets is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewSecretService(tt.fields.SecretService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			_, err := s.LoadSecret(ctx, tt.args.org, tt.args.key)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestSecretService_GetSecretKeys(t *testing.T) {
+	type fields struct {
+		SecretService influxdb.SecretService
+	}
+	type args struct {
+		permission influxdb.Permission
+		org        influxdb.ID
+	}
+	type wants struct {
+		err     error
+		secrets []string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to see all secrets within an org",
+			fields: fields{
+				SecretService: &mock.SecretService{
+					GetSecretKeysFn: func(ctx context.Context, orgID influxdb.ID) ([]string, error) {
+						return []string{
+							"0000000000000001secret1",
+							"0000000000000001secret2",
+							"0000000000000001secret3",
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.SecretsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+					},
+				},
+				org: influxdb.ID(1),
+			},
+			wants: wants{
+				secrets: []string{
+					"0000000000000001secret1",
+					"0000000000000001secret2",
+					"0000000000000001secret3",
+				},
+			},
+		},
+		{
+			name: "unauthorized to see all secrets within an org",
+			fields: fields{
+				SecretService: &mock.SecretService{
+					GetSecretKeysFn: func(ctx context.Context, orgID influxdb.ID) ([]string, error) {
+						return []string{
+							"0000000000000002secret1",
+							"0000000000000002secret2",
+							"0000000000000002secret3",
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.SecretsResourceType,
+						OrgID: influxdbtesting.IDPtr(1),
+					},
+				},
+				org: influxdb.ID(2),
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.EUnauthorized,
+					Msg:  "read:orgs/0000000000000002/secrets is unauthorized",
+				},
+				secrets: []string{},
+			},
+		},
+		{
+			name: "errors when there are not secret into an org",
+			fields: fields{
+				SecretService: &mock.SecretService{
+					GetSecretKeysFn: func(ctx context.Context, orgID influxdb.ID) ([]string, error) {
+						return []string(nil), &influxdb.Error{
+							Code: influxdb.ENotFound,
+							Msg:  "organization has no secret keys",
+						}
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type:  influxdb.SecretsResourceType,
+						OrgID: influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Msg:  "organization has no secret keys",
+				},
+				secrets: []string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewSecretService(tt.fields.SecretService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			secrets, err := s.GetSecretKeys(ctx, tt.args.org)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+
+			if diff := cmp.Diff(secrets, tt.wants.secrets, secretCmpOptions...); diff != "" {
+				t.Errorf("secrets are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}

--- a/authorizer/secret_test.go
+++ b/authorizer/secret_test.go
@@ -250,6 +250,7 @@ func TestSecretService_GetSecretKeys(t *testing.T) {
 						OrgID: influxdbtesting.IDPtr(10),
 					},
 				},
+				org: influxdb.ID(10),
 			},
 			wants: wants{
 				err: &influxdb.Error{

--- a/authz.go
+++ b/authz.go
@@ -115,7 +115,7 @@ const (
 	MacrosResourceType = ResourceType("macros") // 8
 	// ScraperResourceType gives permission to one or more scrapers.
 	ScraperResourceType = ResourceType("scrapers") // 9
-	// SecretsResourceType gives permission to one or more scrapers.
+	// SecretsResourceType gives permission to one or more secrets.
 	SecretsResourceType = ResourceType("secrets") // 10
 )
 

--- a/authz.go
+++ b/authz.go
@@ -115,6 +115,8 @@ const (
 	MacrosResourceType = ResourceType("macros") // 8
 	// ScraperResourceType gives permission to one or more scrapers.
 	ScraperResourceType = ResourceType("scrapers") // 9
+	// SecretsResourceType gives permission to one or more scrapers.
+	SecretsResourceType = ResourceType("secrets") // 10
 )
 
 // AllResourceTypes is the list of all known resource types.
@@ -129,6 +131,7 @@ var AllResourceTypes = []ResourceType{
 	UsersResourceType,          // 7
 	MacrosResourceType,         // 8
 	ScraperResourceType,        // 9
+	SecretsResourceType,        // 10
 }
 
 // OrgResourceTypes is the list of all known resource types that belong to an organization.
@@ -140,6 +143,7 @@ var OrgResourceTypes = []ResourceType{
 	TelegrafsResourceType,  // 6
 	UsersResourceType,      // 7
 	MacrosResourceType,     // 8
+	SecretsResourceType,    // 10
 }
 
 // Valid checks if the resource type is a member of the ResourceType enum.
@@ -160,6 +164,7 @@ func (t ResourceType) Valid() (err error) {
 	case UsersResourceType: // 7
 	case MacrosResourceType: // 8
 	case ScraperResourceType: // 9
+	case SecretsResourceType: // 10
 	default:
 		err = ErrInvalidResourceType
 	}

--- a/secret.go
+++ b/secret.go
@@ -2,6 +2,9 @@ package influxdb
 
 import "context"
 
+// ErrSecretNotFound is the error msg for a missing secret.
+const ErrSecretNotFound = "secret not found"
+
 // SecretService a service for storing and retrieving secrets.
 type SecretService interface {
 	// LoadSecret retrieves the secret value v found at key k for organization orgID.


### PR DESCRIPTION
Closes #11283 

_Briefly describe your proposed changes:_

This PR introduces a secrets service for authorizing requests.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
