### PR TITLE
fix(query/stdlib/influxdb): return error on point explosion

### DIFF
--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -589,6 +589,9 @@ func writeTable(t *ToTransformation, tbl flux.Table) error {
 			}
 		}
 		points, err = tsdb.ExplodePoints(*orgID, *bucketID, points)
+		if err != nil {
+			return err
+		}
 		return d.PointsWriter.WritePoints(context.TODO(), points)
 	})
 }


### PR DESCRIPTION
Should return the error if != nil.
I don't know if there is a valid reason not to do it, but I spent a lot of time wondering why `to` was not writing without knowing it was erroring.

_Briefly describe your proposed changes:_

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
