### PR TITLE
updating token path to generate default directory

### DIFF
--- a/internal/fs/influx_dir.go
+++ b/internal/fs/influx_dir.go
@@ -24,9 +24,9 @@ func InfluxDir() (string, error) {
 		}
 		dir = wd
 	}
-	dir = filepath.Join(dir, ".influxdbv2")
 
-	return dir, nil
+	dir = filepath.Join(dir, ".influxdbv2")
+	return dir, os.MkdirAll(dir, 0700)
 }
 
 // BoltFile returns the path to the bolt file for influxdb


### PR DESCRIPTION
Closes #12356 

_Briefly describe your proposed changes:_

Creates the `.influxdbv2` directory for the default token path in case it doesn't exist.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
