### PR TITLE
Add context to storage.PointsWriter

### DIFF
--- a/gather/recorder.go
+++ b/gather/recorder.go
@@ -1,6 +1,7 @@
 package gather
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/influxdata/influxdb/tsdb"
@@ -25,7 +26,7 @@ func (s PointWriter) Record(collected MetricsCollection) error {
 	if err != nil {
 		return err
 	}
-	return s.Writer.WritePoints(ps)
+	return s.Writer.WritePoints(context.TODO(), ps)
 }
 
 // Recorder record the metrics of a time based.

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -218,7 +218,7 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.PointsWriter.WritePoints(exploded); err != nil {
+	if err := h.PointsWriter.WritePoints(ctx, exploded); err != nil {
 		logger.Error("Error writing points", zap.Error(err))
 		EncodeError(ctx, &platform.Error{
 			Code: platform.EInternal,

--- a/mock/points_writer.go
+++ b/mock/points_writer.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"context"
 	"sync"
 
 	"github.com/influxdata/influxdb/models"
@@ -21,7 +22,7 @@ func (p *PointsWriter) ForceError(err error) {
 }
 
 // WritePoints writes points to the PointsWriter that will be exposed in the Values.
-func (p *PointsWriter) WritePoints(points []models.Point) error {
+func (p *PointsWriter) WritePoints(ctx context.Context, points []models.Point) error {
 	p.mu.Lock()
 	p.Points = append(p.Points, points...)
 	err := p.Err

--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -585,7 +585,7 @@ func writeTable(t *ToTransformation, tbl flux.Table) error {
 			}
 		}
 		points, err = tsdb.ExplodePoints(*orgID, *bucketID, points)
-		return d.PointsWriter.WritePoints(points)
+		return d.PointsWriter.WritePoints(context.TODO(), points)
 	})
 }
 

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -355,7 +355,7 @@ func (e *Engine) CreateCursorIterator(ctx context.Context) (tsdb.CursorIterator,
 // The Engine expects all points to have been correctly validated by the caller.
 // WritePoints will however determine if there are any field type conflicts, and
 // return an appropriate error in that case.
-func (e *Engine) WritePoints(points []models.Point) error {
+func (e *Engine) WritePoints(ctx context.Context, points []models.Point) error {
 	collection, j := tsdb.NewSeriesCollection(points), 0
 	for iter := collection.Iterator(); iter.Next(); {
 		tags := iter.Tags()

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -1,6 +1,7 @@
 package storage_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -359,7 +360,7 @@ func (e *Engine) Write1xPoints(pts []models.Point) error {
 	if err != nil {
 		return err
 	}
-	return e.Engine.WritePoints(points)
+	return e.Engine.WritePoints(context.TODO(), points)
 }
 
 // Write1xPointsWithOrgBucket writes 1.x points with the provided org and bucket id strings.
@@ -378,7 +379,7 @@ func (e *Engine) Write1xPointsWithOrgBucket(pts []models.Point, org, bucket stri
 	if err != nil {
 		return err
 	}
-	return e.Engine.WritePoints(points)
+	return e.Engine.WritePoints(context.TODO(), points)
 }
 
 // Close closes the engine and removes all temporary data.

--- a/storage/points_writer.go
+++ b/storage/points_writer.go
@@ -1,10 +1,12 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/influxdata/influxdb/models"
 )
 
 // PointsWriter describes the ability to write points into a storage engine.
 type PointsWriter interface {
-	WritePoints([]models.Point) error
+	WritePoints(context.Context, []models.Point) error
 }

--- a/task/backend/point_logwriter.go
+++ b/task/backend/point_logwriter.go
@@ -25,7 +25,7 @@ const (
 // Copy of storage.PointsWriter interface.
 // Duplicating it here to avoid having tasks/backend depend directly on storage.
 type PointsWriter interface {
-	WritePoints(points []models.Point) error
+	WritePoints(ctx context.Context, points []models.Point) error
 }
 
 // PointLogWriter writes task and run logs as time-series points.
@@ -61,7 +61,7 @@ func (p *PointLogWriter) UpdateRunState(ctx context.Context, rlb RunLogBase, whe
 		return err
 	}
 
-	return p.pointsWriter.WritePoints(exploded)
+	return p.pointsWriter.WritePoints(ctx, exploded)
 }
 
 func (p *PointLogWriter) AddRunLog(ctx context.Context, rlb RunLogBase, when time.Time, log string) error {
@@ -83,5 +83,5 @@ func (p *PointLogWriter) AddRunLog(ctx context.Context, rlb RunLogBase, when tim
 		return err
 	}
 
-	return p.pointsWriter.WritePoints(exploded)
+	return p.pointsWriter.WritePoints(ctx, exploded)
 }


### PR DESCRIPTION
_Briefly describe your proposed changes:_
This PR adds context to the storage points writer. Where possible the context is plumbed through. If the caller invoking `WritePoints` does not have a context available a `context.TODO()` is used instead.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
