### PR TITLE
fix(ui): add filter list and input to scrapers/collectors

### DIFF
--- a/ui/src/organizations/components/Collectors.tsx
+++ b/ui/src/organizations/components/Collectors.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, ChangeEvent} from 'react'
 
 // Utils
 import {downloadTextFile} from 'src/shared/utils/download'
@@ -16,8 +16,11 @@ import {
   EmptyState,
   Grid,
   Columns,
+  Input,
+  InputType,
 } from 'src/clockface'
 import DataLoadersWizard from 'src/dataLoaders/components/DataLoadersWizard'
+import FilterList from 'src/shared/components/Filter'
 
 // APIS
 import {
@@ -50,6 +53,7 @@ interface Props {
 
 interface State {
   overlayState: OverlayState
+  searchTerm: string
 }
 
 @ErrorHandling
@@ -57,26 +61,47 @@ export default class Collectors extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props)
 
-    this.state = {overlayState: OverlayState.Closed}
+    this.state = {
+      overlayState: OverlayState.Closed,
+      searchTerm: '',
+    }
   }
 
   public render() {
     const {collectors, buckets} = this.props
+    const {searchTerm} = this.state
+
     return (
       <>
         <TabbedPageHeader>
-          <h1>Telegraf Configurations</h1>
+          <Input
+            icon={IconFont.Search}
+            placeholder="Filter telegraf configs by bucket..."
+            widthPixels={290}
+            value={searchTerm}
+            type={InputType.Text}
+            onChange={this.handleFilterChange}
+            onBlur={this.handleFilterBlur}
+          />
           {this.createButton}
         </TabbedPageHeader>
         <Grid>
           <Grid.Row>
             <Grid.Column widthSM={Columns.Twelve}>
-              <CollectorList
-                collectors={collectors}
-                emptyState={this.emptyState}
-                onDownloadConfig={this.handleDownloadConfig}
-                onDelete={this.handleDeleteTelegraf}
-              />
+              <FilterList<Telegraf>
+                searchTerm={searchTerm}
+                searchKeys={['plugins.0.config.bucket']}
+                list={collectors}
+              >
+                {cs => (
+                  <CollectorList
+                    collectors={cs}
+                    emptyState={this.emptyState}
+                    onDownloadConfig={this.handleDownloadConfig}
+                    onDelete={this.handleDeleteTelegraf}
+                  />
+                )}
+              </FilterList>
             </Grid.Column>
             <Grid.Column
               widthSM={Columns.Six}
@@ -149,5 +174,13 @@ export default class Collectors extends PureComponent<Props, State> {
   private handleDeleteTelegraf = async (telegrafID: string) => {
     await deleteTelegrafConfig(telegrafID)
     this.props.onChange()
+  }
+
+  private handleFilterChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    this.setState({searchTerm: e.target.value})
+  }
+
+  private handleFilterBlur = (e: ChangeEvent<HTMLInputElement>): void => {
+    this.setState({searchTerm: e.target.value})
   }
 }

--- a/ui/src/organizations/components/Collectors.tsx
+++ b/ui/src/organizations/components/Collectors.tsx
@@ -1,4 +1,5 @@
 // Libraries
+import _ from 'lodash'
 import React, {PureComponent, ChangeEvent} from 'react'
 
 // Utils
@@ -151,14 +152,23 @@ export default class Collectors extends PureComponent<Props, State> {
 
   private get emptyState(): JSX.Element {
     const {orgName} = this.props
+    const {searchTerm} = this.state
+
+    if (_.isEmpty(searchTerm)) {
+      return (
+        <EmptyState size={ComponentSize.Medium}>
+          <EmptyState.Text
+            text={`${orgName} does not own any Telegraf Configurations, why not create one?`}
+            highlightWords={['Telegraf', 'Configurations']}
+          />
+          {this.createButton}
+        </EmptyState>
+      )
+    }
 
     return (
       <EmptyState size={ComponentSize.Medium}>
-        <EmptyState.Text
-          text={`${orgName} does not own any Telegraf  Configurations , why not create one?`}
-          highlightWords={['Telegraf', 'Configurations']}
-        />
-        {this.createButton}
+        <EmptyState.Text text="No Telegraf Configuration buckets match your query" />
       </EmptyState>
     )
   }

--- a/ui/src/organizations/components/Scrapers.tsx
+++ b/ui/src/organizations/components/Scrapers.tsx
@@ -1,4 +1,5 @@
 // Libraries
+import _ from 'lodash'
 import React, {PureComponent, ChangeEvent} from 'react'
 
 // APIs
@@ -118,13 +119,23 @@ export default class Scrapers extends PureComponent<Props, State> {
 
   private get emptyState(): JSX.Element {
     const {orgName} = this.props
+    const {searchTerm} = this.state
+
+    if (_.isEmpty(searchTerm)) {
+      return (
+        <EmptyState size={ComponentSize.Medium}>
+          <EmptyState.Text
+            text={`${orgName} does not own any Scrapers, why not create one?`}
+            highlightWords={['Scrapers']}
+          />
+          {this.createScraperButton}
+        </EmptyState>
+      )
+    }
+
     return (
       <EmptyState size={ComponentSize.Medium}>
-        <EmptyState.Text
-          text={`${orgName} does not own any Scrapers , why not create one?`}
-          highlightWords={['Scrapers']}
-        />
-        {this.createScraperButton}
+        <EmptyState.Text text="No Scraper buckets match your query" />
       </EmptyState>
     )
   }


### PR DESCRIPTION

Closes #11101 

_Briefly describe your proposed changes:_
Remove `<h1`> on tabs in favor of `FilterList` and `Input` controls

<img width="1491" alt="screen shot 2019-01-22 at 3 49 56 pm" src="https://user-images.githubusercontent.com/4994741/51573296-8d203200-1e5d-11e9-8c26-137beb39367e.png">


<img width="903" alt="screen shot 2019-01-22 at 3 54 48 pm" src="https://user-images.githubusercontent.com/4994741/51573419-1afc1d00-1e5e-11e9-86e7-2ccebff8f5da.png">

  - [ ] Rebased/mergeable
  - [ ] Tests pass
