### PR TITLE
perf(storage): expose ability to peek on stream readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [14631](https://github.com/influxdata/influxdb/pull/14631): Updated name of Local Metrics template
 1. [14631](https://github.com/influxdata/influxdb/pull/14631): Dashboards for all Telegraf config bundles now created
 1. [14694](https://github.com/influxdata/influxdb/pull/14694): Add ability to find tasks by name.
+1. [14901](https://github.com/influxdata/influxdb/pull/14901): Add ability to Peek() on reads package StreamReader types.
 
 ### UI Improvements
 1. [14917](https://github.com/influxdata/influxdb/pull/14917): Make first steps in Monitoring & Alerting more obvious

--- a/storage/reads/stream_reader.go
+++ b/storage/reads/stream_reader.go
@@ -111,6 +111,12 @@ func (r *ResultSetStreamReader) Stats() cursors.CursorStats {
 	return r.fr.stats.Stats()
 }
 
+// Peek reads the next frame on the underlying stream-reader
+// if there is one
+func (r *ResultSetStreamReader) Peek() {
+	r.fr.peekFrame()
+}
+
 func (r *ResultSetStreamReader) Next() bool {
 	if r.fr.state == stateReadSeries {
 		return r.readSeriesFrame()
@@ -176,6 +182,12 @@ func NewGroupResultSetStreamReader(stream StreamReader) *GroupResultSetStreamRea
 }
 
 func (r *GroupResultSetStreamReader) Err() error { return r.fr.err }
+
+// Peek reads the next frame on the underlying stream-reader
+// if there is one
+func (r *GroupResultSetStreamReader) Peek() {
+	r.fr.peekFrame()
+}
 
 func (r *GroupResultSetStreamReader) Next() GroupCursor {
 	if r.fr.state == stateReadGroup {

--- a/storage/reads/stream_reader_test.go
+++ b/storage/reads/stream_reader_test.go
@@ -308,6 +308,10 @@ series: _m=cpu,tag0=val1
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs := reads.NewResultSetStreamReader(tt.stream)
+
+			// ensure a peek doesn't effect the end result
+			rs.Peek()
+
 			sb := new(strings.Builder)
 			ResultSetToString(sb, rs)
 
@@ -582,6 +586,10 @@ group:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs := reads.NewGroupResultSetStreamReader(tt.stream)
+
+			// ensure a peek doesn't effect the end result
+			rs.Peek()
+
 			sb := new(strings.Builder)
 			GroupResultSetToString(sb, rs)
 


### PR DESCRIPTION
Expose ability to Peek on `reads.ResultSetStreamReader` and `reads.GroupResultSetStreamReader`. The purpose being to allows creators of this type to pre-emptively peek at a frame before creating a cursor.

When creating multiple stream readers like these for multiple partitions and joining them into a single sequential or merged result set, a peek on each partition could be issued concurrently by the caller. This would allow us to quickly discard empty results, potentially reducing latency on reads.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
