### PR TITLE
fix(http): invalid compilation should not be 500 error

### DIFF
--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -165,10 +165,9 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 		if cw.Count() == 0 {
 			// Only record the error headers IFF nothing has been written to w.
 			err := &influxdb.Error{
-				Code: influxdb.EInternal,
-				Msg:  "failed to execute query against proxy service",
-				Op:   op,
-				Err:  err,
+				Msg: "failed to execute query against proxy service",
+				Op:  op,
+				Err: err,
 			}
 			h.HandleHTTPError(ctx, err, w)
 			return


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/3887

removed the hard code EInternal, use whatever the query service returns.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
