### PR TITLE
refactor(ui): introduce "Load Data" tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [14694](https://github.com/influxdata/influxdb/pull/14694): Add ability to find tasks by name.
 
 ### UI Improvements
+1. [14709](https://github.com/influxdata/influxdb/pull/14709): Move Buckets, Telgrafs, and Scrapers pages into a tab called "Load Data" for ease of discovery
 
 ### Bug Fixes
 

--- a/ui/cypress/e2e/buckets.test.ts
+++ b/ui/cypress/e2e/buckets.test.ts
@@ -12,7 +12,7 @@ describe('Buckets', () => {
       cy.wrap(body.org).as('org')
       cy.wrap(bucket).as('bucket')
       cy.fixture('routes').then(({orgs}) => {
-        cy.visit(`${orgs}/${id}/buckets`)
+        cy.visit(`${orgs}/${id}/load-data/buckets`)
       })
     })
   })

--- a/ui/cypress/e2e/scrapers.test.ts
+++ b/ui/cypress/e2e/scrapers.test.ts
@@ -13,7 +13,7 @@ describe('Scrapers', () => {
       cy.wrap(bucket).as('bucket')
 
       cy.fixture('routes').then(({orgs}) => {
-        cy.visit(`${orgs}/${id}/scrapers`)
+        cy.visit(`${orgs}/${id}/load-data/scrapers`)
       })
     })
   })
@@ -74,7 +74,7 @@ describe('Scrapers', () => {
 
         cy.fixture('routes').then(({orgs}) => {
           cy.get<Organization>('@org').then(({id}: Organization) => {
-            cy.visit(`${orgs}/${id}/scrapers`)
+            cy.visit(`${orgs}/${id}/load-data/scrapers`)
           })
         })
       })

--- a/ui/src/buckets/components/BucketCard.tsx
+++ b/ui/src/buckets/components/BucketCard.tsx
@@ -63,7 +63,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
       router,
     } = this.props
 
-    router.push(`/orgs/${orgID}/buckets/${id}/rename`)
+    router.push(`/orgs/${orgID}/load-data/buckets/${id}/rename`)
   }
 
   private handleNameClick = (): void => {
@@ -73,7 +73,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
       router,
     } = this.props
 
-    router.push(`/orgs/${orgID}/buckets/${id}/edit`)
+    router.push(`/orgs/${orgID}/load-data/buckets/${id}/edit`)
   }
 
   private handleAddCollector = (): void => {
@@ -82,7 +82,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
       bucket: {id},
     } = this.props
 
-    const link = `/orgs/${orgID}/buckets/${id}/telegrafs/new`
+    const link = `/orgs/${orgID}/load-data/buckets/${id}/telegrafs/new`
     this.props.onAddData(this.props.bucket, DataLoaderType.Streaming, link)
   }
 
@@ -92,7 +92,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
       bucket: {id},
     } = this.props
 
-    const link = `/orgs/${orgID}/buckets/${id}/line-protocols/new`
+    const link = `/orgs/${orgID}/load-data/buckets/${id}/line-protocols/new`
     this.props.onAddData(this.props.bucket, DataLoaderType.LineProtocol, link)
   }
 
@@ -102,7 +102,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
       bucket: {id},
     } = this.props
 
-    const link = `/orgs/${orgID}/buckets/${id}/scrapers/new`
+    const link = `/orgs/${orgID}/load-data/buckets/${id}/scrapers/new`
     this.props.onAddData(this.props.bucket, DataLoaderType.Scraping, link)
   }
 }

