### PR TITLE
fix(ui/dataLoaders): Update the collectors configure step button to 'Create and Verify'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## UI Improvements
 1. [11683](https://github.com/influxdata/influxdb/pull/11683): Change the wording for the plugin config form button to Done
+1. [11689](https://github.com/influxdata/influxdb/pull/11689): Change the wording for the Collectors configure step button to Create and Verify
 
 ## v2.0.0-alpha.1 [2019-01-23]
 

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/TelegrafPluginInstructions.tsx
@@ -59,7 +59,10 @@ export class TelegrafPluginInstructions extends PureComponent<Props> {
             </div>
           </FancyScrollbar>
         </div>
-        <OnboardingButtons onClickBack={onDecrementStep} />
+        <OnboardingButtons
+          onClickBack={onDecrementStep}
+          nextButtonText={'Create and Verify'}
+        />
       </Form>
     )
   }


### PR DESCRIPTION
Closes #11583

_Briefly describe your proposed changes:_
Change the continue button on the configure step of the Telegraf configuration page to be `Create and Verify` rather than `Continue`.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] Update Changelog
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
