### PR TITLE
report-tsm --pattern flag incorrectly matches everything but specified value

### DIFF
--- a/tsdb/tsm1/report.go
+++ b/tsdb/tsm1/report.go
@@ -110,7 +110,7 @@ func (r *Report) Run(print bool) (*ReportSummary, error) {
 
 	var tagBuf models.Tags // Buffer that can be re-used when parsing keys.
 	for _, path := range files {
-		if r.Pattern != "" && strings.Contains(path, r.Pattern) {
+		if r.Pattern != "" && !strings.Contains(path, r.Pattern) {
 			continue
 		}
 


### PR DESCRIPTION
Previously the logic was inverted so `--pattern` matched everything but the specified value.
