### PR TITLE
Fine tune inline label keyboard interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.0.0-alpha.6 [unreleased]
 
 ### Features
+
 1. [12496](https://github.com/influxdata/influxdb/pull/12496): Add ability to import a dashboard
 1. [12524](https://github.com/influxdata/influxdb/pull/12524): Add ability to import a dashboard from org view
 1. [12531](https://github.com/influxdata/influxdb/pull/12531): Add ability to export a dashboard and a task
@@ -8,6 +9,8 @@
 ### Bug Fixes
 
 ### UI Improvements
+
+1. [12610](https://github.com/influxdata/influxdb/pull/12610): Fine tune keyboard interactions for managing labels from a resource card
 
 ## v2.0.0-alpha.5 [2019-03-08]
 

--- a/ui/cypress/e2e/dashboardsIndex.test.ts
+++ b/ui/cypress/e2e/dashboardsIndex.test.ts
@@ -149,7 +149,7 @@ describe('Dashboards', () => {
 
         cy.getByTestID('overlay--container').within(() => {
           cy.getByInputName('name').should('have.value', label)
-          cy.getByTestID('create-label--button').click()
+          cy.getByTestID('create-label-form--submit').click()
         })
 
         cy.getByTestID('dashboard-card')

--- a/ui/cypress/e2e/dashboardsIndex.test.ts
+++ b/ui/cypress/e2e/dashboardsIndex.test.ts
@@ -143,12 +143,12 @@ describe('Dashboards', () => {
           .click()
 
         cy.getByTestID('inline-labels--popover').within(() => {
-          cy.getByTestID('input-field').type(label)
+          cy.getByTestID('inline-labels--popover-field').type(label)
           cy.getByTestID('inline-labels--create-new').click()
         })
 
         cy.getByTestID('overlay--container').within(() => {
-          cy.getByInputName('name').should('have.value', label)
+          cy.getByTestID('create-label-form--name').should('have.value', label)
           cy.getByTestID('create-label-form--submit').click()
         })
 

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -1,6 +1,7 @@
 import {Template, SourceLinks, TemplateType, TemplateValueType} from 'src/types'
 import {Source} from '@influxdata/influx'
-import {Cell, Dashboard, Label, Task} from 'src/types/v2'
+import {Cell, Dashboard, Task} from 'src/types/v2'
+import {ILabel} from '@influxdata/influx'
 import {Links} from 'src/types/v2/links'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 import {WithRouterProps} from 'react-router'
@@ -210,7 +211,7 @@ export const dashboard: Dashboard = {
   labels: [],
 }
 
-export const labels: Label[] = [
+export const labels: ILabel[] = [
   {
     id: '0001',
     name: 'Trogdor',

--- a/ui/src/clockface/components/empty_state/EmptyStateText.tsx
+++ b/ui/src/clockface/components/empty_state/EmptyStateText.tsx
@@ -20,7 +20,7 @@ const highlighter = (
     }
 
     if (word === 'LINEBREAK') {
-      return <br />
+      return <br key={uuid.v4()} />
     }
 
     if (word === 'SPACECHAR') {

--- a/ui/src/clockface/components/form_layout/Form.tsx
+++ b/ui/src/clockface/components/form_layout/Form.tsx
@@ -11,12 +11,17 @@ import FormFooter from 'src/clockface/components/form_layout/FormFooter'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-interface Props {
+interface PassedProps {
   children: JSX.Element[] | JSX.Element
   style?: React.CSSProperties
   className?: string
   onSubmit?: (e: React.FormEvent) => void
 }
+interface DefaultProps {
+  testID?: string
+}
+
+type Props = PassedProps & DefaultProps
 
 interface BoxProps {
   children: JSX.Element | JSX.Element[]
@@ -31,18 +36,23 @@ class Form extends Component<Props> {
   public static Divider = FormDivider
   public static Footer = FormFooter
 
+  public static defaultProps: DefaultProps = {
+    testID: 'form-container',
+  }
+
   public static Box: SFC<BoxProps> = ({children, className = ''}) => (
     <div className={`form--box ${className}`}>{children}</div>
   )
 
   public render() {
-    const {children, style} = this.props
+    const {children, style, testID} = this.props
 
     return (
       <form
         style={style}
         className={this.formWrapperClass}
         onSubmit={this.handleSubmit}
+        data-testid={testID}
       >
         {children}
       </form>

--- a/ui/src/configuration/components/LabelOverlayForm.tsx
+++ b/ui/src/configuration/components/LabelOverlayForm.tsx
@@ -56,7 +56,7 @@ export default class LabelOverlayForm extends PureComponent<Props> {
     } = this.props
 
     return (
-      <Form onSubmit={onSubmit}>
+      <Form onSubmit={onSubmit} testID="label-overlay-form">
         <Grid>
           <Grid.Row>
             <Grid.Column widthXS={Columns.Twelve}>
@@ -89,6 +89,7 @@ export default class LabelOverlayForm extends PureComponent<Props> {
                     onChange={onInputChange}
                     status={status}
                     maxLength={MAX_LABEL_CHARS}
+                    testID="create-label-form--name"
                   />
                 )}
               </Form.ValidationElement>
@@ -101,6 +102,7 @@ export default class LabelOverlayForm extends PureComponent<Props> {
                   name="description"
                   value={description}
                   onChange={onInputChange}
+                  testID="create-label-form--description"
                 />
               </Form.Element>
             </Grid.Column>
@@ -116,12 +118,13 @@ export default class LabelOverlayForm extends PureComponent<Props> {
                   onClick={onCloseModal}
                   titleText="Cancel creation of Label and return to list"
                   type={ButtonType.Button}
+                  testID="create-label-form--cancel"
                 />
                 <Button
                   text={buttonText}
                   color={ComponentColor.Success}
                   type={ButtonType.Submit}
-                  testID="create-label--button"
+                  testID="create-label-form--submit"
                   status={
                     isFormValid
                       ? ComponentStatus.Default

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/__snapshots__/LineProtocol.test.tsx.snap
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/__snapshots__/LineProtocol.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`LineProtocol rendering renders! 1`] = `
 >
   <Form
     onSubmit={[Function]}
+    testID="form-container"
   >
     <div
       className="wizard-step--scroll-area"

--- a/ui/src/me/components/account/__snapshots__/Settings.test.tsx.snap
+++ b/ui/src/me/components/account/__snapshots__/Settings.test.tsx.snap
@@ -86,9 +86,12 @@ exports[`Account rendering renders! 1`] = `
                       <div
                         className="panel-body"
                       >
-                        <Form>
+                        <Form
+                          testID="form-container"
+                        >
                           <form
                             className="form--wrapper"
+                            data-testid="form-container"
                             onSubmit={[Function]}
                           >
                             <FormElement

--- a/ui/src/onboarding/components/__snapshots__/AdminStep.test.tsx.snap
+++ b/ui/src/onboarding/components/__snapshots__/AdminStep.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Onboarding.Components.AdminStep renders 1`] = `
 >
   <Form
     onSubmit={[Function]}
+    testID="form-container"
   >
     <div
       className="wizard-step--scroll-area"

--- a/ui/src/shared/components/inlineLabels/InlineLabelPopover.test.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelPopover.test.tsx
@@ -1,0 +1,197 @@
+// Libraries
+import React from 'react'
+import {render, fireEvent} from 'react-testing-library'
+
+// Components
+import InlineLabelPopover from 'src/shared/components/inlineLabels/InlineLabelPopover'
+
+// Constants
+import {labels} from 'mocks/dummyData'
+import {ADD_NEW_LABEL_ITEM_ID} from 'src/shared/components/inlineLabels/InlineLabelsEditor'
+
+const filteredLabels = [
+  ...labels,
+  {
+    id: '0003',
+    name: 'Pineapple',
+    properties: {
+      color: '#FFB94A',
+      description: 'Tangy and yellow',
+    },
+  },
+]
+
+const setup = (override = {}) => {
+  const props = {
+    searchTerm: '',
+    selectedItemID: labels[0].id,
+    onUpdateSelectedItemID: jest.fn(),
+    allLabelsUsed: false,
+    onDismiss: jest.fn(),
+    onStartCreatingLabel: jest.fn(),
+    onInputChange: jest.fn(),
+    filteredLabels,
+    onAddLabel: jest.fn(),
+    ...override,
+  }
+
+  return render(<InlineLabelPopover {...props} />)
+}
+
+describe('Shared.Components.InlineLabelPopover', () => {
+  describe('rendering', () => {
+    it('renders with text field in focus', () => {
+      const {getByTestId} = setup()
+
+      const input = getByTestId('inline-labels--popover-field')
+
+      expect(document.activeElement).toEqual(input)
+    })
+  })
+
+  describe('mouse interactions', () => {
+    it('clicking outside the input refocuses it', () => {
+      const {getByTestId} = setup()
+
+      const input = getByTestId('inline-labels--popover-field')
+      const popover = getByTestId('inline-labels--popover')
+      fireEvent.click(popover)
+
+      expect(document.activeElement).toEqual(input)
+    })
+
+    it('hovering over a list item updates the selected item ID', () => {
+      const secondLabel = labels[1]
+      const onUpdateSelectedItemID = jest.fn()
+      const {getByTestId} = setup({onUpdateSelectedItemID})
+
+      const secondListItem = getByTestId(`label-list--item ${secondLabel.name}`)
+      fireEvent.mouseOver(secondListItem)
+
+      expect(onUpdateSelectedItemID).toHaveBeenCalledWith(secondLabel.id)
+    })
+
+    it('clicking a list item adds a label and selects the next item on the list', () => {
+      const secondLabel = labels[1]
+      const onAddLabel = jest.fn()
+      const {getByTestId} = setup({onAddLabel})
+
+      const secondListItem = getByTestId(`label-list--item ${secondLabel.name}`)
+      fireEvent.click(secondListItem)
+
+      expect(onAddLabel).toHaveBeenCalledWith(secondLabel.id)
+    })
+  })
+
+  describe('keyboard interactions', () => {
+    it('typing in the input updates parent component', () => {
+      const onInputChange = jest.fn(e => e.target.value)
+      const {getByTestId} = setup({onInputChange})
+
+      const testString = 'bananas'
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.change(input, {target: {value: testString}})
+
+      expect(onInputChange).toHaveReturnedWith(testString)
+    })
+
+    it('pressing ESCAPE dismisses the popover', () => {
+      const onDismiss = jest.fn()
+      const {getByTestId} = setup({onDismiss})
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.keyDown(input, {key: 'Escape', code: 27})
+
+      expect(onDismiss).toHaveBeenCalled()
+    })
+
+    it('pressing ENTER adds the selected item', () => {
+      const selectedItemID = labels[0].id
+      const onAddLabel = jest.fn()
+      const {getByTestId} = setup({
+        onAddLabel,
+        selectedItemID,
+      })
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.keyDown(input, {key: 'Enter', code: 13})
+
+      expect(onAddLabel).toHaveBeenCalledWith(selectedItemID)
+    })
+
+    it('typing a new label name and pressing ENTER starts label creation flow', () => {
+      const onStartCreatingLabel = jest.fn()
+      const searchTerm = 'swogglez'
+      const selectedItemID = ADD_NEW_LABEL_ITEM_ID
+      const {getByTestId} = setup({
+        onStartCreatingLabel,
+        searchTerm,
+        selectedItemID,
+      })
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.keyDown(input, {key: 'Enter', code: 13})
+
+      expect(onStartCreatingLabel).toHaveBeenCalled()
+    })
+
+    it('pressing ARROWUP selects the previous item', () => {
+      const selectedItemID = filteredLabels[1].id
+      const previousItemID = filteredLabels[0].id
+      const onUpdateSelectedItemID = jest.fn()
+      const {getByTestId} = setup({
+        onUpdateSelectedItemID,
+        selectedItemID,
+      })
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.keyDown(input, {key: 'ArrowUp', code: 38})
+
+      expect(onUpdateSelectedItemID).toHaveBeenCalledWith(previousItemID)
+    })
+
+    it('pressing ARROWUP selects the same item', () => {
+      const selectedItemID = filteredLabels[0].id
+      const onUpdateSelectedItemID = jest.fn()
+      const {getByTestId} = setup({
+        onUpdateSelectedItemID,
+        selectedItemID,
+      })
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.keyDown(input, {key: 'ArrowUp', code: 38})
+
+      expect(onUpdateSelectedItemID).toHaveBeenCalledWith(selectedItemID)
+    })
+
+    it('pressing ARROWDOWN selects the next item', () => {
+      const selectedItemID = filteredLabels[1].id
+      const nextItemID = filteredLabels[2].id
+      const onUpdateSelectedItemID = jest.fn()
+      const {getByTestId} = setup({
+        onUpdateSelectedItemID,
+        selectedItemID,
+      })
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.keyDown(input, {key: 'ArrowDown', code: 40})
+
+      expect(onUpdateSelectedItemID).toHaveBeenCalledWith(nextItemID)
+    })
+
+    it('pressing ARROWDOWN selects the same item', () => {
+      const selectedItemID = filteredLabels[2].id
+      const onUpdateSelectedItemID = jest.fn()
+      const {getByTestId} = setup({
+        onUpdateSelectedItemID,
+        selectedItemID,
+      })
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.keyDown(input, {key: 'ArrowDown', code: 40})
+
+      expect(onUpdateSelectedItemID).toHaveBeenCalledWith(selectedItemID)
+    })
+  })
+})

--- a/ui/src/shared/components/inlineLabels/InlineLabelPopover.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelPopover.tsx
@@ -7,6 +7,9 @@ import {Input} from 'src/clockface'
 import InlineLabelsList from 'src/shared/components/inlineLabels/InlineLabelsList'
 import {ClickOutside} from 'src/shared/components/ClickOutside'
 
+// Constants
+import {ADD_NEW_LABEL_ITEM_ID} from 'src/shared/components/inlineLabels/InlineLabelsEditor'
+
 // Types
 import {IconFont} from 'src/clockface/types'
 import {ILabel} from '@influxdata/influx'
@@ -21,13 +24,13 @@ enum ArrowDirection {
 interface Props {
   searchTerm: string
   selectedItemID: string
+  onUpdateSelectedItemID: (highlightedID: string) => void
   allLabelsUsed: boolean
   onDismiss: () => void
   onStartCreatingLabel: () => void
   onInputChange: (e: ChangeEvent<HTMLInputElement>) => void
   filteredLabels: ILabel[]
   onAddLabel: (labelID: string) => void
-  onUpdateSelectedItem: (highlightedID: string) => void
 }
 
 @ErrorHandling
@@ -40,7 +43,7 @@ export default class InlineLabelPopover extends Component<Props> {
       onAddLabel,
       onDismiss,
       onStartCreatingLabel,
-      onUpdateSelectedItem,
+      onUpdateSelectedItemID,
       onInputChange,
       filteredLabels,
     } = this.props
@@ -66,7 +69,7 @@ export default class InlineLabelPopover extends Component<Props> {
             filteredLabels={filteredLabels}
             selectedItemID={selectedItemID}
             onItemClick={onAddLabel}
-            onUpdateSelectedItem={onUpdateSelectedItem}
+            onUpdateSelectedItemID={onUpdateSelectedItemID}
             onStartCreatingLabel={onStartCreatingLabel}
           />
         </div>
@@ -75,46 +78,60 @@ export default class InlineLabelPopover extends Component<Props> {
   }
 
   private handleKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
-    const {selectedItemID, onDismiss, onAddLabel} = this.props
-
-    if (!selectedItemID) {
-      return
-    }
+    const {
+      selectedItemID,
+      onDismiss,
+      onAddLabel,
+      onStartCreatingLabel,
+    } = this.props
 
     switch (e.key) {
       case 'Escape':
-        return onDismiss()
+        onDismiss()
+        break
       case 'Enter':
-        return onAddLabel(selectedItemID)
+        e.preventDefault()
+        e.stopPropagation()
+        if (selectedItemID === ADD_NEW_LABEL_ITEM_ID) {
+          onStartCreatingLabel()
+          break
+        }
+
+        if (selectedItemID) {
+          onAddLabel(selectedItemID)
+          break
+        }
       case 'ArrowUp':
-        return this.handleHighlightAdjacentItem(ArrowDirection.Up)
+        this.handleHighlightAdjacentItem(ArrowDirection.Up)
+        break
       case 'ArrowDown':
-        return this.handleHighlightAdjacentItem(ArrowDirection.Down)
+        this.handleHighlightAdjacentItem(ArrowDirection.Down)
+        break
       default:
         break
     }
   }
 
   private handleHighlightAdjacentItem = (direction: ArrowDirection): void => {
-    const {selectedItemID, filteredLabels, onUpdateSelectedItem} = this.props
+    const {selectedItemID, filteredLabels, onUpdateSelectedItemID} = this.props
 
     if (!filteredLabels.length || !selectedItemID) {
       return null
     }
 
-    const highlightedIndex = _.findIndex(
+    const selectedItemIndex = _.findIndex(
       filteredLabels,
-      label => label.name === selectedItemID
+      label => label.id === selectedItemID
     )
 
     const adjacentIndex = Math.min(
-      Math.max(highlightedIndex + direction, 0),
+      Math.max(selectedItemIndex + direction, 0),
       filteredLabels.length - 1
     )
 
     const adjacentID = filteredLabels[adjacentIndex].id
 
-    onUpdateSelectedItem(adjacentID)
+    onUpdateSelectedItemID(adjacentID)
   }
 
   private handleRefocusInput = (e: ChangeEvent<HTMLInputElement>): void => {

--- a/ui/src/shared/components/inlineLabels/InlineLabelPopover.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelPopover.tsx
@@ -62,6 +62,7 @@ export default class InlineLabelPopover extends Component<Props> {
             onChange={onInputChange}
             autoFocus={true}
             onBlur={this.handleRefocusInput}
+            testID="inline-labels--popover-field"
           />
           <InlineLabelsList
             searchTerm={searchTerm}

--- a/ui/src/shared/components/inlineLabels/InlineLabels.test.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabels.test.tsx
@@ -1,0 +1,62 @@
+// Libraries
+import React from 'react'
+import {render} from 'react-testing-library'
+
+// Components
+import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+
+// Constants
+import {labels} from 'mocks/dummyData'
+const selectedLabels = [labels[0]]
+
+const setup = (override = {}) => {
+  const props = {
+    selectedLabels,
+    labels,
+    onRemoveLabel: jest.fn(),
+    onAddLabel: jest.fn(),
+    onCreateLabel: jest.fn(),
+    onFilterChange: jest.fn(),
+    ...override,
+  }
+
+  return render(<InlineLabels {...props} />)
+}
+
+describe('Shared.Components.InlineLabels', () => {
+  describe('rendering', () => {
+    it('renders selected labels', () => {
+      const {getAllByTestId} = setup()
+
+      const selected = getAllByTestId(/label--pill\s/)
+
+      expect(selected).toHaveLength(selectedLabels.length)
+    })
+  })
+
+  describe('mouse interactions', () => {
+    it('clicking a label sets its name as a search term', () => {
+      const onFilterChange = jest.fn()
+      const wrapper = setup({onFilterChange})
+      const firstSelectedLabelName = selectedLabels[0].name
+
+      const label = wrapper.getByTestId(`label--pill ${firstSelectedLabelName}`)
+      label.click()
+
+      expect(onFilterChange).toHaveBeenCalledWith(firstSelectedLabelName)
+    })
+
+    it('clicking a label X button fires the delete function', () => {
+      const onRemoveLabel = jest.fn()
+      const wrapper = setup({onRemoveLabel})
+      const firstSelectedLabel = selectedLabels[0]
+
+      const labelX = wrapper.getByTestId(
+        `label--pill--delete ${firstSelectedLabel.name}`
+      )
+      labelX.click()
+
+      expect(onRemoveLabel).toHaveBeenCalledWith(firstSelectedLabel)
+    })
+  })
+})

--- a/ui/src/shared/components/inlineLabels/InlineLabelsCreateLabelButton.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsCreateLabelButton.tsx
@@ -1,0 +1,53 @@
+// Libraries
+import React, {Component, MouseEvent} from 'react'
+import classnames from 'classnames'
+import _ from 'lodash'
+
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  active: boolean
+  id: string
+  name: string
+  onClick: () => void
+  onMouseOver: (labelID: string) => void
+}
+
+@ErrorHandling
+class InlineLabelsCreateLabelButton extends Component<Props> {
+  public render() {
+    const {name} = this.props
+
+    return (
+      <div
+        className={this.className}
+        onMouseOver={this.handleMouseOver}
+        onClick={this.handleClick}
+        data-testid="inline-labels--create-new"
+      >
+        Create new label "<strong>{`${name}`}</strong>"
+      </div>
+    )
+  }
+
+  private handleMouseOver = (): void => {
+    const {onMouseOver, id} = this.props
+
+    onMouseOver(id)
+  }
+
+  private handleClick = (e: MouseEvent<HTMLDivElement>): void => {
+    e.stopPropagation()
+    this.props.onClick()
+  }
+
+  private get className(): string {
+    const {active} = this.props
+
+    return classnames('inline-labels--list-item inline-labels--create-new', {
+      active,
+    })
+  }
+}
+
+export default InlineLabelsCreateLabelButton

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.scss
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.scss
@@ -69,10 +69,9 @@ $inline-labels--popover-caret: 12px;
   display: flex;
   align-items: flex-start;
   padding: $ix-marg-a $ix-marg-b;
-  transition: background-color 0.25s ease;
 
   &.active {
-    background-color: $g6-smoke;
+    background-color: $c-pool;
   }
 
   &.active,
@@ -94,10 +93,10 @@ $inline-labels--popover-caret: 12px;
   }
 
   &.active {
-    color: $g15-platinum;
+    color: $c-neutrino;
 
     strong {
-      color: $g18-cloud;
+      color: $g20-white;
     }
   }
 }

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.test.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.test.tsx
@@ -1,0 +1,55 @@
+// Libraries
+import React from 'react'
+import {render} from 'react-testing-library'
+
+// Components
+import InlineLabelsEditor from 'src/shared/components/inlineLabels/InlineLabelsEditor'
+
+// Constants
+import {labels} from 'mocks/dummyData'
+const selectedLabels = [labels[0]]
+
+const setup = (override = {}) => {
+  const props = {
+    selectedLabels,
+    labels,
+    onAddLabel: jest.fn(),
+    onCreateLabel: jest.fn(),
+    ...override,
+  }
+
+  return render(<InlineLabelsEditor {...props} />)
+}
+
+describe('Shared.Components.InlineLabelsEditor', () => {
+  describe('rendering', () => {
+    it('renders a plus button', () => {
+      const {getAllByTestId} = setup()
+
+      const plusButton = getAllByTestId('inline-labels--add')
+
+      expect(plusButton).toHaveLength(selectedLabels.length)
+    })
+
+    it('renders empty state with no selected labels', () => {
+      const {getAllByTestId} = setup({selectedLabels: []})
+
+      const noLabelsIndicator = getAllByTestId('inline-labels--empty')
+
+      expect(noLabelsIndicator).toHaveLength(1)
+    })
+  })
+
+  describe('mouse interactions', () => {
+    it('clicking the plus button opens the popover', () => {
+      const {getByTestId, getAllByTestId} = setup()
+
+      const plusButton = getByTestId('inline-labels--add')
+      plusButton.click()
+
+      const popover = getAllByTestId('inline-labels--popover')
+
+      expect(popover).toHaveLength(1)
+    })
+  })
+})

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.test.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.test.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React from 'react'
-import {render} from 'react-testing-library'
+import {render, fireEvent} from 'react-testing-library'
 
 // Components
 import InlineLabelsEditor from 'src/shared/components/inlineLabels/InlineLabelsEditor'
@@ -50,6 +50,29 @@ describe('Shared.Components.InlineLabelsEditor', () => {
       const popover = getAllByTestId('inline-labels--popover')
 
       expect(popover).toHaveLength(1)
+    })
+
+    it('clicking the suggestion item shows create label overlay with the name field correctly populated', () => {
+      const {getByTestId, getAllByTestId} = setup()
+
+      const plusButton = getByTestId('inline-labels--add')
+      plusButton.click()
+
+      const inputValue = 'yodelling is rad'
+
+      const input = getByTestId('inline-labels--popover-field')
+      fireEvent.change(input, {target: {value: inputValue}})
+
+      const suggestionItem = getByTestId('inline-labels--create-new')
+      fireEvent.click(suggestionItem)
+
+      const labelOverlayForm = getAllByTestId('label-overlay-form')
+
+      expect(labelOverlayForm).toHaveLength(1)
+
+      const labelOverlayNameField = getByTestId('create-label-form--name')
+
+      expect(labelOverlayNameField.getAttribute('value')).toEqual(inputValue)
     })
   })
 })

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -21,7 +21,7 @@ import {OverlayState} from 'src/types/overlay'
 
 // Constants
 export const ADD_NEW_LABEL_ITEM_ID = 'add-new-label'
-const ADD_NEW_LABEL_LABEL: ILabel = {
+export const ADD_NEW_LABEL_LABEL: ILabel = {
   id: ADD_NEW_LABEL_ITEM_ID,
   name: '',
   properties: {

--- a/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsEditor.tsx
@@ -19,6 +19,17 @@ import {validateLabelUniqueness} from 'src/configuration/utils/labels'
 import {ILabel} from '@influxdata/influx'
 import {OverlayState} from 'src/types/overlay'
 
+// Constants
+export const ADD_NEW_LABEL_ITEM_ID = 'add-new-label'
+const ADD_NEW_LABEL_LABEL: ILabel = {
+  id: ADD_NEW_LABEL_ITEM_ID,
+  name: '',
+  properties: {
+    color: '#000000',
+    description: '',
+  },
+}
+
 // Styles
 import 'src/shared/components/inlineLabels/InlineLabelsEditor.scss'
 
@@ -93,13 +104,13 @@ class InlineLabelsEditor extends Component<Props, State> {
         <InlineLabelPopover
           searchTerm={searchTerm}
           selectedItemID={selectedItemID}
+          onUpdateSelectedItemID={this.handleUpdateSelectedItemID}
           allLabelsUsed={labelsUsed}
           onDismiss={this.handleDismissPopover}
           onStartCreatingLabel={this.handleStartCreatingLabel}
           onInputChange={this.handleInputChange}
-          filteredLabels={this.filteredLabels}
+          filteredLabels={this.filterLabels(searchTerm)}
           onAddLabel={this.handleAddLabel}
-          onUpdateSelectedItem={this.handleUpdateSelectedItem}
         />
       )
     }
@@ -129,11 +140,22 @@ class InlineLabelsEditor extends Component<Props, State> {
     const label = labels.find(label => label.id === labelID)
 
     if (label) {
+      this.selectAvailableItem()
       onAddLabel(label)
     }
   }
 
-  private handleUpdateSelectedItem = (selectedItemID: string): void => {
+  private selectAvailableItem = (): void => {
+    const {searchTerm} = this.state
+
+    const filteredLabels = this.filterLabels(searchTerm)
+
+    if (filteredLabels.length) {
+      this.handleUpdateSelectedItemID(filteredLabels[0].id)
+    }
+  }
+
+  private handleUpdateSelectedItemID = (selectedItemID: string): void => {
     this.setState({selectedItemID})
   }
 
@@ -149,7 +171,7 @@ class InlineLabelsEditor extends Component<Props, State> {
       })
     }
 
-    const selectedItemID = this.availableLabels[0].name
+    const selectedItemID = this.availableLabels[0].id
     this.setState({isPopoverVisible: true, selectedItemID, searchTerm: ''})
   }
 
@@ -160,35 +182,63 @@ class InlineLabelsEditor extends Component<Props, State> {
   private handleInputChange = async (
     e: ChangeEvent<HTMLInputElement>
   ): Promise<void> => {
-    const {availableLabels} = this
-    let selectedItemID = this.state.selectedItemID
     const searchTerm = e.target.value
+    const filteredLabels = this.filterLabels(searchTerm)
 
-    const selectedItemIDAvailable = availableLabels.find(
-      al => al.name === selectedItemID
-    )
-
-    const matchingLabels = availableLabels.filter(label => {
-      return label.name.includes(searchTerm)
-    })
-
-    if (!selectedItemIDAvailable && matchingLabels.length) {
-      selectedItemID = matchingLabels[0].name
+    if (filteredLabels.length) {
+      const selectedItemID = filteredLabels[0].id
+      this.setState({searchTerm, selectedItemID})
+    } else {
+      this.setState({searchTerm})
     }
-
-    if (searchTerm.length === 0) {
-      selectedItemID = null
-    }
-
-    this.setState({searchTerm, selectedItemID})
   }
 
-  private get filteredLabels(): ILabel[] {
+  private filterLabels = (searchTerm: string): ILabel[] => {
+    const filteredLabels = this.availableLabels.filter(label => {
+      const lowercaseName = label.name.toLowerCase()
+      const lowercaseSearchTerm = searchTerm.toLowerCase()
+
+      return lowercaseName.includes(lowercaseSearchTerm)
+    })
+
+    const searchTermHasExactMatch = filteredLabels.reduce(
+      (acc: boolean, current: ILabel) => {
+        return acc === true || current.name === searchTerm
+      },
+      false
+    )
+
+    if (!searchTermHasExactMatch && searchTerm) {
+      return this.filteredLabelsWithAddButton(filteredLabels)
+    }
+
+    return this.filteredLabelsWithoutAddButton(filteredLabels)
+  }
+
+  private filteredLabelsWithAddButton = (
+    filteredLabels: ILabel[]
+  ): ILabel[] => {
     const {searchTerm} = this.state
 
-    return this.availableLabels.filter(label => {
-      return label.name.includes(searchTerm)
-    })
+    const updatedAddButton = {...ADD_NEW_LABEL_LABEL, name: searchTerm}
+
+    const addButton = filteredLabels.find(
+      label => label.id === updatedAddButton.id
+    )
+
+    if (addButton) {
+      return filteredLabels.map(fl => {
+        return fl.id === updatedAddButton.id ? updatedAddButton : fl
+      })
+    }
+
+    return [updatedAddButton, ...filteredLabels]
+  }
+
+  private filteredLabelsWithoutAddButton = (
+    filteredLabels: ILabel[]
+  ): ILabel[] => {
+    return filteredLabels.filter(label => label.id !== ADD_NEW_LABEL_ITEM_ID)
   }
 
   private get availableLabels(): ILabel[] {

--- a/ui/src/shared/components/inlineLabels/InlineLabelsList.test.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsList.test.tsx
@@ -1,0 +1,87 @@
+// Libraries
+import React from 'react'
+import {render, fireEvent} from 'react-testing-library'
+
+// Components
+import InlineLabelsList from 'src/shared/components/inlineLabels/InlineLabelsList'
+
+// Constants
+import {labels} from 'mocks/dummyData'
+import {ADD_NEW_LABEL_LABEL} from 'src/shared/components/inlineLabels/InlineLabelsEditor'
+
+const setup = (override = {}) => {
+  const props = {
+    searchTerm: '',
+    selectedItemID: '',
+    onUpdateSelectedItemID: jest.fn(),
+    filteredLabels: labels,
+    onItemClick: jest.fn(),
+    allLabelsUsed: false,
+    onStartCreatingLabel: jest.fn(),
+    ...override,
+  }
+
+  return render(<InlineLabelsList {...props} />)
+}
+
+describe('Shared.Components.InlineLabelsList', () => {
+  describe('rendering', () => {
+    it('renders 1 label component per filtered label', () => {
+      const {getAllByTestId} = setup()
+
+      const labelElements = getAllByTestId(/label--pill\s/)
+
+      expect(labelElements).toHaveLength(labels.length)
+    })
+
+    it('renders correct empty state when all labels are used', () => {
+      const {getAllByTestId} = setup({filteredLabels: [], allLabelsUsed: true})
+
+      const noLabelsIndicator = getAllByTestId('inline-labels-list--used-all')
+
+      expect(noLabelsIndicator).toHaveLength(1)
+    })
+
+    it('renders correct empty state when no labels exist', () => {
+      const {getAllByTestId} = setup({filteredLabels: [], searchTerm: null})
+
+      const noLabelsIndicator = getAllByTestId('inline-labels-list--none-exist')
+
+      expect(noLabelsIndicator).toHaveLength(1)
+    })
+
+    it('renders a suggestion item when present in labels list', () => {
+      const {getAllByTestId} = setup({
+        filteredLabels: [ADD_NEW_LABEL_LABEL, ...labels],
+      })
+
+      const suggestionElement = getAllByTestId('inline-labels--create-new')
+
+      expect(suggestionElement).toHaveLength(1)
+    })
+  })
+
+  describe('mouse interactions', () => {
+    it('clicking a list item fires the correct function', () => {
+      const firstLabel = labels[0]
+      const onItemClick = jest.fn()
+      const {getByTestId} = setup({onItemClick})
+
+      const firstListItem = getByTestId(`label--pill ${firstLabel.name}`)
+      fireEvent.click(firstListItem)
+
+      expect(onItemClick).toHaveBeenCalledWith(firstLabel.id)
+    })
+
+    it('mousing over a list item fires the correct function', () => {
+      const firstLabel = labels[0]
+      const onUpdateSelectedItemID = jest.fn()
+      const {getByTestId} = setup({onUpdateSelectedItemID})
+
+      const firstListItem = getByTestId(`label--pill ${firstLabel.name}`)
+      fireEvent.mouseOver(firstListItem)
+
+      expect(onUpdateSelectedItemID).toHaveBeenCalledWith(firstLabel.id)
+    })
+  })
+})

--- a/ui/src/shared/components/inlineLabels/InlineLabelsList.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsList.tsx
@@ -83,7 +83,10 @@ class InlineLabelsList extends Component<Props> {
 
     if (allLabelsUsed) {
       return (
-        <EmptyState size={ComponentSize.Small}>
+        <EmptyState
+          size={ComponentSize.Small}
+          testID="inline-labels-list--used-all"
+        >
           <EmptyState.Text text="This resource has all available labels, LINEBREAK start typing to create a new label" />
         </EmptyState>
       )
@@ -91,7 +94,10 @@ class InlineLabelsList extends Component<Props> {
 
     if (!searchTerm) {
       return (
-        <EmptyState size={ComponentSize.Small}>
+        <EmptyState
+          size={ComponentSize.Small}
+          testID="inline-labels-list--none-exist"
+        >
           <EmptyState.Text text="Start typing to create a new label" />
         </EmptyState>
       )

--- a/ui/src/shared/components/inlineLabels/InlineLabelsList.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsList.tsx
@@ -7,6 +7,10 @@ import {EmptyState} from 'src/clockface'
 import {ComponentSize} from '@influxdata/clockface'
 import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
 import InlineLabelsListItem from 'src/shared/components/inlineLabels/InlineLabelsListItem'
+import InlineLabelsCreateLabelButton from 'src/shared/components/inlineLabels/InlineLabelsCreateLabelButton'
+
+// Constants
+import {ADD_NEW_LABEL_ITEM_ID} from 'src/shared/components/inlineLabels/InlineLabelsEditor'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -17,9 +21,9 @@ import {ILabel} from '@influxdata/influx'
 interface Props {
   searchTerm: string
   selectedItemID: string
+  onUpdateSelectedItemID: (labelID: string) => void
   filteredLabels: ILabel[]
   onItemClick: (labelID: string) => void
-  onUpdateSelectedItem: (labelID: string) => void
   allLabelsUsed: boolean
   onStartCreatingLabel: () => void
 }
@@ -30,10 +34,7 @@ class InlineLabelsList extends Component<Props> {
     return (
       <div className="inline-labels--list-container">
         <FancyScrollbar autoHide={false} autoHeight={true} maxHeight={250}>
-          <div className="inline-labels--list">
-            {this.createNewLabelButton}
-            {this.menuItems}
-          </div>
+          <div className="inline-labels--list">{this.menuItems}</div>
         </FancyScrollbar>
       </div>
     )
@@ -43,31 +44,47 @@ class InlineLabelsList extends Component<Props> {
     const {
       filteredLabels,
       onItemClick,
-      onUpdateSelectedItem,
+      onUpdateSelectedItemID,
       selectedItemID,
       allLabelsUsed,
       searchTerm,
+      onStartCreatingLabel,
     } = this.props
 
     if (filteredLabels.length) {
-      return filteredLabels.map(label => (
-        <InlineLabelsListItem
-          active={selectedItemID === label.id}
-          key={label.id}
-          name={label.name}
-          id={label.id}
-          description={label.properties.description}
-          colorHex={label.properties.color}
-          onClick={onItemClick}
-          onMouseOver={onUpdateSelectedItem}
-        />
-      ))
+      return filteredLabels.map(label => {
+        if (label.id === ADD_NEW_LABEL_ITEM_ID) {
+          return (
+            <InlineLabelsCreateLabelButton
+              active={selectedItemID === label.id}
+              key={label.id}
+              name={label.name}
+              id={label.id}
+              onClick={onStartCreatingLabel}
+              onMouseOver={onUpdateSelectedItemID}
+            />
+          )
+        }
+
+        return (
+          <InlineLabelsListItem
+            active={selectedItemID === label.id}
+            key={label.id}
+            name={label.name}
+            id={label.id}
+            description={label.properties.description}
+            colorHex={label.properties.color}
+            onClick={onItemClick}
+            onMouseOver={onUpdateSelectedItemID}
+          />
+        )
+      })
     }
 
     if (allLabelsUsed) {
       return (
         <EmptyState size={ComponentSize.Small}>
-          <EmptyState.Text text="This resource uses all available labels" />
+          <EmptyState.Text text="This resource has all available labels, LINEBREAK start typing to create a new label" />
         </EmptyState>
       )
     }
@@ -75,39 +92,10 @@ class InlineLabelsList extends Component<Props> {
     if (!searchTerm) {
       return (
         <EmptyState size={ComponentSize.Small}>
-          <EmptyState.Text text="Type to create your first label" />
+          <EmptyState.Text text="Start typing to create a new label" />
         </EmptyState>
       )
     }
-  }
-
-  private get createNewLabelButton(): JSX.Element {
-    const {searchTerm, filteredLabels, onStartCreatingLabel} = this.props
-
-    if (!searchTerm) {
-      return null
-    }
-
-    const searchTermHasExactMatch = filteredLabels.reduce(
-      (acc: boolean, current: ILabel) => {
-        return acc === true || current.name === searchTerm
-      },
-      false
-    )
-
-    if (searchTermHasExactMatch) {
-      return null
-    }
-
-    return (
-      <div
-        className="inline-labels--list-item inline-labels--create-new"
-        onClick={onStartCreatingLabel}
-        data-testid="inline-labels--create-new"
-      >
-        Create new label "<strong>{`${searchTerm}`}</strong>"
-      </div>
-    )
   }
 }
 

--- a/ui/src/shared/components/inlineLabels/InlineLabelsListItem.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabelsListItem.tsx
@@ -28,6 +28,7 @@ class InlineLabelsListItem extends Component<Props> {
         className={this.className}
         onMouseOver={this.handleMouseOver}
         onClick={this.handleClick}
+        data-testid={`label-list--item ${name}`}
       >
         <Label
           name={name}

--- a/ui/src/tasks/components/__snapshots__/TaskForm.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TaskForm.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TaskForm rendering renders 1`] = `
-<Form>
+<Form
+  testID="form-container"
+>
   <Grid>
     <GridRow>
       <GridColumn


### PR DESCRIPTION
Closes #12609 

- Text field in `Add Label` popover is always focused (to receive keyboard commands)
- There is always a selected item in the list (so that hitting `Enter` always does something)
- Hitting `ArrowUp`/`ArrowDown` changes the selected item in the list
- Abiity to select the suggestion via keyboard shortcuts
- Selected item is much brighter
- Wrote unit tests for every mouse & keyboard interaction associated with inline labels

![inline-labels-keyboard-interactions](https://user-images.githubusercontent.com/2433762/54312425-30571300-4594-11e9-9daa-940a895b0b2d.gif)
![inline-labels-keyboard-empty](https://user-images.githubusercontent.com/2433762/54312438-36e58a80-4594-11e9-84c7-33f8da975f41.gif)


### Checklist

  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
