### PR TITLE
test(launcher): test for query memory limits and launcher test helpers

### DIFF
--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -1,0 +1,381 @@
+package launcher
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	nethttp "net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/lang"
+	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/bolt"
+	"github.com/influxdata/influxdb/http"
+	"github.com/influxdata/influxdb/query"
+)
+
+// TestLauncher is a test wrapper for launcher.Launcher.
+type TestLauncher struct {
+	*Launcher
+
+	// Root temporary directory for all data.
+	Path string
+
+	// Initialized after calling the Setup() helper.
+	User   *platform.User
+	Org    *platform.Organization
+	Bucket *platform.Bucket
+	Auth   *platform.Authorization
+
+	// Standard in/out/err buffers.
+	Stdin  bytes.Buffer
+	Stdout bytes.Buffer
+	Stderr bytes.Buffer
+}
+
+// NewTestLauncher returns a new instance of TestLauncher.
+func NewTestLauncher() *TestLauncher {
+	l := &TestLauncher{Launcher: NewLauncher()}
+	l.Launcher.Stdin = &l.Stdin
+	l.Launcher.Stdout = &l.Stdout
+	l.Launcher.Stderr = &l.Stderr
+	if testing.Verbose() {
+		l.Launcher.Stdout = io.MultiWriter(l.Launcher.Stdout, os.Stdout)
+		l.Launcher.Stderr = io.MultiWriter(l.Launcher.Stderr, os.Stderr)
+	}
+
+	path, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+	l.Path = path
+	return l
+}
+
+// RunLauncherOrFail initializes and starts the server.
+func RunTestLauncherOrFail(tb testing.TB, ctx context.Context, args ...string) *TestLauncher {
+	tb.Helper()
+	l := NewTestLauncher()
+	if err := l.Run(ctx, args...); err != nil {
+		tb.Fatal(err)
+	}
+	return l
+}
+
+// Run executes the program with additional arguments to set paths and ports.
+func (tl *TestLauncher) Run(ctx context.Context, args ...string) error {
+	args = append(args, "--bolt-path", filepath.Join(tl.Path, "influxd.bolt"))
+	args = append(args, "--protos-path", filepath.Join(tl.Path, "protos"))
+	args = append(args, "--engine-path", filepath.Join(tl.Path, "engine"))
+	args = append(args, "--http-bind-address", "127.0.0.1:0")
+	args = append(args, "--log-level", "debug")
+	return tl.Launcher.Run(ctx, args...)
+}
+
+// Shutdown stops the program and cleans up temporary paths.
+func (tl *TestLauncher) Shutdown(ctx context.Context) error {
+	tl.Cancel()
+	tl.Launcher.Shutdown(ctx)
+	return os.RemoveAll(tl.Path)
+}
+
+// ShutdownOrFail stops the program and cleans up temporary paths. Fail on error.
+func (tl *TestLauncher) ShutdownOrFail(tb testing.TB, ctx context.Context) {
+	tb.Helper()
+	if err := tl.Shutdown(ctx); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+// SetupOrFail creates a new user, bucket, org, and auth token. Fail on error.
+func (tl *TestLauncher) SetupOrFail(tb testing.TB) {
+	results := tl.OnBoardOrFail(tb, &platform.OnboardingRequest{
+		User:     "USER",
+		Password: "PASSWORD",
+		Org:      "ORG",
+		Bucket:   "BUCKET",
+	})
+
+	tl.User = results.User
+	tl.Org = results.Org
+	tl.Bucket = results.Bucket
+	tl.Auth = results.Auth
+}
+
+// OnBoardOrFail attempts an on-boarding request or fails on error.
+// The on-boarding status is also reset to allow multiple user/org/buckets to be created.
+func (tl *TestLauncher) OnBoardOrFail(tb testing.TB, req *platform.OnboardingRequest) *platform.OnboardingResults {
+	tb.Helper()
+	res, err := tl.KeyValueService().Generate(context.Background(), req)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	err = tl.KeyValueService().PutOnboardingStatus(context.Background(), false)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	return res
+}
+
+// WriteOrFail attempts a write to the organization and bucket identified by to or fails if there is an error.
+func (tl *TestLauncher) WriteOrFail(tb testing.TB, to *platform.OnboardingResults, data string) {
+	tb.Helper()
+	resp, err := nethttp.DefaultClient.Do(tl.NewHTTPRequestOrFail(tb, "POST", fmt.Sprintf("/api/v2/write?org=%s&bucket=%s", to.Org.ID, to.Bucket.ID), to.Auth.Token, data))
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		tb.Fatal(err)
+	}
+
+	if resp.StatusCode != nethttp.StatusNoContent {
+		tb.Fatalf("unexpected status code: %d, body: %s, headers: %v", resp.StatusCode, body, resp.Header)
+	}
+}
+
+// WriteOrFail attempts a write to the organization and bucket used during setup or fails if there is an error.
+func (tl *TestLauncher) WritePointsOrFail(tb testing.TB, data string) {
+	tb.Helper()
+	resp, err := nethttp.DefaultClient.Do(
+		tl.NewHTTPRequestOrFail(
+			tb,
+			"POST", fmt.Sprintf("/api/v2/write?org=%s&bucket=%s", tl.Org.ID, tl.Bucket.ID),
+			tl.Auth.Token,
+			data))
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		tb.Fatal(err)
+	}
+
+	if resp.StatusCode != nethttp.StatusNoContent {
+		tb.Fatalf("unexpected status code: %d, body: %s, headers: %v", resp.StatusCode, body, resp.Header)
+	}
+}
+
+// MustExecuteQuery executes the provided query panicking if an error is encountered.
+// Callers of MustExecuteQuery must call Done on the returned QueryResults.
+func (tl *TestLauncher) MustExecuteQuery(query string) *QueryResults {
+	results, err := tl.ExecuteQuery(query)
+	if err != nil {
+		panic(err)
+	}
+	return results
+}
+
+// ExecuteQuery executes the provided query against the ith query node.
+// Callers of ExecuteQuery must call Done on the returned QueryResults.
+func (tl *TestLauncher) ExecuteQuery(q string) (*QueryResults, error) {
+	fq, err := tl.QueryController().Query(context.Background(), &query.Request{
+		Authorization:  tl.Auth,
+		OrganizationID: tl.Auth.OrgID,
+		Compiler: lang.FluxCompiler{
+			Query: q,
+		}})
+	if err != nil {
+		return nil, err
+	}
+	if err = fq.Err(); err != nil {
+		return nil, fq.Err()
+	}
+	return &QueryResults{
+		Results: <-fq.Ready(),
+		Query:   fq,
+	}, nil
+}
+
+// QueryAndConsume queries InfluxDB using the request provided. It uses a function to consume the results obtained.
+// It returns the first error encountered when requesting the query, consuming the results, or executing the query.
+func (tl *TestLauncher) QueryAndConsume(ctx context.Context, req *query.Request, fn func(r flux.Result) error) error {
+	res, err := tl.FluxQueryService().Query(ctx, req)
+	if err != nil {
+		return err
+	}
+	// iterate over results to populate res.Err()
+	var gotErr error
+	for res.More() {
+		if err := fn(res.Next()); gotErr == nil {
+			gotErr = err
+		}
+	}
+	if gotErr != nil {
+		return gotErr
+	}
+	return res.Err()
+}
+
+// QueryAndNopConsume does the same as QueryAndConsume but consumes results with a nop function.
+func (tl *TestLauncher) QueryAndNopConsume(ctx context.Context, req *query.Request) error {
+	return tl.QueryAndConsume(ctx, req, func(r flux.Result) error {
+		return r.Tables().Do(func(table flux.Table) error {
+			return nil
+		})
+	})
+}
+
+// FluxQueryOrFail performs a query to the specified organization and returns the results
+// or fails if there is an error.
+func (tl *TestLauncher) FluxQueryOrFail(tb testing.TB, org *platform.Organization, token string, query string) string {
+	tb.Helper()
+
+	b, err := http.SimpleQuery(tl.URL(), query, org.Name, token)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	return string(b)
+}
+
+// MustNewHTTPRequest returns a new nethttp.Request with base URL and auth attached. Fail on error.
+func (tl *TestLauncher) MustNewHTTPRequest(method, rawurl, body string) *nethttp.Request {
+	req, err := nethttp.NewRequest(method, tl.URL()+rawurl, strings.NewReader(body))
+	if err != nil {
+		panic(err)
+	}
+
+	req.Header.Set("Authorization", "Token "+tl.Auth.Token)
+	return req
+}
+
+// MustNewHTTPRequest returns a new nethttp.Request with base URL and auth attached. Fail on error.
+func (tl *TestLauncher) NewHTTPRequestOrFail(tb testing.TB, method, rawurl, token string, body string) *nethttp.Request {
+	tb.Helper()
+	req, err := nethttp.NewRequest(method, tl.URL()+rawurl, strings.NewReader(body))
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	req.Header.Set("Authorization", "Token "+token)
+	return req
+}
+
+// Services
+
+func (tl *TestLauncher) FluxService() *http.FluxService {
+	return &http.FluxService{Addr: tl.URL(), Token: tl.Auth.Token}
+}
+
+func (tl *TestLauncher) FluxQueryService() *http.FluxQueryService {
+	return &http.FluxQueryService{Addr: tl.URL(), Token: tl.Auth.Token}
+}
+
+func (tl *TestLauncher) BucketService() *http.BucketService {
+	return &http.BucketService{Addr: tl.URL(), Token: tl.Auth.Token, OpPrefix: bolt.OpPrefix}
+}
+
+func (tl *TestLauncher) AuthorizationService() *http.AuthorizationService {
+	return &http.AuthorizationService{Addr: tl.URL(), Token: tl.Auth.Token}
+}
+
+func (tl *TestLauncher) TaskService() *http.TaskService {
+	return &http.TaskService{Addr: tl.URL(), Token: tl.Auth.Token}
+}
+
+// QueryResult wraps a single flux.Result with some helper methods.
+type QueryResult struct {
+	t *testing.T
+	q flux.Result
+}
+
+// HasTableWithCols checks if the desired number of tables and columns exist,
+// ignoring any system columns.
+//
+// If the result is not as expected then the testing.T fails.
+func (r *QueryResult) HasTablesWithCols(want []int) {
+	r.t.Helper()
+
+	// _start, _stop, _time, _f
+	systemCols := 4
+	got := []int{}
+	if err := r.q.Tables().Do(func(b flux.Table) error {
+		got = append(got, len(b.Cols())-systemCols)
+		b.Do(func(c flux.ColReader) error { return nil })
+		return nil
+	}); err != nil {
+		r.t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		r.t.Fatalf("got %v, expected %v", got, want)
+	}
+}
+
+// TablesN returns the number of tables for the result.
+func (r *QueryResult) TablesN() int {
+	var total int
+	r.q.Tables().Do(func(b flux.Table) error {
+		total++
+		b.Do(func(c flux.ColReader) error { return nil })
+		return nil
+	})
+	return total
+}
+
+// QueryResults wraps a set of query results with some helper methods.
+type QueryResults struct {
+	Results map[string]flux.Result
+	Query   flux.Query
+}
+
+func (r *QueryResults) Done() {
+	r.Query.Done()
+}
+
+// First returns the first QueryResult. When there are not exactly 1 table First
+// will fail.
+func (r *QueryResults) First(t *testing.T) *QueryResult {
+	r.HasTableCount(t, 1)
+	for _, result := range r.Results {
+		return &QueryResult{t: t, q: result}
+	}
+	return nil
+}
+
+// HasTableCount asserts that there are n tables in the result.
+func (r *QueryResults) HasTableCount(t *testing.T, n int) {
+	if got, exp := len(r.Results), n; got != exp {
+		t.Fatalf("result has %d tables, expected %d. Tables: %s", got, exp, r.Names())
+	}
+}
+
+// Names returns the sorted set of table names for the query results.
+func (r *QueryResults) Names() []string {
+	if len(r.Results) == 0 {
+		return nil
+	}
+	names := make([]string, len(r.Results), 0)
+	for k := range r.Results {
+		names = append(names, k)
+	}
+	return names
+}
+
+// SortedNames returns the sorted set of table names for the query results.
+func (r *QueryResults) SortedNames() []string {
+	names := r.Names()
+	sort.Strings(names)
+	return names
+}

