### PR TITLE
feat(notification/rule): add auth and content-type headers for…

### DIFF
--- a/notification/flux/ast.go
+++ b/notification/flux/ast.go
@@ -199,6 +199,14 @@ func Property(key string, e ast.Expression) *ast.Property {
 	}
 }
 
+// Dictionary returns an *ast.Property of string key to value expression.
+func Dictionary(key string, v ast.Expression) *ast.Property {
+	return &ast.Property{
+		Key:   String(key),
+		Value: v,
+	}
+}
+
 // Object returns an *ast.ObjectExpression with properties ps.
 func Object(ps ...*ast.Property) *ast.ObjectExpression {
 	return &ast.ObjectExpression{

--- a/notification/rule/http_test.go
+++ b/notification/rule/http_test.go
@@ -3,6 +3,7 @@ package rule_test
 import (
 	"testing"
 
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/notification"
 	"github.com/influxdata/influxdb/notification/endpoint"
 	"github.com/influxdata/influxdb/notification/rule"
@@ -18,6 +19,7 @@ import "experimental"
 
 option task = {name: "foo", every: 1h, offset: 1s}
 
+headers = {"Content-Type": "application/json"}
 endpoint = http.endpoint(url: "http://localhost:7777")
 notification = {
 	_notification_rule_id: "0000000000000001",
@@ -35,7 +37,7 @@ all_statuses = crit
 
 all_statuses
 	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) =>
-		({data: json.encode(v: r)})))`
+		({headers: headers, data: json.encode(v: r)})))`
 
 	s := &rule.HTTP{
 		Base: rule.Base{
@@ -59,6 +61,145 @@ all_statuses
 			Name: "foo",
 		},
 		URL: "http://localhost:7777",
+	}
+
+	f, err := s.GenerateFlux(e)
+	if err != nil {
+		panic(err)
+	}
+
+	if f != want {
+		t.Errorf("scripts did not match. want:\n%v\n\ngot:\n%v", want, f)
+	}
+}
+
+func TestHTTP_GenerateFlux_basicAuth(t *testing.T) {
+	want := `package main
+// foo
+import "influxdata/influxdb/monitor"
+import "http"
+import "json"
+import "experimental"
+
+option task = {name: "foo", every: 1h, offset: 1s}
+
+headers = {"Content-Type": "application/json", "Authorization": http.basicAuth(u: secrets.get(key: "000000000000000e-username"), p: secrets.get(key: "000000000000000e-password"))}
+endpoint = http.endpoint(url: "http://localhost:7777")
+notification = {
+	_notification_rule_id: "0000000000000001",
+	_notification_rule_name: "foo",
+	_notification_endpoint_id: "0000000000000002",
+	_notification_endpoint_name: "foo",
+}
+statuses = monitor.from(start: -2h)
+crit = statuses
+	|> filter(fn: (r) =>
+		(r._level == "crit"))
+all_statuses = crit
+	|> filter(fn: (r) =>
+		(r._time > experimental.subDuration(from: now(), d: 1h)))
+
+all_statuses
+	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) =>
+		({headers: headers, data: json.encode(v: r)})))`
+
+	s := &rule.HTTP{
+		Base: rule.Base{
+			ID:         1,
+			Name:       "foo",
+			Every:      mustDuration("1h"),
+			Offset:     mustDuration("1s"),
+			EndpointID: 2,
+			TagRules:   []notification.TagRule{},
+			StatusRules: []notification.StatusRule{
+				{
+					CurrentLevel: notification.Critical,
+				},
+			},
+		},
+	}
+
+	e := &endpoint.HTTP{
+		Base: endpoint.Base{
+			ID:   2,
+			Name: "foo",
+		},
+		URL:        "http://localhost:7777",
+		AuthMethod: "basic",
+		Username: influxdb.SecretField{
+			Key: "000000000000000e-username",
+		},
+		Password: influxdb.SecretField{
+			Key: "000000000000000e-password",
+		},
+	}
+
+	f, err := s.GenerateFlux(e)
+	if err != nil {
+		panic(err)
+	}
+
+	if f != want {
+		t.Errorf("scripts did not match. want:\n%v\n\ngot:\n%v", want, f)
+	}
+}
+
+func TestHTTP_GenerateFlux_bearer(t *testing.T) {
+	want := `package main
+// foo
+import "influxdata/influxdb/monitor"
+import "http"
+import "json"
+import "experimental"
+
+option task = {name: "foo", every: 1h, offset: 1s}
+
+headers = {"Content-Type": "application/json", "Authorization": "Bearer " + secrets.get(key: "000000000000000e-token")}
+endpoint = http.endpoint(url: "http://localhost:7777")
+notification = {
+	_notification_rule_id: "0000000000000001",
+	_notification_rule_name: "foo",
+	_notification_endpoint_id: "0000000000000002",
+	_notification_endpoint_name: "foo",
+}
+statuses = monitor.from(start: -2h)
+crit = statuses
+	|> filter(fn: (r) =>
+		(r._level == "crit"))
+all_statuses = crit
+	|> filter(fn: (r) =>
+		(r._time > experimental.subDuration(from: now(), d: 1h)))
+
+all_statuses
+	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) =>
+		({headers: headers, data: json.encode(v: r)})))`
+
+	s := &rule.HTTP{
+		Base: rule.Base{
+			ID:         1,
+			Name:       "foo",
+			Every:      mustDuration("1h"),
+			Offset:     mustDuration("1s"),
+			EndpointID: 2,
+			TagRules:   []notification.TagRule{},
+			StatusRules: []notification.StatusRule{
+				{
+					CurrentLevel: notification.Critical,
+				},
+			},
+		},
+	}
+
+	e := &endpoint.HTTP{
+		Base: endpoint.Base{
+			ID:   2,
+			Name: "foo",
+		},
+		URL:        "http://localhost:7777",
+		AuthMethod: "bearer",
+		Token: influxdb.SecretField{
+			Key: "000000000000000e-token",
+		},
 	}
 
 	f, err := s.GenerateFlux(e)


### PR DESCRIPTION
Contributes to #14987 

The basic auth headers use a function that will soon be in flux that
renders usernames and passwords into `Basic <b64 u and p>`

This work assumes that AuthMethod has been set as well as the
appropriate secrets

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
