### PR TITLE
fix(ui/labels): filter out hidden label tokens

### DIFF
--- a/ui/src/configuration/components/Labels.tsx
+++ b/ui/src/configuration/components/Labels.tsx
@@ -18,15 +18,15 @@ import FilterList from 'src/shared/components/Filter'
 // Actions
 import {createLabel, updateLabel, deleteLabel} from 'src/labels/actions'
 
+// Selectors
+import {viewableLabels} from 'src/labels/selectors'
+
 // Utils
 import {validateLabelUniqueness} from 'src/configuration/utils/labels'
 
 // Types
 import {AppState} from 'src/types/v2'
 import {ILabel} from '@influxdata/influx'
-
-// Constants
-import {TOKEN_LABEL} from 'src/labels/constants'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -169,10 +169,8 @@ class Labels extends PureComponent<Props, State> {
 }
 
 const mstp = (state: AppState): StateProps => {
-  const labels = state.labels.list.filter(l => l.name !== TOKEN_LABEL)
-
   return {
-    labels,
+    labels: viewableLabels(state.labels.list),
   }
 }
 

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -15,6 +15,9 @@ import {
 } from 'src/dashboards/actions'
 import {createLabel as createLabelAsync} from 'src/labels/actions'
 
+// Selectors
+import {viewableLabels} from 'src/labels/selectors'
+
 // Types
 import {Organization} from 'src/types/v2'
 import {ILabel} from '@influxdata/influx'
@@ -183,7 +186,7 @@ class DashboardCard extends PureComponent<Props> {
 
 const mstp = ({labels, orgs}: AppState): StateProps => {
   return {
-    labels: labels.list,
+    labels: viewableLabels(labels.list),
     orgs,
   }
 }

--- a/ui/src/labels/constants/index.ts
+++ b/ui/src/labels/constants/index.ts
@@ -1,1 +1,2 @@
-export const TOKEN_LABEL = '@influxdata.token'
+export const INFLUX_LABEL_PREFIX = '@influxdata'
+export const TOKEN_LABEL = `${INFLUX_LABEL_PREFIX}.token`

--- a/ui/src/labels/selectors/index.ts
+++ b/ui/src/labels/selectors/index.ts
@@ -1,0 +1,5 @@
+import {ILabel} from '@influxdata/influx'
+import {TOKEN_LABEL} from 'src/labels/constants'
+
+export const viewableLabels = (labels: ILabel[]) =>
+  labels.filter(l => l.name !== TOKEN_LABEL)

--- a/ui/src/labels/selectors/index.ts
+++ b/ui/src/labels/selectors/index.ts
@@ -1,5 +1,5 @@
 import {ILabel} from '@influxdata/influx'
-import {TOKEN_LABEL} from 'src/labels/constants'
+import {INFLUX_LABEL_PREFIX} from 'src/labels/constants'
 
 export const viewableLabels = (labels: ILabel[]) =>
-  labels.filter(l => l.name !== TOKEN_LABEL)
+  labels.filter(l => !l.name.startsWith(INFLUX_LABEL_PREFIX))

--- a/ui/src/organizations/components/CollectorRow.tsx
+++ b/ui/src/organizations/components/CollectorRow.tsx
@@ -19,6 +19,9 @@ import {Telegraf} from '@influxdata/influx'
 import EditableName from 'src/shared/components/EditableName'
 import EditableDescription from 'src/shared/components/editable_description/EditableDescription'
 
+// Selectors
+import {viewableLabels} from 'src/labels/selectors'
+
 // Constants
 import {DEFAULT_COLLECTOR_NAME} from 'src/dashboards/constants'
 
@@ -118,8 +121,8 @@ class CollectorRow extends PureComponent<Props> {
   }
 }
 
-const mstp = ({labels: {list}}: AppState): StateProps => {
-  return {labels: list}
+const mstp = ({labels}: AppState): StateProps => {
+  return {labels: viewableLabels(labels.list)}
 }
 
 export default connect<StateProps, {}, OwnProps>(

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -12,6 +12,9 @@ import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 import {addTaskLabelsAsync, removeTaskLabelsAsync} from 'src/tasks/actions/v2'
 import {createLabel as createLabelAsync} from 'src/labels/actions'
 
+// Selectors
+import {viewableLabels} from 'src/labels/selectors'
+
 // Types
 import {ComponentColor} from '@influxdata/clockface'
 import {ITask as Task, ILabel} from '@influxdata/influx'
@@ -209,7 +212,7 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
 
 const mstp = ({labels}: AppState): StateProps => {
   return {
-    labels: labels.list,
+    labels: viewableLabels(labels.list),
   }
 }
 


### PR DESCRIPTION
Closes #12783 

_Briefly describe your proposed changes:_
Removes `LABEL_TOKEN` from the list of labels used for inline label suggestion.

![Screen Shot 2019-03-20 at 2 04 43 PM](https://user-images.githubusercontent.com/4994741/54708465-ce5d5700-4b19-11e9-971c-e2b98a54f7fe.png)

![Screen Shot 2019-03-20 at 2 05 26 PM](https://user-images.githubusercontent.com/4994741/54708543-fb116e80-4b19-11e9-883f-e55bef6128fc.png)

![Screen Shot 2019-03-20 at 2 05 39 PM](https://user-images.githubusercontent.com/4994741/54708560-ffd62280-4b19-11e9-8361-04f0f7f05437.png)

![Screen Shot 2019-03-20 at 2 05 47 PM](https://user-images.githubusercontent.com/4994741/54708602-1bd9c400-4b1a-11e9-8a52-ee97c8c43560.png)

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
