### PR TITLE
feat(kv): add kv onboarding service

### DIFF
--- a/bolt/onboarding.go
+++ b/bolt/onboarding.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	platform "github.com/influxdata/influxdb"
 )
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -310,7 +310,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		userLogSvc       platform.UserOperationLogService         = m.kvService
 		bucketLogSvc     platform.BucketOperationLogService       = m.kvService
 		orgLogSvc        platform.OrganizationOperationLogService = m.kvService
-		onboardingSvc    platform.OnboardingService               = m.boltClient
+		onboardingSvc    platform.OnboardingService               = m.kvService
 		scraperTargetSvc platform.ScraperTargetStoreService       = m.boltClient
 		telegrafSvc      platform.TelegrafConfigStore             = m.boltClient
 		userResourceSvc  platform.UserResourceMappingService      = m.kvService

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6790,6 +6790,7 @@ components:
       type: object
       properties:
         allowed:
+          description: true means that the influxdb instance has NOT had initial setup; false means that the database has been setup.
           type: boolean
     OnboardingRequest:
       type: object

--- a/kv/onboarding.go
+++ b/kv/onboarding.go
@@ -1,0 +1,174 @@
+package kv
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/influxdata/influxdb"
+)
+
+var (
+	onboardingBucket = []byte("onboardingv1")
+	onboardingKey    = []byte("onboarding_key")
+)
+
+var _ influxdb.OnboardingService = (*Service)(nil)
+
+func (s *Service) initializeOnboarding(ctx context.Context, tx Tx) error {
+	_, err := tx.Bucket(onboardingBucket)
+	return err
+}
+
+// IsOnboarding means if the initial setup of influxdb has happened.
+// true means that the onboarding setup has not yet happened.
+// false means that the onboarding has been completed.
+func (s *Service) IsOnboarding(ctx context.Context) (bool, error) {
+	notSetup := true
+	err := s.kv.View(func(tx Tx) error {
+		bucket, err := tx.Bucket(onboardingBucket)
+		if err != nil {
+			return err
+		}
+		v, err := bucket.Get(onboardingKey)
+		// If the sentinel onboarding key is not found, then, setup
+		// has not been performed.
+		if IsNotFound(err) {
+			notSetup = true
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// If the sentinel key has any bytes whatsoever, then,
+		if len(v) > 0 {
+			notSetup = false // this means that it is setup.  I hate bools.
+		}
+		return nil
+	})
+	return notSetup, err
+}
+
+// PutOnboardingStatus will update the flag,
+// so future onboarding request will be denied.
+// true means that onboarding is NOT needed.
+// false means that onboarding is needed.
+func (s *Service) PutOnboardingStatus(ctx context.Context, hasBeenOnboarded bool) error {
+	return s.kv.Update(func(tx Tx) error {
+		return s.putOnboardingStatus(ctx, tx, hasBeenOnboarded)
+	})
+}
+
+func (s *Service) putOnboardingStatus(ctx context.Context, tx Tx, hasBeenOnboarded bool) error {
+	if hasBeenOnboarded {
+		return s.setOnboarded(ctx, tx)
+	}
+	return s.setOffboarded(ctx, tx)
+}
+
+func (s *Service) setOffboarded(ctx context.Context, tx Tx) error {
+	bucket, err := tx.Bucket(onboardingBucket)
+	if err != nil {
+		// TODO(goller): check err
+		return err
+	}
+	err = bucket.Delete(onboardingKey)
+	if err != nil {
+		// TODO(goller): check err
+		return err
+	}
+	return nil
+}
+
+func (s *Service) setOnboarded(ctx context.Context, tx Tx) error {
+	bucket, err := tx.Bucket(onboardingBucket)
+	if err != nil {
+		// TODO(goller): check err
+		return err
+	}
+	err = bucket.Put(onboardingKey, []byte{0x1})
+	if err != nil {
+		// TODO(goller): check err
+		return err
+	}
+	return nil
+}
+
+// Generate OnboardingResults from onboarding request,
+// update db so this request will be disabled for the second run.
+func (s *Service) Generate(ctx context.Context, req *influxdb.OnboardingRequest) (*influxdb.OnboardingResults, error) {
+	isOnboarding, err := s.IsOnboarding(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !isOnboarding {
+		return nil, &influxdb.Error{
+			Code: influxdb.EConflict,
+			Msg:  "onboarding has already been completed",
+		}
+	}
+
+	if err := req.Valid(); err != nil {
+		return nil, err
+	}
+
+	u := &influxdb.User{Name: req.User}
+	o := &influxdb.Organization{Name: req.Org}
+	bucket := &influxdb.Bucket{
+		Name:            req.Bucket,
+		Organization:    o.Name,
+		RetentionPeriod: time.Duration(req.RetentionPeriod) * time.Hour,
+	}
+	mapping := &influxdb.UserResourceMapping{
+		ResourceType: influxdb.OrgsResourceType,
+		UserType:     influxdb.Owner,
+	}
+	auth := &influxdb.Authorization{
+		Description: fmt.Sprintf("%s's Token", u.Name),
+		Permissions: influxdb.OperPermissions(),
+		Token:       req.Token,
+	}
+
+	err = s.kv.Update(func(tx Tx) error {
+		if err := s.createUser(ctx, tx, u); err != nil {
+			return err
+		}
+
+		if err := s.setPassword(ctx, tx, u.Name, req.Password); err != nil {
+			return err
+		}
+
+		if err := s.createOrganization(ctx, tx, o); err != nil {
+			return err
+		}
+
+		bucket.OrganizationID = o.ID
+		if err := s.createBucket(ctx, tx, bucket); err != nil {
+			return err
+		}
+
+		mapping.ResourceID = o.ID
+		mapping.UserID = u.ID
+		if err := s.createUserResourceMapping(ctx, tx, mapping); err != nil {
+			return err
+		}
+
+		auth.UserID = u.ID
+		auth.OrgID = o.ID
+		if err := s.createAuthorization(ctx, tx, auth); err != nil {
+			return err
+		}
+
+		return s.putOnboardingStatus(ctx, tx, true)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &influxdb.OnboardingResults{
+		User:   u,
+		Org:    o,
+		Bucket: bucket,
+		Auth:   auth,
+	}, nil
+}

--- a/kv/onboarding_test.go
+++ b/kv/onboarding_test.go
@@ -1,0 +1,65 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	influxdb "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+	influxdbtesting "github.com/influxdata/influxdb/testing"
+)
+
+func TestBolOnboardingService(t *testing.T) {
+	influxdbtesting.Generate(initBoltOnboardingService, t)
+}
+
+func TestInmemOnboardingService(t *testing.T) {
+	influxdbtesting.Generate(initInmemOnboardingService, t)
+}
+
+func initBoltOnboardingService(f influxdbtesting.OnboardingFields, t *testing.T) (influxdb.OnboardingService, func()) {
+	s, closeStore, err := NewTestBoltStore()
+	if err != nil {
+		t.Fatalf("failed to create new bolt kv store: %v", err)
+	}
+
+	svc, closeSvc := initOnboardingService(s, f, t)
+	return svc, func() {
+		closeSvc()
+		closeStore()
+	}
+}
+
+func initInmemOnboardingService(f influxdbtesting.OnboardingFields, t *testing.T) (influxdb.OnboardingService, func()) {
+	s, closeStore, err := NewTestInmemStore()
+	if err != nil {
+		t.Fatalf("failed to create new inmem kv store: %v", err)
+	}
+
+	svc, closeSvc := initOnboardingService(s, f, t)
+	return svc, func() {
+		closeSvc()
+		closeStore()
+	}
+}
+
+func initOnboardingService(s kv.Store, f influxdbtesting.OnboardingFields, t *testing.T) (influxdb.OnboardingService, func()) {
+	svc := kv.NewService(s)
+	svc.IDGenerator = f.IDGenerator
+	svc.TokenGenerator = f.TokenGenerator
+	ctx := context.Background()
+	if err := svc.Initialize(ctx); err != nil {
+		t.Fatalf("unable to initialize kv store: %v", err)
+	}
+
+	t.Logf("Onboarding: %v", f.IsOnboarding)
+	if err := svc.PutOnboardingStatus(ctx, !f.IsOnboarding); err != nil {
+		t.Fatalf("failed to set new onboarding finished: %v", err)
+	}
+
+	return svc, func() {
+		if err := svc.PutOnboardingStatus(ctx, false); err != nil {
+			t.Logf("failed to remove onboarding finished: %v", err)
+		}
+	}
+}

--- a/kv/service.go
+++ b/kv/service.go
@@ -104,6 +104,10 @@ func (s *Service) Initialize(ctx context.Context) error {
 			return err
 		}
 
+		if err := s.initializeOnboarding(ctx, tx); err != nil {
+			return err
+		}
+
 		return nil
 	})
 }

