### PR TITLE
test(task): allow log reader/writer test harness to provide authz

### DIFF
--- a/task/backend/logreaderwriter_test.go
+++ b/task/backend/logreaderwriter_test.go
@@ -2,12 +2,15 @@ package backend_test
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/influxdata/flux/control"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/query"
 	pcontrol "github.com/influxdata/influxdb/query/control"
@@ -22,9 +25,9 @@ import (
 func TestInMemRunStore(t *testing.T) {
 	storetest.NewRunStoreTest(
 		"inmem",
-		func(t *testing.T) (backend.LogWriter, backend.LogReader) {
+		func(t *testing.T) (backend.LogWriter, backend.LogReader, storetest.MakeNewAuthorizationFunc) {
 			rw := backend.NewInMemRunReaderWriter()
-			return rw, rw
+			return rw, rw, nil
 		},
 		func(t *testing.T, w backend.LogWriter, r backend.LogReader) {})(t)
 }
@@ -32,9 +35,9 @@ func TestInMemRunStore(t *testing.T) {
 func TestQueryStorageRunStore(t *testing.T) {
 	storetest.NewRunStoreTest(
 		"PointLogWriter and QueryLogReader",
-		func(t *testing.T) (backend.LogWriter, backend.LogReader) {
+		func(t *testing.T) (backend.LogWriter, backend.LogReader, storetest.MakeNewAuthorizationFunc) {
 			lrw := newFullStackAwareLogReaderWriter(t)
-			return lrw, lrw
+			return lrw, lrw, lrw.makeNewAuthorization
 		},
 		func(t *testing.T, w backend.LogWriter, r backend.LogReader) {
 			if w.(*fullStackAwareLogReaderWriter) != r.(*fullStackAwareLogReaderWriter) {
@@ -53,6 +56,8 @@ type fullStackAwareLogReaderWriter struct {
 
 	rootDir       string
 	storageEngine *storage.Engine
+
+	i *inmem.Service
 }
 
 func (lrw *fullStackAwareLogReaderWriter) Close(t *testing.T) {
@@ -65,6 +70,29 @@ func (lrw *fullStackAwareLogReaderWriter) Close(t *testing.T) {
 	if err := os.RemoveAll(lrw.rootDir); err != nil {
 		t.Error(err)
 	}
+}
+
+func (lrw *fullStackAwareLogReaderWriter) makeNewAuthorization(ctx context.Context, t *testing.T) *influxdb.Authorization {
+	o := &influxdb.Organization{Name: fmt.Sprintf("org-%s-%d", t.Name(), time.Now().UnixNano())}
+	if err := lrw.i.CreateOrganization(ctx, o); err != nil {
+		t.Fatal(err)
+	}
+
+	u := &influxdb.User{Name: fmt.Sprintf("user-%s-%d", t.Name(), time.Now().UnixNano())}
+	if err := lrw.i.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &influxdb.Authorization{
+		UserID:      u.ID,
+		OrgID:       o.ID,
+		Permissions: influxdb.OperPermissions(),
+	}
+	if err := lrw.i.CreateAuthorization(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	return a
 }
 
 func newFullStackAwareLogReaderWriter(t *testing.T) *fullStackAwareLogReaderWriter {
@@ -119,5 +147,7 @@ func newFullStackAwareLogReaderWriter(t *testing.T) *fullStackAwareLogReaderWrit
 
 		rootDir:       rootDir,
 		storageEngine: engine,
+
+		i: svc,
 	}
 }

--- a/task/backend/storetest/logstoretest.go
+++ b/task/backend/storetest/logstoretest.go
@@ -14,7 +14,15 @@ import (
 	platformtesting "github.com/influxdata/influxdb/testing"
 )
 
-type CreateRunStoreFunc func(*testing.T) (backend.LogWriter, backend.LogReader)
+// MakeNewAuthorizationFunc is a function that creates a new authorization associated with a valid org and user.
+// The permissions on the authorization should be allowed to do everything (see influxdb.OperPermissions).
+type MakeNewAuthorizationFunc func(context.Context, *testing.T) *platform.Authorization
+
+// CreateRunStoreFunc returns a new LogWriter and LogReader.
+// If the writer and reader are associated with a backend that validates authorizations,
+// it must return a valid MakeNewAuthorizationFunc; otherwise the returned MakeNewAuthorizationFunc may be nil,
+// in which case the tests will use authorizations associated with a random org and user ID.
+type CreateRunStoreFunc func(*testing.T) (backend.LogWriter, backend.LogReader, MakeNewAuthorizationFunc)
 type DestroyRunStoreFunc func(*testing.T, backend.LogWriter, backend.LogReader)
 
 func NewRunStoreTest(name string, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) func(*testing.T) {
@@ -49,7 +57,7 @@ func NewRunStoreTest(name string, crf CreateRunStoreFunc, drf DestroyRunStoreFun
 }
 
 func updateRunState(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) {
-	writer, reader := crf(t)
+	writer, reader, makeAuthz := crf(t)
 	defer drf(t, writer, reader)
 
 	now := time.Now().UTC()
@@ -71,7 +79,8 @@ func updateRunState(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFun
 		RunScheduledFor: scheduledFor.Unix(),
 	}
 
-	ctx := pcontext.SetAuthorizer(context.Background(), makeNewAuthorization())
+	ctx := context.Background()
+	ctx = pcontext.SetAuthorizer(ctx, makeNewAuthorization(ctx, t, makeAuthz))
 
 	startAt := now.Add(-2 * time.Second)
 	if err := writer.UpdateRunState(ctx, rlb, startAt, backend.RunStarted); err != nil {
@@ -107,7 +116,7 @@ func updateRunState(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFun
 }
 
 func runLogTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) {
-	writer, reader := crf(t)
+	writer, reader, makeAuthz := crf(t)
 	defer drf(t, writer, reader)
 
 	task := &backend.StoreTask{
@@ -130,7 +139,8 @@ func runLogTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) {
 		RunScheduledFor: sf.Unix(),
 	}
 
-	ctx := pcontext.SetAuthorizer(context.Background(), makeNewAuthorization())
+	ctx := context.Background()
+	ctx = pcontext.SetAuthorizer(ctx, makeNewAuthorization(ctx, t, makeAuthz))
 
 	if err := writer.UpdateRunState(ctx, rlb, sa, backend.RunStarted); err != nil {
 		t.Fatal(err)
@@ -163,7 +173,7 @@ func runLogTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) {
 }
 
 func listRunsTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) {
-	writer, reader := crf(t)
+	writer, reader, makeAuthz := crf(t)
 	defer drf(t, writer, reader)
 
 	task := &backend.StoreTask{
@@ -171,10 +181,11 @@ func listRunsTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc)
 		Org: platformtesting.MustIDBase16("ab01ab01ab01ab05"),
 	}
 
-	ctx := pcontext.SetAuthorizer(context.Background(), makeNewAuthorization())
+	ctx := context.Background()
+	ctx = pcontext.SetAuthorizer(ctx, makeNewAuthorization(ctx, t, makeAuthz))
 
-	if _, err := reader.ListRuns(ctx, task.ID, platform.RunFilter{Task: task.ID}); err != backend.ErrNoRunsFound {
-		t.Fatalf("with bad org ID, expected error %v, got %v", backend.ErrNoRunsFound, err)
+	if _, err := reader.ListRuns(ctx, task.ID, platform.RunFilter{Task: task.ID}); err == nil {
+		t.Fatal("with bad org ID, expected error but got nil")
 	}
 	if _, err := reader.ListRuns(ctx, task.Org, platform.RunFilter{Task: task.Org}); err != backend.ErrNoRunsFound {
 		t.Fatalf("with bad task ID, expected error %v, got %v", backend.ErrNoRunsFound, err)
@@ -280,7 +291,7 @@ func listRunsTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc)
 }
 
 func findRunByIDTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) {
-	writer, reader := crf(t)
+	writer, reader, makeAuthz := crf(t)
 	defer drf(t, writer, reader)
 
 	if _, err := reader.FindRunByID(context.Background(), platform.InvalidID(), platform.InvalidID()); err == nil {
@@ -307,7 +318,8 @@ func findRunByIDTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFu
 		RunScheduledFor: sf.Unix(),
 	}
 
-	ctx := pcontext.SetAuthorizer(context.Background(), makeNewAuthorization())
+	ctx := context.Background()
+	ctx = pcontext.SetAuthorizer(ctx, makeNewAuthorization(ctx, t, makeAuthz))
 	if err := writer.UpdateRunState(ctx, rlb, sa, backend.RunStarted); err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +351,7 @@ func findRunByIDTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFu
 }
 
 func listLogsTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc) {
-	writer, reader := crf(t)
+	writer, reader, makeAuthz := crf(t)
 	defer drf(t, writer, reader)
 
 	task := &backend.StoreTask{
@@ -347,13 +359,14 @@ func listLogsTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc)
 		Org: platformtesting.MustIDBase16("ab01ab01ab01ab05"),
 	}
 
-	ctx := pcontext.SetAuthorizer(context.Background(), makeNewAuthorization())
+	ctx := context.Background()
+	ctx = pcontext.SetAuthorizer(ctx, makeNewAuthorization(ctx, t, makeAuthz))
 
 	if _, err := reader.ListLogs(ctx, task.Org, platform.LogFilter{}); err == nil {
 		t.Fatalf("expected error when task ID missing, but got nil")
 	}
-	if _, err := reader.ListLogs(ctx, 9999999, platform.LogFilter{Task: task.ID}); err != backend.ErrNoRunsFound {
-		t.Fatalf("with bad org ID, expected error %v, got %v", backend.ErrNoRunsFound, err)
+	if _, err := reader.ListLogs(ctx, 9999999, platform.LogFilter{Task: task.ID}); err == nil {
+		t.Fatal("with bad org ID, expected error but got nil")
 	}
 
 	now := time.Now().UTC()
@@ -405,7 +418,11 @@ func listLogsTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc)
 	}
 }
 
-func makeNewAuthorization() *platform.Authorization {
+func makeNewAuthorization(ctx context.Context, t *testing.T, makeAuthz MakeNewAuthorizationFunc) *platform.Authorization {
+	if makeAuthz != nil {
+		return makeAuthz(ctx, t)
+	}
+
 	return &platform.Authorization{
 		ID:          platformtesting.MustIDBase16("ab01ab01ab01ab01"),
 		UserID:      platformtesting.MustIDBase16("ab01ab01ab01ab01"),


### PR DESCRIPTION
This is particularly relevant when the backing systems (like a real
query service) check authorizations.