### PR TITLE
Update account and org header for cloud specific

### DIFF
--- a/ui/src/me/components/UserPageHeader.tsx
+++ b/ui/src/me/components/UserPageHeader.tsx
@@ -27,7 +27,14 @@ export default class UserPageHeader extends PureComponent<Props> {
 
     const {text, language} = generateRandomGreeting()
 
-    const title = `${text}, ${userName}! Welcome to ${orgName}!`
+    let title = ''
+
+    if (process.env.CLOUD === 'true') {
+      title = `${text}, ${userName}! Welcome to InfluxCloud!`
+    } else {
+      title = `${text}, ${userName}! Welcome to ${orgName}!`
+    }
+
     const altText = `That's how you say hello in ${language}`
 
     return <Page.Title title={title} altText={altText} />

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -8,6 +8,8 @@ import _ from 'lodash'
 import {NavMenu, Icon} from '@influxdata/clockface'
 import CloudNav from 'src/pageLayout/components/CloudNav'
 import AccountNavSubItem from 'src/pageLayout/components/AccountNavSubItem'
+import CloudExclude from 'src/shared/components/cloud/CloudExclude'
+import CloudOnly from 'src/shared/components/cloud/CloudOnly'
 
 // Utils
 import {getNavItemActivation} from 'src/pageLayout/utils'
@@ -70,7 +72,8 @@ class SideNav extends PureComponent<Props, State> {
           <NavMenu.Item
             titleLink={className => (
               <Link className={className} to={orgPrefix}>
-                {`${me.name} (${orgName})`}
+                <CloudOnly>{me.name}</CloudOnly>
+                <CloudExclude>{`${me.name} (${orgName})`}</CloudExclude>
               </Link>
             )}
             iconLink={className => (


### PR DESCRIPTION
Closes #13820 

Describe your proposed changes here.
Update the Nav item for settings to only display the username for Cloud2
Update the title in the homepage/settings page to display `<hello> <username>! Welcome to InfluxCloud! for Cloud2 users.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
