### PR TITLE
feat(ui/template/labels): show template labels

### DIFF
--- a/ui/src/organizations/components/OrgTemplatesPage.tsx
+++ b/ui/src/organizations/components/OrgTemplatesPage.tsx
@@ -8,6 +8,7 @@ import TemplatesHeader from 'src/templates/components/TemplatesHeader'
 import OrgTemplatesList from 'src/organizations/components/OrgTemplatesList'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import GetLabels from 'src/configuration/components/GetLabels'
 
 // Types
 import {TemplateSummary} from '@influxdata/influx'
@@ -45,20 +46,22 @@ class OrgTemplatesPage extends PureComponent<Props, State> {
           isFullPage={false}
           filterComponent={() => this.filterComponent}
         />
-        <FilterList<TemplateSummary>
-          searchTerm={searchTerm}
-          searchKeys={['meta.name', 'labels[].name']}
-          list={templates}
-        >
-          {ts => (
-            <OrgTemplatesList
-              searchTerm={searchTerm}
-              templates={ts}
-              onFilterChange={this.setSearchTerm}
-              onImport={onImport}
-            />
-          )}
-        </FilterList>
+        <GetLabels>
+          <FilterList<TemplateSummary>
+            searchTerm={searchTerm}
+            searchKeys={['meta.name', 'labels[].name']}
+            list={templates}
+          >
+            {ts => (
+              <OrgTemplatesList
+                searchTerm={searchTerm}
+                templates={ts}
+                onFilterChange={this.setSearchTerm}
+                onImport={onImport}
+              />
+            )}
+          </FilterList>
+        </GetLabels>
       </>
     )
   }

