### PR TITLE
fix(storage/reads): stop copying the values to an unnecessary buffer in the storage reader

### DIFF
--- a/storage/reads/table.gen.go
+++ b/storage/reads/table.gen.go
@@ -24,10 +24,9 @@ import (
 
 type floatTable struct {
 	table
-	valBuf []float64
-	mu     sync.Mutex
-	cur    cursors.FloatArrayCursor
-	alloc  *memory.Allocator
+	mu    sync.Mutex
+	cur   cursors.FloatArrayCursor
+	alloc *memory.Allocator
 }
 
 func newFloatTable(
@@ -103,22 +102,8 @@ func (t *floatTable) advance() bool {
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]float64, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -128,10 +113,9 @@ func (t *floatTable) advance() bool {
 
 type floatGroupTable struct {
 	table
-	valBuf []float64
-	mu     sync.Mutex
-	gc     GroupCursor
-	cur    cursors.FloatArrayCursor
+	mu  sync.Mutex
+	gc  GroupCursor
+	cur cursors.FloatArrayCursor
 }
 
 func newFloatGroupTable(
@@ -198,22 +182,8 @@ RETRY:
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]float64, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -259,10 +229,9 @@ func (t *floatGroupTable) Statistics() cursors.CursorStats {
 
 type integerTable struct {
 	table
-	valBuf []int64
-	mu     sync.Mutex
-	cur    cursors.IntegerArrayCursor
-	alloc  *memory.Allocator
+	mu    sync.Mutex
+	cur   cursors.IntegerArrayCursor
+	alloc *memory.Allocator
 }
 
 func newIntegerTable(
@@ -338,22 +307,8 @@ func (t *integerTable) advance() bool {
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]int64, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -363,10 +318,9 @@ func (t *integerTable) advance() bool {
 
 type integerGroupTable struct {
 	table
-	valBuf []int64
-	mu     sync.Mutex
-	gc     GroupCursor
-	cur    cursors.IntegerArrayCursor
+	mu  sync.Mutex
+	gc  GroupCursor
+	cur cursors.IntegerArrayCursor
 }
 
 func newIntegerGroupTable(
@@ -433,22 +387,8 @@ RETRY:
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]int64, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -494,10 +434,9 @@ func (t *integerGroupTable) Statistics() cursors.CursorStats {
 
 type unsignedTable struct {
 	table
-	valBuf []uint64
-	mu     sync.Mutex
-	cur    cursors.UnsignedArrayCursor
-	alloc  *memory.Allocator
+	mu    sync.Mutex
+	cur   cursors.UnsignedArrayCursor
+	alloc *memory.Allocator
 }
 
 func newUnsignedTable(
@@ -573,22 +512,8 @@ func (t *unsignedTable) advance() bool {
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]uint64, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -598,10 +523,9 @@ func (t *unsignedTable) advance() bool {
 
 type unsignedGroupTable struct {
 	table
-	valBuf []uint64
-	mu     sync.Mutex
-	gc     GroupCursor
-	cur    cursors.UnsignedArrayCursor
+	mu  sync.Mutex
+	gc  GroupCursor
+	cur cursors.UnsignedArrayCursor
 }
 
 func newUnsignedGroupTable(
@@ -668,22 +592,8 @@ RETRY:
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]uint64, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -729,10 +639,9 @@ func (t *unsignedGroupTable) Statistics() cursors.CursorStats {
 
 type stringTable struct {
 	table
-	valBuf []string
-	mu     sync.Mutex
-	cur    cursors.StringArrayCursor
-	alloc  *memory.Allocator
+	mu    sync.Mutex
+	cur   cursors.StringArrayCursor
+	alloc *memory.Allocator
 }
 
 func newStringTable(
@@ -808,22 +717,8 @@ func (t *stringTable) advance() bool {
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]string, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -833,10 +728,9 @@ func (t *stringTable) advance() bool {
 
 type stringGroupTable struct {
 	table
-	valBuf []string
-	mu     sync.Mutex
-	gc     GroupCursor
-	cur    cursors.StringArrayCursor
+	mu  sync.Mutex
+	gc  GroupCursor
+	cur cursors.StringArrayCursor
 }
 
 func newStringGroupTable(
@@ -903,22 +797,8 @@ RETRY:
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]string, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -964,10 +844,9 @@ func (t *stringGroupTable) Statistics() cursors.CursorStats {
 
 type booleanTable struct {
 	table
-	valBuf []bool
-	mu     sync.Mutex
-	cur    cursors.BooleanArrayCursor
-	alloc  *memory.Allocator
+	mu    sync.Mutex
+	cur   cursors.BooleanArrayCursor
+	alloc *memory.Allocator
 }
 
 func newBooleanTable(
@@ -1043,22 +922,8 @@ func (t *booleanTable) advance() bool {
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]bool, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -1068,10 +933,9 @@ func (t *booleanTable) advance() bool {
 
 type booleanGroupTable struct {
 	table
-	valBuf []bool
-	mu     sync.Mutex
-	gc     GroupCursor
-	cur    cursors.BooleanArrayCursor
+	mu  sync.Mutex
+	gc  GroupCursor
+	cur cursors.BooleanArrayCursor
 }
 
 func newBooleanGroupTable(
@@ -1138,22 +1002,8 @@ RETRY:
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]bool, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true

--- a/storage/reads/table.gen.go.tmpl
+++ b/storage/reads/table.gen.go.tmpl
@@ -18,7 +18,6 @@ import (
 
 type {{.name}}Table struct {
 	table
-	valBuf []{{.Type}}
 	mu     sync.Mutex
 	cur    cursors.{{.Name}}ArrayCursor
 	alloc  *memory.Allocator
@@ -97,22 +96,8 @@ func (t *{{.name}}Table) advance() bool {
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]{{.Type}}, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true
@@ -122,7 +107,6 @@ func (t *{{.name}}Table) advance() bool {
 
 type {{.name}}GroupTable struct {
 	table
-	valBuf []{{.Type}}
 	mu     sync.Mutex
 	gc     GroupCursor
 	cur    cursors.{{.Name}}ArrayCursor
@@ -192,22 +176,8 @@ RETRY:
 		return false
 	}
 
-	if cap(t.timeBuf) < t.l {
-		t.timeBuf = make([]int64, t.l)
-	} else {
-		t.timeBuf = t.timeBuf[:t.l]
-	}
-	copy(t.timeBuf, a.Timestamps)
-
-	if cap(t.valBuf) < t.l {
-		t.valBuf = make([]{{.Type}}, t.l)
-	} else {
-		t.valBuf = t.valBuf[:t.l]
-	}
-	copy(t.valBuf, a.Values)
-
-	t.colBufs[timeColIdx] = arrow.NewInt(t.timeBuf, &memory.Allocator{})
-	t.colBufs[valueColIdx] = t.toArrowBuffer(t.valBuf)
+	t.colBufs[timeColIdx] = arrow.NewInt(a.Timestamps, t.alloc)
+	t.colBufs[valueColIdx] = t.toArrowBuffer(a.Values)
 	t.appendTags()
 	t.appendBounds()
 	return true

--- a/storage/reads/table.go
+++ b/storage/reads/table.go
@@ -29,7 +29,6 @@ type table struct {
 	l int
 
 	colBufs []array.Interface
-	timeBuf []int64
 
 	err error
 


### PR DESCRIPTION
The copy was unnecessary since it was just going to be copied
immediately afterwards into an Arrow buffer. In the future, we will want
to have storage directly send the arrow buffer, but right now we are
putting it in an array and copying it anyway.

Even when we send an arrow buffer, the underlying sequence of bytes is
probably going to be different and we will rely on the allocator to
reuse bytes so let's remove the extra copy.