--- a/kv/urm.go
+++ b/kv/urm.go
@@ -124,15 +124,7 @@ func (s *Service) findUserResourceMapping(ctx context.Context, tx Tx, filter inf
 // or owner.
 func (s *Service) CreateUserResourceMapping(ctx context.Context, m *influxdb.UserResourceMapping) error {
 	return s.kv.Update(func(tx Tx) error {
-		if err := s.createUserResourceMapping(ctx, tx, m); err != nil {
-			return err
-		}
-
-		if m.ResourceType == influxdb.OrgsResourceType {
-			return s.createOrgDependentMappings(ctx, tx, m)
-		}
-
-		return nil
+		return s.createUserResourceMapping(ctx, tx, m)
 	})
 }
 
@@ -158,6 +150,10 @@ func (s *Service) createUserResourceMapping(ctx context.Context, tx Tx, m *influ
 
 	if err := b.Put(key, v); err != nil {
 		return UnavailableURMServiceError(err)
+	}
+
+	if m.ResourceType == influxdb.OrgsResourceType {
+		return s.createOrgDependentMappings(ctx, tx, m)
 	}
 
 	return nil

--- a/kv/user.go
+++ b/kv/user.go
@@ -226,19 +226,23 @@ func (s *Service) FindUsers(ctx context.Context, filter influxdb.UserFilter, opt
 // CreateUser creates a influxdb user and sets b.ID.
 func (s *Service) CreateUser(ctx context.Context, u *influxdb.User) error {
 	return s.kv.Update(func(tx Tx) error {
-		unique := s.uniqueUserName(ctx, tx, u)
-
-		if !unique {
-			return ErrUserWithNameAlreadyExists(u.Name)
-		}
-
-		u.ID = s.IDGenerator.ID()
-		if err := s.appendUserEventToLog(ctx, tx, u.ID, userCreatedEvent); err != nil {
-			return err
-		}
-
-		return s.putUser(ctx, tx, u)
+		return s.createUser(ctx, tx, u)
 	})
+}
+
+func (s *Service) createUser(ctx context.Context, tx Tx, u *influxdb.User) error {
+	unique := s.uniqueUserName(ctx, tx, u)
+
+	if !unique {
+		return ErrUserWithNameAlreadyExists(u.Name)
+	}
+
+	u.ID = s.IDGenerator.ID()
+	if err := s.appendUserEventToLog(ctx, tx, u.ID, userCreatedEvent); err != nil {
+		return err
+	}
+
+	return s.putUser(ctx, tx, u)
 }
 
 // PutUser will put a user without setting an ID.

--- a/onboarding.go
+++ b/onboarding.go
@@ -2,6 +2,20 @@ package influxdb
 
 import "context"
 
+// OnboardingService represents a service for the first run.
+type OnboardingService interface {
+	PasswordsService
+	BucketService
+	OrganizationService
+	UserService
+	AuthorizationService
+
+	// IsOnboarding determine if onboarding request is allowed.
+	IsOnboarding(ctx context.Context) (bool, error)
+	// Generate OnboardingResults.
+	Generate(ctx context.Context, req *OnboardingRequest) (*OnboardingResults, error)
+}
+
 // OnboardingResults is a group of elements required for first run.
 type OnboardingResults struct {
 	User   *User          `json:"user"`
@@ -21,16 +35,33 @@ type OnboardingRequest struct {
 	Token           string `json:"token,omitempty"`
 }
 
-// OnboardingService represents a service for the first run.
-type OnboardingService interface {
-	PasswordsService
-	BucketService
-	OrganizationService
-	UserService
-	AuthorizationService
+func (r *OnboardingRequest) Valid() error {
+	if r.Password == "" {
+		return &Error{
+			Code: EEmptyValue,
+			Msg:  "password is empty",
+		}
+	}
 
-	// IsOnboarding determine if onboarding request is allowed.
-	IsOnboarding(ctx context.Context) (bool, error)
-	// Generate OnboardingResults.
-	Generate(ctx context.Context, req *OnboardingRequest) (*OnboardingResults, error)
+	if r.User == "" {
+		return &Error{
+			Code: EEmptyValue,
+			Msg:  "username is empty",
+		}
+	}
+
+	if r.Org == "" {
+		return &Error{
+			Code: EEmptyValue,
+			Msg:  "org name is empty",
+		}
+	}
+
+	if r.Bucket == "" {
+		return &Error{
+			Code: EEmptyValue,
+			Msg:  "bucket name is empty",
+		}
+	}
+	return nil
 }

--- a/testing/onboarding.go
+++ b/testing/onboarding.go
@@ -183,10 +183,12 @@ func Generate(
 			ctx := context.Background()
 			results, err := s.Generate(ctx, tt.args.request)
 			if (err != nil) != (tt.wants.errCode != "") {
+				t.Logf("Error: %v", err)
 				t.Fatalf("expected error code '%s' got '%v'", tt.wants.errCode, err)
 			}
 			if err != nil && tt.wants.errCode != "" {
 				if code := platform.ErrorCode(err); code != tt.wants.errCode {
+					t.Logf("Error: %v", err)
 					t.Fatalf("expected error code to match '%s' got '%v'", tt.wants.errCode, code)
 				}
 			}


### PR DESCRIPTION
Closes #11883

_Briefly describe your proposed changes:_
Implement onboarding service with kv store.  Also, I took the opportunity to make the onboarding a single transaction.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
