### PR TITLE
feat(query): implement the read tag keys rpc call in the query engine

### DIFF
--- a/query/stdlib/influxdata/influxdb/operators.go
+++ b/query/stdlib/influxdata/influxdb/operators.go
@@ -12,7 +12,10 @@ import (
 	"github.com/influxdata/influxdb"
 )
 
-const ReadRangePhysKind = "ReadRangePhysKind"
+const (
+	ReadRangePhysKind   = "ReadRangePhysKind"
+	ReadTagKeysPhysKind = "ReadTagKeysPhysKind"
+)
 
 type ReadRangePhysSpec struct {
 	plan.DefaultCost
@@ -88,4 +91,20 @@ func (s *ReadRangePhysSpec) TimeBounds(predecessorBounds *plan.Bounds) *plan.Bou
 		Start: values.ConvertTime(s.Bounds.Start.Time(s.Bounds.Now)),
 		Stop:  values.ConvertTime(s.Bounds.Stop.Time(s.Bounds.Now)),
 	}
+}
+
+type ReadTagKeysPhysSpec struct {
+	ReadRangePhysSpec
+	ValueColumnName string
+}
+
+func (s *ReadTagKeysPhysSpec) Kind() plan.ProcedureKind {
+	return ReadTagKeysPhysKind
+}
+
+func (s *ReadTagKeysPhysSpec) Copy() plan.ProcedureSpec {
+	ns := new(ReadTagKeysPhysSpec)
+	ns.ReadRangePhysSpec = *s.ReadRangePhysSpec.Copy().(*ReadRangePhysSpec)
+	ns.ValueColumnName = s.ValueColumnName
+	return ns
 }

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 )
@@ -99,6 +102,219 @@ func TestPushDownRangeRule(t *testing.T) {
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("ReadRange", &readRangeSpec),
+					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
+					plan.CreatePhysicalNode("mean", &universe.MeanProcedureSpec{}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{0, 2},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
+func TestReadTagKeysRule(t *testing.T) {
+	fromSpec := influxdb.FromProcedureSpec{
+		Bucket: "my-bucket",
+	}
+	rangeSpec := universe.RangeProcedureSpec{
+		Bounds: flux.Bounds{
+			Start: fluxTime(5),
+			Stop:  fluxTime(10),
+		},
+	}
+	filterSpec := universe.FilterProcedureSpec{
+		Fn: &semantic.FunctionExpression{
+			Block: &semantic.FunctionBlock{
+				Parameters: &semantic.FunctionParameters{
+					List: []*semantic.FunctionParameter{{
+						Key: &semantic.Identifier{
+							Name: "r",
+						},
+					}},
+				},
+				Body: &semantic.BinaryExpression{
+					Operator: ast.EqualOperator,
+					Left: &semantic.MemberExpression{
+						Object: &semantic.IdentifierExpression{
+							Name: "r",
+						},
+						Property: "_measurement",
+					},
+					Right: &semantic.StringLiteral{
+						Value: "cpu",
+					},
+				},
+			},
+		},
+	}
+	keysSpec := universe.KeysProcedureSpec{
+		Column: execute.DefaultValueColLabel,
+	}
+	keepSpec := universe.SchemaMutationProcedureSpec{
+		Mutations: []universe.SchemaMutation{
+			&universe.KeepOpSpec{
+				Columns: []string{
+					execute.DefaultValueColLabel,
+				},
+			},
+		},
+	}
+	distinctSpec := universe.DistinctProcedureSpec{
+		Column: execute.DefaultValueColLabel,
+	}
+	readTagKeysSpec := func(filter bool) plan.PhysicalProcedureSpec {
+		s := influxdb.ReadTagKeysPhysSpec{
+			ReadRangePhysSpec: influxdb.ReadRangePhysSpec{
+				Bucket: "my-bucket",
+				Bounds: flux.Bounds{
+					Start: fluxTime(5),
+					Stop:  fluxTime(10),
+				},
+			},
+			ValueColumnName: execute.DefaultValueColLabel,
+		}
+		if filter {
+			s.FilterSet = true
+			s.Filter = filterSpec.Fn
+		}
+		return &s
+	}
+
+	tests := []plantest.RuleTestCase{
+		{
+			Name: "simple",
+			// from -> range -> keys -> keep -> distinct  =>  ReadTagKeys
+			Rules: []plan.Rule{
+				influxdb.PushDownRangeRule{},
+				influxdb.PushDownReadTagKeysRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &fromSpec),
+					plan.CreateLogicalNode("range", &rangeSpec),
+					plan.CreateLogicalNode("keys", &keysSpec),
+					plan.CreateLogicalNode("keep", &keepSpec),
+					plan.CreateLogicalNode("distinct", &distinctSpec),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadTagKeys", readTagKeysSpec(false)),
+				},
+			},
+		},
+		{
+			Name: "with filter",
+			// from -> range -> filter -> keys -> keep -> distinct  =>  ReadTagKeys
+			Rules: []plan.Rule{
+				influxdb.PushDownRangeRule{},
+				influxdb.PushDownFilterRule{},
+				influxdb.PushDownReadTagKeysRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &fromSpec),
+					plan.CreateLogicalNode("range", &rangeSpec),
+					plan.CreateLogicalNode("filter", &filterSpec),
+					plan.CreateLogicalNode("keys", &keysSpec),
+					plan.CreateLogicalNode("keep", &keepSpec),
+					plan.CreateLogicalNode("distinct", &distinctSpec),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+					{4, 5},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadTagKeys", readTagKeysSpec(true)),
+				},
+			},
+		},
+		{
+			Name: "with successor",
+			// from -> range -> keys -> keep -> distinct -> count  =>  ReadTagKeys -> count
+			Rules: []plan.Rule{
+				influxdb.PushDownRangeRule{},
+				influxdb.PushDownReadTagKeysRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &fromSpec),
+					plan.CreateLogicalNode("range", &rangeSpec),
+					plan.CreateLogicalNode("keys", &keysSpec),
+					plan.CreateLogicalNode("keep", &keepSpec),
+					plan.CreateLogicalNode("distinct", &distinctSpec),
+					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+					{4, 5},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadTagKeys", readTagKeysSpec(false)),
+					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
+				},
+				Edges: [][2]int{{0, 1}},
+			},
+		},
+		{
+			Name: "with multiple successors",
+			// count      mean
+			//     \     /          count     mean
+			//      range       =>      \    /
+			//        |               ReadTagKeys
+			//       from
+			Rules: []plan.Rule{
+				influxdb.PushDownRangeRule{},
+				influxdb.PushDownReadTagKeysRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &fromSpec),
+					plan.CreateLogicalNode("range", &rangeSpec),
+					plan.CreateLogicalNode("keys", &keysSpec),
+					plan.CreateLogicalNode("keep", &keepSpec),
+					plan.CreateLogicalNode("distinct", &distinctSpec),
+					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
+					plan.CreatePhysicalNode("mean", &universe.MeanProcedureSpec{}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+					{4, 5},
+					{4, 6},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadTagKeys", readTagKeysSpec(false)),
 					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
 					plan.CreatePhysicalNode("mean", &universe.MeanProcedureSpec{}),
 				},

--- a/query/stdlib/influxdata/influxdb/storage.go
+++ b/query/stdlib/influxdata/influxdb/storage.go
@@ -206,9 +206,15 @@ type ReadFilterSpec struct {
 	Predicate *semantic.FunctionExpression
 }
 
+type ReadTagKeysSpec struct {
+	ReadFilterSpec
+	ValueColumnName string
+}
+
 type Reader interface {
 	Read(ctx context.Context, rs ReadSpec, start, stop execute.Time, alloc *memory.Allocator) (TableIterator, error)
 	ReadFilter(ctx context.Context, spec ReadFilterSpec, alloc *memory.Allocator) (TableIterator, error)
+	ReadTagKeys(ctx context.Context, spec ReadTagKeysSpec, alloc *memory.Allocator) (TableIterator, error)
 	Close()
 }
 

--- a/storage/reads/reader.go
+++ b/storage/reads/reader.go
@@ -61,6 +61,26 @@ func (r *storeReader) ReadFilter(ctx context.Context, spec influxdb.ReadFilterSp
 	}, nil
 }
 
