### PR TITLE
fix(influx_inspect): verify-seriesfile with deleted index entries

### DIFF
--- a/cmd/influx_inspect/verify/seriesfile/verify_test.go
+++ b/cmd/influx_inspect/verify/seriesfile/verify_test.go
@@ -102,8 +102,13 @@ func NewTest(t *testing.T) *Test {
 			tagsSlice = append(tagsSlice, nil)
 		}
 
-		_, err := seriesFile.CreateSeriesListIfNotExists(names, tagsSlice)
+		ids, err := seriesFile.CreateSeriesListIfNotExists(names, tagsSlice)
 		if err != nil {
+			return err
+		}
+
+		// delete one series
+		if err := seriesFile.DeleteSeriesID(ids[0]); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
The series index looks at a set of tombstones when querying the id for
a given key, but it does not look when asking for the offset for some
id, even if that id is deleted.

Update the verify tooling to check that the index agrees with the
deleted status of the id, but skip doing the extra checks if the
id is deleted.