### PR TITLE
fix(ui): inject tvar statements between imports and body

### DIFF
--- a/ui/src/shared/utils/renderQuery.ts
+++ b/ui/src/shared/utils/renderQuery.ts
@@ -23,10 +23,10 @@ export async function renderQuery(
   }
 
   const {imports, body} = await extractImports(query)
-  let variableDelcarations = formatVariables(variables, query)
+  let variableDeclarations = formatVariables(variables, query)
 
   if (query.includes(WINDOW_PERIOD)) {
-    const ast = await getAST(`${variableDelcarations}\n\n${query}`)
+    const ast = await getAST(`${variableDeclarations}\n\n${query}`)
 
     let windowPeriod: number
 
@@ -36,10 +36,10 @@ export async function renderQuery(
       windowPeriod = FALLBACK_WINDOW_PERIOD
     }
 
-    variableDelcarations += `\n${WINDOW_PERIOD} = ${windowPeriod}ms`
+    variableDeclarations += `\n${WINDOW_PERIOD} = ${windowPeriod}ms`
   }
 
-  return `${imports}\n\n${variableDelcarations}\n\n${body}`
+  return `${imports}\n\n${variableDeclarations}\n\n${body}`
 }
 
 async function extractImports(

--- a/ui/src/shared/utils/renderQuery.ts
+++ b/ui/src/shared/utils/renderQuery.ts
@@ -62,7 +62,7 @@ function formatVariables(
     .join('\n')
 }
 
-async function getAST(query: string): Promise<object> {
+async function getAST(query: string): Promise<{files}> {
   const {data} = await queryAPI.queryAstPost(undefined, undefined, {query})
 
   return data.ast


### PR DESCRIPTION
Closes #11428

_Briefly describe your proposed changes:_
Extract import statement(s) and the query expression(s) from the query AST. Inject any UI-generated variables between these two statement blocks. Then submit the concatenated Flux query to the server.

We're opting to retrieve the AST here to base our work on a source of truth. This should help to avoid situations where the user submits an invalid query that is unintentionally made valid by hoisting import statements. We take a latency hit here, but this approach should at least be sufficient for an alpha release.

  - [x] Rebased/mergeable
  - [x] Tests pass