### PR TITLE
fix(variables): close create overlay when new variable created

### DIFF
--- a/ui/src/organizations/components/CreateVariableOverlay.tsx
+++ b/ui/src/organizations/components/CreateVariableOverlay.tsx
@@ -104,7 +104,7 @@ export default class CreateOrgOverlay extends PureComponent<Props, State> {
   }
 
   private handleSubmit = (): void => {
-    const {onCreateVariable, orgID} = this.props
+    const {onCreateVariable, orgID, onCloseModal} = this.props
 
     onCreateVariable({
       name: this.state.name,
@@ -114,6 +114,8 @@ export default class CreateOrgOverlay extends PureComponent<Props, State> {
         values: {query: this.state.script, language: 'flux'},
       },
     })
+
+    onCloseModal()
   }
 
   private handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {

--- a/ui/src/organizations/components/Variables.tsx
+++ b/ui/src/organizations/components/Variables.tsx
@@ -95,6 +95,7 @@ class Variables extends PureComponent<Props, State> {
           searchTerm={searchTerm}
           searchKeys={['name']}
           list={variables}
+          sortByKey="name"
         >
           {variables => (
             <VariableList

--- a/ui/src/variables/actions/index.ts
+++ b/ui/src/variables/actions/index.ts
@@ -9,6 +9,7 @@ import {
   createVariableFailed,
   updateVariableFailed,
   deleteVariableFailed,
+  createVariableSuccess,
 } from 'src/shared/copy/notifications'
 
 // Types
@@ -101,6 +102,7 @@ export const createVariable = (variable: Variable) => async (
     dispatch(
       setVariable(createdVariable.id, RemoteDataState.Done, createdVariable)
     )
+    dispatch(notify(createVariableSuccess(variable.name)))
   } catch (e) {
     console.log(e)
     dispatch(notify(createVariableFailed()))


### PR DESCRIPTION
Closes #12332
Closes #12335

This PR fixes a couple issues with the manage variables page: the create overlay now closes when the submit button is pressed, and the variables in the index are now sorted by name. Also, a notification is displayed to the user when a variable is successfully created.

  - [x] Rebased/mergeable
  - [x] Tests pass