### PR TITLE
#12322: Use the new script value to update flux

### DIFF
--- a/task/backend/bolt/bolt.go
+++ b/task/backend/bolt/bolt.go
@@ -197,7 +197,7 @@ func (s *Store) UpdateTask(ctx context.Context, req backend.UpdateTaskRequest) (
 		}
 		var newScript string
 		if !req.Options.IsZero() || req.Script != "" {
-			if err = req.UpdateFlux(req.Script); err != nil {
+			if err = req.UpdateFlux(res.OldScript); err != nil {
 				return err
 			}
 			newScript = req.Script

--- a/task/backend/bolt/bolt.go
+++ b/task/backend/bolt/bolt.go
@@ -197,7 +197,7 @@ func (s *Store) UpdateTask(ctx context.Context, req backend.UpdateTaskRequest) (
 		}
 		var newScript string
 		if !req.Options.IsZero() || req.Script != "" {
-			if err = req.UpdateFlux(res.OldScript); err != nil {
+			if err = req.UpdateFlux(req.Script); err != nil {
 				return err
 			}
 			newScript = req.Script

--- a/task/backend/store.go
+++ b/task/backend/store.go
@@ -194,6 +194,7 @@ func (t *UpdateTaskRequest) UpdateFlux(oldFlux string) error {
 	}
 	tu := platform.TaskUpdate{
 		Options: t.Options,
+		Flux:    &t.Script,
 	}
 	if err := tu.UpdateFlux(oldFlux); err != nil {
 		return err


### PR DESCRIPTION
Closes #12322

_InfluxDB 2.0: Task API - The task update doesn't work_:

The old one script is used even if I successfully update the Task script.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)