### PR TITLE
fix(storage): run snapshot before retention deletes

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -531,6 +531,11 @@ func (e *Engine) DeleteBucket(orgID, bucketID platform.ID) error {
 
 // DeleteBucketRange deletes an entire bucket from the storage engine.
 func (e *Engine) DeleteBucketRange(orgID, bucketID platform.ID, min, max int64) error {
+	// Snapshot to clear the cache to reduce write contention.
+	if err := e.engine.WriteSnapshot(context.Background()); err != nil {
+		return err
+	}
+
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	if e.closing == nil {


### PR DESCRIPTION
Deleting from the cache takes a lock which blocks writes. Snapshot to clear the
cache before deleting to reduce the lock contention.

Closes #14399