### PR TITLE
fix(influxdb): telegraf compatible mode

### DIFF
--- a/telegraf.go
+++ b/telegraf.go
@@ -156,10 +156,11 @@ type telegrafPluginEncode struct {
 
 // telegrafConfigDecode is the helper struct for json decoding.
 type telegrafConfigDecode struct {
-	ID          ID     `json:"id"`
-	OrgID       ID     `json:"orgID,omitempty"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	ID             ID     `json:"id"`
+	OrganizationID ID     `json:"organizationID,omitempty"`
+	OrgID          ID     `json:"orgID,omitempty"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
 
 	Agent TelegrafAgentConfig `json:"agent"`
 
@@ -305,9 +306,13 @@ func (tc *TelegrafConfig) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, tcd); err != nil {
 		return err
 	}
+	orgID := tcd.OrgID
+	if !orgID.Valid() {
+		orgID = tcd.OrganizationID
+	}
 	*tc = TelegrafConfig{
 		ID:          tcd.ID,
-		OrgID:       tcd.OrgID,
+		OrgID:       orgID,
 		Name:        tcd.Name,
 		Description: tcd.Description,
 		Agent:       tcd.Agent,


### PR DESCRIPTION
Close https://github.com/influxdata/idpe/issues/3758

This change will allow existing old telegraf configs still work with UI before any migration. 
This change won't change the data stored in bolt, unless user made an update.
Manually tested as well.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
