### PR TITLE
fix(http): fix notfication endpoint secret store

### DIFF
--- a/authorizer/notification_endpoint.go
+++ b/authorizer/notification_endpoint.go
@@ -14,7 +14,6 @@ type NotificationEndpointService struct {
 	s influxdb.NotificationEndpointService
 	influxdb.UserResourceMappingService
 	influxdb.OrganizationService
-	influxdb.SecretService
 }
 
 // NewNotificationEndpointService constructs an instance of an authorizing notification endpoint serivce.
@@ -22,13 +21,11 @@ func NewNotificationEndpointService(
 	s influxdb.NotificationEndpointService,
 	urm influxdb.UserResourceMappingService,
 	org influxdb.OrganizationService,
-	srt influxdb.SecretService,
 ) *NotificationEndpointService {
 	return &NotificationEndpointService{
 		s:                          s,
 		UserResourceMappingService: urm,
 		OrganizationService:        org,
-		SecretService:              srt,
 	}
 }
 
@@ -125,14 +122,14 @@ func (s *NotificationEndpointService) PatchNotificationEndpoint(ctx context.Cont
 }
 
 // DeleteNotificationEndpoint checks to see if the authorizer on context has write access to the notification endpoint provided.
-func (s *NotificationEndpointService) DeleteNotificationEndpoint(ctx context.Context, id influxdb.ID) error {
+func (s *NotificationEndpointService) DeleteNotificationEndpoint(ctx context.Context, id influxdb.ID) ([]influxdb.SecretField, influxdb.ID, error) {
 	edp, err := s.FindNotificationEndpointByID(ctx, id)
 	if err != nil {
-		return err
+		return nil, 0, err
 	}
 
 	if err := authorizeWriteOrg(ctx, edp.GetOrgID()); err != nil {
-		return err
+		return nil, 0, err
 	}
 
 	return s.s.DeleteNotificationEndpoint(ctx, id)

--- a/authorizer/notification_endpoint_test.go
+++ b/authorizer/notification_endpoint_test.go
@@ -109,7 +109,7 @@ func TestNotificationEndpointService_FindNotificationEndpointByID(t *testing.T) 
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := authorizer.NewNotificationEndpointService(tt.fields.NotificationEndpointService, mock.NewUserResourceMappingService(), mock.NewOrganizationService(), mock.NewSecretService())
+			s := authorizer.NewNotificationEndpointService(tt.fields.NotificationEndpointService, mock.NewUserResourceMappingService(), mock.NewOrganizationService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
@@ -257,7 +257,7 @@ func TestNotificationEndpointService_FindNotificationEndpoints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := authorizer.NewNotificationEndpointService(tt.fields.NotificationEndpointService,
 				mock.NewUserResourceMappingService(),
-				mock.NewOrganizationService(), mock.NewSecretService())
+				mock.NewOrganizationService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
@@ -382,7 +382,7 @@ func TestNotificationEndpointService_UpdateNotificationEndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := authorizer.NewNotificationEndpointService(tt.fields.NotificationEndpointService,
 				mock.NewUserResourceMappingService(),
-				mock.NewOrganizationService(), mock.NewSecretService())
+				mock.NewOrganizationService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
@@ -502,7 +502,7 @@ func TestNotificationEndpointService_PatchNotificationEndpoint(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := authorizer.NewNotificationEndpointService(tt.fields.NotificationEndpointService, mock.NewUserResourceMappingService(),
-				mock.NewOrganizationService(), mock.NewSecretService())
+				mock.NewOrganizationService())
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
@@ -543,8 +543,8 @@ func TestNotificationEndpointService_DeleteNotificationEndpoint(t *testing.T) {
 							},
 						}, nil
 					},
-					DeleteNotificationEndpointF: func(ctx context.Context, id influxdb.ID) error {
-						return nil
+					DeleteNotificationEndpointF: func(ctx context.Context, id influxdb.ID) ([]influxdb.SecretField, influxdb.ID, error) {
+						return nil, 0, nil
 					},
 				},
 			},
@@ -583,8 +583,8 @@ func TestNotificationEndpointService_DeleteNotificationEndpoint(t *testing.T) {
 							},
 						}, nil
 					},
