### PR TITLE
feat(http):  add scraper interval and timeout

### DIFF
--- a/http/scraper_service.go
+++ b/http/scraper_service.go
@@ -302,6 +302,15 @@ func decodeScraperTargetAddRequest(ctx context.Context, r *http.Request) (*influ
 	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
 		return nil, err
 	}
+
+	if req.Interval.IsZero() {
+		req.Interval = influxdb.DefaultScraperInterval
+	}
+
+	if req.Timeout.IsZero() {
+		req.Timeout = influxdb.DefaultScraperTimeout
+	}
+
 	return req, nil
 }
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7219,6 +7219,16 @@ components:
         bucketID:
           type: string
           description: id of the bucket to be written
+        interval:
+          type: string
+          description: interval duration of the scraper target
+          example: 10s
+          default: 10s
+        timeout:
+          type: string
+          description: timeout for scraper requests
+          example: 30s
+          default: 30s
     ScraperTargetResponse:
       type: object
       allOf:

--- a/scraper.go
+++ b/scraper.go
@@ -2,6 +2,7 @@ package influxdb
 
 import (
 	"context"
+	"github.com/influxdata/influxdb/task/options"
 )
 
 // ErrScraperTargetNotFound is the error msg for a missing scraper target.
@@ -16,14 +17,21 @@ const (
 	OpUpdateTarget  = "UpdateTarget"
 )
 
+var (
+	DefaultScraperInterval = *options.MustParseDuration("10s")
+	DefaultScraperTimeout  = *options.MustParseDuration("30s")
+)
+
 // ScraperTarget is a target to scrape
 type ScraperTarget struct {
-	ID       ID          `json:"id,omitempty"`
-	Name     string      `json:"name"`
-	Type     ScraperType `json:"type"`
-	URL      string      `json:"url"`
-	OrgID    ID          `json:"orgID,omitempty"`
-	BucketID ID          `json:"bucketID,omitempty"`
+	ID       ID               `json:"id,omitempty"`
+	Name     string           `json:"name"`
+	Type     ScraperType      `json:"type"`
+	URL      string           `json:"url"`
+	OrgID    ID               `json:"orgID,omitempty"`
+	BucketID ID               `json:"bucketID,omitempty"`
+	Interval options.Duration `json:"interval,omitempty"`
+	Timeout  options.Duration `json:"timeout,omitempty"`
 }
 
 // ScraperTargetStoreService defines the crud service for ScraperTarget.

--- a/testing/scraper_target.go
+++ b/testing/scraper_target.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/mock"
+	"github.com/influxdata/influxdb/task/options"
 )
 
 const (
@@ -25,6 +26,8 @@ var (
 		BucketID: MustIDBase16(bucketOneID),
 		URL:      "url1",
 		ID:       MustIDBase16(targetOneID),
+		Interval: *options.MustParseDuration("1m"),
+		Timeout:  *options.MustParseDuration("1s"),
 	}
 	target2 = influxdb.ScraperTarget{
 		Name:     "name2",
@@ -33,6 +36,8 @@ var (
 		BucketID: MustIDBase16(bucketTwoID),
 		URL:      "url2",
 		ID:       MustIDBase16(targetTwoID),
+		Interval: *options.MustParseDuration("2m"),
+		Timeout:  *options.MustParseDuration("2s"),
 	}
 	target3 = influxdb.ScraperTarget{
 		Name:     "name3",
@@ -41,6 +46,8 @@ var (
 		BucketID: MustIDBase16(bucketThreeID),
 		URL:      "url3",
 		ID:       MustIDBase16(targetThreeID),
+		Interval: *options.MustParseDuration("3m"),
+		Timeout:  *options.MustParseDuration("3s"),
 	}
 	org1 = influxdb.Organization{
 		ID:   MustIDBase16(orgOneID),
@@ -148,6 +155,8 @@ func AddTarget(
 					OrgID:    MustIDBase16(orgOneID),
 					BucketID: MustIDBase16(bucketOneID),
 					URL:      "url1",
+					Interval: *options.MustParseDuration("1m"),
+					Timeout:  *options.MustParseDuration("1s"),
 				},
 			},
 			wants: wants{
@@ -167,6 +176,8 @@ func AddTarget(
 						BucketID: MustIDBase16(bucketOneID),
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 				},
 			},
@@ -185,6 +196,8 @@ func AddTarget(
 						BucketID: MustIDBase16(bucketOneID),
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 				},
 			},
@@ -195,6 +208,8 @@ func AddTarget(
 					Type:     influxdb.PrometheusScraperType,
 					BucketID: MustIDBase16(bucketTwoID),
 					URL:      "url2",
+					Interval: *options.MustParseDuration("2m"),
+					Timeout:  *options.MustParseDuration("2s"),
 				},
 			},
 			wants: wants{
@@ -212,6 +227,8 @@ func AddTarget(
 						BucketID: MustIDBase16(bucketOneID),
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 				},
 			},
@@ -230,16 +247,20 @@ func AddTarget(
 						BucketID: MustIDBase16(bucketOneID),
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 				},
 			},
 			args: args{
 				target: &influxdb.ScraperTarget{
-					ID:    MustIDBase16(targetTwoID),
-					Name:  "name2",
-					Type:  influxdb.PrometheusScraperType,
-					OrgID: MustIDBase16(orgTwoID),
-					URL:   "url2",
+					ID:       MustIDBase16(targetTwoID),
+					Name:     "name2",
+					Type:     influxdb.PrometheusScraperType,
+					OrgID:    MustIDBase16(orgTwoID),
+					URL:      "url2",
+					Interval: *options.MustParseDuration("2m"),
+					Timeout:  *options.MustParseDuration("2s"),
 				},
 			},
 			wants: wants{
@@ -257,6 +278,8 @@ func AddTarget(
 						BucketID: MustIDBase16(bucketOneID),
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 				},
 			},
