### PR TITLE
move logger facility back to Info from Debug

### DIFF
--- a/logger/fields.go
+++ b/logger/fields.go
@@ -111,7 +111,7 @@ func NewOperation(ctx context.Context, log *zap.Logger, msg, name string, fields
 
 	now := time.Now()
 	log = log.With(f...)
-	log.Debug(msg+" (start)", OperationEventStart())
+	log.Info(msg+" (start)", OperationEventStart())
 
-	return log, func() { log.Debug(msg+" (end)", OperationEventEnd(), OperationElapsed(time.Since(now))) }
+	return log, func() { log.Info(msg+" (end)", OperationEventEnd(), OperationElapsed(time.Since(now))) }
 }

--- a/task/backend/executor/executor.go
+++ b/task/backend/executor/executor.go
@@ -142,11 +142,11 @@ func (p *syncRunPromise) finish(res *runResult, err error) {
 		close(p.ready)
 
 		if err != nil {
-			p.logger.Debug("Execution failed to get result", zap.Error(err))
+			p.logger.Info("Execution failed to get result", zap.Error(err))
 		} else if res.err != nil {
-			p.logger.Debug("Got result with error", zap.Error(res.err))
+			p.logger.Info("Got result with error", zap.Error(res.err))
 		} else {
-			p.logger.Debug("Completed successfully")
+			p.logger.Info("Completed successfully")
 		}
 	})
 }
@@ -378,7 +378,7 @@ func (p *asyncRunPromise) finish(res *runResult, err error) {
 		} else if res.err != nil {
 			p.logger.Info("Got result with error", zap.Error(res.err))
 		} else {
-			p.logger.Debug("Completed successfully")
+			p.logger.Info("Completed successfully")
 		}
 	})
 }

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -679,7 +679,7 @@ func (r *runner) startFromWorking(now int64) {
 	// and we'll quickly end up with many run_ids associated with the log.
 	runLogger := r.logger.With(logger.TraceID(ctx), zap.String("run_id", qr.RunID.String()), zap.Int64("now", qr.Now))
 
-	runLogger.Debug("Created run; beginning execution")
+	runLogger.Info("Created run; beginning execution")
 	r.wg.Add(1)
 	go r.executeAndWait(ctx, qr, runLogger)
 
@@ -784,7 +784,7 @@ func (r *runner) executeAndWait(ctx context.Context, qr QueuedRun, runLogger *za
 		r.taskControlService.AddRunLog(authCtx, r.task.ID, qr.RunID, time.Now(), string(b))
 	}
 	r.updateRunState(qr, RunSuccess, runLogger)
-	runLogger.Debug("Execution succeeded")
+	runLogger.Info("Execution succeeded")
 
 	// Check again if there is a new run available, without returning to idle state.
 	r.startFromWorking(atomic.LoadInt64(r.ts.now))


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/3983

Revert the [changes](https://github.com/influxdata/influxdb/pull/14053) to logger level that silently broke output for the IDPE service. 

Logs for the cloud-based service were no longer displaying information for a variety of tasks, including the `retention_enforcer`, as the log-level was artificially raised to `Debug` from `Info`. In this case the `NewOperation` should not override the `Info` level of the logging messages, as the default value for `log-level` is always `info`.