### PR TITLE
fix(query): re-enable some from/to bucket tests

### DIFF
--- a/query/querytest/compile.go
+++ b/query/querytest/compile.go
@@ -5,69 +5,46 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/semantic/semantictest"
-	"github.com/influxdata/flux/stdlib/universe"
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/query"
 )
 
-type BucketAwareQueryTestCase struct {
+type BucketsAccessedTestCase struct {
 	Name             string
 	Raw              string
-	Want             *flux.Spec
 	WantErr          bool
 	WantReadBuckets  *[]platform.BucketFilter
 	WantWriteBuckets *[]platform.BucketFilter
 }
 
-var opts = append(
-	semantictest.CmpOptions,
-	cmp.AllowUnexported(flux.Spec{}),
-	cmp.AllowUnexported(universe.JoinOpSpec{}),
-	cmpopts.IgnoreUnexported(flux.Spec{}),
-	cmpopts.IgnoreUnexported(universe.JoinOpSpec{}),
-)
-
-func BucketAwareQueryTestHelper(t *testing.T, tc BucketAwareQueryTestCase) {
-	t.Skip("BucketsAccessed needs re-implementing; see https://github.com/influxdata/influxdb/issues/13278")
+func BucketsAccessedTestHelper(t *testing.T, tc BucketsAccessedTestCase) {
 	t.Helper()
 
-	//now := time.Now().UTC()
-	//got, err := flux.Compile(context.Background(), tc.Raw, now)
-	//if (err != nil) != tc.WantErr {
-	//	t.Errorf("error compiling spec error: %v, wantErr %v", err, tc.WantErr)
-	//	return
-	//}
-	//if tc.WantErr {
-	//	return
-	//}
-	//if tc.Want != nil {
-	//	tc.Want.Now = now
-	//	if !cmp.Equal(tc.Want, got, opts...) {
-	//		t.Errorf("unexpected specs -want/+got %s", cmp.Diff(tc.Want, got, opts...))
-	//	}
-	//}
-	//
-	//var gotReadBuckets, gotWriteBuckets []platform.BucketFilter
-	//if tc.WantReadBuckets != nil || tc.WantWriteBuckets != nil {
-	//	gotReadBuckets, gotWriteBuckets, err = query.BucketsAccessed(got, nil)
-	//	if err != nil {
-	//		t.Fatal(err)
-	//	}
-	//}
-	//
-	//if tc.WantReadBuckets != nil {
-	//	if diagnostic := verifyBuckets(*tc.WantReadBuckets, gotReadBuckets); diagnostic != "" {
-	//		t.Errorf("Could not verify read buckets: %v", diagnostic)
-	//	}
-	//}
-	//
-	//if tc.WantWriteBuckets != nil {
-	//	if diagnostic := verifyBuckets(*tc.WantWriteBuckets, gotWriteBuckets); diagnostic != "" {
-	//		t.Errorf("Could not verify write buckets: %v", diagnostic)
-	//	}
-	//}
+	ast, err := flux.Parse(tc.Raw)
+	if err != nil {
+		t.Fatalf("could not parse flux: %v", err)
+	}
+
+	var gotReadBuckets, gotWriteBuckets []platform.BucketFilter
+	if tc.WantReadBuckets != nil || tc.WantWriteBuckets != nil {
+		gotReadBuckets, gotWriteBuckets, err = query.BucketsAccessed(ast, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if tc.WantReadBuckets != nil {
+		if diagnostic := verifyBuckets(*tc.WantReadBuckets, gotReadBuckets); diagnostic != "" {
+			t.Errorf("Could not verify read buckets: %v", diagnostic)
+		}
+	}
+
+	if tc.WantWriteBuckets != nil {
+		if diagnostic := verifyBuckets(*tc.WantWriteBuckets, gotWriteBuckets); diagnostic != "" {
+			t.Errorf("Could not verify write buckets: %v", diagnostic)
+		}
+	}
 }
 
 func verifyBuckets(wantBuckets, gotBuckets []platform.BucketFilter) string {

--- a/query/stdlib/influxdata/influxdb/from_test.go
+++ b/query/stdlib/influxdata/influxdb/from_test.go
@@ -130,7 +130,7 @@ func TestFromOpSpec_BucketsAccessed(t *testing.T) {
 		t.Fatal(err)
 	}
 	invalidID := platform.InvalidID()
-	tests := []pquerytest.BucketAwareQueryTestCase{
+	tests := []pquerytest.BucketsAccessedTestCase{
 		{
 			Name:             "From with bucket",
 			Raw:              fmt.Sprintf(`from(bucket:"%s")`, bucketName),
@@ -154,7 +154,7 @@ func TestFromOpSpec_BucketsAccessed(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			pquerytest.BucketAwareQueryTestHelper(t, tc)
+			pquerytest.BucketsAccessedTestHelper(t, tc)
 		})
 	}
 }

--- a/query/stdlib/influxdata/influxdb/to_test.go
+++ b/query/stdlib/influxdata/influxdb/to_test.go
@@ -10,18 +10,19 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/semantic"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/mock"
 	"github.com/influxdata/influxdb/models"
 	_ "github.com/influxdata/influxdb/query/builtin"
-	"github.com/influxdata/influxdb/query/querytest"
+	pquerytest "github.com/influxdata/influxdb/query/querytest"
 	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/tsdb"
 )
 
 func TestTo_Query(t *testing.T) {
-	tests := []querytest.BucketAwareQueryTestCase{
+	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "from with database with range",
 			Raw:  `from(bucket:"mydb") |> to(bucket:"series1", org:"fred", host:"localhost", token:"auth-token", fieldFn: (r) => ({ col: r.col }) )`,
@@ -77,7 +78,7 @@ func TestTo_Query(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			querytest.BucketAwareQueryTestHelper(t, tc)
+			querytest.NewQueryTestHelper(t, tc)
 		})
 	}
 }
@@ -90,7 +91,7 @@ func TestToOpSpec_BucketsAccessed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tests := []querytest.BucketAwareQueryTestCase{
+	tests := []pquerytest.BucketsAccessedTestCase{
 		{
 			Name:             "from() with bucket and to with org and bucket",
 			Raw:              fmt.Sprintf(`from(bucket:"%s") |> to(bucket:"%s", org:"%s")`, bucketName, bucketName, orgName),
@@ -109,7 +110,7 @@ func TestToOpSpec_BucketsAccessed(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			querytest.BucketAwareQueryTestHelper(t, tc)
+			pquerytest.BucketsAccessedTestHelper(t, tc)
 		})
 	}
 }


### PR DESCRIPTION
_Briefly describe your proposed changes:_

This re-enables some bucket tests for from/to after they were disabled.  I also renamed `BucketAwareQueryTest*` to `BucketsAccessedTest*`, since it's tricky to check both the buckets accessed and verify the spec in the same test case, since `flux.Spec` is trickier to create.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
