### PR TITLE
Ensure sort keys are correctly delimited to avoid collisions

### DIFF
--- a/storage/reads/group_resultset.go
+++ b/storage/reads/group_resultset.go
@@ -244,7 +244,7 @@ func groupBySort(g *groupResultSet) (int, error) {
 			nr.SeriesTags = tagsBuf.copyTags(nr.SeriesTags)
 			nr.Tags = tagsBuf.copyTags(nr.Tags)
 
-			l := 0
+			l := len(g.keys) // for sort key separators
 			for i, k := range g.keys {
 				vals[i] = nr.Tags.Get(k)
 				if len(vals[i]) == 0 {
@@ -256,6 +256,7 @@ func groupBySort(g *groupResultSet) (int, error) {
 			nr.SortKey = make([]byte, 0, l)
 			for _, v := range vals {
 				nr.SortKey = append(nr.SortKey, v...)
+				nr.SortKey = append(nr.SortKey, ',')
 			}
 
 			rows = append(rows, &nr)


### PR DESCRIPTION
This manifested as incorrect sort ordering when serialized via RPC, resulting in an `invalid partition key order` error.

This fix introduces a delimiter to ensure sort keys cannot collide.
