### PR TITLE
fix(task): lookup fully hydrated task after creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,10 @@ jobs:
           command: bash ~/project/etc/litmus_fail_notify.sh Smoke
       - store_artifacts:
           path: ~/project
-
+          destination: raw-daily-output
+      - store_test_results:
+          path: ~/project
+          destination: daily-junit
   litmus_nightly:
     machine: true
     steps:
@@ -37,6 +40,10 @@ jobs:
           command: bash ~/project/etc/litmus_fail_notify.sh Nightly
       - store_artifacts:
           path: ~/project
+          destination: raw-nightly-output
+      - store_test_results:
+          path: ~/project
+          destination: nightly-junit
   e2e:
     docker:
       - image: circleci/golang:1.12-node-browsers
@@ -88,6 +95,7 @@ jobs:
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: '-mod=readonly -p=2' # Go on Circle thinks 32 CPUs are available, but there aren't.
+      TEST_RESULTS: /tmp/test-results
     working_directory: /go/src/github.com/influxdata/influxdb
     steps:
       - checkout
@@ -104,14 +112,14 @@ jobs:
           name: Restoring GOPATH/pkg/mod
           keys:
             - influxdb-gomod-{{ checksum "go.sum" }} # Matches based on go.sum checksum.
+      - run: mkdir -p $TEST_RESULTS
       - run: make test-go # This uses the test cache so it may succeed or fail quickly.
       - run: make vet
       - run: make checkfmt
       - run: make checktidy
-      - run: make test-go-race # This doesn't use the test cache because of -count=1, so it will not complete quickly.
+      - run: GOTRACEBACK=all GO111MODULE=on gotestsum --format standard-verbose --junitfile /tmp/test-results/gotestsum.xml -- -race -count=1 ./...
       # TODO add these checks to the Makefile
       # - run: go get -v -t -d ./...
-
       - run: GO111MODULE=on go mod vendor # staticcheck looks in vendor for dependencies.
       - run: GO111MODULE=on go install honnef.co/go/tools/cmd/staticcheck # Install staticcheck from the version we specify in go.mod.
       - run: staticcheck ./...
@@ -128,7 +136,11 @@ jobs:
           paths:
             - /go/pkg/mod
           when: always
-
+      - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: /tmp/test-results
+          destination: raw-test-output
+      - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: /tmp/test-results
   build:
     docker:
       - image: circleci/golang:1.12-node-browsers
@@ -159,7 +171,6 @@ jobs:
             - bin/linux/influx
             - etc/litmus_success_notify.sh
             - etc/litmus_fail_notify.sh
-
   deploy-nightly:
     docker:
       - image: circleci/golang:1.12-node-browsers
@@ -233,7 +244,6 @@ workflows:
           filters:
             branches:
               only: /^(?!pull\/).*$/
-
   e2e:
     jobs:
       - e2e

--- a/kv/task.go
+++ b/kv/task.go
@@ -558,6 +558,7 @@ func (s *Service) createTask(ctx context.Context, tx Tx, tc influxdb.TaskCreate)
 		tc.Status = string(backend.TaskActive)
 	}
 
