### PR TITLE
fix(storage): Ensure ResponseWriter flushes all buffered data

### DIFF
--- a/pkg/data/gen/arrays.gen.go
+++ b/pkg/data/gen/arrays.gen.go
@@ -11,6 +11,10 @@ import (
 	"github.com/influxdata/influxdb/tsdb/tsm1"
 )
 
+type FloatValues interface {
+	Copy(*tsdb.FloatArray)
+}
+
 type floatArray struct {
 	tsdb.FloatArray
 }
@@ -26,6 +30,15 @@ func newFloatArrayLen(sz int) *floatArray {
 
 func (a *floatArray) Encode(b []byte) ([]byte, error) {
 	return tsm1.EncodeFloatArrayBlock(&a.FloatArray, b)
+}
+
+func (a *floatArray) Copy(dst *tsdb.FloatArray) {
+	dst.Timestamps = append(dst.Timestamps[:0], a.Timestamps...)
+	dst.Values = append(dst.Values[:0], a.Values...)
+}
+
+type IntegerValues interface {
+	Copy(*tsdb.IntegerArray)
 }
 
 type integerArray struct {
@@ -45,6 +58,15 @@ func (a *integerArray) Encode(b []byte) ([]byte, error) {
 	return tsm1.EncodeIntegerArrayBlock(&a.IntegerArray, b)
 }
 
+func (a *integerArray) Copy(dst *tsdb.IntegerArray) {
+	dst.Timestamps = append(dst.Timestamps[:0], a.Timestamps...)
+	dst.Values = append(dst.Values[:0], a.Values...)
+}
+
+type UnsignedValues interface {
+	Copy(*tsdb.UnsignedArray)
+}
+
 type unsignedArray struct {
 	tsdb.UnsignedArray
 }
@@ -60,6 +82,15 @@ func newUnsignedArrayLen(sz int) *unsignedArray {
 
 func (a *unsignedArray) Encode(b []byte) ([]byte, error) {
 	return tsm1.EncodeUnsignedArrayBlock(&a.UnsignedArray, b)
+}
+
+func (a *unsignedArray) Copy(dst *tsdb.UnsignedArray) {
+	dst.Timestamps = append(dst.Timestamps[:0], a.Timestamps...)
+	dst.Values = append(dst.Values[:0], a.Values...)
+}
+
+type StringValues interface {
+	Copy(*tsdb.StringArray)
 }
 
 type stringArray struct {
@@ -79,6 +110,15 @@ func (a *stringArray) Encode(b []byte) ([]byte, error) {
 	return tsm1.EncodeStringArrayBlock(&a.StringArray, b)
 }
 
+func (a *stringArray) Copy(dst *tsdb.StringArray) {
+	dst.Timestamps = append(dst.Timestamps[:0], a.Timestamps...)
+	dst.Values = append(dst.Values[:0], a.Values...)
+}
+
+type BooleanValues interface {
+	Copy(*tsdb.BooleanArray)
+}
+
 type booleanArray struct {
 	tsdb.BooleanArray
 }
@@ -94,4 +134,9 @@ func newBooleanArrayLen(sz int) *booleanArray {
 
 func (a *booleanArray) Encode(b []byte) ([]byte, error) {
 	return tsm1.EncodeBooleanArrayBlock(&a.BooleanArray, b)
+}
+
+func (a *booleanArray) Copy(dst *tsdb.BooleanArray) {
+	dst.Timestamps = append(dst.Timestamps[:0], a.Timestamps...)
+	dst.Values = append(dst.Values[:0], a.Values...)
 }

--- a/pkg/data/gen/arrays.gen.go.tmpl
+++ b/pkg/data/gen/arrays.gen.go.tmpl
@@ -8,6 +8,10 @@ import (
 {{range .}}
 {{ $typename := print .name "Array" }}
 {{ $tsdbname := print .Name "Array" }}
+type {{.Name}}Values interface {
+	Copy(*tsdb.{{$tsdbname}})
+}
+
 type {{$typename}} struct {
 	tsdb.{{$tsdbname}}
 }
@@ -23,5 +27,10 @@ func new{{$tsdbname}}Len(sz int) *{{$typename}} {
 
 func (a *{{$typename}}) Encode(b []byte) ([]byte, error) {
 	return tsm1.Encode{{$tsdbname}}Block(&a.{{$tsdbname}}, b)
+}
+
+func (a *{{$typename}}) Copy(dst *tsdb.{{$tsdbname}}) {
+	dst.Timestamps = append(dst.Timestamps[:0], a.Timestamps...)
+	dst.Values = append(dst.Values[:0], a.Values...)
 }
 {{end}}

--- a/storage/reads/helpers_test.go
+++ b/storage/reads/helpers_test.go
@@ -1,0 +1,169 @@
+package reads_test
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/data/gen"
+	"github.com/influxdata/influxdb/storage/reads"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+)
+
+type seriesGeneratorCursorIterator struct {
+	g   gen.SeriesGenerator
+	f   floatTimeValuesGeneratorCursor
+	i   integerTimeValuesGeneratorCursor
+	u   unsignedTimeValuesGeneratorCursor
+	s   stringTimeValuesGeneratorCursor
+	b   booleanTimeValuesGeneratorCursor
+	cur cursors.Cursor
+}
+
+func (ci *seriesGeneratorCursorIterator) Next(ctx context.Context, r *cursors.CursorRequest) (cursors.Cursor, error) {
+	switch ci.g.FieldType() {
+	case models.Float:
+		ci.f.tv = ci.g.TimeValuesGenerator()
+		ci.cur = &ci.f
+	case models.Integer:
+		ci.i.tv = ci.g.TimeValuesGenerator()
+		ci.cur = &ci.i
+	case models.Unsigned:
+		ci.u.tv = ci.g.TimeValuesGenerator()
+		ci.cur = &ci.u
+	case models.String:
+		ci.s.tv = ci.g.TimeValuesGenerator()
+		ci.cur = &ci.s
+	case models.Boolean:
+		ci.b.tv = ci.g.TimeValuesGenerator()
+		ci.cur = &ci.b
+	default:
+		panic("unreachable")
+	}
+
+	return ci.cur, nil
+}
+
+func (ci *seriesGeneratorCursorIterator) Stats() cursors.CursorStats {
+	return ci.cur.Stats()
+}
+
+type seriesGeneratorSeriesCursor struct {
+	ci seriesGeneratorCursorIterator
+	r  reads.SeriesRow
+}
+
+func newSeriesGeneratorSeriesCursor(g gen.SeriesGenerator) *seriesGeneratorSeriesCursor {
+	s := &seriesGeneratorSeriesCursor{}
+	s.ci.g = g
+	s.r.Query = tsdb.CursorIterators{&s.ci}
+	return s
+}
+
+func (s *seriesGeneratorSeriesCursor) Close()     {}
+func (s *seriesGeneratorSeriesCursor) Err() error { return nil }
+
+func (s *seriesGeneratorSeriesCursor) Next() *reads.SeriesRow {
+	if s.ci.g.Next() {
+		s.r.SeriesTags = s.ci.g.Tags()
+		s.r.Tags = s.ci.g.Tags()
+		return &s.r
+	}
+	return nil
+}
+
+type timeValuesGeneratorCursor struct {
+	tv    gen.TimeValuesSequence
+	stats cursors.CursorStats
+}
+
+func (t timeValuesGeneratorCursor) Close()                     {}
+func (t timeValuesGeneratorCursor) Err() error                 { return nil }
+func (t timeValuesGeneratorCursor) Stats() cursors.CursorStats { return t.stats }
+
+type floatTimeValuesGeneratorCursor struct {
+	timeValuesGeneratorCursor
+	a tsdb.FloatArray
+}
+
+func (c *floatTimeValuesGeneratorCursor) Next() *cursors.FloatArray {
+	if c.tv.Next() {
+		c.tv.Values().(gen.FloatValues).Copy(&c.a)
+	} else {
+		c.a.Timestamps = c.a.Timestamps[:0]
+		c.a.Values = c.a.Values[:0]
+	}
+	c.stats.ScannedBytes += len(c.a.Values) * 8
+	c.stats.ScannedValues += c.a.Len()
+	return &c.a
+}
+
+type integerTimeValuesGeneratorCursor struct {
+	timeValuesGeneratorCursor
+	a tsdb.IntegerArray
+}
+
+func (c *integerTimeValuesGeneratorCursor) Next() *cursors.IntegerArray {
+	if c.tv.Next() {
+		c.tv.Values().(gen.IntegerValues).Copy(&c.a)
+	} else {
+		c.a.Timestamps = c.a.Timestamps[:0]
+		c.a.Values = c.a.Values[:0]
+	}
+	c.stats.ScannedBytes += len(c.a.Values) * 8
+	c.stats.ScannedValues += c.a.Len()
+	return &c.a
+}
+
+type unsignedTimeValuesGeneratorCursor struct {
+	timeValuesGeneratorCursor
+	a tsdb.UnsignedArray
+}
+
+func (c *unsignedTimeValuesGeneratorCursor) Next() *cursors.UnsignedArray {
+	if c.tv.Next() {
+		c.tv.Values().(gen.UnsignedValues).Copy(&c.a)
+	} else {
+		c.a.Timestamps = c.a.Timestamps[:0]
+		c.a.Values = c.a.Values[:0]
+	}
+	c.stats.ScannedBytes += len(c.a.Values) * 8
+	c.stats.ScannedValues += c.a.Len()
+	return &c.a
+}
+
+type stringTimeValuesGeneratorCursor struct {
+	timeValuesGeneratorCursor
+	a tsdb.StringArray
+}
+
+func (c *stringTimeValuesGeneratorCursor) Next() *cursors.StringArray {
+	if c.tv.Next() {
+		c.tv.Values().(gen.StringValues).Copy(&c.a)
+	} else {
+		c.a.Timestamps = c.a.Timestamps[:0]
+		c.a.Values = c.a.Values[:0]
+	}
+	for _, v := range c.a.Values {
+		c.stats.ScannedBytes += len(v)
+	}
+	c.stats.ScannedValues += c.a.Len()
+	return &c.a
+}
+
+type booleanTimeValuesGeneratorCursor struct {
+	timeValuesGeneratorCursor
+	a tsdb.BooleanArray
+}
+
+func (c *booleanTimeValuesGeneratorCursor) Next() *cursors.BooleanArray {
+	if c.tv.Next() {
+		c.tv.Values().(gen.BooleanValues).Copy(&c.a)
+	} else {
+		c.a.Timestamps = c.a.Timestamps[:0]
+		c.a.Values = c.a.Values[:0]
+	}
+	c.stats.ScannedBytes += len(c.a.Values)
+	c.stats.ScannedValues += c.a.Len()
+	return &c.a
+}

--- a/storage/reads/response_writer.gen.go.tmpl
+++ b/storage/reads/response_writer.gen.go.tmpl
@@ -53,39 +53,53 @@ func (w *ResponseWriter) stream{{.Name}}ArrayPoints(cur cursors.{{.Name}}ArrayCu
 	frame := p.{{.Name}}Points
 	w.res.Frames = append(w.res.Frames, datatypes.ReadResponse_Frame{Data: p})
 
-	var (
-		seriesValueCount = 0
-		b                = 0
-	)
-
+	var seriesValueCount = 0
 	for {
+		// If the number of values produced by cur > 1000,
+		// cur.Next() will produce batches of values that are of
+		// length ≤ 1000.
+		// We attempt to limit the frame Timestamps / Values lengths
+		// the same to avoid allocations. These frames are recycled
+		// after flushing so that on repeated use there should be enough space
+		// to append values from a into frame without additional allocations.
 		a := cur.Next()
+
 		if len(a.Timestamps) == 0 {
 			break
 		}
 
+		seriesValueCount += a.Len()
+		// As specified in the struct definition, w.sz is an estimated
+		// size (in bytes) of the buffered data. It is therefore a
+		// deliberate choice to accumulate using the array Size, which is
+		// cheap to calculate. Calling frame.Size() can be expensive
+		// when using varint encoding for numbers.
+		w.sz += a.Size()
+
 		frame.Timestamps = append(frame.Timestamps, a.Timestamps...)
 		frame.Values = append(frame.Values, a.Values...)
 
-		b = len(frame.Timestamps)
-		if b >= batchSize {
-			seriesValueCount += b
-			b = 0
-			w.sz += frame.Size()
-			if w.sz >= writeSize {
-				w.Flush()
-				if w.err != nil {
-					break
-				}
-			}
+		// given the expectation of cur.Next, we attempt to limit
+		// the number of values appended to the frame to batchSize (1000)
+		needsFrame := len(frame.Timestamps) >= batchSize
 
+		if w.sz >= writeSize {
+			needsFrame = true
+			w.Flush()
+			if w.err != nil {
+				break
+			}
+		}
+
+		if needsFrame {
+			// new frames are returned with Timestamps and Values preallocated
+			// to a minimum of batchSize length to reduce further allocations.
 			p = w.get{{.Name}}PointsFrame()
 			frame = p.{{.Name}}Points
 			w.res.Frames = append(w.res.Frames, datatypes.ReadResponse_Frame{Data: p})
 		}
 	}
 
-	seriesValueCount += b
 	w.vc += seriesValueCount
 	if seriesValueCount == 0 {
 		w.sz -= w.sf.Size()

--- a/storage/reads/response_writer.go
+++ b/storage/reads/response_writer.go
@@ -31,7 +31,9 @@ type ResponseWriter struct {
 	// current series
 	sf *datatypes.ReadResponse_SeriesFrame
 	ss int // pointer to current series frame; used to skip writing if no points
-	sz int // estimated size in bytes for pending write
+	// sz is an estimated size in bytes for pending writes to flush periodically
+	// when the size exceeds writeSize.
+	sz int
 
 	vc int // total value count
 

--- a/storage/reads/response_writer_test.go
+++ b/storage/reads/response_writer_test.go
@@ -336,7 +336,7 @@ func TestResponseWriter_WriteResultSet(t *testing.T) {
 	})
 
 	t.Run("issues", func(t *testing.T) {
-		t.Run("#4321 short write", func(t *testing.T) {
+		t.Run("short write", func(t *testing.T) {
 			t.Run("single string series", func(t *testing.T) {
 				exp := sendSummary{seriesCount: 1, stringCount: 1020}
 				var ss sendSummary

--- a/storage/reads/response_writer_test.go
+++ b/storage/reads/response_writer_test.go
@@ -1,12 +1,21 @@
 package reads_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/mock"
+	"github.com/influxdata/influxdb/pkg/data/gen"
+	"github.com/influxdata/influxdb/pkg/testing/assert"
 	"github.com/influxdata/influxdb/storage/reads"
+	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/cursors"
 	"google.golang.org/grpc/metadata"
 )
@@ -122,4 +131,404 @@ func TestResponseWriter_WriteGroupResultSet_Stats(t *testing.T) {
 	if !reflect.DeepEqual(gotTrailer.Get("scanned-bytes"), []string{fmt.Sprint(scannedBytes)}) {
 		t.Errorf("expected scanned-bytes '%v' but got '%v'", []string{fmt.Sprint(scannedBytes)}, gotTrailer.Get("scanned-bytes"))
 	}
+}
+
+var (
+	org         = influxdb.ID(0xff00ff00)
+	bucket      = influxdb.ID(0xcc00cc00)
+	orgBucketID = tsdb.EncodeName(org, bucket)
+)
+
+func makeTypedSeries(m, prefix, field string, val interface{}, valueCount int, counts ...int) gen.SeriesGenerator {
+	spec := gen.TimeSequenceSpec{Count: valueCount, Start: time.Unix(0, 0), Delta: time.Second}
+	ts := gen.NewTimestampSequenceFromSpec(spec)
+	var vg gen.TimeValuesSequence
+	switch val := val.(type) {
+	case float64:
+		vg = gen.NewTimeFloatValuesSequence(spec.Count, ts, gen.NewFloatConstantValuesSequence(val))
+	case int64:
+		vg = gen.NewTimeIntegerValuesSequence(spec.Count, ts, gen.NewIntegerConstantValuesSequence(val))
+	case int:
+		vg = gen.NewTimeIntegerValuesSequence(spec.Count, ts, gen.NewIntegerConstantValuesSequence(int64(val)))
+	case uint64:
+		vg = gen.NewTimeUnsignedValuesSequence(spec.Count, ts, gen.NewUnsignedConstantValuesSequence(val))
+	case string:
+		vg = gen.NewTimeStringValuesSequence(spec.Count, ts, gen.NewStringConstantValuesSequence(val))
+	case bool:
+		vg = gen.NewTimeBooleanValuesSequence(spec.Count, ts, gen.NewBooleanConstantValuesSequence(val))
+	default:
+		panic(fmt.Sprintf("unexpected type %T", val))
+	}
+
+	return gen.NewSeriesGenerator(orgBucketID, []byte(field), vg, gen.NewTagsValuesSequenceCounts(m, field, prefix, counts))
+}
+
+type sendSummary struct {
+	groupCount    int
+	seriesCount   int
+	floatCount    int
+	integerCount  int
+	unsignedCount int
+	stringCount   int
+	booleanCount  int
+}
+
+func (ss *sendSummary) makeSendFunc() func(*datatypes.ReadResponse) error {
+	return func(r *datatypes.ReadResponse) error {
+		for i := range r.Frames {
+			d := r.Frames[i].Data
+			switch p := d.(type) {
+			case *datatypes.ReadResponse_Frame_FloatPoints:
+				ss.floatCount += len(p.FloatPoints.Values)
+			case *datatypes.ReadResponse_Frame_IntegerPoints:
+				ss.integerCount += len(p.IntegerPoints.Values)
+			case *datatypes.ReadResponse_Frame_UnsignedPoints:
+				ss.unsignedCount += len(p.UnsignedPoints.Values)
+			case *datatypes.ReadResponse_Frame_StringPoints:
+				ss.stringCount += len(p.StringPoints.Values)
+			case *datatypes.ReadResponse_Frame_BooleanPoints:
+				ss.booleanCount += len(p.BooleanPoints.Values)
+			case *datatypes.ReadResponse_Frame_Series:
+				ss.seriesCount++
+			case *datatypes.ReadResponse_Frame_Group:
+				ss.groupCount++
+			default:
+				panic("unexpected")
+			}
+		}
+		return nil
+	}
+}
+
+func TestResponseWriter_WriteResultSet(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		t.Run("all types one series each", func(t *testing.T) {
+			exp := sendSummary{
+				seriesCount:   5,
+				floatCount:    500,
+				integerCount:  400,
+				unsignedCount: 300,
+				stringCount:   200,
+				booleanCount:  100,
+			}
+			var ss sendSummary
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = ss.makeSendFunc()
+			w := reads.NewResponseWriter(stream, 0)
+
+			var gens []gen.SeriesGenerator
+
+			gens = append(gens, makeTypedSeries("m0", "t", "ff", 3.3, exp.floatCount, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "if", 100, exp.integerCount, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "uf", uint64(25), exp.unsignedCount, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "sf", "foo", exp.stringCount, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "bf", false, exp.booleanCount, 1))
+
+			cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+			err := w.WriteResultSet(rs)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			w.Flush()
+
+			assert.Equal(t, ss, exp)
+		})
+		t.Run("multi-series floats", func(t *testing.T) {
+			exp := sendSummary{
+				seriesCount: 5,
+				floatCount:  8600,
+			}
+			var ss sendSummary
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = ss.makeSendFunc()
+			w := reads.NewResponseWriter(stream, 0)
+
+			var gens []gen.SeriesGenerator
+			gens = append(gens, makeTypedSeries("m0", "t", "f0", 3.3, 2000, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "f1", 5.3, 1500, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "f2", 5.3, 2500, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "f3", -2.2, 900, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "f4", -9.2, 1700, 1))
+
+			cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+			err := w.WriteResultSet(rs)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			w.Flush()
+
+			assert.Equal(t, ss, exp)
+		})
+
+		t.Run("multi-series strings", func(t *testing.T) {
+			exp := sendSummary{
+				seriesCount: 4,
+				stringCount: 6900,
+			}
+			var ss sendSummary
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = ss.makeSendFunc()
+			w := reads.NewResponseWriter(stream, 0)
+
+			var gens []gen.SeriesGenerator
+			gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 100), 2000, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 200), 1500, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "s2", strings.Repeat("ccc", 300), 2500, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "s3", strings.Repeat("ddd", 200), 900, 1))
+
+			cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+			err := w.WriteResultSet(rs)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			w.Flush()
+
+			assert.Equal(t, ss, exp)
+		})
+
+		t.Run("writer doesn't send series with no values", func(t *testing.T) {
+			exp := sendSummary{
+				seriesCount: 2,
+				stringCount: 3700,
+			}
+			var ss sendSummary
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = ss.makeSendFunc()
+			w := reads.NewResponseWriter(stream, 0)
+
+			var gens []gen.SeriesGenerator
+			gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 100), 2000, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 200), 0, 1))
+			gens = append(gens, makeTypedSeries("m0", "t", "s2", strings.Repeat("ccc", 100), 1700, 1))
+			cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+
+			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+			err := w.WriteResultSet(rs)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			w.Flush()
+
+			assert.Equal(t, ss, exp)
+		})
+	})
+
+	t.Run("error conditions", func(t *testing.T) {
+		t.Run("writer returns stream error", func(t *testing.T) {
+			exp := errors.New("no write")
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = func(r *datatypes.ReadResponse) error { return exp }
+			w := reads.NewResponseWriter(stream, 0)
+
+			cur := newSeriesGeneratorSeriesCursor(makeTypedSeries("m0", "t", "f0", strings.Repeat("0", 1000), 2000, 1))
+			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+			_ = w.WriteResultSet(rs)
+			assert.Equal(t, w.Err(), exp)
+		})
+	})
+
+	t.Run("issues", func(t *testing.T) {
+		t.Run("#4321 short write", func(t *testing.T) {
+			t.Run("single string series", func(t *testing.T) {
+				exp := sendSummary{seriesCount: 1, stringCount: 1020}
+				var ss sendSummary
+
+				stream := mock.NewResponseStream()
+				stream.SendFunc = ss.makeSendFunc()
+				w := reads.NewResponseWriter(stream, 0)
+
+				cur := newSeriesGeneratorSeriesCursor(makeTypedSeries("m0", "t", "f0", strings.Repeat("0", 1000), exp.stringCount, 1))
+				rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+				err := w.WriteResultSet(rs)
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				w.Flush()
+
+				assert.Equal(t, ss, exp)
+			})
+
+			t.Run("single float series", func(t *testing.T) {
+				exp := sendSummary{seriesCount: 1, floatCount: 50500}
+				var ss sendSummary
+
+				stream := mock.NewResponseStream()
+				stream.SendFunc = ss.makeSendFunc()
+				w := reads.NewResponseWriter(stream, 0)
+
+				cur := newSeriesGeneratorSeriesCursor(makeTypedSeries("m0", "t", "f0", 5.5, exp.floatCount, 1))
+				rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+				err := w.WriteResultSet(rs)
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				w.Flush()
+
+				assert.Equal(t, ss, exp)
+			})
+
+			t.Run("multi series", func(t *testing.T) {
+				exp := sendSummary{seriesCount: 2, stringCount: 3700}
+				var ss sendSummary
+
+				stream := mock.NewResponseStream()
+				stream.SendFunc = ss.makeSendFunc()
+				w := reads.NewResponseWriter(stream, 0)
+
+				var gens []gen.SeriesGenerator
+				gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 1000), 2200, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 1000), 1500, 1))
+
+				cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+				rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+				err := w.WriteResultSet(rs)
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				w.Flush()
+
+				assert.Equal(t, ss, exp)
+			})
+		})
+	})
+}
+
+func TestResponseWriter_WriteGroupResultSet(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		t.Run("all types one series each", func(t *testing.T) {
+			exp := sendSummary{
+				groupCount:    1,
+				seriesCount:   5,
+				floatCount:    500,
+				integerCount:  400,
+				unsignedCount: 300,
+				stringCount:   200,
+				booleanCount:  100,
+			}
+			var ss sendSummary
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = ss.makeSendFunc()
+			w := reads.NewResponseWriter(stream, 0)
+
+			newCursor := func() (cursor reads.SeriesCursor, e error) {
+				var gens []gen.SeriesGenerator
+				gens = append(gens, makeTypedSeries("m0", "t", "ff", 3.3, exp.floatCount, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "if", 100, exp.integerCount, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "uf", uint64(25), exp.unsignedCount, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "sf", "foo", exp.stringCount, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "bf", false, exp.booleanCount, 1))
+				return newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens)), nil
+			}
+
+			rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupNone}, newCursor)
+			err := w.WriteGroupResultSet(rs)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			w.Flush()
+
+			assert.Equal(t, ss, exp)
+		})
+		t.Run("multi-series floats", func(t *testing.T) {
+			exp := sendSummary{
+				groupCount:  1,
+				seriesCount: 5,
+				floatCount:  8600,
+			}
+			var ss sendSummary
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = ss.makeSendFunc()
+			w := reads.NewResponseWriter(stream, 0)
+
+			newCursor := func() (cursor reads.SeriesCursor, e error) {
+				var gens []gen.SeriesGenerator
+				gens = append(gens, makeTypedSeries("m0", "t", "f0", 3.3, 2000, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "f1", 5.3, 1500, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "f2", 5.3, 2500, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "f3", -2.2, 900, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "f4", -9.2, 1700, 1))
+				return newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens)), nil
+			}
+
+			rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupNone}, newCursor)
+			err := w.WriteGroupResultSet(rs)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			w.Flush()
+
+			assert.Equal(t, ss, exp)
+		})
+
+		t.Run("multi-series strings", func(t *testing.T) {
+			exp := sendSummary{
+				groupCount:  1,
+				seriesCount: 4,
+				stringCount: 6900,
+			}
+			var ss sendSummary
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = ss.makeSendFunc()
+			w := reads.NewResponseWriter(stream, 0)
+
+			newCursor := func() (cursor reads.SeriesCursor, e error) {
+				var gens []gen.SeriesGenerator
+				gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 100), 2000, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 200), 1500, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "s2", strings.Repeat("ccc", 300), 2500, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "s3", strings.Repeat("ddd", 200), 900, 1))
+				return newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens)), nil
+			}
+
+			rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupNone}, newCursor)
+			err := w.WriteGroupResultSet(rs)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			w.Flush()
+
+			assert.Equal(t, ss, exp)
+		})
+
+		t.Run("writer doesn't send series with no values", func(t *testing.T) {
+			exp := sendSummary{
+				groupCount:  1,
+				seriesCount: 2,
+				stringCount: 3700,
+			}
+			var ss sendSummary
+
+			stream := mock.NewResponseStream()
+			stream.SendFunc = ss.makeSendFunc()
+			w := reads.NewResponseWriter(stream, 0)
+
+			newCursor := func() (cursor reads.SeriesCursor, e error) {
+				var gens []gen.SeriesGenerator
+				gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 100), 2000, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 200), 0, 1))
+				gens = append(gens, makeTypedSeries("m0", "t", "s2", strings.Repeat("ccc", 100), 1700, 1))
+				return newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens)), nil
+			}
+
+			rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupNone}, newCursor)
+			err := w.WriteGroupResultSet(rs)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			w.Flush()
+
+			assert.Equal(t, ss, exp)
+		})
+	})
 }

