### PR TITLE
Large database support for 32bit systems

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -115,6 +115,11 @@
   # It might help users who have slow disks in some cases.
   # tsm-use-madv-willneed = false
 
+  # If true, then the TSM file will accessed via seek/read operations instead of
+  # mmap.  This is required on 32 bit systems with TSM files that have aggregate
+  # size larger than the process memory limit (around typically 2 or 3 GB).
+  # tsm-use-seek = false
+
   # Settings for the inmem index
 
   # The maximum series allowed per database before writes are dropped.  This limit can prevent

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -133,8 +133,15 @@ type Config struct {
 	// TSMWillNeed controls whether we hint to the kernel that we intend to
 	// page in mmap'd sections of TSM files. This setting defaults to off, as it has
 	// been found to be problematic in some cases. It may help users who have
-	// slow disks.
+	// slow disks.  If tsm-use-seek is true, using this option will fadvise instead.
 	TSMWillNeed bool `toml:"tsm-use-madv-willneed"`
+
+	// TSMUseSeek controls how the block accessor reads block data.
+	// If false (the default), mmapped TSM files are used.  If true,
+	// Seek/Read operations are used.  Seek/Read operations are necessary
+	// on 32bit systems with large databases because of the much lower
+	// mmap memory address space limit.
+	TSMUseSeek bool `toml:"tsm-use-seek"`
 }
 
 // NewConfig returns the default configuration for tsdb.
@@ -161,6 +168,7 @@ func NewConfig() Config {
 
 		TraceLoggingEnabled: false,
 		TSMWillNeed:         false,
+		TSMUseSeek:          false,
 	}
 }
 

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -16,6 +16,7 @@ dir = "/var/lib/influxdb/data"
 wal-dir = "/var/lib/influxdb/wal"
 wal-fsync-delay = "10s"
 tsm-use-madv-willneed = true
