### PR TITLE
feat(nav): allow user to switch orgs from the navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [13024](https://github.com/influxdata/influxdb/pull/13024): Add the ability to edit token's description
 1. [13078](https://github.com/influxdata/influxdb/pull/13078): Add the option to create a Dashboard from a Template.
 1. [13161](https://github.com/influxdata/influxdb/pull/13161): Add the ability to add labels on variables
+1. [13171](https://github.com/influxdata/influxdb/pull/13171): Add switch organizations dropdown to home navigation menu item.
 
 ### Bug Fixes
 

--- a/ui/src/clockface/types/index.ts
+++ b/ui/src/clockface/types/index.ts
@@ -188,4 +188,5 @@ export enum Stack {
 export enum NavMenuType {
   RouterLink = 'router',
   HTTPLink = 'http',
+  ShowDropdown = 'showDropdown',
 }

--- a/ui/src/pageLayout/components/AccountNavSubItem.tsx
+++ b/ui/src/pageLayout/components/AccountNavSubItem.tsx
@@ -1,0 +1,76 @@
+// Libraries
+import React, {SFC} from 'react'
+
+// Components
+import NavMenu from 'src/pageLayout/components/NavMenu'
+import {Organization} from '@influxdata/influx'
+import {NavMenuType} from 'src/clockface'
+import CloudFeatureFlag from 'src/shared/components/CloudFeatureFlag'
+
+interface Props {
+  orgs: Organization[]
+  showOrganizations: boolean
+  toggleOrganizationsView: () => void
+}
+
+const AccountNavSubItem: SFC<Props> = ({
+  orgs,
+  showOrganizations,
+  toggleOrganizationsView,
+}) => {
+  if (showOrganizations) {
+    return (
+      <>
+        {orgs.reduce(
+          (acc, org) => {
+            acc.push(
+              <NavMenu.SubItem
+                title={org.name}
+                path={`/orgs/${org.id}`}
+                key={org.id}
+                type={NavMenuType.RouterLink}
+                active={false}
+              />
+            )
+            return acc
+          },
+          [
+            <NavMenu.SubItem
+              title="< Back"
+              onClick={toggleOrganizationsView}
+              type={NavMenuType.ShowDropdown}
+              active={false}
+              key="back-button"
+              className="back-button"
+            />,
+          ]
+        )}
+      </>
+    )
+  }
+
+  return (
+    <>
+      <CloudFeatureFlag key="feature-flag">
+        {orgs.length > 1 && (
+          <NavMenu.SubItem
+            title="Switch Organizations"
+            onClick={toggleOrganizationsView}
+            type={NavMenuType.ShowDropdown}
+            active={false}
+            key="switch-orgs"
+          />
+        )}
+      </CloudFeatureFlag>
+
+      <NavMenu.SubItem
+        title="Logout"
+        path="/logout"
+        active={false}
+        key="logout"
+      />
+    </>
+  )
+}
+
+export default AccountNavSubItem

--- a/ui/src/pageLayout/components/Nav.scss
+++ b/ui/src/pageLayout/components/Nav.scss
@@ -205,4 +205,8 @@ $nav--bg-accent: $c-comet;
   &:last-child {
     border-bottom-right-radius: $radius;
   }
+
+  &.back-button {
+    font-weight: bolder;
+  }
 }

--- a/ui/src/pageLayout/components/NavMenuSubItem.tsx
+++ b/ui/src/pageLayout/components/NavMenuSubItem.tsx
@@ -6,28 +6,24 @@ import classnames from 'classnames'
 // Types
 import {NavMenuType} from 'src/clockface'
 
-interface PassedProps {
+interface Props {
   title: string
-  path: string
+  path?: string
   active: boolean
   className?: string
-}
-
-interface DefaultProps {
   type: NavMenuType
   testID: string
+  onClick?: () => void
 }
 
-type Props = PassedProps & Partial<DefaultProps>
-
 class NavMenuSubItem extends PureComponent<Props> {
-  public static defaultProps: DefaultProps = {
+  public static defaultProps = {
     type: NavMenuType.RouterLink,
     testID: 'nav-menu--sub-item',
   }
 
   public render() {
-    const {title, path, testID, type, active, className} = this.props
+    const {title, path, testID, type, active, className, onClick} = this.props
 
     if (type === NavMenuType.RouterLink) {
       return (
@@ -41,6 +37,14 @@ class NavMenuSubItem extends PureComponent<Props> {
         >
           {title}
         </Link>
+      )
+    }
+
+    if (type === NavMenuType.ShowDropdown) {
+      return (
+        <div className={`nav--sub-item ${className}`} onClick={onClick}>
+          {title}
+        </div>
       )
     }
 


### PR DESCRIPTION
Closes #13157

This PR adds an organizations dropdown to the Home nav bar item. From this dropdown, the user can switch organizations and will be redirected to the Home page in that organization context.

This feature is feature flagged for Cloud for now.

The `/me` subroute is also removed from the Home page because it is redundant. 

![2019-04-04 13 44 19](https://user-images.githubusercontent.com/15273162/55590880-056e6380-56e9-11e9-9bfc-95c51d29ce85.gif)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
