### PR TITLE
Tasks/remove option caching

### DIFF
--- a/task/options/options_test.go
+++ b/task/options/options_test.go
@@ -95,6 +95,15 @@ func TestFromScript(t *testing.T) {
 	}
 }
 
+func BenchmarkFromScriptFunc(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, err := options.FromScript(`option task = {every: 20s, name: "foo"} from(bucket:"x") |> range(start:-1h)`)
+		if err != nil {
+			fmt.Printf("error: %v", err)
+		}
+	}
+}
+
 func TestFromScriptWithUnknownOptions(t *testing.T) {
 	const optPrefix = `option task = { name: "x", every: 1m`
 	const bodySuffix = `} from(bucket:"b") |> range(start:-1m)`

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -22,11 +22,6 @@ import (
 	"github.com/influxdata/influxdb/task/options"
 )
 
-func init() {
-	// TODO(mr): remove as part of https://github.com/influxdata/platform/issues/484.
-	options.EnableScriptCacheForTest()
-}
-
 // BackendComponentFactory is supplied by consumers of the adaptertest package,
 // to provide the values required to constitute a PlatformAdapter.
 // The provided context.CancelFunc is called after the test,


### PR DESCRIPTION
Closes #12829

This PR removes option caching from task tests.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
