### PR TITLE
Use v4 UUID instead of v1 for UI IDs

### DIFF
--- a/ui/src/workers/JobManager.ts
+++ b/ui/src/workers/JobManager.ts
@@ -68,7 +68,7 @@ class JobManager {
 
   // @ts-ignore
   private postJobRequest = async (type: string, payload: any) => {
-    const id = uuid.v1()
+    const id = uuid.v4()
     const deferred = new Deferred()
 
     this.jobs[id] = deferred

--- a/ui/src/workers/utils.ts
+++ b/ui/src/workers/utils.ts
@@ -4,7 +4,7 @@ import uuid from 'uuid'
 import {RequestMessage, ResponseMessage} from 'src/workers/types'
 
 export const postSuccessResponse = async (requestID: string, payload: any) => {
-  const id = uuid.v1()
+  const id = uuid.v4()
 
   await DB.put(id, payload)
 
@@ -18,7 +18,7 @@ export const postSuccessResponse = async (requestID: string, payload: any) => {
 }
 
 export const postErrorResponse = (requestID: string, err: Error) => {
-  const id = uuid.v1()
+  const id = uuid.v4()
 
   const response: ResponseMessage = {
     id,


### PR DESCRIPTION
I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within the code base of influxdb.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

I found three occurrence where v1 UUIDs were being used instead of v4 UUIDs and I was wondering if this case really requires the semantically much more complex v1 UUIDs or whether we could live equally well with purely random v4 UUIDs?

At least the test suite still passes after my changes, so apparently this doesn't seem to introduce any known regressions.

I'd be really curious to understand the motivation for choosing v1 over v4 UUIDs in the first place, so any feedback on this would be highly appreciated!

@chnn, as far as I can tell from the git history you introduced this in https://github.com/influxdata/influxdb/commit/201c4f4304f75d06e72da104dafe702888414905, I'd be really curious about your feedback!

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
