### PR TITLE
fix(ui): fix max call stack exceeded error when parsing CSV

### DIFF
--- a/ui/src/timeMachine/utils/rawFluxDataTable.ts
+++ b/ui/src/timeMachine/utils/rawFluxDataTable.ts
@@ -19,7 +19,13 @@ export const parseFiles = (responses: string[]): ParseFilesResult => {
       data.push([])
     }
 
-    data.push(...parsedChunks[i])
+    for (let j = 0; j < parsedChunks[i].length; j++) {
+      // Danger zone! Since the contents of each chunk are potentially quite
+      // large, the contents need to be concated using a loop rather than with
+      // `concat`, a splat or similar. Otherwise we see a "Maximum call size
+      // exceeded" error for large CSVs
+      data.push(parsedChunks[i][j])
+    }
 
     // Add an empty line at the end
     data.push([])


### PR DESCRIPTION
When parsing a Flux CSV file with hundreds of thousands of lines for the "Raw Data View", we would see a

    Maximum call stack size exceeded

error. This was because every line in the CSV was being passed as an argument in a single `Array.prototype.push` call, and there are [limits][0] to how many arguments can be passed to a function.

This commit avoids passing the arguments all at once.


[0]: https://stackoverflow.com/questions/22747068/is-there-a-max-number-of-arguments-javascript-functions-can-accept

Closes #14566