### PR TITLE
feat(ui): Add link to documentation when uploading line protocol

### DIFF
--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocol.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/LineProtocol.tsx
@@ -60,7 +60,13 @@ export class LineProtocol extends PureComponent<Props> {
             <div>
               <h3 className="wizard-step--title">Add Data via Line Protocol</h3>
               <h5 className="wizard-step--lp-sub-title">
-                Need help writing InfluxDB Line Protocol? See Documentation
+                Need help writing InfluxDB Line Protocol?{' '}
+                <a
+                  href="https://v2.docs.influxdata.com/v2.0/write-data/#write-data-in-the-influxdb-ui"
+                  target="_blank"
+                >
+                  See Documentation
+                </a>
               </h5>
 
               {this.content}

--- a/ui/src/dataLoaders/components/lineProtocolWizard/configure/__snapshots__/LineProtocol.test.tsx.snap
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/configure/__snapshots__/LineProtocol.test.tsx.snap
@@ -26,7 +26,14 @@ exports[`LineProtocol rendering renders! 1`] = `
         <h5
           className="wizard-step--lp-sub-title"
         >
-          Need help writing InfluxDB Line Protocol? See Documentation
+          Need help writing InfluxDB Line Protocol?
+           
+          <a
+            href="https://v2.docs.influxdata.com/v2.0/write-data/#write-data-in-the-influxdb-ui"
+            target="_blank"
+          >
+            See Documentation
+          </a>
         </h5>
         <Connect(LineProtocolTabs)
           bucket="a"


### PR DESCRIPTION
Add documention link in line protocol sub header. 
Link is : https://v2.docs.influxdata.com/v2.0/write-data/#write-data-in-the-influxdb-ui

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
