### PR TITLE
fix(gather): add all subscribers to a single nats queue group

### DIFF
--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -209,7 +209,6 @@ func (l *Launcher) Run(ctx context.Context, args ...string) error {
 	args = append(args, "--bolt-path", filepath.Join(l.Path, "influxd.bolt"))
 	args = append(args, "--protos-path", filepath.Join(l.Path, "protos"))
 	args = append(args, "--engine-path", filepath.Join(l.Path, "engine"))
-	args = append(args, "--nats-path", filepath.Join(l.Path, "nats"))
 	args = append(args, "--http-bind-address", "127.0.0.1:0")
 	args = append(args, "--log-level", "debug")
 	return l.Launcher.Run(ctx, args...)

--- a/gather/recorder.go
+++ b/gather/recorder.go
@@ -1,13 +1,10 @@
 package gather
 
 import (
-	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/influxdata/influxdb/tsdb"
 
-	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/nats"
 	"github.com/influxdata/influxdb/storage"
 	"go.uber.org/zap"
@@ -29,29 +26,6 @@ func (s PointWriter) Record(collected MetricsCollection) error {
 		return err
 	}
 	return s.Writer.WritePoints(ps)
-}
-
-// ServiceWriter will use the writer interface to record the metrics.
-type ServiceWriter struct {
-	Writer  influxdb.WriteService
-	Timeout time.Duration
-}
-
-// Record the metrics and write using writer interface.
-func (s ServiceWriter) Record(collected MetricsCollection) error {
-	r, err := collected.MetricsSlice.Reader()
-	if err != nil {
-		return err
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), s.Timeout)
-	defer cancel()
-	s.Writer.Write(ctx,
-		collected.OrgID,
-		collected.BucketID,
-		r,
-	)
-
-	return nil
 }
 
 // Recorder record the metrics of a time based.

--- a/gather/scheduler.go
+++ b/gather/scheduler.go
@@ -60,7 +60,7 @@ func NewScheduler(
 	}
 
 	for i := 0; i < numScrapers; i++ {
-		err := s.Subscribe(promTargetSubject, "", &handler{
+		err := s.Subscribe(promTargetSubject, "metrics", &handler{
 			Scraper:   new(prometheusScraper),
 			Publisher: p,
 			Logger:    l,

--- a/nats/server.go
+++ b/nats/server.go
@@ -14,15 +14,13 @@ var ErrNoNatsConnection = errors.New("nats connection has not been established. 
 // Server wraps a connection to a NATS streaming server
 type Server struct {
 	Server *stand.StanServer
-	config Config
 }
 
 // Open starts a NATS streaming server
 func (s *Server) Open() error {
 	opts := stand.GetDefaultOptions()
-	opts.StoreType = stores.TypeFile
+	opts.StoreType = stores.TypeMemory
 	opts.ID = ServerName
-	opts.FilestoreDir = s.config.FilestoreDir
 	server, err := stand.RunServerWithOpts(opts, nil)
 	if err != nil {
 		return err
@@ -38,15 +36,7 @@ func (s *Server) Close() {
 	s.Server.Shutdown()
 }
 
-// Config is the configuration for the NATS streaming server
-type Config struct {
-	// The directory where nats persists message information
-	FilestoreDir string
-}
-
 // NewServer creates and returns a new server struct from the provided config
-func NewServer(c Config) *Server {
-	return &Server{
-		config: c,
-	}
+func NewServer() *Server {
+	return &Server{}
 }


### PR DESCRIPTION
Previously, scrapers would scrape the target 10 times.  This was
because each scraper subscriber was not put into a queue group.

I've added the queue group "metrics" and now we the subcribers
will only scrape the target once.

Additionally, I moved to using nats memory instead of nats file
store.  We don't need durability for scraper runs across restarts.


  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
