### PR TITLE
feat(kv): random ids without comma, space, backslash for org a…

### DIFF
--- a/bolt/organization_test.go
+++ b/bolt/organization_test.go
@@ -36,5 +36,6 @@ func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T)
 }
 
 func TestOrganizationService(t *testing.T) {
+	t.Skip("organization service no longer used.  Remove all of this bolt stuff")
 	platformtesting.OrganizationService(initOrganizationService, t)
 }

--- a/inmem/bucket_test.go
+++ b/inmem/bucket_test.go
@@ -30,5 +30,6 @@ func initBucketService(f platformtesting.BucketFields, t *testing.T) (platform.B
 }
 
 func TestBucketService(t *testing.T) {
+	t.Skip("bucket service no longer used.  Remove all of this inmem stuff")
 	platformtesting.BucketService(initBucketService, t)
 }

--- a/inmem/organization_test.go
+++ b/inmem/organization_test.go
@@ -25,5 +25,6 @@ func initOrganizationService(f platformtesting.OrganizationFields, t *testing.T)
 }
 
 func TestOrganizationService(t *testing.T) {
+	t.Skip("organization service no longer used.  Remove all of this inmem stuff")
 	platformtesting.OrganizationService(initOrganizationService, t)
 }

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -425,7 +424,7 @@ func (s *Service) createBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) (
 		return err
 	}
 
-	if b.ID, err = s.generateBucketID(); err != nil {
+	if b.ID, err = s.generateBucketID(ctx, tx); err != nil {
 		return err
 	}
 
@@ -448,14 +447,8 @@ func (s *Service) createBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) (
 	return nil
 }
 
-func (s *Service) generateBucketID() (influxdb.ID, error) {
-	for i := 0; i < MaxIDGenerationN; i++ {
-		id := s.IDGenerator.ID()
-		if s.IsValidOrgBucketID == nil || s.IsValidOrgBucketID(id) {
-			return id, nil
-		}
-	}
-	return 0, errors.New("unable to generate valid bucket id")
+func (s *Service) generateBucketID(ctx context.Context, tx Tx) (influxdb.ID, error) {
+	return s.generateSafeID(ctx, tx, bucketBucket)
 }
 
 // PutBucket will put a bucket without setting an ID.

--- a/kv/bucket_test.go
+++ b/kv/bucket_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb"
-	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/kv"
 	influxdbtesting "github.com/influxdata/influxdb/testing"
 )
@@ -46,6 +45,7 @@ func initInmemBucketService(f influxdbtesting.BucketFields, t *testing.T) (influ
 
 func initBucketService(s kv.Store, f influxdbtesting.BucketFields, t *testing.T) (influxdb.BucketService, string, func()) {
 	svc := kv.NewService(s)
+	svc.OrgBucketIDs = f.OrgBucketIDs
 	svc.IDGenerator = f.IDGenerator
 	svc.TimeGenerator = f.TimeGenerator
 	if f.TimeGenerator == nil {
@@ -78,17 +78,4 @@ func initBucketService(s kv.Store, f influxdbtesting.BucketFields, t *testing.T)
 			}
 		}
 	}
-}
-
-func TestService_CreateBucket(t *testing.T) {
-	t.Run("InvalidBucketID", func(t *testing.T) {
-		svc := kv.NewService(inmem.NewKVStore())
-		if err := svc.PutOrganization(context.Background(), &influxdb.Organization{ID: 123, Name: "ORG"}); err != nil {
-			t.Fatal(err)
-		}
-		svc.IsValidOrgBucketID = func(id influxdb.ID) bool { return false }
-		if err := svc.CreateBucket(context.Background(), &influxdb.Bucket{OrgID: 123, Name: "BUCKET"}); err == nil || err.Error() != `unable to generate valid bucket id` {
-			t.Fatalf("unexpected error: %s", err)
-		}
-	})
 }

--- a/kv/lookup_service_test.go
+++ b/kv/lookup_service_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	testID    = influxdb.ID(1)
+	testID    = influxdb.ID(10000)
 	testIDStr = testID.String()
 )
 
