### PR TITLE
fix(notification/rule): pagerduty helper functions need key ar…

### DIFF
--- a/notification/flux/ast.go
+++ b/notification/flux/ast.go
@@ -113,16 +113,6 @@ func Call(fn ast.Expression, args *ast.ObjectExpression) *ast.CallExpression {
 	}
 }
 
-// DirectCall returns a *ast.CallExpression that is a function call of fn with args.
-func DirectCall(fn ast.Expression, args ast.Expression) *ast.CallExpression {
-	return &ast.CallExpression{
-		Callee: fn,
-		Arguments: []ast.Expression{
-			args,
-		},
-	}
-}
-
 // ExpressionStatement returns an *ast.ExpressionStagement of e.
 func ExpressionStatement(e ast.Expression) *ast.ExpressionStatement {
 	return &ast.ExpressionStatement{Expression: e}

--- a/notification/rule/pagerduty.go
+++ b/notification/rule/pagerduty.go
@@ -150,7 +150,7 @@ func (s *PagerDuty) generateFluxASTNotifyPipe(url string) ast.Statement {
 	// required
 	// string
 	// The unique location of the affected system, preferably a hostname or FQDN
-	endpointProps = append(endpointProps, flux.Property("source", flux.Member("r", "_notification_rule_name")))
+	endpointProps = append(endpointProps, flux.Property("source", flux.Member("notification", "_notification_rule_name")))
 
 	// summary:
 	// required
@@ -177,16 +177,20 @@ func (s *PagerDuty) generateFluxASTNotifyPipe(url string) ast.Statement {
 }
 
 func severityFromLevel() *ast.CallExpression {
-	return flux.DirectCall(
+	return flux.Call(
 		flux.Member("pagerduty", "severityFromLevel"),
-		flux.Member("r", "_level"),
+		flux.Object(
+			flux.Property("level", flux.Member("r", "_level")),
+		),
 	)
 }
 
 func actionFromLevel() *ast.CallExpression {
-	return flux.DirectCall(
+	return flux.Call(
 		flux.Member("pagerduty", "actionFromLevel"),
-		flux.Member("r", "_level"),
+		flux.Object(
+			flux.Property("level", flux.Member("r", "_level")),
+		),
 	)
 }
 

--- a/notification/rule/pagerduty_test.go
+++ b/notification/rule/pagerduty_test.go
@@ -37,9 +37,9 @@ statuses
 			clientURL: "http://localhost:7777",
 			class: r._check_name,
 			group: r._source_measurement,
-			severity: pagerduty.severityFromLevel(r._level),
-			eventAction: pagerduty.actionFromLevel(r._level),
-			source: r._notification_rule_name,
+			severity: pagerduty.severityFromLevel(level: r._level),
+			eventAction: pagerduty.actionFromLevel(level: r._level),
+			source: notification._notification_rule_name,
 			summary: r._message,
 			timestamp: time(v: r._source_timestamp),
 		})))`


### PR DESCRIPTION
 The pagerduty helper functions did not have the correct syntax key/arg syntax.

Additionally, I'm not sure we need token, but, only routing key.  I'll need to investigate.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
