### PR TITLE
fix(notification/rule): remove fieldsAsCols pivot from rules

### DIFF
--- a/notification/rule/http.go
+++ b/notification/rule/http.go
@@ -32,7 +32,7 @@ func (s *HTTP) GenerateFlux(e influxdb.NotificationEndpoint) (string, error) {
 func (s *HTTP) GenerateFluxAST(e *endpoint.HTTP) (*ast.Package, error) {
 	f := flux.File(
 		s.Name,
-		flux.Imports("influxdata/influxdb/monitor", "http", "json", "experimental", "influxdata/influxdb/v1"),
+		flux.Imports("influxdata/influxdb/monitor", "http", "json", "experimental"),
 		s.generateFluxASTBody(e),
 	)
 	return &ast.Package{Package: "main", Files: []*ast.File{f}}, nil

--- a/notification/rule/http_test.go
+++ b/notification/rule/http_test.go
@@ -3,7 +3,6 @@ package rule_test
 import (
 	"testing"
 
-	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/notification"
 	"github.com/influxdata/influxdb/notification/endpoint"
 	"github.com/influxdata/influxdb/notification/rule"
@@ -16,7 +15,6 @@ import "influxdata/influxdb/monitor"
 import "http"
 import "json"
 import "experimental"
-import "influxdata/influxdb/v1"
 
 option task = {name: "foo", every: 1h, offset: 1s}
 
@@ -27,9 +25,7 @@ notification = {
 	_notification_endpoint_id: "0000000000000002",
 	_notification_endpoint_name: "foo",
 }
-statuses = monitor.from(start: -2h, fn: (r) =>
-	(r.foo == "bar" and r.baz == "bang"))
-	|> v1.fieldsAsCols()
+statuses = monitor.from(start: -2h)
 any_to_crit = statuses
 	|> monitor.stateChanges(fromLevel: "any", toLevel: "crit")
 all_statuses = any_to_crit
@@ -47,22 +43,7 @@ all_statuses
 			Every:      mustDuration("1h"),
 			Offset:     mustDuration("1s"),
 			EndpointID: 2,
-			TagRules: []notification.TagRule{
-				{
-					Tag: influxdb.Tag{
-						Key:   "foo",
-						Value: "bar",
-					},
-					Operator: notification.Equal,
-				},
-				{
-					Tag: influxdb.Tag{
-						Key:   "baz",
-						Value: "bang",
-					},
-					Operator: notification.Equal,
-				},
-			},
+			TagRules:   []notification.TagRule{},
 			StatusRules: []notification.StatusRule{
 				{
 					CurrentLevel: notification.Critical,

--- a/notification/rule/http_test.go
+++ b/notification/rule/http_test.go
@@ -26,9 +26,10 @@ notification = {
 	_notification_endpoint_name: "foo",
 }
 statuses = monitor.from(start: -2h)
-any_to_crit = statuses
-	|> monitor.stateChanges(fromLevel: "any", toLevel: "crit")
-all_statuses = any_to_crit
+crit = statuses
+	|> filter(fn: (r) =>
+		(r._level == "crit"))
+all_statuses = crit
 	|> filter(fn: (r) =>
 		(r._time > experimental.subDuration(from: now(), d: 1h)))
 

--- a/notification/rule/rule.go
+++ b/notification/rule/rule.go
@@ -262,10 +262,7 @@ func (b *Base) generateFluxASTStatuses() ast.Statement {
 		props = append(props, flux.Property("fn", flux.Function(flux.FunctionParams("r"), body)))
 	}
 
-	base := flux.Pipe(
-		flux.Call(flux.Member("monitor", "from"), flux.Object(props...)),
-		flux.Call(flux.Member("v1", "fieldsAsCols"), flux.Object()),
-	)
+	base := flux.Call(flux.Member("monitor", "from"), flux.Object(props...))
 
 	return flux.DefineVariable("statuses", base)
 }

--- a/notification/rule/slack.go
+++ b/notification/rule/slack.go
@@ -34,7 +34,7 @@ func (s *Slack) GenerateFlux(e influxdb.NotificationEndpoint) (string, error) {
 func (s *Slack) GenerateFluxAST(e *endpoint.Slack) (*ast.Package, error) {
 	f := flux.File(
 		s.Name,
-		flux.Imports("influxdata/influxdb/monitor", "slack", "influxdata/influxdb/secrets", "experimental", "influxdata/influxdb/v1"),
+		flux.Imports("influxdata/influxdb/monitor", "slack", "influxdata/influxdb/secrets", "experimental"),
 		s.generateFluxASTBody(e),
 	)
 	return &ast.Package{Package: "main", Files: []*ast.File{f}}, nil

--- a/notification/rule/slack_test.go
+++ b/notification/rule/slack_test.go
@@ -43,11 +43,12 @@ notification = {
 }
 statuses = monitor.from(start: -2h, fn: (r) =>
 	(r.foo == "bar" and r.baz == "bang"))
-any_to_crit = statuses
-	|> monitor.stateChanges(fromLevel: "any", toLevel: "crit")
+crit = statuses
+	|> filter(fn: (r) =>
+		(r._level == "crit"))
 info_to_warn = statuses
 	|> monitor.stateChanges(fromLevel: "info", toLevel: "warn")
-all_statuses = union(tables: [any_to_crit, info_to_warn])
+all_statuses = union(tables: [crit, info_to_warn])
 	|> sort(columns: ["_time"])
 	|> filter(fn: (r) =>
 		(r._time > experimental.subDuration(from: now(), d: 1h)))

--- a/notification/rule/slack_test.go
+++ b/notification/rule/slack_test.go
@@ -30,7 +30,6 @@ import "influxdata/influxdb/monitor"
 import "slack"
 import "influxdata/influxdb/secrets"
 import "experimental"
-import "influxdata/influxdb/v1"
 
 option task = {name: "foo", every: 1h}
 
@@ -44,7 +43,6 @@ notification = {
 }
 statuses = monitor.from(start: -2h, fn: (r) =>
 	(r.foo == "bar" and r.baz == "bang"))
-	|> v1.fieldsAsCols()
 any_to_crit = statuses
 	|> monitor.stateChanges(fromLevel: "any", toLevel: "crit")
 info_to_warn = statuses


### PR DESCRIPTION
Previously, I believed that we needed to pivot the table we statuses we fetched, but after testing it out in acceptance it became clear that that was not the case.