### PR TITLE
feat(ui/telegrafs): add inline labels to telegraf rows

### DIFF
--- a/ui/src/configuration/components/Telegrafs.tsx
+++ b/ui/src/configuration/components/Telegrafs.tsx
@@ -41,7 +41,7 @@ import {deleteAuthorization} from 'src/authorizations/actions'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Telegraf, Bucket, Organization} from '@influxdata/influx'
+import {ITelegraf as Telegraf, Bucket, Organization} from '@influxdata/influx'
 import {OverlayState} from 'src/types'
 import {DataLoaderType} from 'src/types/v2/dataLoaders'
 import {AppState} from 'src/types/v2'

--- a/ui/src/organizations/components/CollectorList.tsx
+++ b/ui/src/organizations/components/CollectorList.tsx
@@ -7,7 +7,7 @@ import {IndexList} from 'src/clockface'
 import CollectorRow from 'src/organizations/components/CollectorRow'
 
 // DummyData
-import {Telegraf} from '@influxdata/influx'
+import {ITelegraf as Telegraf} from '@influxdata/influx'
 import {getDeep} from 'src/utils/wrappers'
 
 interface Props {

--- a/ui/src/organizations/components/CollectorRow.tsx
+++ b/ui/src/organizations/components/CollectorRow.tsx
@@ -15,15 +15,24 @@ import {
   Button,
   ComponentColor,
 } from '@influxdata/clockface'
-import {Telegraf} from '@influxdata/influx'
+import {ITelegraf as Telegraf} from '@influxdata/influx'
 import EditableName from 'src/shared/components/EditableName'
 import EditableDescription from 'src/shared/components/editable_description/EditableDescription'
+import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+
+// Actions
+import {
+  addTelelgrafLabelsAsync,
+  removeTelelgrafLabelsAsync,
+} from 'src/telegrafs/actions'
+import {createLabel as createLabelAsync} from 'src/labels/actions'
 
 // Selectors
 import {viewableLabels} from 'src/labels/selectors'
 
 // Constants
 import {DEFAULT_COLLECTOR_NAME} from 'src/dashboards/constants'
+import {TOKEN_LABEL} from 'src/labels/constants'
 
 // Types
 import {AppState} from 'src/types/v2'
@@ -42,8 +51,13 @@ interface OwnProps {
 interface StateProps {
   labels: ILabel[]
 }
+interface DispatchProps {
+  onAddLabels: typeof addTelelgrafLabelsAsync
+  onRemoveLabels: typeof removeTelelgrafLabelsAsync
+  onCreateLabel: typeof createLabelAsync
+}
 
-type Props = OwnProps & StateProps
+type Props = OwnProps & StateProps & DispatchProps
 
 class CollectorRow extends PureComponent<Props> {
   public render() {
@@ -69,6 +83,7 @@ class CollectorRow extends PureComponent<Props> {
                 placeholder={`Describe ${collector.name}`}
                 onUpdate={this.handleUpdateDescription}
               />
+              {this.labels}
             </ComponentSpacer>
           </IndexList.Cell>
           <IndexList.Cell>{bucket}</IndexList.Cell>
@@ -105,6 +120,45 @@ class CollectorRow extends PureComponent<Props> {
     onUpdate({...collector, description})
   }
 
+  private get labels(): JSX.Element {
+    const {collector, labels, onFilterChange} = this.props
+
+    const collectorLabels = collector.labels.filter(
+      l => !l.name.startsWith('@influxdata')
+    )
+
+    return (
+      <InlineLabels
+        selectedLabels={collectorLabels}
+        labels={labels}
+        onFilterChange={onFilterChange}
+        onAddLabel={this.handleAddLabel}
+        onRemoveLabel={this.handleRemoveLabel}
+        onCreateLabel={this.handleCreateLabel}
+      />
+    )
+  }
+
+  private handleAddLabel = (label: ILabel): void => {
+    const {collector, onAddLabels} = this.props
+
+    onAddLabels(collector.id, [label])
+  }
+
+  private handleRemoveLabel = (label: ILabel): void => {
+    const {collector, onRemoveLabels} = this.props
+
+    onRemoveLabels(collector.id, [label])
+  }
+
+  private handleCreateLabel = async (label: ILabel): Promise<void> => {
+    try {
+      await this.props.onCreateLabel(label.orgID, label.name, label.properties)
+    } catch (err) {
+      throw err
+    }
+  }
+
   private handleOpenConfig = (): void => {
     this.props.onOpenTelegrafConfig(
       this.props.collector.id,
@@ -125,7 +179,13 @@ const mstp = ({labels}: AppState): StateProps => {
   return {labels: viewableLabels(labels.list)}
 }
 
-export default connect<StateProps, {}, OwnProps>(
+const mdtp: DispatchProps = {
+  onAddLabels: addTelelgrafLabelsAsync,
+  onRemoveLabels: removeTelelgrafLabelsAsync,
+  onCreateLabel: createLabelAsync,
+}
+
+export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
-  null
+  mdtp
 )(CollectorRow)

--- a/ui/src/organizations/components/CollectorRow.tsx
+++ b/ui/src/organizations/components/CollectorRow.tsx
@@ -32,7 +32,6 @@ import {viewableLabels} from 'src/labels/selectors'
 
 // Constants
 import {DEFAULT_COLLECTOR_NAME} from 'src/dashboards/constants'
-import {TOKEN_LABEL} from 'src/labels/constants'
 
 // Types
 import {AppState} from 'src/types/v2'
@@ -122,10 +121,7 @@ class CollectorRow extends PureComponent<Props> {
 
   private get labels(): JSX.Element {
     const {collector, labels, onFilterChange} = this.props
-
-    const collectorLabels = collector.labels.filter(
-      l => !l.name.startsWith('@influxdata')
-    )
+    const collectorLabels = viewableLabels(collector.labels)
 
     return (
       <InlineLabels
@@ -153,7 +149,8 @@ class CollectorRow extends PureComponent<Props> {
 
   private handleCreateLabel = async (label: ILabel): Promise<void> => {
     try {
-      await this.props.onCreateLabel(label.orgID, label.name, label.properties)
+      const {orgID, name, properties} = label
+      await this.props.onCreateLabel(orgID, name, properties)
     } catch (err) {
       throw err
     }

--- a/ui/src/organizations/components/Collectors.tsx
+++ b/ui/src/organizations/components/Collectors.tsx
@@ -30,7 +30,7 @@ import {updateTelegraf, deleteTelegraf} from 'src/telegrafs/actions'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Telegraf, Bucket} from '@influxdata/influx'
+import {ITelegraf as Telegraf, Bucket} from '@influxdata/influx'
 import {OverlayState} from 'src/types'
 import {
   setDataLoadersType,

--- a/ui/src/organizations/containers/OrgTelegrafsIndex.tsx
+++ b/ui/src/organizations/containers/OrgTelegrafsIndex.tsx
@@ -21,7 +21,7 @@ import * as notifyActions from 'src/shared/actions/notifications'
 import {getOrgTelegrafs} from 'src/telegrafs/actions'
 
 // Types
-import {Bucket, Organization, Telegraf} from '@influxdata/influx'
+import {Bucket, Organization, ITelegraf as Telegraf} from '@influxdata/influx'
 import {client} from 'src/utils/api'
 import {RemoteDataState} from 'src/types'
 

--- a/ui/src/shared/copy/v2/notifications.ts
+++ b/ui/src/shared/copy/v2/notifications.ts
@@ -213,6 +213,16 @@ export const telegrafUpdateFailed = (telegrafName: string): Notification => ({
   message: `Failed to update telegraf: "${telegrafName}"`,
 })
 
+export const addTelelgrafLabelFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to add label to telegraf config`,
+})
+
+export const removeTelelgrafLabelFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to remove label from telegraf config`,
+})
+
 export const authorizationsGetFailed = (): Notification => ({
   ...defaultErrorNotification,
   message: 'Failed to get tokens',

--- a/ui/src/telegrafs/actions/index.ts
+++ b/ui/src/telegrafs/actions/index.ts
@@ -3,7 +3,11 @@ import {client} from 'src/utils/api'
 
 // Types
 import {RemoteDataState} from 'src/types'
-import {Telegraf, Organization} from '@influxdata/influx'
+import {
+  ITelegraf as Telegraf,
+  Organization,
+  ILabel as Label,
+} from '@influxdata/influx'
 import {Dispatch} from 'redux-thunk'
 
 // Actions
@@ -14,6 +18,8 @@ import {
   telegrafCreateFailed,
   telegrafUpdateFailed,
   telegrafDeleteFailed,
+  addTelelgrafLabelFailed,
+  removeTelelgrafLabelFailed,
 } from 'src/shared/copy/v2/notifications'
 
 export type Action = SetTelegrafs | AddTelegraf | EditTelegraf | RemoveTelegraf
@@ -132,5 +138,35 @@ export const deleteTelegraf = (id: string, name: string) => async (
   } catch (e) {
     console.error(e)
     dispatch(notify(telegrafDeleteFailed(name)))
+  }
+}
+
+export const addTelelgrafLabelsAsync = (
+  telegrafID: string,
+  labels: Label[]
+) => async (dispatch): Promise<void> => {
+  try {
+    await client.telegrafConfigs.addLabels(telegrafID, labels)
+    const telegraf = await client.telegrafConfigs.get(telegrafID)
+
+    dispatch(editTelegraf(telegraf))
+  } catch (error) {
+    console.error(error)
+    dispatch(addTelelgrafLabelFailed())
+  }
+}
+
+export const removeTelelgrafLabelsAsync = (
+  telegrafID: string,
+  labels: Label[]
+) => async (dispatch): Promise<void> => {
+  try {
+    await client.telegrafConfigs.addLabels(telegrafID, labels)
+    const telegraf = await client.telegrafConfigs.get(telegrafID)
+
+    dispatch(editTelegraf(telegraf))
+  } catch (error) {
+    console.error(error)
+    dispatch(removeTelelgrafLabelFailed())
   }
 }

--- a/ui/src/telegrafs/reducers/index.ts
+++ b/ui/src/telegrafs/reducers/index.ts
@@ -4,7 +4,7 @@ import {produce} from 'immer'
 // Types
 import {RemoteDataState} from 'src/types'
 import {Action} from 'src/telegrafs/actions'
-import {Telegraf} from '@influxdata/influx'
+import {ITelegraf as Telegraf} from '@influxdata/influx'
 
 const initialState = (): TelegrafsState => ({
   status: RemoteDataState.NotStarted,


### PR DESCRIPTION
Closes #11612 

_Briefly describe your proposed changes:_
Add inline labels to the collectors row for labeling Telegraf configs


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
