### PR TITLE
fix(tsi1): Remove TSI cardinality stats cache

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -614,7 +614,7 @@ func (e *Engine) ApplyFnToSeriesIDSet(fn func(*tsdb.SeriesIDSet)) {
 }
 
 // MeasurementCardinalityStats returns cardinality stats for all measurements.
-func (e *Engine) MeasurementCardinalityStats() tsi1.MeasurementCardinalityStats {
+func (e *Engine) MeasurementCardinalityStats() (tsi1.MeasurementCardinalityStats, error) {
 	return e.index.MeasurementCardinalityStats()
 }
 

--- a/tsdb/tsi1/config.go
+++ b/tsdb/tsi1/config.go
@@ -1,6 +1,10 @@
 package tsi1
 
-import "github.com/influxdata/influxdb/toml"
+import (
+	"time"
+
+	"github.com/influxdata/influxdb/toml"
+)
 
 // DefaultMaxIndexLogFileSize is the default threshold, in bytes, when an index
 // write-ahead log file will compact into an index file.
@@ -25,6 +29,10 @@ type Config struct {
 	// The cache uses an LRU strategy for eviction. Setting the value to 0 will
 	// disable the cache.
 	SeriesIDSetCacheSize uint64
+
+	// StatsTTL sets the time-to-live for the stats cache. If zero, then caching
+	// is disabled. If set then stats are cached for the given amount of time.
+	StatsTTL time.Duration `toml:"stats-ttl"`
 }
 
 // NewConfig returns a new Config.

--- a/tsdb/tsi1/file_set.go
+++ b/tsdb/tsi1/file_set.go
@@ -403,39 +403,6 @@ func (fs *FileSet) TagValueSeriesIDIterator(name, key, value []byte) (tsdb.Serie
 	return tsdb.NewSeriesIDSetIterator(ss), nil
 }
 
-// Stats computes aggregate measurement cardinality stats from the raw index data.
-func (fs *FileSet) Stats() MeasurementCardinalityStats {
-	stats := make(MeasurementCardinalityStats)
-	mitr := fs.MeasurementIterator()
-	if mitr == nil {
-		return stats
-	}
-
-	for {
-		// Iterate over each measurement and set cardinality.
-		mm := mitr.Next()
-		if mm == nil {
-			return stats
-		}
-
-		// Obtain all series for measurement.
-		sitr := fs.MeasurementSeriesIDIterator(mm.Name())
-		if sitr == nil {
-			continue
-		}
-
-		// All iterators should be series id set iterators except legacy 1.x data.
-		// Skip if it does not conform as aggregation would be too slow.
-		ssitr, ok := sitr.(tsdb.SeriesIDSetIterator)
-		if !ok {
-			continue
-		}
-
-		// Set cardinality for the given measurement.
-		stats[string(mm.Name())] = int(ssitr.SeriesIDSet().Cardinality())
-	}
-}
-
 // File represents a log or index file.
 type File interface {
 	Close() error

--- a/tsdb/tsi1/index.go
+++ b/tsdb/tsi1/index.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 	"unsafe"
 
 	"github.com/cespare/xxhash"
@@ -126,6 +127,9 @@ type Index struct {
 	// Index's version.
 	version int
 
+	// Cardinality stats caching time-to-live.
+	StatsTTL time.Duration
+
 	// Number of partitions used by the index.
 	PartitionN uint64
 }
@@ -145,6 +149,7 @@ func NewIndex(sfile *tsdb.SeriesFile, c Config, options ...IndexOption) *Index {
 		version:          Version,
 		config:           c,
 		sfile:            sfile,
+		StatsTTL:         c.StatsTTL,
 		PartitionN:       DefaultPartitionN,
 	}
 
@@ -243,6 +248,7 @@ func (i *Index) Open(ctx context.Context) error {
 	for j := 0; j < len(i.partitions); j++ {
 		p := NewPartition(i.sfile, filepath.Join(i.path, fmt.Sprint(j)))
 		p.MaxLogFileSize = i.maxLogFileSize
+		p.StatsTTL = i.StatsTTL
 		p.nosync = i.disableFsync
 		p.logbufferSize = i.logfileBufferSize
 		p.logger = i.logger.With(zap.String("tsi1_partition", fmt.Sprint(j+1)))
@@ -1194,25 +1200,13 @@ func (i *Index) SetFieldName(measurement []byte, name string) {}
 func (i *Index) Rebuild() {}
 
 // MeasurementCardinalityStats returns cardinality stats for all measurements.
-func (i *Index) MeasurementCardinalityStats() MeasurementCardinalityStats {
+func (i *Index) MeasurementCardinalityStats() (MeasurementCardinalityStats, error) {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
 	stats := NewMeasurementCardinalityStats()
 	for _, p := range i.partitions {
-		stats.Add(p.MeasurementCardinalityStats())
-	}
-	return stats
-}
-
-// ComputeMeasurementCardinalityStats computes the cardinality stats from raw index data.
-func (i *Index) ComputeMeasurementCardinalityStats() (MeasurementCardinalityStats, error) {
-	i.mu.RLock()
-	defer i.mu.RUnlock()
-
-	stats := NewMeasurementCardinalityStats()
-	for _, p := range i.partitions {
-		pstats, err := p.ComputeMeasurementCardinalityStats()
+		pstats, err := p.MeasurementCardinalityStats()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Removes the original implementation of TSI cardinality stats which would cache all files except for the active log file and then merge the stats together on demand. This caused deleted series in the active log file to be ignored.

This PR changes the computation so all file stats are computed together. It also includes a new time based cache (`stats-ttl`) that defaults to `0` (disabled).

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