--- a/ui/src/buckets/components/BucketList.tsx
+++ b/ui/src/buckets/components/BucketList.tsx
@@ -136,13 +136,13 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
   private handleStartEdit = (bucket: PrettyBucket) => {
     const {orgID} = this.props.params
 
-    this.props.router.push(`/orgs/${orgID}/buckets/${bucket.id}/edit`)
+    this.props.router.push(`/orgs/${orgID}/load-data/buckets/${bucket.id}/edit`)
   }
 
   private handleStartDeleteData = (bucket: PrettyBucket) => {
     const {orgID} = this.props.params
 
-    this.props.router.push(`/orgs/${orgID}/buckets/${bucket.id}/delete-data`)
+    this.props.router.push(`/orgs/${orgID}/load-data/buckets/${bucket.id}/delete-data`)
   }
 
   private handleStartAddData = (

--- a/ui/src/buckets/components/BucketList.tsx
+++ b/ui/src/buckets/components/BucketList.tsx
@@ -142,7 +142,9 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
   private handleStartDeleteData = (bucket: PrettyBucket) => {
     const {orgID} = this.props.params
 
-    this.props.router.push(`/orgs/${orgID}/load-data/buckets/${bucket.id}/delete-data`)
+    this.props.router.push(
+      `/orgs/${orgID}/load-data/buckets/${bucket.id}/delete-data`
+    )
   }
 
   private handleStartAddData = (

--- a/ui/src/buckets/components/RenameBucketForm.tsx
+++ b/ui/src/buckets/components/RenameBucketForm.tsx
@@ -137,7 +137,7 @@ class RenameBucketForm extends PureComponent<Props, State> {
       params: {orgID},
     } = this.props
 
-    router.push(`/orgs/${orgID}/buckets`)
+    router.push(`/orgs/${orgID}/load-data/buckets`)
   }
 }
 

--- a/ui/src/buckets/components/RenameBucketOverlay.tsx
+++ b/ui/src/buckets/components/RenameBucketOverlay.tsx
@@ -47,7 +47,7 @@ class RenameBucketOverlay extends PureComponent<WithRouterProps> {
       params: {orgID},
     } = this.props
 
-    router.push(`/orgs/${orgID}/buckets`)
+    router.push(`/orgs/${orgID}/load-data/buckets`)
   }
 }
 

--- a/ui/src/buckets/components/UpdateBucketOverlay.tsx
+++ b/ui/src/buckets/components/UpdateBucketOverlay.tsx
@@ -144,7 +144,7 @@ class UpdateBucketOverlay extends PureComponent<Props, State> {
 
   private handleClose = () => {
     const {orgID} = this.props.params
-    this.props.router.push(`/orgs/${orgID}/buckets`)
+    this.props.router.push(`/orgs/${orgID}/load-data/buckets`)
   }
 }
 

--- a/ui/src/buckets/containers/BucketsIndex.tsx
+++ b/ui/src/buckets/containers/BucketsIndex.tsx
@@ -4,8 +4,8 @@ import {connect} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import SettingsTabbedPage from 'src/settings/components/SettingsTabbedPage'
-import SettingsHeader from 'src/settings/components/SettingsHeader'
+import LoadDataTabbedPage from 'src/settings/components/LoadDataTabbedPage'
+import LoadDataHeader from 'src/settings/components/LoadDataHeader'
 import {Page} from 'src/pageLayout'
 import BucketsTab from 'src/buckets/components/BucketsTab'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
