### PR TITLE
fix(task): Fix flakey tests introduced by task updates

### DIFF
--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -348,6 +348,21 @@ func (s *TickScheduler) UpdateTask(task *StoreTask, meta *StoreTaskMeta) error {
 	ts.nextDue = next
 	ts.nextDueMu.Unlock()
 
+	// check the concurrency
+	// todo(lh): In the near future we may not be using the scheduler to manage concurrency.
+	maxC := int(meta.MaxConcurrency)
+	if maxC != len(ts.runners) {
+		if maxC < len(ts.runners) {
+			ts.runners = ts.runners[:maxC]
+		}
+
+		if maxC > len(ts.runners) {
+			delta := maxC - len(ts.runners)
+			for i := 0; i < delta; i++ {
+				ts.runners = append(ts.runners, newRunner(s.ctx, ts.wg, s.logger, task, s.desiredState, s.executor, s.logWriter, ts))
+			}
+		}
+	}
 	if now := atomic.LoadInt64(&s.now); now >= next || hasQueue {
 		ts.Work()
 	}

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -260,7 +260,6 @@ func TestScheduler_Release(t *testing.T) {
 }
 
 func TestScheduler_UpdateTask(t *testing.T) {
-	t.Skip("flaky test: https://github.com/influxdata/influxdb/issues/12667")
 	t.Parallel()
 
 	d := mock.NewDesiredState()


### PR DESCRIPTION
Closes #12667

Task updates now attempt to keep the existing runners working.
This causes the system to be slightly slower after a task update and caused a flakey test.

