### PR TITLE
update to use org name to create task

### DIFF
--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -384,7 +384,7 @@ export const saveNewScript = (
       org = orgs[0]
     }
 
-    await client.tasks.create(getDeep<string>(org, 'id', ''), scriptWithOptions)
+    await client.tasks.create(org.name, scriptWithOptions)
 
     dispatch(setNewScript(''))
     dispatch(clearTask())


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Create task from the client expects the org name, not the org id. Org name is now being passed rather than org id.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
