### PR TITLE
feat(influxdb): get docs by org id

### DIFF
--- a/http/document_test.go
+++ b/http/document_test.go
@@ -1,0 +1,272 @@
+package http
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	pcontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	influxtesting "github.com/influxdata/influxdb/testing"
+	"github.com/julienschmidt/httprouter"
+	"go.uber.org/zap"
+)
+
+// NewMockDocumentBackend returns a DocumentBackend with mock services.
+func NewMockDocumentBackend() *DocumentBackend {
+	return &DocumentBackend{
+		Logger: zap.NewNop().With(zap.String("handler", "document")),
+
+		DocumentService: mock.NewDocumentService(),
+	}
+}
+
+func TestService_handleGetDocuments(t *testing.T) {
+	type fields struct {
+		DocumentService influxdb.DocumentService
+	}
+	type args struct {
+		queryParams map[string][]string
+		authorizer  influxdb.Authorizer
+	}
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "get all documents without org or orgID",
+			fields: fields{
+				DocumentService: &mock.DocumentService{
+					FindDocumentStoreFn: func(context.Context, string) (influxdb.DocumentStore, error) {
+						return &mock.DocumentStore{}, nil
+					},
+				},
+			},
+			args: args{
+				authorizer: &influxdb.Session{UserID: influxtesting.MustIDBase16("020f755c3c082001")},
+			},
+			wants: wants{
+				statusCode:  http.StatusBadRequest,
+				contentType: "application/json; charset=utf-8",
+				body:        `{"code":"invalid", "message":"Please provide either org or orgID"}`,
+			},
+		},
+		{
+			name: "get all documents with both org and orgID",
+			fields: fields{
+				DocumentService: &mock.DocumentService{
+					FindDocumentStoreFn: func(context.Context, string) (influxdb.DocumentStore, error) {
+						return &mock.DocumentStore{}, nil
+					},
+				},
+			},
+			args: args{
+				queryParams: map[string][]string{
+					"orgID": []string{"020f755c3c082002"},
+					"org":   []string{"org1"},
+				},
+				authorizer: &influxdb.Session{UserID: influxtesting.MustIDBase16("020f755c3c082001")},
+			},
+			wants: wants{
+				statusCode:  http.StatusBadRequest,
+				contentType: "application/json; charset=utf-8",
+				body:        `{"code":"invalid", "message":"Please provide either org or orgID, not both"}`,
+			},
+		},
+		{
+			name: "get all documents with orgID",
+			fields: fields{
+				DocumentService: &mock.DocumentService{
+					FindDocumentStoreFn: func(context.Context, string) (influxdb.DocumentStore, error) {
+						return &mock.DocumentStore{
+							FindDocumentsFn: func(ctx context.Context, opts ...influxdb.DocumentFindOptions) ([]*influxdb.Document, error) {
+								return []*influxdb.Document{
+									{
+										ID: influxtesting.MustIDBase16("020f755c3c082010"),
+										Meta: influxdb.DocumentMeta{
+											Name: "doc1",
+										},
+										Content: "content1",
+										Labels: []*influxdb.Label{
+											{
+												Name: "l1",
+											},
+										},
+									},
+									{
+										ID: influxtesting.MustIDBase16("020f755c3c082011"),
+										Meta: influxdb.DocumentMeta{
+											Name: "doc2",
+										},
+										Content: "content2",
+									},
+								}, nil
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				queryParams: map[string][]string{
+					"orgID": []string{"020f755c3c082002"},
+				},
+				authorizer: &influxdb.Session{UserID: influxtesting.MustIDBase16("020f755c3c082001")},
+			},
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json; charset=utf-8",
+				body: `{
+					"documents":[
+						{
+							"id": "020f755c3c082010",
+							"links": {
+								"self": "/api/v2/documents/template/020f755c3c082010"
+							},
+							"content": "content1",
+							"labels": [
+                   				{
+                      				"name": "l1"
+                    			}
+                  			],
+							"meta": {
+								"name": "doc1"
+							}
+						},
+						{
+							"id": "020f755c3c082011",
+							"links": {
+								"self": "/api/v2/documents/template/020f755c3c082011"
+							},
+							"content": "content2", 
+							"meta": {
+								"name": "doc2"
+							}
+						}
+					]
+				}`,
+			},
+		},
+		{
+			name: "get all documents with org name",
+			fields: fields{
+				DocumentService: &mock.DocumentService{
+					FindDocumentStoreFn: func(context.Context, string) (influxdb.DocumentStore, error) {
+						return &mock.DocumentStore{
+							FindDocumentsFn: func(ctx context.Context, opts ...influxdb.DocumentFindOptions) ([]*influxdb.Document, error) {
+								return []*influxdb.Document{
+									{
+										ID: influxtesting.MustIDBase16("020f755c3c082010"),
+										Meta: influxdb.DocumentMeta{
+											Name: "doc1",
+										},
+										Content: "content1",
+										Labels: []*influxdb.Label{
+											{
+												Name: "l1",
+											},
+										},
+									},
+									{
+										ID: influxtesting.MustIDBase16("020f755c3c082011"),
+										Meta: influxdb.DocumentMeta{
+											Name: "doc2",
+										},
+										Content: "content2",
+									},
+								}, nil
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				queryParams: map[string][]string{
+					"org": []string{"org1"},
+				},
+				authorizer: &influxdb.Session{UserID: influxtesting.MustIDBase16("020f755c3c082001")},
+			},
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json; charset=utf-8",
+				body: `{
+					"documents":[
+						{
+							"id": "020f755c3c082010",
+							"links": {
+								"self": "/api/v2/documents/template/020f755c3c082010"
+							},
+							"content": "content1",
+							"labels": [
+                   				{
+                      				"name": "l1"
+                    			}
+                  			],
+							"meta": {
+								"name": "doc1"
+							}
+						},
+						{
+							"id": "020f755c3c082011",
+							"links": {
+								"self": "/api/v2/documents/template/020f755c3c082011"
+							},
+							"content": "content2", 
+							"meta": {
+								"name": "doc2"
+							}
+						}
+					]
+				}`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			documentBackend := NewMockDocumentBackend()
+			documentBackend.DocumentService = tt.fields.DocumentService
+			h := NewDocumentHandler(documentBackend)
+			r := httptest.NewRequest("GET", "http://any.url", nil)
+			qp := r.URL.Query()
+			for k, vs := range tt.args.queryParams {
+				for _, v := range vs {
+					qp.Add(k, v)
+				}
+			}
+			r.URL.RawQuery = qp.Encode()
+			r = r.WithContext(pcontext.SetAuthorizer(r.Context(), tt.args.authorizer))
+			r = r.WithContext(context.WithValue(r.Context(),
+				httprouter.ParamsKey,
+				httprouter.Params{
+					{
+						Key:   "ns",
+						Value: "template",
+					}}))
+			w := httptest.NewRecorder()
+			h.handleGetDocuments(w, r)
+			res := w.Result()
+			content := res.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(res.Body)
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("%q. handleGetDocuments() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+			}
+			if tt.wants.contentType != "" && content != tt.wants.contentType {
+				t.Errorf("%q. handleGetDocuments() = %v, want %v", tt.name, content, tt.wants.contentType)
+			}
+			if eq, diff, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
+				t.Errorf("%q. handleGetDocuments() = ***%s***", tt.name, diff)
+			}
+		})
+	}
+}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -103,7 +103,11 @@ paths:
           - in: query
             name: org
             description: specifies the name of the organization of the template
-            required: true
+            schema:
+              type: string
+          - in: query
+            name: orgID
+            description: specifies the organization id of the template
             schema:
               type: string
       responses:

--- a/kv/document.go
+++ b/kv/document.go
@@ -306,6 +306,15 @@ func (i *DocumentIndex) FindOrganizationByName(org string) (influxdb.ID, error) 
 	return o.ID, nil
 }
 
+// FindOrganizationByID checks if the org existence by the org id provided.
+func (i *DocumentIndex) FindOrganizationByID(id influxdb.ID) error {
+	_, err := i.service.findOrganizationByID(i.ctx, i.tx, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetDocumentsAccessors retrieves the list of accessors of a document.
 func (i *DocumentIndex) GetDocumentsAccessors(docID influxdb.ID) ([]influxdb.ID, error) {
 	f := influxdb.UserResourceMappingFilter{

--- a/mock/document_service.go
+++ b/mock/document_service.go
@@ -1,0 +1,83 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.DocumentStore = &DocumentStore{}
+
+// DocumentService is mocked document service.
+type DocumentService struct {
+	CreateDocumentStoreFn func(ctx context.Context, name string) (influxdb.DocumentStore, error)
+	FindDocumentStoreFn   func(ctx context.Context, name string) (influxdb.DocumentStore, error)
+}
+
+// CreateDocumentStore calls the mocked CreateDocumentStoreFn.
+func (s *DocumentService) CreateDocumentStore(ctx context.Context, name string) (influxdb.DocumentStore, error) {
+	return s.CreateDocumentStoreFn(ctx, name)
+}
+
+// FindDocumentStore calls the mocked FindDocumentStoreFn.
+func (s *DocumentService) FindDocumentStore(ctx context.Context, name string) (influxdb.DocumentStore, error) {
+	return s.FindDocumentStoreFn(ctx, name)
+}
+
+// NewDocumentService returns a mock of DocumentService where its methods will return zero values.
+func NewDocumentService() *DocumentService {
+	return &DocumentService{
+		CreateDocumentStoreFn: func(ctx context.Context, name string) (influxdb.DocumentStore, error) {
+			return nil, nil
+		},
+		FindDocumentStoreFn: func(ctx context.Context, name string) (influxdb.DocumentStore, error) {
+			return nil, nil
+		},
+	}
+}
+
+// DocumentStore is the mocked document store.
+type DocumentStore struct {
+	CreateDocumentFn  func(ctx context.Context, d *influxdb.Document, opts ...influxdb.DocumentOptions) error
+	UpdateDocumentFn  func(ctx context.Context, d *influxdb.Document, opts ...influxdb.DocumentOptions) error
+	FindDocumentsFn   func(ctx context.Context, opts ...influxdb.DocumentFindOptions) ([]*influxdb.Document, error)
+	DeleteDocumentsFn func(ctx context.Context, opts ...influxdb.DocumentFindOptions) error
+}
+
+// NewDocumentStore returns a mock of DocumentStore where its methods will return zero values.
+func NewDocumentStore() *DocumentStore {
+	return &DocumentStore{
+		CreateDocumentFn: func(ctx context.Context, d *influxdb.Document, opts ...influxdb.DocumentOptions) error {
+			return nil
+		},
+		UpdateDocumentFn: func(ctx context.Context, d *influxdb.Document, opts ...influxdb.DocumentOptions) error {
+			return nil
+		},
+		FindDocumentsFn: func(ctx context.Context, opts ...influxdb.DocumentFindOptions) ([]*influxdb.Document, error) {
+			return nil, nil
+		},
+		DeleteDocumentsFn: func(ctx context.Context, opts ...influxdb.DocumentFindOptions) error {
+			return nil
+		},
+	}
+}
+
+// CreateDocument will call the mocked CreateDocumentFn.
+func (s *DocumentStore) CreateDocument(ctx context.Context, d *influxdb.Document, opts ...influxdb.DocumentOptions) error {
+	return s.CreateDocumentFn(ctx, d, opts...)
+}
+
+// UpdateDocument will call the mocked UpdateDocumentFn.
+func (s *DocumentStore) UpdateDocument(ctx context.Context, d *influxdb.Document, opts ...influxdb.DocumentOptions) error {
+	return s.UpdateDocumentFn(ctx, d, opts...)
+}
+
+// FindDocuments will call the mocked FindDocumentsFn.
+func (s *DocumentStore) FindDocuments(ctx context.Context, opts ...influxdb.DocumentFindOptions) ([]*influxdb.Document, error) {
+	return s.FindDocumentsFn(ctx, opts...)
+}
+
+// DeleteDocuments will call the mocked DeleteDocumentsFn.
+func (s *DocumentStore) DeleteDocuments(ctx context.Context, opts ...influxdb.DocumentFindOptions) error {
+	return s.DeleteDocumentsFn(ctx, opts...)
+}


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/13076

Added the option of getting docs by org id

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
