### PR TITLE
fix(notification/endpoint): pagerduty clientURL should be optional

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9760,7 +9760,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/NotificationEndpointBase"
         - type: object
-          required: [clientURL, routingKey]
+          required: [routingKey]
           properties:
             clientURL:
               type: string

--- a/notification/endpoint/endpoint_test.go
+++ b/notification/endpoint/endpoint_test.go
@@ -96,16 +96,6 @@ func TestValidEndpoint(t *testing.T) {
 			},
 		},
 		{
-			name: "empty pagerduty url",
-			src: &endpoint.PagerDuty{
-				Base: goodBase,
-			},
-			err: &influxdb.Error{
-				Code: influxdb.EInvalid,
-				Msg:  "pagerduty endpoint ClientURL is empty",
-			},
-		},
-		{
 			name: "invalid routine key",
 			src: &endpoint.PagerDuty{
 				Base:       goodBase,

--- a/notification/endpoint/pagerduty.go
+++ b/notification/endpoint/pagerduty.go
@@ -40,12 +40,6 @@ func (s PagerDuty) Valid() error {
 	if err := s.Base.valid(); err != nil {
 		return err
 	}
-	if s.ClientURL == "" {
-		return &influxdb.Error{
-			Code: influxdb.EInvalid,
-			Msg:  "pagerduty endpoint ClientURL is empty",
-		}
-	}
 	if s.RoutingKey.Key != s.ID.String()+routingKeySuffix {
 		return &influxdb.Error{
 			Code: influxdb.EInvalid,


### PR DESCRIPTION
Partially https://github.com/influxdata/influxdb/issues/15104

the api and swagger changes for the pagerduty clientURL to be optional

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
