### PR TITLE
feat(ui): integrate notification rule overlays with API

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9042,7 +9042,7 @@ components:
       type: object
       required:
         - id
-        - orgid
+        - orgID
         - status
         - name
         - tagRules

--- a/ui/src/alerting/components/notifications/EditRuleOverlay.tsx
+++ b/ui/src/alerting/components/notifications/EditRuleOverlay.tsx
@@ -7,6 +7,9 @@ import {connect} from 'react-redux'
 import {Overlay} from '@influxdata/clockface'
 import RuleOverlayContents from 'src/alerting/components/notifications/RuleOverlayContents'
 
+// Actions
+import {updateRule} from 'src/alerting/actions/notifications/rules'
+
 // Utils
 import {RuleOverlayProvider} from './RuleOverlay.reducer'
 
@@ -17,15 +20,30 @@ interface StateProps {
   stateRule: NotificationRuleDraft
 }
 
-type Props = WithRouterProps & StateProps
+interface DispatchProps {
+  onUpdateRule: (rule: NotificationRuleDraft) => Promise<void>
+}
 
-const EditRuleOverlay: FC<Props> = ({params, router, stateRule}) => {
+type Props = WithRouterProps & StateProps & DispatchProps
+
+const EditRuleOverlay: FC<Props> = ({
+  params: {orgID},
+  router,
+  stateRule,
+  onUpdateRule,
+}) => {
   if (!stateRule) {
     return null
   }
 
   const handleDismiss = () => {
-    router.push(`/orgs/${params.orgID}/alerting`)
+    router.push(`/orgs/${orgID}/alerting`)
+  }
+
+  const handleUpdateRule = async (rule: NotificationRuleDraft) => {
+    await onUpdateRule(rule)
+
+    handleDismiss()
   }
 
   return (
@@ -37,7 +55,10 @@ const EditRuleOverlay: FC<Props> = ({params, router, stateRule}) => {
             onDismiss={handleDismiss}
           />
           <Overlay.Body>
-            <RuleOverlayContents />
+            <RuleOverlayContents
+              saveButtonText="Save Changes"
+              onSave={handleUpdateRule}
+            />
           </Overlay.Body>
         </Overlay.Container>
       </Overlay>
@@ -53,4 +74,11 @@ const mstp = ({rules}: AppState, {params}: Props): StateProps => {
   }
 }
 
-export default connect<StateProps>(mstp)(withRouter<Props>(EditRuleOverlay))
+const mdtp = {
+  onUpdateRule: updateRule as any,
+}
+
+export default connect<StateProps, DispatchProps>(
+  mstp,
+  mdtp
+)(withRouter<Props>(EditRuleOverlay))

--- a/ui/src/alerting/components/notifications/RuleCard.tsx
+++ b/ui/src/alerting/components/notifications/RuleCard.tsx
@@ -35,7 +35,7 @@ const RuleCard: FunctionComponent<Props> = ({
   router,
 }) => {
   const onUpdateName = (name: string) => {
-    updateRule({id: rule.id, name})
+    updateRule({...rule, name})
   }
 
   const onDelete = () => {
@@ -49,7 +49,7 @@ const RuleCard: FunctionComponent<Props> = ({
   const onToggle = () => {
     const status = rule.status === 'active' ? 'inactive' : 'active'
 
-    updateRule({id: rule.id, status})
+    updateRule({...rule, status})
   }
 
   const onRuleClick = () => {

--- a/ui/src/alerting/components/notifications/RuleEndpointDropdown.tsx
+++ b/ui/src/alerting/components/notifications/RuleEndpointDropdown.tsx
@@ -1,8 +1,9 @@
 // Libraries
 import React, {FC} from 'react'
+import {get} from 'lodash'
 
 // Components
-import {Dropdown} from '@influxdata/clockface'
+import {Dropdown, ComponentStatus} from '@influxdata/clockface'
 
 // Types
 import {NotificationEndpoint} from 'src/types'
@@ -18,6 +19,18 @@ const RuleEndpointDropdown: FC<Props> = ({
   selectedEndpointID,
   onSelectEndpoint,
 }) => {
+  if (!endpoints.length) {
+    const button = () => (
+      <Dropdown.Button status={ComponentStatus.Disabled} onClick={() => {}}>
+        No Endpoints Found
+      </Dropdown.Button>
+    )
+
+    const menu = () => null
+
+    return <Dropdown button={button} widthPixels={160} menu={menu} />
+  }
+
   const items = endpoints.map(({id, type, name}) => (
     <Dropdown.Item
       key={id}
@@ -30,7 +43,8 @@ const RuleEndpointDropdown: FC<Props> = ({
     </Dropdown.Item>
   ))
 
-  const selectedEndpoint = endpoints.find(e => e.id === selectedEndpointID)
+  const selectedEndpoint =
+    endpoints.find(e => e.id === selectedEndpointID) || endpoints[0]
 
   const button = (active, onClick) => (
     <Dropdown.Button
@@ -38,7 +52,7 @@ const RuleEndpointDropdown: FC<Props> = ({
       active={active}
       onClick={onClick}
     >
-      {selectedEndpoint.name}
+      {get(selectedEndpoint, 'name')}
     </Dropdown.Button>
   )
 

--- a/ui/src/alerting/components/notifications/RuleMessage.tsx
+++ b/ui/src/alerting/components/notifications/RuleMessage.tsx
@@ -7,7 +7,7 @@ import RuleEndpointDropdown from 'src/alerting/components/notifications/RuleEndp
 import RuleMessageContents from 'src/alerting/components/notifications/RuleMessageContents'
 
 // Utils
-import {getEndpointBase} from 'src/alerting/components/notifications/utils'
+import {getRuleVariantDefaults} from 'src/alerting/components/notifications/utils'
 import {useRuleDispatch} from './RuleOverlay.reducer'
 
 // Types
@@ -20,14 +20,13 @@ interface Props {
 
 const RuleMessage: FC<Props> = ({endpoints, rule}) => {
   const dispatch = useRuleDispatch()
-  const onSelectEndpoint = notifyEndpointID => {
-    const endpoint = getEndpointBase(endpoints, notifyEndpointID)
 
+  const onSelectEndpoint = notifyEndpointID => {
     dispatch({
       type: 'UPDATE_RULE',
       rule: {
         ...rule,
-        ...endpoint,
+        ...getRuleVariantDefaults(endpoints, notifyEndpointID),
         notifyEndpointID,
       },
     })

--- a/ui/src/alerting/components/notifications/RuleOverlayContents.tsx
+++ b/ui/src/alerting/components/notifications/RuleOverlayContents.tsx
@@ -13,9 +13,7 @@ import {
 import RuleSchedule from 'src/alerting/components/notifications/RuleSchedule'
 import RuleConditions from 'src/alerting/components/notifications/RuleConditions'
 import RuleMessage from 'src/alerting/components/notifications/RuleMessage'
-
-// Constants
-import {NEW_ENDPOINT_FIXTURES} from 'src/alerting/constants'
+import RuleOverlayFooter from 'src/alerting/components/notifications/RuleOverlayFooter'
 
 // Utils
 import {useRuleState, useRuleDispatch} from './RuleOverlay.reducer'
@@ -23,7 +21,12 @@ import {useRuleState, useRuleDispatch} from './RuleOverlay.reducer'
 // Types
 import {NotificationRuleDraft} from 'src/types'
 
-const RuleOverlayContents: FC = () => {
+interface Props {
+  saveButtonText: string
+  onSave: (draftRule: NotificationRuleDraft) => Promise<void>
+}
+
+const RuleOverlayContents: FC<Props> = ({saveButtonText, onSave}) => {
   const rule = useRuleState()
   const dispatch = useRuleDispatch()
 
@@ -62,7 +65,9 @@ const RuleOverlayContents: FC = () => {
           </Grid.Column>
         </Grid.Row>
         <RuleConditions rule={rule} />
-        <RuleMessage rule={rule} endpoints={NEW_ENDPOINT_FIXTURES} />
+        {/* TODO: Connect to Redux endpoints once they exist */}
+        <RuleMessage rule={rule} endpoints={[]} />
+        <RuleOverlayFooter saveButtonText={saveButtonText} onSave={onSave} />
       </Form>
     </Grid>
   )

--- a/ui/src/alerting/components/notifications/RuleOverlayFooter.scss
+++ b/ui/src/alerting/components/notifications/RuleOverlayFooter.scss
@@ -1,0 +1,9 @@
+.rule-overlay-footer--error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: $c-fire;
+  font-size: $ix-text-base;
+  font-weight: 600;
+  margin: $ix-marg-c 0;
+}

--- a/ui/src/alerting/components/notifications/RuleOverlayFooter.tsx
+++ b/ui/src/alerting/components/notifications/RuleOverlayFooter.tsx
@@ -1,0 +1,71 @@
+import React, {useState, FC} from 'react'
+
+// Components
+import {
+  ComponentColor,
+  Form,
+  Button,
+  ComponentStatus,
+  Grid,
+  Columns,
+} from '@influxdata/clockface'
+
+// Utils
+import {useRuleState} from './RuleOverlay.reducer'
+
+import {NotificationRuleDraft, RemoteDataState} from 'src/types'
+
+interface Props {
+  saveButtonText: string
+  onSave: (draftRule: NotificationRuleDraft) => Promise<void>
+}
+
+const RuleOverlayFooter: FC<Props> = ({saveButtonText, onSave}) => {
+  const rule = useRuleState()
+
+  const [saveStatus, setSaveStatus] = useState(RemoteDataState.NotStarted)
+  const [errorMessage, setErrorMessage] = useState<string>(null)
+
+  const handleSave = async () => {
+    if (saveStatus === RemoteDataState.Loading) {
+      return
+    }
+
+    try {
+      setSaveStatus(RemoteDataState.Loading)
+      setErrorMessage(null)
+
+      await onSave(rule)
+    } catch (e) {
+      setSaveStatus(RemoteDataState.Error)
+      setErrorMessage(e.message)
+    }
+  }
+
+  const buttonStatus =
+    saveStatus === RemoteDataState.Loading
+      ? ComponentStatus.Loading
+      : ComponentStatus.Default
+
+  return (
+    <>
+      <Grid.Row>
+        <Grid.Column widthXS={Columns.Twelve}>
+          {errorMessage && (
+            <div className="rule-overlay-footer--error">{errorMessage}</div>
+          )}
+          <Form.Footer className="rule-overlay-footer">
+            <Button
+              text={saveButtonText}
+              onClick={handleSave}
+              color={ComponentColor.Primary}
+              status={buttonStatus}
+            />
+          </Form.Footer>
+        </Grid.Column>
+      </Grid.Row>
+    </>
+  )
+}
+
+export default RuleOverlayFooter

--- a/ui/src/alerting/components/notifications/utils/index.ts
+++ b/ui/src/alerting/components/notifications/utils/index.ts
@@ -1,40 +1,48 @@
 // Libraries
 import {omit} from 'lodash'
+import uuid from 'uuid'
 
 // Types
 import {
+  StatusRule,
+  TagRule,
   StatusRuleDraft,
   LevelRule,
   SlackNotificationRuleBase,
   SMTPNotificationRuleBase,
   PagerDutyNotificationRuleBase,
   NotificationEndpoint,
+  NotificationRule,
+  NotificationRuleDraft,
+  NewNotificationRule,
 } from 'src/types'
 
-type EndpointBase =
+type RuleVariantFields =
   | SlackNotificationRuleBase
   | SMTPNotificationRuleBase
   | PagerDutyNotificationRuleBase
 
-export const getEndpointBase = (
+export const getRuleVariantDefaults = (
   endpoints: NotificationEndpoint[],
   id: string
-): EndpointBase => {
+): RuleVariantFields => {
   const endpoint = endpoints.find(e => e.id === id)
 
   switch (endpoint.type) {
     case 'slack': {
       return {messageTemplate: '', channel: '', type: 'slack'}
     }
+
     case 'smtp': {
       return {to: '', bodyTemplate: '', subjectTemplate: '', type: 'smtp'}
     }
+
     case 'pagerduty': {
       return {messageTemplate: '', type: 'pagerduty'}
     }
 
     default: {
-      throw new Error('Unknown endpoint type in <RuleMessage />')
+      throw new Error(`Could not find NotificationEndpoint with id "${id}"`)
     }
   }
 }
@@ -59,6 +67,7 @@ export const activeChange = (status: StatusRuleDraft) => {
 }
 
 export const previousLevel: LevelRule = {level: 'OK'}
+
 export const changeStatusRule = (
   status: StatusRuleDraft,
   change: Change
@@ -71,4 +80,67 @@ export const changeStatusRule = (
   const newValue = {...value, previousLevel}
 
   return {...status, value: newValue}
+}
+
+export const initRuleDraft = (orgID: string): NotificationRuleDraft => ({
+  type: 'slack',
+  every: '10m',
+  orgID,
+  name: '',
+  status: 'active',
+  messageTemplate: '',
+  tagRules: [],
+  statusRules: [
+    {
+      cid: '',
+      value: {
+        currentLevel: {operation: 'equal', level: 'WARN'},
+        previousLevel: {operation: 'equal', level: 'OK'},
+        period: '1h',
+        count: 1,
+      },
+    },
+  ],
+  description: '',
+})
+
+// Prepare a newly created rule for persistence
+export const draftRuleToNewRule = (
+  draftRule: NotificationRuleDraft
+): NewNotificationRule => {
+  return {
+    ...draftRule,
+    statusRules: draftRule.statusRules.map(r => r.value),
+    tagRules: draftRule.tagRules.map(r => r.value),
+  }
+}
+
+// Prepare an edited rule for persistence
+export const draftRuleToRule = (
+  draftRule: NotificationRuleDraft
+): NotificationRule => {
+  if (!draftRule.id) {
+    throw new Error('draft rule is missing id')
+  }
+
+  const statusRules: StatusRule[] = draftRule.statusRules.map(r => r.value)
+
+  const tagRules: TagRule[] = draftRule.tagRules.map(r => r.value)
+
+  return {
+    ...draftRule,
+    statusRules,
+    tagRules,
+  } as NotificationRule
+}
+
+// Prepare a persisted rule for editing
+export const ruleToDraftRule = (
+  rule: NotificationRule
+): NotificationRuleDraft => {
+  return {
+    ...rule,
+    statusRules: rule.statusRules.map(value => ({cid: uuid.v4(), value})),
+    tagRules: rule.tagRules.map(value => ({cid: uuid.v4(), value})),
+  }
 }

--- a/ui/src/alerting/constants/index.ts
+++ b/ui/src/alerting/constants/index.ts
@@ -2,9 +2,7 @@ import {
   Check,
   DashboardQuery,
   ThresholdCheck,
-  StatusRuleDraft,
   TagRuleDraft,
-  NotificationRuleDraft,
   DeadmanCheck,
 } from 'src/types'
 import {NotificationEndpoint} from 'src/client'
@@ -89,22 +87,6 @@ export const CHECK_FIXTURE_2: Check = {
 
 export const CHECK_FIXTURES: Array<Check> = [CHECK_FIXTURE_1, CHECK_FIXTURE_2]
 
-export const NEW_STATUS_RULE_DRAFT: StatusRuleDraft = {
-  cid: '',
-  value: {
-    currentLevel: {
-      operation: 'equal',
-      level: 'WARN',
-    },
-    previousLevel: {
-      operation: 'equal',
-      level: 'OK',
-    },
-    period: '1h',
-    count: 1,
-  },
-}
-
 export const NEW_TAG_RULE_DRAFT: TagRuleDraft = {
   cid: '',
   value: {
@@ -112,20 +94,6 @@ export const NEW_TAG_RULE_DRAFT: TagRuleDraft = {
     value: '',
     operator: 'equal',
   },
-}
-
-export const NEW_RULE_DRAFT: NotificationRuleDraft = {
-  id: '',
-  notifyEndpointID: '1',
-  type: 'slack',
-  every: '',
-  orgID: '',
-  name: '',
-  status: 'active',
-  messageTemplate: '',
-  tagRules: [NEW_TAG_RULE_DRAFT],
-  statusRules: [NEW_STATUS_RULE_DRAFT],
-  description: '',
 }
 
 export const NEW_ENDPOINT_FIXTURES: NotificationEndpoint[] = [
@@ -157,23 +125,3 @@ export const NEW_ENDPOINT_FIXTURES: NotificationEndpoint[] = [
     type: 'pagerduty',
   },
 ]
-
-export const RULE_DRAFT_FIXTURE: NotificationRuleDraft = {
-  id: '3',
-  notifyEndpointID: '2',
-  orgID: 'lala',
-  createdAt: '2019-12-17T00:00',
-  updatedAt: '2019-05-17T00:00',
-  status: 'active',
-  description: '',
-  name: 'amazing notification rule',
-  type: 'slack',
-  every: '2d',
-  offset: '5m',
-  limitEvery: 1,
-  limit: 5,
-  tagRules: [],
-  statusRules: [NEW_STATUS_RULE_DRAFT],
-  channel: '#monitoring-team',
-  messageTemplate: 'hello, this is a NotificationRule fixture speaking :)',
-}

--- a/ui/src/alerting/reducers/notifications/rules.test.ts
+++ b/ui/src/alerting/reducers/notifications/rules.test.ts
@@ -1,14 +1,19 @@
 import rulesReducer, {
   defaultNotificationRulesState,
 } from 'src/alerting/reducers/notifications/rules'
+
 import {
   setAllNotificationRules,
   setRule,
   setCurrentRule,
   removeRule,
 } from 'src/alerting/actions/notifications/rules'
+
+import {initRuleDraft} from 'src/alerting/components/notifications/utils'
+
 import {RemoteDataState} from 'src/types'
-import {NEW_RULE_DRAFT} from 'src/alerting/constants'
+
+const NEW_RULE_DRAFT = initRuleDraft('')
 
 describe('rulesReducer', () => {
   describe('setAllNotificationRules', () => {

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -123,6 +123,7 @@
 @import 'src/alerting/components/TagsTableField.scss';
 @import 'src/timeMachine/components/AddCheckDialog.scss';
 @import 'src/alerting/components/SentTableField.scss';
+@import 'src/alerting/components/notifications/RuleOverlayFooter.scss';
 
 // External
 @import '../../node_modules/@influxdata/react-custom-scrollbars/dist/styles.css';

--- a/ui/src/types/alerting.ts
+++ b/ui/src/types/alerting.ts
@@ -5,23 +5,33 @@ import {
   SlackNotificationRuleBase,
   SMTPNotificationRuleBase,
   PagerDutyNotificationRuleBase,
+  NotificationRule,
 } from 'src/client'
 
-export interface WithClientID<T> {
+type Omit<T, U> = Pick<T, Exclude<keyof T, U>>
+type Overwrite<T, U> = Omit<T, keyof U> & U
+
+interface WithClientID<T> {
   cid: string
   value: T
 }
 
 export type StatusRuleDraft = WithClientID<StatusRule>
+
 export type TagRuleDraft = WithClientID<TagRule>
 
-type ExcludeKeys<T> = Pick<T, Exclude<keyof T, 'statusRules' | 'tagRules'>>
+// TODO: Spec this out in the OpenAPI spec instead. It should be whatever the
+// server accepts as the request body for a `POST /api/v2/notificationRules`
+export type NewNotificationRule = Omit<NotificationRule, 'id'>
 
-export interface NotificationRuleBaseDraft
-  extends ExcludeKeys<NotificationRuleBase> {
-  statusRules: StatusRuleDraft[]
-  tagRules: TagRuleDraft[]
-}
+export type NotificationRuleBaseDraft = Overwrite<
+  NotificationRuleBase,
+  {
+    id?: string
+    statusRules: StatusRuleDraft[]
+    tagRules: TagRuleDraft[]
+  }
+>
 
 export type NotificationRuleDraft = SlackRule | SMTPRule | PagerDutyRule
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1112,10 +1112,10 @@
   dependencies:
     axios "^0.19.0"
 
-"@influxdata/influxdb-templates@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/influxdb-templates/-/influxdb-templates-0.6.0.tgz#6766fdfbee0c1a670d00ed912250c78e66c04f84"
-  integrity sha512-eKqIhlo6QZSoMERW7+bdYyeYAyPejKKDOfsCBQMaiEIcDXnVQGNLOzo/AG4cIVPAafo2ojOOEDDzYCkMVvkJkg==
+"@influxdata/influxdb-templates@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/influxdb-templates/-/influxdb-templates-0.7.0.tgz#c2d8061a8e1ed0ce4efffdab61f765518b0e4be3"
+  integrity sha512-iNRgGzM2/qqu1F8Ug1gyKh47EPHBVTEFeu8lY76XPWSzX9m8K+p+c9emVOR0BR0i2FymMKFqYJKBPQWMYAwWUg==
 
 "@influxdata/react-custom-scrollbars@4.3.8":
   version "4.3.8"


### PR DESCRIPTION
Part of #14619

I connected what parts of the notification rule UI I could to the API, but ran into an issue with the required `authorizationID` field. This field needs to be removed, but has not been removed yet. Once it has, I'll finish this up.

![save errors](https://user-images.githubusercontent.com/638955/63132908-a6aed580-bf77-11e9-8315-0e5ea5481e6c.gif)
