### PR TITLE
refactor(query/preauthorizer): preauthorizer now uses a BucketsAccessed method that accepts AST

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/hashicorp/vault v0.11.5
 	github.com/hashicorp/vault-plugin-secrets-kv v0.0.0-20181106190520-2236f141171e // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-	github.com/influxdata/flux v0.23.1-0.20190410201607-f2bb74e76104
+	github.com/influxdata/flux v0.23.1-0.20190410205636-00b899c91516
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368
 	github.com/jefferai/jsonx v0.0.0-20160721235117-9cc31c3135ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/flux v0.23.1-0.20190410201607-f2bb74e76104 h1:v1fe9Molz4ydDqchihs5XxsWZOrClYr9DFj5dtn2ujI=
 github.com/influxdata/flux v0.23.1-0.20190410201607-f2bb74e76104/go.mod h1:YwRX+zCiwIRI+QZB+ywDfz8yqNnwu9g2g5aL4/n/bXY=
+github.com/influxdata/flux v0.23.1-0.20190410205636-00b899c91516 h1:8BWHU9hAHQB/ZAzbxsUXAWhfAutJqyQep8t0yDcnSPA=
+github.com/influxdata/flux v0.23.1-0.20190410205636-00b899c91516/go.mod h1:YwRX+zCiwIRI+QZB+ywDfz8yqNnwu9g2g5aL4/n/bXY=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6 h1:CFx+pP90q/qg3spoiZjf8donE4WpAdjeJfPOcoNqkWo=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6/go.mod h1:KpVI7okXjK6PRi3Z5B+mtKZli+R1DnZgb3N+tzevNgo=

--- a/query/preauthorizer_test.go
+++ b/query/preauthorizer_test.go
@@ -28,7 +28,6 @@ func newBucketServiceWithOneBucket(bucket platform.Bucket) platform.BucketServic
 }
 
 func TestPreAuthorizer_PreAuthorize(t *testing.T) {
-	t.Skip("Re-enable when pre-authorizer works again")
 	ctx := context.Background()
 	// fresh pre-authorizer
 	auth := &platform.Authorization{Status: platform.Active}

--- a/query/spec.go
+++ b/query/spec.go
@@ -2,6 +2,8 @@ package query
 
 import (
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/lang"
 	platform "github.com/influxdata/influxdb"
 )
 
@@ -11,8 +13,8 @@ type BucketAwareOperationSpec interface {
 }
 
 // BucketsAccessed returns the set of buckets read and written by a query spec
-func BucketsAccessed(q *flux.Spec, orgID *platform.ID) (readBuckets, writeBuckets []platform.BucketFilter, err error) {
-	err = q.Walk(func(o *flux.Operation) error {
+func BucketsAccessed(ast *ast.Package, orgID *platform.ID) (readBuckets, writeBuckets []platform.BucketFilter, err error) {
+	err = lang.WalkIR(ast, func(o *flux.Operation) error {
 		bucketAwareOpSpec, ok := o.Spec.(BucketAwareOperationSpec)
 		if ok {
 			opBucketsRead, opBucketsWritten := bucketAwareOpSpec.BucketsAccessed(orgID)


### PR DESCRIPTION
Closes #13278 

tests won't pass until go.mod is updated with the change to flux on https://github.com/influxdata/flux/pull/1149

_Briefly describe your proposed changes:_


  - [X] Rebased/mergeable
  - [X] Tests pass
 
