### PR TITLE
fix(tsdb): Remove TSI stats file cache

### DIFF
--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -1203,6 +1203,22 @@ func (i *Index) MeasurementCardinalityStats() MeasurementCardinalityStats {
 	return stats
 }
 
+// ComputeMeasurementCardinalityStats computes the cardinality stats from raw index data.
+func (i *Index) ComputeMeasurementCardinalityStats() (MeasurementCardinalityStats, error) {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+
+	stats := NewMeasurementCardinalityStats()
+	for _, p := range i.partitions {
+		pstats, err := p.ComputeMeasurementCardinalityStats()
+		if err != nil {
+			return nil, err
+		}
+		stats.Add(pstats)
+	}
+	return stats, nil
+}
+
 func (i *Index) seriesByExprIterator(name []byte, expr influxql.Expr) (tsdb.SeriesIDIterator, error) {
 	switch expr := expr.(type) {
 	case *influxql.BinaryExpr:

--- a/tsdb/tsi1/stats.go
+++ b/tsdb/tsi1/stats.go
@@ -46,7 +46,7 @@ func (s MeasurementCardinalityStats) Inc(name []byte) {
 // Dec decrements a measurement count by 1. Deleted if zero.
 func (s MeasurementCardinalityStats) Dec(name []byte) {
 	v := s[string(name)]
-	if v == 1 {
+	if v <= 1 {
 		delete(s, string(name))
 	} else {
 		s[string(name)] = v - 1


### PR DESCRIPTION
Removes the `STATS` file generated during TSI compaction as it had
potential for becoming inconsistent with the index data. Instead,
stats are recalculated on start up and on each compaction on a
per-partition basis.

Computing stats for 10M series across 10K measurements takes
approximately 0.171s.

_Briefly describe your proposed changes:_

  - [x] Rebased/mergeable
  - [x] Tests pass
