### PR TITLE
fix(query/stdlib/influxdb): make FromOpSpec a BucketAwareSpec

### DIFF
--- a/query/stdlib/influxdata/influxdb/from_test.go
+++ b/query/stdlib/influxdata/influxdb/from_test.go
@@ -1,6 +1,7 @@
 package influxdb_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -122,22 +123,30 @@ func TestFromOperation_Marshaling(t *testing.T) {
 }
 
 func TestFromOpSpec_BucketsAccessed(t *testing.T) {
-	// TODO(adam) add this test back when BucketsAccessed is restored for the from function
-	// https://github.com/influxdata/flux/issues/114
-	t.Skip("https://github.com/influxdata/flux/issues/114")
 	bucketName := "my_bucket"
-	bucketID, _ := platform.IDFromString("deadbeef")
+	bucketIDString := "aaaabbbbccccdddd"
+	bucketID, err := platform.IDFromString(bucketIDString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidID := platform.InvalidID()
 	tests := []pquerytest.BucketAwareQueryTestCase{
 		{
 			Name:             "From with bucket",
-			Raw:              `from(bucket:"my_bucket")`,
+			Raw:              fmt.Sprintf(`from(bucket:"%s")`, bucketName),
 			WantReadBuckets:  &[]platform.BucketFilter{{Name: &bucketName}},
 			WantWriteBuckets: &[]platform.BucketFilter{},
 		},
 		{
 			Name:             "From with bucketID",
-			Raw:              `from(bucketID:"deadbeef")`,
+			Raw:              fmt.Sprintf(`from(bucketID:"%s")`, bucketID),
 			WantReadBuckets:  &[]platform.BucketFilter{{ID: bucketID}},
+			WantWriteBuckets: &[]platform.BucketFilter{},
+		},
+		{
+			Name:             "From invalid bucketID",
+			Raw:              `from(bucketID:"invalid")`,
+			WantReadBuckets:  &[]platform.BucketFilter{{ID: &invalidID}},
 			WantWriteBuckets: &[]platform.BucketFilter{},
 		},
 	}

--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -172,7 +172,13 @@ func (ToOpSpec) Kind() flux.OperationKind {
 
 // BucketsAccessed returns the buckets accessed by the spec.
 func (o *ToOpSpec) BucketsAccessed() (readBuckets, writeBuckets []platform.BucketFilter) {
-	bf := platform.BucketFilter{Name: &o.Bucket, Organization: &o.Org}
+	bf := platform.BucketFilter{}
+	if o.Bucket != "" {
+		bf.Name = &o.Bucket
+	}
+	if o.Org != "" {
+		bf.Organization = &o.Org
+	}
 	if o.OrgID != "" {
 		id, err := platform.IDFromString(o.OrgID)
 		if err == nil {

--- a/query/stdlib/influxdata/influxdb/to_test.go
+++ b/query/stdlib/influxdata/influxdb/to_test.go
@@ -2,6 +2,7 @@ package influxdb_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -82,24 +83,25 @@ func TestTo_Query(t *testing.T) {
 }
 
 func TestToOpSpec_BucketsAccessed(t *testing.T) {
-	// TODO(adam) add this test back when BucketsAccessed is restored for the from function
-	// https://github.com/influxdata/flux/issues/114
-	t.Skip("https://github.com/influxdata/flux/issues/114")
 	bucketName := "my_bucket"
 	orgName := "my_org"
-	id := platform.ID(1)
+	orgIDString := "aaaabbbbccccdddd"
+	orgID, err := platform.IDFromString(orgIDString)
+	if err != nil {
+		t.Fatal(err)
+	}
 	tests := []querytest.BucketAwareQueryTestCase{
 		{
 			Name:             "from() with bucket and to with org and bucket",
-			Raw:              `from(bucket:"my_bucket") |> to(bucket:"my_bucket", org:"my_org")`,
+			Raw:              fmt.Sprintf(`from(bucket:"%s") |> to(bucket:"%s", org:"%s")`, bucketName, bucketName, orgName),
 			WantReadBuckets:  &[]platform.BucketFilter{{Name: &bucketName}},
 			WantWriteBuckets: &[]platform.BucketFilter{{Name: &bucketName, Organization: &orgName}},
 		},
 		{
 			Name:             "from() with bucket and to with orgID and bucket",
-			Raw:              `from(bucket:"my_bucket") |> to(bucket:"my_bucket", orgID:"0000000000000001")`,
+			Raw:              fmt.Sprintf(`from(bucket:"%s") |> to(bucket:"%s", orgID:"%s")`, bucketName, bucketName, orgIDString),
 			WantReadBuckets:  &[]platform.BucketFilter{{Name: &bucketName}},
-			WantWriteBuckets: &[]platform.BucketFilter{{Name: &bucketName, OrganizationID: &id}},
+			WantWriteBuckets: &[]platform.BucketFilter{{Name: &bucketName, OrganizationID: orgID}},
 		},
 	}
 


### PR DESCRIPTION
Closes https://github.com/influxdata/flux/issues/114

_Briefly describe your proposed changes:_
there was a cyclic dependency between Flux and InfluxDB because of `from` being in Flux.
Now that `from` is in InfluxDB, pre-authorization can work for `from`.

I fixed every test that contained "https://github.com/influxdata/flux/issues/114" in the `Skip` reason.  
If there is something else I should be aware of, please tell me.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
