### PR TITLE
Feat/user agent telemetry

### DIFF
--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -1,0 +1,58 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	_ "net/http/pprof"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+)
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	type fields struct {
+		name           string
+		MetricsHandler http.Handler
+		ReadyHandler   http.Handler
+		HealthHandler  http.Handler
+		DebugHandler   http.Handler
+		Handler        http.Handler
+		requests       *prometheus.CounterVec
+		requestDur     *prometheus.HistogramVec
+		Logger         *zap.Logger
+	}
+	type args struct {
+		w *httptest.ResponseRecorder
+		r *http.Request
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{
+			name: "howdy",
+			fields: fields{
+				name:    "doody",
+				Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+				Logger:  zap.NewNop(),
+			},
+			args: args{
+				r: httptest.NewRequest(http.MethodGet, "/", nil),
+				w: httptest.NewRecorder(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Handler{
+				name:    tt.fields.name,
+				Handler: tt.fields.Handler,
+				Logger:  tt.fields.Logger,
+			}
+			h.initMetrics()
+			h.ServeHTTP(tt.args.w, tt.args.r)
+		})
+	}
+}


### PR DESCRIPTION
Closes #13759
Closes https://github.com/influxdata/idpe/issues/2492

This PR adds User Agent metrics to HTTP endpoints, as well as adding testing for http/handler.go

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
