### PR TITLE
fix(query/influxql): update transpiler for moved/renamed code

### DIFF
--- a/query/influxql/function.go
+++ b/query/influxql/function.go
@@ -131,19 +131,11 @@ func createFunctionCursor(t *transpilerState, call *influxql.Call, in cursor, no
 			Argument: in.Expr(),
 			Call: &ast.CallExpression{
 				Callee: &ast.Identifier{
-					Name: "percentile",
+					Name: "median",
 				},
 				Arguments: []ast.Expression{
 					&ast.ObjectExpression{
 						Properties: []*ast.Property{
-							{
-								Key: &ast.Identifier{
-									Name: "percentile",
-								},
-								Value: &ast.FloatLiteral{
-									Value: 0.5,
-								},
-							},
 							{
 								Key: &ast.Identifier{
 									Name: "method",
@@ -186,7 +178,7 @@ func createFunctionCursor(t *transpilerState, call *influxql.Call, in cursor, no
 		args := []*ast.Property{
 			{
 				Key: &ast.Identifier{
-					Name: "percentile",
+					Name: "q",
 				},
 				Value: &ast.FloatLiteral{
 					Value: percentile,
@@ -217,7 +209,7 @@ func createFunctionCursor(t *transpilerState, call *influxql.Call, in cursor, no
 			Argument: in.Expr(),
 			Call: &ast.CallExpression{
 				Callee: &ast.Identifier{
-					Name: "percentile",
+					Name: "quantile",
 				},
 				Arguments: []ast.Expression{
 					&ast.ObjectExpression{

--- a/query/influxql/spectests/show_databases.go
+++ b/query/influxql/spectests/show_databases.go
@@ -6,7 +6,9 @@ func init() {
 			`SHOW DATABASES`,
 			`package main
 
-databases()
+import v1 "influxdata/influxdb/v1"
+
+v1.databases()
 	|> rename(columns: {databaseName: "name"})
 	|> keep(columns: ["name"])
 	|> yield(name: "0")

--- a/query/influxql/spectests/show_retention_policies.go
+++ b/query/influxql/spectests/show_retention_policies.go
@@ -6,7 +6,9 @@ func init() {
 			`SHOW RETENTION POLICIES ON telegraf`,
 			`package main
 
-databases()
+import v1 "influxdata/influxdb/v1"
+
+v1.databases()
 	|> filter(fn: (r) => r.databaseName == "telegraf")
 	|> rename(columns: {retentionPolicy: "name", retentionPeriod: "duration"})
 	|> set(key: "shardGroupDuration", value: "0")


### PR DESCRIPTION
The `databases()` function was moved into the `influxdata/influxdb/v1`
package and so it wouldn't work anymore. The `percentile()` call was
changed to `quantile()` and the argument was changed to `q`. This also
updates `median()` to use `median()` since we now produce AST's and not
the spec so we can use the `median()` definition instead.