### PR TITLE
Add nil check for tagKeyValueEntry.setIDs()

### DIFF
--- a/tsdb/index/inmem/meta.go
+++ b/tsdb/index/inmem/meta.go
@@ -1163,6 +1163,7 @@ func (t *tagKeyValue) Range(f func(tagValue string, a seriesIDs) bool) {
 			return
 		}
 	}
+	t.mu.RUnlock()
 }
 
 // RangeAll calls f sequentially on each key and value. A call to RangeAll on a
@@ -1199,7 +1200,12 @@ func (e *tagKeyValueEntry) ids() (_ seriesIDs, changed bool) {
 	return a, true
 }
 
-func (e *tagKeyValueEntry) setIDs(a seriesIDs) { e.a = a }
+func (e *tagKeyValueEntry) setIDs(a seriesIDs) {
+	if e == nil {
+		return
+	}
+	e.a = a
+}
 
 // SeriesIDs is a convenience type for sorting, checking equality, and doing
 // union and intersection of collections of series ids.


### PR DESCRIPTION
Previously it was possible to set IDs on a `nil` entry which would in turn cause a panic. If this panic was recovered by the server then it would result in a mutex in the `inmem` index staying locked indefinitely.

Related: https://github.com/influxdata/influxdb/issues/13010

_Briefly describe your proposed changes:_

  - [x] Rebased/mergeable
  - [x] Tests pass
