### PR TITLE
ensure editor is focused when editing/creating note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### UI Improvements
 
 1. [12782](https://github.com/influxdata/influxdb/pull/12782): Move bucket selection in the query builder to the first card in the list
+1. [12850](https://github.com/influxdata/influxdb/pull/12850): Ensure editor is automatically focused in note editor
 
 ## v2.0.0-alpha.6 [2019-03-15]
 

--- a/ui/src/dashboards/components/NoteEditorText.tsx
+++ b/ui/src/dashboards/components/NoteEditorText.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {Controlled as ReactCodeMirror} from 'react-codemirror2'
+import {Controlled as ReactCodeMirror, IInstance} from 'react-codemirror2'
 
 // Utils
 import {humanizeNote} from 'src/dashboards/utils/notes'
@@ -35,8 +35,13 @@ class NoteEditorText extends PureComponent<Props, {}> {
         options={OPTIONS}
         onBeforeChange={this.handleChange}
         onTouchStart={noOp}
+        editorDidMount={this.handleMount}
       />
     )
+  }
+
+  private handleMount = (instance: IInstance) => {
+    instance.focus()
   }
 
   private handleChange = (_, __, note: string) => {


### PR DESCRIPTION
Closes #12506

_Briefly describe your proposed changes:_
call focus to editor once editor mounts.

![note-focus](https://user-images.githubusercontent.com/5751863/54855279-faf8a680-4cb2-11e9-80b9-fb7397013b99.gif)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
