### PR TITLE
fix(http): update bucket write links to include org/bucket

### DIFF
--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -243,20 +243,21 @@ func newBucketUpdate(pb *influxdb.BucketUpdate) *bucketUpdate {
 }
 
 type bucketResponse struct {
-	Links map[string]string `json:"links"`
 	bucket
-	Labels []influxdb.Label `json:"labels"`
+	Links  map[string]string `json:"links"`
+	Labels []influxdb.Label  `json:"labels"`
 }
 
 func newBucketResponse(b *influxdb.Bucket, labels []*influxdb.Label) *bucketResponse {
 	res := &bucketResponse{
 		Links: map[string]string{
-			"self":    fmt.Sprintf("/api/v2/buckets/%s", b.ID),
-			"logs":    fmt.Sprintf("/api/v2/buckets/%s/logs", b.ID),
 			"labels":  fmt.Sprintf("/api/v2/buckets/%s/labels", b.ID),
+			"logs":    fmt.Sprintf("/api/v2/buckets/%s/logs", b.ID),
 			"members": fmt.Sprintf("/api/v2/buckets/%s/members", b.ID),
-			"owners":  fmt.Sprintf("/api/v2/buckets/%s/owners", b.ID),
 			"org":     fmt.Sprintf("/api/v2/orgs/%s", b.OrganizationID),
+			"owners":  fmt.Sprintf("/api/v2/buckets/%s/owners", b.ID),
+			"self":    fmt.Sprintf("/api/v2/buckets/%s", b.ID),
+			"write":   fmt.Sprintf("/api/v2/write?org=%s&bucket=%s", b.OrganizationID, b.ID),
 		},
 		bucket: *newBucket(b),
 		Labels: []influxdb.Label{},

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -111,7 +111,8 @@ func TestService_handleGetBuckets(t *testing.T) {
         "logs": "/api/v2/buckets/0b501e7e557ab1ed/logs",
         "labels": "/api/v2/buckets/0b501e7e557ab1ed/labels",
         "owners": "/api/v2/buckets/0b501e7e557ab1ed/owners",
-        "members": "/api/v2/buckets/0b501e7e557ab1ed/members"
+        "members": "/api/v2/buckets/0b501e7e557ab1ed/members",
+        "write": "/api/v2/write?org=50f7ba1150f7ba11&bucket=0b501e7e557ab1ed"
       },
       "id": "0b501e7e557ab1ed",
       "organizationID": "50f7ba1150f7ba11",
@@ -134,7 +135,8 @@ func TestService_handleGetBuckets(t *testing.T) {
         "logs": "/api/v2/buckets/c0175f0077a77005/logs",
         "labels": "/api/v2/buckets/c0175f0077a77005/labels",
         "members": "/api/v2/buckets/c0175f0077a77005/members",
-        "owners": "/api/v2/buckets/c0175f0077a77005/owners"
+        "owners": "/api/v2/buckets/c0175f0077a77005/owners",
+        "write": "/api/v2/write?org=7e55e118dbabb1ed&bucket=c0175f0077a77005"
       },
       "id": "c0175f0077a77005",
       "organizationID": "7e55e118dbabb1ed",
@@ -273,7 +275,8 @@ func TestService_handleGetBucket(t *testing.T) {
 		    "logs": "/api/v2/buckets/020f755c3c082000/logs",
 		    "labels": "/api/v2/buckets/020f755c3c082000/labels",
 		    "members": "/api/v2/buckets/020f755c3c082000/members",
-		    "owners": "/api/v2/buckets/020f755c3c082000/owners"
+		    "owners": "/api/v2/buckets/020f755c3c082000/owners",
+		    "write": "/api/v2/write?org=020f755c3c082000&bucket=020f755c3c082000"
 		  },
 		  "id": "020f755c3c082000",
 		  "organizationID": "020f755c3c082000",
@@ -397,7 +400,8 @@ func TestService_handlePostBucket(t *testing.T) {
     "logs": "/api/v2/buckets/020f755c3c082000/logs",
     "labels": "/api/v2/buckets/020f755c3c082000/labels",
     "members": "/api/v2/buckets/020f755c3c082000/members",
-    "owners": "/api/v2/buckets/020f755c3c082000/owners"
+    "owners": "/api/v2/buckets/020f755c3c082000/owners",
+    "write": "/api/v2/write?org=6f626f7274697320&bucket=020f755c3c082000"
   },
   "id": "020f755c3c082000",
   "organizationID": "6f626f7274697320",
@@ -607,7 +611,8 @@ func TestService_handlePatchBucket(t *testing.T) {
     "logs": "/api/v2/buckets/020f755c3c082000/logs",
     "labels": "/api/v2/buckets/020f755c3c082000/labels",
     "members": "/api/v2/buckets/020f755c3c082000/members",
-    "owners": "/api/v2/buckets/020f755c3c082000/owners"
+    "owners": "/api/v2/buckets/020f755c3c082000/owners",
+    "write": "/api/v2/write?org=020f755c3c082000&bucket=020f755c3c082000"
   },
   "id": "020f755c3c082000",
   "organizationID": "020f755c3c082000",
@@ -682,7 +687,8 @@ func TestService_handlePatchBucket(t *testing.T) {
     "logs": "/api/v2/buckets/020f755c3c082000/logs",
     "labels": "/api/v2/buckets/020f755c3c082000/labels",
     "members": "/api/v2/buckets/020f755c3c082000/members",
-    "owners": "/api/v2/buckets/020f755c3c082000/owners"
+    "owners": "/api/v2/buckets/020f755c3c082000/owners",
+    "write": "/api/v2/write?org=020f755c3c082000&bucket=020f755c3c082000"
   },
   "id": "020f755c3c082000",
   "organizationID": "020f755c3c082000",
@@ -738,7 +744,8 @@ func TestService_handlePatchBucket(t *testing.T) {
     "logs": "/api/v2/buckets/020f755c3c082000/logs",
     "labels": "/api/v2/buckets/020f755c3c082000/labels",
     "members": "/api/v2/buckets/020f755c3c082000/members",
-    "owners": "/api/v2/buckets/020f755c3c082000/owners"
+    "owners": "/api/v2/buckets/020f755c3c082000/owners",
+    "write": "/api/v2/write?org=020f755c3c082000&bucket=020f755c3c082000"
   },
   "id": "020f755c3c082000",
   "organizationID": "020f755c3c082000",

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5447,21 +5447,34 @@ components:
           type: object
           readOnly: true
           example:
-            self: "/api/v2/buckets/1"
-            org: "/api/v2/orgs/2"
-            write: "/api/v2/write?org=myorg"
+            labels: "/api/v2/buckets/1/labels"
+            logs: "/api/v2/buckets/1/logs"
             members: "/api/v2/buckets/1/members"
+            org: "/api/v2/orgs/2"
             owners: "/api/v2/buckets/1/owners"
+            self: "/api/v2/buckets/1"
+            write: "/api/v2/write?org=2&bucket=1"
           properties:
-            self:
+            labels:
+              description: URL to retrieve labels for this bucket
               $ref: "#/components/schemas/Link"
-            org:
-              $ref: "#/components/schemas/Link"
-            write:
+            logs:
+              description: URL to retrieve operation logs for this bucket
               $ref: "#/components/schemas/Link"
             members:
+              description: URL to retrieve members that can read this bucket
+              $ref: "#/components/schemas/Link"
+            org:
+              description: URL to retrieve parent organization for this bucket
               $ref: "#/components/schemas/Link"
             owners:
+              description: URL to retrieve owners that can read and write to this bucket.
+              $ref: "#/components/schemas/Link"
+            self:
+              description: URL for this bucket
+              $ref: "#/components/schemas/Link"
+            write:
+              description: URL to write line protocol for this bucket
               $ref: "#/components/schemas/Link"
         id:
           readOnly: true


### PR DESCRIPTION
Closes #12483

_Briefly describe your proposed changes:_
Add /write convenience links to bucket response.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
