### PR TITLE
fix(ui/resourceLabelForm): fix ResourceLabelForm invalid default

### DIFF
--- a/ui/src/clockface/components/label/LabelSelector.scss
+++ b/ui/src/clockface/components/label/LabelSelector.scss
@@ -28,7 +28,7 @@
 .label-selector--menu {
   width: 100%;
   min-height: 50px;
-  margin: $ix-marg-b;
+  padding: $ix-marg-b;
 }
 
 .label-selector--menu-item {

--- a/ui/src/shared/components/ResourceLabelForm.tsx
+++ b/ui/src/shared/components/ResourceLabelForm.tsx
@@ -52,7 +52,7 @@ export default class ResourceLabelForm extends PureComponent<Props, State> {
     super(props)
 
     this.state = {
-      isValid: false,
+      isValid: true,
       label: {
         name: props.labelName,
         properties: {


### PR DESCRIPTION
Closes #12056

_Briefly describe your proposed changes:_
Wrong default was set for form state.invalid and padding was required instead of margin. 

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
![screen shot 2019-02-21 at 12 38 30 pm](https://user-images.githubusercontent.com/4994741/53189498-a55aac80-35d5-11e9-960c-4fa890f73122.png)
