### PR TITLE
fix(ui): fix overlay transition focusing

### DIFF
--- a/ui/src/clockface/components/label/LabelSelector.tsx
+++ b/ui/src/clockface/components/label/LabelSelector.tsx
@@ -79,6 +79,7 @@ class LabelSelector extends Component<Props, State> {
               onKeyDown={this.handleKeyDown}
               onChange={this.handleInputChange}
               size={inputSize}
+              autoFocus={true}
             />
             {this.suggestionMenu}
           </div>

--- a/ui/src/clockface/components/overlays/Overlay.scss
+++ b/ui/src/clockface/components/overlays/Overlay.scss
@@ -39,12 +39,14 @@ $overlay-gutter: $ix-marg-d;
 
 .overlay-tech {
   @extend %overlay-styles;
-  visibility: hidden;
   transition: all 0.25s ease;
   z-index: $z--overlays;
+  pointer-events: none;
+  opacity: 0;
 
   &.show {
-    visibility: visible;
+    opacity: 1;
+    pointer-events: all;
   }
 }
 


### PR DESCRIPTION

Closes #11497

_Briefly describe your proposed changes:_
Visibility hidden blocks autofocus to prevent certain xss attacks. Using `opacity: 0; pointer-events: none;` and `opacity: 1; pointer-events: all` seems to be a workaround.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
