### PR TITLE
Add delete with predicate overlays

### DIFF
--- a/ui/src/buckets/components/BucketCard.tsx
+++ b/ui/src/buckets/components/BucketCard.tsx
@@ -18,6 +18,7 @@ export interface PrettyBucket extends Bucket {
 interface Props {
   bucket: PrettyBucket
   onEditBucket: (b: PrettyBucket) => void
+  onDeleteData: (b: PrettyBucket) => void
   onDeleteBucket: (b: PrettyBucket) => void
   onAddData: (b: PrettyBucket, d: DataLoaderType, l: string) => void
   onUpdateBucket: (b: PrettyBucket) => void
@@ -26,7 +27,7 @@ interface Props {
 
 class BucketRow extends PureComponent<Props & WithRouterProps> {
   public render() {
-    const {bucket, onDeleteBucket} = this.props
+    const {bucket, onDeleteBucket, onDeleteData} = this.props
     return (
       <>
         <ResourceList.Card
@@ -34,7 +35,8 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
           contextMenu={() => (
             <BucketContextMenu
               bucket={bucket}
-              onDelete={onDeleteBucket}
+              onDeleteBucket={onDeleteBucket}
+              onDeleteData={onDeleteData}
               onRename={this.handleRenameBucket}
               onAddCollector={this.handleAddCollector}
               onAddLineProtocol={this.handleAddLineProtocol}

--- a/ui/src/buckets/components/BucketContextMenu.tsx
+++ b/ui/src/buckets/components/BucketContextMenu.tsx
@@ -3,6 +3,7 @@ import React, {PureComponent} from 'react'
 
 // Components
 import {Context, Alignment, ComponentSize} from 'src/clockface'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
 
@@ -20,7 +21,8 @@ import {PrettyBucket} from 'src/buckets/components/BucketCard'
 
 interface Props {
   bucket: PrettyBucket
-  onDelete: (bucket: PrettyBucket) => void
+  onDeleteBucket: (bucket: PrettyBucket) => void
+  onDeleteData: (bucket: PrettyBucket) => void
   onRename: () => void
   onAddCollector: () => void
   onAddLineProtocol: () => void
@@ -31,7 +33,8 @@ export default class MemberContextMenu extends PureComponent<Props> {
   public render() {
     const {
       bucket,
-      onDelete,
+      onDeleteBucket,
+      onDeleteData,
       onRename,
       onAddCollector,
       onAddLineProtocol,
@@ -51,15 +54,25 @@ export default class MemberContextMenu extends PureComponent<Props> {
               color={ComponentColor.Danger}
             >
               <Context.Item label="Rename" action={onRename} value={bucket} />
+              <FeatureFlag name="deleteWithPredicate">
+                <Context.Item
+                  label="Delete Data By Filter"
+                  action={onDeleteData}
+                  value={bucket}
+                  testID="context-delete-task"
+                />
+              </FeatureFlag>
             </Context.Menu>
             <Context.Menu
               icon={IconFont.Trash}
               color={ComponentColor.Danger}
+              shape={ButtonShape.Default}
+              text="Delete Bucket"
               testID="context-delete-menu"
             >
               <Context.Item
                 label="Delete"
-                action={onDelete}
+                action={onDeleteBucket}
                 value={bucket}
                 testID="context-delete-task"
               />

--- a/ui/src/buckets/components/BucketList.tsx
+++ b/ui/src/buckets/components/BucketList.tsx
@@ -125,6 +125,7 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
         bucket={bucket}
         onEditBucket={this.handleStartEdit}
         onDeleteBucket={onDeleteBucket}
+        onDeleteData={this.handleStartDeleteData}
         onAddData={this.handleStartAddData}
         onUpdateBucket={this.handleUpdateBucket}
         onFilterChange={onFilterChange}
@@ -136,6 +137,12 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
     const {orgID} = this.props.params
 
     this.props.router.push(`/orgs/${orgID}/buckets/${bucket.id}/edit`)
+  }
+
+  private handleStartDeleteData = (bucket: PrettyBucket) => {
+    const {orgID} = this.props.params
+
+    this.props.router.push(`/orgs/${orgID}/buckets/${bucket.id}/delete-data`)
   }
 
   private handleStartAddData = (

--- a/ui/src/dataExplorer/components/DataExplorerPage.tsx
+++ b/ui/src/dataExplorer/components/DataExplorerPage.tsx
@@ -10,6 +10,7 @@ import ViewTypeDropdown from 'src/timeMachine/components/view_options/ViewTypeDr
 import PageTitleWithOrg from 'src/shared/components/PageTitleWithOrg'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 import TimeZoneDropdown from 'src/shared/components/TimeZoneDropdown'
+import DeleteDataButton from 'src/dataExplorer/components/DeleteDataButton'
 
 const DataExplorerPage: SFC = ({children}) => {
   return (
@@ -21,6 +22,7 @@ const DataExplorerPage: SFC = ({children}) => {
             <PageTitleWithOrg title="Data Explorer" />
           </Page.Header.Left>
           <Page.Header.Right>
+            <DeleteDataButton />
             <TimeZoneDropdown />
             <ViewTypeDropdown />
             <VisOptionsButton />

--- a/ui/src/dataExplorer/components/DeleteDataButton.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataButton.tsx
@@ -1,0 +1,26 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+
+// Components
+import {Button} from '@influxdata/clockface'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
+
+const DeleteDataButton: FunctionComponent<WithRouterProps> = ({
+  location: {pathname},
+  router,
+}) => {
+  const onClick = () => router.push(`${pathname}/delete-data`)
+
+  return (
+    <FeatureFlag name="deleteWithPredicate">
+      <Button
+        text="Delete Data"
+        onClick={onClick}
+        titleText="Filter and mark data for deletion"
+      />
+    </FeatureFlag>
+  )
+}
+
+export default withRouter<{}>(DeleteDataButton)

--- a/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
@@ -1,0 +1,74 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+import {withRouter, WithRouterProps} from 'react-router'
+import {Overlay} from '@influxdata/clockface'
+import {get} from 'lodash'
+
+// Components
+import DeleteDataForm from 'src/shared/components/DeleteDataForm/DeleteDataForm'
+import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
+
+// Utils
+import {getActiveTimeMachine, getActiveQuery} from 'src/timeMachine/selectors'
+
+// Types
+import {AppState, TimeRange} from 'src/types'
+
+const resolveTimeRange = (timeRange: TimeRange): [number, number] | null => {
+  const [lower, upper] = [
+    Date.parse(timeRange.lower),
+    Date.parse(timeRange.upper),
+  ]
+
+  if (!isNaN(lower) && !isNaN(upper)) {
+    return [lower, upper]
+  }
+
+  return null
+}
+
+interface StateProps {
+  selectedBucketName?: string
+  selectedTimeRange?: [number, number]
+}
+
+const DeleteDataOverlay: FunctionComponent<StateProps & WithRouterProps> = ({
+  selectedBucketName,
+  selectedTimeRange,
+  router,
+  params: {orgID},
+}) => {
+  const handleDismiss = () => router.push(`/orgs/${orgID}/data-explorer`)
+
+  return (
+    <Overlay visible={true}>
+      <Overlay.Container maxWidth={600}>
+        <Overlay.Header title="Delete Data" onDismiss={handleDismiss} />
+        <Overlay.Body>
+          <GetResources resource={ResourceTypes.Buckets}>
+            <DeleteDataForm
+              initialBucketName={selectedBucketName}
+              initialTimeRange={selectedTimeRange}
+              orgID={orgID}
+            />
+          </GetResources>
+        </Overlay.Body>
+      </Overlay.Container>
+    </Overlay>
+  )
+}
+
+const mstp = (state: AppState): StateProps => {
+  const activeQuery = getActiveQuery(state)
+  const selectedBucketName = get(activeQuery, 'builderConfig.buckets.0')
+
+  const {timeRange} = getActiveTimeMachine(state)
+  const selectedTimeRange = resolveTimeRange(timeRange)
+
+  return {selectedBucketName, selectedTimeRange}
+}
+
+export default connect<StateProps>(mstp)(
+  withRouter<StateProps>(DeleteDataOverlay)
+)

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -76,6 +76,8 @@ import TaskImportFromTemplateOverlay from './tasks/components/TaskImportFromTemp
 import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateViewOverlay'
 import AlertingIndex from 'src/alerting/containers/AlertingIndex'
 import AlertHistoryIndex from 'src/alerting/containers/AlertHistoryIndex'
+import BucketsDeleteDataOverlay from 'src/shared/components/DeleteDataOverlay'
+import DEDeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
 
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
@@ -169,6 +171,10 @@ class Root extends PureComponent {
                             component={DataExplorerPage}
                           >
                             <Route path="save" component={SaveAsOverlay} />
+                            <Route
+                              path="delete-data"
+                              component={DEDeleteDataOverlay}
+                            />
                           </Route>
                           <Route path="dashboards" component={DashboardsIndex}>
                             <Route
@@ -222,6 +228,10 @@ class Root extends PureComponent {
                               <Route
                                 path="edit"
                                 component={UpdateBucketOverlay}
+                              />
+                              <Route
+                                path="delete-data"
+                                component={BucketsDeleteDataOverlay}
                               />
                               <Route
                                 path="rename"

--- a/ui/src/shared/components/DeleteDataForm/BucketsDropdown.tsx
+++ b/ui/src/shared/components/DeleteDataForm/BucketsDropdown.tsx
@@ -1,0 +1,40 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+import {Dropdown} from '@influxdata/clockface'
+
+// Types
+import {AppState, Bucket} from 'src/types'
+
+interface StateProps {
+  buckets: Bucket[]
+}
+
+interface OwnProps {
+  bucketName: string
+  onSetBucketName: (bucketName: string) => any
+}
+
+type Props = StateProps & OwnProps
+
+const BucketsDropdown: FunctionComponent<Props> = ({
+  buckets,
+  bucketName,
+  onSetBucketName,
+}) => {
+  return (
+    <Dropdown selectedID={bucketName} onChange={onSetBucketName}>
+      {buckets.map(bucket => (
+        <Dropdown.Item key={bucket.name} id={bucket.name} value={bucket.name}>
+          {bucket.name}
+        </Dropdown.Item>
+      ))}
+    </Dropdown>
+  )
+}
+
+const mstp = (state: AppState): StateProps => ({
+  buckets: state.buckets.list,
+})
+
+export default connect<StateProps, {}, OwnProps>(mstp)(BucketsDropdown)

--- a/ui/src/shared/components/DeleteDataForm/DeleteButton.tsx
+++ b/ui/src/shared/components/DeleteDataForm/DeleteButton.tsx
@@ -1,0 +1,59 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {
+  Button,
+  ComponentColor,
+  ComponentStatus,
+  Icon,
+  IconFont,
+} from '@influxdata/clockface'
+
+// Types
+import {RemoteDataState} from 'src/types'
+
+interface Props {
+  status: RemoteDataState
+  valid: boolean
+  onClick: () => any
+}
+
+const DeleteButton: FunctionComponent<Props> = ({status, valid, onClick}) => {
+  if (status === RemoteDataState.Done) {
+    return (
+      <div className="delete-data-button delete-data-button--success">
+        <Icon glyph={IconFont.Checkmark} />
+        Success!
+      </div>
+    )
+  }
+
+  if (status === RemoteDataState.Error) {
+    return (
+      <div className="delete-data-button delete-data-button--error">
+        <Icon glyph={IconFont.Remove} />
+        An error occured and has been reported.
+      </div>
+    )
+  }
+
+  let deleteButtonStatus
+
+  if (status === RemoteDataState.Loading) {
+    deleteButtonStatus = ComponentStatus.Loading
+  } else if (!valid) {
+    deleteButtonStatus = ComponentStatus.Disabled
+  } else {
+    deleteButtonStatus = ComponentStatus.Default
+  }
+
+  return (
+    <Button
+      text="Confirm Delete"
+      color={ComponentColor.Danger}
+      status={deleteButtonStatus}
+      onClick={onClick}
+    />
+  )
+}
+
+export default DeleteButton

--- a/ui/src/shared/components/DeleteDataForm/DeleteDataForm.scss
+++ b/ui/src/shared/components/DeleteDataForm/DeleteDataForm.scss
@@ -1,0 +1,67 @@
+.delete-data-filters--filters,
+.delete-data-filters--no-filters
+{
+  margin: $ix-marg-c 0;
+}
+
+.delete-data-filters--no-filters {
+  text-align: center;
+  padding: $ix-marg-d $ix-marg-b;
+}
+
+.delete-data-filter {
+  display: flex; 
+  justify-content: stretch;
+}
+
+.delete-data-filter--equals {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: $g5-pepper;
+  border-radius: $radius;
+  height: $form-sm-height;
+  padding: $form-sm-padding;
+  margin: 0 $ix-marg-a;
+  user-select: none;
+}
+
+.delete-data-filter--remove,
+.delete-data-filter--equals,
+{
+  margin-top: 18px;
+}
+
+.delete-data-filter--remove {
+  flex: 0 0 auto;
+  margin-left: $ix-marg-a;
+}
+
+.delete-data-form--danger-zone {
+  border: 1px solid $c-curacao;
+}
+
+.delete-data-form--confirm {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: $ix-marg-b;
+  height: $form-sm-height;
+}
+
+.delete-data-button {
+  font-weight: bold;
+  font-size: $ix-text-base;
+
+  .icon {
+    padding-right: $ix-marg-a;
+  }
+
+  &.delete-data-button--success {
+    color: $c-viridian;
+  }
+
+  &.delete-data-button--error {
+    color: $c-fire;
+  }
+}

--- a/ui/src/shared/components/DeleteDataForm/DeleteDataForm.tsx
+++ b/ui/src/shared/components/DeleteDataForm/DeleteDataForm.tsx
@@ -1,0 +1,203 @@
+// Libraries
+import React, {useReducer, FunctionComponent} from 'react'
+import moment from 'moment'
+import {Form, Grid, Columns, Panel} from '@influxdata/clockface'
+
+// Components
+import BucketsDropdown from 'src/shared/components/DeleteDataForm/BucketsDropdown'
+import TimeRangeDropdown from 'src/shared/components/DeleteDataForm/TimeRangeDropdown'
+import Checkbox from 'src/shared/components/Checkbox'
+import DeleteButton from 'src/shared/components/DeleteDataForm/DeleteButton'
+import FilterEditor, {
+  Filter,
+} from 'src/shared/components/DeleteDataForm/FilterEditor'
+
+// Types
+import {RemoteDataState} from 'src/types'
+
+const HOUR_MS = 1000 * 60 * 60
+
+const FAKE_API_CALL = async (_: any) => {
+  await new Promise(res => setTimeout(res, 2000))
+}
+
+interface Props {
+  orgID: string
+  initialBucketName?: string
+  initialTimeRange?: [number, number]
+}
+
+interface State {
+  bucketName: string
+  timeRange: [number, number]
+  filters: Filter[]
+  isSerious: boolean
+  deletionStatus: RemoteDataState
+}
+
+type Action =
+  | {type: 'SET_IS_SERIOUS'; isSerious: boolean}
+  | {type: 'SET_BUCKET_NAME'; bucketName: string}
+  | {type: 'SET_TIME_RANGE'; timeRange: [number, number]}
+  | {type: 'SET_FILTER'; filter: Filter; index: number}
+  | {type: 'DELETE_FILTER'; index: number}
+  | {type: 'SET_DELETION_STATUS'; deletionStatus: RemoteDataState}
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'SET_IS_SERIOUS':
+      return {...state, isSerious: action.isSerious}
+
+    case 'SET_BUCKET_NAME':
+      return {...state, bucketName: action.bucketName}
+
+    case 'SET_TIME_RANGE':
+      return {...state, timeRange: action.timeRange}
+
+    case 'SET_FILTER':
+      if (action.index >= state.filters.length) {
+        return {...state, filters: [...state.filters, action.filter]}
+      }
+
+      return {
+        ...state,
+        filters: state.filters.map((filter, i) =>
+          i === action.index ? action.filter : filter
+        ),
+      }
+
+    case 'DELETE_FILTER':
+      return {
+        ...state,
+        filters: state.filters.filter((_, i) => i !== action.index),
+      }
+
+    case 'SET_DELETION_STATUS':
+      return {...state, deletionStatus: action.deletionStatus}
+
+    default:
+      throw new Error('unhandled reducer action in <DeleteDataForm />')
+  }
+}
+
+const DeleteDataForm: FunctionComponent<Props> = ({
+  orgID,
+  initialBucketName,
+  initialTimeRange,
+}) => {
+  const recently = Date.parse(moment().format('YYYY-MM-DD HH:00:00'))
+
+  const initialState: State = {
+    bucketName: initialBucketName,
+    filters: [],
+    timeRange: initialTimeRange || [recently - HOUR_MS, recently],
+    isSerious: false,
+    deletionStatus: RemoteDataState.NotStarted,
+  }
+
+  const [state, dispatch] = useReducer(reducer, initialState)
+
+  const canDelete =
+    state.isSerious &&
+    state.deletionStatus === RemoteDataState.NotStarted &&
+    state.filters.every(f => !!f.key && !!f.value)
+
+  const handleDelete = async () => {
+    try {
+      dispatch({
+        type: 'SET_DELETION_STATUS',
+        deletionStatus: RemoteDataState.Loading,
+      })
+
+      const deleteRequest = {
+        query: {
+          bucket: state.bucketName,
+          org: orgID,
+          precision: 'ms',
+        },
+
+        body: {
+          start: state.timeRange[0],
+          stop: state.timeRange[1],
+          tags: state.filters,
+        },
+      }
+
+      await FAKE_API_CALL(deleteRequest)
+
+      dispatch({
+        type: 'SET_DELETION_STATUS',
+        deletionStatus: RemoteDataState.Done,
+      })
+    } catch {
+      dispatch({
+        type: 'SET_DELETION_STATUS',
+        deletionStatus: RemoteDataState.Error,
+      })
+    }
+  }
+
+  return (
+    <Form className="delete-data-form">
+      <Grid>
+        <Grid.Row>
+          <Grid.Column widthXS={Columns.Four}>
+            <Form.Element label="Target Bucket">
+              <BucketsDropdown
+                bucketName={state.bucketName}
+                onSetBucketName={bucketName =>
+                  dispatch({type: 'SET_BUCKET_NAME', bucketName})
+                }
+              />
+            </Form.Element>
+          </Grid.Column>
+          <Grid.Column widthXS={Columns.Eight}>
+            <Form.Element label="Time Range">
+              <TimeRangeDropdown
+                timeRange={state.timeRange}
+                onSetTimeRange={timeRange =>
+                  dispatch({type: 'SET_TIME_RANGE', timeRange})
+                }
+              />
+            </Form.Element>
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row>
+          <Grid.Column widthXS={Columns.Twelve}>
+            <FilterEditor
+              filters={state.filters}
+              onSetFilter={(filter, index) =>
+                dispatch({type: 'SET_FILTER', filter, index})
+              }
+              onDeleteFilter={index => dispatch({type: 'DELETE_FILTER', index})}
+              shouldValidate={state.isSerious}
+            />
+          </Grid.Column>
+        </Grid.Row>
+        <Grid.Row>
+          <Grid.Column widthXS={Columns.Twelve}>
+            <Panel className="delete-data-form--danger-zone">
+              <Panel.Header title="Danger Zone!" />
+              <Panel.Body className="delete-data-form--confirm">
+                <Checkbox
+                  label="I understand that this cannot be undone."
+                  checked={state.isSerious}
+                  onSetChecked={isSerious =>
+                    dispatch({type: 'SET_IS_SERIOUS', isSerious})
+                  }
+                />
+                <DeleteButton
+                  status={state.deletionStatus}
+                  valid={canDelete}
+                  onClick={handleDelete}
+                />
+              </Panel.Body>
+            </Panel>
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
+    </Form>
+  )
+}
+
+export default DeleteDataForm

--- a/ui/src/shared/components/DeleteDataForm/FilterEditor.tsx
+++ b/ui/src/shared/components/DeleteDataForm/FilterEditor.tsx
@@ -1,0 +1,61 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {Button, IconFont, ButtonShape, Panel} from '@influxdata/clockface'
+
+// Components
+import FilterRow from 'src/shared/components/DeleteDataForm/FilterRow'
+
+export interface Filter {
+  key: string
+  value: string
+}
+
+interface Props {
+  filters: Filter[]
+  onSetFilter: (filter: Filter, index: number) => any
+  onDeleteFilter: (index: number) => any
+  shouldValidate: boolean
+}
+
+const FilterEditor: FunctionComponent<Props> = ({
+  filters,
+  onSetFilter,
+  onDeleteFilter,
+  shouldValidate,
+}) => {
+  return (
+    <div className="delete-data-filters">
+      <Button
+        text="Add Filter"
+        icon={IconFont.Plus}
+        shape={ButtonShape.StretchToFit}
+        className="delete-data-filters--new-filter"
+        onClick={() => onSetFilter({key: '', value: ''}, filters.length)}
+      />
+      {filters.length > 0 ? (
+        <div className="delete-data-filters--filters">
+          {filters.map((filter, i) => (
+            <FilterRow
+              key={i}
+              filter={filter}
+              onChange={filter => onSetFilter(filter, i)}
+              onDelete={() => onDeleteFilter(i)}
+              shouldValidate={shouldValidate}
+            />
+          ))}
+        </div>
+      ) : (
+        <Panel className="delete-data-filters--no-filters">
+          <Panel.Body>
+            <p>
+              If no filters are specified, all data points in the selected time
+              range will be marked for deletion.
+            </p>
+          </Panel.Body>
+        </Panel>
+      )}
+    </div>
+  )
+}
+
+export default FilterEditor

--- a/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
+++ b/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
@@ -1,0 +1,57 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {Form, Input, Button, ButtonShape, IconFont} from '@influxdata/clockface'
+
+// Types
+import {Filter} from 'src/shared/components/DeleteDataForm/FilterEditor'
+
+interface Props {
+  filter: Filter
+  onChange: (filter: Filter) => any
+  onDelete: () => any
+  shouldValidate: boolean
+}
+
+const FilterRow: FunctionComponent<Props> = ({
+  filter: {key, value},
+  onChange,
+  onDelete,
+  shouldValidate,
+}) => {
+  const keyErrorMessage =
+    shouldValidate && key.trim() === '' ? 'Key cannot be empty' : null
+
+  const valueErrorMessage =
+    shouldValidate && value.trim() === '' ? 'Value cannot be empty' : null
+
+  const onChangeKey = e => onChange({key: e.target.value, value})
+  const onChangeValue = e => onChange({key, value: e.target.value})
+
+  return (
+    <div className="delete-data-filter">
+      <Form.Element
+        label="Tag Key"
+        required={true}
+        errorMessage={keyErrorMessage}
+      >
+        <Input value={key} onChange={onChangeKey} />
+      </Form.Element>
+      <div className="delete-data-filter--equals">==</div>
+      <Form.Element
+        label="Tag Value"
+        required={true}
+        errorMessage={valueErrorMessage}
+      >
+        <Input value={value} onChange={onChangeValue} />
+      </Form.Element>
+      <Button
+        className="delete-data-filter--remove"
+        shape={ButtonShape.Square}
+        icon={IconFont.Remove}
+        onClick={onDelete}
+      />
+    </div>
+  )
+}
+
+export default FilterRow

--- a/ui/src/shared/components/DeleteDataForm/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/DeleteDataForm/TimeRangeDropdown.tsx
@@ -1,0 +1,51 @@
+// Libraries
+import React, {useRef, useState, FunctionComponent} from 'react'
+import moment from 'moment'
+import {Dropdown} from '@influxdata/clockface'
+
+// Components
+import DateRangePicker from 'src/shared/components/dateRangePicker/DateRangePicker'
+
+interface Props {
+  timeRange: [number, number]
+  onSetTimeRange: (timeRange: [number, number]) => any
+}
+
+const TimeRangeDropdown: FunctionComponent<Props> = ({
+  timeRange,
+  onSetTimeRange,
+}) => {
+  const [pickerActive, setPickerActive] = useState(false)
+  const buttonRef = useRef<HTMLDivElement>(null)
+
+  let datePickerPosition = null
+
+  if (buttonRef.current) {
+    const {right, top} = buttonRef.current.getBoundingClientRect()
+
+    datePickerPosition = {top: top, right: window.innerWidth - right}
+  }
+
+  const lower = moment(timeRange[0]).format('YYYY-MM-DD HH:mm:ss')
+  const upper = moment(timeRange[1]).format('YYYY-MM-DD HH:mm:ss')
+
+  return (
+    <div ref={buttonRef}>
+      <Dropdown.Button onClick={() => setPickerActive(!pickerActive)}>
+        {lower} - {upper}
+      </Dropdown.Button>
+      {pickerActive && (
+        <DateRangePicker
+          timeRange={{lower, upper}}
+          onSetTimeRange={({lower, upper}) =>
+            onSetTimeRange([Date.parse(lower), Date.parse(upper)])
+          }
+          position={datePickerPosition}
+          onClose={() => setPickerActive(false)}
+        />
+      )}
+    </div>
+  )
+}
+
+export default TimeRangeDropdown

--- a/ui/src/shared/components/DeleteDataOverlay.tsx
+++ b/ui/src/shared/components/DeleteDataOverlay.tsx
@@ -1,0 +1,43 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+import {withRouter, WithRouterProps} from 'react-router'
+import {Overlay} from '@influxdata/clockface'
+
+// Components
+import DeleteDataForm from 'src/shared/components/DeleteDataForm/DeleteDataForm'
+
+// Types
+import {Bucket, AppState} from 'src/types'
+
+interface StateProps {
+  buckets: Bucket[]
+}
+
+const DeleteDataOverlay: FunctionComponent<StateProps & WithRouterProps> = ({
+  router,
+  params: {orgID, bucketID},
+  buckets,
+}) => {
+  const handleDismiss = () => router.push(`/orgs/${orgID}/buckets/${bucketID}`)
+  const bucketName = buckets.find(bucket => bucket.id === bucketID).name
+
+  return (
+    <Overlay visible={true}>
+      <Overlay.Container maxWidth={600}>
+        <Overlay.Header title="Delete Data" onDismiss={handleDismiss} />
+        <Overlay.Body>
+          <DeleteDataForm initialBucketName={bucketName} orgID={orgID} />
+        </Overlay.Body>
+      </Overlay.Container>
+    </Overlay>
+  )
+}
+
+const mstp = (state: AppState): StateProps => {
+  return {buckets: state.buckets.list}
+}
+
+export default connect<StateProps>(mstp)(
+  withRouter<StateProps>(DeleteDataOverlay)
+)

--- a/ui/src/shared/components/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/TimeRangeDropdown.tsx
@@ -26,6 +26,7 @@ export enum RangeType {
 interface Props {
   timeRange: TimeRange
   onSetTimeRange: (timeRange: TimeRange, rangeType?: RangeType) => void
+  centerPicker: boolean
 }
 
 interface State {
@@ -34,6 +35,10 @@ interface State {
 }
 
 class TimeRangeDropdown extends PureComponent<Props, State> {
+  public static defaultProps = {
+    centerPicker: false,
+  }
+
   private dropdownRef = createRef<HTMLDivElement>()
 
   constructor(props: Props) {
@@ -44,6 +49,7 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
 
   public render() {
     const timeRange = this.timeRange
+    const {centerPicker} = this.props
 
     return (
       <>
@@ -52,7 +58,7 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
             timeRange={timeRange}
             onSetTimeRange={this.handleApplyTimeRange}
             onClose={this.handleHideDatePicker}
-            position={this.state.dropdownPosition}
+            position={centerPicker ? null : this.state.dropdownPosition}
           />
         )}
         <div ref={this.dropdownRef}>

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, createRef, CSSProperties} from 'react'
+import React, {PureComponent, CSSProperties} from 'react'
 
 // Components
 import DatePicker from 'src/shared/components/dateRangePicker/DatePicker'
@@ -12,45 +12,24 @@ import {Button, ComponentColor, ComponentSize} from '@influxdata/clockface'
 interface Props {
   timeRange: TimeRange
   onSetTimeRange: (timeRange: TimeRange) => void
-  position?: {top: number; right: number}
   onClose: () => void
+  position?: {top?: number; right?: number; bottom?: number; left?: number}
 }
 
 interface State {
   lower: string
   upper: string
-  bottomPosition?: number
-  topPosition?: number
 }
 
-const PICKER_HEIGHT = 416
-const HORIZONTAL_PADDING = 2
-const VERTICAL_PADDING = 15
-
 class DateRangePicker extends PureComponent<Props, State> {
-  private rangePickerRef = createRef<HTMLDivElement>()
-
   constructor(props: Props) {
     super(props)
+
     const {
       timeRange: {lower, upper},
     } = props
 
-    this.state = {lower, upper, bottomPosition: null}
-  }
-
-  public componentDidMount() {
-    const {
-      bottom,
-      top,
-      height,
-    } = this.rangePickerRef.current.getBoundingClientRect()
-
-    if (bottom > window.innerHeight) {
-      this.setState({bottomPosition: height / 2})
-    } else if (top < 0) {
-      this.setState({topPosition: height / 2})
-    }
+    this.state = {lower, upper}
   }
 
   public render() {
@@ -61,7 +40,6 @@ class DateRangePicker extends PureComponent<Props, State> {
       <ClickOutside onClickOutside={onClose}>
         <div
           className="range-picker react-datepicker-ignore-onclickoutside"
-          ref={this.rangePickerRef}
           style={this.stylePosition}
         >
           <button className="range-picker--dismiss" onClick={onClose} />
@@ -91,28 +69,21 @@ class DateRangePicker extends PureComponent<Props, State> {
 
   private get stylePosition(): CSSProperties {
     const {position} = this.props
-    const {bottomPosition, topPosition} = this.state
 
     if (!position) {
-      return
-    }
-
-    const {top, right} = position
-
-    if (topPosition) {
       return {
-        top: '14px',
-        right: `${right + HORIZONTAL_PADDING}px`,
+        top: `${window.innerHeight / 2}px`,
+        left: `${window.innerWidth / 2}px`,
+        transform: `translate(-50%, -50%)`,
       }
     }
 
-    const bottomPx =
-      (bottomPosition || window.innerHeight - top - VERTICAL_PADDING) -
-      PICKER_HEIGHT / 2
-    return {
-      bottom: `${bottomPx}px`,
-      right: `${right + HORIZONTAL_PADDING}px`,
-    }
+    const style = Object.entries(position).reduce(
+      (acc, [k, v]) => ({...acc, [k]: `${v}px`}),
+      {}
+    )
+
+    return style
   }
 
   private handleSetTimeRange = (): void => {

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -3,10 +3,12 @@ import {CLOUD, CLOUD_BILLING_VISIBLE} from 'src/shared/constants'
 
 const OSS_FLAGS = {
   alerting: false,
+  deleteWithPredicate: false,
 }
 
 const CLOUD_FLAGS = {
   alerting: false,
+  deleteWithPredicate: false,
   cloudBilling: CLOUD_BILLING_VISIBLE, // should be visible in dev and acceptance, but not in cloud
 }
 

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -109,6 +109,8 @@
 @import 'src/onboarding/components/SigninForm.scss';
 @import 'src/shared/components/ThresholdsSettings.scss';
 @import 'src/shared/components/ThresholdMarkers.scss';
+@import 'src/shared/components/DeleteDataForm/DeleteDataForm.scss';
+
 
 // External
 @import '../../node_modules/@influxdata/react-custom-scrollbars/dist/styles.css';

--- a/ui/src/timeMachine/components/Queries.tsx
+++ b/ui/src/timeMachine/components/Queries.tsx
@@ -92,6 +92,7 @@ class TimeMachineQueries extends PureComponent<Props> {
               <TimeRangeDropdown
                 timeRange={timeRange}
                 onSetTimeRange={this.handleSetTimeRange}
+                centerPicker={true}
               />
               <TimeMachineQueriesSwitcher />
               <SubmitQueryButton />


### PR DESCRIPTION
Closes #14354
Closes #14355

Adds a "Delete Data" overlay accessible from the buckets list:

![delete with predicate](https://user-images.githubusercontent.com/638955/61665833-e6d9ab80-ac8a-11e9-80fa-6445800099fb.gif)

![error state](https://user-images.githubusercontent.com/638955/61665910-18527700-ac8b-11e9-962a-cf68787d0192.gif)

The API doesn't exist yet, so the relevant parts of the code are stubbed out and the UI is feature flagged.

The overlay is also accessible from the DE:

![in de](https://user-images.githubusercontent.com/638955/61665960-2ef8ce00-ac8b-11e9-8df1-5e1665c28f39.gif)


