### PR TITLE
chore(authorizer): use org perm for notificationRule

### DIFF
--- a/authorizer/notification_rule.go
+++ b/authorizer/notification_rule.go
@@ -25,36 +25,6 @@ func NewNotificationRuleStore(s influxdb.NotificationRuleStore, urm influxdb.Use
 	}
 }
 
-func newNotificationRulePermission(a influxdb.Action, orgID, id influxdb.ID) (*influxdb.Permission, error) {
-	return influxdb.NewPermissionAtID(id, a, influxdb.NotificationRuleResourceType, orgID)
-}
-
-func authorizeReadNotificationRule(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newNotificationRulePermission(influxdb.ReadAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func authorizeWriteNotificationRule(ctx context.Context, orgID, id influxdb.ID) error {
-	p, err := newNotificationRulePermission(influxdb.WriteAction, orgID, id)
-	if err != nil {
-		return err
-	}
-
-	if err := IsAllowed(ctx, *p); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // FindNotificationRuleByID checks to see if the authorizer on context has read access to the id provided.
 func (s *NotificationRuleStore) FindNotificationRuleByID(ctx context.Context, id influxdb.ID) (influxdb.NotificationRule, error) {
 	nr, err := s.s.FindNotificationRuleByID(ctx, id)
@@ -62,7 +32,7 @@ func (s *NotificationRuleStore) FindNotificationRuleByID(ctx context.Context, id
 		return nil, err
 	}
 
-	if err := authorizeReadNotificationRule(ctx, nr.GetOrgID(), nr.GetID()); err != nil {
+	if err := authorizeReadOrg(ctx, nr.GetOrgID()); err != nil {
 		return nil, err
 	}
 
@@ -82,7 +52,7 @@ func (s *NotificationRuleStore) FindNotificationRules(ctx context.Context, filte
 	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
 	rules := nrs[:0]
 	for _, nr := range nrs {
-		err := authorizeReadNotificationRule(ctx, nr.GetOrgID(), nr.GetID())
+		err := authorizeReadOrg(ctx, nr.GetOrgID())
 		if err != nil && influxdb.ErrorCode(err) != influxdb.EUnauthorized {
 			return nil, 0, err
 		}
@@ -99,7 +69,7 @@ func (s *NotificationRuleStore) FindNotificationRules(ctx context.Context, filte
 
 // CreateNotificationRule checks to see if the authorizer on context has write access to the global notification rule resource.
 func (s *NotificationRuleStore) CreateNotificationRule(ctx context.Context, nr influxdb.NotificationRule, userID influxdb.ID) error {
-	p, err := influxdb.NewPermission(influxdb.WriteAction, influxdb.NotificationRuleResourceType, nr.GetOrgID())
+	p, err := newOrgPermission(influxdb.WriteAction, nr.GetOrgID())
 	if err != nil {
 		return err
 	}
@@ -118,7 +88,7 @@ func (s *NotificationRuleStore) UpdateNotificationRule(ctx context.Context, id i
 		return nil, err
 	}
 
-	if err := authorizeWriteNotificationRule(ctx, nr.GetOrgID(), id); err != nil {
+	if err := authorizeWriteOrg(ctx, nr.GetOrgID()); err != nil {
 		return nil, err
 	}
 
@@ -132,7 +102,7 @@ func (s *NotificationRuleStore) PatchNotificationRule(ctx context.Context, id in
 		return nil, err
 	}
 
-	if err := authorizeWriteNotificationRule(ctx, nr.GetOrgID(), id); err != nil {
+	if err := authorizeWriteOrg(ctx, nr.GetOrgID()); err != nil {
 		return nil, err
 	}
 
@@ -146,7 +116,7 @@ func (s *NotificationRuleStore) DeleteNotificationRule(ctx context.Context, id i
 		return err
 	}
 
-	if err := authorizeWriteNotificationRule(ctx, nr.GetOrgID(), id); err != nil {
+	if err := authorizeWriteOrg(ctx, nr.GetOrgID()); err != nil {
 		return err
 	}
 

--- a/authorizer/notification_rule_test.go
+++ b/authorizer/notification_rule_test.go
@@ -65,8 +65,8 @@ func TestNotificationRuleStore_FindNotificationRuleByID(t *testing.T) {
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type: influxdb.NotificationRuleResourceType,
-						ID:   influxdbtesting.IDPtr(1),
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(10),
 					},
 				},
 				id: 1,
@@ -101,7 +101,7 @@ func TestNotificationRuleStore_FindNotificationRuleByID(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "read:orgs/000000000000000a/notificationRules/0000000000000001 is unauthorized",
+					Msg:  "read:orgs/000000000000000a is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -171,7 +171,7 @@ func TestNotificationRuleStore_FindNotificationRules(t *testing.T) {
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type: influxdb.NotificationRuleResourceType,
+						Type: influxdb.OrgsResourceType,
 					},
 				},
 			},
@@ -230,8 +230,8 @@ func TestNotificationRuleStore_FindNotificationRules(t *testing.T) {
 				permission: influxdb.Permission{
 					Action: "read",
 					Resource: influxdb.Resource{
-						Type:  influxdb.NotificationRuleResourceType,
-						OrgID: influxdbtesting.IDPtr(10),
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(10),
 					},
 				},
 			},
@@ -317,15 +317,15 @@ func TestNotificationRuleStore_UpdateNotificationRule(t *testing.T) {
 					{
 						Action: "write",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 				},
@@ -362,15 +362,15 @@ func TestNotificationRuleStore_UpdateNotificationRule(t *testing.T) {
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a/notificationRules/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/000000000000000a is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -436,15 +436,15 @@ func TestNotificationRuleStore_PatchNotificationRule(t *testing.T) {
 					{
 						Action: "write",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 				},
@@ -481,15 +481,15 @@ func TestNotificationRuleStore_PatchNotificationRule(t *testing.T) {
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a/notificationRules/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/000000000000000a is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -550,15 +550,15 @@ func TestNotificationRuleStore_DeleteNotificationRule(t *testing.T) {
 					{
 						Action: "write",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 				},
@@ -590,15 +590,15 @@ func TestNotificationRuleStore_DeleteNotificationRule(t *testing.T) {
 					{
 						Action: "read",
 						Resource: influxdb.Resource{
-							Type: influxdb.NotificationRuleResourceType,
-							ID:   influxdbtesting.IDPtr(1),
+							Type: influxdb.OrgsResourceType,
+							ID:   influxdbtesting.IDPtr(10),
 						},
 					},
 				},
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a/notificationRules/0000000000000001 is unauthorized",
+					Msg:  "write:orgs/000000000000000a is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},
@@ -650,8 +650,8 @@ func TestNotificationRuleStore_CreateNotificationRule(t *testing.T) {
 				permission: influxdb.Permission{
 					Action: "write",
 					Resource: influxdb.Resource{
-						Type:  influxdb.NotificationRuleResourceType,
-						OrgID: influxdbtesting.IDPtr(10),
+						Type: influxdb.OrgsResourceType,
+						ID:   influxdbtesting.IDPtr(10),
 					},
 				},
 			},
@@ -680,7 +680,7 @@ func TestNotificationRuleStore_CreateNotificationRule(t *testing.T) {
 			},
 			wants: wants{
 				err: &influxdb.Error{
-					Msg:  "write:orgs/000000000000000a/notificationRules is unauthorized",
+					Msg:  "write:orgs/000000000000000a is unauthorized",
 					Code: influxdb.EUnauthorized,
 				},
 			},


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/14546
Use org permission for notification rule

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
