### PR TITLE
fix(influxdb): use influxdb.Error in ID.Decode

### DIFF
--- a/http/dashboard_service.go
+++ b/http/dashboard_service.go
@@ -711,11 +711,7 @@ func decodePostDashboardCellRequest(ctx context.Context, r *http.Request) (*post
 	}
 
 	if err := req.dashboardID.DecodeFromString(id); err != nil {
-		return nil, &platform.Error{
-			Code: platform.EInvalid,
-			Msg:  "invalid dashboard id",
-			Err:  err,
-		}
+		return nil, err
 	}
 
 	return req, nil

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -1033,8 +1033,7 @@ func TestService_handlePostDashboardCell(t *testing.T) {
 				body: `
 				{
 					"code": "invalid",
-					"error": "id must have a length of 16 bytes",
-					"message": "invalid dashboard id"
+					"message": "id must have a length of 16 bytes"
 				}`,
 			},
 		},

--- a/http/variable_service.go
+++ b/http/variable_service.go
@@ -174,10 +174,7 @@ func requestVariableID(ctx context.Context) (platform.ID, error) {
 
 	id, err := platform.IDFromString(urlID)
 	if err != nil {
-		return platform.InvalidID(), &platform.Error{
-			Code: platform.EInvalid,
-			Msg:  err.Error(),
-		}
+		return platform.InvalidID(), err
 	}
 
 	return *id, nil

--- a/id.go
+++ b/id.go
@@ -3,7 +3,6 @@ package influxdb
 import (
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"reflect"
 	"strconv"
 	"unsafe"
@@ -12,11 +11,19 @@ import (
 // IDLength is the exact length a string (or a byte slice representing it) must have in order to be decoded into a valid ID.
 const IDLength = 16
 
-// ErrInvalidID signifies invalid IDs.
-var ErrInvalidID = errors.New("invalid ID")
+var (
+	// ErrInvalidID signifies invalid IDs.
+	ErrInvalidID = &Error{
+		Code: EInvalid,
+		Msg:  "invalid ID",
+	}
 
-// ErrInvalidIDLength is returned when an ID has the incorrect number of bytes.
-var ErrInvalidIDLength = errors.New("id must have a length of 16 bytes")
+	// ErrInvalidIDLength is returned when an ID has the incorrect number of bytes.
+	ErrInvalidIDLength = &Error{
+		Code: EInvalid,
+		Msg:  "id must have a length of 16 bytes",
+	}
+)
 
 // ID is a unique identifier.
 //
@@ -57,7 +64,7 @@ func (i *ID) Decode(b []byte) error {
 
 	res, err := strconv.ParseUint(unsafeBytesToString(b), 16, 64)
 	if err != nil {
-		return err
+		return ErrInvalidID
 	}
 
 	if *i = ID(res); !i.Valid() {

--- a/id_test.go
+++ b/id_test.go
@@ -40,7 +40,7 @@ func TestIDFromString(t *testing.T) {
 			name:    "Should not be able to decode a non hex ID",
 			id:      "gggggggggggggggg",
 			wantErr: true,
-			err:     `strconv.ParseUint: parsing "gggggggggggggggg": invalid syntax`,
+			err: platform.ErrInvalidID.Error(),
 		},
 		{
 			name:    "Should not be able to decode inputs with length less than 16 bytes",

--- a/kv/passwords_test.go
+++ b/kv/passwords_test.go
@@ -192,7 +192,7 @@ func TestService_SetPassword(t *testing.T) {
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("kv/setPassword: <internal error> User ID for user1 has been corrupted; Err: invalid ID"),
+				err: fmt.Errorf("kv/setPassword: <internal error> User ID for user1 has been corrupted; Err: <invalid> invalid ID"),
 			},
 		},
 		{
@@ -403,7 +403,7 @@ func TestService_ComparePassword(t *testing.T) {
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("kv/setPassword: <internal error> User ID for user1 has been corrupted; Err: invalid ID"),
+				err: fmt.Errorf("kv/setPassword: <internal error> User ID for user1 has been corrupted; Err: <invalid> invalid ID"),
 			},
 		},
 		{


### PR DESCRIPTION
Closes #13873

https://github.com/influxdata/influxdb/blob/e725e1a2bc7361b3cbf3e3b85984cd6cbf1d9db2/http/org_service.go#L268-L273

Describe your proposed changes here.
conv `ErrInvalidID` `ErrInvalidIDLength` to `influxdb.Error`.
so all callers of `ID.DecodeFromString` no need to wrap err returned by `ID.DecodeFromString` to `influxdb.Error`.



<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
