### PR TITLE
fix(ui): prevent crash when opening line visualization options

### DIFF
--- a/ui/src/shared/components/ColorSchemeDropdown.tsx
+++ b/ui/src/shared/components/ColorSchemeDropdown.tsx
@@ -6,10 +6,7 @@ import {Dropdown, DropdownMenuTheme} from '@influxdata/clockface'
 import ColorSchemeDropdownItem from 'src/shared/components/ColorSchemeDropdownItem'
 
 // Constants
-import {
-  LINE_COLOR_SCALES,
-  DEFAULT_LINE_COLORS,
-} from 'src/shared/constants/graphColorPalettes'
+import {LINE_COLOR_SCALES} from 'src/shared/constants/graphColorPalettes'
 
 // Types
 import {Color} from 'src/types/colors'
@@ -19,7 +16,13 @@ interface Props {
   onChange: (colors: Color[]) => void
 }
 
-const findSelectedScaleID = (colors: Color[]) => {
+interface Scale {
+  name: string
+  id: string
+  colors: Array<{hex: string}>
+}
+
+const findSelectedScale = (colors: Color[]): Scale => {
   const key = (colors: Color[]) => colors.map(color => color.hex).join(', ')
   const needle = key(colors)
   const selectedScale = LINE_COLOR_SCALES.find(
@@ -27,20 +30,22 @@ const findSelectedScaleID = (colors: Color[]) => {
   )
 
   if (selectedScale) {
-    return selectedScale.id
+    return selectedScale
   } else {
-    return DEFAULT_LINE_COLORS[0].id
+    return LINE_COLOR_SCALES[0]
   }
 }
 
 const ColorSchemeDropdown: SFC<Props> = ({value, onChange}) => {
+  const selectedScale = findSelectedScale(value)
+
   return (
     <Dropdown
       button={(active, onClick) => (
         <Dropdown.Button active={active} onClick={onClick}>
           <ColorSchemeDropdownItem
-            name={value[0].name}
-            colors={value.map(c => c.hex)}
+            name={selectedScale.name}
+            colors={selectedScale.colors.map(c => c.hex)}
           />
         </Dropdown.Button>
       )}
@@ -51,7 +56,7 @@ const ColorSchemeDropdown: SFC<Props> = ({value, onChange}) => {
               key={id}
               id={id}
               value={colors}
-              selected={findSelectedScaleID(value) === id}
+              selected={selectedScale.id === id}
               onClick={onChange}
             >
               <ColorSchemeDropdownItem


### PR DESCRIPTION
For whatever reason, we now have xy views stored with an empty array in the `colors` field. Attempting to open the visualization options for such a view results in a crash.

This commit updates the `ColorSchemeDropdown` to access the `colors` field more defensively.

Closes #14950
