### PR TITLE
fix(ui): deduplicate rows on notifications history page

### DIFF
--- a/ui/src/alerting/utils/history.ts
+++ b/ui/src/alerting/utils/history.ts
@@ -68,6 +68,7 @@ export const loadNotifications = (
 from(bucket: "${MONITORING_BUCKET}")
   |> range(start: ${start}, stop: ${Math.round(until / 1000)})
   |> filter(fn: (r) => r._measurement == "notifications")
+  |> filter(fn: (r) => r._field !~ /^_/)
   |> keep(columns: ["_time",
                     "_check_id",
                     "_check_name",


### PR DESCRIPTION
We want to display a row for each notification, but we were displaying a row for each field for each notification.

By filtering out the system fields (those that start with an underscore), we are in left with only a single user-specific field.