### PR TITLE
fix(notification/rule): convert time, trigger, severity

### DIFF
--- a/notification/flux/ast.go
+++ b/notification/flux/ast.go
@@ -113,6 +113,16 @@ func Call(fn ast.Expression, args *ast.ObjectExpression) *ast.CallExpression {
 	}
 }
 
+// DirectCall returns a *ast.CallExpression that is a function call of fn with args.
+func DirectCall(fn ast.Expression, args ast.Expression) *ast.CallExpression {
+	return &ast.CallExpression{
+		Callee: fn,
+		Arguments: []ast.Expression{
+			args,
+		},
+	}
+}
+
 // ExpressionStatement returns an *ast.ExpressionStagement of e.
 func ExpressionStatement(e ast.Expression) *ast.ExpressionStatement {
 	return &ast.ExpressionStatement{Expression: e}

--- a/notification/rule/pagerduty_test.go
+++ b/notification/rule/pagerduty_test.go
@@ -33,14 +33,15 @@ statuses
 	|> monitor.notify(data: notification, endpoint: pagerduty_endpoint(mapFn: (r) =>
 		({
 			routingKey: pagerduty_secret,
-			client: r._check_name,
+			client: "influxdata",
 			clientURL: "http://localhost:7777",
 			class: r._check_name,
-			group: r._check_name,
-			severity: r._level,
-			source: r._source_measurement,
+			group: r._source_measurement,
+			severity: pagerduty.severityFromLevel(r._level),
+			eventAction: pagerduty.actionFromLevel(r._level),
+			source: r._notification_rule_name,
 			summary: r._message,
-			timestamp: r._status_timestamp,
+			timestamp: time(v: r._source_timestamp),
 		})))`
 
 	s := &rule.PagerDuty{


### PR DESCRIPTION
Semantically, we've done the following:

// name of the client sending the alert.
client: "influxdata"

// url of the client sending the alert.
client_url: the endpoint URL for now (needs to change to rule) tracked in https://github.com/influxdata/influxdb/issues/15042

// The class/type of the event, for example ping failure or cpu load
class: check's name

// Logical grouping of components of a service, for example app-stack
group: source measurement

Co-authored-by: Alirie Gray <alirie.gray@gmail.com>

Closes #15032

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
