### PR TITLE
Fix stale render flash upon opening VEO

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -6106,8 +6106,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6131,15 +6130,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6156,22 +6153,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6302,8 +6296,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6317,7 +6310,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6334,7 +6326,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6343,15 +6334,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6372,7 +6361,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6461,8 +6449,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6476,7 +6463,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6572,8 +6558,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6615,7 +6600,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6637,7 +6621,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6686,15 +6669,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/ui/src/dashboards/components/VEO.tsx
+++ b/ui/src/dashboards/components/VEO.tsx
@@ -48,13 +48,14 @@ class VEO extends PureComponent<Props, State> {
   }
 
   public componentDidUpdate() {
-    if (
-      !this.state.hasActivatedTimeMachine &&
-      this.props.viewsStatus === RemoteDataState.Done
-    ) {
-      this.props.onSetActiveTimeMachine(VEO_TIME_MACHINE_ID, {
-        view: this.props.view,
-      })
+    const {view, onSetActiveTimeMachine} = this.props
+    const {hasActivatedTimeMachine} = this.state
+
+    const timeMachineShouldActivate =
+      !hasActivatedTimeMachine && this.loading === RemoteDataState.Done
+
+    if (timeMachineShouldActivate) {
+      onSetActiveTimeMachine(VEO_TIME_MACHINE_ID, {view})
       this.setState({hasActivatedTimeMachine: true})
     }
   }

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -79,13 +79,7 @@ export const initialStateHelper = (): TimeMachineState => ({
   activeQueryIndex: 0,
   availableXColumns: [],
   availableGroupColumns: [],
-  queryResults: {
-    files: null,
-    status: RemoteDataState.NotStarted,
-    isInitialFetch: true,
-    fetchDuration: null,
-    errorMessage: null,
-  },
+  queryResults: initialQueryResultsState(),
   queryBuilder: {
     buckets: [],
     bucketsStatus: RemoteDataState.NotStarted,
@@ -123,7 +117,7 @@ export const timeMachinesReducer = (
       hidden: false,
     }))
     const queryBuilder = initialQueryBuilderState(draftQueries[0].builderConfig)
-    const activeQueryIndex = 0
+    const queryResults = initialQueryResultsState()
 
     return {
       ...state,
@@ -134,9 +128,13 @@ export const timeMachinesReducer = (
           ...activeTimeMachine,
           ...initialState,
           activeTab: TimeMachineTab.Queries,
-          activeQueryIndex,
+          isViewingRawData: false,
+          availableXColumns: [],
+          availableGroupColumns: [],
+          activeQueryIndex: 0,
           draftQueries,
           queryBuilder,
+          queryResults,
         },
       },
     }
@@ -837,6 +835,14 @@ const initialQueryBuilderState = (
     })),
   }
 }
+
+const initialQueryResultsState = (): QueryResultsState => ({
+  files: null,
+  status: RemoteDataState.NotStarted,
+  isInitialFetch: true,
+  fetchDuration: null,
+  errorMessage: null,
+})
 
 const buildActiveQuery = (draftState: TimeMachineState) => {
   const draftQuery = draftState.draftQueries[draftState.activeQueryIndex]


### PR DESCRIPTION
Closes #12789

A VEO contains a time machine. When the VEO opens, we reset the time machine state according to the current view being edited (for example, the queries in the time machine should start as the queries for the view being edited).

We previously added additional state to the time machine that depends on the view (https://github.com/influxdata/influxdb/pull/12619) , but neglected to reset this state whenever a new time machine was activated.

In particular, the `queryResults` field of the time machine state was not reset, which led to stale data being momentarily rendered in the time machine visualization when a time machine was activated (#12789).

This commit ensures the `queryResults` field is reset whenever a new time machine is activated. It also ensures other data that only correspond to the lifetime of a particular time machine are reset as well.
