### PR TITLE
feat(http): handle flux errors that are returned from the query service

### DIFF
--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/complete"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/iocounter"
@@ -164,18 +165,58 @@ func (h *FluxHandler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	if _, err := h.ProxyQueryService.Query(ctx, &cw, req); err != nil {
 		if cw.Count() == 0 {
 			// Only record the error headers IFF nothing has been written to w.
-			err := &influxdb.Error{
-				Msg: "failed to execute query against proxy service",
-				Op:  op,
-				Err: err,
-			}
-			h.HandleHTTPError(ctx, err, w)
+			h.HandleHTTPError(ctx, handleFluxError(err), w)
 			return
 		}
 		h.Logger.Info("Error writing response to client",
 			zap.String("handler", "flux"),
 			zap.Error(err),
 		)
+	}
+}
+
+// handleFluxError will take a flux.Error and convert it into an influxdb.Error.
+// It will match certain codes to the equivalent in influxdb.
+//
+// If the error is any other type of error, it will return the error untouched.
+//
+// TODO(jsternberg): This likely becomes a public function, but this is just an initial
+// implementation so playing it safe by making it package local for now.
+func handleFluxError(err error) error {
+	ferr, ok := err.(*flux.Error)
+	if !ok {
+		return err
+	}
+
+	code := influxdb.EInternal
+	switch flux.ErrorCode(err) {
+	case codes.NotFound:
+		code = influxdb.ENotFound
+	case codes.Invalid:
+		code = influxdb.EInvalid
+	// These don't really map correctly, but we want
+	// them to show up as 4XX so until influxdb error
+	// codes are updated for more types of failures,
+	// mapping these to invalid.
+	case codes.Canceled,
+		codes.ResourceExhausted,
+		codes.FailedPrecondition,
+		codes.Aborted,
+		codes.OutOfRange,
+		codes.Unimplemented:
+		code = influxdb.EInvalid
+	case codes.PermissionDenied:
+		code = influxdb.EForbidden
+	case codes.Unauthenticated:
+		code = influxdb.EUnauthorized
+	default:
+		// Everything else is treated as an internal error
+		// which is set above.
+	}
+	return &influxdb.Error{
+		Code: code,
+		Msg:  ferr.Msg,
+		Err:  handleFluxError(ferr.Err),
 	}
 }
 

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/influxdb"
@@ -328,7 +328,10 @@ func TestFluxHandler_PostQuery_Errors(t *testing.T) {
 		OrganizationService: i,
 		ProxyQueryService: &mock.ProxyQueryService{
 			QueryF: func(ctx context.Context, w io.Writer, req *query.ProxyRequest) (flux.Statistics, error) {
-				return flux.Statistics{}, errors.New("some query error")
+				return flux.Statistics{}, &flux.Error{
+					Code: codes.Invalid,
+					Msg:  "some query error",
+				}
 			},
 		},
 	}
@@ -392,7 +395,7 @@ func TestFluxHandler_PostQuery_Errors(t *testing.T) {
 		}
 	})
 
-	t.Run("valid request but executing query results in error", func(t *testing.T) {
+	t.Run("valid request but executing query results in client error", func(t *testing.T) {
 		org := influxdb.Organization{Name: t.Name()}
 		if err := i.CreateOrganization(context.Background(), &org); err != nil {
 			t.Fatal(err)
@@ -409,8 +412,8 @@ func TestFluxHandler_PostQuery_Errors(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.handleQuery(w, req)
 
-		if w.Code != http.StatusInternalServerError {
-			t.Errorf("expected internal error status, got %d", w.Code)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected bad request status, got %d", w.Code)
 		}
 
 		body := w.Body.Bytes()
@@ -421,11 +424,11 @@ func TestFluxHandler_PostQuery_Errors(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !strings.Contains(ierr.Msg, "failed to execute query") {
-			t.Fatalf("expected error to mention failure to execute query, got %s", ierr.Msg)
+		if got, want := ierr.Code, influxdb.EInvalid; got != want {
+			t.Fatalf("unexpected error code -want/+got:\n\t- %v\n\t+ %v", want, got)
 		}
-		if ierr.Err.Error() != "some query error" {
-			t.Fatalf("expected wrapped error to be the query service error, got %s", ierr.Err.Error())
+		if ierr.Msg != "some query error" {
+			t.Fatalf("expected error message to mention 'some query error', got %s", ierr.Err.Error())
 		}
 	})
 }


### PR DESCRIPTION
Flux errors that are returned from the query service will be adapted to
an influxdb.Error and then will be written to HTTP correctly.