### PR TITLE
refactor(dashboards): move time series fetcing descision to TimeSeries

### DIFF
--- a/ui/src/dashboards/components/Dashboard.tsx
+++ b/ui/src/dashboards/components/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent} from 'react'
 import classnames from 'classnames'
 
 import Cells from 'src/shared/components/cells/Cells'
@@ -15,11 +15,9 @@ interface Props {
   timeRange: TimeRange
   manualRefresh: number
   inPresentationMode: boolean
-  inView: (cell: Cell) => boolean
   onDeleteCell: (cell: Cell) => void
   onCloneCell: (cell: Cell) => void
   onPositionChange: (cells: Cell[]) => void
-  setScrollTop: (e: MouseEvent<HTMLElement>) => void
   onEditView: (cellID: string) => void
   onAddCell: () => void
   onEditNote: (id: string) => void
@@ -37,7 +35,6 @@ class DashboardComponent extends PureComponent<Props> {
       onEditView,
       onPositionChange,
       inPresentationMode,
-      setScrollTop,
       onAddCell,
       onEditNote,
     } = this.props
@@ -47,7 +44,6 @@ class DashboardComponent extends PureComponent<Props> {
         className={classnames('page-contents', {
           'presentation-mode': inPresentationMode,
         })}
-        setScrollTop={setScrollTop}
       >
         <div className="dashboard container-fluid full-width">
           {dashboard.cells.length ? (

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component, MouseEvent} from 'react'
+import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
 import _ from 'lodash'
@@ -33,10 +33,7 @@ import {
 } from 'src/cloud/utils/limits'
 
 // Constants
-import {
-  DASHBOARD_LAYOUT_ROW_HEIGHT,
-  AUTOREFRESH_DEFAULT,
-} from 'src/shared/constants'
+import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
 import {DEFAULT_TIME_RANGE} from 'src/shared/constants/timeRanges'
 
 // Types
@@ -113,30 +110,14 @@ type Props = PassedProps &
   ManualRefreshProps &
   WithRouterProps
 
-interface State {
-  scrollTop: number
-  windowHeight: number
-}
-
 @ErrorHandling
-class DashboardPage extends Component<Props, State> {
-  public constructor(props: Props) {
-    super(props)
-
-    this.state = {
-      scrollTop: 0,
-      windowHeight: window.innerHeight,
-    }
-  }
-
+class DashboardPage extends Component<Props> {
   public async componentDidMount() {
     const {autoRefresh} = this.props
 
     if (autoRefresh.status === AutoRefreshStatus.Active) {
       GlobalAutoRefresher.poll(autoRefresh.interval)
     }
-
-    window.addEventListener('resize', this.handleWindowResize, true)
 
     await this.getDashboard()
   }
@@ -156,8 +137,6 @@ class DashboardPage extends Component<Props, State> {
 
   public componentWillUnmount() {
     GlobalAutoRefresher.stopPolling()
-
-    window.removeEventListener('resize', this.handleWindowResize, true)
   }
 
   public render() {
@@ -211,11 +190,9 @@ class DashboardPage extends Component<Props, State> {
             />
             {!!dashboard && (
               <DashboardComponent
-                inView={this.inView}
                 dashboard={dashboard}
                 timeRange={timeRange}
                 manualRefresh={manualRefresh}
-                setScrollTop={this.setScrollTop}
                 onCloneCell={this.handleCloneCell}
                 inPresentationMode={inPresentationMode}
                 onPositionChange={this.handlePositionChange}
@@ -236,19 +213,6 @@ class DashboardPage extends Component<Props, State> {
     const {params, getDashboard} = this.props
 
     await getDashboard(params.dashboardID)
-  }
-
-  private inView = (cell: Cell): boolean => {
-    const {scrollTop, windowHeight} = this.state
-    const bufferValue = 600
-    const cellTop = cell.y * DASHBOARD_LAYOUT_ROW_HEIGHT
-    const cellBottom = (cell.y + cell.h) * DASHBOARD_LAYOUT_ROW_HEIGHT
-    const bufferedWindowBottom = windowHeight + scrollTop + bufferValue
-    const bufferedWindowTop = scrollTop - bufferValue
-    const topInView = cellTop < bufferedWindowBottom
-    const bottomInView = cellBottom > bufferedWindowTop
-
-    return topInView && bottomInView
   }
 
   private handleChooseTimeRange = (timeRange: TimeRange): void => {
@@ -329,16 +293,6 @@ class DashboardPage extends Component<Props, State> {
   private handleDeleteDashboardCell = async (cell: Cell): Promise<void> => {
     const {dashboard, deleteCell} = this.props
     await deleteCell(dashboard, cell)
-  }
-
-  private setScrollTop = (e: MouseEvent<HTMLElement>): void => {
-    const target = e.target as HTMLElement
-
-    this.setState({scrollTop: target.scrollTop})
-  }
-
-  private handleWindowResize = (): void => {
-    this.setState({windowHeight: window.innerHeight})
   }
 
   private get pageTitle(): string {

--- a/ui/src/shared/components/CheckPlot.tsx
+++ b/ui/src/shared/components/CheckPlot.tsx
@@ -138,7 +138,7 @@ const CheckPlot: FunctionComponent<Props> = ({
   }
 
   return (
-    <div className="vis-plot-container vis-plot-container--alert-check">
+    <div className="time-series-container time-series-container--alert-check">
       {loading === RemoteDataState.Loading && <GraphLoadingDots />}
       {children(config)}
     </div>

--- a/ui/src/shared/components/HeatmapPlot.tsx
+++ b/ui/src/shared/components/HeatmapPlot.tsx
@@ -112,10 +112,10 @@ const HeatmapPlot: FunctionComponent<Props> = ({
   }
 
   return (
-    <div className="vis-plot-container">
+    <>
       {loading === RemoteDataState.Loading && <GraphLoadingDots />}
       {children(config)}
-    </div>
+    </>
   )
 }
 

--- a/ui/src/shared/components/HistogramPlot.tsx
+++ b/ui/src/shared/components/HistogramPlot.tsx
@@ -85,10 +85,10 @@ const HistogramPlot: FunctionComponent<Props> = ({
   }
 
   return (
-    <div className="vis-plot-container">
+    <>
       {loading === RemoteDataState.Loading && <GraphLoadingDots />}
       {children(config)}
-    </div>
+    </>
   )
 }
 

--- a/ui/src/shared/components/ScatterPlot.tsx
+++ b/ui/src/shared/components/ScatterPlot.tsx
@@ -124,10 +124,10 @@ const ScatterPlot: FunctionComponent<Props> = ({
     ],
   }
   return (
-    <div className="vis-plot-container">
+    <>
       {loading === RemoteDataState.Loading && <GraphLoadingDots />}
       {children(config)}
-    </div>
+    </>
   )
 }
 

--- a/ui/src/shared/components/XYPlot.tsx
+++ b/ui/src/shared/components/XYPlot.tsx
@@ -151,10 +151,10 @@ const XYPlot: FunctionComponent<Props> = ({
   }
 
   return (
-    <div className="vis-plot-container">
+    <>
       {loading === RemoteDataState.Loading && <GraphLoadingDots />}
       {children(config)}
-    </div>
+    </>
   )
 }
 

--- a/ui/src/shared/components/cells/Cell.scss
+++ b/ui/src/shared/components/cells/Cell.scss
@@ -8,7 +8,7 @@ $cell--header-size: 36px;
 .cell {
   background-color: $g3-castle;
   border-radius: $radius;
-  transform: translate3d(0,0,0); // gpu boost
+  transform: translate3d(0, 0, 0); // gpu boost
 }
 
 .cell--view {
@@ -63,7 +63,7 @@ $cell--header-size: 36px;
 }
 
 .dashboard .cell--view-empty .empty-graph-error {
-    top: $ix-marg-c + $cell--header-size;
+  top: $ix-marg-c + $cell--header-size;
 }
 
 .cell--header {

--- a/ui/src/shared/components/cells/Cell.scss
+++ b/ui/src/shared/components/cells/Cell.scss
@@ -30,7 +30,7 @@ $cell--header-size: 36px;
     padding-top: 0;
   }
 
-  .vis-plot-container {
+  .time-series-container {
     padding-top: $ix-marg-a;
   }
 }
@@ -170,12 +170,12 @@ $cell--header-size: 36px;
   }
 }
 
-.vis-plot-container {
+.time-series-container {
   width: 100%;
   height: 100%;
   padding: $ix-marg-c;
 
-  &.vis-plot-container--alert-check {
+  &.time-series-container--alert-check {
     padding-right: $ix-marg-c + 30px;
     overflow: hidden;
   }

--- a/ui/src/shared/components/cells/Cell.tsx
+++ b/ui/src/shared/components/cells/Cell.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component, RefObject} from 'react'
+import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {get} from 'lodash'
 
@@ -48,28 +48,6 @@ type Props = StateProps & OwnProps
 
 @ErrorHandling
 class CellComponent extends Component<Props, State> {
-  state: State = {
-    inView: false,
-  }
-
-  private observer: IntersectionObserver
-
-  private cellRef: RefObject<HTMLDivElement> = React.createRef()
-
-  public componentDidMount() {
-    this.observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        const {isIntersecting} = entry
-        if (isIntersecting) {
-          this.setState({inView: true})
-          this.observer.disconnect()
-        }
-      })
-    })
-
-    this.observer.observe(this.cellRef.current)
-  }
-
   public render() {
     const {
       onEditCell,
@@ -79,7 +57,6 @@ class CellComponent extends Component<Props, State> {
       cell,
       view,
     } = this.props
-    const {inView} = this.state
 
     return (
       <>
@@ -95,12 +72,8 @@ class CellComponent extends Component<Props, State> {
             onCSVDownload={this.handleCSVDownload}
           />
         )}
-        <div
-          className="cell--view"
-          data-testid="cell--view-empty"
-          ref={this.cellRef}
-        >
-          {inView && this.view}
+        <div className="cell--view" data-testid="cell--view-empty">
+          {this.view}
         </div>
       </>
     )


### PR DESCRIPTION
### What
- Move the `IntersectionObserver` logic out of the `Cell` component and into the `TimeSeries` component
- Removed state from `DashboardPage` and moved the "inView" logic into `TimeSeries`

### Why
- Consolidates all logic of wether a `Cell` should fetch data in one place
- Allows @alexpaxton to replace all local page components with `@influxdata/clockface`
- Enables @alexpaxton to remove `FancyScrollbars`
- Enables extracting `ReactGridLayout` and styles into presentational components that can be shared across multiple projects (like Quartz)