### PR TITLE
fix: task members endpoints

### DIFF
--- a/kv/org.go
+++ b/kv/org.go
@@ -614,6 +614,12 @@ func (s *Service) FindResourceOrganizationID(ctx context.Context, rt influxdb.Re
 			return influxdb.InvalidID(), err
 		}
 		return r.OrganizationID, nil
+	case influxdb.TasksResourceType:
+		r, err := s.FindTaskByID(ctx, id)
+		if err != nil {
+			return influxdb.InvalidID(), err
+		}
+		return r.OrganizationID, nil
 	case influxdb.TelegrafsResourceType:
 		r, err := s.FindTelegrafConfigByID(ctx, id)
 		if err != nil {


### PR DESCRIPTION
Fixes a bug that was introduced by #11301. Specifically, the `FindResourceOrganizationID` function it introduces does not handle task resources.

Closes #11491

Referencing tasks handler from a bolt client feels like a major smell and I'd love ideas for how to better communicate between the two bolt stores.