### PR TITLE
fix(ui): Display error message from writing line protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 1. [13584](https://github.com/influxdata/influxdb/pull/13584): Fixed scroll clipping found in label editing flow
 1. [13585](https://github.com/influxdata/influxdb/pull/13585): Prevent overlapping text and dot in time range dropdown
+1. [13618](https://github.com/influxdata/influxdb/pull/13618): Show error message when adding line protocol
 
 ### UI Improvements
 1. [13424](https://github.com/influxdata/influxdb/pull/13424): Add general polish and empty states to Create Dashboard from Template overlay

--- a/ui/src/dataLoaders/actions/dataLoaders.ts
+++ b/ui/src/dataLoaders/actions/dataLoaders.ts
@@ -523,12 +523,15 @@ export const setActiveLPTab = (
 
 interface SetLPStatus {
   type: 'SET_LP_STATUS'
-  payload: {lpStatus: RemoteDataState}
+  payload: {lpStatus: RemoteDataState; lpError: string}
 }
 
-export const setLPStatus = (lpStatus: RemoteDataState): SetLPStatus => ({
+export const setLPStatus = (
+  lpStatus: RemoteDataState,
+  lpError: string = ''
+): SetLPStatus => ({
   type: 'SET_LP_STATUS',
-  payload: {lpStatus},
+  payload: {lpStatus, lpError},
 })
 
 interface SetPrecision {
@@ -552,9 +555,9 @@ export const writeLineProtocolAction = (
     await client.write.create(org, bucket, body, {precision})
     dispatch(setLPStatus(RemoteDataState.Done))
   } catch (error) {
-    dispatch(setLPStatus(RemoteDataState.Error))
-
     const errorMessage = _.get(error, 'response.data.message', '')
+    dispatch(setLPStatus(RemoteDataState.Error, errorMessage))
+
     console.error(errorMessage || error)
 
     if (error.response.status === RATE_LIMIT_ERROR_STATUS) {

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocol.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocol.tsx
@@ -90,19 +90,13 @@ export class LineProtocol extends PureComponent<Props> {
 
   private handleSubmit = () => {
     const {onIncrementCurrentStepIndex} = this.props
+    this.handleUpload()
     onIncrementCurrentStepIndex()
   }
 
   private handleUpload = async () => {
-    const {
-      bucket,
-      org,
-      writeLineProtocolAction,
-      lineProtocolBody,
-      precision,
-    } = this.props
-
-    writeLineProtocolAction(org, bucket, lineProtocolBody, precision)
+    const {bucket, org, lineProtocolBody, precision} = this.props
+    this.props.writeLineProtocolAction(org, bucket, lineProtocolBody, precision)
   }
 }
 

--- a/ui/src/dataLoaders/components/lineProtocolWizard/verify/StatusIndicator.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/verify/StatusIndicator.tsx
@@ -12,6 +12,7 @@ import {AppState} from 'src/types'
 
 interface StateProps {
   status: RemoteDataState
+  errorMessage: string
 }
 
 type Props = StateProps
@@ -27,7 +28,10 @@ export class StatusIndicator extends PureComponent<Props> {
           </div>
         </div>
         <div className="wizard-step--footer">
-          <div className={this.footerClass}>{this.footerText}</div>
+          <div className={this.footerClass}>
+            {this.footerText}
+            {this.errorMessage}
+          </div>
         </div>
         <br />
       </>
@@ -54,14 +58,25 @@ export class StatusIndicator extends PureComponent<Props> {
         return 'Unable to Write Data'
     }
   }
+
+  private get errorMessage(): JSX.Element {
+    if (this.props.status === RemoteDataState.Error)
+      return (
+        <>
+          <br />
+          Error: {this.props.errorMessage}
+        </>
+      )
+  }
 }
 
 const mstp = ({
   dataLoading: {
-    dataLoaders: {lpStatus},
+    dataLoaders: {lpStatus, lpError},
   },
 }: AppState): StateProps => ({
   status: lpStatus,
+  errorMessage: lpError,
 })
 
 export default connect<StateProps, {}, {}>(

--- a/ui/src/dataLoaders/reducers/dataLoaders.ts
+++ b/ui/src/dataLoaders/reducers/dataLoaders.ts
@@ -32,6 +32,7 @@ export const INITIAL_STATE: DataLoadersState = {
   lineProtocolBody: '',
   activeLPTab: LineProtocolTab.UploadFile,
   lpStatus: RemoteDataState.NotStarted,
+  lpError: '',
   precision: WritePrecision.Ns,
   telegrafConfigID: null,
   pluginBundles: [],
@@ -325,9 +326,18 @@ export default (state = INITIAL_STATE, action: Action): DataLoadersState => {
         activeLPTab: action.payload.activeLPTab,
       }
     case 'SET_LP_STATUS':
+      const {lpStatus, lpError} = action.payload
+      if (lpStatus === RemoteDataState.Error) {
+        return {
+          ...state,
+          lpStatus,
+          lpError,
+        }
+      }
       return {
         ...state,
-        lpStatus: action.payload.lpStatus,
+        lpStatus,
+        lpError: '',
       }
     case 'SET_PRECISION':
       return {

--- a/ui/src/types/dataLoaders.ts
+++ b/ui/src/types/dataLoaders.ts
@@ -65,6 +65,7 @@ export interface DataLoadersState {
   activeLPTab: LineProtocolTab
   telegrafConfigID: string
   lpStatus: RemoteDataState
+  lpError: string
   lineProtocolBody: string
   precision: WritePrecision
   scraperTarget: ScraperTarget


### PR DESCRIPTION
Closes #13599

_Briefly describe your proposed changes:_
show line protocol error message
![lp_error_message](https://user-images.githubusercontent.com/5751863/56691854-c8691180-6695-11e9-963a-3e731de172a0.gif)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
