### PR TITLE
Fix/org filter

### DIFF
--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -140,35 +140,11 @@ func (c *Client) FindOrganization(ctx context.Context, filter influxdb.Organizat
 		return o, nil
 	}
 
-	filterFn := filterOrganizationsFn(filter)
-
-	var o *influxdb.Organization
-	err := c.db.View(func(tx *bolt.Tx) error {
-		return forEachOrganization(ctx, tx, func(org *influxdb.Organization) bool {
-			if filterFn(org) {
-				o = org
-				return false
-			}
-			return true
-		})
-	})
-
-	if err != nil {
-		return nil, &influxdb.Error{
-			Op:  op,
-			Err: err,
-		}
+	// If name and ID are not set, then, this is an invalid usage of the API.
+	return nil, &influxdb.Error{
+		Code: influxdb.EInvalid,
+		Msg:  "no filter parameters provided",
 	}
-
-	if o == nil {
-		return nil, &influxdb.Error{
-			Code: influxdb.ENotFound,
-			Op:   op,
-			Msg:  "organization not found",
-		}
-	}
-
-	return o, nil
 }
 
 func filterOrganizationsFn(filter influxdb.OrganizationFilter) func(o *influxdb.Organization) bool {

--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -77,13 +77,11 @@ func TestLauncher_WriteAndQuery(t *testing.T) {
 	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
 		`,result,table,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v` + "\r\n\r\n"
 
-	var buf bytes.Buffer
-	req := (http.QueryRequest{Query: qs, Org: l.Org}).WithDefaults()
-	if preq, err := req.ProxyRequest(); err != nil {
-		t.Fatal(err)
-	} else if _, err := l.FluxService().Query(ctx, &buf, preq); err != nil {
-		t.Fatal(err)
-	} else if diff := cmp.Diff(buf.String(), exp); diff != "" {
+	buf, err := http.SimpleQuery(l.URL(), qs, l.Org.Name, l.Auth.Token)
+	if err != nil {
+		t.Fatalf("unexpected error querying server: %v", err)
+	}
+	if diff := cmp.Diff(string(buf), exp); diff != "" {
 		t.Fatal(diff)
 	}
 }
@@ -117,13 +115,11 @@ func TestLauncher_BucketDelete(t *testing.T) {
 	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
 		`,result,table,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v` + "\r\n\r\n"
 
-	var buf bytes.Buffer
-	req := (http.QueryRequest{Query: qs, Org: l.Org}).WithDefaults()
-	if preq, err := req.ProxyRequest(); err != nil {
-		t.Fatal(err)
-	} else if _, err := l.FluxService().Query(ctx, &buf, preq); err != nil {
-		t.Fatal(err)
-	} else if diff := cmp.Diff(buf.String(), exp); diff != "" {
+	buf, err := http.SimpleQuery(l.URL(), qs, l.Org.Name, l.Auth.Token)
+	if err != nil {
+		t.Fatalf("unexpected error querying server: %v", err)
+	}
+	if diff := cmp.Diff(string(buf), exp); diff != "" {
 		t.Fatal(diff)
 	}
 

--- a/cmd/influxd/launcher/storage_test.go
+++ b/cmd/influxd/launcher/storage_test.go
@@ -1,7 +1,6 @@
 package launcher_test
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	nethttp "net/http"
@@ -75,15 +74,11 @@ func (l *Launcher) WriteOrFail(tb testing.TB, to *influxdb.OnboardingResults, da
 // or fails if there is an error.
 func (l *Launcher) FluxQueryOrFail(tb testing.TB, org *influxdb.Organization, token string, query string) string {
 	tb.Helper()
-	var buf bytes.Buffer
 
-	fs := &http.FluxService{Addr: l.URL(), Token: token}
-
-	req := (http.QueryRequest{Query: query, Org: org}).WithDefaults()
-	if preq, err := req.ProxyRequest(); err != nil {
-		tb.Fatal(err)
-	} else if _, err := fs.Query(ctx, &buf, preq); err != nil {
+	b, err := http.SimpleQuery(l.URL(), query, org.Name, token)
+	if err != nil {
 		tb.Fatal(err)
 	}
-	return buf.String()
+
+	return string(b)
 }

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -305,7 +305,7 @@ func decodeGetOrgsRequest(ctx context.Context, r *http.Request) (*getOrgsRequest
 	qp := r.URL.Query()
 	req := &getOrgsRequest{}
 
-	if orgID := qp.Get("id"); orgID != "" {
+	if orgID := qp.Get(OrgID); orgID != "" {
 		id, err := influxdb.IDFromString(orgID)
 		if err != nil {
 			return nil, err
@@ -313,7 +313,7 @@ func decodeGetOrgsRequest(ctx context.Context, r *http.Request) (*getOrgsRequest
 		req.filter.ID = id
 	}
 
-	if name := qp.Get("name"); name != "" {
+	if name := qp.Get(OrgName); name != "" {
 		req.filter.Name = &name
 	}
 
@@ -586,6 +586,12 @@ func (s *OrganizationService) FindOrganizationByID(ctx context.Context, id influ
 
 // FindOrganization gets a single organization matching the filter using HTTP.
 func (s *OrganizationService) FindOrganization(ctx context.Context, filter influxdb.OrganizationFilter) (*influxdb.Organization, error) {
+	if filter.ID == nil && filter.Name == nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "no filter parameters provided",
+		}
+	}
 	os, n, err := s.FindOrganizations(ctx, filter)
 	if err != nil {
 		return nil, &influxdb.Error{
@@ -614,10 +620,10 @@ func (s *OrganizationService) FindOrganizations(ctx context.Context, filter infl
 	qp := url.Query()
 
 	if filter.Name != nil {
-		qp.Add("name", *filter.Name)
+		qp.Add(OrgName, *filter.Name)
 	}
 	if filter.ID != nil {
-		qp.Add("id", filter.ID.String())
+		qp.Add(OrgID, filter.ID.String())
 	}
 	url.RawQuery = qp.Encode()
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2704,12 +2704,12 @@ paths:
             - application/vnd.flux
       - in: query
         name: org
-        description: specifies the name of the organization executing the query.
+        description: specifies the name of the organization executing the query; if both orgID and org are specified, orgID takes precendence.
         schema:
           type: string
       - in: query
         name: orgID
-        description: specifies the ID of the organization executing the query.
+        description: specifies the ID of the organization executing the query; if both orgID and org are specified, orgID takes precendence.
         schema:
           type: string
     requestBody:
@@ -3243,6 +3243,18 @@ paths:
       tags:
         - Organizations
       summary: List all organizations
+      parameters:
+        - $ref: '#/components/parameters/TraceSpan'
+        - in: query
+          name: org
+          schema:
+            type: string
+          description: filter organizations to a specific organization name
+        - in: query
+          name: orgID
+          schema:
+            type: string
+          description: filter organizations to a specific organization ID
       responses:
         '200':
           description: A list of organizations

--- a/kv/org.go
+++ b/kv/org.go
@@ -141,33 +141,11 @@ func (s *Service) FindOrganization(ctx context.Context, filter influxdb.Organiza
 		return s.FindOrganizationByName(ctx, *filter.Name)
 	}
 
-	filterFn := filterOrganizationsFn(filter)
-
-	var o *influxdb.Organization
-	err := s.kv.View(func(tx Tx) error {
-		return forEachOrganization(ctx, tx, func(org *influxdb.Organization) bool {
-			if filterFn(org) {
-				o = org
-				return false
-			}
-			return true
-		})
-	})
-
-	if err != nil {
-		return nil, &influxdb.Error{
-			Err: err,
-		}
+	// If name and ID are not set, then, this is an invalid usage of the API.
+	return nil, &influxdb.Error{
+		Code: influxdb.EInvalid,
+		Msg:  "no filter parameters provided",
 	}
-
-	if o == nil {
-		return nil, &influxdb.Error{
-			Code: influxdb.ENotFound,
-			Msg:  "organization not found",
-		}
-	}
-
-	return o, nil
 }
 
 func filterOrganizationsFn(filter influxdb.OrganizationFilter) func(o *influxdb.Organization) bool {

--- a/testing/organization_service.go
+++ b/testing/organization_service.go
@@ -603,6 +603,7 @@ func FindOrganization(
 ) {
 	type args struct {
 		name string
+		id   platform.ID
 	}
 
 	type wants struct {
@@ -641,6 +642,48 @@ func FindOrganization(
 			},
 		},
 		{
+			name: "find organization in which no name filter matches should return no org",
+			args: args{
+				name: "unknown",
+			},
+			wants: wants{
+				err: &platform.Error{
+					Code: platform.ENotFound,
+					Op:   platform.OpFindOrganization,
+					Msg:  "organization name \"unknown\" not found",
+				},
+			},
+		},
+		{
+			name: "find organization in which no id filter matches should return no org",
+			args: args{
+				id: platform.ID(3),
+			},
+			wants: wants{
+				err: &platform.Error{
+					Code: platform.ENotFound,
+					Msg:  "organization not found",
+				},
+			},
+		},
+		{
+			name: "find organization no filter is set returns an error about filters not provided",
+			fields: OrganizationFields{
+				Organizations: []*platform.Organization{
+					{
+						ID:   MustIDBase16(orgOneID),
+						Name: "o1",
+					},
+				},
+			},
+			wants: wants{
+				err: &platform.Error{
+					Code: platform.EInvalid,
+					Msg:  "no filter parameters provided",
+				},
+			},
+		},
+		{
 			name: "missing organization returns error",
 			fields: OrganizationFields{
 				Organizations: []*platform.Organization{},
@@ -666,6 +709,9 @@ func FindOrganization(
 			filter := platform.OrganizationFilter{}
 			if tt.args.name != "" {
 				filter.Name = &tt.args.name
+			}
+			if tt.args.id != platform.InvalidID() {
+				filter.ID = &tt.args.id
 			}
 
 			organization, err := s.FindOrganization(ctx, filter)


### PR DESCRIPTION
Closes #12010

_Briefly describe your proposed changes:_
* Add checks and test coverage to FindOrganization with no filters set.
* Add a "SimpleQuery" to just run a query and get the bytes.
* Update swagger to document orgID/org parameters.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

I'd also recommend we remove FluxService, FluxQueryService and probably a variety of endpoints that are not used or confusing.
