### PR TITLE
fix(ui): Update the label preview to be shorter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [11997](https://github.com/influxdata/influxdb/pull/11997): Update the bucket retention policy to update the time in seconds
 
 ### UI Improvements
+1. [12016](https://github.com/influxdata/influxdb/pull/12016): Update the preview in the label overlays to be shorter
 
 ## v2.0.0-alpha.3 [2019-02-15]
 

--- a/ui/src/configuration/components/LabelOverlayForm.scss
+++ b/ui/src/configuration/components/LabelOverlayForm.scss
@@ -8,9 +8,10 @@
 .label-overlay--preview {
   display: flex;
   justify-content: center;
+  height: 50px;
 
   > .label {
-    margin: $ix-marg-d 0;
+    margin: $ix-marg-a 0;
   }
 }
 


### PR DESCRIPTION
Closes #11860

_Briefly describe your proposed changes:_
Make the label preview shorter.

<img width="646" alt="screen shot 2019-02-20 at 1 45 29 pm" src="https://user-images.githubusercontent.com/5751863/53126831-e095a680-3515-11e9-979d-ac936a1f41be.png">


  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
