### PR TITLE
fix(tsdb): add missing err in SeriesPartition.Open

### DIFF
--- a/tsdb/series_partition.go
+++ b/tsdb/series_partition.go
@@ -92,7 +92,7 @@ func (p *SeriesPartition) Open() error {
 
 		if err := p.index.Open(); err != nil {
 			return err
-		} else if p.index.Recover(p.segments); err != nil {
+		} else if err = p.index.Recover(p.segments); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
Closes #

Describe your proposed changes here.
If `SeriesIndex.Recover` fails, the most recent series cannot be queried because the WAL segment has not yet been loaded into the cache.

Therefore, if the `SeriesIndex.Recover` fails, the `SeriesPartition` should not open successfully.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
