### PR TITLE
Add page for hitting onboarding route with user already created

### DIFF
--- a/ui/src/clockface/components/wizard/WizardFullScreen.scss
+++ b/ui/src/clockface/components/wizard/WizardFullScreen.scss
@@ -4,6 +4,7 @@
 */
 
 .wizard--full-screen {
+  position: relative;
   min-width: 100%;
   min-height: 100%;
   max-height: 100%;

--- a/ui/src/onboarding/containers/OnboardingWizardPage.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizardPage.tsx
@@ -3,6 +3,9 @@ import React, {ReactElement, PureComponent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
+// APIs
+import {getSetupStatus} from 'src/onboarding/apis'
+
 // Actions
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
@@ -10,6 +13,14 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import OnboardingWizard from 'src/onboarding/containers/OnboardingWizard'
 import Notifications from 'src/shared/components/notifications/Notifications'
+import {
+  Spinner,
+  ComponentColor,
+  ComponentSize,
+  WizardFullScreen,
+  Button,
+  EmptyState,
+} from 'src/clockface'
 
 // Types
 import {Notification, NotificationFunc, RemoteDataState} from 'src/types'
@@ -51,26 +62,71 @@ export class OnboardingWizardPage extends PureComponent<Props, State> {
     }
   }
 
+  public async componentDidMount() {
+    this.setState({loading: RemoteDataState.Loading})
+    try {
+      const canSetUp = await getSetupStatus()
+      if (!canSetUp) {
+        this.setState({isSetupComplete: true})
+      }
+      this.setState({loading: RemoteDataState.Done})
+    } catch (error) {
+      console.error(error)
+      this.setState({loading: RemoteDataState.Error})
+    }
+  }
+
   public render() {
     const {params} = this.props
+    const {isSetupComplete} = this.state
+
+    if (isSetupComplete) {
+      return (
+        <Spinner loading={this.state.loading}>
+          <WizardFullScreen>
+            <div className="wizard-contents">
+              <div className="wizard-step--container">
+                <EmptyState size={ComponentSize.Large}>
+                  <EmptyState.Text
+                    text="Initial  User  is already set up, nothing to see here folks!"
+                    highlightWords={['Initial', 'User']}
+                  />
+                  <Button
+                    text={'Return to Home Page'}
+                    onClick={this.redirectToHome}
+                    color={ComponentColor.Primary}
+                  />
+                </EmptyState>
+              </div>
+            </div>
+          </WizardFullScreen>
+        </Spinner>
+      )
+    }
 
     return (
-      <div className="chronograf-root">
-        <Notifications inPresentationMode={true} />
-        <OnboardingWizard
-          onDecrementCurrentStepIndex={this.handleDecrementStepIndex}
-          onIncrementCurrentStepIndex={this.handleIncrementStepIndex}
-          onSetCurrentStepIndex={this.setStepIndex}
-          onSetSubstepIndex={this.setSubstepIndex}
-          currentStepIndex={+params.stepID}
-          onCompleteSetup={this.handleCompleteSetup}
-        />
-      </div>
+      <Spinner loading={this.state.loading}>
+        <div className="chronograf-root">
+          <Notifications inPresentationMode={true} />
+          <OnboardingWizard
+            onDecrementCurrentStepIndex={this.handleDecrementStepIndex}
+            onIncrementCurrentStepIndex={this.handleIncrementStepIndex}
+            onSetCurrentStepIndex={this.setStepIndex}
+            onSetSubstepIndex={this.setSubstepIndex}
+            currentStepIndex={+params.stepID}
+            onCompleteSetup={this.handleCompleteSetup}
+          />
+        </div>
+      </Spinner>
     )
   }
 
   public handleCompleteSetup = () => {
     this.setState({isSetupComplete: true})
+  }
+
+  private redirectToHome = () => {
+    this.props.router.push('/')
   }
 
   private handleDecrementStepIndex = () => {


### PR DESCRIPTION
Closes #11395

This PR creates an empty state for when the user reaches the `/onboarding` route when a user has already been set up. This page has a button to redirect the user to the home page.

<img width="1628" alt="screen shot 2019-01-22 at 3 13 45 pm" src="https://user-images.githubusercontent.com/15273162/51571870-55fb5200-1e58-11e9-9de8-f2a8b102df9c.png">


  - [x] Rebased/mergeable
  - [x] Tests pass