### PR TITLE
Ensure GroupCursor Keys is union of keys from all GroupCursors of current partition key

### DIFF
--- a/storage/reads/mergegroupresultset.go
+++ b/storage/reads/mergegroupresultset.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"sort"
 
+	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/slices"
 )
 
@@ -97,6 +98,7 @@ type groupByMergedGroupResultSet struct {
 	nilVal       []byte
 	err          error
 
+	km models.TagKeysSet
 	gc groupByMergedGroupCursor
 }
 
@@ -183,7 +185,13 @@ func (r *groupByMergedGroupResultSet) Next() GroupCursor {
 
 	r.gc.first = true
 	r.gc.heap.init(r.resultSets)
-	r.gc.keys = r.groupCursors[0].Keys()
+
+	r.km.Clear()
+	for i := range r.groupCursors {
+		r.km.UnionBytes(r.groupCursors[i].Keys())
+	}
+
+	r.gc.keys = append(r.gc.keys[:0], r.km.KeysBytes()...)
 	r.gc.vals = r.groupCursors[0].PartitionKeyVals()
 	return &r.gc
 }

--- a/storage/reads/mergegroupresultset_test.go
+++ b/storage/reads/mergegroupresultset_test.go
@@ -225,6 +225,24 @@ group:
 			},
 			exp: exp,
 		},
+		{
+			name: "does merge keys",
+			streams: []*sliceStreamReader{
+				newStreamReader(
+					groupByF("_m,tag1", "val00,<nil>", "aaa,tag0=val00", "cpu,tag0=val00,tag1=val11"),
+					groupByF("_m,tag2", "<nil>,val20", "mem,tag1=val10,tag2=val20"),
+					groupByF("_m,tag1,tag2", "<nil>,val21", "mem,tag1=val11,tag2=val21"),
+				),
+				newStreamReader(
+					groupByF("_m,tag0,tag1", "val00,<nil>", "cpu,tag0=val00,tag1=val10", "cpu,tag0=val00,tag1=val12"),
+					groupByF("_m,tag0", "val01,<nil>", "aaa,tag0=val01"),
+				),
+				newStreamReader(
+					groupByF("_m,tag1", "<nil>,val20", "mem,tag1=val11,tag2=val20"),
+				),
+			},
+			exp: exp,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This fix ensures the `groupByMergedGroupResultSet` produces a merged `GroupCursor` that unions all the `Keys` for the current partition key.

This PR is required for #13623


## Description of failure and test case

The new test case verifies that each `GroupResultSet` instances with the **same partition key** is correctly merged when the Keys of each `GroupResultSet` differ. 

How does it do that? The test uses helper functions to construct a series of protobuf frames that are decoded into `GroupResultSet` instances, required by the function to be tested, `NewGroupByMergedGroupResultSet`.

### `newStreamReader`

https://github.com/influxdata/influxdb/blob/fb39ac39ce4a2ad275d1a7d046232d70df9eb62b/storage/reads/stream_reader_test.go#L733

Each `newStreamReader` takes a series of protobuf `ReadResponse` instances to construct an RPC response. It returns a `GroupResultSet`, which represents a single stream to be merged by the the code being tested, `NewGroupByMergedGroupResultSet`, which produces a single `GroupResultSet` from many input `GroupResultSet` instances.

### `groupByF`

https://github.com/influxdata/influxdb/blob/96c2282aab3e81afbb61b4eedffad2a10cfc1936/storage/reads/mergegroupresultset_test.go#L148

Each `newStreamReader` is initialized with one or more `groupByF` calls, which is a builder to return a `ReadResponse`. The function returns a single group frame and one or more series frames. The first argument to `groupByF` represents the `Keys`:

https://github.com/influxdata/influxdb/blob/7fc9661b7bec253a476e6f984b368670271f1ed4/storage/reads/store.go#L55-L57

The second argument is the `PartitionKeyValues`:

https://github.com/influxdata/influxdb/blob/7fc9661b7bec253a476e6f984b368670271f1ed4/storage/reads/store.go#L59-L65

----

In the following test case:

https://github.com/influxdata/influxdb/blob/96c2282aab3e81afbb61b4eedffad2a10cfc1936/storage/reads/mergegroupresultset_test.go#L229

note there are two instances of partition key `val00,<nil>`, with differing `tagKeys`, here:

https://github.com/influxdata/influxdb/blob/96c2282aab3e81afbb61b4eedffad2a10cfc1936/storage/reads/mergegroupresultset_test.go#L232

and here

https://github.com/influxdata/influxdb/blob/96c2282aab3e81afbb61b4eedffad2a10cfc1936/storage/reads/mergegroupresultset_test.go#L237

The expected, _merged_ output of the `Keys` function is these with the **same partition key** should be:

https://github.com/influxdata/influxdb/blob/96c2282aab3e81afbb61b4eedffad2a10cfc1936/storage/reads/mergegroupresultset_test.go#L159-L168

