### PR TITLE
fix(query/influxql): normalize selectors when an interval is present

### DIFF
--- a/query/influxql/README.md
+++ b/query/influxql/README.md
@@ -149,7 +149,7 @@ If the aggregate is combined with conditions, the column name of `_value` is rep
 
 #### <a name="normalize-time"></a> Normalize the time column
 
-If a function was evaluated and the query type is an aggregate type, then all of the functions need to have their time normalized. If the function is an aggregate, the following is added:
+If a function was evaluated and the query type is an aggregate type or if we are grouping by time, then all of the functions need to have their time normalized. If the function is an aggregate, the following is added:
 
 ```
 ... |> mean() |> duplicate(column: "_start", as: "_time")

--- a/query/influxql/end_to_end_test.go
+++ b/query/influxql/end_to_end_test.go
@@ -84,8 +84,6 @@ var skipTests = map[string]string{
 	"selector_2":               "Transpiler: first function uses different series than influxQL (https://github.com/influxdata/platform/issues/1605)",
 	"selector_6":               "Transpiler: first function uses different series than influxQL (https://github.com/influxdata/platform/issues/1605)",
 	"selector_7":               "Transpiler: first function uses different series than influxQL (https://github.com/influxdata/platform/issues/1605)",
-	"selector_8":               "Transpiler: selectors with group by produce different time values than influxQL (https://github.com/influxdata/platform/issues/1606)",
-	"selector_9":               "Transpiler: selectors with group by produce different time values than influxQL (https://github.com/influxdata/platform/issues/1606)",
 	"series_agg_0":             "Transpiler: Implement difference (https://github.com/influxdata/platform/issues/1609)",
 	"series_agg_1":             "Transpiler: Implement stddev (https://github.com/influxdata/platform/issues/1610)",
 	"series_agg_2":             "Transpiler: Implement spread (https://github.com/influxdata/platform/issues/1611)",

--- a/query/influxql/group.go
+++ b/query/influxql/group.go
@@ -242,7 +242,7 @@ func (gr *groupInfo) createCursor(t *transpilerState) (cursor, error) {
 
 	// If a function call is present, evaluate the function call.
 	if gr.call != nil {
-		c, err := createFunctionCursor(t, gr.call, cur, !gr.selector)
+		c, err := createFunctionCursor(t, gr.call, cur, !gr.selector || interval > 0)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The selector will be normalized to the start time interval when `GROUP
BY time(X)` is present in the query.

Fixes #10747.