### PR TITLE
Correctly check if columnKeys include xColumn in heatmap

### DIFF
--- a/ui/src/shared/components/HeatmapContainer.tsx
+++ b/ui/src/shared/components/HeatmapContainer.tsx
@@ -59,8 +59,8 @@ const HeatmapContainer: FunctionComponent<Props> = ({
   const isValidView =
     xColumn &&
     yColumn &&
-    xColumn in table.columnKeys &&
-    yColumn in table.columnKeys
+    columnKeys.includes(yColumn) &&
+    columnKeys.includes(xColumn)
 
   if (!isValidView) {
     return <EmptyGraphMessage message={INVALID_DATA_COPY} />


### PR DESCRIPTION
heatmaps were not displaying properly because the isValid function was buggy.