### PR TITLE
fix(ui): add ordering to org resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### UI Improvements
 1. [11764](https://github.com/influxdata/influxdb/pull/11764): Move the download telegraf config button to view config overlay
 1. [11879](https://github.com/influxdata/influxdb/pull/11879): Combine permissions for user by type
+1. [11938](https://github.com/influxdata/influxdb/pull/11938): Add ordering to UI list items
 
 ## v2.0.0-alpha.2 [2019-02-07]
 

--- a/ui/src/configuration/components/GetLabels.tsx
+++ b/ui/src/configuration/components/GetLabels.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import {PureComponent} from 'react'
+import _ from 'lodash'
 
 // APIs
 import {client} from 'src/utils/api'
@@ -26,7 +27,10 @@ export default class GetLabels extends PureComponent<Props, State> {
 
   public async componentDidMount() {
     const labels = await client.labels.getAll()
-    this.setState({labels, loading: RemoteDataState.Done})
+    this.setState({
+      labels: _.orderBy(labels, ['name']),
+      loading: RemoteDataState.Done,
+    })
   }
 
   public render() {

--- a/ui/src/organizations/components/GetOrgResources.tsx
+++ b/ui/src/organizations/components/GetOrgResources.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import {PureComponent} from 'react'
+import _ from 'lodash'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -11,6 +12,10 @@ import {Organization} from '@influxdata/influx'
 interface Props<T> {
   organization: Organization
   fetcher: (org: Organization) => Promise<T>
+  orderBy?: {
+    keys: string[]
+    orders?: string[]
+  }
   children: (
     resources: T,
     loading: RemoteDataState,
@@ -55,7 +60,24 @@ export default class GetOrgResources<T> extends PureComponent<
     const {fetcher, organization} = this.props
     if (organization) {
       const resources = await fetcher(organization)
-      this.setState({resources, loading: RemoteDataState.Done})
+      this.setState({
+        resources: this.order(resources),
+        loading: RemoteDataState.Done,
+      })
     }
+  }
+
+  // Todo: unpack the type for resources
+  private order(resources) {
+    const {orderBy} = this.props
+    const isArray = resources instanceof Array
+
+    if (!orderBy || !isArray) {
+      return resources
+    }
+
+    const {keys, orders} = orderBy
+
+    return _.orderBy(resources, keys, orders)
   }
 }

--- a/ui/src/organizations/containers/OrgBucketsIndex.tsx
+++ b/ui/src/organizations/containers/OrgBucketsIndex.tsx
@@ -67,8 +67,7 @@ class OrgBucketsIndex extends Component<Props> {
                   url="buckets_tab"
                   title="Buckets"
                 >
-                  <GetOrgResources<Bucket[]>
-                    orderBy={{keys: ['name']}}
+                  <GetOrgResources<Bucket>
                     organization={org}
                     fetcher={getBuckets}
                   >

--- a/ui/src/organizations/containers/OrgBucketsIndex.tsx
+++ b/ui/src/organizations/containers/OrgBucketsIndex.tsx
@@ -68,6 +68,7 @@ class OrgBucketsIndex extends Component<Props> {
                   title="Buckets"
                 >
                   <GetOrgResources<Bucket[]>
+                    orderBy={{keys: ['name']}}
                     organization={org}
                     fetcher={getBuckets}
                   >

--- a/ui/src/organizations/containers/OrgDashboardsIndex.tsx
+++ b/ui/src/organizations/containers/OrgDashboardsIndex.tsx
@@ -62,7 +62,7 @@ class OrgDashboardsIndex extends Component<Props> {
                   url="dashboards_tab"
                   title="Dashboards"
                 >
-                  <GetOrgResources<Dashboard[]>
+                  <GetOrgResources<Dashboard>
                     organization={org}
                     fetcher={getDashboards}
                   >

--- a/ui/src/organizations/containers/OrgDashboardsIndex.tsx
+++ b/ui/src/organizations/containers/OrgDashboardsIndex.tsx
@@ -65,7 +65,6 @@ class OrgDashboardsIndex extends Component<Props> {
                   <GetOrgResources<Dashboard[]>
                     organization={org}
                     fetcher={getDashboards}
-                    orderBy={{keys: ['name']}}
                   >
                     {(dashboards, loading, fetch) => (
                       <SpinnerContainer

--- a/ui/src/organizations/containers/OrgDashboardsIndex.tsx
+++ b/ui/src/organizations/containers/OrgDashboardsIndex.tsx
@@ -65,6 +65,7 @@ class OrgDashboardsIndex extends Component<Props> {
                   <GetOrgResources<Dashboard[]>
                     organization={org}
                     fetcher={getDashboards}
+                    orderBy={{keys: ['name']}}
                   >
                     {(dashboards, loading, fetch) => (
                       <SpinnerContainer

--- a/ui/src/organizations/containers/OrgMembersIndex.tsx
+++ b/ui/src/organizations/containers/OrgMembersIndex.tsx
@@ -66,7 +66,7 @@ class OrgMembersIndex extends Component<Props> {
                   url="members_tab"
                   title="Members"
                 >
-                  <GetOrgResources<ResourceOwner[]>
+                  <GetOrgResources<ResourceOwner>
                     organization={org}
                     fetcher={getOwnersAndMembers}
                   >

--- a/ui/src/organizations/containers/OrgMembersIndex.tsx
+++ b/ui/src/organizations/containers/OrgMembersIndex.tsx
@@ -69,7 +69,6 @@ class OrgMembersIndex extends Component<Props> {
                   <GetOrgResources<ResourceOwner[]>
                     organization={org}
                     fetcher={getOwnersAndMembers}
-                    orderBy={{keys: ['name']}}
                   >
                     {(members, loading) => (
                       <SpinnerContainer

--- a/ui/src/organizations/containers/OrgMembersIndex.tsx
+++ b/ui/src/organizations/containers/OrgMembersIndex.tsx
@@ -69,6 +69,7 @@ class OrgMembersIndex extends Component<Props> {
                   <GetOrgResources<ResourceOwner[]>
                     organization={org}
                     fetcher={getOwnersAndMembers}
+                    orderBy={{keys: ['name']}}
                   >
                     {(members, loading) => (
                       <SpinnerContainer

--- a/ui/src/organizations/containers/OrganizationView.tsx
+++ b/ui/src/organizations/containers/OrganizationView.tsx
@@ -96,7 +96,7 @@ class OrganizationView extends PureComponent<Props> {
                 url="tasks_tab"
                 title="Tasks"
               >
-                <GetOrgResources<Task[]> organization={org} fetcher={getTasks}>
+                <GetOrgResources<Task> organization={org} fetcher={getTasks}>
                   {(tasks, loading, fetch) => (
                     <SpinnerContainer
                       loading={loading}
@@ -118,7 +118,7 @@ class OrganizationView extends PureComponent<Props> {
                 url="telegrafs_tab"
                 title="Telegraf"
               >
-                <GetOrgResources<Telegraf[]>
+                <GetOrgResources<Telegraf>
                   organization={org}
                   fetcher={getCollectors}
                 >
@@ -127,7 +127,7 @@ class OrganizationView extends PureComponent<Props> {
                       loading={loading}
                       spinnerComponent={<TechnoSpinner />}
                     >
-                      <GetOrgResources<Bucket[]>
+                      <GetOrgResources<Bucket>
                         organization={org}
                         fetcher={getBuckets}
                       >
@@ -155,7 +155,7 @@ class OrganizationView extends PureComponent<Props> {
                 url="scrapers_tab"
                 title="Scrapers"
               >
-                <GetOrgResources<ScraperTargetResponse[]>
+                <GetOrgResources<ScraperTargetResponse>
                   organization={org}
                   fetcher={getScrapers}
                 >
@@ -165,7 +165,7 @@ class OrganizationView extends PureComponent<Props> {
                         loading={loading}
                         spinnerComponent={<TechnoSpinner />}
                       >
-                        <GetOrgResources<Bucket[]>
+                        <GetOrgResources<Bucket>
                           organization={org}
                           fetcher={getBuckets}
                         >
@@ -193,7 +193,7 @@ class OrganizationView extends PureComponent<Props> {
                 url="variables_tab"
                 title="Variables"
               >
-                <GetOrgResources<Variable[]>
+                <GetOrgResources<Variable>
                   organization={org}
                   fetcher={getVariables}
                 >

--- a/ui/src/organizations/containers/OrganizationView.tsx
+++ b/ui/src/organizations/containers/OrganizationView.tsx
@@ -96,7 +96,11 @@ class OrganizationView extends PureComponent<Props> {
                 url="tasks_tab"
                 title="Tasks"
               >
-                <GetOrgResources<Task[]> organization={org} fetcher={getTasks}>
+                <GetOrgResources<Task[]>
+                  organization={org}
+                  fetcher={getTasks}
+                  orderBy={{keys: ['name']}}
+                >
                   {(tasks, loading, fetch) => (
                     <SpinnerContainer
                       loading={loading}
@@ -121,6 +125,7 @@ class OrganizationView extends PureComponent<Props> {
                 <GetOrgResources<Telegraf[]>
                   organization={org}
                   fetcher={getCollectors}
+                  orderBy={{keys: ['name']}}
                 >
                   {(collectors, loading, fetch) => (
                     <SpinnerContainer
@@ -130,6 +135,7 @@ class OrganizationView extends PureComponent<Props> {
                       <GetOrgResources<Bucket[]>
                         organization={org}
                         fetcher={getBuckets}
+                        orderBy={{keys: ['name']}}
                       >
                         {(buckets, loading) => (
                           <SpinnerContainer
@@ -158,6 +164,7 @@ class OrganizationView extends PureComponent<Props> {
                 <GetOrgResources<ScraperTargetResponse[]>
                   organization={org}
                   fetcher={getScrapers}
+                  orderBy={{keys: ['name']}}
                 >
                   {(scrapers, loading, fetch) => {
                     return (
@@ -168,6 +175,7 @@ class OrganizationView extends PureComponent<Props> {
                         <GetOrgResources<Bucket[]>
                           organization={org}
                           fetcher={getBuckets}
+                          orderBy={{keys: ['name']}}
                         >
                           {(buckets, loading) => (
                             <SpinnerContainer
@@ -196,6 +204,7 @@ class OrganizationView extends PureComponent<Props> {
                 <GetOrgResources<Variable[]>
                   organization={org}
                   fetcher={getVariables}
+                  orderBy={{keys: ['name']}}
                 >
                   {(variables, loading, fetch) => {
                     return (

--- a/ui/src/organizations/containers/OrganizationView.tsx
+++ b/ui/src/organizations/containers/OrganizationView.tsx
@@ -96,11 +96,7 @@ class OrganizationView extends PureComponent<Props> {
                 url="tasks_tab"
                 title="Tasks"
               >
-                <GetOrgResources<Task[]>
-                  organization={org}
-                  fetcher={getTasks}
-                  orderBy={{keys: ['name']}}
-                >
+                <GetOrgResources<Task[]> organization={org} fetcher={getTasks}>
                   {(tasks, loading, fetch) => (
                     <SpinnerContainer
                       loading={loading}
@@ -125,7 +121,6 @@ class OrganizationView extends PureComponent<Props> {
                 <GetOrgResources<Telegraf[]>
                   organization={org}
                   fetcher={getCollectors}
-                  orderBy={{keys: ['name']}}
                 >
                   {(collectors, loading, fetch) => (
                     <SpinnerContainer
@@ -135,7 +130,6 @@ class OrganizationView extends PureComponent<Props> {
                       <GetOrgResources<Bucket[]>
                         organization={org}
                         fetcher={getBuckets}
-                        orderBy={{keys: ['name']}}
                       >
                         {(buckets, loading) => (
                           <SpinnerContainer
@@ -164,7 +158,6 @@ class OrganizationView extends PureComponent<Props> {
                 <GetOrgResources<ScraperTargetResponse[]>
                   organization={org}
                   fetcher={getScrapers}
-                  orderBy={{keys: ['name']}}
                 >
                   {(scrapers, loading, fetch) => {
                     return (
@@ -175,7 +168,6 @@ class OrganizationView extends PureComponent<Props> {
                         <GetOrgResources<Bucket[]>
                           organization={org}
                           fetcher={getBuckets}
-                          orderBy={{keys: ['name']}}
                         >
                           {(buckets, loading) => (
                             <SpinnerContainer
@@ -204,7 +196,6 @@ class OrganizationView extends PureComponent<Props> {
                 <GetOrgResources<Variable[]>
                   organization={org}
                   fetcher={getVariables}
-                  orderBy={{keys: ['name']}}
                 >
                   {(variables, loading, fetch) => {
                     return (

--- a/ui/src/shared/components/FetchLabels.tsx
+++ b/ui/src/shared/components/FetchLabels.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import _ from 'lodash'
 
 // Components
 import {EmptyState, SpinnerContainer, TechnoSpinner} from 'src/clockface'
@@ -36,7 +37,10 @@ class FetchLabels extends PureComponent<Props, State> {
 
   public async componentDidMount() {
     const labels = await client.labels.getAll()
-    this.setState({loading: RemoteDataState.Done, labels})
+    this.setState({
+      loading: RemoteDataState.Done,
+      labels: _.orderBy(labels, ['name']),
+    })
   }
 
   public render() {

--- a/ui/src/tasks/components/TaskForm.tsx
+++ b/ui/src/tasks/components/TaskForm.tsx
@@ -157,7 +157,7 @@ export default class TaskForm extends PureComponent<Props, State> {
             {isInOverlay && (
               <Grid.Column widthXS={Columns.Six}>
                 <Form.Element label="Output Bucket">
-                  <GetOrgResources<Bucket[]>
+                  <GetOrgResources<Bucket>
                     organization={this.toOrganization}
                     fetcher={getBuckets}
                   >

--- a/ui/src/tasks/components/TaskForm.tsx
+++ b/ui/src/tasks/components/TaskForm.tsx
@@ -160,7 +160,6 @@ export default class TaskForm extends PureComponent<Props, State> {
                   <GetOrgResources<Bucket[]>
                     organization={this.toOrganization}
                     fetcher={getBuckets}
-                    orderBy={{keys: ['name']}}
                   >
                     {(buckets, loading) => (
                       <TaskOptionsBucketDropdown

--- a/ui/src/tasks/components/TaskForm.tsx
+++ b/ui/src/tasks/components/TaskForm.tsx
@@ -160,6 +160,7 @@ export default class TaskForm extends PureComponent<Props, State> {
                   <GetOrgResources<Bucket[]>
                     organization={this.toOrganization}
                     fetcher={getBuckets}
+                    orderBy={{keys: ['name']}}
                   >
                     {(buckets, loading) => (
                       <TaskOptionsBucketDropdown


### PR DESCRIPTION
Closes #11891

_Briefly describe your proposed changes:_
Adds ordering to labels and org resources

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
