### PR TITLE
refactor(storage): add deeper tracing around deletes

### DIFF
--- a/storage/bucket_service.go
+++ b/storage/bucket_service.go
@@ -10,7 +10,7 @@ import (
 
 // BucketDeleter defines the behaviour of deleting a bucket.
 type BucketDeleter interface {
-	DeleteBucket(platform.ID, platform.ID) error
+	DeleteBucket(context.Context, platform.ID, platform.ID) error
 }
 
 // BucketService wraps an existing platform.BucketService implementation.
@@ -102,7 +102,7 @@ func (s *BucketService) DeleteBucket(ctx context.Context, bucketID platform.ID) 
 	// The data is dropped first from the storage engine. If this fails for any
 	// reason, then the bucket will still be available in the future to retrieve
 	// the orgID, which is needed for the engine.
-	if err := s.engine.DeleteBucket(bucket.OrgID, bucketID); err != nil {
+	if err := s.engine.DeleteBucket(ctx, bucket.OrgID, bucketID); err != nil {
 		return err
 	}
 	return s.inner.DeleteBucket(ctx, bucketID)

--- a/storage/bucket_service_test.go
+++ b/storage/bucket_service_test.go
@@ -57,7 +57,7 @@ type MockDeleter struct {
 	orgID, bucketID platform.ID
 }
 
-func (m *MockDeleter) DeleteBucket(orgID, bucketID platform.ID) error {
+func (m *MockDeleter) DeleteBucket(_ context.Context, orgID, bucketID platform.ID) error {
 	m.orgID, m.bucketID = orgID, bucketID
 	return nil
 }

--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -244,7 +244,7 @@ func TestEngine_DeleteBucket(t *testing.T) {
 	}
 
 	// Remove the original bucket.
-	if err := engine.DeleteBucket(engine.org, engine.bucket); err != nil {
+	if err := engine.DeleteBucket(context.Background(), engine.org, engine.bucket); err != nil {
 		t.Fatal(err)
 	}
 
@@ -309,7 +309,7 @@ func TestEngine_DeleteBucket_Predicate(t *testing.T) {
 	}
 
 	// Remove the matching series.
-	if err := engine.DeleteBucketRangePredicate(engine.org, engine.bucket,
+	if err := engine.DeleteBucketRangePredicate(context.Background(), engine.org, engine.bucket,
 		math.MinInt64, math.MaxInt64, pred); err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +339,7 @@ func TestEngine_DeleteBucket_Predicate(t *testing.T) {
 	}
 
 	// Remove the matching series.
-	if err := engine.DeleteBucketRangePredicate(engine.org, engine.bucket,
+	if err := engine.DeleteBucketRangePredicate(context.Background(), engine.org, engine.bucket,
 		math.MinInt64, math.MaxInt64, pred); err != nil {
 		t.Fatal(err)
 	}
@@ -508,7 +508,7 @@ func BenchmarkDeleteBucket(b *testing.B) {
 		b.Run(fmt.Sprintf("cardinality_%d", card), func(b *testing.B) {
 			setup(card)
 			for i := 0; i < b.N; i++ {
-				if err := engine.DeleteBucket(engine.org, engine.bucket); err != nil {
+				if err := engine.DeleteBucket(context.Background(), engine.org, engine.bucket); err != nil {
 					b.Fatal(err)
 				}
 

--- a/storage/retention_test.go
+++ b/storage/retention_test.go
@@ -58,7 +58,7 @@ func TestRetentionService(t *testing.T) {
 	}
 
 	gotMatched := map[string]struct{}{}
-	engine.DeleteBucketRangeFn = func(orgID, bucketID influxdb.ID, from, to int64) error {
+	engine.DeleteBucketRangeFn = func(ctx context.Context, orgID, bucketID influxdb.ID, from, to int64) error {
 		if from != math.MinInt64 {
 			t.Fatalf("got from %d, expected %d", from, math.MinInt64)
 		}
@@ -144,17 +144,17 @@ func genMeasurementName() []byte {
 }
 
 type TestEngine struct {
-	DeleteBucketRangeFn func(influxdb.ID, influxdb.ID, int64, int64) error
+	DeleteBucketRangeFn func(context.Context, influxdb.ID, influxdb.ID, int64, int64) error
 }
 
 func NewTestEngine() *TestEngine {
 	return &TestEngine{
-		DeleteBucketRangeFn: func(influxdb.ID, influxdb.ID, int64, int64) error { return nil },
+		DeleteBucketRangeFn: func(context.Context, influxdb.ID, influxdb.ID, int64, int64) error { return nil },
 	}
 }
 
-func (e *TestEngine) DeleteBucketRange(orgID, bucketID influxdb.ID, min, max int64) error {
-	return e.DeleteBucketRangeFn(orgID, bucketID, min, max)
+func (e *TestEngine) DeleteBucketRange(ctx context.Context, orgID, bucketID influxdb.ID, min, max int64) error {
+	return e.DeleteBucketRangeFn(ctx, orgID, bucketID, min, max)
 }
 
 type TestSnapshotter struct{}

--- a/tsdb/tsm1/cache_test.go
+++ b/tsdb/tsm1/cache_test.go
@@ -1,6 +1,7 @@
 package tsm1
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -176,7 +177,7 @@ func TestCache_Cache_DeleteBucketRange(t *testing.T) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteBucketRange([]byte("bar"), 2, math.MaxInt64, nil)
+	c.DeleteBucketRange(context.Background(), []byte("bar"), 2, math.MaxInt64, nil)
 
 	if exp, keys := [][]byte{[]byte("bar"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after delete, exp %v, got %v", exp, keys)
@@ -215,7 +216,7 @@ func TestCache_DeleteBucketRange_NoValues(t *testing.T) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteBucketRange([]byte("foo"), math.MinInt64, math.MaxInt64, nil)
+	c.DeleteBucketRange(context.Background(), []byte("foo"), math.MinInt64, math.MaxInt64, nil)
 
 	if exp, keys := 0, len(c.Keys()); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
@@ -250,7 +251,7 @@ func TestCache_DeleteBucketRange_NotSorted(t *testing.T) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteBucketRange([]byte("foo"), 1, 3, nil)
+	c.DeleteBucketRange(context.Background(), []byte("foo"), 1, 3, nil)
 
 	if exp, keys := 0, len(c.Keys()); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after delete, exp %v, got %v", exp, keys)
@@ -268,7 +269,7 @@ func TestCache_DeleteBucketRange_NotSorted(t *testing.T) {
 func TestCache_DeleteBucketRange_NonExistent(t *testing.T) {
 	c := NewCache(1024)
 
-	c.DeleteBucketRange([]byte("bar"), math.MinInt64, math.MaxInt64, nil)
+	c.DeleteBucketRange(context.Background(), []byte("bar"), math.MinInt64, math.MaxInt64, nil)
 
 	if got, exp := c.Size(), uint64(0); exp != got {
 		t.Fatalf("cache size incorrect exp %d, got %d", exp, got)
@@ -300,7 +301,7 @@ func TestCache_Cache_DeleteBucketRange_WithPredicate(t *testing.T) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteBucketRange([]byte("f"), 2, math.MaxInt64, stringPredicate("fee"))
+	c.DeleteBucketRange(context.Background(), []byte("f"), 2, math.MaxInt64, stringPredicate("fee"))
 
 	if exp, keys := [][]byte{[]byte("fee"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after delete, exp %v, got %v", exp, keys)

--- a/tsdb/tsm1/engine_delete_prefix_test.go
+++ b/tsdb/tsm1/engine_delete_prefix_test.go
@@ -3,11 +3,11 @@ package tsm1_test
 import (
 	"bytes"
 	"context"
-	"github.com/influxdata/influxdb/tsdb/tsm1"
 	"reflect"
 	"testing"
 
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb/tsm1"
 )
 
 func TestEngine_DeletePrefix(t *testing.T) {
@@ -43,7 +43,7 @@ func TestEngine_DeletePrefix(t *testing.T) {
 		t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
 	}
 
-	if err := e.DeletePrefixRange([]byte("mm0"), 0, 3, nil); err != nil {
+	if err := e.DeletePrefixRange(context.Background(), []byte("mm0"), 0, 3, nil); err != nil {
 		t.Fatalf("failed to delete series: %v", err)
 	}
 
@@ -89,7 +89,7 @@ func TestEngine_DeletePrefix(t *testing.T) {
 	iter.Close()
 
 	// Deleting remaining series should remove them from the series.
-	if err := e.DeletePrefixRange([]byte("mm0"), 0, 9, nil); err != nil {
+	if err := e.DeletePrefixRange(context.Background(), []byte("mm0"), 0, 9, nil); err != nil {
 		t.Fatalf("failed to delete series: %v", err)
 	}
 

--- a/tsdb/tsm1/engine_test.go
+++ b/tsdb/tsm1/engine_test.go
@@ -61,7 +61,7 @@ func TestIndex_SeriesIDSet(t *testing.T) {
 
 	// Drop all the series for the gpu measurement and they should no longer
 	// be in the series ID set.
-	if err := engine.DeletePrefixRange([]byte("gpu"), math.MinInt64, math.MaxInt64, nil); err != nil {
+	if err := engine.DeletePrefixRange(context.Background(), []byte("gpu"), math.MinInt64, math.MaxInt64, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -485,7 +485,7 @@ func (e *Engine) MustDeleteBucketRange(orgID, bucketID influxdb.ID, min, max int
 	encoded := tsdb.EncodeName(orgID, bucketID)
 	name := models.EscapeMeasurement(encoded[:])
 
-	err := e.DeletePrefixRange(name, min, max, nil)
+	err := e.DeletePrefixRange(context.Background(), name, min, max, nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR adds some deeper tracing around deletes in the storage engine. The main use-case is for helping with performance work around deletes.