### PR TITLE
refactor(tasks): move validator to authorizer package

### DIFF
--- a/authorizer/task.go
+++ b/authorizer/task.go
@@ -1,4 +1,4 @@
-package task
+package authorizer
 
 import (
 	"context"
@@ -31,9 +31,9 @@ type taskServiceValidator struct {
 	logger  *zap.Logger
 }
 
-// TaskValidator wraps ts and checks appropriate permissions before calling requested methods on ts.
+// TaskService wraps ts and checks appropriate permissions before calling requested methods on ts.
 // Authorization failures are logged to the logger.
-func NewValidator(logger *zap.Logger, ts platform.TaskService, bs platform.BucketService) platform.TaskService {
+func NewTaskService(logger *zap.Logger, ts platform.TaskService, bs platform.BucketService) platform.TaskService {
 	return &taskServiceValidator{
 		TaskService: ts,
 		preAuth:     query.NewPreAuthorizer(bs),

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/flux/control"
 	"github.com/influxdata/flux/execute"
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
 	"github.com/influxdata/influxdb/bolt"
 	"github.com/influxdata/influxdb/chronograf/server"
 	"github.com/influxdata/influxdb/gather"
@@ -35,7 +36,6 @@ import (
 	"github.com/influxdata/influxdb/source"
 	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/readservice"
-	"github.com/influxdata/influxdb/task"
 	taskbackend "github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/backend/coordinator"
 	taskexecutor "github.com/influxdata/influxdb/task/backend/executor"
@@ -524,7 +524,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		m.reg.MustRegister(m.scheduler.PrometheusCollectors()...)
 
 		taskSvc = coordinator.New(m.logger.With(zap.String("service", "task-coordinator")), m.scheduler, combinedTaskService)
-		taskSvc = task.NewValidator(m.logger.With(zap.String("service", "task-authz-validator")), taskSvc, bucketSvc)
+		taskSvc = authorizer.NewTaskService(m.logger.With(zap.String("service", "task-authz-validator")), taskSvc, bucketSvc)
 		m.taskControlService = combinedTaskService
 	}
 


### PR DESCRIPTION
Closes #12730

Move task validator from the /task directory to the /authorizer directory to match the pattern used by other resources.

  - [x] Rebased/mergeable
  - [x] Tests pass
