### PR TITLE
fix(tasks): Add a log message for run transition clairity

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 
 # Scripts that run after cloning repository
 install:
- - choco install bzr # Needed to install go modules
+#  - choco install bzr # Needed to install go modules
  - set PATH=%GOROOT%\bin;%GOPATH%\bin;C:\Program Files (x86)\Bazaar\;%PATH%
  - echo %PATH%
  - echo %GOPATH%

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -67,6 +67,15 @@ func (as *AnalyticalStorage) FinishRun(ctx context.Context, taskID, runID influx
 			models.NewTag([]byte(statusField), []byte(run.Status)),
 		}
 
+		// log an error if we have incomplete data on finish
+		if !run.ID.Valid() ||
+			run.ScheduledFor == "" ||
+			run.StartedAt == "" ||
+			run.FinishedAt == "" ||
+			run.Status == "" {
+			as.logger.Error("Run missing critical fields", zap.String("run", fmt.Sprintf("%+v", run), zap.String("runID", run.ID.String())))
+		}
+
 		fields := map[string]interface{}{}
 		fields[statusField] = run.Status
 		fields[runIDField] = run.ID.String()

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -73,7 +73,7 @@ func (as *AnalyticalStorage) FinishRun(ctx context.Context, taskID, runID influx
 			run.StartedAt == "" ||
 			run.FinishedAt == "" ||
 			run.Status == "" {
-			as.logger.Error("Run missing critical fields", zap.String("run", fmt.Sprintf("%+v", run), zap.String("runID", run.ID.String())))
+			as.logger.Error("Run missing critical fields", zap.String("run", fmt.Sprintf("%+v", run)), zap.String("runID", run.ID.String()))
 		}
 
 		fields := map[string]interface{}{}


### PR DESCRIPTION
We on occasion will see a run in chronograf with missing run data.
We need to find out if we are submitting incomplete data or if we submit full data and somethinge else is happening.