### PR TITLE
feat(tasks): use env variable for concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.0.0-alpha.18 [unreleased]
 
 ### Features
+1. [15110](https://github.com/influxdata/influxdb/pull/15110): Adds ability to set the default concurrency for tasks with an environment variable called DEFAULT_CONCURRENCY
 
 ### UI Improvements
 

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -469,6 +471,16 @@ func newTaskScheduler(
 		return nil, err
 	}
 	maxC := defaultConcurrency
+
+	// if an environment variable for default concurrency is set, use this value
+	// this will be overwritten if the Flux script for the task has a concurrency set
+	if envConcurrency := os.Getenv("DEFAULT_CONCURRENCY"); envConcurrency != "" {
+		c, err := strconv.Atoi(envConcurrency)
+		if err == nil {
+			maxC = c
+		}
+	}
+
 	if opt.Concurrency != nil {
 		maxC = int(*opt.Concurrency)
 	}


### PR DESCRIPTION
Closes idpe #4648

This PR adds the ability to set the default concurrency for the task scheduler with an environment variable called `DEFAULT_CONCURRENCY`

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
- [x] Tests pass
