### PR TITLE
test(task/scheduler): skip flakey parallel tests

### DIFF
--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestScheduler_Cancelation(t *testing.T) {
+	t.Skip("https://github.com/influxdata/influxdb/issues/13358")
 	t.Parallel()
 
 	tcs := mock.NewTaskControlService()
@@ -689,6 +690,7 @@ func TestScheduler_RunStatus(t *testing.T) {
 }
 
 func TestScheduler_RunFailureCleanup(t *testing.T) {
+	t.Skip("https://github.com/influxdata/influxdb/issues/13358")
 	t.Parallel()
 
 	tcs := mock.NewTaskControlService()


### PR DESCRIPTION

_Briefly describe your proposed changes:_
Skips flakey Task scheduler tests that seems that run slow and fail on Circle. See #13358 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
