### PR TITLE
fix(notification/endpoint): remove slack token requirement

### DIFF
--- a/notification/endpoint/endpoint_test.go
+++ b/notification/endpoint/endpoint_test.go
@@ -81,10 +81,7 @@ func TestValidEndpoint(t *testing.T) {
 				Base: goodBase,
 				URL:  "localhost",
 			},
-			err: &influxdb.Error{
-				Code: influxdb.EInvalid,
-				Msg:  "slack endpoint token is invalid",
-			},
+			err: nil,
 		},
 		{
 			name: "invalid slack token",

--- a/notification/endpoint/slack.go
+++ b/notification/endpoint/slack.go
@@ -33,9 +33,11 @@ func (s *Slack) BackfillSecretKeys() {
 
 // SecretFields return available secret fields.
 func (s Slack) SecretFields() []influxdb.SecretField {
-	return []influxdb.SecretField{
-		s.Token,
+	arr := []influxdb.SecretField{}
+	if s.Token.Key != "" {
+		arr = append(arr, s.Token)
 	}
+	return arr
 }
 
 // Valid returns error if some configuration is invalid
@@ -56,7 +58,7 @@ func (s Slack) Valid() error {
 		}
 	}
 	// TODO(desa): this requirement seems odd
-	if s.Token.Key != s.ID.String()+slackTokenSuffix {
+	if s.Token.Key != "" && s.Token.Key != s.ID.String()+slackTokenSuffix {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,
 			Msg:  "slack endpoint token is invalid",


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb/issues/14952

This is a partial fix of slack token is not required, we still need to update the generated flux

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
