### PR TITLE
Convert TagValueSeriesIDCache to use string fields.

### DIFF
--- a/pkg/tracing/context.go
+++ b/pkg/tracing/context.go
@@ -3,7 +3,7 @@ package tracing
 import "context"
 
 type (
-	spanContextKey struct{}
+	spanContextKey  struct{}
 	traceContextKey struct{}
 )
 

--- a/query/executor.go
+++ b/query/executor.go
@@ -144,7 +144,7 @@ type ExecutionOptions struct {
 
 type (
 	iteratorsContextKey struct{}
-	monitorContextKey struct{}
+	monitorContextKey   struct{}
 )
 
 // NewContextWithIterators returns a new context.Context with the *Iterators slice added.

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -106,9 +106,9 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 
 	// Create list item, and add to the front of the eviction list.
 	listElement := c.evictor.PushFront(&seriesIDCacheElement{
-		name:        name,
-		key:         key,
-		value:       value,
+		name:        string(name),
+		key:         string(key),
+		value:       string(value),
 		SeriesIDSet: ss,
 	})
 
@@ -188,8 +188,8 @@ func (c *TagValueSeriesIDCache) checkEviction() {
 
 // seriesIDCacheElement is an item stored within a cache.
 type seriesIDCacheElement struct {
-	name        []byte
-	key         []byte
-	value       []byte
+	name        string
+	key         string
+	value       string
 	SeriesIDSet *tsdb.SeriesIDSet
 }


### PR DESCRIPTION
This commit changes `name`, `key`, and `value` to from `[]byte` to `string`.