### PR TITLE
update(ui/client): update to 0.2.37

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -985,9 +985,9 @@
       }
     },
     "@influxdata/influx": {
-      "version": "0.2.35",
-      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.35.tgz",
-      "integrity": "sha512-Ig/nvgtZVqRIqO6MwtoHBngtWRc1yjzSvaoqkGm0TX0uL3rW2L9400SZg1UUvfd7znhkc+HDItec1hUihLqMgQ==",
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.37.tgz",
+      "integrity": "sha512-lpilpi2ZGqBDN3cq9zuqiyH5J6ZIIKFg0XwU+lmL6tNWbs+VjiD1ryvcB6QcDTikKk4SjgQ5W6G0qY/tJyL+FQ==",
       "requires": {
         "axios": "^0.18.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -137,7 +137,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "0.0.5",
-    "@influxdata/influx": "0.2.35",
+    "@influxdata/influx": "0.2.37",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Updates the ui client to `0.2.37` to ensure labels on `Telegraf`  use the `ILabel` interface.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
