### PR TITLE
feat(dashboards): add overlay to create dashboard from template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## v2.0.0-alpha.8 [unreleased]
 
 ### Features
+
 1. [13024](https://github.com/influxdata/influxdb/pull/13024): Add the ability to edit token's description
+1. [13078](https://github.com/influxdata/influxdb/pull/13078): Add the option to create a Dashboard from a Template.
 
 ### Bug Fixes
 

--- a/ui/cypress/e2e/dashboardsIndex.test.ts
+++ b/ui/cypress/e2e/dashboardsIndex.test.ts
@@ -51,6 +51,25 @@ describe('Dashboards', () => {
     cy.getByTestID('dashboard-card').should('have.length', 1)
   })
 
+  it('can create a dashboard from a Template', () => {
+    cy.getByTestID('dashboard-card').should('have.length', 0)
+    cy.get<Organization>('@org').then(({id}) => {
+      cy.createDashboardTemplate(id)
+    })
+
+    cy.get('.page-header--container')
+      .contains('Create')
+      .click()
+
+    cy.getByTestID('dropdown--item From a Template').click()
+
+    cy.getByTestID('card-select-Bashboard-Template').click()
+
+    cy.getByTestID('create-dashboard-button').click()
+
+    cy.getByTestID('dashboard-card').should('have.length', 1)
+  })
+
   describe('Dashboard List', () => {
     beforeEach(() => {
       cy.get<Organization>('@org').then(({id}) => {

--- a/ui/cypress/index.d.ts
+++ b/ui/cypress/index.d.ts
@@ -17,6 +17,7 @@ import {
   createScraper,
   fluxEqual,
   createTelegraf,
+  createDashboardTemplate,
 } from './support/commands'
 
 declare global {
@@ -27,6 +28,7 @@ declare global {
       createSource: typeof createSource
       createTask: typeof createTask
       createVariable: typeof createVariable
+      createDashboardTemplate: typeof createDashboardTemplate
       createDashboard: typeof createDashboard
       createOrg: typeof createOrg
       flush: typeof flush

--- a/ui/cypress/support/commands.ts
+++ b/ui/cypress/support/commands.ts
@@ -28,6 +28,37 @@ export const createDashboard = (
   })
 }
 
+export const createDashboardTemplate = (
+  orgID?: string,
+  name: string = 'Bashboard'
+): Cypress.Chainable<Cypress.Response> => {
+  return cy.request({
+    method: 'POST',
+    url: '/api/v2/documents/templates',
+    body: {
+      content: {
+        data: {
+          attributes: {name, description: ''},
+          relationships: {
+            label: {data: []},
+            cell: {data: []},
+            variable: {data: []},
+          },
+          type: 'dashboard',
+        },
+        included: [],
+      },
+      labels: [],
+      meta: {
+        description: `template created from dashboard: ${name}`,
+        version: '1',
+        name: `${name}-Template`,
+      },
+      orgID,
+    },
+  })
+}
+
 export const createOrg = (): Cypress.Chainable<Cypress.Response> => {
   return cy.request({
     method: 'POST',
@@ -270,6 +301,7 @@ Cypress.Commands.add('setupUser', setupUser)
 
 // dashboards
 Cypress.Commands.add('createDashboard', createDashboard)
+Cypress.Commands.add('createDashboardTemplate', createDashboardTemplate)
 
 // orgs
 Cypress.Commands.add('createOrg', createOrg)

--- a/ui/src/clockface/components/card_select/CardSelectCard.scss
+++ b/ui/src/clockface/components/card_select/CardSelectCard.scss
@@ -4,66 +4,66 @@
 */
 
 .card-select--card {
-    min-width: 100%;
-    min-height: 100%;
-    background-color: $g1-raven;
-    border-radius: $radius;
-    border: $ix-border solid transparent;
-    transition: border-color .2s ease, background-color .2s ease;
-    box-sizing: border-box;
+  min-width: 100%;
+  min-height: 100%;
+  background-color: $g1-raven;
+  border-radius: $radius;
+  border: $ix-border solid transparent;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+  box-sizing: border-box;
 }
 
 .card-select--container {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  cursor: pointer;
+  font-size: 22px;
+  user-select: none;
+  width: 100%;
+  height: 100%;
+  display: inline-flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  input {
     position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
+    opacity: 0;
     cursor: pointer;
-    font-size: 22px;
-    user-select: none;
-    width: 100%;
-    height: 100%;
-    display: inline-flex;
-    justify-content: center;
-    flex-direction: column;
-    align-items: center;
-    input {
-        position: absolute;
-        opacity: 0;
-        cursor: pointer;
-    }
+  }
 }
 
 .card-select--image {
-    justify-content: center;
-    max-width: 60%;
-    filter: grayscale(0.80) opacity(30%);
-    transition: filter .2s ease;
-    img {
-        width: 100%;
-        height: 100%;
-        font-size: $ix-text-base;
-    }
+  justify-content: center;
+  max-width: 60%;
+  filter: grayscale(0.8) opacity(30%);
+  transition: filter 0.2s ease;
+  img {
+    width: 100%;
+    height: 100%;
+    font-size: $ix-text-base;
+  }
 }
 
 .card-select--active:hover,
 .card-select--active.card-select--checked {
-    background-color: $g5-pepper;
-    .card-select--image {
-        filter: grayscale(0) opacity(100%);
-    }
+  background-color: $g5-pepper;
+  .card-select--image {
+    filter: grayscale(0) opacity(100%);
+  }
 }
 
 .card-select--active.card-select--checked {
-    border-color: $c-rainforest;
+  border-color: $c-rainforest;
 }
 
 .card-select--disabled {
-    opacity: .3;
-    .card-select--container {
-        cursor: not-allowed;
-    }
+  opacity: 0.3;
+  .card-select--container {
+    cursor: not-allowed;
+  }
 }
 
 .card-select--label {
@@ -78,17 +78,28 @@
   font-weight: 600;
 }
 
+.card-select--no-image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.card-select--label,
+.card-select--no-image {
+  position: relative;
+}
+
 .card-select--checkmark {
-    position: absolute;
-    left: 5%;
-    top: 5%;
-    height: 22px;
-    width: 22px;
-    color: $c-rainforest;
-    opacity: 0;
-    transition: opacity .2s ease;
+  position: absolute;
+  left: 5%;
+  top: 5%;
+  height: 22px;
+  width: 22px;
+  color: $c-rainforest;
+  opacity: 0;
+  transition: opacity 0.2s ease;
 }
 
 .card-select--checkmark.card-select--checked {
-    opacity: 1;
+  opacity: 1;
 }

--- a/ui/src/clockface/components/card_select/CardSelectCard.tsx
+++ b/ui/src/clockface/components/card_select/CardSelectCard.tsx
@@ -10,6 +10,7 @@ interface Props {
   onClick: () => void
   name?: string
   image?: StatelessComponent
+  hideImage?: boolean
   checked: boolean
   disabled: boolean
 }
@@ -31,6 +32,7 @@ class CardSelectCard extends PureComponent<Props> {
           'card-select--checked': checked,
           'card-select--disabled': disabled,
           'card-select--active': !disabled,
+          'card-select--no-image': this.props.hideImage,
         })}
       >
         <label className="card-select--container">
@@ -60,7 +62,11 @@ class CardSelectCard extends PureComponent<Props> {
   }
 
   private get cardImage(): JSX.Element {
-    const {image, label} = this.props
+    const {image, label, hideImage} = this.props
+
+    if (hideImage) {
+      return
+    }
 
     if (image) {
       return React.createElement(image)

--- a/ui/src/clockface/components/card_select/CardSelectCard.tsx
+++ b/ui/src/clockface/components/card_select/CardSelectCard.tsx
@@ -13,6 +13,7 @@ interface Props {
   hideImage?: boolean
   checked: boolean
   disabled: boolean
+  testID?: string
 }
 
 @ErrorHandling
@@ -23,11 +24,13 @@ class CardSelectCard extends PureComponent<Props> {
   }
 
   public render() {
-    const {id, label, checked, name, disabled} = this.props
+    const {id, label, checked, name, disabled, testID} = this.props
+
     return (
       <div
         data-toggle="card_toggle"
         onClick={this.handleClick}
+        data-testid={testID}
         className={classnames('card-select--card', {
           'card-select--checked': checked,
           'card-select--disabled': disabled,

--- a/ui/src/clockface/components/grid_sizer/ResponsiveGridSizer.scss
+++ b/ui/src/clockface/components/grid_sizer/ResponsiveGridSizer.scss
@@ -3,7 +3,6 @@
   ------------------------------------------------------------------------------
 */
 
-
 .responsive-grid-sizer {
   width: 100%;
   position: relative;
@@ -11,7 +10,7 @@
 
 .responsive-grid-sizer--cells {
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   position: relative;
   flex-wrap: wrap;
 }

--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -231,6 +231,9 @@ export const createDashboardFromTemplate = (
   try {
     await createDashboardFromTemplateAJAX(template, orgID)
 
+    const dashboards = await getDashboardsAJAX()
+
+    dispatch(setDashboards(RemoteDataState.Done, dashboards))
     dispatch(notify(importDashboardSucceeded()))
   } catch (error) {
     dispatch(notify(importDashboardFailed(error)))

--- a/ui/src/dashboards/components/DashboardImportFromTemplateOverlay.scss
+++ b/ui/src/dashboards/components/DashboardImportFromTemplateOverlay.scss
@@ -1,0 +1,35 @@
+@import 'src/style/modules';
+
+.import-template-overlay {
+  display: flex;
+  flex-direction: row;
+  width: 90%;
+  justify-content: center;
+}
+
+.import-template-overlay--details {
+  min-width: 65%;
+  margin-left: $ix-marg-c;
+}
+
+.import-template-overlay--columns {
+  display: flex;
+  justify-content: space-between;
+}
+
+.import-template-overlay--variables-column {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+}
+
+.import-template-overlay--cells-column {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+}
+
+.import-template-overlay--empty {
+  min-width: 65%;
+  margin-left: $ix-marg-c;
+}

--- a/ui/src/dashboards/components/DashboardImportFromTemplateOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardImportFromTemplateOverlay.tsx
@@ -1,0 +1,243 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+import {connect} from 'react-redux'
+import _ from 'lodash'
+
+// Components
+import {Button, ComponentColor} from '@influxdata/clockface'
+import {
+  Overlay,
+  ResponsiveGridSizer,
+  Panel,
+  EmptyState,
+  ComponentSize,
+} from 'src/clockface'
+import {
+  TemplateSummary,
+  ITemplate,
+  Organization,
+  TemplateType,
+  IDashboardTemplateIncluded,
+} from '@influxdata/influx'
+import CardSelectCard from 'src/clockface/components/card_select/CardSelectCard'
+import OrgTemplateFetcher from 'src/organizations/components/OrgTemplateFetcher'
+
+// Actions
+import {createDashboardFromTemplate as createDashboardFromTemplateAction} from 'src/dashboards/actions'
+import {getTemplateByID} from 'src/templates/actions'
+
+// Types
+import {AppState, RemoteDataState, DashboardTemplate} from 'src/types'
+
+interface StateProps {
+  templates: TemplateSummary[]
+  templateStatus: RemoteDataState
+  orgs: Organization[]
+}
+
+interface DispatchProps {
+  createDashboardFromTemplate: typeof createDashboardFromTemplateAction
+}
+
+interface State {
+  selectedTemplateSummary: TemplateSummary
+  selectedTemplate: ITemplate
+  variables: string[]
+  cells: string[]
+}
+
+type Props = DispatchProps & StateProps
+
+class DashboardImportFromTemplateOverlay extends PureComponent<
+  Props & WithRouterProps,
+  State
+> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      selectedTemplateSummary: null,
+      selectedTemplate: null,
+      variables: [],
+      cells: [],
+    }
+  }
+
+  render() {
+    const {selectedTemplateSummary} = this.state
+
+    return (
+      <Overlay visible={true}>
+        <Overlay.Container maxWidth={800}>
+          <Overlay.Heading
+            title="Import Dashboard from a Template"
+            onDismiss={this.onDismiss}
+          />
+          <Overlay.Body>
+            <div className="import-template-overlay">
+              <OrgTemplateFetcher orgName={this.orgName}>
+                <ResponsiveGridSizer columns={3}>
+                  {this.templates}
+                </ResponsiveGridSizer>
+              </OrgTemplateFetcher>
+              {!selectedTemplateSummary && this.emptyState}
+              {selectedTemplateSummary && (
+                <Panel className="import-template-overlay--details">
+                  <Panel.Header
+                    title={_.get(selectedTemplateSummary, 'meta.name')}
+                  />
+                  <Panel.Body>
+                    <div className="import-template-overlay--columns">
+                      <div className="import-template-overlay--variables-column">
+                        <h5>Variables:</h5>
+                        {this.variableItems}
+                      </div>
+                      <div className="import-template-overlay--cells-column">
+                        <h5>Cells:</h5>
+                        {this.cellItems}
+                      </div>
+                    </div>
+                  </Panel.Body>
+                </Panel>
+              )}
+            </div>
+          </Overlay.Body>
+          <Overlay.Footer>{this.buttons}</Overlay.Footer>
+        </Overlay.Container>
+      </Overlay>
+    )
+  }
+
+  private get templates(): JSX.Element[] {
+    const {templates} = this.props
+    const {selectedTemplateSummary} = this.state
+
+    return templates.map(t => {
+      return (
+        <CardSelectCard
+          key={t.id}
+          id={t.id}
+          onClick={this.selectTemplate(t)}
+          checked={_.get(selectedTemplateSummary, 'id', '') === t.id}
+          label={t.meta.name}
+          hideImage={true}
+        />
+      )
+    })
+  }
+
+  private get buttons(): JSX.Element[] {
+    return [
+      <Button text="Cancel" onClick={this.onDismiss} key="cancel-button" />,
+      <Button
+        text="Create Dashboard"
+        onClick={this.onSubmit}
+        key="submit-button"
+        color={ComponentColor.Primary}
+      />,
+    ]
+  }
+
+  private get orgName(): string {
+    const {
+      params: {orgID},
+      orgs,
+    } = this.props
+    return orgs.find(org => {
+      return org.id === orgID
+    }).name
+  }
+
+  private get variableItems(): JSX.Element[] {
+    return this.state.variables.map(v => {
+      return <p key={v}>{v}</p>
+    })
+  }
+
+  private get cellItems(): JSX.Element[] {
+    return this.state.cells.map(c => {
+      return <p key={c}>{c}</p>
+    })
+  }
+
+  private get emptyState(): JSX.Element {
+    return (
+      <Panel className="import-template-overlay--empty">
+        <Panel.Body>
+          <EmptyState size={ComponentSize.Medium}>
+            <EmptyState.Text text="Select a Template on the left" />
+          </EmptyState>
+        </Panel.Body>
+      </Panel>
+    )
+  }
+
+  private getVariablesForTemplate(template: ITemplate): string[] {
+    const variables = []
+    const included = template.content.included as IDashboardTemplateIncluded[]
+    included.forEach(data => {
+      if (data.type === TemplateType.Variable) {
+        variables.push(data.attributes.name)
+      }
+    })
+
+    return variables
+  }
+
+  private getCellsForTemplate(template: ITemplate): string[] {
+    const cells = []
+    const included = template.content.included as IDashboardTemplateIncluded[]
+    included.forEach(data => {
+      if (data.type === TemplateType.View) {
+        cells.push(data.attributes.name)
+      }
+    })
+
+    return cells
+  }
+
+  private selectTemplate = (
+    selectedTemplateSummary: TemplateSummary
+  ) => async (): Promise<void> => {
+    this.setState({selectedTemplateSummary})
+    const selectedTemplate = await getTemplateByID(selectedTemplateSummary.id)
+    this.setState({
+      selectedTemplate,
+      variables: this.getVariablesForTemplate(selectedTemplate),
+      cells: this.getCellsForTemplate(selectedTemplate),
+    })
+  }
+
+  private onDismiss = () => {
+    const {router} = this.props
+    router.goBack()
+  }
+
+  private onSubmit = async (): Promise<void> => {
+    const {
+      createDashboardFromTemplate,
+      params: {orgID},
+    } = this.props
+
+    await createDashboardFromTemplate(
+      this.state.selectedTemplate as DashboardTemplate,
+      orgID
+    )
+    this.onDismiss()
+  }
+}
+
+const mstp = ({templates: {items, status}, orgs}: AppState): StateProps => ({
+  templates: items,
+  templateStatus: status,
+  orgs: orgs.items,
+})
+
+const mdtp: DispatchProps = {
+  createDashboardFromTemplate: createDashboardFromTemplateAction,
+}
+
+export default connect<StateProps>(
+  mstp,
+  mdtp
+)(withRouter(DashboardImportFromTemplateOverlay))

--- a/ui/src/dashboards/components/DashboardImportFromTemplateOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardImportFromTemplateOverlay.tsx
@@ -121,6 +121,7 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
           checked={_.get(selectedTemplateSummary, 'id', '') === t.id}
           label={t.meta.name}
           hideImage={true}
+          testID={`card-select-${t.meta.name}`}
         />
       )
     })
@@ -133,6 +134,7 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
         text="Create Dashboard"
         onClick={this.onSubmit}
         key="submit-button"
+        testID="create-dashboard-button"
         color={ComponentColor.Primary}
       />,
     ]

--- a/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCards.tsx
@@ -41,11 +41,12 @@ class DashboardCards extends PureComponent<Props> {
   }
 
   componentDidUpdate(prevProps) {
-    const {sortDirection, sortKey, sortedIDs} = this.props
+    const {sortDirection, sortKey, sortedIDs, dashboards} = this.props
 
     if (
       prevProps.sortDirection !== sortDirection ||
-      prevProps.sortKey !== sortKey
+      prevProps.sortKey !== sortKey ||
+      prevProps.dashboards.length !== dashboards.length
     ) {
       this.setState({sortedIDs})
     }

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -95,7 +95,9 @@ class DashboardIndex extends PureComponent<Props, State> {
               <AddResourceDropdown
                 onSelectNew={this.handleCreateDashboard}
                 onSelectImport={this.summonImportOverlay}
+                onSelectTemplate={this.summonImportFromTemplateOverlay}
                 resourceName="Dashboard"
+                canImportFromTemplate={true}
               />
             </Page.Header.Right>
           </Page.Header>
@@ -187,6 +189,14 @@ class DashboardIndex extends PureComponent<Props, State> {
       params: {orgID},
     } = this.props
     router.push(`/orgs/${orgID}/dashboards/import`)
+  }
+
+  private summonImportFromTemplateOverlay = (): void => {
+    const {
+      router,
+      params: {orgID},
+    } = this.props
+    router.push(`/orgs/${orgID}/dashboards/import/template`)
   }
 }
 

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -124,6 +124,14 @@ class DashboardsTable extends PureComponent<Props, State> {
     this.setState({sortKey, sortDirection: nextSort, sortType})
   }
 
+  private summonImportFromTemplateOverlay = (): void => {
+    const {
+      router,
+      params: {orgID},
+    } = this.props
+    router.push(`/orgs/${orgID}/dashboards/import/template`)
+  }
+
   private get emptyState(): JSX.Element {
     const {onCreateDashboard, searchTerm, onImportDashboard} = this.props
 
@@ -144,6 +152,7 @@ class DashboardsTable extends PureComponent<Props, State> {
         <AddResourceDropdown
           onSelectNew={onCreateDashboard}
           onSelectImport={onImportDashboard}
+          onSelectTemplate={this.summonImportFromTemplateOverlay}
           resourceName="Dashboard"
         />
       </EmptyState>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -27,6 +27,7 @@ import DashboardPage from 'src/dashboards/components/DashboardPage'
 import DashboardsIndex from 'src/dashboards/components/dashboard_index/DashboardsIndex'
 import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
+import DashboardImportFromTemplateOverlay from 'src/dashboards/components/DashboardImportFromTemplateOverlay'
 import DataExplorerPage from 'src/dataExplorer/components/DataExplorerPage'
 import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
 import {MePage, Account} from 'src/me'
@@ -141,6 +142,10 @@ class Root extends PureComponent {
                             <Route
                               path="import"
                               component={DashboardImportOverlay}
+                            />
+                            <Route
+                              path="import/template"
+                              component={DashboardImportFromTemplateOverlay}
                             />
                             <Route
                               path=":dashboardID/export"

--- a/ui/src/organizations/components/Dashboards.tsx
+++ b/ui/src/organizations/components/Dashboards.tsx
@@ -81,7 +81,9 @@ class Dashboards extends PureComponent<Props, State> {
           <AddResourceDropdown
             onSelectNew={this.handleCreateDashboard}
             onSelectImport={this.summonImportOverlay}
+            onSelectTemplate={this.summonImportFromTemplateOverlay}
             resourceName="Dashboard"
+            canImportFromTemplate={true}
           />
         </Tabs.TabContentsHeader>
         <DashboardsIndexContents
@@ -113,8 +115,19 @@ class Dashboards extends PureComponent<Props, State> {
   }
 
   private summonImportOverlay = (): void => {
-    const {router, params} = this.props
-    router.push(`/organizations/${params.orgID}/dashboards/import`)
+    const {
+      router,
+      params: {orgID},
+    } = this.props
+    router.push(`/organizations/${orgID}/dashboards/import`)
+  }
+
+  private summonImportFromTemplateOverlay = (): void => {
+    const {
+      router,
+      params: {orgID},
+    } = this.props
+    router.push(`/organizations/${orgID}/dashboards/import/template`)
   }
 
   private handleCreateDashboard = async (): Promise<void> => {

--- a/ui/src/shared/components/AddResourceDropdown.tsx
+++ b/ui/src/shared/components/AddResourceDropdown.tsx
@@ -8,13 +8,25 @@ import {Dropdown, DropdownMode} from 'src/clockface'
 // Types
 import {IconFont, ComponentColor, ComponentSize} from '@influxdata/clockface'
 
-interface Props {
+interface OwnProps {
   onSelectNew: () => void
   onSelectImport: () => void
+  onSelectTemplate?: () => void
   resourceName: string
+  canImportFromTemplate?: boolean
 }
 
+interface DefaultProps {
+  canImportFromTemplate: boolean
+}
+
+type Props = OwnProps & DefaultProps
+
 export default class AddResourceDropdown extends PureComponent<Props> {
+  public static defaultProps: DefaultProps = {
+    canImportFromTemplate: false,
+  }
+
   public render() {
     return (
       <Dropdown
@@ -34,7 +46,9 @@ export default class AddResourceDropdown extends PureComponent<Props> {
   private get optionItems(): JSX.Element[] {
     const importOption = this.importOption
     const newOption = this.newOption
-    return [
+    const templateOption = this.templateOption
+
+    const items = [
       <Dropdown.Item id={newOption} key={newOption} value={newOption}>
         {newOption}
       </Dropdown.Item>,
@@ -42,6 +56,20 @@ export default class AddResourceDropdown extends PureComponent<Props> {
         {importOption}
       </Dropdown.Item>,
     ]
+
+    if (!!this.props.canImportFromTemplate) {
+      items.push(
+        <Dropdown.Item
+          id={templateOption}
+          key={templateOption}
+          value={templateOption}
+        >
+          {templateOption}
+        </Dropdown.Item>
+      )
+    }
+
+    return items
   }
 
   private get newOption(): string {
@@ -52,14 +80,21 @@ export default class AddResourceDropdown extends PureComponent<Props> {
     return `Import ${this.props.resourceName}`
   }
 
+  private get templateOption(): string {
+    return `From a Template`
+  }
+
   private handleSelect = (selection: string): void => {
-    const {onSelectNew, onSelectImport} = this.props
+    const {onSelectNew, onSelectImport, onSelectTemplate} = this.props
 
     if (selection === this.newOption) {
       onSelectNew()
     }
     if (selection === this.importOption) {
       onSelectImport()
+    }
+    if (selection == this.templateOption) {
+      onSelectTemplate()
     }
   }
 }

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -107,6 +107,7 @@
 @import 'src/dataLoaders/components/DataLoadersOverlay.scss';
 @import 'src/shared/components/EmptyGraphError.scss';
 @import 'src/shared/components/dapperScrollbars/DapperScrollbars.scss';
+@import 'src/dashboards/components/DashboardImportFromTemplateOverlay.scss';
 
 // External
 @import '../../node_modules/@influxdata/react-custom-scrollbars/dist/styles.css';

--- a/ui/src/templates/actions/index.ts
+++ b/ui/src/templates/actions/index.ts
@@ -94,6 +94,11 @@ const removeTemplateSummary = (templateID: string): RemoveTemplateSummary => ({
   payload: {templateID},
 })
 
+export const getTemplateByID = async (id: string) => {
+  const template = await client.templates.get(id)
+  return template
+}
+
 export const getTemplatesForOrg = (orgName: string) => async dispatch => {
   dispatch(setTemplatesStatus(RemoteDataState.Loading))
   const items = await client.templates.getAll(orgName)


### PR DESCRIPTION
Closes #12913

This PR adds an overlay to create a new dashboard from a template.

![2019-04-01 17 22 52](https://user-images.githubusercontent.com/15273162/55367624-d49ced00-54a2-11e9-96d7-a1219cbc91f1.gif)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
