### PR TITLE
fix(query): make show series exact cardinality count only distinct series

### DIFF
--- a/query/statement_rewriter.go
+++ b/query/statement_rewriter.go
@@ -202,7 +202,16 @@ func rewriteShowSeriesCardinalityStatement(stmt *influxql.ShowSeriesCardinalityS
 
 	return &influxql.SelectStatement{
 		Fields: []*influxql.Field{
-			{Expr: &influxql.Call{Name: "count", Args: []influxql.Expr{&influxql.VarRef{Val: "_seriesKey"}}}, Alias: "count"},
+			{
+				Expr: &influxql.Call{
+					Name: "count",
+					Args: []influxql.Expr{&influxql.Call{
+						Name: "distinct",
+						Args: []influxql.Expr{&influxql.VarRef{Val: "_seriesKey"}},
+					}},
+				},
+				Alias: "count",
+			},
 		},
 		Sources:    rewriteSources2(stmt.Sources, stmt.Database),
 		Condition:  stmt.Condition,

--- a/query/statement_rewriter_test.go
+++ b/query/statement_rewriter_test.go
@@ -125,8 +125,16 @@ func TestRewriteStatement(t *testing.T) {
 			s:    `SELECT _seriesKey AS "key" FROM mydb.myrp1./c.*/ WHERE time > 0`,
 		},
 		{
-			stmt: `SHOW SERIES EXACT CARDINALITY on m`,
-			s:    `SELECT count(distinct(_seriesKey)) AS count FROM m../.+/`,
+			stmt: `SHOW SERIES CARDINALITY FROM m`,
+			s:    `SELECT count(distinct(_seriesKey)) AS count FROM m`,
+		},
+		{
+			stmt: `SHOW SERIES EXACT CARDINALITY`,
+			s:    `SELECT count(distinct(_seriesKey)) AS count FROM /.+/`,
+		},
+		{
+			stmt: `SHOW SERIES EXACT CARDINALITY FROM m`,
+			s:    `SELECT count(distinct(_seriesKey)) AS count FROM m`,
 		},
 		{
 			stmt: `SHOW TAG KEYS`,

--- a/query/statement_rewriter_test.go
+++ b/query/statement_rewriter_test.go
@@ -125,6 +125,10 @@ func TestRewriteStatement(t *testing.T) {
 			s:    `SELECT _seriesKey AS "key" FROM mydb.myrp1./c.*/ WHERE time > 0`,
 		},
 		{
+			stmt: `SHOW SERIES EXACT CARDINALITY on m`,
+			s:    `SELECT count(distinct(_seriesKey)) AS count FROM m../.+/`,
+		},
+		{
 			stmt: `SHOW TAG KEYS`,
 			s:    `SHOW TAG KEYS`,
 		},


### PR DESCRIPTION
Closes #14386 

Wrote this fix last week after discussions in storage re cardinality. 

Adds a `distinct` call to the rewritten queries for `SHOW SERIES EXACT CARDINALITY` and `SHOW SERIES CARDINALITY FROM <measurement>`.

See updated unit tests for the exact rewrites. 

This is the most straightforward fix to the current cardinality bug on 1.x `tsi1`, in which series keys are counted more than once if they are duplicated across shards. The only series cardinality query which is not affected by the bug is `SHOW SERIES CARDINALITY` (run across an entire database) since it is not rewritten and does bitmap level calculations or HLL if on a cluster. 

It is now confirmed that the cardinality bugs were behind https://github.com/influxdata/EAR/issues/992, so I want to continue the conversation and work towards a fix to avoid future customer confusion in this area.  

@stuartcarnie has mentioned that this change would likely cause a decrease in the performance of the affected queries. There could certainly be a more performant solution, and I would appreciate any suggestions!

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass