### PR TITLE
fix(query): add LookupName method to dependency interfaces (needed by flux to())

### DIFF
--- a/mock/dependencies.go
+++ b/mock/dependencies.go
@@ -1,0 +1,41 @@
+package mock
+
+import (
+	"context"
+
+	platform "github.com/influxdata/influxdb"
+)
+
+// BucketLookup implements the BucketLookup interface needed by flux "from" and "to".
+type BucketLookup struct{}
+
+func (BucketLookup) Lookup(_ context.Context, orgID platform.ID, name string) (platform.ID, bool) {
+	if name == "my-bucket" {
+		return platform.ID(1), true
+	}
+	return platform.InvalidID(), false
+}
+
+func (BucketLookup) LookupName(_ context.Context, orgID platform.ID, id platform.ID) string {
+	if id == 1 {
+		return "my-bucket"
+	}
+	return ""
+}
+
+// OrganizationLookup implements the OrganizationLookup interface needed by flux "from" and "to".
+type OrganizationLookup struct{}
+
+func (OrganizationLookup) Lookup(_ context.Context, name string) (platform.ID, bool) {
+	if name == "my-org" {
+		return platform.ID(2), true
+	}
+	return platform.InvalidID(), false
+}
+
+func (OrganizationLookup) LookupName(_ context.Context, id platform.ID) string {
+	if id == 2 {
+		return "my-org"
+	}
+	return ""
+}

--- a/query/dependency.go
+++ b/query/dependency.go
@@ -31,6 +31,21 @@ func (b *BucketLookup) Lookup(ctx context.Context, orgID platform.ID, name strin
 	return bucket.ID, true
 }
 
+// LookupName returns an bucket name given its organization ID and its bucket ID.
+func (b *BucketLookup) LookupName(ctx context.Context, orgID platform.ID, id platform.ID) string {
+	oid := platform.ID(orgID)
+	id = platform.ID(id)
+	filter := platform.BucketFilter{
+		OrganizationID: &oid,
+		ID:             &id,
+	}
+	bucket, err := b.BucketService.FindBucket(ctx, filter)
+	if err != nil || bucket == nil {
+		return ""
+	}
+	return bucket.Name
+}
+
 func (b *BucketLookup) FindAllBuckets(ctx context.Context, orgID platform.ID) ([]*platform.Bucket, int) {
 	oid := platform.ID(orgID)
 	filter := platform.BucketFilter{
@@ -65,4 +80,20 @@ func (o *OrganizationLookup) Lookup(ctx context.Context, name string) (platform.
 		return platform.InvalidID(), false
 	}
 	return org.ID, true
+}
+
+// LookupName returns an organization name given its ID.
+func (o *OrganizationLookup) LookupName(ctx context.Context, id platform.ID) string {
+	id = platform.ID(id)
+	org, err := o.OrganizationService.FindOrganization(
+		ctx,
+		platform.OrganizationFilter{
+			ID: &id,
+		},
+	)
+
+	if err != nil || org == nil {
+		return ""
+	}
+	return org.Name
 }

--- a/query/stdlib/influxdata/influxdb/storage.go
+++ b/query/stdlib/influxdata/influxdb/storage.go
@@ -20,10 +20,12 @@ type HostLookup interface {
 
 type BucketLookup interface {
 	Lookup(ctx context.Context, orgID platform.ID, name string) (platform.ID, bool)
+	LookupName(ctx context.Context, orgID platform.ID, id platform.ID) string
 }
 
 type OrganizationLookup interface {
 	Lookup(ctx context.Context, name string) (platform.ID, bool)
+	LookupName(ctx context.Context, id platform.ID) string
 }
 
 type Dependencies struct {

--- a/query/stdlib/influxdata/influxdb/to_test.go
+++ b/query/stdlib/influxdata/influxdb/to_test.go
@@ -116,8 +116,8 @@ func TestToOpSpec_BucketsAccessed(t *testing.T) {
 }
 
 func TestTo_Process(t *testing.T) {
-	oid, _ := (mockOrgLookup{}).Lookup(context.Background(), "my-org")
-	bid, _ := (mockBucketLookup{}).Lookup(context.Background(), oid, "my-bucket")
+	oid, _ := mock.OrganizationLookup{}.Lookup(context.Background(), "my-org")
+	bid, _ := mock.BucketLookup{}.Lookup(context.Background(), oid, "my-bucket")
 	type wanted struct {
 		result *mock.PointsWriter
 		tables []*executetest.Table
@@ -739,28 +739,10 @@ c _hello=4 41`),
 
 func mockDependencies() influxdb.ToDependencies {
 	return influxdb.ToDependencies{
-		BucketLookup:       mockBucketLookup{},
-		OrganizationLookup: mockOrgLookup{},
+		BucketLookup:       mock.BucketLookup{},
+		OrganizationLookup: mock.OrganizationLookup{},
 		PointsWriter:       new(mock.PointsWriter),
 	}
-}
-
-type mockBucketLookup struct{}
-
-func (mockBucketLookup) Lookup(_ context.Context, orgID platform.ID, name string) (platform.ID, bool) {
-	if name == "my-bucket" {
-		return platform.ID(1), true
-	}
-	return platform.InvalidID(), false
-}
-
-type mockOrgLookup struct{}
-
-func (mockOrgLookup) Lookup(_ context.Context, name string) (platform.ID, bool) {
-	if name == "my-org" {
-		return platform.ID(2), true
-	}
-	return platform.InvalidID(), false
 }
 
 func pointsToStr(points []models.Point) string {


### PR DESCRIPTION
This change adds a `LookupName()` method to the `BucketLookup` and `OrganizationLookup` interfaces.

Both IDs and names are needed in the idpe implementation of `to()`, and the user can only provide one or the other but not both.  This change is part of the fix for influxdata/idpe#4077.

Companion PR in idpe:
https://github.com/influxdata/idpe/pull/4146