### PR TITLE
Fix routing loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 1. [12793](https://github.com/influxdata/influxdb/pull/12793): Fix task creation error when switching schedule types.
 1. [12805](https://github.com/influxdata/influxdb/pull/12805): Fix hidden horizonal scrollbars in flux raw data view
 1. [12827](https://github.com/influxdata/influxdb/pull/12827): Fix screen tearing bug in Raw Data View
+1. [12959](https://github.com/influxdata/influxdb/pull/12959): Fix routing loop
 
 ### UI Improvements
 

--- a/ui/src/Signin.tsx
+++ b/ui/src/Signin.tsx
@@ -94,7 +94,7 @@ export class Signin extends PureComponent<Props, State> {
         this.props.notify(sessionTimedOut())
       }
 
-      this.props.router.push(`/signin${returnTo}`)
+      this.props.router.replace(`/signin${returnTo}`)
     }
   }
 }

--- a/ui/src/onboarding/components/SigninForm.tsx
+++ b/ui/src/onboarding/components/SigninForm.tsx
@@ -134,7 +134,7 @@ class SigninForm extends PureComponent<Props, State> {
     const {query} = this.props.location
 
     if (query && query.returnTo) {
-      router.push(query.returnTo)
+      router.replace(query.returnTo)
     } else {
       router.push('/')
     }


### PR DESCRIPTION
Closes #12892

If a user's session expires while they are viewing a modal, they will be taken through the following router flow:

1. Start at

   ```
   /dashboards <-- current route
   ```

1. Open modal, pushes modal route onto stack

   ```
   /dashboards/:dashboardID/export <--
   /dashboards
   ```

1. Session expires, push signin route onto stack

   ```
   /signin?returnTo=/dashboards/:dashboardID/export <--
   /dashboards/:dashboardID/export
   /dashboards
   ```

1. After signin, push `returnTo` onto stack

   ```
   /dashboards/:dashboardID/export <--
   /signin?returnTo=/dashboards/:dashboardID/export
   /dashboards/:dashboardID/export
   /dashboards
   ```

1. Dismiss modal, which pops last route

   ```
   /signin?returnTo=/dashboards/:dashboardID/export <--
   /dashboards/:dashboardID/export
   /dashboards
   ```

This creates an infinite loop :boom: 

Instead, we want:

1. Start at

   ```
   /dashboards <--
   ```

1. Open modal, pushes modal route onto stack

   ```
   /dashboards/:dashboardID/export <--
   /dashboards
   ```

1. Session expires, __replace__ current route with signin route 

   ```
   /signin?returnTo=/dashboards/:dashboardID/export <--
   /dashboards
   ```

1. After signin, __replace__ sign in route with `returnTo` route

   ```
   /dashboards/:dashboardID/export <--
   /dashboards
   ```

1. Dismiss modal, which pops last route

   ```
   /dashboards <--
   ```
