### PR TITLE
Avoid unnecessary Histogram rerenders

### DIFF
--- a/ui/src/shared/components/Histogram.tsx
+++ b/ui/src/shared/components/Histogram.tsx
@@ -19,6 +19,7 @@ import {tableLoaded} from 'src/timeMachine/actions'
 // Utils
 import {toMinardTable} from 'src/shared/utils/toMinardTable'
 import {useOneWayState} from 'src/shared/utils/useOneWayState'
+import {useSetIdentity} from 'src/shared/utils/useSetIdentity'
 
 // Constants
 import {INVALID_DATA_COPY} from 'src/shared/copy/cell'
@@ -92,9 +93,10 @@ const Histogram: SFC<Props> = ({
     [table]
   )
 
-  const {x, fill} = resolveMappings(table, xColumn, fillColumns)
+  const mappings = resolveMappings(table, xColumn, fillColumns)
+  const fill = useSetIdentity(mappings.fill)
 
-  if (!x) {
+  if (!mappings.x) {
     return <EmptyGraphMessage message={INVALID_DATA_COPY} />
   }
 
@@ -111,7 +113,7 @@ const Histogram: SFC<Props> = ({
           {env => (
             <MinardHistogram
               env={env}
-              x={x}
+              x={mappings.x}
               fill={fill}
               binCount={binCount}
               position={position}

--- a/ui/src/shared/utils/useSetIdentity.ts
+++ b/ui/src/shared/utils/useSetIdentity.ts
@@ -1,0 +1,27 @@
+import {useRef} from 'react'
+
+/*
+  If the supplied set of elements `s` is equal to the previously supplied set
+  of elements, return the previously supplied set.
+
+  The two sets are considered equal if each set contains the other.
+
+  Similar to `useMemo`, this method is useful for preserving the identity of
+  data across rerenders. Unlike `useMemo`, it checks the logical identity of
+  the new data, rather than the reference identity.
+*/
+export const useSetIdentity = <T extends any[]>(s: T): T => {
+  const ref = useRef(s)
+  const prevS = ref.current
+
+  if (prevS !== s) {
+    const isSetEqual =
+      prevS.length === s.length && s.every(x => prevS.includes(x))
+
+    if (!isSetEqual) {
+      ref.current = s
+    }
+  }
+
+  return ref.current
+}


### PR DESCRIPTION
Closes #11953

Previously, opening the histogram options would cause the the histogram computation (binning algorithm) to rerun. Since this computation is rather expensive for large or high cardinality datasets, we only want to run it when absolutely necessary.

The computation would run on every rerender of the parent component, during which a `fill` prop was instantiated and passed to the `Histogram` component. Since the prop was reinstantiated on every render, its reference identity would change, and hence the binning computation would appear stale a run again.

This commit avoids reinstantiating this passed prop on every render with a custom hook.



