### PR TITLE
fix(storage): guard against compaction burst throughput limit

### DIFF
--- a/pkg/limiter/writer.go
+++ b/pkg/limiter/writer.go
@@ -17,6 +17,7 @@ type Writer struct {
 
 type Rate interface {
 	WaitN(ctx context.Context, n int) error
+	Burst() int
 }
 
 func NewRate(bytesPerSec, burstLimit int) Rate {
@@ -53,15 +54,25 @@ func (s *Writer) Write(b []byte) (int, error) {
 		return s.w.Write(b)
 	}
 
-	n, err := s.w.Write(b)
-	if err != nil {
-		return n, err
+	var n int
+	for n < len(b) {
+		wantToWriteN := len(b[n:])
+		if wantToWriteN > s.limiter.Burst() {
+			wantToWriteN = s.limiter.Burst()
+		}
+
+		wroteN, err := s.w.Write(b[n : n+wantToWriteN])
+		if err != nil {
+			return n, err
+		}
+		n += wroteN
+
+		if err := s.limiter.WaitN(s.ctx, wroteN); err != nil {
+			return n, err
+		}
 	}
 
-	if err := s.limiter.WaitN(s.ctx, n); err != nil {
-		return n, err
-	}
-	return n, err
+	return n, nil
 }
 
 func (s *Writer) Sync() error {


### PR DESCRIPTION
Closes #9886

`rate.Limiter.WaitN(ctx, n)`
> returns an error if n exceeds the Limiter's burst size

InfluxDB uses WaitN() to rate limit writes in an io.Writer wrapper, passing the length of the byte slice for n. So, when TSM compaction writes a file larger than compact-throughput-burst, the write fails, rather than being throttled. This causes the entire compaction to unwind, retry, etc.

This change splits calls to the wrapped `Write()` into chunks no larger than the rate limiter's burst threshold.