### PR TITLE
Fix the example function for map

### DIFF
--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -975,7 +975,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     desc: 'Applies a function to each record in the input tables.',
-    example: 'map(fn: (r) => r._value * r._value), mergeKey: true)',
+    example: 'map(fn: (r) => r._value * r._value, mergeKey: true)',
     category: 'Transformations',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/map',


### PR DESCRIPTION
There was an extra perenthesis on the example
