### PR TITLE
feat(storage): Limit concurrent series partition compaction

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -70,9 +70,10 @@ const (
 	// DefaultSeriesIDSetCacheSize is the default number of series ID sets to cache in the TSI index.
 	DefaultSeriesIDSetCacheSize = 100
 
-	// DefaultSeriesFileMaxConcurrentCompactions is the maximum number of concurrent series partition compactions
-	// that can run at one time.  A value of 0 results in runtime.GOMAXPROCS(0).
-	DefaultSeriesFileMaxConcurrentCompactions = 0
+	// DefaultSeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent series
+	// partition snapshot compactions that can run at one time.
+	// A value of 0 results in runtime.GOMAXPROCS(0).
+	DefaultSeriesFileMaxConcurrentSnapshotCompactions = 0
 )
 
 // Config holds the configuration for the tsbd package.
@@ -132,12 +133,12 @@ type Config struct {
 	// Setting series-id-set-cache-size to 0 disables the cache.
 	SeriesIDSetCacheSize int `toml:"series-id-set-cache-size"`
 
-	// SeriesFileMaxConcurrentCompactions is the maximum number of concurrent compactions
-	// that can be running at one time across all series partitions in a database.  Compactions scheduled
-	// to run when the limit is reached are blocked until a running compaction completes.  Only snapshot
-	// compactions are affected by this limit.  A value of 0 limits compactions to the lesser of
+	// SeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent snapshot compactions
+	// that can be running at one time across all series partitions in a database. Snapshots scheduled
+	// to run when the limit is reached are blocked until a running snaphsot completes.  Only snapshot
+	// compactions are affected by this limit. A value of 0 limits snapshot compactions to the lesser of
 	// 8 (series file partition quantity) and runtime.GOMAXPROCS(0).
-	SeriesFileMaxConcurrentCompactions int `toml:"series-file-max-concurrent-compactions"`
+	SeriesFileMaxConcurrentSnapshotCompactions int `toml:"series-file-max-concurrent-snapshot-compactions"`
 
 	TraceLoggingEnabled bool `toml:"trace-logging-enabled"`
 
@@ -170,7 +171,7 @@ func NewConfig() Config {
 		MaxIndexLogFileSize:  toml.Size(DefaultMaxIndexLogFileSize),
 		SeriesIDSetCacheSize: DefaultSeriesIDSetCacheSize,
 
-		SeriesFileMaxConcurrentCompactions: DefaultSeriesFileMaxConcurrentCompactions,
+		SeriesFileMaxConcurrentSnapshotCompactions: DefaultSeriesFileMaxConcurrentSnapshotCompactions,
 
 		TraceLoggingEnabled: false,
 		TSMWillNeed:         false,
@@ -193,7 +194,7 @@ func (c *Config) Validate() error {
 		return errors.New("series-id-set-cache-size must be non-negative")
 	}
 
-	if c.SeriesFileMaxConcurrentCompactions < 0 {
+	if c.SeriesFileMaxConcurrentSnapshotCompactions < 0 {
 		return errors.New("series-file-max-concurrent-compactions must be non-negative")
 	}
 
@@ -237,6 +238,6 @@ func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
 		"max-concurrent-compactions":             c.MaxConcurrentCompactions,
 		"max-index-log-file-size":                c.MaxIndexLogFileSize,
 		"series-id-set-cache-size":               c.SeriesIDSetCacheSize,
-		"series-file-max-concurrent-compactions": c.SeriesFileMaxConcurrentCompactions,
+		"series-file-max-concurrent-compactions": c.SeriesFileMaxConcurrentSnapshotCompactions,
 	}), nil
 }

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -133,9 +133,9 @@ type Config struct {
 	SeriesIDSetCacheSize int `toml:"series-id-set-cache-size"`
 
 	// SeriesFileMaxConcurrentCompactions is the maximum number of concurrent compactions
-	// that can be running at one time across all shards.  Compactions scheduled to run when the
-	// limit is reached are blocked until a running compaction completes.  Only snapshot compactions
-	// are affected by this limit.  A value of 0 limits compactions to the lesser of
+	// that can be running at one time across all series partitions in a database.  Compactions scheduled
+	// to run when the limit is reached are blocked until a running compaction completes.  Only snapshot
+	// compactions are affected by this limit.  A value of 0 limits compactions to the lesser of
 	// 8 (series file partition quantity) and runtime.GOMAXPROCS(0).
 	SeriesFileMaxConcurrentCompactions int `toml:"series-file-max-concurrent-compactions"`
 
@@ -195,8 +195,6 @@ func (c *Config) Validate() error {
 
 	if c.SeriesFileMaxConcurrentCompactions < 0 {
 		return errors.New("series-file-max-concurrent-compactions must be non-negative")
-	} else if c.SeriesFileMaxConcurrentCompactions > SeriesFilePartitionN {
-		return fmt.Errorf("series-file-max-concurrent-compactions must be <= series file partition quantity (%d)", SeriesFilePartitionN)
 	}
 
 	valid := false

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -50,9 +50,6 @@ func NewSeriesFile(path string) *SeriesFile {
 	if maxCompactionConcurrency < 1 {
 		maxCompactionConcurrency = 1
 	}
-	if maxCompactionConcurrency > SeriesFilePartitionN {
-		maxCompactionConcurrency = SeriesFilePartitionN
-	}
 
 	return &SeriesFile{
 		path:                     path,
@@ -63,10 +60,10 @@ func NewSeriesFile(path string) *SeriesFile {
 
 func (f *SeriesFile) WithMaxCompactionConcurrency(maxCompactionConcurrency int) {
 	if maxCompactionConcurrency < 1 {
-		maxCompactionConcurrency = 1
-	}
-	if maxCompactionConcurrency > SeriesFilePartitionN {
-		maxCompactionConcurrency = SeriesFilePartitionN
+		maxCompactionConcurrency = runtime.GOMAXPROCS(0)
+		if maxCompactionConcurrency < 1 {
+			maxCompactionConcurrency = 1
+		}
 	}
 
 	f.maxCompactionConcurrency = maxCompactionConcurrency

--- a/tsdb/series_file.go
+++ b/tsdb/series_file.go
@@ -37,7 +37,7 @@ type SeriesFile struct {
 	path       string
 	partitions []*SeriesPartition
 
-	maxCompactionConcurrency int
+	maxSnapshotConcurrency int
 
 	refs sync.RWMutex // RWMutex to track references to the SeriesFile that are in use.
 
@@ -46,15 +46,15 @@ type SeriesFile struct {
 
 // NewSeriesFile returns a new instance of SeriesFile.
 func NewSeriesFile(path string) *SeriesFile {
-	maxCompactionConcurrency := runtime.GOMAXPROCS(0)
-	if maxCompactionConcurrency < 1 {
-		maxCompactionConcurrency = 1
+	maxSnapshotConcurrency := runtime.GOMAXPROCS(0)
+	if maxSnapshotConcurrency < 1 {
+		maxSnapshotConcurrency = 1
 	}
 
 	return &SeriesFile{
-		path:                     path,
-		maxCompactionConcurrency: maxCompactionConcurrency,
-		Logger:                   zap.NewNop(),
+		path:                   path,
+		maxSnapshotConcurrency: maxSnapshotConcurrency,
+		Logger:                 zap.NewNop(),
 	}
 }
 
@@ -66,7 +66,7 @@ func (f *SeriesFile) WithMaxCompactionConcurrency(maxCompactionConcurrency int) 
 		}
 	}
 
-	f.maxCompactionConcurrency = maxCompactionConcurrency
+	f.maxSnapshotConcurrency = maxCompactionConcurrency
 }
 
 // Open memory maps the data file at the file's path.
@@ -81,7 +81,7 @@ func (f *SeriesFile) Open() error {
 	}
 
 	// Limit concurrent series file compactions
-	compactionLimiter := limiter.NewFixed(f.maxCompactionConcurrency)
+	compactionLimiter := limiter.NewFixed(f.maxSnapshotConcurrency)
 
 	// Open partitions.
 	f.partitions = make([]*SeriesPartition, 0, SeriesFilePartitionN)

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -511,7 +511,7 @@ func (s *Store) openSeriesFile(database string) (*SeriesFile, error) {
 	}
 
 	sfile := NewSeriesFile(filepath.Join(s.path, database, SeriesFileDirectory))
-	sfile.WithMaxCompactionConcurrency(s.EngineOptions.Config.SeriesFileMaxConcurrentCompactions)
+	sfile.WithMaxCompactionConcurrency(s.EngineOptions.Config.SeriesFileMaxConcurrentSnapshotCompactions)
 	sfile.Logger = s.baseLogger
 	if err := sfile.Open(); err != nil {
 		return nil, err

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -511,6 +511,7 @@ func (s *Store) openSeriesFile(database string) (*SeriesFile, error) {
 	}
 
 	sfile := NewSeriesFile(filepath.Join(s.path, database, SeriesFileDirectory))
+	sfile.WithMaxCompactionConcurrency(s.EngineOptions.Config.SeriesFileMaxConcurrentCompactions)
 	sfile.Logger = s.baseLogger
 	if err := sfile.Open(); err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #14066 

Limit concurrent series partition snapshots, to reduce memory and disk contention.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
