### PR TITLE
storage: add SeriesOffsetSize constant

### DIFF
--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -28,9 +28,6 @@ var (
 	ErrInvalidSeriesPartitionID = errors.New("tsdb: invalid series partition id")
 )
 
-// SeriesIDSize is the size in bytes of a series key ID.
-const SeriesIDSize = 8
-
 const (
 	// SeriesFilePartitionN is the number of partitions a series file is split into.
 	SeriesFilePartitionN = 8

--- a/tsdb/series_index.go
+++ b/tsdb/series_index.go
@@ -22,7 +22,7 @@ const (
 	// SeriesIDSize is the size in bytes of a series key ID.
 	SeriesIDSize        = 8
 	SeriesOffsetSize    = 8
-	SeriesIndexElemSize = 16 // offset + id
+	SeriesIndexElemSize = SeriesOffsetSize + SeriesIDSize
 
 	SeriesIndexLoadFactor = 90 // rhh load factor
 

--- a/tsdb/series_index.go
+++ b/tsdb/series_index.go
@@ -19,7 +19,11 @@ const (
 )
 
 const (
-	SeriesIndexElemSize   = 16 // offset + id
+	// SeriesIDSize is the size in bytes of a series key ID.
+	SeriesIDSize        = 8
+	SeriesOffsetSize    = 8
+	SeriesIndexElemSize = 16 // offset + id
+
 	SeriesIndexLoadFactor = 90 // rhh load factor
 
 	SeriesIndexHeaderSize = 0 +
@@ -225,7 +229,7 @@ func (idx *SeriesIndex) FindIDBySeriesKey(segments []*SeriesSegment, key []byte)
 	hash := rhh.HashKey(key)
 	for d, pos := int64(0), hash&idx.mask; ; d, pos = d+1, (pos+1)&idx.mask {
 		elem := idx.keyIDData[(pos * SeriesIndexElemSize):]
-		elemOffset := int64(binary.BigEndian.Uint64(elem[:8]))
+		elemOffset := int64(binary.BigEndian.Uint64(elem[:SeriesOffsetSize]))
 
 		if elemOffset == 0 {
 			return SeriesIDTyped{}
@@ -236,7 +240,7 @@ func (idx *SeriesIndex) FindIDBySeriesKey(segments []*SeriesSegment, key []byte)
 		if d > rhh.Dist(elemHash, pos, idx.capacity) {
 			return SeriesIDTyped{}
 		} else if elemHash == hash && bytes.Equal(elemKey, key) {
-			id := NewSeriesIDTyped(binary.BigEndian.Uint64(elem[8:]))
+			id := NewSeriesIDTyped(binary.BigEndian.Uint64(elem[SeriesOffsetSize:]))
 			if idx.IsDeleted(id.SeriesID()) {
 				return SeriesIDTyped{}
 			}
@@ -276,10 +280,10 @@ func (idx *SeriesIndex) FindOffsetByID(id SeriesID) int64 {
 	hash := rhh.HashUint64(id.RawID())
 	for d, pos := int64(0), hash&idx.mask; ; d, pos = d+1, (pos+1)&idx.mask {
 		elem := idx.idOffsetData[(pos * SeriesIndexElemSize):]
-		elemID := NewSeriesID(binary.BigEndian.Uint64(elem[:8]))
+		elemID := NewSeriesID(binary.BigEndian.Uint64(elem[:SeriesIDSize]))
 
 		if elemID == id {
-			return int64(binary.BigEndian.Uint64(elem[8:]))
+			return int64(binary.BigEndian.Uint64(elem[SeriesIDSize:]))
 		} else if elemID.IsZero() || d > rhh.Dist(rhh.HashUint64(elemID.RawID()), pos, idx.capacity) {
 			return 0
 		}

--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -846,11 +846,11 @@ func (c *SeriesPartitionCompactor) insertKeyIDMap(dst []byte, capacity int64, se
 		elem := dst[(pos * SeriesIndexElemSize):]
 
 		// If empty slot found or matching offset, insert and exit.
-		elemOffset := int64(binary.BigEndian.Uint64(elem[:8]))
-		elemID := NewSeriesIDTyped(binary.BigEndian.Uint64(elem[8:]))
+		elemOffset := int64(binary.BigEndian.Uint64(elem[:SeriesOffsetSize]))
+		elemID := NewSeriesIDTyped(binary.BigEndian.Uint64(elem[SeriesOffsetSize:]))
 		if elemOffset == 0 || elemOffset == offset {
-			binary.BigEndian.PutUint64(elem[:8], uint64(offset))
-			binary.BigEndian.PutUint64(elem[8:], id.RawID())
+			binary.BigEndian.PutUint64(elem[:SeriesOffsetSize], uint64(offset))
+			binary.BigEndian.PutUint64(elem[SeriesOffsetSize:], id.RawID())
 			return nil
 		}
 
@@ -862,8 +862,8 @@ func (c *SeriesPartitionCompactor) insertKeyIDMap(dst []byte, capacity int64, se
 		// existing elem, and keep going to find another slot for that elem.
 		if d := rhh.Dist(elemHash, pos, capacity); d < dist {
 			// Insert current values.
-			binary.BigEndian.PutUint64(elem[:8], uint64(offset))
-			binary.BigEndian.PutUint64(elem[8:], id.RawID())
+			binary.BigEndian.PutUint64(elem[:SeriesOffsetSize], uint64(offset))
+			binary.BigEndian.PutUint64(elem[SeriesOffsetSize:], id.RawID())
 
 			// Swap with values in that position.
 			hash, key, offset, id = elemHash, elemKey, elemOffset, elemID
@@ -884,11 +884,11 @@ func (c *SeriesPartitionCompactor) insertIDOffsetMap(dst []byte, capacity int64,
 		elem := dst[(pos * SeriesIndexElemSize):]
 
 		// If empty slot found or matching id, insert and exit.
-		elemID := NewSeriesID(binary.BigEndian.Uint64(elem[:8]))
-		elemOffset := int64(binary.BigEndian.Uint64(elem[8:]))
+		elemID := NewSeriesID(binary.BigEndian.Uint64(elem[:SeriesIDSize]))
+		elemOffset := int64(binary.BigEndian.Uint64(elem[SeriesIDSize:]))
 		if elemOffset == 0 || elemOffset == offset {
-			binary.BigEndian.PutUint64(elem[:8], id.RawID())
-			binary.BigEndian.PutUint64(elem[8:], uint64(offset))
+			binary.BigEndian.PutUint64(elem[:SeriesIDSize], id.RawID())
+			binary.BigEndian.PutUint64(elem[SeriesIDSize:], uint64(offset))
 			return
 		}
 
@@ -899,8 +899,8 @@ func (c *SeriesPartitionCompactor) insertIDOffsetMap(dst []byte, capacity int64,
 		// existing elem, and keep going to find another slot for that elem.
 		if d := rhh.Dist(elemHash, pos, capacity); d < dist {
 			// Insert current values.
-			binary.BigEndian.PutUint64(elem[:8], id.RawID())
-			binary.BigEndian.PutUint64(elem[8:], uint64(offset))
+			binary.BigEndian.PutUint64(elem[:SeriesIDSize], id.RawID())
+			binary.BigEndian.PutUint64(elem[SeriesIDSize:], uint64(offset))
 
 			// Swap with values in that position.
 			hash, id, offset = elemHash, elemID, elemOffset


### PR DESCRIPTION

_Briefly describe your proposed changes:_
Currently, the `SeriesIDSize` constant is declared but unused.

Use `SeriesIDSize` constant to read/write series ID from/to `SeriesIndexElem`.
Add `SeriesOffsetSize` constant to read/write series offset from/to `SeriesIndexElem`.


  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
