### PR TITLE
fix(http): The org parameter takes either the ID or Name interchangeably

### DIFF
--- a/http/org_service.go
+++ b/http/org_service.go
@@ -327,7 +327,7 @@ func decodeGetOrgsRequest(ctx context.Context, r *http.Request) (*getOrgsRequest
 		req.filter.ID = id
 	}
 
-	if name := qp.Get(OrgName); name != "" {
+	if name := qp.Get(Org); name != "" {
 		req.filter.Name = &name
 	}
 
@@ -660,7 +660,7 @@ func (s *OrganizationService) FindOrganizations(ctx context.Context, filter infl
 	qp := url.Query()
 
 	if filter.Name != nil {
-		qp.Add(OrgName, *filter.Name)
+		qp.Add(Org, *filter.Name)
 	}
 	if filter.ID != nil {
 		qp.Add(OrgID, filter.ID.String())

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -472,7 +472,7 @@ func SimpleQuery(addr, flux, org, token string) ([]byte, error) {
 		return nil, err
 	}
 	params := url.Values{}
-	params.Set(OrgName, org)
+	params.Set(Org, org)
 	u.RawQuery = params.Encode()
 
 	header := true

--- a/http/query_handler_test.go
+++ b/http/query_handler_test.go
@@ -98,7 +98,7 @@ func TestFluxService_Query(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if reqID := r.URL.Query().Get(OrgID); reqID == "" {
-					if name := r.URL.Query().Get(OrgName); name == "" {
+					if name := r.URL.Query().Get(Org); name == "" {
 						// Request must have org or orgID.
 						ErrorHandler(0).HandleHTTPError(context.TODO(), influxdb.ErrInvalidOrgFilter, w)
 						return

--- a/http/requests.go
+++ b/http/requests.go
@@ -12,10 +12,31 @@ const (
 	OrgName = "org"
 	// OrgID is the http query parameter to specify an organization by ID.
 	OrgID = "orgID"
+	// Org is the http query parameter that take either the ID or Name interchangeably
+	Org = "org"
 )
 
 // queryOrganization returns the organization for any http request.
 func queryOrganization(ctx context.Context, r *http.Request, svc platform.OrganizationService) (o *platform.Organization, err error) {
+
+	if organization := r.URL.Query().Get(Org); organization != "" {
+		if id, err := platform.IDFromString(organization); err == nil {
+			// Decoded ID successfully. Make sure it's a real org.
+			o, err := svc.FindOrganization(ctx, platform.OrganizationFilter{ID: id})
+			if err == nil {
+				return o, err
+			} else if platform.ErrorCode(err) != platform.ENotFound {
+				return nil, err
+			}
+		}
+
+		o, err := svc.FindOrganization(ctx, platform.OrganizationFilter{Name: &organization})
+		if err != nil {
+			return nil, err
+		}
+		return o, nil
+	}
+
 	filter := platform.OrganizationFilter{}
 	if reqID := r.URL.Query().Get(OrgID); reqID != "" {
 		filter.ID, err = platform.IDFromString(reqID)
@@ -23,10 +44,5 @@ func queryOrganization(ctx context.Context, r *http.Request, svc platform.Organi
 			return nil, err
 		}
 	}
-
-	if name := r.URL.Query().Get(OrgName); name != "" {
-		filter.Name = &name
-	}
-
 	return svc.FindOrganization(ctx, filter)
 }

--- a/http/requests.go
+++ b/http/requests.go
@@ -8,8 +8,6 @@ import (
 )
 
 const (
-	// OrgName is the http query parameter to specify an organization by name.
-	OrgName = "org"
 	// OrgID is the http query parameter to specify an organization by ID.
 	OrgID = "orgID"
 	// Org is the http query parameter that take either the ID or Name interchangeably
@@ -19,25 +17,16 @@ const (
 // queryOrganization returns the organization for any http request.
 func queryOrganization(ctx context.Context, r *http.Request, svc platform.OrganizationService) (o *platform.Organization, err error) {
 
+	filter := platform.OrganizationFilter{}
+
 	if organization := r.URL.Query().Get(Org); organization != "" {
 		if id, err := platform.IDFromString(organization); err == nil {
-			// Decoded ID successfully. Make sure it's a real org.
-			o, err := svc.FindOrganization(ctx, platform.OrganizationFilter{ID: id})
-			if err == nil {
-				return o, err
-			} else if platform.ErrorCode(err) != platform.ENotFound {
-				return nil, err
-			}
+			filter.ID = id
+		} else {
+			filter.Name = &organization
 		}
-
-		o, err := svc.FindOrganization(ctx, platform.OrganizationFilter{Name: &organization})
-		if err != nil {
-			return nil, err
-		}
-		return o, nil
 	}
 
-	filter := platform.OrganizationFilter{}
 	if reqID := r.URL.Query().Get(OrgID); reqID != "" {
 		filter.ID, err = platform.IDFromString(reqID)
 		if err != nil {

--- a/http/requests_test.go
+++ b/http/requests_test.go
@@ -79,6 +79,29 @@ func Test_queryOrganization(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "org id as org finds organization",
+			want: &platform.Organization{
+				ID: platform.ID(1),
+			},
+			args: args{
+				ctx: context.Background(),
+				r:   httptest.NewRequest(http.MethodPost, "/api/v2/query?org=0000000000000001", nil),
+				svc: &mock.OrganizationService{
+					FindOrganizationF: func(ctx context.Context, filter platform.OrganizationFilter) (*platform.Organization, error) {
+						if *filter.ID == platform.ID(1) {
+							return &platform.Organization{
+								ID: platform.ID(1),
+							}, nil
+						}
+						return nil, &platform.Error{
+							Code: platform.EInvalid,
+							Msg:  "unknown org name",
+						}
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -1561,11 +1561,16 @@ paths:
               - application/json
         - in: query
           name: org
-          description: specifies the destination organization for writes
+          description: specifies the destination organization for writes; take either the ID or Name interchangeably; if both orgID and org are specified, org takes precedence.
           required: true
           schema:
             type: string
             description: all points within batch are written to this organization.
+        - in: query
+          name: orgID
+          description: specifies the ID of the destination organization for writes; if both orgID and org are specified, org takes precedence.
+          schema:
+            type: string
         - in: query
           name: bucket
           description: specifies the destination bucket for writes
@@ -3092,12 +3097,12 @@ paths:
               - application/vnd.flux
         - in: query
           name: org
-          description: specifies the name of the organization executing the query; if both orgID and org are specified, orgID takes precedence.
+          description: specifies the name of the organization executing the query; take either the ID or Name interchangeably; if both orgID and org are specified, org takes precedence.
           schema:
             type: string
         - in: query
           name: orgID
-          description: specifies the ID of the organization executing the query; if both orgID and org are specified, orgID takes precedence.
+          description: specifies the ID of the organization executing the query; if both orgID and org are specified, org takes precedence.
           schema:
             type: string
       requestBody:


### PR DESCRIPTION
Closes #13906

The org parameter could be `Organization.name` or `Organization.id` for '/write' and '/query'.