### PR TITLE
Add route to new member overlay

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -62,6 +62,7 @@ import TelegrafConfigOverlay from 'src/telegrafs/components/TelegrafConfigOverla
 import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard'
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
+import AddMembersOverlay from 'src/members/components/AddMembersOverlay'
 
 // Actions
 import {disablePresentationMode} from 'src/shared/actions/app'
@@ -200,7 +201,9 @@ class Root extends PureComponent {
                             />
                           </Route>
                           <Route path="tokens" component={TokensIndex} />
-                          <Route path="members" component={MembersIndex} />
+                          <Route path="members" component={MembersIndex}>
+                            <Route path="new" component={AddMembersOverlay} />
+                          </Route>
                           <Route path="telegrafs" component={TelegrafsPage}>
                             <Route
                               path=":id/view"

--- a/ui/src/members/components/AddMembersForm.tsx
+++ b/ui/src/members/components/AddMembersForm.tsx
@@ -4,7 +4,7 @@ import React, {PureComponent, ChangeEvent} from 'react'
 // Components
 import {Form, Input, Button, Grid} from '@influxdata/clockface'
 import SelectUsers from 'src/members/components/SelectUsers'
-import {UsersMap} from 'src/members/components/Members'
+import {UsersMap} from 'src/members/reducers'
 
 // Types
 import {User} from '@influxdata/influx'

--- a/ui/src/members/containers/MembersIndex.tsx
+++ b/ui/src/members/containers/MembersIndex.tsx
@@ -54,6 +54,7 @@ class MembersIndex extends Component<Props> {
                 >
                   <GetResources resource={ResourceTypes.Members}>
                     <Members />
+                    {this.props.children}
                   </GetResources>
                 </TabbedPageSection>
               </Tabs.TabContents>

--- a/ui/src/members/reducers/index.ts
+++ b/ui/src/members/reducers/index.ts
@@ -5,15 +5,22 @@ import {produce} from 'immer'
 import {RemoteDataState} from 'src/types'
 import {Action} from 'src/members/actions'
 import {Member} from 'src/types'
+import {User} from '@influxdata/influx'
+
+export interface UsersMap {
+  [userID: string]: User
+}
 
 const initialState = (): MembersState => ({
   status: RemoteDataState.NotStarted,
   list: [],
+  users: {status: RemoteDataState.NotStarted, item: {}},
 })
 
 export interface MembersState {
   status: RemoteDataState
   list: Member[]
+  users: {status: RemoteDataState; item: UsersMap}
 }
 
 export const membersReducer = (
@@ -51,6 +58,18 @@ export const membersReducer = (
         })
 
         draftState.list = deleted
+        return
+      }
+
+      case 'SET_USERS': {
+        const {status, list} = action.payload
+
+        draftState.users.status = status
+
+        if (list) {
+          draftState.users.item = list
+        }
+
         return
       }
     }

--- a/ui/src/shared/components/GetResources.tsx
+++ b/ui/src/shared/components/GetResources.tsx
@@ -13,7 +13,7 @@ import {getDashboardsAsync} from 'src/dashboards/actions'
 import {getTasks} from 'src/tasks/actions'
 import {getAuthorizations} from 'src/authorizations/actions'
 import {getTemplates} from 'src/templates/actions'
-import {getMembers} from 'src/members/actions'
+import {getMembers, getUsers} from 'src/members/actions'
 
 // Types
 import {AppState} from 'src/types'
@@ -26,11 +26,15 @@ import {DashboardsState} from 'src/dashboards/reducers/dashboards'
 import {AuthorizationsState} from 'src/authorizations/reducers'
 import {VariablesState} from 'src/variables/reducers'
 import {TemplatesState} from 'src/templates/reducers'
-import {MembersState} from 'src/members/reducers'
+import {MembersState, UsersMap} from 'src/members/reducers'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {TechnoSpinner, SpinnerContainer} from '@influxdata/clockface'
+import {
+  TechnoSpinner,
+  SpinnerContainer,
+  RemoteDataState,
+} from '@influxdata/clockface'
 
 interface StateProps {
   labels: LabelsState
@@ -43,6 +47,7 @@ interface StateProps {
   templates: TemplatesState
   tasks: TasksState
   members: MembersState
+  users: {status: RemoteDataState; item: UsersMap}
 }
 
 interface DispatchProps {
@@ -56,6 +61,7 @@ interface DispatchProps {
   getTasks: typeof getTasks
   getTemplates: typeof getTemplates
   getMembers: typeof getMembers
+  getUsers: typeof getUsers
 }
 
 interface PassedProps {
@@ -75,6 +81,7 @@ export enum ResourceTypes {
   Tasks = 'tasks',
   Templates = 'templates',
   Members = 'members',
+  Users = 'users',
 }
 
 @ErrorHandling
@@ -121,6 +128,10 @@ class GetResources extends PureComponent<Props, StateProps> {
         return await this.props.getMembers()
       }
 
+      case ResourceTypes.Users: {
+        return await this.props.getUsers()
+      }
+
       default: {
         throw new Error('incorrect resource type provided')
       }
@@ -164,6 +175,7 @@ const mstp = ({
     tasks,
     templates,
     members,
+    users: members.users,
   }
 }
 
@@ -178,6 +190,7 @@ const mdtp = {
   getTasks: getTasks,
   getTemplates: getTemplates,
   getMembers: getMembers,
+  getUsers: getUsers,
 }
 
 export default connect<StateProps, DispatchProps, {}>(


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/292

_Briefly describe your proposed changes:_
The users in new members overlay are now stored in redux state.
Updated the route to /new and include orgID

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
