### PR TITLE
Detect more errors in JSON query responses

### DIFF
--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -84,7 +84,9 @@ export const executeQuery = (
     let bodyError = null
 
     try {
-      bodyError = JSON.parse(xhr.responseText).message
+      const body = JSON.parse(xhr.responseText)
+
+      bodyError = body.message || body.error
     } catch {
       if (xhr.responseText && xhr.responseText.trim() !== '') {
         bodyError = xhr.responseText


### PR DESCRIPTION
Closes #13279

Sometimes Flux queries return errors as a JSON object that looks like this:

```
{
  code: 'internal error',
  error: 'wups'
}
```

We only handled responses that look like this:

```
{
  code: 'internal error',
  message: 'wups'
}
```

This resulted in some errors messages not displaying in the UI. This commit updates our error message detection to handle both cases.