### PR TITLE
fix(http): make getting labels orgID optional

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1856,7 +1856,6 @@ paths:
           - in: query
             name: orgID
             description: specifies the organization of the resource
-            required: true
             schema:
               type: string
       responses:


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/13401

get labels services are protected by authorizer, so have the orgID as optional, could provide more flexibility. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
