### PR TITLE
fix(tasks): report error codes to metrics

### DIFF
--- a/task/backend/executor/executor_metrics.go
+++ b/task/backend/executor/executor_metrics.go
@@ -59,7 +59,7 @@ func NewExecutorMetrics(te *TaskExecutor) *ExecutorMetrics {
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "errors_counter",
-			Help:      "The number of errors thrown by the executor with the type of error (ex. Flux compile, query, etc).",
+			Help:      "The number of errors thrown by the executor with the type of error (ex. Invalid, Internal, etc.)",
 		}, []string{"errorType"}),
 
 		manualRunsCounter: prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -921,6 +921,11 @@ func TestScheduler_Metrics(t *testing.T) {
 		t.Fatalf("expected 1 run failed for task ID %s, got %v", task.ID.String(), got)
 	}
 
+	m = promtest.MustFindMetric(t, mfs, "task_scheduler_errors_counter", map[string]string{"error_type": "internal error"})
+	if got := *m.Counter.Value; got != 1 {
+		t.Fatalf("expected error type in metric to be internal error, got %v", got)
+	}
+
 	// Runs label removed after task released.
 	if err := s.ReleaseTask(task.ID); err != nil {
 		t.Fatal(err)

--- a/task_errors.go
+++ b/task_errors.go
@@ -53,6 +53,11 @@ var (
 		Msg:  "run not found",
 	}
 
+	ErrRunKeyNotFound = &Error{
+		Code: ENotFound,
+		Msg:  "run key not found",
+	}
+
 	ErrPageSizeTooSmall = &Error{
 		Msg:  "cannot have negative page limit",
 		Code: EInvalid,
@@ -109,7 +114,7 @@ func ErrQueryError(err error) *Error {
 // ErrResultIteratorError is returned when an error is thrown by exhaustResultIterators in the executor
 func ErrResultIteratorError(err error) *Error {
 	return &Error{
-		Code: EInternal,
+		Code: EInvalid,
 		Msg:  fmt.Sprintf("Error exhausting result iterator; Err: %v", err),
 		Op:   "kv/taskExecutor",
 		Err:  err,
@@ -159,5 +164,32 @@ func ErrRunNotDueYet(dueAt int64) *Error {
 	return &Error{
 		Code: EInvalid,
 		Msg:  fmt.Sprintf("run not due until: %v", time.Unix(dueAt, 0).UTC().Format(time.RFC3339)),
+	}
+}
+
+func ErrCouldNotLogError(err error) *Error {
+	return &Error{
+		Code: EInternal,
+		Msg:  fmt.Sprintf("unable to log error; Err: %v", err),
+		Op:   "kv/taskScheduler",
+		Err:  err,
+	}
+}
+
+func ErrJsonMarshalError(err error) *Error {
+	return &Error{
+		Code: EInvalid,
+		Msg:  fmt.Sprintf("unable to marshal JSON; Err: %v", err),
+		Op:   "kv/taskScheduler",
+		Err:  err,
+	}
+}
+
+func ErrRunExecutionError(err error) *Error {
+	return &Error{
+		Code: EInternal,
+		Msg:  fmt.Sprintf("could not execute task run; Err: %v", err),
+		Op:   "kv/taskScheduler",
+		Err:  err,
 	}
 }


### PR DESCRIPTION
Closes idpe 4708

Errors in the new executor were previously changed to use influxdb.Error objects and report error codes to metrics in [this PR](https://github.com/influxdata/influxdb/pull/14926/).

This PR implements the same change for error reporting in the scheduler which is currently in use, which will give developers a more accurate picture of what system errors are occurring and need to be responded to. Will not need to be updated when the new scheduler goes into effect, as the new executor already handles this behavior. 

TODO: 
- [x] add metrics testing for errors in both old scheduler and new executor
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
