### PR TITLE
fix(http): log endpoint should be logs

### DIFF
--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -60,7 +60,7 @@ type BucketHandler struct {
 const (
 	bucketsPath            = "/api/v2/buckets"
 	bucketsIDPath          = "/api/v2/buckets/:id"
-	bucketsIDLogPath       = "/api/v2/buckets/:id/log"
+	bucketsIDLogPath       = "/api/v2/buckets/:id/logs"
 	bucketsIDMembersPath   = "/api/v2/buckets/:id/members"
 	bucketsIDMembersIDPath = "/api/v2/buckets/:id/members/:userID"
 	bucketsIDOwnersPath    = "/api/v2/buckets/:id/owners"
@@ -252,7 +252,7 @@ func newBucketResponse(b *influxdb.Bucket, labels []*influxdb.Label) *bucketResp
 	res := &bucketResponse{
 		Links: map[string]string{
 			"self":    fmt.Sprintf("/api/v2/buckets/%s", b.ID),
-			"log":     fmt.Sprintf("/api/v2/buckets/%s/log", b.ID),
+			"logs":    fmt.Sprintf("/api/v2/buckets/%s/logs", b.ID),
 			"labels":  fmt.Sprintf("/api/v2/buckets/%s/labels", b.ID),
 			"members": fmt.Sprintf("/api/v2/buckets/%s/members", b.ID),
 			"owners":  fmt.Sprintf("/api/v2/buckets/%s/owners", b.ID),
@@ -893,14 +893,14 @@ func decodeGetBucketLogRequest(ctx context.Context, r *http.Request) (*getBucket
 }
 
 func newBucketLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *operationLogResponse {
-	log := make([]*operationLogEntryResponse, 0, len(es))
+	logs := make([]*operationLogEntryResponse, 0, len(es))
 	for _, e := range es {
-		log = append(log, newOperationLogEntryResponse(e))
+		logs = append(logs, newOperationLogEntryResponse(e))
 	}
 	return &operationLogResponse{
 		Links: map[string]string{
-			"self": fmt.Sprintf("/api/v2/buckets/%s/log", id),
+			"self": fmt.Sprintf("/api/v2/buckets/%s/logs", id),
 		},
-		Log: log,
+		Logs: logs,
 	}
 }

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -108,7 +108,7 @@ func TestService_handleGetBuckets(t *testing.T) {
       "links": {
         "org": "/api/v2/orgs/50f7ba1150f7ba11",
         "self": "/api/v2/buckets/0b501e7e557ab1ed",
-        "log": "/api/v2/buckets/0b501e7e557ab1ed/log",
+        "logs": "/api/v2/buckets/0b501e7e557ab1ed/logs",
         "labels": "/api/v2/buckets/0b501e7e557ab1ed/labels",
         "owners": "/api/v2/buckets/0b501e7e557ab1ed/owners",
         "members": "/api/v2/buckets/0b501e7e557ab1ed/members"
@@ -131,7 +131,7 @@ func TestService_handleGetBuckets(t *testing.T) {
       "links": {
         "org": "/api/v2/orgs/7e55e118dbabb1ed",
         "self": "/api/v2/buckets/c0175f0077a77005",
-        "log": "/api/v2/buckets/c0175f0077a77005/log",
+        "logs": "/api/v2/buckets/c0175f0077a77005/logs",
         "labels": "/api/v2/buckets/c0175f0077a77005/labels",
         "members": "/api/v2/buckets/c0175f0077a77005/members",
         "owners": "/api/v2/buckets/c0175f0077a77005/owners"
@@ -270,7 +270,7 @@ func TestService_handleGetBucket(t *testing.T) {
 		  "links": {
 		    "org": "/api/v2/orgs/020f755c3c082000",
 		    "self": "/api/v2/buckets/020f755c3c082000",
-		    "log": "/api/v2/buckets/020f755c3c082000/log",
+		    "logs": "/api/v2/buckets/020f755c3c082000/logs",
 		    "labels": "/api/v2/buckets/020f755c3c082000/labels",
 		    "members": "/api/v2/buckets/020f755c3c082000/members",
 		    "owners": "/api/v2/buckets/020f755c3c082000/owners"
@@ -394,7 +394,7 @@ func TestService_handlePostBucket(t *testing.T) {
   "links": {
     "org": "/api/v2/orgs/6f626f7274697320",
     "self": "/api/v2/buckets/020f755c3c082000",
-    "log": "/api/v2/buckets/020f755c3c082000/log",
+    "logs": "/api/v2/buckets/020f755c3c082000/logs",
     "labels": "/api/v2/buckets/020f755c3c082000/labels",
     "members": "/api/v2/buckets/020f755c3c082000/members",
     "owners": "/api/v2/buckets/020f755c3c082000/owners"
@@ -604,7 +604,7 @@ func TestService_handlePatchBucket(t *testing.T) {
   "links": {
     "org": "/api/v2/orgs/020f755c3c082000",
     "self": "/api/v2/buckets/020f755c3c082000",
-    "log": "/api/v2/buckets/020f755c3c082000/log",
+    "logs": "/api/v2/buckets/020f755c3c082000/logs",
     "labels": "/api/v2/buckets/020f755c3c082000/labels",
     "members": "/api/v2/buckets/020f755c3c082000/members",
     "owners": "/api/v2/buckets/020f755c3c082000/owners"
@@ -679,7 +679,7 @@ func TestService_handlePatchBucket(t *testing.T) {
   "links": {
     "org": "/api/v2/orgs/020f755c3c082000",
     "self": "/api/v2/buckets/020f755c3c082000",
-    "log": "/api/v2/buckets/020f755c3c082000/log",
+    "logs": "/api/v2/buckets/020f755c3c082000/logs",
     "labels": "/api/v2/buckets/020f755c3c082000/labels",
     "members": "/api/v2/buckets/020f755c3c082000/members",
     "owners": "/api/v2/buckets/020f755c3c082000/owners"
@@ -735,7 +735,7 @@ func TestService_handlePatchBucket(t *testing.T) {
   "links": {
     "org": "/api/v2/orgs/020f755c3c082000",
     "self": "/api/v2/buckets/020f755c3c082000",
-    "log": "/api/v2/buckets/020f755c3c082000/log",
+    "logs": "/api/v2/buckets/020f755c3c082000/logs",
     "labels": "/api/v2/buckets/020f755c3c082000/labels",
     "members": "/api/v2/buckets/020f755c3c082000/members",
     "owners": "/api/v2/buckets/020f755c3c082000/owners"
@@ -887,7 +887,7 @@ func TestService_handlePostBucketMember(t *testing.T) {
 				body: `
 {
   "links": {
-    "log": "/api/v2/users/6f626f7274697320/log",
+    "logs": "/api/v2/users/6f626f7274697320/logs",
     "self": "/api/v2/users/6f626f7274697320"
   },
   "role": "member",
@@ -977,7 +977,7 @@ func TestService_handlePostBucketOwner(t *testing.T) {
 				body: `
 {
   "links": {
-    "log": "/api/v2/users/6f626f7274697320/log",
+    "logs": "/api/v2/users/6f626f7274697320/logs",
     "self": "/api/v2/users/6f626f7274697320"
   },
   "role": "owner",

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -26,6 +26,7 @@ type DashboardBackend struct {
 	UserService                  platform.UserService
 }
 
+// NewDashboardBackend creates a backend used by the dashboard handler.
 func NewDashboardBackend(b *APIBackend) *DashboardBackend {
 	return &DashboardBackend{
 		Logger: b.Logger.With(zap.String("handler", "dashboard")),
@@ -58,7 +59,7 @@ const (
 	dashboardsIDCellsIDPath     = "/api/v2/dashboards/:id/cells/:cellID"
 	dashboardsIDCellsIDViewPath = "/api/v2/dashboards/:id/cells/:cellID/view"
 	dashboardsIDMembersPath     = "/api/v2/dashboards/:id/members"
-	dashboardsIDLogPath         = "/api/v2/dashboards/:id/log"
+	dashboardsIDLogPath         = "/api/v2/dashboards/:id/logs"
 	dashboardsIDMembersIDPath   = "/api/v2/dashboards/:id/members/:userID"
 	dashboardsIDOwnersPath      = "/api/v2/dashboards/:id/owners"
 	dashboardsIDOwnersIDPath    = "/api/v2/dashboards/:id/owners/:userID"
@@ -134,7 +135,7 @@ type dashboardLinks struct {
 	Members      string `json:"members"`
 	Owners       string `json:"owners"`
 	Cells        string `json:"cells"`
-	Log          string `json:"log"`
+	Logs         string `json:"logs"`
 	Labels       string `json:"labels"`
 	Organization string `json:"org"`
 }
@@ -170,7 +171,7 @@ func newDashboardResponse(d *platform.Dashboard, labels []*platform.Label) dashb
 			Members:      fmt.Sprintf("/api/v2/dashboards/%s/members", d.ID),
 			Owners:       fmt.Sprintf("/api/v2/dashboards/%s/owners", d.ID),
 			Cells:        fmt.Sprintf("/api/v2/dashboards/%s/cells", d.ID),
-			Log:          fmt.Sprintf("/api/v2/dashboards/%s/log", d.ID),
+			Logs:         fmt.Sprintf("/api/v2/dashboards/%s/logs", d.ID),
 			Labels:       fmt.Sprintf("/api/v2/dashboards/%s/labels", d.ID),
 			Organization: fmt.Sprintf("/api/v2/orgs/%s", d.OrganizationID),
 		},
@@ -240,19 +241,19 @@ func newDashboardCellViewResponse(dashID, cellID platform.ID, v *platform.View) 
 
 type operationLogResponse struct {
 	Links map[string]string            `json:"links"`
-	Log   []*operationLogEntryResponse `json:"log"`
+	Logs  []*operationLogEntryResponse `json:"logs"`
 }
 
 func newDashboardLogResponse(id platform.ID, es []*platform.OperationLogEntry) *operationLogResponse {
-	log := make([]*operationLogEntryResponse, 0, len(es))
+	logs := make([]*operationLogEntryResponse, 0, len(es))
 	for _, e := range es {
-		log = append(log, newOperationLogEntryResponse(e))
+		logs = append(logs, newOperationLogEntryResponse(e))
 	}
 	return &operationLogResponse{
 		Links: map[string]string{
-			"self": fmt.Sprintf("/api/v2/dashboards/%s/log", id),
+			"self": fmt.Sprintf("/api/v2/dashboards/%s/logs", id),
 		},
-		Log: log,
+		Logs: logs,
 	}
 }
 

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -152,7 +152,7 @@ func TestService_handleGetDashboards(t *testing.T) {
         "members": "/api/v2/dashboards/da7aba5e5d81e550/members",
         "owners": "/api/v2/dashboards/da7aba5e5d81e550/owners",
         "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
-        "log": "/api/v2/dashboards/da7aba5e5d81e550/log",
+        "logs": "/api/v2/dashboards/da7aba5e5d81e550/logs",
         "labels": "/api/v2/dashboards/da7aba5e5d81e550/labels"
       }
     },
@@ -180,7 +180,7 @@ func TestService_handleGetDashboards(t *testing.T) {
         "org": "/api/v2/orgs/0000000000000001",
         "members": "/api/v2/dashboards/0ca2204eca2204e0/members",
         "owners": "/api/v2/dashboards/0ca2204eca2204e0/owners",
-        "log": "/api/v2/dashboards/0ca2204eca2204e0/log",
+        "logs": "/api/v2/dashboards/0ca2204eca2204e0/logs",
         "cells": "/api/v2/dashboards/0ca2204eca2204e0/cells",
         "labels": "/api/v2/dashboards/0ca2204eca2204e0/labels"
       }
@@ -311,7 +311,7 @@ func TestService_handleGetDashboards(t *testing.T) {
         "members": "/api/v2/dashboards/da7aba5e5d81e550/members",
         "owners": "/api/v2/dashboards/da7aba5e5d81e550/owners",
         "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
-        "log": "/api/v2/dashboards/da7aba5e5d81e550/log",
+        "logs": "/api/v2/dashboards/da7aba5e5d81e550/logs",
         "labels": "/api/v2/dashboards/da7aba5e5d81e550/labels"
       }
     }
@@ -444,7 +444,7 @@ func TestService_handleGetDashboard(t *testing.T) {
     "org": "/api/v2/orgs/0000000000000001",
     "members": "/api/v2/dashboards/020f755c3c082000/members",
     "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-    "log": "/api/v2/dashboards/020f755c3c082000/log",
+    "logs": "/api/v2/dashboards/020f755c3c082000/logs",
     "cells": "/api/v2/dashboards/020f755c3c082000/cells",
     "labels": "/api/v2/dashboards/020f755c3c082000/labels"
   }
@@ -594,7 +594,7 @@ func TestService_handlePostDashboard(t *testing.T) {
     "org": "/api/v2/orgs/0000000000000001",
     "members": "/api/v2/dashboards/020f755c3c082000/members",
     "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-    "log": "/api/v2/dashboards/020f755c3c082000/log",
+    "logs": "/api/v2/dashboards/020f755c3c082000/logs",
     "cells": "/api/v2/dashboards/020f755c3c082000/cells",
     "labels": "/api/v2/dashboards/020f755c3c082000/labels"
   }
@@ -828,7 +828,7 @@ func TestService_handlePatchDashboard(t *testing.T) {
 		    "org": "/api/v2/orgs/0000000000000001",
 		    "members": "/api/v2/dashboards/020f755c3c082000/members",
 		    "owners": "/api/v2/dashboards/020f755c3c082000/owners",
-		    "log": "/api/v2/dashboards/020f755c3c082000/log",
+		    "logs": "/api/v2/dashboards/020f755c3c082000/logs",
 		    "cells": "/api/v2/dashboards/020f755c3c082000/cells",
 		    "labels": "/api/v2/dashboards/020f755c3c082000/labels"
 		  }

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -28,6 +28,7 @@ type OrgBackend struct {
 	UserService                     influxdb.UserService
 }
 
+// NewOrgBackend is a datasource used by the org handler.
 func NewOrgBackend(b *APIBackend) *OrgBackend {
 	return &OrgBackend{
 		Logger: b.Logger.With(zap.String("handler", "org")),
@@ -58,7 +59,7 @@ type OrgHandler struct {
 const (
 	organizationsPath            = "/api/v2/orgs"
 	organizationsIDPath          = "/api/v2/orgs/:id"
-	organizationsIDLogPath       = "/api/v2/orgs/:id/log"
+	organizationsIDLogPath       = "/api/v2/orgs/:id/logs"
 	organizationsIDMembersPath   = "/api/v2/orgs/:id/members"
 	organizationsIDMembersIDPath = "/api/v2/orgs/:id/members/:userID"
 	organizationsIDOwnersPath    = "/api/v2/orgs/:id/owners"
@@ -166,7 +167,7 @@ func newOrgResponse(o *influxdb.Organization) *orgResponse {
 	return &orgResponse{
 		Links: map[string]string{
 			"self":       fmt.Sprintf("/api/v2/orgs/%s", o.ID),
-			"log":        fmt.Sprintf("/api/v2/orgs/%s/log", o.ID),
+			"logs":       fmt.Sprintf("/api/v2/orgs/%s/logs", o.ID),
 			"members":    fmt.Sprintf("/api/v2/orgs/%s/members", o.ID),
 			"owners":     fmt.Sprintf("/api/v2/orgs/%s/owners", o.ID),
 			"secrets":    fmt.Sprintf("/api/v2/orgs/%s/secrets", o.ID),
@@ -876,14 +877,14 @@ func decodeGetOrganizationLogRequest(ctx context.Context, r *http.Request) (*get
 }
 
 func newOrganizationLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *operationLogResponse {
-	log := make([]*operationLogEntryResponse, 0, len(es))
+	logs := make([]*operationLogEntryResponse, 0, len(es))
 	for _, e := range es {
-		log = append(log, newOperationLogEntryResponse(e))
+		logs = append(logs, newOperationLogEntryResponse(e))
 	}
 	return &operationLogResponse{
 		Links: map[string]string{
-			"self": fmt.Sprintf("/api/v2/orgs/%s/log", id),
+			"self": fmt.Sprintf("/api/v2/orgs/%s/logs", id),
 		},
-		Log: log,
+		Logs: logs,
 	}
 }

--- a/http/proto_test.go
+++ b/http/proto_test.go
@@ -162,7 +162,7 @@ func TestProtoHandler(t *testing.T) {
 		        "owners": "/api/v2/dashboards/da7aba5e5d81e550/owners",
 		        "cells": "/api/v2/dashboards/da7aba5e5d81e550/cells",
 		        "labels": "/api/v2/dashboards/da7aba5e5d81e550/labels",
-		        "log": "/api/v2/dashboards/da7aba5e5d81e550/log",
+		        "logs": "/api/v2/dashboards/da7aba5e5d81e550/logs",
 		        "org": "/api/v2/orgs/0000000000000001",
 		        "self": "/api/v2/dashboards/da7aba5e5d81e550"
 		      },
@@ -185,7 +185,7 @@ func TestProtoHandler(t *testing.T) {
 		        "owners": "/api/v2/dashboards/0ca2204eca2204e0/owners",
 		        "cells": "/api/v2/dashboards/0ca2204eca2204e0/cells",
 		        "labels": "/api/v2/dashboards/0ca2204eca2204e0/labels",
-		        "log": "/api/v2/dashboards/0ca2204eca2204e0/log",
+		        "logs": "/api/v2/dashboards/0ca2204eca2204e0/logs",
 		        "org": "/api/v2/orgs/0000000000000001",
 		        "self": "/api/v2/dashboards/0ca2204eca2204e0"
 		      },

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5784,12 +5784,12 @@ components:
           readOnly: true
           example:
             self: "/api/v2/users/1"
-            log: "/api/v2/users/1/log"
+            logs: "/api/v2/users/1/logs"
           properties:
             self:
               type: string
               format: uri
-            log:
+            logs:
               type: string
               format: uri
       required: [name]

--- a/http/user_resource_mapping_test.go
+++ b/http/user_resource_mapping_test.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"go.uber.org/zap"
 
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/mock"
@@ -80,7 +81,7 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
   "users": [
     {
       "links": {
-        "log": "/api/v2/users/0000000000000001/log",
+        "logs": "/api/v2/users/0000000000000001/logs",
         "self": "/api/v2/users/0000000000000001"
       },
       "id": "0000000000000001",
@@ -89,7 +90,7 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
     },
     {
       "links": {
-        "log": "/api/v2/users/0000000000000002/log",
+        "logs": "/api/v2/users/0000000000000002/logs",
         "self": "/api/v2/users/0000000000000002"
       },
       "id": "0000000000000002",
@@ -144,7 +145,7 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
   "users": [
     {
       "links": {
-        "log": "/api/v2/users/0000000000000001/log",
+        "logs": "/api/v2/users/0000000000000001/logs",
         "self": "/api/v2/users/0000000000000001"
       },
       "id": "0000000000000001",
@@ -153,7 +154,7 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
     },
     {
       "links": {
-        "log": "/api/v2/users/0000000000000002/log",
+        "logs": "/api/v2/users/0000000000000002/logs",
         "self": "/api/v2/users/0000000000000002"
       },
       "id": "0000000000000002",
@@ -269,7 +270,7 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 				body: `
 {
 	"links": {
-		"log": "/api/v2/users/0000000000000001/log",
+		"logs": "/api/v2/users/0000000000000001/logs",
 		"self": "/api/v2/users/0000000000000001"
 	},
 	"id": "0000000000000001",
@@ -307,7 +308,7 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 				body: `
 {
 	"links": {
-		"log": "/api/v2/users/0000000000000002/log",
+		"logs": "/api/v2/users/0000000000000002/logs",
 		"self": "/api/v2/users/0000000000000002"
 	},
 	"id": "0000000000000002",

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -48,7 +48,7 @@ const (
 	mePasswordPath    = "/api/v2/me/password"
 	usersIDPath       = "/api/v2/users/:id"
 	usersPasswordPath = "/api/v2/users/:id/password"
-	usersLogPath      = "/api/v2/users/:id/log"
+	usersLogPath      = "/api/v2/users/:id/logs"
 )
 
 // NewUserHandler returns a new instance of UserHandler.
@@ -336,7 +336,7 @@ func newUserResponse(u *influxdb.User) *userResponse {
 	return &userResponse{
 		Links: map[string]string{
 			"self": fmt.Sprintf("/api/v2/users/%s", u.ID),
-			"log":  fmt.Sprintf("/api/v2/users/%s/log", u.ID),
+			"logs": fmt.Sprintf("/api/v2/users/%s/logs", u.ID),
 		},
 		User: *u,
 	}
@@ -746,14 +746,14 @@ func decodeGetUserLogRequest(ctx context.Context, r *http.Request) (*getUserLogR
 }
 
 func newUserLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *operationLogResponse {
-	log := make([]*operationLogEntryResponse, 0, len(es))
+	logs := make([]*operationLogEntryResponse, 0, len(es))
 	for _, e := range es {
-		log = append(log, newOperationLogEntryResponse(e))
+		logs = append(logs, newOperationLogEntryResponse(e))
 	}
 	return &operationLogResponse{
 		Links: map[string]string{
-			"self": fmt.Sprintf("/api/v2/users/%s/log", id),
+			"self": fmt.Sprintf("/api/v2/users/%s/logs", id),
 		},
-		Log: log,
+		Logs: logs,
 	}
 }


### PR DESCRIPTION
Closes #12484 

_Briefly describe your proposed changes:_

Previously, our endpoints were "log" and not "logs."

Plural for consistency.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
