### PR TITLE
fix(ui): update z-index of cells when hovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 1. [12302](https://github.com/influxdata/influxdb/pull/12302): Prevent clipping of code snippets in Firefox
+1. [12379](https://github.com/influxdata/influxdb/pull/12379): Prevent clipping of cell edit menus in dashboards
 
 ### UI Improvements
 

--- a/ui/src/shared/components/cells/react-grid-layout.scss
+++ b/ui/src/shared/components/cells/react-grid-layout.scss
@@ -14,6 +14,10 @@
   z-index: $z--cell-default;
   transition: all 200ms ease;
   transition-property: left, top;
+
+  &:hover {
+    z-index: $z--cell-context-hover;
+  }
 }
 .react-grid-item.cssTransforms {
   transition-property: transform;
@@ -58,7 +62,7 @@
   bottom: 0;
   right: 0;
   opacity: 0;
-  
+
   &:before,
   &:after {
     content: '';


### PR DESCRIPTION
Co-authored-by: thealexpaxton@gmail.com

Closes #11579

_Briefly describe your proposed changes:_
Prevent cells' edit menus from getting clipped when there is another cell directly beneath them.

![screen shot 2019-03-05 at 3 52 40 pm](https://user-images.githubusercontent.com/5751863/53845693-e0a69500-3f5e-11e9-886e-bdea84bebd10.png)


  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
