### PR TITLE
feat(influxd/launcher): add test mimicing chronograf setup

### DIFF
--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -3,6 +3,7 @@ package launcher_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -45,6 +46,104 @@ func TestLauncher_Setup(t *testing.T) {
 		t.Fatal("expected bucket id")
 	} else if results.Auth.Token == "" {
 		t.Fatal("expected auth token")
+	}
+}
+
+// This is to mimic chronograf using cookies as sessions
+// rather than authorizations
+func TestLauncher_SetupWithUsers(t *testing.T) {
+	l := RunLauncherOrFail(t, ctx)
+	l.SetupOrFail(t)
+	defer l.ShutdownOrFail(t, ctx)
+
+	r, err := nethttp.NewRequest("POST", l.URL()+"/api/v2/signin", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r.SetBasicAuth("USER", "PASSWORD")
+
+	resp, err := nethttp.DefaultClient.Do(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != nethttp.StatusNoContent {
+		t.Fatalf("unexpected status code: %d, body: %s, headers: %v", resp.StatusCode, body, resp.Header)
+	}
+
+	cookies := resp.Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie but received %d", len(cookies))
+	}
+
+	user2 := &platform.User{
+		Name: "USER2",
+	}
+
+	b, _ := json.Marshal(user2)
+	r = l.NewHTTPRequestOrFail(t, "POST", "/api/v2/users", l.Auth.Token, string(b))
+
+	resp, err = nethttp.DefaultClient.Do(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != nethttp.StatusCreated {
+		t.Fatalf("unexpected status code: %d, body: %s, headers: %v", resp.StatusCode, body, resp.Header)
+	}
+
+	r, err = nethttp.NewRequest("GET", l.URL()+"/api/v2/users", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.AddCookie(cookies[0])
+
+	resp, err = nethttp.DefaultClient.Do(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != nethttp.StatusOK {
+		t.Fatalf("unexpected status code: %d, body: %s, headers: %v", resp.StatusCode, body, resp.Header)
+	}
+
+	exp := struct {
+		Users []platform.User `json:"users"`
+	}{}
+	err = json.Unmarshal(body, &exp)
+	if err != nil {
+		t.Fatalf("unexpected error unmarshaling user: %v", err)
+	}
+	if len(exp.Users) != 2 {
+		t.Fatalf("unexpected 2 users: %#+v", exp)
 	}
 }
 


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Adds an integration test for #12422

It runs setup, creates a user, and then mimics chronograf by signing in and checking for users.
