### PR TITLE
feat(task): Add task types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [14495](https://github.com/influxdata/influxdb/pull/14495): optional gzip compression of the query CSV response.
+1. [14567](https://github.com/influxdata/influxdb/pull/14567): Add task types.
 
 ### UI Improvements
 

--- a/authorizer/task.go
+++ b/authorizer/task.go
@@ -122,6 +122,10 @@ func (ts *taskServiceValidator) CreateTask(ctx context.Context, t platform.TaskC
 		return nil, influxdb.ErrMissingToken
 	}
 
+	if t.Type == influxdb.TaskTypeWildcard {
+		return nil, influxdb.ErrInvalidTaskType
+	}
+
 	p, err := platform.NewPermission(platform.WriteAction, platform.TasksResourceType, t.OrganizationID)
 	if err != nil {
 		return nil, err

--- a/authorizer/task_test.go
+++ b/authorizer/task_test.go
@@ -216,6 +216,25 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`,
 			auth: &influxdb.Authorization{},
 		},
 		{
+			name: "create bad type",
+			check: func(ctx context.Context, svc influxdb.TaskService) error {
+				_, err := svc.CreateTask(ctx, influxdb.TaskCreate{
+					OrganizationID: r.Org.ID,
+					Token:          r.Auth.Token,
+					Type:           influxdb.TaskTypeWildcard,
+					Flux: `option task = {
+ name: "my_task",
+ every: 1s,
+}
+from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`,
+				})
+				if err != influxdb.ErrInvalidTaskType {
+					return errors.New("failed to error with invalid task type")
+				}
+				return nil
+			},
+			auth: &influxdb.Authorization{},
+		}, {
 			name: "create success",
 			auth: r.Auth,
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
@@ -232,7 +251,7 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`,
 			},
 		},
 		{
-			name: "create badbucket",
+			name: "create bad bucket",
 			auth: r.Auth,
 			check: func(ctx context.Context, svc influxdb.TaskService) error {
 				var (

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6556,6 +6556,9 @@ components:
         id:
           readOnly: true
           type: string
+        type:
+          description: The type of task, this can be used for filtering tasks on list actions.
+          type: string
         orgID:
           description: The ID of the organization that owns this Task.
           type: string
@@ -8816,6 +8819,9 @@ components:
     TaskCreateRequest:
       type: object
       properties:
+        type:
+          description: The type of task, this can be used for filtering tasks on list actions.
+          type: string
         orgID:
           description: The ID of the organization that owns this Task.
           type: string

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -362,6 +362,10 @@ func decodeGetTasksRequest(ctx context.Context, r *http.Request, orgs platform.O
 		req.filter.Limit = platform.TaskDefaultPageSize
 	}
 
+	if ttype := qp.Get("type"); ttype != "" {
+		req.filter.Type = &ttype
+	}
+
 	return req, nil
 }
 
@@ -1311,6 +1315,10 @@ func (t TaskService) FindTasks(ctx context.Context, filter platform.TaskFilter) 
 	}
 	if filter.Limit != 0 {
 		val.Add("limit", strconv.Itoa(filter.Limit))
+	}
+
+	if filter.Type != nil {
+		val.Add("type", *filter.Type)
 	}
 
 	u.RawQuery = val.Encode()

--- a/http/task_test.go
+++ b/http/task_test.go
@@ -67,7 +67,12 @@ func TestTaskService(t *testing.T) {
 				Token: auth.Token,
 			}
 
-			cFunc := func() (servicetest.TestCreds, error) {
+			cFunc := func(t *testing.T) (servicetest.TestCreds, error) {
+				org := &platform.Organization{Name: t.Name() + "_org"}
+				if err := service.CreateOrganization(ctx, org); err != nil {
+					t.Fatal(err)
+				}
+
 				return servicetest.TestCreds{
 					OrgID:           org.ID,
 					Org:             org.Name,

--- a/kv/task.go
+++ b/kv/task.go
@@ -227,6 +227,14 @@ func (s *Service) findTasksByUser(ctx context.Context, tx Tx, filter influxdb.Ta
 			continue
 		}
 
+		if filter.Type == nil {
+			ft := ""
+			filter.Type = &ft
+		}
+		if *filter.Type != influxdb.TaskTypeWildcard && *filter.Type != task.Type {
+			continue
+		}
+
 		ts = append(ts, task)
 
 		if len(ts) >= filter.Limit {
@@ -296,10 +304,16 @@ func (s *Service) findTaskByOrg(ctx context.Context, tx Tx, filter influxdb.Task
 				return nil, 0, err
 			}
 
-			// insert the new task into the list
 			if t != nil {
-				ts = append(ts, t)
+				typ := ""
+				if filter.Type != nil {
+					typ = *filter.Type
+				}
 
+				// if the filter type matches task type or filter type is a wildcard
+				if typ == t.Type || typ == influxdb.TaskTypeWildcard {
+					ts = append(ts, t)
+				}
 			}
 		}
 	}
@@ -332,6 +346,14 @@ func (s *Service) findTaskByOrg(ctx context.Context, tx Tx, filter influxdb.Task
 		// If the new task doesn't belong to the org we have looped outside the org filter
 		if org != nil && t.OrganizationID != org.ID {
 			break
+		}
+
+		if filter.Type == nil {
+			ft := ""
+			filter.Type = &ft
+		}
+		if *filter.Type != influxdb.TaskTypeWildcard && *filter.Type != t.Type {
+			continue
 		}
 
 		// insert the new task into the list
@@ -491,6 +513,7 @@ func (s *Service) createTask(ctx context.Context, tx Tx, tc influxdb.TaskCreate)
 	createdAt := time.Now().UTC().Format(time.RFC3339)
 	task := &influxdb.Task{
 		ID:              s.IDGenerator.ID(),
+		Type:            tc.Type,
 		OrganizationID:  org.ID,
 		Organization:    org.Name,
 		AuthorizationID: auth.Identifier(),

--- a/task.go
+++ b/task.go
@@ -20,11 +20,14 @@ const (
 
 	TaskStatusActive   = "active"
 	TaskStatusInactive = "inactive"
+
+	TaskTypeWildcard = "*"
 )
 
 // Task is a task. 🎊
 type Task struct {
 	ID              ID     `json:"id"`
+	Type            string `json:"type,omitempty"`
 	OrganizationID  ID     `json:"orgID"`
 	Organization    string `json:"org"`
 	AuthorizationID ID     `json:"authorizationID"`
@@ -134,6 +137,7 @@ type TaskService interface {
 
 // TaskCreate is the set of values to create a task.
 type TaskCreate struct {
+	Type           string `json:"type,omitempty"`
 	Flux           string `json:"flux"`
 	Description    string `json:"description,omitempty"`
 	Status         string `json:"status,omitempty"`
@@ -374,6 +378,7 @@ func (t *TaskUpdate) UpdateFlux(oldFlux string) error {
 
 // TaskFilter represents a set of filters that restrict the returned results
 type TaskFilter struct {
+	Type           *string
 	After          *ID
 	OrganizationID *ID
 	Organization   string

--- a/task_errors.go
+++ b/task_errors.go
@@ -36,6 +36,11 @@ var (
 		Msg:  "invalid id",
 	}
 
+	// ErrInvalidTaskType error object for bad id's
+	ErrInvalidTaskType = &Error{
+		Code: EInvalid,
+		Msg:  "invalid task type",
+	}
 	// ErrTaskNotFound indicates no task could be found for given parameters.
 	ErrTaskNotFound = &Error{
 		Code: ENotFound,


### PR DESCRIPTION
Add a type to task's to allow tasks to be filterable.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
