### PR TITLE
Use Systemd for Amazon Linux 2

### DIFF
--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -63,7 +63,10 @@ elif [[ -f /etc/debian_version ]]; then
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
-    if [[ $ID = "amzn" ]]; then
+    if [[ "$NAME" = "Amazon Linux" ]]; then
+        # Amazon Linux 2+ logic
+        install_systemd
+    elif [[ "$NAME" = "Amazon Linux AMI" ]]; then
         # Amazon Linux logic
         install_init
         install_chkconfig

--- a/scripts/post-uninstall.sh
+++ b/scripts/post-uninstall.sh
@@ -43,11 +43,15 @@ elif [[ -f /etc/lsb-release ]]; then
     fi
 elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
-    if [[ $ID = "amzn" ]]; then
-        # Amazon Linux logic
-        if [[ "$1" = "0" ]]; then
-            # InfluxDB is no longer installed, remove from init system
-            rm -f /etc/default/influxdb
+    if [[ "$ID" = "amzn" ]] && [[ "$1" = "0" ]]; then
+        # InfluxDB is no longer installed, remove from init system
+        rm -f /etc/default/influxdb
+
+        if [[ "$NAME" = "Amazon Linux" ]]; then
+            # Amazon Linux 2+ logic
+            disable_systemd
+        elif [[ "$NAME" = "Amazon Linux AMI" ]]; then
+            # Amazon Linux logic
             disable_chkconfig
         fi
     fi


### PR DESCRIPTION
Amazon Linux 2 uses systemd. This PR adds support for Amazon Linux 2 in `influxd`'s `post-install.sh` and `post-uninstall.sh` scripts.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
