### PR TITLE
should use toml:value to get field type from config file

### DIFF
--- a/stress/basic.go
+++ b/stress/basic.go
@@ -46,7 +46,7 @@ func (t AbstractTags) Template() string {
 // defines a field
 type AbstractField struct {
 	Key  string `toml:"key"`
-	Type string `toml:"type"`
+	Type string `toml:"value"`
 }
 
 // AbstractFields is a slice of abstract fields


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
In stress.toml (and other files) we use:
[[write.point_generator.basic.field]]
        key = "value"
        **value** = "float64"

So in stress/basic.go also should use "Type string `toml:"value"`" rather than "Type string `toml:"type"`"
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
