### PR TITLE
Update Go version to 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 v1.8.0 [unreleased]
 -------------------
 
+### Features
+
+-	[#14315](https://github.com/influxdata/influxdb/pull/14315): Update to go 1.12.7
+
 ### Bugfixes
 
 -	[#10503](https://github.com/influxdata/influxdb/pull/10503): Delete rebuilds series index when series to be deleted are only found in cache.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ second to sign our CLA, which can be found
 
 Installing Go
 -------------
-InfluxDB requires Go 1.11.
+InfluxDB requires Go 1.12.
 
 At InfluxDB we find gvm, a Go version manager, useful for installing Go. For instructions
 on how to install it see [the gvm page on github](https://github.com/moovweb/gvm).
@@ -77,8 +77,8 @@ on how to install it see [the gvm page on github](https://github.com/moovweb/gvm
 After installing gvm you can install and set the default go version by
 running the following:
 
-    gvm install go1.11
-    gvm use go1.11 --default
+    gvm install go1.12
+    gvm use go1.12 --default
 
 Installing Dep
 -------------
@@ -279,7 +279,7 @@ Continuous Integration testing
 -----
 InfluxDB uses CircleCI for continuous integration testing. CircleCI executes [test.sh](https://github.com/influxdata/influxdb/blob/master/test.sh), so you may do the same on your local development environment before creating a pull request.
 
-The `test.sh` script executes a test suite with 5 variants (standard 64 bit, 64 bit with race detection, 32 bit, TSI, go version 1.11), each executes with a different arg, 0 through 4. Unless you know differently, `./test.sh 0` is probably all you need.
+The `test.sh` script executes a test suite with 5 variants (standard 64 bit, 64 bit with race detection, 32 bit, TSI, go version 1.12), each executes with a different arg, 0 through 4. Unless you know differently, `./test.sh 0` is probably all you need.
 
 
 Distributions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 as builder
+FROM golang:1.12 as builder
 RUN go get -u github.com/golang/dep/...
 WORKDIR /go/src/github.com/influxdata/influxdb
 COPY Gopkg.toml Gopkg.lock ./

--- a/Dockerfile_build_ubuntu32
+++ b/Dockerfile_build_ubuntu32
@@ -22,7 +22,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.11
+ENV GO_VERSION 1.12
 ENV GO_ARCH 386
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64
+++ b/Dockerfile_build_ubuntu64
@@ -24,7 +24,7 @@ RUN gem install fpm
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.11
+ENV GO_VERSION 1.12
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64_git
+++ b/Dockerfile_build_ubuntu64_git
@@ -27,7 +27,7 @@ VOLUME $PROJECT_DIR
 
 
 # Install go
-ENV GO_VERSION 1.11
+ENV GO_VERSION 1.12
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_build_ubuntu64_go1.12
+++ b/Dockerfile_build_ubuntu64_go1.12
@@ -25,8 +25,7 @@ RUN gem install fpm
 # Install go
 ENV GOPATH /root/go
 
-# TODO(edd) this needs to be updated to 1.11 when the branch is available.
-ENV GO_VERSION 1.11rc1
+ENV GO_VERSION 1.12
 
 ENV GO_ARCH amd64
 RUN wget --no-verbose https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_jenkins_ubuntu32
+++ b/Dockerfile_jenkins_ubuntu32
@@ -10,7 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 # Install go
 ENV GOPATH /go
-ENV GO_VERSION 1.11
+ENV GO_VERSION 1.12
 ENV GO_ARCH 386
 RUN wget --no-verbose -q https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
    tar -C /usr/local/ -xf /go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \

--- a/Dockerfile_jenkins_ubuntu32
+++ b/Dockerfile_jenkins_ubuntu32
@@ -9,6 +9,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install go
+ENV GOCACHE=/tmp
 ENV GOPATH /go
 ENV GO_VERSION 1.12
 ENV GO_ARCH 386

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
     stage('64bit') {
       agent {
         docker {
-          image 'golang:1.11'
+          image 'golang:1.12'
         }
       }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,12 +48,14 @@ pipeline {
       agent {
         docker {
           image 'golang:1.12'
+          inside '-e "GOCACHE=/tmp"'
         }
       }
 
       steps {
         sh """
         mkdir -p /go/src/github.com/influxdata
+        mkdir -p $(go env GOCACHE)
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb
 
         cd /go/src/github.com/influxdata/influxdb
@@ -72,11 +74,14 @@ pipeline {
       agent {
         dockerfile {
           filename 'Dockerfile_jenkins_ubuntu32'
+          inside '-e "GOCACHE=/tmp"'
         }
       }
 
       steps {
         sh """
+        mkdir -p $(go env GOCACHE)
+        
         mkdir -p /go/src/github.com/influxdata
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ pipeline {
       agent {
         docker {
           image 'golang:1.12'
+          args '-e "GOCACHE=/tmp"'
         }
       }
 
@@ -57,13 +58,13 @@ pipeline {
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb
 
         cd /go/src/github.com/influxdata/influxdb
-        GOCACHE=/tmp go get github.com/golang/dep/cmd/dep
+        go get github.com/golang/dep/cmd/dep
         dep ensure -vendor-only
         """
 
         sh """
         cd /go/src/github.com/influxdata/influxdb
-        GOCACHE=/tmp go test -parallel=1 ./...
+        go test -parallel=1 ./...
         """
       }
     }
@@ -83,13 +84,13 @@ pipeline {
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb
 
         cd /go/src/github.com/influxdata/influxdb
-        GOCACHE=/tmp go get github.com/golang/dep/cmd/dep
+        go get github.com/golang/dep/cmd/dep
         dep ensure -vendor-only
         """
 
         sh """
         cd /go/src/github.com/influxdata/influxdb
-        GOCACHE=/tmp go test -parallel=1 ./...
+        go test -parallel=1 ./...
         """
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,19 +53,17 @@ pipeline {
 
       steps {
         sh """
-        mkdir $HOME/.cache
-
         mkdir -p /go/src/github.com/influxdata
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb
 
         cd /go/src/github.com/influxdata/influxdb
-        go get github.com/golang/dep/cmd/dep
+        GOCACHE=/tmp go get github.com/golang/dep/cmd/dep
         dep ensure -vendor-only
         """
 
         sh """
         cd /go/src/github.com/influxdata/influxdb
-        go test -parallel=1 ./...
+        GOCACHE=/tmp go test -parallel=1 ./...
         """
       }
     }
@@ -85,13 +83,13 @@ pipeline {
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb
 
         cd /go/src/github.com/influxdata/influxdb
-        go get github.com/golang/dep/cmd/dep
+        GOCACHE=/tmp go get github.com/golang/dep/cmd/dep
         dep ensure -vendor-only
         """
 
         sh """
         cd /go/src/github.com/influxdata/influxdb
-        go test -parallel=1 ./...
+        GOCACHE=/tmp go test -parallel=1 ./...
         """
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,14 +48,14 @@ pipeline {
       agent {
         docker {
           image 'golang:1.12'
-          inside '-e "GOCACHE=/tmp"'
         }
       }
 
       steps {
         sh """
+        mkdir $HOME/.cache
+
         mkdir -p /go/src/github.com/influxdata
-        mkdir -p $(go env GOCACHE)
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb
 
         cd /go/src/github.com/influxdata/influxdb
@@ -74,13 +74,12 @@ pipeline {
       agent {
         dockerfile {
           filename 'Dockerfile_jenkins_ubuntu32'
-          inside '-e "GOCACHE=/tmp"'
         }
       }
 
       steps {
         sh """
-        mkdir -p $(go env GOCACHE)
+        mkdir $HOME/.cache
         
         mkdir -p /go/src/github.com/influxdata
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,8 +78,6 @@ pipeline {
 
       steps {
         sh """
-        mkdir $HOME/.cache
-        
         mkdir -p /go/src/github.com/influxdata
         cp -a $WORKSPACE /go/src/github.com/influxdata/influxdb
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ clone_folder: c:\gopath\src\github.com\influxdata\influxdb
 
 # Environment variables
 environment:
-  GOROOT: C:\go110
+  GOROOT: C:\go112
   GOPATH: C:\gopath
 
 # Scripts that run after cloning repository

--- a/releng/_go_versions.sh
+++ b/releng/_go_versions.sh
@@ -1,5 +1,5 @@
 # These are the current and "next" Go versions used to build influxdb.
 # This file is meant to be sourced from other scripts.
 
-export GO_CURRENT_VERSION=1.11
-export GO_NEXT_VERSION=1.11
+export GO_CURRENT_VERSION=1.12.7
+export GO_NEXT_VERSION=1.12.7

--- a/services/httpd/response_writer_test.go
+++ b/services/httpd/response_writer_test.go
@@ -213,7 +213,7 @@ func TestResponseWriter_CSV_DifferentColumns(t *testing.T) {
 						Name:    "runtime",
 						Columns: []string{"GOARCH", "GOMAXPROCS", "GOOS", "version"},
 						Values: [][]interface{}{
-							{"amd64", int64(8), "darwin", "go1.11"},
+							{"amd64", int64(8), "darwin", "go1.12"},
 						},
 					},
 				},
@@ -225,7 +225,7 @@ func TestResponseWriter_CSV_DifferentColumns(t *testing.T) {
 network,,localhost
 
 name,tags,GOARCH,GOMAXPROCS,GOOS,version
-runtime,,amd64,8,darwin,go1.11
+runtime,,amd64,8,darwin,go1.12
 `; got != want {
 		t.Errorf("unexpected output:\n\ngot=%v\nwant=%s", got, want)
 	}

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@
 #      1: race enabled 64bit tests
 #      2: normal 32bit tests
 #      3: tsi build
-#      4: go 1.11
+#      4: go 1.12
 #      count: print the number of test environments
 #      *: to run all tests in parallel containers
 #
@@ -124,8 +124,8 @@ case $ENVIRONMENT_INDEX in
         rc=$?
         ;;
     4)
-        # go1.11
-        run_test_docker Dockerfile_build_ubuntu64_go1.11 test_64bit --test --junit-report
+        # go1.12
+        run_test_docker Dockerfile_build_ubuntu64_go1.12 test_64bit --test --junit-report
         rc=$?
         ;;
     "count")


### PR DESCRIPTION
This PR updates the Go runtime used to build InfluxDB to Go 1.12.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
