### PR TITLE
tests(cmd/influxd/launcher): add a launcher test for the secret service

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -721,7 +721,7 @@ func (m *Launcher) BucketService() platform.BucketService {
 	return m.apibackend.BucketService
 }
 
-// UserService returns the internal suser service.
+// UserService returns the internal user service.
 func (m *Launcher) UserService() platform.UserService {
 	return m.apibackend.UserService
 }
@@ -729,6 +729,11 @@ func (m *Launcher) UserService() platform.UserService {
 // AuthorizationService returns the internal authorization service.
 func (m *Launcher) AuthorizationService() platform.AuthorizationService {
 	return m.apibackend.AuthorizationService
+}
+
+// SecretService returns the internal secret service.
+func (m *Launcher) SecretService() platform.SecretService {
+	return m.apibackend.SecretService
 }
 
 // TaskService returns the internal task service.


### PR DESCRIPTION
The secret service is tested by creating a secret and then attempting to
use it in a flux query. There is one test where accessing the secret
should work and one where it should return that the action is forbidden.

#14801