### PR TITLE
Migrate {macro, source, session, secret} service from bolt to kv 

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -315,7 +315,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		telegrafSvc      platform.TelegrafConfigStore             = m.boltClient
 		userResourceSvc  platform.UserResourceMappingService      = m.kvService
 		labelSvc         platform.LabelService                    = m.kvService
-		secretSvc        platform.SecretService                   = m.boltClient
+		secretSvc        platform.SecretService                   = m.kvService
 		lookupSvc        platform.LookupService                   = m.boltClient
 	)
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -300,7 +300,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		orgSvc           platform.OrganizationService             = m.kvService
 		authSvc          platform.AuthorizationService            = m.kvService
 		userSvc          platform.UserService                     = m.kvService
-		macroSvc         platform.MacroService                    = m.boltClient
+		macroSvc         platform.MacroService                    = m.kvService
 		bucketSvc        platform.BucketService                   = m.kvService
 		sourceSvc        platform.SourceService                   = m.boltClient
 		sessionSvc       platform.SessionService                  = m.boltClient

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -303,7 +303,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		macroSvc         platform.MacroService                    = m.kvService
 		bucketSvc        platform.BucketService                   = m.kvService
 		sourceSvc        platform.SourceService                   = m.kvService
-		sessionSvc       platform.SessionService                  = m.boltClient
+		sessionSvc       platform.SessionService                  = m.kvService
 		passwdsSvc       platform.PasswordsService                = m.kvService
 		dashboardSvc     platform.DashboardService                = m.kvService
 		dashboardLogSvc  platform.DashboardOperationLogService    = m.kvService

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -302,7 +302,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		userSvc          platform.UserService                     = m.kvService
 		macroSvc         platform.MacroService                    = m.kvService
 		bucketSvc        platform.BucketService                   = m.kvService
-		sourceSvc        platform.SourceService                   = m.boltClient
+		sourceSvc        platform.SourceService                   = m.kvService
 		sessionSvc       platform.SessionService                  = m.boltClient
 		passwdsSvc       platform.PasswordsService                = m.kvService
 		dashboardSvc     platform.DashboardService                = m.kvService

