### PR TITLE
chore(cmd): Add verifytsm to influx_inspect 2.x

### DIFF
--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -56,7 +56,7 @@ func NewCommand() *Command {
 }
 
 // Run executes the command.
-func (cmd *Command) Run(args ...string) error {
+func (cmd *Command) Run(args []string) error {
 	fs := flag.NewFlagSet("buildtsi", flag.ExitOnError)
 	dataDir := fs.String("datadir", "", "data directory")
 	walDir := fs.String("waldir", "", "WAL directory")

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -1,116 +1,25 @@
 package inspect
 
 import (
-	"errors"
-	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/influxdata/influxdb"
-	"github.com/influxdata/influxdb/internal/fs"
-	"github.com/influxdata/influxdb/tsdb/tsm1"
 	"github.com/spf13/cobra"
 )
 
 // NewCommand creates the new command.
 func NewCommand() *cobra.Command {
-	base := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "inspect",
 		Short: "Commands for inspecting on-disk database data",
 	}
-
-	reportTSMCommand := &cobra.Command{
-		Use:   "report-tsm",
-		Short: "Run TSM report",
-		Long: `
-This command will analyze TSM files within a storage engine directory, reporting 
-the cardinality within the files as well as the time range that the point data 
-covers.
-
-This command only interrogates the index within each file, and does not read any
-block data. To reduce heap requirements, by default report-tsm estimates the 
-overall cardinality in the file set by using the HLL++ algorithm. Exact 
-cardinalities can be determined by using the --exact flag.
-
-For each file, the following is output:
-
-	* The full filename;
-	* The series cardinality within the file;
-	* The number of series first encountered within the file;
-	* The min and max timestamp associated with TSM data in the file; and
-	* The time taken to load the TSM index and apply any tombstones.
-
-The summary section then outputs the total time range and series cardinality for 
-the fileset. Depending on the --detailed flag, series cardinality is segmented 
-in the following ways:
-
-	* Series cardinality for each organization;
-	* Series cardinality for each bucket;
-	* Series cardinality for each measurement;
-	* Number of field keys for each measurement; and
-	* Number of tag values for each tag key.`,
-		RunE: inspectReportTSMF,
-	}
-
-	reportTSMCommand.Flags().StringVarP(&reportTSMFlags.pattern, "pattern", "", "", "only process TSM files containing pattern")
-	reportTSMCommand.Flags().BoolVarP(&reportTSMFlags.exact, "exact", "", false, "calculate and exact cardinality count. Warning, may use significant memory...")
-	reportTSMCommand.Flags().BoolVarP(&reportTSMFlags.detailed, "detailed", "", false, "emit series cardinality segmented by measurements, tag keys and fields. Warning, may take a while.")
-
-	reportTSMCommand.Flags().StringVarP(&reportTSMFlags.orgID, "org-id", "", "", "process only data belonging to organization ID.")
-	reportTSMCommand.Flags().StringVarP(&reportTSMFlags.bucketID, "bucket-id", "", "", "process only data belonging to bucket ID. Requires org flag to be set.")
-
-	dir, err := fs.InfluxDir()
-	if err != nil {
-		panic(err)
-	}
-	dir = filepath.Join(dir, "engine/data")
-	reportTSMCommand.Flags().StringVarP(&reportTSMFlags.dataDir, "data-dir", "", dir, fmt.Sprintf("use provided data directory (defaults to %s).", dir))
-
-	base.AddCommand(reportTSMCommand)
-	return base
+	cmd.AddCommand(newReportTSMCommand())
+	cmd.AddCommand(newVerifyTSMCommand())
+	return cmd
 }
 
-// reportTSMFlags defines the `report-tsm` Command.
-var reportTSMFlags = struct {
-	pattern  string
-	exact    bool
-	detailed bool
-
-	orgID, bucketID string
-	dataDir         string
-}{}
-
-// inspectReportTSMF runs the report-tsm tool.
-func inspectReportTSMF(cmd *cobra.Command, args []string) error {
-	report := &tsm1.Report{
-		Stderr:   os.Stderr,
-		Stdout:   os.Stdout,
-		Dir:      reportTSMFlags.dataDir,
-		Pattern:  reportTSMFlags.pattern,
-		Detailed: reportTSMFlags.detailed,
-		Exact:    reportTSMFlags.exact,
+// idFromStringIfExists parses s into a string if non-blank. Otherwise return 0.
+func idFromStringIfExists(s string) (*influxdb.ID, error) {
+	if s == "" {
+		return nil, nil
 	}
-
-	if reportTSMFlags.orgID == "" && reportTSMFlags.bucketID != "" {
-		return errors.New("org-id must be set for non-empty bucket-id")
-	}
-
-	if reportTSMFlags.orgID != "" {
-		orgID, err := influxdb.IDFromString(reportTSMFlags.orgID)
-		if err != nil {
-			return err
-		}
-		report.OrgID = orgID
-	}
-
-	if reportTSMFlags.bucketID != "" {
-		bucketID, err := influxdb.IDFromString(reportTSMFlags.bucketID)
-		if err != nil {
-			return err
-		}
-		report.BucketID = bucketID
-	}
-
-	_, err := report.Run(true)
-	return err
+	return influxdb.IDFromString(s)
 }

--- a/cmd/influxd/inspect/report_tsm.go
+++ b/cmd/influxd/inspect/report_tsm.go
@@ -1,0 +1,97 @@
+package inspect
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/internal/fs"
+	"github.com/influxdata/influxdb/tsdb/tsm1"
+	"github.com/spf13/cobra"
+)
+
+func newReportTSMCommand() *cobra.Command {
+	var pattern string
+	var exact bool
+	var detailed bool
+	var orgID, bucketID string
+	var dataDir string
+
+	influxDir, err := fs.InfluxDir()
+	if err != nil {
+		panic(err)
+	}
+
+	cmd := &cobra.Command{
+		Use:   "report-tsm",
+		Short: "Run TSM report",
+		Long: `
+This command will analyze TSM files within a storage engine directory, reporting 
+the cardinality within the files as well as the time range that the point data 
+covers.
+
+This command only interrogates the index within each file, and does not read any
+block data. To reduce heap requirements, by default report-tsm estimates the 
+overall cardinality in the file set by using the HLL++ algorithm. Exact 
+cardinalities can be determined by using the --exact flag.
+
+For each file, the following is output:
+
+	* The full filename;
+	* The series cardinality within the file;
+	* The number of series first encountered within the file;
+	* The min and max timestamp associated with TSM data in the file; and
+	* The time taken to load the TSM index and apply any tombstones.
+
+The summary section then outputs the total time range and series cardinality for 
+the fileset. Depending on the --detailed flag, series cardinality is segmented 
+in the following ways:
+
+	* Series cardinality for each organization;
+	* Series cardinality for each bucket;
+	* Series cardinality for each measurement;
+	* Number of field keys for each measurement; and
+	* Number of tag values for each tag key.`,
+	}
+
+	cmd.Flags().StringVarP(&pattern, "pattern", "", "", "only process TSM files containing pattern")
+	cmd.Flags().BoolVarP(&exact, "exact", "", false, "calculate and exact cardinality count. Warning, may use significant memory...")
+	cmd.Flags().BoolVarP(&detailed, "detailed", "", false, "emit series cardinality segmented by measurements, tag keys and fields. Warning, may take a while.")
+	cmd.Flags().StringVarP(&orgID, "org-id", "", "", "process only data belonging to organization ID.")
+	cmd.Flags().StringVarP(&bucketID, "bucket-id", "", "", "process only data belonging to bucket ID. Requires org flag to be set.")
+
+	dir := filepath.Join(influxDir, "engine/data")
+	cmd.Flags().StringVarP(&dataDir, "data-dir", "", dir, fmt.Sprintf("use provided data directory (defaults to %s).", dir))
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) (err error) {
+		report := &tsm1.Report{
+			Stderr:   os.Stderr,
+			Stdout:   os.Stdout,
+			Dir:      dataDir,
+			Pattern:  pattern,
+			Detailed: detailed,
+			Exact:    exact,
+		}
+
+		if orgID == "" && bucketID != "" {
+			return errors.New("org-id must be set for non-empty bucket-id")
+		}
+		if orgID != "" {
+			if report.OrgID, err = influxdb.IDFromString(orgID); err != nil {
+				return err
+			}
+		}
+		if bucketID != "" {
+			if report.BucketID, err = influxdb.IDFromString(bucketID); err != nil {
+				return err
+			}
+		}
+
+		_, err = report.Run(true)
+		return err
+	}
+
+	return cmd
+}

--- a/cmd/influxd/inspect/verify_tsm.go
+++ b/cmd/influxd/inspect/verify_tsm.go
@@ -1,0 +1,63 @@
+package inspect
+
+import (
+	"errors"
+	"path/filepath"
+
+	"github.com/influxdata/influxdb/internal/fs"
+	"github.com/influxdata/influxdb/tsdb/tsm1"
+	"github.com/spf13/cobra"
+)
+
+func newVerifyTSMCommand() *cobra.Command {
+	var pattern string
+	var orgID, bucketID string
+
+	influxDir, err := fs.InfluxDir()
+	if err != nil {
+		panic(err)
+	}
+
+	cmd := &cobra.Command{
+		Use:   "verify-tsm",
+		Short: "Verify TSM file consistency",
+		Long: `
+This command will verify checksums of every block in the specified TSM files.
+If a directory is specified then it is recursively searched for any .tsm files.
+The data directory will be searched if no paths are specified.
+
+For each block, an error will be reported if the block cannot be read or the
+checksum does not match the computed checksum for the block. If a file is
+successfully read without any errors then it will list the file as "healthy".`,
+	}
+
+	cmd.Flags().StringVarP(&pattern, "pattern", "", `\.tsm$`, "only process TSM files containing pattern")
+	cmd.Flags().StringVarP(&orgID, "org-id", "", "", "process only data belonging to organization ID.")
+	cmd.Flags().StringVarP(&bucketID, "bucket-id", "", "", "process only data belonging to bucket ID. Requires org flag to be set.")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) (err error) {
+		if orgID == "" && bucketID != "" {
+			return errors.New("org-id must be set for non-empty bucket-id")
+		}
+
+		// Default to data directory if no paths specified.
+		paths := args
+		if len(paths) == 0 {
+			paths = []string{filepath.Join(influxDir, "engine/data")}
+		}
+
+		report := tsm1.NewVerificationReport()
+		if report.Paths, err = fs.ExpandFiles(args, pattern); err != nil {
+			return err
+		} else if report.OrgID, err = idFromStringIfExists(orgID); err != nil {
+			return err
+		} else if report.BucketID, err = idFromStringIfExists(bucketID); err != nil {
+			return err
+		}
+
+		_, err = report.Run()
+		return err
+	}
+
+	return cmd
+}

