### PR TITLE
fix(task): Make runs sorting and limits work

### DIFF
--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -178,8 +178,8 @@ func (as *AnalyticalStorage) FindRuns(ctx context.Context, filter influxdb.RunFi
 	  |> filter(fn: (r) => r._field != "status")
 	  |> filter(fn: (r) => r._measurement == "runs" and r.taskID == %q)
 	  %s
-	  |> group(columns: ["taskID", "status"])
 	  |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+	  |> group(columns: ["taskID"])
 	  |> sort(columns:["scheduledFor"], desc: true)
 	  |> limit(n:%d)
 
@@ -251,8 +251,8 @@ func (as *AnalyticalStorage) FindRunByID(ctx context.Context, taskID, runID infl
 	|> range(start: -14d)
 	|> filter(fn: (r) => r._field != "status")
 	|> filter(fn: (r) => r._measurement == "runs" and r.taskID == %q)
-	|> group(columns: ["taskID", "status"])
 	|> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+	|> group(columns: ["taskID"])
 	|> filter(fn: (r) => r.runID == %q)
 	  `, taskID.String(), runID.String())
 

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -1099,7 +1099,7 @@ func testRunStorage(t *testing.T, sys *System) {
 	}
 
 	// Mark the second run finished.
-	if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc1.Created.RunID, startedAt.Add(time.Second*2), backend.RunSuccess); err != nil {
+	if err := sys.TaskControlService.UpdateRunState(sys.Ctx, task.ID, rc1.Created.RunID, startedAt.Add(time.Second*2), backend.RunFail); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1183,7 +1183,7 @@ func testRunStorage(t *testing.T, sys *System) {
 	if runs[2].StartedAt != startedAt.Add(time.Second).Format(time.RFC3339Nano) {
 		t.Fatalf("unexpected StartedAt; want %s, got %s", runs[1].StartedAt, startedAt.Add(time.Second))
 	}
-	if runs[2].Status != backend.RunSuccess.String() {
+	if runs[2].Status != backend.RunFail.String() {
 		t.Fatalf("unexpected run status; want %s, got %s", backend.RunSuccess.String(), runs[2].Status)
 	}
 	if exp := startedAt.Add(time.Second * 2).Format(time.RFC3339Nano); runs[2].FinishedAt != exp {


### PR DESCRIPTION
Because we were grouping by taskID and status we are returning limit(n) results for
"success" and limit(n) results for "failed" runs.

In addition we were creating run's from the 2 tables which would cause the order to be [table1...,table2...].