### PR TITLE
Fix version output (v1.7)

### DIFF
--- a/cmd/influx/cli/cli.go
+++ b/cmd/influx/cli/cli.go
@@ -1161,12 +1161,6 @@ func (c *CommandLine) gopher() {
 // Version prints the CLI version.
 func (c *CommandLine) Version() {
 	fmt.Println("InfluxDB shell version:", c.ClientVersion)
-	switch c.Type {
-	case QueryLanguageFlux:
-		fmt.Println("Enter a Flux query")
-	default:
-		fmt.Println("Enter an InfluxQL query")
-	}
 }
 
 func (c *CommandLine) exit() {


### PR DESCRIPTION
Closes #10451

There is no need to print such messages in the CLI output of the version
flag. Besides being unnecessary, it makes harder to automate some tests
for those installing influxDB CE by themselves and/or automating
dockerfiles.

_Briefly describe your proposed changes:_

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] ~~http/swagger.yml updated (if modified Go structs or API)~~
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)