### PR TITLE
fix(ui/exportOverlay): use dispatch props

### DIFF
--- a/ui/src/shared/components/ExportOverlay.tsx
+++ b/ui/src/shared/components/ExportOverlay.tsx
@@ -33,7 +33,7 @@ interface OwnProps {
 }
 
 interface DispatchProps {
-  createTemplateFromResource: typeof createTemplateFromResource
+  onCreateTemplateFromResource: typeof createTemplateFromResource
 }
 
 type Props = OwnProps & DispatchProps
@@ -142,14 +142,20 @@ class ExportOverlay extends PureComponent<Props> {
   }
 
   private handleConvertToTemplate = async (): Promise<void> => {
-    const {resource, onDismissOverlay, resourceName} = this.props
-    createTemplateFromResource(resource, resourceName)
+    const {
+      resource,
+      onDismissOverlay,
+      resourceName,
+      onCreateTemplateFromResource,
+    } = this.props
+
+    onCreateTemplateFromResource(resource, resourceName)
     onDismissOverlay()
   }
 }
 
 const mdtp: DispatchProps = {
-  createTemplateFromResource,
+  onCreateTemplateFromResource: createTemplateFromResource,
 }
 
 export default connect<{}, DispatchProps, OwnProps>(

--- a/ui/src/templates/actions/index.ts
+++ b/ui/src/templates/actions/index.ts
@@ -125,6 +125,7 @@ export const createTemplateFromResource = (
     const {
       orgs: {org},
     } = getState()
+
     await client.templates.create({...resource, orgID: org.id})
     dispatch(notify(copy.resourceSavedAsTemplate(resourceName)))
   } catch (e) {


### PR DESCRIPTION
Closes #13294 

_Briefly describe your proposed changes:_
Use the dispatch props `createTemplateFromResource` in the export overlay.



  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
