### PR TITLE
perf(storage): improve prefix deletion in Cache

### DIFF
--- a/tsdb/tsm1/cache.go
+++ b/tsdb/tsm1/cache.go
@@ -432,8 +432,7 @@ func (c *Cache) DeleteBucketRange(ctx context.Context, name string, min, max int
 
 	for _, k := range toDelete {
 		total += uint64(len(k))
-		// TODO(edd): either use unsafe conversion to []byte or add a removeString
-		// method.
+		// TODO(edd): either use unsafe conversion to []byte or add a removeString method.
 		c.store.remove([]byte(k))
 	}
 

--- a/tsdb/tsm1/cache.go
+++ b/tsdb/tsm1/cache.go
@@ -1,10 +1,10 @@
 package tsm1
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -388,7 +388,7 @@ func (c *Cache) Values(key []byte) Values {
 // DeleteBucketRange removes values for all keys containing points
 // with timestamps between min and max contained in the bucket identified
 // by name from the cache.
-func (c *Cache) DeleteBucketRange(ctx context.Context, name []byte, min, max int64, pred Predicate) {
+func (c *Cache) DeleteBucketRange(ctx context.Context, name string, min, max int64, pred Predicate) {
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
@@ -396,15 +396,17 @@ func (c *Cache) DeleteBucketRange(ctx context.Context, name []byte, min, max int
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var toDelete [][]byte
+	var toDelete []string
 	var total uint64
 
 	// applySerial only errors if the closure returns an error.
-	_ = c.store.applySerial(func(k []byte, e *entry) error {
-		if !bytes.HasPrefix(k, name) {
+	_ = c.store.applySerial(func(k string, e *entry) error {
+		if !strings.HasPrefix(k, name) {
 			return nil
 		}
-		if pred != nil && !pred.Matches(k) {
+		// TODO(edd): either use an unsafe conversion to []byte, or add a MatchesString
+		// method to tsm1.Predicate.
+		if pred != nil && !pred.Matches([]byte(k)) {
 			return nil
 		}
 
@@ -430,7 +432,9 @@ func (c *Cache) DeleteBucketRange(ctx context.Context, name []byte, min, max int
 
 	for _, k := range toDelete {
 		total += uint64(len(k))
-		c.store.remove(k)
+		// TODO(edd): either use unsafe conversion to []byte or add a removeString
+		// method.
+		c.store.remove([]byte(k))
 	}
 
 	c.tracker.DecCacheSize(total)
@@ -461,7 +465,7 @@ func (c *Cache) values(key []byte) Values {
 // ApplyEntryFn applies the function f to each entry in the Cache.
 // ApplyEntryFn calls f on each entry in turn, within the same goroutine.
 // It is safe for use by multiple goroutines.
-func (c *Cache) ApplyEntryFn(f func(key []byte, entry *entry) error) error {
+func (c *Cache) ApplyEntryFn(f func(key string, entry *entry) error) error {
 	c.mu.RLock()
 	store := c.store
 	c.mu.RUnlock()
@@ -503,7 +507,7 @@ func (cl *CacheLoader) Load(cache *Cache) error {
 			encoded := tsdb.EncodeName(en.OrgID, en.BucketID)
 			name := models.EscapeMeasurement(encoded[:])
 
-			cache.DeleteBucketRange(context.Background(), name, en.Min, en.Max, pred)
+			cache.DeleteBucketRange(context.Background(), string(name), en.Min, en.Max, pred)
 			return nil
 		}
 

--- a/tsdb/tsm1/cache_test.go
+++ b/tsdb/tsm1/cache_test.go
@@ -177,7 +177,7 @@ func TestCache_Cache_DeleteBucketRange(t *testing.T) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteBucketRange(context.Background(), []byte("bar"), 2, math.MaxInt64, nil)
+	c.DeleteBucketRange(context.Background(), "bar", 2, math.MaxInt64, nil)
 
 	if exp, keys := [][]byte{[]byte("bar"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after delete, exp %v, got %v", exp, keys)
@@ -216,7 +216,7 @@ func TestCache_DeleteBucketRange_NoValues(t *testing.T) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteBucketRange(context.Background(), []byte("foo"), math.MinInt64, math.MaxInt64, nil)
+	c.DeleteBucketRange(context.Background(), "foo", math.MinInt64, math.MaxInt64, nil)
 
 	if exp, keys := 0, len(c.Keys()); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
@@ -251,7 +251,7 @@ func TestCache_DeleteBucketRange_NotSorted(t *testing.T) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteBucketRange(context.Background(), []byte("foo"), 1, 3, nil)
+	c.DeleteBucketRange(context.Background(), "foo", 1, 3, nil)
 
 	if exp, keys := 0, len(c.Keys()); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after delete, exp %v, got %v", exp, keys)
@@ -269,7 +269,7 @@ func TestCache_DeleteBucketRange_NotSorted(t *testing.T) {
 func TestCache_DeleteBucketRange_NonExistent(t *testing.T) {
 	c := NewCache(1024)
 
-	c.DeleteBucketRange(context.Background(), []byte("bar"), math.MinInt64, math.MaxInt64, nil)
+	c.DeleteBucketRange(context.Background(), "bar", math.MinInt64, math.MaxInt64, nil)
 
 	if got, exp := c.Size(), uint64(0); exp != got {
 		t.Fatalf("cache size incorrect exp %d, got %d", exp, got)
@@ -301,7 +301,7 @@ func TestCache_Cache_DeleteBucketRange_WithPredicate(t *testing.T) {
 		t.Fatalf("cache keys incorrect after 2 writes, exp %v, got %v", exp, keys)
 	}
 
-	c.DeleteBucketRange(context.Background(), []byte("f"), 2, math.MaxInt64, stringPredicate("fee"))
+	c.DeleteBucketRange(context.Background(), "f", 2, math.MaxInt64, stringPredicate("fee"))
 
 	if exp, keys := [][]byte{[]byte("fee"), []byte("foo")}, c.Keys(); !reflect.DeepEqual(keys, exp) {
 		t.Fatalf("cache keys incorrect after delete, exp %v, got %v", exp, keys)

--- a/tsdb/tsm1/engine_delete_prefix.go
+++ b/tsdb/tsm1/engine_delete_prefix.go
@@ -76,6 +76,7 @@ func (e *Engine) DeletePrefixRange(rootCtx context.Context, name []byte, min, ma
 		// TODO(edd): tracing this deep down is currently speculative, so I have
 		// not added the tracing into the TSMReader API.
 		span, _ := tracing.StartSpanFromContextWithOperationName(rootCtx, "TSMFile delete prefix")
+		span.LogKV("file_path", r.Path())
 		defer span.Finish()
 
 		return r.DeletePrefix(name, min, max, pred, func(key []byte) {
@@ -87,13 +88,12 @@ func (e *Engine) DeletePrefixRange(rootCtx context.Context, name []byte, min, ma
 		return err
 	}
 
+	span, _ = tracing.StartSpanFromContextWithOperationName(rootCtx, "Cache find delete keys")
+	span.LogKV("cache_size", e.Cache.Size())
+	var keysChecked int // For tracing information.
 	// ApplySerialEntryFn cannot return an error in this invocation.
 	_ = e.Cache.ApplyEntryFn(func(k []byte, _ *entry) error {
-		// TODO(edd): tracing this deep down is currently speculative, so I have
-		// not added the tracing into the Cache API.
-		span, _ := tracing.StartSpanFromContextWithOperationName(rootCtx, "Cache find delete keys")
-		defer span.Finish()
-
+		keysChecked++
 		if !bytes.HasPrefix(k, name) {
 			return nil
 		}
@@ -107,11 +107,10 @@ func (e *Engine) DeletePrefixRange(rootCtx context.Context, name []byte, min, ma
 
 		return nil
 	})
+	span.LogKV("cache_cardinality", keysChecked)
+	span.Finish()
 
-	sortSpan, _ := tracing.StartSpanFromContextWithOperationName(rootCtx, "Cache sort keys")
-	sortSpan.Finish()
-
-	// Delete from the cache.
+	// Delete from the cache (traced in cache).
 	e.Cache.DeleteBucketRange(ctx, name, min, max, pred)
 
 	// Now that all of the data is purged, we need to find if some keys are fully deleted
@@ -120,11 +119,13 @@ func (e *Engine) DeletePrefixRange(rootCtx context.Context, name []byte, min, ma
 		// TODO(edd): tracing this deep down is currently speculative, so I have
 		// not added the tracing into the Engine API.
 		span, _ := tracing.StartSpanFromContextWithOperationName(rootCtx, "TSMFile determine fully deleted")
+		span.LogKV("file_path", r.Path())
 		defer span.Finish()
 
 		possiblyDead.RLock()
 		defer possiblyDead.RUnlock()
 
+		var keysChecked int
 		iter := r.Iterator(name)
 		for i := 0; iter.Next(); i++ {
 			key := iter.Key()
@@ -149,19 +150,18 @@ func (e *Engine) DeletePrefixRange(rootCtx context.Context, name []byte, min, ma
 				possiblyDead.RLock()
 			}
 		}
-
+		span.LogKV("keys_checked", keysChecked)
 		return iter.Err()
 	}); err != nil {
 		return err
 	}
 
+	span, _ = tracing.StartSpanFromContextWithOperationName(rootCtx, "Cache find delete keys")
+	span.LogKV("cache_size", e.Cache.Size())
+	keysChecked = 0
 	// ApplySerialEntryFn cannot return an error in this invocation.
 	_ = e.Cache.ApplyEntryFn(func(k []byte, _ *entry) error {
-		// TODO(edd): tracing this deep down is currently speculative, so I have
-		// not added the tracing into the Cache API.
-		span, _ := tracing.StartSpanFromContextWithOperationName(rootCtx, "Cache find delete keys")
-		defer span.Finish()
-
+		keysChecked++
 		if !bytes.HasPrefix(k, name) {
 			return nil
 		}
@@ -172,6 +172,8 @@ func (e *Engine) DeletePrefixRange(rootCtx context.Context, name []byte, min, ma
 		delete(possiblyDead.keys, string(k))
 		return nil
 	})
+	span.LogKV("cache_cardinality", keysChecked)
+	span.Finish()
 
 	if len(possiblyDead.keys) > 0 {
 		buf := make([]byte, 1024)
@@ -218,7 +220,8 @@ func (e *Engine) DeletePrefixRange(rootCtx context.Context, name []byte, min, ma
 
 			// Iterate over the series ids we previously extracted from the index
 			// and remove from the series file.
-			span, _ = tracing.StartSpanFromContextWithOperationName(rootCtx, "SFile Delete Series ID")
+			span, _ = tracing.StartSpanFromContextWithOperationName(rootCtx, "SFile Delete Series IDs")
+			span.LogKV("series_id_set_size", set.Cardinality())
 			set.ForEachNoLock(func(id tsdb.SeriesID) {
 				if err = e.sfile.DeleteSeriesID(id); err != nil {
 					return
@@ -230,6 +233,7 @@ func (e *Engine) DeletePrefixRange(rootCtx context.Context, name []byte, min, ma
 
 		// This is the slow path, when not dropping the entire bucket (measurement)
 		span, _ = tracing.StartSpanFromContextWithOperationName(rootCtx, "TSI/SFile Delete keys")
+		span.LogKV("keys_to_delete", len(possiblyDead.keys))
 		for key := range possiblyDead.keys {
 			// TODO(jeff): ugh reduce copies here
 			keyb := []byte(key)

--- a/tsdb/tsm1/engine_delete_prefix_test.go
+++ b/tsdb/tsm1/engine_delete_prefix_test.go
@@ -21,7 +21,7 @@ func TestEngine_DeletePrefix(t *testing.T) {
 	p7 := MustParsePointString("mem,host=C value=1.3 1", "mm1")
 	p8 := MustParsePointString("disk,host=C value=1.3 1", "mm2")
 
-	e, err := NewEngine()
+	e, err := NewEngine(tsm1.NewConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tsdb/tsm1/engine_schema_test.go
+++ b/tsdb/tsm1/engine_schema_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestEngine_CancelContext(t *testing.T) {
-	e, err := NewEngine()
+	e, err := NewEngine(tsm1.NewConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ memB,host=EB,os=macOS value=1.3 201`)
 }
 
 func TestEngine_TagValues(t *testing.T) {
-	e, err := NewEngine()
+	e, err := NewEngine(tsm1.NewConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +390,7 @@ memB,host=EB,os=macOS value=1.3 201`)
 }
 
 func TestEngine_TagKeys(t *testing.T) {
-	e, err := NewEngine()
+	e, err := NewEngine(tsm1.NewConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tsdb/tsm1/engine_test.go
+++ b/tsdb/tsm1/engine_test.go
@@ -342,7 +342,7 @@ func BenchmarkEngine_DeletePrefixRange_Cache(b *testing.B) {
 		}
 	})
 
-	b.Run("not exists", func(b *testing.B) {
+	b.Run("not_exists", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()

--- a/tsdb/tsm1/ring.go
+++ b/tsdb/tsm1/ring.go
@@ -165,14 +165,14 @@ func (r *ring) apply(f func([]byte, *entry) error) error {
 // applySerial is similar to apply, but invokes f on each partition in the same
 // goroutine.
 // apply is safe for use by multiple goroutines.
-func (r *ring) applySerial(f func([]byte, *entry) error) error {
+func (r *ring) applySerial(f func(string, *entry) error) error {
 	for _, p := range r.partitions {
 		p.mu.RLock()
 		for k, e := range p.store {
 			if e.count() == 0 {
 				continue
 			}
-			if err := f([]byte(k), e); err != nil {
+			if err := f(k, e); err != nil {
 				p.mu.RUnlock()
 				return err
 			}


### PR DESCRIPTION
This PR adds several commits that significantly improve the performance of executing prefix-based deletes in the `tsm1.Cache`.

All deletes in 2.x are "prefix-based", because series data is segmented between buckets using an `<org, bucket>` id as the measurement name in the TSM engine and the TSI index.

We have recently been seeing issues where contention over the Cache (contention between a delete and some writes) is becoming problematic and affecting write throughput. This often manifests during a retention check (which is executed as a prefix-based delete for each bucket in the system, across varying time periods).

I tested the improvements in this PR with a benchmark that measures CPU time and allocations when deleting from a cache with 100K keys in it. There are two benchmarks: one where some data in the cache needs to be deleted, and one where nothing in the cache matches the key.

**Follow on Work**: there is some forthcoming follow-on work that's not included in this PR:

 - improving performance of deletion against a cache when there are no matching keys. This can be improved significantly with a Bloom filter or similar and I should have something next week.
 - not touching the cache if we know that there can't be any matching timestamps within it. This should basically mean retention checks generally don't need to touch the cache. All of the work in this PR is still relevant for more general deletions though.

Overall the performance improvement is about **4.5x** for deleting from the cache (`~77-83%` reduction in benchmark time).

Here are some benchstats comparing this PR to the baseline benchmark introduced in deb7a59.

```
name                                          old time/op    new time/op    delta
Engine_DeletePrefixRange_Cache/exists-24         268ms ± 5%      59ms ± 3%  -77.89%  (p=0.000 n=10+8)
Engine_DeletePrefixRange_Cache/not_exists-24     265ms ± 5%      45ms ± 1%  -83.00%  (p=0.000 n=10+10)

name                                          old alloc/op   new alloc/op   delta
Engine_DeletePrefixRange_Cache/exists-24        64.1MB ± 0%     3.1MB ± 2%  -95.15%  (p=0.000 n=9+10)
Engine_DeletePrefixRange_Cache/not_exists-24    59.2MB ± 0%     0.1MB ±86%  -99.86%  (p=0.000 n=8+10)

name                                          old allocs/op  new allocs/op  delta
Engine_DeletePrefixRange_Cache/exists-24          711k ± 0%       28k ± 1%  -96.05%  (p=0.000 n=9+10)
Engine_DeletePrefixRange_Cache/not_exists-24      700k ± 0%        1k ±63%  -99.89%  (p=0.000 n=8+10)
```

The performance improvements focus on two main areas: reducing lock contention and reducing small allocations.


