### PR TITLE
fix(storage/reads): remove duplicate tables from the stream

### DIFF
--- a/storage/reads/reader.go
+++ b/storage/reads/reader.go
@@ -137,7 +137,7 @@ func (fi *filterIterator) Do(f func(flux.Table) error) error {
 		return nil
 	}
 
-	return fi.handleRead(f, rs)
+	return fi.handleRead(filterDuplicateTables(f), rs)
 }
 
 func (fi *filterIterator) handleRead(f func(flux.Table) error, rs ResultSet) error {
@@ -267,7 +267,7 @@ func (gi *groupIterator) Do(f func(flux.Table) error) error {
 	if rs == nil {
 		return nil
 	}
-	return gi.handleRead(f, rs)
+	return gi.handleRead(filterDuplicateTables(f), rs)
 }
 
 func (gi *groupIterator) handleRead(f func(flux.Table) error, rs GroupResultSet) error {
@@ -415,8 +415,8 @@ func determineTableColsForSeries(tags models.Tags, typ flux.ColType) ([]flux.Col
 }
 
 func defaultGroupKeyForSeries(tags models.Tags, bnds execute.Bounds) flux.GroupKey {
-	cols := make([]flux.ColMeta, 2, len(tags))
-	vs := make([]values.Value, 2, len(tags))
+	cols := make([]flux.ColMeta, 2, len(tags)+2)
+	vs := make([]values.Value, 2, len(tags)+2)
 	cols[0] = flux.ColMeta{
 		Label: execute.DefaultStartColLabel,
 		Type:  flux.TTime,
@@ -647,4 +647,28 @@ func (ti *tagValuesIterator) handleRead(f func(flux.Table) error, rs cursors.Str
 
 func (ti *tagValuesIterator) Statistics() cursors.CursorStats {
 	return cursors.CursorStats{}
+}
+
+type duplicateFilter struct {
+	f    func(tbl flux.Table) error
+	seen *execute.GroupLookup
+}
+
+func filterDuplicateTables(f func(tbl flux.Table) error) func(tbl flux.Table) error {
+	filter := &duplicateFilter{
+		f:    f,
+		seen: execute.NewGroupLookup(),
+	}
+	return filter.Process
+}
+
+func (df *duplicateFilter) Process(tbl flux.Table) error {
+	// Identify duplicate keys within the cursor.
+	if _, ok := df.seen.Lookup(tbl.Key()); ok {
+		// Discard this table.
+		tbl.Done()
+		return nil
+	}
+	df.seen.Set(tbl.Key(), true)
+	return df.f(tbl)
 }

--- a/storage/reads/reader_test.go
+++ b/storage/reads/reader_test.go
@@ -1,0 +1,124 @@
+package reads_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/influxdb/mock"
+	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
+	"github.com/influxdata/influxdb/storage/reads"
+	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+)
+
+func TestDuplicateKeys_ReadFilter(t *testing.T) {
+	closed := 0
+
+	s := mock.NewStoreReader()
+	s.ReadFilterFunc = func(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error) {
+		inputs := make([]cursors.Cursor, 2)
+		inputs[0] = func() cursors.Cursor {
+			called := false
+			cur := mock.NewFloatArrayCursor()
+			cur.NextFunc = func() *cursors.FloatArray {
+				if called {
+					return &cursors.FloatArray{}
+				}
+				called = true
+				return &cursors.FloatArray{
+					Timestamps: []int64{0},
+					Values:     []float64{1.0},
+				}
+			}
+			cur.CloseFunc = func() {
+				closed++
+			}
+			return cur
+		}()
+		inputs[1] = func() cursors.Cursor {
+			called := false
+			cur := mock.NewIntegerArrayCursor()
+			cur.NextFunc = func() *cursors.IntegerArray {
+				if called {
+					return &cursors.IntegerArray{}
+				}
+				called = true
+				return &cursors.IntegerArray{
+					Timestamps: []int64{10},
+					Values:     []int64{1},
+				}
+			}
+			cur.CloseFunc = func() {
+				closed++
+			}
+			return cur
+		}()
+
+		idx := -1
+		rs := mock.NewResultSet()
+		rs.NextFunc = func() bool {
+			idx++
+			return idx < len(inputs)
+		}
+		rs.CursorFunc = func() cursors.Cursor {
+			return inputs[idx]
+		}
+		rs.CloseFunc = func() {
+			idx = len(inputs)
+		}
+		return rs, nil
+	}
+
+	r := reads.NewReader(s)
+	ti, err := r.ReadFilter(context.Background(), influxdb.ReadFilterSpec{
+		Bounds: execute.Bounds{
+			Start: execute.Time(0),
+			Stop:  execute.Time(30),
+		},
+	}, &memory.Allocator{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var got []*executetest.Table
+	if err := ti.Do(func(tbl flux.Table) error {
+		t, err := executetest.ConvertTable(tbl)
+		if err != nil {
+			return err
+		}
+		got = append(got, t)
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	want := []*executetest.Table{
+		{
+			ColMeta: []flux.ColMeta{
+				{Label: "_start", Type: flux.TTime},
+				{Label: "_stop", Type: flux.TTime},
+				{Label: "_time", Type: flux.TTime},
+				{Label: "_value", Type: flux.TFloat},
+			},
+			KeyCols: []string{"_start", "_stop"},
+			Data: [][]interface{}{
+				{execute.Time(0), execute.Time(30), execute.Time(0), 1.0},
+			},
+		},
+	}
+	for _, tbl := range want {
+		tbl.Normalize()
+	}
+	if !cmp.Equal(want, got) {
+		t.Fatalf("unexpected output:\n%s", cmp.Diff(want, got))
+	}
+
+	if want, got := closed, 2; want != got {
+		t.Fatalf("unexpected count of closed cursors -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}


### PR DESCRIPTION
If the reader produces more than one table with the same group key, we
discard the later ones because the stream should never give us more than
one table with the same group key.

This is an error and it indicates the server sent us a bad set of data.
This change makes it so that the client is tolerant of that data and
will discard it if it exists.

#4177