### PR TITLE
feat(tools): add build-tsi tool

### DIFF
--- a/cmd/influx_inspect/buildtsi/buildtsi.go
+++ b/cmd/influx_inspect/buildtsi/buildtsi.go
@@ -3,22 +3,13 @@ package buildtsi
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
-	"sync/atomic"
 
-	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/pkg/fs"
-	"github.com/influxdata/influxdb/storage"
 	"github.com/influxdata/influxdb/storage/wal"
 	"github.com/influxdata/influxdb/toml"
 	"github.com/influxdata/influxdb/tsdb"
@@ -26,184 +17,6 @@ import (
 	"github.com/influxdata/influxdb/tsdb/tsm1"
 	"go.uber.org/zap"
 )
-
-const defaultBatchSize = 10000
-
-// Command represents the program execution for "influx_inspect buildtsi".
-type Command struct {
-	Stderr  io.Writer
-	Stdout  io.Writer
-	Verbose bool
-	Logger  *zap.Logger
-
-	concurrency     int // Number of goroutines to dedicate to shard index building.
-	databaseFilter  string
-	retentionFilter string
-	shardFilter     string
-	maxLogFileSize  int64
-	maxCacheSize    uint64
-	batchSize       int
-}
-
-// NewCommand returns a new instance of Command.
-func NewCommand() *Command {
-	return &Command{
-		Stderr:      os.Stderr,
-		Stdout:      os.Stdout,
-		Logger:      zap.NewNop(),
-		batchSize:   defaultBatchSize,
-		concurrency: runtime.GOMAXPROCS(0),
-	}
-}
-
-// Run executes the command.
-func (cmd *Command) Run(args ...string) error {
-	fs := flag.NewFlagSet("buildtsi", flag.ExitOnError)
-	dataDir := fs.String("datadir", "", "data directory")
-	walDir := fs.String("waldir", "", "WAL directory")
-	fs.IntVar(&cmd.concurrency, "concurrency", runtime.GOMAXPROCS(0), "Number of workers to dedicate to shard index building. Defaults to GOMAXPROCS")
-	fs.StringVar(&cmd.databaseFilter, "database", "", "optional: database name")
-	fs.StringVar(&cmd.retentionFilter, "retention", "", "optional: retention policy")
-	fs.StringVar(&cmd.shardFilter, "shard", "", "optional: shard id")
-	fs.Int64Var(&cmd.maxLogFileSize, "max-log-file-size", tsi1.DefaultMaxIndexLogFileSize, "optional: maximum log file size")
-	fs.Uint64Var(&cmd.maxCacheSize, "max-cache-size", uint64(tsm1.DefaultCacheMaxMemorySize), "optional: maximum cache size")
-	fs.IntVar(&cmd.batchSize, "batch-size", defaultBatchSize, "optional: set the size of the batches we write to the index. Setting this can have adverse affects on performance and heap requirements")
-	fs.BoolVar(&cmd.Verbose, "v", false, "verbose")
-	fs.SetOutput(cmd.Stdout)
-	if err := fs.Parse(args); err != nil {
-		return err
-	} else if fs.NArg() > 0 || *dataDir == "" || *walDir == "" {
-		fs.Usage()
-		return nil
-	}
-	cmd.Logger = logger.New(cmd.Stderr)
-
-	return cmd.run(*dataDir, *walDir)
-}
-
-func (cmd *Command) run(dataDir, walDir string) error {
-	// Verify the user actually wants to run as root.
-	if isRoot() {
-		fmt.Println("You are currently running as root. This will build your")
-		fmt.Println("index files with root ownership and will be inaccessible")
-		fmt.Println("if you run influxd as a non-root user. You should run")
-		fmt.Println("buildtsi as the same user you are running influxd.")
-		fmt.Print("Are you sure you want to continue? (y/N): ")
-		var answer string
-		if fmt.Scanln(&answer); !strings.HasPrefix(strings.TrimSpace(strings.ToLower(answer)), "y") {
-			return fmt.Errorf("operation aborted")
-		}
-	}
-
-	fis, err := ioutil.ReadDir(dataDir)
-	if err != nil {
-		return err
-	}
-
-	for _, fi := range fis {
-		name := fi.Name()
-		if !fi.IsDir() {
-			continue
-		} else if cmd.databaseFilter != "" && name != cmd.databaseFilter {
-			continue
-		}
-
-		if err := cmd.processDatabase(name, filepath.Join(dataDir, name), filepath.Join(walDir, name)); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (cmd *Command) processDatabase(dbName, dataDir, walDir string) error {
-	cmd.Logger.Info("Rebuilding database", zap.String("name", dbName))
-
-	sfile := tsdb.NewSeriesFile(filepath.Join(dataDir, storage.DefaultSeriesFileDirectoryName))
-	sfile.Logger = cmd.Logger
-	if err := sfile.Open(context.Background()); err != nil {
-		return err
-	}
-	defer sfile.Close()
-
-	fis, err := ioutil.ReadDir(dataDir)
-	if err != nil {
-		return err
-	}
-
-	for _, fi := range fis {
-		rpName := fi.Name()
-		if !fi.IsDir() {
-			continue
-		} else if rpName == storage.DefaultSeriesFileDirectoryName {
-			continue
-		} else if cmd.retentionFilter != "" && rpName != cmd.retentionFilter {
-			continue
-		}
-
-		if err := cmd.processRetentionPolicy(sfile, dbName, rpName, filepath.Join(dataDir, rpName), filepath.Join(walDir, rpName)); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (cmd *Command) processRetentionPolicy(sfile *tsdb.SeriesFile, dbName, rpName, dataDir, walDir string) error {
-	cmd.Logger.Info("Rebuilding retention policy", logger.Database(dbName), logger.RetentionPolicy(rpName))
-
-	fis, err := ioutil.ReadDir(dataDir)
-	if err != nil {
-		return err
-	}
-
-	type shard struct {
-		ID   uint64
-		Path string
-	}
-
-	var shards []shard
-
-	for _, fi := range fis {
-		if !fi.IsDir() {
-			continue
-		} else if cmd.shardFilter != "" && fi.Name() != cmd.shardFilter {
-			continue
-		}
-
-		shardID, err := strconv.ParseUint(fi.Name(), 10, 64)
-		if err != nil {
-			continue
-		}
-
-		shards = append(shards, shard{shardID, fi.Name()})
-	}
-
-	errC := make(chan error, len(shards))
-	var maxi uint32 // index of maximum shard being worked on.
-	for k := 0; k < cmd.concurrency; k++ {
-		go func() {
-			for {
-				i := int(atomic.AddUint32(&maxi, 1) - 1) // Get next partition to work on.
-				if i >= len(shards) {
-					return // No more work.
-				}
-
-				id, name := shards[i].ID, shards[i].Path
-				log := cmd.Logger.With(logger.Database(dbName), logger.RetentionPolicy(rpName), logger.Shard(id))
-				errC <- IndexShard(sfile, filepath.Join(dataDir, "index"), filepath.Join(dataDir, name), filepath.Join(walDir, name), cmd.maxLogFileSize, cmd.maxCacheSize, cmd.batchSize, log, cmd.Verbose)
-			}
-		}()
-	}
-
-	// Check for error
-	for i := 0; i < cap(errC); i++ {
-		if err := <-errC; err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 func IndexShard(sfile *tsdb.SeriesFile, indexPath, dataDir, walDir string, maxLogFileSize int64, maxCacheSize uint64, batchSize int, log *zap.Logger, verboseLogging bool) error {
 	log.Info("Rebuilding shard")
@@ -430,11 +243,6 @@ func collectWALFiles(path string) ([]string, error) {
 		paths = append(paths, filepath.Join(path, fi.Name()))
 	}
 	return paths, nil
-}
-
-func isRoot() bool {
-	user, _ := user.Current()
-	return user != nil && user.Username == "root"
 }
 
 func modelsFieldType(block byte) models.FieldType {

--- a/cmd/influxd/inspect/build_tsi.go
+++ b/cmd/influxd/inspect/build_tsi.go
@@ -1,0 +1,135 @@
+package inspect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/influxdata/influxdb/cmd/influx_inspect/buildtsi"
+	"github.com/influxdata/influxdb/logger"
+	"github.com/influxdata/influxdb/storage"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/tsdb/tsi1"
+	"github.com/influxdata/influxdb/tsdb/tsm1"
+	"github.com/spf13/cobra"
+)
+
+const defaultBatchSize = 10000
+
+var buildTSIFlags = struct {
+	// Standard input/output, overridden for testing.
+	Stderr io.Writer
+	Stdout io.Writer
+
+	// Data path options
+	DataPath       string // optional. Defaults to <engine_path>/engine/data
+	WALPath        string // optional. Defaults to <engine_path>/engine/wal
+	SeriesFilePath string // optional. Defaults to <engine_path>/engine/_series
+	IndexPath      string // optional. Defaults to <engine_path>/engine/index
+
+	BatchSize      int    // optional. Defaults to 10000
+	MaxLogFileSize int64  // optional. Defaults to tsi1.DefaultMaxIndexLogFileSize
+	MaxCacheSize   uint64 // optional. Defaults to tsm1.DefaultCacheMaxMemorySize
+
+	Concurrency int  // optional. Defaults to GOMAXPROCS(0)
+	Verbose     bool // optional. Defaults to false.
+}{
+	Stderr: os.Stderr,
+	Stdout: os.Stdout,
+}
+
+// NewBuildTSICommand returns a new instance of Command with default setting applied.
+func NewBuildTSICommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "build-tsi",
+		Short: "Rebuilds the TSI index and (where necessary) the Series File.",
+		Long: `This command will rebuild the TSI index and if needed the Series
+		File. 
+
+		The index is built by reading all of the TSM indexes in the TSM data 
+		directory, and all of the WAL entries in the WAL data directory. If the 
+		Series File directory is missing, then the series file will be rebuilt.
+
+		If the TSI index directory already exists, then this tool will fail.
+
+		Performance of the tool can be tweaked by adjusting the max log file size,
+		max cache file size and the batch size.
+		
+		max-log-file-size determines how big in-memory parts of the index have to
+			get before they're compacted into memory-mappable index files. 
+			Consider decreasing this from the default if you find the heap 
+			requirements of your TSI index are too much.
+
+		max-cache-size refers to the maximum cache size allowed. If there are WAL
+			files to index, then they need to be replayed into a tsm1.Cache first
+			by this tool. If the maximum cache size isn't large enough then there
+			will be an error and this tool will fail. Increase max-cache-size to
+			address this.
+
+		batch-size refers to the size of the batches written into the index. 
+			Increasing this can improve performance but can result in much more
+			memory usage.
+		`,
+		RunE: RunBuildTSI,
+	}
+
+	defaultPath := filepath.Join(os.Getenv("HOME"), "/.influxdbv2/engine/")
+	defaultDataPath := filepath.Join(defaultPath, storage.DefaultEngineDirectoryName)
+	defaultWALPath := filepath.Join(defaultPath, storage.DefaultWALDirectoryName)
+	defaultSFilePath := filepath.Join(defaultPath, storage.DefaultSeriesFileDirectoryName)
+	defaultIndexPath := filepath.Join(defaultPath, storage.DefaultIndexDirectoryName)
+
+	cmd.Flags().StringVar(&buildTSIFlags.DataPath, "tsm-path", defaultDataPath, "Path to the TSM data directory. Defaults to "+defaultDataPath)
+	cmd.Flags().StringVar(&buildTSIFlags.WALPath, "wal-path", defaultWALPath, "Path to the WAL data directory. Defaults to "+defaultWALPath)
+	cmd.Flags().StringVar(&buildTSIFlags.SeriesFilePath, "sfile-path", defaultSFilePath, "Path to the Series File directory. Defaults to "+defaultSFilePath)
+	cmd.Flags().StringVar(&buildTSIFlags.IndexPath, "tsi-path", defaultIndexPath, "Path to the TSI index directory. Defaults to "+defaultIndexPath)
+
+	cmd.Flags().IntVar(&buildTSIFlags.Concurrency, "concurrency", runtime.GOMAXPROCS(0), "Number of workers to dedicate to shard index building. Defaults to GOMAXPROCS")
+	cmd.Flags().Int64Var(&buildTSIFlags.MaxLogFileSize, "max-log-file-size", tsi1.DefaultMaxIndexLogFileSize, "optional: maximum log file size")
+	cmd.Flags().Uint64Var(&buildTSIFlags.MaxCacheSize, "max-cache-size", uint64(tsm1.DefaultCacheMaxMemorySize), "optional: maximum cache size")
+	cmd.Flags().IntVar(&buildTSIFlags.BatchSize, "batch-size", defaultBatchSize, "optional: set the size of the batches we write to the index. Setting this can have adverse affects on performance and heap requirements")
+	cmd.Flags().BoolVar(&buildTSIFlags.Verbose, "v", false, "verbose")
+
+	cmd.SetOutput(buildTSIFlags.Stdout)
+
+	return cmd
+}
+
+// RunBuildTSI executes the run command for BuildTSI.
+func RunBuildTSI(cmd *cobra.Command, args []string) error {
+	// Verify the user actually wants to run as root.
+	if isRoot() {
+		fmt.Fprintln(buildTSIFlags.Stdout, "You are currently running as root. This will build your")
+		fmt.Fprintln(buildTSIFlags.Stdout, "index files with root ownership and will be inaccessible")
+		fmt.Fprintln(buildTSIFlags.Stdout, "if you run influxd as a non-root user. You should run")
+		fmt.Fprintln(buildTSIFlags.Stdout, "influxd inspect buildtsi as the same user you are running influxd.")
+		fmt.Fprint(buildTSIFlags.Stdout, "Are you sure you want to continue? (y/N): ")
+		var answer string
+		if fmt.Scanln(&answer); !strings.HasPrefix(strings.TrimSpace(strings.ToLower(answer)), "y") {
+			return fmt.Errorf("operation aborted")
+		}
+	}
+
+	log := logger.New(buildTSIFlags.Stdout)
+
+	sfile := tsdb.NewSeriesFile(buildTSIFlags.SeriesFilePath)
+	sfile.Logger = log
+	if err := sfile.Open(context.Background()); err != nil {
+		return err
+	}
+	defer sfile.Close()
+
+	return buildtsi.IndexShard(sfile, buildTSIFlags.IndexPath, buildTSIFlags.DataPath, buildTSIFlags.WALPath,
+		buildTSIFlags.MaxLogFileSize, buildTSIFlags.MaxCacheSize, buildTSIFlags.BatchSize,
+		log, buildTSIFlags.Verbose)
+}
+
+func isRoot() bool {
+	user, _ := user.Current()
+	return user != nil && user.Username == "root"
+}

--- a/cmd/influxd/inspect/inspect.go
+++ b/cmd/influxd/inspect/inspect.go
@@ -14,6 +14,7 @@ func NewCommand() *cobra.Command {
 	// List of available sub-commands
 	// If a new sub-command is created, it must be added here
 	subCommands := []*cobra.Command{
+		NewBuildTSICommand(),
 		NewExportBlocksCommand(),
 		NewReportTSMCommand(),
 		NewVerifyTSMCommand(),

--- a/cmd/influxd/inspect/report_tsi1.go
+++ b/cmd/influxd/inspect/report_tsi1.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/influxdata/influxdb"
-
 	"github.com/influxdata/influxdb/tsdb/tsi1"
 	"github.com/spf13/cobra"
 )


### PR DESCRIPTION
This PR adds a new `inspect` tool, allowing the operator to rebuild their TSI index.

The tool uses the same APIs for building TSI indexes as we use elsewhere. It contains several configuration options for tweaking performance. The tool documentation explains these