### PR TITLE
Clean up histogram implementation

### DIFF
--- a/ui/src/minard/components/Histogram.tsx
+++ b/ui/src/minard/components/Histogram.tsx
@@ -47,7 +47,7 @@ export const Histogram: SFC<Props> = ({
   const layer = useLayer(
     env,
     () => {
-      const [table, aesthetics] = bin(
+      const [table, mappings] = bin(
         baseTable,
         x,
         xDomain,
@@ -56,7 +56,7 @@ export const Histogram: SFC<Props> = ({
         position
       )
 
-      return {table, aesthetics, colors, scales: {}}
+      return {table, mappings, colors, scales: {}}
     },
     [baseTable, xDomain, x, fill, position, binCount, colors]
   )
@@ -75,12 +75,12 @@ export const Histogram: SFC<Props> = ({
     },
   } = env
 
-  const {aesthetics, table} = layer
+  const {mappings, table} = layer
 
   const hoveredRowIndices = findHoveredRowIndices(
-    table.columns[aesthetics.xMin],
-    table.columns[aesthetics.xMax],
-    table.columns[aesthetics.yMax],
+    table.columns[mappings.xMin],
+    table.columns[mappings.xMax],
+    table.columns[mappings.yMax],
     hoverX,
     hoverY,
     xScale,

--- a/ui/src/minard/components/Histogram.tsx
+++ b/ui/src/minard/components/Histogram.tsx
@@ -1,6 +1,6 @@
 import React, {SFC} from 'react'
 
-import {PlotEnv} from 'src/minard'
+import {PlotEnv, HistogramLayer} from 'src/minard'
 import {bin} from 'src/minard/utils/bin'
 import HistogramBars from 'src/minard/components/HistogramBars'
 import HistogramTooltip from 'src/minard/components/HistogramTooltip'
@@ -56,10 +56,10 @@ export const Histogram: SFC<Props> = ({
         position
       )
 
-      return {table, mappings, colors, scales: {}}
+      return {type: 'histogram', table, mappings, colors}
     },
     [baseTable, xDomain, x, fill, position, binCount, colors]
-  )
+  ) as HistogramLayer
 
   if (!layer) {
     return null
@@ -75,12 +75,10 @@ export const Histogram: SFC<Props> = ({
     },
   } = env
 
-  const {mappings, table} = layer
+  const {table} = layer
 
   const hoveredRowIndices = findHoveredRowIndices(
-    table.columns[mappings.xMin],
-    table.columns[mappings.xMax],
-    table.columns[mappings.yMax],
+    table,
     hoverX,
     hoverY,
     xScale,

--- a/ui/src/minard/components/HistogramBars.tsx
+++ b/ui/src/minard/components/HistogramBars.tsx
@@ -1,6 +1,6 @@
 import React, {useRef, useLayoutEffect, SFC} from 'react'
 
-import {Scale, HistogramPosition, Layer} from 'src/minard'
+import {Scale, HistogramPosition, HistogramLayer} from 'src/minard'
 import {clearCanvas} from 'src/minard/utils/clearCanvas'
 import {getBarFill} from 'src/minard/utils/getBarFill'
 
@@ -11,7 +11,7 @@ const BAR_PADDING = 1.5
 interface Props {
   width: number
   height: number
-  layer: Layer
+  layer: HistogramLayer
   xScale: Scale<number, number>
   yScale: Scale<number, number>
   position: HistogramPosition
@@ -24,11 +24,11 @@ const drawBars = (
 ): void => {
   clearCanvas(canvas, width, height)
 
-  const {table, mappings} = layer
-  const xMinCol = table.columns[mappings.xMin]
-  const xMaxCol = table.columns[mappings.xMax]
-  const yMinCol = table.columns[mappings.yMin]
-  const yMaxCol = table.columns[mappings.yMax]
+  const {table} = layer
+  const xMinCol = table.columns.xMin.data
+  const xMaxCol = table.columns.xMax.data
+  const yMinCol = table.columns.yMin.data
+  const yMaxCol = table.columns.yMax.data
 
   const context = canvas.getContext('2d')
 

--- a/ui/src/minard/components/HistogramBars.tsx
+++ b/ui/src/minard/components/HistogramBars.tsx
@@ -24,11 +24,11 @@ const drawBars = (
 ): void => {
   clearCanvas(canvas, width, height)
 
-  const {table, aesthetics} = layer
-  const xMinCol = table.columns[aesthetics.xMin]
-  const xMaxCol = table.columns[aesthetics.xMax]
-  const yMinCol = table.columns[aesthetics.yMin]
-  const yMaxCol = table.columns[aesthetics.yMax]
+  const {table, mappings} = layer
+  const xMinCol = table.columns[mappings.xMin]
+  const xMaxCol = table.columns[mappings.xMax]
+  const yMinCol = table.columns[mappings.yMin]
+  const yMaxCol = table.columns[mappings.yMax]
 
   const context = canvas.getContext('2d')
 

--- a/ui/src/minard/components/HistogramTooltip.tsx
+++ b/ui/src/minard/components/HistogramTooltip.tsx
@@ -1,6 +1,6 @@
 import React, {useRef, SFC} from 'react'
 
-import {HistogramTooltipProps, Layer} from 'src/minard'
+import {HistogramTooltipProps, HistogramLayer} from 'src/minard'
 import {useLayoutStyle} from 'src/minard/utils/useLayoutStyle'
 import {useMousePos} from 'src/minard/utils/useMousePos'
 import {getHistogramTooltipProps} from 'src/minard/utils/getHistogramTooltipProps'
@@ -12,7 +12,7 @@ interface Props {
   hoverX: number
   hoverY: number
   tooltip?: (props: HistogramTooltipProps) => JSX.Element
-  layer: Layer
+  layer: HistogramLayer
   hoveredRowIndices: number[] | null
 }
 

--- a/ui/src/minard/index.ts
+++ b/ui/src/minard/index.ts
@@ -39,7 +39,7 @@ export interface AestheticScaleMappings {
 
 export interface Layer {
   table?: Table
-  aesthetics: AestheticDataMappings
+  mappings: AestheticDataMappings
   scales: AestheticScaleMappings
   colors?: string[]
   xDomain?: [number, number]

--- a/ui/src/minard/index.ts
+++ b/ui/src/minard/index.ts
@@ -17,34 +17,119 @@ export {
   TooltipProps as HistogramTooltipProps,
 } from 'src/minard/components/Histogram'
 
+export {isNumeric} from 'src/minard/utils/isNumeric'
+
+export type ColumnType = 'int' | 'uint' | 'float' | 'string' | 'time' | 'bool'
+
+export type NumericColumnType = 'int' | 'uint' | 'float' | 'time'
+
+export interface FloatColumn {
+  data: number[]
+  type: 'float'
+}
+
+export interface IntColumn {
+  data: number[]
+  type: 'int'
+}
+
+export interface UIntColumn {
+  data: number[]
+  type: 'uint'
+}
+
+export interface TimeColumn {
+  data: number[]
+  type: 'time'
+}
+
+export interface StringColumn {
+  data: string[]
+  type: 'string'
+}
+
+export interface BoolColumn {
+  data: boolean[]
+  type: 'bool'
+}
+
+export type NumericTableColumn =
+  | FloatColumn
+  | IntColumn
+  | UIntColumn
+  | TimeColumn
+
+export type TableColumn =
+  | FloatColumn
+  | IntColumn
+  | UIntColumn
+  | TimeColumn
+  | StringColumn
+  | BoolColumn
+
+export interface Table {
+  length: number
+  columns: {
+    [columnName: string]: TableColumn
+  }
+}
+
+export type LayerType = 'base' | 'histogram'
+
 export interface Scale<D = number, R = number> {
   (x: D): R
   invert?: (y: R) => D
 }
 
-export interface AestheticDataMappings {
-  x?: string
-  fill?: string[]
-  xMin?: string
-  xMax?: string
-  yMin?: string
-  yMax?: string
+export interface BaseLayerMappings {}
+
+export interface BaseLayerScales {
+  x: Scale<number, number>
+  y: Scale<number, number>
 }
 
-export interface AestheticScaleMappings {
-  x?: Scale<number, number>
-  y?: Scale<number, number>
-  fill?: Scale<string, string>
+export interface BaseLayer {
+  type: 'base'
+  table: Table
+  scales: BaseLayerScales
+  mappings: {}
+  xDomain: [number, number]
+  yDomain: [number, number]
 }
 
-export interface Layer {
-  table?: Table
-  mappings: AestheticDataMappings
-  scales: AestheticScaleMappings
-  colors?: string[]
-  xDomain?: [number, number]
-  yDomain?: [number, number]
+export interface HistogramTable extends Table {
+  columns: {
+    xMin: NumericTableColumn
+    xMax: NumericTableColumn
+    yMin: IntColumn
+    yMax: IntColumn
+    [fillColumn: string]: TableColumn
+  }
+  length: number
 }
+
+export interface HistogramMappings {
+  xMin: 'xMin'
+  xMax: 'xMax'
+  yMin: 'yMin'
+  yMax: 'yMax'
+  fill: string[]
+}
+
+export interface HistogramScales {
+  // x and y scale are from the `BaseLayer`
+  fill: Scale<string, string>
+}
+
+export interface HistogramLayer {
+  type: 'histogram'
+  table: HistogramTable
+  mappings: HistogramMappings
+  scales: HistogramScales
+  colors: string[]
+}
+
+export type Layer = BaseLayer | HistogramLayer
 
 export interface Margins {
   top: number
@@ -69,103 +154,9 @@ export interface PlotEnv {
   xDomain: [number, number]
   yDomain: [number, number]
 
-  baseLayer: Layer
+  baseLayer: BaseLayer
   layers: {[layerKey: string]: Layer}
   hoverX: number
   hoverY: number
   dispatch: (action: PlotAction) => void
 }
-
-export enum ColumnType {
-  Numeric = 'numeric',
-  Categorical = 'categorical',
-  Temporal = 'temporal',
-  Boolean = 'bool',
-}
-
-export interface Table {
-  columns: {[columnName: string]: any[]}
-  columnTypes: {[columnName: string]: ColumnType}
-}
-
-// export enum InterpolationKind {
-//   Linear = 'linear',
-//   MonotoneX = 'monotoneX',
-//   MonotoneY = 'monotoneY',
-//   Cubic = 'cubic',
-//   Step = 'step',
-//   StepBefore = 'stepBefore',
-//   StepAfter = 'stepAfter',
-// }
-
-// export interface LineProps {
-//   x?: string
-//   y?: string
-//   stroke?: string
-//   strokeWidth?: string
-//   interpolate?: InterpolationKind
-// }
-
-// export enum AreaPositionKind {
-//   Stack = 'stack',
-//   Overlay = 'overlay',
-// }
-
-// export interface AreaProps {
-//   x?: string
-//   y?: string
-//   position?: AreaPositionKind
-// }
-
-// export enum ShapeKind {
-//   Point = 'point',
-//   // Spade, Heart, Club, Triangle, Hexagon, etc.
-// }
-
-// export interface PointProps {
-//   x?: string
-//   y?: string
-//   fill?: string
-//   shape?: ShapeKind
-//   radius?: number
-//   alpha?: number
-// }
-
-// export interface ContinuousBarProps {
-//   x0?: string
-//   x1?: string
-//   y?: string
-//   fill?: string
-// }
-
-// export enum DiscreteBarPositionKind {
-//   Stack = 'stack',
-//   Dodge = 'dodge',
-// }
-
-// export interface DiscreteBarProps {
-//   x?: string
-//   y?: string
-//   fill?: string
-//   position?: DiscreteBarPositionKind
-// }
-
-// export interface StepLineProps {
-//   x0?: string
-//   x1?: string
-//   y?: string
-// }
-
-// export interface StepAreaProps {
-//   x0?: string
-//   x1?: string
-//   y?: string
-//   position?: AreaPositionKind
-// }
-
-// export interface Bin2DProps {
-//   x?: string
-//   y?: string
-//   binWidth?: number
-//   binHeight?: number
-// }

--- a/ui/src/minard/utils/bin.test.ts
+++ b/ui/src/minard/utils/bin.test.ts
@@ -1,39 +1,44 @@
-import {HistogramPosition, ColumnType} from 'src/minard'
+import {HistogramPosition, Table} from 'src/minard'
 import {bin} from 'src/minard/utils/bin'
 
-const TABLE = {
+const TABLE: Table = {
   columns: {
-    _value: [70, 56, 60, 100, 76, 0, 63, 48, 79, 67],
-    _field: [
-      'usage_guest',
-      'usage_guest',
-      'usage_guest',
-      'usage_guest',
-      'usage_guest',
-      'usage_idle',
-      'usage_idle',
-      'usage_idle',
-      'usage_idle',
-      'usage_idle',
-    ],
-    cpu: [
-      'cpu0',
-      'cpu0',
-      'cpu0',
-      'cpu1',
-      'cpu1',
-      'cpu0',
-      'cpu0',
-      'cpu0',
-      'cpu1',
-      'cpu1',
-    ],
+    _value: {
+      data: [70, 56, 60, 100, 76, 0, 63, 48, 79, 67],
+      type: 'int',
+    },
+    _field: {
+      data: [
+        'usage_guest',
+        'usage_guest',
+        'usage_guest',
+        'usage_guest',
+        'usage_guest',
+        'usage_idle',
+        'usage_idle',
+        'usage_idle',
+        'usage_idle',
+        'usage_idle',
+      ],
+      type: 'string',
+    },
+    cpu: {
+      data: [
+        'cpu0',
+        'cpu0',
+        'cpu0',
+        'cpu1',
+        'cpu1',
+        'cpu0',
+        'cpu0',
+        'cpu0',
+        'cpu1',
+        'cpu1',
+      ],
+      type: 'string',
+    },
   },
-  columnTypes: {
-    _value: ColumnType.Numeric,
-    _field: ColumnType.Categorical,
-    cpu: ColumnType.Categorical,
-  },
+  length: 10,
 }
 
 describe('bin', () => {
@@ -41,20 +46,15 @@ describe('bin', () => {
     const actual = bin(TABLE, '_value', null, [], 5, HistogramPosition.Stacked)
     const expected = [
       {
-        columnTypes: {
-          xMax: 'numeric',
-          xMin: 'numeric',
-          yMax: 'numeric',
-          yMin: 'numeric',
-        },
         columns: {
-          xMax: [20, 40, 60, 80, 100],
-          xMin: [0, 20, 40, 60, 80],
-          yMax: [1, 0, 2, 6, 1],
-          yMin: [0, 0, 0, 0, 0],
+          xMin: {data: [0, 20, 40, 60, 80], type: 'int'},
+          xMax: {data: [20, 40, 60, 80, 100], type: 'int'},
+          yMin: {data: [0, 0, 0, 0, 0], type: 'int'},
+          yMax: {data: [1, 0, 2, 6, 1], type: 'int'},
         },
+        length: 5,
       },
-      {fill: [], xMax: 'xMax', xMin: 'xMin', yMax: 'yMax', yMin: 'yMin'},
+      {xMin: 'xMin', xMax: 'xMax', yMin: 'yMin', yMax: 'yMax', fill: []},
     ]
 
     expect(actual).toEqual(expected)
@@ -71,22 +71,25 @@ describe('bin', () => {
     )[0].columns
 
     const expected = {
-      _field: [
-        'usage_guest',
-        'usage_guest',
-        'usage_guest',
-        'usage_guest',
-        'usage_guest',
-        'usage_idle',
-        'usage_idle',
-        'usage_idle',
-        'usage_idle',
-        'usage_idle',
-      ],
-      xMax: [20, 40, 60, 80, 100, 20, 40, 60, 80, 100],
-      xMin: [0, 20, 40, 60, 80, 0, 20, 40, 60, 80],
-      yMax: [0, 0, 1, 3, 1, 1, 0, 2, 6, 1],
-      yMin: [0, 0, 0, 0, 0, 0, 0, 1, 3, 1],
+      xMin: {data: [0, 20, 40, 60, 80, 0, 20, 40, 60, 80], type: 'int'},
+      xMax: {data: [20, 40, 60, 80, 100, 20, 40, 60, 80, 100], type: 'int'},
+      yMin: {data: [0, 0, 0, 0, 0, 0, 0, 1, 3, 1], type: 'int'},
+      yMax: {data: [0, 0, 1, 3, 1, 1, 0, 2, 6, 1], type: 'int'},
+      _field: {
+        data: [
+          'usage_guest',
+          'usage_guest',
+          'usage_guest',
+          'usage_guest',
+          'usage_guest',
+          'usage_idle',
+          'usage_idle',
+          'usage_idle',
+          'usage_idle',
+          'usage_idle',
+        ],
+        type: 'string',
+      },
     }
 
     expect(actual).toEqual(expected)
@@ -103,22 +106,25 @@ describe('bin', () => {
     )[0].columns
 
     const expected = {
-      _field: [
-        'usage_guest',
-        'usage_guest',
-        'usage_guest',
-        'usage_guest',
-        'usage_guest',
-        'usage_idle',
-        'usage_idle',
-        'usage_idle',
-        'usage_idle',
-        'usage_idle',
-      ],
-      xMax: [20, 40, 60, 80, 100, 20, 40, 60, 80, 100],
-      xMin: [0, 20, 40, 60, 80, 0, 20, 40, 60, 80],
-      yMax: [0, 0, 1, 3, 1, 1, 0, 1, 3, 0],
-      yMin: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      xMin: {data: [0, 20, 40, 60, 80, 0, 20, 40, 60, 80], type: 'int'},
+      xMax: {data: [20, 40, 60, 80, 100, 20, 40, 60, 80, 100], type: 'int'},
+      yMin: {data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], type: 'int'},
+      yMax: {data: [0, 0, 1, 3, 1, 1, 0, 1, 3, 0], type: 'int'},
+      _field: {
+        data: [
+          'usage_guest',
+          'usage_guest',
+          'usage_guest',
+          'usage_guest',
+          'usage_guest',
+          'usage_idle',
+          'usage_idle',
+          'usage_idle',
+          'usage_idle',
+          'usage_idle',
+        ],
+        type: 'string',
+      },
     }
 
     expect(actual).toEqual(expected)
@@ -135,10 +141,16 @@ describe('bin', () => {
     )[0].columns
 
     const expected = {
-      xMax: [-160, -120, -80, -40, 0, 40, 80, 120, 160, 200],
-      xMin: [-200, -160, -120, -80, -40, 0, 40, 80, 120, 160],
-      yMax: [0, 0, 0, 0, 0, 1, 8, 1, 0, 0],
-      yMin: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      xMin: {
+        data: [-200, -160, -120, -80, -40, 0, 40, 80, 120, 160],
+        type: 'int',
+      },
+      xMax: {
+        data: [-160, -120, -80, -40, 0, 40, 80, 120, 160, 200],
+        type: 'int',
+      },
+      yMin: {data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0], type: 'int'},
+      yMax: {data: [0, 0, 0, 0, 0, 1, 8, 1, 0, 0], type: 'int'},
     }
 
     expect(actual).toEqual(expected)
@@ -155,10 +167,10 @@ describe('bin', () => {
     )[0].columns
 
     const expected = {
-      xMax: [60, 70, 80],
-      xMin: [50, 60, 70],
-      yMax: [1, 3, 3],
-      yMin: [0, 0, 0],
+      xMin: {data: [50, 60, 70], type: 'int'},
+      xMax: {data: [60, 70, 80], type: 'int'},
+      yMin: {data: [0, 0, 0], type: 'int'},
+      yMax: {data: [1, 3, 3], type: 'int'},
     }
 
     expect(actual).toEqual(expected)

--- a/ui/src/minard/utils/bin.ts
+++ b/ui/src/minard/utils/bin.ts
@@ -1,6 +1,13 @@
 import {extent, range, thresholdSturges} from 'd3-array'
 
-import {Table, HistogramPosition, ColumnType} from 'src/minard'
+import {
+  Table,
+  HistogramTable,
+  HistogramMappings,
+  HistogramPosition,
+  NumericColumnType,
+  isNumeric,
+} from 'src/minard'
 import {assert} from 'src/minard/utils/assert'
 import {getGroupKey} from 'src/minard/utils/getGroupKey'
 
@@ -37,15 +44,14 @@ export const bin = (
   groupColNames: string[] = [],
   binCount: number,
   position: HistogramPosition
-) => {
-  const xCol = table.columns[xColName]
-  const xColType = table.columnTypes[xColName]
+): [HistogramTable, HistogramMappings] => {
+  const col = table.columns[xColName]
 
-  assert(`could not find column "${xColName}"`, !!xCol)
-  assert(
-    `unsupported value column type "${xColType}"`,
-    xColType === ColumnType.Numeric || xColType === ColumnType.Temporal
-  )
+  assert(`could not find column "${xColName}"`, !!col)
+  assert(`unsupported value column type "${col.type}"`, isNumeric(col.type))
+
+  const xCol = col.data as number[]
+  const xColType = col.type as NumericColumnType
 
   if (!binCount) {
     binCount = thresholdSturges(xCol)
@@ -91,23 +97,36 @@ export const bin = (
   }
 
   // Next, build up a tabular representation of each of these bins by group
+  const groupKeys = Object.keys(groupsByGroupKey)
   const statTable = {
-    columns: {xMin: [], xMax: [], yMin: [], yMax: []},
-    columnTypes: {
-      xMin: xColType,
-      xMax: xColType,
-      yMin: ColumnType.Numeric,
-      yMax: ColumnType.Numeric,
+    columns: {
+      xMin: {
+        data: [],
+        type: xColType,
+      },
+      xMax: {
+        data: [],
+        type: xColType,
+      },
+      yMin: {
+        data: [],
+        type: 'int',
+      },
+      yMax: {
+        data: [],
+        type: 'int',
+      },
     },
+    length: binCount * groupKeys.length,
   }
 
   // Include original columns used to group data in the resulting table
   for (const name of groupColNames) {
-    statTable.columns[name] = []
-    statTable.columnTypes[name] = table.columnTypes[name]
+    statTable.columns[name] = {
+      data: [],
+      type: table.columns[name].type,
+    }
   }
-
-  const groupKeys = Object.keys(groupsByGroupKey)
 
   for (let i = 0; i < groupKeys.length; i++) {
     const groupKey = groupKeys[i]
@@ -121,18 +140,18 @@ export const bin = (
           .reduce((sum, k) => sum + (bin.values[k] || 0), 0)
       }
 
-      statTable.columns.xMin.push(bin.min)
-      statTable.columns.xMax.push(bin.max)
-      statTable.columns.yMin.push(yMin)
-      statTable.columns.yMax.push(yMin + (bin.values[groupKey] || 0))
+      statTable.columns.xMin.data.push(bin.min)
+      statTable.columns.xMax.data.push(bin.max)
+      statTable.columns.yMin.data.push(yMin)
+      statTable.columns.yMax.data.push(yMin + (bin.values[groupKey] || 0))
 
       for (const [k, v] of Object.entries(groupsByGroupKey[groupKey])) {
-        statTable.columns[k].push(v)
+        statTable.columns[k].data.push(v)
       }
     }
   }
 
-  const mappings: any = {
+  const mappings: HistogramMappings = {
     xMin: 'xMin',
     xMax: 'xMax',
     yMin: 'yMin',
@@ -140,7 +159,7 @@ export const bin = (
     fill: groupColNames,
   }
 
-  return [statTable, mappings]
+  return [statTable as HistogramTable, mappings]
 }
 
 const createBins = (
@@ -186,7 +205,7 @@ const getGroup = (table: Table, groupColNames: string[], i: number) => {
   const result = {}
 
   for (const key of groupColNames) {
-    result[key] = table.columns[key][i]
+    result[key] = table.columns[key].data[i]
   }
 
   return result

--- a/ui/src/minard/utils/findHoveredRowIndices.tsx
+++ b/ui/src/minard/utils/findHoveredRowIndices.tsx
@@ -1,10 +1,10 @@
 import {Scale} from 'src/minard'
 import {range} from 'd3-array'
 
+import {HistogramTable} from 'src/minard'
+
 export const findHoveredRowIndices = (
-  xMinCol: number[],
-  xMaxCol: number[],
-  yMaxCol: number[],
+  table: HistogramTable,
   hoverX: number,
   hoverY: number,
   xScale: Scale,
@@ -14,6 +14,9 @@ export const findHoveredRowIndices = (
     return null
   }
 
+  const xMinCol = table.columns.xMin.data
+  const xMaxCol = table.columns.xMax.data
+  const yMaxCol = table.columns.yMax.data
   const dataX = xScale.invert(hoverX)
   const dataY = yScale.invert(hoverY)
 

--- a/ui/src/minard/utils/getBarFill.ts
+++ b/ui/src/minard/utils/getBarFill.ts
@@ -13,11 +13,11 @@ import {getGroupKey} from 'src/minard/utils/getGroupKey'
 //    key”) that the scale uses as a domain
 // 3. Lookup the scale and get the color via this representation
 export const getBarFill = (
-  {scales, aesthetics, table}: Layer,
+  {scales, mappings, table}: Layer,
   i: number
 ): string => {
   const fillScale = scales.fill
-  const values = aesthetics.fill.map(colKey => table.columns[colKey][i])
+  const values = mappings.fill.map(colKey => table.columns[colKey][i])
   const groupKey = getGroupKey(values)
   const fill = fillScale(groupKey)
 

--- a/ui/src/minard/utils/getBarFill.ts
+++ b/ui/src/minard/utils/getBarFill.ts
@@ -1,4 +1,4 @@
-import {Layer} from 'src/minard'
+import {HistogramLayer} from 'src/minard'
 import {getGroupKey} from 'src/minard/utils/getGroupKey'
 
 // Given a histogram `Layer` and the index of row in its table, this function
@@ -13,11 +13,11 @@ import {getGroupKey} from 'src/minard/utils/getGroupKey'
 //    key”) that the scale uses as a domain
 // 3. Lookup the scale and get the color via this representation
 export const getBarFill = (
-  {scales, mappings, table}: Layer,
+  {scales, mappings, table}: HistogramLayer,
   i: number
 ): string => {
   const fillScale = scales.fill
-  const values = mappings.fill.map(colKey => table.columns[colKey][i])
+  const values = mappings.fill.map(colKey => table.columns[colKey].data[i])
   const groupKey = getGroupKey(values)
   const fill = fillScale(groupKey)
 

--- a/ui/src/minard/utils/getHistogramTooltipProps.ts
+++ b/ui/src/minard/utils/getHistogramTooltipProps.ts
@@ -1,21 +1,22 @@
-import {HistogramTooltipProps, Layer} from 'src/minard'
+import {HistogramTooltipProps, HistogramLayer} from 'src/minard'
 import {getBarFill} from 'src/minard/utils/getBarFill'
 
 export const getHistogramTooltipProps = (
-  layer: Layer,
+  layer: HistogramLayer,
   rowIndices: number[]
 ): HistogramTooltipProps => {
   const {table, mappings} = layer
-  const xMinCol = table.columns[mappings.xMin]
-  const xMaxCol = table.columns[mappings.xMax]
-  const yMinCol = table.columns[mappings.yMin]
-  const yMaxCol = table.columns[mappings.yMax]
+
+  const xMinCol = table.columns.xMin.data
+  const xMaxCol = table.columns.xMax.data
+  const yMinCol = table.columns.yMin.data
+  const yMaxCol = table.columns.yMax.data
 
   const counts = rowIndices.map(i => {
     const grouping = mappings.fill.reduce(
       (acc, colName) => ({
         ...acc,
-        [colName]: table.columns[colName][i],
+        [colName]: table.columns[colName].data[i],
       }),
       {}
     )

--- a/ui/src/minard/utils/getHistogramTooltipProps.ts
+++ b/ui/src/minard/utils/getHistogramTooltipProps.ts
@@ -5,14 +5,14 @@ export const getHistogramTooltipProps = (
   layer: Layer,
   rowIndices: number[]
 ): HistogramTooltipProps => {
-  const {table, aesthetics} = layer
-  const xMinCol = table.columns[aesthetics.xMin]
-  const xMaxCol = table.columns[aesthetics.xMax]
-  const yMinCol = table.columns[aesthetics.yMin]
-  const yMaxCol = table.columns[aesthetics.yMax]
+  const {table, mappings} = layer
+  const xMinCol = table.columns[mappings.xMin]
+  const xMaxCol = table.columns[mappings.xMax]
+  const yMinCol = table.columns[mappings.yMin]
+  const yMaxCol = table.columns[mappings.yMax]
 
   const counts = rowIndices.map(i => {
-    const grouping = aesthetics.fill.reduce(
+    const grouping = mappings.fill.reduce(
       (acc, colName) => ({
         ...acc,
         [colName]: table.columns[colName][i],

--- a/ui/src/minard/utils/isNumeric.ts
+++ b/ui/src/minard/utils/isNumeric.ts
@@ -1,0 +1,6 @@
+import {ColumnType} from 'src/minard'
+
+const NUMERIC_TYPES = new Set(['uint', 'int', 'float', 'time'])
+
+export const isNumeric = (columnType: ColumnType): boolean =>
+  NUMERIC_TYPES.has(columnType)

--- a/ui/src/minard/utils/plotEnvActions.ts
+++ b/ui/src/minard/utils/plotEnvActions.ts
@@ -13,13 +13,13 @@ interface RegisterLayerAction {
   type: 'REGISTER_LAYER'
   payload: {
     layerKey: string
-    layer: Layer
+    layer: Partial<Layer>
   }
 }
 
 export const registerLayer = (
   layerKey: string,
-  layer: Layer
+  layer: Partial<Layer>
 ): RegisterLayerAction => ({
   type: 'REGISTER_LAYER',
   payload: {layerKey, layer},

--- a/ui/src/minard/utils/plotEnvReducer.ts
+++ b/ui/src/minard/utils/plotEnvReducer.ts
@@ -33,7 +33,7 @@ export const INITIAL_PLOT_ENV: PlotEnv = {
   yDomain: null,
   baseLayer: {
     table: {columns: {}, columnTypes: {}},
-    aesthetics: {},
+    mappings: {},
     scales: {},
   },
   layers: {},
@@ -117,20 +117,21 @@ export const plotEnvReducer = (state: PlotEnv, action: PlotAction): PlotEnv =>
 
 /*
   Find all columns in the current in all layers that are mapped to the supplied
-  aesthetics
+  aesthetic mappings
 */
 const getColumnsForAesthetics = (
   state: PlotEnv,
-  aesthetics: string[]
+  mappings: string[]
 ): any[][] => {
   const {baseLayer, layers} = state
 
   const cols = []
 
   for (const layer of Object.values(layers)) {
-    for (const aes of aesthetics) {
-      if (layer.aesthetics[aes]) {
-        const colName = layer.aesthetics[aes]
+    for (const mapping of mappings) {
+      const colName = layer.mappings[mapping]
+
+      if (colName) {
         const col = layer.table
           ? layer.table.columns[colName]
           : baseLayer.table.columns[colName]
@@ -272,8 +273,8 @@ const getColorScale = (
   of data (for now). So the domain of the scale is a set of "group keys" which
   represent all possible groupings of data in the layer.
 */
-const getFillDomain = ({table, aesthetics}: Layer): string[] => {
-  const fillColKeys = aesthetics.fill
+const getFillDomain = ({table, mappings}: Layer): string[] => {
+  const fillColKeys = mappings.fill
 
   if (!fillColKeys.length) {
     return []
@@ -299,7 +300,7 @@ const setFillScales = (draftState: PlotEnv) => {
   layers
     .filter(
       // Pick out the layers that actually need a fill scale
-      layer => layer.aesthetics.fill && layer.colors && layer.colors.length
+      layer => layer.mappings.fill && layer.colors && layer.colors.length
     )
     .forEach(layer => {
       layer.scales.fill = getColorScale(getFillDomain(layer), layer.colors)

--- a/ui/src/minard/utils/useLayer.ts
+++ b/ui/src/minard/utils/useLayer.ts
@@ -10,7 +10,7 @@ import {registerLayer, unregisterLayer} from 'src/minard/utils/plotEnvActions'
 */
 export const useLayer = (
   env: PlotEnv,
-  layerFactory: () => Layer,
+  layerFactory: () => Partial<Layer>,
   inputs?: DependencyList
 ) => {
   const {current: layerKey} = useRef(uuid.v4())

--- a/ui/src/shared/components/Histogram.tsx
+++ b/ui/src/shared/components/Histogram.tsx
@@ -5,8 +5,8 @@ import {AutoSizer} from 'react-virtualized'
 import {
   Plot as MinardPlot,
   Histogram as MinardHistogram,
-  ColumnType,
   Table,
+  isNumeric,
 } from 'src/minard'
 
 // Components
@@ -52,18 +52,18 @@ type Props = OwnProps & DispatchProps
 */
 const resolveMappings = (
   table: Table,
-  preferredXColumn: string,
-  preferredFillColumns: string[] = []
+  preferredXColumnName: string,
+  preferredFillColumnNames: string[] = []
 ): {x: string; fill: string[]} => {
-  let x: string = preferredXColumn
+  let x: string = preferredXColumnName
 
-  if (!table.columns[x] || table.columnTypes[x] !== ColumnType.Numeric) {
-    x = Object.entries(table.columnTypes)
-      .filter(([__, type]) => type === ColumnType.Numeric)
+  if (!table.columns[x] || !isNumeric(table.columns[x].type)) {
+    x = Object.entries(table.columns)
+      .filter(([__, {type}]) => isNumeric(type))
       .map(([name]) => name)[0]
   }
 
-  let fill = preferredFillColumns || []
+  let fill = preferredFillColumnNames || []
 
   fill = fill.filter(name => table.columns[name])
 
@@ -99,27 +99,33 @@ const Histogram: SFC<Props> = ({
 
   return (
     <AutoSizer>
-      {({width, height}) => (
-        <MinardPlot
-          table={table}
-          width={width}
-          height={height}
-          xDomain={xDomain}
-          onSetXDomain={setXDomain}
-        >
-          {env => (
-            <MinardHistogram
-              env={env}
-              x={mappings.x}
-              fill={fill}
-              binCount={binCount}
-              position={position}
-              tooltip={HistogramTooltip}
-              colors={colorHexes}
-            />
-          )}
-        </MinardPlot>
-      )}
+      {({width, height}) => {
+        if (width === 0 || height === 0) {
+          return null
+        }
+
+        return (
+          <MinardPlot
+            table={table}
+            width={width}
+            height={height}
+            xDomain={xDomain}
+            onSetXDomain={setXDomain}
+          >
+            {env => (
+              <MinardHistogram
+                env={env}
+                x={mappings.x}
+                fill={fill}
+                binCount={binCount}
+                position={position}
+                tooltip={HistogramTooltip}
+                colors={colorHexes}
+              />
+            )}
+          </MinardPlot>
+        )
+      }}
     </AutoSizer>
   )
 }

--- a/ui/src/shared/utils/toMinardTable.test.ts
+++ b/ui/src/shared/utils/toMinardTable.test.ts
@@ -20,31 +20,42 @@ describe('toMinardTable', () => {
     const tables = parseResponse(CSV)
     const actual = toMinardTable(tables)
     const expected = {
-      schemaConflicts: [],
       table: {
-        columnTypes: {
-          _field: 'categorical',
-          _measurement: 'categorical',
-          _start: 'temporal',
-          _stop: 'temporal',
-          _time: 'temporal',
-          _value: 'numeric',
-          cpu: 'categorical',
-          host: 'categorical',
-          result: 'categorical',
-        },
         columns: {
-          _field: ['usage_guest', 'usage_guest', 'usage_guest', 'usage_guest'],
-          _measurement: ['cpu', 'cpu', 'cpu', 'cpu'],
-          _start: [1549064312524, 1549064312524, 1549064312524, 1549064312524],
-          _stop: [1549064342524, 1549064342524, 1549064342524, 1549064342524],
-          _time: [1549064313000, 1549064323000, 1549064313000, 1549064323000],
-          _value: [10, 20, 30, 40],
-          cpu: ['cpu-total', 'cpu-total', 'cpu0', 'cpu0'],
-          host: ['oox4k.local', 'oox4k.local', 'oox4k.local', 'oox4k.local'],
-          result: ['_result', '_result', '_result', '_result'],
+          result: {
+            data: ['_result', '_result', '_result', '_result'],
+            type: 'string',
+          },
+          _start: {
+            data: [1549064312524, 1549064312524, 1549064312524, 1549064312524],
+            type: 'time',
+          },
+          _stop: {
+            data: [1549064342524, 1549064342524, 1549064342524, 1549064342524],
+            type: 'time',
+          },
+          _time: {
+            data: [1549064313000, 1549064323000, 1549064313000, 1549064323000],
+            type: 'time',
+          },
+          _value: {data: [10, 20, 30, 40], type: 'float'},
+          _field: {
+            data: ['usage_guest', 'usage_guest', 'usage_guest', 'usage_guest'],
+            type: 'string',
+          },
+          _measurement: {data: ['cpu', 'cpu', 'cpu', 'cpu'], type: 'string'},
+          cpu: {
+            data: ['cpu-total', 'cpu-total', 'cpu0', 'cpu0'],
+            type: 'string',
+          },
+          host: {
+            data: ['oox4k.local', 'oox4k.local', 'oox4k.local', 'oox4k.local'],
+            type: 'string',
+          },
         },
+        length: 4,
       },
+      schemaConflicts: [],
     }
 
     expect(actual).toEqual(expected)
@@ -68,31 +79,42 @@ describe('toMinardTable', () => {
     const tables = parseResponse(CSV)
     const actual = toMinardTable(tables)
     const expected = {
-      schemaConflicts: ['_value'],
       table: {
-        columnTypes: {
-          _field: 'categorical',
-          _measurement: 'categorical',
-          _start: 'temporal',
-          _stop: 'temporal',
-          _time: 'temporal',
-          _value: 'numeric',
-          cpu: 'categorical',
-          host: 'categorical',
-          result: 'categorical',
-        },
         columns: {
-          _field: ['usage_guest', 'usage_guest', 'usage_guest', 'usage_guest'],
-          _measurement: ['cpu', 'cpu', 'cpu', 'cpu'],
-          _start: [1549064312524, 1549064312524, 1549064312524, 1549064312524],
-          _stop: [1549064342524, 1549064342524, 1549064342524, 1549064342524],
-          _time: [1549064313000, 1549064323000, 1549064313000, 1549064323000],
-          _value: [10, 20, undefined, undefined],
-          cpu: ['cpu-total', 'cpu-total', 'cpu0', 'cpu0'],
-          host: ['oox4k.local', 'oox4k.local', 'oox4k.local', 'oox4k.local'],
-          result: ['_result', '_result', '_result', '_result'],
+          result: {
+            data: ['_result', '_result', '_result', '_result'],
+            type: 'string',
+          },
+          _start: {
+            data: [1549064312524, 1549064312524, 1549064312524, 1549064312524],
+            type: 'time',
+          },
+          _stop: {
+            data: [1549064342524, 1549064342524, 1549064342524, 1549064342524],
+            type: 'time',
+          },
+          _time: {
+            data: [1549064313000, 1549064323000, 1549064313000, 1549064323000],
+            type: 'time',
+          },
+          _value: {data: [10, 20, undefined, undefined], type: 'float'},
+          _field: {
+            data: ['usage_guest', 'usage_guest', 'usage_guest', 'usage_guest'],
+            type: 'string',
+          },
+          _measurement: {data: ['cpu', 'cpu', 'cpu', 'cpu'], type: 'string'},
+          cpu: {
+            data: ['cpu-total', 'cpu-total', 'cpu0', 'cpu0'],
+            type: 'string',
+          },
+          host: {
+            data: ['oox4k.local', 'oox4k.local', 'oox4k.local', 'oox4k.local'],
+            type: 'string',
+          },
         },
+        length: 4,
       },
+      schemaConflicts: ['_value'],
     }
 
     expect(actual).toEqual(expected)

--- a/ui/src/timeMachine/actions/index.ts
+++ b/ui/src/timeMachine/actions/index.ts
@@ -15,7 +15,7 @@ import {
 } from 'src/types/v2/dashboards'
 import {TimeMachineTab} from 'src/types/v2/timeMachine'
 import {Color} from 'src/types/colors'
-import {Table, HistogramPosition, ColumnType} from 'src/minard'
+import {Table, HistogramPosition, isNumeric} from 'src/minard'
 
 export type Action =
   | QueryBuilderAction
@@ -511,8 +511,8 @@ interface TableLoadedAction {
 }
 
 export const tableLoaded = (table: Table): TableLoadedAction => {
-  const availableXColumns = Object.entries(table.columnTypes)
-    .filter(([__, type]) => type === ColumnType.Numeric)
+  const availableXColumns = Object.entries(table.columns)
+    .filter(([__, {type}]) => isNumeric(type) && type !== 'time')
     .map(([name]) => name)
 
   const invalidGroupColumns = new Set(['_value', '_start', '_stop', '_time'])


### PR DESCRIPTION
This PR contains some refactoring of the histogram implementation

- Improve the typing of various vis objects
- Use a different `Table` shape for plot layers that colocates data and data types
- Renames the "aesthetics" field of a plot layer to "mappings", since "aesthetics" is difficult to say, difficult to spell, and is less clear than "mappings"
