### PR TITLE
Refactor vis data provisioning

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1016,7 +1016,7 @@
       }
     },
     "@influxdata/influx": {
-      "version": "github:influxdata/influxdb2-js#47621167f05c2fbda3b38f0c6aaa85f29190d39b",
+      "version": "github:influxdata/influxdb2-js#653aeb5c7b4885d1421f6673568e38b76d213dd4",
       "from": "github:influxdata/influxdb2-js#dev",
       "requires": {
         "axios": "^0.18.0"
@@ -6185,8 +6185,7 @@
           "version": "2.1.1",
           "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6210,15 +6209,13 @@
           "version": "1.0.0",
           "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6235,22 +6232,19 @@
           "version": "1.1.0",
           "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6381,8 +6375,7 @@
           "version": "2.0.3",
           "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6396,7 +6389,6 @@
           "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6413,7 +6405,6 @@
           "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6422,15 +6413,13 @@
           "version": "0.0.8",
           "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6451,7 +6440,6 @@
           "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6540,8 +6528,7 @@
           "version": "1.0.1",
           "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6555,7 +6542,6 @@
           "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6651,8 +6637,7 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6694,7 +6679,6 @@
           "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6716,7 +6700,6 @@
           "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6765,15 +6748,13 @@
           "version": "1.0.2",
           "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/ui/src/shared/components/Histogram.tsx
+++ b/ui/src/shared/components/Histogram.tsx
@@ -1,72 +1,27 @@
 // Libraries
-import React, {useMemo, useEffect, SFC} from 'react'
-import {connect} from 'react-redux'
-import {Plot, Table, Config, isNumeric} from '@influxdata/vis'
+import React, {useMemo, FunctionComponent} from 'react'
+import {Plot, Config, Table} from '@influxdata/vis'
 
 // Components
 import HistogramTooltip from 'src/shared/components/HistogramTooltip'
 import EmptyGraphMessage from 'src/shared/components/EmptyGraphMessage'
 
-// Actions
-import {tableLoaded} from 'src/timeMachine/actions'
-
 // Utils
-import {toMinardTable} from 'src/shared/utils/toMinardTable'
 import {useOneWayState} from 'src/shared/utils/useOneWayState'
-import {useSetIdentity} from 'src/shared/utils/useSetIdentity'
 
 // Constants
 import {INVALID_DATA_COPY} from 'src/shared/copy/cell'
 
 // Types
-import {FluxTable} from 'src/types'
 import {HistogramView} from 'src/types/dashboards'
 
-interface DispatchProps {
-  onTableLoaded: typeof tableLoaded
-}
-
-interface OwnProps {
-  tables: FluxTable[]
+interface Props {
+  table: Table
   properties: HistogramView
 }
 
-type Props = OwnProps & DispatchProps
-
-/*
-  Attempt to find valid `x` and `fill` mappings for the histogram.
-
-  The `HistogramView` properties object stores `xColumn` and `fillColumns`
-  fields that are used as data-to-aesthetic mappings in the visualization, but
-  they may be invalid if the retrieved data for the view has just changed (e.g.
-  if a user has submitted a different query). In this case, a `TABLE_LOADED`
-  Redux action will eventually emit and the stored fields will be updated
-  appropriately, but we still have to be defensive about accessing those fields
-  since the component will render before the field resolution takes place.
-*/
-const resolveMappings = (
-  table: Table,
-  preferredXColumnName: string,
-  preferredFillColumnNames: string[] = []
-): {x: string; fill: string[]} => {
-  let x: string = preferredXColumnName
-
-  if (!table.columns[x] || !isNumeric(table.columns[x].type)) {
-    x = Object.entries(table.columns)
-      .filter(([__, {type}]) => isNumeric(type))
-      .map(([name]) => name)[0]
-  }
-
-  let fill = preferredFillColumnNames || []
-
-  fill = fill.filter(name => table.columns[name])
-
-  return {x, fill}
-}
-
-const Histogram: SFC<Props> = ({
-  tables,
-  onTableLoaded,
+const Histogram: FunctionComponent<Props> = ({
+  table,
   properties: {
     xColumn,
     fillColumns,
@@ -77,49 +32,52 @@ const Histogram: SFC<Props> = ({
     xDomain: defaultXDomain,
   },
 }) => {
-  const [xDomain, setXDomain] = useOneWayState(defaultXDomain)
+  const [xDomain, onSetXDomain] = useOneWayState(defaultXDomain)
   const colorHexes = useMemo(() => colors.map(c => c.hex), [colors])
-  const {table} = useMemo(() => toMinardTable(tables), [tables])
 
-  useEffect(() => {
-    onTableLoaded(table)
-  }, [table])
+  const isValidView =
+    xColumn &&
+    table.columns[xColumn] &&
+    fillColumns.every(col => !!table.columns[col])
 
-  const mappings = resolveMappings(table, xColumn, fillColumns)
-  const fill = useSetIdentity(mappings.fill)
-
-  if (!mappings.x) {
+  if (!isValidView) {
     return <EmptyGraphMessage message={INVALID_DATA_COPY} />
   }
 
-  const config: Config = {
-    table,
-    xDomain,
-    onSetXDomain: setXDomain,
-    xAxisLabel,
-    tickFont: 'bold 10px Roboto',
-    tickFill: '#8e91a1',
-    layers: [
-      {
-        type: 'histogram',
-        x: mappings.x,
-        fill,
-        binCount,
-        position,
-        tooltip: HistogramTooltip,
-        colors: colorHexes,
-      },
-    ],
-  }
+  const config: Config = useMemo(
+    () => ({
+      table,
+      xDomain,
+      onSetXDomain,
+      xAxisLabel,
+      tickFont: 'bold 10px Roboto',
+      tickFill: '#8e91a1',
+      layers: [
+        {
+          type: 'histogram' as 'histogram',
+          x: xColumn,
+          fill: fillColumns,
+          binCount,
+          position,
+          tooltip: HistogramTooltip,
+          colors: colorHexes,
+        },
+      ],
+    }),
+    [
+      table,
+      xDomain,
+      onSetXDomain,
+      xAxisLabel,
+      xColumn,
+      fillColumns,
+      binCount,
+      position,
+      colorHexes,
+    ]
+  )
 
   return <Plot config={config} />
 }
 
-const mdtp = {
-  onTableLoaded: tableLoaded,
-}
-
-export default connect<{}, DispatchProps, OwnProps>(
-  null,
-  mdtp
-)(Histogram)
+export default Histogram

--- a/ui/src/shared/components/HistogramTransform.tsx
+++ b/ui/src/shared/components/HistogramTransform.tsx
@@ -1,0 +1,22 @@
+// Libraries
+import {useMemo, FunctionComponent} from 'react'
+import {Table} from '@influxdata/vis'
+
+// Utils
+import {toMinardTable} from 'src/shared/utils/toMinardTable'
+
+// Types
+import {FluxTable} from 'src/types'
+
+interface Props {
+  tables: FluxTable[]
+  children: (table: Table) => JSX.Element
+}
+
+const HistogramTransform: FunctionComponent<Props> = ({tables, children}) => {
+  const {table} = useMemo(() => toMinardTable(tables), [tables])
+
+  return children(table)
+}
+
+export default HistogramTransform

--- a/ui/src/timeMachine/actions/index.ts
+++ b/ui/src/timeMachine/actions/index.ts
@@ -21,7 +21,7 @@ import {
   TimeMachineTab,
 } from 'src/types'
 import {Color} from 'src/types/colors'
-import {Table, HistogramPosition, isNumeric} from '@influxdata/vis'
+import {HistogramPosition} from '@influxdata/vis'
 
 export type Action =
   | QueryBuilderAction
@@ -63,7 +63,6 @@ export type Action =
   | SetFillColumnsAction
   | SetBinCountAction
   | SetHistogramPositionAction
-  | TableLoadedAction
   | SetXDomainAction
   | SetXAxisLabelAction
 
@@ -494,34 +493,6 @@ export const setHistogramPosition = (
   type: 'SET_HISTOGRAM_POSITION',
   payload: {position},
 })
-
-interface TableLoadedAction {
-  type: 'TABLE_LOADED'
-  payload: {
-    availableXColumns: string[]
-    availableGroupColumns: string[]
-  }
-}
-
-export const tableLoaded = (table: Table): TableLoadedAction => {
-  const availableXColumns = Object.entries(table.columns)
-    .filter(([__, {type}]) => isNumeric(type) && type !== 'time')
-    .map(([name]) => name)
-
-  const invalidGroupColumns = new Set(['_value', '_start', '_stop', '_time'])
-
-  const availableGroupColumns = Object.keys(table.columns).filter(
-    name => !invalidGroupColumns.has(name)
-  )
-
-  return {
-    type: 'TABLE_LOADED',
-    payload: {
-      availableXColumns,
-      availableGroupColumns,
-    },
-  }
-}
 
 interface SetXDomainAction {
   type: 'SET_VIEW_X_DOMAIN'

--- a/ui/src/timeMachine/components/HistogramTransform.tsx
+++ b/ui/src/timeMachine/components/HistogramTransform.tsx
@@ -1,0 +1,58 @@
+// Libraries
+import {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+import {Table} from '@influxdata/vis'
+
+// Utils
+import {
+  getVisTable,
+  getXColumnSelection,
+  getFillColumnsSelection,
+} from 'src/timeMachine/selectors'
+
+// Types
+import {AppState} from 'src/types'
+
+interface StateProps {
+  table: Table
+  xColumn: string
+  fillColumns: string[]
+}
+
+interface OwnProps {
+  children: (props: {
+    table: Table
+    xColumn: string
+    fillColumns: string[]
+  }) => JSX.Element
+}
+
+type Props = StateProps & OwnProps
+
+const HistogramTransform: FunctionComponent<Props> = ({
+  table,
+  xColumn,
+  fillColumns,
+  children,
+}) => {
+  return children({table, xColumn, fillColumns})
+}
+
+const mstp = (state: AppState) => {
+  const table = getVisTable(state)
+  const xColumn = getXColumnSelection(state)
+  const fillColumns = getFillColumnsSelection(state)
+
+  return {
+    table,
+    xColumn,
+    fillColumns,
+  }
+}
+
+const mdtp = {}
+
+export default connect<StateProps, {}, OwnProps>(
+  mstp,
+  mdtp
+)(HistogramTransform)

--- a/ui/src/timeMachine/components/Vis.tsx
+++ b/ui/src/timeMachine/components/Vis.tsx
@@ -1,52 +1,33 @@
 // Libraries
 import React, {SFC} from 'react'
 import {connect} from 'react-redux'
-import {AutoSizer} from 'react-virtualized'
 
 // Components
 import EmptyQueryView from 'src/shared/components/EmptyQueryView'
-import QueryViewSwitcher from 'src/shared/components/QueryViewSwitcher'
-import RawFluxDataTable from 'src/timeMachine/components/RawFluxDataTable'
-
-// Actions
-import {setType} from 'src/timeMachine/actions'
+import VisSwitcher from 'src/timeMachine/components/VisSwitcher'
 
 // Utils
 import {getActiveTimeMachine, getTables} from 'src/timeMachine/selectors'
 
 // Types
-import {FluxTable, RemoteDataState} from 'src/types'
-import {View, NewView, TimeRange, DashboardQuery, AppState} from 'src/types'
-import {QueryViewProperties} from 'src/types/dashboards'
+import {FluxTable, RemoteDataState, DashboardQuery, AppState} from 'src/types'
 
 interface StateProps {
-  view: View | NewView
-  timeRange: TimeRange
   queries: DashboardQuery[]
-  isViewingRawData: boolean
-  files: string[]
   tables: FluxTable[]
   loading: RemoteDataState
   errorMessage: string
   isInitialFetch: boolean
 }
 
-interface DispatchProps {
-  onUpdateType: typeof setType
-}
-
-type Props = StateProps & DispatchProps
+type Props = StateProps
 
 const TimeMachineVis: SFC<Props> = ({
-  view,
-  timeRange,
   queries,
-  isViewingRawData,
   tables,
   loading,
   errorMessage,
   isInitialFetch,
-  files,
 }) => {
   return (
     <div className="time-machine--view">
@@ -57,21 +38,7 @@ const TimeMachineVis: SFC<Props> = ({
         isInitialFetch={isInitialFetch}
         queries={queries}
       >
-        {isViewingRawData ? (
-          <AutoSizer>
-            {({width, height}) => (
-              <RawFluxDataTable files={files} width={width} height={height} />
-            )}
-          </AutoSizer>
-        ) : (
-          <QueryViewSwitcher
-            tables={tables}
-            viewID="time-machine-view"
-            loading={loading}
-            timeRange={timeRange}
-            properties={view.properties as QueryViewProperties}
-          />
-        )}
+        <VisSwitcher />
       </EmptyQueryView>
     </div>
   )
@@ -80,9 +47,7 @@ const TimeMachineVis: SFC<Props> = ({
 const mstp = (state: AppState) => {
   const {
     view,
-    timeRange,
-    isViewingRawData,
-    queryResults: {status: loading, errorMessage, isInitialFetch, files},
+    queryResults: {status: loading, errorMessage, isInitialFetch},
   } = getActiveTimeMachine(state)
 
   const {queries} = view.properties
@@ -90,23 +55,12 @@ const mstp = (state: AppState) => {
   const tables = getTables(state)
 
   return {
-    view,
-    timeRange,
-    isViewingRawData,
     queries,
     tables,
-    files,
     loading,
     errorMessage,
     isInitialFetch,
   }
 }
 
-const mdtp = {
-  onUpdateType: setType,
-}
-
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(TimeMachineVis)
+export default connect<StateProps>(mstp)(TimeMachineVis)

--- a/ui/src/timeMachine/components/view_options/HistogramOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/HistogramOptions.tsx
@@ -20,7 +20,12 @@ import {
 } from 'src/timeMachine/actions'
 
 // Utils
-import {getActiveTimeMachine} from 'src/timeMachine/selectors'
+import {
+  getXColumnSelection,
+  getNumericColumns,
+  getGroupableColumns,
+  getFillColumnsSelection,
+} from 'src/timeMachine/selectors'
 
 // Types
 import {ComponentStatus} from '@influxdata/clockface'
@@ -29,6 +34,8 @@ import {Color} from 'src/types/colors'
 import {AppState} from 'src/types'
 
 interface StateProps {
+  xColumn: string
+  fillColumns: string[]
   availableXColumns: string[]
   availableGroupColumns: string[]
 }
@@ -44,8 +51,6 @@ interface DispatchProps {
 }
 
 interface OwnProps {
-  xColumn: string
-  fillColumns: string[]
   position: HistogramPosition
   binCount: number
   colors: Color[]
@@ -157,9 +162,12 @@ const HistogramOptions: SFC<Props> = props => {
 }
 
 const mstp = (state: AppState) => {
-  const {availableXColumns, availableGroupColumns} = getActiveTimeMachine(state)
+  const availableXColumns = getNumericColumns(state)
+  const availableGroupColumns = getGroupableColumns(state)
+  const xColumn = getXColumnSelection(state)
+  const fillColumns = getFillColumnsSelection(state)
 
-  return {availableXColumns, availableGroupColumns}
+  return {availableXColumns, availableGroupColumns, xColumn, fillColumns}
 }
 
 const mdtp = {

--- a/ui/src/timeMachine/reducers/index.ts
+++ b/ui/src/timeMachine/reducers/index.ts
@@ -57,8 +57,6 @@ export interface TimeMachineState {
   isViewingRawData: boolean
   activeTab: TimeMachineTab
   activeQueryIndex: number | null
-  availableXColumns: string[]
-  availableGroupColumns: string[]
   queryBuilder: QueryBuilderState
   queryResults: QueryResultsState
 }
@@ -77,8 +75,6 @@ export const initialStateHelper = (): TimeMachineState => ({
   isViewingRawData: false,
   activeTab: TimeMachineTab.Queries,
   activeQueryIndex: 0,
-  availableXColumns: [],
-  availableGroupColumns: [],
   queryResults: initialQueryResultsState(),
   queryBuilder: {
     buckets: [],
@@ -129,8 +125,6 @@ export const timeMachinesReducer = (
           ...initialState,
           activeTab: TimeMachineTab.Queries,
           isViewingRawData: false,
-          availableXColumns: [],
-          availableGroupColumns: [],
           activeQueryIndex: 0,
           draftQueries,
           queryBuilder,
@@ -291,35 +285,6 @@ export const timeMachineReducer = (
       const {scale} = action.payload
 
       return setYAxis(state, {scale})
-    }
-
-    case 'TABLE_LOADED': {
-      return produce(state, draftState => {
-        const {availableXColumns, availableGroupColumns} = action.payload
-
-        draftState.availableXColumns = availableXColumns
-        draftState.availableGroupColumns = availableGroupColumns
-
-        if (draftState.view.properties.type !== ViewType.Histogram) {
-          return
-        }
-
-        const {xColumn, fillColumns} = draftState.view.properties
-        const xColumnStale = !xColumn || !availableXColumns.includes(xColumn)
-        const fillColumnsStale =
-          !fillColumns ||
-          fillColumns.some(name => !availableGroupColumns.includes(name))
-
-        if (xColumnStale && availableXColumns.includes('_value')) {
-          draftState.view.properties.xColumn = '_value'
-        } else if (xColumnStale) {
-          draftState.view.properties.xColumn = availableXColumns[0]
-        }
-
-        if (fillColumnsStale) {
-          draftState.view.properties.fillColumns = []
-        }
-      })
     }
 
     case 'SET_X_COLUMN': {

--- a/ui/src/timeMachine/selectors/index.ts
+++ b/ui/src/timeMachine/selectors/index.ts
@@ -1,9 +1,11 @@
 // Libraries
 import memoizeOne from 'memoize-one'
-import {flatMap} from 'lodash'
+import {get, flatMap} from 'lodash'
+import {Table, isNumeric} from '@influxdata/vis'
 
 // Utils
 import {parseResponse} from 'src/shared/parsing/flux/response'
+import {toMinardTable} from 'src/shared/utils/toMinardTable'
 
 // Types
 import {FluxTable} from 'src/types'
@@ -29,3 +31,90 @@ const getTablesMemoized = memoizeOne(
 
 export const getTables = (state: AppState): FluxTable[] =>
   getTablesMemoized(getActiveTimeMachine(state).queryResults.files)
+
+const getVisTableMemoized = memoizeOne(toMinardTable)
+
+export const getVisTable = (state: AppState): Table => {
+  const fluxTables = getTables(state)
+  const {table} = getVisTableMemoized(fluxTables)
+
+  return table
+}
+
+const getNumericColumnsMemoized = memoizeOne(
+  (table: Table): string[] => {
+    const numericColumns = Object.entries(table.columns)
+      .filter(([__, {type}]) => isNumeric(type))
+      .map(([name]) => name)
+
+    return numericColumns
+  }
+)
+
+export const getNumericColumns = (state: AppState): string[] => {
+  const table = getVisTable(state)
+
+  return getNumericColumnsMemoized(table)
+}
+
+const getGroupableColumnsMemoized = memoizeOne(
+  (table: Table): string[] => {
+    const invalidGroupColumns = new Set(['_value', '_start', '_stop', '_time'])
+    const groupableColumns = Object.keys(table.columns).filter(
+      name => !invalidGroupColumns.has(name)
+    )
+
+    return groupableColumns
+  }
+)
+
+export const getGroupableColumns = (state: AppState): string[] => {
+  const table = getVisTable(state)
+
+  return getGroupableColumnsMemoized(table)
+}
+
+const getXColumnSelectionMemoized = memoizeOne(
+  (validXColumns: string[], preference: string): string => {
+    if (preference && validXColumns.includes(preference)) {
+      return preference
+    }
+
+    if (validXColumns.includes('_value')) {
+      return '_value'
+    }
+
+    if (validXColumns.length) {
+      return validXColumns[0]
+    }
+
+    return null
+  }
+)
+
+export const getXColumnSelection = (state: AppState): string => {
+  const validXColumns = getNumericColumns(state)
+  const preference = get(getActiveTimeMachine(state), 'view.properties.xColumn')
+
+  return getXColumnSelectionMemoized(validXColumns, preference)
+}
+
+const getFillColumnsSelectionMemoized = memoizeOne(
+  (validFillColumns: string[], preference: string[]): string[] => {
+    if (preference && preference.every(col => validFillColumns.includes(col))) {
+      return preference
+    }
+
+    return []
+  }
+)
+
+export const getFillColumnsSelection = (state: AppState): string[] => {
+  const validFillColumns = getGroupableColumns(state)
+  const preference = get(
+    getActiveTimeMachine(state),
+    'view.properties.fillColumns'
+  )
+
+  return getFillColumnsSelectionMemoized(validFillColumns, preference)
+}


### PR DESCRIPTION
Closes #13227

- Removes derived data from the time machine reducer in favor of computing it in memoized selector functions instead

- Removes two-way data binding from the `Histogram` component (which caused #13227)

- Separates the `QueryViewSwitcher` into two components—one used for dashboards, and one used for time machines. The previous implementation was accumulating confusing branching logic to handle rendering in different locations. The separation into two components introduces some duplication, but removes the branching logic and reduces prop drilling in the time machine version.

- Introduce two `HistogramTransform` components. One is used on dashboards, and one is used in time machines. They provide data from different sources, and behave differently when attempting to render a histogram with a column that doesn't exist in the fetched Flux data. The dashboard version will display an error, because it means the view is configured incorrectly. The time machine version will attempt to fall back to a valid default, which is more convenient when you are exploring data or building a view.