### PR TITLE
chore(tracing): Cleanup

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -14,15 +14,6 @@ import (
 
 	"github.com/influxdata/flux/control"
 	"github.com/influxdata/flux/execute"
-	"github.com/influxdata/influxdb/kit/signals"
-	"github.com/influxdata/influxdb/telemetry"
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/cobra"
-	jaegerconfig "github.com/uber/jaeger-client-go/config"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/bolt"
 	"github.com/influxdata/influxdb/chronograf/server"
@@ -32,6 +23,7 @@ import (
 	"github.com/influxdata/influxdb/internal/fs"
 	"github.com/influxdata/influxdb/kit/cli"
 	"github.com/influxdata/influxdb/kit/prom"
+	"github.com/influxdata/influxdb/kit/signals"
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/kv"
 	influxlogger "github.com/influxdata/influxdb/logger"
@@ -48,10 +40,17 @@ import (
 	taskbolt "github.com/influxdata/influxdb/task/backend/bolt"
 	"github.com/influxdata/influxdb/task/backend/coordinator"
 	taskexecutor "github.com/influxdata/influxdb/task/backend/executor"
+	"github.com/influxdata/influxdb/telemetry"
 	_ "github.com/influxdata/influxdb/tsdb/tsi1" // needed for tsi1
 	_ "github.com/influxdata/influxdb/tsdb/tsm1" // needed for tsm1
 	"github.com/influxdata/influxdb/vault"
 	pzap "github.com/influxdata/influxdb/zap"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/cobra"
+	jaegerconfig "github.com/uber/jaeger-client-go/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -625,7 +624,6 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	h := http.NewHandlerFromRegistry("platform", m.reg)
 	h.Handler = platformHandler
 	h.Logger = httpLogger
-	h.Tracer = opentracing.GlobalTracer()
 
 	m.httpServer.Handler = h
 	// If we are in testing mode we allow all data to be flushed and removed.

--- a/gather/scheduler.go
+++ b/gather/scheduler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/nats"
 	"go.uber.org/zap"
 )
@@ -95,18 +96,27 @@ func (s *Scheduler) run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-s.gather:
-			ctx, cancel := context.WithTimeout(ctx, s.Timeout)
-			defer cancel()
-			targets, err := s.Targets.ListTargets(ctx)
-			if err != nil {
-				s.Logger.Error("cannot list targets", zap.Error(err))
-				continue
-			}
-			for _, target := range targets {
-				if err := requestScrape(target, s.Publisher); err != nil {
-					s.Logger.Error("json encoding error", zap.Error(err))
-				}
-			}
+			s.doGather(ctx)
+		}
+	}
+}
+
+func (s *Scheduler) doGather(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	targets, err := s.Targets.ListTargets(ctx)
+	if err != nil {
+		s.Logger.Error("cannot list targets", zap.Error(err))
+		tracing.LogError(span, err)
+		return
+	}
+	for _, target := range targets {
+		if err := requestScrape(target, s.Publisher); err != nil {
+			s.Logger.Error("json encoding error", zap.Error(err))
+			tracing.LogError(span, err)
 		}
 	}
 }

