### PR TITLE
refactor(http): only generate bindata asset for swagger.yml

### DIFF
--- a/http/swagger.go
+++ b/http/swagger.go
@@ -1,6 +1,7 @@
 package http
 
-//go:generate env GO111MODULE=on go run github.com/kevinburke/go-bindata/go-bindata -o swagger_gen.go -tags assets -ignore go -nocompress -pkg http .
+// Only generate an asset for swagger.yml.
+//go:generate env GO111MODULE=on go run github.com/kevinburke/go-bindata/go-bindata -o swagger_gen.go -tags assets -nocompress -pkg http ./swagger.yml
 
 import (
 	"context"


### PR DESCRIPTION
The previous "." argument with "-ignore go" accidentally matched
README.md and Makefile too, neither of which we care to actually include
as assets.

Now we just explicitly include swagger.yml. It's simple enough to add
another file to the go:generate line if and when we need it.