### PR TITLE
feat(ui/explorer): add imports to flux scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 1. [13423](https://github.com/influxdata/influxdb/pull/13423): Set autorefresh of dashboard to pause if absolute time range is selected
 1. [13473](https://github.com/influxdata/influxdb/pull/13473): Switch task back end to a more modular and flexible system
 1. [13493](https://github.com/influxdata/influxdb/pull/13493): Add org profile tab with ability to edit organization name
-1. [13510](https://github.com/influxdata/influxdb/pull/13510): Add org name to dahboard page title 
+1. [13510](https://github.com/influxdata/influxdb/pull/13510): Add org name to dahboard page title
 1. [13520](https://github.com/influxdata/influxdb/pull/13520): Add cautioning to bucket renaming
 1. [13560](https://github.com/influxdata/influxdb/pull/13560): Add option to generate all access token in tokens tab
 1. [13601](https://github.com/influxdata/influxdb/pull/13601): Add option to generate read/write token in tokens tab
@@ -17,6 +17,7 @@
 1. [13585](https://github.com/influxdata/influxdb/pull/13585): Prevent overlapping text and dot in time range dropdown
 1. [13602](https://github.com/influxdata/influxdb/pull/13602): Updated link in notes cell to a more useful site
 1. [13618](https://github.com/influxdata/influxdb/pull/13618): Show error message when adding line protocol
+1. [13657](https://github.com/influxdata/influxdb/pull/13657): Update UI Flux function documentation
 
 ### UI Improvements
 1. [13424](https://github.com/influxdata/influxdb/pull/13424): Add general polish and empty states to Create Dashboard from Template overlay

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -4,8 +4,10 @@ import {
   FROM,
   RANGE,
   MEAN,
-  ABS,
+  MATH_ABS,
   MATH_FLOOR,
+  STRINGS_TITLE,
+  STRINGS_TRIM,
 } from '../../src/shared/constants/fluxFunctions'
 
 interface HTMLElementCM extends HTMLElement {
@@ -68,12 +70,16 @@ describe('DataExplorer', () => {
       cy.getByTestID('flux-function range').click()
       cy.getByTestID('flux-function math.abs').click()
       cy.getByTestID('flux-function math.floor').click()
+      cy.getByTestID('flux-function strings.title').click()
+      cy.getByTestID('flux-function strings.trim').click()
 
       cy.get<Doc>('@flux').then(doc => {
         const actual = doc.getValue()
-        const expected = `import"${ABS.package}"${FROM.example}|>${
+        const expected = `import"${MATH_ABS.package}"${FROM.example}|>${
           RANGE.example
-        }|>${ABS.example}|>${MATH_FLOOR.example}`
+        }|>${MATH_ABS.example}|>${MATH_FLOOR.example}|>${
+          STRINGS_TITLE.example
+        }${STRINGS_TRIM.example}`
 
         cy.fluxEqual(actual, expected).should('be.true')
       })

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -1,6 +1,12 @@
 import {Doc} from 'codemirror'
 import {Organization} from '@influxdata/influx'
-import {FROM, RANGE, MEAN, ABS, MATH_FLOOR} from '../../src/shared/constants/fluxFunctions'
+import {
+  FROM,
+  RANGE,
+  MEAN,
+  ABS,
+  MATH_FLOOR,
+} from '../../src/shared/constants/fluxFunctions'
 
 interface HTMLElementCM extends HTMLElement {
   CodeMirror: {

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -75,11 +75,15 @@ describe('DataExplorer', () => {
 
       cy.get<Doc>('@flux').then(doc => {
         const actual = doc.getValue()
-        const expected = `import"${MATH_ABS.package}"${FROM.example}|>${
-          RANGE.example
-        }|>${MATH_ABS.example}|>${MATH_FLOOR.example}|>${
-          STRINGS_TITLE.example
-        }${STRINGS_TRIM.example}`
+        const expected = `
+        import"${STRINGS_TITLE.package}"
+        import"${MATH_ABS.package}"
+        ${FROM.example}|>
+        ${RANGE.example}|>
+        ${MATH_ABS.example}|>
+        ${MATH_FLOOR.example}|>
+        ${STRINGS_TITLE.example}|>
+        ${STRINGS_TRIM.example}`
 
         cy.fluxEqual(actual, expected).should('be.true')
       })

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -57,7 +57,7 @@ describe('DataExplorer', () => {
       cy.getByTestID('time-machine-submit-button').should('be.disabled')
     })
 
-    it.only('imports the appropriate packages to build a query', () => {
+    it('imports the appropriate packages to build a query', () => {
       cy.getByTestID('functions-toolbar-tab').click()
 
       cy.get<$CM>('.CodeMirror').then($cm => {

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -1,6 +1,6 @@
 import {Doc} from 'codemirror'
 import {Organization} from '@influxdata/influx'
-import {FROM, RANGE, MEAN} from '../../src/shared/constants/fluxFunctions'
+import {FROM, RANGE, MEAN, ABS, MATH_FLOOR} from '../../src/shared/constants/fluxFunctions'
 
 interface HTMLElementCM extends HTMLElement {
   CodeMirror: {
@@ -47,6 +47,30 @@ describe('DataExplorer', () => {
       })
 
       cy.getByTestID('time-machine-submit-button').should('be.disabled')
+    })
+
+    it.only('imports the appropriate packages to build a query', () => {
+      cy.getByTestID('functions-toolbar-tab').click()
+
+      cy.get<$CM>('.CodeMirror').then($cm => {
+        const cm = $cm[0].CodeMirror
+        cy.wrap(cm.doc).as('flux')
+        expect(cm.doc.getValue()).to.eq('')
+      })
+
+      cy.getByTestID('flux-function from').click()
+      cy.getByTestID('flux-function range').click()
+      cy.getByTestID('flux-function math.abs').click()
+      cy.getByTestID('flux-function math.floor').click()
+
+      cy.get<Doc>('@flux').then(doc => {
+        const actual = doc.getValue()
+        const expected = `import"${ABS.package}"${FROM.example}|>${
+          RANGE.example
+        }|>${ABS.example}|>${MATH_FLOOR.example}`
+
+        cy.fluxEqual(actual, expected).should('be.true')
+      })
     })
 
     it('can use the function selector to build a query', () => {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -943,9 +943,9 @@
       }
     },
     "@cypress/xvfb": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.3.tgz",
-      "integrity": "sha512-yYrK+/bgL3hwoRHMZG4r5fyLniCy1pXex5fimtewAY6vE/jsVs8Q37UsEO03tFlcmiLnQ3rBNMaZBYTi/+C1cw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+      "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
@@ -1016,7 +1016,7 @@
       }
     },
     "@influxdata/influx": {
-      "version": "github:influxdata/influxdb2-js#58a5c8a38feb8d00c947e57f2f03b91f16dcd598",
+      "version": "github:influxdata/influxdb2-js#fbcdd2b3abac4e8a2ff66b17d8ca00160ee6f6da",
       "from": "github:influxdata/influxdb2-js#dev",
       "requires": {
         "axios": "^0.18.0"
@@ -1159,34 +1159,6 @@
       "integrity": "sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==",
       "dev": true
     },
-    "@types/blob-util": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@types/blob-util/-/blob-util-1.3.3.tgz",
-      "integrity": "sha512-4ahcL/QDnpjWA2Qs16ZMQif7HjGP2cw3AGjHabybjw7Vm1EKu+cfQN1D78BaZbS1WJNa1opSMF5HNMztx7lR0w==",
-      "dev": true
-    },
-    "@types/bluebird": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.18.tgz",
-      "integrity": "sha512-OTPWHmsyW18BhrnG5x8F7PzeZ2nFxmHGb42bZn79P9hl+GI5cMzyPgQTwNjbem0lJhoru/8vtjAFCUOu3+gE2w==",
-      "dev": true
-    },
-    "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
-      "dev": true
-    },
-    "@types/chai-jquery": {
-      "version": "1.1.35",
-      "resolved": "https://registry.npmjs.org/@types/chai-jquery/-/chai-jquery-1.1.35.tgz",
-      "integrity": "sha512-7aIt9QMRdxuagLLI48dPz96YJdhu64p6FCa6n4qkGN5DQLHnrIjZpD9bXCvV2G0NwgZ1FAmfP214dxc5zNCfgQ==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "*",
-        "@types/jquery": "*"
-      }
-    },
     "@types/cheerio": {
       "version": "0.22.9",
       "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.9.tgz",
@@ -1279,12 +1251,6 @@
       "integrity": "sha512-G6EBrbjWDfmIpYu8UcRBOhwtDiYaLj5N5jUR5rx0YvbKxRBhXPZVLUmtfShewSUNKiQwpHavpML69a2WMbIlEQ==",
       "dev": true
     },
-    "@types/jquery": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.6.tgz",
-      "integrity": "sha512-403D4wN95Mtzt2EoQHARf5oe/jEPhzBOBNrunk+ydQGW8WmkQ/E8rViRAEB1qEt/vssfGfNVD6ujP4FVeegrLg==",
-      "dev": true
-    },
     "@types/level-codec": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@types/level-codec/-/level-codec-9.0.0.tgz",
@@ -1312,18 +1278,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@types/memoize-one/-/memoize-one-4.1.0.tgz",
       "integrity": "sha512-cmSgi6JMX/yBwgpVm4GooNWIH+vEeJoa8FAa6ExOhpJbC0Juq32/uYKiKb3VPSqrEA0aOnjvwZanla3O1WZMbw==",
-      "dev": true
-    },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
-    },
-    "@types/mocha": {
-      "version": "2.2.44",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
-      "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
       "dev": true
     },
     "@types/node": {
@@ -1464,22 +1418,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
       "dev": true
-    },
-    "@types/sinon": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.0.tgz",
-      "integrity": "sha512-kcYoPw0uKioFVC/oOqafk2yizSceIQXCYnkYts9vJIwQklFRsMubTObTDrjQamUyBRd47332s85074cd/hCwxg==",
-      "dev": true
-    },
-    "@types/sinon-chai": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.2.tgz",
-      "integrity": "sha512-5zSs2AslzyPZdOsbm2NRtuSNAI2aTWzNKOHa/GRecKo7a5efYD7qGcPxMZXQDayVXT2Vnd5waXxBvV31eCZqiA==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "*",
-        "@types/sinon": "*"
-      }
     },
     "@types/text-encoding": {
       "version": "0.0.32",
@@ -3628,13 +3566,10 @@
       "dev": true
     },
     "common-tags": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
-      "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.18.0"
-      }
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -4120,63 +4055,58 @@
       "dev": true
     },
     "cypress": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.5.tgz",
-      "integrity": "sha512-jzYGKJqU1CHoNocPndinf/vbG28SeU+hg+4qhousT/HDBMJxYgjecXOmSgBX/ga9/TakhqSrIrSP2r6gW/OLtg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.2.0.tgz",
+      "integrity": "sha512-PN0wz6x634QyNL56/voTzJoeScDfwtecvSfFTHfv5MkHuECVSR4VQcEZTvYtKWln3CMBMUkWbBKPIwwu2+a/kw==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
-        "@cypress/xvfb": "1.2.3",
-        "@types/blob-util": "1.3.3",
-        "@types/bluebird": "3.5.18",
-        "@types/chai": "4.0.8",
-        "@types/chai-jquery": "1.1.35",
-        "@types/jquery": "3.3.6",
-        "@types/lodash": "4.14.87",
-        "@types/minimatch": "3.0.3",
-        "@types/mocha": "2.2.44",
-        "@types/sinon": "7.0.0",
-        "@types/sinon-chai": "3.2.2",
+        "@cypress/xvfb": "1.2.4",
         "bluebird": "3.5.0",
         "cachedir": "1.3.0",
-        "chalk": "2.4.1",
+        "chalk": "2.4.2",
         "check-more-types": "2.24.0",
-        "commander": "2.11.0",
-        "common-tags": "1.4.0",
+        "commander": "2.15.1",
+        "common-tags": "1.8.0",
         "debug": "3.1.0",
         "execa": "0.10.0",
         "executable": "4.1.1",
-        "extract-zip": "1.6.6",
+        "extract-zip": "1.6.7",
         "fs-extra": "4.0.1",
         "getos": "3.1.0",
-        "glob": "7.1.2",
-        "is-ci": "1.0.10",
+        "glob": "7.1.3",
+        "is-ci": "1.2.1",
         "is-installed-globally": "0.1.0",
         "lazy-ass": "1.6.0",
         "listr": "0.12.0",
         "lodash": "4.17.11",
         "log-symbols": "2.2.0",
         "minimist": "1.2.0",
-        "moment": "2.22.2",
+        "moment": "2.24.0",
         "ramda": "0.24.1",
-        "request": "2.87.0",
-        "request-progress": "0.3.1",
-        "supports-color": "5.1.0",
-        "tmp": "0.0.31",
+        "request": "2.88.0",
+        "request-progress": "0.4.0",
+        "supports-color": "5.5.0",
+        "tmp": "0.0.33",
         "url": "0.11.0",
-        "yauzl": "2.8.0"
+        "yauzl": "2.10.0"
       },
       "dependencies": {
-        "@types/lodash": {
-          "version": "4.14.87",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-          "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
-          "dev": true
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
         },
         "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "debug": {
@@ -4203,75 +4133,19 @@
             "strip-eof": "^1.0.0"
           }
         },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
-          },
-          "dependencies": {
-            "ajv": {
-              "version": "5.5.2",
-              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-              "dev": true,
-              "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
-              }
-            }
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "is-ci": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-          "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
-            "ci-info": "^1.0.0"
+            "ci-info": "^1.5.0"
           }
         },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+        "moment": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
           "dev": true
         },
         "ramda": {
@@ -4279,52 +4153,6 @@
           "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
           "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
           "dev": true
-        },
-        "request": {
-          "version": "2.87.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-          "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "dev": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
         }
       }
     },
@@ -5541,43 +5369,17 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
+        "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
       },
       "dependencies": {
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
         "yauzl": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
@@ -6242,7 +6044,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6266,13 +6069,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6289,19 +6094,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6432,7 +6240,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6446,6 +6255,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6462,6 +6272,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6470,13 +6281,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6497,6 +6310,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6585,7 +6399,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6599,6 +6414,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6694,7 +6510,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6736,6 +6553,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6757,6 +6575,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6805,13 +6624,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10921,6 +10742,12 @@
       "integrity": "sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA==",
       "dev": true
     },
+    "node-eta": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/node-eta/-/node-eta-0.1.1.tgz",
+      "integrity": "sha1-QGYQmzk3HHYccrfr2pqeoKXeEh8=",
+      "dev": true
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -11922,7 +11749,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -14026,12 +13853,13 @@
       }
     },
     "request-progress": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-      "integrity": "sha1-ByHBBdipasayzossia4tXs/Pazo=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.4.0.tgz",
+      "integrity": "sha1-wZVOOQhqqFJpxWYLzuAUKmpw1+c=",
       "dev": true,
       "requires": {
-        "throttleit": "~0.0.2"
+        "node-eta": "^0.1.1",
+        "throttleit": "^0.0.2"
       }
     },
     "request-promise-core": {
@@ -15301,12 +15129,12 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -16708,13 +16536,24 @@
       }
     },
     "yauzl": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
