### PR TITLE
Flush cold shard index

### DIFF
--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -86,6 +86,8 @@ type Index interface {
 	UniqueReferenceID() uintptr
 
 	Rebuild()
+
+	Flush() error
 }
 
 // SeriesElem represents a generic series element.

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -1059,6 +1059,10 @@ func (i *Index) Rebuild() {
 	})
 }
 
+func (i *Index) Flush() error {
+	return nil
+}
+
 // assignExistingSeries assigns the existing series to shardID and returns the series, names and tags that
 // do not exists yet.
 func (i *Index) assignExistingSeries(shardID uint64, seriesIDSet *tsdb.SeriesIDSet, measurements map[string]int,

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -1114,6 +1114,15 @@ func (i *Index) SetFieldName(measurement []byte, name string) {}
 // Rebuild rebuilds an index. It's a no-op for this index.
 func (i *Index) Rebuild() {}
 
+func (i *Index) Flush() error {
+	for _, p := range i.partitions {
+		if err := p.FlushLogFile(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // IsIndexDir returns true if directory contains at least one partition directory.
 func IsIndexDir(path string) (bool, error) {
 	fis, err := ioutil.ReadDir(path)

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -463,6 +463,15 @@ func (s *Shard) Free() error {
 	return engine.Free()
 }
 
+func (s *Shard) FlushIndex() error {
+	index, err := s.Index()
+	if err != nil {
+		return err
+	}
+
+	return index.Flush()
+}
+
 // SetCompactionsEnabled enables or disable shard background compactions.
 func (s *Shard) SetCompactionsEnabled(enabled bool) {
 	engine, err := s.Engine()

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1919,6 +1919,11 @@ func (s *Store) monitorShards() {
 							zap.Error(err),
 							logger.Shard(sh.ID()))
 					}
+					if err := sh.FlushIndex(); err != nil {
+						s.Logger.Warn("Error while flushing cold shard index",
+							zap.Error(err),
+							logger.Shard(sh.ID()))
+					}
 				} else {
 					sh.SetCompactionsEnabled(true)
 				}


### PR DESCRIPTION
Closes #13011

With this change, in my influxdb instance (about 70 shards, each partition has a ~300KB tsl file), the startup time has been reduced from ~30s to ~5s.