### PR TITLE
fix(bolt): use named imports for bbolt

### DIFF
--- a/bolt/keyvalue_log.go
+++ b/bolt/keyvalue_log.go
@@ -9,8 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coreos/bbolt"
-
+	bolt "github.com/coreos/bbolt"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"
 )

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -7,11 +7,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/coreos/bbolt"
-	"go.uber.org/zap"
-
+	bolt "github.com/coreos/bbolt"
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/kv"
+	"go.uber.org/zap"
 )
 
 // KVStore is a kv.Store backed by boltdb.


### PR DESCRIPTION
The bbolt project has one version that uses the import `bolt` and one
that uses `bbolt`. The go module system doesn't really differentiate
between these two as different modules though so it is easy to switch to
using one or the other.

To remain consistent, the `bolt` named import is used everywhere so it
doesn't matter which version is used.