### PR TITLE
fix(ui): show notifications history sent column properly

### DIFF
--- a/ui/src/alerting/components/SentTableField.tsx
+++ b/ui/src/alerting/components/SentTableField.tsx
@@ -10,11 +10,11 @@ interface Props {
 }
 
 const SentTableField: FC<Props> = ({row: {sent}}) => {
-  const modifier = sent ? 'sent' : 'not-sent'
+  const modifier = sent === 'true' ? 'sent' : 'not-sent'
 
   return (
     <div className={`sent-table-field sent-table-field--${modifier}`}>
-      {sent ? (
+      {sent === 'true' ? (
         <Icon glyph={IconFont.Checkmark} />
       ) : (
         <Icon glyph={IconFont.AlertTriangle} />

--- a/ui/src/types/alerting.ts
+++ b/ui/src/types/alerting.ts
@@ -65,7 +65,7 @@ export interface NotificationRow {
   notificationRuleName: string
   notificationEndpointID: string
   notificationEndpointName: string
-  sent: boolean
+  sent: 'true' | 'false' // See https://github.com/influxdata/idpe/issues/4645
 }
 
 export {


### PR DESCRIPTION
The "Sent" column on the notification history page was always showing a green checkbox, even when a particular notification wasn't sent.

Issue seems to be https://github.com/influxdata/idpe/issues/4645, but this is a UI-only workaround.