### PR TITLE
fix: Use simple function name for tracing operation name

### DIFF
--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -3,11 +3,12 @@ package tracing
 import (
 	"context"
 	"errors"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/log"
 	"net/http"
 	"runtime"
 	"strings"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
 )
 
 // LogError adds a span log for an error.

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -3,11 +3,11 @@ package tracing
 import (
 	"context"
 	"errors"
-	"net/http"
-	"runtime"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
+	"net/http"
+	"runtime"
+	"strings"
 )
 
 // LogError adds a span log for an error.
@@ -83,6 +83,9 @@ func StartSpanFromContext(ctx context.Context) (opentracing.Span, context.Contex
 	}
 	fn := runtime.FuncForPC(pcs[0])
 	name := fn.Name()
+	if lastPeriod := strings.LastIndexByte(name, '.'); lastPeriod > 0 {
+		name = name[lastPeriod+1:]
+	}
 
 	var span opentracing.Span
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -84,7 +84,7 @@ func StartSpanFromContext(ctx context.Context) (opentracing.Span, context.Contex
 	}
 	fn := runtime.FuncForPC(pcs[0])
 	name := fn.Name()
-	if lastPeriod := strings.LastIndexByte(name, '.'); lastPeriod > 0 {
+	if lastPeriod := strings.LastIndexByte(name, '/'); lastPeriod > 0 {
 		name = name[lastPeriod+1:]
 	}
 

--- a/kit/tracing/tracing_test.go
+++ b/kit/tracing/tracing_test.go
@@ -120,7 +120,7 @@ func TestStartSpanFromContext(t *testing.T) {
 }
 
 /*
-BenchmarkLocal_StartSpanFromContext-8                          2000000     659 ns/op     224 B/op     4 allocs/op
+BenchmarkLocal_StartSpanFromContext-8                          2000000     681 ns/op     224 B/op     4 allocs/op
 BenchmarkLocal_StartSpanFromContext_runtimeCaller-8            3000000     534 ns/op
 BenchmarkLocal_StartSpanFromContext_runtimeCallers-8          10000000     196 ns/op
 BenchmarkLocal_StartSpanFromContext_runtimeFuncForPC-8       200000000       7.28 ns/op


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Every span has an operation name, which shows up in multiple places in the Jaeger UI. Verbose function names like
```
github.com/influxdata/influxdb/kit/tracing.StartSpanFromContext
```
are not readable in this UI. Shorter function names like
```
StartSpanFromContext
```
improve UX. Context is not lost because (1) the filename and line number are logged with the span and (2) spans are understood in the context of other spans, marked with service name and operation name.

Extra cost is ~22 ns per call to StartSpanFromContext. No additional memory is allocated.

  - [x] Rebased/mergeable
  - [ ] Tests pass