### PR TITLE
add spans to multiple services

### DIFF
--- a/authorizer/bucket.go
+++ b/authorizer/bucket.go
@@ -3,9 +3,8 @@ package authorizer
 import (
 	"context"
 
-	"github.com/opentracing/opentracing-go"
-
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var _ influxdb.BucketService = (*BucketService)(nil)
@@ -28,7 +27,7 @@ func newBucketPermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Pe
 }
 
 func authorizeReadBucket(ctx context.Context, orgID, id influxdb.ID) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "authorizeReadBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	p, err := newBucketPermission(influxdb.ReadAction, orgID, id)
@@ -58,7 +57,7 @@ func authorizeWriteBucket(ctx context.Context, orgID, id influxdb.ID) error {
 
 // FindBucketByID checks to see if the authorizer on context has read access to the id provided.
 func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucketByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	b, err := s.s.FindBucketByID(ctx, id)
@@ -75,7 +74,7 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*in
 
 // FindBucket retrieves the bucket and checks to see if the authorizer on context has read access to the bucket.
 func (s *BucketService) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	b, err := s.s.FindBucket(ctx, filter)
@@ -92,7 +91,7 @@ func (s *BucketService) FindBucket(ctx context.Context, filter influxdb.BucketFi
 
 // FindBuckets retrieves all buckets that match the provided filter and then filters the list down to only the resources that are authorized.
 func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opt ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBuckets")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// TODO: we'll likely want to push this operation into the database eventually since fetching the whole list of data
@@ -123,7 +122,7 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketF
 
 // CreateBucket checks to see if the authorizer on context has write access to the global buckets resource.
 func (s *BucketService) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.CreateBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.BucketsResourceType, b.OrganizationID)

--- a/authorizer/bucket.go
+++ b/authorizer/bucket.go
@@ -2,6 +2,7 @@ package authorizer
 
 import (
 	"context"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/influxdb"
 )
@@ -26,6 +27,9 @@ func newBucketPermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Pe
 }
 
 func authorizeReadBucket(ctx context.Context, orgID, id influxdb.ID) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "authorizeReadBucket")
+	defer span.Finish()
+
 	p, err := newBucketPermission(influxdb.ReadAction, orgID, id)
 	if err != nil {
 		return err
@@ -53,6 +57,9 @@ func authorizeWriteBucket(ctx context.Context, orgID, id influxdb.ID) error {
 
 // FindBucketByID checks to see if the authorizer on context has read access to the id provided.
 func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucketByID")
+	defer span.Finish()
+
 	b, err := s.s.FindBucketByID(ctx, id)
 	if err != nil {
 		return nil, err
@@ -67,6 +74,9 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*in
 
 // FindBucket retrieves the bucket and checks to see if the authorizer on context has read access to the bucket.
 func (s *BucketService) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucket")
+	defer span.Finish()
+
 	b, err := s.s.FindBucket(ctx, filter)
 	if err != nil {
 		return nil, err
@@ -81,6 +91,9 @@ func (s *BucketService) FindBucket(ctx context.Context, filter influxdb.BucketFi
 
 // FindBuckets retrieves all buckets that match the provided filter and then filters the list down to only the resources that are authorized.
 func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opt ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBuckets")
+	defer span.Finish()
+
 	// TODO: we'll likely want to push this operation into the database eventually since fetching the whole list of data
 	// will likely be expensive.
 	bs, _, err := s.s.FindBuckets(ctx, filter, opt...)
@@ -109,6 +122,9 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketF
 
 // CreateBucket checks to see if the authorizer on context has write access to the global buckets resource.
 func (s *BucketService) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.CreateBucket")
+	defer span.Finish()
+
 	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.BucketsResourceType, b.OrganizationID)
 	if err != nil {
 		return err

--- a/authorizer/bucket.go
+++ b/authorizer/bucket.go
@@ -2,6 +2,7 @@ package authorizer
 
 import (
 	"context"
+
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/influxdb"

--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
+	"github.com/opentracing/opentracing-go"
+
 	platform "github.com/influxdata/influxdb"
 	platformcontext "github.com/influxdata/influxdb/context"
 )

--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"time"
 
-	bolt "github.com/coreos/bbolt"
-	"github.com/opentracing/opentracing-go"
+	"github.com/coreos/bbolt"
 
 	platform "github.com/influxdata/influxdb"
 	platformcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var (
@@ -32,7 +32,7 @@ func (c *Client) initializeBuckets(ctx context.Context, tx *bolt.Tx) error {
 }
 
 func (c *Client) setOrganizationOnBucket(ctx context.Context, tx *bolt.Tx, b *platform.Bucket) *platform.Error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.setOrganizationOnBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	o, err := c.findOrganizationByID(ctx, tx, b.OrganizationID)
@@ -47,7 +47,7 @@ func (c *Client) setOrganizationOnBucket(ctx context.Context, tx *bolt.Tx, b *pl
 
 // FindBucketByID retrieves a bucket by id.
 func (c *Client) FindBucketByID(ctx context.Context, id platform.ID) (*platform.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.FindBucketByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b *platform.Bucket
@@ -72,7 +72,7 @@ func (c *Client) FindBucketByID(ctx context.Context, id platform.ID) (*platform.
 }
 
 func (c *Client) findBucketByID(ctx context.Context, tx *bolt.Tx, id platform.ID) (*platform.Bucket, *platform.Error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.findBucketByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b platform.Bucket
@@ -111,7 +111,7 @@ func (c *Client) findBucketByID(ctx context.Context, tx *bolt.Tx, id platform.ID
 // FindBucketByName returns a bucket by name for a particular organization.
 // TODO: have method for finding bucket using organization name and bucket name.
 func (c *Client) FindBucketByName(ctx context.Context, orgID platform.ID, n string) (*platform.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.FindBucketByName")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b *platform.Bucket
@@ -132,7 +132,7 @@ func (c *Client) FindBucketByName(ctx context.Context, orgID platform.ID, n stri
 }
 
 func (c *Client) findBucketByName(ctx context.Context, tx *bolt.Tx, orgID platform.ID, n string) (*platform.Bucket, *platform.Error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.findBucketByName")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	b := &platform.Bucket{
@@ -168,7 +168,7 @@ func (c *Client) findBucketByName(ctx context.Context, tx *bolt.Tx, orgID platfo
 // Filters using ID, or OrganizationID and bucket Name should be efficient.
 // Other filters will do a linear scan across buckets until it finds a match.
 func (c *Client) FindBucket(ctx context.Context, filter platform.BucketFilter) (*platform.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.FindBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b *platform.Bucket
@@ -257,7 +257,7 @@ func filterBucketsFn(filter platform.BucketFilter) func(b *platform.Bucket) bool
 // Filters using ID, or OrganizationID and bucket Name should be efficient.
 // Other filters will do a linear scan across all buckets searching for a match.
 func (c *Client) FindBuckets(ctx context.Context, filter platform.BucketFilter, opts ...platform.FindOptions) ([]*platform.Bucket, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.FindBuckets")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if filter.ID != nil {
@@ -296,7 +296,7 @@ func (c *Client) FindBuckets(ctx context.Context, filter platform.BucketFilter, 
 }
 
 func (c *Client) findBuckets(ctx context.Context, tx *bolt.Tx, filter platform.BucketFilter, opts ...platform.FindOptions) ([]*platform.Bucket, *platform.Error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.findBuckets")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	bs := []*platform.Bucket{}
@@ -345,7 +345,7 @@ func (c *Client) findBuckets(ctx context.Context, tx *bolt.Tx, filter platform.B
 
 // CreateBucket creates a platform bucket and sets b.ID.
 func (c *Client) CreateBucket(ctx context.Context, b *platform.Bucket) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.CreateBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var err error

--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
@@ -30,6 +31,9 @@ func (c *Client) initializeBuckets(ctx context.Context, tx *bolt.Tx) error {
 }
 
 func (c *Client) setOrganizationOnBucket(ctx context.Context, tx *bolt.Tx, b *platform.Bucket) *platform.Error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.setOrganizationOnBucket")
+	defer span.Finish()
+
 	o, err := c.findOrganizationByID(ctx, tx, b.OrganizationID)
 	if err != nil {
 		return &platform.Error{
@@ -42,6 +46,9 @@ func (c *Client) setOrganizationOnBucket(ctx context.Context, tx *bolt.Tx, b *pl
 
 // FindBucketByID retrieves a bucket by id.
 func (c *Client) FindBucketByID(ctx context.Context, id platform.ID) (*platform.Bucket, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.FindBucketByID")
+	defer span.Finish()
+
 	var b *platform.Bucket
 	var err error
 
@@ -64,6 +71,9 @@ func (c *Client) FindBucketByID(ctx context.Context, id platform.ID) (*platform.
 }
 
 func (c *Client) findBucketByID(ctx context.Context, tx *bolt.Tx, id platform.ID) (*platform.Bucket, *platform.Error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.findBucketByID")
+	defer span.Finish()
+
 	var b platform.Bucket
 
 	encodedID, err := id.Encode()
@@ -100,6 +110,9 @@ func (c *Client) findBucketByID(ctx context.Context, tx *bolt.Tx, id platform.ID
 // FindBucketByName returns a bucket by name for a particular organization.
 // TODO: have method for finding bucket using organization name and bucket name.
 func (c *Client) FindBucketByName(ctx context.Context, orgID platform.ID, n string) (*platform.Bucket, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.FindBucketByName")
+	defer span.Finish()
+
 	var b *platform.Bucket
 	var err error
 
@@ -118,6 +131,9 @@ func (c *Client) FindBucketByName(ctx context.Context, orgID platform.ID, n stri
 }
 
 func (c *Client) findBucketByName(ctx context.Context, tx *bolt.Tx, orgID platform.ID, n string) (*platform.Bucket, *platform.Error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.findBucketByName")
+	defer span.Finish()
+
 	b := &platform.Bucket{
 		OrganizationID: orgID,
 		Name:           n,
@@ -151,6 +167,9 @@ func (c *Client) findBucketByName(ctx context.Context, tx *bolt.Tx, orgID platfo
 // Filters using ID, or OrganizationID and bucket Name should be efficient.
 // Other filters will do a linear scan across buckets until it finds a match.
 func (c *Client) FindBucket(ctx context.Context, filter platform.BucketFilter) (*platform.Bucket, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.FindBucket")
+	defer span.Finish()
+
 	var b *platform.Bucket
 	var err error
 
@@ -237,6 +256,9 @@ func filterBucketsFn(filter platform.BucketFilter) func(b *platform.Bucket) bool
 // Filters using ID, or OrganizationID and bucket Name should be efficient.
 // Other filters will do a linear scan across all buckets searching for a match.
 func (c *Client) FindBuckets(ctx context.Context, filter platform.BucketFilter, opts ...platform.FindOptions) ([]*platform.Bucket, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.FindBuckets")
+	defer span.Finish()
+
 	if filter.ID != nil {
 		b, err := c.FindBucketByID(ctx, *filter.ID)
 		if err != nil {
@@ -273,6 +295,9 @@ func (c *Client) FindBuckets(ctx context.Context, filter platform.BucketFilter, 
 }
 
 func (c *Client) findBuckets(ctx context.Context, tx *bolt.Tx, filter platform.BucketFilter, opts ...platform.FindOptions) ([]*platform.Bucket, *platform.Error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.findBuckets")
+	defer span.Finish()
+
 	bs := []*platform.Bucket{}
 	if filter.Organization != nil {
 		o, err := c.findOrganizationByName(ctx, tx, *filter.Organization)
@@ -319,6 +344,9 @@ func (c *Client) findBuckets(ctx context.Context, tx *bolt.Tx, filter platform.B
 
 // CreateBucket creates a platform bucket and sets b.ID.
 func (c *Client) CreateBucket(ctx context.Context, b *platform.Bucket) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.CreateBucket")
+	defer span.Finish()
+
 	var err error
 	op := getOp(platform.OpCreateBucket)
 	return c.db.Update(func(tx *bolt.Tx) error {

--- a/bolt/keyvalue_log.go
+++ b/bolt/keyvalue_log.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
@@ -112,6 +113,9 @@ func (c *Client) initializeKeyValueLog(ctx context.Context, tx *bolt.Tx) error {
 var errKeyValueLogBoundsNotFound = fmt.Errorf("oplog not found")
 
 func (c *Client) getKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, key []byte) (*keyValueLogBounds, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "Client.getKeyValueLogBounds")
+	defer span.Finish()
+
 	k := encodeKeyValueIndexKey(key)
 
 	v := tx.Bucket(keyValueLogIndex).Get(k)
@@ -144,6 +148,9 @@ func (c *Client) putKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, key []by
 }
 
 func (c *Client) updateKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, k []byte, t time.Time) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.updateKeyValueLogBounds")
+	defer span.Finish()
+
 	// retrieve the keyValue log boundaries
 	bounds, err := c.getKeyValueLogBounds(ctx, tx, k)
 	if err != nil && err != errKeyValueLogBoundsNotFound {

--- a/bolt/keyvalue_log.go
+++ b/bolt/keyvalue_log.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"time"
 
-	bolt "github.com/coreos/bbolt"
-	"github.com/opentracing/opentracing-go"
+	"github.com/coreos/bbolt"
 
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var (
@@ -114,7 +114,7 @@ func (c *Client) initializeKeyValueLog(ctx context.Context, tx *bolt.Tx) error {
 var errKeyValueLogBoundsNotFound = fmt.Errorf("oplog not found")
 
 func (c *Client) getKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, key []byte) (*keyValueLogBounds, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "Client.getKeyValueLogBounds")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	k := encodeKeyValueIndexKey(key)
@@ -149,7 +149,7 @@ func (c *Client) putKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, key []by
 }
 
 func (c *Client) updateKeyValueLogBounds(ctx context.Context, tx *bolt.Tx, k []byte, t time.Time) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.updateKeyValueLogBounds")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// retrieve the keyValue log boundaries

--- a/bolt/keyvalue_log.go
+++ b/bolt/keyvalue_log.go
@@ -7,10 +7,11 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
+	"github.com/opentracing/opentracing-go"
+
 	platform "github.com/influxdata/influxdb"
 )
 

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 	"time"
 
-	bolt "github.com/coreos/bbolt"
-	"github.com/opentracing/opentracing-go"
+	"github.com/coreos/bbolt"
 	"go.uber.org/zap"
 
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/kv"
 )
 
@@ -32,7 +32,7 @@ func NewKVStore(path string) *KVStore {
 
 // Open creates boltDB file it doesn't exists and opens it otherwise.
 func (s *KVStore) Open(ctx context.Context) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "KVStore.Open")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Ensure the required directory structure exists.
@@ -102,7 +102,7 @@ func (s *KVStore) WithDB(db *bolt.DB) {
 
 // View opens up a view transaction against the store.
 func (s *KVStore) View(ctx context.Context, fn func(tx kv.Tx) error) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "KVStore.View")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	return s.db.View(func(tx *bolt.Tx) error {
@@ -115,7 +115,7 @@ func (s *KVStore) View(ctx context.Context, fn func(tx kv.Tx) error) error {
 
 // Update opens up an update transaction against the store.
 func (s *KVStore) Update(ctx context.Context, fn func(tx kv.Tx) error) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "KVStore.Update")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	return s.db.Update(func(tx *bolt.Tx) error {

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -3,14 +3,15 @@ package bolt
 import (
 	"context"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"os"
 	"path/filepath"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
-	"github.com/influxdata/influxdb/kv"
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
+
+	"github.com/influxdata/influxdb/kv"
 )
 
 // KVStore is a kv.Store backed by boltdb.

--- a/bolt/kv_test.go
+++ b/bolt/kv_test.go
@@ -1,6 +1,7 @@
 package bolt_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/influxdata/influxdb/kv"
@@ -13,7 +14,7 @@ func initKVStore(f platformtesting.KVStoreFields, t *testing.T) (kv.Store, func(
 		t.Fatalf("failed to create new kv store: %v", err)
 	}
 
-	err = s.Update(func(tx kv.Tx) error {
+	err = s.Update(context.Background(), func(tx kv.Tx) error {
 		b, err := tx.Bucket(f.Bucket)
 		if err != nil {
 			return err

--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"time"
 
-	bolt "github.com/coreos/bbolt"
-	"github.com/opentracing/opentracing-go"
-
-	influxdb "github.com/influxdata/influxdb"
+	"github.com/coreos/bbolt"
+	"github.com/influxdata/influxdb"
 	influxdbcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var (
@@ -54,7 +53,7 @@ func (c *Client) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*inf
 }
 
 func (c *Client) findOrganizationByID(ctx context.Context, tx *bolt.Tx, id influxdb.ID) (*influxdb.Organization, *influxdb.Error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "Client.findOrganizationByID")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	encodedID, err := id.Encode()
@@ -100,7 +99,7 @@ func (c *Client) FindOrganizationByName(ctx context.Context, n string) (*influxd
 }
 
 func (c *Client) findOrganizationByName(ctx context.Context, tx *bolt.Tx, n string) (*influxdb.Organization, *influxdb.Error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.findOrganizationByName")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	o := tx.Bucket(organizationIndex).Get(organizationIndexKey(n))

--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
+	"github.com/opentracing/opentracing-go"
+
 	influxdb "github.com/influxdata/influxdb"
 	influxdbcontext "github.com/influxdata/influxdb/context"
 )

--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"time"
 
 	bolt "github.com/coreos/bbolt"
@@ -52,6 +53,9 @@ func (c *Client) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*inf
 }
 
 func (c *Client) findOrganizationByID(ctx context.Context, tx *bolt.Tx, id influxdb.ID) (*influxdb.Organization, *influxdb.Error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "Client.findOrganizationByID")
+	defer span.Finish()
+
 	encodedID, err := id.Encode()
 	if err != nil {
 		return nil, &influxdb.Error{
@@ -95,6 +99,9 @@ func (c *Client) FindOrganizationByName(ctx context.Context, n string) (*influxd
 }
 
 func (c *Client) findOrganizationByName(ctx context.Context, tx *bolt.Tx, n string) (*influxdb.Organization, *influxdb.Error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.findOrganizationByName")
+	defer span.Finish()
+
 	o := tx.Bucket(organizationIndex).Get(organizationIndexKey(n))
 	if o == nil {
 		return nil, &influxdb.Error{

--- a/chronograf/influx/databases.go
+++ b/chronograf/influx/databases.go
@@ -6,14 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opentracing/opentracing-go"
-
 	"github.com/influxdata/influxdb/chronograf"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // AllDB returns all databases from within Influx
 func (c *Client) AllDB(ctx context.Context) ([]chronograf.Database, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.AllDB")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	return c.showDatabases(ctx)
@@ -21,7 +20,7 @@ func (c *Client) AllDB(ctx context.Context) ([]chronograf.Database, error) {
 
 // CreateDB creates a database within Influx
 func (c *Client) CreateDB(ctx context.Context, db *chronograf.Database) (*chronograf.Database, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.CreateDB")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	_, err := c.Query(ctx, chronograf.Query{
@@ -38,7 +37,7 @@ func (c *Client) CreateDB(ctx context.Context, db *chronograf.Database) (*chrono
 
 // DropDB drops a database within Influx
 func (c *Client) DropDB(ctx context.Context, db string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.DropDB")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	_, err := c.Query(ctx, chronograf.Query{
@@ -53,14 +52,14 @@ func (c *Client) DropDB(ctx context.Context, db string) error {
 
 // AllRP returns all the retention policies for a specific database
 func (c *Client) AllRP(ctx context.Context, db string) ([]chronograf.RetentionPolicy, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.AllRP")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	return c.showRetentionPolicies(ctx, db)
 }
 
 func (c *Client) getRP(ctx context.Context, db, rp string) (chronograf.RetentionPolicy, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.getRP")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	rs, err := c.AllRP(ctx, db)
@@ -78,7 +77,7 @@ func (c *Client) getRP(ctx context.Context, db, rp string) (chronograf.Retention
 
 // CreateRP creates a retention policy for a specific database
 func (c *Client) CreateRP(ctx context.Context, db string, rp *chronograf.RetentionPolicy) (*chronograf.RetentionPolicy, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.CreateRP")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	query := fmt.Sprintf(`CREATE RETENTION POLICY "%s" ON "%s" DURATION %s REPLICATION %d`, rp.Name, db, rp.Duration, rp.Replication)
@@ -108,7 +107,7 @@ func (c *Client) CreateRP(ctx context.Context, db string, rp *chronograf.Retenti
 
 // UpdateRP updates a specific retention policy for a specific database
 func (c *Client) UpdateRP(ctx context.Context, db string, rp string, upd *chronograf.RetentionPolicy) (*chronograf.RetentionPolicy, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.UpdateRP")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var buffer bytes.Buffer
@@ -163,7 +162,7 @@ func (c *Client) UpdateRP(ctx context.Context, db string, rp string, upd *chrono
 
 // DropRP removes a specific retention policy for a specific database
 func (c *Client) DropRP(ctx context.Context, db string, rp string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.DropRP")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	_, err := c.Query(ctx, chronograf.Query{
@@ -181,14 +180,14 @@ func (c *Client) DropRP(ctx context.Context, db string, rp string) error {
 // optional limit and offset. If no limit or offset is provided, it defaults to
 // a limit of 100 measurements with no offset.
 func (c *Client) GetMeasurements(ctx context.Context, db string, limit, offset int) ([]chronograf.Measurement, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.GetMeasurements")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	return c.showMeasurements(ctx, db, limit, offset)
 }
 
 func (c *Client) showDatabases(ctx context.Context) ([]chronograf.Database, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.showDatabases")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	res, err := c.Query(ctx, chronograf.Query{
@@ -211,7 +210,7 @@ func (c *Client) showDatabases(ctx context.Context) ([]chronograf.Database, erro
 }
 
 func (c *Client) showRetentionPolicies(ctx context.Context, db string) ([]chronograf.RetentionPolicy, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.showRetentionPolicies")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	retentionPolicies, err := c.Query(ctx, chronograf.Query{
@@ -236,7 +235,7 @@ func (c *Client) showRetentionPolicies(ctx context.Context, db string) ([]chrono
 }
 
 func (c *Client) showMeasurements(ctx context.Context, db string, limit, offset int) ([]chronograf.Measurement, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.showMeasurements")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	show := fmt.Sprintf(`SHOW MEASUREMENTS ON "%s"`, db)

--- a/chronograf/influx/databases.go
+++ b/chronograf/influx/databases.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/influxdb/chronograf"

--- a/chronograf/influx/databases.go
+++ b/chronograf/influx/databases.go
@@ -5,17 +5,24 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/influxdb/chronograf"
 )
 
 // AllDB returns all databases from within Influx
 func (c *Client) AllDB(ctx context.Context) ([]chronograf.Database, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.AllDB")
+	defer span.Finish()
+
 	return c.showDatabases(ctx)
 }
 
 // CreateDB creates a database within Influx
 func (c *Client) CreateDB(ctx context.Context, db *chronograf.Database) (*chronograf.Database, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.CreateDB")
+	defer span.Finish()
+
 	_, err := c.Query(ctx, chronograf.Query{
 		Command: fmt.Sprintf(`CREATE DATABASE "%s"`, db.Name),
 	})
@@ -30,6 +37,9 @@ func (c *Client) CreateDB(ctx context.Context, db *chronograf.Database) (*chrono
 
 // DropDB drops a database within Influx
 func (c *Client) DropDB(ctx context.Context, db string) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.DropDB")
+	defer span.Finish()
+
 	_, err := c.Query(ctx, chronograf.Query{
 		Command: fmt.Sprintf(`DROP DATABASE "%s"`, db),
 		DB:      db,
@@ -42,10 +52,16 @@ func (c *Client) DropDB(ctx context.Context, db string) error {
 
 // AllRP returns all the retention policies for a specific database
 func (c *Client) AllRP(ctx context.Context, db string) ([]chronograf.RetentionPolicy, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.AllRP")
+	defer span.Finish()
+
 	return c.showRetentionPolicies(ctx, db)
 }
 
 func (c *Client) getRP(ctx context.Context, db, rp string) (chronograf.RetentionPolicy, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.getRP")
+	defer span.Finish()
+
 	rs, err := c.AllRP(ctx, db)
 	if err != nil {
 		return chronograf.RetentionPolicy{}, err
@@ -61,6 +77,9 @@ func (c *Client) getRP(ctx context.Context, db, rp string) (chronograf.Retention
 
 // CreateRP creates a retention policy for a specific database
 func (c *Client) CreateRP(ctx context.Context, db string, rp *chronograf.RetentionPolicy) (*chronograf.RetentionPolicy, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.CreateRP")
+	defer span.Finish()
+
 	query := fmt.Sprintf(`CREATE RETENTION POLICY "%s" ON "%s" DURATION %s REPLICATION %d`, rp.Name, db, rp.Duration, rp.Replication)
 	if len(rp.ShardDuration) != 0 {
 		query = fmt.Sprintf(`%s SHARD DURATION %s`, query, rp.ShardDuration)
@@ -88,6 +107,9 @@ func (c *Client) CreateRP(ctx context.Context, db string, rp *chronograf.Retenti
 
 // UpdateRP updates a specific retention policy for a specific database
 func (c *Client) UpdateRP(ctx context.Context, db string, rp string, upd *chronograf.RetentionPolicy) (*chronograf.RetentionPolicy, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.UpdateRP")
+	defer span.Finish()
+
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf(`ALTER RETENTION POLICY "%s" ON "%s"`, rp, db))
 	if len(upd.Duration) > 0 {
@@ -140,6 +162,9 @@ func (c *Client) UpdateRP(ctx context.Context, db string, rp string, upd *chrono
 
 // DropRP removes a specific retention policy for a specific database
 func (c *Client) DropRP(ctx context.Context, db string, rp string) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.DropRP")
+	defer span.Finish()
+
 	_, err := c.Query(ctx, chronograf.Query{
 		Command: fmt.Sprintf(`DROP RETENTION POLICY "%s" ON "%s"`, rp, db),
 		DB:      db,
@@ -155,10 +180,16 @@ func (c *Client) DropRP(ctx context.Context, db string, rp string) error {
 // optional limit and offset. If no limit or offset is provided, it defaults to
 // a limit of 100 measurements with no offset.
 func (c *Client) GetMeasurements(ctx context.Context, db string, limit, offset int) ([]chronograf.Measurement, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.GetMeasurements")
+	defer span.Finish()
+
 	return c.showMeasurements(ctx, db, limit, offset)
 }
 
 func (c *Client) showDatabases(ctx context.Context) ([]chronograf.Database, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.showDatabases")
+	defer span.Finish()
+
 	res, err := c.Query(ctx, chronograf.Query{
 		Command: `SHOW DATABASES`,
 	})
@@ -179,6 +210,9 @@ func (c *Client) showDatabases(ctx context.Context) ([]chronograf.Database, erro
 }
 
 func (c *Client) showRetentionPolicies(ctx context.Context, db string) ([]chronograf.RetentionPolicy, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.showRetentionPolicies")
+	defer span.Finish()
+
 	retentionPolicies, err := c.Query(ctx, chronograf.Query{
 		Command: fmt.Sprintf(`SHOW RETENTION POLICIES ON "%s"`, db),
 		DB:      db,
@@ -201,6 +235,9 @@ func (c *Client) showRetentionPolicies(ctx context.Context, db string) ([]chrono
 }
 
 func (c *Client) showMeasurements(ctx context.Context, db string, limit, offset int) ([]chronograf.Measurement, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.showMeasurements")
+	defer span.Finish()
+
 	show := fmt.Sprintf(`SHOW MEASUREMENTS ON "%s"`, db)
 	if limit > 0 {
 		show += fmt.Sprintf(" LIMIT %d", limit)

--- a/chronograf/influx/influx.go
+++ b/chronograf/influx/influx.go
@@ -11,8 +11,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/opentracing/opentracing-go"
-
 	"github.com/influxdata/influxdb/chronograf"
 	"github.com/influxdata/influxdb/kit/tracing"
 )
@@ -50,7 +48,7 @@ func (r Response) MarshalJSON() ([]byte, error) {
 }
 
 func (c *Client) query(ctx context.Context, u *url.URL, q chronograf.Query) (chronograf.Response, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "Client.query")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u.Path = "query"
@@ -141,7 +139,7 @@ type result struct {
 // include both the database and retention policy. In-flight requests can be
 // cancelled using the provided context.
 func (c *Client) Query(ctx context.Context, q chronograf.Query) (chronograf.Response, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	resps := make(chan (result))
@@ -160,7 +158,7 @@ func (c *Client) Query(ctx context.Context, q chronograf.Query) (chronograf.Resp
 
 // Connect caches the URL and optional Bearer Authorization for the data source
 func (c *Client) Connect(ctx context.Context, src *chronograf.Source) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "Client.Connect")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := url.Parse(src.URL)
@@ -206,7 +204,7 @@ func (c *Client) Type(ctx context.Context) (string, error) {
 }
 
 func (c *Client) pingTimeout(ctx context.Context) (string, string, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.pingTimeout")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	resps := make(chan (pingResult))
@@ -230,7 +228,7 @@ type pingResult struct {
 }
 
 func (c *Client) ping(ctx context.Context, u *url.URL) (string, string, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "Client.ping")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u.Path = "ping"
@@ -280,7 +278,7 @@ func (c *Client) ping(ctx context.Context, u *url.URL) (string, string, error) {
 
 // Write POSTs line protocol to a database and retention policy
 func (c *Client) Write(ctx context.Context, points []chronograf.Point) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.Write")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	for _, point := range points {
@@ -292,7 +290,7 @@ func (c *Client) Write(ctx context.Context, points []chronograf.Point) error {
 }
 
 func (c *Client) writePoint(ctx context.Context, point *chronograf.Point) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.writePoint")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	lp, err := toLineProtocol(point)
@@ -327,7 +325,7 @@ func (c *Client) writePoint(ctx context.Context, point *chronograf.Point) error 
 }
 
 func (c *Client) write(ctx context.Context, u *url.URL, db, rp, lp string) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.write")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u.Path = "write"

--- a/chronograf/influx/influx.go
+++ b/chronograf/influx/influx.go
@@ -6,14 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/influxdata/influxdb/chronograf"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var _ chronograf.TimeSeries = &Client{}

--- a/chronograf/influx/influx.go
+++ b/chronograf/influx/influx.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -46,7 +48,10 @@ func (r Response) MarshalJSON() ([]byte, error) {
 	return r.Results, nil
 }
 
-func (c *Client) query(u *url.URL, q chronograf.Query) (chronograf.Response, error) {
+func (c *Client) query(ctx context.Context, u *url.URL, q chronograf.Query) (chronograf.Response, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "Client.query")
+	defer span.Finish()
+
 	u.Path = "query"
 	req, err := http.NewRequest("POST", u.String(), nil)
 	if err != nil {
@@ -71,6 +76,7 @@ func (c *Client) query(u *url.URL, q chronograf.Query) (chronograf.Response, err
 		params.Set("epoch", q.Epoch)
 	}
 	req.URL.RawQuery = params.Encode()
+	tracing.InjectToHTTPRequest(span, req)
 
 	if c.Authorizer != nil {
 		if err := c.Authorizer.Set(req); err != nil {
@@ -134,9 +140,12 @@ type result struct {
 // include both the database and retention policy. In-flight requests can be
 // cancelled using the provided context.
 func (c *Client) Query(ctx context.Context, q chronograf.Query) (chronograf.Response, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.Query")
+	defer span.Finish()
+
 	resps := make(chan (result))
 	go func() {
-		resp, err := c.query(c.URL, q)
+		resp, err := c.query(ctx, c.URL, q)
 		resps <- result{resp, err}
 	}()
 
@@ -150,6 +159,9 @@ func (c *Client) Query(ctx context.Context, q chronograf.Query) (chronograf.Resp
 
 // Connect caches the URL and optional Bearer Authorization for the data source
 func (c *Client) Connect(ctx context.Context, src *chronograf.Source) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "Client.Connect")
+	defer span.Finish()
+
 	u, err := url.Parse(src.URL)
 	if err != nil {
 		return err
@@ -193,9 +205,12 @@ func (c *Client) Type(ctx context.Context) (string, error) {
 }
 
 func (c *Client) pingTimeout(ctx context.Context) (string, string, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.pingTimeout")
+	defer span.Finish()
+
 	resps := make(chan (pingResult))
 	go func() {
-		version, tsdbType, err := c.ping(c.URL)
+		version, tsdbType, err := c.ping(ctx, c.URL)
 		resps <- pingResult{version, tsdbType, err}
 	}()
 
@@ -213,13 +228,17 @@ type pingResult struct {
 	Err     error
 }
 
-func (c *Client) ping(u *url.URL) (string, string, error) {
+func (c *Client) ping(ctx context.Context, u *url.URL) (string, string, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "Client.ping")
+	defer span.Finish()
+
 	u.Path = "ping"
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return "", "", err
 	}
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := &http.Client{}
 	if c.InsecureSkipVerify {
@@ -260,6 +279,9 @@ func (c *Client) ping(u *url.URL) (string, string, error) {
 
 // Write POSTs line protocol to a database and retention policy
 func (c *Client) Write(ctx context.Context, points []chronograf.Point) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.Write")
+	defer span.Finish()
+
 	for _, point := range points {
 		if err := c.writePoint(ctx, &point); err != nil {
 			return err
@@ -269,6 +291,9 @@ func (c *Client) Write(ctx context.Context, points []chronograf.Point) error {
 }
 
 func (c *Client) writePoint(ctx context.Context, point *chronograf.Point) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.writePoint")
+	defer span.Finish()
+
 	lp, err := toLineProtocol(point)
 	if err != nil {
 		return err
@@ -301,6 +326,9 @@ func (c *Client) writePoint(ctx context.Context, point *chronograf.Point) error 
 }
 
 func (c *Client) write(ctx context.Context, u *url.URL, db, rp, lp string) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Client.write")
+	defer span.Finish()
+
 	u.Path = "write"
 	req, err := http.NewRequest("POST", u.String(), strings.NewReader(lp))
 	if err != nil {
@@ -318,6 +346,7 @@ func (c *Client) write(ctx context.Context, u *url.URL, db, rp, lp string) error
 	params.Set("db", db)
 	params.Set("rp", rp)
 	req.URL.RawQuery = params.Encode()
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := &http.Client{}
 	if c.InsecureSkipVerify {

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -14,6 +14,12 @@ import (
 
 	"github.com/influxdata/flux/control"
 	"github.com/influxdata/flux/execute"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	jaegerconfig "github.com/uber/jaeger-client-go/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/bolt"
 	"github.com/influxdata/influxdb/chronograf/server"
@@ -44,11 +50,6 @@ import (
 	_ "github.com/influxdata/influxdb/tsdb/tsm1" // needed for tsm1
 	"github.com/influxdata/influxdb/vault"
 	pzap "github.com/influxdata/influxdb/zap"
-	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/client_golang/prometheus"
-	jaegerconfig "github.com/uber/jaeger-client-go/config"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 const (

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -30,6 +30,7 @@ import (
 	"github.com/influxdata/influxdb/internal/fs"
 	"github.com/influxdata/influxdb/kit/cli"
 	"github.com/influxdata/influxdb/kit/prom"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/kv"
 	influxlogger "github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/nats"
@@ -282,7 +283,7 @@ func (m *Launcher) Run(ctx context.Context, args ...string) error {
 }
 
 func (m *Launcher) run(ctx context.Context) (err error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Launcher.run")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	m.running = true

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -320,12 +320,12 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		m.logger.Info("tracing via Jaeger")
 		cfg, err := jaegerconfig.FromEnv()
 		if err != nil {
-			m.logger.Warn("failed to get Jaeger client config from environment variables", zap.Error(err))
+			m.logger.Error("failed to get Jaeger client config from environment variables", zap.Error(err))
 			break
 		}
 		tracer, closer, err := cfg.NewTracer()
 		if err != nil {
-			m.logger.Warn("failed to instantiate Jaeger tracer", zap.Error(err))
+			m.logger.Error("failed to instantiate Jaeger tracer", zap.Error(err))
 			break
 		}
 		opentracing.SetGlobalTracer(tracer)
@@ -602,7 +602,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	m.httpServer.Handler = h
 	// If we are in testing mode we allow all data to be flushed and removed.
 	if m.testing {
-		m.httpServer.Handler = http.DebugFlush(h, flusher)
+		m.httpServer.Handler = http.DebugFlush(ctx, h, flusher)
 	}
 
 	ln, err := net.Listen("tcp", m.httpBindAddress)

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 
 	"github.com/influxdata/influxdb"
@@ -595,7 +594,7 @@ type BucketService struct {
 
 // FindBucketByID returns a single bucket by ID.
 func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucketByID")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(s.Addr, bucketIDPath(id))
@@ -630,7 +629,7 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*in
 
 // FindBucket returns the first bucket that matches filter.
 func (s *BucketService) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	bs, n, err := s.FindBuckets(ctx, filter)
@@ -652,7 +651,7 @@ func (s *BucketService) FindBucket(ctx context.Context, filter influxdb.BucketFi
 // FindBuckets returns a list of buckets that match filter and the total count of matching buckets.
 // Additional options provide pagination & sorting.
 func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opt ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BucketService.FindBuckets")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(s.Addr, bucketPath)
@@ -722,7 +721,7 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketF
 
 // CreateBucket creates a new bucket and sets b.ID with the new identifier.
 func (s *BucketService) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "BucketService.CreateBucket")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(s.Addr, bucketPath)

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -5,15 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 	"net/http"
 	"path"
 	"time"
 
-	"github.com/influxdata/influxdb"
 	"github.com/julienschmidt/httprouter"
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // BucketBackend is all services and associated parameters required to construct

--- a/http/debug.go
+++ b/http/debug.go
@@ -1,17 +1,20 @@
 package http
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // Flusher flushes data from a store to reset; used for testing.
 type Flusher interface {
-	Flush()
+	Flush(ctx context.Context)
 }
 
 // DebugFlush clears all services for testing.
-func DebugFlush(next http.Handler, f Flusher) http.HandlerFunc {
+func DebugFlush(ctx context.Context, next http.Handler, f Flusher) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/debug/flush" {
-			f.Flush()
+			f.Flush(ctx)
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
 			return

--- a/http/influxdb/bucket.go
+++ b/http/influxdb/bucket.go
@@ -3,6 +3,7 @@ package influxdb
 import (
 	"context"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"time"
 
 	platform "github.com/influxdata/influxdb"
@@ -22,6 +23,9 @@ func (s *BucketService) FindBucket(ctx context.Context, filter platform.BucketFi
 }
 
 func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketFilter, opt ...platform.FindOptions) ([]*platform.Bucket, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBuckets")
+	defer span.Finish()
+
 	c, err := newClient(s.Source)
 	if err != nil {
 		return nil, 0, err

--- a/http/influxdb/bucket.go
+++ b/http/influxdb/bucket.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
-
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // BucketService connects to Influx via HTTP using tokens to manage buckets
@@ -24,7 +23,7 @@ func (s *BucketService) FindBucket(ctx context.Context, filter platform.BucketFi
 }
 
 func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketFilter, opt ...platform.FindOptions) ([]*platform.Bucket, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBuckets")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	c, err := newClient(s.Source)

--- a/http/influxdb/bucket.go
+++ b/http/influxdb/bucket.go
@@ -3,8 +3,9 @@ package influxdb
 import (
 	"context"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"time"
+
+	"github.com/opentracing/opentracing-go"
 
 	platform "github.com/influxdata/influxdb"
 )

--- a/http/influxdb/source_proxy_query_service.go
+++ b/http/influxdb/source_proxy_query_service.go
@@ -18,7 +18,6 @@ import (
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/query/influxql"
-	"github.com/opentracing/opentracing-go"
 )
 
 type SourceProxyQueryService struct {

--- a/http/influxdb/source_proxy_query_service.go
+++ b/http/influxdb/source_proxy_query_service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/lang"
-	"github.com/opentracing/opentracing-go"
 
 	platform "github.com/influxdata/influxdb"
 	platformhttp "github.com/influxdata/influxdb/http"
@@ -40,7 +39,7 @@ func (s *SourceProxyQueryService) Query(ctx context.Context, w io.Writer, req *q
 }
 
 func (s *SourceProxyQueryService) fluxQuery(ctx context.Context, w io.Writer, req *query.ProxyRequest) (flux.Statistics, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SourceProxyQueryService.fluxQuery")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	request := struct {
 		Spec    *flux.Spec   `json:"spec"`
@@ -111,7 +110,7 @@ func (s *SourceProxyQueryService) fluxQuery(ctx context.Context, w io.Writer, re
 }
 
 func (s *SourceProxyQueryService) influxQuery(ctx context.Context, w io.Writer, req *query.ProxyRequest) (flux.Statistics, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SourceProxyQueryService.influxQuery")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	if len(s.URL) == 0 {
 		return flux.Statistics{}, tracing.LogError(span, fmt.Errorf("URL from source cannot be empty if the compiler type is influxql"))

--- a/http/influxdb/source_proxy_query_service.go
+++ b/http/influxdb/source_proxy_query_service.go
@@ -11,6 +11,8 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/lang"
+	"github.com/opentracing/opentracing-go"
+
 	platform "github.com/influxdata/influxdb"
 	platformhttp "github.com/influxdata/influxdb/http"
 	"github.com/influxdata/influxdb/kit/tracing"

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -9,7 +9,6 @@ import (
 	"path"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 
 	"github.com/influxdata/influxdb"
@@ -616,7 +615,7 @@ func (s *OrganizationService) FindOrganization(ctx context.Context, filter influ
 
 // FindOrganizations returns all organizations that match the filter via HTTP.
 func (s *OrganizationService) FindOrganizations(ctx context.Context, filter influxdb.OrganizationFilter, opt ...influxdb.FindOptions) ([]*influxdb.Organization, int, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "OrganizationService.FindOrganizations")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if filter.Name != nil {
@@ -689,7 +688,7 @@ func (s *OrganizationService) CreateOrganization(ctx context.Context, o *influxd
 		}
 	}
 
-	span, _ := opentracing.StartSpanFromContext(ctx, "OrganizationService.CreateOrganization")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if o.Name != "" {
@@ -740,7 +739,7 @@ func (s *OrganizationService) CreateOrganization(ctx context.Context, o *influxd
 
 // UpdateOrganization updates the organization over HTTP.
 func (s *OrganizationService) UpdateOrganization(ctx context.Context, id influxdb.ID, upd influxdb.OrganizationUpdate) (*influxdb.Organization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "OrganizationService.UpdateOrganization")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	span.LogKV("org-id", id)
@@ -787,7 +786,7 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, id influxd
 
 // DeleteOrganization removes organization id over HTTP.
 func (s *OrganizationService) DeleteOrganization(ctx context.Context, id influxdb.ID) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "OrganizationService.DeleteOrganization")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(s.Addr, organizationIDPath(id))

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 	"net/http"
 	"path"
 
-	"github.com/influxdata/influxdb"
 	"github.com/julienschmidt/httprouter"
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // OrgBackend is all services and associated parameters required to construct

--- a/http/proxy_query_service.go
+++ b/http/proxy_query_service.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/opentracing/opentracing-go"
 	"io"
 	"net/http"
 
@@ -140,49 +142,52 @@ func (s *ProxyQueryService) Ping(ctx context.Context) error {
 }
 
 func (s *ProxyQueryService) Query(ctx context.Context, w io.Writer, req *query.ProxyRequest) (flux.Statistics, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ProxyQueryService.Query")
+	defer span.Finish()
 	u, err := newURL(s.Addr, proxyQueryPath)
 	if err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(req); err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
 	hreq, err := http.NewRequest("POST", u.String(), &body)
 	if err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
 	token := s.Token
 	if token == "" {
 		token, err = icontext.GetToken(ctx)
 		if err != nil {
-			return flux.Statistics{}, err
+			return flux.Statistics{}, tracing.LogError(span, err)
 		}
 	}
 
 	SetToken(token, hreq)
 	hreq = hreq.WithContext(ctx)
+	tracing.InjectToHTTPRequest(span, hreq)
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)
 	if err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 	defer resp.Body.Close()
 	if err := CheckError(resp); err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
 	if _, err = io.Copy(w, resp.Body); err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
 	data := []byte(resp.Trailer.Get(QueryStatsTrailer))
 	var stats flux.Statistics
 	if err := json.Unmarshal(data, &stats); err != nil {
-		return stats, err
+		return stats, tracing.LogError(span, err)
 	}
 
 	return stats, nil

--- a/http/proxy_query_service.go
+++ b/http/proxy_query_service.go
@@ -5,16 +5,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 	"io"
 	"net/http"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/iocounter"
 	icontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 	"github.com/julienschmidt/httprouter"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )

--- a/http/proxy_query_service.go
+++ b/http/proxy_query_service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 	"github.com/julienschmidt/httprouter"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -142,7 +141,7 @@ func (s *ProxyQueryService) Ping(ctx context.Context) error {
 }
 
 func (s *ProxyQueryService) Query(ctx context.Context, w io.Writer, req *query.ProxyRequest) (flux.Statistics, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ProxyQueryService.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	u, err := newURL(s.Addr, proxyQueryPath)
 	if err != nil {

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -19,12 +17,15 @@ import (
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/iocounter"
 	"github.com/influxdata/flux/parser"
-	platform "github.com/influxdata/influxdb"
-	pcontext "github.com/influxdata/influxdb/context"
-	"github.com/influxdata/influxdb/query"
 	"github.com/julienschmidt/httprouter"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+
+	platform "github.com/influxdata/influxdb"
+	pcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/influxdata/influxdb/query"
 )
 
 const (

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -18,7 +18,6 @@ import (
 	"github.com/influxdata/flux/iocounter"
 	"github.com/influxdata/flux/parser"
 	"github.com/julienschmidt/httprouter"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
@@ -330,7 +329,7 @@ type FluxService struct {
 // Query runs a flux query against a influx server and sends the results to the io.Writer.
 // Will use the token from the context over the token within the service struct.
 func (s *FluxService) Query(ctx context.Context, w io.Writer, r *query.ProxyRequest) (flux.Statistics, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FluxService.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	u, err := newURL(s.Addr, fluxPath)
 	if err != nil {
@@ -386,7 +385,7 @@ type FluxQueryService struct {
 
 // Query runs a flux query against a influx server and decodes the result
 func (s *FluxQueryService) Query(ctx context.Context, r *query.Request) (flux.ResultIterator, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "FluxQueryService.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(s.Addr, fluxPath)

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/opentracing/opentracing-go"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -80,6 +82,9 @@ func NewFluxHandler(b *FluxBackend) *FluxHandler {
 }
 
 func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "FluxHandler")
+	defer span.Finish()
+
 	ctx := r.Context()
 
 	a, err := pcontext.GetAuthorizer(ctx)
@@ -125,6 +130,9 @@ type postFluxASTResponse struct {
 
 // postFluxAST returns a flux AST for provided flux string
 func (h *FluxHandler) postFluxAST(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "FluxHandler")
+	defer span.Finish()
+
 	var request langRequest
 	ctx := r.Context()
 
@@ -161,6 +169,9 @@ func (h *FluxHandler) postFluxAST(w http.ResponseWriter, r *http.Request) {
 
 // postQueryAnalyze parses a query and returns any query errors.
 func (h *FluxHandler) postQueryAnalyze(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "FluxHandler")
+	defer span.Finish()
+
 	ctx := r.Context()
 
 	var req QueryRequest
@@ -190,6 +201,9 @@ type postFluxSpecResponse struct {
 
 // postFluxSpec returns a flux Spec for provided flux string
 func (h *FluxHandler) postFluxSpec(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "FluxHandler")
+	defer span.Finish()
+
 	var req langRequest
 	ctx := r.Context()
 
@@ -239,6 +253,9 @@ type suggestionsResponse struct {
 
 // getFluxSuggestions returns a list of available Flux functions for the Flux Builder
 func (h *FluxHandler) getFluxSuggestions(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "FluxHandler")
+	defer span.Finish()
+
 	ctx := r.Context()
 	completer := complete.DefaultCompleter()
 	names := completer.FunctionNames()
@@ -274,6 +291,9 @@ func (h *FluxHandler) getFluxSuggestions(w http.ResponseWriter, r *http.Request)
 
 // getFluxSuggestion returns the function parameters for the requested function
 func (h *FluxHandler) getFluxSuggestion(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "FluxHandler")
+	defer span.Finish()
+
 	ctx := r.Context()
 	name := httprouter.ParamsFromContext(ctx).ByName("name")
 	completer := complete.DefaultCompleter()
@@ -309,23 +329,25 @@ type FluxService struct {
 // Query runs a flux query against a influx server and sends the results to the io.Writer.
 // Will use the token from the context over the token within the service struct.
 func (s *FluxService) Query(ctx context.Context, w io.Writer, r *query.ProxyRequest) (flux.Statistics, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "FluxService.Query")
+	defer span.Finish()
 	u, err := newURL(s.Addr, fluxPath)
 	if err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
 	qreq, err := QueryRequestFromProxyRequest(r)
 	if err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(qreq); err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
 	hreq, err := http.NewRequest("POST", u.String(), &body)
 	if err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
 	SetToken(s.Token, hreq)
@@ -333,20 +355,21 @@ func (s *FluxService) Query(ctx context.Context, w io.Writer, r *query.ProxyRequ
 	hreq.Header.Set("Content-Type", "application/json")
 	hreq.Header.Set("Accept", "text/csv")
 	hreq = hreq.WithContext(ctx)
+	tracing.InjectToHTTPRequest(span, hreq)
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)
 	if err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 	defer resp.Body.Close()
 
 	if err := CheckError(resp); err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
 	if _, err := io.Copy(w, resp.Body); err != nil {
-		return flux.Statistics{}, err
+		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 	return flux.Statistics{}, nil
 }
@@ -362,9 +385,12 @@ type FluxQueryService struct {
 
 // Query runs a flux query against a influx server and decodes the result
 func (s *FluxQueryService) Query(ctx context.Context, r *query.Request) (flux.ResultIterator, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "FluxQueryService.Query")
+	defer span.Finish()
+
 	u, err := newURL(s.Addr, fluxPath)
 	if err != nil {
-		return nil, err
+		return nil, tracing.LogError(span, err)
 	}
 	params := url.Values{}
 	params.Set(OrgID, r.OrganizationID.String())
@@ -376,16 +402,16 @@ func (s *FluxQueryService) Query(ctx context.Context, r *query.Request) (flux.Re
 	}
 	qreq, err := QueryRequestFromProxyRequest(preq)
 	if err != nil {
-		return nil, err
+		return nil, tracing.LogError(span, err)
 	}
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(qreq); err != nil {
-		return nil, err
+		return nil, tracing.LogError(span, err)
 	}
 
 	hreq, err := http.NewRequest("POST", u.String(), &body)
 	if err != nil {
-		return nil, err
+		return nil, tracing.LogError(span, err)
 	}
 
 	SetToken(s.Token, hreq)
@@ -393,20 +419,26 @@ func (s *FluxQueryService) Query(ctx context.Context, r *query.Request) (flux.Re
 	hreq.Header.Set("Content-Type", "application/json")
 	hreq.Header.Set("Accept", "text/csv")
 	hreq = hreq.WithContext(ctx)
+	tracing.InjectToHTTPRequest(span, hreq)
 
 	hc := newClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)
 	if err != nil {
-		return nil, err
+		return nil, tracing.LogError(span, err)
 	}
 	// Can't defer resp.Body.Close here because the CSV decoder depends on reading from resp.Body after this function returns.
 
 	if err := CheckError(resp); err != nil {
-		return nil, err
+		return nil, tracing.LogError(span, err)
 	}
 
 	decoder := csv.NewMultiResultDecoder(csv.ResultDecoderConfig{})
-	return decoder.Decode(resp.Body)
+	itr, err := decoder.Decode(resp.Body)
+	if err != nil {
+		return nil, tracing.LogError(span, err)
+	}
+
+	return itr, nil
 }
 
 // SimpleQuery runs a flux query with common parameters and returns CSV results.

--- a/http/source_proxy_service.go
+++ b/http/source_proxy_service.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/lang"
-	"github.com/opentracing/opentracing-go"
 
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"
@@ -37,7 +36,7 @@ func (s *SourceProxyQueryService) Query(ctx context.Context, w io.Writer, req *q
 }
 
 func (s *SourceProxyQueryService) queryFlux(ctx context.Context, w io.Writer, req *query.ProxyRequest) (flux.Statistics, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SourceProxyQueryService.queryFlux")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	u, err := newURL(s.Addr, "/api/v2/query")
 	if err != nil {
@@ -75,7 +74,7 @@ func (s *SourceProxyQueryService) queryFlux(ctx context.Context, w io.Writer, re
 }
 
 func (s *SourceProxyQueryService) queryInfluxQL(ctx context.Context, w io.Writer, req *query.ProxyRequest) (flux.Statistics, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "SourceProxyQueryService.queryInfluxQL")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 	compiler, ok := req.Request.Compiler.(*influxql.Compiler)
 

--- a/http/source_proxy_service.go
+++ b/http/source_proxy_service.go
@@ -18,7 +18,6 @@ import (
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/query/influxql"
-	"github.com/opentracing/opentracing-go"
 )
 
 type SourceProxyQueryService struct {

--- a/http/source_proxy_service.go
+++ b/http/source_proxy_service.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/lang"
+	"github.com/opentracing/opentracing-go"
+
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 	"net/http"
 	"net/url"
 	"path"
@@ -16,15 +14,18 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/julienschmidt/httprouter"
+	"github.com/opentracing/opentracing-go"
+	"go.uber.org/zap"
+
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/authorizer"
 	pcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/options"
-	"github.com/julienschmidt/httprouter"
-	"go.uber.org/zap"
 )
 
 // TaskBackend is all services and associated parameters required to construct

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/julienschmidt/httprouter"
-	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 
 	platform "github.com/influxdata/influxdb"
@@ -1366,7 +1365,7 @@ type TaskService struct {
 
 // FindTaskByID returns a single task
 func (t TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platform.Task, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindTaskByID")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(t.Addr, taskIDPath(id))
@@ -1409,7 +1408,7 @@ func (t TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platfor
 // FindTasks returns a list of tasks that match a filter (limit 100) and the total count
 // of matching tasks.
 func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindTasks")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(t.Addr, tasksPath)
@@ -1468,7 +1467,7 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 
 // CreateTask creates a new task.
 func (t TaskService) CreateTask(ctx context.Context, tc platform.TaskCreate) (*platform.Task, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.CreateTask")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(t.Addr, tasksPath)
@@ -1511,7 +1510,7 @@ func (t TaskService) CreateTask(ctx context.Context, tc platform.TaskCreate) (*p
 
 // UpdateTask updates a single task with changeset.
 func (t TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platform.TaskUpdate) (*platform.Task, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.UpdateTask")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(t.Addr, taskIDPath(id))
@@ -1555,7 +1554,7 @@ func (t TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platfor
 
 // DeleteTask removes a task by ID and purges all associated data and scheduled runs.
 func (t TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.DeleteTask")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(t.Addr, taskIDPath(id))
@@ -1585,7 +1584,7 @@ func (t TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
 
 // FindLogs returns logs for a run.
 func (t TaskService) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindLogs")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if !filter.Task.Valid() {
@@ -1633,7 +1632,7 @@ func (t TaskService) FindLogs(ctx context.Context, filter platform.LogFilter) ([
 
 // FindRuns returns a list of runs that match a filter and the total count of returned runs.
 func (t TaskService) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindRuns")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if !filter.Task.Valid() {
@@ -1689,7 +1688,7 @@ func (t TaskService) FindRuns(ctx context.Context, filter platform.RunFilter) ([
 
 // FindRunByID returns a single run of a specific task.
 func (t TaskService) FindRunByID(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindRunByID")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(t.Addr, taskIDRunIDPath(taskID, runID))
@@ -1732,7 +1731,7 @@ func (t TaskService) FindRunByID(ctx context.Context, taskID, runID platform.ID)
 
 // RetryRun creates and returns a new run (which is a retry of another run).
 func (t TaskService) RetryRun(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.RetryRun")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	p := path.Join(taskIDRunIDPath(taskID, runID), "retry")
@@ -1780,7 +1779,7 @@ func (t TaskService) RetryRun(ctx context.Context, taskID, runID platform.ID) (*
 }
 
 func (t TaskService) ForceRun(ctx context.Context, taskID platform.ID, scheduledFor int64) (*platform.Run, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.ForceRun")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(t.Addr, taskIDRunsPath(taskID))
@@ -1832,7 +1831,7 @@ func cancelPath(taskID, runID platform.ID) string {
 }
 
 func (t TaskService) CancelRun(ctx context.Context, taskID, runID platform.ID) error {
-	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.CancelRun")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	u, err := newURL(t.Addr, cancelPath(taskID, runID))

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/opentracing/opentracing-go"
 	"net/http"
 	"net/url"
 	"path"
@@ -1363,6 +1365,9 @@ type TaskService struct {
 
 // FindTaskByID returns a single task
 func (t TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platform.Task, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindTaskByID")
+	defer span.Finish()
+
 	u, err := newURL(t.Addr, taskIDPath(id))
 	if err != nil {
 		return nil, err
@@ -1373,6 +1378,7 @@ func (t TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platfor
 		return nil, err
 	}
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 	resp, err := hc.Do(req)
@@ -1402,6 +1408,9 @@ func (t TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platfor
 // FindTasks returns a list of tasks that match a filter (limit 100) and the total count
 // of matching tasks.
 func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindTasks")
+	defer span.Finish()
+
 	u, err := newURL(t.Addr, tasksPath)
 	if err != nil {
 		return nil, 0, err
@@ -1431,6 +1440,7 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 		return nil, 0, err
 	}
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 	resp, err := hc.Do(req)
@@ -1457,6 +1467,9 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 
 // CreateTask creates a new task.
 func (t TaskService) CreateTask(ctx context.Context, tc platform.TaskCreate) (*platform.Task, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.CreateTask")
+	defer span.Finish()
+
 	u, err := newURL(t.Addr, tasksPath)
 	if err != nil {
 		return nil, err
@@ -1474,6 +1487,7 @@ func (t TaskService) CreateTask(ctx context.Context, tc platform.TaskCreate) (*p
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1496,6 +1510,9 @@ func (t TaskService) CreateTask(ctx context.Context, tc platform.TaskCreate) (*p
 
 // UpdateTask updates a single task with changeset.
 func (t TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platform.TaskUpdate) (*platform.Task, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.UpdateTask")
+	defer span.Finish()
+
 	u, err := newURL(t.Addr, taskIDPath(id))
 	if err != nil {
 		return nil, err
@@ -1513,6 +1530,7 @@ func (t TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platfor
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1536,6 +1554,9 @@ func (t TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platfor
 
 // DeleteTask removes a task by ID and purges all associated data and scheduled runs.
 func (t TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.DeleteTask")
+	defer span.Finish()
+
 	u, err := newURL(t.Addr, taskIDPath(id))
 	if err != nil {
 		return err
@@ -1548,6 +1569,7 @@ func (t TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1562,6 +1584,9 @@ func (t TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
 
 // FindLogs returns logs for a run.
 func (t TaskService) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindLogs")
+	defer span.Finish()
+
 	if !filter.Task.Valid() {
 		return nil, 0, errors.New("task ID required")
 	}
@@ -1583,6 +1608,7 @@ func (t TaskService) FindLogs(ctx context.Context, filter platform.LogFilter) ([
 		return nil, 0, err
 	}
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1606,6 +1632,9 @@ func (t TaskService) FindLogs(ctx context.Context, filter platform.LogFilter) ([
 
 // FindRuns returns a list of runs that match a filter and the total count of returned runs.
 func (t TaskService) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindRuns")
+	defer span.Finish()
+
 	if !filter.Task.Valid() {
 		return nil, 0, errors.New("task ID required")
 	}
@@ -1630,6 +1659,7 @@ func (t TaskService) FindRuns(ctx context.Context, filter platform.RunFilter) ([
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1658,6 +1688,9 @@ func (t TaskService) FindRuns(ctx context.Context, filter platform.RunFilter) ([
 
 // FindRunByID returns a single run of a specific task.
 func (t TaskService) FindRunByID(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.FindRunByID")
+	defer span.Finish()
+
 	u, err := newURL(t.Addr, taskIDRunIDPath(taskID, runID))
 	if err != nil {
 		return nil, err
@@ -1669,6 +1702,7 @@ func (t TaskService) FindRunByID(ctx context.Context, taskID, runID platform.ID)
 	}
 
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1697,6 +1731,9 @@ func (t TaskService) FindRunByID(ctx context.Context, taskID, runID platform.ID)
 
 // RetryRun creates and returns a new run (which is a retry of another run).
 func (t TaskService) RetryRun(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.RetryRun")
+	defer span.Finish()
+
 	p := path.Join(taskIDRunIDPath(taskID, runID), "retry")
 	u, err := newURL(t.Addr, p)
 	if err != nil {
@@ -1709,6 +1746,7 @@ func (t TaskService) RetryRun(ctx context.Context, taskID, runID platform.ID) (*
 	}
 
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1741,6 +1779,9 @@ func (t TaskService) RetryRun(ctx context.Context, taskID, runID platform.ID) (*
 }
 
 func (t TaskService) ForceRun(ctx context.Context, taskID platform.ID, scheduledFor int64) (*platform.Run, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.ForceRun")
+	defer span.Finish()
+
 	u, err := newURL(t.Addr, taskIDRunsPath(taskID))
 	if err != nil {
 		return nil, err
@@ -1753,6 +1794,7 @@ func (t TaskService) ForceRun(ctx context.Context, taskID platform.ID, scheduled
 	}
 
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1789,6 +1831,9 @@ func cancelPath(taskID, runID platform.ID) string {
 }
 
 func (t TaskService) CancelRun(ctx context.Context, taskID, runID platform.ID) error {
+	span, _ := opentracing.StartSpanFromContext(ctx, "TaskService.CancelRun")
+	defer span.Finish()
+
 	u, err := newURL(t.Addr, cancelPath(taskID, runID))
 	if err != nil {
 		return err
@@ -1800,6 +1845,7 @@ func (t TaskService) CancelRun(ctx context.Context, taskID, runID platform.ID) e
 	}
 
 	SetToken(t.Token, req)
+	tracing.InjectToHTTPRequest(span, req)
 
 	hc := newClient(u.Scheme, t.InsecureSkipVerify)
 

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -73,6 +74,9 @@ func NewWriteHandler(b *WriteBackend) *WriteHandler {
 }
 
 func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "WriteHandler")
+	defer span.Finish()
+
 	ctx := r.Context()
 	defer r.Body.Close()
 

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -9,13 +9,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/influxdata/influxdb/kit/tracing"
-
 	"github.com/julienschmidt/httprouter"
 	"go.uber.org/zap"
 
 	platform "github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/tsdb"

--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -4,19 +4,21 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/tracing"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	"github.com/influxdata/influxdb/kit/tracing"
+
+	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
 
 	platform "github.com/influxdata/influxdb"
 	pcontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/tsdb"
-	"github.com/julienschmidt/httprouter"
-	"go.uber.org/zap"
 )
 
 // WriteBackend is all services and associated parameters required to construct

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -24,7 +24,7 @@ func NewKVStore() *KVStore {
 }
 
 // View opens up a transaction with a read lock.
-func (s *KVStore) View(fn func(kv.Tx) error) error {
+func (s *KVStore) View(ctx context.Context, fn func(kv.Tx) error) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.buckets == nil {
@@ -33,12 +33,12 @@ func (s *KVStore) View(fn func(kv.Tx) error) error {
 	return fn(&Tx{
 		kv:       s,
 		writable: false,
-		ctx:      context.Background(),
+		ctx:      ctx,
 	})
 }
 
 // Update opens up a transaction with a write lock.
-func (s *KVStore) Update(fn func(kv.Tx) error) error {
+func (s *KVStore) Update(ctx context.Context, fn func(kv.Tx) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.buckets == nil {
@@ -48,12 +48,12 @@ func (s *KVStore) Update(fn func(kv.Tx) error) error {
 	return fn(&Tx{
 		kv:       s,
 		writable: true,
-		ctx:      context.Background(),
+		ctx:      ctx,
 	})
 }
 
 // Flush removes all data from the buckets.  Used for testing.
-func (s *KVStore) Flush() {
+func (s *KVStore) Flush(ctx context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, b := range s.buckets {
@@ -62,7 +62,7 @@ func (s *KVStore) Flush() {
 }
 
 // Buckets returns the names of all buckets within inmem.KVStore.
-func (s *KVStore) Buckets() [][]byte {
+func (s *KVStore) Buckets(ctx context.Context) [][]byte {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/google/btree"
+
 	"github.com/influxdata/influxdb/kv"
 )
 

--- a/inmem/kv_test.go
+++ b/inmem/kv_test.go
@@ -1,6 +1,7 @@
 package inmem_test
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
@@ -13,7 +14,7 @@ import (
 func initKVStore(f platformtesting.KVStoreFields, t *testing.T) (kv.Store, func()) {
 	s := inmem.NewKVStore()
 
-	err := s.Update(func(tx kv.Tx) error {
+	err := s.Update(context.Background(), func(tx kv.Tx) error {
 		b, err := tx.Bucket(f.Bucket)
 		if err != nil {
 			return err
@@ -57,7 +58,7 @@ func TestKVStore_Buckets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &inmem.KVStore{}
-			err := s.Update(func(tx kv.Tx) error {
+			err := s.Update(context.Background(), func(tx kv.Tx) error {
 				for _, b := range tt.buckets {
 					if _, err := tx.Bucket([]byte(b)); err != nil {
 						return err
@@ -68,7 +69,7 @@ func TestKVStore_Buckets(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unable to setup store with buckets: %v", err)
 			}
-			got := s.Buckets()
+			got := s.Buckets(context.Background())
 			sort.Slice(got, func(i, j int) bool {
 				return string(got[i]) < string(got[j])
 			})

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -3,7 +3,6 @@ package tracing
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"runtime"
 
@@ -44,21 +43,60 @@ func ExtractFromHTTPRequest(req *http.Request, handlerName string) (opentracing.
 	return span, req
 }
 
-// StartSpanFromContext is an easier-to-use opentracing.StartSpanFromContext.
-// Uses the calling function as the operation name, and logs the file:line.
-// TODO unused for now; consider removing this because performance isn't awesome.
+// StartSpanFromContext is an improved opentracing.StartSpanFromContext.
+// Uses the calling function as the operation name, and logs the filename and line number.
+//
+// Passing nil context triggers new context and root span construction.
+// Context without parent span reference triggers root span construction.
+// This function never returns nil values.
+//
+// Performance
+//
+// This function incurs a small performance penalty, roughly 1000 ns/op, 376 B/op, 6 allocs/op.
+// Jaeger timestamp and duration precision is only µs, so this is pretty negligible.
+//
+// Alternatives
+//
+// If this performance penalty is too much, try these, which are also demonstrated in benchmark tests:
+//  // Create a root span
+//  span := opentracing.StartSpan("operation name")
+//
+//  // Create a child span
+//  span := opentracing.StartSpan("operation name", opentracing.ChildOf(sc))
+//
+//  // Sugar to create a child span
+//  span, ctx := opentracing.StartSpanFromContext(ctx, "operation name")
 func StartSpanFromContext(ctx context.Context) (opentracing.Span, context.Context) {
-	pc, _, _, ok := runtime.Caller(1)
-	if !ok {
-		span, ctx := opentracing.StartSpanFromContext(ctx, "unknown")
-		span.LogFields(log.Error(errors.New("failed to get calling frame")))
-		return span, ctx
+	if ctx == nil {
+		// Guard against nil context.
+		ctx = context.Background()
 	}
 
-	frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
+	var frame runtime.Frame
+	{
+		// Get caller frame.
+		pc, _, _, ok := runtime.Caller(1)
+		if !ok {
+			span, ctx := opentracing.StartSpanFromContext(ctx, "unknown")
+			span.LogFields(log.Error(errors.New("runtime.Caller failed")))
+			return span, ctx
+		}
 
-	span, ctx := opentracing.StartSpanFromContext(ctx, frame.Function)
-	span.LogFields(log.String("location", fmt.Sprintf("%s:%d", frame.File, frame.Line)))
+		frame, _ = runtime.CallersFrames([]uintptr{pc}).Next()
+	}
+
+	var span opentracing.Span
+	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
+		// Create a child span.
+		span = opentracing.StartSpan(frame.Function, opentracing.ChildOf(parentSpan.Context()))
+	} else {
+		// Create a root span.
+		span = opentracing.StartSpan(frame.Function)
+	}
+	// New context references this span, not the parent (if there was one).
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	span.LogFields(log.String("filename", frame.File), log.Int("line", frame.Line))
 
 	return span, ctx
 }

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -13,8 +13,7 @@ import (
 
 // LogError adds a span log for an error.
 // Returns unchanged error, so useful to wrap as in:
-//
-// return 0, tracing.LogError(err)
+//  return 0, tracing.LogError(err)
 func LogError(span opentracing.Span, err error) error {
 	span.LogFields(log.Error(err))
 	return err

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -60,9 +60,11 @@ func ExtractFromHTTPRequest(req *http.Request, handlerName string) (opentracing.
 // If this performance penalty is too much, try these, which are also demonstrated in benchmark tests:
 //  // Create a root span
 //  span := opentracing.StartSpan("operation name")
+//  ctx := opentracing.ContextWithSpan(context.Background(), span)
 //
 //  // Create a child span
 //  span := opentracing.StartSpan("operation name", opentracing.ChildOf(sc))
+//  ctx := opentracing.ContextWithSpan(context.Background(), span)
 //
 //  // Sugar to create a child span
 //  span, ctx := opentracing.StartSpanFromContext(ctx, "operation name")

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -70,8 +70,7 @@ func ExtractFromHTTPRequest(req *http.Request, handlerName string) (opentracing.
 //  span, ctx := opentracing.StartSpanFromContext(ctx, "operation name")
 func StartSpanFromContext(ctx context.Context) (opentracing.Span, context.Context) {
 	if ctx == nil {
-		// Guard against nil context.
-		ctx = context.Background()
+		panic("StartSpanFromContext called with nil context")
 	}
 
 	var frame runtime.Frame

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -1,0 +1,64 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+	"net/http"
+	"runtime"
+)
+
+// LogError adds a span log for an error.
+// Returns unchanged error, so useful to wrap as in:
+//
+// return 0, tracing.LogError(err)
+func LogError(span opentracing.Span, err error) error {
+	span.LogFields(log.Error(err))
+	return err
+}
+
+// InjectToHTTPRequest adds tracing headers to an HTTP request.
+// Easier than adding this boilerplate everywhere.
+func InjectToHTTPRequest(span opentracing.Span, req *http.Request) {
+	err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
+	if err != nil {
+		span.LogFields(log.String("trace-inject-error", err.Error()))
+	}
+}
+
+// ExtractFromHTTPRequest gets a child span of the parent referenced in HTTP request headers.
+// Easier than adding this boilerplate everywhere.
+func ExtractFromHTTPRequest(req *http.Request, handlerName string) (opentracing.Span, *http.Request) {
+	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
+	if err != nil {
+		span, ctx := opentracing.StartSpanFromContext(req.Context(), handlerName+":"+req.URL.Path)
+		span.LogFields(log.String("trace-extract-error", err.Error()))
+		req = req.WithContext(ctx)
+		return span, req
+	}
+
+	span := opentracing.StartSpan(handlerName+":"+req.URL.Path, opentracing.ChildOf(spanContext))
+	req = req.WithContext(opentracing.ContextWithSpan(req.Context(), span))
+	return span, req
+}
+
+// StartSpanFromContext is an easier-to-use opentracing.StartSpanFromContext.
+// Uses the calling function as the operation name, and logs the file:line.
+// TODO unused for now; consider removing this because performance isn't awesome.
+func StartSpanFromContext(ctx context.Context) (opentracing.Span, context.Context) {
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		span, ctx := opentracing.StartSpanFromContext(ctx, "unknown")
+		span.LogFields(log.Error(errors.New("failed to get calling frame")))
+		return span, ctx
+	}
+
+	frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, frame.Function)
+	span.LogFields(log.String("location", fmt.Sprintf("%s:%d", frame.File, frame.Line)))
+
+	return span, ctx
+}

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"net/http"
 	"runtime"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
 )
 
 // LogError adds a span log for an error.

--- a/kit/tracing/tracing_test.go
+++ b/kit/tracing/tracing_test.go
@@ -2,38 +2,165 @@ package tracing
 
 import (
 	"context"
+	"fmt"
+	"github.com/uber/jaeger-client-go"
+	"net/http"
+	"runtime"
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
 )
 
+func TestInjectAndExtractHTTPRequest(t *testing.T) {
+	// Use Jaeger tracer simply to avoid using a noop tracer implementation.
+
+	sampler := jaeger.NewConstSampler(true)
+	reporter := jaeger.NewInMemoryReporter()
+	tracer, closer := jaeger.NewTracer("service name", sampler, reporter)
+	defer closer.Close()
+
+	oldTracer := opentracing.GlobalTracer()
+	opentracing.SetGlobalTracer(tracer)
+	defer opentracing.SetGlobalTracer(oldTracer)
+
+	request, err := http.NewRequest(http.MethodPost, "http://localhost/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	span := tracer.StartSpan("operation name")
+
+	InjectToHTTPRequest(span, request)
+	gotSpan, _ := ExtractFromHTTPRequest(request, "MyStruct")
+
+	if span.Context().(jaeger.SpanContext).TraceID().String() != gotSpan.Context().(jaeger.SpanContext).TraceID().String() {
+		t.Error("injected and extracted traceIDs not equal")
+	}
+
+	if span.Context().(jaeger.SpanContext).SpanID() != gotSpan.Context().(jaeger.SpanContext).ParentID() {
+		t.Error("injected and extracted spanIDs not equal")
+	}
+}
+
+func TestStartSpanFromContext(t *testing.T) {
+	// Use Jaeger tracer simply to avoid using a noop tracer implementation.
+
+	sampler := jaeger.NewConstSampler(true)
+	reporter := jaeger.NewInMemoryReporter()
+	tracer, closer := jaeger.NewTracer("service name", sampler, reporter)
+	defer closer.Close()
+
+	oldTracer := opentracing.GlobalTracer()
+	opentracing.SetGlobalTracer(tracer)
+	defer opentracing.SetGlobalTracer(oldTracer)
+
+	type testCase struct {
+		ctx          context.Context
+		expectParent bool
+	}
+	var testCases []testCase
+
+	testCases = append(testCases,
+		testCase{
+			ctx:          nil,
+			expectParent: false,
+		},
+		testCase{
+			ctx:          context.Background(),
+			expectParent: false,
+		})
+
+	parentSpan := opentracing.StartSpan("parent operation name")
+	testCases = append(testCases, testCase{
+		ctx:          opentracing.ContextWithSpan(context.Background(), parentSpan),
+		expectParent: true,
+	})
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+
+			span, ctx := StartSpanFromContext(tc.ctx)
+			if ctx == nil {
+				t.Error("never expect non-nil ctx")
+			}
+			if span == nil {
+				t.Error("never expect non-nil Span")
+			}
+			foundParent := span.Context().(jaeger.SpanContext).ParentID() != 0
+			if tc.expectParent != foundParent {
+				t.Errorf("parent: expect %v got %v", tc.expectParent, foundParent)
+			}
+			if ctx == tc.ctx {
+				t.Errorf("always expect fresh context")
+			}
+		})
+	}
+}
+
 /*
-BenchmarkStartSpanFromContext-8              	 1000000	      1086 ns/op
-BenchmarkOpentracingStartSpanFromContext-8   	20000000	        73.2 ns/op
+BenchmarkLocal_StartSpanFromContext-8                         1000000    1262 ns/op    376 B/op    6 allocs/op
+BenchmarkLocal_StartSpanFromContext_runtimeCaller-8           3000000     526 ns/op
+BenchmarkLocal_StartSpanFromContext_runtimeCallersFrames-8   10000000     237 ns/op
+BenchmarkOpentracing_StartSpanFromContext-8                  10000000     157 ns/op     96 B/op    3 allocs/op
+BenchmarkOpentracing_StartSpan_root-8                       200000000    7.72 ns/op      0 B/op    0 allocs/op
+BenchmarkOpentracing_StartSpan_child-8                       20000000    70.5 ns/op     48 B/op    2 allocs/op
 */
 
-func BenchmarkStartSpanFromContext(b *testing.B) {
-	// Using noop tracer (default).
-	withRuntimeOverhead := func(ctx context.Context) {
-		span, _ := StartSpanFromContext(ctx)
-		span.Finish()
-	}
+func BenchmarkLocal_StartSpanFromContext(b *testing.B) {
+	b.ReportAllocs()
+
+	parentSpan := opentracing.StartSpan("parent operation name")
+	ctx := opentracing.ContextWithSpan(context.Background(), parentSpan)
 
 	for n := 0; n < b.N; n++ {
-		ctx := context.Background()
-		withRuntimeOverhead(ctx)
+		StartSpanFromContext(ctx)
 	}
 }
 
-func BenchmarkOpentracingStartSpanFromContext(b *testing.B) {
-	// Using noop tracer (default).
-	withStaticOperationName := func(ctx context.Context) {
-		span, _ := opentracing.StartSpanFromContext(ctx, "operation name")
-		span.Finish()
+func BenchmarkLocal_StartSpanFromContext_runtimeCaller(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, _, _, _ = runtime.Caller(1)
+	}
+}
+
+func BenchmarkLocal_StartSpanFromContext_runtimeCallersFrames(b *testing.B) {
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		b.Fatal("runtime.Caller failed")
 	}
 
 	for n := 0; n < b.N; n++ {
-		ctx := context.Background()
-		withStaticOperationName(ctx)
+		_, _ = runtime.CallersFrames([]uintptr{pc}).Next()
 	}
 }
+
+func BenchmarkOpentracing_StartSpanFromContext(b *testing.B) {
+	b.ReportAllocs()
+
+	parentSpan := opentracing.StartSpan("parent operation name")
+	ctx := opentracing.ContextWithSpan(context.Background(), parentSpan)
+
+	for n := 0; n < b.N; n++ {
+		_, _ = opentracing.StartSpanFromContext(ctx, "operation name")
+	}
+}
+
+func BenchmarkOpentracing_StartSpan_root(b *testing.B) {
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		_ = opentracing.StartSpan("operation name")
+	}
+}
+
+func BenchmarkOpentracing_StartSpan_child(b *testing.B) {
+	b.ReportAllocs()
+
+	parentSpan := opentracing.StartSpan("parent operation name")
+
+	for n := 0; n < b.N; n++ {
+		_ = opentracing.StartSpan("operation name", opentracing.ChildOf(parentSpan.Context()))
+	}
+}
+
+// TODO test nil and other context problems with StartSpanFromContext.

--- a/kit/tracing/tracing_test.go
+++ b/kit/tracing/tracing_test.go
@@ -1,0 +1,38 @@
+package tracing
+
+import (
+	"context"
+	"github.com/opentracing/opentracing-go"
+	"testing"
+)
+
+/*
+BenchmarkStartSpanFromContext-8              	 1000000	      1086 ns/op
+BenchmarkOpentracingStartSpanFromContext-8   	20000000	        73.2 ns/op
+*/
+
+func BenchmarkStartSpanFromContext(b *testing.B) {
+	// Using noop tracer (default).
+	withRuntimeOverhead := func(ctx context.Context) {
+		span, _ := StartSpanFromContext(ctx)
+		span.Finish()
+	}
+
+	for n := 0; n < b.N; n++ {
+		ctx := context.Background()
+		withRuntimeOverhead(ctx)
+	}
+}
+
+func BenchmarkOpentracingStartSpanFromContext(b *testing.B) {
+	// Using noop tracer (default).
+	withStaticOperationName := func(ctx context.Context) {
+		span, _ := opentracing.StartSpanFromContext(ctx, "operation name")
+		span.Finish()
+	}
+
+	for n := 0; n < b.N; n++ {
+		ctx := context.Background()
+		withStaticOperationName(ctx)
+	}
+}

--- a/kit/tracing/tracing_test.go
+++ b/kit/tracing/tracing_test.go
@@ -3,12 +3,12 @@ package tracing
 import (
 	"context"
 	"fmt"
-	"github.com/uber/jaeger-client-go"
 	"net/http"
 	"runtime"
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
 )
 
 func TestInjectAndExtractHTTPRequest(t *testing.T) {
@@ -162,5 +162,3 @@ func BenchmarkOpentracing_StartSpan_child(b *testing.B) {
 		_ = opentracing.StartSpan("operation name", opentracing.ChildOf(parentSpan.Context()))
 	}
 }
-
-// TODO test nil and other context problems with StartSpanFromContext.

--- a/kit/tracing/tracing_test.go
+++ b/kit/tracing/tracing_test.go
@@ -2,8 +2,9 @@ package tracing
 
 import (
 	"context"
-	"github.com/opentracing/opentracing-go"
 	"testing"
+
+	"github.com/opentracing/opentracing-go"
 )
 
 /*

--- a/kv/auth.go
+++ b/kv/auth.go
@@ -28,7 +28,7 @@ func (s *Service) initializeAuths(ctx context.Context, tx Tx) error {
 // FindAuthorizationByID retrieves a authorization by id.
 func (s *Service) FindAuthorizationByID(ctx context.Context, id influxdb.ID) (*influxdb.Authorization, error) {
 	var a *influxdb.Authorization
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		auth, err := s.findAuthorizationByID(ctx, tx, id)
 		if err != nil {
 			return err
@@ -85,7 +85,7 @@ func (s *Service) findAuthorizationByID(ctx context.Context, tx Tx, id influxdb.
 // FindAuthorizationByToken returns a authorization by token for a particular authorization.
 func (s *Service) FindAuthorizationByToken(ctx context.Context, n string) (*influxdb.Authorization, error) {
 	var a *influxdb.Authorization
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		auth, err := s.findAuthorizationByToken(ctx, tx, n)
 		if err != nil {
 			return err
@@ -176,7 +176,7 @@ func (s *Service) FindAuthorizations(ctx context.Context, filter influxdb.Author
 	}
 
 	as := []*influxdb.Authorization{}
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		auths, err := s.findAuthorizations(ctx, tx, filter)
 		if err != nil {
 			return err
@@ -221,7 +221,7 @@ func (s *Service) findAuthorizations(ctx context.Context, tx Tx, f influxdb.Auth
 
 // CreateAuthorization creates a influxdb authorization and sets b.ID, and b.UserID if not provided.
 func (s *Service) CreateAuthorization(ctx context.Context, a *influxdb.Authorization) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.createAuthorization(ctx, tx, a)
 	})
 }
@@ -266,7 +266,7 @@ func (s *Service) createAuthorization(ctx context.Context, tx Tx, a *influxdb.Au
 
 // PutAuthorization will put a authorization without setting an ID.
 func (s *Service) PutAuthorization(ctx context.Context, a *influxdb.Authorization) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.putAuthorization(ctx, tx, a)
 	})
 }
@@ -371,7 +371,7 @@ func (s *Service) forEachAuthorization(ctx context.Context, tx Tx, fn func(*infl
 
 // DeleteAuthorization deletes a authorization and prunes it from the index.
 func (s *Service) DeleteAuthorization(ctx context.Context, id influxdb.ID) error {
-	return s.kv.Update(func(tx Tx) (err error) {
+	return s.kv.Update(ctx, func(tx Tx) (err error) {
 		return s.deleteAuthorization(ctx, tx, id)
 	})
 }
@@ -415,7 +415,7 @@ func (s *Service) deleteAuthorization(ctx context.Context, tx Tx, id influxdb.ID
 // SetAuthorizationStatus updates the status of the authorization. Useful
 // for setting an authorization to inactive or active.
 func (s *Service) SetAuthorizationStatus(ctx context.Context, id influxdb.ID, status influxdb.Status) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.updateAuthorization(ctx, tx, id, status)
 	})
 }

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
-
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var (
@@ -49,7 +48,7 @@ func (s *Service) bucketsIndexBucket(tx Tx) (Bucket, error) {
 }
 
 func (s *Service) setOrganizationOnBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.setOrganizationOnBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	o, err := s.findOrganizationByID(ctx, tx, b.OrganizationID)
@@ -64,7 +63,7 @@ func (s *Service) setOrganizationOnBucket(ctx context.Context, tx Tx, b *influxd
 
 // FindBucketByID retrieves a bucket by id.
 func (s *Service) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.FindBucketByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b *influxdb.Bucket
@@ -88,7 +87,7 @@ func (s *Service) FindBucketByID(ctx context.Context, id influxdb.ID) (*influxdb
 }
 
 func (s *Service) findBucketByID(ctx context.Context, tx Tx, id influxdb.ID) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.findBucketByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b influxdb.Bucket
@@ -136,7 +135,7 @@ func (s *Service) findBucketByID(ctx context.Context, tx Tx, id influxdb.ID) (*i
 // FindBucketByName returns a bucket by name for a particular organization.
 // TODO: have method for finding bucket using organization name and bucket name.
 func (s *Service) FindBucketByName(ctx context.Context, orgID influxdb.ID, n string) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.FindBucketByName")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b *influxdb.Bucket
@@ -156,7 +155,7 @@ func (s *Service) FindBucketByName(ctx context.Context, orgID influxdb.ID, n str
 }
 
 func (s *Service) findBucketByName(ctx context.Context, tx Tx, orgID influxdb.ID, n string) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.findBucketByName")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	b := &influxdb.Bucket{
@@ -201,7 +200,7 @@ func (s *Service) findBucketByName(ctx context.Context, tx Tx, orgID influxdb.ID
 // Filters using ID, or OrganizationID and bucket Name should be efficient.
 // Other filters will do a linear scan across buckets until it finds a match.
 func (s *Service) FindBucket(ctx context.Context, filter influxdb.BucketFilter) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.FindBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b *influxdb.Bucket
@@ -288,7 +287,7 @@ func filterBucketsFn(filter influxdb.BucketFilter) func(b *influxdb.Bucket) bool
 // Filters using ID, or OrganizationID and bucket Name should be efficient.
 // Other filters will do a linear scan across all buckets searching for a match.
 func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter, opts ...influxdb.FindOptions) ([]*influxdb.Bucket, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.FindBuckets")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if filter.ID != nil {
@@ -327,7 +326,7 @@ func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter,
 }
 
 func (s *Service) findBuckets(ctx context.Context, tx Tx, filter influxdb.BucketFilter, opts ...influxdb.FindOptions) ([]*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.findBuckets")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	bs := []*influxdb.Bucket{}
@@ -376,7 +375,7 @@ func (s *Service) findBuckets(ctx context.Context, tx Tx, filter influxdb.Bucket
 
 // CreateBucket creates a influxdb bucket and sets b.ID.
 func (s *Service) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.CreateBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	return s.kv.Update(ctx, func(tx Tx) error {
@@ -386,7 +385,7 @@ func (s *Service) CreateBucket(ctx context.Context, b *influxdb.Bucket) error {
 
 func (s *Service) createBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
 	if b.OrganizationID.Valid() {
-		span, ctx := opentracing.StartSpanFromContext(ctx, "Service.createBucket")
+		span, ctx := tracing.StartSpanFromContext(ctx)
 		defer span.Finish()
 
 		_, pe := s.findOrganizationByID(ctx, tx, b.OrganizationID)
@@ -442,7 +441,7 @@ func (s *Service) PutBucket(ctx context.Context, b *influxdb.Bucket) error {
 }
 
 func (s *Service) createBucketUserResourceMappings(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.createBucketUserResourceMappings")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	ms, err := s.findUserResourceMappings(ctx, tx, influxdb.UserResourceMappingFilter{
@@ -472,7 +471,7 @@ func (s *Service) createBucketUserResourceMappings(ctx context.Context, tx Tx, b
 }
 
 func (s *Service) putBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.putBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	b.Organization = ""
@@ -531,7 +530,7 @@ func bucketIndexKey(b *influxdb.Bucket) ([]byte, error) {
 
 // forEachBucket will iterate through all buckets while fn returns true.
 func (s *Service) forEachBucket(ctx context.Context, tx Tx, descending bool, fn func(*influxdb.Bucket) bool) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.forEachBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	bkt, err := s.bucketsBucket(tx)
@@ -574,7 +573,7 @@ func (s *Service) forEachBucket(ctx context.Context, tx Tx, descending bool, fn 
 }
 
 func (s *Service) uniqueBucketName(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.uniqueBucketName")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	key, err := bucketIndexKey(b)
@@ -593,7 +592,7 @@ func (s *Service) uniqueBucketName(ctx context.Context, tx Tx, b *influxdb.Bucke
 
 // UpdateBucket updates a bucket according the parameters set on upd.
 func (s *Service) UpdateBucket(ctx context.Context, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.UpdateBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var b *influxdb.Bucket
@@ -610,7 +609,7 @@ func (s *Service) UpdateBucket(ctx context.Context, id influxdb.ID, upd influxdb
 }
 
 func (s *Service) updateBucket(ctx context.Context, tx Tx, id influxdb.ID, upd influxdb.BucketUpdate) (*influxdb.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.updateBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	b, err := s.findBucketByID(ctx, tx, id)

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"time"
+
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"

--- a/kv/dashboard.go
+++ b/kv/dashboard.go
@@ -6,9 +6,10 @@ import (
 	"encoding/json"
 	"time"
 
+	"go.uber.org/zap"
+
 	influxdb "github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
-	"go.uber.org/zap"
 )
 
 var (

--- a/kv/kvlog.go
+++ b/kv/kvlog.go
@@ -178,7 +178,7 @@ func (s *Service) updateKeyValueLogBounds(ctx context.Context, tx Tx, k []byte, 
 
 // ForEachLogEntry retrieves the keyValue log for a resource type ID combination. KeyValues may be returned in ascending and descending order.
 func (s *Service) ForEachLogEntry(ctx context.Context, k []byte, opts platform.FindOptions, fn func([]byte, time.Time) error) error {
-	return s.kv.View(func(tx Tx) error {
+	return s.kv.View(ctx, func(tx Tx) error {
 		return s.forEachLogEntry(ctx, tx, k, opts, fn)
 	})
 }
@@ -274,7 +274,7 @@ func (s *Service) forEachLogEntry(ctx context.Context, tx Tx, k []byte, opts pla
 
 // AddLogEntry logs an keyValue for a particular resource type ID pairing.
 func (s *Service) AddLogEntry(ctx context.Context, k, v []byte, t time.Time) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.addLogEntry(ctx, tx, k, v, t)
 	})
 }
@@ -337,7 +337,7 @@ func (s *Service) FirstLogEntry(ctx context.Context, k []byte) ([]byte, time.Tim
 	var v []byte
 	var t time.Time
 
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		val, ts, err := s.firstLogEntry(ctx, tx, k)
 		if err != nil {
 			return err
@@ -360,7 +360,7 @@ func (s *Service) LastLogEntry(ctx context.Context, k []byte) ([]byte, time.Time
 	var v []byte
 	var t time.Time
 
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		val, ts, err := s.lastLogEntry(ctx, tx, k)
 		if err != nil {
 			return err

--- a/kv/label.go
+++ b/kv/label.go
@@ -29,7 +29,7 @@ func (s *Service) initializeLabels(ctx context.Context, tx Tx) error {
 func (s *Service) FindLabelByID(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
 	var l *influxdb.Label
 
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		label, pe := s.findLabelByID(ctx, tx, id)
 		if pe != nil {
 			return pe
@@ -91,7 +91,7 @@ func filterLabelsFn(filter influxdb.LabelFilter) func(l *influxdb.Label) bool {
 // FindLabels returns a list of labels that match a filter.
 func (s *Service) FindLabels(ctx context.Context, filter influxdb.LabelFilter, opt ...influxdb.FindOptions) ([]*influxdb.Label, error) {
 	ls := []*influxdb.Label{}
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		labels, err := s.findLabels(ctx, tx, filter)
 		if err != nil {
 			return err
@@ -179,7 +179,7 @@ func (s *Service) findResourceLabels(ctx context.Context, tx Tx, filter influxdb
 
 func (s *Service) FindResourceLabels(ctx context.Context, filter influxdb.LabelMappingFilter) ([]*influxdb.Label, error) {
 	ls := []*influxdb.Label{}
-	if err := s.kv.View(func(tx Tx) error {
+	if err := s.kv.View(ctx, func(tx Tx) error {
 		return s.findResourceLabels(ctx, tx, filter, &ls)
 	}); err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func (s *Service) FindResourceLabels(ctx context.Context, filter influxdb.LabelM
 
 // CreateLabelMapping creates a new mapping between a resource and a label.
 func (s *Service) CreateLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.createLabelMapping(ctx, tx, m)
 	})
 }
@@ -210,7 +210,7 @@ func (s *Service) createLabelMapping(ctx context.Context, tx Tx, m *influxdb.Lab
 
 // DeleteLabelMapping deletes a label mapping.
 func (s *Service) DeleteLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
-	err := s.kv.Update(func(tx Tx) error {
+	err := s.kv.Update(ctx, func(tx Tx) error {
 		return s.deleteLabelMapping(ctx, tx, m)
 	})
 	if err != nil {
@@ -245,7 +245,7 @@ func (s *Service) deleteLabelMapping(ctx context.Context, tx Tx, m *influxdb.Lab
 
 // CreateLabel creates a new label.
 func (s *Service) CreateLabel(ctx context.Context, l *influxdb.Label) error {
-	err := s.kv.Update(func(tx Tx) error {
+	err := s.kv.Update(ctx, func(tx Tx) error {
 		l.ID = s.IDGenerator.ID()
 
 		return s.putLabel(ctx, tx, l)
@@ -261,7 +261,7 @@ func (s *Service) CreateLabel(ctx context.Context, l *influxdb.Label) error {
 
 // PutLabel creates a label from the provided struct, without generating a new ID.
 func (s *Service) PutLabel(ctx context.Context, l *influxdb.Label) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		var err error
 		pe := s.putLabel(ctx, tx, l)
 		if pe != nil {
@@ -322,7 +322,7 @@ func (s *Service) forEachLabel(ctx context.Context, tx Tx, fn func(*influxdb.Lab
 // UpdateLabel updates a label.
 func (s *Service) UpdateLabel(ctx context.Context, id influxdb.ID, upd influxdb.LabelUpdate) (*influxdb.Label, error) {
 	var label *influxdb.Label
-	err := s.kv.Update(func(tx Tx) error {
+	err := s.kv.Update(ctx, func(tx Tx) error {
 		labelResponse, pe := s.updateLabel(ctx, tx, id, upd)
 		if pe != nil {
 			return &influxdb.Error{
@@ -402,7 +402,7 @@ func (s *Service) putLabel(ctx context.Context, tx Tx, l *influxdb.Label) error 
 
 // PutLabelMapping writes a label mapping to boltdb
 func (s *Service) PutLabelMapping(ctx context.Context, m *influxdb.LabelMapping) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		var err error
 		pe := s.putLabelMapping(ctx, tx, m)
 		if pe != nil {
@@ -443,7 +443,7 @@ func (s *Service) putLabelMapping(ctx context.Context, tx Tx, m *influxdb.LabelM
 
 // DeleteLabel deletes a label.
 func (s *Service) DeleteLabel(ctx context.Context, id influxdb.ID) error {
-	err := s.kv.Update(func(tx Tx) error {
+	err := s.kv.Update(ctx, func(tx Tx) error {
 		return s.deleteLabel(ctx, tx, id)
 	})
 	if err != nil {

--- a/kv/onboarding.go
+++ b/kv/onboarding.go
@@ -25,7 +25,7 @@ func (s *Service) initializeOnboarding(ctx context.Context, tx Tx) error {
 // false means that the onboarding has been completed.
 func (s *Service) IsOnboarding(ctx context.Context) (bool, error) {
 	notSetup := true
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		bucket, err := tx.Bucket(onboardingBucket)
 		if err != nil {
 			return err
@@ -54,7 +54,7 @@ func (s *Service) IsOnboarding(ctx context.Context) (bool, error) {
 // true means that onboarding is NOT needed.
 // false means that onboarding is needed.
 func (s *Service) PutOnboardingStatus(ctx context.Context, hasBeenOnboarded bool) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.putOnboardingStatus(ctx, tx, hasBeenOnboarded)
 	})
 }
@@ -129,7 +129,7 @@ func (s *Service) Generate(ctx context.Context, req *influxdb.OnboardingRequest)
 		Token:       req.Token,
 	}
 
-	err = s.kv.Update(func(tx Tx) error {
+	err = s.kv.Update(ctx, func(tx Tx) error {
 		if err := s.createUser(ctx, tx, u); err != nil {
 			return err
 		}

--- a/kv/org.go
+++ b/kv/org.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var (
@@ -53,7 +53,7 @@ func (s *Service) FindOrganizationByID(ctx context.Context, id influxdb.ID) (*in
 }
 
 func (s *Service) findOrganizationByID(ctx context.Context, tx Tx, id influxdb.ID) (*influxdb.Organization, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "Service.findOrganizationByID")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	encodedID, err := id.Encode()
@@ -93,7 +93,7 @@ func (s *Service) findOrganizationByID(ctx context.Context, tx Tx, id influxdb.I
 
 // FindOrganizationByName returns a organization by name for a particular organization.
 func (s *Service) FindOrganizationByName(ctx context.Context, n string) (*influxdb.Organization, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.FindOrganizationByName")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var o *influxdb.Organization
@@ -111,7 +111,7 @@ func (s *Service) FindOrganizationByName(ctx context.Context, n string) (*influx
 }
 
 func (s *Service) findOrganizationByName(ctx context.Context, tx Tx, n string) (*influxdb.Organization, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.findOrganizationByName")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	b, err := tx.Bucket(organizationIndex)

--- a/kv/org.go
+++ b/kv/org.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"go.uber.org/zap"
 
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
-	"go.uber.org/zap"
 )
 
 var (

--- a/kv/passwords.go
+++ b/kv/passwords.go
@@ -72,7 +72,7 @@ func (s *Service) initializePasswords(ctx context.Context, tx Tx) error {
 // CompareAndSetPassword checks the password and if they match
 // updates to the new password.
 func (s *Service) CompareAndSetPassword(ctx context.Context, name string, old string, new string) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		if err := s.comparePassword(ctx, tx, name, old); err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func (s *Service) CompareAndSetPassword(ctx context.Context, name string, old st
 
 // SetPassword overrides the password of a known user.
 func (s *Service) SetPassword(ctx context.Context, name string, password string) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.setPassword(ctx, tx, name, password)
 	})
 }
@@ -90,7 +90,7 @@ func (s *Service) SetPassword(ctx context.Context, name string, password string)
 // ComparePassword checks if the password matches the password recorded.
 // Passwords that do not match return errors.
 func (s *Service) ComparePassword(ctx context.Context, name string, password string) error {
-	return s.kv.View(func(tx Tx) error {
+	return s.kv.View(ctx, func(tx Tx) error {
 		return s.comparePassword(ctx, tx, name, password)
 	})
 }

--- a/kv/passwords.go
+++ b/kv/passwords.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/influxdata/influxdb"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/influxdata/influxdb"
 )
 
 // MinPasswordLength is the shortest password we allow into the system.

--- a/kv/scrapers.go
+++ b/kv/scrapers.go
@@ -98,7 +98,7 @@ func (s *Service) scrapersBucket(tx Tx) (Bucket, error) {
 // ListTargets will list all scrape targets.
 func (s *Service) ListTargets(ctx context.Context) ([]influxdb.ScraperTarget, error) {
 	targets := []influxdb.ScraperTarget{}
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		var err error
 		targets, err = s.listTargets(ctx, tx)
 		return err
@@ -130,7 +130,7 @@ func (s *Service) listTargets(ctx context.Context, tx Tx) ([]influxdb.ScraperTar
 
 // AddTarget add a new scraper target into storage.
 func (s *Service) AddTarget(ctx context.Context, target *influxdb.ScraperTarget, userID influxdb.ID) (err error) {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.addTarget(ctx, tx, target, userID)
 	})
 }
@@ -160,7 +160,7 @@ func (s *Service) addTarget(ctx context.Context, tx Tx, target *influxdb.Scraper
 
 // RemoveTarget removes a scraper target from the bucket.
 func (s *Service) RemoveTarget(ctx context.Context, id influxdb.ID) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.removeTarget(ctx, tx, id)
 	})
 }
@@ -201,7 +201,7 @@ func (s *Service) removeTarget(ctx context.Context, tx Tx, id influxdb.ID) error
 // UpdateTarget updates a scraper target.
 func (s *Service) UpdateTarget(ctx context.Context, update *influxdb.ScraperTarget, userID influxdb.ID) (*influxdb.ScraperTarget, error) {
 	var target *influxdb.ScraperTarget
-	err := s.kv.Update(func(tx Tx) error {
+	err := s.kv.Update(ctx, func(tx Tx) error {
 		var err error
 		target, err = s.updateTarget(ctx, tx, update, userID)
 		return err
@@ -234,7 +234,7 @@ func (s *Service) updateTarget(ctx context.Context, tx Tx, update *influxdb.Scra
 // GetTargetByID retrieves a scraper target by id.
 func (s *Service) GetTargetByID(ctx context.Context, id influxdb.ID) (*influxdb.ScraperTarget, error) {
 	var target *influxdb.ScraperTarget
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		var err error
 		target, err = s.findTargetByID(ctx, tx, id)
 		return err
@@ -272,7 +272,7 @@ func (s *Service) findTargetByID(ctx context.Context, tx Tx, id influxdb.ID) (*i
 
 // PutTarget will put a scraper target without setting an ID.
 func (s *Service) PutTarget(ctx context.Context, target *influxdb.ScraperTarget) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.putTarget(ctx, tx, target)
 	})
 }

--- a/kv/secret.go
+++ b/kv/secret.go
@@ -25,7 +25,7 @@ func (s *Service) initializeSecrets(ctx context.Context, tx Tx) error {
 // LoadSecret retrieves the secret value v found at key k for organization orgID.
 func (s *Service) LoadSecret(ctx context.Context, orgID influxdb.ID, k string) (string, error) {
 	var v string
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		val, err := s.loadSecret(ctx, tx, orgID, k)
 		if err != nil {
 			return err
@@ -76,7 +76,7 @@ func (s *Service) loadSecret(ctx context.Context, tx Tx, orgID influxdb.ID, k st
 // GetSecretKeys retrieves all secret keys that are stored for the organization orgID.
 func (s *Service) GetSecretKeys(ctx context.Context, orgID influxdb.ID) ([]string, error) {
 	var vs []string
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		vals, err := s.getSecretKeys(ctx, tx, orgID)
 		if err != nil {
 			return err
@@ -151,7 +151,7 @@ func (s *Service) getSecretKeys(ctx context.Context, tx Tx, orgID influxdb.ID) (
 
 // PutSecret stores the secret pair (k,v) for the organization orgID.
 func (s *Service) PutSecret(ctx context.Context, orgID influxdb.ID, k, v string) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.putSecret(ctx, tx, orgID, k, v)
 	})
 }
@@ -223,7 +223,7 @@ func encodeSecretValue(v string) []byte {
 
 // PutSecrets puts all provided secrets and overwrites any previous values.
 func (s *Service) PutSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		keys, err := s.getSecretKeys(ctx, tx, orgID)
 		if err != nil {
 			return err
@@ -246,7 +246,7 @@ func (s *Service) PutSecrets(ctx context.Context, orgID influxdb.ID, m map[strin
 
 // PatchSecrets patches all provided secrets and updates any previous values.
 func (s *Service) PatchSecrets(ctx context.Context, orgID influxdb.ID, m map[string]string) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		for k, v := range m {
 			if err := s.putSecret(ctx, tx, orgID, k, v); err != nil {
 				return err
@@ -258,7 +258,7 @@ func (s *Service) PatchSecrets(ctx context.Context, orgID influxdb.ID, m map[str
 
 // DeleteSecret removes secrets from the secret store.
 func (s *Service) DeleteSecret(ctx context.Context, orgID influxdb.ID, ks ...string) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		for _, k := range ks {
 			if err := s.deleteSecret(ctx, tx, orgID, k); err != nil {
 				return err

--- a/kv/service.go
+++ b/kv/service.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/rand"
 	"github.com/influxdata/influxdb/snowflake"
-	"go.uber.org/zap"
 )
 
 var (

--- a/kv/service.go
+++ b/kv/service.go
@@ -43,7 +43,7 @@ func NewService(kv Store) *Service {
 
 // Initialize creates Buckets needed.
 func (s *Service) Initialize(ctx context.Context) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		if err := s.initializeAuths(ctx, tx); err != nil {
 			return err
 		}

--- a/kv/session.go
+++ b/kv/session.go
@@ -28,7 +28,7 @@ func (s *Service) RenewSession(ctx context.Context, session *influxdb.Session, n
 			Msg: "session is nil",
 		}
 	}
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		session.ExpiresAt = newExpiration
 		if err := s.putSession(ctx, tx, session); err != nil {
 			return &influxdb.Error{
@@ -42,7 +42,7 @@ func (s *Service) RenewSession(ctx context.Context, session *influxdb.Session, n
 // FindSession retrieves the session found at the provided key.
 func (s *Service) FindSession(ctx context.Context, key string) (*influxdb.Session, error) {
 	var sess *influxdb.Session
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		s, err := s.findSession(ctx, tx, key)
 		if err != nil {
 			return err
@@ -119,7 +119,7 @@ func (s *Service) findSession(ctx context.Context, tx Tx, key string) (*influxdb
 
 // PutSession puts the session at key.
 func (s *Service) PutSession(ctx context.Context, sn *influxdb.Session) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		if err := s.putSession(ctx, tx, sn); err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func (s *Service) putSession(ctx context.Context, tx Tx, sn *influxdb.Session) e
 
 // ExpireSession expires the session at the provided key.
 func (s *Service) ExpireSession(ctx context.Context, key string) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		sn, err := s.findSession(ctx, tx, key)
 		if err != nil {
 			return err
@@ -168,7 +168,7 @@ func (s *Service) ExpireSession(ctx context.Context, key string) error {
 // CreateSession creates a session for a user with the users maximal privileges.
 func (s *Service) CreateSession(ctx context.Context, user string) (*influxdb.Session, error) {
 	var sess *influxdb.Session
-	err := s.kv.Update(func(tx Tx) error {
+	err := s.kv.Update(ctx, func(tx Tx) error {
 		sn, err := s.createSession(ctx, tx, user)
 		if err != nil {
 			return err

--- a/kv/store.go
+++ b/kv/store.go
@@ -23,9 +23,9 @@ func IsNotFound(err error) bool {
 type Store interface {
 	// View opens up a transaction that will not write to any data. Implementing interfaces
 	// should take care to ensure that all view transactions do not mutate any data.
-	View(func(Tx) error) error
+	View(context.Context, func(Tx) error) error
 	// Update opens up a transaction that will mutate data.
-	Update(func(Tx) error) error
+	Update(context.Context, func(Tx) error) error
 }
 
 // Tx is a transaction in the store.
@@ -41,6 +41,7 @@ type Tx interface {
 // Bucket is the abstraction used to perform get/put/delete/get-many operations
 // in a key value store.
 type Bucket interface {
+	// TODO context?
 	// Get returns a key within this bucket. Errors if key does not exist.
 	Get(key []byte) ([]byte, error)
 	// Cursor returns a cursor at the beginning of this bucket.

--- a/kv/telegraf.go
+++ b/kv/telegraf.go
@@ -95,7 +95,7 @@ func (s *Service) FindTelegrafConfigByID(ctx context.Context, id influxdb.ID) (*
 		err error
 	)
 
-	err = s.kv.View(func(tx Tx) error {
+	err = s.kv.View(ctx, func(tx Tx) error {
 		tc, err = s.findTelegrafConfigByID(ctx, tx, id)
 		return err
 	})
@@ -128,7 +128,7 @@ func (s *Service) findTelegrafConfigByID(ctx context.Context, tx Tx, id influxdb
 // FindTelegrafConfigs returns a list of telegraf configs that match filter and the total count of matching telegraf configs.
 // Additional options provide pagination & sorting.
 func (s *Service) FindTelegrafConfigs(ctx context.Context, filter influxdb.TelegrafConfigFilter, opt ...influxdb.FindOptions) (tcs []*influxdb.TelegrafConfig, n int, err error) {
-	err = s.kv.View(func(tx Tx) error {
+	err = s.kv.View(ctx, func(tx Tx) error {
 		tcs, n, err = s.findTelegrafConfigs(ctx, tx, filter)
 		return err
 	})
@@ -167,7 +167,7 @@ func (s *Service) findTelegrafConfigs(ctx context.Context, tx Tx, filter influxd
 
 // PutTelegrafConfig put a telegraf config to storage.
 func (s *Service) PutTelegrafConfig(ctx context.Context, tc *influxdb.TelegrafConfig) error {
-	return s.kv.Update(func(tx Tx) (err error) {
+	return s.kv.Update(ctx, func(tx Tx) (err error) {
 		return s.putTelegrafConfig(ctx, tx, tc)
 	})
 }
@@ -200,7 +200,7 @@ func (s *Service) putTelegrafConfig(ctx context.Context, tx Tx, tc *influxdb.Tel
 
 // CreateTelegrafConfig creates a new telegraf config and sets b.ID with the new identifier.
 func (s *Service) CreateTelegrafConfig(ctx context.Context, tc *influxdb.TelegrafConfig, userID influxdb.ID) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.createTelegrafConfig(ctx, tx, tc, userID)
 	})
 }
@@ -224,7 +224,7 @@ func (s *Service) createTelegrafConfig(ctx context.Context, tx Tx, tc *influxdb.
 // Returns the new telegraf config after update.
 func (s *Service) UpdateTelegrafConfig(ctx context.Context, id influxdb.ID, tc *influxdb.TelegrafConfig, userID influxdb.ID) (*influxdb.TelegrafConfig, error) {
 	var err error
-	err = s.kv.Update(func(tx Tx) error {
+	err = s.kv.Update(ctx, func(tx Tx) error {
 		tc, err = s.updateTelegrafConfig(ctx, tx, id, tc, userID)
 		return err
 	})
@@ -246,7 +246,7 @@ func (s *Service) updateTelegrafConfig(ctx context.Context, tx Tx, id influxdb.I
 
 // DeleteTelegrafConfig removes a telegraf config by ID.
 func (s *Service) DeleteTelegrafConfig(ctx context.Context, id influxdb.ID) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.deleteTelegrafConfig(ctx, tx, id)
 	})
 }

--- a/kv/urm.go
+++ b/kv/urm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/influxdb"

--- a/kv/urm.go
+++ b/kv/urm.go
@@ -5,10 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/opentracing/opentracing-go"
-
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var (
@@ -132,7 +131,7 @@ func (s *Service) CreateUserResourceMapping(ctx context.Context, m *influxdb.Use
 }
 
 func (s *Service) createUserResourceMapping(ctx context.Context, tx Tx, m *influxdb.UserResourceMapping) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.createUserResourceMapping")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if err := s.uniqueUserResourceMapping(ctx, tx, m); err != nil {
@@ -167,7 +166,7 @@ func (s *Service) createUserResourceMapping(ctx context.Context, tx Tx, m *influ
 
 // This method creates the user/resource mappings for resources that belong to an organization.
 func (s *Service) createOrgDependentMappings(ctx context.Context, tx Tx, m *influxdb.UserResourceMapping) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.createOrgDependentMappings")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	bf := influxdb.BucketFilter{OrganizationID: &m.ResourceID}

--- a/kv/user.go
+++ b/kv/user.go
@@ -52,7 +52,7 @@ func (s *Service) userIndexBucket(tx Tx) (Bucket, error) {
 func (s *Service) FindUserByID(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
 	var u *influxdb.User
 
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		usr, err := s.findUserByID(ctx, tx, id)
 		if err != nil {
 			return err
@@ -115,7 +115,7 @@ func MarshalUser(u *influxdb.User) ([]byte, error) {
 func (s *Service) FindUserByName(ctx context.Context, n string) (*influxdb.User, error) {
 	var u *influxdb.User
 
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		usr, err := s.findUserByName(ctx, tx, n)
 		if err != nil {
 			return err
@@ -207,7 +207,7 @@ func (s *Service) FindUsers(ctx context.Context, filter influxdb.UserFilter, opt
 
 	us := []*influxdb.User{}
 	filterFn := filterUsersFn(filter)
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		return s.forEachUser(ctx, tx, func(u *influxdb.User) bool {
 			if filterFn(u) {
 				us = append(us, u)
@@ -225,7 +225,7 @@ func (s *Service) FindUsers(ctx context.Context, filter influxdb.UserFilter, opt
 
 // CreateUser creates a influxdb user and sets b.ID.
 func (s *Service) CreateUser(ctx context.Context, u *influxdb.User) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.createUser(ctx, tx, u)
 	})
 }
@@ -245,7 +245,7 @@ func (s *Service) createUser(ctx context.Context, tx Tx, u *influxdb.User) error
 
 // PutUser will put a user without setting an ID.
 func (s *Service) PutUser(ctx context.Context, u *influxdb.User) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.putUser(ctx, tx, u)
 	})
 }
@@ -325,7 +325,7 @@ func (s *Service) uniqueUserName(ctx context.Context, tx Tx, u *influxdb.User) e
 // UpdateUser updates a user according the parameters set on upd.
 func (s *Service) UpdateUser(ctx context.Context, id influxdb.ID, upd influxdb.UserUpdate) (*influxdb.User, error) {
 	var u *influxdb.User
-	err := s.kv.Update(func(tx Tx) error {
+	err := s.kv.Update(ctx, func(tx Tx) error {
 		usr, err := s.updateUser(ctx, tx, id, upd)
 		if err != nil {
 			return err
@@ -383,7 +383,7 @@ func (s *Service) removeUserFromIndex(ctx context.Context, tx Tx, id influxdb.ID
 
 // DeleteUser deletes a user and prunes it from the index.
 func (s *Service) DeleteUser(ctx context.Context, id influxdb.ID) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		return s.deleteUser(ctx, tx, id)
 	})
 }
@@ -450,7 +450,7 @@ func (s *Service) GetUserOperationLog(ctx context.Context, id influxdb.ID, opts 
 	// TODO(desa): might be worthwhile to allocate a slice of size opts.Limit
 	log := []*influxdb.OperationLogEntry{}
 
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		key, err := encodeUserOperationLogKey(id)
 		if err != nil {
 			return err

--- a/kv/variable.go
+++ b/kv/variable.go
@@ -159,7 +159,7 @@ func (s *Service) forEachVariable(ctx context.Context, tx Tx, fn func(*influxdb.
 func (s *Service) FindVariables(ctx context.Context, filter influxdb.VariableFilter, opt ...influxdb.FindOptions) ([]*influxdb.Variable, error) {
 	// todo(leodido) > handle find options
 	res := []*influxdb.Variable{}
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		variables, err := s.findVariables(ctx, tx, filter)
 		if err != nil && influxdb.ErrorCode(err) != influxdb.ENotFound {
 			return err
@@ -180,7 +180,7 @@ func (s *Service) FindVariables(ctx context.Context, filter influxdb.VariableFil
 // FindVariableByID finds a single variable in the store by its ID
 func (s *Service) FindVariableByID(ctx context.Context, id influxdb.ID) (*influxdb.Variable, error) {
 	var variable *influxdb.Variable
-	err := s.kv.View(func(tx Tx) error {
+	err := s.kv.View(ctx, func(tx Tx) error {
 		m, pe := s.findVariableByID(ctx, tx, id)
 		if pe != nil {
 			return &influxdb.Error{
@@ -236,7 +236,7 @@ func (s *Service) findVariableByID(ctx context.Context, tx Tx, id influxdb.ID) (
 
 // CreateVariable creates a new variable and assigns it an ID
 func (s *Service) CreateVariable(ctx context.Context, variable *influxdb.Variable) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		variable.ID = s.IDGenerator.ID()
 
 		if err := s.putVariableOrgsIndex(ctx, tx, variable); err != nil {
@@ -255,7 +255,7 @@ func (s *Service) CreateVariable(ctx context.Context, variable *influxdb.Variabl
 
 // ReplaceVariable puts a variable in the store
 func (s *Service) ReplaceVariable(ctx context.Context, variable *influxdb.Variable) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		if err := s.putVariableOrgsIndex(ctx, tx, variable); err != nil {
 			return &influxdb.Error{
 				Err: err,
@@ -360,7 +360,7 @@ func (s *Service) putVariable(ctx context.Context, tx Tx, variable *influxdb.Var
 // UpdateVariable updates a single variable in the store with a changeset
 func (s *Service) UpdateVariable(ctx context.Context, id influxdb.ID, update *influxdb.VariableUpdate) (*influxdb.Variable, error) {
 	var variable *influxdb.Variable
-	err := s.kv.Update(func(tx Tx) error {
+	err := s.kv.Update(ctx, func(tx Tx) error {
 		m, pe := s.findVariableByID(ctx, tx, id)
 		if pe != nil {
 			return &influxdb.Error{
@@ -388,7 +388,7 @@ func (s *Service) UpdateVariable(ctx context.Context, id influxdb.ID, update *in
 
 // DeleteVariable removes a single variable from the store by its ID
 func (s *Service) DeleteVariable(ctx context.Context, id influxdb.ID) error {
-	return s.kv.Update(func(tx Tx) error {
+	return s.kv.Update(ctx, func(tx Tx) error {
 		m, pe := s.findVariableByID(ctx, tx, id)
 		if pe != nil {
 			return &influxdb.Error{

--- a/mock/kv.go
+++ b/mock/kv.go
@@ -16,12 +16,12 @@ type Store struct {
 
 // View opens up a transaction that will not write to any data. Implementing interfaces
 // should take care to ensure that all view transactions do not mutate any data.
-func (s *Store) View(fn func(kv.Tx) error) error {
+func (s *Store) View(ctx context.Context, fn func(kv.Tx) error) error {
 	return s.ViewFn(fn)
 }
 
 // Update opens up a transaction that will mutate data.
-func (s *Store) Update(fn func(kv.Tx) error) error {
+func (s *Store) Update(ctx context.Context, fn func(kv.Tx) error) error {
 	return s.UpdateFn(fn)
 }
 

--- a/query/bridges.go
+++ b/query/bridges.go
@@ -8,7 +8,6 @@ import (
 	"github.com/influxdata/flux/csv"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 )
 
 // QueryServiceBridge implements the QueryService interface while consuming the AsyncQueryService interface.
@@ -74,7 +73,7 @@ type ProxyQueryServiceAsyncBridge struct {
 }
 
 func (b ProxyQueryServiceAsyncBridge) Query(ctx context.Context, w io.Writer, req *ProxyRequest) (flux.Statistics, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ProxyQueryServiceBridge.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	q, err := b.AsyncQueryService.Query(ctx, &req.Request)

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -3,6 +3,7 @@ package control
 
 import (
 	"context"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/control"
@@ -28,6 +29,9 @@ func New(config control.Config) *Controller {
 
 // Query satisfies the AsyncQueryService while ensuring the request is propagated on the context.
 func (c *Controller) Query(ctx context.Context, req *query.Request) (flux.Query, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Controller.Query")
+	defer span.Finish()
+
 	// Set the request on the context so platform specific Flux operations can retrieve it later.
 	ctx = query.ContextWithRequest(ctx, req)
 	// Set the org label value for controller metrics

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/control"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 )
 
@@ -30,7 +30,7 @@ func New(config control.Config) *Controller {
 
 // Query satisfies the AsyncQueryService while ensuring the request is propagated on the context.
 func (c *Controller) Query(ctx context.Context, req *query.Request) (flux.Query, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Controller.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Set the request on the context so platform specific Flux operations can retrieve it later.

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -3,13 +3,14 @@ package control
 
 import (
 	"context"
-	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/control"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/query"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // orgLabel is the metric label to use in the controller

--- a/query/influxql/service.go
+++ b/query/influxql/service.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 
 	"github.com/influxdata/flux"
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 )
 

--- a/query/influxql/service.go
+++ b/query/influxql/service.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 
 	"github.com/influxdata/flux"
-	"github.com/opentracing/opentracing-go"
 
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
@@ -32,7 +31,7 @@ type Service struct {
 // Query will execute a query for the influxql.Compiler type against an influxdb 1.x endpoint,
 // and return results using the default decoder.
 func (s *Service) Query(ctx context.Context, req *query.Request) (flux.ResultIterator, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	resp, err := s.query(ctx, req)
@@ -53,7 +52,7 @@ func (s *Service) Query(ctx context.Context, req *query.Request) (flux.ResultIte
 // QueryRawJSON will execute a query for the influxql.Compiler type against an influxdb 1.x endpoint,
 // and return the body of the response as a byte array.
 func (s *Service) QueryRawJSON(ctx context.Context, req *query.Request) ([]byte, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	resp, err := s.query(ctx, req)
@@ -70,7 +69,7 @@ func (s *Service) QueryRawJSON(ctx context.Context, req *query.Request) ([]byte,
 }
 
 func (s *Service) query(ctx context.Context, req *query.Request) (*http.Response, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Service.query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Verify that this is an influxql query in the compiler.

--- a/query/logging.go
+++ b/query/logging.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/influxdb/kit/tracing"
+	"github.com/opentracing/opentracing-go"
 )
 
 // LoggingServiceBridge implements ProxyQueryService and logs the queries while consuming a QueryService interface.
@@ -17,6 +19,9 @@ type LoggingServiceBridge struct {
 
 // Query executes and logs the query.
 func (s *LoggingServiceBridge) Query(ctx context.Context, w io.Writer, req *ProxyRequest) (stats flux.Statistics, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "LoggingServiceBridge.Query")
+	defer span.Finish()
+
 	var n int64
 	defer func() {
 		r := recover()
@@ -38,7 +43,7 @@ func (s *LoggingServiceBridge) Query(ctx context.Context, w io.Writer, req *Prox
 
 	results, err := s.QueryService.Query(ctx, &req.Request)
 	if err != nil {
-		return stats, err
+		return stats, tracing.LogError(span, err)
 	}
 	// Check if this result iterator reports stats. We call this defer before cancel because
 	// the query needs to be finished before it will have valid statistics.
@@ -50,8 +55,11 @@ func (s *LoggingServiceBridge) Query(ctx context.Context, w io.Writer, req *Prox
 	encoder := req.Dialect.Encoder()
 	n, err = encoder.Encode(w, results)
 	if err != nil {
-		return stats, err
+		return stats, tracing.LogError(span, err)
 	}
 	// The results iterator may have had an error independent of encoding errors.
-	return stats, results.Err()
+	if err = results.Err(); err != nil {
+		return 0, tracing.LogError(span, err)
+	}
+	return stats, nil
 }

--- a/query/logging.go
+++ b/query/logging.go
@@ -59,7 +59,7 @@ func (s *LoggingServiceBridge) Query(ctx context.Context, w io.Writer, req *Prox
 	}
 	// The results iterator may have had an error independent of encoding errors.
 	if err = results.Err(); err != nil {
-		return 0, tracing.LogError(span, err)
+		return n, tracing.LogError(span, err)
 	}
 	return stats, nil
 }

--- a/query/logging.go
+++ b/query/logging.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/influxdb/kit/tracing"
-	"github.com/opentracing/opentracing-go"
 )
 
 // LoggingServiceBridge implements ProxyQueryService and logs the queries while consuming a QueryService interface.
@@ -19,7 +18,7 @@ type LoggingServiceBridge struct {
 
 // Query executes and logs the query.
 func (s *LoggingServiceBridge) Query(ctx context.Context, w io.Writer, req *ProxyRequest) (stats flux.Statistics, err error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "LoggingServiceBridge.Query")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	var n int64
@@ -59,7 +58,7 @@ func (s *LoggingServiceBridge) Query(ctx context.Context, w io.Writer, req *Prox
 	}
 	// The results iterator may have had an error independent of encoding errors.
 	if err = results.Err(); err != nil {
-		return n, tracing.LogError(span, err)
+		return stats, tracing.LogError(span, err)
 	}
 	return stats, nil
 }

--- a/storage/bucket_service.go
+++ b/storage/bucket_service.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/opentracing/opentracing-go"
-
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // BucketDeleter defines the behaviour of deleting a bucket.
@@ -35,7 +34,7 @@ func NewBucketService(s platform.BucketService, engine BucketDeleter) *BucketSer
 
 // FindBucketByID returns a single bucket by ID.
 func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*platform.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucketByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if s.inner == nil || s.engine == nil {
@@ -46,7 +45,7 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*pl
 
 // FindBucket returns the first bucket that matches filter.
 func (s *BucketService) FindBucket(ctx context.Context, filter platform.BucketFilter) (*platform.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if s.inner == nil || s.engine == nil {
@@ -58,7 +57,7 @@ func (s *BucketService) FindBucket(ctx context.Context, filter platform.BucketFi
 // FindBuckets returns a list of buckets that match filter and the total count of matching buckets.
 // Additional options provide pagination & sorting.
 func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketFilter, opt ...platform.FindOptions) ([]*platform.Bucket, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBuckets")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if s.inner == nil || s.engine == nil {
@@ -69,7 +68,7 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketF
 
 // CreateBucket creates a new bucket and sets b.ID with the new identifier.
 func (s *BucketService) CreateBucket(ctx context.Context, b *platform.Bucket) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.CreateBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if s.inner == nil || s.engine == nil {
@@ -81,7 +80,7 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *platform.Bucket) er
 // UpdateBucket updates a single bucket with changeset.
 // Returns the new bucket state after update.
 func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd platform.BucketUpdate) (*platform.Bucket, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.UpdateBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if s.inner == nil || s.engine == nil {
@@ -92,7 +91,7 @@ func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd pl
 
 // DeleteBucket removes a bucket by ID.
 func (s *BucketService) DeleteBucket(ctx context.Context, bucketID platform.ID) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.DeleteBucket")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	bucket, err := s.FindBucketByID(ctx, bucketID)

--- a/storage/bucket_service.go
+++ b/storage/bucket_service.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"github.com/opentracing/opentracing-go"
 
 	platform "github.com/influxdata/influxdb"
 )
@@ -33,6 +34,9 @@ func NewBucketService(s platform.BucketService, engine BucketDeleter) *BucketSer
 
 // FindBucketByID returns a single bucket by ID.
 func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*platform.Bucket, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucketByID")
+	defer span.Finish()
+
 	if s.inner == nil || s.engine == nil {
 		return nil, errors.New("nil inner BucketService or Engine")
 	}
@@ -41,6 +45,9 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id platform.ID) (*pl
 
 // FindBucket returns the first bucket that matches filter.
 func (s *BucketService) FindBucket(ctx context.Context, filter platform.BucketFilter) (*platform.Bucket, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBucket")
+	defer span.Finish()
+
 	if s.inner == nil || s.engine == nil {
 		return nil, errors.New("nil inner BucketService or Engine")
 	}
@@ -50,6 +57,9 @@ func (s *BucketService) FindBucket(ctx context.Context, filter platform.BucketFi
 // FindBuckets returns a list of buckets that match filter and the total count of matching buckets.
 // Additional options provide pagination & sorting.
 func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketFilter, opt ...platform.FindOptions) ([]*platform.Bucket, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.FindBuckets")
+	defer span.Finish()
+
 	if s.inner == nil || s.engine == nil {
 		return nil, 0, errors.New("nil inner BucketService or Engine")
 	}
@@ -58,6 +68,9 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter platform.BucketF
 
 // CreateBucket creates a new bucket and sets b.ID with the new identifier.
 func (s *BucketService) CreateBucket(ctx context.Context, b *platform.Bucket) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.CreateBucket")
+	defer span.Finish()
+
 	if s.inner == nil || s.engine == nil {
 		return errors.New("nil inner BucketService or Engine")
 	}
@@ -67,6 +80,9 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *platform.Bucket) er
 // UpdateBucket updates a single bucket with changeset.
 // Returns the new bucket state after update.
 func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd platform.BucketUpdate) (*platform.Bucket, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.UpdateBucket")
+	defer span.Finish()
+
 	if s.inner == nil || s.engine == nil {
 		return nil, errors.New("nil inner BucketService or Engine")
 	}
@@ -75,6 +91,9 @@ func (s *BucketService) UpdateBucket(ctx context.Context, id platform.ID, upd pl
 
 // DeleteBucket removes a bucket by ID.
 func (s *BucketService) DeleteBucket(ctx context.Context, bucketID platform.ID) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BucketService.DeleteBucket")
+	defer span.Finish()
+
 	bucket, err := s.FindBucketByID(ctx, bucketID)
 	if err != nil {
 		return err

--- a/storage/bucket_service.go
+++ b/storage/bucket_service.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+
 	"github.com/opentracing/opentracing-go"
 
 	platform "github.com/influxdata/influxdb"

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -18,7 +18,7 @@ import (
 	"github.com/influxdata/influxdb/tsdb/tsm1"
 	"github.com/influxdata/influxdb/tsdb/value"
 	"github.com/influxdata/influxql"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )

--- a/storage/wal/wal.go
+++ b/storage/wal/wal.go
@@ -308,7 +308,10 @@ func (l *WAL) sync() {
 // WriteMulti writes the given values to the WAL. It returns the WAL segment ID to
 // which the points were written. If an error is returned the segment ID should
 // be ignored. If the WAL is disabled, -1 and nil is returned.
-func (l *WAL) WriteMulti(values map[string][]value.Value) (int, error) {
+func (l *WAL) WriteMulti(ctx context.Context, values map[string][]value.Value) (int, error) {
+	span, _ := opentracing.StartSpanFromContext(ctx, "WAL.WriteMulti")
+	defer span.Finish()
+
 	if !l.enabled {
 		return -1, nil
 	}

--- a/storage/wal/wal.go
+++ b/storage/wal/wal.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/pkg/limiter"
 	"github.com/influxdata/influxdb/pkg/pool"
 	"github.com/influxdata/influxdb/tsdb/value"
@@ -171,7 +172,7 @@ func (l *WAL) Open(ctx context.Context) error {
 		return nil
 	}
 
-	span, _ := opentracing.StartSpanFromContext(ctx, "WAL.Open")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	span.LogKV("segment_size", l.SegmentSize,
@@ -310,7 +311,7 @@ func (l *WAL) sync() {
 // which the points were written. If an error is returned the segment ID should
 // be ignored. If the WAL is disabled, -1 and nil is returned.
 func (l *WAL) WriteMulti(ctx context.Context, values map[string][]value.Value) (int, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "WAL.WriteMulti")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	if !l.enabled {
@@ -374,7 +375,7 @@ func (l *WAL) Remove(ctx context.Context, files []string) error {
 		return nil
 	}
 
-	span, _ := opentracing.StartSpanFromContext(ctx, "WAL.Remove")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	l.mu.Lock()

--- a/storage/wal/wal.go
+++ b/storage/wal/wal.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"io"
 	"math"
 	"os"
@@ -19,12 +18,14 @@ import (
 	"time"
 
 	"github.com/golang/snappy"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/pkg/limiter"
 	"github.com/influxdata/influxdb/pkg/pool"
 	"github.com/influxdata/influxdb/tsdb/value"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 )
 
 const (

--- a/storage/wal/wal_test.go
+++ b/storage/wal/wal_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/golang/snappy"
+
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/tsdb/value"
 )

--- a/storage/wal/wal_test.go
+++ b/storage/wal/wal_test.go
@@ -278,7 +278,7 @@ func TestWAL_ClosedSegments(t *testing.T) {
 		t.Fatalf("close segment length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if _, err := w.WriteMulti(map[string][]value.Value{
+	if _, err := w.WriteMulti(context.Background(), map[string][]value.Value{
 		"cpu,host=A#!~#value": []value.Value{
 			value.NewValue(1, 1.1),
 		},

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 var (
@@ -639,7 +640,7 @@ func (r *runner) clearRunning(id platform.ID) {
 func (r *runner) executeAndWait(ctx context.Context, qr QueuedRun, runLogger *zap.Logger) {
 	defer r.wg.Done()
 
-	sp, spCtx := opentracing.StartSpanFromContext(ctx, "task.run.execution")
+	sp, spCtx := tracing.StartSpanFromContext(ctx)
 	defer sp.Finish()
 
 	rp, err := r.executor.Execute(spCtx, qr)

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	platform "github.com/influxdata/influxdb"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
+
+	platform "github.com/influxdata/influxdb"
 )
 
 var (

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/influxdata/flux"
 	platform "github.com/influxdata/influxdb"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -597,7 +597,12 @@ func (r *runner) startFromWorking(now int64) {
 		atomic.StoreUint32(r.state, runnerIdle)
 		return
 	}
-	ctx, cancel := context.WithCancel(r.ctx)
+
+	span := opentracing.StartSpan("runner.startFromWorking")
+	ctx := opentracing.ContextWithSpan(r.ctx, span)
+	defer span.Finish()
+
+	ctx, cancel := context.WithCancel(ctx)
 	rc, err := r.desiredState.CreateNextRun(ctx, r.task.ID, now)
 	if err != nil {
 		r.logger.Info("Failed to create run", zap.Error(err))

--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"time"
+
+	"github.com/opentracing/opentracing-go"
 
 	platform "github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"

--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"time"
 
 	platform "github.com/influxdata/influxdb"
@@ -36,6 +37,9 @@ type pAdapter struct {
 var _ platform.TaskService = pAdapter{}
 
 func (p pAdapter) FindTaskByID(ctx context.Context, id platform.ID) (*platform.Task, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindTaskByID")
+	defer span.Finish()
+
 	t, m, err := p.s.FindTaskByIDWithMeta(ctx, id)
 	if err != nil {
 		return nil, err
@@ -49,6 +53,9 @@ func (p pAdapter) FindTaskByID(ctx context.Context, id platform.ID) (*platform.T
 }
 
 func (p pAdapter) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindTasks")
+	defer span.Finish()
+
 	params := backend.TaskSearchParams{PageSize: filter.Limit}
 	org := platform.Organization{
 		Name: filter.Organization,
@@ -118,6 +125,9 @@ func (p pAdapter) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]
 }
 
 func (p pAdapter) CreateTask(ctx context.Context, t platform.TaskCreate) (*platform.Task, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.CreateTask")
+	defer span.Finish()
+
 	auth, err := icontext.GetAuthorizer(ctx)
 	if err != nil {
 		return nil, err
@@ -194,6 +204,9 @@ func (p pAdapter) CreateTask(ctx context.Context, t platform.TaskCreate) (*platf
 }
 
 func (p pAdapter) UpdateTask(ctx context.Context, id platform.ID, upd platform.TaskUpdate) (*platform.Task, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.CreateTask")
+	defer span.Finish()
+
 	err := upd.Validate()
 	if err != nil {
 		return nil, err
@@ -225,6 +238,9 @@ func (p pAdapter) UpdateTask(ctx context.Context, id platform.ID, upd platform.T
 }
 
 func (p pAdapter) DeleteTask(ctx context.Context, id platform.ID) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.DeleteTask")
+	defer span.Finish()
+
 	_, err := p.s.DeleteTask(ctx, id)
 	if err != nil {
 		return err
@@ -250,6 +266,9 @@ func (p pAdapter) DeleteTask(ctx context.Context, id platform.ID) error {
 }
 
 func (p pAdapter) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindLogs")
+	defer span.Finish()
+
 	task, err := p.s.FindTaskByID(ctx, filter.Task)
 	if err != nil {
 		return nil, 0, err
@@ -264,6 +283,9 @@ func (p pAdapter) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*p
 }
 
 func (p pAdapter) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindRuns")
+	defer span.Finish()
+
 	task, err := p.s.FindTaskByID(ctx, filter.Task)
 	if err != nil {
 		return nil, 0, err
@@ -274,6 +296,9 @@ func (p pAdapter) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*p
 }
 
 func (p pAdapter) FindRunByID(ctx context.Context, taskID, id platform.ID) (*platform.Run, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindRunByID")
+	defer span.Finish()
+
 	task, err := p.s.FindTaskByID(ctx, taskID)
 	if err != nil {
 		return nil, err
@@ -282,6 +307,9 @@ func (p pAdapter) FindRunByID(ctx context.Context, taskID, id platform.ID) (*pla
 }
 
 func (p pAdapter) RetryRun(ctx context.Context, taskID, id platform.ID) (*platform.Run, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.RetryRun")
+	defer span.Finish()
+
 	task, err := p.s.FindTaskByID(ctx, taskID)
 	if err != nil {
 		return nil, err
@@ -315,6 +343,9 @@ func (p pAdapter) RetryRun(ctx context.Context, taskID, id platform.ID) (*platfo
 }
 
 func (p pAdapter) ForceRun(ctx context.Context, taskID platform.ID, scheduledFor int64) (*platform.Run, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.ForceRun")
+	defer span.Finish()
+
 	requestedAt := time.Now()
 	m, err := p.s.ManuallyRunTimeRange(ctx, taskID, scheduledFor, scheduledFor, requestedAt.Unix())
 	if err != nil {
@@ -330,6 +361,9 @@ func (p pAdapter) ForceRun(ctx context.Context, taskID platform.ID, scheduledFor
 }
 
 func (p pAdapter) CancelRun(ctx context.Context, taskID, runID platform.ID) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.CancelRun")
+	defer span.Finish()
+
 	return p.rc.CancelRun(ctx, taskID, runID)
 }
 

--- a/task/platform_adapter.go
+++ b/task/platform_adapter.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
-
 	platform "github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/options"
 )
@@ -38,7 +37,7 @@ type pAdapter struct {
 var _ platform.TaskService = pAdapter{}
 
 func (p pAdapter) FindTaskByID(ctx context.Context, id platform.ID) (*platform.Task, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindTaskByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	t, m, err := p.s.FindTaskByIDWithMeta(ctx, id)
@@ -54,7 +53,7 @@ func (p pAdapter) FindTaskByID(ctx context.Context, id platform.ID) (*platform.T
 }
 
 func (p pAdapter) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindTasks")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	params := backend.TaskSearchParams{PageSize: filter.Limit}
@@ -126,7 +125,7 @@ func (p pAdapter) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]
 }
 
 func (p pAdapter) CreateTask(ctx context.Context, t platform.TaskCreate) (*platform.Task, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.CreateTask")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	auth, err := icontext.GetAuthorizer(ctx)
@@ -205,7 +204,7 @@ func (p pAdapter) CreateTask(ctx context.Context, t platform.TaskCreate) (*platf
 }
 
 func (p pAdapter) UpdateTask(ctx context.Context, id platform.ID, upd platform.TaskUpdate) (*platform.Task, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.CreateTask")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	err := upd.Validate()
@@ -239,7 +238,7 @@ func (p pAdapter) UpdateTask(ctx context.Context, id platform.ID, upd platform.T
 }
 
 func (p pAdapter) DeleteTask(ctx context.Context, id platform.ID) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.DeleteTask")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	_, err := p.s.DeleteTask(ctx, id)
@@ -267,7 +266,7 @@ func (p pAdapter) DeleteTask(ctx context.Context, id platform.ID) error {
 }
 
 func (p pAdapter) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindLogs")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	task, err := p.s.FindTaskByID(ctx, filter.Task)
@@ -284,7 +283,7 @@ func (p pAdapter) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*p
 }
 
 func (p pAdapter) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindRuns")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	task, err := p.s.FindTaskByID(ctx, filter.Task)
@@ -297,7 +296,7 @@ func (p pAdapter) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*p
 }
 
 func (p pAdapter) FindRunByID(ctx context.Context, taskID, id platform.ID) (*platform.Run, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.FindRunByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	task, err := p.s.FindTaskByID(ctx, taskID)
@@ -308,7 +307,7 @@ func (p pAdapter) FindRunByID(ctx context.Context, taskID, id platform.ID) (*pla
 }
 
 func (p pAdapter) RetryRun(ctx context.Context, taskID, id platform.ID) (*platform.Run, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.RetryRun")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	task, err := p.s.FindTaskByID(ctx, taskID)
@@ -344,7 +343,7 @@ func (p pAdapter) RetryRun(ctx context.Context, taskID, id platform.ID) (*platfo
 }
 
 func (p pAdapter) ForceRun(ctx context.Context, taskID platform.ID, scheduledFor int64) (*platform.Run, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.ForceRun")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	requestedAt := time.Now()
@@ -362,7 +361,7 @@ func (p pAdapter) ForceRun(ctx context.Context, taskID platform.ID, scheduledFor
 }
 
 func (p pAdapter) CancelRun(ctx context.Context, taskID, runID platform.ID) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "pAdapter.CancelRun")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	return p.rc.CancelRun(ctx, taskID, runID)

--- a/task/validator.go
+++ b/task/validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/opentracing/opentracing-go"
 	"time"
 
 	"github.com/influxdata/flux"
@@ -37,6 +38,9 @@ func NewValidator(ts platform.TaskService, bs platform.BucketService) platform.T
 }
 
 func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id platform.ID) (*platform.Task, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindTaskByID")
+	defer span.Finish()
+
 	// Unauthenticated task lookup, to identify the task's organization.
 	task, err := ts.TaskService.FindTaskByID(ctx, id)
 	if err != nil {
@@ -56,6 +60,9 @@ func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id platform.ID
 }
 
 func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindTasks")
+	defer span.Finish()
+
 	// First, get the tasks in the organization, without authentication.
 	unauthenticatedTasks, _, err := ts.TaskService.FindTasks(ctx, filter)
 	if err != nil {
@@ -82,6 +89,9 @@ func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter platform.T
 }
 
 func (ts *taskServiceValidator) CreateTask(ctx context.Context, t platform.TaskCreate) (*platform.Task, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.CreateTask")
+	defer span.Finish()
+
 	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, t.OrganizationID)
 	if err != nil {
 		return nil, err
@@ -99,6 +109,9 @@ func (ts *taskServiceValidator) CreateTask(ctx context.Context, t platform.TaskC
 }
 
 func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id platform.ID, upd platform.TaskUpdate) (*platform.Task, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.UpdateTask")
+	defer span.Finish()
+
 	// Unauthenticated task lookup, to identify the task's organization.
 	task, err := ts.TaskService.FindTaskByID(ctx, id)
 	if err != nil {
@@ -122,6 +135,9 @@ func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id platform.ID, 
 }
 
 func (ts *taskServiceValidator) DeleteTask(ctx context.Context, id platform.ID) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.DeleteTask")
+	defer span.Finish()
+
 	// Unauthenticated task lookup, to identify the task's organization.
 	task, err := ts.TaskService.FindTaskByID(ctx, id)
 	if err != nil {
@@ -141,6 +157,9 @@ func (ts *taskServiceValidator) DeleteTask(ctx context.Context, id platform.ID) 
 }
 
 func (ts *taskServiceValidator) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindLogs")
+	defer span.Finish()
+
 	// Look up the task first, through the validator, to ensure we have permission to view the task.
 	if _, err := ts.FindTaskByID(ctx, filter.Task); err != nil {
 		return nil, -1, err
@@ -151,6 +170,9 @@ func (ts *taskServiceValidator) FindLogs(ctx context.Context, filter platform.Lo
 }
 
 func (ts *taskServiceValidator) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindRuns")
+	defer span.Finish()
+
 	// Look up the task first, through the validator, to ensure we have permission to view the task.
 	task, err := ts.FindTaskByID(ctx, filter.Task)
 	if err != nil {
@@ -171,6 +193,9 @@ func (ts *taskServiceValidator) FindRuns(ctx context.Context, filter platform.Ru
 }
 
 func (ts *taskServiceValidator) FindRunByID(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindRunByID")
+	defer span.Finish()
+
 	// Unauthenticated task lookup, to identify the task's organization.
 	task, err := ts.TaskService.FindTaskByID(ctx, taskID)
 	if err != nil {
@@ -190,6 +215,9 @@ func (ts *taskServiceValidator) FindRunByID(ctx context.Context, taskID, runID p
 }
 
 func (ts *taskServiceValidator) CancelRun(ctx context.Context, taskID, runID platform.ID) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.CancelRun")
+	defer span.Finish()
+
 	// Unauthenticated task lookup, to identify the task's organization.
 	task, err := ts.TaskService.FindTaskByID(ctx, taskID)
 	if err != nil {
@@ -209,6 +237,9 @@ func (ts *taskServiceValidator) CancelRun(ctx context.Context, taskID, runID pla
 }
 
 func (ts *taskServiceValidator) RetryRun(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.RetryRun")
+	defer span.Finish()
+
 	// Unauthenticated task lookup, to identify the task's organization.
 	task, err := ts.TaskService.FindTaskByID(ctx, taskID)
 	if err != nil {
@@ -228,6 +259,9 @@ func (ts *taskServiceValidator) RetryRun(ctx context.Context, taskID, runID plat
 }
 
 func (ts *taskServiceValidator) ForceRun(ctx context.Context, taskID platform.ID, scheduledFor int64) (*platform.Run, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.ForceRun")
+	defer span.Finish()
+
 	// Unauthenticated task lookup, to identify the task's organization.
 	task, err := ts.TaskService.FindTaskByID(ctx, taskID)
 	if err != nil {

--- a/task/validator.go
+++ b/task/validator.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/opentracing/opentracing-go"
+
 	platform "github.com/influxdata/influxdb"
 	platcontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/query"

--- a/task/validator.go
+++ b/task/validator.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/opentracing/opentracing-go"
 
 	platform "github.com/influxdata/influxdb"
 	platcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 )
 
@@ -39,7 +39,7 @@ func NewValidator(ts platform.TaskService, bs platform.BucketService) platform.T
 }
 
 func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id platform.ID) (*platform.Task, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindTaskByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Unauthenticated task lookup, to identify the task's organization.
@@ -61,7 +61,7 @@ func (ts *taskServiceValidator) FindTaskByID(ctx context.Context, id platform.ID
 }
 
 func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter platform.TaskFilter) ([]*platform.Task, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindTasks")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// First, get the tasks in the organization, without authentication.
@@ -90,7 +90,7 @@ func (ts *taskServiceValidator) FindTasks(ctx context.Context, filter platform.T
 }
 
 func (ts *taskServiceValidator) CreateTask(ctx context.Context, t platform.TaskCreate) (*platform.Task, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.CreateTask")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, t.OrganizationID)
@@ -110,7 +110,7 @@ func (ts *taskServiceValidator) CreateTask(ctx context.Context, t platform.TaskC
 }
 
 func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id platform.ID, upd platform.TaskUpdate) (*platform.Task, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.UpdateTask")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Unauthenticated task lookup, to identify the task's organization.
@@ -136,7 +136,7 @@ func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id platform.ID, 
 }
 
 func (ts *taskServiceValidator) DeleteTask(ctx context.Context, id platform.ID) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.DeleteTask")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Unauthenticated task lookup, to identify the task's organization.
@@ -158,7 +158,7 @@ func (ts *taskServiceValidator) DeleteTask(ctx context.Context, id platform.ID) 
 }
 
 func (ts *taskServiceValidator) FindLogs(ctx context.Context, filter platform.LogFilter) ([]*platform.Log, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindLogs")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Look up the task first, through the validator, to ensure we have permission to view the task.
@@ -171,7 +171,7 @@ func (ts *taskServiceValidator) FindLogs(ctx context.Context, filter platform.Lo
 }
 
 func (ts *taskServiceValidator) FindRuns(ctx context.Context, filter platform.RunFilter) ([]*platform.Run, int, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindRuns")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Look up the task first, through the validator, to ensure we have permission to view the task.
@@ -194,7 +194,7 @@ func (ts *taskServiceValidator) FindRuns(ctx context.Context, filter platform.Ru
 }
 
 func (ts *taskServiceValidator) FindRunByID(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.FindRunByID")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Unauthenticated task lookup, to identify the task's organization.
@@ -216,7 +216,7 @@ func (ts *taskServiceValidator) FindRunByID(ctx context.Context, taskID, runID p
 }
 
 func (ts *taskServiceValidator) CancelRun(ctx context.Context, taskID, runID platform.ID) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.CancelRun")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Unauthenticated task lookup, to identify the task's organization.
@@ -238,7 +238,7 @@ func (ts *taskServiceValidator) CancelRun(ctx context.Context, taskID, runID pla
 }
 
 func (ts *taskServiceValidator) RetryRun(ctx context.Context, taskID, runID platform.ID) (*platform.Run, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.RetryRun")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Unauthenticated task lookup, to identify the task's organization.
@@ -260,7 +260,7 @@ func (ts *taskServiceValidator) RetryRun(ctx context.Context, taskID, runID plat
 }
 
 func (ts *taskServiceValidator) ForceRun(ctx context.Context, taskID platform.ID, scheduledFor int64) (*platform.Run, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "taskServiceValidator.ForceRun")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Unauthenticated task lookup, to identify the task's organization.

--- a/testing/kv.go
+++ b/testing/kv.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -125,7 +126,7 @@ func KVGet(
 			s, close := init(tt.fields, t)
 			defer close()
 
-			err := s.View(func(tx kv.Tx) error {
+			err := s.View(context.Background(), func(tx kv.Tx) error {
 				b, err := tx.Bucket(tt.args.bucket)
 				if err != nil {
 					t.Errorf("unexpected error retrieving bucket: %v", err)
@@ -200,7 +201,7 @@ func KVPut(
 			s, close := init(tt.fields, t)
 			defer close()
 
-			err := s.Update(func(tx kv.Tx) error {
+			err := s.Update(context.Background(), func(tx kv.Tx) error {
 				b, err := tx.Bucket(tt.args.bucket)
 				if err != nil {
 					t.Errorf("unexpected error retrieving bucket: %v", err)
@@ -286,7 +287,7 @@ func KVDelete(
 			s, close := init(tt.fields, t)
 			defer close()
 
-			err := s.Update(func(tx kv.Tx) error {
+			err := s.Update(context.Background(), func(tx kv.Tx) error {
 				b, err := tx.Bucket(tt.args.bucket)
 				if err != nil {
 					t.Errorf("unexpected error retrieving bucket: %v", err)
@@ -416,7 +417,7 @@ func KVCursor(
 			s, close := init(tt.fields, t)
 			defer close()
 
-			err := s.View(func(tx kv.Tx) error {
+			err := s.View(context.Background(), func(tx kv.Tx) error {
 				b, err := tx.Bucket(tt.args.bucket)
 				if err != nil {
 					t.Errorf("unexpected error retrieving bucket: %v", err)
@@ -601,7 +602,7 @@ func KVView(
 			s, close := init(tt.fields, t)
 			defer close()
 
-			err := s.View(func(tx kv.Tx) error {
+			err := s.View(context.Background(), func(tx kv.Tx) error {
 				b, err := tx.Bucket(tt.args.bucket)
 				if err != nil {
 					t.Errorf("unexpected error retrieving bucket: %v", err)
@@ -719,7 +720,7 @@ func KVUpdate(
 			defer close()
 
 			{
-				err := s.Update(func(tx kv.Tx) error {
+				err := s.Update(context.Background(), func(tx kv.Tx) error {
 					b, err := tx.Bucket(tt.args.bucket)
 					if err != nil {
 						t.Errorf("unexpected error retrieving bucket: %v", err)
@@ -764,7 +765,7 @@ func KVUpdate(
 			}
 
 			{
-				err := s.View(func(tx kv.Tx) error {
+				err := s.View(context.Background(), func(tx kv.Tx) error {
 					b, err := tx.Bucket(tt.args.bucket)
 					if err != nil {
 						t.Errorf("unexpected error retrieving bucket: %v", err)
@@ -848,7 +849,7 @@ func KVConcurrentUpdate(
 
 			errCh := make(chan error)
 			var fn = func(v []byte) {
-				err := s.Update(func(tx kv.Tx) error {
+				err := s.Update(context.Background(), func(tx kv.Tx) error {
 					b, err := tx.Bucket(tt.args.bucket)
 					if err != nil {
 						return err
@@ -886,7 +887,7 @@ func KVConcurrentUpdate(
 			close(errCh)
 
 			{
-				err := s.View(func(tx kv.Tx) error {
+				err := s.View(context.Background(), func(tx kv.Tx) error {
 					b, err := tx.Bucket(tt.args.bucket)
 					if err != nil {
 						t.Errorf("unexpected error retrieving bucket: %v", err)

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -6,13 +6,13 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"os"
 	"path/filepath"
 	"sort"
 	"sync"
 
 	"github.com/cespare/xxhash"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/binaryutil"
@@ -92,7 +92,7 @@ func (f *SeriesFile) Open(ctx context.Context) error {
 		return errors.New("series file already opened")
 	}
 
-	span, _ := opentracing.StartSpanFromContext(ctx, "SeriesFile.Open")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	_, logEnd := logger.NewOperation(f.Logger, "Opening Series File", "series_file_open", zap.String("path", f.path))

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 	"unsafe"
 
 	"github.com/cespare/xxhash"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/lifecycle"
 	"github.com/influxdata/influxdb/pkg/slices"
@@ -217,7 +217,7 @@ func (i *Index) Open(ctx context.Context) error {
 		return errors.New("index already open")
 	}
 
-	span, _ := opentracing.StartSpanFromContext(ctx, "Index.Open")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Ensure root exists.

--- a/tsdb/tsm1/compact.go
+++ b/tsdb/tsm1/compact.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"io"
 	"math"
 	"os"
@@ -27,6 +26,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/pkg/limiter"
 	"github.com/influxdata/influxdb/tsdb"
 )
@@ -811,7 +811,7 @@ func (c *Compactor) EnableCompactions() {
 
 // WriteSnapshot writes a Cache snapshot to one or more new TSM files.
 func (c *Compactor) WriteSnapshot(ctx context.Context, cache *Cache) ([]string, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "Compactor.WriteSnapshot")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	c.mu.RLock()

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/lifecycle"
@@ -495,7 +496,7 @@ func (e *Engine) initTrackers() {
 
 // Open opens and initializes the engine.
 func (e *Engine) Open(ctx context.Context) (err error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Engine.Open")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	defer func() {
@@ -775,7 +776,7 @@ func (t *compactionTracker) SetFullQueue(length uint64) { t.SetQueue(5, length) 
 
 // WriteSnapshot will snapshot the cache and write a new TSM file with its contents, releasing the snapshot when done.
 func (e *Engine) WriteSnapshot(ctx context.Context) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "Engine.WriteSnapshot")
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// Lock and grab the cache snapshot along with all the closed WAL

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
 	"io/ioutil"
 	"math"
 	"os"
@@ -18,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/pkg/file"
 	"github.com/influxdata/influxdb/pkg/limiter"
 	"github.com/influxdata/influxdb/pkg/metrics"
@@ -517,7 +517,7 @@ func (f *FileStore) Open(ctx context.Context) error {
 		return errors.New("cannot open FileStore without an OpenLimiter (is EngineOptions.OpenLimiter set?)")
 	}
 
-	span, _ := opentracing.StartSpanFromContext(ctx, "FileStore.Open")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	// find the current max ID for temp directories
@@ -1104,7 +1104,7 @@ func (f *FileStore) locations(key []byte, t int64, ascending bool) []*location {
 // CreateSnapshot creates hardlinks for all tsm and tombstone files
 // in the path provided.
 func (f *FileStore) CreateSnapshot(ctx context.Context) (string, error) {
-	span, _ := opentracing.StartSpanFromContext(ctx, "FileStore.CreateSnapshot")
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	span.LogKV("dir", f.dir)


### PR DESCRIPTION
Added tracing to a few services: storage, flux, tasks, org, bucket. Some of the results attached.

Trying to establish patterns:
```golang
func (s *Struct) Func(ctx context.Context) error {
  // Add a span.
  span, ctx := opentracing.StartSpanFromContext(ctx, "Struct.Func")
  defer span.Finish()
  ...
  // Log to the span instead of stdout/stderr.
  span.LogKV("org", org)
  ...
  // Inject a span context to an HTTP request.
  req, err := http.NewRequest("GET", u.String(), nil)
  if err != nil {
    return tracing.LogError(span, err)
  }
  tracing.InjectToHTTPRequest(span, req)
  ...
}

func (h *BucketHandler) handleGetBuckets(w http.ResponseWriter, r *http.Request) {
  // Extract a span context from an HTTP request.
  span, r := tracing.ExtractFromHTTPRequest(r, "BucketHandler")
  defer span.Finish()
  ...
}
```

![screen shot 2019-03-04 at 4 28 03 pm](https://user-images.githubusercontent.com/622263/53772851-df149880-3e9c-11e9-8287-ae9eafd6dd88.png)

![screen shot 2019-03-04 at 3 53 01 pm](https://user-images.githubusercontent.com/622263/53772857-e5a31000-3e9c-11e9-831a-5e9b67cf272f.png)

  - [ ] Rebased/mergeable
  - [ ] Tests pass
