### PR TITLE
fix(ui/templates/import): add orgID to created

### DIFF
--- a/ui/src/shared/components/ImportOverlay.tsx
+++ b/ui/src/shared/components/ImportOverlay.tsx
@@ -132,14 +132,14 @@ class ImportOverlay extends PureComponent<Props, State> {
     )
   }
 
-  private submit = () => {
+  private submit = async () => {
     const {importContent} = this.state
     const {
       onSubmit,
       params: {orgID},
     } = this.props
 
-    onSubmit(importContent, orgID)
+    await onSubmit(importContent, orgID)
     this.clearImportContent()
   }
 

--- a/ui/src/templates/actions/index.ts
+++ b/ui/src/templates/actions/index.ts
@@ -107,9 +107,16 @@ export const getTemplates = () => async (dispatch, getState: GetState) => {
   dispatch(populateTemplateSummaries(items))
 }
 
-export const createTemplate = (template: DocumentCreate) => async dispatch => {
+export const createTemplate = (template: DocumentCreate) => async (
+  dispatch,
+  getState: GetState
+) => {
   try {
-    await client.templates.create(template)
+    const {
+      orgs: {org},
+    } = getState()
+
+    await client.templates.create({...template, orgID: org.id})
     dispatch(notify(copy.importTemplateSucceeded()))
   } catch (e) {
     console.error(e)

--- a/ui/src/templates/components/TemplateImportOverlay.tsx
+++ b/ui/src/templates/components/TemplateImportOverlay.tsx
@@ -8,16 +8,16 @@ import ImportOverlay from 'src/shared/components/ImportOverlay'
 // Actions
 import {
   createTemplate as createTemplateAction,
-  setTemplatesStatus as setTemplatesStatusAction,
+  getTemplates as getTemplatesAction,
 } from 'src/templates/actions'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 // Types
-import {AppState, Organization, RemoteDataState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 
 interface DispatchProps {
   createTemplate: typeof createTemplateAction
-  setTemplatesStatus: typeof setTemplatesStatusAction
+  getTemplates: typeof getTemplatesAction
   notify: typeof notifyAction
 }
 
@@ -48,15 +48,15 @@ class TemplateImportOverlay extends PureComponent<Props> {
     router.goBack()
   }
 
-  private handleImportTemplate = () => async (
+  private handleImportTemplate = async (
     importString: string
   ): Promise<void> => {
-    const {createTemplate} = this.props
-    const {setTemplatesStatus} = this.props
+    const {createTemplate, getTemplates} = this.props
 
     const template = JSON.parse(importString)
     await createTemplate(template)
-    setTemplatesStatus(RemoteDataState.NotStarted)
+
+    getTemplates()
 
     this.onDismiss()
   }
@@ -75,7 +75,7 @@ const mstp = (state: AppState, props: Props): StateProps => {
 const mdtp: DispatchProps = {
   notify: notifyAction,
   createTemplate: createTemplateAction,
-  setTemplatesStatus: setTemplatesStatusAction,
+  getTemplates: getTemplatesAction,
 }
 
 export default connect<StateProps, DispatchProps, Props>(


### PR DESCRIPTION
Closes #13307 

_Briefly describe your proposed changes:_
Fixes an issue where orgID was not set in create and where onDismiss was causing the remote data state be stuck in loading templates.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
