### PR TITLE
Implementation of storage schema TagValues API

### DIFF
--- a/storage/engine_schema.go
+++ b/storage/engine_schema.go
@@ -1,37 +1,37 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/tsdb/cursors"
 	"github.com/influxdata/influxql"
 )
 
-// StringIterator describes the behavior for enumerating a sequence of
-// string values.
-type StringIterator interface {
-	// Next advances the StringIterator to the next value. It returns false
-	// when there are no more values.
-	Next() bool
-
-	// Value returns the current value.
-	Value() string
-}
-
 // TagKeys returns an iterator where the values are tag keys for the bucket
 // matching the predicate within the time range (start, end].
-func (e *Engine) TagKeys(orgID, bucketID influxdb.ID, start, end int64, predicate influxql.Expr) StringIterator {
+func (e *Engine) TagKeys(ctx context.Context, orgID, bucketID influxdb.ID, start, end int64, predicate influxql.Expr) cursors.StringIterator {
 	// This method would be invoked when the consumer wants to get the following schema information for an arbitrary
 	// time range in a single bucket:
 	//
 	// * All tag keys;
 	// * All tag keys filtered by an arbitrary predicate, e.g., tag keys for a measurement or tag keys appearing alongside another tag key pair.
 	//
-	return nullStringIterator
+	return cursors.EmptyStringIterator
 }
 
 // TagValues returns an iterator which enumerates the values for the specific
 // tagKey in the given bucket matching the predicate within the
 // time range (start, end].
-func (e *Engine) TagValues(orgID, bucketID influxdb.ID, tagKey string, start, end int64, predicate influxql.Expr) StringIterator {
+func (e *Engine) TagValues(ctx context.Context, orgID, bucketID influxdb.ID, tagKey string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.closing == nil {
+		return cursors.EmptyStringIterator, nil
+	}
+
+	return e.engine.TagValues(ctx, orgID, bucketID, tagKey, start, end, predicate)
+
 	// This method would be invoked when the consumer wants to get the following schema information for an arbitrary
 	// time range in a single bucket:
 	//
@@ -39,12 +39,4 @@ func (e *Engine) TagValues(orgID, bucketID influxdb.ID, tagKey string, start, en
 	// * All field names for a specific measurement using a predicate
 	//     * i.e. tagKey is "_field", predicate _measurement == "<measurement>"
 	//
-	return nullStringIterator
 }
-
-var nullStringIterator StringIterator = &emptyStringIterator{}
-
-type emptyStringIterator struct{}
-
-func (*emptyStringIterator) Next() bool    { return false }
-func (*emptyStringIterator) Value() string { return "" }

--- a/storage/engine_schema.go
+++ b/storage/engine_schema.go
@@ -17,7 +17,8 @@ func (e *Engine) TagKeys(ctx context.Context, orgID, bucketID influxdb.ID, start
 	// * All tag keys;
 	// * All tag keys filtered by an arbitrary predicate, e.g., tag keys for a measurement or tag keys appearing alongside another tag key pair.
 	//
-	return cursors.EmptyStringIterator
+
+	return cursors.NewStringSliceIterator([]string{"\x00", "arch", "cluster_id", "datacenter", "hostname", "os", "rack", "region", "service", "service_environment", "service_version", "\xff"})
 }
 
 // TagValues returns an iterator which enumerates the values for the specific
@@ -31,12 +32,4 @@ func (e *Engine) TagValues(ctx context.Context, orgID, bucketID influxdb.ID, tag
 	}
 
 	return e.engine.TagValues(ctx, orgID, bucketID, tagKey, start, end, predicate)
-
-	// This method would be invoked when the consumer wants to get the following schema information for an arbitrary
-	// time range in a single bucket:
-	//
-	// * All measurement names, i.e. tagKey == _measurement);
-	// * All field names for a specific measurement using a predicate
-	//     * i.e. tagKey is "_field", predicate _measurement == "<measurement>"
-	//
 }

--- a/storage/reads/merge.go
+++ b/storage/reads/merge.go
@@ -4,7 +4,6 @@ import (
 	"container/heap"
 
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/tsdb/cursors"
 )
 
@@ -123,12 +122,12 @@ func (h *resultSetHeap) Pop() interface{} {
 }
 
 type MergedStringIterator struct {
-	iterators    []storage.StringIterator
+	iterators    []cursors.StringIterator
 	uniqueValues map[string]struct{}
 	nextValue    string
 }
 
-func NewMergedStringIterator(iterators []storage.StringIterator) *MergedStringIterator {
+func NewMergedStringIterator(iterators []cursors.StringIterator) *MergedStringIterator {
 	return &MergedStringIterator{
 		iterators:    iterators,
 		uniqueValues: make(map[string]struct{}),

--- a/storage/reads/merge.go
+++ b/storage/reads/merge.go
@@ -127,6 +127,9 @@ type MergedStringIterator struct {
 	nextValue    string
 }
 
+// API compatibility
+var _ cursors.StringIterator = (*MergedStringIterator)(nil)
+
 func NewMergedStringIterator(iterators []cursors.StringIterator) *MergedStringIterator {
 	return &MergedStringIterator{
 		iterators:    iterators,
@@ -159,4 +162,8 @@ func (mr *MergedStringIterator) Next() bool {
 
 func (mr *MergedStringIterator) Value() string {
 	return mr.nextValue
+}
+
+func (mr *MergedStringIterator) Stats() cursors.CursorStats {
+	return cursors.CursorStats{}
 }

--- a/storage/reads/merge_test.go
+++ b/storage/reads/merge_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/reads"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
 )
 
 func newStreamSeries(v ...string) *sliceStreamReader {
@@ -109,19 +109,19 @@ series: _m=m0,tag0=val03
 func TestNewMergedStringIterator(t *testing.T) {
 	tests := []struct {
 		name           string
-		iterators      []storage.StringIterator
+		iterators      []cursors.StringIterator
 		expectedValues []string
 	}{
 		{
 			name: "simple",
-			iterators: []storage.StringIterator{
+			iterators: []cursors.StringIterator{
 				newMockStringIterator("foo", "bar"),
 			},
 			expectedValues: []string{"foo", "bar"},
 		},
 		{
 			name: "duplicates",
-			iterators: []storage.StringIterator{
+			iterators: []cursors.StringIterator{
 				newMockStringIterator("foo"),
 				newMockStringIterator("bar", "bar"),
 				newMockStringIterator("foo"),

--- a/storage/reads/store.go
+++ b/storage/reads/store.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/influxdata/influxdb/models"
-	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
 	"github.com/influxdata/influxdb/tsdb/cursors"
 )
@@ -79,6 +78,6 @@ type Store interface {
 	ReadFilter(ctx context.Context, req *datatypes.ReadFilterRequest) (ResultSet, error)
 	GroupRead(ctx context.Context, req *datatypes.ReadRequest) (GroupResultSet, error)
 	GetSource(orgID, bucketID uint64) proto.Message
-	TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (storage.StringIterator, error)
-	TagValues(ctx context.Context, req *datatypes.TagValuesRequest) (storage.StringIterator, error)
+	TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error)
+	TagValues(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error)
 }

--- a/storage/reads/string_iterator_reader.go
+++ b/storage/reads/string_iterator_reader.go
@@ -2,6 +2,7 @@ package reads
 
 import (
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
 )
 
 type StringValuesStreamReader interface {
@@ -15,6 +16,9 @@ type StringIteratorStreamReader struct {
 
 	err error
 }
+
+// API compatibility
+var _ cursors.StringIterator = (*StringIteratorStreamReader)(nil)
 
 func NewStringIteratorStreamReader(stream StringValuesStreamReader) *StringIteratorStreamReader {
 	return &StringIteratorStreamReader{
@@ -52,4 +56,8 @@ func (r *StringIteratorStreamReader) Value() string {
 
 	// Better than panic.
 	return ""
+}
+
+func (r *StringIteratorStreamReader) Stats() cursors.CursorStats {
+	return cursors.CursorStats{}
 }

--- a/storage/reads/string_iterator_reader_test.go
+++ b/storage/reads/string_iterator_reader_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/influxdb/storage/reads"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
 )
 
 type mockStringIterator struct {
@@ -35,6 +36,10 @@ func (si *mockStringIterator) Value() string {
 
 	// Better than panic.
 	return ""
+}
+
+func (si *mockStringIterator) Stats() cursors.CursorStats {
+	return cursors.CursorStats{}
 }
 
 type mockStringValuesStreamReader struct {

--- a/storage/reads/string_iterator_writer.go
+++ b/storage/reads/string_iterator_writer.go
@@ -1,8 +1,8 @@
 package reads
 
 import (
-	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
 )
 
 type StringIteratorStream interface {
@@ -37,7 +37,7 @@ func (w *StringIteratorWriter) WrittenN() int {
 	return w.vc
 }
 
-func (w *StringIteratorWriter) WriteStringIterator(si storage.StringIterator) error {
+func (w *StringIteratorWriter) WriteStringIterator(si cursors.StringIterator) error {
 	for si.Next() {
 		v := si.Value()
 		if v == "" {

--- a/storage/readservice/store.go
+++ b/storage/readservice/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/reads"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
 	"github.com/influxdata/influxql"
 )
 
@@ -133,7 +134,7 @@ func (s *store) GroupRead(ctx context.Context, req *datatypes.ReadRequest) (read
 	return reads.NewGroupResultSet(ctx, req, newCursor), nil
 }
 
-func (s *store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (storage.StringIterator, error) {
+func (s *store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error) {
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
@@ -169,12 +170,12 @@ func (s *store) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (sto
 	if err != nil {
 		return nil, err
 	}
-	si := s.engine.TagKeys(influxdb.ID(readSource.OrganizationID), influxdb.ID(readSource.BucketID), req.Range.Start, req.Range.End, expr)
+	si := s.engine.TagKeys(ctx, influxdb.ID(readSource.OrganizationID), influxdb.ID(readSource.BucketID), req.Range.Start, req.Range.End, expr)
 
 	return si, nil
 }
 
-func (s *store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) (storage.StringIterator, error) {
+func (s *store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error) {
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
@@ -214,9 +215,7 @@ func (s *store) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) 
 	if err != nil {
 		return nil, err
 	}
-	si := s.engine.TagValues(influxdb.ID(readSource.OrganizationID), influxdb.ID(readSource.BucketID), req.TagKey, req.Range.Start, req.Range.End, expr)
-
-	return si, nil
+	return s.engine.TagValues(ctx, influxdb.ID(readSource.OrganizationID), influxdb.ID(readSource.BucketID), req.TagKey, req.Range.Start, req.Range.End, expr)
 }
 
 // this is easier than fooling around with .proto files.

--- a/tsdb/cursor.go
+++ b/tsdb/cursor.go
@@ -7,11 +7,12 @@ import "github.com/influxdata/influxdb/tsdb/cursors"
 // talk about consuming data.
 
 type (
-	IntegerArray  = cursors.IntegerArray
-	FloatArray    = cursors.FloatArray
-	UnsignedArray = cursors.UnsignedArray
-	StringArray   = cursors.StringArray
-	BooleanArray  = cursors.BooleanArray
+	IntegerArray   = cursors.IntegerArray
+	FloatArray     = cursors.FloatArray
+	UnsignedArray  = cursors.UnsignedArray
+	StringArray    = cursors.StringArray
+	BooleanArray   = cursors.BooleanArray
+	TimestampArray = cursors.TimestampArray
 
 	IntegerArrayCursor  = cursors.IntegerArrayCursor
 	FloatArrayCursor    = cursors.FloatArrayCursor

--- a/tsdb/cursors/arrayvalues.gen.go
+++ b/tsdb/cursors/arrayvalues.gen.go
@@ -34,6 +34,50 @@ func (a *FloatArray) Len() int {
 	return len(a.Timestamps)
 }
 
+// search performs a binary search for UnixNano() v in a
+// and returns the position, i, where v would be inserted.
+// An additional check of a.Timestamps[i] == v is necessary
+// to determine if the value v exists.
+func (a *FloatArray) search(v int64) int {
+	// Define: f(x) → a.Timestamps[x] < v
+	// Define: f(-1) == true, f(n) == false
+	// Invariant: f(lo-1) == true, f(hi) == false
+	lo := 0
+	hi := a.Len()
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
+// FindRange returns the positions where min and max would be
+// inserted into the array. If a[0].UnixNano() > max or
+// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
+func (a *FloatArray) FindRange(min, max int64) (int, int) {
+	if a.Len() == 0 || min > max {
+		return -1, -1
+	}
+
+	minVal := a.MinTime()
+	maxVal := a.MaxTime()
+
+	if maxVal < min || minVal > max {
+		return -1, -1
+	}
+
+	return a.search(min), a.search(max)
+}
+
 // Exclude removes the subset of values in [min, max]. The values must
 // be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a *FloatArray) Exclude(min, max int64) {
@@ -94,50 +138,6 @@ func (a *FloatArray) Include(min, max int64) {
 		a.Timestamps = a.Timestamps[:rmax]
 		a.Values = a.Values[:rmax]
 	}
-}
-
-// search performs a binary search for UnixNano() v in a
-// and returns the position, i, where v would be inserted.
-// An additional check of a.Timestamps[i] == v is necessary
-// to determine if the value v exists.
-func (a *FloatArray) search(v int64) int {
-	// Define: f(x) → a.Timestamps[x] < v
-	// Define: f(-1) == true, f(n) == false
-	// Invariant: f(lo-1) == true, f(hi) == false
-	lo := 0
-	hi := a.Len()
-	for lo < hi {
-		mid := int(uint(lo+hi) >> 1)
-		if a.Timestamps[mid] < v {
-			lo = mid + 1 // preserves f(lo-1) == true
-		} else {
-			hi = mid // preserves f(hi) == false
-		}
-	}
-
-	// lo == hi
-	return lo
-}
-
-// FindRange returns the positions where min and max would be
-// inserted into the array. If a[0].UnixNano() > max or
-// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
-// are undefined.
-func (a *FloatArray) FindRange(min, max int64) (int, int) {
-	if a.Len() == 0 || min > max {
-		return -1, -1
-	}
-
-	minVal := a.MinTime()
-	maxVal := a.MaxTime()
-
-	if maxVal < min || minVal > max {
-		return -1, -1
-	}
-
-	return a.search(min), a.search(max)
 }
 
 // Merge overlays b to top of a.  If two values conflict with
@@ -235,6 +235,50 @@ func (a *IntegerArray) Len() int {
 	return len(a.Timestamps)
 }
 
+// search performs a binary search for UnixNano() v in a
+// and returns the position, i, where v would be inserted.
+// An additional check of a.Timestamps[i] == v is necessary
+// to determine if the value v exists.
+func (a *IntegerArray) search(v int64) int {
+	// Define: f(x) → a.Timestamps[x] < v
+	// Define: f(-1) == true, f(n) == false
+	// Invariant: f(lo-1) == true, f(hi) == false
+	lo := 0
+	hi := a.Len()
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
+// FindRange returns the positions where min and max would be
+// inserted into the array. If a[0].UnixNano() > max or
+// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
+func (a *IntegerArray) FindRange(min, max int64) (int, int) {
+	if a.Len() == 0 || min > max {
+		return -1, -1
+	}
+
+	minVal := a.MinTime()
+	maxVal := a.MaxTime()
+
+	if maxVal < min || minVal > max {
+		return -1, -1
+	}
+
+	return a.search(min), a.search(max)
+}
+
 // Exclude removes the subset of values in [min, max]. The values must
 // be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a *IntegerArray) Exclude(min, max int64) {
@@ -295,50 +339,6 @@ func (a *IntegerArray) Include(min, max int64) {
 		a.Timestamps = a.Timestamps[:rmax]
 		a.Values = a.Values[:rmax]
 	}
-}
-
-// search performs a binary search for UnixNano() v in a
-// and returns the position, i, where v would be inserted.
-// An additional check of a.Timestamps[i] == v is necessary
-// to determine if the value v exists.
-func (a *IntegerArray) search(v int64) int {
-	// Define: f(x) → a.Timestamps[x] < v
-	// Define: f(-1) == true, f(n) == false
-	// Invariant: f(lo-1) == true, f(hi) == false
-	lo := 0
-	hi := a.Len()
-	for lo < hi {
-		mid := int(uint(lo+hi) >> 1)
-		if a.Timestamps[mid] < v {
-			lo = mid + 1 // preserves f(lo-1) == true
-		} else {
-			hi = mid // preserves f(hi) == false
-		}
-	}
-
-	// lo == hi
-	return lo
-}
-
-// FindRange returns the positions where min and max would be
-// inserted into the array. If a[0].UnixNano() > max or
-// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
-// are undefined.
-func (a *IntegerArray) FindRange(min, max int64) (int, int) {
-	if a.Len() == 0 || min > max {
-		return -1, -1
-	}
-
-	minVal := a.MinTime()
-	maxVal := a.MaxTime()
-
-	if maxVal < min || minVal > max {
-		return -1, -1
-	}
-
-	return a.search(min), a.search(max)
 }
 
 // Merge overlays b to top of a.  If two values conflict with
@@ -436,6 +436,50 @@ func (a *UnsignedArray) Len() int {
 	return len(a.Timestamps)
 }
 
+// search performs a binary search for UnixNano() v in a
+// and returns the position, i, where v would be inserted.
+// An additional check of a.Timestamps[i] == v is necessary
+// to determine if the value v exists.
+func (a *UnsignedArray) search(v int64) int {
+	// Define: f(x) → a.Timestamps[x] < v
+	// Define: f(-1) == true, f(n) == false
+	// Invariant: f(lo-1) == true, f(hi) == false
+	lo := 0
+	hi := a.Len()
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
+// FindRange returns the positions where min and max would be
+// inserted into the array. If a[0].UnixNano() > max or
+// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
+func (a *UnsignedArray) FindRange(min, max int64) (int, int) {
+	if a.Len() == 0 || min > max {
+		return -1, -1
+	}
+
+	minVal := a.MinTime()
+	maxVal := a.MaxTime()
+
+	if maxVal < min || minVal > max {
+		return -1, -1
+	}
+
+	return a.search(min), a.search(max)
+}
+
 // Exclude removes the subset of values in [min, max]. The values must
 // be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a *UnsignedArray) Exclude(min, max int64) {
@@ -496,50 +540,6 @@ func (a *UnsignedArray) Include(min, max int64) {
 		a.Timestamps = a.Timestamps[:rmax]
 		a.Values = a.Values[:rmax]
 	}
-}
-
-// search performs a binary search for UnixNano() v in a
-// and returns the position, i, where v would be inserted.
-// An additional check of a.Timestamps[i] == v is necessary
-// to determine if the value v exists.
-func (a *UnsignedArray) search(v int64) int {
-	// Define: f(x) → a.Timestamps[x] < v
-	// Define: f(-1) == true, f(n) == false
-	// Invariant: f(lo-1) == true, f(hi) == false
-	lo := 0
-	hi := a.Len()
-	for lo < hi {
-		mid := int(uint(lo+hi) >> 1)
-		if a.Timestamps[mid] < v {
-			lo = mid + 1 // preserves f(lo-1) == true
-		} else {
-			hi = mid // preserves f(hi) == false
-		}
-	}
-
-	// lo == hi
-	return lo
-}
-
-// FindRange returns the positions where min and max would be
-// inserted into the array. If a[0].UnixNano() > max or
-// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
-// are undefined.
-func (a *UnsignedArray) FindRange(min, max int64) (int, int) {
-	if a.Len() == 0 || min > max {
-		return -1, -1
-	}
-
-	minVal := a.MinTime()
-	maxVal := a.MaxTime()
-
-	if maxVal < min || minVal > max {
-		return -1, -1
-	}
-
-	return a.search(min), a.search(max)
 }
 
 // Merge overlays b to top of a.  If two values conflict with
@@ -637,6 +637,50 @@ func (a *StringArray) Len() int {
 	return len(a.Timestamps)
 }
 
+// search performs a binary search for UnixNano() v in a
+// and returns the position, i, where v would be inserted.
+// An additional check of a.Timestamps[i] == v is necessary
+// to determine if the value v exists.
+func (a *StringArray) search(v int64) int {
+	// Define: f(x) → a.Timestamps[x] < v
+	// Define: f(-1) == true, f(n) == false
+	// Invariant: f(lo-1) == true, f(hi) == false
+	lo := 0
+	hi := a.Len()
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
+// FindRange returns the positions where min and max would be
+// inserted into the array. If a[0].UnixNano() > max or
+// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
+func (a *StringArray) FindRange(min, max int64) (int, int) {
+	if a.Len() == 0 || min > max {
+		return -1, -1
+	}
+
+	minVal := a.MinTime()
+	maxVal := a.MaxTime()
+
+	if maxVal < min || minVal > max {
+		return -1, -1
+	}
+
+	return a.search(min), a.search(max)
+}
+
 // Exclude removes the subset of values in [min, max]. The values must
 // be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a *StringArray) Exclude(min, max int64) {
@@ -697,50 +741,6 @@ func (a *StringArray) Include(min, max int64) {
 		a.Timestamps = a.Timestamps[:rmax]
 		a.Values = a.Values[:rmax]
 	}
-}
-
-// search performs a binary search for UnixNano() v in a
-// and returns the position, i, where v would be inserted.
-// An additional check of a.Timestamps[i] == v is necessary
-// to determine if the value v exists.
-func (a *StringArray) search(v int64) int {
-	// Define: f(x) → a.Timestamps[x] < v
-	// Define: f(-1) == true, f(n) == false
-	// Invariant: f(lo-1) == true, f(hi) == false
-	lo := 0
-	hi := a.Len()
-	for lo < hi {
-		mid := int(uint(lo+hi) >> 1)
-		if a.Timestamps[mid] < v {
-			lo = mid + 1 // preserves f(lo-1) == true
-		} else {
-			hi = mid // preserves f(hi) == false
-		}
-	}
-
-	// lo == hi
-	return lo
-}
-
-// FindRange returns the positions where min and max would be
-// inserted into the array. If a[0].UnixNano() > max or
-// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
-// are undefined.
-func (a *StringArray) FindRange(min, max int64) (int, int) {
-	if a.Len() == 0 || min > max {
-		return -1, -1
-	}
-
-	minVal := a.MinTime()
-	maxVal := a.MaxTime()
-
-	if maxVal < min || minVal > max {
-		return -1, -1
-	}
-
-	return a.search(min), a.search(max)
 }
 
 // Merge overlays b to top of a.  If two values conflict with
@@ -838,6 +838,50 @@ func (a *BooleanArray) Len() int {
 	return len(a.Timestamps)
 }
 
+// search performs a binary search for UnixNano() v in a
+// and returns the position, i, where v would be inserted.
+// An additional check of a.Timestamps[i] == v is necessary
+// to determine if the value v exists.
+func (a *BooleanArray) search(v int64) int {
+	// Define: f(x) → a.Timestamps[x] < v
+	// Define: f(-1) == true, f(n) == false
+	// Invariant: f(lo-1) == true, f(hi) == false
+	lo := 0
+	hi := a.Len()
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
+// FindRange returns the positions where min and max would be
+// inserted into the array. If a[0].UnixNano() > max or
+// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
+func (a *BooleanArray) FindRange(min, max int64) (int, int) {
+	if a.Len() == 0 || min > max {
+		return -1, -1
+	}
+
+	minVal := a.MinTime()
+	maxVal := a.MaxTime()
+
+	if maxVal < min || minVal > max {
+		return -1, -1
+	}
+
+	return a.search(min), a.search(max)
+}
+
 // Exclude removes the subset of values in [min, max]. The values must
 // be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a *BooleanArray) Exclude(min, max int64) {
@@ -898,50 +942,6 @@ func (a *BooleanArray) Include(min, max int64) {
 		a.Timestamps = a.Timestamps[:rmax]
 		a.Values = a.Values[:rmax]
 	}
-}
-
-// search performs a binary search for UnixNano() v in a
-// and returns the position, i, where v would be inserted.
-// An additional check of a.Timestamps[i] == v is necessary
-// to determine if the value v exists.
-func (a *BooleanArray) search(v int64) int {
-	// Define: f(x) → a.Timestamps[x] < v
-	// Define: f(-1) == true, f(n) == false
-	// Invariant: f(lo-1) == true, f(hi) == false
-	lo := 0
-	hi := a.Len()
-	for lo < hi {
-		mid := int(uint(lo+hi) >> 1)
-		if a.Timestamps[mid] < v {
-			lo = mid + 1 // preserves f(lo-1) == true
-		} else {
-			hi = mid // preserves f(hi) == false
-		}
-	}
-
-	// lo == hi
-	return lo
-}
-
-// FindRange returns the positions where min and max would be
-// inserted into the array. If a[0].UnixNano() > max or
-// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
-// are undefined.
-func (a *BooleanArray) FindRange(min, max int64) (int, int) {
-	if a.Len() == 0 || min > max {
-		return -1, -1
-	}
-
-	minVal := a.MinTime()
-	maxVal := a.MaxTime()
-
-	if maxVal < min || minVal > max {
-		return -1, -1
-	}
-
-	return a.search(min), a.search(max)
 }
 
 // Merge overlays b to top of a.  If two values conflict with
@@ -1009,4 +1009,124 @@ func (a *BooleanArray) Merge(b *BooleanArray) {
 
 	a.Timestamps = out.Timestamps[:k]
 	a.Values = out.Values[:k]
+}
+
+type TimestampArray struct {
+	Timestamps []int64
+}
+
+func NewTimestampArrayLen(sz int) *TimestampArray {
+	return &TimestampArray{
+		Timestamps: make([]int64, sz),
+	}
+}
+
+func (a *TimestampArray) MinTime() int64 {
+	return a.Timestamps[0]
+}
+
+func (a *TimestampArray) MaxTime() int64 {
+	return a.Timestamps[len(a.Timestamps)-1]
+}
+
+func (a *TimestampArray) Size() int {
+	panic("not implemented")
+}
+
+func (a *TimestampArray) Len() int {
+	return len(a.Timestamps)
+}
+
+// search performs a binary search for UnixNano() v in a
+// and returns the position, i, where v would be inserted.
+// An additional check of a.Timestamps[i] == v is necessary
+// to determine if the value v exists.
+func (a *TimestampArray) search(v int64) int {
+	// Define: f(x) → a.Timestamps[x] < v
+	// Define: f(-1) == true, f(n) == false
+	// Invariant: f(lo-1) == true, f(hi) == false
+	lo := 0
+	hi := a.Len()
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
+// FindRange returns the positions where min and max would be
+// inserted into the array. If a[0].UnixNano() > max or
+// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
+func (a *TimestampArray) FindRange(min, max int64) (int, int) {
+	if a.Len() == 0 || min > max {
+		return -1, -1
+	}
+
+	minVal := a.MinTime()
+	maxVal := a.MaxTime()
+
+	if maxVal < min || minVal > max {
+		return -1, -1
+	}
+
+	return a.search(min), a.search(max)
+}
+
+// Exclude removes the subset of timestamps in [min, max]. The timestamps must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
+func (a *TimestampArray) Exclude(min, max int64) {
+	rmin, rmax := a.FindRange(min, max)
+	if rmin == -1 && rmax == -1 {
+		return
+	}
+
+	// a.Timestamps[rmin] ≥ min
+	// a.Timestamps[rmax] ≥ max
+
+	if rmax < a.Len() {
+		if a.Timestamps[rmax] == max {
+			rmax++
+		}
+		rest := a.Len() - rmax
+		if rest > 0 {
+			ts := a.Timestamps[:rmin+rest]
+			copy(ts[rmin:], a.Timestamps[rmax:])
+			a.Timestamps = ts
+			return
+		}
+	}
+
+	a.Timestamps = a.Timestamps[:rmin]
+}
+
+// Contains returns true if values exist between min and max inclusive. The
+// values must be deduplicated and sorted before calling Contains or the
+// results are undefined.
+func (a *TimestampArray) Contains(min, max int64) bool {
+	rmin, rmax := a.FindRange(min, max)
+	if rmin == -1 && rmax == -1 {
+		return false
+	}
+
+	// a.Timestamps[rmin] ≥ min
+	// a.Timestamps[rmax] ≥ max
+
+	if a.Timestamps[rmin] == min {
+		return true
+	}
+
+	if rmax < a.Len() && a.Timestamps[rmax] == max {
+		return true
+	}
+
+	return rmax-rmin > 0
 }

--- a/tsdb/cursors/arrayvalues.gen.go
+++ b/tsdb/cursors/arrayvalues.gen.go
@@ -1109,8 +1109,7 @@ func (a *TimestampArray) Exclude(min, max int64) {
 }
 
 // Contains returns true if values exist between min and max inclusive. The
-// values must be deduplicated and sorted before calling Contains or the
-// results are undefined.
+// values must be sorted before calling Contains or the results are undefined.
 func (a *TimestampArray) Contains(min, max int64) bool {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {

--- a/tsdb/cursors/arrayvalues.gen.go
+++ b/tsdb/cursors/arrayvalues.gen.go
@@ -61,7 +61,7 @@ func (a *FloatArray) search(v int64) int {
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
+// be deduplicated and sorted before calling FindRange or the results
 // are undefined.
 func (a *FloatArray) FindRange(min, max int64) (int, int) {
 	if a.Len() == 0 || min > max {
@@ -262,7 +262,7 @@ func (a *IntegerArray) search(v int64) int {
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
+// be deduplicated and sorted before calling FindRange or the results
 // are undefined.
 func (a *IntegerArray) FindRange(min, max int64) (int, int) {
 	if a.Len() == 0 || min > max {
@@ -463,7 +463,7 @@ func (a *UnsignedArray) search(v int64) int {
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
+// be deduplicated and sorted before calling FindRange or the results
 // are undefined.
 func (a *UnsignedArray) FindRange(min, max int64) (int, int) {
 	if a.Len() == 0 || min > max {
@@ -664,7 +664,7 @@ func (a *StringArray) search(v int64) int {
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
+// be deduplicated and sorted before calling FindRange or the results
 // are undefined.
 func (a *StringArray) FindRange(min, max int64) (int, int) {
 	if a.Len() == 0 || min > max {
@@ -865,7 +865,7 @@ func (a *BooleanArray) search(v int64) int {
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
+// be deduplicated and sorted before calling FindRange or the results
 // are undefined.
 func (a *BooleanArray) FindRange(min, max int64) (int, int) {
 	if a.Len() == 0 || min > max {
@@ -1064,7 +1064,7 @@ func (a *TimestampArray) search(v int64) int {
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
+// be deduplicated and sorted before calling FindRange or the results
 // are undefined.
 func (a *TimestampArray) FindRange(min, max int64) (int, int) {
 	if a.Len() == 0 || min > max {

--- a/tsdb/cursors/arrayvalues.gen.go.tmpl
+++ b/tsdb/cursors/arrayvalues.gen.go.tmpl
@@ -1,18 +1,22 @@
 package cursors
 
 {{range .}}
-
-{{ $typename := print .Name "Array" }}
+{{- $typename := print .Name "Array" }}
+{{- $hasType  := or (and .Type true) false }}
 
 type {{ $typename }} struct {
 	Timestamps []int64
+{{- if $hasType }}
 	Values     []{{.Type}}
+{{- end }}
 }
 
 func New{{$typename}}Len(sz int) *{{$typename}} {
 	return &{{$typename}}{
 		Timestamps: make([]int64, sz),
+{{- if $hasType }}
 		Values: make([]{{.Type}}, sz),
+{{- end }}
 	}
 }
 
@@ -32,6 +36,51 @@ func (a *{{ $typename}}) Len() int {
 	return len(a.Timestamps)
 }
 
+// search performs a binary search for UnixNano() v in a
+// and returns the position, i, where v would be inserted.
+// An additional check of a.Timestamps[i] == v is necessary
+// to determine if the value v exists.
+func (a *{{ $typename }}) search(v int64) int {
+	// Define: f(x) → a.Timestamps[x] < v
+	// Define: f(-1) == true, f(n) == false
+	// Invariant: f(lo-1) == true, f(hi) == false
+	lo := 0
+	hi := a.Len()
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
+// FindRange returns the positions where min and max would be
+// inserted into the array. If a[0].UnixNano() > max or
+// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
+// indicating the array is outside the [min, max]. The values must
+// be deduplicated and sorted before calling Exclude or the results
+// are undefined.
+func (a *{{ $typename }}) FindRange(min, max int64) (int, int) {
+	if a.Len() == 0 || min > max {
+		return -1, -1
+	}
+
+	minVal := a.MinTime()
+	maxVal := a.MaxTime()
+
+	if maxVal < min || minVal > max {
+		return -1, -1
+	}
+
+	return a.search(min), a.search(max)
+}
+
+{{- if $hasType }}
 // Exclude removes the subset of values in [min, max]. The values must
 // be deduplicated and sorted before calling Exclude or the results are undefined.
 func (a *{{ $typename }}) Exclude(min, max int64) {
@@ -92,50 +141,6 @@ func (a *{{ $typename }}) Include(min, max int64) {
 		a.Timestamps = a.Timestamps[:rmax]
 		a.Values = a.Values[:rmax]
 	}
-}
-
-// search performs a binary search for UnixNano() v in a
-// and returns the position, i, where v would be inserted.
-// An additional check of a.Timestamps[i] == v is necessary
-// to determine if the value v exists.
-func (a *{{ $typename }}) search(v int64) int {
-	// Define: f(x) → a.Timestamps[x] < v
-	// Define: f(-1) == true, f(n) == false
-	// Invariant: f(lo-1) == true, f(hi) == false
-	lo := 0
-	hi := a.Len()
-	for lo < hi {
-		mid := int(uint(lo+hi) >> 1)
-		if a.Timestamps[mid] < v {
-			lo = mid + 1 // preserves f(lo-1) == true
-		} else {
-			hi = mid // preserves f(hi) == false
-		}
-	}
-
-	// lo == hi
-	return lo
-}
-
-// FindRange returns the positions where min and max would be
-// inserted into the array. If a[0].UnixNano() > max or
-// a[len-1].UnixNano() < min then FindRange returns (-1, -1)
-// indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
-// are undefined.
-func (a *{{ $typename }}) FindRange(min, max int64) (int, int) {
-	if a.Len() == 0 || min > max {
-		return -1, -1
-	}
-
-	minVal := a.MinTime()
-	maxVal := a.MaxTime()
-
-	if maxVal < min || minVal > max {
-		return -1, -1
-	}
-
-	return a.search(min), a.search(max)
 }
 
 // Merge overlays b to top of a.  If two values conflict with
@@ -204,5 +209,56 @@ func (a *{{ $typename }}) Merge(b *{{ $typename }}) {
 	a.Timestamps = out.Timestamps[:k]
 	a.Values = out.Values[:k]
 }
+{{ else }}
+// Exclude removes the subset of timestamps in [min, max]. The timestamps must
+// be deduplicated and sorted before calling Exclude or the results are undefined.
+func (a *{{ $typename }}) Exclude(min, max int64) {
+	rmin, rmax := a.FindRange(min, max)
+	if rmin == -1 && rmax == -1 {
+		return
+	}
+
+	// a.Timestamps[rmin] ≥ min
+	// a.Timestamps[rmax] ≥ max
+
+	if rmax < a.Len() {
+		if a.Timestamps[rmax] == max {
+			rmax++
+		}
+		rest := a.Len()-rmax
+		if rest > 0 {
+			ts := a.Timestamps[:rmin+rest]
+			copy(ts[rmin:], a.Timestamps[rmax:])
+			a.Timestamps = ts
+			return
+		}
+	}
+
+	a.Timestamps = a.Timestamps[:rmin]
+}
+
+// Contains returns true if values exist between min and max inclusive. The
+// values must be deduplicated and sorted before calling Contains or the
+// results are undefined.
+func (a *{{ $typename }}) Contains(min, max int64) bool {
+	rmin, rmax := a.FindRange(min, max)
+	if rmin == -1 && rmax == -1 {
+		return false
+	}
+
+	// a.Timestamps[rmin] ≥ min
+	// a.Timestamps[rmax] ≥ max
+
+	if a.Timestamps[rmin] == min {
+		return true
+	}
+
+	if rmax < a.Len() && a.Timestamps[rmax] == max {
+		return true
+	}
+
+	return rmax-rmin > 0
+}
+{{ end }}
 
 {{ end }}

--- a/tsdb/cursors/arrayvalues.gen.go.tmpl
+++ b/tsdb/cursors/arrayvalues.gen.go.tmpl
@@ -238,8 +238,7 @@ func (a *{{ $typename }}) Exclude(min, max int64) {
 }
 
 // Contains returns true if values exist between min and max inclusive. The
-// values must be deduplicated and sorted before calling Contains or the
-// results are undefined.
+// values must be sorted before calling Contains or the results are undefined.
 func (a *{{ $typename }}) Contains(min, max int64) bool {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {

--- a/tsdb/cursors/arrayvalues.gen.go.tmpl
+++ b/tsdb/cursors/arrayvalues.gen.go.tmpl
@@ -63,7 +63,7 @@ func (a *{{ $typename }}) search(v int64) int {
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
 // indicating the array is outside the [min, max]. The values must
-// be deduplicated and sorted before calling Exclude or the results
+// be deduplicated and sorted before calling FindRange or the results
 // are undefined.
 func (a *{{ $typename }}) FindRange(min, max int64) (int, int) {
 	if a.Len() == 0 || min > max {

--- a/tsdb/cursors/arrayvalues.gen.go.tmpldata
+++ b/tsdb/cursors/arrayvalues.gen.go.tmpldata
@@ -18,5 +18,9 @@
 	{
 		"Name":"Boolean",
 		"Type":"bool"
+	},
+	{
+		"Name":"Timestamp",
+		"Type": null
 	}
 ]

--- a/tsdb/cursors/arrayvalues.gen.go.tmpldata
+++ b/tsdb/cursors/arrayvalues.gen.go.tmpldata
@@ -1,27 +1,22 @@
 [
 	{
 		"Name":"Float",
-		"name":"float",
 		"Type":"float64"
 	},
 	{
 		"Name":"Integer",
-		"name":"integer",
 		"Type":"int64"
 	},
 	{
 		"Name":"Unsigned",
-		"name":"unsigned",
 		"Type":"uint64"
 	},
 	{
 		"Name":"String",
-		"name":"string",
 		"Type":"string"
 	},
 	{
 		"Name":"Boolean",
-		"name":"boolean",
 		"Type":"bool"
 	}
 ]

--- a/tsdb/cursors/arrayvalues.gen_test.go
+++ b/tsdb/cursors/arrayvalues.gen_test.go
@@ -122,6 +122,50 @@ func TestIntegerArray_Include(t *testing.T) {
 	}
 }
 
+func makeTimestampArray(count int, min, max int64) *TimestampArray {
+	vals := NewTimestampArrayLen(count)
+
+	ts := min
+	inc := (max - min) / int64(count)
+
+	for i := 0; i < count; i++ {
+		vals.Timestamps[i] = ts
+		ts += inc
+	}
+
+	return vals
+}
+
+func TestTimestampArray_Contains(t *testing.T) {
+	cases := []struct {
+		n        string
+		min, max int64
+		exp      bool
+	}{
+		{"no/lo", 0, 9, false},
+		{"no/hi", 19, 30, false},
+		{"no/middle", 13, 13, false},
+
+		{"yes/first", 0, 10, true},
+		{"yes/first-eq", 10, 10, true},
+		{"yes/last", 18, 20, true},
+		{"yes/last-eq", 18, 18, true},
+		{"yes/all but first and last", 12, 16, true},
+		{"yes/middle-eq", 14, 14, true},
+		{"yes/middle-overlap", 13, 15, true},
+		{"yes/covers", 8, 22, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s[%d,%d]", tc.n, tc.min, tc.max), func(t *testing.T) {
+			vals := makeTimestampArray(5, 10, 20)
+			if got := vals.Contains(tc.min, tc.max); got != tc.exp {
+				t.Errorf("Contains -got/+exp\n%s", cmp.Diff(got, tc.exp))
+			}
+		})
+	}
+}
+
 func benchExclude(b *testing.B, vals *IntegerArray, min, max int64) {
 	b.ResetTimer()
 

--- a/tsdb/cursors/gen.go
+++ b/tsdb/cursors/gen.go
@@ -1,0 +1,3 @@
+package cursors
+
+//go:generate env GO111MODULE=on go run github.com/benbjohnson/tmpl -data=@arrayvalues.gen.go.tmpldata arrayvalues.gen.go.tmpl

--- a/tsdb/cursors/string.go
+++ b/tsdb/cursors/string.go
@@ -1,0 +1,76 @@
+package cursors
+
+// StringIterator describes the behavior for enumerating a sequence of
+// string values.
+type StringIterator interface {
+	// Next advances the StringIterator to the next value. It returns false
+	// when there are no more values.
+	Next() bool
+
+	// Value returns the current value.
+	Value() string
+
+	Stats() CursorStats
+}
+
+// EmptyStringIterator is an implementation of StringIterator that returns
+// no values.
+var EmptyStringIterator StringIterator = &stringIterator{}
+
+type stringIterator struct{}
+
+func (*stringIterator) Next() bool         { return false }
+func (*stringIterator) Value() string      { return "" }
+func (*stringIterator) Stats() CursorStats { return CursorStats{} }
+
+type StringSliceIterator struct {
+	s []string
+	v string
+	i int
+}
+
+func NewStringSliceIterator(s []string) *StringSliceIterator {
+	return &StringSliceIterator{s: s, i: 0}
+}
+
+func (s *StringSliceIterator) Next() bool {
+	if s.i < len(s.s) {
+		s.v = s.s[s.i]
+		s.i++
+		return true
+	}
+	s.v = ""
+	return false
+}
+
+func (s *StringSliceIterator) Value() string {
+	return s.v
+}
+
+func (s *StringSliceIterator) Stats() CursorStats {
+	return CursorStats{}
+}
+
+func (s *StringSliceIterator) toSlice() []string {
+	if s.i < len(s.s) {
+		return s.s[s.i:]
+	}
+	return nil
+}
+
+// StringIteratorToSlice reads the remainder of i into a slice and
+// returns the result.
+func StringIteratorToSlice(i StringIterator) []string {
+	if i == nil {
+		return nil
+	}
+
+	if si, ok := i.(*StringSliceIterator); ok {
+		return si.toSlice()
+	}
+	var a []string
+	for i.Next() {
+		a = append(a, i.Value())
+	}
+	return a
+}

--- a/tsdb/tsm1/array_encoding.go
+++ b/tsdb/tsm1/array_encoding.go
@@ -110,3 +110,15 @@ func DecodeStringArrayBlock(block []byte, a *tsdb.StringArray) error {
 	a.Values, err = StringArrayDecodeAll(vb, a.Values)
 	return err
 }
+
+// DecodeTimestampArrayBlock decodes the timestamps from the specified
+// block, ignoring the block type and the values.
+func DecodeTimestampArrayBlock(block []byte, a *tsdb.TimestampArray) error {
+	tb, _, err := unpackBlock(block[1:])
+	if err != nil {
+		return err
+	}
+
+	a.Timestamps, err = TimeArrayDecodeAll(tb, a.Timestamps)
+	return err
+}

--- a/tsdb/tsm1/encoding.go
+++ b/tsdb/tsm1/encoding.go
@@ -114,6 +114,29 @@ func (a Values) Encode(buf []byte) ([]byte, error) {
 	return nil, fmt.Errorf("unsupported value type %T", a[0])
 }
 
+// Contains returns true if values exist for the time interval [min, max]
+// inclusive. The values must be deduplicated and sorted before calling
+// Contains or the results are undefined.
+func (a Values) Contains(min, max int64) bool {
+	rmin, rmax := a.FindRange(min, max)
+	if rmin == -1 && rmax == -1 {
+		return false
+	}
+
+	// a[rmin].UnixNano() ≥ min
+	// a[rmax].UnixNano() ≥ max
+
+	if a[rmin].UnixNano() == min {
+		return true
+	}
+
+	if rmax < a.Len() && a[rmax].UnixNano() == max {
+		return true
+	}
+
+	return rmax-rmin > 0
+}
+
 // InfluxQLType returns the influxql.DataType the values map to.
 func (a Values) InfluxQLType() (influxql.DataType, error) {
 	if len(a) == 0 {

--- a/tsdb/tsm1/encoding.go
+++ b/tsdb/tsm1/encoding.go
@@ -115,8 +115,8 @@ func (a Values) Encode(buf []byte) ([]byte, error) {
 }
 
 // Contains returns true if values exist for the time interval [min, max]
-// inclusive. The values must be deduplicated and sorted before calling
-// Contains or the results are undefined.
+// inclusive. The values must be sorted before calling Contains or the
+// results are undefined.
 func (a Values) Contains(min, max int64) bool {
 	rmin, rmax := a.FindRange(min, max)
 	if rmin == -1 && rmax == -1 {

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -1337,6 +1337,15 @@ func SeriesFieldKeyBytes(seriesKey, field string) []byte {
 	return b
 }
 
+// AppendSeriesFieldKeyBytes combines seriesKey and field such
+// that can be used to search a TSM index. The value is appended to dst and
+// the extended buffer returned.
+func AppendSeriesFieldKeyBytes(dst, seriesKey, field []byte) []byte {
+	dst = append(dst, seriesKey...)
+	dst = append(dst, KeyFieldSeparatorBytes...)
+	return append(dst, field...)
+}
+
 var (
 	blockToFieldType = [8]influxql.DataType{
 		BlockFloat64:  influxql.Float,

--- a/tsdb/tsm1/engine_schema.go
+++ b/tsdb/tsm1/engine_schema.go
@@ -20,20 +20,11 @@ import (
 func (e *Engine) TagValues(ctx context.Context, orgID, bucketID influxdb.ID, tagKey string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
 	encoded := tsdb.EncodeName(orgID, bucketID)
 
-	var tagKeyBytes []byte
-	if tagKey == "_measurement" {
-		tagKeyBytes = models.MeasurementTagKeyBytes
-	} else if tagKey == "_field" {
-		tagKeyBytes = models.FieldKeyTagKeyBytes
-	} else {
-		tagKeyBytes = []byte(tagKey)
-	}
-
 	if predicate == nil {
-		return e.tagValuesNoPredicate(ctx, encoded[:], tagKeyBytes, start, end)
+		return e.tagValuesNoPredicate(ctx, encoded[:], []byte(tagKey), start, end)
 	}
 
-	return e.tagValuesPredicate(ctx, encoded[:], tagKeyBytes, start, end, predicate)
+	return e.tagValuesPredicate(ctx, encoded[:], []byte(tagKey), start, end, predicate)
 }
 
 func (e *Engine) tagValuesNoPredicate(ctx context.Context, orgBucket, tagKeyBytes []byte, start, end int64) (cursors.StringIterator, error) {

--- a/tsdb/tsm1/engine_schema.go
+++ b/tsdb/tsm1/engine_schema.go
@@ -1,0 +1,256 @@
+package tsm1
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+	"github.com/influxdata/influxql"
+)
+
+// TagValues returns an iterator which enumerates the values for the specific
+// tagKey in the given bucket matching the predicate within the
+// time range (start, end].
+func (e *Engine) TagValues(ctx context.Context, orgID, bucketID influxdb.ID, tagKey string, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+	encoded := tsdb.EncodeName(orgID, bucketID)
+
+	var tagKeyBytes []byte
+	if tagKey == "_measurement" {
+		tagKeyBytes = models.MeasurementTagKeyBytes
+	} else if tagKey == "_field" {
+		tagKeyBytes = models.FieldKeyTagKeyBytes
+	} else {
+		tagKeyBytes = []byte(tagKey)
+	}
+
+	if predicate == nil {
+		return e.tagValuesNoPredicate(ctx, encoded[:], tagKeyBytes, start, end)
+	}
+
+	return e.tagValuesPredicate(ctx, encoded[:], tagKeyBytes, start, end, predicate)
+}
+
+func (e *Engine) tagValuesNoPredicate(ctx context.Context, orgBucket, tagKeyBytes []byte, start, end int64) (cursors.StringIterator, error) {
+	tsmValues := make(map[string]struct{})
+	var tags models.Tags
+
+	// TODO(edd): we need to clean up how we're encoding the prefix so that we
+	// don't have to remember to get it right everywhere we need to touch TSM data.
+	prefix := models.EscapeMeasurement(orgBucket)
+
+	// TODO(sgc): extend prefix when filtering by \x00 == <measurement>
+
+	e.FileStore.ForEachFile(func(f TSMFile) bool {
+		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(prefix, prefix) {
+			// TODO(sgc): create f.TimeRangeIterator(minKey, maxKey, start, end)
+			iter := f.TimeRangeIterator(prefix, start, end)
+			for i := 0; iter.Next(); i++ {
+				sfkey := iter.Key()
+				if !bytes.HasPrefix(sfkey, prefix) {
+					// end of org+bucket
+					break
+				}
+
+				key, _ := SeriesAndFieldFromCompositeKey(sfkey)
+				_, tags = models.ParseKeyBytesWithTags(key, tags[:0])
+				curVal := tags.Get(tagKeyBytes)
+				if len(curVal) == 0 {
+					continue
+				}
+
+				if _, ok := tsmValues[string(curVal)]; ok {
+					continue
+				}
+
+				if iter.HasData() {
+					tsmValues[string(curVal)] = struct{}{}
+				}
+			}
+		}
+		return true
+	})
+
+	_ = e.Cache.ApplyEntryFn(func(sfkey []byte, entry *entry) error {
+		if !bytes.HasPrefix(sfkey, prefix) {
+			return nil
+		}
+
+		key, _ := SeriesAndFieldFromCompositeKey(sfkey)
+		_, tags = models.ParseKeyBytesWithTags(key, tags[:0])
+		curVal := tags.Get(tagKeyBytes)
+		if len(curVal) == 0 {
+			return nil
+		}
+
+		if _, ok := tsmValues[string(curVal)]; ok {
+			return nil
+		}
+
+		if entry.values.Contains(start, end) {
+			tsmValues[string(curVal)] = struct{}{}
+		}
+		return nil
+	})
+
+	vals := make([]string, 0, len(tsmValues))
+	for val := range tsmValues {
+		vals = append(vals, val)
+	}
+	sort.Strings(vals)
+
+	return cursors.NewStringSliceIterator(vals), nil
+}
+
+func (e *Engine) tagValuesPredicate(ctx context.Context, orgBucket, tagKeyBytes []byte, start, end int64, predicate influxql.Expr) (cursors.StringIterator, error) {
+	if err := ValidateTagPredicate(predicate); err != nil {
+		return nil, err
+	}
+
+	keys, err := e.findCandidateKeys(ctx, orgBucket, predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	var files []TSMFile
+	defer func() {
+		for _, f := range files {
+			f.Unref()
+		}
+	}()
+	var iters []*TimeRangeIterator
+
+	// TODO(edd): we need to clean up how we're encoding the prefix so that we
+	// don't have to remember to get it right everywhere we need to touch TSM data.
+	prefix := models.EscapeMeasurement(orgBucket)
+
+	e.FileStore.ForEachFile(func(f TSMFile) bool {
+		if f.OverlapsTimeRange(start, end) && f.OverlapsKeyPrefixRange(prefix, prefix) {
+			f.Ref()
+			files = append(files, f)
+			iters = append(iters, f.TimeRangeIterator(prefix, start, end))
+		}
+		return true
+	})
+
+	tsmValues := make(map[string]struct{})
+
+	// reusable buffers
+	var (
+		tags   models.Tags
+		keybuf []byte
+		sfkey  []byte
+	)
+
+	for i := range keys {
+		_, tags = tsdb.ParseSeriesKeyInto(keys[i], tags[:0])
+		curVal := tags.Get(tagKeyBytes)
+		if len(curVal) == 0 {
+			continue
+		}
+
+		if _, ok := tsmValues[string(curVal)]; ok {
+			continue
+		}
+
+		keybuf = models.AppendMakeKey(keybuf[:0], prefix, tags)
+		sfkey = AppendSeriesFieldKeyBytes(sfkey[:0], keybuf, tags.Get(models.FieldKeyTagKeyBytes))
+
+		if e.Cache.Values(sfkey).Contains(start, end) {
+			tsmValues[string(curVal)] = struct{}{}
+			continue
+		}
+
+		for _, iter := range iters {
+			if exact, _ := iter.Seek(sfkey); !exact {
+				continue
+			}
+
+			if iter.HasData() {
+				tsmValues[string(curVal)] = struct{}{}
+				break
+			}
+		}
+	}
+
+	vals := make([]string, 0, len(tsmValues))
+	for val := range tsmValues {
+		vals = append(vals, val)
+	}
+	sort.Strings(vals)
+
+	return cursors.NewStringSliceIterator(vals), nil
+}
+
+func (e *Engine) findCandidateKeys(ctx context.Context, orgBucket []byte, predicate influxql.Expr) ([][]byte, error) {
+	// determine candidate series keys
+	sitr, err := e.index.MeasurementSeriesByExprIterator(orgBucket, predicate)
+	if err != nil {
+		return nil, err
+	} else if sitr == nil {
+		return nil, nil
+	}
+	defer sitr.Close()
+
+	var keys [][]byte
+	for {
+		elem, err := sitr.Next()
+		if err != nil {
+			return nil, err
+		} else if elem.SeriesID.IsZero() {
+			break
+		}
+
+		key := e.sfile.SeriesKey(elem.SeriesID)
+		if len(key) == 0 {
+			continue
+		}
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+var errUnexpectedTagComparisonOperator = errors.New("unexpected tag comparison operator")
+
+func ValidateTagPredicate(expr influxql.Expr) (err error) {
+	influxql.WalkFunc(expr, func(node influxql.Node) {
+		if err != nil {
+			return
+		}
+
+		switch n := node.(type) {
+		case *influxql.BinaryExpr:
+			switch n.Op {
+			case influxql.EQ, influxql.NEQ, influxql.EQREGEX, influxql.NEQREGEX, influxql.OR, influxql.AND:
+			default:
+				err = errUnexpectedTagComparisonOperator
+			}
+
+			switch r := n.LHS.(type) {
+			case *influxql.VarRef:
+			case *influxql.BinaryExpr:
+			default:
+				err = fmt.Errorf("binary expression: LHS must be tag key reference, got: %T", r)
+			}
+
+			switch r := n.RHS.(type) {
+			case *influxql.StringLiteral:
+			case *influxql.RegexLiteral:
+			case *influxql.BinaryExpr:
+			default:
+				err = fmt.Errorf("binary expression: RHS must be string or regex, got: %T", r)
+			}
+		}
+	})
+	return err
+}

--- a/tsdb/tsm1/engine_schema_test.go
+++ b/tsdb/tsm1/engine_schema_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/tsdb/cursors"
 	"github.com/influxdata/influxdb/tsdb/tsm1"
 	"github.com/influxdata/influxql"
@@ -164,12 +165,12 @@ memB,host=EB,os=macOS value=1.3 201`)
 			exp: nil,
 		},
 
-		// _measurement tag
+		// models.MeasurementTagKey tag
 		{
 			name: "_measurement/all",
 			args: args{
 				org: 0,
-				key: "_measurement",
+				key: models.MeasurementTagKey,
 				min: 0,
 				max: 399,
 			},
@@ -179,7 +180,7 @@ memB,host=EB,os=macOS value=1.3 201`)
 			name: "_measurement/some",
 			args: args{
 				org: 0,
-				key: "_measurement",
+				key: models.MeasurementTagKey,
 				min: 205,
 				max: 399,
 			},

--- a/tsdb/tsm1/engine_schema_test.go
+++ b/tsdb/tsm1/engine_schema_test.go
@@ -1,0 +1,281 @@
+package tsm1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+	"github.com/influxdata/influxdb/tsdb/tsm1"
+	"github.com/influxdata/influxql"
+)
+
+func TestEngine_TagValues(t *testing.T) {
+	e, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Open(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+
+	orgs := []struct {
+		org, bucket influxdb.ID
+	}{
+		{
+			org:    0x5020,
+			bucket: 0x5100,
+		},
+		{
+			org:    0x6000,
+			bucket: 0x6100,
+		},
+	}
+
+	// this org will require escaping the 0x20 byte
+	e.MustWritePointsString(orgs[0].org, orgs[0].bucket, `
+cpuA,host=0A,os=linux value=1.1 101
+cpuA,host=AA,os=linux value=1.2 102
+cpuA,host=AA,os=linux value=1.3 104
+cpuA,host=CA,os=linux value=1.3 104
+cpuA,host=CA,os=linux value=1.3 105
+cpuA,host=DA,os=macOS value=1.3 106
+memA,host=DA,os=macOS value=1.3 101`)
+	e.MustWritePointsString(orgs[1].org, orgs[1].bucket, `
+cpuB,host=0B,os=linux value=1.1 101
+cpuB,host=AB,os=linux value=1.2 102
+cpuB,host=AB,os=linux value=1.3 104
+cpuB,host=CB,os=linux value=1.3 104
+cpuB,host=CB,os=linux value=1.3 105
+cpuB,host=DB,os=macOS value=1.3 106
+memB,host=DB,os=macOS value=1.3 101`)
+
+	// send some points to TSM data
+	e.MustWriteSnapshot()
+
+	// delete some data from the first bucket
+	e.MustDeleteBucketRange(orgs[0].org, orgs[0].bucket, 0, 105)
+
+	// leave some points in the cache
+	e.MustWritePointsString(orgs[0].org, orgs[0].bucket, `
+cpuA,host=0A,os=linux value=1.1 201
+cpuA,host=AA,os=linux value=1.2 202
+cpuA,host=AA,os=linux value=1.3 204
+cpuA,host=BA,os=macOS value=1.3 204
+cpuA,host=BA,os=macOS value=1.3 205
+cpuA,host=EA,os=linux value=1.3 206
+memA,host=EA,os=linux value=1.3 201`)
+	e.MustWritePointsString(orgs[1].org, orgs[1].bucket, `
+cpuB,host=0B,os=linux value=1.1 201
+cpuB,host=AB,os=linux value=1.2 202
+cpuB,host=AB,os=linux value=1.3 204
+cpuB,host=BB,os=linux value=1.3 204
+cpuB,host=BB,os=linux value=1.3 205
+cpuB,host=EB,os=macOS value=1.3 206
+memB,host=EB,os=macOS value=1.3 201`)
+
+	type args struct {
+		org      int
+		key      string
+		min, max int64
+		expr     string
+	}
+
+	var tests = []struct {
+		name string
+		args args
+		exp  []string
+	}{
+		// ***********************
+		// * queries for the first org, which has some deleted data
+		// ***********************
+
+		// host tag
+		{
+			name: "TSM and cache",
+			args: args{
+				org: 0,
+				key: "host",
+				min: 0,
+				max: 300,
+			},
+			exp: []string{"0A", "AA", "BA", "DA", "EA"},
+		},
+		{
+			name: "only TSM",
+			args: args{
+				org: 0,
+				key: "host",
+				min: 0,
+				max: 199,
+			},
+			exp: []string{"DA"},
+		},
+		{
+			name: "only cache",
+			args: args{
+				org: 0,
+				key: "host",
+				min: 200,
+				max: 299,
+			},
+			exp: []string{"0A", "AA", "BA", "EA"},
+		},
+		{
+			name: "one timestamp TSM/data",
+			args: args{
+				org: 0,
+				key: "host",
+				min: 106,
+				max: 106,
+			},
+			exp: []string{"DA"},
+		},
+		{
+			name: "one timestamp cache/data",
+			args: args{
+				org: 0,
+				key: "host",
+				min: 201,
+				max: 201,
+			},
+			exp: []string{"0A", "EA"},
+		},
+		{
+			name: "one timestamp TSM/nodata",
+			args: args{
+				org: 0,
+				key: "host",
+				min: 103,
+				max: 103,
+			},
+			exp: nil,
+		},
+		{
+			name: "one timestamp cache/nodata",
+			args: args{
+				org: 0,
+				key: "host",
+				min: 203,
+				max: 203,
+			},
+			exp: nil,
+		},
+
+		// _measurement tag
+		{
+			name: "_measurement/all",
+			args: args{
+				org: 0,
+				key: "_measurement",
+				min: 0,
+				max: 399,
+			},
+			exp: []string{"cpuA", "memA"},
+		},
+		{
+			name: "_measurement/some",
+			args: args{
+				org: 0,
+				key: "_measurement",
+				min: 205,
+				max: 399,
+			},
+			exp: []string{"cpuA"},
+		},
+
+		// queries with predicates
+		{
+			name: "predicate/macOS",
+			args: args{
+				org:  0,
+				key:  "host",
+				min:  0,
+				max:  300,
+				expr: `os = 'macOS'`,
+			},
+			exp: []string{"BA", "DA"},
+		},
+		{
+			name: "predicate/linux",
+			args: args{
+				org:  0,
+				key:  "host",
+				min:  0,
+				max:  300,
+				expr: `os = 'linux'`,
+			},
+			exp: []string{"0A", "AA", "EA"},
+		},
+
+		// ***********************
+		// * queries for the second org, which has no deleted data
+		// ***********************
+		{
+			args: args{
+				org: 1,
+				key: "host",
+				min: 0,
+				max: 1000,
+			},
+			exp: []string{"0B", "AB", "BB", "CB", "DB", "EB"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tc.args
+			var expr influxql.Expr
+			if len(a.expr) > 0 {
+				expr = influxql.MustParseExpr(a.expr)
+			}
+
+			iter, err := e.TagValues(context.Background(), orgs[a.org].org, orgs[a.org].bucket, a.key, a.min, a.max, expr)
+			if err != nil {
+				t.Fatalf("TagValues: error %v", err)
+			}
+
+			got := cursors.StringIteratorToSlice(iter)
+			if !cmp.Equal(got, tc.exp) {
+				t.Errorf("unexpected TagValues: -got/+exp\n%v", cmp.Diff(got, tc.exp))
+			}
+		})
+	}
+}
+
+func TestValidateTagPredicate(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		{
+			expr:    `"_m" = 'foo'`,
+			wantErr: false,
+		},
+		{
+			expr:    `_m = 'foo'`,
+			wantErr: false,
+		},
+		{
+			expr:    `_m = foo`,
+			wantErr: true,
+		},
+		{
+			expr:    `_m = 5`,
+			wantErr: true,
+		},
+		{
+			expr:    `_m =~ //`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tsm1.ValidateTagPredicate(influxql.MustParseExpr(tt.expr)); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTagPredicate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -150,6 +150,12 @@ type TSMFile interface {
 	// allows sequential iteration to each and every block.
 	BlockIterator() *BlockIterator
 
+	// TimeRangeIterator returns an iterator over the keys, starting at the provided
+	// key. Calling the HasData accessor will return true if data exists for the
+	// interval [min, max] for the current key.
+	// Next must be called before calling any of the accessors.
+	TimeRangeIterator(key []byte, min, max int64) *TimeRangeIterator
+
 	// Free releases any resources held by the FileStore to free up system resources.
 	Free() error
 

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -79,6 +79,11 @@ type TSMFile interface {
 	// OverlapsKeyRange returns true if the key range of the file intersects min and max.
 	OverlapsKeyRange(min, max []byte) bool
 
+	// OverlapsKeyPrefixRange returns true if the key range of the file
+	// intersects min and max, evaluating up to the length of min and max
+	// of the key range.
+	OverlapsKeyPrefixRange(min, max []byte) bool
+
 	// TimeRange returns the min and max time across all keys in the file.
 	TimeRange() (int64, int64)
 
@@ -425,6 +430,31 @@ func (f *FileStore) Type(key []byte) (byte, error) {
 // Delete removes the keys from the set of keys available in this file.
 func (f *FileStore) Delete(keys [][]byte) error {
 	return f.DeleteRange(keys, math.MinInt64, math.MaxInt64)
+}
+
+type unrefs []TSMFile
+
+func (u *unrefs) Unref() {
+	for _, f := range *u {
+		f.Unref()
+	}
+}
+
+// ForEachFile calls fn for all TSM files or until fn returns false.
+// fn is called on the same goroutine as the caller.
+func (f *FileStore) ForEachFile(fn func(f TSMFile) bool) {
+	f.mu.RLock()
+	files := make(unrefs, 0, len(f.files))
+	defer files.Unref()
+
+	for _, f := range f.files {
+		f.Ref()
+		files = append(files, f)
+		if !fn(f) {
+			break
+		}
+	}
+	f.mu.RUnlock()
 }
 
 func (f *FileStore) Apply(fn func(r TSMFile) error) error {

--- a/tsdb/tsm1/reader.go
+++ b/tsdb/tsm1/reader.go
@@ -358,6 +358,13 @@ func (t *TSMReader) OverlapsKeyRange(min, max []byte) bool {
 	return t.index.OverlapsKeyRange(min, max)
 }
 
+// OverlapsKeyPrefixRange returns true if the key range of the file
+// intersects min and max, evaluating up to the length of min and max
+// of the key range.
+func (t *TSMReader) OverlapsKeyPrefixRange(min, max []byte) bool {
+	return t.index.OverlapsKeyPrefixRange(min, max)
+}
+
 // TimeRange returns the min and max time across all keys in the file.
 func (t *TSMReader) TimeRange() (int64, int64) {
 	return t.index.TimeRange()

--- a/tsdb/tsm1/reader.go
+++ b/tsdb/tsm1/reader.go
@@ -456,6 +456,25 @@ func (t *TSMReader) BlockIterator() *BlockIterator {
 	}
 }
 
+// TimeRangeIterator returns an iterator over the keys, starting at the provided
+// key. Calling the HasData accessor will return true if data exists for the
+// interval [min, max] for the current key.
+// Next must be called before calling any of the accessors.
+func (t *TSMReader) TimeRangeIterator(key []byte, min, max int64) *TimeRangeIterator {
+	t.mu.RLock()
+	iter := t.index.Iterator(key)
+	t.mu.RUnlock()
+
+	return &TimeRangeIterator{
+		r:    t,
+		iter: iter,
+		tr: TimeRange{
+			Min: min,
+			Max: max,
+		},
+	}
+}
+
 type BatchDeleter interface {
 	DeleteRange(keys [][]byte, min, max int64) error
 	Commit() error

--- a/tsdb/tsm1/reader_index.go
+++ b/tsdb/tsm1/reader_index.go
@@ -59,6 +59,11 @@ type TSMIndex interface {
 	// OverlapsKeyRange returns true if the min and max keys of the file overlap the arguments min and max.
 	OverlapsKeyRange(min, max []byte) bool
 
+	// OverlapsKeyPrefixRange returns true if the key range of the file
+	// intersects min and max, evaluating up to the length of min and max
+	// of the key range.
+	OverlapsKeyPrefixRange(min, max []byte) bool
+
 	// Size returns the size of the current index in bytes.
 	Size() uint32
 
@@ -623,6 +628,20 @@ func (d *indirectIndex) OverlapsTimeRange(min, max int64) bool {
 // OverlapsKeyRange returns true if the min and max keys of the file overlap the arguments min and max.
 func (d *indirectIndex) OverlapsKeyRange(min, max []byte) bool {
 	return bytes.Compare(d.minKey, max) <= 0 && bytes.Compare(d.maxKey, min) >= 0
+}
+
+// OverlapsKeyPrefixRange returns true if the key range of the file
+// intersects min and max, evaluating up to the length of min and max
+// of the key range.
+func (d *indirectIndex) OverlapsKeyPrefixRange(min, max []byte) bool {
+	minKey, maxKey := d.minKey, d.maxKey
+	if len(maxKey) > len(min) {
+		maxKey = maxKey[:len(min)]
+	}
+	if len(minKey) > len(max) {
+		minKey = minKey[:len(max)]
+	}
+	return bytes.Compare(minKey, max) <= 0 && bytes.Compare(maxKey, min) >= 0
 }
 
 // KeyRange returns the min and max keys in the index.

--- a/tsdb/tsm1/reader_index_iterator.go
+++ b/tsdb/tsm1/reader_index_iterator.go
@@ -1,8 +1,10 @@
 package tsm1
 
 import (
-	"fmt"
+	"errors"
 )
+
+var errKeyCountChanged = errors.New("TSMIndexIterator: key count changed during iteration")
 
 // TSMIndexIterator allows one to iterate over the TSM index.
 type TSMIndexIterator struct {
@@ -31,7 +33,7 @@ type TSMIndexIterator struct {
 func (t *TSMIndexIterator) Next() bool {
 	t.d.mu.RLock()
 	if n := len(t.d.ro.offsets); t.n != n {
-		t.err, t.ok = fmt.Errorf("Key count changed during iteration"), false
+		t.err, t.ok = errKeyCountChanged, false
 	}
 	if !t.ok || t.err != nil {
 		t.d.mu.RUnlock()
@@ -65,7 +67,7 @@ func (t *TSMIndexIterator) Next() bool {
 func (t *TSMIndexIterator) Seek(key []byte) (exact, ok bool) {
 	t.d.mu.RLock()
 	if n := len(t.d.ro.offsets); t.n != n {
-		t.err, t.ok = fmt.Errorf("Key count changed during iteration"), false
+		t.err, t.ok = errKeyCountChanged, false
 	}
 	if t.err != nil {
 		t.d.mu.RUnlock()

--- a/tsdb/tsm1/reader_index_iterator.go
+++ b/tsdb/tsm1/reader_index_iterator.go
@@ -59,6 +59,39 @@ func (t *TSMIndexIterator) Next() bool {
 	return true
 }
 
+// Seek points the iterator at the smallest key greater than or equal to the
+// given key, returning true if it was an exact match. It returns false for
+// ok if the key does not exist.
+func (t *TSMIndexIterator) Seek(key []byte) (exact, ok bool) {
+	t.d.mu.RLock()
+	if n := len(t.d.ro.offsets); t.n != n {
+		t.err, t.ok = fmt.Errorf("Key count changed during iteration"), false
+	}
+	if t.err != nil {
+		t.d.mu.RUnlock()
+		return false, false
+	}
+
+	t.peeked = false
+	t.first = false
+
+	exact, t.ok = t.iter.Seek(key, t.b)
+	if !t.ok {
+		t.d.mu.RUnlock()
+		return false, false
+	}
+
+	t.offset = t.iter.Offset()
+	t.eoffset = t.iter.EntryOffset(t.b)
+	t.d.mu.RUnlock()
+
+	// reset lazy loaded state
+	t.key = nil
+	t.typ = 0
+	t.entries = t.entries[:0]
+	return exact, true
+}
+
 // Peek reports the next key or nil if there is not one or an error happened.
 func (t *TSMIndexIterator) Peek() []byte {
 	if !t.ok || t.err != nil {

--- a/tsdb/tsm1/reader_index_iterator_test.go
+++ b/tsdb/tsm1/reader_index_iterator_test.go
@@ -51,6 +51,38 @@ func TestIndirectIndexIterator(t *testing.T) {
 	checkEqual(t, iter.Next(), false)
 	checkEqual(t, iter.Err(), error(nil))
 
+	// check can seek and iterate index
+	iter = ind.Iterator(nil)
+	exact, ok := iter.Seek([]byte("cpu2"))
+	checkEqual(t, exact, true)
+	checkEqual(t, ok, true)
+	checkEqual(t, iter.Key(), []byte("cpu2"))
+	checkEqual(t, iter.Type(), BlockInteger)
+	checkEqual(t, iter.Entries(), []IndexEntry{
+		{0, 10, 10, 20},
+		{10, 20, 10, 20},
+	})
+	checkEqual(t, iter.Next(), true)
+	checkEqual(t, iter.Key(), []byte("mem"))
+	checkEqual(t, iter.Next(), false)
+	exact, ok = iter.Seek([]byte("cpu1"))
+	checkEqual(t, exact, true)
+	checkEqual(t, ok, true)
+	checkEqual(t, iter.Key(), []byte("cpu1"))
+	exact, ok = iter.Seek([]byte("cpu3"))
+	checkEqual(t, exact, false)
+	checkEqual(t, ok, true)
+	checkEqual(t, iter.Key(), []byte("mem"))
+	exact, ok = iter.Seek([]byte("cpu0"))
+	checkEqual(t, exact, false)
+	checkEqual(t, ok, true)
+	checkEqual(t, iter.Key(), []byte("cpu1"))
+	exact, ok = iter.Seek([]byte("zzz"))
+	checkEqual(t, exact, false)
+	checkEqual(t, ok, false)
+	checkEqual(t, iter.Next(), false)
+	checkEqual(t, iter.Err(), error(nil))
+
 	// delete the cpu2 key and make sure it's skipped
 	ind.Delete([][]byte{[]byte("cpu2")})
 	iter = ind.Iterator(nil)

--- a/tsdb/tsm1/reader_range_iterator.go
+++ b/tsdb/tsm1/reader_range_iterator.go
@@ -1,0 +1,186 @@
+package tsm1
+
+import (
+	"github.com/influxdata/influxdb/tsdb"
+)
+
+// TimeRangeIterator will iterate over the keys of a TSM file, starting at
+// the provided key. It is used to determine if each key has data which exists
+// within a specified time interval.
+type TimeRangeIterator struct {
+	r    *TSMReader
+	iter *TSMIndexIterator
+	tr   TimeRange
+	err  error
+
+	// temporary storage
+	trbuf []TimeRange
+	buf   []byte
+	a     tsdb.TimestampArray
+}
+
+func (b *TimeRangeIterator) Err() error {
+	if b.err != nil {
+		return b.err
+	}
+	return b.iter.Err()
+}
+
+// Next advances the iterator and reports if it is still valid.
+func (b *TimeRangeIterator) Next() bool {
+	if b.Err() != nil {
+		return false
+	}
+
+	return b.iter.Next()
+}
+
+// Seek points the iterator at the smallest key greater than or equal to the
+// given key, returning true if it was an exact match. It returns false for
+// ok if the key does not exist.
+func (b *TimeRangeIterator) Seek(key []byte) (exact, ok bool) {
+	if b.Err() != nil {
+		return false, false
+	}
+
+	return b.iter.Seek(key)
+}
+
+// Key reports the current key.
+func (b *TimeRangeIterator) Key() []byte {
+	return b.iter.Key()
+}
+
+// HasData reports true if the current key has data for the time range.
+func (b *TimeRangeIterator) HasData() bool {
+	if b.Err() != nil {
+		return false
+	}
+
+	e := excludeEntries(b.iter.Entries(), b.tr)
+	if len(e) == 0 {
+		return false
+	}
+
+	b.trbuf = b.r.TombstoneRange(b.iter.Key(), b.trbuf[:0])
+	var ts []TimeRange
+	if len(b.trbuf) > 0 {
+		ts = excludeTimeRanges(b.trbuf, b.tr)
+	}
+
+	if len(ts) == 0 {
+		// no tombstones, fast path will avoid decoding blocks
+		// if queried time interval intersects with one of the entries
+		if intersectsEntry(e, b.tr) {
+			return true
+		}
+
+		for i := range e {
+			_, b.buf, b.err = b.r.ReadBytes(&e[i], b.buf)
+			if b.err != nil {
+				return false
+			}
+
+			b.err = DecodeTimestampArrayBlock(b.buf, &b.a)
+			if b.err != nil {
+				return false
+			}
+
+			if b.a.Contains(b.tr.Min, b.tr.Max) {
+				return true
+			}
+		}
+	} else {
+		for i := range e {
+			_, b.buf, b.err = b.r.ReadBytes(&e[i], b.buf)
+			if b.err != nil {
+				return false
+			}
+
+			b.err = DecodeTimestampArrayBlock(b.buf, &b.a)
+			if b.err != nil {
+				return false
+			}
+
+			// remove tombstoned timestamps
+			for i := range ts {
+				b.a.Exclude(ts[i].Min, ts[i].Max)
+			}
+
+			if b.a.Contains(b.tr.Min, b.tr.Max) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+/*
+intersectsEntry determines whether the range [min, max]
+intersects one or both boundaries of IndexEntry.
+
+          +------------------+
+          |    IndexEntry    |
++---------+------------------+---------+
+|  RANGE  |                  |  RANGE  |
++-+-------+-+           +----+----+----+
+  |  RANGE  |           |  RANGE  |
+  +----+----+-----------+---------+
+       |          RANGE           |
+       +--------------------------+
+*/
+
+// intersectsEntry determines if tr overlaps one or both boundaries
+// of at least one element of e. If that is the case,
+// and the block has no tombstones, the block timestamps do not
+// need to be decoded.
+func intersectsEntry(e []IndexEntry, tr TimeRange) bool {
+	for i := range e {
+		min, max := e[i].MinTime, e[i].MaxTime
+		if tr.Overlaps(min, max) && !tr.Within(min, max) {
+			return true
+		}
+	}
+	return false
+}
+
+// excludeEntries returns a slice which excludes leading and trailing
+// elements of e that are outside the time range specified by tr.
+func excludeEntries(e []IndexEntry, tr TimeRange) []IndexEntry {
+	for i := range e {
+		if e[i].OverlapsTimeRange(tr.Min, tr.Max) {
+			e = e[i:]
+			break
+		}
+	}
+
+	for i := range e {
+		if !e[i].OverlapsTimeRange(tr.Min, tr.Max) {
+			e = e[:i]
+			break
+		}
+	}
+
+	return e
+}
+
+// excludeTimeRanges returns a slice which excludes leading and trailing
+// elements of e that are outside the time range specified by tr.
+func excludeTimeRanges(e []TimeRange, tr TimeRange) []TimeRange {
+	for i := range e {
+		if e[i].Overlaps(tr.Min, tr.Max) {
+			e = e[i:]
+			break
+		}
+	}
+
+	for i := range e {
+		if !e[i].Overlaps(tr.Min, tr.Max) {
+			e = e[:i]
+			break
+		}
+	}
+
+	return e
+}

--- a/tsdb/tsm1/reader_range_iterator_test.go
+++ b/tsdb/tsm1/reader_range_iterator_test.go
@@ -1,0 +1,670 @@
+package tsm1
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
+)
+
+func TestTimeRangeIterator(t *testing.T) {
+	tsm := mustWriteTSM(
+		bucket{
+			org:    0x50,
+			bucket: 0x60,
+			w: writes(
+				mw("cpu",
+					kw("tag0=val0",
+						vals(tvi(1000, 1), tvi(1010, 2), tvi(1020, 3)),
+						vals(tvi(2000, 1), tvi(2010, 2), tvi(2020, 3)),
+					),
+					kw("tag0=val1",
+						vals(tvi(2000, 1), tvi(2010, 2), tvi(2020, 3)),
+						vals(tvi(3000, 1), tvi(3010, 2), tvi(3020, 3)),
+					),
+				),
+			),
+		},
+
+		bucket{
+			org:    0x51,
+			bucket: 0x61,
+			w: writes(
+				mw("mem",
+					kw("tag0=val0",
+						vals(tvi(1000, 1), tvi(1010, 2), tvi(1020, 3)),
+						vals(tvi(2000, 1), tvi(2010, 2), tvi(2020, 3)),
+					),
+					kw("tag0=val1",
+						vals(tvi(1000, 1), tvi(1010, 2), tvi(1020, 3)),
+						vals(tvi(2000, 1)),
+					),
+					kw("tag0=val2",
+						vals(tvi(2000, 1), tvi(2010, 2), tvi(2020, 3)),
+						vals(tvi(3000, 1), tvi(3010, 2), tvi(3020, 3)),
+					),
+				),
+			),
+		},
+	)
+	defer tsm.RemoveAll()
+
+	orgBucket := func(org, bucket uint) []byte {
+		n := tsdb.EncodeName(influxdb.ID(org), influxdb.ID(bucket))
+		return n[:]
+	}
+
+	type args struct {
+		min int64
+		max int64
+	}
+
+	type res struct {
+		k       string
+		hasData bool
+	}
+
+	EXP := func(r ...interface{}) (rr []res) {
+		for i := 0; i+1 < len(r); i += 2 {
+			rr = append(rr, res{k: r[i].(string), hasData: r[i+1].(bool)})
+		}
+		return
+	}
+
+	type test struct {
+		name    string
+		args    args
+		exp     []res
+		hasData []bool
+	}
+
+	type bucketTest struct {
+		org, bucket uint
+		m           string
+		tests       []test
+	}
+
+	r := tsm.TSMReader()
+
+	runTests := func(name string, tests []bucketTest) {
+		t.Run(name, func(t *testing.T) {
+			for _, bt := range tests {
+				key := orgBucket(bt.org, bt.bucket)
+				t.Run(fmt.Sprintf("0x%x-0x%x", bt.org, bt.bucket), func(t *testing.T) {
+					for _, tt := range bt.tests {
+						t.Run(tt.name, func(t *testing.T) {
+							iter := r.TimeRangeIterator(key, tt.args.min, tt.args.max)
+							count := 0
+							for i, exp := range tt.exp {
+								if !iter.Next() {
+									t.Errorf("Next(%d): expected true", i)
+								}
+
+								expKey := makeKey(influxdb.ID(bt.org), influxdb.ID(bt.bucket), bt.m, exp.k)
+								if got := iter.Key(); !cmp.Equal(got, expKey) {
+									t.Errorf("Key(%d): -got/+exp\n%v", i, cmp.Diff(got, expKey))
+								}
+
+								if got := iter.HasData(); got != exp.hasData {
+									t.Errorf("HasData(%d): -got/+exp\n%v", i, cmp.Diff(got, exp.hasData))
+								}
+								count++
+							}
+							if count != len(tt.exp) {
+								t.Errorf("count: -got/+exp\n%v", cmp.Diff(count, len(tt.exp)))
+							}
+						})
+
+					}
+				})
+			}
+		})
+	}
+
+	runTests("before delete", []bucketTest{
+		{
+			org:    0x50,
+			bucket: 0x60,
+			m:      "cpu",
+			tests: []test{
+				{
+					name: "cover file",
+					args: args{
+						min: 900,
+						max: 10000,
+					},
+					exp: EXP("tag0=val0", true, "tag0=val1", true),
+				},
+				{
+					name: "within block",
+					args: args{
+						min: 2001,
+						max: 2011,
+					},
+					exp: EXP("tag0=val0", true, "tag0=val1", true),
+				},
+				{
+					name: "to_2999",
+					args: args{
+						min: 0,
+						max: 2999,
+					},
+					exp: EXP("tag0=val0", true, "tag0=val1", true),
+				},
+				{
+					name: "intersects block",
+					args: args{
+						min: 1500,
+						max: 2500,
+					},
+					exp: EXP("tag0=val0", true, "tag0=val1", true),
+				},
+			},
+		},
+
+		{
+			org:    0x51,
+			bucket: 0x61,
+			m:      "mem",
+			tests: []test{
+				{
+					name: "cover file",
+					args: args{
+						min: 900,
+						max: 10000,
+					},
+					exp: EXP("tag0=val0", true, "tag0=val1", true, "tag0=val2", true),
+				},
+				{
+					name: "within block",
+					args: args{
+						min: 2001,
+						max: 2011,
+					},
+					exp: EXP("tag0=val0", true, "tag0=val1", false, "tag0=val2", true),
+				},
+				{
+					name: "1000_2999",
+					args: args{
+						min: 1000,
+						max: 2500,
+					},
+					exp: EXP("tag0=val0", true, "tag0=val1", true, "tag0=val2", true),
+				},
+			},
+		},
+	})
+
+	tsm.MustDeletePrefix(orgBucket(0x50, 0x60), 0, 2999)
+	tsm.MustDelete(makeKey(0x51, 0x61, "mem", "tag0=val0"))
+	tsm.MustDeleteRange(2000, 2999,
+		makeKey(0x51, 0x61, "mem", "tag0=val1"),
+		makeKey(0x51, 0x61, "mem", "tag0=val2"),
+	)
+
+	runTests("after delete", []bucketTest{
+		{
+			org:    0x50,
+			bucket: 0x60,
+			m:      "cpu",
+			tests: []test{
+				{
+					name: "cover file",
+					args: args{
+						min: 900,
+						max: 10000,
+					},
+					exp: EXP("tag0=val1", true),
+				},
+				{
+					name: "within block",
+					args: args{
+						min: 2001,
+						max: 2011,
+					},
+					exp: nil,
+				},
+				{
+					name: "to_2999",
+					args: args{
+						min: 0,
+						max: 2999,
+					},
+					exp: EXP("tag0=val1", false),
+				},
+				{
+					name: "intersects block",
+					args: args{
+						min: 1500,
+						max: 2500,
+					},
+					exp: EXP("tag0=val1", false),
+				},
+				{
+					name: "beyond all tombstones",
+					args: args{
+						min: 3000,
+						max: 4000,
+					},
+					exp: EXP("tag0=val1", true),
+				},
+			},
+		},
+
+		{
+			org:    0x51,
+			bucket: 0x61,
+			m:      "mem",
+			tests: []test{
+				{
+					name: "cover file",
+					args: args{
+						min: 900,
+						max: 10000,
+					},
+					exp: EXP("tag0=val1", true, "tag0=val2", true),
+				},
+				{
+					name: "within block",
+					args: args{
+						min: 2001,
+						max: 2011,
+					},
+					exp: EXP("tag0=val1", false, "tag0=val2", false),
+				},
+				{
+					name: "1000_2500",
+					args: args{
+						min: 1000,
+						max: 2500,
+					},
+					exp: EXP("tag0=val1", true, "tag0=val2", false),
+				},
+			},
+		},
+	})
+}
+
+func TestExcludeEntries(t *testing.T) {
+	entries := func(ts ...int64) (e []IndexEntry) {
+		for i := 0; i+1 < len(ts); i += 2 {
+			e = append(e, IndexEntry{MinTime: ts[i], MaxTime: ts[i+1]})
+		}
+		return
+	}
+
+	eq := func(a, b []IndexEntry) bool {
+		if len(a) == 0 && len(b) == 0 {
+			return true
+		}
+		return cmp.Equal(a, b)
+	}
+
+	type args struct {
+		e   []IndexEntry
+		min int64
+		max int64
+	}
+	tests := []struct {
+		name string
+		args args
+		exp  []IndexEntry
+	}{
+		{
+			args: args{
+				e:   entries(0, 10, 12, 15, 19, 21),
+				min: 11,
+				max: 13,
+			},
+			exp: entries(12, 15),
+		},
+		{
+			args: args{
+				e:   entries(0, 10, 12, 15, 19, 21),
+				min: 10,
+				max: 13,
+			},
+			exp: entries(0, 10, 12, 15),
+		},
+		{
+			args: args{
+				e:   entries(0, 10, 12, 15, 19, 21),
+				min: 12,
+				max: 30,
+			},
+			exp: entries(12, 15, 19, 21),
+		},
+		{
+			args: args{
+				e:   entries(0, 10, 12, 15, 19, 21),
+				min: 0,
+				max: 100,
+			},
+			exp: entries(0, 10, 12, 15, 19, 21),
+		},
+		{
+			args: args{
+				e:   entries(0, 10, 13, 15, 19, 21),
+				min: 11,
+				max: 12,
+			},
+			exp: entries(),
+		},
+		{
+			args: args{
+				e:   entries(12, 15, 19, 21),
+				min: 0,
+				max: 9,
+			},
+			exp: entries(),
+		},
+		{
+			args: args{
+				e:   entries(12, 15, 19, 21),
+				min: 22,
+				max: 30,
+			},
+			exp: entries(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := excludeEntries(tt.args.e, TimeRange{tt.args.min, tt.args.max}); !cmp.Equal(got, tt.exp, cmp.Comparer(eq)) {
+				t.Errorf("excludeEntries() -got/+exp\n%v", cmp.Diff(got, tt.exp))
+			}
+		})
+	}
+}
+
+func TestExcludeTimeRanges(t *testing.T) {
+	entries := func(ts ...int64) (e []TimeRange) {
+		for i := 0; i+1 < len(ts); i += 2 {
+			e = append(e, TimeRange{Min: ts[i], Max: ts[i+1]})
+		}
+		return
+	}
+
+	eq := func(a, b []TimeRange) bool {
+		if len(a) == 0 && len(b) == 0 {
+			return true
+		}
+		return cmp.Equal(a, b)
+	}
+
+	type args struct {
+		e   []TimeRange
+		min int64
+		max int64
+	}
+	tests := []struct {
+		name string
+		args args
+		exp  []TimeRange
+	}{
+		{
+			args: args{
+				e:   entries(0, 10, 12, 15, 19, 21),
+				min: 11,
+				max: 13,
+			},
+			exp: entries(12, 15),
+		},
+		{
+			args: args{
+				e:   entries(0, 10, 12, 15, 19, 21),
+				min: 10,
+				max: 13,
+			},
+			exp: entries(0, 10, 12, 15),
+		},
+		{
+			args: args{
+				e:   entries(0, 10, 12, 15, 19, 21),
+				min: 12,
+				max: 30,
+			},
+			exp: entries(12, 15, 19, 21),
+		},
+		{
+			args: args{
+				e:   entries(0, 10, 12, 15, 19, 21),
+				min: 0,
+				max: 100,
+			},
+			exp: entries(0, 10, 12, 15, 19, 21),
+		},
+		{
+			args: args{
+				e:   entries(0, 10, 13, 15, 19, 21),
+				min: 11,
+				max: 12,
+			},
+			exp: entries(),
+		},
+		{
+			args: args{
+				e:   entries(12, 15, 19, 21),
+				min: 0,
+				max: 9,
+			},
+			exp: entries(),
+		},
+		{
+			args: args{
+				e:   entries(12, 15, 19, 21),
+				min: 22,
+				max: 30,
+			},
+			exp: entries(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := excludeTimeRanges(tt.args.e, TimeRange{tt.args.min, tt.args.max}); !cmp.Equal(got, tt.exp, cmp.Comparer(eq)) {
+				t.Errorf("excludeEntries() -got/+exp\n%v", cmp.Diff(got, tt.exp))
+			}
+		})
+	}
+}
+
+func TestIntersectsEntries(t *testing.T) {
+	entries := func(ts ...int64) (e []IndexEntry) {
+		for i := 0; i+1 < len(ts); i += 2 {
+			e = append(e, IndexEntry{MinTime: ts[i], MaxTime: ts[i+1]})
+		}
+		return
+	}
+
+	type args struct {
+		e  []IndexEntry
+		tr TimeRange
+	}
+	tests := []struct {
+		name string
+		args args
+		exp  bool
+	}{
+		{
+			name: "",
+			args: args{
+				e:  entries(5, 10, 13, 15, 19, 21, 22, 27),
+				tr: TimeRange{6, 9},
+			},
+			exp: false,
+		},
+		{
+			args: args{
+				e:  entries(5, 10, 13, 15, 19, 21, 22, 27),
+				tr: TimeRange{11, 12},
+			},
+			exp: false,
+		},
+		{
+			args: args{
+				e:  entries(5, 10, 13, 15, 19, 21, 22, 27),
+				tr: TimeRange{2, 4},
+			},
+			exp: false,
+		},
+		{
+			args: args{
+				e:  entries(5, 10, 13, 15, 19, 21, 22, 27),
+				tr: TimeRange{28, 40},
+			},
+			exp: false,
+		},
+
+		{
+			args: args{
+				e:  entries(5, 10, 13, 15, 19, 21, 22, 27),
+				tr: TimeRange{3, 11},
+			},
+			exp: true,
+		},
+		{
+			args: args{
+				e:  entries(5, 10, 13, 15, 19, 21, 22, 27),
+				tr: TimeRange{5, 27},
+			},
+			exp: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := intersectsEntry(tt.args.e, tt.args.tr); got != tt.exp {
+				t.Errorf("excludeEntries() -got/+exp\n%v", cmp.Diff(got, tt.exp))
+			}
+		})
+	}
+}
+
+type bucket struct {
+	org, bucket influxdb.ID
+	w           []measurementWrite
+}
+
+func writes(w ...measurementWrite) []measurementWrite {
+	return w
+}
+
+type measurementWrite struct {
+	m string
+	w []keyWrite
+}
+
+func mw(m string, w ...keyWrite) measurementWrite {
+	return measurementWrite{m, w}
+}
+
+type keyWrite struct {
+	k string
+	w []Values
+}
+
+func kw(k string, w ...Values) keyWrite { return keyWrite{k, w} }
+func vals(tv ...Value) Values           { return tv }
+func tvi(ts int64, v int64) Value       { return NewIntegerValue(ts, v) }
+
+type tsmState struct {
+	dir  string
+	file string
+	r    *TSMReader
+}
+
+const fieldName = "v"
+
+func makeKey(org, bucket influxdb.ID, m string, k string) []byte {
+	name := tsdb.EncodeName(org, bucket)
+	line := string(m) + "," + k
+	tags := make(models.Tags, 1)
+	tags[0] = models.NewTag(models.MeasurementTagKeyBytes, []byte(m))
+	tags = append(tags, models.ParseTags([]byte(line))...)
+	tags = append(tags, models.NewTag(models.FieldKeyTagKeyBytes, []byte(fieldName)))
+	return SeriesFieldKeyBytes(string(models.MakeKey(name[:], tags)), fieldName)
+}
+
+func mustWriteTSM(writes ...bucket) (s *tsmState) {
+	dir := mustTempDir()
+	defer func() {
+		if s == nil {
+			_ = os.RemoveAll(dir)
+		}
+	}()
+
+	f := mustTempFile(dir)
+
+	w, err := NewTSMWriter(f)
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error creating writer: %v", err))
+	}
+
+	for _, ob := range writes {
+		for _, mw := range ob.w {
+			for _, kw := range mw.w {
+				key := makeKey(ob.org, ob.bucket, mw.m, kw.k)
+				for _, vw := range kw.w {
+					if err := w.Write(key, vw); err != nil {
+						panic(fmt.Sprintf("Write failed: %v", err))
+					}
+				}
+			}
+		}
+	}
+
+	if err := w.WriteIndex(); err != nil {
+		panic(fmt.Sprintf("WriteIndex: %v", err))
+	}
+
+	if err := w.Close(); err != nil {
+		panic(fmt.Sprintf("Close: %v", err))
+	}
+
+	fd, err := os.Open(f.Name())
+	if err != nil {
+		panic(fmt.Sprintf("os.Open: %v", err))
+	}
+
+	r, err := NewTSMReader(fd)
+	if err != nil {
+		panic(fmt.Sprintf("NewTSMReader: %v", err))
+	}
+
+	return &tsmState{
+		dir:  dir,
+		file: f.Name(),
+		r:    r,
+	}
+}
+
+func (s *tsmState) TSMReader() *TSMReader {
+	return s.r
+}
+
+func (s *tsmState) RemoveAll() {
+	_ = os.RemoveAll(s.dir)
+}
+
+func (s *tsmState) MustDeletePrefix(key []byte, min, max int64) {
+	err := s.r.DeletePrefix(key, min, max, nil)
+	if err != nil {
+		panic(fmt.Sprintf("DeletePrefix: %v", err))
+	}
+}
+
+func (s *tsmState) MustDelete(keys ...[]byte) {
+	err := s.r.Delete(keys)
+	if err != nil {
+		panic(fmt.Sprintf("Delete: %v", err))
+	}
+}
+
+func (s *tsmState) MustDeleteRange(min, max int64, keys ...[]byte) {
+	err := s.r.DeleteRange(keys, min, max)
+	if err != nil {
+		panic(fmt.Sprintf("DeleteRange: %v", err))
+	}
+}

--- a/tsdb/tsm1/reader_range_iterator_test.go
+++ b/tsdb/tsm1/reader_range_iterator_test.go
@@ -76,10 +76,9 @@ func TestTimeRangeIterator(t *testing.T) {
 	}
 
 	type test struct {
-		name    string
-		args    args
-		exp     []res
-		hasData []bool
+		name string
+		args args
+		exp  []res
 	}
 
 	type bucketTest struct {

--- a/tsdb/tsm1/reader_time_range.go
+++ b/tsdb/tsm1/reader_time_range.go
@@ -9,6 +9,12 @@ func (t TimeRange) Overlaps(min, max int64) bool {
 	return t.Min <= max && t.Max >= min
 }
 
+// Within returns true if min < t.Min and t.Max < max and therefore the interval [t.Min, t.Max] is
+// contained within [min, max]
+func (t TimeRange) Within(min, max int64) bool {
+	return min < t.Min && t.Max < max
+}
+
 func (t TimeRange) Less(o TimeRange) bool {
 	return t.Min < o.Min || (t.Min == o.Min && t.Max < o.Max)
 }


### PR DESCRIPTION
This PR has been separated into multiple commits in an effort to aid reviewers. Therefore it is my recommendation each commit is reviewed in isolation. 

Closes #13369

The implementation follows the RFC with the exception of one outstanding detail, noted in `engine_schema.go`:

> // TODO(sgc): extend prefix when filtering by `\x00 == <measurement>`

Should be addressed by completing issue #13497.

----

### Benchmarks

I will create some larger data sets with the `influxd generate` tools and run benchmarks to gather empirical evidence regarding the performance characteristics and any potential hotspots.


### Other observations

##### Extend internal index iterators

It would be worth extending `TSMIndexIterator` to support a min and optionally max prefix, to reduce the search space. I presented this scenario in the RFC:

> We can eliminate the prefix check in the linear scan by performing a binary search for the first and last keys of a given prefix (for org + measurement). That would change the number of prefix checks from O(log(M)+N) (for binary search to first over M total series keys + linear scan for N measurement keys) to O(2·log(M)) (two binary searches for first and last keys).

##### Excessive scans

There are cases where linear scanning a subset of the index for the current bucket (and / or measurement) may be wasteful. Two cases that come to mind are
* tag keys with low cardinality (e.g. `yes` and `no`) or 
* tag keys which sort further to the right within a series key

Those further to the right will change frequently such that we may discover the full set of values early within the scan. Low cardinality will depend on where the tag key is sorted in the key. 

For example, if the query is for tag key `~_f`, scanning the following may yield the distinct values (`usage_idle`, `usage_system` and `usage_user`) after three keys:

```text
_m=aaa,host=host01,region=us-east-01,~_f=usage_idle
_m=aaa,host=host01,region=us-east-01,~_f=usage_system
_m=aaa,host=host01,region=us-east-01,~_f=usage_user
_m=aaa,host=host01,region=us-west-01,~_f=usage_idle
_m=aaa,host=host01,region=us-west-01,~_f=usage_system
_m=aaa,host=host01,region=us-west-01,~_f=usage_user
_m=aaa,host=host02,region=us-east-01,~_f=usage_idle
_m=aaa,host=host02,region=us-east-01,~_f=usage_system
_m=aaa,host=host02,region=us-east-01,~_f=usage_user
_m=aaa,host=host02,region=us-west-01,~_f=usage_idle
_m=aaa,host=host02,region=us-west-01,~_f=usage_system
_m=aaa,host=host02,region=us-west-01,~_f=usage_user
```

It may be worth considering querying TSI and for low cardinality tag keys, read the set of potential values and early exit the scan once all have been seen.