### PR TITLE
fix(ui): Ensure template dashboard only gets created on config creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Bug Fixes
 1. [11819](https://github.com/influxdata/influxdb/pull/11819): Update the inline edit for resource names to guard for empty strings
+1. [11852](https://github.com/influxdata/influxdb/pull/11852): Prevent a new template dashboard from being created on every telegraf config update
+
 ### UI Improvements
 1. [11764](https://github.com/influxdata/influxdb/pull/11764): Move the download telegraf config button to view config overlay
 

--- a/ui/src/dataLoaders/components/verifyStep/CreateOrUpdateConfig.test.tsx
+++ b/ui/src/dataLoaders/components/verifyStep/CreateOrUpdateConfig.test.tsx
@@ -15,6 +15,7 @@ const setup = async (override = {}) => {
     createDashboardsForPlugins: jest.fn(),
     notify: jest.fn(),
     authToken: '',
+    telegrafConfigID: '',
     ...override,
   }
 

--- a/ui/src/dataLoaders/components/verifyStep/CreateOrUpdateConfig.tsx
+++ b/ui/src/dataLoaders/components/verifyStep/CreateOrUpdateConfig.tsx
@@ -20,19 +20,24 @@ import {
 
 // Types
 import {RemoteDataState, NotificationAction} from 'src/types'
+import {AppState} from 'src/types/v2'
 
-export interface OwnProps {
+interface OwnProps {
   org: string
   children: () => JSX.Element
 }
 
-export interface DispatchProps {
+interface StateProps {
+  telegrafConfigID: string
+}
+
+interface DispatchProps {
   notify: NotificationAction
   onSaveTelegrafConfig: typeof createOrUpdateTelegrafConfigAsync
   createDashboardsForPlugins: typeof createDashboardsForPluginsAction
 }
 
-type Props = OwnProps & DispatchProps
+type Props = OwnProps & StateProps & DispatchProps
 
 interface State {
   loading: RemoteDataState
@@ -51,6 +56,7 @@ export class CreateOrUpdateConfig extends PureComponent<Props, State> {
       onSaveTelegrafConfig,
       notify,
       createDashboardsForPlugins,
+      telegrafConfigID,
     } = this.props
 
     this.setState({loading: RemoteDataState.Loading})
@@ -58,7 +64,10 @@ export class CreateOrUpdateConfig extends PureComponent<Props, State> {
     try {
       await onSaveTelegrafConfig()
       notify(TelegrafConfigCreationSuccess)
-      await createDashboardsForPlugins()
+
+      if (!telegrafConfigID) {
+        await createDashboardsForPlugins()
+      }
 
       this.setState({loading: RemoteDataState.Done})
     } catch (error) {
@@ -79,13 +88,21 @@ export class CreateOrUpdateConfig extends PureComponent<Props, State> {
   }
 }
 
+const mstp = ({
+  dataLoading: {
+    dataLoaders: {telegrafConfigID},
+  },
+}: AppState): StateProps => {
+  return {telegrafConfigID}
+}
+
 const mdtp: DispatchProps = {
   notify: notifyAction,
   onSaveTelegrafConfig: createOrUpdateTelegrafConfigAsync,
   createDashboardsForPlugins: createDashboardsForPluginsAction,
 }
 
-export default connect<null, DispatchProps, OwnProps>(
-  null,
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mstp,
   mdtp
 )(CreateOrUpdateConfig)


### PR DESCRIPTION
Closes #11783

_Briefly describe your proposed changes:_
Rather than creating  a template dashboard on every telegraf config creation and update, a template dashboard will only get created when the telegraf config gets created.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
