### PR TITLE
fix(kv): ignore not found error when removing org dep resources

### DIFF
--- a/kv/urm.go
+++ b/kv/urm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/kit/tracing"
+	"go.uber.org/zap"
 )
 
 var (
@@ -359,6 +360,10 @@ func (s *Service) deleteOrgDependentMappings(ctx context.Context, tx Tx, m *infl
 			ResourceID:   b.ID,
 			UserID:       m.UserID,
 		}); err != nil {
+			if influxdb.ErrorCode(err) == influxdb.ENotFound {
+				s.Logger.Info("URM bucket is missing", zap.Stringer("orgID", m.ResourceID))
+				continue
+			}
 			return err
 		}
 		// TODO(desa): add support for all other resource types.


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/14876

Issue only happens in cloud,
if an org dependent resource doesn't exist, such an error shouldn't be a stopper to prevent the whole remove process. 

Manually tested

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
