### PR TITLE
fix(task): populate created task response, the same as finding

### DIFF
--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -75,7 +75,7 @@ func (p pAdapter) CreateTask(ctx context.Context, t *platform.Task) error {
 		return err
 	}
 
-	// TODO(mr): decide whether we allow user to configure scheduleAfter. https://github.com/influxdata/influxdb/issues/595
+	// TODO(mr): decide whether we allow user to configure scheduleAfter. https://github.com/influxdata/influxdb/issues/10884
 	scheduleAfter := time.Now().Unix()
 
 	if t.Status == "" {
@@ -95,8 +95,15 @@ func (p pAdapter) CreateTask(ctx context.Context, t *platform.Task) error {
 		return err
 	}
 	t.ID = id
-	t.Every = opts.Every.String()
 	t.Cron = opts.Cron
+	t.Name = opts.Name
+
+	if opts.Every != 0 {
+		t.Every = opts.Every.String()
+	}
+	if opts.Offset != 0 {
+		t.Offset = opts.Offset.String()
+	}
 
 	return nil
 }

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -122,7 +122,9 @@ func testTaskCRUD(t *testing.T, sys *System) {
 
 	// Look up a task the different ways we can.
 	// Map of method name to found task.
-	found := make(map[string]*platform.Task)
+	found := map[string]*platform.Task{
+		"Created": task,
+	}
 
 	// Find by ID should return the right task.
 	f, err := sys.ts.FindTaskByID(sys.Ctx, task.ID)


### PR DESCRIPTION
The response from a created task was missing the name field; now a test
ensures that response matches what is returned when listing tasks.
