### PR TITLE
chore(task): move 'task retry' command to 'task run retry'

### DIFF
--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -598,7 +598,7 @@ func init() {
 	cmd.MarkFlagRequired("task-id")
 	cmd.MarkFlagRequired("run-id")
 
-	taskCmd.AddCommand(cmd)
+	runCmd.AddCommand(cmd)
 }
 
 func runRetryF(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Runs are retried; tasks aren't.

Closes #11170.