### PR TITLE
Update line protocol to write data only once

### DIFF
--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocol.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocol.tsx
@@ -83,7 +83,6 @@ export class LineProtocol extends PureComponent<Props> {
         tabs={this.LineProtocolTabs}
         bucket={bucket}
         org={org}
-        handleUpload={this.handleUpload}
       />
     )
   }

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocolTabs.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocolTabs.tsx
@@ -17,7 +17,6 @@ import {WritePrecision} from '@influxdata/influx'
 import {
   setLineProtocolBody,
   setActiveLPTab,
-  writeLineProtocolAction,
   setPrecision,
 } from 'src/dataLoaders/actions/dataLoaders'
 
@@ -25,7 +24,6 @@ interface OwnProps {
   tabs: LineProtocolTab[]
   bucket: string
   org: string
-  handleUpload?: () => void
 }
 
 type Props = OwnProps & DispatchProps & StateProps
@@ -33,7 +31,6 @@ type Props = OwnProps & DispatchProps & StateProps
 interface DispatchProps {
   setLineProtocolBody: typeof setLineProtocolBody
   setActiveLPTab: typeof setActiveLPTab
-  writeLineProtocolAction: typeof writeLineProtocolAction
   setPrecision: typeof setPrecision
 }
 
@@ -64,7 +61,6 @@ export class LineProtocolTabs extends PureComponent<Props, State> {
       tabs,
       setLineProtocolBody,
       lineProtocolBody,
-      handleUpload,
     } = this.props
 
     const {urlInput} = this.state
@@ -99,7 +95,6 @@ export class LineProtocolTabs extends PureComponent<Props, State> {
                     urlInput={urlInput}
                     lineProtocolBody={lineProtocolBody}
                     setLineProtocolBody={setLineProtocolBody}
-                    handleUpload={handleUpload}
                   />
                 </div>
               </div>
@@ -133,7 +128,6 @@ const mstp = ({
 const mdtp: DispatchProps = {
   setLineProtocolBody,
   setActiveLPTab,
-  writeLineProtocolAction,
   setPrecision,
 }
 

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/TabBody.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/TabBody.tsx
@@ -17,7 +17,6 @@ interface Props {
   setLineProtocolBody: typeof setLineProtocolBody
   onURLChange: (url: string) => void
   urlInput: string
-  handleUpload?: () => void
 }
 
 export default class extends PureComponent<Props> {
@@ -79,11 +78,8 @@ export default class extends PureComponent<Props> {
     setLineProtocolBody(lpBody)
   }
 
-  private handleSetLineProtocol = async (lpBody: string) => {
-    const {setLineProtocolBody, handleUpload} = this.props
-    await setLineProtocolBody(lpBody)
-    if (handleUpload) {
-      handleUpload()
-    }
+  private handleSetLineProtocol = (lpBody: string) => {
+    const {setLineProtocolBody} = this.props
+    setLineProtocolBody(lpBody)
   }
 }

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/__snapshots__/LineProtocol.test.tsx.snap
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/__snapshots__/LineProtocol.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`LineProtocol rendering renders! 1`] = `
         </h5>
         <Connect(LineProtocolTabs)
           bucket="a"
-          handleUpload={[Function]}
           org="a"
           tabs={
             Array [


### PR DESCRIPTION
Closes #13812 

Describe your proposed changes here.
Update line protocol's drag and drop to not handle write protocol data
Clean line protocol by removing unused actions

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
