### PR TITLE
Update client dependency to fix dashboard cloning and task import

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -985,9 +985,9 @@
       }
     },
     "@influxdata/influx": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.27.tgz",
-      "integrity": "sha512-B00No54veQGtteUwEcc6/NSCL1bvgOhk3PeD8qPSkHiGHlPZjt3ae+F3sisVtJ4DDqqQTkZTKTyfuBjPX0LntA==",
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.28.tgz",
+      "integrity": "sha512-jnn6MDbj3/VRh188nYQCGYk4uN4WSyeeFhorPgN8tD6ziCTu000ZI2hgUvsjPL7Um3WXH1yIH7qIfBeP0whFtw==",
       "requires": {
         "axios": "^0.18.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -137,7 +137,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "0.0.5",
-    "@influxdata/influx": "0.2.27",
+    "@influxdata/influx": "0.2.28",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -221,7 +221,6 @@ class DashboardIndex extends PureComponent<Props, State> {
         notify(cantImportInvalidResource('Dashboard'))
         return
       }
-      console.log(resource)
       this.handleToggleImportOverlay()
       notify(dashboardImported())
     } catch (error) {


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Update the client dependency will fix issue where cells are duplicated during a dashboard clone and fix issue where task labels are not imported when a task is imported
Removes console.log

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
