### PR TITLE
feat(notification/rule): add _version: 1 to HTTP body

### DIFF
--- a/notification/flux/ast.go
+++ b/notification/flux/ast.go
@@ -232,6 +232,15 @@ func Object(ps ...*ast.Property) *ast.ObjectExpression {
 	}
 }
 
+// ObjectWith adds many properties to an existing named identifier.
+func ObjectWith(name string, ps ...*ast.Property) *ast.ObjectExpression {
+	obj := Object(ps...)
+	obj.With = &ast.Identifier{
+		Name: name,
+	}
+	return obj
+}
+
 // Array returns *ast.ArrayExpression with elements es.
 func Array(es ...ast.Expression) *ast.ArrayExpression {
 	return &ast.ArrayExpression{

--- a/notification/rule/http_test.go
+++ b/notification/rule/http_test.go
@@ -37,22 +37,9 @@ all_statuses = crit
 
 all_statuses
 	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) => {
-		body = {
-			"version": 1,
-			"rule_name": notification._notification_rule_name,
-			"rule_id": notification._notification_rule_id,
-			"endpoint_name": notification._notification_endpoint_name,
-			"endpoint_id": notification._notification_endpoint_id,
-			"check_name": r._check_name,
-			"check_id": r._check_id,
-			"check_type": r._type,
-			"source_measurement": r._source_measurement,
-			"source_timestamp": r._source_timestamp,
-			"level": r._level,
-			"message": r._message,
-		}
+		body = {r with _version: 1}
 
-		return {headers: headers, data: json.encode(v: r)}
+		return {headers: headers, data: json.encode(v: body)}
 	}))`
 
 	s := &rule.HTTP{
@@ -96,6 +83,7 @@ import "influxdata/influxdb/monitor"
 import "http"
 import "json"
 import "experimental"
+import "influxdata/influxdb/secrets"
 
 option task = {name: "foo", every: 1h, offset: 1s}
 
@@ -117,22 +105,9 @@ all_statuses = crit
 
 all_statuses
 	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) => {
-		body = {
-			"version": 1,
-			"rule_name": notification._notification_rule_name,
-			"rule_id": notification._notification_rule_id,
-			"endpoint_name": notification._notification_endpoint_name,
-			"endpoint_id": notification._notification_endpoint_id,
-			"check_name": r._check_name,
-			"check_id": r._check_id,
-			"check_type": r._type,
-			"source_measurement": r._source_measurement,
-			"source_timestamp": r._source_timestamp,
-			"level": r._level,
-			"message": r._message,
-		}
+		body = {r with _version: 1}
 
-		return {headers: headers, data: json.encode(v: r)}
+		return {headers: headers, data: json.encode(v: body)}
 	}))`
 	s := &rule.HTTP{
 		Base: rule.Base{
@@ -182,6 +157,7 @@ import "influxdata/influxdb/monitor"
 import "http"
 import "json"
 import "experimental"
+import "influxdata/influxdb/secrets"
 
 option task = {name: "foo", every: 1h, offset: 1s}
 
@@ -203,22 +179,9 @@ all_statuses = crit
 
 all_statuses
 	|> monitor.notify(data: notification, endpoint: endpoint(mapFn: (r) => {
-		body = {
-			"version": 1,
-			"rule_name": notification._notification_rule_name,
-			"rule_id": notification._notification_rule_id,
-			"endpoint_name": notification._notification_endpoint_name,
-			"endpoint_id": notification._notification_endpoint_id,
-			"check_name": r._check_name,
-			"check_id": r._check_id,
-			"check_type": r._type,
-			"source_measurement": r._source_measurement,
-			"source_timestamp": r._source_timestamp,
-			"level": r._level,
-			"message": r._message,
-		}
+		body = {r with _version: 1}
 
-		return {headers: headers, data: json.encode(v: r)}
+		return {headers: headers, data: json.encode(v: body)}
 	}))`
 
 	s := &rule.HTTP{


### PR DESCRIPTION
This adds the _version: 1 correctly to the body of the HTTP POST.

Additionally, this fixes the imports when using secrets.

The POSTed JSON body now is:

```json
{
  "_check_id": "046cac59e2aa3000",
  "_check_name": "High CPU User Usage",
  "_level": "crit",
  "_measurement": "notifications",
  "_message": "High CPU User Usage: rsavage.prod is crit",
  "_notification_endpoint_id": "046cad0c83aec000",
  "_notification_endpoint_name": "HTTP Endpoint",
  "_notification_rule_id": "046dff53d4183000",
  "_notification_rule_name": "HTTP Notification",
  "_source_measurement": "cpu",
  "_source_timestamp": 1567797375000000000,
  "_start": "2019-09-06T19:15:59Z",
  "_status_timestamp": 1567797376416632300,
  "_stop": "2019-09-06T19:16:20.362006739Z",
  "_time": "2019-09-06T19:16:20.609629338Z",
  "_type": "threshold",
  "_version": 1,
  "cpu": "cpu-total",
  "host": "rsavage.prod",
  "usage_user": 91.12278069517379
}
```

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
