### PR TITLE
refactor(explorer): hide variables tab in explorer behind feature flag

### DIFF
--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -27,6 +27,7 @@ import {AppState} from 'src/types/v2'
 
 // Styles
 import 'src/timeMachine/components/TimeMachineFluxEditor.scss'
+import FeatureFlag from 'src/shared/components/FeatureFlag'
 
 interface StateProps {
   activeQueryText: string
@@ -83,11 +84,13 @@ class TimeMachineFluxEditor extends PureComponent<Props, State> {
           return (
             <>
               <div className="toolbar-tab-container">
-                <ToolbarTab
-                  onSetActive={this.hideFluxFunctions}
-                  name="Variables"
-                  active={!this.state.displayFluxFunctions}
-                />
+                <FeatureFlag>
+                  <ToolbarTab
+                    onSetActive={this.hideFluxFunctions}
+                    name="Variables"
+                    active={!this.state.displayFluxFunctions}
+                  />
+                </FeatureFlag>
                 <ToolbarTab
                   onSetActive={this.showFluxFunctions}
                   name="Functions"


### PR DESCRIPTION
Closes #12340

This PR places the variables tab in the explorer sidebar behind a feature flag.

The feature flag will be removed when the user is able to add a variable to the script from the sidebar.

  - [x] Rebased/mergeable
  - [x] Tests pass