### PR TITLE
Some preperation for delete safety

### DIFF
--- a/pkg/lifecycle/lifecycle.go
+++ b/pkg/lifecycle/lifecycle.go
@@ -1,38 +1,38 @@
-package storage
+package lifecycle
 
 import (
 	"io"
 )
 
-// opener is something that can be opened and closed.
-type opener interface {
+// Resource is something that can be opened and closed.
+type Resource interface {
 	Open() error
 	io.Closer
 }
 
-// openHelper is a helper to abstract the pattern of opening multiple things,
+// Opener is a helper to abstract the pattern of opening multiple things,
 // exiting early if any open fails, and closing any of the opened things
 // in the case of failure.
-type openHelper struct {
+type Opener struct {
 	opened []io.Closer
 	err    error
 }
 
-// Open attempts to open the opener. If an error has happened already
-// then no calls are made to the opener.
-func (o *openHelper) Open(op opener) {
+// Open attempts to open the resource. If an error has happened already
+// then no calls are made to the resource.
+func (o *Opener) Open(res Resource) {
 	if o.err != nil {
 		return
 	}
-	o.err = op.Open()
+	o.err = res.Open()
 	if o.err == nil {
-		o.opened = append(o.opened, op)
+		o.opened = append(o.opened, res)
 	}
 }
 
 // Done returns the error of the first open and closes in reverse
 // order any opens that have already happened if there was an error.
-func (o *openHelper) Done() error {
+func (o *Opener) Done() error {
 	if o.err == nil {
 		return nil
 	}
@@ -42,20 +42,20 @@ func (o *openHelper) Done() error {
 	return o.err
 }
 
-// closeHelper is a helper to abstract the pattern of closing multiple
+// Closer is a helper to abstract the pattern of closing multiple
 // things and keeping track of the first encountered error.
-type closeHelper struct {
+type Closer struct {
 	err error
 }
 
 // Close closes the closer and keeps track of the first error.
-func (c *closeHelper) Close(cl io.Closer) {
+func (c *Closer) Close(cl io.Closer) {
 	if err := cl.Close(); c.err == nil {
 		c.err = err
 	}
 }
 
 // Done returns the first error.
-func (c *closeHelper) Done() error {
+func (c *Closer) Done() error {
 	return c.err
 }

--- a/pkg/lifecycle/tracker.go
+++ b/pkg/lifecycle/tracker.go
@@ -1,0 +1,76 @@
+package lifecycle
+
+import "sync"
+
+// Tracker helps keep track of background processes, signal them to exit
+// and wait for them to finish.
+type Tracker struct {
+	mu   sync.RWMutex
+	wg   sync.WaitGroup
+	open bool
+	intC chan struct{}
+}
+
+// Open starts the Tracker. It returns a channel that can be monitored for when
+// the tracker is closed. This is useful for syncronously spawning tasks during
+// open, as Start also returns the channel. Prefer using the channel from start
+// to avoid issues where the incorrect channel is read from for cancellation.
+// It should not be called concurrently with Close.
+func (t *Tracker) Open() chan struct{} {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if !t.open {
+		t.open = true
+		t.intC = make(chan struct{})
+	}
+
+	return t.intC
+}
+
+// Close signals to any started tasks that they should exit and waits for there
+// to be no tasks. It should not be called concurrently with Open.
+func (t *Tracker) Close() {
+	t.mu.Lock()
+	if t.open {
+		t.open = false
+		close(t.intC)
+	}
+	t.mu.Unlock()
+
+	// It's safe to wait without the lock because we know that the only time
+	// someone adds to the wait group is during startTask, which checks for
+	// closed and adds to the wait group under the read lock. Thus, no adds
+	// can happen after the mutex unlock until the next call to Open.
+	t.wg.Wait()
+}
+
+// Start reports a channel to check for interrupts as well as a boolean indicating
+// if the tracker is open.
+func (t *Tracker) Start() (chan struct{}, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if !t.open {
+		return nil, false
+	}
+
+	t.wg.Add(1)
+	return t.intC, t.open
+}
+
+// Check reports if the tracker is open.
+func (t *Tracker) Check() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	return t.open
+}
+
+// Stop signals to the tracker that the task has finished.
+func (t *Tracker) Stop() {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	t.wg.Done()
+}

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -700,11 +700,6 @@ func (i *Index) CreateSeriesListIfNotExists(collection *tsdb.SeriesCollection) e
 	return nil
 }
 
-// InitializeSeries is a no-op. This only applies to the in-memory index.
-func (i *Index) InitializeSeries(*tsdb.SeriesCollection) error {
-	return nil
-}
-
 // DropSeries drops the provided series from the index.  If cascade is true
 // and this is the last series to the measurement, the measurment will also be dropped.
 func (i *Index) DropSeries(seriesID tsdb.SeriesID, key []byte, cascade bool) error {
@@ -743,9 +738,6 @@ func (i *Index) DropSeries(seriesID tsdb.SeriesID, key []byte, cascade bool) err
 	}
 	return nil
 }
-
-// DropSeriesGlobal is a no-op on the tsi1 index.
-func (i *Index) DropSeriesGlobal(key []byte) error { return nil }
 
 // DropMeasurementIfSeriesNotExist drops a measurement only if there are no more
 // series for the measurment.
@@ -1147,12 +1139,6 @@ func (i *Index) RetainFileSet() (*FileSet, error) {
 	}
 	return fs, nil
 }
-
-// SetFieldName is a no-op on this index.
-func (i *Index) SetFieldName(measurement []byte, name string) {}
-
-// Rebuild rebuilds an index. It's a no-op for this index.
-func (i *Index) Rebuild() {}
 
 // MeasurementCardinalityStats returns cardinality stats for all measurements.
 func (i *Index) MeasurementCardinalityStats() MeasurementCardinalityStats {

--- a/tsdb/tsi1/partition.go
+++ b/tsdb/tsi1/partition.go
@@ -870,10 +870,6 @@ func (p *Partition) TagKeyCardinality(name, key []byte) int {
 	return 0
 }
 
-func (p *Partition) SetFieldName(measurement []byte, name string) {}
-func (p *Partition) RemoveShard(shardID uint64)                   {}
-func (p *Partition) AssignShard(k string, shardID uint64)         {}
-
 // Compact requests a compaction of log files.
 func (p *Partition) Compact() {
 	p.mu.Lock()
@@ -1100,8 +1096,6 @@ func (p *Partition) compactToLevel(files []*IndexFile, level int, interrupt <-ch
 		}
 	}
 }
-
-func (p *Partition) Rebuild() {}
 
 func (p *Partition) CheckLogFile() error {
 	// Check log file size under read lock.

--- a/tsdb/tsm1/array_cursor_iterator.gen.go
+++ b/tsdb/tsm1/array_cursor_iterator.gen.go
@@ -17,7 +17,7 @@ import (
 // buildFloatArrayCursor creates an array cursor for a float field.
 func (q *arrayCursorIterator) buildFloatArrayCursor(ctx context.Context, name []byte, tags models.Tags, field string, opt query.IteratorOptions) tsdb.FloatArrayCursor {
 	key := q.seriesFieldKeyBytes(name, tags, field)
-	cacheValues := q.e.Cache.Values(key)
+	cacheValues := q.e.cache.Values(key)
 	keyCursor := q.e.KeyCursor(ctx, key, opt.SeekTime(), opt.Ascending)
 	if opt.Ascending {
 		if q.asc.Float == nil {
@@ -37,7 +37,7 @@ func (q *arrayCursorIterator) buildFloatArrayCursor(ctx context.Context, name []
 // buildIntegerArrayCursor creates an array cursor for a integer field.
 func (q *arrayCursorIterator) buildIntegerArrayCursor(ctx context.Context, name []byte, tags models.Tags, field string, opt query.IteratorOptions) tsdb.IntegerArrayCursor {
 	key := q.seriesFieldKeyBytes(name, tags, field)
-	cacheValues := q.e.Cache.Values(key)
+	cacheValues := q.e.cache.Values(key)
 	keyCursor := q.e.KeyCursor(ctx, key, opt.SeekTime(), opt.Ascending)
 	if opt.Ascending {
 		if q.asc.Integer == nil {
@@ -57,7 +57,7 @@ func (q *arrayCursorIterator) buildIntegerArrayCursor(ctx context.Context, name 
 // buildUnsignedArrayCursor creates an array cursor for a unsigned field.
 func (q *arrayCursorIterator) buildUnsignedArrayCursor(ctx context.Context, name []byte, tags models.Tags, field string, opt query.IteratorOptions) tsdb.UnsignedArrayCursor {
 	key := q.seriesFieldKeyBytes(name, tags, field)
-	cacheValues := q.e.Cache.Values(key)
+	cacheValues := q.e.cache.Values(key)
 	keyCursor := q.e.KeyCursor(ctx, key, opt.SeekTime(), opt.Ascending)
 	if opt.Ascending {
 		if q.asc.Unsigned == nil {
@@ -77,7 +77,7 @@ func (q *arrayCursorIterator) buildUnsignedArrayCursor(ctx context.Context, name
 // buildStringArrayCursor creates an array cursor for a string field.
 func (q *arrayCursorIterator) buildStringArrayCursor(ctx context.Context, name []byte, tags models.Tags, field string, opt query.IteratorOptions) tsdb.StringArrayCursor {
 	key := q.seriesFieldKeyBytes(name, tags, field)
-	cacheValues := q.e.Cache.Values(key)
+	cacheValues := q.e.cache.Values(key)
 	keyCursor := q.e.KeyCursor(ctx, key, opt.SeekTime(), opt.Ascending)
 	if opt.Ascending {
 		if q.asc.String == nil {
@@ -97,7 +97,7 @@ func (q *arrayCursorIterator) buildStringArrayCursor(ctx context.Context, name [
 // buildBooleanArrayCursor creates an array cursor for a boolean field.
 func (q *arrayCursorIterator) buildBooleanArrayCursor(ctx context.Context, name []byte, tags models.Tags, field string, opt query.IteratorOptions) tsdb.BooleanArrayCursor {
 	key := q.seriesFieldKeyBytes(name, tags, field)
-	cacheValues := q.e.Cache.Values(key)
+	cacheValues := q.e.cache.Values(key)
 	keyCursor := q.e.KeyCursor(ctx, key, opt.SeekTime(), opt.Ascending)
 	if opt.Ascending {
 		if q.asc.Boolean == nil {

--- a/tsdb/tsm1/array_cursor_iterator.gen.go.tmpl
+++ b/tsdb/tsm1/array_cursor_iterator.gen.go.tmpl
@@ -13,7 +13,7 @@ import (
 // build{{.Name}}ArrayCursor creates an array cursor for a {{.name}} field.
 func (q *arrayCursorIterator) build{{.Name}}ArrayCursor(ctx context.Context, name []byte, tags models.Tags, field string, opt query.IteratorOptions) tsdb.{{.Name}}ArrayCursor {
 	key := q.seriesFieldKeyBytes(name, tags, field)
-	cacheValues := q.e.Cache.Values(key)
+	cacheValues := q.e.cache.Values(key)
 	keyCursor := q.e.KeyCursor(ctx, key, opt.SeekTime(), opt.Ascending)
 	if opt.Ascending {
 		if q.asc.{{.Name}} == nil {

--- a/tsdb/tsm1/cache.go
+++ b/tsdb/tsm1/cache.go
@@ -16,13 +16,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// ringShards specifies the number of partitions that the hash ring used to
-// store the entry mappings contains. It must be a power of 2. From empirical
-// testing, a value above the number of cores on the machine does not provide
-// any additional benefit. For now we'll set it to the number of cores on the
-// largest box we could imagine running influx.
-const ringShards = 16
-
 var (
 	// ErrSnapshotInProgress is returned if a snapshot is attempted while one is already running.
 	ErrSnapshotInProgress = fmt.Errorf("snapshot in progress")
@@ -175,53 +168,22 @@ type Cache struct {
 	tracker       *cacheTracker
 	lastSnapshot  time.Time
 	lastWriteTime time.Time
-
-	// A one time synchronization used to initial the cache with a store.  Since the store can allocate a
-	// a large amount memory across shards, we lazily create it.
-	initialize       atomic.Value
-	initializedCount uint32
 }
 
 // NewCache returns an instance of a cache which will use a maximum of maxSize bytes of memory.
 // Only used for engine caches, never for snapshots.
 func NewCache(maxSize uint64) *Cache {
-	c := &Cache{
+	return &Cache{
 		maxSize:      maxSize,
-		store:        emptyStore{},
+		store:        newring(),
 		lastSnapshot: time.Now(),
 		tracker:      newCacheTracker(newCacheMetrics(nil), nil),
 	}
-	c.initialize.Store(&sync.Once{})
-	return c
-}
-
-// init initializes the cache and allocates the underlying store.  Once initialized,
-// the store re-used until Freed.
-func (c *Cache) init() {
-	if !atomic.CompareAndSwapUint32(&c.initializedCount, 0, 1) {
-		return
-	}
-
-	c.mu.Lock()
-	c.store, _ = newring(ringShards)
-	c.mu.Unlock()
-}
-
-// Free releases the underlying store and memory held by the Cache.
-func (c *Cache) Free() {
-	if !atomic.CompareAndSwapUint32(&c.initializedCount, 1, 0) {
-		return
-	}
-
-	c.mu.Lock()
-	c.store = emptyStore{}
-	c.mu.Unlock()
 }
 
 // Write writes the set of values for the key to the cache. This function is goroutine-safe.
 // It returns an error if the cache will exceed its max size by adding the new values.
 func (c *Cache) Write(key []byte, values []Value) error {
-	c.init()
 	addedSize := uint64(Values(values).Size())
 
 	// Enough room in the cache?
@@ -259,7 +221,6 @@ func (c *Cache) Write(key []byte, values []Value) error {
 // values as possible.  If one key fails, the others can still succeed and an
 // error will be returned.
 func (c *Cache) WriteMulti(values map[string][]Value) error {
-	c.init()
 	var addedSize uint64
 	for _, v := range values {
 		addedSize += uint64(Values(v).Size())
@@ -320,8 +281,6 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 // Snapshot takes a snapshot of the current cache, adds it to the slice of caches that
 // are being flushed, and resets the current cache with new values.
 func (c *Cache) Snapshot() (*Cache, error) {
-	c.init()
-
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -334,13 +293,8 @@ func (c *Cache) Snapshot() (*Cache, error) {
 
 	// If no snapshot exists, create a new one, otherwise update the existing snapshot
 	if c.snapshot == nil {
-		store, err := newring(ringShards)
-		if err != nil {
-			return nil, err
-		}
-
 		c.snapshot = &Cache{
-			store:   store,
+			store:   newring(),
 			tracker: newCacheTracker(c.tracker.metrics, c.tracker.labels),
 		}
 	}
@@ -384,8 +338,6 @@ func (c *Cache) Deduplicate() {
 // ClearSnapshot removes the snapshot cache from the list of flushing caches and
 // adjusts the size.
 func (c *Cache) ClearSnapshot(success bool) {
-	c.init()
-
 	c.mu.RLock()
 	snapStore := c.snapshot.store
 	c.mu.RUnlock()
@@ -550,8 +502,6 @@ func (c *Cache) Values(key []byte) Values {
 // with timestamps between min and max contained in the bucket identified
 // by name from the cache.
 func (c *Cache) DeleteBucketRange(name []byte, min, max int64) {
-	c.init()
-
 	// TODO(edd/jeff): find a way to optimize lock usage
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -851,16 +801,3 @@ func valueType(v Value) byte {
 		return 0
 	}
 }
-
-type emptyStore struct{}
-
-func (e emptyStore) entry(key []byte) *entry                        { return nil }
-func (e emptyStore) write(key []byte, values Values) (bool, error)  { return false, nil }
-func (e emptyStore) add(key []byte, entry *entry)                   {}
-func (e emptyStore) remove(key []byte)                              {}
-func (e emptyStore) keys(sorted bool) [][]byte                      { return nil }
-func (e emptyStore) apply(f func([]byte, *entry) error) error       { return nil }
-func (e emptyStore) applySerial(f func([]byte, *entry) error) error { return nil }
-func (e emptyStore) reset()                                         {}
-func (e emptyStore) split(n int) []storer                           { return nil }
-func (e emptyStore) count() int                                     { return 0 }

--- a/tsdb/tsm1/cache_test.go
+++ b/tsdb/tsm1/cache_test.go
@@ -793,7 +793,7 @@ func (s *TestStore) count() int                                     { return s.c
 var fvSize = uint64(NewValue(1, float64(1)).Size())
 
 func BenchmarkCacheFloatEntries(b *testing.B) {
-	cache := NewCache(uint64(b.N) * fvSize)
+	cache := NewCache(uint64(b.N)*fvSize + 4) // 4 for the size of the measurement
 	vals := make([][]Value, b.N)
 	for i := 0; i < b.N; i++ {
 		vals[i] = []Value{NewValue(1, float64(i))}

--- a/tsdb/tsm1/cache_test.go
+++ b/tsdb/tsm1/cache_test.go
@@ -119,7 +119,6 @@ func TestCache_WriteMulti_Stats(t *testing.T) {
 
 	// Fail one of the values in the write.
 	c = NewCache(50)
-	c.init()
 	c.store = ms
 
 	ms.writef = func(key []byte, v Values) (bool, error) {

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -418,11 +418,6 @@ func (e *Engine) disableSnapshotCompactions() {
 	e.mu.Lock()
 	e.snapDone = nil
 	e.mu.Unlock()
-
-	// If the cache is empty, free up its resources as well.
-	if e.Cache.Size() == 0 {
-		e.Cache.Free()
-	}
 }
 
 // ScheduleFullCompaction will force the engine to fully compact all data stored.
@@ -556,12 +551,6 @@ func (e *Engine) WithLogger(log *zap.Logger) {
 func (e *Engine) IsIdle() bool {
 	cacheEmpty := e.Cache.Size() == 0
 	return cacheEmpty && e.compactionTracker.AllActive() == 0 && e.CompactionPlan.FullyCompacted()
-}
-
-// Free releases any resources held by the engine to free up memory or CPU.
-func (e *Engine) Free() error {
-	e.Cache.Free()
-	return e.FileStore.Free()
 }
 
 // WritePoints saves the set of points in the engine.

--- a/tsdb/tsm1/engine_delete_bucket.go
+++ b/tsdb/tsm1/engine_delete_bucket.go
@@ -32,15 +32,6 @@ func (e *Engine) DeleteBucketRange(name []byte, min, max int64) error {
 	}
 	defer fs.Release()
 
-	// Disable and abort running compactions so that tombstones added existing tsm
-	// files don't get removed. This would cause deleted measurements/series to
-	// re-appear once the compaction completed. We only disable the level compactions
-	// so that snapshotting does not stop while writing out tombstones. If it is stopped,
-	// and writing tombstones takes a long time, writes can get rejected due to the cache
-	// filling up.
-	e.disableLevelCompactions(true)
-	defer e.enableLevelCompactions(true)
-
 	e.sfile.DisableCompactions()
 	defer e.sfile.EnableCompactions()
 	e.sfile.Wait()

--- a/tsdb/tsm1/engine_delete_bucket_test.go
+++ b/tsdb/tsm1/engine_delete_bucket_test.go
@@ -1,4 +1,4 @@
-package tsm1_test
+package tsm1
 
 import (
 	"bytes"
@@ -19,16 +19,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 	p7 := MustParsePointString("mem,host=C value=1.3 1")
 	p8 := MustParsePointString("disk,host=C value=1.3 1")
 
-	e, err := NewEngine()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// mock the planner so compactions don't run during the test
-	e.CompactionPlan = &mockPlanner{}
-	if err := e.Open(); err != nil {
-		t.Fatal(err)
-	}
+	e := MustOpenEngine()
 	defer e.Close()
 
 	if err := e.writePoints(p1, p2, p3, p4, p5, p6, p7, p8); err != nil {
@@ -39,7 +30,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 		t.Fatalf("failed to snapshot: %s", err.Error())
 	}
 
-	keys := e.FileStore.Keys()
+	keys := e.fileStore.Keys()
 	if exp, got := 6, len(keys); exp != got {
 		t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
 	}
@@ -48,7 +39,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 		t.Fatalf("failed to delete series: %v", err)
 	}
 
-	keys = e.FileStore.Keys()
+	keys = e.fileStore.Keys()
 	if exp, got := 4, len(keys); exp != got {
 		t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
 	}
@@ -94,7 +85,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 		t.Fatalf("failed to delete series: %v", err)
 	}
 
-	keys = e.FileStore.Keys()
+	keys = e.fileStore.Keys()
 	if exp, got := 2, len(keys); exp != got {
 		t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
 	}

--- a/tsdb/tsm1/engine_test.go
+++ b/tsdb/tsm1/engine_test.go
@@ -127,45 +127,6 @@ func TestEngine_ShouldCompactCache(t *testing.T) {
 	}
 }
 
-// This test ensures that "sync: WaitGroup is reused before previous Wait has returned" is
-// is not raised.
-func TestEngine_DisableEnableCompactions_Concurrent(t *testing.T) {
-	e := MustOpenEngine()
-	defer e.Close()
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 1000; i++ {
-			e.setCompactionsEnabled(true)
-			e.setCompactionsEnabled(false)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 1000; i++ {
-			e.setCompactionsEnabled(false)
-			e.setCompactionsEnabled(true)
-		}
-	}()
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	// Wait for waitgroup or fail if it takes too long.
-	select {
-	case <-time.NewTimer(30 * time.Second).C:
-		t.Fatalf("timed out after 30 seconds waiting for waitgroup")
-	case <-done:
-	}
-}
-
 // BenchmarkEngine_WritePoints reports how quickly we can write points for different
 // batch sizes.
 func BenchmarkEngine_WritePoints(b *testing.B) {

--- a/tsdb/tsm1/ring_test.go
+++ b/tsdb/tsm1/ring_test.go
@@ -8,38 +8,22 @@ import (
 )
 
 func TestRing_newRing(t *testing.T) {
-	examples := []struct {
-		n         int
-		returnErr bool
-	}{
-		{n: 1}, {n: 2}, {n: 4}, {n: 8}, {n: 16}, {n: 32, returnErr: true},
-		{n: 0, returnErr: true}, {n: 3, returnErr: true},
+	r := newring()
+
+	if got, exp := len(r.partitions), partitions; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
 	}
 
-	for i, example := range examples {
-		r, err := newring(example.n)
-		if err != nil {
-			if example.returnErr {
-				continue // expecting an error.
-			}
-			t.Fatal(err)
+	// Check partitions distributed correctly
+	ps := make([]*partition, 0)
+	for i, partition := range r.partitions {
+		if i == 0 || partition != ps[len(ps)-1] {
+			ps = append(ps, partition)
 		}
+	}
 
-		if got, exp := len(r.partitions), example.n; got != exp {
-			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
-		}
-
-		// Check partitions distributed correctly
-		partitions := make([]*partition, 0)
-		for i, partition := range r.partitions {
-			if i == 0 || partition != partitions[len(partitions)-1] {
-				partitions = append(partitions, partition)
-			}
-		}
-
-		if got, exp := len(partitions), example.n; got != exp {
-			t.Fatalf("[Example %d] got %v, expected %v", i, got, exp)
-		}
+	if got, exp := len(ps), partitions; got != exp {
+		t.Fatalf("got %v, expected %v", got, exp)
 	}
 }
 
@@ -48,7 +32,7 @@ var strSliceRes [][]byte
 func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	// Add some keys
 	for i := 0; i < keys; i++ {
-		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), nil)
+		r.add([]byte(fmt.Sprintf("cpu,host=server-%d value=1", i)), new(entry))
 	}
 
 	b.ReportAllocs()
@@ -58,10 +42,10 @@ func benchmarkRingkeys(b *testing.B, r *ring, keys int) {
 	}
 }
 
-func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, MustNewRing(256), 100) }
-func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, MustNewRing(256), 1000) }
-func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, MustNewRing(256), 10000) }
-func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, MustNewRing(256), 100000) }
+func BenchmarkRing_keys_100(b *testing.B)    { benchmarkRingkeys(b, newring(), 100) }
+func BenchmarkRing_keys_1000(b *testing.B)   { benchmarkRingkeys(b, newring(), 1000) }
+func BenchmarkRing_keys_10000(b *testing.B)  { benchmarkRingkeys(b, newring(), 10000) }
+func BenchmarkRing_keys_100000(b *testing.B) { benchmarkRingkeys(b, newring(), 100000) }
 
 func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 	vals := make([][]byte, keys)
@@ -69,7 +53,7 @@ func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 	// Add some keys
 	for i := 0; i < keys; i++ {
 		vals[i] = []byte(fmt.Sprintf("cpu,host=server-%d field1=value1,field2=value2,field4=value4,field5=value5,field6=value6,field7=value7,field8=value1,field9=value2,field10=value4,field11=value5,field12=value6,field13=value7", i))
-		r.add(vals[i], nil)
+		r.add(vals[i], new(entry))
 	}
 
 	b.ReportAllocs()
@@ -79,10 +63,8 @@ func benchmarkRingGetPartition(b *testing.B, r *ring, keys int) {
 	}
 }
 
-func BenchmarkRing_getPartition_100(b *testing.B) { benchmarkRingGetPartition(b, MustNewRing(256), 100) }
-func BenchmarkRing_getPartition_1000(b *testing.B) {
-	benchmarkRingGetPartition(b, MustNewRing(256), 1000)
-}
+func BenchmarkRing_getPartition_100(b *testing.B)  { benchmarkRingGetPartition(b, newring(), 100) }
+func BenchmarkRing_getPartition_1000(b *testing.B) { benchmarkRingGetPartition(b, newring(), 1000) }
 
 func benchmarkRingWrite(b *testing.B, r *ring, n int) {
 	b.ReportAllocs()
@@ -114,31 +96,7 @@ func benchmarkRingWrite(b *testing.B, r *ring, n int) {
 	}
 }
 
-func BenchmarkRing_write_1_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(1), 100) }
-func BenchmarkRing_write_1_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(1), 1000) }
-func BenchmarkRing_write_1_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(1), 10000) }
-func BenchmarkRing_write_1_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(1), 100000) }
-func BenchmarkRing_write_4_100(b *testing.B)      { benchmarkRingWrite(b, MustNewRing(4), 100) }
-func BenchmarkRing_write_4_1000(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(4), 1000) }
-func BenchmarkRing_write_4_10000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(4), 10000) }
-func BenchmarkRing_write_4_100000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(4), 100000) }
-func BenchmarkRing_write_32_100(b *testing.B)     { benchmarkRingWrite(b, MustNewRing(32), 100) }
-func BenchmarkRing_write_32_1000(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(32), 1000) }
-func BenchmarkRing_write_32_10000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(32), 10000) }
-func BenchmarkRing_write_32_100000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(32), 100000) }
-func BenchmarkRing_write_128_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(128), 100) }
-func BenchmarkRing_write_128_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(128), 1000) }
-func BenchmarkRing_write_128_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(128), 10000) }
-func BenchmarkRing_write_128_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
-func BenchmarkRing_write_256_100(b *testing.B)    { benchmarkRingWrite(b, MustNewRing(256), 100) }
-func BenchmarkRing_write_256_1000(b *testing.B)   { benchmarkRingWrite(b, MustNewRing(256), 1000) }
-func BenchmarkRing_write_256_10000(b *testing.B)  { benchmarkRingWrite(b, MustNewRing(256), 10000) }
-func BenchmarkRing_write_256_100000(b *testing.B) { benchmarkRingWrite(b, MustNewRing(256), 100000) }
-
-func MustNewRing(n int) *ring {
-	r, err := newring(n)
-	if err != nil {
-		panic(err)
-	}
-	return r
-}
+func BenchmarkRing_write_100(b *testing.B)    { benchmarkRingWrite(b, newring(), 100) }
+func BenchmarkRing_write_1000(b *testing.B)   { benchmarkRingWrite(b, newring(), 1000) }
+func BenchmarkRing_write_10000(b *testing.B)  { benchmarkRingWrite(b, newring(), 10000) }
+func BenchmarkRing_write_100000(b *testing.B) { benchmarkRingWrite(b, newring(), 100000) }


### PR DESCRIPTION
The tsm1 package had a lot of exported fields that were unused making it hard to reason about changes to locks. The exported fields were only used in the tests and only because the tests were of the `tsm1_test` style. Just make it internal and do some cleanups.

The tsi1 package had some methods that were only used to be api compatible with inmem, which is no longer a thing. Baleeted.

The cache ring had code to support multiple sizes of rings that was totally dead and broken. Additionally, it had races that could cause data loss during compaction enable/disable. Removes all that support, and fixes up benchmarks/tests.