### PR TITLE
Catch cancellation errors more reliably

### DIFF
--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -2,10 +2,7 @@ import {getWindowVars} from 'src/variables/utils/getWindowVars'
 import {buildVarsOption} from 'src/variables/utils/buildVarsOption'
 import {client} from 'src/utils/api'
 
-import {
-  File,
-  CancellationError as ClientCancellationError,
-} from '@influxdata/influx'
+import {File} from '@influxdata/influx'
 
 // Types
 import {WrappedCancelablePromise, CancellationError} from 'src/types/promises'
@@ -18,19 +15,10 @@ export const runQuery = (
   query: string,
   extern?: File
 ): WrappedCancelablePromise<string> => {
-  const {promise, cancel} = client.queries.execute(orgID, query, {
+  return client.queries.execute(orgID, query, {
     extern,
     limitChars: MAX_RESPONSE_CHARS,
   })
-
-  // Convert the client `CancellationError` to a UI `CancellationError`
-  const wrappedPromise = promise.catch(error =>
-    error instanceof ClientCancellationError
-      ? Promise.reject(CancellationError)
-      : Promise.reject(error)
-  )
-
-  return {promise: wrappedPromise, cancel}
 }
 
 /*

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -5,7 +5,7 @@ import {client} from 'src/utils/api'
 import {File} from '@influxdata/influx'
 
 // Types
-import {WrappedCancelablePromise, CancellationError} from 'src/types/promises'
+import {CancelBox, CancellationError} from 'src/types/promises'
 import {VariableAssignment} from 'src/types/ast'
 
 const MAX_RESPONSE_CHARS = 50000 * 160
@@ -14,7 +14,7 @@ export const runQuery = (
   orgID: string,
   query: string,
   extern?: File
-): WrappedCancelablePromise<string> => {
+): CancelBox<string> => {
   return client.queries.execute(orgID, query, {
     extern,
     limitChars: MAX_RESPONSE_CHARS,
@@ -42,7 +42,7 @@ export const executeQueryWithVars = (
   orgID: string,
   query: string,
   variables?: VariableAssignment[]
-): WrappedCancelablePromise<string> => {
+): CancelBox<string> => {
   let isCancelled = false
   let cancelExecution
 

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -23,7 +23,7 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 import {RemoteDataState} from 'src/types'
 import {DashboardQuery} from 'src/types/dashboards'
 import {AppState} from 'src/types'
-import {WrappedCancelablePromise} from 'src/types/promises'
+import {CancelBox} from 'src/types/promises'
 import {VariableAssignment} from 'src/types/ast'
 
 interface QueriesState {
@@ -78,7 +78,7 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
 
   public state: State = defaultState()
 
-  private pendingResults: Array<WrappedCancelablePromise<string>> = []
+  private pendingResults: Array<CancelBox<string>> = []
 
   public async componentDidMount() {
     this.reload()

--- a/ui/src/shared/components/TimeSeries.tsx
+++ b/ui/src/shared/components/TimeSeries.tsx
@@ -23,7 +23,7 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 import {RemoteDataState} from 'src/types'
 import {DashboardQuery} from 'src/types/dashboards'
 import {AppState} from 'src/types'
-import {WrappedCancelablePromise, CancellationError} from 'src/types/promises'
+import {WrappedCancelablePromise} from 'src/types/promises'
 import {VariableAssignment} from 'src/types/ast'
 
 interface QueriesState {
@@ -152,7 +152,7 @@ class TimeSeries extends Component<Props & WithRouterProps, State> {
         loading: RemoteDataState.Done,
       })
     } catch (error) {
-      if (error instanceof CancellationError) {
+      if (error.name === 'CancellationError') {
         return
       }
 

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -24,7 +24,7 @@ import {
 } from 'src/variables/selectors'
 
 // Types
-import {WrappedCancelablePromise, CancellationError} from 'src/types/promises'
+import {WrappedCancelablePromise} from 'src/types/promises'
 import {RemoteDataState} from 'src/types'
 import {GetState} from 'src/types'
 
@@ -120,7 +120,7 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
 
     dispatch(setQueryResults(RemoteDataState.Done, files, duration))
   } catch (e) {
-    if (e instanceof CancellationError) {
+    if (e.name === 'CancellationError') {
       return
     }
 

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -24,7 +24,7 @@ import {
 } from 'src/variables/selectors'
 
 // Types
-import {WrappedCancelablePromise} from 'src/types/promises'
+import {CancelBox} from 'src/types/promises'
 import {RemoteDataState} from 'src/types'
 import {GetState} from 'src/types'
 
@@ -82,7 +82,7 @@ export const refreshTimeMachineVariableValues = () => async (
   await dispatch(refreshVariableValues(contextID, variablesToRefresh))
 }
 
-let pendingResults: Array<WrappedCancelablePromise<string>> = []
+let pendingResults: Array<CancelBox<string>> = []
 
 export const executeQueries = () => async (dispatch, getState: GetState) => {
   const {view, timeRange} = getActiveTimeMachine(getState())

--- a/ui/src/timeMachine/actions/queryBuilder.ts
+++ b/ui/src/timeMachine/actions/queryBuilder.ts
@@ -8,7 +8,6 @@ import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'
 import {Dispatch} from 'redux-thunk'
 import {GetState} from 'src/types'
 import {RemoteDataState} from 'src/types'
-import {CancellationError} from 'src/types/promises'
 
 export type Action =
   | SetBuilderBucketSelectionAction
@@ -246,7 +245,7 @@ export const loadBuckets = () => async (
       dispatch(selectBucket(buckets[0], true))
     }
   } catch (e) {
-    if (e instanceof CancellationError) {
+    if (e.name === 'CancellationError') {
       return
     }
 
@@ -314,7 +313,7 @@ export const loadTagSelector = (index: number) => async (
     dispatch(setBuilderTagKeys(index, keys))
     dispatch(loadTagSelectorValues(index))
   } catch (e) {
-    if (e instanceof CancellationError) {
+    if (e.name === 'CancellationError') {
       return
     }
 
@@ -364,7 +363,7 @@ const loadTagSelectorValues = (index: number) => async (
     dispatch(setBuilderTagValues(index, values))
     dispatch(loadTagSelector(index + 1))
   } catch (e) {
-    if (e instanceof CancellationError) {
+    if (e.name === 'CancellationError') {
       return
     }
 

--- a/ui/src/timeMachine/apis/QueryBuilderFetcher.ts
+++ b/ui/src/timeMachine/apis/QueryBuilderFetcher.ts
@@ -9,9 +9,9 @@ import {
 } from 'src/timeMachine/apis/queryBuilder'
 
 // Types
-import {WrappedCancelablePromise} from 'src/types'
+import {CancelBox} from 'src/types'
 
-type CancelableQuery = WrappedCancelablePromise<string[]>
+type CancelableQuery = CancelBox<string[]>
 
 class QueryBuilderFetcher {
   private findBucketsQuery: CancelableQuery

--- a/ui/src/timeMachine/apis/queryBuilder.ts
+++ b/ui/src/timeMachine/apis/queryBuilder.ts
@@ -11,12 +11,12 @@ import {formatExpression} from 'src/variables/utils/formatExpression'
 
 // Types
 import {TimeRange, BuilderConfig} from 'src/types'
-import {WrappedCancelablePromise} from 'src/types/promises'
+import {CancelBox} from 'src/types/promises'
 
 const DEFAULT_TIME_RANGE: TimeRange = {lower: 'now() - 30d'}
 const DEFAULT_LIMIT = 200
 
-type CancelableQuery = WrappedCancelablePromise<string[]>
+type CancelableQuery = CancelBox<string[]>
 
 export interface FindBucketsOptions {
   url: string

--- a/ui/src/types/promises.ts
+++ b/ui/src/types/promises.ts
@@ -3,4 +3,10 @@ export interface WrappedCancelablePromise<T> {
   cancel: () => void
 }
 
-export class CancellationError extends Error {}
+export class CancellationError extends Error {
+  constructor() {
+    super(...arguments)
+
+    this.name = 'CancellationError'
+  }
+}

--- a/ui/src/types/promises.ts
+++ b/ui/src/types/promises.ts
@@ -1,4 +1,4 @@
-export interface WrappedCancelablePromise<T> {
+export interface CancelBox<T> {
   promise: Promise<T>
   cancel: () => void
 }

--- a/ui/src/utils/promises.ts
+++ b/ui/src/utils/promises.ts
@@ -1,8 +1,6 @@
-import {WrappedCancelablePromise} from 'src/types/promises'
+import {CancelBox} from 'src/types/promises'
 
-export const makeCancelable = <T>(
-  promise: Promise<T>
-): WrappedCancelablePromise<T> => {
+export const makeCancelable = <T>(promise: Promise<T>): CancelBox<T> => {
   let isCanceled = false
 
   const wrappedPromise = new Promise<T>(async (resolve, reject) => {

--- a/ui/src/utils/restartable.test.ts
+++ b/ui/src/utils/restartable.test.ts
@@ -1,5 +1,4 @@
 import {restartable} from 'src/utils/restartable'
-import {CancellationError} from 'src/types/promises'
 
 describe('restartable', () => {
   test('with three concurrent promises', async () => {
@@ -17,7 +16,7 @@ describe('restartable', () => {
 
         successMock(result)
       } catch (e) {
-        if (e instanceof CancellationError) {
+        if (e.name === 'CancellationError') {
           errorMock()
         }
       }
@@ -50,7 +49,7 @@ describe('restartable', () => {
 
         successMock(result)
       } catch (e) {
-        if (e instanceof CancellationError) {
+        if (e.name === 'CancellationError') {
           errorMock()
         }
       }

--- a/ui/src/variables/actions/index.ts
+++ b/ui/src/variables/actions/index.ts
@@ -21,7 +21,7 @@ import {createVariableFromTemplate as createVariableFromTemplateAJAX} from 'src/
 
 // Utils
 import {getValueSelections, extractVariablesList} from 'src/variables/selectors'
-import {WrappedCancelablePromise, CancellationError} from 'src/types/promises'
+import {WrappedCancelablePromise} from 'src/types/promises'
 import {variableToTemplate} from 'src/shared/utils/resourceToTemplate'
 import {findDepedentVariables} from 'src/variables/utils/exportVariables'
 
@@ -286,7 +286,7 @@ export const refreshVariableValues = (
 
     dispatch(setValues(contextID, RemoteDataState.Done, values))
   } catch (e) {
-    if (e instanceof CancellationError) {
+    if (e.name === 'CancellationError') {
       return
     }
 

--- a/ui/src/variables/actions/index.ts
+++ b/ui/src/variables/actions/index.ts
@@ -21,7 +21,7 @@ import {createVariableFromTemplate as createVariableFromTemplateAJAX} from 'src/
 
 // Utils
 import {getValueSelections, extractVariablesList} from 'src/variables/selectors'
-import {WrappedCancelablePromise} from 'src/types/promises'
+import {CancelBox} from 'src/types/promises'
 import {variableToTemplate} from 'src/shared/utils/resourceToTemplate'
 import {findDepedentVariables} from 'src/variables/utils/exportVariables'
 
@@ -253,7 +253,7 @@ export const deleteVariable = (id: string) => async (
 }
 
 interface PendingValueRequests {
-  [contextID: string]: WrappedCancelablePromise<VariableValuesByID>
+  [contextID: string]: CancelBox<VariableValuesByID>
 }
 
 let pendingValueRequests: PendingValueRequests = {}

--- a/ui/src/variables/utils/ValueFetcher.ts
+++ b/ui/src/variables/utils/ValueFetcher.ts
@@ -9,7 +9,7 @@ import {parseResponse} from 'src/shared/parsing/flux/response'
 // Types
 import {VariableAssignment} from 'src/types/ast'
 import {VariableValues, FluxColumnType} from 'src/variables/types'
-import {WrappedCancelablePromise} from 'src/types/promises'
+import {CancelBox} from 'src/types/promises'
 
 const cacheKey = (
   url: string,
@@ -71,7 +71,7 @@ export interface ValueFetcher {
     variables: VariableAssignment[],
     prevSelection: string,
     defaultSelection: string
-  ) => WrappedCancelablePromise<VariableValues>
+  ) => CancelBox<VariableValues>
 }
 
 export class DefaultValueFetcher implements ValueFetcher {

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -412,7 +412,7 @@ export const hydrateVars = (
 
       return Promise.all(node.parents.filter(readyToResolve).map(resolve))
     } catch (e) {
-      if (e instanceof CancellationError) {
+      if (e.name === 'CancellationError') {
         return
       }
 

--- a/ui/src/variables/utils/hydrateVars.ts
+++ b/ui/src/variables/utils/hydrateVars.ts
@@ -10,7 +10,7 @@ import {OPTION_NAME, BOUNDARY_GROUP} from 'src/variables/constants/index'
 // Types
 import {RemoteDataState} from 'src/types'
 import {IVariable as Variable} from '@influxdata/influx'
-import {WrappedCancelablePromise, CancellationError} from 'src/types/promises'
+import {CancelBox, CancellationError} from 'src/types/promises'
 import {
   VariableValues,
   VariableValuesByID,
@@ -392,7 +392,7 @@ export const hydrateVars = (
   variables: Variable[],
   allVariables: Variable[],
   options: HydrateVarsOptions
-): WrappedCancelablePromise<VariableValuesByID> => {
+): CancelBox<VariableValuesByID> => {
   const graph = findSubgraph(createVariableGraph(allVariables), variables)
 
   invalidateCycles(graph)


### PR DESCRIPTION
Fixes all the `CancellationError`s showing up in HoneyBadger.

Also took the opportunity to rename the unwieldy `WrappedCanceablePromise<T>` type to `CancelBox<T>`. 