--- a/http/client.go
+++ b/http/client.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/url"
+
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // Service connects to an InfluxDB via HTTP.
@@ -90,6 +92,7 @@ type traceClient struct {
 
 // Do injects the trace and then performs the request.
 func (c *traceClient) Do(r *http.Request) (*http.Response, error) {
-	InjectTrace(r)
+	span, _ := tracing.StartSpanFromContext(r.Context())
+	tracing.InjectToHTTPRequest(span, r)
 	return c.Client.Do(r)
 }

--- a/http/influxdb/client.go
+++ b/http/influxdb/client.go
@@ -8,7 +8,7 @@ import (
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/chronograf"
 	"github.com/influxdata/influxdb/chronograf/influx"
-	platformhttp "github.com/influxdata/influxdb/http"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // Shared transports for all clients to prevent leaking connections
@@ -79,6 +79,7 @@ type traceClient struct {
 
 // Do injects the trace and then performs the request.
 func (c *traceClient) Do(r *http.Request) (*http.Response, error) {
-	platformhttp.InjectTrace(r)
+	span, _ := tracing.StartSpanFromContext(r.Context())
+	tracing.InjectToHTTPRequest(span, r)
 	return c.Client.Do(r)
 }

--- a/kit/tracing/tracing.go
+++ b/kit/tracing/tracing.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 )
 
@@ -15,7 +16,18 @@ import (
 // Returns unchanged error, so useful to wrap as in:
 //  return 0, tracing.LogError(err)
 func LogError(span opentracing.Span, err error) error {
-	span.LogFields(log.Error(err))
+	// Get caller frame.
+	var pcs [1]uintptr
+	n := runtime.Callers(2, pcs[:])
+	if n < 1 {
+		span.LogFields(log.Error(err))
+		span.LogFields(log.Error(errors.New("runtime.Callers failed")))
+		return err
+	}
+
+	file, line := runtime.FuncForPC(pcs[0]).FileLine(pcs[0])
+	span.LogFields(log.String("filename", file), log.Int("line", line), log.Error(err))
+
 	return err
 }
 
@@ -24,22 +36,23 @@ func LogError(span opentracing.Span, err error) error {
 func InjectToHTTPRequest(span opentracing.Span, req *http.Request) {
 	err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
 	if err != nil {
-		span.LogFields(log.String("trace-inject-error", err.Error()))
+		LogError(span, err)
 	}
 }
 
 // ExtractFromHTTPRequest gets a child span of the parent referenced in HTTP request headers.
+// Returns the request with updated tracing context.
 // Easier than adding this boilerplate everywhere.
 func ExtractFromHTTPRequest(req *http.Request, handlerName string) (opentracing.Span, *http.Request) {
 	spanContext, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
 	if err != nil {
 		span, ctx := opentracing.StartSpanFromContext(req.Context(), handlerName+":"+req.URL.Path)
-		span.LogFields(log.String("trace-extract-error", err.Error()))
+		LogError(span, err)
 		req = req.WithContext(ctx)
 		return span, req
 	}
 
-	span := opentracing.StartSpan(handlerName+":"+req.URL.Path, opentracing.ChildOf(spanContext))
+	span := opentracing.StartSpan(handlerName+":"+req.URL.Path, opentracing.ChildOf(spanContext), ext.RPCServerOption(spanContext))
 	req = req.WithContext(opentracing.ContextWithSpan(req.Context(), span))
 	return span, req
 }
@@ -47,7 +60,7 @@ func ExtractFromHTTPRequest(req *http.Request, handlerName string) (opentracing.
 // StartSpanFromContext is an improved opentracing.StartSpanFromContext.
 // Uses the calling function as the operation name, and logs the filename and line number.
 //
-// Passing nil context triggers new context and root span construction.
+// Passing nil context induces panic.
 // Context without parent span reference triggers root span construction.
 // This function never returns nil values.
 //
@@ -84,8 +97,8 @@ func StartSpanFromContext(ctx context.Context) (opentracing.Span, context.Contex
 	}
 	fn := runtime.FuncForPC(pcs[0])
 	name := fn.Name()
-	if lastPeriod := strings.LastIndexByte(name, '/'); lastPeriod > 0 {
-		name = name[lastPeriod+1:]
+	if lastSlash := strings.LastIndexByte(name, '/'); lastSlash > 0 {
+		name = name[lastSlash+1:]
 	}
 
 	var span opentracing.Span
@@ -100,6 +113,38 @@ func StartSpanFromContext(ctx context.Context) (opentracing.Span, context.Contex
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
 	file, line := fn.FileLine(pcs[0])
+	span.LogFields(log.String("filename", file), log.Int("line", line))
+
+	return span, ctx
+}
+
+// StartSpanFromContextWithOperationName is like StartSpanFromContext, but the caller determines the operation name.
+func StartSpanFromContextWithOperationName(ctx context.Context, operationName string) (opentracing.Span, context.Context) {
+	if ctx == nil {
+		panic("StartSpanFromContextWithOperationName called with nil context")
+	}
+
+	// Get caller frame.
+	var pcs [1]uintptr
+	n := runtime.Callers(2, pcs[:])
+	if n < 1 {
+		span, ctx := opentracing.StartSpanFromContext(ctx, operationName)
+		span.LogFields(log.Error(errors.New("runtime.Callers failed")))
+		return span, ctx
+	}
+	file, line := runtime.FuncForPC(pcs[0]).FileLine(pcs[0])
+
+	var span opentracing.Span
+	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
+		// Create a child span.
+		span = opentracing.StartSpan(operationName, opentracing.ChildOf(parentSpan.Context()))
+	} else {
+		// Create a root span.
+		span = opentracing.StartSpan(operationName)
+	}
+	// New context references this span, not the parent (if there was one).
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
 	span.LogFields(log.String("filename", file), log.Int("line", line))
 
 	return span, ctx

--- a/query/dependency.go
+++ b/query/dependency.go
@@ -19,13 +19,13 @@ type BucketLookup struct {
 }
 
 // Lookup returns the bucket id and its existence given an org id and bucket name.
-func (b *BucketLookup) Lookup(orgID platform.ID, name string) (platform.ID, bool) {
+func (b *BucketLookup) Lookup(ctx context.Context, orgID platform.ID, name string) (platform.ID, bool) {
 	oid := platform.ID(orgID)
 	filter := platform.BucketFilter{
 		OrganizationID: &oid,
 		Name:           &name,
 	}
-	bucket, err := b.BucketService.FindBucket(context.Background(), filter)
+	bucket, err := b.BucketService.FindBucket(ctx, filter)
 	if err != nil {
 		return platform.InvalidID(), false
 	}

--- a/query/stdlib/influxdata/influxdb/from.go
+++ b/query/stdlib/influxdata/influxdb/from.go
@@ -1,7 +1,9 @@
 package influxdb
 
 import (
+	"context"
 	"fmt"
+	"github.com/influxdata/influxdb/kit/tracing"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
@@ -649,6 +651,9 @@ func (FromKeysRule) Rewrite(keysNode plan.Node) (plan.Node, bool, error) {
 }
 
 func createFromSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
+	span, ctx := tracing.StartSpanFromContext(context.TODO())
+	defer span.Finish()
+
 	spec := prSpec.(*PhysicalFromProcedureSpec)
 	var w execute.Window
 	bounds := a.StreamContext().Bounds()
@@ -685,7 +690,7 @@ func createFromSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execu
 	// Determine bucketID
 	switch {
 	case spec.Bucket != "":
-		b, ok := deps.BucketLookup.Lookup(orgID, spec.Bucket)
+		b, ok := deps.BucketLookup.Lookup(ctx, orgID, spec.Bucket)
 		if !ok {
 			return nil, fmt.Errorf("could not find bucket %q", spec.Bucket)
 		}

--- a/query/stdlib/influxdata/influxdb/source.go
+++ b/query/stdlib/influxdata/influxdb/source.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/tsdb/cursors"
 )
@@ -114,6 +115,9 @@ func (s *readFilterSource) run(ctx context.Context) error {
 }
 
 func createReadFilterSource(s plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
+	span, ctx := tracing.StartSpanFromContext(context.TODO())
+	defer span.Finish()
+
 	spec := s.(*ReadRangePhysSpec)
 
 	bounds := a.StreamContext().Bounds()
@@ -133,7 +137,7 @@ func createReadFilterSource(s plan.ProcedureSpec, id execute.DatasetID, a execut
 	// Determine bucketID
 	switch {
 	case spec.Bucket != "":
-		b, ok := deps.BucketLookup.Lookup(orgID, spec.Bucket)
+		b, ok := deps.BucketLookup.Lookup(ctx, orgID, spec.Bucket)
 		if !ok {
 			return nil, fmt.Errorf("could not find bucket %q", spec.Bucket)
 		}

--- a/query/stdlib/influxdata/influxdb/storage.go
+++ b/query/stdlib/influxdata/influxdb/storage.go
@@ -21,7 +21,7 @@ type HostLookup interface {
 }
 
 type BucketLookup interface {
-	Lookup(orgID platform.ID, name string) (platform.ID, bool)
+	Lookup(ctx context.Context, orgID platform.ID, name string) (platform.ID, bool)
 }
 
 type OrganizationLookup interface {

--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/flux/stdlib/kafka"
 	"github.com/influxdata/flux/values"
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/tsdb"
@@ -439,6 +440,9 @@ func (s Stats) Update(o Stats) {
 }
 
 func writeTable(t *ToTransformation, tbl flux.Table) error {
+	span, ctx := tracing.StartSpanFromContext(context.TODO())
+	defer span.Finish()
+
 	var bucketID, orgID *platform.ID
 	var err error
 
@@ -458,7 +462,7 @@ func writeTable(t *ToTransformation, tbl flux.Table) error {
 
 	// Get bucket ID
 	if spec.Bucket != "" {
-		bID, ok := d.BucketLookup.Lookup(*orgID, spec.Bucket)
+		bID, ok := d.BucketLookup.Lookup(ctx, *orgID, spec.Bucket)
 		if !ok {
 			return fmt.Errorf("failed to look up bucket %q in org %q", spec.Bucket, spec.Org)
 		}

--- a/query/stdlib/influxdata/influxdb/to_test.go
+++ b/query/stdlib/influxdata/influxdb/to_test.go
@@ -592,7 +592,7 @@ func mockDependencies() influxdb.ToDependencies {
 
 type mockBucketLookup struct{}
 
-func (mockBucketLookup) Lookup(orgID platform.ID, name string) (platform.ID, bool) {
+func (mockBucketLookup) Lookup(_ context.Context, orgID platform.ID, name string) (platform.ID, bool) {
 	if name == "my-bucket" {
 		return platform.ID(1), true
 	}

--- a/query/stdlib/influxdata/influxdb/to_test.go
+++ b/query/stdlib/influxdata/influxdb/to_test.go
@@ -116,7 +116,7 @@ func TestToOpSpec_BucketsAccessed(t *testing.T) {
 
 func TestTo_Process(t *testing.T) {
 	oid, _ := (mockOrgLookup{}).Lookup(context.Background(), "my-org")
-	bid, _ := (mockBucketLookup{}).Lookup(oid, "my-bucket")
+	bid, _ := (mockBucketLookup{}).Lookup(nil, oid, "my-bucket")
 	type wanted struct {
 		result *mock.PointsWriter
 		tables []*executetest.Table

--- a/query/stdlib/influxdata/influxdb/to_test.go
+++ b/query/stdlib/influxdata/influxdb/to_test.go
@@ -116,7 +116,7 @@ func TestToOpSpec_BucketsAccessed(t *testing.T) {
 
 func TestTo_Process(t *testing.T) {
 	oid, _ := (mockOrgLookup{}).Lookup(context.Background(), "my-org")
-	bid, _ := (mockBucketLookup{}).Lookup(nil, oid, "my-bucket")
+	bid, _ := (mockBucketLookup{}).Lookup(context.Background(), oid, "my-bucket")
 	type wanted struct {
 		result *mock.PointsWriter
 		tables []*executetest.Table

--- a/storage/readservice/cursor.go
+++ b/storage/readservice/cursor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/storage"
@@ -13,7 +14,6 @@ import (
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxql"
-	opentracing "github.com/opentracing/opentracing-go"
 )
 
 const (
@@ -45,11 +45,8 @@ func newIndexSeriesCursor(ctx context.Context, src *readSource, predicate *datat
 		return nil, nil
 	}
 
-	span := opentracing.SpanFromContext(ctx)
-	if span != nil {
-		span = opentracing.StartSpan("index_cursor.create", opentracing.ChildOf(span.Context()))
-		defer span.Finish()
-	}
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
 
 	opt := query.IteratorOptions{
 		Aux:        []influxql.VarRef{{Val: "key"}},

--- a/storage/wal/wal.go
+++ b/storage/wal/wal.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/golang/snappy"
-	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
@@ -549,7 +548,7 @@ func (l *WAL) Close() error {
 	}
 
 	l.once.Do(func() {
-		span := opentracing.StartSpan("WAL.Close once.Do")
+		span, _ := tracing.StartSpanFromContextWithOperationName(context.Background(), "WAL.Close once.Do")
 		defer span.Finish()
 
 		span.LogKV("path", l.path)

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -14,7 +14,6 @@ import (
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/task/options"
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -639,8 +638,7 @@ func (r *runner) startFromWorking(now int64) {
 		return
 	}
 
-	span := opentracing.StartSpan("runner.startFromWorking")
-	ctx := opentracing.ContextWithSpan(r.ctx, span)
+	span, ctx := tracing.StartSpanFromContext(r.ctx)
 	defer span.Finish()
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -1115,7 +1115,7 @@ func (s *compactionStrategy) Apply(ctx context.Context) {
 
 // compactGroup executes the compaction strategy against a single CompactionGroup.
 func (s *compactionStrategy) compactGroup(ctx context.Context) {
-	span, ctx := tracing.StartSpanFromContext(ctx)
+	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	now := time.Now()


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Various tracing cleanups:
- Add parent spans where child spans were triggering root spans (eg Scheduler, Flux from/to)
- Remove a Tracer pointer (we use `opentracing.GlobalTracer`)
- Add some `tracing.LogError` love
- Inject and extract HTTP headers with library rather than copy-pasted code
- Log file/line from `tracing.LogError`
- Add `tracing.StartSpanFromContextWithOperationName`
- Generally replace opentracing usage with `kit/tracing` for consistency and better spans

  - [x] Rebased/mergeable
  - [ ] Tests pass
