### PR TITLE
fix(telegrafs): add get telegrafs to BucketsPage

### DIFF
--- a/ui/src/buckets/containers/BucketsIndex.tsx
+++ b/ui/src/buckets/containers/BucketsIndex.tsx
@@ -42,8 +42,10 @@ class BucketsIndex extends Component<StateProps> {
                     title="Buckets"
                   >
                     <GetResources resource={ResourceTypes.Buckets}>
-                      <BucketsTab />
-                      {this.props.children}
+                      <GetResources resource={ResourceTypes.Telegrafs}>
+                        <BucketsTab />
+                        {this.props.children}
+                      </GetResources>
                     </GetResources>
                   </TabbedPageSection>
                 </Tabs.TabContents>


### PR DESCRIPTION
This PR adds a `GetResources` component for Telegrafs to the `BucketsPage` in order to open the `TelegrafConfigOverlay`


  - [x] Rebased/mergeable
  - [x] Tests pass
