### PR TITLE
track remote read requests to prometheus remote read handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v1.8.0 [unreleased]
 
 -	[#10503](https://github.com/influxdata/influxdb/pull/10503): Delete rebuilds series index when series to be deleted are only found in cache.
 -	[#10504](https://github.com/influxdata/influxdb/issue/10504): Delete rebuilds series index when series to be deleted are outside timerange.
+-	[#13181](https://github.com/influxdata/influxdb/pull/13181): Track prometheus remote read request stats.
 
 v1.7.0 [unreleased]
 -------------------

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1034,6 +1034,7 @@ func (h *Handler) servePromWrite(w http.ResponseWriter, r *http.Request, user me
 // servePromRead will convert a Prometheus remote read request into a storage
 // query and returns data in Prometheus remote read protobuf format.
 func (h *Handler) servePromRead(w http.ResponseWriter, r *http.Request, user meta.User) {
+	atomic.AddInt64(&h.stats.PromReadRequests, 1)
 	compressed, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		h.httpError(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Closes #13167 

_Briefly describe your proposed changes:_

track remote read requests from prometheus handler with the PromReadRequests stat. aka mirror functionality done in the PromWriteRequests stats from the servePromWrite() handler

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
