### PR TITLE
Add types for JSON representation of a Flux AST

### DIFF
--- a/ui/src/shared/apis/v2/ast.ts
+++ b/ui/src/shared/apis/v2/ast.ts
@@ -1,0 +1,8 @@
+import {queryAPI} from 'src/utils/api'
+import {Package} from 'src/types/ast'
+
+export const getAST = async (query: string): Promise<Package> => {
+  const {data} = await queryAPI.queryAstPost(undefined, undefined, {query})
+
+  return data.ast
+}

--- a/ui/src/shared/utils/renderQuery.ts
+++ b/ui/src/shared/utils/renderQuery.ts
@@ -1,5 +1,7 @@
+// APIs
+import {getAST} from 'src/shared/apis/v2/ast'
+
 // Utils
-import {queryAPI} from 'src/utils/api'
 import {getMinDurationFromAST} from 'src/shared/utils/getMinDurationFromAST'
 
 // Constants
@@ -62,12 +64,6 @@ function formatVariables(
     .filter(([key]) => query.includes(key))
     .map(([key, value]) => `${key} = ${value}`)
     .join('\n')
-}
-
-async function getAST(query: string): Promise<{files}> {
-  const {data} = await queryAPI.queryAstPost(undefined, undefined, {query})
-
-  return data.ast
 }
 
 function getWindowInterval(durationMilliseconds: number = DEFAULT_DURATION_MS) {

--- a/ui/src/types/ast.ts
+++ b/ui/src/types/ast.ts
@@ -130,18 +130,28 @@ export interface MemberAssignment extends BaseNode {
   type: 'MemberExpression'
 }
 
-type Expression =
+export type Expression =
   | ArrayExpression
   | FunctionExpression
   | BinaryExpression
+  | BooleanLiteral
   | CallExpression
   | ConditionalExpression
+  | DateTimeLiteral
+  | DurationLiteral
+  | FloatLiteral
+  | Identifier
+  | IntegerLiteral
   | LogicalExpression
   | MemberExpression
   | IndexExpression
-  | PipeExpression
   | ObjectExpression
+  | PipeExpression
+  | PipeLiteral
+  | RegexpLiteral
+  | StringLiteral
   | UnaryExpression
+  | UnsignedIntegerLiteral
 
 export interface ArrayExpression extends BaseNode {
   elements: Expression[]
@@ -163,7 +173,7 @@ export interface BinaryExpression extends BaseNode {
 
 export interface CallExpression extends BaseNode {
   callee: Expression
-  arrguments: Expression[]
+  arguments: Expression[]
   type: 'CallExpression'
 }
 
@@ -231,9 +241,22 @@ export interface DateTimeLiteral extends BaseNode {
   type: 'DateTimeLiteral'
 }
 
+export type DurationUnit =
+  | 'y'
+  | 'mo'
+  | 'w'
+  | 'd'
+  | 'h'
+  | 'm'
+  | 's'
+  | 'ms'
+  | 'us'
+  | 'µs'
+  | 'ns'
+
 export interface Duration {
   magnitude: number
-  unit: string
+  unit: DurationUnit
 }
 
 export interface DurationLiteral extends BaseNode {
@@ -310,3 +333,5 @@ export type Operator =
   | NotRegexpMatchOperator
 
 export type LogicalOperator = AndOperator | OrOperator
+
+export type PropertyKey = Identifier | StringLiteral

--- a/ui/src/types/ast.ts
+++ b/ui/src/types/ast.ts
@@ -1,0 +1,312 @@
+export type Node =
+  | Package
+  | File
+  | PackageClause
+  | ImportDeclaration
+  | Block
+  | BadStatement
+  | ExpressionStatement
+  | ReturnStatement
+  | OptionStatement
+  | BuiltinStatement
+  | VariableAssignment
+  | MemberAssignment
+  | ArrayExpression
+  | FunctionExpression
+  | BinaryExpression
+  | CallExpression
+  | ConditionalExpression
+  | LogicalExpression
+  | MemberExpression
+  | IndexExpression
+  | PipeExpression
+  | ObjectExpression
+  | UnaryExpression
+  | Property
+  | Identifier
+  | BooleanLiteral
+  | DateTimeLiteral
+  | DurationLiteral
+  | FloatLiteral
+  | IntegerLiteral
+  | PipeLiteral
+  | RegexpLiteral
+  | StringLiteral
+  | UnsignedIntegerLiteral
+
+export interface Position {
+  line: number
+  column: number
+}
+
+export interface SourceLocation {
+  file: string
+  start: Position
+  end: Position
+  source: string
+}
+
+export interface BaseNode {
+  location?: SourceLocation
+  errors?: Array<{msg: string}>
+}
+
+export interface Package extends BaseNode {
+  path?: string
+  package: string
+  files: File[]
+  type: 'Package'
+}
+
+export interface File extends BaseNode {
+  name?: string
+  package: PackageClause
+  imports: ImportDeclaration[]
+  body: Statement[]
+  type: 'File'
+}
+
+export interface PackageClause extends BaseNode {
+  name: Identifier
+  type: 'PackageClause'
+}
+
+export interface ImportDeclaration extends BaseNode {
+  as: Identifier
+  path: StringLiteral
+  type: 'ImportDeclaration'
+}
+
+export interface Block extends BaseNode {
+  body: Statement[]
+  type: 'Block'
+}
+
+export type Statement =
+  | BadStatement
+  | ExpressionStatement
+  | ReturnStatement
+  | OptionStatement
+  | BuiltinStatement
+  | VariableAssignment
+  | MemberAssignment
+
+export interface BadStatement extends BaseNode {
+  text: string
+  type: 'BadStatement'
+}
+
+export interface ExpressionStatement extends BaseNode {
+  expression: Expression
+  type: 'ExpressionStatement'
+}
+
+export interface ReturnStatement extends BaseNode {
+  argument: Expression
+  type: 'ReturnStatement'
+}
+
+export interface OptionStatement extends BaseNode {
+  assignment: Assignment
+  type: 'OptionStatement'
+}
+
+export interface BuiltinStatement extends BaseNode {
+  id: Identifier
+  type: 'BuiltinStatement'
+}
+
+export type Assignment = VariableAssignment | MemberAssignment
+
+export interface VariableAssignment extends BaseNode {
+  id: Identifier
+  init: Expression
+  type: 'VariableAssignment'
+}
+
+export interface MemberAssignment extends BaseNode {
+  member: MemberExpression
+  init: Expression
+  type: 'MemberExpression'
+}
+
+type Expression =
+  | ArrayExpression
+  | FunctionExpression
+  | BinaryExpression
+  | CallExpression
+  | ConditionalExpression
+  | LogicalExpression
+  | MemberExpression
+  | IndexExpression
+  | PipeExpression
+  | ObjectExpression
+  | UnaryExpression
+
+export interface ArrayExpression extends BaseNode {
+  elements: Expression[]
+  type: 'ArrayExpression'
+}
+
+export interface FunctionExpression extends BaseNode {
+  params: Property[]
+  body: Node
+  type: 'FunctionExpression'
+}
+
+export interface BinaryExpression extends BaseNode {
+  operator: Operator
+  left: Expression
+  right: Expression
+  type: 'BinaryExpression'
+}
+
+export interface CallExpression extends BaseNode {
+  callee: Expression
+  arrguments: Expression[]
+  type: 'CallExpression'
+}
+
+export interface ConditionalExpression extends BaseNode {
+  test: Expression
+  alternate: Expression
+  consequent: Expression
+  type: 'ConditionalExpression'
+}
+
+export interface LogicalExpression extends BaseNode {
+  operator: LogicalOperator
+  left: Expression
+  right: Expression
+  type: 'LogicalExpression'
+}
+
+export interface MemberExpression extends BaseNode {
+  object: Expression
+  property: PropertyKey
+  type: 'MemberExpression'
+}
+
+export interface IndexExpression extends BaseNode {
+  array: Expression
+  index: Expression
+  type: 'IndexExpression'
+}
+
+export interface PipeExpression extends BaseNode {
+  argument: Expression
+  call: CallExpression
+  type: 'PipeExpression'
+}
+
+export interface ObjectExpression extends BaseNode {
+  properties: Property[]
+  type: 'ObjectExpression'
+}
+
+export interface UnaryExpression extends BaseNode {
+  operator: Operator
+  argument: Expression
+  type: 'UnaryExpression'
+}
+
+export interface Property extends BaseNode {
+  key: PropertyKey
+  value: Expression
+  type: 'Property'
+}
+
+export interface Identifier extends BaseNode {
+  name: string
+  type: 'Identifier'
+}
+
+export interface BooleanLiteral extends BaseNode {
+  value: boolean
+  type: 'BooleanLiteral'
+}
+
+export interface DateTimeLiteral extends BaseNode {
+  value: string // RCF3339 datetime
+  type: 'DateTimeLiteral'
+}
+
+export interface Duration {
+  magnitude: number
+  unit: string
+}
+
+export interface DurationLiteral extends BaseNode {
+  values: Duration[]
+  type: 'DurationLiteral'
+}
+
+export interface FloatLiteral extends BaseNode {
+  value: number
+  type: 'FloatLiteral'
+}
+
+export interface IntegerLiteral extends BaseNode {
+  value: number
+  type: 'IntegerLiteral'
+}
+
+export interface PipeLiteral extends BaseNode {
+  type: 'PipeLiteral'
+}
+
+export interface RegexpLiteral extends BaseNode {
+  value: string
+  type: 'RegexpLiteral'
+}
+
+export interface StringLiteral extends BaseNode {
+  value: string
+  type: 'StringLiteral'
+}
+
+export interface UnsignedIntegerLiteral extends BaseNode {
+  value: number
+  type: 'UnsignedIntegerLiteral'
+}
+
+export type MultiplicationOperator = '*'
+export type DivisionOperator = '/'
+export type AdditionOperator = '+'
+export type SubtractionOperator = '-'
+export type LessThanEqualOperator = '<='
+export type LessThanOperator = '<'
+export type GreaterThanOperator = '>'
+export type GreaterThanEqualOperator = '>='
+export type InOperator = 'in'
+export type NotOperator = 'not'
+export type NotEmptyOperator = 'not empty'
+export type EmptyOperator = 'empty'
+export type StartsWithOperator = 'startswith'
+export type EqualOperator = '=='
+export type NotEqualOperator = '!='
+export type RegexpMatchOperator = '=~'
+export type NotRegexpMatchOperator = '!~'
+export type AndOperator = 'and'
+export type OrOperator = 'or'
+
+export type Operator =
+  | MultiplicationOperator
+  | DivisionOperator
+  | AdditionOperator
+  | SubtractionOperator
+  | LessThanEqualOperator
+  | LessThanOperator
+  | GreaterThanOperator
+  | GreaterThanEqualOperator
+  | InOperator
+  | NotOperator
+  | NotEmptyOperator
+  | EmptyOperator
+  | StartsWithOperator
+  | EqualOperator
+  | NotEqualOperator
+  | RegexpMatchOperator
+  | NotRegexpMatchOperator
+
+export type LogicalOperator = AndOperator | OrOperator


### PR DESCRIPTION
These types were lifted from the [Flux source](https://github.com/influxdata/flux/blob/master/ast/ast.go).

Eventually it would be nice to generate them directly from the source, rather than writing them by hand. This might prove a bit challenging, since Go's type system is at odds with TypeScript's (there are no union types in Go).