### PR TITLE
Add the ability to add members to an org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## v2.0.0-alpha.5 [unreleased]
 
 ### Features
+
 1. [12096](https://github.com/influxdata/influxdb/pull/12096): Add labels to cloned tasks
 1. [12111](https://github.com/influxdata/influxdb/pull/12111): Add ability to filter resources by clicking a label
+1. [12401](https://github.com/influxdata/influxdb/pull/12401): Add ability to add a member to org
 
 ### Bug Fixes
 
@@ -19,6 +21,7 @@
 ## v2.0.0-alpha.4 [2019-02-21]
 
 ### Features
+
 1. [11954](https://github.com/influxdata/influxdb/pull/11954): Add the ability to run a task manually from tasks page
 1. [11990](https://github.com/influxdata/influxdb/pull/11990): Add the ability to select a custom time range in explorer and dashboard
 1. [12009](https://github.com/influxdata/influxdb/pull/12009): Display the version information on the login page
@@ -28,17 +31,20 @@
 1. [11973](https://github.com/influxdata/influxdb/pull/11973): Add ability to create or add labels to a resource from labels editor
 
 ### Bug Fixes
+
 1. [11997](https://github.com/influxdata/influxdb/pull/11997): Update the bucket retention policy to update the time in seconds
 
 ### UI Improvements
+
 1. [12016](https://github.com/influxdata/influxdb/pull/12016): Update the preview in the label overlays to be shorter
-1. [12012](https://github.com/influxdata/influxdb/pull/12012): Add notifications to scrapers page for created/deleted/updated scrapers 
+1. [12012](https://github.com/influxdata/influxdb/pull/12012): Add notifications to scrapers page for created/deleted/updated scrapers
 1. [12023](https://github.com/influxdata/influxdb/pull/12023): Add notifications to buckets page for created/deleted/updated buckets
 1. [12072](https://github.com/influxdata/influxdb/pull/12072): Update the admin page to display error for password length
 
 ## v2.0.0-alpha.3 [2019-02-15]
 
 ### Features
+
 1. [11809](https://github.com/influxdata/influxdb/pull/11809): Add the ability to name a scraper target
 1. [11821](https://github.com/influxdata/influxdb/pull/11821): Display scraper name as the first and only updatable column in scrapers list
 1. [11804](https://github.com/influxdata/influxdb/pull/11804): Add the ability to view runs for a task
@@ -46,11 +52,13 @@
 1. [11836](https://github.com/influxdata/influxdb/pull/11836): Add the ability to view the logs for a specific task run
 
 ### Bug Fixes
+
 1. [11819](https://github.com/influxdata/influxdb/pull/11819): Update the inline edit for resource names to guard for empty strings
 1. [11852](https://github.com/influxdata/influxdb/pull/11852): Prevent a new template dashboard from being created on every telegraf config update
 1. [11848](https://github.com/influxdata/influxdb/pull/11848): Fix overlapping buttons in the telegrafs verify data step
 
 ### UI Improvements
+
 1. [11764](https://github.com/influxdata/influxdb/pull/11764): Move the download telegraf config button to view config overlay
 1. [11879](https://github.com/influxdata/influxdb/pull/11879): Combine permissions for user by type
 1. [11938](https://github.com/influxdata/influxdb/pull/11938): Add ordering to UI list items
@@ -58,8 +66,9 @@
 ## v2.0.0-alpha.2 [2019-02-07]
 
 ### Features
+
 1. [11677](https://github.com/influxdata/influxdb/pull/11677): Add instructions button to view `$INFLUX_TOKEN` setup for telegraf configs
-1. [11693](https://github.com/influxdata/influxdb/pull/11693): Save the $INFLUX_TOKEN environmental variable in telegraf configs
+1. [11693](https://github.com/influxdata/influxdb/pull/11693): Save the \$INFLUX_TOKEN environmental variable in telegraf configs
 1. [11700](https://github.com/influxdata/influxdb/pull/11700): Update Tasks tab on Org page to look like Tasks Page
 1. [11740](https://github.com/influxdata/influxdb/pull/11740): Add view button to view the telegraf config toml
 1. [11522](https://github.com/influxdata/influxdb/pull/11522): Add plugin information step to allow for config naming and configure one plugin at a time
@@ -67,10 +76,12 @@
 1. [11810](https://github.com/influxdata/influxdb/pull/11810): Add tab for template variables under organizations page
 
 ## Bug Fixes
+
 1. [11678](https://github.com/influxdata/influxdb/pull/11678): Update the System Telegraf Plugin bundle to include the swap plugin
 1. [11722](https://github.com/influxdata/influxdb/pull/11722): Revert behavior allowing users to create authorizations on behalf of another user
 
 ### UI Improvements
+
 1. [11683](https://github.com/influxdata/influxdb/pull/11683): Change the wording for the plugin config form button to Done
 1. [11689](https://github.com/influxdata/influxdb/pull/11689): Change the wording for the Collectors configure step button to Create and Verify
 1. [11697](https://github.com/influxdata/influxdb/pull/11697): Standardize page loading spinner styles

--- a/ui/src/organizations/components/AddMembersForm.tsx
+++ b/ui/src/organizations/components/AddMembersForm.tsx
@@ -1,0 +1,56 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import {Button, ButtonType} from '@influxdata/clockface'
+import {Form, Grid} from 'src/clockface'
+import SelectUsers from 'src/organizations/components/SelectUsers'
+import {User} from '@influxdata/influx'
+
+interface Props {
+  onCloseModal: () => void
+  users: User[]
+  onSelect: (selectedIDs: string[]) => void
+  selectedUserIDs: string[]
+  onSave: () => void
+}
+
+export default class AddMembersForm extends PureComponent<Props> {
+  public render() {
+    const {onCloseModal, users, onSelect, selectedUserIDs, onSave} = this.props
+
+    return (
+      <Form>
+        <Grid>
+          <Grid.Row>
+            <Grid.Column>
+              <Form.Element label="Select Users">
+                <SelectUsers
+                  users={users}
+                  onSelect={onSelect}
+                  selectedUserIDs={selectedUserIDs}
+                />
+              </Form.Element>
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Column>
+              <Form.Footer>
+                <Button
+                  text="Cancel"
+                  type={ButtonType.Button}
+                  onClick={onCloseModal}
+                />
+                <Button
+                  text="Save Changes"
+                  type={ButtonType.Submit}
+                  onClick={onSave}
+                />
+              </Form.Footer>
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Form>
+    )
+  }
+}

--- a/ui/src/organizations/components/AddMembersOverlay.tsx
+++ b/ui/src/organizations/components/AddMembersOverlay.tsx
@@ -1,0 +1,66 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import {OverlayBody, OverlayHeading, OverlayContainer} from 'src/clockface'
+import AddMembersForm from './AddMembersForm'
+import {User, AddResourceMemberRequestBody} from '@influxdata/influx'
+
+interface Props {
+  onCloseModal: () => void
+  users: User[]
+  addUser: (user: AddResourceMemberRequestBody) => void
+}
+
+interface State {
+  selectedUserIDs: string[]
+}
+
+export default class AddMembersOverlay extends PureComponent<Props, State> {
+  public state: State = {
+    selectedUserIDs: [],
+  }
+
+  constructor(props) {
+    super(props)
+  }
+
+  public render() {
+    const {onCloseModal, users} = this.props
+    const {selectedUserIDs} = this.state
+
+    return (
+      <OverlayContainer maxWidth={500}>
+        <OverlayHeading title="Add Member" onDismiss={onCloseModal} />
+        <OverlayBody>
+          <AddMembersForm
+            onCloseModal={onCloseModal}
+            users={users}
+            onSelect={this.handleSelectUserID}
+            selectedUserIDs={selectedUserIDs}
+            onSave={this.handleSave}
+          />
+        </OverlayBody>
+      </OverlayContainer>
+    )
+  }
+
+  private handleSelectUserID = (selectedIDs: string[]) => {
+    this.setState({selectedUserIDs: selectedIDs})
+  }
+
+  private handleSave = () => {
+    const {users, addUser} = this.props
+    const {selectedUserIDs} = this.state
+
+    selectedUserIDs.forEach(id => {
+      const user = users.find(l => {
+        return l.id === id
+      })
+
+      if (user) {
+        addUser({id: user.id, name: user.name})
+      }
+    })
+  }
+}

--- a/ui/src/organizations/components/Members.tsx
+++ b/ui/src/organizations/components/Members.tsx
@@ -3,20 +3,48 @@ import React, {PureComponent, ChangeEvent} from 'react'
 import _ from 'lodash'
 
 // Components
-import {ComponentSize, EmptyState, IconFont, Input, Tabs} from 'src/clockface'
+import {
+  ComponentSize,
+  EmptyState,
+  IconFont,
+  Input,
+  Tabs,
+  OverlayTechnology,
+} from 'src/clockface'
 import MemberList from 'src/organizations/components/MemberList'
 import FilterList from 'src/shared/components/Filter'
+import AddMembersOverlay from 'src/organizations/components/AddMembersOverlay'
+
+// Actions
+import * as NotificationsActions from 'src/types/actions/notifications'
 
 // Types
-import {ResourceOwner} from '@influxdata/influx'
+import {
+  ResourceOwner,
+  User,
+  AddResourceMemberRequestBody,
+} from '@influxdata/influx'
+import {OverlayState} from 'src/types'
+import {Button, ComponentColor} from '@influxdata/clockface'
+
+// APIs
+import {client} from 'src/utils/api'
+import {
+  memberAddSuccess,
+  memberAddFailed,
+} from 'src/shared/copy/v2/notifications'
 
 interface Props {
   members: ResourceOwner[]
   orgName: string
+  orgID: string
+  notify: NotificationsActions.PublishNotificationActionCreator
 }
 
 interface State {
   searchTerm: string
+  overlayState: OverlayState
+  users: User[]
 }
 
 export default class Members extends PureComponent<Props, State> {
@@ -24,10 +52,12 @@ export default class Members extends PureComponent<Props, State> {
     super(props)
     this.state = {
       searchTerm: '',
+      overlayState: OverlayState.Closed,
+      users: [],
     }
   }
   public render() {
-    const {searchTerm} = this.state
+    const {searchTerm, overlayState} = this.state
 
     return (
       <>
@@ -40,6 +70,12 @@ export default class Members extends PureComponent<Props, State> {
             onChange={this.handleFilterChange}
             onBlur={this.handleFilterChange}
           />
+          <Button
+            text="Add Member"
+            icon={IconFont.Plus}
+            color={ComponentColor.Primary}
+            onClick={this.handleOpenModal}
+          />
         </Tabs.TabContentsHeader>
         <FilterList<ResourceOwner>
           list={this.props.members}
@@ -48,12 +84,48 @@ export default class Members extends PureComponent<Props, State> {
         >
           {ms => <MemberList members={ms} emptyState={this.emptyState} />}
         </FilterList>
+        <OverlayTechnology visible={overlayState === OverlayState.Open}>
+          <AddMembersOverlay
+            onCloseModal={this.handleCloseModal}
+            users={this.state.users}
+            addUser={this.addUser}
+          />
+        </OverlayTechnology>
       </>
     )
   }
 
   private handleFilterChange = (e: ChangeEvent<HTMLInputElement>): void => {
     this.setState({searchTerm: e.target.value})
+  }
+
+  private handleOpenModal = async () => {
+    await this.getUsers()
+    this.setState({overlayState: OverlayState.Open})
+  }
+
+  private handleCloseModal = (): void => {
+    this.setState({overlayState: OverlayState.Closed})
+  }
+
+  private async getUsers() {
+    const data = await client.users.getAllUsers()
+    this.setState({users: data.users})
+  }
+
+  private addUser = async (user: AddResourceMemberRequestBody) => {
+    const {notify} = this.props
+
+    try {
+      await client.organizations.addMember(this.props.orgID, user)
+      this.setState({overlayState: OverlayState.Closed})
+      notify(memberAddSuccess())
+    } catch (e) {
+      console.error(e)
+      this.setState({overlayState: OverlayState.Closed})
+      const message = _.get(e, 'response.data.message', 'Unknown error')
+      notify(memberAddFailed(message))
+    }
   }
 
   private get emptyState(): JSX.Element {

--- a/ui/src/organizations/components/SelectUsers.tsx
+++ b/ui/src/organizations/components/SelectUsers.tsx
@@ -1,0 +1,30 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {MultiSelectDropdown, Dropdown} from 'src/clockface'
+import {User} from '@influxdata/influx'
+
+interface Props {
+  users: User[]
+  onSelect: (selectedIDs: string[]) => void
+  selectedUserIDs: string[]
+}
+
+export default class SelectUsers extends PureComponent<Props> {
+  public render() {
+    return (
+      <>
+        <MultiSelectDropdown
+          selectedIDs={this.props.selectedUserIDs}
+          onChange={this.props.onSelect}
+          emptyText="Select user"
+        >
+          {this.props.users.map(cn => (
+            <Dropdown.Item id={cn.id} key={cn.id} value={cn}>
+              {cn.name}
+            </Dropdown.Item>
+          ))}
+        </MultiSelectDropdown>
+      </>
+    )
+  }
+}

--- a/ui/src/organizations/containers/OrgMembersIndex.tsx
+++ b/ui/src/organizations/containers/OrgMembersIndex.tsx
@@ -13,6 +13,10 @@ import TabbedPageSection from 'src/shared/components/tabbed_page/TabbedPageSecti
 import GetOrgResources from 'src/organizations/components/GetOrgResources'
 import Members from 'src/organizations/components/Members'
 
+//Actions
+import * as NotificationsActions from 'src/types/actions/notifications'
+import * as notifyActions from 'src/shared/actions/notifications'
+
 // APIs
 import {client} from 'src/utils/api'
 
@@ -27,11 +31,15 @@ interface RouterProps {
   }
 }
 
+interface DispatchProps {
+  notify: NotificationsActions.PublishNotificationActionCreator
+}
+
 interface StateProps {
   org: Organization
 }
 
-type Props = WithRouterProps & RouterProps & StateProps
+type Props = WithRouterProps & RouterProps & StateProps & DispatchProps
 
 const getOwnersAndMembers = async (org: Organization) => {
   const allMembers = await Promise.all([
@@ -49,7 +57,7 @@ class OrgMembersIndex extends Component<Props> {
   }
 
   public render() {
-    const {org} = this.props
+    const {org, notify} = this.props
 
     return (
       <Page titleTag={org.name}>
@@ -73,7 +81,12 @@ class OrgMembersIndex extends Component<Props> {
                         loading={loading}
                         spinnerComponent={<TechnoSpinner />}
                       >
-                        <Members members={members} orgName={org.name} />
+                        <Members
+                          members={members}
+                          orgName={org.name}
+                          orgID={org.id}
+                          notify={notify}
+                        />
                       </SpinnerContainer>
                     )}
                   </GetOrgResources>
@@ -95,4 +108,11 @@ const mstp = (state: AppState, props: Props) => {
   }
 }
 
-export default connect<StateProps>(mstp)(withRouter<{}>(OrgMembersIndex))
+const mdtp: DispatchProps = {
+  notify: notifyActions.notify,
+}
+
+export default connect<StateProps>(
+  mstp,
+  mdtp
+)(withRouter<{}>(OrgMembersIndex))

--- a/ui/src/shared/copy/v2/notifications.ts
+++ b/ui/src/shared/copy/v2/notifications.ts
@@ -212,3 +212,13 @@ export const telegrafDeleteFailed = (telegrafName: string): Notification => ({
   ...defaultErrorNotification,
   message: `Failed to delete telegraf: "${telegrafName}"`,
 })
+
+export const memberAddSuccess = (): Notification => ({
+  ...defaultSuccessNotification,
+  message: 'Members added successfully',
+})
+
+export const memberAddFailed = (message: string): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to add members: "${message}"`,
+})


### PR DESCRIPTION
Closes #11854 

_Briefly describe your proposed changes:_
Create a component overlay for the add members and a form component on the overlay. Add api calls on the client to get all users and add member to an org. 

  - [x] Rebased/mergeable
  - [x] Tests pass
