### PR TITLE
fix(ui/dataLoaders): Add swap to system bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v2.0.0-alpha.2 [unreleased]
+
+## Features
+
+## Bug Fixes
+1. [11678](https://github.com/influxdata/influxdb/pull/11678): Update the System Telegraf Plugin bundle to include the swap plugin
+
+## UI Improvements
+
+
 ## v2.0.0-alpha.1 [2019-01-23]
 
 ### Release Notes

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -17,6 +17,7 @@ import {
   TelegrafPluginInputNet,
   TelegrafPluginInputProcstat,
   TelegrafPluginInputDocker,
+  TelegrafPluginInputSwap,
   Task as TaskApi,
   Organization,
 } from 'src/api'
@@ -398,6 +399,12 @@ export const systemTelegrafPlugin = {
 export const redisTelegrafPlugin = {
   ...telegrafPlugin,
   name: TelegrafPluginInputRedis.NameEnum.Redis,
+}
+
+export const swapTelegrafPlugin = {
+  ...telegrafPlugin,
+  name: TelegrafPluginInputSwap.NameEnum.Swap,
+  configured: ConfigurationState.Configured,
 }
 
 export const redisPlugin = {

--- a/ui/src/dataLoaders/constants/pluginConfigs.ts
+++ b/ui/src/dataLoaders/constants/pluginConfigs.ts
@@ -43,6 +43,7 @@ export const pluginsByBundle: PluginBundles = {
     TelegrafPluginInputMem.NameEnum.Mem,
     TelegrafPluginInputNet.NameEnum.Net,
     TelegrafPluginInputProcesses.NameEnum.Processes,
+    TelegrafPluginInputSwap.NameEnum.Swap,
   ],
   [BundleName.Docker]: [TelegrafPluginInputDocker.NameEnum.Docker],
   [BundleName.Kubernetes]: [TelegrafPluginInputKubernetes.NameEnum.Kubernetes],

--- a/ui/src/dataLoaders/reducers/dataLoaders.test.ts
+++ b/ui/src/dataLoaders/reducers/dataLoaders.test.ts
@@ -39,6 +39,7 @@ import {
   token,
   telegrafConfig,
   dockerTelegrafPlugin,
+  swapTelegrafPlugin,
 } from 'mocks/dummyData'
 import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/dataLoaders/constants/pluginConfigs'
 
@@ -506,6 +507,7 @@ describe('dataLoader reducer', () => {
         memTelegrafPlugin,
         netTelegrafPlugin,
         processesTelegrafPlugin,
+        swapTelegrafPlugin,
       ])
     )
   })


### PR DESCRIPTION
Closes #11584 

_Briefly describe your proposed changes:_
Swap was missing from the system telegraf plugin bundle. This pr will add that plugin.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Updated ChangeLog
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
