### PR TITLE
fix(series file): Sync series segment after truncate

### DIFF
--- a/tsdb/series_segment.go
+++ b/tsdb/series_segment.go
@@ -70,6 +70,8 @@ func CreateSeriesSegment(id uint16, path string) (*SeriesSegment, error) {
 		return nil, err
 	} else if err := f.Truncate(int64(SeriesSegmentSize(id))); err != nil {
 		return nil, err
+	} else if err := f.Sync(); err != nil {
+		return nil, err
 	} else if err := f.Close(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On rare occasion, when an influxdb instance is terminated abruptly on a particular ARM platform, the series segment file contains only zeros. Assuming hardware and OS are functioning properly, this change should prevent that from happening, by forcing a `sync()` after zero-padding with `truncate()`.

Helps #10543 

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
