### PR TITLE
fix(task): return ErrRunNotFound when finding run by ID

### DIFF
--- a/task/backend/query_logreader.go
+++ b/task/backend/query_logreader.go
@@ -175,7 +175,10 @@ from(bucketID: "000000000000000a")
 	if err != nil {
 		return nil, err
 	}
-	if len(runs) != 1 {
+	if len(runs) == 0 {
+		return nil, ErrRunNotFound
+	}
+	if len(runs) > 1 {
 		return nil, fmt.Errorf("expected one run, got %d", len(runs))
 	}
 

--- a/task/backend/storetest/logstoretest.go
+++ b/task/backend/storetest/logstoretest.go
@@ -330,6 +330,11 @@ func findRunByIDTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFu
 	if reflect.DeepEqual(returnedRun, rr2) {
 		t.Fatalf("updateing returned run modified RunStore data")
 	}
+
+	_, err = reader.FindRunByID(ctx, task.Org, 0xccc)
+	if err != backend.ErrRunNotFound {
+		t.Fatalf("expected finding run with invalid ID to return %v, got %v", backend.ErrRunNotFound, err)
+	}
 }
 
 func listLogsTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) {


### PR DESCRIPTION
This is necessary to return 404 from the HTTP handler.