### PR TITLE
fix(notification/rule): remove name from notify call

### DIFF
--- a/notification/rule/http.go
+++ b/notification/rule/http.go
@@ -63,7 +63,6 @@ func (s *HTTP) generateFluxASTNotifyPipe() ast.Statement {
 	endpointFn := flux.Function(flux.FunctionParams("r"), flux.Object(endpointProps...))
 
 	props := []*ast.Property{}
-	props = append(props, flux.Property("name", flux.String(s.Name)))
 	props = append(props, flux.Property("data", flux.Identifier("notification")))
 	props = append(props, flux.Property("endpoint",
 		flux.Call(flux.Identifier("endpoint"), flux.Object(flux.Property("mapFn", endpointFn)))))

--- a/notification/rule/http_test.go
+++ b/notification/rule/http_test.go
@@ -29,7 +29,7 @@ statuses = monitor.from(start: -1h, fn: (r) =>
 	(r.foo == "bar" and r.baz == "bang"))
 
 statuses
-	|> monitor.notify(name: "foo", data: notification, endpoint: endpoint(mapFn: (r) =>
+	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) =>
 		({data: json.encode(v: r)})))`
 
 	s := &rule.HTTP{


### PR DESCRIPTION
Removes `name` call from `monitor.notify` for http rule.