+tsm-use-seek = true
 `, &c); err != nil {
 		t.Fatal(err)
 	}
@@ -35,6 +36,9 @@ tsm-use-madv-willneed = true
 	}
 	if got, exp := c.TSMWillNeed, true; got != exp {
 		t.Errorf("unexpected tsm-madv-willneed:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
+	}
+	if got, exp := c.TSMUseSeek, true; got != exp {
+		t.Errorf("unexpected tsm-use-seek:\n\nexp=%v\n\ngot=%v\n\n", exp, got)
 	}
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -212,6 +212,7 @@ func NewEngine(id uint64, idx tsdb.Index, path string, walPath string, sfile *ts
 		fs.WithObserver(opt.FileStoreObserver)
 	}
 	fs.tsmMMAPWillNeed = opt.Config.TSMWillNeed
+	fs.tsmUseSeek = opt.Config.TSMUseSeek
 
 	cache := NewCache(uint64(opt.Config.CacheMaxMemorySize))
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -179,6 +179,7 @@ type FileStore struct {
 
 	files           []TSMFile
 	tsmMMAPWillNeed bool          // If true then the kernel will be advised MMAP_WILLNEED for TSM files.
+	tsmUseSeek bool               // If true, seek/read ops are used instead of mmap for TSM files
 	openLimiter     limiter.Fixed // limit the number of concurrent opening TSM files.
 
 	logger       *zap.Logger // Logger to be used for important messages
@@ -532,7 +533,9 @@ func (f *FileStore) Open() error {
 			defer f.openLimiter.Release()
 
 			start := time.Now()
-			df, err := NewTSMReader(file, WithMadviseWillNeed(f.tsmMMAPWillNeed))
+			df, err := NewTSMReader(file,
+				WithMadviseWillNeed(f.tsmMMAPWillNeed),
+				WithUseSeek(f.tsmUseSeek))
 			f.logger.Info("Opened file",
 				zap.String("path", file.Name()),
 				zap.Int("id", idx),
@@ -760,7 +763,9 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 			}
 		}
 
-		tsm, err := NewTSMReader(fd, WithMadviseWillNeed(f.tsmMMAPWillNeed))
+		tsm, err := NewTSMReader(fd,
+			WithMadviseWillNeed(f.tsmMMAPWillNeed),
+			WithUseSeek(f.tsmUseSeek))
 		if err != nil {
 			if newName != oldName {
 				if err1 := os.Rename(newName, oldName); err1 != nil {

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -41,3 +41,15 @@ func madviseDontNeed(b []byte) error {
 func madvise(b []byte, advice int) (err error) {
 	return unix.Madvise(b, advice)
 }
+
+// Fadvise
+func fadviseWillNeed(fd uintptr, l int64) error {
+	return fadvise(fd, l, unix.FADV_WILLNEED)
+}
+
+func fadviseDontNeed(fd uintptr, l int64) error {
+	return fadvise(fd, l, unix.FADV_DONTNEED)
+}
+func fadvise(fd uintptr, l int64, advice int) (err error) {
+	return unix.Fadvise(int(fd), 0, l, advice)
+}

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -131,3 +131,14 @@ func madvise(b []byte, advice int) error {
 	// Not implemented
 	return nil
 }
+// Fadvise, not supported on Windows
+func fadviseWillNeed(fd uintptr, l int64) error {
+	return nil
+}
+
+func fadviseDontNeed(fd uintptr, l int64) error {
+	return nil
+}
+func fadvise(fd uintptr, l int64, advice int) (err error) {
+	return nil
+}

--- a/tsdb/engine/tsm1/reader.gen.go
+++ b/tsdb/engine/tsm1/reader.gen.go
@@ -90,24 +90,16 @@ func (t *TSMReader) ReadBooleanArrayBlockAt(entry *IndexEntry, vals *tsdb.Boolea
 	return err
 }
 
-// blockaccessor abstracts a method of accessing blocks from a
-// TSM file through the accessor.
-type blockAccessor interface {
-	init() (*indirectIndex, error)
-	read(int64, int64) []byte
-	free() error
-}
-
 func (m *accessor) readFloatBlock(entry *IndexEntry, values *[]FloatValue) ([]FloatValue, error) {
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeFloatBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	a, err := DecodeFloatBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	if err != nil {
@@ -121,12 +113,12 @@ func (m *accessor) readFloatArrayBlock(entry *IndexEntry, values *tsdb.FloatArra
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return ErrTSMClosed
 	}
 
-	err := DecodeFloatArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	err := DecodeFloatArrayBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	return err
@@ -136,12 +128,12 @@ func (m *accessor) readIntegerBlock(entry *IndexEntry, values *[]IntegerValue) (
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeIntegerBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	a, err := DecodeIntegerBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	if err != nil {
@@ -155,12 +147,12 @@ func (m *accessor) readIntegerArrayBlock(entry *IndexEntry, values *tsdb.Integer
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return ErrTSMClosed
 	}
 
-	err := DecodeIntegerArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	err := DecodeIntegerArrayBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	return err
@@ -170,12 +162,12 @@ func (m *accessor) readUnsignedBlock(entry *IndexEntry, values *[]UnsignedValue)
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeUnsignedBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	a, err := DecodeUnsignedBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	if err != nil {
@@ -189,12 +181,12 @@ func (m *accessor) readUnsignedArrayBlock(entry *IndexEntry, values *tsdb.Unsign
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return ErrTSMClosed
 	}
 
-	err := DecodeUnsignedArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	err := DecodeUnsignedArrayBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	return err
@@ -204,12 +196,12 @@ func (m *accessor) readStringBlock(entry *IndexEntry, values *[]StringValue) ([]
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeStringBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	a, err := DecodeStringBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	if err != nil {
@@ -223,12 +215,12 @@ func (m *accessor) readStringArrayBlock(entry *IndexEntry, values *tsdb.StringAr
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return ErrTSMClosed
 	}
 
-	err := DecodeStringArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	err := DecodeStringArrayBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	return err
@@ -238,12 +230,12 @@ func (m *accessor) readBooleanBlock(entry *IndexEntry, values *[]BooleanValue) (
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return nil, ErrTSMClosed
 	}
 
-	a, err := DecodeBooleanBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	a, err := DecodeBooleanBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	if err != nil {
@@ -257,12 +249,12 @@ func (m *accessor) readBooleanArrayBlock(entry *IndexEntry, values *tsdb.Boolean
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return ErrTSMClosed
 	}
 
-	err := DecodeBooleanArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	err := DecodeBooleanArrayBlock(m.b.read(entry.Offset+4, entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	return err

--- a/tsdb/engine/tsm1/reader.gen.go
+++ b/tsdb/engine/tsm1/reader.gen.go
@@ -90,31 +90,15 @@ func (t *TSMReader) ReadBooleanArrayBlockAt(entry *IndexEntry, vals *tsdb.Boolea
 	return err
 }
 
-// blockAccessor abstracts a method of accessing blocks from a
-// TSM file.
+// blockaccessor abstracts a method of accessing blocks from a
+// TSM file through the accessor.
 type blockAccessor interface {
 	init() (*indirectIndex, error)
-	read(key []byte, timestamp int64) ([]Value, error)
-	readAll(key []byte) ([]Value, error)
-	readBlock(entry *IndexEntry, values []Value) ([]Value, error)
-	readFloatBlock(entry *IndexEntry, values *[]FloatValue) ([]FloatValue, error)
-	readFloatArrayBlock(entry *IndexEntry, values *tsdb.FloatArray) error
-	readIntegerBlock(entry *IndexEntry, values *[]IntegerValue) ([]IntegerValue, error)
-	readIntegerArrayBlock(entry *IndexEntry, values *tsdb.IntegerArray) error
-	readUnsignedBlock(entry *IndexEntry, values *[]UnsignedValue) ([]UnsignedValue, error)
-	readUnsignedArrayBlock(entry *IndexEntry, values *tsdb.UnsignedArray) error
-	readStringBlock(entry *IndexEntry, values *[]StringValue) ([]StringValue, error)
-	readStringArrayBlock(entry *IndexEntry, values *tsdb.StringArray) error
-	readBooleanBlock(entry *IndexEntry, values *[]BooleanValue) ([]BooleanValue, error)
-	readBooleanArrayBlock(entry *IndexEntry, values *tsdb.BooleanArray) error
-	readBytes(entry *IndexEntry, buf []byte) (uint32, []byte, error)
-	rename(path string) error
-	path() string
-	close() error
+	read(int64, int64) []byte
 	free() error
 }
 
-func (m *mmapAccessor) readFloatBlock(entry *IndexEntry, values *[]FloatValue) ([]FloatValue, error) {
+func (m *accessor) readFloatBlock(entry *IndexEntry, values *[]FloatValue) ([]FloatValue, error) {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -133,7 +117,7 @@ func (m *mmapAccessor) readFloatBlock(entry *IndexEntry, values *[]FloatValue) (
 	return a, nil
 }
 
-func (m *mmapAccessor) readFloatArrayBlock(entry *IndexEntry, values *tsdb.FloatArray) error {
+func (m *accessor) readFloatArrayBlock(entry *IndexEntry, values *tsdb.FloatArray) error {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -148,7 +132,7 @@ func (m *mmapAccessor) readFloatArrayBlock(entry *IndexEntry, values *tsdb.Float
 	return err
 }
 
-func (m *mmapAccessor) readIntegerBlock(entry *IndexEntry, values *[]IntegerValue) ([]IntegerValue, error) {
+func (m *accessor) readIntegerBlock(entry *IndexEntry, values *[]IntegerValue) ([]IntegerValue, error) {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -167,7 +151,7 @@ func (m *mmapAccessor) readIntegerBlock(entry *IndexEntry, values *[]IntegerValu
 	return a, nil
 }
 
-func (m *mmapAccessor) readIntegerArrayBlock(entry *IndexEntry, values *tsdb.IntegerArray) error {
+func (m *accessor) readIntegerArrayBlock(entry *IndexEntry, values *tsdb.IntegerArray) error {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -182,7 +166,7 @@ func (m *mmapAccessor) readIntegerArrayBlock(entry *IndexEntry, values *tsdb.Int
 	return err
 }
 
-func (m *mmapAccessor) readUnsignedBlock(entry *IndexEntry, values *[]UnsignedValue) ([]UnsignedValue, error) {
+func (m *accessor) readUnsignedBlock(entry *IndexEntry, values *[]UnsignedValue) ([]UnsignedValue, error) {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -201,7 +185,7 @@ func (m *mmapAccessor) readUnsignedBlock(entry *IndexEntry, values *[]UnsignedVa
 	return a, nil
 }
 
-func (m *mmapAccessor) readUnsignedArrayBlock(entry *IndexEntry, values *tsdb.UnsignedArray) error {
+func (m *accessor) readUnsignedArrayBlock(entry *IndexEntry, values *tsdb.UnsignedArray) error {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -216,7 +200,7 @@ func (m *mmapAccessor) readUnsignedArrayBlock(entry *IndexEntry, values *tsdb.Un
 	return err
 }
 
-func (m *mmapAccessor) readStringBlock(entry *IndexEntry, values *[]StringValue) ([]StringValue, error) {
+func (m *accessor) readStringBlock(entry *IndexEntry, values *[]StringValue) ([]StringValue, error) {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -235,7 +219,7 @@ func (m *mmapAccessor) readStringBlock(entry *IndexEntry, values *[]StringValue)
 	return a, nil
 }
 
-func (m *mmapAccessor) readStringArrayBlock(entry *IndexEntry, values *tsdb.StringArray) error {
+func (m *accessor) readStringArrayBlock(entry *IndexEntry, values *tsdb.StringArray) error {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -250,7 +234,7 @@ func (m *mmapAccessor) readStringArrayBlock(entry *IndexEntry, values *tsdb.Stri
 	return err
 }
 
-func (m *mmapAccessor) readBooleanBlock(entry *IndexEntry, values *[]BooleanValue) ([]BooleanValue, error) {
+func (m *accessor) readBooleanBlock(entry *IndexEntry, values *[]BooleanValue) ([]BooleanValue, error) {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -269,7 +253,7 @@ func (m *mmapAccessor) readBooleanBlock(entry *IndexEntry, values *[]BooleanValu
 	return a, nil
 }
 
-func (m *mmapAccessor) readBooleanArrayBlock(entry *IndexEntry, values *tsdb.BooleanArray) error {
+func (m *accessor) readBooleanArrayBlock(entry *IndexEntry, values *tsdb.BooleanArray) error {
 	m.incAccess()
 
 	m.mu.RLock()

--- a/tsdb/engine/tsm1/reader.gen.go.tmpl
+++ b/tsdb/engine/tsm1/reader.gen.go.tmpl
@@ -22,25 +22,17 @@ func (t *TSMReader) Read{{.Name}}ArrayBlockAt(entry *IndexEntry, vals *tsdb.{{.N
 }
 {{end}}
 
-// blockaccessor abstracts a method of accessing blocks from a
-// TSM file through the accessor.
-type blockAccessor interface {
-	init() (*indirectIndex, error)
-	read(int64, int64) []byte
-	free() error
-}
-
 {{range .}}
 func (m *accessor) read{{.Name}}Block(entry *IndexEntry, values *[]{{.Name}}Value) ([]{{.Name}}Value, error) {
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return nil, ErrTSMClosed
 	}
 
-	a, err := Decode{{.Name}}Block(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	a, err := Decode{{.Name}}Block(m.b.read(entry.Offset+4,entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	if err != nil {
@@ -54,12 +46,12 @@ func (m *accessor) read{{.Name}}ArrayBlock(entry *IndexEntry, values *tsdb.{{.Na
 	m.incAccess()
 
 	m.mu.RLock()
-	if int64(len(m.b)) < entry.Offset+int64(entry.Size) {
+	if int64(m.b.length()) < entry.Offset+int64(entry.Size) {
 		m.mu.RUnlock()
 		return ErrTSMClosed
 	}
 
-	err := Decode{{.Name}}ArrayBlock(m.b[entry.Offset+4:entry.Offset+int64(entry.Size)], values)
+	err := Decode{{.Name}}ArrayBlock(m.b.read(entry.Offset+4,entry.Offset+int64(entry.Size)), values)
 	m.mu.RUnlock()
 
 	return err

--- a/tsdb/engine/tsm1/reader.gen.go.tmpl
+++ b/tsdb/engine/tsm1/reader.gen.go.tmpl
@@ -22,26 +22,16 @@ func (t *TSMReader) Read{{.Name}}ArrayBlockAt(entry *IndexEntry, vals *tsdb.{{.N
 }
 {{end}}
 
-// blockAccessor abstracts a method of accessing blocks from a
-// TSM file.
+// blockaccessor abstracts a method of accessing blocks from a
+// TSM file through the accessor.
 type blockAccessor interface {
 	init() (*indirectIndex, error)
-	read(key []byte, timestamp int64) ([]Value, error)
-	readAll(key []byte) ([]Value, error)
-	readBlock(entry *IndexEntry, values []Value) ([]Value, error)
-{{- range .}}
-	read{{.Name}}Block(entry *IndexEntry, values *[]{{.Name}}Value) ([]{{.Name}}Value, error)
-	read{{.Name}}ArrayBlock(entry *IndexEntry, values *tsdb.{{.Name}}Array) error
-{{- end}}
-	readBytes(entry *IndexEntry, buf []byte) (uint32, []byte, error)
-	rename(path string) error
-	path() string
-	close() error
+	read(int64, int64) []byte
 	free() error
 }
 
 {{range .}}
-func (m *mmapAccessor) read{{.Name}}Block(entry *IndexEntry, values *[]{{.Name}}Value) ([]{{.Name}}Value, error) {
+func (m *accessor) read{{.Name}}Block(entry *IndexEntry, values *[]{{.Name}}Value) ([]{{.Name}}Value, error) {
 	m.incAccess()
 
 	m.mu.RLock()
@@ -60,7 +50,7 @@ func (m *mmapAccessor) read{{.Name}}Block(entry *IndexEntry, values *[]{{.Name}}
 	return a, nil
 }
 
-func (m *mmapAccessor) read{{.Name}}ArrayBlock(entry *IndexEntry, values *tsdb.{{.Name}}Array) error {
+func (m *accessor) read{{.Name}}ArrayBlock(entry *IndexEntry, values *tsdb.{{.Name}}Array) error {
 	m.incAccess()
 
 	m.mu.RLock()


### PR DESCRIPTION
Closes #10486

_Briefly describe your proposed changes:_

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [] http/swagger.yml updated (if modified Go structs or API) <- is this relevant to 1.8 branch?
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This PR implements a fix to allow 32bit systems to have large databases.  Most of the discussion on #10486 still applies, but the implemented fix is different than my original attempt, and much cleaner, I think.

The implementation makes changes to the mmapAccessor in reader.go and supporting files.

- Changes the role of the accessor interface.  The interface is modified to only be relevant to accessing the block data of the TSM file (previously m.b), and not other things like access locking.
- One implementation of the new interface, mmapAccessor (same name as previously) implements the existing method of mmapping TSM block data into the process address space.
- Another implementation of the new interface, seekAccessor, uses seek/read operations to access the TSM block data.  This eliminates much of the mmapping, preventing out of memory errors on large databases.
- A new configuration property `tsm-use-seek`, default false, can be specified to use the seek accessor instead of the mmap accessor.

I ran the same tests described in #10486.  With tsm-use-seek = false, I encountered the same out of memory errors when trying to run compaction jobs at the 3.6GB file limit:

```
3.6G    /LASERINFO/influxdb/data/stress/autogen/
174.2M  /LASERINFO/influxdb/data/stress/autogen/2
371.6M  /LASERINFO/influxdb/data/stress/autogen/3
839.7M  /LASERINFO/influxdb/data/stress/autogen/4
851.2M  /LASERINFO/influxdb/data/stress/autogen/5
768.5M  /LASERINFO/influxdb/data/stress/autogen/6
635.5M  /LASERINFO/influxdb/data/stress/autogen/7
8.0K    /LASERINFO/influxdb/data/stress/autogen/8
```

I then killed influxd, set tsm-use-seek=true, then continued the test.  Compaction jobs that failed started running immediately, and eventually the total size of the DB far exceeded the 3.6 GB limit.  See again, as in #10486, the peak VM memory usage is less than 1 GB.

```
root@plnx_arm:~# du -hs /LASERINFO/influxdb/data/stress/autogen/ && du -hs /LASERINFO/influxdb/data/stress/autogen/* && cat /proc/1153/status && tail -n 4 /LASERINFO/dan_influxlog_seek
5.2G    /LASERINFO/influxdb/data/stress/autogen/
284.7M  /LASERINFO/influxdb/data/stress/autogen/10
325.7M  /LASERINFO/influxdb/data/stress/autogen/11
416.6M  /LASERINFO/influxdb/data/stress/autogen/12
438.7M  /LASERINFO/influxdb/data/stress/autogen/13
448.8M  /LASERINFO/influxdb/data/stress/autogen/14
452.3M  /LASERINFO/influxdb/data/stress/autogen/15
420.4M  /LASERINFO/influxdb/data/stress/autogen/16
136.5M  /LASERINFO/influxdb/data/stress/autogen/17
174.2M  /LASERINFO/influxdb/data/stress/autogen/2
371.6M  /LASERINFO/influxdb/data/stress/autogen/3
419.6M  /LASERINFO/influxdb/data/stress/autogen/4
425.3M  /LASERINFO/influxdb/data/stress/autogen/5
404.4M  /LASERINFO/influxdb/data/stress/autogen/6
415.3M  /LASERINFO/influxdb/data/stress/autogen/7
8.2M    /LASERINFO/influxdb/data/stress/autogen/8
221.9M  /LASERINFO/influxdb/data/stress/autogen/9
Name:   influxd
Umask:  0022
State:  S (sleeping)
Tgid:   1153
Ngid:   0
Pid:    1153
PPid:   939
TracerPid:      0
Uid:    0       0       0       0
Gid:    0       0       0       0
FDSize: 256
Groups: 0
VmPeak:   924972 kB <----------------------- less than 1GB
```

I was also able to query influxd using the influx client while running the test without any problems.  In my previous fix attempt, querying (even if no data was being written) could cause memory faults and kill the process.

This fix should help ease a consistent pain point with InfluxDB running on 32bit systems (like RPi or Zynq) in which is works great for long periods of time but then hits a wall at the e.g. 3.6 GB limit (depending on system).