### PR TITLE
tsm1: predicate deletes

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -535,7 +535,7 @@ func (e *Engine) deleteBucketRangeLocked(orgID, bucketID platform.ID, min, max i
 	encoded := tsdb.EncodeName(orgID, bucketID)
 	name := models.EscapeMeasurement(encoded[:])
 
-	return e.engine.DeleteBucketRange(name, min, max)
+	return e.engine.DeletePrefixRange(name, min, max, nil)
 }
 
 // SeriesCardinality returns the number of series in the engine.

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -520,7 +520,7 @@ func (e *Engine) DeleteBucketRange(orgID, bucketID platform.ID, min, max int64) 
 	}
 
 	// Add the delete to the WAL to be replayed if there is a crash or shutdown.
-	if _, err := e.wal.DeleteBucketRange(orgID, bucketID, min, max); err != nil {
+	if _, err := e.wal.DeleteBucketRange(orgID, bucketID, min, max, nil); err != nil {
 		return err
 	}
 

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -535,7 +535,8 @@ func (e *Engine) DeleteBucketRange(orgID, bucketID platform.ID, min, max int64) 
 	return e.deleteBucketRangeLocked(orgID, bucketID, min, max, nil)
 }
 
-// DeleteBucketRangePredicate deletes an entire bucket from the storage engine.
+// DeleteBucketRangePredicate deletes data within a bucket from the storage engine. Any data
+// deleted must be in [min, max], and the key must match the predicate if provided.
 func (e *Engine) DeleteBucketRangePredicate(orgID, bucketID platform.ID,
 	min, max int64, pred tsm1.Predicate) error {
 

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -317,7 +317,7 @@ func TestEngine_DeleteBucket_Predicate(t *testing.T) {
 		t.Fatalf("got %d series, exp %d series in index", got, exp)
 	}
 
-	// Delete based on field.
+	// Delete based on field key.
 	pred, err = tsm1.NewProtobufPredicate(&datatypes.Predicate{
 		Root: &datatypes.Node{
 			NodeType: datatypes.NodeTypeComparisonExpression,

--- a/storage/wal/wal_test.go
+++ b/storage/wal/wal_test.go
@@ -222,10 +222,11 @@ func TestWALWriter_DeleteBucketRange(t *testing.T) {
 	w := NewWALSegmentWriter(f)
 
 	entry := &DeleteBucketRangeWALEntry{
-		OrgID:    influxdb.ID(1),
-		BucketID: influxdb.ID(2),
-		Min:      3,
-		Max:      4,
+		OrgID:     influxdb.ID(1),
+		BucketID:  influxdb.ID(2),
+		Min:       3,
+		Max:       4,
+		Predicate: []byte("predicate"),
 	}
 
 	if err := w.Write(mustMarshalEntry(entry)); err != nil {
@@ -449,10 +450,14 @@ func TestWriteWALSegment_UnmarshalBinary_WriteWALCorrupt(t *testing.T) {
 func TestDeleteBucketRangeWALEntry_UnmarshalBinary(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		in := &DeleteBucketRangeWALEntry{
-			OrgID:    influxdb.ID(rand.Int63()) + 1,
-			BucketID: influxdb.ID(rand.Int63()) + 1,
-			Min:      rand.Int63(),
-			Max:      rand.Int63(),
+			OrgID:     influxdb.ID(rand.Int63()) + 1,
+			BucketID:  influxdb.ID(rand.Int63()) + 1,
+			Min:       rand.Int63(),
+			Max:       rand.Int63(),
+			Predicate: make([]byte, rand.Intn(100)),
+		}
+		if len(in.Predicate) == 0 {
+			in.Predicate = nil
 		}
 
 		b, err := in.MarshalBinary()
@@ -473,10 +478,11 @@ func TestDeleteBucketRangeWALEntry_UnmarshalBinary(t *testing.T) {
 
 func TestWriteWALSegment_UnmarshalBinary_DeleteBucketRangeWALCorrupt(t *testing.T) {
 	w := &DeleteBucketRangeWALEntry{
-		OrgID:    influxdb.ID(1),
-		BucketID: influxdb.ID(2),
-		Min:      3,
-		Max:      4,
+		OrgID:     influxdb.ID(1),
+		BucketID:  influxdb.ID(2),
+		Min:       3,
+		Max:       4,
+		Predicate: []byte("predicate"),
 	}
 
 	b, err := w.MarshalBinary()

--- a/tsdb/tsm1/engine_delete_prefix.go
+++ b/tsdb/tsm1/engine_delete_prefix.go
@@ -11,10 +11,17 @@ import (
 	"github.com/influxdata/influxql"
 )
 
-// DeleteBucketRange removes all TSM data belonging to a bucket, and removes all index
+// Predicate is something that can match on a series key. It also exports some other
+// methods that can be used in order to more efficiently walk indexes.
+type Predicate interface {
+	Matches(key []byte) bool
+	Measurement() []byte // if non-nil, specifies a specific measurement to match
+}
+
+// DeletePrefixRange removes all TSM data belonging to a bucket, and removes all index
 // and series file data associated with the bucket. The provided time range ensures
 // that only bucket data for that range is removed.
-func (e *Engine) DeleteBucketRange(name []byte, min, max int64) error {
+func (e *Engine) DeletePrefixRange(name []byte, min, max int64, pred Predicate) error {
 	// TODO(jeff): we need to block writes to this prefix while deletes are in progress
 	// otherwise we can end up in a situation where we have staged data in the cache or
 	// WAL that was deleted from the index, or worse. This needs to happen at a higher

--- a/tsdb/tsm1/engine_delete_prefix.go
+++ b/tsdb/tsm1/engine_delete_prefix.go
@@ -11,13 +11,6 @@ import (
 	"github.com/influxdata/influxql"
 )
 
-// Predicate is something that can match on a series key. It also exports some other
-// methods that can be used in order to more efficiently walk indexes.
-type Predicate interface {
-	Matches(key []byte) bool
-	Measurement() []byte // if non-nil, specifies a specific measurement to match
-}
-
 // DeletePrefixRange removes all TSM data belonging to a bucket, and removes all index
 // and series file data associated with the bucket. The provided time range ensures
 // that only bucket data for that range is removed.
@@ -71,7 +64,7 @@ func (e *Engine) DeletePrefixRange(name []byte, min, max int64, pred Predicate) 
 	possiblyDead.keys = make(map[string]struct{})
 
 	if err := e.FileStore.Apply(func(r TSMFile) error {
-		return r.DeletePrefix(name, min, max, func(key []byte) {
+		return r.DeletePrefix(name, min, max, pred, func(key []byte) {
 			possiblyDead.Lock()
 			possiblyDead.keys[string(key)] = struct{}{}
 			possiblyDead.Unlock()

--- a/tsdb/tsm1/engine_delete_prefix.go
+++ b/tsdb/tsm1/engine_delete_prefix.go
@@ -84,9 +84,6 @@ func (e *Engine) DeletePrefixRange(name []byte, min, max int64, pred Predicate) 
 			return nil
 		}
 
-		if deleteKeys == nil {
-			deleteKeys = make([][]byte, 0, 10000)
-		}
 		deleteKeys = append(deleteKeys, k)
 
 		// we have to double check every key in the cache because maybe

--- a/tsdb/tsm1/engine_delete_prefix_test.go
+++ b/tsdb/tsm1/engine_delete_prefix_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 )
 
-func TestEngine_DeleteBucket(t *testing.T) {
+func TestEngine_DeletePrefix(t *testing.T) {
 	// Create a few points.
 	p1 := MustParsePointString("cpu,host=0 value=1.1 6", "mm0")
 	p2 := MustParsePointString("cpu,host=A value=1.2 2", "mm0")
@@ -42,7 +42,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 		t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
 	}
 
-	if err := e.DeleteBucketRange([]byte("mm0"), 0, 3); err != nil {
+	if err := e.DeletePrefixRange([]byte("mm0"), 0, 3, nil); err != nil {
 		t.Fatalf("failed to delete series: %v", err)
 	}
 
@@ -88,7 +88,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 	iter.Close()
 
 	// Deleting remaining series should remove them from the series.
-	if err := e.DeleteBucketRange([]byte("mm0"), 0, 9); err != nil {
+	if err := e.DeletePrefixRange([]byte("mm0"), 0, 9, nil); err != nil {
 		t.Fatalf("failed to delete series: %v", err)
 	}
 

--- a/tsdb/tsm1/engine_test.go
+++ b/tsdb/tsm1/engine_test.go
@@ -60,9 +60,8 @@ func TestIndex_SeriesIDSet(t *testing.T) {
 	}
 
 	// Drop all the series for the gpu measurement and they should no longer
-	// be in the series ID set. This relies on the fact that DeleteBucketRange is really
-	// operating on prefixes.
-	if err := engine.DeleteBucketRange([]byte("gpu"), math.MinInt64, math.MaxInt64); err != nil {
+	// be in the series ID set.
+	if err := engine.DeletePrefixRange([]byte("gpu"), math.MinInt64, math.MaxInt64, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -486,7 +485,7 @@ func (e *Engine) MustDeleteBucketRange(orgID, bucketID influxdb.ID, min, max int
 	encoded := tsdb.EncodeName(orgID, bucketID)
 	name := models.EscapeMeasurement(encoded[:])
 
-	err := e.DeleteBucketRange(name, min, max)
+	err := e.DeletePrefixRange(name, min, max, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/tsdb/tsm1/engine_test.go
+++ b/tsdb/tsm1/engine_test.go
@@ -477,8 +477,8 @@ func (e *Engine) MustWritePointsString(org, bucket influxdb.ID, buf string) {
 	}
 }
 
-// MustDeleteBucketRange calls DeleteBucketRange using the org and bucket for
-// the name. Panic on error.
+// MustDeleteBucketRange calls DeletePrefixRange using the org and bucket for
+// the prefix. Panic on error.
 func (e *Engine) MustDeleteBucketRange(orgID, bucketID influxdb.ID, min, max int64) {
 	// TODO(edd): we need to clean up how we're encoding the prefix so that we
 	// don't have to remember to get it right everywhere we need to touch TSM data.

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -117,7 +117,7 @@ type TSMFile interface {
 
 	// DeletePrefix removes the values for keys beginning with prefix. It calls dead with
 	// any keys that became dead as a result of this call.
-	DeletePrefix(prefix []byte, min, max int64, dead func([]byte)) error
+	DeletePrefix(prefix []byte, min, max int64, pred Predicate, dead func([]byte)) error
 
 	// HasTombstones returns true if file contains values that have been deleted.
 	HasTombstones() bool

--- a/tsdb/tsm1/predicate.go
+++ b/tsdb/tsm1/predicate.go
@@ -1,0 +1,7 @@
+package tsm1
+
+// Predicate is something that can match on a series key.
+type Predicate interface {
+	Matches(key []byte) bool
+	Marshal() ([]byte, error)
+}

--- a/tsdb/tsm1/predicate.go
+++ b/tsdb/tsm1/predicate.go
@@ -1,6 +1,13 @@
 package tsm1
 
-import "errors"
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/storage/reads/datatypes"
+)
 
 // Predicate is something that can match on a series key.
 type Predicate interface {
@@ -8,9 +15,591 @@ type Predicate interface {
 	Marshal() ([]byte, error)
 }
 
+// UnmarshalPredicate takes stored predicate bytes from a Marshal call and returns a Predicate.
 func UnmarshalPredicate(data []byte) (Predicate, error) {
-	if data != nil {
-		return nil, errors.New("unimplemented")
+	if len(data) == 0 {
+		return nil, nil
+	} else if data[0] != '\x00' {
+		return nil, fmt.Errorf("unknown tag byte: %x", data[0])
 	}
-	return nil, nil
+
+	pred := new(datatypes.Predicate)
+	if err := pred.Unmarshal(data[1:]); err != nil {
+		return nil, err
+	}
+	return NewProtobufPredicate(pred)
+}
+
+//
+// Design
+//
+
+// Predicates lazily evaluate with memoization so that we can walk a series key
+// by the tags without parsing them into a structure and allocating. Each node
+// in a predicate tree keeps a cache if it has enough information to have a
+// definite value. The predicate state keeps track of all of the tag key/value
+// pairs passed to it, and has a reset function to start over for a new series key.
+//
+// For example, imagine a query like
+//
+//	("tag1" == "val1" AND "tag2" == "val2") OR "tag3" == "val3"
+//
+// The state would have tag values set on it like
+//
+//	state.Set("tag1", "val1")        => NeedMore
+//	state.Set("tag2", "not-val2")    => NeedMore
+//	state.Set("tag3", "val3")        => True
+//
+// where after the first Set, the AND and OR clauses are both NeedMore, after
+// the second Set, the AND clause is False and the OR clause is NeedMore, and
+// after the last Set, the AND clause is still False, and the OR clause is True.
+//
+// Fast resetting is achieved by having each cache maintain a pointer to the state
+// and both having a generation number. When the state resets, it bumps the generation
+// number, and when the value is set in the cache, it is set with the current generation
+// of the state. When querying the cache, it checks if the generation still matches.
+
+//
+// Protobuf Implementation
+//
+
+// NewProtobufPredicate returns a Predicate that matches based on the comparison structure
+// described by the incoming protobuf.
+func NewProtobufPredicate(pred *datatypes.Predicate) (Predicate, error) {
+	// Walk the predicate to collect the tag refs
+	locs := make(map[string]int)
+	walkPredicateNodes(pred.Root, func(node *datatypes.Node) {
+		if node.GetNodeType() == datatypes.NodeTypeTagRef {
+			locs[node.GetTagRefValue()] = len(locs)
+		} else if node.GetNodeType() == datatypes.NodeTypeFieldRef {
+			locs[models.FieldKeyTagKey] = len(locs)
+		}
+	})
+
+	// Construct the shared state and root predicate node.
+	state := newPredicateState(locs)
+	root, err := buildPredicateNode(state, pred.Root)
+	if err != nil {
+		return nil, err
+	}
+
+	return &predicateMatcher{
+		pred:  pred,
+		state: state,
+		root:  root,
+	}, nil
+}
+
+// predicateMatcher implements Predicate for a protobuf.
+type predicateMatcher struct {
+	pred  *datatypes.Predicate
+	state *predicateState
+	root  predicateNode
+}
+
+// Matches checks if the key matches the predicate by feeding individual tags into the
+// state and returning as soon as the root node has a definite answer.
+func (p *predicateMatcher) Matches(key []byte) bool {
+	p.state.Reset()
+
+	popTag := predicatePopTag
+	if bytes.IndexByte(key, '\\') != -1 {
+		popTag = predicatePopTagEscape
+	}
+
+	var tag, value []byte
+	for len(key) > 0 {
+		tag, value, key = popTag(key)
+		if tag == nil || !p.state.Set(tag, value) {
+			continue
+		}
+		resp := p.root.Update()
+		if resp == predicateResponse_true {
+			return true
+		} else if resp == predicateResponse_false {
+			return false
+		}
+	}
+
+	return false
+}
+
+// Marshal returns a buffer representing the protobuf predicate.
+func (p *predicateMatcher) Marshal() ([]byte, error) {
+	// Prefix it with a zero byte so that we can change in the future if necessary
+	buf := make([]byte, 1+p.pred.Size())
+	_, err := p.pred.MarshalTo(buf[1:])
+	return buf, err
+}
+
+// walkPredicateNodes recursively calls the function for each node.
+func walkPredicateNodes(node *datatypes.Node, fn func(node *datatypes.Node)) {
+	fn(node)
+	for _, ch := range node.Children {
+		walkPredicateNodes(ch, fn)
+	}
+}
+
+// buildPredicateNode takes a protobuf node and converts it into a predicateNode. It is strict
+// in what it accepts.
+func buildPredicateNode(state *predicateState, node *datatypes.Node) (predicateNode, error) {
+	switch node.GetNodeType() {
+	case datatypes.NodeTypeComparisonExpression:
+		children := node.GetChildren()
+		if len(children) != 2 {
+			return nil, fmt.Errorf("invalid number of children for logical expression: %v", len(children))
+		}
+		left, right := children[0], children[1]
+
+		comp := &predicateNodeComparison{
+			predicateCache: newPredicateCache(state),
+			comp:           node.GetComparison(),
+		}
+
+		// Fill in the left side of the comparison
+		switch left.GetNodeType() {
+		// Field refs are actually for the '\xff' tag
+		case datatypes.NodeTypeFieldRef:
+			idx, ok := state.locs[models.FieldKeyTagKey]
+			if !ok {
+				return nil, fmt.Errorf("invalid field ref in comparison: %v", left.GetTagRefValue())
+			}
+			comp.leftIndex = idx
+
+		// Tag refs look up the location of the tag in the state
+		case datatypes.NodeTypeTagRef:
+			idx, ok := state.locs[left.GetTagRefValue()]
+			if !ok {
+				return nil, fmt.Errorf("invalid tag ref in comparison: %v", left.GetTagRefValue())
+			}
+			comp.leftIndex = idx
+
+		// Left literals are only allowed to be strings
+		case datatypes.NodeTypeLiteral:
+			lit, ok := left.GetValue().(*datatypes.Node_StringValue)
+			if !ok {
+				return nil, fmt.Errorf("invalid left literal in comparison: %v", left.GetValue())
+			}
+			comp.leftLiteral = []byte(lit.StringValue)
+
+		default:
+			return nil, fmt.Errorf("invalid left node in comparison: %v", left.GetNodeType())
+		}
+
+		// Fill in the right side of the comparison
+		switch right.GetNodeType() {
+		// Field refs are actually for the '\xff' tag
+		case datatypes.NodeTypeFieldRef:
+			idx, ok := state.locs[models.FieldKeyTagKey]
+			if !ok {
+				return nil, fmt.Errorf("invalid field ref in comparison: %v", left.GetTagRefValue())
+			}
+			comp.rightIndex = idx
+
+		// Tag refs look up the location of the tag in the state
+		case datatypes.NodeTypeTagRef:
+			idx, ok := state.locs[right.GetTagRefValue()]
+			if !ok {
+				return nil, fmt.Errorf("invalid tag ref in comparison: %v", right.GetTagRefValue())
+			}
+			comp.rightIndex = idx
+
+		// Right literals are allowed to be regexes as well as strings
+		case datatypes.NodeTypeLiteral:
+			switch lit := right.GetValue().(type) {
+			case *datatypes.Node_StringValue:
+				comp.rightLiteral = []byte(lit.StringValue)
+
+			case *datatypes.Node_RegexValue:
+				reg, err := regexp.Compile(lit.RegexValue)
+				if err != nil {
+					return nil, err
+				}
+				comp.rightReg = reg
+
+			default:
+				return nil, fmt.Errorf("invalid right literal in comparison: %v", right.GetValue())
+			}
+
+		default:
+			return nil, fmt.Errorf("invalid right node in comparison: %v", right.GetNodeType())
+		}
+
+		// Ensure that a regex is set on the right if and only if the comparison is a regex
+		if comp.rightReg == nil {
+			if comp.comp == datatypes.ComparisonRegex || comp.comp == datatypes.ComparisonNotRegex {
+				return nil, fmt.Errorf("invalid comparison involving regex: %v", node)
+			}
+		} else {
+			if comp.comp != datatypes.ComparisonRegex && comp.comp != datatypes.ComparisonNotEqual {
+				return nil, fmt.Errorf("invalid comparison not against regex: %v", node)
+			}
+		}
+
+		return comp, nil
+
+	case datatypes.NodeTypeLogicalExpression:
+		children := node.GetChildren()
+		if len(children) != 2 {
+			return nil, fmt.Errorf("invalid number of children for logical expression: %v", len(children))
+		}
+
+		left, err := buildPredicateNode(state, children[0])
+		if err != nil {
+			return nil, err
+		}
+		right, err := buildPredicateNode(state, children[1])
+		if err != nil {
+			return nil, err
+		}
+
+		switch node.GetLogical() {
+		case datatypes.LogicalAnd:
+			return &predicateNodeAnd{
+				predicateCache: newPredicateCache(state),
+				left:           left,
+				right:          right,
+			}, nil
+
+		case datatypes.LogicalOr:
+			return &predicateNodeOr{
+				predicateCache: newPredicateCache(state),
+				left:           left,
+				right:          right,
+			}, nil
+
+		default:
+			return nil, fmt.Errorf("unknown logical type: %v", node.GetLogical())
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported predicate type: %v", node.GetNodeType())
+	}
+}
+
+//
+// Predicate Responses
+//
+
+type predicateResponse uint8
+
+const (
+	predicateResponse_needMore predicateResponse = iota
+	predicateResponse_true
+	predicateResponse_false
+)
+
+//
+// Predicate State
+//
+
+// predicateState keeps track of tag key=>value mappings with cheap methods
+// to reset to a blank state.
+type predicateState struct {
+	gen    uint64
+	locs   map[string]int
+	values [][]byte
+}
+
+// newPredicateState creates a predicateState given a map of keys to indexes into an
+// an array.
+func newPredicateState(locs map[string]int) *predicateState {
+	return &predicateState{
+		gen:    1, // so that caches start out unfilled since they start at 0
+		locs:   locs,
+		values: make([][]byte, len(locs)),
+	}
+}
+
+// Reset clears any set values for the state.
+func (p *predicateState) Reset() {
+	p.gen++
+
+	for i := range p.values {
+		p.values[i] = nil
+	}
+}
+
+// Set sets the key to be the value and returns true if the key is part of the considered
+// set of keys.
+func (p *predicateState) Set(key, value []byte) bool {
+	i, ok := p.locs[string(key)]
+	if ok {
+		p.values[i] = value
+	}
+	return ok
+}
+
+//
+// Predicate Cache
+//
+
+// predicateCache interacts with the predicateState to keep determined responses
+// memoized until the state has been Reset to avoid recomputing nodes.
+type predicateCache struct {
+	state *predicateState
+	gen   uint64
+	resp  predicateResponse
+}
+
+// newPredicateCache constructs a predicateCache for the provided state.
+func newPredicateCache(state *predicateState) predicateCache {
+	return predicateCache{
+		state: state,
+		gen:   0,
+		resp:  predicateResponse_needMore,
+	}
+}
+
+// Cached returns the cached response and a boolean indicating if it is valid.
+func (p *predicateCache) Cached() (predicateResponse, bool) {
+	return p.resp, p.gen == p.state.gen
+}
+
+// Store sets the cache to the provided response until the state is Reset.
+func (p *predicateCache) Store(resp predicateResponse) {
+	p.gen = p.state.gen
+	p.resp = resp
+}
+
+//
+// Predicate Nodes
+//
+
+// predicateNode is the interface that any parts of a predicate tree implement.
+type predicateNode interface {
+	// Update informs the node that the state has been updated and asks it to return
+	// a response.
+	Update() predicateResponse
+}
+
+// predicateNodeAnd combines two predicate nodes with an And.
+type predicateNodeAnd struct {
+	predicateCache
+	left, right predicateNode
+}
+
+// Update checks if both of the left and right nodes are true. If either is false
+// then the node is definitely false. Otherwise, it needs more information.
+func (p *predicateNodeAnd) Update() predicateResponse {
+	if resp, ok := p.Cached(); ok {
+		return resp
+	}
+
+	left := p.left.Update()
+	if left == predicateResponse_false {
+		p.Store(predicateResponse_false)
+		return predicateResponse_false
+	} else if left == predicateResponse_needMore {
+		return predicateResponse_needMore
+	}
+
+	right := p.right.Update()
+	if right == predicateResponse_false {
+		p.Store(predicateResponse_false)
+		return predicateResponse_false
+	} else if right == predicateResponse_needMore {
+		return predicateResponse_needMore
+	}
+
+	return predicateResponse_true
+}
+
+// predicateNodeOr combines two predicate nodes with an Or.
+type predicateNodeOr struct {
+	predicateCache
+	left, right predicateNode
+}
+
+// Update checks if either the left and right nodes are true. If both nodes
+// are false, then the node is definitely asle. Otherwise, it needs more information.
+func (p *predicateNodeOr) Update() predicateResponse {
+	if resp, ok := p.Cached(); ok {
+		return resp
+	}
+
+	left := p.left.Update()
+	if left == predicateResponse_true {
+		p.Store(predicateResponse_true)
+		return predicateResponse_true
+	}
+
+	right := p.right.Update()
+	if right == predicateResponse_true {
+		p.Store(predicateResponse_true)
+		return predicateResponse_true
+	}
+
+	if left == predicateResponse_false && right == predicateResponse_false {
+		p.Store(predicateResponse_false)
+		return predicateResponse_false
+	}
+
+	return predicateResponse_needMore
+}
+
+// predicateNodeComparison compares values of tags.
+type predicateNodeComparison struct {
+	predicateCache
+	comp         datatypes.Node_Comparison
+	rightReg     *regexp.Regexp
+	leftLiteral  []byte
+	rightLiteral []byte
+	leftIndex    int
+	rightIndex   int
+}
+
+// Update checks if both sides of the comparison are determined, and if so, evaluates
+// the comparison to a determined truth value.
+func (p *predicateNodeComparison) Update() predicateResponse {
+	if resp, ok := p.Cached(); ok {
+		return resp
+	}
+
+	left := p.leftLiteral
+	if left == nil {
+		left = p.state.values[p.leftIndex]
+		if left == nil {
+			return predicateResponse_needMore
+		}
+	}
+
+	right := p.rightLiteral
+	if right == nil && p.rightReg != nil {
+		right = p.state.values[p.rightIndex]
+		if right == nil {
+			return predicateResponse_needMore
+		}
+	}
+
+	if predicateEval(p.comp, left, right, p.rightReg) {
+		p.Store(predicateResponse_true)
+		return predicateResponse_true
+	} else {
+		p.Store(predicateResponse_false)
+		return predicateResponse_false
+	}
+}
+
+// predicateEval is a helper to do the appropriate comparison depending on which comparison
+// enumeration value was passed.
+func predicateEval(comp datatypes.Node_Comparison, left, right []byte, rightReg *regexp.Regexp) bool {
+	switch comp {
+	case datatypes.ComparisonEqual:
+		return string(left) == string(right)
+	case datatypes.ComparisonNotEqual:
+		return string(left) != string(right)
+	case datatypes.ComparisonStartsWith:
+		return bytes.HasPrefix(left, right)
+	case datatypes.ComparisonLess:
+		return string(left) < string(right)
+	case datatypes.ComparisonLessEqual:
+		return string(left) <= string(right)
+	case datatypes.ComparisonGreater:
+		return string(left) > string(right)
+	case datatypes.ComparisonGreaterEqual:
+		return string(left) >= string(right)
+	case datatypes.ComparisonRegex:
+		return rightReg.Match(left)
+	case datatypes.ComparisonNotRegex:
+		return !rightReg.Match(left)
+	}
+	return false
+}
+
+//
+// Popping Tags
+//
+
+// The models package has some of this logic as well, but doesn't export ways to get
+// at individual tags one at a time. In the common, no escape characters case, popping
+// the first tag off of a series key takes around ~10ns.
+
+// predicatePopTag pops a tag=value pair from the front of series, returning the
+// remainder in rest. it assumes there are no escaped characters in the series.
+func predicatePopTag(series []byte) (tag, value []byte, rest []byte) {
+	// find the first ','
+	i := bytes.IndexByte(series, ',')
+	if i >= 0 && i < len(series) {
+		series, rest = series[:i], series[i+1:]
+	}
+
+	// find the first '='
+	j := bytes.IndexByte(series, '=')
+	if j >= 0 && j < len(series) {
+		tag, value = series[:j], series[j+1:]
+	}
+
+	return tag, value, rest
+}
+
+// predicatePopTagEscape pops a tag=value pair from the front of series, returning the
+// remainder in rest. it assumes there are possibly/likely escaped characters in the series.
+func predicatePopTagEscape(series []byte) (tag, value []byte, rest []byte) {
+	// find the first unescaped ','
+	for j := uint(0); j < uint(len(series)); {
+		i := bytes.IndexByte(series[j:], ',')
+		if i < 0 {
+			break
+		}
+		ui := uint(i)
+
+		if ui > 0 && ui-1 < uint(len(series)) && series[ui-1] == '\\' {
+			j = ui + 1
+			continue
+		}
+
+		idx := ui + j
+		series, rest = series[:idx], series[idx+1:]
+		break
+	}
+
+	// find the first unescaped '='
+	for j := uint(0); j < uint(len(series)); {
+		i := bytes.IndexByte(series[j:], '=')
+		if i < 0 {
+			break
+		}
+		ui := uint(i)
+
+		if ui > 0 && ui-1 < uint(len(series)) && series[ui-1] == '\\' {
+			j = ui + 1
+			continue
+		}
+
+		idx := ui + j
+		tag, value = series[:idx], series[idx+1:]
+		break
+	}
+
+	// sad time: it's possible this tag/value has escaped characters, so we have to
+	// find an unescape them. since the byte slice may refer to read-only memory, we
+	// can't do this in place, so we make copies.
+	if bytes.IndexByte(tag, '\\') != -1 {
+		unescapedTag := make([]byte, 0, len(tag))
+		for i, c := range tag {
+			if c == '\\' && i+1 < len(tag) {
+				if c := tag[i+1]; c == ',' || c == ' ' || c == '=' {
+					continue
+				}
+			}
+			unescapedTag = append(unescapedTag, c)
+		}
+		tag = unescapedTag
+	}
+
+	if bytes.IndexByte(value, '\\') != -1 {
+		unescapedValue := make([]byte, 0, len(value))
+		for i, c := range value {
+			if c == '\\' && i+1 < len(value) {
+				if c := value[i+1]; c == ',' || c == ' ' || c == '=' {
+					continue
+				}
+			}
+			unescapedValue = append(unescapedValue, c)
+		}
+		value = unescapedValue
+	}
+
+	return tag, value, rest
 }

--- a/tsdb/tsm1/predicate.go
+++ b/tsdb/tsm1/predicate.go
@@ -1,7 +1,16 @@
 package tsm1
 
+import "errors"
+
 // Predicate is something that can match on a series key.
 type Predicate interface {
 	Matches(key []byte) bool
 	Marshal() ([]byte, error)
+}
+
+func UnmarshalPredicate(data []byte) (Predicate, error) {
+	if data != nil {
+		return nil, errors.New("unimplemented")
+	}
+	return nil, nil
 }

--- a/tsdb/tsm1/predicate_test.go
+++ b/tsdb/tsm1/predicate_test.go
@@ -1,0 +1,165 @@
+package tsm1
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/influxdata/influxdb/storage/reads/datatypes"
+)
+
+func TestPredicate(t *testing.T) {
+	cases := []struct {
+		Name      string
+		Predicate *datatypes.Predicate
+		Key       string
+		Matches   bool
+	}{
+		{
+			Name: "Basic Matching",
+			Predicate: predicate(
+				comparisonNode(datatypes.ComparisonEqual, tagNode("tag3"), stringNode("val3")),
+			),
+			Key:     "bucketorg,tag3=val3",
+			Matches: true,
+		},
+
+		{
+			Name: "Basic Unmatching",
+			Predicate: predicate(
+				comparisonNode(datatypes.ComparisonEqual, tagNode("tag3"), stringNode("val3")),
+			),
+			Key:     "bucketorg,tag3=val2",
+			Matches: false,
+		},
+
+		{
+			Name: "Compound Logical Matching",
+			Predicate: predicate(
+				orNode(
+					andNode(
+						comparisonNode(datatypes.ComparisonEqual, tagNode("foo"), stringNode("bar")),
+						comparisonNode(datatypes.ComparisonEqual, tagNode("baz"), stringNode("no")),
+					),
+					comparisonNode(datatypes.ComparisonEqual, tagNode("tag3"), stringNode("val3")),
+				),
+			),
+			Key:     "bucketorg,foo=bar,baz=bif,tag3=val3",
+			Matches: true,
+		},
+
+		{
+			Name: "Compound Logical Unmatching",
+			Predicate: predicate(
+				orNode(
+					andNode(
+						comparisonNode(datatypes.ComparisonEqual, tagNode("foo"), stringNode("bar")),
+						comparisonNode(datatypes.ComparisonEqual, tagNode("baz"), stringNode("no")),
+					),
+					comparisonNode(datatypes.ComparisonEqual, tagNode("tag3"), stringNode("val3")),
+				),
+			),
+			Key:     "bucketorg,foo=bar,baz=bif,tag3=val2",
+			Matches: false,
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.Name, func(t *testing.T) {
+			pred, err := NewProtobufPredicate(test.Predicate)
+			if err != nil {
+				t.Fatal("compile failure:", err)
+			}
+
+			if got, exp := pred.Matches([]byte(test.Key)), test.Matches; got != exp {
+				t.Fatal("match failure:", "got", got, "!=", "exp", exp)
+			}
+		})
+	}
+}
+
+func BenchmarkPredicate(b *testing.B) {
+	run := func(b *testing.B, predicate *datatypes.Predicate) {
+		pred, err := NewProtobufPredicate(predicate)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		series := []byte("bucketorg,")
+		for i := 0; i < 10; i++ {
+			series = append(series, fmt.Sprintf("tag%d=val%d,", i, i)...)
+		}
+		series = series[:len(series)-1]
+
+		b.SetBytes(int64(len(series)))
+		b.ReportAllocs()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			pred.Matches(series)
+		}
+	}
+
+	b.Run("Basic", func(b *testing.B) {
+		run(b, predicate(
+			comparisonNode(datatypes.ComparisonEqual, tagNode("tag5"), stringNode("val5")),
+		))
+	})
+
+	b.Run("Compound", func(b *testing.B) {
+		run(b, predicate(
+			orNode(
+				andNode(
+					comparisonNode(datatypes.ComparisonEqual, tagNode("tag0"), stringNode("val0")),
+					comparisonNode(datatypes.ComparisonEqual, tagNode("tag6"), stringNode("val5")),
+				),
+				comparisonNode(datatypes.ComparisonEqual, tagNode("tag5"), stringNode("val5")),
+			),
+		))
+	})
+}
+
+//
+// Helpers to create predicate protobufs
+//
+
+func tagNode(s string) *datatypes.Node {
+	return &datatypes.Node{
+		NodeType: datatypes.NodeTypeTagRef,
+		Value:    &datatypes.Node_TagRefValue{TagRefValue: s},
+	}
+}
+
+func stringNode(s string) *datatypes.Node {
+	return &datatypes.Node{
+		NodeType: datatypes.NodeTypeLiteral,
+		Value:    &datatypes.Node_StringValue{StringValue: s},
+	}
+}
+
+func comparisonNode(comp datatypes.Node_Comparison, left, right *datatypes.Node) *datatypes.Node {
+	return &datatypes.Node{
+		NodeType: datatypes.NodeTypeComparisonExpression,
+		Value:    &datatypes.Node_Comparison_{Comparison: comp},
+		Children: []*datatypes.Node{left, right},
+	}
+}
+
+func andNode(left, right *datatypes.Node) *datatypes.Node {
+	return &datatypes.Node{
+		NodeType: datatypes.NodeTypeLogicalExpression,
+		Value:    &datatypes.Node_Logical_{Logical: datatypes.LogicalAnd},
+		Children: []*datatypes.Node{left, right},
+	}
+}
+
+func orNode(left, right *datatypes.Node) *datatypes.Node {
+	return &datatypes.Node{
+		NodeType: datatypes.NodeTypeLogicalExpression,
+		Value:    &datatypes.Node_Logical_{Logical: datatypes.LogicalOr},
+		Children: []*datatypes.Node{left, right},
+	}
+}
+
+func predicate(root *datatypes.Node) *datatypes.Predicate {
+	return &datatypes.Predicate{Root: root}
+}

--- a/tsdb/tsm1/reader_index.go
+++ b/tsdb/tsm1/reader_index.go
@@ -25,7 +25,7 @@ type TSMIndex interface {
 	// DeletePrefix removes keys that begin with the given prefix with data between minTime and
 	// maxTime from the index. Returns true if there were any changes. It calls dead with any
 	// keys that became dead as a result of this call.
-	DeletePrefix(prefix []byte, minTime, maxTime int64, dead func([]byte)) bool
+	DeletePrefix(prefix []byte, minTime, maxTime int64, pred Predicate, dead func([]byte)) bool
 
 	// MaybeContainsKey returns true if the given key may exist in the index. This is faster than
 	// Contains but, may return false positives.
@@ -299,10 +299,10 @@ func (d *indirectIndex) coversEntries(offset uint32, key []byte, buf []TimeRange
 	// create the merger with the other tombstone entries: the ones for the specific
 	// key and the one we have proposed to add.
 	merger := timeRangeMerger{
-		sorted:   d.tombstones[offset],
-		unsorted: buf,
-		single:   TimeRange{Min: minTime, Max: maxTime},
-		used:     false,
+		fromMap:    d.tombstones[offset],
+		fromPrefix: buf,
+		single:     TimeRange{Min: minTime, Max: maxTime},
+		used:       false,
 	}
 
 	return buf, timeRangesCoverEntries(merger, entries)
@@ -381,7 +381,7 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) bool 
 			Index:       iter.Index(),
 			Offset:      offset,
 			EntryOffset: entryOffset,
-			Tombstones:  len(d.tombstones[offset]),
+			Tombstones:  len(d.tombstones[offset]) + d.prefixTombstones.Count(key),
 		})
 	}
 
@@ -395,10 +395,12 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) bool 
 	defer d.mu.Unlock()
 
 	for _, p := range pending {
-		// Check the existing tombstones. If the length did not/ change, then we know
+		key := keys[p.Key]
+
+		// Check the existing tombstones. If the length did not change, then we know
 		// that we don't need to double check coverage, since we only ever increase the
 		// number of tombstones for a key.
-		if trs := d.tombstones[p.Offset]; p.Tombstones == len(trs) {
+		if trs := d.tombstones[p.Offset]; p.Tombstones == len(trs)+d.prefixTombstones.Count(key) {
 			d.tombstones[p.Offset] = insertTimeRange(trs, minTime, maxTime)
 			continue
 		}
@@ -421,7 +423,7 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) bool 
 			continue
 		}
 
-		trbuf, ok = d.coversEntries(p.Offset, keys[p.Key], trbuf, entries, minTime, maxTime)
+		trbuf, ok = d.coversEntries(p.Offset, key, trbuf, entries, minTime, maxTime)
 		if ok {
 			delete(d.tombstones, p.Offset)
 			iter.SetIndex(p.Index)
@@ -443,7 +445,9 @@ func (d *indirectIndex) DeleteRange(keys [][]byte, minTime, maxTime int64) bool 
 // DeletePrefix removes keys that begin with the given prefix with data between minTime and
 // maxTime from the index. Returns true if there were any changes. It calls dead with any
 // keys that became dead as a result of this call.
-func (d *indirectIndex) DeletePrefix(prefix []byte, minTime, maxTime int64, dead func([]byte)) bool {
+func (d *indirectIndex) DeletePrefix(prefix []byte, minTime, maxTime int64,
+	pred Predicate, dead func([]byte)) bool {
+
 	if dead == nil {
 		dead = func([]byte) {}
 	}
@@ -461,6 +465,8 @@ func (d *indirectIndex) DeletePrefix(prefix []byte, minTime, maxTime int64, dead
 		ok        bool
 		trbuf     []TimeRange
 		entries   []IndexEntry
+		pending   []pendingTombstone
+		keys      [][]byte
 		err       error
 		mustTrack bool
 	)
@@ -482,6 +488,11 @@ func (d *indirectIndex) DeletePrefix(prefix []byte, minTime, maxTime int64, dead
 		key := iter.Key(&d.b)
 		if !bytes.HasPrefix(key, prefix) {
 			break
+		}
+
+		// If we have a predicate, skip the key if it doesn't match.
+		if pred != nil && !pred.Matches(key) {
+			continue
 		}
 
 		// if we're not doing a partial delete, we don't need to read the entries and
@@ -517,7 +528,8 @@ func (d *indirectIndex) DeletePrefix(prefix []byte, minTime, maxTime int64, dead
 		}
 
 		// Does adding the minTime and maxTime cover the entries?
-		trbuf, ok = d.coversEntries(iter.Offset(), iter.Key(&d.b), trbuf, entries, minTime, maxTime)
+		offset := iter.Offset()
+		trbuf, ok = d.coversEntries(offset, iter.Key(&d.b), trbuf, entries, minTime, maxTime)
 		if ok {
 			dead(key)
 			iter.Delete()
@@ -526,25 +538,94 @@ func (d *indirectIndex) DeletePrefix(prefix []byte, minTime, maxTime int64, dead
 
 		// Otherwise, we have to track it in the prefix tombstones list.
 		mustTrack = true
+
+		// If we have a predicate, we must keep track of a pending tombstone entry for the key.
+		if pred != nil {
+			pending = append(pending, pendingTombstone{
+				Key:         len(keys),
+				Index:       iter.Index(),
+				Offset:      offset,
+				EntryOffset: entryOffset,
+				Tombstones:  len(d.tombstones[offset]) + d.prefixTombstones.Count(key),
+			})
+			keys = append(keys, key)
+		}
 	}
 	d.mu.RUnlock()
 
 	// Check and abort if nothing needs to be done.
-	if !mustTrack && !iter.HasDeletes() {
+	if !mustTrack && len(pending) == 0 && !iter.HasDeletes() {
 		return false
 	}
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if mustTrack {
-		d.prefixTombstones.Append(prefix, TimeRange{Min: minTime, Max: maxTime})
+	if pred == nil {
+		// If we don't have a predicate, we can add a single prefix tombstone entry.
+		if mustTrack {
+			d.prefixTombstones.Append(prefix, TimeRange{Min: minTime, Max: maxTime})
+		}
+
+		// Clean up any fully deleted keys.
+		if iter.HasDeletes() {
+			iter.Done()
+		}
+		return true
 	}
 
+	// Otherwise, we must walk the pending deletes individually.
+	for _, p := range pending {
+		key := keys[p.Key]
+
+		// Check the existing tombstones. If the length did not change, then we know
+		// that we don't need to double check coverage, since we only ever increase the
+		// number of tombstones for a key.
+		if trs := d.tombstones[p.Offset]; p.Tombstones == len(trs)+d.prefixTombstones.Count(key) {
+			d.tombstones[p.Offset] = insertTimeRange(trs, minTime, maxTime)
+			continue
+		}
+
+		// Since the length changed, we have to do the expensive overlap check again.
+		// We re-read the entries again under the write lock because this should be
+		// rare and only during concurrent deletes to the same key. We could make
+		// a copy of the entries before getting here, but that penalizes the common
+		// no-concurrent case.
+		entries, err = readEntriesTimes(d.b.access(p.EntryOffset, 0), entries)
+		if err != nil {
+			// If we have an error reading the entries for a key, we should just pretend
+			// the whole key is deleted. Maybe a better idea is to report this up somehow
+			// but that's for another time.
+			delete(d.tombstones, p.Offset)
+			iter.SetIndex(p.Index)
+			if iter.Offset() == p.Offset {
+				dead(key)
+				iter.Delete()
+			}
+			continue
+		}
+
+		// If it does cover, remove the key entirely.
+		trbuf, ok = d.coversEntries(p.Offset, key, trbuf, entries, minTime, maxTime)
+		if ok {
+			delete(d.tombstones, p.Offset)
+			iter.SetIndex(p.Index)
+			if iter.Offset() == p.Offset {
+				dead(key)
+				iter.Delete()
+			}
+			continue
+		}
+
+		// Append the TimeRange into the tombstones.
+		trs := d.tombstones[p.Offset]
+		d.tombstones[p.Offset] = insertTimeRange(trs, minTime, maxTime)
+	}
+
+	// Clean up any fully deleted keys.
 	if iter.HasDeletes() {
 		iter.Done()
 	}
-
 	return true
 }
 

--- a/tsdb/tsm1/reader_index_test.go
+++ b/tsdb/tsm1/reader_index_test.go
@@ -157,8 +157,6 @@ func TestIndirectIndex_DeleteRange(t *testing.T) {
 	check(t, ind.MaybeContainsValue([]byte("cpu2"), 16), false)
 }
 
-// TODO(jeff): predicate tests
-
 func TestIndirectIndex_DeletePrefix(t *testing.T) {
 	check := func(t *testing.T, got, exp bool) {
 		t.Helper()

--- a/tsdb/tsm1/reader_prefix_tree.go
+++ b/tsdb/tsm1/reader_prefix_tree.go
@@ -69,6 +69,27 @@ func (p *prefixTree) Search(key []byte, buf []TimeRange) []TimeRange {
 	return buf
 }
 
+func (p *prefixTree) Count(key []byte) int {
+	count := len(p.values)
+
+	if len(key) > 0 {
+		if ch, ok := p.short[key[0]]; ok {
+			count += ch.Count(key[1:])
+		}
+	}
+
+	if len(key) >= prefixTreeKeySize {
+		var lookup prefixTreeKey
+		copy(lookup[:], key)
+
+		if ch, ok := p.long[lookup]; ok {
+			count += ch.Count(key[prefixTreeKeySize:])
+		}
+	}
+
+	return count
+}
+
 func (p *prefixTree) checkOverlap(key []byte, ts int64) bool {
 	for _, t := range p.values {
 		if t.Min <= ts && ts <= t.Max {

--- a/tsdb/tsm1/reader_range_iterator_test.go
+++ b/tsdb/tsm1/reader_range_iterator_test.go
@@ -669,7 +669,7 @@ func (s *tsmState) RemoveAll() {
 }
 
 func (s *tsmState) MustDeletePrefix(key []byte, min, max int64) {
-	err := s.r.DeletePrefix(key, min, max, nil)
+	err := s.r.DeletePrefix(key, min, max, nil, nil)
 	if err != nil {
 		panic(fmt.Sprintf("DeletePrefix: %v", err))
 	}

--- a/tsdb/tsm1/reader_test.go
+++ b/tsdb/tsm1/reader_test.go
@@ -1581,7 +1581,7 @@ func TestTSMReader_DeletePrefix(t *testing.T) {
 	r, err := NewTSMReader(f)
 	fatalIfErr(t, "creating reader", err)
 
-	err = r.DeletePrefix([]byte("c"), 0, 5, nil)
+	err = r.DeletePrefix([]byte("c"), 0, 5, nil, nil)
 	fatalIfErr(t, "deleting prefix", err)
 
 	values, err := r.ReadAll([]byte("cpu"))

--- a/tsdb/tsm1/reader_time_range.go
+++ b/tsdb/tsm1/reader_time_range.go
@@ -60,10 +60,10 @@ func timeRangesCoverEntries(merger timeRangeMerger, entries []IndexEntry) (cover
 // timeRangeMerger is a special purpose data structure to merge three sources of
 // TimeRanges so that we can check if they cover a slice of index entries.
 type timeRangeMerger struct {
-	sorted   []TimeRange
-	unsorted []TimeRange
-	single   TimeRange
-	used     bool // if single has been used
+	fromMap    []TimeRange
+	fromPrefix []TimeRange
+	single     TimeRange
+	used       bool // if single has been used
 }
 
 // Pop returns the next TimeRange in sorted order and a boolean indicating that
@@ -72,14 +72,14 @@ func (t *timeRangeMerger) Pop() (out TimeRange, ok bool) {
 	var where *[]TimeRange
 	var what []TimeRange
 
-	if len(t.sorted) > 0 {
-		where, what = &t.sorted, t.sorted[1:]
-		out, ok = t.sorted[0], true
+	if len(t.fromMap) > 0 {
+		where, what = &t.fromMap, t.fromMap[1:]
+		out, ok = t.fromMap[0], true
 	}
 
-	if len(t.unsorted) > 0 && (!ok || t.unsorted[0].Less(out)) {
-		where, what = &t.unsorted, t.unsorted[1:]
-		out, ok = t.unsorted[0], true
+	if len(t.fromPrefix) > 0 && (!ok || t.fromPrefix[0].Less(out)) {
+		where, what = &t.fromPrefix, t.fromPrefix[1:]
+		out, ok = t.fromPrefix[0], true
 	}
 
 	if !t.used && (!ok || t.single.Less(out)) {

--- a/tsdb/tsm1/reader_time_range_test.go
+++ b/tsdb/tsm1/reader_time_range_test.go
@@ -34,19 +34,19 @@ func TestTimeRangeMerger(t *testing.T) {
 	}
 
 	check(t, ranges(0, 1, 2, 3, 4, 5, 6), timeRangeMerger{
-		sorted:   ranges(0, 2, 6),
-		unsorted: ranges(1, 3, 5),
-		single:   TimeRange{4, 4},
+		fromMap:    ranges(0, 2, 6),
+		fromPrefix: ranges(1, 3, 5),
+		single:     TimeRange{4, 4},
 	})
 
 	check(t, ranges(0, 1, 2), timeRangeMerger{
-		sorted: ranges(0, 1, 2),
-		used:   true,
+		fromMap: ranges(0, 1, 2),
+		used:    true,
 	})
 
 	check(t, ranges(0, 1, 2), timeRangeMerger{
-		unsorted: ranges(0, 1, 2),
-		used:     true,
+		fromPrefix: ranges(0, 1, 2),
+		used:       true,
 	})
 
 	check(t, ranges(0), timeRangeMerger{
@@ -54,9 +54,9 @@ func TestTimeRangeMerger(t *testing.T) {
 	})
 
 	check(t, ranges(0, 0, 0), timeRangeMerger{
-		sorted:   ranges(0),
-		unsorted: ranges(0),
-		single:   TimeRange{0, 0},
+		fromMap:    ranges(0),
+		fromPrefix: ranges(0),
+		single:     TimeRange{0, 0},
 	})
 }
 
@@ -78,7 +78,7 @@ func TestTimeRangeCoverEntries(t *testing.T) {
 	check := func(t *testing.T, ranges []TimeRange, entries []IndexEntry, covers bool) {
 		t.Helper()
 		sort.Slice(ranges, func(i, j int) bool { return ranges[i].Less(ranges[j]) })
-		got := timeRangesCoverEntries(timeRangeMerger{sorted: ranges, used: true}, entries)
+		got := timeRangesCoverEntries(timeRangeMerger{fromMap: ranges, used: true}, entries)
 		if got != covers {
 			t.Fatalf("bad covers:\nranges: %v\nentries: %v\ncovers: %v\ngot: %v",
 				ranges, entries, covers, got)

--- a/tsdb/tsm1/tombstone_test.go
+++ b/tsdb/tsm1/tombstone_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"reflect"
 	"testing"
@@ -80,48 +79,6 @@ func TestTombstoner_Add(t *testing.T) {
 	}
 }
 
-func TestTombstoner_AddPrefix(t *testing.T) {
-	dir := MustTempDir()
-	defer func() { os.RemoveAll(dir) }()
-
-	f := MustTempFile(dir)
-	ts := tsm1.NewTombstoner(f.Name(), nil)
-
-	entries := mustReadAll(ts)
-	if got, exp := len(entries), 0; got != exp {
-		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
-	}
-
-	stats := ts.TombstoneFiles()
-	if got, exp := len(stats), 0; got != exp {
-		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
-	}
-
-	if err := ts.AddPrefix([]byte("some-prefix")); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := ts.Flush(); err != nil {
-		t.Fatalf("unexpected error flushing tombstone: %v", err)
-	}
-
-	exp := tsm1.Tombstone{
-		Key:    []byte("some-prefix"),
-		Min:    math.MinInt64,
-		Max:    math.MaxInt64,
-		Prefix: true,
-	}
-
-	entries = mustReadAll(ts)
-	if got, exp := len(entries), 1; got != exp {
-		t.Fatalf("length mismatch: got %v, exp %v", got, exp)
-	}
-
-	if got := entries[0]; !reflect.DeepEqual(got, exp) {
-		t.Fatalf("unexpected tombstone entry. Got %s, expected %s", got, exp)
-	}
-}
-
 func TestTombstoner_AddPrefixRange(t *testing.T) {
 	dir := MustTempDir()
 	defer func() { os.RemoveAll(dir) }()
@@ -139,7 +96,7 @@ func TestTombstoner_AddPrefixRange(t *testing.T) {
 		t.Fatalf("stat length mismatch: got %v, exp %v", got, exp)
 	}
 
-	if err := ts.AddPrefixRange([]byte("some-prefix"), 20, 30); err != nil {
+	if err := ts.AddPrefixRange([]byte("some-prefix"), 20, 30, []byte("some-predicate")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,10 +105,11 @@ func TestTombstoner_AddPrefixRange(t *testing.T) {
 	}
 
 	exp := tsm1.Tombstone{
-		Key:    []byte("some-prefix"),
-		Min:    20,
-		Max:    30,
-		Prefix: true,
+		Key:       []byte("some-prefix"),
+		Min:       20,
+		Max:       30,
+		Prefix:    true,
+		Predicate: []byte("some-predicate"),
 	}
 
 	entries = mustReadAll(ts)
@@ -483,7 +441,7 @@ func TestTombstoner_Existing(t *testing.T) {
 
 	t.Run("add_prefix", func(t *testing.T) {
 		ts := tsm1.NewTombstoner(name, nil)
-		if err := ts.AddPrefixRange([]byte("new-prefix"), 10, 20); err != nil {
+		if err := ts.AddPrefixRange([]byte("new-prefix"), 10, 20, []byte("new-predicate")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -500,10 +458,11 @@ func TestTombstoner_Existing(t *testing.T) {
 		}
 
 		exp := tsm1.Tombstone{
-			Key:    []byte("new-prefix"),
-			Min:    10,
-			Max:    20,
-			Prefix: true,
+			Key:       []byte("new-prefix"),
+			Min:       10,
+			Max:       20,
+			Prefix:    true,
+			Predicate: []byte("new-predicate"),
 		}
 
 		if !reflect.DeepEqual(got, exp) {
@@ -517,11 +476,19 @@ func mustReadAll(t *tsm1.Tombstoner) []tsm1.Tombstone {
 	if err := t.Walk(func(t tsm1.Tombstone) error {
 		b := make([]byte, len(t.Key))
 		copy(b, t.Key)
+
+		var p []byte
+		if t.Predicate != nil {
+			p = make([]byte, len(t.Predicate))
+			copy(p, t.Predicate)
+		}
+
 		tombstones = append(tombstones, tsm1.Tombstone{
-			Min:    t.Min,
-			Max:    t.Max,
-			Key:    b,
-			Prefix: t.Prefix,
+			Min:       t.Min,
+			Max:       t.Max,
+			Key:       b,
+			Prefix:    t.Prefix,
+			Predicate: p,
 		})
 		return nil
 	}); err != nil {


### PR DESCRIPTION
This PR implements most of predicate deletes from the engine layer down. Specifically,

- the tsm1 reader index can delete a prefix with a predicate
- the cache can delete a prefix with a predciate
- the tsm1 engine can delete a prefix with a predicate
- the storage engine can delete a bucket with a predicate
- tsm1 tombstones can record predicate data
- predicates are applied when reading tombstones
- the wal includes predicate data
- converts a predicate protobuf into an efficient series key matcher