### PR TITLE
fix(query): recover from panics during compiler and start steps

### DIFF
--- a/http/task_test.go
+++ b/http/task_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestTaskService(t *testing.T) {
+	t.Skip("TODO(#14108): flaky test (https://github.com/influxdata/influxdb/issues/14108)")
 	t.Parallel()
 	servicetest.TestTaskService(
 		t,


### PR DESCRIPTION
Fixes influxdata/idpe#3409.
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->
