### PR TITLE
refactor(query/control): move the controller from flux to influxdb

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/influxdata/flux/control"
 	"github.com/influxdata/flux/execute"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/authorizer"
@@ -32,7 +31,7 @@ import (
 	"github.com/influxdata/influxdb/nats"
 	infprom "github.com/influxdata/influxdb/prometheus"
 	"github.com/influxdata/influxdb/query"
-	pcontrol "github.com/influxdata/influxdb/query/control"
+	"github.com/influxdata/influxdb/query/control"
 	"github.com/influxdata/influxdb/snowflake"
 	"github.com/influxdata/influxdb/source"
 	"github.com/influxdata/influxdb/storage"
@@ -218,7 +217,7 @@ type Launcher struct {
 	engine        *storage.Engine
 	StorageConfig storage.Config
 
-	queryController *pcontrol.Controller
+	queryController *control.Controller
 
 	httpPort   int
 	httpServer *nethttp.Server
@@ -519,7 +518,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 			return err
 		}
 
-		c, err := pcontrol.New(cc)
+		c, err := control.New(cc)
 		if err != nil {
 			m.logger.Error("Failed to create query controller", zap.Error(err))
 			return err
@@ -681,7 +680,7 @@ func (m *Launcher) OrganizationService() platform.OrganizationService {
 }
 
 // QueryController returns the internal query service.
-func (m *Launcher) QueryController() *pcontrol.Controller {
+func (m *Launcher) QueryController() *control.Controller {
 	return m.queryController
 }
 

--- a/query/control/controller.go
+++ b/query/control/controller.go
@@ -1,34 +1,136 @@
-// Package control provides a query controller.
+// Package control keeps track of resources and manages queries.
+//
+// The Controller manages the resources available to each query by
+// managing the memory allocation and concurrency usage of each query.
+// The Controller will compile a program by using the passed in language
+// and it will start the program using the ResourceManager.
+//
+// It will guarantee that each program that is started has at least
+// one goroutine that it can use with the dispatcher and it will
+// ensure a minimum amount of memory is available before the program
+// runs.
+//
+// Other goroutines and memory usage is at the will of the specific
+// resource strategy that the Controller is using.
+//
+// The Controller also provides visibility into the lifetime of the query
+// and its current resource usage.
 package control
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/control"
-	"github.com/prometheus/client_golang/prometheus"
-
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/memory"
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/errors"
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/query"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 )
 
 // orgLabel is the metric label to use in the controller
 const orgLabel = "org"
 
-// Controller implements AsyncQueryService by consuming a control.Controller.
+// Controller provides a central location to manage all incoming queries.
+// The controller is responsible for compiling, queueing, and executing queries.
 type Controller struct {
-	c *control.Controller
+	lastID     uint64
+	queriesMu  sync.RWMutex
+	queries    map[QueryID]*Query
+	queryQueue chan *Query
+	wg         sync.WaitGroup
+	shutdown   bool
+	done       chan struct{}
+	abortOnce  sync.Once
+	abort      chan struct{}
+
+	memoryBytesQuotaPerQuery int64
+
+	metrics   *controllerMetrics
+	labelKeys []string
+
+	logger *zap.Logger
+
+	dependencies execute.Dependencies
 }
 
-// NewController creates a new Controller specific to platform.
-func New(config control.Config) (*Controller, error) {
-	config.MetricLabelKeys = append(config.MetricLabelKeys, orgLabel)
-	c, err := control.New(config)
-	if err != nil {
-		return nil, err
+type Config struct {
+	// ConcurrencyQuota is the number of queries that are allowed to execute concurrently.
+	ConcurrencyQuota int
+	// MemoryBytesQuotaPerQuery is the maximum number of bytes (in table memory) a query is allowed to use at
+	// any given time.
+	//
+	// The maximum amount of memory the controller is allowed to consume is
+	//   ConcurrencyQuota * MemoryBytesQuotaPerQuery
+	MemoryBytesQuotaPerQuery int64
+	// QueueSize is the number of queries that are allowed to be awaiting execution before new queries are
+	// rejected.
+	QueueSize int
+	Logger    *zap.Logger
+	// MetricLabelKeys is a list of labels to add to the metrics produced by the controller.
+	// The value for a given key will be read off the context.
+	// The context value must be a string or an implementation of the Stringer interface.
+	MetricLabelKeys []string
+
+	ExecutorDependencies execute.Dependencies
+}
+
+func (c *Config) Validate() error {
+	if c.ConcurrencyQuota <= 0 {
+		return errors.New("ConcurrencyQuota must be positive")
 	}
-	return &Controller{c: c}, nil
+	if c.MemoryBytesQuotaPerQuery <= 0 {
+		return errors.New("MemoryBytesQuotaPerQuery must be positive")
+	}
+	if c.QueueSize <= 0 {
+		return errors.New("QueueSize must be positive")
+	}
+	return nil
+}
+
+type QueryID uint64
+
+func New(c Config) (*Controller, error) {
+	if err := c.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid controller config")
+	}
+	c.MetricLabelKeys = append(c.MetricLabelKeys, orgLabel)
+	logger := c.Logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	logger.Info("Starting query controller",
+		zap.Int("concurrency_quota", c.ConcurrencyQuota),
+		zap.Int64("memory_bytes_quota_per_query", c.MemoryBytesQuotaPerQuery),
+		zap.Int("queue_size", c.QueueSize))
+	ctrl := &Controller{
+		queries:                  make(map[QueryID]*Query),
+		queryQueue:               make(chan *Query, c.QueueSize),
+		done:                     make(chan struct{}),
+		abort:                    make(chan struct{}),
+		memoryBytesQuotaPerQuery: c.MemoryBytesQuotaPerQuery,
+		logger:                   logger,
+		metrics:                  newControllerMetrics(c.MetricLabelKeys),
+		labelKeys:                c.MetricLabelKeys,
+		dependencies:             c.ExecutorDependencies,
+	}
+	ctrl.wg.Add(c.ConcurrencyQuota)
+	for i := 0; i < c.ConcurrencyQuota; i++ {
+		go func() {
+			defer ctrl.wg.Done()
+			ctrl.processQueryQueue()
+		}()
+	}
+	return ctrl, nil
 }
 
 // Query satisfies the AsyncQueryService while ensuring the request is propagated on the context.
@@ -40,7 +142,7 @@ func (c *Controller) Query(ctx context.Context, req *query.Request) (flux.Query,
 	ctx = query.ContextWithRequest(ctx, req)
 	// Set the org label value for controller metrics
 	ctx = context.WithValue(ctx, orgLabel, req.OrganizationID.String())
-	q, err := c.c.Query(ctx, req.Compiler)
+	q, err := c.query(ctx, req.Compiler)
 	if err != nil {
 		// If the controller reports an error, it's usually because of a syntax error
 		// or other problem that the client must fix.
@@ -53,12 +155,706 @@ func (c *Controller) Query(ctx context.Context, req *query.Request) (flux.Query,
 	return q, nil
 }
 
-// PrometheusCollectors satisifies the prom.PrometheusCollector interface.
-func (c *Controller) PrometheusCollectors() []prometheus.Collector {
-	return c.c.PrometheusCollectors()
+// query submits a query for execution returning immediately.
+// Done must be called on any returned Query objects.
+func (c *Controller) query(ctx context.Context, compiler flux.Compiler) (flux.Query, error) {
+	q, err := c.createQuery(ctx, compiler.CompilerType())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.compileQuery(q, compiler); err != nil {
+		q.setErr(err)
+		c.finish(q)
+		c.countQueryRequest(q, labelCompileError)
+		return nil, q.Err()
+	}
+	if err := c.enqueueQuery(q); err != nil {
+		q.setErr(err)
+		c.finish(q)
+		c.countQueryRequest(q, labelQueueError)
+		return nil, q.Err()
+	}
+	return q, nil
 }
 
-// Shutdown shuts down the underlying Controller.
+func (c *Controller) createQuery(ctx context.Context, ct flux.CompilerType) (*Query, error) {
+	c.queriesMu.RLock()
+	if c.shutdown {
+		c.queriesMu.RUnlock()
+		return nil, errors.New("query controller shutdown")
+	}
+	c.queriesMu.RUnlock()
+
+	id := c.nextID()
+	labelValues := make([]string, len(c.labelKeys))
+	compileLabelValues := make([]string, len(c.labelKeys)+1)
+	for i, k := range c.labelKeys {
+		value := ctx.Value(k)
+		var str string
+		switch v := value.(type) {
+		case string:
+			str = v
+		case fmt.Stringer:
+			str = v.String()
+		}
+		labelValues[i] = str
+		compileLabelValues[i] = str
+	}
+	compileLabelValues[len(compileLabelValues)-1] = string(ct)
+
+	cctx, cancel := context.WithCancel(ctx)
+	parentSpan, parentCtx := StartSpanFromContext(
+		cctx,
+		"all",
+		c.metrics.allDur.WithLabelValues(labelValues...),
+		c.metrics.all.WithLabelValues(labelValues...),
+	)
+	q := &Query{
+		id:                 id,
+		labelValues:        labelValues,
+		compileLabelValues: compileLabelValues,
+		state:              Created,
+		c:                  c,
+		results:            make(chan flux.Result),
+		parentCtx:          parentCtx,
+		parentSpan:         parentSpan,
+		cancel:             cancel,
+		doneCh:             make(chan struct{}),
+	}
+
+	// Lock the queries mutex for the rest of this method.
+	c.queriesMu.Lock()
+	defer c.queriesMu.Unlock()
+
+	if c.shutdown {
+		// Query controller was shutdown between when we started
+		// creating the query and ending it.
+		err := errors.New("query controller shutdown")
+		q.setErr(err)
+		return nil, err
+	}
+	c.queries[id] = q
+	return q, nil
+}
+
+func (c *Controller) nextID() QueryID {
+	nextID := atomic.AddUint64(&c.lastID, 1)
+	return QueryID(nextID)
+}
+
+func (c *Controller) countQueryRequest(q *Query, result requestsLabel) {
+	l := len(q.labelValues)
+	lvs := make([]string, l+1)
+	copy(lvs, q.labelValues)
+	lvs[l] = string(result)
+	c.metrics.requests.WithLabelValues(lvs...).Inc()
+}
+
+func (c *Controller) compileQuery(q *Query, compiler flux.Compiler) error {
+	ctx, ok := q.tryCompile()
+	if !ok {
+		return errors.New("failed to transition query to compiling state")
+	}
+
+	prog, err := compiler.Compile(ctx)
+	if err != nil {
+		return errors.Wrap(err, "compilation failed")
+	}
+
+	if p, ok := prog.(lang.DependenciesAwareProgram); ok {
+		p.SetExecutorDependencies(c.dependencies)
+		p.SetLogger(c.logger)
+	}
+
+	q.program = prog
+	return nil
+}
+
+func (c *Controller) enqueueQuery(q *Query) error {
+	if _, ok := q.tryQueue(); !ok {
+		return errors.New("failed to transition query to queueing state")
+	}
+
+	select {
+	case c.queryQueue <- q:
+	default:
+		return errors.New("queue length exceeded")
+	}
+
+	return nil
+}
+
+func (c *Controller) processQueryQueue() {
+	for {
+		select {
+		case <-c.done:
+			return
+		case q := <-c.queryQueue:
+			c.executeQuery(q)
+		}
+	}
+}
+
+func (c *Controller) executeQuery(q *Query) {
+	ctx, ok := q.tryExec()
+	if !ok {
+		// This may happen if the query was cancelled (either because the
+		// client cancelled it, or because the controller is shutting down)
+		// In the case of cancellation, SetErr() should reset the error to an
+		// appropriate message.
+		q.setErr(errors.New("impossible state transition"))
+		return
+	}
+
+	q.alloc = new(memory.Allocator)
+	q.alloc.Limit = func(v int64) *int64 { return &v }(c.memoryBytesQuotaPerQuery)
+	exec, err := q.program.Start(ctx, q.alloc)
+	if err != nil {
+		q.addRuntimeError(err)
+		q.setErr(err)
+		return
+	}
+	q.exec = exec
+	q.pump(exec, ctx.Done())
+}
+
+func (c *Controller) finish(q *Query) {
+	c.queriesMu.Lock()
+	delete(c.queries, q.id)
+	if len(c.queries) == 0 && c.shutdown {
+		close(c.done)
+	}
+	c.queriesMu.Unlock()
+}
+
+// Queries reports the active queries.
+func (c *Controller) Queries() []*Query {
+	c.queriesMu.RLock()
+	defer c.queriesMu.RUnlock()
+	queries := make([]*Query, 0, len(c.queries))
+	for _, q := range c.queries {
+		queries = append(queries, q)
+	}
+	return queries
+}
+
+// Shutdown will signal to the Controller that it should not accept any
+// new queries and that it should finish executing any existing queries.
+// This will return once the Controller's run loop has been exited and all
+// queries have been finished or until the Context has been canceled.
 func (c *Controller) Shutdown(ctx context.Context) error {
-	return c.c.Shutdown(ctx)
+	// Mark that the controller is shutdown so it does not
+	// accept new queries.
+	c.queriesMu.Lock()
+	c.shutdown = true
+	if len(c.queries) == 0 {
+		c.queriesMu.Unlock()
+		return nil
+	}
+	c.queriesMu.Unlock()
+
+	// Cancel all of the currently active queries.
+	c.queriesMu.RLock()
+	for _, q := range c.queries {
+		q.Cancel()
+	}
+	c.queriesMu.RUnlock()
+
+	// Wait for query processing goroutines to finish.
+	defer c.wg.Wait()
+
+	// Wait for all of the queries to be cleaned up or until the
+	// context is done.
+	select {
+	case <-c.done:
+		return nil
+	case <-ctx.Done():
+		c.abortOnce.Do(func() {
+			close(c.abort)
+		})
+		return ctx.Err()
+	}
+}
+
+// PrometheusCollectors satisifies the prom.PrometheusCollector interface.
+func (c *Controller) PrometheusCollectors() []prometheus.Collector {
+	return c.metrics.PrometheusCollectors()
+}
+
+// Query represents a single request.
+type Query struct {
+	id QueryID
+
+	labelValues        []string
+	compileLabelValues []string
+
+	c *Controller
+
+	// query state. The stateMu protects access for the group below.
+	stateMu     sync.RWMutex
+	state       State
+	err         error
+	runtimeErrs []error
+	cancel      func()
+
+	parentCtx               context.Context
+	parentSpan, currentSpan *span
+	stats                   flux.Statistics
+
+	done   sync.Once
+	doneCh chan struct{}
+
+	program flux.Program
+	exec    flux.Query
+	results chan flux.Result
+	alloc   *memory.Allocator
+}
+
+// ID reports an ephemeral unique ID for the query.
+func (q *Query) ID() QueryID {
+	return q.id
+}
+
+// Cancel will stop the query execution.
+func (q *Query) Cancel() {
+	// Call the cancel function to signal that execution should
+	// be interrupted.
+	q.cancel()
+}
+
+// Results returns a channel that will deliver the query results.
+//
+// It's possible that the channel is closed before any results arrive.
+// In particular, if a query's context or the query itself is canceled,
+// the query may close the results channel before any results are computed.
+//
+// The query may also have an error during execution so the Err()
+// function should be used to check if an error happened.
+func (q *Query) Results() <-chan flux.Result {
+	return q.results
+}
+
+// Done signals to the Controller that this query is no longer
+// being used and resources related to the query may be freed.
+func (q *Query) Done() {
+	// This must only be invoked once.
+	q.done.Do(func() {
+		// All done calls should block until the first done call succeeds.
+		defer close(q.doneCh)
+
+		// Lock the state mutex and transition to the finished state.
+		// Then force the query to cancel to tell it to stop executing.
+		// We transition to the new state first so that we do not enter
+		// the canceled state at any point (as we have not been canceled).
+		q.stateMu.Lock()
+		q.transitionTo(Finished)
+		q.cancel()
+		q.stateMu.Unlock()
+
+		// Ensure that all of the results have been drained.
+		// It is ok to read this as the user has already indicated they don't
+		// care about the results. When this is closed, it tells us an error has
+		// been set or the results have finished being pumped.
+		for range q.results {
+			// Do nothing with the results.
+		}
+
+		// No other goroutines should be modifying state at this point so we
+		// can do things that would be unsafe in another context.
+		if q.exec != nil {
+			// Mark the program as being done and copy out the error if it exists.
+			q.exec.Done()
+			if q.err == nil {
+				// TODO(jsternberg): The underlying program never returns
+				// this so maybe their interface should change?
+				q.err = q.exec.Err()
+			}
+			// Merge the metadata from the program into the controller stats.
+			stats := q.exec.Statistics()
+			q.stats.Metadata = stats.Metadata
+		}
+
+		// Retrieve the runtime errors that have been accumulated.
+		errMsgs := make([]string, 0, len(q.runtimeErrs))
+		for _, e := range q.runtimeErrs {
+			errMsgs = append(errMsgs, e.Error())
+		}
+		q.stats.RuntimeErrors = errMsgs
+
+		// Mark the query as finished so it is removed from the query map.
+		q.c.finish(q)
+
+		// count query request
+		if q.err != nil || len(q.runtimeErrs) > 0 {
+			q.c.countQueryRequest(q, labelRuntimeError)
+		} else {
+			q.c.countQueryRequest(q, labelSuccess)
+		}
+	})
+	<-q.doneCh
+}
+
+// Statistics reports the statistics for the query.
+//
+// This method must be called after Done. It will block until
+// the query has been finalized unless a context is given.
+func (q *Query) Statistics() flux.Statistics {
+	stats := q.stats
+	if q.alloc != nil {
+		stats.MaxAllocated = q.alloc.MaxAllocated()
+	}
+	return stats
+}
+
+// State reports the current state of the query.
+func (q *Query) State() State {
+	q.stateMu.RLock()
+	state := q.state
+	if !isFinishedState(state) {
+		// If the query is a non-finished state, check the
+		// context to see if we have been interrupted.
+		select {
+		case <-q.parentCtx.Done():
+			// The query has been canceled so report to the
+			// outside world that we have been canceled.
+			// Do NOT attempt to change the internal state
+			// variable here. It is a minefield. Leave the
+			// normal query execution to figure that out.
+			state = Canceled
+		default:
+			// The context has not been canceled.
+		}
+	}
+	q.stateMu.RUnlock()
+	return state
+}
+
+// transitionTo will transition from one state to another. If a list of current states
+// is given, then the query must be in one of those states for the transition to succeed.
+// This method must be called with a lock and it must be called from within the run loop.
+func (q *Query) transitionTo(newState State, currentState ...State) (context.Context, bool) {
+	// If we are transitioning to a non-finished state, the query
+	// may have been canceled. If the query was canceled, then
+	// we need to transition to the canceled state
+	if !isFinishedState(newState) {
+		select {
+		case <-q.parentCtx.Done():
+			// Transition to the canceled state and report that
+			// we failed to transition to the desired state.
+			_, _ = q.transitionTo(Canceled)
+			return nil, false
+		default:
+		}
+	}
+
+	if len(currentState) > 0 {
+		// Find the current state in the list of current states.
+		for _, st := range currentState {
+			if q.state == st {
+				goto TRANSITION
+			}
+		}
+		return nil, false
+	}
+
+TRANSITION:
+	// We are transitioning to a new state. Close the current span (if it exists).
+	if q.currentSpan != nil {
+		q.currentSpan.Finish()
+		switch q.state {
+		case Compiling:
+			q.stats.CompileDuration += q.currentSpan.Duration
+		case Queueing:
+			q.stats.QueueDuration += q.currentSpan.Duration
+		case Executing:
+			q.stats.ExecuteDuration += q.currentSpan.Duration
+		}
+	}
+	q.currentSpan = nil
+
+	if isFinishedState(newState) {
+		// Invoke the cancel function to ensure that we have signaled that the query should be done.
+		// The user is supposed to read the entirety of the tables returned before we end up in a finished
+		// state, but user error may have caused this not to happen so there's no harm to canceling multiple
+		// times.
+		q.cancel()
+
+		// If we are transitioning to a finished state from a non-finished state, finish the parent span.
+		if q.parentSpan != nil {
+			q.parentSpan.Finish()
+			q.stats.TotalDuration = q.parentSpan.Duration
+			q.parentSpan = nil
+		}
+	}
+
+	// Transition to the new state.
+	q.state = newState
+
+	// Start a new span and set a new context.
+	var (
+		dur         *prometheus.HistogramVec
+		gauge       *prometheus.GaugeVec
+		labelValues = q.labelValues
+	)
+	switch newState {
+	case Compiling:
+		dur, gauge = q.c.metrics.compilingDur, q.c.metrics.compiling
+		labelValues = q.compileLabelValues
+	case Queueing:
+		dur, gauge = q.c.metrics.queueingDur, q.c.metrics.queueing
+	case Executing:
+		dur, gauge = q.c.metrics.executingDur, q.c.metrics.executing
+	default:
+		// This state is not tracked so do not create a new span or context for it.
+		// Use the parent context if one is needed.
+		return q.parentCtx, true
+	}
+	var currentCtx context.Context
+	q.currentSpan, currentCtx = StartSpanFromContext(
+		q.parentCtx,
+		newState.String(),
+		dur.WithLabelValues(labelValues...),
+		gauge.WithLabelValues(labelValues...),
+	)
+	return currentCtx, true
+}
+
+// Err reports any error the query may have encountered.
+func (q *Query) Err() error {
+	q.stateMu.Lock()
+	err := q.err
+	q.stateMu.Unlock()
+	return err
+}
+
+// setErr marks this query with an error. If the query was
+// canceled, then the error is ignored.
+//
+// This will mark the query as ready so setResults must not
+// be called if this method is invoked.
+func (q *Query) setErr(err error) {
+	q.stateMu.Lock()
+	defer q.stateMu.Unlock()
+
+	// We may have this get called when the query is canceled.
+	// If that is the case, transition to the canceled state
+	// instead and record the error from that since the error
+	// we received is probably wrong.
+	select {
+	case <-q.parentCtx.Done():
+		q.transitionTo(Canceled)
+		err = q.parentCtx.Err()
+	default:
+		q.transitionTo(Errored)
+	}
+	q.err = err
+
+	// Close the ready channel to report that no results
+	// will be sent.
+	close(q.results)
+}
+
+func (q *Query) addRuntimeError(e error) {
+	q.stateMu.Lock()
+	defer q.stateMu.Unlock()
+
+	q.runtimeErrs = append(q.runtimeErrs, e)
+}
+
+// pump will read from the executing query results and pump the
+// results to our destination.
+// When there are no more results, then this will close our own
+// results channel.
+func (q *Query) pump(exec flux.Query, done <-chan struct{}) {
+	defer close(q.results)
+
+	// When our context is canceled, we need to propagate that cancel
+	// signal down to the executing program just in case it is waiting
+	// for a cancel signal and is ignoring the passed in context.
+	// We want this signal to only be sent once and we want to continue
+	// draining the results until the underlying program has actually
+	// been finished so we copy this to a new channel and set it to
+	// nil when it has been closed.
+	signalCh := done
+	for {
+		select {
+		case res, ok := <-exec.Results():
+			if !ok {
+				return
+			}
+
+			// It is possible for the underlying query to misbehave.
+			// We have to continue pumping results even if this is the
+			// case, but if the query has been canceled or finished with
+			// done, nobody is going to read these values so we need
+			// to avoid blocking.
+			ecr := &errorCollectingResult{
+				Result: res,
+				q:      q,
+			}
+			select {
+			case <-done:
+			case q.results <- ecr:
+			}
+		case <-signalCh:
+			// Signal to the underlying executor that the query
+			// has been canceled. Usually, the signal on the context
+			// is likely enough, but this explicitly signals just in case.
+			exec.Cancel()
+
+			// Set the done channel to nil so we don't do this again
+			// and we continue to drain the results.
+			signalCh = nil
+		case <-q.c.abort:
+			// If we get here, then any running queries should have been cancelled
+			// in controller.Shutdown().
+			return
+		}
+	}
+}
+
+// tryCompile attempts to transition the query into the Compiling state.
+func (q *Query) tryCompile() (context.Context, bool) {
+	q.stateMu.Lock()
+	defer q.stateMu.Unlock()
+
+	return q.transitionTo(Compiling, Created)
+}
+
+// tryQueue attempts to transition the query into the Queueing state.
+func (q *Query) tryQueue() (context.Context, bool) {
+	q.stateMu.Lock()
+	defer q.stateMu.Unlock()
+
+	return q.transitionTo(Queueing, Compiling)
+}
+
+// tryExec attempts to transition the query into the Executing state.
+func (q *Query) tryExec() (context.Context, bool) {
+	q.stateMu.Lock()
+	defer q.stateMu.Unlock()
+
+	return q.transitionTo(Executing, Queueing)
+}
+
+type errorCollectingResult struct {
+	flux.Result
+	q *Query
+}
+
+func (r *errorCollectingResult) Tables() flux.TableIterator {
+	return &errorCollectingTableIterator{
+		TableIterator: r.Result.Tables(),
+		q:             r.q,
+	}
+}
+
+type errorCollectingTableIterator struct {
+	flux.TableIterator
+	q *Query
+}
+
+func (ti *errorCollectingTableIterator) Do(f func(t flux.Table) error) error {
+	err := ti.TableIterator.Do(f)
+	if err != nil {
+		ti.q.addRuntimeError(err)
+	}
+	return err
+}
+
+// State is the query state.
+type State int
+
+const (
+	// Created indicates the query has been created.
+	Created State = iota
+
+	// Compiling indicates that the query is in the process
+	// of executing the compiler associated with the query.
+	Compiling
+
+	// Queueing indicates the query is waiting inside of the
+	// scheduler to be executed.
+	// TODO(jsternberg): This stage isn't used currently, but
+	// it makes sense to readd this once we have a work queue again.
+	Queueing
+
+	// Executing indicates that the query is currently executing.
+	Executing
+
+	// Errored indicates that there was an error when attempting
+	// to execute a query within any state inside of the controller.
+	Errored
+
+	// Finished indicates that the query has been marked as Done
+	// and it is awaiting removal from the Controller or has already
+	// been removed.
+	Finished
+
+	// Canceled indicates that the query was signaled to be
+	// canceled. A canceled query must still be released with Done.
+	Canceled
+)
+
+func (s State) String() string {
+	switch s {
+	case Created:
+		return "created"
+	case Compiling:
+		return "compiling"
+	case Queueing:
+		return "queueing"
+	case Executing:
+		return "executing"
+	case Errored:
+		return "errored"
+	case Finished:
+		return "finished"
+	case Canceled:
+		return "canceled"
+	default:
+		return "unknown"
+	}
+}
+
+func isFinishedState(state State) bool {
+	switch state {
+	case Canceled, Errored, Finished:
+		return true
+	default:
+		return false
+	}
+}
+
+// span is a simple wrapper around opentracing.Span in order to
+// get access to the duration of the span for metrics reporting.
+type span struct {
+	s        opentracing.Span
+	start    time.Time
+	Duration time.Duration
+	hist     prometheus.Observer
+	gauge    prometheus.Gauge
+}
+
+func StartSpanFromContext(ctx context.Context, operationName string, hist prometheus.Observer, gauge prometheus.Gauge) (*span, context.Context) {
+	start := time.Now()
+	s, sctx := opentracing.StartSpanFromContext(ctx, operationName, opentracing.StartTime(start))
+	gauge.Inc()
+	return &span{
+		s:     s,
+		start: start,
+		hist:  hist,
+		gauge: gauge,
+	}, sctx
+}
+
+func (s *span) Finish() {
+	finish := time.Now()
+	s.Duration = finish.Sub(s.start)
+	s.s.FinishWithOptions(opentracing.FinishOptions{
+		FinishTime: finish,
+	})
+	s.hist.Observe(s.Duration.Seconds())
+	s.gauge.Dec()
 }

--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -1,0 +1,841 @@
+package control_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/influxdata/flux"
+	_ "github.com/influxdata/flux/builtin"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/mock"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/plan/plantest"
+	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/influxdb/query"
+	"github.com/influxdata/influxdb/query/control"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"go.uber.org/zap/zaptest"
+)
+
+func init() {
+	execute.RegisterSource(executetest.AllocatingFromTestKind, executetest.CreateAllocatingFromSource)
+}
+
+var (
+	mockCompiler = &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					q.ResultsCh <- &executetest.Result{}
+				},
+			}, nil
+		},
+	}
+	config = control.Config{
+		ConcurrencyQuota:         1,
+		MemoryBytesQuotaPerQuery: 1024,
+		QueueSize:                1,
+	}
+)
+
+func setupPromRegistry(c *control.Controller) *prometheus.Registry {
+	reg := prometheus.NewRegistry()
+	for _, col := range c.PrometheusCollectors() {
+		err := reg.Register(col)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return reg
+}
+
+func validateRequestTotals(t testing.TB, reg *prometheus.Registry, success, compile, runtime, queue int) {
+	t.Helper()
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	validate := func(name string, want int) {
+		m := FindMetric(
+			metrics,
+			"query_control_requests_total",
+			map[string]string{
+				"result": name,
+				"org":    "",
+			},
+		)
+		var got int
+		if m != nil {
+			got = int(*m.Counter.Value)
+		}
+		if got != want {
+			t.Errorf("unexpected %s total: got %d want: %d", name, got, want)
+		}
+	}
+	validate("success", success)
+	validate("compile_error", compile)
+	validate("runtime_error", runtime)
+	validate("queue_error", queue)
+}
+
+func TestController_QuerySuccess(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	reg := setupPromRegistry(ctrl)
+
+	q, err := ctrl.Query(context.Background(), makeRequest(mockCompiler))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	for range q.Results() {
+		// discard the results as we do not care.
+	}
+	q.Done()
+
+	if err := q.Err(); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	stats := q.Statistics()
+	if stats.CompileDuration == 0 {
+		t.Error("expected compile duration to be above zero")
+	}
+	if stats.QueueDuration == 0 {
+		t.Error("expected queue duration to be above zero")
+	}
+	if stats.ExecuteDuration == 0 {
+		t.Error("expected execute duration to be above zero")
+	}
+	if stats.TotalDuration == 0 {
+		t.Error("expected total duration to be above zero")
+	}
+	validateRequestTotals(t, reg, 1, 0, 0, 0)
+}
+
+func TestController_QueryCompileError(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	reg := setupPromRegistry(ctrl)
+
+	q, err := ctrl.Query(context.Background(), makeRequest(&mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return nil, errors.New("compile error")
+		},
+	}))
+	if err == nil {
+		t.Error("expected compiler error")
+	}
+
+	if q != nil {
+		t.Errorf("unexpected query value: %v", q)
+		defer q.Done()
+	}
+
+	validateRequestTotals(t, reg, 0, 1, 0, 0)
+}
+
+func TestController_QueryRuntimeError(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	reg := setupPromRegistry(ctrl)
+
+	q, err := ctrl.Query(context.Background(), makeRequest(&mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					q.SetErr(errors.New("runtime error"))
+				},
+			}, nil
+		},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	for range q.Results() {
+		// discard the results as we do not care.
+	}
+	q.Done()
+
+	if q.Err() == nil {
+		t.Error("expected runtime error")
+	}
+
+	stats := q.Statistics()
+	if stats.CompileDuration == 0 {
+		t.Error("expected compile duration to be above zero")
+	}
+	if stats.QueueDuration == 0 {
+		t.Error("expected queue duration to be above zero")
+	}
+	if stats.ExecuteDuration == 0 {
+		t.Error("expected execute duration to be above zero")
+	}
+	if stats.TotalDuration == 0 {
+		t.Error("expected total duration to be above zero")
+	}
+	validateRequestTotals(t, reg, 0, 0, 1, 0)
+}
+
+func TestController_QueryQueueError(t *testing.T) {
+	t.Skip("This test exposed several race conditions, its not clear if the races are specific to the test case")
+
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	reg := setupPromRegistry(ctrl)
+
+	// This channel blocks program execution until we are done
+	// with running the test.
+	done := make(chan struct{})
+	defer close(done)
+
+	// Insert three queries, two that block forever and a last that does not.
+	// The third should error to be enqueued.
+	for i := 0; i < 2; i++ {
+		q, err := ctrl.Query(context.Background(), makeRequest(&mock.Compiler{
+			CompileFn: func(ctx context.Context) (flux.Program, error) {
+				return &mock.Program{
+					ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+						// Block until test is finished
+						<-done
+					},
+				}, nil
+			},
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer q.Done()
+	}
+
+	// Third "normal" query
+	q, err := ctrl.Query(context.Background(), makeRequest(mockCompiler))
+	if err == nil {
+		t.Error("expected queue error")
+	}
+
+	if q != nil {
+		t.Errorf("unexpected query value: %v", q)
+		defer q.Done()
+	}
+
+	validateRequestTotals(t, reg, 0, 0, 0, 1)
+}
+
+// TODO(nathanielc): Use promtest in influxdb/kit
+
+// FindMetric iterates through mfs to find the first metric family matching name.
+// If a metric family matches, then the metrics inside the family are searched,
+// and the first metric whose labels match the given labels are returned.
+// If no matches are found, FindMetric returns nil.
+//
+// FindMetric assumes that the labels on the metric family are well formed,
+// i.e. there are no duplicate label names, and the label values are not empty strings.
+func FindMetric(mfs []*dto.MetricFamily, name string, labels map[string]string) *dto.Metric {
+	_, m := findMetric(mfs, name, labels)
+	return m
+}
+
+// findMetric is a helper that returns the matching family and the matching metric.
+// The exported FindMetric function specifically only finds the metric, not the family,
+// but for test it is more helpful to identify whether the family was matched.
+func findMetric(mfs []*dto.MetricFamily, name string, labels map[string]string) (*dto.MetricFamily, *dto.Metric) {
+	var fam *dto.MetricFamily
+
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			fam = mf
+			break
+		}
+	}
+
+	if fam == nil {
+		// No family matching the name.
+		return nil, nil
+	}
+
+	for _, m := range fam.Metric {
+		if len(m.Label) != len(labels) {
+			continue
+		}
+
+		match := true
+		for _, l := range m.Label {
+			if labels[l.GetName()] != l.GetValue() {
+				match = false
+				break
+			}
+		}
+
+		if !match {
+			continue
+		}
+
+		// All labels matched.
+		return fam, m
+	}
+
+	// Didn't find a metric whose labels all matched.
+	return fam, nil
+}
+
+func TestController_AfterShutdown(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shutdown(t, ctrl)
+
+	// No point in continuing. The shutdown didn't work
+	// even though there are no queries.
+	if t.Failed() {
+		return
+	}
+
+	if _, err := ctrl.Query(context.Background(), makeRequest(mockCompiler)); err == nil {
+		t.Error("expected error")
+	} else if got, want := err.Error(), "<invalid> query controller shutdown"; got != want {
+		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+	}
+}
+
+func TestController_CompileError(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return nil, errors.New("expected error")
+		},
+	}
+	if _, err := ctrl.Query(context.Background(), makeRequest(compiler)); err == nil {
+		t.Error("expected error")
+	} else if got, want := err.Error(), "<invalid> compilation failed: expected error"; got != want {
+		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+	}
+}
+
+func TestController_ExecuteError(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				StartFn: func(ctx context.Context, alloc *memory.Allocator) (*mock.Query, error) {
+					return nil, errors.New("expected error")
+				},
+			}, nil
+		},
+	}
+
+	q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// There should be no results.
+	numResults := 0
+	for range q.Results() {
+		numResults++
+	}
+
+	if numResults != 0 {
+		t.Errorf("no results should have been returned, but %d were", numResults)
+	}
+	q.Done()
+
+	if err := q.Err(); err == nil {
+		t.Error("expected error")
+	} else if got, want := err.Error(), "expected error"; got != want {
+		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+	}
+}
+
+func TestController_LimitExceededError(t *testing.T) {
+	const memoryBytesQuotaPerQuery = 64
+	config := config
+	config.MemoryBytesQuotaPerQuery = memoryBytesQuotaPerQuery
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			// Return a program that will allocate one more byte than is allowed.
+			pts := plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("allocating-from-test", &executetest.AllocatingFromProcedureSpec{
+						ByteCount: memoryBytesQuotaPerQuery + 1,
+					}),
+					plan.CreatePhysicalNode("yield", &universe.YieldProcedureSpec{Name: "_result"}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+				Resources: flux.ResourceManagement{
+					ConcurrencyQuota: 1,
+				},
+			}
+
+			ps := plantest.CreatePlanSpec(&pts)
+			prog := &lang.Program{
+				Logger:   zaptest.NewLogger(t),
+				PlanSpec: ps,
+			}
+
+			return prog, nil
+		},
+	}
+
+	q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ri := flux.NewResultIteratorFromQuery(q)
+	defer ri.Release()
+	for ri.More() {
+		res := ri.Next()
+		err = res.Tables().Do(func(t flux.Table) error {
+			return nil
+		})
+		if err != nil {
+			break
+		}
+	}
+	ri.Release()
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	if !strings.Contains(err.Error(), "memory") {
+		t.Fatalf("expected an error about memory limit exceeded, got %v", err)
+	}
+
+	stats := ri.Statistics()
+	if len(stats.RuntimeErrors) != 1 {
+		t.Fatal("expected one runtime error reported in stats")
+	}
+
+	if !strings.Contains(stats.RuntimeErrors[0], "memory") {
+		t.Fatalf("expected an error about memory limit exceeded, got %v", err)
+	}
+}
+
+func TestController_ShutdownWithRunningQuery(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	executing := make(chan struct{})
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					close(executing)
+					<-ctx.Done()
+
+					// This should still be read even if we have been canceled.
+					q.ResultsCh <- &executetest.Result{}
+				},
+			}, nil
+		},
+	}
+
+	q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range q.Results() {
+			// discard the results
+		}
+		q.Done()
+	}()
+
+	// Wait until execution has started.
+	<-executing
+
+	// Shutdown should succeed and not timeout. The above blocked
+	// query should be canceled and then shutdown should return.
+	shutdown(t, ctrl)
+	wg.Wait()
+}
+
+func TestController_ShutdownWithTimeout(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	// This channel blocks program execution until we are done
+	// with running the test.
+	done := make(chan struct{})
+	defer close(done)
+
+	executing := make(chan struct{})
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					// This should just block until the end of the test
+					// when we perform cleanup.
+					close(executing)
+					<-done
+				},
+			}, nil
+		},
+	}
+
+	q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	go func() {
+		for range q.Results() {
+			// discard the results
+		}
+		q.Done()
+	}()
+
+	// Wait until execution has started.
+	<-executing
+
+	// The shutdown should not succeed.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	if err := ctrl.Shutdown(ctx); err == nil {
+		t.Error("expected error")
+	} else if got, want := err.Error(), context.DeadlineExceeded.Error(); got != want {
+		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
+	}
+	cancel()
+}
+
+func TestController_PerQueryMemoryLimit(t *testing.T) {
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					// This is emulating the behavior of exceeding the memory limit at runtime
+					if err := alloc.Allocate(int(config.MemoryBytesQuotaPerQuery + 1)); err != nil {
+						q.SetErr(err)
+					}
+				},
+			}, nil
+		},
+	}
+
+	q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for range q.Results() {
+		// discard the results
+	}
+	q.Done()
+
+	if q.Err() == nil {
+		t.Fatal("expected error about memory limit exceeded")
+	}
+}
+
+func TestController_ConcurrencyQuota(t *testing.T) {
+	const (
+		numQueries       = 3
+		concurrencyQuota = 2
+	)
+
+	config := config
+	config.ConcurrencyQuota = concurrencyQuota
+	config.QueueSize = numQueries
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	executing := make(chan struct{}, numQueries)
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					select {
+					case <-q.Canceled:
+					default:
+						executing <- struct{}{}
+						<-q.Canceled
+					}
+				},
+			}, nil
+		},
+	}
+
+	for i := 0; i < numQueries; i++ {
+		q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+		if err != nil {
+			t.Fatal(err)
+		}
+		go func() {
+			for range q.Results() {
+				// discard the results
+			}
+			q.Done()
+		}()
+	}
+
+	// Give 2 queries a chance to begin executing.  The remaining third query should stay queued.
+	time.Sleep(250 * time.Millisecond)
+
+	if err := ctrl.Shutdown(context.Background()); err != nil {
+		t.Error(err)
+	}
+
+	// There is a chance that the remaining query managed to get executed after the executing queries
+	// were canceled.  As a result, this test is somewhat flaky.
+
+	close(executing)
+
+	var count int
+	for range executing {
+		count++
+	}
+
+	if count != concurrencyQuota {
+		t.Fatalf("expected exactly %v queries to execute, but got: %v", concurrencyQuota, count)
+	}
+}
+
+func TestController_QueueSize(t *testing.T) {
+	const (
+		concurrencyQuota = 2
+		queueSize        = 3
+	)
+
+	config := config
+	config.ConcurrencyQuota = concurrencyQuota
+	config.QueueSize = queueSize
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	// This channel blocks program execution until we are done
+	// with running the test.
+	done := make(chan struct{})
+	defer close(done)
+
+	executing := make(chan struct{}, config.ConcurrencyQuota)
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					executing <- struct{}{}
+					// Block until test is finished
+					<-done
+				},
+			}, nil
+		},
+	}
+
+	// Start as many queries as can be running at the same time
+	for i := 0; i < concurrencyQuota; i++ {
+		q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+		if err != nil {
+			t.Fatal(err)
+		}
+		go func() {
+			for range q.Results() {
+				// discard the results
+			}
+			q.Done()
+		}()
+
+		// Wait until it's executing
+		<-executing
+	}
+
+	// Now fill up the queue
+	for i := 0; i < queueSize; i++ {
+		q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+		if err != nil {
+			t.Fatal(err)
+		}
+		go func() {
+			for range q.Results() {
+				// discard the results
+			}
+			q.Done()
+		}()
+	}
+
+	_, err = ctrl.Query(context.Background(), makeRequest(compiler))
+	if err == nil {
+		t.Fatal("expected an error about queue length exceeded")
+	}
+}
+
+// Test that rapidly starting and canceling the query and then calling done will correctly
+// cancel the query and not result in a race condition.
+func TestController_CancelDone(t *testing.T) {
+	config := config
+	config.ConcurrencyQuota = 10
+	config.QueueSize = 200
+
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					// Ensure the query takes a little bit of time so the cancel actually cancels something.
+					t := time.NewTimer(time.Second)
+					defer t.Stop()
+
+					select {
+					case <-t.C:
+					case <-ctx.Done():
+					}
+				},
+			}, nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+				return
+			}
+			q.Cancel()
+			q.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+// Test that rapidly starts and calls done on queries without reading the result.
+func TestController_DoneWithoutRead(t *testing.T) {
+	config := config
+	config.ConcurrencyQuota = 10
+	config.QueueSize = 200
+
+	ctrl, err := control.New(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shutdown(t, ctrl)
+
+	compiler := &mock.Compiler{
+		CompileFn: func(ctx context.Context) (flux.Program, error) {
+			return &mock.Program{
+				ExecuteFn: func(ctx context.Context, q *mock.Query, alloc *memory.Allocator) {
+					// Ensure the query takes a little bit of time so the cancel actually cancels something.
+					t := time.NewTimer(time.Second)
+					defer t.Stop()
+
+					select {
+					case <-t.C:
+						q.ResultsCh <- &executetest.Result{
+							Nm:   "_result",
+							Tbls: []*executetest.Table{},
+						}
+					case <-ctx.Done():
+					}
+				},
+			}, nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			q, err := ctrl.Query(context.Background(), makeRequest(compiler))
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+				return
+			}
+			// If we call done without reading anything it should work just fine.
+			q.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func shutdown(t *testing.T, ctrl *control.Controller) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := ctrl.Shutdown(ctx); err != nil {
+		t.Error(err)
+	}
+}
+
+func makeRequest(c flux.Compiler) *query.Request {
+	return &query.Request{
+		Compiler: c,
+	}
+}

--- a/query/control/metrics.go
+++ b/query/control/metrics.go
@@ -1,0 +1,129 @@
+package control
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// controllerMetrics holds metrics related to the query controller.
+type controllerMetrics struct {
+	requests  *prometheus.CounterVec
+	functions *prometheus.CounterVec
+
+	all       *prometheus.GaugeVec
+	compiling *prometheus.GaugeVec
+	queueing  *prometheus.GaugeVec
+	executing *prometheus.GaugeVec
+
+	allDur       *prometheus.HistogramVec
+	compilingDur *prometheus.HistogramVec
+	queueingDur  *prometheus.HistogramVec
+	executingDur *prometheus.HistogramVec
+}
+
+type requestsLabel string
+
+const (
+	labelSuccess      = requestsLabel("success")
+	labelCompileError = requestsLabel("compile_error")
+	labelRuntimeError = requestsLabel("runtime_error")
+	labelQueueError   = requestsLabel("queue_error")
+)
+
+func newControllerMetrics(labels []string) *controllerMetrics {
+	const (
+		namespace = "query"
+		subsystem = "control"
+	)
+
+	return &controllerMetrics{
+		requests: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "requests_total",
+			Help:      "Count of the query requests",
+		}, append(labels, "result")),
+
+		functions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "functions_total",
+			Help:      "Count of functions in queries",
+		}, append(labels, "function")),
+
+		all: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "all_active",
+			Help:      "Number of queries in all states",
+		}, labels),
+
+		compiling: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "compiling_active",
+			Help:      "Number of queries actively compiling",
+		}, append(labels, "compiler_type")),
+
+		queueing: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "queueing_active",
+			Help:      "Number of queries actively queueing",
+		}, labels),
+
+		executing: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "executing_active",
+			Help:      "Number of queries actively executing",
+		}, labels),
+
+		allDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "all_duration_seconds",
+			Help:      "Histogram of total times spent in all query states",
+			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+		}, labels),
+
+		compilingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "compiling_duration_seconds",
+			Help:      "Histogram of times spent compiling queries",
+			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+		}, append(labels, "compiler_type")),
+
+		queueingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "queueing_duration_seconds",
+			Help:      "Histogram of times spent queueing queries",
+			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+		}, labels),
+
+		executingDur: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "executing_duration_seconds",
+			Help:      "Histogram of times spent executing queries",
+			Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+		}, labels),
+	}
+}
+
+// PrometheusCollectors satisifies the prom.PrometheusCollector interface.
+func (cm *controllerMetrics) PrometheusCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		cm.requests,
+		cm.functions,
+
+		cm.all,
+		cm.compiling,
+		cm.queueing,
+		cm.executing,
+
+		cm.allDur,
+		cm.compilingDur,
+		cm.queueingDur,
+		cm.executingDur,
+	}
+}

