### PR TITLE
Fixed task manual run notification type

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,5 +17,5 @@ markComment: >
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
   This issue has been automatically closed because it has not had
-  recent activity. Please reopen if this issue is still 
+  recent activity. Please reopen if this issue is still
   important to you. Thank you for your contributions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 1. [14287](https://github.com/influxdata/influxdb/pull/14287) Fix incorrect reporting of task as successful when error occurs during result iteration 
+1. [14412](https://github.com/influxdata/influxdb/pull/14412) Fix incorrect notification type for manually running a Task
 
 ### Known Issues
 

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -500,13 +500,13 @@ export const taskImportSuccess = (): Notification => ({
 })
 
 export const taskRunSuccess = (): Notification => ({
-  ...defaultErrorNotification,
+  ...defaultSuccessNotification,
   duration: FIVE_SECONDS,
   message: 'Task scheduled successfully',
 })
 
 export const taskRunFailed = (error: string): Notification => ({
-  ...defaultSuccessNotification,
+  ...defaultErrorNotification,
   duration: FIVE_SECONDS,
   message: `Failed to run task: ${error}`,
 })


### PR DESCRIPTION
Closes #

Describe your proposed changes here.
The notification types on the manual run task were swapped. this fixes that.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
