### PR TITLE
feat(tasks): add health check to kv service

### DIFF
--- a/kv/service.go
+++ b/kv/service.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/check"
 	"github.com/influxdata/influxdb/rand"
 	"github.com/influxdata/influxdb/snowflake"
 )
@@ -134,4 +135,14 @@ func (s *Service) Initialize(ctx context.Context) error {
 // Should only be used in tests for mocking.
 func (s *Service) WithStore(store Store) {
 	s.kv = store
+}
+
+// Check calls the check function on the kv store if it implements the
+// check interface, otherwise returns pass
+func (s *Service) Check(ctx context.Context) check.Response {
+	if check, ok := s.kv.(check.Checker); ok {
+		return check.Check(ctx)
+	}
+
+	return check.Pass()
 }


### PR DESCRIPTION
This PR implements the `Check` function on the kv service, and simply returns a success response if the kv store does not implement the Check interface.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