--- a/tsdb/cursors/arrayvalues.gen.go
+++ b/tsdb/cursors/arrayvalues.gen.go
@@ -26,10 +26,6 @@ func (a *FloatArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
 }
 
-func (a *FloatArray) Size() int {
-	panic("not implemented")
-}
-
 func (a *FloatArray) Len() int {
 	return len(a.Timestamps)
 }
@@ -225,10 +221,6 @@ func (a *IntegerArray) MinTime() int64 {
 
 func (a *IntegerArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
-}
-
-func (a *IntegerArray) Size() int {
-	panic("not implemented")
 }
 
 func (a *IntegerArray) Len() int {
@@ -428,10 +420,6 @@ func (a *UnsignedArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
 }
 
-func (a *UnsignedArray) Size() int {
-	panic("not implemented")
-}
-
 func (a *UnsignedArray) Len() int {
 	return len(a.Timestamps)
 }
@@ -627,10 +615,6 @@ func (a *StringArray) MinTime() int64 {
 
 func (a *StringArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
-}
-
-func (a *StringArray) Size() int {
-	panic("not implemented")
 }
 
 func (a *StringArray) Len() int {
@@ -830,10 +814,6 @@ func (a *BooleanArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
 }
 
-func (a *BooleanArray) Size() int {
-	panic("not implemented")
-}
-
 func (a *BooleanArray) Len() int {
 	return len(a.Timestamps)
 }
@@ -1027,10 +1007,6 @@ func (a *TimestampArray) MinTime() int64 {
 
 func (a *TimestampArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
-}
-
-func (a *TimestampArray) Size() int {
-	panic("not implemented")
 }
 
 func (a *TimestampArray) Len() int {

--- a/tsdb/cursors/arrayvalues.gen.go.tmpl
+++ b/tsdb/cursors/arrayvalues.gen.go.tmpl
@@ -28,10 +28,6 @@ func (a *{{ $typename }}) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
 }
 
-func (a *{{ $typename }}) Size() int {
-	panic("not implemented")
-}
-
 func (a *{{ $typename}}) Len() int {
 	return len(a.Timestamps)
 }

--- a/tsdb/cursors/arrayvalues.go
+++ b/tsdb/cursors/arrayvalues.go
@@ -1,0 +1,29 @@
+package cursors
+
+func (a *FloatArray) Size() int {
+	// size of timestamps + values
+	return len(a.Timestamps)*8 + len(a.Values)*8
+}
+
+func (a *IntegerArray) Size() int {
+	// size of timestamps + values
+	return len(a.Timestamps)*8 + len(a.Values)*8
+}
+
+func (a *UnsignedArray) Size() int {
+	// size of timestamps + values
+	return len(a.Timestamps)*8 + len(a.Values)*8
+}
+
+func (a *StringArray) Size() int {
+	sz := len(a.Timestamps) * 8
+	for _, s := range a.Values {
+		sz += len(s)
+	}
+	return sz
+}
+
+func (a *BooleanArray) Size() int {
+	// size of timestamps + values
+	return len(a.Timestamps)*8 + len(a.Values)
+}


### PR DESCRIPTION
The `ResponseWriter` would truncate the last series if the byte size of the points frames exceeded the `writeSize` constant, causing a `Flush` to occur and the cumulative `ResponseWriter.sz` to reset to zero. Because `ResponseWriter.sz` was not incremented for each frame, it remained at zero, which resulted in the final `Flush` short circuiting.

This PR implements the `Size` method for the `cursors.Array` types to be used to estimate the size of frame. This is in place of calling the Protocol Buffer `Size` function, which can be very expensive for varint types.