### PR TITLE
fix(reads): HasFieldValueKey searches for "$", not "_value"

### DIFF
--- a/storage/reads/predicate.go
+++ b/storage/reads/predicate.go
@@ -18,6 +18,7 @@ const (
 	fieldKey       = "_field"
 	measurementKey = "_measurement"
 	valueKey       = "_value"
+	fieldRef       = "$"
 )
 
 // NodeVisitor can be called by Walk to traverse the Node hierarchy.
@@ -454,7 +455,7 @@ func (v *nodeToExprVisitor) Visit(n *datatypes.Node) NodeVisitor {
 		return nil
 
 	case datatypes.NodeTypeFieldRef:
-		v.exprs = append(v.exprs, &influxql.VarRef{Val: "$"})
+		v.exprs = append(v.exprs, &influxql.VarRef{Val: fieldRef})
 		return nil
 
 	case datatypes.NodeTypeLiteral:
@@ -533,7 +534,7 @@ func RewriteExprRemoveFieldValue(expr influxql.Expr) influxql.Expr {
 	return influxql.RewriteExpr(expr, func(expr influxql.Expr) influxql.Expr {
 		if be, ok := expr.(*influxql.BinaryExpr); ok {
 			if ref, ok := be.LHS.(*influxql.VarRef); ok {
-				if ref.Val == "$" {
+				if ref.Val == fieldRef {
 					return &influxql.BooleanLiteral{Val: true}
 				}
 			}
@@ -576,7 +577,7 @@ func (v *hasRefs) Visit(node influxql.Node) influxql.Visitor {
 }
 
 func HasFieldValueKey(expr influxql.Expr) bool {
-	refs := hasRefs{refs: []string{valueKey}, found: make([]bool, 1)}
+	refs := hasRefs{refs: []string{fieldRef}, found: make([]bool, 1)}
 	influxql.Walk(&refs, expr)
 	return refs.found[0]
 }

--- a/storage/reads/predicate_test.go
+++ b/storage/reads/predicate_test.go
@@ -56,3 +56,87 @@ func TestPredicateToExprString(t *testing.T) {
 		})
 	}
 }
+
+func TestHasFieldValueKey(t *testing.T) {
+	predicates := []*datatypes.Node{
+		{
+			NodeType: datatypes.NodeTypeComparisonExpression,
+			Value: &datatypes.Node_Comparison_{
+				Comparison: datatypes.ComparisonLess,
+			},
+			Children: []*datatypes.Node{
+				{
+					NodeType: datatypes.NodeTypeFieldRef,
+					Value: &datatypes.Node_FieldRefValue{
+						FieldRefValue: "_value",
+					},
+				},
+				{
+					NodeType: datatypes.NodeTypeLiteral,
+					Value: &datatypes.Node_IntegerValue{
+						IntegerValue: 3000,
+					},
+				},
+			},
+		},
+		{
+			NodeType: datatypes.NodeTypeLogicalExpression,
+			Value: &datatypes.Node_Logical_{
+				Logical: datatypes.LogicalAnd,
+			},
+			Children: []*datatypes.Node{
+				{
+					NodeType: datatypes.NodeTypeComparisonExpression,
+					Value: &datatypes.Node_Comparison_{
+						Comparison: datatypes.ComparisonEqual,
+					},
+					Children: []*datatypes.Node{
+						{
+							NodeType: datatypes.NodeTypeTagRef,
+							Value: &datatypes.Node_TagRefValue{
+								TagRefValue: "_measurement",
+							},
+						},
+						{
+							NodeType: datatypes.NodeTypeLiteral,
+							Value: &datatypes.Node_StringValue{
+								StringValue: "cpu",
+							},
+						},
+					},
+				},
+				{
+					NodeType: datatypes.NodeTypeComparisonExpression,
+					Value: &datatypes.Node_Comparison_{
+						Comparison: datatypes.ComparisonLess,
+					},
+					Children: []*datatypes.Node{
+						{
+							NodeType: datatypes.NodeTypeFieldRef,
+							Value: &datatypes.Node_FieldRefValue{
+								FieldRefValue: "_value",
+							},
+						},
+						{
+							NodeType: datatypes.NodeTypeLiteral,
+							Value: &datatypes.Node_IntegerValue{
+								IntegerValue: 3000,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, predicate := range predicates {
+		t.Run("", func(t *testing.T) {
+			expr, err := reads.NodeToExpr(predicate, nil)
+			if err != nil {
+				t.Fatalf("unexpected error converting predicate to InfluxQL expression: %v", err)
+			}
+			if !reads.HasFieldValueKey(expr) {
+				t.Fatalf("did not find a field reference in %v", expr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_

The function `HasKeyFieldValue` searched an influxql expression for references to `_value`. But the function `NodeToExpr` takes an influxql expression (protobuf message) and replaces all references to `_value` with `$`.

This change makes it so `HasKeyFieldValue` searches for references to `$`. This fixes a bug where a value predicate would mistakenly be assigned as predicate consisting only of tag values.
https://github.com/influxdata/influxdb/blob/a5478652ba0eefa2c1bef8dc091305f29086d405/storage/readservice/cursor.go#L67

This would cause a series cursor error for any queries that filtered on `_value` like so:

    from() |> range() |> filter(fn: (r) => r._value < 3000)

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
