### PR TITLE
fix(ui): change patchCheck to putCheck for updating check in UI

### DIFF
--- a/ui/src/alerting/actions/checks.ts
+++ b/ui/src/alerting/actions/checks.ts
@@ -156,7 +156,7 @@ export const saveCheckFromTimeMachine = () => async (
 export const updateCheck = (check: Partial<Check>) => async (
   dispatch: Dispatch<Action | NotificationAction>
 ) => {
-  const resp = await api.patchCheck({checkID: check.id, data: check as Check})
+  const resp = await api.putCheck({checkID: check.id, data: check as Check})
 
   if (resp.status === 200) {
     dispatch(setCheck(resp.data))


### PR DESCRIPTION
The easiest path forward for fixing
https://github.com/influxdata/influxdb/issues/14966 is to have the UI
use put instead of patch for updating checks. Long term, we will want to
be able to use patch, but as of now patch is not functional.