### PR TITLE
Feat/add zeros to tsm filename

### DIFF
--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -1179,7 +1179,7 @@ type FormatFileNameFunc func(generation, sequence int) string
 
 // DefaultFormatFileName is the default implementation to format TSM filenames.
 func DefaultFormatFileName(generation, sequence int) string {
-	return fmt.Sprintf("%09d-%09d", generation, sequence)
+	return fmt.Sprintf("%015d-%09d", generation, sequence)
 }
 
 // ParseFileNameFunc is executed when parsing a TSM filename into generation & sequence.
@@ -1200,7 +1200,7 @@ func DefaultParseFileName(name string) (int, int, error) {
 		return 0, 0, fmt.Errorf("file %s is named incorrectly", name)
 	}
 
-	generation, err := strconv.ParseUint(id[:idx], 10, 32)
+	generation, err := strconv.ParseUint(id[:idx], 10, 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("file %s is named incorrectly", name)
 	}


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Add leading zeros to sequence value of TSM filename. Value parser was changed from 32 bit to 64 bit. Checked for uses of this value, it looks to be isolated to Compactor and FileStore.

I'll bring this into IDPE next to check for compatibility issues there.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)

