### PR TITLE
feat(tasks): report error messages to metrics

### DIFF
--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -316,7 +316,7 @@ func (w *worker) start(p *Promise) {
 	w.te.metrics.StartRun(p.task.ID, time.Since(p.createdAt))
 }
 
-func (w *worker) finish(p *Promise, rs backend.RunStatus, err error) {
+func (w *worker) finish(p *Promise, rs backend.RunStatus, err *influxdb.Error) {
 	// trace
 	span, ctx := tracing.StartSpanFromContext(p.ctx)
 	defer span.Finish()
@@ -332,9 +332,9 @@ func (w *worker) finish(p *Promise, rs backend.RunStatus, err error) {
 	w.te.metrics.FinishRun(p.task.ID, rs, rd)
 
 	// log error
-	if err != nil {
+	if err.Err != nil {
 		w.te.logger.Debug("execution failed", zap.Error(err), zap.String("taskID", p.task.ID.String()))
-		w.te.metrics.LogError()
+		w.te.metrics.LogError(err)
 		p.err = err
 	} else {
 		w.te.logger.Debug("Completed successfully", zap.String("taskID", p.task.ID.String()))
@@ -350,13 +350,13 @@ func (w *worker) executeQuery(p *Promise) {
 
 	pkg, err := flux.Parse(p.task.Flux)
 	if err != nil {
-		w.finish(p, backend.RunFail, err)
+		w.finish(p, backend.RunFail, influxdb.ErrFluxParseError(err))
 		return
 	}
 
 	sf, err := p.run.ScheduledForTime()
 	if err != nil {
-		w.finish(p, backend.RunFail, err)
+		w.finish(p, backend.RunFail, influxdb.ErrTaskTimeParse(err))
 		return
 	}
 
@@ -372,7 +372,7 @@ func (w *worker) executeQuery(p *Promise) {
 	it, err := w.te.qs.Query(ctx, req)
 	if err != nil {
 		// Assume the error should not be part of the runResult.
-		w.finish(p, backend.RunFail, err)
+		w.finish(p, backend.RunFail, influxdb.ErrQueryError(err))
 		return
 	}
 
@@ -400,7 +400,7 @@ func (w *worker) executeQuery(p *Promise) {
 		w.te.tcs.AddRunLog(p.ctx, p.task.ID, p.run.ID, time.Now(), string(b))
 	}
 
-	w.finish(p, backend.RunSuccess, runErr)
+	w.finish(p, backend.RunSuccess, influxdb.ErrResultIteratorError(runErr))
 }
 
 // RunsActive returns the current number of workers, which is equivalent to

--- a/task/backend/executor/task_executor_test.go
+++ b/task/backend/executor/task_executor_test.go
@@ -267,6 +267,7 @@ func testLimitFunc(t *testing.T) {
 		t.Fatal(err)
 	}
 	forcedErr := errors.New("forced")
+	forcedQueryErr := influxdb.ErrQueryError(forcedErr)
 	tes.svc.FailNextQuery(forcedErr)
 
 	count := 0
@@ -285,7 +286,7 @@ func testLimitFunc(t *testing.T) {
 
 	<-promise.Done()
 
-	if got := promise.Error(); got != forcedErr {
+	if got := promise.Error(); got.Error() != forcedQueryErr.Error() {
 		t.Fatal("failed to get failure from forced error")
 	}
 

--- a/task_errors.go
+++ b/task_errors.go
@@ -86,6 +86,36 @@ var (
 	}
 )
 
+// ErrFluxParseError is returned when an error is thrown by Flux.Parse in the task executor
+func ErrFluxParseError(err error) *Error {
+	return &Error{
+		Code: EInvalid,
+		Msg:  fmt.Sprintf("could not parse Flux script; Err: %v", err),
+		Op:   "kv/taskExecutor",
+		Err:  err,
+	}
+}
+
+// ErrQueryError is returned when an error is thrown by Query service in the task executor
+func ErrQueryError(err error) *Error {
+	return &Error{
+		Code: EInternal,
+		Msg:  fmt.Sprintf("unexpected error from queryd; Err: %v", err),
+		Op:   "kv/taskExecutor",
+		Err:  err,
+	}
+}
+
+// ErrResultIteratorError is returned when an error is thrown by exhaustResultIterators in the executor
+func ErrResultIteratorError(err error) *Error {
+	return &Error{
+		Code: EInternal,
+		Msg:  fmt.Sprintf("Error exhausting result iterator; Err: %v", err),
+		Op:   "kv/taskExecutor",
+		Err:  err,
+	}
+}
+
 func ErrInternalTaskServiceError(err error) *Error {
 	return &Error{
 		Code: EInternal,


### PR DESCRIPTION
Closes https://github.com/influxdata/idpe/issues/4262

This PR makes a change to the new executor, which will be put into effect when the new scheduler is merged.

Previously, executor metrics only reported the number of errors thrown by the executor, without any information on what type of errors were occurring. This PR attaches an error type to the error metric, so that developers can observe error trends in the tasks dashboard.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
