### PR TITLE
fix(query): release the query results before requesting statistics

### DIFF
--- a/query/bridges.go
+++ b/query/bridges.go
@@ -85,10 +85,10 @@ func (b ProxyQueryServiceAsyncBridge) Query(ctx context.Context, w io.Writer, re
 	defer results.Release()
 
 	encoder := req.Dialect.Encoder()
-	_, err = encoder.Encode(w, results)
-	if err != nil {
+	if _, err := encoder.Encode(w, results); err != nil {
 		return flux.Statistics{}, tracing.LogError(span, err)
 	}
+	results.Release()
 
 	stats := results.Statistics()
 	return stats, nil


### PR DESCRIPTION
The statistics are only finalized after release is called. Defer a call
to release to ensure they are released, but explicitly release on
success to ensure that the statistics are finalized from all sources
before returning them.