### PR TITLE
feat(ui): show auto window period in function selector dropdown

### DIFF
--- a/ui/src/alerting/constants/index.ts
+++ b/ui/src/alerting/constants/index.ts
@@ -9,6 +9,7 @@ import {
 } from 'src/types'
 import {NotificationEndpoint, CheckStatusLevel} from 'src/client'
 import {ComponentColor} from '@influxdata/clockface'
+import {DurationOption} from 'src/shared/components/DurationSelector'
 
 export const DEFAULT_CHECK_NAME = 'Name this Check'
 export const DEFAULT_NOTIFICATION_RULE_NAME = 'Name this Notification Rule'
@@ -21,9 +22,9 @@ export const DEFAULT_DEADMAN_LEVEL: CheckStatusLevel = 'CRIT'
 export const DEFAULT_STATUS_MESSAGE =
   'Check: ${ r._check_name } is: ${ r._level }'
 
-export const CHECK_EVERY_OPTIONS = DURATIONS
+export const CHECK_EVERY_OPTIONS: DurationOption[] = DURATIONS
 
-export const CHECK_OFFSET_OPTIONS = [
+export const CHECK_OFFSET_OPTIONS: DurationOption[] = [
   {duration: '0s', displayText: 'None'},
   {duration: '5s', displayText: '5 seconds'},
   {duration: '15s', displayText: '15 seconds'},

--- a/ui/src/buckets/components/Retention.tsx
+++ b/ui/src/buckets/components/Retention.tsx
@@ -4,7 +4,9 @@ import {connect} from 'react-redux'
 
 // Components
 import {Radio, ButtonShape} from '@influxdata/clockface'
-import DurationSelector from 'src/shared/components/DurationSelector'
+import DurationSelector, {
+  DurationOption,
+} from 'src/shared/components/DurationSelector'
 
 // Utils
 import {parseDuration, durationToMilliseconds} from 'src/shared/utils/duration'
@@ -15,7 +17,7 @@ import {AppState} from 'src/types'
 
 export const DEFAULT_SECONDS = 259200 // 72 hours
 
-export const DURATION_OPTIONS = [
+export const DURATION_OPTIONS: DurationOption[] = [
   {duration: '1h', displayText: '1 hour'},
   {duration: '6h', displayText: '6 hours'},
   {duration: '12h', displayText: '12 hours'},

--- a/ui/src/shared/components/DurationSelector.tsx
+++ b/ui/src/shared/components/DurationSelector.tsx
@@ -7,10 +7,15 @@ import {Dropdown, ComponentStatus} from '@influxdata/clockface'
 // Utils
 import {areDurationsEqual} from 'src/shared/utils/duration'
 
+export interface DurationOption {
+  duration: string
+  displayText: string
+}
+
 interface Props {
   selectedDuration: string
   onSelectDuration: (duration: string) => any
-  durations: Array<{duration: string; displayText: string}>
+  durations: DurationOption[]
   disabled?: boolean
 }
 
@@ -21,7 +26,7 @@ const DurationSelector: FunctionComponent<Props> = ({
   disabled = false,
 }) => {
   let resolvedDurations = durations
-  let selected = durations.find(
+  let selected: DurationOption = durations.find(
     d =>
       selectedDuration === d.duration ||
       areDurationsEqual(selectedDuration, d.duration)

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -14,8 +14,6 @@ import {AutoRefreshStatus} from 'src/types'
 
 export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss ZZ'
 
-export const DEFAULT_DURATION_MS = 1000
-
 export const DROPDOWN_MENU_MAX_HEIGHT = 240
 
 export const PRESENTATION_MODE_ANIMATION_DELAY = 0 // In milliseconds.

--- a/ui/src/shared/utils/duration.test.tsx
+++ b/ui/src/shared/utils/duration.test.tsx
@@ -2,6 +2,7 @@ import {
   parseDuration,
   durationToMilliseconds,
   areDurationsEqual,
+  millisecondsToDuration,
 } from 'src/shared/utils/duration'
 
 const TEST_CASES = [
@@ -54,5 +55,14 @@ describe('areDurationsEqual', () => {
     expect(areDurationsEqual('howdy', '1h')).toBe(false)
     expect(areDurationsEqual('howdy', 'howdy')).toBe(false)
     expect(areDurationsEqual('howdy', 'hi')).toBe(false)
+  })
+})
+
+describe('millisecondsToDuration', () => {
+  test('can convert millisecond duration to duration ast', () => {
+    expect(millisecondsToDuration(150_000)).toEqual('2m30s')
+    expect(millisecondsToDuration(7_200_005)).toEqual('2h5ms')
+    expect(millisecondsToDuration(9_000_000)).toEqual('2h30m')
+    expect(millisecondsToDuration(2 / 1_000_000)).toEqual('2ns')
   })
 })

--- a/ui/src/shared/utils/duration.ts
+++ b/ui/src/shared/utils/duration.ts
@@ -1,4 +1,5 @@
-import {Duration} from 'src/types/ast'
+import {TimeRange} from 'src/types'
+import {Duration, DurationUnit} from 'src/types/ast'
 
 export const parseDuration = (input: string): Duration[] => {
   const r = /([0-9]+)(y|mo|w|d|h|ms|s|m|us|µs|ns)/g
@@ -42,6 +43,39 @@ export const durationToMilliseconds = (duration: Duration[]): number =>
     0
   )
 
+/*
+  Convert an amount of milliseconds to a duration string.
+
+  The returned duration string will use the largest units possible, e.g.
+
+      millisecondsToDuration(9_000_000)
+
+  Will return `2h30m` rather than `9000000ms`.
+*/
+export const millisecondsToDuration = (value: number): string => {
+  const unitsAndMs = Object.entries(UNIT_TO_APPROX_MS).sort(
+    (a, b) => b[1] - a[1]
+  ) as [DurationUnit, number][]
+
+  const durations: Duration[] = []
+
+  let unitIndex = 0
+  let remainder = value
+
+  while (unitIndex < unitsAndMs.length) {
+    let [unit, unitAsMs] = unitsAndMs[unitIndex]
+    let valueInUnit = remainder / unitAsMs
+
+    durations.push({unit, magnitude: Math.floor(valueInUnit)})
+    remainder = remainder - Math.floor(valueInUnit) * unitAsMs
+    unitIndex += 1
+  }
+
+  return durations
+    .filter(({magnitude}) => magnitude > 0)
+    .reduce((s, {unit, magnitude}) => `${s}${magnitude}${unit}`, '')
+}
+
 export const areDurationsEqual = (a: string, b: string): boolean => {
   try {
     return (
@@ -51,4 +85,12 @@ export const areDurationsEqual = (a: string, b: string): boolean => {
   } catch {
     return false
   }
+}
+
+export const timeRangeToDuration = (timeRange: TimeRange): string => {
+  if (timeRange.upper || !timeRange.lower || !timeRange.lower.includes('now')) {
+    throw new Error('cannot convert time range to duration')
+  }
+
+  return timeRange.lower.replace(/\s/g, '').replace(/now\(\)-/, '')
 }

--- a/ui/src/shared/utils/getMinDurationFromAST.ts
+++ b/ui/src/shared/utils/getMinDurationFromAST.ts
@@ -30,6 +30,11 @@ export function getMinDurationFromAST(ast: Package): number {
   // 4. Take the minimum duration
   //
   const times = allRangeTimes(ast)
+
+  if (!times.length) {
+    throw new Error('no time ranges found in query')
+  }
+
   const starts = times.map(t => t[0])
   const stops = times.map(t => t[1])
   const cartesianProduct = starts.map(start => stops.map(stop => [start, stop]))

--- a/ui/src/timeMachine/actions/queries.ts
+++ b/ui/src/timeMachine/actions/queries.ts
@@ -13,9 +13,10 @@ import {notify} from 'src/shared/actions/notifications'
 import {rateLimitReached, resultTooLarge} from 'src/shared/copy/notifications'
 
 // Utils
-import {getActiveTimeMachine, getTimeRange} from 'src/timeMachine/selectors'
-import {getVariableAssignments} from 'src/variables/selectors'
-import {getTimeRangeVars} from 'src/variables/utils/getTimeRangeVars'
+import {
+  getActiveTimeMachine,
+  getVariableAssignments,
+} from 'src/timeMachine/selectors'
 import {filterUnusedVars} from 'src/shared/utils/filterUnusedVars'
 import {checkQueryResult} from 'src/shared/utils/checkQueryResult'
 import {
@@ -89,7 +90,6 @@ let pendingResults: Array<CancelBox<RunQueryResult>> = []
 
 export const executeQueries = () => async (dispatch, getState: GetState) => {
   const {view} = getActiveTimeMachine(getState())
-  const timeRange = getTimeRange(getState())
   const queries = view.properties.queries.filter(({text}) => !!text.trim())
 
   if (!queries.length) {
@@ -102,11 +102,8 @@ export const executeQueries = () => async (dispatch, getState: GetState) => {
     await dispatch(refreshTimeMachineVariableValues())
 
     const orgID = getState().orgs.org.id
-    const activeTimeMachineID = getState().timeMachines.activeTimeMachineID
-    const variableAssignments = [
-      ...getVariableAssignments(getState(), activeTimeMachineID),
-      ...getTimeRangeVars(timeRange),
-    ]
+
+    const variableAssignments = getVariableAssignments(getState())
 
     const startTime = Date.now()
 

--- a/ui/src/timeMachine/constants/queryBuilder.ts
+++ b/ui/src/timeMachine/constants/queryBuilder.ts
@@ -16,11 +16,6 @@ export const DURATIONS = [
   {duration: '30d', displayText: 'Every 30 days'},
 ]
 
-export const AUTO_NONE_DURATIONS = [
-  {duration: AGG_WINDOW_AUTO, displayText: 'Auto'},
-  {duration: AGG_WINDOW_NONE, displayText: 'None'},
-]
-
 export interface QueryFn {
   name: string
   flux: (period?: string) => string

--- a/ui/src/timeMachine/selectors/index.ts
+++ b/ui/src/timeMachine/selectors/index.ts
@@ -12,6 +12,9 @@ import {
   getNumericColumns as getNumericColumnsUtil,
   getGroupableColumns as getGroupableColumnsUtil,
 } from 'src/shared/utils/vis'
+import {getVariableAssignments as getVariableAssignmentsForContext} from 'src/variables/selectors'
+import {getTimeRangeVars} from 'src/variables/utils/getTimeRangeVars'
+import {getWindowPeriod} from 'src/variables/utils/getWindowVars'
 
 // Types
 import {
@@ -20,6 +23,7 @@ import {
   AppState,
   DashboardDraftQuery,
   TimeRange,
+  VariableAssignment,
 } from 'src/types'
 
 export const getActiveTimeMachine = (state: AppState) => {
@@ -47,6 +51,28 @@ export const getActiveQuery = (state: AppState): DashboardDraftQuery => {
   const {draftQueries, activeQueryIndex} = getActiveTimeMachine(state)
 
   return draftQueries[activeQueryIndex]
+}
+
+export const getVariableAssignments = (
+  state: AppState
+): VariableAssignment[] => {
+  return [
+    ...getTimeRangeVars(getTimeRange(state)),
+    ...getVariableAssignmentsForContext(
+      state,
+      state.timeMachines.activeTimeMachineID
+    ),
+  ]
+}
+
+/*
+  Get the value of the `v.windowPeriod` variable for the currently active query, in milliseconds.
+*/
+export const getActiveWindowPeriod = (state: AppState) => {
+  const {text} = getActiveQuery(state)
+  const variables = getVariableAssignments(state)
+
+  return getWindowPeriod(text, variables)
 }
 
 const getTablesMemoized = memoizeOne(

--- a/ui/src/variables/utils/getTimeRangeVars.ts
+++ b/ui/src/variables/utils/getTimeRangeVars.ts
@@ -1,10 +1,12 @@
+// Utils
+import {parseDuration, timeRangeToDuration} from 'src/shared/utils/duration'
+
 // Constants
 import {TIME_RANGE_START, TIME_RANGE_STOP} from 'src/variables/constants'
 
 // Types
 import {TimeRange} from 'src/types'
-import {VariableAssignment, Duration} from 'src/types/ast'
-import {parseDuration} from 'src/shared/utils/duration'
+import {VariableAssignment} from 'src/types/ast'
 
 export const getTimeRangeVars = (
   timeRange: TimeRange
@@ -35,7 +37,7 @@ export const getTimeRangeVars = (
         operator: '-',
         argument: {
           type: 'DurationLiteral',
-          values: toFluxDuration(timeRange.lower),
+          values: parseDuration(timeRangeToDuration(timeRange)),
         },
       },
     }
@@ -77,6 +79,3 @@ export const getTimeRangeVars = (
 
 const isDate = (ambiguousString: string): boolean =>
   !isNaN(Date.parse(ambiguousString))
-
-const toFluxDuration = (relativeInfluxQLTime: string): Duration[] =>
-  parseDuration(relativeInfluxQLTime.replace(/\s/g, '').replace(/now\(\)-/, ''))


### PR DESCRIPTION
Shows the computed value of the aggregate window period in the function selector dropdown:

![auto dropdown](https://user-images.githubusercontent.com/638955/64732719-2e650280-d498-11e9-875a-03a7bff7f17e.gif)

Not in this PR, but I also want to add the `v.timeRangeStart`, `v.timeRangeStop`, and `v.windowPeriod` variables to this list as well:

<img width="859" alt="Screen Shot 2019-09-11 at 1 31 10 PM" src="https://user-images.githubusercontent.com/638955/64732926-9ca9c500-d498-11e9-8a39-16b93e2fdb94.png">

