### PR TITLE
chore(storage): Don't log every read request

### DIFF
--- a/storage/reads/group_resultset.go
+++ b/storage/reads/group_resultset.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"sort"
 
-	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
 	"github.com/influxdata/influxdb/tsdb/cursors"
-	"github.com/opentracing/opentracing-go"
-	"go.uber.org/zap"
 )
 
 type groupResultSet struct {
@@ -113,31 +111,13 @@ func (g *groupResultSet) Next() GroupCursor {
 }
 
 func (g *groupResultSet) sort() (int, error) {
-	log := logger.LoggerFromContext(g.ctx)
-	if log != nil {
-		var f func()
-		log, f = logger.NewOperation(log, "Sort", "group.sort", zap.String("group_type", g.req.Group.String()))
-		defer f()
-	}
-
-	span := opentracing.SpanFromContext(g.ctx)
-	if span != nil {
-		span = opentracing.StartSpan(
-			"group.sort",
-			opentracing.ChildOf(span.Context()),
-			opentracing.Tag{Key: "group_type", Value: g.req.Group.String()})
-		defer span.Finish()
-	}
+	span, _ := tracing.StartSpanFromContext(g.ctx)
+	defer span.Finish()
+	span.LogKV("group_type", g.req.Group.String())
 
 	n, err := g.sortFn(g)
 
-	if span != nil {
-		span.SetTag("rows", n)
-	}
-
-	if log != nil {
-		log.Info("Sort completed", zap.Int("rows", n))
-	}
+	span.LogKV("rows", n)
 
 	return n, err
 }

--- a/storage/reads/group_resultset.go
+++ b/storage/reads/group_resultset.go
@@ -117,7 +117,9 @@ func (g *groupResultSet) sort() (int, error) {
 
 	n, err := g.sortFn(g)
 
-	span.LogKV("rows", n)
+	if err != nil {
+		span.LogKV("rows", n)
+	}
 
 	return n, err
 }


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Every read request gets a little love from `groupResultSet.sort` which creates a massive logging burden at scale. Removed the log altogether because there's a span that's just as useful.

Also reduced the cardinality of the span by converting tags to logs.

Helps https://github.com/influxdata/idpe/issues/2961

  - [x] Rebased/mergeable
  - [ ] Tests pass
