### PR TITLE
refactor(query/stdlib): update tests for new Flux test name conventions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c // indirect
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
-	github.com/influxdata/flux v0.39.1-0.20190814210305-3e49c7b43d0a
+	github.com/influxdata/flux v0.39.1-0.20190815172552-7cd93c0dbf18
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368
 	github.com/jessevdk/go-flags v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/changelog v1.0.0 h1:RstJD6H48zLQj0GdE6E6k/6RPwtUjkyzIe/T1E/xuWU=
 github.com/influxdata/changelog v1.0.0/go.mod h1:uzpGWE/qehT8L426YuXwpMQub+a63vIINhIeEI9mnSM=
-github.com/influxdata/flux v0.39.1-0.20190814210305-3e49c7b43d0a h1:6VUDQMWYQ1rd+kwtDhoyRzzL5BD2XLw6VKUc1DUFAv8=
-github.com/influxdata/flux v0.39.1-0.20190814210305-3e49c7b43d0a/go.mod h1:pFWDX62wdE2DtMsXtYpYMRrTkZiIn3BYB5mQgCF57Yw=
+github.com/influxdata/flux v0.39.1-0.20190815172552-7cd93c0dbf18 h1:2y7AEir7q9TfWziF2qq4CiDtWmHdog10X/zKgs+/dV0=
+github.com/influxdata/flux v0.39.1-0.20190815172552-7cd93c0dbf18/go.mod h1:pFWDX62wdE2DtMsXtYpYMRrTkZiIn3BYB5mQgCF57Yw=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6 h1:CFx+pP90q/qg3spoiZjf8donE4WpAdjeJfPOcoNqkWo=

--- a/query/stdlib/testing/end_to_end_test.go
+++ b/query/stdlib/testing/end_to_end_test.go
@@ -45,9 +45,9 @@ func runEndToEnd(t *testing.T, pkgs []*ast.Package) {
 	defer l.ShutdownOrFail(t, ctx)
 	for _, pkg := range pkgs {
 		pkg := pkg.Copy().(*ast.Package)
-		name := pkg.Files[0].Name
+		name := strings.TrimSuffix(pkg.Files[0].Name, "_test.flux")
 		t.Run(name, func(t *testing.T) {
-			if reason, ok := itesting.FluxEndToEndSkipList[strings.TrimSuffix(name, ".flux")]; ok {
+			if reason, ok := itesting.FluxEndToEndSkipList[name]; ok {
 				t.Skip(reason)
 			}
 			testFlux(t, l, pkg)


### PR DESCRIPTION
See https://github.com/influxdata/flux/pull/1706 for context on the changes.