### PR TITLE
Remove unnecessary search term from Variables filter

### DIFF
--- a/ui/src/organizations/components/Variables.tsx
+++ b/ui/src/organizations/components/Variables.tsx
@@ -71,7 +71,7 @@ export default class Variables extends PureComponent<Props, State> {
         </TabbedPageHeader>
         <FilterList<Variable>
           searchTerm={searchTerm}
-          searchKeys={['name', 'ruleString']}
+          searchKeys={['name']}
           list={variables}
         >
           {variables => (


### PR DESCRIPTION
This PR fixes an error when filtering variables.

  - [x] Rebased/mergeable
  - [x] Tests pass
