### PR TITLE
feat(tasks): add runID to Log struct

### DIFF
--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -438,11 +438,15 @@ func taskLogFindF(cmd *cobra.Command, args []string) error {
 
 	w := internal.NewTabWriter(os.Stdout)
 	w.WriteHeaders(
-		"Log",
+		"RunID",
+		"Time",
+		"Message",
 	)
 	for _, log := range logs {
 		w.Write(map[string]interface{}{
-			"Log": *log,
+			"RunID":   log.RunID,
+			"Time":    log.Time,
+			"Message": log.Message,
 		})
 	}
 	w.Flush()

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5945,6 +5945,8 @@ components:
           items:
             type: object
             properties:
+              runID:
+                type: string
               time:
                 type: string
               message:

--- a/kv/task.go
+++ b/kv/task.go
@@ -1601,7 +1601,7 @@ func (s *Service) addRunLog(ctx context.Context, tx Tx, taskID, runID influxdb.I
 		return err
 	}
 	// update log
-	l := influxdb.Log{Time: when.Format(time.RFC3339Nano), Message: log}
+	l := influxdb.Log{RunID: runID, Time: when.Format(time.RFC3339Nano), Message: log}
 	run.Log = append(run.Log, l)
 	// save run
 	b, err := tx.Bucket(taskRunBucket)

--- a/task.go
+++ b/task.go
@@ -84,6 +84,7 @@ func (r *Run) RequestedAtTime() (time.Time, error) {
 
 // Log represents a link to a log resource
 type Log struct {
+	RunID   ID     `json:"runID,omitempty"`
 	Time    string `json:"time"`
 	Message string `json:"message"`
 }

--- a/task/mock/task_control_service.go
+++ b/task/mock/task_control_service.go
@@ -286,7 +286,7 @@ func (d *TaskControlService) AddRunLog(ctx context.Context, taskID, runID influx
 	if run == nil {
 		panic("cannot add a log to a non existent run")
 	}
-	run.Log = append(run.Log, influxdb.Log{Time: when.Format(time.RFC3339Nano), Message: log})
+	run.Log = append(run.Log, influxdb.Log{RunID: runID, Time: when.Format(time.RFC3339Nano), Message: log})
 	return nil
 }
 

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -769,7 +769,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 			t.Fatal(err)
 		}
 
-		expLine1 := &influxdb.Log{Time: log1Time.Format(time.RFC3339Nano), Message: "entry 1"}
+		expLine1 := &influxdb.Log{RunID: rc1.Created.RunID, Time: log1Time.Format(time.RFC3339Nano), Message: "entry 1"}
 		exp := []*influxdb.Log{expLine1}
 		if diff := cmp.Diff(logs, exp); diff != "" {
 			t.Fatalf("unexpected log: -got/+want: %s", diff)
@@ -788,7 +788,7 @@ func testTaskRuns(t *testing.T, sys *System) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		expLine2 := &influxdb.Log{Time: log2Time.Format(time.RFC3339Nano), Message: "entry 2"}
+		expLine2 := &influxdb.Log{RunID: rc2.Created.RunID, Time: log2Time.Format(time.RFC3339Nano), Message: "entry 2"}
 		exp = []*influxdb.Log{expLine1, expLine2}
 		if diff := cmp.Diff(logs, exp); diff != "" {
 			t.Fatalf("unexpected log: -got/+want: %s", diff)


### PR DESCRIPTION
Closes #12694

This PR adds a `RunID` property to run logs.

- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)