### PR TITLE
fix(ui/editablename): add spinner to  pending name edits

### DIFF
--- a/ui/src/clockface/components/resource_list/ResourceName.tsx
+++ b/ui/src/clockface/components/resource_list/ResourceName.tsx
@@ -1,10 +1,14 @@
 // Libraries
 import React, {Component, KeyboardEvent, ChangeEvent, MouseEvent} from 'react'
 import classnames from 'classnames'
+import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 
 // Components
 import {Input, ComponentSize} from 'src/clockface'
 import {ClickOutside} from 'src/shared/components/ClickOutside'
+
+// Types
+import {RemoteDataState} from 'src/types'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -33,6 +37,7 @@ type Props = PassedProps & DefaultProps
 interface State {
   isEditing: boolean
   workingName: string
+  loading: RemoteDataState
 }
 
 @ErrorHandling
@@ -50,6 +55,7 @@ class ResourceName extends Component<Props, State> {
     this.state = {
       isEditing: false,
       workingName: props.name,
+      loading: RemoteDataState.Done,
     }
   }
 
@@ -65,9 +71,14 @@ class ResourceName extends Component<Props, State> {
 
     return (
       <div className={this.className} data-testid={parentTestID}>
-        <a href={hrefValue} onClick={onEditName}>
-          <span>{name || noNameString}</span>
-        </a>
+        <SpinnerContainer
+          loading={this.state.loading}
+          spinnerComponent={<TechnoSpinner diameterPixels={20} />}
+        >
+          <a href={hrefValue} onClick={onEditName}>
+            <span>{name || noNameString}</span>
+          </a>
+        </SpinnerContainer>
         <div
           className="resource-name--toggle"
           onClick={this.handleStartEditing}
@@ -82,9 +93,9 @@ class ResourceName extends Component<Props, State> {
 
   private get input(): JSX.Element {
     const {placeholder, inputTestID} = this.props
-    const {workingName, isEditing} = this.state
+    const {workingName, isEditing, loading} = this.state
 
-    if (isEditing) {
+    if (isEditing && loading !== RemoteDataState.Loading) {
       return (
         <ClickOutside onClickOutside={this.handleStopEditing}>
           <Input
@@ -113,9 +124,9 @@ class ResourceName extends Component<Props, State> {
     const {workingName} = this.state
     const {onUpdate} = this.props
 
+    this.setState({loading: RemoteDataState.Loading})
     await onUpdate(workingName)
-
-    this.setState({isEditing: false})
+    this.setState({loading: RemoteDataState.Done, isEditing: false})
   }
 
   private handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
@@ -130,12 +141,15 @@ class ResourceName extends Component<Props, State> {
 
     if (e.key === 'Enter') {
       e.persist()
+
       if (!workingName) {
         this.setState({isEditing: false, workingName: name})
+
         return
       }
+      this.setState({loading: RemoteDataState.Loading})
       await onUpdate(workingName)
-      this.setState({isEditing: false})
+      this.setState({isEditing: false, loading: RemoteDataState.Done})
     }
 
     if (e.key === 'Escape') {

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -59,8 +59,8 @@ export default class DashboardCard extends PureComponent<Props> {
     )
   }
 
-  private handleUpdateDashboard = (name: string) => {
-    this.props.onUpdateDashboard({...this.props.dashboard, name})
+  private handleUpdateDashboard = async (name: string) => {
+    await this.props.onUpdateDashboard({...this.props.dashboard, name})
   }
 
   private get contextMenu(): JSX.Element {

--- a/ui/src/dashboards/components/dashboard_index/TableRow.tsx
+++ b/ui/src/dashboards/components/dashboard_index/TableRow.tsx
@@ -128,8 +128,8 @@ export default class DashboardsIndexTableRow extends PureComponent<Props> {
     )
   }
 
-  private handleUpdateDashboard = (name: string) => {
-    this.props.onUpdateDashboard({...this.props.dashboard, name})
+  private handleUpdateDashboard = async (name: string) => {
+    await this.props.onUpdateDashboard({...this.props.dashboard, name})
   }
 
   private get labels(): JSX.Element {

--- a/ui/src/organizations/components/BucketRow.tsx
+++ b/ui/src/organizations/components/BucketRow.tsx
@@ -87,8 +87,8 @@ export default class BucketRow extends PureComponent<Props> {
     )
   }
 
-  private handleUpdateBucketName = (value: string) => {
-    this.props.onUpdateBucket({...this.props.bucket, name: value})
+  private handleUpdateBucketName = async (value: string) => {
+    await this.props.onUpdateBucket({...this.props.bucket, name: value})
   }
 
   private handleEditBucket = (): void => {

--- a/ui/src/organizations/components/CollectorRow.tsx
+++ b/ui/src/organizations/components/CollectorRow.tsx
@@ -79,10 +79,10 @@ export default class CollectorRow extends PureComponent<Props> {
     )
   }
 
-  private handleUpdateName = (name: string) => {
+  private handleUpdateName = async (name: string) => {
     const {onUpdate, collector} = this.props
 
-    onUpdate({...collector, name})
+    await onUpdate({...collector, name})
   }
 
   private handleUpdateDescription = (description: string) => {

--- a/ui/src/organizations/components/ScraperRow.tsx
+++ b/ui/src/organizations/components/ScraperRow.tsx
@@ -49,8 +49,8 @@ export default class ScraperRow extends PureComponent<Props> {
     )
   }
 
-  private handleUpdateScraperName = (name: string) => {
+  private handleUpdateScraperName = async (name: string) => {
     const {onUpdateScraper, scraper} = this.props
-    onUpdateScraper({...scraper, name})
+    await onUpdateScraper({...scraper, name})
   }
 }

--- a/ui/src/organizations/components/VariableRow.tsx
+++ b/ui/src/organizations/components/VariableRow.tsx
@@ -50,10 +50,10 @@ export default class VariableRow extends PureComponent<Props> {
     )
   }
 
-  private handleUpdateVariableName = (name: string) => {
+  private handleUpdateVariableName = async (name: string) => {
     const {onUpdateVariableName, variable} = this.props
 
-    onUpdateVariableName({id: variable.id, name})
+    await onUpdateVariableName({id: variable.id, name})
   }
 
   private handleEditVariable = (): void => {

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -111,9 +111,9 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
     router.push(`tasks/${task.id}/runs`)
   }
 
-  private handleRenameTask = (name: string) => {
+  private handleRenameTask = async (name: string) => {
     const {onUpdate, task} = this.props
-    onUpdate({...task, name})
+    await onUpdate({...task, name})
   }
 
   private handleExport = () => {


### PR DESCRIPTION
Closes #12059

_Briefly describe your proposed changes:_
Adds a spinner to pending updates to resource list names

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

![kapture 2019-03-04 at 11 53 55](https://user-images.githubusercontent.com/4994741/53753517-75d25c80-3e7f-11e9-80e8-01d1927838b6.gif)
