### PR TITLE
fix(query/control): queue size test was flaky

### DIFF
--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -675,7 +675,7 @@ func TestController_QueueSize(t *testing.T) {
 	done := make(chan struct{})
 	defer close(done)
 
-	executing := make(chan struct{}, config.ConcurrencyQuota)
+	executing := make(chan struct{}, concurrencyQuota+queueSize)
 	compiler := &mock.Compiler{
 		CompileFn: func(ctx context.Context) (flux.Program, error) {
 			return &mock.Program{


### PR DESCRIPTION
In the QueueSize test, it was possible that after the `done` channel was
closed, one of the queries from the queue would begin executing. If all
three began executing before the shutdown was done, the third would
block on attempting to send a value to the `executing` channel and it
would never finish so the controller would report that shutdown failed.

This increases the queue size to a combination of the concurrency quota
and the queue size so all of the started queries will never block when
sending a signal to the executing channel.