### PR TITLE
feat(query/stdlib): push down exists operator to storage

### DIFF
--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -123,6 +123,7 @@ func (PushDownFilterRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
 		// Nothing could be pushed down, no rewrite can happen
 		return pn, false, nil
 	}
+	pushable, _ = rewritePushableExpr(pushable)
 
 	newFromSpec := fromSpec.Copy().(*ReadRangePhysSpec)
 	if newFromSpec.FilterSet {
@@ -324,21 +325,60 @@ func isPushableExpr(paramName string, expr semantic.Expression) (bool, error) {
 
 		return isPushableExpr(paramName, e.Right)
 
+	case *semantic.UnaryExpression:
+		if isPushableUnaryPredicate(paramName, e) {
+			return true, nil
+		}
+
 	case *semantic.BinaryExpression:
-		if isPushablePredicate(paramName, e) {
+		if isPushableBinaryPredicate(paramName, e) {
 			return true, nil
 		}
 	}
 
 	return false, nil
 }
-func isPushablePredicate(paramName string, be *semantic.BinaryExpression) bool {
+
+func isPushableUnaryPredicate(paramName string, ue *semantic.UnaryExpression) bool {
+	switch ue.Operator {
+	case ast.NotOperator:
+		// TODO(jsternberg): We should be able to rewrite `not r.host == "tag"` to `r.host != "tag"`
+		// but that is beyond what we do right now.
+		arg, ok := ue.Argument.(*semantic.UnaryExpression)
+		if !ok {
+			return false
+		}
+		return isPushableUnaryPredicate(paramName, arg)
+	case ast.ExistsOperator:
+		return isTag(paramName, ue.Argument)
+	default:
+		return false
+	}
+}
+
+func isPushableBinaryPredicate(paramName string, be *semantic.BinaryExpression) bool {
 	// Manual testing seems to indicate that (at least right now) we can
 	// only handle predicates of the form <fn param>.<property> <op> <literal>
 	// and the literal must be on the RHS.
 
 	if !isLiteral(be.Right) {
 		return false
+	}
+
+	// If the predicate is a string literal, we are comparing for equality,
+	// it is a tag, and it is empty, then it is not pushable.
+	//
+	// This is because the storage engine does not consider there a difference
+	// between a tag with an empty value and a non-existant tag. We have made
+	// the decision that a missing tag is null and not an empty string, so empty
+	// string isn't something that can be returned from the storage layer.
+	if lit, ok := be.Right.(*semantic.StringLiteral); ok {
+		if be.Operator == ast.EqualOperator && isTag(paramName, be.Left) && lit.Value == "" {
+			// The string literal is pushable if the operator is != because
+			// != "" will evaluate to true with everything that has a tag value
+			// and false when the tag value is null.
+			return false
+		}
 	}
 
 	if isField(paramName, be.Left) && isPushableFieldOperator(be.Operator) {
@@ -350,6 +390,54 @@ func isPushablePredicate(paramName string, be *semantic.BinaryExpression) bool {
 	}
 
 	return false
+}
+
+// rewritePushableExpr will rewrite the expression for the storage layer.
+func rewritePushableExpr(e semantic.Expression) (semantic.Expression, bool) {
+	switch e := e.(type) {
+	case *semantic.UnaryExpression:
+		var changed bool
+		if arg, ok := rewritePushableExpr(e.Argument); ok {
+			e = e.Copy().(*semantic.UnaryExpression)
+			e.Argument = arg
+			changed = true
+		}
+
+		switch e.Operator {
+		case ast.NotOperator:
+			if be, ok := e.Argument.(*semantic.BinaryExpression); ok {
+				switch be.Operator {
+				case ast.EqualOperator:
+					be = be.Copy().(*semantic.BinaryExpression)
+					be.Operator = ast.NotEqualOperator
+					return be, true
+				case ast.NotEqualOperator:
+					be = be.Copy().(*semantic.BinaryExpression)
+					be.Operator = ast.EqualOperator
+					return be, true
+				}
+			}
+		case ast.ExistsOperator:
+			return &semantic.BinaryExpression{
+				Operator: ast.NotEqualOperator,
+				Left:     e.Argument,
+				Right: &semantic.StringLiteral{
+					Value: "",
+				},
+			}, true
+		}
+		return e, changed
+
+	case *semantic.BinaryExpression:
+		left, lok := rewritePushableExpr(e.Left)
+		right, rok := rewritePushableExpr(e.Right)
+		if lok || rok {
+			e = e.Copy().(*semantic.BinaryExpression)
+			e.Left, e.Right = left, right
+			return e, true
+		}
+	}
+	return e, false
 }
 
 func isLiteral(e semantic.Expression) bool {

--- a/query/stdlib/influxdata/influxdb/rules_test.go
+++ b/query/stdlib/influxdata/influxdb/rules_test.go
@@ -350,6 +350,227 @@ func TestPushDownFilterRule(t *testing.T) {
 			},
 			NoChange: true,
 		},
+		{
+			Name:  `exists r.host`,
+			Rules: []plan.Rule{influxdb.PushDownFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", &influxdb.ReadRangePhysSpec{
+						Bounds: bounds,
+					}),
+					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+						Fn: makeFilterFn(&semantic.UnaryExpression{
+							Operator: ast.ExistsOperator,
+							Argument: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "host",
+							},
+						}),
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
+						Bounds:    bounds,
+						FilterSet: true,
+						Filter: makeFilterFn(&semantic.BinaryExpression{
+							Operator: ast.NotEqualOperator,
+							Left: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "host",
+							},
+							Right: &semantic.StringLiteral{
+								Value: "",
+							},
+						}),
+					}),
+				},
+			},
+		},
+		{
+			Name:  `not exists r.host`,
+			Rules: []plan.Rule{influxdb.PushDownFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", &influxdb.ReadRangePhysSpec{
+						Bounds: bounds,
+					}),
+					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+						Fn: makeFilterFn(&semantic.UnaryExpression{
+							Operator: ast.NotOperator,
+							Argument: &semantic.UnaryExpression{
+								Operator: ast.ExistsOperator,
+								Argument: &semantic.MemberExpression{
+									Object:   &semantic.IdentifierExpression{Name: "r"},
+									Property: "host",
+								},
+							},
+						}),
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
+						Bounds:    bounds,
+						FilterSet: true,
+						Filter: makeFilterFn(&semantic.BinaryExpression{
+							Operator: ast.EqualOperator,
+							Left: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "host",
+							},
+							Right: &semantic.StringLiteral{
+								Value: "",
+							},
+						}),
+					}),
+				},
+			},
+		},
+		{
+			Name:  `r.host == ""`,
+			Rules: []plan.Rule{influxdb.PushDownFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", &influxdb.ReadRangePhysSpec{
+						Bounds: bounds,
+					}),
+					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+						Fn: makeFilterFn(&semantic.BinaryExpression{
+							Operator: ast.EqualOperator,
+							Left: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "host",
+							},
+							Right: &semantic.StringLiteral{Value: ""},
+						}),
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
+		{
+			Name:  `r.host != ""`,
+			Rules: []plan.Rule{influxdb.PushDownFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", &influxdb.ReadRangePhysSpec{
+						Bounds: bounds,
+					}),
+					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+						Fn: makeFilterFn(&semantic.BinaryExpression{
+							Operator: ast.NotEqualOperator,
+							Left: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "host",
+							},
+							Right: &semantic.StringLiteral{Value: ""},
+						}),
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
+						Bounds:    bounds,
+						FilterSet: true,
+						Filter: makeFilterFn(&semantic.BinaryExpression{
+							Operator: ast.NotEqualOperator,
+							Left: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "host",
+							},
+							Right: &semantic.StringLiteral{
+								Value: "",
+							},
+						}),
+					}),
+				},
+			},
+		},
+		{
+			Name:  `r._value == ""`,
+			Rules: []plan.Rule{influxdb.PushDownFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", &influxdb.ReadRangePhysSpec{
+						Bounds: bounds,
+					}),
+					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+						Fn: makeFilterFn(&semantic.BinaryExpression{
+							Operator: ast.EqualOperator,
+							Left: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "_value",
+							},
+							Right: &semantic.StringLiteral{Value: ""},
+						}),
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("merged_ReadRange_filter", &influxdb.ReadRangePhysSpec{
+						Bounds:    bounds,
+						FilterSet: true,
+						Filter: makeFilterFn(&semantic.BinaryExpression{
+							Operator: ast.EqualOperator,
+							Left: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "_value",
+							},
+							Right: &semantic.StringLiteral{Value: ""},
+						}),
+					}),
+				},
+			},
+		},
+		{
+			// TODO(jsternberg): This one should be rewritten, but is not currently.
+			Name:  `not r.host == "server01"`,
+			Rules: []plan.Rule{influxdb.PushDownFilterRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("ReadRange", &influxdb.ReadRangePhysSpec{
+						Bounds: bounds,
+					}),
+					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+						Fn: makeFilterFn(&semantic.UnaryExpression{
+							Operator: ast.NotOperator,
+							Argument: &semantic.BinaryExpression{
+								Operator: ast.EqualOperator,
+								Left: &semantic.MemberExpression{
+									Object:   &semantic.IdentifierExpression{Name: "r"},
+									Property: "host",
+								},
+								Right: &semantic.StringLiteral{Value: "server01"},
+							},
+						}),
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
The `exists` operator now gets pushed down to storage correctly. If
`exists` is used on a tag, then it will be rewritten to `tag != ""`
which is how storage defines if a tag exists. If `not exists` is used,
then it will use `tag == ""` which is how you would query storage for
only if a tag doesn't exist.

The `tag == ""` and `tag != ""` are different. For `tag == ""`, the
predicate is impossible for the storage layer to return true with.
Ideally, we would just rewrite this to return nothing and we wouldn't
bother with even querying storage. Instead, we just do not rewrite this
predicate because it cannot be rewritten to make sense with storage. If
we see `tag != ""`, it is the only one that can be passed through as-is
because `tag != ""` returns the same values as `exists tag`. It will
return true for every non-null value.

#14092