### PR TITLE
fix(testing): update bucket update uniqueness

### DIFF
--- a/bolt/bucket.go
+++ b/bolt/bucket.go
@@ -528,6 +528,14 @@ func (c *Client) updateBucket(ctx context.Context, tx *bolt.Tx, id platform.ID, 
 	}
 
 	if upd.Name != nil {
+		_, err := c.findBucketByName(ctx, tx, b.OrganizationID, *upd.Name)
+		if err == nil {
+			return nil, &platform.Error{
+				Code: platform.EConflict,
+				Msg:  "bucket name is not unique",
+			}
+		}
+
 		key, err := bucketIndexKey(b)
 		if err != nil {
 			return nil, err

--- a/inmem/bucket_service.go
+++ b/inmem/bucket_service.go
@@ -294,6 +294,16 @@ func (s *Service) UpdateBucket(ctx context.Context, id platform.ID, upd platform
 		b.RetentionPeriod = *upd.RetentionPeriod
 	}
 
+	_, err = s.FindBucket(ctx, platform.BucketFilter{
+		Name: upd.Name,
+	})
+	if err == nil {
+		return nil, &platform.Error{
+			Code: platform.EConflict,
+			Msg:  "bucket name is not unique",
+		}
+	}
+
 	s.bucketKV.Store(b.ID.String(), b)
 
 	return b, nil

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -573,6 +573,13 @@ func (s *Service) updateBucket(ctx context.Context, tx Tx, id influxdb.ID, upd i
 	}
 
 	if upd.Name != nil {
+		_, err := s.findBucketByName(ctx, tx, b.OrganizationID, *upd.Name)
+		if err == nil {
+			return nil, &influxdb.Error{
+				Code: influxdb.EConflict,
+				Msg:  "bucket name is not unique",
+			}
+		}
 		key, err := bucketIndexKey(b)
 		if err != nil {
 			return nil, err

--- a/testing/bucket_service.go
+++ b/testing/bucket_service.go
@@ -1134,6 +1134,39 @@ func UpdateBucket(
 			},
 		},
 		{
+			name: "update name unique",
+			fields: BucketFields{
+				Organizations: []*platform.Organization{
+					{
+						Name: "theorg",
+						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Buckets: []*platform.Bucket{
+					{
+						ID:             MustIDBase16(bucketOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "bucket1",
+					},
+					{
+						ID:             MustIDBase16(bucketTwoID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "bucket2",
+					},
+				},
+			},
+			args: args{
+				id:   MustIDBase16(bucketOneID),
+				name: "bucket2",
+			},
+			wants: wants{
+				err: &platform.Error{
+					Code: platform.EConflict,
+					Msg:  "bucket name is not unique",
+				},
+			},
+		},
+		{
 			name: "update retention",
 			fields: BucketFields{
 				Organizations: []*platform.Organization{


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/12381

fix the update bucket name to prevent duplicate name
add test case

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