--- a/ui/src/shared/components/inlineLabels/InlineLabels.tsx
+++ b/ui/src/shared/components/inlineLabels/InlineLabels.tsx
@@ -12,17 +12,27 @@ import {ILabel} from '@influxdata/influx'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+export enum LabelsEditMode {
+  Editable = 'editable',
+  Readonly = 'readonly',
+}
+
 interface Props {
+  editMode?: LabelsEditMode // temporary for displaying labels
   selectedLabels: ILabel[]
   labels: ILabel[]
-  onRemoveLabel: (label: ILabel) => void
-  onAddLabel: (label: ILabel) => void
-  onCreateLabel: (label: ILabel) => Promise<void>
-  onFilterChange: (searchTerm: string) => void
+  onRemoveLabel?: (label: ILabel) => void
+  onAddLabel?: (label: ILabel) => void
+  onCreateLabel?: (label: ILabel) => Promise<void>
+  onFilterChange?: (searchTerm: string) => void
 }
 
 @ErrorHandling
 export default class InlineLabels extends Component<Props> {
+  public static defaultProps = {
+    editMode: LabelsEditMode.Editable,
+  }
+
   public render() {
     return <div className="inline-labels">{this.selectedLabels}</div>
   }
@@ -32,12 +42,14 @@ export default class InlineLabels extends Component<Props> {
 
     return (
       <div className="inline-labels--container">
-        <InlineLabelsEditor
-          labels={labels}
-          selectedLabels={selectedLabels}
-          onAddLabel={onAddLabel}
-          onCreateLabel={onCreateLabel}
-        />
+        {this.isEditable && (
+          <InlineLabelsEditor
+            labels={labels}
+            selectedLabels={selectedLabels}
+            onAddLabel={onAddLabel}
+            onCreateLabel={onCreateLabel}
+          />
+        )}
         {this.currentLabels}
       </div>
     )
@@ -45,6 +57,7 @@ export default class InlineLabels extends Component<Props> {
 
   private get currentLabels(): JSX.Element[] {
     const {selectedLabels} = this.props
+    const onDelete = this.isEditable ? this.handleDeleteLabel : null
 
     if (selectedLabels.length) {
       return selectedLabels.map(label => (
@@ -54,11 +67,15 @@ export default class InlineLabels extends Component<Props> {
           name={label.name}
           colorHex={label.properties.color}
           description={label.properties.description}
-          onDelete={this.handleDeleteLabel}
+          onDelete={onDelete}
           onClick={this.handleLabelClick}
         />
       ))
     }
+  }
+
+  private get isEditable(): boolean {
+    return this.props.editMode === LabelsEditMode.Editable
   }
 
   private handleLabelClick = (labelID: string): void => {

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -798,6 +798,16 @@ export const importFailed = (): Notification => ({
 })
 
 // Templates
+export const addTemplatLabelFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Failed to add label to template',
+})
+
+export const removedTemplateLabelFailed = (): Notification => ({
+  ...defaultErrorNotification,
+  message: 'Failed to remove label from template',
+})
+
 export const TelegrafDashboardCreated = (configs: string[]): Notification => ({
   ...defaultSuccessNotification,
   message: `Successfully created dashboards for telegraf plugin${

--- a/ui/src/templates/actions/index.ts
+++ b/ui/src/templates/actions/index.ts
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import {templateToExport} from 'src/shared/utils/resourceToTemplate'
 
 // Types
-import {TemplateSummary, DocumentCreate} from '@influxdata/influx'
+import {TemplateSummary, DocumentCreate, ILabel} from '@influxdata/influx'
 import {RemoteDataState} from 'src/types'
 
 // Actions
@@ -187,4 +187,20 @@ export const cloneTemplate = (templateID: string, orgID: string) => async (
     console.error(e)
     dispatch(notify(copy.cloneTemplateFailed(e)))
   }
+}
+
+export const addTemplateLabelsAsync = (
+  _templateID: string,
+  _labels: ILabel[]
+) => async dispatch => {
+  // Todo add labels once API supports addition
+  dispatch(notify(copy.addTemplatLabelFailed()))
+}
+
+export const removeTemplateLabelsAsync = (
+  _templateID: string,
+  _labels: ILabel[]
+) => async dispatch => {
+  // Todo remove labels once API supports addition
+  dispatch(notify(copy.removedTemplateLabelFailed()))
 }

--- a/ui/src/templates/actions/index.ts
+++ b/ui/src/templates/actions/index.ts
@@ -4,12 +4,7 @@ import _ from 'lodash'
 import {templateToExport} from 'src/shared/utils/resourceToTemplate'
 
 // Types
-import {
-  TemplateSummary,
-  DocumentCreate,
-  ILabel,
-  ITemplate,
-} from '@influxdata/influx'
+import {TemplateSummary, DocumentCreate} from '@influxdata/influx'
 import {RemoteDataState} from 'src/types'
 
 // Actions
@@ -192,42 +187,4 @@ export const cloneTemplate = (templateID: string, orgID: string) => async (
     console.error(e)
     dispatch(notify(copy.cloneTemplateFailed(e)))
   }
-}
-
-export const addTemplateLabelsAsync = (
-  templateID: string,
-  labels: ILabel[]
-) => async dispatch => {
-  try {
-    const templateDocument = await client.templates.get(templateID)
-
-    const templateLabelsUpdate: Partial<ITemplate> = {
-      id: templateID,
-      labels: [...templateDocument.labels, ...labels],
-    }
-
-    const {id, labels: updatedLables, meta} = await client.templates.update(
-      templateID,
-      templateLabelsUpdate
-    )
-
-    dispatch(
-      setTemplateSummary(templateID, {
-        id,
-        meta,
-        labels: updatedLables,
-      })
-    )
-  } catch (e) {
-    // Todo add labels once API supports addition
-    dispatch(notify(copy.addTemplatLabelFailed()))
-  }
-}
-
-export const removeTemplateLabelsAsync = (
-  _templateID: string,
-  _labels: ILabel[]
-) => async dispatch => {
-  // Todo remove labels once API supports addition
-  dispatch(notify(copy.removedTemplateLabelFailed()))
 }

--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -5,18 +5,16 @@ import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {ResourceList, Context, IconFont} from 'src/clockface'
-import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+import InlineLabels, {
+  LabelsEditMode,
+} from 'src/shared/components/inlineLabels/InlineLabels'
 
 // Actions
 import {
   deleteTemplate,
   cloneTemplate,
   updateTemplate,
-  addTemplateLabelsAsync,
-  removeTemplateLabelsAsync,
 } from 'src/templates/actions'
-import {createLabel as createLabelAsync} from 'src/labels/actions'
-
 // Selectors
 import {viewableLabels} from 'src/labels/selectors'
 
@@ -37,9 +35,6 @@ interface DispatchProps {
   onDelete: typeof deleteTemplate
   onClone: typeof cloneTemplate
   onUpdate: typeof updateTemplate
-  onCreateLabel: typeof createLabelAsync
-  onAddLabels: typeof addTemplateLabelsAsync
-  onRemoveLabels: typeof removeTemplateLabelsAsync
 }
 
 interface StateProps {
@@ -48,7 +43,7 @@ interface StateProps {
 
 type Props = DispatchProps & OwnProps & StateProps
 
-export class TemplateCard extends PureComponent<Props & WithRouterProps> {
+class TemplateCard extends PureComponent<Props & WithRouterProps> {
   public render() {
     const {template, labels, onFilterChange} = this.props
 
@@ -72,37 +67,11 @@ export class TemplateCard extends PureComponent<Props & WithRouterProps> {
             selectedLabels={template.labels}
             labels={labels}
             onFilterChange={onFilterChange}
-            onAddLabel={this.handleAddLabel}
-            onRemoveLabel={this.handleRemoveLabel}
-            onCreateLabel={this.handleCreateLabel}
+            editMode={LabelsEditMode.Readonly}
           />
         )}
       />
     )
-  }
-
-  private handleAddLabel = (label: ILabel) => {
-    const {onAddLabels, template} = this.props
-
-    onAddLabels(template.id, [label])
-  }
-
-  private handleRemoveLabel = (label: ILabel) => {
-    const {onRemoveLabels, template} = this.props
-
-    onRemoveLabels(template.id, [label])
-  }
-
-  private handleCreateLabel = async (label: ILabel): Promise<void> => {
-    try {
-      await this.props.onCreateLabel(label.orgID, label.name, label.properties)
-
-      // notify success
-    } catch (err) {
-      console.error(err)
-      // notify of fail
-      throw err
-    }
   }
 
   private handleUpdateTemplate = (name: string) => {
@@ -177,12 +146,9 @@ const mdtp: DispatchProps = {
   onDelete: deleteTemplate,
   onClone: cloneTemplate,
   onUpdate: updateTemplate,
-  onCreateLabel: createLabelAsync,
-  onAddLabels: addTemplateLabelsAsync,
-  onRemoveLabels: removeTemplateLabelsAsync,
 }
 
-export default connect<{}, DispatchProps, OwnProps>(
+export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
 )(withRouter<Props>(TemplateCard))


### PR DESCRIPTION
Closes #12907 

_Briefly describe your proposed changes:_
Display labels for templates, but hold off on adding and removing templates labels in the UI. This is accomplished by adding a `editMode` prop to the `InlineLabels` component. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

![Screen Shot 2019-04-02 at 5 24 35 PM](https://user-images.githubusercontent.com/4994741/55437166-3d9c6780-556c-11e9-96c6-7f9a095d63ad.png)
Clicking also filters
![Screen Shot 2019-04-02 at 5 26 24 PM](https://user-images.githubusercontent.com/4994741/55437284-848a5d00-556c-11e9-88f7-c19585c5d22b.png)
