### PR TITLE
Clean tmp tsm files when replace fails

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2214,7 +2214,7 @@ func (s *compactionStrategy) compactGroup() {
 		// Remove the new snapshot files. We will try again.
 		for _, file := range files {
 			if err := os.Remove(file); err != nil {
-				log.Info("Unable to remove file", zap.String("path", file), zap.Error(err))
+				log.Error("Unable to remove file", zap.String("path", file), zap.Error(err))
 			}
 		}
 		return

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2210,6 +2210,13 @@ func (s *compactionStrategy) compactGroup() {
 		log.Info("Error replacing new TSM files", zap.Error(err))
 		atomic.AddInt64(s.errorStat, 1)
 		time.Sleep(time.Second)
+
+		// Remove the new snapshot files. We will try again.
+		for _, file := range files {
+			if err := os.Remove(file); err != nil {
+				log.Info("Unable to remove file", zap.String("path", file), zap.Error(err))
+			}
+		}
 		return
 	}
 


### PR DESCRIPTION
Closes #14058 

Backport for 1.8 branch.
Instead of only logging error message when compaction fails, log the message and clear all tmp.tsm files so we can try again

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
