### PR TITLE
fix(query/to): make orgID default to the context org

### DIFF
--- a/authorizer/task_test.go
+++ b/authorizer/task_test.go
@@ -297,54 +297,6 @@ from(bucket:"bad") |> range(start:-5m) |> to(bucket:"bad", org:"thing")`,
 			},
 		},
 		{
-			name: "create missing org in to parameters",
-			auth: r.Auth,
-			check: func(ctx context.Context, svc influxdb.TaskService) error {
-				var (
-					expMsg  = "Failed to compile flux script."
-					expErr  = fmt.Errorf("error calling function \"to\": missing required keyword argument \"orgID\"")
-					expCode = influxdb.EInvalid
-					errfmt  = "expected %q, got %q"
-					_, err  = svc.CreateTask(ctx, influxdb.TaskCreate{
-						OrganizationID: r.Org.ID,
-						OwnerID:        r.Auth.GetUserID(),
-						Flux: `option task = {
- name: "my_task",
- every: 1s,
-}
-from(bucket:"bad") |> range(start:-5m) |> to(bucket:"bad")`,
-					})
-				)
-
-				if err == nil {
-					return errors.New("created task without bucket permission")
-				}
-
-				perr, ok := err.(*influxdb.Error)
-				if !ok {
-					return fmt.Errorf(errfmt, &influxdb.Error{}, err)
-				}
-
-				if perr.Code != expCode {
-					return fmt.Errorf(errfmt, expCode, perr.Code)
-				}
-
-				if perr.Err == nil {
-					return fmt.Errorf(errfmt, "platform.Error.Err to be present", perr.Err)
-				}
-
-				if perr.Err.Error() != expErr.Error() {
-					return fmt.Errorf(errfmt, expErr, perr.Err)
-				}
-
-				if perr.Msg != expMsg {
-					return fmt.Errorf(errfmt, expMsg, perr.Msg)
-				}
-
-				return nil
-			},
-		},
-		{
 			name: "FindTaskByID missing auth",
 			auth: &influxdb.Authorization{Permissions: []influxdb.Permission{}},
 			check: func(ctx context.Context, svc influxdb.TaskService) error {

--- a/query/preauthorizer_test.go
+++ b/query/preauthorizer_test.go
@@ -146,10 +146,10 @@ func TestPreAuthorizer_PreAuthorize_FailToParse(t *testing.T) {
 		authorizer         = query.NewPreAuthorizer(emptyBucketService)
 		errfmt             = "Expected %q, Got %q"
 		// inputs
-		q = `from(bucket:"foo") |> range(start:-2h) |> to(bucket: "bar")`
+		q = `from(bucket:"foo") |> range(start:-2h) |> to(org: "bar")`
 		// expectations
 		msg    = "Failed to compile flux script."
-		errMsg = `error calling function "to": missing required keyword argument "orgID"`
+		errMsg = `error calling function "to": missing required keyword argument "bucketID"`
 		code   = platform.EInvalid
 	)
 

--- a/query/stdlib/experimental/to.go
+++ b/query/stdlib/experimental/to.go
@@ -59,7 +59,7 @@ func (o *ToOpSpec) ReadArgs(args flux.Arguments) error {
 	}
 
 	if o.Org, ok, _ = args.GetString("org"); !ok {
-		if o.OrgID, err = args.GetRequiredString("orgID"); err != nil {
+		if o.OrgID, _, err = args.GetString("orgID"); err != nil {
 			return err
 		}
 	} else if o.OrgID, ok, _ = args.GetString("orgID"); ok {

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -33,14 +33,14 @@ describe('Tasks', () => {
 v1.tagValues(bucket: "${name}", tag: "_field")
 from(bucket: "${name}")
   |> range(start: -2m)
-  |> to(bucket: "${name}")`
+  |> to(org: "${name}")`
     })
 
     cy.contains('Save').click()
 
     cy.getByTestID('notification-error').should(
       'contain',
-      'error calling function "to": missing required keyword argument "orgID"'
+      'error calling function "to": missing required keyword argument "bucketID"'
     )
   })
 


### PR DESCRIPTION
This change makes it so that if an org or orgID are missing on calls to the `to` function
that the orgID is retrieved from the request context.

This is consistent with how `from` works.
