### PR TITLE
fix(storage/reads): translate measurement and field tag key names

### DIFF
--- a/storage/reads/reader.go
+++ b/storage/reads/reader.go
@@ -779,8 +779,24 @@ func (ti *tagKeysIterator) handleRead(f func(flux.Table) error, rs cursors.Strin
 	}
 	defer builder.ClearData()
 
+	// Add the _start and _stop columns that come from storage.
+	if err := builder.AppendString(valueIdx, "_start"); err != nil {
+		return err
+	}
+	if err := builder.AppendString(valueIdx, "_stop"); err != nil {
+		return err
+	}
+
 	for rs.Next() {
-		if err := builder.AppendString(valueIdx, rs.Value()); err != nil {
+		v := rs.Value()
+		switch v {
+		case models.MeasurementTagKey:
+			v = "_measurement"
+		case models.FieldKeyTagKey:
+			v = "_field"
+		}
+
+		if err := builder.AppendString(valueIdx, v); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Translate the measurement and field tag key names to their non-storage
names and add the `_start` and `_stop` tag keys to the output since
they aren't real tags, but ones that are added by range.

https://github.com/influxdata/influxdb/pull/13705#issuecomment-487752507