### PR TITLE
test(ui/de): add test for deleting de query text

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -19,4 +19,17 @@ describe('DataExplorer', () => {
       cy.getByTestID('time-machine-submit-button').should('not.be.disabled')
     })
   })
+
+  it('deleting query from script editor disables submit', () => {
+    cy.getByTestID('switch-to-script-editor').click()
+
+    cy.getByTestID('flux-editor').within(() => {
+      cy.get('textarea').type('from(bucket: "foo")', {force: true})
+      cy.getByTestID('time-machine-submit-button').should('not.be.disabled')
+
+      cy.get('textarea').type('{selectall} {backspace}', {force: true})
+    })
+
+    cy.getByTestID('time-machine-submit-button').should('be.disabled')
+  })
 })


### PR DESCRIPTION
Closes #12193

_Briefly describe your proposed changes:_
Adds test for adding then removing a query. However, an empty query
with only spaces will not currently disable the de submit

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
