### PR TITLE
feat(authentication): Add cli args for specifying session length and renewal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [13850](https://github.com/influxdata/influxdb/pull/13850): Add description field to Tasks.
+1. [13924](https://github.com/influxdata/influxdb/pull/13924): Add CLI arguments for configuring session length and renewal.
 
 ### Bug Fixes
 

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -175,6 +175,18 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 			Default: false,
 			Desc:    "disable sending telemetry data to https://telemetry.influxdata.com every 8 hours",
 		},
+		{
+			DestP: &l.sessionLength,
+			Flag: "session-length",
+			Default: 60, // 60 minutes
+			Desc: "ttl in minutes for newly created sessions",
+		},
+		{
+			DestP: &l.sessionAutoRenew,
+			Flag: "session-auto-renew",
+			Default: true,
+			Desc: "automatically extends session ttl on request",
+		}
 	}
 
 	cli.BindOptions(cmd, opts)
@@ -189,6 +201,8 @@ type Launcher struct {
 	storeType  string
 	assetsPath string
 	testing    bool
+	sessionLength int
+	sessionAutoRenew bool
 
 	logLevel          string
 	tracingType       string
@@ -580,6 +594,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	m.apibackend = &http.APIBackend{
 		AssetsPath:           m.assetsPath,
 		Logger:               m.logger,
+		SessionAutoRenew:			m.sessionAutoRenew,
 		NewBucketService:     source.NewBucketService,
 		NewQueryService:      source.NewQueryService,
 		PointsWriter:         pointsWriter,

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -176,16 +176,16 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 			Desc:    "disable sending telemetry data to https://telemetry.influxdata.com every 8 hours",
 		},
 		{
-			DestP: &l.sessionLength,
-			Flag: "session-length",
+			DestP:   &l.sessionLength,
+			Flag:    "session-length",
 			Default: 60, // 60 minutes
-			Desc: "ttl in minutes for newly created sessions",
+			Desc:    "ttl in minutes for newly created sessions",
 		},
 		{
-			DestP: &l.sessionAutoRenew,
-			Flag: "session-auto-renew",
-			Default: true,
-			Desc: "automatically extends session ttl on request",
+			DestP:   &l.sessionRenewDisabled,
+			Flag:    "session-renew-disabled",
+			Default: false,
+			Desc:    "disables automatically extending session ttl on request",
 		},
 	}
 