--- a/kv/macro.go
+++ b/kv/macro.go
@@ -1,0 +1,425 @@
+package kv
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	influxdb "github.com/influxdata/influxdb"
+)
+
+var (
+	macroBucket    = []byte("macrosv1")
+	macroOrgsIndex = []byte("macroorgsv1")
+)
+
+func (s *Service) initializeMacros(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket(macroBucket); err != nil {
+		return err
+	}
+	if _, err := tx.Bucket(macroOrgsIndex); err != nil {
+		return err
+	}
+	return nil
+}
+
+func decodeMacroOrgsIndexKey(indexKey []byte) (orgID influxdb.ID, macroID influxdb.ID, err error) {
+	if len(indexKey) != 2*influxdb.IDLength {
+		return 0, 0, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "malformed macro orgs index key (please report this error)",
+		}
+	}
+
+	if err := (&orgID).Decode(indexKey[:influxdb.IDLength]); err != nil {
+		return 0, 0, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "bad org id",
+			Err:  influxdb.ErrInvalidID,
+		}
+	}
+
+	if err := (&macroID).Decode(indexKey[influxdb.IDLength:]); err != nil {
+		return 0, 0, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "bad macro id",
+			Err:  influxdb.ErrInvalidID,
+		}
+	}
+
+	return orgID, macroID, nil
+}
+
+func (s *Service) findOrganizationMacros(ctx context.Context, tx Tx, orgID influxdb.ID) ([]*influxdb.Macro, error) {
+	idx, err := tx.Bucket(macroOrgsIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(leodido): support find options
+	cur, err := idx.Cursor()
+	if err != nil {
+		return nil, err
+	}
+
+	prefix, err := orgID.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	macros := []*influxdb.Macro{}
+	for k, _ := cur.Seek(prefix); bytes.HasPrefix(k, prefix); k, _ = cur.Next() {
+		_, id, err := decodeMacroOrgsIndexKey(k)
+		if err != nil {
+			return nil, err
+		}
+
+		m, err := s.findMacroByID(ctx, tx, id)
+		if err != nil {
+			return nil, err
+		}
+
+		macros = append(macros, m)
+	}
+
+	return macros, nil
+}
+
+func (s *Service) findMacros(ctx context.Context, tx Tx, filter influxdb.MacroFilter) ([]*influxdb.Macro, error) {
+	if filter.OrganizationID != nil {
+		return s.findOrganizationMacros(ctx, tx, *filter.OrganizationID)
+	}
+
+	if filter.Organization != nil {
+		o, err := s.findOrganizationByName(ctx, tx, *filter.Organization)
+		if err != nil {
+			return nil, err
+		}
+		return s.findOrganizationMacros(ctx, tx, o.ID)
+	}
+
+	macros := []*influxdb.Macro{}
+	filterFn := filterMacrosFn(filter)
+	err := s.forEachMacro(ctx, tx, func(m *influxdb.Macro) bool {
+		if filterFn(m) {
+			macros = append(macros, m)
+		}
+		return true
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return macros, nil
+}
+
+func filterMacrosFn(filter influxdb.MacroFilter) func(m *influxdb.Macro) bool {
+	if filter.ID != nil {
+		return func(m *influxdb.Macro) bool {
+			return m.ID == *filter.ID
+		}
+	}
+
+	if filter.OrganizationID != nil {
+		return func(m *influxdb.Macro) bool {
+			return m.OrganizationID == *filter.OrganizationID
+		}
+	}
+
+	return func(m *influxdb.Macro) bool { return true }
+}
+
+// forEachMacro will iterate through all macros while fn returns true.
+func (s *Service) forEachMacro(ctx context.Context, tx Tx, fn func(*influxdb.Macro) bool) error {
+	b, err := tx.Bucket(macroBucket)
+	if err != nil {
+		return err
+	}
+
+	cur, err := b.Cursor()
+	if err != nil {
+		return err
+	}
+
+	for k, v := cur.First(); k != nil; k, v = cur.Next() {
+		m := &influxdb.Macro{}
+		if err := json.Unmarshal(v, m); err != nil {
+			return err
+		}
+		if !fn(m) {
+			break
+		}
+	}
+
+	return nil
+}
+
+// FindMacros returns all macros in the store
+func (s *Service) FindMacros(ctx context.Context, filter influxdb.MacroFilter, opt ...influxdb.FindOptions) ([]*influxdb.Macro, error) {
+	// todo(leodido) > handle find options
+	res := []*influxdb.Macro{}
+	err := s.kv.View(func(tx Tx) error {
+		macros, err := s.findMacros(ctx, tx, filter)
+		if err != nil && influxdb.ErrorCode(err) != influxdb.ENotFound {
+			return err
+		}
+		res = macros
+		return nil
+	})
+
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return res, nil
+}
+
+// FindMacroByID finds a single macro in the store by its ID
+func (s *Service) FindMacroByID(ctx context.Context, id influxdb.ID) (*influxdb.Macro, error) {
+	var macro *influxdb.Macro
+	err := s.kv.View(func(tx Tx) error {
+		m, pe := s.findMacroByID(ctx, tx, id)
+		if pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+		}
+		macro = m
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return macro, nil
+}
+
+func (s *Service) findMacroByID(ctx context.Context, tx Tx, id influxdb.ID) (*influxdb.Macro, error) {
+	encID, err := id.Encode()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	b, err := tx.Bucket(macroBucket)
+	if err != nil {
+		return nil, err
+	}
+
+	d, err := b.Get(encID)
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  influxdb.ErrMacroNotFound,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	macro := &influxdb.Macro{}
+	err = json.Unmarshal(d, &macro)
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return macro, nil
+}
+
+// CreateMacro creates a new macro and assigns it an ID
+func (s *Service) CreateMacro(ctx context.Context, macro *influxdb.Macro) error {
+	return s.kv.Update(func(tx Tx) error {
+		macro.ID = s.IDGenerator.ID()
+
+		if err := s.putMacroOrgsIndex(ctx, tx, macro); err != nil {
+			return err
+		}
+
+		if pe := s.putMacro(ctx, tx, macro); pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+
+		}
+		return nil
+	})
+}
+
+// ReplaceMacro puts a macro in the store
+func (s *Service) ReplaceMacro(ctx context.Context, macro *influxdb.Macro) error {
+	return s.kv.Update(func(tx Tx) error {
+		if err := s.putMacroOrgsIndex(ctx, tx, macro); err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+		return s.putMacro(ctx, tx, macro)
+	})
+}
+
+func encodeMacroOrgsIndex(macro *influxdb.Macro) ([]byte, error) {
+	oID, err := macro.OrganizationID.Encode()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+			Msg: "bad organization id",
+		}
+	}
+
+	mID, err := macro.ID.Encode()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+			Msg: "bad macro id",
+		}
+	}
+
+	key := make([]byte, 0, influxdb.IDLength*2)
+	key = append(key, oID...)
+	key = append(key, mID...)
+
+	return key, nil
+}
+
+func (s *Service) putMacroOrgsIndex(ctx context.Context, tx Tx, macro *influxdb.Macro) error {
+	key, err := encodeMacroOrgsIndex(macro)
+	if err != nil {
+		return err
+	}
+
+	idx, err := tx.Bucket(macroOrgsIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := idx.Put(key, nil); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) removeMacroOrgsIndex(ctx context.Context, tx Tx, macro *influxdb.Macro) error {
+	key, err := encodeMacroOrgsIndex(macro)
+	if err != nil {
+		return err
+	}
+
+	idx, err := tx.Bucket(macroOrgsIndex)
+	if err != nil {
+		return err
+	}
+
+	if err := idx.Delete(key); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) putMacro(ctx context.Context, tx Tx, macro *influxdb.Macro) error {
+	m, err := json.Marshal(macro)
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	encID, err := macro.ID.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	b, err := tx.Bucket(macroBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put(encID, m); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return nil
+}
+
+// UpdateMacro updates a single macro in the store with a changeset
+func (s *Service) UpdateMacro(ctx context.Context, id influxdb.ID, update *influxdb.MacroUpdate) (*influxdb.Macro, error) {
+	var macro *influxdb.Macro
+	err := s.kv.Update(func(tx Tx) error {
+		m, pe := s.findMacroByID(ctx, tx, id)
+		if pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+		}
+
+		if err := update.Apply(m); err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		macro = m
+		if pe = s.putMacro(ctx, tx, macro); pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+		}
+		return nil
+	})
+
+	return macro, err
+}
+
+// DeleteMacro removes a single macro from the store by its ID
+func (s *Service) DeleteMacro(ctx context.Context, id influxdb.ID) error {
+	return s.kv.Update(func(tx Tx) error {
+		m, pe := s.findMacroByID(ctx, tx, id)
+		if pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+		}
+
+		encID, err := id.Encode()
+		if err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		if err := s.removeMacroOrgsIndex(ctx, tx, m); err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		b, err := tx.Bucket(macroBucket)
+		if err != nil {
+			return err
+		}
+
+		if err := b.Delete(encID); err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		return nil
+	})
+}

