### PR TITLE
fix(gather): add bkt and org id to scraper writer

### DIFF
--- a/gather/recorder.go
+++ b/gather/recorder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/influxdata/influxdb/nats"
 	"github.com/influxdata/influxdb/storage"
+	"github.com/influxdata/influxdb/tsdb"
 	"go.uber.org/zap"
 )
 
@@ -20,6 +21,11 @@ func (s PointWriter) Record(collected MetricsCollection) error {
 	if err != nil {
 		return err
 	}
+	ps, err = tsdb.ExplodePoints(collected.OrgID, collected.BucketID, ps)
+	if err != nil {
+		return err
+	}
+
 	return s.Writer.WritePoints(context.TODO(), ps)
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/13647

recent changes, result tags with no bkt id and org id to be dropped. 
Manually tested scrapers works fine after this change

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] http/swagger.yml updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
