### PR TITLE
refactor(ui): use locally generated client for buckets and orgs

### DIFF
--- a/ui/src/authorizations/containers/TokensIndex.tsx
+++ b/ui/src/authorizations/containers/TokensIndex.tsx
@@ -13,8 +13,7 @@ import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 import TokensTab from 'src/authorizations/components/TokensTab'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 
 interface StateProps {
   org: Organization

--- a/ui/src/buckets/containers/BucketsIndex.tsx
+++ b/ui/src/buckets/containers/BucketsIndex.tsx
@@ -14,8 +14,7 @@ import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 
 interface StateProps {
   org: Organization

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -27,8 +27,8 @@ import {
 // Types
 import * as AppActions from 'src/types/actions/app'
 import * as QueriesModels from 'src/types/queries'
-import {Dashboard, Organization} from '@influxdata/influx'
-import {AutoRefresh, AutoRefreshStatus} from 'src/types'
+import {Dashboard} from '@influxdata/influx'
+import {AutoRefresh, AutoRefreshStatus, Organization} from 'src/types'
 
 interface Props {
   org: Organization

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -49,6 +49,7 @@ import {
   AppState,
   AutoRefresh,
   AutoRefreshStatus,
+  Organization,
 } from 'src/types'
 import {RemoteDataState} from 'src/types'
 import {WithRouterProps} from 'react-router'
@@ -57,7 +58,6 @@ import {Location} from 'history'
 import * as AppActions from 'src/types/actions/app'
 import * as ColorsModels from 'src/types/colors'
 import {toggleShowVariablesControls} from 'src/userSettings/actions'
-import {Organization} from '@influxdata/influx'
 import {LimitStatus} from 'src/cloud/actions/limits'
 
 interface StateProps {

--- a/ui/src/labels/containers/LabelsIndex.tsx
+++ b/ui/src/labels/containers/LabelsIndex.tsx
@@ -13,8 +13,7 @@ import LabelsTab from 'src/labels/components/LabelsTab'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 
 interface StateProps {
   org: Organization

--- a/ui/src/members/containers/MembersIndex.tsx
+++ b/ui/src/members/containers/MembersIndex.tsx
@@ -13,8 +13,7 @@ import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 import Members from 'src/members/components/Members'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 
 interface StateProps {
   org: Organization

--- a/ui/src/onboarding/components/CompletionAdvancedButton.tsx
+++ b/ui/src/onboarding/components/CompletionAdvancedButton.tsx
@@ -8,7 +8,7 @@ import {Button, ComponentColor, ComponentSize} from '@influxdata/clockface'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Organization} from '@influxdata/influx'
+import {Organization} from 'src/types'
 
 interface OwnProps {
   orgs: Organization[]

--- a/ui/src/onboarding/components/CompletionStep.tsx
+++ b/ui/src/onboarding/components/CompletionStep.tsx
@@ -21,6 +21,7 @@ import {QUICKSTART_DASHBOARD_NAME} from 'src/onboarding/constants'
 import {getDashboards} from 'src/organizations/apis'
 import {client} from 'src/utils/api'
 import {createDashboardFromTemplate as createDashboardFromTemplateAJAX} from 'src/templates/api'
+import * as api from 'src/client'
 
 // Types
 import {
@@ -30,8 +31,8 @@ import {
   Columns,
   Grid,
 } from '@influxdata/clockface'
-import {DashboardTemplate} from 'src/types'
-import {Organization, Dashboard, ScraperTargetRequest} from '@influxdata/influx'
+import {DashboardTemplate, Organization} from 'src/types'
+import {Dashboard, ScraperTargetRequest} from '@influxdata/influx'
 import {OnboardingStepProps} from 'src/onboarding/containers/OnboardingWizard'
 import {QUICKSTART_SCRAPER_TARGET_URL} from 'src/dataLoaders/constants/pluginConfigs'
 
@@ -40,7 +41,14 @@ interface Props extends OnboardingStepProps {
   bucketID: string
 }
 
-const getOrganizations = () => client.organizations.getAll()
+const getOrganizations = async () => {
+  const resp = await api.getOrgs({})
+  if (resp.status !== 200) {
+    throw new Error(resp.data.message)
+  }
+
+  return resp.data.orgs
+}
 
 @ErrorHandling
 class CompletionStep extends PureComponent<Props> {

--- a/ui/src/organizations/actions/orgs.ts
+++ b/ui/src/organizations/actions/orgs.ts
@@ -186,9 +186,9 @@ export const createOrgWithBucket = (
     dispatch(addOrg(createdOrg))
     dispatch(push(`/orgs/${createdOrg.id}`))
 
-    bucket.orgID = createdOrg.id
-
-    const bucketResp = await api.postBucket({data: bucket})
+    const bucketResp = await api.postBucket({
+      data: {...bucket, orgID: createdOrg.id},
+    })
 
     if (bucketResp.status !== 201) {
       throw new Error(bucketResp.data.message)

--- a/ui/src/organizations/actions/orgs.ts
+++ b/ui/src/organizations/actions/orgs.ts
@@ -4,6 +4,7 @@ import {push, RouterAction} from 'react-router-redux'
 
 // APIs
 import {client, getErrorMessage} from 'src/utils/api'
+import {postBucket} from 'src/client'
 
 // Actions
 import {notify} from 'src/shared/actions/notifications'
@@ -22,8 +23,12 @@ import {
 } from 'src/shared/copy/notifications'
 
 // Types
-import {Bucket} from '@influxdata/influx'
-import {Organization, RemoteDataState, NotificationAction} from 'src/types'
+import {
+  Organization,
+  RemoteDataState,
+  NotificationAction,
+  Bucket,
+} from 'src/types'
 
 export enum ActionTypes {
   SetOrgs = 'SET_ORGS',
@@ -168,10 +173,13 @@ export const createOrgWithBucket = (
     dispatch(addOrg(createdOrg))
     dispatch(push(`/orgs/${createdOrg.id}`))
 
-    await client.buckets.create({
-      ...bucket,
-      orgID: createdOrg.id,
-    })
+    bucket.orgID = createdOrg.id
+
+    const resp = await postBucket({data: bucket})
+
+    if (resp.status !== 201) {
+      throw new Error(resp.data.message)
+    }
 
     dispatch(notify(bucketCreateSuccess()))
   } catch (e) {

--- a/ui/src/organizations/apis/index.ts
+++ b/ui/src/organizations/apis/index.ts
@@ -4,8 +4,7 @@ import _ from 'lodash'
 import {client} from 'src/utils/api'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {Dashboard} from 'src/types'
+import {Dashboard, Organization} from 'src/types'
 
 // CRUD APIs for Organizations and Organization resources
 // i.e. Organization Members, Buckets, Dashboards etc

--- a/ui/src/organizations/components/CreateOrgOverlay.tsx
+++ b/ui/src/organizations/components/CreateOrgOverlay.tsx
@@ -9,8 +9,7 @@ import _ from 'lodash'
 import {Form, Input, Button, Overlay} from '@influxdata/clockface'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {Bucket} from 'src/types'
+import {Bucket, Organization} from 'src/types'
 import {
   ButtonType,
   ComponentColor,

--- a/ui/src/organizations/components/RenameOrgForm.tsx
+++ b/ui/src/organizations/components/RenameOrgForm.tsx
@@ -24,9 +24,8 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import {renameOrg} from 'src/organizations/actions/orgs'
 
 // Types
-import {Organization} from '@influxdata/influx'
 import {ComponentStatus} from '@influxdata/clockface'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 
 interface StateProps {
   startOrg: Organization

--- a/ui/src/organizations/containers/OrgProfilePage.tsx
+++ b/ui/src/organizations/containers/OrgProfilePage.tsx
@@ -12,8 +12,7 @@ import TabbedPageSection from 'src/shared/components/tabbed_page/TabbedPageSecti
 import {Grid, Columns} from '@influxdata/clockface'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 import OrgProfileTab from '../components/OrgProfileTab'
 
 interface StateProps {

--- a/ui/src/pageLayout/components/AccountNavSubItem.tsx
+++ b/ui/src/pageLayout/components/AccountNavSubItem.tsx
@@ -4,9 +4,11 @@ import {Link} from 'react-router'
 
 // Components
 import {NavMenu} from '@influxdata/clockface'
-import {Organization} from '@influxdata/influx'
 import SortingHat from 'src/shared/components/sorting_hat/SortingHat'
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
+
+// Types
+import {Organization} from 'src/types'
 
 interface Props {
   orgs: Organization[]

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -16,9 +16,8 @@ import {FeatureFlag} from 'src/shared/utils/featureFlag'
 import {getNavItemActivation} from 'src/pageLayout/utils'
 
 // Types
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 import {IconFont} from '@influxdata/clockface'
-import {Organization} from '@influxdata/influx'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'

--- a/ui/src/scrapers/containers/ScrapersIndex.tsx
+++ b/ui/src/scrapers/containers/ScrapersIndex.tsx
@@ -15,8 +15,7 @@ import Scrapers from 'src/scrapers/components/Scrapers'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 
 interface StateProps {
   org: Organization

--- a/ui/src/shared/containers/RouteToOrg.tsx
+++ b/ui/src/shared/containers/RouteToOrg.tsx
@@ -4,8 +4,7 @@ import {connect} from 'react-redux'
 import {WithRouterProps} from 'react-router'
 
 // Types
-import {AppState} from 'src/types'
-import {Organization} from '@influxdata/influx'
+import {AppState, Organization} from 'src/types'
 
 // Decorators
 

--- a/ui/src/shared/containers/SetOrg.tsx
+++ b/ui/src/shared/containers/SetOrg.tsx
@@ -3,8 +3,7 @@ import React, {useEffect, useState, FunctionComponent} from 'react'
 import {connect} from 'react-redux'
 
 // Types
-import {AppState} from 'src/types'
-import {Organization} from '@influxdata/influx'
+import {AppState, Organization} from 'src/types'
 
 // Actions
 import {setOrg as setOrgAction} from 'src/organizations/actions/orgs'

--- a/ui/src/telegrafs/components/CollectorCard.tsx
+++ b/ui/src/telegrafs/components/CollectorCard.tsx
@@ -7,7 +7,6 @@ import {withRouter, WithRouterProps, Link} from 'react-router'
 import {Context} from 'src/clockface'
 import {ResourceCard, IconFont} from '@influxdata/clockface'
 import {ComponentColor} from '@influxdata/clockface'
-import {ITelegraf as Telegraf, Organization} from '@influxdata/influx'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 
 // Actions
@@ -24,8 +23,8 @@ import {viewableLabels} from 'src/labels/selectors'
 import {DEFAULT_COLLECTOR_NAME} from 'src/dashboards/constants'
 
 // Types
-import {AppState} from 'src/types'
-import {ILabel} from '@influxdata/influx'
+import {AppState, Organization} from 'src/types'
+import {ILabel, ITelegraf as Telegraf} from '@influxdata/influx'
 
 interface OwnProps {
   collector: Telegraf

--- a/ui/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/ui/src/telegrafs/containers/TelegrafsPage.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import {AppState} from 'src/types'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -14,7 +13,7 @@ import TabbedPageSection from 'src/shared/components/tabbed_page/TabbedPageSecti
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 
 // Types
-import {Organization} from '@influxdata/influx'
+import {AppState, Organization} from 'src/types'
 
 interface StateProps {
   org: Organization

--- a/ui/src/templates/containers/TemplatesIndex.tsx
+++ b/ui/src/templates/containers/TemplatesIndex.tsx
@@ -12,8 +12,7 @@ import TabbedPageSection from 'src/shared/components/tabbed_page/TabbedPageSecti
 import TemplatesPage from 'src/templates/components/TemplatesPage'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 
 interface StateProps {

--- a/ui/src/types/members.ts
+++ b/ui/src/types/members.ts
@@ -1,3 +1,3 @@
-import {ResourceMember, ResourceOwner} from '@influxdata/influx'
+import {ResourceMember, ResourceOwner} from 'src/client'
 
 export type Member = ResourceMember | ResourceOwner

--- a/ui/src/types/orgs.ts
+++ b/ui/src/types/orgs.ts
@@ -1,3 +1,1 @@
-import {Organization as OrgsAPI} from '@influxdata/influx'
-
-export interface Organization extends OrgsAPI {}
+export {Organization} from 'src/client'

--- a/ui/src/variables/containers/VariablesIndex.tsx
+++ b/ui/src/variables/containers/VariablesIndex.tsx
@@ -13,8 +13,7 @@ import VariablesTab from 'src/variables/components/VariablesTab'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 
 // Types
-import {Organization} from '@influxdata/influx'
-import {AppState} from 'src/types'
+import {AppState, Organization} from 'src/types'
 
 interface StateProps {
   org: Organization


### PR DESCRIPTION
Link #14482 

This PR uses the locally generated client instead of `@influxdata/influx` for API calls. I figured it would be best to open a bunch of smaller PRs rather than one massive PR for all of the types. 