### PR TITLE
Fix the http handler to not mislabel series as partial

### DIFF
--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -664,6 +664,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 					}
 					// Values are for the same series, so append them.
 					lastSeries.Values = append(lastSeries.Values, row.Values...)
+					lastSeries.Partial = row.Partial
 					rowsMerged++
 				}
 			}

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -319,6 +319,39 @@ func TestHandler_Query_MergeEmptyResults(t *testing.T) {
 	}
 }
 
+// Ensure the handler merges series from the same result.
+func TestHandler_Query_MergeSeries(t *testing.T) {
+	h := NewHandler(false)
+	h.StatementExecutor.ExecuteStatementFn = func(stmt influxql.Statement, ctx *query.ExecutionContext) error {
+		ctx.Results <- &query.Result{StatementID: 1, Series: models.Rows([]*models.Row{
+			{
+				Name: "series0",
+				Values: [][]interface{}{
+					{float64(2.0)},
+				},
+				Partial: true,
+			},
+		})}
+		ctx.Results <- &query.Result{StatementID: 1, Series: models.Rows([]*models.Row{
+			{
+				Name: "series0",
+				Values: [][]interface{}{
+					{float64(3.0)},
+				},
+			},
+		})}
+		return nil
+	}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, MustNewJSONRequest("GET", "/query?db=foo&q=SELECT+*+FROM+bar", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", w.Code)
+	} else if body := strings.TrimSpace(w.Body.String()); body != `{"results":[{"statement_id":1,"series":[{"name":"series0","values":[[2],[3]]}]}]}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
 // Ensure the handler can parse chunked and chunk size query parameters.
 func TestHandler_Query_Chunked(t *testing.T) {
 	h := NewHandler(false)

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -6861,17 +6861,20 @@ func TestServer_Query_TimeZone(t *testing.T) {
 	}
 }
 
-func TestServer_Query_Chunk(t *testing.T) {
+func TestServer_Query_MaxRowLimit(t *testing.T) {
 	t.Parallel()
-	s := OpenServer(NewConfig())
+	config := NewConfig()
+	config.HTTPD.MaxRowLimit = 10
+
+	s := OpenServer(config)
 	defer s.Close()
 
 	if err := s.CreateDatabaseAndRetentionPolicy("db0", NewRetentionPolicySpec("rp0", 1, 0), true); err != nil {
 		t.Fatal(err)
 	}
 
-	writes := make([]string, 10001) // 10,000 is the default chunking size, even when no chunking requested.
-	expectedValues := make([]string, len(writes))
+	writes := make([]string, 11) // write one extra value beyond the max row limit
+	expectedValues := make([]string, 10)
 	for i := 0; i < len(writes); i++ {
 		writes[i] = fmt.Sprintf(`cpu value=%d %d`, i, time.Unix(0, int64(i)).UnixNano())
 		if i < len(expectedValues) {


### PR DESCRIPTION
If a series was split by the encoder because of chunking and it was
reconstructed by the http handler, it would not reset the partial
indicator for the series to indicate if the series was still partial or
not. That meant that a result that returned more than the 10,000 values
in a single series with chunking disabled would say that the series was
partial, but it was not.

This fixes it so the handler now correctly sets the partial attribute of
the series to indicate if the series is still partial or not. This was
done when merging results, but was not done with series.