### PR TITLE
Update Editable name to not allow empty string inline edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ### Features
 1. [11809](https://github.com/influxdata/influxdb/pull/11809): Add the ability to name a scraper target
 1. [11821](https://github.com/influxdata/influxdb/pull/11821): Display scraper name as the first and only updatable column in scrapers list
+1. [11804](https://github.com/influxdata/influxdb/pull/11804): Add the ability to view runs for a task
 
 ### Bug Fixes
-
+1. [11819](https://github.com/influxdata/influxdb/pull/11819): Update the inline edit for resource names to guard for empty strings
 ### UI Improvements
 1. [11764](https://github.com/influxdata/influxdb/pull/11764): Move the download telegraf config button to view config overlay
 

--- a/ui/src/shared/components/EditableName.tsx
+++ b/ui/src/shared/components/EditableName.tsx
@@ -113,6 +113,10 @@ class EditableName extends Component<Props, State> {
     const {workingName} = this.state
 
     if (e.key === 'Enter') {
+      if (!workingName) {
+        this.setState({isEditing: false, workingName: name})
+        return
+      }
       await onUpdate(workingName)
       this.setState({isEditing: false})
     }


### PR DESCRIPTION
Closes #11818 

_Briefly describe your proposed changes:_
Update Editable Name to not allow empty string for name

  - [x] Rebased/mergeable
  - [x] Tests pass

![kapture 2019-02-12 at 10 02 13](https://user-images.githubusercontent.com/26464594/52657503-a856ee00-2ead-11e9-9a9f-5a37077be087.gif)