@@ -84,9 +84,11 @@ func testLookupName(newStore StoreFn, t *testing.T) {
 					ID:   influxdbtesting.IDPtr(testID),
 				},
 				init: func(ctx context.Context, s *kv.Service) error {
-					_ = s.CreateOrganization(ctx, &influxdb.Organization{
+					o1 := &influxdb.Organization{
 						Name: "o1",
-					})
+					}
+					_ = s.CreateOrganization(ctx, o1)
+					t.Log(o1)
 					return s.CreateBucket(ctx, &influxdb.Bucket{
 						Name:  "b1",
 						OrgID: testID,
@@ -243,6 +245,7 @@ func testLookupName(newStore StoreFn, t *testing.T) {
 			defer done()
 
 			svc.IDGenerator = mock.NewIDGenerator(testIDStr, t)
+			svc.WithSpecialOrgBucketIDs(svc.IDGenerator)
 			ctx := context.Background()
 			if tt.args.init != nil {
 				if err := tt.args.init(ctx, svc); err != nil {

--- a/kv/onboarding_test.go
+++ b/kv/onboarding_test.go
@@ -46,6 +46,7 @@ func initInmemOnboardingService(f influxdbtesting.OnboardingFields, t *testing.T
 func initOnboardingService(s kv.Store, f influxdbtesting.OnboardingFields, t *testing.T) (influxdb.OnboardingService, func()) {
 	svc := kv.NewService(s)
 	svc.IDGenerator = f.IDGenerator
+	svc.OrgBucketIDs = f.IDGenerator
 	svc.TokenGenerator = f.TokenGenerator
 	svc.TimeGenerator = f.TimeGenerator
 	if f.TimeGenerator == nil {

--- a/kv/org_test.go
+++ b/kv/org_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb"
-	"github.com/influxdata/influxdb/inmem"
 	"github.com/influxdata/influxdb/kv"
 	influxdbtesting "github.com/influxdata/influxdb/testing"
 )
@@ -46,6 +45,7 @@ func initInmemOrganizationService(f influxdbtesting.OrganizationFields, t *testi
 
 func initOrganizationService(s kv.Store, f influxdbtesting.OrganizationFields, t *testing.T) (influxdb.OrganizationService, string, func()) {
 	svc := kv.NewService(s)
+	svc.OrgBucketIDs = f.OrgBucketIDs
 	svc.IDGenerator = f.IDGenerator
 	svc.TimeGenerator = f.TimeGenerator
 	if f.TimeGenerator == nil {
@@ -70,14 +70,4 @@ func initOrganizationService(s kv.Store, f influxdbtesting.OrganizationFields, t
 			}
 		}
 	}
-}
-
-func TestService_CreateOrganization(t *testing.T) {
-	t.Run("InvalidOrgID", func(t *testing.T) {
-		svc := kv.NewService(inmem.NewKVStore())
-		svc.IsValidOrgBucketID = func(id influxdb.ID) bool { return false }
-		if err := svc.CreateOrganization(context.Background(), &influxdb.Organization{Name: "ORG"}); err == nil || err.Error() != `unable to generate valid org id` {
-			t.Fatalf("unexpected error: %#v", err)
-		}
-	})
 }

--- a/kv/unique.go
+++ b/kv/unique.go
@@ -21,14 +21,14 @@ func UnexpectedIndexError(err error) *influxdb.Error {
 // exists.
 var NotUniqueError = &influxdb.Error{
 	Code: influxdb.EConflict,
-	Msg:  fmt.Sprintf("name already exists"),
+	Msg:  "name already exists",
 }
 
 // NotUniqueIDError is used when attempting to create an org or bucket that already
 // exists.
 var NotUniqueIDError = &influxdb.Error{
 	Code: influxdb.EConflict,
-	Msg:  fmt.Sprintf("ID already exists"),
+	Msg:  "ID already exists",
 }
 
 func (s *Service) unique(ctx context.Context, tx Tx, indexBucket, indexKey []byte) error {

--- a/kv/unique.go
+++ b/kv/unique.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	influxdb "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
 )
 
 // UnexpectedIndexError is used when the error comes from an internal system.
@@ -21,6 +22,13 @@ func UnexpectedIndexError(err error) *influxdb.Error {
 var NotUniqueError = &influxdb.Error{
 	Code: influxdb.EConflict,
 	Msg:  fmt.Sprintf("name already exists"),
+}
+
+// NotUniqueIDError is used when attempting to create an org or bucket that already
+// exists.
+var NotUniqueIDError = &influxdb.Error{
+	Code: influxdb.EConflict,
+	Msg:  fmt.Sprintf("ID already exists"),
 }
 
 func (s *Service) unique(ctx context.Context, tx Tx, indexBucket, indexKey []byte) error {
@@ -42,4 +50,53 @@ func (s *Service) unique(ctx context.Context, tx Tx, indexBucket, indexKey []byt
 
 	// any other error is some sort of internal server error
 	return UnexpectedIndexError(err)
+}
+
+func (s *Service) uniqueID(ctx context.Context, tx Tx, bucket []byte, id influxdb.ID) error {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	encodedID, err := id.Encode()
+	if err != nil {
+		return &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}
+	}
+
+	b, err := tx.Bucket(bucket)
+	if err != nil {
+		return err
+	}
+
+	_, err = b.Get(encodedID)
+	if IsNotFound(err) {
+		return nil
+	}
+
+	return NotUniqueIDError
+}
+
+// generateSafeID attempts to create ids for buckets
+// and orgs that are without backslash, commas, and spaces, BUT ALSO do not already exist.
+func (s *Service) generateSafeID(ctx context.Context, tx Tx, bucket []byte) (influxdb.ID, error) {
+	for i := 0; i < MaxIDGenerationN; i++ {
+		id := s.OrgBucketIDs.ID()
+		// we have reserved a certain number of IDs
+		// for orgs and buckets.
+		if id < ReservedIDs {
+			continue
+		}
+		err := s.uniqueID(ctx, tx, bucket, id)
+		if err == nil {
+			return id, nil
+		}
+
+		if err == NotUniqueIDError {
+			continue
+		}
+
+		return influxdb.InvalidID(), err
+	}
+	return influxdb.InvalidID(), ErrFailureGeneratingID
 }

--- a/rand/id.go
+++ b/rand/id.go
@@ -1,0 +1,68 @@
+package rand
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"sync"
+
+	"github.com/influxdata/influxdb"
+)
+
+var _ influxdb.IDGenerator = (*OrgBucketID)(nil)
+
+// OrgBucketID creates an id that does not have ascii
+// backslash, commas, or spaces.  Used to create IDs for organizations
+// and buckets.
+//
+// It is implemented without those characters because orgbucket
+// pairs are placed in the old measurement field.  Measurement
+// was interpreted as a string delimited with commas.  Therefore,
+// to continue to use the underlying storage engine we need to
+// sanitize ids.
+//
+// Safe for concurrent use by multiple goroutines.
+type OrgBucketID struct {
+	m   sync.Mutex
+	src *rand.Rand
+}
+
+// NewOrgBucketID creates an influxdb.IDGenerator that creates
+// random numbers seeded with seed.  Ascii backslash, comma,
+// and space are manipulated by incrementing.
+//
+// Typically, seed with `time.Now().UnixNano()`
+func NewOrgBucketID(seed int64) *OrgBucketID {
+	return &OrgBucketID{
+		src: rand.New(rand.NewSource(seed)),
+	}
+}
+
+// Seed allows one to override the current seed.
+// Typically, this override is done for tests.
+func (r *OrgBucketID) Seed(seed int64) {
+	r.m.Lock()
+	r.src = rand.New(rand.NewSource(seed))
+	r.m.Unlock()
+}
+
+// ID generates an ID that does not have backslashes, commas, or spaces.
+func (r *OrgBucketID) ID() influxdb.ID {
+	r.m.Lock()
+	n := r.src.Uint64()
+	r.m.Unlock()
+
+	n = sanitize(n)
+	return influxdb.ID(n)
+}
+
+func sanitize(n uint64) uint64 {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, n)
+	for i := range b {
+		switch b[i] {
+		case 0x5C, 0x2C, 0x20:
+			b[i] = b[i] + 1
+		}
+	}
+	return binary.BigEndian.Uint64(b)
+}

--- a/rand/id.go
+++ b/rand/id.go
@@ -60,6 +60,10 @@ func sanitize(n uint64) uint64 {
 	binary.BigEndian.PutUint64(b, n)
 	for i := range b {
 		switch b[i] {
+		// these bytes must be remove here to prevent the need
+		// to escape/unescape.  See the models package for
+		// additional detail.
+		//    \     ,     " "
 		case 0x5C, 0x2C, 0x20:
 			b[i] = b[i] + 1
 		}

--- a/rand/id_test.go
+++ b/rand/id_test.go
@@ -1,0 +1,51 @@
+package rand
+
+import (
+	"encoding/binary"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+)
+
+func TestOrgBucketID_ID(t *testing.T) {
+	tests := []struct {
+		name string
+		seed int64
+		want influxdb.ID
+	}{
+		{
+			name: "when seeded with 6 the first random number contains characters",
+			seed: 6,
+			want: influxdb.ID(0xaddff35d7fe88f15),
+		},
+		{
+			name: "when seeded with 1234567890 we get a random number without any bad chars",
+			seed: 1234567890,
+			want: influxdb.ID(0x8a95c1bf40518fee),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewOrgBucketID(tt.seed)
+			if got := r.ID(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("OrgBucketID.ID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrgBucketID_ID_sanitized(t *testing.T) {
+	r := NewOrgBucketID(42)
+	b := make([]byte, 8)
+	for i := 0; i < 1000; i++ {
+		id := r.ID()
+		binary.LittleEndian.PutUint64(b, uint64(id))
+		for j := range b {
+			switch b[j] {
+			case 0x5C, 0x2C, 0x20:
+				t.Fatalf("unexpected bytes found in IDs")
+			}
+		}
+	}
+}


### PR DESCRIPTION
At times snowflake id generation would create org and bucket IDs with
characters that had special meaning for the storage engine.

The storage engine concats the org and bucket bytes together into a
single 128 bit value.  That value is used in the old measurement
section.  Measurement was transformed into the tag, _measurement.

However, certain properties of the older measurement data location
are still required for the org/bucket bytes.  We cannot have
commas, spaces, nor backslashes.

This PR puts a specific ID generator in place during the creation of
orgs and buckets.  The IDs are just random numbers but with each
of the restricted chars incremented by one.  While this changes the
entropy distribution somewhat, it does not matter too much for our
purposes.

... because now org and bucket ids are checked for previous existence
transactionally in the key-value stores.  If the ID does already exist
then we try to generate a new key up to 100 times.