### PR TITLE
Improve display of query errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [12791](https://github.com/influxdata/influxdb/pull/12791): Use time range for metaqueries in Data Explorer and Cell Editor Overlay
 1. [12827](https://github.com/influxdata/influxdb/pull/12827): Fix screen tearing bug in Raw Data View
 1. [12843](https://github.com/influxdata/influxdb/pull/12843): Add copy to clipboard button to export overlays
+1. [12826](https://github.com/influxdata/influxdb/pull/12826): Enable copying error messages to the clipboard from dashboard cells
 
 ### Bug Fixes
 

--- a/ui/src/shared/components/EmptyGraphError.scss
+++ b/ui/src/shared/components/EmptyGraphError.scss
@@ -23,4 +23,9 @@
   top: $ix-marg-b;
   right: $ix-marg-b;
   opacity: 0.9;
+  display: none;
+
+  .empty-graph-error:hover & {
+    display: inherit;
+  }
 }

--- a/ui/src/shared/components/EmptyGraphError.scss
+++ b/ui/src/shared/components/EmptyGraphError.scss
@@ -1,0 +1,26 @@
+.empty-graph-error {
+  border-radius: $radius;
+  background: $g2-kevlar;
+  position: relative;
+  color: $c-dreamsicle;
+  border: $ix-border solid $g5-pepper;
+
+  pre {
+    font-size: 14px;
+    padding: $ix-marg-c;
+    user-select: text !important;
+    cursor: text;
+  }
+}
+
+.empty-graph-error--icon {
+  display: inline-block;
+  margin-right: $ix-marg-b;
+}
+
+.empty-graph-error--copy {
+  position: absolute;
+  top: $ix-marg-b;
+  right: $ix-marg-b;
+  opacity: 0.9;
+}

--- a/ui/src/shared/components/EmptyGraphError.tsx
+++ b/ui/src/shared/components/EmptyGraphError.tsx
@@ -1,0 +1,63 @@
+// Libraries
+import React, {useState, FunctionComponent} from 'react'
+import CopyToClipboard from 'react-copy-to-clipboard'
+
+// Components
+import {
+  Button,
+  ComponentSize,
+  ComponentColor,
+  IconFont,
+} from '@influxdata/clockface'
+import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar'
+
+interface Props {
+  message: string
+  testID?: string
+}
+
+const EmptyGraphError: FunctionComponent<Props> = ({message, testID}) => {
+  const [didCopy, setDidCopy] = useState(false)
+
+  const buttonText = didCopy ? 'Copied!' : 'Copy'
+  const buttonColor = didCopy ? ComponentColor.Success : ComponentColor.Default
+
+  const onClick = () => {
+    setDidCopy(true)
+    setTimeout(() => setDidCopy(false), 2000)
+  }
+
+  return (
+    <div className="cell--view-empty" data-testid={testID}>
+      <div className="empty-graph-error">
+        <CopyToClipboard text={message}>
+          <Button
+            size={ComponentSize.ExtraSmall}
+            color={buttonColor}
+            titleText={buttonText}
+            text={buttonText}
+            onClick={onClick}
+            customClass="empty-graph-error--copy"
+          />
+        </CopyToClipboard>
+        <FancyScrollbar
+          className="empty-graph-error--scroll"
+          autoHide={false}
+          thumbStartColor="#FF8564"
+          thumbStopColor="#DC4E58"
+        >
+          <pre>
+            <span
+              className={`icon ${
+                IconFont.AlertTriangle
+              } empty-graph-error--icon`}
+            />
+            <code>{message}</code>
+          </pre>
+        </FancyScrollbar>
+      </div>
+    </div>
+  )
+}
+
+export default EmptyGraphError

--- a/ui/src/shared/components/EmptyQueryView.tsx
+++ b/ui/src/shared/components/EmptyQueryView.tsx
@@ -3,6 +3,7 @@ import React, {PureComponent} from 'react'
 
 // Components
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
+import EmptyGraphError from 'src/shared/components/EmptyGraphError'
 import Markdown from 'src/shared/components/views/Markdown'
 
 // Constants
@@ -43,10 +44,7 @@ export default class EmptyQueryView extends PureComponent<Props> {
 
     if (errorMessage) {
       return (
-        <EmptyGraphMessage
-          message={`Error: ${errorMessage}`}
-          testID="empty-graph--error"
-        />
+        <EmptyGraphError message={errorMessage} testID="empty-graph--error" />
       )
     }
 

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -12,6 +12,7 @@ import {
 // Utils
 import {parseResponse} from 'src/shared/parsing/flux/response'
 import {getActiveOrg} from 'src/organizations/selectors'
+import {checkQueryResult} from 'src/shared/utils/checkQueryResult'
 
 // Types
 import {RemoteDataState, FluxTable} from 'src/types'
@@ -136,6 +137,8 @@ class TimeSeries extends Component<Props, State> {
       const duration = Date.now() - startTime
       const tables = flatten(results.map(r => parseResponse(r.csv)))
       const files = results.map(r => r.csv)
+
+      files.forEach(checkQueryResult)
 
       this.setState({
         tables,

--- a/ui/src/shared/components/cells/Cell.scss
+++ b/ui/src/shared/components/cells/Cell.scss
@@ -42,11 +42,34 @@ $cell--header-size: 36px;
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  align-content: center;
   color: $empty-state-text;
   @extend %no-user-select;
+  padding: 0 $ix-marg-d $ix-marg-d $ix-marg-d;
+  overflow: hidden;
+  
+  .empty-graph-error {
+    position: absolute;
+    top: $ix-marg-c;
+    right: $ix-marg-c;
+    bottom: $ix-marg-c;
+    left: $ix-marg-c;
+  }
+
+  .empty-graph-error--scroll {
+    z-index: 0;
+    position: absolute;
+  }
+
+  .empty-graph-error--copy {
+    z-index: 1;
+  }
+}
+
+.dashboard .cell--view-empty .empty-graph-error {
+    top: $ix-marg-c + $cell--header-size;
 }
 
 .cell--header {

--- a/ui/src/shared/utils/checkQueryResult.test.ts
+++ b/ui/src/shared/utils/checkQueryResult.test.ts
@@ -1,0 +1,28 @@
+import {checkQueryResult} from 'src/shared/utils/checkQueryResult'
+
+describe('checkQueryResult', () => {
+  test('throws an error when the response has an error table', () => {
+    const RESPONSE = `#group,true,true
+#datatype,string,string
+#default,,
+,error,reference
+,"function references unknown column ""_value""",`
+
+    expect(() => {
+      checkQueryResult(RESPONSE)
+    }).toThrow('function references unknown column')
+  })
+
+  test('does not throw an error when the response is valid', () => {
+    const RESPONSE = `#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_measurement,host,_field
+,,0,2019-03-21T18:54:14.113478Z,2019-03-21T19:54:14.113478Z,2019-03-21T18:54:21Z,4780101632,mem,oox4k.local,active
+,,0,2019-03-21T18:54:14.113478Z,2019-03-21T19:54:14.113478Z,2019-03-21T18:54:31Z,5095436288,mem,oox4k.local,active`
+
+    expect(() => {
+      checkQueryResult(RESPONSE)
+    }).not.toThrow()
+  })
+})

--- a/ui/src/shared/utils/checkQueryResult.ts
+++ b/ui/src/shared/utils/checkQueryResult.ts
@@ -1,0 +1,56 @@
+/*
+  Given Flux query response as a CSV, check if the CSV contains an error table
+  as the first result. If it does, throw the error message contained within
+  that table. 
+
+  For example, given the following response:
+
+      #datatype,string,long
+      ,error,reference
+      ,Failed to parse query,897
+
+  we want to throw an error with the message "Failed to parse query".
+
+  See https://github.com/influxdata/flux/blob/master/docs/SPEC.md#errors.
+*/
+export const checkQueryResult = (file: string): void => {
+  // Don't check the whole file, since it could be huge and the error table
+  // will be within the first few lines (if it exists)
+  const fileHead = file.slice(0, findNthIndex(file, '\n', 6))
+
+  const lines = fileHead.split('\n').filter(line => !line.startsWith('#'))
+
+  if (!lines.length || !lines[0].includes('error') || !lines[1]) {
+    return
+  }
+
+  const header = lines[0].split(',').map(s => s.trim())
+  const row = lines[1].split(',').map(s => s.trim())
+  const index = header.indexOf('error')
+
+  if (index === -1 || !row[index]) {
+    return
+  }
+
+  // Trim off extra quotes at start and end of message
+  const errorMessage = row[index].replace(/^"/, '').replace(/"$/, '')
+
+  throw new Error(errorMessage)
+}
+
+const findNthIndex = (s: string, c: string, n: number) => {
+  let count = 0
+  let i = 0
+
+  while (i < s.length) {
+    if (s[i] == c) {
+      count += 1
+    }
+
+    if (count === n) {
+      return i
+    }
+
+    i += 1
+  }
+}

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -105,6 +105,7 @@
 @import 'src/timeMachine/components/view_options/ViewTypeDropdown.scss';
 @import 'src/dataLoaders/components/side_bar/SideBar.scss';
 @import 'src/dataLoaders/components/DataLoadersOverlay.scss';
+@import 'src/shared/components/EmptyGraphError.scss';
 
 // External
 @import '../../node_modules/@influxdata/react-custom-scrollbars/dist/styles.css';

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -13,6 +13,7 @@ import {getActiveOrg} from 'src/organizations/selectors'
 import {getVariableAssignments} from 'src/variables/selectors'
 import {getTimeRangeVars} from 'src/variables/utils/getTimeRangeVars'
 import {filterUnusedVars} from 'src/shared/utils/filterUnusedVars'
+import {checkQueryResult} from 'src/shared/utils/checkQueryResult'
 import {
   getVariablesForOrg,
   getVariable,
@@ -113,8 +114,9 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
     const results = await Promise.all(pendingResults.map(r => r.promise))
 
     const duration = Date.now() - startTime
-
     const files = results.map(r => r.csv)
+
+    files.forEach(checkQueryResult)
 
     dispatch(setQueryResults(RemoteDataState.Done, files, duration))
   } catch (e) {


### PR DESCRIPTION
Closes #12686

![error](https://user-images.githubusercontent.com/638955/54782250-a9311d00-4bdb-11e9-9beb-4bcb14efda71.gif)

<img width="1092" alt="Screen Shot 2019-03-21 at 1 14 21 PM" src="https://user-images.githubusercontent.com/638955/54782266-b0f0c180-4bdb-11e9-8279-f2b4a683deaa.png">

Also tweaks the query execution code to check for [error messages that appear as a Flux table](https://github.com/influxdata/flux/blob/master/docs/SPEC.md#errors). Previously we ignored these errors and attempted to plot the data anyway.

