### PR TITLE
Fix invalid query submission on Data Explorer load

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -100,9 +100,7 @@ describe('DataExplorer', () => {
         cy.getByTestID('time-machine-submit-button').click()
       })
 
-      cy.getByTestID('empty-graph-message').within(() => {
-        cy.contains('No Results').should('exist')
-      })
+      cy.getByTestID('empty-graph--no-results').should('exist')
     })
   })
 
@@ -125,6 +123,10 @@ describe('DataExplorer', () => {
 
   describe('visualizations', () => {
     describe('empty states', () => {
+      it('shows a message if no queries have been created', () => {
+        cy.getByTestID('empty-graph--no-queries').should('exist')
+      })
+
       it('shows an error if a query is syntactically invalid', () => {
         cy.getByTestID('switch-to-script-editor').click()
 
@@ -133,9 +135,7 @@ describe('DataExplorer', () => {
           cy.getByTestID('time-machine-submit-button').click()
         })
 
-        cy.getByTestID('empty-graph-message').within(() => {
-          cy.contains('Error').should('exist')
-        })
+        cy.getByTestID('empty-graph--error').should('exist')
       })
     })
   })

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11010,7 +11010,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },

--- a/ui/src/shared/components/EmptyGraphMessage.tsx
+++ b/ui/src/shared/components/EmptyGraphMessage.tsx
@@ -2,11 +2,12 @@ import React, {SFC} from 'react'
 
 interface Props {
   message: string
+  testID?: string
 }
 
-const EmptyGraphMessage: SFC<Props> = ({message}) => {
+const EmptyGraphMessage: SFC<Props> = ({message, testID}) => {
   return (
-    <div className="cell--view-empty" data-testid="empty-graph-message">
+    <div className="cell--view-empty" data-testid={testID}>
       <h4>{message}</h4>
     </div>
   )

--- a/ui/src/shared/components/EmptyQueryView.tsx
+++ b/ui/src/shared/components/EmptyQueryView.tsx
@@ -32,16 +32,22 @@ export default class EmptyQueryView extends PureComponent<Props> {
       fallbackNote,
     } = this.props
 
-    if (loading === RemoteDataState.NotStarted) {
-      return <EmptyGraphMessage message={emptyGraphCopy} />
-    }
-
-    if (!queries.length) {
-      return <EmptyGraphMessage message={emptyGraphCopy} />
+    if (loading === RemoteDataState.NotStarted || !queries.length) {
+      return (
+        <EmptyGraphMessage
+          message={emptyGraphCopy}
+          testID="empty-graph--no-queries"
+        />
+      )
     }
 
     if (error) {
-      return <EmptyGraphMessage message={`Error: ${error.message}`} />
+      return (
+        <EmptyGraphMessage
+          message={`Error: ${error.message}`}
+          testID="empty-graph--error"
+        />
+      )
     }
 
     const hasNoResults = tables.every(d => !d.data.length)
@@ -58,7 +64,12 @@ export default class EmptyQueryView extends PureComponent<Props> {
     }
 
     if (hasNoResults) {
-      return <EmptyGraphMessage message="No Results" />
+      return (
+        <EmptyGraphMessage
+          message="No Results"
+          testID="empty-graph--no-results"
+        />
+      )
     }
 
     return this.props.children

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -99,7 +99,8 @@ class TimeSeries extends Component<Props, State> {
   }
 
   private reload = async () => {
-    const {inView, queries, queryLink, variables} = this.props
+    const {inView, queryLink, variables} = this.props
+    const queries = this.props.queries.filter(({text}) => !!text.trim())
     const orgID = this.props.activeOrg.id
 
     if (!inView) {


### PR DESCRIPTION
Fixes an issue where the Data Explorer would issue an empty (invalid)
query upon first load.

Adds a test to catch similar regressions in the future, and refactors
e2e tests to use a `testID` for asserting that empty graph messages
exist.

Closes #12326