### PR TITLE
fix(kv): check createdat and updatedat should be identical

### DIFF
--- a/kv/check.go
+++ b/kv/check.go
@@ -320,8 +320,9 @@ func (s *Service) createCheck(ctx context.Context, tx Tx, c influxdb.Check, user
 
 	c.SetID(s.IDGenerator.ID())
 	c.SetOwnerID(userID)
-	c.SetCreatedAt(s.Now())
-	c.SetUpdatedAt(s.Now())
+	now := s.Now()
+	c.SetCreatedAt(now)
+	c.SetUpdatedAt(now)
 
 	t, err := s.createCheckTask(ctx, tx, c)
 	if err != nil {


### PR DESCRIPTION
When a check is created, its initial createdat and updatedat timestamps should be the same.