### PR TITLE
refactor(variables): update CreateVariableOverlay to use routes

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -28,6 +28,7 @@ import DashboardsIndex from 'src/dashboards/components/dashboard_index/Dashboard
 import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
 import DashboardImportFromTemplateOverlay from 'src/dashboards/components/DashboardImportFromTemplateOverlay'
+import CreateVariableOverlay from 'src/variables/components/CreateVariableOverlay'
 import DataExplorerPage from 'src/dataExplorer/components/DataExplorerPage'
 import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
 import {MePage, Account} from 'src/me'
@@ -207,6 +208,10 @@ class Root extends PureComponent {
                             <Route
                               path=":id/export"
                               component={VariableExportOverlay}
+                            />
+                            <Route
+                              path="new"
+                              component={CreateVariableOverlay}
                             />
                           </Route>
                           <Route path="scrapers" component={OrgScrapersIndex} />

--- a/ui/src/variables/components/CreateVariableOverlay.tsx
+++ b/ui/src/variables/components/CreateVariableOverlay.tsx
@@ -1,37 +1,61 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+import {withRouter, WithRouterProps} from 'react-router'
 
 // Styles
 import 'src/variables/components/CreateVariableOverlay.scss'
+
+// Actions
+import {createVariable} from 'src/variables/actions'
 
 // Components
 import {Overlay} from 'src/clockface'
 import VariableForm from 'src/variables/components/VariableForm'
 
-// Types
-import {IVariable as Variable} from '@influxdata/influx'
-
-interface Props {
-  onCreateVariable: (variable: Pick<Variable, 'name' | 'arguments'>) => void
-  onHideOverlay: () => void
-  initialScript?: string
+interface DispatchProps {
+  onCreateVariable: typeof createVariable
 }
 
-export default class CreateVariableOverlay extends PureComponent<Props> {
+type Props = DispatchProps & WithRouterProps
+
+class CreateVariableOverlay extends PureComponent<Props> {
   public render() {
-    const {onHideOverlay, onCreateVariable, initialScript} = this.props
+    const {onCreateVariable} = this.props
 
     return (
-      <Overlay.Container maxWidth={1000}>
-        <Overlay.Heading title="Create Variable" onDismiss={onHideOverlay} />
-        <Overlay.Body>
-          <VariableForm
-            onCreateVariable={onCreateVariable}
-            onHideOverlay={onHideOverlay}
-            initialScript={initialScript}
+      <Overlay visible={true}>
+        <Overlay.Container maxWidth={1000}>
+          <Overlay.Heading
+            title="Create Variable"
+            onDismiss={this.handleHideOverlay}
           />
-        </Overlay.Body>
-      </Overlay.Container>
+          <Overlay.Body>
+            <VariableForm
+              onCreateVariable={onCreateVariable}
+              onHideOverlay={this.handleHideOverlay}
+            />
+          </Overlay.Body>
+        </Overlay.Container>
+      </Overlay>
     )
   }
+
+  private handleHideOverlay = () => {
+    const {
+      router,
+      params: {orgID},
+    } = this.props
+
+    router.push(`/orgs/${orgID}/variables`)
+  }
 }
+
+const mdtp: DispatchProps = {
+  onCreateVariable: createVariable,
+}
+
+export default connect<Props>(
+  null,
+  mdtp
+)(withRouter<{}>(CreateVariableOverlay))

--- a/ui/src/variables/components/VariablesTab.tsx
+++ b/ui/src/variables/components/VariablesTab.tsx
@@ -5,18 +5,12 @@ import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
 // Utils
-import {
-  createVariable,
-  updateVariable,
-  deleteVariable,
-} from 'src/variables/actions'
+import {updateVariable, deleteVariable} from 'src/variables/actions'
 import {extractVariablesList} from 'src/variables/selectors'
 
 // Components
 import {Input, EmptyState} from '@influxdata/clockface'
-import {Overlay} from 'src/clockface'
 import TabbedPageHeader from 'src/shared/components/tabbed_page/TabbedPageHeader'
-import CreateVariableOverlay from 'src/variables/components/CreateVariableOverlay'
 import VariableList from 'src/variables/components/VariableList'
 import FilterList from 'src/shared/components/Filter'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
@@ -33,7 +27,6 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  onCreateVariable: typeof createVariable
   onUpdateVariable: typeof updateVariable
   onDeleteVariable: typeof deleteVariable
 }
@@ -42,20 +35,18 @@ type Props = StateProps & DispatchProps & WithRouterProps
 
 interface State {
   searchTerm: string
-  createOverlayState: OverlayState
   importOverlayState: OverlayState
 }
 
 class VariablesTab extends PureComponent<Props, State> {
   public state: State = {
     searchTerm: '',
-    createOverlayState: OverlayState.Closed,
     importOverlayState: OverlayState.Closed,
   }
 
   public render() {
-    const {variables, onCreateVariable} = this.props
-    const {searchTerm, createOverlayState} = this.state
+    const {variables} = this.props
+    const {searchTerm} = this.state
 
     return (
       <>
@@ -92,12 +83,6 @@ class VariablesTab extends PureComponent<Props, State> {
             )}
           </FilterList>
         </GetLabels>
-        <Overlay visible={createOverlayState === OverlayState.Open}>
-          <CreateVariableOverlay
-            onCreateVariable={onCreateVariable}
-            onHideOverlay={this.handleCloseCreateOverlay}
-          />
-        </Overlay>
       </>
     )
   }
@@ -150,11 +135,12 @@ class VariablesTab extends PureComponent<Props, State> {
   }
 
   private handleOpenCreateOverlay = (): void => {
-    this.setState({createOverlayState: OverlayState.Open})
-  }
+    const {
+      router,
+      params: {orgID},
+    } = this.props
 
-  private handleCloseCreateOverlay = (): void => {
-    this.setState({createOverlayState: OverlayState.Closed})
+    router.push(`/orgs/${orgID}/variables/new`)
   }
 
   private handleUpdateVariable = (variable: Partial<Variable>): void => {
@@ -177,7 +163,6 @@ const mstp = (state: AppState): StateProps => {
 }
 
 const mdtp: DispatchProps = {
-  onCreateVariable: createVariable,
   onUpdateVariable: updateVariable,
   onDeleteVariable: deleteVariable,
 }


### PR DESCRIPTION
Closes #13243

This PR changes the `CreateVariableOverlay` to use React Router rather than open/close state in the parent component.

  - [x] Rebased/mergeable
  - [x] Tests pass
