### PR TITLE
fix(notifications): fix a double locking notification rule lookup

### DIFF
--- a/kv/notification_rule.go
+++ b/kv/notification_rule.go
@@ -305,7 +305,7 @@ func (s *Service) findNotificationRules(ctx context.Context, tx Tx, filter influ
 	}
 
 	if filter.OrgID != nil || filter.Organization != nil {
-		o, err := s.FindOrganization(ctx, influxdb.OrganizationFilter{
+		o, err := s.findOrganization(ctx, tx, influxdb.OrganizationFilter{
 			ID:   filter.OrgID,
 			Name: filter.Organization,
 		})


### PR DESCRIPTION
When using a internal function in kv we can only use internal funciton calls.
By trying to use a Public function we attempt to create a read lock after acquiring a write lock
