### PR TITLE
test(task/backend): skip flakey TestScheduler_Metrics

### DIFF
--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -773,6 +773,7 @@ func TestScheduler_RunFailureCleanup(t *testing.T) {
 }
 
 func TestScheduler_Metrics(t *testing.T) {
+	t.Skip("https://github.com/influxdata/influxdb/issues/13523")
 	t.Parallel()
 
 	tcs := mock.NewTaskControlService()


### PR DESCRIPTION

_Briefly describe your proposed changes:_
Skipping the flakey task test for backend. The TestScheduler_Metrics fails every now and again.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
