### PR TITLE
fix(ui/dataLoaders): Ensure the correct line protocol is written 

### DIFF
--- a/ui/src/onboarding/actions/dataLoaders.ts
+++ b/ui/src/onboarding/actions/dataLoaders.ts
@@ -395,15 +395,19 @@ export const setPrecision = (precision: WritePrecision): SetPrecision => ({
   payload: {precision},
 })
 
-export const writeLineProtocolAction = (
-  org: string,
-  bucket: string,
-  body: string,
-  precision: WritePrecision
-) => async dispatch => {
+export const writeLineProtocolAction = () => async (
+  dispatch,
+  getState: GetState
+) => {
+  const {
+    dataLoading: {
+      dataLoaders: {lineProtocolBody, precision},
+      steps: {org, bucket},
+    },
+  } = getState()
   try {
     dispatch(setLPStatus(RemoteDataState.Loading))
-    await writeLineProtocol(org, bucket, body, precision)
+    await writeLineProtocol(org, bucket, lineProtocolBody, precision)
     dispatch(setLPStatus(RemoteDataState.Done))
   } catch (error) {
     dispatch(setLPStatus(RemoteDataState.Error))

--- a/ui/src/onboarding/components/configureStep/lineProtocol/LineProtocol.tsx
+++ b/ui/src/onboarding/components/configureStep/lineProtocol/LineProtocol.tsx
@@ -90,15 +90,7 @@ export class LineProtocol extends PureComponent<Props> {
   }
 
   private handleSubmit = async () => {
-    const {
-      bucket,
-      org,
-      writeLineProtocolAction,
-      lineProtocolBody,
-      precision,
-    } = this.props
-
-    writeLineProtocolAction(org, bucket, lineProtocolBody, precision)
+    writeLineProtocolAction()
     this.props.onClickNext()
   }
 }


### PR DESCRIPTION
Closes #11433

_Briefly describe your proposed changes:_
previously, when uploading a file, it was using stale data to write to the api rather than what was uploaded

  - [ ] Rebased/mergeable
  - [ ] Tests pass
