### PR TITLE
fix(http): make org param optional in document get request

### DIFF
--- a/http/document_service.go
+++ b/http/document_service.go
@@ -217,12 +217,6 @@ func (h *DocumentHandler) handleGetDocuments(w http.ResponseWriter, r *http.Requ
 		opt = influxdb.AuthorizedWhereOrgID(a, *req.OrgID)
 	} else if req.Org != "" {
 		opt = influxdb.AuthorizedWhereOrg(a, req.Org)
-	} else {
-		EncodeError(ctx, &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "Please provide either org or orgID",
-		}, w)
-		return
 	}
 
 	ds, err := s.FindDocuments(ctx, opt, influxdb.IncludeLabels)

--- a/http/document_test.go
+++ b/http/document_test.go
@@ -135,7 +135,7 @@ var (
 				"links": {
 					"self": "/api/v2/documents/template/020f755c3c082011"
 				},
-				"content": "content2", 
+				"content": "content2",
 				"meta": {
 					"name": "doc2"
 				}
@@ -626,20 +626,6 @@ func TestService_handleGetDocuments(t *testing.T) {
 		args   args
 		wants  wants
 	}{
-		{
-			name: "get all documents without org or orgID",
-			fields: fields{
-				DocumentService: findDocsServiceMock,
-			},
-			args: args{
-				authorizer: &influxdb.Session{UserID: user1ID},
-			},
-			wants: wants{
-				statusCode:  http.StatusBadRequest,
-				contentType: "application/json; charset=utf-8",
-				body:        `{"code":"invalid", "message":"Please provide either org or orgID"}`,
-			},
-		},
 		{
 			name: "get all documents with both org and orgID",
 			fields: fields{


### PR DESCRIPTION
Fixes an issue introduced by #13085

Document org and orgID params should be optional, and not required.