### PR TITLE
fix(http): fix swagger health & ready

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1473,6 +1473,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   /ready:
+    servers:
+        - url: /
     get:
       tags:
         - Ready
@@ -1491,6 +1493,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
   /health:
+    servers:
+        - url: /
     get:
       tags:
         - Health


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/12811

Added the server override for /health and /ready

