### PR TITLE
Fix the sort order for aggregates so that they are sorted by tag and then time

### DIFF
--- a/query/iterator.gen.go
+++ b/query/iterator.gen.go
@@ -1115,6 +1115,8 @@ func (itr *floatReduceFloatIterator) reduce() ([]FloatPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -1123,13 +1125,17 @@ func (itr *floatReduceFloatIterator) reduce() ([]FloatPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]FloatPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(floatPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -1138,18 +1144,10 @@ func (itr *floatReduceFloatIterator) reduce() ([]FloatPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(floatPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -1395,6 +1393,8 @@ func (itr *floatReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -1403,13 +1403,17 @@ func (itr *floatReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]IntegerPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(integerPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -1418,18 +1422,10 @@ func (itr *floatReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(integerPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -1675,6 +1671,8 @@ func (itr *floatReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -1683,13 +1681,17 @@ func (itr *floatReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]UnsignedPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(unsignedPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -1698,18 +1700,10 @@ func (itr *floatReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(unsignedPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -1955,6 +1949,8 @@ func (itr *floatReduceStringIterator) reduce() ([]StringPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -1963,13 +1959,17 @@ func (itr *floatReduceStringIterator) reduce() ([]StringPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]StringPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(stringPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -1978,18 +1978,10 @@ func (itr *floatReduceStringIterator) reduce() ([]StringPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(stringPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -2235,6 +2227,8 @@ func (itr *floatReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -2243,13 +2237,17 @@ func (itr *floatReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]BooleanPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(booleanPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -2258,18 +2256,10 @@ func (itr *floatReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(booleanPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -3739,6 +3729,8 @@ func (itr *integerReduceFloatIterator) reduce() ([]FloatPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -3747,13 +3739,17 @@ func (itr *integerReduceFloatIterator) reduce() ([]FloatPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]FloatPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(floatPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -3762,18 +3758,10 @@ func (itr *integerReduceFloatIterator) reduce() ([]FloatPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(floatPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -4019,6 +4007,8 @@ func (itr *integerReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -4027,13 +4017,17 @@ func (itr *integerReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]IntegerPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(integerPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -4042,18 +4036,10 @@ func (itr *integerReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(integerPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -4299,6 +4285,8 @@ func (itr *integerReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -4307,13 +4295,17 @@ func (itr *integerReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]UnsignedPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(unsignedPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -4322,18 +4314,10 @@ func (itr *integerReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(unsignedPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -4579,6 +4563,8 @@ func (itr *integerReduceStringIterator) reduce() ([]StringPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -4587,13 +4573,17 @@ func (itr *integerReduceStringIterator) reduce() ([]StringPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]StringPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(stringPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -4602,18 +4592,10 @@ func (itr *integerReduceStringIterator) reduce() ([]StringPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(stringPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -4859,6 +4841,8 @@ func (itr *integerReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -4867,13 +4851,17 @@ func (itr *integerReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]BooleanPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(booleanPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -4882,18 +4870,10 @@ func (itr *integerReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(booleanPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -6363,6 +6343,8 @@ func (itr *unsignedReduceFloatIterator) reduce() ([]FloatPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -6371,13 +6353,17 @@ func (itr *unsignedReduceFloatIterator) reduce() ([]FloatPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]FloatPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(floatPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -6386,18 +6372,10 @@ func (itr *unsignedReduceFloatIterator) reduce() ([]FloatPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(floatPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -6643,6 +6621,8 @@ func (itr *unsignedReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -6651,13 +6631,17 @@ func (itr *unsignedReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]IntegerPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(integerPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -6666,18 +6650,10 @@ func (itr *unsignedReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(integerPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -6923,6 +6899,8 @@ func (itr *unsignedReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -6931,13 +6909,17 @@ func (itr *unsignedReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]UnsignedPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(unsignedPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -6946,18 +6928,10 @@ func (itr *unsignedReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(unsignedPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -7203,6 +7177,8 @@ func (itr *unsignedReduceStringIterator) reduce() ([]StringPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -7211,13 +7187,17 @@ func (itr *unsignedReduceStringIterator) reduce() ([]StringPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]StringPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(stringPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -7226,18 +7206,10 @@ func (itr *unsignedReduceStringIterator) reduce() ([]StringPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(stringPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -7483,6 +7455,8 @@ func (itr *unsignedReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -7491,13 +7465,17 @@ func (itr *unsignedReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]BooleanPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(booleanPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -7506,18 +7484,10 @@ func (itr *unsignedReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(booleanPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -8973,6 +8943,8 @@ func (itr *stringReduceFloatIterator) reduce() ([]FloatPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -8981,13 +8953,17 @@ func (itr *stringReduceFloatIterator) reduce() ([]FloatPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]FloatPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(floatPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -8996,18 +8972,10 @@ func (itr *stringReduceFloatIterator) reduce() ([]FloatPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(floatPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -9253,6 +9221,8 @@ func (itr *stringReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -9261,13 +9231,17 @@ func (itr *stringReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]IntegerPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(integerPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -9276,18 +9250,10 @@ func (itr *stringReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(integerPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -9533,6 +9499,8 @@ func (itr *stringReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -9541,13 +9509,17 @@ func (itr *stringReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]UnsignedPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(unsignedPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -9556,18 +9528,10 @@ func (itr *stringReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(unsignedPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -9813,6 +9777,8 @@ func (itr *stringReduceStringIterator) reduce() ([]StringPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -9821,13 +9787,17 @@ func (itr *stringReduceStringIterator) reduce() ([]StringPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]StringPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(stringPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -9836,18 +9806,10 @@ func (itr *stringReduceStringIterator) reduce() ([]StringPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(stringPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -10093,6 +10055,8 @@ func (itr *stringReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -10101,13 +10065,17 @@ func (itr *stringReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]BooleanPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(booleanPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -10116,18 +10084,10 @@ func (itr *stringReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(booleanPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -11583,6 +11543,8 @@ func (itr *booleanReduceFloatIterator) reduce() ([]FloatPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -11591,13 +11553,17 @@ func (itr *booleanReduceFloatIterator) reduce() ([]FloatPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]FloatPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(floatPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -11606,18 +11572,10 @@ func (itr *booleanReduceFloatIterator) reduce() ([]FloatPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(floatPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -11863,6 +11821,8 @@ func (itr *booleanReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -11871,13 +11831,17 @@ func (itr *booleanReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]IntegerPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(integerPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -11886,18 +11850,10 @@ func (itr *booleanReduceIntegerIterator) reduce() ([]IntegerPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(integerPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -12143,6 +12099,8 @@ func (itr *booleanReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -12151,13 +12109,17 @@ func (itr *booleanReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]UnsignedPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(unsignedPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -12166,18 +12128,10 @@ func (itr *booleanReduceUnsignedIterator) reduce() ([]UnsignedPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(unsignedPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -12423,6 +12377,8 @@ func (itr *booleanReduceStringIterator) reduce() ([]StringPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -12431,13 +12387,17 @@ func (itr *booleanReduceStringIterator) reduce() ([]StringPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]StringPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(stringPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -12446,18 +12406,10 @@ func (itr *booleanReduceStringIterator) reduce() ([]StringPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(stringPointsByTime(a)))
-	}
-
 	return a, nil
 }
 
@@ -12703,6 +12655,8 @@ func (itr *booleanReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -12711,13 +12665,17 @@ func (itr *booleanReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]BooleanPoint, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable(booleanPointsByTime(points))
+		}
 		for i := len(points) - 1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -12726,18 +12684,10 @@ func (itr *booleanReduceBooleanIterator) reduce() ([]BooleanPoint, error) {
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse(booleanPointsByTime(a)))
-	}
-
 	return a, nil
 }
 

--- a/query/iterator.gen.go.tmpl
+++ b/query/iterator.gen.go.tmpl
@@ -1119,6 +1119,8 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() ([]{{$v.Name}}Point, e
 	}
 
 	// Reverse sort points by name & tag if our output is supposed to be ordered.
+	// This is because the final array needs to have the first
+	// point at the end since they are popped off of the end.
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
@@ -1127,13 +1129,17 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() ([]{{$v.Name}}Point, e
 		sort.Sort(reverseStringSlice(keys))
 	}
 
-	// Assume the points are already sorted until proven otherwise.
-	sortedByTime := true
 	// Emit the points for each name & tag combination.
 	a := make([]{{$v.Name}}Point, 0, len(m))
 	for _, k := range keys {
 		rp := m[k]
 		points := rp.Emitter.Emit()
+		// If the points are meant to be ordered,
+		// ensure that is done here. The tags are already
+		// sorted and should remain sorted.
+		if len(points) > 1 && itr.opt.Ordered {
+			sort.Stable({{$v.name}}PointsByTime(points))
+		}
 		for i := len(points)-1; i >= 0; i-- {
 			points[i].Name = rp.Name
 			if !itr.keepTags {
@@ -1142,18 +1148,10 @@ func (itr *{{$k.name}}Reduce{{$v.Name}}Iterator) reduce() ([]{{$v.Name}}Point, e
 			// Set the points time to the interval time if the reducer didn't provide one.
 			if points[i].Time == ZeroTime {
 				points[i].Time = startTime
-			} else {
-				sortedByTime = false
 			}
 			a = append(a, points[i])
 		}
 	}
-
-	// Points may be out of order. Perform a stable sort by time if requested.
-	if !sortedByTime && itr.opt.Ordered {
-		sort.Stable(sort.Reverse({{$v.name}}PointsByTime(a)))
-	}
-
 	return a, nil
 }
 


### PR DESCRIPTION
The reduce iterators would read in the points for a window, which
matched the grouping of the outermost query, and then it would sort them
by the time before emitting the points.

When there were multiple series, this would sometimes cause a conflict
because it would change the sorting of the inner query output when
selectors were used within a subquery. Then, these emitted points would
be output in the wrong order and they wouldn't join correctly when
multiple cursors were used.

This fixes it so the sorting happens per series grouping rather than on
all of the points together so they retain their tag order which is the
correct sorting method.