### PR TITLE
fix(tsdb): Fix series file count

### DIFF
--- a/tsdb/series_file_test.go
+++ b/tsdb/series_file_test.go
@@ -131,6 +131,11 @@ func TestSeriesFileCompactor(t *testing.T) {
 			t.Fatalf("series does not exist: %s,%s", iter.Name(), iter.Tags().String())
 		}
 	}
+
+	// Verify total number of series is correct.
+	if got, exp := sfile.SeriesCount(), uint64(len(collection.Names)); got != exp {
+		t.Fatalf("SeriesCount()=%d, expected %d (after compaction)", got, exp)
+	}
 }
 
 // Ensures that types are tracked and checked by the series file.
@@ -192,29 +197,64 @@ func TestSeriesFile_DeleteSeriesID(t *testing.T) {
 	}
 	id := sfile.SeriesID([]byte("m1"), nil, nil)
 
+	// Verify total number of series is correct.
+	if got, exp := sfile.SeriesCount(), uint64(2); got != exp {
+		t.Fatalf("SeriesCount()=%d, expected %d (before deleted)", got, exp)
+	}
+
 	// Delete and ensure deletion.
 	if err := sfile.DeleteSeriesID(id); err != nil {
 		t.Fatal(err)
-	} else if err := sfile.CreateSeriesListIfNotExists(&tsdb.SeriesCollection{
-		Names: [][]byte{[]byte("m1")},
-		Tags:  []models.Tags{{}},
-		Types: []models.FieldType{models.String},
-	}); err != nil {
-		t.Fatal(err)
 	} else if !sfile.IsDeleted(id) {
 		t.Fatal("expected deletion before compaction")
+	}
+
+	// Verify total number of series is correct.
+	if got, exp := sfile.SeriesCount(), uint64(1); got != exp {
+		t.Fatalf("SeriesCount()=%d, expected %d (before compaction)", got, exp)
 	}
 
 	if err := sfile.ForceCompact(); err != nil {
 		t.Fatal(err)
 	} else if !sfile.IsDeleted(id) {
 		t.Fatal("expected deletion after compaction")
+	} else if got, exp := sfile.SeriesCount(), uint64(1); got != exp {
+		t.Fatalf("SeriesCount()=%d, expected %d (after compaction)", got, exp)
 	}
 
 	if err := sfile.Reopen(); err != nil {
 		t.Fatal(err)
 	} else if !sfile.IsDeleted(id) {
 		t.Fatal("expected deletion after reopen")
+	} else if got, exp := sfile.SeriesCount(), uint64(1); got != exp {
+		t.Fatalf("SeriesCount()=%d, expected %d (after reopen)", got, exp)
+	}
+
+	// Recreate series with new ID.
+	if err := sfile.CreateSeriesListIfNotExists(&tsdb.SeriesCollection{
+		Names: [][]byte{[]byte("m1")},
+		Tags:  []models.Tags{{}},
+		Types: []models.FieldType{models.String},
+	}); err != nil {
+		t.Fatal(err)
+	} else if got, exp := sfile.SeriesCount(), uint64(2); got != exp {
+		t.Fatalf("SeriesCount()=%d, expected %d (after recreate)", got, exp)
+	}
+
+	if err := sfile.ForceCompact(); err != nil {
+		t.Fatal(err)
+	} else if !sfile.IsDeleted(id) {
+		t.Fatal("expected deletion after compaction")
+	} else if got, exp := sfile.SeriesCount(), uint64(2); got != exp {
+		t.Fatalf("SeriesCount()=%d, expected %d (after recreate & compaction)", got, exp)
+	}
+
+	if err := sfile.Reopen(); err != nil {
+		t.Fatal(err)
+	} else if !sfile.IsDeleted(id) {
+		t.Fatal("expected deletion after reopen")
+	} else if got, exp := sfile.SeriesCount(), uint64(2); got != exp {
+		t.Fatalf("SeriesCount()=%d, expected %d (after recreate & compaction)", got, exp)
 	}
 }
 

--- a/tsdb/series_index_test.go
+++ b/tsdb/series_index_test.go
@@ -55,6 +55,10 @@ func TestSeriesIndex_Delete(t *testing.T) {
 	} else if idx.IsDeleted(tsdb.NewSeriesID(2)) {
 		t.Fatal("expected series to exist")
 	}
+
+	if exp, got := idx.Count(), uint64(1); exp != got {
+		t.Fatalf("Count()=%d, expected %d", exp, got)
+	}
 }
 
 func TestSeriesIndex_FindIDBySeriesKey(t *testing.T) {


### PR DESCRIPTION
Previously the series file did not include tombstones in the total count. This commit now includes tombstones in the count as well as fixes an issue where replayed tombstone records could exist but their underlying ID did not exist. This caused the count to become negative and with the count being `uint64` it caused the count to rollover to `math.Uint64Max`.

Related: https://github.com/influxdata/influxdb/issues/13690

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr)
