### PR TITLE
fix(tasks) report errors found when iterating over flux query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+1. [14287](https://github.com/influxdata/influxdb/pull/14287) Fix incorrect reporting of task as successful when error occurs during result iteration 
+
 ## v2.0.0-alpha.14 [2019-06-28]
 
 ### Features

--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -180,7 +180,7 @@ func (p *syncRunPromise) doQuery(wg *sync.WaitGroup) {
 	for it.More() {
 		// Consume the full iterator so that we don't leak outstanding iterators.
 		res := it.Next()
-		if err := exhaustResultIterators(res); err != nil {
+		if err = exhaustResultIterators(res); err != nil {
 			p.logger.Info("Error exhausting result iterator", zap.Error(err), zap.String("name", res.Name()))
 		}
 	}
@@ -189,8 +189,12 @@ func (p *syncRunPromise) doQuery(wg *sync.WaitGroup) {
 	// It's safe for Release to be called multiple times.
 	it.Release()
 
+	if err == nil {
+		err = it.Err()
+	}
+
 	// Is it okay to assume it.Err will be set if the query context is canceled?
-	p.finish(&runResult{err: it.Err(), statistics: it.Statistics()}, nil)
+	p.finish(&runResult{err: err, statistics: it.Statistics()}, nil)
 }
 
 func (p *syncRunPromise) cancelOnContextDone(wg *sync.WaitGroup) {


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/14239

This is an attempt to bubble up an error so that it fails a task appropriately.

Need help with testing and knowledge on desired task behavior. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] ~http/swagger.yml updated (if modified Go structs or API)~
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
