### PR TITLE
fix(releng): update releng to match build.py

### DIFF
--- a/releng/packages/fs/usr/local/bin/influxdb_packages.bash
+++ b/releng/packages/fs/usr/local/bin/influxdb_packages.bash
@@ -127,6 +127,8 @@ elif [ "$OS" == "linux" ] || [ "$OS" == "darwin" ]; then
         --maintainer "support@influxdb.com" \
         --directories /var/log/influxdb \
         --directories /var/lib/influxdb \
+        --rpm-attr 755,influxdb,influxdb:/var/log/influxdb \
+        --rpm-attr 755,influxdb,influxdb:/var/lib/influxdb \
         --description 'Distributed time-series database.' \
         --config-files /etc/influxdb/influxdb.conf \
         --config-files /etc/logrotate.d/influxdb \


### PR DESCRIPTION
I updated `build.py` in https://github.com/influxdata/influxdb/pull/13397, but I didn't update `releng` to match those.

@gshif I haven't tested `releng` scripts locally yet, because I think I need more context on this.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
