### PR TITLE
feat(tasks): add description field to tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## v2.0.0-alpha.10 [unreleased]
+
 ### Features
 
+1. [13850](https://github.com/influxdata/influxdb/pull/13850): Add description field to Tasks.
+
 ### Bug Fixes
+
 1. [13753](https://github.com/influxdata/influxdb/pull/13753): Removed hardcoded bucket for Getting Started with Flux dashboard
 1. [13783](https://github.com/influxdata/influxdb/pull/13783): Ensure map type variables allow for selecting values
 1. [13800](https://github.com/influxdata/influxdb/pull/13800): Generate more idiomatic Flux in query builder

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5840,7 +5840,10 @@ components:
           description: The name of the organization that owns this Task.
           type: string
         name:
-          description: A description of the task.
+          description: The name of the task.
+          type: string
+        description:
+          descripton: An optional description of the task.
           type: string
         status:
           description: The current status of the task. When updated to 'inactive', cancels all queued jobs of this task.

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -87,6 +87,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 							{
 								ID:              1,
 								Name:            "task1",
+								Description:     "A little Task",
 								OrganizationID:  1,
 								Organization:    "test",
 								AuthorizationID: 0x100,
@@ -137,7 +138,8 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
       },
       "id": "0000000000000001",
       "name": "task1",
-			"labels": [
+	  "description": "A little Task",
+	  "labels": [
         {
           "id": "fc3dc670a4be9b9a",
           "name": "label",
@@ -449,6 +451,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
 						return &platform.Task{
 							ID:              1,
 							Name:            "task1",
+							Description:     "Brand New Task",
 							OrganizationID:  1,
 							Organization:    "test",
 							AuthorizationID: 0x100,
@@ -472,6 +475,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
   },
   "id": "0000000000000001",
   "name": "task1",
+  "description": "Brand New Task",
   "labels": [],
   "orgID": "0000000000000001",
   "org": "test",

--- a/kv/task.go
+++ b/kv/task.go
@@ -565,6 +565,7 @@ func (s *Service) createTask(ctx context.Context, tx Tx, tc influxdb.TaskCreate)
 		Organization:    org.Name,
 		AuthorizationID: auth.Identifier(),
 		Name:            opt.Name,
+		Description:     tc.Description,
 		Status:          tc.Status,
 		Flux:            tc.Flux,
 		Every:           opt.Every.String(),
@@ -675,6 +676,10 @@ func (s *Service) updateTask(ctx context.Context, tx Tx, id influxdb.ID, upd inf
 			return nil, err
 		}
 		task.AuthorizationID = auth.ID
+	}
+
+	if upd.Description != nil {
+		task.Description = *upd.Description
 	}
 
 	if upd.Status != nil {

--- a/task.go
+++ b/task.go
@@ -29,6 +29,7 @@ type Task struct {
 	Organization    string `json:"org"`
 	AuthorizationID ID     `json:"authorizationID"`
 	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
 	Status          string `json:"status"`
 	Flux            string `json:"flux"`
 	Every           string `json:"every,omitempty"`
@@ -133,6 +134,7 @@ type TaskService interface {
 // TaskCreate is the set of values to create a task.
 type TaskCreate struct {
 	Flux           string `json:"flux"`
+	Description    string `json:"description,omitempty"`
 	Status         string `json:"status,omitempty"`
 	OrganizationID ID     `json:"orgID,omitempty"`
 	Organization   string `json:"org,omitempty"`
@@ -153,8 +155,9 @@ func (t TaskCreate) Validate() error {
 
 // TaskUpdate represents updates to a task. Options updates override any options set in the Flux field.
 type TaskUpdate struct {
-	Flux   *string `json:"flux,omitempty"`
-	Status *string `json:"status,omitempty"`
+	Flux        *string `json:"flux,omitempty"`
+	Status      *string `json:"status,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// LatestCompleted us to set latest completed on startup to skip task catchup
 	LatestCompleted *string `json:"-"`
@@ -169,9 +172,10 @@ type TaskUpdate struct {
 func (t *TaskUpdate) UnmarshalJSON(data []byte) error {
 	// this is a type so we can marshal string into durations nicely
 	jo := struct {
-		Flux   *string `json:"flux,omitempty"`
-		Status *string `json:"status,omitempty"`
-		Name   string  `json:"name,omitempty"`
+		Flux        *string `json:"flux,omitempty"`
+		Status      *string `json:"status,omitempty"`
+		Name        string  `json:"name,omitempty"`
+		Description *string `json:"description,omitempty"`
 
 		// Cron is a cron style time schedule that can be used in place of Every.
 		Cron string `json:"cron,omitempty"`
@@ -195,6 +199,7 @@ func (t *TaskUpdate) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	t.Options.Name = jo.Name
+	t.Description = jo.Description
 	t.Options.Cron = jo.Cron
 	t.Options.Every = jo.Every
 	if jo.Offset != nil {
@@ -212,9 +217,10 @@ func (t *TaskUpdate) UnmarshalJSON(data []byte) error {
 
 func (t TaskUpdate) MarshalJSON() ([]byte, error) {
 	jo := struct {
-		Flux   *string `json:"flux,omitempty"`
-		Status *string `json:"status,omitempty"`
-		Name   string  `json:"name,omitempty"`
+		Flux        *string `json:"flux,omitempty"`
+		Status      *string `json:"status,omitempty"`
+		Name        string  `json:"name,omitempty"`
+		Description *string `json:"description,omitempty"`
 
 		// Cron is a cron style time schedule that can be used in place of Every.
 		Cron string `json:"cron,omitempty"`
@@ -234,6 +240,7 @@ func (t TaskUpdate) MarshalJSON() ([]byte, error) {
 	jo.Name = t.Options.Name
 	jo.Cron = t.Options.Cron
 	jo.Every = t.Options.Every
+	jo.Description = t.Description
 	if t.Options.Offset != nil {
 		offset := *t.Options.Offset
 		jo.Offset = &offset


### PR DESCRIPTION
Closes #12386

This PR adds a `Description` property to Tasks in the Swagger definition as well as in the API.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)