### PR TITLE
Remove the option to create a template

### DIFF
--- a/ui/src/organizations/components/OrgTemplatesPage.tsx
+++ b/ui/src/organizations/components/OrgTemplatesPage.tsx
@@ -40,7 +40,6 @@ class OrgTemplatesPage extends PureComponent<Props, State> {
     return (
       <>
         <TemplatesHeader
-          onCreateTemplate={onImport}
           onImportTemplate={onImport}
           showOrgDropdown={false}
           isFullPage={false}

--- a/ui/src/templates/components/TemplatesHeader.tsx
+++ b/ui/src/templates/components/TemplatesHeader.tsx
@@ -4,10 +4,9 @@ import {Page} from 'src/pageLayout'
 
 // Components
 import {Tabs, ComponentSpacer, Alignment, Stack} from 'src/clockface'
-import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
+import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
 
 interface Props {
-  onCreateTemplate: () => void
   onImportTemplate: () => void
   showOrgDropdown?: boolean
   isFullPage?: boolean
@@ -24,12 +23,7 @@ export default class TemplatesHeader extends PureComponent<Props> {
   }
 
   public render() {
-    const {
-      onCreateTemplate,
-      onImportTemplate,
-      isFullPage,
-      filterComponent,
-    } = this.props
+    const {isFullPage, filterComponent} = this.props
 
     if (isFullPage) {
       return (
@@ -37,13 +31,7 @@ export default class TemplatesHeader extends PureComponent<Props> {
           <Page.Header.Left>
             <Page.Title title={this.pageTitle} />
           </Page.Header.Left>
-          <Page.Header.Right>
-            <AddResourceDropdown
-              onSelectNew={onCreateTemplate}
-              onSelectImport={onImportTemplate}
-              resourceName="Template"
-            />
-          </Page.Header.Right>
+          <Page.Header.Right>{this.importButton}</Page.Header.Right>
         </Page.Header>
       )
     }
@@ -52,11 +40,7 @@ export default class TemplatesHeader extends PureComponent<Props> {
       <Tabs.TabContentsHeader>
         {filterComponent()}
         <ComponentSpacer align={Alignment.Right} stackChildren={Stack.Columns}>
-          <AddResourceDropdown
-            onSelectNew={onCreateTemplate}
-            onSelectImport={onImportTemplate}
-            resourceName="Template"
-          />
+          {this.importButton}
         </ComponentSpacer>
       </Tabs.TabContentsHeader>
     )
@@ -70,5 +54,16 @@ export default class TemplatesHeader extends PureComponent<Props> {
     }
 
     return ''
+  }
+
+  private get importButton(): JSX.Element {
+    return (
+      <Button
+        text="Import Template"
+        icon={IconFont.Plus}
+        color={ComponentColor.Primary}
+        onClick={this.props.onImportTemplate}
+      />
+    )
   }
 }


### PR DESCRIPTION
Closes #12755

![Screen Shot 2019-03-22 at 2 19 11 PM](https://user-images.githubusercontent.com/5751863/54853607-95ee8200-4cad-11e9-96be-874c0eca2da7.png)


_Briefly describe your proposed changes:_
Rather than having both the option to create and import a template. Remove the option to create a template, so only import remains.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
