### PR TITLE
ci: use latest staticcheck

### DIFF
--- a/chronograf/server/server.go
+++ b/chronograf/server/server.go
@@ -98,7 +98,7 @@ type Server struct {
 	TelegrafSystemInterval time.Duration     `long:"telegraf-system-interval" default:"1m" description:"Duration used in the GROUP BY time interval for the hosts list" env:"TELEGRAF_SYSTEM_INTERVAL"`
 
 	ReportingDisabled bool   `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
-	LogLevel          string `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"error" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`
+	LogLevel          string `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"error" default:"info" description:"Set the logging level" env:"LOG_LEVEL"` //lint:ignore SA5008 duplicate tag choice is expected with go-flags.
 	Basepath          string `short:"p" long:"basepath" description:"A URL path prefix under which all chronograf routes will be mounted. (Note: PREFIX_ROUTES has been deprecated. Now, if basepath is set, all routes will be prefixed with it.)" env:"BASE_PATH"`
 	ShowVersion       bool   `short:"v" long:"version" description:"Show Chronograf version info"`
 	BuildInfo         chronograf.BuildInfo

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	gopkg.in/ini.v1 v1.42.0 // indirect
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1 // indirect
-	honnef.co/go/tools v0.0.0-20190812140558-8bd8df698242 // indirect
+	honnef.co/go/tools v0.0.1-2019.2.3.0.20190904154718-afd67930eec2
 	labix.org/v2/mgo v0.0.0-20140701140051-000000000287 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -544,8 +544,8 @@ honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20181108184350-ae8f1f9103cc h1:VdiEcF0DrrUbDdrLBceS0h7LE60ebD5yRYLLXi0ezIs=
 honnef.co/go/tools v0.0.0-20181108184350-ae8f1f9103cc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-honnef.co/go/tools v0.0.0-20190812140558-8bd8df698242 h1:o4vydRJR8cV2rSlUkfP0aRbr0sOMX+iAdUTFbQV4goo=
-honnef.co/go/tools v0.0.0-20190812140558-8bd8df698242/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+honnef.co/go/tools v0.0.1-2019.2.3.0.20190904154718-afd67930eec2 h1:TeRFic5UJx5LXC3n8mOt92bqyM5J+so5EuErnxK4PAk=
+honnef.co/go/tools v0.0.1-2019.2.3.0.20190904154718-afd67930eec2/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 labix.org/v2/mgo v0.0.0-20140701140051-000000000287 h1:L0cnkNl4TfAXzvdrqsYEmxOHOCv2p5I3taaReO8BWFs=
 labix.org/v2/mgo v0.0.0-20140701140051-000000000287/go.mod h1:Lg7AYkt1uXJoR9oeSZ3W/8IXLdvOfIITgZnommstyz4=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=

--- a/tools.go
+++ b/tools.go
@@ -11,7 +11,7 @@ import (
 	_ "github.com/kevinburke/go-bindata/go-bindata"
 	_ "github.com/mna/pigeon"
 	_ "golang.org/x/tools/cmd/stringer"
-	_ "honnef.co/go/tools/cmd/megacheck"
+	_ "honnef.co/go/tools/cmd/staticcheck"
 )
 
 // This package is a workaround for adding additional paths to the go.mod file

--- a/tsdb/series_id.go
+++ b/tsdb/series_id.go
@@ -12,7 +12,7 @@ const (
 	seriesIDValueMask = 0xFFFFFFFF                // series ids numerically are 32 bits
 	seriesIDTypeShift = 32                        // we put the type right after the value info
 	seriesIDTypeMask  = 0xFF << seriesIDTypeShift // a mask for the type byte
-	seriesIDSize      = 8                         //lint:ignore U1000 This const is used in a discarded compile-time type assertion.
+	seriesIDSize      = 8
 )
 
 // SeriesID is the type of a series id. It is logically a uint64, but encoded as a struct so


### PR DESCRIPTION
We were still referring to megacheck in tools.go; this confused
dependent projects also using staticcheck.
