### PR TITLE
fix client tracing propagation from doubly recording

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/nats-io/nuid v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
-	github.com/opentracing/opentracing-go v1.0.2
+	github.com/opentracing/opentracing-go v1.1.0
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,8 @@ github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVo
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=

--- a/http/bucket_service.go
+++ b/http/bucket_service.go
@@ -605,7 +605,6 @@ func (s *BucketService) FindBucketByID(ctx context.Context, id influxdb.ID) (*in
 		return nil, err
 	}
 	SetToken(s.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(req)
@@ -692,7 +691,6 @@ func (s *BucketService) FindBuckets(ctx context.Context, filter influxdb.BucketF
 
 	req.URL.RawQuery = query.Encode()
 	SetToken(s.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(req)
@@ -745,7 +743,6 @@ func (s *BucketService) CreateBucket(ctx context.Context, b *influxdb.Bucket) er
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(s.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
 

--- a/http/client.go
+++ b/http/client.go
@@ -3,8 +3,6 @@ package http
 import (
 	"net/http"
 	"net/url"
-
-	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // Service connects to an InfluxDB via HTTP.
@@ -54,6 +52,7 @@ func NewService(addr, token string) *Service {
 	}
 }
 
+// NewURL concats addr and path.
 func NewURL(addr, path string) (*url.URL, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
@@ -63,27 +62,14 @@ func NewURL(addr, path string) (*url.URL, error) {
 	return u, nil
 }
 
-func NewClient(scheme string, insecure bool) *traceClient {
-	hc := &traceClient{
-		Client: http.Client{
-			Transport: defaultTransport,
-		},
+// NewClient returns a pooling http.Client.
+func NewClient(scheme string, insecure bool) *http.Client {
+	hc := &http.Client{
+		Transport: defaultTransport,
 	}
 	if scheme == "https" && insecure {
 		hc.Transport = skipVerifyTransport
 	}
 
 	return hc
-}
-
-// traceClient always injects any opentracing trace into the client requests.
-type traceClient struct {
-	http.Client
-}
-
-// Do injects the trace and then performs the request.
-func (c *traceClient) Do(r *http.Request) (*http.Response, error) {
-	span, _ := tracing.StartSpanFromContext(r.Context())
-	tracing.InjectToHTTPRequest(span, r)
-	return c.Client.Do(r)
 }

--- a/http/client.go
+++ b/http/client.go
@@ -54,6 +54,7 @@ func NewService(addr, token string) *Service {
 	}
 }
 
+// NewURL concats addr and path.
 func NewURL(addr, path string) (*url.URL, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
@@ -63,6 +64,7 @@ func NewURL(addr, path string) (*url.URL, error) {
 	return u, nil
 }
 
+// NewClient returns an http.Client that pools connections and injects a span.
 func NewClient(scheme string, insecure bool) *traceClient {
 	hc := &traceClient{
 		Client: http.Client{
@@ -84,6 +86,7 @@ type traceClient struct {
 // Do injects the trace and then performs the request.
 func (c *traceClient) Do(r *http.Request) (*http.Response, error) {
 	span, _ := tracing.StartSpanFromContext(r.Context())
+	defer span.Finish()
 	tracing.InjectToHTTPRequest(span, r)
 	return c.Client.Do(r)
 }

--- a/http/influxdb/client.go
+++ b/http/influxdb/client.go
@@ -80,6 +80,7 @@ type traceClient struct {
 // Do injects the trace and then performs the request.
 func (c *traceClient) Do(r *http.Request) (*http.Response, error) {
 	span, _ := tracing.StartSpanFromContext(r.Context())
+	defer span.Finish()
 	tracing.InjectToHTTPRequest(span, r)
 	return c.Client.Do(r)
 }

--- a/http/influxdb/source_proxy_query_service.go
+++ b/http/influxdb/source_proxy_query_service.go
@@ -92,7 +92,6 @@ func (s *SourceProxyQueryService) fluxQuery(ctx context.Context, w io.Writer, re
 	hreq.Header.Set("Authorization", s.Token)
 	hreq.Header.Set("Content-Type", "application/json")
 	hreq = hreq.WithContext(ctx)
-	tracing.InjectToHTTPRequest(span, hreq)
 
 	hc := newTraceClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)
@@ -140,7 +139,6 @@ func (s *SourceProxyQueryService) influxQuery(ctx context.Context, w io.Writer, 
 	params.Set("rp", compiler.RP)
 
 	hreq.URL.RawQuery = params.Encode()
-	tracing.InjectToHTTPRequest(span, hreq)
 
 	hc := newTraceClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -656,7 +656,6 @@ func (s *OrganizationService) FindOrganizations(ctx context.Context, filter infl
 	if err != nil {
 		return nil, 0, tracing.LogError(span, err)
 	}
-	tracing.InjectToHTTPRequest(span, req)
 
 	SetToken(s.Token, req)
 	hc := NewClient(url.Scheme, s.InsecureSkipVerify)
@@ -707,7 +706,6 @@ func (s *OrganizationService) CreateOrganization(ctx context.Context, o *influxd
 	if err != nil {
 		return tracing.LogError(span, err)
 	}
-	tracing.InjectToHTTPRequest(span, req)
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(s.Token, req)
@@ -754,7 +752,6 @@ func (s *OrganizationService) UpdateOrganization(ctx context.Context, id influxd
 	if err != nil {
 		return nil, tracing.LogError(span, err)
 	}
-	tracing.InjectToHTTPRequest(span, req)
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(s.Token, req)
@@ -793,7 +790,6 @@ func (s *OrganizationService) DeleteOrganization(ctx context.Context, id influxd
 	if err != nil {
 		return tracing.LogError(span, err)
 	}
-	tracing.InjectToHTTPRequest(span, req)
 
 	SetToken(s.Token, req)
 

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -370,7 +370,6 @@ func (s *FluxService) Query(ctx context.Context, w io.Writer, r *query.ProxyRequ
 	hreq.Header.Set("Content-Type", "application/json")
 	hreq.Header.Set("Accept", "text/csv")
 	hreq = hreq.WithContext(ctx)
-	tracing.InjectToHTTPRequest(span, hreq)
 
 	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)
@@ -438,7 +437,6 @@ func (s *FluxQueryService) Query(ctx context.Context, r *query.Request) (flux.Re
 	hreq.Header.Set("Content-Type", "application/json")
 	hreq.Header.Set("Accept", "text/csv")
 	hreq = hreq.WithContext(ctx)
-	tracing.InjectToHTTPRequest(span, hreq)
 
 	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)

--- a/http/source_proxy_service.go
+++ b/http/source_proxy_service.go
@@ -54,7 +54,6 @@ func (s *SourceProxyQueryService) queryFlux(ctx context.Context, w io.Writer, re
 	hreq.Header.Set("Authorization", fmt.Sprintf("Token %s", s.Token))
 	hreq.Header.Set("Content-Type", "application/json")
 	hreq = hreq.WithContext(ctx)
-	tracing.InjectToHTTPRequest(span, hreq)
 
 	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
 	resp, err := hc.Do(hreq)

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -1373,7 +1373,6 @@ func (t TaskService) FindTaskByID(ctx context.Context, id platform.ID) (*platfor
 		return nil, err
 	}
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 	resp, err := hc.Do(req)
@@ -1435,7 +1434,6 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 		return nil, 0, err
 	}
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 	resp, err := hc.Do(req)
@@ -1482,7 +1480,6 @@ func (t TaskService) CreateTask(ctx context.Context, tc platform.TaskCreate) (*p
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1525,7 +1522,6 @@ func (t TaskService) UpdateTask(ctx context.Context, id platform.ID, upd platfor
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1564,7 +1560,6 @@ func (t TaskService) DeleteTask(ctx context.Context, id platform.ID) error {
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1603,7 +1598,6 @@ func (t TaskService) FindLogs(ctx context.Context, filter platform.LogFilter) ([
 		return nil, 0, err
 	}
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1657,7 +1651,6 @@ func (t TaskService) FindRuns(ctx context.Context, filter platform.RunFilter) ([
 
 	req.Header.Set("Content-Type", "application/json")
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1700,7 +1693,6 @@ func (t TaskService) FindRunByID(ctx context.Context, taskID, runID platform.ID)
 	}
 
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1744,7 +1736,6 @@ func (t TaskService) RetryRun(ctx context.Context, taskID, runID platform.ID) (*
 	}
 
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1792,7 +1783,6 @@ func (t TaskService) ForceRun(ctx context.Context, taskID platform.ID, scheduled
 	}
 
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 
@@ -1843,7 +1833,6 @@ func (t TaskService) CancelRun(ctx context.Context, taskID, runID platform.ID) e
 	}
 
 	SetToken(t.Token, req)
-	tracing.InjectToHTTPRequest(span, req)
 
 	hc := NewClient(u.Scheme, t.InsecureSkipVerify)
 


### PR DESCRIPTION
Closes #14203 

The HTTP service clients would inject any trace into the request header.  Also, the http.Client would also inject the header.  Because version 1.0.2 of opentracing used http.Header.Add multiple trace spans would be propagated.

Opentracing version 1.1.0 switches to http.Header.Set so that last span injection wins.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
