### PR TITLE
fix(http/swagger/dashboard): update the swagger post dashboards

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1683,7 +1683,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Dashboard"
+                $ref: "#/components/schemas/CreateDashboardRequest"
       responses:
         '201':
           description: Added dashboard
@@ -6615,6 +6615,20 @@ components:
             $ref: "#/components/schemas/Cells"
         labels:
             $ref: "#/components/schemas/Labels"
+    CreateDashboardRequest:
+      properties:
+        orgID:
+          type: string
+          description: id of the organization that owns the dashboard
+        name:
+          type: string
+          description: user-facing name of the dashboard
+        description:
+          type: string
+          description: user-facing description of the dashboard
+      required:
+        - orgID
+        - name
     Dashboards:
       type: object
       properties:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6582,53 +6582,48 @@ components:
           items:
             $ref: "#/components/schemas/Proto"
     Dashboard:
-      properties:
-        links:
-          type: object
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/CreateDashboardRequest"
+        - type: object
           properties:
-            self:
+            links:
+              type: object
+              properties:
+                self:
+                  type: string
+                cells:
+                  type: string
+            id:
+              readOnly: true
               type: string
+            meta:
+              type: object
+              properties:
+                createdAt:
+                  type: string
+                  format: date
+                updatedAt:
+                  type: string
+                  format: date
             cells:
-              type: string
-        id:
-          readOnly: true
-          type: string
-        orgID:
-          type: string
-          description: id of the organization that owns the dashboard
-        name:
-          type: string
-          description: user-facing name of the dashboard
-        description:
-          type: string
-          description: user-facing description of the dashboard
-        meta:
-          type: object
-          properties:
-            createdAt:
-              type: string
-              format: date
-            updatedAt:
-              type: string
-              format: date
-        cells:
-            $ref: "#/components/schemas/Cells"
-        labels:
-            $ref: "#/components/schemas/Labels"
-    CreateDashboardRequest:
-      properties:
-        orgID:
-          type: string
-          description: id of the organization that owns the dashboard
-        name:
-          type: string
-          description: user-facing name of the dashboard
-        description:
-          type: string
-          description: user-facing description of the dashboard
-      required:
-        - orgID
-        - name
+                $ref: "#/components/schemas/Cells"
+            labels:
+                $ref: "#/components/schemas/Labels"
+      CreateDashboardRequest:
+        properties:
+          orgID:
+            type: string
+            description: id of the organization that owns the dashboard
+          name:
+            type: string
+            description: user-facing name of the dashboard
+          description:
+            type: string
+            description: user-facing description of the dashboard
+        required:
+          - orgID
+          - name
     Dashboards:
       type: object
       properties:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6581,6 +6581,20 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Proto"
+    CreateDashboardRequest:
+      properties:
+        orgID:
+          type: string
+          description: id of the organization that owns the dashboard
+        name:
+          type: string
+          description: user-facing name of the dashboard
+        description:
+          type: string
+          description: user-facing description of the dashboard
+      required:
+        - orgID
+        - name
     Dashboard:
       type: object
       allOf:
@@ -6610,20 +6624,6 @@ components:
                 $ref: "#/components/schemas/Cells"
             labels:
                 $ref: "#/components/schemas/Labels"
-      CreateDashboardRequest:
-        properties:
-          orgID:
-            type: string
-            description: id of the organization that owns the dashboard
-          name:
-            type: string
-            description: user-facing name of the dashboard
-          description:
-            type: string
-            description: user-facing description of the dashboard
-        required:
-          - orgID
-          - name
     Dashboards:
       type: object
       properties:


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Updates the swagger definition for the post dashboard request.  Using `Dashboard` for both Request and Response causes typing paining in the UI where `labels`, `cells`, etc are optional. 

Our first steps for fixing `labels` being generated as optional on `Bucket`, `Dashboard`, `Telegraf`, and `Task` is to create PRs for separating out their post request schema from the response schema. 

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
