### PR TITLE
fix(ui/dygraph): guard against undefined dygraph

### DIFF
--- a/ui/src/shared/components/dygraph/Dygraph.tsx
+++ b/ui/src/shared/components/dygraph/Dygraph.tsx
@@ -165,7 +165,7 @@ class Dygraph extends Component<Props, State> {
         {legendData && (
           <Legend {...legendData} seriesDescriptions={seriesDescriptions} />
         )}
-        {!!hoverTime && (
+        {!!hoverTime && !!this.dygraph && (
           <HoverTimeMarker x={this.dygraph.toDomXCoord(hoverTime)} />
         )}
         {this.nestedGraph}


### PR DESCRIPTION
Closes #12658 

_Briefly describe your proposed changes:_
Dygraph could render and be `undefined` causing hoverTime conversion to `toDomXCoord` to fail. This update ensures dygraph is defined in the constructor and appends dygraph once the graph container is mounted.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
