### PR TITLE
fix(swagger): synchronize enum with defined error constants

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,7 @@ import (
 
 // Some error code constant, ideally we want define common platform codes here
 // projects on use platform's error, should have their own central place like this.
+// Any time this set of constants changes, you must also update the swagger for Error.properties.code.enum.
 const (
 	EInternal            = "internal error"
 	ENotFound            = "not found"

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5877,13 +5877,18 @@ components:
           description: code is the machine-readable error code.
           readOnly: true
           type: string
+          # This set of enumerations must remain in sync with the constants defined in errors.go
           enum:
             - internal error
             - not found
             - conflict
             - invalid
+            - unprocessable entity
             - empty value
             - unavailable
+            - forbidden
+            - unauthorized
+            - method not allowed
         message:
           readOnly: true
           description: message is a human-readable message.


### PR DESCRIPTION
Discovered this discrepancy during a failed signin request, with my experimental swagger validation branch.