### PR TITLE
Update client dependency for dashboards get all

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -985,9 +985,9 @@
       }
     },
     "@influxdata/influx": {
-      "version": "0.2.56",
-      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.56.tgz",
-      "integrity": "sha512-T3kHMi+i/3hu7arS8V7FoFWzExjZsm8Vsy2Clo4puczM+1zHNYLP/zaC/eFyD5VaVsfQmJ3FgbLPUcYiFLPUbg==",
+      "version": "0.2.59",
+      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.2.59.tgz",
+      "integrity": "sha512-ow3iqzryF5a17kBbWLxCRjrLqAVAuMsVa2wSeaWikL7SgWDK3+oEi5T5StvM9SreB6+3Q0RIyct5TC+7T1QPiA==",
       "requires": {
         "axios": "^0.18.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -137,7 +137,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "0.0.8",
-    "@influxdata/influx": "0.2.56",
+    "@influxdata/influx": "0.2.59",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "@influxdata/vis": "^0.2.3",
     "axios": "^0.18.0",

--- a/ui/src/authorizations/apis/__mocks__/data.ts
+++ b/ui/src/authorizations/apis/__mocks__/data.ts
@@ -1,8 +1,13 @@
-import {Permission, PermissionResource, Authorization} from '@influxdata/influx'
+import {
+  Permission,
+  PermissionResource,
+  Authorization,
+  AuthorizationUpdateRequest,
+} from '@influxdata/influx'
 
 const {TypeEnum} = PermissionResource
 const {ActionEnum} = Permission
-const {StatusEnum} = Authorization
+const {StatusEnum} = AuthorizationUpdateRequest
 
 export const authorization: Authorization = {
   links: {

--- a/ui/src/authorizations/components/TokenRow.tsx
+++ b/ui/src/authorizations/components/TokenRow.tsx
@@ -14,7 +14,7 @@ import {IndexList, ComponentSpacer, ConfirmationButton} from 'src/clockface'
 import EditableName from 'src/shared/components/EditableName'
 
 // Types
-import {Authorization} from '@influxdata/influx'
+import {Authorization, AuthorizationUpdateRequest} from '@influxdata/influx'
 
 interface OwnProps {
   auth: Authorization
@@ -65,15 +65,15 @@ class TokenRow extends PureComponent<Props> {
 
   private get isTokenEnbled(): boolean {
     const {auth} = this.props
-    return auth.status === Authorization.StatusEnum.Active
+    return auth.status === AuthorizationUpdateRequest.StatusEnum.Active
   }
 
   private changeToggle = () => {
     const {auth, onUpdate} = this.props
-    if (auth.status === Authorization.StatusEnum.Active) {
-      auth.status = Authorization.StatusEnum.Inactive
+    if (auth.status === AuthorizationUpdateRequest.StatusEnum.Active) {
+      auth.status = AuthorizationUpdateRequest.StatusEnum.Inactive
     } else {
-      auth.status = Authorization.StatusEnum.Active
+      auth.status = AuthorizationUpdateRequest.StatusEnum.Active
     }
     onUpdate(auth)
   }

--- a/ui/src/dashboards/apis/index.ts
+++ b/ui/src/dashboards/apis/index.ts
@@ -21,7 +21,7 @@ export const addDashboardIDToCells = (
 
 // TODO(desa): what to do about getting dashboards from another v2 source
 export const getDashboards = async (orgID: string): Promise<Dashboard[]> => {
-  const dashboards = await client.dashboards.getAllByOrgID(orgID)
+  const dashboards = await client.dashboards.getAll(orgID)
 
   return dashboards.map(d => ({
     ...d,
@@ -41,7 +41,7 @@ export const getDashboard = async (id: string): Promise<Dashboard> => {
 export const getDashboardsByOrgID = async (
   orgID: string
 ): Promise<Dashboard[]> => {
-  const dashboards = await client.dashboards.getAllByOrgID(orgID)
+  const dashboards = await client.dashboards.getAll(orgID)
 
   return dashboards.map(d => ({
     ...d,

--- a/ui/src/dashboards/apis/v2/index.ts
+++ b/ui/src/dashboards/apis/v2/index.ts
@@ -32,7 +32,7 @@ export const getDashboards = async (): Promise<Dashboard[]> => {
 export const getDashboardsByOrgID = async (
   orgID: string
 ): Promise<Dashboard[]> => {
-  const dashboards = await client.dashboards.getAllByOrgID(orgID)
+  const dashboards = await client.dashboards.getAll(orgID)
 
   return dashboards.map(d => ({
     ...d,


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Additionally, updates the where the Authorization status enum comes from due to api generation changes.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
