### PR TITLE
feat(query): wrap the secret service for flux

### DIFF
--- a/query/dependency_test.go
+++ b/query/dependency_test.go
@@ -1,0 +1,33 @@
+package query_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/mock"
+	"github.com/influxdata/influxdb/query"
+)
+
+func TestSecretLookup(t *testing.T) {
+	req := &query.Request{OrganizationID: orgID}
+	ctx := query.ContextWithRequest(context.Background(), req)
+	svc := &mock.SecretService{
+		LoadSecretFn: func(ctx context.Context, orgID influxdb.ID, k string) (string, error) {
+			if want, got := req.OrganizationID, orgID; want != got {
+				t.Errorf("unexpected organization id -want/+got:\n\t- %v\n\t+ %v", want, got)
+			}
+			if want, got := "mysecret", k; want != got {
+				t.Errorf("unexpected secret key -want/+got:\n\t- %v\n\t+ %v", want, got)
+			}
+			return "mypassword", nil
+		},
+	}
+
+	dep := query.FromSecretService(svc)
+	if val, err := dep.LoadSecret(ctx, "mysecret"); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if want, got := "mypassword", val; want != got {
+		t.Errorf("unexpected secret value -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+}


### PR DESCRIPTION
The secret service is wrapped to be compatible with the flux interface
to the secret service.

The organization id is not part of the flux interface so this code
extracts the organization id from the query context so that it can lookup
a secret within the organization.

influxdata/flux#1680