### PR TITLE
feat(me): return oauth id with user object

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6089,7 +6089,6 @@ components:
           readOnly: true
           type: string
         oauthID:
-          readOnly: true
           type: string
         name:
           type: string

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6088,6 +6088,9 @@ components:
         id:
           readOnly: true
           type: string
+        oauthID:
+          readOnly: true
+          type: string
         name:
           type: string
         status:

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -188,17 +188,9 @@ func (h *UserHandler) handleGetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	switch s := a.(type) {
-	case *influxdb.Session:
-		if err := encodeResponse(ctx, w, http.StatusOK, newUserResponseFromSession(user, s)); err != nil {
-			EncodeError(ctx, err, w)
-			return
-		}
-	case *influxdb.Authorization:
-		if err := encodeResponse(ctx, w, http.StatusOK, newUserResponse(user)); err != nil {
-			EncodeError(ctx, err, w)
-			return
-		}
+	if err := encodeResponse(ctx, w, http.StatusOK, newUserResponse(user)); err != nil {
+		EncodeError(ctx, err, w)
+		return
 	}
 }
 
@@ -330,18 +322,6 @@ func newUserResponse(u *influxdb.User) *userResponse {
 			"logs": fmt.Sprintf("/api/v2/users/%s/logs", u.ID),
 		},
 		User: *u,
-	}
-}
-
-type userResponseFromSession struct {
-	*userResponse
-	OAuthID string `json:"oauthID,omitempty"`
-}
-
-func newUserResponseFromSession(u *influxdb.User, s *influxdb.Session) *userResponseFromSession {
-	return &userResponseFromSession{
-		userResponse: newUserResponse(u),
-		OAuthID:      s.OAuthID,
 	}
 }
 

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -333,13 +333,13 @@ func newUserResponse(u *influxdb.User) *userResponse {
 	}
 }
 
-type decoratedUserResponse struct {
+type userResponseFromSession struct {
 	*userResponse
 	OAuthID string `json:"oauthID,omitempty"`
 }
 
-func newUserResponseFromSession(u *influxdb.User, s *influxdb.Session) *decoratedUserResponse {
-	return &decoratedUserResponse{
+func newUserResponseFromSession(u *influxdb.User, s *influxdb.Session) *userResponseFromSession {
+	return &userResponseFromSession{
 		userResponse: newUserResponse(u),
 		OAuthID:      s.OAuthID,
 	}

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -190,7 +190,7 @@ func (h *UserHandler) handleGetMe(w http.ResponseWriter, r *http.Request) {
 
 	switch s := a.(type) {
 	case *influxdb.Session:
-		if err := encodeResponse(ctx, w, http.StatusOK, newDecoratedUserResponse(user, s)); err != nil {
+		if err := encodeResponse(ctx, w, http.StatusOK, newUserResponseFromSession(user, s)); err != nil {
 			EncodeError(ctx, err, w)
 			return
 		}
@@ -338,7 +338,7 @@ type decoratedUserResponse struct {
 	OAuthID string `json:"oauthID,omitempty"`
 }
 
-func newDecoratedUserResponse(u *influxdb.User, s *influxdb.Session) *decoratedUserResponse {
+func newUserResponseFromSession(u *influxdb.User, s *influxdb.Session) *decoratedUserResponse {
 	return &decoratedUserResponse{
 		userResponse: newUserResponse(u),
 		OAuthID:      s.OAuthID,

--- a/session.go
+++ b/session.go
@@ -40,6 +40,7 @@ type Session struct {
 	ExpiresAt   time.Time    `json:"expiresAt"`
 	UserID      ID           `json:"userID,omitempty"`
 	Permissions []Permission `json:"permissions,omitempty"`
+	OAuthID     string       `json:"oauthID,omitempty"`
 }
 
 // Expired returns an error if the session is expired.

--- a/session.go
+++ b/session.go
@@ -40,7 +40,6 @@ type Session struct {
 	ExpiresAt   time.Time    `json:"expiresAt"`
 	UserID      ID           `json:"userID,omitempty"`
 	Permissions []Permission `json:"permissions,omitempty"`
-	OAuthID     string       `json:"oauthID,omitempty"`
 }
 
 // Expired returns an error if the session is expired.

--- a/user.go
+++ b/user.go
@@ -6,8 +6,9 @@ import (
 
 // User is a user. 🎉
 type User struct {
-	ID   ID     `json:"id,omitempty"`
-	Name string `json:"name"`
+	ID      ID     `json:"id,omitempty"`
+	Name    string `json:"name"`
+	OAuthID string `json:"oauthID,omitempty"`
 }
 
 // Ops for user errors and op log.


### PR DESCRIPTION
`/me` will now include an `oauthID` attribute. If influxdb has a configured OAuth provider, then we should expect `/me` to include the corresponding provider id for that user. If influxdb does not have OAuth configured, and is reliant on the local username/password bolt store, then `oauthID` will be omitted.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
