### PR TITLE
storage: detect conflicting types in a single batch of points

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -405,7 +405,7 @@ func (e *Engine) WritePoints(ctx context.Context, points []models.Point) error {
 	}
 
 	// Convert the points to values for adding to the WAL/Cache.
-	values, err := tsm1.PointsToValues(collection.Points)
+	values, err := tsm1.CollectionToValues(collection)
 	if err != nil {
 		return err
 	}
@@ -433,7 +433,7 @@ func (e *Engine) writePointsLocked(collection *tsdb.SeriesCollection, values map
 	// more than the points so we need to recreate them.
 	if collection.PartialWriteError() != nil {
 		var err error
-		values, err = tsm1.PointsToValues(collection.Points)
+		values, err = tsm1.CollectionToValues(collection)
 		if err != nil {
 			return err
 		}

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -588,12 +588,18 @@ func (e *Engine) Free() error {
 
 // WritePoints saves the set of points in the engine.
 func (e *Engine) WritePoints(points []models.Point) error {
-	values, err := PointsToValues(points)
+	collection := tsdb.NewSeriesCollection(points)
+
+	values, err := CollectionToValues(collection)
 	if err != nil {
 		return err
 	}
 
-	return e.WriteValues(values)
+	if err := e.WriteValues(values); err != nil {
+		return err
+	}
+
+	return collection.PartialWriteError()
 }
 
 // WriteValues saves the set of values in the engine.


### PR DESCRIPTION
When the WAL was moved up, the validation that happened at the cache was skipped. This moves the field type validation for a batch of points up ahead of the WAL again.

Closes #12117.
