### PR TITLE
Add retry and bail-out to reader

### DIFF
--- a/storage/reads/merge.go
+++ b/storage/reads/merge.go
@@ -47,6 +47,7 @@ func (r *mergedResultSet) Next() bool {
 			return true
 		}
 		err := top.Err()
+		stats := top.Stats()
 		top.Close()
 		heap.Pop(&r.heap)
 		if err != nil {
@@ -54,7 +55,7 @@ func (r *mergedResultSet) Next() bool {
 			r.Close()
 		}
 
-		r.stats.Add(top.Stats())
+		r.stats.Add(stats)
 
 		return len(r.heap.items) > 0
 	}

--- a/storage/reads/mergegroupresultset_test.go
+++ b/storage/reads/mergegroupresultset_test.go
@@ -2,7 +2,6 @@ package reads_test
 
 import (
 	"errors"
-	"io"
 	"strings"
 	"testing"
 
@@ -125,7 +124,7 @@ func TestGroupNoneMergedGroupResultSet_ErrNoData(t *testing.T) {
 	}
 }
 
-func TestGroupNoneMergedGroupResultSet_ErrUnexpectedEOF(t *testing.T) {
+func TestGroupNoneMergedGroupResultSet_ErrStreamNoData(t *testing.T) {
 	streams := []reads.StreamReader{
 		newGroupNoneStreamSeries("m0,tag2", "m0,tag2=val20"),
 		&emptyStreamReader{},
@@ -141,7 +140,7 @@ func TestGroupNoneMergedGroupResultSet_ErrUnexpectedEOF(t *testing.T) {
 		t.Errorf("expected nil")
 	}
 
-	if got, expErr := grs.Err(), io.ErrUnexpectedEOF; !cmp.Equal(got, expErr, cmp.Comparer(errCmp)) {
+	if got, expErr := grs.Err(), reads.ErrStreamNoData; !cmp.Equal(got, expErr, cmp.Comparer(errCmp)) {
 		t.Errorf("unexpected error; -got/+exp\n%s", cmp.Diff(got, expErr, cmp.Transformer("err", errTr)))
 	}
 }

--- a/storage/reads/reader.go
+++ b/storage/reads/reader.go
@@ -192,10 +192,10 @@ READ:
 			}
 		}
 
-		table.Close()
 		stats := table.Statistics()
 		bi.stats.ScannedValues += stats.ScannedValues
 		bi.stats.ScannedBytes += stats.ScannedBytes
+		table.Close()
 		table = nil
 	}
 	return rs.Err()
@@ -318,10 +318,10 @@ READ:
 			break READ
 		}
 
-		table.Close()
 		stats := table.Statistics()
 		bi.stats.ScannedValues += stats.ScannedValues
 		bi.stats.ScannedBytes += stats.ScannedBytes
+		table.Close()
 		table = nil
 
 		gc = rs.Next()

--- a/storage/reads/stream_reader.gen.go
+++ b/storage/reads/stream_reader.gen.go
@@ -56,7 +56,9 @@ func (c *floatCursorStreamReader) readFrame() {
 	}
 }
 
-func (c *floatCursorStreamReader) Stats() cursors.CursorStats { return cursors.CursorStats{} }
+func (c *floatCursorStreamReader) Stats() cursors.CursorStats {
+	return c.fr.stats.Stats()
+}
 
 type integerCursorStreamReader struct {
 	fr *frameReader
@@ -101,7 +103,9 @@ func (c *integerCursorStreamReader) readFrame() {
 	}
 }
 
-func (c *integerCursorStreamReader) Stats() cursors.CursorStats { return cursors.CursorStats{} }
+func (c *integerCursorStreamReader) Stats() cursors.CursorStats {
+	return c.fr.stats.Stats()
+}
 
 type unsignedCursorStreamReader struct {
 	fr *frameReader
@@ -146,7 +150,9 @@ func (c *unsignedCursorStreamReader) readFrame() {
 	}
 }
 
-func (c *unsignedCursorStreamReader) Stats() cursors.CursorStats { return cursors.CursorStats{} }
+func (c *unsignedCursorStreamReader) Stats() cursors.CursorStats {
+	return c.fr.stats.Stats()
+}
 
 type stringCursorStreamReader struct {
 	fr *frameReader
@@ -191,7 +197,9 @@ func (c *stringCursorStreamReader) readFrame() {
 	}
 }
 
-func (c *stringCursorStreamReader) Stats() cursors.CursorStats { return cursors.CursorStats{} }
+func (c *stringCursorStreamReader) Stats() cursors.CursorStats {
+	return c.fr.stats.Stats()
+}
 
 type booleanCursorStreamReader struct {
 	fr *frameReader
@@ -236,4 +244,6 @@ func (c *booleanCursorStreamReader) readFrame() {
 	}
 }
 
-func (c *booleanCursorStreamReader) Stats() cursors.CursorStats { return cursors.CursorStats{} }
+func (c *booleanCursorStreamReader) Stats() cursors.CursorStats {
+	return c.fr.stats.Stats()
+}

--- a/storage/reads/stream_reader.gen.go.tmpl
+++ b/storage/reads/stream_reader.gen.go.tmpl
@@ -52,6 +52,8 @@ func (c *{{.name}}CursorStreamReader) readFrame() {
 	}
 }
 
-func (c *{{.name}}CursorStreamReader) Stats() cursors.CursorStats { return cursors.CursorStats{} }
+func (c *{{.name}}CursorStreamReader) Stats() cursors.CursorStats {
+	return c.fr.stats.Stats()
+}
 
 {{end}}

--- a/storage/reads/stream_reader.go
+++ b/storage/reads/stream_reader.go
@@ -358,6 +358,7 @@ RETRY:
 	}
 
 	r.p = 0
+	r.buf = nil
 	res, err := r.s.Recv()
 	if err == nil {
 		if res != nil {

--- a/storage/reads/stream_reader_test.go
+++ b/storage/reads/stream_reader_test.go
@@ -272,6 +272,27 @@ series: _m=cpu,tag0=val1
 		},
 
 		{
+			name: "last frame empty",
+			stream: newStreamReader(
+				response(
+					seriesF(Float, "cpu,tag0=val0"),
+					floatF(floatS{
+						0: 1.0,
+						1: 2.0,
+						2: 3.0,
+					}),
+				),
+				response(),
+			),
+			exp: `series: _m=cpu,tag0=val0
+  cursor:Float
+                     0 |               1.00
+                     1 |               2.00
+                     2 |               3.00
+`,
+		},
+
+		{
 			name: "ErrUnexpectedEOF",
 			stream: newStreamReader(
 				response(


### PR DESCRIPTION
This work is necessary to support gRPC streams.

It is possible a `StreamReader` (gRPC) may return an empty response. This change adds retry and bail-out support. When a bail-out occurs, `reads.ErrStreamNoData` is returned.
