### PR TITLE
fix(http): remove newPatchLabelHandler

### DIFF
--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -120,7 +120,6 @@ func NewBucketHandler(b *BucketBackend) *BucketHandler {
 	h.HandlerFunc("GET", bucketsIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", bucketsIDLabelsPath, newPostLabelHandler(labelBackend))
 	h.HandlerFunc("DELETE", bucketsIDLabelsIDPath, newDeleteLabelHandler(labelBackend))
-	h.HandlerFunc("PATCH", bucketsIDLabelsIDPath, newPatchLabelHandler(labelBackend))
 
 	return h
 }

--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -125,7 +125,6 @@ func NewDashboardHandler(b *DashboardBackend) *DashboardHandler {
 	h.HandlerFunc("GET", dashboardsIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", dashboardsIDLabelsPath, newPostLabelHandler(labelBackend))
 	h.HandlerFunc("DELETE", dashboardsIDLabelsIDPath, newDeleteLabelHandler(labelBackend))
-	h.HandlerFunc("PATCH", dashboardsIDLabelsIDPath, newPatchLabelHandler(labelBackend))
 
 	return h
 }

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -432,30 +432,6 @@ func decodePostLabelMappingRequest(ctx context.Context, r *http.Request, rt plat
 	return req, nil
 }
 
-// newPatchLabelHandler returns a handler func for a PATCH to /labels endpoints
-func newPatchLabelHandler(b *LabelBackend) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-
-		req, err := decodePatchLabelRequest(ctx, r)
-		if err != nil {
-			EncodeError(ctx, err, w)
-			return
-		}
-
-		label, err := b.LabelService.UpdateLabel(ctx, req.LabelID, req.Update)
-		if err != nil {
-			EncodeError(ctx, err, w)
-			return
-		}
-
-		if err := encodeResponse(ctx, w, http.StatusOK, newLabelResponse(label)); err != nil {
-			logEncodingError(b.Logger, r, err)
-			return
-		}
-	}
-}
-
 // newDeleteLabelHandler returns a handler func for a DELETE to /labels endpoints
 func newDeleteLabelHandler(b *LabelBackend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -127,7 +127,6 @@ func NewOrgHandler(b *OrgBackend) *OrgHandler {
 	h.HandlerFunc("GET", organizationsIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", organizationsIDLabelsPath, newPostLabelHandler(labelBackend))
 	h.HandlerFunc("DELETE", organizationsIDLabelsIDPath, newDeleteLabelHandler(labelBackend))
-	h.HandlerFunc("PATCH", organizationsIDLabelsIDPath, newPatchLabelHandler(labelBackend))
 
 	return h
 }

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -145,7 +145,6 @@ func NewTaskHandler(b *TaskBackend) *TaskHandler {
 	h.HandlerFunc("GET", tasksIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", tasksIDLabelsPath, newPostLabelHandler(labelBackend))
 	h.HandlerFunc("DELETE", tasksIDLabelsIDPath, newDeleteLabelHandler(labelBackend))
-	h.HandlerFunc("PATCH", tasksIDLabelsIDPath, newPatchLabelHandler(labelBackend))
 
 	return h
 }

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -111,7 +111,6 @@ func NewTelegrafHandler(b *TelegrafBackend) *TelegrafHandler {
 	h.HandlerFunc("GET", telegrafsIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", telegrafsIDLabelsPath, newPostLabelHandler(labelBackend))
 	h.HandlerFunc("DELETE", telegrafsIDLabelsIDPath, newDeleteLabelHandler(labelBackend))
-	h.HandlerFunc("PATCH", telegrafsIDLabelsIDPath, newPatchLabelHandler(labelBackend))
 
 	return h
 }


### PR DESCRIPTION
This was removed in the labels 2.0 rewrite, and looks like it was added back as a regression.

I need :eyes: on this from someone consuming from the labels API to make sure that this endpoint isn't being used (it shouldn't be, because it's not in our swagger docs).