### PR TITLE
chore(log): Put trace_id back in logs

### DIFF
--- a/storage/retention.go
+++ b/storage/retention.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -86,15 +87,18 @@ func (s *retentionEnforcer) run() {
 		return // Not initialized
 	}
 
-	log, logEnd := logger.NewOperation(s.logger, "Data retention check", "data_retention_check")
+	span, ctx := tracing.StartSpanFromContext(context.Background())
+	defer span.Finish()
+
+	log, logEnd := logger.NewOperation(ctx, s.logger, "Data retention check", "data_retention_check")
 	defer logEnd()
 
 	now := time.Now().UTC()
-	buckets, err := s.getBucketInformation()
+	buckets, err := s.getBucketInformation(ctx)
 	if err != nil {
 		log.Error("Unable to determine bucket information", zap.Error(err))
 	} else {
-		s.expireData(buckets, now)
+		s.expireData(ctx, buckets, now)
 	}
 	s.tracker.CheckDuration(time.Since(now), err == nil)
 }
@@ -103,14 +107,21 @@ func (s *retentionEnforcer) run() {
 //
 // Any series data that (1) belongs to a bucket in the provided list and
 // (2) falls outside the bucket's indicated retention period will be deleted.
-func (s *retentionEnforcer) expireData(buckets []*influxdb.Bucket, now time.Time) {
-	logger, logEnd := logger.NewOperation(s.logger, "Data deletion", "data_deletion")
+func (s *retentionEnforcer) expireData(ctx context.Context, buckets []*influxdb.Bucket, now time.Time) {
+	logger, logEnd := logger.NewOperation(ctx, s.logger, "Data deletion", "data_deletion")
 	defer logEnd()
 
 	for _, b := range buckets {
 		if b.RetentionPeriod == 0 {
 			continue
 		}
+
+		span, _ := tracing.StartSpanFromContext(ctx)
+		span.LogKV(
+			"bucket", b.Name,
+			"org_id", b.OrgID,
+			"retention_period", b.RetentionPeriod,
+			"retention_policy", b.RetentionPolicyName)
 
 		max := now.Add(-b.RetentionPeriod).UnixNano()
 		err := s.Engine.DeleteBucketRange(b.OrgID, b.ID, math.MinInt64, max)
@@ -119,14 +130,17 @@ func (s *retentionEnforcer) expireData(buckets []*influxdb.Bucket, now time.Time
 				zap.String("bucket id", b.ID.String()),
 				zap.String("org id", b.OrgID.String()),
 				zap.Error(err))
+			tracing.LogError(span, err)
 		}
 		s.tracker.IncChecks(b.OrgID, b.ID, err == nil)
+
+		span.Finish()
 	}
 }
 
 // getBucketInformation returns a slice of buckets to run retention on.
-func (s *retentionEnforcer) getBucketInformation() ([]*influxdb.Bucket, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), bucketAPITimeout)
+func (s *retentionEnforcer) getBucketInformation(ctx context.Context) ([]*influxdb.Bucket, error) {
+	ctx, cancel := context.WithTimeout(ctx, bucketAPITimeout)
 	defer cancel()
 
 	buckets, _, err := s.BucketService.FindBuckets(ctx, influxdb.BucketFilter{})

--- a/storage/retention_test.go
+++ b/storage/retention_test.go
@@ -20,8 +20,8 @@ func TestRetentionService(t *testing.T) {
 	now := time.Date(2018, 4, 10, 23, 12, 33, 0, time.UTC)
 
 	t.Run("no buckets", func(t *testing.T) {
-		service.expireData(nil, now)
-		service.expireData([]*influxdb.Bucket{}, now)
+		service.expireData(context.Background(), nil, now)
+		service.expireData(context.Background(), []*influxdb.Bucket{}, now)
 	})
 
 	// Generate some buckets to expire
@@ -75,7 +75,7 @@ func TestRetentionService(t *testing.T) {
 	}
 
 	t.Run("multiple buckets", func(t *testing.T) {
-		service.expireData(buckets, now)
+		service.expireData(context.Background(), buckets, now)
 		if !reflect.DeepEqual(gotMatched, expMatched) {
 			t.Fatalf("got\n%#v\nexpected\n%#v", gotMatched, expMatched)
 		}

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -93,10 +93,10 @@ func (f *SeriesFile) Open(ctx context.Context) error {
 		return errors.New("series file already opened")
 	}
 
-	span, _ := tracing.StartSpanFromContext(ctx)
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
-	_, logEnd := logger.NewOperation(f.Logger, "Opening Series File", "series_file_open", zap.String("path", f.path))
+	_, logEnd := logger.NewOperation(ctx, f.Logger, "Opening Series File", "series_file_open", zap.String("path", f.path))
 	defer logEnd()
 
 	// Create path if it doesn't exist.

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -779,7 +779,7 @@ func (e *Engine) WriteSnapshot(ctx context.Context) error {
 
 	started := time.Now()
 
-	log, logEnd := logger.NewOperation(e.logger, "Cache snapshot", "tsm1_cache_snapshot")
+	log, logEnd := logger.NewOperation(ctx, e.logger, "Cache snapshot", "tsm1_cache_snapshot")
 	defer func() {
 		elapsed := time.Since(started)
 		log.Info("Snapshot for path written",
@@ -1115,12 +1115,12 @@ func (s *compactionStrategy) Apply(ctx context.Context) {
 
 // compactGroup executes the compaction strategy against a single CompactionGroup.
 func (s *compactionStrategy) compactGroup(ctx context.Context) {
-	span, _ := tracing.StartSpanFromContext(ctx)
+	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
 	now := time.Now()
 	group := s.group
-	log, logEnd := logger.NewOperation(s.logger, "TSM compaction", "tsm1_compact_group")
+	log, logEnd := logger.NewOperation(ctx, s.logger, "TSM compaction", "tsm1_compact_group")
 	defer logEnd()
 
 	log.Info("Beginning compaction", zap.Int("tsm1_files_n", len(group)))


### PR DESCRIPTION
PR #12878 removed the `trace_id` field from logging. This adds it back in most of the places it was removed, but now the `trace_id` field matches the Jaeger `trace_id` for the context, so some cross-referencing is possible.

Fixes #13580