### PR TITLE
Fix flaky getMinDurationFromAST test

### DIFF
--- a/ui/src/shared/utils/getMinDurationFromAST.test.ts
+++ b/ui/src/shared/utils/getMinDurationFromAST.test.ts
@@ -1769,6 +1769,8 @@ export const AST_TESTS = [
 
 describe('getMinDurationFromAST', () => {
   test.each(AST_TESTS)('%s:\n\n```\n%s\n```', (__, ___, expected, ast) => {
-    expect(getMinDurationFromAST(ast)).toEqual(expected)
+    const actual = getMinDurationFromAST(ast)
+
+    expect(Math.abs(actual - expected)).toBeLessThan(5)
   })
 })


### PR DESCRIPTION
`getMinDurationFromAST` relies on `Date.now()` internally. Depending on the current time, the test for `getMinDurationFromAST` would sometimes fail due to floating point arithmetic inaccuracies.

This commit adds a bit of leeway so that the test won't fail due to tolerable floating point inaccuracies.