### PR TITLE
tsi1: partition close deadlock

### DIFF
--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -318,12 +318,14 @@ func (i *Index) Compact() {
 	}
 }
 
+// EnableCompactions allows compactions to proceed again.
 func (i *Index) EnableCompactions() {
 	for _, p := range i.partitions {
 		p.EnableCompactions()
 	}
 }
 
+// DisableCompactions stops any ongoing compactions and waits for them to finish.
 func (i *Index) DisableCompactions() {
 	for _, p := range i.partitions {
 		p.DisableCompactions()

--- a/tsdb/tsi1/index_file.go
+++ b/tsdb/tsi1/index_file.go
@@ -127,10 +127,12 @@ func (f *IndexFile) Open() (err error) {
 
 	data, err := mmap.Map(f.Path(), 0)
 	if err != nil {
+		f.sfileref.Release()
 		return err
 	}
 
 	if err := f.UnmarshalBinary(data); err != nil {
+		f.sfileref.Release()
 		f.Close()
 		return err
 	}

--- a/tsdb/tsi1/partition_test.go
+++ b/tsdb/tsi1/partition_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestPartition_Open(t *testing.T) {
-	t.Parallel() // There's a bit of IO in this test.
-
 	sfile := MustOpenSeriesFile()
 	defer sfile.Close()
 
@@ -26,15 +24,20 @@ func TestPartition_Open(t *testing.T) {
 
 		fs, err := p.FileSet()
 		if err != nil {
+			p.Close()
 			t.Fatal(err)
 		}
 		defer fs.Release()
 
 		// Check version set appropriately.
 		if got, exp := p.Manifest(fs).Version, 1; got != exp {
+			p.Close()
 			t.Fatalf("got index version %d, expected %d", got, exp)
 		}
 	})
+	if t.Failed() {
+		return
+	}
 
 	// Reopening an open index should return an error.
 	t.Run("reopen open index", func(t *testing.T) {
@@ -45,6 +48,9 @@ func TestPartition_Open(t *testing.T) {
 		}
 		p.Close()
 	})
+	if t.Failed() {
+		return
+	}
 
 	// Opening an incompatible index should return an error.
 	incompatibleVersions := []int{-1, 0, 2}
@@ -75,6 +81,9 @@ func TestPartition_Open(t *testing.T) {
 				t.Fatalf("got error %v, expected %v", err, tsi1.ErrIncompatibleVersion)
 			}
 		})
+		if t.Failed() {
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
When a tsi1 partition closes, it waits on the wait group for compactions
and then acquires the lock. Unfortunately, a compaction may start in the
mean time, holding on to some resources. Then, close will attempt to
close those resources while holding the lock. That will block until
the compaction has finished, but it also needs to acquire the lock
in order to finish, leading to deadlock.

One cannot just move the wait group wait into the lock because, once
again, the compaction must acquire the lock before finishing. Compaction
can't finish before acquiring the lock because then it might be operating
on an invalid resource.

This change splits the locks into two: one to protect just against
concurrent Open and Close calls, and one to protect all of the other
state. We then just close the partition, acquire the lock, then free
the resources. Starting a compaction requires acquiring a resource
to the partition itself, so that it can't start one after it has
started closing.

This change also introduces a cancellation channel into a reference
to a resource that is closed when the resource is being closed, allowing
processes that have acquired a reference to clean up quicker if someone
is trying to close the resource.

Closes #12756