### PR TITLE
fix(ui/types/v2/labels): fix dashboard labels to use v2/labels

### DIFF
--- a/ui/src/dashboards/actions/v2/index.ts
+++ b/ui/src/dashboards/actions/v2/index.ts
@@ -40,7 +40,7 @@ import {RemoteDataState} from 'src/types'
 import {PublishNotificationAction} from 'src/types/actions/notifications'
 import {CreateCell} from '@influxdata/influx'
 import {Dashboard, NewView, Cell} from 'src/types/v2'
-import {Label} from '@influxdata/influx'
+import {Label} from 'src/types/v2/labels'
 
 export enum ActionTypes {
   LoadDashboards = 'LOAD_DASHBOARDS',

--- a/ui/src/dashboards/apis/v2/index.ts
+++ b/ui/src/dashboards/apis/v2/index.ts
@@ -8,7 +8,7 @@ import {incrementCloneName} from 'src/utils/naming'
 // Types
 
 import {Cell, NewCell, Dashboard, View} from 'src/types/v2'
-import {Label} from '@influxdata/influx'
+import {Label} from 'src/types/v2/labels'
 
 import {Cell as CellAPI} from '@influxdata/influx'
 import {client} from 'src/utils/api'
@@ -108,7 +108,7 @@ export const addDashboardLabels = async (
     })
   )
 
-  return addedLabels
+  return addedLabels as Label[]
 }
 
 export const removeDashboardLabels = async (

--- a/ui/src/types/v2/dashboards.ts
+++ b/ui/src/types/v2/dashboards.ts
@@ -1,6 +1,7 @@
 import {HistogramPosition} from 'src/minard'
 import {Color} from 'src/types/colors'
-import {Label} from '@influxdata/influx'
+import {Label} from 'src/types/v2/labels'
+
 import {
   Dashboard as DashboardAPI,
   View as ViewAPI,


### PR DESCRIPTION
Closes #12234 

_Briefly describe your proposed changes:_
Use the Label's from `src/types/v2` where properties are not `any`

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
