### PR TITLE
Update variables to use view overlay instead of export overlay

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -57,6 +57,7 @@ import CreateOrgOverlay from 'src/organizations/components/CreateOrgOverlay'
 import TokensIndex from 'src/authorizations/containers/TokensIndex'
 import MembersIndex from 'src/members/containers/MembersIndex'
 import LabelsIndex from 'src/labels/containers/LabelsIndex'
+import TemplateViewOverlay from 'src/templates/components/TemplateViewOverlay'
 
 // Actions
 import {disablePresentationMode} from 'src/shared/actions/app'
@@ -196,6 +197,10 @@ class Root extends PureComponent {
                             <Route
                               path=":id/export"
                               component={TemplateExportOverlay}
+                            />
+                            <Route
+                              path=":id/view"
+                              component={TemplateViewOverlay}
                             />
                           </Route>
                           <Route path="variables" component={VariablesIndex}>

--- a/ui/src/shared/components/ViewOverlay.tsx
+++ b/ui/src/shared/components/ViewOverlay.tsx
@@ -1,0 +1,106 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import {Button, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
+import {Overlay, ComponentSize} from 'src/clockface'
+import {Controlled as ReactCodeMirror} from 'react-codemirror2'
+import CopyButton from 'src/shared/components/CopyButton'
+
+// Types
+import {DocumentCreate} from '@influxdata/influx'
+import {ComponentColor} from '@influxdata/clockface'
+import {RemoteDataState} from 'src/types'
+
+interface Props {
+  onDismissOverlay: () => void
+  resource: DocumentCreate
+  overlayHeading: string
+  status: RemoteDataState
+  isVisible: boolean
+}
+
+export default class ViewOverlay extends PureComponent<Props> {
+  public static defaultProps = {
+    isVisible: true,
+  }
+
+  public render() {
+    const {isVisible, overlayHeading, onDismissOverlay, status} = this.props
+
+    return (
+      <Overlay visible={isVisible}>
+        <Overlay.Container maxWidth={800}>
+          <Overlay.Heading
+            title={overlayHeading}
+            onDismiss={onDismissOverlay}
+          />
+          <Overlay.Body>
+            <SpinnerContainer
+              loading={status}
+              spinnerComponent={<TechnoSpinner />}
+            >
+              {this.overlayBody}
+            </SpinnerContainer>
+          </Overlay.Body>
+          <Overlay.Footer>
+            {this.closeButton}
+            {this.copyButton}
+          </Overlay.Footer>
+        </Overlay.Container>
+      </Overlay>
+    )
+  }
+
+  private doNothing = () => {}
+
+  private get overlayBody(): JSX.Element {
+    const options = {
+      tabIndex: 1,
+      mode: 'json',
+      readonly: true,
+      lineNumbers: true,
+      autoRefresh: true,
+      theme: 'time-machine',
+      completeSingle: false,
+    }
+
+    return (
+      <div className="export-overlay--text-area">
+        <ReactCodeMirror
+          autoFocus={false}
+          autoCursor={true}
+          value={this.resourceText}
+          options={options}
+          onBeforeChange={this.doNothing}
+          onTouchStart={this.doNothing}
+        />
+      </div>
+    )
+  }
+
+  private get resourceText(): string {
+    return JSON.stringify(this.props.resource, null, 1)
+  }
+
+  private get copyButton(): JSX.Element {
+    return (
+      <CopyButton
+        textToCopy={this.resourceText}
+        contentName={this.props.overlayHeading}
+        size={ComponentSize.Small}
+        color={ComponentColor.Secondary}
+      />
+    )
+  }
+
+  private get closeButton(): JSX.Element {
+    return (
+      <Button
+        text="Close"
+        onClick={this.props.onDismissOverlay}
+        color={ComponentColor.Primary}
+      />
+    )
+  }
+}

--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -123,12 +123,12 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
 
   private handleNameClick = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
-    this.handleExport()
+    this.handleViewTemplate()
   }
 
-  private handleExport = () => {
+  private handleViewTemplate = () => {
     const {router, template, org} = this.props
-    router.push(`orgs/${org.id}/templates/${template.id}/export`)
+    router.push(`/orgs/${org.id}/templates/${template.id}/view`)
   }
 }
 

--- a/ui/src/templates/components/TemplateViewOverlay.tsx
+++ b/ui/src/templates/components/TemplateViewOverlay.tsx
@@ -1,0 +1,89 @@
+import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+import {withRouter, WithRouterProps} from 'react-router'
+import _ from 'lodash'
+
+// Components
+import ViewOverlay from 'src/shared/components/ViewOverlay'
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+// Actions
+import {
+  convertToTemplate as convertToTemplateAction,
+  clearExportTemplate as clearExportTemplateAction,
+} from 'src/templates/actions'
+
+// Types
+import {DocumentCreate} from '@influxdata/influx'
+import {AppState} from 'src/types'
+import {RemoteDataState} from 'src/types'
+
+interface OwnProps {
+  params: {id: string}
+}
+
+interface DispatchProps {
+  convertToTemplate: typeof convertToTemplateAction
+  clearExportTemplate: typeof clearExportTemplateAction
+}
+
+interface StateProps {
+  exportTemplate: DocumentCreate
+  status: RemoteDataState
+}
+
+type Props = OwnProps & StateProps & DispatchProps & WithRouterProps
+
+@ErrorHandling
+class TemplateExportOverlay extends PureComponent<Props> {
+  public componentDidMount() {
+    const {
+      params: {id},
+      convertToTemplate,
+    } = this.props
+    convertToTemplate(id)
+  }
+
+  public render() {
+    const {exportTemplate, status} = this.props
+
+    return (
+      <ViewOverlay
+        resource={exportTemplate}
+        overlayHeading={this.overlayTitle}
+        onDismissOverlay={this.onDismiss}
+        status={status}
+      />
+    )
+  }
+
+  private get overlayTitle() {
+    const {exportTemplate} = this.props
+    if (exportTemplate) {
+      return exportTemplate.meta.name
+    }
+    return ''
+  }
+
+  private onDismiss = () => {
+    const {router, clearExportTemplate} = this.props
+
+    router.goBack()
+    clearExportTemplate()
+  }
+}
+
+const mstp = (state: AppState): StateProps => ({
+  exportTemplate: state.templates.exportTemplate.item,
+  status: state.templates.exportTemplate.status,
+})
+
+const mdtp: DispatchProps = {
+  convertToTemplate: convertToTemplateAction,
+  clearExportTemplate: clearExportTemplateAction,
+}
+
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mstp,
+  mdtp
+)(withRouter<Props>(TemplateExportOverlay))

--- a/ui/src/templates/containers/TemplatesIndex.tsx
+++ b/ui/src/templates/containers/TemplatesIndex.tsx
@@ -11,9 +11,6 @@ import OrgHeader from 'src/organizations/containers/OrgHeader'
 import TabbedPageSection from 'src/shared/components/tabbed_page/TabbedPageSection'
 import TemplatesPage from 'src/templates/components/TemplatesPage'
 
-//Actions
-import {setTemplatesStatus as setTemplatesStatusAction} from 'src/templates/actions/index'
-
 // Types
 import {Organization} from '@influxdata/influx'
 import {AppState} from 'src/types'
@@ -25,11 +22,7 @@ interface StateProps {
   org: Organization
 }
 
-interface DispatchProps {
-  setTemplatesStatus: typeof setTemplatesStatusAction
-}
-
-type Props = WithRouterProps & StateProps & DispatchProps
+type Props = WithRouterProps & StateProps
 
 @ErrorHandling
 class TemplatesIndex extends Component<Props> {


### PR DESCRIPTION
Closes #12914

_Briefly describe your proposed changes:_
Created a generic component for ViewOverlay
Created a TemplateViewOverlay that gets the template and passes into ViewOverlay as a resource.
Updated the route for viewing templates to `/view`

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
