### PR TITLE
Storage reads should be in domain [start, end)

### DIFF
--- a/storage/reads/datatypes/storage_common.proto
+++ b/storage/reads/datatypes/storage_common.proto
@@ -173,7 +173,7 @@ message TimestampRange {
   // Start defines the inclusive lower bound.
   int64 start = 1;
 
-  // End defines the inclusive upper bound.
+  // End defines the exclusive upper bound.
   int64 end = 2;
 }
 

--- a/tsdb/tsm1/array_cursor.gen.go
+++ b/tsdb/tsm1/array_cursor.gen.go
@@ -133,9 +133,9 @@ func (c *floatArrayAscendingCursor) Next() *tsdb.FloatArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -292,9 +292,9 @@ func (c *floatArrayDescendingCursor) Next() *tsdb.FloatArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++
@@ -441,9 +441,9 @@ func (c *integerArrayAscendingCursor) Next() *tsdb.IntegerArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -600,9 +600,9 @@ func (c *integerArrayDescendingCursor) Next() *tsdb.IntegerArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++
@@ -749,9 +749,9 @@ func (c *unsignedArrayAscendingCursor) Next() *tsdb.UnsignedArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -908,9 +908,9 @@ func (c *unsignedArrayDescendingCursor) Next() *tsdb.UnsignedArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++
@@ -1057,9 +1057,9 @@ func (c *stringArrayAscendingCursor) Next() *tsdb.StringArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -1218,9 +1218,9 @@ func (c *stringArrayDescendingCursor) Next() *tsdb.StringArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++
@@ -1369,9 +1369,9 @@ func (c *booleanArrayAscendingCursor) Next() *tsdb.BooleanArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -1528,9 +1528,9 @@ func (c *booleanArrayDescendingCursor) Next() *tsdb.BooleanArray {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++

--- a/tsdb/tsm1/array_cursor.gen.go.tmpl
+++ b/tsdb/tsm1/array_cursor.gen.go.tmpl
@@ -41,7 +41,7 @@ func new{{$Type}}() *{{$type}} {
 }
 
 func (c *{{$type}}) reset(seek, end int64, cacheValues Values, tsmKeyCursor *KeyCursor) {
-c.end = end
+	c.end = end
 	c.cache.values = cacheValues
 	c.cache.pos = sort.Search(len(c.cache.values), func(i int) bool {
 		return c.cache.values[i].UnixNano() >= seek
@@ -132,9 +132,9 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] > c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] >= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] > c.end {
+		for pos >= 0 && c.res.Timestamps[pos] >= c.end {
 			pos--
 		}
 		pos++
@@ -299,9 +299,9 @@ func (c *{{$type}}) Next() {{$arrayType}} {
 		}
 	}
 
-	if pos > 0 && c.res.Timestamps[pos-1] < c.end {
+	if pos > 0 && c.res.Timestamps[pos-1] <= c.end {
 		pos -= 2
-		for pos >= 0 && c.res.Timestamps[pos] < c.end {
+		for pos >= 0 && c.res.Timestamps[pos] <= c.end {
 			pos--
 		}
 		pos++


### PR DESCRIPTION
Closes https://github.com/influxdata/flux/issues/1427
Closes #14249

This PR changes how storage read cursors work. Previously storage returned points in the domain `[start, end]`.

However, Flux's `range` function uses the range `[start, stop)`. 

Storage now uses the domain `[start, end)`.