### PR TITLE
httpd/handler: fix panic in servePromRead on nil result

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1057,17 +1057,42 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 		return
 	}
 
+	respond := func(resp *remote.ReadResponse) {
+		data, err := proto.Marshal(resp)
+		if err != nil {
+			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.Header().Set("Content-Encoding", "snappy")
+
+		compressed = snappy.Encode(nil, data)
+		if _, err := w.Write(compressed); err != nil {
+			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		atomic.AddInt64(&h.stats.QueryRequestBytesTransmitted, int64(len(compressed)))
+	}
+
 	ctx := context.Background()
 	rs, err := h.Store.Read(ctx, readRequest)
 	if err != nil {
 		h.httpError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	defer rs.Close()
 
 	resp := &remote.ReadResponse{
 		Results: []*remote.QueryResult{{}},
 	}
+
+	if rs == nil {
+		respond(resp)
+		return
+	}
+	defer rs.Close()
+
 	for rs.Next() {
 		cur := rs.Cursor()
 		if cur == nil {
@@ -1125,22 +1150,8 @@ func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user met
 			)
 		}
 	}
-	data, err := proto.Marshal(resp)
-	if err != nil {
-		h.httpError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 
-	w.Header().Set("Content-Type", "application/x-protobuf")
-	w.Header().Set("Content-Encoding", "snappy")
-
-	compressed = snappy.Encode(nil, data)
-	if _, err := w.Write(compressed); err != nil {
-		h.httpError(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	atomic.AddInt64(&h.stats.QueryRequestBytesTransmitted, int64(len(compressed)))
+	respond(resp)
 }
 
 func (h *Handler) serveFluxQuery(w http.ResponseWriter, r *http.Request, user meta.User) {

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
+	"github.com/influxdata/platform/storage/reads"
+	"github.com/influxdata/platform/storage/reads/datatypes"
 )
 
 // Ensure the handler returns results from a query (including nil results).
@@ -818,6 +820,67 @@ func TestHandler_Flux_DisabledByDefault(t *testing.T) {
 	exp := "Flux query service disabled. Verify flux-enabled=true in the [http] section of the InfluxDB config.\n"
 	if got := string(w.Body.Bytes()); !cmp.Equal(got, exp) {
 		t.Fatalf("unexpected body -got/+exp\n%s", cmp.Diff(got, exp))
+	}
+}
+
+func TestHandler_PromRead_NilResultSet(t *testing.T) {
+	req := &remote.ReadRequest{
+		Queries: []*remote.Query{{
+			Matchers: []*remote.LabelMatcher{
+				{
+					Type:  remote.MatchType_EQUAL,
+					Name:  "__name__",
+					Value: "value",
+				},
+			},
+			StartTimestampMs: 1,
+			EndTimestampMs:   2,
+		}},
+	}
+	data, err := proto.Marshal(req)
+	if err != nil {
+		log.Fatal("couldn't marshal prometheus request")
+	}
+	compressed := snappy.Encode(nil, data)
+	b := bytes.NewReader(compressed)
+
+	h := NewHandler(false)
+
+	// Mocks the case when Store.Read() returns nil, nil
+	h.Handler.Store.(*internal.StorageStoreMock).ReadFn = func(ctx context.Context, req *datatypes.ReadRequest) (reads.ResultSet, error) {
+		return nil, nil
+	}
+
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, MustNewRequest("POST", "/api/v1/prom/read?db=foo&rp=bar", b))
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", w.Code)
+	}
+
+	if w.Header().Get("Content-Type") != "application/x-protobuf" {
+		t.Fatalf("Got unexpected \"Content-Type\" header value:\n%v", cmp.Diff("application/x-protobuf", w.Header().Get("Content-Type")))
+	}
+	if w.Header().Get("Content-Encoding") != "snappy" {
+		t.Fatalf("Got unexpected \"Content-Encoding\" header value:\n%v", cmp.Diff("snappy", w.Header().Get("Content-Encoding")))
+	}
+
+	decompressed, err := snappy.Decode(nil, w.Body.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(remote.ReadResponse)
+	err = proto.Unmarshal(decompressed, resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &remote.ReadResponse{
+		Results: []*remote.QueryResult{{}},
+	}
+	if !reflect.DeepEqual(resp, expected) {
+		t.Fatalf("Results differ:\n%v", cmp.Diff(expected, resp))
 	}
 }
 


### PR DESCRIPTION
Please consider already merged fix for Prometheus read API for 1.7 stable branch.

Ported from: https://github.com/influxdata/influxdb/pull/10591

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
