### PR TITLE
Enforce single org for series key reads

### DIFF
--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -140,35 +140,11 @@ func (c *Client) FindOrganization(ctx context.Context, filter influxdb.Organizat
 		return o, nil
 	}
 
-	filterFn := filterOrganizationsFn(filter)
-
-	var o *influxdb.Organization
-	err := c.db.View(func(tx *bolt.Tx) error {
-		return forEachOrganization(ctx, tx, func(org *influxdb.Organization) bool {
-			if filterFn(org) {
-				o = org
-				return false
-			}
-			return true
-		})
-	})
-
-	if err != nil {
-		return nil, &influxdb.Error{
-			Op:  op,
-			Err: err,
-		}
+	// If name and ID are not set, then, this is an invalid usage of the API.
+	return nil, &influxdb.Error{
+		Code: influxdb.EInvalid,
+		Msg:  "no filter parameters provided",
 	}
-
-	if o == nil {
-		return nil, &influxdb.Error{
-			Code: influxdb.ENotFound,
-			Op:   op,
-			Msg:  "organization not found",
-		}
-	}
-
-	return o, nil
 }
 
 func filterOrganizationsFn(filter influxdb.OrganizationFilter) func(o *influxdb.Organization) bool {

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -626,3 +626,8 @@ func (m *Launcher) TaskStore() taskbackend.Store {
 func (m *Launcher) TaskScheduler() taskbackend.Scheduler {
 	return m.scheduler
 }
+
+// KeyValueService returns the internal key-value service.
+func (m *Launcher) KeyValueService() *kv.Service {
+	return m.kvService
+}

--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -77,13 +77,11 @@ func TestLauncher_WriteAndQuery(t *testing.T) {
 	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
 		`,result,table,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v` + "\r\n\r\n"
 
-	var buf bytes.Buffer
-	req := (http.QueryRequest{Query: qs, Org: l.Org}).WithDefaults()
-	if preq, err := req.ProxyRequest(); err != nil {
-		t.Fatal(err)
-	} else if _, err := l.FluxService().Query(ctx, &buf, preq); err != nil {
-		t.Fatal(err)
-	} else if diff := cmp.Diff(buf.String(), exp); diff != "" {
+	buf, err := http.SimpleQuery(l.URL(), qs, l.Org.Name, l.Auth.Token)
+	if err != nil {
+		t.Fatalf("unexpected error querying server: %v", err)
+	}
+	if diff := cmp.Diff(string(buf), exp); diff != "" {
 		t.Fatal(diff)
 	}
 }
@@ -117,13 +115,11 @@ func TestLauncher_BucketDelete(t *testing.T) {
 	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
 		`,result,table,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v` + "\r\n\r\n"
 
-	var buf bytes.Buffer
-	req := (http.QueryRequest{Query: qs, Org: l.Org}).WithDefaults()
-	if preq, err := req.ProxyRequest(); err != nil {
-		t.Fatal(err)
-	} else if _, err := l.FluxService().Query(ctx, &buf, preq); err != nil {
-		t.Fatal(err)
-	} else if diff := cmp.Diff(buf.String(), exp); diff != "" {
+	buf, err := http.SimpleQuery(l.URL(), qs, l.Org.Name, l.Auth.Token)
+	if err != nil {
+		t.Fatalf("unexpected error querying server: %v", err)
+	}
+	if diff := cmp.Diff(string(buf), exp); diff != "" {
 		t.Fatal(diff)
 	}
 

--- a/cmd/influxd/launcher/storage_test.go
+++ b/cmd/influxd/launcher/storage_test.go
@@ -1,0 +1,89 @@
+package launcher_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/http"
+)
+
+func TestStorage_WriteAndQuery(t *testing.T) {
+	l := RunLauncherOrFail(t, ctx)
+
+	org1 := l.OnBoardOrFail(t, &influxdb.OnboardingRequest{
+		User:     "USER-1",
+		Password: "PASSWORD-1",
+		Org:      "ORG-01",
+		Bucket:   "BUCKET",
+	})
+	org2 := l.OnBoardOrFail(t, &influxdb.OnboardingRequest{
+		User:     "USER-2",
+		Password: "PASSWORD-1",
+		Org:      "ORG-02",
+		Bucket:   "BUCKET",
+	})
+
+	defer l.ShutdownOrFail(t, ctx)
+
+	// Execute single write against the server.
+	l.WriteOrFail(t, org1, `m,k=v1 f=100i 946684800000000000`)
+	l.WriteOrFail(t, org2, `m,k=v2 f=200i 946684800000000000`)
+
+	qs := `from(bucket:"BUCKET") |> range(start:2000-01-01T00:00:00Z,stop:2000-01-02T00:00:00Z)`
+
+	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
+		`,result,table,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v1` + "\r\n\r\n"
+	if got := l.FluxQueryOrFail(t, org1.Org, org1.Auth.Token, qs); !cmp.Equal(got, exp) {
+		t.Errorf("unexpected query results -got/+exp\n%s", cmp.Diff(got, exp))
+	}
+
+	exp = `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
+		`,result,table,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,200,f,m,v2` + "\r\n\r\n"
+	if got := l.FluxQueryOrFail(t, org2.Org, org2.Auth.Token, qs); !cmp.Equal(got, exp) {
+		t.Errorf("unexpected query results -got/+exp\n%s", cmp.Diff(got, exp))
+	}
+}
+
+// WriteOrFail attempts a write to the organization and bucket identified by to or fails if there is an error.
+func (l *Launcher) WriteOrFail(tb testing.TB, to *influxdb.OnboardingResults, data string) {
+	tb.Helper()
+	resp, err := nethttp.DefaultClient.Do(l.NewHTTPRequestOrFail(tb, "POST", fmt.Sprintf("/api/v2/write?org=%s&bucket=%s", to.Org.ID, to.Bucket.ID), to.Auth.Token, data))
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		tb.Fatal(err)
+	}
+
+	if resp.StatusCode != nethttp.StatusNoContent {
+		tb.Fatalf("unexpected status code: %d, body: %s, headers: %v", resp.StatusCode, body, resp.Header)
+	}
+}
+
+// FluxQueryOrFail performs a query to the specified organization and returns the results
+// or fails if there is an error.
+func (l *Launcher) FluxQueryOrFail(tb testing.TB, org *influxdb.Organization, token string, query string) string {
+	tb.Helper()
+	var buf bytes.Buffer
+
+	fs := &http.FluxService{Addr: l.URL(), Token: token}
+
+	req := (http.QueryRequest{Query: query, Org: org}).WithDefaults()
+	if preq, err := req.ProxyRequest(); err != nil {
+		tb.Fatal(err)
+	} else if _, err := fs.Query(ctx, &buf, preq); err != nil {
+		tb.Fatal(err)
+	}
+	return buf.String()
+}

--- a/cmd/influxd/launcher/storage_test.go
+++ b/cmd/influxd/launcher/storage_test.go
@@ -1,7 +1,6 @@
 package launcher_test
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	nethttp "net/http"
@@ -75,15 +74,11 @@ func (l *Launcher) WriteOrFail(tb testing.TB, to *influxdb.OnboardingResults, da
 // or fails if there is an error.
 func (l *Launcher) FluxQueryOrFail(tb testing.TB, org *influxdb.Organization, token string, query string) string {
 	tb.Helper()
-	var buf bytes.Buffer
 
-	fs := &http.FluxService{Addr: l.URL(), Token: token}
-
-	req := (http.QueryRequest{Query: query, Org: org}).WithDefaults()
-	if preq, err := req.ProxyRequest(); err != nil {
-		tb.Fatal(err)
-	} else if _, err := fs.Query(ctx, &buf, preq); err != nil {
+	b, err := http.SimpleQuery(l.URL(), query, org.Name, token)
+	if err != nil {
 		tb.Fatal(err)
 	}
-	return buf.String()
+
+	return string(b)
 }

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -305,7 +305,7 @@ func decodeGetOrgsRequest(ctx context.Context, r *http.Request) (*getOrgsRequest
 	qp := r.URL.Query()
 	req := &getOrgsRequest{}
 
-	if orgID := qp.Get("id"); orgID != "" {
+	if orgID := qp.Get(OrgID); orgID != "" {
 		id, err := influxdb.IDFromString(orgID)
 		if err != nil {
 			return nil, err
@@ -313,7 +313,7 @@ func decodeGetOrgsRequest(ctx context.Context, r *http.Request) (*getOrgsRequest
 		req.filter.ID = id
 	}
 
-	if name := qp.Get("name"); name != "" {
+	if name := qp.Get(OrgName); name != "" {
 		req.filter.Name = &name
 	}
 
@@ -586,6 +586,12 @@ func (s *OrganizationService) FindOrganizationByID(ctx context.Context, id influ
 
 // FindOrganization gets a single organization matching the filter using HTTP.
 func (s *OrganizationService) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+	if filter.ID == nil && filter.Name == nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "no filter parameters provided",
+		}
+	}
 	os, n, err := s.FindOrganizations(ctx, filter)
 	if err != nil {
 		return nil, &influxdb.Error{
@@ -614,10 +620,10 @@ func (s *OrganizationService) FindOrganizations(ctx context.Context, filter infl
 	qp := url.Query()
 
 	if filter.Name != nil {
-		qp.Add("name", *filter.Name)
+		qp.Add(OrgName, *filter.Name)
 	}
 	if filter.ID != nil {
-		qp.Add("id", filter.ID.String())
+		qp.Add(OrgID, filter.ID.String())
 	}
 	url.RawQuery = qp.Encode()
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2704,12 +2704,12 @@ paths:
             - application/vnd.flux
       - in: query
         name: org
-        description: specifies the name of the organization executing the query.
+        description: specifies the name of the organization executing the query; if both orgID and org are specified, orgID takes precendence.
         schema:
           type: string
       - in: query
         name: orgID
-        description: specifies the ID of the organization executing the query.
+        description: specifies the ID of the organization executing the query; if both orgID and org are specified, orgID takes precendence.
         schema:
           type: string
     requestBody:
@@ -3243,6 +3243,18 @@ paths:
       tags:
         - Organizations
       summary: List all organizations
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: query
+          name: org
+          schema:
+            type: string
+          description: filter organizations to a specific organization name
+        - in: query
+          name: orgID
+          schema:
+            type: string
+          description: filter organizations to a specific organization ID
       responses:
         '200':
           description: A list of organizations

--- a/kv/org.go
+++ b/kv/org.go
@@ -141,33 +141,11 @@ func (s *Service) FindOrganization(ctx context.Context, filter influxdb.Organiza
 		return s.FindOrganizationByName(ctx, *filter.Name)
 	}
 
-	filterFn := filterOrganizationsFn(filter)
-
-	var o *influxdb.Organization
-	err := s.kv.View(func(tx Tx) error {
-		return forEachOrganization(ctx, tx, func(org *influxdb.Organization) bool {
-			if filterFn(org) {
-				o = org
-				return false
-			}
-			return true
-		})
-	})
-
-	if err != nil {
-		return nil, &influxdb.Error{
-			Err: err,
-		}
+	// If name and ID are not set, then, this is an invalid usage of the API.
+	return nil, &influxdb.Error{
+		Code: influxdb.EInvalid,
+		Msg:  "no filter parameters provided",
 	}
-
-	if o == nil {
-		return nil, &influxdb.Error{
-			Code: influxdb.ENotFound,
-			Msg:  "organization not found",
-		}
-	}
-
-	return o, nil
 }
 
 func filterOrganizationsFn(filter influxdb.OrganizationFilter) func(o *influxdb.Organization) bool {

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -336,7 +336,8 @@ func (e *Engine) CreateSeriesCursor(ctx context.Context, req SeriesCursorRequest
 	if e.closing == nil {
 		return nil, ErrEngineClosed
 	}
-	return newSeriesCursor(req, e.index, cond)
+
+	return newSeriesCursor(req, e.index, e.sfile, cond)
 }
 
 // CreateCursorIterator creates a CursorIterator for usage with the read service.

--- a/storage/readservice/cursor.go
+++ b/storage/readservice/cursor.go
@@ -47,9 +47,6 @@ func newIndexSeriesCursor(ctx context.Context, src *readSource, req *datatypes.R
 	}
 	p := &indexSeriesCursor{row: reads.SeriesRow{Query: tsdb.CursorIterators{queries}}}
 
-	m := tsdb.EncodeName(platform.ID(src.OrganizationID), platform.ID(src.BucketID))
-	mi := tsdb.NewMeasurementSliceIterator([][]byte{m[:]})
-
 	if root := req.Predicate.GetRoot(); root != nil {
 		if p.cond, err = reads.NodeToExpr(root, nil); err != nil {
 			return nil, err
@@ -66,7 +63,10 @@ func newIndexSeriesCursor(ctx context.Context, src *readSource, req *datatypes.R
 		}
 	}
 
-	p.sqry, err = engine.CreateSeriesCursor(ctx, storage.SeriesCursorRequest{Measurements: mi}, opt.Condition)
+	scr := storage.SeriesCursorRequest{
+		Name: tsdb.EncodeName(platform.ID(src.OrganizationID), platform.ID(src.BucketID)),
+	}
+	p.sqry, err = engine.CreateSeriesCursor(ctx, scr, opt.Condition)
 	if err != nil {
 		p.Close()
 		return nil, err

--- a/storage/series_cursor_test.go
+++ b/storage/series_cursor_test.go
@@ -1,0 +1,38 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/tsdb"
+)
+
+func Test_NewSeriesCursor_UnexpectedOrg(t *testing.T) {
+	makeKey := func(org, bucket uint64) []byte {
+		name := tsdb.EncodeName(influxdb.ID(org), influxdb.ID(bucket))
+		return tsdb.AppendSeriesKey(nil, name[:], nil)
+	}
+
+	nm := tsdb.EncodeName(0x0f0f, 0xb0b0)
+	cur := &seriesCursor{
+		keys: [][]byte{
+			makeKey(0x0f0f, 0xb0b0),
+			makeKey(0xffff, 0xb0b0),
+		},
+		orgID: nm[:8],
+	}
+	_, err := cur.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = cur.Next()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !cmp.Equal(err.Error(), errUnexpectedOrg.Error()) {
+		t.Errorf("unexpected error -got/+exp\n%s", cmp.Diff(err.Error(), errUnexpectedOrg.Error()))
+	}
+}

--- a/storage/series_cursor_test.go
+++ b/storage/series_cursor_test.go
@@ -20,7 +20,8 @@ func Test_NewSeriesCursor_UnexpectedOrg(t *testing.T) {
 			makeKey(0x0f0f, 0xb0b0),
 			makeKey(0xffff, 0xb0b0),
 		},
-		orgID: nm[:8],
+		name: nm,
+		init: true,
 	}
 	_, err := cur.Next()
 	if err != nil {

--- a/testing/organization_service.go
+++ b/testing/organization_service.go
@@ -603,6 +603,7 @@ func FindOrganization(
 ) {
 	type args struct {
 		name string
+		id   platform.ID
 	}
 
 	type wants struct {
@@ -641,6 +642,48 @@ func FindOrganization(
 			},
 		},
 		{
+			name: "find organization in which no name filter matches should return no org",
+			args: args{
+				name: "unknown",
+			},
+			wants: wants{
+				err: &platform.Error{
+					Code: platform.ENotFound,
+					Op:   platform.OpFindOrganization,
+					Msg:  "organization name \"unknown\" not found",
+				},
+			},
+		},
+		{
+			name: "find organization in which no id filter matches should return no org",
+			args: args{
+				id: platform.ID(3),
+			},
+			wants: wants{
+				err: &platform.Error{
+					Code: platform.ENotFound,
+					Msg:  "organization not found",
+				},
+			},
+		},
+		{
+			name: "find organization no filter is set returns an error about filters not provided",
+			fields: OrganizationFields{
+				Organizations: []*platform.Organization{
+					{
+						ID:   MustIDBase16(orgOneID),
+						Name: "o1",
+					},
+				},
+			},
+			wants: wants{
+				err: &platform.Error{
+					Code: platform.EInvalid,
+					Msg:  "no filter parameters provided",
+				},
+			},
+		},
+		{
 			name: "missing organization returns error",
 			fields: OrganizationFields{
 				Organizations: []*platform.Organization{},
@@ -666,6 +709,9 @@ func FindOrganization(
 			filter := platform.OrganizationFilter{}
 			if tt.args.name != "" {
 				filter.Name = &tt.args.name
+			}
+			if tt.args.id != platform.InvalidID() {
+				filter.ID = &tt.args.id
 			}
 
 			organization, err := s.FindOrganization(ctx, filter)


### PR DESCRIPTION
_Briefly describe your proposed changes:_

These changes modify the parameters to a series cursor request and render the intent explicitly; series keys returned by the cursor must never cross organization boundaries.

* `SeriesCursorRequest` takes a single `Name` parameter, specifying the 16-byte tsdb encoded org and bucket ID
* `seriesCursor` ensures the first 8 bytes of the measurement name returned from the series index matches the current organization ID

**Blocked by #12010**
