### PR TITLE
Update users dropdown to filter out the users that already exist in org

### DIFF
--- a/ui/src/organizations/components/AddMembersForm.tsx
+++ b/ui/src/organizations/components/AddMembersForm.tsx
@@ -5,11 +5,13 @@ import React, {PureComponent} from 'react'
 import {Button, ButtonType} from '@influxdata/clockface'
 import {Form, Grid} from 'src/clockface'
 import SelectUsers from 'src/organizations/components/SelectUsers'
-import {User} from '@influxdata/influx'
+
+// Types
+import {UsersMap} from 'src/organizations/components/Members'
 
 interface Props {
   onCloseModal: () => void
-  users: User[]
+  users: UsersMap
   onSelect: (selectedIDs: string[]) => void
   selectedUserIDs: string[]
   onSave: () => void

--- a/ui/src/organizations/components/AddMembersOverlay.tsx
+++ b/ui/src/organizations/components/AddMembersOverlay.tsx
@@ -4,11 +4,14 @@ import React, {PureComponent} from 'react'
 // Components
 import {OverlayBody, OverlayHeading, OverlayContainer} from 'src/clockface'
 import AddMembersForm from './AddMembersForm'
-import {User, AddResourceMemberRequestBody} from '@influxdata/influx'
+import {AddResourceMemberRequestBody} from '@influxdata/influx'
+
+// Types
+import {UsersMap} from 'src/organizations/components/Members'
 
 interface Props {
   onCloseModal: () => void
-  users: User[]
+  users: UsersMap
   addUser: (user: AddResourceMemberRequestBody) => void
 }
 
@@ -54,12 +57,8 @@ export default class AddMembersOverlay extends PureComponent<Props, State> {
     const {selectedUserIDs} = this.state
 
     selectedUserIDs.forEach(id => {
-      const user = users.find(l => {
-        return l.id === id
-      })
-
-      if (user) {
-        addUser({id: user.id, name: user.name})
+      if (users[id]) {
+        addUser({id: id, name: users[id].name})
       }
     })
   }

--- a/ui/src/organizations/components/SelectUsers.tsx
+++ b/ui/src/organizations/components/SelectUsers.tsx
@@ -1,16 +1,22 @@
 // Libraries
 import React, {PureComponent} from 'react'
+
+//Components
 import {MultiSelectDropdown, Dropdown} from 'src/clockface'
-import {User} from '@influxdata/influx'
+
+// Types
+import {UsersMap} from 'src/organizations/components/Members'
 
 interface Props {
-  users: User[]
+  users: UsersMap
   onSelect: (selectedIDs: string[]) => void
   selectedUserIDs: string[]
 }
 
 export default class SelectUsers extends PureComponent<Props> {
   public render() {
+    const {users} = this.props
+
     return (
       <>
         <MultiSelectDropdown
@@ -18,9 +24,9 @@ export default class SelectUsers extends PureComponent<Props> {
           onChange={this.props.onSelect}
           emptyText="Select user"
         >
-          {this.props.users.map(cn => (
-            <Dropdown.Item id={cn.id} key={cn.id} value={cn}>
-              {cn.name}
+          {Object.keys(users).map(key => (
+            <Dropdown.Item id={key} key={key} value={users[key]}>
+              {users[key].name}
             </Dropdown.Item>
           ))}
         </MultiSelectDropdown>

--- a/ui/src/organizations/containers/OrgMembersIndex.tsx
+++ b/ui/src/organizations/containers/OrgMembersIndex.tsx
@@ -76,7 +76,7 @@ class OrgMembersIndex extends Component<Props> {
                     organization={org}
                     fetcher={getOwnersAndMembers}
                   >
-                    {(members, loading) => (
+                    {(members, loading, fetch) => (
                       <SpinnerContainer
                         loading={loading}
                         spinnerComponent={<TechnoSpinner />}
@@ -86,6 +86,7 @@ class OrgMembersIndex extends Component<Props> {
                           orgName={org.name}
                           orgID={org.id}
                           notify={notify}
+                          onChange={fetch}
                         />
                       </SpinnerContainer>
                     )}


### PR DESCRIPTION
Closes #12426 #12411 

_Briefly describe your proposed changes:_
Changed users to be a key value object instead of an array. Added filter on users object for the members that already exist in an org. Updated the component to re-fetch members when save is clicked on the overlay. 

  - [x] Rebased/mergeable
  - [x] Tests pass

![kapture 2019-03-07 at 11 28 02](https://user-images.githubusercontent.com/26464594/53988035-651c2380-40d7-11e9-86f1-008c93875722.gif)
