### PR TITLE
Update max buckets to be greater than the number

### DIFF
--- a/ui/src/cloud/actions/limits.ts
+++ b/ui/src/cloud/actions/limits.ts
@@ -204,7 +204,7 @@ export const checkBucketLimits = () => async (
     const bucketsMax = extractBucketMax(limits)
     const bucketsCount = list.length
 
-    if (bucketsCount >= bucketsMax) {
+    if (bucketsCount > bucketsMax) {
       dispatch(setBucketLimitStatus(LimitStatus.EXCEEDED))
       dispatch(notify(resourceLimitReached('buckets')))
     } else {


### PR DESCRIPTION
Closes #13807 

Describe your proposed changes here.
Bucket creation on cloud was showing a notification for 2 buckets even when the user is allowed to have upto two buckets as the free tier value. Updated the bucket limits check if number of buckets is `greater than` max buckets rather than `greater than equal to`.

This allows user to create at least 2 buckets without errors.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass