### PR TITLE
Add a cloud feature flag and prevent scrapers from showing up in cloud

### DIFF
--- a/ui/src/organizations/components/BucketRow.tsx
+++ b/ui/src/organizations/components/BucketRow.tsx
@@ -18,6 +18,7 @@ import {
 import {Bucket} from '@influxdata/influx'
 import {DataLoaderType} from 'src/types/v2/dataLoaders'
 import EditableName from 'src/shared/components/EditableName'
+import CloudFeatureFlag from 'src/shared/components/CloudFeatureFlag'
 
 export interface PrettyBucket extends Bucket {
   ruleString: string
@@ -75,11 +76,13 @@ export default class BucketRow extends PureComponent<Props> {
                   description="Quickly load an existing line protocol file."
                   action={this.handleAddLineProtocol}
                 />
-                <Context.Item
-                  label="Scrape Metrics"
-                  description="Add a scrape target to pull data into your bucket."
-                  action={this.handleAddScraper}
-                />
+                <CloudFeatureFlag>
+                  <Context.Item
+                    label="Scrape Metrics"
+                    description="Add a scrape target to pull data into your bucket."
+                    action={this.handleAddScraper}
+                  />
+                </CloudFeatureFlag>
               </Context.Menu>
             </Context>
           </IndexList.Cell>

--- a/ui/src/organizations/components/OrganizationNavigation.tsx
+++ b/ui/src/organizations/components/OrganizationNavigation.tsx
@@ -7,6 +7,7 @@ import {Tabs} from 'src/clockface'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import CloudFeatureFlag from 'src/shared/components/CloudFeatureFlag'
 
 interface Props {
   tab: string
@@ -52,12 +53,15 @@ class OrganizationNavigation extends PureComponent<Props> {
           url={`${route}/telegrafs`}
           active={'telegrafs' === tab}
         />
-        <Tabs.Tab
-          title={'Scrapers'}
-          id={'scrapers'}
-          url={`${route}/scrapers`}
-          active={'scrapers' === tab}
-        />
+        <CloudFeatureFlag>
+          <Tabs.Tab
+            title={'Scrapers'}
+            id={'scrapers'}
+            url={`${route}/scrapers`}
+            active={'scrapers' === tab}
+          />
+        </CloudFeatureFlag>
+
         <Tabs.Tab
           title={'Variables'}
           id={'variables'}

--- a/ui/src/shared/components/CloudFeatureFlag.tsx
+++ b/ui/src/shared/components/CloudFeatureFlag.tsx
@@ -1,0 +1,23 @@
+// Libraries
+import {PureComponent} from 'react'
+
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+interface Props {
+  name?: string
+}
+
+export default class extends PureComponent<Props> {
+  public render() {
+    if (this.isHidden) {
+      return null
+    }
+
+    return this.props.children
+  }
+
+  private get isHidden(): boolean {
+    return CLOUD
+  }
+}

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -434,3 +434,5 @@ export const MIN_SIZE = 0
 
 export const VERSION = process.env.npm_package_version
 export const GIT_SHA = process.env.GIT_SHA
+
+export const CLOUD = !!process.env.CLOUD ? process.env.CLOUD === 'true' : false

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -435,4 +435,4 @@ export const MIN_SIZE = 0
 export const VERSION = process.env.npm_package_version
 export const GIT_SHA = process.env.GIT_SHA
 
-export const CLOUD = !!process.env.CLOUD ? process.env.CLOUD === 'true' : false
+export const CLOUD = process.env.CLOUD && process.env.CLOUD === 'true'


### PR DESCRIPTION
Closes #12337

_Briefly describe your proposed changes:_
Create a CloudFeatureFlag that disables features if in the cloud environment.
This assumes there is an environmental variable CLOUD that is set to `"true"`
Use this flag to hide scrapers in the organization view and from the buckets add data drop down

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
