### PR TITLE
fix(tests): ensure NATS server port free

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/mna/pigeon v1.0.1-0.20180808201053-bb0192cfc2ae
 	github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae // indirect
-	github.com/nats-io/gnatsd v1.3.0 // indirect
+	github.com/nats-io/gnatsd v1.3.0
 	github.com/nats-io/go-nats v1.7.0 // indirect
 	github.com/nats-io/go-nats-streaming v0.4.0
 	github.com/nats-io/nats-streaming-server v0.11.2

--- a/nats/publisher.go
+++ b/nats/publisher.go
@@ -17,15 +17,16 @@ type AsyncPublisher struct {
 	ClientID   string
 	Connection stan.Conn
 	Logger     *zap.Logger
+	Addr       string
 }
 
-func NewAsyncPublisher(clientID string) *AsyncPublisher {
-	return &AsyncPublisher{ClientID: clientID}
+func NewAsyncPublisher(clientID string, addr string) *AsyncPublisher {
+	return &AsyncPublisher{ClientID: clientID, Addr: addr}
 }
 
 // Open creates and maintains a connection to NATS server
 func (p *AsyncPublisher) Open() error {
-	sc, err := stan.Connect(ServerName, p.ClientID)
+	sc, err := stan.Connect(ServerName, p.ClientID, stan.NatsURL(p.Addr))
 	if err != nil {
 		return err
 	}

--- a/nats/subscriber.go
+++ b/nats/subscriber.go
@@ -12,15 +12,16 @@ type Subscriber interface {
 type QueueSubscriber struct {
 	ClientID   string
 	Connection stan.Conn
+	Addr       string
 }
 
-func NewQueueSubscriber(clientID string) *QueueSubscriber {
-	return &QueueSubscriber{ClientID: clientID}
+func NewQueueSubscriber(clientID string, addr string) *QueueSubscriber {
+	return &QueueSubscriber{ClientID: clientID, Addr: addr}
 }
 
 // Open creates and maintains a connection to NATS server
 func (s *QueueSubscriber) Open() error {
-	sc, err := stan.Connect(ServerName, s.ClientID)
+	sc, err := stan.Connect(ServerName, s.ClientID, stan.NatsURL(s.Addr))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #12697 
Closes #10628

This PR ensures that a port is free for the nats server, if it's initialised multiple times during tests. The obvious thing would have been to tell the server to bind to a random port `:0` but I couldn't for the life of me get that working with the library.

This will work until we rip out NATS.