### PR TITLE
Update task servicetest to move dependency to the new TaskControlService

### DIFF
--- a/http/task_test.go
+++ b/http/task_test.go
@@ -55,11 +55,9 @@ func httpTaskServiceFactory(t *testing.T) (*servicetest.System, context.CancelFu
 		server.Close()
 	}()
 
-	tsFunc := func() platform.TaskService {
-		return http.TaskService{
-			Addr:  server.URL,
-			Token: auth.Token,
-		}
+	taskService := http.TaskService{
+		Addr:  server.URL,
+		Token: auth.Token,
 	}
 
 	cFunc := func() (servicetest.TestCreds, error) {
@@ -73,13 +71,11 @@ func httpTaskServiceFactory(t *testing.T) (*servicetest.System, context.CancelFu
 	}
 
 	return &servicetest.System{
-		S:               store,
-		LR:              rrw,
-		LW:              rrw,
-		I:               i,
-		Ctx:             ctx,
-		TaskServiceFunc: tsFunc,
-		CredsFunc:       cFunc,
+		TaskControlService: servicetest.TaskControlAdaptor(store, rrw, rrw),
+		TaskService:        taskService,
+		Ctx:                ctx,
+		I:                  i,
+		CredsFunc:          cFunc,
 	}, cancel
 }
 

--- a/task/backend/task.go
+++ b/task/backend/task.go
@@ -21,7 +21,7 @@ type TaskControlService interface {
 
 	// NextDueRun returns the Unix timestamp of when the next call to CreateNextRun will be ready.
 	// The returned timestamp reflects the task's offset, so it does not necessarily exactly match the schedule time.
-	NextDueRun() (int64, error)
+	NextDueRun(ctx context.Context, taskID influxdb.ID) (int64, error)
 
 	// UpdateRunState sets the run state at the respective time.
 	UpdateRunState(ctx context.Context, taskID, runID influxdb.ID, when time.Time, state RunStatus) error

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -1,5 +1,5 @@
 // Package servicetest provides tests to ensure that implementations of
-// platform/task/backend.Store and platform/task/backend.LogReader meet the requirements of platform.TaskService.
+// platform/task/backend.Store and platform/task/backend.LogReader meet the requirements of influxdb.TaskService.
 //
 // Consumers of this package must import query/builtin.
 // This package does not import it directly, to avoid requiring it too early.
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/pkg/pointer"
@@ -37,17 +37,109 @@ func init() {
 // If creating the System fails, the implementer should call t.Fatal.
 type BackendComponentFactory func(t *testing.T) (*System, context.CancelFunc)
 
+// UsePlatformAdaptor allows you to set the platform adaptor as your TaskService.
+func UsePlatformAdaptor(s backend.Store, lr backend.LogReader, rc task.RunController, i *inmem.Service) influxdb.TaskService {
+	return task.PlatformAdapter(s, lr, rc, i, i, i)
+}
+
+// TaskControlAdaptor creates a TaskControlService for the older TaskStore system.
+func TaskControlAdaptor(s backend.Store, lw backend.LogWriter, lr backend.LogReader) backend.TaskControlService {
+	return &taskControlAdaptor{s, lw, lr}
+}
+
+// taskControlAdaptor adapts a backend.Store and log readers and writers to implement the task control service.
+type taskControlAdaptor struct {
+	s  backend.Store
+	lw backend.LogWriter
+	lr backend.LogReader
+}
+
+func (tcs *taskControlAdaptor) CreateNextRun(ctx context.Context, taskID influxdb.ID, now int64) (backend.RunCreation, error) {
+	return tcs.s.CreateNextRun(ctx, taskID, now)
+}
+func (tcs *taskControlAdaptor) FinishRun(ctx context.Context, taskID, runID influxdb.ID) (*influxdb.Run, error) {
+	// the tests arent looking for a returned Run because the old system didn't return one
+	// Once we completely switch over to the new system we can look at the returned run in the tests.
+	return nil, tcs.s.FinishRun(ctx, taskID, runID)
+}
+func (tcs *taskControlAdaptor) NextDueRun(ctx context.Context, taskID influxdb.ID) (int64, error) {
+	_, m, err := tcs.s.FindTaskByIDWithMeta(ctx, taskID)
+	if err != nil {
+		return 0, err
+	}
+	return m.NextDueRun()
+}
+func (tcs *taskControlAdaptor) UpdateRunState(ctx context.Context, taskID, runID influxdb.ID, when time.Time, state backend.RunStatus) error {
+	st, m, err := tcs.s.FindTaskByIDWithMeta(ctx, taskID)
+	if err != nil {
+		return err
+	}
+	var (
+		schedFor, reqAt time.Time
+	)
+	// check the log store
+	r, err := tcs.lr.FindRunByID(ctx, st.Org, runID)
+	if err == nil {
+		schedFor, _ = time.Parse(time.RFC3339, r.ScheduledFor)
+		reqAt, _ = time.Parse(time.RFC3339, r.RequestedAt)
+	}
+
+	// in the old system the log store may not have the run until after the first
+	// state update, so we will need to pull the currently running.
+	tt := time.Time{}
+	if schedFor == tt {
+		for _, cr := range m.CurrentlyRunning {
+			if influxdb.ID(cr.RunID) == runID {
+				schedFor = time.Unix(cr.Now, 0)
+				reqAt = time.Unix(cr.RequestedAt, 0)
+			}
+		}
+
+	}
+
+	// Update the run state to Started; normally the scheduler would do this.
+	rlb := backend.RunLogBase{
+		Task:            st,
+		RunID:           runID,
+		RunScheduledFor: schedFor.Unix(),
+		RequestedAt:     reqAt.Unix(),
+	}
+
+	if err := tcs.lw.UpdateRunState(ctx, rlb, when, state); err != nil {
+		return err
+	}
+	return nil
+}
+func (tcs *taskControlAdaptor) AddRunLog(ctx context.Context, taskID, runID influxdb.ID, when time.Time, log string) error {
+	st, err := tcs.s.FindTaskByID(ctx, taskID)
+	if err != nil {
+		return err
+	}
+
+	r, err := tcs.lr.FindRunByID(ctx, st.Org, runID)
+	if err != nil {
+		return err
+	}
+	schFor, _ := time.Parse(time.RFC3339, r.ScheduledFor)
+	reqAt, _ := time.Parse(time.RFC3339, r.RequestedAt)
+
+	// Update the run state to Started; normally the scheduler would do this.
+	rlb := backend.RunLogBase{
+		Task:            st,
+		RunID:           runID,
+		RunScheduledFor: schFor.Unix(),
+		RequestedAt:     reqAt.Unix(),
+	}
+
+	return tcs.lw.AddRunLog(ctx, rlb, when, log)
+}
+
 // TestTaskService should be called by consumers of the servicetest package.
-// This will call fn once to create a single platform.TaskService
+// This will call fn once to create a single influxdb.TaskService
 // used across all subtests in TestTaskService.
 func TestTaskService(t *testing.T, fn BackendComponentFactory) {
 	sys, cancel := fn(t)
 	defer cancel()
-	if sys.TaskServiceFunc == nil {
-		sys.ts = task.PlatformAdapter(sys.S, sys.LR, sys.Sch, sys.I, sys.I, sys.I)
-	} else {
-		sys.ts = sys.TaskServiceFunc()
-	}
 
 	t.Run("TaskService", func(t *testing.T) {
 		// We're running the subtests in parallel, but if we don't use this wrapper,
@@ -88,13 +180,13 @@ func TestTaskService(t *testing.T, fn BackendComponentFactory) {
 
 // TestCreds encapsulates credentials needed for a system to properly work with tasks.
 type TestCreds struct {
-	OrgID, UserID, AuthorizationID platform.ID
+	OrgID, UserID, AuthorizationID influxdb.ID
 	Org                            string
 	Token                          string
 }
 
-func (tc TestCreds) Authorizer() platform.Authorizer {
-	return &platform.Authorization{
+func (tc TestCreds) Authorizer() influxdb.Authorizer {
+	return &influxdb.Authorization{
 		ID:     tc.AuthorizationID,
 		OrgID:  tc.OrgID,
 		UserID: tc.UserID,
@@ -102,13 +194,10 @@ func (tc TestCreds) Authorizer() platform.Authorizer {
 	}
 }
 
-// System, as in "system under test", encapsulates the required parts of a platform.TaskAdapter
+// System, as in "system under test", encapsulates the required parts of a influxdb.TaskAdapter
 // (the underlying Store, LogReader, and LogWriter) for low-level operations.
 type System struct {
-	S   backend.Store
-	LR  backend.LogReader
-	LW  backend.LogWriter
-	Sch backend.Scheduler
+	TaskControlService backend.TaskControlService
 
 	// Used in the Creds function to create valid organizations, users, tokens, etc.
 	I *inmem.Service
@@ -117,9 +206,8 @@ type System struct {
 	// will clean up after themselves.
 	Ctx context.Context
 
-	// Override for how to create a TaskService.
-	// Most callers should leave this nil, in which case the tests will call task.PlatformAdapter.
-	TaskServiceFunc func() platform.TaskService
+	// TaskService is the task service we would like to test
+	TaskService influxdb.TaskService
 
 	// Override for accessing credentials for an individual test.
 	// Callers can leave this nil and the test will create its own random IDs for each test.
@@ -127,10 +215,6 @@ type System struct {
 	// the caller should set this value and return valid IDs and a valid token.
 	// It is safe if this returns the same values every time it is called.
 	CredsFunc func() (TestCreds, error)
-
-	// Underlying task service, initialized inside TestTaskService,
-	// either by instantiating a PlatformAdapter directly or by calling TaskServiceFunc.
-	ts platform.TaskService
 }
 
 func testTaskCRUD(t *testing.T, sys *System) {
@@ -138,7 +222,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	authzID := cr.AuthorizationID
 
 	// Create a task.
-	tc := platform.TaskCreate{
+	tc := influxdb.TaskCreate{
 		OrganizationID: cr.OrgID,
 		Flux:           fmt.Sprintf(scriptFmt, 0),
 		Token:          cr.Token,
@@ -146,7 +230,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 
 	authorizedCtx := icontext.SetAuthorizer(sys.Ctx, cr.Authorizer())
 
-	tsk, err := sys.ts.CreateTask(authorizedCtx, tc)
+	tsk, err := sys.TaskService.CreateTask(authorizedCtx, tc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +238,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		t.Fatal("no task ID set")
 	}
 
-	findTask := func(tasks []*platform.Task, id platform.ID) *platform.Task {
+	findTask := func(tasks []*influxdb.Task, id influxdb.ID) *influxdb.Task {
 		for _, t := range tasks {
 			if t.ID == id {
 				return t
@@ -166,25 +250,25 @@ func testTaskCRUD(t *testing.T, sys *System) {
 
 	// Look up a task the different ways we can.
 	// Map of method name to found task.
-	found := map[string]*platform.Task{
+	found := map[string]*influxdb.Task{
 		"Created": tsk,
 	}
 
 	// Find by ID should return the right task.
-	f, err := sys.ts.FindTaskByID(sys.Ctx, tsk.ID)
+	f, err := sys.TaskService.FindTaskByID(sys.Ctx, tsk.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	found["FindTaskByID"] = f
 
-	fs, _, err := sys.ts.FindTasks(sys.Ctx, platform.TaskFilter{OrganizationID: &cr.OrgID})
+	fs, _, err := sys.TaskService.FindTasks(sys.Ctx, influxdb.TaskFilter{OrganizationID: &cr.OrgID})
 	if err != nil {
 		t.Fatal(err)
 	}
 	f = findTask(fs, tsk.ID)
 	found["FindTasks with Organization filter"] = f
 
-	fs, _, err = sys.ts.FindTasks(sys.Ctx, platform.TaskFilter{User: &cr.UserID})
+	fs, _, err = sys.TaskService.FindTasks(sys.Ctx, influxdb.TaskFilter{User: &cr.UserID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +305,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	// Update task: script only.
 	newFlux := fmt.Sprintf(scriptFmt, 99)
 	origID := f.ID
-	f, err = sys.ts.UpdateTask(authorizedCtx, origID, platform.TaskUpdate{Flux: &newFlux})
+	f, err = sys.TaskService.UpdateTask(authorizedCtx, origID, influxdb.TaskUpdate{Flux: &newFlux})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +322,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 
 	// Update task: status only.
 	newStatus := string(backend.TaskInactive)
-	f, err = sys.ts.UpdateTask(authorizedCtx, origID, platform.TaskUpdate{Status: &newStatus})
+	f, err = sys.TaskService.UpdateTask(authorizedCtx, origID, influxdb.TaskUpdate{Status: &newStatus})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +336,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	// Update task: reactivate status and update script.
 	newStatus = string(backend.TaskActive)
 	newFlux = fmt.Sprintf(scriptFmt, 98)
-	f, err = sys.ts.UpdateTask(authorizedCtx, origID, platform.TaskUpdate{Flux: &newFlux, Status: &newStatus})
+	f, err = sys.TaskService.UpdateTask(authorizedCtx, origID, influxdb.TaskUpdate{Flux: &newFlux, Status: &newStatus})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +350,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	// Update task: just update an option.
 	newStatus = string(backend.TaskActive)
 	newFlux = "import \"http\"\n\noption task = {\n\tname: \"task-changed #98\",\n\tcron: \"* * * * *\",\n\toffset: 5s,\n\tconcurrency: 100,\n}\n\nfrom(bucket: \"b\")\n\t|> http.to(url: \"http://example.com\")"
-	f, err = sys.ts.UpdateTask(authorizedCtx, origID, platform.TaskUpdate{Options: options.Options{Name: "task-changed #98"}})
+	f, err = sys.TaskService.UpdateTask(authorizedCtx, origID, influxdb.TaskUpdate{Options: options.Options{Name: "task-changed #98"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +365,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	// Update task: switch to every.
 	newStatus = string(backend.TaskActive)
 	newFlux = "import \"http\"\n\noption task = {\n\tname: \"task-changed #98\",\n\tevery: 30000000000ns,\n\toffset: 5s,\n\tconcurrency: 100,\n}\n\nfrom(bucket: \"b\")\n\t|> http.to(url: \"http://example.com\")"
-	f, err = sys.ts.UpdateTask(authorizedCtx, origID, platform.TaskUpdate{Options: options.Options{Every: 30 * time.Second}})
+	f, err = sys.TaskService.UpdateTask(authorizedCtx, origID, influxdb.TaskUpdate{Options: options.Options{Every: 30 * time.Second}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +380,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	// Update task: just cron.
 	newStatus = string(backend.TaskActive)
 	newFlux = fmt.Sprintf(scriptDifferentName, 98)
-	f, err = sys.ts.UpdateTask(authorizedCtx, origID, platform.TaskUpdate{Options: options.Options{Cron: "* * * * *"}})
+	f, err = sys.TaskService.UpdateTask(authorizedCtx, origID, influxdb.TaskUpdate{Options: options.Options{Cron: "* * * * *"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,12 +394,12 @@ func testTaskCRUD(t *testing.T, sys *System) {
 
 	// Update task: use a new token on the context and modify some other option.
 	// Ensure the authorization doesn't change -- it did change at one time, which was bug https://github.com/influxdata/influxdb/issues/12218.
-	newAuthz := &platform.Authorization{OrgID: cr.OrgID, UserID: cr.UserID, Permissions: platform.OperPermissions()}
+	newAuthz := &influxdb.Authorization{OrgID: cr.OrgID, UserID: cr.UserID, Permissions: influxdb.OperPermissions()}
 	if err := sys.I.CreateAuthorization(sys.Ctx, newAuthz); err != nil {
 		t.Fatal(err)
 	}
 	newAuthorizedCtx := icontext.SetAuthorizer(sys.Ctx, newAuthz)
-	f, err = sys.ts.UpdateTask(newAuthorizedCtx, origID, platform.TaskUpdate{Options: options.Options{Name: "foo"}})
+	f, err = sys.TaskService.UpdateTask(newAuthorizedCtx, origID, influxdb.TaskUpdate{Options: options.Options{Name: "foo"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +411,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	}
 
 	// Now actually update to use the new token, from the original authorization context.
-	f, err = sys.ts.UpdateTask(authorizedCtx, origID, platform.TaskUpdate{Token: newAuthz.Token})
+	f, err = sys.TaskService.UpdateTask(authorizedCtx, origID, influxdb.TaskUpdate{Token: newAuthz.Token})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,12 +420,12 @@ func testTaskCRUD(t *testing.T, sys *System) {
 	}
 
 	// Delete task.
-	if err := sys.ts.DeleteTask(sys.Ctx, origID); err != nil {
+	if err := sys.TaskService.DeleteTask(sys.Ctx, origID); err != nil {
 		t.Fatal(err)
 	}
 
 	// Task should not be returned.
-	if _, err := sys.ts.FindTaskByID(sys.Ctx, origID); err != backend.ErrTaskNotFound {
+	if _, err := sys.TaskService.FindTaskByID(sys.Ctx, origID); err != backend.ErrTaskNotFound {
 		t.Fatalf("expected %v, got %v", backend.ErrTaskNotFound, err)
 	}
 }
@@ -372,21 +456,21 @@ from(bucket: "b")
 
 	cr := creds(t, sys)
 
-	ct := platform.TaskCreate{
+	ct := influxdb.TaskCreate{
 		OrganizationID: cr.OrgID,
 		Flux:           script,
 		Token:          cr.Token,
 	}
 	authorizedCtx := icontext.SetAuthorizer(sys.Ctx, cr.Authorizer())
-	task, err := sys.ts.CreateTask(authorizedCtx, ct)
+	task, err := sys.TaskService.CreateTask(authorizedCtx, ct)
 	if err != nil {
 		t.Fatal(err)
 	}
-	f, err := sys.ts.UpdateTask(authorizedCtx, task.ID, platform.TaskUpdate{Options: options.Options{Offset: pointer.Duration(0), Every: 10 * time.Second}})
+	f, err := sys.TaskService.UpdateTask(authorizedCtx, task.ID, influxdb.TaskUpdate{Options: options.Options{Offset: pointer.Duration(0), Every: 10 * time.Second}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	savedTask, err := sys.ts.FindTaskByID(sys.Ctx, f.ID)
+	savedTask, err := sys.TaskService.FindTaskByID(sys.Ctx, f.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,18 +484,18 @@ func testMetaUpdate(t *testing.T, sys *System) {
 	cr := creds(t, sys)
 
 	now := time.Now()
-	ct := platform.TaskCreate{
+	ct := influxdb.TaskCreate{
 		OrganizationID: cr.OrgID,
 		Flux:           fmt.Sprintf(scriptFmt, 0),
 		Token:          cr.Token,
 	}
 	authorizedCtx := icontext.SetAuthorizer(sys.Ctx, cr.Authorizer())
-	task, err := sys.ts.CreateTask(authorizedCtx, ct)
+	task, err := sys.TaskService.CreateTask(authorizedCtx, ct)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	st, err := sys.ts.FindTaskByID(sys.Ctx, task.ID)
+	st, err := sys.TaskService.FindTaskByID(sys.Ctx, task.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,16 +524,16 @@ func testMetaUpdate(t *testing.T, sys *System) {
 
 	requestedAtUnix := time.Now().Add(5 * time.Minute).UTC().Unix()
 
-	rc, err := sys.S.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
+	rc, err := sys.TaskControlService.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := sys.S.FinishRun(sys.Ctx, task.ID, rc.Created.RunID); err != nil {
+	if _, err := sys.TaskControlService.FinishRun(sys.Ctx, task.ID, rc.Created.RunID); err != nil {
 		t.Fatal(err)
 	}
 
-	st2, err := sys.ts.FindTaskByID(sys.Ctx, task.ID)
+	st2, err := sys.TaskService.FindTaskByID(sys.Ctx, task.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -460,7 +544,7 @@ func testMetaUpdate(t *testing.T, sys *System) {
 
 	now = time.Now()
 	flux := fmt.Sprintf(scriptFmt, 1)
-	task, err = sys.ts.UpdateTask(authorizedCtx, task.ID, platform.TaskUpdate{Flux: &flux})
+	task, err = sys.TaskService.UpdateTask(authorizedCtx, task.ID, influxdb.TaskUpdate{Flux: &flux})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,7 +562,7 @@ func testMetaUpdate(t *testing.T, sys *System) {
 		t.Fatalf("updatedAt not accurate, expected %s to be between %s and %s", ua, earliestUA, latestUA)
 	}
 
-	st, err = sys.ts.FindTaskByID(sys.Ctx, task.ID)
+	st, err = sys.TaskService.FindTaskByID(sys.Ctx, task.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -501,23 +585,19 @@ func testTaskRuns(t *testing.T, sys *System) {
 
 		// Script is set to run every minute. The platform adapter is currently hardcoded to schedule after "now",
 		// which makes timing of runs somewhat difficult.
-		ct := platform.TaskCreate{
+		ct := influxdb.TaskCreate{
 			OrganizationID: cr.OrgID,
 			Flux:           fmt.Sprintf(scriptFmt, 0),
 			Token:          cr.Token,
 		}
-		task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
-		if err != nil {
-			t.Fatal(err)
-		}
-		st, err := sys.S.FindTaskByID(sys.Ctx, task.ID)
+		task, err := sys.TaskService.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		requestedAtUnix := time.Now().Add(5 * time.Minute).UTC().Unix() // This should guarantee we can make two runs.
 
-		rc0, err := sys.S.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
+		rc0, err := sys.TaskControlService.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -528,44 +608,32 @@ func testTaskRuns(t *testing.T, sys *System) {
 		startedAt := time.Now().UTC()
 
 		// Update the run state to Started; normally the scheduler would do this.
-		rlb0 := backend.RunLogBase{
-			Task:            st,
-			RunID:           rc0.Created.RunID,
-			RunScheduledFor: rc0.Created.Now,
-			RequestedAt:     requestedAtUnix,
-		}
-		if err := sys.LW.UpdateRunState(sys.Ctx, rlb0, startedAt, backend.RunStarted); err != nil {
+		if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc0.Created.RunID, startedAt, backend.RunStarted); err != nil {
 			t.Fatal(err)
 		}
 
-		rc1, err := sys.S.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
+		rc1, err := sys.TaskControlService.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if rc1.Created.TaskID != task.ID {
-			t.Fatalf("wrong task ID on created task: got %s, want %s", rc1.Created.TaskID, task.ID)
+			t.Fatalf("wrong task ID on created task run: got %s, want %s", rc1.Created.TaskID, task.ID)
 		}
 
 		// Update the run state to Started; normally the scheduler would do this.
-		rlb1 := backend.RunLogBase{
-			Task:            st,
-			RunID:           rc1.Created.RunID,
-			RunScheduledFor: rc1.Created.Now,
-			RequestedAt:     requestedAtUnix,
-		}
-		if err := sys.LW.UpdateRunState(sys.Ctx, rlb1, startedAt, backend.RunStarted); err != nil {
+		if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc1.Created.RunID, startedAt, backend.RunStarted); err != nil {
 			t.Fatal(err)
 		}
 		// Mark the second run finished.
-		if err := sys.S.FinishRun(sys.Ctx, task.ID, rlb1.RunID); err != nil {
+		if _, err := sys.TaskControlService.FinishRun(sys.Ctx, task.ID, rc1.Created.RunID); err != nil {
 			t.Fatal(err)
 		}
-		if err := sys.LW.UpdateRunState(sys.Ctx, rlb1, startedAt.Add(time.Second), backend.RunSuccess); err != nil {
+		if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc1.Created.RunID, startedAt.Add(time.Second), backend.RunSuccess); err != nil {
 			t.Fatal(err)
 		}
 
 		// Limit 1 should only return the earlier run.
-		runs, _, err := sys.ts.FindRuns(sys.Ctx, platform.RunFilter{Task: task.ID, Limit: 1})
+		runs, _, err := sys.TaskService.FindRuns(sys.Ctx, influxdb.RunFilter{Task: task.ID, Limit: 1})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -586,7 +654,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 		}
 
 		// Unspecified limit returns both runs.
-		runs, _, err = sys.ts.FindRuns(sys.Ctx, platform.RunFilter{Task: task.ID})
+		runs, _, err = sys.TaskService.FindRuns(sys.Ctx, influxdb.RunFilter{Task: task.ID})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -620,18 +688,18 @@ func testTaskRuns(t *testing.T, sys *System) {
 		}
 
 		// Look for a run that doesn't exist.
-		_, err = sys.ts.FindRunByID(sys.Ctx, task.ID, platform.ID(math.MaxUint64))
+		_, err = sys.TaskService.FindRunByID(sys.Ctx, task.ID, influxdb.ID(math.MaxUint64))
 		if err == nil {
 			t.Fatalf("expected %s but got %s instead", backend.ErrRunNotFound, err)
 		}
 
 		// look for a taskID that doesn't exist.
-		_, err = sys.ts.FindRunByID(sys.Ctx, platform.ID(math.MaxUint64), runs[0].ID)
+		_, err = sys.TaskService.FindRunByID(sys.Ctx, influxdb.ID(math.MaxUint64), runs[0].ID)
 		if err == nil {
 			t.Fatalf("expected %s but got %s instead", backend.ErrRunNotFound, err)
 		}
 
-		foundRun0, err := sys.ts.FindRunByID(sys.Ctx, task.ID, runs[0].ID)
+		foundRun0, err := sys.TaskService.FindRunByID(sys.Ctx, task.ID, runs[0].ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -640,7 +708,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 			t.Fatalf("difference between listed run and found run: %s", diff)
 		}
 
-		foundRun1, err := sys.ts.FindRunByID(sys.Ctx, task.ID, runs[1].ID)
+		foundRun1, err := sys.TaskService.FindRunByID(sys.Ctx, task.ID, runs[1].ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -654,29 +722,24 @@ func testTaskRuns(t *testing.T, sys *System) {
 
 		// Script is set to run every minute. The platform adapter is currently hardcoded to schedule after "now",
 		// which makes timing of runs somewhat difficult.
-		ct := platform.TaskCreate{
+		ct := influxdb.TaskCreate{
 			OrganizationID: cr.OrgID,
 			Flux:           fmt.Sprintf(scriptFmt, 0),
 			Token:          cr.Token,
 		}
-		task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
+		task, err := sys.TaskService.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
 		if err != nil {
 			t.Fatal(err)
 		}
-		st, err := sys.S.FindTaskByID(sys.Ctx, task.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		// Non-existent ID should return the right error.
-		_, err = sys.ts.RetryRun(sys.Ctx, task.ID, platform.ID(math.MaxUint64))
+		_, err = sys.TaskService.RetryRun(sys.Ctx, task.ID, influxdb.ID(math.MaxUint64))
 		if err != backend.ErrRunNotFound {
 			t.Errorf("expected retrying run that doesn't exist to return %v, got %v", backend.ErrRunNotFound, err)
 		}
 
 		requestedAtUnix := time.Now().Add(5 * time.Minute).UTC().Unix() // This should guarantee we can make a run.
 
-		rc, err := sys.S.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
+		rc, err := sys.TaskControlService.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -687,24 +750,18 @@ func testTaskRuns(t *testing.T, sys *System) {
 		startedAt := time.Now().UTC()
 
 		// Update the run state to Started then Failed; normally the scheduler would do this.
-		rlb := backend.RunLogBase{
-			Task:            st,
-			RunID:           rc.Created.RunID,
-			RunScheduledFor: rc.Created.Now,
-			RequestedAt:     requestedAtUnix,
-		}
-		if err := sys.LW.UpdateRunState(sys.Ctx, rlb, startedAt, backend.RunStarted); err != nil {
+		if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc.Created.RunID, startedAt, backend.RunStarted); err != nil {
 			t.Fatal(err)
 		}
-		if err := sys.S.FinishRun(sys.Ctx, task.ID, rlb.RunID); err != nil {
+		if _, err := sys.TaskControlService.FinishRun(sys.Ctx, task.ID, rc.Created.RunID); err != nil {
 			t.Fatal(err)
 		}
-		if err := sys.LW.UpdateRunState(sys.Ctx, rlb, startedAt.Add(time.Second), backend.RunFail); err != nil {
+		if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc.Created.RunID, startedAt.Add(time.Second), backend.RunFail); err != nil {
 			t.Fatal(err)
 		}
 
 		// Now retry the run.
-		m, err := sys.ts.RetryRun(sys.Ctx, task.ID, rlb.RunID)
+		m, err := sys.TaskService.RetryRun(sys.Ctx, task.ID, rc.Created.RunID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -722,27 +779,10 @@ func testTaskRuns(t *testing.T, sys *System) {
 			t.Fatalf("wrong scheduledFor on task: got %s, want %s", m.ScheduledFor, time.Unix(rc.Created.Now, 0).Format(time.RFC3339))
 		}
 
-		// Ensure the retry is added on the store task meta.
-		meta, err := sys.S.FindTaskMetaByID(sys.Ctx, task.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		found := false
-		for _, mr := range meta.ManualRuns {
-			if mr.Start == mr.End && mr.Start == rc.Created.Now {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("didn't find matching manual run after successful RetryRun call; got: %v", meta.ManualRuns)
-		}
-
 		exp := backend.RequestStillQueuedError{Start: rc.Created.Now, End: rc.Created.Now}
 
 		// Retrying a run which has been queued but not started, should be rejected.
-		if _, err = sys.ts.RetryRun(sys.Ctx, task.ID, rlb.RunID); err != exp {
+		if _, err = sys.TaskService.RetryRun(sys.Ctx, task.ID, rc.Created.RunID); err != exp {
 			t.Fatalf("subsequent retry should have been rejected with %v; got %v", exp, err)
 		}
 	})
@@ -750,45 +790,28 @@ func testTaskRuns(t *testing.T, sys *System) {
 	t.Run("ForceRun", func(t *testing.T) {
 		t.Parallel()
 
-		ct := platform.TaskCreate{
+		ct := influxdb.TaskCreate{
 			OrganizationID: cr.OrgID,
 			Flux:           fmt.Sprintf(scriptFmt, 0),
 			Token:          cr.Token,
 		}
-		task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
+		task, err := sys.TaskService.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		beforeForce := time.Now().Unix()
 		const scheduledFor = 77
-		forcedRun, err := sys.ts.ForceRun(sys.Ctx, task.ID, scheduledFor)
-		if err != nil {
-			t.Fatal(err)
-		}
-		afterForce := time.Now().Unix()
-
-		m, err := sys.S.FindTaskMetaByID(sys.Ctx, task.ID)
+		_, err = sys.TaskService.ForceRun(sys.Ctx, task.ID, scheduledFor)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if len(m.ManualRuns) != 1 {
-			t.Fatalf("expected 1 manual run created, got: %#v", m.ManualRuns)
-		}
-
-		if rid := platform.ID(m.ManualRuns[0].RunID); rid != forcedRun.ID {
-			t.Fatalf("expected run ID %s, got %s", forcedRun.ID, rid)
-		}
-
-		if requestedAt := m.ManualRuns[0].RequestedAt; requestedAt < beforeForce || requestedAt > afterForce {
-			t.Fatalf("expected run RequestedAt to be in [%d, %d]; got %d", beforeForce, afterForce, requestedAt)
-		}
+		// TODO(lh): Once we have moved over to kv we can list runs and see the manual queue in the list
 
 		exp := backend.RequestStillQueuedError{Start: scheduledFor, End: scheduledFor}
 
 		// Forcing the same run before it's executed should be rejected.
-		if _, err = sys.ts.ForceRun(sys.Ctx, task.ID, scheduledFor); err != exp {
+		if _, err = sys.TaskService.ForceRun(sys.Ctx, task.ID, scheduledFor); err != exp {
 			t.Fatalf("subsequent force should have been rejected with %v; got %v", exp, err)
 		}
 	})
@@ -796,16 +819,12 @@ func testTaskRuns(t *testing.T, sys *System) {
 	t.Run("FindLogs", func(t *testing.T) {
 		t.Parallel()
 
-		ct := platform.TaskCreate{
+		ct := influxdb.TaskCreate{
 			OrganizationID: cr.OrgID,
 			Flux:           fmt.Sprintf(scriptFmt, 0),
 			Token:          cr.Token,
 		}
-		task, err := sys.ts.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
-		if err != nil {
-			t.Fatal(err)
-		}
-		st, err := sys.S.FindTaskByID(sys.Ctx, task.ID)
+		task, err := sys.TaskService.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -813,42 +832,30 @@ func testTaskRuns(t *testing.T, sys *System) {
 		requestedAtUnix := time.Now().Add(5 * time.Minute).UTC().Unix() // This should guarantee we can make a run.
 
 		// Create two runs.
-		rc1, err := sys.S.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
+		rc1, err := sys.TaskControlService.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
 		if err != nil {
 			t.Fatal(err)
 		}
-		rlb1 := backend.RunLogBase{
-			Task:            st,
-			RunID:           rc1.Created.RunID,
-			RunScheduledFor: rc1.Created.Now,
-			RequestedAt:     requestedAtUnix,
-		}
-		if err := sys.LW.UpdateRunState(sys.Ctx, rlb1, time.Now(), backend.RunStarted); err != nil {
+		if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc1.Created.RunID, time.Now(), backend.RunStarted); err != nil {
 			t.Fatal(err)
 		}
 
-		rc2, err := sys.S.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
+		rc2, err := sys.TaskControlService.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
 		if err != nil {
 			t.Fatal(err)
 		}
-		rlb2 := backend.RunLogBase{
-			Task:            st,
-			RunID:           rc2.Created.RunID,
-			RunScheduledFor: rc2.Created.Now,
-			RequestedAt:     requestedAtUnix,
-		}
-		if err := sys.LW.UpdateRunState(sys.Ctx, rlb2, time.Now(), backend.RunStarted); err != nil {
+		if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc2.Created.RunID, time.Now(), backend.RunStarted); err != nil {
 			t.Fatal(err)
 		}
 
 		// Add a log for the first run.
 		log1Time := time.Now().UTC()
-		if err := sys.LW.AddRunLog(sys.Ctx, rlb1, log1Time, "entry 1"); err != nil {
+		if err := sys.TaskControlService.AddRunLog(sys.Ctx, task.ID, rc1.Created.RunID, log1Time, "entry 1"); err != nil {
 			t.Fatal(err)
 		}
 
 		// Ensure it is returned when filtering logs by run ID.
-		logs, err := sys.LR.ListLogs(sys.Ctx, cr.OrgID, platform.LogFilter{
+		logs, _, err := sys.TaskService.FindLogs(sys.Ctx, influxdb.LogFilter{
 			Task: task.ID,
 			Run:  &rc1.Created.RunID,
 		})
@@ -856,28 +863,28 @@ func testTaskRuns(t *testing.T, sys *System) {
 			t.Fatal(err)
 		}
 
-		expLine1 := platform.Log{Time: log1Time.Format(time.RFC3339Nano), Message: "entry 1"}
-		exp := []platform.Log{expLine1}
+		expLine1 := &influxdb.Log{Time: log1Time.Format(time.RFC3339Nano), Message: "entry 1"}
+		exp := []*influxdb.Log{expLine1}
 		if diff := cmp.Diff(logs, exp); diff != "" {
 			t.Fatalf("unexpected log: -got/+want: %s", diff)
 		}
 
 		// Add a log for the second run.
 		log2Time := time.Now().UTC()
-		if err := sys.LW.AddRunLog(sys.Ctx, rlb2, log2Time, "entry 2"); err != nil {
+		if err := sys.TaskControlService.AddRunLog(sys.Ctx, task.ID, rc2.Created.RunID, log2Time, "entry 2"); err != nil {
 			t.Fatal(err)
 		}
 
 		// Ensure both returned when filtering logs by task ID.
-		logs, err = sys.LR.ListLogs(sys.Ctx, cr.OrgID, platform.LogFilter{
+		logs, _, err = sys.TaskService.FindLogs(sys.Ctx, influxdb.LogFilter{
 			Task: task.ID,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		expLine2 := platform.Log{Time: log2Time.Format(time.RFC3339Nano), Message: "entry 2"}
-		exp = []platform.Log{expLine1, expLine2}
+		expLine2 := &influxdb.Log{Time: log2Time.Format(time.RFC3339Nano), Message: "entry 2"}
+		exp = []*influxdb.Log{expLine1, expLine2}
 		if diff := cmp.Diff(logs, exp); diff != "" {
 			t.Fatalf("unexpected log: -got/+want: %s", diff)
 		}
@@ -888,13 +895,13 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 	cr := creds(t, sys)
 
 	const numTasks = 450 // Arbitrarily chosen to get a reasonable count of concurrent creates and deletes.
-	createTaskCh := make(chan platform.TaskCreate, numTasks)
+	createTaskCh := make(chan influxdb.TaskCreate, numTasks)
 
 	// Since this test is run in parallel with other tests,
 	// we need to keep a whitelist of IDs that are okay to delete.
 	// This only matters when the creds function returns an identical user/org from another test.
 	var idMu sync.Mutex
-	taskIDs := make(map[platform.ID]struct{})
+	taskIDs := make(map[influxdb.ID]struct{})
 
 	var createWg sync.WaitGroup
 	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
@@ -903,7 +910,7 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 			defer createWg.Done()
 			aCtx := icontext.SetAuthorizer(sys.Ctx, cr.Authorizer())
 			for ct := range createTaskCh {
-				task, err := sys.ts.CreateTask(aCtx, ct)
+				task, err := sys.TaskService.CreateTask(aCtx, ct)
 				if err != nil {
 					t.Errorf("error creating task: %v", err)
 					continue
@@ -941,7 +948,7 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 			}
 
 			// Get all the tasks.
-			tasks, _, err := sys.ts.FindTasks(sys.Ctx, platform.TaskFilter{OrganizationID: &cr.OrgID})
+			tasks, _, err := sys.TaskService.FindTasks(sys.Ctx, influxdb.TaskFilter{OrganizationID: &cr.OrgID})
 			if err != nil {
 				t.Errorf("error finding tasks: %v", err)
 				return
@@ -969,7 +976,7 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 				// Task was in whitelist. Delete it from the TaskService.
 				// We could remove it from the taskIDs map, but this test is short-lived enough
 				// that clearing out the map isn't really worth taking the lock again.
-				if err := sys.ts.DeleteTask(sys.Ctx, tsk.ID); err != nil {
+				if err := sys.TaskService.DeleteTask(sys.Ctx, tsk.ID); err != nil {
 					t.Errorf("error deleting task: %v", err)
 					return
 				}
@@ -999,7 +1006,7 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 			}
 
 			// Get all the tasks.
-			tasks, _, err := sys.ts.FindTasks(sys.Ctx, platform.TaskFilter{OrganizationID: &cr.OrgID})
+			tasks, _, err := sys.TaskService.FindTasks(sys.Ctx, influxdb.TaskFilter{OrganizationID: &cr.OrgID})
 			if err != nil {
 				t.Errorf("error finding tasks: %v", err)
 				return
@@ -1018,9 +1025,10 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 			// Create a run for the last task we found.
 			// The script should run every minute, so use max now.
 			tid := tasks[len(tasks)-1].ID
-			if _, err := sys.S.CreateNextRun(sys.Ctx, tid, math.MaxInt64); err != nil {
+			if _, err := sys.TaskControlService.CreateNextRun(sys.Ctx, tid, math.MaxInt64); err != nil {
 				// This may have errored due to the task being deleted. Check if the task still exists.
-				if _, err2 := sys.S.FindTaskByID(sys.Ctx, tid); err2 == backend.ErrTaskNotFound {
+
+				if _, err2 := sys.TaskService.FindTaskByID(sys.Ctx, tid); err2 == backend.ErrTaskNotFound {
 					// It was deleted. Just continue.
 					continue
 				}
@@ -1037,7 +1045,7 @@ func testTaskConcurrency(t *testing.T, sys *System) {
 
 	// Start adding tasks.
 	for i := 0; i < numTasks; i++ {
-		createTaskCh <- platform.TaskCreate{
+		createTaskCh <- influxdb.TaskCreate{
 			OrganizationID: cr.OrgID,
 			Flux:           fmt.Sprintf(scriptFmt, i),
 			Token:          cr.Token,
@@ -1054,28 +1062,28 @@ func creds(t *testing.T, s *System) TestCreds {
 	t.Helper()
 
 	if s.CredsFunc == nil {
-		u := &platform.User{Name: t.Name() + "-user"}
+		u := &influxdb.User{Name: t.Name() + "-user"}
 		if err := s.I.CreateUser(s.Ctx, u); err != nil {
 			t.Fatal(err)
 		}
-		o := &platform.Organization{Name: t.Name() + "-org"}
+		o := &influxdb.Organization{Name: t.Name() + "-org"}
 		if err := s.I.CreateOrganization(s.Ctx, o); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := s.I.CreateUserResourceMapping(s.Ctx, &platform.UserResourceMapping{
-			ResourceType: platform.OrgsResourceType,
+		if err := s.I.CreateUserResourceMapping(s.Ctx, &influxdb.UserResourceMapping{
+			ResourceType: influxdb.OrgsResourceType,
 			ResourceID:   o.ID,
 			UserID:       u.ID,
-			UserType:     platform.Owner,
+			UserType:     influxdb.Owner,
 		}); err != nil {
 			t.Fatal(err)
 		}
 
-		authz := platform.Authorization{
+		authz := influxdb.Authorization{
 			OrgID:       o.ID,
 			UserID:      u.ID,
-			Permissions: platform.OperPermissions(),
+			Permissions: influxdb.OperPermissions(),
 		}
 		if err := s.I.CreateAuthorization(context.Background(), &authz); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
closes #12724

We will now have the capability to write new task services that dont have to implement the backend.Store or LogReader or LogWriters
