### PR TITLE
fix(storage): translate _measurement and _field to the proper strings

### DIFF
--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -154,23 +154,23 @@ func (rule PushDownReadTagKeysRule) Rewrite(pn plan.Node) (plan.Node, bool, erro
 	// The schema mutator needs to correspond to a keep call
 	// on the column specified by the keys procedure.
 	if len(keepSpec.Mutations) != 1 {
-		return nil, false, nil
+		return pn, false, nil
 	} else if m, ok := keepSpec.Mutations[0].(*universe.KeepOpSpec); !ok {
-		return nil, false, nil
+		return pn, false, nil
 	} else if m.Predicate != nil || len(m.Columns) != 1 {
 		// We have a keep mutator, but it uses a function or
 		// it retains more than one column so it does not match
 		// what we want.
-		return nil, false, nil
+		return pn, false, nil
 	} else if m.Columns[0] != keysSpec.Column {
 		// We are not keeping the value column so this optimization
 		// will not work.
-		return nil, false, nil
+		return pn, false, nil
 	}
 
 	// The distinct spec should keep only the value column.
 	if distinctSpec.Column != keysSpec.Column {
-		return nil, false, nil
+		return pn, false, nil
 	}
 
 	// We have passed all of the necessary prerequisites
@@ -216,32 +216,32 @@ func (rule PushDownReadTagValuesRule) Rewrite(pn plan.Node) (plan.Node, bool, er
 
 	// All of the values need to be grouped into the same table.
 	if groupSpec.GroupMode != flux.GroupModeBy {
-		return nil, false, nil
+		return pn, false, nil
 	} else if len(groupSpec.GroupKeys) > 0 {
-		return nil, false, nil
+		return pn, false, nil
 	}
 
 	// The column that distinct is for will be the tag key.
 	tagKey := distinctSpec.Column
 	if !isValidTagKeyForTagValues(tagKey) {
-		return nil, false, nil
+		return pn, false, nil
 	}
 
 	// The schema mutator needs to correspond to a keep call
 	// on the tag key column.
 	if len(keepSpec.Mutations) != 1 {
-		return nil, false, nil
+		return pn, false, nil
 	} else if m, ok := keepSpec.Mutations[0].(*universe.KeepOpSpec); !ok {
-		return nil, false, nil
+		return pn, false, nil
 	} else if m.Predicate != nil || len(m.Columns) != 1 {
 		// We have a keep mutator, but it uses a function or
 		// it retains more than one column so it does not match
 		// what we want.
-		return nil, false, nil
+		return pn, false, nil
 	} else if m.Columns[0] != tagKey {
 		// We are not keeping the value column so this optimization
 		// will not work.
-		return nil, false, nil
+		return pn, false, nil
 	}
 
 	// We have passed all of the necessary prerequisites

--- a/storage/reads/reader.go
+++ b/storage/reads/reader.go
@@ -828,7 +828,14 @@ func (ti *tagValuesIterator) Do(f func(flux.Table) error) error {
 	} else {
 		req.TagsSource = any
 	}
-	req.TagKey = ti.readSpec.TagKey
+	switch ti.readSpec.TagKey {
+	case "_measurement":
+		req.TagKey = models.MeasurementTagKey
+	case "_field":
+		req.TagKey = models.FieldKeyTagKey
+	default:
+		req.TagKey = ti.readSpec.TagKey
+	}
 	req.Predicate = ti.predicate
 	req.Range.Start = int64(ti.bounds.Start)
 	req.Range.End = int64(ti.bounds.Stop)


### PR DESCRIPTION
The RPC call should translate `_measurement` and `_field` to their
proper shortened byte strings when requesting the tag values.

This also fixes the planner rewrites to return the root node even when
no rewrite happened as this is required by the planner.