### PR TITLE
Fix typos in tsdb package

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -213,7 +213,7 @@ func (itr *SeriesIDExprIterator) Next() (SeriesIDElem, error) {
 }
 
 // MergeSeriesIDIterators returns an iterator that merges a set of iterators.
-// Iterators that are first in the list take precendence and a deletion by those
+// Iterators that are first in the list take precedence and a deletion by those
 // early iterators will invalidate elements by later iterators.
 func MergeSeriesIDIterators(itrs ...SeriesIDIterator) SeriesIDIterator {
 	if n := len(itrs); n == 0 {
@@ -582,7 +582,7 @@ func (itr *measurementSliceIterator) Next() (name []byte, err error) {
 }
 
 // MergeMeasurementIterators returns an iterator that merges a set of iterators.
-// Iterators that are first in the list take precendence and a deletion by those
+// Iterators that are first in the list take precedence and a deletion by those
 // early iterators will invalidate elements by later iterators.
 func MergeMeasurementIterators(itrs ...MeasurementIterator) MeasurementIterator {
 	if len(itrs) == 0 {

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -209,7 +209,7 @@ func (f *SeriesFile) DisableCompactions() {
 // CreateSeriesListIfNotExists creates a list of series in bulk if they don't exist. It overwrites
 // the collection's Keys and SeriesIDs fields. The collection's SeriesIDs slice will have IDs for
 // every name+tags, creating new series IDs as needed. If any SeriesID is zero, then a type
-// conflict has occured for that series.
+// conflict has occurred for that series.
 func (f *SeriesFile) CreateSeriesListIfNotExists(collection *SeriesCollection) error {
 	collection.SeriesKeys = GenerateSeriesKeys(collection.Names, collection.Tags)
 	collection.SeriesIDs = make([]SeriesID, len(collection.SeriesKeys))

--- a/tsdb/series_segment.go
+++ b/tsdb/series_segment.go
@@ -302,12 +302,12 @@ func SplitSeriesOffset(offset int64) (segmentID uint16, pos uint32) {
 	return uint16((offset >> 32) & 0xFFFF), uint32(offset & 0xFFFFFFFF)
 }
 
-// IsValidSeriesSegmentFilename returns true if filename is a 4-character lowercase hexidecimal number.
+// IsValidSeriesSegmentFilename returns true if filename is a 4-character lowercase hexadecimal number.
 func IsValidSeriesSegmentFilename(filename string) bool {
 	return seriesSegmentFilenameRegex.MatchString(filename)
 }
 
-// ParseSeriesSegmentFilename returns the id represented by the hexidecimal filename.
+// ParseSeriesSegmentFilename returns the id represented by the hexadecimal filename.
 func ParseSeriesSegmentFilename(filename string) (uint16, error) {
 	i, err := strconv.ParseUint(filename, 16, 32)
 	return uint16(i), err

--- a/tsdb/tsi1/file_set.go
+++ b/tsdb/tsi1/file_set.go
@@ -459,7 +459,7 @@ type File interface {
 	TagKeySeriesIDIterator(name, key []byte) tsdb.SeriesIDIterator
 	TagValueSeriesIDSet(name, key, value []byte) (*tsdb.SeriesIDSet, error)
 
-	// Bitmap series existance.
+	// Bitmap series existence.
 	SeriesIDSet() (*tsdb.SeriesIDSet, error)
 	TombstoneSeriesIDSet() (*tsdb.SeriesIDSet, error)
 

--- a/tsdb/tsi1/partition.go
+++ b/tsdb/tsi1/partition.go
@@ -268,7 +268,7 @@ func (p *Partition) Open() (err error) {
 		}
 	}
 
-	// Build series existance set.
+	// Build series existence set.
 	if err := p.buildSeriesSet(); err != nil {
 		return err
 	}

--- a/tsdb/tsi1/tsi1.go
+++ b/tsdb/tsi1/tsi1.go
@@ -32,7 +32,7 @@ type MeasurementIterator interface {
 }
 
 // MergeMeasurementIterators returns an iterator that merges a set of iterators.
-// Iterators that are first in the list take precendence and a deletion by those
+// Iterators that are first in the list take precedence and a deletion by those
 // early iterators will invalidate elements by later iterators.
 func MergeMeasurementIterators(itrs ...MeasurementIterator) MeasurementIterator {
 	if len(itrs) == 0 {
@@ -180,7 +180,7 @@ func (itr *tsdbTagKeyIteratorAdapter) Next() ([]byte, error) {
 }
 
 // MergeTagKeyIterators returns an iterator that merges a set of iterators.
-// Iterators that are first in the list take precendence and a deletion by those
+// Iterators that are first in the list take precedence and a deletion by those
 // early iterators will invalidate elements by later iterators.
 func MergeTagKeyIterators(itrs ...TagKeyIterator) TagKeyIterator {
 	if len(itrs) == 0 {
@@ -318,7 +318,7 @@ func (itr *tsdbTagValueIteratorAdapter) Next() ([]byte, error) {
 }
 
 // MergeTagValueIterators returns an iterator that merges a set of iterators.
-// Iterators that are first in the list take precendence and a deletion by those
+// Iterators that are first in the list take precedence and a deletion by those
 // early iterators will invalidate elements by later iterators.
 func MergeTagValueIterators(itrs ...TagValueIterator) TagValueIterator {
 	if len(itrs) == 0 {

--- a/tsdb/tsm1/batch_integer_test.go
+++ b/tsdb/tsm1/batch_integer_test.go
@@ -41,7 +41,7 @@ func TestIntegerArrayEncodeAll_NoValues(t *testing.T) {
 	}
 
 	if len(b) > 0 {
-		t.Fatalf("unexpected lenght: exp 0, got %v", len(b))
+		t.Fatalf("unexpected length: exp 0, got %v", len(b))
 	}
 
 	var dec IntegerDecoder

--- a/tsdb/tsm1/bool.go
+++ b/tsdb/tsm1/bool.go
@@ -52,7 +52,7 @@ func (e *BooleanEncoder) Write(b bool) {
 	}
 
 	// Use 1 bit for each boolean value, shift the current byte
-	// by 1 and set the least signficant bit acordingly
+	// by 1 and set the least significant bit accordingly
 	e.b = e.b << 1
 	if b {
 		e.b |= 1

--- a/tsdb/tsm1/compact.go
+++ b/tsdb/tsm1/compact.go
@@ -1249,7 +1249,7 @@ type tsmKeyIterator struct {
 	// values is the temporary buffers for each key that is returned by a reader
 	values map[string][]Value
 
-	// pos is the current key postion within the corresponding readers slice.  A value of
+	// pos is the current key position within the corresponding readers slice.  A value of
 	// pos[0] = 1, means the reader[0] is currently at key 1 in its ordered index.
 	pos []int
 
@@ -1582,7 +1582,7 @@ type tsmBatchKeyIterator struct {
 	// values is the temporary buffers for each key that is returned by a reader
 	values map[string][]Value
 
-	// pos is the current key postion within the corresponding readers slice.  A value of
+	// pos is the current key position within the corresponding readers slice.  A value of
 	// pos[0] = 1, means the reader[0] is currently at key 1 in its ordered index.
 	pos []int
 

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -338,7 +338,7 @@ func (f *FileStore) Count() int {
 }
 
 // Files returns the slice of TSM files currently loaded. This is only used for
-// tests, and the files aren't guaranteed to stay valid in the presense of compactions.
+// tests, and the files aren't guaranteed to stay valid in the presence of compactions.
 func (f *FileStore) Files() []TSMFile {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/tsdb/tsm1/int_test.go
+++ b/tsdb/tsm1/int_test.go
@@ -17,7 +17,7 @@ func Test_IntegerEncoder_NoValues(t *testing.T) {
 	}
 
 	if len(b) > 0 {
-		t.Fatalf("unexpected lenght: exp 0, got %v", len(b))
+		t.Fatalf("unexpected length: exp 0, got %v", len(b))
 	}
 
 	var dec IntegerDecoder

--- a/tsdb/tsm1/reader_index.go
+++ b/tsdb/tsm1/reader_index.go
@@ -114,7 +114,7 @@ type indirectIndex struct {
 	// Using this offset slice we can find `Key 2` by doing a binary search
 	// over the offsets slice.  Instead of comparing the value in the offsets
 	// (e.g. `62`), we use that as an index into the underlying index to
-	// retrieve the key at postion `62` and perform our comparisons with that.
+	// retrieve the key at position `62` and perform our comparisons with that.
 
 	// When we have identified the correct position in the index for a given
 	// key, we could perform another binary search or a linear scan.  This

--- a/tsdb/tsm1/timestamp.go
+++ b/tsdb/tsm1/timestamp.go
@@ -27,7 +27,7 @@ package tsm1
 // next 1-10 bytes is the count of values.
 //
 // For simple8b encoding, the 4 low bits store the log10 of the scaling factor.  The next 8 bytes is the
-// first delta value stored uncompressed, the remaining bytes are 64bit words containg compressed delta
+// first delta value stored uncompressed, the remaining bytes are 64bit words containing compressed delta
 // values.
 //
 // For uncompressed encoding, the delta values are stored using 8 bytes each.


### PR DESCRIPTION
Fixes some typos in the `tsdb` package. Probably doesn't need a CHANGELOG entry.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
