### PR TITLE
feat(cmd/influxd): scrapers should run every ten seconds

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -394,7 +394,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 			Writer: pointsWriter,
 		},
 	})
-	scraperScheduler, err := gather.NewScheduler(10, m.logger, scraperTargetSvc, publisher, subscriber, 0, 0)
+	scraperScheduler, err := gather.NewScheduler(10, m.logger, scraperTargetSvc, publisher, subscriber, 10*time.Second, 0)
 	if err != nil {
 		m.logger.Error("failed to create scraper subscriber", zap.Error(err))
 		return err


### PR DESCRIPTION

_Briefly describe your proposed changes:_

Previously, scrapers were running every one minute.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
