### PR TITLE
Add values and language properties to QueryMacroProperties

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5745,10 +5745,13 @@ components:
         type:
           type: string
           enum: ["query"]
-        query:
-          type: string
-        queryType:
-          type: string
+        values:
+          type: object
+          properties:
+            query:
+              type: string
+            language:
+              type: string
     Macro:
       type: object
       properties:


### PR DESCRIPTION
This PR updates the shape of the `QueryMacroProperties` type on the Macros spec to match the implementation.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)