### PR TITLE
feat(http): query client fallback uses context auth

### DIFF
--- a/context/token.go
+++ b/context/token.go
@@ -2,6 +2,7 @@ package context
 
 import (
 	"context"
+	"fmt"
 
 	platform "github.com/influxdata/influxdb"
 )
@@ -28,4 +29,25 @@ func GetAuthorizer(ctx context.Context) (platform.Authorizer, error) {
 	}
 
 	return a, nil
+}
+
+// GetToken retrieves a token from the context; errors if no token.
+func GetToken(ctx context.Context) (string, error) {
+	a, ok := ctx.Value(authorizerCtxKey).(platform.Authorizer)
+	if !ok {
+		return "", &platform.Error{
+			Msg:  "authorizer not found on context",
+			Code: platform.EInternal,
+		}
+	}
+
+	auth, ok := a.(*platform.Authorization)
+	if !ok {
+		return "", &platform.Error{
+			Msg:  fmt.Sprintf("authorizer not an authorization but a %T", a),
+			Code: platform.EInternal,
+		}
+	}
+
+	return auth.Token, nil
 }

--- a/context/token_test.go
+++ b/context/token_test.go
@@ -1,0 +1,24 @@
+package context_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	icontext "github.com/influxdata/influxdb/context"
+)
+
+func TestGetToken(t *testing.T) {
+	ctx := context.Background()
+	ctx = icontext.SetAuthorizer(ctx, &influxdb.Authorization{
+		Token: "howdy",
+	})
+	got, err := icontext.GetToken(ctx)
+	if err != nil {
+		t.Errorf("unexpected error while retrieving token: %v", err)
+	}
+
+	if want := "howdy"; got != want {
+		t.Errorf("GetToken() want %s, got %s", want, got)
+	}
+}


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Tasks instantiates the query service but does not know the token
it will use ahead of time.  This allows the token to be optionally
set on context.




  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
