### PR TITLE
fix(kv): create task in kv

### DIFF
--- a/check.go
+++ b/check.go
@@ -43,6 +43,7 @@ type CheckService interface {
 	UserResourceMappingService
 	// OrganizationService is needed for search filter
 	OrganizationService
+	TaskService
 
 	// FindCheckByID returns a single check by ID.
 	FindCheckByID(ctx context.Context, id ID) (Check, error)

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -167,7 +167,6 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	notificationRuleBackend := NewNotificationRuleBackend(b)
 	notificationRuleBackend.NotificationRuleStore = authorizer.NewNotificationRuleStore(b.NotificationRuleStore,
 		b.UserResourceMappingService, b.OrganizationService)
-	notificationRuleBackend.TaskService = b.TaskService
 	h.NotificationRuleHandler = NewNotificationRuleHandler(notificationRuleBackend)
 
 	notificationEndpointBackend := NewNotificationEndpointBackend(b)
@@ -178,7 +177,6 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 	checkBackend := NewCheckBackend(b)
 	checkBackend.CheckService = authorizer.NewCheckService(b.CheckService,
 		b.UserResourceMappingService, b.OrganizationService)
-	checkBackend.TaskService = b.TaskService
 	h.CheckHandler = NewCheckHandler(checkBackend)
 
 	writeBackend := NewWriteBackend(b)

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -28,7 +28,6 @@ func NewMockCheckBackend() *CheckBackend {
 		Logger: zap.NewNop().With(zap.String("handler", "check")),
 
 		CheckService:               mock.NewCheckService(),
-		TaskService:                &mock.TaskService{},
 		UserResourceMappingService: mock.NewUserResourceMappingService(),
 		LabelService:               mock.NewLabelService(),
 		UserService:                mock.NewUserService(),
@@ -600,7 +599,6 @@ func TestService_handleGetCheck(t *testing.T) {
 func TestService_handlePostCheck(t *testing.T) {
 	type fields struct {
 		CheckService        influxdb.CheckService
-		TaskService         influxdb.TaskService
 		OrganizationService influxdb.OrganizationService
 	}
 	type args struct {
@@ -622,11 +620,6 @@ func TestService_handlePostCheck(t *testing.T) {
 		{
 			name: "create a new check",
 			fields: fields{
-				TaskService: &mock.TaskService{
-					CreateTaskFn: func(ctx context.Context, tc influxdb.TaskCreate) (*influxdb.Task, error) {
-						return &influxdb.Task{ID: 3}, nil
-					},
-				},
 				CheckService: &mock.CheckService{
 					CreateCheckFn: func(ctx context.Context, c influxdb.Check, userID influxdb.ID) error {
 						c.SetID(influxTesting.MustIDBase16("020f755c3c082000"))
@@ -720,7 +713,6 @@ func TestService_handlePostCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend()
-			checkBackend.TaskService = tt.fields.TaskService
 			checkBackend.CheckService = tt.fields.CheckService
 			checkBackend.OrganizationService = tt.fields.OrganizationService
 			h := NewCheckHandler(checkBackend)
@@ -1030,7 +1022,6 @@ func TestService_handlePatchCheck(t *testing.T) {
 
 func TestService_handleUpdateCheck(t *testing.T) {
 	type fields struct {
-		TaskService  influxdb.TaskService
 		CheckService influxdb.CheckService
 	}
 	type args struct {
@@ -1052,14 +1043,6 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		{
 			name: "update a check name",
 			fields: fields{
-				TaskService: &mock.TaskService{
-					CreateTaskFn: func(ctx context.Context, tc influxdb.TaskCreate) (*influxdb.Task, error) {
-						return &influxdb.Task{ID: 3}, nil
-					},
-					DeleteTaskFn: func(ctx context.Context, id influxdb.ID) error {
-						return nil
-					},
-				},
 				CheckService: &mock.CheckService{
 					UpdateCheckFn: func(ctx context.Context, id influxdb.ID, chk influxdb.Check) (influxdb.Check, error) {
 						if id == influxTesting.MustIDBase16("020f755c3c082000") {
@@ -1139,14 +1122,6 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		{
 			name: "check not found",
 			fields: fields{
-				TaskService: &mock.TaskService{
-					CreateTaskFn: func(ctx context.Context, tc influxdb.TaskCreate) (*influxdb.Task, error) {
-						return &influxdb.Task{ID: 3}, nil
-					},
-					DeleteTaskFn: func(ctx context.Context, id influxdb.ID) error {
-						return nil
-					},
-				},
 				CheckService: &mock.CheckService{
 					UpdateCheckFn: func(ctx context.Context, id influxdb.ID, chk influxdb.Check) (influxdb.Check, error) {
 						return nil, &influxdb.Error{
@@ -1174,7 +1149,6 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			checkBackend := NewMockCheckBackend()
 			checkBackend.HTTPErrorHandler = ErrorHandler(0)
-			checkBackend.TaskService = tt.fields.TaskService
 			checkBackend.CheckService = tt.fields.CheckService
 			h := NewCheckHandler(checkBackend)
 

--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -21,7 +21,6 @@ type NotificationRuleBackend struct {
 	Logger *zap.Logger
 
 	NotificationRuleStore      influxdb.NotificationRuleStore
-	TaskService                influxdb.TaskService
 	UserResourceMappingService influxdb.UserResourceMappingService
 	LabelService               influxdb.LabelService
 	UserService                influxdb.UserService
@@ -35,7 +34,6 @@ func NewNotificationRuleBackend(b *APIBackend) *NotificationRuleBackend {
 		Logger:           b.Logger.With(zap.String("handler", "notification_rule")),
 
 		NotificationRuleStore:      b.NotificationRuleStore,
-		TaskService:                b.TaskService,
 		UserResourceMappingService: b.UserResourceMappingService,
 		LabelService:               b.LabelService,
 		UserService:                b.UserService,
@@ -50,7 +48,6 @@ type NotificationRuleHandler struct {
 	Logger *zap.Logger
 
 	NotificationRuleStore      influxdb.NotificationRuleStore
-	TaskService                influxdb.TaskService
 	UserResourceMappingService influxdb.UserResourceMappingService
 	LabelService               influxdb.LabelService
 	UserService                influxdb.UserService
@@ -76,7 +73,6 @@ func NewNotificationRuleHandler(b *NotificationRuleBackend) *NotificationRuleHan
 		Logger:           b.Logger,
 
 		NotificationRuleStore:      b.NotificationRuleStore,
-		TaskService:                b.TaskService,
 		UserResourceMappingService: b.UserResourceMappingService,
 		LabelService:               b.LabelService,
 		UserService:                b.UserService,
@@ -137,43 +133,6 @@ type notificationRuleResponse struct {
 	influxdb.NotificationRule
 	Labels []influxdb.Label      `json:"labels"`
 	Links  notificationRuleLinks `json:"links"`
-}
-
-func createRuleTask(ctx context.Context,
-	s influxdb.TaskService,
-	nr influxdb.NotificationRule) error {
-	if nr.GetStatus() == influxdb.Inactive {
-		return nil
-	}
-	script, err := nr.GenerateFlux(nil)
-	if err != nil {
-		return &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Err:  err,
-		}
-	}
-
-	tc := influxdb.TaskCreate{
-		Type:           nr.Type(),
-		Flux:           script,
-		OwnerID:        nr.GetOwnerID(),
-		OrganizationID: nr.GetOrgID(),
-	}
-	t, err := s.CreateTask(ctx, tc)
-	if err != nil {
-		return err
-	}
-	nr.SetTaskID(t.ID)
-
-	return nil
-}
-
-func removeRuleTask(ctx context.Context, s influxdb.TaskService, nr influxdb.NotificationRule) error {
-	err := s.DeleteTask(ctx, nr.GetTaskID())
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (resp notificationRuleResponse) MarshalJSON() ([]byte, error) {
@@ -454,10 +413,6 @@ func (h *NotificationRuleHandler) handlePostNotificationRule(w http.ResponseWrit
 		return
 	}
 
-	if err = createRuleTask(ctx, h.TaskService, nr); err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
 	auth, err := pctx.GetAuthorizer(ctx)
 	if err != nil {
 		h.HandleHTTPError(ctx, err, w)
@@ -483,15 +438,6 @@ func (h *NotificationRuleHandler) handlePutNotificationRule(w http.ResponseWrite
 	nr, err := decodePutNotificationRuleRequest(ctx, r)
 	if err != nil {
 		h.Logger.Debug("failed to decode request", zap.Error(err))
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-	if err = removeRuleTask(ctx, h.TaskService, nr); err != nil {
-		h.HandleHTTPError(ctx, err, w)
-		return
-	}
-
-	if err = createRuleTask(ctx, h.TaskService, nr); err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
@@ -529,17 +475,6 @@ func (h *NotificationRuleHandler) handlePatchNotificationRule(w http.ResponseWri
 		h.Logger.Debug("failed to decode request", zap.Error(err))
 		h.HandleHTTPError(ctx, err, w)
 		return
-	}
-	if req.Update.Status != nil && *req.Update.Status == influxdb.Inactive {
-		nr, err := h.NotificationRuleStore.FindNotificationRuleByID(ctx, req.ID)
-		if err != nil {
-			h.HandleHTTPError(ctx, err, w)
-			return
-		}
-		if err = removeRuleTask(ctx, h.TaskService, nr); err != nil {
-			h.HandleHTTPError(ctx, err, w)
-			return
-		}
 	}
 
 	nr, err := h.NotificationRuleStore.PatchNotificationRule(ctx, req.ID, req.Update)

--- a/kv/check_test.go
+++ b/kv/check_test.go
@@ -65,6 +65,11 @@ func initCheckService(s kv.Store, f influxdbtesting.CheckFields, t *testing.T) (
 			t.Fatalf("failed to populate organizations")
 		}
 	}
+	for _, tc := range f.Tasks {
+		if _, err := svc.CreateTask(ctx, tc); err != nil {
+			t.Fatalf("failed to populate tasks: %v", err)
+		}
+	}
 	for _, c := range f.Checks {
 		if err := svc.PutCheck(ctx, c); err != nil {
 			t.Fatalf("failed to populate checks")

--- a/kv/notification_rule.go
+++ b/kv/notification_rule.go
@@ -79,6 +79,15 @@ func (s *Service) createNotificationRule(ctx context.Context, tx Tx, nr influxdb
 	nr.SetCreatedAt(now)
 	nr.SetUpdatedAt(now)
 
+	if nr.GetStatus() == influxdb.Active {
+		t, err := s.createNotificationTask(ctx, tx, nr)
+		if err != nil {
+			return err
+		}
+
+		nr.SetTaskID(t.ID)
+	}
+
 	if err := s.putNotificationRule(ctx, tx, nr); err != nil {
 		return err
 	}
@@ -90,6 +99,34 @@ func (s *Service) createNotificationRule(ctx context.Context, tx Tx, nr influxdb
 		ResourceType: influxdb.NotificationRuleResourceType,
 	}
 	return s.createUserResourceMapping(ctx, tx, urm)
+}
+
+func (s *Service) createNotificationTask(ctx context.Context, tx Tx, r influxdb.NotificationRule) (*influxdb.Task, error) {
+	// TODO(desa): figure out what to do about this
+	//ep, _, _, err := s.findNotificationEndpointByID(ctx, tx, r.GetEndpointID())
+	//if err != nil {
+	//	return nil, err
+	//}
+
+	// TODO(desa): pass in non nil notification endpoint.
+	script, err := r.GenerateFlux(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tc := influxdb.TaskCreate{
+		Type:           r.Type(),
+		Flux:           script,
+		OwnerID:        r.GetOwnerID(),
+		OrganizationID: r.GetOrgID(),
+	}
+
+	t, err := s.createTask(ctx, tx, tc)
+	if err != nil {
+		return nil, err
+	}
+
+	return t, nil
 }
 
 // UpdateNotificationRule updates a single notification rule.
@@ -116,7 +153,21 @@ func (s *Service) updateNotificationRule(ctx context.Context, tx Tx, id influxdb
 	nr.SetOwnerID(current.GetOwnerID())
 	nr.SetCreatedAt(current.GetCRUDLog().CreatedAt)
 	nr.SetUpdatedAt(s.TimeGenerator.Now())
-	nr.SetTaskID(current.GetTaskID())
+
+	if nr.GetTaskID().Valid() {
+		if err := s.deleteTask(ctx, tx, nr.GetTaskID()); err != nil {
+			return nil, err
+		}
+	}
+
+	if nr.GetStatus() == influxdb.Active {
+		t, err := s.createNotificationTask(ctx, tx, nr)
+		if err != nil {
+			return nil, err
+		}
+
+		nr.SetTaskID(t.ID)
+	}
 
 	if err := s.putNotificationRule(ctx, tx, nr); err != nil {
 		return nil, err
@@ -161,6 +212,12 @@ func (s *Service) patchNotificationRule(ctx context.Context, tx Tx, id influxdb.
 	err = s.putNotificationRule(ctx, tx, nr)
 	if err != nil {
 		return nil, err
+	}
+
+	if nr.GetTaskID().Valid() && nr.GetStatus() == influxdb.Inactive {
+		if err := s.deleteTask(ctx, tx, nr.GetTaskID()); err != nil {
+			return nil, err
+		}
 	}
 
 	return nr, nil
@@ -360,9 +417,15 @@ func (s *Service) DeleteNotificationRule(ctx context.Context, id influxdb.ID) er
 }
 
 func (s *Service) deleteNotificationRule(ctx context.Context, tx Tx, id influxdb.ID) error {
-	_, err := s.findNotificationRuleByID(ctx, tx, id)
+	nr, err := s.findNotificationRuleByID(ctx, tx, id)
 	if err != nil {
 		return err
+	}
+
+	if nr.GetTaskID().Valid() {
+		if err := s.deleteTask(ctx, tx, nr.GetTaskID()); err != nil {
+			return err
+		}
 	}
 
 	encodedID, err := id.Encode()

--- a/kv/notification_rule_test.go
+++ b/kv/notification_rule_test.go
@@ -74,6 +74,12 @@ func initNotificationRuleStore(s kv.Store, f influxdbtesting.NotificationRuleFie
 		}
 	}
 
+	for _, c := range f.Tasks {
+		if _, err := svc.CreateTask(ctx, c); err != nil {
+			t.Fatalf("failed to populate task: %v", err)
+		}
+	}
+
 	return svc, func() {
 		for _, nr := range f.NotificationRules {
 			if err := svc.DeleteNotificationRule(ctx, nr.GetID()); err != nil {

--- a/mock/notification_rule_store.go
+++ b/mock/notification_rule_store.go
@@ -12,6 +12,7 @@ var _ influxdb.NotificationRuleStore = &NotificationRuleStore{}
 type NotificationRuleStore struct {
 	OrganizationService
 	UserResourceMappingService
+	TaskService
 	FindNotificationRuleByIDF func(ctx context.Context, id influxdb.ID) (influxdb.NotificationRule, error)
 	FindNotificationRulesF    func(ctx context.Context, filter influxdb.NotificationRuleFilter, opt ...influxdb.FindOptions) ([]influxdb.NotificationRule, int, error)
 	CreateNotificationRuleF   func(ctx context.Context, nr influxdb.NotificationRule, userID influxdb.ID) error

--- a/notification.go
+++ b/notification.go
@@ -115,6 +115,7 @@ type NotificationRuleStore interface {
 	UserResourceMappingService
 	// OrganizationService is needed for search filter
 	OrganizationService
+	TaskService
 
 	// FindNotificationRuleByID returns a single notification rule by ID.
 	FindNotificationRuleByID(ctx context.Context, id ID) (NotificationRule, error)

--- a/testing/checks.go
+++ b/testing/checks.go
@@ -111,6 +111,7 @@ type CheckFields struct {
 	Checks               []influxdb.Check
 	Organizations        []*influxdb.Organization
 	UserResourceMappings []*influxdb.UserResourceMapping
+	Tasks                []influxdb.TaskCreate
 }
 
 type checkServiceF func(
@@ -868,6 +869,14 @@ func DeleteCheck(
 						ID:   MustIDBase16(orgOneID),
 					},
 				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
+					},
+				},
 				Checks: []influxdb.Check{
 					deadman1,
 					threshold1,
@@ -890,6 +899,14 @@ func DeleteCheck(
 					{
 						Name: "theorg",
 						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1088,6 +1105,14 @@ func UpdateCheck(
 				Checks: []influxdb.Check{
 					deadman1,
 				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
+					},
+				},
 			},
 			args: args{
 				id: MustIDBase16(checkOneID),
@@ -1257,11 +1282,20 @@ func PatchCheck(
 		{
 			name: "mixed patch",
 			fields: CheckFields{
+				IDGenerator:   mock.NewIDGenerator("0000000000000001", t),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2007, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
 						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
 					},
 				},
 				Checks: []influxdb.Check{
@@ -1308,11 +1342,20 @@ func PatchCheck(
 		{
 			name: "update name unique",
 			fields: CheckFields{
+				IDGenerator:   mock.NewIDGenerator("0000000000000001", t),
 				TimeGenerator: mock.TimeGenerator{FakeValue: time.Date(2006, 5, 4, 1, 2, 3, 0, time.UTC)},
 				Organizations: []*influxdb.Organization{
 					{
 						Name: "theorg",
 						ID:   MustIDBase16(orgOneID),
+					},
+				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						Flux: `option task = { every: 10s, name: "foo" }
+		data = from(bucket: "telegraf") |> range(start: -1m)`,
+						OrganizationID: MustIDBase16(orgOneID),
+						OwnerID:        MustIDBase16(sixID),
 					},
 				},
 				Checks: []influxdb.Check{

--- a/testing/notification_rule.go
+++ b/testing/notification_rule.go
@@ -20,6 +20,7 @@ type NotificationRuleFields struct {
 	NotificationRules    []influxdb.NotificationRule
 	Orgs                 []*influxdb.Organization
 	UserResourceMappings []*influxdb.UserResourceMapping
+	Tasks                []influxdb.TaskCreate
 }
 
 var notificationRuleCmpOptions = cmp.Options{
@@ -1396,6 +1397,15 @@ func UpdateNotificationRule(
 						ResourceType: influxdb.NotificationRuleResourceType,
 					},
 				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						OwnerID:        MustIDBase16(sixID),
+						OrganizationID: MustIDBase16(fourID),
+						Flux: `from(bucket: "foo") |> range(start: -1m)
+						option task = {name: "bar", every: 1m}
+						`,
+					},
+				},
 				Orgs: []*influxdb.Organization{
 					{
 						ID:   MustIDBase16(fourID),
@@ -1858,6 +1868,15 @@ func DeleteNotificationRule(
 						ResourceType: influxdb.NotificationRuleResourceType,
 					},
 				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						OwnerID:        MustIDBase16(sixID),
+						OrganizationID: MustIDBase16(fourID),
+						Flux: `from(bucket: "foo") |> range(start: -1m)
+						option task = {name: "bar", every: 1m}
+						`,
+					},
+				},
 				IDGenerator: mock.NewIDGenerator(twoID, t),
 				Orgs: []*influxdb.Organization{
 					{
@@ -1985,6 +2004,15 @@ func DeleteNotificationRule(
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Member,
 						ResourceType: influxdb.NotificationRuleResourceType,
+					},
+				},
+				Tasks: []influxdb.TaskCreate{
+					{
+						OwnerID:        MustIDBase16(sixID),
+						OrganizationID: MustIDBase16(fourID),
+						Flux: `from(bucket: "foo") |> range(start: -1m)
+						option task = {name: "bar", every: 1m}
+						`,
 					},
 				},
 				IDGenerator: mock.NewIDGenerator(twoID, t),


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/14728

Add task creation back to kv, in favor of task dispatcher interface.


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
