### PR TITLE
NewScraperBackend doesn't have associate UserService, UserResourceMappingService and LabelService

### DIFF
--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -31,9 +31,12 @@ func NewScraperBackend(b *APIBackend) *ScraperBackend {
 	return &ScraperBackend{
 		Logger: b.Logger.With(zap.String("handler", "scraper")),
 
-		ScraperStorageService: b.ScraperTargetStoreService,
-		BucketService:         b.BucketService,
-		OrganizationService:   b.OrganizationService,
+		ScraperStorageService:      b.ScraperTargetStoreService,
+		BucketService:              b.BucketService,
+		OrganizationService:        b.OrganizationService,
+		UserService:                b.UserService,
+		UserResourceMappingService: b.UserResourceMappingService,
+		LabelService:               b.LabelService,
 	}
 }
 


### PR DESCRIPTION
Closes #11767

The problem is that the NewScraperBackend doesn't have associate UserService, UserResourceMappingService and LabelService.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)