### PR TITLE
feat(query): implement the read tag values rpc call in the query engine

### DIFF
--- a/query/stdlib/influxdata/influxdb/operators.go
+++ b/query/stdlib/influxdata/influxdb/operators.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	ReadRangePhysKind   = "ReadRangePhysKind"
-	ReadTagKeysPhysKind = "ReadTagKeysPhysKind"
+	ReadRangePhysKind     = "ReadRangePhysKind"
+	ReadTagKeysPhysKind   = "ReadTagKeysPhysKind"
+	ReadTagValuesPhysKind = "ReadTagValuesPhysKind"
 )
 
 type ReadRangePhysSpec struct {
@@ -95,7 +96,6 @@ func (s *ReadRangePhysSpec) TimeBounds(predecessorBounds *plan.Bounds) *plan.Bou
 
 type ReadTagKeysPhysSpec struct {
 	ReadRangePhysSpec
-	ValueColumnName string
 }
 
 func (s *ReadTagKeysPhysSpec) Kind() plan.ProcedureKind {
@@ -105,6 +105,21 @@ func (s *ReadTagKeysPhysSpec) Kind() plan.ProcedureKind {
 func (s *ReadTagKeysPhysSpec) Copy() plan.ProcedureSpec {
 	ns := new(ReadTagKeysPhysSpec)
 	ns.ReadRangePhysSpec = *s.ReadRangePhysSpec.Copy().(*ReadRangePhysSpec)
-	ns.ValueColumnName = s.ValueColumnName
+	return ns
+}
+
+type ReadTagValuesPhysSpec struct {
+	ReadRangePhysSpec
+	TagKey string
+}
+
+func (s *ReadTagValuesPhysSpec) Kind() plan.ProcedureKind {
+	return ReadTagValuesPhysKind
+}
+
+func (s *ReadTagValuesPhysSpec) Copy() plan.ProcedureSpec {
+	ns := new(ReadTagValuesPhysSpec)
+	ns.ReadRangePhysSpec = *s.ReadRangePhysSpec.Copy().(*ReadRangePhysSpec)
+	ns.TagKey = s.TagKey
 	return ns
 }

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -181,7 +181,6 @@ func TestReadTagKeysRule(t *testing.T) {
 					Stop:  fluxTime(10),
 				},
 			},
-			ValueColumnName: execute.DefaultValueColLabel,
 		}
 		if filter {
 			s.FilterSet = true
@@ -315,6 +314,220 @@ func TestReadTagKeysRule(t *testing.T) {
 			After: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("ReadTagKeys", readTagKeysSpec(false)),
+					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
+					plan.CreatePhysicalNode("mean", &universe.MeanProcedureSpec{}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{0, 2},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}
+
+func TestReadTagValuesRule(t *testing.T) {
+	fromSpec := influxdb.FromProcedureSpec{
+		Bucket: "my-bucket",
+	}
+	rangeSpec := universe.RangeProcedureSpec{
+		Bounds: flux.Bounds{
+			Start: fluxTime(5),
+			Stop:  fluxTime(10),
+		},
+	}
+	filterSpec := universe.FilterProcedureSpec{
+		Fn: &semantic.FunctionExpression{
+			Block: &semantic.FunctionBlock{
+				Parameters: &semantic.FunctionParameters{
+					List: []*semantic.FunctionParameter{{
+						Key: &semantic.Identifier{
+							Name: "r",
+						},
+					}},
+				},
+				Body: &semantic.BinaryExpression{
+					Operator: ast.EqualOperator,
+					Left: &semantic.MemberExpression{
+						Object: &semantic.IdentifierExpression{
+							Name: "r",
+						},
+						Property: "_measurement",
+					},
+					Right: &semantic.StringLiteral{
+						Value: "cpu",
+					},
+				},
+			},
+		},
+	}
+	keepSpec := universe.SchemaMutationProcedureSpec{
+		Mutations: []universe.SchemaMutation{
+			&universe.KeepOpSpec{
+				Columns: []string{
+					"host",
+				},
+			},
+		},
+	}
+	groupSpec := universe.GroupProcedureSpec{
+		GroupMode: flux.GroupModeBy,
+		GroupKeys: []string{},
+	}
+	distinctSpec := universe.DistinctProcedureSpec{
+		Column: "host",
+	}
+	readTagValuesSpec := func(filter bool) plan.PhysicalProcedureSpec {
+		s := influxdb.ReadTagValuesPhysSpec{
+			ReadRangePhysSpec: influxdb.ReadRangePhysSpec{
+				Bucket: "my-bucket",
+				Bounds: flux.Bounds{
+					Start: fluxTime(5),
+					Stop:  fluxTime(10),
+				},
+			},
+			TagKey: "host",
+		}
+		if filter {
+			s.FilterSet = true
+			s.Filter = filterSpec.Fn
+		}
+		return &s
+	}
+
+	tests := []plantest.RuleTestCase{
+		{
+			Name: "simple",
+			// from -> range -> keep -> group -> distinct  =>  ReadTagValues
+			Rules: []plan.Rule{
+				influxdb.PushDownRangeRule{},
+				influxdb.PushDownReadTagValuesRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &fromSpec),
+					plan.CreateLogicalNode("range", &rangeSpec),
+					plan.CreateLogicalNode("keep", &keepSpec),
+					plan.CreateLogicalNode("group", &groupSpec),
+					plan.CreateLogicalNode("distinct", &distinctSpec),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadTagValues", readTagValuesSpec(false)),
+				},
+			},
+		},
+		{
+			Name: "with filter",
+			// from -> range -> filter -> keep -> group -> distinct  =>  ReadTagValues
+			Rules: []plan.Rule{
+				influxdb.PushDownRangeRule{},
+				influxdb.PushDownFilterRule{},
+				influxdb.PushDownReadTagValuesRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &fromSpec),
+					plan.CreateLogicalNode("range", &rangeSpec),
+					plan.CreateLogicalNode("filter", &filterSpec),
+					plan.CreateLogicalNode("keep", &keepSpec),
+					plan.CreateLogicalNode("group", &groupSpec),
+					plan.CreateLogicalNode("distinct", &distinctSpec),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+					{4, 5},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadTagValues", readTagValuesSpec(true)),
+				},
+			},
+		},
+		{
+			Name: "with successor",
+			// from -> range -> keep -> group -> distinct -> count  =>  ReadTagValues -> count
+			Rules: []plan.Rule{
+				influxdb.PushDownRangeRule{},
+				influxdb.PushDownReadTagValuesRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &fromSpec),
+					plan.CreateLogicalNode("range", &rangeSpec),
+					plan.CreateLogicalNode("keep", &keepSpec),
+					plan.CreateLogicalNode("group", &groupSpec),
+					plan.CreateLogicalNode("distinct", &distinctSpec),
+					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+					{4, 5},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadTagValues", readTagValuesSpec(false)),
+					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
+				},
+				Edges: [][2]int{{0, 1}},
+			},
+		},
+		{
+			Name: "with multiple successors",
+			// count      mean
+			//     \     /          count     mean
+			//      range       =>      \    /
+			//        |               ReadTagValues
+			//       from
+			Rules: []plan.Rule{
+				influxdb.PushDownRangeRule{},
+				influxdb.PushDownReadTagValuesRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &fromSpec),
+					plan.CreateLogicalNode("range", &rangeSpec),
+					plan.CreateLogicalNode("keep", &keepSpec),
+					plan.CreateLogicalNode("group", &groupSpec),
+					plan.CreateLogicalNode("distinct", &distinctSpec),
+					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
+					plan.CreatePhysicalNode("mean", &universe.MeanProcedureSpec{}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+					{4, 5},
+					{4, 6},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadTagValues", readTagValuesSpec(false)),
 					plan.CreatePhysicalNode("count", &universe.CountProcedureSpec{}),
 					plan.CreatePhysicalNode("mean", &universe.MeanProcedureSpec{}),
 				},

--- a/query/stdlib/influxdata/influxdb/storage.go
+++ b/query/stdlib/influxdata/influxdb/storage.go
@@ -208,13 +208,18 @@ type ReadFilterSpec struct {
 
 type ReadTagKeysSpec struct {
 	ReadFilterSpec
-	ValueColumnName string
+}
+
+type ReadTagValuesSpec struct {
+	ReadFilterSpec
+	TagKey string
 }
 
 type Reader interface {
 	Read(ctx context.Context, rs ReadSpec, start, stop execute.Time, alloc *memory.Allocator) (TableIterator, error)
 	ReadFilter(ctx context.Context, spec ReadFilterSpec, alloc *memory.Allocator) (TableIterator, error)
 	ReadTagKeys(ctx context.Context, spec ReadTagKeysSpec, alloc *memory.Allocator) (TableIterator, error)
+	ReadTagValues(ctx context.Context, spec ReadTagValuesSpec, alloc *memory.Allocator) (TableIterator, error)
 	Close()
 }
 


### PR DESCRIPTION
If a pattern is seen that matches the `v1.tagValues(...)` call, then it
will be replaced with a direct RPC call to read the tag values for the
selected tag key which should be better optimized than reading from the
storage engine tsm1 files.

Fixes #12851.