### PR TITLE
Fix aggregate window: change name parameter to period

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6834,7 +6834,7 @@ components:
         aggregateWindow:
           type: object
           properties:
-            name:
+            period:
               type: string
     BuilderTagsType:
       type: object


### PR DESCRIPTION
There was a mistake in our swagger, changed name to period