-					DeleteNotificationEndpointF: func(ctx context.Context, id influxdb.ID) error {
-						return nil
+					DeleteNotificationEndpointF: func(ctx context.Context, id influxdb.ID) ([]influxdb.SecretField, influxdb.ID, error) {
+						return nil, 0, nil
 					},
 				},
 			},
@@ -613,13 +613,12 @@ func TestNotificationEndpointService_DeleteNotificationEndpoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := authorizer.NewNotificationEndpointService(tt.fields.NotificationEndpointService, mock.NewUserResourceMappingService(),
 				mock.NewOrganizationService(),
-				mock.NewSecretService(),
 			)
 
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{tt.args.permissions})
 
-			err := s.DeleteNotificationEndpoint(ctx, tt.args.id)
+			_, _, err := s.DeleteNotificationEndpoint(ctx, tt.args.id)
 			influxdbtesting.ErrorsEqual(t, err, tt.wants.err)
 		})
 	}
@@ -722,8 +721,7 @@ func TestNotificationEndpointService_CreateNotificationEndpoint(t *testing.T) {
 			s := authorizer.NewNotificationEndpointService(tt.fields.NotificationEndpointService,
 				mock.NewUserResourceMappingService(),
 				mock.NewOrganizationService(),
-				mock.NewSecretService())
-
+			)
 			ctx := context.Background()
 			ctx = influxdbcontext.SetAuthorizer(ctx, &Authorizer{[]influxdb.Permission{tt.args.permission}})
 

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -171,7 +171,7 @@ func NewAPIHandler(b *APIBackend) *APIHandler {
 
 	notificationEndpointBackend := NewNotificationEndpointBackend(b)
 	notificationEndpointBackend.NotificationEndpointService = authorizer.NewNotificationEndpointService(b.NotificationEndpointService,
-		b.UserResourceMappingService, b.OrganizationService, b.SecretService)
+		b.UserResourceMappingService, b.OrganizationService)
 	h.NotificationEndpointHandler = NewNotificationEndpointHandler(notificationEndpointBackend)
 
 	checkBackend := NewCheckBackend(b)

--- a/kv/notification_endpoint_test.go
+++ b/kv/notification_endpoint_test.go
@@ -56,14 +56,6 @@ func initNotificationEndpointService(s kv.Store, f influxdbtesting.NotificationE
 		t.Fatalf("error initializing user service: %v", err)
 	}
 
