### PR TITLE
fix(tasks): add run limit check to analytical store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [14480](https://github.com/influxdata/influxdb/pull/14480): Fix authentication when updating a task with invalid org or bucket.
 1. [14497](https://github.com/influxdata/influxdb/pull/14497): Update the documentation link for Telegraf.
 1. [14492](https://github.com/influxdata/influxdb/pull/14492): Fix to surface errors properly as task notifications on create.
+1. [14569](https://github.com/influxdata/influxdb/pull/14569): Fix limiting of get runs for task.
 
 ## v2.0.0-alpha.16 [2019-07-25]
 

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -180,8 +180,9 @@ func (as *AnalyticalStorage) FindRuns(ctx context.Context, filter influxdb.RunFi
 	  %s
 	  |> group(columns: ["taskID"])
 	  |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+	  |> limit(n:%d)
 
-	  `, filter.Task.String(), filterPart)
+	  `, filter.Task.String(), filterPart, filter.Limit-len(runs))
 
 	// At this point we are behind authorization
 	// so we are faking a read only permission to the org's system bucket


### PR DESCRIPTION
Closes #13575

This PR fixes an issue where setting a limit in the query for getting runs for a task did not work, and would instead return all runs for the task. A limit was added to the flux function retrieving the runs, and the length of the runs was checking before adding to the runs to be returned.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
- [x] Tests pass
