### PR TITLE
fix(http): if bucket or org do not exist, do not report

### DIFF
--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -458,6 +458,8 @@ func (h *ScraperHandler) newTargetResponse(ctx context.Context, target influxdb.
 		res.Bucket = bucket.Name
 		res.BucketID = bucket.ID
 		res.Links.Bucket = bucketIDPath(bucket.ID)
+	} else {
+		res.BucketID = influxdb.InvalidID()
 	}
 
 	org, err := h.OrganizationService.FindOrganizationByID(ctx, target.OrgID)
@@ -465,6 +467,8 @@ func (h *ScraperHandler) newTargetResponse(ctx context.Context, target influxdb.
 		res.Organization = org.Name
 		res.OrgID = org.ID
 		res.Links.Organization = organizationIDPath(org.ID)
+	} else {
+		res.OrgID = influxdb.InvalidID()
 	}
 
 	return res, nil

--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -411,7 +411,7 @@ type getTargetsLinks struct {
 
 type getTargetsResponse struct {
 	Links   getTargetsLinks  `json:"links"`
-	Targets []targetResponse `json:"scraper_targets"`
+	Targets []targetResponse `json:"configurations"`
 }
 
 type targetLinks struct {

--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -415,16 +415,16 @@ type getTargetsResponse struct {
 }
 
 type targetLinks struct {
-	Self string `json:"self"`
+	Self         string `json:"self"`
+	Bucket       string `json:"bucket,omitempty"`
+	Organization string `json:"organization,omitempty"`
 }
 
 type targetResponse struct {
 	influxdb.ScraperTarget
-	// Organization name.
-	Organization string `json:"organization"`
-	// Bucket name.
-	Bucket string      `json:"bucket"`
-	Links  targetLinks `json:"links"`
+	Organization string      `json:"organization,omitempty"`
+	Bucket       string      `json:"bucket,omitempty"`
+	Links        targetLinks `json:"links"`
 }
 
 func (h *ScraperHandler) newListTargetsResponse(ctx context.Context, targets []influxdb.ScraperTarget) (getTargetsResponse, error) {
@@ -447,20 +447,25 @@ func (h *ScraperHandler) newListTargetsResponse(ctx context.Context, targets []i
 }
 
 func (h *ScraperHandler) newTargetResponse(ctx context.Context, target influxdb.ScraperTarget) (targetResponse, error) {
-	bucket, err := h.BucketService.FindBucketByID(ctx, target.BucketID)
-	if err != nil {
-		return targetResponse{}, err
-	}
-	org, err := h.OrganizationService.FindOrganizationByID(ctx, target.OrgID)
-	if err != nil {
-		return targetResponse{}, err
-	}
-	return targetResponse{
+	res := targetResponse{
 		Links: targetLinks{
 			Self: targetIDPath(target.ID),
 		},
-		Bucket:        bucket.Name,
-		Organization:  org.Name,
 		ScraperTarget: target,
-	}, nil
+	}
+	bucket, err := h.BucketService.FindBucketByID(ctx, target.BucketID)
+	if err == nil {
+		res.Bucket = bucket.Name
+		res.BucketID = bucket.ID
+		res.Links.Bucket = bucketIDPath(bucket.ID)
+	}
+
+	org, err := h.OrganizationService.FindOrganizationByID(ctx, target.OrgID)
+	if err == nil {
+		res.Organization = org.Name
+		res.OrgID = org.ID
+		res.Links.Organization = organizationIDPath(org.ID)
+	}
+
+	return res, nil
 }

--- a/http/scraper_service_test.go
+++ b/http/scraper_service_test.go
@@ -102,7 +102,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 					  "links": {
 					    "self": "/api/v2/scrapers"
 					  },
-					  "scraper_targets": [
+					  "configurations": [
 					    {
 					      "id": "%s",
 						  "name": "target-1",
@@ -175,7 +175,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
                   "links": {
                     "self": "/api/v2/scrapers"
                   },
-                  "scraper_targets": []
+                  "configurations": []
                 }
                 `,
 			},

--- a/http/scraper_service_test.go
+++ b/http/scraper_service_test.go
@@ -113,6 +113,8 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 						  "type": "prometheus",
 						  "url": "www.one.url",
 						  "links": {
+						    "bucket": "/api/v2/buckets/0000000000000212",
+						    "organization": "/api/v2/orgs/0000000000000211",
 						    "self": "/api/v2/scrapers/0000000000000111"
 						  }
 						},
@@ -126,6 +128,8 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 						  "type": "prometheus",
 						  "url": "www.two.url",
 						  "links": {
+						    "bucket": "/api/v2/buckets/0000000000000212",
+						    "organization": "/api/v2/orgs/0000000000000211",
 						    "self": "/api/v2/scrapers/0000000000000222"
 						  }
                         }
@@ -210,7 +214,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 				t.Errorf("%q. handleGetScraperTargets() = %v, want %v", tt.name, content, tt.wants.contentType)
 			}
 			if eq, diff, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
-				t.Errorf("%q. handleGetScraperTargets() = ***%s***", tt.name, diff)
+				t.Errorf("%q. handleGetScraperTargets() = ***%s***\n\ngot:\n%s\n\nwant:\n%s", tt.name, diff, string(body), tt.wants.body)
 			}
 		})
 	}
@@ -295,6 +299,8 @@ func TestService_handleGetScraperTarget(t *testing.T) {
 					  "orgID": "0000000000000211",
 					  "organization": "org1",
                       "links": {
+                        "bucket": "/api/v2/buckets/0000000000000212",
+                        "organization": "/api/v2/orgs/0000000000000211",
                         "self": "/api/v2/scrapers/%[1]s"
                       }
                     }
@@ -518,6 +524,8 @@ func TestService_handlePostScraperTarget(t *testing.T) {
 					  "bucket": "bucket1",
                       "bucketID": "0000000000000212",
                       "links": {
+                        "bucket": "/api/v2/buckets/0000000000000212",
+                        "organization": "/api/v2/orgs/0000000000000211",
                         "self": "/api/v2/scrapers/%[1]s"
                       }
                     }
@@ -643,6 +651,8 @@ func TestService_handlePatchScraperTarget(t *testing.T) {
 					  "bucket": "bucket1",
 					  "bucketID":"0000000000000212",
 		              "links":{
+		                "bucket": "/api/v2/buckets/0000000000000212",
+		                "organization": "/api/v2/orgs/0000000000000211",
 		                "self":"/api/v2/scrapers/%[1]s"
 		              }
 		            }`,

--- a/ui/src/organizations/components/ScraperList.tsx
+++ b/ui/src/organizations/components/ScraperList.tsx
@@ -6,13 +6,10 @@ import {IndexList} from 'src/clockface'
 import ScraperRow from 'src/organizations/components/ScraperRow'
 
 // Types
-import {ScraperTargetResponses, ScraperTargetResponse} from 'src/api'
-
-// Utils
-import {getDeep} from 'src/utils/wrappers'
+import {ScraperTargetResponse} from 'src/api'
 
 interface Props {
-  scrapers: ScraperTargetResponses
+  scrapers: ScraperTargetResponse[]
   emptyState: JSX.Element
   onDeleteScraper: (scraper) => void
 }
@@ -38,14 +35,9 @@ export default class ScraperList extends PureComponent<Props> {
 
   public get scrapersList(): JSX.Element[] {
     const {scrapers, onDeleteScraper} = this.props
-    const scraperTargets = getDeep<ScraperTargetResponse[]>(
-      scrapers,
-      'scraper_targets',
-      []
-    )
 
-    if (scraperTargets !== undefined) {
-      return scraperTargets.map(scraper => (
+    if (scrapers !== undefined) {
+      return scrapers.map(scraper => (
         <ScraperRow
           key={scraper.id}
           scraper={scraper}

--- a/ui/src/organizations/components/Scrapers.tsx
+++ b/ui/src/organizations/components/Scrapers.tsx
@@ -18,7 +18,6 @@ import {
   InputType,
 } from 'src/clockface'
 import DataLoadersWizard from 'src/dataLoaders/components/DataLoadersWizard'
-import FilterList from 'src/shared/components/Filter'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -52,7 +51,7 @@ export default class Scrapers extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {scrapers, buckets} = this.props
+    const {buckets} = this.props
     const {searchTerm} = this.state
 
     return (
@@ -69,19 +68,11 @@ export default class Scrapers extends PureComponent<Props, State> {
           />
           {this.createScraperButton}
         </TabbedPageHeader>
-        <FilterList<ScraperTargetResponse>
-          searchTerm={searchTerm}
-          searchKeys={['bucket']}
-          list={scrapers.configurations || []}
-        >
-          {configurations => (
-            <ScraperList
-              scrapers={{configurations}}
-              emptyState={this.emptyState}
-              onDeleteScraper={this.handleDeleteScraper}
-            />
-          )}
-        </FilterList>
+        <ScraperList
+          scrapers={this.configurations}
+          emptyState={this.emptyState}
+          onDeleteScraper={this.handleDeleteScraper}
+        />
         <DataLoadersWizard
           visible={this.isOverlayVisible}
           onCompleteSetup={this.handleDismissDataLoaders}
@@ -91,6 +82,28 @@ export default class Scrapers extends PureComponent<Props, State> {
         />
       </>
     )
+  }
+
+  private get configurations(): ScraperTargetResponse[] {
+    const {scrapers} = this.props
+    const {searchTerm} = this.state
+
+    if (!scrapers || !scrapers.configurations) {
+      return []
+    }
+
+    return scrapers.configurations.filter(c => {
+      if (!searchTerm) {
+        return true
+      }
+      if (!c.bucket) {
+        return false
+      }
+
+      return String(c.bucket)
+        .toLocaleLowerCase()
+        .includes(searchTerm.toLocaleLowerCase())
+    })
   }
 
   private get isOverlayVisible(): boolean {

--- a/ui/src/organizations/containers/OrganizationView.tsx
+++ b/ui/src/organizations/containers/OrganizationView.tsx
@@ -199,25 +199,27 @@ class OrganizationView extends PureComponent<Props> {
                   organization={org}
                   fetcher={getScrapers}
                 >
-                  {(scrapers, loading, fetch) => (
-                    <Spinner loading={loading}>
-                      <GetOrgResources<Bucket[]>
-                        organization={org}
-                        fetcher={getBuckets}
-                      >
-                        {(buckets, loading) => (
-                          <Spinner loading={loading}>
-                            <Scrapers
-                              scrapers={scrapers}
-                              onChange={fetch}
-                              orgName={org.name}
-                              buckets={buckets}
-                            />
-                          </Spinner>
-                        )}
-                      </GetOrgResources>
-                    </Spinner>
-                  )}
+                  {(scrapers, loading, fetch) => {
+                    return (
+                      <Spinner loading={loading}>
+                        <GetOrgResources<Bucket[]>
+                          organization={org}
+                          fetcher={getBuckets}
+                        >
+                          {(buckets, loading) => (
+                            <Spinner loading={loading}>
+                              <Scrapers
+                                scrapers={scrapers}
+                                onChange={fetch}
+                                orgName={org.name}
+                                buckets={buckets}
+                              />
+                            </Spinner>
+                          )}
+                        </GetOrgResources>
+                      </Spinner>
+                    )
+                  }}
                 </GetOrgResources>
               </TabbedPageSection>
             </TabbedPage>


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Previously, scrapers would not return if any bucket or org was missing.
Now, the bucket or org and their links will not be shown.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
