### PR TITLE
docs(http): remove FluxLinks schema

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5907,18 +5907,6 @@ components:
               type: string
             params:
               type: object
-    FluxLinks:
-      type: object
-      properties:
-        ast:
-          type: string
-          format: uri
-        self:
-          type: string
-          format: uri
-        suggestions:
-          type: string
-          format: uri
     Routes:
       properties:
         authorizations:


### PR DESCRIPTION
Closes #13145

The `FluxLinks` 
https://github.com/influxdata/influxdb/blob/77829324e949aef5b022f51f8e2d431dfad64795/http/swagger.yml#L5910-L5921

has been replaced by 
https://github.com/influxdata/influxdb/blob/77829324e949aef5b022f51f8e2d431dfad64795/http/swagger.yml#L5948-L5965

Related PR https://github.com/influxdata/platform/pull/2088

_Briefly describe your proposed changes:_

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
