### PR TITLE
Update the swagger definition for a telegraf labels post response

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -336,11 +336,11 @@ paths:
               $ref: "#/components/schemas/LabelMapping"
       responses:
         '200':
-          description: a list of all labels for a telegraf config
+          description: "the label added to the telegraf config"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LabelsResponse"
+                $ref: "#/components/schemas/LabelResponse"
         default:
           description: unexpected error
           content:
@@ -2136,7 +2136,7 @@ paths:
               $ref: "#/components/schemas/LabelMapping"
       responses:
         '200':
-          description: a list of all labels for a dashboard
+          description: the label added to the dashboard
           content:
             application/json:
               schema:


### PR DESCRIPTION
Connects #11612

_Briefly describe your proposed changes:_
update swagger to reflect that a post request to the telegraf config labels endpoint should return the label rather than a list of labels.
update the description for a post request to the dashboards labels endpoint's response 

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
