### PR TITLE
fix(storage): add missing RUnlock in Engine.Close

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -315,6 +315,9 @@ func (e *Engine) runRetentionEnforcer() {
 func (e *Engine) Close() error {
 	e.mu.RLock()
 	if e.closing == nil {
+		e.mu.RUnlock()
+		// Unusual if an engine is closed more than once, so note it.
+		e.logger.Info("Close() called on already-closed engine")
 		return nil // Already closed
 	}
 


### PR DESCRIPTION
I don't see anywhere obvious that an engine would be closed twice, but
if it was, the RLock would have been held permanently, such that a Lock
could not be taken later.

Running go test ./storage/... did not trigger a double-close.