-      "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "~1.1.0"
+      },
+      "dependencies": {
+        "fd-slicer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+          "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+          "dev": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        }
       }
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -113,7 +113,7 @@
     "ajv": "^6.7.0",
     "autoprefixer": "^6.3.1",
     "babel-loader": "^8.0.5",
-    "cypress": "^3.1.5",
+    "cypress": "^3.2.0",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.6.0",
     "enzyme-to-json": "^3.3.4",

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -83,6 +83,40 @@ export const UNION: FluxToolbarFunction = {
     'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/union/',
 }
 
+export const ABS: FluxToolbarFunction = {
+  name: 'math.abs',
+  args: [
+    {
+      name: 'x',
+      desc: 'The value used in the operation.',
+      type: 'Float',
+    },
+  ],
+  package: 'math',
+  desc: 'Returns the absolute value of x.',
+  example: 'math.abs(x: r._value)',
+  category: 'Transformations',
+  link:
+    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/abs/',
+}
+
+export const MATH_FLOOR: FluxToolbarFunction = {
+  name: 'math.floor',
+  args: [
+    {
+      name: 'x',
+      desc: 'The value used in the operation.',
+      type: 'Float',
+    },
+  ],
+  package: 'math',
+  desc: 'Returns the greatest integer value less than or equal to x.',
+  example: 'math.floor(x: r._value)',
+  category: 'Transformations',
+  link:
+    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/floor/',
+}
+
 export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'aggregateWindow',
@@ -1128,22 +1162,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/map/',
   },
-  {
-    name: 'math.abs',
-    args: [
-      {
-        name: 'x',
-        desc: 'The value used in the operation.',
-        type: 'Float',
-      },
-    ],
-    package: 'math',
-    desc: 'Returns the absolute value of x.',
-    example: 'math.abs(x: r._value)',
-    category: 'Transformations',
-    link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/abs/',
-  },
+  ABS,
   {
     name: 'math.acos',
     args: [
@@ -1501,22 +1520,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/float64bits/',
   },
-  {
-    name: 'math.floor',
-    args: [
-      {
-        name: 'x',
-        desc: 'The value used in the operation.',
-        type: 'Float',
-      },
-    ],
-    package: 'math',
-    desc: 'Returns the greatest integer value less than or equal to x.',
-    example: 'math.floor(x: r._value)',
-    category: 'Transformations',
-    link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/floor/',
-  },
+  MATH_FLOOR,
   {
     name: 'math.frexp',
     args: [

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -16,10 +16,10 @@ export const FROM: FluxToolbarFunction = {
   ],
   desc:
     'Used to retrieve data from an InfluxDB data source. It returns a stream of tables from the specified bucket. Each unique series is contained within its own table. Each record in the table represents a single point in the series.',
-  example: 'from(bucket: "telegraf/autogen")',
+  example: 'from(bucket: "default")',
   category: 'Inputs',
   link:
-    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/inputs/from',
+    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/inputs/from/',
 }
 
 export const RANGE: FluxToolbarFunction = {
@@ -42,24 +42,24 @@ export const RANGE: FluxToolbarFunction = {
   example: 'range(start: -15m, stop: now)',
   category: 'Transformations',
   link:
-    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/range',
+    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/range/',
 }
 
 export const MEAN: FluxToolbarFunction = {
   name: 'mean',
   args: [
     {
-      name: 'columns',
+      name: 'column',
       desc:
-        'A list of columns on which to compute the mean. Defaults to `["_value"]`',
-      type: 'Array of Strings',
+        'The column on which to compute the mean. Defaults to `"_value"`',
+      type: 'String',
     },
   ],
   desc: 'Computes the mean or average of non-null records in the input table.',
-  example: 'mean(columns: ["_value"])',
+  example: 'mean(column: "_value")',
   category: 'Aggregates',
   link:
-    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/mean',
+    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/mean/',
 }
 
 export const UNION: FluxToolbarFunction = {
@@ -77,7 +77,7 @@ export const UNION: FluxToolbarFunction = {
   example: 'union(tables: [table1, table2])',
   category: 'Transformations',
   link:
-    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/union',
+    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/union/',
 }
 
 export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
@@ -95,10 +95,10 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Unquoted String',
       },
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'A list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
       },
       {
         name: 'timeSrc',
@@ -123,32 +123,22 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'aggregateWindow(every: 1m, fn: mean)',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/aggregatewindow',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/aggregatewindow/',
   },
   {
-    name: 'assertEquals',
+    name: 'bool',
     args: [
       {
-        name: 'name',
-        desc: 'Unique name given to the assertion.',
-        type: 'String',
-      },
-      {
-        name: 'got',
-        desc: 'The stream containing data to test.',
-        type: 'Object',
-      },
-      {
-        name: 'want',
-        desc: 'The stream that contains the expected data to test against.',
-        type: 'Object',
+        name: 'v',
+        desc: 'The value to convert.',
+        type: 'String, Integer, UInteger, Float',
       },
     ],
-    desc: 'Tests whether two streams have identical data.',
-    example: 'assertEquals(got: got, want: want)',
-    category: 'Test',
+    desc: 'Converts a single value to a boolean.',
+    example: 'bool(v: r._value)',
+    category: 'Type Conversions',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/tests/assertequals',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/bool/',
   },
   {
     name: 'bottom',
@@ -159,17 +149,17 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
       {
-        name: 'cols',
+        name: 'columns',
         desc:
           'List of columns by which to sort. Sort precedence is determined by list order (left to right) .Default is `["_value"]`',
         type: 'Array of Strings',
       },
     ],
     desc: 'Sorts a table by columns and keeps only the bottom n rows.',
-    example: 'bottom(n:10, cols: ["_value"])',
+    example: 'bottom(n:10, columns: ["_value"])',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/bottom',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/bottom/',
   },
   {
     name: 'buckets',
@@ -178,7 +168,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'buckets()',
     category: 'Inputs',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/inputs/buckets',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/inputs/buckets/',
   },
   {
     name: 'columns',
@@ -194,23 +184,45 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'columns(column: "_value")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/columns',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/columns/',
+  },
+  {
+    name: 'contains',
+    args: [
+      {
+        name: 'value',
+        desc:
+          'The value to search for.',
+        type: 'Boolean, Integer, UInteger, Float, String, Time',
+      },
+      {
+        name: 'set',
+        desc:
+          'The set of values in which to search.',
+        type: 'Boolean, Integer, UInteger, Float, String, Time',
+      },
+    ],
+    desc: 'Tests whether a value is a member of a set.',
+    example: 'contains(value: 1, set: [1,2,3])',
+    category: 'Test',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/tests/contains/',
   },
   {
     name: 'count',
     args: [
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'A list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
       },
     ],
-    desc: 'Outputs the number of records in each aggregated column.',
-    example: 'count(columns: ["_value"])',
+    desc: 'Outputs the number of records in the specified column.',
+    example: 'count(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/count',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/count/',
   },
   {
     name: 'cov',
@@ -243,7 +255,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'cov(x: table1, y: table2, on: ["_time", "_field"], pearsonr: false)',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/cov',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/cov/',
   },
   {
     name: 'covariance',
@@ -272,7 +284,29 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'covariance(columns: ["column_x", "column_y"], pearsonr: false, valueDst: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/covariance',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/covariance/',
+  },
+  {
+    name: 'csv.from',
+    args: [
+      {
+        name: 'file',
+        desc: 'The file path of the CSV file to query.',
+        type: 'String',
+      },
+      {
+        name: 'csv',
+        desc:
+          'Raw CSV-formatted text. CSV data must be in the CSV format produced by the Flux HTTP response standard.',
+        type: 'String',
+      },
+    ],
+    package: 'csv',
+    desc: 'Retrieves data from a comma-separated value (CSV) data source.',
+    example: 'csv.from(file: "/path/to/data-file.csv")',
+    category: 'Inputs',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/csv/from/',
   },
   {
     name: 'cumulativeSum',
@@ -289,7 +323,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'cumulativeSum(columns: ["_value"])',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/cumulativesum',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/cumulativesum/',
   },
   {
     name: 'derivative',
@@ -306,10 +340,10 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'A list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
       },
       {
         name: 'timeColumn',
@@ -320,10 +354,10 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     desc:
       'Computes the rate of change per unit of time between subsequent non-null records. The output table schema will be the same as the input table.',
     example:
-      'derivative(unit: 1s, nonNegative: true, columns: ["_value"], timeColumn: "_time")',
+      'derivative(unit: 1s, nonNegative: true, column: "_value", timeColumn: "_time")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/derivative',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/derivative/',
   },
   {
     name: 'difference',
@@ -335,17 +369,17 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'A list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
       },
     ],
-    desc: 'Computes the difference between subsequent records.',
-    example: 'difference(nonNegative: false, columns: ["_value"])',
+    desc: 'Computes the difference between subsequent records in the specified column.',
+    example: 'difference(nonNegative: false, column: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/difference',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/difference/',
   },
   {
     name: 'distinct',
@@ -360,7 +394,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'distinct(column: "host")',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/distinct',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/distinct/',
   },
   {
     name: 'drop',
@@ -383,7 +417,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'drop(columns: ["col1", "col2"])',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/drop',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/drop/',
   },
   {
     name: 'duplicate',
@@ -403,7 +437,22 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'duplicate(column: "column-name", as: "duplicate-name")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/duplicate',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/duplicate/',
+  },
+  {
+    name: 'duration',
+    args: [
+      {
+        name: 'v',
+        desc: 'The value to convert.',
+        type: 'String',
+      },
+    ],
+    desc: 'Converts a single value to a duration.',
+    example: 'duration(v: r._value)',
+    category: 'Type Conversions',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/duration/',
   },
   {
     name: 'fill',
@@ -431,7 +480,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'fill(column: "_value", usePrevious: true)',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/fill',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/fill/',
   },
   {
     name: 'filter',
@@ -448,7 +497,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'filter(fn: (r) => r._measurement == "cpu")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/filter',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/filter/',
   },
   {
     name: 'first',
@@ -457,30 +506,24 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'first()',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/first',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/first/',
   },
