### PR TITLE
Change button text from next to finish for configure scraping step

### DIFF
--- a/ui/src/onboarding/components/configureStep/Scraping.tsx
+++ b/ui/src/onboarding/components/configureStep/Scraping.tsx
@@ -92,6 +92,7 @@ export class Scraping extends PureComponent<Props> {
           autoFocusNext={false}
           skipButtonText={'Skip'}
           nextButtonStatus={this.nextButtonStatus}
+          nextButtonText={'Finish'}
         />
       </Form>
     )


### PR DESCRIPTION
Closes #11378

This PR changes the button text from "next" to "finish" for the configure scraping data step of the admin UI wizard. The verify scrapers step mentioned in the issue above seems to already have been removed from the wizard.

  - [x] Rebased/mergeable
  - [x] Tests pass
