### PR TITLE
Move org/bucket/auth/user services from bolt to kv

### DIFF
--- a/bolt/authorization.go
+++ b/bolt/authorization.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	authorizationBucket = []byte("authorizationsv1")
-	authorizationIndex  = []byte("authorizationindexv1")
+	authorizationBucket = []byte("authorizations/v1")
+	authorizationIndex  = []byte("authorizationindex/v1")
 )
 
 var _ platform.AuthorizationService = (*Client)(nil)

--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	bucketBucket = []byte("bucketsv1")
-	bucketIndex  = []byte("bucketindexv1")
+	bucketBucket = []byte("buckets/v1")
+	bucketIndex  = []byte("bucketindex/v1")
 )
 
 var _ platform.BucketService = (*Client)(nil)

--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	organizationBucket = []byte("organizationsv1")
-	organizationIndex  = []byte("organizationindexv1")
+	organizationBucket = []byte("organizations/v1")
+	organizationIndex  = []byte("organizationindex/v1")
 )
 
 var _ influxdb.OrganizationService = (*Client)(nil)

--- a/bolt/user.go
+++ b/bolt/user.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	userBucket         = []byte("usersv1")
-	userIndex          = []byte("userindexv1")
-	userpasswordBucket = []byte("userspasswordv1")
+	userBucket         = []byte("users/v1")
+	userIndex          = []byte("userindex/v1")
+	userpasswordBucket = []byte("userspassword/v1")
 )
 
 var _ platform.UserService = (*Client)(nil)

