### PR TITLE
storage: fix problems with keeping resources alive

### DIFF
--- a/pkg/lifecycle/resource.go
+++ b/pkg/lifecycle/resource.go
@@ -1,0 +1,94 @@
+package lifecycle
+
+import (
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+// Resource keeps track of references and has some compile time debug hooks
+// to help diagnose leaks. It keeps track of if it is open or not and allows
+// blocking until all references are released.
+type Resource struct {
+	sem  sync.RWMutex
+	open bool
+}
+
+// Open waits for any outstanding references, of which there should be none
+// and marks the reference counter as open.
+func (res *Resource) Open() {
+	res.sem.Lock()
+	res.open = true
+	res.sem.Unlock()
+}
+
+// Close waits for any outstanding references and marks the reference counter
+// as closed, so that Acquire returns an error.
+func (res *Resource) Close() {
+	res.sem.Lock()
+	res.open = false
+	res.sem.Unlock()
+}
+
+// Opened returns true if the resource is currently open.
+func (res *Resource) Opened() bool {
+	res.sem.RLock()
+	open := res.open
+	res.sem.RUnlock()
+	return open
+}
+
+// Acquire returns a Reference used to keep alive some resource.
+func (res *Resource) Acquire() (*Reference, error) {
+	res.sem.RLock()
+	if !res.open {
+		res.sem.RUnlock()
+		return nil, resourceClosed()
+	}
+	// RLock intentionally left open.
+
+	return live.track(&Reference{
+		res: res,
+		id:  0, // required because staticcheck
+	}), nil
+}
+
+// Reference is an open reference for some resource.
+type Reference struct {
+	res *Resource
+	id  uint64
+}
+
+// Release causes the Reference to be freed. It is safe to call multiple times.
+func (r *Reference) Release() {
+	// Inline a sync.Once using the res pointer as the flag for if we have
+	// called unlock or not. This reduces the size of a ref.
+	addr := (*unsafe.Pointer)(unsafe.Pointer(&r.res))
+	old := atomic.LoadPointer(addr)
+	if old != nil && atomic.CompareAndSwapPointer(addr, old, nil) {
+		live.untrack(r)
+		(*Resource)(old).sem.RUnlock()
+	}
+}
+
+// Close makes a Reference an io.Closer. It is safe to call multiple times.
+func (r *Reference) Close() error {
+	r.Release()
+	return nil
+}
+
+// References is a helper to aggregate a group of references.
+type References []*Reference
+
+// Release releases all of the references. It is safe to call multiple times.
+func (rs References) Release() {
+	for _, r := range rs {
+		r.Release()
+	}
+}
+
+// Close makes references an io.Closer. It is safe to call multiple times.
+func (rs References) Close() error {
+	rs.Release()
+	return nil
+}

--- a/pkg/lifecycle/resource_debug_disabled.go
+++ b/pkg/lifecycle/resource_debug_disabled.go
@@ -1,0 +1,20 @@
+// +build !debug_ref
+
+package lifecycle
+
+import "errors"
+
+// When not in debug mode, all of the expensive tracking is compile time
+// disabled so that it has no overhead.
+
+var errResourceClosed = errors.New("resource closed")
+
+func resourceClosed() error { return errResourceClosed }
+
+type emptyLive struct{}
+
+var live emptyLive
+
+func (emptyLive) track(r *Reference) *Reference { return r }
+
+func (emptyLive) untrack(r *Reference) {}

--- a/pkg/lifecycle/resource_debug_enabled.go
+++ b/pkg/lifecycle/resource_debug_enabled.go
@@ -1,0 +1,118 @@
+// +build debug_ref
+
+package lifecycle
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"syscall"
+)
+
+// When in debug mode, we associate each reference an id and with that id the
+// stack trace that created it. We can't directly refer to the reference here
+// because we also associate a finalizer to print to stderr if a reference is
+// leaked, including where it came from if possible.
+
+func init() {
+	// This goroutine will dump all live references and where they were created
+	// when SIGUSR2 is sent to the process.
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, syscall.SIGUSR2)
+		for range ch {
+			live.mu.Lock()
+			for id, pcs := range live.live {
+				fmt.Fprintln(os.Stderr, "=====================================================")
+				fmt.Fprintln(os.Stderr, "=== Live reference with id", id, "created from")
+				summarizeStack(os.Stderr, pcs)
+				fmt.Fprintln(os.Stderr, "=====================================================")
+			}
+			live.mu.Unlock()
+		}
+	}()
+}
+
+// resourceClosed returns an error stating that some resource is closed with the
+// stack trace of the caller embedded.
+func resourceClosed() error {
+	var buf [4096]byte
+	return fmt.Errorf("resource closed:\n%s", buf[:runtime.Stack(buf[:], false)])
+}
+
+// liveReferences keeps track of the stack traces of all of the live references.
+type liveReferences struct {
+	mu   sync.Mutex
+	id   uint64
+	live map[uint64][]uintptr
+}
+
+var live = &liveReferences{
+	live: make(map[uint64][]uintptr),
+}
+
+// finishId informs the liveReferences that the id is no longer in use.
+func (l *liveReferences) untrack(r *Reference) {
+	l.mu.Lock()
+	delete(l.live, r.id)
+	runtime.SetFinalizer(r, nil)
+	l.mu.Unlock()
+}
+
+// withFinalizer associates a finalizer with the Reference that will cause it
+// to print a leak message if it is not closed before it is garbage collected.
+func (l *liveReferences) track(r *Reference) *Reference {
+	var buf [32]uintptr
+	pcs := append([]uintptr(nil), buf[:runtime.Callers(3, buf[:])]...)
+
+	l.mu.Lock()
+	r.id, l.id = l.id, l.id+1
+	l.live[r.id] = pcs
+	l.mu.Unlock()
+
+	runtime.SetFinalizer(r, func(r *Reference) {
+		l.leaked(r)
+		r.Release()
+	})
+
+	return r
+}
+
+// leaked prints a loud message on stderr that the Reference was leaked and
+// what was responsible for calling it.
+func (l *liveReferences) leaked(r *Reference) {
+	l.mu.Lock()
+	pcs, ok := l.live[r.id]
+	l.mu.Unlock()
+
+	if !ok {
+		fmt.Fprintln(os.Stderr, "=====================================================")
+		fmt.Fprintln(os.Stderr, "=== Leaked a reference with no stack associated!? ===")
+		fmt.Fprintln(os.Stderr, "=====================================================")
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "=====================================================")
+	fmt.Fprintln(os.Stderr, "=== Leaked a reference! Created from")
+	summarizeStack(os.Stderr, pcs)
+	fmt.Fprintln(os.Stderr, "=====================================================")
+}
+
+// summarizeStack prints a line for each stack entry in the pcs to the writer.
+func summarizeStack(w io.Writer, pcs []uintptr) {
+	frames := runtime.CallersFrames(pcs)
+	for {
+		frame, more := frames.Next()
+		if !more {
+			break
+		}
+		fmt.Fprintf(w, "    %s:%s:%d\n",
+			frame.Function,
+			filepath.Base(frame.File),
+			frame.Line)
+	}
+}

