### PR TITLE
fix(influxdb): rename telegraf orgID

### DIFF
--- a/authorizer/telegraf.go
+++ b/authorizer/telegraf.go
@@ -60,7 +60,7 @@ func (s *TelegrafConfigService) FindTelegrafConfigByID(ctx context.Context, id i
 		return nil, err
 	}
 
-	if err := authorizeReadTelegraf(ctx, tc.OrganizationID, id); err != nil {
+	if err := authorizeReadTelegraf(ctx, tc.OrgID, id); err != nil {
 		return nil, err
 	}
 
@@ -80,7 +80,7 @@ func (s *TelegrafConfigService) FindTelegrafConfigs(ctx context.Context, filter 
 	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 	telegrafs := ts[:0]
 	for _, tc := range ts {
-		err := authorizeReadTelegraf(ctx, tc.OrganizationID, tc.ID)
+		err := authorizeReadTelegraf(ctx, tc.OrgID, tc.ID)
 		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
 			return nil, 0, err
 		}
@@ -97,7 +97,7 @@ func (s *TelegrafConfigService) FindTelegrafConfigs(ctx context.Context, filter 
 
 // CreateTelegrafConfig checks to see if the authorizer on context has write access to the global telegraf config resource.
 func (s *TelegrafConfigService) CreateTelegrafConfig(ctx context.Context, tc *influxdb.TelegrafConfig, userID influxdb.ID) error {
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.TelegrafsResourceType, tc.OrganizationID)
+	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.TelegrafsResourceType, tc.OrgID)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (s *TelegrafConfigService) UpdateTelegrafConfig(ctx context.Context, id inf
 		return nil, err
 	}
 
-	if err := authorizeWriteTelegraf(ctx, tc.OrganizationID, id); err != nil {
+	if err := authorizeWriteTelegraf(ctx, tc.OrgID, id); err != nil {
 		return nil, err
 	}
 
@@ -130,7 +130,7 @@ func (s *TelegrafConfigService) DeleteTelegrafConfig(ctx context.Context, id inf
 		return err
 	}
 
-	if err := authorizeWriteTelegraf(ctx, tc.OrganizationID, id); err != nil {
+	if err := authorizeWriteTelegraf(ctx, tc.OrgID, id); err != nil {
 		return err
 	}
 

--- a/authorizer/telegraf_test.go
+++ b/authorizer/telegraf_test.go
@@ -51,8 +51,8 @@ func TestTelegrafConfigStore_FindTelegrafConfigByID(t *testing.T) {
 				TelegrafConfigStore: &mock.TelegrafConfigStore{
 					FindTelegrafConfigByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.TelegrafConfig, error) {
 						return &influxdb.TelegrafConfig{
-							ID:             id,
-							OrganizationID: 10,
+							ID:    id,
+							OrgID: 10,
 						}, nil
 					},
 				},
@@ -77,8 +77,8 @@ func TestTelegrafConfigStore_FindTelegrafConfigByID(t *testing.T) {
 				TelegrafConfigStore: &mock.TelegrafConfigStore{
 					FindTelegrafConfigByIDF: func(ctx context.Context, id influxdb.ID) (*influxdb.TelegrafConfig, error) {
 						return &influxdb.TelegrafConfig{
-							ID:             id,
-							OrganizationID: 10,
+							ID:    id,
+							OrgID: 10,
 						}, nil
 					},
 				},
@@ -140,16 +140,16 @@ func TestTelegrafConfigStore_FindTelegrafConfigs(t *testing.T) {
 					FindTelegrafConfigsF: func(ctx context.Context, filter influxdb.TelegrafConfigFilter, opt ...influxdb.FindOptions) ([]*influxdb.TelegrafConfig, int, error) {
 						return []*influxdb.TelegrafConfig{
 							{
-								ID:             1,
-								OrganizationID: 10,
+								ID:    1,
+								OrgID: 10,
 							},
 							{
-								ID:             2,
-								OrganizationID: 10,
+								ID:    2,
+								OrgID: 10,
 							},
 							{
-								ID:             3,
-								OrganizationID: 11,
+								ID:    3,
+								OrgID: 11,
 							},
 						}, 3, nil
 					},
@@ -166,16 +166,16 @@ func TestTelegrafConfigStore_FindTelegrafConfigs(t *testing.T) {
 			wants: wants{
 				telegrafs: []*influxdb.TelegrafConfig{
 					{
-						ID:             1,
-						OrganizationID: 10,
+						ID:    1,
+						OrgID: 10,
 					},
 					{
-						ID:             2,
-						OrganizationID: 10,
+						ID:    2,
+						OrgID: 10,
 					},
 					{
-						ID:             3,
-						OrganizationID: 11,
+						ID:    3,
+						OrgID: 11,
 					},
 				},
 			},
@@ -187,16 +187,16 @@ func TestTelegrafConfigStore_FindTelegrafConfigs(t *testing.T) {
 					FindTelegrafConfigsF: func(ctx context.Context, filter influxdb.TelegrafConfigFilter, opt ...influxdb.FindOptions) ([]*influxdb.TelegrafConfig, int, error) {
 						return []*influxdb.TelegrafConfig{
 							{
-								ID:             1,
-								OrganizationID: 10,
+								ID:    1,
+								OrgID: 10,
 							},
 							{
-								ID:             2,
-								OrganizationID: 10,
+								ID:    2,
+								OrgID: 10,
 							},
 							{
-								ID:             3,
-								OrganizationID: 11,
+								ID:    3,
+								OrgID: 11,
 							},
 						}, 3, nil
 					},
@@ -214,12 +214,12 @@ func TestTelegrafConfigStore_FindTelegrafConfigs(t *testing.T) {
 			wants: wants{
 				telegrafs: []*influxdb.TelegrafConfig{
 					{
-						ID:             1,
-						OrganizationID: 10,
+						ID:    1,
+						OrgID: 10,
 					},
 					{
-						ID:             2,
-						OrganizationID: 10,
+						ID:    2,
+						OrgID: 10,
 					},
 				},
 			},
@@ -267,14 +267,14 @@ func TestTelegrafConfigStore_UpdateTelegrafConfig(t *testing.T) {
 				TelegrafConfigStore: &mock.TelegrafConfigStore{
 					FindTelegrafConfigByIDF: func(ctc context.Context, id influxdb.ID) (*influxdb.TelegrafConfig, error) {
 						return &influxdb.TelegrafConfig{
-							ID:             1,
-							OrganizationID: 10,
+							ID:    1,
+							OrgID: 10,
 						}, nil
 					},
 					UpdateTelegrafConfigF: func(ctx context.Context, id influxdb.ID, upd *influxdb.TelegrafConfig, userID influxdb.ID) (*influxdb.TelegrafConfig, error) {
 						return &influxdb.TelegrafConfig{
-							ID:             1,
-							OrganizationID: 10,
+							ID:    1,
+							OrgID: 10,
 						}, nil
 					},
 				},
@@ -308,14 +308,14 @@ func TestTelegrafConfigStore_UpdateTelegrafConfig(t *testing.T) {
 				TelegrafConfigStore: &mock.TelegrafConfigStore{
 					FindTelegrafConfigByIDF: func(ctc context.Context, id influxdb.ID) (*influxdb.TelegrafConfig, error) {
 						return &influxdb.TelegrafConfig{
-							ID:             1,
-							OrganizationID: 10,
+							ID:    1,
+							OrgID: 10,
 						}, nil
 					},
 					UpdateTelegrafConfigF: func(ctx context.Context, id influxdb.ID, upd *influxdb.TelegrafConfig, userID influxdb.ID) (*influxdb.TelegrafConfig, error) {
 						return &influxdb.TelegrafConfig{
-							ID:             1,
-							OrganizationID: 10,
+							ID:    1,
+							OrgID: 10,
 						}, nil
 					},
 				},
@@ -378,8 +378,8 @@ func TestTelegrafConfigStore_DeleteTelegrafConfig(t *testing.T) {
 				TelegrafConfigStore: &mock.TelegrafConfigStore{
 					FindTelegrafConfigByIDF: func(ctc context.Context, id influxdb.ID) (*influxdb.TelegrafConfig, error) {
 						return &influxdb.TelegrafConfig{
-							ID:             1,
-							OrganizationID: 10,
+							ID:    1,
+							OrgID: 10,
 						}, nil
 					},
 					DeleteTelegrafConfigF: func(ctx context.Context, id influxdb.ID) error {
@@ -416,8 +416,8 @@ func TestTelegrafConfigStore_DeleteTelegrafConfig(t *testing.T) {
 				TelegrafConfigStore: &mock.TelegrafConfigStore{
 					FindTelegrafConfigByIDF: func(ctc context.Context, id influxdb.ID) (*influxdb.TelegrafConfig, error) {
 						return &influxdb.TelegrafConfig{
-							ID:             1,
-							OrganizationID: 10,
+							ID:    1,
+							OrgID: 10,
 						}, nil
 					},
 					DeleteTelegrafConfigF: func(ctx context.Context, id influxdb.ID) error {
@@ -535,7 +535,7 @@ func TestTelegrafConfigStore_CreateTelegrafConfig(t *testing.T) {
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
 
-			err := s.CreateTelegrafConfig(ctx, &influxdb.TelegrafConfig{OrganizationID: tt.args.orgID}, influxdb.ID(1))
+			err := s.CreateTelegrafConfig(ctx, &influxdb.TelegrafConfig{OrgID: tt.args.orgID}, influxdb.ID(1))
 			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
 		})
 	}

--- a/bolt/lookup_service_test.go
+++ b/bolt/lookup_service_test.go
@@ -180,8 +180,8 @@ func TestClient_Name(t *testing.T) {
 				},
 				init: func(ctx context.Context, s *bolt.Client) error {
 					return s.CreateTelegrafConfig(ctx, &platform.TelegrafConfig{
-						OrganizationID: platformtesting.MustIDBase16("0000000000000009"),
-						Name:           "telegraf1",
+						OrgID: platformtesting.MustIDBase16("0000000000000009"),
+						Name:  "telegraf1",
 					}, testID)
 				},
 			},

--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -549,7 +549,7 @@ func (c *Client) FindResourceOrganizationID(ctx context.Context, rt influxdb.Res
 		if err != nil {
 			return influxdb.InvalidID(), err
 		}
-		return r.OrganizationID, nil
+		return r.OrgID, nil
 	case influxdb.VariablesResourceType:
 		r, err := c.FindVariableByID(ctx, id)
 		if err != nil {

--- a/bolt/telegraf.go
+++ b/bolt/telegraf.go
@@ -80,7 +80,7 @@ func (c *Client) findTelegrafConfigs(ctx context.Context, tx *bolt.Tx, filter pl
 		}
 		if tc != nil {
 			// Restrict results by organization ID, if it has been provided
-			if filter.OrganizationID != nil && filter.OrganizationID.Valid() && tc.OrganizationID != *filter.OrganizationID {
+			if filter.OrgID != nil && filter.OrgID.Valid() && tc.OrgID != *filter.OrgID {
 				continue
 			}
 			tcs = append(tcs, tc)
@@ -119,10 +119,10 @@ func (c *Client) putTelegrafConfig(ctx context.Context, tx *bolt.Tx, tc *platfor
 			Err:  err,
 		}
 	}
-	if !tc.OrganizationID.Valid() {
+	if !tc.OrgID.Valid() {
 		return &platform.Error{
 			Code: platform.EEmptyValue,
-			Msg:  platform.ErrTelegrafConfigInvalidOrganizationID,
+			Msg:  platform.ErrTelegrafConfigInvalidOrgID,
 		}
 	}
 	err = tx.Bucket(telegrafBucket).Put(encodedID, v)
@@ -172,8 +172,8 @@ func (c *Client) UpdateTelegrafConfig(ctx context.Context, id platform.ID, tc *p
 			return err
 		}
 		tc.ID = id
-		// OrganizationID can not be updated
-		tc.OrganizationID = current.OrganizationID
+		// OrgID can not be updated
+		tc.OrgID = current.OrgID
 		pErr = c.putTelegrafConfig(ctx, tx, tc)
 		if pErr != nil {
 			return &platform.Error{

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7381,7 +7381,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TelegrafRequestPlugin"
-        organizationID:
+        orgID:
           type: string
     TelegrafRequestPlugin:
         oneOf:

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -137,26 +137,26 @@ func (r *telegrafResponse) MarshalJSON() ([]byte, error) {
 
 	// telegrafConfigEncode is the helper struct for json encoding.
 	type telegrafConfigEncode struct {
-		ID             platform.ID                  `json:"id"`
-		OrganizationID platform.ID                  `json:"organizationID,omitempty"`
-		Name           string                       `json:"name"`
-		Description    string                       `json:"description"`
-		Agent          platform.TelegrafAgentConfig `json:"agent"`
-		Plugins        []telegrafPluginEncode       `json:"plugins"`
-		Labels         []platform.Label             `json:"labels"`
-		Links          telegrafLinks                `json:"links"`
+		ID          platform.ID                  `json:"id"`
+		OrgID       platform.ID                  `json:"OrgID,omitempty"`
+		Name        string                       `json:"name"`
+		Description string                       `json:"description"`
+		Agent       platform.TelegrafAgentConfig `json:"agent"`
+		Plugins     []telegrafPluginEncode       `json:"plugins"`
+		Labels      []platform.Label             `json:"labels"`
+		Links       telegrafLinks                `json:"links"`
 	}
 
 	tce := new(telegrafConfigEncode)
 	*tce = telegrafConfigEncode{
-		ID:             r.ID,
-		OrganizationID: r.OrganizationID,
-		Name:           r.Name,
-		Description:    r.Description,
-		Agent:          r.Agent,
-		Plugins:        make([]telegrafPluginEncode, len(r.Plugins)),
-		Labels:         r.Labels,
-		Links:          r.Links,
+		ID:          r.ID,
+		OrgID:       r.OrgID,
+		Name:        r.Name,
+		Description: r.Description,
+		Agent:       r.Agent,
+		Plugins:     make([]telegrafPluginEncode, len(r.Plugins)),
+		Labels:      r.Labels,
+		Links:       r.Links,
 	}
 
 	for k, p := range r.Plugins {
@@ -303,7 +303,7 @@ func decodeTelegrafConfigFilter(ctx context.Context, r *http.Request) (*platform
 				Err:  err,
 			}
 		}
-		f.OrganizationID = orgID
+		f.OrgID = orgID
 	} else if orgNameStr := q.Get("org"); orgNameStr != "" {
 		*f.Organization = orgNameStr
 	}

--- a/http/telegraf_test.go
+++ b/http/telegraf_test.go
@@ -48,13 +48,13 @@ func TestTelegrafHandler_handleGetTelegrafs(t *testing.T) {
 			r:    httptest.NewRequest("GET", "http://any.url/api/v2/telegrafs?orgID=0000000000000002", nil),
 			svc: &mock.TelegrafConfigStore{
 				FindTelegrafConfigsF: func(ctx context.Context, filter platform.TelegrafConfigFilter, opt ...platform.FindOptions) ([]*platform.TelegrafConfig, int, error) {
-					if filter.OrganizationID != nil && *filter.OrganizationID == platform.ID(2) {
+					if filter.OrgID != nil && *filter.OrgID == platform.ID(2) {
 						return []*platform.TelegrafConfig{
 							{
-								ID:             platform.ID(1),
-								OrganizationID: platform.ID(2),
-								Name:           "tc1",
-								Description:    "",
+								ID:          platform.ID(1),
+								OrgID:       platform.ID(2),
+								Name:        "tc1",
+								Description: "",
 								Plugins: []platform.TelegrafPlugin{
 									{
 										Config: &inputs.CPUStats{},
@@ -82,7 +82,7 @@ func TestTelegrafHandler_handleGetTelegrafs(t *testing.T) {
 								"self": "/api/v2/telegrafs/0000000000000001"
 							},
 						"id":"0000000000000001",
-						"organizationID":"0000000000000002",
+						"OrgID":"0000000000000002",
 						"name":"tc1",
 						"description":"",
 						"agent":{
@@ -110,10 +110,10 @@ func TestTelegrafHandler_handleGetTelegrafs(t *testing.T) {
 				FindTelegrafConfigsF: func(ctx context.Context, filter platform.TelegrafConfigFilter, opt ...platform.FindOptions) ([]*platform.TelegrafConfig, int, error) {
 					return []*platform.TelegrafConfig{
 						{
-							ID:             platform.ID(1),
-							OrganizationID: platform.ID(2),
-							Name:           "my config",
-							Description:    "my description",
+							ID:          platform.ID(1),
+							OrgID:       platform.ID(2),
+							Name:        "my config",
+							Description: "my description",
 							Agent: platform.TelegrafAgentConfig{
 								Interval: 10000,
 							},
@@ -150,7 +150,7 @@ func TestTelegrafHandler_handleGetTelegrafs(t *testing.T) {
 								"self": "/api/v2/telegrafs/0000000000000001"
 							},
             "id": "0000000000000001",
-            "organizationID": "0000000000000002",
+            "OrgID": "0000000000000002",
             "name": "my config",
 						"description": "my description",
             "agent": {
@@ -233,10 +233,10 @@ func TestTelegrafHandler_handleGetTelegraf(t *testing.T) {
 			svc: &mock.TelegrafConfigStore{
 				FindTelegrafConfigByIDF: func(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error) {
 					return &platform.TelegrafConfig{
-						ID:             platform.ID(1),
-						OrganizationID: platform.ID(2),
-						Name:           "my config",
-						Description:    "",
+						ID:          platform.ID(1),
+						OrgID:       platform.ID(2),
+						Name:        "my config",
+						Description: "",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 10000,
 						},
@@ -263,7 +263,7 @@ func TestTelegrafHandler_handleGetTelegraf(t *testing.T) {
 				contentType: "application/json; charset=utf-8",
 				body: `{
             "id": "0000000000000001",
-            "organizationID": "0000000000000002",
+            "OrgID": "0000000000000002",
             "name": "my config",
 						"description": "",
             "agent": {
@@ -307,10 +307,10 @@ func TestTelegrafHandler_handleGetTelegraf(t *testing.T) {
 			svc: &mock.TelegrafConfigStore{
 				FindTelegrafConfigByIDF: func(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error) {
 					return &platform.TelegrafConfig{
-						ID:             platform.ID(1),
-						OrganizationID: platform.ID(2),
-						Name:           "my config",
-						Description:    "",
+						ID:          platform.ID(1),
+						OrgID:       platform.ID(2),
+						Name:        "my config",
+						Description: "",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 10000,
 						},
@@ -337,7 +337,7 @@ func TestTelegrafHandler_handleGetTelegraf(t *testing.T) {
 				contentType: "application/json; charset=utf-8",
 				body: `{
             "id": "0000000000000001",
-            "organizationID": "0000000000000002",
+            "OrgID": "0000000000000002",
             "name": "my config",
 						"description": "",
             "agent": {
@@ -381,9 +381,9 @@ func TestTelegrafHandler_handleGetTelegraf(t *testing.T) {
 			svc: &mock.TelegrafConfigStore{
 				FindTelegrafConfigByIDF: func(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error) {
 					return &platform.TelegrafConfig{
-						ID:             platform.ID(1),
-						OrganizationID: platform.ID(2),
-						Name:           "my config",
+						ID:    platform.ID(1),
+						OrgID: platform.ID(2),
+						Name:  "my config",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 10000,
 						},
@@ -496,9 +496,9 @@ func TestTelegrafHandler_handleGetTelegraf(t *testing.T) {
 			svc: &mock.TelegrafConfigStore{
 				FindTelegrafConfigByIDF: func(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error) {
 					return &platform.TelegrafConfig{
-						ID:             platform.ID(1),
-						OrganizationID: platform.ID(2),
-						Name:           "my config",
+						ID:    platform.ID(1),
+						OrgID: platform.ID(2),
+						Name:  "my config",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 10000,
 						},
@@ -612,9 +612,9 @@ func TestTelegrafHandler_handleGetTelegraf(t *testing.T) {
 			svc: &mock.TelegrafConfigStore{
 				FindTelegrafConfigByIDF: func(ctx context.Context, id platform.ID) (*platform.TelegrafConfig, error) {
 					return &platform.TelegrafConfig{
-						ID:             platform.ID(1),
-						OrganizationID: platform.ID(2),
-						Name:           "my config",
+						ID:    platform.ID(1),
+						OrgID: platform.ID(2),
+						Name:  "my config",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 10000,
 						},
@@ -769,10 +769,10 @@ func Test_newTelegrafResponses(t *testing.T) {
 			args: args{
 				tcs: []*platform.TelegrafConfig{
 					{
-						ID:             platform.ID(1),
-						OrganizationID: platform.ID(2),
-						Name:           "my config",
-						Description:    "",
+						ID:          platform.ID(1),
+						OrgID:       platform.ID(2),
+						Name:        "my config",
+						Description: "",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 10000,
 						},
@@ -806,7 +806,7 @@ func Test_newTelegrafResponses(t *testing.T) {
 	        "self": "/api/v2/telegrafs/0000000000000001"
           },
           "id": "0000000000000001",
-          "organizationID": "0000000000000002",
+          "OrgID": "0000000000000002",
           "name": "my config",
 					"description": "",
           "agent": {
@@ -866,10 +866,10 @@ func Test_newTelegrafResponse(t *testing.T) {
 		{
 			args: args{
 				tc: &platform.TelegrafConfig{
-					ID:             platform.ID(1),
-					OrganizationID: platform.ID(2),
-					Name:           "my config",
-					Description:    "my description",
+					ID:          platform.ID(1),
+					OrgID:       platform.ID(2),
+					Name:        "my config",
+					Description: "my description",
 					Agent: platform.TelegrafAgentConfig{
 						Interval: 10000,
 					},
@@ -892,7 +892,7 @@ func Test_newTelegrafResponse(t *testing.T) {
 			},
 			want: `{
       "id": "0000000000000001",
-      "organizationID": "0000000000000002",
+      "OrgID": "0000000000000002",
       "name": "my config",
 			"description": "my description",
       "agent": {

--- a/inmem/lookup_service_test.go
+++ b/inmem/lookup_service_test.go
@@ -153,8 +153,8 @@ func TestService_Name(t *testing.T) {
 				},
 				init: func(ctx context.Context, s *Service) error {
 					return s.CreateTelegrafConfig(ctx, &platform.TelegrafConfig{
-						OrganizationID: platformtesting.MustIDBase16("0000000000000009"),
-						Name:           "telegraf1",
+						OrgID: platformtesting.MustIDBase16("0000000000000009"),
+						Name:  "telegraf1",
 					}, testID)
 				},
 			},

--- a/inmem/telegraf.go
+++ b/inmem/telegraf.go
@@ -58,7 +58,7 @@ func (s *Service) findTelegrafConfigs(ctx context.Context, filter platform.Teleg
 		}
 		if tc != nil {
 			// Restrict results by organization ID, if it has been provided
-			if filter.OrganizationID != nil && filter.OrganizationID.Valid() && tc.OrganizationID != *filter.OrganizationID {
+			if filter.OrgID != nil && filter.OrgID.Valid() && tc.OrgID != *filter.OrgID {
 				continue
 			}
 			tcs = append(tcs, tc)
@@ -88,10 +88,10 @@ func (s *Service) putTelegrafConfig(ctx context.Context, tc *platform.TelegrafCo
 			Err:  platform.ErrInvalidID,
 		}
 	}
-	if !tc.OrganizationID.Valid() {
+	if !tc.OrgID.Valid() {
 		return &platform.Error{
 			Code: platform.EEmptyValue,
-			Msg:  platform.ErrTelegrafConfigInvalidOrganizationID,
+			Msg:  platform.ErrTelegrafConfigInvalidOrgID,
 		}
 	}
 	s.telegrafConfigKV.Store(tc.ID, *tc)
@@ -135,7 +135,7 @@ func (s *Service) UpdateTelegrafConfig(ctx context.Context, id platform.ID, tc *
 	}
 	tc.ID = id
 	// OrganizationID can not be updated
-	tc.OrganizationID = current.OrganizationID
+	tc.OrgID = current.OrgID
 	pErr = s.putTelegrafConfig(ctx, tc)
 	if pErr != nil {
 		pErr.Op = op

--- a/kv/lookup_service_test.go
+++ b/kv/lookup_service_test.go
@@ -190,8 +190,8 @@ func testLookupName(newStore StoreFn, t *testing.T) {
 				},
 				init: func(ctx context.Context, s *kv.Service) error {
 					return s.CreateTelegrafConfig(ctx, &influxdb.TelegrafConfig{
-						OrganizationID: influxdbtesting.MustIDBase16("0000000000000009"),
-						Name:           "telegraf1",
+						OrgID: influxdbtesting.MustIDBase16("0000000000000009"),
+						Name:  "telegraf1",
 					}, testID)
 				},
 			},

--- a/kv/org.go
+++ b/kv/org.go
@@ -619,7 +619,7 @@ func (s *Service) FindResourceOrganizationID(ctx context.Context, rt influxdb.Re
 		if err != nil {
 			return influxdb.InvalidID(), err
 		}
-		return r.OrganizationID, nil
+		return r.OrgID, nil
 	case influxdb.VariablesResourceType:
 		r, err := s.FindVariableByID(ctx, id)
 		if err != nil {

--- a/kv/telegraf.go
+++ b/kv/telegraf.go
@@ -157,7 +157,7 @@ func (s *Service) findTelegrafConfigs(ctx context.Context, tx Tx, filter influxd
 		}
 
 		// Restrict results by organization ID, if it has been provided
-		if filter.OrganizationID != nil && filter.OrganizationID.Valid() && tc.OrganizationID != *filter.OrganizationID {
+		if filter.OrgID != nil && filter.OrgID.Valid() && tc.OrgID != *filter.OrgID {
 			continue
 		}
 		tcs = append(tcs, tc)
@@ -178,7 +178,7 @@ func (s *Service) putTelegrafConfig(ctx context.Context, tx Tx, tc *influxdb.Tel
 		return ErrInvalidTelegrafID
 	}
 
-	if !tc.OrganizationID.Valid() {
+	if !tc.OrgID.Valid() {
 		return ErrInvalidTelegrafOrgID
 	}
 
@@ -239,7 +239,7 @@ func (s *Service) updateTelegrafConfig(ctx context.Context, tx Tx, id influxdb.I
 
 	// ID and OrganizationID can not be updated
 	tc.ID = current.ID
-	tc.OrganizationID = current.OrganizationID
+	tc.OrgID = current.OrgID
 	err = s.putTelegrafConfig(ctx, tx, tc)
 	return tc, err
 }

--- a/telegraf.go
+++ b/telegraf.go
@@ -12,8 +12,8 @@ import (
 	"github.com/influxdata/influxdb/telegraf/plugins/outputs"
 )
 
-// ErrTelegrafConfigInvalidOrganizationID is the error message for a missing or invalid organization ID.
-const ErrTelegrafConfigInvalidOrganizationID = "invalid organization ID"
+// ErrTelegrafConfigInvalidOrgID is the error message for a missing or invalid organization ID.
+const ErrTelegrafConfigInvalidOrgID = "invalid org ID"
 
 // ErrTelegrafConfigNotFound is the error message for a missing telegraf config.
 const ErrTelegrafConfigNotFound = "telegraf configuration not found"
@@ -53,17 +53,17 @@ type TelegrafConfigStore interface {
 
 // TelegrafConfigFilter represents a set of filter that restrict the returned telegraf configs.
 type TelegrafConfigFilter struct {
-	OrganizationID *ID
-	Organization   *string
+	OrgID        *ID
+	Organization *string
 	UserResourceMappingFilter
 }
 
 // TelegrafConfig stores telegraf config for one telegraf instance.
 type TelegrafConfig struct {
-	ID             ID
-	OrganizationID ID
-	Name           string
-	Description    string
+	ID          ID
+	OrgID       ID
+	Name        string
+	Description string
 
 	Agent   TelegrafAgentConfig
 	Plugins []TelegrafPlugin
@@ -135,10 +135,10 @@ func (tc TelegrafConfig) TOML() string {
 
 // telegrafConfigEncode is the helper struct for json encoding.
 type telegrafConfigEncode struct {
-	ID             ID     `json:"id"`
-	OrganizationID ID     `json:"organizationID,omitempty"`
-	Name           string `json:"name"`
-	Description    string `json:"description"`
+	ID          ID     `json:"id"`
+	OrgID       ID     `json:"orgID,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 
 	Agent TelegrafAgentConfig `json:"agent"`
 
@@ -156,10 +156,10 @@ type telegrafPluginEncode struct {
 
 // telegrafConfigDecode is the helper struct for json decoding.
 type telegrafConfigDecode struct {
-	ID             ID     `json:"id"`
-	OrganizationID ID     `json:"organizationID,omitempty"`
-	Name           string `json:"name"`
-	Description    string `json:"description"`
+	ID          ID     `json:"id"`
+	OrgID       ID     `json:"orgID,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 
 	Agent TelegrafAgentConfig `json:"agent"`
 
@@ -199,12 +199,12 @@ const (
 func (tc *TelegrafConfig) MarshalJSON() ([]byte, error) {
 	tce := new(telegrafConfigEncode)
 	*tce = telegrafConfigEncode{
-		ID:             tc.ID,
-		OrganizationID: tc.OrganizationID,
-		Name:           tc.Name,
-		Description:    tc.Description,
-		Agent:          tc.Agent,
-		Plugins:        make([]telegrafPluginEncode, len(tc.Plugins)),
+		ID:          tc.ID,
+		OrgID:       tc.OrgID,
+		Name:        tc.Name,
+		Description: tc.Description,
+		Agent:       tc.Agent,
+		Plugins:     make([]telegrafPluginEncode, len(tc.Plugins)),
 	}
 	for k, p := range tc.Plugins {
 		tce.Plugins[k] = telegrafPluginEncode{
@@ -306,12 +306,12 @@ func (tc *TelegrafConfig) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	*tc = TelegrafConfig{
-		ID:             tcd.ID,
-		OrganizationID: tcd.OrganizationID,
-		Name:           tcd.Name,
-		Description:    tcd.Description,
-		Agent:          tcd.Agent,
-		Plugins:        make([]TelegrafPlugin, len(tcd.Plugins)),
+		ID:          tcd.ID,
+		OrgID:       tcd.OrgID,
+		Name:        tcd.Name,
+		Description: tcd.Description,
+		Agent:       tcd.Agent,
+		Plugins:     make([]TelegrafPlugin, len(tcd.Plugins)),
 	}
 	return decodePluginRaw(tcd, tc)
 }

--- a/telegraf_test.go
+++ b/telegraf_test.go
@@ -165,9 +165,9 @@ func TestTelegrafConfigJSON(t *testing.T) {
 		{
 			name: "regular config",
 			cfg: &TelegrafConfig{
-				ID:             *id1,
-				OrganizationID: *id2,
-				Name:           "n1",
+				ID:    *id1,
+				OrgID: *id2,
+				Name:  "n1",
 				Agent: TelegrafAgentConfig{
 					Interval: 4000,
 				},
@@ -201,9 +201,9 @@ func TestTelegrafConfigJSON(t *testing.T) {
 		{
 			name: "unsupported plugin type",
 			cfg: &TelegrafConfig{
-				ID:             *id1,
-				OrganizationID: *id2,
-				Name:           "n1",
+				ID:    *id1,
+				OrgID: *id2,
+				Name:  "n1",
 				Plugins: []TelegrafPlugin{
 					{
 						Comment: "comment3",
@@ -222,9 +222,9 @@ func TestTelegrafConfigJSON(t *testing.T) {
 		{
 			name: "unsupported plugin",
 			cfg: &TelegrafConfig{
-				ID:             *id1,
-				OrganizationID: *id2,
-				Name:           "n1",
+				ID:    *id1,
+				OrgID: *id2,
+				Name:  "n1",
 				Plugins: []TelegrafPlugin{
 					{
 						Config: &unsupportedPlugin{

--- a/testing/telegraf.go
+++ b/testing/telegraf.go
@@ -124,7 +124,7 @@ func CreateTelegrafConfig(
 			wants: wants{
 				err: &platform.Error{
 					Code: platform.EEmptyValue,
-					Msg:  platform.ErrTelegrafConfigInvalidOrganizationID,
+					Msg:  platform.ErrTelegrafConfigInvalidOrgID,
 				},
 			},
 		},
@@ -138,8 +138,8 @@ func CreateTelegrafConfig(
 			args: args{
 				userID: MustIDBase16(threeID),
 				telegrafConfig: &platform.TelegrafConfig{
-					OrganizationID: MustIDBase16(twoID),
-					Name:           "name1",
+					OrgID: MustIDBase16(twoID),
+					Name:  "name1",
 					Agent: platform.TelegrafAgentConfig{
 						Interval: 1000,
 					},
@@ -171,9 +171,9 @@ func CreateTelegrafConfig(
 				},
 				telegrafs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "name1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "name1",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 1000,
 						},
@@ -202,9 +202,9 @@ func CreateTelegrafConfig(
 				IDGenerator: mock.NewIDGenerator(twoID, t),
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc1",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 4000,
 						},
@@ -228,8 +228,8 @@ func CreateTelegrafConfig(
 			args: args{
 				userID: MustIDBase16(threeID),
 				telegrafConfig: &platform.TelegrafConfig{
-					OrganizationID: MustIDBase16(twoID),
-					Name:           "name2",
+					OrgID: MustIDBase16(twoID),
+					Name:  "name2",
 					Agent: platform.TelegrafAgentConfig{
 						Interval: 1001,
 					},
@@ -253,9 +253,9 @@ func CreateTelegrafConfig(
 			wants: wants{
 				telegrafs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc1",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 4000,
 						},
@@ -267,9 +267,9 @@ func CreateTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "name2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "name2",
 						Agent: platform.TelegrafAgentConfig{
 							Interval: 1001,
 						},
@@ -379,9 +379,9 @@ func FindTelegrafConfigByID(
 			fields: TelegrafConfigFields{
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -389,9 +389,9 @@ func FindTelegrafConfigByID(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -419,9 +419,9 @@ func FindTelegrafConfigByID(
 			fields: TelegrafConfigFields{
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -429,9 +429,9 @@ func FindTelegrafConfigByID(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -462,9 +462,9 @@ func FindTelegrafConfigByID(
 			fields: TelegrafConfigFields{
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -472,9 +472,9 @@ func FindTelegrafConfigByID(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -495,9 +495,9 @@ func FindTelegrafConfigByID(
 			},
 			wants: wants{
 				telegrafConfig: &platform.TelegrafConfig{
-					ID:             MustIDBase16(twoID),
-					OrganizationID: MustIDBase16(threeID),
-					Name:           "tc2",
+					ID:    MustIDBase16(twoID),
+					OrgID: MustIDBase16(threeID),
+					Name:  "tc2",
 					Plugins: []platform.TelegrafPlugin{
 						{
 							Comment: "comment1",
@@ -592,9 +592,9 @@ func FindTelegrafConfigs(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -602,9 +602,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -631,9 +631,9 @@ func FindTelegrafConfigs(
 			wants: wants{
 				telegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -641,9 +641,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -679,9 +679,9 @@ func FindTelegrafConfigs(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -689,9 +689,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -719,9 +719,9 @@ func FindTelegrafConfigs(
 			wants: wants{
 				telegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -756,9 +756,9 @@ func FindTelegrafConfigs(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -766,9 +766,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -783,9 +783,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(fourID),
-						OrganizationID: MustIDBase16(oneID),
-						Name:           "tc3",
+						ID:    MustIDBase16(fourID),
+						OrgID: MustIDBase16(oneID),
+						Name:  "tc3",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -796,15 +796,15 @@ func FindTelegrafConfigs(
 			},
 			args: args{
 				filter: platform.TelegrafConfigFilter{
-					OrganizationID: idPtr(MustIDBase16(oneID)),
+					OrgID: idPtr(MustIDBase16(oneID)),
 				},
 			},
 			wants: wants{
 				telegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(fourID),
-						OrganizationID: MustIDBase16(oneID),
-						Name:           "tc3",
+						ID:    MustIDBase16(fourID),
+						OrgID: MustIDBase16(oneID),
+						Name:  "tc3",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -839,9 +839,9 @@ func FindTelegrafConfigs(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -849,9 +849,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -866,9 +866,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(fourID),
-						OrganizationID: MustIDBase16(oneID),
-						Name:           "tc3",
+						ID:    MustIDBase16(fourID),
+						OrgID: MustIDBase16(oneID),
+						Name:  "tc3",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -879,7 +879,7 @@ func FindTelegrafConfigs(
 			},
 			args: args{
 				filter: platform.TelegrafConfigFilter{
-					OrganizationID: idPtr(MustIDBase16(oneID)),
+					OrgID: idPtr(MustIDBase16(oneID)),
 					UserResourceMappingFilter: platform.UserResourceMappingFilter{
 						UserID:       MustIDBase16(threeID),
 						ResourceType: platform.TelegrafsResourceType,
@@ -890,9 +890,9 @@ func FindTelegrafConfigs(
 			wants: wants{
 				telegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(fourID),
-						OrganizationID: MustIDBase16(oneID),
-						Name:           "tc3",
+						ID:    MustIDBase16(fourID),
+						OrgID: MustIDBase16(oneID),
+						Name:  "tc3",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -921,9 +921,9 @@ func FindTelegrafConfigs(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -931,9 +931,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -951,7 +951,7 @@ func FindTelegrafConfigs(
 			},
 			args: args{
 				filter: platform.TelegrafConfigFilter{
-					OrganizationID: idPtr(MustIDBase16(oneID)),
+					OrgID: idPtr(MustIDBase16(oneID)),
 				},
 			},
 			wants: wants{
@@ -977,9 +977,9 @@ func FindTelegrafConfigs(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -987,9 +987,9 @@ func FindTelegrafConfigs(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1074,9 +1074,9 @@ func UpdateTelegrafConfig(
 			fields: TelegrafConfigFields{
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -1084,9 +1084,9 @@ func UpdateTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1133,9 +1133,9 @@ func UpdateTelegrafConfig(
 			fields: TelegrafConfigFields{
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -1143,9 +1143,9 @@ func UpdateTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1165,8 +1165,8 @@ func UpdateTelegrafConfig(
 				userID: MustIDBase16(fourID),
 				id:     MustIDBase16(twoID),
 				telegrafConfig: &platform.TelegrafConfig{
-					OrganizationID: MustIDBase16(oneID), // notice this get ignored - ie., resulting TelegrafConfig will have OrganizationID equal to fourID
-					Name:           "tc2",
+					OrgID: MustIDBase16(oneID), // notice this get ignored - ie., resulting TelegrafConfig will have OrgID equal to fourID
+					Name:  "tc2",
 					Plugins: []platform.TelegrafPlugin{
 						{
 							Comment: "comment3",
@@ -1181,9 +1181,9 @@ func UpdateTelegrafConfig(
 			},
 			wants: wants{
 				telegrafConfig: &platform.TelegrafConfig{
-					ID:             MustIDBase16(twoID),
-					OrganizationID: MustIDBase16(fourID),
-					Name:           "tc2",
+					ID:    MustIDBase16(twoID),
+					OrgID: MustIDBase16(fourID),
+					Name:  "tc2",
 					Plugins: []platform.TelegrafPlugin{
 						{
 							Comment: "comment3",
@@ -1202,9 +1202,9 @@ func UpdateTelegrafConfig(
 			fields: TelegrafConfigFields{
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(oneID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(oneID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -1212,9 +1212,9 @@ func UpdateTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(oneID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(oneID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1265,9 +1265,9 @@ func UpdateTelegrafConfig(
 			},
 			wants: wants{
 				telegrafConfig: &platform.TelegrafConfig{
-					ID:             MustIDBase16(twoID),
-					OrganizationID: MustIDBase16(oneID),
-					Name:           "tc2",
+					ID:    MustIDBase16(twoID),
+					OrgID: MustIDBase16(oneID),
+					Name:  "tc2",
 					Plugins: []platform.TelegrafPlugin{
 						{
 							Comment: "comment1",
@@ -1354,9 +1354,9 @@ func DeleteTelegrafConfig(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -1364,9 +1364,9 @@ func DeleteTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1404,9 +1404,9 @@ func DeleteTelegrafConfig(
 				},
 				telegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -1414,9 +1414,9 @@ func DeleteTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(fourID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(fourID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1452,9 +1452,9 @@ func DeleteTelegrafConfig(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -1462,9 +1462,9 @@ func DeleteTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1502,9 +1502,9 @@ func DeleteTelegrafConfig(
 				},
 				telegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -1512,9 +1512,9 @@ func DeleteTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(threeID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(threeID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1550,9 +1550,9 @@ func DeleteTelegrafConfig(
 				},
 				TelegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},
@@ -1560,9 +1560,9 @@ func DeleteTelegrafConfig(
 						},
 					},
 					{
-						ID:             MustIDBase16(twoID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc2",
+						ID:    MustIDBase16(twoID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc2",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Comment: "comment1",
@@ -1593,9 +1593,9 @@ func DeleteTelegrafConfig(
 				},
 				telegrafConfigs: []*platform.TelegrafConfig{
 					{
-						ID:             MustIDBase16(oneID),
-						OrganizationID: MustIDBase16(twoID),
-						Name:           "tc1",
+						ID:    MustIDBase16(oneID),
+						OrgID: MustIDBase16(twoID),
+						Name:  "tc1",
 						Plugins: []platform.TelegrafPlugin{
 							{
 								Config: &inputs.CPUStats{},

--- a/ui/cypress/support/commands.ts
+++ b/ui/cypress/support/commands.ts
@@ -246,7 +246,7 @@ export const createScraper = (
 export const createTelegraf = (
   name?: string,
   description?: string,
-  organizationID?: string
+  orgID?: string
 ): Cypress.Chainable<Cypress.Response> => {
   return cy.request({
     method: 'POST',
@@ -256,7 +256,7 @@ export const createTelegraf = (
       description,
       agent: {collectionInterval: 10000},
       plugins: [],
-      organizationID,
+      orgID,
     },
   })
 }

--- a/ui/mocks/dummyData.ts
+++ b/ui/mocks/dummyData.ts
@@ -410,7 +410,7 @@ export const influxDB2Plugin = {
 
 export const telegrafConfig = {
   id: telegrafConfigID,
-  organizationID: '1',
+  orgID: '1',
   name: 'in n out',
   created: '2018-11-28T18:56:48.854337-08:00',
   lastModified: '2018-11-28T18:56:48.854337-08:00',
@@ -500,8 +500,7 @@ export const bucket = {
     self: '/api/v2/buckets/034a10d6f7a6b000',
   },
   id: '034a10d6f7a6b000',
-  organizationID: '034a0adc49a6b000',
-  organization: 'default',
+  orgID: '034a0adc49a6b000',
   name: 'newbuck',
   retentionRules: [],
   labels: [],
@@ -516,8 +515,7 @@ export const buckets = [
       self: '/api/v2/buckets/034a10d6f7a6b000',
     },
     id: '034a10d6f7a6b000',
-    organizationID: '034a0adc49a6b000',
-    organization: 'default',
+    orgID: '034a0adc49a6b000',
     name: 'newbuck',
     retentionRules: [],
     labels: [],
@@ -530,8 +528,7 @@ export const buckets = [
       self: '/api/v2/buckets/034a10d6f7a6b000',
     },
     id: '034a10d6f7a6b001',
-    organizationID: '034a0adc49a6b000',
-    organization: 'default',
+    orgID: '034a0adc49a6b000',
     name: 'newbuck1',
     retentionRules: [],
     labels: [],
@@ -557,7 +554,6 @@ export const setSetupParamsResponse = {
       },
       id: '033bc62534fe3000',
       orgID: '033bc62534be3000',
-      organization: 'default',
       name: 'defbuck',
       retentionRules: [],
       labels: [],
@@ -652,12 +648,12 @@ export const telegraf = [
   {
     id: '03636a150fb51000',
     name: 'Name this Configuration',
-    organizationID: '03636a0aabb51000',
+    orgID: '03636a0aabb51000',
   },
   {
     id: '03636a150fb51001',
     name: 'Name this Configuration',
-    organizationID: '03636a0aabb51000',
+    orgID: '03636a0aabb51000',
   },
 ]
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1030,9 +1030,8 @@
       }
     },
     "@influxdata/influx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@influxdata/influx/-/influx-0.3.4.tgz",
-      "integrity": "sha512-WUkugWDdvG5BpdRtdrFPnevFlJOmxod3t91cUuTcUiGdYATqCnVgMYvjmK0oXu/8DFrGAZlzg/u4vMQq8ndhnA==",
+      "version": "github:influxdata/influxdb2-js#4bb7981498a2649391fbebdcaababafbf304f642",
+      "from": "github:influxdata/influxdb2-js#dev",
       "requires": {
         "axios": "^0.18.0"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -140,7 +140,7 @@
   },
   "dependencies": {
     "@influxdata/clockface": "0.0.13",
-    "@influxdata/influx": "0.3.4",
+    "@influxdata/influx": "github:influxdata/influxdb2-js#dev",
     "@influxdata/influxdb-templates": "influxdata/influxdb-templates",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "@influxdata/vis": "^0.9.0",

--- a/ui/src/dataLoaders/actions/dataLoaders.ts
+++ b/ui/src/dataLoaders/actions/dataLoaders.ts
@@ -402,7 +402,7 @@ const createTelegraf = async (dispatch, getState, plugins) => {
       name: telegrafConfigName,
       description: telegrafConfigDescription,
       agent: {collectionInterval: DEFAULT_COLLECTION_INTERVAL},
-      organizationID: org.id,
+      orgID: org.id,
       plugins,
     }
 

--- a/ui/src/telegrafs/components/__snapshots__/Collectors.test.tsx.snap
+++ b/ui/src/telegrafs/components/__snapshots__/Collectors.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`CollectorList rendering renders 1`] = `
           Object {
             "id": "03636a150fb51000",
             "name": "Name this Configuration",
-            "organizationID": "03636a0aabb51000",
+            "orgID": "03636a0aabb51000",
           }
         }
         key="03636a150fb51000"
@@ -37,7 +37,7 @@ exports[`CollectorList rendering renders 1`] = `
           Object {
             "id": "03636a150fb51001",
             "name": "Name this Configuration",
-            "organizationID": "03636a0aabb51000",
+            "orgID": "03636a0aabb51000",
           }
         }
         key="03636a150fb51001"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/13147

rename telegraf config's OrganizationID to OrgID
only merged after https://github.com/influxdata/influxdb/issues/13404 resolved


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
