### PR TITLE
fix(e2e-tests): make task use default bucket from user fixture

### DIFF
--- a/query/preauthorizer_test.go
+++ b/query/preauthorizer_test.go
@@ -124,14 +124,16 @@ func TestPreAuthorizer_RequiredPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	pRead, err := platform.NewPermissionAtID(bFrom.ID, platform.ReadAction, platform.BucketsResourceType, o.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
 	pWrite, err := platform.NewPermissionAtID(bTo.ID, platform.WriteAction, platform.BucketsResourceType, o.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	t.Log("WARNING: this test does not validate permissions on the 'from' bucket. Please update after https://github.com/influxdata/flux/issues/114.")
-
-	exp := []platform.Permission{*pWrite}
+	exp := []platform.Permission{*pRead, *pWrite}
 	if diff := cmp.Diff(exp, perms); diff != "" {
 		t.Fatalf("unexpected permissions: %s", diff)
 	}

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -24,7 +24,7 @@ describe('Tasks', () => {
 
     cy.getByDataTest('flux-editor').within(() => {
       cy.get('textarea').type(
-        `from(bucket: "default")
+        `from(bucket: "defbuck")
       |> range(start: -2m)`,
         {force: true}
       )

--- a/ui/cypress/support/commands.ts
+++ b/ui/cypress/support/commands.ts
@@ -51,7 +51,7 @@ export const createTask = (
     every: 1d,
     offset: 20m
   }
-  from(bucket: "default")
+  from(bucket: "defbuck")
         |> range(start: -2m)`
 
   return cy.request({


### PR DESCRIPTION
Closes #12138 

_Briefly describe your proposed changes:_

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
