### PR TITLE
fix(ui/FilterList): add filtering on labels

### DIFF
--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -116,7 +116,7 @@ class DashboardIndex extends PureComponent<Props, State> {
             <Page.Header.Right>
               <SearchWidget
                 placeholderText="Filter dashboards by name..."
-                onSearch={this.filterDashboards}
+                onSearch={this.handleFilterDashboards}
               />
               <AddResourceDropdown
                 onSelectNew={this.handleCreateDashboard}
@@ -232,7 +232,7 @@ class DashboardIndex extends PureComponent<Props, State> {
     })
   }
 
-  private filterDashboards = (searchTerm: string): void => {
+  private handleFilterDashboards = (searchTerm: string): void => {
     this.setState({searchTerm})
   }
 

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
@@ -52,6 +52,7 @@ export default class DashboardsIndexContents extends Component<Props> {
         list={dashboards}
         searchTerm={searchTerm}
         searchKeys={['name', 'labels[].name']}
+        sortByKey="name"
       >
         {filteredDashboards => (
           <Table

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
@@ -4,6 +4,7 @@ import _ from 'lodash'
 
 // Components
 import Table from 'src/dashboards/components/dashboard_index/Table'
+import FilterList from 'src/shared/components/Filter'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -43,33 +44,32 @@ export default class DashboardsIndexContents extends Component<Props> {
       searchTerm,
       orgs,
       showOwnerColumn,
+      dashboards,
     } = this.props
 
     return (
-      <Table
+      <FilterList<Dashboard>
+        list={dashboards}
         searchTerm={searchTerm}
-        dashboards={this.filteredDashboards}
-        onDeleteDashboard={onDeleteDashboard}
-        onCreateDashboard={onCreateDashboard}
-        onCloneDashboard={onCloneDashboard}
-        onExportDashboard={onExportDashboard}
-        defaultDashboardLink={defaultDashboardLink}
-        onSetDefaultDashboard={onSetDefaultDashboard}
-        onUpdateDashboard={onUpdateDashboard}
-        onEditLabels={onEditLabels}
-        orgs={orgs}
-        showOwnerColumn={showOwnerColumn}
-      />
+        searchKeys={['name', 'labels[].name']}
+      >
+        {filteredDashboards => (
+          <Table
+            searchTerm={searchTerm}
+            dashboards={filteredDashboards}
+            onDeleteDashboard={onDeleteDashboard}
+            onCreateDashboard={onCreateDashboard}
+            onCloneDashboard={onCloneDashboard}
+            onExportDashboard={onExportDashboard}
+            defaultDashboardLink={defaultDashboardLink}
+            onSetDefaultDashboard={onSetDefaultDashboard}
+            onUpdateDashboard={onUpdateDashboard}
+            onEditLabels={onEditLabels}
+            orgs={orgs}
+            showOwnerColumn={showOwnerColumn}
+          />
+        )}
+      </FilterList>
     )
-  }
-
-  private get filteredDashboards(): Dashboard[] {
-    const {dashboards, searchTerm} = this.props
-
-    const matchingDashboards = dashboards.filter(d =>
-      d.name.toLowerCase().includes(searchTerm.toLowerCase())
-    )
-
-    return _.sortBy(matchingDashboards, d => d.name.toLowerCase())
   }
 }

--- a/ui/src/organizations/components/Buckets.tsx
+++ b/ui/src/organizations/components/Buckets.tsx
@@ -82,7 +82,7 @@ export default class Buckets extends PureComponent<Props, State> {
         </Tabs.TabContentsHeader>
         <FilterList<PrettyBucket>
           searchTerm={searchTerm}
-          searchKeys={['name', 'ruleString']}
+          searchKeys={['name', 'ruleString', 'labels[].name']}
           list={this.prettyBuckets(buckets)}
         >
           {bs => (

--- a/ui/src/organizations/components/Collectors.tsx
+++ b/ui/src/organizations/components/Collectors.tsx
@@ -103,7 +103,7 @@ export class Collectors extends PureComponent<Props, State> {
             <Grid.Column widthSM={Columns.Twelve}>
               <FilterList<Telegraf>
                 searchTerm={searchTerm}
-                searchKeys={['plugins.0.config.bucket']}
+                searchKeys={['plugins.0.config.bucket', 'labels[].name']}
                 list={collectors}
               >
                 {cs => (

--- a/ui/src/organizations/components/OrgTasksPage.tsx
+++ b/ui/src/organizations/components/OrgTasksPage.tsx
@@ -115,7 +115,7 @@ class OrgTasksPage extends PureComponent<Props, State> {
           />
           <FilterList<Task>
             searchTerm={searchTerm}
-            searchKeys={['name']}
+            searchKeys={['name', 'labels[].name']}
             list={this.filteredTasks}
           >
             {ts => (

--- a/ui/src/organizations/containers/OrganizationsIndex.tsx
+++ b/ui/src/organizations/containers/OrganizationsIndex.tsx
@@ -20,6 +20,7 @@ import {Organization, Links} from 'src/types/v2'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import FilterList from 'src/shared/components/Filter'
 
 interface StateProps {
   links: Links
@@ -51,7 +52,7 @@ class OrganizationsIndex extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {links, onCreateOrg, onDeleteOrg} = this.props
+    const {links, onCreateOrg, onDeleteOrg, orgs} = this.props
     const {modalState, searchTerm} = this.state
 
     return (
@@ -76,11 +77,19 @@ class OrganizationsIndex extends PureComponent<Props, State> {
             </Page.Header.Right>
           </Page.Header>
           <Page.Contents fullWidth={false} scrollable={true}>
-            <OrganizationsIndexContents
-              orgs={this.filteredOrgs}
-              onDeleteOrg={onDeleteOrg}
+            <FilterList<Organization>
+              searchKeys={['name']}
               searchTerm={searchTerm}
-            />
+              list={orgs}
+            >
+              {filteredOrgs => (
+                <OrganizationsIndexContents
+                  orgs={filteredOrgs}
+                  onDeleteOrg={onDeleteOrg}
+                  searchTerm={searchTerm}
+                />
+              )}
+            </FilterList>
           </Page.Contents>
         </Page>
         <OverlayTechnology visible={modalState === ModalState.Open}>
@@ -92,17 +101,6 @@ class OrganizationsIndex extends PureComponent<Props, State> {
         </OverlayTechnology>
       </>
     )
-  }
-
-  private get filteredOrgs(): Organization[] {
-    const {orgs} = this.props
-    const {searchTerm} = this.state
-
-    const filteredOrgs = orgs.filter(org =>
-      org.name.toLowerCase().includes(searchTerm.toLowerCase())
-    )
-
-    return filteredOrgs
   }
 
   private handleOpenModal = (): void => {

--- a/ui/src/shared/components/Filter.test.tsx
+++ b/ui/src/shared/components/Filter.test.tsx
@@ -1,0 +1,231 @@
+import React, {Component} from 'react'
+import {render} from 'react-testing-library'
+
+import FilterList from 'src/shared/components/Filter'
+
+function setup<T>(override?) {
+  const props = {
+    list: [],
+    searchTerm: '',
+    searchKeys: [],
+    sortByKey: '',
+    ...override,
+  }
+
+  return render(
+    <FilterList<T> {...props}>
+      {filtered =>
+        filtered.map((item, index) => <TestListItem key={index} {...item} />)
+      }
+    </FilterList>
+  )
+}
+
+describe('FilterList', () => {
+  it('renders', () => {
+    const list = [{name: 'foo'}, {name: 'bar'}]
+    const {getAllByTestId} = setup<{name: string}>({list})
+
+    const expected = getAllByTestId('list-item')
+    expect(expected.length).toEqual(list.length)
+  })
+
+  it('renders a sorted list', () => {
+    const itemOne = {name: 'foo'}
+    const itemTwo = {name: 'bar'}
+    const list = [itemOne, itemTwo]
+    const {getAllByTestId} = setup<{name: string}>({list, sortByKey: 'name'})
+
+    const expected = getAllByTestId('list-item')
+
+    expect(expected.length).toEqual(list.length)
+    expect(expected[0].textContent).toEqual(itemTwo.name)
+    expect(expected[1].textContent).toEqual(itemOne.name)
+  })
+
+  it('filters list of flat objects', () => {
+    const list = [{name: 'foo'}, {name: 'bar'}]
+    const searchTerm = 'fo'
+    const searchKeys = ['name']
+    const {getAllByTestId} = setup<{name: string}>({
+      list,
+      searchTerm,
+      searchKeys,
+    })
+
+    const expected = getAllByTestId('list-item')
+
+    expect(expected.length).toEqual(1)
+    expect(expected[0].textContent).toEqual('foo')
+  })
+
+  it('filters list of nested objects', () => {
+    const itemOne = {
+      id: '1',
+      name: 'aPplication',
+      labels: [{name: 'foo'}, {name: 'bar'}],
+    }
+    const itemTwo = {
+      id: '2',
+      name: 'ports',
+      labels: [{name: 'aPple'}, {name: 'code'}],
+    }
+    const list = [
+      itemOne,
+      itemTwo,
+      {
+        id: '3',
+        name: 'hipster',
+        labels: [{name: 'bike'}, {name: 'glasses'}],
+      },
+    ]
+    const searchTerm = 'ApP'
+    const searchKeys = ['name', 'labels[].name']
+    const {getAllByTestId} = setup<{
+      labels: Array<{name: string}>
+      id: string
+      name: string
+    }>({
+      list,
+      searchTerm,
+      searchKeys,
+    })
+
+    const expected = getAllByTestId('list-item')
+
+    expect(expected.length).toEqual(2)
+    expect(expected[0].textContent).toEqual(itemOne.name)
+    expect(expected[1].textContent).toEqual(itemTwo.name)
+  })
+
+  it('filters deeply nested inexact paths', () => {
+    const itemOne = {
+      id: '1',
+      name: 'crackle',
+      labels: [
+        {
+          name: 'snap',
+          labels: [{name: 'super aPplication', labels: {name: 'pop'}}],
+        },
+      ],
+    }
+    const itemTwo = {
+      id: '2',
+      name: 'ports',
+      labels: [
+        {name: 'beep', labels: [{name: 'boop', labels: {name: 'RRRRRaPps'}}]},
+      ],
+    }
+
+    const itemThree = {
+      id: '3',
+      name: 'rando',
+      labels: [
+        {name: 'TEST_APP', labels: [{name: 'a', labels: {name: 'match'}}]},
+      ],
+    }
+
+    const list = [itemOne, itemTwo, itemThree]
+
+    const searchTerm = 'ApP'
+    const searchKeys = [
+      'labels[].name',
+      'labels[].labels[].name',
+      'labels[].labels[].labels[].name',
+    ]
+    const {getAllByTestId} = setup<{
+      labels: Array<{
+        name: string
+        labels: Array<{
+          name: string
+          labels: Array<{name: string}>
+        }>
+      }>
+      id: string
+      name: string
+    }>({
+      list,
+      searchTerm,
+      searchKeys,
+    })
+
+    const expected = getAllByTestId('list-item')
+
+    expect(expected.length).toEqual(3)
+    expect(expected[0].textContent).toEqual(itemOne.name)
+    expect(expected[1].textContent).toEqual(itemTwo.name)
+    expect(expected[2].textContent).toEqual(itemThree.name)
+  })
+
+  it('errors when searchKey value is an object', () => {
+    const itemOne = {
+      name: {
+        first: 'Hip',
+        last: 'Bot',
+      },
+    }
+
+    const list = [itemOne]
+    const searchTerm = 'bo'
+    const searchKeys = ['name']
+    const consoleSpy = jest.spyOn(global.console, 'error')
+    consoleSpy.mockImplementation(() => {})
+
+    expect(() => {
+      setup<{
+        name: {
+          first: string
+          last: string
+        }
+      }>({
+        list,
+        searchTerm,
+        searchKeys,
+      })
+    }).toThrowError()
+
+    consoleSpy.mockRestore()
+  })
+
+  it('errors when inexact searchKey value is an object', () => {
+    const itemOne = {
+      things: [
+        {
+          name: {
+            first: 'Hip',
+            last: 'Bot',
+          },
+        },
+      ],
+    }
+
+    const list = [itemOne]
+    const searchTerm = 'be'
+    const searchKeys = ['things[].name']
+    const consoleSpy = jest.spyOn(global.console, 'error')
+    consoleSpy.mockImplementation(() => {})
+
+    expect(() => {
+      setup<{
+        things: Array<{
+          name: {
+            first: string
+            last: string
+          }
+        }>
+      }>({
+        list,
+        searchTerm,
+        searchKeys,
+      })
+    }).toThrowError()
+
+    consoleSpy.mockRestore()
+  })
+})
+
+class TestListItem extends Component<any> {
+  public render() {
+    return <div data-testid="list-item">{this.props.name}</div>
+  }
+}

--- a/ui/src/shared/components/Filter.tsx
+++ b/ui/src/shared/components/Filter.tsx
@@ -11,24 +11,46 @@ interface Props<T> {
   children: (list: T[]) => any
 }
 
+const INEXACT_PATH = /\w+\[\]/g
+
+/**
+ * Filters a list using a searchTerm and searchKeys where
+ *  searchKeys is an array of strings represents either an
+ *  exact or inexact path to a property value(s):
+ *  "user.name" (exact) or "authors[].name" (inexact)
+ *
+ */
 export default class FilterList<T> extends PureComponent<Props<T>> {
   public render() {
     return this.props.children(this.filtered)
   }
 
   private get filtered(): T[] {
-    const {list, searchKeys, searchTerm} = this.props
+    const {list, searchKeys} = this.props
+    const {formattedSearchTerm} = this
+
+    if (_.isEmpty(formattedSearchTerm)) {
+      return list
+    }
 
     const filtered = list.filter(item => {
       const isInList = searchKeys.some(key => {
-        if (_.isObject(item[key])) {
+        const value = this.getKey(item, key)
+
+        const isStringArray =
+          (_.isArray(value) && _.isEmpty(value)) || _.isString(value[0])
+
+        if (!isStringArray && _.isObject(value)) {
           throw new Error(
             `The value at key "${key}" is an object.  Take a look at "searchKeys" and 
              make sure you're indexing onto a primitive value`
           )
         }
 
-        const value = _.get(item, key, '')
+        if (isStringArray) {
+          const searchIndex = this.createIndex(value)
+          return this.checkIndex(searchIndex, formattedSearchTerm)
+        }
 
         if (value === '') {
           throw new Error(`${key} is undefined.  Take a look at "searchKeys". `)
@@ -36,12 +58,59 @@ export default class FilterList<T> extends PureComponent<Props<T>> {
 
         return String(value)
           .toLocaleLowerCase()
-          .includes(searchTerm.toLocaleLowerCase())
+          .includes(formattedSearchTerm)
       })
 
       return isInList
     })
 
     return filtered
+  }
+
+  private get formattedSearchTerm(): string {
+    return this.props.searchTerm.trimLeft().toLocaleLowerCase()
+  }
+
+  private getKey(item: T, key: string) {
+    const isInexact = key.match(INEXACT_PATH)
+
+    if (!isInexact) {
+      return _.get(item, key, '')
+    } else {
+      const paths = key.split(/\[\]?\./)
+      // flattens nested arrays into one large array
+      const values = paths.reduce(
+        (results, path) => _.flatMap(results, r => _.get(r, path, [])),
+        [item]
+      )
+
+      return values
+    }
+  }
+
+  private createIndex = (terms: string[]) => {
+    return _.flatMap(terms, this.extractSuffixes).sort()
+  }
+
+  private checkIndex = (sortedSuffixes: string[], searchTerm) => {
+    const index = _.sortedIndex(sortedSuffixes, searchTerm)
+    const nearestSuffix = sortedSuffixes[index]
+
+    if (!!nearestSuffix && nearestSuffix.includes(searchTerm)) {
+      return true
+    }
+
+    return false
+  }
+
+  private extractSuffixes = (term: string) => {
+    const suffixes = new Array(term.length)
+    const lowerTerm = term.toLocaleLowerCase()
+
+    for (let i = 0; i < suffixes.length; i++) {
+      suffixes[i] = lowerTerm.slice(i)
+    }
+
+    return suffixes
   }
 }


### PR DESCRIPTION
Closes #11866 

_Briefly describe your proposed changes:_
Updates filterList to allow searching by inexact object paths using `labels[].name`. Label names are kept in sorted order and searched using binary search for a closest suffix and then checked for term inclusion. 

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
