### PR TITLE
fix(ui): use slack as default endpoint

### DIFF
--- a/ui/cypress/e2e/notificationEndpoints.test.ts
+++ b/ui/cypress/e2e/notificationEndpoints.test.ts
@@ -50,7 +50,7 @@ describe('Notification Endpoints', () => {
       .click()
       .within(() => {
         cy.getByTestID('endpoint--dropdown--button').within(() => {
-          cy.contains('HTTP')
+          cy.contains('Slack')
         })
 
         cy.getByTestID('endpoint--dropdown-item pagerduty').click()

--- a/ui/src/alerting/constants/index.ts
+++ b/ui/src/alerting/constants/index.ts
@@ -146,13 +146,11 @@ export const DEFAULT_ENDPOINT_URLS = {
 
 export const NEW_ENDPOINT_DRAFT: NotificationEndpoint = {
   name: 'Name this Endpoint',
-  method: 'POST',
-  authMethod: 'none',
   description: '',
   status: 'active',
-  type: 'http',
+  type: 'slack',
   token: '',
-  url: DEFAULT_ENDPOINT_URLS['http'],
+  url: DEFAULT_ENDPOINT_URLS['slack'],
 }
 
 export const NEW_ENDPOINT_FIXTURES: NotificationEndpoint[] = [


### PR DESCRIPTION
This is so that in cloud there is not a weird UX for initial users who
see http, but cannot create an http endpoint.