### PR TITLE
feat(cmd/influx): allow infinite retention in non-interactive setup

### DIFF
--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -115,7 +115,8 @@ func nonInteractive() (*platform.OnboardingRequest, error) {
 		Bucket:          setupFlags.bucket,
 		RetentionPeriod: uint(setupFlags.retention),
 	}
-	if req.RetentionPeriod < 0 {
+
+	if setupFlags.retention < 0 {
 		req.RetentionPeriod = platform.InfiniteRetention
 	}
 	return req, nil


### PR DESCRIPTION
Closes #12048 

_Briefly describe your proposed changes:_
If retention duration is not set by default during a non-interactive setup, no retention policy is set (infinite).

```
$ ./influx setup -f -b prom -o prom -u prom -p prometheus
Your token has been stored in /Users/goller/.influxdbv2/credentials.
User    Organization    Bucket
prom    prom            prom
```

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