--- a/cmd/influxd/launcher/launcher_test.go
+++ b/cmd/influxd/launcher/launcher_test.go
@@ -1,15 +1,10 @@
 package launcher_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	nethttp "net/http"
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 
 	platform "github.com/influxdata/influxdb"
@@ -22,7 +17,7 @@ import (
 var ctx = context.Background()
 
 func TestLauncher_Setup(t *testing.T) {
-	l := NewLauncher()
+	l := launcher.NewTestLauncher()
 	if err := l.Run(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +45,7 @@ func TestLauncher_Setup(t *testing.T) {
 // This is to mimic chronograf using cookies as sessions
 // rather than authorizations
 func TestLauncher_SetupWithUsers(t *testing.T) {
-	l := RunLauncherOrFail(t, ctx)
+	l := launcher.RunTestLauncherOrFail(t, ctx)
 	l.SetupOrFail(t)
 	defer l.ShutdownOrFail(t, ctx)
 
@@ -143,148 +138,4 @@ func TestLauncher_SetupWithUsers(t *testing.T) {
 	if len(exp.Users) != 2 {
 		t.Fatalf("unexpected 2 users: %#+v", exp)
 	}
-}
-
-// Launcher is a test wrapper for launcher.Launcher.
-type Launcher struct {
-	*launcher.Launcher
-
-	// Root temporary directory for all data.
-	Path string
-
-	// Initialized after calling the Setup() helper.
-	User   *platform.User
-	Org    *platform.Organization
-	Bucket *platform.Bucket
-	Auth   *platform.Authorization
-
-	// Standard in/out/err buffers.
-	Stdin  bytes.Buffer
-	Stdout bytes.Buffer
-	Stderr bytes.Buffer
-}
-
-// NewLauncher returns a new instance of Launcher.
-func NewLauncher() *Launcher {
-	l := &Launcher{Launcher: launcher.NewLauncher()}
-	l.Launcher.Stdin = &l.Stdin
-	l.Launcher.Stdout = &l.Stdout
-	l.Launcher.Stderr = &l.Stderr
-	if testing.Verbose() {
-		l.Launcher.Stdout = io.MultiWriter(l.Launcher.Stdout, os.Stdout)
-		l.Launcher.Stderr = io.MultiWriter(l.Launcher.Stderr, os.Stderr)
-	}
-
-	path, err := ioutil.TempDir("", "")
-	if err != nil {
-		panic(err)
-	}
-	l.Path = path
-	return l
-}
-
-// RunLauncherOrFail initializes and starts the server.
-func RunLauncherOrFail(tb testing.TB, ctx context.Context, args ...string) *Launcher {
-	tb.Helper()
-	l := NewLauncher()
-	if err := l.Run(ctx, args...); err != nil {
-		tb.Fatal(err)
-	}
-	return l
-}
-
-// Run executes the program with additional arguments to set paths and ports.
-func (l *Launcher) Run(ctx context.Context, args ...string) error {
-	args = append(args, "--bolt-path", filepath.Join(l.Path, "influxd.bolt"))
-	args = append(args, "--protos-path", filepath.Join(l.Path, "protos"))
-	args = append(args, "--engine-path", filepath.Join(l.Path, "engine"))
-	args = append(args, "--http-bind-address", "127.0.0.1:0")
-	args = append(args, "--log-level", "debug")
-	return l.Launcher.Run(ctx, args...)
-}
-
-// Shutdown stops the program and cleans up temporary paths.
-func (l *Launcher) Shutdown(ctx context.Context) error {
-	l.Cancel()
-	l.Launcher.Shutdown(ctx)
-	return os.RemoveAll(l.Path)
-}
-
-// ShutdownOrFail stops the program and cleans up temporary paths. Fail on error.
-func (l *Launcher) ShutdownOrFail(tb testing.TB, ctx context.Context) {
-	tb.Helper()
-	if err := l.Shutdown(ctx); err != nil {
-		tb.Fatal(err)
-	}
-}
-
-// SetupOrFail creates a new user, bucket, org, and auth token. Fail on error.
-func (l *Launcher) SetupOrFail(tb testing.TB) {
-	results := l.OnBoardOrFail(tb, &platform.OnboardingRequest{
-		User:     "USER",
-		Password: "PASSWORD",
-		Org:      "ORG",
-		Bucket:   "BUCKET",
-	})
-
-	l.User = results.User
-	l.Org = results.Org
-	l.Bucket = results.Bucket
-	l.Auth = results.Auth
-}
-
-// OnBoardOrFail attempts an on-boarding request or fails on error.
-// The on-boarding status is also reset to allow multiple user/org/buckets to be created.
-func (l *Launcher) OnBoardOrFail(tb testing.TB, req *platform.OnboardingRequest) *platform.OnboardingResults {
-	tb.Helper()
-	res, err := l.KeyValueService().Generate(context.Background(), req)
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	err = l.KeyValueService().PutOnboardingStatus(context.Background(), false)
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	return res
-}
-
-func (l *Launcher) FluxService() *http.FluxService {
-	return &http.FluxService{Addr: l.URL(), Token: l.Auth.Token}
-}
-
-func (l *Launcher) BucketService() *http.BucketService {
-	return &http.BucketService{Addr: l.URL(), Token: l.Auth.Token}
-}
-
-func (l *Launcher) AuthorizationService() *http.AuthorizationService {
-	return &http.AuthorizationService{Addr: l.URL(), Token: l.Auth.Token}
-}
-
-func (l *Launcher) TaskService() *http.TaskService {
-	return &http.TaskService{Addr: l.URL(), Token: l.Auth.Token}
-}
-
-// MustNewHTTPRequest returns a new nethttp.Request with base URL and auth attached. Fail on error.
-func (l *Launcher) MustNewHTTPRequest(method, rawurl, body string) *nethttp.Request {
-	req, err := nethttp.NewRequest(method, l.URL()+rawurl, strings.NewReader(body))
-	if err != nil {
-		panic(err)
-	}
-
-	req.Header.Set("Authorization", "Token "+l.Auth.Token)
-	return req
-}
-
-// MustNewHTTPRequest returns a new nethttp.Request with base URL and auth attached. Fail on error.
-func (l *Launcher) NewHTTPRequestOrFail(tb testing.TB, method, rawurl, token string, body string) *nethttp.Request {
-	tb.Helper()
-	req, err := nethttp.NewRequest(method, l.URL()+rawurl, strings.NewReader(body))
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	req.Header.Set("Authorization", "Token "+token)
-	return req
 }

--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -6,20 +6,19 @@ import (
 	"fmt"
 	"io"
 	nethttp "net/http"
-	"reflect"
-	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/lang"
-	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/cmd/influxd/launcher"
 	phttp "github.com/influxdata/influxdb/http"
 	"github.com/influxdata/influxdb/query"
 )
 
 func TestPipeline_Write_Query_FieldKey(t *testing.T) {
-	be := RunLauncherOrFail(t, ctx)
+	be := launcher.RunTestLauncherOrFail(t, ctx)
 	be.SetupOrFail(t)
 	defer be.ShutdownOrFail(t, ctx)
 
@@ -55,7 +54,7 @@ mem,server=b value=45.2`))
 	// _measurement=cpu,region=west,server=a,_field=v0
 	// _measurement=cpu,region=west,server=b,_field=v0
 	//
-	results := be.MustExecuteQuery(be.Org.ID, rawQ, be.Auth)
+	results := be.MustExecuteQuery(rawQ)
 	defer results.Done()
 	results.First(t).HasTablesWithCols([]int{5, 4, 4})
 }
@@ -64,9 +63,7 @@ mem,server=b value=45.2`))
 // and checks that the queried results contain the expected number of tables
 // and expected number of columns.
 func TestPipeline_WriteV2_Query(t *testing.T) {
-	t.Parallel()
-
-	be := RunLauncherOrFail(t, ctx)
+	be := launcher.RunTestLauncherOrFail(t, ctx)
 	be.SetupOrFail(t)
 	defer be.ShutdownOrFail(t, ctx)
 
@@ -97,127 +94,52 @@ func TestPipeline_WriteV2_Query(t *testing.T) {
 		t.Fatalf("exp status %d; got %d, body: %s", nethttp.StatusNoContent, resp.StatusCode, buf.String())
 	}
 
-	res := be.MustExecuteQuery(
-		be.Org.ID,
-		fmt.Sprintf(`from(bucket:"%s") |> range(start:-5m)`, be.Bucket.Name),
-		be.Auth)
+	res := be.MustExecuteQuery(fmt.Sprintf(`from(bucket:"%s") |> range(start:-5m)`, be.Bucket.Name))
 	defer res.Done()
 	res.HasTableCount(t, 1)
 }
 
-// QueryResult wraps a single flux.Result with some helper methods.
-type QueryResult struct {
-	t *testing.T
-	q flux.Result
-}
+// This test initializes a default launcher; writes some data; queries the data (success);
+// sets memory limits to the same read query; checks that the query fails because limits are exceeded.
+func TestPipeline_QueryMemoryLimits(t *testing.T) {
+	l := launcher.RunTestLauncherOrFail(t, ctx)
+	l.SetupOrFail(t)
+	defer l.ShutdownOrFail(t, ctx)
 
-// HasTableWithCols checks if the desired number of tables and columns exist,
-// ignoring any system columns.
-//
-// If the result is not as expected then the testing.T fails.
-func (r *QueryResult) HasTablesWithCols(want []int) {
-	r.t.Helper()
-
-	// _start, _stop, _time, _f
-	systemCols := 4
-	got := []int{}
-	if err := r.q.Tables().Do(func(b flux.Table) error {
-		got = append(got, len(b.Cols())-systemCols)
-		b.Do(func(c flux.ColReader) error { return nil })
-		return nil
-	}); err != nil {
-		r.t.Fatal(err)
+	// write some points
+	for i := 0; i < 100; i++ {
+		l.WritePointsOrFail(t, fmt.Sprintf(`m,k=v1 f=%di %d`, i*100, time.Now().UnixNano()))
 	}
 
-	if !reflect.DeepEqual(got, want) {
-		r.t.Fatalf("got %v, expected %v", got, want)
-	}
-}
-
-// TablesN returns the number of tables for the result.
-func (r *QueryResult) TablesN() int {
-	var total int
-	r.q.Tables().Do(func(b flux.Table) error {
-		total++
-		b.Do(func(c flux.ColReader) error { return nil })
-		return nil
-	})
-	return total
-}
-
-// MustExecuteQuery executes the provided query panicking if an error is encountered.
-// Callers of MustExecuteQuery must call Done on the returned QueryResults.
-func (p *Launcher) MustExecuteQuery(orgID platform.ID, query string, auth *platform.Authorization) *QueryResults {
-	results, err := p.ExecuteQuery(orgID, query, auth)
+	// compile a from query and get the spec
+	spec, err := flux.Compile(context.Background(), fmt.Sprintf(`from(bucket:"%s") |> range(start:-5m)`, l.Bucket.Name), time.Now())
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	return results
-}
 
-// ExecuteQuery executes the provided query against the ith query node.
-// Callers of ExecuteQuery must call Done on the returned QueryResults.
-func (p *Launcher) ExecuteQuery(orgID platform.ID, q string, auth *platform.Authorization) (*QueryResults, error) {
-	fq, err := p.QueryController().Query(context.Background(), &query.Request{
-		Authorization:  auth,
-		OrganizationID: orgID,
-		Compiler: lang.FluxCompiler{
-			Query: q,
-		}})
-	if err != nil {
-		return nil, err
+	// we expect this request to succeed
+	req := &query.Request{
+		Authorization:  l.Auth,
+		OrganizationID: l.Org.ID,
+		Compiler: lang.SpecCompiler{
+			Spec: spec,
+		},
 	}
-	if err = fq.Err(); err != nil {
-		return nil, fq.Err()
+	if err := l.QueryAndNopConsume(context.Background(), req); err != nil {
+		t.Fatal(err)
 	}
-	return &QueryResults{
-		Results: <-fq.Ready(),
-		Query:   fq,
-	}, nil
-}
 
-// QueryResults wraps a set of query results with some helper methods.
-type QueryResults struct {
-	Results map[string]flux.Result
-	Query   flux.Query
-}
-
-func (r *QueryResults) Done() {
-	r.Query.Done()
-}
-
-// First returns the first QueryResult. When there are not exactly 1 table First
-// will fail.
-func (r *QueryResults) First(t *testing.T) *QueryResult {
-	r.HasTableCount(t, 1)
-	for _, result := range r.Results {
-		return &QueryResult{t: t, q: result}
+	// ok, the first request went well, let's add memory limits:
+	// this query should error.
+	spec.Resources = flux.ResourceManagement{
+		MemoryBytesQuota: 100,
 	}
-	return nil
-}
 
-// HasTableCount asserts that there are n tables in the result.
-func (r *QueryResults) HasTableCount(t *testing.T, n int) {
-	if got, exp := len(r.Results), n; got != exp {
-		t.Fatalf("result has %d tables, expected %d. Tables: %s", got, exp, r.Names())
+	if err := l.QueryAndNopConsume(context.Background(), req); err != nil {
+		if !strings.Contains(err.Error(), "allocation limit reached") {
+			t.Fatalf("query errored with unexpected error: %v", err)
+		}
+	} else {
+		t.Fatal("expected error, got successful query execution")
 	}
-}
-
-// Names returns the sorted set of table names for the query results.
-func (r *QueryResults) Names() []string {
-	if len(r.Results) == 0 {
-		return nil
-	}
-	names := make([]string, len(r.Results), 0)
-	for k := range r.Results {
-		names = append(names, k)
-	}
-	return names
-}
-
-// SortedNames returns the sorted set of table names for the query results.
-func (r *QueryResults) SortedNames() []string {
-	names := r.Names()
-	sort.Strings(names)
-	return names
 }

--- a/cmd/influxd/launcher/tasks_test.go
+++ b/cmd/influxd/launcher/tasks_test.go
@@ -13,12 +13,13 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/cmd/influxd/launcher"
 	pctx "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/task/backend"
 )
 
 func TestLauncher_Task(t *testing.T) {
-	be := RunLauncherOrFail(t, ctx)
+	be := launcher.RunTestLauncherOrFail(t, ctx)
 	be.SetupOrFail(t)
 	defer be.ShutdownOrFail(t, ctx)
 
@@ -160,7 +161,7 @@ from(bucket:"my_bucket_in") |> range(start:-5m) |> to(bucket:"%s", org:"%s")`, b
 	// Explicitly set the now option so want and got have the same _start and _end values.
 	nowOpt := fmt.Sprintf("option now = () => %s\n", time.Unix(now, 0).UTC().Format(time.RFC3339))
 
-	res := be.MustExecuteQuery(org.ID, nowOpt+`from(bucket:"my_bucket_in") |> range(start:-5m)`, be.Auth)
+	res := be.MustExecuteQuery(nowOpt + `from(bucket:"my_bucket_in") |> range(start:-5m)`)
 	defer res.Done()
 	if len(res.Results) < 1 {
 		t.Fail()
@@ -185,7 +186,7 @@ from(bucket:"my_bucket_in") |> range(start:-5m) |> to(bucket:"%s", org:"%s")`, b
 	for _, w := range want {
 		executetest.NormalizeTables(w)
 	}
-	res = be.MustExecuteQuery(org.ID, nowOpt+`from(bucket:"my_bucket_out") |> range(start:-5m)`, be.Auth)
+	res = be.MustExecuteQuery(nowOpt + `from(bucket:"my_bucket_out") |> range(start:-5m)`)
 	defer res.Done()
 	got := make(map[string][]*executetest.Table)
 	for k, v := range res.Results {

--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -4,11 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"io"
-	"io/ioutil"
-	nethttp "net/http"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -20,9 +15,7 @@ import (
 	"github.com/influxdata/flux/stdlib"
 
 	platform "github.com/influxdata/influxdb"
-	"github.com/influxdata/influxdb/bolt"
 	"github.com/influxdata/influxdb/cmd/influxd/launcher"
-	"github.com/influxdata/influxdb/http"
 	"github.com/influxdata/influxdb/query"
 
 	_ "github.com/influxdata/flux/stdlib"           // Import the built-in functions
@@ -146,7 +139,7 @@ func BenchmarkFluxEndToEnd(b *testing.B) {
 }
 
 func runEndToEnd(t *testing.T, pkgs []*ast.Package) {
-	l := RunMainOrFail(t, ctx)
+	l := launcher.RunTestLauncherOrFail(t, ctx)
 	l.SetupOrFail(t)
 	defer l.ShutdownOrFail(t, ctx)
 	for _, pkg := range pkgs {
@@ -162,7 +155,7 @@ func runEndToEnd(t *testing.T, pkgs []*ast.Package) {
 }
 
 func benchEndToEnd(b *testing.B, pkgs []*ast.Package) {
-	l := RunMainOrFail(b, ctx)
+	l := launcher.RunTestLauncherOrFail(b, ctx)
 	l.SetupOrFail(b)
 	defer l.ShutdownOrFail(b, ctx)
 	for _, pkg := range pkgs {
@@ -202,7 +195,7 @@ func init() {
 	optionsAST = pkg.Files[0]
 }
 
-func testFlux(t testing.TB, l *Launcher, pkg *ast.Package) {
+func testFlux(t testing.TB, l *launcher.TestLauncher, pkg *ast.Package) {
 
 	// Query server to ensure write persists.
 
@@ -244,7 +237,7 @@ func testFlux(t testing.TB, l *Launcher, pkg *ast.Package) {
 		OrganizationID: l.Org.ID,
 		Compiler:       lang.ASTCompiler{AST: pkg},
 	}
-	if r, err := l.FluxService().Query(ctx, req); err != nil {
+	if r, err := l.FluxQueryService().Query(ctx, req); err != nil {
 		t.Fatal(err)
 	} else {
 		for r.More() {
@@ -263,7 +256,7 @@ func testFlux(t testing.TB, l *Launcher, pkg *ast.Package) {
 	// this time we use a call to `run` so that the assertion error is triggered
 	runCalls := stdlib.TestingRunCalls(pkg)
 	pkg.Files[len(pkg.Files)-1] = runCalls
-	r, err := l.FluxService().Query(ctx, req)
+	r, err := l.FluxQueryService().Query(ctx, req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +273,7 @@ func testFlux(t testing.TB, l *Launcher, pkg *ast.Package) {
 		t.Error(err)
 		// Replace the testing.run calls with testing.inspect calls.
 		pkg.Files[len(pkg.Files)-1] = inspectCalls
-		r, err := l.FluxService().Query(ctx, req)
+		r, err := l.FluxQueryService().Query(ctx, req)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -304,119 +297,4 @@ func testFlux(t testing.TB, l *Launcher, pkg *ast.Package) {
 			t.Error(err)
 		}
 	}
-}
-
-// Launcher is a test wrapper for main.Launcher.
-type Launcher struct {
-	*launcher.Launcher
-
-	// Root temporary directory for all data.
-	Path string
-
-	// Initialized after calling the Setup() helper.
-	User   *platform.User
-	Org    *platform.Organization
-	Bucket *platform.Bucket
-	Auth   *platform.Authorization
-
-	// Standard in/out/err buffers.
-	Stdin  bytes.Buffer
-	Stdout bytes.Buffer
-	Stderr bytes.Buffer
-}
-
-// NewLauncher returns a new instance of Launcher.
-func NewLauncher() *Launcher {
-	l := &Launcher{Launcher: launcher.NewLauncher()}
-	l.Launcher.Stdin = &l.Stdin
-	l.Launcher.Stdout = &l.Stdout
-	l.Launcher.Stderr = &l.Stderr
-	if testing.Verbose() {
-		l.Launcher.Stdout = io.MultiWriter(l.Launcher.Stdout, os.Stdout)
-		l.Launcher.Stderr = io.MultiWriter(l.Launcher.Stderr, os.Stderr)
-	}
-
-	path, err := ioutil.TempDir("", "")
-	if err != nil {
-		panic(err)
-	}
-	l.Path = path
-	return l
-}
-
-// RunMainOrFail initializes and starts the server.
-func RunMainOrFail(tb testing.TB, ctx context.Context, args ...string) *Launcher {
-	tb.Helper()
-	l := NewLauncher()
-	if err := l.Run(ctx, args...); err != nil {
-		tb.Fatal(err)
-	}
-	return l
-}
-
-// Run executes the program with additional arguments to set paths and ports.
-func (l *Launcher) Run(ctx context.Context, args ...string) error {
-	args = append(args, "--bolt-path", filepath.Join(l.Path, "influxd.bolt"))
-	args = append(args, "--protos-path", filepath.Join(l.Path, "protos"))
-	args = append(args, "--engine-path", filepath.Join(l.Path, "engine"))
-	args = append(args, "--http-bind-address", "127.0.0.1:0")
-	args = append(args, "--log-level", "debug")
-	return l.Launcher.Run(ctx, args...)
-}
-
-// Shutdown stops the program and cleans up temporary paths.
-func (l *Launcher) Shutdown(ctx context.Context) error {
-	l.Cancel()
-	l.Launcher.Shutdown(ctx)
-	return os.RemoveAll(l.Path)
-}
-
-// ShutdownOrFail stops the program and cleans up temporary paths. Fail on error.
-func (l *Launcher) ShutdownOrFail(tb testing.TB, ctx context.Context) {
-	tb.Helper()
-	if err := l.Shutdown(ctx); err != nil {
-		tb.Fatal(err)
-	}
-}
-
-// SetupOrFail creates a new user, bucket, org, and auth token. Fail on error.
-func (l *Launcher) SetupOrFail(tb testing.TB) {
-	svc := &http.SetupService{Addr: l.URL()}
-	results, err := svc.Generate(ctx, &platform.OnboardingRequest{
-		User:     "USER",
-		Password: "PASSWORD",
-		Org:      "ORG",
-		Bucket:   "BUCKET",
-	})
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	l.User = results.User
-	l.Org = results.Org
-	l.Bucket = results.Bucket
-	l.Auth = results.Auth
-}
-
-func (l *Launcher) FluxService() *http.FluxQueryService {
-	return &http.FluxQueryService{Addr: l.URL(), Token: l.Auth.Token}
-}
-
-func (l *Launcher) BucketService() *http.BucketService {
-	return &http.BucketService{
-		Addr:     l.URL(),
-		Token:    l.Auth.Token,
-		OpPrefix: bolt.OpPrefix,
-	}
-}
-
-// MustNewHTTPRequest returns a new nethttp.Request with base URL and auth attached. Fail on error.
-func (l *Launcher) MustNewHTTPRequest(method, rawurl, body string) *nethttp.Request {
-	req, err := nethttp.NewRequest(method, l.URL()+rawurl, strings.NewReader(body))
-	if err != nil {
-		panic(err)
-	}
-
-	req.Header.Set("Authorization", "Token "+l.Auth.Token)
-	return req
 }


### PR DESCRIPTION
InfluxDB's counterpart of https://github.com/influxdata/idpe/issues/2900

This PR adds a launcher test for query memory limits and helpers for launcher tests.  
It also refactors tests that use the launcher.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
