### PR TITLE
fix(influxdb): updated auth shall return

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -104,7 +104,7 @@ type AuthorizationService interface {
 	CreateAuthorization(ctx context.Context, a *Authorization) error
 
 	// UpdateAuthorization updates the status and description if available.
-	UpdateAuthorization(ctx context.Context, id ID, udp *AuthorizationUpdate) error
+	UpdateAuthorization(ctx context.Context, id ID, udp *AuthorizationUpdate) (*Authorization, error)
 
 	// Removes a authorization by token.
 	DeleteAuthorization(ctx context.Context, id ID) error

--- a/authorizer/auth.go
+++ b/authorizer/auth.go
@@ -144,14 +144,14 @@ func VerifyPermissions(ctx context.Context, ps []influxdb.Permission) error {
 }
 
 // UpdateAuthorization checks to see if the authorizer on context has write access to the authorization provided.
-func (s *AuthorizationService) UpdateAuthorization(ctx context.Context, id influxdb.ID, upd *influxdb.AuthorizationUpdate) error {
+func (s *AuthorizationService) UpdateAuthorization(ctx context.Context, id influxdb.ID, upd *influxdb.AuthorizationUpdate) (*influxdb.Authorization, error) {
 	a, err := s.s.FindAuthorizationByID(ctx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := authorizeWriteAuthorization(ctx, a.UserID); err != nil {
-		return err
+		return nil, err
 	}
 
 	return s.s.UpdateAuthorization(ctx, id, upd)

--- a/authorizer/auth_test.go
+++ b/authorizer/auth_test.go
@@ -244,8 +244,8 @@ func TestAuthorizationService_WriteAuthorization(t *testing.T) {
 			m.DeleteAuthorizationFn = func(ctx context.Context, id influxdb.ID) error {
 				return nil
 			}
-			m.UpdateAuthorizationFn = func(ctx context.Context, id influxdb.ID, upd *influxdb.AuthorizationUpdate) error {
-				return nil
+			m.UpdateAuthorizationFn = func(ctx context.Context, id influxdb.ID, upd *influxdb.AuthorizationUpdate) (*influxdb.Authorization, error) {
+				return nil, nil
 			}
 			s := authorizer.NewAuthorizationService(m)
 
@@ -258,7 +258,7 @@ func TestAuthorizationService_WriteAuthorization(t *testing.T) {
 			})
 
 			t.Run("update authorization", func(t *testing.T) {
-				err := s.UpdateAuthorization(ctx, 10, &influxdb.AuthorizationUpdate{Status: influxdb.Active.Ptr()})
+				_, err := s.UpdateAuthorization(ctx, 10, &influxdb.AuthorizationUpdate{Status: influxdb.Active.Ptr()})
 				influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
 			})
 

--- a/bolt/authorization.go
+++ b/bolt/authorization.go
@@ -383,9 +383,12 @@ func (c *Client) deleteAuthorization(ctx context.Context, tx *bolt.Tx, id platfo
 }
 
 // UpdateAuthorization updates the status and description if available.
-func (c *Client) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) error {
-	return c.db.Update(func(tx *bolt.Tx) error {
-		if pe := c.updateAuthorization(ctx, tx, id, upd); pe != nil {
+func (c *Client) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) (*platform.Authorization, error) {
+	var a *platform.Authorization
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		var pe *platform.Error
+		a, pe = c.updateAuthorization(ctx, tx, id, upd)
+		if pe != nil {
 			return &platform.Error{
 				Err: pe,
 				Op:  platform.OpUpdateAuthorization,
@@ -393,12 +396,13 @@ func (c *Client) UpdateAuthorization(ctx context.Context, id platform.ID, upd *p
 		}
 		return nil
 	})
+	return a, err
 }
 
-func (c *Client) updateAuthorization(ctx context.Context, tx *bolt.Tx, id platform.ID, upd *platform.AuthorizationUpdate) *platform.Error {
+func (c *Client) updateAuthorization(ctx context.Context, tx *bolt.Tx, id platform.ID, upd *platform.AuthorizationUpdate) (*platform.Authorization, *platform.Error) {
 	a, pe := c.findAuthorizationByID(ctx, tx, id)
 	if pe != nil {
-		return pe
+		return nil, pe
 	}
 
 	if upd.Status != nil {
@@ -410,22 +414,22 @@ func (c *Client) updateAuthorization(ctx context.Context, tx *bolt.Tx, id platfo
 
 	b, err := encodeAuthorization(a)
 	if err != nil {
-		return &platform.Error{
+		return nil, &platform.Error{
 			Err: err,
 		}
 	}
 
 	encodedID, err := id.Encode()
 	if err != nil {
-		return &platform.Error{
+		return nil, &platform.Error{
 			Err: err,
 		}
 	}
 
 	if err = tx.Bucket(authorizationBucket).Put(encodedID, b); err != nil {
-		return &platform.Error{
+		return nil, &platform.Error{
 			Err: err,
 		}
 	}
-	return nil
+	return a, nil
 }

--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -456,14 +456,14 @@ func authorizationActiveF(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.TODO()
-	a, err := s.FindAuthorizationByID(ctx, id)
-	if err != nil {
+	if _, err := s.FindAuthorizationByID(ctx, id); err != nil {
 		return err
 	}
 
-	if err := s.UpdateAuthorization(context.Background(), id, &platform.AuthorizationUpdate{
+	a, err := s.UpdateAuthorization(context.Background(), id, &platform.AuthorizationUpdate{
 		Status: platform.Active.Ptr(),
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 
@@ -527,14 +527,14 @@ func authorizationInactiveF(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.TODO()
-	a, err := s.FindAuthorizationByID(ctx, id)
-	if err != nil {
+	if _, err = s.FindAuthorizationByID(ctx, id); err != nil {
 		return err
 	}
 
-	if err := s.UpdateAuthorization(context.Background(), id, &platform.AuthorizationUpdate{
+	a, err := s.UpdateAuthorization(context.Background(), id, &platform.AuthorizationUpdate{
 		Status: platform.Inactive.Ptr(),
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 

--- a/inmem/auth_service.go
+++ b/inmem/auth_service.go
@@ -193,11 +193,11 @@ func (s *Service) DeleteAuthorization(ctx context.Context, id platform.ID) error
 }
 
 // UpdateAuthorization updates the status and description if available.
-func (s *Service) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) error {
+func (s *Service) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) (*platform.Authorization, error) {
 	op := OpPrefix + platform.OpUpdateAuthorization
 	a, err := s.FindAuthorizationByID(ctx, id)
 	if err != nil {
-		return &platform.Error{
+		return nil, &platform.Error{
 			Err: err,
 			Op:  op,
 		}
@@ -208,7 +208,7 @@ func (s *Service) UpdateAuthorization(ctx context.Context, id platform.ID, upd *
 		switch status {
 		case platform.Active, platform.Inactive:
 		default:
-			return &platform.Error{
+			return nil, &platform.Error{
 				Code: platform.EInvalid,
 				Msg:  "unknown authorization status",
 				Op:   op,
@@ -221,5 +221,5 @@ func (s *Service) UpdateAuthorization(ctx context.Context, id platform.ID, upd *
 		a.Description = *upd.Description
 	}
 
-	return s.PutAuthorization(ctx, a)
+	return a, s.PutAuthorization(ctx, a)
 }

--- a/mock/auth_service.go
+++ b/mock/auth_service.go
@@ -21,7 +21,7 @@ type AuthorizationService struct {
 	FindAuthorizationsFn       func(context.Context, platform.AuthorizationFilter, ...platform.FindOptions) ([]*platform.Authorization, int, error)
 	CreateAuthorizationFn      func(context.Context, *platform.Authorization) error
 	DeleteAuthorizationFn      func(context.Context, platform.ID) error
-	UpdateAuthorizationFn      func(context.Context, platform.ID, *platform.AuthorizationUpdate) error
+	UpdateAuthorizationFn      func(context.Context, platform.ID, *platform.AuthorizationUpdate) (*platform.Authorization, error)
 }
 
 // NewAuthorizationService returns a mock AuthorizationService where its methods will return
@@ -35,7 +35,9 @@ func NewAuthorizationService() *AuthorizationService {
 		},
 		CreateAuthorizationFn: func(context.Context, *platform.Authorization) error { return nil },
 		DeleteAuthorizationFn: func(context.Context, platform.ID) error { return nil },
-		UpdateAuthorizationFn: func(context.Context, platform.ID, *platform.AuthorizationUpdate) error { return nil },
+		UpdateAuthorizationFn: func(context.Context, platform.ID, *platform.AuthorizationUpdate) (*platform.Authorization, error) {
+			return nil, nil
+		},
 	}
 }
 
@@ -64,6 +66,6 @@ func (s *AuthorizationService) DeleteAuthorization(ctx context.Context, id platf
 }
 
 // UpdateAuthorization updates the status and description if available.
-func (s *AuthorizationService) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) error {
+func (s *AuthorizationService) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) (*platform.Authorization, error) {
 	return s.UpdateAuthorizationFn(ctx, id, upd)
 }

--- a/prometheus/auth_service.go
+++ b/prometheus/auth_service.go
@@ -110,7 +110,7 @@ func (s *AuthorizationService) DeleteAuthorization(ctx context.Context, id platf
 }
 
 // UpdateAuthorization updates the status and description.
-func (s *AuthorizationService) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) (err error) {
+func (s *AuthorizationService) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) (a *platform.Authorization, err error) {
 	defer func(start time.Time) {
 		labels := prometheus.Labels{
 			"method": "setAuthorizationStatus",

--- a/prometheus/auth_service_test.go
+++ b/prometheus/auth_service_test.go
@@ -38,8 +38,8 @@ func (a *authzSvc) DeleteAuthorization(context.Context, platform.ID) error {
 	return a.Err
 }
 
-func (a *authzSvc) UpdateAuthorization(context.Context, platform.ID, *platform.AuthorizationUpdate) error {
-	return a.Err
+func (a *authzSvc) UpdateAuthorization(context.Context, platform.ID, *platform.AuthorizationUpdate) (*platform.Authorization, error) {
+	return nil, a.Err
 }
 
 func TestAuthorizationService_Metrics(t *testing.T) {

--- a/testing/auth.go
+++ b/testing/auth.go
@@ -682,7 +682,7 @@ func UpdateAuthorization(
 			defer done()
 			ctx := context.Background()
 
-			err := s.UpdateAuthorization(ctx, tt.args.id, tt.args.upd)
+			updatedAuth, err := s.UpdateAuthorization(ctx, tt.args.id, tt.args.upd)
 			diffPlatformErrors(tt.name, err, tt.wants.err, opPrefix, t)
 
 			if tt.wants.err == nil {
@@ -691,6 +691,9 @@ func UpdateAuthorization(
 					t.Errorf("%s failed, got error %s", tt.name, err.Error())
 				}
 				if diff := cmp.Diff(authorization, tt.wants.authorization, authorizationCmpOptions...); diff != "" {
+					t.Errorf("authorization is different -got/+want\ndiff %s", diff)
+				}
+				if diff := cmp.Diff(authorization, updatedAuth, authorizationCmpOptions...); diff != "" {
 					t.Errorf("authorization is different -got/+want\ndiff %s", diff)
 				}
 			}

--- a/zap/auth_service.go
+++ b/zap/auth_service.go
@@ -71,7 +71,7 @@ func (s *AuthorizationService) DeleteAuthorization(ctx context.Context, id platf
 }
 
 // UpdateAuthorization updates an authorization's status, description and logs any errors.
-func (s *AuthorizationService) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) (err error) {
+func (s *AuthorizationService) UpdateAuthorization(ctx context.Context, id platform.ID, upd *platform.AuthorizationUpdate) (a *platform.Authorization, err error) {
 	defer func() {
 		if err != nil {
 			s.Logger.Info("error updating authorization", zap.Error(err))


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/13026

Update the authorization update interface to return the updated authorization

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
