### PR TITLE
feat(http): convert user sessions to auth for query service

### DIFF
--- a/http/proxy_query_service.go
+++ b/http/proxy_query_service.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/iocounter"
-	icontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 	"github.com/julienschmidt/httprouter"
@@ -157,15 +156,6 @@ func (s *ProxyQueryService) Query(ctx context.Context, w io.Writer, req *query.P
 		return flux.Statistics{}, tracing.LogError(span, err)
 	}
 
-	token := s.Token
-	if token == "" {
-		token, err = icontext.GetToken(ctx)
-		if err != nil {
-			return flux.Statistics{}, tracing.LogError(span, err)
-		}
-	}
-
-	SetToken(token, hreq)
 	hreq = hreq.WithContext(ctx)
 	tracing.InjectToHTTPRequest(span, hreq)
 

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -99,6 +99,9 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Transform the context into one with the request's authorization.
+	ctx = pcontext.SetAuthorizer(ctx, req.Request.Authorization)
+
 	hd, ok := req.Dialect.(HTTPDialect)
 	if !ok {
 		EncodeError(ctx, fmt.Errorf("unsupported dialect over HTTP %T", req.Dialect), w)

--- a/session.go
+++ b/session.go
@@ -25,6 +25,7 @@ var (
 	OpRenewSession = "RenewSession"
 )
 
+// SessionAuthorizionKind defines the type of authorizer
 const SessionAuthorizionKind = "session"
 
 // Session is a user session.
@@ -69,6 +70,18 @@ func (s *Session) Identifier() ID { return s.ID }
 // GetUserID returns the user id.
 func (s *Session) GetUserID() ID {
 	return s.UserID
+}
+
+// EphemeralAuth generates an Authorization that is not stored
+// but at the user's max privs.
+func (s *Session) EphemeralAuth(orgID ID) *Authorization {
+	return &Authorization{
+		ID:          s.ID,
+		OrgID:       orgID,
+		Status:      Active,
+		UserID:      s.UserID,
+		Permissions: s.Permissions,
+	}
 }
 
 // SessionService represents a service for managing user sessions.


### PR DESCRIPTION
_Briefly describe your proposed changes:_
When a query from the UI occurs this transforms authorizer from a session to an ephemeral authorization token.

  - [ ] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
