### PR TITLE
feat(http): gzip compress the query CSV response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.0.0-alpha.17 [unreleased]
 
 ### Features
+1. [14495](https://github.com/influxdata/influxdb/pull/14495): optional gzip compression of the query CSV response.
 
 ### UI Improvements
 

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/NYTimes/gziphandler"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/complete"
@@ -88,7 +89,9 @@ func NewFluxHandler(b *FluxBackend) *FluxHandler {
 		EventRecorder:       b.QueryEventRecorder,
 	}
 
-	h.HandlerFunc("POST", fluxPath, h.handleQuery)
+	// query reponses can optionally be gzip encoded
+	qh := gziphandler.GzipHandler(http.HandlerFunc(h.handleQuery))
+	h.Handler("POST", fluxPath, qh)
 	h.HandlerFunc("POST", "/api/v2/query/ast", h.postFluxAST)
 	h.HandlerFunc("POST", "/api/v2/query/analyze", h.postQueryAnalyze)
 	h.HandlerFunc("GET", "/api/v2/query/suggestions", h.getFluxSuggestions)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3074,6 +3074,16 @@ paths:
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: header
+          name: Accept-Encoding
+          description: The Accept-Encoding request HTTP header advertises which content encoding, usually a compression algorithm, the client is able to understand.
+          schema:
+            type: string
+            description: specifies that the query response in the body should be encoded with gzip or not encoded with identity.
+            default: identity
+            enum:
+              - gzip
+              - identity
+        - in: header
           name: Content-Type
           schema:
             type: string
@@ -3102,6 +3112,16 @@ paths:
       responses:
           '200':
             description: query results
+            headers:
+              Content-Encoding:
+                description: The Content-Encoding entity header is used to compress the media-type.  When present, its value indicates which encodings were applied to the entity-body
+                schema:
+                    type: string
+                    description: specifies that the response in the body is encoded with gzip or not encoded with identity.
+                    default: identity
+                    enum:
+                    - gzip
+                    - identity
             content:
               text/csv:
                 schema:


### PR DESCRIPTION
If client requests with `Accept-Encoding: gzip`, then
compress response and return with `Content-Encoding: gzip`.

This increases the server-side load by about 12%, but saves network bandwidth.

```
benchmark                     old ns/op     new ns/op     delta
Benchmark_Query_no_gzip-4     123609        137885        +11.55%

benchmark                     old allocs     new allocs     delta
Benchmark_Query_no_gzip-4     149            150            +0.67%

benchmark                     old bytes     new bytes     delta
Benchmark_Query_no_gzip-4     14297         15205         +6.35%
```

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
