### PR TITLE
Remove sort behavior from Store.Read RPC, fix Tags invariant violation

### DIFF
--- a/cmd/influxd/launcher/query_test.go
+++ b/cmd/influxd/launcher/query_test.go
@@ -46,17 +46,18 @@ mem,server=b value=45.2`))
 	rawQ := fmt.Sprintf(`from(bucket:"%s")
 	|> range(start:-1m)
 	|> filter(fn: (r) => r._measurement ==  "cpu" and (r._field == "v1" or r._field == "v0"))
+	|> group(columns:["_time", "_value"], mode:"except")
 	`, be.Bucket.Name)
 
 	// Expected keys:
 	//
-	// _measurement=cpu,region=east,server=b,area=z,_field=v1
 	// _measurement=cpu,region=west,server=a,_field=v0
 	// _measurement=cpu,region=west,server=b,_field=v0
+	// _measurement=cpu,region=east,server=b,area=z,_field=v1
 	//
 	results := be.MustExecuteQuery(rawQ)
 	defer results.Done()
-	results.First(t).HasTablesWithCols([]int{5, 4, 4})
+	results.First(t).HasTablesWithCols([]int{4, 4, 5})
 }
 
 // This test initialises a default launcher writes some data,

--- a/cmd/influxd/launcher/storage_test.go
+++ b/cmd/influxd/launcher/storage_test.go
@@ -40,14 +40,14 @@ func TestStorage_WriteAndQuery(t *testing.T) {
 
 	qs := `from(bucket:"BUCKET") |> range(start:2000-01-01T00:00:00Z,stop:2000-01-02T00:00:00Z)`
 
-	exp := `,result,table,_start,_stop,_time,_value,_measurement,k,_field` + "\r\n" +
-		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,m,v1,f` + "\r\n\r\n"
+	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
+		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v1` + "\r\n\r\n"
 	if got := l.FluxQueryOrFail(t, org1.Org, org1.Auth.Token, qs); !cmp.Equal(got, exp) {
 		t.Errorf("unexpected query results -got/+exp\n%s", cmp.Diff(got, exp))
 	}
 
-	exp = `,result,table,_start,_stop,_time,_value,_measurement,k,_field` + "\r\n" +
-		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,200,m,v2,f` + "\r\n\r\n"
+	exp = `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
+		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,200,f,m,v2` + "\r\n\r\n"
 	if got := l.FluxQueryOrFail(t, org2.Org, org2.Auth.Token, qs); !cmp.Equal(got, exp) {
 		t.Errorf("unexpected query results -got/+exp\n%s", cmp.Diff(got, exp))
 	}
