### PR TITLE
fix(http): task owner id path formatting

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4688,7 +4688,7 @@ paths:
               application/json:
                 schema:
                   $ref: "#/components/schemas/Error"
-  '/tasks/taskID}/owners/{userID}':
+  '/tasks/{taskID}/owners/{userID}':
     delete:
       tags:
         - Users


### PR DESCRIPTION
Closes #13951 

Fixing syntax for autogeneration of client

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
