### PR TITLE
fix(templates): update export template route

### DIFF
--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -131,7 +131,7 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
       template,
       params: {orgID},
     } = this.props
-    router.push(`organizations/${orgID}/templates/${template.id}/export`)
+    router.push(`orgs/${orgID}/templates/${template.id}/export`)
   }
 }
 


### PR DESCRIPTION
Closes #13232

This PR fixes a 404 error by updating the export template URL to reflect the re-org route change.

  - [x] Rebased/mergeable
  - [x] Tests pass
