### PR TITLE
feat(ui): add alert history page

### DIFF
--- a/ui/src/alerting/components/CheckNameTableField.tsx
+++ b/ui/src/alerting/components/CheckNameTableField.tsx
@@ -1,0 +1,13 @@
+// Libraries
+import React, {FC} from 'react'
+import {Link} from 'react-router'
+
+interface Props {
+  row: {checkName: string; checkID: string}
+}
+
+const CheckNameTableField: FC<Props> = ({row: {checkName, checkID}}) => {
+  return <Link to={`../alerting/checks/${checkID}/edit`}>{checkName}</Link>
+}
+
+export default CheckNameTableField

--- a/ui/src/alerting/components/StatusSearchBar.tsx
+++ b/ui/src/alerting/components/StatusSearchBar.tsx
@@ -1,0 +1,76 @@
+// Libraries
+import React, {useState, FC} from 'react'
+import {Input} from '@influxdata/clockface'
+import {isEqual} from 'lodash'
+
+// Actions
+import {
+  search,
+  clearSearch,
+} from 'src/eventViewer/components/EventViewer.reducer'
+
+// Utils
+import {useDebouncedValue} from 'src/shared/utils/useDebouncedValue'
+import {useMountedEffect} from 'src/shared/utils/useMountedEffect'
+
+// Types
+import {EventViewerChildProps, SearchExpr} from 'src/eventViewer/types'
+
+const SEARCH_DELAY_MS = 500
+
+// Given a search term, build a search expression representing:
+//
+//     checkName =~ /term/ or message =~ /term/
+//
+// An empty search term results in a null expression.
+const searchExprForTerm = (term: string): SearchExpr | null => {
+  if (term.trim() === '') {
+    return null
+  }
+
+  return {
+    type: 'BINARY_EXPR',
+    op: 'OR',
+    left: {
+      type: 'BINARY_EXPR',
+      op: 'REG_MATCH',
+      left: 'checkName',
+      right: term,
+    },
+    right: {
+      type: 'BINARY_EXPR',
+      op: 'REG_MATCH',
+      left: 'message',
+      right: term,
+    },
+  }
+}
+
+type Props = EventViewerChildProps & {
+  placeholder?: string
+}
+
+const StatusSearchBar: FC<Props> = ({state, dispatch, loadRows}) => {
+  const [searchTerm, setSearchTerm] = useState<string>('')
+  const debouncedSearchTerm = useDebouncedValue(searchTerm, SEARCH_DELAY_MS)
+  const searchExpr = searchExprForTerm(debouncedSearchTerm)
+
+  useMountedEffect(() => {
+    if (searchExpr && !isEqual(searchExpr, state.searchExpr)) {
+      search(state, dispatch, loadRows, searchExpr)
+    } else if (!isEqual(searchExpr, state.searchExpr)) {
+      clearSearch(state, dispatch, loadRows)
+    }
+  }, [state, dispatch, loadRows, searchExpr])
+
+  return (
+    <Input
+      className="status-search-bar"
+      placeholder="Status message or check name..."
+      value={searchTerm}
+      onChange={e => setSearchTerm(e.target.value)}
+    />
+  )
+}
+
+export default StatusSearchBar

--- a/ui/src/alerting/components/StatusTableField.scss
+++ b/ui/src/alerting/components/StatusTableField.scss
@@ -1,0 +1,24 @@
+.status-table-field {
+  font-weight: 600;
+}
+
+.status-table-field--crit {
+  color: $c-fire;
+}
+
+.status-table-field--warn {
+  color: $c-tiger;
+}
+
+.status-table-field--ok {
+  color: $c-rainforest;
+}
+
+.status-table-field--info {
+  color: $c-pool;
+}
+
+.status-table-field--unknown {
+  color: $c-amethyst;
+}
+

--- a/ui/src/alerting/components/StatusTableField.tsx
+++ b/ui/src/alerting/components/StatusTableField.tsx
@@ -1,0 +1,18 @@
+// Libraries
+import React, {FC} from 'react'
+
+interface Props {
+  row: {status: string}
+}
+
+const StatusTableField: FC<Props> = ({row: {status}}) => {
+  return (
+    <div
+      className={`status-table-field status-table-field--${status.toLowerCase()}`}
+    >
+      {status}
+    </div>
+  )
+}
+
+export default StatusTableField

--- a/ui/src/alerting/components/TagsTableField.scss
+++ b/ui/src/alerting/components/TagsTableField.scss
@@ -1,0 +1,26 @@
+.tags-table-field {
+  display: flex
+}
+
+.tags-table-field--tag {
+  color: $g12-forge;
+  margin-right: $ix-marg-b;
+
+  &:after {
+    content: ", "
+  }
+
+  &:last-child:after {
+    content: ""
+  }
+}
+
+.tags-table-field--key {
+  color: red;
+  color: $g12-forge;
+}
+
+.tags-table-field--value {
+  color: pink;
+  color: $g16-pearl;
+}

