### PR TITLE
Extract "retry after" from query limit error response headers and reveal to user in notifications

### DIFF
--- a/ui/src/cloud/actions/limits.ts
+++ b/ui/src/cloud/actions/limits.ts
@@ -11,10 +11,7 @@ import {AppState} from 'src/types'
 import {notify} from 'src/shared/actions/notifications'
 
 // Constants
-import {
-  readLimitReached,
-  resourceLimitReached,
-} from 'src/shared/copy/notifications'
+import {readLimitReached} from 'src/shared/copy/notifications'
 
 // Types
 import {RemoteDataState} from '@influxdata/clockface'
@@ -182,7 +179,6 @@ export const checkDashboardLimits = () => (
 
     if (dashboardsCount >= dashboardsMax) {
       dispatch(setDashboardLimitStatus(LimitStatus.EXCEEDED))
-      dispatch(notify(resourceLimitReached('dashboards')))
     } else {
       dispatch(setDashboardLimitStatus(LimitStatus.OK))
     }
@@ -206,7 +202,6 @@ export const checkBucketLimits = () => async (
 
     if (bucketsCount > bucketsMax) {
       dispatch(setBucketLimitStatus(LimitStatus.EXCEEDED))
-      dispatch(notify(resourceLimitReached('buckets')))
     } else {
       dispatch(setBucketLimitStatus(LimitStatus.OK))
     }
@@ -230,7 +225,6 @@ export const checkTaskLimits = () => async (
 
     if (tasksCount >= tasksMax) {
       dispatch(setTaskLimitStatus(LimitStatus.EXCEEDED))
-      dispatch(notify(resourceLimitReached('tasks')))
     } else {
       dispatch(setTaskLimitStatus(LimitStatus.OK))
     }

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -16,7 +16,7 @@ import {checkQueryResult} from 'src/shared/utils/checkQueryResult'
 
 // Constants
 import {RATE_LIMIT_ERROR_STATUS} from 'src/cloud/constants/index'
-import {readLimitReached} from 'src/shared/copy/notifications'
+import {rateLimitReached} from 'src/shared/copy/notifications'
 import {RATE_LIMIT_ERROR_TEXT} from 'src/cloud/constants'
 
 // Actions
@@ -172,7 +172,9 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
       let errorMessage = get(error, 'message', '')
 
       if (get(error, 'status') === RATE_LIMIT_ERROR_STATUS) {
-        notify(readLimitReached())
+        const retryAfter = get(error, 'headers.Retry-After')
+
+        notify(rateLimitReached(retryAfter))
         errorMessage = RATE_LIMIT_ERROR_TEXT
       }
 

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -417,12 +417,15 @@ export const readLimitReached = (): Notification => ({
   type: 'readLimitReached',
 })
 
-export const rateLimitReached = (secs: string): Notification => ({
-  ...defaultErrorNotification,
-  message: `Exceeded rate limits. Please try again in ${secs} seconds`,
-  duration: FIVE_SECONDS,
-  type: 'rateLimitReached',
-})
+export const rateLimitReached = (secs?: string): Notification => {
+  const retryText = ` Please try again in ${secs} seconds`
+  return {
+    ...defaultErrorNotification,
+    message: `Exceeded rate limits.${secs ? retryText : ''} `,
+    duration: FIVE_SECONDS,
+    type: 'rateLimitReached',
+  }
+}
 
 export const resourceLimitReached = (resourceName: string): Notification => ({
   ...defaultErrorNotification,

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -406,21 +406,28 @@ export const getBucketsFailed = (): Notification => ({
 export const writeLimitReached = (): Notification => ({
   ...defaultErrorNotification,
   message: `Exceeded write limits.`,
-  duration: TEN_SECONDS,
+  duration: FIVE_SECONDS,
   type: 'writeLimitReached',
 })
 
 export const readLimitReached = (): Notification => ({
   ...defaultErrorNotification,
-  message: `Exceeded quota for concurrent queries.`,
-  duration: TEN_SECONDS,
+  message: `Exceeded query limits.`,
+  duration: FIVE_SECONDS,
   type: 'readLimitReached',
+})
+
+export const rateLimitReached = (secs: string): Notification => ({
+  ...defaultErrorNotification,
+  message: `Exceeded rate limits. Please try again in ${secs} seconds`,
+  duration: FIVE_SECONDS,
+  type: 'rateLimitReached',
 })
 
 export const resourceLimitReached = (resourceName: string): Notification => ({
   ...defaultErrorNotification,
   message: `Oops. It looks like you have reached the maximum number of ${resourceName} allowed as part of your plan. If you would like to upgrade and remove this restriction, reach out to cloudbeta@influxdata.com.`,
-  duration: TEN_SECONDS,
+  duration: FIVE_SECONDS,
   type: 'resourceLimitReached',
 })
 

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -11,7 +11,7 @@ import {refreshVariableValues, selectValue} from 'src/variables/actions'
 import {notify} from 'src/shared/actions/notifications'
 
 // Constants
-import {readLimitReached} from 'src/shared/copy/notifications'
+import {rateLimitReached} from 'src/shared/copy/notifications'
 import {RATE_LIMIT_ERROR_STATUS} from 'src/cloud/constants/index'
 
 // Utils
@@ -129,7 +129,8 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
     }
 
     if (get(e, 'status') === RATE_LIMIT_ERROR_STATUS) {
-      dispatch(notify(readLimitReached()))
+      const retryAfter = get(e, 'headers.Retry-After')
+      dispatch(notify(rateLimitReached(retryAfter)))
     }
 
     console.error(e)


### PR DESCRIPTION
Query limit notification should include cool down timer
Documentation on error headers :https://github.com/influxdata/influxdb/blob/master/http/swagger.yml#L1556-L1563