### PR TITLE
Reorder the task runs columns

### DIFF
--- a/ui/src/tasks/actions/index.ts
+++ b/ui/src/tasks/actions/index.ts
@@ -3,7 +3,7 @@ import {push, goBack} from 'react-router-redux'
 import _ from 'lodash'
 
 // APIs
-import {Run, LogEvent, ITask as Task} from '@influxdata/influx'
+import {LogEvent, ITask as Task} from '@influxdata/influx'
 import {client} from 'src/utils/api'
 import {notify} from 'src/shared/actions/notifications'
 import {
@@ -41,6 +41,7 @@ import {taskToTemplate} from 'src/shared/utils/resourceToTemplate'
 
 // Types
 import {RemoteDataState} from '@influxdata/clockface'
+import {Run} from 'src/tasks/components/TaskRunsPage'
 
 export type Action =
   | SetNewScript
@@ -460,7 +461,17 @@ export const getRuns = (taskID: string) => async (dispatch): Promise<void> => {
 
     const runs = await client.tasks.getRunsByTaskID(taskID)
 
-    dispatch(setRuns(runs, RemoteDataState.Done))
+    const runsWithDuration = runs.map(run => {
+      const finished = new Date(run.finishedAt)
+      const started = new Date(run.startedAt)
+
+      return {
+        ...run,
+        duration: `${finished.getTime() - started.getTime()} seconds`,
+      }
+    })
+
+    dispatch(setRuns(runsWithDuration, RemoteDataState.Done))
   } catch (error) {
     console.error(error)
     const message = getErrorMessage(error)

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -124,8 +124,12 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
   }
 
   private handleViewRuns = () => {
-    const {router, task} = this.props
-    router.push(`tasks/${task.id}/runs`)
+    const {
+      router,
+      task,
+      params: {orgID},
+    } = this.props
+    router.push(`/orgs/${orgID}/tasks/${task.id}/runs`)
   }
 
   private handleRenameTask = async (name: string) => {

--- a/ui/src/tasks/components/TaskRunsList.tsx
+++ b/ui/src/tasks/components/TaskRunsList.tsx
@@ -8,8 +8,8 @@ import TaskRunsRow from 'src/tasks/components/TaskRunsRow'
 import SortingHat from 'src/shared/components/sorting_hat/SortingHat'
 
 // Types
-import {Run} from '@influxdata/influx'
 import {Sort, ComponentSize} from '@influxdata/clockface'
+import {Run} from 'src/tasks/components/TaskRunsPage'
 
 interface Props {
   taskID: string
@@ -34,49 +34,42 @@ export default class TaskRunsList extends PureComponent<Props, State> {
 
   public render() {
     const {sortKey, sortDirection} = this.state
+
     const headerKeys: SortKey[] = [
-      'requestedAt',
-      'startedAt',
-      'finishedAt',
       'status',
       'scheduledFor',
+      'startedAt',
+      'duration',
     ]
     return (
       <IndexList>
         <IndexList.Header>
           <IndexList.HeaderCell
-            columnName="Requested At"
-            width="20%"
+            columnName="Status"
+            width="10%"
             sortKey={headerKeys[0]}
             sort={sortKey === headerKeys[0] ? sortDirection : Sort.None}
             onClick={this.handleClickColumn}
           />
           <IndexList.HeaderCell
-            columnName="Started At"
+            columnName="Schedule"
             width="20%"
             sortKey={headerKeys[1]}
             sort={sortKey === headerKeys[1] ? sortDirection : Sort.None}
             onClick={this.handleClickColumn}
           />
           <IndexList.HeaderCell
-            columnName="Finished At"
+            columnName="Started"
             width="20%"
             sortKey={headerKeys[2]}
             sort={sortKey === headerKeys[2] ? sortDirection : Sort.None}
             onClick={this.handleClickColumn}
           />
           <IndexList.HeaderCell
-            columnName="Status"
-            width="10%"
+            columnName="Duration"
+            width="20%"
             sortKey={headerKeys[3]}
             sort={sortKey === headerKeys[3] ? sortDirection : Sort.None}
-            onClick={this.handleClickColumn}
-          />
-          <IndexList.HeaderCell
-            columnName="Schedule For"
-            width="20%"
-            sortKey={headerKeys[4]}
-            sort={sortKey === headerKeys[4] ? sortDirection : Sort.None}
             onClick={this.handleClickColumn}
           />
           <IndexList.HeaderCell width="10%" />

--- a/ui/src/tasks/components/TaskRunsPage.tsx
+++ b/ui/src/tasks/components/TaskRunsPage.tsx
@@ -9,12 +9,16 @@ import TaskRunsList from 'src/tasks/components/TaskRunsList'
 // Types
 import {AppState} from 'src/types'
 import {RemoteDataState} from 'src/types'
-import {Run} from '@influxdata/influx'
+import {Run as APIRun} from '@influxdata/influx'
 import {SpinnerContainer, TechnoSpinner, Button} from '@influxdata/clockface'
 
 // Actions
 import {getRuns, runTask} from 'src/tasks/actions'
 import {IconFont} from 'src/clockface'
+
+export interface Run extends APIRun {
+  duration: string
+}
 
 interface OwnProps {
   params: {id: string}
@@ -35,6 +39,7 @@ type Props = OwnProps & DispatchProps & StateProps
 class TaskRunsPage extends PureComponent<Props> {
   public render() {
     const {params, runs} = this.props
+
     return (
       <SpinnerContainer
         loading={this.props.runStatus}

--- a/ui/src/tasks/components/TaskRunsRow.tsx
+++ b/ui/src/tasks/components/TaskRunsRow.tsx
@@ -12,9 +12,10 @@ import {getLogs} from 'src/tasks/actions'
 
 // Types
 import {ComponentSize, ComponentColor, Button} from '@influxdata/clockface'
-import {Run, LogEvent} from '@influxdata/influx'
+import {LogEvent} from '@influxdata/influx'
 import {AppState} from 'src/types'
 import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+import {Run} from 'src/tasks/components/TaskRunsPage'
 
 interface OwnProps {
   taskID: string
@@ -49,15 +50,12 @@ class TaskRunsRow extends PureComponent<Props, State> {
     return (
       <>
         <IndexList.Row>
-          <IndexList.Cell>
-            {this.dateTimeString(run.requestedAt)}
-          </IndexList.Cell>
-          <IndexList.Cell>{this.dateTimeString(run.startedAt)}</IndexList.Cell>
-          <IndexList.Cell>{this.dateTimeString(run.finishedAt)}</IndexList.Cell>
           <IndexList.Cell>{run.status}</IndexList.Cell>
           <IndexList.Cell>
             {this.dateTimeString(run.scheduledFor)}
           </IndexList.Cell>
+          <IndexList.Cell>{this.dateTimeString(run.startedAt)}</IndexList.Cell>
+          <IndexList.Cell>{run.duration}</IndexList.Cell>
           <IndexList.Cell>
             <Button
               key={run.id}

--- a/ui/src/tasks/reducers/index.ts
+++ b/ui/src/tasks/reducers/index.ts
@@ -1,10 +1,11 @@
 import {TaskOptions, TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
-import {Run, LogEvent} from '@influxdata/influx'
+import {LogEvent} from '@influxdata/influx'
 
 //Types
 import {Action} from 'src/tasks/actions'
 import {ITask as Task} from '@influxdata/influx'
 import {RemoteDataState} from '@influxdata/clockface'
+import {Run} from 'src/tasks/components/TaskRunsPage'
 
 export interface State {
   newScript: string


### PR DESCRIPTION
Closes #13047 

_Briefly describe your proposed changes:_
Updated the order of columns on tasks runs and added duration onto the Run object
Updated tasks runs route to include orgs/orgID

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
