### PR TITLE
chore(ui): disable eslint via fork-ts-checker-webpack-plugin

### DIFF
--- a/ui/webpack.dev.ts
+++ b/ui/webpack.dev.ts
@@ -43,8 +43,6 @@ module.exports = merge(common, {
       context: path.join(__dirname, 'build'),
       manifest: require('./build/vendor-manifest.json'),
     }),
-    new ForkTsCheckerWebpackPlugin({
-      eslint: true,
-    }),
+    new ForkTsCheckerWebpackPlugin(),
   ],
 })

--- a/ui/webpack.prod.ts
+++ b/ui/webpack.prod.ts
@@ -48,8 +48,6 @@ module.exports = merge(common, {
       filename: '[name].[hash].css',
       chunkFilename: '[id].[hash].css',
     }),
-    new ForkTsCheckerWebpackPlugin({
-      eslint: false,
-    }),
+    new ForkTsCheckerWebpackPlugin(),
   ],
 })


### PR DESCRIPTION
Disables running ESLint through the fork-ts-checker-webpack-plugin in development, due to its tendency to overuse CPU.

I think this OK since linter errors, unlike typechecking errors, are usually confined to the file you are working within. So they're a good fit to run via an editor, rather than the build tool.