### PR TITLE
fix(http): return correct response code when dashboard creation fails

### DIFF
--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -431,11 +431,7 @@ func (h *DashboardHandler) handlePostDashboard(w http.ResponseWriter, r *http.Re
 		return
 	}
 	if err := h.DashboardService.CreateDashboard(ctx, req.Dashboard); err != nil {
-		EncodeError(ctx, &platform.Error{
-			Code: platform.EInternal,
-			Msg:  "Error loading dashboards",
-			Err:  err,
-		}, w)
+		EncodeError(ctx, err, w)
 		return
 	}
 


### PR DESCRIPTION
We're currently swallowing all dashboard creation failures with a 500 response. Returning the response directly will correctly respond with 400-level responses when they apply.