### PR TITLE
feat(ui/dash/export): add route for dash exporting

### DIFF
--- a/ui/src/dashboards/components/DashboardExportOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardExportOverlay.tsx
@@ -1,0 +1,56 @@
+import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+
+// Components
+import ExportOverlay from 'src/shared/components/ExportOverlay'
+
+// Utils
+import {dashboardToTemplate} from 'src/shared/utils/resourceToTemplate'
+
+// APIs
+import {getDashboard} from 'src/dashboards/apis/v2'
+
+interface State {
+  dashboardTemplate: Record<string, any>
+}
+
+interface Props extends WithRouterProps {
+  params: {dashboardID: string; orgID: string}
+}
+
+class DashboardExportOverlay extends PureComponent<Props, State> {
+  public state: State = {dashboardTemplate: null}
+
+  public async componentDidMount() {
+    const {
+      params: {dashboardID},
+    } = this.props
+    console.log('loading!?')
+    const dashboard = await getDashboard(dashboardID)
+    const dashboardTemplate = dashboardToTemplate(dashboard)
+
+    this.setState({dashboardTemplate})
+  }
+
+  public render() {
+    const {dashboardTemplate} = this.state
+    if (!dashboardTemplate) {
+      return null
+    }
+    return (
+      <ExportOverlay
+        resourceName="Dashboard"
+        resource={dashboardTemplate}
+        onDismissOverlay={this.onDismiss}
+      />
+    )
+  }
+
+  private onDismiss = () => {
+    const {router} = this.props
+
+    router.goBack()
+  }
+}
+
+export default withRouter(DashboardExportOverlay)

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
+import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {IconFont, ComponentColor} from '@influxdata/clockface'
@@ -28,7 +29,6 @@ interface PassedProps {
   orgs: Organization[]
   onDeleteDashboard: (dashboard: IDashboard) => void
   onCloneDashboard: (dashboard: IDashboard) => void
-  onExportDashboard: (dashboard: IDashboard) => void
   onUpdateDashboard: (dashboard: IDashboard) => void
   showOwnerColumn: boolean
   onFilterChange: (searchTerm: string) => void
@@ -43,7 +43,7 @@ interface DispatchProps {
   onRemoveDashboardLabels: typeof removeDashboardLabelsAsync
 }
 
-type Props = PassedProps & DispatchProps & StateProps
+type Props = PassedProps & DispatchProps & StateProps & WithRouterProps
 
 class DashboardCard extends PureComponent<Props> {
   public render() {
@@ -94,12 +94,7 @@ class DashboardCard extends PureComponent<Props> {
   }
 
   private get contextMenu(): JSX.Element {
-    const {
-      dashboard,
-      onDeleteDashboard,
-      onExportDashboard,
-      onCloneDashboard,
-    } = this.props
+    const {dashboard, onDeleteDashboard, onCloneDashboard} = this.props
 
     return (
       <Context>
@@ -107,7 +102,7 @@ class DashboardCard extends PureComponent<Props> {
           <Context.Menu icon={IconFont.CogThick}>
             <Context.Item
               label="Export"
-              action={onExportDashboard}
+              action={this.handleExport}
               value={dashboard}
             />
           </Context.Menu>
@@ -176,6 +171,16 @@ class DashboardCard extends PureComponent<Props> {
       throw err
     }
   }
+
+  private handleExport = () => {
+    const {
+      router,
+      dashboard,
+      location: {pathname},
+    } = this.props
+
+    router.push(`${pathname}/${dashboard.id}/export`)
+  }
 }
 
 const mstp = ({labels}: AppState): StateProps => {
@@ -192,4 +197,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, PassedProps>(
   mstp,
   mdtp
-)(DashboardCard)
+)(withRouter(DashboardCard))

--- a/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -11,7 +11,6 @@ interface Props {
   dashboards: Dashboard[]
   onDeleteDashboard: (dashboard: Dashboard) => void
   onCloneDashboard: (dashboard: Dashboard) => void
-  onExportDashboard: (dashboard: Dashboard) => void
   onUpdateDashboard: (dashboard: Dashboard) => void
   orgs: Organization[]
   showOwnerColumn: boolean
@@ -22,7 +21,6 @@ export default class DashboardCards extends PureComponent<Props> {
   public render() {
     const {
       dashboards,
-      onExportDashboard,
       onCloneDashboard,
       onDeleteDashboard,
       onUpdateDashboard,
@@ -35,7 +33,6 @@ export default class DashboardCards extends PureComponent<Props> {
       <DashboardCard
         key={d.id}
         dashboard={d}
-        onExportDashboard={onExportDashboard}
         onCloneDashboard={onCloneDashboard}
         onDeleteDashboard={onDeleteDashboard}
         onUpdateDashboard={onUpdateDashboard}

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -130,7 +130,6 @@ class DashboardIndex extends PureComponent<Props, State> {
                 onDeleteDashboard={this.handleDeleteDashboard}
                 onCreateDashboard={this.handleCreateDashboard}
                 onCloneDashboard={this.handleCloneDashboard}
-                onExportDashboard={this.handleExportDashboard}
                 onUpdateDashboard={handleUpdateDashboard}
                 notify={notify}
                 searchTerm={searchTerm}
@@ -196,10 +195,6 @@ class DashboardIndex extends PureComponent<Props, State> {
 
   private handleDeleteDashboard = (dashboard: Dashboard) => {
     this.props.handleDeleteDashboard(dashboard)
-  }
-
-  private handleExportDashboard = (dashboard: Dashboard): void => {
-    this.setState({exportDashboard: dashboard, isExportingDashboard: true})
   }
 
   private handleImportDashboard = async (

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
@@ -21,7 +21,6 @@ interface Props {
   onSetDefaultDashboard: (dashboardLink: string) => void
   onCreateDashboard: () => void
   onCloneDashboard: (dashboard: Dashboard) => void
-  onExportDashboard: (dashboard: Dashboard) => void
   onDeleteDashboard: (dashboard: Dashboard) => void
   onUpdateDashboard: (dashboard: Dashboard) => void
   onFilterChange: (searchTerm: string) => void
@@ -37,7 +36,6 @@ export default class DashboardsIndexContents extends Component<Props> {
     const {
       onDeleteDashboard,
       onCloneDashboard,
-      onExportDashboard,
       onCreateDashboard,
       defaultDashboardLink,
       onSetDefaultDashboard,
@@ -66,7 +64,6 @@ export default class DashboardsIndexContents extends Component<Props> {
               onDeleteDashboard={onDeleteDashboard}
               onCreateDashboard={onCreateDashboard}
               onCloneDashboard={onCloneDashboard}
-              onExportDashboard={onExportDashboard}
               defaultDashboardLink={defaultDashboardLink}
               onSetDefaultDashboard={onSetDefaultDashboard}
               onUpdateDashboard={onUpdateDashboard}

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -25,7 +25,6 @@ interface Props {
   onDeleteDashboard: (dashboard: Dashboard) => void
   onCreateDashboard: () => void
   onCloneDashboard: (dashboard: Dashboard) => void
-  onExportDashboard: (dashboard: Dashboard) => void
   onUpdateDashboard: (dashboard: Dashboard) => void
   onSetDefaultDashboard: (dashboardLink: string) => void
   onFilterChange: (searchTerm: string) => void
@@ -109,7 +108,6 @@ class DashboardsTable extends PureComponent<Props & WithRouterProps, State> {
   private get sortedCards(): JSX.Element {
     const {
       dashboards,
-      onExportDashboard,
       onCloneDashboard,
       onDeleteDashboard,
       onUpdateDashboard,
@@ -131,7 +129,6 @@ class DashboardsTable extends PureComponent<Props & WithRouterProps, State> {
             <DashboardCards
               dashboards={ds}
               onCloneDashboard={onCloneDashboard}
-              onExportDashboard={onExportDashboard}
               onDeleteDashboard={onDeleteDashboard}
               onUpdateDashboard={onUpdateDashboard}
               orgs={orgs}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -29,6 +29,7 @@ import OrgBucketIndex from 'src/organizations/containers/OrgBucketsIndex'
 import TaskEditPage from 'src/tasks/containers/TaskEditPage'
 import DashboardPage from 'src/dashboards/components/DashboardPage'
 import DashboardsIndex from 'src/dashboards/components/dashboard_index/DashboardsIndex'
+import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 import DataExplorerPage from 'src/dataExplorer/components/DataExplorerPage'
 import {MePage, Account} from 'src/me'
 import NotFound from 'src/shared/components/NotFound'
@@ -110,10 +111,13 @@ class Root extends PureComponent {
                           <IndexRoute component={OrganizationsIndex} />
                           <Route path=":orgID">
                             <Route path="buckets" component={OrgBucketIndex} />
-                            <Route
-                              path="dashboards"
-                              component={OrgDashboardsIndex}
-                            />
+                            <Route path="dashboards">
+                              <IndexRoute component={OrgDashboardsIndex} />
+                              <Route
+                                path=":dashboardID/export"
+                                component={DashboardExportOverlay}
+                              />
+                            </Route>
                             <Route path="members" component={OrgMembersIndex} />
                             <Route
                               path="telegrafs"
@@ -166,6 +170,10 @@ class Root extends PureComponent {
                           <Route
                             path=":dashboardID"
                             component={DashboardPage}
+                          />
+                          <Route
+                            path=":dashboardID/export"
+                            component={DashboardExportOverlay}
                           />
                         </Route>
                         <Route path="me" component={MePage} />

--- a/ui/src/organizations/components/Dashboards.tsx
+++ b/ui/src/organizations/components/Dashboards.tsx
@@ -2,7 +2,6 @@
 import React, {PureComponent, ChangeEvent} from 'react'
 import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
-import {downloadTextFile} from 'src/shared/utils/download'
 import _ from 'lodash'
 
 // Components
@@ -32,8 +31,6 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 import {
   dashboardSetDefaultFailed,
-  dashboardExported,
-  dashboardExportFailed,
   dashboardCreateFailed,
 } from 'src/shared/copy/notifications'
 
@@ -42,7 +39,6 @@ import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants/index'
 
 // Types
 import {Notification} from 'src/types/notifications'
-import {DashboardFile} from 'src/types/v2/dashboards'
 import {Links, Cell, Dashboard, AppState, Organization} from 'src/types/v2'
 
 // Decorators
@@ -135,7 +131,6 @@ class Dashboards extends PureComponent<Props, State> {
           onDeleteDashboard={this.handleDeleteDashboard}
           onCreateDashboard={this.handleCreateDashboard}
           onCloneDashboard={this.handleCloneDashboard}
-          onExportDashboard={this.handleExportDashboard}
           onUpdateDashboard={handleUpdateDashboard}
           notify={notify}
           searchTerm={searchTerm}
@@ -208,30 +203,6 @@ class Dashboards extends PureComponent<Props, State> {
 
   private handleDeleteDashboard = (dashboard: Dashboard) => {
     this.props.handleDeleteDashboard(dashboard)
-  }
-
-  private handleExportDashboard = async (
-    dashboard: Dashboard
-  ): Promise<void> => {
-    const {notify} = this.props
-    const dashboardForDownload = await this.modifyDashboardForDownload(
-      dashboard
-    )
-    try {
-      downloadTextFile(
-        JSON.stringify(dashboardForDownload, null, '\t'),
-        `${dashboard.name}.json`
-      )
-      notify(dashboardExported(dashboard.name))
-    } catch (error) {
-      notify(dashboardExportFailed(dashboard.name, error))
-    }
-  }
-
-  private modifyDashboardForDownload = async (
-    dashboard: Dashboard
-  ): Promise<DashboardFile> => {
-    return {meta: {chronografVersion: '2.0'}, dashboard}
   }
 
   private handleImportDashboard = async (

--- a/ui/src/shared/utils/resourceToTemplate.ts
+++ b/ui/src/shared/utils/resourceToTemplate.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import {getDeep} from 'src/utils/wrappers'
-import {Task, Label} from 'src/types/v2'
+import {Task, Label, Dashboard} from 'src/types/v2'
 import {ITemplate, TemplateType} from '@influxdata/influx'
 
 const CURRENT_TEMPLATE_VERSION = '1'
@@ -95,3 +95,9 @@ export const taskToTemplate = (
 
   return template
 }
+
+// Todo: update template to match task format
+export const dashboardToTemplate = (dashboard: Dashboard) => ({
+  meta: {chronografVersion: '2.0'},
+  dashboard,
+})


### PR DESCRIPTION
Closes #11151

_Briefly describe your proposed changes:_
Add the dashboards export route and redirect to `id/export` on export.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

![Kapture 2019-03-08 at 16 27 00](https://user-images.githubusercontent.com/4994741/54056782-1ea1f400-41bf-11e9-80ab-bc3832f05b57.gif)
