### PR TITLE
ci(docker): add ca-certificates to the docker build

### DIFF
--- a/docker/influxd/Dockerfile
+++ b/docker/influxd/Dockerfile
@@ -4,6 +4,10 @@ COPY influx /usr/bin/influx
 
 EXPOSE 9999
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY docker/influxd/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["influxd"]


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Previously, we didn't have certs in our containers.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
