### PR TITLE
fix(ui/dashboards): prevent default on anchor tag

### DIFF
--- a/ui/src/alerting/components/CheckCard.tsx
+++ b/ui/src/alerting/components/CheckCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
@@ -39,7 +39,9 @@ const CheckCard: FunctionComponent<Props> = ({
     updateCheck({id: check.id, name})
   }
 
-  const onClickName = () => {
+  const onClickName = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
+
     router.push(`/orgs/${orgID}/checks/${check.id}`)
   }
 

--- a/ui/src/alerting/components/CheckCard.tsx
+++ b/ui/src/alerting/components/CheckCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent, MouseEvent} from 'react'
+import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
@@ -32,17 +32,10 @@ const CheckCard: FunctionComponent<Props> = ({
   check,
   updateCheck,
   deleteCheck,
-  router,
   params: {orgID},
 }) => {
   const onUpdateName = (name: string) => {
     updateCheck({id: check.id, name})
-  }
-
-  const onClickName = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-
-    router.push(`/orgs/${orgID}/checks/${check.id}`)
   }
 
   const onDelete = () => {
@@ -68,7 +61,7 @@ const CheckCard: FunctionComponent<Props> = ({
       name={() => (
         <ResourceList.EditableName
           onUpdate={onUpdateName}
-          onClick={onClickName}
+          hrefValue={`/orgs/${orgID}/checks/${check.id}`}
           name={check.name}
           noNameString={DEFAULT_CHECK_NAME}
           parentTestID="check-card--name"

--- a/ui/src/alerting/components/NotificationRuleCard.tsx
+++ b/ui/src/alerting/components/NotificationRuleCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent, MouseEvent} from 'react'
+import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
@@ -35,17 +35,10 @@ const NotificationRuleCard: FunctionComponent<Props> = ({
   notificationRule,
   updateNotificationRule,
   deleteNotificationRule,
-  router,
   params: {orgID},
 }) => {
   const onUpdateName = (name: string) => {
     updateNotificationRule({id: notificationRule.id, name})
-  }
-
-  const onClickName = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-
-    router.push(`/orgs/${orgID}/notificationRules/${notificationRule.id}`)
   }
 
   const onDelete = () => {
@@ -71,7 +64,7 @@ const NotificationRuleCard: FunctionComponent<Props> = ({
       name={() => (
         <ResourceList.EditableName
           onUpdate={onUpdateName}
-          onClick={onClickName}
+          hrefValue={`/orgs/${orgID}/notificationRules/${notificationRule.id}`}
           name={notificationRule.name}
           noNameString={DEFAULT_NOTIFICATION_RULE_NAME}
           parentTestID="notificationRule-card--name"

--- a/ui/src/alerting/components/NotificationRuleCard.tsx
+++ b/ui/src/alerting/components/NotificationRuleCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
@@ -42,7 +42,9 @@ const NotificationRuleCard: FunctionComponent<Props> = ({
     updateNotificationRule({id: notificationRule.id, name})
   }
 
-  const onClickName = () => {
+  const onClickName = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
+
     router.push(`/orgs/${orgID}/notificationRules/${notificationRule.id}`)
   }
 

--- a/ui/src/authorizations/components/TokenRow.tsx
+++ b/ui/src/authorizations/components/TokenRow.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 
 // Actions
@@ -82,8 +82,11 @@ class TokenRow extends PureComponent<Props> {
     this.props.onDelete(id, description)
   }
 
-  private handleClickDescription = () => {
+  private handleClickDescription = (e: MouseEvent<HTMLAnchorElement>) => {
     const {onClickDescription, auth} = this.props
+
+    e.preventDefault()
+
     onClickDescription(auth.id)
   }
 

--- a/ui/src/clockface/components/resource_list/ResourceEditableName.tsx
+++ b/ui/src/clockface/components/resource_list/ResourceEditableName.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import React, {Component, KeyboardEvent, ChangeEvent, MouseEvent} from 'react'
 import classnames from 'classnames'
+import {Link} from 'react-router'
 
 // Components
 import {Input, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
@@ -16,7 +17,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 interface Props {
   onUpdate: (name: string) => void
   name: string
-  onClick?: (e: MouseEvent<HTMLAnchorElement>) => void
+  onClick?: (e: MouseEvent) => void
   placeholder?: string
   noNameString: string
   parentTestID: string
@@ -65,9 +66,9 @@ class ResourceEditableName extends Component<Props, State> {
           loading={this.state.loading}
           spinnerComponent={<TechnoSpinner diameterPixels={20} />}
         >
-          <a href={hrefValue} onClick={this.handleClick}>
+          <Link to={hrefValue} onClick={this.handleClick}>
             <span>{name || noNameString}</span>
-          </a>
+          </Link>
         </SpinnerContainer>
         <div
           className="resource-editable-name--toggle"
@@ -106,8 +107,9 @@ class ResourceEditableName extends Component<Props, State> {
     }
   }
 
-  private handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+  private handleClick = (e: MouseEvent) => {
     const {onClick} = this.props
+
     if (onClick) {
       onClick(e)
     }

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
@@ -49,7 +49,12 @@ type Props = PassedProps & DispatchProps & StateProps & WithRouterProps
 
 class DashboardCard extends PureComponent<Props> {
   public render() {
-    const {dashboard, onFilterChange, labels} = this.props
+    const {
+      dashboard,
+      onFilterChange,
+      labels,
+      params: {orgID},
+    } = this.props
     const {id} = dashboard
 
     return (
@@ -59,6 +64,7 @@ class DashboardCard extends PureComponent<Props> {
         name={() => (
           <ResourceList.EditableName
             onUpdate={this.handleUpdateDashboard}
+            hrefValue={`/orgs/${orgID}/dashboards/${dashboard.id}`}
             onClick={this.handleClickDashboard}
             name={dashboard.name}
             noNameString={DEFAULT_DASHBOARD_NAME}
@@ -132,19 +138,10 @@ class DashboardCard extends PureComponent<Props> {
     )
   }
 
-  private handleClickDashboard = (e: MouseEvent<HTMLAnchorElement>) => {
-    const {
-      router,
-      dashboard,
-      onResetViews,
-      params: {orgID},
-    } = this.props
-
-    e.preventDefault()
+  private handleClickDashboard = () => {
+    const {onResetViews} = this.props
 
     onResetViews()
-
-    router.push(`/orgs/${orgID}/dashboards/${dashboard.id}`)
   }
 
   private handleUpdateDescription = (description: string): void => {

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
@@ -132,13 +132,15 @@ class DashboardCard extends PureComponent<Props> {
     )
   }
 
-  private handleClickDashboard = () => {
+  private handleClickDashboard = (e: MouseEvent<HTMLAnchorElement>) => {
     const {
       router,
       dashboard,
       onResetViews,
       params: {orgID},
     } = this.props
+
+    e.preventDefault()
 
     onResetViews()
 

--- a/ui/src/scrapers/components/ScraperRow.tsx
+++ b/ui/src/scrapers/components/ScraperRow.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 
 // Components
 import {ResourceList, Context} from 'src/clockface'
@@ -28,6 +28,7 @@ export default class ScraperRow extends PureComponent<Props> {
               noNameString={DEFAULT_SCRAPER_NAME}
               buttonTestID="editable-name"
               inputTestID="input-field"
+              onClick={this.handleClick}
             />
           )}
           metaData={() => [
@@ -52,6 +53,10 @@ export default class ScraperRow extends PureComponent<Props> {
         </Context.Menu>
       </Context>
     )
+  }
+
+  private handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
   }
 
   private handleDeleteScraper = () => {

--- a/ui/src/scrapers/components/ScraperRow.tsx
+++ b/ui/src/scrapers/components/ScraperRow.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent} from 'react'
 
 // Components
 import {ResourceList, Context} from 'src/clockface'
@@ -28,7 +28,6 @@ export default class ScraperRow extends PureComponent<Props> {
               noNameString={DEFAULT_SCRAPER_NAME}
               buttonTestID="editable-name"
               inputTestID="input-field"
-              onClick={this.handleClick}
             />
           )}
           metaData={() => [
@@ -53,10 +52,6 @@ export default class ScraperRow extends PureComponent<Props> {
         </Context.Menu>
       </Context>
     )
-  }
-
-  private handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
   }
 
   private handleDeleteScraper = () => {

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
@@ -116,7 +116,9 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
     )
   }
 
-  private handleNameClick = () => {
+  private handleNameClick = (e: MouseEvent) => {
+    e.preventDefault()
+
     this.props.onSelect(this.props.task)
   }
 

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
@@ -116,9 +116,7 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
     )
   }
 
-  private handleNameClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-
+  private handleNameClick = () => {
     this.props.onSelect(this.props.task)
   }
 

--- a/ui/src/telegrafs/components/CollectorCard.tsx
+++ b/ui/src/telegrafs/components/CollectorCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps, Link} from 'react-router'
 
@@ -146,8 +146,7 @@ class CollectorRow extends PureComponent<Props & WithRouterProps> {
     }
   }
 
-  private handleNameClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
+  private handleNameClick = () => {
     this.handleOpenConfig()
   }
 

--- a/ui/src/telegrafs/components/CollectorCard.tsx
+++ b/ui/src/telegrafs/components/CollectorCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps, Link} from 'react-router'
 
@@ -146,7 +146,9 @@ class CollectorRow extends PureComponent<Props & WithRouterProps> {
     }
   }
 
-  private handleNameClick = () => {
+  private handleNameClick = (e: MouseEvent) => {
+    e.preventDefault()
+
     this.handleOpenConfig()
   }
 

--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 import _ from 'lodash'
 import {withRouter, WithRouterProps} from 'react-router'
@@ -191,8 +191,7 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
     onClone(id)
   }
 
-  private handleNameClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
+  private handleNameClick = () => {
     this.handleViewTemplate()
   }
 

--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 import _ from 'lodash'
 import {withRouter, WithRouterProps} from 'react-router'
@@ -191,7 +191,9 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
     onClone(id)
   }
 
-  private handleNameClick = () => {
+  private handleNameClick = (e: MouseEvent) => {
+    e.preventDefault()
+
     this.handleViewTemplate()
   }
 


### PR DESCRIPTION
__Describe your proposed changes here.__
Fixes an issue where clicking on a dashboard name from the dashboards index caused an incorrect redirect due to default behavior on the anchor tag. 


- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass