### PR TITLE
Clear query builder cache on Data Explorer load

### DIFF
--- a/ui/src/dataExplorer/components/DataExplorer.tsx
+++ b/ui/src/dataExplorer/components/DataExplorer.tsx
@@ -11,6 +11,7 @@ import {setActiveTimeMachine} from 'src/shared/actions/v2/timeMachines'
 // Utils
 import {DE_TIME_MACHINE_ID} from 'src/shared/constants/timeMachine'
 import {HoverTimeProvider} from 'src/dashboards/utils/hoverTime'
+import {queryBuilderFetcher} from 'src/shared/apis/v2/queryBuilder'
 
 // Styles
 import './DataExplorer.scss'
@@ -24,6 +25,7 @@ class DataExplorer extends PureComponent<DispatchProps, {}> {
     super(props)
 
     props.onSetActiveTimeMachine(DE_TIME_MACHINE_ID)
+    queryBuilderFetcher.clearCache()
   }
 
   public render() {

--- a/ui/src/shared/actions/v2/queryBuilder.ts
+++ b/ui/src/shared/actions/v2/queryBuilder.ts
@@ -1,5 +1,5 @@
 // APIs
-import {QueryBuilderFetcher} from 'src/shared/apis/v2/queryBuilder'
+import {queryBuilderFetcher} from 'src/shared/apis/v2/queryBuilder'
 
 // Utils
 import {
@@ -13,8 +13,6 @@ import {Dispatch} from 'redux-thunk'
 import {GetState} from 'src/types/v2'
 import {RemoteDataState} from 'src/types'
 import {CancellationError} from 'src/types/promises'
-
-const fetcher = new QueryBuilderFetcher()
 
 export type Action =
   | SetBuilderBucketSelectionAction
@@ -207,7 +205,7 @@ export const loadBuckets = () => async (
 
   try {
     const queryURL = getActiveQuerySource(getState()).links.query
-    const buckets = await fetcher.findBuckets(queryURL)
+    const buckets = await queryBuilderFetcher.findBuckets(queryURL)
     const selectedBucket = getActiveQuery(getState()).builderConfig.buckets[0]
 
     dispatch(setBuilderBuckets(buckets))
@@ -254,7 +252,7 @@ export const loadTagSelector = (index: number) => async (
     const searchTerm = getActiveTimeMachine(getState()).queryBuilder.tags[index]
       .keysSearchTerm
 
-    const keys = await fetcher.findKeys(
+    const keys = await queryBuilderFetcher.findKeys(
       index,
       queryURL,
       buckets[0],
@@ -306,7 +304,7 @@ const loadTagSelectorValues = (index: number) => async (
     const key = getActiveQuery(getState()).builderConfig.tags[index].key
     const searchTerm = getActiveTimeMachine(getState()).queryBuilder.tags[index]
       .valuesSearchTerm
-    const values = await fetcher.findValues(
+    const values = await queryBuilderFetcher.findValues(
       index,
       queryURL,
       buckets[0],
@@ -394,8 +392,8 @@ export const addTagSelector = () => async (
 export const removeTagSelector = (index: number) => async (
   dispatch: Dispatch<Action>
 ) => {
-  fetcher.cancelFindValues(index)
-  fetcher.cancelFindKeys(index)
+  queryBuilderFetcher.cancelFindValues(index)
+  queryBuilderFetcher.cancelFindKeys(index)
 
   dispatch(removeTagSelectorSync(index))
   dispatch(loadTagSelector(index))

--- a/ui/src/shared/apis/v2/queryBuilder.ts
+++ b/ui/src/shared/apis/v2/queryBuilder.ts
@@ -144,7 +144,7 @@ function formatSearchFilterCall(searchTerm: string) {
   return `\n  |> filter(fn: (r) => r._value =~ /(?i:${searchTerm})/)`
 }
 
-export class QueryBuilderFetcher {
+class QueryBuilderFetcher {
   private findBucketsQuery: CancelableQuery
   private findKeysQueries: CancelableQuery[] = []
   private findValuesQueries: CancelableQuery[] = []
@@ -249,4 +249,12 @@ export class QueryBuilderFetcher {
       this.findValuesQueries[index].cancel()
     }
   }
+
+  public clearCache(): void {
+    this.findBucketsCache = {}
+    this.findKeysCache = {}
+    this.findValuesCache = {}
+  }
 }
+
+export const queryBuilderFetcher = new QueryBuilderFetcher()


### PR DESCRIPTION
Fixes an issue where a user would:

1. Use the Data Explorer
2. Navigate to an organization page and create a bucket
3. Navigate back to the Data Explorer
4. Not see the bucket
