### PR TITLE
Labels authorizer

### DIFF
--- a/authorizer/label.go
+++ b/authorizer/label.go
@@ -1,0 +1,163 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.LabelService = (*LabelService)(nil)
+
+// LabelService wraps a influxdb.LabelService and authorizes actions
+// against it appropriately.
+type LabelService struct {
+	s influxdb.LabelService
+}
+
+// NewLabelService constructs an instance of an authorizing label serivce.
+func NewLabelService(s influxdb.LabelService) *LabelService {
+	return &LabelService{
+		s: s,
+	}
+}
+
+func newLabelPermission(a influxdb.Action, id influxdb.ID) (*influxdb.Permission, error) {
+	p := &influxdb.Permission{
+		Action: a,
+		Resource: influxdb.Resource{
+			Type: influxdb.LabelsResourceType,
+			ID:   &id,
+		},
+	}
+
+	return p, p.Valid()
+}
+
+func authorizeReadLabel(ctx context.Context, id influxdb.ID) error {
+	p, err := newLabelPermission(influxdb.ReadAction, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func authorizeWriteLabel(ctx context.Context, id influxdb.ID) error {
+	p, err := newLabelPermission(influxdb.WriteAction, id)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// FindLabelByID checks to see if the authorizer on context has read access to the label id provided.
+func (s *LabelService) FindLabelByID(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
+	if err := authorizeReadLabel(ctx, id); err != nil {
+		return nil, err
+	}
+
+	l, err := s.s.FindLabelByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+// FindLabels retrieves all labels that match the provided filter and then filters the list down to only the resources that are authorized.
+func (s *LabelService) FindLabels(ctx context.Context, filter influxdb.LabelFilter, opt ...influxdb.FindOptions) ([]*influxdb.Label, error) {
+	// TODO: we'll likely want to push this operation into the database eventually since fetching the whole list of data
+	// will likely be expensive.
+	ls, err := s.s.FindLabels(ctx, filter, opt...)
+	if err != nil {
+		return nil, err
+	}
+
+	// This filters without allocating
+	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
+	labels := ls[:0]
+	for _, l := range ls {
+		err := authorizeReadLabel(ctx, l.ID)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
+			return nil, err
+		}
+
+		if influxdb.ErrorCode(err) == influxdb.EUnauthorized {
+			continue
+		}
+
+		labels = append(labels, l)
+	}
+
+	return labels, nil
+}
+
+func (s *LabelService) FindResourceLabels(ctx context.Context, filter influxdb.LabelMappingFilter) ([]*influxdb.Label, error) {
+	panic("tbd")
+}
+
+// CreateLabel checks to see if the authorizer on context has write access to the global labels resource.
+func (s *LabelService) CreateLabel(ctx context.Context, l *influxdb.Label) error {
+	p, err := influxdb.NewGlobalPermission(influxdb.WriteAction, influxdb.LabelsResourceType)
+	if err != nil {
+		return err
+	}
+
+	if err := IsAllowed(ctx, *p); err != nil {
+		return err
+	}
+
+	return s.s.CreateLabel(ctx, l)
+}
+
+// CreateLabelMapping checks to see if the authorizer on context has write access to
+func (s *LabelService) CreateLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
+	// note(leodido) > LabelMapping does not have its own ID
+	if err := authorizeWriteLabel(ctx, *m.LabelID); err != nil {
+		return err
+	}
+
+	// todo(leodido) > do we have/want to check also m.ResourceID write permission?
+	panic("tbd")
+}
+
+// UpdateLabel checks to see if the authorizer on context has write access to the label provided.
+func (s *LabelService) UpdateLabel(ctx context.Context, id influxdb.ID, upd influxdb.LabelUpdate) (*influxdb.Label, error) {
+	_, err := s.s.FindLabelByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := authorizeWriteLabel(ctx, id); err != nil {
+		return nil, err
+	}
+
+	return s.s.UpdateLabel(ctx, id, upd)
+}
+
+// DeleteLabel checks to see if the authorizer on context has write access to the label provided.
+func (s *LabelService) DeleteLabel(ctx context.Context, id influxdb.ID) error {
+	_, err := s.s.FindLabelByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := authorizeWriteLabel(ctx, id); err != nil {
+		return err
+	}
+
+	return s.s.DeleteLabel(ctx, id)
+}
+
+func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
+	panic("tbd")
+}

--- a/authorizer/label.go
+++ b/authorizer/label.go
@@ -148,7 +148,7 @@ func (s *LabelService) CreateLabel(ctx context.Context, l *influxdb.Label) error
 	return s.s.CreateLabel(ctx, l)
 }
 
