### PR TITLE
Add type metadata to User Templates

### DIFF
--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -114,8 +114,8 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
 
   private get description(): JSX.Element {
     const {template} = this.props
-    const description = _.get(template, 'meta.description')
-    const name = _.get(template, 'meta.name')
+    const description = _.get(template, 'meta.description', '')
+    const name = _.get(template, 'meta.name', '')
 
     return (
       <ResourceList.Description
@@ -131,7 +131,7 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
 
     return (
       <div className="resource-list--meta-item">
-        {_.get(template, 'meta.type')}
+        {_.get(template, 'meta.type', '')}
       </div>
     )
   }

--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -89,6 +89,7 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
             onCreateLabel={this.handleCreateLabel}
           />
         )}
+        metaData={() => [this.templateType]}
       />
     )
   }
@@ -113,7 +114,6 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
 
   private get description(): JSX.Element {
     const {template} = this.props
-
     const description = _.get(template, 'meta.description')
     const name = _.get(template, 'meta.name')
 
@@ -123,6 +123,16 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
         description={description}
         placeholder={`Describe ${name} Template`}
       />
+    )
+  }
+
+  private get templateType(): JSX.Element {
+    const {template} = this.props
+
+    return (
+      <div className="resource-list--meta-item">
+        {_.get(template, 'meta.type')}
+      </div>
     )
   }
 


### PR DESCRIPTION
Closes #14098

Add type metadata to User Templates

![image](https://user-images.githubusercontent.com/11937365/59716300-9a520a80-91ca-11e9-8aa0-86af9ebb0a11.png)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass