### PR TITLE
Fix writing millisecond timestamps through OpenTSDB telnet protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v1.7.7 [unreleased]
 -	[#13837](https://github.com/influxdata/influxdb/pull/13837): Fix open/close race in SeriesFile.
 -	[#13860](https://github.com/influxdata/influxdb/pull/13860): Sync series segment after truncate.
 -	[#13854](https://github.com/influxdata/influxdb/pull/13854): Fix the ordering for selectors within a subquery with different outer tags.
+-	[#14063](https://github.com/influxdata/influxdb/pull/14063): Fix writing millisecond timestamps through OpenTSDB telnet protocol
 
 v1.7.6 [2019-04-16]
 -------------------

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -403,7 +403,7 @@ func (s *Service) handleTelnetConn(conn net.Conn) {
 		case 10:
 			t = time.Unix(ts, 0)
 		case 13:
-			t = time.Unix(ts/1000, (ts%1000)*1000)
+			t = time.Unix(ts/1000, (ts%1000)*1000000)
 		default:
 			atomic.AddInt64(&s.stats.TelnetBadTime, 1)
 			if s.LogPointErrors {


### PR DESCRIPTION
When points are written through OpenTSDB telnet interface with millisecond precision, it leads to invalid timestamps.
Commands to reproduce:
```
$ echo 'put test_measurement 1559746555444 1234567 some=tag' | netcat localhost 4242
$ influx -database opentsdb -execute 'select * from test_measurement'
name: test_measurement
time                some value
----                ---- -----
1559746555000444000 tag  1234567
```
Note the three zeros between 555 and 444, which were not part of original timestamp.

This PR fixes the issue.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
