### PR TITLE
Update the scrapers and variables empty state to match other org views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 1. [12684](https://github.com/influxdata/influxdb/pull/12684): Fix mismatch in bucket row and header
 1. [12703](https://github.com/influxdata/influxdb/pull/12703): Allows user to edit note on cell
+1. [12764](https://github.com/influxdata/influxdb/pull/12764): Fix empty state styles in scrapers in org view
 
 ### UI Improvements
 

--- a/ui/src/organizations/components/ScraperList.tsx
+++ b/ui/src/organizations/components/ScraperList.tsx
@@ -28,7 +28,7 @@ export default class ScraperList extends PureComponent<Props> {
             <IndexList.HeaderCell columnName="Bucket" width="15%" />
             <IndexList.HeaderCell columnName="" width="15%" />
           </IndexList.Header>
-          <IndexList.Body columnCount={3} emptyState={emptyState}>
+          <IndexList.Body columnCount={4} emptyState={emptyState}>
             {this.scrapersList}
           </IndexList.Body>
         </IndexList>

--- a/ui/src/organizations/components/Scrapers.tsx
+++ b/ui/src/organizations/components/Scrapers.tsx
@@ -164,7 +164,7 @@ class Scrapers extends PureComponent<Props, State> {
 
     if (_.isEmpty(searchTerm)) {
       return (
-        <EmptyState size={ComponentSize.Medium}>
+        <EmptyState size={ComponentSize.Large}>
           <EmptyState.Text
             text={`${orgName} does not own any Scrapers , why not create one?`}
             highlightWords={['Scrapers']}
@@ -175,7 +175,7 @@ class Scrapers extends PureComponent<Props, State> {
     }
 
     return (
-      <EmptyState size={ComponentSize.Medium}>
+      <EmptyState size={ComponentSize.Large}>
         <EmptyState.Text text="No Scrapers match your query" />
       </EmptyState>
     )

--- a/ui/src/organizations/components/Variables.tsx
+++ b/ui/src/organizations/components/Variables.tsx
@@ -131,7 +131,6 @@ class Variables extends PureComponent<Props, State> {
             highlightWords={['Variables']}
           />
           <Button
-            size={ComponentSize.Medium}
             text="Create Variable"
             icon={IconFont.Plus}
             color={ComponentColor.Primary}

--- a/ui/src/organizations/components/__snapshots__/Scrapers.test.tsx.snap
+++ b/ui/src/organizations/components/__snapshots__/Scrapers.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`ScraperList rendering renders 1`] = `
       />
     </IndexListHeader>
     <IndexListBody
-      columnCount={3}
+      columnCount={4}
       emptyState={<React.Fragment />}
     >
       <ScraperRow


### PR DESCRIPTION
Closes #12659

_Briefly describe your proposed changes:_
Updates the grey box in the scrapers empty state to be the full width
Larger scrapers empty state text
Update variables create button to be smaller

![Screen Shot 2019-03-19 at 4 39 00 PM](https://user-images.githubusercontent.com/5751863/54648979-8c72d900-4a65-11e9-885f-92a0e4d5e9ac.png)

![Screen Shot 2019-03-19 at 4 39 44 PM](https://user-images.githubusercontent.com/5751863/54648999-a2809980-4a65-11e9-917e-84c6337e936c.png)



  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
