### PR TITLE
fix(ui): Stop hiding horizontal scrollbar in flux raw data view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 1. [12764](https://github.com/influxdata/influxdb/pull/12764): Fix empty state styles in scrapers in org view
 1. [12790](https://github.com/influxdata/influxdb/pull/12790): Fix bucket creation error when changing rentention rules types.
 1. [12793](https://github.com/influxdata/influxdb/pull/12793): Fix task creation error when switching schedule types.
+1. [12805](https://github.com/influxdata/influxdb/pull/12805): Fix hidden horizonal scrollbars in flux raw data view
 
 ### UI Improvements
 

--- a/ui/src/clockface/components/overlays/Overlay.scss
+++ b/ui/src/clockface/components/overlays/Overlay.scss
@@ -48,7 +48,7 @@ $overlay--container-padding: $ix-marg-c + $ix-marg-d;
     pointer-events: all;
   }
 
-  .fancy-scroll--track-h {
+  & > .fancy-scroll--track-h {
     display: none;
   }
 }


### PR DESCRIPTION
Closes #12719

_Briefly describe your proposed changes:_
Make the style that hides the horizontal scroll in overlays more specific. It should only hide it for the direct children, not any children.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
