### PR TITLE
fix(ui): upgrade clockface to 0.0.19

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -156,7 +156,7 @@
     "ts-node": "^8.3.0"
   },
   "dependencies": {
-    "@influxdata/clockface": "0.0.18",
+    "@influxdata/clockface": "0.0.19",
     "@influxdata/giraffe": "0.16.1",
     "@influxdata/influx": "0.5.5",
     "@influxdata/influxdb-templates": "0.5.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1136,14 +1136,10 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
   integrity sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==
 
-"@influxdata/clockface@0.0.18":
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-0.0.18.tgz#9455fa5236be8ab0733ddde8b57ce818ce6889a7"
-  integrity sha512-LFaj+PV3ikugOHivGWAefDaN2ZazrxA6GfCfYhWqBH1bkZY94w0QY72doAmPBvxPfdr2wY8cPP1WD7lkU2fTYQ==
-  dependencies:
-    chroma-js "^2.0.3"
-    classnames "^2.2.6"
-    react-scrollbars-custom "^4.0.4"
+"@influxdata/clockface@0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-0.0.19.tgz#eb1beaceaf677c88a54f5f923b97ab5bc67b8173"
+  integrity sha512-MI3Qx4rzZWQIHRpAi0TRQ4h2Wn9f9mUftCN4fNydifqY5iFKcy9qeQFBDkLPEtQz+DcKhdNYBWGrsmS8B2EUfw==
 
 "@influxdata/giraffe@0.16.1":
   version "0.16.1"
@@ -3092,11 +3088,6 @@ chroma-js@^1.3.6:
   resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-1.4.0.tgz#695c52e7c97617e5f687db31913503d410481ae4"
   integrity sha512-5vBYGJkhSnK2SRZ0XkxwTL+TSRyP7PHIxjeg+1uce5qpNDRLLwAXcF12kIztas/BYakWPQhchzV4TKkiwKNd8Q==
 
-chroma-js@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-2.0.3.tgz#2521d4f80c4e786e00064c4a62824e38ff6557c4"
-  integrity sha512-2kTvZZOFSV1O81/rm99t9vmkh9jQxsHqsRRoZevDVz/VCC3yKMyPuMK8M5yHG+UMg2tV6cRoqtZtgcD92udcBw==
-
 chrome-trace-event@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz#45a91bd2c20c9411f0963b5aaeb9a1b95e09cc48"
@@ -3132,7 +3123,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.x, classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6:
+classnames@2.x, classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -3263,11 +3254,6 @@ cnbuilder@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/cnbuilder/-/cnbuilder-1.0.8.tgz#2b5a700e4d541085df31709b5678c786d29967da"
   integrity sha512-05l9Bhs0FhEFGJ6vFkqL9O9USCKT3zBfOoTAYXGDKA4nFBX1Qc780bvppG9av2U1sKpa27JT8brJtM6VQquRcQ==
-
-cnbuilder@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/cnbuilder/-/cnbuilder-1.1.7.tgz#04ef08d278efd69bc65a95b087328455a85a2eef"
-  integrity sha512-8D9dpabOVOh7GX/qPZ60sJpqxHaiLqSDsuZOYH1TvoNkgMrO7BJHCbNepHHoglSdU//M2sjLHaL9Vu0qibSV2A==
 
 co@^4.6.0:
   version "4.6.0"
@@ -9931,7 +9917,7 @@ react-draggable@3.x, "react-draggable@^2.2.6 || ^3.0.3":
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-draggable@^3.2.1, react-draggable@^3.3.0:
+react-draggable@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-3.3.0.tgz#2ed7ea3f92e7d742d747f9e6324860606cd4d997"
   integrity sha512-U7/jD0tAW4T0S7DCPK0kkKLyL0z61sC/eqU+NUfDjnq+JtBKaYKDHpsK2wazctiA4alEzCXUnzkREoxppOySVw==
@@ -10040,15 +10026,6 @@ react-scrollbars-custom@^4.0.0-alpha.8:
   dependencies:
     cnbuilder "^1.0.8"
     react-draggable "^3.2.1"
-
-react-scrollbars-custom@^4.0.4:
-  version "4.0.16"
-  resolved "https://registry.yarnpkg.com/react-scrollbars-custom/-/react-scrollbars-custom-4.0.16.tgz#6f00be36591d64c07ae5be365efe8188406dd894"
-  integrity sha512-QNNYuRqGo6voqtxxmTq5qnPz0GrmtparGuo/UfmRVnkDbEPL3ExO9Y5w0TTOA1AgKZdc6keYhKfkN6daDX9J3Q==
-  dependencies:
-    cnbuilder "^1.1.7"
-    react-draggable "^3.3.0"
-    zoom-level "^1.2.4"
 
 react-test-renderer@^16.0.0-0:
   version "16.5.2"
@@ -12788,8 +12765,3 @@ yn@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.0.tgz#fcbe2db63610361afcc5eb9e0ac91e976d046114"
   integrity sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==
-
-zoom-level@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/zoom-level/-/zoom-level-1.2.4.tgz#52bc5ae3af945cac82f9f685e8707fa2c9b962e2"
-  integrity sha512-nGFUhyU3Y4jWh6l+hYCVVUxu3vrD0i/RkumJRzYGU0COMWMs2Szs84mltacd64R9zJcxwKckWQN/KKbfB1btVA==


### PR DESCRIPTION
Closes #13725

Just propagating the fix from here: https://github.com/influxdata/clockface/pull/190