### PR TITLE
fix(ui/onboarding): add flex 1 to admin step

### DIFF
--- a/ui/src/onboarding/OnboardingWizard.scss
+++ b/ui/src/onboarding/OnboardingWizard.scss
@@ -75,8 +75,8 @@
 }
 
 .onboarding-step {
+  flex: 1 0 0;
   min-width: 100%;
-  min-height: 100%;
   text-align: center;
   position: relative;
   display: inline-flex;


### PR DESCRIPTION

Firefox:
![Screen Shot 2019-03-19 at 11 43 37 AM](https://user-images.githubusercontent.com/4994741/54620305-5a994c80-4a3c-11e9-9cf5-858b676ba37b.png)

Chrome:
![Screen Shot 2019-03-19 at 11 43 47 AM](https://user-images.githubusercontent.com/4994741/54620366-6f75e000-4a3c-11e9-845d-c0a7b5cd2985.png)

Safari:
![Screen Shot 2019-03-19 at 11 44 03 AM](https://user-images.githubusercontent.com/4994741/54620386-77ce1b00-4a3c-11e9-93b5-bcd959bbb88e.png)


Closes #12551 

_Briefly describe your proposed changes:_
Add `flex: 1` styling to the onboarding step container so it fills the available height. This is also similar to what the onboarding form and other onboarding styles do.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
