### PR TITLE
fix(influxdb): revert functionality added in pr#10947

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Bug Fixes
 1. [11678](https://github.com/influxdata/influxdb/pull/11678): Update the System Telegraf Plugin bundle to include the swap plugin
+1. [11722](https://github.com/influxdata/influxdb/pull/11722): Revert behavior allowing users to create authorizations on behalf of another user
 
 ## UI Improvements
 1. [11683](https://github.com/influxdata/influxdb/pull/11683): Change the wording for the plugin config form button to Done

--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -228,23 +228,6 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 		OrgID:       o.ID,
 	}
 
-	if authorizationCreateFlags.user != "" {
-		// if the user flag is supplied, then set the user ID explicitly on the request
-		userSvc, err := newUserService(flags)
-		if err != nil {
-			return err
-		}
-		userFilter := platform.UserFilter{
-			Name: &authorizationCreateFlags.user,
-		}
-		user, err := userSvc.FindUser(context.Background(), userFilter)
-		if err != nil {
-			return err
-		}
-
-		authorization.UserID = user.ID
-	}
-
 	s, err := newAuthorizationService(flags)
 	if err != nil {
 		return err

--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -188,25 +188,10 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 		return
 	}
 
-	var user *platform.User
-	// allow the user id to be specified optionally, if it is not set
-	// we use the id from the authorizer
-	if req.UserID == nil {
-		u, err := getAuthorizedUser(r, h.UserService)
-		if err != nil {
-			EncodeError(ctx, platform.ErrUnableToCreateToken, w)
-			return
-		}
-
-		user = u
-	} else {
-		u, err := h.UserService.FindUserByID(ctx, *req.UserID)
-		if err != nil {
-			EncodeError(ctx, platform.ErrUnableToCreateToken, w)
-			return
-		}
-
-		user = u
+	user, err := getAuthorizedUser(r, h.UserService)
+	if err != nil {
+		EncodeError(ctx, platform.ErrUnableToCreateToken, w)
+		return
 	}
 
 	auth := req.toPlatform(user.ID)


### PR DESCRIPTION
_Briefly describe your proposed changes:_
This PR undoes the work behavior that was added in https://github.com/influxdata/influxdb/pull/10947

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
