### PR TITLE
Update return type for get/task route

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3734,7 +3734,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TaskUpdateRequest"
+                $ref: "#/components/schemas/Task"
         default:
           description: unexpected error
           content:


### PR DESCRIPTION
This PR fixes the return type of the get by ID route for a task in the Swagger documentation.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated
