### PR TITLE
chore(ui/lint): no unnecessary curly braces for string props

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-unused-vars": ["error", {"varsIgnorePattern": "^_", "argsIgnorePattern": "^_"}],
     "react/jsx-no-target-blank": "off",
+    "react/jsx-curly-brace-presence": ["error", {"props": "never", "children": "never" }],
     "react/display-name": "off",
     "react/no-unescaped-entities": "off",
     "react/prop-types": "off",

--- a/ui/src/clockface/components/grid_sizer/GridSizer.tsx
+++ b/ui/src/clockface/components/grid_sizer/GridSizer.tsx
@@ -82,7 +82,7 @@ class GridSizer extends PureComponent<Props, State> {
         <div
           key={`grid_cell_${i}`}
           style={columnStyle}
-          className={`grid-sizer--cell`}
+          className="grid-sizer--cell"
         >
           <div className="grid-sizer--content">{child}</div>
         </div>

--- a/ui/src/clockface/components/inputs/multipleInput/Row.tsx
+++ b/ui/src/clockface/components/inputs/multipleInput/Row.tsx
@@ -48,8 +48,8 @@ class Row extends PureComponent<RowProps> {
             <IndexList.Cell alignment={Alignment.Right}>
               <ConfirmationButton
                 onConfirm={this.handleClickDelete(item)}
-                text={'Delete'}
-                confirmText={'Confirm'}
+                text="Delete"
+                confirmText="Confirm"
                 size={ComponentSize.ExtraSmall}
               />
             </IndexList.Cell>

--- a/ui/src/configuration/components/ConfigurationPage.tsx
+++ b/ui/src/configuration/components/ConfigurationPage.tsx
@@ -44,8 +44,8 @@ class ConfigurationPage extends Component<Props> {
           <div className="col-xs-12">
             <GetResources resource={ResourceTypes.Authorizations}>
               <TabbedPage
-                name={'Configuration'}
-                parentUrl={`/configuration`}
+                name="Configuration"
+                parentUrl="/configuration"
                 activeTabUrl={tab}
               >
                 <TabbedPageSection

--- a/ui/src/dataExplorer/components/DashboardsDropdown.tsx
+++ b/ui/src/dataExplorer/components/DashboardsDropdown.tsx
@@ -25,7 +25,7 @@ class DashboardsDropdown extends PureComponent<Props> {
       <MultiSelectDropdown
         selectedIDs={selectedIDs}
         onChange={onSelect}
-        emptyText={'Choose at least 1 dashboard'}
+        emptyText="Choose at least 1 dashboard"
       >
         {this.dropdownItems}
       </MultiSelectDropdown>

--- a/ui/src/dataExplorer/components/SaveAsCellForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsCellForm.tsx
@@ -108,7 +108,7 @@ class SaveAsCellForm extends PureComponent<Props, State> {
                   type={ButtonType.Button}
                 />
                 <Button
-                  text={'Save as Dashboard Cell'}
+                  text="Save as Dashboard Cell"
                   color={ComponentColor.Success}
                   type={ButtonType.Submit}
                   onClick={this.handleSubmit}

--- a/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/CollectorsWizard.tsx
@@ -91,7 +91,7 @@ class CollectorsWizard extends PureComponent<Props> {
     return (
       <WizardOverlay
         visible={visible}
-        title={'Create a Telegraf Config'}
+        title="Create a Telegraf Config"
         onDismiss={this.handleDismiss}
       >
         <CollectorsStepSwitcher stepProps={this.stepProps} buckets={buckets} />

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/ConfigFieldHandler.tsx
@@ -44,7 +44,7 @@ export class ConfigFieldHandler extends PureComponent<Props> {
     const {configFields, telegrafPlugin, onSetConfigArrayValue} = this.props
 
     if (!configFields) {
-      return <p data-testid={'no-config'}>No configuration required.</p>
+      return <p data-testid="no-config">No configuration required.</p>
     }
 
     return Object.entries(configFields).map(

--- a/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
+++ b/ui/src/dataLoaders/components/collectorsWizard/configure/PluginConfigForm.tsx
@@ -68,7 +68,7 @@ export class PluginConfigForm extends PureComponent<Props> {
         </FancyScrollbar>
         <OnboardingButtons
           autoFocusNext={this.autoFocus}
-          nextButtonText={'Done'}
+          nextButtonText="Done"
           className="data-loading--button-container"
         />
       </Form>

--- a/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard.tsx
@@ -80,7 +80,7 @@ class CollectorsWizard extends PureComponent<Props> {
     return (
       <WizardOverlay
         visible={visible}
-        title={'Add Line Protocol'}
+        title="Add Line Protocol"
         onDismiss={this.handleDismiss}
       >
         <div className="wizard-contents">

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocolTabs.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocolTabs.tsx
@@ -90,7 +90,7 @@ export class LineProtocolTabs extends PureComponent<Props, State> {
               offsetLG={Columns.Two}
             >
               <div className="onboarding--admin-user-form">
-                <div className={'wizard-step--lp-body'}>
+                <div className="wizard-step--lp-body">
                   <TabBody
                     onURLChange={this.handleURLChange}
                     activeLPTab={activeLPTab}

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/PrecisionDropdown.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/PrecisionDropdown.tsx
@@ -31,7 +31,7 @@ class PrecisionDropdown extends PureComponent<Props> {
   public render() {
     const {setPrecision, precision} = this.props
     return (
-      <div className={'wizard-step--footer dropdown'}>
+      <div className="wizard-step--footer dropdown">
         <label>Time Precision </label>
         <Dropdown
           selectedID={precision}

--- a/ui/src/dataLoaders/components/lineProtocolWizard/verify/LineProtocolVerifyStep.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/verify/LineProtocolVerifyStep.tsx
@@ -31,7 +31,7 @@ export class VerifyLineProtocolStep extends PureComponent<Props> {
           </div>
           <OnboardingButtons
             onClickBack={onDecrementCurrentStepIndex}
-            nextButtonText={'Finish'}
+            nextButtonText="Finish"
           />
         </Form>
       </div>

--- a/ui/src/dataLoaders/components/lineProtocolWizard/verify/StatusIndicator.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/verify/StatusIndicator.tsx
@@ -21,12 +21,12 @@ export class StatusIndicator extends PureComponent<Props> {
     const {status} = this.props
     return (
       <>
-        <div className={'wizard-step--top-container'}>
-          <div className={'wizard-step--sparkle-container'}>
+        <div className="wizard-step--top-container">
+          <div className="wizard-step--sparkle-container">
             <SparkleSpinner loading={status} />
           </div>
         </div>
-        <div className={'wizard-step--footer'}>
+        <div className="wizard-step--footer">
           <div className={this.footerClass}>{this.footerText}</div>
         </div>
         <br />

--- a/ui/src/dataLoaders/components/side_bar/SideBar.test.tsx
+++ b/ui/src/dataLoaders/components/side_bar/SideBar.test.tsx
@@ -12,17 +12,17 @@ const onClick = jest.fn(() => {})
 
 const childrenArray = [
   <SideBar.Tab
-    label={'a'}
-    key={'a'}
-    id={'a'}
+    label="a"
+    key="a"
+    id="a"
     active={true}
     status={TabStatus.Default}
     onClick={onClick}
   />,
   <SideBar.Tab
-    label={'b'}
-    key={'b'}
-    id={'b'}
+    label="b"
+    key="b"
+    id="b"
     active={false}
     status={TabStatus.Default}
     onClick={onClick}

--- a/ui/src/dataLoaders/components/verifyStep/DataListening.tsx
+++ b/ui/src/dataLoaders/components/verifyStep/DataListening.tsx
@@ -107,7 +107,7 @@ class DataListening extends PureComponent<Props, State> {
         size={ComponentSize.Medium}
         onClick={this.handleClick}
         status={ComponentStatus.Default}
-        titleText={'Listen for Data'}
+        titleText="Listen for Data"
       />
     )
   }

--- a/ui/src/dataLoaders/graphics/LogoApache.tsx
+++ b/ui/src/dataLoaders/graphics/LogoApache.tsx
@@ -79,7 +79,7 @@ const LogoApache: SFC = () => {
           xlinkHref="#apache_b"
         />
       </defs>
-      <title>{'logo_apache'}</title>
+      <title>logo_apache</title>
       <path
         d="M42.56.48C41 1.4 38.39 4 35.28 7.82l2.85 5.39a71.05 71.05 0 0 1 6.1-7.65 3.45 3.45 0 0 1 .25-.26l-.25.26a64.18 64.18 0 0 0-5.72 7.76A108.36 108.36 0 0 0 49.62 12c1.09-6.18-1.08-9-1.08-9S45.79-1.43 42.56.48z"
         fill="url(#apache_c)"

--- a/ui/src/dataLoaders/graphics/LogoIis.tsx
+++ b/ui/src/dataLoaders/graphics/LogoIis.tsx
@@ -49,7 +49,7 @@ const LogoIis: SFC = () => {
           xlinkHref="#iis_a"
         />
       </defs>
-      <title>{'logo_iis'}</title>
+      <title>logo_iis</title>
       <path
         d="M0 67.57V32.43C0 4.05 4.05 0 32.4 0h35.2C96 0 100 4.05 100 32.43v35.14C100 96 96 100 67.6 100H32.4C4.05 100 0 96 0 67.57z"
         fill="url(#iis_b)"

--- a/ui/src/dataLoaders/graphics/LogoMongodb.tsx
+++ b/ui/src/dataLoaders/graphics/LogoMongodb.tsx
@@ -51,7 +51,7 @@ const LogoMongodb: SFC = () => {
           <stop offset={1} stopColor="#69b655" />
         </linearGradient>
       </defs>
-      <title>{'logo_mongodb'}</title>
+      <title>logo_mongodb</title>
       <path
         d="M24.7 100l-2.7-.89s.34-13.57-4.55-14.52c-3.23-3.74.49-159.8 12.22-.54 0 0-4 2-4.77 5.44S24.7 100 24.7 100z"
         fill="url(#mongodb_a)"

--- a/ui/src/me/components/GettingStarted.tsx
+++ b/ui/src/me/components/GettingStarted.tsx
@@ -34,7 +34,7 @@ class GettingStarted extends PureComponent<StateProps> {
           </Link>
         </div>
         <div className="getting-started--container">
-          <Link to={`/dashboards`} className="getting-started--card">
+          <Link to="/dashboards" className="getting-started--card">
             <GradientBorder />
             <DashboardingGraphic />
             <h3 className="getting-started--title">
@@ -45,7 +45,7 @@ class GettingStarted extends PureComponent<StateProps> {
           </Link>
         </div>
         <div className="getting-started--container">
-          <Link to={`/data-explorer`} className="getting-started--card">
+          <Link to="/data-explorer" className="getting-started--card">
             <GradientBorder />
             <ExploreGraphic />
             <h3 className="getting-started--title">

--- a/ui/src/me/components/Resources.tsx
+++ b/ui/src/me/components/Resources.tsx
@@ -37,10 +37,10 @@ class ResourceLists extends PureComponent<Props> {
           <Panel.Body>
             <ul className="link-list">
               <li>
-                <Link to={`/configuration/settings_tab`}>Profile</Link>
+                <Link to="/configuration/settings_tab">Profile</Link>
               </li>
               <li>
-                <Link to={`/configuration/tokens_tab`}>Tokens</Link>
+                <Link to="/configuration/tokens_tab">Tokens</Link>
               </li>
             </ul>
           </Panel.Body>

--- a/ui/src/onboarding/components/AdminStep.tsx
+++ b/ui/src/onboarding/components/AdminStep.tsx
@@ -233,8 +233,8 @@ class AdminStep extends PureComponent<Props, State> {
     return (
       <QuestionMarkTooltip
         tipID="admin_org_tooltip"
-        tipContent={`An organization is a workspace for a group of users requiring access to time series data, dashboards, and other resources.
-        You can create organizations for different functional groups, teams, or projects.`}
+        tipContent="An organization is a workspace for a group of users requiring access to time series data, dashboards, and other resources.
+        You can create organizations for different functional groups, teams, or projects."
       />
     )
   }

--- a/ui/src/onboarding/components/OtherStep.tsx
+++ b/ui/src/onboarding/components/OtherStep.tsx
@@ -37,7 +37,7 @@ class OtherStep extends PureComponent<OnboardingStepProps, null> {
             text="Next"
             size={ComponentSize.Medium}
             onClick={this.handleNext}
-            titleText={'Next'}
+            titleText="Next"
           />
         </div>
       </div>

--- a/ui/src/onboarding/containers/OnboardingWizardPage.tsx
+++ b/ui/src/onboarding/containers/OnboardingWizardPage.tsx
@@ -90,7 +90,7 @@ export class OnboardingWizardPage extends PureComponent<Props, State> {
                     highlightWords={['Initial', 'User']}
                   />
                   <Button
-                    text={'Return to Home Page'}
+                    text="Return to Home Page"
                     onClick={this.redirectToHome}
                     color={ComponentColor.Primary}
                   />

--- a/ui/src/organizations/components/OrganizationNavigation.tsx
+++ b/ui/src/organizations/components/OrganizationNavigation.tsx
@@ -24,52 +24,52 @@ class OrganizationNavigation extends PureComponent<Props> {
     return (
       <Tabs.Nav>
         <Tabs.Tab
-          title={'Members'}
-          id={'members'}
+          title="Members"
+          id="members"
           url={`${route}/members`}
           active={'members' === tab}
         />
         <Tabs.Tab
-          title={'Buckets'}
-          id={'buckets'}
+          title="Buckets"
+          id="buckets"
           url={`${route}/buckets`}
           active={'buckets' === tab}
         />
         <Tabs.Tab
-          title={'Dashboards'}
-          id={'dashboards'}
+          title="Dashboards"
+          id="dashboards"
           url={`${route}/dashboards`}
           active={'dashboards' === tab}
         />
         <Tabs.Tab
-          title={'Tasks'}
-          id={'tasks'}
+          title="Tasks"
+          id="tasks"
           url={`${route}/tasks`}
           active={'tasks' === tab}
         />
         <Tabs.Tab
-          title={'Telegraf'}
-          id={'telegrafs'}
+          title="Telegraf"
+          id="telegrafs"
           url={`${route}/telegrafs`}
           active={'telegrafs' === tab}
         />
         <CloudFeatureFlag>
           <Tabs.Tab
-            title={'Scrapers'}
-            id={'scrapers'}
+            title="Scrapers"
+            id="scrapers"
             url={`${route}/scrapers`}
             active={'scrapers' === tab}
           />
         </CloudFeatureFlag>
         <Tabs.Tab
-          title={'Variables'}
-          id={'variables'}
+          title="Variables"
+          id="variables"
           url={`${route}/variables`}
           active={'variables' === tab}
         />
         <Tabs.Tab
-          title={'Templates'}
-          id={'templates'}
+          title="Templates"
+          id="templates"
           url={`${route}/templates`}
           active={'templates' === tab}
         />

--- a/ui/src/organizations/components/TelegrafConfigOverlay.tsx
+++ b/ui/src/organizations/components/TelegrafConfigOverlay.tsx
@@ -60,7 +60,7 @@ export class TelegrafConfigOverlay extends PureComponent<Props> {
           <Overlay.Footer>
             <Button
               color={ComponentColor.Secondary}
-              text={'Download Config'}
+              text="Download Config"
               onClick={this.handleDownloadConfig}
             />
           </Overlay.Footer>

--- a/ui/src/organizations/components/VariableRow.tsx
+++ b/ui/src/organizations/components/VariableRow.tsx
@@ -30,13 +30,13 @@ export default class VariableRow extends PureComponent<Props> {
           <EditableName
             onUpdate={this.handleUpdateVariableName}
             name={variable.name}
-            noNameString={'NAME THIS VARIABLE'}
+            noNameString="NAME THIS VARIABLE"
             onEditName={this.handleEditVariable}
           >
             {variable.name}
           </EditableName>
         </IndexList.Cell>
-        <IndexList.Cell alignment={Alignment.Left}>{'Query'}</IndexList.Cell>
+        <IndexList.Cell alignment={Alignment.Left}>Query</IndexList.Cell>
         <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
           <ConfirmationButton
             size={ComponentSize.ExtraSmall}

--- a/ui/src/organizations/containers/OrgBucketsIndex.tsx
+++ b/ui/src/organizations/containers/OrgBucketsIndex.tsx
@@ -58,7 +58,7 @@ class OrgBucketsIndex extends Component<Props> {
         <Page.Contents fullWidth={false} scrollable={true}>
           <div className="col-xs-12">
             <Tabs>
-              <OrganizationNavigation tab={'buckets'} orgID={org.id} />
+              <OrganizationNavigation tab="buckets" orgID={org.id} />
               <Tabs.TabContents>
                 <TabbedPageSection
                   id="org-view-tab--buckets"

--- a/ui/src/organizations/containers/OrgDashboardsIndex.tsx
+++ b/ui/src/organizations/containers/OrgDashboardsIndex.tsx
@@ -80,7 +80,7 @@ class OrgDashboardsIndex extends Component<Props, State> {
           <Page.Contents fullWidth={false} scrollable={true}>
             <div className="col-xs-12">
               <Tabs>
-                <OrganizationNavigation tab={'dashboards'} orgID={org.id} />
+                <OrganizationNavigation tab="dashboards" orgID={org.id} />
                 <Tabs.TabContents>
                   <TabbedPageSection
                     id="org-view-tab--dashboards"

--- a/ui/src/organizations/containers/OrgMembersIndex.tsx
+++ b/ui/src/organizations/containers/OrgMembersIndex.tsx
@@ -65,7 +65,7 @@ class OrgMembersIndex extends Component<Props> {
         <Page.Contents fullWidth={false} scrollable={true}>
           <div className="col-xs-12">
             <Tabs>
-              <OrganizationNavigation tab={'members'} orgID={org.id} />
+              <OrganizationNavigation tab="members" orgID={org.id} />
               <Tabs.TabContents>
                 <TabbedPageSection
                   id="org-view-tab--members"

--- a/ui/src/organizations/containers/OrgScrapersIndex.tsx
+++ b/ui/src/organizations/containers/OrgScrapersIndex.tsx
@@ -62,7 +62,7 @@ class OrgScrapersIndex extends Component<Props> {
         <Page.Contents fullWidth={false} scrollable={true}>
           <div className="col-xs-12">
             <Tabs>
-              <OrganizationNavigation tab={'scrapers'} orgID={org.id} />
+              <OrganizationNavigation tab="scrapers" orgID={org.id} />
               <Tabs.TabContents>
                 <TabbedPageSection
                   id="org-view-tab--scrapers"

--- a/ui/src/organizations/containers/OrgTasksIndex.tsx
+++ b/ui/src/organizations/containers/OrgTasksIndex.tsx
@@ -67,7 +67,7 @@ class OrgTasksIndex extends Component<Props, State> {
           <Page.Contents fullWidth={false} scrollable={true}>
             <div className="col-xs-12">
               <Tabs>
-                <OrganizationNavigation tab={'tasks'} orgID={org.id} />
+                <OrganizationNavigation tab="tasks" orgID={org.id} />
                 <Tabs.TabContents>
                   <TabbedPageSection
                     id="org-view-tab--tasks"

--- a/ui/src/organizations/containers/OrgTelegrafsIndex.tsx
+++ b/ui/src/organizations/containers/OrgTelegrafsIndex.tsx
@@ -82,7 +82,7 @@ class OrgTelegrafsIndex extends Component<Props, State> {
         <Page.Contents fullWidth={false} scrollable={true}>
           <div className="col-xs-12">
             <Tabs>
-              <OrganizationNavigation tab={'telegrafs'} orgID={org.id} />
+              <OrganizationNavigation tab="telegrafs" orgID={org.id} />
               <Tabs.TabContents>
                 <TabbedPageSection
                   id="org-view-tab--telegrafs"

--- a/ui/src/organizations/containers/OrgTemplatesIndex.tsx
+++ b/ui/src/organizations/containers/OrgTemplatesIndex.tsx
@@ -53,7 +53,7 @@ class OrgTemplatesIndex extends Component<Props> {
           <Page.Contents fullWidth={false} scrollable={true}>
             <div className="col-xs-12">
               <Tabs>
-                <OrganizationNavigation tab={'templates'} orgID={org.id} />
+                <OrganizationNavigation tab="templates" orgID={org.id} />
                 <Tabs.TabContents>
                   <TabbedPageSection
                     id="org-view-tab--templates"

--- a/ui/src/organizations/containers/OrgVariablesIndex.tsx
+++ b/ui/src/organizations/containers/OrgVariablesIndex.tsx
@@ -47,7 +47,7 @@ class OrgVariablesIndex extends Component<Props> {
         <Page.Contents fullWidth={false} scrollable={true}>
           <div className="col-xs-12">
             <Tabs>
-              <OrganizationNavigation tab={'variables'} orgID={org.id} />
+              <OrganizationNavigation tab="variables" orgID={org.id} />
               <Tabs.TabContents>
                 <TabbedPageSection
                   id="org-view-tab--variables"

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -40,7 +40,7 @@ class SideNav extends PureComponent<Props> {
         >
           <NavMenu.SubItem
             title="Logout"
-            link={`/logout`}
+            link="/logout"
             location={location.pathname}
             highlightPaths={[]}
           />

--- a/ui/src/shared/components/CodeSnippet.tsx
+++ b/ui/src/shared/components/CodeSnippet.tsx
@@ -45,7 +45,7 @@ class CodeSnippet extends PureComponent<Props> {
           </div>
         </FancyScrollbar>
         <div className="code-snippet--footer">
-          <CopyButton textToCopy={copyText} contentName={'Script'} />
+          <CopyButton textToCopy={copyText} contentName="Script" />
           <label className="code-snippet--label">{label}</label>
         </div>
       </div>

--- a/ui/src/shared/components/ExportOverlay.tsx
+++ b/ui/src/shared/components/ExportOverlay.tsx
@@ -130,7 +130,7 @@ class ExportOverlay extends PureComponent<Props> {
   private get downloadButton(): JSX.Element {
     return (
       <Button
-        text={`Download JSON`}
+        text="Download JSON"
         onClick={this.handleExport}
         color={ComponentColor.Primary}
       />
@@ -140,7 +140,7 @@ class ExportOverlay extends PureComponent<Props> {
   private get toTemplateButton(): JSX.Element {
     return (
       <Button
-        text={`Save as template`}
+        text="Save as template"
         onClick={this.handleConvertToTemplate}
         color={ComponentColor.Primary}
       />

--- a/ui/src/shared/components/cells/Cells.tsx
+++ b/ui/src/shared/components/cells/Cells.tsx
@@ -75,7 +75,7 @@ class Cells extends Component<Props & WithRouterProps, State> {
         containerPadding={[0, 0]}
         margin={[LAYOUT_MARGIN, LAYOUT_MARGIN]}
         onLayoutChange={this.handleLayoutChange}
-        draggableHandle={'.cell--draggable'}
+        draggableHandle=".cell--draggable"
         isDraggable={this.isDashboard}
         isResizable={this.isDashboard}
       >

--- a/ui/src/shared/components/search_widget/SearchWidget.tsx
+++ b/ui/src/shared/components/search_widget/SearchWidget.tsx
@@ -56,7 +56,7 @@ class SearchWidget extends Component<Props, State> {
         value={searchTerm}
         onChange={this.handleChange}
         onBlur={this.handleBlur}
-        testID={`search-widget`}
+        testID="search-widget"
       />
     )
   }

--- a/ui/src/shared/components/tables/TableGraphs.tsx
+++ b/ui/src/shared/components/tables/TableGraphs.tsx
@@ -79,7 +79,7 @@ class TableGraphs extends PureComponent<Props, State> {
           />
         )}
         {!this.hasData && (
-          <EmptyGraphMessage message={'This table has no data'} />
+          <EmptyGraphMessage message="This table has no data" />
         )}
       </div>
     )

--- a/ui/src/tasks/components/EmptyTasksList.tsx
+++ b/ui/src/tasks/components/EmptyTasksList.tsx
@@ -45,7 +45,7 @@ export default class EmptyTasksLists extends PureComponent<Props> {
 
     return (
       <EmptyState size={ComponentSize.Large}>
-        <EmptyState.Text text={'No Tasks match your search term'} />
+        <EmptyState.Text text="No Tasks match your search term" />
       </EmptyState>
     )
   }

--- a/ui/src/tasks/components/RunLogsList.tsx
+++ b/ui/src/tasks/components/RunLogsList.tsx
@@ -24,7 +24,7 @@ class RunLogsOverlay extends PureComponent<Props> {
     const {onDismissOverlay} = this.props
 
     return (
-      <Overlay.Container customClass={'run-logs--list'}>
+      <Overlay.Container customClass="run-logs--list">
         <Overlay.Heading title="Run Logs" onDismiss={onDismissOverlay} />
         <Overlay.Body>
           <FancyScrollbar autoHeight={true} maxHeight={700}>

--- a/ui/src/tasks/components/TaskForm.tsx
+++ b/ui/src/tasks/components/TaskForm.tsx
@@ -198,7 +198,7 @@ export default class TaskForm extends PureComponent<Props, State> {
             type={ButtonType.Button}
           />
           <Button
-            text={'Save as Task'}
+            text="Save as Task"
             color={ComponentColor.Success}
             type={ButtonType.Submit}
             onClick={onSubmit}

--- a/ui/src/tasks/components/TasksOptionsBucketDropdown.tsx
+++ b/ui/src/tasks/components/TasksOptionsBucketDropdown.tsx
@@ -50,11 +50,7 @@ export default class TaskOptionsBucketDropdown extends PureComponent<Props> {
       })
     } else {
       return [
-        <Dropdown.Item
-          id={'no-buckets'}
-          key={'no-buckets'}
-          value={'no-buckets'}
-        >
+        <Dropdown.Item id="no-buckets" key="no-buckets" value="no-buckets">
           {'no buckets found in org'}
         </Dropdown.Item>,
       ]

--- a/ui/src/templates/components/EmptyTemplatesList.tsx
+++ b/ui/src/templates/components/EmptyTemplatesList.tsx
@@ -35,7 +35,7 @@ const EmptyTemplatesList: FunctionComponent<Props> = ({
 
   return (
     <EmptyState size={ComponentSize.Large}>
-      <EmptyState.Text text={'No Templates match your search term'} />
+      <EmptyState.Text text="No Templates match your search term" />
     </EmptyState>
   )
 }

--- a/ui/src/timeMachine/components/FunctionSelector.tsx
+++ b/ui/src/timeMachine/components/FunctionSelector.tsx
@@ -45,7 +45,7 @@ class FunctionSelector extends PureComponent<Props, State> {
       <div className="function-selector">
         <h3>Aggregate Functions</h3>
         <Input
-          customClass={'function-selector--search'}
+          customClass="function-selector--search"
           value={searchTerm}
           onChange={this.handleSetSearchTerm}
           placeholder="Search functions..."

--- a/ui/src/timeMachine/components/QueryTab.tsx
+++ b/ui/src/timeMachine/components/QueryTab.tsx
@@ -86,14 +86,14 @@ class TimeMachineQueryTab extends PureComponent<Props, State> {
           <RightClick.Menu>
             <RightClick.MenuItem
               onClick={this.handleEditActiveQueryName}
-              testID={'right-click--edit-tab'}
+              testID="right-click--edit-tab"
             >
               Edit
             </RightClick.MenuItem>
             <RightClick.MenuItem
               onClick={this.handleRemove}
               disabled={!this.isRemovable}
-              testID={'right-click--remove-tab'}
+              testID="right-click--remove-tab"
             >
               Remove
             </RightClick.MenuItem>

--- a/ui/src/timeMachine/components/variableToolbar/VariableToolbar.tsx
+++ b/ui/src/timeMachine/components/variableToolbar/VariableToolbar.tsx
@@ -31,7 +31,7 @@ const VariableToolbar: FunctionComponent<OwnProps & StateProps> = ({
 
   return (
     <div className="variable-toolbar">
-      <SearchBar onSearch={setSearchTerm} resourceName={'Variables'} />
+      <SearchBar onSearch={setSearchTerm} resourceName="Variables" />
       <FancyScrollbar>
         <div className="variables-toolbar--list">
           {variables


### PR DESCRIPTION
When passing string props to a component do this:

```
<Foo bar="baz" />
```
not
```
<Foo bar={'baz'} />
```
Now, you wont have to remember because the linter will yell at you.