### PR TITLE
chore(storage): remove metric storage_retention_checks_total

### DIFF
--- a/storage/metrics.go
+++ b/storage/metrics.go
@@ -35,7 +35,6 @@ const retentionSubsystem = "retention" // sub-system associated with metrics for
 // retentionMetrics is a set of metrics concerned with tracking data about retention policies.
 type retentionMetrics struct {
 	labels        prometheus.Labels
-	Checks        *prometheus.CounterVec
 	CheckDuration *prometheus.HistogramVec
 }
 
@@ -46,21 +45,11 @@ func newRetentionMetrics(labels prometheus.Labels) *retentionMetrics {
 	}
 	sort.Strings(names)
 
-	checksNames := append(append([]string(nil), names...), "status", "org_id", "bucket_id")
-	sort.Strings(checksNames)
-
 	checkDurationNames := append(append([]string(nil), names...), "status")
 	sort.Strings(checkDurationNames)
 
 	return &retentionMetrics{
 		labels: labels,
-		Checks: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: retentionSubsystem,
-			Name:      "checks_total",
-			Help:      "Number of retention check operations performed by org/bucket id.",
-		}, checksNames),
-
 		CheckDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: retentionSubsystem,
@@ -84,7 +73,6 @@ func (m *retentionMetrics) Labels() prometheus.Labels {
 // PrometheusCollectors satisfies the prom.PrometheusCollector interface.
 func (rm *retentionMetrics) PrometheusCollectors() []prometheus.Collector {
 	return []prometheus.Collector{
-		rm.Checks,
 		rm.CheckDuration,
 	}
 }

--- a/storage/retention.go
+++ b/storage/retention.go
@@ -146,7 +146,6 @@ func (s *retentionEnforcer) expireData(ctx context.Context, buckets []*influxdb.
 				zap.Error(err))
 			tracing.LogError(span, err)
 		}
-		s.tracker.IncChecks(b.OrgID, b.ID, err == nil)
 
 		span.Finish()
 	}
@@ -181,21 +180,6 @@ func (t *retentionTracker) Labels() prometheus.Labels {
 		l[k] = v
 	}
 	return l
-}
-
-// IncChecks signals that a check happened for some bucket.
-func (t *retentionTracker) IncChecks(orgID, bucketID influxdb.ID, success bool) {
-	labels := t.Labels()
-	labels["org_id"] = orgID.String()
-	labels["bucket_id"] = bucketID.String()
-
-	if success {
-		labels["status"] = "ok"
-	} else {
-		labels["status"] = "error"
-	}
-
-	t.metrics.Checks.With(labels).Inc()
 }
 
 // CheckDuration records the overall duration of a full retention check.


### PR DESCRIPTION
Fixes https://github.com/influxdata/idpe/issues/4366

When many buckets are hosted in a single InfluxDB instance, cardinality for the storage_retention_checks_total measurement becomes a material burden. The metric doesn't seem to be valuable, so we'll remove it.