### PR TITLE
Error encode interface

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -596,6 +596,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 
 	m.apibackend = &http.APIBackend{
 		AssetsPath:           m.assetsPath,
+		HTTPErrorHandler:     http.ErrorHandler(0),
 		Logger:               m.logger,
 		SessionRenewDisabled: m.sessionRenewDisabled,
 		NewBucketService:     source.NewBucketService,

--- a/errors.go
+++ b/errors.go
@@ -1,9 +1,11 @@
 package influxdb
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 )
 
@@ -261,4 +263,9 @@ func decodeInternalError(target interface{}) error {
 		return internalErr
 	}
 	return nil
+}
+
+// HTTPErrorHandler is the interface to handle http error.
+type HTTPErrorHandler interface {
+	HandleHTTPError(ctx context.Context, err error, w http.ResponseWriter)
 }

--- a/http/api_handler_test.go
+++ b/http/api_handler_test.go
@@ -49,7 +49,9 @@ func TestAPIHandler_NotFound(t *testing.T) {
 			r := httptest.NewRequest(tt.args.method, tt.args.path, nil)
 			w := httptest.NewRecorder()
 
-			b := &APIBackend{}
+			b := &APIBackend{
+				HTTPErrorHandler: ErrorHandler(0),
+			}
 			b.Logger = zap.NewNop()
 
 			h := NewAPIHandler(b)

--- a/http/auth_service.go
+++ b/http/auth_service.go
@@ -19,6 +19,7 @@ import (
 // AuthorizationBackend is all services and associated parameters required to construct
 // the AuthorizationHandler.
 type AuthorizationBackend struct {
+	platform.HTTPErrorHandler
 	Logger *zap.Logger
 
 	AuthorizationService platform.AuthorizationService
@@ -30,7 +31,8 @@ type AuthorizationBackend struct {
 // NewAuthorizationBackend returns a new instance of AuthorizationBackend.
 func NewAuthorizationBackend(b *APIBackend) *AuthorizationBackend {
 	return &AuthorizationBackend{
-		Logger: b.Logger.With(zap.String("handler", "authorization")),
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Logger:           b.Logger.With(zap.String("handler", "authorization")),
 
 		AuthorizationService: b.AuthorizationService,
 		OrganizationService:  b.OrganizationService,
@@ -42,6 +44,7 @@ func NewAuthorizationBackend(b *APIBackend) *AuthorizationBackend {
 // AuthorizationHandler represents an HTTP API handler for authorizations.
 type AuthorizationHandler struct {
 	*httprouter.Router
+	platform.HTTPErrorHandler
 	Logger *zap.Logger
 
 	OrganizationService  platform.OrganizationService
@@ -53,8 +56,9 @@ type AuthorizationHandler struct {
 // NewAuthorizationHandler returns a new instance of AuthorizationHandler.
 func NewAuthorizationHandler(b *AuthorizationBackend) *AuthorizationHandler {
 	h := &AuthorizationHandler{
-		Router: NewRouter(),
-		Logger: b.Logger,
+		Router:           NewRouter(b.HTTPErrorHandler),
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Logger:           b.Logger,
 
 		AuthorizationService: b.AuthorizationService,
 		OrganizationService:  b.OrganizationService,
@@ -184,13 +188,13 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 
 	req, err := decodePostAuthorizationRequest(ctx, r)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	user, err := getAuthorizedUser(r, h.UserService)
 	if err != nil {
-		EncodeError(ctx, platform.ErrUnableToCreateToken, w)
+		h.HandleHTTPError(ctx, platform.ErrUnableToCreateToken, w)
 		return
 	}
 
@@ -198,18 +202,18 @@ func (h *AuthorizationHandler) handlePostAuthorization(w http.ResponseWriter, r 
 
 	org, err := h.OrganizationService.FindOrganizationByID(ctx, auth.OrgID)
 	if err != nil {
-		EncodeError(ctx, platform.ErrUnableToCreateToken, w)
+		h.HandleHTTPError(ctx, platform.ErrUnableToCreateToken, w)
 		return
 	}
 
 	if err := h.AuthorizationService.CreateAuthorization(ctx, auth); err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	perms, err := newPermissionsResponse(ctx, auth.Permissions, h.LookupService)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
@@ -318,14 +322,14 @@ func (h *AuthorizationHandler) handleGetAuthorizations(w http.ResponseWriter, r 
 	req, err := decodeGetAuthorizationsRequest(ctx, r)
 	if err != nil {
 		h.Logger.Info("failed to decode request", zap.String("handler", "getAuthorizations"), zap.Error(err))
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	opts := platform.FindOptions{}
 	as, _, err := h.AuthorizationService.FindAuthorizations(ctx, req.filter, opts)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
@@ -345,7 +349,7 @@ func (h *AuthorizationHandler) handleGetAuthorizations(w http.ResponseWriter, r 
 
 		ps, err := newPermissionsResponse(ctx, a.Permissions, h.LookupService)
 		if err != nil {
-			EncodeError(ctx, err, w)
+			h.HandleHTTPError(ctx, err, w)
 			return
 		}
 
@@ -353,7 +357,7 @@ func (h *AuthorizationHandler) handleGetAuthorizations(w http.ResponseWriter, r 
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newAuthsResponse(auths)); err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 }
@@ -414,37 +418,37 @@ func (h *AuthorizationHandler) handleGetAuthorization(w http.ResponseWriter, r *
 	req, err := decodeGetAuthorizationRequest(ctx, r)
 	if err != nil {
 		h.Logger.Info("failed to decode request", zap.String("handler", "getAuthorization"), zap.Error(err))
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	a, err := h.AuthorizationService.FindAuthorizationByID(ctx, req.ID)
 	if err != nil {
 		// Don't log here, it should already be handled by the service
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	o, err := h.OrganizationService.FindOrganizationByID(ctx, a.OrgID)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	u, err := h.UserService.FindUserByID(ctx, a.UserID)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	ps, err := newPermissionsResponse(ctx, a.Permissions, h.LookupService)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newAuthResponse(a, o, u, ps)); err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 }
@@ -480,42 +484,42 @@ func (h *AuthorizationHandler) handleUpdateAuthorization(w http.ResponseWriter, 
 	req, err := decodeUpdateAuthorizationRequest(ctx, r)
 	if err != nil {
 		h.Logger.Info("failed to decode request", zap.String("handler", "updateAuthorization"), zap.Error(err))
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	a, err := h.AuthorizationService.FindAuthorizationByID(ctx, req.ID)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	a, err = h.AuthorizationService.UpdateAuthorization(ctx, a.ID, req.AuthorizationUpdate)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	o, err := h.OrganizationService.FindOrganizationByID(ctx, a.OrgID)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	u, err := h.UserService.FindUserByID(ctx, a.UserID)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	ps, err := newPermissionsResponse(ctx, a.Permissions, h.LookupService)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newAuthResponse(a, o, u, ps)); err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 }
@@ -558,13 +562,13 @@ func (h *AuthorizationHandler) handleDeleteAuthorization(w http.ResponseWriter, 
 	req, err := decodeDeleteAuthorizationRequest(ctx, r)
 	if err != nil {
 		h.Logger.Info("failed to decode request", zap.String("handler", "deleteAuthorization"), zap.Error(err))
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	if err := h.AuthorizationService.DeleteAuthorization(ctx, req.ID); err != nil {
 		// Don't log here, it should already be handled by the service
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 

--- a/http/auth_test.go
+++ b/http/auth_test.go
@@ -323,6 +323,7 @@ func TestService_handleGetAuthorizations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authorizationBackend := NewMockAuthorizationBackend()
+			authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
 			authorizationBackend.AuthorizationService = tt.fields.AuthorizationService
 			authorizationBackend.UserService = tt.fields.UserService
 			authorizationBackend.OrganizationService = tt.fields.OrganizationService
@@ -505,6 +506,7 @@ func TestService_handleGetAuthorization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authorizationBackend := NewMockAuthorizationBackend()
+			authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
 			authorizationBackend.AuthorizationService = tt.fields.AuthorizationService
 			authorizationBackend.UserService = tt.fields.UserService
 			authorizationBackend.OrganizationService = tt.fields.OrganizationService
@@ -682,6 +684,7 @@ func TestService_handlePostAuthorization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authorizationBackend := NewMockAuthorizationBackend()
+			authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
 			authorizationBackend.AuthorizationService = tt.fields.AuthorizationService
 			authorizationBackend.UserService = tt.fields.UserService
 			authorizationBackend.OrganizationService = tt.fields.OrganizationService
@@ -795,6 +798,7 @@ func TestService_handleDeleteAuthorization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authorizationBackend := NewMockAuthorizationBackend()
+			authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
 			authorizationBackend.AuthorizationService = tt.fields.AuthorizationService
 			authorizationBackend.UserService = tt.fields.UserService
 			authorizationBackend.OrganizationService = tt.fields.OrganizationService
@@ -881,6 +885,7 @@ func initAuthorizationService(f platformtesting.AuthorizationFields, t *testing.
 	}
 
 	authorizationBackend := NewMockAuthorizationBackend()
+	authorizationBackend.HTTPErrorHandler = ErrorHandler(0)
 	authorizationBackend.AuthorizationService = svc
 	authorizationBackend.UserService = svc
 	authorizationBackend.OrganizationService = svc
@@ -897,7 +902,7 @@ func initAuthorizationService(f platformtesting.AuthorizationFields, t *testing.
 	}
 
 	authZ := NewAuthorizationHandler(authorizationBackend)
-	authN := NewAuthenticationHandler()
+	authN := NewAuthenticationHandler(ErrorHandler(0))
 	authN.AuthorizationService = svc
 	authN.Handler = authZ
 

--- a/http/authentication_test.go
+++ b/http/authentication_test.go
@@ -122,7 +122,7 @@ func TestAuthenticationHandler(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			h := platformhttp.NewAuthenticationHandler()
+			h := platformhttp.NewAuthenticationHandler(platformhttp.ErrorHandler(0))
 			h.AuthorizationService = tt.fields.AuthorizationService
 			h.SessionService = tt.fields.SessionService
 			h.Handler = handler
@@ -275,7 +275,7 @@ func TestAuthenticationHandler_NoAuthRoutes(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			h := platformhttp.NewAuthenticationHandler()
+			h := platformhttp.NewAuthenticationHandler(platformhttp.ErrorHandler(0))
 			h.AuthorizationService = mock.NewAuthorizationService()
 			h.SessionService = mock.NewSessionService()
 			h.Handler = handler

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -317,6 +317,7 @@ func TestService_handleGetBucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bucketBackend := NewMockBucketBackend()
+			bucketBackend.HTTPErrorHandler = ErrorHandler(0)
 			bucketBackend.BucketService = tt.fields.BucketService
 			h := NewBucketHandler(bucketBackend)
 
@@ -527,6 +528,7 @@ func TestService_handleDeleteBucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bucketBackend := NewMockBucketBackend()
+			bucketBackend.HTTPErrorHandler = ErrorHandler(0)
 			bucketBackend.BucketService = tt.fields.BucketService
 			h := NewBucketHandler(bucketBackend)
 
@@ -826,6 +828,7 @@ func TestService_handlePatchBucket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bucketBackend := NewMockBucketBackend()
+			bucketBackend.HTTPErrorHandler = ErrorHandler(0)
 			bucketBackend.BucketService = tt.fields.BucketService
 			h := NewBucketHandler(bucketBackend)
 
@@ -1085,6 +1088,7 @@ func initBucketService(f platformtesting.BucketFields, t *testing.T) (platform.B
 	}
 
 	bucketBackend := NewMockBucketBackend()
+	bucketBackend.HTTPErrorHandler = ErrorHandler(0)
 	bucketBackend.BucketService = svc
 	bucketBackend.OrganizationService = svc
 	handler := NewBucketHandler(bucketBackend)

--- a/http/chronograf_handler.go
+++ b/http/chronograf_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/NYTimes/gziphandler"
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/chronograf/server"
 	"github.com/julienschmidt/httprouter"
 )
@@ -15,9 +16,9 @@ type ChronografHandler struct {
 }
 
 // NewChronografHandler is the constructor an chronograf handler.
-func NewChronografHandler(s *server.Service) *ChronografHandler {
+func NewChronografHandler(s *server.Service, he influxdb.HTTPErrorHandler) *ChronografHandler {
 	h := &ChronografHandler{
-		Router:  NewRouter(),
+		Router:  NewRouter(he),
 		Service: s,
 	}
 	/* API */

--- a/http/dashboard_test.go
+++ b/http/dashboard_test.go
@@ -332,6 +332,7 @@ func TestService_handleGetDashboards(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.LabelService = tt.fields.LabelService
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(dashboardBackend)
@@ -487,6 +488,7 @@ func TestService_handleGetDashboard(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(dashboardBackend)
 
@@ -622,6 +624,7 @@ func TestService_handlePostDashboard(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(dashboardBackend)
 
@@ -717,6 +720,7 @@ func TestService_handleDeleteDashboard(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(dashboardBackend)
 
@@ -900,6 +904,7 @@ func TestService_handlePatchDashboard(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(dashboardBackend)
 
@@ -1080,6 +1085,7 @@ func TestService_handlePostDashboardCell(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(dashboardBackend)
 			buf := new(bytes.Buffer)
@@ -1163,6 +1169,7 @@ func TestService_handleDeleteDashboardCell(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(dashboardBackend)
 
@@ -1277,6 +1284,7 @@ func TestService_handlePatchDashboardCell(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.DashboardService = tt.fields.DashboardService
 			h := NewDashboardHandler(dashboardBackend)
 
@@ -1371,6 +1379,7 @@ func initDashboardService(f platformtesting.DashboardFields, t *testing.T) (plat
 	}
 
 	dashboardBackend := NewMockDashboardBackend()
+	dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 	dashboardBackend.DashboardService = svc
 	h := NewDashboardHandler(dashboardBackend)
 	server := httptest.NewServer(h)
@@ -1455,6 +1464,7 @@ func TestService_handlePostDashboardLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dashboardBackend := NewMockDashboardBackend()
+			dashboardBackend.HTTPErrorHandler = ErrorHandler(0)
 			dashboardBackend.LabelService = tt.fields.LabelService
 			h := NewDashboardHandler(dashboardBackend)
 

--- a/http/document_test.go
+++ b/http/document_test.go
@@ -291,6 +291,7 @@ func TestService_handleDeleteDocumentLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend()
+			documentBackend.HTTPErrorHandler = ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			documentBackend.LabelService = tt.fields.LabelService
 			h := NewDocumentHandler(documentBackend)
@@ -476,6 +477,7 @@ func TestService_handlePostDocumentLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend()
+			documentBackend.HTTPErrorHandler = ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			documentBackend.LabelService = tt.fields.LabelService
 			h := NewDocumentHandler(documentBackend)
@@ -580,6 +582,7 @@ func TestService_handleGetDocumentLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend()
+			documentBackend.HTTPErrorHandler = ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			documentBackend.LabelService = tt.fields.LabelService
 			h := NewDocumentHandler(documentBackend)
@@ -703,6 +706,7 @@ func TestService_handleGetDocuments(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend()
+			documentBackend.HTTPErrorHandler = ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			h := NewDocumentHandler(documentBackend)
 			r := httptest.NewRequest("GET", "http://any.url", nil)
@@ -902,6 +906,7 @@ func TestService_handlePostDocuments(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			documentBackend := NewMockDocumentBackend()
+			documentBackend.HTTPErrorHandler = ErrorHandler(0)
 			documentBackend.DocumentService = tt.fields.DocumentService
 			documentBackend.LabelService = tt.fields.LabelService
 			h := NewDocumentHandler(documentBackend)

--- a/http/errors.go
+++ b/http/errors.go
@@ -76,11 +76,14 @@ func CheckError(resp *http.Response) (err error) {
 	return pe
 }
 
-// EncodeError encodes err with the appropriate status code and format,
+// ErrorHandler is the error handler in http package.
+type ErrorHandler int
+
+// HandleHTTPError encodes err with the appropriate status code and format,
 // sets the X-Platform-Error-Code headers on the response.
 // We're no longer using X-Influx-Error and X-Influx-Reference.
 // and sets the response status to the corresponding status code.
-func EncodeError(ctx context.Context, err error, w http.ResponseWriter) {
+func (h ErrorHandler) HandleHTTPError(ctx context.Context, err error, w http.ResponseWriter) {
 	if err == nil {
 		return
 	}
@@ -112,8 +115,8 @@ func EncodeError(ctx context.Context, err error, w http.ResponseWriter) {
 }
 
 // UnauthorizedError encodes a error message and status code for unauthorized access.
-func UnauthorizedError(ctx context.Context, w http.ResponseWriter) {
-	EncodeError(ctx, &platform.Error{
+func UnauthorizedError(ctx context.Context, h platform.HTTPErrorHandler, w http.ResponseWriter) {
+	h.HandleHTTPError(ctx, &platform.Error{
 		Code: platform.EUnauthorized,
 		Msg:  "unauthorized access",
 	}, w)

--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -15,7 +15,7 @@ func TestEncodeError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	http.EncodeError(ctx, nil, w)
+	http.ErrorHandler(0).HandleHTTPError(ctx, nil, w)
 
 	if w.Code != 200 {
 		t.Errorf("expected status code 200, got: %d", w.Code)
@@ -28,7 +28,7 @@ func TestEncodeErrorWithError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 
-	http.EncodeError(ctx, err, w)
+	http.ErrorHandler(0).HandleHTTPError(ctx, err, w)
 
 	if w.Code != 500 {
 		t.Errorf("expected status code 500, got: %d", w.Code)

--- a/http/label_test.go
+++ b/http/label_test.go
@@ -108,7 +108,7 @@ func TestService_handleGetLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(tt.fields.LabelService)
+			h := NewLabelHandler(tt.fields.LabelService, ErrorHandler(0))
 
 			r := httptest.NewRequest("GET", "http://any.url", nil)
 
@@ -216,7 +216,7 @@ func TestService_handleGetLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(tt.fields.LabelService)
+			h := NewLabelHandler(tt.fields.LabelService, ErrorHandler(0))
 
 			r := httptest.NewRequest("GET", "http://any.url", nil)
 
@@ -311,7 +311,7 @@ func TestService_handlePostLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(tt.fields.LabelService)
+			h := NewLabelHandler(tt.fields.LabelService, ErrorHandler(0))
 
 			l, err := json.Marshal(tt.args.label)
 			if err != nil {
@@ -402,7 +402,7 @@ func TestService_handleDeleteLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(tt.fields.LabelService)
+			h := NewLabelHandler(tt.fields.LabelService, ErrorHandler(0))
 
 			r := httptest.NewRequest("GET", "http://any.url", nil)
 
@@ -541,7 +541,7 @@ func TestService_handlePatchLabel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewLabelHandler(tt.fields.LabelService)
+			h := NewLabelHandler(tt.fields.LabelService, ErrorHandler(0))
 
 			upd := platform.LabelUpdate{}
 			if len(tt.args.properties) > 0 {

--- a/http/onboarding_test.go
+++ b/http/onboarding_test.go
@@ -37,6 +37,7 @@ func initOnboardingService(f platformtesting.OnboardingFields, t *testing.T) (pl
 	}
 
 	setupBackend := NewMockSetupBackend()
+	setupBackend.HTTPErrorHandler = ErrorHandler(0)
 	setupBackend.OnboardingService = svc
 	handler := NewSetupHandler(setupBackend)
 	server := httptest.NewServer(handler)

--- a/http/org_test.go
+++ b/http/org_test.go
@@ -49,6 +49,7 @@ func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T)
 	}
 
 	orgBackend := NewMockOrgBackend()
+	orgBackend.HTTPErrorHandler = ErrorHandler(0)
 	orgBackend.OrganizationService = svc
 	handler := NewOrgHandler(orgBackend)
 	server := httptest.NewServer(handler)
@@ -144,6 +145,7 @@ func TestSecretService_handleGetSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			orgBackend := NewMockOrgBackend()
+			orgBackend.HTTPErrorHandler = ErrorHandler(0)
 			orgBackend.SecretService = tt.fields.SecretService
 			h := NewOrgHandler(orgBackend)
 
@@ -219,6 +221,7 @@ func TestSecretService_handlePatchSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			orgBackend := NewMockOrgBackend()
+			orgBackend.HTTPErrorHandler = ErrorHandler(0)
 			orgBackend.SecretService = tt.fields.SecretService
 			h := NewOrgHandler(orgBackend)
 
@@ -300,6 +303,7 @@ func TestSecretService_handleDeleteSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			orgBackend := NewMockOrgBackend()
+			orgBackend.HTTPErrorHandler = ErrorHandler(0)
 			orgBackend.SecretService = tt.fields.SecretService
 			h := NewOrgHandler(orgBackend)
 

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -24,7 +24,7 @@ func setCORSResponseHeaders(w http.ResponseWriter, r *http.Request) {
 
 // NewPlatformHandler returns a platform handler that serves the API and associated assets.
 func NewPlatformHandler(b *APIBackend) *PlatformHandler {
-	h := NewAuthenticationHandler()
+	h := NewAuthenticationHandler(b.HTTPErrorHandler)
 	h.Handler = NewAPIHandler(b)
 	h.AuthorizationService = b.AuthorizationService
 	h.SessionService = b.SessionService

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -229,7 +229,9 @@ func TestFluxHandler_postFluxAST(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := &FluxHandler{}
+			h := &FluxHandler{
+				HTTPErrorHandler: ErrorHandler(0),
+			}
 			h.postFluxAST(tt.w, tt.r)
 			if got := tt.w.Body.String(); got != tt.want {
 				t.Errorf("http.postFluxAST = got\n%vwant\n%v", got, tt.want)
@@ -293,6 +295,7 @@ var _ metric.EventRecorder = noopEventRecorder{}
 func TestFluxHandler_PostQuery_Errors(t *testing.T) {
 	i := inmem.NewService()
 	b := &FluxBackend{
+		HTTPErrorHandler:    ErrorHandler(0),
 		Logger:              zaptest.NewLogger(t),
 		QueryEventRecorder:  noopEventRecorder{},
 		OrganizationService: i,

--- a/http/router.go
+++ b/http/router.go
@@ -15,27 +15,32 @@ import (
 )
 
 // NewRouter returns a new router with a 404 handler, a 405 handler, and a panic handler.
-func NewRouter() *httprouter.Router {
+func NewRouter(h platform.HTTPErrorHandler) *httprouter.Router {
+	b := baseHandler{HTTPErrorHandler: h}
 	router := httprouter.New()
-	router.NotFound = http.HandlerFunc(notFoundHandler)
-	router.MethodNotAllowed = http.HandlerFunc(methodNotAllowedHandler)
-	router.PanicHandler = panicHandler
+	router.NotFound = http.HandlerFunc(b.notFound)
+	router.MethodNotAllowed = http.HandlerFunc(b.methodNotAllowed)
+	router.PanicHandler = b.panic
 	return router
 }
 
-// notFoundHandler represents a 404 handler that return a JSON response.
-func notFoundHandler(w http.ResponseWriter, r *http.Request) {
+type baseHandler struct {
+	platform.HTTPErrorHandler
+}
+
+// notFound represents a 404 handler that return a JSON response.
+func (h baseHandler) notFound(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	pe := &platform.Error{
 		Code: platform.ENotFound,
 		Msg:  "path not found",
 	}
 
-	EncodeError(ctx, pe, w)
+	h.HandleHTTPError(ctx, pe, w)
 }
 
-// methodNotAllowedHandler represents a 405 handler that return a JSON response.
-func methodNotAllowedHandler(w http.ResponseWriter, r *http.Request) {
+// methodNotAllowed represents a 405 handler that return a JSON response.
+func (h baseHandler) methodNotAllowed(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	allow := w.Header().Get("Allow")
 	pe := &platform.Error{
@@ -43,12 +48,12 @@ func methodNotAllowedHandler(w http.ResponseWriter, r *http.Request) {
 		Msg:  fmt.Sprintf("allow: %s", allow),
 	}
 
-	EncodeError(ctx, pe, w)
+	h.HandleHTTPError(ctx, pe, w)
 }
 
-// panicHandler handles panics recovered from http handlers.
+// panic handles panics recovered from http handlers.
 // It returns a json response with http status code 500 and the recovered error message.
-func panicHandler(w http.ResponseWriter, r *http.Request, rcv interface{}) {
+func (h baseHandler) panic(w http.ResponseWriter, r *http.Request, rcv interface{}) {
 	ctx := r.Context()
 	pe := &platform.Error{
 		Code: platform.EInternal,
@@ -62,7 +67,7 @@ func panicHandler(w http.ResponseWriter, r *http.Request, rcv interface{}) {
 		entry.Write(zap.Error(pe.Err))
 	}
 
-	EncodeError(ctx, pe, w)
+	h.HandleHTTPError(ctx, pe, w)
 }
 
 var panicLogger *zap.Logger

--- a/http/router_test.go
+++ b/http/router_test.go
@@ -82,7 +82,7 @@ func TestRouter_NotFound(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			router := NewRouter()
+			router := NewRouter(ErrorHandler(0))
 			router.HandlerFunc(tt.fields.method, tt.fields.path, tt.fields.handlerFn)
 
 			r := httptest.NewRequest(tt.args.method, tt.args.path, nil)
@@ -190,7 +190,7 @@ func TestRouter_Panic(t *testing.T) {
 			tw := newTestLogWriter(t)
 			panicLogger = zaptest.NewLogger(tw)
 
-			router := NewRouter()
+			router := NewRouter(ErrorHandler(0))
 			router.HandlerFunc(tt.fields.method, tt.fields.path, tt.fields.handlerFn)
 
 			r := httptest.NewRequest(tt.args.method, tt.args.path, nil)
@@ -289,7 +289,7 @@ func TestRouter_MethodNotAllowed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			router := NewRouter()
+			router := NewRouter(ErrorHandler(0))
 			router.HandlerFunc(tt.fields.method, tt.fields.path, tt.fields.handlerFn)
 
 			r := httptest.NewRequest(tt.args.method, tt.args.path, nil)

--- a/http/scraper_service_test.go
+++ b/http/scraper_service_test.go
@@ -207,6 +207,7 @@ func TestService_handleGetScraperTargets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend()
+			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.ScraperTargetStoreService
 			scraperBackend.OrganizationService = tt.fields.OrganizationService
 			scraperBackend.BucketService = tt.fields.BucketService
@@ -343,6 +344,7 @@ func TestService_handleGetScraperTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend()
+			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.ScraperTargetStoreService
 			scraperBackend.OrganizationService = tt.fields.OrganizationService
 			scraperBackend.BucketService = tt.fields.BucketService
@@ -450,6 +452,7 @@ func TestService_handleDeleteScraperTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend()
+			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.Service
 			h := NewScraperHandler(scraperBackend)
 
@@ -580,6 +583,7 @@ func TestService_handlePostScraperTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend()
+			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.ScraperTargetStoreService
 			scraperBackend.OrganizationService = tt.fields.OrganizationService
 			scraperBackend.BucketService = tt.fields.BucketService
@@ -757,6 +761,7 @@ func TestService_handlePatchScraperTarget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scraperBackend := NewMockScraperBackend()
+			scraperBackend.HTTPErrorHandler = ErrorHandler(0)
 			scraperBackend.ScraperStorageService = tt.fields.ScraperTargetStoreService
 			scraperBackend.OrganizationService = tt.fields.OrganizationService
 			scraperBackend.BucketService = tt.fields.BucketService
@@ -832,6 +837,7 @@ func initScraperService(f platformtesting.TargetFields, t *testing.T) (influxdb.
 	}
 
 	scraperBackend := NewMockScraperBackend()
+	scraperBackend.HTTPErrorHandler = ErrorHandler(0)
 	scraperBackend.ScraperStorageService = svc
 	scraperBackend.OrganizationService = svc
 	scraperBackend.BucketService = &mock.BucketService{

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -391,6 +391,7 @@ func TestTaskHandler_handleGetTasks(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			taskBackend := NewMockTaskBackend(t)
+			taskBackend.HTTPErrorHandler = ErrorHandler(0)
 			taskBackend.TaskService = tt.fields.taskService
 			taskBackend.LabelService = tt.fields.labelService
 			h := NewTaskHandler(taskBackend)
@@ -502,6 +503,7 @@ func TestTaskHandler_handlePostTasks(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			taskBackend := NewMockTaskBackend(t)
+			taskBackend.HTTPErrorHandler = ErrorHandler(0)
 			taskBackend.TaskService = tt.fields.taskService
 			h := NewTaskHandler(taskBackend)
 			h.handlePostTask(w, r)
@@ -611,6 +613,7 @@ func TestTaskHandler_handleGetRun(t *testing.T) {
 			r = r.WithContext(pcontext.SetAuthorizer(r.Context(), &platform.Authorization{Permissions: platform.OperPermissions()}))
 			w := httptest.NewRecorder()
 			taskBackend := NewMockTaskBackend(t)
+			taskBackend.HTTPErrorHandler = ErrorHandler(0)
 			taskBackend.TaskService = tt.fields.taskService
 			h := NewTaskHandler(taskBackend)
 			h.handleGetRun(w, r)
@@ -724,6 +727,7 @@ func TestTaskHandler_handleGetRuns(t *testing.T) {
 			r = r.WithContext(pcontext.SetAuthorizer(r.Context(), &platform.Authorization{Permissions: platform.OperPermissions()}))
 			w := httptest.NewRecorder()
 			taskBackend := NewMockTaskBackend(t)
+			taskBackend.HTTPErrorHandler = ErrorHandler(0)
 			taskBackend.TaskService = tt.fields.taskService
 			h := NewTaskHandler(taskBackend)
 			h.handleGetRuns(w, r)
@@ -754,6 +758,7 @@ func TestTaskHandler_NotFoundStatus(t *testing.T) {
 
 	im := inmem.NewService()
 	taskBackend := NewMockTaskBackend(t)
+	taskBackend.HTTPErrorHandler = ErrorHandler(0)
 	h := NewTaskHandler(taskBackend)
 	h.UserResourceMappingService = im
 	h.LabelService = im
@@ -1283,7 +1288,8 @@ func TestTaskHandler_Sessions(t *testing.T) {
 
 	newHandler := func(t *testing.T, ts *mock.TaskService) *TaskHandler {
 		return NewTaskHandler(&TaskBackend{
-			Logger: zaptest.NewLogger(t),
+			HTTPErrorHandler: ErrorHandler(0),
+			Logger:           zaptest.NewLogger(t),
 
 			TaskService:                ts,
 			AuthorizationService:       i,

--- a/http/task_test.go
+++ b/http/task_test.go
@@ -28,9 +28,10 @@ func TestTaskService(t *testing.T) {
 				t.Fatalf("error initializing urm service: %v", err)
 			}
 
-			h := http.NewAuthenticationHandler()
+			h := http.NewAuthenticationHandler(http.ErrorHandler(0))
 			h.AuthorizationService = service
 			th := http.NewTaskHandler(&http.TaskBackend{
+				HTTPErrorHandler:           http.ErrorHandler(0),
 				Logger:                     zaptest.NewLogger(t).With(zap.String("handler", "task")),
 				TaskService:                service,
 				AuthorizationService:       service,

--- a/http/telegraf.go
+++ b/http/telegraf.go
@@ -18,6 +18,7 @@ import (
 // TelegrafBackend is all services and associated parameters required to construct
 // the TelegrafHandler.
 type TelegrafBackend struct {
+	platform.HTTPErrorHandler
 	Logger *zap.Logger
 
 	TelegrafService            platform.TelegrafConfigStore
@@ -30,7 +31,8 @@ type TelegrafBackend struct {
 // NewTelegrafBackend returns a new instance of TelegrafBackend.
 func NewTelegrafBackend(b *APIBackend) *TelegrafBackend {
 	return &TelegrafBackend{
-		Logger: b.Logger.With(zap.String("handler", "telegraf")),
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Logger:           b.Logger.With(zap.String("handler", "telegraf")),
 
 		TelegrafService:            b.TelegrafService,
 		UserResourceMappingService: b.UserResourceMappingService,
@@ -43,6 +45,7 @@ func NewTelegrafBackend(b *APIBackend) *TelegrafBackend {
 // TelegrafHandler is the handler for the telegraf service
 type TelegrafHandler struct {
 	*httprouter.Router
+	platform.HTTPErrorHandler
 	Logger *zap.Logger
 
 	TelegrafService            platform.TelegrafConfigStore
@@ -66,8 +69,9 @@ const (
 // NewTelegrafHandler returns a new instance of TelegrafHandler.
 func NewTelegrafHandler(b *TelegrafBackend) *TelegrafHandler {
 	h := &TelegrafHandler{
-		Router: NewRouter(),
-		Logger: b.Logger,
+		Router:           NewRouter(b.HTTPErrorHandler),
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Logger:           b.Logger,
 
 		TelegrafService:            b.TelegrafService,
 		UserResourceMappingService: b.UserResourceMappingService,
@@ -82,6 +86,7 @@ func NewTelegrafHandler(b *TelegrafBackend) *TelegrafHandler {
 	h.HandlerFunc("PUT", telegrafsIDPath, h.handlePutTelegraf)
 
 	memberBackend := MemberBackend{
+		HTTPErrorHandler:           b.HTTPErrorHandler,
 		Logger:                     b.Logger.With(zap.String("handler", "member")),
 		ResourceType:               platform.TelegrafsResourceType,
 		UserType:                   platform.Member,
@@ -93,6 +98,7 @@ func NewTelegrafHandler(b *TelegrafBackend) *TelegrafHandler {
 	h.HandlerFunc("DELETE", telegrafsIDMembersIDPath, newDeleteMemberHandler(memberBackend))
 
 	ownerBackend := MemberBackend{
+		HTTPErrorHandler:           b.HTTPErrorHandler,
 		Logger:                     b.Logger.With(zap.String("handler", "member")),
 		ResourceType:               platform.TelegrafsResourceType,
 		UserType:                   platform.Owner,
@@ -104,9 +110,10 @@ func NewTelegrafHandler(b *TelegrafBackend) *TelegrafHandler {
 	h.HandlerFunc("DELETE", telegrafsIDOwnersIDPath, newDeleteMemberHandler(ownerBackend))
 
 	labelBackend := &LabelBackend{
-		Logger:       b.Logger.With(zap.String("handler", "label")),
-		LabelService: b.LabelService,
-		ResourceType: platform.TelegrafsResourceType,
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Logger:           b.Logger.With(zap.String("handler", "label")),
+		LabelService:     b.LabelService,
+		ResourceType:     platform.TelegrafsResourceType,
 	}
 	h.HandlerFunc("GET", telegrafsIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", telegrafsIDLabelsPath, newPostLabelHandler(labelBackend))
@@ -232,12 +239,12 @@ func (h *TelegrafHandler) handleGetTelegrafs(w http.ResponseWriter, r *http.Requ
 	filter, err := decodeTelegrafConfigFilter(ctx, r)
 	if err != nil {
 		h.Logger.Debug("failed to decode request", zap.Error(err))
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 	tcs, _, err := h.TelegrafService.FindTelegrafConfigs(ctx, *filter)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 	if err := encodeResponse(ctx, w, http.StatusOK, newTelegrafResponses(ctx, tcs, h.LabelService)); err != nil {
@@ -250,12 +257,12 @@ func (h *TelegrafHandler) handleGetTelegraf(w http.ResponseWriter, r *http.Reque
 	ctx := r.Context()
 	id, err := decodeGetTelegrafRequest(ctx, r)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 	tc, err := h.TelegrafService.FindTelegrafConfigByID(ctx, id)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
@@ -271,7 +278,7 @@ func (h *TelegrafHandler) handleGetTelegraf(w http.ResponseWriter, r *http.Reque
 	case "application/json":
 		labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: tc.ID})
 		if err != nil {
-			EncodeError(ctx, err, w)
+			h.HandleHTTPError(ctx, err, w)
 			return
 		}
 
@@ -366,17 +373,17 @@ func (h *TelegrafHandler) handlePostTelegraf(w http.ResponseWriter, r *http.Requ
 	tc, err := decodePostTelegrafRequest(ctx, r)
 	if err != nil {
 		h.Logger.Debug("failed to decode request", zap.Error(err))
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 	auth, err := pctx.GetAuthorizer(ctx)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	if err := h.TelegrafService.CreateTelegrafConfig(ctx, tc, auth.GetUserID()); err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
@@ -392,24 +399,24 @@ func (h *TelegrafHandler) handlePutTelegraf(w http.ResponseWriter, r *http.Reque
 	tc, err := decodePutTelegrafRequest(ctx, r)
 	if err != nil {
 		h.Logger.Debug("failed to decode request", zap.Error(err))
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 	auth, err := pctx.GetAuthorizer(ctx)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	tc, err = h.TelegrafService.UpdateTelegrafConfig(ctx, tc.ID, tc, auth.GetUserID())
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: tc.ID})
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
@@ -423,12 +430,12 @@ func (h *TelegrafHandler) handleDeleteTelegraf(w http.ResponseWriter, r *http.Re
 	ctx := r.Context()
 	i, err := decodeGetTelegrafRequest(ctx, r)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	if err = h.TelegrafService.DeleteTelegrafConfig(ctx, i); err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 

--- a/http/usage_service.go
+++ b/http/usage_service.go
@@ -14,16 +14,16 @@ import (
 // UsageHandler represents an HTTP API handler for usages.
 type UsageHandler struct {
 	*httprouter.Router
-
+	platform.HTTPErrorHandler
 	Logger *zap.Logger
 
 	UsageService platform.UsageService
 }
 
 // NewUsageHandler returns a new instance of UsageHandler.
-func NewUsageHandler() *UsageHandler {
+func NewUsageHandler(he platform.HTTPErrorHandler) *UsageHandler {
 	h := &UsageHandler{
-		Router: NewRouter(),
+		Router: NewRouter(he),
 		Logger: zap.NewNop(),
 	}
 
@@ -37,13 +37,13 @@ func (h *UsageHandler) handleGetUsage(w http.ResponseWriter, r *http.Request) {
 
 	req, err := decodeGetUsageRequest(ctx, r)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	b, err := h.UsageService.GetUsage(ctx, req.filter)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 

--- a/http/user_resource_mapping_service.go
+++ b/http/user_resource_mapping_service.go
@@ -56,6 +56,7 @@ func newResourceUsersResponse(opts platform.FindOptions, f platform.UserResource
 // MemberBackend is all services and associated parameters required to construct
 // member handler.
 type MemberBackend struct {
+	platform.HTTPErrorHandler
 	Logger *zap.Logger
 
 	ResourceType platform.ResourceType
@@ -72,13 +73,13 @@ func newPostMemberHandler(b MemberBackend) http.HandlerFunc {
 
 		req, err := decodePostMemberRequest(ctx, r)
 		if err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 
 		user, err := b.UserService.FindUserByID(ctx, req.MemberID)
 		if err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 
@@ -90,12 +91,12 @@ func newPostMemberHandler(b MemberBackend) http.HandlerFunc {
 		}
 
 		if err := b.UserResourceMappingService.CreateUserResourceMapping(ctx, mapping); err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 
 		if err := encodeResponse(ctx, w, http.StatusCreated, newResourceUserResponse(user, b.UserType)); err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 	}
@@ -146,7 +147,7 @@ func newGetMembersHandler(b MemberBackend) http.HandlerFunc {
 
 		req, err := decodeGetMembersRequest(ctx, r)
 		if err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 
@@ -159,7 +160,7 @@ func newGetMembersHandler(b MemberBackend) http.HandlerFunc {
 		opts := platform.FindOptions{}
 		mappings, _, err := b.UserResourceMappingService.FindUserResourceMappings(ctx, filter)
 		if err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 
@@ -170,7 +171,7 @@ func newGetMembersHandler(b MemberBackend) http.HandlerFunc {
 			}
 			user, err := b.UserService.FindUserByID(ctx, m.UserID)
 			if err != nil {
-				EncodeError(ctx, err, w)
+				b.HandleHTTPError(ctx, err, w)
 				return
 			}
 
@@ -178,7 +179,7 @@ func newGetMembersHandler(b MemberBackend) http.HandlerFunc {
 		}
 
 		if err := encodeResponse(ctx, w, http.StatusOK, newResourceUsersResponse(opts, filter, users)); err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 	}
@@ -218,12 +219,12 @@ func newDeleteMemberHandler(b MemberBackend) http.HandlerFunc {
 
 		req, err := decodeDeleteMemberRequest(ctx, r)
 		if err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 
 		if err := b.UserResourceMappingService.DeleteUserResourceMapping(ctx, req.ResourceID, req.MemberID); err != nil {
-			EncodeError(ctx, err, w)
+			b.HandleHTTPError(ctx, err, w)
 			return
 		}
 

--- a/http/user_test.go
+++ b/http/user_test.go
@@ -35,6 +35,7 @@ func initUserService(f platformtesting.UserFields, t *testing.T) (platform.UserS
 	}
 
 	userBackend := NewMockUserBackend()
+	userBackend.HTTPErrorHandler = ErrorHandler(0)
 	userBackend.UserService = svc
 	handler := NewUserHandler(userBackend)
 	server := httptest.NewServer(handler)

--- a/http/variable_service.go
+++ b/http/variable_service.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"path"
+
 	platform "github.com/influxdata/influxdb"
 	"github.com/julienschmidt/httprouter"
 	"go.uber.org/zap"
-	"net/http"
-	"path"
 )
 
 const (
@@ -19,6 +20,7 @@ const (
 // VariableBackend is all services and associated parameters required to construct
 // the VariableHandler.
 type VariableBackend struct {
+	platform.HTTPErrorHandler
 	Logger          *zap.Logger
 	VariableService platform.VariableService
 	LabelService    platform.LabelService
@@ -27,9 +29,10 @@ type VariableBackend struct {
 // NewVariableBackend creates a backend used by the variable handler.
 func NewVariableBackend(b *APIBackend) *VariableBackend {
 	return &VariableBackend{
-		Logger:          b.Logger.With(zap.String("handler", "variable")),
-		VariableService: b.VariableService,
-		LabelService:    b.LabelService,
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Logger:           b.Logger.With(zap.String("handler", "variable")),
+		VariableService:  b.VariableService,
+		LabelService:     b.LabelService,
 	}
 }
 
@@ -37,6 +40,7 @@ func NewVariableBackend(b *APIBackend) *VariableBackend {
 type VariableHandler struct {
 	*httprouter.Router
 
+	platform.HTTPErrorHandler
 	Logger *zap.Logger
 
 	VariableService platform.VariableService
@@ -46,8 +50,9 @@ type VariableHandler struct {
 // NewVariableHandler creates a new VariableHandler
 func NewVariableHandler(b *VariableBackend) *VariableHandler {
 	h := &VariableHandler{
-		Router: NewRouter(),
-		Logger: b.Logger,
+		Router:           NewRouter(b.HTTPErrorHandler),
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Logger:           b.Logger,
 
 		VariableService: b.VariableService,
 		LabelService:    b.LabelService,
@@ -65,9 +70,10 @@ func NewVariableHandler(b *VariableBackend) *VariableHandler {
 	h.HandlerFunc("DELETE", entityPath, h.handleDeleteVariable)
 
 	labelBackend := &LabelBackend{
-		Logger:       b.Logger.With(zap.String("handler", "label")),
-		LabelService: b.LabelService,
-		ResourceType: platform.DashboardsResourceType,
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Logger:           b.Logger.With(zap.String("handler", "label")),
+		LabelService:     b.LabelService,
+		ResourceType:     platform.DashboardsResourceType,
 	}
 	h.HandlerFunc("GET", entityLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", entityLabelsPath, newPostLabelHandler(labelBackend))
@@ -140,13 +146,13 @@ func (h *VariableHandler) handleGetVariables(w http.ResponseWriter, r *http.Requ
 
 	req, err := decodeGetVariablesRequest(ctx, r)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	variables, err := h.VariableService.FindVariables(ctx, req.filter, req.opts)
 	if err != nil {
-		EncodeError(ctx, &platform.Error{
+		h.HandleHTTPError(ctx, &platform.Error{
 			Code: platform.EInternal,
 			Msg:  "could not read variables",
 			Err:  err,
@@ -184,19 +190,19 @@ func (h *VariableHandler) handleGetVariable(w http.ResponseWriter, r *http.Reque
 
 	id, err := requestVariableID(ctx)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	variable, err := h.VariableService.FindVariableByID(ctx, id)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: variable.ID})
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
@@ -240,13 +246,13 @@ func (h *VariableHandler) handlePostVariable(w http.ResponseWriter, r *http.Requ
 	ctx := r.Context()
 	req, err := decodePostVariableRequest(ctx, r)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	err = h.VariableService.CreateVariable(ctx, req.variable)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 	if err := encodeResponse(ctx, w, http.StatusCreated, newVariableResponse(req.variable, []*platform.Label{})); err != nil {
@@ -293,19 +299,19 @@ func (h *VariableHandler) handlePatchVariable(w http.ResponseWriter, r *http.Req
 
 	req, err := decodePatchVariableRequest(ctx, r)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	variable, err := h.VariableService.UpdateVariable(ctx, req.id, req.variableUpdate)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: variable.ID})
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
@@ -361,19 +367,19 @@ func (h *VariableHandler) handlePutVariable(w http.ResponseWriter, r *http.Reque
 
 	req, err := decodePutVariableRequest(ctx, r)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	err = h.VariableService.ReplaceVariable(ctx, req.variable)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	labels, err := h.LabelService.FindResourceLabels(ctx, platform.LabelMappingFilter{ResourceID: req.variable.ID})
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
@@ -422,13 +428,13 @@ func (h *VariableHandler) handleDeleteVariable(w http.ResponseWriter, r *http.Re
 
 	id, err := requestVariableID(ctx)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 
 	err = h.VariableService.DeleteVariable(ctx, id)
 	if err != nil {
-		EncodeError(ctx, err, w)
+		h.HandleHTTPError(ctx, err, w)
 		return
 	}
 

--- a/http/variable_test.go
+++ b/http/variable_test.go
@@ -296,6 +296,7 @@ func TestVariableService_handleGetVariables(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend()
+			variableBackend.HTTPErrorHandler = ErrorHandler(0)
 			variableBackend.LabelService = tt.fields.LabelService
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(variableBackend)
@@ -427,6 +428,7 @@ func TestVariableService_handleGetVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend()
+			variableBackend.HTTPErrorHandler = ErrorHandler(0)
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(variableBackend)
 			r := httptest.NewRequest("GET", "http://howdy.tld", nil)
@@ -565,6 +567,7 @@ func TestVariableService_handlePostVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend()
+			variableBackend.HTTPErrorHandler = ErrorHandler(0)
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(variableBackend)
 			r := httptest.NewRequest("GET", "http://howdy.tld", bytes.NewReader([]byte(tt.args.variable)))
@@ -664,6 +667,7 @@ func TestVariableService_handlePatchVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend()
+			variableBackend.HTTPErrorHandler = ErrorHandler(0)
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(variableBackend)
 			r := httptest.NewRequest("GET", "http://howdy.tld", bytes.NewReader([]byte(tt.args.update)))
@@ -757,6 +761,7 @@ func TestVariableService_handleDeleteVariable(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend()
+			variableBackend.HTTPErrorHandler = ErrorHandler(0)
 			variableBackend.VariableService = tt.fields.VariableService
 			h := NewVariableHandler(variableBackend)
 			r := httptest.NewRequest("GET", "http://howdy.tld", nil)
@@ -849,6 +854,7 @@ func TestService_handlePostVariableLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			variableBackend := NewMockVariableBackend()
+			variableBackend.HTTPErrorHandler = ErrorHandler(0)
 			variableBackend.LabelService = tt.fields.LabelService
 			h := NewVariableHandler(variableBackend)
 
@@ -900,6 +906,7 @@ func initVariableService(f platformtesting.VariableFields, t *testing.T) (platfo
 	}
 
 	variableBackend := NewMockVariableBackend()
+	variableBackend.HTTPErrorHandler = ErrorHandler(0)
 	variableBackend.VariableService = svc
 	handler := NewVariableHandler(variableBackend)
 	server := httptest.NewServer(handler)


### PR DESCRIPTION
part of issue https://github.com/influxdata/idpe/issues/3795

convert http.ErrorEncode to an interface. So we can add more handle procedure in cloud

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
