### PR TITLE
feat(tsi1): port the dump-tsi tool to 2.x

### DIFF
--- a/cmd/influxd/inspect/dump_tsi1.go
+++ b/cmd/influxd/inspect/dump_tsi1.go
@@ -1,0 +1,138 @@
+// inspects low-level details about tsi1 files.
+package inspect
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"regexp"
+
+	"github.com/influxdata/influxdb/internal/fs"
+	"github.com/influxdata/influxdb/tsdb/tsi1"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+// Command represents the program execution for "influxd dumptsi".
+var measurementFilter, tagKeyFilter, tagValueFilter string
+var dumpTsiFlags = struct {
+	// Standard input/output, overridden for testing.
+	Stderr io.Writer
+	Stdout io.Writer
+
+	seriesFilePath string
+	dataPath       string
+
+	showSeries         bool
+	showMeasurements   bool
+	showTagKeys        bool
+	showTagValues      bool
+	showTagValueSeries bool
+
+	measurementFilter *regexp.Regexp
+	tagKeyFilter      *regexp.Regexp
+	tagValueFilter    *regexp.Regexp
+}{}
+
+// NewCommand returns a new instance of Command.
+func NewDumpTsiCommand() *cobra.Command {
+	dumpTsiCommand := &cobra.Command{
+		Use:   "dump-tsi",
+		Short: "Dump low level tsi information",
+		Long: `Dumps low-level details about tsi1 files.
+
+		Usage: influx_inspect dumptsi [flags] path...
+		
+			-series
+					Dump raw series data
+			-measurements
+					Dump raw measurement data
+			-tag-keys
+					Dump raw tag keys
+			-tag-values
+					Dump raw tag values
+			-tag-value-series
+					Dump raw series for each tag value
+			-measurement-filter REGEXP
+					Filters data by measurement regular expression
+			-series-file PATH
+					Path to the "_series" directory under the database data directory.
+					Required.
+			-tag-key-filter REGEXP
+					Filters data by tag key regular expression
+			-tag-value-filter REGEXP
+					Filters data by tag value regular expression
+		
+		One or more paths are required. Path must specify either a TSI index directory
+		or it should specify one or more .tsi/.tsl files. If no flags are specified
+		then summary stats are provided for each file.
+		`,
+		RunE: dumpTsi,
+	}
+	defaultDataDir, _ := fs.InfluxDir()
+	defaultDataDir = filepath.Join(defaultDataDir, "engine")
+	defaultIndexDir := filepath.Join(defaultDataDir, "index")
+	defaultSeriesDir := filepath.Join(defaultDataDir, "_series")
+
+	dumpTsiCommand.Flags().StringVar(&dumpTsiFlags.seriesFilePath, "series-file", defaultSeriesDir, "Path to series file")
+	dumpTsiCommand.Flags().StringVar(&dumpTsiFlags.dataPath, "data-path", defaultIndexDir, "Path to the index directory of the data engine")
+	dumpTsiCommand.Flags().BoolVar(&dumpTsiFlags.showSeries, "series", false, "Show raw series data")
+	dumpTsiCommand.Flags().BoolVar(&dumpTsiFlags.showMeasurements, "measurements", false, "Show raw measurement data")
+	dumpTsiCommand.Flags().BoolVar(&dumpTsiFlags.showTagKeys, "tag-keys", false, "Show raw tag key data")
+	dumpTsiCommand.Flags().BoolVar(&dumpTsiFlags.showTagValues, "tag-values", false, "Show raw tag value data")
+	dumpTsiCommand.Flags().BoolVar(&dumpTsiFlags.showTagValueSeries, "tag-value-series", false, "Show raw series data for each value")
+	dumpTsiCommand.Flags().StringVar(&measurementFilter, "measurement-filter", "", "Regex measurement filter")
+	dumpTsiCommand.Flags().StringVar(&tagKeyFilter, "tag-key-filter", "", "Regex tag key filter")
+	dumpTsiCommand.Flags().StringVar(&tagValueFilter, "tag-value-filter", "", "Regex tag value filter")
+
+	return dumpTsiCommand
+}
+
+func dumpTsi(cmd *cobra.Command, args []string) error {
+	logger := zap.NewNop()
+
+	// Parse filters.
+	if measurementFilter != "" {
+		re, err := regexp.Compile(measurementFilter)
+		if err != nil {
+			return err
+		}
+		dumpTsiFlags.measurementFilter = re
+	}
+	if tagKeyFilter != "" {
+		re, err := regexp.Compile(tagKeyFilter)
+		if err != nil {
+			return err
+		}
+		dumpTsiFlags.tagKeyFilter = re
+	}
+	if tagValueFilter != "" {
+		re, err := regexp.Compile(tagValueFilter)
+		if err != nil {
+			return err
+		}
+		dumpTsiFlags.tagValueFilter = re
+	}
+
+	if dumpTsiFlags.dataPath == "" {
+		return errors.New("data path must be specified")
+	}
+
+	// Some flags imply other flags.
+	if dumpTsiFlags.showTagValueSeries {
+		dumpTsiFlags.showTagValues = true
+	}
+	if dumpTsiFlags.showTagValues {
+		dumpTsiFlags.showTagKeys = true
+	}
+	if dumpTsiFlags.showTagKeys {
+		dumpTsiFlags.showMeasurements = true
+	}
+
+	dump := tsi1.NewDumpTsi(logger, dumpTsiFlags.seriesFilePath, dumpTsiFlags.dataPath,
+		dumpTsiFlags.showSeries, dumpTsiFlags.showMeasurements, dumpTsiFlags.showTagKeys,
+		dumpTsiFlags.showTagValues, dumpTsiFlags.showTagValueSeries, dumpTsiFlags.measurementFilter,
+		dumpTsiFlags.tagKeyFilter, dumpTsiFlags.tagValueFilter)
+
+	return dump.Run()
+}

