### PR TITLE
Scope labels to organizations

### DIFF
--- a/authorizer/label.go
+++ b/authorizer/label.go
@@ -159,14 +159,9 @@ func (s *LabelService) FindResourceLabels(ctx context.Context, filter influxdb.L
 	return labels, nil
 }
 
-// CreateLabel checks to see if the authorizer on context has write access to the global labels resource.
+// CreateLabel checks to see if the authorizer on context has read access to the new label's org.
 func (s *LabelService) CreateLabel(ctx context.Context, l *influxdb.Label) error {
-	p, err := influxdb.NewGlobalPermission(influxdb.WriteAction, influxdb.LabelsResourceType)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
+	if err := authorizeReadOrg(ctx, l.OrganizationID); err != nil {
 		return err
 	}
 

--- a/authorizer/label_test.go
+++ b/authorizer/label_test.go
@@ -818,6 +818,12 @@ func TestLabelService_CreateLabelMapping(t *testing.T) {
 			name: "authorized to create label mapping",
 			fields: fields{
 				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
+						}, nil
+					},
 					CreateLabelMappingFn: func(ctx context.Context, lm *influxdb.LabelMapping) error {
 						return nil
 					},
@@ -853,6 +859,12 @@ func TestLabelService_CreateLabelMapping(t *testing.T) {
 			name: "unauthorized to create label mapping for resources on which the user does not have write access",
 			fields: fields{
 				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
+						}, nil
+					},
 					CreateLabelMappingFn: func(ctx context.Context, lm *influxdb.LabelMapping) error {
 						return nil
 					},
@@ -884,6 +896,12 @@ func TestLabelService_CreateLabelMapping(t *testing.T) {
 			name: "unauthorized to create label mapping",
 			fields: fields{
 				LabelService: &mock.LabelService{
+					FindLabelByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
+						return &influxdb.Label{
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
+						}, nil
+					},
 					CreateLabelMappingFn: func(ctx context.Context, lm *influxdb.LabelMapping) error {
 						return nil
 					},
@@ -906,7 +924,7 @@ func TestLabelService_CreateLabelMapping(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:labels/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/020f755c3c083000/labels/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -950,7 +968,8 @@ func TestLabelService_DeleteLabelMapping(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 					DeleteLabelMappingFn: func(ctx context.Context, m *influxdb.LabelMapping) error {
@@ -990,7 +1009,8 @@ func TestLabelService_DeleteLabelMapping(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 					DeleteLabelMappingFn: func(ctx context.Context, m *influxdb.LabelMapping) error {
@@ -1026,7 +1046,8 @@ func TestLabelService_DeleteLabelMapping(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 					DeleteLabelMappingFn: func(ctx context.Context, m *influxdb.LabelMapping) error {
@@ -1051,7 +1072,7 @@ func TestLabelService_DeleteLabelMapping(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:labels/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/020f755c3c083000/labels/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},

--- a/authorizer/label_test.go
+++ b/authorizer/label_test.go
@@ -55,7 +55,8 @@ func TestLabelService_FindLabelByID(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: id,
+							ID:             id,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 				},
@@ -80,7 +81,8 @@ func TestLabelService_FindLabelByID(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: id,
+							ID:             id,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 				},
@@ -97,7 +99,7 @@ func TestLabelService_FindLabelByID(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "read:labels/0000000000000001 is unauthorized",
+					Msg:  "read:orgs/020f755c3c083000/labels/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -142,13 +144,16 @@ func TestLabelService_FindLabels(t *testing.T) {
 					FindLabelsFn: func(ctx context.Context, filter influxdb.LabelFilter) ([]*influxdb.Label, error) {
 						return []*influxdb.Label{
 							{
-								ID: 1,
+								ID:             1,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 2,
+								ID:             2,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 3,
+								ID:             3,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 						}, nil
 					},
@@ -165,13 +170,16 @@ func TestLabelService_FindLabels(t *testing.T) {
 			wants: wants{
 				labels: []*influxdb.Label{
 					{
-						ID: 1,
+						ID:             1,
+						OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 					},
 					{
-						ID: 2,
+						ID:             2,
+						OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 					},
 					{
-						ID: 3,
+						ID:             3,
+						OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 					},
 				},
 			},
@@ -183,13 +191,16 @@ func TestLabelService_FindLabels(t *testing.T) {
 					FindLabelsFn: func(ctx context.Context, filter influxdb.LabelFilter) ([]*influxdb.Label, error) {
 						return []*influxdb.Label{
 							{
-								ID: 1,
+								ID:             1,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 2,
+								ID:             2,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 3,
+								ID:             3,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 						}, nil
 					},
@@ -207,7 +218,8 @@ func TestLabelService_FindLabels(t *testing.T) {
 			wants: wants{
 				labels: []*influxdb.Label{
 					{
-						ID: 1,
+						ID:             1,
+						OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 					},
 				},
 			},
@@ -219,13 +231,16 @@ func TestLabelService_FindLabels(t *testing.T) {
 					FindLabelsFn: func(ctx context.Context, filter influxdb.LabelFilter) ([]*influxdb.Label, error) {
 						return []*influxdb.Label{
 							{
-								ID: 1,
+								ID:             1,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 2,
+								ID:             2,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 3,
+								ID:             3,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 						}, nil
 					},
@@ -287,12 +302,14 @@ func TestLabelService_UpdateLabel(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 					UpdateLabelFn: func(ctx context.Context, id influxdb.ID, upd influxdb.LabelUpdate) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 				},
@@ -319,12 +336,14 @@ func TestLabelService_UpdateLabel(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 					UpdateLabelFn: func(ctx context.Context, id influxdb.ID, upd influxdb.LabelUpdate) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 				},
@@ -343,7 +362,7 @@ func TestLabelService_UpdateLabel(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:labels/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/020f755c3c083000/labels/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -387,7 +406,8 @@ func TestLabelService_DeleteLabel(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 					DeleteLabelFn: func(ctx context.Context, id influxdb.ID) error {
@@ -401,8 +421,9 @@ func TestLabelService_DeleteLabel(t *testing.T) {
 					{
 						Action: "write",
 						Resource: influxdb.Resource{
-							Type: influxdb.LabelsResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type:  influxdb.LabelsResourceType,
+							ID:    influxdbtesting.IDPtr(1),
+							OrgID: influxdbtesting.IDPtr(influxdbtesting.MustIDBase16(orgOneID)),
 						},
 					},
 				},
@@ -417,7 +438,8 @@ func TestLabelService_DeleteLabel(t *testing.T) {
 				LabelService: &mock.LabelService{
 					FindLabelByIDFn: func(ctc context.Context, id influxdb.ID) (*influxdb.Label, error) {
 						return &influxdb.Label{
-							ID: 1,
+							ID:             1,
+							OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 						}, nil
 					},
 					DeleteLabelFn: func(ctx context.Context, id influxdb.ID) error {
@@ -431,15 +453,16 @@ func TestLabelService_DeleteLabel(t *testing.T) {
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type: influxdb.LabelsResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type:  influxdb.LabelsResourceType,
+							ID:    influxdbtesting.IDPtr(1),
+							OrgID: influxdbtesting.IDPtr(influxdbtesting.MustIDBase16(orgOneID)),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:labels/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/020f755c3c083000/labels/0000000000000001 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -562,13 +585,16 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 					FindResourceLabelsFn: func(ctx context.Context, f influxdb.LabelMappingFilter) ([]*influxdb.Label, error) {
 						return []*influxdb.Label{
 							{
-								ID: 1,
+								ID:             1,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 2,
+								ID:             2,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 3,
+								ID:             3,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 						}, nil
 					},
@@ -599,13 +625,16 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 				err: nil,
 				labels: []*influxdb.Label{
 					{
-						ID: 1,
+						ID:             1,
+						OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 					},
 					{
-						ID: 2,
+						ID:             2,
+						OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 					},
 					{
-						ID: 3,
+						ID:             3,
+						OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 					},
 				},
 			},
@@ -617,13 +646,16 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 					FindResourceLabelsFn: func(ctx context.Context, f influxdb.LabelMappingFilter) ([]*influxdb.Label, error) {
 						return []*influxdb.Label{
 							{
-								ID: 1,
+								ID:             1,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 2,
+								ID:             2,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 3,
+								ID:             3,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 						}, nil
 					},
@@ -655,7 +687,8 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 				err: nil,
 				labels: []*influxdb.Label{
 					{
-						ID: 3,
+						ID:             3,
+						OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 					},
 				},
 			},
@@ -667,13 +700,16 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 					FindResourceLabelsFn: func(ctx context.Context, f influxdb.LabelMappingFilter) ([]*influxdb.Label, error) {
 						return []*influxdb.Label{
 							{
-								ID: 1,
+								ID:             1,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 2,
+								ID:             2,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 3,
+								ID:             3,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 						}, nil
 					},
@@ -705,13 +741,16 @@ func TestLabelService_FindResourceLabels(t *testing.T) {
 					FindResourceLabelsFn: func(ctx context.Context, f influxdb.LabelMappingFilter) ([]*influxdb.Label, error) {
 						return []*influxdb.Label{
 							{
-								ID: 1,
+								ID:             1,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 2,
+								ID:             2,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 							{
-								ID: 3,
+								ID:             3,
+								OrganizationID: influxdbtesting.MustIDBase16(orgOneID),
 							},
 						}, nil
 					},

--- a/authorizer/label_test.go
+++ b/authorizer/label_test.go
@@ -14,6 +14,10 @@ import (
 	influxdbtesting "github.com/influxdata/influxdb/testing"
 )
 
+const (
+	orgOneID = "020f755c3c083000"
+)
+
 var labelCmpOptions = cmp.Options{
 	cmp.Comparer(func(x, y []byte) bool {
 		return bytes.Equal(x, y)
@@ -483,9 +487,10 @@ func TestLabelService_CreateLabel(t *testing.T) {
 			},
 			args: args{
 				permission: influxdb.Permission{
-					Action: "write",
+					Action: "read",
 					Resource: influxdb.Resource{
-						Type: influxdb.LabelsResourceType,
+						ID:   influxdbtesting.IDPtr(influxdbtesting.MustIDBase16(orgOneID)),
+						Type: influxdb.OrgsResourceType,
 					},
 				},
 			},
@@ -512,7 +517,7 @@ func TestLabelService_CreateLabel(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:labels is unauthorized",
+					Msg:  "read:orgs/020f755c3c083000 is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -526,7 +531,7 @@ func TestLabelService_CreateLabel(t *testing.T) {
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
 
-			err := s.CreateLabel(ctx, &influxdb.Label{Name: "name"})
+			err := s.CreateLabel(ctx, &influxdb.Label{Name: "name", OrganizationID: influxdbtesting.MustIDBase16(orgOneID)})
 			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
 		})
 	}

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -78,9 +78,16 @@ func (b postLabelRequest) Validate() error {
 			Msg:  "label requires a name",
 		}
 	}
+	if !b.Label.OrganizationID.Valid() {
+		return &platform.Error{
+			Code: platform.EInvalid,
+			Msg:  "label requires a valid orgID",
+		}
+	}
 	return nil
 }
 
+// TODO(jm): ensure that the specified org actually exists
 func decodePostLabelRequest(ctx context.Context, r *http.Request) (*postLabelRequest, error) {
 	l := &platform.Label{}
 	if err := json.NewDecoder(r.Body).Decode(l); err != nil {

--- a/http/label_test.go
+++ b/http/label_test.go
@@ -282,7 +282,8 @@ func TestService_handlePostLabel(t *testing.T) {
 			},
 			args: args{
 				label: &platform.Label{
-					Name: "mylabel",
+					Name:           "mylabel",
+					OrganizationID: platformtesting.MustIDBase16("020f755c3c082008"),
 				},
 			},
 			wants: wants{
@@ -295,7 +296,8 @@ func TestService_handlePostLabel(t *testing.T) {
   },
   "label": {
     "id": "020f755c3c082000",
-    "name": "mylabel"
+    "name": "mylabel",
+		"orgID": "020f755c3c082008"
   }
 }
 `,

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1638,7 +1638,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Label"
+                $ref: "#/components/schemas/LabelCreateRequest"
       responses:
         '201':
           description: Added label
@@ -7692,6 +7692,22 @@ components:
       properties:
         id:
           readOnly: true
+          type: string
+        orgID:
+          readOnly: true
+          type: string
+        name:
+          type: string
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+          description: Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
+          example: {"color": "ffb3b3", "description": "this is a description"}
+    LabelCreateRequest:
+      type: object
+      properties:
+        orgID:
           type: string
         name:
           type: string

--- a/label.go
+++ b/label.go
@@ -47,9 +47,10 @@ type LabelService interface {
 
 // Label is a tag set on a resource, typically used for filtering on a UI.
 type Label struct {
-	ID         ID                `json:"id,omitempty"`
-	Name       string            `json:"name"`
-	Properties map[string]string `json:"properties,omitempty"`
+	ID             ID                `json:"id,omitempty"`
+	OrganizationID ID                `json:"orgID,omitempty"`
+	Name           string            `json:"name"`
+	Properties     map[string]string `json:"properties,omitempty"`
 }
 
 // Validate returns an error if the label is invalid.
@@ -58,6 +59,13 @@ func (l *Label) Validate() error {
 		return &Error{
 			Code: EInvalid,
 			Msg:  "label name is required",
+		}
+	}
+
+	if l.OrganizationID == 0 {
+		return &Error{
+			Code: EInvalid,
+			Msg:  "organization ID is required",
 		}
 	}
 
@@ -105,7 +113,8 @@ type LabelUpdate struct {
 
 // LabelFilter represents a set of filters that restrict the returned results.
 type LabelFilter struct {
-	Name string
+	Name  string
+	OrgID *ID
 }
 
 // LabelMappingFilter represents a set of filters that restrict the returned results.

--- a/label.go
+++ b/label.go
@@ -62,7 +62,7 @@ func (l *Label) Validate() error {
 		}
 	}
 
-	if l.OrganizationID == 0 {
+	if !l.OrganizationID.Valid() {
 		return &Error{
 			Code: EInvalid,
 			Msg:  "organization ID is required",

--- a/label_test.go
+++ b/label_test.go
@@ -3,13 +3,19 @@ package influxdb_test
 import (
 	"testing"
 
+	"github.com/influxdata/influxdb"
 	platform "github.com/influxdata/influxdb"
+	influxtest "github.com/influxdata/influxdb/testing"
+)
+
+const (
+	orgOneID = "020f755c3c083000"
 )
 
 func TestLabelValidate(t *testing.T) {
 	type fields struct {
-		ResourceID platform.ID
-		Name       string
+		Name  string
+		OrgID influxdb.ID
 	}
 	tests := []struct {
 		name    string
@@ -19,19 +25,30 @@ func TestLabelValidate(t *testing.T) {
 		{
 			name: "valid label",
 			fields: fields{
-				Name: "iot",
+				Name:  "iot",
+				OrgID: influxtest.MustIDBase16(orgOneID),
 			},
 		},
 		{
-			name:    "label requires a name",
-			fields:  fields{},
+			name: "label requires a name",
+			fields: fields{
+				OrgID: influxtest.MustIDBase16(orgOneID),
+			},
+			wantErr: true,
+		},
+		{
+			name: "label requires an organization ID",
+			fields: fields{
+				Name: "iot",
+			},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := platform.Label{
-				Name: tt.fields.Name,
+				Name:           tt.fields.Name,
+				OrganizationID: tt.fields.OrgID,
 			}
 			if err := m.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("Label.Validate() error = %v, wantErr %v", err, tt.wantErr)

--- a/testing/label_service.go
+++ b/testing/label_service.go
@@ -345,8 +345,9 @@ func UpdateLabel(
 			fields: LabelFields{
 				Labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 					},
 				},
 			},
@@ -359,8 +360,9 @@ func UpdateLabel(
 			wants: wants{
 				labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "NotTag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "NotTag1",
 					},
 				},
 			},
@@ -370,8 +372,9 @@ func UpdateLabel(
 			fields: LabelFields{
 				Labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 					},
 				},
 			},
@@ -386,8 +389,9 @@ func UpdateLabel(
 			wants: wants{
 				labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -400,8 +404,9 @@ func UpdateLabel(
 			fields: LabelFields{
 				Labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 						Properties: map[string]string{
 							"color":       "fff000",
 							"description": "description",
@@ -420,8 +425,9 @@ func UpdateLabel(
 			wants: wants{
 				labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 						Properties: map[string]string{
 							"color":       "abc123",
 							"description": "description",
@@ -435,8 +441,9 @@ func UpdateLabel(
 			fields: LabelFields{
 				Labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 						Properties: map[string]string{
 							"color":       "fff000",
 							"description": "description",
@@ -455,8 +462,9 @@ func UpdateLabel(
 			wants: wants{
 				labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 						Properties: map[string]string{
 							"color": "fff000",
 						},
@@ -530,12 +538,14 @@ func DeleteLabel(
 			fields: LabelFields{
 				Labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 					},
 					{
-						ID:   MustIDBase16(labelTwoID),
-						Name: "Tag2",
+						ID:             MustIDBase16(labelTwoID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag2",
 					},
 				},
 			},
@@ -545,8 +555,9 @@ func DeleteLabel(
 			wants: wants{
 				labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelTwoID),
-						Name: "Tag2",
+						ID:             MustIDBase16(labelTwoID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag2",
 					},
 				},
 			},
@@ -556,8 +567,9 @@ func DeleteLabel(
 			fields: LabelFields{
 				Labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 					},
 				},
 			},
@@ -567,8 +579,9 @@ func DeleteLabel(
 			wants: wants{
 				labels: []*influxdb.Label{
 					{
-						ID:   MustIDBase16(labelOneID),
-						Name: "Tag1",
+						ID:             MustIDBase16(labelOneID),
+						OrganizationID: MustIDBase16(orgOneID),
+						Name:           "Tag1",
 					},
 				},
 				err: &influxdb.Error{


### PR DESCRIPTION
- adds an organization ID to labels
- labels must specify their org on creation; a user can create that label if they have read permissions for that org (is that weird?)
- user resource mappings are created for a newly created label, to allow auth enforcement over non-token session

This is red right now because it breaks some chronograf tests (chronograf needs to be updated include an `orgID` in the label body when posting a new label).