### PR TITLE
fix(http): add return after returning system bucket errror

### DIFF
--- a/http/write_handler.go
+++ b/http/write_handler.go
@@ -184,6 +184,7 @@ func (h *WriteHandler) handleWrite(w http.ResponseWriter, r *http.Request) {
 			Op:   "http/handleWrite",
 			Msg:  fmt.Sprintf("cannot write to internal bucket %s", bucket.Name),
 		}, w)
+		return
 	}
 
 	p, err := platform.NewPermissionAtID(bucket.ID, platform.WriteAction, platform.BucketsResourceType, org.ID)


### PR DESCRIPTION
Prevents write from continuing on after error condition met.