@@ -273,6 +296,8 @@ func AddTarget(
 						BucketID: MustIDBase16(bucketOneID),
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 				},
 				Organizations: []*influxdb.Organization{&org1, &org2},
@@ -294,6 +319,8 @@ func AddTarget(
 					OrgID:    MustIDBase16(orgTwoID),
 					BucketID: MustIDBase16(bucketTwoID),
 					URL:      "url2",
+					Interval: *options.MustParseDuration("2m"),
+					Timeout:  *options.MustParseDuration("2s"),
 				},
 			},
 			wants: wants{
@@ -319,6 +346,8 @@ func AddTarget(
 						BucketID: MustIDBase16(bucketOneID),
 						URL:      "url1",
 						ID:       MustIDBase16(targetOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 					{
 						Name:     "name2",
@@ -327,6 +356,8 @@ func AddTarget(
 						BucketID: MustIDBase16(bucketTwoID),
 						URL:      "url2",
 						ID:       MustIDBase16(targetTwoID),
+						Interval: *options.MustParseDuration("2m"),
+						Timeout:  *options.MustParseDuration("2s"),
 					},
 				},
 			},
@@ -600,12 +631,16 @@ func GetTargetByID(
 						Name:     "target1",
 						OrgID:    MustIDBase16(orgOneID),
 						BucketID: MustIDBase16(bucketOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
 						Name:     "target2",
 						OrgID:    MustIDBase16(orgOneID),
 						BucketID: MustIDBase16(bucketOneID),
+						Interval: *options.MustParseDuration("2m"),
+						Timeout:  *options.MustParseDuration("2s"),
 					},
 				},
 			},
@@ -618,6 +653,8 @@ func GetTargetByID(
 					Name:     "target2",
 					OrgID:    MustIDBase16(orgOneID),
 					BucketID: MustIDBase16(bucketOneID),
+					Interval: *options.MustParseDuration("2m"),
+					Timeout:  *options.MustParseDuration("2s"),
 				},
 			},
 		},
@@ -630,12 +667,16 @@ func GetTargetByID(
 						Name:     "target1",
 						OrgID:    MustIDBase16(orgOneID),
 						BucketID: MustIDBase16(bucketOneID),
+						Interval: *options.MustParseDuration("1m"),
+						Timeout:  *options.MustParseDuration("1s"),
 					},
 					{
 						ID:       MustIDBase16(targetTwoID),
 						Name:     "target2",
 						OrgID:    MustIDBase16(orgOneID),
 						BucketID: MustIDBase16(bucketOneID),
+						Interval: *options.MustParseDuration("2m"),
+						Timeout:  *options.MustParseDuration("2s"),
 					},
 				},
 			},


### PR DESCRIPTION
Updates #12963

Describe your proposed changes here.
add scraper interval and timeout options, so scrapers can be scheduled base on customized interval and timeout, not global options.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
