### PR TITLE
feat(limits): Add Cardinality limit alerts

### DIFF
--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -93,6 +93,11 @@ class BucketsTab extends PureComponent<Props, State> {
 
     return (
       <>
+        <AssetLimitAlert
+          resourceName="buckets"
+          limitStatus={limitStatus}
+          className="load-data--asset-alert"
+        />
         <SettingsTabbedPageHeader>
           <SearchWidget
             placeholderText="Filter buckets..."
@@ -109,7 +114,6 @@ class BucketsTab extends PureComponent<Props, State> {
             titleText={this.createButtonTitleText}
           />
         </SettingsTabbedPageHeader>
-        <AssetLimitAlert resourceName="buckets" limitStatus={limitStatus} />
         <FilterList<PrettyBucket>
           searchTerm={searchTerm}
           searchKeys={['name', 'ruleString', 'labels[].name']}

--- a/ui/src/buckets/containers/BucketsIndex.tsx
+++ b/ui/src/buckets/containers/BucketsIndex.tsx
@@ -10,40 +10,77 @@ import {Page} from 'src/pageLayout'
 import BucketsTab from 'src/buckets/components/BucketsTab'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
 import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
+import LimitChecker from 'src/cloud/components/LimitChecker'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
+import {FlexBox, FlexDirection, JustifyContent} from '@influxdata/clockface'
+
+// Utils
+import {
+  extractRateLimitResources,
+  extractRateLimitStatus,
+} from 'src/cloud/utils/limits'
 
 // Types
 import {AppState, Organization} from 'src/types'
+import {LimitStatus} from 'src/cloud/actions/limits'
 
 interface StateProps {
   org: Organization
+  limitedResources: string[]
+  limitStatus: LimitStatus
 }
 
 @ErrorHandling
 class BucketsIndex extends Component<StateProps> {
   public render() {
-    const {org, children} = this.props
+    const {org, children, limitedResources, limitStatus} = this.props
 
     return (
       <>
         <Page titleTag={org.name}>
-          <LoadDataHeader />
-          <LoadDataTabbedPage activeTab="buckets" orgID={org.id}>
-            <GetResources resource={ResourceTypes.Buckets}>
-              <GetResources resource={ResourceTypes.Telegrafs}>
-                <GetAssetLimits>
-                  <BucketsTab />
-                </GetAssetLimits>
+          <LimitChecker>
+            <LoadDataHeader />
+            <FlexBox
+              direction={FlexDirection.Row}
+              justifyContent={JustifyContent.Center}
+            >
+              {this.isCardinalityExceeded && (
+                <RateLimitAlert
+                  resources={limitedResources}
+                  limitStatus={limitStatus}
+                  className="load-data--rate-alert"
+                />
+              )}
+            </FlexBox>
+            <LoadDataTabbedPage activeTab="buckets" orgID={org.id}>
+              <GetResources resource={ResourceTypes.Buckets}>
+                <GetResources resource={ResourceTypes.Telegrafs}>
+                  <GetAssetLimits>
+                    <BucketsTab />
+                  </GetAssetLimits>
+                </GetResources>
               </GetResources>
-            </GetResources>
-          </LoadDataTabbedPage>
+            </LoadDataTabbedPage>
+          </LimitChecker>
         </Page>
         {children}
       </>
     )
   }
+
+  private get isCardinalityExceeded(): boolean {
+    const {limitedResources} = this.props
+
+    return limitedResources.includes('cardinality')
+  }
 }
 
-const mstp = ({orgs: {org}}: AppState) => ({org})
+const mstp = ({orgs: {org}, cloud: {limits}}: AppState) => {
+  const limitedResources = extractRateLimitResources(limits)
+  const limitStatus = extractRateLimitStatus(limits)
+
+  return {org, limitedResources, limitStatus}
+}
 
 export default connect<StateProps, {}, {}>(
   mstp,

--- a/ui/src/cloud/apis/limits.ts
+++ b/ui/src/cloud/apis/limits.ts
@@ -1,6 +1,6 @@
 import AJAX from 'src/utils/ajax'
 
-export const getReadWriteLimits = async (orgID: string) => {
+export const getReadWriteCardinalityLimits = async (orgID: string) => {
   try {
     const {data} = await AJAX({
       method: 'GET',

--- a/ui/src/cloud/components/LimitChecker.tsx
+++ b/ui/src/cloud/components/LimitChecker.tsx
@@ -3,16 +3,16 @@ import {PureComponent} from 'react'
 import {connect} from 'react-redux'
 
 // Actions
-import {getReadWriteLimits as getReadWriteLimitsAction} from 'src/cloud/actions/limits'
+import {getReadWriteCardinalityLimits as getReadWriteCardinalityLimitsAction} from 'src/cloud/actions/limits'
 
 interface DispatchProps {
-  getReadWriteLimits: typeof getReadWriteLimitsAction
+  getReadWriteCardinalityLimits: typeof getReadWriteCardinalityLimitsAction
 }
 
 class LimitChecker extends PureComponent<DispatchProps, {}> {
   public componentDidMount() {
     if (process.env.CLOUD === 'true') {
-      this.props.getReadWriteLimits()
+      this.props.getReadWriteCardinalityLimits()
     }
   }
 
@@ -21,7 +21,9 @@ class LimitChecker extends PureComponent<DispatchProps, {}> {
   }
 }
 
-const mdtp: DispatchProps = {getReadWriteLimits: getReadWriteLimitsAction}
+const mdtp: DispatchProps = {
+  getReadWriteCardinalityLimits: getReadWriteCardinalityLimitsAction,
+}
 
 export default connect<{}, DispatchProps, {}>(
   null,

--- a/ui/src/cloud/components/RateLimitAlert.tsx
+++ b/ui/src/cloud/components/RateLimitAlert.tsx
@@ -1,0 +1,63 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import {
+  FlexBox,
+  FlexDirection,
+  AlignItems,
+  ComponentSize,
+  IconFont,
+  ComponentColor,
+  Alert,
+  JustifyContent,
+} from '@influxdata/clockface'
+
+// Constants
+import {CLOUD} from 'src/shared/constants'
+
+// Types
+import {LimitStatus} from 'src/cloud/actions/limits'
+import CheckoutButton from 'src/cloud/components/CheckoutButton'
+
+interface Props {
+  resourceName: string
+  limitStatus: LimitStatus
+  className?: string
+}
+
+export default class RateLimitAlert extends PureComponent<Props> {
+  public render() {
+    const {limitStatus, resourceName, className} = this.props
+
+    if (CLOUD && limitStatus === LimitStatus.EXCEEDED) {
+      return (
+        <FlexBox
+          direction={FlexDirection.Column}
+          alignItems={AlignItems.Center}
+          margin={ComponentSize.Large}
+          stretchToFitWidth={true}
+          className={className}
+        >
+          <Alert icon={IconFont.Cloud} color={ComponentColor.Primary}>
+            <FlexBox
+              alignItems={AlignItems.Center}
+              direction={FlexDirection.Row}
+              justifyContent={JustifyContent.SpaceBetween}
+              margin={ComponentSize.Medium}
+            >
+              <div>
+                {`Hey there, it looks like you have exceeded your plan's
+              ${resourceName} limits.`}
+                <br />
+              </div>
+              <CheckoutButton />
+            </FlexBox>
+          </Alert>
+        </FlexBox>
+      )
+    }
+
+    return null
+  }
+}

--- a/ui/src/cloud/components/RateLimitAlert.tsx
+++ b/ui/src/cloud/components/RateLimitAlert.tsx
@@ -21,14 +21,14 @@ import {LimitStatus} from 'src/cloud/actions/limits'
 import CheckoutButton from 'src/cloud/components/CheckoutButton'
 
 interface Props {
-  resourceName: string
+  resources: string[]
   limitStatus: LimitStatus
   className?: string
 }
 
 export default class RateLimitAlert extends PureComponent<Props> {
   public render() {
-    const {limitStatus, resourceName, className} = this.props
+    const {limitStatus, className} = this.props
 
     if (CLOUD && limitStatus === LimitStatus.EXCEEDED) {
       return (
@@ -47,8 +47,7 @@ export default class RateLimitAlert extends PureComponent<Props> {
               margin={ComponentSize.Medium}
             >
               <div>
-                {`Hey there, it looks like you have exceeded your plan's
-              ${resourceName} limits.`}
+                {this.message}
                 <br />
               </div>
               <CheckoutButton />
@@ -59,5 +58,33 @@ export default class RateLimitAlert extends PureComponent<Props> {
     }
 
     return null
+  }
+
+  private get message(): string {
+    return `Hey there, it looks like you have exceeded your plan's ${
+      this.resourceName
+    } limits.${this.additionalMessage}`
+  }
+
+  private get additionalMessage(): string {
+    if (this.props.resources.includes('cardinality')) {
+      return ' Your writes will be rejected until resolved.'
+    }
+
+    return ''
+  }
+
+  private get resourceName(): string {
+    const {resources} = this.props
+
+    const renamedResources = resources.map(resource => {
+      if (resource === 'cardinality') {
+        return 'total series'
+      }
+
+      return resource
+    })
+
+    return renamedResources.join(' and ')
   }
 }

--- a/ui/src/cloud/reducers/limits.ts
+++ b/ui/src/cloud/reducers/limits.ts
@@ -17,6 +17,7 @@ export interface LimitsState {
   rate: {
     readKBs: Limit
     writeKBs: Limit
+    cardinality: Limit
   }
   status: RemoteDataState
 }
@@ -33,6 +34,7 @@ export const defaultState: LimitsState = {
   rate: {
     readKBs: defaultLimit,
     writeKBs: defaultLimit,
+    cardinality: defaultLimit,
   },
   status: RemoteDataState.NotStarted,
 }
@@ -55,13 +57,14 @@ export const limitsReducer = (
         const {maxBuckets} = limits.bucket
         const {maxDashboards} = limits.dashboard
         const {maxTasks} = limits.task
-        const {readKBs, writeKBs} = limits.rate
+        const {readKBs, writeKBs, cardinality} = limits.rate
 
         draftState.buckets.maxAllowed = maxBuckets
         draftState.dashboards.maxAllowed = maxDashboards
         draftState.tasks.maxAllowed = maxTasks
         draftState.rate.readKBs.maxAllowed = readKBs
         draftState.rate.writeKBs.maxAllowed = writeKBs
+        draftState.rate.cardinality.maxAllowed = cardinality
 
         return
       }
@@ -83,6 +86,10 @@ export const limitsReducer = (
       }
       case ActionTypes.SetWriteRateLimitStatus: {
         draftState.rate.writeKBs.limitStatus = action.payload.limitStatus
+        return
+      }
+      case ActionTypes.SetCardinalityLimitStatus: {
+        draftState.rate.cardinality.limitStatus = action.payload.limitStatus
         return
       }
     }

--- a/ui/src/cloud/utils/limits.ts
+++ b/ui/src/cloud/utils/limits.ts
@@ -35,6 +35,7 @@ export const extractRateLimitStatus = (limits: LimitsState): LimitStatus => {
   const statuses = [
     get(limits, 'rate.writeKBs.limitStatus'),
     get(limits, 'rate.readKBs.limitStatus'),
+    get(limits, 'rate.cardinality.limitStatus'),
   ]
 
   if (statuses.includes(LimitStatus.EXCEEDED)) {
@@ -47,12 +48,16 @@ export const extractRateLimitStatus = (limits: LimitsState): LimitStatus => {
 export const extractRateLimitResourceName = (limits: LimitsState): string => {
   const rateLimitedResources = []
 
-  if (get(limits, 'rate.writeKBs.limitStatus') === LimitStatus.EXCEEDED) {
-    rateLimitedResources.push('writes')
+  if (get(limits, 'rate.readKBs.limitStatus') === LimitStatus.EXCEEDED) {
+    rateLimitedResources.push('read')
   }
 
-  if (get(limits, 'rate.readKBs.limitStatus') === LimitStatus.EXCEEDED) {
-    rateLimitedResources.push('reads')
+  if (get(limits, 'rate.writeKBs.limitStatus') === LimitStatus.EXCEEDED) {
+    rateLimitedResources.push('write')
+  }
+
+  if (get(limits, 'rate.cardinality.limitStatus') === LimitStatus.EXCEEDED) {
+    rateLimitedResources.push('cardinality')
   }
 
   return rateLimitedResources.join(' and ')

--- a/ui/src/cloud/utils/limits.ts
+++ b/ui/src/cloud/utils/limits.ts
@@ -45,7 +45,7 @@ export const extractRateLimitStatus = (limits: LimitsState): LimitStatus => {
   return LimitStatus.OK
 }
 
-export const extractRateLimitResourceName = (limits: LimitsState): string => {
+export const extractRateLimitResources = (limits: LimitsState): string[] => {
   const rateLimitedResources = []
 
   if (get(limits, 'rate.readKBs.limitStatus') === LimitStatus.EXCEEDED) {
@@ -60,5 +60,5 @@ export const extractRateLimitResourceName = (limits: LimitsState): string => {
     rateLimitedResources.push('cardinality')
   }
 
-  return rateLimitedResources.join(' and ')
+  return rateLimitedResources
 }

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -180,14 +180,14 @@ class DashboardPage extends Component<Props> {
               toggleVariablesControlBar={onToggleShowVariablesControls}
               isShowingVariablesControlBar={showVariablesControls}
             />
-            {showVariablesControls && !!dashboard && (
-              <VariablesControlBar dashboardID={dashboard.id} />
-            )}
             <RateLimitAlert
               resources={limitedResources}
               limitStatus={limitStatus}
-              className="dashboard--asset-alert"
+              className="dashboard--rate-alert"
             />
+            {showVariablesControls && !!dashboard && (
+              <VariablesControlBar dashboardID={dashboard.id} />
+            )}
             {!!dashboard && (
               <DashboardComponent
                 dashboard={dashboard}

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -28,7 +28,7 @@ import {
 // Utils
 import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 import {
-  extractRateLimitResourceName,
+  extractRateLimitResources,
   extractRateLimitStatus,
 } from 'src/cloud/utils/limits'
 
@@ -58,7 +58,7 @@ import {toggleShowVariablesControls} from 'src/userSettings/actions'
 import {LimitStatus} from 'src/cloud/actions/limits'
 
 interface StateProps {
-  resourceName: string
+  limitedResources: string[]
   limitStatus: LimitStatus
   org: Organization
   links: Links
@@ -147,7 +147,7 @@ class DashboardPage extends Component<Props> {
       dashboard,
       autoRefresh,
       limitStatus,
-      resourceName,
+      limitedResources,
       manualRefresh,
       onManualRefresh,
       inPresentationMode,
@@ -184,7 +184,7 @@ class DashboardPage extends Component<Props> {
               <VariablesControlBar dashboardID={dashboard.id} />
             )}
             <RateLimitAlert
-              resourceName={resourceName}
+              resources={limitedResources}
               limitStatus={limitStatus}
               className="dashboard--asset-alert"
             />
@@ -323,7 +323,7 @@ const mstp = (state: AppState, {params: {dashboardID}}): StateProps => {
 
   const dashboard = dashboards.list.find(d => d.id === dashboardID)
 
-  const resourceName = extractRateLimitResourceName(limits)
+  const limitedResources = extractRateLimitResources(limits)
   const limitStatus = extractRateLimitStatus(limits)
 
   return {
@@ -335,7 +335,7 @@ const mstp = (state: AppState, {params: {dashboardID}}): StateProps => {
     dashboard,
     autoRefresh,
     limitStatus,
-    resourceName,
+    limitedResources,
     inPresentationMode,
     showVariablesControls,
   }

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -13,7 +13,7 @@ import ManualRefresh from 'src/shared/components/ManualRefresh'
 import {HoverTimeProvider} from 'src/dashboards/utils/hoverTime'
 import VariablesControlBar from 'src/dashboards/components/variablesControlBar/VariablesControlBar'
 import LimitChecker from 'src/cloud/components/LimitChecker'
-import AssetLimitAlert from 'src/cloud/components/AssetLimitAlert'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 // Actions
 import * as dashboardActions from 'src/dashboards/actions'
@@ -183,7 +183,7 @@ class DashboardPage extends Component<Props> {
             {showVariablesControls && !!dashboard && (
               <VariablesControlBar dashboardID={dashboard.id} />
             )}
-            <AssetLimitAlert
+            <RateLimitAlert
               resourceName={resourceName}
               limitStatus={limitStatus}
               className="dashboard--asset-alert"

--- a/ui/src/dataExplorer/components/DataExplorer.tsx
+++ b/ui/src/dataExplorer/components/DataExplorer.tsx
@@ -14,7 +14,7 @@ import {setActiveTimeMachine} from 'src/timeMachine/actions'
 import {HoverTimeProvider} from 'src/dashboards/utils/hoverTime'
 import {queryBuilderFetcher} from 'src/timeMachine/apis/QueryBuilderFetcher'
 import {
-  extractRateLimitResourceName,
+  extractRateLimitResources,
   extractRateLimitStatus,
 } from 'src/cloud/utils/limits'
 
@@ -23,7 +23,7 @@ import {AppState} from 'src/types'
 import {LimitStatus} from 'src/cloud/actions/limits'
 
 interface StateProps {
-  resourceName: string
+  limitedResources: string[]
   limitStatus: LimitStatus
 }
 
@@ -41,11 +41,14 @@ class DataExplorer extends PureComponent<Props, {}> {
   }
 
   public render() {
-    const {resourceName, limitStatus} = this.props
+    const {limitedResources, limitStatus} = this.props
 
     return (
       <LimitChecker>
-        <RateLimitAlert resourceName={resourceName} limitStatus={limitStatus} />
+        <RateLimitAlert
+          resources={limitedResources}
+          limitStatus={limitStatus}
+        />
         <div className="data-explorer">
           <HoverTimeProvider>
             <TimeMachine />
@@ -62,7 +65,7 @@ const mstp = (state: AppState): StateProps => {
   } = state
 
   return {
-    resourceName: extractRateLimitResourceName(limits),
+    limitedResources: extractRateLimitResources(limits),
     limitStatus: extractRateLimitStatus(limits),
   }
 }

--- a/ui/src/dataExplorer/components/DataExplorer.tsx
+++ b/ui/src/dataExplorer/components/DataExplorer.tsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux'
 // Components
 import TimeMachine from 'src/timeMachine/components/TimeMachine'
 import LimitChecker from 'src/cloud/components/LimitChecker'
-import AssetLimitAlert from 'src/cloud/components/AssetLimitAlert'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
 
 // Actions
 import {setActiveTimeMachine} from 'src/timeMachine/actions'
@@ -45,10 +45,7 @@ class DataExplorer extends PureComponent<Props, {}> {
 
     return (
       <LimitChecker>
-        <AssetLimitAlert
-          resourceName={resourceName}
-          limitStatus={limitStatus}
-        />
+        <RateLimitAlert resourceName={resourceName} limitStatus={limitStatus} />
         <div className="data-explorer">
           <HoverTimeProvider>
             <TimeMachine />

--- a/ui/src/dataLoaders/actions/dataLoaders.ts
+++ b/ui/src/dataLoaders/actions/dataLoaders.ts
@@ -45,7 +45,7 @@ import {notify} from 'src/shared/actions/notifications'
 import {
   TelegrafConfigCreationError,
   TelegrafConfigCreationSuccess,
-  writeLimitReached,
+  readWriteCardinalityLimitReached,
 } from 'src/shared/copy/notifications'
 
 type GetState = () => AppState
@@ -559,7 +559,7 @@ export const writeLineProtocolAction = (
     if (resp.status === 204) {
       dispatch(setLPStatus(RemoteDataState.Done))
     } else if (resp.status === 429) {
-      dispatch(notify(writeLimitReached()))
+      dispatch(notify(readWriteCardinalityLimitReached(resp.data.message)))
       dispatch(setLPStatus(RemoteDataState.Error))
     } else {
       throw new Error(_.get(resp, 'data.message', 'Failed to write data'))

--- a/ui/src/shared/components/cloud/CloudOnly.scss
+++ b/ui/src/shared/components/cloud/CloudOnly.scss
@@ -1,4 +1,15 @@
-.dashboard--asset-alert {
+.dashboard--rate-alert {
     padding: 0 $page-gutter;
-    width: 100%
+    width: 100%;
+    padding-bottom: 16px;
+}
+
+.load-data--rate-alert {
+    padding: 0 $page-gutter;
+    padding-bottom: 16px;
+    max-width: 1608px;
+}
+
+.load-data--asset-alert {
+    padding-bottom: 16px;
 }

--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -4196,8 +4196,7 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
     ],
     package: '',
     desc: 'The `to()` function writes data to an InfluxDB v2.0 bucket.',
-    example:
-      'to(bucket:"my-bucket", org:"my-org")',
+    example: 'to(bucket:"my-bucket", org:"my-org")',
     category: 'Outputs',
     link:
       'https://v2.docs.influxdata.com/v2.0/reference/flux/functions/built-in/outputs/to/',

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -420,11 +420,13 @@ export const getBucketsFailed = (): Notification => ({
 })
 
 // Limits
-export const writeLimitReached = (): Notification => ({
+export const readWriteCardinalityLimitReached = (
+  message: string
+): Notification => ({
   ...defaultErrorNotification,
-  message: `Exceeded write limits.`,
+  message: `Failed to write data due to plan limits: ${message}`,
   duration: FIVE_SECONDS,
-  type: 'writeLimitReached',
+  type: 'readWriteCardinalityLimitReached',
 })
 
 export const readLimitReached = (): Notification => ({

--- a/ui/src/telegrafs/containers/TelegrafsPage.tsx
+++ b/ui/src/telegrafs/containers/TelegrafsPage.tsx
@@ -9,39 +9,73 @@ import LoadDataHeader from 'src/settings/components/LoadDataHeader'
 import {Page} from 'src/pageLayout'
 import Collectors from 'src/telegrafs/components/Collectors'
 import GetResources, {ResourceTypes} from 'src/shared/components/GetResources'
+import LimitChecker from 'src/cloud/components/LimitChecker'
+import RateLimitAlert from 'src/cloud/components/RateLimitAlert'
+import {FlexBox, FlexDirection, JustifyContent} from '@influxdata/clockface'
+
+// Utils
+import {
+  extractRateLimitResources,
+  extractRateLimitStatus,
+} from 'src/cloud/utils/limits'
 
 // Types
 import {AppState, Organization} from 'src/types'
+import {LimitStatus} from 'src/cloud/actions/limits'
 
 interface StateProps {
   org: Organization
+  limitedResources: string[]
+  limitStatus: LimitStatus
 }
 
 @ErrorHandling
 class TelegrafsPage extends PureComponent<StateProps> {
   public render() {
-    const {org, children} = this.props
+    const {org, children, limitedResources, limitStatus} = this.props
 
     return (
       <>
         <Page titleTag={org.name}>
-          <LoadDataHeader />
-          <LoadDataTabbedPage activeTab="telegrafs" orgID={org.id}>
-            <GetResources resource={ResourceTypes.Buckets}>
-              <GetResources resource={ResourceTypes.Telegrafs}>
-                <Collectors />
+          <LimitChecker>
+            <LoadDataHeader />
+            <FlexBox
+              direction={FlexDirection.Row}
+              justifyContent={JustifyContent.Center}
+            >
+              {this.isCardinalityExceeded && (
+                <RateLimitAlert
+                  resources={limitedResources}
+                  limitStatus={limitStatus}
+                  className="load-data--rate-alert"
+                />
+              )}
+            </FlexBox>
+            <LoadDataTabbedPage activeTab="telegrafs" orgID={org.id}>
+              <GetResources resource={ResourceTypes.Buckets}>
+                <GetResources resource={ResourceTypes.Telegrafs}>
+                  <Collectors />
+                </GetResources>
               </GetResources>
-            </GetResources>
-          </LoadDataTabbedPage>
+            </LoadDataTabbedPage>
+          </LimitChecker>
         </Page>
         {children}
       </>
     )
   }
+  private get isCardinalityExceeded(): boolean {
+    const {limitedResources} = this.props
+
+    return limitedResources.includes('cardinality')
+  }
 }
 
-const mstp = ({orgs: {org}}: AppState): StateProps => ({
-  org,
-})
+const mstp = ({orgs: {org}, cloud: {limits}}: AppState) => {
+  const limitedResources = extractRateLimitResources(limits)
+  const limitStatus = extractRateLimitStatus(limits)
+
+  return {org, limitedResources, limitStatus}
+}
 
 export default connect<StateProps>(mstp)(TelegrafsPage)


### PR DESCRIPTION
Closes #14824 

Add rate limit alert to load data pages and dashboard/de pages for cardinality.

![Screen Shot 2019-08-28 at 4 32 01 PM](https://user-images.githubusercontent.com/5751863/63899754-f4cdcb00-c9b2-11e9-9afc-f3f25bf98e10.png)
![Screen Shot 2019-08-28 at 4 36 11 PM](https://user-images.githubusercontent.com/5751863/63899755-f4cdcb00-c9b2-11e9-99cc-67e174748fe1.png)


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
