### PR TITLE
test(explorer): test empty state for tag keys

### DIFF
--- a/ui/cypress/e2e/collectors.tests.ts
+++ b/ui/cypress/e2e/collectors.tests.ts
@@ -9,7 +9,7 @@ describe('Collectors', () => {
       cy.wrap(body.org).as('org')
 
       cy.fixture('routes').then(({orgs}) => {
-        cy.visit(`${orgs}/${id}/telegrafs_tab`)
+        cy.visit(`${orgs}/${id}/telegrafs`)
       })
     })
   })

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -55,6 +55,10 @@ describe('DataExplorer', () => {
           cy.contains('Error').should('exist')
         })
       })
+
+      it('show an empty state for tag keys when the bucket is empty', () => {
+        cy.getByTestID('empty-tag-keys').should('exist')
+      })
     })
   })
 })

--- a/ui/src/timeMachine/components/TagSelector.tsx
+++ b/ui/src/timeMachine/components/TagSelector.tsx
@@ -101,7 +101,9 @@ class TagSelector extends PureComponent<Props> {
       return (
         <>
           <div className="tag-selector--top">{this.removeButton}</div>
-          <div className="tag-selector--empty">No more tag keys found</div>
+          <div className="tag-selector--empty" data-testid="empty-tag-keys">
+            No more tag keys found
+          </div>
         </>
       )
     }


### PR DESCRIPTION
Closes #12180

This PR adds a test for the empty state of the tag keys card in the Data Explorer when the selected bucket is empty.

It also fixes a failing e2e test by renaming `telegrafs_tab` to `telegrafs` in the URL in the collectors test.

  - [x] Rebased/mergeable
  - [x] Tests pass
