### PR TITLE
fix(task): Update task in scheduler to show updated logs.

### DIFF
--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -359,6 +359,12 @@ func (s *TickScheduler) UpdateTask(authCtx context.Context, task *platform.Task)
 	ts.nextDue = next
 	ts.authCtx = authCtx
 	ts.nextDueMu.Unlock()
+
+	// update the current runners cached task for logs
+	for _, runner := range ts.runners {
+		runner.task = task
+	}
+
 	// check the concurrency
 	// todo(lh): In the near future we may not be using the scheduler to manage concurrency.
 	maxC := len(ts.runners)


### PR DESCRIPTION
The current behavior is that the update is pushed into the scheduler,
and the scheduler cherry pick's what it needs. This leaves the task itself out
meaning any logging the scheduler did was not going to have the new task information in it.