### PR TITLE
feat(ui/dataLoaders): Move download config into view overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 ### UI Improvements
+1. [11764](https://github.com/influxdata/influxdb/pull/11764): Move the download telegraf config button to view config overlay
 
 ## v2.0.0-alpha.2 [2019-02-07]
 

--- a/ui/src/organizations/components/CollectorList.tsx
+++ b/ui/src/organizations/components/CollectorList.tsx
@@ -13,7 +13,6 @@ import {getDeep} from 'src/utils/wrappers'
 interface Props {
   collectors: Telegraf[]
   emptyState: JSX.Element
-  onDownloadConfig: (telegrafID: string, telegrafName: string) => void
   onDelete: (telegrafID: string) => void
   onUpdate: (telegraf: Telegraf) => void
   onOpenInstructions: (telegrafID: string) => void
@@ -42,7 +41,6 @@ export default class CollectorList extends PureComponent<Props> {
   public get collectorsList(): JSX.Element[] {
     const {
       collectors,
-      onDownloadConfig,
       onDelete,
       onUpdate,
       onOpenInstructions,
@@ -55,7 +53,6 @@ export default class CollectorList extends PureComponent<Props> {
           key={collector.id}
           collector={collector}
           bucket={getDeep<string>(collector, 'plugins.0.config.bucket', '')}
-          onDownloadConfig={onDownloadConfig}
           onDelete={onDelete}
           onUpdate={onUpdate}
           onOpenInstructions={onOpenInstructions}

--- a/ui/src/organizations/components/CollectorRow.tsx
+++ b/ui/src/organizations/components/CollectorRow.tsx
@@ -17,7 +17,6 @@ import EditableName from 'src/shared/components/EditableName'
 interface Props {
   collector: Telegraf
   bucket: string
-  onDownloadConfig: (telegrafID: string, telegrafName: string) => void
   onDelete: (telegrafID: string) => void
   onUpdate: (telegraf: Telegraf) => void
   onOpenInstructions: (telegrafID: string) => void
@@ -39,12 +38,6 @@ export default class CollectorRow extends PureComponent<Props> {
           <IndexList.Cell>{bucket}</IndexList.Cell>
           <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
             <ComponentSpacer align={Alignment.Right}>
-              <Button
-                size={ComponentSize.ExtraSmall}
-                color={ComponentColor.Secondary}
-                text={'Download Config'}
-                onClick={this.handleDownloadConfig}
-              />
               <Button
                 size={ComponentSize.ExtraSmall}
                 color={ComponentColor.Secondary}
@@ -77,13 +70,6 @@ export default class CollectorRow extends PureComponent<Props> {
 
   private handleOpenConfig = (): void => {
     this.props.onOpenTelegrafConfig(
-      this.props.collector.id,
-      this.props.collector.name
-    )
-  }
-
-  private handleDownloadConfig = (): void => {
-    this.props.onDownloadConfig(
       this.props.collector.id,
       this.props.collector.name
     )

--- a/ui/src/organizations/components/Collectors.tsx
+++ b/ui/src/organizations/components/Collectors.tsx
@@ -3,9 +3,6 @@ import _ from 'lodash'
 import React, {PureComponent, ChangeEvent} from 'react'
 import {connect} from 'react-redux'
 
-// Utils
-import {downloadTextFile} from 'src/shared/utils/download'
-
 // Components
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
 import CollectorList from 'src/organizations/components/CollectorList'
@@ -31,11 +28,7 @@ import {client} from 'src/utils/api'
 
 // Actions
 import * as NotificationsActions from 'src/types/actions/notifications'
-import {notify} from 'src/shared/actions/notifications'
 import {setBucketInfo} from 'src/dataLoaders/actions/steps'
-
-// Constants
-import {getTelegrafConfigFailed} from 'src/shared/copy/v2/notifications'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -121,7 +114,6 @@ export class Collectors extends PureComponent<Props, State> {
                   <CollectorList
                     collectors={cs}
                     emptyState={this.emptyState}
-                    onDownloadConfig={this.handleDownloadConfig}
                     onDelete={this.handleDeleteTelegraf}
                     onUpdate={this.handleUpdateTelegraf}
                     onOpenInstructions={this.handleOpenInstructions}
@@ -257,18 +249,6 @@ export class Collectors extends PureComponent<Props, State> {
         <EmptyState.Text text="No Telegraf  Configuration buckets match your query" />
       </EmptyState>
     )
-  }
-
-  private handleDownloadConfig = async (
-    telegrafID: string,
-    telegrafName: string
-  ) => {
-    try {
-      const config = await client.telegrafConfigs.getTOML(telegrafID)
-      downloadTextFile(config, `${telegrafName || 'config'}.toml`)
-    } catch (error) {
-      notify(getTelegrafConfigFailed())
-    }
   }
 
   private handleDeleteTelegraf = async (telegrafID: string) => {

--- a/ui/src/organizations/components/TelegrafConfigOverlay.scss
+++ b/ui/src/organizations/components/TelegrafConfigOverlay.scss
@@ -1,0 +1,7 @@
+.config-overlay {
+  height: calc(100vh - 350px);
+  width: 100%;
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
Closes #11606

_Briefly describe your proposed changes:_
Move the Download Config button into the View config overlay.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] Update Changelog
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
