### PR TITLE
Update tasks runs list to display 20 latest runs

### DIFF
--- a/ui/src/tasks/components/TaskRunsList.tsx
+++ b/ui/src/tasks/components/TaskRunsList.tsx
@@ -27,7 +27,7 @@ export default class TaskRunsList extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
-      sortKey: null,
+      sortKey: 'scheduledFor',
       sortDirection: Sort.Descending,
     }
   }
@@ -104,9 +104,12 @@ export default class TaskRunsList extends PureComponent<Props, State> {
 
   public listRuns = (runs: Run[]): JSX.Element => {
     const {taskID} = this.props
+
+    let recentRuns = runs.slice(0, 20)
+
     const runsRow = (
       <>
-        {runs.map(r => (
+        {recentRuns.map(r => (
           <TaskRunsRow key={`run-id--${r.id}`} taskID={taskID} run={r} />
         ))}
       </>


### PR DESCRIPTION
Closes #12874 

_Briefly describe your proposed changes:_
Sorting was not working since sort key was null in state so updated sort key to "scheduleFor"
Updated runs to filter for 20 runs to display latest 20 runs

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
