### PR TITLE
feat(notification/rule): add JSON body for the HTTP POST

### DIFF
--- a/notification/flux/ast.go
+++ b/notification/flux/ast.go
@@ -126,6 +126,17 @@ func Function(params []*ast.Property, b ast.Expression) *ast.FunctionExpression 
 	}
 }
 
+// FuncBlock takes a series of statements and produces a function.
+func FuncBlock(params []*ast.Property, stms ...ast.Statement) *ast.FunctionExpression {
+	b := &ast.Block{
+		Body: stms,
+	}
+	return &ast.FunctionExpression{
+		Params: params,
+		Body:   b,
+	}
+}
+
 // String returns an *ast.StringLiteral of s.
 func String(s string) *ast.StringLiteral {
 	return &ast.StringLiteral{
@@ -161,6 +172,13 @@ func Identifier(i string) *ast.Identifier {
 func Float(f float64) *ast.FloatLiteral {
 	return &ast.FloatLiteral{
 		Value: f,
+	}
+}
+
+// Integer returns an *ast.IntegerLiteral of i.
+func Integer(i int64) *ast.IntegerLiteral {
+	return &ast.IntegerLiteral{
+		Value: i,
 	}
 }
 

--- a/notification/rule/http.go
+++ b/notification/rule/http.go
@@ -118,7 +118,12 @@ func (s *HTTP) generateFluxASTNotifyPipe() ast.Statement {
 		headers,
 		flux.Property("data", endpointBody),
 	}
-	endpointFn := flux.Function(flux.FunctionParams("r"), flux.Object(endpointProps...))
+	endpointFn := flux.FuncBlock(flux.FunctionParams("r"),
+		s.generateBody(),
+		&ast.ReturnStatement{
+			Argument: flux.Object(endpointProps...),
+		},
+	)
 
 	props := []*ast.Property{}
 	props = append(props, flux.Property("data", flux.Identifier("notification")))
@@ -128,6 +133,48 @@ func (s *HTTP) generateFluxASTNotifyPipe() ast.Statement {
 	call := flux.Call(flux.Member("monitor", "notify"), flux.Object(props...))
 
 	return flux.ExpressionStatement(flux.Pipe(flux.Identifier("all_statuses"), call))
+}
+
+func (s *HTTP) generateBody() ast.Statement {
+	props := []*ast.Property{
+		flux.Dictionary(
+			"version", flux.Integer(1),
+		),
+		flux.Dictionary(
+			"rule_name", flux.Member("notification", "_notification_rule_name"),
+		),
+		flux.Dictionary(
+			"rule_id", flux.Member("notification", "_notification_rule_id"),
+		),
+		flux.Dictionary(
+			"endpoint_name", flux.Member("notification", "_notification_endpoint_name"),
+		),
+		flux.Dictionary(
+			"endpoint_id", flux.Member("notification", "_notification_endpoint_id"),
+		),
+		flux.Dictionary(
+			"check_name", flux.Member("r", "_check_name"),
+		),
+		flux.Dictionary(
+			"check_id", flux.Member("r", "_check_id"),
+		),
+		flux.Dictionary(
+			"check_type", flux.Member("r", "_type"),
+		),
+		flux.Dictionary(
+			"source_measurement", flux.Member("r", "_source_measurement"),
+		),
+		flux.Dictionary(
+			"source_timestamp", flux.Member("r", "_source_timestamp"),
+		),
+		flux.Dictionary(
+			"level", flux.Member("r", "_level"),
+		),
+		flux.Dictionary(
+			"message", flux.Member("r", "_message"),
+		),
+	}
+	return flux.DefineVariable("body", flux.Object(props...))
 }
 
 type httpAlias HTTP

--- a/notification/rule/http_test.go
+++ b/notification/rule/http_test.go
@@ -36,8 +36,24 @@ all_statuses = crit
 		(r._time > experimental.subDuration(from: now(), d: 1h)))
 
 all_statuses
-	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) =>
-		({headers: headers, data: json.encode(v: r)})))`
+	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) => {
+		body = {
+			"version": 1,
+			"rule_name": notification._notification_rule_name,
+			"rule_id": notification._notification_rule_id,
+			"endpoint_name": notification._notification_endpoint_name,
+			"endpoint_id": notification._notification_endpoint_id,
+			"check_name": r._check_name,
+			"check_id": r._check_id,
+			"check_type": r._type,
+			"source_measurement": r._source_measurement,
+			"source_timestamp": r._source_timestamp,
+			"level": r._level,
+			"message": r._message,
+		}
+
+		return {headers: headers, data: json.encode(v: r)}
+	}))`
 
 	s := &rule.HTTP{
 		Base: rule.Base{
@@ -100,9 +116,24 @@ all_statuses = crit
 		(r._time > experimental.subDuration(from: now(), d: 1h)))
 
 all_statuses
-	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) =>
-		({headers: headers, data: json.encode(v: r)})))`
+	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) => {
+		body = {
+			"version": 1,
+			"rule_name": notification._notification_rule_name,
+			"rule_id": notification._notification_rule_id,
+			"endpoint_name": notification._notification_endpoint_name,
+			"endpoint_id": notification._notification_endpoint_id,
+			"check_name": r._check_name,
+			"check_id": r._check_id,
+			"check_type": r._type,
+			"source_measurement": r._source_measurement,
+			"source_timestamp": r._source_timestamp,
+			"level": r._level,
+			"message": r._message,
+		}
 
+		return {headers: headers, data: json.encode(v: r)}
+	}))`
 	s := &rule.HTTP{
 		Base: rule.Base{
 			ID:         1,
@@ -171,8 +202,24 @@ all_statuses = crit
 		(r._time > experimental.subDuration(from: now(), d: 1h)))
 
 all_statuses
-	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) =>
-		({headers: headers, data: json.encode(v: r)})))`
+	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) => {
+		body = {
+			"version": 1,
+			"rule_name": notification._notification_rule_name,
+			"rule_id": notification._notification_rule_id,
+			"endpoint_name": notification._notification_endpoint_name,
+			"endpoint_id": notification._notification_endpoint_id,
+			"check_name": r._check_name,
+			"check_id": r._check_id,
+			"check_type": r._type,
+			"source_measurement": r._source_measurement,
+			"source_timestamp": r._source_timestamp,
+			"level": r._level,
+			"message": r._message,
+		}
+
+		return {headers: headers, data: json.encode(v: r)}
+	}))`
 
 	s := &rule.HTTP{
 		Base: rule.Base{


### PR DESCRIPTION
Closes: #14987

The body of the JSON webhook would be:
{
        "version": 1,
        "rule_name": notification._notification_rule_name,
        "rule_id": notification._notification_rule_id,
        "endpoint_name": notification._notification_endpoint_name,
        "endpoint_id": notification._notification_endpoint_id,
        "check_name": r._check_name,
        "check_id": r._check_id,
        "check_type": r._type,
        "source_measurement": r._source_measurement,
        "source_timestamp": r._source_timestamp,
        "level": r._level,
        "message": r._message,
}

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
