### PR TITLE
fix(http): change secrets to match swagger

### DIFF
--- a/http/org_service.go
+++ b/http/org_service.go
@@ -188,8 +188,8 @@ type secretsResponse struct {
 func newSecretsResponse(orgID influxdb.ID, ks []string) *secretsResponse {
 	return &secretsResponse{
 		Links: map[string]string{
-			"org":     fmt.Sprintf("/api/v2/orgs/%s", orgID),
-			"secrets": fmt.Sprintf("/api/v2/orgs/%s/secrets", orgID),
+			"org":  fmt.Sprintf("/api/v2/orgs/%s", orgID),
+			"self": fmt.Sprintf("/api/v2/orgs/%s/secrets", orgID),
 		},
 		Secrets: ks,
 	}

--- a/http/org_test.go
+++ b/http/org_test.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"go.uber.org/zap"
 
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
@@ -98,7 +99,7 @@ func TestSecretService_handleGetSecrets(t *testing.T) {
 {
   "links": {
     "org": "/api/v2/orgs/0000000000000001",
-    "secrets": "/api/v2/orgs/0000000000000001/secrets"
+    "self": "/api/v2/orgs/0000000000000001/secrets"
   },
   "secrets": [
     "hello",
@@ -127,7 +128,7 @@ func TestSecretService_handleGetSecrets(t *testing.T) {
 {
   "links": {
     "org": "/api/v2/orgs/0000000000000001",
-    "secrets": "/api/v2/orgs/0000000000000001/secrets"
+    "self": "/api/v2/orgs/0000000000000001/secrets"
   },
   "secrets": []
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/12587

update the link endpoint to match swagger file
