### PR TITLE
Add slack notifications to litmus nightly runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"SUCCESSFUL: 'Branch: CIRCLE_BRANCH', Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)","username":"CircleCI Nightly Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)","username":"CircleCI Nightly Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data "{'channel':'#testing','text':'SUCCESSFUL: $MESSAGE','username:'CircleCI Nightly OSS Litmus Tests','icon_emoji':':circleci-pass:'}" https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: $MESSAGE","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,10 @@ jobs:
     machine: true
     steps:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
-      #- run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
-      - run:
-          name: Set Env Var
-          command: |
-            echo  'export MESSAGE="Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)"' >> $BASH_ENV
-            source $BASH_ENV
-            echo $MESSAGE
+      #- run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
           name: Litmus Nightly Tests Success
-          when: on_success
+          when: on_fail
           command: |
             curl -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_TOKEN" \
@@ -29,9 +23,20 @@ jobs:
             )
       - run:
           name: Litmus Nightly Tests Fail
-          when: on_fail
+          when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"FAIL: $MESSAGE","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-fail:"}' https://slack.com/api/chat.postMessage
+            curl -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-type: application/json; charset=utf-8" \
+            --data @<(cat <<EOF
+            {
+              "channel":"#testing",
+              "text":"FAIL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL",
+              "username:"CircleCI Nightly Litmus OSS Litmus Tests",
+              "icon_emoji":":circleci-fail:"
+            }
+            EOF
+            )
       - store_artifacts:
           path: ~/project 
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H 'Content-type: application/json' --data '{"token":"$SLACK_TOKEN","channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail
           command: |
-            curl curl -X POST -H 'Authorization: Bearer $SLACK_TOKEN' -H 'Content-type: application/json' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
       - store_artifacts:
           path: ~/project 
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST https://slack.com/api/chat.postMessage 
-            -H "Authorization: Bearer $SLACK_TOKEN"
-            -H "Content-type: application/json; charset=utf-8"
+            curl -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H "Content-type: application/json; charset=utf-8" \
             --data @<(cat <<EOF
             {
               "channel":"#testing",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data @<(cat <<EOF {"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM", Build URL: '$CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}EOF) https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data @<(cat <<EOF {"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}EOF) https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: Set Env Var
           command: |
-            echo  "export MESSAGE="Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]\($CIRCLE_BUILD_URL\)" >> $BASH_ENV
+            echo  'export MESSAGE="Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)"' >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: Litmus Nightly Tests Success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH'","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH', Job: '$CIRCLE_JOB'['$CIRCLE_BUILD_NUM']('$CIRCLE_BUILD_URL')","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes","username":"CircleCI Nightly Litmus Tests"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine: true
     steps:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
-      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      #- run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
           name: Set Env Var
           command: |
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH', Job: '$CIRCLE_JOB', Build: '$CIRCLE_BUILD_NUM', Build URL: '$CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH' Job: '$CIRCLE_JOB'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,18 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data @<(cat <<EOF {"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL","username":"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"} EOF) https://slack.com/api/chat.postMessage
+            curl -X POST 
+            -H "Authorization: Bearer $SLACK_TOKEN" 
+            -H "Content-type: application/json; charset=utf-8" 
+            --data @<(cat <<EOF
+            {
+              "channel":"#testing",
+              "text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL",
+              "username":"CircleCI Nightly Litmus OSS Litmus Tests",
+              "icon_emoji":":circleci-pass:"
+            }
+            EOF
+            ) https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes","username":"CircleCI Nightly Litmus Tests"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"SUCCESSFUL: 'Branch: CIRCLE_BRANCH', Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)","username":"CircleCI Nightly Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes","username:"CircleCI Nightly Litmus Tests","icon_emoji":":circleci-fail:"}' https://slack.com/api/chat.postMessage
       - store_artifacts:
           path: ~/project 
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST 
-            -H "Authorization: Bearer $SLACK_TOKEN" 
-            -H "Content-type: application/json; charset=utf-8" 
+            curl -X POST https://slack.com/api/chat.postMessage 
+            -H "Authorization: Bearer $SLACK_TOKEN"
+            -H "Content-type: application/json; charset=utf-8"
             --data @<(cat <<EOF
             {
               "channel":"#testing",
@@ -27,7 +27,6 @@ jobs:
             }
             EOF
             )
-            --url https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH'"+", Job: '$CIRCLE_JOB'"+", Build: '$CIRCLE_BUILD_NUM'", Build URL: '$CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data @<(cat <<EOF {"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM", Build URL: '$CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}EOF) https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data @<(cat <<EOF {"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}EOF) https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data @<(cat <<EOF {"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL","username":"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}EOF) https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH', Job: '$CIRCLE_JOB'['$CIRCLE_BUILD_NUM']('$CIRCLE_BUILD_URL')","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH', Job: '$CIRCLE_JOB'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH'", Job: '$CIRCLE_JOB'", Build: '$CIRCLE_BUILD_NUM'", Build URL: '$CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH'"+", Job: '$CIRCLE_JOB'"+", Build: '$CIRCLE_BUILD_NUM'", Build URL: '$CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,20 @@ jobs:
     machine: true
     steps:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
-      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      - run:
+          name: Litmus Nightly Tests Success
+          when: on_success
+          command: |
+            curl -X POST -H 'Authorization: Bearer $SLACK_TOKEN' -H 'Content-type: application/json' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
+      - run:
+          name: Litmus Nightly Tests Fail
+          when: on_fail
+          command: |
+            curl curl -X POST -H 'Authorization: Bearer $SLACK_TOKEN' -H 'Content-type: application/json' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
       - store_artifacts:
-          path: ~/project
-  
+          path: ~/project 
+ 
   jstest:
     docker:
       - image: circleci/golang:1.11-node-browsers
@@ -174,9 +184,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - gotest
-      - jstest
-      - build
+      - litmus_nightly 
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H 'Authorization: Bearer $SLACK_TOKEN' -H 'Content-type: application/json' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H 'Content-type: application/json' --data '{"token":"$SLACK_TOKEN","channel":"#testing","text":"Example Litmus nightly Test Passes"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             }
             EOF
             )
-            https://slack.com/api/chat.postMessage
+            --url https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ jobs:
     machine: true
     steps:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
-      #- run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
           name: Litmus Nightly Tests Success
-          when: on_fail
+          when: on_success
           command: |
             curl -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_TOKEN" \
@@ -23,7 +23,7 @@ jobs:
             )
       - run:
           name: Litmus Nightly Tests Fail
-          when: on_success
+          when: on_fail
           command: |
             curl -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_TOKEN" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             EOF
             )
       - store_artifacts:
