### PR TITLE
fix(task): clean up offset when removed in script

### DIFF
--- a/kv/task.go
+++ b/kv/task.go
@@ -713,7 +713,9 @@ func (s *Service) updateTask(ctx context.Context, tx Tx, id influxdb.ID, upd inf
 		task.Name = options.Name
 		task.Every = options.Every.String()
 		task.Cron = options.Cron
-		if options.Offset != nil {
+		if options.Offset == nil {
+			task.Offset = ""
+		} else {
 			task.Offset = options.Offset.String()
 		}
 	}

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -488,6 +488,22 @@ from(bucket: "b")
 			diff := cmp.Diff(savedTask.Flux, expectedFlux)
 			t.Fatalf("flux unexpected updated: %s", diff)
 		}
+
+		withoutOffset := `option task = {
+	name: "task-Options-Update",
+	every: 10s,
+	concurrency: 100,
+}
+
+from(bucket: "b")
+	|> to(bucket: "two", orgID: "000000000000000")`
+		fNoOffset, err := sys.TaskService.UpdateTask(authorizedCtx, task.ID, influxdb.TaskUpdate{Flux: &withoutOffset})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fNoOffset.Offset != "" {
+			t.Fatal("removing offset failed")
+		}
 	})
 
 }


### PR DESCRIPTION
When the flux script removes a offset it should be removed from the task
