### PR TITLE
fix(http): set org ID on event metric

### DIFF
--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -121,6 +121,7 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		EncodeError(ctx, err, w)
 		return
 	}
+	orgID = req.Request.OrganizationID
 	requestBytes = n
 
 	// Transform the context into one with the request's authorization.


### PR DESCRIPTION
Looks like this field was just mistakenly overlooked when it was
introduced.