### PR TITLE
feat(ui/dataLoaders): Use env var for telegraf config auth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.0.0-alpha.2 [unreleased]
 
 ## Features
+1. [11693](https://github.com/influxdata/influxdb/pull/11693): Save the $INFLUX_TOKEN environmental variable in telegraf configs
 
 ## Bug Fixes
 1. [11678](https://github.com/influxdata/influxdb/pull/11678): Update the System Telegraf Plugin bundle to include the swap plugin

--- a/ui/src/dataLoaders/actions/dataLoaders.ts
+++ b/ui/src/dataLoaders/actions/dataLoaders.ts
@@ -283,7 +283,7 @@ export const removePluginBundleWithPlugins = (
   dispatch(removeBundlePlugins(bundle))
 }
 
-export const createOrUpdateTelegrafConfigAsync = (authToken: string) => async (
+export const createOrUpdateTelegrafConfigAsync = () => async (
   dispatch,
   getState: GetState
 ) => {
@@ -299,7 +299,7 @@ export const createOrUpdateTelegrafConfigAsync = (authToken: string) => async (
     type: TelegrafPluginOutputInfluxDBV2.TypeEnum.Output,
     config: {
       urls: ['http://127.0.0.1:9999'],
-      token: authToken,
+      token: '$INFLUX_TOKEN',
       organization: org,
       bucket,
     },

--- a/ui/src/dataLoaders/components/verifyStep/CreateOrUpdateConfig.tsx
+++ b/ui/src/dataLoaders/components/verifyStep/CreateOrUpdateConfig.tsx
@@ -23,7 +23,6 @@ import {RemoteDataState, NotificationAction} from 'src/types'
 
 export interface OwnProps {
   org: string
-  authToken: string
   children: () => JSX.Element
 }
 
@@ -50,7 +49,6 @@ export class CreateOrUpdateConfig extends PureComponent<Props, State> {
   public async componentDidMount() {
     const {
       onSaveTelegrafConfig,
-      authToken,
       notify,
       createDashboardsForPlugins,
     } = this.props
@@ -58,7 +56,7 @@ export class CreateOrUpdateConfig extends PureComponent<Props, State> {
     this.setState({loading: RemoteDataState.Loading})
 
     try {
-      await onSaveTelegrafConfig(authToken)
+      await onSaveTelegrafConfig()
       notify(TelegrafConfigCreationSuccess)
       await createDashboardsForPlugins()
 

--- a/ui/src/dataLoaders/components/verifyStep/DataStreaming.tsx
+++ b/ui/src/dataLoaders/components/verifyStep/DataStreaming.tsx
@@ -28,7 +28,7 @@ class DataStreaming extends PureComponent<Props> {
 
     return (
       <>
-        <CreateOrUpdateConfig org={org} authToken={authToken}>
+        <CreateOrUpdateConfig org={org}>
           {() => (
             <TelegrafInstructions
               notify={notify}

--- a/ui/src/dataLoaders/reducers/dataLoaders.test.ts
+++ b/ui/src/dataLoaders/reducers/dataLoaders.test.ts
@@ -36,7 +36,6 @@ import {
   processesTelegrafPlugin,
   systemTelegrafPlugin,
   redisTelegrafPlugin,
-  token,
   telegrafConfig,
   dockerTelegrafPlugin,
   swapTelegrafPlugin,
@@ -488,7 +487,7 @@ describe('dataLoader reducer', () => {
         },
       },
     })
-    await createOrUpdateTelegrafConfigAsync(token)(dispatch, getState)
+    await createOrUpdateTelegrafConfigAsync()(dispatch, getState)
 
     expect(dispatch).toBeCalledWith(setTelegrafConfigID(telegrafConfig.id))
   })


### PR DESCRIPTION
Closes #11609

_Briefly describe your proposed changes:_
Rather than using the actual auth token for the telegraf config, the environmental variable `$INFLUX_TOKEN` will now get saved into the config.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Update Changelog
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
