### PR TITLE
Expose debug pprof port 6060

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=builder /go/bin/* /usr/bin/
 COPY --from=builder /go/src/github.com/influxdata/influxdb/etc/config.sample.toml /etc/influxdb/influxdb.conf
 
 EXPOSE 8086
+EXPOSE 6060
 VOLUME /var/lib/influxdb
 
 COPY docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This pull request exposes port `6060` in the `Dockerfile` to allow the port to be accessed when the `http.debug-pprof-enabled` flag is set.