### PR TITLE
docs(http): specify that label properties keys must be strings

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7678,6 +7678,8 @@ components:
           type: string
         properties:
           type: object
+          additionalProperties:
+            type: string
           description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
           example: {"color": "ffb3b3", "description": "this is a description"}
     LabelUpdate:


### PR DESCRIPTION
Closes #12482 

_Briefly describe your proposed changes:_
Without this restriction the specification implied the key could be any data type.

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
