### PR TITLE
Add check for nil document in post document request

### DIFF
--- a/http/document_service.go
+++ b/http/document_service.go
@@ -151,6 +151,13 @@ func decodePostDocumentRequest(ctx context.Context, r *http.Request) (*postDocum
 		return nil, err
 	}
 
+	if req.Document == nil {
+		return nil, &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Msg:  "missing document body",
+		}
+	}
+
 	params := httprouter.ParamsFromContext(ctx)
 	req.Namespace = params.ByName("ns")
 	if req.Namespace == "" {


### PR DESCRIPTION
Closes #12861 

_Briefly describe your proposed changes:_
This PR introduces a nil check to ensure that nil documents aren't passed 

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