@@ -198,11 +198,11 @@ type Launcher struct {
 	cancel  func()
 	running bool
 
-	storeType  string
-	assetsPath string
-	testing    bool
-	sessionLength int // in minutes
-	sessionAutoRenew bool
+	storeType            string
+	assetsPath           string
+	testing              bool
+	sessionLength        int // in minutes
+	sessionRenewDisabled bool
 
 	logLevel          string
 	tracingType       string
@@ -598,7 +598,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	m.apibackend = &http.APIBackend{
 		AssetsPath:           m.assetsPath,
 		Logger:               m.logger,
-		SessionAutoRenew:			m.sessionAutoRenew,
+		SessionRenewDisabled: m.sessionRenewDisabled,
 		NewBucketService:     source.NewBucketService,
 		NewQueryService:      source.NewQueryService,
 		PointsWriter:         pointsWriter,

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -41,9 +41,9 @@ type APIHandler struct {
 // APIBackend is all services and associated parameters required to construct
 // an APIHandler.
 type APIBackend struct {
-	AssetsPath       string // if empty then assets are served from bindata.
-	Logger           *zap.Logger
-	SessionAutoRenew bool
+	AssetsPath           string // if empty then assets are served from bindata.
+	Logger               *zap.Logger
+	SessionRenewDisabled bool
 
 	NewBucketService func(*influxdb.Source) (influxdb.BucketService, error)
 	NewQueryService  func(*influxdb.Source) (query.ProxyQueryService, error)

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -41,8 +41,9 @@ type APIHandler struct {
 // APIBackend is all services and associated parameters required to construct
 // an APIHandler.
 type APIBackend struct {
-	AssetsPath string // if empty then assets are served from bindata.
-	Logger     *zap.Logger
+	AssetsPath       string // if empty then assets are served from bindata.
+	Logger           *zap.Logger
+	SessionAutoRenew bool
 
 	NewBucketService func(*influxdb.Source) (influxdb.BucketService, error)
 	NewQueryService  func(*influxdb.Source) (query.ProxyQueryService, error)

--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -18,7 +18,7 @@ type AuthenticationHandler struct {
 
 	AuthorizationService platform.AuthorizationService
 	SessionService       platform.SessionService
-	SessionAutoRenew     bool
+	SessionRenewDisabled bool
 
 	// This is only really used for it's lookup method the specific http
 	// handler used to register routes does not matter.
@@ -124,8 +124,8 @@ func (h *AuthenticationHandler) extractSession(ctx context.Context, r *http.Requ
 		return ctx, e
 	}
 
-	// if the session is not expired, renew the session
-	if h.SessionAutoRenew {
+	if !h.SessionRenewDisabled {
+		// if the session is not expired, renew the session
 		e = h.SessionService.RenewSession(ctx, s, time.Now().Add(platform.RenewSessionTime))
 		if e != nil {
 			return ctx, e

--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -28,12 +28,11 @@ type AuthenticationHandler struct {
 }
 
 // NewAuthenticationHandler creates an authentication handler.
-func NewAuthenticationHandler(b *APIBackend) *AuthenticationHandler {
+func NewAuthenticationHandler() *AuthenticationHandler {
 	return &AuthenticationHandler{
-		Logger:           zap.NewNop(),
-		Handler:          http.DefaultServeMux,
-		noAuthRouter:     httprouter.New(),
-		SessionAutoRenew: b.SessionAutoRenew,
+		Logger:       zap.NewNop(),
+		Handler:      http.DefaultServeMux,
+		noAuthRouter: httprouter.New(),
 	}
 }
 

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -24,10 +24,11 @@ func setCORSResponseHeaders(w http.ResponseWriter, r *http.Request) {
 
 // NewPlatformHandler returns a platform handler that serves the API and associated assets.
 func NewPlatformHandler(b *APIBackend) *PlatformHandler {
-	h := NewAuthenticationHandler(b)
+	h := NewAuthenticationHandler()
 	h.Handler = NewAPIHandler(b)
 	h.AuthorizationService = b.AuthorizationService
 	h.SessionService = b.SessionService
+	h.SessionAutoRenew = b.SessionAutoRenew
 
 	h.RegisterNoAuthRoute("GET", "/api/v2")
 	h.RegisterNoAuthRoute("POST", "/api/v2/signin")

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -24,7 +24,7 @@ func setCORSResponseHeaders(w http.ResponseWriter, r *http.Request) {
 
 // NewPlatformHandler returns a platform handler that serves the API and associated assets.
 func NewPlatformHandler(b *APIBackend) *PlatformHandler {
-	h := NewAuthenticationHandler()
+	h := NewAuthenticationHandler(b)
 	h.Handler = NewAPIHandler(b)
 	h.AuthorizationService = b.AuthorizationService
 	h.SessionService = b.SessionService

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -28,7 +28,7 @@ func NewPlatformHandler(b *APIBackend) *PlatformHandler {
 	h.Handler = NewAPIHandler(b)
 	h.AuthorizationService = b.AuthorizationService
 	h.SessionService = b.SessionService
-	h.SessionAutoRenew = b.SessionAutoRenew
+	h.SessionRenewDisabled = b.SessionRenewDisabled
 
 	h.RegisterNoAuthRoute("GET", "/api/v2")
 	h.RegisterNoAuthRoute("POST", "/api/v2/signin")

--- a/kv/service.go
+++ b/kv/service.go
@@ -22,6 +22,7 @@ const OpPrefix = "kv/"
 type Service struct {
 	kv     Store
 	Logger *zap.Logger
+	Config ServiceConfig
 
 	IDGenerator    influxdb.IDGenerator
 	TokenGenerator influxdb.TokenGenerator
@@ -31,15 +32,29 @@ type Service struct {
 }
 
 // NewService returns an instance of a Service.
-func NewService(kv Store) *Service {
-	return &Service{
-		Logger:         zap.NewNop(),
+func NewService(kv Store, configs ...ServiceConfig) *Service {
+	s := &Service{
+		Logger: zap.NewNop(),
+		// Config:         config,
 		IDGenerator:    snowflake.NewIDGenerator(),
 		TokenGenerator: rand.NewTokenGenerator(64),
 		Hash:           &Bcrypt{},
 		kv:             kv,
 		time:           time.Now,
 	}
+
+	if len(configs) > 0 {
+		s.Config = configs[0]
+	} else {
+		s.Config.SessionLength = influxdb.DefaultSessionLength
+	}
+
+	return s
+}
+
+// ServiceConfig allows us to configure Services
+type ServiceConfig struct {
+	SessionLength time.Duration
 }
 
 // Initialize creates Buckets needed.

--- a/kv/service.go
+++ b/kv/service.go
@@ -34,8 +34,7 @@ type Service struct {
 // NewService returns an instance of a Service.
 func NewService(kv Store, configs ...ServiceConfig) *Service {
 	s := &Service{
-		Logger: zap.NewNop(),
-		// Config:         config,
+		Logger:         zap.NewNop(),
 		IDGenerator:    snowflake.NewIDGenerator(),
 		TokenGenerator: rand.NewTokenGenerator(64),
 		Hash:           &Bcrypt{},

--- a/kv/service_test.go
+++ b/kv/service_test.go
@@ -1,0 +1,39 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kv"
+)
+
+type mockStore struct {
+}
+
+func (s mockStore) View(context.Context, func(kv.Tx) error) error {
+	return nil
+}
+
+func (s mockStore) Update(context.Context, func(kv.Tx) error) error {
+	return nil
+}
+
+func TestNewService(t *testing.T) {
+	s := kv.NewService(mockStore{})
+
+	if s.Config.SessionLength != influxdb.DefaultSessionLength {
+		t.Errorf("Service session length should use default length when not set")
+	}
+
+	config := kv.ServiceConfig{
+		SessionLength: time.Duration(time.Hour * 4),
+	}
+
+	s = kv.NewService(mockStore{}, config)
+
+	if s.Config != config {
+		t.Errorf("Service config not set by constructor")
+	}
+}

--- a/kv/session.go
+++ b/kv/session.go
@@ -215,8 +215,7 @@ func (s *Service) createSession(ctx context.Context, tx Tx, user string) (*influ
 	sn.Key = k
 	sn.UserID = u.ID
 	sn.CreatedAt = time.Now()
-	// TODO(desa): make this configurable
-	sn.ExpiresAt = sn.CreatedAt.Add(time.Hour)
+	sn.ExpiresAt = sn.CreatedAt.Add(s.sessionLength)
 	// TODO(desa): not totally sure what to do here. Possibly we should have a maximal privilege permission.
 	sn.Permissions = []influxdb.Permission{}
 

--- a/kv/session.go
+++ b/kv/session.go
@@ -215,7 +215,7 @@ func (s *Service) createSession(ctx context.Context, tx Tx, user string) (*influ
 	sn.Key = k
 	sn.UserID = u.ID
 	sn.CreatedAt = time.Now()
-	sn.ExpiresAt = sn.CreatedAt.Add(s.sessionLength)
+	sn.ExpiresAt = sn.CreatedAt.Add(s.Config.SessionLength)
 	// TODO(desa): not totally sure what to do here. Possibly we should have a maximal privilege permission.
 	sn.Permissions = []influxdb.Permission{}
 

--- a/session.go
+++ b/session.go
@@ -14,6 +14,9 @@ const ErrSessionExpired = "session has expired"
 // RenewSessionTime is the the time to extend session, currently set to 5min.
 var RenewSessionTime = time.Duration(time.Second * 300)
 
+// DefaultSessionLength is the default session length on initial creation.
+var DefaultSessionLength = time.Hour
+
 var (
 	// OpFindSession represents the operation that looks for sessions.
 	OpFindSession = "FindSession"


### PR DESCRIPTION
This change adds in two CLI args for specifying session length and whether or not the session should be renewed. `session-length` and `session-renew-disabled`. 
The defaults are 60 for session length and false for session renew disabled.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr)
