### PR TITLE
Refactor/remove spec http api

### DIFF
--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -160,7 +160,6 @@ var apiLinks = map[string]interface{}{
 		"self":        "/api/v2/query",
 		"ast":         "/api/v2/query/ast",
 		"analyze":     "/api/v2/query/analyze",
-		"spec":        "/api/v2/query/spec",
 		"suggestions": "/api/v2/query/suggestions",
 	},
 	"setup":    "/api/v2/setup",

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2589,38 +2589,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /query/spec:
-    post:
-      description: analyzes flux query and generates a query specification.
-      tags:
-        - Query
-      parameters:
-      - $ref: '#/components/parameters/TraceSpan'
-      - in: header
-        name: Content-Type
-        schema:
-          type: string
-          enum:
-            - application/json
-      requestBody:
-        description: analyzed flux query to generate specification.
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LanguageRequest"
-      responses:
-        '200':
-          description: Specification of flux query.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/QuerySpecification"
-        default:
-          description: Any response other than 200 is an internal server error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
   /query/suggestions:
     get:
       tags:
@@ -4831,7 +4799,7 @@ components:
           description: flux query script to be analyzed
           type: string
     Query:
-      description: query influx with specified return formatting. The spec and query fields are mutually exclusive.
+      description: query influx with specified return formatting.
       type: object
       required:
         - query
@@ -4841,8 +4809,6 @@ components:
         query:
           description: query script to execute.
           type: string
-        spec:
-          $ref: "#/components/schemas/QuerySpecification"
         type:
           description: type of query
           type: string
@@ -5268,61 +5234,6 @@ components:
     NodeType:
       description: type of AST node
       type: string
-    QuerySpecification:
-      description: consists of a set of operations and a set of edges between those operations to instruct the query engine to operate.
-      type: object
-      properties:
-        operations:
-          type: array
-          items:
-            type: object
-            properties:
-              kind:
-                description: name of the operation to perform
-                type: string
-              id:
-                description: identifier for this operation; it must be unique per query specification; used in edges
-                type: string
-              spec:
-                description: set of properties that specify details of the operation. These vary by the kind of operation.
-                type: object
-        edges:
-          description: list of declaring a parent child id relationship between operations
-          type: array
-          items:
-            type: object
-            properties:
-              parent:
-                description: id of parent node of child within graph of opertions
-                type: string
-              child:
-                description: id of child node of parent within the graph of operations
-                type: string
-        resources:
-          description: optional set of contraints on the resources the query can consume
-          type: object
-          properties:
-            priority:
-              description: priority of the query
-              oneOf:
-              - type: string
-                description: lower value will move to the front of the priority queue
-                pattern: '^\d+$'
-              - type: string
-                description: constants to represent the extreme high and low priorities; high is effectively 0.
-                enum:
-                  - high
-                  - low
-            concurrency_quota:
-              description: number of concurrent workers allowed to process this query; 0 indicates the planner can pick the optimal concurrency.
-              type: integer
-              default: 0
-            memory_bytes_quota:
-              description: number of bytes of RAM this query may consume; 0 means unlimited.
-              type: integer
-              default: 0
-        dialect:
-          $ref: "#/components/schemas/Dialect"
     Dialect:
           description: dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
           type: object
@@ -5975,9 +5886,6 @@ components:
               type: string
               format: uri
             analyze:
-              type: string
-              format: uri
-            spec:
               type: string
               format: uri
             suggestions:
@@ -6843,7 +6751,6 @@ components:
             enum:
               - flux
               - influxql
-              - spec
     Sources:
       type: object
       properties:

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/lang"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/authorizer"
 	pcontext "github.com/influxdata/influxdb/context"
@@ -379,13 +379,13 @@ func (h *TaskHandler) createBootstrapTaskAuthorizationIfNotExists(ctx context.Co
 		return nil, nil
 	}
 
-	spec, err := flux.Compile(ctx, t.Flux, time.Now())
+	prog, err := lang.Compile(t.Flux, time.Now())
 	if err != nil {
 		return nil, err
 	}
 
 	preAuthorizer := query.NewPreAuthorizer(h.BucketService)
-	ps, err := preAuthorizer.RequiredPermissions(ctx, spec, &t.OrganizationID)
+	ps, err := preAuthorizer.RequiredPermissions(ctx, prog.Ast, &t.OrganizationID)
 	if err != nil {
 		return nil, err
 	}

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -40,7 +40,6 @@ export const links: Links = {
   query: {
     ast: '/api/v2/query/ast',
     self: '/api/v2/query',
-    spec: '/api/v2/query/spec',
     suggestions: '/api/v2/query/suggestions',
   },
   setup: '/api/v2/setup',

--- a/ui/src/shared/reducers/links.test.ts
+++ b/ui/src/shared/reducers/links.test.ts
@@ -14,7 +14,6 @@ const links: Links = {
   query: {
     self: '/api/v2/query',
     ast: '/api/v2/query/ast',
-    spec: '/api/v2/query/spec',
     suggestions: '/api/v2/query/suggestions',
   },
   orgs: '/api/v2/orgs',

--- a/ui/src/shared/reducers/links.ts
+++ b/ui/src/shared/reducers/links.ts
@@ -11,7 +11,6 @@ const initialState: Links = {
   query: {
     self: '',
     ast: '',
-    spec: '',
     suggestions: '',
   },
   orgs: '',

--- a/ui/src/types/links.ts
+++ b/ui/src/types/links.ts
@@ -11,7 +11,6 @@ export interface Links {
   query: {
     self: string
     ast: string
-    spec: string
     suggestions: string
   }
   orgs: string


### PR DESCRIPTION
Closes #12882 .

_Briefly describe your proposed changes:_

Removes the `api/v2/query/spec` endpoint from the http api specification.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