-  FROM,
   {
-    name: 'fromCSV',
+    name: 'float',
     args: [
       {
-        name: 'file',
-        desc: 'The file path of the CSV file to query.',
-        type: 'String',
-      },
-      {
-        name: 'csv',
-        desc:
-          'Raw CSV-formatted text. CSV data must be in the CSV format produced by the Flux HTTP response standard.',
-        type: 'String',
+        name: 'v',
+        desc: 'The value to convert.',
+        type: 'String, Integer, UInteger, Boolean',
       },
     ],
-    desc: 'Retrieves data from a comma-separated value (CSV) data source.',
-    example: 'from(file: "/path/to/data-file.csv")',
-    category: 'Inputs',
+    desc: 'Converts a single value to a float.',
+    example: 'float(v: r._value)',
+    category: 'Type Conversions',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/inputs/fromcsv',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/float/',
   },
+  FROM,
   {
     name: 'group',
     args: [
@@ -502,7 +545,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'group(columns: ["host", "_measurement"], mode:"by")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/group',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/group/',
   },
   {
     name: 'highestAverage',
@@ -513,9 +556,9 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
       {
-        name: 'columns',
-        desc: 'List of columns by which to sort. Default is `["_value"]`.',
-        type: 'Array of Strings',
+        name: 'column',
+        desc: 'Column by which to sort. Default is `"_value"`.',
+        type: 'String',
       },
       {
         name: 'groupColumns',
@@ -529,7 +572,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'highestAverage(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/highestaverage',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/highestaverage/',
   },
   {
     name: 'highestCurrent',
@@ -540,9 +583,9 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
       {
-        name: 'columns',
-        desc: 'List of columns by which to sort. Default is `["_value"]`.',
-        type: 'Array of Strings',
+        name: 'column',
+        desc: 'Column by which to sort. Default is `"_value"`.',
+        type: 'String',
       },
       {
         name: 'groupColumns',
@@ -556,7 +599,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'highestCurrent(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/highestcurrent',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/highestcurrent/',
   },
   {
     name: 'highestMax',
@@ -567,9 +610,9 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
       {
-        name: 'columns',
-        desc: 'List of columns by which to sort. Default is `["_value"]`.',
-        type: 'Array of Strings',
+        name: 'column',
+        desc: 'Column by which to sort. Default is `"_value"`.',
+        type: 'String',
       },
       {
         name: 'groupColumns',
@@ -583,7 +626,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'highestMax(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/highestmax',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/highestmax/',
   },
   {
     name: 'histogram',
@@ -625,7 +668,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'histogram(column: "_value", upperBoundColumn: "le", countColumn: "_value", bins: [50.0, 75.0, 90.0], normalize: false)',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/histogram',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/histogram/',
   },
   {
     name: 'histogramQuantile',
@@ -667,24 +710,39 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'histogramQuantile(quantile: 0.5, countColumn: "_value", upperBoundColumn: "le", valueColumn: "_value", minValue: 0)',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/histogramquantile',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/histogramquantile/',
   },
   {
     name: 'increase',
     args: [
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'A list of columns for which the increase is calculated. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column for which the increase is calculated. Defaults to `"_value"`.',
+        type: 'String',
       },
     ],
     desc:
       'Computes the total non-negative difference between values in a table.',
-    example: 'increase(columns: ["_values"])',
+    example: 'increase(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/increase',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/increase/',
+  },
+  {
+    name: 'int',
+    args: [
+      {
+        name: 'v',
+        desc: 'The value to convert.',
+        type: 'String, Integer, UInteger, Float, Boolean',
+      },
+    ],
+    desc: 'Converts a single value to a integer.',
+    example: 'int(v: r._value)',
+    category: 'Type Conversions',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/int/',
   },
   {
     name: 'integral',
@@ -695,18 +753,18 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Duration',
       },
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'A list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
       },
     ],
     desc:
       'Computes the area under the curve per unit of time of subsequent non-null records. The curve is defined using `_time` as the domain and record values as the range.',
-    example: 'integral(unit: 10s, columns: ["_value"])',
+    example: 'integral(unit: 10s, column: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/integral',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/integral/',
   },
   {
     name: 'intervals',
@@ -740,7 +798,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'intervals()',
     category: 'Miscellaneous',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/misc/intervals',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/misc/intervals/',
   },
   {
     name: 'join',
@@ -768,7 +826,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'join(tables: {key1: table1, key2: table2}, on: ["_time", "_field"], method: "inner")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/join',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/join/',
   },
   {
     name: 'keep',
@@ -791,7 +849,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'keep(columns: ["col1", "col2"])',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/keep',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/keep/',
   },
   {
     name: 'keys',
@@ -808,7 +866,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'keys(column: "_value")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/keys',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/keys/',
   },
   {
     name: 'keyValues',
@@ -831,7 +889,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'keyValues(keyColumns: ["usage_idle", "usage_user"])',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/keyvalues',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/keyvalues/',
   },
   {
     name: 'last',
@@ -840,7 +898,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'last()',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/last',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/last/',
   },
   {
     name: 'limit',
@@ -862,7 +920,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'limit(n:10, offset: 0)',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/limit',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/limit/',
   },
   {
     name: 'linearBins',
@@ -893,7 +951,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'linearBins(start: 0.0, width: 5.0, count: 20, infinity: true)',
     category: 'Miscellaneous',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/misc/linearbins',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/misc/linearbins/',
   },
   {
     name: 'logarithmicBins',
@@ -925,7 +983,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'logarithmicBins(start: 1.0, factor: 2.0, count: 10, infinty: true)',
     category: 'Miscellaneous',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/misc/logarithmicbins',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/misc/logarithmicbins/',
   },
   {
     name: 'lowestAverage',
@@ -936,9 +994,9 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
       {
-        name: 'columns',
-        desc: 'List of columns by which to sort. Default is `["_value"]`.',
-        type: 'Array of Strings',
+        name: 'column',
+        desc: 'Column by which to sort. Default is `"_value"`.',
+        type: 'String',
       },
       {
         name: 'groupColumns',
@@ -952,7 +1010,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'lowestAverage(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/lowestaverage',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/lowestaverage/',
   },
   {
     name: 'lowestCurrent',
@@ -963,9 +1021,9 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
       {
-        name: 'columns',
-        desc: 'List of columns by which to sort. Default is `["_value"]`.',
-        type: 'Array of Strings',
+        name: 'column',
+        desc: 'Column by which to sort. Default is `"_value"`.',
+        type: 'String',
       },
       {
         name: 'groupColumns',
@@ -979,7 +1037,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'lowestCurrent(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/lowestcurrent',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/lowestcurrent/',
   },
   {
     name: 'lowestMin',
@@ -990,9 +1048,9 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
       {
-        name: 'columns',
-        desc: 'List of columns by which to sort. Default is `["_value"]`.',
-        type: 'Array of Strings',
+        name: 'column',
+        desc: 'Column by which to sort. Default is `"_value"`.',
+        type: 'String',
       },
       {
         name: 'groupColumns',
@@ -1006,7 +1064,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'lowestMin(n:10, groupColumns: ["host"])',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/lowestmin',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/lowestmin/',
   },
   {
     name: 'map',
@@ -1028,7 +1086,1066 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'map(fn: (r) => r._value * r._value, mergeKey: true)',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/map',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/map/',
+  },
+  {
+    name: 'math.abs',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the absolute value of x.',
+    example: 'math.abs(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/abs/',
+  },
+  {
+    name: 'math.acos',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the arccosine of x in radians.',
+    example: 'math.acos(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/acos/',
+  },
+  {
+    name: 'math.acosh',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation. Should be greater than 1.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the inverse hyperbolic cosine of x.',
+    example: 'math.acosh(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/acosh/',
+  },
+  {
+    name: 'math.asin',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation. Should be greater than -1 and less than 1.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the arcsine of x in radians.',
+    example: 'math.asin(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/asin/',
+  },
+  {
+    name: 'math.asinh',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the inverse hyperbolic sine of x.',
+    example: 'math.asinh(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/asinh/',
+  },
+  {
+    name: 'math.atan',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the arctangent of x in radians.',
+    example: 'math.atan(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/atan/',
+  },
+  {
+    name: 'math.atan2',
+    args: [
+      {
+        name: 'y',
+        desc: 'The y coordinate used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'x',
+        desc: 'The x coordinate used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the arc tangent of y/x, using the signs of the two to determine the quadrant of the return value.',
+    example: 'math.atan2(y: r.y_coord, x: r.x_coord)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/atan2/',
+  },
+  {
+    name: 'math.atanh',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation. Should be greater than -1 and less than 1.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the inverse hyperbolic tangent of x.',
+    example: 'math.atanh(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/atanh/',
+  },
+  {
+    name: 'math.cbrt',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the cube root of x.',
+    example: 'math.cbrt(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/cbrt/',
+  },
+  {
+    name: 'math.ceil',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the least integer value greater than or equal to x.',
+    example: 'math.ceil(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/ceil/',
+  },
+  {
+    name: 'math.copysign',
+    args: [
+      {
+        name: 'x',
+        desc: 'The magnitude used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'y',
+        desc: 'The sign used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns a value with the magnitude of x and the sign of y.',
+    example: 'math.copysign(x: r._magnitude, r._sign)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/copysign/',
+  },
+  {
+    name: 'math.cos',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the cosine of the radian argument x.',
+    example: 'math.cos(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/cos/',
+  },
+  {
+    name: 'math.cosh',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the hyperbolic cosine of x.',
+    example: 'math.cosh(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/cosh/',
+  },
+  {
+    name: 'math.dim',
+    args: [
+      {
+        name: 'x',
+        desc: 'The X value used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'y',
+        desc: 'The Y value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the maximum of (x - y) or 0.',
+    example: 'math.dim(x: r._value1, y: r._value2)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/dim/',
+  },
+  {
+    name: 'math.erf',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the error function of x.',
+    example: 'math.erf(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/erf/',
+  },
+  {
+    name: 'math.erfc',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the complementary error function of x.',
+    example: 'math.erfc(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/erfc/',
+  },
+  {
+    name: 'math.erfcinv',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation. Should be greater than 0 and less than 2.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the inverse of `math.erfc()`.',
+    example: 'math.erfcinv(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/erfcinv/',
+  },
+  {
+    name: 'math.erfinv',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation. Should be greater than -1 and less than 1.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the inverse error function of x.',
+    example: 'math.erfinv(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/erfinv/',
+  },
+  {
+    name: 'math.exp',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the base-e exponential of x (`e**x`).',
+    example: 'math.exp(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/exp/',
+  },
+  {
+    name: 'math.exp2',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the base-2 exponential of x (`2**x`).',
+    example: 'math.exp2(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/exp2/',
+  },
+  {
+    name: 'math.expm1',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the base-e exponential of x minus 1 (`e**x - 1`).',
+    example: 'math.expm1(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/expm1/',
+  },
+  {
+    name: 'math.float64bits',
+    args: [
+      {
+        name: 'f',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the IEEE 754 binary representation of f, with the sign bit of f and the result in the same bit position.',
+    example: 'math.float64bits(f: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/float64bits/',
+  },
+  {
+    name: 'math.floor',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the greatest integer value less than or equal to x.',
+    example: 'math.floor(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/floor/',
+  },
+  {
+    name: 'math.frexp',
+    args: [
+      {
+        name: 'f',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Breaks f into a normalized fraction and an integral power of two.',
+    example: 'math.frexp(f: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/frexp/',
+  },
+  {
+    name: 'math.gamma',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the Gamma function of x.',
+    example: 'math.gamma(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/gamma/',
+  },
+  {
+    name: 'math.hypot',
+    args: [
+      {
+        name: 'p',
+        desc: 'The p value used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'q',
+        desc: 'The q value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the square root of `p*p + q*q`, taking care to avoid overflow and underflow.',
+    example: 'math.hypot(p: r.opp, p: r.adj)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/hypot/',
+  },
+  {
+    name: 'math.ilogb',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the binary exponent of x as an integer.',
+    example: 'math.ilogb(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/ilogb/',
+  },
+  {
+    name: 'math.isInf',
+    args: [
+      {
+        name: 'f',
+        desc: 'The value used in the evaluation.',
+        type: 'Float',
+      },
+      {
+        name: 'sign',
+        desc: 'The sign used in the evaluation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Reports whether f is an infinity, according to sign.',
+    example: 'math.isInf(f: r._value, sign: r.sign)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/isinf/',
+  },
+  {
+    name: 'math.isNaN',
+    args: [
+      {
+        name: 'f',
+        desc: 'The value used in the evaluation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Reports whether f is an IEEE 754 NaN value.',
+    example: 'math.isNaN(f: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/isnan/',
+  },
+  {
+    name: 'math.j0',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the order-zero Bessel function of the first kind.',
+    example: 'math.j0(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/j0/',
+  },
+  {
+    name: 'math.j1',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the order-one Bessel function of the first kind.',
+    example: 'math.j1(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/j1/',
+  },
+  {
+    name: 'math.jn',
+    args: [
+      {
+        name: 'n',
+        desc: 'The order number.',
+        type: 'Float',
+      },{
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the order-n Bessel function of the first kind.',
+    example: 'math.jn(n: 2, x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/jn/',
+  },
+  {
+    name: 'math.ldexp',
+    args: [
+      {
+        name: 'frac',
+        desc: 'The fraction used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'exp',
+        desc: 'The exponent used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns `frac × 2**exp`. It is the inverse of `math.frexp()`.',
+    example: 'math.ldexp(frac: r.frac, exp: r.exp)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/ldexp/',
+  },
+  {
+    name: 'math.lgamma',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the natural logarithm and sign (-1 or +1) of `math.gamma(x:x)`.',
+    example: 'math.lgamma(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/lgamma/',
+  },
+  {
+    name: 'math.log',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the natural logarithm of x.',
+    example: 'math.log(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/log/',
+  },
+  {
+    name: 'math.log1p',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the natural logarithm of 1 plus its argument x.',
+    example: 'math.log1p(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/log1p/',
+  },
+  {
+    name: 'math.log2',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the binary logarithm of x.',
+    example: 'math.log2(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/log2/',
+  },
+  {
+    name: 'math.logb',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the binary exponent of x.',
+    example: 'math.logb(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/logb/',
+  },
+  {
+    name: 'math.m_inf',
+    args: [
+      {
+        name: 'sign',
+        desc: 'The sign value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns positive infinity if `sign >= 0`, negative infinity if `sign < 0`.',
+    example: 'math.m_inf(sign: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/m_inf/',
+  },
+  {
+    name: 'math.m_max',
+    args: [
+      {
+        name: 'x',
+        desc: 'The X value used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'y',
+        desc: 'The Y value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the larger of x or y.',
+    example: 'math.m_max(x: r.x_value, y: r.y_value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/m_max/',
+  },
+  {
+    name: 'math.m_min',
+    args: [
+      {
+        name: 'x',
+        desc: 'The X value used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'y',
+        desc: 'The Y value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the smaller of x or y.',
+    example: 'math.m_min(x: r.x_value, y: r.y_value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/m_min/',
+  },
+  {
+    name: 'math.mod',
+    args: [
+      {
+        name: 'x',
+        desc: 'The X value used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'y',
+        desc: 'The Y value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc: 'Returns the floating-point remainder of x/y.',
+    example: 'math.mod(x: r.x_value, y: r.y_value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/mod/',
+  },
+  {
+    name: 'math.modf',
+    args: [
+      {
+        name: 'f',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns integer and fractional floating-point numbers that sum to f. Both values have the same sign as f.',
+    example: 'math.modf(f: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/modf/',
+  },
+  {
+    name: 'math.NaN',
+    args: [],
+    package: 'math',
+    desc: 'Returns an IEEE 754 NaN value.',
+    example: 'math.NaN()',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/nan/',
+  },
+  {
+    name: 'math.nextafter',
+    args: [
+      {
+        name: 'x',
+        desc: 'The X value used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'y',
+        desc: 'The Y value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the next representable float value after x towards y.',
+    example: 'math.nextafter(x: r.x_value, y: r.y_value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/nextafter/',
+  },
+  {
+    name: 'math.pow',
+    args: [
+      {
+        name: 'x',
+        desc: 'The X value used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'y',
+        desc: 'The Y value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the base-x exponential of y, `x**y`.',
+    example: 'math.pow(x: r.x_value, y: r.y_value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/pow/',
+  },
+  {
+    name: 'math.pow10',
+    args: [
+      {
+        name: 'n',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the base-10 exponential of n, `10**n`.',
+    example: 'math.pow10(n: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/pow10/',
+  },
+  {
+    name: 'math.remainder',
+    args: [
+      {
+        name: 'x',
+        desc: 'The numerator used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'y',
+        desc: 'The denominator used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the IEEE 754 floating-point remainder of `x / y`.',
+    example: 'math.remainder(x: r.numerator, y: r.denominator)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/remainder/',
+  },
+  {
+    name: 'math.round',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the nearest integer, rounding half away from zero.',
+    example: 'math.round(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/round/',
+  },
+  {
+    name: 'math.roundtoeven',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the nearest integer, rounding ties to even.',
+    example: 'math.roundtoeven(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/roundtoeven/',
+  },
+  {
+    name: 'math.signbit',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the evaluation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Reports whether x is negative or negative zero.',
+    example: 'math.signbit(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/signbit/',
+  },
+  {
+    name: 'math.sin',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the sine of the radian argument x.',
+    example: 'math.sin(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/sin/',
+  },
+  {
+    name: 'math.sincos',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the values of `math.sin(x:x)` and `math.cos(x:x)`.',
+    example: 'math.sincos(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/sincos/',
+  },
+  {
+    name: 'math.sinh',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the hyperbolic sine of x.',
+    example: 'math.sinh(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/sinh/',
+  },
+  {
+    name: 'math.sqrt',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the square root of x.',
+    example: 'math.sqrt(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/sqrt/',
+  },
+  {
+    name: 'math.tan',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the tangent of the radian argument x.',
+    example: 'math.tan(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/tan/',
+  },
+  {
+    name: 'math.tanh',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the hyperbolic tangent of x.',
+    example: 'math.tanh(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/tanh/',
+  },
+  {
+    name: 'math.trunc',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the integer value of x.',
+    example: 'math.trunc(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/trunc/',
+  },
+  {
+    name: 'math.y0',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the order-zero Bessel function of the second kind.',
+    example: 'math.y0(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/y0/',
+  },
+  {
+    name: 'math.y1',
+    args: [
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the order-one Bessel function of the second kind.',
+    example: 'math.y1(x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/y1/',
+  },
+  {
+    name: 'math.yn',
+    args: [
+      {
+        name: 'n',
+        desc: 'The order number used in the operation.',
+        type: 'Float',
+      },
+      {
+        name: 'x',
+        desc: 'The value used in the operation.',
+        type: 'Float',
+      },
+    ],
+    package: 'math',
+    desc:
+      'Returns the order-n Bessel function of the second kind.',
+    example: 'math.yn(n: 3, x: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/yn/',
   },
   {
     name: 'max',
@@ -1037,25 +2154,25 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'max()',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/max',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/max/',
   },
   MEAN,
   {
     name: 'median',
     args: [
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'A list of columns on which to compute the mean. Defaults to `["_value"]`',
-        type: 'Array of Strings',
+          'The column on which to compute the mean. Defaults to `"_value"`',
+        type: 'String',
       },
     ],
     desc:
       'Returns the median `_value` of an input table. The `median()` function can only be used with float value types.',
-    example: 'median()',
+    example: 'median(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/median',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/median/',
   },
   {
     name: 'min',
@@ -1064,7 +2181,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'min()',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/min',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/min/',
   },
   {
     name: 'pearsonr',
@@ -1090,42 +2207,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'pearsonr(x: table1, y: table2, on: ["_time", "_field"])',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/pearsonr',
-  },
-  {
-    name: 'percentile',
-    args: [
-      {
-        name: 'columns',
-        desc:
-          'A list of columns on which to compute the percentile. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
-      },
-      {
-        name: 'percentile',
-        desc: 'A value between 0 and 1 indicating the desired percentile.',
-        type: 'Float',
-      },
-      {
-        name: 'method',
-        desc:
-          'Defines the method of computation. The available options are: `estimate_tdigest`, `exact_mean`, or `exact_selector`.',
-        type: 'String',
-      },
-      {
-        name: 'compression',
-        desc:
-          'Indicates how many centroids to use when compressing the dataset. A larger number produces a more accurate result at the cost of increased memory requirements. Defaults to 1000.',
-        type: 'Float',
-      },
-    ],
-    desc:
-      'This is both an aggregate and selector function depending on the `method` used. When using the `estimate_tdigest` or `exact_mean` methods, it outputs non-null records with values that fall within the specified percentile. When using the `exact_selector` method, it outputs the non-null record with the value that represents the specified percentile.',
-    example:
-      'percentile(columns: ["_value"], percentile: 0.99, method: "estimate_tdigest", compression: 1000)',
-    category: 'Aggregates',
-    link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/percentile',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/pearsonr/',
   },
   {
     name: 'pivot',
@@ -1154,9 +2236,65 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/pivot',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/pivot/',
+  },
+  {
+    name: 'quantile',
+    args: [
+      {
+        name: 'column',
+        desc:
+          'The column on which to compute the quantile. Defaults to `"_value"`.',
+        type: 'String',
+      },
+      {
+        name: 'quantile',
+        desc: 'A value between 0 and 1 indicating the desired quantile.',
+        type: 'Float',
+      },
+      {
+        name: 'method',
+        desc:
+          'Defines the method of computation. The available options are: `estimate_tdigest`, `exact_mean`, or `exact_selector`.',
+        type: 'String',
+      },
+      {
+        name: 'compression',
+        desc:
+          'Indicates how many centroids to use when compressing the dataset. A larger number produces a more accurate result at the cost of increased memory requirements. Defaults to 1000.',
+        type: 'Float',
+      },
+    ],
+    desc:
+      'This is both an aggregate and selector function depending on the `method` used. When using the `estimate_tdigest` or `exact_mean` methods, it outputs non-null records with values that fall within the specified quantile. When using the `exact_selector` method, it outputs the non-null record with the value that represents the specified quantile.',
+    example:
+      'quantile(column: "_value", quantile: 0.99, method: "estimate_tdigest", compression: 1000)',
+    category: 'Aggregates',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/quantile/',
   },
   RANGE,
+  {
+    name: 'reduce',
+    args: [
+      {
+        name: 'fn',
+        desc: 'Function to apply to each record with a reducer object. The function expects two objects: `r` and `accumulator`.',
+        type: 'Function',
+      },
+      {
+        name: 'identity',
+        desc:
+          'Defines the reducer object and provides initial values to use when creating a reducer.',
+        type: 'Object',
+      },
+    ],
+    desc: 'Aggregates records in each table according to the reducer, `fn`',
+    example: 'reduce(fn: (r, accumulator) => ({ sum: r._value + accumulator.sum }), identity: {sum: 0.0})',
+    category: 'Aggregates',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/reduce/',
+  },
   {
     name: 'rename',
     args: [
@@ -1178,7 +2316,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'rename(columns: {host: "server", facility: "datacenter"})',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/rename',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/rename/',
   },
   {
     name: 'sample',
@@ -1199,7 +2337,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'sample(n:5, pos: -1)',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/sample',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/sample/',
   },
   {
     name: 'set',
@@ -1220,46 +2358,23 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'set(key: "myKey", value: "myValue")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/set',
-  },
-  {
-    name: 'timeShift',
-    args: [
-      {
-        name: 'duration',
-        desc:
-          'The amount of time to add to each time value. May be a negative duration.',
-        type: 'String',
-      },
-      {
-        name: 'columns',
-        desc:
-          'The list of all columns to be shifted. Defaults to `["_start", "_stop", "_time"]`.',
-        type: 'Array of Strings',
-      },
-    ],
-    desc:
-      'Adds a fixed duration to time columns. The output table schema is the same as the input table.',
-    example: 'timeShift(duration: 10h, columns: ["_start", "_stop", "_time"])',
-    category: 'Transformations',
-    link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/shift',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/set/',
   },
   {
     name: 'skew',
     args: [
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'Specifies a list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
       },
     ],
     desc: 'Outputs the skew of non-null records as a float.',
-    example: 'skew(columns: ["_value"])',
+    example: 'skew(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/skew',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/skew/',
   },
   {
     name: 'sort',
@@ -1281,24 +2396,24 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'sort(columns: ["_value"], desc: false)',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/sort',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/sort/',
   },
   {
     name: 'spread',
     args: [
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'Specifies a list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
       },
     ],
     desc:
-      'Outputs the difference between the minimum and maximum values in each specified column. Only `uint`, `int`, and `float` column types can be used.',
-    example: 'spread(columns: ["_value"])',
+      'Outputs the difference between the minimum and maximum values in the specified column. Only `uint`, `int`, and `float` column types can be used.',
+    example: 'spread(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/spread',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/spread/',
   },
   {
     name: 'stateCount',
@@ -1321,7 +2436,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'stateCount(fn: (r) => r._field == "state", column: "stateCount")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/statecount',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/statecount/',
   },
   {
     name: 'stateDuration',
@@ -1350,40 +2465,188 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'stateDuration(fn: (r) => r._measurement == "state", column: "stateDuration", unit: 1s)',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/stateduration',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/stateduration/',
   },
   {
     name: 'stddev',
     args: [
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'Specifies a list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
+      },
+      {
+        name: 'mode',
+        desc:
+          'The standard deviation mode (sample or population). Defaults to `"sample"`.',
+        type: 'String',
       },
     ],
     desc:
-      'Computes the standard deviation of non-null records in specified columns.',
-    example: 'stddev(columns: ["_value"])',
+      'Computes the standard deviation of non-null records in specified column.',
+    example: 'stddev(column: "_value", mode: "sample")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/stddev',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/stddev/',
+  },
+  {
+    name: 'string',
+    args: [
+      {
+        name: 'v',
+        desc: 'The value to convert.',
+        type: 'Integer, UInteger, Float, Boolean, Duration, Time',
+      },
+    ],
+    desc: 'Converts a single value to a string.',
+    example: 'string(v: r._value)',
+    category: 'Type Conversions',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/string/',
+  },
+  {
+    name: 'strings.title',
+    args: [
+      {
+        name: 'v',
+        desc: 'The string value to convert.',
+        type: 'String',
+      },
+    ],
+    package: 'strings',
+    desc: 'Converts a string to title case.',
+    example: 'strings.title(v: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/title/',
+  },
+  {
+    name: 'strings.toLower',
+    args: [
+      {
+        name: 'v',
+        desc: 'The string value to convert.',
+        type: 'String',
+      },
+    ],
+    package: 'strings',
+    desc: 'Converts a string to lower case.',
+    example: 'strings.toLower(v: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/tolower/',
+  },
+  {
+    name: 'strings.toUpper',
+    args: [
+      {
+        name: 'v',
+        desc: 'The string value to convert.',
+        type: 'String',
+      },
+    ],
+    package: 'strings',
+    desc: 'Converts a string to upper case.',
+    example: 'strings.toUpper(v: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/toupper/',
+  },
+  {
+    name: 'strings.trim',
+    args: [
+      {
+        name: 'v',
+        desc: 'The string value to trim.',
+        type: 'String',
+      },
+      {
+        name: 'cutset',
+        desc: 'The leading and trailing characters to trim from the string value. Only characters that match exactly are trimmed.',
+        type: 'String',
+      },
+    ],
+    package: 'strings',
+    desc: 'Removes specified leading and trailing characters from a string.',
+    example: 'strings.trim(v: r._value, cutset: "_")',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/trim/',
+  },
+  {
+    name: 'strings.trimPrefix',
+    args: [
+      {
+        name: 'v',
+        desc: 'The string value to trim.',
+        type: 'String',
+      },
+      {
+        name: 'prefix',
+        desc: 'The prefix to remove.',
+        type: 'String',
+      },
+    ],
+    package: 'strings',
+    desc: 'Removes a prefix from a string. Strings that do not start with the prefix are returned unchanged.',
+    example: 'strings.trimPrefix(v: r._value, prefix: "abc_")',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/trimprefix/',
+  },
+  {
+    name: 'strings.trimSpace',
+    args: [
+      {
+        name: 'v',
+        desc: 'The string value to trim.',
+        type: 'String',
+      },
+    ],
+    package: 'strings',
+    desc: 'Removes leading and trailing spaces from a string.',
+    example: 'strings.trimSpace(v: r._value)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/trimspace/',
+  },
+  {
+    name: 'strings.trimSuffix',
+    args: [
+      {
+        name: 'v',
+        desc: 'The string value to trim.',
+        type: 'String',
+      },
+      {
+        name: 'suffix',
+        desc: 'The suffix to remove.',
+        type: 'String',
+      },
+    ],
+    package: 'strings',
+    desc: 'Removes a suffix from a string. Strings that do not end with the suffix are returned unchanged.',
+    example: 'strings.trimSuffix(v: r._value, suffix: "_123")',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/trimsuffix/',
   },
   {
     name: 'sum',
     args: [
       {
-        name: 'columns',
+        name: 'column',
         desc:
-          'Specifies a list of columns on which to operate. Defaults to `["_value"]`.',
-        type: 'Array of Strings',
+          'The column on which to operate. Defaults to `"_value"`.',
+        type: 'String',
       },
     ],
-    desc: 'Computes the sum of non-null records in specified columns.',
-    example: 'sum(columns: ["_value"])',
+    desc: 'Computes the sum of non-null records in the specified column.',
+    example: 'sum(column: "_value")',
     category: 'Aggregates',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/aggregates/sum',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/sum/',
   },
   {
     name: 'systemTime',
@@ -1392,7 +2655,102 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'systemTime()',
     category: 'Miscellaneous',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/misc/systemtime',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/misc/systemtime/',
+  },
+  {
+    name: 'testing.assertEmpty',
+    args: [],
+    package: 'testing',
+    desc: 'Tests if an input stream is empty.',
+    example: 'testing.assertEmpty()',
+    category: 'Test',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/testing/assertempty/',
+  },
+  {
+    name: 'testing.assertEquals',
+    args: [
+      {
+        name: 'name',
+        desc: 'Unique name given to the assertion.',
+        type: 'String',
+      },
+      {
+        name: 'got',
+        desc: 'The stream containing data to test.',
+        type: 'Obscflect',
+      },
+      {
+        name: 'want',
+        desc: 'The stream that contains the expected data to test against.',
+        type: 'Object',
+      },
+    ],
+    package: 'testing',
+    desc: 'Tests whether two streams have identical data.',
+    example: 'testing.assertEquals(got: got, want: want)',
+    category: 'Test',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/testing/assertequals/',
+  },
+  {
+    name: 'testing.diff',
+    args: [
+      {
+        name: 'got',
+        desc: 'The stream containing data to test.',
+        type: 'Obscflect',
+      },
+      {
+        name: 'want',
+        desc: 'The stream that contains the expected data to test against.',
+        type: 'Object',
+      },
+    ],
+    package: 'testing',
+    desc: 'Produces a diff between two streams.',
+    example: 'testing.assertEquals(got: got, want: want)',
+    category: 'Test',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/testing/diff/',
+  },
+  {
+    name: 'time',
+    args: [
+      {
+        name: 'v',
+        desc: 'The value to convert.',
+        type: 'String, Integer, UInteger',
+      },
+    ],
+    desc: 'Converts a single value to a time.',
+    example: 'time(v: r._value)',
+    category: 'Type Conversions',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/time/',
+  },
+  {
+    name: 'timeShift',
+    args: [
+      {
+        name: 'duration',
+        desc:
+          'The amount of time to add to each time value. May be a negative duration.',
+        type: 'String',
+      },
+      {
+        name: 'columns',
+        desc:
+          'The list of all columns to be shifted. Defaults to `["_start", "_stop", "_time"]`.',
+        type: 'Array of Strings',
+      },
+    ],
+    desc:
+      'Adds a fixed duration to time columns. The output table schema is the same as the input table.',
+    example: 'timeShift(duration: 10h, columns: ["_start", "_stop", "_time"])',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/shift/',
   },
   {
     name: 'to',
@@ -1456,43 +2814,70 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'to(bucket: "my-bucket", org: "my-org", host: "http://example.com:8086", token: "xxxxxx", timeColumn: "_time", tagColumns: ["tag1", "tag2", "tag3"], fieldFn: (r) => ({ [r._field]: r._value }))',
     category: 'Outputs',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/outputs/to',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/outputs/to/',
   },
   {
     name: 'toBool',
     args: [],
-    desc: 'Converts a value to a boolean.',
+    desc: 'Converts all values in the `_value` column to a boolean.',
     example: 'toBool()',
     category: 'Type Conversions',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/type-conversions/tobool',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/tobool',
   },
   {
     name: 'toDuration',
     args: [],
-    desc: 'Converts a value to a duration.',
+    desc: 'Converts all values in the `_value` column to a duration.',
     example: 'toDuration()',
     category: 'Type Conversions',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/type-conversions/toduration',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/toduration/',
   },
   {
     name: 'toFloat',
     args: [],
-    desc: 'Converts a value to a float.',
+    desc: 'Converts all values in the `_value` column to a float.',
     example: 'toFloat()',
     category: 'Type Conversions',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/type-conversions/tofloat',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/tofloat/',
   },
   {
     name: 'toInt',
     args: [],
-    desc: 'Converts a value to a integer.',
+    desc: 'Converts all values in the `_value` column to a integer.',
     example: 'toInt()',
     category: 'Type Conversions',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/type-conversions/toint',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/toint/',
+  },
+  {
+    name: 'toString',
+    args: [],
+    desc: 'Converts a value to a string.',
+    example: 'toString()',
+    category: 'Type Conversions',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/tostring/',
+  },
+  {
+    name: 'toTime',
+    args: [],
+    desc: 'Converts a value to a time.',
+    example: 'toTime()',
+    category: 'Type Conversions',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/totime/',
+  },
+  {
+    name: 'toUInt',
+    args: [],
+    desc: 'Converts a value to an unsigned integer.',
+    example: 'toUInt()',
+    category: 'Type Conversions',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/touint/',
   },
   {
     name: 'top',
@@ -1513,34 +2898,22 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'top(n:10, cols: ["_value"])',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/top',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/top/',
   },
   {
-    name: 'toString',
-    args: [],
-    desc: 'Converts a value to a string.',
-    example: 'toString()',
+    name: 'uint',
+    args: [
+      {
+        name: 'v',
+        desc: 'The value to convert.',
+        type: 'String, Integer, Boolean',
+      },
+    ],
+    desc: 'Converts a single value to a uinteger.',
+    example: 'uint(v: r._value)',
     category: 'Type Conversions',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/type-conversions/tostring',
-  },
-  {
-    name: 'toTime',
-    args: [],
-    desc: 'Converts a value to a time.',
-    example: 'toTime()',
-    category: 'Type Conversions',
-    link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/type-conversions/totime',
-  },
-  {
-    name: 'toUInt',
-    args: [],
-    desc: 'Converts a value to an unsigned integer.',
-    example: 'toUInt()',
-    category: 'Type Conversions',
-    link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/type-conversions/touint',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/uint/',
   },
   UNION,
   {
@@ -1556,7 +2929,137 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'unique(column: "_value")',
     category: 'Selectors',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/selectors/unique',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/selectors/unique/',
+  },
+  {
+    name: 'v1.fieldsAsCols',
+    args: [],
+    package: 'influxdata/influxdb/v1',
+    desc: 'Aligns fields within each input table that have the same timestamp.',
+    example: 'v1.fieldsAsCols()',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/influxdb-v1/fieldsascols/',
+  },
+  {
+    name: 'v1.measurementTagKeys',
+    args: [
+      {
+        name: 'bucket',
+        desc: 'The bucket from which to return tag keys for a specific measurement.',
+        type: 'String',
+      },
+      {
+        name: 'measurement',
+        desc: 'The measurement from which to return tag keys.',
+        type: 'String',
+      },
+    ],
+    package: 'influxdata/influxdb/v1',
+    desc: 'Returns a list of tag keys for a specific measurement.',
+    example: 'v1.measurementTagKeys(bucket: "default", measurement: "mem")',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/influxdb-v1/measurementtagkeys/',
+  },
+  {
+    name: 'v1.measurementTagValues',
+    args: [
+      {
+        name: 'bucket',
+        desc: 'The bucket from which to return tag keys for a specific measurement.',
+        type: 'String',
+      },
+      {
+        name: 'measurement',
+        desc: 'The measurement from which to return tag values.',
+        type: 'String',
+      },
+      {
+        name: 'tag',
+        desc: 'The tag from which to return all unique values.',
+        type: 'String',
+      },
+    ],
+    package: 'influxdata/influxdb/v1',
+    desc: 'Returns a list of tag values for a specific measurement.',
+    example: 'v1.measurementTagValues(bucket: "default", measurement: "mem", tag: "host")',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/influxdb-v1/measurementtagvalues/',
+  },
+  {
+    name: 'v1.measurements',
+    args: [
+      {
+        name: 'bucket',
+        desc: 'The bucket from which to list measurements.',
+        type: 'String',
+      },
+    ],
+    package: 'influxdata/influxdb/v1',
+    desc: 'Returns a list of measurements in a specific bucket.',
+    example: 'v1.measurements(bucket: "default")',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/influxdb-v1/measurements/',
+  },
+  {
+    name: 'v1.tagKeys',
+    args: [
+      {
+        name: 'bucket',
+        desc: 'The bucket from which to list tag keys.',
+        type: 'String',
+      },
+      {
+        name: 'predicate',
+        desc: 'The predicate function that filters tag keys. Defaults to `(r) => true.`',
+        type: 'Function',
+      },
+      {
+        name: 'start',
+        desc: 'Specifies the oldest time to be included in the results. Defaults to `-30d`.',
+        type: 'Duration, Time',
+      },
+    ],
+    package: 'influxdata/influxdb/v1',
+    desc: 'Returns a list of tag keys for all series that match the predicate.',
+    example: 'v1.tagKeys(bucket: "default")',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/influxdb-v1/tagkeys/',
+  },
+  {
+    name: 'v1.tagValues',
+    args: [
+      {
+        name: 'bucket',
+        desc: 'The bucket from which to list tag values.',
+        type: 'String',
+      },
+      {
+        name: 'tag',
+        desc: 'The tag for which to return unique values.',
+        type: 'String',
+      },
+      {
+        name: 'predicate',
+        desc: 'The predicate function that filters tag values. Defaults to `(r) => true.`',
+        type: 'Function',
+      },
+      {
+        name: 'start',
+        desc: 'Specifies the oldest time to be included in the results. Defaults to `-30d`.',
+        type: 'Duration, Time',
+      },
+    ],
+    package: 'influxdata/influxdb/v1',
+    desc: 'Returns a list of unique values for a given tag.',
+    example: 'v1.tagValues(bucket: "default")',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/influxdb-v1/tagvalues/',
   },
   {
     name: 'window',
@@ -1608,7 +3111,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'window(every: 5m, period: 5m, offset: 12h, timeCol: "_time", startCol: "_start", stopCol: "_stop")',
     category: 'Transformations',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/transformations/window',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/window/',
   },
   {
     name: 'yield',
@@ -1624,6 +3127,6 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     example: 'yield(name: "custom-name")',
     category: 'Outputs',
     link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/outputs/yield',
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/outputs/yield/',
   },
 ]

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -52,8 +52,7 @@ export const MEAN: FluxToolbarFunction = {
   args: [
     {
       name: 'column',
-      desc:
-        'The column on which to compute the mean. Defaults to `"_value"`',
+      desc: 'The column on which to compute the mean. Defaults to `"_value"`',
       type: 'String',
     },
   ],
@@ -100,8 +99,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
       {
@@ -200,14 +198,12 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'value',
-        desc:
-          'The value to search for.',
+        desc: 'The value to search for.',
         type: 'Boolean, Integer, UInteger, Float, String, Time',
       },
       {
         name: 'set',
-        desc:
-          'The set of values in which to search.',
+        desc: 'The set of values in which to search.',
         type: 'Boolean, Integer, UInteger, Float, String, Time',
       },
     ],
@@ -223,8 +219,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
     ],
@@ -355,8 +350,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
       {
@@ -385,13 +379,13 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
     ],
     package: '',
-    desc: 'Computes the difference between subsequent records in the specified column.',
+    desc:
+      'Computes the difference between subsequent records in the specified column.',
     example: 'difference(nonNegative: false, column: "_value")',
     category: 'Aggregates',
     link:
@@ -786,8 +780,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
     ],
@@ -1187,7 +1180,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'x',
-        desc: 'The value used in the operation. Should be greater than -1 and less than 1.',
+        desc:
+          'The value used in the operation. Should be greater than -1 and less than 1.',
         type: 'Float',
       },
     ],
@@ -1257,7 +1251,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'x',
-        desc: 'The value used in the operation. Should be greater than -1 and less than 1.',
+        desc:
+          'The value used in the operation. Should be greater than -1 and less than 1.',
         type: 'Float',
       },
     ],
@@ -1411,7 +1406,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'x',
-        desc: 'The value used in the operation. Should be greater than 0 and less than 2.',
+        desc:
+          'The value used in the operation. Should be greater than 0 and less than 2.',
         type: 'Float',
       },
     ],
@@ -1427,7 +1423,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'x',
-        desc: 'The value used in the operation. Should be greater than -1 and less than 1.',
+        desc:
+          'The value used in the operation. Should be greater than -1 and less than 1.',
         type: 'Float',
       },
     ],
@@ -1566,7 +1563,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc: 'Returns the square root of `p*p + q*q`, taking care to avoid overflow and underflow.',
+    desc:
+      'Returns the square root of `p*p + q*q`, taking care to avoid overflow and underflow.',
     example: 'math.hypot(p: r.opp, p: r.adj)',
     category: 'Transformations',
     link:
@@ -1664,7 +1662,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         name: 'n',
         desc: 'The order number.',
         type: 'Float',
-      },{
+      },
+      {
         name: 'x',
         desc: 'The value used in the operation.',
         type: 'Float',
@@ -1708,7 +1707,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc: 'Returns the natural logarithm and sign (-1 or +1) of `math.gamma(x:x)`.',
+    desc:
+      'Returns the natural logarithm and sign (-1 or +1) of `math.gamma(x:x)`.',
     example: 'math.lgamma(x: r._value)',
     category: 'Transformations',
     link:
@@ -1788,7 +1788,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc: 'Returns positive infinity if `sign >= 0`, negative infinity if `sign < 0`.',
+    desc:
+      'Returns positive infinity if `sign >= 0`, negative infinity if `sign < 0`.',
     example: 'math.m_inf(sign: r._value)',
     category: 'Transformations',
     link:
@@ -1899,8 +1900,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the next representable float value after x towards y.',
+    desc: 'Returns the next representable float value after x towards y.',
     example: 'math.nextafter(x: r.x_value, y: r.y_value)',
     category: 'Transformations',
     link:
@@ -1921,8 +1921,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the base-x exponential of y, `x**y`.',
+    desc: 'Returns the base-x exponential of y, `x**y`.',
     example: 'math.pow(x: r.x_value, y: r.y_value)',
     category: 'Transformations',
     link:
@@ -1938,8 +1937,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the base-10 exponential of n, `10**n`.',
+    desc: 'Returns the base-10 exponential of n, `10**n`.',
     example: 'math.pow10(n: r._value)',
     category: 'Transformations',
     link:
@@ -1960,8 +1958,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the IEEE 754 floating-point remainder of `x / y`.',
+    desc: 'Returns the IEEE 754 floating-point remainder of `x / y`.',
     example: 'math.remainder(x: r.numerator, y: r.denominator)',
     category: 'Transformations',
     link:
@@ -1977,8 +1974,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the nearest integer, rounding half away from zero.',
+    desc: 'Returns the nearest integer, rounding half away from zero.',
     example: 'math.round(x: r._value)',
     category: 'Transformations',
     link:
@@ -1994,8 +1990,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the nearest integer, rounding ties to even.',
+    desc: 'Returns the nearest integer, rounding ties to even.',
     example: 'math.roundtoeven(x: r._value)',
     category: 'Transformations',
     link:
@@ -2011,8 +2006,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Reports whether x is negative or negative zero.',
+    desc: 'Reports whether x is negative or negative zero.',
     example: 'math.signbit(x: r._value)',
     category: 'Transformations',
     link:
@@ -2028,8 +2022,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the sine of the radian argument x.',
+    desc: 'Returns the sine of the radian argument x.',
     example: 'math.sin(x: r._value)',
     category: 'Transformations',
     link:
@@ -2045,8 +2038,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the values of `math.sin(x:x)` and `math.cos(x:x)`.',
+    desc: 'Returns the values of `math.sin(x:x)` and `math.cos(x:x)`.',
     example: 'math.sincos(x: r._value)',
     category: 'Transformations',
     link:
@@ -2062,8 +2054,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the hyperbolic sine of x.',
+    desc: 'Returns the hyperbolic sine of x.',
     example: 'math.sinh(x: r._value)',
     category: 'Transformations',
     link:
@@ -2079,8 +2070,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the square root of x.',
+    desc: 'Returns the square root of x.',
     example: 'math.sqrt(x: r._value)',
     category: 'Transformations',
     link:
@@ -2096,8 +2086,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the tangent of the radian argument x.',
+    desc: 'Returns the tangent of the radian argument x.',
     example: 'math.tan(x: r._value)',
     category: 'Transformations',
     link:
@@ -2113,8 +2102,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the hyperbolic tangent of x.',
+    desc: 'Returns the hyperbolic tangent of x.',
     example: 'math.tanh(x: r._value)',
     category: 'Transformations',
     link:
@@ -2130,8 +2118,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the integer value of x.',
+    desc: 'Returns the integer value of x.',
     example: 'math.trunc(x: r._value)',
     category: 'Transformations',
     link:
@@ -2147,8 +2134,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the order-zero Bessel function of the second kind.',
+    desc: 'Returns the order-zero Bessel function of the second kind.',
     example: 'math.y0(x: r._value)',
     category: 'Transformations',
     link:
@@ -2164,8 +2150,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the order-one Bessel function of the second kind.',
+    desc: 'Returns the order-one Bessel function of the second kind.',
     example: 'math.y1(x: r._value)',
     category: 'Transformations',
     link:
@@ -2186,8 +2171,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'math',
-    desc:
-      'Returns the order-n Bessel function of the second kind.',
+    desc: 'Returns the order-n Bessel function of the second kind.',
     example: 'math.yn(n: 3, x: r._value)',
     category: 'Transformations',
     link:
@@ -2209,8 +2193,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'column',
-        desc:
-          'The column on which to compute the mean. Defaults to `"_value"`',
+        desc: 'The column on which to compute the mean. Defaults to `"_value"`',
         type: 'String',
       },
     ],
@@ -2331,7 +2314,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'fn',
-        desc: 'Function to apply to each record with a reducer object. The function expects two objects: `r` and `accumulator`.',
+        desc:
+          'Function to apply to each record with a reducer object. The function expects two objects: `r` and `accumulator`.',
         type: 'Function',
       },
       {
@@ -2343,7 +2327,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: '',
     desc: 'Aggregates records in each table according to the reducer, `fn`',
-    example: 'reduce(fn: (r, accumulator) => ({ sum: r._value + accumulator.sum }), identity: {sum: 0.0})',
+    example:
+      'reduce(fn: (r, accumulator) => ({ sum: r._value + accumulator.sum }), identity: {sum: 0.0})',
     category: 'Aggregates',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/reduce/',
@@ -2421,8 +2406,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
     ],
@@ -2461,8 +2445,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
     ],
@@ -2533,8 +2516,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
       {
@@ -2626,7 +2608,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
       {
         name: 'cutset',
-        desc: 'The leading and trailing characters to trim from the string value. Only characters that match exactly are trimmed.',
+        desc:
+          'The leading and trailing characters to trim from the string value. Only characters that match exactly are trimmed.',
         type: 'String',
       },
     ],
@@ -2652,7 +2635,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'strings',
-    desc: 'Removes a prefix from a string. Strings that do not start with the prefix are returned unchanged.',
+    desc:
+      'Removes a prefix from a string. Strings that do not start with the prefix are returned unchanged.',
     example: 'strings.trimPrefix(v: r._value, prefix: "abc_")',
     category: 'Transformations',
     link:
@@ -2689,7 +2673,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     package: 'strings',
-    desc: 'Removes a suffix from a string. Strings that do not end with the suffix are returned unchanged.',
+    desc:
+      'Removes a suffix from a string. Strings that do not end with the suffix are returned unchanged.',
     example: 'strings.trimSuffix(v: r._value, suffix: "_123")',
     category: 'Transformations',
     link:
@@ -2700,8 +2685,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'column',
-        desc:
-          'The column on which to operate. Defaults to `"_value"`.',
+        desc: 'The column on which to operate. Defaults to `"_value"`.',
         type: 'String',
       },
     ],
@@ -3024,7 +3008,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'bucket',
-        desc: 'The bucket from which to return tag keys for a specific measurement.',
+        desc:
+          'The bucket from which to return tag keys for a specific measurement.',
         type: 'String',
       },
       {
@@ -3045,7 +3030,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     args: [
       {
         name: 'bucket',
-        desc: 'The bucket from which to return tag keys for a specific measurement.',
+        desc:
+          'The bucket from which to return tag keys for a specific measurement.',
         type: 'String',
       },
       {
@@ -3061,7 +3047,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: 'influxdata/influxdb/v1',
     desc: 'Returns a list of tag values for a specific measurement.',
-    example: 'v1.measurementTagValues(bucket: "default", measurement: "mem", tag: "host")',
+    example:
+      'v1.measurementTagValues(bucket: "default", measurement: "mem", tag: "host")',
     category: 'Transformations',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/influxdb-v1/measurementtagvalues/',
@@ -3092,12 +3079,14 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
       {
         name: 'predicate',
-        desc: 'The predicate function that filters tag keys. Defaults to `(r) => true.`',
+        desc:
+          'The predicate function that filters tag keys. Defaults to `(r) => true.`',
         type: 'Function',
       },
       {
         name: 'start',
-        desc: 'Specifies the oldest time to be included in the results. Defaults to `-30d`.',
+        desc:
+          'Specifies the oldest time to be included in the results. Defaults to `-30d`.',
         type: 'Duration, Time',
       },
     ],
@@ -3123,12 +3112,14 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
       {
         name: 'predicate',
-        desc: 'The predicate function that filters tag values. Defaults to `(r) => true.`',
+        desc:
+          'The predicate function that filters tag values. Defaults to `(r) => true.`',
         type: 'Function',
       },
       {
         name: 'start',
-        desc: 'Specifies the oldest time to be included in the results. Defaults to `-30d`.',
+        desc:
+          'Specifies the oldest time to be included in the results. Defaults to `-30d`.',
         type: 'Duration, Time',
       },
     ],

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -83,7 +83,7 @@ export const UNION: FluxToolbarFunction = {
     'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/union/',
 }
 
-export const ABS: FluxToolbarFunction = {
+export const MATH_ABS: FluxToolbarFunction = {
   name: 'math.abs',
   args: [
     {
@@ -115,6 +115,46 @@ export const MATH_FLOOR: FluxToolbarFunction = {
   category: 'Transformations',
   link:
     'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/math/floor/',
+}
+
+export const STRINGS_TITLE: FluxToolbarFunction = {
+  name: 'strings.title',
+  args: [
+    {
+      name: 'v',
+      desc: 'The string value to convert.',
+      type: 'String',
+    },
+  ],
+  package: 'strings',
+  desc: 'Converts a string to title case.',
+  example: 'strings.title(v: r._value)',
+  category: 'Transformations',
+  link:
+    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/title/',
+}
+
+export const STRINGS_TRIM: FluxToolbarFunction = {
+  name: 'strings.trim',
+  args: [
+    {
+      name: 'v',
+      desc: 'The string value to trim.',
+      type: 'String',
+    },
+    {
+      name: 'cutset',
+      desc:
+        'The leading and trailing characters to trim from the string value. Only characters that match exactly are trimmed.',
+      type: 'String',
+    },
+  ],
+  package: 'strings',
+  desc: 'Removes specified leading and trailing characters from a string.',
+  example: 'strings.trim(v: r._value, cutset: "_")',
+  category: 'Transformations',
+  link:
+    'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/trim/',
 }
 
 export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
@@ -1162,7 +1202,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/map/',
   },
-  ABS,
+  MATH_ABS,
   {
     name: 'math.acos',
     args: [
@@ -2555,22 +2595,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/type-conversions/string/',
   },
-  {
-    name: 'strings.title',
-    args: [
-      {
-        name: 'v',
-        desc: 'The string value to convert.',
-        type: 'String',
-      },
-    ],
-    package: 'strings',
-    desc: 'Converts a string to title case.',
-    example: 'strings.title(v: r._value)',
-    category: 'Transformations',
-    link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/title/',
-  },
+  STRINGS_TITLE,
   {
     name: 'strings.toLower',
     args: [
@@ -2603,28 +2628,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/toupper/',
   },
-  {
-    name: 'strings.trim',
-    args: [
-      {
-        name: 'v',
-        desc: 'The string value to trim.',
-        type: 'String',
-      },
-      {
-        name: 'cutset',
-        desc:
-          'The leading and trailing characters to trim from the string value. Only characters that match exactly are trimmed.',
-        type: 'String',
-      },
-    ],
-    package: 'strings',
-    desc: 'Removes specified leading and trailing characters from a string.',
-    example: 'strings.trim(v: r._value, cutset: "_")',
-    category: 'Transformations',
-    link:
-      'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/strings/trim/',
-  },
+  STRINGS_TRIM,
   {
     name: 'strings.trimPrefix',
     args: [

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -14,6 +14,7 @@ export const FROM: FluxToolbarFunction = {
       type: 'String',
     },
   ],
+  package: '',
   desc:
     'Used to retrieve data from an InfluxDB data source. It returns a stream of tables from the specified bucket. Each unique series is contained within its own table. Each record in the table represents a single point in the series.',
   example: 'from(bucket: "default")',
@@ -37,6 +38,7 @@ export const RANGE: FluxToolbarFunction = {
       type: 'Duration',
     },
   ],
+  package: '',
   desc:
     "Filters records based on time bounds. Each input table's records are filtered to contain only records that exist within the time bounds. Each input table's group key value is modified to fit within the time bounds. Tables where all records exists outside the time bounds are filtered entirely.",
   example: 'range(start: -15m, stop: now)',
@@ -55,6 +57,7 @@ export const MEAN: FluxToolbarFunction = {
       type: 'String',
     },
   ],
+  package: '',
   desc: 'Computes the mean or average of non-null records in the input table.',
   example: 'mean(column: "_value")',
   category: 'Aggregates',
@@ -72,6 +75,7 @@ export const UNION: FluxToolbarFunction = {
       type: 'Array of Strings',
     },
   ],
+  package: '',
   desc:
     'Concatenates two or more input streams into a single output stream. The output schemas of the `union()` function is the union of all input schemas. A sort operation may be added if a specific sort order is needed.',
   example: 'union(tables: [table1, table2])',
@@ -119,6 +123,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
     ],
+    package: '',
     desc: 'Applies an aggregate function to fixed windows of time.',
     example: 'aggregateWindow(every: 1m, fn: mean)',
     category: 'Aggregates',
@@ -134,6 +139,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String, Integer, UInteger, Float',
       },
     ],
+    package: '',
     desc: 'Converts a single value to a boolean.',
     example: 'bool(v: r._value)',
     category: 'Type Conversions',
@@ -155,6 +161,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc: 'Sorts a table by columns and keeps only the bottom n rows.',
     example: 'bottom(n:10, columns: ["_value"])',
     category: 'Selectors',
@@ -164,6 +171,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'buckets',
     args: [],
+    package: '',
     desc: 'Returns a list of buckets in the organization.',
     example: 'buckets()',
     category: 'Inputs',
@@ -180,6 +188,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Lists the column labels of input tables.',
     example: 'columns(column: "_value")',
     category: 'Transformations',
@@ -202,6 +211,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean, Integer, UInteger, Float, String, Time',
       },
     ],
+    package: '',
     desc: 'Tests whether a value is a member of a set.',
     example: 'contains(value: 1, set: [1,2,3])',
     category: 'Test',
@@ -218,6 +228,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Outputs the number of records in the specified column.',
     example: 'count(column: "_value")',
     category: 'Aggregates',
@@ -249,6 +260,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
     ],
+    package: '',
     desc:
       'Computes the covariance between two streams by first joining the streams, then performing the covariance operation.',
     example:
@@ -279,6 +291,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Computes the covariance between two columns.',
     example:
       'covariance(columns: ["column_x", "column_y"], pearsonr: false, valueDst: "_value")',
@@ -318,6 +331,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Computes a running sum for non-null records in the table. The output table schema will be the same as the input table.',
     example: 'cumulativeSum(columns: ["_value"])',
@@ -351,6 +365,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Computes the rate of change per unit of time between subsequent non-null records. The output table schema will be the same as the input table.',
     example:
@@ -375,6 +390,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Computes the difference between subsequent records in the specified column.',
     example: 'difference(nonNegative: false, column: "_value")',
     category: 'Aggregates',
@@ -390,6 +406,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Returns the unique values for a given column.',
     example: 'distinct(column: "host")',
     category: 'Selectors',
@@ -412,6 +429,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Function',
       },
     ],
+    package: '',
     desc:
       'Removes specified columns from a table. Columns can be specified either through a list or a predicate function. When a dropped column is part of the group key, it will be removed from the key.',
     example: 'drop(columns: ["col1", "col2"])',
@@ -433,6 +451,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Duplicates a specified column in a table.',
     example: 'duplicate(column: "column-name", as: "duplicate-name")',
     category: 'Transformations',
@@ -448,6 +467,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Converts a single value to a duration.',
     example: 'duration(v: r._value)',
     category: 'Type Conversions',
@@ -475,6 +495,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
     ],
+    package: '',
     desc:
       'replaces all null values in an input stream and replace them with a non-null value.',
     example: 'fill(column: "_value", usePrevious: true)',
@@ -492,6 +513,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Function',
       },
     ],
+    package: '',
     desc:
       'Filters data based on conditions defined in the function. The output tables have the same schema as the corresponding input tables.',
     example: 'filter(fn: (r) => r._measurement == "cpu")',
@@ -502,6 +524,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'first',
     args: [],
+    package: '',
     desc: 'Selects the first non-null record from an input table.',
     example: 'first()',
     category: 'Selectors',
@@ -517,6 +540,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String, Integer, UInteger, Boolean',
       },
     ],
+    package: '',
     desc: 'Converts a single value to a float.',
     example: 'float(v: r._value)',
     category: 'Type Conversions',
@@ -540,6 +564,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Groups records based on their values for specific columns. It produces tables with new group keys based on provided properties.',
     example: 'group(columns: ["host", "_measurement"], mode:"by")',
@@ -567,6 +592,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Returns the top `n` records from all groups using the average of each group.',
     example: 'highestAverage(n:10, groupColumns: ["host"])',
@@ -594,6 +620,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Returns the top `n` records from all groups using the last value of each group.',
     example: 'highestCurrent(n:10, groupColumns: ["host"])',
@@ -621,6 +648,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Returns the top `n` records from all groups using the maximum of each group.',
     example: 'highestMax(n:10, groupColumns: ["host"])',
@@ -662,6 +690,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
     ],
+    package: '',
     desc:
       'Approximates the cumulative distribution function of a dataset by counting data frequencies for a list of buckets.',
     example:
@@ -704,6 +733,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Float',
       },
     ],
+    package: '',
     desc:
       'Approximates a quantile given a histogram that approximates the cumulative distribution of the dataset.',
     example:
@@ -722,6 +752,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Computes the total non-negative difference between values in a table.',
     example: 'increase(column: "_value")',
@@ -738,6 +769,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String, Integer, UInteger, Float, Boolean',
       },
     ],
+    package: '',
     desc: 'Converts a single value to a integer.',
     example: 'int(v: r._value)',
     category: 'Type Conversions',
@@ -759,6 +791,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Computes the area under the curve per unit of time of subsequent non-null records. The curve is defined using `_time` as the domain and record values as the range.',
     example: 'integral(unit: 10s, column: "_value")',
@@ -794,6 +827,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Function',
       },
     ],
+    package: '',
     desc: 'Generates a set of time intervals over a range of time.',
     example: 'intervals()',
     category: 'Miscellaneous',
@@ -820,6 +854,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Merges two or more input streams, whose values are equal on a set of common columns, into a single output stream. The resulting schema is the union of the input schemas. The resulting group key is the union of the input group keys.',
     example:
@@ -844,6 +879,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Function',
       },
     ],
+    package: '',
     desc:
       'Returns a table containing only the specified columns, ignoring all others. Only columns in the group key that are also specified in the `keep()` function will be kept in the resulting group key. It is the inverse of `drop`.',
     example: 'keep(columns: ["col1", "col2"])',
@@ -861,6 +897,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       "Outputs the group key of input tables. For each input table, it outputs a table with the same group key columns, plus a _value column containing the labels of the input table's group key.",
     example: 'keys(column: "_value")',
@@ -884,6 +921,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Function',
       },
     ],
+    package: '',
     desc:
       "Returns a table with the input table's group key plus two columns, `_key` and `_value`, that correspond to unique column + value pairs from the input table.",
     example: 'keyValues(keyColumns: ["usage_idle", "usage_user"])',
@@ -894,6 +932,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'last',
     args: [],
+    package: '',
     desc: 'Selects the last non-null record from an input table.',
     example: 'last()',
     category: 'Selectors',
@@ -915,6 +954,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
     ],
