### PR TITLE
feat(ui/org/vars): export var as template

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -43,6 +43,7 @@ import OrgDashboardsIndex from 'src/organizations/containers/OrgDashboardsIndex'
 import OrgMembersIndex from 'src/organizations/containers/OrgMembersIndex'
 import OrgTelegrafsIndex from 'src/organizations/containers/OrgTelegrafsIndex'
 import OrgVariablesIndex from 'src/organizations/containers/OrgVariablesIndex'
+import OrgVariableExportOverlay from 'src/organizations/components/OrgVariableExportOverlay'
 import OrgScrapersIndex from 'src/organizations/containers/OrgScrapersIndex'
 import OrgTasksIndex from 'src/organizations/containers/OrgTasksIndex'
 import TaskExportOverlay from 'src/organizations/components/TaskExportOverlay'
@@ -167,7 +168,12 @@ class Root extends PureComponent {
                             <Route
                               path="variables"
                               component={OrgVariablesIndex}
-                            />
+                            >
+                              <Route
+                                path=":id/export"
+                                component={OrgVariableExportOverlay}
+                              />
+                            </Route>
                             <Route
                               path="scrapers"
                               component={OrgScrapersIndex}

--- a/ui/src/organizations/components/OrgVariableExportOverlay.tsx
+++ b/ui/src/organizations/components/OrgVariableExportOverlay.tsx
@@ -1,0 +1,86 @@
+import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+import {connect} from 'react-redux'
+
+// Components
+import ExportOverlay from 'src/shared/components/ExportOverlay'
+
+// Actions
+import {convertToTemplate as convertToTemplateAction} from 'src/variables/actions'
+import {clearExportTemplate as clearExportTemplateAction} from 'src/templates/actions'
+
+// Types
+import {AppState} from 'src/types'
+import {DocumentCreate} from '@influxdata/influx'
+import {RemoteDataState} from 'src/types'
+
+interface OwnProps {
+  params: {id: string; orgID: string}
+}
+
+interface DispatchProps {
+  convertToTemplate: typeof convertToTemplateAction
+  clearExportTemplate: typeof clearExportTemplateAction
+}
+
+interface StateProps {
+  variableTemplate: DocumentCreate
+  status: RemoteDataState
+  orgID: string
+}
+
+type Props = OwnProps & StateProps & DispatchProps & WithRouterProps
+
+class OrgVariableExportOverlay extends PureComponent<Props> {
+  public async componentDidMount() {
+    const {
+      params: {id},
+      convertToTemplate,
+    } = this.props
+
+    convertToTemplate(id)
+  }
+
+  public render() {
+    const {variableTemplate, status} = this.props
+
+    return (
+      <ExportOverlay
+        resourceName="Variable"
+        resource={variableTemplate}
+        onDismissOverlay={this.onDismiss}
+        orgID={this.orgID}
+        status={status}
+      />
+    )
+  }
+
+  private get orgID() {
+    const orgFromExistingResource = this.props.orgID
+    const orgInRoutes = this.props.params.orgID
+    return orgFromExistingResource || orgInRoutes
+  }
+
+  private onDismiss = () => {
+    const {router, clearExportTemplate} = this.props
+
+    router.goBack()
+    clearExportTemplate()
+  }
+}
+
+const mstp = (state: AppState): StateProps => ({
+  variableTemplate: state.templates.exportTemplate.item,
+  status: state.templates.exportTemplate.status,
+  orgID: state.templates.exportTemplate.orgID,
+})
+
+const mdtp: DispatchProps = {
+  convertToTemplate: convertToTemplateAction,
+  clearExportTemplate: clearExportTemplateAction,
+}
+
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mstp,
+  mdtp
+)(withRouter<Props>(OrgVariableExportOverlay))

--- a/ui/src/organizations/components/VariableRow.tsx
+++ b/ui/src/organizations/components/VariableRow.tsx
@@ -1,26 +1,25 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
-import {
-  IndexList,
-  Alignment,
-  ComponentSize,
-  ConfirmationButton,
-} from 'src/clockface'
+import {IndexList, Alignment, Context, IconFont} from 'src/clockface'
+import {ComponentColor} from '@influxdata/clockface'
 
 // Types
 import {Variable} from '@influxdata/influx'
 import EditableName from 'src/shared/components/EditableName'
 
