### PR TITLE
feat(ui): Persist variables control bar preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [12876](https://github.com/influxdata/influxdb/pull/12876): Add the ability to update token's status in Token list
 1. [12821](https://github.com/influxdata/influxdb/pull/12821): Allow variables to be re-ordered within control bar on a dashboard.
 1. [12888](https://github.com/influxdata/influxdb/pull/12888): Add the ability to delete a template
+1. [12901](https://github.com/influxdata/influxdb/pull/12901): Save user preference for variable control bar visibility and default to visible
 
 ### Bug Fixes
 

--- a/ui/src/dashboards/actions/views.ts
+++ b/ui/src/dashboards/actions/views.ts
@@ -9,7 +9,7 @@ import {RemoteDataState} from 'src/types'
 import {Dispatch} from 'redux'
 import {View} from 'src/types'
 
-export type Action = SetViewAction | SetViewsAction
+export type Action = SetViewAction | SetViewsAction | ResetViewsAction
 
 export interface SetViewsAction {
   type: 'SET_VIEWS'
@@ -43,6 +43,14 @@ export const setView = (
 ): SetViewAction => ({
   type: 'SET_VIEW',
   payload: {id, view, status},
+})
+
+export interface ResetViewsAction {
+  type: 'RESET_VIEWS'
+}
+
+export const resetViews = (): ResetViewsAction => ({
+  type: 'RESET_VIEWS',
 })
 
 export const getView = (dashboardID: string, cellID: string) => async (

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -39,7 +39,6 @@ interface Props extends DefaultProps {
   onManualRefresh: () => void
   handleClickPresentationButton: AppActions.DelayEnablePresentationModeDispatcher
   onAddCell: () => void
-  showTemplateControlBar: boolean
   onRenameDashboard: (name: string) => Promise<void>
   toggleVariablesControlBar: () => void
   isShowingVariablesControlBar: boolean

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -37,6 +37,7 @@ import {Location} from 'history'
 import * as AppActions from 'src/types/actions/app'
 import * as ColorsModels from 'src/types/colors'
 import * as NotificationsActions from 'src/types/actions/notifications'
+import {toggleShowVariablesControls} from 'src/userSettings/actions'
 
 interface StateProps {
   links: Links
@@ -45,7 +46,7 @@ interface StateProps {
   dashboard: Dashboard
   autoRefresh: number
   inPresentationMode: boolean
-  showTemplateControlBar: boolean
+  showVariablesControls: boolean
   views: {[cellID: string]: {view: View; status: RemoteDataState}}
 }
 
@@ -64,6 +65,7 @@ interface DispatchProps {
   onCreateCellWithView: typeof dashboardActions.createCellWithView
   onUpdateView: typeof dashboardActions.updateView
   onSetActiveTimeMachine: typeof setActiveTimeMachine
+  onToggleShowVariablesControls: typeof toggleShowVariablesControls
 }
 
 interface PassedProps {
@@ -90,8 +92,6 @@ type Props = PassedProps &
 interface State {
   scrollTop: number
   windowHeight: number
-  isShowingVEO: boolean
-  isShowingVariablesControlBar: boolean
 }
 
 @ErrorHandling
@@ -102,8 +102,6 @@ class DashboardPage extends Component<Props, State> {
     this.state = {
       scrollTop: 0,
       windowHeight: window.innerHeight,
-      isShowingVEO: false,
-      isShowingVariablesControlBar: false,
     }
   }
 
@@ -142,17 +140,17 @@ class DashboardPage extends Component<Props, State> {
     const {
       timeRange,
       zoomedTimeRange,
-      showTemplateControlBar,
       dashboard,
       autoRefresh,
       manualRefresh,
       onManualRefresh,
       inPresentationMode,
+      showVariablesControls,
       handleChooseAutoRefresh,
       handleClickPresentationButton,
+      onToggleShowVariablesControls,
       children,
     } = this.props
-    const {isShowingVariablesControlBar} = this.state
 
     return (
       <Page titleTag={this.pageTitle}>
@@ -168,14 +166,13 @@ class DashboardPage extends Component<Props, State> {
             zoomedTimeRange={zoomedTimeRange}
             onRenameDashboard={this.handleRenameDashboard}
             activeDashboard={dashboard ? dashboard.name : ''}
-            showTemplateControlBar={showTemplateControlBar}
             handleChooseAutoRefresh={handleChooseAutoRefresh}
             handleChooseTimeRange={this.handleChooseTimeRange}
             handleClickPresentationButton={handleClickPresentationButton}
-            toggleVariablesControlBar={this.toggleVariablesControlBar}
-            isShowingVariablesControlBar={isShowingVariablesControlBar}
+            toggleVariablesControlBar={onToggleShowVariablesControls}
+            isShowingVariablesControlBar={showVariablesControls}
           />
-          {isShowingVariablesControlBar && (
+          {showVariablesControls && !!dashboard && (
             <VariablesControlBar dashboardID={dashboard.id} />
           )}
           {!!dashboard && (
@@ -292,12 +289,6 @@ class DashboardPage extends Component<Props, State> {
     this.setState({windowHeight: window.innerHeight})
   }
 
-  private toggleVariablesControlBar = (): void => {
-    this.setState({
-      isShowingVariablesControlBar: !this.state.isShowingVariablesControlBar,
-    })
-  }
-
   private get pageTitle(): string {
     const {dashboard} = this.props
 
@@ -310,11 +301,12 @@ const mstp = (state: AppState, {params: {dashboardID}}): StateProps => {
     links,
     app: {
       ephemeral: {inPresentationMode},
-      persisted: {autoRefresh, showTemplateControlBar},
+      persisted: {autoRefresh},
     },
     ranges,
     dashboards,
     views: {views},
+    userSettings: {showVariablesControls},
   } = state
 
   const timeRange =
@@ -330,7 +322,7 @@ const mstp = (state: AppState, {params: {dashboardID}}): StateProps => {
     dashboard,
     autoRefresh,
     inPresentationMode,
-    showTemplateControlBar,
+    showVariablesControls,
   }
 }
 
@@ -349,6 +341,7 @@ const mdtp: DispatchProps = {
   onCreateCellWithView: dashboardActions.createCellWithView,
   onUpdateView: dashboardActions.updateView,
   onSetActiveTimeMachine: setActiveTimeMachine,
+  onToggleShowVariablesControls: toggleShowVariablesControls,
 }
 
 export default connect(

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -25,6 +25,7 @@ import {AppState, Dashboard} from 'src/types'
 
 // Constants
 import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants'
+import {resetViews} from 'src/dashboards/actions/views'
 
 interface PassedProps {
   dashboard: Dashboard
@@ -44,6 +45,7 @@ interface DispatchProps {
   onAddDashboardLabels: typeof addDashboardLabelsAsync
   onRemoveDashboardLabels: typeof removeDashboardLabelsAsync
   onCreateLabel: typeof createLabelAsync
+  onResetViews: typeof resetViews
 }
 
 type Props = PassedProps & DispatchProps & StateProps & WithRouterProps
@@ -145,7 +147,9 @@ class DashboardCard extends PureComponent<Props> {
   }
 
   private handleClickDashboard = () => {
-    const {router, dashboard} = this.props
+    const {router, dashboard, onResetViews} = this.props
+
+    onResetViews()
 
     router.push(`/dashboards/${dashboard.id}`)
   }
@@ -203,6 +207,7 @@ const mdtp: DispatchProps = {
   onCreateLabel: createLabelAsync,
   onAddDashboardLabels: addDashboardLabelsAsync,
   onRemoveDashboardLabels: removeDashboardLabelsAsync,
+  onResetViews: resetViews,
 }
 
 export default connect<StateProps, DispatchProps, PassedProps>(

--- a/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.scss
+++ b/ui/src/dashboards/components/variablesControlBar/VariablesControlBar.scss
@@ -23,7 +23,12 @@ $variables-control-bar--gutter: $ix-marg-a;
   .variable-dropdown {
     margin: 0 $variables-control-bar--gutter / 2;
   }
+
+  .variables-spinner-container {
+    height: $variables-control-bar--height;
+  }
 }
+
 
 .variables-control-bar--empty {
   background-color: $g3-castle;

--- a/ui/src/dashboards/reducers/views.ts
+++ b/ui/src/dashboards/reducers/views.ts
@@ -61,6 +61,10 @@ const viewsReducer = (
         },
       }
     }
+
+    case 'RESET_VIEWS': {
+      return initialState()
+    }
   }
 
   return state

--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -31,6 +31,7 @@ export const saveToLocalStorage = ({
   app: {persisted},
   ranges,
   variables,
+  userSettings,
 }: LocalStorage): void => {
   try {
     const appPersisted = {app: {persisted}}
@@ -41,6 +42,7 @@ export const saveToLocalStorage = ({
         VERSION,
         ranges: normalizer(ranges),
         variables,
+        userSettings,
       })
     )
   } catch (err) {

--- a/ui/src/mockState.tsx
+++ b/ui/src/mockState.tsx
@@ -3,7 +3,8 @@ import {Provider} from 'react-redux'
 import {Router, createMemoryHistory} from 'react-router'
 
 import {render} from 'react-testing-library'
-import {initialState} from 'src/variables/reducers'
+import {initialState as initialVariablesState} from 'src/variables/reducers'
+import {initialState as initialUserSettingsState} from 'src/userSettings/reducers'
 import configureStore from 'src/store/configureStore'
 
 const localState = {
@@ -25,7 +26,8 @@ const localState = {
       duration: '15m',
     },
   ],
-  variables: initialState(),
+  variables: initialVariablesState(),
+  userSettings: initialUserSettingsState(),
 }
 
 const history = createMemoryHistory({entries: ['/']})

--- a/ui/src/store/configureStore.ts
+++ b/ui/src/store/configureStore.ts
@@ -29,6 +29,7 @@ import {telegrafsReducer} from 'src/telegrafs/reducers'
 import {authorizationsReducer} from 'src/authorizations/reducers'
 import templatesReducer from 'src/templates/reducers'
 import {scrapersReducer} from 'src/scrapers/reducers'
+import {userSettingsReducer} from 'src/userSettings/reducers'
 
 // Types
 import {LocalStorage} from 'src/types/localStorage'
@@ -58,6 +59,7 @@ export const rootReducer = combineReducers<ReducerState>({
   tokens: authorizationsReducer,
   scrapers: scrapersReducer,
   templates: templatesReducer,
+  userSettings: userSettingsReducer,
   VERSION: () => '',
 })
 

--- a/ui/src/types/localStorage.ts
+++ b/ui/src/types/localStorage.ts
@@ -1,9 +1,11 @@
 import {AppState} from 'src/shared/reducers/app'
 import {VariablesState} from 'src/variables/reducers'
+import {UserSettingsState} from 'src/userSettings/reducers'
 
 export interface LocalStorage {
   VERSION: string
   app: AppState
   ranges: any[]
   variables: VariablesState
+  userSettings: UserSettingsState
 }

--- a/ui/src/types/stores.ts
+++ b/ui/src/types/stores.ts
@@ -22,6 +22,7 @@ import {AuthorizationsState} from 'src/authorizations/reducers'
 import {RangeState} from 'src/dashboards/reducers/ranges'
 import {ViewsState} from 'src/dashboards/reducers/views'
 import {ScrapersState} from 'src/scrapers/reducers'
+import {UserSettingsState} from 'src/userSettings/reducers'
 
 export interface AppState {
   VERSION: string
@@ -49,6 +50,7 @@ export interface AppState {
   tokens: AuthorizationsState
   templates: TemplatesState
   scrapers: ScrapersState
+  userSettings: UserSettingsState
 }
 
 export type GetState = () => AppState

--- a/ui/src/userSettings/actions/index.ts
+++ b/ui/src/userSettings/actions/index.ts
@@ -1,0 +1,9 @@
+export type ActionTypes = ToggleShowVariablesControlsAction
+
+interface ToggleShowVariablesControlsAction {
+  type: 'TOGGLE_SHOW_VARIABLES_CONTROLS'
+}
+
+export const toggleShowVariablesControls = (): ToggleShowVariablesControlsAction => ({
+  type: 'TOGGLE_SHOW_VARIABLES_CONTROLS',
+})

--- a/ui/src/userSettings/reducers/index.ts
+++ b/ui/src/userSettings/reducers/index.ts
@@ -1,0 +1,21 @@
+import {ActionTypes} from 'src/userSettings/actions'
+
+export interface UserSettingsState {
+  showVariablesControls: boolean
+}
+
+export const initialState = (): UserSettingsState => ({
+  showVariablesControls: true,
+})
+
+export const userSettingsReducer = (
+  state = initialState(),
+  action: ActionTypes
+): UserSettingsState => {
+  switch (action.type) {
+    case 'TOGGLE_SHOW_VARIABLES_CONTROLS':
+      return {...state, showVariablesControls: !state.showVariablesControls}
+    default:
+      return state
+  }
+}

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -154,6 +154,12 @@ export const getTimeMachineValuesStatus = (
   return valuesStatus
 }
 
+export const getDashboardVariablesStatus = (
+  state: AppState
+): RemoteDataState => {
+  return get(state, 'variables.status')
+}
+
 export const getDashboardValuesStatus = (
   state: AppState,
   dashboardID: string


### PR DESCRIPTION
Closes #12845
Closes #12846


_Briefly describe your proposed changes:_
Save user preference for open or closed variables control bar in local storage.
default to open.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
