### PR TITLE
Check error when writing token file during setup

### DIFF
--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -71,7 +71,11 @@ func setupF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to setup instance: %v", err)
 	}
-	writeTokenToPath(result.Auth.Token, defaultTokenPath())
+	err = writeTokenToPath(result.Auth.Token, defaultTokenPath())
+	if err != nil {
+		return fmt.Errorf("failed to write token to path %q: %v", defaultTokenPath(), err)
+	}
+
 	fmt.Println(promptWithColor("Your token has been stored in "+defaultTokenPath()+".", colorCyan))
 
 	w := internal.NewTabWriter(os.Stdout)


### PR DESCRIPTION
Signed-off-by: Julius Volz <julius.volz@gmail.com>

This tripped me up because the CLI does not actually create the directory it wants to write the token into, and at the same time the CLI always uses the user's home dir, while the server allows configuring the storage path (which is what I did, which is why the `~/.influxdbv2` didn't exist for the CLI to find). So that should probably also be fixed (create the dir if it doesn't exist) and configurable.