### PR TITLE
fix(swagger): add type to expected telegraf request properties

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6949,6 +6949,7 @@ components:
       properties:
         name:
           type: string
+          example: cpu
         type:
           type: string
           enum:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6945,9 +6945,15 @@ components:
         propertyName: "name"
       required:
         - name
+        - type
       properties:
         name:
           type: string
+        type:
+          type: string
+          enum:
+            - input
+            - output
     TelegrafPluginInputCpu:
       type: object
       required:


### PR DESCRIPTION
When creating a new telegraf, the plugin's type is a required field. I've updated the swagger to reflect this.