### PR TITLE
refactor(ui): fix update timestamps, fix onboarding button, and create client libraries page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### UI Improvements
 1. [14709](https://github.com/influxdata/influxdb/pull/14709): Move Buckets, Telgrafs, and Scrapers pages into a tab called "Load Data" for ease of discovery
+1. [14846](https://github.com/influxdata/influxdb/pull/14846): Standardize formatting of "updated at" timestamp in all resource cards
 
 ### Bug Fixes
 
@@ -20,6 +21,7 @@
 1. [14492](https://github.com/influxdata/influxdb/pull/14492): Fix to surface errors properly as task notifications on create.
 1. [14569](https://github.com/influxdata/influxdb/pull/14569): Fix limiting of get runs for task.
 1. [14779](https://github.com/influxdata/influxdb/pull/14779): Refactor tasks coordinator.
+1. [14846](https://github.com/influxdata/influxdb/pull/14846): Ensure onboarding "advanced" button goes to correct location
 
 ## v2.0.0-alpha.16 [2019-07-25]
 

--- a/ui/src/alerting/components/CheckCard.tsx
+++ b/ui/src/alerting/components/CheckCard.tsx
@@ -29,6 +29,9 @@ import {viewableLabels} from 'src/labels/selectors'
 // Types
 import {Check, Label, AppState, AlertHistoryType} from 'src/types'
 
+// Utilities
+import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
+
 interface DispatchProps {
   updateCheck: typeof updateCheck
   deleteCheck: typeof deleteCheck
@@ -156,7 +159,9 @@ const CheckCard: FunctionComponent<Props> = ({
           onClone={onClone}
         />
       }
-      metaData={[<>Last updated: {check.updatedAt}</>]}
+      metaData={[
+        <>{relativeTimestampFormatter(check.updatedAt, 'Last updated ')}</>,
+      ]}
     />
   )
 }

--- a/ui/src/alerting/components/endpoints/EndpointCard.tsx
+++ b/ui/src/alerting/components/endpoints/EndpointCard.tsx
@@ -36,6 +36,9 @@ import {
 } from 'src/types'
 import {Action} from 'src/alerting/actions/notifications/endpoints'
 
+// Utilities
+import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
+
 interface DispatchProps {
   onDeleteEndpoint: typeof deleteEndpoint
   onAddEndpointLabel: typeof addEndpointLabel
@@ -172,7 +175,9 @@ const EndpointCard: FC<Props> = ({
       description={descriptionComponent}
       labels={labelsComponent}
       disabled={status === 'inactive'}
-      metaData={[<>Last updated: {endpoint.updatedAt}</>]}
+      metaData={[
+        <>{relativeTimestampFormatter(endpoint.updatedAt, 'Last updated ')}</>,
+      ]}
       testID={`endpoint-card ${name}`}
     />
   )

--- a/ui/src/alerting/components/notifications/RuleCard.tsx
+++ b/ui/src/alerting/components/notifications/RuleCard.tsx
@@ -34,6 +34,9 @@ import {
   AlertHistoryType,
 } from 'src/types'
 
+// Utilities
+import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
+
 interface DispatchProps {
   onUpdateRuleProperties: typeof updateRuleProperties
   deleteNotificationRule: typeof deleteRule
@@ -161,7 +164,9 @@ const RuleCard: FC<Props> = ({
           onDelete={onDelete}
         />
       }
-      metaData={[<>Last updated: {rule.updatedAt}</>]}
+      metaData={[
+        <>{relativeTimestampFormatter(rule.updatedAt, 'Last updated ')}</>,
+      ]}
     />
   )
 }

--- a/ui/src/clientLibraries/components/ClientLibraries.tsx
+++ b/ui/src/clientLibraries/components/ClientLibraries.tsx
@@ -1,0 +1,138 @@
+// Libraries
+import _ from 'lodash'
+import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+import {withRouter, WithRouterProps} from 'react-router'
+
+// Components
+import {EmptyState, Grid, Sort} from '@influxdata/clockface'
+import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
+import SettingsTabbedPageHeader from 'src/settings/components/SettingsTabbedPageHeader'
+import ClientLibraryList from 'src/clientLibraries/components/ClientLibraryList'
+import FilterList from 'src/shared/components/Filter'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+// Types
+import {ComponentSize} from '@influxdata/clockface'
+import {AppState} from 'src/types'
+import {SortTypes} from 'src/shared/utils/sort'
+
+// Mocks
+import {ClientLibrary} from 'src/clientLibraries/constants/mocks'
+
+interface StateProps {
+  orgName: string
+}
+
+interface OwnProps {
+  libraries: ClientLibrary[]
+}
+
+type Props = OwnProps & StateProps & WithRouterProps
+
+interface State {
+  searchTerm: string
+  sortKey: SortKey
+  sortDirection: Sort
+  sortType: SortTypes
+}
+
+type SortKey = keyof ClientLibrary
+
+@ErrorHandling
+class ClientLibraries extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      searchTerm: '',
+      sortKey: 'name',
+      sortDirection: Sort.Ascending,
+      sortType: SortTypes.String,
+    }
+  }
+
+  public render() {
+    const {libraries} = this.props
+    const {searchTerm, sortKey, sortDirection, sortType} = this.state
+
+    return (
+      <>
+        <SettingsTabbedPageHeader>
+          <SearchWidget
+            placeholderText="Filter client libraries..."
+            searchTerm={searchTerm}
+            onSearch={this.handleFilterChange}
+          />
+        </SettingsTabbedPageHeader>
+        <Grid>
+          <Grid.Row>
+            <Grid.Column>
+              {/* Do we need the "No Buckets" warning here? */}
+              <FilterList<ClientLibrary>
+                searchTerm={searchTerm}
+                searchKeys={['name', 'description']}
+                list={libraries}
+              >
+                {cl => (
+                  <ClientLibraryList
+                    libraries={cl}
+                    emptyState={this.emptyState}
+                    sortKey={sortKey}
+                    sortDirection={sortDirection}
+                    sortType={sortType}
+                    onClickColumn={this.handleClickColumn}
+                  />
+                )}
+              </FilterList>
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </>
+    )
+  }
+
+  private handleClickColumn = (nextSort: Sort, sortKey: SortKey) => {
+    const sortType = SortTypes.String
+    this.setState({sortKey, sortDirection: nextSort, sortType})
+  }
+
+  private get emptyState(): JSX.Element {
+    const {searchTerm} = this.state
+
+    if (_.isEmpty(searchTerm)) {
+      return (
+        <EmptyState size={ComponentSize.Medium}>
+          <EmptyState.Text text="This list should not be empty" />
+        </EmptyState>
+      )
+    }
+
+    return (
+      <EmptyState size={ComponentSize.Medium}>
+        <EmptyState.Text
+          text="No Client  Libraries  match your query"
+          highlightWords={['Client', 'Libraries']}
+        />
+      </EmptyState>
+    )
+  }
+
+  private handleFilterChange = (searchTerm: string): void => {
+    this.handleFilterUpdate(searchTerm)
+  }
+
+  private handleFilterUpdate = (searchTerm: string) => {
+    this.setState({searchTerm})
+  }
+}
+const mstp = ({orgs: {org}}: AppState): StateProps => ({
+  orgName: org.name,
+})
+
+export default connect<StateProps, {}>(
+  mstp,
+  null
+)(withRouter<OwnProps>(ClientLibraries))

--- a/ui/src/clientLibraries/components/ClientLibraryList.tsx
+++ b/ui/src/clientLibraries/components/ClientLibraryList.tsx
@@ -1,0 +1,80 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import _ from 'lodash'
+import memoizeOne from 'memoize-one'
+
+// Components
+import {ResourceList} from '@influxdata/clockface'
+import LibraryCard from 'src/clientLibraries/components/LibraryCard'
+
+// Types
+import {Sort} from '@influxdata/clockface'
+import {SortTypes, getSortedResources} from 'src/shared/utils/sort'
+
+// Mocks
+import {ClientLibrary} from 'src/clientLibraries/constants/mocks'
+
+type SortKey = keyof ClientLibrary
+
+interface Props {
+  libraries: ClientLibrary[]
+  emptyState: JSX.Element
+  sortKey: string
+  sortDirection: Sort
+  sortType: SortTypes
+  onClickColumn: (nextSort: Sort, sortKey: SortKey) => void
+}
+
+export default class CollectorList extends PureComponent<Props> {
+  private memGetSortedResources = memoizeOne<typeof getSortedResources>(
+    getSortedResources
+  )
+
+  public render() {
+    const {emptyState, sortKey, sortDirection, onClickColumn} = this.props
+
+    return (
+      <>
+        <ResourceList>
+          <ResourceList.Header>
+            <ResourceList.Sorter
+              sortKey={this.headerKeys[0]}
+              sort={sortKey === this.headerKeys[0] ? sortDirection : Sort.None}
+              name="Name"
+              onClick={onClickColumn}
+            />
+            <ResourceList.Sorter
+              name="Description"
+              sortKey={this.headerKeys[1]}
+              sort={sortKey === this.headerKeys[1] ? sortDirection : Sort.None}
+              onClick={onClickColumn}
+            />
+          </ResourceList.Header>
+          <ResourceList.Body emptyState={emptyState}>
+            {this.libraryList}
+          </ResourceList.Body>
+        </ResourceList>
+      </>
+    )
+  }
+
+  private get headerKeys(): SortKey[] {
+    return ['name', 'description']
+  }
+
+  public get libraryList(): JSX.Element[] {
+    const {libraries, sortKey, sortDirection, sortType} = this.props
+    const sortedLibraries = this.memGetSortedResources(
+      libraries,
+      sortKey,
+      sortDirection,
+      sortType
+    )
+
+    if (libraries !== undefined) {
+      return sortedLibraries.map(library => (
+        <LibraryCard key={library.id} library={library} />
+      ))
+    }
+  }
+}

--- a/ui/src/clientLibraries/components/LibraryCard.tsx
+++ b/ui/src/clientLibraries/components/LibraryCard.tsx
@@ -1,0 +1,35 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import {ResourceCard} from '@influxdata/clockface'
+
+// Mocks
+import {ClientLibrary} from 'src/clientLibraries/constants/mocks'
+
+interface OwnProps {
+  library: ClientLibrary
+}
+
+type Props = OwnProps
+
+class LibraryCard extends PureComponent<Props> {
+  public render() {
+    const {library} = this.props
+
+    return (
+      <ResourceCard
+        key={`library-id--${library.id}`}
+        testID="resource-card"
+        name={
+          <ResourceCard.Name name={library.name} testID="library-card--name" />
+        }
+        description={
+          <ResourceCard.Description description={library.description} />
+        }
+      />
+    )
+  }
+}
+
+export default LibraryCard

--- a/ui/src/clientLibraries/constants/mocks.ts
+++ b/ui/src/clientLibraries/constants/mocks.ts
@@ -1,0 +1,28 @@
+export interface ClientLibrary {
+  id: string
+  name: string
+  description?: string
+}
+
+export const mockClientLibraries: ClientLibrary[] = [
+  {
+    id: 'client-lib-js',
+    name: 'Javascript',
+    description: 'Write to InfuxDB using Javascript',
+  },
+  {
+    id: 'client-lib-node',
+    name: 'Node',
+    description: 'Write to InfuxDB using Node',
+  },
+  {
+    id: 'client-lib-go',
+    name: 'GO',
+    description: 'Write to InfuxDB using GO',
+  },
+  {
+    id: 'client-lib-python',
+    name: 'Python',
+    description: 'Write to InfuxDB using Python',
+  },
+]

--- a/ui/src/clientLibraries/containers/ClientLibrariesPage.tsx
+++ b/ui/src/clientLibraries/containers/ClientLibrariesPage.tsx
@@ -1,0 +1,46 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+
+// Components
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import LoadDataTabbedPage from 'src/settings/components/LoadDataTabbedPage'
+import LoadDataHeader from 'src/settings/components/LoadDataHeader'
+import {Page} from 'src/pageLayout'
+import ClientLibraries from 'src/clientLibraries/components/ClientLibraries'
+
+// Types
+import {AppState, Organization} from 'src/types'
+
+// Mocks
+import {mockClientLibraries} from 'src/clientLibraries/constants/mocks'
+
+interface StateProps {
+  org: Organization
+}
+
+@ErrorHandling
+class ClientLibrariesPage extends PureComponent<StateProps> {
+  public render() {
+    const {org, children} = this.props
+
+    return (
+      <>
+        <Page titleTag={org.name}>
+          <LoadDataHeader />
+          <LoadDataTabbedPage activeTab="client-libraries" orgID={org.id}>
+            {/* TODO: use GetResources here when this resource exists */}
+            <ClientLibraries libraries={mockClientLibraries} />
+          </LoadDataTabbedPage>
+        </Page>
+        {children}
+      </>
+    )
+  }
+}
+
+const mstp = ({orgs: {org}}: AppState): StateProps => ({
+  org,
+})
+
+export default connect<StateProps>(mstp)(ClientLibrariesPage)

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -25,6 +25,9 @@ import {AppState, Dashboard, Label} from 'src/types'
 import {DEFAULT_DASHBOARD_NAME} from 'src/dashboards/constants'
 import {resetViews} from 'src/dashboards/actions/views'
 
+// Utilities
+import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
+
 interface PassedProps {
   dashboard: Dashboard
   onDeleteDashboard: (dashboard: Dashboard) => void
@@ -83,7 +86,14 @@ class DashboardCard extends PureComponent<Props> {
             onCreateLabel={this.handleCreateLabel}
           />
         }
-        metaData={[<>Last updated: {dashboard.meta.updatedAt}</>]}
+        metaData={[
+          <>
+            {relativeTimestampFormatter(
+              dashboard.meta.updatedAt,
+              'Last modified '
+            )}
+          </>,
+        ]}
         contextMenu={this.contextMenu}
       />
     )

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -46,6 +46,7 @@ import OnboardingWizardPage from 'src/onboarding/containers/OnboardingWizardPage
 import BucketsIndex from 'src/buckets/containers/BucketsIndex'
 import TemplatesIndex from 'src/templates/containers/TemplatesIndex'
 import TelegrafsPage from 'src/telegrafs/containers/TelegrafsPage'
+import ClientLibrariesPage from 'src/clientLibraries/containers/ClientLibrariesPage'
 import TemplateImportOverlay from 'src/templates/components/TemplateImportOverlay'
 import TemplateExportOverlay from 'src/templates/components/TemplateExportOverlay'
 import VariablesIndex from 'src/variables/containers/VariablesIndex'
@@ -265,6 +266,12 @@ class Root extends PureComponent {
                                 component={CreateScraperOverlay}
                               />
                             </Route>
+                            <FeatureFlag name="clientLibrariesPage">
+                              <Route
+                                path="client-libraries"
+                                component={ClientLibrariesPage}
+                              />
+                            </FeatureFlag>
                           </Route>
                           <Route path="tokens" component={TokensIndex}>
                             <Route path="generate">

--- a/ui/src/onboarding/components/CompletionAdvancedButton.tsx
+++ b/ui/src/onboarding/components/CompletionAdvancedButton.tsx
@@ -35,7 +35,7 @@ class CompletionAdvancedButton extends PureComponent<Props> {
     const {router, orgs, onExit} = this.props
     const id = _.get(orgs, '0.id', null)
     if (id) {
-      router.push(`/orgs/${id}/buckets`)
+      router.push(`/orgs/${id}/load-data/buckets`)
     } else {
       onExit()
     }

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -68,6 +68,7 @@ class SideNav extends PureComponent<Props, State> {
     const bucketsLink = `${orgPrefix}/load-data/buckets`
     const telegrafsLink = `${orgPrefix}/load-data/telegrafs`
     const scrapersLink = `${orgPrefix}/load-data/scrapers`
+    const clientLibrariesLink = `${orgPrefix}/load-data/client-libraries`
     const settingsLink = `${orgPrefix}/settings`
     const feedbackLink =
       'https://docs.google.com/forms/d/e/1FAIpQLSdGJpnIZGotN1VFJPkgZEhrt4t4f6QY1lMgMSRUnMeN3FjCKA/viewform?usp=sf_link'
@@ -204,6 +205,20 @@ class SideNav extends PureComponent<Props, State> {
             active={getNavItemActivation(['scrapers'], location.pathname)}
             key="scrapers"
           />
+          <FeatureFlag name="clientLibrariesPage">
+            <NavMenu.SubItem
+              titleLink={className => (
+                <Link to={clientLibrariesLink} className={className}>
+                  Client Libraries
+                </Link>
+              )}
+              active={getNavItemActivation(
+                ['client-libraries'],
+                location.pathname
+              )}
+              key="client-libraries"
+            />
+          </FeatureFlag>
         </NavMenu.Item>
         <NavMenu.Item
           titleLink={className => (

--- a/ui/src/settings/components/LoadDataNavigation.tsx
+++ b/ui/src/settings/components/LoadDataNavigation.tsx
@@ -11,6 +11,7 @@ import {
   ComponentSize,
   InfluxColors,
 } from '@influxdata/clockface'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -37,16 +38,25 @@ class LoadDataNavigation extends PureComponent<Props> {
         text: 'Buckets',
         id: 'buckets',
         cloudExclude: false,
+        featureFlag: null,
       },
       {
         text: 'Telegraf',
         id: 'telegrafs',
         cloudExclude: false,
+        featureFlag: null,
       },
       {
         text: 'Scrapers',
         id: 'scrapers',
         cloudExclude: true,
+        featureFlag: null,
+      },
+      {
+        text: 'Client Libraries',
+        id: 'client-libraries',
+        cloudExclude: false,
+        featureFlag: 'clientLibrariesPage',
       },
     ]
 
@@ -57,21 +67,7 @@ class LoadDataNavigation extends PureComponent<Props> {
         backgroundColor={`${chroma(`${InfluxColors.Castle}`).alpha(0.1)}`}
       >
         {tabs.map(t => {
-          if (t.cloudExclude) {
-            return (
-              <CloudExclude key={t.id}>
-                <Tabs.Tab
-                  text={t.text}
-                  id={t.id}
-                  onClick={handleTabClick}
-                  active={t.id === activeTab}
-                  size={ComponentSize.Large}
-                  backgroundColor={InfluxColors.Castle}
-                />
-              </CloudExclude>
-            )
-          }
-          return (
+          let tabElement = (
             <Tabs.Tab
               key={t.id}
               text={t.text}
@@ -82,6 +78,19 @@ class LoadDataNavigation extends PureComponent<Props> {
               backgroundColor={InfluxColors.Castle}
             />
           )
+
+          if (t.cloudExclude) {
+            tabElement = <CloudExclude key={t.id}>{tabElement}</CloudExclude>
+          }
+
+          if (t.featureFlag) {
+            tabElement = (
+              <FeatureFlag key={t.id} name={t.featureFlag}>
+                {tabElement}
+              </FeatureFlag>
+            )
+          }
+          return tabElement
         })}
       </Tabs>
     )

--- a/ui/src/shared/utils/relativeTimestampFormatter.ts
+++ b/ui/src/shared/utils/relativeTimestampFormatter.ts
@@ -1,0 +1,14 @@
+import moment from 'moment'
+
+export const relativeTimestampFormatter = (
+  time: string,
+  prefix?: string
+): string => {
+  const timeFromNow = moment(time).fromNow()
+
+  if (prefix) {
+    return `${prefix}${timeFromNow}`
+  }
+
+  return timeFromNow
+}

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -57,7 +57,6 @@
 @import 'src/shared/components/CodeSnippet.scss';
 @import 'src/buckets/components/Retention.scss';
 @import 'src/telegrafs/components/TelegrafConfigOverlay.scss';
-@import 'src/telegrafs/components/TelegrafExplainer.scss';
 @import 'src/variables/components/CreateVariableOverlay.scss';
 @import 'src/authorizations/components/BucketsSelector.scss';
 @import 'src/tasks/components/TaskForm.scss';

--- a/ui/src/telegrafs/components/Collectors.tsx
+++ b/ui/src/telegrafs/components/Collectors.tsx
@@ -199,7 +199,7 @@ class Collectors extends PureComponent<Props, State> {
 
     onSetDataLoadersType(DataLoaderType.Scraping)
 
-    router.push(`/orgs/${orgID}/telegrafs/new`)
+    router.push(`/orgs/${orgID}/load-data/telegrafs/new`)
   }
 
   private get emptyState(): JSX.Element {
@@ -220,7 +220,10 @@ class Collectors extends PureComponent<Props, State> {
 
     return (
       <EmptyState size={ComponentSize.Medium}>
-        <EmptyState.Text text="No Telegraf  Configuration buckets match your query" />
+        <EmptyState.Text
+          text="No Telegraf  Configurations  match your query"
+          highlightWords={['Telegraf', 'Configurations']}
+        />
       </EmptyState>
     )
   }

--- a/ui/src/telegrafs/components/Collectors.tsx
+++ b/ui/src/telegrafs/components/Collectors.tsx
@@ -102,7 +102,11 @@ class Collectors extends PureComponent<Props, State> {
         </SettingsTabbedPageHeader>
         <Grid>
           <Grid.Row>
-            <Grid.Column widthSM={Columns.Twelve}>
+            <Grid.Column
+              widthXS={Columns.Twelve}
+              widthSM={Columns.Eight}
+              widthMD={Columns.Ten}
+            >
               <NoBucketsWarning
                 visible={this.hasNoBuckets}
                 resourceName="Telegraf Configurations"
@@ -130,10 +134,9 @@ class Collectors extends PureComponent<Props, State> {
               </GetResources>
             </Grid.Column>
             <Grid.Column
-              widthSM={Columns.Six}
-              widthMD={Columns.Four}
-              offsetSM={Columns.Three}
-              offsetMD={Columns.Four}
+              widthXS={Columns.Twelve}
+              widthSM={Columns.Four}
+              widthMD={Columns.Two}
             >
               <TelegrafExplainer />
             </Grid.Column>

--- a/ui/src/telegrafs/components/TelegrafExplainer.scss
+++ b/ui/src/telegrafs/components/TelegrafExplainer.scss
@@ -1,6 +1,0 @@
-.telegraf-explainer {
-  margin-top: $ix-marg-d;
-  color: $g13-mist;
-  user-select: none;
-}
-

--- a/ui/src/telegrafs/components/TelegrafExplainer.tsx
+++ b/ui/src/telegrafs/components/TelegrafExplainer.tsx
@@ -2,10 +2,10 @@
 import React, {SFC} from 'react'
 
 // Components
-import {Panel} from '@influxdata/clockface'
+import {Panel, InfluxColors} from '@influxdata/clockface'
 
 const TelegrafExplainer: SFC = () => (
-  <Panel className="telegraf-explainer">
+  <Panel backgroundColor={InfluxColors.Onyx} style={{marginTop: '32px'}}>
     <Panel.Header>
       <Panel.Title>What is Telegraf?</Panel.Title>
     </Panel.Header>
@@ -13,6 +13,7 @@ const TelegrafExplainer: SFC = () => (
       <p>
         Telegraf is an agent written in Go for collecting metrics and writing
         them into <strong>InfluxDB</strong> or other possible outputs.
+        <br />
         <br />
         Here's a handy guide for{' '}
         <a


### PR DESCRIPTION
Closes #14839 
Closes #14827 
Closes #14748 

- Make Telegraf explainer widget appear to the right of the list instead of below
- Ensure onboarding "advanced" button goes to correct location
- Standardize formatting of updated at timestamps in resource cards
- Introduce "Client Libraries" page
  - Feature flag name: `clientLibrariesPage`
  - Uses mock data & type
  - Intentionally left very plain in anticipation of an actual design for this page

![Screen Shot 2019-08-28 at 9 03 07 AM](https://user-images.githubusercontent.com/2433762/63889103-2b94e880-c995-11e9-9579-a65b41c15a96.png)
![Screen Shot 2019-08-28 at 1 10 23 PM](https://user-images.githubusercontent.com/2433762/63889118-394a6e00-c995-11e9-9eb3-cd7474863499.png)
![Screen Shot 2019-08-28 at 1 10 28 PM](https://user-images.githubusercontent.com/2433762/63889120-3b143180-c995-11e9-9a8c-e3dacd9edb52.png)


<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
