### PR TITLE
Ensure credentials are passed for Flux queries when using influx command

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -207,7 +207,7 @@ func (c *CommandLine) Run() error {
 	c.Version()
 
 	if c.Type == QueryLanguageFlux {
-		repl, err := getFluxREPL(c.Host, c.Port, c.Ssl)
+		repl, err := getFluxREPL(c.Host, c.Port, c.Ssl, c.ClientConfig.Username, c.ClientConfig.Password)
 		if err != nil {
 			return err
 		}
@@ -1194,7 +1194,7 @@ func (c *CommandLine) ExecuteFluxQuery(query string) error {
 		}()
 	}
 
-	repl, err := getFluxREPL(c.Host, c.Port, c.Ssl)
+	repl, err := getFluxREPL(c.Host, c.Port, c.Ssl, c.ClientConfig.Username, c.ClientConfig.Password)
 	if err != nil {
 		return err
 	}

--- a/cmd/influx/cli/flux.go
+++ b/cmd/influx/cli/flux.go
@@ -30,10 +30,12 @@ func (q *replQuerier) Query(ctx context.Context, compiler flux.Compiler) (flux.R
 	return q.client.Query(ctx, req)
 }
 
-func getFluxREPL(host string, port int, ssl bool) (*repl.REPL, error) {
+func getFluxREPL(host string, port int, ssl bool, username, password string) (*repl.REPL, error) {
 	c, err := client.NewHTTP(host, port, ssl)
 	if err != nil {
 		return nil, err
 	}
+	c.Username = username
+	c.Password = password
 	return repl.New(&replQuerier{client: c}), nil
 }

--- a/flux/client/http.go
+++ b/flux/client/http.go
@@ -36,6 +36,8 @@ var (
 // API endpoint.
 type HTTP struct {
 	Addr               string
+	Username           string
+	Password           string
 	InsecureSkipVerify bool
 	url                *url.URL
 }
@@ -65,6 +67,9 @@ func (s *HTTP) Query(ctx context.Context, r *ProxyRequest) (flux.ResultIterator,
 	hreq, err := http.NewRequest("POST", s.url.String(), &body)
 	if err != nil {
 		return nil, err
+	}
+	if s.Username != "" {
+		hreq.SetBasicAuth(s.Username, s.Password)
 	}
 
 	hreq.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
Fixes #11710

Credentials were being ignored when using the `influx` CLI tool and the `-type=flux` switch. This PR ensures the credentials are correctly passed when executing Flux HTTP requests.