### PR TITLE
Fix building queries with derivatives

### DIFF
--- a/ui/src/timeMachine/constants/queryBuilder.ts
+++ b/ui/src/timeMachine/constants/queryBuilder.ts
@@ -1,4 +1,4 @@
-import {WINDOW_PERIOD} from 'src/variables/constants'
+import {WINDOW_PERIOD, OPTION_NAME} from 'src/variables/constants'
 
 export interface QueryFn {
   name: string
@@ -14,7 +14,7 @@ export const FUNCTIONS: QueryFn[] = [
   {name: 'sum', flux: '|> sum()', aggregate: true},
   {
     name: 'derivative',
-    flux: `|> derivative(unit: ${WINDOW_PERIOD}, nonNegative: false)`,
+    flux: `|> derivative(unit: ${OPTION_NAME}.${WINDOW_PERIOD}, nonNegative: false)`,
     aggregate: false,
   },
   {name: 'distinct', flux: '|> distinct()', aggregate: false},


### PR DESCRIPTION
Fixes an issue where you could not build a query with a `derivative` function applied using the builder (regression introduced in #12217).

<img width="1552" alt="screen shot 2019-03-04 at 3 18 59 pm" src="https://user-images.githubusercontent.com/638955/53769487-df0e9b80-3e90-11e9-8ade-e5f790394f96.png">