--- a/bolt/user_resource_mapping.go
+++ b/bolt/user_resource_mapping.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	userResourceMappingBucket = []byte("userresourcemappingsv1")
+	userResourceMappingBucket = []byte("userresourcemappings/v1")
 )
 
 func (c *Client) initializeUserResourceMappings(ctx context.Context, tx *bolt.Tx) error {

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -297,23 +297,23 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	m.reg.MustRegister(m.boltClient)
 
 	var (
-		orgSvc           platform.OrganizationService             = m.boltClient
-		authSvc          platform.AuthorizationService            = m.boltClient
+		orgSvc           platform.OrganizationService             = m.kvService
+		authSvc          platform.AuthorizationService            = m.kvService
 		userSvc          platform.UserService                     = m.kvService
 		macroSvc         platform.MacroService                    = m.boltClient
-		bucketSvc        platform.BucketService                   = m.boltClient
+		bucketSvc        platform.BucketService                   = m.kvService
 		sourceSvc        platform.SourceService                   = m.boltClient
 		sessionSvc       platform.SessionService                  = m.boltClient
 		basicAuthSvc     platform.BasicAuthService                = m.boltClient
 		dashboardSvc     platform.DashboardService                = m.boltClient
 		dashboardLogSvc  platform.DashboardOperationLogService    = m.boltClient
-		userLogSvc       platform.UserOperationLogService         = m.boltClient
-		bucketLogSvc     platform.BucketOperationLogService       = m.boltClient
-		orgLogSvc        platform.OrganizationOperationLogService = m.boltClient
+		userLogSvc       platform.UserOperationLogService         = m.kvService
+		bucketLogSvc     platform.BucketOperationLogService       = m.kvService
+		orgLogSvc        platform.OrganizationOperationLogService = m.kvService
 		onboardingSvc    platform.OnboardingService               = m.boltClient
 		scraperTargetSvc platform.ScraperTargetStoreService       = m.boltClient
 		telegrafSvc      platform.TelegrafConfigStore             = m.boltClient
-		userResourceSvc  platform.UserResourceMappingService      = m.boltClient
+		userResourceSvc  platform.UserResourceMappingService      = m.kvService
 		labelSvc         platform.LabelService                    = m.boltClient
 		secretSvc        platform.SecretService                   = m.boltClient
 		lookupSvc        platform.LookupService                   = m.boltClient
@@ -496,7 +496,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		SecretService:                   secretSvc,
 		LookupService:                   lookupSvc,
 		ProtoService:                    protoSvc,
-		OrgLookupService:                m.boltClient,
+		OrgLookupService:                m.kvService,
 	}
 
 	// HTTP server

--- a/kv/auth.go
+++ b/kv/auth.go
@@ -14,7 +14,7 @@ var (
 
 var _ influxdb.AuthorizationService = (*Service)(nil)
 
-func (s *Service) initializeAuthorizations(ctx context.Context, tx Tx) error {
+func (s *Service) initializeAuths(ctx context.Context, tx Tx) error {
 	if _, err := tx.Bucket(authBucket); err != nil {
 		return err
 	}

--- a/kv/auth.go
+++ b/kv/auth.go
@@ -1,0 +1,460 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+
+	influxdb "github.com/influxdata/influxdb"
+)
+
+var (
+	authBucket = []byte("authorizations/v1")
+	authIndex  = []byte("authorizationindex/v1")
+)
+
+var _ influxdb.AuthorizationService = (*Service)(nil)
+
+func (s *Service) initializeAuthorizations(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket(authBucket); err != nil {
+		return err
+	}
+	if _, err := tx.Bucket(authIndex); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FindAuthorizationByID retrieves a authorization by id.
+func (s *Service) FindAuthorizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Authorization, error) {
+	var a *influxdb.Authorization
+	err := s.kv.View(func(tx Tx) error {
+		auth, err := s.findAuthorizationByID(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+
+		a = auth
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+func (s *Service) findAuthorizationByID(ctx context.Context, tx Tx, id influxdb.ID) (*influxdb.Authorization, error) {
+	encodedID, err := id.Encode()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	b, err := tx.Bucket(authBucket)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := b.Get(encodedID)
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "authorization not found",
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	a := &influxdb.Authorization{}
+	if err := decodeAuthorization(v, a); err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	return a, nil
+}
+
+// FindAuthorizationByToken returns a authorization by token for a particular authorization.
+func (s *Service) FindAuthorizationByToken(ctx context.Context, n string) (*influxdb.Authorization, error) {
+	var a *influxdb.Authorization
+	err := s.kv.View(func(tx Tx) error {
+		auth, err := s.findAuthorizationByToken(ctx, tx, n)
+		if err != nil {
+			return err
+		}
+
+		a = auth
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}
+
+func (s *Service) findAuthorizationByToken(ctx context.Context, tx Tx, n string) (*influxdb.Authorization, error) {
+	idx, err := tx.Bucket(authIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	a, err := idx.Get(authIndexKey(n))
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "authorization not found",
+		}
+	}
+
+	var id influxdb.ID
+	if err := id.Decode(a); err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+	return s.findAuthorizationByID(ctx, tx, id)
+}
+
+func filterAuthorizationsFn(filter influxdb.AuthorizationFilter) func(a *influxdb.Authorization) bool {
+	if filter.ID != nil {
+		return func(a *influxdb.Authorization) bool {
+			return a.ID == *filter.ID
+		}
+	}
+
+	if filter.Token != nil {
+		return func(a *influxdb.Authorization) bool {
+			return a.Token == *filter.Token
+		}
+	}
+
+	if filter.UserID != nil {
+		return func(a *influxdb.Authorization) bool {
+			return a.UserID == *filter.UserID
+		}
+	}
+
+	return func(a *influxdb.Authorization) bool { return true }
+}
+
+// FindAuthorizations retrives all authorizations that match an arbitrary authorization filter.
+// Filters using ID, or Token should be efficient.
+// Other filters will do a linear scan across all authorizations searching for a match.
+func (s *Service) FindAuthorizations(ctx context.Context, filter influxdb.AuthorizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Authorization, int, error) {
+	if filter.ID != nil {
+		a, err := s.FindAuthorizationByID(ctx, *filter.ID)
+		if err != nil {
+			return nil, 0, &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		return []*influxdb.Authorization{a}, 1, nil
+	}
+
+	if filter.Token != nil {
+		a, err := s.FindAuthorizationByToken(ctx, *filter.Token)
+		if err != nil {
+			return nil, 0, &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		return []*influxdb.Authorization{a}, 1, nil
+	}
+
+	as := []*influxdb.Authorization{}
+	err := s.kv.View(func(tx Tx) error {
+		auths, err := s.findAuthorizations(ctx, tx, filter)
+		if err != nil {
+			return err
+		}
+		as = auths
+		return nil
+	})
+
+	if err != nil {
+		return nil, 0, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return as, len(as), nil
+}
+
+func (s *Service) findAuthorizations(ctx context.Context, tx Tx, f influxdb.AuthorizationFilter) ([]*influxdb.Authorization, error) {
+	// If the users name was provided, look up user by ID first
+	if f.User != nil {
+		u, err := s.findUserByName(ctx, tx, *f.User)
+		if err != nil {
+			return nil, err
+		}
+		f.UserID = &u.ID
+	}
+
+	as := []*influxdb.Authorization{}
+	filterFn := filterAuthorizationsFn(f)
+	err := s.forEachAuthorization(ctx, tx, func(a *influxdb.Authorization) bool {
+		if filterFn(a) {
+			as = append(as, a)
+		}
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return as, nil
+}
+
+// CreateAuthorization creates a influxdb authorization and sets b.ID, and b.UserID if not provided.
+func (s *Service) CreateAuthorization(ctx context.Context, a *influxdb.Authorization) error {
+	if err := a.Valid(); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return s.kv.Update(func(tx Tx) error {
+		if _, err := s.findUserByID(ctx, tx, a.UserID); err != nil {
+			return influxdb.ErrUnableToCreateToken
+		}
+
+		if _, err := s.findOrganizationByID(ctx, tx, a.OrgID); err != nil {
+			return influxdb.ErrUnableToCreateToken
+		}
+
+		if unique := s.uniqueAuthorizationToken(ctx, tx, a); !unique {
+			return influxdb.ErrUnableToCreateToken
+		}
+
+		if a.Token == "" {
+			token, err := s.TokenGenerator.Token()
+			if err != nil {
+				return &influxdb.Error{
+					Err: err,
+				}
+			}
+			a.Token = token
+		}
+
+		a.ID = s.IDGenerator.ID()
+
+		if err := s.putAuthorization(ctx, tx, a); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// PutAuthorization will put a authorization without setting an ID.
+func (s *Service) PutAuthorization(ctx context.Context, a *influxdb.Authorization) error {
+	return s.kv.Update(func(tx Tx) error {
+		return s.putAuthorization(ctx, tx, a)
+	})
+}
+
+func encodeAuthorization(a *influxdb.Authorization) ([]byte, error) {
+	switch a.Status {
+	case influxdb.Active, influxdb.Inactive:
+	case "":
+		a.Status = influxdb.Active
+	default:
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "unknown authorization status",
+		}
+	}
+
+	return json.Marshal(a)
+}
+
+func (s *Service) putAuthorization(ctx context.Context, tx Tx, a *influxdb.Authorization) error {
+	v, err := encodeAuthorization(a)
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	encodedID, err := a.ID.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Err:  err,
+		}
+	}
+
+	idx, err := tx.Bucket(authIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := idx.Put(authIndexKey(a.Token), encodedID); err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInternal,
+			Err:  err,
+		}
+	}
+
+	b, err := tx.Bucket(authBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put(encodedID, v); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return nil
+}
+
+func authIndexKey(n string) []byte {
+	return []byte(n)
+}
+
+func decodeAuthorization(b []byte, a *influxdb.Authorization) error {
+	if err := json.Unmarshal(b, a); err != nil {
+		return err
+	}
+	if a.Status == "" {
+		a.Status = influxdb.Active
+	}
+	return nil
+}
+
+// forEachAuthorization will iterate through all authorizations while fn returns true.
+func (s *Service) forEachAuthorization(ctx context.Context, tx Tx, fn func(*influxdb.Authorization) bool) error {
+	b, err := tx.Bucket(authBucket)
+	if err != nil {
+		return err
+	}
+
+	cur, err := b.Cursor()
+	if err != nil {
+		return err
+	}
+
+	for k, v := cur.First(); k != nil; k, v = cur.Next() {
+		a := &influxdb.Authorization{}
+
+		if err := decodeAuthorization(v, a); err != nil {
+			return err
+		}
+		if !fn(a) {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) uniqueAuthorizationToken(ctx context.Context, tx Tx, a *influxdb.Authorization) bool {
+	idx, err := tx.Bucket(authIndex)
+	if err != nil {
+		return false
+	}
+
+	_, err = idx.Get(authIndexKey(a.Token))
+	return IsNotFound(err)
+}
+
+// DeleteAuthorization deletes a authorization and prunes it from the index.
+func (s *Service) DeleteAuthorization(ctx context.Context, id influxdb.ID) error {
+	return s.kv.Update(func(tx Tx) (err error) {
+		return s.deleteAuthorization(ctx, tx, id)
+	})
+}
+
+func (s *Service) deleteAuthorization(ctx context.Context, tx Tx, id influxdb.ID) error {
+	a, err := s.findAuthorizationByID(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+
+	idx, err := tx.Bucket(authIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := idx.Delete(authIndexKey(a.Token)); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	encodedID, err := id.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	b, err := tx.Bucket(authBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Delete(encodedID); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	return nil
+}
+
+// SetAuthorizationStatus updates the status of the authorization. Useful
+// for setting an authorization to inactive or active.
+func (s *Service) SetAuthorizationStatus(ctx context.Context, id influxdb.ID, status influxdb.Status) error {
+	return s.kv.Update(func(tx Tx) error {
+		return s.updateAuthorization(ctx, tx, id, status)
+	})
+}
+
+func (s *Service) updateAuthorization(ctx context.Context, tx Tx, id influxdb.ID, status influxdb.Status) error {
+	a, err := s.findAuthorizationByID(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+
+	a.Status = status
+	v, err := encodeAuthorization(a)
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	encodedID, err := id.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	b, err := tx.Bucket(authBucket)
+	if err != nil {
+		return err
+	}
+
+	if err = b.Put(encodedID, v); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	return nil
+}

--- a/kv/auth_test.go
+++ b/kv/auth_test.go
@@ -1,0 +1,93 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltAuthorizationService(t *testing.T) {
+	influxdbtesting.AuthorizationService(initBoltAuthorizationService, t)
+}
+
+func TestInmemAuthorizationService(t *testing.T) {
+	influxdbtesting.AuthorizationService(initInmemAuthorizationService, t)
+}
+
+func initBoltAuthorizationService(f influxdbtesting.AuthorizationFields, t *testing.T) (influxdb.AuthorizationService, string, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initAuthorizationService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemAuthorizationService(f influxdbtesting.AuthorizationFields, t *testing.T) (influxdb.AuthorizationService, string, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initAuthorizationService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initAuthorizationService(s kv.Store, f influxdbtesting.AuthorizationFields, t *testing.T) (influxdb.AuthorizationService, string, func()) {
+	svc := kv.NewService(s)
+	svc.IDGenerator = f.IDGenerator
+	svc.TokenGenerator = f.TokenGenerator
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing authorization service: %v", err)
+	}
+
+	for _, u := range f.Users {
+		if err := svc.PutUser(ctx, u); err != nil {
+			t.Fatalf("failed to populate users")
+		}
+	}
+
+	for _, o := range f.Orgs {
+		if err := svc.PutOrganization(ctx, o); err != nil {
+			t.Fatalf("failed to populate orgs")
+		}
+	}
+
+	for _, a := range f.Authorizations {
+		if err := svc.PutAuthorization(ctx, a); err != nil {
+			t.Fatalf("failed to populate authorizations %s", err)
+		}
+	}
+
+	return svc, kv.OpPrefix, func() {
+		for _, u := range f.Users {
+			if err := svc.DeleteUser(ctx, u.ID); err != nil {
+				t.Logf("failed to remove user: %v", err)
+			}
+		}
+
+		for _, o := range f.Orgs {
+			if err := svc.DeleteOrganization(ctx, o.ID); err != nil {
+				t.Logf("failed to remove org: %v", err)
+			}
+		}
+
+		for _, a := range f.Authorizations {
+			if err := svc.DeleteAuthorization(ctx, a.ID); err != nil {
+				t.Logf("failed to remove authorizations: %v", err)
+			}
+		}
+	}
+}

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/influxdata/influxdb"
+	icontext "github.com/influxdata/influxdb/context"
 )
 
 var (
@@ -14,8 +16,7 @@ var (
 )
 
 var _ influxdb.BucketService = (*Service)(nil)
-
-//var _ influxdb.BucketOperationLogService = (*Client)(nil)
+var _ influxdb.BucketOperationLogService = (*Service)(nil)
 
 func (s *Service) initializeBuckets(ctx context.Context, tx Tx) error {
 	if _, err := tx.Bucket(bucketBucket); err != nil {
@@ -357,11 +358,11 @@ func (s *Service) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
 
 		b.ID = s.IDGenerator.ID()
 
-		//if err = s.appendBucketEventToLog(ctx, tx, b.ID, bucketCreatedEvent); err != nil {
-		//	return &influxdb.Error{
-		//		Err: err,
-		//	}
-		//}
+		if err := s.appendBucketEventToLog(ctx, tx, b.ID, bucketCreatedEvent); err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
 
 		if err := s.putBucket(ctx, tx, b); err != nil {
 			return err
@@ -564,9 +565,9 @@ func (s *Service) updateBucket(ctx context.Context, tx Tx, id influxdb.ID, upd i
 		b.Name = *upd.Name
 	}
 
-	//if err := s.appendBucketEventToLog(ctx, tx, b.ID, bucketUpdatedEvent); err != nil {
-	//	return nil, err
-	//}
+	if err := s.appendBucketEventToLog(ctx, tx, b.ID, bucketUpdatedEvent); err != nil {
+		return nil, err
+	}
 
 	if err := s.putBucket(ctx, tx, b); err != nil {
 		return nil, err
@@ -643,75 +644,75 @@ func (s *Service) deleteBucket(ctx context.Context, tx Tx, id influxdb.ID) error
 	return nil
 }
 
-//const bucketOperationLogKeyPrefix = "bucket"
-//
-//func encodeBucketOperationLogKey(id influxdb.ID) ([]byte, error) {
-//	buf, err := id.Encode()
-//	if err != nil {
-//		return nil, err
-//	}
-//	return append([]byte(bucketOperationLogKeyPrefix), buf...), nil
-//}
-//
-//// GetBucketOperationLog retrieves a buckets operation log.
-//func (s *Service) GetBucketOperationLog(ctx context.Context, id influxdb.ID, opts influxdb.FindOptions) ([]*influxdb.OperationLogEntry, int, error) {
-//	// TODO(desa): might be worthwhile to allocate a slice of size opts.Limit
-//	log := []*influxdb.OperationLogEntry{}
-//
-//	err := s.kv.View(func(tx Tx) error {
-//		key, err := encodeBucketOperationLogKey(id)
-//		if err != nil {
-//			return err
-//		}
-//
-//		return s.forEachLogEntry(ctx, tx, key, opts, func(v []byte, t time.Time) error {
-//			e := &influxdb.OperationLogEntry{}
-//			if err := json.Unmarshal(v, e); err != nil {
-//				return err
-//			}
-//			e.Time = t
-//
-//			log = append(log, e)
-//
-//			return nil
-//		})
-//	})
-//
-//	if err != nil {
-//		return nil, 0, err
-//	}
-//
-//	return log, len(log), nil
-//}
-//
-//// TODO(desa): what do we want these to be?
-//const (
-//	bucketCreatedEvent = "Bucket Created"
-//	bucketUpdatedEvent = "Bucket Updated"
-//)
-//
-//func (s *Service) appendBucketEventToLog(ctx context.Context, tx Tx, id influxdb.ID, s string) error {
-//	e := &influxdb.OperationLogEntry{
-//		Description: s,
-//	}
-//	// TODO(desa): this is fragile and non explicit since it requires an authorizer to be on context. It should be
-//	//             replaced with a higher level transaction so that adding to the log can take place in the http handler
-//	//             where the userID will exist explicitly.
-//	a, err := influxdbcontext.GetAuthorizer(ctx)
-//	if err == nil {
-//		// Add the user to the log if you can, but don't error if its not there.
-//		e.UserID = a.GetUserID()
-//	}
-//
-//	v, err := json.Marshal(e)
-//	if err != nil {
-//		return err
-//	}
-//
-//	k, err := encodeBucketOperationLogKey(id)
-//	if err != nil {
-//		return err
-//	}
-//
-//	return s.addLogEntry(ctx, tx, k, v, s.time())
-//}
+const bucketOperationLogKeyPrefix = "bucket"
+
+func encodeBucketOperationLogKey(id influxdb.ID) ([]byte, error) {
+	buf, err := id.Encode()
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(bucketOperationLogKeyPrefix), buf...), nil
+}
+
+// GetBucketOperationLog retrieves a buckets operation log.
+func (s *Service) GetBucketOperationLog(ctx context.Context, id influxdb.ID, opts influxdb.FindOptions) ([]*influxdb.OperationLogEntry, int, error) {
+	// TODO(desa): might be worthwhile to allocate a slice of size opts.Limit
+	log := []*influxdb.OperationLogEntry{}
+
+	err := s.kv.View(func(tx Tx) error {
+		key, err := encodeBucketOperationLogKey(id)
+		if err != nil {
+			return err
+		}
+
+		return s.forEachLogEntry(ctx, tx, key, opts, func(v []byte, t time.Time) error {
+			e := &influxdb.OperationLogEntry{}
+			if err := json.Unmarshal(v, e); err != nil {
+				return err
+			}
+			e.Time = t
+
+			log = append(log, e)
+
+			return nil
+		})
+	})
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return log, len(log), nil
+}
+
+// TODO(desa): what do we want these to be?
+const (
+	bucketCreatedEvent = "Bucket Created"
+	bucketUpdatedEvent = "Bucket Updated"
+)
+
+func (s *Service) appendBucketEventToLog(ctx context.Context, tx Tx, id influxdb.ID, st string) error {
+	e := &influxdb.OperationLogEntry{
+		Description: st,
+	}
+	// TODO(desa): this is fragile and non explicit since it requires an authorizer to be on context. It should be
+	//             replaced with a higher level transaction so that adding to the log can take place in the http handler
+	//             where the userID will exist explicitly.
+	a, err := icontext.GetAuthorizer(ctx)
+	if err == nil {
+		// Add the user to the log if you can, but don't error if its not there.
+		e.UserID = a.GetUserID()
+	}
+
+	v, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+
+	k, err := encodeBucketOperationLogKey(id)
+	if err != nil {
+		return err
+	}
+
+	return s.addLogEntry(ctx, tx, k, v, s.time())
+}

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -368,9 +368,9 @@ func (s *Service) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
 			return err
 		}
 
-		//if pe := s.createBucketUserResourceMappings(ctx, tx, b); pe != nil {
-		//	err = pe
-		//}
+		if err := s.createBucketUserResourceMappings(ctx, tx, b); err != nil {
+			return err
+		}
 		return nil
 	})
 }
@@ -387,32 +387,32 @@ func (s *Service) PutBucket(ctx context.Context, b *influxdb.Bucket) error {
 	})
 }
 
-//func (s *Service) createBucketUserResourceMappings(ctx context.Context, tx Tx, b *influxdb.Bucket) *influxdb.Error {
-//	ms, err := s.findUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
-//		ResourceType: influxdb.OrgsResourceType,
-//		ResourceID:   b.OrganizationID,
-//	})
-//	if err != nil {
-//		return &influxdb.Error{
-//			Err: err,
-//		}
-//	}
-//
-//	for _, m := range ms {
-//		if err := s.createUserResourceMapping(ctx, tx, &influxdb.UserResourceMapping{
-//			ResourceType: influxdb.BucketsResourceType,
-//			ResourceID:   b.ID,
-//			UserID:       m.UserID,
-//			UserType:     m.UserType,
-//		}); err != nil {
-//			return &influxdb.Error{
-//				Err: err,
-//			}
-//		}
-//	}
-//
-//	return nil
-//}
+func (s *Service) createBucketUserResourceMappings(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
+	ms, err := s.findUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
+		ResourceType: influxdb.OrgsResourceType,
+		ResourceID:   b.OrganizationID,
+	})
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	for _, m := range ms {
+		if err := s.createUserResourceMapping(ctx, tx, &influxdb.UserResourceMapping{
+			ResourceType: influxdb.BucketsResourceType,
+			ResourceID:   b.ID,
+			UserID:       m.UserID,
+			UserType:     m.UserType,
+		}); err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+	}
+
+	return nil
+}
 
 func (s *Service) putBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
 	b.Organization = ""
@@ -632,14 +632,12 @@ func (s *Service) deleteBucket(ctx context.Context, tx Tx, id influxdb.ID) error
 		}
 	}
 
-	//if err := s.deleteUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
-	//	ResourceID:   id,
-	//	ResourceType: influxdb.BucketsResourceType,
-	//}); err != nil {
-	//	return &influxdb.Error{
-	//		Err: err,
-	//	}
-	//}
+	if err := s.deleteUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
+		ResourceID:   id,
+		ResourceType: influxdb.BucketsResourceType,
+	}); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -142,11 +142,15 @@ func (s *Service) findBucketByName(ctx context.Context, tx Tx, orgID influxdb.ID
 	}
 
 	buf, err := idx.Get(key)
-	if buf == nil {
+	if IsNotFound(err) {
 		return nil, &influxdb.Error{
 			Code: influxdb.ENotFound,
 			Msg:  "bucket not found",
 		}
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	var id influxdb.ID

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -1,0 +1,717 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/influxdata/influxdb"
+)
+
+var (
+	bucketBucket = []byte("buckets/v1")
+	bucketIndex  = []byte("bucketindex/v1")
+)
+
+var _ influxdb.BucketService = (*Service)(nil)
+
+//var _ influxdb.BucketOperationLogService = (*Client)(nil)
+
+func (s *Service) initializeBuckets(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket(bucketBucket); err != nil {
+		return err
+	}
+	if _, err := tx.Bucket(bucketIndex); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Service) setOrganizationOnBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
+	o, err := s.findOrganizationByID(ctx, tx, b.OrganizationID)
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	b.Organization = o.Name
+	return nil
+}
+
+// FindBucketByID retrieves a bucket by id.
+func (s *Service) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
+	var b *influxdb.Bucket
+	var err error
+
+	err = s.kv.View(func(tx Tx) error {
+		bkt, pe := s.findBucketByID(ctx, tx, id)
+		if pe != nil {
+			err = pe
+			return err
+		}
+		b = bkt
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func (s *Service) findBucketByID(ctx context.Context, tx Tx, id influxdb.ID) (*influxdb.Bucket, error) {
+	var b influxdb.Bucket
+
+	encodedID, err := id.Encode()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	bkt, err := tx.Bucket(bucketBucket)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := bkt.Get(encodedID)
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "bucket not found",
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(v, &b); err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	if err := s.setOrganizationOnBucket(ctx, tx, &b); err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return &b, nil
+}
+
+// FindBucketByName returns a bucket by name for a particular organization.
+// TODO: have method for finding bucket using organization name and bucket name.
+func (s *Service) FindBucketByName(ctx context.Context, orgID influxdb.ID, n string) (*influxdb.Bucket, error) {
+	var b *influxdb.Bucket
+	var err error
+
+	err = s.kv.View(func(tx Tx) error {
+		bkt, pe := s.findBucketByName(ctx, tx, orgID, n)
+		if pe != nil {
+			err = pe
+			return err
+		}
+		b = bkt
+		return nil
+	})
+
+	return b, err
+}
+
+func (s *Service) findBucketByName(ctx context.Context, tx Tx, orgID influxdb.ID, n string) (*influxdb.Bucket, error) {
+	b := &influxdb.Bucket{
+		OrganizationID: orgID,
+		Name:           n,
+	}
+	key, err := bucketIndexKey(b)
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	idx, err := tx.Bucket(bucketIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	buf, err := idx.Get(key)
+	if buf == nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "bucket not found",
+		}
+	}
+
+	var id influxdb.ID
+	if err := id.Decode(buf); err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+	return s.findBucketByID(ctx, tx, id)
+}
+
+// FindBucket retrives a bucket using an arbitrary bucket filter.
+// Filters using ID, or OrganizationID and bucket Name should be efficient.
+// Other filters will do a linear scan across buckets until it finds a match.
+func (s *Service) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
+	var b *influxdb.Bucket
+	var err error
+
+	if filter.ID != nil {
+		b, err = s.FindBucketByID(ctx, *filter.ID)
+		if err != nil {
+			return nil, &influxdb.Error{
+				Err: err,
+			}
+		}
+		return b, nil
+	}
+
+	if filter.Name != nil && filter.OrganizationID != nil {
+		return s.FindBucketByName(ctx, *filter.OrganizationID, *filter.Name)
+	}
+
+	err = s.kv.View(func(tx Tx) error {
+		if filter.Organization != nil {
+			o, err := s.findOrganizationByName(ctx, tx, *filter.Organization)
+			if err != nil {
+				return err
+			}
+			filter.OrganizationID = &o.ID
+		}
+
+		filterFn := filterBucketsFn(filter)
+		return s.forEachBucket(ctx, tx, false, func(bkt *influxdb.Bucket) bool {
+			if filterFn(bkt) {
+				b = bkt
+				return false
+			}
+			return true
+		})
+	})
+
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	if b == nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "bucket not found",
+		}
+	}
+
+	return b, nil
+}
+
+func filterBucketsFn(filter influxdb.BucketFilter) func(b *influxdb.Bucket) bool {
+	if filter.ID != nil {
+		return func(b *influxdb.Bucket) bool {
+			return b.ID == *filter.ID
+		}
+	}
+
+	if filter.Name != nil && filter.OrganizationID != nil {
+		return func(b *influxdb.Bucket) bool {
+			return b.Name == *filter.Name && b.OrganizationID == *filter.OrganizationID
+		}
+	}
+
+	if filter.Name != nil {
+		return func(b *influxdb.Bucket) bool {
+			return b.Name == *filter.Name
+		}
+	}
+
+	if filter.OrganizationID != nil {
+		return func(b *influxdb.Bucket) bool {
+			return b.OrganizationID == *filter.OrganizationID
+		}
+	}
+
+	return func(b *influxdb.Bucket) bool { return true }
+}
+
+// FindBuckets retrives all buckets that match an arbitrary bucket filter.
+// Filters using ID, or OrganizationID and bucket Name should be efficient.
+// Other filters will do a linear scan across all buckets searching for a match.
+func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opts ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+	if filter.ID != nil {
+		b, err := s.FindBucketByID(ctx, *filter.ID)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		return []*influxdb.Bucket{b}, 1, nil
+	}
+
+	if filter.Name != nil && filter.OrganizationID != nil {
+		b, err := s.FindBucketByName(ctx, *filter.OrganizationID, *filter.Name)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		return []*influxdb.Bucket{b}, 1, nil
+	}
+
+	bs := []*influxdb.Bucket{}
+	err := s.kv.View(func(tx Tx) error {
+		bkts, err := s.findBuckets(ctx, tx, filter, opts...)
+		if err != nil {
+			return err
+		}
+		bs = bkts
+		return nil
+	})
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return bs, len(bs), nil
+}
+
+func (s *Service) findBuckets(ctx context.Context, tx Tx, filter influxdb.BucketFilter, opts ...influxdb.FindOptions) ([]*influxdb.Bucket, error) {
+	bs := []*influxdb.Bucket{}
+	if filter.Organization != nil {
+		o, err := s.findOrganizationByName(ctx, tx, *filter.Organization)
+		if err != nil {
+			return nil, &influxdb.Error{
+				Err: err,
+			}
+		}
+		filter.OrganizationID = &o.ID
+	}
+
+	var offset, limit, count int
+	var descending bool
+	if len(opts) > 0 {
+		offset = opts[0].Offset
+		limit = opts[0].Limit
+		descending = opts[0].Descending
+	}
+
+	filterFn := filterBucketsFn(filter)
+	err := s.forEachBucket(ctx, tx, descending, func(b *influxdb.Bucket) bool {
+		if filterFn(b) {
+			if count >= offset {
+				bs = append(bs, b)
+			}
+			count++
+		}
+
+		if limit > 0 && len(bs) >= limit {
+			return false
+		}
+
+		return true
+	})
+
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return bs, nil
+}
+
+// CreateBucket creates a influxdb bucket and sets b.ID.
+func (s *Service) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
+	return s.kv.Update(func(tx Tx) error {
+		if b.OrganizationID.Valid() {
+			_, pe := s.findOrganizationByID(ctx, tx, b.OrganizationID)
+			if pe != nil {
+				return &influxdb.Error{
+					Err: pe,
+				}
+			}
+		} else {
+			o, pe := s.findOrganizationByName(ctx, tx, b.Organization)
+			if pe != nil {
+				return &influxdb.Error{
+					Err: pe,
+				}
+			}
+			b.OrganizationID = o.ID
+		}
+
+		unique := s.uniqueBucketName(ctx, tx, b)
+
+		if !unique {
+			// TODO: make standard error
+			return &influxdb.Error{
+				Code: influxdb.EConflict,
+				Msg:  fmt.Sprintf("bucket with name %s already exists", b.Name),
+			}
+		}
+
+		b.ID = s.IDGenerator.ID()
+
+		//if err = s.appendBucketEventToLog(ctx, tx, b.ID, bucketCreatedEvent); err != nil {
+		//	return &influxdb.Error{
+		//		Err: err,
+		//	}
+		//}
+
+		if err := s.putBucket(ctx, tx, b); err != nil {
+			return err
+		}
+
+		//if pe := s.createBucketUserResourceMappings(ctx, tx, b); pe != nil {
+		//	err = pe
+		//}
+		return nil
+	})
+}
+
+// PutBucket will put a bucket without setting an ID.
+func (s *Service) PutBucket(ctx context.Context, b *influxdb.Bucket) error {
+	return s.kv.Update(func(tx Tx) error {
+		var err error
+		pe := s.putBucket(ctx, tx, b)
+		if pe != nil {
+			err = pe
+		}
+		return err
+	})
+}
+
+//func (s *Service) createBucketUserResourceMappings(ctx context.Context, tx Tx, b *influxdb.Bucket) *influxdb.Error {
+//	ms, err := s.findUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
+//		ResourceType: influxdb.OrgsResourceType,
+//		ResourceID:   b.OrganizationID,
+//	})
+//	if err != nil {
+//		return &influxdb.Error{
+//			Err: err,
+//		}
+//	}
+//
+//	for _, m := range ms {
+//		if err := s.createUserResourceMapping(ctx, tx, &influxdb.UserResourceMapping{
+//			ResourceType: influxdb.BucketsResourceType,
+//			ResourceID:   b.ID,
+//			UserID:       m.UserID,
+//			UserType:     m.UserType,
+//		}); err != nil {
+//			return &influxdb.Error{
+//				Err: err,
+//			}
+//		}
+//	}
+//
+//	return nil
+//}
+
+func (s *Service) putBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
+	b.Organization = ""
+	v, err := json.Marshal(b)
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	encodedID, err := b.ID.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	key, pe := bucketIndexKey(b)
+	if err != nil {
+		return pe
+	}
+
+	idx, err := tx.Bucket(bucketIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := idx.Put(key, encodedID); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	bkt, err := tx.Bucket(bucketBucket)
+	if bkt.Put(encodedID, v); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	return s.setOrganizationOnBucket(ctx, tx, b)
+}
+
+func bucketIndexKey(b *influxdb.Bucket) ([]byte, error) {
+	orgID, err := b.OrganizationID.Encode()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+	k := make([]byte, influxdb.IDLength+len(b.Name))
+	copy(k, orgID)
+	copy(k[influxdb.IDLength:], []byte(b.Name))
+	return k, nil
+}
+
+// forEachBucket will iterate through all buckets while fn returns true.
+func (s *Service) forEachBucket(ctx context.Context, tx Tx, descending bool, fn func(*influxdb.Bucket) bool) error {
+	bkt, err := tx.Bucket(bucketBucket)
+	if err != nil {
+		return err
+	}
+
+	cur, err := bkt.Cursor()
+	if err != nil {
+		return err
+	}
+
+	var k, v []byte
+	if descending {
+		k, v = cur.Last()
+	} else {
+		k, v = cur.First()
+	}
+
+	for k != nil {
+		b := &influxdb.Bucket{}
+		if err := json.Unmarshal(v, b); err != nil {
+			return err
+		}
+		if err := s.setOrganizationOnBucket(ctx, tx, b); err != nil {
+			return err
+		}
+		if !fn(b) {
+			break
+		}
+
+		if descending {
+			k, v = cur.Prev()
+		} else {
+			k, v = cur.Next()
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) uniqueBucketName(ctx context.Context, tx Tx, b *influxdb.Bucket) bool {
+	key, err := bucketIndexKey(b)
+	if err != nil {
+		return false
+	}
+	idx, err := tx.Bucket(bucketIndex)
+	if err != nil {
+		return false
+	}
+
+	_, err = idx.Get(key)
+
+	return IsNotFound(err)
+}
+
+// UpdateBucket updates a bucket according the parameters set on upd.
+func (s *Service) UpdateBucket(ctx context.Context, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
+	var b *influxdb.Bucket
+	err := s.kv.Update(func(tx Tx) error {
+		bkt, err := s.updateBucket(ctx, tx, id, upd)
+		if err != nil {
+			return err
+		}
+		b = bkt
+		return nil
+	})
+
+	return b, err
+}
+
+func (s *Service) updateBucket(ctx context.Context, tx Tx, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
+	b, err := s.findBucketByID(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if upd.RetentionPeriod != nil {
+		b.RetentionPeriod = *upd.RetentionPeriod
+	}
+
+	if upd.Name != nil {
+		key, err := bucketIndexKey(b)
+		if err != nil {
+			return nil, err
+		}
+		idx, err := tx.Bucket(bucketIndex)
+		if err != nil {
+			return nil, err
+		}
+		// Buckets are indexed by name and so the bucket index must be pruned when name is modified.
+		if err := idx.Delete(key); err != nil {
+			return nil, err
+		}
+		b.Name = *upd.Name
+	}
+
+	//if err := s.appendBucketEventToLog(ctx, tx, b.ID, bucketUpdatedEvent); err != nil {
+	//	return nil, err
+	//}
+
+	if err := s.putBucket(ctx, tx, b); err != nil {
+		return nil, err
+	}
+
+	if err := s.setOrganizationOnBucket(ctx, tx, b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// DeleteBucket deletes a bucket and prunes it from the index.
+func (s *Service) DeleteBucket(ctx context.Context, id influxdb.ID) error {
+	return s.kv.Update(func(tx Tx) error {
+		var err error
+		if pe := s.deleteBucket(ctx, tx, id); pe != nil {
+			err = pe
+		}
+		return err
+	})
+}
+
+func (s *Service) deleteBucket(ctx context.Context, tx Tx, id influxdb.ID) error {
+	b, pe := s.findBucketByID(ctx, tx, id)
+	if pe != nil {
+		return pe
+	}
+
+	key, pe := bucketIndexKey(b)
+	if pe != nil {
+		return pe
+	}
+
+	idx, err := tx.Bucket(bucketIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := idx.Delete(key); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	encodedID, err := id.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	bkt, err := tx.Bucket(bucketBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := bkt.Delete(encodedID); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	//if err := s.deleteUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
+	//	ResourceID:   id,
+	//	ResourceType: influxdb.BucketsResourceType,
+	//}); err != nil {
+	//	return &influxdb.Error{
+	//		Err: err,
+	//	}
+	//}
+
+	return nil
+}
+
+//const bucketOperationLogKeyPrefix = "bucket"
+//
+//func encodeBucketOperationLogKey(id influxdb.ID) ([]byte, error) {
+//	buf, err := id.Encode()
+//	if err != nil {
+//		return nil, err
+//	}
+//	return append([]byte(bucketOperationLogKeyPrefix), buf...), nil
+//}
+//
+//// GetBucketOperationLog retrieves a buckets operation log.
+//func (s *Service) GetBucketOperationLog(ctx context.Context, id influxdb.ID, opts influxdb.FindOptions) ([]*influxdb.OperationLogEntry, int, error) {
+//	// TODO(desa): might be worthwhile to allocate a slice of size opts.Limit
+//	log := []*influxdb.OperationLogEntry{}
+//
+//	err := s.kv.View(func(tx Tx) error {
+//		key, err := encodeBucketOperationLogKey(id)
+//		if err != nil {
+//			return err
+//		}
+//
+//		return s.forEachLogEntry(ctx, tx, key, opts, func(v []byte, t time.Time) error {
+//			e := &influxdb.OperationLogEntry{}
+//			if err := json.Unmarshal(v, e); err != nil {
+//				return err
+//			}
+//			e.Time = t
+//
+//			log = append(log, e)
+//
+//			return nil
+//		})
+//	})
+//
+//	if err != nil {
+//		return nil, 0, err
+//	}
+//
+//	return log, len(log), nil
+//}
+//
+//// TODO(desa): what do we want these to be?
+//const (
+//	bucketCreatedEvent = "Bucket Created"
+//	bucketUpdatedEvent = "Bucket Updated"
+//)
+//
+//func (s *Service) appendBucketEventToLog(ctx context.Context, tx Tx, id influxdb.ID, s string) error {
+//	e := &influxdb.OperationLogEntry{
+//		Description: s,
+//	}
+//	// TODO(desa): this is fragile and non explicit since it requires an authorizer to be on context. It should be
+//	//             replaced with a higher level transaction so that adding to the log can take place in the http handler
+//	//             where the userID will exist explicitly.
+//	a, err := influxdbcontext.GetAuthorizer(ctx)
+//	if err == nil {
+//		// Add the user to the log if you can, but don't error if its not there.
+//		e.UserID = a.GetUserID()
+//	}
+//
+//	v, err := json.Marshal(e)
+//	if err != nil {
+//		return err
+//	}
+//
+//	k, err := encodeBucketOperationLogKey(id)
+//	if err != nil {
+//		return err
+//	}
+//
+//	return s.addLogEntry(ctx, tx, k, v, s.time())
+//}

--- a/kv/bucket_test.go
+++ b/kv/bucket_test.go
@@ -1,0 +1,76 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltBucketService(t *testing.T) {
+	influxdbtesting.BucketService(initBoltBucketService, t)
+}
+
+func TestInmemBucketService(t *testing.T) {
+	influxdbtesting.BucketService(initInmemBucketService, t)
+}
+
+func initBoltBucketService(f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initBucketService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemBucketService(f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initBucketService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initBucketService(s kv.Store, f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {
+	svc := kv.NewService(s)
+	svc.IDGenerator = f.IDGenerator
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing bucket service: %v", err)
+	}
+	for _, o := range f.Organizations {
+		if err := svc.PutOrganization(ctx, o); err != nil {
+			t.Fatalf("failed to populate organizations")
+		}
+	}
+	for _, b := range f.Buckets {
+		if err := svc.PutBucket(ctx, b); err != nil {
+			t.Fatalf("failed to populate buckets")
+		}
+	}
+	return svc, kv.OpPrefix, func() {
+		for _, o := range f.Organizations {
+			if err := svc.DeleteOrganization(ctx, o.ID); err != nil {
+				t.Logf("failed to remove organization: %v", err)
+			}
+		}
+		for _, b := range f.Buckets {
+			if err := svc.DeleteBucket(ctx, b.ID); err != nil {
+				t.Logf("failed to remove bucket: %v", err)
+			}
+		}
+	}
+}

--- a/kv/kvlog.go
+++ b/kv/kvlog.go
@@ -1,0 +1,397 @@
+package kv
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	platform "github.com/influxdata/influxdb"
+)
+
+var (
+	kvlogBucket = []byte("keyvaluelog/v1")
+	kvlogIndex  = []byte("keyvaluelogindex/v1")
+)
+
+var _ platform.KeyValueLog = (*Service)(nil)
+
+type keyValueLogBounds struct {
+	Start int64 `json:"start"`
+	Stop  int64 `json:"stop"`
+}
+
+func newKeyValueLogBounds(now time.Time) *keyValueLogBounds {
+	return &keyValueLogBounds{
+		Start: now.UTC().UnixNano(),
+		Stop:  now.UTC().UnixNano(),
+	}
+}
+
+func (b *keyValueLogBounds) update(t time.Time) {
+	now := t.UTC().UnixNano()
+	if now < b.Start {
+		b.Start = now
+	} else if b.Stop < now {
+		b.Stop = now
+	}
+}
+
+// StartTime retrieves the start value of a bounds as a time.Time
+func (b *keyValueLogBounds) StartTime() time.Time {
+	return time.Unix(0, b.Start)
+}
+
+// StopTime retrieves the stop value of a bounds as a time.Time
+func (b *keyValueLogBounds) StopTime() time.Time {
+	return time.Unix(0, b.Stop)
+}
+
+// Bounds returns the key boundaries for the keyvaluelog for a resourceType/resourceID pair.
+func (b *keyValueLogBounds) Bounds(k []byte) ([]byte, []byte, error) {
+	start, err := encodeLogEntryKey(k, b.Start)
+	if err != nil {
+		return nil, nil, err
+	}
+	stop, err := encodeLogEntryKey(k, b.Stop)
+	if err != nil {
+		return nil, nil, err
+	}
+	return start, stop, nil
+}
+
+func encodeLogEntryKey(key []byte, v int64) ([]byte, error) {
+	prefix := encodeKeyValueIndexKey(key)
+	k := make([]byte, len(prefix)+8)
+
+	buf := bytes.NewBuffer(k)
+	_, err := buf.Write(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	// This needs to be big-endian so that the iteration order is preserved when scanning keys
+	if err := binary.Write(buf, binary.BigEndian, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), err
+}
+
+func decodeLogEntryKey(key []byte) ([]byte, time.Time, error) {
+	buf := bytes.NewReader(key[len(key)-8:])
+	var ts int64
+	// This needs to be big-endian so that the iteration order is preserved when scanning keys
+	err := binary.Read(buf, binary.BigEndian, &ts)
+	if err != nil {
+		return nil, time.Unix(0, 0), err
+	}
+	return key[:len(key)-8], time.Unix(0, ts), nil
+}
+
+func encodeKeyValueIndexKey(k []byte) []byte {
+	// keys produced must be fixed length to ensure that we can iterate through the keyspace without any error.
+	h := sha1.New()
+	h.Write([]byte(k))
+	return h.Sum(nil)
+}
+
+func (s *Service) initializeKVLog(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket(kvlogBucket); err != nil {
+		return err
+	}
+	if _, err := tx.Bucket(kvlogIndex); err != nil {
+		return err
+	}
+	return nil
+}
+
+var errKeyValueLogBoundsNotFound = fmt.Errorf("oplog not found")
+
+func (s *Service) getKeyValueLogBounds(ctx context.Context, tx Tx, key []byte) (*keyValueLogBounds, error) {
+	k := encodeKeyValueIndexKey(key)
+
+	b, err := tx.Bucket(kvlogIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := b.Get(k)
+	if IsNotFound(err) {
+		return nil, errKeyValueLogBoundsNotFound
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	bounds := &keyValueLogBounds{}
+	if err := json.Unmarshal(v, bounds); err != nil {
+		return nil, err
+	}
+
+	return bounds, nil
+}
+
+func (s *Service) putKeyValueLogBounds(ctx context.Context, tx Tx, key []byte, bounds *keyValueLogBounds) error {
+	k := encodeKeyValueIndexKey(key)
+
+	v, err := json.Marshal(bounds)
+	if err != nil {
+		return err
+	}
+
+	b, err := tx.Bucket(kvlogIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put(k, v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) updateKeyValueLogBounds(ctx context.Context, tx Tx, k []byte, t time.Time) error {
+	// retrieve the keyValue log boundaries
+	bounds, err := s.getKeyValueLogBounds(ctx, tx, k)
+	if err != nil && err != errKeyValueLogBoundsNotFound {
+		return err
+	}
+
+	if err == errKeyValueLogBoundsNotFound {
+		// if the bounds don't exist yet, create them
+		bounds = newKeyValueLogBounds(t)
+	}
+
+	// update the bounds to if needed
+	bounds.update(t)
+	if err := s.putKeyValueLogBounds(ctx, tx, k, bounds); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ForEachLogEntry retrieves the keyValue log for a resource type ID combination. KeyValues may be returned in ascending and descending order.
+func (s *Service) ForEachLogEntry(ctx context.Context, k []byte, opts platform.FindOptions, fn func([]byte, time.Time) error) error {
+	return s.kv.View(func(tx Tx) error {
+		return s.forEachLogEntry(ctx, tx, k, opts, fn)
+	})
+}
+
+func (s *Service) forEachLogEntry(ctx context.Context, tx Tx, k []byte, opts platform.FindOptions, fn func([]byte, time.Time) error) error {
+	b, err := s.getKeyValueLogBounds(ctx, tx, k)
+	if err != nil {
+		return err
+	}
+
+	bkt, err := tx.Bucket(kvlogBucket)
+	if err != nil {
+		return err
+	}
+
+	cur, err := bkt.Cursor()
+	if err != nil {
+		return err
+	}
+
+	next := cur.Next
+	startKey, stopKey, err := b.Bounds(k)
+	if err != nil {
+		return err
+	}
+
+	if opts.Descending {
+		next = cur.Prev
+		startKey, stopKey = stopKey, startKey
+	}
+
+	k, v := cur.Seek(startKey)
+	if !bytes.Equal(k, startKey) {
+		return fmt.Errorf("the first key not the key found in the log bounds. This should be impossible. Please report this error")
+	}
+
+	count := 0
+
+	if opts.Offset == 0 {
+		// Seek returns the kv at the position that was seeked to which should be the first element
+		// in the sequence of keyValues. If this condition is reached we need to start of iteration
+		// at 1 instead of 0.
+		_, ts, err := decodeLogEntryKey(k)
+		if err != nil {
+			return err
+		}
+		if err := fn(v, ts); err != nil {
+			return err
+		}
+		count++
+		if bytes.Equal(startKey, stopKey) {
+			// If the start and stop are the same, then there is only a single entry in the log
+			return nil
+		}
+	} else {
+		// Skip offset many items
+		for i := 0; i < opts.Offset-1; i++ {
+			k, _ := next()
+			if bytes.Equal(k, stopKey) {
+				return nil
+			}
+		}
+	}
+
+	for {
+		if count >= opts.Limit && opts.Limit != 0 {
+			break
+		}
+
+		k, v := next()
+
+		_, ts, err := decodeLogEntryKey(k)
+		if err != nil {
+			return err
+		}
+
+		if err := fn(v, ts); err != nil {
+			return err
+		}
+
+		if bytes.Equal(k, stopKey) {
+			// if we've reached the stop key, there are no keys log entries left
+			// in the keyspace.
+			break
+		}
+
+		count++
+	}
+
+	return nil
+
+}
+
+// LogKeyValue logs an keyValue for a particular resource type ID pairing.
+func (s *Service) AddLogEntry(ctx context.Context, k, v []byte, t time.Time) error {
+	return s.kv.Update(func(tx Tx) error {
+		return s.addLogEntry(ctx, tx, k, v, t)
+	})
+}
+
+func (s *Service) addLogEntry(ctx context.Context, tx Tx, k, v []byte, t time.Time) error {
+	if err := s.updateKeyValueLogBounds(ctx, tx, k, t); err != nil {
+		return err
+	}
+
+	if err := s.putLogEntry(ctx, tx, k, v, t); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) putLogEntry(ctx context.Context, tx Tx, k, v []byte, t time.Time) error {
+	key, err := encodeLogEntryKey(k, t.UTC().UnixNano())
+	if err != nil {
+		return err
+	}
+
+	b, err := tx.Bucket(kvlogBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put(key, v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) getLogEntry(ctx context.Context, tx Tx, k []byte, t time.Time) ([]byte, time.Time, error) {
+	key, err := encodeLogEntryKey(k, t.UTC().UnixNano())
+	if err != nil {
+		return nil, t, err
+	}
+
+	b, err := tx.Bucket(kvlogBucket)
+	if err != nil {
+		return nil, t, err
+	}
+
+	v, err := b.Get(key)
+	if IsNotFound(err) {
+		return nil, t, fmt.Errorf("log entry not found")
+	}
+
+	if err != nil {
+		return nil, t, err
+	}
+
+	return v, t, nil
+}
+
+// FirstLogEntry retrieves the first log entry for a key value log.
+func (s *Service) FirstLogEntry(ctx context.Context, k []byte) ([]byte, time.Time, error) {
+	var v []byte
+	var t time.Time
+
+	err := s.kv.View(func(tx Tx) error {
+		val, ts, err := s.firstLogEntry(ctx, tx, k)
+		if err != nil {
+			return err
+		}
+
+		v, t = val, ts
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, t, err
+	}
+
+	return v, t, nil
+}
+
+// LastLogEntry retrieves the first log entry for a key value log.
+func (s *Service) LastLogEntry(ctx context.Context, k []byte) ([]byte, time.Time, error) {
+	var v []byte
+	var t time.Time
+
+	err := s.kv.View(func(tx Tx) error {
+		val, ts, err := s.lastLogEntry(ctx, tx, k)
+		if err != nil {
+			return err
+		}
+
+		v, t = val, ts
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, t, err
+	}
+
+	return v, t, nil
+}
+
+func (s *Service) firstLogEntry(ctx context.Context, tx Tx, k []byte) ([]byte, time.Time, error) {
+	bounds, err := s.getKeyValueLogBounds(ctx, tx, k)
+	if err != nil {
+		return nil, bounds.StartTime(), err
+	}
+
+	return s.getLogEntry(ctx, tx, k, bounds.StartTime())
+}
+
+func (s *Service) lastLogEntry(ctx context.Context, tx Tx, k []byte) ([]byte, time.Time, error) {
+	bounds, err := s.getKeyValueLogBounds(ctx, tx, k)
+	if err != nil {
+		return nil, bounds.StopTime(), err
+	}
+
+	return s.getLogEntry(ctx, tx, k, bounds.StopTime())
+}

--- a/kv/kvlog_test.go
+++ b/kv/kvlog_test.go
@@ -1,0 +1,61 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltKeyValueLog(t *testing.T) {
+	influxdbtesting.KeyValueLog(initBoltKeyValueLog, t)
+}
+
+func TestInmemKeyValueLog(t *testing.T) {
+	influxdbtesting.KeyValueLog(initInmemKeyValueLog, t)
+}
+
+func initBoltKeyValueLog(f influxdbtesting.KeyValueLogFields, t *testing.T) (influxdb.KeyValueLog, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, closeSvc := initKeyValueLog(s, f, t)
+	return svc, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemKeyValueLog(f influxdbtesting.KeyValueLogFields, t *testing.T) (influxdb.KeyValueLog, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, closeSvc := initKeyValueLog(s, f, t)
+	return svc, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initKeyValueLog(s kv.Store, f influxdbtesting.KeyValueLogFields, t *testing.T) (influxdb.KeyValueLog, func()) {
+	svc := kv.NewService(s)
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing organization service: %v", err)
+	}
+
+	for _, e := range f.LogEntries {
+		if err := svc.AddLogEntry(ctx, e.Key, e.Value, e.Time); err != nil {
+			t.Fatalf("failed to populate log entries")
+		}
+	}
+	return svc, func() {
+	}
+}

--- a/kv/org.go
+++ b/kv/org.go
@@ -546,59 +546,61 @@ func (s *Service) appendOrganizationEventToLog(ctx context.Context, tx Tx, id in
 	return s.addLogEntry(ctx, tx, k, v, s.time())
 }
 
-//func (s *Service) FindResourceOrganizationID(ctx context.Context, rt influxdb.ResourceType, id influxdb.ID) (influxdb.ID, error) {
-//	switch rt {
-//	case influxdb.AuthorizationsResourceType:
-//		r, err := s.FindAuthorizationByID(ctx, id)
-//		if err != nil {
-//			return influxdb.InvalidID(), err
-//		}
-//		return r.OrgID, nil
-//	case influxdb.BucketsResourceType:
-//		r, err := s.FindBucketByID(ctx, id)
-//		if err != nil {
-//			return influxdb.InvalidID(), err
-//		}
-//		return r.OrganizationID, nil
-//	case influxdb.DashboardsResourceType:
-//		r, err := s.FindDashboardByID(ctx, id)
-//		if err != nil {
-//			return influxdb.InvalidID(), err
-//		}
-//		return r.OrganizationID, nil
-//	case influxdb.OrgsResourceType:
-//		r, err := s.FindOrganizationByID(ctx, id)
-//		if err != nil {
-//			return influxdb.InvalidID(), err
-//		}
-//		return r.ID, nil
-//	case influxdb.SourcesResourceType:
-//		r, err := s.FindSourceByID(ctx, id)
-//		if err != nil {
-//			return influxdb.InvalidID(), err
-//		}
-//		return r.OrganizationID, nil
-//	case influxdb.TelegrafsResourceType:
-//		r, err := s.FindTelegrafConfigByID(ctx, id)
-//		if err != nil {
-//			return influxdb.InvalidID(), err
-//		}
-//		return r.OrganizationID, nil
-//	case influxdb.MacrosResourceType:
-//		r, err := s.FindMacroByID(ctx, id)
-//		if err != nil {
-//			return influxdb.InvalidID(), err
-//		}
-//		return r.OrganizationID, nil
-//	case influxdb.ScraperResourceType:
-//		r, err := s.GetTargetByID(ctx, id)
-//		if err != nil {
-//			return influxdb.InvalidID(), err
-//		}
-//		return r.OrgID, nil
-//	}
-//
-//	return influxdb.InvalidID(), &influxdb.Error{
-//		Msg: fmt.Sprintf("unsupported resource type %s", rt),
-//	}
-//}
+// FindResourceOrganizationID is used to find the organization that a resource belongs to five the id of a resource and a resource type.
+func (s *Service) FindResourceOrganizationID(ctx context.Context, rt influxdb.ResourceType, id influxdb.ID) (influxdb.ID, error) {
+	switch rt {
+	case influxdb.AuthorizationsResourceType:
+		r, err := s.FindAuthorizationByID(ctx, id)
+		if err != nil {
+			return influxdb.InvalidID(), err
+		}
+		return r.OrgID, nil
+	case influxdb.BucketsResourceType:
+		r, err := s.FindBucketByID(ctx, id)
+		if err != nil {
+			return influxdb.InvalidID(), err
+		}
+		return r.OrganizationID, nil
+	case influxdb.OrgsResourceType:
+		r, err := s.FindOrganizationByID(ctx, id)
+		if err != nil {
+			return influxdb.InvalidID(), err
+		}
+		return r.ID, nil
+		// TODO(desa): uncomment these as more resource types are added.
+		//case influxdb.DashboardsResourceType:
+		//	r, err := s.FindDashboardByID(ctx, id)
+		//	if err != nil {
+		//		return influxdb.InvalidID(), err
+		//	}
+		//	return r.OrganizationID, nil
+		//case influxdb.SourcesResourceType:
+		//	r, err := s.FindSourceByID(ctx, id)
+		//	if err != nil {
+		//		return influxdb.InvalidID(), err
+		//	}
+		//	return r.OrganizationID, nil
+		//case influxdb.TelegrafsResourceType:
+		//	r, err := s.FindTelegrafConfigByID(ctx, id)
+		//	if err != nil {
+		//		return influxdb.InvalidID(), err
+		//	}
+		//	return r.OrganizationID, nil
+		//case influxdb.MacrosResourceType:
+		//	r, err := s.FindMacroByID(ctx, id)
+		//	if err != nil {
+		//		return influxdb.InvalidID(), err
+		//	}
+		//	return r.OrganizationID, nil
+		//case influxdb.ScraperResourceType:
+		//	r, err := s.GetTargetByID(ctx, id)
+		//	if err != nil {
+		//		return influxdb.InvalidID(), err
+		//	}
+		//	return r.OrgID, nil
+	}
+
+	return influxdb.InvalidID(), &influxdb.Error{
+		Msg: fmt.Sprintf("unsupported resource type %s", rt),
+	}
+}

--- a/kv/org.go
+++ b/kv/org.go
@@ -1,0 +1,601 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	influxdb "github.com/influxdata/influxdb"
+)
+
+var (
+	organizationBucket = []byte("organizations/v1")
+	organizationIndex  = []byte("organizationindex/v1")
+)
+
+var _ influxdb.OrganizationService = (*Service)(nil)
+
+//var _ influxdb.OrganizationOperationLogService = (*Service)(nil)
+
+func (s *Service) initializeOrgs(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket(organizationBucket); err != nil {
+		return err
+	}
+	if _, err := tx.Bucket(organizationIndex); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FindOrganizationByID retrieves a organization by id.
+func (s *Service) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Organization, error) {
+	var o *influxdb.Organization
+	err := s.kv.View(func(tx Tx) error {
+		org, pe := s.findOrganizationByID(ctx, tx, id)
+		if pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+		}
+		o = org
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return o, nil
+}
+
+func (s *Service) findOrganizationByID(ctx context.Context, tx Tx, id influxdb.ID) (*influxdb.Organization, error) {
+	encodedID, err := id.Encode()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	b, err := tx.Bucket(organizationBucket)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := b.Get(encodedID)
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "organization not found",
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var o influxdb.Organization
+	if err := json.Unmarshal(v, &o); err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return &o, nil
+}
+
+// FindOrganizationByName returns a organization by name for a particular organization.
+func (s *Service) FindOrganizationByName(ctx context.Context, n string) (*influxdb.Organization, error) {
+	var o *influxdb.Organization
+
+	err := s.kv.View(func(tx Tx) error {
+		org, err := s.findOrganizationByName(ctx, tx, n)
+		if err != nil {
+			fmt.Println(n, err)
+			return err
+		}
+		o = org
+		return nil
+	})
+
+	return o, err
+}
+
+func (s *Service) findOrganizationByName(ctx context.Context, tx Tx, n string) (*influxdb.Organization, error) {
+	b, err := tx.Bucket(organizationIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	o, err := b.Get(organizationIndexKey(n))
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  fmt.Sprintf("organization name \"%s\" not found", n),
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var id influxdb.ID
+	if err := id.Decode(o); err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+	return s.findOrganizationByID(ctx, tx, id)
+}
+
+// FindOrganization retrives a organization using an arbitrary organization filter.
+// Filters using ID, or Name should be efficient.
+// Other filters will do a linear scan across organizations until it finds a match.
+func (s *Service) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+	if filter.ID != nil {
+		return s.FindOrganizationByID(ctx, *filter.ID)
+	}
+
+	if filter.Name != nil {
+		return s.FindOrganizationByName(ctx, *filter.Name)
+	}
+
+	filterFn := filterOrganizationsFn(filter)
+
+	var o *influxdb.Organization
+	err := s.kv.View(func(tx Tx) error {
+		return forEachOrganization(ctx, tx, func(org *influxdb.Organization) bool {
+			if filterFn(org) {
+				o = org
+				return false
+			}
+			return true
+		})
+	})
+
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	if o == nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "organization not found",
+		}
+	}
+
+	return o, nil
+}
+
+func filterOrganizationsFn(filter influxdb.OrganizationFilter) func(o *influxdb.Organization) bool {
+	if filter.ID != nil {
+		return func(o *influxdb.Organization) bool {
+			return o.ID == *filter.ID
+		}
+	}
+
+	if filter.Name != nil {
+		return func(o *influxdb.Organization) bool {
+			return o.Name == *filter.Name
+		}
+	}
+
+	return func(o *influxdb.Organization) bool { return true }
+}
+
+// FindOrganizations retrives all organizations that match an arbitrary organization filter.
+// Filters using ID, or Name should be efficient.
+// Other filters will do a linear scan across all organizations searching for a match.
+func (s *Service) FindOrganizations(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {
+	if filter.ID != nil {
+		o, err := s.FindOrganizationByID(ctx, *filter.ID)
+		if err != nil {
+			return nil, 0, &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		return []*influxdb.Organization{o}, 1, nil
+	}
+
+	if filter.Name != nil {
+		o, err := s.FindOrganizationByName(ctx, *filter.Name)
+		if err != nil {
+			return nil, 0, &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		return []*influxdb.Organization{o}, 1, nil
+	}
+
+	os := []*influxdb.Organization{}
+	filterFn := filterOrganizationsFn(filter)
+	err := s.kv.View(func(tx Tx) error {
+		return forEachOrganization(ctx, tx, func(o *influxdb.Organization) bool {
+			if filterFn(o) {
+				os = append(os, o)
+			}
+			return true
+		})
+	})
+
+	if err != nil {
+		return nil, 0, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return os, len(os), nil
+}
+
+// CreateOrganization creates a influxdb organization and sets b.ID.
+func (s *Service) CreateOrganization(ctx context.Context, o *influxdb.Organization) error {
+	return s.kv.Update(func(tx Tx) error {
+		unique := s.uniqueOrganizationName(ctx, tx, o)
+		if !unique {
+			return &influxdb.Error{
+				Code: influxdb.EConflict,
+				Msg:  fmt.Sprintf("organization with name %s already exists", o.Name),
+			}
+		}
+
+		o.ID = s.IDGenerator.ID()
+		//if err := s.appendOrganizationEventToLog(ctx, tx, o.ID, organizationCreatedEvent); err != nil {
+		//	return &influxdb.Error{
+		//		Err: err,
+		//	}
+		//}
+
+		if err := s.putOrganization(ctx, tx, o); err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+		return nil
+	})
+}
+
+// PutOrganization will put a organization without setting an ID.
+func (s *Service) PutOrganization(ctx context.Context, o *influxdb.Organization) error {
+	var err error
+	return s.kv.Update(func(tx Tx) error {
+		if pe := s.putOrganization(ctx, tx, o); pe != nil {
+			err = pe
+		}
+		return err
+	})
+}
+
+func (s *Service) putOrganization(ctx context.Context, tx Tx, o *influxdb.Organization) error {
+	v, err := json.Marshal(o)
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	encodedID, err := o.ID.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	idx, err := tx.Bucket(organizationIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := idx.Put(organizationIndexKey(o.Name), encodedID); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	b, err := tx.Bucket(organizationBucket)
+	if err != nil {
+		return err
+	}
+
+	if err = b.Put(encodedID, v); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func organizationIndexKey(n string) []byte {
+	return []byte(n)
+}
+
+// forEachOrganization will iterate through all organizations while fn returns true.
+func forEachOrganization(ctx context.Context, tx Tx, fn func(*influxdb.Organization) bool) error {
+	b, err := tx.Bucket(organizationBucket)
+	if err != nil {
+		return err
+	}
+
+	cur, err := b.Cursor()
+	if err != nil {
+		return err
+	}
+
+	for k, v := cur.First(); k != nil; k, v = cur.Next() {
+		o := &influxdb.Organization{}
+		if err := json.Unmarshal(v, o); err != nil {
+			return err
+		}
+		if !fn(o) {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) uniqueOrganizationName(ctx context.Context, tx Tx, o *influxdb.Organization) bool {
+	b, err := tx.Bucket(organizationIndex)
+	if err != nil {
+		return false
+	}
+
+	_, err = b.Get(organizationIndexKey(o.Name))
+	return IsNotFound(err)
+}
+
+// UpdateOrganization updates a organization according the parameters set on upd.
+func (s *Service) UpdateOrganization(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
+	var o *influxdb.Organization
+	err := s.kv.Update(func(tx Tx) error {
+		org, pe := s.updateOrganization(ctx, tx, id, upd)
+		if pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+		}
+		o = org
+		return nil
+	})
+
+	return o, err
+}
+
+func (s *Service) updateOrganization(ctx context.Context, tx Tx, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
+	o, pe := s.findOrganizationByID(ctx, tx, id)
+	if pe != nil {
+		return nil, pe
+	}
+
+	if upd.Name != nil {
+		// Organizations are indexed by name and so the organization index must be pruned
+		// when name is modified.
+		idx, err := tx.Bucket(organizationIndex)
+		if err != nil {
+			return nil, err
+		}
+		if err := idx.Delete(organizationIndexKey(o.Name)); err != nil {
+			return nil, &influxdb.Error{
+				Err: err,
+			}
+		}
+		o.Name = *upd.Name
+	}
+
+	//if err := s.appendOrganizationEventToLog(ctx, tx, o.ID, organizationUpdatedEvent); err != nil {
+	//	return nil, &influxdb.Error{
+	//		Err: err,
+	//	}
+	//}
+
+	if pe := s.putOrganization(ctx, tx, o); pe != nil {
+		return nil, pe
+	}
+
+	return o, nil
+}
+
+// DeleteOrganization deletes a organization and prunes it from the index.
+func (s *Service) DeleteOrganization(ctx context.Context, id influxdb.ID) error {
+	err := s.kv.Update(func(tx Tx) error {
+		//if pe := s.deleteOrganizationsBuckets(ctx, tx, id); pe != nil {
+		//	return pe
+		//}
+		if pe := s.deleteOrganization(ctx, tx, id); pe != nil {
+			return pe
+		}
+		return nil
+	})
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	return nil
+}
+
+func (s *Service) deleteOrganization(ctx context.Context, tx Tx, id influxdb.ID) error {
+	o, pe := s.findOrganizationByID(ctx, tx, id)
+	if pe != nil {
+		return pe
+	}
+
+	idx, err := tx.Bucket(organizationIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := idx.Delete(organizationIndexKey(o.Name)); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	encodedID, err := id.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	b, err := tx.Bucket(organizationBucket)
+	if err != nil {
+		return err
+	}
+
+	if err = b.Delete(encodedID); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return nil
+}
+
+//func (s *Service) deleteOrganizationsBuckets(ctx context.Context, tx Tx, id influxdb.ID) error {
+//	filter := influxdb.BucketFilter{
+//		OrganizationID: &id,
+//	}
+//	bs, pe := s.findBuckets(ctx, tx, filter)
+//	if pe != nil {
+//		return pe
+//	}
+//	for _, b := range bs {
+//		if pe := s.deleteBucket(ctx, tx, b.ID); pe != nil {
+//			return pe
+//		}
+//	}
+//	return nil
+//}
+
+//// GeOrganizationOperationLog retrieves a organization operation log.
+//func (s *Service) GetOrganizationOperationLog(ctx context.Context, id influxdb.ID, opts influxdb.FindOptions) ([]*influxdb.OperationLogEntry, int, error) {
+//	// TODO(desa): might be worthwhile to allocate a slice of size opts.Limit
+//	log := []*influxdb.OperationLogEntry{}
+//
+//	err := s.kv.View(func(tx Tx) error {
+//		key, err := encodeBucketOperationLogKey(id)
+//		if err != nil {
+//			return err
+//		}
+//
+//		return s.forEachLogEntry(ctx, tx, key, opts, func(v []byte, t time.Time) error {
+//			e := &influxdb.OperationLogEntry{}
+//			if err := json.Unmarshal(v, e); err != nil {
+//				return err
+//			}
+//			e.Time = t
+//
+//			log = append(log, e)
+//
+//			return nil
+//		})
+//	})
+//
+//	if err != nil {
+//		return nil, 0, err
+//	}
+//
+//	return log, len(log), nil
+//}
+//
+//// TODO(desa): what do we want these to be?
+//const (
+//	organizationCreatedEvent = "Organization Created"
+//	organizationUpdatedEvent = "Organization Updated"
+//)
+//
+//func encodeOrganizationOperationLogKey(id influxdb.ID) ([]byte, error) {
+//	buf, err := id.Encode()
+//	if err != nil {
+//		return nil, err
+//	}
+//	return append([]byte(bucketOperationLogKeyPrefix), buf...), nil
+//}
+//
+//func (s *Service) appendOrganizationEventToLog(ctx context.Context, tx Tx, id influxdb.ID, s string) error {
+//	e := &influxdb.OperationLogEntry{
+//		Description: s,
+//	}
+//	// TODO(desa): this is fragile and non explicit since it requires an authorizer to be on context. It should be
+//	//             replaced with a higher level transaction so that adding to the log can take place in the http handler
+//	//             where the organizationID will exist explicitly.
+//	a, err := influxdbcontext.GetAuthorizer(ctx)
+//	if err == nil {
+//		// Add the organization to the log if you can, but don't error if its not there.
+//		e.UserID = a.GetUserID()
+//	}
+//
+//	v, err := json.Marshal(e)
+//	if err != nil {
+//		return err
+//	}
+//
+//	k, err := encodeOrganizationOperationLogKey(id)
+//	if err != nil {
+//		return err
+//	}
+//
+//	return s.addLogEntry(ctx, tx, k, v, s.time())
+//}
+//
+//func (s *Service) FindResourceOrganizationID(ctx context.Context, rt influxdb.ResourceType, id influxdb.ID) (influxdb.ID, error) {
+//	switch rt {
+//	case influxdb.AuthorizationsResourceType:
+//		r, err := s.FindAuthorizationByID(ctx, id)
+//		if err != nil {
+//			return influxdb.InvalidID(), err
+//		}
+//		return r.OrgID, nil
+//	case influxdb.BucketsResourceType:
+//		r, err := s.FindBucketByID(ctx, id)
+//		if err != nil {
+//			return influxdb.InvalidID(), err
+//		}
+//		return r.OrganizationID, nil
+//	case influxdb.DashboardsResourceType:
+//		r, err := s.FindDashboardByID(ctx, id)
+//		if err != nil {
+//			return influxdb.InvalidID(), err
+//		}
+//		return r.OrganizationID, nil
+//	case influxdb.OrgsResourceType:
+//		r, err := s.FindOrganizationByID(ctx, id)
+//		if err != nil {
+//			return influxdb.InvalidID(), err
+//		}
+//		return r.ID, nil
+//	case influxdb.SourcesResourceType:
+//		r, err := s.FindSourceByID(ctx, id)
+//		if err != nil {
+//			return influxdb.InvalidID(), err
+//		}
+//		return r.OrganizationID, nil
+//	case influxdb.TelegrafsResourceType:
+//		r, err := s.FindTelegrafConfigByID(ctx, id)
+//		if err != nil {
+//			return influxdb.InvalidID(), err
+//		}
+//		return r.OrganizationID, nil
+//	case influxdb.MacrosResourceType:
+//		r, err := s.FindMacroByID(ctx, id)
+//		if err != nil {
+//			return influxdb.InvalidID(), err
+//		}
+//		return r.OrganizationID, nil
+//	case influxdb.ScraperResourceType:
+//		r, err := s.GetTargetByID(ctx, id)
+//		if err != nil {
+//			return influxdb.InvalidID(), err
+//		}
+//		return r.OrgID, nil
+//	}
+//
+//	return influxdb.InvalidID(), &influxdb.Error{
+//		Msg: fmt.Sprintf("unsupported resource type %s", rt),
+//	}
+//}

--- a/kv/org_test.go
+++ b/kv/org_test.go
@@ -1,0 +1,68 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltOrganizationService(t *testing.T) {
+	influxdbtesting.OrganizationService(initBoltOrganizationService, t)
+}
+
+func TestInmemOrganizationService(t *testing.T) {
+	influxdbtesting.OrganizationService(initInmemOrganizationService, t)
+}
+
+func initBoltOrganizationService(f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initOrganizationService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemOrganizationService(f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initOrganizationService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initOrganizationService(s kv.Store, f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {
+	svc := kv.NewService(s)
+	svc.IDGenerator = f.IDGenerator
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing organization service: %v", err)
+	}
+
+	for _, u := range f.Organizations {
+		if err := svc.PutOrganization(ctx, u); err != nil {
+			t.Fatalf("failed to populate organizations")
+		}
+	}
+
+	return svc, kv.OpPrefix, func() {
+		for _, u := range f.Organizations {
+			if err := svc.DeleteOrganization(ctx, u.ID); err != nil {
+				t.Logf("failed to remove organizations: %v", err)
+			}
+		}
+	}
+}

--- a/kv/service.go
+++ b/kv/service.go
@@ -50,6 +50,10 @@ func (s *Service) Initialize(ctx context.Context) error {
 			return err
 		}
 
+		if err := s.initializeKVLog(ctx, tx); err != nil {
+			return err
+		}
+
 		return nil
 	})
 }

--- a/kv/service.go
+++ b/kv/service.go
@@ -53,11 +53,19 @@ func (s *Service) Initialize(ctx context.Context) error {
 			return err
 		}
 
+		if err := s.initializeBuckets(ctx, tx); err != nil {
+			return err
+		}
+
 		if err := s.initializeKVLog(ctx, tx); err != nil {
 			return err
 		}
 
 		if err := s.initializeURMs(ctx, tx); err != nil {
+			return err
+		}
+
+		if err := s.initializeAuths(ctx, tx); err != nil {
 			return err
 		}
 

--- a/kv/service.go
+++ b/kv/service.go
@@ -46,6 +46,10 @@ func (s *Service) Initialize(ctx context.Context) error {
 			return err
 		}
 
+		if err := s.initializeBuckets(ctx, tx); err != nil {
+			return err
+		}
+
 		return nil
 	})
 }

--- a/kv/service.go
+++ b/kv/service.go
@@ -42,6 +42,10 @@ func (s *Service) Initialize(ctx context.Context) error {
 			return err
 		}
 
+		if err := s.initializeOrgs(ctx, tx); err != nil {
+			return err
+		}
+
 		return nil
 	})
 }

--- a/kv/urm.go
+++ b/kv/urm.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	urmBucket = []byte("urm/v1")
+	urmBucket = []byte("userresourcemappings/v1")
 )
 
 func (s *Service) initializeURMs(ctx context.Context, tx Tx) error {

--- a/kv/urm.go
+++ b/kv/urm.go
@@ -1,0 +1,293 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/influxdata/influxdb"
+)
+
+var (
+	urmBucket = []byte("urm/v1")
+)
+
+func (s *Service) initializeURMs(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket(urmBucket); err != nil {
+		return err
+	}
+	return nil
+}
+
+func filterMappingsFn(filter influxdb.UserResourceMappingFilter) func(m *influxdb.UserResourceMapping) bool {
+	return func(mapping *influxdb.UserResourceMapping) bool {
+		return (!filter.UserID.Valid() || (filter.UserID == mapping.UserID)) &&
+			(!filter.ResourceID.Valid() || (filter.ResourceID == mapping.ResourceID)) &&
+			(filter.UserType == "" || (filter.UserType == mapping.UserType)) &&
+			(filter.ResourceType == "" || (filter.ResourceType == mapping.ResourceType))
+	}
+}
+
+// FindUserResourceMappings returns a list of UserResourceMappings that match filter and the total count of matching mappings.
+func (s *Service) FindUserResourceMappings(ctx context.Context, filter influxdb.UserResourceMappingFilter, opt ...influxdb.FindOptions) ([]*influxdb.UserResourceMapping, int, error) {
+	ms := []*influxdb.UserResourceMapping{}
+	err := s.kv.View(func(tx Tx) error {
+		mappings, err := s.findUserResourceMappings(ctx, tx, filter)
+		if err != nil {
+			return err
+		}
+		ms = mappings
+		return nil
+	})
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return ms, len(ms), nil
+}
+
+func (s *Service) findUserResourceMappings(ctx context.Context, tx Tx, filter influxdb.UserResourceMappingFilter) ([]*influxdb.UserResourceMapping, error) {
+	ms := []*influxdb.UserResourceMapping{}
+	filterFn := filterMappingsFn(filter)
+	err := s.forEachUserResourceMapping(ctx, tx, func(m *influxdb.UserResourceMapping) bool {
+		if filterFn(m) {
+			ms = append(ms, m)
+		}
+		return true
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ms, nil
+}
+
+func (s *Service) findUserResourceMapping(ctx context.Context, tx Tx, filter influxdb.UserResourceMappingFilter) (*influxdb.UserResourceMapping, error) {
+	ms, err := s.findUserResourceMappings(ctx, tx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ms) == 0 {
+		return nil, fmt.Errorf("userResource mapping not found")
+	}
+
+	return ms[0], nil
+}
+
+func (s *Service) CreateUserResourceMapping(ctx context.Context, m *influxdb.UserResourceMapping) error {
+	return s.kv.Update(func(tx Tx) error {
+		if err := s.createUserResourceMapping(ctx, tx, m); err != nil {
+			return err
+		}
+
+		if m.ResourceType == influxdb.OrgsResourceType {
+			return s.createOrgDependentMappings(ctx, tx, m)
+		}
+
+		return nil
+	})
+}
+
+func (s *Service) createUserResourceMapping(ctx context.Context, tx Tx, m *influxdb.UserResourceMapping) error {
+	unique := s.uniqueUserResourceMapping(ctx, tx, m)
+
+	if !unique {
+		return fmt.Errorf("mapping for user %s already exists", m.UserID.String())
+	}
+
+	v, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	key, err := userResourceKey(m)
+	if err != nil {
+		return err
+	}
+
+	b, err := tx.Bucket(urmBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put(key, v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// This method creates the user/resource mappings for resources that belong to an organization.
+func (s *Service) createOrgDependentMappings(ctx context.Context, tx Tx, m *influxdb.UserResourceMapping) error {
+	bf := influxdb.BucketFilter{OrganizationID: &m.ResourceID}
+	bs, err := s.findBuckets(ctx, tx, bf)
+	if err != nil {
+		return err
+	}
+	for _, b := range bs {
+		m := &influxdb.UserResourceMapping{
+			ResourceType: influxdb.BucketsResourceType,
+			ResourceID:   b.ID,
+			UserType:     m.UserType,
+			UserID:       m.UserID,
+		}
+		if err := s.createUserResourceMapping(ctx, tx, m); err != nil {
+			return err
+		}
+		// TODO(desa): add support for all other resource types.
+	}
+
+	return nil
+}
+
+func userResourceKey(m *influxdb.UserResourceMapping) ([]byte, error) {
+	encodedResourceID, err := m.ResourceID.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	encodedUserID, err := m.UserID.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	key := make([]byte, len(encodedResourceID)+len(encodedUserID))
+	copy(key, encodedResourceID)
+	copy(key[len(encodedResourceID):], encodedUserID)
+
+	return key, nil
+}
+
+func (s *Service) forEachUserResourceMapping(ctx context.Context, tx Tx, fn func(*influxdb.UserResourceMapping) bool) error {
+	b, err := tx.Bucket(urmBucket)
+	if err != nil {
+		return err
+	}
+
+	cur, err := b.Cursor()
+	if err != nil {
+		return err
+	}
+
+	for k, v := cur.First(); k != nil; k, v = cur.Next() {
+		m := &influxdb.UserResourceMapping{}
+		if err := json.Unmarshal(v, m); err != nil {
+			return err
+		}
+		if !fn(m) {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) uniqueUserResourceMapping(ctx context.Context, tx Tx, m *influxdb.UserResourceMapping) bool {
+	key, err := userResourceKey(m)
+	if err != nil {
+		return false
+	}
+
+	b, err := tx.Bucket(urmBucket)
+	if err != nil {
+		return false
+	}
+
+	_, err = b.Get(key)
+	return IsNotFound(err)
+}
+
+// DeleteUserResourceMapping deletes a user resource mapping.
+func (s *Service) DeleteUserResourceMapping(ctx context.Context, resourceID influxdb.ID, userID influxdb.ID) error {
+	return s.kv.Update(func(tx Tx) error {
+		m, err := s.findUserResourceMapping(ctx, tx, influxdb.UserResourceMappingFilter{
+			ResourceID: resourceID,
+			UserID:     userID,
+		})
+		if err != nil {
+			return err
+		}
+
+		if err := s.deleteUserResourceMapping(ctx, tx, influxdb.UserResourceMappingFilter{
+			ResourceID: resourceID,
+			UserID:     userID,
+		}); err != nil {
+			return err
+		}
+
+		if m.ResourceType == influxdb.OrgsResourceType {
+			return s.deleteOrgDependentMappings(ctx, tx, m)
+		}
+
+		return nil
+	})
+}
+
+func (s *Service) deleteUserResourceMapping(ctx context.Context, tx Tx, filter influxdb.UserResourceMappingFilter) error {
+	ms, err := s.findUserResourceMappings(ctx, tx, filter)
+	if err != nil {
+		return err
+	}
+	if len(ms) == 0 {
+		return fmt.Errorf("userResource mapping not found")
+	}
+
+	key, err := userResourceKey(ms[0])
+	if err != nil {
+		return err
+	}
+
+	b, err := tx.Bucket(urmBucket)
+	if err != nil {
+		return err
+	}
+
+	return b.Delete(key)
+}
+
+func (s *Service) deleteUserResourceMappings(ctx context.Context, tx Tx, filter influxdb.UserResourceMappingFilter) error {
+	ms, err := s.findUserResourceMappings(ctx, tx, filter)
+	if err != nil {
+		return err
+	}
+	for _, m := range ms {
+		key, err := userResourceKey(m)
+		if err != nil {
+			return err
+		}
+
+		b, err := tx.Bucket(urmBucket)
+		if err != nil {
+			return err
+		}
+
+		if err = b.Delete(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// This method deletes the user/resource mappings for resources that belong to an organization.
+func (s *Service) deleteOrgDependentMappings(ctx context.Context, tx Tx, m *influxdb.UserResourceMapping) error {
+	bf := influxdb.BucketFilter{OrganizationID: &m.ResourceID}
+	bs, err := s.findBuckets(ctx, tx, bf)
+	if err != nil {
+		return err
+	}
+	for _, b := range bs {
+		if err := s.deleteUserResourceMapping(ctx, tx, influxdb.UserResourceMappingFilter{
+			ResourceType: influxdb.BucketsResourceType,
+			ResourceID:   b.ID,
+			UserID:       m.UserID,
+		}); err != nil {
+			return err
+		}
+		// TODO(desa): add support for all other resource types.
+	}
+
+	return nil
+}

--- a/kv/urm_test.go
+++ b/kv/urm_test.go
@@ -1,0 +1,67 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltUserResourceMappingService(t *testing.T) {
+	influxdbtesting.UserResourceMappingService(initBoltUserResourceMappingService, t)
+}
+
+func TestInmemUserResourceMappingService(t *testing.T) {
+	influxdbtesting.UserResourceMappingService(initInmemUserResourceMappingService, t)
+}
+
+func initBoltUserResourceMappingService(f influxdbtesting.UserResourceFields, t *testing.T) (influxdb.UserResourceMappingService, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, closeSvc := initUserResourceMappingService(s, f, t)
+	return svc, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemUserResourceMappingService(f influxdbtesting.UserResourceFields, t *testing.T) (influxdb.UserResourceMappingService, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, closeSvc := initUserResourceMappingService(s, f, t)
+	return svc, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initUserResourceMappingService(s kv.Store, f influxdbtesting.UserResourceFields, t *testing.T) (influxdb.UserResourceMappingService, func()) {
+	svc := kv.NewService(s)
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing urm service: %v", err)
+	}
+
+	for _, m := range f.UserResourceMappings {
+		if err := svc.CreateUserResourceMapping(ctx, m); err != nil {
+			t.Fatalf("failed to populate mappings")
+		}
+	}
+
+	return svc, func() {
+		for _, m := range f.UserResourceMappings {
+			if err := svc.DeleteUserResourceMapping(ctx, m.ResourceID, m.UserID); err != nil {
+				t.Logf("failed to remove user resource mapping: %v", err)
+			}
+		}
+	}
+}

--- a/kv/user.go
+++ b/kv/user.go
@@ -352,7 +352,7 @@ func (s *Service) updateUser(ctx context.Context, tx Tx, id influxdb.ID, upd inf
 		u.Name = *upd.Name
 	}
 
-	if err := s.appendUserEventToLog(ctx, tx, u.ID, userCreatedEvent); err != nil {
+	if err := s.appendUserEventToLog(ctx, tx, u.ID, userUpdatedEvent); err != nil {
 		return nil, err
 	}
 

--- a/kv/user.go
+++ b/kv/user.go
@@ -412,6 +412,12 @@ func (s *Service) deleteUser(ctx context.Context, tx Tx, id influxdb.ID) error {
 		return ErrInternalUserServiceError(err)
 	}
 
+	if err := s.deleteUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
+		UserID: id,
+	}); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/kv/user.go
+++ b/kv/user.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	userBucket = []byte("usersv1")
-	userIndex  = []byte("userindexv1")
+	userBucket = []byte("users/v1")
+	userIndex  = []byte("userindex/v1")
 )
 
 var _ influxdb.UserService = (*Service)(nil)

--- a/kv/user.go
+++ b/kv/user.go
@@ -390,6 +390,11 @@ func (s *Service) deleteUser(ctx context.Context, tx Tx, id influxdb.ID) error {
 	if err != nil {
 		return err
 	}
+
+	if err := s.deleteUsersAuthorizations(ctx, tx, id); err != nil {
+		return err
+	}
+
 	encodedID, err := id.Encode()
 	if err != nil {
 		return InvalidUserIDError(err)
@@ -418,6 +423,22 @@ func (s *Service) deleteUser(ctx context.Context, tx Tx, id influxdb.ID) error {
 		return err
 	}
 
+	return nil
+}
+
+func (s *Service) deleteUsersAuthorizations(ctx context.Context, tx Tx, id influxdb.ID) error {
+	authFilter := influxdb.AuthorizationFilter{
+		UserID: &id,
+	}
+	as, err := s.findAuthorizations(ctx, tx, authFilter)
+	if err != nil {
+		return err
+	}
+	for _, a := range as {
+		if err := s.deleteAuthorization(ctx, tx, a.ID); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #11716 
Closes #11718 
Closes #11719 
Closes #11720  

_Briefly describe your proposed changes:_

The PR moves Orgs, Buckets, Authorizations, and Users to their kv implementations.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
