### PR TITLE
feat(tasks): add last and checkpoint functions

### DIFF
--- a/task/backend/task_service_checkpointer.go
+++ b/task/backend/task_service_checkpointer.go
@@ -1,0 +1,47 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/influxdata/influxdb"
+)
+
+// Checkpointer allows us to restart a service from the last time we executed.
+type TaskServiceCheckpointer struct {
+	ts influxdb.TaskService
+}
+
+func NewTaskServiceCheckpointer(ts influxdb.TaskService) *TaskServiceCheckpointer {
+	return &TaskServiceCheckpointer{
+		ts: ts,
+	}
+}
+
+// Checkpoint updates a task's LatestCompleted value with the given time
+func (c *TaskServiceCheckpointer) Checkpoint(ctx context.Context, id influxdb.ID, t time.Time) error {
+	s := t.Format(time.RFC3339Nano)
+	_, err := c.ts.UpdateTask(ctx, id, influxdb.TaskUpdate{
+		LatestCompleted: &s,
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not update checkpoint for task: %v", err)
+	}
+	return nil
+}
+
+// Last retrieves a task by its ID and returns its LatestCompleted value
+func (c *TaskServiceCheckpointer) Last(ctx context.Context, id influxdb.ID) (time.Time, error) {
+	task, err := c.ts.FindTaskByID(ctx, id)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("could not fetch task: %v", err)
+	}
+
+	last, err := time.Parse(time.RFC3339Nano, task.LatestCompleted)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("internal server error: corrupt LastCompleted format: %v", err)
+	}
+	return last, nil
+}

--- a/task/backend/task_service_checkpointer_test.go
+++ b/task/backend/task_service_checkpointer_test.go
@@ -1,0 +1,85 @@
+package backend_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/mock"
+	"github.com/influxdata/influxdb/task/backend"
+)
+
+func TestCheckpoint(t *testing.T) {
+	mockService := &mock.TaskService{
+		UpdateTaskFn: func(context.Context, influxdb.ID, influxdb.TaskUpdate) (*influxdb.Task, error) { return nil, nil },
+	}
+
+	cp := backend.NewTaskServiceCheckpointer(mockService)
+	err := cp.Checkpoint(context.Background(), influxdb.ID(1), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckpointError(t *testing.T) {
+	mockService := &mock.TaskService{
+		UpdateTaskFn: func(context.Context, influxdb.ID, influxdb.TaskUpdate) (*influxdb.Task, error) {
+			return nil, fmt.Errorf("error!")
+		},
+	}
+
+	cp := backend.NewTaskServiceCheckpointer(mockService)
+	err := cp.Checkpoint(context.Background(), influxdb.ID(1), time.Now())
+	if err == nil {
+		t.Fatalf("Expected error")
+	}
+}
+
+func TestLast(t *testing.T) {
+	want := time.Now()
+	s := want.Format(time.RFC3339Nano)
+	mockService := &mock.TaskService{
+		FindTaskByIDFn: func(context.Context, influxdb.ID) (*influxdb.Task, error) {
+			return &influxdb.Task{LatestCompleted: s}, nil
+		},
+	}
+
+	cp := backend.NewTaskServiceCheckpointer(mockService)
+	got, err := cp.Last(context.Background(), influxdb.ID(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("wrong time, wanted: %v, got: %v", want, got)
+	}
+}
+
+func TestLastFetchError(t *testing.T) {
+	mockService := &mock.TaskService{
+		FindTaskByIDFn: func(context.Context, influxdb.ID) (*influxdb.Task, error) {
+			return nil, fmt.Errorf("error 1")
+		},
+	}
+
+	cp := backend.NewTaskServiceCheckpointer(mockService)
+	_, err := cp.Last(context.Background(), influxdb.ID(1))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestLastParseError(t *testing.T) {
+	mockService := &mock.TaskService{
+		FindTaskByIDFn: func(context.Context, influxdb.ID) (*influxdb.Task, error) {
+			return &influxdb.Task{LatestCompleted: "howdy"}, nil
+		},
+	}
+
+	cp := backend.NewTaskServiceCheckpointer(mockService)
+	_, err := cp.Last(context.Background(), influxdb.ID(1))
+	if err == nil {
+		t.Fatalf("expected error parsing invalid time: %v", err)
+	}
+}


### PR DESCRIPTION
This PR implements the `Checkpoint` and `Last` functions using a Task Service

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
