### PR TITLE
fix(kv): fix createdAt and updatedAt logic

### DIFF
--- a/crud_log.go
+++ b/crud_log.go
@@ -28,6 +28,14 @@ func (log *CRUDLog) SetUpdatedAt(now time.Time) {
 	log.UpdatedAt = now
 }
 
+// UpdateTimestamps always sets UpdatedAt to now. If CreatedAt is unset, it will set it to now.
+func (log *CRUDLog) UpdateTimestamps(now time.Time) {
+	log.UpdatedAt = now
+	if log.CreatedAt.IsZero() {
+		log.CreatedAt = now
+	}
+}
+
 // TimeGenerator represents a generator for now.
 type TimeGenerator interface {
 	// Now creates the generated time.

--- a/inmem/bucket_service.go
+++ b/inmem/bucket_service.go
@@ -242,8 +242,9 @@ func (s *Service) CreateBucket(ctx context.Context, b *platform.Bucket) error {
 		}
 	}
 	b.ID = s.IDGenerator.ID()
-	b.CreatedAt = s.Now()
-	b.UpdatedAt = s.Now()
+	now := s.Now()
+	b.CreatedAt = now
+	b.UpdatedAt = now
 	return s.PutBucket(ctx, b)
 }
 

--- a/inmem/dashboard.go
+++ b/inmem/dashboard.go
@@ -129,8 +129,9 @@ func (s *Service) FindDashboards(ctx context.Context, filter platform.DashboardF
 // CreateDashboard implements platform.DashboardService interface.
 func (s *Service) CreateDashboard(ctx context.Context, d *platform.Dashboard) error {
 	d.ID = s.IDGenerator.ID()
-	d.Meta.CreatedAt = s.Now()
-	d.Meta.UpdatedAt = s.Now()
+	now := s.Now()
+	d.Meta.CreatedAt = now
+	d.Meta.UpdatedAt = now
 	err := s.PutDashboardWithMeta(ctx, d)
 	if err != nil {
 		return &platform.Error{

--- a/inmem/organization_service.go
+++ b/inmem/organization_service.go
@@ -190,8 +190,9 @@ func (s *Service) CreateOrganization(ctx context.Context, o *platform.Organizati
 		}
 	}
 	o.ID = s.IDGenerator.ID()
-	o.CreatedAt = s.Now()
-	o.UpdatedAt = s.Now()
+	now := s.Now()
+	o.CreatedAt = now
+	o.UpdatedAt = now
 	err := s.PutOrganization(ctx, o)
 	if err != nil {
 		return &platform.Error{

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -383,8 +383,9 @@ func (s *Service) createBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) e
 	}
 
 	b.ID = s.IDGenerator.ID()
-	b.CreatedAt = s.Now()
-	b.UpdatedAt = s.Now()
+	now := s.Now()
+	b.CreatedAt = now
+	b.UpdatedAt = now
 
 	if err := s.appendBucketEventToLog(ctx, tx, b.ID, bucketCreatedEvent); err != nil {
 		return &influxdb.Error{

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -383,9 +383,6 @@ func (s *Service) createBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) e
 	}
 
 	b.ID = s.IDGenerator.ID()
-	now := s.Now()
-	b.CreatedAt = now
-	b.UpdatedAt = now
 
 	if err := s.appendBucketEventToLog(ctx, tx, b.ID, bucketCreatedEvent); err != nil {
 		return &influxdb.Error{
@@ -446,6 +443,8 @@ func (s *Service) createBucketUserResourceMappings(ctx context.Context, tx Tx, b
 }
 
 func (s *Service) putBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) error {
+	b.UpdateTimestamps(s.Now())
+
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 

--- a/kv/dashboard.go
+++ b/kv/dashboard.go
@@ -300,8 +300,9 @@ func (s *Service) CreateDashboard(ctx context.Context, d *influxdb.Dashboard) er
 			return err
 		}
 
-		d.Meta.CreatedAt = s.Now()
-		d.Meta.UpdatedAt = s.Now()
+		now := s.Now()
+		d.Meta.CreatedAt = now
+		d.Meta.UpdatedAt = now
 
 		if err := s.putDashboardWithMeta(ctx, tx, d); err != nil {
 			return err

--- a/kv/document.go
+++ b/kv/document.go
@@ -348,8 +348,9 @@ func (i *DocumentIndex) GetAccessorsDocuments(ownerType string, ownerID influxdb
 
 func (s *Service) createDocument(ctx context.Context, tx Tx, ns string, d *influxdb.Document) error {
 	d.ID = s.IDGenerator.ID()
-	d.Meta.CreatedAt = s.Now()
-	d.Meta.UpdatedAt = s.Now()
+	now := s.Now()
+	d.Meta.CreatedAt = now
+	d.Meta.UpdatedAt = now
 	if err := s.putDocument(ctx, tx, ns, d); err != nil {
 		return err
 	}

--- a/kv/org.go
+++ b/kv/org.go
@@ -249,8 +249,9 @@ func (s *Service) createOrganization(ctx context.Context, tx Tx, o *influxdb.Org
 	}
 
 	o.ID = s.IDGenerator.ID()
-	o.CreatedAt = s.Now()
-	o.UpdatedAt = s.Now()
+	now := s.Now()
+	o.CreatedAt = now
+	o.UpdatedAt = now
 	if err := s.appendOrganizationEventToLog(ctx, tx, o.ID, organizationCreatedEvent); err != nil {
 		return &influxdb.Error{
 			Err: err,

--- a/kv/org.go
+++ b/kv/org.go
@@ -249,9 +249,6 @@ func (s *Service) createOrganization(ctx context.Context, tx Tx, o *influxdb.Org
 	}
 
 	o.ID = s.IDGenerator.ID()
-	now := s.Now()
-	o.CreatedAt = now
-	o.UpdatedAt = now
 	if err := s.appendOrganizationEventToLog(ctx, tx, o.ID, organizationCreatedEvent); err != nil {
 		return &influxdb.Error{
 			Err: err,
@@ -278,6 +275,8 @@ func (s *Service) PutOrganization(ctx context.Context, o *influxdb.Organization)
 }
 
 func (s *Service) putOrganization(ctx context.Context, tx Tx, o *influxdb.Organization) error {
+	o.UpdateTimestamps(s.Now())
+
 	v, err := json.Marshal(o)
 	if err != nil {
 		return &influxdb.Error{
@@ -404,8 +403,6 @@ func (s *Service) updateOrganization(ctx context.Context, tx Tx, id influxdb.ID,
 	if upd.Description != nil {
 		o.Description = *upd.Description
 	}
-
-	o.UpdatedAt = s.Now()
 
 	if err := s.appendOrganizationEventToLog(ctx, tx, o.ID, organizationUpdatedEvent); err != nil {
 		return nil, &influxdb.Error{

--- a/kv/variable.go
+++ b/kv/variable.go
@@ -242,9 +242,6 @@ func (s *Service) CreateVariable(ctx context.Context, variable *influxdb.Variabl
 		if err := s.putVariableOrgsIndex(ctx, tx, variable); err != nil {
 			return err
 		}
-		now := s.Now()
-		variable.CreatedAt = now
-		variable.UpdatedAt = now
 		if pe := s.putVariable(ctx, tx, variable); pe != nil {
 			return &influxdb.Error{
 				Err: pe,
@@ -330,6 +327,8 @@ func (s *Service) removeVariableOrgsIndex(ctx context.Context, tx Tx, variable *
 }
 
 func (s *Service) putVariable(ctx context.Context, tx Tx, variable *influxdb.Variable) error {
+	variable.UpdateTimestamps(s.Now())
+
 	m, err := json.Marshal(variable)
 	if err != nil {
 		return &influxdb.Error{
@@ -369,7 +368,6 @@ func (s *Service) UpdateVariable(ctx context.Context, id influxdb.ID, update *in
 				Err: pe,
 			}
 		}
-		m.UpdatedAt = s.Now()
 		if err := update.Apply(m); err != nil {
 			return &influxdb.Error{
 				Err: err,


### PR DESCRIPTION
* moves timestamp logic into kv `put` methods to ensure that it always occurs, no matter how the object is created
* createdAt is only set the first time, but updatedAt is always updated
* createdAt and updatedAt now will have the same timestamp on creation
