### PR TITLE
Add ability to delete a variable from organizations page

### DIFF
--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -20,6 +20,7 @@ import {
   TelegrafPluginInputSwap,
   Task as TaskApi,
   Organization,
+  Macro,
 } from '@influxdata/influx'
 
 export const links: Links = {
@@ -304,6 +305,17 @@ export const tasks: Task[] = [
       name: 'RadicalOrganization',
     },
     labels,
+  },
+]
+
+export const variables: Macro[] = [
+  {
+    name: 'a little variable',
+    orgID: '0',
+    arguments: {
+      type: 'query',
+      values: {query: '1 + 1 ', language: 'flux'},
+    },
   },
 ]
 

--- a/ui/src/organizations/components/VariableList.tsx
+++ b/ui/src/organizations/components/VariableList.tsx
@@ -11,15 +11,16 @@ import {Macro} from '@influxdata/influx'
 interface Props {
   variables: Macro[]
   emptyState: JSX.Element
+  onDeleteVariable: (variable: Macro) => void
 }
 
-class VariablesList extends PureComponent<Props> {
+class VariableList extends PureComponent<Props> {
   constructor(props) {
     super(props)
   }
 
   public render() {
-    const {emptyState, variables} = this.props
+    const {emptyState, variables, onDeleteVariable} = this.props
 
     return (
       <>
@@ -30,7 +31,11 @@ class VariablesList extends PureComponent<Props> {
           </IndexList.Header>
           <IndexList.Body columnCount={3} emptyState={emptyState}>
             {variables.map(variable => (
-              <VariableRow key={variable.id} variable={variable} />
+              <VariableRow
+                key={variable.id}
+                variable={variable}
+                onDeleteVariable={onDeleteVariable}
+              />
             ))}
           </IndexList.Body>
         </IndexList>
@@ -39,4 +44,4 @@ class VariablesList extends PureComponent<Props> {
   }
 }
 
-export default VariablesList
+export default VariableList

--- a/ui/src/organizations/components/VariableRow.tsx
+++ b/ui/src/organizations/components/VariableRow.tsx
@@ -2,24 +2,40 @@
 import React, {PureComponent} from 'react'
 
 // Components
-import {IndexList, Alignment} from 'src/clockface'
+import {
+  IndexList,
+  Alignment,
+  ComponentSize,
+  ConfirmationButton,
+} from 'src/clockface'
 
 // Types
 import {Macro} from '@influxdata/influx'
 
 interface Props {
   variable: Macro
+  onDeleteVariable: (variable: Macro) => void
 }
 
 export default class VariableRow extends PureComponent<Props> {
   public render() {
-    const {variable} = this.props
+    const {variable, onDeleteVariable} = this.props
+
     return (
       <IndexList.Row>
         <IndexList.Cell alignment={Alignment.Left}>
           {variable.name}
         </IndexList.Cell>
         <IndexList.Cell alignment={Alignment.Left}>{'Query'}</IndexList.Cell>
+        <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
+          <ConfirmationButton
+            size={ComponentSize.ExtraSmall}
+            text="Delete"
+            confirmText="Confirm"
+            onConfirm={onDeleteVariable}
+            returnValue={variable}
+          />
+        </IndexList.Cell>
       </IndexList.Row>
     )
   }

--- a/ui/src/organizations/components/Variables.test.tsx
+++ b/ui/src/organizations/components/Variables.test.tsx
@@ -1,0 +1,31 @@
+// Libraries
+import React from 'react'
+import {shallow} from 'enzyme'
+
+// Components
+import VariableList from 'src/organizations/components/VariableList'
+
+// Constants
+import {variables} from 'mocks/dummyData'
+
+const setup = (override?) => {
+  const props = {
+    variables,
+    emptyState: <></>,
+    onDeleteVariable: jest.fn(),
+    ...override,
+  }
+
+  const wrapper = shallow(<VariableList {...props} />)
+
+  return {wrapper}
+}
+
+describe('VariableList', () => {
+  describe('rendering', () => {
+    it('renders', () => {
+      const {wrapper} = setup()
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+})

--- a/ui/src/organizations/components/__snapshots__/Variables.test.tsx.snap
+++ b/ui/src/organizations/components/__snapshots__/Variables.test.tsx.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VariableList rendering renders 1`] = `
+<Fragment>
+  <IndexList>
+    <IndexListHeader>
+      <IndexListHeaderCell
+        alignment="left"
+        columnName="Name"
+        width="60%"
+      />
+      <IndexListHeaderCell
+        alignment="left"
+        columnName="Type"
+        width="40%"
+      />
+    </IndexListHeader>
+    <IndexListBody
+      columnCount={3}
+      emptyState={<React.Fragment />}
+    >
+      <VariableRow
+        onDeleteVariable={[MockFunction]}
+        variable={
+          Object {
+            "arguments": Object {
+              "type": "query",
+              "values": Object {
+                "language": "flux",
+                "query": "1 + 1 ",
+              },
+            },
+            "name": "a little variable",
+            "orgID": "0",
+          }
+        }
+      />
+    </IndexListBody>
+  </IndexList>
+</Fragment>
+`;

--- a/ui/src/organizations/containers/OrganizationView.tsx
+++ b/ui/src/organizations/containers/OrganizationView.tsx
@@ -208,6 +208,7 @@ class OrganizationView extends PureComponent<Props> {
                           variables={variables}
                           orgName={org.name}
                           orgID={org.id}
+                          notify={notify}
                         />
                       </SpinnerContainer>
                     )

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -599,6 +599,30 @@ export const invalidZoomedTimeRangeValueInURLQuery = (): Notification => ({
   message: `Invalid URL query value supplied for zoomed lower or zoomed upper time range.`,
 })
 
+export const addVariableFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  icon: 'cube',
+  message: `Failed to create variable.`,
+})
+
+export const addVariableSuccess = (name: string): Notification => ({
+  ...defaultSuccessNotification,
+  icon: 'cube',
+  message: `Successfully created new variable ${name}.`,
+})
+
+export const deleteVariableFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  icon: 'cube',
+  message: `Failed to delete variable.`,
+})
+
+export const deleteVariableSuccess = (name: string): Notification => ({
+  ...defaultSuccessNotification,
+  icon: 'cube',
+  message: `Successfully deleted variable ${name}.`,
+})
+
 //  Rule Builder Notifications
 //  ----------------------------------------------------------------------------
 export const alertRuleCreated = (ruleName: string): Notification => ({


### PR DESCRIPTION
Closes: https://github.com/influxdata/applications-team-issues/issues/286

This PR adds a button to the `VariableRow` component that allows the user to delete a variable.

  - [x] Rebased/mergeable
  - [x] Tests pass
