### PR TITLE
Create a generic dropdown for creating/importing a resource

### DIFF
--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -9,7 +9,7 @@ import DashboardsIndexContents from 'src/dashboards/components/dashboard_index/D
 import {Page} from 'src/pageLayout'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import {OverlayTechnology} from 'src/clockface'
-import CreateDashboardDropdown from 'src/dashboards/components/dashboard_index/CreateDashboardDropdown'
+import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 import ImportOverlay from 'src/shared/components/ImportOverlay'
 import ExportOverlay from 'src/shared/components/ExportOverlay'
 import EditLabelsOverlay from 'src/shared/components/EditLabelsOverlay'
@@ -119,9 +119,10 @@ class DashboardIndex extends PureComponent<Props, State> {
                 placeholderText="Filter dashboards by name..."
                 onSearch={this.filterDashboards}
               />
-              <CreateDashboardDropdown
-                onNewDashboard={this.handleCreateDashboard}
-                onToggleOverlay={this.handleToggleImportOverlay}
+              <AddResourceDropdown
+                onSelectNew={this.handleCreateDashboard}
+                onSelectImport={this.handleToggleImportOverlay}
+                resourceName="Dashboard"
               />
             </Page.Header.Right>
           </Page.Header>

--- a/ui/src/shared/components/AddResourceDropdown.tsx
+++ b/ui/src/shared/components/AddResourceDropdown.tsx
@@ -8,14 +8,10 @@ import {Dropdown, DropdownMode} from 'src/clockface'
 // Types
 import {IconFont, ComponentColor, ComponentSize} from '@influxdata/clockface'
 
-enum CreateOption {
-  New = 'New Dashboard',
-  Import = 'Import Dashboard',
-}
-
 interface Props {
-  onNewDashboard: () => void
-  onToggleOverlay: () => void
+  onSelectNew: () => void
+  onSelectImport: () => void
+  resourceName: string
 }
 
 export default class CreateDashboardDropdown extends PureComponent<Props> {
@@ -23,7 +19,7 @@ export default class CreateDashboardDropdown extends PureComponent<Props> {
     return (
       <Dropdown
         mode={DropdownMode.ActionList}
-        titleText={'Create Dashboard'}
+        titleText={`Create ${this.props.resourceName}`}
         icon={IconFont.Plus}
         buttonColor={ComponentColor.Primary}
         buttonSize={ComponentSize.Small}
@@ -38,22 +34,37 @@ export default class CreateDashboardDropdown extends PureComponent<Props> {
   private get optionItems(): JSX.Element[] {
     return [
       <Dropdown.Item
-        id={CreateOption.New}
-        key={CreateOption.New}
-        value={CreateOption.New}
+        id={this.newOption}
+        key={this.newOption}
+        value={this.newOption}
       >
-        {CreateOption.New}
+        {this.newOption}
+      </Dropdown.Item>,
+      <Dropdown.Item
+        id={this.importOption}
+        key={this.importOption}
+        value={this.importOption}
+      >
+        {this.importOption}
       </Dropdown.Item>,
     ]
   }
 
-  private handleSelect = (selection: CreateOption): void => {
-    const {onNewDashboard, onToggleOverlay} = this.props
+  private get newOption(): string {
+    return `New ${this.props.resourceName}`
+  }
+
+  private get importOption(): string {
+    return `Import ${this.props.resourceName}`
+  }
+
+  private handleSelect = (selection: string): void => {
+    const {onSelectNew, onSelectImport} = this.props
     switch (selection) {
-      case CreateOption.New:
-        onNewDashboard()
-      case CreateOption.Import:
-        onToggleOverlay()
+      case this.newOption:
+        onSelectNew()
+      case this.importOption:
+        onSelectImport()
     }
   }
 }


### PR DESCRIPTION
Closes #11913

This PR creates a new component, `AddResourceDropdown`. This component takes in a string `resource` and two functions, `onSelectNew` and `onSelectImport`. From this dropdown, the user can create a new resource by either creating it from scratch or by importing it.

<img width="254" alt="screen shot 2019-02-15 at 12 53 20 pm" src="https://user-images.githubusercontent.com/15273162/52883691-b2345780-3120-11e9-80c5-cb18317d2959.png">


  - [x] Rebased/mergeable
  - [x] Tests pass