+	createdAt := time.Now().UTC().Format(time.RFC3339)
 	task := &influxdb.Task{
 		ID:              s.IDGenerator.ID(),
 		OrganizationID:  org.ID,
@@ -568,7 +569,8 @@ func (s *Service) createTask(ctx context.Context, tx Tx, tc influxdb.TaskCreate)
 		Flux:            tc.Flux,
 		Every:           opt.Every.String(),
 		Cron:            opt.Cron,
-		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:       createdAt,
+		LatestCompleted: createdAt,
 	}
 	if opt.Offset != nil {
 		task.Offset = opt.Offset.String()

--- a/task/backend/storetest/storetest.go
+++ b/task/backend/storetest/storetest.go
@@ -359,22 +359,36 @@ from(bucket:"test") |> range(start:-1h)`
 		}
 
 		// should return the last 2 tasks
-		newID2, err := s.CreateTask(context.Background(), backend.CreateTaskRequest{Org: orgID, AuthorizationID: authzID, Script: fmt.Sprintf(scriptFmt, 3)})
+		_, err = s.CreateTask(context.Background(), backend.CreateTaskRequest{Org: orgID, AuthorizationID: authzID, Script: fmt.Sprintf(scriptFmt, 3)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = s.CreateTask(context.Background(), backend.CreateTaskRequest{Org: orgID, AuthorizationID: authzID, Script: fmt.Sprintf(scriptFmt, 4)})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		ts, err = s.ListTasks(context.Background(), backend.TaskSearchParams{After: id})
+		// get all the tasks
+		ts, err = s.ListTasks(context.Background(), backend.TaskSearchParams{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(ts) != 2 {
-			t.Fatalf("expected 1 result, got %d", len(ts))
+		if len(ts) != 4 {
+			t.Fatalf("expected 4 result, got %d", len(ts))
 		}
-		for _, tsk := range ts {
-			if tsk.Task.ID != newID && tsk.Task.ID != newID2 {
-				t.Fatalf("got task ID %v, exp %v or %v", tsk.Task.ID, newID, newID2)
-			}
+
+		tsSubset, err := s.ListTasks(context.Background(), backend.TaskSearchParams{After: ts[1].Task.ID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(tsSubset) != 2 {
+			t.Fatalf("expected 2 result, got %d", len(ts))
+		}
+		if ts[2].Task.ID != tsSubset[0].Task.ID {
+			t.Fatalf("got task ID %v, exp %v", ts[2].Task.ID, tsSubset[0].Task.ID)
+		}
+		if ts[3].Task.ID != tsSubset[1].Task.ID {
+			t.Fatalf("got task ID %v, exp %v", ts[3].Task.ID, tsSubset[1].Task.ID)
 		}
 	})
 

--- a/task/backend/storetest/storetest.go
+++ b/task/backend/storetest/storetest.go
@@ -338,18 +338,6 @@ from(bucket:"test") |> range(start:-1h)`
 			t.Fatalf("got task ID %v, exp %v", ts[1].Task.ID, newID)
 		}
 
-		// Should return only one task
-		ts, err = s.ListTasks(context.Background(), backend.TaskSearchParams{After: id})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(ts) != 1 {
-			t.Fatalf("expected 1 result, got %d", len(ts))
-		}
-		if ts[0].Task.ID != newID {
-			t.Fatalf("got task ID %v, exp %v", ts[0].Task.ID, newID)
-		}
-
 		// Test ListTasks with OrgID, should return same result
 		ts, err = s.ListTasks(context.Background(), backend.TaskSearchParams{Org: orgID, After: id})
 		if err != nil {
@@ -368,6 +356,25 @@ from(bucket:"test") |> range(start:-1h)`
 		}
 		if !ts[0].Meta.Equal(*meta) {
 			t.Fatalf("exp meta %v, got meta %v", *meta, ts[0].Meta)
+		}
+
+		// should return the last 2 tasks
+		newID2, err := s.CreateTask(context.Background(), backend.CreateTaskRequest{Org: orgID, AuthorizationID: authzID, Script: fmt.Sprintf(scriptFmt, 3)})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ts, err = s.ListTasks(context.Background(), backend.TaskSearchParams{After: id})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ts) != 2 {
+			t.Fatalf("expected 1 result, got %d", len(ts))
+		}
+		for _, tsk := range ts {
+			if tsk.Task.ID != newID && tsk.Task.ID != newID2 {
+				t.Fatalf("got task ID %v, exp %v or %v", tsk.Task.ID, newID, newID2)
+			}
 		}
 	})
 


### PR DESCRIPTION
Closes #12021

When creating a task, not all fields were available in the response.  This loads the task from the backing store to return all fields.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
