### PR TITLE
fix(main): require either org or org-id when creating buckets

### DIFF
--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -73,7 +73,8 @@ func newBucketService(f Flags) (platform.BucketService, error) {
 }
 
 func bucketCreateF(cmd *cobra.Command, args []string) error {
-	if bucketCreateFlags.org != "" && bucketCreateFlags.orgID != "" {
+	if (bucketCreateFlags.org == "" && bucketCreateFlags.orgID == "") ||
+		(bucketCreateFlags.org != "" && bucketCreateFlags.orgID != "") {
 		return fmt.Errorf("must specify exactly one of org or org-id")
 	}
 


### PR DESCRIPTION
Closes #10776 
