### PR TITLE
fix(storage): don't remap renamed TSM file

### DIFF
--- a/tsdb/tsm1/reader_mmap.go
+++ b/tsdb/tsm1/reader_mmap.go
@@ -20,9 +20,10 @@ type mmapAccessor struct {
 	logger       *zap.Logger
 	mmapWillNeed bool // If true then mmap advise value MADV_WILLNEED will be provided the kernel for b.
 
-	mu sync.RWMutex
-	b  []byte
-	f  *os.File
+	mu    sync.RWMutex
+	b     []byte
+	f     *os.File
+	_path string // If the underlying file is renamed then this gets updated
 
 	index *indirectIndex
 }
@@ -30,6 +31,9 @@ type mmapAccessor struct {
 func (m *mmapAccessor) init() (*indirectIndex, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	// Set the path explicitly.
+	m._path = m.f.Name()
 
 	if err := verifyVersion(m.f); err != nil {
 		return nil, err
@@ -119,41 +123,10 @@ func (m *mmapAccessor) rename(path string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	err := munmap(m.b)
-	if err != nil {
+	if err := file.RenameFile(m._path, path); err != nil {
 		return err
 	}
-
-	if err := m.f.Close(); err != nil {
-		return err
-	}
-
-	if err := file.RenameFile(m.f.Name(), path); err != nil {
-		return err
-	}
-
-	m.f, err = os.Open(path)
-	if err != nil {
-		return err
-	}
-
-	if _, err := m.f.Seek(0, 0); err != nil {
-		return err
-	}
-
-	stat, err := m.f.Stat()
-	if err != nil {
-		return err
-	}
-
-	m.b, err = mmap(m.f, 0, int(stat.Size()))
-	if err != nil {
-		return err
-	}
-
-	if m.mmapWillNeed {
-		return madviseWillNeed(m.b)
-	}
+	m._path = path
 	return nil
 }
 
@@ -251,9 +224,8 @@ func (m *mmapAccessor) readAll(key []byte) ([]Value, error) {
 
 func (m *mmapAccessor) path() string {
 	m.mu.RLock()
-	path := m.f.Name()
-	m.mu.RUnlock()
-	return path
+	defer m.mu.RUnlock()
+	return m._path
 }
 
 func (m *mmapAccessor) close() error {


### PR DESCRIPTION
**Note!** - this has not been proved. It’s become very hard to try and reproduce this bug. So consider this conjecture…

We have recently being hitting a very rare segfault where a read of the TSM index is accessing unmapped data. 

The panic typically looks like this:

```
unexpected fault address 0x7f534ccbdb00
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7f534ccbdb00 pc=0xe92628]
goroutine 73939753 [running]:
runtime.throw(0x16e97e5, 0x5)
	/usr/local/go/src/runtime/panic.go:617 +0x72 fp=0xc248f62a70 sp=0xc248f62a40 pc=0x42d892
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:397 +0x401 fp=0xc248f62aa0 sp=0xc248f62a70 pc=0x442fc1
github.com/influxdata/influxdb/tsdb/tsm1.(*readerOffsetsIterator).Length(...)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/reader_offsets.go:117
github.com/influxdata/influxdb/tsdb/tsm1.(*readerOffsetsIterator).Key(0xc248f62bf8, 0xc1e141f5b0, 0x0, 0xe93516, 0x14913c0)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/reader_offsets.go:125 +0xe8 fp=0xc248f62ab0 sp=0xc248f62aa0 pc=0xe92628
github.com/influxdata/influxdb/tsdb/tsm1.(*readerOffsetsIterator).Compare(0xc248f62bf8, 0xc05464c6c0, 0x6c, 0x120, 0x4a27dcf3b1047b6d, 0xc1e141f5b0, 0x1)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/reader_offsets.go:254 +0x88 fp=0xc248f62af8 sp=0xc248f62ab0 pc=0xe92f08
github.com/influxdata/influxdb/tsdb/tsm1.(*readerOffsetsIterator).Seek(0xc248f62bf8, 0xc05464c6c0, 0x6c, 0x120, 0xc1e141f5b0, 0x0)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/reader_offsets.go:222 +0x143 fp=0xc248f62b70 sp=0xc248f62af8 pc=0xe92c23
github.com/influxdata/influxdb/tsdb/tsm1.(*indirectIndex).TombstoneRange(0xc1e141f590, 0xc05464c6c0, 0x6c, 0x120, 0x0, 0x0, 0x0, 0xc26878c550, 0xc2589175f0, 0x0)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/reader_index.go:556 +0x188 fp=0xc248f62c88 sp=0xc248f62b70 pc=0xe8da98
github.com/influxdata/influxdb/tsdb/tsm1.(*TSMReader).TombstoneRange(0xc1fb6f6c00, 0xc05464c6c0, 0x6c, 0x120, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/reader.go:433 +0x9e fp=0xc248f62d00 sp=0xc248f62c88 pc=0xe895fe
github.com/influxdata/influxdb/tsdb/tsm1.(*KeyCursor).ReadFloatArrayBlock(0xc27b2d8780, 0xc2589175f0, 0xc2589175f0, 0x0, 0x0)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/file_store_array.gen.go:34 +0x192 fp=0xc248f62de0 sp=0xc248f62d00 pc=0xe7cb82
github.com/influxdata/influxdb/tsdb/tsm1.(*floatArrayAscendingCursor).readArrayBlock(...)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/array_cursor.gen.go:162
github.com/influxdata/influxdb/tsdb/tsm1.(*floatArrayAscendingCursor).nextTSM(0xc247657aa0, 0x1597d7410f24d870)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/array_cursor.gen.go:156 +0x4b fp=0xc248f62e18 sp=0xc248f62de0 pc=0xe2fddb
github.com/influxdata/influxdb/tsdb/tsm1.(*floatArrayAscendingCursor).Next(0xc247657aa0, 0x2)
	/go/src/github.com/influxdata/project/vendor/github.com/influxdata/influxdb/tsdb/tsm1/array_cursor.gen.go:102 +0x17c fp=0xc248f62e80 sp=0xc248f62e18 pc=0xe2f7bc
github.com/influxdata/influxdb/storage/reads.(*floatMultiShardArrayCursor).Next(0xc23c02cd58, 0x3e86)

```

It’s a read on some unmapped data.

The existing implementation of the `FileStore` attempts to handle the situation where a file is compacted out but still being read in the following way:

- First it determines that the TSM file [is in use](https://github.com/influxdata/influxdb/blob/master/tsdb/tsm1/file_store.go#L923).
- If it is in use then it attempts to put it to one side. It does this by [renaming the TSM file](https://github.com/influxdata/influxdb/blob/master/tsdb/tsm1/reader.go#L264), which takes a lock over the `TSMReader`.
- At this point it’s worth remembering that the entire TSM file is memory-mapped. We access both the index portion and the blocks portion via the `TSMReader.Reader` API.
- `TSMReader.Reader.Rename` renames the underlying file. Before doing that it instructs the [block accessor to close the file](https://github.com/influxdata/influxdb/blob/master/tsdb/tsm1/reader_mmap.go#L127). Becuase it closes the file, it also unmaps the memory, and remaps it after the file is open at the new location.
- Once this rename is complete the `FileStore` then [initialises a](https://github.com/influxdata/influxdb/blob/master/tsdb/tsm1/file_store.go#L969) `tsm1.purger`.
- The role of the `purger` is to wait until the `TSMReader` is no longer being used (by queries for example), and then the close the `TSMReader` and remove the underlying file.

Initially in the investigation is looked like the `purger` was the issue. It does not synchronise with the `FileStore`, so it looked like it could be removing TSM files that were still being read. However, testing as an attempt to reproduce this issue proved to me that this was not possible. Because:

- `FileStore.replace` does the rename and purger initialisation under a `Lock`.
- Given it happens under a lock no new `KeyCursor`s can [be created](https://github.com/influxdata/influxdb/blob/master/tsdb/tsm1/file_store.go#L762-L766) until `rename` returns.
- When `rename` returns the `FileStore.files` will have had the outgoing `TSMFile` **removed**. Therefore they will not attempt to read from files that are scheduled to be purged.
- This only then leaves in-flight `KeyCursors`. These will be cursors that were created **before** the `FileStore.replace` call, but have not yet been closed out.
- The `purger` will **not** close down `TSMFiles` that have in-flight `KeyCursors` because the `TSMFile` will [still be in use](https://github.com/influxdata/influxdb/blob/master/tsdb/tsm1/file_store.go#L1524).

So, that’s a rather clunky way to synchronise the `FileStore` and the `purger` but I think it’s technically correct.

So at this point we go back to `TSMReader.Reader.Rename` where the underlying block accessor is unmapping and re-mapping the memory-mapped blocks and index.

We know from the stack trace that something is reading unmapped memory:

```
unexpected fault address 0x7f534ccbdb00
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7f534ccbdb00 pc=0xe92628]
goroutine 73939753 [running]:
runtime.throw(0x16e97e5, 0x5)
    /usr/local/go/src/runtime/panic.go:617 +0x72 fp=0xc248f62a70 sp=0xc248f62a40 pc=0x42d892
runtime.sigpanic()
    /usr/local/go/src/runtime/signal_unix.go:397 +0x401 fp=0xc248f62aa0 sp=0xc248f62a70 pc=0x442fc1
github.com/influxdata/influxdb/tsdb/tsm1.(*readerOffsetsIterator).Length(...)
```

The prime suspect is obviously the `unmap` that happens during the `mmapAccessor.rename` call. On the face of it, it just looks _plain racy_. The `m.b` slice is used to back both the index and all the block data. Two things have references to `m.b`. One is the `mmapAccessor` itself, and the other is the TSM index abstraction, called the [`indirectIndex`](https://github.com/influxdata/influxdb/blob/master/tsdb/tsm1/reader_index.go#L94). The `indirectIndex` actually has a reference via a helper type called a `faultBuffer`, but that’s not important.

The initial thought here is that `mmapAccessor.rename` has just [unmapped](https://github.com/influxdata/influxdb/blob/master/tsdb/tsm1/reader_mmap.go#L122-L125) `m.b` and the something attempts to read block or index data on the `TSMReader`, which will then cause a `SIGSEGV` to be triggered.

However:

- This would probably happen **a lot**. This panic is very rare.
- The accessor holds a `Lock`, and all access to the `mmapAccessor` is via an `RLock`.

The most likely scenario causing the segfault is as follows:

There are two references to the memory-mapped `[]byte`, `m.b`. One is on the `mmapAccessor`, which is responsible for reading block data from the slice. The second is on the `indirectIndex`, which is responsible for reading the TSM index portion of the slice. When the unmap/remap happens, only the `mmapAccessor` slice reference is re-assigned.

It would be reasonable to assume that the `indirectIndex` `m.b` reference would then immediately point at unmapped memory when a TSM file was renamed, and that the engines should be panicking frequently. However, it turns out that _typically_, when the TSM file is unmapped, closed, renamed, opened and then mapped again, the underlying address to the memory-mapped data **does not change**. That means that if there are readers to the stale `indirectIndex` reference of `m.b`, the slice’s backing array still ends up with the same address as the new `m.b` that was set on the `mmapAccessor`. So typically, even though `m.b` gets unmapped and remapped it doesn’t matter. All the readers find the correct data.

Somewhat rarely—I suspect when there is significant virtual memory pressure—a new address is returned during the remap. Any reads to the stale `indirectIndex` `m.b` reference will now segfault because they refer to an address that points at unmapped memory. 

This code has been this way for many years, so it’s still strange that the effects have only being noticeable recently. 
I believe that https://github.com/influxdata/platform/pull/1984 increased the likelihood of triggering the bug, because due to the way the improved tombstone checking works, every read that has tombstones will involve checking the TSM index for prefixes matching the tombstones. Checking the TSM index means reading the stale reference to `m.b` in the `indirectIndex`, which means an increased likelihood of reading the slice on the rare occasions that the address changed during the remap. 

#### Fix

The fix here is pretty simple. There is no need to actually unmap and remap a file just to rename it. Instead, you just rename the file. The file handler will stay open, and will be closed when the `TSMReader` is closed. The underlying path to the file is updated, so any callers will get the correct renamed path if they need it.