### PR TITLE
fix(bolt): import bbolt as bolt

### DIFF
--- a/bolt/keyvalue_log.go
+++ b/bolt/keyvalue_log.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 	"go.uber.org/zap"
 
 	"github.com/influxdata/influxdb/kit/tracing"


### PR DESCRIPTION
Build fails because bolt is undefined in both bolt/keyvalue_log.go
and bolt/kv.go. Importing bbolt as bolt fixes the issue.

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

Closes #13916 

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
