### PR TITLE
Generate more idiomatic Flux in query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bug Fixes
 1. [13753](https://github.com/influxdata/influxdb/pull/13753): Removed hardcoded bucket for Getting Started with Flux dashboard
 1. [13783](https://github.com/influxdata/influxdb/pull/13783): Ensure map type variables allow for selecting values
+1. [13800](https://github.com/influxdata/influxdb/pull/13800): Generate more idiomatic Flux in query builder
 
 ### UI Improvements
 

--- a/ui/src/timeMachine/constants/queryBuilder.ts
+++ b/ui/src/timeMachine/constants/queryBuilder.ts
@@ -3,28 +3,75 @@ import {WINDOW_PERIOD, OPTION_NAME} from 'src/variables/constants'
 export interface QueryFn {
   name: string
   flux: string
-  aggregate: boolean
 }
 
 export const FUNCTIONS: QueryFn[] = [
-  {name: 'mean', flux: `|> mean()`, aggregate: true},
-  {name: 'median', flux: '|> toFloat()\n  |> median()', aggregate: true},
-  {name: 'max', flux: '|> max()', aggregate: true},
-  {name: 'min', flux: '|> min()', aggregate: true},
-  {name: 'sum', flux: '|> sum()', aggregate: true},
+  {
+    name: 'mean',
+    flux: `|> aggregateWindow(every: ${OPTION_NAME}.${WINDOW_PERIOD}, fn: mean)`,
+  },
+  {
+    name: 'median',
+    // TODO: https://github.com/influxdata/influxdb/issues/13806
+    flux: `|> window(period: ${OPTION_NAME}.${WINDOW_PERIOD})
+  |> toFloat()
+  |> median()
+  |> group(columns: ["_value", "_time", "_start", "_stop"], mode: "except")`,
+  },
+  {
+    name: 'max',
+    flux: `|> aggregateWindow(every: ${OPTION_NAME}.${WINDOW_PERIOD}, fn: max)`,
+  },
+  {
+    name: 'min',
+    flux: `|> aggregateWindow(every: ${OPTION_NAME}.${WINDOW_PERIOD}, fn: min)`,
+  },
+  {
+    name: 'sum',
+    flux: `|> aggregateWindow(every: ${OPTION_NAME}.${WINDOW_PERIOD}, fn: sum)`,
+  },
   {
     name: 'derivative',
     flux: `|> derivative(unit: ${OPTION_NAME}.${WINDOW_PERIOD}, nonNegative: false)`,
-    aggregate: false,
   },
-  {name: 'distinct', flux: '|> distinct()', aggregate: false},
-  {name: 'count', flux: '|> count()', aggregate: false},
-  {name: 'increase', flux: '|> increase()', aggregate: false},
-  {name: 'skew', flux: '|> skew()', aggregate: false},
-  {name: 'spread', flux: '|> spread()', aggregate: false},
-  {name: 'stddev', flux: '|> stddev()', aggregate: true},
-  {name: 'first', flux: '|> first()', aggregate: true},
-  {name: 'last', flux: '|> last()', aggregate: true},
-  {name: 'unique', flux: '|> unique()', aggregate: false},
-  {name: 'sort', flux: '|> sort()', aggregate: false},
+  {
+    name: 'distinct',
+    flux: '|> distinct()',
+  },
+  {
+    name: 'count',
+    flux: '|> count()',
+  },
+  {
+    name: 'increase',
+    flux: '|> increase()',
+  },
+  {
+    name: 'skew',
+    flux: '|> skew()',
+  },
+  {
+    name: 'spread',
+    flux: '|> spread()',
+  },
+  {
+    name: 'stddev',
+    flux: `|> aggregateWindow(every: ${OPTION_NAME}.${WINDOW_PERIOD}, fn: stddev)`,
+  },
+  {
+    name: 'first',
+    flux: `|> aggregateWindow(every: ${OPTION_NAME}.${WINDOW_PERIOD}, fn: first)`,
+  },
+  {
+    name: 'last',
+    flux: `|> aggregateWindow(every: ${OPTION_NAME}.${WINDOW_PERIOD}, fn: last)`,
+  },
+  {
+    name: 'unique',
+    flux: '|> unique()',
+  },
+  {
+    name: 'sort',
+    flux: '|> sort()',
+  },
 ]

--- a/ui/src/timeMachine/utils/queryBuilder.test.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.test.ts
@@ -49,9 +49,7 @@ describe('buildQuery', () => {
     const expected = `from(bucket: "b0")
   |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
   |> filter(fn: (r) => r._measurement == "m0")
-  |> window(period: v.windowPeriod)
-  |> mean()
-  |> group(columns: ["_value", "_time", "_start", "_stop"], mode: "except")
+  |> aggregateWindow(every: v.windowPeriod, fn: mean)
   |> yield(name: "mean")
 
 from(bucket: "b0")

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -4,7 +4,6 @@ import {FUNCTIONS} from 'src/timeMachine/constants/queryBuilder'
 import {
   TIME_RANGE_START,
   TIME_RANGE_STOP,
-  WINDOW_PERIOD,
   OPTION_NAME,
 } from 'src/variables/constants'
 
@@ -47,23 +46,13 @@ function buildQueryHelper(
 }
 
 export function formatFunctionCall(fn: BuilderConfig['functions'][0]) {
-  const fnSpec = FUNCTIONS.find(f => f.name === fn.name)
+  const fnSpec = FUNCTIONS.find(spec => spec.name === fn.name)
 
-  let fnCall: string = ''
-
-  if (fnSpec && fnSpec.aggregate) {
-    fnCall = `
-  |> window(period: ${OPTION_NAME}.${WINDOW_PERIOD})
-  ${fnSpec.flux}
-  |> group(columns: ["_value", "_time", "_start", "_stop"], mode: "except")
-  |> yield(name: "${fn.name}")`
-  } else {
-    fnCall = `
-  ${fnSpec.flux}
-  |> yield(name: "${fn.name}")`
+  if (!fnSpec) {
+    return ''
   }
 
-  return fnCall
+  return `\n  ${fnSpec.flux}\n  |> yield(name: "${fn.name}")`
 }
 
 function formatTagFilterCall(tagsSelections: BuilderConfig['tags']) {


### PR DESCRIPTION
Closes #13775

Updates the Flux code generated by the query builder to use the `aggregateWindow` helper when possible. Queries previously generated like so:

```
from(bucket: "telegraf")
  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
  |> filter(fn: (r) => r._measurement == "cpu" or r._measurement == "disk")
  |> filter(fn: (r) => r._field == "used_percent")
  |> window(period: v.windowPeriod)
  |> mean()
  |> group(columns: ["_value", "_time", "_start", "_stop"], mode: "except")
  |> yield(name: "mean")
```

Will now be generated as:

```
from(bucket: "telegraf")
  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
  |> filter(fn: (r) => r._measurement == "cpu" or r._measurement == "disk")
  |> filter(fn: (r) => r._field == "used_percent")
  |> aggregateWindow(every: v.windowPeriod, fn: mean)
  |> yield(name: "mean")
```