### PR TITLE
Fix dashboards in org

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -985,9 +985,9 @@
       }
     },
     "@influxdata/influx": {
-      "version": "0.2.35",
-      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.35.tgz",
-      "integrity": "sha512-Ig/nvgtZVqRIqO6MwtoHBngtWRc1yjzSvaoqkGm0TX0uL3rW2L9400SZg1UUvfd7znhkc+HDItec1hUihLqMgQ==",
+      "version": "0.2.40",
+      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.40.tgz",
+      "integrity": "sha512-Z7ZZJq2xGwBWnVzON4GgbaLJajJcE9Di8MnL1Wuvrw1OgMbdSwSWIgy+wpIOQezEw28FSw2mp22QCZzUxChFeg==",
       "requires": {
         "axios": "^0.18.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -137,7 +137,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "0.0.5",
-    "@influxdata/influx": "0.2.35",
+    "@influxdata/influx": "0.2.40",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",

--- a/ui/src/dashboards/apis/v2/index.ts
+++ b/ui/src/dashboards/apis/v2/index.ts
@@ -32,6 +32,18 @@ export const getDashboards = async (): Promise<Dashboard[]> => {
   }))
 }
 
+export const getDashboardsByOrgID = async (
+  orgID: string
+): Promise<Dashboard[]> => {
+  const dashboards = await client.dashboards.getAllByOrgID(orgID)
+
+  return dashboards.map(d => ({
+    ...d,
+    labels: d.labels.map(addLabelDefaults),
+    cells: addDashboardIDToCells(d.cells, d.id),
+  }))
+}
+
 export const getDashboard = async (id: string): Promise<Dashboard> => {
   const dashboard = await client.dashboards.get(id)
 
@@ -155,7 +167,10 @@ export const cloneDashboard = async (
     dashboardToClone.name
   )
 
-  if (dashboardToClone.id) {
-    return client.dashboards.clone(dashboardToClone.id, clonedName)
-  }
+  const clonedDashboard = await client.dashboards.clone(
+    dashboardToClone.id,
+    clonedName
+  )
+
+  return clonedDashboard
 }

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -17,24 +17,24 @@ import {createLabel as createLabelAsync} from 'src/labels/actions'
 
 // Types
 import {Organization} from 'src/types/v2'
-import {IDashboard, ILabel} from '@influxdata/influx'
-import {AppState} from 'src/types/v2'
+import {ILabel} from '@influxdata/influx'
+import {AppState, Dashboard} from 'src/types/v2'
 
 // Constants
 import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants'
 
 interface PassedProps {
-  dashboard: IDashboard
-  orgs: Organization[]
-  onDeleteDashboard: (dashboard: IDashboard) => void
-  onCloneDashboard: (dashboard: IDashboard) => void
-  onUpdateDashboard: (dashboard: IDashboard) => void
+  dashboard: Dashboard
+  onDeleteDashboard: (dashboard: Dashboard) => void
+  onCloneDashboard: (dashboard: Dashboard) => void
+  onUpdateDashboard: (dashboard: Dashboard) => void
   showOwnerColumn: boolean
   onFilterChange: (searchTerm: string) => void
 }
 
 interface StateProps {
   labels: ILabel[]
+  orgs: Organization[]
 }
 
 interface DispatchProps {
@@ -181,9 +181,10 @@ class DashboardCard extends PureComponent<Props> {
   }
 }
 
