### PR TITLE
fix(http): separate InfluxQL and Flux services

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -535,7 +535,8 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		VariableService:                 variableSvc,
 		PasswordsService:                passwdsSvc,
 		OnboardingService:               onboardingSvc,
-		ProxyQueryService:               storageQueryService,
+		InfluxQLService:                 nil, // No InfluxQL support
+		FluxService:                     storageQueryService,
 		TaskService:                     taskSvc,
 		TelegrafService:                 telegrafSvc,
 		ScraperTargetStoreService:       scraperTargetSvc,

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -61,7 +61,8 @@ type APIBackend struct {
 	VariableService                 influxdb.VariableService
 	PasswordsService                influxdb.PasswordsService
 	OnboardingService               influxdb.OnboardingService
-	ProxyQueryService               query.ProxyQueryService
+	InfluxQLService                 query.ProxyQueryService
+	FluxService                     query.ProxyQueryService
 	TaskService                     influxdb.TaskService
 	TelegrafService                 influxdb.TelegrafConfigStore
 	ScraperTargetStoreService       influxdb.ScraperTargetStoreService

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -42,7 +42,7 @@ func NewFluxBackend(b *APIBackend) *FluxBackend {
 	return &FluxBackend{
 		Logger: b.Logger.With(zap.String("handler", "query")),
 
-		ProxyQueryService:   b.ProxyQueryService,
+		ProxyQueryService:   b.FluxService,
 		OrganizationService: b.OrganizationService,
 	}
 }


### PR DESCRIPTION
Previously the APIBackend understood only a ProxyQueryService,
but it needs to understand that there are two implementations of the
ProxyQueryService one for handling InfluxQL queries and one for handling
Flux queries. The names of the fields have been updated to make this
clear. As well as the FluxBackend is now initialized using the
FluxService explicitly.