--- a/pkg/lifecycle/resource_test.go
+++ b/pkg/lifecycle/resource_test.go
@@ -1,0 +1,14 @@
+package lifecycle
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestReferenceLeak is only useful to test printing with the debug build tag.
+func TestReferenceLeak(t *testing.T) {
+	var res Resource
+	res.Open()
+	res.Acquire()
+	runtime.GC()
+}

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/binaryutil"
+	"github.com/influxdata/influxdb/pkg/lifecycle"
 	"github.com/influxdata/influxdb/pkg/rhh"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -35,6 +36,9 @@ const (
 
 // SeriesFile represents the section of the index that holds series data.
 type SeriesFile struct {
+	mu  sync.Mutex // protects concurrent open and close
+	res lifecycle.Resource
+
 	path       string
 	partitions []*SeriesPartition
 
@@ -44,8 +48,6 @@ type SeriesFile struct {
 	// partition id label values.
 	defaultMetricLabels prometheus.Labels
 	metricsEnabled      bool
-
-	refs sync.RWMutex // RWMutex to track references to the SeriesFile that are in use.
 
 	Logger *zap.Logger
 }
@@ -81,12 +83,15 @@ func (f *SeriesFile) DisableMetrics() {
 
 // Open memory maps the data file at the file's path.
 func (f *SeriesFile) Open() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.res.Opened() {
+		return errors.New("series file already opened")
+	}
+
 	_, logEnd := logger.NewOperation(f.Logger, "Opening Series File", "series_file_open", zap.String("path", f.path))
 	defer logEnd()
-
-	// Wait for all references to be released and prevent new ones from being acquired.
-	f.refs.Lock()
-	defer f.refs.Unlock()
 
 	// Create path if it doesn't exist.
 	if err := os.MkdirAll(filepath.Join(f.path), 0777); err != nil {
@@ -140,14 +145,19 @@ func (f *SeriesFile) Open() error {
 		f.partitions = append(f.partitions, p)
 	}
 
+	// The resource is now open.
+	f.res.Open()
+
 	return nil
 }
 
 // Close unmaps the data file.
 func (f *SeriesFile) Close() (err error) {
-	// Wait for all references to be released and prevent new ones from being acquired.
-	f.refs.Lock()
-	defer f.refs.Unlock()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Close the resource and wait for any outstanding references.
+	f.res.Close()
 
 	for _, p := range f.partitions {
 		if e := p.Close(); e != nil && err == nil {
@@ -169,15 +179,10 @@ func (f *SeriesFile) SeriesPartitionPath(i int) string {
 // Partitions returns all partitions.
 func (f *SeriesFile) Partitions() []*SeriesPartition { return f.partitions }
 
-// Retain adds a reference count to the file.  It returns a release func.
-func (f *SeriesFile) Retain() func() {
-	if f != nil {
-		f.refs.RLock()
-
-		// Return the RUnlock func as the release func to be called when done.
-		return f.refs.RUnlock
-	}
-	return nop
+// Acquire ensures that the series file won't be closed until after the reference
+// has been released.
+func (f *SeriesFile) Acquire() (*lifecycle.Reference, error) {
+	return f.res.Acquire()
 }
 
 // EnableCompactions allows compactions to run.
@@ -192,12 +197,6 @@ func (f *SeriesFile) DisableCompactions() {
 	for _, p := range f.partitions {
 		p.DisableCompactions()
 	}
-}
-
-// Wait waits for all Retains to be released.
-func (f *SeriesFile) Wait() {
-	f.refs.Lock()
-	defer f.refs.Unlock()
 }
 
 // CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist. It overwrites
@@ -575,5 +574,3 @@ func SeriesKeySize(name []byte, tags models.Tags) int {
 	n += binaryutil.UvarintSize(uint64(n))
 	return n
 }
-
-func nop() {}

--- a/tsdb/tsi1/file_set.go
+++ b/tsdb/tsi1/file_set.go
@@ -2,38 +2,56 @@ package tsi1
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"regexp"
-	"sync"
 	"unsafe"
 
+	"github.com/influxdata/influxdb/pkg/lifecycle"
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
 )
 
 // FileSet represents a collection of files.
 type FileSet struct {
-	levels       []CompactionLevel
 	sfile        *tsdb.SeriesFile
+	sfileref     *lifecycle.Reference
 	files        []File
+	filesref     lifecycle.References
 	manifestSize int64 // Size of the manifest file in bytes.
 }
 
 // NewFileSet returns a new instance of FileSet.
-func NewFileSet(levels []CompactionLevel, sfile *tsdb.SeriesFile, files []File) (*FileSet, error) {
+func NewFileSet(sfile *tsdb.SeriesFile, files []File) (*FileSet, error) {
+	// First try to acquire a reference to the series file.
+	sfileref, err := sfile.Acquire()
+	if err != nil {
+		return nil, err
+	}
+
+	// Next, acquire references to all of the passed in files.
+	filesref := make(lifecycle.References, 0, len(files))
+	for _, f := range files {
+		ref, err := f.Acquire()
+		if err != nil {
+			filesref.Release()
+			sfileref.Release()
+			return nil, err
+		}
+		filesref = append(filesref, ref)
+	}
+
 	return &FileSet{
-		levels: levels,
-		sfile:  sfile,
-		files:  files,
+		sfile:    sfile,
+		sfileref: sfileref,
+		files:    files,
+		filesref: filesref,
 	}, nil
 }
 
 // bytes estimates the memory footprint of this FileSet, in bytes.
 func (fs *FileSet) bytes() int {
 	var b int
-	for _, level := range fs.levels {
-		b += int(unsafe.Sizeof(level))
-	}
 	// Do not count SeriesFile because it belongs to the code that constructed this FileSet.
 	for _, file := range fs.files {
 		b += file.bytes()
@@ -42,42 +60,24 @@ func (fs *FileSet) bytes() int {
 	return b
 }
 
-// Close closes all the files in the file set.
-func (fs FileSet) Close() error {
-	var err error
-	for _, f := range fs.files {
-		if e := f.Close(); e != nil && err == nil {
-			err = e
-		}
-	}
-	return err
-}
-
-// Retain adds a reference count to all files.
-func (fs *FileSet) Retain() {
-	for _, f := range fs.files {
-		f.Retain()
-	}
-}
-
-// Release removes a reference count from all files.
-func (fs *FileSet) Release() {
-	for _, f := range fs.files {
-		f.Release()
-	}
-}
-
-// SeriesFile returns the attached series file.
 func (fs *FileSet) SeriesFile() *tsdb.SeriesFile { return fs.sfile }
+
+// Release releases all resources on the file set.
+func (fs *FileSet) Release() {
+	fs.filesref.Release()
+	fs.sfileref.Release()
+}
+
+// Duplicate returns a copy of the FileSet, acquiring another resource to the
+// files and series file for the file set.
+func (fs *FileSet) Duplicate() (*FileSet, error) {
+	return NewFileSet(fs.sfile, fs.files)
+}
 
 // PrependLogFile returns a new file set with f added at the beginning.
 // Filters do not need to be rebuilt because log files have no bloom filter.
-func (fs *FileSet) PrependLogFile(f *LogFile) *FileSet {
-	return &FileSet{
-		levels: fs.levels,
-		sfile:  fs.sfile,
-		files:  append([]File{f}, fs.files...),
-	}
+func (fs *FileSet) PrependLogFile(f *LogFile) (*FileSet, error) {
+	return NewFileSet(fs.sfile, append([]File{f}, fs.files...))
 }
 
 // Size returns the on-disk size of the FileSet.
@@ -91,7 +91,7 @@ func (fs *FileSet) Size() int64 {
 
 // MustReplace swaps a list of files for a single file and returns a new file set.
 // The caller should always guarantee that the files exist and are contiguous.
-func (fs *FileSet) MustReplace(oldFiles []File, newFile File) *FileSet {
+func (fs *FileSet) MustReplace(oldFiles []File, newFile File) (*FileSet, error) {
 	assert(len(oldFiles) > 0, "cannot replace empty files")
 
 	// Find index of first old file.
@@ -100,14 +100,14 @@ func (fs *FileSet) MustReplace(oldFiles []File, newFile File) *FileSet {
 		if fs.files[i] == oldFiles[0] {
 			break
 		} else if i == len(fs.files)-1 {
-			panic("first replacement file not found")
+			return nil, errors.New("first replacement file not found")
 		}
 	}
 
 	// Ensure all old files are contiguous.
 	for j := range oldFiles {
 		if fs.files[i+j] != oldFiles[j] {
-			panic(fmt.Sprintf("cannot replace non-contiguous files: subset=%+v, fileset=%+v", Files(oldFiles).IDs(), Files(fs.files).IDs()))
+			return nil, fmt.Errorf("cannot replace non-contiguous files: subset=%+v, fileset=%+v", Files(oldFiles).IDs(), Files(fs.files).IDs())
 		}
 	}
 
@@ -118,10 +118,7 @@ func (fs *FileSet) MustReplace(oldFiles []File, newFile File) *FileSet {
 	copy(other[i+1:], fs.files[i+len(oldFiles):])
 
 	// Build new fileset and rebuild changed filters.
-	return &FileSet{
-		levels: fs.levels,
-		files:  other,
-	}
+	return NewFileSet(fs.sfile, other)
 }
 
 // MaxID returns the highest file identifier.
@@ -434,8 +431,7 @@ type File interface {
 	TombstoneSeriesIDSet() (*tsdb.SeriesIDSet, error)
 
 	// Reference counting.
-	Retain()
-	Release()
+	Acquire() (*lifecycle.Reference, error)
 
 	// Size of file on disk
 	Size() int64
@@ -456,9 +452,8 @@ func (a Files) IDs() []int {
 
 // fileSetSeriesIDIterator attaches a fileset to an iterator that is released on close.
 type fileSetSeriesIDIterator struct {
-	once sync.Once
-	fs   *FileSet
-	itr  tsdb.SeriesIDIterator
+	fs  *FileSet
+	itr tsdb.SeriesIDIterator
 }
 
 func newFileSetSeriesIDIterator(fs *FileSet, itr tsdb.SeriesIDIterator) tsdb.SeriesIDIterator {
@@ -477,15 +472,14 @@ func (itr *fileSetSeriesIDIterator) Next() (tsdb.SeriesIDElem, error) {
 }
 
 func (itr *fileSetSeriesIDIterator) Close() error {
-	itr.once.Do(func() { itr.fs.Release() })
+	itr.fs.Release()
 	return itr.itr.Close()
 }
 
 // fileSetSeriesIDSetIterator attaches a fileset to an iterator that is released on close.
 type fileSetSeriesIDSetIterator struct {
-	once sync.Once
-	fs   *FileSet
-	itr  tsdb.SeriesIDSetIterator
+	fs  *FileSet
+	itr tsdb.SeriesIDSetIterator
 }
 
 func (itr *fileSetSeriesIDSetIterator) Next() (tsdb.SeriesIDElem, error) {
@@ -493,7 +487,7 @@ func (itr *fileSetSeriesIDSetIterator) Next() (tsdb.SeriesIDElem, error) {
 }
 
 func (itr *fileSetSeriesIDSetIterator) Close() error {
-	itr.once.Do(func() { itr.fs.Release() })
+	itr.fs.Release()
 	return itr.itr.Close()
 }
 
@@ -503,12 +497,15 @@ func (itr *fileSetSeriesIDSetIterator) SeriesIDSet() *tsdb.SeriesIDSet {
 
 // fileSetMeasurementIterator attaches a fileset to an iterator that is released on close.
 type fileSetMeasurementIterator struct {
-	once sync.Once
-	fs   *FileSet
-	itr  tsdb.MeasurementIterator
+	fs  *FileSet
+	itr tsdb.MeasurementIterator
 }
 
-func newFileSetMeasurementIterator(fs *FileSet, itr tsdb.MeasurementIterator) *fileSetMeasurementIterator {
+func newFileSetMeasurementIterator(fs *FileSet, itr tsdb.MeasurementIterator) tsdb.MeasurementIterator {
+	if itr == nil {
+		fs.Release()
+		return nil
+	}
 	return &fileSetMeasurementIterator{fs: fs, itr: itr}
 }
 
@@ -517,18 +514,21 @@ func (itr *fileSetMeasurementIterator) Next() ([]byte, error) {
 }
 
 func (itr *fileSetMeasurementIterator) Close() error {
-	itr.once.Do(func() { itr.fs.Release() })
+	itr.fs.Release()
 	return itr.itr.Close()
 }
 
 // fileSetTagKeyIterator attaches a fileset to an iterator that is released on close.
 type fileSetTagKeyIterator struct {
-	once sync.Once
-	fs   *FileSet
-	itr  tsdb.TagKeyIterator
+	fs  *FileSet
+	itr tsdb.TagKeyIterator
 }
 
-func newFileSetTagKeyIterator(fs *FileSet, itr tsdb.TagKeyIterator) *fileSetTagKeyIterator {
+func newFileSetTagKeyIterator(fs *FileSet, itr tsdb.TagKeyIterator) tsdb.TagKeyIterator {
+	if itr == nil {
+		fs.Release()
+		return nil
+	}
 	return &fileSetTagKeyIterator{fs: fs, itr: itr}
 }
 
@@ -537,18 +537,21 @@ func (itr *fileSetTagKeyIterator) Next() ([]byte, error) {
 }
 
 func (itr *fileSetTagKeyIterator) Close() error {
-	itr.once.Do(func() { itr.fs.Release() })
+	itr.fs.Release()
 	return itr.itr.Close()
 }
 
 // fileSetTagValueIterator attaches a fileset to an iterator that is released on close.
 type fileSetTagValueIterator struct {
-	once sync.Once
-	fs   *FileSet
-	itr  tsdb.TagValueIterator
+	fs  *FileSet
+	itr tsdb.TagValueIterator
 }
 
-func newFileSetTagValueIterator(fs *FileSet, itr tsdb.TagValueIterator) *fileSetTagValueIterator {
+func newFileSetTagValueIterator(fs *FileSet, itr tsdb.TagValueIterator) tsdb.TagValueIterator {
+	if itr == nil {
+		fs.Release()
+		return nil
+	}
 	return &fileSetTagValueIterator{fs: fs, itr: itr}
 }
 
@@ -557,6 +560,6 @@ func (itr *fileSetTagValueIterator) Next() ([]byte, error) {
 }
 
 func (itr *fileSetTagValueIterator) Close() error {
-	itr.once.Do(func() { itr.fs.Release() })
+	itr.fs.Release()
 	return itr.itr.Close()
 }

--- a/tsdb/tsi1/file_set_test.go
+++ b/tsdb/tsi1/file_set_test.go
@@ -27,7 +27,7 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 
 	// Verify initial set of series.
 	idx.Run(t, func(t *testing.T) {
-		fs, err := idx.PartitionAt(0).RetainFileSet()
+		fs, err := idx.PartitionAt(0).FileSet()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -57,7 +57,7 @@ func TestFileSet_SeriesIDIterator(t *testing.T) {
 
 	// Verify additional series.
 	idx.Run(t, func(t *testing.T) {
-		fs, err := idx.PartitionAt(0).RetainFileSet()
+		fs, err := idx.PartitionAt(0).FileSet()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -96,7 +96,7 @@ func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
 
 	// Verify initial set of series.
 	idx.Run(t, func(t *testing.T) {
-		fs, err := idx.PartitionAt(0).RetainFileSet()
+		fs, err := idx.PartitionAt(0).FileSet()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -125,7 +125,7 @@ func TestFileSet_MeasurementSeriesIDIterator(t *testing.T) {
 
 	// Verify additional series.
 	idx.Run(t, func(t *testing.T) {
-		fs, err := idx.PartitionAt(0).RetainFileSet()
+		fs, err := idx.PartitionAt(0).FileSet()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -161,7 +161,7 @@ func TestFileSet_MeasurementIterator(t *testing.T) {
 
 	// Verify initial set of series.
 	idx.Run(t, func(t *testing.T) {
-		fs, err := idx.PartitionAt(0).RetainFileSet()
+		fs, err := idx.PartitionAt(0).FileSet()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -195,7 +195,7 @@ func TestFileSet_MeasurementIterator(t *testing.T) {
 
 	// Verify additional series.
 	idx.Run(t, func(t *testing.T) {
-		fs, err := idx.PartitionAt(0).RetainFileSet()
+		fs, err := idx.PartitionAt(0).FileSet()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -236,7 +236,7 @@ func TestFileSet_TagKeyIterator(t *testing.T) {
 
 	// Verify initial set of series.
 	idx.Run(t, func(t *testing.T) {
-		fs, err := idx.PartitionAt(0).RetainFileSet()
+		fs, err := idx.PartitionAt(0).FileSet()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -266,7 +266,7 @@ func TestFileSet_TagKeyIterator(t *testing.T) {
 
 	// Verify additional series.
 	idx.Run(t, func(t *testing.T) {
-		fs, err := idx.PartitionAt(0).RetainFileSet()
+		fs, err := idx.PartitionAt(0).FileSet()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cespare/xxhash"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/lifecycle"
 	"github.com/influxdata/influxdb/pkg/slices"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/tsdb"
@@ -100,7 +101,7 @@ var DisableMetrics = func() IndexOption {
 type Index struct {
 	mu         sync.RWMutex
 	partitions []*Partition
-	opened     bool
+	res        lifecycle.Resource
 
 	defaultLabels prometheus.Labels
 
@@ -169,7 +170,7 @@ func (i *Index) Bytes() int {
 	for _, p := range i.partitions {
 		b += int(unsafe.Sizeof(p)) + p.bytes()
 	}
-	b += int(unsafe.Sizeof(i.opened))
+	b += int(unsafe.Sizeof(i.res))
 	b += int(unsafe.Sizeof(i.path)) + len(i.path)
 	b += int(unsafe.Sizeof(i.disableCompactions))
 	b += int(unsafe.Sizeof(i.maxLogFileSize))
@@ -210,7 +211,7 @@ func (i *Index) Open() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
-	if i.opened {
+	if i.res.Opened() {
 		return errors.New("index already open")
 	}
 
@@ -275,17 +276,32 @@ func (i *Index) Open() error {
 		}(k)
 	}
 
-	// Check for error
+	// Check for error. Be sure to read from every partition so that we can
+	// clean up appropriately in the case of errors.
+	var err error
 	for i := 0; i < partitionN; i++ {
-		if err := <-errC; err != nil {
-			return err
+		if perr := <-errC; err == nil {
+			err = perr
 		}
+	}
+	if err != nil {
+		for _, p := range i.partitions {
+			p.Close()
+		}
+		return err
 	}
 
 	// Mark opened.
-	i.opened = true
+	i.res.Open()
 	i.logger.Info("Index opened", zap.Int("partitions", partitionN))
+
 	return nil
+}
+
+// Acquire returns a reference to the index that causes it to be unable to be
+// closed until the reference is released.
+func (i *Index) Acquire() (*lifecycle.Reference, error) {
+	return i.res.Acquire()
 }
 
 // Compact requests a compaction of partitions.
@@ -322,14 +338,16 @@ func (i *Index) Close() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	// Wait for any references to the index before closing
+	// the partitions.
+	i.res.Close()
+
 	for _, p := range i.partitions {
 		if err := p.Close(); err != nil {
 			return err
 		}
 	}
 
-	// Mark index as closed.
-	i.opened = false
 	return nil
 }
 
@@ -516,16 +534,12 @@ func (i *Index) MeasurementSeriesByExprIterator(name []byte, expr influxql.Expr)
 // series file.
 func (i *Index) measurementSeriesByExprIterator(name []byte, expr influxql.Expr) (tsdb.SeriesIDIterator, error) {
 	// Return all series for the measurement if there are no tag expressions.
-
-	release := i.sfile.Retain()
-	defer release()
-
 	if expr == nil {
 		itr, err := i.measurementSeriesIDIterator(name)
 		if err != nil {
 			return nil, err
 		}
-		return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr), nil
+		return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr)
 	}
 
 	itr, err := i.seriesByExprIterator(name, expr)
@@ -533,7 +547,7 @@ func (i *Index) measurementSeriesByExprIterator(name []byte, expr influxql.Expr)
 		return nil, err
 	}
 
-	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr), nil
+	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr)
 }
 
 // MeasurementSeriesIDIterator returns an iterator over all non-tombstoned series
@@ -543,10 +557,7 @@ func (i *Index) MeasurementSeriesIDIterator(name []byte) (tsdb.SeriesIDIterator,
 	if err != nil {
 		return nil, err
 	}
-
-	release := i.sfile.Retain()
-	defer release()
-	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr), nil
+	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr)
 }
 
 // measurementSeriesIDIterator returns an iterator over all series in a measurement.
@@ -866,8 +877,13 @@ func (i *Index) HasTagValue(name, key, value []byte) (bool, error) {
 func (i *Index) TagKeyIterator(name []byte) (tsdb.TagKeyIterator, error) {
 	a := make([]tsdb.TagKeyIterator, 0, len(i.partitions))
 	for _, p := range i.partitions {
-		itr := p.TagKeyIterator(name)
-		if itr != nil {
+		itr, err := p.TagKeyIterator(name)
+		if err != nil {
+			for _, itr := range a {
+				itr.Close()
+			}
+			return nil, err
+		} else if itr != nil {
 			a = append(a, itr)
 		}
 	}
@@ -878,8 +894,13 @@ func (i *Index) TagKeyIterator(name []byte) (tsdb.TagKeyIterator, error) {
 func (i *Index) TagValueIterator(name, key []byte) (tsdb.TagValueIterator, error) {
 	a := make([]tsdb.TagValueIterator, 0, len(i.partitions))
 	for _, p := range i.partitions {
-		itr := p.TagValueIterator(name, key)
-		if itr != nil {
+		itr, err := p.TagValueIterator(name, key)
+		if err != nil {
+			for _, itr := range a {
+				itr.Close()
+			}
+			return nil, err
+		} else if itr != nil {
 			a = append(a, itr)
 		}
 	}
@@ -888,38 +909,38 @@ func (i *Index) TagValueIterator(name, key []byte) (tsdb.TagValueIterator, error
 
 // TagKeySeriesIDIterator returns a series iterator for all values across a single key.
 func (i *Index) TagKeySeriesIDIterator(name, key []byte) (tsdb.SeriesIDIterator, error) {
-	release := i.sfile.Retain()
-	defer release()
-
 	itr, err := i.tagKeySeriesIDIterator(name, key)
 	if err != nil {
 		return nil, err
 	}
-	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr), nil
+	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr)
 }
 
 // tagKeySeriesIDIterator returns a series iterator for all values across a single key.
 func (i *Index) tagKeySeriesIDIterator(name, key []byte) (tsdb.SeriesIDIterator, error) {
 	a := make([]tsdb.SeriesIDIterator, 0, len(i.partitions))
 	for _, p := range i.partitions {
-		itr := p.TagKeySeriesIDIterator(name, key)
-		if itr != nil {
+		itr, err := p.TagKeySeriesIDIterator(name, key)
+		if err != nil {
+			for _, itr := range a {
+				itr.Close()
+			}
+			return nil, err
+		} else if itr != nil {
 			a = append(a, itr)
 		}
 	}
+
 	return tsdb.MergeSeriesIDIterators(a...), nil
 }
 
 // TagValueSeriesIDIterator returns a series iterator for a single tag value.
 func (i *Index) TagValueSeriesIDIterator(name, key, value []byte) (tsdb.SeriesIDIterator, error) {
-	release := i.sfile.Retain()
-	defer release()
-
 	itr, err := i.tagValueSeriesIDIterator(name, key, value)
 	if err != nil {
 		return nil, err
 	}
-	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr), nil
+	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr)
 }
 
 // tagValueSeriesIDIterator returns a series iterator for a single tag value.
@@ -956,9 +977,6 @@ func (i *Index) tagValueSeriesIDIterator(name, key, value []byte) (tsdb.SeriesID
 }
 
 func (i *Index) TagSets(name []byte, opt query.IteratorOptions) ([]*query.TagSet, error) {
-	release := i.sfile.Retain()
-	defer release()
-
 	itr, err := i.MeasurementSeriesByExprIterator(name, opt.Condition)
 	if err != nil {
 		return nil, err
@@ -1108,7 +1126,7 @@ func (i *Index) MeasurementTagKeysByExpr(name []byte, expr influxql.Expr) (map[s
 
 // DiskSizeBytes returns the size of the index on disk.
 func (i *Index) DiskSizeBytes() int64 {
-	fs, err := i.RetainFileSet()
+	fs, err := i.FileSet()
 	if err != nil {
 		i.logger.Warn("Index is closing down")
 		return 0
@@ -1130,22 +1148,36 @@ func (i *Index) TagKeyCardinality(name, key []byte) int {
 	return 0
 }
 
-// RetainFileSet returns the set of all files across all partitions.
-// This is only needed when all files need to be retained for an operation.
-func (i *Index) RetainFileSet() (*FileSet, error) {
+// FileSet returns the set of all files across all partitions. It must be released.
+func (i *Index) FileSet() (*FileSet, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
-	fs, _ := NewFileSet(nil, i.sfile, nil)
+	// Keep track of all of the file sets returned from the partitions temporarily.
+	// Keeping them alive keeps all of their underlying files alive. We release
+	// whatever we have when we return.
+	fss := make([]*FileSet, 0, len(i.partitions))
+	defer func() {
+		for _, fs := range fss {
+			fs.Release()
+		}
+	}()
+
+	// Collect the set of files from each partition.
+	var files []File
 	for _, p := range i.partitions {
-		pfs, err := p.RetainFileSet()
+		fs, err := p.FileSet()
 		if err != nil {
-			fs.Close()
 			return nil, err
 		}
-		fs.files = append(fs.files, pfs.files...)
+		fss = append(fss, fs)
+		files = append(files, fs.files...)
 	}
-	return fs, nil
+
+	// Construct a new file set from the set of files. This acquires references to
+	// each of the files, so we can release all of the file sets returned from the
+	// partitions, which happens automatically during the defer.
+	return NewFileSet(i.sfile, files)
 }
 
 // SetFieldName is a no-op on this index.
@@ -1377,14 +1409,11 @@ func (i *Index) seriesByBinaryExprVarRefIterator(name, key []byte, value *influx
 // MatchTagValueSeriesIDIterator returns a series iterator for tags which match value.
 // If matches is false, returns iterators which do not match value.
 func (i *Index) MatchTagValueSeriesIDIterator(name, key []byte, value *regexp.Regexp, matches bool) (tsdb.SeriesIDIterator, error) {
-	release := i.sfile.Retain()
-	defer release()
-
 	itr, err := i.matchTagValueSeriesIDIterator(name, key, value, matches)
 	if err != nil {
 		return nil, err
 	}
-	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr), nil
+	return tsdb.FilterUndeletedSeriesIDIterator(i.sfile, itr)
 }
 
 // matchTagValueSeriesIDIterator returns a series iterator for tags which match

--- a/tsdb/tsi1/index_file_test.go
+++ b/tsdb/tsi1/index_file_test.go
@@ -22,6 +22,7 @@ func TestCreateIndexFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
 
 	if e := f.TagValueElem([]byte("cpu"), []byte("region"), []byte("west")); e == nil {
 		t.Fatal("expected element")
@@ -40,6 +41,7 @@ func TestGenerateIndexFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
 
 	// Verify that tag/value series can be fetched.
 	if e := f.TagValueElem([]byte("measurement0"), []byte("key0"), []byte("value0")); e == nil {
@@ -85,6 +87,7 @@ func TestIndexFile_MeasurementHasSeries_Tombstoned(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
 
 	// Simulate all series are tombstoned
 	ss := tsdb.NewSeriesIDSet()
@@ -131,6 +134,7 @@ func CreateIndexFile(sfile *tsdb.SeriesFile, series []Series) (*tsi1.IndexFile, 
 	if err != nil {
 		return nil, err
 	}
+	defer lf.Close()
 
 	// Write index file to buffer.
 	var buf bytes.Buffer
@@ -154,6 +158,7 @@ func GenerateIndexFile(sfile *tsdb.SeriesFile, measurementN, tagN, valueN int) (
 	if err != nil {
 		return nil, err
 	}
+	defer lf.Close()
 
 	// Compact log file to buffer.
 	var buf bytes.Buffer

--- a/tsdb/tsi1/partition_test.go
+++ b/tsdb/tsi1/partition_test.go
@@ -24,8 +24,14 @@ func TestPartition_Open(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		fs, err := p.FileSet()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fs.Release()
+
 		// Check version set appropriately.
-		if got, exp := p.Manifest().Version, 1; got != exp {
+		if got, exp := p.Manifest(fs).Version, 1; got != exp {
 			t.Fatalf("got index version %d, expected %d", got, exp)
 		}
 	})
@@ -78,7 +84,15 @@ func TestPartition_Manifest(t *testing.T) {
 		defer sfile.Close()
 
 		p := MustOpenPartition(sfile.SeriesFile)
-		if got, exp := p.Manifest().Version, tsi1.Version; got != exp {
+		defer p.Close()
+
+		fs, err := p.FileSet()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fs.Release()
+
+		if got, exp := p.Manifest(fs).Version, tsi1.Version; got != exp {
 			t.Fatalf("got MANIFEST version %d, expected %d", got, exp)
 		}
 	})

--- a/tsdb/tsm1/engine_delete_bucket_test.go
+++ b/tsdb/tsm1/engine_delete_bucket_test.go
@@ -23,9 +23,6 @@ func TestEngine_DeleteBucket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// mock the planner so compactions don't run during the test
-	e.CompactionPlan = &mockPlanner{}
 	if err := e.Open(); err != nil {
 		t.Fatal(err)
 	}
@@ -110,15 +107,13 @@ func TestEngine_DeleteBucket(t *testing.T) {
 	if iter, err = e.index.MeasurementSeriesIDIterator([]byte("cpu")); err != nil {
 		t.Fatalf("iterator error: %v", err)
 	}
-	if iter == nil {
-		return
-	}
-
-	defer iter.Close()
-	if elem, err = iter.Next(); err != nil {
-		t.Fatal(err)
-	}
-	if !elem.SeriesID.IsZero() {
-		t.Fatalf("got an undeleted series id, but series should be dropped from index")
+	if iter != nil {
+		defer iter.Close()
+		if elem, err = iter.Next(); err != nil {
+			t.Fatal(err)
+		}
+		if !elem.SeriesID.IsZero() {
+			t.Fatalf("got an undeleted series id, but series should be dropped from index")
+		}
 	}
 }

--- a/tsdb/tsm1/engine_test.go
+++ b/tsdb/tsm1/engine_test.go
@@ -115,6 +115,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 	if err := e.Open(); err != nil {
 		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
 	}
+	defer e.Close()
 
 	// Make sure Snapshots are disabled.
 	e.SetCompactionsEnabled(false)
@@ -355,6 +356,11 @@ func (e *Engine) Close() error {
 }
 
 func (e *Engine) close(cleanup bool) error {
+	err := e.Engine.Close()
+	if err != nil {
+		return err
+	}
+
 	if e.index != nil {
 		e.index.Close()
 	}
@@ -363,12 +369,11 @@ func (e *Engine) close(cleanup bool) error {
 		e.sfile.Close()
 	}
 
-	defer func() {
-		if cleanup {
-			os.RemoveAll(e.root)
-		}
-	}()
-	return e.Engine.Close()
+	if cleanup {
+		os.RemoveAll(e.root)
+	}
+
+	return nil
 }
 
 // Reopen closes and reopens the engine.


### PR DESCRIPTION
This commit adds the `pkg/lifecycle.Resource` type to help manage opening, closing, and leasing out references to some resource. A resource cannot be closed until all acquired references have been released. If the `debug_ref` tag is enabled, all resource acquisitions keep track of the stack trace that created them and have a finalizer associated with them to print on stderr if they are leaked. It also registers a handler on SIGUSR2 to dump all of the currently live
resources.

Having resources tracked in a uniform way with a data type allows us to do more sophisticated tracking with the `debug_ref` tag, as well. For example, we could show references and panic the process if a resource cannot be closed within a certain time frame, or attempt to figure out the DAG of resource ownership dynamically. If we go all in, we can require that callers present a reference in order to use some APIs to statically ensure that you're holding a reference.

This commit also fixes some issues around resources, correctness during error scenarios, reporting of errors, idempotency of open and close, tracking of memory for some data structures, resource leaks in tests, and out of order dependency closes in tests.