+    package: '',
     desc:
       'Limits the number of records in output tables to a fixed number `n` records after the `offset`. If the input table has less than `n` records, all records are be output.',
     example: 'limit(n:10, offset: 0)',
@@ -947,6 +987,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
     ],
+    package: '',
     desc: 'Generates a list of linearly separated floats.',
     example: 'linearBins(start: 0.0, width: 5.0, count: 20, infinity: true)',
     category: 'Miscellaneous',
@@ -978,6 +1019,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
     ],
+    package: '',
     desc: 'Generates a list of exponentially separated floats.',
     example:
       'logarithmicBins(start: 1.0, factor: 2.0, count: 10, infinty: true)',
@@ -1005,6 +1047,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Returns the bottom `n` records from all groups using the average of each group.',
     example: 'lowestAverage(n:10, groupColumns: ["host"])',
@@ -1032,6 +1075,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Returns the bottom `n` records from all groups using the last value of each group.',
     example: 'lowestCurrent(n:10, groupColumns: ["host"])',
@@ -1059,6 +1103,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Returns the bottom `n` records from all groups using the maximum of each group.',
     example: 'lowestMin(n:10, groupColumns: ["host"])',
@@ -1082,6 +1127,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
     ],
+    package: '',
     desc: 'Applies a function to each record in the input tables.',
     example: 'map(fn: (r) => r._value * r._value, mergeKey: true)',
     category: 'Transformations',