-	for _, s := range f.Secrets {
-		for k, v := range s.Env {
-			if err := svc.PutSecret(ctx, s.OrganizationID, k, v); err != nil {
-				t.Fatalf("failed to populate secrets")
-			}
-		}
-	}
-
 	for _, edp := range f.NotificationEndpoints {
 		if err := svc.PutNotificationEndpoint(ctx, edp); err != nil {
 			t.Fatalf("failed to populate notification endpoint: %v", err)
@@ -84,7 +76,7 @@ func initNotificationEndpointService(s kv.Store, f influxdbtesting.NotificationE
 
 	return svc, func() {
 		for _, edp := range f.NotificationEndpoints {
-			if err := svc.DeleteNotificationEndpoint(ctx, edp.GetID()); err != nil {
+			if _, _, err := svc.DeleteNotificationEndpoint(ctx, edp.GetID()); err != nil {
 				t.Logf("failed to remove notification endpoint: %v", err)
 			}
 		}
@@ -97,14 +89,6 @@ func initNotificationEndpointService(s kv.Store, f influxdbtesting.NotificationE
 		for _, urm := range f.UserResourceMappings {
 			if err := svc.DeleteUserResourceMapping(ctx, urm.ResourceID, urm.UserID); err != nil && influxdb.ErrorCode(err) != influxdb.ENotFound {
 				t.Logf("failed to remove urm rule: %v", err)
-			}
-		}
-
-		for _, s := range f.Secrets {
-			for k, v := range s.Env {
-				if err := svc.DeleteSecret(ctx, s.OrganizationID, k, v); err != nil && influxdb.ErrorCode(err) != influxdb.ENotFound {
-					t.Fatalf("failed to populate secrets")
-				}
 			}
 		}
 	}

--- a/mock/notification_endpoint_service.go
+++ b/mock/notification_endpoint_service.go
@@ -12,13 +12,12 @@ var _ influxdb.NotificationEndpointService = &NotificationEndpointService{}
 type NotificationEndpointService struct {
 	OrganizationService
 	UserResourceMappingService
-	SecretService
 	FindNotificationEndpointByIDF func(ctx context.Context, id influxdb.ID) (influxdb.NotificationEndpoint, error)
 	FindNotificationEndpointsF    func(ctx context.Context, filter influxdb.NotificationEndpointFilter, opt ...influxdb.FindOptions) ([]influxdb.NotificationEndpoint, int, error)
 	CreateNotificationEndpointF   func(ctx context.Context, nr influxdb.NotificationEndpoint, userID influxdb.ID) error
 	UpdateNotificationEndpointF   func(ctx context.Context, id influxdb.ID, nr influxdb.NotificationEndpoint, userID influxdb.ID) (influxdb.NotificationEndpoint, error)
 	PatchNotificationEndpointF    func(ctx context.Context, id influxdb.ID, upd influxdb.NotificationEndpointUpdate) (influxdb.NotificationEndpoint, error)
-	DeleteNotificationEndpointF   func(ctx context.Context, id influxdb.ID) error
+	DeleteNotificationEndpointF   func(ctx context.Context, id influxdb.ID) ([]influxdb.SecretField, influxdb.ID, error)
 }
 
 // FindNotificationEndpointByID returns a single telegraf config by ID.
@@ -50,6 +49,6 @@ func (s *NotificationEndpointService) PatchNotificationEndpoint(ctx context.Cont
 }
 
 // DeleteNotificationEndpoint removes a notification rule by ID.
-func (s *NotificationEndpointService) DeleteNotificationEndpoint(ctx context.Context, id influxdb.ID) error {
+func (s *NotificationEndpointService) DeleteNotificationEndpoint(ctx context.Context, id influxdb.ID) ([]influxdb.SecretField, influxdb.ID, error) {
 	return s.DeleteNotificationEndpointF(ctx, id)
 }

--- a/notification_endpoint.go
+++ b/notification_endpoint.go
@@ -97,8 +97,6 @@ type NotificationEndpointService interface {
 	UserResourceMappingService
 	// OrganizationService is needed for search filter
 	OrganizationService
-	// SecretService is needed to check if the secret key exists.
-	SecretService
 
 	// FindNotificationEndpointByID returns a single notification endpoint by ID.
 	FindNotificationEndpointByID(ctx context.Context, id ID) (NotificationEndpoint, error)
@@ -118,6 +116,6 @@ type NotificationEndpointService interface {
 	// Returns the new notification endpoint state after update.
 	PatchNotificationEndpoint(ctx context.Context, id ID, upd NotificationEndpointUpdate) (NotificationEndpoint, error)
 
-	// DeleteNotificationEndpoint removes a notification endpoint by ID.
-	DeleteNotificationEndpoint(ctx context.Context, id ID) error
+	// DeleteNotificationEndpoint removes a notification endpoint by ID, returns secret fields, orgID for further deletion.
+	DeleteNotificationEndpoint(ctx context.Context, id ID) (flds []SecretField, orgID ID, err error)
 }

--- a/testing/notification_endpoint.go
+++ b/testing/notification_endpoint.go
@@ -20,7 +20,6 @@ type NotificationEndpointFields struct {
 	NotificationEndpoints []influxdb.NotificationEndpoint
 	Orgs                  []*influxdb.Organization
 	UserResourceMappings  []*influxdb.UserResourceMapping
-	Secrets               []Secret
 }
 
 var timeGen1 = mock.TimeGenerator{FakeValue: time.Date(2006, time.July, 13, 4, 19, 10, 0, time.UTC)}
@@ -106,14 +105,6 @@ func CreateNotificationEndpoint(
 				TimeGenerator: fakeGenerator,
 				Orgs: []*influxdb.Organization{
 					{ID: MustIDBase16(fourID), Name: "org1"},
-				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token": "slack-secret-1",
-						},
-					},
 				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
@@ -203,90 +194,6 @@ func CreateNotificationEndpoint(
 				},
 			},
 		},
-		{
-			name: "secret not found",
-			fields: NotificationEndpointFields{
-				IDGenerator:   mock.NewIDGenerator(twoID, t),
-				TimeGenerator: fakeGenerator,
-				Orgs: []*influxdb.Organization{
-					{ID: MustIDBase16(fourID), Name: "org1"},
-				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token": "slack-secret-1",
-						},
-					},
-				},
-				NotificationEndpoints: []influxdb.NotificationEndpoint{
-					&endpoint.Slack{
-						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
-							Status: influxdb.Active,
-							CRUDLog: influxdb.CRUDLog{
-								CreatedAt: timeGen1.Now(),
-								UpdatedAt: timeGen2.Now(),
-							},
-						},
-						URL:   "example-slack.com",
-						Token: influxdb.SecretField{Key: oneID + "-token"},
-					},
-				},
-				UserResourceMappings: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(oneID),
-						ResourceType: influxdb.NotificationEndpointResourceType,
-						UserID:       MustIDBase16(sixID),
-						UserType:     influxdb.Member,
-					},
-				},
-			},
-			args: args{
-				userID: MustIDBase16(sixID),
-				notificationEndpoint: &endpoint.PagerDuty{
-					Base: endpoint.Base{
-						Name:   "name2",
-						OrgID:  MustIDBase16(fourID),
-						Status: influxdb.Active,
-					},
-					URL:        "example-pagerduty.com",
-					RoutingKey: influxdb.SecretField{Key: twoID + "-routing-key"},
-				},
-			},
-			wants: wants{
-				err: &influxdb.Error{
-					Code: influxdb.EInvalid,
-					Msg:  "Unable to locate secret key: " + twoID + "-routing-key",
-				},
-				notificationEndpoints: []influxdb.NotificationEndpoint{
-					&endpoint.Slack{
-						Base: endpoint.Base{
-							ID:     MustIDBase16(oneID),
-							Name:   "name1",
-							OrgID:  MustIDBase16(fourID),
-							Status: influxdb.Active,
-							CRUDLog: influxdb.CRUDLog{
-								CreatedAt: timeGen1.Now(),
-								UpdatedAt: timeGen2.Now(),
-							},
-						},
-						URL:   "example-slack.com",
-						Token: influxdb.SecretField{Key: oneID + "-token"},
-					},
-				},
-				userResourceMapping: []*influxdb.UserResourceMapping{
-					{
-						ResourceID:   MustIDBase16(oneID),
-						ResourceType: influxdb.NotificationEndpointResourceType,
-						UserID:       MustIDBase16(sixID),
-						UserType:     influxdb.Member,
-					},
-				},
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -358,15 +265,6 @@ func FindNotificationEndpointByID(
 						ResourceType: influxdb.NotificationEndpointResourceType,
 					},
 				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
@@ -425,15 +323,6 @@ func FindNotificationEndpointByID(
 						ResourceType: influxdb.NotificationEndpointResourceType,
 					},
 				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
@@ -490,15 +379,6 @@ func FindNotificationEndpointByID(
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Member,
 						ResourceType: influxdb.NotificationEndpointResourceType,
-					},
-				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
 					},
 				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
@@ -602,15 +482,6 @@ func FindNotificationEndpoints(
 		{
 			name: "find all notification endpoints",
 			fields: NotificationEndpointFields{
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
@@ -681,21 +552,6 @@ func FindNotificationEndpoints(
 		{
 			name: "filter by organization id only",
 			fields: NotificationEndpointFields{
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-					{
-						OrganizationID: MustIDBase16(oneID),
-						Env: map[string]string{
-							fourID + "-routing-key": "pager-duty-secret-3",
-						},
-					},
-				},
 				Orgs: []*influxdb.Organization{
 					{
 						ID:   MustIDBase16(oneID),
@@ -762,20 +618,6 @@ func FindNotificationEndpoints(
 		{
 			name: "filter by organization name only",
 			fields: NotificationEndpointFields{
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token": "slack-secret-1",
-						},
-					},
-					{
-						OrganizationID: MustIDBase16(oneID),
-						Env: map[string]string{
-							fourID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				Orgs: []*influxdb.Organization{
 					{
 						ID:   MustIDBase16(oneID),
@@ -854,20 +696,6 @@ func FindNotificationEndpoints(
 		{
 			name: "find by id",
 			fields: NotificationEndpointFields{
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token": "slack-secret-1",
-						},
-					},
-					{
-						OrganizationID: MustIDBase16(oneID),
-						Env: map[string]string{
-							fourID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				Orgs: []*influxdb.Organization{
 					{
 						ID:   MustIDBase16(oneID),
@@ -935,15 +763,6 @@ func FindNotificationEndpoints(
 		{
 			name: "look for organization not bound to any notification endpoint",
 			fields: NotificationEndpointFields{
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":         "slack-secret-1",
-							threeID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				Orgs: []*influxdb.Organization{
 					{
 						ID:   MustIDBase16(oneID),
@@ -999,15 +818,6 @@ func FindNotificationEndpoints(
 		{
 			name: "find nothing",
 			fields: NotificationEndpointFields{
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":         "slack-secret-1",
-							threeID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				Orgs: []*influxdb.Organization{
 					{
 						ID:   MustIDBase16(oneID),
@@ -1093,7 +903,6 @@ func UpdateNotificationEndpoint(
 
 	type wants struct {
 		notificationEndpoint influxdb.NotificationEndpoint
-		secret               *Secret
 		err                  error
 	}
 	tests := []struct {
@@ -1118,15 +927,6 @@ func UpdateNotificationEndpoint(
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Member,
 						ResourceType: influxdb.NotificationEndpointResourceType,
-					},
-				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
 					},
 				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
@@ -1199,15 +999,6 @@ func UpdateNotificationEndpoint(
 						ResourceType: influxdb.NotificationEndpointResourceType,
 					},
 				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
@@ -1253,12 +1044,6 @@ func UpdateNotificationEndpoint(
 				},
 			},
 			wants: wants{
-				secret: &Secret{
-					OrganizationID: MustIDBase16(fourID),
-					Env: map[string]string{
-						twoID + "-routing-key": "pager-duty-secret-2",
-					},
-				},
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
 						ID:     MustIDBase16(twoID),
@@ -1291,15 +1076,6 @@ func UpdateNotificationEndpoint(
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Member,
 						ResourceType: influxdb.NotificationEndpointResourceType,
-					},
-				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
 					},
 				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
@@ -1351,12 +1127,6 @@ func UpdateNotificationEndpoint(
 				},
 			},
 			wants: wants{
-				secret: &Secret{
-					OrganizationID: MustIDBase16(fourID),
-					Env: map[string]string{
-						twoID + "-routing-key": "pager-duty-value2",
-					},
-				},
 				notificationEndpoint: &endpoint.PagerDuty{
 					Base: endpoint.Base{
 						ID:     MustIDBase16(twoID),
@@ -1391,20 +1161,6 @@ func UpdateNotificationEndpoint(
 			}
 			if err != nil {
 				return
-			}
-			scrt := &Secret{
-				OrganizationID: tt.args.orgID,
-				Env:            make(map[string]string),
-			}
-			for _, fld := range edp.SecretFields() {
-				scrtValue, err := s.LoadSecret(ctx, tt.args.orgID, fld.Key)
-				if err != nil {
-					t.Fatalf("failed to retrieve keys")
-				}
-				scrt.Env[fld.Key] = scrtValue
-			}
-			if diff := cmp.Diff(scrt, tt.wants.secret, secretCmpOptions); diff != "" {
-				t.Errorf("secret is different -got/+want\ndiff %s", diff)
 			}
 		})
 	}
@@ -1451,15 +1207,6 @@ func PatchNotificationEndpoint(
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Member,
 						ResourceType: influxdb.NotificationEndpointResourceType,
-					},
-				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
 					},
 				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
@@ -1523,15 +1270,6 @@ func PatchNotificationEndpoint(
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Member,
 						ResourceType: influxdb.NotificationEndpointResourceType,
-					},
-				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
 					},
 				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
@@ -1619,7 +1357,8 @@ func DeleteNotificationEndpoint(
 	type wants struct {
 		notificationEndpoints []influxdb.NotificationEndpoint
 		userResourceMappings  []*influxdb.UserResourceMapping
-		secrets               []string
+		secretFlds            []influxdb.SecretField
+		orgID                 influxdb.ID
 		err                   error
 	}
 	tests := []struct {
@@ -1643,15 +1382,6 @@ func DeleteNotificationEndpoint(
 						UserID:       MustIDBase16(sixID),
 						UserType:     influxdb.Member,
 						ResourceType: influxdb.NotificationEndpointResourceType,
-					},
-				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
 					},
 				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
@@ -1694,10 +1424,6 @@ func DeleteNotificationEndpoint(
 				err: &influxdb.Error{
 					Code: influxdb.EInvalid,
 					Msg:  "provided notification endpoint ID has invalid format",
-				},
-				secrets: []string{
-					oneID + "-token",
-					twoID + "-routing-key",
 				},
 				userResourceMappings: []*influxdb.UserResourceMapping{
 					{
@@ -1761,15 +1487,6 @@ func DeleteNotificationEndpoint(
 						ResourceType: influxdb.NotificationEndpointResourceType,
 					},
 				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
@@ -1809,10 +1526,6 @@ func DeleteNotificationEndpoint(
 				err: &influxdb.Error{
 					Code: influxdb.ENotFound,
 					Msg:  "notification endpoint not found",
-				},
-				secrets: []string{
-					oneID + "-token",
-					twoID + "-routing-key",
 				},
 				userResourceMappings: []*influxdb.UserResourceMapping{
 					{
@@ -1877,15 +1590,6 @@ func DeleteNotificationEndpoint(
 						ResourceType: influxdb.NotificationEndpointResourceType,
 					},
 				},
-				Secrets: []Secret{
-					{
-						OrganizationID: MustIDBase16(fourID),
-						Env: map[string]string{
-							oneID + "-token":       "slack-secret-1",
-							twoID + "-routing-key": "pager-duty-secret-2",
-						},
-					},
-				},
 				NotificationEndpoints: []influxdb.NotificationEndpoint{
 					&endpoint.Slack{
 						Base: endpoint.Base{
@@ -1923,9 +1627,10 @@ func DeleteNotificationEndpoint(
 				userID: MustIDBase16(sixID),
 			},
 			wants: wants{
-				secrets: []string{
-					oneID + "-token",
+				secretFlds: []influxdb.SecretField{
+					{Key: twoID + "-routing-key"},
 				},
+				orgID: MustIDBase16(fourID),
 				userResourceMappings: []*influxdb.UserResourceMapping{
 					{
 						ResourceID:   MustIDBase16(oneID),
@@ -1958,8 +1663,16 @@ func DeleteNotificationEndpoint(
 			s, done := init(tt.fields, t)
 			defer done()
 			ctx := context.Background()
-			err := s.DeleteNotificationEndpoint(ctx, tt.args.id)
+			flds, orgID, err := s.DeleteNotificationEndpoint(ctx, tt.args.id)
 			ErrorsEqual(t, err, tt.wants.err)
+			if err != nil {
+				if diff := cmp.Diff(flds, tt.wants.secretFlds); diff != "" {
+					t.Errorf("delete notification endpoint secret fields are different -got/+want\ndiff %s", diff)
+				}
+				if diff := cmp.Diff(orgID, tt.wants.orgID); diff != "" {
+					t.Errorf("delete notification endpoint org id is different -got/+want\ndiff %s", diff)
+				}
+			}
 
 			filter := influxdb.NotificationEndpointFilter{}
 			edps, n, err := s.FindNotificationEndpoints(ctx, filter)
@@ -1989,13 +1702,6 @@ func DeleteNotificationEndpoint(
 			}
 			if diff := cmp.Diff(urms, tt.wants.userResourceMappings, userResourceMappingCmpOptions...); diff != "" {
 				t.Errorf("user resource mappings are different -got/+want\ndiff %s", diff)
-			}
-			scrtKeys, err := s.GetSecretKeys(ctx, tt.args.orgID)
-			if err != nil {
-				t.Fatalf("failed to retrieve secret keys: %v", err)
-			}
-			if diff := cmp.Diff(scrtKeys, tt.wants.secrets, secretCmpOptions...); diff != "" {
-				t.Errorf("secret keys are different -got/+want\ndiff %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/14828

Move secret store from kv to http, manually tested with a local vault cluster. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
