### PR TITLE
Display latest commit hash in UI

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,8 +16,8 @@
     "src": "./src"
   },
   "scripts": {
-    "start": "npm i && parcel watch -d build src/index.html",
-    "build": "parcel build -d build --no-source-maps --log-level 2 src/index.html",
+    "start": "npm i && GIT_SHA=$(git rev-parse HEAD) parcel watch -d build src/index.html",
+    "build": "GIT_SHA=$(git rev-parse HEAD) parcel build -d build --no-source-maps --log-level 2 src/index.html",
     "clean": "rm -rf ./build && rm -rf ./.cache && rm -rf node_modules",
     "test": "jest --maxWorkers=2",
     "test:watch": "jest --watch --verbose false",

--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -1,12 +1,11 @@
 import normalizer from 'src/normalizers/dashboardTime'
+import {VERSION} from 'src/shared/constants'
 import {
   newVersion,
   loadLocalSettingsFailed,
 } from 'src/shared/copy/notifications'
 
 import {LocalStorage} from 'src/types/localStorage'
-
-const VERSION = process.env.npm_package_version
 
 export const loadLocalStorage = (): LocalStorage => {
   try {

--- a/ui/src/me/components/Resources.tsx
+++ b/ui/src/me/components/Resources.tsx
@@ -10,14 +10,15 @@ import DashboardsList from 'src/me/components/DashboardsList'
 import ResourceFetcher from 'src/shared/components/resource_fetcher'
 import {Panel, Spinner} from 'src/clockface'
 
+// Constants
+import {VERSION, GIT_SHA} from 'src/shared/constants'
+
 // APIs
 import {getOrganizations, getDashboards} from 'src/organizations/apis'
 
 // Types
 import {Dashboard, MeState} from 'src/types/v2'
 import {Organization} from 'src/api'
-
-const VERSION = process.env.npm_package_version
 
 interface Props {
   me: MeState
@@ -72,7 +73,10 @@ class ResourceLists extends PureComponent<Props> {
             <Support />
           </Panel.Body>
           <Panel.Footer>
-            <p>Version {VERSION}</p>
+            <p>
+              Version {VERSION}{' '}
+              {GIT_SHA && <code>({GIT_SHA.slice(0, 7)})</code>}
+            </p>
           </Panel.Footer>
         </Panel>
       </>

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -434,3 +434,6 @@ export const HANDLE_PIXELS = 20
 export const MIN_HANDLE_PIXELS = 20
 export const MAX_SIZE = 1
 export const MIN_SIZE = 0
+
+export const VERSION = process.env.npm_package_version
+export const GIT_SHA = process.env.GIT_SHA


### PR DESCRIPTION
Closes #10818

Adds the first 7 characters of the latest commit hash next to the version stamp in the UI. For example, see the `Version 2.0.0 (5207308)` stamp in the lower right:

![screen shot 2019-01-23 at 4 10 58 pm](https://user-images.githubusercontent.com/638955/51645547-b60df900-1f29-11e9-9bc8-54212947d7d8.png)