--- a/internal/fs/influx_dir.go
+++ b/internal/fs/influx_dir.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -56,4 +57,26 @@ func BoltFile() (string, error) {
 	}
 
 	return file, nil
+}
+
+// ExpandFiles expands any directories listed in paths and filters out any
+// paths which do not match the regular expression pattern.
+func ExpandFiles(paths []string, pattern string) ([]string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	var other []string
+	for _, path := range paths {
+		if err := filepath.Walk(path, func(path string, fi os.FileInfo, err error) error {
+			if !fi.IsDir() && re.MatchString(path) {
+				other = append(other, path)
+			}
+			return err
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return other, nil
 }

--- a/tsdb/explode.go
+++ b/tsdb/explode.go
@@ -14,6 +14,13 @@ func DecodeName(name [16]byte) (org, bucket platform.ID) {
 	return
 }
 
+// DecodeNameSlice converts tsdb internal serialization back to organization and bucket IDs.
+func DecodeNameSlice(name []byte) (org, bucket platform.ID) {
+	org = platform.ID(binary.BigEndian.Uint64(name[0:8]))
+	bucket = platform.ID(binary.BigEndian.Uint64(name[8:16]))
+	return
+}
+
 // EncodeName converts org/bucket pairs to the tsdb internal serialization
 func EncodeName(org, bucket platform.ID) [16]byte {
 	var nameBytes [16]byte

--- a/tsdb/tsm1/verification_report.go
+++ b/tsdb/tsm1/verification_report.go
@@ -1,0 +1,123 @@
+package tsm1
+
+import (
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"time"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/tsdb"
+)
+
+// VerificationReport represents a report for verifying TSM1 file consistency.
+type VerificationReport struct {
+	Stderr io.Writer
+	Stdout io.Writer
+
+	Paths    []string     // Files to verify.
+	OrgID    *influxdb.ID // Optional organization filter.
+	BucketID *influxdb.ID // Optional bucket filter.
+}
+
+// NewVerificationReport returns a new instance of VerificationReport.
+func NewVerificationReport() *VerificationReport {
+	return &VerificationReport{
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}
+
+// Run executes the report.
+func (r *VerificationReport) Run() (*VerificationReportResult, error) {
+	var result VerificationReportResult
+	start := time.Now()
+
+	// Process each file.
+	for _, path := range r.Paths {
+		file, err := r.VerifyFile(path)
+		if err != nil {
+			return nil, err
+		}
+
+		result.TotalBlockN += file.TotalBlockN
+		result.CorruptBlockN += file.CorruptBlockN
+		result.Files = append(result.Files, file)
+	}
+
+	// Calculate elapsed time.
+	result.Elapsed = time.Since(start)
+
+	return &result, nil
+}
+
+// VerifyFile reads and verifies a single TSM file.
+func (r *VerificationReport) VerifyFile(filename string) (*VerificationReportFileResult, error) {
+	var result VerificationReportFileResult
+	result.Name = filename
+
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	rd, err := NewTSMReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer rd.Close()
+
+	// Iterate over every block and verify that it's readable and the checksum matches.
+	for itr, n := rd.BlockIterator(), 0; itr.Next(); n++ {
+		key, _, _, _, checksum, buf, err := itr.Read()
+
+		// Filter by org/bucket ID, if specified.
+		if key != nil {
+			if orgID, bucketID := tsdb.DecodeNameSlice(key[:16]); r.OrgID != nil && *r.OrgID != orgID {
+				continue
+			} else if r.BucketID != nil && *r.BucketID != bucketID {
+				continue
+			}
+		}
+
+		if err != nil {
+			result.CorruptBlockN++
+			fmt.Fprintf(r.Stdout, "%s: could not get checksum for key 0x%x block %d due to error: %q\n", filename, key, n, err)
+		} else if expected := crc32.ChecksumIEEE(buf); checksum != expected {
+			result.CorruptBlockN++
+			fmt.Fprintf(r.Stdout, "%s: got 0x%x but expected 0x%x for key 0x%x, block %d\n", filename, checksum, expected, key, n)
+		}
+
+		result.TotalBlockN++
+	}
+
+	// 	Report file as healthy if no corrupt blocks exist.
+	if result.CorruptBlockN == 0 {
+		fmt.Fprintf(r.Stdout, "%s: healthy\n", filename)
+	}
+
+	// Verify reader & file can close without error.
+	if err := rd.Close(); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// VerificationReportResult represents the results of VerificationReport.
+type VerificationReportResult struct {
+	TotalBlockN   int           // total number of blocks
+	CorruptBlockN int           // number of corrupt blocks
+	Elapsed       time.Duration // time to verify
+
+	Files []*VerificationReportFileResult // individual file results
+}
+
+// VerificationReportFileResult represents the results of a single file verification.
+type VerificationReportFileResult struct {
+	Name          string
+	TotalBlockN   int // total number of blocks
+	CorruptBlockN int // number of corrupt blocks
+}

--- a/tsdb/tsm1/verification_report_test.go
+++ b/tsdb/tsm1/verification_report_test.go
@@ -1,0 +1,102 @@
+package tsm1_test
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/influxdb/tsdb/tsm1"
+)
+
+func TestVerificationReport_VerifyFile(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		dir := MustTempDir()
+		defer os.RemoveAll(dir)
+
+		// Write TSM file.
+		if f, err := os.Create(filepath.Join(dir, "0000.tsm")); err != nil {
+			t.Fatal(err)
+		} else if w, err := tsm1.NewTSMWriter(f); err != nil {
+			t.Fatal(err)
+		} else if err := w.Write([]byte("cpu"), []tsm1.Value{tsm1.NewValue(0, 1.0)}); err != nil {
+			t.Fatal(err)
+		} else if err := w.WriteIndex(); err != nil {
+			t.Fatal(err)
+		} else if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Process single healthy file.
+		cmd := NewVerificationReport()
+		if stats, err := cmd.VerifyFile(filepath.Join(dir, "0000.tsm")); err != nil {
+			t.Fatal(err)
+		} else if got, want := stats.TotalBlockN, 1; got != want {
+			t.Fatalf("TotalBlockN=%d, want %d", got, want)
+		} else if got, want := stats.CorruptBlockN, 0; got != want {
+			t.Fatalf("CorruptBlockN=%d, want %d", got, want)
+		} else if stdout := cmd.Stdout.String(); !strings.Contains(stdout, "0000.tsm: healthy") {
+			t.Fatal("expected health report")
+		}
+	})
+
+	t.Run("ErrChecksumMismatch", func(t *testing.T) {
+		dir := MustTempDir()
+		defer os.RemoveAll(dir)
+
+		// Generate TSM file data.
+		var buf bytes.Buffer
+		if w, err := tsm1.NewTSMWriter(&buf); err != nil {
+			t.Fatal(err)
+		} else if err := w.Write([]byte("cpu"), []tsm1.Value{tsm1.NewValue(0, 1.0)}); err != nil {
+			t.Fatal(err)
+		} else if err := w.WriteIndex(); err != nil {
+			t.Fatal(err)
+		} else if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Corrupt single non-checksum byte and write to disk.
+		b := buf.Bytes()
+		b[10] = 200
+		if err := ioutil.WriteFile(filepath.Join(dir, "0000.tsm"), buf.Bytes(), 0666); err != nil {
+			t.Fatal(err)
+		}
+
+		// Process single healthy file.
+		cmd := NewVerificationReport()
+		if stats, err := cmd.VerifyFile(filepath.Join(dir, "0000.tsm")); err != nil {
+			t.Fatal(err)
+		} else if got, want := stats.TotalBlockN, 1; got != want {
+			t.Fatalf("TotalBlockN=%d, want %d", got, want)
+		} else if got, want := stats.CorruptBlockN, 1; got != want {
+			t.Fatalf("CorruptBlockN=%d, want %d", got, want)
+		} else if stdout := cmd.Stdout.String(); !strings.Contains(stdout, "0000.tsm: got 0xe3f3ee14 but expected 0x1b277449 for key 0x637075, block 0") {
+			t.Fatal("expected corruption report")
+		}
+	})
+}
+
+// VerificationReport represents a test wrapper for tsm1.VerificationReport.
+type VerificationReport struct {
+	*tsm1.VerificationReport
+
+	Stdout bytes.Buffer
+	Stderr bytes.Buffer
+}
+
+// NewVerificationReport returns a new instance of VerificationReport.
+func NewVerificationReport() *VerificationReport {
+	var cmd VerificationReport
+	cmd.VerificationReport = tsm1.NewVerificationReport()
+	cmd.VerificationReport.Stdout = &cmd.Stdout
+	cmd.VerificationReport.Stderr = &cmd.Stderr
+	if testing.Verbose() {
+		cmd.VerificationReport.Stdout = io.MultiWriter(cmd.VerificationReport.Stdout, os.Stderr)
+		cmd.VerificationReport.Stderr = io.MultiWriter(cmd.VerificationReport.Stderr, os.Stderr)
+	}
+	return &cmd
+}


### PR DESCRIPTION
Adds support for the `verify-tsm` command in the 2.x version of
`influxd inspect`. Removes the UTF-8 validation as all 2.x keys
must be UTF-8. Also changes the CLI interface to accept a list of
directories and filenames instead of the previously rigid format.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
