### PR TITLE
fix(ui/dataLoaders): Update plugin form to use correct documentation link

### DIFF
--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.test.tsx
@@ -58,4 +58,15 @@ describe('DataLoaders.Components.CollectorsWizard.Configure.PluginConfigForm', (
       expect(onboardingButtons.exists()).toBe(true)
     })
   })
+
+  it('has a link to documentation containing plugin name', () => {
+    const {wrapper} = setup({
+      telegrafPlugin,
+    })
+
+    const link = wrapper.find({'data-test': 'docs-link'})
+
+    expect(link.exists()).toBe(true)
+    expect(link.prop('href')).toContain(telegrafPlugin.name)
+  })
 })

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
@@ -50,7 +50,10 @@ export class PluginConfigForm extends PureComponent<Props> {
                 For more information about this plugin, see{' '}
                 <a
                   target="_blank"
-                  href={`https://github.com/influxdata/telegraf/tree/master/plugins/inputs/${name}`}
+                  data-test="docs-link"
+                  href={`https://github.com/influxdata/telegraf/tree/master/plugins/inputs/${
+                    telegrafPlugin.name
+                  }`}
                 >
                   Documentation
                 </a>


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Name was no longer getting extracted from telegrafPlugin so the documentation link did not take you to the plugin's documentation.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
