### PR TITLE
Add name, orgID, and arguments as required properties to Macro type

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5754,6 +5754,10 @@ components:
               type: string
     Macro:
       type: object
+      required:
+        - name
+        - orgID
+        - arguments
       properties:
         links:
           type: object


### PR DESCRIPTION
This PR will add required properties to the Macro (Variable) type in the Swagger documentation

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)