### PR TITLE
feat(ui/buckets): add buckets danger zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [13473](https://github.com/influxdata/influxdb/pull/13473): Switch task back end to a more modular and flexible system
 1. [13493](https://github.com/influxdata/influxdb/pull/13493): Add org profile tab with ability to edit organization name
 1. [13510](https://github.com/influxdata/influxdb/pull/13510): Add org name to dahboard page title 
+1. [13520](https://github.com/influxdata/influxdb/pull/13520): Add cautioning to bucket renaming
 
 ### Bug Fixes
 

--- a/ui/cypress/e2e/buckets.test.ts
+++ b/ui/cypress/e2e/buckets.test.ts
@@ -35,9 +35,7 @@ describe('Buckets', () => {
         .and('contain', newBucket)
     })
 
-    it('can update a buckets name and retention rules', () => {
-      const newName = 'newdefbuck'
-
+    it("can update a bucket's retention rules", () => {
       cy.get<Bucket>('@bucket').then(({name}) => {
         cy.contains(name).click()
       })
@@ -52,16 +50,10 @@ describe('Buckets', () => {
       cy.getByInputName('seconds').type('{uparrow}')
 
       cy.getByTestID('overlay--container').within(() => {
-        cy.getByInputName('name')
-          .clear()
-          .type(newName)
-
         cy.contains('Save').click()
       })
 
-      cy.getByTestID('table-row')
-        .should('contain', '1 day')
-        .and('contain', newName)
+      cy.getByTestID('table-row').should('contain', '1 day')
     })
 
     it.skip('can delete a bucket', () => {

--- a/ui/src/buckets/actions/index.ts
+++ b/ui/src/buckets/actions/index.ts
@@ -14,6 +14,9 @@ import {
   bucketCreateFailed,
   bucketUpdateFailed,
   bucketDeleteFailed,
+  bucketUpdateSuccess,
+  bucketRenameSuccess,
+  bucketRenameFailed,
 } from 'src/shared/copy/v2/notifications'
 
 export type Action = SetBuckets | AddBucket | EditBucket | RemoveBucket
@@ -117,9 +120,25 @@ export const updateBucket = (updatedBucket: Bucket) => async (
     const bucket = await client.buckets.update(updatedBucket.id, updatedBucket)
 
     dispatch(editBucket(bucket))
+    dispatch(notify(bucketUpdateSuccess(updatedBucket.name)))
   } catch (e) {
     console.error(e)
     dispatch(notify(bucketUpdateFailed(updatedBucket.name)))
+  }
+}
+
+export const renameBucket = (
+  originalName: string,
+  updatedBucket: Bucket
+) => async (dispatch: Dispatch<Action>) => {
+  try {
+    const bucket = await client.buckets.update(updatedBucket.id, updatedBucket)
+
+    dispatch(editBucket(bucket))
+    dispatch(notify(bucketRenameSuccess(updatedBucket.name)))
+  } catch (e) {
+    console.error(e)
+    dispatch(notify(bucketRenameFailed(originalName)))
   }
 }
 

--- a/ui/src/buckets/components/BucketList.tsx
+++ b/ui/src/buckets/components/BucketList.tsx
@@ -5,9 +5,8 @@ import {connect} from 'react-redux'
 import {get} from 'lodash'
 
 // Components
-import UpdateBucketOverlay from 'src/buckets/components/UpdateBucketOverlay'
 import BucketRow, {PrettyBucket} from 'src/buckets/components/BucketRow'
-import {Overlay, IndexList} from 'src/clockface'
+import {IndexList} from 'src/clockface'
 
 // Actions
 import {setBucketInfo} from 'src/dataLoaders/actions/steps'
@@ -78,27 +77,14 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
             ))}
           </IndexList.Body>
         </IndexList>
-        <Overlay visible={this.isBucketOverlayVisible}>
-          <UpdateBucketOverlay
-            bucket={this.bucket}
-            onCloseModal={this.handleCloseModal}
-            onUpdateBucket={this.handleUpdateBucket}
-          />
-        </Overlay>
       </>
     )
   }
 
-  private get bucket(): PrettyBucket {
-    return this.props.buckets.find(b => b.id === this.state.bucketID)
-  }
-
-  private handleCloseModal = () => {
-    this.setState({bucketOverlayState: OverlayState.Closed})
-  }
-
   private handleStartEdit = (bucket: PrettyBucket) => {
-    this.setState({bucketID: bucket.id, bucketOverlayState: OverlayState.Open})
+    const {orgID} = this.props.params
+
+    this.props.router.push(`/orgs/${orgID}/buckets/${bucket.id}/edit`)
   }
 
   private handleStartAddData = (
@@ -120,11 +106,6 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
 
     onSetDataLoadersType(dataLoaderType)
     router.push(link)
-  }
-
-  private get isBucketOverlayVisible(): boolean {
-    const {bucketID, bucketOverlayState} = this.state
-    return !!bucketID && bucketOverlayState === OverlayState.Open
   }
 
   private handleUpdateBucket = async (updatedBucket: PrettyBucket) => {

--- a/ui/src/buckets/components/BucketOverlayForm.tsx
+++ b/ui/src/buckets/components/BucketOverlayForm.tsx
@@ -52,7 +52,11 @@ export default class BucketOverlayForm extends PureComponent<Props> {
         <Grid>
           <Grid.Row>
             <Grid.Column>
-              <Form.Element label="Name" errorMessage={nameErrorMessage}>
+              <Form.Element
+                label="Name"
+                errorMessage={nameErrorMessage}
+                helpText={this.nameHelpText}
+              >
                 <Input
                   placeholder="Give your bucket a name"
                   name="name"
@@ -95,6 +99,14 @@ export default class BucketOverlayForm extends PureComponent<Props> {
         </Grid>
       </Form>
     )
+  }
+
+  private get nameHelpText(): string {
+    if (this.props.nameInputStatus !== ComponentStatus.Disabled) {
+      return ''
+    }
+
+    return 'To rename the bucket use the rename button. Bucket renaming is not allowed here.'
   }
 
   private get submitButtonColor(): ComponentColor {

--- a/ui/src/buckets/components/BucketRow.tsx
+++ b/ui/src/buckets/components/BucketRow.tsx
@@ -1,15 +1,11 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
+import {withRouter, WithRouterProps, Link} from 'react-router'
 import _ from 'lodash'
 
 // Components
 import {IndexList, ConfirmationButton, Context} from 'src/clockface'
-import EditableName from 'src/shared/components/EditableName'
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
-
-// Constants
-import {DEFAULT_BUCKET_NAME} from 'src/dashboards/constants'
 
 // Types
 import {
@@ -17,6 +13,10 @@ import {
   ComponentSize,
   ComponentColor,
   IconFont,
+  Button,
+  ComponentSpacer,
+  AlignItems,
+  FlexDirection,
 } from '@influxdata/clockface'
 import {Alignment} from 'src/clockface'
 import {Bucket} from 'src/types'
@@ -42,22 +42,33 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
       <>
         <IndexList.Row>
           <IndexList.Cell>
-            <EditableName
-              onUpdate={this.handleUpdateBucketName}
-              name={bucket.name}
-              onEditName={this.handleEditBucket}
-              noNameString={DEFAULT_BUCKET_NAME}
-            />
+            <div className="editable-name">
+              <Link to={this.editBucketLink}>
+                <span>{bucket.name}</span>
+              </Link>
+            </div>
           </IndexList.Cell>
           <IndexList.Cell>{bucket.ruleString}</IndexList.Cell>
           <IndexList.Cell revealOnHover={true} alignment={Alignment.Right}>
-            <ConfirmationButton
-              size={ComponentSize.ExtraSmall}
-              text="Delete"
-              confirmText="Confirm"
-              onConfirm={onDeleteBucket}
-              returnValue={bucket}
-            />
+            <ComponentSpacer
+              alignItems={AlignItems.Center}
+              direction={FlexDirection.Row}
+              margin={ComponentSize.Small}
+            >
+              <Button
+                text="Rename"
+                onClick={this.handleRenameBucket}
+                color={ComponentColor.Danger}
+                size={ComponentSize.ExtraSmall}
+              />
+              <ConfirmationButton
+                size={ComponentSize.ExtraSmall}
+                text="Delete"
+                confirmText="Confirm"
+                onConfirm={onDeleteBucket}
+                returnValue={bucket}
+              />
+            </ComponentSpacer>
           </IndexList.Cell>
           <IndexList.Cell alignment={Alignment.Right}>
             <Context align={Alignment.Center}>
@@ -92,12 +103,23 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
     )
   }
 
-  private handleUpdateBucketName = async (value: string) => {
-    await this.props.onUpdateBucket({...this.props.bucket, name: value})
+  private handleRenameBucket = () => {
+    const {
+      params: {orgID},
+      bucket: {id},
+      router,
+    } = this.props
+
+    router.push(`/orgs/${orgID}/buckets/${id}/rename`)
   }
 
-  private handleEditBucket = (): void => {
-    this.props.onEditBucket(this.props.bucket)
+  private get editBucketLink(): string {
+    const {
+      params: {orgID},
+      bucket: {id},
+    } = this.props
+
+    return `/orgs/${orgID}/buckets/${id}/edit`
   }
 
   private handleAddCollector = (): void => {

--- a/ui/src/buckets/components/RenameBucketForm.tsx
+++ b/ui/src/buckets/components/RenameBucketForm.tsx
@@ -1,0 +1,169 @@
+// Libraries
+import React, {PureComponent, ChangeEvent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+import {connect} from 'react-redux'
+
+// Components
+import {ComponentStatus} from 'src/clockface'
+import {
+  Form,
+  Input,
+  Button,
+  ButtonType,
+  ComponentColor,
+  ComponentSpacer,
+  AlignItems,
+  FlexDirection,
+  ComponentSize,
+} from '@influxdata/clockface'
+
+// Actions
+import {renameBucket} from 'src/buckets/actions'
+
+// Types
+import {IBucket as Bucket} from '@influxdata/influx'
+import {AppState} from 'src/types'
+
+interface State {
+  bucket: Bucket
+}
+
+interface StateProps {
+  startBucket: Bucket
+  buckets: Bucket[]
+}
+
+interface DispatchProps {
+  onRenameBucket: typeof renameBucket
+}
+
+type OwnProps = {}
+
+type Props = StateProps & DispatchProps & WithRouterProps & OwnProps
+
+class RenameBucketForm extends PureComponent<Props, State> {
+  public state = {bucket: this.props.startBucket}
+
+  public render() {
+    const {bucket} = this.state
+
+    return (
+      <Form onSubmit={this.handleSubmit}>
+        <Form.ValidationElement
+          label="Name"
+          validationFunc={this.handleValidation}
+          value={bucket.name}
+        >
+          {status => (
+            <>
+              <ComponentSpacer
+                alignItems={AlignItems.Center}
+                direction={FlexDirection.Column}
+                margin={ComponentSize.Large}
+              >
+                <Input
+                  placeholder="Give your bucket a name"
+                  name="name"
+                  autoFocus={true}
+                  value={bucket.name}
+                  onChange={this.handleChangeInput}
+                  status={status}
+                />
+                <ComponentSpacer
+                  alignItems={AlignItems.Center}
+                  direction={FlexDirection.Row}
+                  margin={ComponentSize.Small}
+                >
+                  <Button
+                    text="Cancel"
+                    onClick={this.handleClose}
+                    type={ButtonType.Button}
+                  />
+                  <Button
+                    text="Change Bucket Name"
+                    color={ComponentColor.Danger}
+                    status={this.saveButtonStatus(status)}
+                    type={ButtonType.Submit}
+                  />
+                </ComponentSpacer>
+              </ComponentSpacer>
+            </>
+          )}
+        </Form.ValidationElement>
+      </Form>
+    )
+  }
+
+  private saveButtonStatus = (
+    validationStatus: ComponentStatus
+  ): ComponentStatus => {
+    if (
+      this.state.bucket.name === this.props.startBucket.name ||
+      validationStatus === ComponentStatus.Error
+    ) {
+      return ComponentStatus.Disabled
+    }
+
+    return validationStatus
+  }
+
+  private handleValidation = (bucketName: string): string | null => {
+    if (!bucketName) {
+      return 'Name is required'
+    }
+
+    if (this.props.buckets.find(b => b.name === bucketName)) {
+      return 'This bucket name is taken'
+    }
+  }
+
+  private handleSubmit = (): void => {
+    const {startBucket, onRenameBucket} = this.props
+    const {bucket} = this.state
+
+    onRenameBucket(startBucket.name, bucket)
+    this.handleClose()
+  }
+
+  private handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const name = e.target.value
+    const bucket = {...this.state.bucket, name}
+
+    this.setState({bucket})
+  }
+
+  private handleClose = () => {
+    const {
+      router,
+      params: {orgID},
+    } = this.props
+
+    router.push(`/orgs/${orgID}/buckets`)
+  }
+}
+
+const mstp = (state: AppState, props: Props): StateProps => {
+  const {
+    params: {bucketID},
+  } = props
+
+  const startBucket = state.buckets.list.find(b => b.id === bucketID)
+  const buckets = state.buckets.list.filter(b => b.id !== bucketID)
+
+  return {
+    startBucket,
+    buckets,
+  }
+}
+
+const mdtp: DispatchProps = {
+  onRenameBucket: renameBucket,
+}
+
+// state mapping requires router
+export default withRouter<OwnProps>(
+  connect<StateProps, DispatchProps, OwnProps>(
+    mstp,
+    mdtp
+  )(RenameBucketForm)
+)

--- a/ui/src/buckets/components/RenameBucketOverlay.tsx
+++ b/ui/src/buckets/components/RenameBucketOverlay.tsx
@@ -1,0 +1,54 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+
+import _ from 'lodash'
+
+// Components
+import DangerConfirmationOverlay from 'src/shared/components/dangerConfirmation/DangerConfirmationOverlay'
+import RenameBucketForm from 'src/buckets/components/RenameBucketForm'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+@ErrorHandling
+class RenameBucketOverlay extends PureComponent<WithRouterProps> {
+  public render() {
+    return (
+      <DangerConfirmationOverlay
+        title="Rename Bucket"
+        message={this.message}
+        effectedItems={this.effectedItems}
+        onClose={this.handleClose}
+        confirmButtonText="I understand, let's rename my Bucket"
+      >
+        <RenameBucketForm />
+      </DangerConfirmationOverlay>
+    )
+  }
+
+  private get message(): string {
+    return 'Updating the name of a Bucket can have unintended consequences. Anything that references this Bucket by name will stop working including:'
+  }
+
+  private get effectedItems(): string[] {
+    return [
+      'Queries',
+      'Dashboards',
+      'Tasks',
+      'Telegraf Configurations',
+      'Templates',
+    ]
+  }
+
+  private handleClose = () => {
+    const {
+      router,
+      params: {orgID},
+    } = this.props
+
+    router.push(`/orgs/${orgID}/buckets`)
+  }
+}
+
+export default withRouter(RenameBucketOverlay)

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -64,7 +64,8 @@ import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/Collec
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import AddMembersOverlay from 'src/members/components/AddMembersOverlay'
 import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
-import EditOrgProfileOverlay from 'src/organizations/components/EditOrgProfileOverlay'
+import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
+import UpdateBucketOverlay from 'src/buckets/components/UpdateBucketOverlay'
 
 // Actions
 import {disablePresentationMode} from 'src/shared/actions/app'
@@ -72,6 +73,7 @@ import {disablePresentationMode} from 'src/shared/actions/app'
 // Styles
 import 'src/style/chronograf.scss'
 import '@influxdata/clockface/dist/index.css'
+import RenameBucketOverlay from './buckets/components/RenameBucketOverlay'
 
 const rootNode = getRootNode()
 const basepath = getBasepath()
@@ -189,18 +191,28 @@ class Root extends PureComponent {
                             <IndexRoute component={MembersIndex} />
                           </Route>
                           <Route path="buckets" component={BucketsIndex}>
-                            <Route
-                              path=":bucketID/line-protocols/new"
-                              component={LineProtocolWizard}
-                            />
-                            <Route
-                              path=":bucketID/telegrafs/new"
-                              component={CollectorsWizard}
-                            />
-                            <Route
-                              path=":bucketID/scrapers/new"
-                              component={CreateScraperOverlay}
-                            />
+                            <Route path=":bucketID">
+                              <Route
+                                path="line-protocols/new"
+                                component={LineProtocolWizard}
+                              />
+                              <Route
+                                path="telegrafs/new"
+                                component={CollectorsWizard}
+                              />
+                              <Route
+                                path="scrapers/new"
+                                component={CreateScraperOverlay}
+                              />
+                              <Route
+                                path="edit"
+                                component={UpdateBucketOverlay}
+                              />
+                              <Route
+                                path="rename"
+                                component={RenameBucketOverlay}
+                              />
+                            </Route>
                           </Route>
                           <Route path="tokens" component={TokensIndex} />
                           <Route path="members" component={MembersIndex}>
@@ -253,10 +265,7 @@ class Root extends PureComponent {
                             />
                           </Route>
                           <Route path="profile" component={OrgProfilePage}>
-                            <Route
-                              path="edit"
-                              component={EditOrgProfileOverlay}
-                            />
+                            <Route path="rename" component={RenameOrgOverlay} />
                           </Route>
                         </Route>
                       </Route>

--- a/ui/src/organizations/actions/orgs.ts
+++ b/ui/src/organizations/actions/orgs.ts
@@ -17,6 +17,8 @@ import {
   bucketCreateFailed,
   orgEditSuccess,
   orgEditFailed,
+  orgRenameSuccess,
+  orgRenameFailed,
 } from 'src/shared/copy/v2/notifications'
 
 // Types
@@ -219,6 +221,19 @@ export const updateOrg = (org: Organization) => async (
     dispatch(notify(orgEditSuccess()))
   } catch (e) {
     dispatch(notify(orgEditFailed()))
+    console.error(e)
+  }
+}
+
+export const renameOrg = (originalName: string, org: Organization) => async (
+  dispatch: Dispatch<EditOrg | PublishNotificationAction>
+) => {
+  try {
+    const updatedOrg = await client.organizations.update(org.id, org)
+    dispatch(editOrg(updatedOrg))
+    dispatch(notify(orgRenameSuccess(updatedOrg.name)))
+  } catch (e) {
+    dispatch(notify(orgRenameFailed(originalName)))
     console.error(e)
   }
 }

--- a/ui/src/organizations/components/OrgProfileTab.tsx
+++ b/ui/src/organizations/components/OrgProfileTab.tsx
@@ -69,7 +69,7 @@ class OrgProfileTab extends PureComponent<Props> {
       router,
     } = this.props
 
-    router.push(`/orgs/${orgID}/profile/edit`)
+    router.push(`/orgs/${orgID}/profile/rename`)
   }
 }
 

--- a/ui/src/organizations/components/RenameOrgForm.tsx
+++ b/ui/src/organizations/components/RenameOrgForm.tsx
@@ -21,7 +21,7 @@ import {
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Actions
-import {updateOrg} from 'src/organizations/actions/orgs'
+import {renameOrg} from 'src/organizations/actions/orgs'
 
 // Types
 import {Organization} from '@influxdata/influx'
@@ -34,7 +34,7 @@ interface StateProps {
 }
 
 interface DispatchProps {
-  updateOrg: typeof updateOrg
+  onRenameOrg: typeof renameOrg
 }
 
 type Props = StateProps & DispatchProps & WithRouterProps
@@ -56,53 +56,51 @@ class RenameOrgForm extends PureComponent<Props, State> {
     const {org} = this.state
 
     return (
-      <>
-        <Form onSubmit={this.handleRenameOrg}>
-          <Form.ValidationElement
-            label="Name"
-            validationFunc={this.handleValidation}
-            value={org.name}
-          >
-            {status => (
-              <>
+      <Form onSubmit={this.handleRenameOrg}>
+        <Form.ValidationElement
+          label="Name"
+          validationFunc={this.handleValidation}
+          value={org.name}
+        >
+          {status => (
+            <>
+              <ComponentSpacer
+                alignItems={AlignItems.Center}
+                direction={FlexDirection.Column}
+                margin={ComponentSize.Large}
+              >
+                <Input
+                  placeholder="Give your organization a name"
+                  name="name"
+                  autoFocus={true}
+                  onChange={this.handleInputChange}
+                  value={org.name}
+                  status={status}
+                  testID="create-org-name-input"
+                />
                 <ComponentSpacer
                   alignItems={AlignItems.Center}
-                  direction={FlexDirection.Column}
-                  margin={ComponentSize.Large}
+                  direction={FlexDirection.Row}
+                  margin={ComponentSize.Small}
                 >
-                  <Input
-                    placeholder="Give your organization a name"
-                    name="name"
-                    autoFocus={true}
-                    onChange={this.handleInputChange}
-                    value={org.name}
-                    status={status}
-                    testID="create-org-name-input"
+                  <Button
+                    text="Cancel"
+                    icon={IconFont.Remove}
+                    onClick={this.handleGoBack}
                   />
-                  <ComponentSpacer
-                    alignItems={AlignItems.Center}
-                    direction={FlexDirection.Row}
-                    margin={ComponentSize.Small}
-                  >
-                    <Button
-                      text="Cancel"
-                      icon={IconFont.Remove}
-                      onClick={this.handleGoBack}
-                    />
-                    <Button
-                      text="Save"
-                      icon={IconFont.Checkmark}
-                      status={this.saveButtonStatus(status)}
-                      color={ComponentColor.Success}
-                      type={ButtonType.Submit}
-                    />
-                  </ComponentSpacer>
+                  <Button
+                    text="Change Organization Name"
+                    icon={IconFont.Checkmark}
+                    status={this.saveButtonStatus(status)}
+                    color={ComponentColor.Success}
+                    type={ButtonType.Submit}
+                  />
                 </ComponentSpacer>
-              </>
-            )}
-          </Form.ValidationElement>
-        </Form>
-      </>
+              </ComponentSpacer>
+            </>
+          )}
+        </Form.ValidationElement>
+      </Form>
     )
   }
 
@@ -145,9 +143,10 @@ class RenameOrgForm extends PureComponent<Props, State> {
   }
 
   private handleRenameOrg = async () => {
+    const {onRenameOrg, startOrg} = this.props
     const {org} = this.state
 
-    await this.props.updateOrg(org)
+    await onRenameOrg(startOrg.name, org)
 
     this.handleGoBack()
   }
@@ -164,10 +163,10 @@ const mstp = (state: AppState) => {
 }
 
 const mdtp = {
-  updateOrg,
+  onRenameOrg: renameOrg,
 }
 
 export default connect<StateProps, DispatchProps>(
   mstp,
   mdtp
-)(withRouter(RenameOrgForm))
+)(withRouter<{}>(RenameOrgForm))

--- a/ui/src/organizations/components/RenameOrgOverlay.tsx
+++ b/ui/src/organizations/components/RenameOrgOverlay.tsx
@@ -1,0 +1,54 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+
+import _ from 'lodash'
+
+// Components
+import DangerConfirmationOverlay from 'src/shared/components/dangerConfirmation/DangerConfirmationOverlay'
+import RenameOrgForm from 'src/organizations/components/RenameOrgForm'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+@ErrorHandling
+class RenameOrgOverlay extends PureComponent<WithRouterProps> {
+  public render() {
+    return (
+      <DangerConfirmationOverlay
+        title="Rename Organization"
+        message={this.message}
+        effectedItems={this.effectedItems}
+        onClose={this.handleClose}
+        confirmButtonText="I understand, let's rename my Organization"
+      >
+        <RenameOrgForm />
+      </DangerConfirmationOverlay>
+    )
+  }
+
+  private get message(): string {
+    return 'Updating the name of an Organization can have unintended consequences. Anything that references this Organization by name will stop working including:'
+  }
+
+  private get effectedItems(): string[] {
+    return [
+      'Queries',
+      'Dashboards',
+      'Tasks',
+      'Telegraf Configurations',
+      'Client Libraries',
+    ]
+  }
+
+  private handleClose = () => {
+    const {
+      router,
+      params: {orgID},
+    } = this.props
+
+    router.push(`/orgs/${orgID}/profile`)
+  }
+}
+
+export default withRouter(RenameOrgOverlay)

--- a/ui/src/shared/components/dangerConfirmation/DangerConfirmationForm.tsx
+++ b/ui/src/shared/components/dangerConfirmation/DangerConfirmationForm.tsx
@@ -19,16 +19,17 @@ import {Form} from 'src/clockface'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
+  message: string
+  effectedItems: string[]
   onConfirm: () => void
+  confirmButtonText: string
 }
 
 @ErrorHandling
-class EditOrgConfirmationForm extends PureComponent<Props> {
+class DangerConfirmationForm extends PureComponent<Props> {
   public render() {
-    const {onConfirm} = this.props
-
     return (
-      <Form onSubmit={onConfirm}>
+      <Form onSubmit={this.props.onConfirm}>
         <ComponentSpacer
           alignItems={AlignItems.Center}
           direction={FlexDirection.Column}
@@ -39,17 +40,11 @@ class EditOrgConfirmationForm extends PureComponent<Props> {
           </Alert>
           <Form.Element label="">
             <>
-              <p>
-                Updating the name of an Organization can have unintended
-                consequences. Anything that references this Organization by name
-                will stop working including:
-              </p>
+              <p>{this.props.message}</p>
               <ul>
-                <li>Queries</li>
-                <li>Dashboards</li>
-                <li>Tasks</li>
-                <li>Telegraf Configurations</li>
-                <li>Client Libraries</li>
+                {this.props.effectedItems.map(item => (
+                  <li key={item}>{item}</li>
+                ))}
               </ul>
             </>
           </Form.Element>
@@ -60,7 +55,7 @@ class EditOrgConfirmationForm extends PureComponent<Props> {
           >
             <Button
               color={ComponentColor.Danger}
-              text="I understand, let's rename my Organization"
+              text={this.props.confirmButtonText}
               type={ButtonType.Submit}
             />
           </ComponentSpacer>
@@ -70,4 +65,4 @@ class EditOrgConfirmationForm extends PureComponent<Props> {
   }
 }
 
-export default EditOrgConfirmationForm
+export default DangerConfirmationForm

--- a/ui/src/shared/components/dangerConfirmation/DangerConfirmationOverlay.tsx
+++ b/ui/src/shared/components/dangerConfirmation/DangerConfirmationOverlay.tsx
@@ -1,23 +1,27 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {WithRouterProps, withRouter} from 'react-router'
 
 import _ from 'lodash'
 
 // Components
 import {Overlay} from 'src/clockface'
-import RenameOrgForm from 'src/organizations/components/RenameOrgForm'
-import EditOrgConfirmationForm from 'src/organizations/components/EditOrgConfirmationForm'
+import DangerConfirmationForm from 'src/shared/components/dangerConfirmation/DangerConfirmationForm'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-type Props = WithRouterProps
+interface Props {
+  message: string
+  effectedItems: string[]
+  title: string
+  onClose: () => void
+  confirmButtonText: string
+}
 
 interface State {
   isConfirmed: boolean
 }
 
 @ErrorHandling
-class EditOrgProfileOverlay extends PureComponent<Props, State> {
+class DangerConfirmationOverlay extends PureComponent<Props, State> {
   public state = {
     isConfirmed: false,
   }
@@ -37,27 +41,33 @@ class EditOrgProfileOverlay extends PureComponent<Props, State> {
   }
 
   private get overlayTitle() {
+    const {title} = this.props
+
     if (this.state.isConfirmed) {
-      return 'Rename Organization'
+      return title
     }
 
     return 'Are you sure?'
   }
 
   private get overlayContents() {
+    const {message, effectedItems, confirmButtonText} = this.props
     if (this.state.isConfirmed) {
-      return <RenameOrgForm />
+      return this.props.children
     }
 
-    return <EditOrgConfirmationForm onConfirm={this.handleConfirm} />
+    return (
+      <DangerConfirmationForm
+        onConfirm={this.handleConfirm}
+        message={message}
+        effectedItems={effectedItems}
+        confirmButtonText={confirmButtonText}
+      />
+    )
   }
 
   private handleCloseOverlay = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-    router.push(`/orgs/${orgID}/profile`)
+    this.props.onClose()
   }
 
   private handleConfirm = () => {
@@ -65,4 +75,4 @@ class EditOrgProfileOverlay extends PureComponent<Props, State> {
   }
 }
 
-export default withRouter(EditOrgProfileOverlay)
+export default DangerConfirmationOverlay

--- a/ui/src/shared/copy/v2/notifications.ts
+++ b/ui/src/shared/copy/v2/notifications.ts
@@ -163,6 +163,16 @@ export const bucketUpdateFailed = (bucketName: string): Notification => ({
   message: `Failed to update bucket: "${bucketName}"`,
 })
 
+export const bucketRenameSuccess = (bucketName: string): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Bucket was successfully renamed "${bucketName}"`,
+})
+
+export const bucketRenameFailed = (bucketName: string): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to rename bucket "${bucketName}"`,
+})
+
 export const orgCreateSuccess = (): Notification => ({
   ...defaultSuccessNotification,
   message: 'Organization was successfully created',
@@ -181,6 +191,16 @@ export const orgEditSuccess = (): Notification => ({
 export const orgEditFailed = (): Notification => ({
   ...defaultErrorNotification,
   message: 'Failed to update organization',
+})
+
+export const orgRenameSuccess = (orgName: string): Notification => ({
+  ...defaultSuccessNotification,
+  message: `Organization was successfully renamed "${orgName}"`,
+})
+
+export const orgRenameFailed = (orgName): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to update organization "${orgName}"`,
 })
 
 export const scraperDeleteSuccess = (scraperName: string): Notification => ({

--- a/ui/src/types/dashboards.ts
+++ b/ui/src/types/dashboards.ts
@@ -104,7 +104,7 @@ export interface Dashboard extends Omit<DashboardAPI, 'cells'> {
   cells: Cell[]
 }
 
-type Omit<K, V> = Pick<K, Exclude<keyof K, V>>
+export type Omit<K, V> = Pick<K, Exclude<keyof K, V>>
 
 export type NewView<T extends ViewProperties = ViewProperties> = Omit<
   View<T>,


### PR DESCRIPTION
Closes #13494 

_Briefly describe your proposed changes:_
Adds a danger zone warning users about the perils of editing a bucket name.

![Screen Shot 2019-04-19 at 4 11 22 PM](https://user-images.githubusercontent.com/4994741/56442199-d564ba00-62bd-11e9-9c8f-16ebcf55b3ce.png)

![Screen Shot 2019-04-19 at 4 12 43 PM](https://user-images.githubusercontent.com/4994741/56442239-004f0e00-62be-11e9-83c2-904a701614e5.png)

![Screen Shot 2019-04-19 at 4 13 28 PM](https://user-images.githubusercontent.com/4994741/56442277-25438100-62be-11e9-99a7-d4a75e4be6e3.png)


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
