### PR TITLE
fix(http): fix the swagger for cell update

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6639,8 +6639,18 @@ components:
     CellUpdate:
       type: object
       properties:
-        name:
-          type: string
+        x:
+          type: integer
+          format: int32
+        "y": # Quoted to prevent YAML parser from interpreting y as shorthand for true.
+          type: integer
+          format: int32
+        w:
+          type: integer
+          format: int32
+        h:
+          type: integer
+          format: int32
     CreateCell:
       type: object
       properties:


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/13081

CellUpdate shouldn't update the name

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
