### PR TITLE
fix(ui/cloud): update location for upgrade button

### DIFF
--- a/ui/src/cloud/components/CheckoutButton.tsx
+++ b/ui/src/cloud/components/CheckoutButton.tsx
@@ -12,11 +12,11 @@ import {
 } from '@influxdata/clockface'
 
 // Constants
-import {CLOUD_CHECKOUT_PATH, CLOUD_URL} from 'src/shared/constants'
+import {CLOUD_BILLING_PATH, CLOUD_URL} from 'src/shared/constants'
 
 const CheckoutButton: FunctionComponent<{}> = () => {
-  const checkoutURL = `${CLOUD_URL}${CLOUD_CHECKOUT_PATH}`
-  const onClick = () => (window.location.href = checkoutURL)
+  const billingURL = `${CLOUD_URL}${CLOUD_BILLING_PATH}`
+  const onClick = () => (window.location.href = billingURL)
 
   return (
     <FeatureFlag name="cloudBilling">

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -48,6 +48,7 @@ export const CLOUD_BILLING_VISIBLE =
   CLOUD && process.env.CLOUD_BILLING_VISIBLE === 'true'
 export const CLOUD_URL = process.env.CLOUD_URL
 export const CLOUD_CHECKOUT_PATH = process.env.CLOUD_CHECKOUT_PATH
+export const CLOUD_BILLING_PATH = process.env.CLOUD_BILLING_PATH
 
 export const VIS_SIG_DIGITS = 4
 


### PR DESCRIPTION

Describe your proposed changes here.
Updates the cloud checkout button to go to billing instead of directly to `/checkout`.

- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass