### PR TITLE
fix(readservice): normalize special tag keys after reducing request p…

### DIFF
--- a/storage/readservice/cursor.go
+++ b/storage/readservice/cursor.go
@@ -129,16 +129,8 @@ func (c *indexSeriesCursor) Next() *reads.SeriesRow {
 	//TODO(edd): check this.
 	c.row.SeriesTags = copyTags(c.row.SeriesTags, sr.Tags)
 	c.row.Tags = copyTags(c.row.Tags, sr.Tags)
-
-	// Normalise the special tag keys to the emitted format.
-	mv := c.row.Tags.Get(models.MeasurementTagKeyBytes)
-	c.row.Tags.Delete(models.MeasurementTagKeyBytes)
-	c.row.Tags.Set(measurementKeyBytes, mv)
-
 	fv := c.row.Tags.Get(models.FieldKeyTagKeyBytes)
 	c.row.Field = string(fv)
-	c.row.Tags.Delete(models.FieldKeyTagKeyBytes)
-	c.row.Tags.Set(fieldKeyBytes, fv)
 
 	if c.cond != nil && c.hasValueExpr {
 		// TODO(sgc): lazily evaluate valueCond
@@ -148,6 +140,13 @@ func (c *indexSeriesCursor) Next() *reads.SeriesRow {
 			c.row.ValueCond = nil
 		}
 	}
+
+	// Normalise the special tag keys to the emitted format.
+	mv := c.row.Tags.Get(models.MeasurementTagKeyBytes)
+	c.row.Tags.Delete(models.MeasurementTagKeyBytes)
+	c.row.Tags.Set(measurementKeyBytes, mv)
+	c.row.Tags.Delete(models.FieldKeyTagKeyBytes)
+	c.row.Tags.Set(fieldKeyBytes, fv)
 
 	return &c.row
 }


### PR DESCRIPTION
…redicate

When InfluxDB receives a read filter request, it parses the predicate and transforms special tag keys (`_measurement` and `_field`) to its internal encoding:

https://github.com/influxdata/influxdb/blob/2909927ab0eaa2943905f5beab5bbb8d71ca18b8/storage/reads/predicate.go#L260

The encoding is later reverted to reflect the emitted format.

However, if the predicate contains a filtering expression on the value, that expression is reduced to be evaluated later.

The encoding must be reverted after this operation is performed, otherwise the reduction will produce wrong values.


- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
