### PR TITLE
Histogram polish

### DIFF
--- a/ui/src/minard/components/Histogram.tsx
+++ b/ui/src/minard/components/Histogram.tsx
@@ -99,8 +99,6 @@ export const Histogram: SFC<Props> = props => {
           hoverX={hoverX}
           hoverY={hoverY}
           hoveredRowIndices={hoveredRowIndices}
-          width={innerWidth}
-          height={innerHeight}
           layer={layer}
           tooltip={props.tooltip}
         />

--- a/ui/src/minard/components/HistogramTooltip.tsx
+++ b/ui/src/minard/components/HistogramTooltip.tsx
@@ -2,6 +2,7 @@ import React, {useRef, SFC} from 'react'
 
 import {HistogramTooltipProps, Layer} from 'src/minard'
 import {useLayoutStyle} from 'src/minard/utils/useLayoutStyle'
+import {useMousePos} from 'src/minard/utils/useMousePos'
 import {getHistogramTooltipProps} from 'src/minard/utils/getHistogramTooltipProps'
 
 const MARGIN_X = 15
@@ -11,8 +12,6 @@ interface Props {
   hoverX: number
   hoverY: number
   tooltip?: (props: HistogramTooltipProps) => JSX.Element
-  width: number
-  height: number
   layer: Layer
   hoveredRowIndices: number[] | null
 }
@@ -21,27 +20,42 @@ const HistogramTooltip: SFC<Props> = ({
   hoverX,
   hoverY,
   tooltip,
-  width,
-  height,
   layer,
   hoveredRowIndices,
 }: Props) => {
   const tooltipEl = useRef<HTMLDivElement>(null)
+  const {x: absoluteHoverX, y: absoluteHoverY} = useMousePos(document.body)
 
+  // Position the tooltip next to the mouse cursor, like this:
+  //
+  //                   ┌─────────────┐
+  //                   │             │
+  //          (mouse)  │   tooltip   │
+  //                   │             │
+  //                   └─────────────┘
+  //
+  // The positioning is subject to the following restrictions:
+  //
+  // - If the tooltip overflows the right side of the screen, position it on
+  //   the left side of the cursor instead
+  //
+  // - If the tooltip overflows the top or bottom of the screen (with a bit of
+  //   margin), shift it just enough so that it is fully back inside the screen
+  //
   useLayoutStyle(tooltipEl, ({offsetWidth, offsetHeight}) => {
     let dx = MARGIN_X
-    let dy = MARGIN_Y
+    let dy = 0 - offsetHeight / 2
 
-    if (hoverX + MARGIN_X + offsetWidth > width) {
-      // If the tooltip overflows off the right edge of the visualization,
-      // position it on the left side of the mouse instead
+    if (absoluteHoverX + MARGIN_X + offsetWidth > window.innerWidth) {
       dx = 0 - MARGIN_X - offsetWidth
     }
 
-    if (hoverY + MARGIN_Y + offsetHeight > height) {
-      // If the tooltip overflows off the bottom edge of the visualization,
-      // position it on the top side of the mouse instead
-      dy = 0 - MARGIN_Y - offsetHeight
+    if (absoluteHoverY + offsetHeight / 2 + MARGIN_Y > window.innerHeight) {
+      dy = 0 - (absoluteHoverY + offsetHeight - window.innerHeight) - MARGIN_Y
+    }
+
+    if (absoluteHoverY - offsetHeight / 2 - MARGIN_Y < 0) {
+      dy = 0 - absoluteHoverY + MARGIN_Y
     }
 
     return {

--- a/ui/src/minard/components/Plot.tsx
+++ b/ui/src/minard/components/Plot.tsx
@@ -87,7 +87,7 @@ export const Plot: SFC<Props> = ({
   useEffect(() => dispatch(setColors(colors)), [colors])
 
   const mouseRegion = useRef<HTMLDivElement>(null)
-  const [hoverX, hoverY] = useMousePos(mouseRegion)
+  const {x: hoverX, y: hoverY} = useMousePos(mouseRegion.current)
 
   const childProps = useMemo(
     () => ({

--- a/ui/src/minard/utils/useMousePos.ts
+++ b/ui/src/minard/utils/useMousePos.ts
@@ -1,40 +1,38 @@
-import {useState, useEffect, MutableRefObject} from 'react'
+import {useState, useEffect} from 'react'
 
-export const useMousePos = (
-  ref: MutableRefObject<Element>
-): [number, number] => {
-  const [[x, y], setXY] = useState([null, null])
+export const useMousePos = (el: Element): {x: number; y: number} => {
+  const [state, setState] = useState({x: null, y: null})
 
   useEffect(
     () => {
-      if (!ref.current) {
+      if (!el) {
         return
       }
 
       const onMouseEnter = e => {
-        const {left, top} = ref.current.getBoundingClientRect()
+        const {left, top} = el.getBoundingClientRect()
 
-        setXY([e.pageX - left, e.pageY - top])
+        setState({x: e.pageX - left, y: e.pageY - top})
       }
 
       const onMouseMove = onMouseEnter
 
       const onMouseLeave = () => {
-        setXY([null, null])
+        setState({x: null, y: null})
       }
 
-      ref.current.addEventListener('mouseenter', onMouseEnter)
-      ref.current.addEventListener('mousemove', onMouseMove)
-      ref.current.addEventListener('mouseleave', onMouseLeave)
+      el.addEventListener('mouseenter', onMouseEnter)
+      el.addEventListener('mousemove', onMouseMove)
+      el.addEventListener('mouseleave', onMouseLeave)
 
       return () => {
-        ref.current.removeEventListener('mouseenter', onMouseEnter)
-        ref.current.removeEventListener('mousemove', onMouseMove)
-        ref.current.removeEventListener('mouseleave', onMouseLeave)
+        el.removeEventListener('mouseenter', onMouseEnter)
+        el.removeEventListener('mousemove', onMouseMove)
+        el.removeEventListener('mouseleave', onMouseLeave)
       }
     },
-    [ref.current]
+    [el]
   )
 
-  return [x, y]
+  return state
 }

--- a/ui/src/shared/components/HistogramTooltip.scss
+++ b/ui/src/shared/components/HistogramTooltip.scss
@@ -8,6 +8,7 @@
   border: 1px solid $g3-castle;
   padding: 10px;
   color: $g14-chromium;
+  z-index: $z--dygraph-legend;
 }
 
 .histogram-tooltip--table {

--- a/ui/src/timeMachine/components/view_options/HistogramOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/HistogramOptions.tsx
@@ -56,7 +56,6 @@ interface OwnProps {
 
 type Props = OwnProps & DispatchProps & StateProps
 
-// TODO: These options are currently hardcoded
 const HistogramOptions: SFC<Props> = props => {
   const {
     xColumn,
@@ -90,6 +89,7 @@ const HistogramOptions: SFC<Props> = props => {
           selectedID={xColumn}
           onChange={onSetXColumn}
           status={xDropdownStatus}
+          titleText="None"
         >
           {availableXColumns.map(columnName => (
             <Dropdown.Item id={columnName} key={columnName} value={columnName}>


### PR DESCRIPTION
Adds an empty state to the histogram "Column" option:

<img width="396" alt="screen shot 2019-02-14 at 10 42 49 am" src="https://user-images.githubusercontent.com/638955/52809528-5d6fde80-3045-11e9-9160-93f62b18784f.png">

Updates the tooltip positioning so that it can overflow the `Plot` component. It will detect collisions with the edge of the screen instead:

![positioning](https://user-images.githubusercontent.com/638955/52809582-7a0c1680-3045-11e9-9cf0-e4102b243a30.gif)
