### PR TITLE
Polish Overlays

### DIFF
--- a/ui/src/clockface/components/overlays/Overlay.scss
+++ b/ui/src/clockface/components/overlays/Overlay.scss
@@ -47,6 +47,10 @@ $overlay--container-padding: $ix-marg-c + $ix-marg-d;
     opacity: 1;
     pointer-events: all;
   }
+
+  .fancy-scroll--track-h {
+    display: none;
+  }
 }
 
 // Open State

--- a/ui/src/clockface/components/overlays/Overlay.scss
+++ b/ui/src/clockface/components/overlays/Overlay.scss
@@ -1,17 +1,13 @@
+@import 'src/style/modules';
 /*
    Overlays
    -----------------------------------------------------------------------------
 */
 
-$overlay-title-height: $chronograf-page-header-height;
+$overlay-title-height: $page-header-size;
 $overlay-gutter: $ix-marg-d;
 
-
-/*
-    Overlay Technology Styles
-    ----------------------------------------------------------------------------
-*/
-
+// Mixin for shared styles
 %overlay-styles {
   position: fixed;
   width: 100%;
@@ -21,26 +17,27 @@ $overlay-gutter: $ix-marg-d;
 }
 
 .overlay--mask {
-  @extend %overlay-styles;
   z-index: 1;
+  @extend %overlay-styles;
   opacity: 0;
   transition: opacity 0.25s ease;
-  @include gradient-diag-down($c-pool,$c-comet);
+  @include gradient-diag-down($c-pool, $c-comet);
 }
 
-.overlay--dialog {
+.overlay--transition {
   height: 100%;
   position: relative;
   z-index: 2;
   transform: translateY(72px);
   opacity: 0;
-  transition: transform 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.25s ease;
+  transition: transform 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275),
+    opacity 0.25s ease;
 }
 
