### PR TITLE
fix(query): fix same bucket name with different orgs

### DIFF
--- a/http/task_service.go
+++ b/http/task_service.go
@@ -387,7 +387,7 @@ func (h *TaskHandler) createBootstrapTaskAuthorizationIfNotExists(ctx context.Co
 	}
 
 	preAuthorizer := query.NewPreAuthorizer(h.BucketService)
-	ps, err := preAuthorizer.RequiredPermissions(ctx, spec)
+	ps, err := preAuthorizer.RequiredPermissions(ctx, spec, &t.OrganizationID)
 	if err != nil {
 		return nil, err
 	}

--- a/query/preauthorizer.go
+++ b/query/preauthorizer.go
@@ -13,8 +13,8 @@ import (
 // callers to fail early for operations that are not allowed.  However, it's still possible
 // for authorization to be denied at runtime even if this check passes.
 type PreAuthorizer interface {
-	PreAuthorize(ctx context.Context, spec *flux.Spec, auth platform.Authorizer) error
-	RequiredPermissions(ctx context.Context, spec *flux.Spec) ([]platform.Permission, error)
+	PreAuthorize(ctx context.Context, spec *flux.Spec, auth platform.Authorizer, orgID *platform.ID) error
+	RequiredPermissions(ctx context.Context, spec *flux.Spec, orgID *platform.ID) ([]platform.Permission, error)
 }
 
 // NewPreAuthorizer creates a new PreAuthorizer
@@ -28,8 +28,8 @@ type preAuthorizer struct {
 
 // PreAuthorize finds all the buckets read and written by the given spec, and ensures that execution is allowed
 // given the Authorizer.  Returns nil on success, and an error with an appropriate message otherwise.
-func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth platform.Authorizer) error {
-	readBuckets, writeBuckets, err := BucketsAccessed(spec)
+func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth platform.Authorizer, orgID *platform.ID) error {
+	readBuckets, writeBuckets, err := BucketsAccessed(spec, orgID)
 
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve buckets for query.Spec")
@@ -75,8 +75,8 @@ func (a *preAuthorizer) PreAuthorize(ctx context.Context, spec *flux.Spec, auth 
 
 // RequiredPermissions returns a slice of permissions required for the query contained in spec.
 // This method also validates that the buckets exist.
-func (a *preAuthorizer) RequiredPermissions(ctx context.Context, spec *flux.Spec) ([]platform.Permission, error) {
-	readBuckets, writeBuckets, err := BucketsAccessed(spec)
+func (a *preAuthorizer) RequiredPermissions(ctx context.Context, spec *flux.Spec, orgID *platform.ID) ([]platform.Permission, error) {
+	readBuckets, writeBuckets, err := BucketsAccessed(spec, orgID)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve buckets for query.Spec")

--- a/query/preauthorizer_test.go
+++ b/query/preauthorizer_test.go
@@ -42,7 +42,7 @@ func TestPreAuthorizer_PreAuthorize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error compiling query: %v", err)
 	}
-	err = preAuthorizer.PreAuthorize(ctx, spec, auth)
+	err = preAuthorizer.PreAuthorize(ctx, spec, auth, nil)
 	if diagnostic := cmp.Diff("bucket service returned nil bucket", err.Error()); diagnostic != "" {
 		t.Errorf("Authorize message mismatch: -want/+got:\n%v", diagnostic)
 	}
@@ -54,7 +54,7 @@ func TestPreAuthorizer_PreAuthorize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error compiling query: %v", err)
 	}
-	err = preAuthorizer.PreAuthorize(ctx, spec, auth)
+	err = preAuthorizer.PreAuthorize(ctx, spec, auth, nil)
 	if diagnostic := cmp.Diff("bucket service returned nil bucket", err.Error()); diagnostic != "" {
 		t.Errorf("Authorize message mismatch: -want/+got:\n%v", diagnostic)
 	}
@@ -73,7 +73,7 @@ func TestPreAuthorizer_PreAuthorize(t *testing.T) {
 	})
 
 	preAuthorizer = query.NewPreAuthorizer(bucketService)
-	err = preAuthorizer.PreAuthorize(ctx, spec, auth)
+	err = preAuthorizer.PreAuthorize(ctx, spec, auth, &orgID)
 	if diagnostic := cmp.Diff(`no read permission for bucket: "my_bucket"`, err.Error()); diagnostic != "" {
 		t.Errorf("Authorize message mismatch: -want/+got:\n%v", diagnostic)
 	}
@@ -88,7 +88,7 @@ func TestPreAuthorizer_PreAuthorize(t *testing.T) {
 		Permissions: []platform.Permission{*p},
 	}
 
-	err = preAuthorizer.PreAuthorize(ctx, spec, auth)
+	err = preAuthorizer.PreAuthorize(ctx, spec, auth, &orgID)
 	if err != nil {
 		t.Errorf("Expected successful authorization, but got error: \"%v\"", err.Error())
 	}
@@ -119,7 +119,7 @@ func TestPreAuthorizer_RequiredPermissions(t *testing.T) {
 	}
 
 	preAuthorizer := query.NewPreAuthorizer(i)
-	perms, err := preAuthorizer.RequiredPermissions(ctx, spec)
+	perms, err := preAuthorizer.RequiredPermissions(ctx, spec, &o.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/query/querytest/compile.go
+++ b/query/querytest/compile.go
@@ -54,7 +54,7 @@ func BucketAwareQueryTestHelper(t *testing.T, tc BucketAwareQueryTestCase) {
 
 	var gotReadBuckets, gotWriteBuckets []platform.BucketFilter
 	if tc.WantReadBuckets != nil || tc.WantWriteBuckets != nil {
-		gotReadBuckets, gotWriteBuckets, err = query.BucketsAccessed(got)
+		gotReadBuckets, gotWriteBuckets, err = query.BucketsAccessed(got, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/query/spec.go
+++ b/query/spec.go
@@ -7,15 +7,15 @@ import (
 
 // BucketAwareOperationSpec specifies an operation that reads or writes buckets
 type BucketAwareOperationSpec interface {
-	BucketsAccessed() (readBuckets, writeBuckets []platform.BucketFilter)
+	BucketsAccessed(orgID *platform.ID) (readBuckets, writeBuckets []platform.BucketFilter)
 }
 
 // BucketsAccessed returns the set of buckets read and written by a query spec
-func BucketsAccessed(q *flux.Spec) (readBuckets, writeBuckets []platform.BucketFilter, err error) {
+func BucketsAccessed(q *flux.Spec, orgID *platform.ID) (readBuckets, writeBuckets []platform.BucketFilter, err error) {
 	err = q.Walk(func(o *flux.Operation) error {
 		bucketAwareOpSpec, ok := o.Spec.(BucketAwareOperationSpec)
 		if ok {
-			opBucketsRead, opBucketsWritten := bucketAwareOpSpec.BucketsAccessed()
+			opBucketsRead, opBucketsWritten := bucketAwareOpSpec.BucketsAccessed(orgID)
 			readBuckets = append(readBuckets, opBucketsRead...)
 			writeBuckets = append(writeBuckets, opBucketsWritten...)
 		}

--- a/query/stdlib/influxdata/influxdb/from.go
+++ b/query/stdlib/influxdata/influxdb/from.go
@@ -80,10 +80,13 @@ func (s *FromOpSpec) Kind() flux.OperationKind {
 }
 
 // BucketsAccessed makes FromOpSpec a query.BucketAwareOperationSpec
-func (s *FromOpSpec) BucketsAccessed() (readBuckets, writeBuckets []platform.BucketFilter) {
+func (s *FromOpSpec) BucketsAccessed(orgID *platform.ID) (readBuckets, writeBuckets []platform.BucketFilter) {
 	bf := platform.BucketFilter{}
 	if s.Bucket != "" {
 		bf.Name = &s.Bucket
+	}
+	if orgID != nil {
+		bf.OrganizationID = orgID
 	}
 
 	if len(s.BucketID) > 0 {

--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -171,7 +171,7 @@ func (ToOpSpec) Kind() flux.OperationKind {
 }
 
 // BucketsAccessed returns the buckets accessed by the spec.
-func (o *ToOpSpec) BucketsAccessed() (readBuckets, writeBuckets []platform.BucketFilter) {
+func (o *ToOpSpec) BucketsAccessed(orgID *platform.ID) (readBuckets, writeBuckets []platform.BucketFilter) {
 	bf := platform.BucketFilter{}
 	if o.Bucket != "" {
 		bf.Name = &o.Bucket

--- a/task/validator.go
+++ b/task/validator.go
@@ -102,7 +102,7 @@ func (ts *taskServiceValidator) CreateTask(ctx context.Context, t platform.TaskC
 		return nil, err
 	}
 
-	if err := validateBucket(ctx, t.Flux, ts.preAuth); err != nil {
+	if err := validateBucket(ctx, t.Flux, ts.preAuth, t.OrganizationID); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +128,7 @@ func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id platform.ID, 
 		return nil, err
 	}
 
-	if err := validateBucket(ctx, task.Flux, ts.preAuth); err != nil {
+	if err := validateBucket(ctx, task.Flux, ts.preAuth, task.OrganizationID); err != nil {
 		return nil, err
 	}
 
@@ -294,7 +294,7 @@ func validatePermission(ctx context.Context, perm platform.Permission) error {
 	return nil
 }
 
-func validateBucket(ctx context.Context, script string, preAuth query.PreAuthorizer) error {
+func validateBucket(ctx context.Context, script string, preAuth query.PreAuthorizer, orgID platform.ID) error {
 	auth, err := platcontext.GetAuthorizer(ctx)
 	if err != nil {
 		return err
@@ -308,7 +308,7 @@ func validateBucket(ctx context.Context, script string, preAuth query.PreAuthori
 			platform.WithErrorCode(platform.EInvalid))
 	}
 
-	if err := preAuth.PreAuthorize(ctx, spec, auth); err != nil {
+	if err := preAuth.PreAuthorize(ctx, spec, auth, &orgID); err != nil {
 		return platform.NewError(
 			platform.WithErrorErr(err),
 			platform.WithErrorMsg("Failed to authorize."),

--- a/task/validator_test.go
+++ b/task/validator_test.go
@@ -109,13 +109,11 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`,
 
 func TestValidations(t *testing.T) {
 	var (
-		orgID  influxdb.ID = 0x046
 		taskID influxdb.ID = 0x7456
 		runID  influxdb.ID = 0x402
 	)
 
 	inmem := inmem.NewService()
-	validTaskService := task.NewValidator(mockTaskService(orgID, taskID, runID), inmem)
 
 	r, err := inmem.Generate(context.Background(), &influxdb.OnboardingRequest{
 		User:            "Setec Astronomy",
@@ -127,6 +125,8 @@ func TestValidations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	orgID := r.Org.ID
+	validTaskService := task.NewValidator(mockTaskService(orgID, taskID, runID), inmem)
 
 	var (
 		// Read all tasks in org.
@@ -316,10 +316,10 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`
 			auth: &influxdb.Authorization{Status: "active", Permissions: orgWriteAllTaskBucketPermissions},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				flux := `option task = {
- name: "my_task",
- every: 1s,
-}
-from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`
+		 name: "my_task",
+		 every: 1s,
+		}
+		from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`
 				_, err := svc.UpdateTask(ctx, taskID, influxdb.TaskUpdate{
 					Flux: &flux,
 				})


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/12462

Add an optional orgID to the preAuthorizer func

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
