### PR TITLE
feat(ui/oauth/redirect): redirects to /api/v2/signin

### DIFF
--- a/ui/src/Logout.tsx
+++ b/ui/src/Logout.tsx
@@ -5,6 +5,9 @@ import {withRouter, WithRouterProps} from 'react-router'
 // APIs
 import {client} from 'src/utils/api'
 
+// Constants
+import {CLOUD, CLOUD_SIGNIN_PATHNAME} from 'src/shared/constants'
+
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -22,6 +25,11 @@ export class Logout extends PureComponent<Props> {
 
   private handleSignOut = async () => {
     await client.auth.signout()
+
+    if (CLOUD) {
+      window.location.pathname = CLOUD_SIGNIN_PATHNAME
+      return
+    }
 
     this.props.router.push(`/signin`)
   }

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -67,6 +67,7 @@ export class Signin extends PureComponent<Props, State> {
 
   private checkForLogin = async () => {
     try {
+      this.setState({loading: RemoteDataState.Loading})
       await client.users.me()
       this.setState({loading: RemoteDataState.Done})
     } catch (error) {

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -14,6 +14,7 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 // Constants
 import {sessionTimedOut} from 'src/shared/copy/notifications'
+import {CLOUD, CLOUD_SIGNIN_PATHNAME} from 'src/shared/constants'
 
 // Types
 import {RemoteDataState} from 'src/types'
@@ -46,8 +47,7 @@ export class Signin extends PureComponent<Props, State> {
   }
 
   public async componentDidMount() {
-    this.setState({loading: RemoteDataState.Done})
-    this.checkForLogin()
+    await this.checkForLogin()
     this.intervalID = setInterval(this.checkForLogin, FETCH_WAIT)
   }
 
@@ -68,11 +68,19 @@ export class Signin extends PureComponent<Props, State> {
   private checkForLogin = async () => {
     try {
       await client.users.me()
+      this.setState({loading: RemoteDataState.Done})
     } catch (error) {
       const {
         location: {pathname},
       } = this.props
       clearInterval(this.intervalID)
+
+      // TODO: add returnTo to CLOUD signin
+      if (CLOUD) {
+        window.location.pathname = CLOUD_SIGNIN_PATHNAME
+
+        return
+      }
 
       if (pathname.startsWith('/signin')) {
         return

--- a/ui/src/onboarding/containers/SigninPage.tsx
+++ b/ui/src/onboarding/containers/SigninPage.tsx
@@ -15,6 +15,9 @@ import {RemoteDataState} from 'src/types'
 import Notifications from 'src/shared/components/notifications/Notifications'
 import VersionInfo from 'src/shared/components/VersionInfo'
 
+// Constants
+import {CLOUD, CLOUD_SIGNIN_PATHNAME} from 'src/shared/constants'
+
 interface State {
   status: RemoteDataState
 }
@@ -33,6 +36,9 @@ class SigninPage extends PureComponent<WithRouterProps, State> {
 
     if (allowed) {
       this.props.router.push('/onboarding/0')
+    } else if (CLOUD) {
+      window.location.pathname = CLOUD_SIGNIN_PATHNAME
+      return
     }
 
     this.setState({status: RemoteDataState.Done})

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -436,3 +436,4 @@ export const VERSION = process.env.npm_package_version
 export const GIT_SHA = process.env.GIT_SHA
 
 export const CLOUD = process.env.CLOUD && process.env.CLOUD === 'true'
+export const CLOUD_SIGNIN_PATHNAME = '/api/v2/signin'


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Creates a redirect for `/api/v2/signin` in the ui when `CLOUD=true` otherwise does the typical auth flow for OSS. 

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
