### PR TITLE
fix(ui/var/dropdown): display map key names in dropdown

### DIFF
--- a/ui/src/dashboards/components/variablesControlBar/VariableDropdown.tsx
+++ b/ui/src/dashboards/components/variablesControlBar/VariableDropdown.tsx
@@ -10,14 +10,14 @@ import {Dropdown, DropdownMenuColors} from 'src/clockface'
 import {selectVariableValue} from 'src/dashboards/actions/index'
 
 // Utils
-import {getValuesForVariable} from 'src/variables/selectors'
+import {getVariableValuesForDropdown} from 'src/dashboards/selectors'
 
 // Types
 import {AppState} from 'src/types'
 
 interface StateProps {
-  values: string[]
-  selectedValue: string
+  values: [string, string][]
+  selectedKey: string
 }
 
 interface DispatchProps {
@@ -37,23 +37,27 @@ type Props = StateProps & DispatchProps & OwnProps
 
 class VariableDropdown extends PureComponent<Props> {
   render() {
-    const {selectedValue} = this.props
+    const {selectedKey} = this.props
     const dropdownValues = this.props.values || []
 
     return (
       <div className="variable-dropdown">
         {/* TODO: Add variable description to title attribute when it is ready */}
         <Dropdown
-          selectedID={selectedValue}
+          selectedID={selectedKey}
           onChange={this.handleSelect}
           widthPixels={140}
           titleText="No Values"
           customClass="variable-dropdown--dropdown"
           menuColor={DropdownMenuColors.Amethyst}
         >
-          {dropdownValues.map(v => (
-            <Dropdown.Item key={v} id={v} value={v}>
-              {v}
+          {dropdownValues.map(([key]) => (
+            /*
+              Use key as value since they are unique otherwise 
+              multiple selection appear in the dropdown
+            */
+            <Dropdown.Item key={key} id={key} value={key}>
+              {key}
             </Dropdown.Item>
           ))}
         </Dropdown>
@@ -61,23 +65,26 @@ class VariableDropdown extends PureComponent<Props> {
     )
   }
 
-  private handleSelect = (value: string) => {
-    const {dashboardID, variableID, onSelectValue} = this.props
+  private handleSelect = (selectedKey: string) => {
+    const {dashboardID, variableID, onSelectValue, values} = this.props
 
-    onSelectValue(dashboardID, variableID, value)
+    const selection = values.find(v => v[0] === selectedKey)
+    const selectedValue = !!selection ? selection[1] : ''
+
+    onSelectValue(dashboardID, variableID, selectedValue)
   }
 }
 
 const mstp = (state: AppState, props: OwnProps): StateProps => {
   const {dashboardID, variableID} = props
 
-  const {selectedValue, values} = getValuesForVariable(
+  const {selectedKey, list} = getVariableValuesForDropdown(
     state,
     variableID,
     dashboardID
   )
 
-  return {values, selectedValue}
+  return {values: list, selectedKey}
 }
 
 const mdtp = {

--- a/ui/src/dashboards/components/variablesControlBar/VariableDropdown.tsx
+++ b/ui/src/dashboards/components/variablesControlBar/VariableDropdown.tsx
@@ -16,7 +16,7 @@ import {getVariableValuesForDropdown} from 'src/dashboards/selectors'
 import {AppState} from 'src/types'
 
 interface StateProps {
-  values: [string, string][]
+  values: {name: string; value: string}[]
   selectedKey: string
 }
 
@@ -51,13 +51,13 @@ class VariableDropdown extends PureComponent<Props> {
           customClass="variable-dropdown--dropdown"
           menuColor={DropdownMenuColors.Amethyst}
         >
-          {dropdownValues.map(([key]) => (
+          {dropdownValues.map(({name}) => (
             /*
               Use key as value since they are unique otherwise 
               multiple selection appear in the dropdown
             */
-            <Dropdown.Item key={key} id={key} value={key}>
-              {key}
+            <Dropdown.Item key={name} id={name} value={name}>
+              {name}
             </Dropdown.Item>
           ))}
         </Dropdown>
@@ -68,8 +68,8 @@ class VariableDropdown extends PureComponent<Props> {
   private handleSelect = (selectedKey: string) => {
     const {dashboardID, variableID, onSelectValue, values} = this.props
 
-    const selection = values.find(v => v[0] === selectedKey)
-    const selectedValue = !!selection ? selection[1] : ''
+    const selection = values.find(v => v.name === selectedKey)
+    const selectedValue = !!selection ? selection.value : ''
 
     onSelectValue(dashboardID, variableID, selectedValue)
   }

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -2,6 +2,12 @@ import {get} from 'lodash'
 
 import {AppState, View} from 'src/types'
 
+import {
+  getValuesForVariable,
+  getTypeForVariable,
+  getArgumentValuesForVariable,
+} from 'src/variables/selectors'
+
 export const getView = (state: AppState, id: string): View => {
   return get(state, `views.views.${id}.view`)
 }
@@ -21,4 +27,38 @@ export const getViewsForDashboard = (
     .filter(view => cellIDs.has(view.cellID))
 
   return views
+}
+
+interface DropdownValues {
+  list: [string, string][]
+  selectedKey: string
+}
+
+export const getVariableValuesForDropdown = (
+  state: AppState,
+  variableID: string,
+  contextID: string
+): DropdownValues => {
+  const {selectedValue, values} = getValuesForVariable(
+    state,
+    variableID,
+    contextID
+  )
+  const type = getTypeForVariable(state, variableID)
+
+  switch (type) {
+    case 'map': {
+      const mapValues = getArgumentValuesForVariable<'map'>(state, variableID)
+      const list = Object.entries(mapValues)
+      const selection = list.find(([_, value]) => value === selectedValue)
+
+      return {
+        selectedKey: selection[0],
+        list,
+      }
+    }
+    default:
+      const list = values.map((v): [string, string] => [v, v])
+      return {selectedKey: selectedValue, list}
+  }
 }

--- a/ui/src/dashboards/selectors/index.ts
+++ b/ui/src/dashboards/selectors/index.ts
@@ -30,7 +30,7 @@ export const getViewsForDashboard = (
 }
 
 interface DropdownValues {
-  list: [string, string][]
+  list: {name: string; value: string}[]
   selectedKey: string
 }
 
@@ -48,9 +48,14 @@ export const getVariableValuesForDropdown = (
 
   switch (type) {
     case 'map': {
-      const mapValues = getArgumentValuesForVariable<'map'>(state, variableID)
-      const list = Object.entries(mapValues)
-      const selection = list.find(([_, value]) => value === selectedValue)
+      const mapValues = getArgumentValuesForVariable(state, variableID) as {
+        [key: string]: string
+      }
+      const list = Object.entries(mapValues).map(([name, value]) => ({
+        name,
+        value,
+      }))
+      const selection = list.find(({value}) => value === selectedValue)
 
       return {
         selectedKey: selection[0],
@@ -58,7 +63,7 @@ export const getVariableValuesForDropdown = (
       }
     }
     default:
-      const list = values.map((v): [string, string] => [v, v])
+      const list = values.map(v => ({name: v, value: v}))
       return {selectedKey: selectedValue, list}
   }
 }

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -8,7 +8,7 @@ import {getVarAssignment} from 'src/variables/utils/getVarAssignment'
 // Types
 import {RemoteDataState} from 'src/types'
 import {VariableAssignment} from 'src/types/ast'
-import {AppState} from 'src/types'
+import {AppState, VariableArguments} from 'src/types'
 import {
   VariableValues,
   VariableValuesByID,
@@ -65,6 +65,33 @@ export const getValuesForVariable = (
   contextID: string
 ): VariableValues => {
   return get(state, `variables.values.${contextID}.values.${variableID}`)
+}
+
+export const getTypeForVariable = (
+  state: AppState,
+  variableID: string
+): VariableArguments['type'] => {
+  return get(
+    state,
+    `variables.variables.${variableID}.variable.arguments.type`,
+    ''
+  )
+}
+
+interface ArgumentMap {
+  map: {[key: string]: string}
+  list: string[]
+}
+
+export const getArgumentValuesForVariable = <T extends keyof ArgumentMap>(
+  state: AppState,
+  variableID: string
+): ArgumentMap[T] => {
+  return get(
+    state,
+    `variables.variables.${variableID}.variable.arguments.values`,
+    {}
+  )
 }
 
 export const getValueSelections = (

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -78,15 +78,12 @@ export const getTypeForVariable = (
   )
 }
 
-interface ArgumentMap {
-  map: {[key: string]: string}
-  list: string[]
-}
+type ArgumentValues = {[key: string]: string} | string[]
 
-export const getArgumentValuesForVariable = <T extends keyof ArgumentMap>(
+export const getArgumentValuesForVariable = (
   state: AppState,
   variableID: string
-): ArgumentMap[T] => {
+): ArgumentValues => {
   return get(
     state,
     `variables.variables.${variableID}.variable.arguments.values`,


### PR DESCRIPTION
Closes #13651 

_Briefly describe your proposed changes:_
Map variables need to display their key name instead of their key values. This adds a selector to return an array of value entries from a selector. Using entries allows the variable dropdown to handle and render items without switching on types. However, displaying keys and values revealed an issue where variable two keys could have the same value. This can be resolved in a separate issue, https://github.com/influxdata/influxdb/issues/13658.

![Screen Shot 2019-04-26 at 11 08 19 AM](https://user-images.githubusercontent.com/4994741/56817655-f96f5080-6813-11e9-9127-c0941e9a4604.png)

![Screen Shot 2019-04-26 at 11 08 55 AM](https://user-images.githubusercontent.com/4994741/56817667-04c27c00-6814-11e9-8973-d5a3ff7ff5d8.png)

![Screen Shot 2019-04-26 at 11 10 41 AM](https://user-images.githubusercontent.com/4994741/56817680-0a1fc680-6814-11e9-9055-297ddc9a305b.png)



  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] http/swagger.yml updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
