### PR TITLE
feat(query): Buffered writer for to function

### DIFF
--- a/mock/points_writer.go
+++ b/mock/points_writer.go
@@ -9,9 +9,10 @@ import (
 
 // PointsWriter is a mock structure for writing points.
 type PointsWriter struct {
-	mu     sync.RWMutex
-	Points []models.Point
-	Err    error
+	timesWriteCalled int
+	mu               sync.RWMutex
+	Points           []models.Point
+	Err              error
 }
 
 // ForceError is for error testing, if WritePoints is called after ForceError, it will return that error.
@@ -24,6 +25,7 @@ func (p *PointsWriter) ForceError(err error) {
 // WritePoints writes points to the PointsWriter that will be exposed in the Values.
 func (p *PointsWriter) WritePoints(ctx context.Context, points []models.Point) error {
 	p.mu.Lock()
+	p.timesWriteCalled++
 	p.Points = append(p.Points, points...)
 	err := p.Err
 	p.mu.Unlock()
@@ -44,4 +46,10 @@ func (p *PointsWriter) Next() models.Point {
 	defer p.mu.Unlock()
 	points, p.Points = p.Points[0], p.Points[1:]
 	return points
+}
+
+func (p *PointsWriter) WritePointsCalled() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.timesWriteCalled
 }

--- a/storage/points_writer.go
+++ b/storage/points_writer.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"sync"
 
 	"github.com/influxdata/influxdb/models"
 )
@@ -9,4 +10,63 @@ import (
 // PointsWriter describes the ability to write points into a storage engine.
 type PointsWriter interface {
 	WritePoints(context.Context, []models.Point) error
+}
+
+type BufferedPointsWriter struct {
+	sync.Mutex
+	buf []models.Point
+	n   int
+	wr  PointsWriter
+	err error
+}
+
+func NewBufferedPointsWriter(size int, pointswriter PointsWriter) *BufferedPointsWriter {
+	return &BufferedPointsWriter{
+		buf: make([]models.Point, size),
+		wr:  pointswriter,
+	}
+}
+
+// WritePoints writes the points to the underlying PointsWriter.
+func (b *BufferedPointsWriter) WritePoints(ctx context.Context, p []models.Point) error {
+	for len(p) > b.Available() && b.err == nil {
+		var n int
+		if b.Buffered() == 0 {
+			// Large write, empty buffer.
+			// Write directly from p to avoid copy.
+			b.err = b.wr.WritePoints(ctx, p)
+		} else {
+			b.n += copy(b.buf[b.n:], p)
+			b.err = b.Flush(ctx)
+		}
+		p = p[n:]
+	}
+	if b.err != nil {
+		return b.err
+	}
+	b.n += copy(b.buf[b.n:], p)
+	return nil
+}
+
+// Available returns how many models.Points are unused in the buffer.
+func (b *BufferedPointsWriter) Available() int { return len(b.buf) - b.n }
+
+// Buffered returns the number of models.Points that have been written into the current buffer.
+func (b *BufferedPointsWriter) Buffered() int { return len(b.buf) }
+
+// Flush writes any buffered data to the underlying PointsWriter.
+func (b *BufferedPointsWriter) Flush(ctx context.Context) error {
+	if b.err != nil {
+		return b.err
+	}
+	if b.n == 0 {
+		return nil
+	}
+
+	b.err = b.wr.WritePoints(ctx, b.buf[:b.n])
+	if b.err != nil {
+		return b.err
+	}
+	b.n = 0
+	return nil
 }

--- a/storage/points_writer_test.go
+++ b/storage/points_writer_test.go
@@ -1,0 +1,120 @@
+package storage_test
+
+//WritePoints does nothing in error state
+//the main WritePoints scenarios (large write, etc)
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/storage"
+	"github.com/influxdata/influxdb/tsdb"
+
+	"github.com/influxdata/influxdb/mock"
+)
+
+func TestBufferedPointsWriter(t *testing.T) {
+	t.Run("large empty write on empty buffer", func(t *testing.T) {
+		pw := &mock.PointsWriter{}
+		bpw := storage.NewBufferedPointsWriter(6, pw)
+		bpw.WritePoints(
+			context.Background(),
+			mockPoints(
+				1,
+				2,
+				`a day="Monday",humidity=1,ratio=2,temperature=2 11
+a day="Tuesday",humidity=2,ratio=1,temperature=2 21
+b day="Wednesday",humidity=4,ratio=0.25,temperature=1 21
+a day="Thursday",humidity=3,ratio=1,temperature=3 31
+c day="Friday",humidity=5,ratio=0,temperature=4 41
+e day="Saturday",humidity=6,ratio=0.1,temperature=99 51
+`))
+
+		if pw.Err != nil {
+			t.Error(pw.Err)
+		}
+		if len(pw.Points) != 24 {
+			t.Errorf("long writes on empty buffer should write all points but only wrote %d", len(pw.Points))
+		}
+		if pw.WritePointsCalled() != 1 {
+			t.Errorf("expected WritePoints to be called once, but was called %d times", pw.WritePointsCalled())
+		}
+	})
+	t.Run("do nothing in error state", func(t *testing.T) {
+		pw := &mock.PointsWriter{}
+		bpw := storage.NewBufferedPointsWriter(6, pw)
+		bpw.WritePoints(
+			context.Background(),
+			mockPoints(
+				1,
+				2,
+				`a day="Monday",humidity=1,ratio=2,temperature=2 11
+`))
+		pw.ForceError(errors.New("OH NO! ERRORZ!"))
+		err := bpw.WritePoints(
+			context.Background(),
+			mockPoints(
+				1,
+				2,
+				`a day="Tuesday",humidity=2,ratio=1,temperature=2 21
+b day="Wednesday",humidity=4,ratio=0.25,temperature=1 21
+a day="Thursday",humidity=3,ratio=1,temperature=3 31
+c day="Friday",humidity=5,ratio=0,temperature=4 41
+e day="Saturday",humidity=6,ratio=0.1,temperature=99 51
+`))
+		if pw.Err != err {
+			t.Error("expected the error returned to be the forced one, but it was not")
+		}
+		if pw.WritePointsCalled() != 1 {
+			t.Errorf("expected WritePoints to be called once, since it should do nothing in the error state, but was called %d times", pw.WritePointsCalled())
+		}
+
+	})
+	t.Run("flush on write when over limit", func(t *testing.T) {
+		pw := &mock.PointsWriter{}
+		bpw := storage.NewBufferedPointsWriter(6, pw)
+		bpw.WritePoints(context.Background(), mockPoints(1, 2, `a day="Monday",humidity=1,ratio=2,temperature=2 11`))
+		bpw.WritePoints(context.Background(), mockPoints(1, 2, `a day="Tuesday",humidity=2,ratio=1,temperature=2 21`))
+		bpw.WritePoints(context.Background(), mockPoints(1, 2, `b day="Wednesday",humidity=4,ratio=0.25,temperature=1 21`))
+		bpw.WritePoints(context.Background(), mockPoints(1, 2, `a day="Thursday",humidity=3,ratio=1,temperature=3 31`))
+		bpw.WritePoints(context.Background(), mockPoints(1, 2, `c day="Friday",humidity=5,ratio=0,temperature=4 41`))
+		bpw.WritePoints(context.Background(), mockPoints(1, 2, `e day="Saturday",humidity=6,ratio=0.1,temperature=99 51`))
+		if pw.Err != nil {
+			t.Errorf("expected no error, but got %v", pw.Err)
+		}
+		if pw.WritePointsCalled() != 3 {
+			t.Errorf("expected WritePoints to be called 3 times, but was called %d times", pw.WritePointsCalled())
+		}
+
+		bpw.Flush(context.Background())
+		if pw.WritePointsCalled() != 4 {
+			t.Errorf("expected WritePoints to be called 4 times, but was called %d times", pw.WritePointsCalled())
+		}
+
+		bpw.Flush(context.Background())
+		if pw.WritePointsCalled() != 4 {
+			t.Errorf("expected WritePoints to be called 4 times, but was called %d times", pw.WritePointsCalled())
+		}
+	})
+
+	t.Run("don't flush when empty", func(t *testing.T) {
+		pw := &mock.PointsWriter{}
+		bpw := storage.NewBufferedPointsWriter(6, pw)
+		bpw.Flush(context.Background())
+		if pw.WritePointsCalled() != 0 {
+			t.Errorf("expected WritePoints to not be falled but was called %d times", pw.WritePointsCalled())
+		}
+	})
+}
+
+func mockPoints(org, bucket platform.ID, pointdata string) []models.Point {
+	name := tsdb.EncodeName(org, bucket)
+	points, err := models.ParsePoints([]byte(pointdata), name[:])
+	if err != nil {
+		panic(err)
+	}
+	return points
+}


### PR DESCRIPTION
This adds a buffered synchronous PointsWriter.  It wraps a regular PointsWriter and allows for fast buffered writing of points.  It is not thread-safe.