@@ -2150,6 +2196,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'max',
     args: [],
+    package: '',
     desc: 'Selects record with the highest `_value` from the input table.',
     example: 'max()',
     category: 'Selectors',
@@ -2167,6 +2214,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Returns the median `_value` of an input table. The `median()` function can only be used with float value types.',
     example: 'median(column: "_value")',
@@ -2177,6 +2225,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'min',
     args: [],
+    package: '',
     desc: 'Selects record with the lowest `_value` from the input table.',
     example: 'min()',
     category: 'Selectors',
@@ -2202,6 +2251,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Computes the Pearson R correlation coefficient between two streams by first joining the streams, then performing the covariance operation normalized to compute R.',
     example: 'pearsonr(x: table1, y: table2, on: ["_time", "_field"])',
@@ -2230,6 +2280,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Collects values stored vertically (column-wise) in a table and aligns them horizontally (row-wise) into logical sets.',
     example:
@@ -2265,6 +2316,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Float',
       },
     ],
+    package: '',
     desc:
       'This is both an aggregate and selector function depending on the `method` used. When using the `estimate_tdigest` or `exact_mean` methods, it outputs non-null records with values that fall within the specified quantile. When using the `exact_selector` method, it outputs the non-null record with the value that represents the specified quantile.',
     example:
@@ -2289,6 +2341,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Object',
       },
     ],
+    package: '',
     desc: 'Aggregates records in each table according to the reducer, `fn`',
     example: 'reduce(fn: (r, accumulator) => ({ sum: r._value + accumulator.sum }), identity: {sum: 0.0})',
     category: 'Aggregates',
@@ -2311,6 +2364,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Function',
       },
     ],
+    package: '',
     desc:
       'Renames specified columns in a table. If a column is renamed and is part of the group key, the column name in the group key will be updated.',
     example: 'rename(columns: {host: "server", facility: "datacenter"})',
@@ -2333,6 +2387,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer',
       },
     ],
+    package: '',
     desc: 'Selects a subset of the records from the input table.',
     example: 'sample(n:5, pos: -1)',
     category: 'Selectors',
@@ -2353,6 +2408,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Assigns a static value to each record in the input table. The key may modify an existing column or add a new column to the tables. If the modified column is part of the group key, the output tables are regrouped as needed.',
     example: 'set(key: "myKey", value: "myValue")',
@@ -2370,6 +2426,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Outputs the skew of non-null records as a float.',
     example: 'skew(column: "_value")',
     category: 'Aggregates',
@@ -2391,6 +2448,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
     ],
+    package: '',
     desc:
       'Orders the records within each table. One output table is produced for each input table. The output tables will have the same schema as their corresponding input tables.',
     example: 'sort(columns: ["_value"], desc: false)',
