### PR TITLE
Fix Dropdown Overlapping Dot & Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [13560](https://github.com/influxdata/influxdb/pull/13560): Add option to generate all access token in tokens tab
 
 ### Bug Fixes
+1. [13585](https://github.com/influxdata/influxdb/pull/13585): Prevent overlapping text and dot in time range dropdown
 
 ### UI Improvements
 1. [13424](https://github.com/influxdata/influxdb/pull/13424): Add general polish and empty states to Create Dashboard from Template overlay

--- a/ui/src/clockface/components/dropdowns/Dropdown.tsx
+++ b/ui/src/clockface/components/dropdowns/Dropdown.tsx
@@ -118,6 +118,7 @@ class Dropdown extends Component<Props, State> {
       customClass,
       mode,
       wrapMenuText,
+      selectedID,
     } = this.props
 
     return classnames(
@@ -127,7 +128,8 @@ class Dropdown extends Component<Props, State> {
         'dropdown-wrap': wrapMenuText,
         'dropdown-truncate': !wrapMenuText,
         [customClass]: customClass,
-        [`dropdown--${mode}`]: mode,
+        'dropdown--radio': mode === DropdownMode.Radio,
+        'dropdown--action': mode === DropdownMode.ActionList && !selectedID,
       }
     )
   }


### PR DESCRIPTION
Closes #13341 

Only add `dropdown--action` classname (which removes padding for dots) if there is no `selectedID` prop

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
