### PR TITLE
fix(tests): fix flaky dashboards e2e test

### DIFF
--- a/ui/cypress/e2e/dashboardsIndex.test.ts
+++ b/ui/cypress/e2e/dashboardsIndex.test.ts
@@ -65,6 +65,8 @@ describe('Dashboards', () => {
 
     cy.getByTestID('card-select-Bashboard-Template').click()
 
+    cy.getByTestID('template-panel').should('exist')
+
     cy.getByTestID('create-dashboard-button').click()
 
     cy.getByTestID('dashboard-card').should('have.length', 1)

--- a/ui/src/dashboards/components/DashboardImportFromTemplateOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardImportFromTemplateOverlay.tsx
@@ -11,6 +11,7 @@ import {
   Panel,
   EmptyState,
   ComponentSize,
+  ComponentStatus,
 } from '@influxdata/clockface'
 import {Overlay, ResponsiveGridSizer} from 'src/clockface'
 import {
@@ -84,7 +85,10 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
               </GetResources>
               {!selectedTemplateSummary && this.emptyState}
               {selectedTemplateSummary && (
-                <Panel className="import-template-overlay--details">
+                <Panel
+                  className="import-template-overlay--details"
+                  testID="template-panel"
+                >
                   <Panel.Header
                     title={_.get(selectedTemplateSummary, 'meta.name')}
                   />
@@ -136,6 +140,11 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
         text="Create Dashboard"
         onClick={this.onSubmit}
         key="submit-button"
+        status={
+          this.state.selectedTemplate
+            ? ComponentStatus.Default
+            : ComponentStatus.Disabled
+        }
         testID="create-dashboard-button"
         color={ComponentColor.Primary}
       />,
@@ -193,9 +202,9 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
   private selectTemplate = (
     selectedTemplateSummary: TemplateSummary
   ) => async (): Promise<void> => {
-    this.setState({selectedTemplateSummary})
     const selectedTemplate = await getTemplateByID(selectedTemplateSummary.id)
     this.setState({
+      selectedTemplateSummary,
       selectedTemplate,
       variables: this.getVariablesForTemplate(selectedTemplate),
       cells: this.getCellsForTemplate(selectedTemplate),


### PR DESCRIPTION
Fix a flaky Create Dashboard From Template end-to-end test by making sure that the Template has been selected before trying to create the Dashboard.

Also disables the "Create Dashboard" button in `CreateDasboardFromTemplateOverlay` until the user has selected a template

  - [x] Rebased/mergeable
  - [x] Tests pass