-const mstp = ({labels}: AppState): StateProps => {
+const mstp = ({labels, orgs}: AppState): StateProps => {
   return {
     labels: labels.list,
+    orgs,
   }
 }
 

--- a/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -5,14 +5,13 @@ import React, {PureComponent} from 'react'
 import DashboardCard from 'src/dashboards/components/dashboard_index/DashboardCard'
 
 // Types
-import {Dashboard, Organization} from 'src/types/v2'
+import {Dashboard} from 'src/types/v2'
 
 interface Props {
   dashboards: Dashboard[]
   onDeleteDashboard: (dashboard: Dashboard) => void
   onCloneDashboard: (dashboard: Dashboard) => void
   onUpdateDashboard: (dashboard: Dashboard) => void
-  orgs: Organization[]
   showOwnerColumn: boolean
   onFilterChange: (searchTerm: string) => void
 }
@@ -24,7 +23,6 @@ export default class DashboardCards extends PureComponent<Props> {
       onCloneDashboard,
       onDeleteDashboard,
       onUpdateDashboard,
-      orgs,
       showOwnerColumn,
       onFilterChange,
     } = this.props
@@ -36,7 +34,6 @@ export default class DashboardCards extends PureComponent<Props> {
         onCloneDashboard={onCloneDashboard}
         onDeleteDashboard={onDeleteDashboard}
         onUpdateDashboard={onUpdateDashboard}
-        orgs={orgs}
         showOwnerColumn={showOwnerColumn}
         onFilterChange={onFilterChange}
       />

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -20,16 +20,12 @@ import {
   addDashboardLabelsAsync,
   removeDashboardLabelsAsync,
 } from 'src/dashboards/actions/v2'
-import {setDefaultDashboard} from 'src/shared/actions/links'
 import {retainRangesDashTimeV1 as retainRangesDashTimeV1Action} from 'src/dashboards/actions/v2/ranges'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 // Constants
 import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants/index'
-import {
-  dashboardSetDefaultFailed,
-  dashboardCreateFailed,
-} from 'src/shared/copy/notifications'
+import {dashboardCreateFailed} from 'src/shared/copy/notifications'
 
 // Types
 import {Notification} from 'src/types/notifications'
@@ -39,7 +35,6 @@ import {Links, Dashboard, AppState, Organization} from 'src/types/v2'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface DispatchProps {
-  handleSetDefaultDashboard: typeof setDefaultDashboard
   handleGetDashboards: typeof getDashboardsAsync
   handleDeleteDashboard: typeof deleteDashboardAsync
   handleUpdateDashboard: typeof updateDashboardAsync
@@ -83,7 +78,7 @@ class DashboardIndex extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {dashboards, notify, links, handleUpdateDashboard, orgs} = this.props
+    const {dashboards, notify, handleUpdateDashboard} = this.props
     const {searchTerm} = this.state
 
     return (
@@ -113,8 +108,6 @@ class DashboardIndex extends PureComponent<Props, State> {
                 )}
                 orgs={orgs}
                 dashboards={dashboards}
-                onSetDefaultDashboard={this.handleSetDefaultDashboard}
-                defaultDashboardLink={links.defaultDashboard}
                 onDeleteDashboard={this.handleDeleteDashboard}
                 onCreateDashboard={this.handleCreateDashboard}
                 onCloneDashboard={this.handleCloneDashboard}
@@ -130,20 +123,6 @@ class DashboardIndex extends PureComponent<Props, State> {
         {this.props.children}
       </>
     )
-  }
-
-  private handleSetDefaultDashboard = async (
-    defaultDashboardLink: string
-  ): Promise<void> => {
-    const {dashboards, notify, handleSetDefaultDashboard} = this.props
-    const {name} = dashboards.find(d => d.links.self === defaultDashboardLink)
-
-    try {
-      await handleSetDefaultDashboard(defaultDashboardLink)
-    } catch (error) {
-      console.error(error)
-      notify(dashboardSetDefaultFailed(name))
-    }
   }
 
   private handleCreateDashboard = async (): Promise<void> => {
@@ -206,7 +185,6 @@ const mstp = (state: AppState): StateProps => {
 
 const mdtp: DispatchProps = {
   notify: notifyAction,
-  handleSetDefaultDashboard: setDefaultDashboard,
   handleGetDashboards: getDashboardsAsync,
   handleDeleteDashboard: deleteDashboardAsync,
   handleUpdateDashboard: updateDashboardAsync,

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -106,7 +106,6 @@ class DashboardIndex extends PureComponent<Props, State> {
                     searchTerm={searchTerm}
                   />
                 )}
-                orgs={orgs}
                 dashboards={dashboards}
                 onDeleteDashboard={this.handleDeleteDashboard}
                 onCreateDashboard={this.handleCreateDashboard}

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
@@ -11,12 +11,11 @@ import GetLabels from 'src/configuration/components/GetLabels'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Dashboard, Organization} from 'src/types/v2'
+import {Dashboard} from 'src/types/v2'
 import {Notification} from 'src/types/notifications'
 
 interface Props {
   dashboards: Dashboard[]
-  orgs: Organization[]
   onCreateDashboard: () => void
   onCloneDashboard: (dashboard: Dashboard) => void
   onDeleteDashboard: (dashboard: Dashboard) => void
@@ -37,7 +36,6 @@ export default class DashboardsIndexContents extends Component<Props> {
       onCreateDashboard,
       onUpdateDashboard,
       searchTerm,
-      orgs,
       showOwnerColumn,
       dashboards,
       filterComponent,
@@ -61,7 +59,6 @@ export default class DashboardsIndexContents extends Component<Props> {
               onCreateDashboard={onCreateDashboard}
               onCloneDashboard={onCloneDashboard}
               onUpdateDashboard={onUpdateDashboard}
-              orgs={orgs}
               showOwnerColumn={showOwnerColumn}
               onFilterChange={onFilterChange}
             />

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
@@ -17,8 +17,6 @@ import {Notification} from 'src/types/notifications'
 interface Props {
   dashboards: Dashboard[]
   orgs: Organization[]
-  defaultDashboardLink: string
-  onSetDefaultDashboard: (dashboardLink: string) => void
   onCreateDashboard: () => void
   onCloneDashboard: (dashboard: Dashboard) => void
   onDeleteDashboard: (dashboard: Dashboard) => void
@@ -37,8 +35,6 @@ export default class DashboardsIndexContents extends Component<Props> {
       onDeleteDashboard,
       onCloneDashboard,
       onCreateDashboard,
-      defaultDashboardLink,
-      onSetDefaultDashboard,
       onUpdateDashboard,
       searchTerm,
       orgs,
@@ -64,8 +60,6 @@ export default class DashboardsIndexContents extends Component<Props> {
               onDeleteDashboard={onDeleteDashboard}
               onCreateDashboard={onCreateDashboard}
               onCloneDashboard={onCloneDashboard}
-              defaultDashboardLink={defaultDashboardLink}
-              onSetDefaultDashboard={onSetDefaultDashboard}
               onUpdateDashboard={onUpdateDashboard}
               orgs={orgs}
               showOwnerColumn={showOwnerColumn}

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -21,12 +21,10 @@ import {Dashboard, Organization} from 'src/types/v2'
 interface Props {
   searchTerm: string
   dashboards: Dashboard[]
-  defaultDashboardLink: string
   onDeleteDashboard: (dashboard: Dashboard) => void
   onCreateDashboard: () => void
   onCloneDashboard: (dashboard: Dashboard) => void
   onUpdateDashboard: (dashboard: Dashboard) => void
-  onSetDefaultDashboard: (dashboardLink: string) => void
   onFilterChange: (searchTerm: string) => void
   orgs: Organization[]
   showOwnerColumn: boolean

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -16,7 +16,7 @@ import SortingHat from 'src/shared/components/sorting_hat/SortingHat'
 
 // Types
 import {Sort} from 'src/clockface'
-import {Dashboard, Organization} from 'src/types/v2'
+import {Dashboard} from 'src/types/v2'
 
 interface Props {
   searchTerm: string
@@ -26,7 +26,6 @@ interface Props {
   onCloneDashboard: (dashboard: Dashboard) => void
   onUpdateDashboard: (dashboard: Dashboard) => void
   onFilterChange: (searchTerm: string) => void
-  orgs: Organization[]
   showOwnerColumn: boolean
   filterComponent?: () => JSX.Element
 }
@@ -109,7 +108,6 @@ class DashboardsTable extends PureComponent<Props & WithRouterProps, State> {
       onCloneDashboard,
       onDeleteDashboard,
       onUpdateDashboard,
-      orgs,
       showOwnerColumn,
       onFilterChange,
     } = this.props
@@ -129,7 +127,6 @@ class DashboardsTable extends PureComponent<Props & WithRouterProps, State> {
               onCloneDashboard={onCloneDashboard}
               onDeleteDashboard={onDeleteDashboard}
               onUpdateDashboard={onUpdateDashboard}
-              orgs={orgs}
               showOwnerColumn={showOwnerColumn}
               onFilterChange={onFilterChange}
             />

--- a/ui/src/organizations/actions/orgView.ts
+++ b/ui/src/organizations/actions/orgView.ts
@@ -5,20 +5,20 @@ import {
   ITask as Task,
   ITaskTemplate,
 } from '@influxdata/influx'
+import {Dashboard} from 'src/types/v2'
 
 // API
 import {client} from 'src/utils/api'
-
-// Actions
-import {UpdateTask} from 'src/tasks/actions/v2'
+import {getDashboardsByOrgID} from 'src/dashboards/apis/v2/index'
 
 export enum ActionTypes {
   GetTasks = 'GET_TASKS',
   PopulateTasks = 'POPULATE_TASKS',
-  UpdateTask = 'UPDATE_TASK',
+  getDashboards = 'GET_DASHBOARDS',
+  PopulateDashboards = 'POPULATE_DASHBOARDS',
 }
 
-export type Actions = UpdateTask | PopulateTasks
+export type Actions = PopulateTasks | PopulateDashboards
 
 export interface PopulateTasks {
   type: ActionTypes.PopulateTasks
@@ -33,6 +33,23 @@ export const populateTasks = (tasks: Task[]): PopulateTasks => ({
 export const getTasks = (orgID: string) => async dispatch => {
   const tasks = await client.tasks.getAllByOrgID(orgID)
   dispatch(populateTasks(tasks))
+}
+
+export interface PopulateDashboards {
+  type: ActionTypes.PopulateDashboards
+  payload: {dashboards: Dashboard[]}
+}
+
+export const populateDashboards = (
+  dashboards: Dashboard[]
+): PopulateDashboards => ({
+  type: ActionTypes.PopulateDashboards,
+  payload: {dashboards},
+})
+
+export const getDashboards = (orgID: string) => async dispatch => {
+  const dashboards = await getDashboardsByOrgID(orgID)
+  dispatch(populateDashboards(dashboards))
 }
 
 export const createScraper = (scraper: ScraperTargetRequest) => async () => {

--- a/ui/src/organizations/components/Dashboards.tsx
+++ b/ui/src/organizations/components/Dashboards.tsx
@@ -15,58 +15,38 @@ import {createDashboard, cloneDashboard} from 'src/dashboards/apis/v2/'
 
 // Actions
 import {
-  getDashboardsAsync,
-  importDashboardAsync,
   deleteDashboardAsync,
   updateDashboardAsync,
-  addDashboardLabelsAsync,
-  removeDashboardLabelsAsync,
 } from 'src/dashboards/actions/v2'
-import {retainRangesDashTimeV1 as retainRangesDashTimeV1Action} from 'src/dashboards/actions/v2/ranges'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
-import {dashboardCreateFailed} from 'src/shared/copy/notifications'
-
 // Constants
+import {dashboardCreateFailed} from 'src/shared/copy/notifications'
 import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants/index'
 
 // Types
 import {Notification} from 'src/types/notifications'
-import {Links, Dashboard, AppState, Organization} from 'src/types/v2'
+import {Dashboard} from 'src/types/v2'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface DispatchProps {
-  handleGetDashboards: typeof getDashboardsAsync
   handleDeleteDashboard: typeof deleteDashboardAsync
-  handleImportDashboard: typeof importDashboardAsync
   handleUpdateDashboard: typeof updateDashboardAsync
   notify: (message: Notification) => void
-  retainRangesDashTimeV1: (dashboardIDs: string[]) => void
-  onAddDashboardLabels: typeof addDashboardLabelsAsync
-  onRemoveDashboardLabels: typeof removeDashboardLabelsAsync
-}
-
-interface StateProps {
-  links: Links
-  dashboards: Dashboard[]
-  orgs: Organization[]
 }
 
 interface OwnProps {
   dashboards: Dashboard[]
   onChange: () => void
-  orgName: string
   orgID: string
 }
 
-type Props = DispatchProps & StateProps & OwnProps & WithRouterProps
+type Props = DispatchProps & OwnProps & WithRouterProps
 
 interface State {
   searchTerm: string
-  isEditingDashboardLabels: boolean
-  dashboardLabelsEdit: Dashboard
 }
 
 @ErrorHandling
@@ -76,20 +56,11 @@ class Dashboards extends PureComponent<Props, State> {
 
     this.state = {
       searchTerm: '',
-      isEditingDashboardLabels: false,
-      dashboardLabelsEdit: null,
     }
   }
 
-  public async componentDidMount() {
-    const {handleGetDashboards, dashboards} = this.props
-    await handleGetDashboards()
-    const dashboardIDs = dashboards.map(d => d.id)
-    this.props.retainRangesDashTimeV1(dashboardIDs)
-  }
-
   public render() {
-    const {dashboards, notify, links, handleUpdateDashboard, orgs} = this.props
+    const {dashboards, notify, handleUpdateDashboard} = this.props
     const {searchTerm} = this.state
 
     return (
@@ -107,13 +78,12 @@ class Dashboards extends PureComponent<Props, State> {
           />
           <AddResourceDropdown
             onSelectNew={this.handleCreateDashboard}
-            onSelectImport={this.handleImport}
+            onSelectImport={this.summonImportOverlay}
             resourceName="Dashboard"
           />
         </Tabs.TabContentsHeader>
         <DashboardsIndexContents
           dashboards={dashboards}
-          orgs={orgs}
           onDeleteDashboard={this.handleDeleteDashboard}
           onCreateDashboard={this.handleCreateDashboard}
           onCloneDashboard={this.handleCloneDashboard}
@@ -139,18 +109,18 @@ class Dashboards extends PureComponent<Props, State> {
     this.setState({searchTerm})
   }
 
-  private handleImport = (): void => {
+  private summonImportOverlay = (): void => {
     const {router, params} = this.props
     router.push(`/organizations/${params.orgID}/dashboards/import`)
   }
 
   private handleCreateDashboard = async (): Promise<void> => {
-    const {router, notify, orgs} = this.props
+    const {router, notify, orgID} = this.props
     try {
       const newDashboard = {
         name: DEFAULT_DASHBOARD_NAME,
         cells: [],
-        orgID: orgs[0].id,
+        orgID: orgID,
       }
       const data = await createDashboard(newDashboard)
       router.push(`/dashboards/${data.id}`)
@@ -162,15 +132,9 @@ class Dashboards extends PureComponent<Props, State> {
   private handleCloneDashboard = async (
     dashboard: Dashboard
   ): Promise<void> => {
-    const {router, notify, orgs, dashboards} = this.props
+    const {router, notify, dashboards} = this.props
     try {
-      const data = await cloneDashboard(
-        {
-          ...dashboard,
-          orgID: orgs[0].id,
-        },
-        dashboards
-      )
+      const data = await cloneDashboard(dashboard, dashboards)
       router.push(`/dashboards/${data.id}`)
     } catch (error) {
       console.error(error)
@@ -183,27 +147,13 @@ class Dashboards extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState): StateProps => {
-  const {dashboards, links, orgs} = state
-
-  return {
-    orgs,
-    dashboards,
-    links,
-  }
-}
-
 const mdtp: DispatchProps = {
   notify: notifyAction,
-  handleGetDashboards: getDashboardsAsync,
   handleDeleteDashboard: deleteDashboardAsync,
   handleUpdateDashboard: updateDashboardAsync,
-  retainRangesDashTimeV1: retainRangesDashTimeV1Action,
-  onAddDashboardLabels: addDashboardLabelsAsync,
-  onRemoveDashboardLabels: removeDashboardLabelsAsync,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
-  mstp,
+export default connect<{}, DispatchProps, OwnProps>(
+  null,
   mdtp
 )(withRouter(Dashboards))

--- a/ui/src/organizations/components/Dashboards.tsx
+++ b/ui/src/organizations/components/Dashboards.tsx
@@ -22,14 +22,10 @@ import {
   addDashboardLabelsAsync,
   removeDashboardLabelsAsync,
 } from 'src/dashboards/actions/v2'
-import {setDefaultDashboard} from 'src/shared/actions/links'
 import {retainRangesDashTimeV1 as retainRangesDashTimeV1Action} from 'src/dashboards/actions/v2/ranges'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
-import {
-  dashboardSetDefaultFailed,
-  dashboardCreateFailed,
-} from 'src/shared/copy/notifications'
+import {dashboardCreateFailed} from 'src/shared/copy/notifications'
 
 // Constants
 import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants/index'
@@ -42,7 +38,6 @@ import {Links, Dashboard, AppState, Organization} from 'src/types/v2'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface DispatchProps {
-  handleSetDefaultDashboard: typeof setDefaultDashboard
   handleGetDashboards: typeof getDashboardsAsync
   handleDeleteDashboard: typeof deleteDashboardAsync
   handleImportDashboard: typeof importDashboardAsync
@@ -119,8 +114,6 @@ class Dashboards extends PureComponent<Props, State> {
         <DashboardsIndexContents
           dashboards={dashboards}
           orgs={orgs}
-          onSetDefaultDashboard={this.handleSetDefaultDashboard}
-          defaultDashboardLink={links.defaultDashboard}
           onDeleteDashboard={this.handleDeleteDashboard}
           onCreateDashboard={this.handleCreateDashboard}
           onCloneDashboard={this.handleCloneDashboard}
@@ -149,20 +142,6 @@ class Dashboards extends PureComponent<Props, State> {
   private handleImport = (): void => {
     const {router, params} = this.props
     router.push(`/organizations/${params.orgID}/dashboards/import`)
-  }
-
-  private handleSetDefaultDashboard = async (
-    defaultDashboardLink: string
-  ): Promise<void> => {
-    const {dashboards, notify, handleSetDefaultDashboard} = this.props
-    const {name} = dashboards.find(d => d.links.self === defaultDashboardLink)
-
-    try {
-      await handleSetDefaultDashboard(defaultDashboardLink)
-    } catch (error) {
-      console.error(error)
-      notify(dashboardSetDefaultFailed(name))
-    }
   }
 
   private handleCreateDashboard = async (): Promise<void> => {
@@ -216,10 +195,8 @@ const mstp = (state: AppState): StateProps => {
 
 const mdtp: DispatchProps = {
   notify: notifyAction,
-  handleSetDefaultDashboard: setDefaultDashboard,
   handleGetDashboards: getDashboardsAsync,
   handleDeleteDashboard: deleteDashboardAsync,
-  handleImportDashboard: importDashboardAsync,
   handleUpdateDashboard: updateDashboardAsync,
   retainRangesDashTimeV1: retainRangesDashTimeV1Action,
   onAddDashboardLabels: addDashboardLabelsAsync,

--- a/ui/src/organizations/containers/OrgDashboardsIndex.tsx
+++ b/ui/src/organizations/containers/OrgDashboardsIndex.tsx
@@ -12,18 +12,19 @@ import {Page} from 'src/pageLayout'
 import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
 import TabbedPageSection from 'src/shared/components/tabbed_page/TabbedPageSection'
 import Dashboards from 'src/organizations/components/Dashboards'
-import GetOrgResources from 'src/organizations/components/GetOrgResources'
 
 //Actions
 import * as NotificationsActions from 'src/types/actions/notifications'
 import * as notifyActions from 'src/shared/actions/notifications'
-
-// APIs
-import {getDashboards} from 'src/organizations/apis'
+import {
+  getDashboards as getDashboardsAction,
+  populateDashboards as populateDashboardsAction,
+} from 'src/organizations/actions/orgView'
 
 // Types
 import {Organization} from '@influxdata/influx'
 import {AppState, Dashboard} from 'src/types/v2'
+import {RemoteDataState} from 'src/types'
 
 interface RouterProps {
   params: {
@@ -33,73 +34,110 @@ interface RouterProps {
 
 interface DispatchProps {
   notify: NotificationsActions.PublishNotificationActionCreator
+  getDashboards: typeof getDashboardsAction
+  populateDashboards: typeof populateDashboardsAction
 }
 
 interface StateProps {
   org: Organization
+  dashboards: Dashboard[]
 }
 
 type Props = WithRouterProps & RouterProps & DispatchProps & StateProps
 
+interface State {
+  loadingState: RemoteDataState
+}
+
 @ErrorHandling
-class OrgDashboardsIndex extends Component<Props> {
+class OrgDashboardsIndex extends Component<Props, State> {
+  public state = {
+    loadingState: RemoteDataState.NotStarted,
+  }
+
+  public componentDidMount = async () => {
+    this.setState({loadingState: RemoteDataState.Loading})
+
+    const {getDashboards, org} = this.props
+
+    await getDashboards(org.id)
+
+    this.setState({loadingState: RemoteDataState.Done})
+  }
+
+  public componentWillUnmount = async () => {
+    const {populateDashboards} = this.props
+    populateDashboards([])
+  }
+
   public render() {
     const {org} = this.props
 
     return (
-      <>
-        <Page titleTag={org.name}>
-          <OrgHeader orgID={org.id} />
-          <Page.Contents fullWidth={false} scrollable={true}>
-            <div className="col-xs-12">
-              <Tabs>
-                <OrganizationNavigation tab={'dashboards'} orgID={org.id} />
-                <Tabs.TabContents>
-                  <TabbedPageSection
-                    id="org-view-tab--dashboards"
-                    url="dashboards"
-                    title="Dashboards"
-                  >
-                    <GetOrgResources<Dashboard>
-                      organization={org}
-                      fetcher={getDashboards}
-                    >
-                      {(dashboards, loading, fetch) => (
-                        <SpinnerContainer
-                          loading={loading}
-                          spinnerComponent={<TechnoSpinner />}
-                        >
-                          <Dashboards
-                            dashboards={dashboards}
-                            orgName={org.name}
-                            onChange={fetch}
-                            orgID={org.id}
-                          />
-                        </SpinnerContainer>
-                      )}
-                    </GetOrgResources>
-                  </TabbedPageSection>
-                </Tabs.TabContents>
-              </Tabs>
-            </div>
-          </Page.Contents>
-        </Page>
-        {this.props.children}
-      </>
+      <Page titleTag={org.name}>
+        <OrgHeader orgID={org.id} />
+        <Page.Contents fullWidth={false} scrollable={true}>
+          <div className="col-xs-12">
+            <Tabs>
+              <OrganizationNavigation tab={'dashboards'} orgID={org.id} />
+              <Tabs.TabContents>
+                <TabbedPageSection
+                  id="org-view-tab--dashboards"
+                  url="dashboards"
+                  title="Dashboards"
+                >
+                  {this.orgsDashboardsPage}
+                </TabbedPageSection>
+              </Tabs.TabContents>
+            </Tabs>
+          </div>
+        </Page.Contents>
+      </Page>
     )
+  }
+
+  private get orgsDashboardsPage() {
+    const {org, dashboards} = this.props
+    const {loadingState} = this.state
+    return (
+      <SpinnerContainer
+        loading={loadingState}
+        spinnerComponent={<TechnoSpinner />}
+      >
+        <Dashboards
+          dashboards={dashboards}
+          onChange={this.getDashboards}
+          orgID={org.id}
+        />
+      </SpinnerContainer>
+    )
+  }
+
+  private getDashboards = async () => {
+    const {getDashboards, org} = this.props
+
+    await getDashboards(org.id)
   }
 }
 
-const mstp = (state: AppState, props: Props) => {
-  const {orgs} = state
+const mstp = (state: AppState, props: Props): StateProps => {
+  const {
+    orgs,
+    orgView: {dashboards},
+  } = state
+
   const org = orgs.find(o => o.id === props.params.orgID)
+
   return {
     org,
+    dashboards,
   }
 }
 
 const mdtp: DispatchProps = {
   notify: notifyActions.notify,
+  getDashboards: getDashboardsAction,
+  populateDashboards: populateDashboardsAction,
 }
 
 export default connect<StateProps, DispatchProps, {}>(

--- a/ui/src/organizations/reducers/orgView.ts
+++ b/ui/src/organizations/reducers/orgView.ts
@@ -1,41 +1,23 @@
-import {
-  Variable,
-  Telegraf,
-  ScraperTargetResponse,
-  Bucket,
-  ITask as Task,
-} from '@influxdata/influx'
-import {Dashboard} from 'src/types'
+import {ITask as Task} from '@influxdata/influx'
+import {Dashboard} from 'src/types/v2'
 import {Actions, ActionTypes} from 'src/organizations/actions/orgView'
 
 export interface OrgViewState {
   tasks: Task[]
-  telegrafs: Telegraf[]
-  scrapers: ScraperTargetResponse[]
-  variables: Variable[]
   dashboards: Dashboard[]
-  buckets: Bucket[]
 }
 
 const defaultState: OrgViewState = {
   tasks: [],
-  telegrafs: [],
-  scrapers: [],
-  variables: [],
   dashboards: [],
-  buckets: [],
 }
 
 export default (state = defaultState, action: Actions): OrgViewState => {
   switch (action.type) {
     case ActionTypes.PopulateTasks:
       return {...state, tasks: action.payload.tasks}
-    case ActionTypes.UpdateTask: {
-      const {task} = action.payload
-      const tasks = state.tasks.map(t => (t.id === task.id ? task : t))
-
-      return {...state, tasks}
-    }
+    case ActionTypes.PopulateDashboards:
+      return {...state, dashboards: action.payload.dashboards}
     default:
       return state
   }

--- a/ui/src/protos/actions/index.ts
+++ b/ui/src/protos/actions/index.ts
@@ -12,8 +12,8 @@ import {loadDashboard} from 'src/dashboards/actions/v2/'
 import {notify} from 'src/shared/actions/notifications'
 
 // Types
-import {Proto, IDashboard} from '@influxdata/influx'
-import {GetState} from 'src/types/v2'
+import {Proto} from '@influxdata/influx'
+import {GetState, Dashboard} from 'src/types/v2'
 import {ConfigurationState} from 'src/types/v2/dataLoaders'
 
 // Const
@@ -59,7 +59,7 @@ export const createDashFromProto = (
   try {
     const dashboards = await client.dashboards.createFromProto(protoID, orgID)
 
-    dashboards.forEach((d: IDashboard) => {
+    dashboards.forEach((d: Dashboard) => {
       const updatedDashboard = {
         ...d,
         labels: d.labels.map(addLabelDefaults),

--- a/ui/src/shared/actions/links.ts
+++ b/ui/src/shared/actions/links.ts
@@ -9,26 +9,9 @@ export enum ActionTypes {
   LinksGetRequested = 'LINKS_GET_REQUESTED',
   LinksGetCompleted = 'LINKS_GET_COMPLETED',
   LinksGetFailed = 'LINKS_GET_FAILED',
-  SetDefaultDashboardLink = 'SET_DEFAULT_DASHBOARD_LINK',
 }
 
-export type Action = LinksGetCompletedAction | SetDefaultDashboardAction
-
-export interface SetDefaultDashboardAction {
-  type: ActionTypes.SetDefaultDashboardLink
-  payload: {
-    defaultDashboard: string
-  }
-}
-
-export const setDefaultDashboard = (
-  defaultDashboard: string
-): SetDefaultDashboardAction => ({
-  type: ActionTypes.SetDefaultDashboardLink,
-  payload: {
-    defaultDashboard,
-  },
-})
+export type Action = LinksGetCompletedAction
 
 export interface LinksGetRequestedAction {
   type: ActionTypes.LinksGetRequested

--- a/ui/src/shared/reducers/links.test.ts
+++ b/ui/src/shared/reducers/links.test.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 import linksReducer from 'src/shared/reducers/links'
-import {linksGetCompleted, setDefaultDashboard} from 'src/shared/actions/links'
+import {linksGetCompleted} from 'src/shared/actions/links'
 import {Links} from 'src/types/v2/links'
 
 const links: Links = {
@@ -41,14 +41,5 @@ describe('Shared.Reducers.linksReducer', () => {
     const actual = linksReducer(undefined, linksGetCompleted(links))
     const expected = links
     expect(_.isEqual(actual, expected)).toBe(true)
-  })
-
-  it('can reduce SET_DEFAULT_DASHBOARD_LINK', () => {
-    const defaultDashboard = '/v2/dashboards/defaultiest_dashboard'
-    const actual = linksReducer(links, setDefaultDashboard(defaultDashboard))
-
-    const expected = {...links, defaultDashboard}
-
-    expect(actual).toEqual(expected)
   })
 })

--- a/ui/src/shared/reducers/links.ts
+++ b/ui/src/shared/reducers/links.ts
@@ -35,11 +35,6 @@ const linksReducer = (state = initialState, action: Action): Links => {
       const {links} = action.payload
       return {...links, defaultDashboard: '/v2/dashboards/029d13fda9c5b000'}
     }
-
-    case ActionTypes.SetDefaultDashboardLink: {
-      const {defaultDashboard} = action.payload
-      return {...state, defaultDashboard}
-    }
   }
 
   return state


### PR DESCRIPTION
Closes #12574 

_Briefly describe your proposed changes:_
Org view dashboards were loading dashboards in a number of places in the component hierarchy and there was a lot of general confusion in the components. 
I did a lot of clean up, as well as centralizing where dashboard get was being performed. 