### PR TITLE
chore(tasks): update run limits in swagger and FindRuns

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4349,8 +4349,8 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 100
-            default: 20
+            maximum: 500
+            default: 100
           description: the number of runs to return
         - in: query
           name: afterTime

--- a/kv/task.go
+++ b/kv/task.go
@@ -862,9 +862,14 @@ func (s *Service) FindRuns(ctx context.Context, filter influxdb.RunFilter) ([]*i
 }
 
 func (s *Service) findRuns(ctx context.Context, tx Tx, filter influxdb.RunFilter) ([]*influxdb.Run, int, error) {
-	if filter.Limit == 0 || filter.Limit > influxdb.TaskMaxPageSize {
-		filter.Limit = influxdb.TaskMaxPageSize
+	if filter.Limit == 0 {
+		filter.Limit = influxdb.TaskDefaultPageSize
 	}
+
+	if filter.Limit < 0 || filter.Limit > influxdb.TaskMaxPageSize {
+		return nil, 0, backend.ErrOutOfBoundsLimit
+	}
+
 	var runs []*influxdb.Run
 	// manual runs
 	manualRuns, err := s.manualRuns(ctx, tx, filter.Task)

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -602,6 +602,17 @@ func testTaskRuns(t *testing.T, sys *System) {
 			t.Fatal(err)
 		}
 
+		// check run filter errors
+		_, _, err0 := sys.TaskService.FindRuns(sys.Ctx, influxdb.RunFilter{Task: task.ID, Limit: -1})
+		if err0 != backend.ErrOutOfBoundsLimit {
+			t.Fatalf("failed to error with out of bounds run limit: %d", -1)
+		}
+
+		_, _, err1 := sys.TaskService.FindRuns(sys.Ctx, influxdb.RunFilter{Task: task.ID, Limit: influxdb.TaskMaxPageSize + 1})
+		if err1 != backend.ErrOutOfBoundsLimit {
+			t.Fatalf("failed to error with out of bounds run limit: %d", influxdb.TaskMaxPageSize+1)
+		}
+
 		requestedAtUnix := time.Now().Add(5 * time.Minute).UTC().Unix() // This should guarantee we can make two runs.
 
 		rc0, err := sys.TaskControlService.CreateNextRun(sys.Ctx, task.ID, requestedAtUnix)
@@ -1031,6 +1042,17 @@ func testRunStorage(t *testing.T, sys *System) {
 	task, err := sys.TaskService.CreateTask(icontext.SetAuthorizer(sys.Ctx, cr.Authorizer()), ct)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// check run filter errors
+	_, _, err0 := sys.TaskService.FindRuns(sys.Ctx, influxdb.RunFilter{Task: task.ID, Limit: -1})
+	if err0 != backend.ErrOutOfBoundsLimit {
+		t.Fatalf("failed to error with out of bounds run limit: %d", -1)
+	}
+
+	_, _, err1 := sys.TaskService.FindRuns(sys.Ctx, influxdb.RunFilter{Task: task.ID, Limit: influxdb.TaskMaxPageSize + 1})
+	if err1 != backend.ErrOutOfBoundsLimit {
+		t.Fatalf("failed to error with out of bounds run limit: %d", influxdb.TaskMaxPageSize+1)
 	}
 
 	requestedAtUnix := time.Now().Add(5 * time.Minute).UTC().Unix() // This should guarantee we can make two runs.


### PR DESCRIPTION
This PR updates the swagger document to reflect the correct default and maximum number of runs returned by `FindRuns`. It also updates the `FindRuns` function to set the number returned to the default if the limit is 0 or not set, and set it to the maximum if it was higher than the maximum. Previously, it was set to the maximum whether it was zero or greater than the max.

- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
