### PR TITLE
fix(ui/dashindex): hide import overlay on new dash create

### DIFF
--- a/ui/src/shared/components/AddResourceDropdown.tsx
+++ b/ui/src/shared/components/AddResourceDropdown.tsx
@@ -55,9 +55,9 @@ export default class AddResourceDropdown extends PureComponent<Props> {
     const {onSelectNew, onSelectImport} = this.props
     switch (selection) {
       case this.newOption:
-        onSelectNew()
+        return onSelectNew()
       case this.importOption:
-        onSelectImport()
+        return onSelectImport()
     }
   }
 }


### PR DESCRIPTION
Closes #12058 

_Briefly describe your proposed changes:_
Fixes a `switch` fall through that caused the import overlay to display `onSelectNew` from the `AddResourceDropdown`.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
