### PR TITLE
fix(.github): Add changelog task back into PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ Describe your proposed changes here.
 
 <!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->
 
+- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
 - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
 - [ ] Rebased/mergeable
 - [ ] Tests pass


### PR DESCRIPTION
Adds the changelog task to the PR template, which was removed in https://github.com/influxdata/influxdb/pull/13373.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
