### PR TITLE
Fix the csv encoder output when all of the tag values for a series are empty

### DIFF
--- a/services/httpd/response_writer.go
+++ b/services/httpd/response_writer.go
@@ -178,7 +178,11 @@ func (f *csvFormatter) WriteResponse(w io.Writer, resp Response) (err error) {
 
 			f.columns[0] = row.Name
 			if len(row.Tags) > 0 {
-				f.columns[1] = string(models.NewTags(row.Tags).HashKey()[1:])
+				if hashKey := string(models.NewTags(row.Tags).HashKey()); len(hashKey) > 0 {
+					f.columns[1] = hashKey[1:]
+				} else {
+					f.columns[1] = ""
+				}
 			} else {
 				f.columns[1] = ""
 			}


### PR DESCRIPTION
If the tag values for a series were all empty, it would output an empty
hash key. Since the csv encoder unconditionally tried to remove the
preceding comma from the hash key, this would cause a panic when no hash
key was output.

It was invalid to assume that the hash key would always be of at least
length 1.