### PR TITLE
fix(notification/check): pivot table before sending to deadman call

### DIFF
--- a/notification/check/deadman.go
+++ b/notification/check/deadman.go
@@ -62,7 +62,7 @@ func (c Deadman) GenerateFluxAST() (*ast.Package, error) {
 	f := p.Files[0]
 	assignPipelineToData(f)
 
-	f.Imports = append(f.Imports, flux.Imports("influxdata/influxdb/monitor", "experimental")...)
+	f.Imports = append(f.Imports, flux.Imports("influxdata/influxdb/monitor", "experimental", "influxdata/influxdb/v1")...)
 	f.Body = append(f.Body, c.generateFluxASTBody()...)
 
 	return p, nil
@@ -92,6 +92,7 @@ func (c Deadman) generateFluxASTChecksFunction() ast.Statement {
 	sub := flux.Call(flux.Member("experimental", "subDuration"), flux.Object(flux.Property("from", now), flux.Property("d", dur)))
 	return flux.ExpressionStatement(flux.Pipe(
 		flux.Identifier("data"),
+		flux.Call(flux.Member("v1", "fieldsAsCols"), flux.Object()),
 		flux.Call(flux.Member("monitor", "deadman"), flux.Object(flux.Property("t", sub))),
 		c.generateFluxASTChecksCall(),
 	))

--- a/notification/check/deadman_test.go
+++ b/notification/check/deadman_test.go
@@ -58,6 +58,7 @@ func TestDeadman_GenerateFlux(t *testing.T) {
 				script: `package main
 import "influxdata/influxdb/monitor"
 import "experimental"
+import "influxdata/influxdb/v1"
 
 data = from(bucket: "foo")
 	|> range(start: -10m)
@@ -76,6 +77,7 @@ messageFn = (r) =>
 	("whoa! {r.dead}")
 
 data
+	|> v1.fieldsAsCols()
 	|> monitor.deadman(t: experimental.subDuration(from: now(), d: 60s))
 	|> monitor.check(data: check, messageFn: messageFn, info: info)`,
 			},
@@ -117,6 +119,7 @@ data
 				script: `package main
 import "influxdata/influxdb/monitor"
 import "experimental"
+import "influxdata/influxdb/v1"
 
 data = from(bucket: "foo")
 	|> range(start: -10m)
@@ -135,6 +138,7 @@ messageFn = (r) =>
 	("whoa! {r.dead}")
 
 data
+	|> v1.fieldsAsCols()
 	|> monitor.deadman(t: experimental.subDuration(from: now(), d: 60s))
 	|> monitor.check(data: check, messageFn: messageFn, info: info)`,
 			},


### PR DESCRIPTION
Discovered that the deadman table needs to be pivoted before the data
can be passed to deadman.