### PR TITLE
Update admin to show error if password is not 8 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [12016](https://github.com/influxdata/influxdb/pull/12016): Update the preview in the label overlays to be shorter
 1. [12012](https://github.com/influxdata/influxdb/pull/12012): Add notifications to scrapers page for created/deleted/updated scrapers 
 1. [12023](https://github.com/influxdata/influxdb/pull/12023): Add notifications to buckets page for created/deleted/updated buckets
+1. [12072](https://github.com/influxdata/influxdb/pull/12072): Update the admin page to display error for password length
 
 ## v2.0.0-alpha.3 [2019-02-15]
 

--- a/ui/src/onboarding/actions/index.ts
+++ b/ui/src/onboarding/actions/index.ts
@@ -1,3 +1,6 @@
+// Libraries
+import _ from 'lodash'
+
 // Constants
 import {StepStatus} from 'src/clockface/constants/wizard'
 import {SetupSuccess, SetupError} from 'src/shared/copy/notifications'
@@ -5,6 +8,7 @@ import {SetupSuccess, SetupError} from 'src/shared/copy/notifications'
 // Actions
 import {notify} from 'src/shared/actions/notifications'
 
+// APIs
 import {client} from 'src/utils/api'
 
 // Types
@@ -62,7 +66,9 @@ export const setBucketID = (bucketID: string): SetBucketID => ({
   payload: {bucketID},
 })
 
-export const setupAdmin = (params: ISetupParams) => async dispatch => {
+export const setupAdmin = (params: ISetupParams) => async (
+  dispatch
+): Promise<boolean> => {
   try {
     dispatch(setSetupParams(params))
     const response = await client.setup.create(params)
@@ -77,8 +83,12 @@ export const setupAdmin = (params: ISetupParams) => async dispatch => {
 
     await client.auth.signin(username, password)
     dispatch(notify(SetupSuccess))
+    dispatch(setStepStatus(1, StepStatus.Complete))
+    return true
   } catch (err) {
     console.error(err)
-    dispatch(notify(SetupError))
+    let message = _.get(err, 'response.data.message', '')
+    dispatch(notify(SetupError(message)))
+    dispatch(setStepStatus(1, StepStatus.Error))
   }
 }

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -99,10 +99,10 @@ export const SetupSuccess: Notification = {
   message: 'Initial user details have been successfully set',
 }
 
-export const SetupError: Notification = {
+export const SetupError = (message: string): Notification => ({
   ...defaultErrorNotification,
-  message: `Could not initial user at this time.`,
-}
+  message: `Could not set up admin user: ${message}`,
+})
 
 export const SetupNotAllowed: Notification = {
   ...defaultErrorNotification,


### PR DESCRIPTION
Closes #12028 

_Briefly describe your proposed changes:_
Update admin page to not proceed to next step if there is an error with passwords that are not 8 characters long

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

![kapture 2019-02-21 at 11 43 50](https://user-images.githubusercontent.com/26464594/53203196-616ba580-35dd-11e9-9ac7-b141650e580e.gif)