+func (r *storeReader) ReadTagKeys(ctx context.Context, spec influxdb.ReadTagKeysSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+	var predicate *datatypes.Predicate
+	if spec.Predicate != nil {
+		p, err := toStoragePredicate(spec.Predicate)
+		if err != nil {
+			return nil, err
+		}
+		predicate = p
+	}
+
+	return &tagKeysIterator{
+		ctx:       ctx,
+		bounds:    spec.Bounds,
+		s:         r.s,
+		readSpec:  spec,
+		predicate: predicate,
+		alloc:     alloc,
+	}, nil
+}
+
 func (r *storeReader) Close() {}
 
 type simpleTableIterator struct {
@@ -693,4 +713,72 @@ func groupKeyForGroup(kv [][]byte, readSpec *influxdb.ReadSpec, bnds execute.Bou
 		vs = append(vs, values.NewString(string(kv[i])))
 	}
 	return execute.NewGroupKey(cols, vs)
+}
+
+type tagKeysIterator struct {
+	ctx       context.Context
+	bounds    execute.Bounds
+	s         Store
+	readSpec  influxdb.ReadTagKeysSpec
+	predicate *datatypes.Predicate
+	alloc     *memory.Allocator
+}
+
+func (ti *tagKeysIterator) Do(f func(flux.Table) error) error {
+	src := ti.s.GetSource(
+		uint64(ti.readSpec.OrganizationID),
+		uint64(ti.readSpec.BucketID),
+	)
+
+	var req datatypes.TagKeysRequest
+	if any, err := types.MarshalAny(src); err != nil {
+		return err
+	} else {
+		req.TagsSource = any
+	}
+	req.Predicate = ti.predicate
+	req.Range.Start = int64(ti.bounds.Start)
+	req.Range.End = int64(ti.bounds.Stop)
+
+	rs, err := ti.s.TagKeys(ti.ctx, &req)
+	if err != nil {
+		return err
+	}
+	return ti.handleRead(f, rs)
+}
+
+func (ti *tagKeysIterator) handleRead(f func(flux.Table) error, rs cursors.StringIterator) error {
+	key := execute.NewGroupKey(nil, nil)
+	builder := execute.NewColListTableBuilder(key, ti.alloc)
+	valueIdx, err := builder.AddCol(flux.ColMeta{
+		Label: ti.readSpec.ValueColumnName,
+		Type:  flux.TString,
+	})
+	if err != nil {
+		return err
+	}
+	defer builder.ClearData()
+
+	for rs.Next() {
+		if err := builder.AppendString(valueIdx, rs.Value()); err != nil {
+			return err
+		}
+	}
+
+	// Construct the table and add to the reference count
+	// so we can free the table later.
+	tbl, err := builder.Table()
+	if err != nil {
+		return err
+	}
+	tbl.RefCount(1)
+	defer tbl.RefCount(-1)
+
+	// Release the references to the arrays held by the builder.
+	builder.ClearData()
+	return f(tbl)
+}
+
+func (ti *tagKeysIterator) Statistics() cursors.CursorStats {
+	return cursors.CursorStats{}
 }


### PR DESCRIPTION
If a pattern is seen that matches reading the tag keys, it will be
replaced with a direct RPC call to read the tag keys which should be
better optimized than reading from the storage engine tsm1 files.

Related to #12851.