### PR TITLE
feat(tasks): look up tasks by orgname

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3790,6 +3790,11 @@ paths:
           name: org
           schema:
             type: string
+          description: filter tasks to a specific organization name
+        - in: query
+          name: orgID
+          schema:
+            type: string
           description: filter tasks to a specific organization ID
         - in: query
           name: limit

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -17,6 +17,7 @@ import (
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/authorizer"
 	pcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/options"
@@ -259,7 +260,7 @@ func newRunsResponse(rs []*platform.Run, taskID platform.ID) runsResponse {
 func (h *TaskHandler) handleGetTasks(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	req, err := decodeGetTasksRequest(ctx, r)
+	req, err := decodeGetTasksRequest(ctx, r, h.OrganizationService)
 	if err != nil {
 		err = &platform.Error{
 			Err:  err,
@@ -323,7 +324,7 @@ type getTasksRequest struct {
 	filter platform.TaskFilter
 }
 
-func decodeGetTasksRequest(ctx context.Context, r *http.Request) (*getTasksRequest, error) {
+func decodeGetTasksRequest(ctx context.Context, r *http.Request, orgs platform.OrganizationService) (*getTasksRequest, error) {
 	qp := r.URL.Query()
 	req := &getTasksRequest{}
 
@@ -335,12 +336,26 @@ func decodeGetTasksRequest(ctx context.Context, r *http.Request) (*getTasksReque
 		req.filter.After = id
 	}
 
-	if orgID := qp.Get("organization"); orgID != "" {
-		id, err := platform.IDFromString(orgID)
+	if orgName := qp.Get("org"); orgName != "" {
+		o, err := orgs.FindOrganization(ctx, platform.OrganizationFilter{Name: &orgName})
+		if err != nil {
+			if pErr, ok := err.(*platform.Error); ok && pErr != nil {
+				if kv.IsNotFound(err) || pErr.Code == platform.EUnauthorized {
+					return nil, &platform.Error{
+						Err: errors.New("org not found or unauthorized"),
+						Msg: "org " + orgName + " not found or unauthorized",
+					}
+				}
+			}
+			return nil, err
+		}
+		req.filter.Organization = &o.ID
+	} else if oid := qp.Get("orgID"); oid != "" {
+		orgID, err := platform.IDFromString(oid)
 		if err != nil {
 			return nil, err
 		}
-		req.filter.Organization = id
+		req.filter.Organization = orgID
 	}
 
 	if userID := qp.Get("user"); userID != "" {
@@ -1409,7 +1424,7 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 		val.Add("after", filter.After.String())
 	}
 	if filter.Organization != nil {
-		val.Add("organization", filter.Organization.String())
+		val.Add("orgID", filter.Organization.String())
 	}
 	if filter.User != nil {
 		val.Add("user", filter.User.String())

--- a/task_test.go
+++ b/task_test.go
@@ -64,4 +64,20 @@ from(bucket:"x")
 			t.Fail()
 		}
 	})
+	t.Run("test add new option", func(t *testing.T) {
+		tu := &platform.TaskUpdate{}
+		tu.Options.Offset = 30 * time.Second
+		if err := tu.UpdateFlux(`option task = {every: 20s, name: "foo"} from(bucket:"x") |> range(start:-1h)`); err != nil {
+			t.Fatal(err)
+		}
+
+		op, err := options.FromScript(*tu.Flux)
+		if err != nil {
+			t.Error(err)
+		}
+		if op.Offset != 30*time.Second {
+			t.Fatalf("expected every to be 30s but was %s", op.Every)
+		}
+	})
+
 }


### PR DESCRIPTION
closes #11822 and #11781

This allows lookups by org name and makes the api more consistent.