### PR TITLE
refactor(task): remove explicit org from run/log lookup

### DIFF
--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -378,7 +378,6 @@ func taskDeleteF(cmd *cobra.Command, args []string) error {
 type TaskLogFindFlags struct {
 	taskID string
 	runID  string
-	orgID  string
 }
 
 var taskLogFindFlags TaskLogFindFlags
@@ -392,7 +391,6 @@ func init() {
 
 	taskLogFindCmd.Flags().StringVarP(&taskLogFindFlags.taskID, "task-id", "", "", "task id (required)")
 	taskLogFindCmd.Flags().StringVarP(&taskLogFindFlags.runID, "run-id", "", "", "run id")
-	taskLogFindCmd.Flags().StringVarP(&taskLogFindFlags.orgID, "org-id", "", "", "organization id")
 	taskLogFindCmd.MarkFlagRequired("task-id")
 
 	logCmd.AddCommand(taskLogFindCmd)
@@ -409,7 +407,7 @@ func taskLogFindF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	filter.Task = id
+	filter.Task = *id
 
 	if taskLogFindFlags.runID != "" {
 		id, err := platform.IDFromString(taskLogFindFlags.runID)
@@ -417,14 +415,6 @@ func taskLogFindF(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		filter.Run = id
-	}
-
-	if taskLogFindFlags.orgID != "" {
-		id, err := platform.IDFromString(taskLogFindFlags.orgID)
-		if err != nil {
-			return err
-		}
-		filter.Org = id
 	}
 
 	ctx := context.TODO()
@@ -451,7 +441,6 @@ func taskLogFindF(cmd *cobra.Command, args []string) error {
 type TaskRunFindFlags struct {
 	runID      string
 	taskID     string
-	orgID      string
 	afterTime  string
 	beforeTime string
 	limit      int
@@ -468,13 +457,11 @@ func init() {
 
 	taskRunFindCmd.Flags().StringVarP(&taskRunFindFlags.taskID, "task-id", "", "", "task id (required)")
 	taskRunFindCmd.Flags().StringVarP(&taskRunFindFlags.runID, "run-id", "", "", "run id")
-	taskRunFindCmd.Flags().StringVarP(&taskRunFindFlags.orgID, "org-id", "", "", "organization id")
 	taskRunFindCmd.Flags().StringVarP(&taskRunFindFlags.afterTime, "after", "", "", "after time for filtering")
 	taskRunFindCmd.Flags().StringVarP(&taskRunFindFlags.beforeTime, "before", "", "", "before time for filtering")
 	taskRunFindCmd.Flags().IntVarP(&taskRunFindFlags.limit, "limit", "", 0, "limit the results")
 
 	taskRunFindCmd.MarkFlagRequired("task-id")
-	taskRunFindCmd.MarkFlagRequired("org-id")
 
 	runCmd.AddCommand(taskRunFindCmd)
 }
@@ -494,13 +481,7 @@ func taskRunFindF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	filter.Task = taskID
-
-	orgID, err := platform.IDFromString(taskRunFindFlags.orgID)
-	if err != nil {
-		return err
-	}
-	filter.Org = orgID
+	filter.Task = *taskID
 
 	var runs []*platform.Run
 	if taskRunFindFlags.runID != "" {
@@ -508,7 +489,7 @@ func taskRunFindF(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		run, err := s.FindRunByID(context.Background(), *filter.Org, *id)
+		run, err := s.FindRunByID(context.Background(), filter.Task, *id)
 		if err != nil {
 			return err
 		}

--- a/cmd/influxd/launcher/tasks_test.go
+++ b/cmd/influxd/launcher/tasks_test.go
@@ -122,7 +122,7 @@ from(bucket:"my_bucket_in") |> range(start:-5m) |> to(bucket:"%s", org:"%s")`, b
 		}
 		time.Sleep(5 * time.Millisecond)
 
-		runs, _, err := be.TaskService().FindRuns(ctx, influxdb.RunFilter{Org: &org.ID, Task: &created.ID, Limit: 1})
+		runs, _, err := be.TaskService().FindRuns(ctx, influxdb.RunFilter{Task: created.ID, Limit: 1})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -219,7 +219,7 @@ from(bucket:"my_bucket_in") |> range(start:-5m) |> to(bucket:"%s", org:"%s")`, b
 	})
 
 	// now lets see a logs
-	logs, _, err := be.TaskService().FindLogs(ctx, influxdb.LogFilter{Org: &org.ID, Task: &created.ID, Run: &targetRun.ID})
+	logs, _, err := be.TaskService().FindLogs(ctx, influxdb.LogFilter{Task: created.ID, Run: &targetRun.ID})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -440,7 +440,7 @@ func TestTaskHandler_handleGetRuns(t *testing.T) {
 						runs := []*platform.Run{
 							{
 								ID:           platform.ID(2),
-								TaskID:       *f.Task,
+								TaskID:       f.Task,
 								Status:       "success",
 								ScheduledFor: "2018-12-01T17:00:13Z",
 								StartedAt:    "2018-12-01T17:00:03.155645Z",
@@ -617,7 +617,7 @@ func TestTaskHandler_NotFoundStatus(t *testing.T) {
 			name: "get task logs",
 			svc: &mock.TaskService{
 				FindLogsFn: func(_ context.Context, f platform.LogFilter) ([]*platform.Log, int, error) {
-					if *f.Task == taskID {
+					if f.Task == taskID {
 						return nil, 0, nil
 					}
 
@@ -633,7 +633,7 @@ func TestTaskHandler_NotFoundStatus(t *testing.T) {
 			name: "get run logs",
 			svc: &mock.TaskService{
 				FindLogsFn: func(_ context.Context, f platform.LogFilter) ([]*platform.Log, int, error) {
-					if *f.Task != taskID {
+					if f.Task != taskID {
 						return nil, 0, backend.ErrTaskNotFound
 					}
 					if *f.Run != runID {
@@ -652,7 +652,7 @@ func TestTaskHandler_NotFoundStatus(t *testing.T) {
 			name: "get runs",
 			svc: &mock.TaskService{
 				FindRunsFn: func(_ context.Context, f platform.RunFilter) ([]*platform.Run, int, error) {
-					if *f.Task != taskID {
+					if f.Task != taskID {
 						return nil, 0, backend.ErrTaskNotFound
 					}
 

--- a/task.go
+++ b/task.go
@@ -251,17 +251,20 @@ type TaskFilter struct {
 
 // RunFilter represents a set of filters that restrict the returned results
 type RunFilter struct {
-	Org        *ID
-	Task       *ID
+	// Task ID is required for listing runs.
+	Task ID
+
 	After      *ID
 	Limit      int
 	AfterTime  string
 	BeforeTime string
 }
 
-// LogFilter represents a set of filters that restrict the returned results
+// LogFilter represents a set of filters that restrict the returned log results.
 type LogFilter struct {
-	Org  *ID
-	Task *ID
-	Run  *ID
+	// Task ID is required.
+	Task ID
+
+	// The optional Run ID limits logs to a single run.
+	Run *ID
 }

--- a/task/backend/inmem_logreaderwriter.go
+++ b/task/backend/inmem_logreaderwriter.go
@@ -10,14 +10,20 @@ import (
 	platform "github.com/influxdata/influxdb"
 )
 
+// orgtask is used as a key for storing runs by org and task ID.
+// This is only relevant for the in-memory run store.
+type orgtask struct {
+	o, t platform.ID
+}
+
 type runReaderWriter struct {
-	mu       sync.RWMutex
-	byTaskID map[string][]*platform.Run
-	byRunID  map[string]*platform.Run
+	mu        sync.RWMutex
+	byOrgTask map[orgtask][]*platform.Run
+	byRunID   map[string]*platform.Run
 }
 
 func NewInMemRunReaderWriter() *runReaderWriter {
-	return &runReaderWriter{byRunID: map[string]*platform.Run{}, byTaskID: map[string][]*platform.Run{}}
+	return &runReaderWriter{byRunID: map[string]*platform.Run{}, byOrgTask: map[orgtask][]*platform.Run{}}
 }
 
 func (r *runReaderWriter) UpdateRunState(ctx context.Context, rlb RunLogBase, when time.Time, status RunStatus) error {
@@ -48,8 +54,8 @@ func (r *runReaderWriter) UpdateRunState(ctx context.Context, rlb RunLogBase, wh
 		}
 		timeSetter(run)
 		r.byRunID[ridStr] = run
-		tidStr := rlb.Task.ID.String()
-		r.byTaskID[tidStr] = append(r.byTaskID[tidStr], run)
+		ot := orgtask{o: rlb.Task.Org, t: rlb.Task.ID}
+		r.byOrgTask[ot] = append(r.byOrgTask[ot], run)
 		return nil
 	}
 
@@ -75,15 +81,15 @@ func (r *runReaderWriter) AddRunLog(ctx context.Context, rlb RunLogBase, when ti
 	return nil
 }
 
-func (r *runReaderWriter) ListRuns(ctx context.Context, runFilter platform.RunFilter) ([]*platform.Run, error) {
+func (r *runReaderWriter) ListRuns(ctx context.Context, orgID platform.ID, runFilter platform.RunFilter) ([]*platform.Run, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	if runFilter.Task == nil {
+	if !runFilter.Task.Valid() {
 		return nil, errors.New("task is required")
 	}
 
-	ex, ok := r.byTaskID[runFilter.Task.String()]
+	ex, ok := r.byOrgTask[orgtask{o: orgID, t: runFilter.Task}]
 	if !ok {
 		return nil, ErrRunNotFound
 	}
@@ -129,12 +135,12 @@ func (r *runReaderWriter) FindRunByID(ctx context.Context, orgID, runID platform
 	return &rtnRun, nil
 }
 
-func (r *runReaderWriter) ListLogs(ctx context.Context, logFilter platform.LogFilter) ([]platform.Log, error) {
+func (r *runReaderWriter) ListLogs(ctx context.Context, orgID platform.ID, logFilter platform.LogFilter) ([]platform.Log, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	if logFilter.Task == nil && logFilter.Run == nil {
-		return nil, errors.New("task or run is required")
+	if !logFilter.Task.Valid() {
+		return nil, errors.New("task ID required")
 	}
 
 	if logFilter.Run != nil {
@@ -142,12 +148,19 @@ func (r *runReaderWriter) ListLogs(ctx context.Context, logFilter platform.LogFi
 		if !ok {
 			return nil, ErrRunNotFound
 		}
+		// TODO(mr): validate that task ID matches, if task is also set. Needs test.
 		return []platform.Log{run.Log}, nil
 	}
 
-	logs := []platform.Log{}
-	for _, run := range r.byTaskID[logFilter.Task.String()] {
+	var logs []platform.Log
+	ot := orgtask{o: orgID, t: logFilter.Task}
+	for _, run := range r.byOrgTask[ot] {
 		logs = append(logs, run.Log)
 	}
+
+	if len(logs) == 0 {
+		return nil, errors.New("no matching runs found")
+	}
+
 	return logs, nil
 }

--- a/task/backend/store.go
+++ b/task/backend/store.go
@@ -329,6 +329,8 @@ type LogWriter interface {
 // This is useful for test, but not much else.
 type NopLogWriter struct{}
 
+var _ LogWriter = NopLogWriter{}
+
 func (NopLogWriter) UpdateRunState(context.Context, RunLogBase, time.Time, RunStatus) error {
 	return nil
 }
@@ -340,21 +342,25 @@ func (NopLogWriter) AddRunLog(context.Context, RunLogBase, time.Time, string) er
 // LogReader reads log information and log data from a store.
 type LogReader interface {
 	// ListRuns returns a list of runs belonging to a task.
-	ListRuns(ctx context.Context, runFilter platform.RunFilter) ([]*platform.Run, error)
+	// orgID is necessary to look in the correct system bucket.
+	ListRuns(ctx context.Context, orgID platform.ID, runFilter platform.RunFilter) ([]*platform.Run, error)
 
 	// FindRunByID finds a run given a orgID and runID.
 	// orgID is necessary to look in the correct system bucket.
 	FindRunByID(ctx context.Context, orgID, runID platform.ID) (*platform.Run, error)
 
 	// ListLogs lists logs for a task or a specified run of a task.
-	ListLogs(ctx context.Context, logFilter platform.LogFilter) ([]platform.Log, error)
+	// orgID is necessary to look in the correct system bucket.
+	ListLogs(ctx context.Context, orgID platform.ID, logFilter platform.LogFilter) ([]platform.Log, error)
 }
 
-// NopLogWriter is a LogWriter that doesn't do anything when its methods are called.
+// NopLogReader is a LogReader that doesn't do anything when its methods are called.
 // This is useful for test, but not much else.
 type NopLogReader struct{}
 
-func (NopLogReader) ListRuns(ctx context.Context, runFilter platform.RunFilter) ([]*platform.Run, error) {
+var _ LogReader = NopLogReader{}
+
+func (NopLogReader) ListRuns(ctx context.Context, orgID platform.ID, runFilter platform.RunFilter) ([]*platform.Run, error) {
 	return nil, nil
 }
 
@@ -362,7 +368,7 @@ func (NopLogReader) FindRunByID(ctx context.Context, orgID, runID platform.ID) (
 	return nil, nil
 }
 
-func (NopLogReader) ListLogs(ctx context.Context, logFilter platform.LogFilter) ([]platform.Log, error) {
+func (NopLogReader) ListLogs(ctx context.Context, orgID platform.ID, logFilter platform.LogFilter) ([]platform.Log, error) {
 	return nil, nil
 }
 

--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -230,7 +230,12 @@ func (p pAdapter) DeleteTask(ctx context.Context, id platform.ID) error {
 }
 
 func (p pAdapter) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
-	logs, err := p.r.ListLogs(ctx, filter)
+	task, err := p.s.FindTaskByID(ctx, filter.Task)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	logs, err := p.r.ListLogs(ctx, task.Org, filter)
 	logPointers := make([]*platform.Log, len(logs))
 	for i := range logs {
 		logPointers[i] = &logs[i]
@@ -239,7 +244,12 @@ func (p pAdapter) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*p
 }
 
 func (p pAdapter) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
-	runs, err := p.r.ListRuns(ctx, filter)
+	task, err := p.s.FindTaskByID(ctx, filter.Task)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	runs, err := p.r.ListRuns(ctx, task.Org, filter)
 	return runs, len(runs), err
 }
 

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -462,7 +462,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 		}
 
 		// Limit 1 should only return the earlier run.
-		runs, _, err := sys.ts.FindRuns(sys.Ctx, platform.RunFilter{Org: &cr.OrgID, Task: &task.ID, Limit: 1})
+		runs, _, err := sys.ts.FindRuns(sys.Ctx, platform.RunFilter{Task: task.ID, Limit: 1})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -483,7 +483,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 		}
 
 		// Unspecified limit returns both runs.
-		runs, _, err = sys.ts.FindRuns(sys.Ctx, platform.RunFilter{Org: &cr.OrgID, Task: &task.ID})
+		runs, _, err = sys.ts.FindRuns(sys.Ctx, platform.RunFilter{Task: task.ID})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -745,9 +745,8 @@ func testTaskRuns(t *testing.T, sys *System) {
 		}
 
 		// Ensure it is returned when filtering logs by run ID.
-		logs, err := sys.LR.ListLogs(sys.Ctx, platform.LogFilter{
-			Org:  &cr.OrgID,
-			Task: &task.ID,
+		logs, err := sys.LR.ListLogs(sys.Ctx, cr.OrgID, platform.LogFilter{
+			Task: task.ID,
 			Run:  &rc1.Created.RunID,
 		})
 		if err != nil {
@@ -767,9 +766,8 @@ func testTaskRuns(t *testing.T, sys *System) {
 		}
 
 		// Ensure both returned when filtering logs by task ID.
-		logs, err = sys.LR.ListLogs(sys.Ctx, platform.LogFilter{
-			Org:  &cr.OrgID,
-			Task: &task.ID,
+		logs, err = sys.LR.ListLogs(sys.Ctx, cr.OrgID, platform.LogFilter{
+			Task: task.ID,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/task/validator_test.go
+++ b/task/validator_test.go
@@ -323,7 +323,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.OrgsResourceType, OrgID: &taskID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindLogs(ctx, influxdb.LogFilter{
-					Org: &orgID,
+					Task: taskID,
 				})
 				if err == nil {
 					return errors.New("returned no error with a invalid auth")
@@ -336,16 +336,8 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindLogs(ctx, influxdb.LogFilter{
-					Org: &orgID,
+					Task: taskID,
 				})
-				return err
-			},
-		},
-		{
-			name: "FindLogs without org",
-			auth: &influxdb.Authorization{Status: "active"},
-			check: func(ctx context.Context, svc influxdb.TaskService) error {
-				_, _, err := svc.FindLogs(ctx, influxdb.LogFilter{})
 				return err
 			},
 		},
@@ -354,7 +346,7 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.OrgsResourceType, OrgID: &taskID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindRuns(ctx, influxdb.RunFilter{
-					Org: &orgID,
+					Task: taskID,
 				})
 				if err == nil {
 					return errors.New("returned no error with a invalid auth")
@@ -367,16 +359,8 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 			auth: &influxdb.Authorization{Status: "active", Permissions: []influxdb.Permission{influxdb.Permission{Action: influxdb.ReadAction, Resource: influxdb.Resource{Type: influxdb.TasksResourceType, OrgID: &orgID}}}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				_, _, err := svc.FindRuns(ctx, influxdb.RunFilter{
-					Org: &orgID,
+					Task: taskID,
 				})
-				return err
-			},
-		},
-		{
-			name: "FindRuns without org",
-			auth: &influxdb.Authorization{Status: "active"},
-			check: func(ctx context.Context, svc influxdb.TaskService) error {
-				_, _, err := svc.FindRuns(ctx, influxdb.RunFilter{})
 				return err
 			},
 		},
@@ -469,5 +453,4 @@ from(bucket:"cows") |> range(start:-5m) |> to(bucket:"cows", org:"thing")`
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
Task ID is now a required value on run and log filters. It was
effectively required by all implementations before anyway, so now those
types reflect that requirement.

Organization ID was removed from those same fields. The TaskService
looks up the organization ID via the task in cases where we need it at a
lower layer.

Closes #11807.