### PR TITLE
feat(influxdb): add org create and update time

### DIFF
--- a/bolt/organization.go
+++ b/bolt/organization.go
@@ -230,6 +230,8 @@ func (c *Client) CreateOrganization(ctx context.Context, o *influxdb.Organizatio
 		}
 
 		o.ID = c.IDGenerator.ID()
+		o.CreatedAt = c.Now()
+		o.UpdatedAt = c.Now()
 		if err := c.appendOrganizationEventToLog(ctx, tx, o.ID, organizationCreatedEvent); err != nil {
 			return &influxdb.Error{
 				Err: err,
@@ -362,6 +364,8 @@ func (c *Client) updateOrganization(ctx context.Context, tx *bolt.Tx, id influxd
 	if upd.Description != nil {
 		o.Description = *upd.Description
 	}
+
+	o.UpdatedAt = c.Now()
 
 	if err := c.appendOrganizationEventToLog(ctx, tx, o.ID, organizationUpdatedEvent); err != nil {
 		return nil, &influxdb.Error{

--- a/bolt/organization_test.go
+++ b/bolt/organization_test.go
@@ -15,6 +15,10 @@ func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T)
 		t.Fatalf("failed to create new bolt client: %v", err)
 	}
 	c.IDGenerator = f.IDGenerator
+	c.TimeGenerator = f.TimeGenerator
+	if f.TimeGenerator == nil {
+		c.TimeGenerator = platform.RealTimeGenerator{}
+	}
 	ctx := context.TODO()
 	for _, u := range f.Organizations {
 		if err := c.PutOrganization(ctx, u); err != nil {

--- a/http/org_test.go
+++ b/http/org_test.go
@@ -36,6 +36,10 @@ func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T)
 	t.Helper()
 	svc := inmem.NewService()
 	svc.IDGenerator = f.IDGenerator
+	svc.TimeGenerator = f.TimeGenerator
+	if f.TimeGenerator == nil {
+		svc.TimeGenerator = platform.RealTimeGenerator{}
+	}
 
 	ctx := context.Background()
 	for _, o := range f.Organizations {

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5734,6 +5734,14 @@ components:
           type: string
         description:
           type: string
+        createdAt:
+          type: string
+          format: date-time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          readOnly: true
         status:
           description: if inactive the organization is inactive.
           default: active

--- a/inmem/organization_service.go
+++ b/inmem/organization_service.go
@@ -190,6 +190,8 @@ func (s *Service) CreateOrganization(ctx context.Context, o *platform.Organizati
 		}
 	}
 	o.ID = s.IDGenerator.ID()
+	o.CreatedAt = s.Now()
+	o.UpdatedAt = s.Now()
 	err := s.PutOrganization(ctx, o)
 	if err != nil {
 		return &platform.Error{
@@ -232,6 +234,8 @@ func (s *Service) UpdateOrganization(ctx context.Context, id platform.ID, upd pl
 	if upd.Description != nil {
 		o.Description = *upd.Description
 	}
+
+	o.UpdatedAt = s.Now()
 
 	s.organizationKV.Store(o.ID.String(), o)
 

--- a/inmem/organization_test.go
+++ b/inmem/organization_test.go
@@ -11,6 +11,10 @@ import (
 func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T) (platform.OrganizationService, string, func()) {
 	s := NewService()
 	s.IDGenerator = f.IDGenerator
+	s.TimeGenerator = f.TimeGenerator
+	if f.TimeGenerator == nil {
+		s.TimeGenerator = platform.RealTimeGenerator{}
+	}
 	ctx := context.TODO()
 	for _, o := range f.Organizations {
 		if err := s.PutOrganization(ctx, o); err != nil {

--- a/kv/org.go
+++ b/kv/org.go
@@ -249,6 +249,8 @@ func (s *Service) createOrganization(ctx context.Context, tx Tx, o *influxdb.Org
 	}
 
 	o.ID = s.IDGenerator.ID()
+	o.CreatedAt = s.Now()
+	o.UpdatedAt = s.Now()
 	if err := s.appendOrganizationEventToLog(ctx, tx, o.ID, organizationCreatedEvent); err != nil {
 		return &influxdb.Error{
 			Err: err,
@@ -401,6 +403,8 @@ func (s *Service) updateOrganization(ctx context.Context, tx Tx, id influxdb.ID,
 	if upd.Description != nil {
 		o.Description = *upd.Description
 	}
+
+	o.UpdatedAt = s.Now()
 
 	if err := s.appendOrganizationEventToLog(ctx, tx, o.ID, organizationUpdatedEvent); err != nil {
 		return nil, &influxdb.Error{

--- a/kv/org_test.go
+++ b/kv/org_test.go
@@ -46,6 +46,10 @@ func initInmemOrganizationService(f influxdbtesting.OrganizationFields, t *testi
 func initOrganizationService(s kv.Store, f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {
 	svc := kv.NewService(s)
 	svc.IDGenerator = f.IDGenerator
+	svc.TimeGenerator = f.TimeGenerator
+	if f.TimeGenerator == nil {
+		svc.TimeGenerator = influxdb.RealTimeGenerator{}
+	}
 
 	ctx := context.Background()
 	if err := svc.Initialize(ctx); err != nil {

--- a/organization.go
+++ b/organization.go
@@ -7,6 +7,7 @@ type Organization struct {
 	ID          ID     `json:"id,omitempty"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	CRUDLog
 }
 
 // errors of org

--- a/testing/onboarding.go
+++ b/testing/onboarding.go
@@ -157,6 +157,10 @@ func Generate(
 					Org: &platform.Organization{
 						ID:   MustIDBase16(twoID),
 						Name: "org1",
+						CRUDLog: platform.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
 					},
 					Bucket: &platform.Bucket{
 						ID:              MustIDBase16(threeID),

--- a/testing/organization_service.go
+++ b/testing/organization_service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	platform "github.com/influxdata/influxdb"
@@ -33,6 +34,7 @@ var organizationCmpOptions = cmp.Options{
 type OrganizationFields struct {
 	IDGenerator   platform.IDGenerator
 	Organizations []*platform.Organization
+	TimeGenerator platform.TimeGenerator
 }
 
 // OrganizationService tests all the service functions.
@@ -99,6 +101,7 @@ func CreateOrganization(
 			name: "create organizations with empty set",
 			fields: OrganizationFields{
 				IDGenerator:   mock.NewIDGenerator(orgOneID, t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{},
 			},
 			args: args{
@@ -114,6 +117,10 @@ func CreateOrganization(
 						Name:        "name1",
 						ID:          MustIDBase16(orgOneID),
 						Description: "desc1",
+						CRUDLog: platform.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
 					},
 				},
 			},
@@ -121,7 +128,8 @@ func CreateOrganization(
 		{
 			name: "basic create organization",
 			fields: OrganizationFields{
-				IDGenerator: mock.NewIDGenerator(orgTwoID, t),
+				IDGenerator:   mock.NewIDGenerator(orgTwoID, t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -144,6 +152,10 @@ func CreateOrganization(
 					{
 						ID:   MustIDBase16(orgTwoID),
 						Name: "organization2",
+						CRUDLog: platform.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
 					},
 				},
 			},
@@ -151,7 +163,8 @@ func CreateOrganization(
 		{
 			name: "empty name",
 			fields: OrganizationFields{
-				IDGenerator: mock.NewIDGenerator(orgTwoID, t),
+				IDGenerator:   mock.NewIDGenerator(orgTwoID, t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -177,7 +190,8 @@ func CreateOrganization(
 		{
 			name: "name only have spaces",
 			fields: OrganizationFields{
-				IDGenerator: mock.NewIDGenerator(orgTwoID, t),
+				IDGenerator:   mock.NewIDGenerator(orgTwoID, t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -204,7 +218,8 @@ func CreateOrganization(
 		{
 			name: "names should be unique",
 			fields: OrganizationFields{
-				IDGenerator: mock.NewIDGenerator(orgTwoID, t),
+				IDGenerator:   mock.NewIDGenerator(orgTwoID, t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -235,7 +250,8 @@ func CreateOrganization(
 		{
 			name: "create organization with no id",
 			fields: OrganizationFields{
-				IDGenerator: mock.NewIDGenerator(orgTwoID, t),
+				IDGenerator:   mock.NewIDGenerator(orgTwoID, t),
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -257,6 +273,10 @@ func CreateOrganization(
 					{
 						ID:   MustIDBase16(orgTwoID),
 						Name: "organization2",
+						CRUDLog: platform.CRUDLog{
+							CreatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+							UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+						},
 					},
 				},
 			},
@@ -802,6 +822,7 @@ func UpdateOrganization(
 		{
 			name: "update id not exists",
 			fields: OrganizationFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -828,6 +849,7 @@ func UpdateOrganization(
 		{
 			name: "update name",
 			fields: OrganizationFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -847,12 +869,16 @@ func UpdateOrganization(
 				organization: &platform.Organization{
 					ID:   MustIDBase16(orgOneID),
 					Name: "changed",
+					CRUDLog: platform.CRUDLog{
+						UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+					},
 				},
 			},
 		},
 		{
 			name: "update name not unique",
 			fields: OrganizationFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -879,6 +905,7 @@ func UpdateOrganization(
 		{
 			name: "update name is empty",
 			fields: OrganizationFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -901,6 +928,7 @@ func UpdateOrganization(
 		{
 			name: "update name only has space",
 			fields: OrganizationFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:   MustIDBase16(orgOneID),
@@ -923,6 +951,7 @@ func UpdateOrganization(
 		{
 			name: "update description",
 			fields: OrganizationFields{
+				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*platform.Organization{
 					{
 						ID:          MustIDBase16(orgOneID),
@@ -945,6 +974,9 @@ func UpdateOrganization(
 					ID:          MustIDBase16(orgOneID),
 					Name:        "organization1",
 					Description: "changed",
+					CRUDLog: platform.CRUDLog{
+						UpdatedAt: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/13479
Closes https://github.com/influxdata/influxdb/issues/13480

Add createdat, updatedat in org resource


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)