### PR TITLE
use os.UserHomeDir for InfluxDir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           path: ~/project
   e2e:
     docker:
-      - image: circleci/golang:1.11-node-browsers
+      - image: circleci/golang:1.12-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: '-mod=readonly -p=4' # Go on Circle thinks 32 CPUs are available, but there aren't.
@@ -79,7 +79,7 @@ jobs:
           destination: screenshots
   jstest:
     docker:
-      - image: circleci/golang:1.11-node-browsers
+      - image: circleci/golang:1.12-node-browsers
     working_directory: /go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -102,7 +102,7 @@ jobs:
 
   gotest:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.12
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: '-mod=readonly -p=2' # Go on Circle thinks 32 CPUs are available, but there aren't.
@@ -154,7 +154,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/golang:1.11-node-browsers
+      - image: circleci/golang:1.12-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: '-mod=readonly -p=4' # Go on Circle thinks 32 CPUs are available, but there aren't.
@@ -188,7 +188,7 @@ jobs:
 
   deploy-nightly:
     docker:
-      - image: circleci/golang:1.11-node-browsers
+      - image: circleci/golang:1.12-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: '-mod=readonly -p=4' # Go on Circle thinks 32 CPUs are available, but there aren't.
@@ -224,7 +224,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.11-node-browsers
+      - image: circleci/golang:1.12-node-browsers
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: '-mod=readonly -p=4' # Go on Circle thinks 32 CPUs are available, but there aren't.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We have nightly and weekly versioned Docker images, Debian packages, RPM package
 
 ## Building From Source
 
-This project requires Go 1.11 and Go module support.
+This project requires Go 1.12 and Go module support.
 
 Set `GO111MODULE=on` or build the project outside of your `GOPATH` for it to succeed.
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/influxdata/influxdb
 
+go 1.12
+
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Jeffail/gabs v1.1.1 // indirect

--- a/internal/fs/influx_dir.go
+++ b/internal/fs/influx_dir.go
@@ -3,7 +3,6 @@ package fs
 import (
 	"fmt"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 )
@@ -12,10 +11,7 @@ import (
 func InfluxDir() (string, error) {
 	var dir string
 	// By default, store meta and data files in current users home directory
-	u, err := user.Current()
-	if err == nil {
-		dir = u.HomeDir
-	} else if home := os.Getenv("HOME"); home != "" {
+	if home, err := os.UserHomeDir(); err == nil {
 		dir = home
 	} else {
 		wd, err := os.Getwd()


### PR DESCRIPTION
The os.UserHomeDir() API introduced in Go1.12.

It's maybe a breakage for influxDB, but we now in alpha stage. 
We need to support these platforms at the start.

```
On Unix, including macOS, it returns the $HOME environment variable.
On Windows, it returns %USERPROFILE%.
On Plan 9, it returns the $home environment variable.
...
```

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
