### PR TITLE
Add get variable by ID route to swagger.yml

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1032,6 +1032,37 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   '/variables/{variableID}':
+    get:
+      tags:
+        - Variables
+      summary: get a variable
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: path
+          name: variableID
+          required: true
+          schema:
+            type: string
+          description: ID of the variable
+      responses:
+        '200':
+          description: variable found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Variable"
+        '404':
+          description: variable not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        default:
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
     delete:
       tags:
         - Variables


### PR DESCRIPTION
Closes #11840 

This PR adds the get by ID route for a variable to the Swagger documentation

  - [x] Rebased/mergeable
  - [x] Tests pass
