### PR TITLE
fix(tsdb): Fix tsm1 block merge.

### DIFF
--- a/tsdb/tsm1/reader_block_iterator.go
+++ b/tsdb/tsm1/reader_block_iterator.go
@@ -10,6 +10,9 @@ type BlockIterator struct {
 
 // PeekNext returns the next key to be iterated or an empty string.
 func (b *BlockIterator) PeekNext() []byte {
+	if len(b.entries) > 1 {
+		return b.iter.Key()
+	}
 	return b.iter.Peek()
 }
 


### PR DESCRIPTION
Fixes the `tsm1.BlockIterator` so that it returns the current key if there are still additional entries remaining. This previously caused multiple entries not to be merged together during compaction because the iterator would check if the next key matched the current key but the key for the next set of entries was returned.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