@@ -2408,6 +2466,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Outputs the difference between the minimum and maximum values in the specified column. Only `uint`, `int`, and `float` column types can be used.',
     example: 'spread(column: "_value")',
@@ -2431,6 +2490,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Computes the number of consecutive records in a given state and stores the increment in a new column.',
     example: 'stateCount(fn: (r) => r._field == "state", column: "stateCount")',
@@ -2459,6 +2519,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Duration',
       },
     ],
+    package: '',
     desc:
       'Computes the duration of a given state and stores the increment in a new column.',
     example:
@@ -2483,6 +2544,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Computes the standard deviation of non-null records in specified column.',
     example: 'stddev(column: "_value", mode: "sample")',
@@ -2499,6 +2561,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Integer, UInteger, Float, Boolean, Duration, Time',
       },
     ],
+    package: '',
     desc: 'Converts a single value to a string.',
     example: 'string(v: r._value)',
     category: 'Type Conversions',
@@ -2642,6 +2705,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Computes the sum of non-null records in the specified column.',
     example: 'sum(column: "_value")',
     category: 'Aggregates',
@@ -2651,6 +2715,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'systemTime',
     args: [],
+    package: '',
     desc: 'Returns the current system time.',
     example: 'systemTime()',
     category: 'Miscellaneous',
