### PR TITLE
feat(ui): Display scraper name in scrapers list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [11809](https://github.com/influxdata/influxdb/pull/11809): Add the ability to name a scraper target
+1. [11821](https://github.com/influxdata/influxdb/pull/11821): Display scraper name as the first and only updatable column in scrapers list
 
 ### Bug Fixes
 

--- a/ui/src/organizations/components/ScraperList.tsx
+++ b/ui/src/organizations/components/ScraperList.tsx
@@ -23,8 +23,9 @@ export default class ScraperList extends PureComponent<Props> {
       <>
         <IndexList>
           <IndexList.Header>
-            <IndexList.HeaderCell columnName="URL" width="50%" />
-            <IndexList.HeaderCell columnName="Bucket" width="50%" />
+            <IndexList.HeaderCell columnName="Name" width="33%" />
+            <IndexList.HeaderCell columnName="URL" width="34%" />
+            <IndexList.HeaderCell columnName="Bucket" width="33%" />
           </IndexList.Header>
           <IndexList.Body columnCount={3} emptyState={emptyState}>
             {this.scrapersList}

--- a/ui/src/organizations/components/ScraperRow.tsx
+++ b/ui/src/organizations/components/ScraperRow.tsx
@@ -28,11 +28,12 @@ export default class ScraperRow extends PureComponent<Props> {
         <IndexList.Row>
           <IndexList.Cell>
             <EditableName
-              onUpdate={this.handleUpdateScraper}
-              name={scraper.url}
+              onUpdate={this.handleUpdateScraperName}
+              name={scraper.name}
               noNameString={DEFAULT_SCRAPER_NAME}
             />
           </IndexList.Cell>
+          <IndexList.Cell>{scraper.url}</IndexList.Cell>
           <IndexList.Cell>{scraper.bucket}</IndexList.Cell>
           <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
             <ConfirmationButton
@@ -48,8 +49,8 @@ export default class ScraperRow extends PureComponent<Props> {
     )
   }
 
-  private handleUpdateScraper = (name: string) => {
+  private handleUpdateScraperName = (name: string) => {
     const {onUpdateScraper, scraper} = this.props
-    onUpdateScraper({...scraper, url: name})
+    onUpdateScraper({...scraper, name})
   }
 }

--- a/ui/src/organizations/components/__snapshots__/Scrapers.test.tsx.snap
+++ b/ui/src/organizations/components/__snapshots__/Scrapers.test.tsx.snap
@@ -6,13 +6,18 @@ exports[`ScraperList rendering renders 1`] = `
     <IndexListHeader>
       <IndexListHeaderCell
         alignment="left"
+        columnName="Name"
+        width="33%"
+      />
+      <IndexListHeaderCell
+        alignment="left"
         columnName="URL"
-        width="50%"
+        width="34%"
       />
       <IndexListHeaderCell
         alignment="left"
         columnName="Bucket"
-        width="50%"
+        width="33%"
       />
     </IndexListHeader>
     <IndexListBody


### PR DESCRIPTION
Closes #11811 

_Briefly describe your proposed changes:_
Add scraper name as the first column in the scrapers list.
Allow for renaming of this scraper.
No longer allow url to updated from this list.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
