### PR TITLE
fix(ui/dataLoaders): Set collectors data loading type in the correct place

### DIFF
--- a/ui/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/select/SelectCollectorsStep.tsx
@@ -14,17 +14,12 @@ import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar
 import {
   addPluginBundleWithPlugins,
   removePluginBundleWithPlugins,
-  setDataLoadersType,
 } from 'src/dataLoaders/actions/dataLoaders'
 import {setBucketInfo} from 'src/dataLoaders/actions/steps'
 
 // Types
 import {CollectorsStepProps} from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
-import {
-  TelegrafPlugin,
-  DataLoaderType,
-  BundleName,
-} from 'src/types/v2/dataLoaders'
+import {TelegrafPlugin, BundleName} from 'src/types/v2/dataLoaders'
 import {Bucket} from 'src/api'
 import {AppState} from 'src/types/v2'
 
@@ -33,7 +28,6 @@ export interface OwnProps extends CollectorsStepProps {
 }
 
 export interface StateProps {
-  type: DataLoaderType
   bucket: string
   telegrafPlugins: TelegrafPlugin[]
   pluginBundles: BundleName[]
@@ -42,7 +36,6 @@ export interface StateProps {
 export interface DispatchProps {
   onAddPluginBundle: typeof addPluginBundleWithPlugins
   onRemovePluginBundle: typeof removePluginBundleWithPlugins
-  onSetDataLoadersType: typeof setDataLoadersType
   onSetBucketInfo: typeof setBucketInfo
 }
 
@@ -50,12 +43,6 @@ type Props = OwnProps & StateProps & DispatchProps
 
 @ErrorHandling
 export class SelectCollectorsStep extends PureComponent<Props> {
-  public componentDidMount() {
-    if (this.props.type !== DataLoaderType.Streaming) {
-      this.props.onSetDataLoadersType(DataLoaderType.Streaming)
-    }
-  }
-
   public render() {
     return (
       <div className="onboarding-step">
@@ -88,17 +75,13 @@ export class SelectCollectorsStep extends PureComponent<Props> {
   }
 
   private get nextButtonStatus(): ComponentStatus {
-    const {type, telegrafPlugins, buckets} = this.props
+    const {telegrafPlugins, buckets} = this.props
 
     if (!buckets || !buckets.length) {
       return ComponentStatus.Disabled
     }
 
-    const isTypeEmpty = type === DataLoaderType.Empty
-    const isStreamingWithoutPlugin =
-      type === DataLoaderType.Streaming && !telegrafPlugins.length
-
-    if (isTypeEmpty || isStreamingWithoutPlugin) {
+    if (!telegrafPlugins.length) {
       return ComponentStatus.Disabled
     }
 
@@ -132,18 +115,16 @@ export class SelectCollectorsStep extends PureComponent<Props> {
 
 const mstp = ({
   dataLoading: {
-    dataLoaders: {telegrafPlugins, pluginBundles, type},
+    dataLoaders: {telegrafPlugins, pluginBundles},
     steps: {bucket},
   },
 }: AppState): StateProps => ({
-  type,
   telegrafPlugins,
   bucket,
   pluginBundles,
 })
 
 const mdtp: DispatchProps = {
-  onSetDataLoadersType: setDataLoadersType,
   onAddPluginBundle: addPluginBundleWithPlugins,
   onRemovePluginBundle: removePluginBundleWithPlugins,
   onSetBucketInfo: setBucketInfo,

--- a/ui/src/organizations/components/Collectors.tsx
+++ b/ui/src/organizations/components/Collectors.tsx
@@ -41,6 +41,8 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 // Types
 import {Telegraf, Bucket} from 'src/api'
 import {OverlayState} from 'src/types/v2'
+import {setDataLoadersType} from 'src/dataLoaders/actions/dataLoaders'
+import {DataLoaderType} from 'src/types/v2/dataLoaders'
 
 interface OwnProps {
   collectors: Telegraf[]
@@ -52,6 +54,7 @@ interface OwnProps {
 
 interface DispatchProps {
   onSetBucketInfo: typeof setBucketInfo
+  onSetDataLoadersType: typeof setDataLoadersType
 }
 
 type Props = OwnProps & DispatchProps
@@ -145,12 +148,15 @@ export class Collectors extends PureComponent<Props, State> {
   }
 
   private handleAddCollector = () => {
-    const {buckets, onSetBucketInfo} = this.props
+    const {buckets, onSetBucketInfo, onSetDataLoadersType} = this.props
 
     if (buckets && buckets.length) {
       const {organization, organizationID, name, id} = buckets[0]
       onSetBucketInfo(organization, organizationID, name, id)
     }
+
+    onSetDataLoadersType(DataLoaderType.Scraping)
+
     this.setState({overlayState: OverlayState.Open})
   }
 
@@ -215,6 +221,7 @@ export class Collectors extends PureComponent<Props, State> {
 
 const mdtp: DispatchProps = {
   onSetBucketInfo: setBucketInfo,
+  onSetDataLoadersType: setDataLoadersType,
 }
 
 export default connect<null, DispatchProps, OwnProps>(


### PR DESCRIPTION
_Briefly describe your proposed changes:_
The issue is that after the state for data loader type was cleared after completing the collectors setup flow, the type was getting reset to 'streaming/collectors'. The problem was from the type getting set on the component did mount for one of these components. This just changes where the type gets set.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
