### PR TITLE
task(fix): Tasks should no longer have inaccurate response data

### DIFF
--- a/task/backend/query_logreader.go
+++ b/task/backend/query_logreader.go
@@ -310,10 +310,12 @@ func (re *runExtractor) extractRecord(cr flux.ColReader) error {
 					r.Status = col.Label
 				}
 			case RunSuccess.String(), RunFail.String(), RunCanceled.String():
-				r.FinishedAt = values.Time(cr.Times(j).Value(i)).Time().Format(time.RFC3339Nano)
-				// Finished can be set unconditionally;
-				// it's fine to overwrite if the status was already set to started.
-				r.Status = col.Label
+				if cr.Times(j).Value(i) != 0 {
+					r.FinishedAt = values.Time(cr.Times(j).Value(i)).Time().Format(time.RFC3339Nano)
+					// Finished can be set unconditionally;
+					// it's fine to overwrite if the status was already set to started.
+					r.Status = col.Label
+				}
 			}
 		}
 

--- a/task/backend/storetest/logstoretest.go
+++ b/task/backend/storetest/logstoretest.go
@@ -142,7 +142,6 @@ func updateRunState(t *testing.T, crf CreateRunStoreFunc, drf DestroyRunStoreFun
 	run2.FinishedAt = endAt2.Format(time.RFC3339Nano)
 	run2.Status = "failed"
 
-	time.Sleep(5 * time.Second)
 	runs, err := reader.ListRuns(ctx, task.Org, platform.RunFilter{Task: task.ID})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
tasks should be able to pull from a table with both success and failed results

Co-authored-by: AlirieGray <alirie@influxdata.com>
Co-authored-by: docmerlin <emrys@influxdata.com>

Closes #
