### PR TITLE
 refactor(tsdb/cursors): Add boundSearch to improve FindRange

### DIFF
--- a/tsdb/cursors/arrayvalues.gen.go
+++ b/tsdb/cursors/arrayvalues.gen.go
@@ -57,6 +57,20 @@ func (a *FloatArray) search(v int64) int {
 	return lo
 }
 
+func (a *FloatArray) boundSearch(v int64, lo, hi int) int {
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
@@ -75,7 +89,8 @@ func (a *FloatArray) FindRange(min, max int64) (int, int) {
 		return -1, -1
 	}
 
-	return a.search(min), a.search(max)
+	lo := a.search(min)
+	return lo, a.boundSearch(max, lo, a.Len())
 }
 
 // Exclude removes the subset of values in [min, max]. The values must
@@ -258,6 +273,20 @@ func (a *IntegerArray) search(v int64) int {
 	return lo
 }
 
+func (a *IntegerArray) boundSearch(v int64, lo, hi int) int {
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
@@ -276,7 +305,8 @@ func (a *IntegerArray) FindRange(min, max int64) (int, int) {
 		return -1, -1
 	}
 
-	return a.search(min), a.search(max)
+	lo := a.search(min)
+	return lo, a.boundSearch(max, lo, a.Len())
 }
 
 // Exclude removes the subset of values in [min, max]. The values must
@@ -459,6 +489,20 @@ func (a *UnsignedArray) search(v int64) int {
 	return lo
 }
 
+func (a *UnsignedArray) boundSearch(v int64, lo, hi int) int {
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
@@ -477,7 +521,8 @@ func (a *UnsignedArray) FindRange(min, max int64) (int, int) {
 		return -1, -1
 	}
 
-	return a.search(min), a.search(max)
+	lo := a.search(min)
+	return lo, a.boundSearch(max, lo, a.Len())
 }
 
 // Exclude removes the subset of values in [min, max]. The values must
@@ -660,6 +705,20 @@ func (a *StringArray) search(v int64) int {
 	return lo
 }
 
+func (a *StringArray) boundSearch(v int64, lo, hi int) int {
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
@@ -678,7 +737,8 @@ func (a *StringArray) FindRange(min, max int64) (int, int) {
 		return -1, -1
 	}
 
-	return a.search(min), a.search(max)
+	lo := a.search(min)
+	return lo, a.boundSearch(max, lo, a.Len())
 }
 
 // Exclude removes the subset of values in [min, max]. The values must
@@ -861,6 +921,20 @@ func (a *BooleanArray) search(v int64) int {
 	return lo
 }
 
+func (a *BooleanArray) boundSearch(v int64, lo, hi int) int {
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
@@ -879,7 +953,8 @@ func (a *BooleanArray) FindRange(min, max int64) (int, int) {
 		return -1, -1
 	}
 
-	return a.search(min), a.search(max)
+	lo := a.search(min)
+	return lo, a.boundSearch(max, lo, a.Len())
 }
 
 // Exclude removes the subset of values in [min, max]. The values must
@@ -1060,6 +1135,20 @@ func (a *TimestampArray) search(v int64) int {
 	return lo
 }
 
+func (a *TimestampArray) boundSearch(v int64, lo, hi int) int {
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if a.Timestamps[mid] < v {
+			lo = mid + 1 // preserves f(lo-1) == true
+		} else {
+			hi = mid // preserves f(hi) == false
+		}
+	}
+
+	// lo == hi
+	return lo
+}
+
 // FindRange returns the positions where min and max would be
 // inserted into the array. If a[0].UnixNano() > max or
 // a[len-1].UnixNano() < min then FindRange returns (-1, -1)
@@ -1078,7 +1167,8 @@ func (a *TimestampArray) FindRange(min, max int64) (int, int) {
 		return -1, -1
 	}
 
-	return a.search(min), a.search(max)
+	lo := a.search(min)
+	return lo, a.boundSearch(max, lo, a.Len())
 }
 
 // Exclude removes the subset of timestamps in [min, max]. The timestamps must

