### PR TITLE
Hide result and table columns from being shown in table options

### DIFF
--- a/ui/src/shared/components/view_options/TableOptions.tsx
+++ b/ui/src/shared/components/view_options/TableOptions.tsx
@@ -72,6 +72,14 @@ export class TableOptions extends Component<Props, {}> {
       onSetDecimalPlaces,
     } = this.props
 
+    const filteredColumns = fieldOptions.filter(
+      col =>
+        col.internalName !== 'time' &&
+        col.internalName !== '' &&
+        col.internalName !== 'result' &&
+        col.internalName !== 'table'
+    )
+
     const {fixFirstColumn, verticalTimeAxis, sortBy} = tableOptions
 
     return (
@@ -109,7 +117,7 @@ export class TableOptions extends Component<Props, {}> {
           onToggleFixFirstColumn={this.handleToggleFixFirstColumn}
         />
         <ColumnOptions
-          columns={fieldOptions}
+          columns={filteredColumns}
           onMoveColumn={this.handleMoveColumn}
           onUpdateColumn={this.handleUpdateColumn}
         />


### PR DESCRIPTION
Closes #11373

This PR prevents the result and table columns from being shown in the table options sidebar for a table graph, since they do not appear on the table graph itself.

  - [x] Rebased/mergeable
  - [ ] Tests pass
