### PR TITLE
fix: enforce bucket authentication on task update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+1. [14480](https://github.com/influxdata/influxdb/pull/14480): Fix authentication when updating a task with invalid org or bucket.
+
 ## v2.0.0-alpha.16 [2019-07-25]
 
 ### Bug Fixes

--- a/authorizer/task.go
+++ b/authorizer/task.go
@@ -155,8 +155,11 @@ func (ts *taskServiceValidator) UpdateTask(ctx context.Context, id platform.ID, 
 		return nil, err
 	}
 
-	if err := ts.validateBucket(ctx, task.Flux, task.OrganizationID, loggerFields...); err != nil {
-		return nil, err
+	// given an update to the task flux definition
+	if upd.Flux != nil {
+		if err := ts.validateBucket(ctx, *upd.Flux, task.OrganizationID, loggerFields...); err != nil {
+			return nil, err
+		}
 	}
 
 	return ts.TaskService.UpdateTask(ctx, id, upd)


### PR DESCRIPTION
Prior to this change the UpdateTask action would authorize the original task and not the updated task.

This change ensures that the update being applied to a task is authorized.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] ~http/swagger.yml updated (if modified Go structs or API)~
- [x] ~Documentation updated or issue created (provide link to issue/pr)~
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
