### PR TITLE
 Refresh dashboard values when any cell changes

### DIFF
--- a/ui/src/dashboards/actions/v2/views.ts
+++ b/ui/src/dashboards/actions/v2/views.ts
@@ -69,6 +69,7 @@ export const updateView = (dashboardID: string, view: View) => async (
     const newView = await updateViewAJAX(dashboardID, viewID, view)
 
     dispatch(setView(viewID, newView, RemoteDataState.Done))
+
     return newView
   } catch {
     dispatch(setView(viewID, null, RemoteDataState.Error))

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -20,7 +20,6 @@ import * as dashboardActions from 'src/dashboards/actions/v2'
 import * as rangesActions from 'src/dashboards/actions/v2/ranges'
 import * as appActions from 'src/shared/actions/app'
 import * as notifyActions from 'src/shared/actions/notifications'
-import * as viewActions from 'src/dashboards/actions/v2/views'
 import {setActiveTimeMachine} from 'src/timeMachine/actions'
 
 // Utils
@@ -76,9 +75,8 @@ interface DispatchProps {
   handleChooseAutoRefresh: AppActions.SetAutoRefreshActionCreator
   handleClickPresentationButton: AppActions.DelayEnablePresentationModeDispatcher
   notify: NotificationsActions.PublishNotificationActionCreator
-  onAddCell: typeof dashboardActions.addCellAsync
   onCreateCellWithView: typeof dashboardActions.createCellWithView
-  onUpdateView: typeof viewActions.updateView
+  onUpdateView: typeof dashboardActions.updateView
   onSetActiveTimeMachine: typeof setActiveTimeMachine
 }
 
@@ -262,7 +260,7 @@ class DashboardPage extends Component<Props, State> {
 
     try {
       if (view.id) {
-        onUpdateView(dashboard.id, view)
+        onUpdateView(dashboard, view)
       } else {
         await onCreateCellWithView(dashboard, view)
       }
@@ -372,9 +370,8 @@ const mdtp: DispatchProps = {
   setDashTimeV1: rangesActions.setDashTimeV1,
   updateQueryParams: rangesActions.updateQueryParams,
   setZoomedTimeRange: rangesActions.setZoomedTimeRange,
-  onAddCell: dashboardActions.addCellAsync,
   onCreateCellWithView: dashboardActions.createCellWithView,
-  onUpdateView: viewActions.updateView,
+  onUpdateView: dashboardActions.updateView,
   onSetActiveTimeMachine: setActiveTimeMachine,
 }
 

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -4,3 +4,20 @@ import {AppState, View} from 'src/types/v2'
 
 export const getView = (state: AppState, id: string): View =>
   get(state, `views.views.${id}.view`)
+
+export const getViewsForDashboard = (
+  state: AppState,
+  dashboardID: string
+): View[] => {
+  const dashboard = state.dashboards.find(
+    dashboard => dashboard.id === dashboardID
+  )
+
+  const cellIDs = new Set(dashboard.cells.map(cell => cell.id))
+
+  const views = Object.values(state.views.views)
+    .map(d => d.view)
+    .filter(view => cellIDs.has(view.cellID))
+
+  return views
+}

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -563,6 +563,11 @@ export const cellAddFailed = (
   message: `Failed to add cell ${cellName + ' '}to dashboard ${dashboardName}`,
 })
 
+export const cellUpdateFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to update cell`,
+})
+
 export const cellDeleted = (): Notification => ({
   ...defaultDeletionNotification,
   icon: 'dash-h',


### PR DESCRIPTION
Closes #12550

The set of external variables used in a dashboard may change whenever a cell is added, updated, or removed, so we refresh the variable values when these actions are taken.

Here's an example of a cell using a `my_bucket` variable that I have defined in the org page:

![using a variable](https://user-images.githubusercontent.com/638955/54223599-11ce1a80-44b5-11e9-8ddc-30c6a521b7fc.gif)
