### PR TITLE
fix(tests): TestServer_Query_ImplicitFill should skip when using remote server to test

### DIFF
--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -6716,6 +6716,10 @@ func TestServer_Query_ImplicitFill(t *testing.T) {
 	s := OpenServer(config)
 	defer s.Close()
 
+       if _, ok := s.(*RemoteServer); ok {
+	        t.Skip("Skipping. Cannot change config remotely")
+	}
+
 	if err := s.CreateDatabaseAndRetentionPolicy("db0", NewRetentionPolicySpec("rp0", 1, 0), true); err != nil {
 		t.Fatal(err)
 	}

--- a/tests/server_test.go
+++ b/tests/server_test.go
@@ -6716,8 +6716,8 @@ func TestServer_Query_ImplicitFill(t *testing.T) {
 	s := OpenServer(config)
 	defer s.Close()
 
-       if _, ok := s.(*RemoteServer); ok {
-	        t.Skip("Skipping. Cannot change config remotely")
+	if _, ok := s.(*RemoteServer); ok {
+		t.Skip("Skipping. Cannot change config remotely")
 	}
 
 	if err := s.CreateDatabaseAndRetentionPolicy("db0", NewRetentionPolicySpec("rp0", 1, 0), true); err != nil {


### PR DESCRIPTION
Closes #14572 

Skip the test when using remote server, or the test will fail because of the config could not take
effect in remote server

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Documentation updated or issue created (provide link to issue/pr)

