### PR TITLE
fix(ui): Ensure telegraf setup instructions has token information

### DIFF
--- a/ui/src/organizations/components/TelegrafInstructionsOverlay.tsx
+++ b/ui/src/organizations/components/TelegrafInstructionsOverlay.tsx
@@ -54,7 +54,8 @@ export class TelegrafInstructionsOverlay extends PureComponent<Props> {
 
   private get token(): string {
     const {collector, telegrafs} = this.props
-    const config = telegrafs.find(t => get(collector, 'id', '') === t.id)
+    const config =
+      telegrafs.find(t => get(collector, 'id', '') === t.id) || collector
 
     if (!config) {
       return ''


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Fixes issue where there is no token in the setup instructions overlay when viewed from the org view.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
