### PR TITLE
Update tagKeyValue mutex to write lock.

### DIFF
--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -1128,8 +1128,14 @@ func (t *tagKeyValue) Load(value string) seriesIDs {
 
 	t.mu.RLock()
 	entry := t.entries[value]
-	ids := entry.ids()
+	ids, changed := entry.ids()
 	t.mu.RUnlock()
+
+	if changed {
+		t.mu.Lock()
+		entry.setIDs(ids)
+		t.mu.Unlock()
+	}
 	return ids
 }
 
@@ -1142,10 +1148,18 @@ func (t *tagKeyValue) Range(f func(tagValue string, a seriesIDs) bool) {
 	}
 
 	t.mu.RLock()
-	defer t.mu.RUnlock()
 	for tagValue, entry := range t.entries {
-		ids := entry.ids()
+		ids, changed := entry.ids()
+		if changed {
+			t.mu.RUnlock()
+			t.mu.Lock()
+			entry.setIDs(ids)
+			t.mu.Unlock()
+			t.mu.RLock()
+		}
+
 		if !f(tagValue, ids) {
+			t.mu.RUnlock()
 			return
 		}
 	}
@@ -1169,13 +1183,11 @@ func newTagKeyValueEntry() *tagKeyValueEntry {
 	return &tagKeyValueEntry{m: make(map[uint64]struct{})}
 }
 
-func (e *tagKeyValueEntry) ids() seriesIDs {
+func (e *tagKeyValueEntry) ids() (_ seriesIDs, changed bool) {
 	if e == nil {
-		return nil
-	}
-
-	if len(e.a) == len(e.m) {
-		return e.a
+		return nil, false
+	} else if len(e.a) == len(e.m) {
+		return e.a, false
 	}
 
 	a := make(seriesIDs, 0, len(e.m))
@@ -1184,10 +1196,10 @@ func (e *tagKeyValueEntry) ids() seriesIDs {
 	}
 	radix.SortUint64s(a)
 
-	e.a = a
-	return e.a
-
+	return a, true
 }
+
+func (e *tagKeyValueEntry) setIDs(a seriesIDs) { e.a = a }
 
 // SeriesIDs is a convenience type for sorting, checking equality, and doing
 // union and intersection of collections of series ids.


### PR DESCRIPTION
_Briefly describe your proposed changes:_

This commit changes the read lock to a write lock when calling the
`ids()` function because `ids()` can mutate the underlying series
ids slice.


  - [x] Rebased/mergeable
  - [x] Tests pass
