### PR TITLE
fix(ui/dataLoading): Ensure that a bucket gets passed into the datalistening query

### DIFF
--- a/ui/src/dataLoaders/components/StepSwitcher.tsx
+++ b/ui/src/dataLoaders/components/StepSwitcher.tsx
@@ -114,6 +114,7 @@ class StepSwitcher extends PureComponent<Props> {
             {...onboardingStepProps}
             {...dataLoaders}
             bucket={bucketName}
+            selectedBucket={selectedBucket}
             username={username}
             org={org}
             onSaveTelegrafConfig={onSaveTelegrafConfig}

--- a/ui/src/onboarding/components/verifyStep/VerifyDataStep.test.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataStep.test.tsx
@@ -31,6 +31,7 @@ const setup = (override = {}) => {
     username: 'user',
     org: '',
     notify: jest.fn(),
+    selectedBucket: '',
     ...override,
   }
 

--- a/ui/src/onboarding/components/verifyStep/VerifyDataStep.tsx
+++ b/ui/src/onboarding/components/verifyStep/VerifyDataStep.tsx
@@ -35,6 +35,7 @@ export interface OwnProps extends DataLoaderStepProps {
   bucket: string
   username: string
   org: string
+  selectedBucket: string
 }
 
 interface StateProps {
@@ -57,7 +58,6 @@ export class VerifyDataStep extends PureComponent<Props> {
 
   public render() {
     const {
-      bucket,
       username,
       telegrafConfigID,
       type,
@@ -80,7 +80,7 @@ export class VerifyDataStep extends PureComponent<Props> {
                   telegrafConfigID={telegrafConfigID}
                   onSaveTelegrafConfig={onSaveTelegrafConfig}
                   org={org}
-                  bucket={bucket}
+                  bucket={this.bucket}
                   username={username}
                   onDecrementCurrentStep={onDecrementCurrentStepIndex}
                   lpStatus={lpStatus}
@@ -95,6 +95,12 @@ export class VerifyDataStep extends PureComponent<Props> {
         </Form>
       </div>
     )
+  }
+
+  private get bucket(): string {
+    const {bucket, selectedBucket} = this.props
+
+    return selectedBucket || bucket
   }
 
   private get previousStepName() {


### PR DESCRIPTION
Closes #11329

_Briefly describe your proposed changes:_
Data listening wasnt working when you opened the data loading wizard from the collectors page. Now the selected bucket is passed in.

  - [x] Rebased/mergeable
  - [x] Tests pass