### PR TITLE
fix(ui/dataLoaders): Update plugin config button to 'Done'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 1. [11678](https://github.com/influxdata/influxdb/pull/11678): Update the System Telegraf Plugin bundle to include the swap plugin
 
 ## UI Improvements
-
+1. [11683](https://github.com/influxdata/influxdb/pull/11683): Change the wording for the plugin config form button to Done
 
 ## v2.0.0-alpha.1 [2019-01-23]
 

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
@@ -62,7 +62,10 @@ export class PluginConfigForm extends PureComponent<Props> {
             </div>
           </FancyScrollbar>
         </div>
-        <OnboardingButtons autoFocusNext={this.autoFocus} />
+        <OnboardingButtons
+          autoFocusNext={this.autoFocus}
+          nextButtonText={'Done'}
+        />
       </Form>
     )
   }


### PR DESCRIPTION
Closes #11581

_Briefly describe your proposed changes:_
Update the wording in for the plugin config form button to say `Done` instead of `Continue`.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
