### PR TITLE
Update query builder metaqueries

### DIFF
--- a/ui/src/timeMachine/apis/queryBuilder.ts
+++ b/ui/src/timeMachine/apis/queryBuilder.ts
@@ -66,9 +66,9 @@ export function findKeys({
   |> range(${timeRangeArguments})
   |> filter(fn: ${tagFilters})
   |> keys()
-  |> keep(columns: ["_value"])${searchFilter}${previousKeyFilter}
+  |> keep(columns: ["_value"])
+  |> distinct()${searchFilter}${previousKeyFilter}
   |> filter(fn: (r) => r._value != "_time" and r._value != "_start" and r._value !=  "_stop" and r._value != "_value")
-  |> distinct()
   |> sort()
   |> limit(n: ${limit})`
 
@@ -110,9 +110,9 @@ export function findValues({
   const query = `from(bucket: "${bucket}")
   |> range(${timeRangeArguments})
   |> filter(fn: ${tagFilters})
-  |> group(columns: ["${key}"])
-  |> distinct(column: "${key}")
-  |> keep(columns: ["_value"])${searchFilter}
+  |> keep(columns: ["${key}"])
+  |> group()
+  |> distinct(column: "${key}")${searchFilter}
   |> limit(n: ${limit})
   |> sort()`
 


### PR DESCRIPTION
Currently, slight changes in the form of a Flux metaquery can have drastic performance implications. To solve this issue, the Flux language provides helper metaquery functions such as `v1.tagKeys` and `v1.tagValues` which are guaranteed to be as fast as possible. 

In #12791, we switched away from using the `v1.tagKeys` and `v1.tagValues` functions in the query builder to their underlying Flux implementations in order to implement a UI feature. While the new metaqueries used in the query builder were still optimized at the time, the Flux language has since changed and this is no longer the case.

In addition, the metaqueries in the UI no longer hit the same code-path in Flux which has exposed a logic bug in the queries. So when executed, the metaqueries return the following error: 

    schema collision detected: column ""_value"" is both of type float and int

This PR updates the metaqueries used in the query builder to their [currently optimized form][0]. The long term solution is to address [this][1] issue and then switch back to using the safer `v1.tagKeys` and `v1.tagValues` functions directly.

[0]: https://github.com/influxdata/flux/blob/master/stdlib/influxdata/influxdb/v1/v1.flux
[1]: https://github.com/influxdata/flux/issues/1071

Closes https://github.com/influxdata/influxdb/issues/13660
