### PR TITLE
fix(cmd/influx): user flag shouldn't be ignore

### DIFF
--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -226,6 +226,20 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 		OrgID:       o.ID,
 	}
 
+	if userName := authorizationCreateFlags.user; userName != "" {
+		userSvc, err := newUserService(flags)
+		if err != nil {
+			return err
+		}
+		user, err := userSvc.FindUser(ctx, platform.UserFilter{
+			Name: &userName,
+		})
+		if err != nil {
+			return err
+		}
+		authorization.UserID = user.ID
+	}
+
 	s, err := newAuthorizationService(flags)
 	if err != nil {
 		return err


### PR DESCRIPTION
Additional to the API fix of https://github.com/influxdata/influxdb/pull/14344
the influx CLI is ignoring the user flag. This fix should patch that issue.
Manually tested.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
