### PR TITLE
chore(ui/templates/api): add create task from template

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -985,9 +985,9 @@
       }
     },
     "@influxdata/influx": {
-      "version": "0.2.49",
-      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.49.tgz",
-      "integrity": "sha512-Gt5mEyokQ/WxrYK1EhmuYSIWvCnG+X83RblmPFaGKZyhoeBk8G1F8lNoH0bWZzVMnMt9RcnvJmWcDq2L2iGpJw==",
+      "version": "0.2.50",
+      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.50.tgz",
+      "integrity": "sha512-M/aHzNBXcp0UKxQDh/bzZKeYe0WFz0TdZ91Bqv3LqH07j73gi5DVpZQDEoXK3Ogy2MAKvjpOMA5+1qZF3HMHRg==",
       "requires": {
         "axios": "^0.18.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -137,7 +137,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "0.0.5",
-    "@influxdata/influx": "0.2.49",
+    "@influxdata/influx": "0.2.50",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",

--- a/ui/src/organizations/actions/orgView.ts
+++ b/ui/src/organizations/actions/orgView.ts
@@ -10,6 +10,7 @@ import {Dashboard} from 'src/types'
 // API
 import {client} from 'src/utils/api'
 import {getDashboardsByOrgID} from 'src/dashboards/apis/v2/index'
+import {createTaskFromTemplate as createTaskFromTemplateAJAX} from 'src/templates/api'
 
 export enum ActionTypes {
   GetTasks = 'GET_TASKS',
@@ -60,5 +61,5 @@ export const createTaskFromTemplate = (
   template: ITaskTemplate,
   orgID: string
 ) => async () => {
-  await client.tasks.createFromTemplate(template, orgID)
+  await createTaskFromTemplateAJAX(template, orgID)
 }

--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -214,7 +214,7 @@ export const createTaskFromTemplate = async (
 
   await createTaskLabelsFromTemplate(template, createdTask)
 
-  const task = await this.get(createdTask.id)
+  const task = await client.tasks.get(createdTask.id)
 
   return task
 }

--- a/ui/src/templates/api/index.ts
+++ b/ui/src/templates/api/index.ts
@@ -59,13 +59,16 @@ const createDashboardLabelsFromTemplate = async (
   template: DashboardTemplate,
   dashboard: IDashboard
 ) => {
-  const templateLabels = await createLabelsFromTemplate(template, dashboard)
+  const templateLabels = await createLabelsFromTemplate(
+    template,
+    dashboard.orgID
+  )
   await client.dashboards.addLabels(dashboard.id, templateLabels)
 }
 
-const createLabelsFromTemplate = async <T extends TemplateBase, R>(
+const createLabelsFromTemplate = async <T extends TemplateBase>(
   template: T,
-  resource: R & {orgID: string}
+  orgID: string
 ) => {
   const {
     content: {data, included},
@@ -86,9 +89,9 @@ const createLabelsFromTemplate = async <T extends TemplateBase, R>(
 
   const labelsToCreate = findLabelsToCreate(existingLabels, labelsIncluded).map(
     l => ({
+      orgID,
       name: _.get(l, 'attributes.name', ''),
       properties: _.get(l, 'attributes.properties', {}),
-      orgID: resource.orgID,
     })
   )
 
@@ -223,6 +226,6 @@ const createTaskLabelsFromTemplate = async (
   template: TaskTemplate,
   task: Task
 ) => {
-  const templateLabels = await createLabelsFromTemplate(template, task)
+  const templateLabels = await createLabelsFromTemplate(template, task.orgID)
   await client.tasks.addLabels(task.id, templateLabels)
 }

--- a/ui/src/types/templates.ts
+++ b/ui/src/types/templates.ts
@@ -21,7 +21,7 @@ interface KeyValuePairs {
 }
 
 // Templates
-interface TemplateBase extends Document {
+export interface TemplateBase extends Document {
   content: {data: TemplateData; included: TemplateIncluded[]}
   labels?: ILabel[]
 }


### PR DESCRIPTION
Closes #12889

_Briefly describe your proposed changes:_
Move `createTaskFromTemplate` from `client` to UI.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
