### PR TITLE
fix(setup): create dir when influxdb ran as a different user

### DIFF
--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -71,12 +71,16 @@ func setupF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to setup instance: %v", err)
 	}
-	err = writeTokenToPath(result.Auth.Token, defaultTokenPath())
+	dPath, dir, err := defaultTokenPath()
 	if err != nil {
-		return fmt.Errorf("failed to write token to path %q: %v", defaultTokenPath(), err)
+		return err
+	}
+	err = writeTokenToPath(result.Auth.Token, dPath, dir)
+	if err != nil {
+		return fmt.Errorf("failed to write token to path %q: %v", dPath, err)
 	}
 
-	fmt.Println(promptWithColor("Your token has been stored in "+defaultTokenPath()+".", colorCyan))
+	fmt.Println(promptWithColor("Your token has been stored in "+dPath+".", colorCyan))
 
 	w := internal.NewTabWriter(os.Stdout)
 	w.WriteHeaders(


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/12356
So this issue happens when the influxdb user and cli user is different. Which results the InfluxDir ends up with different folders. 

_Briefly describe your proposed changes:_

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
