### PR TITLE
Cleanup Tabbed Page Nested Styles

### DIFF
--- a/ui/src/clockface/components/index_views/IndexList.scss
+++ b/ui/src/clockface/components/index_views/IndexList.scss
@@ -129,7 +129,6 @@
   ------------------------------------------------------------------------------
 */
 
-.tabbed-page-content, 
 .tabs--contents {
   .index-list--cell {
     background-color: $g4-onyx;

--- a/ui/src/clockface/components/panel/Panel.scss
+++ b/ui/src/clockface/components/panel/Panel.scss
@@ -59,7 +59,7 @@ $panel-nested-background: $g4-onyx;
 
 //  Panels Nested inside Tabbed Pages
 //  ----------------------------------------------------------------------------
-.tabbed-page .panel {
+.tabs--contents .panel {
   background-color: $panel-nested-background;
 
   .panel-footer {


### PR DESCRIPTION
Ensure panels nested inside tabbed pages receive the depth styling
Remove deprecated classname from stylesheet

  - [x] Rebased/mergeable
  - [x] Tests pass
