### PR TITLE
test(explorer): move test for filtering functions

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -32,6 +32,13 @@ describe('DataExplorer', () => {
 
       cy.getByTestID('time-machine-submit-button').should('be.disabled')
     })
+
+    it('can filter aggregation functions by name from script editor mode', () => {
+      cy.getByTestID('switch-to-script-editor').click()
+
+      cy.get('.input-field').type('covariance')
+      cy.getByTestID('toolbar-function').should('have.length', 1)
+    })
   })
 
   describe('visualizations', () => {
@@ -49,12 +56,5 @@ describe('DataExplorer', () => {
         })
       })
     })
-  })
-
-  it('can filter aggregation functions by name from script editor mode', () => {
-    cy.getByTestID('switch-to-script-editor').click()
-
-    cy.get('.input-field').type('covariance')
-    cy.getByTestID('toolbar-function').should('have.length', 1)
   })
 })


### PR DESCRIPTION
This fixes an error in an earlier PR where the filtering function test was added to the wrong code block.