--- a/tsdb/cursors/arrayvalues.gen_test.go
+++ b/tsdb/cursors/arrayvalues.gen_test.go
@@ -253,30 +253,29 @@ func BenchmarkIntegerArray_IncludeLast_10000(b *testing.B) {
 	benchInclude(b, makeIntegerArray(10000, 10000, 20000), 19999, 20000)
 }
 
-func BenchmarkIntegerArray_FindRange_10000(b *testing.B) {
-	vals := makeIntegerArray(10000, 10000, 20000)
+func BenchmarkIntegerArray_FindRange_100000(b *testing.B) {
+	vals := makeIntegerArray(100000, 100000, 200000)
 	cases := []struct {
 		min, max       int64
 		expId1, expId2 int
 	}{
-		{11000, 12000, 1000, 2000},
-		{12000, 13000, 2000, 3000},
-		{13000, 14000, 3000, 4000},
-		{14000, 15000, 4000, 5000},
-		{15000, 16000, 5000, 6000},
-		{16000, 17000, 6000, 7000},
-		{17000, 18000, 7000, 8000},
-		{18000, 19000, 8000, 9000},
+		{110000, 120000, 10000, 20000},
+		{120000, 130000, 20000, 30000},
+		{130000, 140000, 30000, 40000},
+		{140000, 150000, 40000, 50000},
+		{150000, 160000, 50000, 60000},
+		{160000, 170000, 60000, 70000},
+		{170000, 180000, 70000, 80000},
+		{180000, 190000, 80000, 90000},
 	}
 
 	b.ResetTimer()
-	b.ResetAllocs()
 
 	for j := 0; j < b.N; j++ {
 		for _, c := range cases {
 			id1, id2 := vals.FindRange(c.min, c.max)
 			if !cmp.Equal(id1, c.expId1) || !cmp.Equal(id2, c.expId2) {
-				t.Errorf("unexpected ids [%d, %d] -got [%d, %d]\n%s", c.expId1, c.expId2, id1, id2)
+				b.Errorf("unexpected ids [%d, %d] -got [%d, %d]\n", c.expId1, c.expId2, id1, id2)
 			}
 		}
 	}

--- a/tsdb/cursors/arrayvalues.gen_test.go
+++ b/tsdb/cursors/arrayvalues.gen_test.go
@@ -252,3 +252,32 @@ func BenchmarkIntegerArray_IncludeFirst_10000(b *testing.B) {
 func BenchmarkIntegerArray_IncludeLast_10000(b *testing.B) {
 	benchInclude(b, makeIntegerArray(10000, 10000, 20000), 19999, 20000)
 }
+
+func BenchmarkIntegerArray_FindRange_10000(b *testing.B) {
+	vals := makeIntegerArray(10000, 10000, 20000)
+	cases := []struct {
+		min, max       int64
+		expId1, expId2 int
+	}{
+		{11000, 12000, 1000, 2000},
+		{12000, 13000, 2000, 3000},
+		{13000, 14000, 3000, 4000},
+		{14000, 15000, 4000, 5000},
+		{15000, 16000, 5000, 6000},
+		{16000, 17000, 6000, 7000},
+		{17000, 18000, 7000, 8000},
+		{18000, 19000, 8000, 9000},
+	}
+
+	b.ResetTimer()
+	b.ResetAllocs()
+
+	for j := 0; j < b.N; j++ {
+		for _, c := range cases {
+			id1, id2 := vals.FindRange(c.min, c.max)
+			if !cmp.Equal(id1, c.expId1) || !cmp.Equal(id2, c.expId2) {
+				t.Errorf("unexpected ids [%d, %d] -got [%d, %d]\n%s", c.expId1, c.expId2, id1, id2)
+			}
+		}
+	}
+}


### PR DESCRIPTION
As title, add boundSearch to reduce some unnecessary checks in the binary search of FindRange.
I add benchmark for the IntegerArray.
```
benchmark                                    old ns/op     new ns/op     delta
BenchmarkIntegerArray_FindRange_100000-8     14166         12611         -10.98%
