### PR TITLE
refactor(ui): expose bucket options as buttons instead of context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [14694](https://github.com/influxdata/influxdb/pull/14694): Add ability to find tasks by name.
 
 ### UI Improvements
+1. [14889](https://github.com/influxdata/influxdb/pull/14889): Make adding data to buckets more discoverable
 1. [14709](https://github.com/influxdata/influxdb/pull/14709): Move Buckets, Telgrafs, and Scrapers pages into a tab called "Load Data" for ease of discovery
 1. [14846](https://github.com/influxdata/influxdb/pull/14846): Standardize formatting of "updated at" timestamp in all resource cards
 

--- a/ui/src/buckets/components/BucketAddDataButton.scss
+++ b/ui/src/buckets/components/BucketAddDataButton.scss
@@ -1,0 +1,52 @@
+.bucket-add-data {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: $ix-marg-b + $ix-marg-a;
+}
+
+.bucket-add-data--option {
+  border-radius: $ix-radius;
+  background-color: $g3-castle;
+  margin-bottom: $ix-border;
+  padding: $ix-marg-b + $ix-marg-a;
+  transition: background-color 0.25s ease;
+
+  &:last-child {
+    margin-bottom: $ix-border;
+  }
+}
+
+.bucket-add-data--option-header,
+.bucket-add-data--option-desc {
+  transition: color 0.25s ease;
+  user-select: none;
+}
+
+.bucket-add-data--option-header {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: $ix-marg-a + $ix-border;
+  color: $g14-chromium;
+}
+
+.bucket-add-data--option-desc {
+  font-size: 13px;
+  font-weight: 500;
+  color: $g11-sidewalk;
+}
+
+/*
+  Hover State
+*/
+.bucket-add-data--option:hover {
+  cursor: pointer;
+  background-color: $g5-pepper;
+
+  .bucket-add-data--option-header {
+    color: $g18-cloud;
+  }
+  .bucket-add-data--option-desc {
+    color: $g13-mist;
+  }
+}

--- a/ui/src/buckets/components/BucketAddDataButton.tsx
+++ b/ui/src/buckets/components/BucketAddDataButton.tsx
@@ -1,0 +1,75 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import CloudExclude from 'src/shared/components/cloud/CloudExclude'
+import {
+  Button,
+  IconFont,
+  ComponentSize,
+  ComponentColor,
+  Popover,
+  PopoverType,
+  PopoverPosition,
+} from '@influxdata/clockface'
+
+interface Props {
+  onAddCollector: () => void
+  onAddLineProtocol: () => void
+  onAddScraper: () => void
+}
+
+export default class BucketAddDataButton extends PureComponent<Props> {
+  public render() {
+    const {onAddCollector, onAddLineProtocol, onAddScraper} = this.props
+
+    return (
+      <Popover
+        color={ComponentColor.Secondary}
+        type={PopoverType.Outline}
+        position={PopoverPosition.ToTheRight}
+        distanceFromTrigger={8}
+        contents={onHide => (
+          <div className="bucket-add-data" onClick={onHide}>
+            <div className="bucket-add-data--option" onClick={onAddCollector}>
+              <div className="bucket-add-data--option-header">
+                Configure Telegraf Agent
+              </div>
+              <div className="bucket-add-data--option-desc">
+                Configure a Telegraf agent to push data into your bucket.
+              </div>
+            </div>
+            <div
+              className="bucket-add-data--option"
+              onClick={onAddLineProtocol}
+            >
+              <div className="bucket-add-data--option-header">
+                Line Protocol
+              </div>
+              <div className="bucket-add-data--option-desc">
+                Quickly load an existing line protocol file.
+              </div>
+            </div>
+            <CloudExclude>
+              <div className="bucket-add-data--option" onClick={onAddScraper}>
+                <div className="bucket-add-data--option-header">
+                  Scrape Metrics
+                </div>
+                <div className="bucket-add-data--option-desc">
+                  Add a scrape target to pull data into your bucket.
+                </div>
+              </div>
+            </CloudExclude>
+          </div>
+        )}
+      >
+        <Button
+          text="Add Data"
+          icon={IconFont.Plus}
+          size={ComponentSize.ExtraSmall}
+          color={ComponentColor.Secondary}
+        />
+      </Popover>
+    )
+  }
+}

--- a/ui/src/buckets/components/BucketCard.tsx
+++ b/ui/src/buckets/components/BucketCard.tsx
@@ -37,47 +37,46 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
   public render() {
     const {bucket, onDeleteBucket} = this.props
     return (
-      <>
-        <ResourceCard
-          testID="bucket--card"
-          contextMenu={
-            <BucketContextMenu
-              bucket={bucket}
-              onDeleteBucket={onDeleteBucket}
-            />
-          }
-          name={
-            <ResourceCard.Name
-              testID={`bucket--card ${bucket.name}`}
-              onClick={this.handleNameClick}
-              name={bucket.name}
-            />
-          }
-          metaData={[<>Retention: {bucket.ruleString}</>]}
+      <ResourceCard
+        testID="bucket--card"
+        contextMenu={
+          <BucketContextMenu bucket={bucket} onDeleteBucket={onDeleteBucket} />
+        }
+        name={
+          <ResourceCard.Name
+            testID={`bucket--card ${bucket.name}`}
+            onClick={this.handleNameClick}
+            name={bucket.name}
+          />
+        }
+        metaData={[<>Retention: {bucket.ruleString}</>]}
+      >
+        <FlexBox
+          direction={FlexDirection.Row}
+          margin={ComponentSize.Small}
+          style={{marginTop: '4px'}}
         >
-          <FlexBox direction={FlexDirection.Row} margin={ComponentSize.Small}>
-            <BucketAddDataButton
-              onAddCollector={this.handleAddCollector}
-              onAddLineProtocol={this.handleAddLineProtocol}
-              onAddScraper={this.handleAddScraper}
-            />
+          <BucketAddDataButton
+            onAddCollector={this.handleAddCollector}
+            onAddLineProtocol={this.handleAddLineProtocol}
+            onAddScraper={this.handleAddScraper}
+          />
+          <Button
+            text="Rename"
+            testID="bucket-rename"
+            size={ComponentSize.ExtraSmall}
+            onClick={this.handleRenameBucket}
+          />
+          <FeatureFlag name="deleteWithPredicate">
             <Button
-              text="Rename"
-              testID="bucket-rename"
+              text="Delete Data By Filter"
+              testID="bucket-delete-task"
               size={ComponentSize.ExtraSmall}
-              onClick={this.handleRenameBucket}
+              onClick={this.handleDeleteData}
             />
-            <FeatureFlag name="deleteWithPredicate">
-              <Button
-                text="Delete Data By Filter"
-                testID="bucket-delete-task"
-                size={ComponentSize.ExtraSmall}
-                onClick={this.handleDeleteData}
-              />
-            </FeatureFlag>
-          </FlexBox>
-        </ResourceCard>
-      </>
+          </FeatureFlag>
+        </FlexBox>
+      </ResourceCard>
     )
   }
 

--- a/ui/src/buckets/components/BucketCard.tsx
+++ b/ui/src/buckets/components/BucketCard.tsx
@@ -4,8 +4,16 @@ import {withRouter, WithRouterProps} from 'react-router'
 import _ from 'lodash'
 
 // Components
-import {ResourceCard} from '@influxdata/clockface'
+import {
+  Button,
+  ResourceCard,
+  FlexBox,
+  FlexDirection,
+  ComponentSize,
+} from '@influxdata/clockface'
 import BucketContextMenu from 'src/buckets/components/BucketContextMenu'
+import BucketAddDataButton from 'src/buckets/components/BucketAddDataButton'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Types
 import {Bucket} from 'src/types'
@@ -27,7 +35,7 @@ interface Props {
 
 class BucketRow extends PureComponent<Props & WithRouterProps> {
   public render() {
-    const {bucket, onDeleteBucket, onDeleteData} = this.props
+    const {bucket, onDeleteBucket} = this.props
     return (
       <>
         <ResourceCard
@@ -36,11 +44,6 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
             <BucketContextMenu
               bucket={bucket}
               onDeleteBucket={onDeleteBucket}
-              onDeleteData={onDeleteData}
-              onRename={this.handleRenameBucket}
-              onAddCollector={this.handleAddCollector}
-              onAddLineProtocol={this.handleAddLineProtocol}
-              onAddScraper={this.handleAddScraper}
             />
           }
           name={
@@ -51,9 +54,37 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
             />
           }
           metaData={[<>Retention: {bucket.ruleString}</>]}
-        />
+        >
+          <FlexBox direction={FlexDirection.Row} margin={ComponentSize.Small}>
+            <BucketAddDataButton
+              onAddCollector={this.handleAddCollector}
+              onAddLineProtocol={this.handleAddLineProtocol}
+              onAddScraper={this.handleAddScraper}
+            />
+            <Button
+              text="Rename"
+              testID="bucket-rename"
+              size={ComponentSize.ExtraSmall}
+              onClick={this.handleRenameBucket}
+            />
+            <FeatureFlag name="deleteWithPredicate">
+              <Button
+                text="Delete Data By Filter"
+                testID="bucket-delete-task"
+                size={ComponentSize.ExtraSmall}
+                onClick={this.handleDeleteData}
+              />
+            </FeatureFlag>
+          </FlexBox>
+        </ResourceCard>
       </>
     )
+  }
+
+  private handleDeleteData = () => {
+    const {onDeleteData, bucket} = this.props
+
+    onDeleteData(bucket)
   }
 
   private handleRenameBucket = () => {

--- a/ui/src/buckets/components/BucketContextMenu.tsx
+++ b/ui/src/buckets/components/BucketContextMenu.tsx
@@ -3,9 +3,6 @@ import React, {PureComponent} from 'react'
 
 // Components
 import {Context, Alignment, ComponentSize} from 'src/clockface'
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
-
-import CloudExclude from 'src/shared/components/cloud/CloudExclude'
 
 import {
   ButtonShape,
@@ -22,24 +19,11 @@ import {PrettyBucket} from 'src/buckets/components/BucketCard'
 interface Props {
   bucket: PrettyBucket
   onDeleteBucket: (bucket: PrettyBucket) => void
-  onDeleteData: (bucket: PrettyBucket) => void
-  onRename: () => void
-  onAddCollector: () => void
-  onAddLineProtocol: () => void
-  onAddScraper: () => void
 }
 
 export default class BucketContextMenu extends PureComponent<Props> {
   public render() {
-    const {
-      bucket,
-      onDeleteBucket,
-      onDeleteData,
-      onRename,
-      onAddCollector,
-      onAddLineProtocol,
-      onAddScraper,
-    } = this.props
+    const {bucket, onDeleteBucket} = this.props
 
     return (
       <>
@@ -50,20 +34,6 @@ export default class BucketContextMenu extends PureComponent<Props> {
             margin={ComponentSize.Small}
           >
             <Context.Menu
-              icon={IconFont.CogThick}
-              color={ComponentColor.Danger}
-            >
-              <Context.Item label="Rename" action={onRename} value={bucket} />
-              <FeatureFlag name="deleteWithPredicate">
-                <Context.Item
-                  label="Delete Data By Filter"
-                  action={onDeleteData}
-                  value={bucket}
-                  testID="context-delete-task"
-                />
-              </FeatureFlag>
-            </Context.Menu>
-            <Context.Menu
               icon={IconFont.Trash}
               color={ComponentColor.Danger}
               shape={ButtonShape.Default}
@@ -71,35 +41,11 @@ export default class BucketContextMenu extends PureComponent<Props> {
               testID="context-delete-menu"
             >
               <Context.Item
-                label="Delete"
+                label="Confirm"
                 action={onDeleteBucket}
                 value={bucket}
                 testID="context-delete-task"
               />
-            </Context.Menu>
-            <Context.Menu
-              icon={IconFont.Plus}
-              text="Add Data"
-              shape={ButtonShape.Default}
-              color={ComponentColor.Primary}
-            >
-              <Context.Item
-                label="Configure Telegraf Agent"
-                description="Configure a Telegraf agent to push data into your bucket."
-                action={onAddCollector}
-              />
-              <Context.Item
-                label="Line Protocol"
-                description="Quickly load an existing line protocol file."
-                action={onAddLineProtocol}
-              />
-              <CloudExclude>
-                <Context.Item
-                  label="Scrape Metrics"
-                  description="Add a scrape target to pull data into your bucket."
-                  action={onAddScraper}
-                />
-              </CloudExclude>
             </Context.Menu>
           </FlexBox>
         </Context>

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -56,6 +56,7 @@
 @import 'src/shared/components/selectorList/SelectorList.scss';
 @import 'src/shared/components/CodeSnippet.scss';
 @import 'src/buckets/components/Retention.scss';
+@import 'src/buckets/components/BucketAddDataButton.scss';
 @import 'src/telegrafs/components/TelegrafConfigOverlay.scss';
 @import 'src/variables/components/CreateVariableOverlay.scss';
 @import 'src/authorizations/components/BucketsSelector.scss';


### PR DESCRIPTION
Describe your proposed changes here.

- Move `Rename` , `Add Data`, and `Delete Data by Filter` into resource card instead of context menu
- Use Clockface `Popover` for `Add Data` button

### Why

Despite making each bucket card a bit busier, I predict this change will make the options more discoverable and faster to access.

![updated-bucket-list](https://user-images.githubusercontent.com/2433762/64043829-3fb62280-cb1a-11e9-982a-ea5c277613b5.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
