### PR TITLE
fix(ui): fix redirect to buckets tab overlay

### DIFF
--- a/ui/src/onboarding/components/CompletionAdvancedButton.tsx
+++ b/ui/src/onboarding/components/CompletionAdvancedButton.tsx
@@ -34,7 +34,7 @@ class CompletionAdvancedButton extends PureComponent<Props> {
     const {router, orgs, onExit} = this.props
     const id = _.get(orgs, '0.id', null)
     if (id) {
-      router.push(`/organizations/${id}/buckets_tab?openDataLoaderOverlay=true`)
+      router.push(`/organizations/${id}/buckets_tab`)
     } else {
       onExit()
     }


### PR DESCRIPTION
Closes #11408

_Briefly describe your proposed changes:_
redirect to buckets tab instead of buckets tab overlay

  - [ ] Rebased/mergeable
  - [ ] Tests pass