@@ -2723,6 +2788,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String, Integer, UInteger',
       },
     ],
+    package: '',
     desc: 'Converts a single value to a time.',
     example: 'time(v: r._value)',
     category: 'Type Conversions',
@@ -2745,6 +2811,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc:
       'Adds a fixed duration to time columns. The output table schema is the same as the input table.',
     example: 'timeShift(duration: 10h, columns: ["_start", "_stop", "_time"])',
@@ -2809,6 +2876,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Function',
       },
     ],
+    package: '',
     desc: 'The `to()` function writes data to an InfluxDB v2.0 bucket.',
     example:
       'to(bucket: "my-bucket", org: "my-org", host: "http://example.com:8086", token: "xxxxxx", timeColumn: "_time", tagColumns: ["tag1", "tag2", "tag3"], fieldFn: (r) => ({ [r._field]: r._value }))',
@@ -2819,6 +2887,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'toBool',
     args: [],
+    package: '',
     desc: 'Converts all values in the `_value` column to a boolean.',
     example: 'toBool()',
     category: 'Type Conversions',
@@ -2828,6 +2897,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'toDuration',
     args: [],
+    package: '',
     desc: 'Converts all values in the `_value` column to a duration.',
     example: 'toDuration()',
     category: 'Type Conversions',
@@ -2846,6 +2916,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'toInt',
     args: [],
+    package: '',
     desc: 'Converts all values in the `_value` column to a integer.',
     example: 'toInt()',
     category: 'Type Conversions',
@@ -2855,6 +2926,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'toString',
     args: [],
+    package: '',
     desc: 'Converts a value to a string.',
     example: 'toString()',
     category: 'Type Conversions',
@@ -2864,6 +2936,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'toTime',
     args: [],
+    package: '',
     desc: 'Converts a value to a time.',
     example: 'toTime()',
     category: 'Type Conversions',
@@ -2873,6 +2946,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'toUInt',
     args: [],
+    package: '',
     desc: 'Converts a value to an unsigned integer.',
     example: 'toUInt()',
     category: 'Type Conversions',
@@ -2894,6 +2968,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
     ],
+    package: '',
     desc: 'Sorts a table by columns and keeps only the top n rows.',
     example: 'top(n:10, cols: ["_value"])',
     category: 'Selectors',
@@ -2909,6 +2984,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String, Integer, Boolean',
       },
     ],
+    package: '',
     desc: 'Converts a single value to a uinteger.',
     example: 'uint(v: r._value)',
     category: 'Type Conversions',
@@ -2925,6 +3001,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc: 'Returns all rows containing unique values in a specified column.',
     example: 'unique(column: "_value")',
     category: 'Selectors',
@@ -3105,6 +3182,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Groups records based on a time value. New columns are added to uniquely identify each window. Those columns are added to the group key of the output tables. A single input record will be placed into zero or more output tables, depending on the specific windowing function.',
     example:
@@ -3122,6 +3200,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'String',
       },
     ],
+    package: '',
     desc:
       'Indicates the input tables received should be delivered as a result of the query. Yield outputs the input stream unmodified. A query may have multiple results, each identified by the name provided to the `yield()` function.',
     example: 'yield(name: "custom-name")',

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -350,7 +350,8 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       },
       {
         name: 'columns',
-        desc: 'A list of columns on which to operate. Defaults to `["_value"]`.',
+        desc:
+          'A list of columns on which to operate. Defaults to `["_value"]`.',
         type: 'Array of Strings',
       },
       {

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -2907,6 +2907,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
   {
     name: 'toFloat',
     args: [],
+    package: '',
     desc: 'Converts all values in the `_value` column to a float.',
     example: 'toFloat()',
     category: 'Type Conversions',

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -349,9 +349,9 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
         type: 'Boolean',
       },
       {
-        name: 'column',
-        desc: 'The column on which to operate. Defaults to `"_value"`.',
-        type: 'String',
+        name: 'columns',
+        desc: 'A list of columns on which to operate. Defaults to `["_value"]`.',
+        type: 'Array of Strings',
       },
       {
         name: 'timeColumn',
@@ -363,7 +363,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     desc:
       'Computes the rate of change per unit of time between subsequent non-null records. The output table schema will be the same as the input table.',
     example:
-      'derivative(unit: 1s, nonNegative: true, column: "_value", timeColumn: "_time")',
+      'derivative(unit: 1s, nonNegative: true, columns: ["_value"], timeColumn: "_time")',
     category: 'Aggregates',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/transformations/aggregates/derivative/',

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -23,7 +23,7 @@ import {insertVariable} from 'src/timeMachine/utils/insertVariable'
 import {HANDLE_VERTICAL, HANDLE_NONE} from 'src/shared/constants'
 
 // Types
-import {AppState} from 'src/types'
+import {AppState, FluxToolbarFunction} from 'src/types'
 
 interface StateProps {
   activeQueryText: string
@@ -135,8 +135,7 @@ class TimeMachineFluxEditor extends PureComponent<Props, State> {
   }
 
   private handleInsertFluxFunction = async (
-    functionName: string,
-    fluxFunction: string
+    func: FluxToolbarFunction
   ): Promise<void> => {
     const {activeQueryText} = this.props
     const {line} = this.cursorPosition
@@ -144,8 +143,7 @@ class TimeMachineFluxEditor extends PureComponent<Props, State> {
     const {updatedScript, cursorPosition} = insertFluxFunction(
       line,
       activeQueryText,
-      functionName,
-      fluxFunction
+      func
     )
     await this.props.onSetActiveQueryText(updatedScript)
 

--- a/ui/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
+++ b/ui/src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar.tsx
@@ -19,10 +19,10 @@ import {getActiveQuery} from 'src/timeMachine/selectors'
 import {FLUX_FUNCTIONS} from 'src/shared/constants/fluxFunctions'
 
 // Types
-import {AppState} from 'src/types'
+import {AppState, FluxToolbarFunction} from 'src/types'
 
 interface OwnProps {
-  onInsertFluxFunction: (functionName: string, text: string) => void
+  onInsertFluxFunction: (func: FluxToolbarFunction) => void
 }
 
 interface StateProps {
@@ -75,8 +75,8 @@ class FluxFunctionsToolbar extends PureComponent<Props, State> {
     this.setState({searchTerm})
   }
 
-  private handleClickFunction = (funcName: string, funcExample: string) => {
-    this.props.onInsertFluxFunction(funcName, funcExample)
+  private handleClickFunction = (func: FluxToolbarFunction) => {
+    this.props.onInsertFluxFunction(func)
   }
 }
 

--- a/ui/src/timeMachine/components/fluxFunctionsToolbar/FunctionCategory.tsx
+++ b/ui/src/timeMachine/components/fluxFunctionsToolbar/FunctionCategory.tsx
@@ -10,7 +10,7 @@ import {FluxToolbarFunction} from 'src/types/shared'
 interface Props {
   category: string
   funcs: FluxToolbarFunction[]
-  onClickFunction: (name: string, example: string) => void
+  onClickFunction: (func: FluxToolbarFunction) => void
 }
 
 const FunctionCategory: SFC<Props> = props => {

--- a/ui/src/timeMachine/components/fluxFunctionsToolbar/ToolbarFunction.tsx
+++ b/ui/src/timeMachine/components/fluxFunctionsToolbar/ToolbarFunction.tsx
@@ -10,7 +10,7 @@ import {FluxToolbarFunction} from 'src/types/shared'
 
 interface Props {
   func: FluxToolbarFunction
-  onClickFunction: (name: string, example: string) => void
+  onClickFunction: (func: FluxToolbarFunction) => void
   testID: string
 }
 
@@ -83,7 +83,7 @@ class ToolbarFunction extends PureComponent<Props, State> {
   private handleClickFunction = () => {
     const {func, onClickFunction} = this.props
 
-    onClickFunction(func.name, func.example)
+    onClickFunction(func)
   }
 }
 

--- a/ui/src/timeMachine/utils/insertFunction.ts
+++ b/ui/src/timeMachine/utils/insertFunction.ts
@@ -16,8 +16,6 @@ const insertAtLine = (
   textToInsert: string,
   insertOnSameLine?: boolean
 ): string => {
-  const numPackages = scriptLines.filter(sl => sl.includes('import "')).length
-
   const front = scriptLines.slice(0, lineNumber)
   const backStartIndex = insertOnSameLine ? lineNumber + 1 : lineNumber
   const back = scriptLines.slice(backStartIndex)

--- a/ui/src/types/shared.ts
+++ b/ui/src/types/shared.ts
@@ -27,6 +27,7 @@ export interface FluxToolbarFunction {
   name: string
   args: FluxToolbarArg[]
   desc: string
+  package: string
   example: string
   category: string
   link: string


### PR DESCRIPTION
Closes #13667
- If a user clicks on a function in the raw text editor, the builder adds the appropriate imports for said function
- It does not duplicate imports
- Maintains cursor / line positioning
- Add e2e tests 

![Kapture 2019-04-29 at 16 42 35](https://user-images.githubusercontent.com/7582765/56933719-dbb51c00-6a9d-11e9-99f2-664990011adf.gif)
