### PR TITLE
feat(storage): add tsm level metrics

### DIFF
--- a/tsdb/tsm1/metrics.go
+++ b/tsdb/tsm1/metrics.go
@@ -136,6 +136,7 @@ func newFileMetrics(labels prometheus.Labels) *fileMetrics {
 	for k := range labels {
 		names = append(names, k)
 	}
+	names = append(names, "level")
 	sort.Strings(names)
 
 	return &fileMetrics{

--- a/tsdb/tsm1/metrics_test.go
+++ b/tsdb/tsm1/metrics_test.go
@@ -18,11 +18,11 @@ func TestMetrics_Filestore(t *testing.T) {
 	reg.MustRegister(metrics.PrometheusCollectors()...)
 
 	// Generate some measurements.
-	t1.AddBytes(100)
-	t1.SetFileCount(3)
+	t1.AddBytes(100, 0)
+	t1.SetFileCount(map[int]uint64{0: 3})
 
-	t2.AddBytes(200)
-	t2.SetFileCount(4)
+	t2.AddBytes(200, 0)
+	t2.SetFileCount(map[int]uint64{0: 4})
 
 	// Test that all the correct metrics are present.
 	mfs, err := reg.Gather()
@@ -31,10 +31,10 @@ func TestMetrics_Filestore(t *testing.T) {
 	}
 
 	base := namespace + "_" + fileStoreSubsystem + "_"
-	m1Bytes := promtest.MustFindMetric(t, mfs, base+"disk_bytes", prometheus.Labels{"engine_id": "0", "node_id": "0"})
-	m2Bytes := promtest.MustFindMetric(t, mfs, base+"disk_bytes", prometheus.Labels{"engine_id": "1", "node_id": "0"})
-	m1Files := promtest.MustFindMetric(t, mfs, base+"total", prometheus.Labels{"engine_id": "0", "node_id": "0"})
-	m2Files := promtest.MustFindMetric(t, mfs, base+"total", prometheus.Labels{"engine_id": "1", "node_id": "0"})
+	m1Bytes := promtest.MustFindMetric(t, mfs, base+"disk_bytes", prometheus.Labels{"engine_id": "0", "node_id": "0", "level": "0"})
+	m2Bytes := promtest.MustFindMetric(t, mfs, base+"disk_bytes", prometheus.Labels{"engine_id": "1", "node_id": "0", "level": "0"})
+	m1Files := promtest.MustFindMetric(t, mfs, base+"total", prometheus.Labels{"engine_id": "0", "node_id": "0", "level": "0"})
+	m2Files := promtest.MustFindMetric(t, mfs, base+"total", prometheus.Labels{"engine_id": "1", "node_id": "0", "level": "0"})
 
 	if m, got, exp := m1Bytes, m1Bytes.GetGauge().GetValue(), 100.0; got != exp {
 		t.Errorf("[%s] got %v, expected %v", m, got, exp)


### PR DESCRIPTION
Adds prometheus metrics recording compaction levels for TSM files.

Closes https://github.com/influxdata/influxdb/issues/11969