-          path: ~/project 
+          path: ~/project
  
   jstest:
     docker:
@@ -208,7 +208,7 @@ workflows:
     jobs:
       - gotest
       - jstest
-      - build 
+      - build
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: '$MESSAGE'","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH'","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: Set Env Var
           command: |
-            echo  "export MESSAGE="Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)" >> $BASH_ENV
+            echo  "export MESSAGE="Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]\($CIRCLE_BUILD_URL\)" >> $BASH_ENV
             source $BASH_ENV
       - run:
           name: Litmus Nightly Tests Success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: $MESSAGE","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data "'"'{"channel":"#testing","text":"SUCCESSFUL: $MESSAGE","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}'"'" https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine: true
     steps:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
-      #- run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
           name: Set Env Var
           command: |
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH', Job: '$CIRCLE_JOB'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH', Job: '$CIRCLE_JOB', Build: '$CIRCLE_BUILD_NUM', Build URL: '$CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine: true
     steps:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
-      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      #- run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
           name: Set Env Var
           command: |
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data "'"'{"channel":"#testing","text":"SUCCESSFUL: $MESSAGE","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}'"'" https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data "'"'{"channel":"#testing","text":"SUCCESSFUL: MESSAGE","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}'"'" https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" -d "channel:#testing&text:SUCCESSFUL: $MESSAGE&username:CircleCI Nightly OSS Litmus Tests&icon_emoji::circleci-pass:" https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: MESSAGE","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine: true
     steps:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
-      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      #- run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
           name: Litmus Nightly Tests Success
           when: on_success
@@ -206,7 +206,9 @@ workflows:
   version: 2
   build:
     jobs:
