### PR TITLE
Add configuration for stale probot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Configuration for https://probot.github.io/apps/stale/
+#
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: true
+


### PR DESCRIPTION
This PR configures https://probot.github.io/apps/stale/ (which I installed separately) to mark all tickets inactive for 90s as stale - and to close stale tickets 7 days later.  

This is a step towards applying discipline to the influxdb repository issue cruft.

Separately, Russ and I are creating a triage process for new issues and community PRs.