### PR TITLE
fix(ui/filter): update filter sorting to ignore casing

### DIFF
--- a/ui/src/shared/components/Filter.test.tsx
+++ b/ui/src/shared/components/Filter.test.tsx
@@ -31,7 +31,7 @@ describe('FilterList', () => {
   })
 
   it('renders a sorted list', () => {
-    const itemOne = {name: 'foo'}
+    const itemOne = {name: 'Foo'}
     const itemTwo = {name: 'bar'}
     const list = [itemOne, itemTwo]
     const {getAllByTestId} = setup<{name: string}>({list, sortByKey: 'name'})

--- a/ui/src/shared/components/Filter.test.tsx
+++ b/ui/src/shared/components/Filter.test.tsx
@@ -31,7 +31,7 @@ describe('FilterList', () => {
   })
 
   it('renders a sorted list', () => {
-    const itemOne = {name: 'Foo'}
+    const itemOne = {name: 'foo'}
     const itemTwo = {name: 'bar'}
     const list = [itemOne, itemTwo]
     const {getAllByTestId} = setup<{name: string}>({list, sortByKey: 'name'})
@@ -41,6 +41,22 @@ describe('FilterList', () => {
     expect(expected.length).toEqual(list.length)
     expect(expected[0].textContent).toEqual(itemTwo.name)
     expect(expected[1].textContent).toEqual(itemOne.name)
+  })
+
+  it('can ignore casing in sorting', () => {
+    const itemOne = {name: 'BBB'}
+    const itemTwo = {name: 'aaa'}
+    const itemThree = {name: 'CCC'}
+
+    const list = [itemOne, itemTwo, itemThree]
+    const {getAllByTestId} = setup<{name: string}>({list, sortByKey: 'name'})
+
+    const expected = getAllByTestId('list-item')
+
+    expect(expected.length).toEqual(list.length)
+    expect(expected[0].textContent).toEqual(itemTwo.name)
+    expect(expected[1].textContent).toEqual(itemOne.name)
+    expect(expected[2].textContent).toEqual(itemThree.name)
   })
 
   it('filters list of flat objects', () => {

--- a/ui/src/shared/components/Filter.tsx
+++ b/ui/src/shared/components/Filter.tsx
@@ -23,7 +23,21 @@ const EMPTY_ARRAY_BRACKETS = /\[\]?\./
  */
 export default class FilterList<T> extends PureComponent<Props<T>> {
   public render() {
-    return this.props.children(_.sortBy(this.filtered, this.props.sortByKey))
+    return this.props.children(this.sorted)
+  }
+
+  private get sorted(): T[] {
+    return _.sortBy<T>(this.filtered, [
+      (item: T) => {
+        const value = _.get(item, this.props.sortByKey)
+
+        if (!!value && _.isString(value)) {
+          return value.toLocaleLowerCase()
+        }
+
+        return value
+      },
+    ])
   }
 
   private get filtered(): T[] {


### PR DESCRIPTION
Closes #12441 

_Briefly describe your proposed changes:_
Updates the `Filter` sortBy option to utilize lowercasing when sorting string values.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
