### PR TITLE
fix(package): make rpm verify pass after installation

### DIFF
--- a/build.py
+++ b/build.py
@@ -18,6 +18,8 @@ import argparse
 
 # Packaging variables
 PACKAGE_NAME = "influxdb"
+USER = "influxdb"
+GROUP = "influxdb"
 INSTALL_ROOT_DIR = "/usr/bin"
 LOG_DIR = "/var/log/influxdb"
 DATA_DIR = "/var/lib/influxdb"
@@ -63,6 +65,8 @@ fpm_common_args = "-f -s dir --log error \
 --directories {} \
 --directories {} \
 --directories {} \
+--rpm-attr 755,{},{}:{} \
+--rpm-attr 755,{},{}:{} \
 --description \"{}\"".format(
      VENDOR,
      PACKAGE_URL,
@@ -74,6 +78,8 @@ fpm_common_args = "-f -s dir --log error \
      LOG_DIR,
      DATA_DIR,
      MAN_DIR,
+     USER, GROUP, LOG_DIR,
+     USER, GROUP, DATA_DIR,
      DESCRIPTION)
 
 for f in CONFIGURATION_FILES:
@@ -168,7 +174,7 @@ def go_get(branch, update=False, no_uncommitted=False):
         run(get_command)
     logging.info("Retrieving dependencies with `dep`...")
     sys.stdout.flush()
-    run("{}/bin/dep ensure -v -vendor-only".format(os.environ.get("GOPATH")))
+    run("{}/bin/dep ensure -v -vendor-only".format(os.environ.get("GOPATH", os.path.expanduser("~/go"))))
     return True
 
 def run_tests(race, parallel, timeout, no_vet, junit=False):

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -24,14 +24,6 @@ function install_chkconfig {
     chkconfig --add influxdb
 }
 
-id influxdb &>/dev/null
-if [[ $? -ne 0 ]]; then
-    useradd --system -U -M influxdb -s /bin/false -d $DATA_DIR
-fi
-
-chown -R -L influxdb:influxdb $DATA_DIR
-chown -R -L influxdb:influxdb $LOG_DIR
-
 # Add defaults file, if it doesn't exist
 if [[ ! -f /etc/default/influxdb ]]; then
     touch /etc/default/influxdb
@@ -53,6 +45,14 @@ if [[ -f /etc/redhat-release ]]; then
         install_chkconfig
     fi
 elif [[ -f /etc/debian_version ]]; then
+    # Ownership for RH-based platforms is set in build.py via the `rmp-attr` option.
+    # We perform ownership change only for Debian-based systems.
+    # Moving these lines out of this if statement would make `rmp -V` fail after installation.
+    chown -R -L influxdb:influxdb $LOG_DIR
+    chown -R -L influxdb:influxdb $DATA_DIR
+    chmod 755 $LOG_DIR
+    chmod 755 $DATA_DIR
+
     # Debian/Ubuntu logic
     if command -v systemctl &>/dev/null; then
         install_systemd

--- a/scripts/pre-install.sh
+++ b/scripts/pre-install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+DATA_DIR=/var/lib/influxdb
+
+if ! id influxdb &>/dev/null; then
+    useradd --system -U -M influxdb -s /bin/false -d $DATA_DIR
+fi
+
 if [[ -d /etc/opt/influxdb ]]; then
     # Legacy configuration found
     if [[ ! -d /etc/influxdb ]]; then


### PR DESCRIPTION
This change sets the ownership of directories on package generation with fpm instead that in post-install to make `rpm -V` pass.

For more details, see: influxdata/EAR#716

_Briefly describe your proposed changes:_

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
