### PR TITLE
fix(storage/reads): ensure that the column reader gets its length set

### DIFF
--- a/storage/reads/table.go
+++ b/storage/reads/table.go
@@ -70,6 +70,8 @@ func (t *table) isCancelled() bool {
 // is not used anymore, then it may be reused.
 func (t *table) getBuffer(l int) *colReader {
 	if t.colBufs != nil && atomic.LoadInt64(&t.colBufs.refCount) == 0 {
+		t.colBufs.refCount = 1
+		t.colBufs.l = l
 		return t.colBufs
 	}
 


### PR DESCRIPTION
When a buffered column reader was used, the length was not reset to
whatever the requested length was for the buffer so it was possible for
the length to be longer than the actual columns.