### PR TITLE
Import NotificationStyle enum directly from notification types

### DIFF
--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -1,6 +1,7 @@
 // All copy for notifications should be stored here for easy editing
 // and ensuring stylistic consistency
-import {Notification, NotificationStyle} from 'src/types'
+import {Notification} from 'src/types'
+import {NotificationStyle} from 'src/types/notifications'
 
 type NotificationExcludingMessage = Pick<
   Notification,

--- a/ui/src/shared/reducers/notifications.test.ts
+++ b/ui/src/shared/reducers/notifications.test.ts
@@ -6,7 +6,7 @@ import {
 import {notify, dismissNotification} from 'src/shared/actions/notifications'
 
 import {FIVE_SECONDS} from 'src/shared/constants/index'
-import {NotificationStyle} from 'src/types'
+import {NotificationStyle} from 'src/types/notifications'
 
 const notificationID = '000'
 


### PR DESCRIPTION
tests were failing locally because jest could not import `NotificationStyle` enum from `src/types`.
