### PR TITLE
fix(ui/dataLoaders): Update default telegraf config name to 'Name this Configuration'

### DIFF
--- a/ui/src/dataLoaders/reducers/dataLoaders.ts
+++ b/ui/src/dataLoaders/reducers/dataLoaders.ts
@@ -36,7 +36,7 @@ export const INITIAL_STATE: DataLoadersState = {
   telegrafConfigID: null,
   pluginBundles: [],
   scraperTarget: {bucket: '', url: QUICKSTART_SCRAPER_TARGET_URL},
-  telegrafConfigName: 'new config',
+  telegrafConfigName: 'Name this Configuration',
 }
 
 export default (state = INITIAL_STATE, action: Action): DataLoadersState => {


### PR DESCRIPTION
Closes #11582

_Briefly describe your proposed changes:_
Update the default telegraf config name to 'Name this Configuration' rather than 'new config'

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
