### PR TITLE
Make user owner of org/dashboard on create

### DIFF
--- a/kv/dashboard.go
+++ b/kv/dashboard.go
@@ -8,6 +8,7 @@ import (
 
 	influxdb "github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
+	"go.uber.org/zap"
 )
 
 var (
@@ -301,7 +302,15 @@ func (s *Service) CreateDashboard(ctx context.Context, d *influxdb.Dashboard) er
 		// TODO(desa): don't populate this here. use the first/last methods of the oplog to get meta fields.
 		d.Meta.CreatedAt = s.time()
 
-		return s.putDashboardWithMeta(ctx, tx, d)
+		if err := s.putDashboardWithMeta(ctx, tx, d); err != nil {
+			return err
+		}
+
+		if err := s.addDashboardOwner(ctx, tx, d.ID); err != nil {
+			s.Logger.Info("failed to make user owner of organization", zap.Error(err))
+		}
+
+		return nil
 	})
 	if err != nil {
 		return &influxdb.Error{
@@ -309,6 +318,12 @@ func (s *Service) CreateDashboard(ctx context.Context, d *influxdb.Dashboard) er
 		}
 	}
 	return nil
+}
+
+// addDashboardOwner attempts to create a user resource mapping for the user on the
+// authorizer found on context. If no authorizer is found on context if returns an error.
+func (s *Service) addDashboardOwner(ctx context.Context, tx Tx, orgID influxdb.ID) error {
+	return s.addResourceOwner(ctx, tx, influxdb.DashboardsResourceType, orgID)
 }
 
 func (s *Service) createCellView(ctx context.Context, tx Tx, dashID, cellID influxdb.ID, view *influxdb.View) error {

--- a/kv/org.go
+++ b/kv/org.go
@@ -8,6 +8,7 @@ import (
 
 	influxdb "github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
+	"go.uber.org/zap"
 )
 
 var (
@@ -213,8 +214,24 @@ func (s *Service) FindOrganizations(ctx context.Context, filter influxdb.Organiz
 // CreateOrganization creates a influxdb organization and sets b.ID.
 func (s *Service) CreateOrganization(ctx context.Context, o *influxdb.Organization) error {
 	return s.kv.Update(func(tx Tx) error {
-		return s.createOrganization(ctx, tx, o)
+		if err := s.createOrganization(ctx, tx, o); err != nil {
+			return err
+		}
+
+		// Attempt to add user as owner of organization, if that is not possible allow the
+		// organization to be created anyways.
+		if err := s.addOrgOwner(ctx, tx, o.ID); err != nil {
+			s.Logger.Info("failed to make user owner of organization", zap.Error(err))
+		}
+
+		return nil
 	})
+}
+
+// addOrgOwner attempts to create a user resource mapping for the user on the
+// authorizer found on context. If no authorizer is found on context if returns an error.
+func (s *Service) addOrgOwner(ctx context.Context, tx Tx, orgID influxdb.ID) error {
+	return s.addResourceOwner(ctx, tx, influxdb.OrgsResourceType, orgID)
 }
 
 func (s *Service) createOrganization(ctx context.Context, tx Tx, o *influxdb.Organization) error {


### PR DESCRIPTION
Closes #12067

_Briefly describe your proposed changes:_
This PR attempts to add the user as an owner of an organization or dashboard when they are created. If the add fails, it logs an error, but still creates the resource.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
