### PR TITLE
refactor(task): extract TaskCreate struct

### DIFF
--- a/cmd/influxd/launcher/tasks_test.go
+++ b/cmd/influxd/launcher/tasks_test.go
@@ -85,16 +85,16 @@ stuff f=-123.456,b=true,s="hello"
 		t.Fatalf("exp status %d; got %d", nethttp.StatusNoContent, resp.StatusCode)
 	}
 
-	created := &influxdb.Task{
+	create := influxdb.TaskCreate{
 		OrganizationID: org.ID,
-		Owner:          *be.User,
 		Flux: fmt.Sprintf(`option task = {
  name: "my_task",
  every: 1s,
 }
 from(bucket:"my_bucket_in") |> range(start:-5m) |> to(bucket:"%s", org:"%s")`, bOut.Name, be.Org.Name),
 	}
-	if err := be.TaskService().CreateTask(ctx, created); err != nil {
+	created, err := be.TaskService().CreateTask(pctx.SetAuthorizer(ctx, be.Auth), create)
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6914,6 +6914,9 @@ components:
         orgID:
           description: The ID of the organization that owns this Task.
           type: string
+        org:
+          description: The name of the organization that owns this Task.
+          type: string
         status:
           description: Starting state of the task. 'inactive' tasks are not run until they are updated to 'active'
           default: active
@@ -6924,4 +6927,4 @@ components:
         flux:
           description: The Flux script to run for this task.
           type: string
-      required: [orgID, flux]
+      required: [flux]

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -365,7 +365,7 @@ func (h *TaskHandler) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.populateOrg(ctx, req.Task); err != nil {
+	if err := h.populateTaskCreateOrg(ctx, &req.TaskCreate); err != nil {
 		err = &platform.Error{
 			Err: err,
 			Msg: "could not identify organization",
@@ -374,7 +374,7 @@ func (h *TaskHandler) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !req.Task.OrganizationID.Valid() {
+	if !req.TaskCreate.OrganizationID.Valid() {
 		err := &platform.Error{
 			Code: platform.EInvalid,
 			Msg:  "invalid organization id",
@@ -383,11 +383,8 @@ func (h *TaskHandler) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !req.Task.Owner.ID.Valid() {
-		req.Task.Owner.ID = auth.GetUserID()
-	}
-
-	if err := h.TaskService.CreateTask(ctx, req.Task); err != nil {
+	task, err := h.TaskService.CreateTask(ctx, req.TaskCreate)
+	if err != nil {
 		if e, ok := err.(AuthzError); ok {
 			h.logger.Error("failed authentication", zap.Errors("error messages", []error{err, e.AuthzError()}))
 		}
@@ -404,12 +401,12 @@ func (h *TaskHandler) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		UserID:       auth.GetUserID(),
 		UserType:     platform.Owner,
 		ResourceType: platform.TasksResourceType,
-		ResourceID:   req.Task.ID,
+		ResourceID:   task.ID,
 	}
 	if err := h.UserResourceMappingService.CreateUserResourceMapping(ctx, urm); err != nil {
 		// clean up the task if we fail to map the user and resource
 		// TODO(lh): Multi step creates could benefit from a service wide transactional request
-		if derr := h.TaskService.DeleteTask(ctx, req.Task.ID); derr != nil {
+		if derr := h.TaskService.DeleteTask(ctx, task.ID); derr != nil {
 			err = fmt.Errorf("%s: failed to clean up task: %s", err.Error(), derr.Error())
 		}
 
@@ -422,24 +419,24 @@ func (h *TaskHandler) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := encodeResponse(ctx, w, http.StatusCreated, newTaskResponse(*req.Task, []*platform.Label{})); err != nil {
+	if err := encodeResponse(ctx, w, http.StatusCreated, newTaskResponse(*task, []*platform.Label{})); err != nil {
 		logEncodingError(h.logger, r, err)
 		return
 	}
 }
 
 type postTaskRequest struct {
-	Task *platform.Task
+	TaskCreate platform.TaskCreate
 }
 
 func decodePostTaskRequest(ctx context.Context, r *http.Request) (*postTaskRequest, error) {
-	task := &platform.Task{}
-	if err := json.NewDecoder(r.Body).Decode(task); err != nil {
+	var tc platform.TaskCreate
+	if err := json.NewDecoder(r.Body).Decode(&tc); err != nil {
 		return nil, err
 	}
 
 	return &postTaskRequest{
-		Task: task,
+		TaskCreate: tc,
 	}, nil
 }
 
@@ -1250,20 +1247,20 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 }
 
 // CreateTask creates a new task.
-func (t TaskService) CreateTask(ctx context.Context, tsk *platform.Task) error {
+func (t TaskService) CreateTask(ctx context.Context, tc platform.TaskCreate) (*platform.Task, error) {
 	u, err := newURL(t.Addr, tasksPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	taskBytes, err := json.Marshal(tsk)
+	taskBytes, err := json.Marshal(tc)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(taskBytes))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -1273,21 +1270,19 @@ func (t TaskService) CreateTask(ctx context.Context, tsk *platform.Task) error {
 
 	resp, err := hc.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if err := CheckError(resp); err != nil {
-		return err
+		return nil, err
 	}
 
 	var tr taskResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
-		return err
+		return nil, err
 	}
-	*tsk = tr.Task
-
-	return nil
+	return &tr.Task, nil
 }
 
 // UpdateTask updates a single task with changeset.
@@ -1653,6 +1648,31 @@ func (h *TaskHandler) populateOrg(ctx context.Context, t *platform.Task) error {
 			return err
 		}
 		t.OrganizationID = o.ID
+	}
+	return nil
+}
+
+func (h *TaskHandler) populateTaskCreateOrg(ctx context.Context, tc *platform.TaskCreate) error {
+	if tc.OrganizationID.Valid() && tc.Organization != "" {
+		return nil
+	}
+
+	if !tc.OrganizationID.Valid() && tc.Organization == "" {
+		return errors.New("missing orgID and organization name")
+	}
+
+	if tc.OrganizationID.Valid() {
+		o, err := h.OrganizationService.FindOrganizationByID(ctx, tc.OrganizationID)
+		if err != nil {
+			return err
+		}
+		tc.Organization = o.Name
+	} else {
+		o, err := h.OrganizationService.FindOrganization(ctx, platform.OrganizationFilter{Name: &tc.Organization})
+		if err != nil {
+			return err
+		}
+		tc.OrganizationID = o.ID
 	}
 	return nil
 }

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/zap"
-
 	platform "github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/inmem"
@@ -21,6 +19,7 @@ import (
 	"github.com/influxdata/influxdb/task/backend"
 	platformtesting "github.com/influxdata/influxdb/testing"
 	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 )
 
 // NewMockTaskBackend returns a TaskBackend with mock services.
@@ -231,9 +230,14 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
 			},
 			fields: fields{
 				taskService: &mock.TaskService{
-					CreateTaskFn: func(ctx context.Context, t *platform.Task) error {
-						t.ID = 1
-						return nil
+					CreateTaskFn: func(ctx context.Context, tc platform.TaskCreate) (*platform.Task, error) {
+						return &platform.Task{
+							ID:             1,
+							Name:           "task1",
+							OrganizationID: 1,
+							Organization:   "test",
+							Owner:          platform.User{ID: 1, Name: "user1"},
+						}, nil
 					},
 				},
 			},
@@ -815,9 +819,9 @@ func TestTaskUserResourceMap(t *testing.T) {
 	taskID := platform.ID(1)
 
 	h.TaskService = &mock.TaskService{
-		CreateTaskFn: func(ctx context.Context, t *platform.Task) error {
-			t.ID = taskID
-			return nil
+		CreateTaskFn: func(ctx context.Context, tc platform.TaskCreate) (*platform.Task, error) {
+			taskCopy := task
+			return &taskCopy, nil
 		},
 		DeleteTaskFn: func(ctx context.Context, id platform.ID) error {
 			return nil

--- a/mock/task_service.go
+++ b/mock/task_service.go
@@ -6,12 +6,12 @@ import (
 	platform "github.com/influxdata/influxdb"
 )
 
-var _ platform.TaskService = &TaskService{}
+var _ platform.TaskService = (*TaskService)(nil)
 
 type TaskService struct {
 	FindTaskByIDFn func(context.Context, platform.ID) (*platform.Task, error)
 	FindTasksFn    func(context.Context, platform.TaskFilter) ([]*platform.Task, int, error)
-	CreateTaskFn   func(context.Context, *platform.Task) error
+	CreateTaskFn   func(context.Context, platform.TaskCreate) (*platform.Task, error)
 	UpdateTaskFn   func(context.Context, platform.ID, platform.TaskUpdate) (*platform.Task, error)
 	DeleteTaskFn   func(context.Context, platform.ID) error
 	FindLogsFn     func(context.Context, platform.LogFilter) ([]*platform.Log, int, error)
@@ -30,7 +30,7 @@ func (s *TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter)
 	return s.FindTasksFn(ctx, filter)
 }
 
-func (s *TaskService) CreateTask(ctx context.Context, t *platform.Task) error {
+func (s *TaskService) CreateTask(ctx context.Context, t platform.TaskCreate) (*platform.Task, error) {
 	return s.CreateTaskFn(ctx, t)
 }
 

--- a/task.go
+++ b/task.go
@@ -60,7 +60,8 @@ type TaskService interface {
 	FindTasks(ctx context.Context, filter TaskFilter) ([]*Task, int, error)
 
 	// CreateTask creates a new task.
-	CreateTask(ctx context.Context, t *Task) error
+	// The owner of the task is inferred from the authorizer associated with ctx.
+	CreateTask(ctx context.Context, t TaskCreate) (*Task, error)
 
 	// UpdateTask updates a single task with changeset.
 	UpdateTask(ctx context.Context, id ID, upd TaskUpdate) (*Task, error)
@@ -86,6 +87,14 @@ type TaskService interface {
 	// ForceRun forces a run to occur with unix timestamp scheduledFor, to be executed as soon as possible.
 	// The value of scheduledFor may or may not align with the task's schedule.
 	ForceRun(ctx context.Context, taskID ID, scheduledFor int64) (*Run, error)
+}
+
+// TaskCreate is the set of values to create a task.
+type TaskCreate struct {
+	Flux           string `json:"flux"`
+	Status         string `json:"status,omitempty"`
+	OrganizationID ID     `json:"orgID,omitempty"`
+	Organization   string `json:"org,omitempty"`
 }
 
 // TaskUpdate represents updates to a task. Options updates override any options set in the Flux field.

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	platform "github.com/influxdata/influxdb"
+	icontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/snowflake"
 	"github.com/influxdata/influxdb/task"
 	"github.com/influxdata/influxdb/task/backend"
@@ -108,11 +109,20 @@ type System struct {
 }
 
 func testTaskCRUD(t *testing.T, sys *System) {
-	orgID, userID, _ := creds(t, sys)
-
+	orgID, userID, tok := creds(t, sys)
+	authorizer := &platform.Authorization{
+		ID:     orgID + userID,
+		Token:  tok,
+		OrgID:  orgID,
+		UserID: userID,
+	}
 	// Create a task.
-	task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
-	if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
+	ct := platform.TaskCreate{
+		OrganizationID: orgID,
+		Flux:           fmt.Sprintf(scriptFmt, 0),
+	}
+	task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, authorizer), ct)
+	if err != nil {
 		t.Fatal(err)
 	}
 	if !task.ID.Valid() {
@@ -250,11 +260,21 @@ func testTaskCRUD(t *testing.T, sys *System) {
 }
 
 func testMetaUpdate(t *testing.T, sys *System) {
-	orgID, userID, _ := creds(t, sys)
+	orgID, userID, tok := creds(t, sys)
+	authorizer := &platform.Authorization{
+		ID:     orgID + userID,
+		Token:  tok,
+		OrgID:  orgID,
+		UserID: userID,
+	}
 
 	now := time.Now()
-	task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
-	if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
+	ct := platform.TaskCreate{
+		OrganizationID: orgID,
+		Flux:           fmt.Sprintf(scriptFmt, 0),
+	}
+	task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, authorizer), ct)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -341,15 +361,25 @@ func testMetaUpdate(t *testing.T, sys *System) {
 }
 
 func testTaskRuns(t *testing.T, sys *System) {
-	orgID, userID, _ := creds(t, sys)
+	orgID, userID, tok := creds(t, sys)
+	authorizer := &platform.Authorization{
+		ID:     orgID + userID,
+		Token:  tok,
+		OrgID:  orgID,
+		UserID: userID,
+	}
 
 	t.Run("FindRuns and FindRunByID", func(t *testing.T) {
 		t.Parallel()
 
 		// Script is set to run every minute. The platform adapter is currently hardcoded to schedule after "now",
 		// which makes timing of runs somewhat difficult.
-		task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
-		if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
+		ct := platform.TaskCreate{
+			OrganizationID: orgID,
+			Flux:           fmt.Sprintf(scriptFmt, 0),
+		}
+		task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, authorizer), ct)
+		if err != nil {
 			t.Fatal(err)
 		}
 		st, err := sys.S.FindTaskByID(sys.Ctx, task.ID)
@@ -496,8 +526,12 @@ func testTaskRuns(t *testing.T, sys *System) {
 
 		// Script is set to run every minute. The platform adapter is currently hardcoded to schedule after "now",
 		// which makes timing of runs somewhat difficult.
-		task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
-		if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
+		ct := platform.TaskCreate{
+			OrganizationID: orgID,
+			Flux:           fmt.Sprintf(scriptFmt, 0),
+		}
+		task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, authorizer), ct)
+		if err != nil {
 			t.Fatal(err)
 		}
 		st, err := sys.S.FindTaskByID(sys.Ctx, task.ID)
@@ -587,8 +621,12 @@ func testTaskRuns(t *testing.T, sys *System) {
 	t.Run("ForceRun", func(t *testing.T) {
 		t.Parallel()
 
-		task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
-		if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
+		ct := platform.TaskCreate{
+			OrganizationID: orgID,
+			Flux:           fmt.Sprintf(scriptFmt, 0),
+		}
+		task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, authorizer), ct)
+		if err != nil {
 			t.Fatal(err)
 		}
 
@@ -628,8 +666,12 @@ func testTaskRuns(t *testing.T, sys *System) {
 	t.Run("FindLogs", func(t *testing.T) {
 		t.Parallel()
 
-		task := &platform.Task{OrganizationID: orgID, Owner: platform.User{ID: userID}, Flux: fmt.Sprintf(scriptFmt, 0)}
-		if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
+		ct := platform.TaskCreate{
+			OrganizationID: orgID,
+			Flux:           fmt.Sprintf(scriptFmt, 0),
+		}
+		task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, authorizer), ct)
+		if err != nil {
 			t.Fatal(err)
 		}
 		st, err := sys.S.FindTaskByID(sys.Ctx, task.ID)
@@ -714,10 +756,16 @@ func testTaskRuns(t *testing.T, sys *System) {
 }
 
 func testTaskConcurrency(t *testing.T, sys *System) {
-	orgID, userID, _ := creds(t, sys)
+	orgID, userID, tok := creds(t, sys)
+	authorizer := &platform.Authorization{
+		ID:     orgID + userID,
+		Token:  tok,
+		OrgID:  orgID,
+		UserID: userID,
+	}
 
 	const numTasks = 450 // Arbitrarily chosen to get a reasonable count of concurrent creates and deletes.
-	taskCh := make(chan *platform.Task, numTasks)
+	createTaskCh := make(chan platform.TaskCreate, numTasks)
 
 	// Since this test is run in parallel with other tests,
 	// we need to keep a whitelist of IDs that are okay to delete.
@@ -730,9 +778,12 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 		createWg.Add(1)
 		go func() {
 			defer createWg.Done()
-			for task := range taskCh {
-				if err := sys.ts.CreateTask(sys.Ctx, task); err != nil {
+			aCtx := icontext.SetAuthorizer(sys.Ctx, authorizer)
+			for ct := range createTaskCh {
+				task, err := sys.ts.CreateTask(aCtx, ct)
+				if err != nil {
 					t.Errorf("error creating task: %v", err)
+					continue
 				}
 				idMu.Lock()
 				taskIDs[task.ID] = struct{}{}
@@ -863,15 +914,14 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 
 	// Start adding tasks.
 	for i := 0; i < numTasks; i++ {
-		taskCh <- &platform.Task{
+		createTaskCh <- platform.TaskCreate{
 			OrganizationID: orgID,
-			Owner:          platform.User{ID: userID},
 			Flux:           fmt.Sprintf(scriptFmt, i),
 		}
 	}
 
 	// Done adding. Wait for cleanup.
-	close(taskCh)
+	close(createTaskCh)
 	createWg.Wait()
 	extraWg.Wait()
 }

--- a/task/validator.go
+++ b/task/validator.go
@@ -70,18 +70,18 @@ func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter platform.T
 	return ts.TaskService.FindTasks(ctx, filter)
 }
 
-func (ts *taskServiceValidator) CreateTask(ctx context.Context, t *platform.Task) error {
+func (ts *taskServiceValidator) CreateTask(ctx context.Context, t platform.TaskCreate) (*platform.Task, error) {
 	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, t.OrganizationID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := validatePermission(ctx, *p); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := validateBucket(ctx, t.Flux, ts.preAuth); err != nil {
-		return err
+		return nil, err
 	}
 
 	return ts.TaskService.CreateTask(ctx, t)


### PR DESCRIPTION
With the ongoing authorization work, creation arguments will differ from
what's returned on reads. More specifically, creation will accept a
token, but reads will report back a token ID.

This refactor facilitates that authorization work, and also brings the
code closer to the swagger definition, for the TaskCreateRequest type in
particular.