### PR TITLE
feat(ui): add organization dropdown to import overlay

### DIFF
--- a/ui/src/clockface/components/overlays/OverlayHeading.tsx
+++ b/ui/src/clockface/components/overlays/OverlayHeading.tsx
@@ -18,7 +18,11 @@ class OverlayHeading extends PureComponent<Props> {
       <div className="overlay--heading">
         <div className="overlay--title">{title}</div>
         {onDismiss && (
-          <button className="overlay--dismiss" onClick={onDismiss} />
+          <button
+            className="overlay--dismiss"
+            onClick={onDismiss}
+            type="button"
+          />
         )}
         {children && children}
       </div>

--- a/ui/src/dashboards/components/ImportDashboardOverlay.tsx
+++ b/ui/src/dashboards/components/ImportDashboardOverlay.tsx
@@ -16,7 +16,6 @@ import {createDashboardFromTemplate as createDashboardFromTemplateAction} from '
 
 interface OwnProps {
   onDismissOverlay: () => void
-  orgID: string
   isVisible: boolean
 }
 interface DispatchProps {
@@ -46,14 +45,14 @@ class ImportDashboardOverlay extends PureComponent<Props> {
   }
 
   private handleUploadDashboard = async (
-    uploadContent: string
+    uploadContent: string,
+    orgID: string
   ): Promise<void> => {
     const {
       notify,
       createDashboardFromTemplate,
       onDismissOverlay,
       populateDashboards,
-      orgID,
     } = this.props
 
     try {

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -2,7 +2,6 @@
 import React, {PureComponent} from 'react'
 import {InjectedRouter} from 'react-router'
 import {connect} from 'react-redux'
-import {get} from 'lodash'
 
 // Components
 import DashboardsIndexContents from 'src/dashboards/components/dashboard_index/DashboardsIndexContents'
@@ -198,12 +197,10 @@ class DashboardIndex extends PureComponent<Props, State> {
 
   private get importOverlay(): JSX.Element {
     const {isImportingDashboard} = this.state
-    const {orgs} = this.props
 
     return (
       <ImportDashboardOverlay
         onDismissOverlay={this.handleToggleImportOverlay}
-        orgID={get(orgs, '0.id', '')}
         isVisible={isImportingDashboard}
       />
     )

--- a/ui/src/me/components/account/__snapshots__/ViewTokenOverlay.test.tsx.snap
+++ b/ui/src/me/components/account/__snapshots__/ViewTokenOverlay.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`Account rendering renders! 1`] = `
           <button
             className="overlay--dismiss"
             onClick={[Function]}
+            type="button"
           />
         </div>
       </OverlayHeading>

--- a/ui/src/organizations/actions/orgView.ts
+++ b/ui/src/organizations/actions/orgView.ts
@@ -1,17 +1,10 @@
 import _ from 'lodash'
 
-import {notify} from 'src/shared/actions/notifications'
-
 import {
   ScraperTargetRequest,
   ITask as Task,
   ITaskTemplate,
 } from '@influxdata/influx'
-
-import {
-  importTaskSucceeded,
-  importTaskFailed,
-} from 'src/shared/copy/notifications'
 
 // API
 import {client} from 'src/utils/api'
@@ -49,12 +42,6 @@ export const createScraper = (scraper: ScraperTargetRequest) => async () => {
 export const createTaskFromTemplate = (
   template: ITaskTemplate,
   orgID: string
-) => async dispatch => {
-  try {
-    await client.tasks.createFromTemplate(template, orgID)
-
-    dispatch(notify(importTaskSucceeded()))
-  } catch (error) {
-    dispatch(notify(importTaskFailed(error)))
-  }
+) => async () => {
+  await client.tasks.createFromTemplate(template, orgID)
 }

--- a/ui/src/organizations/components/Dashboards.tsx
+++ b/ui/src/organizations/components/Dashboards.tsx
@@ -207,12 +207,10 @@ class Dashboards extends PureComponent<Props, State> {
 
   private get renderImportOverlay(): JSX.Element {
     const {isImportingDashboard} = this.state
-    const {orgs} = this.props
 
     return (
       <ImportDashboardOverlay
         onDismissOverlay={this.handleToggleOverlay}
-        orgID={_.get(orgs, '0.id', '')}
         isVisible={isImportingDashboard}
       />
     )

--- a/ui/src/shared/components/ExportOverlay.tsx
+++ b/ui/src/shared/components/ExportOverlay.tsx
@@ -5,6 +5,7 @@ import {client} from 'src/utils/api'
 
 // Components
 import {Overlay} from 'src/clockface'
+import {Form} from 'src/clockface'
 import {Button, ComponentColor} from '@influxdata/clockface'
 import {Controlled as ReactCodeMirror} from 'react-codemirror2'
 
@@ -60,26 +61,28 @@ class ExportOverlay extends PureComponent<Props> {
     return (
       <Overlay visible={isVisible}>
         <Overlay.Container maxWidth={800}>
-          <Overlay.Heading
-            title={`Export ${resourceName}`}
-            onDismiss={onDismissOverlay}
-          />
-          <Overlay.Body>
-            <div className="export-overlay--text-area">
-              <ReactCodeMirror
-                autoFocus={true}
-                autoCursor={true}
-                value={JSON.stringify(resource, null, 1)}
-                options={options}
-                onBeforeChange={this.doNothing}
-                onTouchStart={this.doNothing}
-              />
-            </div>
-          </Overlay.Body>
-          <Overlay.Footer>
-            {this.downloadButton}
-            {this.toTemplateButton}
-          </Overlay.Footer>
+          <Form onSubmit={this.handleExport}>
+            <Overlay.Heading
+              title={`Export ${resourceName}`}
+              onDismiss={onDismissOverlay}
+            />
+            <Overlay.Body>
+              <div className="export-overlay--text-area">
+                <ReactCodeMirror
+                  autoFocus={false}
+                  autoCursor={true}
+                  value={JSON.stringify(resource, null, 1)}
+                  options={options}
+                  onBeforeChange={this.doNothing}
+                  onTouchStart={this.doNothing}
+                />
+              </div>
+            </Overlay.Body>
+            <Overlay.Footer>
+              {this.downloadButton}
+              {this.toTemplateButton}
+            </Overlay.Footer>
+          </Form>
         </Overlay.Container>
       </Overlay>
     )

--- a/ui/src/shared/components/ImportOverlay.scss
+++ b/ui/src/shared/components/ImportOverlay.scss
@@ -1,6 +1,12 @@
+@import "src/style/modules";
+
 .import--options {
   display: flex;
-  margin-top: -10px;
-  margin-bottom: 10px;
+  margin-top: -8px;
+  margin-bottom: $ix-marg-b;
   justify-content: center;
+}
+
+.import--dropdown {
+  margin-top: $ix-marg-b;
 }

--- a/ui/src/shared/components/OrgDropdown.tsx
+++ b/ui/src/shared/components/OrgDropdown.tsx
@@ -1,0 +1,56 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+
+// Components
+import {Dropdown} from 'src/clockface'
+
+// Types
+import {Organization} from 'src/types/v2'
+
+interface OwnProps {
+  selectedOrgID: string
+  onSelectOrg: (orgID: string) => void
+}
+
+interface StateProps {
+  orgs: Organization[]
+}
+
+type Props = OwnProps & StateProps
+
+class OrgDropdown extends PureComponent<Props> {
+  public render() {
+    const {orgs, onSelectOrg} = this.props
+
+    return (
+      <Dropdown
+        selectedID={this.selectedID}
+        onChange={onSelectOrg}
+        widthPixels={200}
+      >
+        {orgs.map(({id, name}) => (
+          <Dropdown.Item key={id} value={id} id={id}>
+            {name}
+          </Dropdown.Item>
+        ))}
+      </Dropdown>
+    )
+  }
+
+  private get selectedID(): string {
+    const {selectedOrgID} = this.props
+    return selectedOrgID
+  }
+}
+
+const mstp = ({orgs}): StateProps => {
+  return {
+    orgs,
+  }
+}
+
+export default connect<StateProps, {}, OwnProps>(
+  mstp,
+  null
+)(OrgDropdown)


### PR DESCRIPTION
Closes #12504
Closes #12306


_Briefly describe your proposed changes:_
Add org dropdown to import overlays
Use form in import and export overlays 

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
