### PR TITLE
fix(http): add org ID to flux handler

### DIFF
--- a/http/query.go
+++ b/http/query.go
@@ -279,6 +279,7 @@ func QueryRequestFromProxyRequest(req *query.ProxyRequest) (*QueryRequest, error
 	case lang.FluxCompiler:
 		qr.Type = "flux"
 		qr.Query = c.Query
+		qr.Extern = c.Extern
 	case repl.Compiler:
 		qr.Type = "flux"
 		qr.Spec = c.Spec

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -350,6 +350,9 @@ func (s *FluxService) Query(ctx context.Context, w io.Writer, r *query.ProxyRequ
 	if err != nil {
 		return flux.Statistics{}, tracing.LogError(span, err)
 	}
+	params := url.Values{}
+	params.Set(OrgID, r.Request.OrganizationID.String())
+	u.RawQuery = params.Encode()
 
 	qreq, err := QueryRequestFromProxyRequest(r)
 	if err != nil {

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/lang"
-	influxdb "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb"
 	platform "github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/http/metric"
@@ -31,6 +31,10 @@ import (
 )
 
 func TestFluxService_Query(t *testing.T) {
+	orgID, err := influxdb.IDFromString("abcdabcdabcdabcd")
+	if err != nil {
+		t.Fatal(err)
+	}
 	tests := []struct {
 		name    string
 		token   string
@@ -47,6 +51,7 @@ func TestFluxService_Query(t *testing.T) {
 			token: "mytoken",
 			r: &query.ProxyRequest{
 				Request: query.Request{
+					OrganizationID: *orgID,
 					Compiler: lang.FluxCompiler{
 						Query: "from()",
 					},
@@ -58,11 +63,26 @@ func TestFluxService_Query(t *testing.T) {
 			wantW:  "howdy\n",
 		},
 		{
+			name:  "missing org id",
+			ctx:   context.Background(),
+			token: "mytoken",
+			r: &query.ProxyRequest{
+				Request: query.Request{
+					Compiler: lang.FluxCompiler{
+						Query: "from()",
+					},
+				},
+				Dialect: csv.DefaultDialect(),
+			},
+			wantErr: true,
+		},
+		{
 			name:  "error status",
 			token: "mytoken",
 			ctx:   context.Background(),
 			r: &query.ProxyRequest{
 				Request: query.Request{
+					OrganizationID: *orgID,
 					Compiler: lang.FluxCompiler{
 						Query: "from()",
 					},
@@ -76,8 +96,15 @@ func TestFluxService_Query(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if reqID := r.URL.Query().Get(OrgID); reqID == "" {
+					if name := r.URL.Query().Get(OrgName); name == "" {
+						// Request must have org or orgID.
+						EncodeError(context.TODO(), influxdb.ErrInvalidOrgFilter, w)
+						return
+					}
+				}
 				w.WriteHeader(tt.status)
-				fmt.Fprintln(w, "howdy")
+				_, _ = fmt.Fprintln(w, "howdy")
 			}))
 			defer ts.Close()
 			s := &FluxService{


### PR DESCRIPTION
`FluxService` must be dead code (until now; I'm using for the query capacity tool) since I don't think it worked at all since auth changes were made several months ago.

I added the orgID to the HTTP query string, similar to `FluxQueryService`.