### PR TITLE
fix(task): filter by measurement early in query logreader

### DIFF
--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -260,6 +260,7 @@ func TestScheduler_Release(t *testing.T) {
 }
 
 func TestScheduler_UpdateTask(t *testing.T) {
+	t.Skip("flaky test: https://github.com/influxdata/influxdb/issues/12667")
 	t.Parallel()
 
 	d := mock.NewDesiredState()


### PR DESCRIPTION
The late measurement filter, after a pivot, had the potential to result
in empty groups without a runID, which would cause a runtime error,
which would cause the whole query to fail.

Experimentation has shown that those empty tables will no longer arrive
by filtering early on measurement.