### PR TITLE
chore(ui/client): update ui client to 0.2.21

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -985,9 +985,9 @@
       }
     },
     "@influxdata/influx": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.19.tgz",
-      "integrity": "sha512-0xOkdOE8q9JJZlEgqMgSpaaVYScP+NAqN136gt8CQE/ZZrZKXHpGBAVo0Dz1oeIPq7B0l8XtpcRyx/+JrEvW7Q==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.21.tgz",
+      "integrity": "sha512-ckXKekCMHR3OcdPCGc2w1/y+Z4ARPTmcFmdYNZJ6biIBGKNV+mKyVB3ATLyTfpZrjYV6YtQtWSe8PurUzc/5fA==",
       "requires": {
         "axios": "^0.18.0"
       }
@@ -11010,7 +11010,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },

--- a/ui/package.json
+++ b/ui/package.json
@@ -137,7 +137,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "0.0.5",
-    "@influxdata/influx": "0.2.19",
+    "@influxdata/influx": "0.2.21",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",

--- a/ui/src/dashboards/apis/v2/index.ts
+++ b/ui/src/dashboards/apis/v2/index.ts
@@ -6,11 +6,10 @@ import {addLabelDefaults} from 'src/shared/utils/labels'
 import {incrementCloneName} from 'src/utils/naming'
 
 // Types
-
 import {Cell, NewCell, Dashboard, View} from 'src/types/v2'
 import {Label} from 'src/types/v2/labels'
 
-import {Cell as CellAPI} from '@influxdata/influx'
+import {Cell as CellAPI, CreateDashboardRequest} from '@influxdata/influx'
 import {client} from 'src/utils/api'
 
 export const addDashboardIDToCells = (
@@ -44,7 +43,7 @@ export const getDashboard = async (id: string): Promise<Dashboard> => {
 }
 
 export const createDashboard = async (
-  props: Partial<Dashboard>
+  props: CreateDashboardRequest
 ): Promise<Dashboard> => {
   const dashboard = await client.dashboards.create(props)
 
@@ -104,7 +103,7 @@ export const addDashboardLabels = async (
 ): Promise<Label[]> => {
   const addedLabels = await Promise.all(
     labels.map(async label => {
-      return client.dashboards.createLabel(dashboardID, label.id)
+      return client.dashboards.addLabel(dashboardID, label.id)
     })
   )
 
@@ -117,7 +116,7 @@ export const removeDashboardLabels = async (
 ): Promise<void> => {
   await Promise.all(
     labels.map(label => {
-      return client.dashboards.deleteLabel(dashboardID, label.id)
+      return client.dashboards.removeLabel(dashboardID, label.id)
     })
   )
 }

--- a/ui/src/dashboards/constants/index.ts
+++ b/ui/src/dashboards/constants/index.ts
@@ -63,7 +63,7 @@ export type EmptyDefaultDashboard = Pick<
   Dashboard,
   Exclude<
     keyof Dashboard,
-    'templates' | 'links' | 'organization' | 'cells' | 'labels'
+    'templates' | 'links' | 'organization' | 'cells' | 'labels' | 'orgID'
   >
 > & {
   cells: NewDefaultCell[]

--- a/ui/src/dashboards/resources.ts
+++ b/ui/src/dashboards/resources.ts
@@ -22,6 +22,7 @@ import {Color} from 'src/types/colors'
 export const dashboard: Dashboard = {
   id: '1',
   name: 'd1',
+  orgID: '1',
   cells: [
     {
       x: 1,

--- a/ui/src/types/v2/labels.ts
+++ b/ui/src/types/v2/labels.ts
@@ -1,11 +1,5 @@
-import {Label as LabelAPI} from '@influxdata/influx'
+import {ILabel as LabelAPI} from '@influxdata/influx'
 
-/**
- * Required key/value properties for labels
- */
-export interface LabelProperties {
-  color: string // Every label should have a color
-  description?: string
-}
+export type LabelProperties = LabelAPI['properties']
 
-export type Label = LabelAPI & {properties: LabelProperties}
+export type Label = LabelAPI

--- a/ui/src/variables/utils/getWindowVars.ts
+++ b/ui/src/variables/utils/getWindowVars.ts
@@ -60,7 +60,14 @@ export const getWindowVars = async (
 const getAST = async (query: string): Promise<Package> => {
   try {
     const resp = await client.queries.ast(query)
-    return resp
+
+    // TODO: update client Package and remove map
+    return {
+      type: 'Package',
+      path: resp.path,
+      files: resp.files,
+      package: resp._package || '',
+    }
   } catch (e) {
     const message = get(e, 'response.data.error')
 


### PR DESCRIPTION
Closes #12231 

_Briefly describe your proposed changes:_
- Bump version of client to `0.2.21`
- Creates a temporary wrapper for `Package` type incompatability

It would have been nice to have `Dashboard` in `src/types/v2/dashboards` extend the `IDashboard` interface, but it looks like this this creates more conflicts with the `0.2.21` version of the client.  See more on this issue here: https://github.com/influxdata/influxdb2-js/issues/33 `IDashboard` is preferable because it requires `id`, `name`, etc.

The issue of consuming types that require labels can be found here: https://github.com/influxdata/influxdb/issues/12243

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
