### PR TITLE
Update scraper url to match quick start scraper url

### DIFF
--- a/ui/src/logs/constants/index.ts
+++ b/ui/src/logs/constants/index.ts
@@ -11,8 +11,6 @@ export const DEFAULT_TRUNCATION = true
 
 export const LOG_VIEW_NAME = 'LOGS_PAGE'
 
-export const QUICKSTART_SCRAPER_TARGET_URL = 'http://localhost:9999/metrics'
-
 export const EMPTY_VIEW_PROPERTIES: LogViewerView = {
   columns: [],
   type: ViewType.LogViewer,

--- a/ui/src/onboarding/components/CompletionStep.tsx
+++ b/ui/src/onboarding/components/CompletionStep.tsx
@@ -28,7 +28,7 @@ import {
 } from 'src/clockface'
 import {Organization, Dashboard} from 'src/api'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
-import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/logs/constants'
+import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/onboarding/constants/pluginConfigs'
 
 interface Props extends OnboardingStepProps {
   orgID: string

--- a/ui/src/onboarding/constants/pluginConfigs.ts
+++ b/ui/src/onboarding/constants/pluginConfigs.ts
@@ -28,6 +28,8 @@ import {
   TelegrafPluginInputTail,
 } from 'src/api'
 
+export const QUICKSTART_SCRAPER_TARGET_URL = 'http://localhost:9999/metrics'
+
 interface PluginBundles {
   [bundleName: string]: TelegrafPluginName[]
 }

--- a/ui/src/onboarding/reducers/dataLoaders.test.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.test.ts
@@ -39,6 +39,7 @@ import {
   telegrafConfig,
   dockerTelegrafPlugin,
 } from 'mocks/dummyData'
+import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/onboarding/constants/pluginConfigs'
 
 // Types
 import {
@@ -410,7 +411,7 @@ describe('dataLoader reducer', () => {
 
     const expected = {
       ...INITIAL_STATE,
-      scraperTarget: {bucket: 'a', url: 'http://127.0.0.1:9999/metrics'},
+      scraperTarget: {bucket: 'a', url: QUICKSTART_SCRAPER_TARGET_URL},
     }
 
     expect(actual).toEqual(expected)

--- a/ui/src/onboarding/reducers/dataLoaders.ts
+++ b/ui/src/onboarding/reducers/dataLoaders.ts
@@ -24,6 +24,7 @@ import {
 } from 'src/types/v2/dataLoaders'
 import {RemoteDataState} from 'src/types'
 import {WritePrecision} from 'src/api'
+import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/onboarding/constants/pluginConfigs'
 
 export const INITIAL_STATE: DataLoadersState = {
   telegrafPlugins: [],
@@ -34,7 +35,7 @@ export const INITIAL_STATE: DataLoadersState = {
   precision: WritePrecision.Ns,
   telegrafConfigID: null,
   pluginBundles: [],
-  scraperTarget: {bucket: '', url: 'http://127.0.0.1:9999/metrics'},
+  scraperTarget: {bucket: '', url: QUICKSTART_SCRAPER_TARGET_URL},
 }
 
 export default (state = INITIAL_STATE, action: Action): DataLoadersState => {

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -8,7 +8,7 @@ type NotificationExcludingMessage = Pick<
 >
 
 import {FIVE_SECONDS, TEN_SECONDS, INFINITE} from 'src/shared/constants/index'
-import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/logs/constants'
+import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/onboarding/constants/pluginConfigs'
 
 const defaultErrorNotification: NotificationExcludingMessage = {
   type: 'error',


### PR DESCRIPTION
_Briefly describe your proposed changes:_
use `http://localhost:9999/metrics` rather than `http://127.0.0.1:9999/metrics`
constant was originally made in the wrong location 

  - [x] Rebased/mergeable
  - [ ] Tests pass
