### PR TITLE
docs(http): update NotificationEndpoint swagger definition to reflect reality

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5811,7 +5811,7 @@ paths:
               $ref: "#/components/schemas/NotificationEndpoint"
       responses:
         '201':
-          description: Notification rule created
+          description: Notification endpoint created
           content:
             application/json:
               schema:
@@ -9714,7 +9714,7 @@ components:
           $ref: "#/components/schemas/Links"
     NotificationEndpointBase:
       type: object
-      required: [type]
+      required: [type, name]
       properties:
         id:
           type: string
@@ -9742,6 +9742,27 @@ components:
           enum: ["active", "inactive"]
         labels:
           $ref: "#/components/schemas/Labels"
+        links:
+          type: object
+          readOnly: true
+          example:
+            self: "/api/v2/notificationEndpoints/1"
+            labels: "/api/v2/notificationEndpoints/1/labels"
+            members: "/api/v2/notificationEndpoints/1/members"
+            owners: "/api/v2/notificationEndpoints/1/owners"
+          properties:
+            self:
+              description: URL for this endpoint
+              $ref: "#/components/schemas/Link"
+            labels:
+              description: URL to retrieve labels for this endpoint
+              $ref: "#/components/schemas/Link"
+            members:
+              description: URL to retrieve members for this endpoint
+              $ref: "#/components/schemas/Link"
+            owners:
+              description: URL to retrieve owners for this endpoint
+              $ref: "#/components/schemas/Link"
         type:
           $ref: "#/components/schemas/NotificationEndpointType"
     SlackNotificationEndpoint:
@@ -9749,11 +9770,12 @@ components:
       allOf:
         - $ref: "#/components/schemas/NotificationEndpointBase"
         - type: object
-          required: [url, token]
           properties:
             url:
+              description: specifies the URL of the slack endpoint; either URL or Token should be specified
               type: string
             token:
+              description: specifies the api token string; either URL or Token should be specified
               type: string
     PagerDutyNotificationEndpoint:
       type: object

--- a/notification/endpoint/endpoint_test.go
+++ b/notification/endpoint/endpoint_test.go
@@ -55,6 +55,22 @@ func TestValidEndpoint(t *testing.T) {
 			},
 		},
 		{
+			name: "empty name",
+			src: &endpoint.PagerDuty{
+				Base: endpoint.Base{
+					ID:     influxTesting.MustIDBase16(id1),
+					OrgID:  influxTesting.MustIDBase16(id3),
+					Status: influxdb.Active,
+				},
+				ClientURL:  "https://events.pagerduty.com/v2/enqueue",
+				RoutingKey: influxdb.SecretField{Key: id1 + "-routing-key"},
+			},
+			err: &influxdb.Error{
+				Code: influxdb.EInvalid,
+				Msg:  "Notification Endpoint Name can't be empty",
+			},
+		},
+		{
 			name: "empty slack url and token",
 			src: &endpoint.Slack{
 				Base: goodBase,
@@ -186,6 +202,22 @@ func TestJSON(t *testing.T) {
 				},
 				URL:   "https://slack.com/api/chat.postMessage",
 				Token: influxdb.SecretField{Key: "token-key-1"},
+			},
+		},
+		{
+			name: "Slack without token",
+			src: &endpoint.Slack{
+				Base: endpoint.Base{
+					ID:     influxTesting.MustIDBase16(id1),
+					Name:   "name1",
+					OrgID:  influxTesting.MustIDBase16(id3),
+					Status: influxdb.Active,
+					CRUDLog: influxdb.CRUDLog{
+						CreatedAt: timeGen1.Now(),
+						UpdatedAt: timeGen2.Now(),
+					},
+				},
+				URL: "https://hooks.slack.com/services/x/y/z",
 			},
 		},
 		{


### PR DESCRIPTION
1. The `NotificationEndpoint.name` should be required - see sources:
https://github.com/influxdata/influxdb/blob/b26ed76d6ae42eaed66e755c9e3c770fbf80ab90/notification/endpoint/endpoint.go#L63
2. The `NotificationEndpointBase` also contains `links` property - see sources:
https://github.com/influxdata/influxdb/blob/7a677e9532835961febc83734837c31d38b07769/http/notification_endpoint.go#L136
3. The `SlackNotificationEndpoint` properties should be optional  - because than the client is assume that has to to fill both property - see sources:
https://github.com/influxdata/influxdb/blob/79a6b353e3dacd9e6588ea695ab0de54de253a9c/notification/endpoint/slack.go#L44 and also as its is in [slack.flux](https://github.com/influxdata/flux/blob/master/stdlib/slack/slack.flux).

---

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)