### PR TITLE
fix(ui): prevent visualization crash in DE

### DIFF
--- a/ui/src/shared/utils/useVisDomainSettings.ts
+++ b/ui/src/shared/utils/useVisDomainSettings.ts
@@ -16,12 +16,15 @@ import {extent} from 'src/shared/utils/vis'
 */
 export const useVisDomainSettings = (
   storedDomain: [number, number],
-  data: NumericColumnData = []
+  data: NumericColumnData
 ) => {
-  const initialDomain = useMemo(
-    () => (storedDomain ? storedDomain : extent(data as number[])),
-    [storedDomain, data]
-  )
+  const initialDomain = useMemo(() => {
+    if (storedDomain) {
+      return storedDomain
+    }
+
+    return extent((data as number[]) || [])
+  }, [storedDomain, data])
 
   const [domain, setDomain] = useOneWayState(initialDomain)
   const resetDomain = () => setDomain(initialDomain)


### PR DESCRIPTION
Fixes the following crash:

![crash](https://user-images.githubusercontent.com/638955/59213993-00a3b100-8b6b-11e9-942f-8ab944011ffb.gif)

The regression was introduced in https://github.com/influxdata/influxdb/commit/eee441680910ca6cc55b23a666eacd84a12d6909. A default argument was supplied to an argument in the `useVisDomainSettings`, but the default was never being used since `null` and not `undefined` was being passed.