--- a/ui/src/alerting/components/TagsTableField.tsx
+++ b/ui/src/alerting/components/TagsTableField.tsx
@@ -1,0 +1,21 @@
+// Libraries
+import React, {FC} from 'react'
+
+interface Props {
+  row: {tags: {[tagKey: string]: string}}
+}
+
+const TagsTableField: FC<Props> = ({row: {tags}}) => {
+  return (
+    <div className="tags-table-field">
+      {Object.keys(tags).map(key => (
+        <div key={key} className="tags-table-field--tag">
+          <span className="tags-table-field--key">{key}</span>=
+          <span className="tags-table-field--value">{tags[key]}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default TagsTableField

--- a/ui/src/alerting/components/TimeTableField.tsx
+++ b/ui/src/alerting/components/TimeTableField.tsx
@@ -1,0 +1,20 @@
+// Libraries
+import React, {FC} from 'react'
+import moment from 'moment'
+
+// Constants
+import {DEFAULT_TIME_FORMAT} from 'src/shared/constants'
+
+interface Props {
+  row: {time: string | number}
+}
+
+const TimeTableField: FC<Props> = ({row: {time}}) => {
+  return (
+    <div className="time-table-field">
+      {moment.utc(time).format(DEFAULT_TIME_FORMAT)}
+    </div>
+  )
+}
+
+export default TimeTableField

--- a/ui/src/alerting/containers/AlertHistoryIndex.scss
+++ b/ui/src/alerting/containers/AlertHistoryIndex.scss
@@ -1,0 +1,37 @@
+// TODO: Fix this in clockface
+.alert-history-page .cf-page-contents.full-height .cf-page-contents--padding {
+  width: 100%;
+  height: 100%;
+  padding: 0 54px 54px 54px;
+}
+
+.alert-history-page--header,
+.alert-history-page--controls {
+  display: flex;
+  align-items: center;
+}
+
+.alert-history-page--header {
+  width: 100%;
+  justify-content: space-between;
+}
+
+.alert-history-page--controls {
+  flex-grow: 1;
+  justify-content: flex-end;
+
+  > * {
+    margin-left: $ix-marg-a;
+  }
+}
+
+.alert-history-page .status-search-bar {
+  flex-basis: 300px;
+}
+
+.alert-history {
+  width: 100%;
+  height: 100%;
+  padding-top: $ix-marg-c;
+  overflow: hidden;
+}

--- a/ui/src/alerting/containers/AlertHistoryIndex.tsx
+++ b/ui/src/alerting/containers/AlertHistoryIndex.tsx
@@ -1,7 +1,76 @@
-import React, {FunctionComponent} from 'react'
+// Libraries
+import React, {FC} from 'react'
+import {Page} from '@influxdata/clockface'
 
-const AlertHistoryIndex: FunctionComponent = () => {
-  return <div />
+// Components
+import EventViewer from 'src/eventViewer/components/EventViewer'
+import EventTable from 'src/eventViewer/components/EventTable'
+import BackToTopButton from 'src/eventViewer/components/BackToTopButton'
+import LimitDropdown from 'src/eventViewer/components/LimitDropdown'
+import StatusSearchBar from 'src/alerting/components/StatusSearchBar'
+import StatusTableField from 'src/alerting/components/StatusTableField'
+import TagsTableField from 'src/alerting/components/TagsTableField'
+import TimeTableField from 'src/alerting/components/TimeTableField'
+import CheckNameTableField from 'src/alerting/components/CheckNameTableField'
+
+// Utils
+import {fakeLoadRows} from 'src/eventViewer/utils/fakeLoadRows'
+
+// Types
+import {FieldComponents} from 'src/eventViewer/types'
+
+const FIELD_COMPONENTS: FieldComponents = {
+  time: TimeTableField,
+  status: StatusTableField,
+  tags: TagsTableField,
+  checkName: CheckNameTableField,
+}
+
+const FIELD_WIDTHS = {
+  time: 160,
+  checkName: 100,
+  message: 300,
+  status: 50,
+  tags: 300,
+}
+
+const AlertHistoryIndex: FC = () => {
+  return (
+    <EventViewer loadRows={fakeLoadRows}>
+      {props => (
+        <Page
+          titleTag="Alert History | InfluxDB 2.0"
+          className="alert-history-page"
+        >
+          <Page.Header fullWidth={true}>
+            <div className="alert-history-page--header">
+              <Page.Title title="Alert History" />
+              <div className="alert-history-page--controls">
+                <BackToTopButton {...props} />
+                <LimitDropdown {...props} />
+                <StatusSearchBar {...props} />
+              </div>
+            </div>
+          </Page.Header>
+          <Page.Contents
+            fullWidth={true}
+            fullHeight={true}
+            scrollable={false}
+            className="alert-history-page--contents"
+          >
+            <div className="alert-history">
+              <EventTable
+                {...props}
+                fields={['time', 'checkName', 'status', 'message', 'tags']}
+                fieldWidths={FIELD_WIDTHS}
+                fieldComponents={FIELD_COMPONENTS}
+              />
+            </div>
+          </Page.Contents>
+        </Page>
+      )}
+    </EventViewer>
+  )
 }
 
 export default AlertHistoryIndex

--- a/ui/src/eventViewer/components/BackToTopButton.tsx
+++ b/ui/src/eventViewer/components/BackToTopButton.tsx
@@ -1,0 +1,37 @@
+// Libraries
+import React, {FC} from 'react'
+import {Button, IconFont} from '@influxdata/clockface'
+
+// Utils
+import {refresh} from 'src/eventViewer/components/EventViewer.reducer'
+
+// Types
+import {EventViewerChildProps} from 'src/eventViewer/types'
+
+const BackToTopButton: FC<EventViewerChildProps> = ({
+  state,
+  dispatch,
+  loadRows,
+}) => {
+  if (state.scrollTop === 0) {
+    return (
+      <Button
+        className="back-to-top-button"
+        icon={IconFont.Refresh}
+        text="Refresh"
+        onClick={() => refresh(state, dispatch, loadRows)}
+      />
+    )
+  }
+
+  return (
+    <Button
+      className="back-to-top-button"
+      icon={IconFont.CaretUp}
+      text="Back to Top"
+      onClick={() => dispatch({type: 'CLICKED_BACK_TO_TOP'})}
+    />
+  )
+}
+
+export default BackToTopButton

--- a/ui/src/eventViewer/components/ErrorRow.tsx
+++ b/ui/src/eventViewer/components/ErrorRow.tsx
@@ -1,0 +1,18 @@
+import React, {CSSProperties, FC} from 'react'
+
+interface Props {
+  style: CSSProperties
+  index: number
+}
+
+const ErrorRow: FC<Props> = ({style, index}) => {
+  return (
+    <div style={style}>
+      <div className="event-error-row">
+        {index === 0 ? 'Failed to load :(' : 'Failed to load next rows :('}
+      </div>
+    </div>
+  )
+}
+
+export default ErrorRow

--- a/ui/src/eventViewer/components/EventTable.scss
+++ b/ui/src/eventViewer/components/EventTable.scss
@@ -1,0 +1,97 @@
+$event-table--field-margin: $ix-marg-b;
+
+.event-table {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
+
+  .event-table--table {
+    flex: 1 1 100%;
+  }
+
+  .event-table-header {
+    flex: 0 0 auto;
+  }
+}
+
+
+.event-table-header, .event-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  > * {
+    flex-grow: 1;
+    flex-shrink: 0;
+  }
+}
+
+.event-table-header {
+  padding: 0 $event-table--field-margin;
+  margin-bottom: $ix-marg-c;
+}
+
+.event-table-header--field {
+  user-select: none;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: $g11-sidewalk;
+  margin: 0 $event-table--field-margin;
+}
+
+.event-row, .event-loading-row, .event-footer-row, .event-error-row {
+  height: calc(100% - 4px);
+  width: 100%;
+  border-radius: $radius;
+  display: flex;
+  align-items: center;
+  font-size: $ix-text-base;
+  padding: 0 $event-table--field-margin;
+}
+
+.event-row, .event-loading-row {
+  background: $g3-castle;
+}
+
+.event-footer-row, .event-error-row {
+  justify-content: center;
+  font-weight: 600;
+  user-select: none;
+}
+
+.event-footer-row {
+  color: $g11-sidewalk;
+}
+
+.event-error-row {
+  color: $c-curacao;
+}
+
+.event-row--field, .event-loading-row--placeholder {
+  margin: 0 $event-table--field-margin;
+}
+
+.event-row--field {
+  overflow: hidden;
+}
+
+@keyframes glow {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0.8;
+  }
+}
+
+.event-loading-row--placeholder {
+  background-color: $g6-smoke;
+  border-radius: $radius-small;
+  animation-name: glow;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+}

--- a/ui/src/eventViewer/components/EventTable.tsx
+++ b/ui/src/eventViewer/components/EventTable.tsx
@@ -1,0 +1,117 @@
+// Libraries
+import React, {useEffect, FC} from 'react'
+import {AutoSizer, InfiniteLoader, List} from 'react-virtualized'
+
+// Components
+import Header from 'src/eventViewer/components/Header'
+import TableRow from 'src/eventViewer/components/TableRow'
+import LoadingRow from 'src/eventViewer/components/LoadingRow'
+import FooterRow from 'src/eventViewer/components/FooterRow'
+import ErrorRow from 'src/eventViewer/components/ErrorRow'
+
+// Utils
+import {
+  loadNextRows,
+  getRowCount,
+} from 'src/eventViewer/components/EventViewer.reducer'
+
+// Types
+import {EventViewerChildProps, FieldComponents} from 'src/eventViewer/types'
+import {RemoteDataState} from 'src/types'
+
+type Props = EventViewerChildProps & {
+  fields: string[]
+  fieldWidths: {[field: string]: number}
+  fieldComponents: FieldComponents
+}
+
+const EventTable: FC<Props> = ({
+  state,
+  dispatch,
+  loadRows,
+  fields,
+  fieldWidths,
+  fieldComponents,
+}) => {
+  const rowCount = getRowCount(state)
+
+  const isRowLoaded = ({index}) => !!state.rows[index]
+
+  const loadMoreRows = () => loadNextRows(state, dispatch, loadRows)
+
+  const rowRenderer = ({key, index, style}) => {
+    const isLastRow = index === state.rows.length
+
+    if (isLastRow && state.nextRowsStatus === RemoteDataState.Error) {
+      return <ErrorRow key={key} index={index} style={style} />
+    }
+
+    if (isLastRow && state.hasReachedEnd) {
+      return <FooterRow key={key} style={style} />
+    }
+
+    if (!state.rows[index]) {
+      return <LoadingRow key={key} index={index} style={style} />
+    }
+
+    return (
+      <TableRow
+        key={key}
+        style={style}
+        row={state.rows[index]}
+        fields={fields}
+        fieldWidths={fieldWidths}
+        fieldComponents={fieldComponents}
+      />
+    )
+  }
+
+  const scrollIndex =
+    state.nextScrollIndex === null ? undefined : state.nextScrollIndex
+
+  useEffect(() => {
+    dispatch({type: 'CONSUMED_NEXT_SCROLL_INDEX'})
+  }, [state.nextScrollIndex, dispatch])
+
+  return (
+    <div className="event-table">
+      <Header fields={fields} fieldWidths={fieldWidths} />
+      <div className="event-table--table">
+        <AutoSizer>
+          {({width, height}) => {
+            if (!width || !height) {
+              return null
+            }
+
+            return (
+              <InfiniteLoader
+                isRowLoaded={isRowLoaded}
+                loadMoreRows={loadMoreRows}
+                rowCount={rowCount}
+              >
+                {({onRowsRendered, registerChild}) => (
+                  <List
+                    width={width}
+                    height={height}
+                    ref={registerChild}
+                    onRowsRendered={onRowsRendered}
+                    rowCount={rowCount}
+                    rowHeight={38}
+                    rowRenderer={rowRenderer}
+                    overscanRowCount={20}
+                    scrollToIndex={scrollIndex}
+                    onScroll={({scrollTop}) =>
+                      dispatch({type: 'SCROLLED', scrollTop})
+                    }
+                  />
+                )}
+              </InfiniteLoader>
+            )
+          }}
+        </AutoSizer>
+      </div>
+    </div>
+  )
+}
+
+export default EventTable

--- a/ui/src/eventViewer/components/EventViewer.reducer.ts
+++ b/ui/src/eventViewer/components/EventViewer.reducer.ts
@@ -1,0 +1,336 @@
+// Types
+import {Dispatch as ReactDispatch} from 'react'
+import {RemoteDataState} from 'src/types'
+import {Row, LoadRows, SearchExpr} from 'src/eventViewer/types'
+
+export interface State {
+  // All rows currently in the table
+  rows: Row[]
+
+  // The offset to use next time we load data
+  offset: number
+
+  // The number of rows to load next time we load data
+  limit: number
+
+  // The definition of "now" when running queries that are relative to "now"
+  now: number | null
+
+  // A expression used to filter results when we load rows
+  searchExpr: SearchExpr | null
+
+  // Tracks the loading status of the next rows being loading
+  nextRowsStatus: RemoteDataState
+
+  // If the next rows failed to load, this field should contain a
+  // human-friendly error message indicating why the rows failed to load
+  nextRowsErrorMessage: string | null
+
+  // A function that can be used to cancel any rows currently being loaded
+  nextRowsCanceller: null | (() => void)
+
+  // If a user has loaded all the rows that exist
+  hasReachedEnd: boolean
+
+  // When set, the table will render with this index in view
+  nextScrollIndex: number | null
+
+  // How many pixels into the table we have currently scrolled
+  scrollTop: number
+}
+
+export type Action =
+  | {type: 'NEXT_ROWS_LOADED'; rows: Row[]}
+  | {type: 'NEXT_ROWS_FAILED_TO_LOAD'; errorMessage: string}
+  | {type: 'NEXT_ROWS_LOADING'; cancel: () => void; now?: number}
+  | {type: 'SEARCH_ENTERED'; cancel: () => void; expr: SearchExpr; now: number}
+  | {type: 'SEARCH_COMPLETED'; rows: Row[]; limit: number}
+  | {type: 'SEARCH_CLEARED'; now: number; cancel: () => void}
+  | {type: 'SEARCH_FAILED'; errorMessage: string}
+  | {type: 'SCROLLED'; scrollTop: number}
+  | {type: 'CONSUMED_NEXT_SCROLL_INDEX'}
+  | {type: 'CLICKED_BACK_TO_TOP'}
+  | {type: 'LIMIT_CHANGED'; limit: number}
+  | {type: 'REFRESHED'; cancel: () => void; now: number}
+
+export type Dispatch = ReactDispatch<Action>
+
+export const INITIAL_STATE: State = {
+  rows: [],
+  offset: 0,
+  limit: 100,
+  now: null,
+  nextRowsStatus: RemoteDataState.NotStarted,
+  nextRowsErrorMessage: null,
+  nextRowsCanceller: null,
+  hasReachedEnd: false,
+  searchExpr: null,
+  scrollTop: 0,
+  nextScrollIndex: null,
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'NEXT_ROWS_LOADING': {
+      return {
+        ...state,
+        nextRowsStatus: RemoteDataState.Loading,
+        nextRowsCanceller: action.cancel,
+        now: action.now ? action.now : state.now,
+      }
+    }
+
+    case 'NEXT_ROWS_FAILED_TO_LOAD': {
+      return {
+        ...state,
+        nextRowsStatus: RemoteDataState.Error,
+        nextRowsErrorMessage: action.errorMessage,
+      }
+    }
+
+    case 'NEXT_ROWS_LOADED': {
+      const rows = [...state.rows, ...action.rows]
+
+      return {
+        ...state,
+        rows,
+        nextRowsStatus: RemoteDataState.Done,
+        offset: rows.length,
+        hasReachedEnd: action.rows.length === 0,
+      }
+    }
+
+    case 'SEARCH_ENTERED': {
+      return {
+        ...state,
+        rows: [],
+        offset: 0,
+        now: action.now,
+        searchExpr: action.expr,
+        nextRowsCanceller: action.cancel,
+        nextRowsStatus: RemoteDataState.Loading,
+        hasReachedEnd: false,
+      }
+    }
+
+    case 'SEARCH_COMPLETED': {
+      return {
+        ...state,
+        rows: action.rows,
+        nextRowsStatus: RemoteDataState.Done,
+        offset: action.rows.length,
+        hasReachedEnd: action.rows.length < action.limit,
+      }
+    }
+
+    case 'SEARCH_FAILED': {
+      return {
+        ...state,
+        nextRowsStatus: RemoteDataState.Error,
+        nextRowsErrorMessage: action.errorMessage,
+      }
+    }
+
+    case 'SEARCH_CLEARED': {
+      return {
+        ...state,
+        rows: [],
+        offset: 0,
+        now: action.now,
+        nextRowsStatus: RemoteDataState.Loading,
+        hasReachedEnd: false,
+        nextRowsCanceller: action.cancel,
+        searchExpr: null,
+      }
+    }
+
+    case 'SCROLLED': {
+      return {...state, scrollTop: action.scrollTop}
+    }
+
+    case 'CLICKED_BACK_TO_TOP': {
+      return {...state, nextScrollIndex: 0}
+    }
+
+    case 'CONSUMED_NEXT_SCROLL_INDEX': {
+      return {...state, nextScrollIndex: null}
+    }
+
+    case 'LIMIT_CHANGED': {
+      return {...state, limit: action.limit}
+    }
+
+    case 'REFRESHED': {
+      return {
+        ...state,
+        rows: [],
+        offset: 0,
+        now: action.now,
+        nextRowsStatus: RemoteDataState.Loading,
+        hasReachedEnd: false,
+        nextRowsCanceller: action.cancel,
+      }
+    }
+
+    default: {
+      const neverAction: never = action
+
+      throw new Error(`unhandled action "${(neverAction as any).type}"`)
+    }
+  }
+}
+
+export const loadNextRows = async (
+  state: State,
+  dispatch: Dispatch,
+  loadRows: LoadRows,
+  now?: number
+): Promise<void> => {
+  if (
+    state.nextRowsStatus === RemoteDataState.Loading ||
+    state.nextRowsStatus === RemoteDataState.Error ||
+    state.hasReachedEnd
+  ) {
+    return
+  }
+
+  try {
+    const {promise, cancel} = loadRows({
+      offset: state.offset,
+      limit: state.limit,
+      since: now || state.now,
+      filter: state.searchExpr,
+    })
+
+    dispatch({type: 'NEXT_ROWS_LOADING', cancel, now})
+
+    const rows = await promise
+
+    dispatch({type: 'NEXT_ROWS_LOADED', rows})
+  } catch (error) {
+    if (error.name === 'CancellationError') {
+      return
+    }
+
+    dispatch({type: 'NEXT_ROWS_FAILED_TO_LOAD', errorMessage: error.message})
+  }
+}
+
+export const search = async (
+  state: State,
+  dispatch: Dispatch,
+  loadRows: LoadRows,
+  searchExpr: SearchExpr
+): Promise<void> => {
+  try {
+    if (state.nextRowsCanceller) {
+      // Cancel existing pending search, if there is one
+      state.nextRowsCanceller()
+    }
+
+    const now = Date.now()
+    const limit = state.limit
+
+    const {promise, cancel} = loadRows({
+      offset: 0,
+      limit,
+      since: now,
+      filter: searchExpr,
+    })
+
+    dispatch({type: 'SEARCH_ENTERED', cancel, now, expr: searchExpr})
+
+    const rows = await promise
+
+    dispatch({type: 'SEARCH_COMPLETED', rows, limit})
+  } catch (error) {
+    if (error.name === 'CancellationError') {
+      return
+    }
+
+    dispatch({type: 'SEARCH_FAILED', errorMessage: error.message})
+  }
+}
+
+export const clearSearch = async (
+  state: State,
+  dispatch: Dispatch,
+  loadRows: LoadRows
+): Promise<void> => {
+  try {
+    if (state.nextRowsCanceller) {
+      // Cancel existing pending search, if there is one
+      state.nextRowsCanceller()
+    }
+
+    const now = Date.now()
+
+    const {promise, cancel} = loadRows({
+      offset: 0,
+      limit: state.limit,
+      since: now,
+    })
+
+    dispatch({type: 'SEARCH_CLEARED', now, cancel})
+
+    const rows = await promise
+
+    dispatch({type: 'NEXT_ROWS_LOADED', rows})
+  } catch (error) {
+    if (error.name === 'CancellationError') {
+      return
+    }
+
+    dispatch({type: 'NEXT_ROWS_FAILED_TO_LOAD', errorMessage: error.message})
+  }
+}
+
+export const refresh = async (
+  state: State,
+  dispatch: Dispatch,
+  loadRows: LoadRows
+): Promise<void> => {
+  try {
+    if (state.nextRowsCanceller) {
+      // Cancel existing pending fetch, if one exists
+      state.nextRowsCanceller()
+    }
+
+    const now = Date.now()
+
+    const {promise, cancel} = loadRows({
+      offset: 0,
+      limit: state.limit,
+      since: now,
+      filter: state.searchExpr,
+    })
+
+    dispatch({type: 'REFRESHED', cancel, now})
+
+    const rows = await promise
+
+    dispatch({type: 'NEXT_ROWS_LOADED', rows})
+  } catch (error) {
+    if (error.name === 'CancellationError') {
+      return
+    }
+
+    dispatch({type: 'NEXT_ROWS_FAILED_TO_LOAD', errorMessage: error.message})
+  }
+}
+
+/*
+  Given the current state, how many rows should be rendered in the table?
+*/
+export const getRowCount = (state: State): number => {
+  const isInitialLoad =
+    state.rows.length === 0 &&
+    state.offset === 0 &&
+    state.nextRowsStatus === RemoteDataState.Loading
+
+  if (isInitialLoad && state.nextRowsStatus !== RemoteDataState.Error) {
+    return state.rows.length + 100
+  }
+
+  return state.rows.length + 1
+}

--- a/ui/src/eventViewer/components/EventViewer.tsx
+++ b/ui/src/eventViewer/components/EventViewer.tsx
@@ -1,0 +1,29 @@
+// Libraries
+import {useEffect, useReducer, FC, ReactElement} from 'react'
+
+// Utils
+import {
+  reducer,
+  INITIAL_STATE,
+  loadNextRows,
+} from 'src/eventViewer/components/EventViewer.reducer'
+
+// Types
+import {LoadRows, EventViewerChildProps} from 'src/eventViewer/types'
+
+interface Props {
+  loadRows: LoadRows
+  children: (props: EventViewerChildProps) => ReactElement
+}
+
+const EventViewer: FC<Props> = ({loadRows, children}) => {
+  const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
+
+  useEffect(() => {
+    loadNextRows(state, dispatch, loadRows, Date.now())
+  }, [])
+
+  return children({state, dispatch, loadRows})
+}
+
+export default EventViewer

--- a/ui/src/eventViewer/components/FooterRow.tsx
+++ b/ui/src/eventViewer/components/FooterRow.tsx
@@ -1,0 +1,15 @@
+import React, {CSSProperties, FC} from 'react'
+
+interface Props {
+  style: CSSProperties
+}
+
+const FooterRow: FC<Props> = ({style}) => {
+  return (
+    <div style={style}>
+      <div className="event-footer-row">No more data found.</div>
+    </div>
+  )
+}
+
+export default FooterRow

--- a/ui/src/eventViewer/components/Header.tsx
+++ b/ui/src/eventViewer/components/Header.tsx
@@ -1,0 +1,39 @@
+import React, {FC} from 'react'
+
+// Adds spaces to camelcased names, e.g. "checkName" to "check Name"
+const stylizeName = (name: string): string => {
+  let result = ''
+
+  for (const c of name) {
+    if (c === c.toUpperCase()) {
+      result = result + ' ' + c
+    } else {
+      result = result + c
+    }
+  }
+
+  return result.toUpperCase()
+}
+
+interface Props {
+  fields: string[]
+  fieldWidths: {[field: string]: number}
+}
+
+const Header: FC<Props> = ({fields, fieldWidths}) => {
+  return (
+    <div className="event-table-header">
+      {fields.map(field => {
+        const style = {flexBasis: `${fieldWidths[field]}px`}
+
+        return (
+          <div key={field} className="event-table-header--field" style={style}>
+            {stylizeName(field)}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default Header

--- a/ui/src/eventViewer/components/LimitDropdown.tsx
+++ b/ui/src/eventViewer/components/LimitDropdown.tsx
@@ -1,0 +1,35 @@
+// Libraries
+import React, {FC} from 'react'
+import {Dropdown} from '@influxdata/clockface'
+
+// Types
+import {EventViewerChildProps} from 'src/eventViewer/types'
+
+const LIMIT_CHOICES = [50, 100, 500, 1000, 2000]
+
+const LimitDropdown: FC<EventViewerChildProps> = ({state, dispatch}) => {
+  const button = (active, onClick) => (
+    <Dropdown.Button active={active} onClick={onClick}>
+      {state.limit} Results Per Fetch
+    </Dropdown.Button>
+  )
+
+  const menu = onCollapse => (
+    <Dropdown.Menu onCollapse={onCollapse}>
+      {LIMIT_CHOICES.map(limit => (
+        <Dropdown.Item
+          key={limit}
+          id={String(limit)}
+          value={limit}
+          onClick={limit => dispatch({type: 'LIMIT_CHANGED', limit})}
+        >
+          {limit} Results Per Fetch
+        </Dropdown.Item>
+      ))}
+    </Dropdown.Menu>
+  )
+
+  return <Dropdown widthPixels={165} button={button} menu={menu} />
+}
+
+export default LimitDropdown

--- a/ui/src/eventViewer/components/LoadingRow.tsx
+++ b/ui/src/eventViewer/components/LoadingRow.tsx
@@ -1,0 +1,39 @@
+// Libraries
+import React, {FC, CSSProperties} from 'react'
+import {range} from 'lodash'
+
+const PLACEHOLDER_MIN_WIDTH = 80
+const PLACEHOLDER_MAX_WIDTH = 140
+const PLACEHOLDER_HEIGHT = 10
+const RANDOM_NUMBERS = range(30).map(_ => Math.random())
+
+interface Props {
+  index: number
+  style: CSSProperties
+}
+
+const LoadingRow: FC<Props> = ({index, style}) => {
+  const randomNumber = RANDOM_NUMBERS[index % RANDOM_NUMBERS.length]
+
+  const width = Math.floor(
+    PLACEHOLDER_MIN_WIDTH +
+      randomNumber * (PLACEHOLDER_MAX_WIDTH - PLACEHOLDER_MIN_WIDTH)
+  )
+
+  return (
+    <div style={style}>
+      <div className="event-loading-row">
+        <div
+          className="event-loading-row--placeholder"
+          style={{
+            width: `${width}px`,
+            height: `${PLACEHOLDER_HEIGHT}px`,
+            animationDelay: `${(index % 5) / 2}s`,
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default LoadingRow

--- a/ui/src/eventViewer/components/TableRow.tsx
+++ b/ui/src/eventViewer/components/TableRow.tsx
@@ -1,0 +1,42 @@
+import React, {FC, CSSProperties} from 'react'
+
+import {Row, FieldComponents} from 'src/eventViewer/types'
+
+interface Props {
+  row: Row
+  style: CSSProperties
+  fields: string[]
+  fieldWidths: {[field: string]: number}
+  fieldComponents: FieldComponents
+}
+
+const TableRow: FC<Props> = ({
+  row,
+  style,
+  fields,
+  fieldComponents,
+  fieldWidths,
+}) => {
+  return (
+    <div style={style}>
+      <div className="event-row">
+        {fields.map(field => {
+          const Component = fieldComponents[field]
+          const style = {flexBasis: `${fieldWidths[field]}px`}
+
+          return (
+            <div key={field} className="event-row--field" style={style}>
+              {Component ? (
+                <Component key={field} row={row} />
+              ) : (
+                String(row[field])
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default TableRow

--- a/ui/src/eventViewer/types/index.ts
+++ b/ui/src/eventViewer/types/index.ts
@@ -1,0 +1,50 @@
+// Types
+import {ComponentType} from 'react'
+import {CancelBox} from 'src/types'
+import {State, Dispatch} from 'src/eventViewer/components/EventViewer.reducer'
+
+export interface Row {
+  [k: string]: any
+}
+
+export type LoadRows = (options: LoadRowsOptions) => CancelBox<Row[]>
+
+export interface LoadRowsOptions {
+  offset: number
+  limit: number
+  since: number
+  until?: number
+  filter?: SearchExpr
+}
+
+export type SearchExpr = SearchNotExpr | SearchBinaryExpr | string | number
+
+export interface SearchNotExpr {
+  type: 'NOT'
+  value: SearchExpr
+}
+
+export interface SearchBinaryExpr {
+  type: 'BINARY_EXPR'
+  left: SearchExpr
+  right: SearchExpr
+  op: SearchBinaryOp
+}
+
+export type SearchBinaryOp =
+  | 'AND'
+  | 'OR'
+  | 'EQUALS'
+  | 'NOT_EQUALS'
+  | 'REG_MATCH'
+  | 'NOT_REG_MATCH'
+
+export interface EventViewerChildProps {
+  state: State
+  dispatch: Dispatch
+  loadRows: LoadRows
+}
+
+export interface FieldComponents {
+  [fieldName: string]: ComponentType<{row: Row}>
+}

--- a/ui/src/eventViewer/utils/fakeLoadRows.ts
+++ b/ui/src/eventViewer/utils/fakeLoadRows.ts
@@ -1,0 +1,60 @@
+// This file provides a fake API and should be deleted soon
+
+import {range} from 'lodash'
+import {Row, LoadRows} from 'src/eventViewer/types'
+import {CheckStatusLevel, CancellationError} from 'src/types'
+
+const ROW_COUNT = 222
+
+const notFizzBuzz = (i: number): CheckStatusLevel => {
+  if (i % 3 === 0 && i % 5 === 0) {
+    return 'CRIT'
+  } else if (i % 5 === 0 || i % 3 === 0) {
+    return 'WARN'
+  } else {
+    return 'OK'
+  }
+}
+
+const rowsRequest = (rows, delay) => {
+  let reject
+
+  const promise = new Promise<Row[]>((res, rej) => {
+    reject = rej
+
+    setTimeout(() => res(rows), delay)
+  })
+
+  const cancel = () => reject(new CancellationError())
+
+  return {promise, cancel}
+}
+
+export const fakeLoadRows: LoadRows = ({offset, limit, since, filter}) => {
+  if (offset >= ROW_COUNT) {
+    return rowsRequest([], 500)
+  }
+
+  const allRows = range(ROW_COUNT).map(i => ({
+    time: since - 1000 * 30 * i,
+    checkID: '123',
+    checkName: i % 5 === 0 ? 'high mem' : 'low CPU',
+    status: notFizzBuzz(i),
+    message: `hello from row ${i}`,
+    tags: {host: 'pt2ph8', environment: 'dev'},
+  }))
+
+  let currentRows = allRows
+
+  if (filter) {
+    currentRows = currentRows.filter(
+      row =>
+        row.message.includes((filter as any).right.right) ||
+        row.checkName.includes((filter as any).left.right)
+    )
+  }
+
+  currentRows = currentRows.slice(offset, Math.min(ROW_COUNT, offset + limit))
+
+  return rowsRequest(currentRows, 1000)
+}

--- a/ui/src/shared/utils/useDebouncedValue.ts
+++ b/ui/src/shared/utils/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+import {useState} from 'react'
+import {useMountedEffect} from 'src/shared/utils/useMountedEffect'
+
+export const useDebouncedValue = <T extends any>(
+  value: T,
+  delay: number
+): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useMountedEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay)
+
+    return () => clearTimeout(handler)
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/ui/src/shared/utils/useMountedEffect.ts
+++ b/ui/src/shared/utils/useMountedEffect.ts
@@ -1,0 +1,22 @@
+import {useEffect, useRef, EffectCallback, DependencyList} from 'react'
+
+/*
+  Behaves like `useEffect`, but won't fire after the initial render of a
+  component.
+*/
+export const useMountedEffect = (
+  effect: EffectCallback,
+  inputs?: DependencyList
+) => {
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+
+      return
+    }
+
+    return effect()
+  }, inputs)
+}

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -116,6 +116,10 @@
 @import 'src/shared/components/dashed_button/DashedButton.scss';
 @import 'src/alerting/components/AlertingIndex.scss';
 @import 'src/alerting/components/builder/AlertBuilder.scss';
+@import 'src/eventViewer/components/EventTable.scss';
+@import 'src/alerting/containers/AlertHistoryIndex.scss';
+@import 'src/alerting/components/StatusTableField.scss';
+@import 'src/alerting/components/TagsTableField.scss';
 
 // External
 @import '../../node_modules/@influxdata/react-custom-scrollbars/dist/styles.css';


### PR DESCRIPTION
Closes #14393

Adds a page for viewing check statuses. 

The page visualizes events from the status bucket in an infinite table:

![1 infinite loading](https://user-images.githubusercontent.com/638955/62741780-fda13180-b9f0-11e9-82ea-2207c643aea9.gif)

When first displayed, the table records the current "now", and displays rows ordered from most recent to least recent.

The table can be refreshed to load any new statuses that have been written since you first viewed the page:

![2 back to top](https://user-images.githubusercontent.com/638955/62741881-5b357e00-b9f1-11e9-9497-b0fbdd353919.gif)

The table can also be searched:

![4 searching](https://user-images.githubusercontent.com/638955/62742015-cbdc9a80-b9f1-11e9-91de-d3d9a2752153.gif)

## Event Viewer

As you'll see in the code, I'm hoping this can provide the foundation for a more general event viewer that can be used in place of the table visualization.

To that end, there's a control for how many rows are loaded at once:

<img width="295" alt="3 can control how many results loaded at once" src="https://user-images.githubusercontent.com/638955/62741989-b1a2bc80-b9f1-11e9-95b0-ae78c29be94e.png">

This lets someone exploring their event data tailor their UI experience to their data. Data sets with less indexing are slower to search, so it may be desirable to use a lower row limit to make the table load faster. How indexed a data set is varies from user to user.

There are also a number of locations in the code where I have attempted to anticipate a broader use case:

- The fields displayed in the table are pluggable with custom components. For example, if we wanted to view syslog events, we could write components for displaying [syslog facility codes](https://en.wikipedia.org/wiki/Syslog#Syslog_message_components) and use the same table code

- The query that fetches results is also generic (must conform to the `LoadRows` interface)

- The table component can be used independently of the controls used on the alert history page. This lets us write custom controls for different event-viewing use cases, or put an event viewer in a dashboard cell with no controls

- An event viewer component owns it's own state entirely, so that multiple can be rendered at once easily (i.e. no redux or context)


## To Do

- [ ] Hook this up to an actual Flux query that retrieves statuses from the system bucket

Also probably want:

- [ ] Scrollbars 😱 
- [ ] Add more advanced ability to navigate time (I think this needs careful design)

Maybe some day in the future:

- [ ] Add ability to resize columns
- [ ] Add ability to sort table by columns (lot of open UX questions of what this actually means)

