### PR TITLE
fix(ui/labels): update empty state for no labels

### DIFF
--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -93,7 +93,8 @@ class InlineLabelsEditor extends Component<Props, State> {
     const {labels, selectedLabels} = this.props
     const {searchTerm, isPopoverVisible, selectedItemID} = this.state
 
-    const labelsUsed = labels.length === selectedLabels.length
+    const labelsUsed =
+      labels.length > 0 && labels.length === selectedLabels.length
 
     if (isPopoverVisible) {
       return (

--- a/ui/src/shared/components/inlineLabels/InlineLabelsList.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsList.tsx
@@ -46,6 +46,7 @@ class InlineLabelsList extends Component<Props> {
       onUpdateSelectedItem,
       selectedItemID,
       allLabelsUsed,
+      searchTerm,
     } = this.props
 
     if (filteredLabels.length) {
@@ -67,6 +68,14 @@ class InlineLabelsList extends Component<Props> {
       return (
         <EmptyState size={ComponentSize.Small}>
           <EmptyState.Text text="This resource uses all available labels" />
+        </EmptyState>
+      )
+    }
+
+    if (!searchTerm) {
+      return (
+        <EmptyState size={ComponentSize.Small}>
+          <EmptyState.Text text="Type to create your first label" />
         </EmptyState>
       )
     }


### PR DESCRIPTION
Closes #12469 

_Briefly describe your proposed changes:_
Resolves awkward empty state with prompting for typing to create a new label
![Screen Shot 2019-03-11 at 5 51 12 PM](https://user-images.githubusercontent.com/4994741/54161326-303a0480-4428-11e9-96c0-b0d13160ccae.png)


  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
