### PR TITLE
fix(templates): import static templates for creating dashboards

### DIFF
--- a/ui/src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay.tsx
+++ b/ui/src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay.tsx
@@ -18,6 +18,9 @@ import TemplateBrowserEmpty from 'src/templates/components/createFromTemplateOve
 import {createDashboardFromTemplate as createDashboardFromTemplateAction} from 'src/dashboards/actions'
 import {getTemplateByID} from 'src/templates/actions'
 
+// Constants
+import {influxdbTemplateList} from 'src/templates/constants/defaultTemplates'
+
 // Types
 import {
   TemplateSummary,
@@ -151,7 +154,14 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
   private handleSelectTemplate = async (
     selectedTemplateSummary: TemplateSummary
   ): Promise<void> => {
-    const selectedTemplate = await getTemplateByID(selectedTemplateSummary.id)
+    const {id} = selectedTemplateSummary
+    let selectedTemplate
+
+    if (!id.includes('influxdb-template')) {
+      selectedTemplate = await getTemplateByID(id)
+    } else {
+      selectedTemplate = selectedTemplateSummary
+    }
 
     this.setState({
       selectedTemplateSummary,
@@ -185,7 +195,7 @@ const mstp = ({templates: {items, status}}: AppState): StateProps => {
   )
 
   return {
-    templates,
+    templates: [...templates, ...influxdbTemplateList],
     templateStatus: status,
   }
 }

--- a/ui/src/templates/components/createFromTemplateOverlay/TemplateBrowserList.tsx
+++ b/ui/src/templates/components/createFromTemplateOverlay/TemplateBrowserList.tsx
@@ -26,11 +26,11 @@ class TemplateBrowser extends PureComponent<Props> {
         {templates.map(t => (
           <TemplateBrowserListItem
             key={t.id}
-            onClick={onSelectTemplate}
-            selected={_.get(selectedTemplateSummary, 'id', '') === t.id}
-            label={t.meta.name}
             template={t}
+            label={t.meta.name}
+            onClick={onSelectTemplate}
             testID={`template--${t.meta.name}`}
+            selected={_.get(selectedTemplateSummary, 'id', '') === t.id}
           />
         ))}
       </DapperScrollbars>

--- a/ui/src/templates/constants/defaultTemplates.ts
+++ b/ui/src/templates/constants/defaultTemplates.ts
@@ -29,3 +29,13 @@ export const staticTemplates = {
   Nginx: nginx,
   Kubernetes: kubernetes,
 }
+
+export const influxdbTemplateList = [
+  system,
+  localMetrics,
+  gettingStarted,
+  docker,
+  nginx,
+  redis,
+  kubernetes,
+].map((t, i) => ({...t, id: `influxdb-template-${i}`}))


### PR DESCRIPTION
Addresses #14341

### The Problem
When trying to create a Dashboard from a template via the Dashboard index the templates from `@influxdata/influxdb-templates` were not listed.  

### The Solution
Import the templates from our package and display them to the user. 

