### PR TITLE
Add the ability to inline-edit for Bucket, Dashboard, Tasks, Collecto…

### DIFF
--- a/ui/src/organizations/components/BucketList.tsx
+++ b/ui/src/organizations/components/BucketList.tsx
@@ -83,6 +83,7 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
                 onEditBucket={this.handleStartEdit}
                 onDeleteBucket={onDeleteBucket}
                 onAddData={this.handleStartAddData}
+                onUpdateBucket={this.handleUpdateBucket}
               />
             ))}
           </IndexList.Body>

--- a/ui/src/organizations/components/BucketRow.tsx
+++ b/ui/src/organizations/components/BucketRow.tsx
@@ -15,6 +15,7 @@ import {
 // Types
 import {Bucket} from 'src/api'
 import {DataLoaderType} from 'src/types/v2/dataLoaders'
+import EditableName from 'src/shared/components/EditableName'
 
 export interface PrettyBucket extends Bucket {
   ruleString: string
@@ -25,6 +26,7 @@ interface Props {
   onEditBucket: (b: PrettyBucket) => void
   onDeleteBucket: (b: PrettyBucket) => void
   onAddData: (b: PrettyBucket, d: DataLoaderType) => void
+  onUpdateBucket: (b: PrettyBucket) => void
 }
 
 export default class BucketRow extends PureComponent<Props> {
@@ -34,9 +36,11 @@ export default class BucketRow extends PureComponent<Props> {
       <>
         <IndexList.Row>
           <IndexList.Cell>
-            <a href="#" onClick={this.handleEditBucket}>
-              <span>{bucket.name}</span>
-            </a>
+            <EditableName
+              onUpdate={this.handleUpdateBucketName}
+              name={bucket.name}
+              onEditName={this.handleEditBucket}
+            />
           </IndexList.Cell>
           <IndexList.Cell>{bucket.ruleString}</IndexList.Cell>
           <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
@@ -76,6 +80,10 @@ export default class BucketRow extends PureComponent<Props> {
         </IndexList.Row>
       </>
     )
+  }
+
+  private handleUpdateBucketName = (value: string) => {
+    this.props.onUpdateBucket({...this.props.bucket, name: value})
   }
 
   private handleEditBucket = (): void => {

--- a/ui/src/organizations/components/Buckets.tsx
+++ b/ui/src/organizations/components/Buckets.tsx
@@ -112,6 +112,7 @@ export default class Buckets extends PureComponent<Props, State> {
     await client.buckets.update(updatedBucket.id, updatedBucket)
     this.props.onChange()
   }
+
   private handleDeleteBucket = async (deletedBucket: PrettyBucket) => {
     const {onChange, notify} = this.props
     await client.buckets.delete(deletedBucket.id)

--- a/ui/src/organizations/components/CollectorList.tsx
+++ b/ui/src/organizations/components/CollectorList.tsx
@@ -15,6 +15,7 @@ interface Props {
   emptyState: JSX.Element
   onDownloadConfig: (telegrafID: string, telegrafName: string) => void
   onDelete: (telegrafID: string) => void
+  onUpdate: (telegraf: Telegraf) => void
 }
 
 export default class CollectorList extends PureComponent<Props> {
@@ -37,7 +38,7 @@ export default class CollectorList extends PureComponent<Props> {
   }
 
   public get collectorsList(): JSX.Element[] {
-    const {collectors, onDownloadConfig, onDelete} = this.props
+    const {collectors, onDownloadConfig, onDelete, onUpdate} = this.props
 
     if (collectors !== undefined) {
       return collectors.map(collector => (
@@ -47,6 +48,7 @@ export default class CollectorList extends PureComponent<Props> {
           bucket={getDeep<string>(collector, 'plugins.0.config.bucket', '')}
           onDownloadConfig={onDownloadConfig}
           onDelete={onDelete}
+          onUpdate={onUpdate}
         />
       ))
     }

--- a/ui/src/organizations/components/CollectorRow.tsx
+++ b/ui/src/organizations/components/CollectorRow.tsx
@@ -12,12 +12,14 @@ import {
   ComponentSpacer,
 } from 'src/clockface'
 import {Telegraf} from 'src/api'
+import EditableName from 'src/shared/components/EditableName'
 
 interface Props {
   collector: Telegraf
   bucket: string
   onDownloadConfig: (telegrafID: string, telegrafName: string) => void
   onDelete: (telegrafID: string) => void
+  onUpdate: (telegraf: Telegraf) => void
 }
 
 export default class CollectorRow extends PureComponent<Props> {
@@ -26,7 +28,12 @@ export default class CollectorRow extends PureComponent<Props> {
     return (
       <>
         <IndexList.Row>
-          <IndexList.Cell>{collector.name}</IndexList.Cell>
+          <IndexList.Cell>
+            <EditableName
+              onUpdate={this.handleUpdateConfig}
+              name={collector.name}
+            />
+          </IndexList.Cell>
           <IndexList.Cell>{bucket}</IndexList.Cell>
           <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
             <ComponentSpacer align={Alignment.Right}>
@@ -47,6 +54,11 @@ export default class CollectorRow extends PureComponent<Props> {
         </IndexList.Row>
       </>
     )
+  }
+
+  private handleUpdateConfig = (name: string) => {
+    const {onUpdate, collector} = this.props
+    onUpdate({...collector, name})
   }
 
   private handleDownloadConfig = (): void => {

--- a/ui/src/organizations/components/Collectors.tsx
+++ b/ui/src/organizations/components/Collectors.tsx
@@ -104,6 +104,7 @@ export class Collectors extends PureComponent<Props, State> {
                     emptyState={this.emptyState}
                     onDownloadConfig={this.handleDownloadConfig}
                     onDelete={this.handleDeleteTelegraf}
+                    onUpdate={this.handleUpdateTelegraf}
                   />
                 )}
               </FilterList>
@@ -195,6 +196,11 @@ export class Collectors extends PureComponent<Props, State> {
 
   private handleDeleteTelegraf = async (telegrafID: string) => {
     await client.telegrafConfigs.delete(telegrafID)
+    this.props.onChange()
+  }
+
+  private handleUpdateTelegraf = async (telegraf: Telegraf) => {
+    await client.telegrafConfigs.update(telegraf.id, telegraf)
     this.props.onChange()
   }
 

--- a/ui/src/organizations/components/DashboardList.tsx
+++ b/ui/src/organizations/components/DashboardList.tsx
@@ -33,6 +33,7 @@ interface OwnProps {
   dashboards: Dashboard[]
   emptyState: JSX.Element
   onDeleteDashboard: (dashboard: Dashboard) => void
+  onUpdateDashboard: (dashboard: Dashboard) => void
 }
 
 type Props = DispatchProps & OwnProps
@@ -73,13 +74,14 @@ class DashboardList extends PureComponent<Props> {
   }
 
   private get rows(): JSX.Element[] {
-    const {onDeleteDashboard} = this.props
+    const {onDeleteDashboard, onUpdateDashboard} = this.props
 
     return this.props.dashboards.map(d => (
       <DashboardRow
         dashboard={d}
         key={d.id}
         onDeleteDashboard={onDeleteDashboard}
+        onUpdateDashboard={onUpdateDashboard}
         onCloneDashboard={this.handleCloneDashboard}
       />
     ))

--- a/ui/src/organizations/components/DashboardRow.tsx
+++ b/ui/src/organizations/components/DashboardRow.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {Link} from 'react-router'
 import moment from 'moment'
 
 // Components
@@ -21,10 +20,12 @@ import {Dashboard} from 'src/types/v2'
 
 // Constants
 import {UPDATED_AT_TIME_FORMAT} from 'src/dashboards/constants'
+import EditableName from 'src/shared/components/EditableName'
 
 interface Props {
   dashboard: Dashboard
   onDeleteDashboard: (dashboard: Dashboard) => void
+  onUpdateDashboard: (dashboard: Dashboard) => void
   onCloneDashboard: (dashboard: Dashboard) => void
 }
 
@@ -35,7 +36,11 @@ export default class DashboardRow extends PureComponent<Props> {
     return (
       <IndexList.Row key={dashboard.id}>
         <IndexList.Cell>
-          <Link to={`/dashboards/${dashboard.id}`}>{dashboard.name}</Link>
+          <EditableName
+            onUpdate={this.handleUpdateDashboard}
+            name={dashboard.name}
+            hrefValue={`/dashboards/${dashboard.id}`}
+          />
         </IndexList.Cell>
         {this.lastModifiedCell}
         <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
@@ -59,6 +64,10 @@ export default class DashboardRow extends PureComponent<Props> {
         </IndexList.Cell>
       </IndexList.Row>
     )
+  }
+
+  private handleUpdateDashboard = (name: string) => {
+    this.props.onUpdateDashboard({...this.props.dashboard, name})
   }
 
   private handleCloneDashboard = (): void => {

--- a/ui/src/organizations/components/Dashboards.tsx
+++ b/ui/src/organizations/components/Dashboards.tsx
@@ -3,9 +3,6 @@ import React, {PureComponent, ChangeEvent} from 'react'
 import {withRouter, WithRouterProps} from 'react-router'
 import _ from 'lodash'
 
-// APIs
-import {deleteDashboard} from 'src/dashboards/apis'
-
 // Components
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import {ComponentSize, EmptyState, Input, IconFont} from 'src/clockface'
@@ -17,6 +14,7 @@ import {Dashboard} from 'src/types/v2'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import {deleteDashboard, updateDashboard} from 'src/dashboards/apis/v2'
 
 interface OwnProps {
   dashboards: Dashboard[]
@@ -66,6 +64,7 @@ class Dashboards extends PureComponent<Props, State> {
               dashboards={ds}
               emptyState={this.emptyState}
               onDeleteDashboard={this.handleDeleteDashboard}
+              onUpdateDashboard={this.handleUpdateDashboard}
               orgID={orgID}
               router={router}
             />
@@ -73,6 +72,11 @@ class Dashboards extends PureComponent<Props, State> {
         </FilterList>
       </>
     )
+  }
+
+  private handleUpdateDashboard = async (dashboard: Dashboard) => {
+    await updateDashboard(dashboard)
+    this.props.onChange()
   }
 
   private handleFilterChange = (e: ChangeEvent<HTMLInputElement>): void => {

--- a/ui/src/organizations/components/ScraperList.tsx
+++ b/ui/src/organizations/components/ScraperList.tsx
@@ -12,6 +12,7 @@ interface Props {
   scrapers: ScraperTargetResponse[]
   emptyState: JSX.Element
   onDeleteScraper: (scraper) => void
+  onUpdateScraper: (scraper: ScraperTargetResponse) => void
 }
 
 export default class ScraperList extends PureComponent<Props> {
@@ -34,7 +35,7 @@ export default class ScraperList extends PureComponent<Props> {
   }
 
   public get scrapersList(): JSX.Element[] {
-    const {scrapers, onDeleteScraper} = this.props
+    const {scrapers, onDeleteScraper, onUpdateScraper} = this.props
 
     if (scrapers !== undefined) {
       return scrapers.map(scraper => (
@@ -42,6 +43,7 @@ export default class ScraperList extends PureComponent<Props> {
           key={scraper.id}
           scraper={scraper}
           onDeleteScraper={onDeleteScraper}
+          onUpdateScraper={onUpdateScraper}
         />
       ))
     }

--- a/ui/src/organizations/components/ScraperRow.tsx
+++ b/ui/src/organizations/components/ScraperRow.tsx
@@ -9,10 +9,12 @@ import {
   Alignment,
 } from 'src/clockface'
 import {ScraperTargetResponse} from 'src/api'
+import EditableName from 'src/shared/components/EditableName'
 
 interface Props {
   scraper: ScraperTargetResponse
   onDeleteScraper: (scraper) => void
+  onUpdateScraper: (scraper: ScraperTargetResponse) => void
 }
 
 export default class ScraperRow extends PureComponent<Props> {
@@ -21,7 +23,12 @@ export default class ScraperRow extends PureComponent<Props> {
     return (
       <>
         <IndexList.Row>
-          <IndexList.Cell>{scraper.url}</IndexList.Cell>
+          <IndexList.Cell>
+            <EditableName
+              onUpdate={this.handleUpdateScraper}
+              name={scraper.url}
+            />
+          </IndexList.Cell>
           <IndexList.Cell>{scraper.bucket}</IndexList.Cell>
           <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
             <ConfirmationButton
@@ -35,5 +42,10 @@ export default class ScraperRow extends PureComponent<Props> {
         </IndexList.Row>
       </>
     )
+  }
+
+  private handleUpdateScraper = (name: string) => {
+    const {onUpdateScraper, scraper} = this.props
+    onUpdateScraper({...scraper, url: name})
   }
 }

--- a/ui/src/organizations/components/Scrapers.tsx
+++ b/ui/src/organizations/components/Scrapers.tsx
@@ -71,6 +71,7 @@ export default class Scrapers extends PureComponent<Props, State> {
           scrapers={this.configurations}
           emptyState={this.emptyState}
           onDeleteScraper={this.handleDeleteScraper}
+          onUpdateScraper={this.handleUpdateScraper}
         />
         <DataLoadersWizard
           visible={this.isOverlayVisible}
@@ -159,6 +160,11 @@ export default class Scrapers extends PureComponent<Props, State> {
         <EmptyState.Text text="No Scraper buckets match your query" />
       </EmptyState>
     )
+  }
+
+  private handleUpdateScraper = async (scraper: ScraperTargetResponse) => {
+    await client.scrapers.update(scraper.id, scraper)
+    this.props.onChange()
   }
 
   private handleDeleteScraper = async (scraper: ScraperTargetResponse) => {

--- a/ui/src/organizations/components/TaskList.tsx
+++ b/ui/src/organizations/components/TaskList.tsx
@@ -12,6 +12,7 @@ interface Props {
   tasks: Task[]
   emptyState: JSX.Element
   onDelete: (taskID: string) => void
+  onUpdate: (task: Task) => void
 }
 
 export default class TaskList extends PureComponent<Props> {
@@ -31,9 +32,14 @@ export default class TaskList extends PureComponent<Props> {
   }
 
   private get rows(): JSX.Element[] {
-    const {tasks, onDelete} = this.props
+    const {tasks, onDelete, onUpdate} = this.props
     return tasks.map(task => (
-      <TaskRow key={task.id} task={task} onDelete={onDelete} />
+      <TaskRow
+        key={task.id}
+        task={task}
+        onDelete={onDelete}
+        onUpdate={onUpdate}
+      />
     ))
   }
 }

--- a/ui/src/organizations/components/TaskRow.tsx
+++ b/ui/src/organizations/components/TaskRow.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {Link} from 'react-router'
 
 // Components
 import {
@@ -12,10 +11,12 @@ import {
 
 // Api
 import {Task} from 'src/api'
+import EditableName from 'src/shared/components/EditableName'
 
 interface Props {
   task: Task
   onDelete: (taskID: string) => void
+  onUpdate: (task: Task) => void
 }
 
 export default class TaskRow extends PureComponent<Props> {
@@ -26,9 +27,13 @@ export default class TaskRow extends PureComponent<Props> {
       <>
         <IndexList.Row key={task.id}>
           <IndexList.Cell>
-            <Link to={`/tasks/${task.id}`}>{task.name}</Link>
+            <EditableName
+              onUpdate={this.handleUpdateTask}
+              name={task.name}
+              hrefValue={`/tasks/${task.id}`}
+            />
           </IndexList.Cell>
-          <IndexList.Cell>{task.owner.name}</IndexList.Cell>
+          <IndexList.Cell>{task.name}</IndexList.Cell>
           <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
             <ConfirmationButton
               size={ComponentSize.ExtraSmall}
@@ -40,6 +45,11 @@ export default class TaskRow extends PureComponent<Props> {
         </IndexList.Row>
       </>
     )
+  }
+
+  private handleUpdateTask = (name: string) => {
+    const {onUpdate, task} = this.props
+    onUpdate({...task, name})
   }
 
   private handleDeleteTask = (): void => {

--- a/ui/src/organizations/components/Tasks.tsx
+++ b/ui/src/organizations/components/Tasks.tsx
@@ -57,6 +57,7 @@ export default class Tasks extends PureComponent<Props, State> {
               tasks={ts}
               emptyState={this.emptyState}
               onDelete={this.handleDeleteTask}
+              onUpdate={this.handleUpdateTask}
             />
           )}
         </FilterList>
@@ -92,6 +93,11 @@ export default class Tasks extends PureComponent<Props, State> {
         <EmptyState.Text text="No Tasks match your query" />
       </EmptyState>
     )
+  }
+
+  private handleUpdateTask = async (task: Task) => {
+    await client.tasks.update(task.id, task)
+    this.props.onChange()
   }
 
   private handleDeleteTask = async (taskID: string) => {

--- a/ui/src/shared/components/EditableName.scss
+++ b/ui/src/shared/components/EditableName.scss
@@ -1,0 +1,86 @@
+/*
+  Editable Name Component Styles
+  ------------------------------------------------------------------------------
+*/
+
+@import 'src/style/modules';
+
+$rename-dash-title-padding: 5px;
+
+.editable-name {
+  height: $form-xs-height;
+  width: 100%;
+  margin-top: -3px;
+}
+
+.editable-name--preview,
+.input.editable-name--input > input {
+  font-size: $form-xs-font;
+  font-weight: 400;
+  font-family: $ix-text-font;
+  padding: 0 $rename-dash-title-padding;
+}
+
+.editable-name--preview,
+.editable-name--input {
+  position: relative;
+  width: 100%;
+}
+
+.editable-name--preview {
+  display: inline-flex;
+  justify-content: flex-start;
+  align-items: center;
+  border-radius: $radius;
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  @include no-user-select();
+  color: $g13-mist;
+  transition: color 0.25s ease, background-color 0.25s ease, border-color 0.25s ease;
+  border: $ix-border solid transparent;
+  height: $form-xs-height;
+  line-height: $form-xs-height - ($ix-border * 2);
+  
+  .icon {
+    position: relative;
+    display: inline-block;
+    margin-left: $ix-marg-b;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    color: $g11-sidewalk;
+  }
+  
+  &:hover .icon {
+    opacity: 1;
+  }
+  
+  &.untitled {
+    color: $g9-mountain;
+    font-style: italic;
+  }
+
+  &:hover {
+    cursor: text;
+    color: $g20-white;
+    // background-color: $g3-castle;
+    // border-color: $g3-castle;
+  }
+}
+
+/* Ensure placeholder text matches font weight of title */
+.input.editable-name--input > input {
+  &::-webkit-input-placeholder {
+      font-weight: $page-title-weight !important;
+    }
+    &::-moz-placeholder {
+      font-weight: $page-title-weight !important;
+    }
+    &:-ms-input-placeholder {
+      font-weight: $page-title-weight !important;
+    }
+    &:-moz-placeholder {
+      font-weight: $page-title-weight !important;
+    }
+}

--- a/ui/src/shared/components/EditableName.tsx
+++ b/ui/src/shared/components/EditableName.tsx
@@ -1,0 +1,139 @@
+// Libraries
+import React, {Component, KeyboardEvent, ChangeEvent} from 'react'
+import classnames from 'classnames'
+
+// Components
+import {Input, ComponentSize} from 'src/clockface'
+import {ClickOutside} from 'src/shared/components/ClickOutside'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+// Styles
+import 'src/shared/components/EditableName.scss'
+
+interface Props {
+  onUpdate: (name: string) => void
+  name: string
+  onEditName: () => void
+  hrefValue?: string
+  placeholder?: string
+}
+
+interface State {
+  isEditing: boolean
+  workingName: string
+}
+
+@ErrorHandling
+class EditableName extends Component<Props, State> {
+  public static defaultProps: Partial<Props> = {
+    hrefValue: '#',
+  }
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      isEditing: false,
+      workingName: props.name,
+    }
+  }
+
+  public render() {
+    const {name, onEditName, hrefValue} = this.props
+    const {isEditing} = this.state
+
+    if (isEditing) {
+      return (
+        <div className="editable-name">
+          <ClickOutside onClickOutside={this.handleStopEditing}>
+            {this.input}
+          </ClickOutside>
+        </div>
+      )
+    }
+
+    return (
+      <>
+        <a href={hrefValue} onClick={onEditName}>
+          <span>{name || 'No name'}</span>
+        </a>
+        <div className="editable-name">
+          <div
+            className={this.previewClassName}
+            onClick={this.handleStartEditing}
+          >
+            <span className="icon pencil" />
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  private get input(): JSX.Element {
+    const {placeholder} = this.props
+    const {workingName} = this.state
+
+    return (
+      <Input
+        size={ComponentSize.ExtraSmall}
+        maxLength={90}
+        autoFocus={true}
+        spellCheck={false}
+        placeholder={placeholder}
+        onFocus={this.handleInputFocus}
+        onChange={this.handleInputChange}
+        onKeyDown={this.handleKeyDown}
+        customClass="editable-name--input"
+        value={workingName}
+      />
+    )
+  }
+
+  private handleStartEditing = (): void => {
+    this.setState({isEditing: true})
+  }
+
+  private handleStopEditing = async (): Promise<void> => {
+    const {workingName} = this.state
+    const {onUpdate} = this.props
+
+    await onUpdate(workingName)
+
+    this.setState({isEditing: false})
+  }
+
+  private handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    this.setState({workingName: e.target.value})
+  }
+
+  private handleKeyDown = async (
+    e: KeyboardEvent<HTMLInputElement>
+  ): Promise<void> => {
+    const {onUpdate, name} = this.props
+    const {workingName} = this.state
+
+    if (e.key === 'Enter') {
+      await onUpdate(workingName)
+      this.setState({isEditing: false})
+    }
+
+    if (e.key === 'Escape') {
+      this.setState({isEditing: false, workingName: name})
+    }
+  }
+
+  private handleInputFocus = (e: ChangeEvent<HTMLInputElement>): void => {
+    e.currentTarget.select()
+  }
+
+  private get previewClassName(): string {
+    const {name} = this.props
+
+    return classnames('editable-name--preview', {
+      untitled: name === '',
+    })
+  }
+}
+
+export default EditableName


### PR DESCRIPTION
…rs and Scraper names

Closes #11555

_Briefly describe your proposed changes:_
Created new component for editable name on resource names for buckets, dashboard, tasks, collectors and scrapers.

  - [x] Rebased/mergeable
  - [ ] Tests pass

![kapture 2019-02-04 at 16 24 29](https://user-images.githubusercontent.com/26464594/52246142-8819a480-2899-11e9-8ba4-54d208a45534.gif)
