### PR TITLE
chore(http): split taskservice from check and notification

### DIFF
--- a/check.go
+++ b/check.go
@@ -43,7 +43,6 @@ type CheckService interface {
 	UserResourceMappingService
 	// OrganizationService is needed for search filter
 	OrganizationService
-	TaskService
 
 	// FindCheckByID returns a single check by ID.
 	FindCheckByID(ctx context.Context, id ID) (Check, error)

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -167,6 +167,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	notificationRuleBackend := NewNotificationRuleBackend(b)
 	notificationRuleBackend.NotificationRuleStore = authorizer.NewNotificationRuleStore(b.NotificationRuleStore,
 		b.UserResourceMappingService, b.OrganizationService)
+	notificationRuleBackend.TaskService = b.TaskService
 	h.NotificationRuleHandler = NewNotificationRuleHandler(notificationRuleBackend)
 
 	notificationEndpointBackend := NewNotificationEndpointBackend(b)
@@ -177,6 +178,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	checkBackend := NewCheckBackend(b)
 	checkBackend.CheckService = authorizer.NewCheckService(b.CheckService,
 		b.UserResourceMappingService, b.OrganizationService)
+	checkBackend.TaskService = b.TaskService
 	h.CheckHandler = NewCheckHandler(checkBackend)
 
 	writeBackend := NewWriteBackend(b)

--- a/http/check_service.go
+++ b/http/check_service.go
@@ -21,6 +21,7 @@ type CheckBackend struct {
 	Logger *zap.Logger
 
 	CheckService               influxdb.CheckService
+	TaskService                influxdb.TaskService
 	UserResourceMappingService influxdb.UserResourceMappingService
 	LabelService               influxdb.LabelService
 	UserService                influxdb.UserService
@@ -48,6 +49,7 @@ type CheckHandler struct {
 	Logger *zap.Logger
 
 	CheckService               influxdb.CheckService
+	TaskService                influxdb.TaskService
 	UserResourceMappingService influxdb.UserResourceMappingService
 	LabelService               influxdb.LabelService
 	UserService                influxdb.UserService
@@ -73,6 +75,7 @@ func NewCheckHandler(b *CheckBackend) *CheckHandler {
 		Logger:           b.Logger,
 
 		CheckService:               b.CheckService,
+		TaskService:                b.TaskService,
 		UserResourceMappingService: b.UserResourceMappingService,
 		LabelService:               b.LabelService,
 		UserService:                b.UserService,
@@ -378,6 +381,41 @@ func decodePatchCheckRequest(ctx context.Context, r *http.Request) (*patchCheckR
 	return req, nil
 }
 
+func createCheckTask(ctx context.Context, s influxdb.TaskService, c influxdb.Check) error {
+	if c.GetStatus() == influxdb.Inactive {
+		return nil
+	}
+	script, err := c.GenerateFlux()
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	tc := influxdb.TaskCreate{
+		Type:           c.Type(),
+		Flux:           script,
+		OwnerID:        c.GetOwnerID(),
+		OrganizationID: c.GetOrgID(),
+	}
+	t, err := s.CreateTask(ctx, tc)
+	if err != nil {
+		return err
+	}
+	c.SetTaskID(t.ID)
+
+	return nil
+}
+
+func removeCheckTask(ctx context.Context, s influxdb.TaskService, c influxdb.Check) error {
+	err := s.DeleteTask(ctx, c.GetTaskID())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // handlePostCheck is the HTTP handler for the POST /api/v2/checks route.
 func (h *CheckHandler) handlePostCheck(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -385,6 +423,10 @@ func (h *CheckHandler) handlePostCheck(w http.ResponseWriter, r *http.Request) {
 	chk, err := decodePostCheckRequest(ctx, r)
 	if err != nil {
 		h.Logger.Debug("failed to decode request", zap.Error(err))
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+	if err := createCheckTask(ctx, h.TaskService, chk); err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
@@ -418,6 +460,16 @@ func (h *CheckHandler) handlePutCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err = removeCheckTask(ctx, h.TaskService, chk); err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+
+	if err = createCheckTask(ctx, h.TaskService, chk); err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+
 	chk, err = h.CheckService.UpdateCheck(ctx, chk.GetID(), chk)
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
@@ -446,6 +498,18 @@ func (h *CheckHandler) handlePatchCheck(w http.ResponseWriter, r *http.Request) 
 		h.Logger.Debug("failed to decode request", zap.Error(err))
 		h.HandleHTTPError(ctx, err, w)
 		return
+	}
+
+	if req.Update.Status != nil && *req.Update.Status == influxdb.Inactive {
+		chk, err := h.CheckService.FindCheckByID(ctx, req.ID)
+		if err != nil {
+			h.HandleHTTPError(ctx, err, w)
+			return
+		}
+		if err = removeCheckTask(ctx, h.TaskService, chk); err != nil {
+			h.HandleHTTPError(ctx, err, w)
+			return
+		}
 	}
 
 	chk, err := h.CheckService.PatchCheck(ctx, req.ID, req.Update)

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -28,6 +28,7 @@ func NewMockCheckBackend() *CheckBackend {
 		Logger: zap.NewNop().With(zap.String("handler", "check")),
 
 		CheckService:               mock.NewCheckService(),
+		TaskService:                &mock.TaskService{},
 		UserResourceMappingService: mock.NewUserResourceMappingService(),
 		LabelService:               mock.NewLabelService(),
 		UserService:                mock.NewUserService(),
@@ -468,6 +469,7 @@ func TestService_handleGetCheck(t *testing.T) {
 func TestService_handlePostCheck(t *testing.T) {
 	type fields struct {
 		CheckService        influxdb.CheckService
+		TaskService         influxdb.TaskService
 		OrganizationService influxdb.OrganizationService
 	}
 	type args struct {
@@ -489,6 +491,11 @@ func TestService_handlePostCheck(t *testing.T) {
 		{
 			name: "create a new check",
 			fields: fields{
+				TaskService: &mock.TaskService{
+					CreateTaskFn: func(ctx context.Context, tc influxdb.TaskCreate) (*influxdb.Task, error) {
+						return &influxdb.Task{ID: 3}, nil
+					},
+				},
 				CheckService: &mock.CheckService{
 					CreateCheckFn: func(ctx context.Context, c influxdb.Check, userID influxdb.ID) error {
 						c.SetID(influxTesting.MustIDBase16("020f755c3c082000"))
@@ -582,6 +589,7 @@ func TestService_handlePostCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend()
+			checkBackend.TaskService = tt.fields.TaskService
 			checkBackend.CheckService = tt.fields.CheckService
 			checkBackend.OrganizationService = tt.fields.OrganizationService
 			h := NewCheckHandler(checkBackend)
@@ -891,6 +899,7 @@ func TestService_handlePatchCheck(t *testing.T) {
 
 func TestService_handleUpdateCheck(t *testing.T) {
 	type fields struct {
+		TaskService  influxdb.TaskService
 		CheckService influxdb.CheckService
 	}
 	type args struct {
@@ -912,7 +921,15 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		{
 			name: "update a check name",
 			fields: fields{
-				&mock.CheckService{
+				TaskService: &mock.TaskService{
+					CreateTaskFn: func(ctx context.Context, tc influxdb.TaskCreate) (*influxdb.Task, error) {
+						return &influxdb.Task{ID: 3}, nil
+					},
+					DeleteTaskFn: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+				CheckService: &mock.CheckService{
 					UpdateCheckFn: func(ctx context.Context, id influxdb.ID, chk influxdb.Check) (influxdb.Check, error) {
 						if id == influxTesting.MustIDBase16("020f755c3c082000") {
 							d := &check.Deadman{
@@ -991,7 +1008,15 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		{
 			name: "check not found",
 			fields: fields{
-				&mock.CheckService{
+				TaskService: &mock.TaskService{
+					CreateTaskFn: func(ctx context.Context, tc influxdb.TaskCreate) (*influxdb.Task, error) {
+						return &influxdb.Task{ID: 3}, nil
+					},
+					DeleteTaskFn: func(ctx context.Context, id influxdb.ID) error {
+						return nil
+					},
+				},
+				CheckService: &mock.CheckService{
 					UpdateCheckFn: func(ctx context.Context, id influxdb.ID, chk influxdb.Check) (influxdb.Check, error) {
 						return nil, &influxdb.Error{
 							Code: influxdb.ENotFound,
@@ -1018,6 +1043,7 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend()
 			checkBackend.HTTPErrorHandler = ErrorHandler(0)
+			checkBackend.TaskService = tt.fields.TaskService
 			checkBackend.CheckService = tt.fields.CheckService
 			h := NewCheckHandler(checkBackend)
 

--- a/kv/check.go
+++ b/kv/check.go
@@ -323,13 +323,6 @@ func (s *Service) createCheck(ctx context.Context, tx Tx, c influxdb.Check, user
 	c.SetCreatedAt(s.Now())
 	c.SetUpdatedAt(s.Now())
 
-	t, err := s.createCheckTask(ctx, tx, c)
-	if err != nil {
-		return err
-	}
-
-	c.SetTaskID(t.ID)
-
 	if err := s.putCheck(ctx, tx, c); err != nil {
 		return err
 	}
@@ -338,27 +331,6 @@ func (s *Service) createCheck(ctx context.Context, tx Tx, c influxdb.Check, user
 		return err
 	}
 	return nil
-}
-
-func (s *Service) createCheckTask(ctx context.Context, tx Tx, c influxdb.Check) (*influxdb.Task, error) {
-	script, err := c.GenerateFlux()
-	if err != nil {
-		return nil, err
-	}
-
-	tc := influxdb.TaskCreate{
-		Type:           c.Type(),
-		Flux:           script,
-		OwnerID:        c.GetOwnerID(),
-		OrganizationID: c.GetOrgID(),
-	}
-
-	t, err := s.createTask(ctx, tx, tc)
-	if err != nil {
-		return nil, err
-	}
-
-	return t, nil
 }
 
 // PutCheck will put a check without setting an ID.
@@ -571,19 +543,9 @@ func (s *Service) updateCheck(ctx context.Context, tx Tx, id influxdb.ID, chk in
 		}
 	}
 
-	if err := s.deleteTask(ctx, tx, chk.GetTaskID()); err != nil {
-		return nil, err
-	}
-
 	chk.SetOwnerID(current.GetOwnerID())
 
-	t, err := s.createCheckTask(ctx, tx, chk)
-	if err != nil {
-		return nil, err
-	}
-
 	// ID and OrganizationID can not be updated
-	chk.SetTaskID(t.ID)
 	chk.SetID(current.GetID())
 	chk.SetOrgID(current.GetOrgID())
 	chk.SetCreatedAt(current.GetCRUDLog().CreatedAt)
@@ -697,10 +659,6 @@ func (s *Service) deleteCheck(ctx context.Context, tx Tx, id influxdb.ID) error 
 	c, pe := s.findCheckByID(ctx, tx, id)
 	if pe != nil {
 		return pe
-	}
-
-	if err := s.deleteTask(ctx, tx, c.GetTaskID()); err != nil {
-		return err
 	}
 
 	key, pe := checkIndexKey(c.GetOrgID(), c.GetName())

--- a/kv/check_test.go
+++ b/kv/check_test.go
@@ -70,11 +70,6 @@ func initCheckService(s kv.Store, f influxdbtesting.CheckFields, t *testing.T) (
 			t.Fatalf("failed to populate checks")
 		}
 	}
-	for _, tc := range f.Tasks {
-		if _, err := svc.CreateTask(ctx, tc); err != nil {
-			t.Fatalf("failed to populate tasks: %v", err)
-		}
-	}
 	return svc, kv.OpPrefix, func() {
 		for _, o := range f.Organizations {
 			if err := svc.DeleteOrganization(ctx, o.ID); err != nil {

--- a/kv/notification_rule_test.go
+++ b/kv/notification_rule_test.go
@@ -74,12 +74,6 @@ func initNotificationRuleStore(s kv.Store, f influxdbtesting.NotificationRuleFie
 		}
 	}
 
-	for _, c := range f.Tasks {
-		if _, err := svc.CreateTask(ctx, c); err != nil {
-			t.Fatalf("failed to populate task: %v", err)
-		}
-	}
-
 	return svc, func() {
 		for _, nr := range f.NotificationRules {
 			if err := svc.DeleteNotificationRule(ctx, nr.GetID()); err != nil {

--- a/mock/check_service.go
+++ b/mock/check_service.go
@@ -11,7 +11,6 @@ import (
 type CheckService struct {
 	OrganizationService
 	UserResourceMappingService
-	TaskService
 
 	// Methods for an influxdb.CheckService
 	FindCheckByIDFn func(context.Context, influxdb.ID) (influxdb.Check, error)

--- a/testing/checks.go
+++ b/testing/checks.go
@@ -111,7 +111,6 @@ type CheckFields struct {
 	Checks               []influxdb.Check
 	Organizations        []*influxdb.Organization
 	UserResourceMappings []*influxdb.UserResourceMapping
-	Tasks                []influxdb.TaskCreate
 }
 
 type checkServiceF func(
@@ -869,14 +868,6 @@ func DeleteCheck(
 						ID:   MustIDBase16(orgOneID),
 					},
 				},
-				Tasks: []influxdb.TaskCreate{
-					{
-						Flux: `option task = { every: 10s, name: "foo" }
-data = from(bucket: "telegraf") |> range(start: -1m)`,
-						OrganizationID: MustIDBase16(orgOneID),
-						OwnerID:        MustIDBase16(sixID),
-					},
-				},
 				Checks: []influxdb.Check{
 					deadman1,
 					threshold1,
@@ -899,14 +890,6 @@ data = from(bucket: "telegraf") |> range(start: -1m)`,
 					{
 						Name: "theorg",
 						ID:   MustIDBase16(orgOneID),
-					},
-				},
-				Tasks: []influxdb.TaskCreate{
-					{
-						Flux: `option task = { every: 10s, name: "foo" }
-data = from(bucket: "telegraf") |> range(start: -1m)`,
-						OrganizationID: MustIDBase16(orgOneID),
-						OwnerID:        MustIDBase16(sixID),
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1104,14 +1087,6 @@ func UpdateCheck(
 				},
 				Checks: []influxdb.Check{
 					deadman1,
-				},
-				Tasks: []influxdb.TaskCreate{
-					{
-						Flux: `option task = { every: 10s, name: "foo" }
-data = from(bucket: "telegraf") |> range(start: -1m)`,
-						OrganizationID: MustIDBase16(orgOneID),
-						OwnerID:        MustIDBase16(sixID),
-					},
 				},
 			},
 			args: args{

--- a/testing/notification_rule.go
+++ b/testing/notification_rule.go
@@ -20,7 +20,6 @@ type NotificationRuleFields struct {
 	NotificationRules    []influxdb.NotificationRule
 	Orgs                 []*influxdb.Organization
 	UserResourceMappings []*influxdb.UserResourceMapping
-	Tasks                []influxdb.TaskCreate
 }
 
 var notificationRuleCmpOptions = cmp.Options{
@@ -1397,15 +1396,6 @@ func UpdateNotificationRule(
 						ResourceType: influxdb.NotificationRuleResourceType,
 					},
 				},
-				Tasks: []influxdb.TaskCreate{
-					{
-						OwnerID:        MustIDBase16(sixID),
-						OrganizationID: MustIDBase16(fourID),
-						Flux: `from(bucket: "foo") |> range(start: -1m)
-						option task = {name: "bar", every: 1m}
-						`,
-					},
-				},
 				Orgs: []*influxdb.Organization{
 					{
 						ID:   MustIDBase16(fourID),
@@ -1868,15 +1858,6 @@ func DeleteNotificationRule(
 						ResourceType: influxdb.NotificationRuleResourceType,
 					},
 				},
-				Tasks: []influxdb.TaskCreate{
-					{
-						OwnerID:        MustIDBase16(sixID),
-						OrganizationID: MustIDBase16(fourID),
-						Flux: `from(bucket: "foo") |> range(start: -1m)
-						option task = {name: "bar", every: 1m}
-						`,
-					},
-				},
 				IDGenerator: mock.NewIDGenerator(twoID, t),
 				Orgs: []*influxdb.Organization{
 					{
@@ -2004,15 +1985,6 @@ func DeleteNotificationRule(
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Member,
 						ResourceType: influxdb.NotificationRuleResourceType,
-					},
-				},
-				Tasks: []influxdb.TaskCreate{
-					{
-						OwnerID:        MustIDBase16(sixID),
-						OrganizationID: MustIDBase16(fourID),
-						Flux: `from(bucket: "foo") |> range(start: -1m)
-						option task = {name: "bar", every: 1m}
-						`,
 					},
 				},
 				IDGenerator: mock.NewIDGenerator(twoID, t),


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/14710

remove the task service of checks and notifications from kv, add them in http controller
Todo: figure out a way to make two service in one transaction

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
