### PR TITLE
Change return type of get/macros to an array

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5810,7 +5810,9 @@ components:
             language: flux
       properties:
         macros:
-          $ref: "#/components/schemas/Macro"
+          type: array
+          items:
+            $ref: "#/components/schemas/Macro"
     View:
       properties:
         links:


### PR DESCRIPTION
This PR fixes the return type in the swagger documentation of the /get/macros route to be an array instead of a single macro.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
