### PR TITLE
Allow TSI bitset cache to be configured

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -110,14 +110,12 @@
   # will allow TSM compactions to write to disk.
   # compact-throughput-burst = "48m"
 
-  # The threshold, in bytes, when an index write-ahead log file will compact
-  # into an index file. Lower sizes will cause log files to be compacted more
-  # quickly and result in lower heap usage at the expense of write throughput.
-  # Higher sizes will be compacted less frequently, store more series in-memory,
-  # and provide higher write throughput.
-  # Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
-  # Values without a size suffix are in bytes.
-  # max-index-log-file-size = "1m"
+  # If true, then the mmap advise value MADV_WILLNEED will be provided to the kernel with respect to
+  # TSM files. This setting has been found to be problematic on some kernels, and defaults to off.
+  # It might help users who have slow disks in some cases.
+  # tsm-use-madv-willneed = false
+
+  # Settings for the inmem index
 
   # The maximum series allowed per database before writes are dropped.  This limit can prevent
   # high cardinality issues at the database level.  This limit can be disabled by setting it to
@@ -129,10 +127,26 @@
   # disabled by setting it to 0.
   # max-values-per-tag = 100000
 
-  # If true, then the mmap advise value MADV_WILLNEED will be provided to the kernel with respect to
-  # TSM files. This setting has been found to be problematic on some kernels, and defaults to off.
-  # It might help users who have slow disks in some cases.
-  # tsm-use-madv-willneed = false
+  # Settings for the tsi1 index
+
+  # The threshold, in bytes, when an index write-ahead log file will compact
+  # into an index file. Lower sizes will cause log files to be compacted more
+  # quickly and result in lower heap usage at the expense of write throughput.
+  # Higher sizes will be compacted less frequently, store more series in-memory,
+  # and provide higher write throughput.
+  # Valid size suffixes are k, m, or g (case insensitive, 1024 = 1k).
+  # Values without a size suffix are in bytes.
+  # max-index-log-file-size = "1m"
+
+  # The size of the internal cache used in the TSI index to store previously 
+  # calculated series results. Cached results will be returned quickly from the cache rather
+  # than needing to be recalculated when a subsequent query with a matching tag key/value 
+  # predicate is executed. Setting this value to 0 will disable the cache, which may
+  # lead to query performance issues.
+  # This value should only be increased if it is known that the set of regularly used 
+  # tag key/value predicates across all measurements for a database is larger than 100. An
+  # increase in cache size may lead to an increase in heap usage.
+  series-id-set-cache-size = 100
 
 ###
 ### [coordinator]

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -70,6 +70,11 @@ func TestConfig_Validate_Error(t *testing.T) {
 	if err := c.Validate(); err != nil {
 		t.Error(err)
 	}
+
+	c.SeriesIDSetCacheSize = -1
+	if err := c.Validate(); err == nil || err.Error() != "series-id-set-cache-size must be non-negative" {
+		t.Errorf("unexpected error: %s", err)
+	}
 }
 
 func TestConfig_ByteSizes(t *testing.T) {

--- a/tsdb/index/tsi1/testdata/line-protocol-1M.txt.gz
+++ b/tsdb/index/tsi1/testdata/line-protocol-1M.txt.gz
@@ -1,0 +1,1 @@
+../../../testdata/line-protocol-1M.txt.gz

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -310,13 +310,26 @@ type Index struct {
 	sfile     *tsdb.SeriesFile
 }
 
+type EngineOption func(opts *tsdb.EngineOptions)
+
+// DisableTSICache allows the caller to disable the TSI bitset cache during a test.
+var DisableTSICache = func() EngineOption {
+	return func(opts *tsdb.EngineOptions) {
+		opts.Config.SeriesIDSetCacheSize = 0
+	}
+}
+
 // MustNewIndex will initialize a new index using the provide type. It creates
 // everything under the same root directory so it can be cleanly removed on Close.
 //
 // The index will not be opened.
-func MustNewIndex(index string) *Index {
+func MustNewIndex(index string, eopts ...EngineOption) *Index {
 	opts := tsdb.NewEngineOptions()
 	opts.IndexVersion = index
+
+	for _, opt := range eopts {
+		opt(&opts)
+	}
 
 	rootPath, err := ioutil.TempDir("", "influxdb-tsdb")
 	if err != nil {
@@ -357,8 +370,8 @@ func MustNewIndex(index string) *Index {
 
 // MustOpenNewIndex will initialize a new index using the provide type and opens
 // it.
-func MustOpenNewIndex(index string) *Index {
-	idx := MustNewIndex(index)
+func MustOpenNewIndex(index string, opts ...EngineOption) *Index {
+	idx := MustNewIndex(index, opts...)
 	idx.MustOpen()
 	return idx
 }
@@ -585,8 +598,14 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 		tags = append(tags, pt.Tags())
 	}
 
-	runBenchmark := func(b *testing.B, index string, queryN int) {
-		idx := MustOpenNewIndex(index)
+	runBenchmark := func(b *testing.B, index string, queryN int, useTSICache bool) {
+		var idx *Index
+		if !useTSICache {
+			idx = MustOpenNewIndex(index, DisableTSICache())
+		} else {
+			idx = MustOpenNewIndex(index)
+		}
+
 		var wg sync.WaitGroup
 		begin := make(chan struct{})
 
@@ -659,13 +678,11 @@ func BenchmarkIndex_ConcurrentWriteQuery(b *testing.B) {
 			for _, queryN := range queries {
 				b.Run(fmt.Sprintf("queries %d", queryN), func(b *testing.B) {
 					b.Run("cache", func(b *testing.B) {
-						tsi1.EnableBitsetCache = true
-						runBenchmark(b, indexType, queryN)
+						runBenchmark(b, indexType, queryN, true)
 					})
 
 					b.Run("no cache", func(b *testing.B) {
-						tsi1.EnableBitsetCache = false
-						runBenchmark(b, indexType, queryN)
+						runBenchmark(b, indexType, queryN, false)
 					})
 				})
 			}


### PR DESCRIPTION
This PR allows the TSI series id set cache (bitset cache) to be configured via the config. The new config option is as follows:


```toml
[data]
  ...
  tsi-cache-size = 100
  ...
```

The value defaults to `100`. Setting the value to `0` will disable the cache completely. Disabling the cache can lead to query performance degradation. 

From a docs perspective, I would describe this setting as follows:

>The size of the internal cache used in the TSI index to store previously calculated series results. Cached results will be returned quickly from the cache rather than needing to be recalculated when a subsequent query with a matching tag key/value predicate is executed. Setting this value to 0 will disable the cache, which may lead to query performance issues. This value should only be increased if it is known that the set of regularly used tag key/value predicates across all measurements for a database is larger than 100. An increase in cache size may lead to an increase in heap usage.

/cc @stevebang 
