### PR TITLE
fix(tsm1): check if blocks are overlapping in KeyCursor.Next

### DIFF
--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -1448,9 +1448,13 @@ func (c *KeyCursor) nextAscending() {
 	}
 	c.current[0] = c.seeks[c.pos]
 
-	// If we have ovelapping blocks, append all their values so we can dedup
+	// If we have overlapping blocks, append all their values so we can dedup
 	for i := c.pos + 1; i < len(c.seeks); i++ {
 		if c.seeks[i].read() {
+			continue
+		}
+
+		if !c.seeks[i].entry.Contains(c.current[0].entry.MaxTime) {
 			continue
 		}
 
@@ -1470,17 +1474,22 @@ func (c *KeyCursor) nextDescending() {
 
 	// Append the first matching block
 	if len(c.current) == 0 {
-		c.current = make([]*location, 1)
+		c.current = append(c.current, nil)
 	} else {
 		c.current = c.current[:1]
 	}
 	c.current[0] = c.seeks[c.pos]
 
-	// If we have ovelapping blocks, append all their values so we can dedup
+	// If we have overlapping blocks, append all their values so we can dedup
 	for i := c.pos; i >= 0; i-- {
 		if c.seeks[i].read() {
 			continue
 		}
+
+		if !c.seeks[i].entry.Contains(c.current[0].entry.MinTime) {
+			continue
+		}
+
 		c.current = append(c.current, c.seeks[i])
 	}
 }


### PR DESCRIPTION
Closes #

## Background
From `KeyCursor.current` comment,  `KeyCursor.current` should only contain overlapping blocks.
https://github.com/influxdata/influxdb/blob/063d487c4e66f09d6cfc7a04e93950baad9fcbb6/tsdb/tsm1/file_store.go#L1277-L1282

In `KeyCursor.nextDescending` method, append nonoverlapping blocks to `KeyCursor.current`.
https://github.com/influxdata/influxdb/blob/063d487c4e66f09d6cfc7a04e93950baad9fcbb6/tsdb/tsm1/file_store.go#L1450-L1458

But in `ReadFloatArrayBlock` func, nonoverlapping blocks are ignored.
https://github.com/influxdata/influxdb/blob/063d487c4e66f09d6cfc7a04e93950baad9fcbb6/tsdb/tsm1/file_store_array.gen.go#L82-L91


Describe your proposed changes here.
In `KeyCursor.nextDescending` method, should only append overlapping blocks to `KeyCursor.current`.

---
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