-.overlay-tech {
+.overlay {
+  z-index: $z--overlays;
   @extend %overlay-styles;
   transition: all 0.25s ease;
-  z-index: $z--overlays;
   pointer-events: none;
   opacity: 0;
 
@@ -51,11 +48,11 @@ $overlay-gutter: $ix-marg-d;
 }
 
 // Open State
-.overlay-tech.show {
+.overlay.show {
   .overlay--mask {
     opacity: 0.7;
   }
-  .overlay--dialog {
+  .overlay--transition {
     opacity: 1;
     transform: translateY(0);
   }
@@ -105,10 +102,10 @@ $overlay-gutter: $ix-marg-d;
     transition: background-color 0.25s ease;
   }
   &:before {
-    transform: translate(-50%,-50%) rotate(45deg);
+    transform: translate(-50%, -50%) rotate(45deg);
   }
   &:after {
-    transform: translate(-50%,-50%) rotate(-45deg);
+    transform: translate(-50%, -50%) rotate(-45deg);
   }
   /* Hover State */
   &:hover {

--- a/ui/src/clockface/components/overlays/Overlay.scss
+++ b/ui/src/clockface/components/overlays/Overlay.scss
@@ -4,20 +4,23 @@
    -----------------------------------------------------------------------------
 */
 
-$overlay-title-height: $page-header-size;
-$overlay-gutter: $ix-marg-d;
+$overlay--gutter: $ix-marg-c + $ix-marg-b;
+$overlay--header-height: $page-header-size;
+$overlay--title-size: $page-title-size;
+$overlay--title-weight: $page-title-weight;
+$overlay--container-padding: $ix-marg-c + $ix-marg-d;
 
 // Mixin for shared styles
 %overlay-styles {
-  position: fixed;
-  width: 100%;
-  height: 100%;
+  position: fixed !important;
+  width: 100% !important;
+  height: 100% !important;
   top: 0;
   left: 0;
 }
 
 .overlay--mask {
-  z-index: 1;
+  z-index: 0;
   @extend %overlay-styles;
   opacity: 0;
   transition: opacity 0.25s ease;
@@ -25,7 +28,6 @@ $overlay-gutter: $ix-marg-d;
 }
 
 .overlay--transition {
-  height: 100%;
   position: relative;
   z-index: 2;
   transform: translateY(72px);
@@ -59,30 +61,30 @@ $overlay-gutter: $ix-marg-d;
 }
 
 .overlay--container {
-  margin: 40px auto;
+  margin: $overlay--container-padding auto;
   @include gradient-v($g3-castle, $g2-kevlar);
   border-radius: $radius;
 }
 
 .overlay--heading {
-  height: 80px;
+  height: $overlay--header-height;
   display: flex;
+  padding: 0 $overlay--gutter;
   justify-content: space-between;
   align-items: center;
-  padding: 0 $overlay-gutter;
   @include no-user-select();
 }
 
 .overlay--title {
-  font-size: 19px;
-  font-weight: 400;
+  font-size: $overlay--title-size;
+  font-weight: $overlay--title-weight;
   color: $g17-whisper;
   white-space: nowrap;
 }
 
 .overlay--dismiss {
-  width: ($overlay-title-height - 20px);
-  height: ($overlay-title-height - 20px);
+  width: ($overlay--header-height - 20px);
+  height: ($overlay--header-height - 20px);
   position: relative;
   background-color: transparent;
   border: 0;
@@ -118,9 +120,8 @@ $overlay-gutter: $ix-marg-d;
 }
 
 .overlay--body {
-  padding: $overlay-gutter;
+  padding: $overlay--gutter;
   padding-top: 0;
-  padding-bottom: $overlay-gutter / 2;
   color: $g13-mist;
 
   p {
@@ -129,6 +130,6 @@ $overlay-gutter: $ix-marg-d;
 }
 
 .overlay--footer {
-  padding: $overlay-gutter 0;
-  padding-top: $overlay-gutter / 2;
+  padding: $overlay--gutter;
+  padding-top: 0;
 }

--- a/ui/src/clockface/components/overlays/Overlay.tsx
+++ b/ui/src/clockface/components/overlays/Overlay.tsx
@@ -2,6 +2,16 @@
 import React, {Component} from 'react'
 import classnames from 'classnames'
 
+// Components
+import OverlayContainer from 'src/clockface/components/overlays/OverlayContainer'
+import OverlayHeading from 'src/clockface/components/overlays/OverlayHeading'
+import OverlayBody from 'src/clockface/components/overlays/OverlayBody'
+import OverlayFooter from 'src/clockface/components/overlays/OverlayFooter'
+
+// Styles
+import 'src/clockface/components/overlays/Overlay.scss'
+
+// Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
@@ -14,7 +24,12 @@ interface State {
 }
 
 @ErrorHandling
-class OverlayTechnology extends Component<Props, State> {
+class Overlay extends Component<Props, State> {
+  public static Container = OverlayContainer
+  public static Heading = OverlayHeading
+  public static Body = OverlayBody
+  public static Footer = OverlayFooter
+
   public static getDerivedStateFromProps(props) {
     if (props.visible) {
       return {showChildren: true}
@@ -55,19 +70,21 @@ class OverlayTechnology extends Component<Props, State> {
 
     if (showChildren) {
       return (
-        <div className="overlay--dialog" data-testid="overlay-children">
+        <div className="overlay--transition" data-testid="overlay-children">
           {children}
         </div>
       )
     }
 
-    return <div className="overlay--dialog" data-testid="overlay-children" />
+    return (
+      <div className="overlay--transition" data-testid="overlay-children" />
+    )
   }
 
   private get overlayClass(): string {
     const {visible} = this.props
 
-    return classnames('overlay-tech', {show: visible})
+    return classnames('overlay', {show: visible})
   }
 
   private hideChildren = (): void => {
@@ -75,4 +92,4 @@ class OverlayTechnology extends Component<Props, State> {
   }
 }
 
-export default OverlayTechnology
+export default Overlay

--- a/ui/src/clockface/components/overlays/Overlay.tsx
+++ b/ui/src/clockface/components/overlays/Overlay.tsx
@@ -7,6 +7,7 @@ import OverlayContainer from 'src/clockface/components/overlays/OverlayContainer
 import OverlayHeading from 'src/clockface/components/overlays/OverlayHeading'
 import OverlayBody from 'src/clockface/components/overlays/OverlayBody'
 import OverlayFooter from 'src/clockface/components/overlays/OverlayFooter'
+import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
 
 // Styles
 import 'src/clockface/components/overlays/Overlay.scss'
@@ -57,10 +58,15 @@ class Overlay extends Component<Props, State> {
 
   public render() {
     return (
-      <div className={this.overlayClass}>
+      <FancyScrollbar
+        className={this.overlayClass}
+        thumbStartColor="#ffffff"
+        thumbStopColor="#C9D0FF"
+        autoHide={false}
+      >
         {this.childContainer}
         <div className="overlay--mask" />
-      </div>
+      </FancyScrollbar>
     )
   }
 

--- a/ui/src/clockface/components/wizard/WizardOverlay.tsx
+++ b/ui/src/clockface/components/wizard/WizardOverlay.tsx
@@ -2,10 +2,7 @@
 import React, {PureComponent} from 'react'
 
 // Components
-import OverlayBody from 'src/clockface/components/overlays/OverlayBody'
-import OverlayContainer from 'src/clockface/components/overlays/OverlayContainer'
-import Overlay from 'src/clockface/components/overlays/Overlay'
-import OverlayHeading from 'src/clockface/components/overlays/OverlayHeading'
+import {Overlay} from 'src/clockface'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -28,12 +25,12 @@ class WizardOverlay extends PureComponent<Props> {
 
     return (
       <Overlay visible={visible}>
-        <OverlayContainer maxWidth={maxWidth}>
-          <OverlayHeading title={title} onDismiss={onDismiss} />
-          <OverlayBody>
+        <Overlay.Container maxWidth={maxWidth}>
+          <Overlay.Heading title={title} onDismiss={onDismiss} />
+          <Overlay.Body>
             <div className="data-loading--overlay">{children}</div>
-          </OverlayBody>
-        </OverlayContainer>
+          </Overlay.Body>
+        </Overlay.Container>
       </Overlay>
     )
   }

--- a/ui/src/clockface/components/wizard/WizardOverlay.tsx
+++ b/ui/src/clockface/components/wizard/WizardOverlay.tsx
@@ -4,7 +4,7 @@ import React, {PureComponent} from 'react'
 // Components
 import OverlayBody from 'src/clockface/components/overlays/OverlayBody'
 import OverlayContainer from 'src/clockface/components/overlays/OverlayContainer'
-import OverlayTechnology from 'src/clockface/components/overlays/OverlayTechnology'
+import Overlay from 'src/clockface/components/overlays/Overlay'
 import OverlayHeading from 'src/clockface/components/overlays/OverlayHeading'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -27,14 +27,14 @@ class WizardOverlay extends PureComponent<Props> {
     const {visible, title, maxWidth, children, onDismiss} = this.props
 
     return (
-      <OverlayTechnology visible={visible}>
+      <Overlay visible={visible}>
         <OverlayContainer maxWidth={maxWidth}>
           <OverlayHeading title={title} onDismiss={onDismiss} />
           <OverlayBody>
             <div className="data-loading--overlay">{children}</div>
           </OverlayBody>
         </OverlayContainer>
-      </OverlayTechnology>
+      </Overlay>
     )
   }
 }

--- a/ui/src/clockface/index.ts
+++ b/ui/src/clockface/index.ts
@@ -11,10 +11,6 @@ import MultipleInput, {
   MultiInputType,
 } from './components/inputs/multipleInput/MultipleInput'
 import Overlay from './components/overlays/Overlay'
-import OverlayContainer from './components/overlays/OverlayContainer'
-import OverlayHeading from './components/overlays/OverlayHeading'
-import OverlayBody from './components/overlays/OverlayBody'
-import OverlayFooter from './components/overlays/OverlayFooter'
 import Panel from './components/panel/Panel'
 import Radio from './components/radio_buttons/RadioButtons'
 import WizardFullScreen from './components/wizard/WizardFullScreen'
@@ -88,10 +84,6 @@ export {
   MultiSelectDropdown,
   MultiInputType,
   MultipleInput,
-  OverlayBody,
-  OverlayContainer,
-  OverlayFooter,
-  OverlayHeading,
   Overlay,
   Panel,
   ProgressBar,

--- a/ui/src/clockface/index.ts
+++ b/ui/src/clockface/index.ts
@@ -10,7 +10,7 @@ import Input, {InputType, AutoComplete} from './components/inputs/Input'
 import MultipleInput, {
   MultiInputType,
 } from './components/inputs/multipleInput/MultipleInput'
-import OverlayTechnology from './components/overlays/OverlayTechnology'
+import Overlay from './components/overlays/Overlay'
 import OverlayContainer from './components/overlays/OverlayContainer'
 import OverlayHeading from './components/overlays/OverlayHeading'
 import OverlayBody from './components/overlays/OverlayBody'
@@ -92,7 +92,7 @@ export {
   OverlayContainer,
   OverlayFooter,
   OverlayHeading,
-  OverlayTechnology,
+  Overlay,
   Panel,
   ProgressBar,
   QuestionMarkTooltip,

--- a/ui/src/clockface/styles.scss
+++ b/ui/src/clockface/styles.scss
@@ -11,12 +11,10 @@
 @import 'components/grid_sizer/GridSizer';
 @import 'components/inputs/Input';
 @import 'components/inputs/multipleInput/MultipleInput';
-@import 'components/overlays/Overlay';
 @import 'components/panel/Panel';
 @import 'components/wizard/WizardFullScreen';
 @import 'components/wizard/WizardProgressHeader';
 @import 'components/wizard/ProgressBar';
 @import 'components/wizard/WizardOverlay';
-@import 'components/component_spacer/ComponentSpacer';
 @import 'components/empty_state/EmptyState';
 @import 'components/tooltips/Tooltips';

--- a/ui/src/configuration/components/BucketList.tsx
+++ b/ui/src/configuration/components/BucketList.tsx
@@ -7,7 +7,7 @@ import _ from 'lodash'
 // Components
 import UpdateBucketOverlay from 'src/organizations/components/UpdateBucketOverlay'
 import BucketRow, {PrettyBucket} from 'src/organizations/components/BucketRow'
-import {OverlayTechnology, IndexList} from 'src/clockface'
+import {Overlay, IndexList} from 'src/clockface'
 import DataLoaderSwitcher from 'src/dataLoaders/components/DataLoaderSwitcher'
 
 // Actions
@@ -98,13 +98,13 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
             ))}
           </IndexList.Body>
         </IndexList>
-        <OverlayTechnology visible={this.isBucketOverlayVisible}>
+        <Overlay visible={this.isBucketOverlayVisible}>
           <UpdateBucketOverlay
             bucket={this.bucket}
             onCloseModal={this.handleCloseModal}
             onUpdateBucket={this.handleUpdateBucket}
           />
-        </OverlayTechnology>
+        </Overlay>
         <DataLoaderSwitcher
           type={dataLoaderType}
           visible={this.isDataLoadersWizardVisible}

--- a/ui/src/configuration/components/Buckets.tsx
+++ b/ui/src/configuration/components/Buckets.tsx
@@ -15,7 +15,7 @@ import {
   ComponentColor,
   IconFont,
 } from '@influxdata/clockface'
-import {Input, OverlayTechnology, EmptyState, Tabs} from 'src/clockface'
+import {Input, Overlay, EmptyState, Tabs} from 'src/clockface'
 
 // Actions
 import {createBucket, updateBucket, deleteBucket} from 'src/buckets/actions'
@@ -100,13 +100,13 @@ class Buckets extends PureComponent<Props, State> {
             />
           )}
         </FilterList>
-        <OverlayTechnology visible={overlayState === OverlayState.Open}>
+        <Overlay visible={overlayState === OverlayState.Open}>
           <CreateBucketOverlay
             orgs={orgs}
             onCloseModal={this.handleCloseModal}
             onCreateBucket={this.handleCreateBucket}
           />
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/configuration/components/CreateBucketOverlay.tsx
+++ b/ui/src/configuration/components/CreateBucketOverlay.tsx
@@ -2,12 +2,7 @@
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
 
 // Components
-import {
-  OverlayBody,
-  OverlayHeading,
-  ComponentStatus,
-  OverlayContainer,
-} from 'src/clockface'
+import {ComponentStatus, Overlay} from 'src/clockface'
 import BucketOverlayForm from 'src/organizations/components/BucketOverlayForm'
 
 // Types
@@ -47,12 +42,12 @@ export default class BucketOverlay extends PureComponent<Props, State> {
     const {bucket, nameInputStatus, nameErrorMessage, ruleType} = this.state
 
     return (
-      <OverlayContainer maxWidth={500}>
-        <OverlayHeading
+      <Overlay.Container maxWidth={500}>
+        <Overlay.Heading
           title="Create Bucket"
           onDismiss={this.props.onCloseModal}
         />
-        <OverlayBody>
+        <Overlay.Body>
           <BucketOverlayForm
             name={bucket.name}
             buttonText="Create"
@@ -66,8 +61,8 @@ export default class BucketOverlay extends PureComponent<Props, State> {
             onChangeRuleType={this.handleChangeRuleType}
             onChangeRetentionRule={this.handleChangeRetentionRule}
           />
-        </OverlayBody>
-      </OverlayContainer>
+        </Overlay.Body>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/configuration/components/CreateLabelOverlay.tsx
+++ b/ui/src/configuration/components/CreateLabelOverlay.tsx
@@ -4,7 +4,7 @@ import React, {Component, ChangeEvent} from 'react'
 // Components
 import LabelOverlayForm from 'src/configuration/components/LabelOverlayForm'
 import {
-  OverlayTechnology,
+  Overlay,
   OverlayContainer,
   OverlayBody,
   OverlayHeading,
@@ -61,7 +61,7 @@ class CreateLabelOverlay extends Component<Props, State> {
     const {label} = this.state
 
     return (
-      <OverlayTechnology visible={isVisible}>
+      <Overlay visible={isVisible}>
         <OverlayContainer maxWidth={400}>
           <OverlayHeading title="Create Label" onDismiss={onDismiss} />
           <OverlayBody>
@@ -80,7 +80,7 @@ class CreateLabelOverlay extends Component<Props, State> {
             />
           </OverlayBody>
         </OverlayContainer>
-      </OverlayTechnology>
+      </Overlay>
     )
   }
 

--- a/ui/src/configuration/components/CreateLabelOverlay.tsx
+++ b/ui/src/configuration/components/CreateLabelOverlay.tsx
@@ -3,13 +3,7 @@ import React, {Component, ChangeEvent} from 'react'
 
 // Components
 import LabelOverlayForm from 'src/configuration/components/LabelOverlayForm'
-import {
-  Overlay,
-  OverlayContainer,
-  OverlayBody,
-  OverlayHeading,
-  ComponentStatus,
-} from 'src/clockface'
+import {Overlay, ComponentStatus} from 'src/clockface'
 
 // Types
 import {ILabel} from '@influxdata/influx'
@@ -62,9 +56,9 @@ class CreateLabelOverlay extends Component<Props, State> {
 
     return (
       <Overlay visible={isVisible}>
-        <OverlayContainer maxWidth={400}>
-          <OverlayHeading title="Create Label" onDismiss={onDismiss} />
-          <OverlayBody>
+        <Overlay.Container maxWidth={400}>
+          <Overlay.Heading title="Create Label" onDismiss={onDismiss} />
+          <Overlay.Body>
             <LabelOverlayForm
               id={label.id}
               name={label.name}
@@ -78,8 +72,8 @@ class CreateLabelOverlay extends Component<Props, State> {
               isFormValid={this.isFormValid}
               onNameValidation={onNameValidation}
             />
-          </OverlayBody>
-        </OverlayContainer>
+          </Overlay.Body>
+        </Overlay.Container>
       </Overlay>
     )
   }

--- a/ui/src/configuration/components/LabelList.tsx
+++ b/ui/src/configuration/components/LabelList.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent} from 'react'
 
 // Components
-import {IndexList, OverlayTechnology} from 'src/clockface'
+import {IndexList, Overlay} from 'src/clockface'
 import UpdateLabelOverlay from 'src/configuration/components/UpdateLabelOverlay'
 import LabelRow from 'src/configuration/components/LabelRow'
 
@@ -48,14 +48,14 @@ export default class LabelList extends PureComponent<Props, State> {
             {this.rows}
           </IndexList.Body>
         </IndexList>
-        <OverlayTechnology visible={this.isOverlayVisible}>
+        <Overlay visible={this.isOverlayVisible}>
           <UpdateLabelOverlay
             label={this.label}
             onDismiss={this.handleCloseModal}
             onUpdateLabel={this.handleUpdateLabel}
             onNameValidation={this.handleNameValidation}
           />
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/configuration/components/UpdateLabelOverlay.tsx
+++ b/ui/src/configuration/components/UpdateLabelOverlay.tsx
@@ -3,7 +3,7 @@ import React, {Component, ChangeEvent} from 'react'
 
 // Components
 import LabelOverlayForm from 'src/configuration/components/LabelOverlayForm'
-import {OverlayContainer, OverlayBody, OverlayHeading} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 import {ComponentStatus} from '@influxdata/clockface'
 
 // Types
@@ -40,9 +40,9 @@ class UpdateLabelOverlay extends Component<Props, State> {
     const {label} = this.state
 
     return (
-      <OverlayContainer maxWidth={400}>
-        <OverlayHeading title="Edit Label" onDismiss={onDismiss} />
-        <OverlayBody>
+      <Overlay.Container maxWidth={400}>
+        <Overlay.Heading title="Edit Label" onDismiss={onDismiss} />
+        <Overlay.Body>
           <LabelOverlayForm
             id={label.id}
             name={label.name}
@@ -56,8 +56,8 @@ class UpdateLabelOverlay extends Component<Props, State> {
             isFormValid={this.isFormValid}
             onNameValidation={onNameValidation}
           />
-        </OverlayBody>
-      </OverlayContainer>
+        </Overlay.Body>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -11,7 +11,7 @@ import DashboardHeader from 'src/dashboards/components/DashboardHeader'
 import DashboardComponent from 'src/dashboards/components/Dashboard'
 import ManualRefresh from 'src/shared/components/ManualRefresh'
 import VEO from 'src/dashboards/components/VEO'
-import {OverlayTechnology} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 import {HoverTimeProvider} from 'src/dashboards/utils/hoverTime'
 import NoteEditorContainer from 'src/dashboards/components/NoteEditorContainer'
 
@@ -202,9 +202,9 @@ class DashboardPage extends Component<Props, State> {
               onAddCell={this.handleAddCell}
             />
           )}
-          <OverlayTechnology visible={isShowingVEO}>
+          <Overlay visible={isShowingVEO}>
             <VEO onHide={this.handleHideVEO} onSave={this.handleSaveVEO} />
-          </OverlayTechnology>
+          </Overlay>
         </HoverTimeProvider>
         <NoteEditorContainer />
       </Page>

--- a/ui/src/dashboards/components/NoteEditorContainer.tsx
+++ b/ui/src/dashboards/components/NoteEditorContainer.tsx
@@ -9,7 +9,7 @@ import {Button, ComponentColor, ComponentStatus} from '@influxdata/clockface'
 import {
   OverlayBody,
   OverlayHeading,
-  OverlayTechnology,
+  Overlay,
   OverlayContainer,
   OverlayFooter,
 } from 'src/clockface'
@@ -59,7 +59,7 @@ class NoteEditorContainer extends PureComponent<Props, State> {
 
     return (
       <div className="note-editor-container">
-        <OverlayTechnology visible={overlayVisible}>
+        <Overlay visible={overlayVisible}>
           <OverlayContainer maxWidth={900}>
             <OverlayHeading title={this.overlayTitle} onDismiss={onHide} />
             <OverlayBody>
@@ -75,7 +75,7 @@ class NoteEditorContainer extends PureComponent<Props, State> {
               />
             </OverlayFooter>
           </OverlayContainer>
-        </OverlayTechnology>
+        </Overlay>
       </div>
     )
   }

--- a/ui/src/dashboards/components/NoteEditorContainer.tsx
+++ b/ui/src/dashboards/components/NoteEditorContainer.tsx
@@ -6,13 +6,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 // Components
 import NoteEditor from 'src/dashboards/components/NoteEditor'
 import {Button, ComponentColor, ComponentStatus} from '@influxdata/clockface'
-import {
-  OverlayBody,
-  OverlayHeading,
-  Overlay,
-  OverlayContainer,
-  OverlayFooter,
-} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 
 // Actions
 import {
@@ -60,12 +54,12 @@ class NoteEditorContainer extends PureComponent<Props, State> {
     return (
       <div className="note-editor-container">
         <Overlay visible={overlayVisible}>
-          <OverlayContainer maxWidth={900}>
-            <OverlayHeading title={this.overlayTitle} onDismiss={onHide} />
-            <OverlayBody>
+          <Overlay.Container maxWidth={900}>
+            <Overlay.Heading title={this.overlayTitle} onDismiss={onHide} />
+            <Overlay.Body>
               <NoteEditor />
-            </OverlayBody>
-            <OverlayFooter>
+            </Overlay.Body>
+            <Overlay.Footer>
               <Button text="Cancel" onClick={onHide} />
               <Button
                 text="Save"
@@ -73,8 +67,8 @@ class NoteEditorContainer extends PureComponent<Props, State> {
                 status={this.saveButtonStatus}
                 onClick={this.handleSave}
               />
-            </OverlayFooter>
-          </OverlayContainer>
+            </Overlay.Footer>
+          </Overlay.Container>
         </Overlay>
       </div>
     )

--- a/ui/src/dataExplorer/components/SaveAsButton.tsx
+++ b/ui/src/dataExplorer/components/SaveAsButton.tsx
@@ -7,7 +7,7 @@ import SaveAsTaskForm from 'src/dataExplorer/components/SaveAsTaskForm'
 import {IconFont, Button, ComponentColor} from '@influxdata/clockface'
 import {
   Radio,
-  OverlayTechnology,
+  Overlay,
   OverlayBody,
   OverlayHeading,
   OverlayContainer,
@@ -46,7 +46,7 @@ class SaveAsButton extends PureComponent<Props, State> {
           color={ComponentColor.Primary}
           titleText="Save your query as a Dashboard Cell or a Task"
         />
-        <OverlayTechnology visible={isOverlayVisible}>
+        <Overlay visible={isOverlayVisible}>
           <OverlayContainer maxWidth={600}>
             <OverlayHeading
               title="Save As"
@@ -76,7 +76,7 @@ class SaveAsButton extends PureComponent<Props, State> {
               {this.saveAsForm}
             </OverlayBody>
           </OverlayContainer>
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/dataExplorer/components/SaveAsButton.tsx
+++ b/ui/src/dataExplorer/components/SaveAsButton.tsx
@@ -5,13 +5,7 @@ import React, {PureComponent} from 'react'
 import SaveAsCellForm from 'src/dataExplorer/components/SaveAsCellForm'
 import SaveAsTaskForm from 'src/dataExplorer/components/SaveAsTaskForm'
 import {IconFont, Button, ComponentColor} from '@influxdata/clockface'
-import {
-  Radio,
-  Overlay,
-  OverlayBody,
-  OverlayHeading,
-  OverlayContainer,
-} from 'src/clockface'
+import {Radio, Overlay} from 'src/clockface'
 
 // Styles
 import 'src/dataExplorer/components/SaveAsButton.scss'
@@ -47,12 +41,12 @@ class SaveAsButton extends PureComponent<Props, State> {
           titleText="Save your query as a Dashboard Cell or a Task"
         />
         <Overlay visible={isOverlayVisible}>
-          <OverlayContainer maxWidth={600}>
-            <OverlayHeading
+          <Overlay.Container maxWidth={600}>
+            <Overlay.Heading
               title="Save As"
               onDismiss={this.handleHideOverlay}
             />
-            <OverlayBody>
+            <Overlay.Body>
               <div className="save-as--options">
                 <Radio>
                   <Radio.Button
@@ -74,8 +68,8 @@ class SaveAsButton extends PureComponent<Props, State> {
                 </Radio>
               </div>
               {this.saveAsForm}
-            </OverlayBody>
-          </OverlayContainer>
+            </Overlay.Body>
+          </Overlay.Container>
         </Overlay>
       </>
     )

--- a/ui/src/dataExplorer/components/__snapshots__/SaveAsButton.test.tsx.snap
+++ b/ui/src/dataExplorer/components/__snapshots__/SaveAsButton.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`SaveAsButton rendering renders 1`] = `
     titleText="Save your query as a Dashboard Cell or a Task"
     type="button"
   />
-  <OverlayTechnology
+  <Overlay
     visible={false}
   >
     <OverlayContainer
@@ -63,6 +63,6 @@ exports[`SaveAsButton rendering renders 1`] = `
         />
       </OverlayBody>
     </OverlayContainer>
-  </OverlayTechnology>
+  </Overlay>
 </Fragment>
 `;

--- a/ui/src/me/components/account/TokensList.tsx
+++ b/ui/src/me/components/account/TokensList.tsx
@@ -6,7 +6,7 @@ import {
   IndexList,
   EmptyState,
   ComponentSize,
-  OverlayTechnology,
+  Overlay,
 } from 'src/clockface'
 import TokenRow from 'src/me/components/account/TokenRow'
 
@@ -60,13 +60,13 @@ export default class TokenList extends PureComponent<Props, State> {
             })}
           </IndexList.Body>
         </IndexList>
-        <OverlayTechnology visible={isTokenOverlayVisible}>
+        <Overlay visible={isTokenOverlayVisible}>
           <ViewTokenOverlay
             onNotify={onNotify}
             auth={authInView}
             onDismissOverlay={this.handleDismissOverlay}
           />
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/me/components/account/ViewTokenOverlay.tsx
+++ b/ui/src/me/components/account/ViewTokenOverlay.tsx
@@ -3,7 +3,7 @@ import React, {PureComponent} from 'react'
 import {get} from 'lodash'
 
 // Components
-import {OverlayContainer, OverlayBody, OverlayHeading} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 import PermissionsWidget, {
   PermissionsWidgetMode,
   PermissionsWidgetSelection,
@@ -30,9 +30,9 @@ export default class ViewTokenOverlay extends PureComponent<Props> {
     const permissions = this.permissions
 
     return (
-      <OverlayContainer>
-        <OverlayHeading title={description} onDismiss={this.handleDismiss} />
-        <OverlayBody>
+      <Overlay.Container>
+        <Overlay.Heading title={description} onDismiss={this.handleDismiss} />
+        <Overlay.Body>
           <CodeSnippet copyText={this.props.auth.token} notify={onNotify} />
           <PermissionsWidget
             mode={PermissionsWidgetMode.Read}
@@ -58,8 +58,8 @@ export default class ViewTokenOverlay extends PureComponent<Props> {
               )
             })}
           </PermissionsWidget>
-        </OverlayBody>
-      </OverlayContainer>
+        </Overlay.Body>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/organizations/components/AddMembersOverlay.tsx
+++ b/ui/src/organizations/components/AddMembersOverlay.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent} from 'react'
 
 // Components
-import {OverlayBody, OverlayHeading, OverlayContainer} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 import AddMembersForm from './AddMembersForm'
 import {AddResourceMemberRequestBody} from '@influxdata/influx'
 
@@ -33,9 +33,9 @@ export default class AddMembersOverlay extends PureComponent<Props, State> {
     const {selectedUserIDs} = this.state
 
     return (
-      <OverlayContainer maxWidth={500}>
-        <OverlayHeading title="Add Member" onDismiss={onCloseModal} />
-        <OverlayBody>
+      <Overlay.Container maxWidth={500}>
+        <Overlay.Heading title="Add Member" onDismiss={onCloseModal} />
+        <Overlay.Body>
           <AddMembersForm
             onCloseModal={onCloseModal}
             users={users}
@@ -43,8 +43,8 @@ export default class AddMembersOverlay extends PureComponent<Props, State> {
             selectedUserIDs={selectedUserIDs}
             onSave={this.handleSave}
           />
-        </OverlayBody>
-      </OverlayContainer>
+        </Overlay.Body>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/organizations/components/BucketList.tsx
+++ b/ui/src/organizations/components/BucketList.tsx
@@ -7,7 +7,7 @@ import _ from 'lodash'
 // Components
 import UpdateBucketOverlay from 'src/organizations/components/UpdateBucketOverlay'
 import BucketRow, {PrettyBucket} from 'src/organizations/components/BucketRow'
-import {OverlayTechnology, IndexList} from 'src/clockface'
+import {Overlay, IndexList} from 'src/clockface'
 import DataLoaderSwitcher from 'src/dataLoaders/components/DataLoaderSwitcher'
 
 // Actions
@@ -97,13 +97,13 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
             ))}
           </IndexList.Body>
         </IndexList>
-        <OverlayTechnology visible={this.isBucketOverlayVisible}>
+        <Overlay visible={this.isBucketOverlayVisible}>
           <UpdateBucketOverlay
             bucket={this.bucket}
             onCloseModal={this.handleCloseModal}
             onUpdateBucket={this.handleUpdateBucket}
           />
-        </OverlayTechnology>
+        </Overlay>
         <DataLoaderSwitcher
           type={dataLoaderType}
           visible={this.isDataLoadersWizardVisible}

--- a/ui/src/organizations/components/Buckets.tsx
+++ b/ui/src/organizations/components/Buckets.tsx
@@ -13,7 +13,7 @@ import {
   ComponentColor,
   IconFont,
 } from '@influxdata/clockface'
-import {Input, OverlayTechnology, EmptyState, Tabs} from 'src/clockface'
+import {Input, Overlay, EmptyState, Tabs} from 'src/clockface'
 
 // Actions
 import * as NotificationsActions from 'src/types/actions/notifications'
@@ -102,13 +102,13 @@ export default class Buckets extends PureComponent<Props, State> {
             />
           )}
         </FilterList>
-        <OverlayTechnology visible={overlayState === OverlayState.Open}>
+        <Overlay visible={overlayState === OverlayState.Open}>
           <CreateBucketOverlay
             org={org}
             onCloseModal={this.handleCloseModal}
             onCreateBucket={this.handleCreateBucket}
           />
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/organizations/components/CreateBucketOverlay.tsx
+++ b/ui/src/organizations/components/CreateBucketOverlay.tsx
@@ -2,12 +2,7 @@
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
 
 // Components
-import {
-  OverlayBody,
-  OverlayHeading,
-  ComponentStatus,
-  OverlayContainer,
-} from 'src/clockface'
+import {Overlay, ComponentStatus} from 'src/clockface'
 import BucketOverlayForm from 'src/organizations/components/BucketOverlayForm'
 
 // Types
@@ -47,12 +42,12 @@ export default class BucketOverlay extends PureComponent<Props, State> {
     const {bucket, nameInputStatus, nameErrorMessage, ruleType} = this.state
 
     return (
-      <OverlayContainer maxWidth={500}>
-        <OverlayHeading
+      <Overlay.Container maxWidth={500}>
+        <Overlay.Heading
           title="Create Bucket"
           onDismiss={this.props.onCloseModal}
         />
-        <OverlayBody>
+        <Overlay.Body>
           <BucketOverlayForm
             name={bucket.name}
             buttonText="Create"
@@ -66,8 +61,8 @@ export default class BucketOverlay extends PureComponent<Props, State> {
             onChangeRuleType={this.handleChangeRuleType}
             onChangeRetentionRule={this.handleChangeRetentionRule}
           />
-        </OverlayBody>
-      </OverlayContainer>
+        </Overlay.Body>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/organizations/components/CreateOrgOverlay.tsx
+++ b/ui/src/organizations/components/CreateOrgOverlay.tsx
@@ -9,14 +9,7 @@ import {
   ComponentStatus,
   ButtonType,
 } from '@influxdata/clockface'
-import {
-  Form,
-  OverlayBody,
-  OverlayHeading,
-  OverlayContainer,
-  OverlayFooter,
-  Input,
-} from 'src/clockface'
+import {Form, Overlay, Input} from 'src/clockface'
 
 // Types
 import {Organization} from '@influxdata/influx'
@@ -49,13 +42,13 @@ export default class CreateOrgOverlay extends PureComponent<Props, State> {
     const {org, nameInputStatus, errorMessage} = this.state
 
     return (
-      <OverlayContainer maxWidth={500}>
-        <OverlayHeading
+      <Overlay.Container maxWidth={500}>
+        <Overlay.Heading
           title="Create Organization"
           onDismiss={this.props.onCloseModal}
         />
         <Form onSubmit={this.handleCreateOrg}>
-          <OverlayBody>
+          <Overlay.Body>
             <Form.Element label="Name" errorMessage={errorMessage}>
               <Input
                 placeholder="Give your organization a name"
@@ -67,8 +60,8 @@ export default class CreateOrgOverlay extends PureComponent<Props, State> {
                 testID="create-org-name-input"
               />
             </Form.Element>
-          </OverlayBody>
-          <OverlayFooter>
+          </Overlay.Body>
+          <Overlay.Footer>
             <Button text="Cancel" onClick={onCloseModal} />
             <Button
               text="Create"
@@ -77,9 +70,9 @@ export default class CreateOrgOverlay extends PureComponent<Props, State> {
               status={this.submitButtonStatus}
               testID="create-org-submit-button"
             />
-          </OverlayFooter>
+          </Overlay.Footer>
         </Form>
-      </OverlayContainer>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/organizations/components/CreateScraperOverlay.tsx
+++ b/ui/src/organizations/components/CreateScraperOverlay.tsx
@@ -11,7 +11,7 @@ import {
   OverlayHeading,
   OverlayBody,
   OverlayFooter,
-  OverlayTechnology,
+  Overlay,
 } from 'src/clockface'
 import CreateScraperForm from 'src/organizations/components/CreateScraperForm'
 
@@ -88,7 +88,7 @@ class CreateScraperOverlay extends PureComponent<Props, State> {
     const {onDismiss, visible, buckets} = this.props
 
     return (
-      <OverlayTechnology visible={visible}>
+      <Overlay visible={visible}>
         <OverlayContainer maxWidth={600}>
           <OverlayHeading title="Create Scraper" onDismiss={onDismiss} />
           <Form onSubmit={this.handleSubmit}>
@@ -122,7 +122,7 @@ class CreateScraperOverlay extends PureComponent<Props, State> {
             </OverlayFooter>
           </Form>
         </OverlayContainer>
-      </OverlayTechnology>
+      </Overlay>
     )
   }
 

--- a/ui/src/organizations/components/CreateScraperOverlay.tsx
+++ b/ui/src/organizations/components/CreateScraperOverlay.tsx
@@ -5,14 +5,7 @@ import _ from 'lodash'
 
 // Components
 import {Button, ComponentColor, ComponentStatus} from '@influxdata/clockface'
-import {
-  Form,
-  OverlayContainer,
-  OverlayHeading,
-  OverlayBody,
-  OverlayFooter,
-  Overlay,
-} from 'src/clockface'
+import {Form, Overlay} from 'src/clockface'
 import CreateScraperForm from 'src/organizations/components/CreateScraperForm'
 
 // Actions
@@ -89,10 +82,10 @@ class CreateScraperOverlay extends PureComponent<Props, State> {
 
     return (
       <Overlay visible={visible}>
-        <OverlayContainer maxWidth={600}>
-          <OverlayHeading title="Create Scraper" onDismiss={onDismiss} />
+        <Overlay.Container maxWidth={600}>
+          <Overlay.Heading title="Create Scraper" onDismiss={onDismiss} />
           <Form onSubmit={this.handleSubmit}>
-            <OverlayBody>
+            <Overlay.Body>
               <h5 className="wizard-step--sub-title">
                 Scrapers collect data from multiple targets at regular intervals
                 and to write to a bucket
@@ -105,8 +98,8 @@ class CreateScraperOverlay extends PureComponent<Props, State> {
                 onInputChange={this.handleInputChange}
                 onSelectBucket={this.handleSelectBucket}
               />
-            </OverlayBody>
-            <OverlayFooter>
+            </Overlay.Body>
+            <Overlay.Footer>
               <Button
                 text="Cancel"
                 onClick={onDismiss}
@@ -119,9 +112,9 @@ class CreateScraperOverlay extends PureComponent<Props, State> {
                 color={ComponentColor.Success}
                 testID="create-scraper--submit"
               />
-            </OverlayFooter>
+            </Overlay.Footer>
           </Form>
-        </OverlayContainer>
+        </Overlay.Container>
       </Overlay>
     )
   }

--- a/ui/src/organizations/components/CreateVariableOverlay.tsx
+++ b/ui/src/organizations/components/CreateVariableOverlay.tsx
@@ -5,14 +5,7 @@ import React, {PureComponent, ChangeEvent} from 'react'
 import 'src/organizations/components/CreateVariableOverlay.scss'
 
 // Components
-import {
-  Form,
-  OverlayBody,
-  OverlayHeading,
-  OverlayContainer,
-  Input,
-  OverlayFooter,
-} from 'src/clockface'
+import {Form, Input, Overlay} from 'src/clockface'
 import {Button} from '@influxdata/clockface'
 import FluxEditor from 'src/shared/components/FluxEditor'
 
@@ -53,14 +46,14 @@ export default class CreateOrgOverlay extends PureComponent<Props, State> {
     const {nameInputStatus, name, script} = this.state
 
     return (
-      <OverlayContainer maxWidth={1000}>
-        <OverlayHeading
+      <Overlay.Container maxWidth={1000}>
+        <Overlay.Heading
           title="Create Variable"
           onDismiss={this.props.onCloseModal}
         />
 
         <Form onSubmit={this.handleSubmit}>
-          <OverlayBody>
+          <Overlay.Body>
             <div className="overlay-flux-editor--spacing">
               <Form.Element label="Name">
                 <Input
@@ -85,7 +78,7 @@ export default class CreateOrgOverlay extends PureComponent<Props, State> {
               </div>
             </Form.Element>
 
-            <OverlayFooter>
+            <Overlay.Footer>
               <Button
                 text="Cancel"
                 color={ComponentColor.Danger}
@@ -96,10 +89,10 @@ export default class CreateOrgOverlay extends PureComponent<Props, State> {
                 type={ButtonType.Submit}
                 color={ComponentColor.Primary}
               />
-            </OverlayFooter>
-          </OverlayBody>
+            </Overlay.Footer>
+          </Overlay.Body>
         </Form>
-      </OverlayContainer>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/organizations/components/Members.tsx
+++ b/ui/src/organizations/components/Members.tsx
@@ -9,7 +9,7 @@ import {
   IconFont,
   Input,
   Tabs,
-  OverlayTechnology,
+  Overlay,
 } from 'src/clockface'
 import MemberList from 'src/organizations/components/MemberList'
 import FilterList from 'src/shared/components/Filter'
@@ -97,13 +97,13 @@ export default class Members extends PureComponent<Props, State> {
             />
           )}
         </FilterList>
-        <OverlayTechnology visible={overlayState === OverlayState.Open}>
+        <Overlay visible={overlayState === OverlayState.Open}>
           <AddMembersOverlay
             onCloseModal={this.handleCloseModal}
             users={this.state.users}
             addMember={this.addMember}
           />
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/organizations/components/TelegrafConfigOverlay.tsx
+++ b/ui/src/organizations/components/TelegrafConfigOverlay.tsx
@@ -6,7 +6,7 @@ import {connect} from 'react-redux'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import OverlayBody from 'src/clockface/components/overlays/OverlayBody'
 import OverlayContainer from 'src/clockface/components/overlays/OverlayContainer'
-import OverlayTechnology from 'src/clockface/components/overlays/OverlayTechnology'
+import Overlay from 'src/clockface/components/overlays/Overlay'
 import OverlayHeading from 'src/clockface/components/overlays/OverlayHeading'
 import TelegrafConfig from 'src/organizations/components/TelegrafConfig'
 import {ComponentColor, Button} from '@influxdata/clockface'
@@ -52,7 +52,7 @@ export class TelegrafConfigOverlay extends PureComponent<Props> {
     const {visible, onDismiss, telegrafConfigName} = this.props
 
     return (
-      <OverlayTechnology visible={visible}>
+      <Overlay visible={visible}>
         <OverlayContainer maxWidth={1200}>
           <OverlayHeading
             title={`Telegraf Configuration - ${telegrafConfigName}`}
@@ -72,7 +72,7 @@ export class TelegrafConfigOverlay extends PureComponent<Props> {
             />
           </OverlayFooter>
         </OverlayContainer>
-      </OverlayTechnology>
+      </Overlay>
     )
   }
 

--- a/ui/src/organizations/components/TelegrafConfigOverlay.tsx
+++ b/ui/src/organizations/components/TelegrafConfigOverlay.tsx
@@ -4,13 +4,9 @@ import {connect} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import OverlayBody from 'src/clockface/components/overlays/OverlayBody'
-import OverlayContainer from 'src/clockface/components/overlays/OverlayContainer'
-import Overlay from 'src/clockface/components/overlays/Overlay'
-import OverlayHeading from 'src/clockface/components/overlays/OverlayHeading'
 import TelegrafConfig from 'src/organizations/components/TelegrafConfig'
 import {ComponentColor, Button} from '@influxdata/clockface'
-import {OverlayFooter} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 
 // Utils
 import {downloadTextFile} from 'src/shared/utils/download'
@@ -53,25 +49,25 @@ export class TelegrafConfigOverlay extends PureComponent<Props> {
 
     return (
       <Overlay visible={visible}>
-        <OverlayContainer maxWidth={1200}>
-          <OverlayHeading
+        <Overlay.Container maxWidth={1200}>
+          <Overlay.Heading
             title={`Telegraf Configuration - ${telegrafConfigName}`}
             onDismiss={onDismiss}
           />
 
-          <OverlayBody>
+          <Overlay.Body>
             <div className="config-overlay">
               <TelegrafConfig />
             </div>
-          </OverlayBody>
-          <OverlayFooter>
+          </Overlay.Body>
+          <Overlay.Footer>
             <Button
               color={ComponentColor.Secondary}
               text={'Download Config'}
               onClick={this.handleDownloadConfig}
             />
-          </OverlayFooter>
-        </OverlayContainer>
+          </Overlay.Footer>
+        </Overlay.Container>
       </Overlay>
     )
   }

--- a/ui/src/organizations/components/UpdateBucketOverlay.tsx
+++ b/ui/src/organizations/components/UpdateBucketOverlay.tsx
@@ -2,12 +2,7 @@
 import React, {PureComponent, ChangeEvent} from 'react'
 
 // Components
-import {
-  OverlayBody,
-  OverlayHeading,
-  ComponentStatus,
-  OverlayContainer,
-} from 'src/clockface'
+import {Overlay, ComponentStatus} from 'src/clockface'
 import BucketOverlayForm from 'src/organizations/components/BucketOverlayForm'
 
 // Constants
@@ -48,12 +43,12 @@ export default class BucketOverlay extends PureComponent<Props, State> {
     const {bucket, nameInputStatus, nameErrorMessage, ruleType} = this.state
 
     return (
-      <OverlayContainer maxWidth={500}>
-        <OverlayHeading
+      <Overlay.Container maxWidth={500}>
+        <Overlay.Heading
           title="Edit Bucket"
           onDismiss={this.props.onCloseModal}
         />
-        <OverlayBody>
+        <Overlay.Body>
           <BucketOverlayForm
             name={bucket.name}
             buttonText="Save Changes"
@@ -67,8 +62,8 @@ export default class BucketOverlay extends PureComponent<Props, State> {
             onChangeRuleType={this.handleChangeRuleType}
             onChangeRetentionRule={this.handleChangeRetentionRule}
           />
-        </OverlayBody>
-      </OverlayContainer>
+        </Overlay.Body>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/organizations/components/UpdateVariableOverlay.tsx
+++ b/ui/src/organizations/components/UpdateVariableOverlay.tsx
@@ -3,15 +3,7 @@ import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
 import _ from 'lodash'
 
 // Components
-import {
-  OverlayBody,
-  OverlayHeading,
-  OverlayFooter,
-  ComponentStatus,
-  OverlayContainer,
-  Form,
-  Input,
-} from 'src/clockface'
+import {Overlay, ComponentStatus, Form, Input} from 'src/clockface'
 import {Button, ButtonType, ComponentColor} from '@influxdata/clockface'
 import FluxEditor from 'src/shared/components/FluxEditor'
 
@@ -51,14 +43,14 @@ export default class UpdateVariableOverlay extends PureComponent<Props, State> {
     const {variable, nameInputStatus, nameErrorMessage, script} = this.state
 
     return (
-      <OverlayContainer maxWidth={1000}>
-        <OverlayHeading
+      <Overlay.Container maxWidth={1000}>
+        <Overlay.Heading
           title="Edit Variable"
           onDismiss={this.props.onCloseOverlay}
         />
 
         <Form onSubmit={this.handleSubmit}>
-          <OverlayBody>
+          <Overlay.Body>
             <div className="overlay-flux-editor--spacing">
               <Form.Element label="Name" errorMessage={nameErrorMessage}>
                 <Input
@@ -83,7 +75,7 @@ export default class UpdateVariableOverlay extends PureComponent<Props, State> {
               </div>
             </Form.Element>
 
-            <OverlayFooter>
+            <Overlay.Footer>
               <Button
                 text="Cancel"
                 color={ComponentColor.Danger}
@@ -99,10 +91,10 @@ export default class UpdateVariableOverlay extends PureComponent<Props, State> {
                     : ComponentStatus.Disabled
                 }
               />
-            </OverlayFooter>
-          </OverlayBody>
+            </Overlay.Footer>
+          </Overlay.Body>
         </Form>
-      </OverlayContainer>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/organizations/components/VariableList.tsx
+++ b/ui/src/organizations/components/VariableList.tsx
@@ -2,7 +2,7 @@
 import React, {PureComponent} from 'react'
 
 // Components
-import {IndexList, OverlayTechnology} from 'src/clockface'
+import {IndexList, Overlay} from 'src/clockface'
 import VariableRow from 'src/organizations/components/VariableRow'
 import UpdateVariableOverlay from 'src/organizations/components/UpdateVariableOverlay'
 
@@ -59,13 +59,13 @@ class VariableList extends PureComponent<Props, State> {
             ))}
           </IndexList.Body>
         </IndexList>
-        <OverlayTechnology visible={this.isVariableOverlayVisible}>
+        <Overlay visible={this.isVariableOverlayVisible}>
           <UpdateVariableOverlay
             variable={this.variable}
             onCloseOverlay={this.handleCloseOverlay}
             onUpdateVariable={this.handleUpdateVariable}
           />
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/organizations/components/Variables.tsx
+++ b/ui/src/organizations/components/Variables.tsx
@@ -17,7 +17,7 @@ import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader
 import CreateVariableOverlay from 'src/organizations/components/CreateVariableOverlay'
 import {Button, ComponentSize, TechnoSpinner} from '@influxdata/clockface'
 import VariableList from 'src/organizations/components/VariableList'
-import {Input, OverlayTechnology, EmptyState} from 'src/clockface'
+import {Input, Overlay, EmptyState} from 'src/clockface'
 import FilterList from 'src/shared/components/Filter'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 
@@ -106,13 +106,13 @@ class Variables extends PureComponent<Props, State> {
             />
           )}
         </FilterList>
-        <OverlayTechnology visible={createOverlayState === OverlayState.Open}>
+        <Overlay visible={createOverlayState === OverlayState.Open}>
           <CreateVariableOverlay
             onCreateVariable={this.handleCreateVariable}
             onCloseModal={this.handleCloseCreateOverlay}
             orgID={org.id}
           />
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/organizations/components/__snapshots__/Buckets.test.tsx.snap
+++ b/ui/src/organizations/components/__snapshots__/Buckets.test.tsx.snap
@@ -344,15 +344,39 @@ Object {
         </tbody>
       </table>
       <div
-        class="overlay-tech"
+        class="fancy-scroll--container overlay"
+        style="position: relative; overflow: hidden; width: 100%; height: 100%;"
       >
         <div
-          class="overlay--dialog"
-          data-testid="overlay-children"
-        />
+          class="fancy-scroll--view"
+          style="position: absolute; top: 0px; left: 0px; right: 0px; bottom: 0px; overflow: scroll; margin-right: 0px; margin-bottom: 0px;"
+        >
+          <div
+            class="overlay--transition"
+            data-testid="overlay-children"
+          />
+          <div
+            class="overlay--mask"
+          />
+        </div>
         <div
-          class="overlay--mask"
-        />
+          class="fancy-scroll--track-h"
+          style="position: absolute; width: 100%; height: 12px; bottom: 0px; left: 0px; padding: 3px; cursor: pointer;"
+        >
+          <div
+            class="fancy-scroll--thumb-h"
+            style="position: relative; display: block; height: 6px; border-radius: 3px;"
+          />
+        </div>
+        <div
+          class="fancy-scroll--track-v"
+          style="position: absolute; width: 12px; height: 100%; top: 0px; right: 0px; padding: 3px; cursor: pointer;"
+        >
+          <div
+            class="fancy-scroll--thumb-v"
+            style="position: relative; display: block; width: 6px; border-radius: 3px;"
+          />
+        </div>
       </div>
       <div
         data-testid="data-loader-empty"
@@ -699,15 +723,39 @@ Object {
       </tbody>
     </table>
     <div
-      class="overlay-tech"
+      class="fancy-scroll--container overlay"
+      style="position: relative; overflow: hidden; width: 100%; height: 100%;"
     >
       <div
-        class="overlay--dialog"
-        data-testid="overlay-children"
-      />
+        class="fancy-scroll--view"
+        style="position: absolute; top: 0px; left: 0px; right: 0px; bottom: 0px; overflow: scroll; margin-right: 0px; margin-bottom: 0px;"
+      >
+        <div
+          class="overlay--transition"
+          data-testid="overlay-children"
+        />
+        <div
+          class="overlay--mask"
+        />
+      </div>
       <div
-        class="overlay--mask"
-      />
+        class="fancy-scroll--track-h"
+        style="position: absolute; width: 100%; height: 12px; bottom: 0px; left: 0px; padding: 3px; cursor: pointer;"
+      >
+        <div
+          class="fancy-scroll--thumb-h"
+          style="position: relative; display: block; height: 6px; border-radius: 3px;"
+        />
+      </div>
+      <div
+        class="fancy-scroll--track-v"
+        style="position: absolute; width: 12px; height: 100%; top: 0px; right: 0px; padding: 3px; cursor: pointer;"
+      >
+        <div
+          class="fancy-scroll--thumb-v"
+          style="position: relative; display: block; width: 6px; border-radius: 3px;"
+        />
+      </div>
     </div>
     <div
       data-testid="data-loader-empty"

--- a/ui/src/organizations/components/__snapshots__/Variables.test.tsx.snap
+++ b/ui/src/organizations/components/__snapshots__/Variables.test.tsx.snap
@@ -39,13 +39,13 @@ exports[`VariableList rendering renders 1`] = `
       />
     </IndexListBody>
   </IndexList>
-  <OverlayTechnology
+  <Overlay
     visible={false}
   >
     <UpdateVariableOverlay
       onCloseOverlay={[Function]}
       onUpdateVariable={[Function]}
     />
-  </OverlayTechnology>
+  </Overlay>
 </Fragment>
 `;

--- a/ui/src/organizations/containers/OrganizationsIndex.tsx
+++ b/ui/src/organizations/containers/OrganizationsIndex.tsx
@@ -10,7 +10,7 @@ import CreateOrgOverlay from 'src/organizations/components/CreateOrgOverlay'
 import OrganizationsIndexContents from 'src/organizations/components/OrganizationsIndexContents'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
-import {OverlayTechnology} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 
 // Actions
 import {createOrg, deleteOrg} from 'src/organizations/actions/orgs'
@@ -93,13 +93,13 @@ class OrganizationsIndex extends PureComponent<Props, State> {
             </FilterList>
           </Page.Contents>
         </Page>
-        <OverlayTechnology visible={modalState === ModalState.Open}>
+        <Overlay visible={modalState === ModalState.Open}>
           <CreateOrgOverlay
             link={links.orgs}
             onCloseModal={this.handleCloseModal}
             onCreateOrg={onCreateOrg}
           />
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/shared/components/ExportOverlay.tsx
+++ b/ui/src/shared/components/ExportOverlay.tsx
@@ -3,7 +3,7 @@ import {get} from 'lodash'
 
 // Components
 import {
-  OverlayTechnology,
+  Overlay,
   OverlayBody,
   OverlayContainer,
   OverlayHeading,
@@ -42,7 +42,7 @@ export default class ExportOverlay extends PureComponent<Props> {
       completeSingle: false,
     }
     return (
-      <OverlayTechnology visible={isVisible}>
+      <Overlay visible={isVisible}>
         <OverlayContainer maxWidth={800}>
           <OverlayHeading
             title={`Export ${resourceName}`}
@@ -62,7 +62,7 @@ export default class ExportOverlay extends PureComponent<Props> {
           </OverlayBody>
           <OverlayFooter>{this.submitButton}</OverlayFooter>
         </OverlayContainer>
-      </OverlayTechnology>
+      </Overlay>
     )
   }
 

--- a/ui/src/shared/components/ExportOverlay.tsx
+++ b/ui/src/shared/components/ExportOverlay.tsx
@@ -2,13 +2,7 @@ import React, {PureComponent} from 'react'
 import {get} from 'lodash'
 
 // Components
-import {
-  Overlay,
-  OverlayBody,
-  OverlayContainer,
-  OverlayHeading,
-  OverlayFooter,
-} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 import {Button, ComponentColor} from '@influxdata/clockface'
 import {Controlled as ReactCodeMirror} from 'react-codemirror2'
 
@@ -43,12 +37,12 @@ export default class ExportOverlay extends PureComponent<Props> {
     }
     return (
       <Overlay visible={isVisible}>
-        <OverlayContainer maxWidth={800}>
-          <OverlayHeading
+        <Overlay.Container maxWidth={800}>
+          <Overlay.Heading
             title={`Export ${resourceName}`}
             onDismiss={onDismissOverlay}
           />
-          <OverlayBody>
+          <Overlay.Body>
             <div className="export-overlay--text-area">
               <ReactCodeMirror
                 autoFocus={true}
@@ -59,9 +53,9 @@ export default class ExportOverlay extends PureComponent<Props> {
                 onTouchStart={this.doNothing}
               />
             </div>
-          </OverlayBody>
-          <OverlayFooter>{this.submitButton}</OverlayFooter>
-        </OverlayContainer>
+          </Overlay.Body>
+          <Overlay.Footer>{this.submitButton}</Overlay.Footer>
+        </Overlay.Container>
       </Overlay>
     )
   }

--- a/ui/src/shared/components/ImportOverlay.tsx
+++ b/ui/src/shared/components/ImportOverlay.tsx
@@ -3,15 +3,7 @@ import _ from 'lodash'
 
 // Components
 import DragAndDrop from 'src/shared/components/DragAndDrop'
-import {
-  Overlay,
-  OverlayBody,
-  OverlayContainer,
-  OverlayHeading,
-  OverlayFooter,
-  Radio,
-  ComponentStatus,
-} from 'src/clockface'
+import {Overlay, Radio, ComponentStatus} from 'src/clockface'
 import {Button, ComponentColor} from '@influxdata/clockface'
 
 // Styles
@@ -53,12 +45,12 @@ export default class ImportOverlay extends PureComponent<Props, State> {
 
     return (
       <Overlay visible={isVisible}>
-        <OverlayContainer maxWidth={800}>
-          <OverlayHeading
+        <Overlay.Container maxWidth={800}>
+          <Overlay.Heading
             title={`Import ${resourceName}`}
             onDismiss={this.onDismiss}
           />
-          <OverlayBody>
+          <Overlay.Body>
             <div className="import--options">
               <Radio>
                 <Radio.Button
@@ -78,9 +70,9 @@ export default class ImportOverlay extends PureComponent<Props, State> {
               </Radio>
             </div>
             {this.importBody}
-          </OverlayBody>
-          <OverlayFooter>{this.submitButton}</OverlayFooter>
-        </OverlayContainer>
+          </Overlay.Body>
+          <Overlay.Footer>{this.submitButton}</Overlay.Footer>
+        </Overlay.Container>
       </Overlay>
     )
   }

--- a/ui/src/shared/components/ImportOverlay.tsx
+++ b/ui/src/shared/components/ImportOverlay.tsx
@@ -4,7 +4,7 @@ import _ from 'lodash'
 // Components
 import DragAndDrop from 'src/shared/components/DragAndDrop'
 import {
-  OverlayTechnology,
+  Overlay,
   OverlayBody,
   OverlayContainer,
   OverlayHeading,
@@ -52,7 +52,7 @@ export default class ImportOverlay extends PureComponent<Props, State> {
     const {selectedImportOption} = this.state
 
     return (
-      <OverlayTechnology visible={isVisible}>
+      <Overlay visible={isVisible}>
         <OverlayContainer maxWidth={800}>
           <OverlayHeading
             title={`Import ${resourceName}`}
@@ -81,7 +81,7 @@ export default class ImportOverlay extends PureComponent<Props, State> {
           </OverlayBody>
           <OverlayFooter>{this.submitButton}</OverlayFooter>
         </OverlayContainer>
-      </OverlayTechnology>
+      </Overlay>
     )
   }
 

--- a/ui/src/tasks/components/RunLogsList.tsx
+++ b/ui/src/tasks/components/RunLogsList.tsx
@@ -3,12 +3,7 @@ import React, {PureComponent} from 'react'
 import _ from 'lodash'
 
 //Components
-import {
-  OverlayContainer,
-  OverlayHeading,
-  OverlayBody,
-  IndexList,
-} from 'src/clockface'
+import {IndexList, Overlay} from 'src/clockface'
 import RunLogRow from 'src/tasks/components/RunLogRow'
 import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
 
@@ -32,9 +27,9 @@ class RunLogsOverlay extends PureComponent<Props> {
     const {onDismissOverlay} = this.props
 
     return (
-      <OverlayContainer customClass={'run-logs--list'}>
-        <OverlayHeading title="Run Logs" onDismiss={onDismissOverlay} />
-        <OverlayBody>
+      <Overlay.Container customClass={'run-logs--list'}>
+        <Overlay.Heading title="Run Logs" onDismiss={onDismissOverlay} />
+        <Overlay.Body>
           <FancyScrollbar autoHeight={true} maxHeight={700}>
             <IndexList>
               <IndexList.Header>
@@ -46,8 +41,8 @@ class RunLogsOverlay extends PureComponent<Props> {
               </IndexList.Body>
             </IndexList>
           </FancyScrollbar>
-        </OverlayBody>
-      </OverlayContainer>
+        </Overlay.Body>
+      </Overlay.Container>
     )
   }
 

--- a/ui/src/tasks/components/TaskRunsRow.tsx
+++ b/ui/src/tasks/components/TaskRunsRow.tsx
@@ -4,7 +4,7 @@ import {connect} from 'react-redux'
 import moment from 'moment'
 
 // Components
-import {IndexList, OverlayTechnology} from 'src/clockface'
+import {IndexList, Overlay} from 'src/clockface'
 import RunLogsOverlay from 'src/tasks/components/RunLogsList'
 
 // Actions
@@ -95,12 +95,12 @@ class TaskRunsRow extends PureComponent<Props, State> {
     const {logs} = this.props
 
     return (
-      <OverlayTechnology visible={isImportOverlayVisible}>
+      <Overlay visible={isImportOverlayVisible}>
         <RunLogsOverlay
           onDismissOverlay={this.handleToggleOverlay}
           logs={logs}
         />
-      </OverlayTechnology>
+      </Overlay>
     )
   }
 }

--- a/ui/src/timeMachine/components/QueriesSwitcher.tsx
+++ b/ui/src/timeMachine/components/QueriesSwitcher.tsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux'
 // Components
 import {Button, ComponentColor} from '@influxdata/clockface'
 import {
-  OverlayTechnology,
+  Overlay,
   OverlayBody,
   OverlayHeading,
   OverlayContainer,
@@ -58,7 +58,7 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props, State> {
     return (
       <>
         {this.button}
-        <OverlayTechnology visible={isOverlayVisible}>
+        <Overlay visible={isOverlayVisible}>
           <OverlayContainer maxWidth={400}>
             <OverlayHeading
               title="Are you sure?"
@@ -79,7 +79,7 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props, State> {
               />
             </OverlayFooter>
           </OverlayContainer>
-        </OverlayTechnology>
+        </Overlay>
       </>
     )
   }

--- a/ui/src/timeMachine/components/QueriesSwitcher.tsx
+++ b/ui/src/timeMachine/components/QueriesSwitcher.tsx
@@ -4,13 +4,7 @@ import {connect} from 'react-redux'
 
 // Components
 import {Button, ComponentColor} from '@influxdata/clockface'
-import {
-  Overlay,
-  OverlayBody,
-  OverlayHeading,
-  OverlayContainer,
-  OverlayFooter,
-} from 'src/clockface'
+import {Overlay} from 'src/clockface'
 
 // Actions
 import {
@@ -59,26 +53,26 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props, State> {
       <>
         {this.button}
         <Overlay visible={isOverlayVisible}>
-          <OverlayContainer maxWidth={400}>
-            <OverlayHeading
+          <Overlay.Container maxWidth={400}>
+            <Overlay.Heading
               title="Are you sure?"
               onDismiss={this.handleDismissOverlay}
             />
-            <OverlayBody>
+            <Overlay.Body>
               <p className="queries-switcher--warning">
                 Switching to Query Builder mode will discard any changes you
                 have made using Flux. This cannot be recovered.
               </p>
-            </OverlayBody>
-            <OverlayFooter>
+            </Overlay.Body>
+            <Overlay.Footer>
               <Button text="Cancel" onClick={this.handleDismissOverlay} />
               <Button
                 color={ComponentColor.Danger}
                 text="Switch to Builder"
                 onClick={this.handleConfirmSwitch}
               />
-            </OverlayFooter>
-          </OverlayContainer>
+            </Overlay.Footer>
+          </Overlay.Container>
         </Overlay>
       </>
     )


### PR DESCRIPTION
Closes #12526

Tested in Safari + Firefox

![scrollable-overlays](https://user-images.githubusercontent.com/2433762/54164840-6d4bca00-441b-11e9-9079-eaacd6a70b1b.gif)
Allow scrolling within overlay mask

### Refactor notes:
- Making the Overlay component family's usage pattern similar to other Clockface components
- `OverlayTechnology` renamed to `Overlay`
- All overlay subcomponents are accessible from the primary `Overlay` class
  - ex: `<Overlay.Container>`
- All instances of overlay have been updated to only import the primary `Overlay` class
- `Overlay` imports its own stylesheet instead of being imported into `chronograf.scss`
- Overlay styles now reference global styles such as page header height and font sizes
- Overlay gutter is slightly smaller

### Checklist
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
