### PR TITLE
Update swagger to contain bucket property for type of the bucket

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6737,6 +6737,8 @@ components:
           type: string
         orgID:
           type: string
+        type:
+          type: string
         rp:
           type: string
         createdAt:


### PR DESCRIPTION
Updating swagger to match the bucket properties. Bucket type was added for differentiating between `system` and `user` buckets.