### PR TITLE
tsi1: don't do verbose debug logging unless test fails

### DIFF
--- a/tsdb/tsi1/index_test.go
+++ b/tsdb/tsi1/index_test.go
@@ -477,10 +477,15 @@ func TestIndex_CompactionConsistency(t *testing.T) {
 	close(done)
 	wg.Wait()
 
-	t.Log("expect", len(expected), "measurements after", len(operations), "operations")
-	for _, op := range operations {
-		t.Log(op)
-	}
+	defer func() {
+		if !t.Failed() {
+			return
+		}
+		t.Log("expect", len(expected), "measurements after", len(operations), "operations")
+		for _, op := range operations {
+			t.Log(op)
+		}
+	}()
 
 	for m := range expected {
 		if v, err := idx.MeasurementExists([]byte(m)); err != nil {


### PR DESCRIPTION
This test does a lot of fuzzing against the tsi1 index and logs out what operations were performed in what order. Since it's a lot of operations, it's needlessly verbose if it passes. Set it up to only log if it fails.