### PR TITLE
Prevent data from re-appearing on startup in some cases

### DIFF
--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -222,8 +222,9 @@ func (l *WAL) Open() error {
 			}
 			l.currentSegmentWriter = NewWALSegmentWriter(fd)
 
-			// Reset the current segment size stat
+			// Set the correct size on the segment writer
 			atomic.StoreInt64(&l.stats.CurrentBytes, stat.Size())
+			l.currentSegmentWriter.size = int(stat.Size())
 		}
 	}
 


### PR DESCRIPTION
Closes #14229

This PR fixes a strange bug where data can re-appear after a restart. The issue arises if the cache is snapshotted _before_ a write lands in the WAL. In such a scenario, the Engine thinks that the WAL is empty, and decides it does not need truncating when the cache snapshot completes.

The data in the WAL then persists after the snapshot, and is then replayed again on startup. The catch is that if a user attempts to delete this data post-snapshot, no delete entry will be added to the WAL because the cache is empty. So when the replay happens there is no delete command to replay.