### PR TITLE
fix(notificationRules): remove initial tag filter from draft rule

### DIFF
--- a/ui/src/alerting/components/notifications/utils/index.ts
+++ b/ui/src/alerting/components/notifications/utils/index.ts
@@ -88,12 +88,7 @@ export const initRuleDraft = (orgID: string): NotificationRuleDraft => ({
   name: '',
   status: 'active',
   endpointID: '',
-  tagRules: [
-    {
-      cid: uuid.v4(),
-      value: {key: '', value: '', operator: 'equal'},
-    },
-  ],
+  tagRules: [],
   statusRules: [
     {
       cid: uuid.v4(),


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15000

When submitted, with the default draft rule, the request would fail due
to the backend attempting to contruct flux with empty string values.