### PR TITLE
fix(launcher): print inspect as a subcommand when running with --help flag

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -18,6 +18,7 @@ import (
 	"github.com/influxdata/influxdb/authorizer"
 	"github.com/influxdata/influxdb/bolt"
 	"github.com/influxdata/influxdb/chronograf/server"
+	"github.com/influxdata/influxdb/cmd/influxd/inspect"
 	"github.com/influxdata/influxdb/gather"
 	"github.com/influxdata/influxdb/http"
 	"github.com/influxdata/influxdb/inmem"
@@ -189,6 +190,8 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 	}
 
 	cli.BindOptions(cmd, opts)
+	cmd.AddCommand(inspect.NewCommand())
+
 }
 
 // Launcher represents the main program execution.


### PR DESCRIPTION
Closes #13289

Add `inspect` as subcommand when `influxd --help` is run. Currently, only flags are printed when running `influxd --help` while only subcommands are printed when running `influxd help`.

This PR adds the `inspect` command to the list of available commands when running `influxd --help`. It would be simple to add the `generate` command to this list if that is desired as well.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
