### PR TITLE
feat(task): add run duration to task metrics

### DIFF
--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -327,7 +327,7 @@ func (w *worker) finish(p *Promise, rs backend.RunStatus, err error) {
 	w.te.tcs.UpdateRunState(ctx, p.task.ID, p.run.ID, time.Now(), rs)
 
 	// add to metrics
-	s, _ := p.run.ScheduledForTime()
+	s, _ := p.run.StartedAtTime()
 	rd := time.Since(s)
 	w.te.metrics.FinishRun(p.task.ID, rs, rd)
 

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -861,7 +861,7 @@ func TestScheduler_Metrics(t *testing.T) {
 	if got := *m.Gauge.Value; got != 1 {
 		t.Fatalf("expected 1 run active for task ID %s, got %v", task.ID.String(), got)
 	}
-	m = promtest.MustFindMetric(t, mfs, "task_scheduler_run_queue_delta", nil)
+	m = promtest.MustFindMetric(t, mfs, "task_scheduler_run_queue_delta", map[string]string{"taskID": "all"})
 	if got := m.Summary.GetSampleCount(); got != 1.0 {
 		t.Fatalf("expected 1 delta in summary: got: %v", got)
 	}
@@ -879,7 +879,7 @@ func TestScheduler_Metrics(t *testing.T) {
 	if got := *m.Gauge.Value; got != 2 {
 		t.Fatalf("expected 2 runs active for task ID %s, got %v", task.ID.String(), got)
 	}
-	m = promtest.MustFindMetric(t, mfs, "task_scheduler_run_queue_delta", nil)
+	m = promtest.MustFindMetric(t, mfs, "task_scheduler_run_queue_delta", map[string]string{"taskID": "all"})
 	if got := m.Summary.GetSampleCount(); got != 2.0 {
 		t.Fatalf("expected 2 delta in summary: got: %v", got)
 	}


### PR DESCRIPTION
We need to be able to see how long its taking task's to run as well
be able to see the start delta time per task.
