### PR TITLE
fix(task): don't error when URM task disappears

### DIFF
--- a/http/task_service.go
+++ b/http/task_service.go
@@ -271,47 +271,14 @@ func (h *TaskHandler) handleGetTasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var tasks []*platform.Task
-
-	if req.filter.User != nil {
-		ownedTasks, _, err := h.UserResourceMappingService.FindUserResourceMappings(
-			ctx,
-			platform.UserResourceMappingFilter{
-				UserID:       *req.filter.User,
-				UserType:     platform.Owner,
-				ResourceType: platform.TasksResourceType,
-			},
-		)
-		if err != nil {
-			err = &platform.Error{
-				Err: err,
-				Msg: "failed to pull user's resources",
-			}
-			EncodeError(ctx, err, w)
-			return
+	tasks, _, err := h.TaskService.FindTasks(ctx, req.filter)
+	if err != nil {
+		err = &platform.Error{
+			Err: err,
+			Msg: "failed to find tasks",
 		}
-		for _, ownedTask := range ownedTasks {
-			task, err := h.TaskService.FindTaskByID(ctx, ownedTask.ResourceID)
-			if err != nil {
-				err = &platform.Error{
-					Err: err,
-					Msg: "failed to find tasks",
-				}
-				EncodeError(ctx, err, w)
-				return
-			}
-			tasks = append(tasks, task)
-		}
-	} else {
-		tasks, _, err = h.TaskService.FindTasks(ctx, req.filter)
-		if err != nil {
-			err = &platform.Error{
-				Err: err,
-				Msg: "failed to find tasks",
-			}
-			EncodeError(ctx, err, w)
-			return
-		}
+		EncodeError(ctx, err, w)
+		return
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newTasksResponse(ctx, tasks, h.LabelService)); err != nil {


### PR DESCRIPTION
In the platform adapter, we ask the URM for a list of tasks the user
owns, and then we look up each task individually.

The task service tests uncovered a legitimate bug where FindTasks would
return a "task not found" error, originating from looking up a task that
was present when we interrogated the URM but was deleted before we could
find it in the task store.

This change also removes duplicated URM logic from the HTTP handler
which has since been pushed down into the platform adapter.

Closes #12003.