### PR TITLE
Enforce minimum retention policy of 1 hour in UI

### DIFF
--- a/ui/src/organizations/components/CreateBucketOverlay.tsx
+++ b/ui/src/organizations/components/CreateBucketOverlay.tsx
@@ -21,9 +21,9 @@ interface Props {
 
 interface State {
   bucket: Bucket
-  errorMessage: string
   ruleType: BucketRetentionRules.TypeEnum
   nameInputStatus: ComponentStatus
+  nameErrorMessage: string
 }
 
 const emptyBucket = {
@@ -35,7 +35,7 @@ export default class BucketOverlay extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
-      errorMessage: '',
+      nameErrorMessage: '',
       bucket: emptyBucket,
       ruleType: null,
       nameInputStatus: ComponentStatus.Default,
@@ -44,7 +44,7 @@ export default class BucketOverlay extends PureComponent<Props, State> {
 
   public render() {
     const {onCloseModal} = this.props
-    const {bucket, nameInputStatus, errorMessage, ruleType} = this.state
+    const {bucket, nameInputStatus, nameErrorMessage, ruleType} = this.state
 
     return (
       <OverlayContainer maxWidth={500}>
@@ -58,7 +58,7 @@ export default class BucketOverlay extends PureComponent<Props, State> {
             buttonText="Create"
             ruleType={ruleType}
             onCloseModal={onCloseModal}
-            errorMessage={errorMessage}
+            nameErrorMessage={nameErrorMessage}
             onSubmit={this.handleSubmit}
             nameInputStatus={nameInputStatus}
             onChangeInput={this.handleChangeInput}
@@ -77,22 +77,20 @@ export default class BucketOverlay extends PureComponent<Props, State> {
     )
 
     if (!rule) {
-      return 0
+      return 3600
     }
 
     return rule.everySeconds
   }
 
   private handleChangeRetentionRule = (everySeconds: number): void => {
-    let retentionRules = []
-
-    if (everySeconds > 0) {
-      retentionRules = [
+    const bucket = {
+      ...this.state.bucket,
+      retentionRules: [
         {type: BucketRetentionRules.TypeEnum.Expire, everySeconds},
-      ]
+      ],
     }
 
-    const bucket = {...this.state.bucket, retentionRules}
     this.setState({bucket})
   }
 
@@ -128,14 +126,14 @@ export default class BucketOverlay extends PureComponent<Props, State> {
       return this.setState({
         bucket,
         nameInputStatus: ComponentStatus.Error,
-        errorMessage: `Bucket ${key} cannot be empty`,
+        nameErrorMessage: `Bucket ${key} cannot be empty`,
       })
     }
 
     this.setState({
       bucket,
       nameInputStatus: ComponentStatus.Valid,
-      errorMessage: '',
+      nameErrorMessage: '',
     })
   }
 }

--- a/ui/src/organizations/components/Retention.scss
+++ b/ui/src/organizations/components/Retention.scss
@@ -1,0 +1,3 @@
+.retention--radio {
+  margin-bottom: 10px;
+}

--- a/ui/src/organizations/components/Retention.tsx
+++ b/ui/src/organizations/components/Retention.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent, ChangeEvent} from 'react'
 
 // Components
-import {Grid, Form, Radio, ButtonShape} from 'src/clockface'
+import {Radio, ButtonShape} from 'src/clockface'
 import RetentionDuration from 'src/organizations/components/RetentionDuration'
 
 // Utils
@@ -11,6 +11,8 @@ import {
   durationToSeconds,
   secondsToDuration,
 } from 'src/utils/formatting'
+
+import 'src/organizations/components/Retention.scss'
 
 import {BucketRetentionRules} from 'src/api'
 
@@ -27,26 +29,22 @@ export default class Retention extends PureComponent<Props> {
 
     return (
       <>
-        <Grid.Column>
-          <Form.Element label="How often to clear data?">
-            <Radio shape={ButtonShape.StretchToFit}>
-              <Radio.Button
-                active={type === BucketRetentionRules.TypeEnum.Expire}
-                onClick={this.handleRadioClick}
-                value={BucketRetentionRules.TypeEnum.Expire}
-              >
-                Periodically
-              </Radio.Button>
-              <Radio.Button
-                active={type === null}
-                onClick={this.handleRadioClick}
-                value={null}
-              >
-                Never
-              </Radio.Button>
-            </Radio>
-          </Form.Element>
-        </Grid.Column>
+        <Radio shape={ButtonShape.StretchToFit} customClass="retention--radio">
+          <Radio.Button
+            active={type === BucketRetentionRules.TypeEnum.Expire}
+            onClick={this.handleRadioClick}
+            value={BucketRetentionRules.TypeEnum.Expire}
+          >
+            Periodically
+          </Radio.Button>
+          <Radio.Button
+            active={type === null}
+            onClick={this.handleRadioClick}
+            value={null}
+          >
+            Never
+          </Radio.Button>
+        </Radio>
         <RetentionDuration
           type={type}
           retentionSeconds={retentionSeconds}

--- a/ui/src/organizations/components/RetentionDuration.tsx
+++ b/ui/src/organizations/components/RetentionDuration.tsx
@@ -30,7 +30,7 @@ export default class RetentionDuration extends PureComponent<Props> {
     }
 
     return (
-      <>
+      <Grid.Row>
         <Grid.Column widthSM={Columns.Three}>
           <Form.Element label="Days">
             <Input
@@ -74,7 +74,7 @@ export default class RetentionDuration extends PureComponent<Props> {
             />
           </Form.Element>
         </Grid.Column>
-      </>
+      </Grid.Row>
     )
   }
 }

--- a/ui/src/organizations/components/UpdateBucketOverlay.tsx
+++ b/ui/src/organizations/components/UpdateBucketOverlay.tsx
@@ -11,7 +11,6 @@ import {
 import BucketOverlayForm from 'src/organizations/components/BucketOverlayForm'
 
 // Types
-import {RetentionRuleTypes} from 'src/types/v2'
 import {Bucket, BucketRetentionRules} from 'src/api'
 
 interface Props {
@@ -22,7 +21,7 @@ interface Props {
 
 interface State {
   bucket: Bucket
-  errorMessage: string
+  nameErrorMessage: string
   ruleType: BucketRetentionRules.TypeEnum
   nameInputStatus: ComponentStatus
 }
@@ -30,18 +29,20 @@ interface State {
 export default class BucketOverlay extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
+
     const {bucket} = this.props
+
     this.state = {
       ruleType: this.ruleType(bucket),
       bucket,
       nameInputStatus: ComponentStatus.Default,
-      errorMessage: '',
+      nameErrorMessage: '',
     }
   }
 
   public render() {
     const {onCloseModal} = this.props
-    const {bucket, nameInputStatus, errorMessage, ruleType} = this.state
+    const {bucket, nameInputStatus, nameErrorMessage, ruleType} = this.state
 
     return (
       <OverlayContainer maxWidth={500}>
@@ -55,7 +56,7 @@ export default class BucketOverlay extends PureComponent<Props, State> {
             buttonText="Save Changes"
             ruleType={ruleType}
             onCloseModal={onCloseModal}
-            errorMessage={errorMessage}
+            nameErrorMessage={nameErrorMessage}
             onSubmit={this.handleSubmit}
             nameInputStatus={nameInputStatus}
             onChangeInput={this.handleChangeInput}
@@ -74,7 +75,7 @@ export default class BucketOverlay extends PureComponent<Props, State> {
     )
 
     if (!rule) {
-      return 0
+      return 3600
     }
 
     return rule.everySeconds
@@ -93,13 +94,13 @@ export default class BucketOverlay extends PureComponent<Props, State> {
   }
 
   private handleChangeRetentionRule = (everySeconds: number): void => {
-    let retentionRules = []
-
-    if (everySeconds > 0) {
-      retentionRules = [{type: RetentionRuleTypes.Expire, everySeconds}]
+    const bucket = {
+      ...this.state.bucket,
+      retentionRules: [
+        {type: BucketRetentionRules.TypeEnum.Expire, everySeconds},
+      ],
     }
 
-    const bucket = {...this.state.bucket, retentionRules}
     this.setState({bucket})
   }
 
@@ -129,14 +130,14 @@ export default class BucketOverlay extends PureComponent<Props, State> {
       return this.setState({
         bucket,
         nameInputStatus: ComponentStatus.Error,
-        errorMessage: `Bucket ${key} cannot be empty`,
+        nameErrorMessage: `Bucket ${key} cannot be empty`,
       })
     }
 
     this.setState({
       bucket,
       nameInputStatus: ComponentStatus.Valid,
-      errorMessage: '',
+      nameErrorMessage: '',
     })
   }
 }

--- a/ui/src/organizations/constants/index.ts
+++ b/ui/src/organizations/constants/index.ts
@@ -1,0 +1,1 @@
+export const MIN_RETENTION_SECONDS = 3600


### PR DESCRIPTION
Closes #11299 

![validation](https://user-images.githubusercontent.com/638955/51566522-94d5db80-1e49-11e9-8651-61cad6ac833f.gif)

Implementation wise, this splits validation logic somewhat awkwardly between the `CreateBucketOverlay` / `UpdateBucketOverlay` and `BucketOverlayForm`. It would be nice to have this all in one place, but I think we should reduce the duplication between the `CreateBucketOverlay` and `UpdateBucketOverlay` before consolidating any validation logic. In the interest of time, I opted to not do this right now.