--- a/storage/readservice/service.go
+++ b/storage/readservice/service.go
@@ -1,10 +1,9 @@
 package readservice
 
 import (
-	"github.com/influxdata/flux/control"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/query"
-	pcontrol "github.com/influxdata/influxdb/query/control"
+	"github.com/influxdata/influxdb/query/control"
 	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/reads"
@@ -12,7 +11,7 @@ import (
 
 // NewProxyQueryService returns a proxy query service based on the given queryController
 // suitable for the storage read service.
-func NewProxyQueryService(queryController *pcontrol.Controller) query.ProxyQueryService {
+func NewProxyQueryService(queryController *control.Controller) query.ProxyQueryService {
 	return query.ProxyQueryServiceAsyncBridge{
 		AsyncQueryService: queryController,
 	}

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/influxdata/flux/control"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
@@ -14,7 +13,7 @@ import (
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/query"
 	_ "github.com/influxdata/influxdb/query/builtin"
-	pcontrol "github.com/influxdata/influxdb/query/control"
+	"github.com/influxdata/influxdb/query/control"
 	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/readservice"
 	"github.com/influxdata/influxdb/task/backend"
@@ -56,7 +55,7 @@ func TestAnalyticalStore(t *testing.T) {
 }
 
 type analyticalBackend struct {
-	queryController *pcontrol.Controller
+	queryController *control.Controller
 	rootDir         string
 	storageEngine   *storage.Engine
 }
@@ -124,7 +123,7 @@ func newAnalyticalBackend(t *testing.T, orgSvc influxdb.OrganizationService, buc
 		t.Fatal(err)
 	}
 
-	queryController, err := pcontrol.New(cc)
+	queryController, err := control.New(cc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/task/backend/logreaderwriter_test.go
+++ b/task/backend/logreaderwriter_test.go
@@ -8,12 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/flux/control"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/query"
-	pcontrol "github.com/influxdata/influxdb/query/control"
+	"github.com/influxdata/influxdb/query/control"
 	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/readservice"
 	"github.com/influxdata/influxdb/task/backend"
@@ -52,7 +51,7 @@ type fullStackAwareLogReaderWriter struct {
 	*backend.PointLogWriter
 	*backend.QueryLogReader
 
-	queryController *pcontrol.Controller
+	queryController *control.Controller
 
 	rootDir       string
 	storageEngine *storage.Engine
@@ -139,7 +138,7 @@ func newFullStackAwareLogReaderWriter(t *testing.T) *fullStackAwareLogReaderWrit
 		t.Fatal(err)
 	}
 
-	queryController, err := pcontrol.New(cc)
+	queryController, err := control.New(cc)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The controller implementation is primarily used by influxdb so it
shouldn't be part of the flux repository. This copies the code from flux
to influxdb so it can be removed from the next flux release.

Related to influxdata/flux#1251.