### PR TITLE
Remove copy-on-write when caching bitmaps

### DIFF
--- a/tsdb/series_set.go
+++ b/tsdb/series_set.go
@@ -86,16 +86,6 @@ func (s *SeriesIDSet) Contains(id SeriesID) bool {
 	return x
 }
 
-// SetCOW sets the copy-on-write status of the underlying bitmap. When SetCOW(true)
-// is called, modifications to the bitmap will result in copies of the relevant
-// data structures being made, preventing consumers of clones of the bitmap from
-// seeing those modifications.
-func (s *SeriesIDSet) SetCOW(b bool) {
-	s.Lock()
-	defer s.Unlock()
-	s.bitmap.SetCopyOnWrite(b)
-}
-
 // ContainsNoLock returns true if the id exists in the set. ContainsNoLock is
 // not safe for use from multiple goroutines. The caller must manage synchronization.
 func (s *SeriesIDSet) ContainsNoLock(id SeriesID) bool {

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -950,7 +950,6 @@ func (i *Index) tagValueSeriesIDIterator(name, key, value []byte) (tsdb.SeriesID
 	// Check if the iterator contains only series id sets. Cache them...
 	if ssitr, ok := itr.(tsdb.SeriesIDSetIterator); ok {
 		ss := ssitr.SeriesIDSet()
-		ss.SetCOW(true) // This is important to speed the clone up.
 		i.tagValueCache.Put(name, key, value, ss)
 	}
 	return itr, nil


### PR DESCRIPTION
In the case of caching TSI bitmaps belonging to immutable .tsi files,
the underlying bitset data can be mmapped. It is possible, though rare,
for this data to be unmapped (e.g., via a TSI compaction) but for the
cached bitmap to be subsequently read. This leads to a segfault.

This only happens when copy-on-write is set to true on the roaring
bitmap, because in that case only the internal pointers are cloned.

This change will reduce the TSI cache performance by around 10%, which I
have deemed to account for only a few microseconds typically.