### PR TITLE
fix(bolt): provide better error message when unable to find org by name

### DIFF
--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -99,7 +99,7 @@ func (c *Client) findOrganizationByName(ctx context.Context, tx *bolt.Tx, n stri
 	if o == nil {
 		return nil, &influxdb.Error{
 			Code: influxdb.ENotFound,
-			Msg:  "organization not found",
+			Msg:  fmt.Sprintf("organization name \"%s\" not found", n),
 		}
 	}
 


### PR DESCRIPTION
Closes #10622

```
bin/darwin/influx --token xxx bucket create -n jadebucket --org foobar
Error: Bolt/FindOrganization: <not found> organization name "foobar" not found.
```