### PR TITLE
Gauge polish

### DIFF
--- a/ui/src/shared/components/Gauge.tsx
+++ b/ui/src/shared/components/Gauge.tsx
@@ -282,15 +282,14 @@ class Gauge extends Component<Props> {
     const {prefix, suffix, decimalPlaces} = this.props
     const {degree, lineCount, labelColor, labelFontSize} = GAUGE_SPECS
 
-    const incrementValue = (maxValue - minValue) / lineCount
+    const tickValues = [
+      ..._.range(minValue, maxValue, Math.abs(maxValue - minValue) / lineCount),
+      maxValue,
+    ]
 
-    const labels = []
-    for (let g = minValue; g < maxValue; g += incrementValue) {
-      const valueString = formatStatValue(g, {decimalPlaces, prefix, suffix})
-      labels.push(valueString)
-    }
-
-    labels.push(formatStatValue(maxValue, {decimalPlaces, prefix, suffix}))
+    const labels = tickValues.map(tick =>
+      formatStatValue(tick, {decimalPlaces, prefix, suffix})
+    )
 
     const startDegree = degree * 135
     const arcLength = Math.PI * 1.5
@@ -349,10 +348,18 @@ class Gauge extends Component<Props> {
 
   private drawNeedle = (ctx, radius, minValue, maxValue) => {
     const {gaugePosition} = this.props
-    const {degree, needleColor0, needleColor1} = GAUGE_SPECS
+    const {degree, needleColor0, needleColor1, overflowDelta} = GAUGE_SPECS
     const arcDistance = Math.PI * 1.5
 
-    const needleRotation = (gaugePosition - minValue) / (maxValue - minValue)
+    let needleRotation: number
+
+    if (gaugePosition <= minValue) {
+      needleRotation = 0 - overflowDelta
+    } else if (gaugePosition >= maxValue) {
+      needleRotation = 1 + overflowDelta
+    } else {
+      needleRotation = (gaugePosition - minValue) / (maxValue - minValue)
+    }
 
     const needleGradient = ctx.createLinearGradient(0, -10, 0, radius)
     needleGradient.addColorStop(0, needleColor0)

--- a/ui/src/shared/components/Gauge.tsx
+++ b/ui/src/shared/components/Gauge.tsx
@@ -62,21 +62,16 @@ class Gauge extends Component<Props> {
     )
   }
 
-  private resetCanvas = (canvas, context) => {
-    context.setTransform(1, 0, 0, 1, 0, 0)
-    context.clearRect(0, 0, canvas.width, canvas.height)
-  }
-
   private updateCanvas = () => {
+    this.resetCanvas()
+
     const canvas = this.canvasRef.current
-    canvas.width = canvas.height * (canvas.clientWidth / canvas.clientHeight)
     const ctx = canvas.getContext('2d')
+    const {width, height} = this.props
 
-    this.resetCanvas(canvas, ctx)
-
-    const centerX = canvas.width / 2
-    const centerY = (canvas.height / 2) * 1.13
-    const radius = (Math.min(canvas.width, canvas.height) / 2) * 0.5
+    const centerX = width / 2
+    const centerY = (height / 2) * 1.13
+    const radius = (Math.min(width, height) / 2) * 0.5
 
     const {minLineWidth, minFontSize} = GAUGE_SPECS
     const gradientThickness = Math.max(minLineWidth, radius / 4)
@@ -121,6 +116,23 @@ class Gauge extends Component<Props> {
     this.drawGaugeLabels(ctx, radius, gradientThickness, minValue, maxValue)
     this.drawGaugeValue(ctx, radius, labelValueFontSize)
     this.drawNeedle(ctx, radius, minValue, maxValue)
+  }
+
+  private resetCanvas = () => {
+    const canvas = this.canvasRef.current
+    const ctx = canvas.getContext('2d')
+    const {width, height} = this.props
+    const dpRatio = window.devicePixelRatio || 1
+
+    // Set up canvas to draw on HiDPI / Retina screens correctly
+    canvas.width = width * dpRatio
+    canvas.height = height * dpRatio
+    canvas.style.width = `${width}px`
+    canvas.style.height = `${height}px`
+    ctx.scale(dpRatio, dpRatio)
+
+    // Clear the canvas
+    ctx.clearRect(0, 0, width, height)
   }
 
   private drawGradientGauge = (ctx, xc, yc, r, gradientThickness) => {

--- a/ui/src/shared/constants/gaugeSpecs.ts
+++ b/ui/src/shared/constants/gaugeSpecs.ts
@@ -1,5 +1,5 @@
 export const GAUGE_SPECS = {
-  degree: Math.PI / 180,
+  degree: (5 / 4) * Math.PI,
   lineCount: 5,
   smallLineCount: 10,
   lineColor: '#545667',
@@ -14,4 +14,10 @@ export const GAUGE_SPECS = {
   valueColor: '#ffffff',
   needleColor0: '#434453',
   needleColor1: '#ffffff',
+
+  // This constant expresses how far past the gauge max the needle should be
+  // drawn if the value for the needle is greater than the gauge max. It is
+  // expressed as a percentage of the circumference of a circle, e.g. 0.5 means
+  // draw halfway around the gauge from the max value
+  overflowDelta: 0.03,
 }


### PR DESCRIPTION
I investigated https://github.com/influxdata/influxdb/issues/14175 + https://github.com/influxdata/EAR/issues/823  and discovered the root issue is that the threshold settings component emits nonsensical settings. I opened up https://github.com/influxdata/influxdb/issues/14190 to track resolution.


In the meantime I made some minor gauge tweaks. It now displays better on HiDPI / Retina screens.

Before (you will need a HiDPI screen to see the blurriness): 

<img width="419" alt="before" src="https://user-images.githubusercontent.com/638955/60056250-282f6900-9695-11e9-877d-e09dea843d14.png">


After:

<img width="407" alt="after" src="https://user-images.githubusercontent.com/638955/60056254-2b2a5980-9695-11e9-91bf-3fa0d5cd1903.png">


I also tweaked how the gauge behaves when the needle position is beyond the domain of the gauge (for example if the current value is 6,000,000 and the max value for the gauge is 100). Before the needle would display at an essentially random position ¯\_(ツ)_/¯ (some sort of modular arithmetic).

Now it will be clamped to just beyond the domain:

<img width="517" alt="Screen Shot 2019-06-24 at 3 30 58 PM" src="https://user-images.githubusercontent.com/638955/60056347-747aa900-9695-11e9-9c70-b58c3daf0ad2.png">
