### PR TITLE
feat(tasks): add ability to find tasks by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1. [14631](https://github.com/influxdata/influxdb/pull/14631): Added Github and Apache templates
 1. [14631](https://github.com/influxdata/influxdb/pull/14631): Updated name of Local Metrics template
 1. [14631](https://github.com/influxdata/influxdb/pull/14631): Dashboards for all Telegraf config bundles now created
+1. [14694](https://github.com/influxdata/influxdb/pull/14694): Add ability to find tasks by name.
 
 ### UI Improvements
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4207,6 +4207,11 @@ paths:
       parameters:
         - $ref: '#/components/parameters/TraceSpan'
         - in: query
+          name: name
+          description: only returns tasks with the specified name
+          schema:
+            type: string
+        - in: query
           name: after
           schema:
             type: string

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -362,6 +362,10 @@ func decodeGetTasksRequest(ctx context.Context, r *http.Request, orgs platform.O
 		req.filter.Type = &ttype
 	}
 
+	if name := qp.Get("name"); name != "" {
+		req.filter.Name = &name
+	}
+
 	return req, nil
 }
 

--- a/kv/task.go
+++ b/kv/task.go
@@ -203,7 +203,7 @@ func (s *Service) findTasks(ctx context.Context, tx Tx, filter influxdb.TaskFilt
 	if filter.User != nil {
 		return s.findTasksByUser(ctx, tx, filter)
 	} else if org != nil {
-		return s.findTaskByOrg(ctx, tx, filter)
+		return s.findTasksByOrg(ctx, tx, filter)
 	}
 
 	return s.findAllTasks(ctx, tx, filter)
@@ -270,11 +270,16 @@ func (s *Service) findTasksByUser(ctx context.Context, tx Tx, filter influxdb.Ta
 			break
 		}
 	}
+
+	if filter.Name != nil {
+		ts = filterByName(ts, *filter.Name)
+	}
+
 	return ts, len(ts), nil
 }
 
-// findTaskByOrg is a subset of the find tasks function. Used for cleanliness
-func (s *Service) findTaskByOrg(ctx context.Context, tx Tx, filter influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
+// findTasksByOrg is a subset of the find tasks function. Used for cleanliness
+func (s *Service) findTasksByOrg(ctx context.Context, tx Tx, filter influxdb.TaskFilter) ([]*influxdb.Task, int, error) {
 	var org *influxdb.Organization
 	var err error
 	if filter.OrganizationID != nil {
@@ -393,6 +398,11 @@ func (s *Service) findTaskByOrg(ctx context.Context, tx Tx, filter influxdb.Task
 			break
 		}
 	}
+
+	if filter.Name != nil {
+		ts = filterByName(ts, *filter.Name)
+	}
+
 	return ts, len(ts), err
 }
 
@@ -475,7 +485,24 @@ func (s *Service) findAllTasks(ctx context.Context, tx Tx, filter influxdb.TaskF
 			break
 		}
 	}
+
+	if filter.Name != nil {
+		ts = filterByName(ts, *filter.Name)
+	}
+
 	return ts, len(ts), err
+}
+
+func filterByName(ts []*influxdb.Task, taskName string) []*influxdb.Task {
+	filtered := []*influxdb.Task{}
+
+	for _, task := range ts {
+		if task.Name == taskName {
+			filtered = append(filtered, task)
+		}
+	}
+
+	return filtered
 }
 
 // CreateTask creates a new task.

--- a/task.go
+++ b/task.go
@@ -382,6 +382,7 @@ func (t *TaskUpdate) UpdateFlux(oldFlux string) error {
 // TaskFilter represents a set of filters that restrict the returned results
 type TaskFilter struct {
 	Type           *string
+	Name           *string
 	After          *ID
 	OrganizationID *ID
 	Organization   string


### PR DESCRIPTION
Closes #12170

Adds ability to find tasks with a name specified in the query parameters. An exact matched is used, to be consistent with the way filtering by name works with other resources such as buckets.

For example, a request to `http://localhost:9999/api/v2/tasks?name=mytask` will return the task(s) with the name `mytask`

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
