### PR TITLE
docs(http): update suggestions swagger definition to reflect reality

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -2865,7 +2865,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FluxSuggestions"
+                $ref: "#/components/schemas/FluxSuggestion"
         default:
           description: Any response other than 200 is an internal server error
           content:
@@ -6728,12 +6728,18 @@ components:
       type: object
       properties:
         funcs:
+          type: array
+          items:
+            $ref: "#/components/schemas/FluxSuggestion"
+    FluxSuggestion:
+      type: object
+      properties:
+        name:
+          type: string
+        params:
           type: object
-          properties:
-            name:
-              type: string
-            params:
-              type: object
+          additionalProperties:
+            type: string
     Routes:
       properties:
         authorizations:


### PR DESCRIPTION
Closes #13368

The `FluxSuggestions` schema is defined as:

```yaml
FluxSuggestions:
      type: object
      properties:
        funcs:
          type: object
          properties:
            name:
              type: string
            params:
              type: object
```

but go implementation has a structure:

```go
// fluxParams contain flux funciton parameters as defined by the semantic graph
type fluxParams map[string]string

// suggestionResponse provides the parameters available for a given Flux function
type suggestionResponse struct {
	Name   string     `json:"name"`
	Params fluxParams `json:"params"`
}

// suggestionsResponse provides a list of available Flux functions
type suggestionsResponse struct {
	Functions []suggestionResponse `json:"funcs"`
}
```

The `FluxSuggestions` should be defined as:

```yaml
FluxSuggestions:
      type: object
      properties:
        funcs:
          type: array
          items:
            $ref: "#/components/schemas/FluxSuggestion"
FluxSuggestion:
      type: object
      properties:
        name:
          type: string
        params:
          type: object
          additionalProperties:
            type: string
```

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)