### PR TITLE
fix(task): execution metric now shows correct data

### DIFF
--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -726,7 +726,7 @@ func (r *runner) fail(qr QueuedRun, runLogger *zap.Logger, stage string, reason 
 
 func (r *runner) executeAndWait(ctx context.Context, qr QueuedRun, runLogger *zap.Logger) {
 	r.updateRunState(qr, RunStarted, runLogger)
-
+	qr.startedAt = time.Now()
 	defer r.wg.Done()
 	errMsg := "Failed to finish run"
 	defer func() {
@@ -816,7 +816,6 @@ func (r *runner) updateRunState(qr QueuedRun, s RunStatus, runLogger *zap.Logger
 	switch s {
 	case RunStarted:
 		dueAt := time.Unix(qr.DueAt, 0)
-		qr.startedAt = time.Now()
 		r.ts.metrics.StartRun(r.task.ID.String(), time.Since(dueAt))
 		r.taskControlService.AddRunLog(r.ts.authCtx, r.task.ID, qr.RunID, time.Now(), fmt.Sprintf("Started task from script: %q", r.task.Flux))
 	case RunSuccess:

--- a/task/backend/scheduler_metrics.go
+++ b/task/backend/scheduler_metrics.go
@@ -77,7 +77,7 @@ func newSchedulerMetrics() *schedulerMetrics {
 			Namespace:  namespace,
 			Subsystem:  subsystem,
 			Name:       "run_execution_delta",
-			Help:       "The duration in seconds between a run being due to start and complete execution.",
+			Help:       "The duration in seconds between a run starting and complete execution.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}, []string{"taskID"}),
 	}


### PR DESCRIPTION
The first pass failed to save the correct execution metrics,
it will now compare the difference between start and finish.
