### PR TITLE
fix(tasks): replace organization on tasks with org name string

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5604,7 +5604,7 @@ components:
           description: The ID of the organization that owns this Task.
           type: string
         org:
-          description: The organization that owns this Task.
+          description: The name of the organization that owns this Task.
           type: string
         name:
           description: A description of the task.

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -280,7 +280,7 @@ export const tasks: Task[] = [
     flux:
       'option task = {\n  name: "pasdlak",\n  cron: "2 0 * * *"\n}\nfrom(bucket: "inbucket") \n|> range(start: -1h)',
     cron: '2 0 * * *',
-    organization: orgs[0],
+    org: 'default',
     labels: [],
   },
   {
@@ -291,16 +291,7 @@ export const tasks: Task[] = [
     flux:
       'option task = {\n  name: "somename",\n  every: 1m,\n}\nfrom(bucket: "inbucket") \n|> range(start: -task.every)',
     every: '1m0s',
-    organization: {
-      links: {
-        buckets: '/api/v2/buckets?org=RadicalOrganization',
-        dashboards: '/api/v2/dashboards?org=RadicalOrganization',
-        self: '/api/v2/orgs/02ee9e2a29d73000',
-        tasks: '/api/v2/tasks?org=RadicalOrganization',
-      },
-      id: '02ee9e2a29d73000',
-      name: 'RadicalOrganization',
-    },
+    org: 'default',
     labels,
   },
 ]

--- a/ui/src/organizations/actions/orgView.ts
+++ b/ui/src/organizations/actions/orgView.ts
@@ -1,5 +1,5 @@
-import {Task, Organization} from 'src/types/v2'
-import {ScraperTargetRequest} from '@influxdata/influx'
+import {Organization} from 'src/types/v2'
+import {ScraperTargetRequest, Task} from '@influxdata/influx'
 
 import {client} from 'src/utils/api'
 