-// CreateLabelMapping checks to see if the authorizer on context has write access to
+// CreateLabelMapping checks to see if the authorizer on context has write access to the label and the resource contained by the label mapping in creation.
 func (s *LabelService) CreateLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
 	if err := authorizeWriteLabel(ctx, m.LabelID); err != nil {
 		return err
@@ -189,6 +189,20 @@ func (s *LabelService) DeleteLabel(ctx context.Context, id influxdb.ID) error {
 	return s.s.DeleteLabel(ctx, id)
 }
 
+// DeleteLabelMapping checks to see if the authorizer on context has write access to the label and the resource of the label mapping to delete.
 func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
-	panic("tbd")
+	_, err := s.s.FindLabelByID(ctx, m.LabelID)
+	if err != nil {
+		return err
+	}
+
+	if err := authorizeWriteLabel(ctx, m.LabelID); err != nil {
+		return err
+	}
+
+	if err := authorizeLabelMappingAction(ctx, influxdb.WriteAction, m.ResourceID, m.ResourceType); err != nil {
+		return err
+	}
+
+	return s.s.DeleteLabelMapping(ctx, m)
 }

--- a/authorizer/label_test.go
+++ b/authorizer/label_test.go
@@ -1,0 +1,533 @@
+package authorizer_test
+
+import (
+	"bytes"
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+var labelCmpOptions = cmp.Options{
+	cmp.Comparer(func(x, y []byte) bool {
+		return bytes.Equal(x, y)
+	}),
+	cmp.Transformer("Sort", func(in []*influxdb.Label) []*influxdb.Label {
+		out := append([]*influxdb.Label(nil), in...) // Copy input to avoid mutating it
+		sort.Slice(out, func(i, j int) bool {
+			return out[i].ID.String() > out[j].ID.String()
+		})
+		return out
+	}),
+}
+
+func TestLabelService_FindLabelByID(t *testing.T) {
+	type fields struct {
+		LabelService influxdb.LabelService
+	}
+	type args struct {
+		permission influxdb.Permission
+		id         influxdb.ID
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to access id",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID: id,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.LabelsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to access id",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID: id,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.LabelsResourceType,
+						ID:   influxdbtesting.IDPtr(2),
+					},
+				},
+				id: 1,
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "read:labels/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewLabelService(tt.fields.LabelService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			_, err := s.FindLabelByID(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestLabelService_FindLabels(t *testing.T) {
+	type fields struct {
+		LabelService influxdb.LabelService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err    error
+		labels []*influxdb.Label
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to see all labels",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelsFn: func(ctx context.Context, filter influxdb.LabelFilter) ([]*influxdb.Label, error) {
+						return []*influxdb.Label{
+							{
+								ID: 1,
+							},
+							{
+								ID: 2,
+							},
+							{
+								ID: 3,
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.LabelsResourceType,
+					},
+				},
+			},
+			wants: wants{
+				labels: []*influxdb.Label{
+					{
+						ID: 1,
+					},
+					{
+						ID: 2,
+					},
+					{
+						ID: 3,
+					},
+				},
+			},
+		},
+		{
+			name: "authorized to access a single label",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelsFn: func(ctx context.Context, filter influxdb.LabelFilter) ([]*influxdb.Label, error) {
+						return []*influxdb.Label{
+							{
+								ID: 1,
+							},
+							{
+								ID: 2,
+							},
+							{
+								ID: 3,
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.LabelsResourceType,
+						ID:   influxdbtesting.IDPtr(1),
+					},
+				},
+			},
+			wants: wants{
+				labels: []*influxdb.Label{
+					{
+						ID: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "unable to access labels",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelsFn: func(ctx context.Context, filter influxdb.LabelFilter) ([]*influxdb.Label, error) {
+						return []*influxdb.Label{
+							{
+								ID: 1,
+							},
+							{
+								ID: 2,
+							},
+							{
+								ID: 3,
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.LabelsResourceType,
+						ID:   influxdbtesting.IDPtr(10),
+					},
+				},
+			},
+			wants: wants{
+				// fixme(leodido) > should we return error in this case?
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewLabelService(tt.fields.LabelService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			labels, err := s.FindLabels(ctx, influxdb.LabelFilter{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+
+			if diff := cmp.Diff(labels, tt.wants.labels, labelCmpOptions...); diff != "" {
+				t.Errorf("labels are different -got/+want\ndiff %s", diff)
+			}
+		})
+	}
+}
+
+func TestLabelService_UpdateLabel(t *testing.T) {
+	type fields struct {
+		LabelService influxdb.LabelService
+	}
+	type args struct {
+		id          influxdb.ID
+		permissions []influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to update label",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID: 1,
+						}, nil
+					},
+					UpdateLabelFn: func(ctx context.Context, id influxdb.ID, upd influxdb.LabelUpdate) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "write",
+						Resource: influxdb.Resource{
+							Type: influxdb.LabelsResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to update label",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID: 1,
+						}, nil
+					},
+					UpdateLabelFn: func(ctx context.Context, id influxdb.ID, upd influxdb.LabelUpdate) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID: 1,
+						}, nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.LabelsResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:labels/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewLabelService(tt.fields.LabelService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
+
+			_, err := s.UpdateLabel(ctx, tt.args.id, influxdb.LabelUpdate{})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestLabelService_DeleteLabel(t *testing.T) {
+	type fields struct {
+		LabelService influxdb.LabelService
+	}
+	type args struct {
+		id          influxdb.ID
+		permissions []influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to delete label",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID: 1,
+						}, nil
+					},
+					DeleteLabelFn: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "write",
+						Resource: influxdb.Resource{
+							Type: influxdb.LabelsResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to delete label",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID: 1,
+						}, nil
+					},
+					DeleteLabelFn: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				id: 1,
+				permissions: []influxdb.Permission{
+					{
+						Action: "read",
+						Resource: influxdb.Resource{
+							Type: influxdb.LabelsResourceType,
+							ID:   influxdbtesting.IDPtr(1),
+						},
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:labels/0000000000000001 is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewLabelService(tt.fields.LabelService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
+
+			err := s.DeleteLabel(ctx, tt.args.id)
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}
+
+func TestLabelService_CreateLabel(t *testing.T) {
+	type fields struct {
+		LabelService influxdb.LabelService
+	}
+	type args struct {
+		permission influxdb.Permission
+	}
+	type wants struct {
+		err error
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "authorized to create label",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					CreateLabelFn: func(ctx context.Context, b *influxdb.Label) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "write",
+					Resource: influxdb.Resource{
+						Type: influxdb.LabelsResourceType,
+					},
+				},
+			},
+			wants: wants{
+				err: nil,
+			},
+		},
+		{
+			name: "unauthorized to create label",
+			fields: fields{
+				LabelService: &mock.LabelService{
+					CreateLabelFn: func(ctx context.Context, b *influxdb.Label) error {
+						return nil
+					},
+				},
+			},
+			args: args{
+				permission: influxdb.Permission{
+					Action: "read",
+					Resource: influxdb.Resource{
+						Type: influxdb.LabelsResourceType,
+					},
+				},
+			},
+			wants: wants{
+				err: &influxdb.Error{
+					Msg:  "write:labels is unauthorized",
+					Code: influxdb.EUnauthorized,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := authorizer.NewLabelService(tt.fields.LabelService)
+
+			ctx := context.Background()
+			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
+
+			err := s.CreateLabel(ctx, &influxdb.Label{Name: "name"})
+			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
+		})
+	}
+}

--- a/authz.go
+++ b/authz.go
@@ -117,6 +117,8 @@ const (
 	ScraperResourceType = ResourceType("scrapers") // 9
 	// SecretsResourceType gives permission to one or more secrets.
 	SecretsResourceType = ResourceType("secrets") // 10
+	// LabelsResourceType gives permission to one or more labels.
+	LabelsResourceType = ResourceType("labels") // 11
 )
 
 // AllResourceTypes is the list of all known resource types.
@@ -132,6 +134,7 @@ var AllResourceTypes = []ResourceType{
 	MacrosResourceType,         // 8
 	ScraperResourceType,        // 9
 	SecretsResourceType,        // 10
+	LabelsResourceType,         // 11
 }
 
 // OrgResourceTypes is the list of all known resource types that belong to an organization.
@@ -165,6 +168,7 @@ func (t ResourceType) Valid() (err error) {
 	case MacrosResourceType: // 8
 	case ScraperResourceType: // 9
 	case SecretsResourceType: // 10
+	case LabelsResourceType: // 11
 	default:
 		err = ErrInvalidResourceType
 	}

--- a/bolt/label.go
+++ b/bolt/label.go
@@ -184,7 +184,7 @@ func (c *Client) FindResourceLabels(ctx context.Context, filter influxdb.LabelMa
 
 // CreateLabelMapping creates a new mapping between a resource and a label.
 func (c *Client) CreateLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
-	_, err := c.FindLabelByID(ctx, *m.LabelID)
+	_, err := c.FindLabelByID(ctx, m.LabelID)
 	if err != nil {
 		return &influxdb.Error{
 			Err: err,

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -359,7 +359,7 @@ func newPostLabelHandler(s platform.LabelService) http.HandlerFunc {
 			return
 		}
 
-		label, err := s.FindLabelByID(ctx, *req.Mapping.LabelID)
+		label, err := s.FindLabelByID(ctx, req.Mapping.LabelID)
 		if err != nil {
 			EncodeError(ctx, err, w)
 			return
@@ -396,7 +396,7 @@ func decodePostLabelMappingRequest(ctx context.Context, r *http.Request) (*postL
 		return nil, err
 	}
 
-	mapping.ResourceID = &rid
+	mapping.ResourceID = rid
 
 	if err := mapping.Validate(); err != nil {
 		return nil, err
@@ -421,8 +421,8 @@ func newDeleteLabelHandler(s platform.LabelService) http.HandlerFunc {
 		}
 
 		mapping := &platform.LabelMapping{
-			LabelID:    &req.LabelID,
-			ResourceID: &req.ResourceID,
+			LabelID:    req.LabelID,
+			ResourceID: req.ResourceID,
 		}
 
 		if err := s.DeleteLabelMapping(ctx, mapping); err != nil {
@@ -592,7 +592,7 @@ func (s *LabelService) CreateLabelMapping(ctx context.Context, m *platform.Label
 		return err
 	}
 
-	url, err := newURL(s.Addr, resourceIDPath(s.BasePath, *m.ResourceID))
+	url, err := newURL(s.Addr, resourceIDPath(s.BasePath, m.ResourceID))
 	if err != nil {
 		return err
 	}
@@ -692,7 +692,7 @@ func (s *LabelService) DeleteLabel(ctx context.Context, id platform.ID) error {
 }
 
 func (s *LabelService) DeleteLabelMapping(ctx context.Context, m *platform.LabelMapping) error {
-	url, err := newURL(s.Addr, labelNamePath(s.BasePath, *m.ResourceID, *m.LabelID))
+	url, err := newURL(s.Addr, labelNamePath(s.BasePath, m.ResourceID, m.LabelID))
 	if err != nil {
 		return err
 	}

--- a/http/label_test.go
+++ b/http/label_test.go
@@ -201,7 +201,7 @@ func TestService_handleGetLabel(t *testing.T) {
 					FindLabelByIDFn: func(ctx context.Context, id platform.ID) (*platform.Label, error) {
 						return nil, &platform.Error{
 							Code: platform.ENotFound,
-							Msg:  "label not found",
+							Err:  platform.ErrLabelNotFound,
 						}
 					},
 				},
@@ -383,7 +383,7 @@ func TestService_handleDeleteLabel(t *testing.T) {
 					DeleteLabelFn: func(ctx context.Context, id platform.ID) error {
 						return &platform.Error{
 							Code: platform.ENotFound,
-							Msg:  "label not found",
+							Err:  platform.ErrLabelNotFound,
 						}
 					},
 				},
@@ -516,7 +516,7 @@ func TestService_handlePatchLabel(t *testing.T) {
 					UpdateLabelFn: func(ctx context.Context, id platform.ID, upd platform.LabelUpdate) (*platform.Label, error) {
 						return nil, &platform.Error{
 							Code: platform.ENotFound,
-							Msg:  "label not found",
+							Err:  platform.ErrLabelNotFound,
 						}
 					},
 				},

--- a/inmem/label_service.go
+++ b/inmem/label_service.go
@@ -129,7 +129,7 @@ func (s *Service) FindResourceLabels(ctx context.Context, filter influxdb.LabelM
 
 	ls := []*influxdb.Label{}
 	for _, m := range mappings {
-		l, err := s.FindLabelByID(ctx, *m.LabelID)
+		l, err := s.FindLabelByID(ctx, m.LabelID)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +149,7 @@ func (s *Service) CreateLabel(ctx context.Context, l *influxdb.Label) error {
 
 // CreateLabelMapping creates a mapping that associates a label to a resource.
 func (s *Service) CreateLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
-	_, err := s.FindLabelByID(ctx, *m.LabelID)
+	_, err := s.FindLabelByID(ctx, m.LabelID)
 	if err != nil {
 		return &influxdb.Error{
 			Err: err,

--- a/label.go
+++ b/label.go
@@ -67,16 +67,26 @@ func (l *Label) Validate() error {
 // LabelMapping is used to map resource to its labels.
 // It should not be shared directly over the HTTP API.
 type LabelMapping struct {
-	LabelID    *ID `json:"labelID"`
-	ResourceID *ID
+	LabelID    ID `json:"labelID"`
+	ResourceID ID
+	ResourceType
 }
 
 // Validate returns an error if the mapping is invalid.
 func (l *LabelMapping) Validate() error {
+
+	// todo(leodido) > check LabelID is valid too?
+
 	if !l.ResourceID.Valid() {
 		return &Error{
 			Code: EInvalid,
 			Msg:  "resourceID is required",
+		}
+	}
+	if err := l.ResourceType.Valid(); err != nil {
+		return &Error{
+			Code: EInvalid,
+			Err:  err,
 		}
 	}
 

--- a/label.go
+++ b/label.go
@@ -67,20 +67,23 @@ func (l *Label) Validate() error {
 // LabelMapping is used to map resource to its labels.
 // It should not be shared directly over the HTTP API.
 type LabelMapping struct {
-	LabelID    ID `json:"labelID"`
-	ResourceID ID
-	ResourceType
+	LabelID      ID `json:"labelID"`
+	ResourceID   ID `json:"resourceID"`
+	ResourceType `json:"resourceType"`
 }
 
 // Validate returns an error if the mapping is invalid.
 func (l *LabelMapping) Validate() error {
-
-	// todo(leodido) > check LabelID is valid too?
-
+	if !l.LabelID.Valid() {
+		return &Error{
+			Code: EInvalid,
+			Msg:  "label id is required",
+		}
+	}
 	if !l.ResourceID.Valid() {
 		return &Error{
 			Code: EInvalid,
-			Msg:  "resourceID is required",
+			Msg:  "resource id is required",
 		}
 	}
 	if err := l.ResourceType.Valid(); err != nil {

--- a/label.go
+++ b/label.go
@@ -108,4 +108,5 @@ type LabelFilter struct {
 // LabelMappingFilter represents a set of filters that restrict the returned results.
 type LabelMappingFilter struct {
 	ResourceID ID
+	ResourceType
 }

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -671,8 +671,8 @@ func CreateLabelMapping(
 			},
 			args: args{
 				mapping: &influxdb.LabelMapping{
-					LabelID:    IDPtr(MustIDBase16(labelOneID)),
-					ResourceID: IDPtr(MustIDBase16(bucketOneID)),
+					LabelID:    MustIDBase16(labelOneID),
+					ResourceID: MustIDBase16(bucketOneID),
 				},
 				filter: &influxdb.LabelMappingFilter{
 					ResourceID: MustIDBase16(bucketOneID),
@@ -695,8 +695,8 @@ func CreateLabelMapping(
 			},
 			args: args{
 				mapping: &influxdb.LabelMapping{
-					LabelID:    IDPtr(MustIDBase16(labelOneID)),
-					ResourceID: IDPtr(MustIDBase16(bucketOneID)),
+					LabelID:    MustIDBase16(labelOneID),
+					ResourceID: MustIDBase16(bucketOneID),
 				},
 			},
 			wants: wants{
@@ -790,15 +790,15 @@ func DeleteLabelMapping(
 				},
 				Mappings: []*influxdb.LabelMapping{
 					{
-						LabelID:    IDPtr(MustIDBase16(labelOneID)),
-						ResourceID: IDPtr(MustIDBase16(bucketOneID)),
+						LabelID:    MustIDBase16(labelOneID),
+						ResourceID: MustIDBase16(bucketOneID),
 					},
 				},
 			},
 			args: args{
 				mapping: &influxdb.LabelMapping{
-					LabelID:    IDPtr(MustIDBase16(labelOneID)),
-					ResourceID: IDPtr(MustIDBase16(bucketOneID)),
+					LabelID:    MustIDBase16(labelOneID),
+					ResourceID: MustIDBase16(bucketOneID),
 				},
 				filter: influxdb.LabelMappingFilter{
 					ResourceID: MustIDBase16(bucketOneID),

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/mock"
 )
 
@@ -20,8 +20,8 @@ var labelCmpOptions = cmp.Options{
 	cmp.Comparer(func(x, y []byte) bool {
 		return bytes.Equal(x, y)
 	}),
-	cmp.Transformer("Sort", func(in []*platform.Label) []*platform.Label {
-		out := append([]*platform.Label(nil), in...) // Copy input to avoid mutating it
+	cmp.Transformer("Sort", func(in []*influxdb.Label) []*influxdb.Label {
+		out := append([]*influxdb.Label(nil), in...) // Copy input to avoid mutating it
 		sort.Slice(out, func(i, j int) bool {
 			return out[i].Name < out[j].Name
 		})
@@ -31,19 +31,19 @@ var labelCmpOptions = cmp.Options{
 
 // LabelFields include the IDGenerator, labels and their mappings
 type LabelFields struct {
-	Labels      []*platform.Label
-	Mappings    []*platform.LabelMapping
-	IDGenerator platform.IDGenerator
+	Labels      []*influxdb.Label
+	Mappings    []*influxdb.LabelMapping
+	IDGenerator influxdb.IDGenerator
 }
 
 type labelServiceF func(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 )
 
 // LabelService tests all the service functions.
 func LabelService(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 ) {
 	tests := []struct {
@@ -87,15 +87,15 @@ func LabelService(
 }
 
 func CreateLabel(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 ) {
 	type args struct {
-		label *platform.Label
+		label *influxdb.Label
 	}
 	type wants struct {
 		err    error
-		labels []*platform.Label
+		labels []*influxdb.Label
 	}
 
 	tests := []struct {
@@ -108,10 +108,10 @@ func CreateLabel(
 			name: "basic create label",
 			fields: LabelFields{
 				IDGenerator: mock.NewIDGenerator(labelOneID, t),
-				Labels:      []*platform.Label{},
+				Labels:      []*influxdb.Label{},
 			},
 			args: args{
-				label: &platform.Label{
+				label: &influxdb.Label{
 					Name: "Tag2",
 					Properties: map[string]string{
 						"color": "fff000",
@@ -119,7 +119,7 @@ func CreateLabel(
 				},
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag2",
@@ -134,26 +134,26 @@ func CreateLabel(
 		// 	name: "duplicate labels fail",
 		// 	fields: LabelFields{
 		// 		IDGenerator: mock.NewIDGenerator(labelTwoID, t),
-		// 		Labels: []*platform.Label{
+		// 		Labels: []*influxdb.Label{
 		// 			{
 		// 				Name: "Tag1",
 		// 			},
 		// 		},
 		// 	},
 		// 	args: args{
-		// 		label: &platform.Label{
+		// 		label: &influxdb.Label{
 		// 			Name: "Tag1",
 		// 		},
 		// 	},
 		// 	wants: wants{
-		// 		labels: []*platform.Label{
+		// 		labels: []*influxdb.Label{
 		// 			{
 		// 				Name: "Tag1",
 		// 			},
 		// 		},
-		// 		err: &platform.Error{
-		// 			Code: platform.EConflict,
-		// 			Op:   platform.OpCreateLabel,
+		// 		err: &influxdb.Error{
+		// 			Code: influxdb.EConflict,
+		// 			Op:   influxdb.OpCreateLabel,
 		// 			Msg:  "label Tag1 already exists",
 		// 		},
 		// 	},
@@ -170,7 +170,7 @@ func CreateLabel(
 
 			defer s.DeleteLabel(ctx, tt.args.label.ID)
 
-			labels, err := s.FindLabels(ctx, platform.LabelFilter{})
+			labels, err := s.FindLabels(ctx, influxdb.LabelFilter{})
 			if err != nil {
 				t.Fatalf("failed to retrieve labels: %v", err)
 			}
@@ -182,15 +182,15 @@ func CreateLabel(
 }
 
 func FindLabels(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 ) {
 	type args struct {
-		filter platform.LabelFilter
+		filter influxdb.LabelFilter
 	}
 	type wants struct {
 		err    error
-		labels []*platform.Label
+		labels []*influxdb.Label
 	}
 
 	tests := []struct {
@@ -202,7 +202,7 @@ func FindLabels(
 		{
 			name: "basic find labels",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -214,10 +214,10 @@ func FindLabels(
 				},
 			},
 			args: args{
-				filter: platform.LabelFilter{},
+				filter: influxdb.LabelFilter{},
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -232,7 +232,7 @@ func FindLabels(
 		{
 			name: "find labels filtering",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -244,12 +244,12 @@ func FindLabels(
 				},
 			},
 			args: args{
-				filter: platform.LabelFilter{
+				filter: influxdb.LabelFilter{
 					Name: "Tag1",
 				},
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -275,15 +275,15 @@ func FindLabels(
 }
 
 func FindLabelByID(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 ) {
 	type args struct {
-		id platform.ID
+		id influxdb.ID
 	}
 	type wants struct {
 		err   error
-		label *platform.Label
+		label *influxdb.Label
 	}
 
 	tests := []struct {
@@ -295,7 +295,7 @@ func FindLabelByID(
 		{
 			name: "find label by ID",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -310,7 +310,7 @@ func FindLabelByID(
 				id: MustIDBase16(labelOneID),
 			},
 			wants: wants{
-				label: &platform.Label{
+				label: &influxdb.Label{
 					ID:   MustIDBase16(labelOneID),
 					Name: "Tag1",
 				},
@@ -319,16 +319,16 @@ func FindLabelByID(
 		{
 			name: "label does not exist",
 			fields: LabelFields{
-				Labels: []*platform.Label{},
+				Labels: []*influxdb.Label{},
 			},
 			args: args{
 				id: MustIDBase16(labelOneID),
 			},
 			wants: wants{
-				err: &platform.Error{
-					Code: platform.ENotFound,
-					Op:   platform.OpFindLabelByID,
-					Msg:  "label not found",
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Op:   influxdb.OpFindLabelByID,
+					Err:  influxdb.ErrLabelNotFound,
 				},
 			},
 		},
@@ -350,16 +350,16 @@ func FindLabelByID(
 }
 
 func UpdateLabel(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 ) {
 	type args struct {
-		labelID platform.ID
-		update  platform.LabelUpdate
+		labelID influxdb.ID
+		update  influxdb.LabelUpdate
 	}
 	type wants struct {
 		err    error
-		labels []*platform.Label
+		labels []*influxdb.Label
 	}
 
 	tests := []struct {
@@ -371,7 +371,7 @@ func UpdateLabel(
 		{
 			name: "update label properties",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -380,14 +380,14 @@ func UpdateLabel(
 			},
 			args: args{
 				labelID: MustIDBase16(labelOneID),
-				update: platform.LabelUpdate{
+				update: influxdb.LabelUpdate{
 					Properties: map[string]string{
 						"color": "fff000",
 					},
 				},
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -401,7 +401,7 @@ func UpdateLabel(
 		{
 			name: "replacing a label property",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -414,14 +414,14 @@ func UpdateLabel(
 			},
 			args: args{
 				labelID: MustIDBase16(labelOneID),
-				update: platform.LabelUpdate{
+				update: influxdb.LabelUpdate{
 					Properties: map[string]string{
 						"color": "abc123",
 					},
 				},
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -436,7 +436,7 @@ func UpdateLabel(
 		{
 			name: "deleting a label property",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -449,14 +449,14 @@ func UpdateLabel(
 			},
 			args: args{
 				labelID: MustIDBase16(labelOneID),
-				update: platform.LabelUpdate{
+				update: influxdb.LabelUpdate{
 					Properties: map[string]string{
 						"description": "",
 					},
 				},
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -470,7 +470,7 @@ func UpdateLabel(
 		// {
 		// 	name: "label update proliferation",
 		// 	fields: LabelFields{
-		// 		Labels: []*platform.Label{
+		// 		Labels: []*influxdb.Label{
 		// 			{
 		// 				ResourceID: MustIDBase16(bucketOneID),
 		// 				Name:       "Tag1",
@@ -482,16 +482,16 @@ func UpdateLabel(
 		// 		},
 		// 	},
 		// 	args: args{
-		// 		label: platform.Label{
+		// 		label: influxdb.Label{
 		// 			ResourceID: MustIDBase16(bucketOneID),
 		// 			Name:       "Tag1",
 		// 		},
-		// 		update: platform.LabelUpdate{
+		// 		update: influxdb.LabelUpdate{
 		// 			Color: &validColor,
 		// 		},
 		// 	},
 		// 	wants: wants{
-		// 		labels: []*platform.Label{
+		// 		labels: []*influxdb.Label{
 		// 			{
 		// 				ResourceID: MustIDBase16(bucketOneID),
 		// 				Name:       "Tag1",
@@ -508,22 +508,22 @@ func UpdateLabel(
 		{
 			name: "updating a non-existent label",
 			fields: LabelFields{
-				Labels: []*platform.Label{},
+				Labels: []*influxdb.Label{},
 			},
 			args: args{
 				labelID: MustIDBase16(labelOneID),
-				update: platform.LabelUpdate{
+				update: influxdb.LabelUpdate{
 					Properties: map[string]string{
 						"color": "fff000",
 					},
 				},
 			},
 			wants: wants{
-				labels: []*platform.Label{},
-				err: &platform.Error{
-					Code: platform.ENotFound,
-					Op:   platform.OpUpdateLabel,
-					Msg:  "label not found",
+				labels: []*influxdb.Label{},
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Op:   influxdb.OpUpdateLabel,
+					Err:  influxdb.ErrLabelNotFound,
 				},
 			},
 		},
@@ -537,7 +537,7 @@ func UpdateLabel(
 			_, err := s.UpdateLabel(ctx, tt.args.labelID, tt.args.update)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
-			labels, err := s.FindLabels(ctx, platform.LabelFilter{})
+			labels, err := s.FindLabels(ctx, influxdb.LabelFilter{})
 			if err != nil {
 				t.Fatalf("failed to retrieve labels: %v", err)
 			}
@@ -549,15 +549,15 @@ func UpdateLabel(
 }
 
 func DeleteLabel(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 ) {
 	type args struct {
-		labelID platform.ID
+		labelID influxdb.ID
 	}
 	type wants struct {
 		err    error
-		labels []*platform.Label
+		labels []*influxdb.Label
 	}
 
 	tests := []struct {
@@ -569,7 +569,7 @@ func DeleteLabel(
 		{
 			name: "basic delete label",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -584,7 +584,7 @@ func DeleteLabel(
 				labelID: MustIDBase16(labelOneID),
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelTwoID),
 						Name: "Tag2",
@@ -595,7 +595,7 @@ func DeleteLabel(
 		{
 			name: "deleting a non-existant label",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -606,16 +606,16 @@ func DeleteLabel(
 				labelID: MustIDBase16(labelTwoID),
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 				},
-				err: &platform.Error{
-					Code: platform.ENotFound,
-					Op:   platform.OpDeleteLabel,
-					Msg:  "label not found",
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Op:   influxdb.OpDeleteLabel,
+					Err:  influxdb.ErrLabelNotFound,
 				},
 			},
 		},
@@ -629,7 +629,7 @@ func DeleteLabel(
 			err := s.DeleteLabel(ctx, tt.args.labelID)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
-			labels, err := s.FindLabels(ctx, platform.LabelFilter{})
+			labels, err := s.FindLabels(ctx, influxdb.LabelFilter{})
 			if err != nil {
 				t.Fatalf("failed to retrieve labels: %v", err)
 			}
@@ -641,16 +641,16 @@ func DeleteLabel(
 }
 
 func CreateLabelMapping(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 ) {
 	type args struct {
-		mapping *platform.LabelMapping
-		filter  *platform.LabelMappingFilter
+		mapping *influxdb.LabelMapping
+		filter  *influxdb.LabelMappingFilter
 	}
 	type wants struct {
 		err    error
-		labels []*platform.Label
+		labels []*influxdb.Label
 	}
 
 	tests := []struct {
@@ -662,7 +662,7 @@ func CreateLabelMapping(
 		{
 			name: "create label mapping",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -670,16 +670,16 @@ func CreateLabelMapping(
 				},
 			},
 			args: args{
-				mapping: &platform.LabelMapping{
+				mapping: &influxdb.LabelMapping{
 					LabelID:    IDPtr(MustIDBase16(labelOneID)),
 					ResourceID: IDPtr(MustIDBase16(bucketOneID)),
 				},
-				filter: &platform.LabelMappingFilter{
+				filter: &influxdb.LabelMappingFilter{
 					ResourceID: MustIDBase16(bucketOneID),
 				},
 			},
 			wants: wants{
-				labels: []*platform.Label{
+				labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
@@ -691,19 +691,19 @@ func CreateLabelMapping(
 			name: "mapping to a nonexistent label",
 			fields: LabelFields{
 				IDGenerator: mock.NewIDGenerator(labelOneID, t),
-				Labels:      []*platform.Label{},
+				Labels:      []*influxdb.Label{},
 			},
 			args: args{
-				mapping: &platform.LabelMapping{
+				mapping: &influxdb.LabelMapping{
 					LabelID:    IDPtr(MustIDBase16(labelOneID)),
 					ResourceID: IDPtr(MustIDBase16(bucketOneID)),
 				},
 			},
 			wants: wants{
-				err: &platform.Error{
-					Code: platform.ENotFound,
-					Op:   platform.OpDeleteLabel,
-					Msg:  "label not found",
+				err: &influxdb.Error{
+					Code: influxdb.ENotFound,
+					Op:   influxdb.OpDeleteLabel,
+					Err:  influxdb.ErrLabelNotFound,
 				},
 			},
 		},
@@ -711,10 +711,10 @@ func CreateLabelMapping(
 		// 	name: "duplicate label mappings",
 		// 	fields: LabelFields{
 		// 		IDGenerator: mock.NewIDGenerator(labelOneID, t),
-		// 		Labels:      []*platform.Label{},
+		// 		Labels:      []*influxdb.Label{},
 		// 	},
 		// 	args: args{
-		// 		label: &platform.Label{
+		// 		label: &influxdb.Label{
 		// 			Name: "Tag2",
 		// 			Properties: map[string]string{
 		// 				"color": "fff000",
@@ -722,7 +722,7 @@ func CreateLabelMapping(
 		// 		},
 		// 	},
 		// 	wants: wants{
-		// 		labels: []*platform.Label{
+		// 		labels: []*influxdb.Label{
 		// 			{
 		// 				ID:   MustIDBase16(labelOneID),
 		// 				Name: "Tag2",
@@ -761,16 +761,16 @@ func CreateLabelMapping(
 }
 
 func DeleteLabelMapping(
-	init func(LabelFields, *testing.T) (platform.LabelService, string, func()),
+	init func(LabelFields, *testing.T) (influxdb.LabelService, string, func()),
 	t *testing.T,
 ) {
 	type args struct {
-		mapping *platform.LabelMapping
-		filter  platform.LabelMappingFilter
+		mapping *influxdb.LabelMapping
+		filter  influxdb.LabelMappingFilter
 	}
 	type wants struct {
 		err    error
-		labels []*platform.Label
+		labels []*influxdb.Label
 	}
 
 	tests := []struct {
@@ -782,13 +782,13 @@ func DeleteLabelMapping(
 		{
 			name: "delete label mapping",
 			fields: LabelFields{
-				Labels: []*platform.Label{
+				Labels: []*influxdb.Label{
 					{
 						ID:   MustIDBase16(labelOneID),
 						Name: "Tag1",
 					},
 				},
-				Mappings: []*platform.LabelMapping{
+				Mappings: []*influxdb.LabelMapping{
 					{
 						LabelID:    IDPtr(MustIDBase16(labelOneID)),
 						ResourceID: IDPtr(MustIDBase16(bucketOneID)),
@@ -796,16 +796,16 @@ func DeleteLabelMapping(
 				},
 			},
 			args: args{
-				mapping: &platform.LabelMapping{
+				mapping: &influxdb.LabelMapping{
 					LabelID:    IDPtr(MustIDBase16(labelOneID)),
 					ResourceID: IDPtr(MustIDBase16(bucketOneID)),
 				},
-				filter: platform.LabelMappingFilter{
+				filter: influxdb.LabelMappingFilter{
 					ResourceID: MustIDBase16(bucketOneID),
 				},
 			},
 			wants: wants{
-				labels: []*platform.Label{},
+				labels: []*influxdb.Label{},
 			},
 		},
 	}


### PR DESCRIPTION
Closes #11280 

Closes part of #10814 

_Briefly describe your proposed changes:_

Implementation of authorization layer for v2 labels.
Addition of `ResourceType` to `LabelMapping` struct and `LabelMappingFilter` struct since we need it to check for permissions on resources.


  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
