### PR TITLE
fix(ui/inlinelabels): filter labels in render

### DIFF
--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -158,13 +158,11 @@ class DashboardCard extends PureComponent<Props> {
     onRemoveDashboardLabels(dashboard.id, [label])
   }
 
-  private handleCreateLabel = async (label: ILabel): Promise<ILabel> => {
+  private handleCreateLabel = async (label: ILabel): Promise<void> => {
     try {
       await this.props.onCreateLabel(label.name, label.properties)
 
-      const createdLabel = this.props.labels.find(l => l.name === label.name)
       // notify success
-      return createdLabel
     } catch (err) {
       console.error(err)
       // notify of fail

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -9,11 +9,11 @@ import {ResourceList, Context} from 'src/clockface'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 
 // Actions
-import {createLabelAJAX} from 'src/labels/api'
 import {
   addDashboardLabelsAsync,
   removeDashboardLabelsAsync,
 } from 'src/dashboards/actions/v2'
+import {createLabel as createLabelAsync} from 'src/labels/actions'
 
 // Types
 import {Organization} from 'src/types/v2'
@@ -40,6 +40,7 @@ interface StateProps {
 interface DispatchProps {
   onAddDashboardLabels: typeof addDashboardLabelsAsync
   onRemoveDashboardLabels: typeof removeDashboardLabelsAsync
+  onCreateLabel: typeof createLabelAsync
 }
 
 type Props = PassedProps & DispatchProps & StateProps & WithRouterProps
@@ -159,9 +160,11 @@ class DashboardCard extends PureComponent<Props> {
 
   private handleCreateLabel = async (label: ILabel): Promise<ILabel> => {
     try {
-      const newLabel = await createLabelAJAX(label)
+      await this.props.onCreateLabel(label.name, label.properties)
+
+      const createdLabel = this.props.labels.find(l => l.name === label.name)
       // notify success
-      return newLabel
+      return createdLabel
     } catch (err) {
       console.error(err)
       // notify of fail
@@ -187,6 +190,7 @@ const mstp = ({labels}: AppState): StateProps => {
 }
 
 const mdtp: DispatchProps = {
+  onCreateLabel: createLabelAsync,
   onAddDashboardLabels: addDashboardLabelsAsync,
   onRemoveDashboardLabels: removeDashboardLabelsAsync,
 }

--- a/ui/src/labels/actions/index.ts
+++ b/ui/src/labels/actions/index.ts
@@ -87,7 +87,7 @@ export const createLabel = (
   try {
     const createdLabel = await client.labels.create(name, properties)
 
-    dispatch(addLabel(createdLabel))
+    await dispatch(addLabel(createdLabel))
   } catch (e) {
     console.log(e)
     dispatch(notify(createLabelFailed()))

--- a/ui/src/labels/actions/index.ts
+++ b/ui/src/labels/actions/index.ts
@@ -74,7 +74,7 @@ export const getLabels = () => async (dispatch: Dispatch<Action>) => {
 
     dispatch(setLabels(RemoteDataState.Done, labels))
   } catch (e) {
-    console.log(e)
+    console.error(e)
     dispatch(setLabels(RemoteDataState.Error))
     dispatch(notify(getLabelsFailed()))
   }
@@ -87,9 +87,9 @@ export const createLabel = (
   try {
     const createdLabel = await client.labels.create(name, properties)
 
-    await dispatch(addLabel(createdLabel))
+    dispatch(addLabel(createdLabel))
   } catch (e) {
-    console.log(e)
+    console.error(e)
     dispatch(notify(createLabelFailed()))
   }
 }
@@ -102,7 +102,7 @@ export const updateLabel = (id: string, properties: LabelProperties) => async (
 
     dispatch(editLabel(label))
   } catch (e) {
-    console.log(e)
+    console.error(e)
     dispatch(notify(updateLabelFailed()))
   }
 }
@@ -115,7 +115,7 @@ export const deleteLabel = (id: string) => async (
 
     dispatch(removeLabel(id))
   } catch (e) {
-    console.log(e)
+    console.error(e)
     dispatch(notify(deleteLabelFailed()))
   }
 }

--- a/ui/src/shared/components/inlineLabels/InlineLabels.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabels.tsx
@@ -20,7 +20,7 @@ interface Props {
   labels: ILabel[]
   onRemoveLabel: (label: ILabel) => void
   onAddLabel: (label: ILabel) => void
-  onCreateLabel: (label: ILabel) => Promise<ILabel>
+  onCreateLabel: (label: ILabel) => Promise<void>
   onFilterChange: (searchTerm: string) => void
 }
 

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -12,12 +12,12 @@ import {
 import InlineLabelPopover from 'src/shared/components/inlineLabels/InlineLabelPopover'
 import CreateLabelOverlay from 'src/configuration/components/CreateLabelOverlay'
 
+// Utils
+import {validateLabelUniqueness} from 'src/configuration/utils/labels'
+
 // Types
 import {ILabel} from '@influxdata/influx'
 import {OverlayState} from 'src/types/overlay'
-
-// Utils
-import {validateLabelUniqueness} from 'src/configuration/utils/labels'
 
 // Styles
 import 'src/shared/components/inlineLabels/InlineLabelsEditor.scss'
@@ -163,7 +163,7 @@ class InlineLabelsEditor extends Component<Props, State> {
     let selectedItemID = this.state.selectedItemID
     const searchTerm = e.target.value
 
-    const selectedItemIDAvailable = this.availableLabels.find(
+    const selectedItemIDAvailable = availableLabels.find(
       al => al.name === selectedItemID
     )
 
@@ -184,11 +184,8 @@ class InlineLabelsEditor extends Component<Props, State> {
 
   private get filteredLabels(): ILabel[] {
     const {searchTerm} = this.state
-    const {labels, selectedLabels} = this.props
 
-    const availableLabels = _.differenceBy(labels, selectedLabels, l => l.name)
-
-    return availableLabels.filter(label => {
+    return this.availableLabels.filter(label => {
       return label.name.includes(searchTerm)
     })
   }
@@ -201,9 +198,14 @@ class InlineLabelsEditor extends Component<Props, State> {
 
   private handleCreateLabel = async (label: ILabel) => {
     const {onCreateLabel, onAddLabel} = this.props
-    await onCreateLabel(label)
-    const newLabel = this.props.labels.find(l => l.name === label.name)
-    await onAddLabel(newLabel)
+
+    try {
+      await onCreateLabel(label)
+      const newLabel = this.props.labels.find(l => l.name === label.name)
+      await onAddLabel(newLabel)
+    } catch (error) {
+      console.error(error)
+    }
   }
 
   private handleStartCreatingLabel = (): void => {

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -127,7 +127,9 @@ class InlineLabelsEditor extends Component<Props, State> {
 
     const label = labels.find(label => label.id === labelID)
 
-    onAddLabel(label)
+    if (label) {
+      onAddLabel(label)
+    }
   }
 
   private handleUpdateSelectedItem = (selectedItemID: string): void => {

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -28,7 +28,7 @@ interface Props {
   selectedLabels: ILabel[]
   labels: ILabel[]
   onAddLabel: (label: ILabel) => void
-  onCreateLabel: (label: ILabel) => Promise<ILabel>
+  onCreateLabel: (label: ILabel) => Promise<void>
 }
 
 interface State {
@@ -201,7 +201,8 @@ class InlineLabelsEditor extends Component<Props, State> {
 
   private handleCreateLabel = async (label: ILabel) => {
     const {onCreateLabel, onAddLabel} = this.props
-    const newLabel = await onCreateLabel(label)
+    await onCreateLabel(label)
+    const newLabel = this.props.labels.find(l => l.name === label.name)
     await onAddLabel(newLabel)
   }
 

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -464,6 +464,18 @@ export const databaseNameAlreadyExists = (): Notification => ({
   message: 'A Database by this name already exists.',
 })
 
+//  Task Notifications
+//  ----------------------------------------------------------------------------
+export const addTaskLabelFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Failed to add label to task',
+})
+
+export const removeTaskLabelFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Failed to remove label from task',
+})
+
 //  Dashboard Notifications
 //  ----------------------------------------------------------------------------
 export const tempVarAlreadyExists = (tempVarName: string): Notification => ({

--- a/ui/src/tasks/actions/v2/index.ts
+++ b/ui/src/tasks/actions/v2/index.ts
@@ -23,6 +23,9 @@ import {
   taskGetFailed,
 } from 'src/shared/copy/v2/notifications'
 
+// Constants
+import * as copy from 'src/shared/copy/notifications'
+
 // Types
 import {AppState, Label} from 'src/types/v2'
 
@@ -229,6 +232,7 @@ export const addTaskLabelsAsync = (taskID: string, labels: Label[]) => async (
     dispatch(updateTask(task))
   } catch (error) {
     console.error(error)
+    dispatch(copy.addTaskLabelFailed())
   }
 }
 
@@ -243,6 +247,7 @@ export const removeTaskLabelsAsync = (
     dispatch(updateTask(task))
   } catch (error) {
     console.error(error)
+    dispatch(copy.removeTaskLabelFailed())
   }
 }
 

--- a/ui/src/tasks/components/TaskCard.test.tsx
+++ b/ui/src/tasks/components/TaskCard.test.tsx
@@ -23,6 +23,7 @@ const setup = (override = {}) => {
     onUpdate: jest.fn(),
     onAddTaskLabels: jest.fn(),
     onRemoveTaskLabels: jest.fn(),
+    onCreateLabel: jest.fn(),
     labels: [], // all labels
     ...override,
   }

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -8,11 +8,9 @@ import {SlideToggle, ComponentSize} from '@influxdata/clockface'
 import {ResourceList, Context} from 'src/clockface'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 
-// API
-import {createLabelAJAX} from 'src/labels/api'
-
 // Actions
 import {addTaskLabelsAsync, removeTaskLabelsAsync} from 'src/tasks/actions/v2'
+import {createLabel as createLabelAsync} from 'src/labels/actions'
 
 // Types
 import {ComponentColor} from '@influxdata/clockface'
@@ -41,6 +39,7 @@ interface StateProps {
 interface DispatchProps {
   onAddTaskLabels: typeof addTaskLabelsAsync
   onRemoveTaskLabels: typeof removeTaskLabelsAsync
+  onCreateLabel: typeof createLabelAsync
 }
 
 type Props = PassedProps & StateProps & DispatchProps
@@ -167,11 +166,9 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
     onRemoveTaskLabels(task.id, [label])
   }
 
-  private handleCreateLabel = async (label: ILabel): Promise<ILabel> => {
+  private handleCreateLabel = async (label: ILabel): Promise<void> => {
     try {
-      const newLabel = await createLabelAJAX(label)
-
-      return newLabel
+      await this.props.onCreateLabel(label.name, label.properties)
     } catch (err) {
       throw err
     }
@@ -217,6 +214,7 @@ const mstp = ({labels}: AppState): StateProps => {
 }
 
 const mdtp: DispatchProps = {
+  onCreateLabel: createLabelAsync,
   onAddTaskLabels: addTaskLabelsAsync,
   onRemoveTaskLabels: removeTaskLabelsAsync,
 }


### PR DESCRIPTION
Closes #124688

_Briefly describe your proposed changes:_
Stale labels stored in component state required the dashboard index to be refreshed to add a newly created label to multiple list items. This change prefers to filter the labels by search term on render and resolves issues with stale label lists.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
