### PR TITLE
refactor(prometheus): rename date to build_date for clarity

### DIFF
--- a/prometheus/influx.go
+++ b/prometheus/influx.go
@@ -10,8 +10,7 @@ import (
 )
 
 type influxCollector struct {
-	influxInfoDesc *prometheus.Desc
-
+	influxInfoDesc   *prometheus.Desc
 	influxUptimeDesc *prometheus.Desc
 	start            time.Time
 }
@@ -25,12 +24,12 @@ func NewInfluxCollector(procID platform.IDGenerator, build platform.BuildInfo) p
 			"influxdb_info",
 			"Information about the influxdb environment.",
 			nil, prometheus.Labels{
-				"version": build.Version,
-				"commit":  build.Commit,
-				"date":    build.Date,
-				"os":      runtime.GOOS,
-				"arch":    runtime.GOARCH,
-				"cpus":    strconv.Itoa(runtime.NumCPU()),
+				"version":    build.Version,
+				"commit":     build.Commit,
+				"build_date": build.Date,
+				"os":         runtime.GOOS,
+				"arch":       runtime.GOARCH,
+				"cpus":       strconv.Itoa(runtime.NumCPU()),
 			},
 		),
 		influxUptimeDesc: prometheus.NewDesc(


### PR DESCRIPTION
_Briefly describe your proposed changes:_

The prometheus metric `influx_info` had the label `date`.  This was the build date, so, for clarity, I've renamed it `build_date`.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
