### PR TITLE
storage: reduce allocations and iterations in DeleteBucketRange

### DIFF
--- a/tsdb/tsm1/cache.go
+++ b/tsdb/tsm1/cache.go
@@ -549,7 +549,7 @@ func (c *Cache) Values(key []byte) Values {
 // DeleteBucketRange removes values for all keys containing points
 // with timestamps between min and max contained in the bucket identified
 // by name from the cache.
-func (c *Cache) DeleteBucketRange(name []byte, min, max int64) {
+func (c *Cache) DeleteBucketRange(name []byte, min, max int64) [][]byte {
 	c.init()
 
 	// TODO(edd/jeff): find a way to optimize lock usage
@@ -591,6 +591,8 @@ func (c *Cache) DeleteBucketRange(name []byte, min, max int64) {
 
 	c.tracker.DecCacheSize(total)
 	c.tracker.SetMemBytes(uint64(c.Size()))
+
+	return toDelete
 }
 
 // SetMaxSize updates the memory limit of the cache.


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Change `e.Cache.DeleteBucketRange` method to return deleted keys.
Append keys to `possiblyDead.keys`.

Benchmark:
```
benchmark                                 old ns/op       new ns/op       delta
BenchmarkEngine_DeleteBucket/100-4        134685          21032           -84.38%
BenchmarkEngine_DeleteBucket/1000-4       586056          120230          -79.48%
BenchmarkEngine_DeleteBucket/5000-4       2608844         630471          -75.83%
BenchmarkEngine_DeleteBucket/10000-4      5881396         1322523         -77.51%
BenchmarkEngine_DeleteBucket/50000-4      43190026        10862006        -74.85%

benchmark                                 old allocs     new allocs     delta
BenchmarkEngine_DeleteBucket/100-4        231            73             -68.40%
BenchmarkEngine_DeleteBucket/1000-4       2045           523            -74.43%
BenchmarkEngine_DeleteBucket/5000-4       10085          2523           -74.98%
BenchmarkEngine_DeleteBucket/10000-4      20137          5023           -75.06%
BenchmarkEngine_DeleteBucket/50000-4      100891         25024          -75.20%

benchmark                                 old bytes      new bytes      delta
BenchmarkEngine_DeleteBucket/100-4        256049         2976           -98.84%
BenchmarkEngine_DeleteBucket/1000-4       353850         17376          -95.09%
BenchmarkEngine_DeleteBucket/5000-4       738212         81380          -88.98%
BenchmarkEngine_DeleteBucket/10000-4      1229378        161386         -86.87%
BenchmarkEngine_DeleteBucket/50000-4      6624780        801478         -87.90%
```

---

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

