### PR TITLE
chore(swagger): update codeowners file for swagger spec

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,6 @@
 # Here is information about how to configure this file:
 # https://help.github.com/en/articles/about-code-owners
 
-# API team will help to review swagger.yml changes.
+# API and monitoring team will help to review swagger.yml changes.
 #
-http/swagger.yml @influxdata/api
+http/swagger.yml @influxdata/api @influxdata/monitoring-team


### PR DESCRIPTION
We've been writing UI code off of the swagger spec before an actual API implementation exists. Recently, we coded against a spec that was changed during the implementation of the API. This broke our UI code, but we didn't find out about it until working on an unrelated task days later (when we regenerated our client from the spec).

By adding some UI representation to review `swagger.yml`, we can more proactively identify these issues. 