### PR TITLE
feat: Add influx ping subcommand

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -34,6 +34,7 @@ func init() {
 	influxCmd.AddCommand(taskCmd)
 	influxCmd.AddCommand(userCmd)
 	influxCmd.AddCommand(writeCmd)
+	influxCmd.AddCommand(pingCmd)
 }
 
 // Flags contains all the CLI flag values for influx.

--- a/cmd/influx/ping.go
+++ b/cmd/influx/ping.go
@@ -3,11 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/check"
-	"github.com/spf13/cobra"
-	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/influxdata/influxdb/kit/check"
+	"github.com/spf13/cobra"
 )
 
 var pingCmd = &cobra.Command{
@@ -30,17 +30,13 @@ func pingF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
 		return fmt.Errorf("got %d from '%s'", resp.StatusCode, url)
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
 	var healthResponse check.Response
-	if err = json.Unmarshal(b, &healthResponse); err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&healthResponse); err != nil {
 		return err
 	}
 

--- a/cmd/influx/ping.go
+++ b/cmd/influx/ping.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/influxdata/influxdb/kit/check"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+var pingCmd = &cobra.Command{
+	Use:   "ping",
+	Short: "Check the InfluxDB /health endpoint",
+	Long:  `Checks the health of a running InfluxDB instance by querying /health. Does not require valid token.`,
+	RunE:  pingF,
+}
+
+func pingF(cmd *cobra.Command, args []string) error {
+	if flags.local {
+		return fmt.Errorf("local flag not supported for ping command")
+	}
+
+	c := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	url := flags.host + "/health"
+	resp, err := c.Get(url)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("got %d from '%s'", resp.StatusCode, url)
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var healthResponse check.Response
+	if err = json.Unmarshal(b, &healthResponse); err != nil {
+		return err
+	}
+
+	if healthResponse.Status == check.StatusPass {
+		fmt.Println("OK")
+	} else {
+		return fmt.Errorf("health check failed: '%s'", healthResponse.Message)
+	}
+
+	return nil
+}


### PR DESCRIPTION
For environments that do not have `nc`, `lsof`, `nmap`, `netstat`, but just a way to know if influxdb is up, this subcommand should work nicely.

I'll use it in Kubernetes with the nightly influxdb image, something like this:
```
...
      containers:
      - name: influxdb
        image: quay.io/influxdb/influx:nightly
        lifecycle:
          postStart:
            exec:
              command:
              - sh
              - -c
              - until influx ping; do echo waiting for influxd; sleep 1; done; influx setup -u $USERNAME -p $PASSWORD -o $ORGANIZATION -b $BUCKET -r 720 -t $INFLUX_TOKEN -f
...
```