### PR TITLE
Display relevant tokens based on permissions in token dropdown

### DIFF
--- a/ui/src/dataExplorer/components/SaveAsTaskForm.tsx
+++ b/ui/src/dataExplorer/components/SaveAsTaskForm.tsx
@@ -120,8 +120,9 @@ class SaveAsTaskForm extends PureComponent<Props & WithRouterProps> {
       readBucketName = draftQueries[activeQueryIndex].builderConfig.buckets[0]
     } else {
       const text = draftQueries[activeQueryIndex].text
-      const res = text.split('bucket:')
-      readBucketName = res[1].slice(2, 3)
+      const splitBucket = text.split('bucket:')
+      const splitQuotes = splitBucket[1].split('"')
+      readBucketName = splitQuotes[1]
     }
     const writeBucketName = this.props.taskOptions.toBucketName
 

--- a/ui/src/tasks/components/TaskTokenDropdown.tsx
+++ b/ui/src/tasks/components/TaskTokenDropdown.tsx
@@ -15,21 +15,43 @@ interface Props {
 
 export default class TaskTokenDropdown extends PureComponent<Props> {
   public render() {
-    const {tokens, selectedToken, onTokenChange} = this.props
+    const {onTokenChange} = this.props
 
     return (
       <Dropdown
-        selectedID={selectedToken.id}
+        selectedID={this.selectedID}
         buttonColor={ComponentColor.Primary}
         buttonSize={ComponentSize.Small}
         onChange={onTokenChange}
       >
-        {tokens.map(t => (
-          <Dropdown.Item id={t.id} key={t.id} value={t}>
-            {t.description || 'Name this token'}
-          </Dropdown.Item>
-        ))}
+        {this.dropdownTokens}
       </Dropdown>
     )
+  }
+  private get dropdownTokens(): JSX.Element[] {
+    const {tokens} = this.props
+    if (tokens.length > 0) {
+      return tokens.map(t => (
+        <Dropdown.Item id={t.id} key={t.id} value={t}>
+          {t.description || 'Name this token'}
+        </Dropdown.Item>
+      ))
+    }
+    return [
+      <Dropdown.Item id="no-tokens" key="no-tokens" value="no-tokens">
+        {'You don’t have any tokens with appropriate permissions for this use'}
+      </Dropdown.Item>,
+    ]
+  }
+
+  private get selectedID(): string {
+    const {selectedToken, tokens} = this.props
+
+    if (tokens.length > 0) {
+      if (selectedToken) {
+        return selectedToken.id
+      }
+    }
+    return 'no-tokens'
   }
 }

--- a/ui/src/tasks/components/TaskTokenDropdown.tsx
+++ b/ui/src/tasks/components/TaskTokenDropdown.tsx
@@ -30,7 +30,7 @@ export default class TaskTokenDropdown extends PureComponent<Props> {
   }
   private get dropdownTokens(): JSX.Element[] {
     const {tokens} = this.props
-    if (tokens.length > 0) {
+    if (tokens.length) {
       return tokens.map(t => (
         <Dropdown.Item id={t.id} key={t.id} value={t}>
           {t.description || 'Name this token'}
@@ -39,7 +39,7 @@ export default class TaskTokenDropdown extends PureComponent<Props> {
     }
     return [
       <Dropdown.Item id="no-tokens" key="no-tokens" value="no-tokens">
-        {'You don’t have any tokens with appropriate permissions for this use'}
+        You don’t have any tokens with appropriate permissions for this use
       </Dropdown.Item>,
     ]
   }
@@ -47,10 +47,8 @@ export default class TaskTokenDropdown extends PureComponent<Props> {
   private get selectedID(): string {
     const {selectedToken, tokens} = this.props
 
-    if (tokens.length > 0) {
-      if (selectedToken) {
-        return selectedToken.id
-      }
+    if (tokens.length && selectedToken) {
+      return selectedToken.id
     }
     return 'no-tokens'
   }


### PR DESCRIPTION
Closes #14219 

Describe your proposed changes here.
Updated the token dropdown in data explorer to only show relevant tokens which have read and write permissions on the buckets selected in from and to
Create a filter to find all tokens with read bucket selected in `from`
Create a filter to find all tokens with write bucket selected in `to`
Create an intersection between the two arrays to find the tokens relevant to both `from` and `to`
Update the dropdown to display an empty state if there are no tokens being listed

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
