### PR TITLE
feat(ui): stub out check visualization options

### DIFF
--- a/ui/src/shared/components/CheckPlot.tsx
+++ b/ui/src/shared/components/CheckPlot.tsx
@@ -54,6 +54,7 @@ const CheckPlot: FunctionComponent<Props> = ({
   loading,
   children,
   timeZone,
+  viewProperties: {colors},
 }) => {
   let thresholds = []
   if (check && check.type === 'threshold') {
@@ -119,6 +120,7 @@ const CheckPlot: FunctionComponent<Props> = ({
         y: Y_COLUMN,
         fill: groupKey,
         interpolation: 'monotoneX',
+        colors,
       },
       {
         type: 'custom',

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -1,5 +1,15 @@
 import _ from 'lodash'
-import {Config} from '@influxdata/giraffe'
+import {
+  Config,
+  NINETEEN_EIGHTY_FOUR,
+  ATLANTIS,
+  DO_ANDROIDS_DREAM,
+  DELOREAN,
+  CTHULHU,
+  ECTOPLASM,
+  T_MAX_400_FILM,
+} from '@influxdata/giraffe'
+
 import {AutoRefreshStatus} from 'src/types'
 
 export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss ZZ'
@@ -69,3 +79,13 @@ export const VIS_THEME: Partial<Config> = {
   legendBorder: '1px solid #202028',
   legendCrosshairColor: '#434453',
 }
+
+export const GIRAFFE_COLOR_SCHEMES = [
+  {name: 'Nineteen Eighty Four', colors: NINETEEN_EIGHTY_FOUR},
+  {name: 'Atlantis', colors: ATLANTIS},
+  {name: 'Do Androids Dream of Electric Sheep?', colors: DO_ANDROIDS_DREAM},
+  {name: 'Delorean', colors: DELOREAN},
+  {name: 'Cthulhu', colors: CTHULHU},
+  {name: 'Ectoplasm', colors: ECTOPLASM},
+  {name: 'T-MAX 400 Film', colors: T_MAX_400_FILM},
+]

--- a/ui/src/timeMachine/components/view_options/CheckOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/CheckOptions.tsx
@@ -1,0 +1,49 @@
+// Libraries
+import React, {FC} from 'react'
+import {connect} from 'react-redux'
+import {Form, Grid} from '@influxdata/clockface'
+
+// Components
+import HexColorSchemeDropdown from 'src/shared/components/HexColorSchemeDropdown'
+
+// Actions
+import {setColorHexes} from 'src/timeMachine/actions'
+
+// Constants
+import {GIRAFFE_COLOR_SCHEMES} from 'src/shared/constants'
+
+// Types
+import {CheckViewProperties} from 'src/types'
+
+interface OwnProps {
+  properties: CheckViewProperties
+}
+
+interface DispatchProps {
+  onSetColors: typeof setColorHexes
+}
+
+type Props = OwnProps & DispatchProps
+
+const CheckOptions: FC<Props> = ({properties: {colors}, onSetColors}) => {
+  return (
+    <Grid.Column>
+      <Form.Element label="Color Scheme">
+        <HexColorSchemeDropdown
+          colorSchemes={GIRAFFE_COLOR_SCHEMES}
+          selectedColorScheme={colors}
+          onSelectColorScheme={onSetColors}
+        />
+      </Form.Element>
+    </Grid.Column>
+  )
+}
+
+const mdtp = {
+  onSetColors: setColorHexes,
+}
+
+export default connect<{}, DispatchProps>(
+  null,
+  mdtp
+)(CheckOptions)

--- a/ui/src/timeMachine/components/view_options/OptionsSwitcher.tsx
+++ b/ui/src/timeMachine/components/view_options/OptionsSwitcher.tsx
@@ -9,6 +9,7 @@ import TableOptions from 'src/timeMachine/components/view_options/TableOptions'
 import HistogramOptions from 'src/timeMachine/components/view_options/HistogramOptions'
 import HeatmapOptions from 'src/timeMachine/components/view_options/HeatmapOptions'
 import ScatterOptions from 'src/timeMachine/components/view_options/ScatterOptions'
+import CheckOptions from 'src/timeMachine/components/view_options/CheckOptions'
 
 // Types
 import {View, NewView} from 'src/types'
@@ -43,6 +44,8 @@ class OptionsSwitcher extends PureComponent<Props> {
         return <HeatmapOptions {...view.properties} />
       case 'scatter':
         return <ScatterOptions {...view.properties} />
+      case 'check':
+        return <CheckOptions properties={view.properties} />
       default:
         return <div />
     }

--- a/ui/src/timeMachine/components/view_options/ScatterOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/ScatterOptions.tsx
@@ -1,15 +1,6 @@
 // Libraries
 import React, {SFC} from 'react'
 import {connect} from 'react-redux'
-import {
-  NINETEEN_EIGHTY_FOUR,
-  ATLANTIS,
-  DO_ANDROIDS_DREAM,
-  DELOREAN,
-  CTHULHU,
-  ECTOPLASM,
-  T_MAX_400_FILM,
-} from '@influxdata/giraffe'
 
 // Components
 import {Form, Input, Grid, MultiSelectDropdown} from '@influxdata/clockface'
@@ -39,22 +30,15 @@ import {
   getNumericColumns,
 } from 'src/timeMachine/selectors'
 
+// Constants
+import {GIRAFFE_COLOR_SCHEMES} from 'src/shared/constants'
+
 // Types
 import {ComponentStatus} from '@influxdata/clockface'
 import {AppState} from 'src/types'
 import HexColorSchemeDropdown from 'src/shared/components/HexColorSchemeDropdown'
 import AutoDomainInput from 'src/shared/components/AutoDomainInput'
 import ColumnSelector from 'src/shared/components/ColumnSelector'
-
-const COLOR_SCHEMES = [
-  {name: 'Nineteen Eighty Four', colors: NINETEEN_EIGHTY_FOUR},
-  {name: 'Atlantis', colors: ATLANTIS},
-  {name: 'Do Androids Dream of Electric Sheep?', colors: DO_ANDROIDS_DREAM},
-  {name: 'Delorean', colors: DELOREAN},
-  {name: 'Cthulhu', colors: CTHULHU},
-  {name: 'Ectoplasm', colors: ECTOPLASM},
-  {name: 'T-MAX 400 Film', colors: T_MAX_400_FILM},
-]
 
 interface StateProps {
   fillColumns: string[]
@@ -187,7 +171,7 @@ const ScatterOptions: SFC<Props> = props => {
       <h5 className="view-options--header">Options</h5>
       <Form.Element label="Color Scheme">
         <HexColorSchemeDropdown
-          colorSchemes={COLOR_SCHEMES}
+          colorSchemes={GIRAFFE_COLOR_SCHEMES}
           selectedColorScheme={colors}
           onSelectColorScheme={onSetColors}
         />


### PR DESCRIPTION
Closes #14633

Currently, the only supported visualization option is the color scheme. I think that before adding more, we should consider as a whole what these visualization options should be (e.g. is it exactly the same as an `XYView`? or would a scatterplot more appropriate? should we allow setting the y domain, or derive it from the thresholds of a check? etc. etc.)

![properties](https://user-images.githubusercontent.com/638955/62904904-ffcefd00-bd1c-11e9-97fa-99d9a80b6948.gif)
