### PR TITLE
Fix requested at for task runs

### DIFF
--- a/task/backend/storetest/logstoretest.go
+++ b/task/backend/storetest/logstoretest.go
@@ -326,6 +326,7 @@ func listRunsTest(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFunc)
 	if err := writer.UpdateRunState(ctx, rlb, scheduledFor.Add(time.Second), backend.RunStarted); err != nil {
 		t.Fatal(err)
 	}
+	time.Sleep(time.Second)
 	listRuns, err = reader.ListRuns(ctx, task.Org, platform.RunFilter{
 		Task:  task.ID,
 		Limit: 2 * nRuns,


### PR DESCRIPTION
Closes #12452 

_Briefly describe your proposed changes:_
Task runs have an optional field (requestedAt). This causes problems when we attempt to query it. If we include the optional field and the table doesn't have the column it fails. To remedy this we attempt to run the query with the optional field and if it fails we remove the optional field and run the query again.