### PR TITLE
test(stdlib): skip failing window test due to new trigger optimization

### DIFF
--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -134,6 +134,8 @@ var skipTests = map[string]string{
 	"drop_referenced":             "need to support known errors in new test framework (https://github.com/influxdata/flux/issues/536)",
 	"yield":                       "yield requires special test case (https://github.com/influxdata/flux/issues/535)",
 	"rowfn_with_import":           "imported libraries are not visible in user-defined functions (https://github.com/influxdata/flux/issues/1000)",
+
+	"window_group_mean_ungroup":   "window trigger optimization modifies sort order of its output tables (https://github.com/influxdata/flux/issues/1067)",
 }
 
 func TestFluxEndToEnd(t *testing.T) {


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_

Skip failing end-to-end test due to https://github.com/influxdata/flux/issues/1067

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
