### PR TITLE
Ensure that cached series id sets are Go heap backed

### DIFF
--- a/tsdb/tsi1/cache.go
+++ b/tsdb/tsi1/cache.go
@@ -110,6 +110,11 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 	}
 	defer c.Unlock()
 
+	// Ensure our SeriesIDSet is go heap backed.
+	if ss != nil {
+		ss = ss.Clone()
+	}
+
 	// Create list item, and add to the front of the eviction list.
 	listElement := c.evictor.PushFront(&seriesIDCacheElement{
 		name:        string(name),

--- a/tsdb/tsi1/cache_test.go
+++ b/tsdb/tsi1/cache_test.go
@@ -147,7 +147,7 @@ func TestTagValueSeriesIDCache_addToSet(t *testing.T) {
 
 	cache.addToSet([]byte("m0"), []byte("k0"), []byte("v0"), tsdb.NewSeriesID(20))  // No non-nil set exists so one will be created
 	cache.addToSet([]byte("m0"), []byte("k0"), []byte("v1"), tsdb.NewSeriesID(101)) // No non-nil set exists so one will be created
-	cache.Has(t, "m0", "k0", "v1", s2)
+	cache.Has(t, "m0", "k0", "v1", newSeriesIDSet(100, 101))
 
 	ss := cache.GetByString("m0", "k0", "v0")
 	if !newSeriesIDSet(20).Equals(ss) {
@@ -232,13 +232,15 @@ type TestCache struct {
 }
 
 func (c TestCache) Has(t *testing.T, name, key, value string, ss *tsdb.SeriesIDSet) {
-	if got, exp := c.Get([]byte(name), []byte(key), []byte(value)), ss; got != exp {
+	if got, exp := c.Get([]byte(name), []byte(key), []byte(value)), ss; !got.Equals(exp) {
+		t.Helper()
 		t.Fatalf("got set %v, expected %v", got, exp)
 	}
 }
 
 func (c TestCache) HasNot(t *testing.T, name, key, value string) {
 	if got := c.Get([]byte(name), []byte(key), []byte(value)); got != nil {
+		t.Helper()
 		t.Fatalf("got non-nil set %v for {%q, %q, %q}", got, name, key, value)
 	}
 }


### PR DESCRIPTION
This is a port of #11832 to 2.0.