### PR TITLE
chore: add go directive to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/influxdata/influxdb
 
+go 1.12
+
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Jeffail/gabs v1.1.1 // indirect


### PR DESCRIPTION
As of golang/go#31960, go1.13 (or tip) will always add the go directive
to go.mod. Add it now as go 1.12 so that we don't have churn later as
people start using 1.13, before we're ready to officially switch to
building influxdb with 1.13.