### PR TITLE
Update predicate key mapping to match 2.x behavior

### DIFF
--- a/services/storage/predicate_influxql.go
+++ b/services/storage/predicate_influxql.go
@@ -1,11 +1,14 @@
 package storage
 
-import "github.com/influxdata/influxql"
+import (
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxql"
+)
 
 var measurementRemap = map[string]string{
-	"_measurement": "_name",
-	"_m":           "_name",
-	"_f":           "_field",
+	"_measurement":           "_name",
+	models.MeasurementTagKey: "_name",
+	models.FieldKeyTagKey:    "_field",
 }
 
 func RewriteExprRemoveFieldKeyAndValue(expr influxql.Expr) influxql.Expr {


### PR DESCRIPTION
When a Flux predicate is transformed to a Store.Read / GroupRead request,
the `_measurement` and `_field` keys are remapped to match 2.x internal
tag keys.

This change does not modify the 2.x behavior, but rather updates the
1.x mapping, so merging future updates from the 2.x storage/reads
package should have fewer conflicts.

Closes #13194