### PR TITLE
Fix misplaced emdash in hover legend

### DIFF
--- a/ui/src/shared/components/Legend.tsx
+++ b/ui/src/shared/components/Legend.tsx
@@ -53,15 +53,19 @@ class Legend extends PureComponent<Props> {
                 className={`legend--column ${isNumeric ? 'numeric' : ''}`}
               >
                 <div className="legend--column-header">{name}</div>
-                {rows.map(({color, value}) => (
-                  <div
-                    key={color}
-                    className={`legend--column-row ${!value ? 'empty' : ''}`}
-                    style={{color}}
-                  >
-                    {isNumber(value) ? value.toFixed(VALUE_PRECISION) : value}
-                  </div>
-                ))}
+                {rows.map(({color, value}) => {
+                  const emptyClass = !value && value !== 0 ? 'empty' : ''
+
+                  return (
+                    <div
+                      key={color}
+                      className={`legend--column-row ${emptyClass}`}
+                      style={{color}}
+                    >
+                      {isNumber(value) ? value.toFixed(VALUE_PRECISION) : value}
+                    </div>
+                  )
+                })}
               </div>
             ))}
           </div>


### PR DESCRIPTION
Before:

![screen shot 2019-01-22 at 3 17 57 pm](https://user-images.githubusercontent.com/638955/51572309-d9697300-1e59-11e9-9e75-05adf4acae99.png)

After:

![screen shot 2019-01-22 at 3 21 56 pm](https://user-images.githubusercontent.com/638955/51572316-de2e2700-1e59-11e9-874c-b6f13acedf22.png)

Revolutionary, really.