### PR TITLE
test(de): remove a second query

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -119,6 +119,30 @@ describe('DataExplorer', () => {
       cy.getByTestID('dropdown--item defbuck').should('exist')
       cy.getByTestID('dropdown--item newBucket').should('exist')
     })
+
+    it('can delete a second query', () => {
+      cy.get('.time-machine-queries--new').click()
+      cy.get('.query-tab').should('have.length', 2)
+      cy.get('.query-tab--close')
+        .first()
+        .click()
+      cy.get('.query-tab').should('have.length', 1)
+    })
+
+    it('can remove a second query using tab context menu', () => {
+      cy.get('.query-tab').trigger('contextmenu')
+      cy.getByTestID('right-click--remove-tab').should('have.class', 'disabled')
+
+      cy.get('.time-machine-queries--new').click()
+      cy.get('.query-tab').should('have.length', 2)
+
+      cy.get('.query-tab')
+        .first()
+        .trigger('contextmenu')
+      cy.getByTestID('right-click--remove-tab').click()
+
+      cy.get('.query-tab').should('have.length', 1)
+    })
   })
 
   describe('visualizations', () => {

--- a/ui/src/clockface/components/right_click_menu/RightClickMenuItem.tsx
+++ b/ui/src/clockface/components/right_click_menu/RightClickMenuItem.tsx
@@ -6,14 +6,23 @@ interface Props {
   disabled?: boolean
   onClick: (e?: MouseEvent<HTMLLIElement>) => void
   children: JSX.Element[] | JSX.Element | string
+  testID?: string
 }
 
 class RightClickMenuItem extends Component<Props> {
+  static defaultProps: Pick<Props, 'testID'> = {
+    testID: 'right-click--menu-item',
+  }
+
   public render() {
-    const {children} = this.props
+    const {children, testID} = this.props
 
     return (
-      <li className={this.className} onClick={this.handleClick}>
+      <li
+        className={this.className}
+        onClick={this.handleClick}
+        data-testid={testID}
+      >
         {children}
       </li>
     )

--- a/ui/src/timeMachine/components/QueryTab.tsx
+++ b/ui/src/timeMachine/components/QueryTab.tsx
@@ -88,12 +88,16 @@ class TimeMachineQueryTab extends PureComponent<Props, State> {
         </RightClick.Trigger>
         <RightClick.MenuContainer>
           <RightClick.Menu>
-            <RightClick.MenuItem onClick={this.handleEditActiveQueryName}>
+            <RightClick.MenuItem
+              onClick={this.handleEditActiveQueryName}
+              testID={'right-click--edit-tab'}
+            >
               Edit
             </RightClick.MenuItem>
             <RightClick.MenuItem
               onClick={this.handleRemove}
               disabled={!this.isRemovable}
+              testID={'right-click--remove-tab'}
             >
               Remove
             </RightClick.MenuItem>


### PR DESCRIPTION
Closes #12182 

_Briefly describe your proposed changes:_
Add test for removing a query tab when more than one query tab exists.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
