### PR TITLE
feat(ui): Create dashboards from templates for telegraf plugins

### DIFF
--- a/ui/src/protos/actions/index.ts
+++ b/ui/src/protos/actions/index.ts
@@ -18,8 +18,8 @@ import {ConfigurationState} from 'src/types/v2/dataLoaders'
 
 // Const
 import {
-  ProtoDashboardFailed,
-  ProtoDashboardCreated,
+  TelegrafDashboardFailed,
+  TelegrafDashboardCreated,
 } from 'src/shared/copy/notifications'
 
 export enum ActionTypes {
@@ -98,10 +98,10 @@ export const createDashboardsForPlugins = () => async (
     })
 
     if (plugins.length) {
-      dispatch(notify(ProtoDashboardCreated(plugins)))
+      dispatch(notify(TelegrafDashboardCreated(plugins)))
     }
   } catch (err) {
     console.error(err)
-    dispatch(notify(ProtoDashboardFailed()))
+    dispatch(notify(TelegrafDashboardFailed()))
   }
 }

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -769,17 +769,6 @@ export const fluxTimeSeriesError = (message: string): Notification => ({
 })
 
 // Protos
-export const ProtoDashboardCreated = (configs: string[]): Notification => ({
-  ...defaultSuccessNotification,
-  message: `Successfully created dashboards for telegraf plugin${
-    configs.length > 1 ? 's' : ''
-  }: ${configs.join(', ')}.`,
-})
-
-export const ProtoDashboardFailed = (): Notification => ({
-  ...defaultErrorNotification,
-  message: `Could not create dashboards for one or more plugins`,
-})
 
 export const importSucceeded = (): Notification => ({
   ...defaultSuccessNotification,
@@ -792,6 +781,17 @@ export const importFailed = (): Notification => ({
 })
 
 // Templates
+export const TelegrafDashboardCreated = (configs: string[]): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Successfully created dashboards for telegraf plugin${
+    configs.length > 1 ? 's' : ''
+  }: ${configs.join(', ')}.`,
+})
+
+export const TelegrafDashboardFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Could not create dashboards for one or more plugins`,
+})
 
 export const importTaskSucceeded = (): Notification => ({
   ...defaultSuccessNotification,


### PR DESCRIPTION
Closes #12492

_Briefly describe your proposed changes:_
Create dashboards from templates rather than protos after creating telegraf plugins

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
