### PR TITLE
tsdb: fix disabling metrics in the series index

### DIFF
--- a/tsdb/metrics_test.go
+++ b/tsdb/metrics_test.go
@@ -1,9 +1,13 @@
 package tsdb
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/influxdata/influxdb/kit/prom/promtest"
+	"github.com/influxdata/influxdb/models"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
@@ -128,5 +132,47 @@ func TestMetrics_SeriesPartition(t *testing.T) {
 				t.Errorf("[%s %d] got %v, expected %v", name, i, got, exp)
 			}
 		}
+	}
+}
+
+// This test ensures that disabling metrics works even if a series file has been created before.
+func TestMetrics_Disabled(t *testing.T) {
+	// This test messes with global state. Gotta fix it up otherwise other tests panic. I really
+	// am beginning to wonder about our metrics.
+	defer func() {
+		mmu.Lock()
+		sms = nil
+		ims = nil
+		mmu.Unlock()
+	}()
+
+	path, err := ioutil.TempDir("", "sfile-metrics-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(path)
+
+	// Step 1. make a series file with metrics and some labels
+	sfile := NewSeriesFile(path)
+	sfile.SetDefaultMetricLabels(prometheus.Labels{"foo": "bar"})
+	if err := sfile.Open(); err != nil {
+		t.Fatal(err)
+	}
+	if err := sfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2. open the series file again, but disable metrics
+	sfile = NewSeriesFile(path)
+	sfile.DisableMetrics()
+	if err := sfile.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer sfile.Close()
+
+	// Step 3. add a series
+	points := []models.Point{models.MustNewPoint("a", models.Tags{}, models.Fields{"f": 1.0}, time.Now())}
+	if err := sfile.CreateSeriesListIfNotExists(NewSeriesCollection(points)); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/tsdb/series_index.go
+++ b/tsdb/series_index.go
@@ -125,6 +125,7 @@ func (idx *SeriesIndex) Recover(segments []*SeriesSegment) error {
 	options := rhh.DefaultOptions
 	options.Metrics = idx.rhhMetrics
 	options.Labels = idx.rhhLabels
+	options.MetricsEnabled = idx.rhhMetricsEnabled
 
 	idx.keyIDMap = rhh.NewHashMap(options)
 	idx.idOffsetMap = make(map[SeriesID]int64)


### PR DESCRIPTION
During Recover, we forgot to propagate the disabled flag to the keyIDMap options like we do during Open. Since we still do propagate the singleton `ims` which is initialized lazily, if the first initialization has a different set of labels, it will cause an inconsistent usage even if the metrics are disabled.
