### PR TITLE
Remove stray fmt.Println in tsm1.StringArrayEncodeAll

### DIFF
--- a/tsdb/engine/tsm1/batch_string.go
+++ b/tsdb/engine/tsm1/batch_string.go
@@ -38,7 +38,6 @@ func StringArrayEncodeAll(src []string, b []byte) ([]byte, error) {
 
 	// determine the maximum possible length needed for the buffer, which
 	// includes the compressed size
-	fmt.Println(srcSz64, srcSz)
 	var compressedSz = 0
 	if len(src) > 0 {
 		mle := snappy.MaxEncodedLen(srcSz)


### PR DESCRIPTION
It was introduced in #13699.

Updates #14265.