-interface Props {
+interface OwnProps {
   variable: Variable
   onDeleteVariable: (variable: Variable) => void
   onUpdateVariableName: (variable: Partial<Variable>) => void
   onEditVariable: (variable: Variable) => void
 }
 
-export default class VariableRow extends PureComponent<Props> {
+type Props = OwnProps & WithRouterProps
+
+class VariableRow extends PureComponent<Props> {
   public render() {
     const {variable, onDeleteVariable} = this.props
 
@@ -38,16 +37,36 @@ export default class VariableRow extends PureComponent<Props> {
         </IndexList.Cell>
         <IndexList.Cell alignment={Alignment.Left}>Query</IndexList.Cell>
         <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
-          <ConfirmationButton
-            size={ComponentSize.ExtraSmall}
-            text="Delete"
-            confirmText="Confirm"
-            onConfirm={onDeleteVariable}
-            returnValue={variable}
-          />
+          <Context>
+            <Context.Menu icon={IconFont.CogThick}>
+              <Context.Item label="Export" action={this.handleExport} />
+            </Context.Menu>
+            <Context.Menu
+              icon={IconFont.Trash}
+              color={ComponentColor.Danger}
+              testID="context-delete-menu"
+            >
+              <Context.Item
+                label="Delete"
+                action={onDeleteVariable}
+                value={variable}
+                testID="context-delete-task"
+              />
+            </Context.Menu>
+          </Context>
         </IndexList.Cell>
       </IndexList.Row>
     )
+  }
+
+  private handleExport = () => {
+    const {
+      router,
+      variable,
+      location: {pathname},
+    } = this.props
+
+    router.push(`${pathname}/${variable.id}/export`)
   }
 
   private handleUpdateVariableName = async (name: string) => {
@@ -60,3 +79,5 @@ export default class VariableRow extends PureComponent<Props> {
     this.props.onEditVariable(this.props.variable)
   }
 }
+
+export default withRouter<OwnProps>(VariableRow)

--- a/ui/src/organizations/components/__snapshots__/Variables.test.tsx.snap
+++ b/ui/src/organizations/components/__snapshots__/Variables.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`VariableList rendering renders 1`] = `
       columnCount={3}
       emptyState={<React.Fragment />}
     >
-      <VariableRow
+      <withRouter(VariableRow)
         key="variable-undefined"
         onDeleteVariable={[MockFunction]}
         onEditVariable={[Function]}

--- a/ui/src/organizations/containers/OrgVariablesIndex.tsx
+++ b/ui/src/organizations/containers/OrgVariablesIndex.tsx
@@ -39,28 +39,31 @@ type Props = WithRouterProps & RouterProps & DispatchProps & StateProps
 @ErrorHandling
 class OrgVariablesIndex extends Component<Props> {
   public render() {
-    const {org} = this.props
+    const {org, children} = this.props
 
     return (
-      <Page titleTag={org.name}>
-        <OrgHeader orgID={org.id} />
-        <Page.Contents fullWidth={false} scrollable={true}>
-          <div className="col-xs-12">
-            <Tabs>
-              <OrganizationNavigation tab="variables" orgID={org.id} />
-              <Tabs.TabContents>
-                <TabbedPageSection
-                  id="org-view-tab--variables"
-                  url="variables"
-                  title="Variables"
-                >
-                  <Variables org={org} />
-                </TabbedPageSection>
-              </Tabs.TabContents>
-            </Tabs>
-          </div>
-        </Page.Contents>
-      </Page>
+      <>
+        <Page titleTag={org.name}>
+          <OrgHeader orgID={org.id} />
+          <Page.Contents fullWidth={false} scrollable={true}>
+            <div className="col-xs-12">
+              <Tabs>
+                <OrganizationNavigation tab="variables" orgID={org.id} />
+                <Tabs.TabContents>
+                  <TabbedPageSection
+                    id="org-view-tab--variables"
+                    url="variables"
+                    title="Variables"
+                  >
+                    <Variables org={org} />
+                  </TabbedPageSection>
+                </Tabs.TabContents>
+              </Tabs>
+            </div>
+          </Page.Contents>
+        </Page>
+        {children}
+      </>
     )
   }
 }

--- a/ui/src/shared/utils/resourceToTemplate.test.ts
+++ b/ui/src/shared/utils/resourceToTemplate.test.ts
@@ -2,8 +2,9 @@ import {
   labelToRelationship,
   labelToIncluded,
   taskToTemplate,
+  variableToTemplate,
 } from 'src/shared/utils/resourceToTemplate'
-import {TemplateType} from '@influxdata/influx'
+import {TemplateType, Variable} from '@influxdata/influx'
 import {Label, Task, TaskStatus} from 'src/types'
 
 const myfavelabel: Label = {
@@ -30,6 +31,20 @@ const myfavetask: Task = {
   org: 'org',
   orgID: '037b084ec8ebc000',
   status: TaskStatus.Active,
+}
+
+const myVariable: Variable = {
+  id: '039ae3b3b74b0000',
+  orgID: '039aa15b38cb0000',
+  name: 'beep',
+  selected: null,
+  arguments: {
+    type: 'query',
+    values: {
+      query: 'test!',
+      language: 'flux',
+    },
+  },
 }
 
 describe('resourceToTemplate', () => {
@@ -59,6 +74,42 @@ describe('resourceToTemplate', () => {
       expect(actual).toEqual(expected)
     })
   })
+
+  describe('variableToTemplate', () => {
+    it('converts a variable to a template', () => {
+      const actual = variableToTemplate(myVariable)
+      const expected = {
+        meta: {
+          version: '1',
+          name: 'beep-Template',
+          description: 'template created from variable: beep',
+        },
+        content: {
+          data: {
+            type: 'variable',
+            id: '039ae3b3b74b0000',
+            attributes: {
+              name: 'beep',
+              arguments: {
+                type: 'query',
+                values: {
+                  query: 'test!',
+                  language: 'flux',
+                },
+              },
+              selected: null,
+            },
+            relationships: {},
+          },
+          included: [],
+        },
+        labels: [],
+      }
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
   describe('taskToTemplate', () => {
     it('converts a task to a template', () => {
       const actual = taskToTemplate(myfavetask)

--- a/ui/src/shared/utils/resourceToTemplate.ts
+++ b/ui/src/shared/utils/resourceToTemplate.ts
@@ -29,6 +29,18 @@ const blankTaskTemplate = () => {
   }
 }
 
+const blankVariableTemplate = () => {
+  const baseTemplate = blankTemplate()
+  return {
+    ...baseTemplate,
+    content: {
+      ...baseTemplate.content,
+      data: {...baseTemplate.content.data, type: TemplateType.Variable},
+    },
+    labels: [],
+  }
+}
+
 const blankDashboardTemplate = () => {
   const baseTemplate = blankTemplate()
   return {
@@ -137,6 +149,33 @@ const cellToRelationship = (cell: Cell) => ({
   type: TemplateType.Cell,
   id: cell.id,
 })
+
+export const variableToTemplate = (
+  v: Variable,
+  baseTemplate = blankVariableTemplate()
+) => {
+  const variableName = _.get(v, 'name', '')
+  const templateName = `${variableName}-Template`
+  const variableData = variableToIncluded(v)
+
+  return {
+    ...baseTemplate,
+    meta: {
+      ...baseTemplate.meta,
+      name: templateName,
+      description: `template created from variable: ${variableName}`,
+    },
+    content: {
+      ...baseTemplate.content,
+      data: {
+        ...baseTemplate.content.data,
+        ...variableData,
+        relationships: {},
+      },
+      included: [],
+    },
+  }
+}
 
 const variableToIncluded = (v: Variable) => {
   const variableAttributes = _.pick(v, ['name', 'arguments', 'selected'])

--- a/ui/src/variables/actions/index.ts
+++ b/ui/src/variables/actions/index.ts
@@ -14,10 +14,15 @@ import {
   createVariableSuccess,
   updateVariableSuccess,
 } from 'src/shared/copy/notifications'
+import {setExportTemplate} from 'src/templates/actions'
 
 // Utils
 import {getValueSelections, getVariablesForOrg} from 'src/variables/selectors'
 import {WrappedCancelablePromise, CancellationError} from 'src/types/promises'
+import {variableToTemplate} from 'src/shared/utils/resourceToTemplate'
+
+// Constants
+import * as copy from 'src/shared/copy/notifications'
 
 // Types
 import {Dispatch} from 'redux-thunk'
@@ -244,5 +249,22 @@ export const refreshVariableValues = (
 
     console.error(e)
     dispatch(setValues(contextID, RemoteDataState.Error))
+  }
+}
+
+export const convertToTemplate = (variableID: string) => async (
+  dispatch
+): Promise<void> => {
+  try {
+    dispatch(setExportTemplate(RemoteDataState.Loading))
+
+    const variable = await client.variables.get(variableID)
+    const variableTemplate = variableToTemplate(variable)
+    const orgID = variable.orgID // TODO remove when org is implicit app state
+
+    dispatch(setExportTemplate(RemoteDataState.Done, variableTemplate, orgID))
+  } catch (error) {
+    dispatch(setExportTemplate(RemoteDataState.Error))
+    dispatch(notify(copy.createTemplateFailed(error)))
   }
 }


### PR DESCRIPTION
Closes #11872 

_Briefly describe your proposed changes:_
Add the ability to export a variable as a template using an overlay at `/organizations/:id/variables/:varID/export`.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
