### PR TITLE
fix(task): Remove timeout on task run updates

### DIFF
--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -805,11 +805,7 @@ func (r *runner) updateRunState(qr QueuedRun, s RunStatus, runLogger *zap.Logger
 		runLogger.Warn("Unhandled run state", zap.Stringer("state", s))
 	}
 
-	// Arbitrarily chosen short time limit for how fast the log write must complete.
-	// If we start seeing errors from this, we know the time limit is too short or the system is overloaded.
-	ctx, cancel := context.WithTimeout(r.ctx, 10*time.Millisecond)
-	defer cancel()
-	if err := r.taskControlService.UpdateRunState(ctx, r.task.ID, qr.RunID, time.Now(), s); err != nil {
+	if err := r.taskControlService.UpdateRunState(r.ctx, r.task.ID, qr.RunID, time.Now(), s); err != nil {
 		runLogger.Info("Error updating run state", zap.Stringer("state", s), zap.Error(err))
 	}
 }


### PR DESCRIPTION
Now that the run status updates are transactional actions
We no longer have to add a timer to keep things on track.

This is causing a problem where some runs are showing up without a start or stop time if the system is busy.
I would rather have the scheduler hang on the update then leave a run action without required fields.
