### PR TITLE
ci(litmus): do not run litmus tests on forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
+      - run:
+          name: Check if PR is from fork.
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER"	]; then
+              echo "litmus_daily is not being run on forked PRs."
+              circleci step halt
+            fi
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e ONE_TEST=src/cloud/rest_api/smoke/test_smoke.py -e PROTOSPATH=/Litmus/result/influxd_test -e BINARYPATH=/Litmus/result/bin/linux/influxd -e BOLTPATH=/Litmus/result/influxd_test/influxd.bolt -e ENGINEPATH=/Litmus/result/influxd_test --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,8 @@ workflows:
       - litmus_daily:
           requires:
             - build
+          filters:
+            only: /^(?!pull\/).*$/
 
   e2e:
     jobs:
@@ -289,8 +291,6 @@ workflows:
       - litmus_nightly:
           requires:
             - deploy-nightly
-          filters:
-            only: /^(?!pull\/).*$/
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,8 @@ workflows:
           requires:
             - build
           filters:
-            only: /^(?!pull\/).*$/
+            branches:
+              only: /^(?!pull\/).*$/
 
   e2e:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
-      - run:
-          name: Check if PR is from fork.
-          command: |
-            if [ -n "$CIRCLE_PR_NUMBER"	]; then
-              echo "litmus_daily is not being run on forked PRs."
-              circleci step halt
-            fi
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run: docker run --entrypoint "./run_litmus_tests_oss.sh" -e ONE_TEST=src/cloud/rest_api/smoke/test_smoke.py -e PROTOSPATH=/Litmus/result/influxd_test -e BINARYPATH=/Litmus/result/bin/linux/influxd -e BOLTPATH=/Litmus/result/influxd_test/influxd.bolt -e ENGINEPATH=/Litmus/result/influxd_test --net host -v /var/run/docker.sock:/var/run/docker.sock -v ~/project:/Litmus/result quay.io/influxdb/litmus:latest
       - run:
@@ -296,6 +289,8 @@ workflows:
       - litmus_nightly:
           requires:
             - deploy-nightly
+          filters:
+            only: /^(?!pull\/).*$/
 
   release:
     jobs:


### PR DESCRIPTION
- add a step to check if PR is from fork. If it is, then stop execution of the step and successfully return.
- Fix for https://github.com/influxdata/influxdb/issues/11965

Closes #

_Briefly describe your proposed changes:_

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
