### PR TITLE
Initial support for variables in DE/CEO

### DIFF
--- a/ui/src/timeMachine/actions/index.ts
+++ b/ui/src/timeMachine/actions/index.ts
@@ -35,7 +35,7 @@ export type Action =
   | SetTimeRangeAction
   | SetTypeAction
   | SetActiveQueryText
-  | SubmitScriptAction
+  | SubmitQueriesAction
   | SetIsViewingRawDataAction
   | SetGeomAction
   | SetDecimalPlaces
@@ -140,12 +140,12 @@ export const setActiveQueryText = (text: string): SetActiveQueryText => ({
   payload: {text},
 })
 
-interface SubmitScriptAction {
-  type: 'SUBMIT_SCRIPT'
+interface SubmitQueriesAction {
+  type: 'SUBMIT_QUERIES'
 }
 
-export const submitScript = (): SubmitScriptAction => ({
-  type: 'SUBMIT_SCRIPT',
+export const submitQueries = (): SubmitQueriesAction => ({
+  type: 'SUBMIT_QUERIES',
 })
 
 interface SetIsViewingRawDataAction {
@@ -405,7 +405,7 @@ export const toggleQuery = (queryIndex: number) => (
   dispatch: Dispatch<Action>
 ) => {
   dispatch(toggleQuerySync(queryIndex))
-  dispatch(submitScript())
+  dispatch(submitQueries())
 }
 
 interface UpdateActiveQueryNameAction {

--- a/ui/src/timeMachine/actions/index.ts
+++ b/ui/src/timeMachine/actions/index.ts
@@ -405,7 +405,7 @@ export const toggleQuery = (queryIndex: number) => (
   dispatch: Dispatch<Action>
 ) => {
   dispatch(toggleQuerySync(queryIndex))
-  dispatch(submitQueries())
+  dispatch(submitQueriesWithVars())
 }
 
 interface UpdateActiveQueryNameAction {
@@ -559,10 +559,14 @@ export const refreshTimeMachineVariableValues = () => async (
   const contextID = getState().timeMachines.activeTimeMachineID
 
   // Find variables currently used by queries in the TimeMachine
-  const view = getActiveTimeMachine(getState()).view
+  const {view, draftQueries} = getActiveTimeMachine(getState())
+  const draftView = {
+    ...view,
+    properties: {...view.properties, queries: draftQueries},
+  }
   const orgID = getActiveOrg(getState()).id
   const variables = getVariablesForOrg(getState(), orgID)
-  const variablesInUse = filterUnusedVars(variables, [view])
+  const variablesInUse = filterUnusedVars(variables, [draftView])
 
   // Find variables whose values have already been loaded by the TimeMachine
   // (regardless of whether these variables are currently being used)
@@ -576,4 +580,10 @@ export const refreshTimeMachineVariableValues = () => async (
   )
 
   await dispatch(refreshVariableValues(contextID, orgID, variablesToRefresh))
+}
+
+export const submitQueriesWithVars = () => async dispatch => {
+  await dispatch(refreshTimeMachineVariableValues())
+
+  dispatch(submitQueries())
 }

--- a/ui/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/ui/src/timeMachine/components/SubmitQueryButton.tsx
@@ -11,7 +11,7 @@ import {
 } from '@influxdata/clockface'
 
 // Actions
-import {submitScript} from 'src/timeMachine/actions'
+import {submitQueries} from 'src/timeMachine/actions'
 
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
@@ -25,7 +25,7 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  onSubmitScript: typeof submitScript
+  onSubmitQueries: typeof submitQueries
 }
 
 interface OwnProps {
@@ -80,7 +80,7 @@ class SubmitQueryButton extends PureComponent<Props, State> {
   }
 
   private handleClick = (): void => {
-    this.props.onSubmitScript()
+    this.props.onSubmitQueries()
     this.setState({didClick: true})
   }
 }
@@ -92,7 +92,7 @@ const mstp = (state: AppState) => {
 }
 
 const mdtp = {
-  onSubmitScript: submitScript,
+  onSubmitQueries: submitQueries,
 }
 
 export default connect<StateProps, DispatchProps, OwnProps>(

--- a/ui/src/timeMachine/components/SubmitQueryButton.tsx
+++ b/ui/src/timeMachine/components/SubmitQueryButton.tsx
@@ -11,7 +11,7 @@ import {
 } from '@influxdata/clockface'
 
 // Actions
-import {submitQueries} from 'src/timeMachine/actions'
+import {submitQueriesWithVars} from 'src/timeMachine/actions'
 
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
@@ -25,7 +25,7 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  onSubmitQueries: typeof submitQueries
+  onSubmitQueries: typeof submitQueriesWithVars
 }
 
 interface OwnProps {
@@ -92,7 +92,7 @@ const mstp = (state: AppState) => {
 }
 
 const mdtp = {
-  onSubmitQueries: submitQueries,
+  onSubmitQueries: submitQueriesWithVars,
 }
 
 export default connect<StateProps, DispatchProps, OwnProps>(

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -10,7 +10,10 @@ import VariablesToolbar from 'src/timeMachine/components/variableToolbar/Variabl
 import ToolbarTab from 'src/timeMachine/components/ToolbarTab'
 
 // Actions
-import {setActiveQueryText, submitQueries} from 'src/timeMachine/actions'
+import {
+  setActiveQueryText,
+  submitQueriesWithVars,
+} from 'src/timeMachine/actions'
 
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
@@ -31,7 +34,7 @@ interface StateProps {
 
 interface DispatchProps {
   onSetActiveQueryText: typeof setActiveQueryText
-  onSubmitQueries: typeof submitQueries
+  onSubmitQueries: typeof submitQueriesWithVars
 }
 
 interface State {
@@ -124,7 +127,7 @@ const mstp = (state: AppState) => {
 
 const mdtp = {
   onSetActiveQueryText: setActiveQueryText,
-  onSubmitQueries: submitQueries,
+  onSubmitQueries: submitQueriesWithVars,
 }
 
 export default connect<StateProps, DispatchProps, {}>(

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -10,7 +10,7 @@ import VariablesToolbar from 'src/timeMachine/components/variableToolbar/Variabl
 import ToolbarTab from 'src/timeMachine/components/ToolbarTab'
 
 // Actions
-import {setActiveQueryText, submitScript} from 'src/timeMachine/actions'
+import {setActiveQueryText, submitQueries} from 'src/timeMachine/actions'
 
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
@@ -31,7 +31,7 @@ interface StateProps {
 
 interface DispatchProps {
   onSetActiveQueryText: typeof setActiveQueryText
-  onSubmitScript: typeof submitScript
+  onSubmitQueries: typeof submitQueries
 }
 
 interface State {
@@ -46,7 +46,7 @@ class TimeMachineFluxEditor extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {activeQueryText, onSubmitScript, onSetActiveQueryText} = this.props
+    const {activeQueryText, onSubmitQueries, onSetActiveQueryText} = this.props
 
     const divisions = [
       {
@@ -57,7 +57,7 @@ class TimeMachineFluxEditor extends PureComponent<Props, State> {
             script={activeQueryText}
             status={{type: '', text: ''}}
             onChangeScript={onSetActiveQueryText}
-            onSubmitScript={onSubmitScript}
+            onSubmitScript={onSubmitQueries}
             suggestions={[]}
           />
         ),
@@ -124,7 +124,7 @@ const mstp = (state: AppState) => {
 
 const mdtp = {
   onSetActiveQueryText: setActiveQueryText,
-  onSubmitScript: submitScript,
+  onSubmitQueries: submitQueries,
 }
 
 export default connect<StateProps, DispatchProps, {}>(

--- a/ui/src/timeMachine/reducers/index.test.ts
+++ b/ui/src/timeMachine/reducers/index.test.ts
@@ -10,7 +10,7 @@ import {
 
 // Actions
 import {
-  submitScript,
+  submitQueries,
   setActiveTab,
   setActiveTimeMachine,
   setActiveQueryIndexSync,
@@ -108,7 +108,7 @@ describe('timeMachinesReducer', () => {
 })
 
 describe('timeMachineReducer', () => {
-  describe('SUBMIT_SCRIPT', () => {
+  describe('SUBMIT_QUERIES', () => {
     test('replaces each queries text', () => {
       const state = initialStateHelper()
 
@@ -133,7 +133,7 @@ describe('timeMachineReducer', () => {
         {...queryB, text: 'buzz', hidden: false},
       ]
 
-      const actual = timeMachineReducer(state, submitScript()).view.properties
+      const actual = timeMachineReducer(state, submitQueries()).view.properties
         .queries
 
       const expected = state.draftQueries

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -190,7 +190,7 @@ export const timeMachineReducer = (
       return {...state, draftQueries}
     }
 
-    case 'SUBMIT_SCRIPT': {
+    case 'SUBMIT_QUERIES': {
       return produce(state, draftState => {
         submitQueries(draftState)
       })

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -60,7 +60,7 @@ const getVariableAssignmentsMemoized = memoizeOne(
     valuesState: ValuesState,
     variablesState: VariablesState
   ): VariableAssignment[] => {
-    if (!valuesState) {
+    if (!valuesState || !valuesState.values) {
       return []
     }
 


### PR DESCRIPTION
This PR enables a user to use variables in the Data Explorer and CEO.

When they first open up the CEO to edit a cell, any variables in use in the queries for that cell will be hydrated ("hydrate" = "load values for a variable by executing its query").

When they edit their script and then press submit, any variables they have started to use in their script will be hydrated before executing the query.