### PR TITLE
chore: prevent stale-exempt labelled issue from closing

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - security
+  - stale-exempt
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
If you label an issue with `stale-exempt`, it won't be automatically marked as stale or closed.