### PR TITLE
Feat/clone tasks

### DIFF
--- a/ui/src/dashboards/apis/v2/index.ts
+++ b/ui/src/dashboards/apis/v2/index.ts
@@ -4,6 +4,7 @@ import _ from 'lodash'
 
 // Utils
 import {addLabelDefaults} from 'src/shared/utils/labels'
+import {incrementCloneName} from 'src/utils/naming'
 
 // Types
 
@@ -199,10 +200,23 @@ export const addCellUpdateView = async (
   return updateView(dashboard.id, createdCell.id, view)
 }
 
-export const cloneDashboard = async (dashboardToClone: Dashboard) => {
+export const cloneDashboard = async (
+  dashboardToClone: Dashboard,
+  dashboards: Dashboard[]
+) => {
+  const allDashboardNames = dashboards.map(d => d.name)
+
+  const clonedName = incrementCloneName(
+    allDashboardNames,
+    dashboardToClone.name
+  )
+
   const dashboardNoCells = _.omit(dashboardToClone, ['cells'])
 
-  const createdDashboard = await createDashboard(dashboardNoCells)
+  const createdDashboard = await createDashboard({
+    ...dashboardNoCells,
+    name: clonedName,
+  })
 
   const cells = dashboardToClone.cells
 

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -186,14 +186,15 @@ class DashboardIndex extends PureComponent<Props, State> {
   private handleCloneDashboard = async (
     dashboard: Dashboard
   ): Promise<void> => {
-    const {router, notify, orgs} = this.props
-    const name = `${dashboard.name} (clone)`
+    const {router, notify, orgs, dashboards} = this.props
     try {
-      const data = await cloneDashboard({
-        ...dashboard,
-        name,
-        orgID: orgs[0].id,
-      })
+      const data = await cloneDashboard(
+        {
+          ...dashboard,
+          orgID: orgs[0].id,
+        },
+        dashboards
+      )
       router.push(`/dashboards/${data.id}`)
     } catch (error) {
       console.error(error)

--- a/ui/src/organizations/components/DashboardList.tsx
+++ b/ui/src/organizations/components/DashboardList.tsx
@@ -58,14 +58,17 @@ class DashboardList extends PureComponent<Props> {
   private handleCloneDashboard = async (
     dashboard: Dashboard
   ): Promise<void> => {
-    const {router, notify, orgID} = this.props
+    const {router, notify, orgID, dashboards} = this.props
     const name = `${dashboard.name} (clone)`
     try {
-      const data = await cloneDashboard({
-        ...dashboard,
-        name,
-        orgID,
-      })
+      const data = await cloneDashboard(
+        {
+          ...dashboard,
+          name,
+          orgID,
+        },
+        dashboards
+      )
 
       router.push(`/dashboards/${data.id}`)
     } catch (error) {

--- a/ui/src/organizations/components/TaskList.tsx
+++ b/ui/src/organizations/components/TaskList.tsx
@@ -13,6 +13,7 @@ interface Props {
   emptyState: JSX.Element
   onDelete: (taskID: string) => void
   onUpdate: (task: Task) => void
+  onClone: (task: Task) => void
 }
 
 export default class TaskList extends PureComponent<Props> {
@@ -32,13 +33,14 @@ export default class TaskList extends PureComponent<Props> {
   }
 
   private get rows(): JSX.Element[] {
-    const {tasks, onDelete, onUpdate} = this.props
+    const {tasks, onDelete, onClone, onUpdate} = this.props
     return tasks.map(task => (
       <TaskRow
         key={task.id}
         task={task}
         onDelete={onDelete}
         onUpdate={onUpdate}
+        onClone={onClone}
       />
     ))
   }

--- a/ui/src/organizations/components/TaskRow.tsx
+++ b/ui/src/organizations/components/TaskRow.tsx
@@ -7,6 +7,9 @@ import {
   IndexList,
   ConfirmationButton,
   Alignment,
+  Button,
+  IconFont,
+  ComponentColor,
 } from 'src/clockface'
 
 // Api
@@ -17,6 +20,7 @@ interface Props {
   task: Task
   onDelete: (taskID: string) => void
   onUpdate: (task: Task) => void
+  onClone: (task: Task) => void
 }
 
 export default class TaskRow extends PureComponent<Props> {
@@ -35,6 +39,13 @@ export default class TaskRow extends PureComponent<Props> {
           </IndexList.Cell>
           <IndexList.Cell>{task.name}</IndexList.Cell>
           <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
+            <Button
+              size={ComponentSize.ExtraSmall}
+              color={ComponentColor.Secondary}
+              text="Clone"
+              icon={IconFont.Duplicate}
+              onClick={this.handleClone}
+            />
             <ConfirmationButton
               size={ComponentSize.ExtraSmall}
               text="Delete"
@@ -50,6 +61,10 @@ export default class TaskRow extends PureComponent<Props> {
   private handleUpdateTask = (name: string) => {
     const {onUpdate, task} = this.props
     onUpdate({...task, name})
+  }
+
+  private handleClone = (): void => {
+    this.props.onClone(this.props.task)
   }
 
   private handleDeleteTask = (): void => {

--- a/ui/src/organizations/components/Tasks.tsx
+++ b/ui/src/organizations/components/Tasks.tsx
@@ -107,7 +107,7 @@ export default class Tasks extends PureComponent<Props, State> {
   }
 
   private handleCloneTask = async (task: Task) => {
-    await client.tasks.create(task.orgID, task.flux, task.name)
+    await client.tasks.create(task.orgID, task.flux)
     this.props.onChange()
   }
 }

--- a/ui/src/organizations/components/Tasks.tsx
+++ b/ui/src/organizations/components/Tasks.tsx
@@ -58,6 +58,7 @@ export default class Tasks extends PureComponent<Props, State> {
               emptyState={this.emptyState}
               onDelete={this.handleDeleteTask}
               onUpdate={this.handleUpdateTask}
+              onClone={this.handleCloneTask}
             />
           )}
         </FilterList>
@@ -102,6 +103,11 @@ export default class Tasks extends PureComponent<Props, State> {
 
   private handleDeleteTask = async (taskID: string) => {
     await client.tasks.delete(taskID)
+    this.props.onChange()
+  }
+
+  private handleCloneTask = async (task: Task) => {
+    await client.tasks.create(task.orgID, task.flux, task.name)
     this.props.onChange()
   }
 }

--- a/ui/src/shared/copy/v2/notifications.ts
+++ b/ui/src/shared/copy/v2/notifications.ts
@@ -48,6 +48,19 @@ export const taskDeleteSuccess = (): Notification => ({
   message: 'Task was deleted successfully',
 })
 
+export const taskCloneSuccess = (taskName: string): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Successfully cloned task ${taskName}`,
+})
+
+export const taskCloneFailed = (
+  taskName: string,
+  additionalMessage: string
+): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to clone task ${taskName}: ${additionalMessage} `,
+})
+
 export const taskUpdateFailed = (additionalMessage: string): Notification => ({
   ...defaultErrorNotification,
   message: `Failed to update task: ${additionalMessage}`,

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -33,6 +33,7 @@ import {
   TaskOptions,
   TaskSchedule,
 } from 'src/utils/taskOptionsToFluxScript'
+import {incrementCloneName} from 'src/utils/naming'
 
 export type Action =
   | SetNewScript
@@ -246,9 +247,11 @@ export const deleteTask = (task: Task) => async dispatch => {
   }
 }
 
-export const cloneTask = (task: Task) => async dispatch => {
+export const cloneTask = (task: Task, tasks: Tasks[]) => async dispatch => {
   try {
-    await client.tasks.create(task.orgID, task.flux, task.name)
+    const allTaskNames = tasks.map(t => t.name)
+    const clonedName = incrementCloneName(allTaskNames, task.name)
+    await client.tasks.create(task.orgID, task.flux, clonedName)
 
     dispatch(notify(taskCloneSuccess(task.name)))
     dispatch(populateTasks())

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -17,6 +17,8 @@ import {
   taskUpdateSuccess,
   taskCreatedSuccess,
   taskDeleteSuccess,
+  taskCloneSuccess,
+  taskCloneFailed,
 } from 'src/shared/copy/v2/notifications'
 
 // Types
@@ -241,6 +243,19 @@ export const deleteTask = (task: Task) => async dispatch => {
     console.error(e)
     const message = getErrorMessage(e)
     dispatch(notify(taskDeleteFailed(message)))
+  }
+}
+
+export const cloneTask = (task: Task) => async dispatch => {
+  try {
+    await client.tasks.create(task.orgID, task.flux, task.name)
+
+    dispatch(notify(taskCloneSuccess(task.name)))
+    dispatch(populateTasks())
+  } catch (e) {
+    console.error(e)
+    const message = getErrorMessage(e)
+    dispatch(notify(taskCloneFailed(task.name, message)))
   }
 }
 

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -33,7 +33,6 @@ import {
   TaskOptions,
   TaskSchedule,
 } from 'src/utils/taskOptionsToFluxScript'
-import {incrementCloneName} from 'src/utils/naming'
 
 export type Action =
   | SetNewScript
@@ -247,11 +246,11 @@ export const deleteTask = (task: Task) => async dispatch => {
   }
 }
 
-export const cloneTask = (task: Task, tasks: Tasks[]) => async dispatch => {
+export const cloneTask = (task: Task, _) => async dispatch => {
   try {
-    const allTaskNames = tasks.map(t => t.name)
-    const clonedName = incrementCloneName(allTaskNames, task.name)
-    await client.tasks.create(task.orgID, task.flux, clonedName)
+    // const allTaskNames = tasks.map(t => t.name)
+    // const clonedName = incrementCloneName(allTaskNames, task.name)
+    await client.tasks.create(task.orgID, task.flux)
 
     dispatch(notify(taskCloneSuccess(task.name)))
     dispatch(populateTasks())

--- a/ui/src/tasks/components/TaskRow.test.tsx
+++ b/ui/src/tasks/components/TaskRow.test.tsx
@@ -17,6 +17,7 @@ const setup = (override = {}) => {
     task: tasks[0],
     onActivate: jest.fn(),
     onDelete: jest.fn(),
+    onClone: jest.fn(),
     onSelect: jest.fn(),
     onEditLabels: jest.fn(),
     ...override,

--- a/ui/src/tasks/components/TaskRow.tsx
+++ b/ui/src/tasks/components/TaskRow.tsx
@@ -5,6 +5,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 // Components
 import {
   ComponentSpacer,
+  ComponentColor,
   Alignment,
   Button,
   ComponentSize,
@@ -31,6 +32,7 @@ interface Props {
   onActivate: (task: Task) => void
   onDelete: (task: Task) => void
   onSelect: (task: Task) => void
+  onClone: (task: Task) => void
   onEditLabels: (task: Task) => void
 }
 
@@ -76,6 +78,13 @@ export class TaskRow extends PureComponent<Props & WithRouterProps> {
               icon={IconFont.Export}
               onClick={this.handleExport}
             />
+            <Button
+              size={ComponentSize.ExtraSmall}
+              color={ComponentColor.Secondary}
+              text="Clone"
+              icon={IconFont.Duplicate}
+              onClick={this.handleClone}
+            />
             <ConfirmationButton
               size={ComponentSize.ExtraSmall}
               text="Delete"
@@ -98,6 +107,11 @@ export class TaskRow extends PureComponent<Props & WithRouterProps> {
   private handleExport = () => {
     const {task} = this.props
     downloadTextFile(task.flux, `${task.name}.flux`)
+  }
+
+  private handleClone = () => {
+    const {task, onClone} = this.props
+    onClone(task)
   }
 
   private handleOrgClick = () => {

--- a/ui/src/tasks/components/TasksList.tsx
+++ b/ui/src/tasks/components/TasksList.tsx
@@ -27,6 +27,7 @@ interface Props {
   onDelete: (task: Task) => void
   onCreate: () => void
   onSelect: (task: Task) => void
+  onClone: (task: Task) => void
   totalCount: number
   onRemoveTaskLabels: typeof removeTaskLabelsAsync
   onAddTaskLabels: typeof addTaskLabelsAsync
@@ -120,7 +121,7 @@ export default class TasksList extends PureComponent<Props, State> {
   }
 
   private rows = (tasks: Task[]): JSX.Element => {
-    const {onActivate, onDelete, onSelect} = this.props
+    const {onActivate, onDelete, onSelect, onClone} = this.props
     const taskrows = (
       <>
         {tasks.map(t => (
@@ -129,6 +130,7 @@ export default class TasksList extends PureComponent<Props, State> {
             task={t}
             onActivate={onActivate}
             onDelete={onDelete}
+            onClone={onClone}
             onSelect={onSelect}
             onEditLabels={this.handleStartEditingLabels}
           />

--- a/ui/src/tasks/components/__snapshots__/TaskRow.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TaskRow.test.tsx.snap
@@ -75,6 +75,17 @@ exports[`Tasks.Components.TaskRow renders 1`] = `
         text="Export"
         type="button"
       />
+      <Button
+        active={false}
+        color="secondary"
+        icon="duplicate"
+        onClick={[Function]}
+        shape="none"
+        size="xs"
+        status="default"
+        text="Clone"
+        type="button"
+      />
       <ConfirmationButton
         confirmText="Confirm"
         onConfirm={[MockFunction]}

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -145,7 +145,8 @@ class TasksPage extends PureComponent<Props, State> {
   }
 
   private handleClone = (task: Task) => {
-    this.props.cloneTask(task)
+    const {tasks} = this.props
+    this.props.cloneTask(task, tasks)
   }
 
   private handleCreateTask = () => {

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -17,6 +17,7 @@ import {
   updateTaskStatus,
   deleteTask,
   selectTask,
+  cloneTask,
   setSearchTerm as setSearchTermAction,
   setShowInactive as setShowInactiveAction,
   setDropdownOrgID as setDropdownOrgIDAction,
@@ -30,6 +31,7 @@ import {allOrganizationsID} from 'src/tasks/constants'
 
 // Types
 import {Task as TaskAPI, User, Organization} from 'src/api'
+import {AppState} from 'src/types/v2'
 
 interface Task extends TaskAPI {
   organization: Organization
@@ -45,6 +47,7 @@ interface ConnectedDispatchProps {
   populateTasks: typeof populateTasks
   updateTaskStatus: typeof updateTaskStatus
   deleteTask: typeof deleteTask
+  cloneTask: typeof cloneTask
   selectTask: typeof selectTask
   setSearchTerm: typeof setSearchTermAction
   setShowInactive: typeof setShowInactiveAction
@@ -115,6 +118,7 @@ class TasksPage extends PureComponent<Props, State> {
                 onActivate={this.handleActivate}
                 onDelete={this.handleDelete}
                 onCreate={this.handleCreateTask}
+                onClone={this.handleClone}
                 onSelect={this.props.selectTask}
                 onAddTaskLabels={onAddTaskLabels}
                 onRemoveTaskLabels={onRemoveTaskLabels}
@@ -131,12 +135,17 @@ class TasksPage extends PureComponent<Props, State> {
   public componentDidMount() {
     this.props.populateTasks()
   }
+
   private handleActivate = (task: Task) => {
     this.props.updateTaskStatus(task)
   }
 
   private handleDelete = (task: Task) => {
     this.props.deleteTask(task)
+  }
+
+  private handleClone = (task: Task) => {
+    this.props.cloneTask(task)
   }
 
   private handleCreateTask = () => {
@@ -217,7 +226,7 @@ class TasksPage extends PureComponent<Props, State> {
 const mstp = ({
   tasks: {tasks, searchTerm, showInactive, dropdownOrgID},
   orgs,
-}): ConnectedStateProps => {
+}: AppState): ConnectedStateProps => {
   return {
     tasks,
     searchTerm,
@@ -232,6 +241,7 @@ const mdtp: ConnectedDispatchProps = {
   updateTaskStatus,
   deleteTask,
   selectTask,
+  cloneTask,
   setSearchTerm: setSearchTermAction,
   setShowInactive: setShowInactiveAction,
   setDropdownOrgID: setDropdownOrgIDAction,

--- a/ui/src/utils/naming.ts
+++ b/ui/src/utils/naming.ts
@@ -1,0 +1,33 @@
+export const incrementCloneName = (
+  namesList: string[],
+  cloneName: string
+): string => {
+  const root = cloneName.replace(/\s\(clone\s(\d)+\)/g, '').replace(/\)/, '')
+
+  const filteredNames = namesList.filter(n => n.includes(root))
+
+  const highestNumberedClone = filteredNames.reduce((acc, name) => {
+    if (name.match(/\(clone(\s|\d)+\)/)) {
+      const strippedName = name
+        .replace(root, '')
+        .replace(/\(clone/, '')
+        .replace(/\)/, '')
+
+      const cloneNumber = Number(strippedName)
+
+      return cloneNumber >= acc ? cloneNumber : acc
+    }
+
+    return acc
+  }, 0)
+
+  if (highestNumberedClone) {
+    const newCloneNumber = highestNumberedClone + 1
+    return `${cloneName.replace(
+      /\(clone\s(\d)+\)/,
+      ''
+    )} (clone ${newCloneNumber})`
+  }
+
+  return `${cloneName} (clone 1)`
+}


### PR DESCRIPTION
Closes #11499 

Added ability to clone tasks, but temporarily removed ability to change name of cloned task, waiting on client changes that are in the pipeline. Added a clone name increment function, and added that to dashboard cloning. cell cloning is more tricky, because it is possible not all views in a dashboard are loaded. 
