### PR TITLE
Fix ARM64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@ CMDS := \
 #
 # This target sets up the dependencies to correctly build all go commands.
 # Other targets must depend on this target to correctly builds CMDS.
-all: GO_ARGS=-tags 'assets $(GO_TAGS)'
+ifeq ($(GOARCH), arm64)
+    all: GO_ARGS=-tags ' assets noasm $(GO_TAGS)'
+else
+    all: GO_ARGS=-tags 'assets $(GO_TAGS)'
+endif
 all: subdirs generate $(CMDS)
 
 # Target to build subdirs.


### PR DESCRIPTION
This fixes builds for ARM64 -- which requires the 'noasm' tag -- while not changing other builds for other architectures.

Closes #

_Briefly describe your proposed changes:_

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
