### PR TITLE
checktime - custom error message to match precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [13024](https://github.com/influxdata/influxdb/pull/13024): Add the ability to edit token's description
 1. [13078](https://github.com/influxdata/influxdb/pull/13078): Add the option to create a Dashboard from a Template.
+1. [13120](https://github.com/influxdata/influxdb/pull/13120): Fix checktime error message to match precision
 
 ### Bug Fixes
 

--- a/models/time.go
+++ b/models/time.go
@@ -38,7 +38,9 @@ var (
 	maxNanoTime = time.Unix(0, MaxNanoTime).UTC()
 
 	// ErrTimeOutOfRange gets returned when time is out of the representable range using int64 nanoseconds since the epoch.
-	ErrTimeOutOfRange = fmt.Errorf("time outside range %d - %d", MinNanoTime, MaxNanoTime)
+	ErrTimeOutOfRange = func(timestamp, mult int64) error {
+		return fmt.Errorf("time %d is outside the range [%d, %d]", timestamp, MinNanoTime/mult, MaxNanoTime/mult)
+	}
 )
 
 // SafeCalcTime safely calculates the time given. Will return error if the time is outside the
@@ -50,13 +52,13 @@ func SafeCalcTime(timestamp int64, precision string) (time.Time, error) {
 		return tme, CheckTime(tme)
 	}
 
-	return time.Time{}, ErrTimeOutOfRange
+	return time.Time{}, ErrTimeOutOfRange(timestamp, mult)
 }
 
 // CheckTime checks that a time is within the safe range.
 func CheckTime(t time.Time) error {
 	if t.Before(minNanoTime) || t.After(maxNanoTime) {
-		return ErrTimeOutOfRange
+		return ErrTimeOutOfRange(t.Unix(), 1)
 	}
 	return nil
 }

--- a/models/time_test.go
+++ b/models/time_test.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCheckTimeOutOfRangeErrorByPrecision(t *testing.T) {
+	type args struct {
+		timestamp int64
+		precision string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{name: "nanoSeconds", args: args{timestamp: 1554210031000000000, precision: "ns"}, want: time.Unix(0, 1554210031000000000).UTC().String()},
+		{name: "microSeconds", args: args{timestamp: 1554210031000000000, precision: "us"}, want: "time 1554210031000000000 is outside the range [-9223372036854775, 9223372036854775]", wantErr: true},
+		{name: "milliSeconds", args: args{timestamp: 1554210031000000000, precision: "ms"}, want: "time 1554210031000000000 is outside the range [-9223372036854, 9223372036854]", wantErr: true},
+		{name: "seconds", args: args{timestamp: 1554210031000000000, precision: "s"}, want: "time 1554210031000000000 is outside the range [-9223372036, 9223372036]", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeCalcTime(tt.args.timestamp, tt.args.precision)
+			if tt.wantErr {
+				if !reflect.DeepEqual(err.Error(), tt.want) {
+					t.Errorf("SafeCalcTime() = %v, want %v", err.Error(), tt.want)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got.String(), tt.want) {
+				t.Errorf("SafeCalcTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #13118

The PR enriches the error message by adding the time ranges by precision. 

  - [ X ] Rebased/mergeable
  - [ X ] Tests pass
  - [ X ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
