### PR TITLE
Create interface to identify a remote streamed cursor

### DIFF
--- a/storage/reads/stream_reader.gen.go
+++ b/storage/reads/stream_reader.gen.go
@@ -13,10 +13,16 @@ import (
 	"github.com/influxdata/influxdb/tsdb/cursors"
 )
 
+type streamCursor interface {
+	streamCursor()
+}
+
 type floatCursorStreamReader struct {
 	fr *frameReader
 	a  cursors.FloatArray
 }
+
+func (c *floatCursorStreamReader) streamCursor() {}
 
 func (c *floatCursorStreamReader) Close() {
 	for c.fr.state == stateReadFloatPoints {
@@ -65,6 +71,8 @@ type integerCursorStreamReader struct {
 	a  cursors.IntegerArray
 }
 
+func (c *integerCursorStreamReader) streamCursor() {}
+
 func (c *integerCursorStreamReader) Close() {
 	for c.fr.state == stateReadIntegerPoints {
 		c.readFrame()
@@ -111,6 +119,8 @@ type unsignedCursorStreamReader struct {
 	fr *frameReader
 	a  cursors.UnsignedArray
 }
+
+func (c *unsignedCursorStreamReader) streamCursor() {}
 
 func (c *unsignedCursorStreamReader) Close() {
 	for c.fr.state == stateReadUnsignedPoints {
@@ -159,6 +169,8 @@ type stringCursorStreamReader struct {
 	a  cursors.StringArray
 }
 
+func (c *stringCursorStreamReader) streamCursor() {}
+
 func (c *stringCursorStreamReader) Close() {
 	for c.fr.state == stateReadStringPoints {
 		c.readFrame()
@@ -205,6 +217,8 @@ type booleanCursorStreamReader struct {
 	fr *frameReader
 	a  cursors.BooleanArray
 }
+
+func (c *booleanCursorStreamReader) streamCursor() {}
 
 func (c *booleanCursorStreamReader) Close() {
 	for c.fr.state == stateReadBooleanPoints {

--- a/storage/reads/stream_reader.gen.go.tmpl
+++ b/storage/reads/stream_reader.gen.go.tmpl
@@ -7,12 +7,17 @@ import (
 	"github.com/influxdata/influxdb/tsdb/cursors"
 )
 
+type streamCursor interface {
+	streamCursor()
+}
 
 {{range .}}
 type {{.name}}CursorStreamReader struct {
 	fr *frameReader
 	a  cursors.{{.Name}}Array
 }
+
+func (c *{{.name}}CursorStreamReader) streamCursor() {}
 
 func (c *{{.name}}CursorStreamReader) Close() {
 	for c.fr.state == stateRead{{.Name}}Points {

--- a/storage/reads/table.go
+++ b/storage/reads/table.go
@@ -164,6 +164,14 @@ func hasPoints(cur cursors.Cursor) bool {
 		return false
 	}
 
+	// TODO(sgc): this is a temporary fix to identify a remote cursor
+	//  which will not stream points causing hasPoints to return false.
+	//  This is the cause of https://github.com/influxdata/idpe/issues/2774
+	if _, ok := cur.(streamCursor); ok {
+		cur.Close()
+		return true
+	}
+
 	res := false
 	switch cur := cur.(type) {
 	case cursors.IntegerArrayCursor:


### PR DESCRIPTION
A cursor can be in-process (local) or remote. Remote cursors have already applied the `hasPoints` check, to reduce network traffic. Testing whether the cursor has points again here:

https://github.com/influxdata/influxdb/blob/9216528555244353725b6a565dd056be41fe2c4b/storage/reads/reader.go#L221-L224

will always return `false` for a remote cursor that has applied the `NoPoints` optimization.

This temporary fix allows the `hasPoints` function to differentiate a streamCursor and always return true in that case.

A future fix will ensure `hasPoints` is always performed by the cursor to remove the check in reader.go

