### PR TITLE
Rename Macro to Variable in generated client imports

### DIFF
--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -20,7 +20,7 @@ import {
   TelegrafPluginInputSwap,
   Task as TaskApi,
   Organization,
-  Macro as Variable,
+  Variable,
 } from '@influxdata/influx'
 
 export const links: Links = {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -838,9 +838,9 @@
       }
     },
     "@influxdata/influx": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.9.tgz",
-      "integrity": "sha512-hS+FRtHH+zUVMRGDrlkUQaFUpbrKZUqE0zMD5TIPoYbK9dgKLcOF1pT36btzV2BsDNhwXD2SCHuXimzLaD2koQ==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.10.tgz",
+      "integrity": "sha512-apEhHRmxolj/fqB0J+hoWXP2NDWJFqDA9waMmYY5El/v8FTINTNWOdz8StSVWbqtmJ5uf0/D/JJig75aLaffaw==",
       "requires": {
         "axios": "^0.18.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -117,7 +117,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "0.0.4",
-    "@influxdata/influx": "^0.2.9",
+    "@influxdata/influx": "^0.2.10",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",

--- a/ui/src/organizations/components/CreateVariableOverlay.tsx
+++ b/ui/src/organizations/components/CreateVariableOverlay.tsx
@@ -17,7 +17,7 @@ import {Button} from '@influxdata/clockface'
 import FluxEditor from 'src/shared/components/FluxEditor'
 
 // Types
-import {Macro as Variable} from '@influxdata/influx'
+import {Variable} from '@influxdata/influx'
 import {
   ComponentColor,
   ComponentStatus,

--- a/ui/src/organizations/components/VariableList.tsx
+++ b/ui/src/organizations/components/VariableList.tsx
@@ -6,7 +6,7 @@ import {IndexList} from 'src/clockface'
 import VariableRow from 'src/organizations/components/VariableRow'
 
 // Types
-import {Macro as Variable} from '@influxdata/influx'
+import {Variable} from '@influxdata/influx'
 
 interface Props {
   variables: Variable[]

--- a/ui/src/organizations/components/VariableRow.tsx
+++ b/ui/src/organizations/components/VariableRow.tsx
@@ -10,7 +10,7 @@ import {
 } from 'src/clockface'
 
 // Types
-import {Macro as Variable} from '@influxdata/influx'
+import {Variable} from '@influxdata/influx'
 
 interface Props {
   variable: Variable

--- a/ui/src/organizations/components/Variables.tsx
+++ b/ui/src/organizations/components/Variables.tsx
@@ -17,7 +17,7 @@ import * as NotificationsActions from 'src/types/actions/notifications'
 import {ComponentColor, IconFont} from '@influxdata/clockface'
 import {OverlayState} from 'src/types'
 import {client} from 'src/utils/api'
-import {Macro as Variable} from '@influxdata/influx'
+import {Variable} from '@influxdata/influx'
 import {
   addVariableFailed,
   deleteVariableFailed,

--- a/ui/src/organizations/containers/OrganizationView.tsx
+++ b/ui/src/organizations/containers/OrganizationView.tsx
@@ -48,7 +48,7 @@ import {
   ScraperTargetResponse,
 } from '@influxdata/influx'
 import * as NotificationsActions from 'src/types/actions/notifications'
-import {Macro as Variable} from '@influxdata/influx'
+import {Variable} from '@influxdata/influx'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'


### PR DESCRIPTION
This PR renames the imports from the generated client library from "Macro" to "Variable"

  - [x] Rebased/mergeable
  - [ ] Tests pass
