### PR TITLE
fix(storage): Add WithCurrentGenerationFunc() for generation injection.

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -63,6 +63,13 @@ func WithTSMFilenameFormatter(fn tsm1.FormatFileNameFunc) Option {
 	}
 }
 
+// WithCurrentGenerationFunc sets a function for obtaining the current generation.
+func WithCurrentGenerationFunc(fn func() int) Option {
+	return func(e *Engine) {
+		e.engine.WithCurrentGenerationFunc(fn)
+	}
+}
+
 // WithEngineID sets an engine id, which can be useful for logging when multiple
 // engines are in use.
 func WithEngineID(id int) Option {

--- a/tsdb/tsm1/compact.go
+++ b/tsdb/tsm1/compact.go
@@ -690,6 +690,7 @@ type Compactor struct {
 	Size int
 
 	FileStore interface {
+		SetCurrentGenerationFunc(func() int)
 		NextGeneration() int
 		TSMReader(path string) *TSMReader
 	}

--- a/tsdb/tsm1/compact_test.go
+++ b/tsdb/tsm1/compact_test.go
@@ -2993,6 +2993,8 @@ func (w *fakeFileStore) NextGeneration() int {
 	return 1
 }
 
+func (w *fakeFileStore) SetCurrentGenerationFunc(fn func() int) {}
+
 func (w *fakeFileStore) LastModified() time.Time {
 	return w.lastModified
 }

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -240,6 +240,10 @@ func (e *Engine) WithParseFileNameFunc(parseFileNameFunc ParseFileNameFunc) {
 	e.Compactor.WithParseFileNameFunc(parseFileNameFunc)
 }
 
+func (e *Engine) WithCurrentGenerationFunc(fn func() int) {
+	e.Compactor.FileStore.SetCurrentGenerationFunc(fn)
+}
+
 func (e *Engine) WithFileStoreObserver(obs FileStoreObserver) {
 	e.FileStore.WithObserver(obs)
 }


### PR DESCRIPTION
Adds the ability to set the current generation to use when compacting
the cache only. Previously, we used the current generation for all
files but this causes issues and we should only use the current
generation for level 1 compaction.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