@@ -26,8 +26,8 @@ class BucketsIndex extends Component<StateProps> {
     return (
       <>
         <Page titleTag={org.name}>
-          <SettingsHeader />
-          <SettingsTabbedPage activeTab="buckets" orgID={org.id}>
+          <LoadDataHeader />
+          <LoadDataTabbedPage activeTab="buckets" orgID={org.id}>
             <GetResources resource={ResourceTypes.Buckets}>
               <GetResources resource={ResourceTypes.Telegrafs}>
                 <GetAssetLimits>
@@ -35,7 +35,7 @@ class BucketsIndex extends Component<StateProps> {
                 </GetAssetLimits>
               </GetResources>
             </GetResources>
-          </SettingsTabbedPage>
+          </LoadDataTabbedPage>
         </Page>
         {children}
       </>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -216,31 +216,51 @@ class Root extends PureComponent {
                           <Route path="settings">
                             <IndexRoute component={MembersIndex} />
                           </Route>
-                          <Route path="buckets" component={BucketsIndex}>
-                            <Route path=":bucketID">
+                          <Route path="load-data">
+                            <IndexRoute component={BucketsIndex} />
+                            <Route path="buckets" component={BucketsIndex}>
+                              <Route path=":bucketID">
+                                <Route
+                                  path="line-protocols/new"
+                                  component={LineProtocolWizard}
+                                />
+                                <Route
+                                  path="telegrafs/new"
+                                  component={CollectorsWizard}
+                                />
+                                <Route
+                                  path="scrapers/new"
+                                  component={CreateScraperOverlay}
+                                />
+                                <Route
+                                  path="edit"
+                                  component={UpdateBucketOverlay}
+                                />
+                                <Route
+                                  path="delete-data"
+                                  component={BucketsDeleteDataOverlay}
+                                />
+                                <Route
+                                  path="rename"
+                                  component={RenameBucketOverlay}
+                                />
+                              </Route>
+                            </Route>
+                            <Route path="telegrafs" component={TelegrafsPage}>
                               <Route
-                                path="line-protocols/new"
-                                component={LineProtocolWizard}
+                                path=":id/view"
+                                component={TelegrafConfigOverlay}
                               />
                               <Route
-                                path="telegrafs/new"
-                                component={CollectorsWizard}
+                                path=":id/instructions"
+                                component={TelegrafInstructionsOverlay}
                               />
+                              <Route path="new" component={CollectorsWizard} />
+                            </Route>
+                            <Route path="scrapers" component={ScrapersIndex}>
                               <Route
-                                path="scrapers/new"
+                                path="new"
                                 component={CreateScraperOverlay}
-                              />
-                              <Route
-                                path="edit"
-                                component={UpdateBucketOverlay}
-                              />
-                              <Route
-                                path="delete-data"
-                                component={BucketsDeleteDataOverlay}
-                              />
-                              <Route
-                                path="rename"
-                                component={RenameBucketOverlay}
                               />
                             </Route>
                           </Route>
@@ -311,12 +331,6 @@ class Root extends PureComponent {
                             />
                           </Route>
                           <Route path="labels" component={LabelsIndex} />
-                          <Route path="scrapers" component={ScrapersIndex}>
-                            <Route
-                              path="new"
-                              component={CreateScraperOverlay}
-                            />
-                          </Route>
                           <FeatureFlag name="alerting">
                             <Route path="alerting" component={AlertingIndex}>
                               <Route path="checks/new" component={NewCheckEO} />

--- a/ui/src/me/components/GettingStarted.tsx
+++ b/ui/src/me/components/GettingStarted.tsx
@@ -17,7 +17,7 @@ class GettingStarted extends PureComponent<WithRouterProps> {
       <div className="getting-started">
         <div className="getting-started--container">
           <Link
-            to={`/orgs/${orgID}/telegrafs`}
+            to={`/orgs/${orgID}/load-data/telegrafs`}
             className="getting-started--card"
           >
             <GradientBorder />

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -64,6 +64,10 @@ class SideNav extends PureComponent<Props, State> {
     const tasksLink = `${orgPrefix}/tasks`
     const alertingLink = `${orgPrefix}/alerting`
     const alertHistoryLink = `${orgPrefix}/alert-history`
+    const loadDataLink = `${orgPrefix}/load-data/buckets`
+    const bucketsLink = `${orgPrefix}/load-data/buckets`
+    const telegrafsLink = `${orgPrefix}/load-data/telegrafs`
+    const scrapersLink = `${orgPrefix}/load-data/scrapers`
     const settingsLink = `${orgPrefix}/settings`
     const feedbackLink =
       'https://docs.google.com/forms/d/e/1FAIpQLSdGJpnIZGotN1VFJPkgZEhrt4t4f6QY1lMgMSRUnMeN3FjCKA/viewform?usp=sf_link'
@@ -152,11 +156,55 @@ class SideNav extends PureComponent<Props, State> {
                   Check Statuses
                 </Link>
               )}
-              active={false}
+              active={getNavItemActivation(
+                ['alert-history'],
+                location.pathname
+              )}
               key="alert-history"
             />
           </NavMenu.Item>
         </FeatureFlag>
+        <NavMenu.Item
+          titleLink={className => (
+            <Link className={className} to={loadDataLink}>
+              Load Data
+            </Link>
+          )}
+          iconLink={className => (
+            <Link to={loadDataLink} className={className}>
+              <Icon glyph={IconFont.Disks} />
+            </Link>
+          )}
+          active={getNavItemActivation(['load-data'], location.pathname)}
+        >
+          <NavMenu.SubItem
+            titleLink={className => (
+              <Link to={bucketsLink} className={className}>
+                Buckets
+              </Link>
+            )}
+            active={getNavItemActivation(['buckets'], location.pathname)}
+            key="buckets"
+          />
+          <NavMenu.SubItem
+            titleLink={className => (
+              <Link to={telegrafsLink} className={className}>
+                Telegrafs
+              </Link>
+            )}
+            active={getNavItemActivation(['telegrafs'], location.pathname)}
+            key="telegrafs"
+          />
+          <NavMenu.SubItem
+            titleLink={className => (
+              <Link to={scrapersLink} className={className}>
+                Scrapers
+              </Link>
+            )}
+            active={getNavItemActivation(['scrapers'], location.pathname)}
+            key="scrapers"
+          />
+        </NavMenu.Item>
         <NavMenu.Item
           titleLink={className => (
             <Link className={className} to={settingsLink}>

--- a/ui/src/pageLayout/utils/index.ts
+++ b/ui/src/pageLayout/utils/index.ts
@@ -1,10 +1,8 @@
-import _ from 'lodash'
-
 export const getNavItemActivation = (
   keywords: string[],
   location: string
 ): boolean => {
   const ignoreOrgAndOrgID = 3
-  const parentPath = _.get(location.split('/'), ignoreOrgAndOrgID, '')
-  return keywords.some(path => path === parentPath)
+  const parentPath = location.split('/').slice(ignoreOrgAndOrgID)
+  return keywords.some(path => parentPath.includes(path))
 }

--- a/ui/src/scrapers/components/Scrapers.tsx
+++ b/ui/src/scrapers/components/Scrapers.tsx
@@ -184,7 +184,7 @@ class Scrapers extends PureComponent<Props, State> {
       return
     }
 
-    router.push(`/orgs/${orgID}/scrapers/new`)
+    router.push(`/orgs/${orgID}/load-data/scrapers/new`)
   }
 
   private handleFilterChange = (searchTerm: string): void => {

--- a/ui/src/scrapers/containers/ScrapersIndex.tsx
+++ b/ui/src/scrapers/containers/ScrapersIndex.tsx
@@ -4,8 +4,8 @@ import {connect} from 'react-redux'
 
 // Components
 import {Page} from 'src/pageLayout'
-import SettingsHeader from 'src/settings/components/SettingsHeader'
-import SettingsTabbedPage from 'src/settings/components/SettingsTabbedPage'
+import LoadDataHeader from 'src/settings/components/LoadDataHeader'
+import LoadDataTabbedPage from 'src/settings/components/LoadDataTabbedPage'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 import Scrapers from 'src/scrapers/components/Scrapers'
 
@@ -27,14 +27,14 @@ class ScrapersIndex extends Component<StateProps> {
     return (
       <>
         <Page titleTag={org.name}>
-          <SettingsHeader />
-          <SettingsTabbedPage activeTab="scrapers" orgID={org.id}>
+          <LoadDataHeader />
+          <LoadDataTabbedPage activeTab="scrapers" orgID={org.id}>
             <GetResources resource={ResourceTypes.Scrapers}>
               <GetResources resource={ResourceTypes.Buckets}>
                 <Scrapers orgName={org.name} />
               </GetResources>
             </GetResources>
-          </SettingsTabbedPage>
+          </LoadDataTabbedPage>
         </Page>
         {children}
       </>

--- a/ui/src/settings/components/LoadDataHeader.tsx
+++ b/ui/src/settings/components/LoadDataHeader.tsx
@@ -1,0 +1,20 @@
+import React, {Component} from 'react'
+
+// Components
+import {Page} from 'src/pageLayout'
+import PageTitleWithOrg from 'src/shared/components/PageTitleWithOrg'
+
+class LoadDataHeader extends Component {
+  public render() {
+    return (
+      <Page.Header fullWidth={false}>
+        <Page.Header.Left>
+          <PageTitleWithOrg title="Load Data" />
+        </Page.Header.Left>
+        <Page.Header.Right />
+      </Page.Header>
+    )
+  }
+}
+
+export default LoadDataHeader

--- a/ui/src/settings/components/LoadDataNavigation.tsx
+++ b/ui/src/settings/components/LoadDataNavigation.tsx
@@ -24,50 +24,35 @@ interface OwnProps {
 type Props = OwnProps & WithRouterProps
 
 @ErrorHandling
-class SettingsNavigation extends PureComponent<Props> {
+class LoadDataNavigation extends PureComponent<Props> {
   public render() {
     const {activeTab, orgID, router} = this.props
 
     const handleTabClick = (id: string): void => {
-      router.push(`/orgs/${orgID}/${id}`)
+      router.push(`/orgs/${orgID}/load-data/${id}`)
     }
 
     const tabs = [
       {
-        text: 'Members',
-        id: 'members',
+        text: 'Buckets',
+        id: 'buckets',
         cloudExclude: false,
       },
       {
-        text: 'Variables',
-        id: 'variables',
+        text: 'Telegraf',
+        id: 'telegrafs',
         cloudExclude: false,
       },
       {
-        text: 'Templates',
-        id: 'templates',
-        cloudExclude: false,
-      },
-      {
-        text: 'Labels',
-        id: 'labels',
-        cloudExclude: false,
-      },
-      {
-        text: 'Tokens',
-        id: 'tokens',
-        cloudExclude: false,
-      },
-      {
-        text: 'Org Profile',
-        id: 'profile',
-        cloudExclude: false,
+        text: 'Scrapers',
+        id: 'scrapers',
+        cloudExclude: true,
       },
     ]
 
     return (
       <Tabs
-        orientation={Orientation.Vertical}
+        orientation={Orientation.Horizontal}
         padding={ComponentSize.Large}
         backgroundColor={`${chroma(`${InfluxColors.Castle}`).alpha(0.1)}`}
       >
@@ -80,7 +65,7 @@ class SettingsNavigation extends PureComponent<Props> {
                   id={t.id}
                   onClick={handleTabClick}
                   active={t.id === activeTab}
-                  size={ComponentSize.Medium}
+                  size={ComponentSize.Large}
                   backgroundColor={InfluxColors.Castle}
                 />
               </CloudExclude>
@@ -93,7 +78,7 @@ class SettingsNavigation extends PureComponent<Props> {
               id={t.id}
               onClick={handleTabClick}
               active={t.id === activeTab}
-              size={ComponentSize.Medium}
+              size={ComponentSize.Large}
               backgroundColor={InfluxColors.Castle}
             />
           )
@@ -103,4 +88,4 @@ class SettingsNavigation extends PureComponent<Props> {
   }
 }
 
-export default withRouter(SettingsNavigation)
+export default withRouter(LoadDataNavigation)

--- a/ui/src/settings/components/LoadDataTabbedPage.tsx
+++ b/ui/src/settings/components/LoadDataTabbedPage.tsx
@@ -1,0 +1,49 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import _ from 'lodash'
+
+// Components
+import LoadDataNavigation from 'src/settings/components/LoadDataNavigation'
+import {
+  Tabs,
+  Orientation,
+  ComponentSize,
+  InfluxColors,
+} from '@influxdata/clockface'
+import {Page} from 'src/pageLayout'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  activeTab: string
+  orgID: string
+}
+
+@ErrorHandling
+class LoadDataTabbedPage extends PureComponent<Props> {
+  public render() {
+    const {activeTab, orgID, children} = this.props
+
+    return (
+      <Page.Contents fullWidth={false} scrollable={true}>
+        <div className="col-xs-12">
+          <Tabs.Container
+            orientation={Orientation.Horizontal}
+            className="tabs tabbed-page"
+          >
+            <LoadDataNavigation activeTab={activeTab} orgID={orgID} />
+            <Tabs.TabContents
+              padding={ComponentSize.Large}
+              backgroundColor={InfluxColors.Castle}
+            >
+              {children}
+            </Tabs.TabContents>
+          </Tabs.Container>
+        </div>
+      </Page.Contents>
+    )
+  }
+}
+
+export default LoadDataTabbedPage

--- a/ui/src/settings/components/SettingsNavigation.tsx
+++ b/ui/src/settings/components/SettingsNavigation.tsx
@@ -67,7 +67,7 @@ class SettingsNavigation extends PureComponent<Props> {
 
     return (
       <Tabs
-        orientation={Orientation.Vertical}
+        orientation={Orientation.Horizontal}
         padding={ComponentSize.Large}
         backgroundColor={`${chroma(`${InfluxColors.Castle}`).alpha(0.1)}`}
       >
@@ -80,7 +80,7 @@ class SettingsNavigation extends PureComponent<Props> {
                   id={t.id}
                   onClick={handleTabClick}
                   active={t.id === activeTab}
-                  size={ComponentSize.Medium}
+                  size={ComponentSize.Large}
                   backgroundColor={InfluxColors.Castle}
                 />
               </CloudExclude>
@@ -93,7 +93,7 @@ class SettingsNavigation extends PureComponent<Props> {
               id={t.id}
               onClick={handleTabClick}
               active={t.id === activeTab}
-              size={ComponentSize.Medium}
+              size={ComponentSize.Large}
               backgroundColor={InfluxColors.Castle}
             />
           )

--- a/ui/src/settings/components/SettingsTabbedPage.tsx
+++ b/ui/src/settings/components/SettingsTabbedPage.tsx
@@ -29,7 +29,7 @@ class SettingsTabbedPage extends PureComponent<Props> {
       <Page.Contents fullWidth={false} scrollable={true}>
         <div className="col-xs-12">
           <Tabs.Container
-            orientation={Orientation.Vertical}
+            orientation={Orientation.Horizontal}
             className="tabs tabbed-page"
           >
             <SettingsNavigation activeTab={activeTab} orgID={orgID} />

--- a/ui/src/shared/components/DeleteDataOverlay.tsx
+++ b/ui/src/shared/components/DeleteDataOverlay.tsx
@@ -19,7 +19,7 @@ const DeleteDataOverlay: FunctionComponent<StateProps & WithRouterProps> = ({
   params: {orgID, bucketID},
   buckets,
 }) => {
-  const handleDismiss = () => router.push(`/orgs/${orgID}/buckets/${bucketID}`)
+  const handleDismiss = () => router.push(`/orgs/${orgID}/load-data/buckets/${bucketID}`)
   const bucketName = buckets.find(bucket => bucket.id === bucketID).name
 
   return (

--- a/ui/src/shared/components/DeleteDataOverlay.tsx
+++ b/ui/src/shared/components/DeleteDataOverlay.tsx
@@ -19,7 +19,8 @@ const DeleteDataOverlay: FunctionComponent<StateProps & WithRouterProps> = ({
   params: {orgID, bucketID},
   buckets,
 }) => {
-  const handleDismiss = () => router.push(`/orgs/${orgID}/load-data/buckets/${bucketID}`)
+  const handleDismiss = () =>
+    router.push(`/orgs/${orgID}/load-data/buckets/${bucketID}`)
   const bucketName = buckets.find(bucket => bucket.id === bucketID).name
 
   return (

--- a/ui/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/ui/src/telegrafs/containers/TelegrafsPage.tsx
@@ -4,8 +4,8 @@ import {connect} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import SettingsTabbedPage from 'src/settings/components/SettingsTabbedPage'
-import SettingsHeader from 'src/settings/components/SettingsHeader'
+import LoadDataTabbedPage from 'src/settings/components/LoadDataTabbedPage'
+import LoadDataHeader from 'src/settings/components/LoadDataHeader'
 import {Page} from 'src/pageLayout'
 import Collectors from 'src/telegrafs/components/Collectors'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
@@ -25,14 +25,14 @@ class TelegrafsPage extends PureComponent<StateProps> {
     return (
       <>
         <Page titleTag={org.name}>
-          <SettingsHeader />
-          <SettingsTabbedPage activeTab="telegrafs" orgID={org.id}>
+          <LoadDataHeader />
+          <LoadDataTabbedPage activeTab="telegrafs" orgID={org.id}>
             <GetResources resource={ResourceTypes.Buckets}>
               <GetResources resource={ResourceTypes.Telegrafs}>
                 <Collectors />
               </GetResources>
             </GetResources>
-          </SettingsTabbedPage>
+          </LoadDataTabbedPage>
         </Page>
         {children}
       </>


### PR DESCRIPTION
- Create `Load Data` tab
- Move `Buckets`, `Telegrafs`,  and `Scrapers` from settings into load data
- Extend URL activator utility to scan URLs of any length
- Change orientation of tabs in settings page to be horizontal

![Screen Shot 2019-08-19 at 11 28 35 AM](https://user-images.githubusercontent.com/2433762/63289763-bd557500-c274-11e9-9992-67e2eea08970.png)

Created this issue: https://github.com/influxdata/influxdb/issues/14708

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
