### PR TITLE
fix(http): fixed http NotificationEndpoint

### DIFF
--- a/http/notification_endpoint.go
+++ b/http/notification_endpoint.go
@@ -119,7 +119,7 @@ func NewNotificationEndpointHandler(b *NotificationEndpointBackend) *Notificatio
 		LabelService:     b.LabelService,
 		ResourceType:     influxdb.TelegrafsResourceType,
 	}
-	h.HandlerFunc("GET", notificationEndpointsIDLabelsIDPath, newGetLabelsHandler(labelBackend))
+	h.HandlerFunc("GET", notificationEndpointsIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", notificationEndpointsIDLabelsPath, newPostLabelHandler(labelBackend))
 	h.HandlerFunc("DELETE", notificationEndpointsIDLabelsIDPath, newDeleteLabelHandler(labelBackend))
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -5776,6 +5776,7 @@ paths:
           - NotificationEndpoints
       summary: Get all notification endpoints
       parameters:
+        - $ref: '#/components/parameters/TraceSpan'
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/Limit'
         - in: query

--- a/kv/notification_endpoint.go
+++ b/kv/notification_endpoint.go
@@ -384,7 +384,7 @@ func (s *Service) findNotificationEndpointByID(ctx context.Context, tx Tx,
 // Additional options provide pagination & sorting.
 func (s *Service) FindNotificationEndpoints(ctx context.Context, filter influxdb.NotificationEndpointFilter, opt ...influxdb.FindOptions) (edps []influxdb.NotificationEndpoint, n int, err error) {
 	err = s.kv.View(ctx, func(tx Tx) error {
-		edps, n, err = s.findNotificationEndpoints(ctx, tx, filter)
+		edps, n, err = s.findNotificationEndpoints(ctx, tx, filter, opt...)
 		return err
 	})
 	return edps, n, err


### PR DESCRIPTION
* Added `TraceSpan` parameter into  Get all notification endpoints operation
* Fixed handler path for a list of all labels for a notification endpoint
* Fixed filtering NotificationEndpoints by `limit` and `offset`

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)