--- a/cmd/influxd/inspect/dump_tsi1.go
+++ b/cmd/influxd/inspect/dump_tsi1.go
@@ -55,17 +55,14 @@ func NewDumpTsiCommand() *cobra.Command {
 					Dump raw series for each tag value
 			-measurement-filter REGEXP
 					Filters data by measurement regular expression
-			-series-file PATH
+			-series-path PATH
 					Path to the "_series" directory under the database data directory.
-					Required.
+			-index-path PATH
+					Path to the "index" directory under the database data directory.
 			-tag-key-filter REGEXP
 					Filters data by tag key regular expression
 			-tag-value-filter REGEXP
 					Filters data by tag value regular expression
-		
-		One or more paths are required. Path must specify either a TSI index directory
-		or it should specify one or more .tsi/.tsl files. If no flags are specified
-		then summary stats are provided for each file.
 		`,
 		RunE: dumpTsi,
 	}
@@ -74,8 +71,8 @@ func NewDumpTsiCommand() *cobra.Command {
 	defaultIndexDir := filepath.Join(defaultDataDir, "index")
 	defaultSeriesDir := filepath.Join(defaultDataDir, "_series")
 
-	dumpTsiCommand.Flags().StringVar(&dumpTsiFlags.seriesFilePath, "series-file", defaultSeriesDir, "Path to series file")
-	dumpTsiCommand.Flags().StringVar(&dumpTsiFlags.dataPath, "data-path", defaultIndexDir, "Path to the index directory of the data engine")
+	dumpTsiCommand.Flags().StringVar(&dumpTsiFlags.seriesFilePath, "series-path", defaultSeriesDir, "Path to series file")
+	dumpTsiCommand.Flags().StringVar(&dumpTsiFlags.dataPath, "index-path", defaultIndexDir, "Path to the index directory of the data engine")
 	dumpTsiCommand.Flags().BoolVar(&dumpTsiFlags.showSeries, "series", false, "Show raw series data")
 	dumpTsiCommand.Flags().BoolVar(&dumpTsiFlags.showMeasurements, "measurements", false, "Show raw measurement data")
 	dumpTsiCommand.Flags().BoolVar(&dumpTsiFlags.showTagKeys, "tag-keys", false, "Show raw tag key data")

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -21,6 +21,7 @@ func NewCommand() *cobra.Command {
 		NewReportTSICommand(),
 		NewVerifySeriesFileCommand(),
 		NewDumpWALCommand(),
+		NewDumpTSICommand(),
 	}
 
 	base.AddCommand(subCommands...)

--- a/tsdb/tsi1/dump_tsi1.go
+++ b/tsdb/tsi1/dump_tsi1.go
@@ -1,0 +1,453 @@
+package tsi1
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"text/tabwriter"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
+	"go.uber.org/zap"
+)
+
+// Command represents the program execution for "influxd dumptsi".
+type DumpTsi struct {
+	// Standard input/output, overridden for testing.
+	Stderr io.Writer
+	Stdout io.Writer
+
+	Logger *zap.Logger
+
+	// Optional: defaults to DataPath/_series
+	seriesFilePath string
+
+	// root dir of the engine
+	DataPath string
+
+	showSeries         bool
+	showMeasurements   bool
+	showTagKeys        bool
+	showTagValues      bool
+	showTagValueSeries bool
+
+	measurementFilter *regexp.Regexp
+	tagKeyFilter      *regexp.Regexp
+	tagValueFilter    *regexp.Regexp
+}
+
+// NewCommand returns a new instance of Command.
+func NewDumpTsi(logger *zap.Logger, seriesPath string, dataPath string, showSeries, showMeasurements, showTagKeys, showTagValues, showTagValueSeries bool, measurementFilter, tagKeyFilter, tagValueFilter *regexp.Regexp) DumpTsi {
+	dump := DumpTsi{
+		Logger:             logger,
+		seriesFilePath:     seriesPath,
+		DataPath:           dataPath,
+		showSeries:         showSeries,
+		showMeasurements:   showMeasurements,
+		showTagKeys:        showTagKeys,
+		showTagValues:      showTagValues,
+		showTagValueSeries: showTagValueSeries,
+		measurementFilter:  measurementFilter,
+		tagKeyFilter:       tagKeyFilter,
+		tagValueFilter:     tagValueFilter,
+		Stderr:             os.Stderr,
+		Stdout:             os.Stdout,
+	}
+	return dump
+}
+
+// Run executes the command.
+func (cmd *DumpTsi) Run() error {
+	sfile := tsdb.NewSeriesFile(cmd.seriesFilePath)
+	sfile.Logger = cmd.Logger
+	if err := sfile.Open(context.Background()); err != nil {
+		return err
+	}
+	defer sfile.Close()
+
+	// Build a file set from the paths on the command line.
+	idx, fs, err := cmd.readFileSet(sfile)
+	if err != nil {
+		return err
+	}
+
+	if cmd.showSeries {
+		if err := cmd.printSeries(sfile); err != nil {
+			return err
+		}
+	}
+
+	// If this is an ad-hoc fileset then process it and close afterward.
+	if fs != nil {
+		defer fs.Release()
+		// defer fs.Close()
+		if cmd.showSeries || cmd.showMeasurements {
+			return cmd.printMeasurements(sfile, fs)
+		}
+		return cmd.printFileSummaries(fs)
+	}
+
+	// Otherwise iterate over each partition in the index.
+	defer idx.Close()
+	for i := 0; i < int(idx.PartitionN); i++ {
+		if err := func() error {
+			// original
+			// fs, err := idx.PartitionAt(i).RetainFileSet()
+			// may need to call Acquire for each file
+			fs := idx.PartitionAt(i).fileSet
+			if err != nil {
+				return err
+			}
+			defer fs.Release()
+
+			if cmd.showSeries || cmd.showMeasurements {
+				return cmd.printMeasurements(sfile, fs)
+			}
+			return cmd.printFileSummaries(fs)
+		}(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (cmd *DumpTsi) readFileSet(sfile *tsdb.SeriesFile) (*Index, *FileSet, error) {
+
+	index := NewIndex(sfile, NewConfig(), WithPath(cmd.DataPath), DisableCompactions())
+
+	if err := index.Open(context.Background()); err != nil {
+		return nil, nil, err
+	}
+	return index, nil, nil
+
+	// // If only one path exists and it's a directory then open as an index.
+	// if len(cmd.paths) == 1 {
+	// 	fi, err := os.Stat(cmd.paths[0])
+	// 	if err != nil {
+	// 		return nil, nil, err
+	// 	} else if fi.IsDir() {
+	// 		// Verify directory is an index before opening it.
+	// 		if ok, err := IsIndexDir(cmd.paths[0]); err != nil {
+	// 			return nil, nil, err
+	// 		} else if !ok {
+	// 			return nil, nil, fmt.Errorf("Not an index directory: %q", cmd.paths[0])
+	// 		}
+
+	// 		idx := NewIndex(sfile,
+	// 			NewConfig(),
+	// 			WithPath(cmd.paths[0]),
+	// 			DisableCompactions(),
+	// 		)
+	// 		if err := idx.Open(context.Background()); err != nil {
+	// 			return nil, nil, err
+	// 		}
+	// 		return idx, nil, nil
+	// 	}
+	// }
+
+	// TODO: use this logic if we want to support entering custom file paths
+	// Open each file and group into a fileset.
+	// var files []File
+	// for _, path := range cmd.paths {
+	// 	switch ext := filepath.Ext(path); ext {
+	// 	case LogFileExt:
+	// 		f := NewLogFile(sfile, path)
+	// 		if err := f.Open(); err != nil {
+	// 			return nil, nil, err
+	// 		}
+	// 		files = append(files, f)
+
+	// 	case IndexFileExt:
+	// 		f := NewIndexFile(sfile)
+	// 		f.SetPath(path)
+	// 		if err := f.Open(); err != nil {
+	// 			return nil, nil, err
+	// 		}
+	// 		files = append(files, f)
+
+	// 	default:
+	// 		return nil, nil, fmt.Errorf("unexpected file extension: %s", ext)
+	// 	}
+	// }
+
+	// fs, err := NewFileSet(sfile, files)
+	// if err != nil {
+	// 	return nil, nil, err
+	// }
+	// return nil, fs, nil
+}
+
+func (cmd *DumpTsi) printSeries(sfile *tsdb.SeriesFile) error {
+	if !cmd.showSeries {
+		return nil
+	}
+
+	// Print header.
+	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
+	fmt.Fprintln(tw, "Series\t")
+
+	// Iterate over each series.
+	fmt.Printf("series file path: %v\n", sfile.Path())
+	itr := sfile.SeriesIDIterator()
+	for {
+		e, err := itr.Next()
+		if err != nil {
+			return err
+		} else if e.SeriesID.ID == 0 {
+			break
+		}
+		name, tags := tsdb.ParseSeriesKey(sfile.SeriesKey(e.SeriesID))
+
+		if !cmd.matchSeries(name, tags) {
+			continue
+		}
+
+		deleted := sfile.IsDeleted(e.SeriesID)
+
+		fmt.Fprintf(tw, "%s%s\t%v\n", name, tags.HashKey(), deletedString(deleted))
+	}
+
+	// Flush & write footer spacing.
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	fmt.Fprint(cmd.Stdout, "\n\n")
+
+	return nil
+}
+
+func (cmd *DumpTsi) printMeasurements(sfile *tsdb.SeriesFile, fs *FileSet) error {
+	if !cmd.showMeasurements {
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
+	fmt.Fprintln(tw, "Measurement\t")
+
+	// Iterate over each series.
+	if itr := fs.MeasurementIterator(); itr != nil {
+		for e := itr.Next(); e != nil; e = itr.Next() {
+			if cmd.measurementFilter != nil && !cmd.measurementFilter.Match(e.Name()) {
+				continue
+			}
+
+			fmt.Fprintf(tw, "%s\t%v\n", e.Name(), deletedString(e.Deleted()))
+			if err := tw.Flush(); err != nil {
+				return err
+			}
+
+			if err := cmd.printTagKeys(sfile, fs, e.Name()); err != nil {
+				return err
+			}
+		}
+	}
+
+	fmt.Fprint(cmd.Stdout, "\n\n")
+
+	return nil
+}
+
+func (cmd *DumpTsi) printTagKeys(sfile *tsdb.SeriesFile, fs *FileSet, name []byte) error {
+	if !cmd.showTagKeys {
+		return nil
+	}
+
+	// Iterate over each key.
+	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
+	itr := fs.TagKeyIterator(name)
+	for e := itr.Next(); e != nil; e = itr.Next() {
+		if cmd.tagKeyFilter != nil && !cmd.tagKeyFilter.Match(e.Key()) {
+			continue
+		}
+
+		fmt.Fprintf(tw, "    %s\t%v\n", e.Key(), deletedString(e.Deleted()))
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+
+		if err := cmd.printTagValues(sfile, fs, name, e.Key()); err != nil {
+			return err
+		}
+	}
+	fmt.Fprint(cmd.Stdout, "\n")
+
+	return nil
+}
+
+func (cmd *DumpTsi) printTagValues(sfile *tsdb.SeriesFile, fs *FileSet, name, key []byte) error {
+	if !cmd.showTagValues {
+		return nil
+	}
+
+	// Iterate over each value.
+	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
+	itr := fs.TagValueIterator(name, key)
+	for e := itr.Next(); e != nil; e = itr.Next() {
+		if cmd.tagValueFilter != nil && !cmd.tagValueFilter.Match(e.Value()) {
+			continue
+		}
+
+		fmt.Fprintf(tw, "        %s\t%v\n", e.Value(), deletedString(e.Deleted()))
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+
+		if err := cmd.printTagValueSeries(sfile, fs, name, key, e.Value()); err != nil {
+			return err
+		}
+	}
+	fmt.Fprint(cmd.Stdout, "\n")
+
+	return nil
+}
+
+func (cmd *DumpTsi) printTagValueSeries(sfile *tsdb.SeriesFile, fs *FileSet, name, key, value []byte) error {
+	if !cmd.showTagValueSeries {
+		return nil
+	}
+
+	// Iterate over each series.
+	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
+	itr, err := fs.TagValueSeriesIDIterator(name, key, value)
+	if err != nil {
+		return err
+	}
+	for {
+		e, err := itr.Next()
+		if err != nil {
+			return err
+		} else if e.SeriesID.ID == 0 {
+			break
+		}
+
+		name, tags := tsdb.ParseSeriesKey(sfile.SeriesKey(e.SeriesID))
+
+		if !cmd.matchSeries(name, tags) {
+			continue
+		}
+
+		fmt.Fprintf(tw, "            %s%s\n", name, tags.HashKey())
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+	}
+	fmt.Fprint(cmd.Stdout, "\n")
+
+	return nil
+}
+
+func (cmd *DumpTsi) printFileSummaries(fs *FileSet) error {
+	for _, f := range fs.Files() {
+		switch f := f.(type) {
+		case *LogFile:
+			fmt.Printf("got an alleged LogFile: %v\n", f.Path())
+			if err := cmd.printLogFileSummary(f); err != nil {
+				return err
+			}
+		case *IndexFile:
+			if err := cmd.printIndexFileSummary(f); err != nil {
+				return err
+			}
+		default:
+			panic("unreachable")
+		}
+		fmt.Fprintln(cmd.Stdout, "")
+	}
+	return nil
+}
+
+func (cmd *DumpTsi) printLogFileSummary(f *LogFile) error {
+	fmt.Fprintf(cmd.Stdout, "[LOG FILE] %s\n", filepath.Base(f.Path()))
+	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
+	fmt.Fprintf(tw, "Series:\t%d\n", f.SeriesN())
+	fmt.Fprintf(tw, "Measurements:\t%d\n", f.MeasurementN())
+	fmt.Fprintf(tw, "Tag Keys:\t%d\n", f.TagKeyN())
+	fmt.Fprintf(tw, "Tag Values:\t%d\n", f.TagValueN())
+	return tw.Flush()
+}
+
+func (cmd *DumpTsi) printIndexFileSummary(f *IndexFile) error {
+	fmt.Fprintf(cmd.Stdout, "[INDEX FILE] %s\n", filepath.Base(f.Path()))
+
+	// Calculate summary stats.
+	var measurementN, measurementSeriesN, measurementSeriesSize uint64
+	var keyN uint64
+	var valueN, valueSeriesN, valueSeriesSize uint64
+
+	if mitr := f.MeasurementIterator(); mitr != nil {
+		for me, _ := mitr.Next().(*MeasurementBlockElem); me != nil; me, _ = mitr.Next().(*MeasurementBlockElem) {
+			kitr := f.TagKeyIterator(me.Name())
+			for ke, _ := kitr.Next().(*TagBlockKeyElem); ke != nil; ke, _ = kitr.Next().(*TagBlockKeyElem) {
+				vitr := f.TagValueIterator(me.Name(), ke.Key())
+				for ve, _ := vitr.Next().(*TagBlockValueElem); ve != nil; ve, _ = vitr.Next().(*TagBlockValueElem) {
+					valueN++
+					valueSeriesN += uint64(ve.SeriesN())
+					valueSeriesSize += uint64(len(ve.SeriesData()))
+				}
+				keyN++
+			}
+			measurementN++
+			measurementSeriesN += uint64(me.SeriesN())
+			measurementSeriesSize += uint64(len(me.SeriesData()))
+		}
+	}
+
+	// Write stats.
+	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
+	fmt.Fprintf(tw, "Measurements:\t%d\n", measurementN)
+	fmt.Fprintf(tw, "  Series data size:\t%d (%s)\n", measurementSeriesSize, formatSize(measurementSeriesSize))
+	fmt.Fprintf(tw, "  Bytes per series:\t%.01fb\n", float64(measurementSeriesSize)/float64(measurementSeriesN))
+	fmt.Fprintf(tw, "Tag Keys:\t%d\n", keyN)
+	fmt.Fprintf(tw, "Tag Values:\t%d\n", valueN)
+	fmt.Fprintf(tw, "  Series:\t%d\n", valueSeriesN)
+	fmt.Fprintf(tw, "  Series data size:\t%d (%s)\n", valueSeriesSize, formatSize(valueSeriesSize))
+	fmt.Fprintf(tw, "  Bytes per series:\t%.01fb\n", float64(valueSeriesSize)/float64(valueSeriesN))
+	return tw.Flush()
+}
+
+// matchSeries returns true if the command filters matches the series.
+func (cmd *DumpTsi) matchSeries(name []byte, tags models.Tags) bool {
+	// Filter by measurement.
+	if cmd.measurementFilter != nil && !cmd.measurementFilter.Match(name) {
+		return false
+	}
+
+	// Filter by tag key/value.
+	if cmd.tagKeyFilter != nil || cmd.tagValueFilter != nil {
+		var matched bool
+		for _, tag := range tags {
+			if (cmd.tagKeyFilter == nil || cmd.tagKeyFilter.Match(tag.Key)) && (cmd.tagValueFilter == nil || cmd.tagValueFilter.Match(tag.Value)) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+// deletedString returns "(deleted)" if v is true.
+func deletedString(v bool) string {
+	if v {
+		return "(deleted)"
+	}
+	return ""
+}
+
+func formatSize(v uint64) string {
+	denom := uint64(1)
+	var uom string
+	for _, uom = range []string{"b", "kb", "mb", "gb", "tb"} {
+		if denom*1024 > v {
+			break
+		}
+		denom *= 1024
+	}
+	return fmt.Sprintf("%0.01f%s", float64(v)/float64(denom), uom)
+}

--- a/tsdb/tsi1/dump_tsi1.go
+++ b/tsdb/tsi1/dump_tsi1.go
@@ -14,8 +14,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// Command represents the program execution for "influxd dumptsi".
-type DumpTsi struct {
+// Command represents the program execution for "influxd inspect dump-tsi".
+type DumpTSI struct {
 	// Standard input/output, overridden for testing.
 	Stderr io.Writer
 	Stdout io.Writer
@@ -23,45 +23,35 @@ type DumpTsi struct {
 	Logger *zap.Logger
 
 	// Optional: defaults to DataPath/_series
-	seriesFilePath string
+	SeriesFilePath string
 
 	// root dir of the engine
 	DataPath string
 
-	showSeries         bool
-	showMeasurements   bool
-	showTagKeys        bool
-	showTagValues      bool
-	showTagValueSeries bool
+	ShowSeries         bool
+	ShowMeasurements   bool
+	ShowTagKeys        bool
+	ShowTagValues      bool
+	ShowTagValueSeries bool
 
-	measurementFilter *regexp.Regexp
-	tagKeyFilter      *regexp.Regexp
-	tagValueFilter    *regexp.Regexp
+	MeasurementFilter *regexp.Regexp
+	TagKeyFilter      *regexp.Regexp
+	TagValueFilter    *regexp.Regexp
 }
 
 // NewCommand returns a new instance of Command.
-func NewDumpTsi(logger *zap.Logger, seriesPath string, dataPath string, showSeries, showMeasurements, showTagKeys, showTagValues, showTagValueSeries bool, measurementFilter, tagKeyFilter, tagValueFilter *regexp.Regexp) DumpTsi {
-	dump := DumpTsi{
-		Logger:             logger,
-		seriesFilePath:     seriesPath,
-		DataPath:           dataPath,
-		showSeries:         showSeries,
-		showMeasurements:   showMeasurements,
-		showTagKeys:        showTagKeys,
-		showTagValues:      showTagValues,
-		showTagValueSeries: showTagValueSeries,
-		measurementFilter:  measurementFilter,
-		tagKeyFilter:       tagKeyFilter,
-		tagValueFilter:     tagValueFilter,
-		Stderr:             os.Stderr,
-		Stdout:             os.Stdout,
+func NewDumpTSI(logger *zap.Logger) DumpTSI {
+	dump := DumpTSI{
+		Logger: logger,
+		Stderr: os.Stderr,
+		Stdout: os.Stdout,
 	}
 	return dump
 }
 
 // Run executes the command.
-func (cmd *DumpTsi) Run() error {
-	sfile := tsdb.NewSeriesFile(cmd.seriesFilePath)
+func (cmd *DumpTSI) Run() error {
+	sfile := tsdb.NewSeriesFile(cmd.SeriesFilePath)
 	sfile.Logger = cmd.Logger
 	if err := sfile.Open(context.Background()); err != nil {
 		return err
@@ -74,7 +64,7 @@ func (cmd *DumpTsi) Run() error {
 		return err
 	}
 
-	if cmd.showSeries {
+	if cmd.ShowSeries {
 		if err := cmd.printSeries(sfile); err != nil {
 			return err
 		}
@@ -83,8 +73,7 @@ func (cmd *DumpTsi) Run() error {
 	// If this is an ad-hoc fileset then process it and close afterward.
 	if fs != nil {
 		defer fs.Release()
-		// defer fs.Close()
-		if cmd.showSeries || cmd.showMeasurements {
+		if cmd.ShowSeries || cmd.ShowMeasurements {
 			return cmd.printMeasurements(sfile, fs)
 		}
 		return cmd.printFileSummaries(fs)
@@ -94,16 +83,13 @@ func (cmd *DumpTsi) Run() error {
 	defer idx.Close()
 	for i := 0; i < int(idx.PartitionN); i++ {
 		if err := func() error {
-			// original
-			// fs, err := idx.PartitionAt(i).RetainFileSet()
-			// may need to call Acquire for each file
 			fs := idx.PartitionAt(i).fileSet
 			if err != nil {
 				return err
 			}
 			defer fs.Release()
 
-			if cmd.showSeries || cmd.showMeasurements {
+			if cmd.ShowSeries || cmd.ShowMeasurements {
 				return cmd.printMeasurements(sfile, fs)
 			}
 			return cmd.printFileSummaries(fs)
@@ -114,74 +100,17 @@ func (cmd *DumpTsi) Run() error {
 	return nil
 }
 
-func (cmd *DumpTsi) readFileSet(sfile *tsdb.SeriesFile) (*Index, *FileSet, error) {
-
+func (cmd *DumpTSI) readFileSet(sfile *tsdb.SeriesFile) (*Index, *FileSet, error) {
 	index := NewIndex(sfile, NewConfig(), WithPath(cmd.DataPath), DisableCompactions())
 
 	if err := index.Open(context.Background()); err != nil {
 		return nil, nil, err
 	}
 	return index, nil, nil
-
-	// // If only one path exists and it's a directory then open as an index.
-	// if len(cmd.paths) == 1 {
-	// 	fi, err := os.Stat(cmd.paths[0])
-	// 	if err != nil {
-	// 		return nil, nil, err
-	// 	} else if fi.IsDir() {
-	// 		// Verify directory is an index before opening it.
-	// 		if ok, err := IsIndexDir(cmd.paths[0]); err != nil {
-	// 			return nil, nil, err
-	// 		} else if !ok {
-	// 			return nil, nil, fmt.Errorf("Not an index directory: %q", cmd.paths[0])
-	// 		}
-
-	// 		idx := NewIndex(sfile,
-	// 			NewConfig(),
-	// 			WithPath(cmd.paths[0]),
-	// 			DisableCompactions(),
-	// 		)
-	// 		if err := idx.Open(context.Background()); err != nil {
-	// 			return nil, nil, err
-	// 		}
-	// 		return idx, nil, nil
-	// 	}
-	// }
-
-	// TODO: use this logic if we want to support entering custom file paths
-	// Open each file and group into a fileset.
-	// var files []File
-	// for _, path := range cmd.paths {
-	// 	switch ext := filepath.Ext(path); ext {
-	// 	case LogFileExt:
-	// 		f := NewLogFile(sfile, path)
-	// 		if err := f.Open(); err != nil {
-	// 			return nil, nil, err
-	// 		}
-	// 		files = append(files, f)
-
-	// 	case IndexFileExt:
-	// 		f := NewIndexFile(sfile)
-	// 		f.SetPath(path)
-	// 		if err := f.Open(); err != nil {
-	// 			return nil, nil, err
-	// 		}
-	// 		files = append(files, f)
-
-	// 	default:
-	// 		return nil, nil, fmt.Errorf("unexpected file extension: %s", ext)
-	// 	}
-	// }
-
-	// fs, err := NewFileSet(sfile, files)
-	// if err != nil {
-	// 	return nil, nil, err
-	// }
-	// return nil, fs, nil
 }
 
-func (cmd *DumpTsi) printSeries(sfile *tsdb.SeriesFile) error {
-	if !cmd.showSeries {
+func (cmd *DumpTSI) printSeries(sfile *tsdb.SeriesFile) error {
+	if !cmd.ShowSeries {
 		return nil
 	}
 
@@ -190,7 +119,6 @@ func (cmd *DumpTsi) printSeries(sfile *tsdb.SeriesFile) error {
 	fmt.Fprintln(tw, "Series\t")
 
 	// Iterate over each series.
-	fmt.Printf("series file path: %v\n", sfile.Path())
 	itr := sfile.SeriesIDIterator()
 	for {
 		e, err := itr.Next()
@@ -219,8 +147,8 @@ func (cmd *DumpTsi) printSeries(sfile *tsdb.SeriesFile) error {
 	return nil
 }
 
-func (cmd *DumpTsi) printMeasurements(sfile *tsdb.SeriesFile, fs *FileSet) error {
-	if !cmd.showMeasurements {
+func (cmd *DumpTSI) printMeasurements(sfile *tsdb.SeriesFile, fs *FileSet) error {
+	if !cmd.ShowMeasurements {
 		return nil
 	}
 
@@ -230,7 +158,7 @@ func (cmd *DumpTsi) printMeasurements(sfile *tsdb.SeriesFile, fs *FileSet) error
 	// Iterate over each series.
 	if itr := fs.MeasurementIterator(); itr != nil {
 		for e := itr.Next(); e != nil; e = itr.Next() {
-			if cmd.measurementFilter != nil && !cmd.measurementFilter.Match(e.Name()) {
+			if cmd.MeasurementFilter != nil && !cmd.MeasurementFilter.Match(e.Name()) {
 				continue
 			}
 
@@ -250,8 +178,8 @@ func (cmd *DumpTsi) printMeasurements(sfile *tsdb.SeriesFile, fs *FileSet) error
 	return nil
 }
 
-func (cmd *DumpTsi) printTagKeys(sfile *tsdb.SeriesFile, fs *FileSet, name []byte) error {
-	if !cmd.showTagKeys {
+func (cmd *DumpTSI) printTagKeys(sfile *tsdb.SeriesFile, fs *FileSet, name []byte) error {
+	if !cmd.ShowTagKeys {
 		return nil
 	}
 
@@ -259,7 +187,7 @@ func (cmd *DumpTsi) printTagKeys(sfile *tsdb.SeriesFile, fs *FileSet, name []byt
 	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
 	itr := fs.TagKeyIterator(name)
 	for e := itr.Next(); e != nil; e = itr.Next() {
-		if cmd.tagKeyFilter != nil && !cmd.tagKeyFilter.Match(e.Key()) {
+		if cmd.TagKeyFilter != nil && !cmd.TagKeyFilter.Match(e.Key()) {
 			continue
 		}
 
@@ -277,8 +205,8 @@ func (cmd *DumpTsi) printTagKeys(sfile *tsdb.SeriesFile, fs *FileSet, name []byt
 	return nil
 }
 
-func (cmd *DumpTsi) printTagValues(sfile *tsdb.SeriesFile, fs *FileSet, name, key []byte) error {
-	if !cmd.showTagValues {
+func (cmd *DumpTSI) printTagValues(sfile *tsdb.SeriesFile, fs *FileSet, name, key []byte) error {
+	if !cmd.ShowTagValues {
 		return nil
 	}
 
@@ -286,7 +214,7 @@ func (cmd *DumpTsi) printTagValues(sfile *tsdb.SeriesFile, fs *FileSet, name, ke
 	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
 	itr := fs.TagValueIterator(name, key)
 	for e := itr.Next(); e != nil; e = itr.Next() {
-		if cmd.tagValueFilter != nil && !cmd.tagValueFilter.Match(e.Value()) {
+		if cmd.TagValueFilter != nil && !cmd.TagValueFilter.Match(e.Value()) {
 			continue
 		}
 
@@ -304,8 +232,8 @@ func (cmd *DumpTsi) printTagValues(sfile *tsdb.SeriesFile, fs *FileSet, name, ke
 	return nil
 }
 
-func (cmd *DumpTsi) printTagValueSeries(sfile *tsdb.SeriesFile, fs *FileSet, name, key, value []byte) error {
-	if !cmd.showTagValueSeries {
+func (cmd *DumpTSI) printTagValueSeries(sfile *tsdb.SeriesFile, fs *FileSet, name, key, value []byte) error {
+	if !cmd.ShowTagValueSeries {
 		return nil
 	}
 
@@ -339,7 +267,7 @@ func (cmd *DumpTsi) printTagValueSeries(sfile *tsdb.SeriesFile, fs *FileSet, nam
 	return nil
 }
 
-func (cmd *DumpTsi) printFileSummaries(fs *FileSet) error {
+func (cmd *DumpTSI) printFileSummaries(fs *FileSet) error {
 	for _, f := range fs.Files() {
 		switch f := f.(type) {
 		case *LogFile:
@@ -359,7 +287,7 @@ func (cmd *DumpTsi) printFileSummaries(fs *FileSet) error {
 	return nil
 }
 
-func (cmd *DumpTsi) printLogFileSummary(f *LogFile) error {
+func (cmd *DumpTSI) printLogFileSummary(f *LogFile) error {
 	fmt.Fprintf(cmd.Stdout, "[LOG FILE] %s\n", filepath.Base(f.Path()))
 	tw := tabwriter.NewWriter(cmd.Stdout, 8, 8, 1, '\t', 0)
 	fmt.Fprintf(tw, "Series:\t%d\n", f.SeriesN())
@@ -369,7 +297,7 @@ func (cmd *DumpTsi) printLogFileSummary(f *LogFile) error {
 	return tw.Flush()
 }
 
-func (cmd *DumpTsi) printIndexFileSummary(f *IndexFile) error {
+func (cmd *DumpTSI) printIndexFileSummary(f *IndexFile) error {
 	fmt.Fprintf(cmd.Stdout, "[INDEX FILE] %s\n", filepath.Base(f.Path()))
 
 	// Calculate summary stats.
@@ -409,17 +337,17 @@ func (cmd *DumpTsi) printIndexFileSummary(f *IndexFile) error {
 }
 
 // matchSeries returns true if the command filters matches the series.
-func (cmd *DumpTsi) matchSeries(name []byte, tags models.Tags) bool {
+func (cmd *DumpTSI) matchSeries(name []byte, tags models.Tags) bool {
 	// Filter by measurement.
-	if cmd.measurementFilter != nil && !cmd.measurementFilter.Match(name) {
+	if cmd.MeasurementFilter != nil && !cmd.MeasurementFilter.Match(name) {
 		return false
 	}
 
 	// Filter by tag key/value.
-	if cmd.tagKeyFilter != nil || cmd.tagValueFilter != nil {
+	if cmd.TagKeyFilter != nil || cmd.TagValueFilter != nil {
 		var matched bool
 		for _, tag := range tags {
-			if (cmd.tagKeyFilter == nil || cmd.tagKeyFilter.Match(tag.Key)) && (cmd.tagValueFilter == nil || cmd.tagValueFilter.Match(tag.Value)) {
+			if (cmd.TagKeyFilter == nil || cmd.TagKeyFilter.Match(tag.Key)) && (cmd.TagValueFilter == nil || cmd.TagValueFilter.Match(tag.Value)) {
 				matched = true
 				break
 			}


### PR DESCRIPTION
Closes #14754

Add the `dumptsi` tool to 2.x, now called with `influxd inspect dump-tsi`. The old functionality of the tool is retained, but the output can be difficult to read, as tsi information is printed as raw bytes. This is the largest drawback of this tool, and something that needs to be done in the future is reformatting the output to be more usable.

The ability to manually input file paths that will be checked as indexes has been removed, as has the requirement to specify a series file path. The tool now infers the series file and index file directories if none are specified.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