-      - litmus_nightly 
+      - gotest
+      - jstest
+      - build 
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH'", Job: '$CIRCLE_JOB'", Build: '$CIRCLE_BUILD_NUM'", Build URL: '$CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" -d "channel":"#testing&text:SUCCESSFUL: $MESSAGE&username:CircleCI Nightly OSS Litmus Tests&icon_emoji::circleci-pass:" https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" -d "channel:#testing&text:SUCCESSFUL: $MESSAGE&username:CircleCI Nightly OSS Litmus Tests&icon_emoji::circleci-pass:" https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)","username":"CircleCI Nightly Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data "{'channel':'#testing','text':'SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)','username:'CircleCI Nightly OSS Litmus Tests','icon_emoji':':circleci-pass:'}" https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             {
               "channel":"#testing",
               "text":"FAIL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL",
-              "username:"CircleCI Nightly Litmus OSS Litmus Tests",
+              "username":"CircleCI Nightly Litmus OSS Litmus Tests",
               "icon_emoji":":circleci-fail:"
             }
             EOF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: MESSAGE","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: '$MESSAGE'","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,8 @@ jobs:
               "icon_emoji":":circleci-pass:"
             }
             EOF
-            ) https://slack.com/api/chat.postMessage
+            )
+            https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,15 @@ jobs:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_users_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
+          name: Set Env Var
+          command: |
+            echo  "export MESSAGE="Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)" >> $BASH_ENV
+            source $BASH_ENV
+      - run:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data "{'channel':'#testing','text':'SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)','username:'CircleCI Nightly OSS Litmus Tests','icon_emoji':':circleci-pass:'}" https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data "{'channel':'#testing','text':'SUCCESSFUL: $MESSAGE','username:'CircleCI Nightly OSS Litmus Tests','icon_emoji':':circleci-pass:'}" https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine: true
     steps:
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
-      #- run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
+      - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e TEST_LIST=tests_lists/gateway_api_tests.list --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
           name: Litmus Nightly Tests Success
           when: on_success
@@ -209,7 +209,6 @@ workflows:
       - gotest
       - jstest
       - build 
-      - litmus_nightly
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           command: |
             echo  'export MESSAGE="Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB[$CIRCLE_BUILD_NUM]($CIRCLE_BUILD_URL)"' >> $BASH_ENV
             source $BASH_ENV
+            echo $MESSAGE
       - run:
           name: Litmus Nightly Tests Success
           when: on_success
@@ -19,7 +20,7 @@ jobs:
           name: Litmus Nightly Tests Fail
           when: on_fail
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"Example Litmus nightly Test Passes","username:"CircleCI Nightly Litmus Tests","icon_emoji":":circleci-fail:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H 'Content-type: application/json; charset=utf-8' --data '{"channel":"#testing","text":"FAIL: $MESSAGE","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-fail:"}' https://slack.com/api/chat.postMessage
       - store_artifacts:
           path: ~/project 
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,7 @@ workflows:
       - gotest
       - jstest
       - build 
+      - litmus_nightly
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH' Job: '$CIRCLE_JOB'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data '{"channel":"#testing","text":"SUCCESSFUL: Branch: '$CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL'","username:"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}' https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data @<(cat <<EOF {"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL","username":"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"}EOF) https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data @<(cat <<EOF {"channel":"#testing","text":"SUCCESSFUL: Branch: $CIRCLE_BRANCH, Job: $CIRCLE_JOB, Build: $CIRCLE_BUILD_NUM, Build URL: $CIRCLE_BUILD_URL","username":"CircleCI Nightly Litmus OSS Litmus Tests","icon_emoji":":circleci-pass:"} EOF) https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Litmus Nightly Tests Success
           when: on_success
           command: |
-            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" --data "'"'{"channel":"#testing","text":"SUCCESSFUL: MESSAGE","username":"CircleCI Nightly OSS Litmus Tests","icon_emoji":":circleci-pass:"}'"'" https://slack.com/api/chat.postMessage
+            curl -X POST -H "Authorization: Bearer $SLACK_TOKEN" -H "Content-type: application/json; charset=utf-8" -d "channel":"#testing&text:SUCCESSFUL: $MESSAGE&username:CircleCI Nightly OSS Litmus Tests&icon_emoji::circleci-pass:" https://slack.com/api/chat.postMessage
       - run:
           name: Litmus Nightly Tests Fail
           when: on_fail


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
- Add a conditional slack notification to litmus nightly job. The notification(s) will be sent to the #testing channel and wold contain a link to the build. 

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
