### PR TITLE
Polish Dropdowns

### DIFF
--- a/ui/src/clockface/components/dropdowns/Dropdown.scss
+++ b/ui/src/clockface/components/dropdowns/Dropdown.scss
@@ -48,14 +48,12 @@
   color: fade-out($g20-white, 0.18);
   white-space: nowrap;
   position: relative;
+  text-align: left;
 
   &.active,
   &.checked {
     color: $g20-white;
   }
-  
-  // &.active {
-  // }
   
   &.checked {
     padding-left: 24px;

--- a/ui/src/clockface/components/dropdowns/Dropdown.scss
+++ b/ui/src/clockface/components/dropdowns/Dropdown.scss
@@ -41,6 +41,7 @@
 
 .dropdown--item {
   padding: 6px 11px;
+  padding-left: 21px;
   font-size: 12px;
   line-height: 12px;
   font-weight: 600;
@@ -48,9 +49,16 @@
   white-space: nowrap;
   position: relative;
 
-  &.active {
-    padding-left: 24px;
+  &.active,
+  &.checked {
     color: $g20-white;
+  }
+  
+  // &.active {
+  // }
+  
+  &.checked {
+    padding-left: 24px;
   }
 
   &:hover {
@@ -71,7 +79,7 @@
   border-radius: 50%;
   position: absolute;
   top: 50%;
-  left: 11px;
+  left: 8px;
   transform: translateY(-50%);
   background-color: $g20-white;
 

--- a/ui/src/clockface/components/dropdowns/DropdownItem.tsx
+++ b/ui/src/clockface/components/dropdowns/DropdownItem.tsx
@@ -29,14 +29,15 @@ class DropdownItem extends Component<Props> {
     return (
       <div
         className={classnames('dropdown--item', {
-          active: selected,
+          checked: selected && checkbox,
+          active: selected && !checkbox,
           'multi-select--item': checkbox,
         })}
         onClick={this.handleClick}
       >
         {this.checkBox}
-        {this.dot}
         {this.childElements}
+        {this.dot}
       </div>
     )
   }


### PR DESCRIPTION
Align active and inactive items in dropdown menus via indentation
Ensure dropdown items have a higher specificity `text-align: left` so they don't inherit other alignments from parents

Closes #11383 

![screen shot 2019-01-22 at 11 52 14 am](https://user-images.githubusercontent.com/2433762/51561674-b7152c80-1e3c-11e9-80e7-4746c3b1494c.png)
![screen shot 2019-01-22 at 11 50 58 am](https://user-images.githubusercontent.com/2433762/51561701-c98f6600-1e3c-11e9-9747-0f0621611a0b.png)

  - [x] Rebased/mergeable
  - [x] Tests pass
