### PR TITLE
feat(tasks): sort runs by most recently scheduled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [14495](https://github.com/influxdata/influxdb/pull/14495): optional gzip compression of the query CSV response.
 1. [14567](https://github.com/influxdata/influxdb/pull/14567): Add task types.
+1. [14604](https://github.com/influxdata/influxdb/pull/14604): When getting task runs from the API, runs will be returned in order of most recently scheduled first.
 
 ### UI Improvements
 

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -181,6 +181,7 @@ func (as *AnalyticalStorage) FindRuns(ctx context.Context, filter influxdb.RunFi
 	  |> group(columns: ["taskID"])
 	  |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
 	  |> limit(n:%d)
+	  |> sort(columns:["scheduledFor"], desc: true)
 
 	  `, filter.Task.String(), filterPart, filter.Limit-len(runs))
 

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -1155,8 +1155,9 @@ func testRunStorage(t *testing.T, sys *System) {
 		t.Fatalf("retrieved wrong run ID; want %s, got %s", rc0.Created.RunID, runs[0].ID)
 	}
 
-	// Unspecified limit returns all three runs.
+	// Unspecified limit returns all three runs, sorted by most recently scheduled first.
 	runs, _, err = sys.TaskService.FindRuns(sys.Ctx, influxdb.RunFilter{Task: task.ID})
+
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1176,17 +1177,17 @@ func testRunStorage(t *testing.T, sys *System) {
 		t.Fatalf("expected empty FinishedAt, got %q", runs[0].FinishedAt)
 	}
 
-	if runs[1].ID != rc1.Created.RunID {
-		t.Fatalf("retrieved wrong run ID; want %s, got %s", rc1.Created.RunID, runs[1].ID)
+	if runs[2].ID != rc1.Created.RunID {
+		t.Fatalf("retrieved wrong run ID; want %s, got %s", rc2.Created.RunID, runs[1].ID)
 	}
-	if runs[1].StartedAt != startedAt.Add(time.Second).Format(time.RFC3339Nano) {
-		t.Fatalf("unexpected StartedAt; want %s, got %s", runs[0].StartedAt, startedAt.Add(time.Second))
+	if runs[2].StartedAt != startedAt.Add(time.Second).Format(time.RFC3339Nano) {
+		t.Fatalf("unexpected StartedAt; want %s, got %s", runs[1].StartedAt, startedAt.Add(time.Second))
 	}
-	if runs[1].Status != backend.RunSuccess.String() {
-		t.Fatalf("unexpected run status; want %s, got %s", backend.RunSuccess.String(), runs[0].Status)
+	if runs[2].Status != backend.RunSuccess.String() {
+		t.Fatalf("unexpected run status; want %s, got %s", backend.RunSuccess.String(), runs[2].Status)
 	}
-	if exp := startedAt.Add(time.Second * 2).Format(time.RFC3339Nano); runs[1].FinishedAt != exp {
-		t.Fatalf("unexpected FinishedAt; want %s, got %s", exp, runs[1].FinishedAt)
+	if exp := startedAt.Add(time.Second * 2).Format(time.RFC3339Nano); runs[2].FinishedAt != exp {
+		t.Fatalf("unexpected FinishedAt; want %s, got %s", exp, runs[2].FinishedAt)
 	}
 
 	// Look for a run that doesn't exist.


### PR DESCRIPTION
Closes #14439

This PR sorts runs in the `handleGetRuns` function in `task_service.go` by most recent `scheduledFor` time.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
- [x] Tests pass