### PR TITLE
fix(notification/rule): pagerduty does not need token and url

### DIFF
--- a/notification/rule/pagerduty.go
+++ b/notification/rule/pagerduty.go
@@ -92,10 +92,7 @@ func (s *PagerDuty) generateFluxASTSecrets(e *endpoint.PagerDuty) ast.Statement 
 
 func (s *PagerDuty) generateFluxASTEndpoint(e *endpoint.PagerDuty) ast.Statement {
 	call := flux.Call(flux.Member("pagerduty", "endpoint"),
-		flux.Object(
-			flux.Property("token", flux.Identifier("pagerduty_secret")),
-			flux.Property("url", flux.String(e.URL)),
-		),
+		flux.Object(),
 	)
 
 	return flux.DefineVariable("pagerduty_endpoint", call)

--- a/notification/rule/pagerduty_test.go
+++ b/notification/rule/pagerduty_test.go
@@ -19,7 +19,7 @@ import "influxdata/influxdb/secrets"
 option task = {name: "foo", every: 1h}
 
 pagerduty_secret = secrets.get(key: "pagerduty_token")
-pagerduty_endpoint = pagerduty.endpoint(token: pagerduty_secret, url: "http://localhost:7777")
+pagerduty_endpoint = pagerduty.endpoint()
 notification = {
 	_notification_rule_id: "0000000000000001",
 	_notification_rule_name: "foo",


### PR DESCRIPTION
Previously, the URL would cause pages to be sent to incorrect addresses.
Token is only needed for PagerDuty REST API and not events.

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)


Requires: https://github.com/influxdata/flux/pull/1825