### PR TITLE
docs: update issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,57 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!--
+
+Thank you for reporting a bug in InfluxDB. 
+
+* Please ask usage questions on the Influx Community site.
+    * https://community.influxdata.com/
+* Please add a :+1: or comment on a similar existing bug report instead of opening a new one.
+    * https://github.com/influxdata/influxdb/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+is%3Aclosed+sort%3Aupdated-desc+label%3Akind%2Fbug+
+* Please check whether the bug can be reproduced with the latest release.
+* The fastest way to fix a bug is to open a Pull Request.
+    * https://github.com/influxdata/influxdb/pulls
+
+-->
+
+__Steps to reproduce:__
+List the minimal actions needed to reproduce the behavior.
+
+1. ...
+2. ...
+3. ...
+
+__Expected behavior:__
+Describe what you expected to happen.
+
+__Actual behavior:__
+Describe What actually happened.
+
+__Environment info:__
+
+* System info: Run `uname -srm` and copy the output here
+* InfluxDB version: Run `influxd version` and copy the output here
+* Other relevant environment details: Container runtime, disk info, etc
+
+__Config:__
+Copy any non-default config values here or attach the full config as a gist or file.
+
+<!-- The following sections are only required if relevant. -->
+
+__Logs:__
+Include snippet of errors in log.
+
+__Performance:__
+Generate profiles with the following commands for bugs related to performance, locking, out of memory (OOM), etc.
+
+```sh
+# Commands should be run when the bug is actively.
+# Note: This command will run for at least 30 seconds.
+curl -o profiles.tar.gz "http://localhost:8086/debug/pprof/all?cpu=true"
+curl -o vars.txt "http://localhost:8086/debug/vars"
+iostat -xd 1 30 > iostat.txt
+# Attach the `profiles.tar.gz`, `vars.txt`, and `iostat.txt` output files.
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: Opening a feature request kicks off a discussion
+---
+
+<!--
+
+Thank you for suggesting an idea to improve InfluxDB. 
+
+* Please ask usage questions on the Influx Community site.
+    * https://community.influxdata.com/
+* Please add a :+1: or comment on a similar existing feature request instead of opening a new one.
+    * https://github.com/influxdata/influxdb/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+is%3Aclosed+sort%3Aupdated-desc+label%3A%22kind%2Ffeature+request%22+
+
+-->
+
+__Proposal:__
+Short summary of the feature.
+
+__Current behavior:__
+Describe what currently happens.
+
+__Desired behavior:__
+Describe what you want.
+
+__Alternatives considered:__
+Describe other solutions or features you considered.
+
+__Use case:__
+Why is this important (helps with prioritizing requests)?

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,9 +1,0 @@
-Closes #
-
-_Briefly describe your proposed changes:_
-
-  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
-  - [ ] Rebased/mergeable
-  - [ ] Tests pass
-  - [ ] http/swagger.yml updated (if modified Go structs or API)
-  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+Closes #
+
+Describe your proposed changes here.
+
+<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->
+
+- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
+- [ ] Rebased/mergeable
+- [ ] Tests pass
+- [ ] http/swagger.yml updated (if modified Go structs or API)
+- [ ] Documentation updated or issue created (provide link to issue/pr)
+- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)


### PR DESCRIPTION
I noticed the GitHub bug report, feature request, and pull request templates were dropped when the 2.0 branch was switched to `master`. I've cleaned up the templates from the 1.x branch.