### PR TITLE
feat(influxd): Tracing refactor

### DIFF
--- a/authorizer/variable_test.go
+++ b/authorizer/variable_test.go
@@ -123,7 +123,7 @@ func TestVariableService_FindVariables(t *testing.T) {
 		permission influxdb.Permission
 	}
 	type wants struct {
-		err    error
+		err       error
 		variables []*influxdb.Variable
 	}
 
@@ -359,7 +359,7 @@ func TestVariableService_ReplaceVariable(t *testing.T) {
 		VariableService influxdb.VariableService
 	}
 	type args struct {
-		variable       influxdb.Variable
+		variable    influxdb.Variable
 		permissions []influxdb.Permission
 	}
 	type wants struct {

--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -2,6 +2,7 @@
 package buildtsi
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -119,7 +120,7 @@ func (cmd *Command) processDatabase(dbName, dataDir, walDir string) error {
 
 	sfile := tsdb.NewSeriesFile(filepath.Join(dataDir, storage.DefaultSeriesFileDirectoryName))
 	sfile.Logger = cmd.Logger
-	if err := sfile.Open(); err != nil {
+	if err := sfile.Open(context.Background()); err != nil {
 		return err
 	}
 	defer sfile.Close()
@@ -237,7 +238,7 @@ func IndexShard(sfile *tsdb.SeriesFile, indexPath, dataDir, walDir string, maxLo
 	tsiIndex.WithLogger(log)
 
 	log.Info("Opening tsi index in temporary location", zap.String("path", tmpPath))
-	if err := tsiIndex.Open(); err != nil {
+	if err := tsiIndex.Open(context.Background()); err != nil {
 		return err
 	}
 	defer tsiIndex.Close()

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -216,8 +216,8 @@ func (m *Launcher) Run(ctx context.Context, args ...string) error {
 			{
 				DestP:   &m.tracingType,
 				Flag:    "tracing-type",
-				Default: LogTracing,
-				Desc:    fmt.Sprintf("supported tracing types are %s", LogTracing),
+				Default: "",
+				Desc:    fmt.Sprintf("supported tracing types are %s, %s", LogTracing, JaegerTracing),
 			},
 			{
 				DestP:   &m.httpBindAddress,

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -271,6 +271,9 @@ func (m *Launcher) Run(ctx context.Context, args ...string) error {
 }
 
 func (m *Launcher) run(ctx context.Context) (err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Launcher.run")
+	defer span.Finish()
+
 	m.running = true
 	ctx, m.cancel = context.WithCancel(ctx)
 
@@ -416,7 +419,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		m.engine = storage.NewEngine(m.enginePath, storage.NewConfig(), storage.WithRetentionEnforcer(bucketSvc))
 		m.engine.WithLogger(m.logger)
 
-		if err := m.engine.Open(); err != nil {
+		if err := m.engine.Open(ctx); err != nil {
 			m.logger.Error("failed to open engine", zap.Error(err))
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -111,6 +111,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.0.0-20190108154635-47c0da630f72
 	github.com/tinylib/msgp v1.1.0 // indirect
 	github.com/tylerb/graceful v1.2.15
+	github.com/uber-go/atomic v1.3.2 // indirect
 	github.com/uber/jaeger-client-go v2.15.0+incompatible
 	github.com/uber/jaeger-lib v1.5.0+incompatible // indirect
 	github.com/willf/bitset v1.1.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/bouk/httprouter v0.0.0-20160817010721-ee8b3818a7f5
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/cespare/xxhash v1.1.0
+	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 // indirect
 	github.com/coreos/bbolt v1.3.1-coreos.6
 	github.com/davecgh/go-spew v1.1.1
@@ -110,6 +111,8 @@ require (
 	github.com/testcontainers/testcontainers-go v0.0.0-20190108154635-47c0da630f72
 	github.com/tinylib/msgp v1.1.0 // indirect
 	github.com/tylerb/graceful v1.2.15
+	github.com/uber/jaeger-client-go v2.15.0+incompatible
+	github.com/uber/jaeger-lib v1.5.0+incompatible // indirect
 	github.com/willf/bitset v1.1.9 // indirect
 	github.com/yudai/gojsondiff v1.0.0
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,7 +228,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/flux v0.21.2 h1:/DpkdlJ1SvW5hjXfu0fgVIC56SJRb07fYHLj2SZsDqo=
 github.com/influxdata/flux v0.21.2/go.mod h1:0f5Yrm4VPSd/Ne6jIVOVtPo0MFe6jpLCr6vdaZYp7wY=
-github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6 h1:CFx+pP90q/qg3spoiZjf8donE4WpAdjeJfPOcoNqkWo=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
@@ -408,6 +407,8 @@ github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tylerb/graceful v1.2.15 h1:B0x01Y8fsJpogzZTkDg6BDi6eMf03s01lEKGdrv83oA=
 github.com/tylerb/graceful v1.2.15/go.mod h1:LPYTbOYmUTdabwRt0TGhLllQ0MUNbs0Y5q1WXJOI9II=
+github.com/uber-go/atomic v1.3.2 h1:Azu9lPBWRNKzYXSIwRfgRuDuS0YKsK4NFhiQv98gkxo=
+github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/uber/jaeger-client-go v2.15.0+incompatible h1:NP3qsSqNxh8VYr956ur1N/1C1PjvOJnJykCzcD5QHbk=
 github.com/uber/jaeger-client-go v2.15.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v1.5.0+incompatible h1:QsjOHVbRaYpt001rdkD/nNjuaSTWI+oxlMUJUIZmzR4=

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
+github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 h1:4BX8f882bXEDKfWIf0wa8HRvpnBoPszJJXL+TVbBw4M=
 github.com/containerd/continuity v0.0.0-20181203112020-004b46473808/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/coreos/bbolt v1.3.1-coreos.6 h1:uTXKg9gY70s9jMAKdfljFQcuh4e/BXOM+V+d00KFj3A=
@@ -226,6 +228,7 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/flux v0.21.2 h1:/DpkdlJ1SvW5hjXfu0fgVIC56SJRb07fYHLj2SZsDqo=
 github.com/influxdata/flux v0.21.2/go.mod h1:0f5Yrm4VPSd/Ne6jIVOVtPo0MFe6jpLCr6vdaZYp7wY=
+github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6 h1:CFx+pP90q/qg3spoiZjf8donE4WpAdjeJfPOcoNqkWo=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=
@@ -405,6 +408,10 @@ github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tylerb/graceful v1.2.15 h1:B0x01Y8fsJpogzZTkDg6BDi6eMf03s01lEKGdrv83oA=
 github.com/tylerb/graceful v1.2.15/go.mod h1:LPYTbOYmUTdabwRt0TGhLllQ0MUNbs0Y5q1WXJOI9II=
+github.com/uber/jaeger-client-go v2.15.0+incompatible h1:NP3qsSqNxh8VYr956ur1N/1C1PjvOJnJykCzcD5QHbk=
+github.com/uber/jaeger-client-go v2.15.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-lib v1.5.0+incompatible h1:QsjOHVbRaYpt001rdkD/nNjuaSTWI+oxlMUJUIZmzR4=
+github.com/uber/jaeger-lib v1.5.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/willf/bitset v1.1.9 h1:GBtFynGY9ZWZmEC9sWuu41/7VBXPFCOAbCbqTflOg9c=
 github.com/willf/bitset v1.1.9/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=

--- a/http/query_test.go
+++ b/http/query_test.go
@@ -254,7 +254,7 @@ func TestQueryRequest_proxyRequest(t *testing.T) {
 								},
 							},
 						},
-						Now: time.Unix(1,1),
+						Now: time.Unix(1, 1),
 					},
 				},
 				Dialect: &csv.Dialect{
@@ -281,7 +281,7 @@ func TestQueryRequest_proxyRequest(t *testing.T) {
 				Request: query.Request{
 					Compiler: lang.ASTCompiler{
 						AST: &ast.Package{},
-						Now: time.Unix(1,1),
+						Now: time.Unix(1, 1),
 					},
 				},
 				Dialect: &csv.Dialect{
@@ -331,7 +331,7 @@ func TestQueryRequest_proxyRequest(t *testing.T) {
 								},
 							},
 						},
-						Now: time.Unix(1,1),
+						Now: time.Unix(1, 1),
 					},
 				},
 				Dialect: &csv.Dialect{

--- a/query/promql/query_test.go
+++ b/query/promql/query_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/semantic/semantictest"
-	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 )
 
 func TestParsePromQL(t *testing.T) {

--- a/storage/compat/compat.go
+++ b/storage/compat/compat.go
@@ -27,7 +27,6 @@ type Config struct {
 	CompactThroughput              toml.Size     `toml:"compact-throughput"`
 	CompactThroughputBurst         toml.Size     `toml:"compact-throughput-burst"`
 	MaxConcurrentCompactions       int           `toml:"max-concurrent-compactions"`
-	TraceLoggingEnabled            bool          `toml:"trace-logging-enabled"`
 	TSMWillNeed                    bool          `toml:"tsm-use-madv-willneed"`
 }
 
@@ -43,7 +42,6 @@ func NewConfig() Config {
 		CompactThroughput:              toml.Size(tsm1.DefaultCompactThroughput),
 		CompactThroughputBurst:         toml.Size(tsm1.DefaultCompactThroughputBurst),
 		MaxConcurrentCompactions:       tsm1.DefaultCompactMaxConcurrent,
-		TraceLoggingEnabled:            storage.DefaultTraceLoggingEnabled,
 		TSMWillNeed:                    tsm1.DefaultMADVWillNeed,
 	}
 }
@@ -52,7 +50,6 @@ func NewConfig() Config {
 // of the Dir key so that it can be passed through appropriately to the storage engine constructor.
 func Convert(oldConfig Config) (string, storage.Config) {
 	newConfig := storage.NewConfig()
-	newConfig.TraceLoggingEnabled = oldConfig.TraceLoggingEnabled
 	newConfig.ValidateKeys = oldConfig.ValidateKeys
 	newConfig.Engine.MADVWillNeed = oldConfig.TSMWillNeed
 	newConfig.Engine.Cache.MaxMemorySize = oldConfig.CacheMaxMemorySize

--- a/storage/config.go
+++ b/storage/config.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	DefaultRetentionInterval   = 1 * time.Hour
-	DefaultValidateKeys        = false
+	DefaultRetentionInterval = 1 * time.Hour
+	DefaultValidateKeys      = false
 
 	DefaultSeriesFileDirectoryName = "_series"
 	DefaultIndexDirectoryName      = "index"

--- a/storage/config.go
+++ b/storage/config.go
@@ -12,7 +12,6 @@ import (
 const (
 	DefaultRetentionInterval   = 1 * time.Hour
 	DefaultValidateKeys        = false
-	DefaultTraceLoggingEnabled = false
 
 	DefaultSeriesFileDirectoryName = "_series"
 	DefaultIndexDirectoryName      = "index"
@@ -27,9 +26,6 @@ type Config struct {
 
 	// Enables unicode validation on series keys on write.
 	ValidateKeys bool `toml:"validate-keys"`
-
-	// Enables trace logging for the engine.
-	TraceLoggingEnabled bool `toml:"trace-logging-enabled"`
 
 	// Series file config.
 	SeriesFilePath string `toml:"series-file-path"` // Overrides the default path.
@@ -50,9 +46,8 @@ type Config struct {
 // NewConfig initialises a new config for an Engine.
 func NewConfig() Config {
 	return Config{
-		RetentionInterval:   toml.Duration(DefaultRetentionInterval),
-		ValidateKeys:        DefaultValidateKeys,
-		TraceLoggingEnabled: DefaultTraceLoggingEnabled,
+		RetentionInterval: toml.Duration(DefaultRetentionInterval),
+		ValidateKeys:      DefaultValidateKeys,
 
 		WAL:    tsm1.NewWALConfig(),
 		Engine: tsm1.NewConfig(),

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -450,7 +450,7 @@ func (e *Engine) writePointsLocked(collection *tsdb.SeriesCollection, values map
 // AcquireSegments closes the current WAL segment, gets the set of all the currently closed
 // segments, and calls the callback. It does all of this under the lock on the engine.
 func (e *Engine) AcquireSegments(ctx context.Context, fn func(segs []string) error) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Engine.AcquireSegments")
+	span, _ := opentracing.StartSpanFromContext(ctx, "Engine.AcquireSegments")
 	defer span.Finish()
 
 	e.mu.Lock()

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -205,7 +205,7 @@ func TestEngine_OpenClose(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := engine.Open(); err != nil {
+	if err := engine.Open(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -239,7 +239,7 @@ func TestEngineClose_RemoveIndex(t *testing.T) {
 
 	// ensure the index gets loaded after closing and opening the shard
 	engine.Engine.Close() // Don't destroy temporary data.
-	engine.Open()
+	engine.Open(context.Background())
 
 	if got, exp := engine.SeriesCardinality(), int64(1); got != exp {
 		t.Fatalf("got %d series, exp %d series in index", got, exp)
@@ -347,7 +347,7 @@ func NewDefaultEngine() *Engine {
 
 // MustOpen opens the engine or panicks.
 func (e *Engine) MustOpen() {
-	if err := e.Engine.Open(); err != nil {
+	if err := e.Engine.Open(context.Background()); err != nil {
 		panic(err)
 	}
 }

--- a/storage/opener.go
+++ b/storage/opener.go
@@ -1,13 +1,14 @@
 package storage
 
 import (
+	"context"
 	"io"
 )
 
 // opener is something that can be opened and closed.
 type opener interface {
-	Open() error
-	io.Closer
+	Open(context.Context) error
+	io.Closer // TODO consider a closer-with-context instead
 }
 
 // openHelper is a helper to abstract the pattern of opening multiple things,
@@ -20,11 +21,11 @@ type openHelper struct {
 
 // Open attempts to open the opener. If an error has happened already
 // then no calls are made to the opener.
-func (o *openHelper) Open(op opener) {
+func (o *openHelper) Open(ctx context.Context, op opener) {
 	if o.err != nil {
 		return
 	}
-	o.err = op.Open()
+	o.err = op.Open(ctx)
 	if o.err == nil {
 		o.opened = append(o.opened, op)
 	}

--- a/storage/wal/wal.go
+++ b/storage/wal/wal.go
@@ -170,7 +170,7 @@ func (l *WAL) Open(ctx context.Context) error {
 		return nil
 	}
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WAL.Open")
+	span, _ := opentracing.StartSpanFromContext(ctx, "WAL.Open")
 	defer span.Finish()
 
 	span.LogKV("segment_size", l.SegmentSize,
@@ -370,7 +370,8 @@ func (l *WAL) Remove(ctx context.Context, files []string) error {
 		return nil
 	}
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, "WAL.Remove")
+	span, _ := opentracing.StartSpanFromContext(ctx, "WAL.Remove")
+	defer span.Finish()
 
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/storage/wal/wal.go
+++ b/storage/wal/wal.go
@@ -2,8 +2,10 @@ package wal
 
 import (
 	"bufio"
+	"context"
 	"encoding/binary"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"io"
 	"math"
 	"os"
@@ -101,9 +103,7 @@ type WAL struct {
 	syncDelay time.Duration
 
 	// WALOutput is the writer used by the logger.
-	logger       *zap.Logger // Logger to be used for important messages
-	traceLogger  *zap.Logger // Logger to be used when trace-logging is on.
-	traceLogging bool
+	logger *zap.Logger // Logger to be used for important messages
 
 	// SegmentSize is the file size at which a segment file will be rotated
 	SegmentSize int
@@ -127,15 +127,6 @@ func NewWAL(path string) *WAL {
 		syncWaiters: make(chan chan error, 1024),
 		limiter:     limiter.NewFixed(defaultWaitingWALWrites),
 		logger:      logger,
-		traceLogger: logger,
-	}
-}
-
-// EnableTraceLogging must be called before the WAL is opened.
-func (l *WAL) EnableTraceLogging(enabled bool) {
-	l.traceLogging = enabled
-	if enabled {
-		l.traceLogger = l.logger
 	}
 }
 
@@ -152,10 +143,6 @@ func (l *WAL) SetEnabled(enabled bool) {
 // WithLogger sets the WAL's logger.
 func (l *WAL) WithLogger(log *zap.Logger) {
 	l.logger = log.With(zap.String("service", "wal"))
-
-	if l.traceLogging {
-		l.traceLogger = l.logger
-	}
 }
 
 // SetDefaultMetricLabels sets the default labels for metrics on the engine.
@@ -175,13 +162,19 @@ func (l *WAL) Path() string {
 }
 
 // Open opens and initializes the Log. Open can recover from previous unclosed shutdowns.
-func (l *WAL) Open() error {
+func (l *WAL) Open(ctx context.Context) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	if !l.enabled {
 		return nil
 	}
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WAL.Open")
+	defer span.Finish()
+
+	span.LogKV("segment_size", l.SegmentSize,
+		"path", l.path)
 
 	// Initialise metrics for trackers.
 	mmu.Lock()
@@ -192,9 +185,6 @@ func (l *WAL) Open() error {
 
 	// Set the shared metrics for the tracker
 	l.tracker = newWALTracker(wms, l.defaultMetricLabels)
-
-	l.traceLogger.Info("tsm1 WAL starting", zap.Int("segment_size", l.SegmentSize))
-	l.traceLogger.Info("tsm1 WAL writing", zap.String("path", l.path))
 
 	if err := os.MkdirAll(l.path, 0777); err != nil {
 		return err
@@ -375,16 +365,18 @@ func (l *WAL) ClosedSegments() ([]string, error) {
 }
 
 // Remove deletes the given segment file paths from disk and cleans up any associated objects.
-func (l *WAL) Remove(files []string) error {
+func (l *WAL) Remove(ctx context.Context, files []string) error {
 	if !l.enabled {
 		return nil
 	}
 
+	span, ctx := opentracing.StartSpanFromContext(ctx, "WAL.Remove")
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	for _, fn := range files {
-		l.traceLogger.Info("Removing WAL file", zap.String("path", fn))
+	for i, fn := range files {
+		span.LogKV(fmt.Sprintf("path-%d", i), fn)
 		os.RemoveAll(fn)
 	}
 
@@ -551,8 +543,12 @@ func (l *WAL) Close() error {
 	}
 
 	l.once.Do(func() {
+		span := opentracing.StartSpan("WAL.Close once.Do")
+		defer span.Finish()
+
+		span.LogKV("path", l.path)
+
 		// Close, but don't set to nil so future goroutines can still be signaled
-		l.traceLogger.Info("Closing WAL file", zap.String("path", l.path))
 		close(l.closing)
 
 		if l.currentSegmentWriter != nil {

--- a/storage/wal/wal_test.go
+++ b/storage/wal/wal_test.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
@@ -264,7 +265,7 @@ func TestWAL_ClosedSegments(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	w := NewWAL(dir)
-	if err := w.Open(); err != nil {
+	if err := w.Open(context.Background()); err != nil {
 		t.Fatalf("error opening WAL: %v", err)
 	}
 
@@ -292,7 +293,7 @@ func TestWAL_ClosedSegments(t *testing.T) {
 	// Re-open the WAL
 	w = NewWAL(dir)
 	defer w.Close()
-	if err := w.Open(); err != nil {
+	if err := w.Open(context.Background()); err != nil {
 		t.Fatalf("error opening WAL: %v", err)
 	}
 

--- a/task/backend/logreaderwriter_test.go
+++ b/task/backend/logreaderwriter_test.go
@@ -79,7 +79,7 @@ func newFullStackAwareLogReaderWriter(t *testing.T) *fullStackAwareLogReaderWrit
 	engine := storage.NewEngine(rootDir, storage.NewConfig())
 	engine.WithLogger(logger)
 
-	if err := engine.Open(); err != nil {
+	if err := engine.Open(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tsdb/index_test.go
+++ b/tsdb/index_test.go
@@ -2,6 +2,7 @@ package tsdb_test
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -86,7 +87,7 @@ func MustNewIndex(c tsi1.Config) *Index {
 	}
 
 	sfile := tsdb.NewSeriesFile(seriesPath)
-	if err := sfile.Open(); err != nil {
+	if err := sfile.Open(context.Background()); err != nil {
 		panic(err)
 	}
 
@@ -115,7 +116,7 @@ func MustOpenNewIndex(c tsi1.Config) *Index {
 
 // MustOpen opens the underlying index or panics.
 func (i *Index) MustOpen() {
-	if err := i.Index.Open(); err != nil {
+	if err := i.Index.Open(context.Background()); err != nil {
 		panic(err)
 	}
 }
@@ -131,13 +132,13 @@ func (i *Index) Reopen() error {
 	}
 
 	i.sfile = tsdb.NewSeriesFile(i.sfile.Path())
-	if err := i.sfile.Open(); err != nil {
+	if err := i.sfile.Open(context.Background()); err != nil {
 		return err
 	}
 
 	i.Index = tsi1.NewIndex(i.SeriesFile(), i.config,
 		tsi1.WithPath(filepath.Join(i.rootPath, "index")))
-	return i.Index.Open()
+	return i.Index.Open(context.Background())
 }
 
 // Close closes the index cleanly and removes all on-disk data.

--- a/tsdb/metrics_test.go
+++ b/tsdb/metrics_test.go
@@ -1,6 +1,7 @@
 package tsdb
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -155,7 +156,7 @@ func TestMetrics_Disabled(t *testing.T) {
 	// Step 1. make a series file with metrics and some labels
 	sfile := NewSeriesFile(path)
 	sfile.SetDefaultMetricLabels(prometheus.Labels{"foo": "bar"})
-	if err := sfile.Open(); err != nil {
+	if err := sfile.Open(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if err := sfile.Close(); err != nil {
@@ -165,7 +166,7 @@ func TestMetrics_Disabled(t *testing.T) {
 	// Step 2. open the series file again, but disable metrics
 	sfile = NewSeriesFile(path)
 	sfile.DisableMetrics()
-	if err := sfile.Open(); err != nil {
+	if err := sfile.Open(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	defer sfile.Close()

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -92,7 +92,7 @@ func (f *SeriesFile) Open(ctx context.Context) error {
 		return errors.New("series file already opened")
 	}
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SeriesFile.Open")
+	span, _ := opentracing.StartSpanFromContext(ctx, "SeriesFile.Open")
 	defer span.Finish()
 
 	_, logEnd := logger.NewOperation(f.Logger, "Opening Series File", "series_file_open", zap.String("path", f.path))

--- a/tsdb/series_file_test.go
+++ b/tsdb/series_file_test.go
@@ -2,6 +2,7 @@ package tsdb_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -243,7 +244,7 @@ func NewSeriesFile() *SeriesFile {
 func MustOpenSeriesFile() *SeriesFile {
 	f := NewSeriesFile()
 	f.Logger = logger.New(os.Stdout)
-	if err := f.Open(); err != nil {
+	if err := f.Open(context.Background()); err != nil {
 		panic(err)
 	}
 	return f
@@ -261,7 +262,7 @@ func (f *SeriesFile) Reopen() error {
 		return err
 	}
 	f.SeriesFile = tsdb.NewSeriesFile(f.SeriesFile.Path())
-	return f.SeriesFile.Open()
+	return f.SeriesFile.Open(context.Background())
 }
 
 // ForceCompact executes an immediate compaction across all partitions.

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -217,7 +217,7 @@ func (i *Index) Open(ctx context.Context) error {
 		return errors.New("index already open")
 	}
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Index.Open")
+	span, _ := opentracing.StartSpanFromContext(ctx, "Index.Open")
 	defer span.Finish()
 
 	// Ensure root exists.

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -2,8 +2,10 @@ package tsi1
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -207,13 +209,16 @@ func (i *Index) SeriesIDSet() *tsdb.SeriesIDSet {
 }
 
 // Open opens the index.
-func (i *Index) Open() error {
+func (i *Index) Open(ctx context.Context) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
 	if i.res.Opened() {
 		return errors.New("index already open")
 	}
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Index.Open")
+	defer span.Finish()
 
 	// Ensure root exists.
 	if err := os.MkdirAll(i.path, 0777); err != nil {

--- a/tsdb/tsi1/index_file_test.go
+++ b/tsdb/tsi1/index_file_test.go
@@ -2,6 +2,7 @@ package tsi1_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/influxdata/influxdb/models"
@@ -55,7 +56,7 @@ func TestGenerateIndexFile(t *testing.T) {
 func TestGenerateIndexFile_Uvarint(t *testing.T) {
 	// Load previously generated series file.
 	sfile := tsdb.NewSeriesFile("testdata/uvarint/_series")
-	if err := sfile.Open(); err != nil {
+	if err := sfile.Open(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	defer sfile.Close()

--- a/tsdb/tsi1/index_test.go
+++ b/tsdb/tsi1/index_test.go
@@ -1,6 +1,7 @@
 package tsi1_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -436,10 +437,10 @@ func MustOpenIndex(partitionN uint64, c tsi1.Config) *Index {
 
 // Open opens the underlying tsi1.Index and tsdb.SeriesFile
 func (idx Index) Open() error {
-	if err := idx.SeriesFile.Open(); err != nil {
+	if err := idx.SeriesFile.Open(context.Background()); err != nil {
 		return err
 	}
-	return idx.Index.Open()
+	return idx.Index.Open(context.Background())
 }
 
 // Close closes and removes the index directory.

--- a/tsdb/tsi1/legacy_test.go
+++ b/tsdb/tsi1/legacy_test.go
@@ -1,6 +1,7 @@
 package tsi1
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -16,13 +17,13 @@ func TestLegacyOpen(t *testing.T) {
 	os.RemoveAll(dir)
 
 	sfile := tsdb.NewSeriesFile(dir)
-	if err := sfile.Open(); err != nil {
+	if err := sfile.Open(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	defer sfile.Close()
 
 	index := NewIndex(sfile, NewConfig(), WithPath("testdata/index-file-index"))
-	if err := index.Open(); err != nil {
+	if err := index.Open(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	defer index.Close()

--- a/tsdb/tsi1/tsi1_test.go
+++ b/tsdb/tsi1/tsi1_test.go
@@ -2,6 +2,7 @@ package tsi1_test
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -300,7 +301,7 @@ func NewSeriesFile() *SeriesFile {
 // MustOpenSeriesFile returns a new, open instance of SeriesFile. Panic on error.
 func MustOpenSeriesFile() *SeriesFile {
 	f := NewSeriesFile()
-	if err := f.Open(); err != nil {
+	if err := f.Open(context.Background()); err != nil {
 		panic(err)
 	}
 	return f

--- a/tsdb/tsm1/compact.go
+++ b/tsdb/tsm1/compact.go
@@ -14,7 +14,9 @@ package tsm1
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"io"
 	"math"
 	"os"
@@ -808,7 +810,10 @@ func (c *Compactor) EnableCompactions() {
 }
 
 // WriteSnapshot writes a Cache snapshot to one or more new TSM files.
-func (c *Compactor) WriteSnapshot(cache *Cache) ([]string, error) {
+func (c *Compactor) WriteSnapshot(ctx context.Context, cache *Cache) ([]string, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "Compactor.WriteSnapshot")
+	defer span.Finish()
+
 	c.mu.RLock()
 	enabled := c.snapshotsEnabled
 	intC := c.snapshotsInterrupt

--- a/tsdb/tsm1/compact_test.go
+++ b/tsdb/tsm1/compact_test.go
@@ -2,6 +2,7 @@ package tsm1_test
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -40,7 +41,7 @@ func TestCompactor_Snapshot(t *testing.T) {
 	compactor.Dir = dir
 	compactor.FileStore = &fakeFileStore{}
 
-	files, err := compactor.WriteSnapshot(c)
+	files, err := compactor.WriteSnapshot(context.Background(), c)
 	if err == nil {
 		t.Fatalf("expected error writing snapshot: %v", err)
 	}
@@ -51,7 +52,7 @@ func TestCompactor_Snapshot(t *testing.T) {
 
 	compactor.Open()
 
-	files, err = compactor.WriteSnapshot(c)
+	files, err = compactor.WriteSnapshot(context.Background(), c)
 	if err != nil {
 		t.Fatalf("unexpected error writing snapshot: %v", err)
 	}

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -71,13 +72,6 @@ const (
 // an Engine.
 type EngineOption func(i *Engine)
 
-// WithTraceLogging sets if trace logging is enabled for the engine.
-func WithTraceLogging(logging bool) EngineOption {
-	return func(e *Engine) {
-		e.FileStore.enableTraceLogging(logging)
-	}
-}
-
 // WithCompactionPlanner sets the compaction planner for the engine.
 func WithCompactionPlanner(planner CompactionPlanner) EngineOption {
 	return func(e *Engine) {
@@ -90,14 +84,14 @@ func WithCompactionPlanner(planner CompactionPlanner) EngineOption {
 // it can be removed one day. The weird interface is due to the weird inversion of locking
 // that has to happen.
 type Snapshotter interface {
-	AcquireSegments(func(segments []string) error) error
-	CommitSegments(segments []string, fn func() error) error
+	AcquireSegments(context.Context, func(segments []string) error) error
+	CommitSegments(ctx context.Context, segments []string, fn func() error) error
 }
 
 type noSnapshotter struct{}
 
-func (noSnapshotter) AcquireSegments(fn func([]string) error) error    { return fn(nil) }
-func (noSnapshotter) CommitSegments(_ []string, fn func() error) error { return fn() }
+func (noSnapshotter) AcquireSegments(_ context.Context, fn func([]string) error) error    { return fn(nil) }
+func (noSnapshotter) CommitSegments(_ context.Context, _ []string, fn func() error) error { return fn() }
 
 // WithSnapshotter sets the callbacks for the engine to use when creating snapshots.
 func WithSnapshotter(snapshotter Snapshotter) EngineOption {
@@ -132,8 +126,6 @@ type Engine struct {
 	sfile        *tsdb.SeriesFile
 	sfileref     *lifecycle.Reference
 	logger       *zap.Logger // Logger to be used for important messages
-	traceLogger  *zap.Logger // Logger to be used when trace-logging is on.
-	traceLogging bool
 
 	Cache          *Cache
 	Compactor      *Compactor
@@ -204,11 +196,10 @@ func NewEngine(path string, idx *tsi1.Index, config Config, options ...EngineOpt
 
 	logger := zap.NewNop()
 	e := &Engine{
-		path:        path,
-		index:       idx,
-		sfile:       idx.SeriesFile(),
-		logger:      logger,
-		traceLogger: logger,
+		path:   path,
+		index:  idx,
+		sfile:  idx.SeriesFile(),
+		logger: logger,
 
 		Cache: cache,
 
@@ -431,9 +422,9 @@ func (e *Engine) disableSnapshotCompactions() {
 // ScheduleFullCompaction will force the engine to fully compact all data stored.
 // This will cancel and running compactions and snapshot any data in the cache to
 // TSM files.  This is an expensive operation.
-func (e *Engine) ScheduleFullCompaction() error {
+func (e *Engine) ScheduleFullCompaction(ctx context.Context) error {
 	// Snapshot any data in the cache
-	if err := e.WriteSnapshot(); err != nil {
+	if err := e.WriteSnapshot(ctx); err != nil {
 		return err
 	}
 
@@ -503,7 +494,10 @@ func (e *Engine) initTrackers() {
 }
 
 // Open opens and initializes the engine.
-func (e *Engine) Open() (err error) {
+func (e *Engine) Open(ctx context.Context) (err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Engine.Open")
+	defer span.Finish()
+
 	defer func() {
 		if err != nil {
 			e.Close()
@@ -530,7 +524,7 @@ func (e *Engine) Open() (err error) {
 		return err
 	}
 
-	if err := e.FileStore.Open(); err != nil {
+	if err := e.FileStore.Open(ctx); err != nil {
 		return err
 	}
 
@@ -575,10 +569,6 @@ func (e *Engine) Close() error {
 // WithLogger sets the logger for the engine.
 func (e *Engine) WithLogger(log *zap.Logger) {
 	e.logger = log.With(zap.String("engine", "tsm1"))
-
-	if e.traceLogging {
-		e.traceLogger = e.logger
-	}
 
 	e.FileStore.WithLogger(e.logger)
 }
@@ -778,7 +768,10 @@ func (t *compactionTracker) SetOptimiseQueue(length uint64) { t.SetQueue(4, leng
 func (t *compactionTracker) SetFullQueue(length uint64) { t.SetQueue(5, length) }
 
 // WriteSnapshot will snapshot the cache and write a new TSM file with its contents, releasing the snapshot when done.
-func (e *Engine) WriteSnapshot() error {
+func (e *Engine) WriteSnapshot(ctx context.Context) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Engine.WriteSnapshot")
+	defer span.Finish()
+
 	// Lock and grab the cache snapshot along with all the closed WAL
 	// filenames associated with the snapshot
 
@@ -797,7 +790,7 @@ func (e *Engine) WriteSnapshot() error {
 		snapshot *Cache
 		segments []string
 	)
-	if err := e.snapshotter.AcquireSegments(func(segs []string) (err error) {
+	if err := e.snapshotter.AcquireSegments(ctx, func(segs []string) (err error) {
 		segments = segs
 
 		e.mu.Lock()
@@ -816,17 +809,13 @@ func (e *Engine) WriteSnapshot() error {
 	// The snapshotted cache may have duplicate points and unsorted data.  We need to deduplicate
 	// it before writing the snapshot.  This can be very expensive so it's done while we are not
 	// holding the engine write lock.
-	dedup := time.Now()
 	snapshot.Deduplicate()
-	e.traceLogger.Info("Snapshot for path deduplicated",
-		zap.String("path", e.path),
-		zap.Duration("duration", time.Since(dedup)))
 
-	return e.writeSnapshotAndCommit(log, snapshot, segments)
+	return e.writeSnapshotAndCommit(ctx, log, snapshot, segments)
 }
 
 // writeSnapshotAndCommit will write the passed cache to a new TSM file and remove the closed WAL segments.
-func (e *Engine) writeSnapshotAndCommit(log *zap.Logger, snapshot *Cache, segments []string) (err error) {
+func (e *Engine) writeSnapshotAndCommit(ctx context.Context, log *zap.Logger, snapshot *Cache, segments []string) (err error) {
 	defer func() {
 		if err != nil {
 			e.Cache.ClearSnapshot(false)
@@ -834,13 +823,13 @@ func (e *Engine) writeSnapshotAndCommit(log *zap.Logger, snapshot *Cache, segmen
 	}()
 
 	// write the new snapshot files
-	newFiles, err := e.Compactor.WriteSnapshot(snapshot)
+	newFiles, err := e.Compactor.WriteSnapshot(ctx, snapshot)
 	if err != nil {
 		log.Info("Error writing snapshot from compactor", zap.Error(err))
 		return err
 	}
 
-	return e.snapshotter.CommitSegments(segments, func() error {
+	return e.snapshotter.CommitSegments(ctx, segments, func() error {
 		e.mu.RLock()
 		defer e.mu.RUnlock()
 
@@ -870,15 +859,20 @@ func (e *Engine) compactCache() {
 			return
 
 		case <-t.C:
+
 			e.Cache.UpdateAge()
 			if e.ShouldCompactCache(time.Now()) {
+				span, ctx := opentracing.StartSpanFromContext(context.Background(), "Engine.compactCache <-t.C")
+				span.LogKV("path", e.path)
+
 				start := time.Now()
-				e.traceLogger.Info("Compacting cache", zap.String("path", e.path))
-				err := e.WriteSnapshot()
+				err := e.WriteSnapshot(ctx)
 				if err != nil && err != errCompactionsDisabled {
 					e.logger.Info("Error writing snapshot", zap.Error(err))
 				}
 				e.compactionTracker.SnapshotAttempted(err == nil || err == errCompactionsDisabled, time.Since(start))
+
+				span.Finish()
 			}
 		}
 	}

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -122,10 +122,10 @@ type Engine struct {
 	snapDone chan struct{}   // channel to signal snapshot compactions to stop
 	snapWG   *sync.WaitGroup // waitgroup for running snapshot compactions
 
-	path         string
-	sfile        *tsdb.SeriesFile
-	sfileref     *lifecycle.Reference
-	logger       *zap.Logger // Logger to be used for important messages
+	path     string
+	sfile    *tsdb.SeriesFile
+	sfileref *lifecycle.Reference
+	logger   *zap.Logger // Logger to be used for important messages
 
 	Cache          *Cache
 	Compactor      *Compactor

--- a/tsdb/tsm1/engine_delete_bucket_test.go
+++ b/tsdb/tsm1/engine_delete_bucket_test.go
@@ -2,6 +2,7 @@ package tsm1_test
 
 import (
 	"bytes"
+	"context"
 	"reflect"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := e.Open(); err != nil {
+	if err := e.Open(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	defer e.Close()
@@ -32,7 +33,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 		t.Fatalf("failed to write points: %s", err.Error())
 	}
 
-	if err := e.WriteSnapshot(); err != nil {
+	if err := e.WriteSnapshot(context.Background()); err != nil {
 		t.Fatalf("failed to snapshot: %s", err.Error())
 	}
 

--- a/tsdb/tsm1/engine_test.go
+++ b/tsdb/tsm1/engine_test.go
@@ -1,6 +1,7 @@
 package tsm1_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -112,7 +113,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 		tsm1.WithCompactionPlanner(newMockPlanner()))
 
 	e.SetEnabled(false)
-	if err := e.Open(); err != nil {
+	if err := e.Open(context.Background()); err != nil {
 		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
 	}
 	defer e.Close()
@@ -123,7 +124,7 @@ func TestEngine_SnapshotsDisabled(t *testing.T) {
 
 	// Writing a snapshot should not fail when the snapshot is empty
 	// even if snapshots are disabled.
-	if err := e.WriteSnapshot(); err != nil {
+	if err := e.WriteSnapshot(context.Background()); err != nil {
 		t.Fatalf("failed to snapshot: %s", err.Error())
 	}
 }
@@ -139,7 +140,7 @@ func TestEngine_ShouldCompactCache(t *testing.T) {
 	// mock the planner so compactions don't run during the test
 	e.CompactionPlan = &mockPlanner{}
 	e.SetEnabled(false)
-	if err := e.Open(); err != nil {
+	if err := e.Open(context.Background()); err != nil {
 		t.Fatalf("failed to open tsm1 engine: %s", err.Error())
 	}
 	defer e.Close()
@@ -317,7 +318,7 @@ func NewEngine() (*Engine, error) {
 	// Setup series file.
 	sfile := tsdb.NewSeriesFile(filepath.Join(root, "_series"))
 	sfile.Logger = logger.New(os.Stdout)
-	if err = sfile.Open(); err != nil {
+	if err = sfile.Open(context.Background()); err != nil {
 		return nil, err
 	}
 
@@ -344,7 +345,7 @@ func MustOpenEngine() *Engine {
 		panic(err)
 	}
 
-	if err := e.Open(); err != nil {
+	if err := e.Open(context.Background()); err != nil {
 		panic(err)
 	}
 	return e
@@ -385,7 +386,7 @@ func (e *Engine) Reopen() error {
 
 	// Re-open series file. Must create a new series file using the same data.
 	e.sfile = tsdb.NewSeriesFile(e.sfile.Path())
-	if err := e.sfile.Open(); err != nil {
+	if err := e.sfile.Open(context.Background()); err != nil {
 		return err
 	}
 
@@ -398,7 +399,7 @@ func (e *Engine) Reopen() error {
 		tsm1.WithCompactionPlanner(newMockPlanner()))
 
 	// Reopen engine
-	if err := e.Engine.Open(); err != nil {
+	if err := e.Engine.Open(context.Background()); err != nil {
 		return err
 	}
 
@@ -454,14 +455,14 @@ func (e *Engine) MustAddSeries(name string, tags map[string]string) {
 
 // MustWriteSnapshot forces a snapshot of the engine. Panic on error.
 func (e *Engine) MustWriteSnapshot() {
-	if err := e.WriteSnapshot(); err != nil {
+	if err := e.WriteSnapshot(context.Background()); err != nil {
 		panic(err)
 	}
 }
 
 func MustOpenIndex(path string, seriesIDSet *tsdb.SeriesIDSet, sfile *tsdb.SeriesFile) *tsi1.Index {
 	idx := tsi1.NewIndex(sfile, tsi1.NewConfig(), tsi1.WithPath(path))
-	if err := idx.Open(); err != nil {
+	if err := idx.Open(context.Background()); err != nil {
 		panic(err)
 	}
 	return idx
@@ -484,7 +485,7 @@ func NewSeriesFile() *SeriesFile {
 // MustOpenSeriesFile returns a new, open instance of SeriesFile. Panic on error.
 func MustOpenSeriesFile() *SeriesFile {
 	f := NewSeriesFile()
-	if err := f.Open(); err != nil {
+	if err := f.Open(context.Background()); err != nil {
 		panic(err)
 	}
 	return f

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"math"
 	"os"
@@ -194,9 +195,7 @@ type FileStore struct {
 	tsmMMAPWillNeed bool          // If true then the kernel will be advised MMAP_WILLNEED for TSM files.
 	openLimiter     limiter.Fixed // limit the number of concurrent opening TSM files.
 
-	logger       *zap.Logger // Logger to be used for important messages
-	traceLogger  *zap.Logger // Logger to be used when trace-logging is on.
-	traceLogging bool
+	logger *zap.Logger // Logger to be used for important messages
 
 	tracker *fileTracker
 	purger  *purger
@@ -240,7 +239,6 @@ func NewFileStore(dir string) *FileStore {
 		dir:          dir,
 		lastModified: time.Time{},
 		logger:       logger,
-		traceLogger:  logger,
 		openLimiter:  limiter.NewFixed(runtime.GOMAXPROCS(0)),
 		purger: &purger{
 			files:  map[string]TSMFile{},
@@ -270,22 +268,10 @@ func (f *FileStore) ParseFileName(path string) (int, int, error) {
 	return f.parseFileName(path)
 }
 
-// enableTraceLogging must be called before the FileStore is opened.
-func (f *FileStore) enableTraceLogging(enabled bool) {
-	f.traceLogging = enabled
-	if enabled {
-		f.traceLogger = f.logger
-	}
-}
-
 // WithLogger sets the logger on the file store.
 func (f *FileStore) WithLogger(log *zap.Logger) {
 	f.logger = log.With(zap.String("service", "filestore"))
 	f.purger.logger = f.logger
-
-	if f.traceLogging {
-		f.traceLogger = f.logger
-	}
 }
 
 // FileStoreStatistics keeps statistics about the file store.
@@ -518,7 +504,7 @@ func (f *FileStore) DeleteRange(keys [][]byte, min, max int64) error {
 }
 
 // Open loads all the TSM files in the configured directory.
-func (f *FileStore) Open() error {
+func (f *FileStore) Open(ctx context.Context) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -530,6 +516,9 @@ func (f *FileStore) Open() error {
 	if f.openLimiter == nil {
 		return errors.New("cannot open FileStore without an OpenLimiter (is EngineOptions.OpenLimiter set?)")
 	}
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "FileStore.Open")
+	defer span.Finish()
 
 	// find the current max ID for temp directories
 	tmpfiles, err := ioutil.ReadDir(f.dir)
@@ -1114,8 +1103,11 @@ func (f *FileStore) locations(key []byte, t int64, ascending bool) []*location {
 
 // CreateSnapshot creates hardlinks for all tsm and tombstone files
 // in the path provided.
-func (f *FileStore) CreateSnapshot() (string, error) {
-	f.traceLogger.Info("Creating snapshot", zap.String("dir", f.dir))
+func (f *FileStore) CreateSnapshot(ctx context.Context) (string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "FileStore.CreateSnapshot")
+	defer span.Finish()
+
+	span.LogKV("dir", f.dir)
 
 	f.mu.Lock()
 	// create a copy of the files slice and ensure they aren't closed out from

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -517,7 +517,7 @@ func (f *FileStore) Open(ctx context.Context) error {
 		return errors.New("cannot open FileStore without an OpenLimiter (is EngineOptions.OpenLimiter set?)")
 	}
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FileStore.Open")
+	span, _ := opentracing.StartSpanFromContext(ctx, "FileStore.Open")
 	defer span.Finish()
 
 	// find the current max ID for temp directories
@@ -1104,7 +1104,7 @@ func (f *FileStore) locations(key []byte, t int64, ascending bool) []*location {
 // CreateSnapshot creates hardlinks for all tsm and tombstone files
 // in the path provided.
 func (f *FileStore) CreateSnapshot(ctx context.Context) (string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FileStore.CreateSnapshot")
+	span, _ := opentracing.StartSpanFromContext(ctx, "FileStore.CreateSnapshot")
 	defer span.Finish()
 
 	span.LogKV("dir", f.dir)

--- a/tsdb/tsm1/file_store_test.go
+++ b/tsdb/tsm1/file_store_test.go
@@ -3034,8 +3034,8 @@ func TestDefaultParseFileName(t *testing.T) {
 		expectedSequence:   0,
 		expectError:        true,
 	}, {
-		filename:           "00000000000000a-00000000a.tsm",
-		expectError:        true,
+		filename:    "00000000000000a-00000000a.tsm",
+		expectError: true,
 	}, {
 		filename:           "000000000000000-000000000.tsm",
 		expectedGeneration: 0,

--- a/tsdb/tsm1/file_store_test.go
+++ b/tsdb/tsm1/file_store_test.go
@@ -2363,7 +2363,7 @@ func TestFileStore_Open(t *testing.T) {
 	}
 
 	fs := tsm1.NewFileStore(dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 	defer fs.Close()
@@ -2394,7 +2394,7 @@ func TestFileStore_Remove(t *testing.T) {
 	}
 
 	fs := tsm1.NewFileStore(dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 	defer fs.Close()
@@ -2443,7 +2443,7 @@ func TestFileStore_Replace(t *testing.T) {
 	os.Rename(files[2], replacement)
 
 	fs := tsm1.NewFileStore(dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 	defer fs.Close()
@@ -2529,7 +2529,7 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 	}
 
 	fs := tsm1.NewFileStore(dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 	defer fs.Close()
@@ -2543,7 +2543,7 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 	}
 
 	fs2 := tsm1.NewFileStore(dir)
-	if err := fs2.Open(); err != nil {
+	if err := fs2.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 	defer fs2.Close()
@@ -2641,7 +2641,7 @@ func TestFileStore_Stats(t *testing.T) {
 	}
 
 	fs := tsm1.NewFileStore(dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(context.Background()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 	defer fs.Close()
@@ -2723,7 +2723,7 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
-	s, e := fs.CreateSnapshot()
+	s, e := fs.CreateSnapshot(context.Background())
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -2972,7 +2972,7 @@ func BenchmarkFileStore_Stats(b *testing.B) {
 		fs.WithLogger(logger.New(os.Stderr))
 	}
 
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(context.Background()); err != nil {
 		b.Fatalf("opening file store %v", err)
 	}
 	defer fs.Close()


### PR DESCRIPTION
`influxd` generates a lot of logs, many of which are tracing spans. Changes makes the feature configurable, and changes the default behavior to not log traces.

This change also adds Jaeger tracing.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
