### PR TITLE
chore(.github): specify influxdata api team as code owner of swagger.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# This file allows teams or people to be assigned as
+# automatic code-reviewers for files or directories.
+#
+# Here is information about how to configure this file:
+# https://help.github.com/en/articles/about-code-owners
+
+# API team will help to review swagger.yml changes.
+#
+http/swagger.yml @influxdata/api


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Require API team to review changes to http/swagger.yml

Add a github CODEOWNERS file that specifies the api team as reviewers for http/swagger.yml.  

To enable this feature someone will need to turn on "code owners" in the reviewing:
https://help.github.com/en/articles/enabling-required-reviews-for-pull-requests

Here is more information about code owners:

https://help.github.com/en/articles/about-code-owners

> When someone with admin or owner permissions has enabled required reviews, they also can optionally require approval from a code owner before the author can merge a pull request in the repository. For more information, see "Enabling required reviews for pull requests."

