### PR TITLE
Resolve field options after excluding data in tables

### DIFF
--- a/ui/src/dashboards/utils/tableGraph.ts
+++ b/ui/src/dashboards/utils/tableGraph.ts
@@ -259,9 +259,12 @@ export const transformTableData = (
 ): TransformTableDataReturnType => {
   const {verticalTimeAxis} = tableOptions
 
-  const resolvedFieldOptions = resolveFieldOptions(fieldOptions, data[0])
-
   const excludedData = excludeNoisyColumns(data)
+
+  const resolvedFieldOptions = resolveFieldOptions(
+    fieldOptions,
+    excludedData[0]
+  )
 
   const {sortedData, sortedTimeVals} = sortTableData(excludedData, sortOptions)
 


### PR DESCRIPTION
Closes #11368 

_Briefly describe your proposed changes:_
Resolved field options was being calculated before excluding noisy columns, and this was causing a mismatch between what was in the table and how time column was being determined. 