### PR TITLE
fix(ui): add label from resource labels editor

### DIFF
--- a/ui/src/clockface/components/label/LabelSelector.scss
+++ b/ui/src/clockface/components/label/LabelSelector.scss
@@ -28,22 +28,13 @@
 .label-selector--menu {
   width: 100%;
   min-height: 50px;
+  margin: $ix-marg-b;
 }
 
 .label-selector--menu-item {
-  padding: $ix-marg-a $ix-marg-b;
-  color: $g13-mist;
-  transition: color 0.25s ease, background-color 0.25s ease;
-  
-  &.active,
-  &.active:hover {
-    cursor: pointer;
-    color: $g18-cloud;
-    background-color: $g6-smoke;
-  }
+  margin: 1px;
 }
 
-.label-selector--description,
 .label-selector--empty {
   font-size: 13px;
   font-weight: 500;
@@ -61,15 +52,10 @@
   line-height: 30px;
 }
 
-.label-selector--description {
-  margin-left: 6px;
-  color: $g13-mist;
-  flex: 2 0 50%;
-}
-
-.label-selector--bottom {
+.label-selector--selection {
   display: flex;
   flex-wrap: nowrap;
+  margin-bottom: $ix-marg-c;
 }
 
 .label-selector--remove-all {

--- a/ui/src/clockface/components/label/LabelSelector.scss
+++ b/ui/src/clockface/components/label/LabelSelector.scss
@@ -27,14 +27,10 @@
 
 .label-selector--menu {
   width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  min-height: 50px;
 }
 
 .label-selector--menu-item {
-  display: flex;
-  align-items: center;
   padding: $ix-marg-a $ix-marg-b;
   color: $g13-mist;
   transition: color 0.25s ease, background-color 0.25s ease;
@@ -45,10 +41,6 @@
     color: $g18-cloud;
     background-color: $g6-smoke;
   }
-}
-
-.label-selector--label {
-  flex: 4 0 0
 }
 
 .label-selector--description,

--- a/ui/src/clockface/components/label/LabelSelector.tsx
+++ b/ui/src/clockface/components/label/LabelSelector.tsx
@@ -2,6 +2,9 @@
 import React, {Component, ChangeEvent, KeyboardEvent} from 'react'
 import _ from 'lodash'
 
+// APIs
+import {client} from 'src/utils/api'
+
 // Components
 import {Button} from '@influxdata/clockface'
 import Input from 'src/clockface/components/inputs/Input'
@@ -12,7 +15,7 @@ import {ClickOutside} from 'src/shared/components/ClickOutside'
 
 // Types
 import {ComponentSize} from 'src/clockface/types'
-import {Label as LabelAPI} from '@influxdata/influx'
+import {Label as APILabel} from 'src/types/v2/labels'
 
 // Styles
 import './LabelSelector.scss'
@@ -25,18 +28,19 @@ enum ArrowDirection {
 }
 
 interface Props {
-  selectedLabels: LabelAPI[]
-  allLabels: LabelAPI[]
-  onAddLabel: (label: LabelAPI) => void
-  onRemoveLabel: (label: LabelAPI) => void
+  selectedLabels: APILabel[]
+  allLabels: APILabel[]
+  onAddLabel: (label: APILabel) => void
+  onRemoveLabel: (label: APILabel) => void
   onRemoveAllLabels: () => void
+  onCreateLabel: (label: APILabel) => void
   resourceType: string
   inputSize?: ComponentSize
 }
 
 interface State {
   filterValue: string
-  filteredLabels: LabelAPI[]
+  filteredLabels: APILabel[]
   isSuggesting: boolean
   highlightedID: string
 }
@@ -64,31 +68,21 @@ class LabelSelector extends Component<Props, State> {
     }
   }
 
