### PR TITLE
refactor(query): handle flux errors in the query controller instead of http

### DIFF
--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/influxdb"
@@ -328,8 +327,8 @@ func TestFluxHandler_PostQuery_Errors(t *testing.T) {
 		OrganizationService: i,
 		ProxyQueryService: &mock.ProxyQueryService{
 			QueryF: func(ctx context.Context, w io.Writer, req *query.ProxyRequest) (flux.Statistics, error) {
-				return flux.Statistics{}, &flux.Error{
-					Code: codes.Invalid,
+				return flux.Statistics{}, &influxdb.Error{
+					Code: influxdb.EInvalid,
 					Msg:  "some query error",
 				}
 			},

--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/lang"
@@ -319,7 +320,7 @@ func TestController_AfterShutdown(t *testing.T) {
 
 	if _, err := ctrl.Query(context.Background(), makeRequest(mockCompiler)); err == nil {
 		t.Error("expected error")
-	} else if got, want := err.Error(), "<invalid> query controller shutdown"; got != want {
+	} else if got, want := err.Error(), "query controller shutdown"; got != want {
 		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
 	}
 }
@@ -333,12 +334,17 @@ func TestController_CompileError(t *testing.T) {
 
 	compiler := &mock.Compiler{
 		CompileFn: func(ctx context.Context) (flux.Program, error) {
-			return nil, errors.New("expected error")
+			return nil, &flux.Error{
+				Code: codes.Invalid,
+				Msg:  "expected error",
+			}
 		},
 	}
 	if _, err := ctrl.Query(context.Background(), makeRequest(compiler)); err == nil {
 		t.Error("expected error")
-	} else if got, want := err.Error(), "<invalid> compilation failed: expected error"; got != want {
+	} else if got, want := err.Error(), "<invalid> expected error"; got != want {
+		// TODO(jsternberg): This should be "<invalid> compilation error: expected error", but the
+		// influxdb error library does not include the message when it is wrapping an error for some reason.
 		t.Errorf("unexpected error -want/+got\n\t- %q\n\t+ %q", want, got)
 	}
 }


### PR DESCRIPTION
If we handle the flux errors in the query controller, it makes it so we
are handling the errors in the location where the happen rather than at
a layer further up the stack.

This should simplify it so the errors are handled in this single
location instead.