### PR TITLE
feat(kv): Add kv.Service org & bucket ID validation hooks.

### DIFF
--- a/kv/org_test.go
+++ b/kv/org_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/kv"
 	influxdbtesting "github.com/influxdata/influxdb/testing"
 )
@@ -69,4 +70,14 @@ func initOrganizationService(s kv.Store, f influxdbtesting.OrganizationFields, t
 			}
 		}
 	}
+}
+
+func TestService_CreateOrganization(t *testing.T) {
+	t.Run("InvalidOrgID", func(t *testing.T) {
+		svc := kv.NewService(inmem.NewKVStore())
+		svc.IsValidOrgBucketID = func(id influxdb.ID) bool { return false }
+		if err := svc.CreateOrganization(context.Background(), &influxdb.Organization{Name: "ORG"}); err == nil || err.Error() != `unable to generate valid org id` {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	})
 }

--- a/kv/service.go
+++ b/kv/service.go
@@ -28,6 +28,9 @@ type Service struct {
 	TokenGenerator influxdb.TokenGenerator
 	influxdb.TimeGenerator
 	Hash Crypt
+
+	// Organization & bucket specific validation.
+	IsValidOrgBucketID func(influxdb.ID) bool
 }
 
 // NewService returns an instance of a Service.


### PR DESCRIPTION
Adds the ability to customize validation of organization and bucket IDs in the `kv.Service`.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