-  public render() {
-    const {resourceType, inputSize} = this.props
-    const {filterValue} = this.state
+  public componentDidMount() {
+    this.handleStartSuggesting()
+  }
 
+  public render() {
     return (
-      <div className="label-selector">
-        <ClickOutside onClickOutside={this.handleStopSuggesting}>
-          <div className="label-selector--input">
-            <Input
-              placeholder={`Add labels to ${resourceType}`}
-              value={filterValue}
-              onFocus={this.handleStartSuggesting}
-              onKeyDown={this.handleKeyDown}
-              onChange={this.handleInputChange}
-              size={inputSize}
-              autoFocus={true}
-            />
-            {this.suggestionMenu}
+      <ClickOutside onClickOutside={this.handleStopSuggesting}>
+        <div className="label-selector">
+          {this.input}
+          <div className="label-selector--bottom">
+            {this.selectedLabels}
+            {this.clearSelectedButton}
           </div>
-        </ClickOutside>
-        <div className="label-selector--bottom">
-          {this.selectedLabels}
-          {this.clearSelectedButton}
         </div>
-      </div>
+      </ClickOutside>
     )
   }
 
@@ -121,21 +115,43 @@ class LabelSelector extends Component<Props, State> {
 
   private get suggestionMenu(): JSX.Element {
     const {allLabels, selectedLabels} = this.props
-    const {isSuggesting, highlightedID} = this.state
+    const {isSuggesting, highlightedID, filterValue} = this.state
 
     const allLabelsUsed = allLabels.length === selectedLabels.length
 
     if (isSuggesting) {
       return (
         <LabelSelectorMenu
+          filterValue={filterValue}
           allLabelsUsed={allLabelsUsed}
           filteredLabels={this.availableLabels}
           highlightItemID={highlightedID}
           onItemClick={this.handleAddLabel}
           onItemHighlight={this.handleItemHighlight}
+          onCreateLabel={this.handleCreateLabel}
         />
       )
     }
+  }
+
+  private get input(): JSX.Element {
+    const {resourceType, inputSize} = this.props
+    const {filterValue} = this.state
+
+    return (
+      <div className="label-selector--input">
+        <Input
+          placeholder={`Add labels to ${resourceType}`}
+          value={filterValue}
+          onFocus={this.handleStartSuggesting}
+          onKeyDown={this.handleKeyDown}
+          onChange={this.handleInputChange}
+          size={inputSize}
+          autoFocus={true}
+        />
+        {this.suggestionMenu}
+      </div>
+    )
   }
 
   private handleAddLabel = (labelID: string): void => {
@@ -184,20 +200,7 @@ class LabelSelector extends Component<Props, State> {
     )
 
     const filteredLabels = availableLabels.filter(label => {
-      const filterChars = _.lowerCase(filterValue)
-        .replace(/\s/g, '')
-        .split('')
-      const labelChars = _.lowerCase(label.name)
-        .replace(/\s/g, '')
-        .split('')
-
-      const overlap = _.difference(filterChars, labelChars)
-
-      if (overlap.length) {
-        return false
-      }
-
-      return true
+      return label.name.includes(filterValue)
     })
 
     const highlightedIDAvailable = filteredLabels.find(
@@ -208,10 +211,19 @@ class LabelSelector extends Component<Props, State> {
       highlightedID = filteredLabels[0].name
     }
 
+    if (filterValue.length === 0) {
+      return this.setState({
+        isSuggesting: true,
+        filteredLabels: this.props.allLabels,
+        highlightedID: null,
+        filterValue: '',
+      })
+    }
+
     this.setState({filterValue, filteredLabels, highlightedID})
   }
 
-  private get availableLabels(): LabelAPI[] {
+  private get availableLabels(): APILabel[] {
     const {selectedLabels} = this.props
     const {filteredLabels} = this.state
 
@@ -287,6 +299,12 @@ class LabelSelector extends Component<Props, State> {
         onClick={onRemoveAllLabels}
       />
     )
+  }
+
+  private handleCreateLabel = async (label: APILabel) => {
+    const newLabel = await client.labels.create(label.name, label.properties)
+    this.props.onAddLabel(newLabel)
+    this.handleStopSuggesting()
   }
 }
 

--- a/ui/src/clockface/components/label/LabelSelector.tsx
+++ b/ui/src/clockface/components/label/LabelSelector.tsx
@@ -76,11 +76,11 @@ class LabelSelector extends Component<Props, State> {
     return (
       <ClickOutside onClickOutside={this.handleStopSuggesting}>
         <div className="label-selector">
-          {this.input}
-          <div className="label-selector--bottom">
+          <div className="label-selector--selection">
             {this.selectedLabels}
             {this.clearSelectedButton}
           </div>
+          {this.input}
         </div>
       </ClickOutside>
     )

--- a/ui/src/clockface/components/label/LabelSelectorMenu.tsx
+++ b/ui/src/clockface/components/label/LabelSelectorMenu.tsx
@@ -5,19 +5,22 @@ import _ from 'lodash'
 // Components
 import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
 import LabelSelectorMenuItem from 'src/clockface/components/label/LabelSelectorMenuItem'
+import ResourceLabelForm from 'src/shared/components/ResourceLabelForm'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Label} from '@influxdata/influx'
+import {Label} from 'src/types/v2/labels'
 
 interface Props {
+  filterValue: string
   highlightItemID: string
   filteredLabels: Label[]
   onItemClick: (labelID: string) => void
   onItemHighlight: (labelID: string) => void
   allLabelsUsed: boolean
+  onCreateLabel: (label: Label) => Promise<void>
 }
 
 @ErrorHandling
@@ -26,7 +29,10 @@ class LabelSelectorMenu extends Component<Props> {
     return (
       <div className="label-selector--menu-container">
         <FancyScrollbar autoHide={false} autoHeight={true} maxHeight={250}>
-          <div className="label-selector--menu">{this.menuItems}</div>
+          <div className="label-selector--menu">
+            {this.resourceLabelForm}
+            {this.menuItems}
+          </div>
         </FancyScrollbar>
       </div>
     )
@@ -66,6 +72,18 @@ class LabelSelectorMenu extends Component<Props> {
     }
 
     return 'No labels match your query'
+  }
+
+  private get resourceLabelForm(): JSX.Element {
+    const {filterValue, onCreateLabel, filteredLabels} = this.props
+
+    if (!filterValue || filteredLabels.find(l => l.name === filterValue)) {
+      return
+    }
+
+    return (
+      <ResourceLabelForm labelName={filterValue} onSubmit={onCreateLabel} />
+    )
   }
 }
 

--- a/ui/src/clockface/components/label/LabelSelectorMenuItem.tsx
+++ b/ui/src/clockface/components/label/LabelSelectorMenuItem.tsx
@@ -23,7 +23,11 @@ class LabelSelectorMenuItem extends Component<Props> {
     const {name, colorHex, description, id} = this.props
 
     return (
-      <span onMouseOver={this.handleMouseOver} onClick={this.handleClick}>
+      <span
+        className="label-selector--menu-item"
+        onMouseOver={this.handleMouseOver}
+        onClick={this.handleClick}
+      >
         <Label
           name={name}
           description={description}

--- a/ui/src/clockface/components/label/LabelSelectorMenuItem.tsx
+++ b/ui/src/clockface/components/label/LabelSelectorMenuItem.tsx
@@ -24,21 +24,14 @@ class LabelSelectorMenuItem extends Component<Props> {
     const {name, colorHex, description, id} = this.props
 
     return (
-      <div
-        className={this.className}
-        onMouseOver={this.handleMouseOver}
-        onClick={this.handleClick}
-      >
-        <div className="label-selector--label">
-          <Label
-            name={name}
-            description={description}
-            id={id}
-            colorHex={colorHex}
-          />
-        </div>
-        <div className="label-selector--description">{description}</div>
-      </div>
+      <span onMouseOver={this.handleMouseOver} onClick={this.handleClick}>
+        <Label
+          name={name}
+          description={description}
+          id={id}
+          colorHex={colorHex}
+        />
+      </span>
     )
   }
 

--- a/ui/src/clockface/components/label/LabelSelectorMenuItem.tsx
+++ b/ui/src/clockface/components/label/LabelSelectorMenuItem.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {Component} from 'react'
-import classnames from 'classnames'
 import _ from 'lodash'
 
 // Components
@@ -33,12 +32,6 @@ class LabelSelectorMenuItem extends Component<Props> {
         />
       </span>
     )
-  }
-
-  private get className(): string {
-    const {highlighted} = this.props
-
-    return classnames('label-selector--menu-item', {active: highlighted})
   }
 
   private handleMouseOver = (): void => {

--- a/ui/src/configuration/components/RandomLabelColor.scss
+++ b/ui/src/configuration/components/RandomLabelColor.scss
@@ -8,8 +8,10 @@
 .random-color--button {
     display: flex;
     align-items: center;
+    justify-content: center;
+    margin-bottom: $ix-marg-b;
 
     .label-colors--swatch {
-        margin-right: 12px;
+        margin-right: $ix-marg-c;
     }
 }

--- a/ui/src/configuration/components/RandomLabelColor.scss
+++ b/ui/src/configuration/components/RandomLabelColor.scss
@@ -10,6 +10,6 @@
     align-items: center;
 
     .label-colors--swatch {
-        margin-left: 6px,
+        margin-right: 12px;
     }
 }

--- a/ui/src/configuration/components/RandomLabelColor.scss
+++ b/ui/src/configuration/components/RandomLabelColor.scss
@@ -1,0 +1,15 @@
+@import 'src/style/modules';
+
+/*
+  RandomLabelColor Styles
+  ------------------------------------------------------------------------------
+*/
+
+.random-color--button {
+    display: flex;
+    align-items: center;
+
+    .label-colors--swatch {
+        margin-left: 6px,
+    }
+}

--- a/ui/src/configuration/components/RandomLabelColor.tsx
+++ b/ui/src/configuration/components/RandomLabelColor.tsx
@@ -1,0 +1,46 @@
+import React, {Component} from 'react'
+import _ from 'lodash'
+
+import {Button} from '@influxdata/clockface'
+
+import {PRESET_LABEL_COLORS} from 'src/configuration/constants/LabelColors'
+
+// Styles
+import 'src/configuration/components/RandomLabelColor.scss'
+
+interface Props {
+  colorHex: string
+  onClick: (newRandomHex: string) => void
+}
+
+export default class RandomLabelColorButton extends Component<Props> {
+  public componentDidMount() {
+    this.handleClick()
+  }
+
+  public render() {
+    const {colorHex} = this.props
+    return (
+      <button
+        className="button button-sm button-default random-color--button "
+        onClick={this.handleClick}
+      >
+        New Color
+        <div
+          className="label-colors--swatch"
+          style={{
+            backgroundColor: colorHex,
+          }}
+        />
+      </button>
+    )
+  }
+
+  private handleClick = () => {
+    this.props.onClick(this.randomColor())
+  }
+
+  private randomColor(): string {
+    return _.sample(PRESET_LABEL_COLORS.slice(1)).colorHex
+  }
+}

--- a/ui/src/configuration/components/RandomLabelColor.tsx
+++ b/ui/src/configuration/components/RandomLabelColor.tsx
@@ -1,9 +1,8 @@
 import React, {Component} from 'react'
 import _ from 'lodash'
 
-import {Button} from '@influxdata/clockface'
-
 import {PRESET_LABEL_COLORS} from 'src/configuration/constants/LabelColors'
+import {IconFont} from 'src/clockface'
 
 // Styles
 import 'src/configuration/components/RandomLabelColor.scss'
@@ -25,13 +24,13 @@ export default class RandomLabelColorButton extends Component<Props> {
         className="button button-sm button-default random-color--button "
         onClick={this.handleClick}
       >
-        New Color
         <div
           className="label-colors--swatch"
           style={{
             backgroundColor: colorHex,
           }}
         />
+        <span className={`button-icon icon ${IconFont.Refresh}`} />
       </button>
     )
   }

--- a/ui/src/configuration/components/RandomLabelColor.tsx
+++ b/ui/src/configuration/components/RandomLabelColor.tsx
@@ -1,7 +1,8 @@
 import React, {Component} from 'react'
 import _ from 'lodash'
 
-import {PRESET_LABEL_COLORS} from 'src/configuration/constants/LabelColors'
+// Utils
+import {randomPresetColor} from 'src/configuration/utils/labels'
 import {IconFont} from 'src/clockface'
 
 // Styles
@@ -13,10 +14,6 @@ interface Props {
 }
 
 export default class RandomLabelColorButton extends Component<Props> {
-  public componentDidMount() {
-    this.handleClick()
-  }
-
   public render() {
     const {colorHex} = this.props
     return (
@@ -36,10 +33,6 @@ export default class RandomLabelColorButton extends Component<Props> {
   }
 
   private handleClick = () => {
-    this.props.onClick(this.randomColor())
-  }
-
-  private randomColor(): string {
-    return _.sample(PRESET_LABEL_COLORS.slice(1)).colorHex
+    this.props.onClick(randomPresetColor())
   }
 }

--- a/ui/src/configuration/utils/labels.ts
+++ b/ui/src/configuration/utils/labels.ts
@@ -1,5 +1,13 @@
+import _ from 'lodash'
+
 import {LabelType} from 'src/clockface'
-import {HEX_CODE_CHAR_LENGTH} from 'src/configuration/constants/LabelColors'
+import {
+  HEX_CODE_CHAR_LENGTH,
+  PRESET_LABEL_COLORS,
+} from 'src/configuration/constants/LabelColors'
+
+export const randomPresetColor = () =>
+  _.sample(PRESET_LABEL_COLORS.slice(1)).colorHex
 
 export const validateLabelName = (
   labels: LabelType[],

--- a/ui/src/shared/components/EditLabelsOverlay.tsx
+++ b/ui/src/shared/components/EditLabelsOverlay.tsx
@@ -23,7 +23,7 @@ import FetchLabels from 'src/shared/components/FetchLabels'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Label} from '@influxdata/influx'
+import {Label} from 'src/types/v2/labels'
 import {RemoteDataState} from 'src/types'
 
 // Utils

--- a/ui/src/shared/components/FetchLabels.tsx
+++ b/ui/src/shared/components/FetchLabels.tsx
@@ -10,7 +10,7 @@ import {client} from 'src/utils/api'
 
 // Types
 import {RemoteDataState} from 'src/types'
-import {Label} from '@influxdata/influx'
+import {Label} from 'src/types/v2/labels'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'

--- a/ui/src/shared/components/ResourceLabelForm.scss
+++ b/ui/src/shared/components/ResourceLabelForm.scss
@@ -5,7 +5,7 @@
 */
 
 .resource-label--form {
-    margin: $ix-marg-b;
+    margin-bottom: $ix-marg-b;
 
     .resource-label--create-button {
         margin-top: $ix-marg-c + 2px;

--- a/ui/src/shared/components/ResourceLabelForm.scss
+++ b/ui/src/shared/components/ResourceLabelForm.scss
@@ -1,0 +1,13 @@
+@import 'src/style/modules';
+/*
+  Resource Label Form styling
+  ---------------------------------------------
+*/
+
+.resource-label--form {
+    margin: $ix-marg-b;
+
+    .resource-label--create-button {
+        margin-top: $ix-marg-c + 2px;
+    }
+}   

--- a/ui/src/shared/components/ResourceLabelForm.tsx
+++ b/ui/src/shared/components/ResourceLabelForm.tsx
@@ -8,20 +8,14 @@ import {
   ComponentColor,
   ButtonType,
   Columns,
-  Alignment,
-  Stack,
   ComponentStatus,
 } from '@influxdata/clockface'
-import {Grid, Form, Input, ComponentSpacer, InputType} from 'src/clockface'
+import {Grid, Form, Input, InputType} from 'src/clockface'
 import RandomLabelColorButton from 'src/configuration/components/RandomLabelColor'
 import {Label, LabelProperties} from 'src/types/v2/labels'
 
 // Constants
-import {
-  CUSTOM_LABEL,
-  HEX_CODE_CHAR_LENGTH,
-  PRESET_LABEL_COLORS,
-} from 'src/configuration/constants/LabelColors'
+import {HEX_CODE_CHAR_LENGTH} from 'src/configuration/constants/LabelColors'
 
 // Utils
 import {validateHexCode} from 'src/configuration/utils/labels'
@@ -68,6 +62,26 @@ export default class ResourceLabelForm extends PureComponent<Props, State> {
     return (
       <Grid>
         <Grid.Row>
+          <Grid.Column widthSM={Columns.Ten}>
+            <Grid.Column widthXS={Columns.Two}>
+              <RandomLabelColorButton
+                colorHex={this.colorHex}
+                onClick={this.handleColorChange}
+              />
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Three}>
+              {this.customColorInput}
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Seven}>
+              <Input
+                type={InputType.Text}
+                placeholder="Add a optional description"
+                name="description"
+                value={this.description}
+                onChange={this.handleInputChange}
+              />
+            </Grid.Column>
+          </Grid.Column>
           <Grid.Column widthXS={Columns.Two}>
             <Button
               text="Create Label"
@@ -78,26 +92,6 @@ export default class ResourceLabelForm extends PureComponent<Props, State> {
               }
               onClick={this.handleSubmit}
             />
-          </Grid.Column>
-          <Grid.Column widthSM={Columns.Ten}>
-            <Grid.Column widthXS={Columns.Three}>
-              <RandomLabelColorButton
-                colorHex={this.colorHex}
-                onClick={this.handleColorChange}
-              />
-            </Grid.Column>
-            <Grid.Column widthXS={Columns.Three}>
-              {this.customColorInput}
-            </Grid.Column>
-            <Grid.Column widthXS={Columns.Six}>
-              <Input
-                type={InputType.Text}
-                placeholder="Add a optional description"
-                name="description"
-                value={this.description}
-                onChange={this.handleInputChange}
-              />
-            </Grid.Column>
           </Grid.Column>
         </Grid.Row>
       </Grid>

--- a/ui/src/shared/components/ResourceLabelForm.tsx
+++ b/ui/src/shared/components/ResourceLabelForm.tsx
@@ -1,0 +1,193 @@
+// Libraries
+import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
+import _ from 'lodash'
+
+// Components
+import {
+  Button,
+  ComponentColor,
+  ButtonType,
+  Columns,
+  Alignment,
+  Stack,
+  ComponentStatus,
+} from '@influxdata/clockface'
+import {Grid, Form, Input, ComponentSpacer, InputType} from 'src/clockface'
+import LabelColorDropdown from 'src/configuration/components/LabelColorDropdown'
+import {Label, LabelProperties} from 'src/types/v2/labels'
+
+// Constants
+import {
+  CUSTOM_LABEL,
+  HEX_CODE_CHAR_LENGTH,
+  PRESET_LABEL_COLORS,
+} from 'src/configuration/constants/LabelColors'
+
+// Utils
+import {validateHexCode} from 'src/configuration/utils/labels'
+
+// Styles
+import 'src/configuration/components/LabelOverlayForm.scss'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  labelName: string
+  onSubmit: (label: Label) => void
+}
+
+interface State {
+  isCustomColor: boolean
+  label: Label
+}
+
+@ErrorHandling
+export default class ResourceLabelForm extends PureComponent<Props, State> {
+  public constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      isCustomColor: false,
+      label: {
+        name: props.labelName,
+        properties: {
+          description: '',
+          color: _.sample(PRESET_LABEL_COLORS.slice(1)).colorHex,
+        },
+      },
+    }
+  }
+
+  public componentDidUpdate() {
+    if (this.props.labelName !== this.state.label.name) {
+      this.setState({label: {...this.state.label, name: this.props.labelName}})
+    }
+  }
+
+  public render() {
+    const {isCustomColor} = this.state
+
+    return (
+      <Grid>
+        <Grid.Row>
+          <Grid.Column widthSM={Columns.Ten}>
+            <Grid.Column widthXS={Columns.Six}>
+              <ComponentSpacer
+                align={Alignment.Left}
+                stackChildren={Stack.Rows}
+              >
+                <LabelColorDropdown
+                  colorHex={this.dropdownColorHex}
+                  onChange={this.handleColorChange}
+                  useCustomColorHex={isCustomColor}
+                  onToggleCustomColorHex={this.handleToggleCustomColorHex}
+                />
+                {this.customColorInput}
+              </ComponentSpacer>
+            </Grid.Column>
+            <Grid.Column widthXS={Columns.Six}>
+              <Input
+                type={InputType.Text}
+                placeholder="Add a optional description"
+                name="description"
+                value={this.description}
+                onChange={this.handleInputChange}
+              />
+            </Grid.Column>
+          </Grid.Column>
+          <Grid.Column widthXS={Columns.Two}>
+            <ComponentSpacer align={Alignment.Center}>
+              <Button
+                text="Create Label"
+                color={ComponentColor.Success}
+                type={ButtonType.Submit}
+                status={ComponentStatus.Default}
+                onClick={this.handleSubmit}
+              />
+            </ComponentSpacer>
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    )
+  }
+
+  private handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+
+    this.props.onSubmit(this.state.label)
+  }
+
+  private handleCustomColorChange = (
+    e: ChangeEvent<HTMLInputElement>
+  ): void => {
+    this.updateProperties({color: e.target.value})
+  }
+
+  private handleColorChange = (color: string) => {
+    this.updateProperties({color})
+  }
+
+  private handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    this.updateProperties({description: e.target.value})
+  }
+
+  private handleToggleCustomColorHex = (isCustomColor: boolean) => {
+    this.setState({isCustomColor})
+  }
+
+  private updateProperties(update: Partial<LabelProperties>) {
+    const {label} = this.state
+
+    this.setState({
+      label: {
+        ...label,
+        properties: {...label.properties, ...update},
+      },
+    })
+  }
+
+  private get dropdownColorHex(): string {
+    if (this.state.isCustomColor) {
+      return CUSTOM_LABEL.colorHex
+    }
+
+    return this.colorHex
+  }
+
+  private get customColorInput(): JSX.Element {
+    const {colorHex} = this
+
+    if (!this.state.isCustomColor) {
+      return null
+    }
+
+    return (
+      <Form.ValidationElement
+        label="Enter a Hexcode"
+        value={colorHex}
+        validationFunc={validateHexCode}
+      >
+        {status => (
+          <Input
+            type={InputType.Text}
+            value={colorHex}
+            placeholder="#000000"
+            onChange={this.handleCustomColorChange}
+            status={status}
+            autoFocus={true}
+            maxLength={HEX_CODE_CHAR_LENGTH}
+          />
+        )}
+      </Form.ValidationElement>
+    )
+  }
+
+  private get colorHex(): string {
+    return this.state.label.properties.color
+  }
+
+  private get description(): string {
+    return this.state.label.properties.description
+  }
+}

--- a/ui/src/shared/components/ResourceLabelForm.tsx
+++ b/ui/src/shared/components/ResourceLabelForm.tsx
@@ -10,7 +10,14 @@ import {
   Columns,
   ComponentStatus,
 } from '@influxdata/clockface'
-import {Grid, Form, Input, InputType} from 'src/clockface'
+import {
+  Grid,
+  Form,
+  Input,
+  InputType,
+  ComponentSpacer,
+  Alignment,
+} from 'src/clockface'
 import RandomLabelColorButton from 'src/configuration/components/RandomLabelColor'
 import {Label, LabelProperties} from 'src/types/v2/labels'
 
@@ -22,6 +29,9 @@ import {validateHexCode} from 'src/configuration/utils/labels'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
+
+// Style
+import 'src/shared/components/ResourceLabelForm.scss'
 
 interface Props {
   labelName: string
@@ -60,19 +70,21 @@ export default class ResourceLabelForm extends PureComponent<Props, State> {
     const {isValid} = this.state
 
     return (
-      <Grid>
+      <div className="resource-label--form">
         <Grid.Row>
-          <Grid.Column widthSM={Columns.Ten}>
-            <Grid.Column widthXS={Columns.Two}>
-              <RandomLabelColorButton
-                colorHex={this.colorHex}
-                onClick={this.handleColorChange}
-              />
-            </Grid.Column>
-            <Grid.Column widthXS={Columns.Three}>
-              {this.customColorInput}
-            </Grid.Column>
-            <Grid.Column widthXS={Columns.Seven}>
+          <Grid.Column widthXS={Columns.Five}>
+            <Form.Element label="Color">
+              <ComponentSpacer stretchToFitWidth={true} align={Alignment.Left}>
+                <RandomLabelColorButton
+                  colorHex={this.colorHex}
+                  onClick={this.handleColorChange}
+                />
+                {this.customColorInput}
+              </ComponentSpacer>
+            </Form.Element>
+          </Grid.Column>
+          <Grid.Column widthXS={Columns.Five}>
+            <Form.Element label="Description">
               <Input
                 type={InputType.Text}
                 placeholder="Add a optional description"
@@ -80,21 +92,24 @@ export default class ResourceLabelForm extends PureComponent<Props, State> {
                 value={this.description}
                 onChange={this.handleInputChange}
               />
-            </Grid.Column>
+            </Form.Element>
           </Grid.Column>
           <Grid.Column widthXS={Columns.Two}>
-            <Button
-              text="Create Label"
-              color={ComponentColor.Success}
-              type={ButtonType.Submit}
-              status={
-                isValid ? ComponentStatus.Default : ComponentStatus.Disabled
-              }
-              onClick={this.handleSubmit}
-            />
+            <Form.Element label="">
+              <Button
+                customClass="resource-label--create-button"
+                text="Create Label"
+                color={ComponentColor.Success}
+                type={ButtonType.Submit}
+                status={
+                  isValid ? ComponentStatus.Default : ComponentStatus.Disabled
+                }
+                onClick={this.handleSubmit}
+              />
+            </Form.Element>
           </Grid.Column>
         </Grid.Row>
-      </Grid>
+      </div>
     )
   }
 

--- a/ui/src/shared/components/ResourceLabelForm.tsx
+++ b/ui/src/shared/components/ResourceLabelForm.tsx
@@ -25,7 +25,10 @@ import {Label, LabelProperties} from 'src/types/v2/labels'
 import {HEX_CODE_CHAR_LENGTH} from 'src/configuration/constants/LabelColors'
 
 // Utils
-import {validateHexCode} from 'src/configuration/utils/labels'
+import {
+  validateHexCode,
+  randomPresetColor,
+} from 'src/configuration/utils/labels'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -54,7 +57,7 @@ export default class ResourceLabelForm extends PureComponent<Props, State> {
         name: props.labelName,
         properties: {
           description: '',
-          color: '',
+          color: randomPresetColor(),
         },
       },
     }


### PR DESCRIPTION
Closes #11624

_Briefly describe your proposed changes:_
Add resource label creation form when label is not present. Tune label filtering to not aggressively match labels not in the list to more easily enable user to create a new label. Add a random color button instead of a color dropdown which does not work well in the label list dropdown.


  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
![kapture 2019-02-21 at 7 29 57](https://user-images.githubusercontent.com/4994741/53169271-c78b0500-35aa-11e9-8dd8-18e1105f9b23.gif)
