### PR TITLE
Separate input element from date-picker

### DIFF
--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -62,6 +62,7 @@ export default class DashboardHeader extends Component<Props> {
       org,
       handleChooseAutoRefresh,
       onManualRefresh,
+      timeRange,
       timeRange: {upper, lower},
       zoomedTimeRange: {upper: zoomedUpper, lower: zoomedLower},
       isHidden,
@@ -106,6 +107,7 @@ export default class DashboardHeader extends Component<Props> {
           <TimeRangeDropdown
             onSetTimeRange={this.handleChooseTimeRange}
             timeRange={{
+              ...timeRange,
               upper: zoomedUpper || upper,
               lower: zoomedLower || lower,
             }}

--- a/ui/src/shared/components/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/TimeRangeDropdown.tsx
@@ -113,10 +113,13 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
 
     if (isDatePickerOpen) {
       const date = new Date().toISOString()
+
       const upper =
         timeRange.upper && this.isCustomTimeRange ? timeRange.upper : date
       const lower =
-        timeRange.lower && this.isCustomTimeRange ? timeRange.lower : date
+        timeRange.lower && this.isCustomTimeRange
+          ? timeRange.lower
+          : this.calculatedLower
       return {
         label: CUSTOM_TIME_RANGE_LABEL,
         lower,
@@ -142,6 +145,20 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
 
   private get isDatePickerVisible() {
     return this.state.isDatePickerOpen
+  }
+
+  private get calculatedLower() {
+    const {
+      timeRange: {seconds},
+    } = this.props
+
+    if (seconds) {
+      return moment()
+        .subtract(seconds, 's')
+        .toISOString()
+    }
+
+    return new Date().toISOString()
   }
 
   private handleApplyTimeRange = (timeRange: TimeRange) => {

--- a/ui/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -4,14 +4,14 @@ import ReactDatePicker from 'react-datepicker'
 import moment from 'moment'
 
 // Components
-import {Form, Input, Grid} from '@influxdata/clockface'
+import {Input, Grid, ComponentStatus} from '@influxdata/clockface'
 
 // Styles
 import 'react-datepicker/dist/react-datepicker.css'
 
 // Types
 import {Columns, ComponentSize} from '@influxdata/clockface'
-import {ComponentStatus} from 'src/clockface'
+import {Form} from 'src/clockface'
 
 interface Props {
   label: string
@@ -38,7 +38,7 @@ export default class DatePicker extends PureComponent<Props, State> {
       <div className="range-picker--date-picker">
         <Grid.Row>
           <Grid.Column widthXS={Columns.Twelve}>
-            <Form.Element label={label}>
+            <Form.Element label={label} errorMessage={this.inputErrorMessage}>
               <Input
                 size={ComponentSize.Medium}
                 className="range-picker--input react-datepicker-ignore-onclickoutside"
@@ -47,24 +47,24 @@ export default class DatePicker extends PureComponent<Props, State> {
                 onChange={this.handleChangeInput}
                 status={this.inputStatus}
               />
-              <div className="range-picker--popper-container">
-                <ReactDatePicker
-                  inline
-                  selected={date}
-                  onChange={this.handleSelectDate}
-                  startOpen={true}
-                  dateFormat="yyyy-MM-dd HH:mm"
-                  showTimeSelect={true}
-                  timeFormat="HH:mm"
-                  shouldCloseOnSelect={false}
-                  disabledKeyboardNavigation={true}
-                  calendarClassName="range-picker--calendar"
-                  dayClassName={this.dayClassName}
-                  timeIntervals={60}
-                  fixedHeight={true}
-                />
-              </div>
             </Form.Element>
+            <div className="range-picker--popper-container">
+              <ReactDatePicker
+                inline
+                selected={date}
+                onChange={this.handleSelectDate}
+                startOpen={true}
+                dateFormat="yyyy-MM-dd HH:mm"
+                showTimeSelect={true}
+                timeFormat="HH:mm"
+                shouldCloseOnSelect={false}
+                disabledKeyboardNavigation={true}
+                calendarClassName="range-picker--calendar"
+                dayClassName={this.dayClassName}
+                timeIntervals={60}
+                fixedHeight={true}
+              />
+            </div>
           </Grid.Column>
         </Grid.Row>
       </div>
@@ -88,6 +88,14 @@ export default class DatePicker extends PureComponent<Props, State> {
       return false
     }
     return !moment(inputValue, 'YYYY-MM-DD HH:mm', true).isValid()
+  }
+
+  private get inputErrorMessage(): string | undefined {
+    if (this.isInputValueInvalid) {
+      return 'Format must be YYYY-MM-DD HH:mm'
+    }
+
+    return '\u00a0\u00a0'
   }
 
   private get inputStatus(): ComponentStatus {

--- a/ui/src/shared/components/dateRangePicker/DatePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DatePicker.tsx
@@ -4,14 +4,13 @@ import ReactDatePicker from 'react-datepicker'
 import moment from 'moment'
 
 // Components
-import {Input, Grid, ComponentStatus} from '@influxdata/clockface'
+import {Input, Grid, Form} from '@influxdata/clockface'
 
 // Styles
 import 'react-datepicker/dist/react-datepicker.css'
 
 // Types
-import {Columns, ComponentSize} from '@influxdata/clockface'
-import {Form} from 'src/clockface'
+import {Columns, ComponentSize, ComponentStatus} from '@influxdata/clockface'
 
 interface Props {
   label: string

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.scss
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.scss
@@ -8,10 +8,9 @@
   text-align: center;
   background-color: $g1-raven;
   border: $ix-border solid $c-pool;
-  padding: 0 $ix-marg-b;
+  padding: $ix-marg-b;
   border-radius: $ix-radius;
   z-index: 9999;
-  height: 416px;
   
   .react-datepicker {
     font-family: $ix-text-font;
@@ -23,10 +22,11 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-top: $ix-marg-b;
+    margin-bottom: $ix-marg-b;
     
     .range-picker--date-picker {
       margin: $ix-marg-a;
+      margin-top: 0;
 
       .react-datepicker-wrapper,
       .react-datepicker__input-container {
@@ -169,6 +169,10 @@
   }
 }
 
+.range-picker--submit {
+  margin-bottom: $ix-marg-b;
+}
+
 .range-picker--dismiss {
   position: absolute;
   z-index: 5000;
@@ -207,4 +211,8 @@
     background-color: $c-laser;
     cursor: pointer;
   }
+}
+
+.range-picker--input {
+  margin-bottom: $ix-marg-a;
 }

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.scss
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.scss
@@ -33,143 +33,137 @@
         width: 100%;
       }
 
-      .range-picker--popper-container {
+      .range-picker--calendar-container {
         position: relative;
       }
     
-      .range-picker--popper {
-        position: relative !important;
-        transform: none !important;
-        @include no-user-select();
+      .range-picker--calendar {
+        background-color: transparent;
+        border: none;
+        color: $c-pool;
+        display: inline-flex;
+        flex-direction: row;
 
-        .range-picker--calendar {
-          background-color: transparent;
+        .react-datepicker__month-container {
+          background-color: $g3-castle;
+          border-radius: 0 0 $ix-radius $ix-radius;
+          width: 260px;
+        }
+
+        .react-datepicker__navigation {
+          outline: none;
+          cursor: pointer;
+        }
+
+        .react-datepicker__navigation--next {
+          border-left-color: $g18-cloud;
+        }
+
+        .react-datepicker__navigation--previous {
+          border-right-color: $g18-cloud;
+        }
+        
+        .range-picker--day {
+          color: $g7-graphite;
+
+          &:hover {
+            background-color: $c-laser;
+            color: $g20-white;
+          }
+        }
+
+        .range-picker--day-in-month {
+          color: $g14-chromium;
+          
+          &:hover {
+            background-color: $c-laser;
+            color: $g20-white;
+          }
+        }
+
+        .react-datepicker__day--selected {
+          background-color: $c-pool;
+          color: $g18-cloud;
+        }
+
+        .react-datepicker__triangle {
+          display: none;
+        }
+
+        .react-datepicker__header {
+          
+          border-radius: 0;
+          padding: 0;
           border: none;
-          color: $c-pool;
-          display: inline-flex;
-          flex-direction: row;
+          background: transparent;
 
-          .react-datepicker__month-container {
-            background-color: $g3-castle;
-            border-radius: 0 0 $ix-radius $ix-radius;
-            width: 260px;
-          }
-
-          .react-datepicker__navigation {
-            outline: none;
-            cursor: pointer;
-          }
-
-          .react-datepicker__navigation--next {
-            border-left-color: $g18-cloud;
-          }
-
-          .react-datepicker__navigation--previous {
-            border-right-color: $g18-cloud;
+          .react-datepicker__day-name {
+            color: $c-rainforest;
+            font-weight: 700;
           }
           
-          .range-picker--day {
-            color: $g7-graphite;
-
-            &:hover {
-              background-color: $c-laser;
-              color: $g20-white;
-            }
+          .react-datepicker__current-month {
+            width: 100%;
+            border-radius: $ix-radius $ix-radius 0 0;
+            background-color: $g4-onyx;
+            color: $g18-cloud;
+            font-weight: 700;
+            height: $ix-marg-d;
+            display: inline-flex;
+            flex-direction: row;
+            justify-content: center;
+            align-items: center;
+          }
+        }
+        
+        .react-datepicker__time-container {
+          width: 70px;
+          border: none;
+          margin-left: $ix-marg-a;
+          border-radius: $ix-radius;
+          background-color: transparent;
+          overflow: hidden;
+          
+          .react-datepicker__header--time {
+            width: 100%;
+            border-radius: $ix-radius $ix-radius 0 0;
+            background-color: $g4-onyx;
+            font-weight: 700;
+            height: $ix-marg-d;
+            display: inline-flex;
+            flex-direction: row;
+            justify-content: center;
+            align-items: center;
           }
 
-          .range-picker--day-in-month {
-            color: $g14-chromium;
-            
-            &:hover {
-              background-color: $c-laser;
-              color: $g20-white;
-            }
-          }
-
-          .react-datepicker__day--selected {
-            background-color: $c-pool;
+          .react-datepicker-time__header {
             color: $g18-cloud;
           }
 
-          .react-datepicker__triangle {
-            display: none;
-          }
-
-          .react-datepicker__header {
-            
-            border-radius: 0;
-            padding: 0;
-            border: none;
-            background: transparent;
-
-            .react-datepicker__day-name {
-              color: $c-rainforest;
-              font-weight: 700;
-            }
-            
-            .react-datepicker__current-month {
-              width: 100%;
-              border-radius: $ix-radius $ix-radius 0 0;
-              background-color: $g4-onyx;
-              color: $g18-cloud;
-              font-weight: 700;
-              height: $ix-marg-d;
-              display: inline-flex;
-              flex-direction: row;
-              justify-content: center;
-              align-items: center;
-            }
-          }
-          
-          .react-datepicker__time-container {
-            width: 70px;
-            border: none;
-            margin-left: $ix-marg-a;
-            border-radius: $ix-radius;
+          .react-datepicker__time {
             background-color: transparent;
-            overflow: hidden;
-            
-            .react-datepicker__header--time {
+
+            .react-datepicker__time-box {
               width: 100%;
-              border-radius: $ix-radius $ix-radius 0 0;
-              background-color: $g4-onyx;
-              font-weight: 700;
-              height: $ix-marg-d;
-              display: inline-flex;
-              flex-direction: row;
-              justify-content: center;
-              align-items: center;
-            }
+              background-color: $g3-castle;
+              color: $g14-chromium;
 
-            .react-datepicker-time__header {
-              color: $g18-cloud;
-            }
+              .react-datepicker__time-list {
+                font-size: $ix-text-base;
 
-            .react-datepicker__time {
-              background-color: transparent;
+                .react-datepicker__time-list-item:hover {
+                  background-color: $c-laser;
+                  color: $g20-white;
+                }
 
-              .react-datepicker__time-box {
-                width: 100%;
-                background-color: $g3-castle;
-                color: $g14-chromium;
-
-                .react-datepicker__time-list {
-                  font-size: $ix-text-base;
-
-                  .react-datepicker__time-list-item:hover {
-                    background-color: $c-laser;
-                    color: $g20-white;
-                  }
-
-                  .react-datepicker__time-list-item--selected {
-                    background-color: $c-pool;
-                  }
+                .react-datepicker__time-list-item--selected {
+                  background-color: $c-pool;
                 }
               }
             }
           }
-
         }
+
       }
     }
   }

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.scss
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.scss
@@ -41,12 +41,13 @@
         background-color: transparent;
         border: none;
         color: $c-pool;
-        display: inline-flex;
+        display: flex;
         flex-direction: row;
+        align-items: stretch;
 
         .react-datepicker__month-container {
           background-color: $g3-castle;
-          border-radius: 0 0 $ix-radius $ix-radius;
+          border-radius: $ix-radius $ix-radius;
           width: 260px;
         }
 
@@ -119,17 +120,18 @@
         .react-datepicker__time-container {
           width: 70px;
           border: none;
-          margin-left: $ix-marg-a;
+          margin-left: $ix-border;
           border-radius: $ix-radius;
           background-color: transparent;
-          overflow: hidden;
+          display: flex;
+          flex-direction: column;
           
           .react-datepicker__header--time {
             width: 100%;
             border-radius: $ix-radius $ix-radius 0 0;
             background-color: $g4-onyx;
             font-weight: 700;
-            height: $ix-marg-d;
+            flex: 0 0 $ix-marg-d;
             display: inline-flex;
             flex-direction: row;
             justify-content: center;
@@ -141,24 +143,42 @@
           }
 
           .react-datepicker__time {
+            flex: 1 0 calc(100% - #{$ix-marg-d});
             background-color: transparent;
 
             .react-datepicker__time-box {
               width: 100%;
+              height: 100%;
               background-color: $g3-castle;
               color: $g14-chromium;
+              border-radius: 0 0 $ix-radius $ix-radius;
+              position: relative;
 
               .react-datepicker__time-list {
+                position: absolute;
+                width: 100%;
+                height: 100%;
                 font-size: $ix-text-base;
+                @include custom-scrollbar-round($g3-castle, $c-pool);
+
+                .react-datepicker__time-list-item {
+                  height: initial;
+                  padding: $ix-marg-a $ix-marg-b;
+                  transition: background-color 0.25s ease, color 0.25s ease;
+                  line-height: 1.25em;
+                  margin: 0;
+                }
 
                 .react-datepicker__time-list-item:hover {
-                  background-color: $c-laser;
+                  background-color: $g6-smoke;
                   color: $g20-white;
                 }
 
-                .react-datepicker__time-list-item--selected {
+                .react-datepicker__time-list-item--selected,
+                .react-datepicker__time-list-item--selected:hover {
                   background-color: $c-pool;
                 }
+
               }
             }
           }
@@ -211,8 +231,4 @@
     background-color: $c-laser;
     cursor: pointer;
   }
-}
-
-.range-picker--input {
-  margin-bottom: $ix-marg-a;
 }

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
@@ -78,6 +78,7 @@ class DateRangePicker extends PureComponent<Props, State> {
             />
           </div>
           <Button
+            className="range-picker--submit"
             color={ComponentColor.Primary}
             size={ComponentSize.Small}
             onClick={this.handleSetTimeRange}


### PR DESCRIPTION
Closes #13829 

Add separate input element to handle text based inputs to the date picker. 
If text input is invalid do not update the timeRange, but continue displaying in text input. 
When opening date picker for the first time, select time range that was already selected in Time Range Dropdown. So that if Past 5m were selected -> lower= now-5m and upper = now. 