### PR TITLE
fix(ui): add guard for hasKey check

### DIFF
--- a/ui/src/organizations/components/GetOrgResources.tsx
+++ b/ui/src/organizations/components/GetOrgResources.tsx
@@ -97,10 +97,10 @@ export default class GetOrgResources<T> extends PureComponent<
     resources: T[],
     key: string | number | symbol
   ): key is keyof T {
-    const resource = resources[0]
+    const resource = _.get(resources, '0', null)
     // gaurd against null and primitive types
     const isObject = !!resource && typeof resource === 'object'
 
-    return isObject && key in resource
+    return isObject && _.hasIn(resource, key)
   }
 }

--- a/ui/src/organizations/components/GetOrgResources.tsx
+++ b/ui/src/organizations/components/GetOrgResources.tsx
@@ -75,11 +75,11 @@ export default class GetOrgResources<T> extends PureComponent<
     }
   }
 
-  // Todo: improve typing for unpacking array
   private order(resources: T[]): T[] {
     const {orderBy} = this.props
 
     const defaultKeys = this.extractDefaultKeys(resources)
+
     if (orderBy) {
       return _.orderBy(resources, orderBy.keys, orderBy.orders)
     } else if (defaultKeys.length !== 0) {
@@ -97,6 +97,10 @@ export default class GetOrgResources<T> extends PureComponent<
     resources: T[],
     key: string | number | symbol
   ): key is keyof T {
-    return key in resources[0]
+    const resource = resources[0]
+    // gaurd against null and primitive types
+    const isObject = !!resource && typeof resource === 'object'
+
+    return isObject && key in resource
   }
 }


### PR DESCRIPTION
Fixes checking key in primitive or null types

Closes #11993 

_Briefly describe your proposed changes:_
Empty resources and primitive data types could cause the `in` operator to error and not load resources.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
