### PR TITLE
fix(http): use the content type header to determine how to parse http errors

### DIFF
--- a/http/errors_test.go
+++ b/http/errors_test.go
@@ -2,12 +2,17 @@ package http_test
 
 import (
 	"context"
+	"encoding/json"
+	stderrors "errors"
 	"fmt"
+	"io"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/http"
+	"github.com/pkg/errors"
 )
 
 func TestEncodeError(t *testing.T) {
@@ -47,5 +52,64 @@ func TestEncodeErrorWithError(t *testing.T) {
 	pe := http.CheckError(w.Result())
 	if pe.(*influxdb.Error).Err.Error() != expected.Err.Error() {
 		t.Errorf("errors encode err: got %s", w.Body.String())
+	}
+}
+
+func TestCheckError(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		write func(w *httptest.ResponseRecorder)
+		want  error
+	}{
+		{
+			name: "platform error",
+			write: func(w *httptest.ResponseRecorder) {
+				h := http.ErrorHandler(0)
+				err := &influxdb.Error{
+					Msg:  "expected",
+					Code: influxdb.EInvalid,
+				}
+				h.HandleHTTPError(context.Background(), err, w)
+			},
+			want: &influxdb.Error{
+				Msg:  "expected",
+				Code: influxdb.EInvalid,
+			},
+		},
+		{
+			name: "text error",
+			write: func(w *httptest.ResponseRecorder) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(500)
+				_, _ = io.WriteString(w, "upstream timeout\n")
+			},
+			want: stderrors.New("upstream timeout"),
+		},
+		{
+			name: "error with bad json",
+			write: func(w *httptest.ResponseRecorder) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(500)
+				_, _ = io.WriteString(w, "upstream timeout\n")
+			},
+			want: errors.Wrap(stderrors.New("upstream timeout"), "invalid character 'u' looking for beginning of value"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			tt.write(w)
+
+			resp := w.Result()
+			cmpopt := cmp.Transformer("error", func(e error) string {
+				if e, ok := e.(*influxdb.Error); ok {
+					out, _ := json.Marshal(e)
+					return string(out)
+				}
+				return e.Error()
+			})
+			if got, want := http.CheckError(resp), tt.want; !cmp.Equal(want, got, cmpopt) {
+				t.Fatalf("unexpected error -want/+got:\n%s", cmp.Diff(want, got, cmpopt))
+			}
+		})
 	}
 }


### PR DESCRIPTION
This will only attempt to parse an error as JSON if it has the content
type `application/json` so that it stops trying to parse the result as
JSON when it isn't JSON.

While the real error message is included, the addition of the "could not
parse json" makes it very confusing to read and distracts from the real
issue.

#3944