@@ -79,8 +79,8 @@ func TestLauncher_WriteAndQuery(t *testing.T) {
 
 	// Query server to ensure write persists.
 	qs := `from(bucket:"BUCKET") |> range(start:2000-01-01T00:00:00Z,stop:2000-01-02T00:00:00Z)`
-	exp := `,result,table,_start,_stop,_time,_value,_measurement,k,_field` + "\r\n" +
-		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,m,v,f` + "\r\n\r\n"
+	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
+		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v` + "\r\n\r\n"
 
 	buf, err := http.SimpleQuery(l.URL(), qs, l.Org.Name, l.Auth.Token)
 	if err != nil {
@@ -117,8 +117,8 @@ func TestLauncher_BucketDelete(t *testing.T) {
 
 	// Query server to ensure write persists.
 	qs := `from(bucket:"BUCKET") |> range(start:2000-01-01T00:00:00Z,stop:2000-01-02T00:00:00Z)`
-	exp := `,result,table,_start,_stop,_time,_value,_measurement,k,_field` + "\r\n" +
-		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,m,v,f` + "\r\n\r\n"
+	exp := `,result,table,_start,_stop,_time,_value,_field,_measurement,k` + "\r\n" +
+		`,_result,0,2000-01-01T00:00:00Z,2000-01-02T00:00:00Z,2000-01-01T00:00:00Z,100,f,m,v` + "\r\n\r\n"
 
 	buf, err := http.SimpleQuery(l.URL(), qs, l.Org.Name, l.Auth.Token)
 	if err != nil {

--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -110,6 +110,7 @@ var skipTests = map[string]string{
 	"filter_by_regex":             "failed to read metadata",
 	"filter_by_tags":              "failed to read metadata",
 	"group":                       "failed to read metadata",
+	"group_except":                "failed to read metadata",
 	"group_ungroup":               "failed to read metadata",
 	"pivot_mean":                  "failed to read metadata",
 	"select_measurement":          "failed to read metadata",

--- a/storage/reads/merge_test.go
+++ b/storage/reads/merge_test.go
@@ -19,6 +19,115 @@ func newStreamSeries(v ...string) *sliceStreamReader {
 	return newStreamReader(response(frames...))
 }
 
+func TestNewSequenceResultSet(t *testing.T) {
+	tests := []struct {
+		name    string
+		streams []*sliceStreamReader
+		exp     string
+	}{
+		{
+			name: "outer inner",
+			streams: []*sliceStreamReader{
+				newStreamSeries("m0,tag0=val01", "m0,tag0=val02"),
+				newStreamSeries("m0,tag0=val00", "m0,tag0=val03"),
+			},
+			exp: `series: _m=m0,tag0=val01
+  cursor:Float
+series: _m=m0,tag0=val02
+  cursor:Float
+series: _m=m0,tag0=val00
+  cursor:Float
+series: _m=m0,tag0=val03
+  cursor:Float
+`,
+		},
+		{
+			name: "sequential",
+			streams: []*sliceStreamReader{
+				newStreamSeries("m0,tag0=val00", "m0,tag0=val01"),
+				newStreamSeries("m0,tag0=val02", "m0,tag0=val03"),
+			},
+			exp: `series: _m=m0,tag0=val00
+  cursor:Float
+series: _m=m0,tag0=val01
+  cursor:Float
+series: _m=m0,tag0=val02
+  cursor:Float
+series: _m=m0,tag0=val03
+  cursor:Float
+`,
+		},
+		{
+			name: "single resultset",
+			streams: []*sliceStreamReader{
+				newStreamSeries("m0,tag0=val00", "m0,tag0=val01", "m0,tag0=val02", "m0,tag0=val03"),
+			},
+			exp: `series: _m=m0,tag0=val00
+  cursor:Float
+series: _m=m0,tag0=val01
+  cursor:Float
+series: _m=m0,tag0=val02
+  cursor:Float
+series: _m=m0,tag0=val03
+  cursor:Float
+`,
+		},
+		{
+			name: "single series ordered",
+			streams: []*sliceStreamReader{
+				newStreamSeries("m0,tag0=val00"),
+				newStreamSeries("m0,tag0=val01"),
+				newStreamSeries("m0,tag0=val02"),
+				newStreamSeries("m0,tag0=val03"),
+			},
+			exp: `series: _m=m0,tag0=val00
+  cursor:Float
+series: _m=m0,tag0=val01
+  cursor:Float
+series: _m=m0,tag0=val02
+  cursor:Float
+series: _m=m0,tag0=val03
+  cursor:Float
+`,
+		},
+		{
+			name: "single series random order",
+			streams: []*sliceStreamReader{
+				newStreamSeries("m0,tag0=val02"),
+				newStreamSeries("m0,tag0=val03"),
+				newStreamSeries("m0,tag0=val00"),
+				newStreamSeries("m0,tag0=val01"),
+			},
+			exp: `series: _m=m0,tag0=val02
+  cursor:Float
+series: _m=m0,tag0=val03
+  cursor:Float
+series: _m=m0,tag0=val00
+  cursor:Float
+series: _m=m0,tag0=val01
+  cursor:Float
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rss := make([]reads.ResultSet, len(tt.streams))
+			for i := range tt.streams {
+				rss[i] = reads.NewResultSetStreamReader(tt.streams[i])
+			}
+
+			rs := reads.NewSequenceResultSet(rss)
+			sb := new(strings.Builder)
+			ResultSetToString(sb, rs)
+
+			if got := sb.String(); !cmp.Equal(got, tt.exp) {
+				t.Errorf("unexpected value; -got/+exp\n%s", cmp.Diff(got, tt.exp))
+			}
+		})
+	}
+}
+
 func TestNewMergedResultSet(t *testing.T) {
 	exp := `series: _m=m0,tag0=val00
   cursor:Float

--- a/storage/reads/stream_reader.go
+++ b/storage/reads/stream_reader.go
@@ -13,10 +13,6 @@ import (
 )
 
 var (
-	// ErrSeriesKeyOrder means the series keys for a ResultSetStreamReader were
-	// incorrectly ordered.
-	ErrSeriesKeyOrder = errors.New("invalid series key order")
-
 	// ErrPartitionKeyOrder means the partition keys for a
 	// GroupResultSetStreamReader were incorrectly ordered.
 	ErrPartitionKeyOrder = errors.New("invalid partition key order")
@@ -146,11 +142,9 @@ func (r *ResultSetStreamReader) readSeriesFrame() bool {
 			r.tags[i].Value = sf.Series.Tags[i].Value
 		}
 
-		if models.CompareTags(r.tags, r.prev) == 1 || r.prev == nil {
-			r.cur.nextType = sf.Series.DataType
-			return true
-		}
-		r.fr.setErr(ErrSeriesKeyOrder)
+		r.cur.nextType = sf.Series.DataType
+
+		return true
 	} else {
 		r.fr.setErr(fmt.Errorf("expected series frame, got %T", f.Data))
 	}

--- a/storage/reads/stream_reader_test.go
+++ b/storage/reads/stream_reader_test.go
@@ -218,20 +218,6 @@ series: _m=cpu,tag0=unsigned
 		},
 
 		{
-			name: "invalid series key order",
-			stream: newStreamReader(
-				response(
-					seriesF(Float, "cpu,tag0=val1"),
-					seriesF(Float, "cpu,tag0=val0"),
-				),
-			),
-			exp: `series: _m=cpu,tag0=val1
-  cursor:Float
-`,
-			expErr: reads.ErrSeriesKeyOrder,
-		},
-
-		{
 			name: "some empty frames",
 			stream: newStreamReader(
 				response(

--- a/storage/series_cursor.go
+++ b/storage/series_cursor.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"bytes"
 	"errors"
-	"sort"
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/models"
@@ -103,7 +102,7 @@ func (cur *seriesCursor) Next() (*SeriesCursorRow, error) {
 	}
 
 	if cur.ofs < len(cur.keys) {
-		cur.row.Name, cur.row.Tags = tsdb.ParseSeriesKey(cur.keys[cur.ofs])
+		cur.row.Name, cur.row.Tags = tsdb.ParseSeriesKeyInto(cur.keys[cur.ofs], cur.row.Tags)
 		if !bytes.HasPrefix(cur.row.Name, cur.name[:influxdb.OrgIDLength]) {
 			return nil, errUnexpectedOrg
 		}
@@ -138,15 +137,5 @@ func (cur *seriesCursor) readSeriesKeys() error {
 		cur.keys = append(cur.keys, key)
 	}
 
-	// Sort keys.
-	sort.Sort(seriesKeys(cur.keys))
 	return nil
-}
-
-type seriesKeys [][]byte
-
-func (a seriesKeys) Len() int      { return len(a) }
-func (a seriesKeys) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a seriesKeys) Less(i, j int) bool {
-	return tsdb.CompareSeriesKeys(a[i], a[j]) == -1
 }


### PR DESCRIPTION
This PR addresses #13581 and comes with some small perf improvements. It will also improve group read performance as it no longer does a redundant sort of the series keys.

### Before

`Store.Read`

```
Consuming data...
Series:   827942
Points:   0
Time:     8163ms
Series/s: 101422.339
Points/s: 0.000
```

`engine.CreateSeriesCursor`

```
Series:   827942
Time:     4612ms
Series/s: 179532.229
```



### After

`Store.Read`

```
Consuming data...
Series:   827942
Points:   0
Time:     5313ms
Series/s: 155844.129
Points/s: 0.000
```

`engine.CreateSeriesCursor`

```
Series:   827942
Time:     732ms
Series/s: 1130639.508
```


Closes #13581
