### PR TITLE
fix(http): update swagger to include correct label add responses

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -459,7 +459,7 @@ paths:
             schema:
               $ref: "#/components/schemas/LabelMapping"
       responses:
-        '200':
+        '201':
           description: "the label added to the telegraf config"
           content:
             application/json:
@@ -819,12 +819,12 @@ paths:
             schema:
               $ref: "#/components/schemas/LabelMapping"
       responses:
-        '200':
-          description: a list of all labels for a scraper target
+        '201':
+          description: the newly added label
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LabelsResponse"
+                $ref: "#/components/schemas/LabelResponse"
         default:
           description: unexpected error
           content:
@@ -1308,12 +1308,12 @@ paths:
             schema:
               $ref: "#/components/schemas/LabelMapping"
       responses:
-        '200':
-          description: a list of all labels for a variable
+        '201':
+          description: the newly added label
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LabelsResponse"
+                $ref: "#/components/schemas/LabelResponse"
         default:
           description: unexpected error
           content:
@@ -2337,7 +2337,7 @@ paths:
             schema:
               $ref: "#/components/schemas/LabelMapping"
       responses:
-        '200':
+        '201':
           description: the label added to the dashboard
           content:
             application/json:
@@ -3177,12 +3177,12 @@ paths:
             schema:
               $ref: "#/components/schemas/LabelMapping"
       responses:
-        '200':
-          description: a list of all labels for a bucket
+        '201':
+          description: the newly added label
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/LabelsResponse"
+                $ref: "#/components/schemas/LabelResponse"
         default:
           description: unexpected error
           content:
@@ -3617,7 +3617,7 @@ paths:
             schema:
               $ref: "#/components/schemas/LabelMapping"
       responses:
-        '200':
+        '201':
           description: returns the created label
           content:
             application/json:


### PR DESCRIPTION
Closes #13034
Closes #13059

There were several issues with label add responses that I found in our swagger, where either it did not specify the correct 201 response, or used `LabelsResponse` instead of `LabelResponse`. This PR fixes these issues.