--- a/kv/macro_test.go
+++ b/kv/macro_test.go
@@ -1,0 +1,69 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltMacroService(t *testing.T) {
+	influxdbtesting.MacroService(initBoltMacroService, t)
+}
+
+func TestInmemMacroService(t *testing.T) {
+	influxdbtesting.MacroService(initInmemMacroService, t)
+}
+
+func initBoltMacroService(f influxdbtesting.MacroFields, t *testing.T) (influxdb.MacroService, string, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initMacroService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemMacroService(f influxdbtesting.MacroFields, t *testing.T) (influxdb.MacroService, string, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initMacroService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initMacroService(s kv.Store, f influxdbtesting.MacroFields, t *testing.T) (influxdb.MacroService, string, func()) {
+	svc := kv.NewService(s)
+	svc.IDGenerator = f.IDGenerator
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing macro service: %v", err)
+	}
+	for _, macro := range f.Macros {
+		if err := svc.ReplaceMacro(ctx, macro); err != nil {
+			t.Fatalf("failed to populate test macros: %v", err)
+		}
+	}
+
+	done := func() {
+		for _, macro := range f.Macros {
+			if err := svc.DeleteMacro(ctx, macro.ID); err != nil {
+				t.Fatalf("failed to clean up macros bolt test: %v", err)
+			}
+		}
+	}
+
+	return svc, kv.OpPrefix, done
+}

--- a/kv/secret.go
+++ b/kv/secret.go
@@ -1,0 +1,283 @@
+package kv
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/influxdb"
+)
+
+var (
+	secretBucket = []byte("secretsv1")
+)
+
+var _ influxdb.SecretService = (*Service)(nil)
+
+func (s *Service) initializeSecrets(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket(secretBucket); err != nil {
+		return err
+	}
+	return nil
+}
+
+// LoadSecret retrieves the secret value v found at key k for organization orgID.
+func (s *Service) LoadSecret(ctx context.Context, orgID influxdb.ID, k string) (string, error) {
+	var v string
+	err := s.kv.View(func(tx Tx) error {
+		val, err := s.loadSecret(ctx, tx, orgID, k)
+		if err != nil {
+			return err
+		}
+
+		v = val
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return v, nil
+}
+
+func (s *Service) loadSecret(ctx context.Context, tx Tx, orgID influxdb.ID, k string) (string, error) {
+	key, err := encodeSecretKey(orgID, k)
+	if err != nil {
+		return "", err
+	}
+
+	b, err := tx.Bucket(secretBucket)
+	if err != nil {
+		return "", err
+	}
+
+	val, err := b.Get(key)
+	if IsNotFound(err) {
+		return "", &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  influxdb.ErrSecretNotFound,
+		}
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	v, err := decodeSecretValue(val)
+	if err != nil {
+		return "", err
+	}
+
+	return v, nil
+}
+
+// GetSecretKeys retrieves all secret keys that are stored for the organization orgID.
+func (s *Service) GetSecretKeys(ctx context.Context, orgID influxdb.ID) ([]string, error) {
+	var vs []string
+	err := s.kv.View(func(tx Tx) error {
+		vals, err := s.getSecretKeys(ctx, tx, orgID)
+		if err != nil {
+			return err
+		}
+
+		vs = vals
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return vs, nil
+}
+
+func (s *Service) getSecretKeys(ctx context.Context, tx Tx, orgID influxdb.ID) ([]string, error) {
+	b, err := tx.Bucket(secretBucket)
+	if err != nil {
+		return nil, err
+	}
+
+	cur, err := b.Cursor()
+	if err != nil {
+		return nil, err
+	}
+
+	prefix, err := orgID.Encode()
+	if err != nil {
+		return nil, err
+	}
+	k, _ := cur.Seek(prefix)
+
+	if len(k) == 0 {
+		return []string{}, nil
+	}
+
+	id, key, err := decodeSecretKey(k)
+	if err != nil {
+		return nil, err
+	}
+
+	if id != orgID {
+		return nil, fmt.Errorf("organization has no secret keys")
+	}
+
+	keys := []string{key}
+
+	for {
+		k, _ = cur.Next()
+
+		if len(k) == 0 {
+			// We've reached the end of the keys so we're done
+			break
+		}
+
+		id, key, err = decodeSecretKey(k)
+		if err != nil {
+			return nil, err
+		}
+
+		if id != orgID {
+			// We've reached the end of the keyspace for the provided orgID
+			break
+		}
+
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+// PutSecret stores the secret pair (k,v) for the organization orgID.
+func (s *Service) PutSecret(ctx context.Context, orgID influxdb.ID, k, v string) error {
+	return s.kv.Update(func(tx Tx) error {
+		return s.putSecret(ctx, tx, orgID, k, v)
+	})
+}
+
+func (s *Service) putSecret(ctx context.Context, tx Tx, orgID influxdb.ID, k, v string) error {
+	key, err := encodeSecretKey(orgID, k)
+	if err != nil {
+		return err
+	}
+
+	val := encodeSecretValue(v)
+
+	b, err := tx.Bucket(secretBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put(key, val); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func encodeSecretKey(orgID influxdb.ID, k string) ([]byte, error) {
+	buf, err := orgID.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	key := make([]byte, 0, influxdb.IDLength+len(k))
+	key = append(key, buf...)
+	key = append(key, k...)
+
+	return key, nil
+}
+
+func decodeSecretKey(key []byte) (influxdb.ID, string, error) {
+	if len(key) < influxdb.IDLength {
+		// This should not happen.
+		return influxdb.InvalidID(), "", errors.New("provided key is too short to contain an ID (please report this error)")
+	}
+
+	var id influxdb.ID
+	if err := id.Decode(key[:influxdb.IDLength]); err != nil {
+		return influxdb.InvalidID(), "", err
+	}
+
+	k := string(key[influxdb.IDLength:])
+
+	return id, k, nil
+}
+
+func decodeSecretValue(val []byte) (string, error) {
+	// store the secret value base64 encoded so that it's marginally better than plaintext
+	v := make([]byte, base64.StdEncoding.DecodedLen(len(val)))
+	if _, err := base64.StdEncoding.Decode(v, val); err != nil {
+		return "", err
+	}
+
+	return string(v), nil
+}
+
+func encodeSecretValue(v string) []byte {
+	val := make([]byte, base64.StdEncoding.EncodedLen(len(v)))
+	base64.StdEncoding.Encode(val, []byte(v))
+	return val
+}
+
+// PutSecrets puts all provided secrets and overwrites any previous values.
+func (s *Service) PutSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
+	return s.kv.Update(func(tx Tx) error {
+		keys, err := s.getSecretKeys(ctx, tx, orgID)
+		if err != nil {
+			return err
+		}
+		for k, v := range m {
+			if err := s.putSecret(ctx, tx, orgID, k, v); err != nil {
+				return err
+			}
+		}
+		for _, k := range keys {
+			if _, ok := m[k]; !ok {
+				if err := s.deleteSecret(ctx, tx, orgID, k); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// PatchSecrets patches all provided secrets and updates any previous values.
+func (s *Service) PatchSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
+	return s.kv.Update(func(tx Tx) error {
+		for k, v := range m {
+			if err := s.putSecret(ctx, tx, orgID, k, v); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// DeleteSecret removes secrets from the secret store.
+func (s *Service) DeleteSecret(ctx context.Context, orgID influxdb.ID, ks ...string) error {
+	return s.kv.Update(func(tx Tx) error {
+		for _, k := range ks {
+			if err := s.deleteSecret(ctx, tx, orgID, k); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (s *Service) deleteSecret(ctx context.Context, tx Tx, orgID influxdb.ID, k string) error {
+	key, err := encodeSecretKey(orgID, k)
+	if err != nil {
+		return err
+	}
+
+	b, err := tx.Bucket(secretBucket)
+	if err != nil {
+		return err
+	}
+
+	return b.Delete(key)
+}

--- a/kv/secret_test.go
+++ b/kv/secret_test.go
@@ -1,0 +1,62 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltSecretService(t *testing.T) {
+	influxdbtesting.SecretService(initBoltSecretService, t)
+}
+
+func TestInmemSecretService(t *testing.T) {
+	influxdbtesting.SecretService(initInmemSecretService, t)
+}
+
+func initBoltSecretService(f influxdbtesting.SecretServiceFields, t *testing.T) (influxdb.SecretService, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, closeSvc := initSecretService(s, f, t)
+	return svc, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemSecretService(f influxdbtesting.SecretServiceFields, t *testing.T) (influxdb.SecretService, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, closeSvc := initSecretService(s, f, t)
+	return svc, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initSecretService(s kv.Store, f influxdbtesting.SecretServiceFields, t *testing.T) (influxdb.SecretService, func()) {
+	svc := kv.NewService(s)
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing secret service: %v", err)
+	}
+
+	for _, s := range f.Secrets {
+		for k, v := range s.Env {
+			if err := svc.PutSecret(ctx, s.OrganizationID, k, v); err != nil {
+				t.Fatalf("failed to populate secrets")
+			}
+		}
+	}
+
+	return svc, func() {}
+}

--- a/kv/service.go
+++ b/kv/service.go
@@ -44,6 +44,10 @@ func NewService(kv Store) *Service {
 // Initialize creates Buckets needed.
 func (s *Service) Initialize(ctx context.Context) error {
 	return s.kv.Update(func(tx Tx) error {
+		if err := s.initializeSources(ctx, tx); err != nil {
+			return err
+		}
+
 		if err := s.initializeMacros(ctx, tx); err != nil {
 			return err
 		}

--- a/kv/service.go
+++ b/kv/service.go
@@ -44,6 +44,10 @@ func NewService(kv Store) *Service {
 // Initialize creates Buckets needed.
 func (s *Service) Initialize(ctx context.Context) error {
 	return s.kv.Update(func(tx Tx) error {
+		if err := s.initializeMacros(ctx, tx); err != nil {
+			return err
+		}
+
 		if err := s.initializeUsers(ctx, tx); err != nil {
 			return err
 		}

--- a/kv/service.go
+++ b/kv/service.go
@@ -44,6 +44,10 @@ func NewService(kv Store) *Service {
 // Initialize creates Buckets needed.
 func (s *Service) Initialize(ctx context.Context) error {
 	return s.kv.Update(func(tx Tx) error {
+		if err := s.initializeSecrets(ctx, tx); err != nil {
+			return err
+		}
+
 		if err := s.initializeSessions(ctx, tx); err != nil {
 			return err
 		}

--- a/kv/service.go
+++ b/kv/service.go
@@ -44,6 +44,10 @@ func NewService(kv Store) *Service {
 // Initialize creates Buckets needed.
 func (s *Service) Initialize(ctx context.Context) error {
 	return s.kv.Update(func(tx Tx) error {
+		if err := s.initializeSessions(ctx, tx); err != nil {
+			return err
+		}
+
 		if err := s.initializeSources(ctx, tx); err != nil {
 			return err
 		}

--- a/kv/session.go
+++ b/kv/session.go
@@ -1,0 +1,216 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/influxdata/influxdb"
+)
+
+var (
+	sessionBucket = []byte("sessionsv1")
+)
+
+var _ influxdb.SessionService = (*Service)(nil)
+
+func (s *Service) initializeSessions(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket([]byte(sessionBucket)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RenewSession extends the expire time to newExpiration.
+func (s *Service) RenewSession(ctx context.Context, session *influxdb.Session, newExpiration time.Time) error {
+	if session == nil {
+		return &influxdb.Error{
+			Msg: "session is nil",
+		}
+	}
+	return s.kv.Update(func(tx Tx) error {
+		session.ExpiresAt = newExpiration
+		if err := s.putSession(ctx, tx, session); err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+		return nil
+	})
+}
+
+// FindSession retrieves the session found at the provided key.
+func (s *Service) FindSession(ctx context.Context, key string) (*influxdb.Session, error) {
+	var sess *influxdb.Session
+	err := s.kv.View(func(tx Tx) error {
+		s, err := s.findSession(ctx, tx, key)
+		if err != nil {
+			return err
+		}
+
+		sess = s
+		return nil
+	})
+
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	if err := sess.Expired(); err != nil {
+		// todo(leodido) > do we want to return session also if expired?
+		return sess, &influxdb.Error{
+			Err: err,
+		}
+	}
+	return sess, nil
+}
+
+func (s *Service) findSession(ctx context.Context, tx Tx, key string) (*influxdb.Session, error) {
+	b, err := tx.Bucket(sessionBucket)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := b.Get([]byte(key))
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  influxdb.ErrSessionNotFound,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	sn := &influxdb.Session{}
+	if err := json.Unmarshal(v, sn); err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	// TODO(desa): these values should be cached so it's not so expensive to lookup each time.
+	f := influxdb.UserResourceMappingFilter{UserID: sn.UserID}
+	mappings, err := s.findUserResourceMappings(ctx, tx, f)
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	ps := make([]influxdb.Permission, 0, len(mappings))
+	for _, m := range mappings {
+		p, err := m.ToPermissions()
+		if err != nil {
+			return nil, &influxdb.Error{
+				Err: err,
+			}
+		}
+
+		ps = append(ps, p...)
+	}
+	ps = append(ps, influxdb.MePermissions(sn.UserID)...)
+	sn.Permissions = ps
+	return sn, nil
+}
+
+// PutSession puts the session at key.
+func (s *Service) PutSession(ctx context.Context, sn *influxdb.Session) error {
+	return s.kv.Update(func(tx Tx) error {
+		if err := s.putSession(ctx, tx, sn); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (s *Service) putSession(ctx context.Context, tx Tx, sn *influxdb.Session) error {
+	v, err := json.Marshal(sn)
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	b, err := tx.Bucket(sessionBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put([]byte(sn.Key), v); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	return nil
+}
+
+// ExpireSession expires the session at the provided key.
+func (s *Service) ExpireSession(ctx context.Context, key string) error {
+	return s.kv.Update(func(tx Tx) error {
+		sn, err := s.findSession(ctx, tx, key)
+		if err != nil {
+			return err
+		}
+
+		sn.ExpiresAt = time.Now()
+
+		if err := s.putSession(ctx, tx, sn); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// CreateSession creates a session for a user with the users maximal privileges.
+func (s *Service) CreateSession(ctx context.Context, user string) (*influxdb.Session, error) {
+	var sess *influxdb.Session
+	err := s.kv.Update(func(tx Tx) error {
+		sn, err := s.createSession(ctx, tx, user)
+		if err != nil {
+			return err
+		}
+
+		sess = sn
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return sess, nil
+}
+
+func (s *Service) createSession(ctx context.Context, tx Tx, user string) (*influxdb.Session, error) {
+	u, pe := s.findUserByName(ctx, tx, user)
+	if pe != nil {
+		return nil, pe
+	}
+
+	sn := &influxdb.Session{}
+	sn.ID = s.IDGenerator.ID()
+	k, err := s.TokenGenerator.Token()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+	sn.Key = k
+	sn.UserID = u.ID
+	sn.CreatedAt = time.Now()
+	// TODO(desa): make this configurable
+	sn.ExpiresAt = sn.CreatedAt.Add(time.Hour)
+	// TODO(desa): not totally sure what to do here. Possibly we should have a maximal privilege permission.
+	sn.Permissions = []influxdb.Permission{}
+
+	if err := s.putSession(ctx, tx, sn); err != nil {
+		return nil, err
+	}
+
+	return sn, nil
+}

--- a/kv/session_test.go
+++ b/kv/session_test.go
@@ -1,0 +1,73 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltSessionService(t *testing.T) {
+	influxdbtesting.SessionService(initBoltSessionService, t)
+}
+
+func TestInmemSessionService(t *testing.T) {
+	influxdbtesting.SessionService(initInmemSessionService, t)
+}
+
+func initBoltSessionService(f influxdbtesting.SessionFields, t *testing.T) (influxdb.SessionService, string, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initSessionService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemSessionService(f influxdbtesting.SessionFields, t *testing.T) (influxdb.SessionService, string, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initSessionService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initSessionService(s kv.Store, f influxdbtesting.SessionFields, t *testing.T) (influxdb.SessionService, string, func()) {
+	svc := kv.NewService(s)
+	svc.IDGenerator = f.IDGenerator
+	svc.TokenGenerator = f.TokenGenerator
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing session service: %v", err)
+	}
+
+	for _, u := range f.Users {
+		if err := svc.PutUser(ctx, u); err != nil {
+			t.Fatalf("failed to populate users")
+		}
+	}
+	for _, s := range f.Sessions {
+		if err := svc.PutSession(ctx, s); err != nil {
+			t.Fatalf("failed to populate sessions")
+		}
+	}
+	return svc, kv.OpPrefix, func() {
+		for _, u := range f.Users {
+			if err := svc.DeleteUser(ctx, u.ID); err != nil {
+				t.Logf("failed to remove users: %v", err)
+			}
+		}
+	}
+}

--- a/kv/source.go
+++ b/kv/source.go
@@ -1,0 +1,336 @@
+package kv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	influxdb "github.com/influxdata/influxdb"
+)
+
+var (
+	sourceBucket = []byte("sourcesv1")
+)
+
+// DefaultSource is the default source.
+var DefaultSource = influxdb.Source{
+	Default: true,
+	Name:    "autogen",
+	Type:    influxdb.SelfSourceType,
+}
+
+const (
+	// DefaultSourceID it the default source identifier
+	DefaultSourceID = "020f755c3c082000"
+	// DefaultSourceOrganizationID is the default source's organization identifier
+	DefaultSourceOrganizationID = "50616e67652c206c"
+)
+
+func init() {
+	if err := DefaultSource.ID.DecodeFromString(DefaultSourceID); err != nil {
+		panic(fmt.Sprintf("failed to decode default source id: %v", err))
+	}
+
+	if err := DefaultSource.OrganizationID.DecodeFromString(DefaultSourceOrganizationID); err != nil {
+		panic(fmt.Sprintf("failed to decode default source organization id: %v", err))
+	}
+}
+
+func (s *Service) initializeSources(ctx context.Context, tx Tx) error {
+	if _, err := tx.Bucket(sourceBucket); err != nil {
+		return err
+	}
+
+	_, pe := s.findSourceByID(ctx, tx, DefaultSource.ID)
+	if pe != nil && influxdb.ErrorCode(pe) != influxdb.ENotFound {
+		return pe
+	}
+
+	if influxdb.ErrorCode(pe) == influxdb.ENotFound {
+		if err := s.putSource(ctx, tx, &DefaultSource); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DefaultSource retrieves the default source.
+func (s *Service) DefaultSource(ctx context.Context) (*influxdb.Source, error) {
+	var sr *influxdb.Source
+
+	err := s.kv.View(func(tx Tx) error {
+		// TODO(desa): make this faster by putting the default source in an index.
+		srcs, err := s.findSources(ctx, tx, influxdb.FindOptions{})
+		if err != nil {
+			return err
+		}
+		for _, src := range srcs {
+			if src.Default {
+				sr = src
+				return nil
+			}
+		}
+		return &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "no default source found",
+		}
+	})
+
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return sr, nil
+}
+
+// FindSourceByID retrieves a source by id.
+func (s *Service) FindSourceByID(ctx context.Context, id influxdb.ID) (*influxdb.Source, error) {
+	var sr *influxdb.Source
+
+	err := s.kv.View(func(tx Tx) error {
+		src, pe := s.findSourceByID(ctx, tx, id)
+		if pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+		}
+		sr = src
+		return nil
+	})
+	return sr, err
+}
+
+func (s *Service) findSourceByID(ctx context.Context, tx Tx, id influxdb.ID) (*influxdb.Source, error) {
+	encodedID, err := id.Encode()
+	if err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	b, err := tx.Bucket(sourceBucket)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := b.Get(encodedID)
+	if IsNotFound(err) {
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  influxdb.ErrSourceNotFound,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var sr influxdb.Source
+	if err := json.Unmarshal(v, &sr); err != nil {
+		return nil, &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	return &sr, nil
+}
+
+// FindSources retrives all sources that match an arbitrary source filter.
+// Filters using ID, or OrganizationID and source Name should be efficient.
+// Other filters will do a linear scan across all sources searching for a match.
+func (s *Service) FindSources(ctx context.Context, opt influxdb.FindOptions) ([]*influxdb.Source, int, error) {
+	ss := []*influxdb.Source{}
+	err := s.kv.View(func(tx Tx) error {
+		srcs, err := s.findSources(ctx, tx, opt)
+		if err != nil {
+			return err
+		}
+		ss = srcs
+		return nil
+	})
+
+	if err != nil {
+		return nil, 0, &influxdb.Error{
+			Op:  influxdb.OpFindSources,
+			Err: err,
+		}
+	}
+
+	return ss, len(ss), nil
+}
+
+func (s *Service) findSources(ctx context.Context, tx Tx, opt influxdb.FindOptions) ([]*influxdb.Source, error) {
+	ss := []*influxdb.Source{}
+
+	err := s.forEachSource(ctx, tx, func(s *influxdb.Source) bool {
+		ss = append(ss, s)
+		return true
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ss, nil
+}
+
+// CreateSource creates a influxdb source and sets s.ID.
+func (s *Service) CreateSource(ctx context.Context, src *influxdb.Source) error {
+	err := s.kv.Update(func(tx Tx) error {
+		src.ID = s.IDGenerator.ID()
+
+		// Generating an organization id if it missing or invalid
+		if !src.OrganizationID.Valid() {
+			src.OrganizationID = s.IDGenerator.ID()
+		}
+
+		return s.putSource(ctx, tx, src)
+	})
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	return nil
+}
+
+// PutSource will put a source without setting an ID.
+func (s *Service) PutSource(ctx context.Context, src *influxdb.Source) error {
+	return s.kv.Update(func(tx Tx) error {
+		return s.putSource(ctx, tx, src)
+	})
+}
+
+func (s *Service) putSource(ctx context.Context, tx Tx, src *influxdb.Source) error {
+	v, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+
+	encodedID, err := src.ID.Encode()
+	if err != nil {
+		return err
+	}
+
+	b, err := tx.Bucket(sourceBucket)
+	if err != nil {
+		return err
+	}
+
+	if err := b.Put(encodedID, v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// forEachSource will iterate through all sources while fn returns true.
+func (s *Service) forEachSource(ctx context.Context, tx Tx, fn func(*influxdb.Source) bool) error {
+	b, err := tx.Bucket(sourceBucket)
+	if err != nil {
+		return err
+	}
+
+	cur, err := b.Cursor()
+	if err != nil {
+		return err
+	}
+
+	for k, v := cur.First(); k != nil; k, v = cur.Next() {
+		s := &influxdb.Source{}
+		if err := json.Unmarshal(v, s); err != nil {
+			return err
+		}
+		if !fn(s) {
+			break
+		}
+	}
+
+	return nil
+}
+
+// UpdateSource updates a source according the parameters set on upd.
+func (s *Service) UpdateSource(ctx context.Context, id influxdb.ID, upd influxdb.SourceUpdate) (*influxdb.Source, error) {
+	var sr *influxdb.Source
+	err := s.kv.Update(func(tx Tx) error {
+		src, err := s.updateSource(ctx, tx, id, upd)
+		if err != nil {
+			return &influxdb.Error{
+				Err: err,
+			}
+		}
+		sr = src
+		return nil
+	})
+
+	return sr, err
+}
+
+func (s *Service) updateSource(ctx context.Context, tx Tx, id influxdb.ID, upd influxdb.SourceUpdate) (*influxdb.Source, error) {
+	src, pe := s.findSourceByID(ctx, tx, id)
+	if pe != nil {
+		return nil, pe
+	}
+
+	if err := upd.Apply(src); err != nil {
+		return nil, err
+	}
+
+	if err := s.putSource(ctx, tx, src); err != nil {
+		return nil, err
+	}
+
+	return src, nil
+}
+
+// DeleteSource deletes a source and prunes it from the index.
+func (s *Service) DeleteSource(ctx context.Context, id influxdb.ID) error {
+	return s.kv.Update(func(tx Tx) error {
+		pe := s.deleteSource(ctx, tx, id)
+		if pe != nil {
+			return &influxdb.Error{
+				Err: pe,
+			}
+		}
+		return nil
+	})
+}
+
+func (s *Service) deleteSource(ctx context.Context, tx Tx, id influxdb.ID) error {
+	if id == DefaultSource.ID {
+		return &influxdb.Error{
+			Code: influxdb.EForbidden,
+			Msg:  "cannot delete autogen source",
+		}
+	}
+	_, pe := s.findSourceByID(ctx, tx, id)
+	if pe != nil {
+		return pe
+	}
+
+	encodedID, err := id.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+
+	b, err := tx.Bucket(sourceBucket)
+	if err != nil {
+		return err
+	}
+
+	if err = b.Delete(encodedID); err != nil {
+		return &influxdb.Error{
+			Err: err,
+		}
+	}
+	return nil
+}

--- a/kv/source_test.go
+++ b/kv/source_test.go
@@ -1,0 +1,72 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBoltSourceService(t *testing.T) {
+	t.Run("CreateSource", func(t *testing.T) { influxdbtesting.CreateSource(initBoltSourceService, t) })
+	t.Run("FindSourceByID", func(t *testing.T) { influxdbtesting.FindSourceByID(initBoltSourceService, t) })
+	t.Run("FindSources", func(t *testing.T) { influxdbtesting.FindSources(initBoltSourceService, t) })
+	t.Run("DeleteSource", func(t *testing.T) { influxdbtesting.DeleteSource(initBoltSourceService, t) })
+}
+
+func TestInmemSourceService(t *testing.T) {
+	t.Run("CreateSource", func(t *testing.T) { influxdbtesting.CreateSource(initInmemSourceService, t) })
+	t.Run("FindSourceByID", func(t *testing.T) { influxdbtesting.FindSourceByID(initInmemSourceService, t) })
+	t.Run("FindSources", func(t *testing.T) { influxdbtesting.FindSources(initInmemSourceService, t) })
+	t.Run("DeleteSource", func(t *testing.T) { influxdbtesting.DeleteSource(initInmemSourceService, t) })
+}
+
+func initBoltSourceService(f influxdbtesting.SourceFields, t *testing.T) (influxdb.SourceService, string, func()) {
+	s, closeBolt, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initSourceService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initInmemSourceService(f influxdbtesting.SourceFields, t *testing.T) (influxdb.SourceService, string, func()) {
+	s, closeBolt, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new kv store: %v", err)
+	}
+
+	svc, op, closeSvc := initSourceService(s, f, t)
+	return svc, op, func() {
+		closeSvc()
+		closeBolt()
+	}
+}
+
+func initSourceService(s kv.Store, f influxdbtesting.SourceFields, t *testing.T) (influxdb.SourceService, string, func()) {
+	svc := kv.NewService(s)
+	svc.IDGenerator = f.IDGenerator
+
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("error initializing source service: %v", err)
+	}
+	for _, b := range f.Sources {
+		if err := svc.PutSource(ctx, b); err != nil {
+			t.Fatalf("failed to populate sources")
+		}
+	}
+	return svc, kv.OpPrefix, func() {
+		for _, b := range f.Sources {
+			if err := svc.DeleteSource(ctx, b.ID); err != nil {
+				t.Logf("failed to remove source: %v", err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #11727

_Briefly describe your proposed changes:_
This PR moves the bolt implementation of the macro, source, session, and secret services to the generic kv store.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
