### PR TITLE
fix(ui): Update keys for legend items to avoid duplicate key warnings

### DIFF
--- a/ui/src/shared/components/Legend.tsx
+++ b/ui/src/shared/components/Legend.tsx
@@ -47,18 +47,18 @@ class Legend extends PureComponent<Props> {
         <div className="legend--time">{this.time}</div>
         <FancyScrollbar autoHeight={true} maxHeight={120}>
           <div className="legend--columns">
-            {this.columns.map(({name, isNumeric, rows}) => (
+            {this.columns.map(({name, isNumeric, rows}, i) => (
               <div
-                key={name}
+                key={`${name}-${i}`}
                 className={`legend--column ${isNumeric ? 'numeric' : ''}`}
               >
                 <div className="legend--column-header">{name}</div>
-                {rows.map(({color, value}) => {
+                {rows.map(({color, value}, j) => {
                   const emptyClass = !value && value !== 0 ? 'empty' : ''
 
                   return (
                     <div
-                      key={color}
+                      key={`${color}-${j}`}
                       className={`legend--column-row ${emptyClass}`}
                       style={{color}}
                     >


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Fixes issue when a query returns a lot of series you get a ton of console warning for the duplicate key

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
