### PR TITLE
Fix Name of Label Path Var

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -731,7 +731,7 @@ paths:
           required: true
           description: ID of the scraper target
         - in: path
-          name: label
+          name: labelID
           schema:
             type: string
           required: true
@@ -6129,7 +6129,7 @@ components:
             bucket:
               type: string
               description: name of the bucket
-            name: 
+            name:
                 type: string
                 description: name of scraper target
             links:


### PR DESCRIPTION
I was trying to build the PHP client lib and the generation was failing due to path/name mismatch.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