@@ -22,10 +22,8 @@ export const populateTasks = (tasks: Task[]): PopulateTasks => ({
 
 export const getTasks = (org: Organization) => async dispatch => {
   const tasks = await client.tasks.getAllByOrg(org.name)
-  const organization = await client.organizations.get(org.id)
-  const tasksWithOrg = tasks.map(t => ({...t, organization})) as Task[]
-
-  dispatch(populateTasks(tasksWithOrg))
+  console.log(tasks)
+  dispatch(populateTasks(tasks))
 }
 
 export const createScraper = (scraper: ScraperTargetRequest) => async () => {

--- a/ui/src/organizations/components/OrgTaskEditPage.tsx
+++ b/ui/src/organizations/components/OrgTaskEditPage.tsx
@@ -22,8 +22,8 @@ import {
 } from 'src/tasks/actions/v2'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {Task, Links} from 'src/types/v2'
+import {Organization, Task} from '@influxdata/influx'
+import {Links} from 'src/types/v2'
 import {State as TasksState} from 'src/tasks/reducers/v2'
 import {
   TaskOptions,

--- a/ui/src/organizations/components/OrgTasksPage.tsx
+++ b/ui/src/organizations/components/OrgTasksPage.tsx
@@ -26,8 +26,8 @@ import {
 } from 'src/tasks/actions/v2'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState, Task, TaskStatus} from 'src/types/v2'
+import {Organization, Task} from '@influxdata/influx'
+import {AppState, TaskStatus} from 'src/types/v2'
 import {client} from 'src/utils/api'
 
 interface PassedInProps {

--- a/ui/src/organizations/reducers/orgView.ts
+++ b/ui/src/organizations/reducers/orgView.ts
@@ -3,8 +3,8 @@ import {
   Telegraf,
   ScraperTargetResponse,
   Bucket,
+  Task,
 } from '@influxdata/influx'
-import {Task} from 'src/types/v2'
 import {Dashboard} from 'src/types'
 import {ActionTypes, Actions} from 'src/organizations/actions/orgView'
 

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -24,7 +24,8 @@ import {
 } from 'src/shared/copy/v2/notifications'
 
 // Types
-import {AppState, Label, Task} from 'src/types/v2'
+import {AppState, Label} from 'src/types/v2'
+import {Task} from '@influxdata/influx'
 
 // Utils
 import {getDeep} from 'src/utils/wrappers'
@@ -327,16 +328,12 @@ export const populateTasks = () => async (
 }
 
 export const selectTaskByID = (id: string, route?: string) => async (
-  dispatch,
-  getState: GetStateFunc
+  dispatch
 ): Promise<void> => {
   try {
-    const {orgs} = getState()
-
     const task = (await client.tasks.get(id)) as Task
-    const org = orgs.find(org => org.id === task.orgID)
 
-    return dispatch(setCurrentTask({...task, organization: org}))
+    return dispatch(setCurrentTask({...task}))
   } catch (e) {
     console.error(e)
     dispatch(goToTasks(route))

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -9,8 +9,7 @@ import FeatureFlag from 'src/shared/components/FeatureFlag'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'
-import {Task as TaskAPI} from '@influxdata/influx'
-import {Task} from 'src/types/v2'
+import {Task} from '@influxdata/influx'
 
 // Constants
 import {DEFAULT_TASK_NAME} from 'src/dashboards/constants'
@@ -37,7 +36,7 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
         testID="task-card"
         disabled={!this.isTaskActive}
         labels={() => this.labels}
-        owner={task.organization}
+        owner={{name: task.org, id: task.orgID}}
         contextMenu={() => this.contextMenu}
         name={() => (
           <ResourceList.Name
@@ -118,9 +117,7 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
 
   private handleExport = () => {
     const {router, task} = this.props
-    router.push(
-      `/organizations/${task.organization.id}/tasks/${task.id}/export`
-    )
+    router.push(`/organizations/${task.orgID}/tasks/${task.id}/export`)
   }
 
   private get labels(): JSX.Element {
@@ -154,7 +151,7 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
 
   private get isTaskActive(): boolean {
     const {task} = this.props
-    if (task.status === TaskAPI.StatusEnum.Active) {
+    if (task.status === Task.StatusEnum.Active) {
       return true
     }
     return false
@@ -168,10 +165,10 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
 
   private changeToggle = () => {
     const {task, onActivate} = this.props
-    if (task.status === TaskAPI.StatusEnum.Active) {
-      task.status = TaskAPI.StatusEnum.Inactive
+    if (task.status === Task.StatusEnum.Active) {
+      task.status = Task.StatusEnum.Inactive
     } else {
-      task.status = TaskAPI.StatusEnum.Active
+      task.status = Task.StatusEnum.Active
     }
     onActivate(task)
   }

--- a/ui/src/tasks/components/TasksList.tsx
+++ b/ui/src/tasks/components/TasksList.tsx
@@ -11,7 +11,7 @@ import EditLabelsOverlay from 'src/shared/components/EditLabelsOverlay'
 
 // Types
 import EmptyTasksList from 'src/tasks/components/EmptyTasksList'
-import {Task} from 'src/types/v2'
+import {Task} from '@influxdata/influx'
 
 import {Sort} from 'src/clockface'
 import {

--- a/ui/src/tasks/components/__snapshots__/TasksList.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TasksList.test.tsx.snap
@@ -58,17 +58,8 @@ from(bucket: \\"inbucket\\")
               "id": "02ef9deff2141000",
               "labels": Array [],
               "name": "pasdlak",
+              "org": "default",
               "orgID": "02ee9e2a29d73000",
-              "organization": Object {
-                "id": "02ee9e2a29d73000",
-                "links": Object {
-                  "buckets": "/api/v2/buckets?org=RadicalOrganization",
-                  "dashboards": "/api/v2/dashboards?org=RadicalOrganization",
-                  "self": "/api/v2/orgs/02ee9e2a29d73000",
-                  "tasks": "/api/v2/tasks?org=RadicalOrganization",
-                },
-                "name": "RadicalOrganization",
-              },
               "status": "active",
             },
             Object {
@@ -99,17 +90,8 @@ from(bucket: \\"inbucket\\")
                 },
               ],
               "name": "somename",
+              "org": "default",
               "orgID": "02ee9e2a29d73000",
-              "organization": Object {
-                "id": "02ee9e2a29d73000",
-                "links": Object {
-                  "buckets": "/api/v2/buckets?org=RadicalOrganization",
-                  "dashboards": "/api/v2/dashboards?org=RadicalOrganization",
-                  "self": "/api/v2/orgs/02ee9e2a29d73000",
-                  "tasks": "/api/v2/tasks?org=RadicalOrganization",
-                },
-                "name": "RadicalOrganization",
-              },
               "status": "active",
             },
           ]

--- a/ui/src/tasks/containers/TaskEditPage.tsx
+++ b/ui/src/tasks/containers/TaskEditPage.tsx
@@ -22,14 +22,14 @@ import {
 } from 'src/tasks/actions/v2'
 
 // Types
-import {Organization} from '@influxdata/influx'
+import {Organization, Task} from '@influxdata/influx'
 import {State as TasksState} from 'src/tasks/reducers/v2'
 import {
   TaskOptions,
   TaskOptionKeys,
   TaskSchedule,
 } from 'src/utils/taskOptionsToFluxScript'
-import {Task, Links} from 'src/types/v2'
+import {Links} from 'src/types/v2'
 
 interface PassedInProps {
   router: InjectedRouter

--- a/ui/src/tasks/reducers/v2/index.ts
+++ b/ui/src/tasks/reducers/v2/index.ts
@@ -1,10 +1,10 @@
 import {TaskOptions, TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
 import {Run, LogEvent} from '@influxdata/influx'
 
-//Types
+// Types
 import {Action} from 'src/tasks/actions/v2'
+import {Task} from '@influxdata/influx'
 import {RemoteDataState} from '@influxdata/clockface'
-import {Task} from 'src/types/v2'
 
 export interface State {
   newScript: string

--- a/ui/src/types/tasks.ts
+++ b/ui/src/types/tasks.ts
@@ -1,0 +1,3 @@
+import {Task as TaskAPI} from '@influxdata/influx'
+
+export const TaskStatus = TaskAPI.StatusEnum

--- a/ui/src/types/v2/index.ts
+++ b/ui/src/types/v2/index.ts
@@ -19,9 +19,9 @@ import {
 } from 'src/types/v2/dashboards'
 
 import {Source} from '@influxdata/influx'
-import {Task, TaskStatus} from 'src/types/v2/tasks'
 import {Member} from 'src/types/v2/members'
-import {Organization} from '@influxdata/influx'
+import {Organization, Task} from '@influxdata/influx'
+import {TaskStatus} from 'src/types/tasks'
 import {Links} from 'src/types/v2/links'
 import {Notification} from 'src/types'
 import {TimeRange} from 'src/types/queries'

--- a/ui/src/types/v2/tasks.ts
+++ b/ui/src/types/v2/tasks.ts
@@ -1,9 +1,0 @@
-import {Task as TaskAPI, Organization, User, Label} from '@influxdata/influx'
-
-export interface Task extends Exclude<TaskAPI, 'labels'> {
-  labels: Label[]
-  organization: Organization
-  owner?: User
-}
-
-export const TaskStatus = TaskAPI.StatusEnum


### PR DESCRIPTION
Closes #12250 

This PR replaces removes the wrapper for the Task type from the "types" directory and replaces it with a direct import from the client library. It also moves the Task types file to live under "src/types" rather than "src/types/v2."

The addition of an "organization" object to Tasks in the `orgView` actions is removed. The correct property on a Task object is a string `org` which is the name of the organization the Task belongs too.

  - [x] Rebased/mergeable
  - [x] Tests pass
