### PR TITLE
feat(ui/dash/import): create dashboards from imported templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.0.0-alpha.6 [unreleased]
 
 ### Features
+1. [12496](https://github.com/influxdata/influxdb/pull/12496): Add ability to import a dashboard
 
 ### Bug Fixes
 

--- a/ui/src/dashboards/actions/v2/index.ts
+++ b/ui/src/dashboards/actions/v2/index.ts
@@ -16,6 +16,7 @@ import {
   removeDashboardLabels as removeDashboardLabelsAJAX,
   updateView as updateViewAJAX,
 } from 'src/dashboards/apis/v2'
+import {client} from 'src/utils/api'
 
 // Actions
 import {notify} from 'src/shared/actions/notifications'
@@ -25,6 +26,10 @@ import {
   DeleteTimeRangeAction,
 } from 'src/dashboards/actions/v2/ranges'
 import {setView, SetViewAction} from 'src/dashboards/actions/v2/views'
+import {
+  importDashboardSucceeded,
+  importDashboardFailed,
+} from 'src/shared/copy/notifications'
 
 // Utils
 import {
@@ -38,7 +43,7 @@ import * as copy from 'src/shared/copy/notifications'
 // Types
 import {RemoteDataState} from 'src/types'
 import {PublishNotificationAction} from 'src/types/actions/notifications'
-import {CreateCell} from '@influxdata/influx'
+import {CreateCell, IDashboardTemplate} from '@influxdata/influx'
 import {Dashboard, NewView, Cell} from 'src/types/v2'
 import {ILabel} from '@influxdata/influx'
 
@@ -198,6 +203,19 @@ export const getDashboardsAsync = () => async (
   } catch (error) {
     console.error(error)
     throw error
+  }
+}
+
+export const createDashboardFromTemplate = (
+  template: IDashboardTemplate,
+  orgID: string
+) => async dispatch => {
+  try {
+    await client.dashboards.createFromTemplate(template, orgID)
+
+    dispatch(notify(importDashboardSucceeded()))
+  } catch (error) {
+    dispatch(notify(importDashboardFailed(error)))
   }
 }
 

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -2,15 +2,15 @@
 import React, {PureComponent} from 'react'
 import {InjectedRouter} from 'react-router'
 import {connect} from 'react-redux'
-import {isEmpty} from 'lodash'
+import {get} from 'lodash'
 
 // Components
 import DashboardsIndexContents from 'src/dashboards/components/dashboard_index/DashboardsIndexContents'
 import {Page} from 'src/pageLayout'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
-import ImportOverlay from 'src/shared/components/ImportOverlay'
 import ExportOverlay from 'src/shared/components/ExportOverlay'
+import ImportDashboardOverlay from 'src/dashboards/components/ImportDashboardOverlay'
 
 // APIs
 import {createDashboard, cloneDashboard} from 'src/dashboards/apis/v2/'
@@ -32,10 +32,7 @@ import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants/index'
 import {
   dashboardSetDefaultFailed,
   dashboardCreateFailed,
-  dashboardImported,
-  dashboardImportFailed,
 } from 'src/shared/copy/notifications'
-import {cantImportInvalidResource} from 'src/shared/copy/v2/notifications'
 
 // Types
 import {Notification} from 'src/types/notifications'
@@ -197,24 +194,6 @@ class DashboardIndex extends PureComponent<Props, State> {
     this.props.handleDeleteDashboard(dashboard)
   }
 
-  private handleImportDashboard = async (
-    importString: string
-  ): Promise<void> => {
-    const {notify} = this.props
-    try {
-      const resource = JSON.parse(importString)
-
-      if (isEmpty(resource)) {
-        notify(cantImportInvalidResource('Dashboard'))
-        return
-      }
-      this.handleToggleImportOverlay()
-      notify(dashboardImported())
-    } catch (error) {
-      notify(dashboardImportFailed(error))
-    }
-  }
-
   private handleFilterDashboards = (searchTerm: string): void => {
     this.setState({searchTerm})
   }
@@ -229,13 +208,13 @@ class DashboardIndex extends PureComponent<Props, State> {
 
   private get importOverlay(): JSX.Element {
     const {isImportingDashboard} = this.state
+    const {orgs} = this.props
 
     return (
-      <ImportOverlay
-        isVisible={isImportingDashboard}
-        resourceName="Dashboard"
+      <ImportDashboardOverlay
         onDismissOverlay={this.handleToggleImportOverlay}
-        onSubmit={this.handleImportDashboard}
+        orgID={get(orgs, '0.id', '')}
+        isVisible={isImportingDashboard}
       />
     )
   }

--- a/ui/src/organizations/components/Dashboards.tsx
+++ b/ui/src/organizations/components/Dashboards.tsx
@@ -6,12 +6,9 @@ import _ from 'lodash'
 
 // Components
 import DashboardsIndexContents from 'src/dashboards/components/dashboard_index/DashboardsIndexContents'
-import {OverlayTechnology, Input, Tabs} from 'src/clockface'
+import {Input, Tabs} from 'src/clockface'
 import {Button, ComponentColor, IconFont} from '@influxdata/clockface'
 import ImportDashboardOverlay from 'src/dashboards/components/ImportDashboardOverlay'
-
-// Utils
-import {getDeep} from 'src/utils/wrappers'
 
 // APIs
 import {createDashboard, cloneDashboard} from 'src/dashboards/apis/v2/'
@@ -39,7 +36,7 @@ import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants/index'
 
 // Types
 import {Notification} from 'src/types/notifications'
-import {Links, Cell, Dashboard, AppState, Organization} from 'src/types/v2'
+import {Links, Dashboard, AppState, Organization} from 'src/types/v2'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -205,46 +202,20 @@ class Dashboards extends PureComponent<Props, State> {
     this.props.handleDeleteDashboard(dashboard)
   }
 
-  private handleImportDashboard = async (
-    dashboard: Dashboard
-  ): Promise<void> => {
-    const defaultCell = {
-      x: 0,
-      y: 0,
-      w: 4,
-      h: 4,
-    }
-
-    const name = _.get(dashboard, 'name', DEFAULT_DASHBOARD_NAME)
-    const cellsWithDefaultsApplied = getDeep<Cell[]>(
-      dashboard,
-      'cells',
-      []
-    ).map(c => ({...defaultCell, ...c}))
-
-    await this.props.handleImportDashboard({
-      ...dashboard,
-      name,
-      cells: cellsWithDefaultsApplied,
-    })
-  }
-
   private handleToggleOverlay = (): void => {
     this.setState({isImportingDashboard: !this.state.isImportingDashboard})
   }
 
   private get renderImportOverlay(): JSX.Element {
-    const {notify} = this.props
     const {isImportingDashboard} = this.state
+    const {orgs} = this.props
 
     return (
-      <OverlayTechnology visible={isImportingDashboard}>
-        <ImportDashboardOverlay
-          onDismissOverlay={this.handleToggleOverlay}
-          onImportDashboard={this.handleImportDashboard}
-          notify={notify}
-        />
-      </OverlayTechnology>
+      <ImportDashboardOverlay
+        onDismissOverlay={this.handleToggleOverlay}
+        orgID={_.get(orgs, '0.id', '')}
+        isVisible={isImportingDashboard}
+      />
     )
   }
 }

--- a/ui/src/shared/components/ImportOverlay.tsx
+++ b/ui/src/shared/components/ImportOverlay.tsx
@@ -10,6 +10,7 @@ import {
   OverlayHeading,
   OverlayFooter,
   Radio,
+  ComponentStatus,
 } from 'src/clockface'
 import {Button, ComponentColor} from '@influxdata/clockface'
 
@@ -93,6 +94,7 @@ export default class ImportOverlay extends PureComponent<Props, State> {
           submitText="Upload"
           handleSubmit={this.handleSetImportContent}
           submitOnDrop={true}
+          submitOnUpload={true}
           onCancel={this.clearImportContent}
         />
       )
@@ -110,18 +112,21 @@ export default class ImportOverlay extends PureComponent<Props, State> {
   private get submitButton(): JSX.Element {
     const {resourceName} = this.props
     const {selectedImportOption, importContent} = this.state
-    if (
+    const isEnabled =
       selectedImportOption === ImportOption.Paste ||
       (selectedImportOption === ImportOption.Upload && importContent)
-    ) {
-      return (
-        <Button
-          text={`Import JSON as ${resourceName}`}
-          onClick={this.submit}
-          color={ComponentColor.Primary}
-        />
-      )
-    }
+    const status = isEnabled
+      ? ComponentStatus.Default
+      : ComponentStatus.Disabled
+
+    return (
+      <Button
+        text={`Import JSON as ${resourceName}`}
+        onClick={this.submit}
+        color={ComponentColor.Primary}
+        status={status}
+      />
+    )
   }
 
   private submit = () => {

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -799,8 +799,17 @@ export const importTaskSucceeded = (): Notification => ({
 })
 
 export const importTaskFailed = (error: string): Notification => ({
-  ...defaultSuccessNotification,
+  ...defaultErrorNotification,
   message: `Failed to import task: ${error}`,
+})
+export const importDashboardSucceeded = (): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Successfully imported dashboard.`,
+})
+
+export const importDashboardFailed = (error: string): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to import dashboard: ${error}`,
 })
 
 // Labels


### PR DESCRIPTION
Closes #11533

_Briefly describe your proposed changes:_
Create a dashboard from the imported dashboard.
Make import button in import overlay visible and disabled rather than not visible

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
