### PR TITLE
fix(http): add ParenExpression

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6376,7 +6376,7 @@ components:
           items:
             $ref: "#/components/schemas/Property"
     ParenExpression:
-      description: represents an expression wrapped in parenthesis
+      description: Represents an expression wrapped in parenthesis
       type: object
       properties:
         type:

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6258,6 +6258,7 @@ components:
         - $ref: "#/components/schemas/MemberExpression"
         - $ref: "#/components/schemas/IndexExpression"
         - $ref: "#/components/schemas/ObjectExpression"
+        - $ref: "#/components/schemas/ParenExpression"
         - $ref: "#/components/schemas/PipeExpression"
         - $ref: "#/components/schemas/UnaryExpression"
         - $ref: "#/components/schemas/BooleanLiteral"
@@ -6374,6 +6375,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Property"
+    ParenExpression:
+      description: represents an expression wrapped in parenthesis
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/NodeType"
+        expression:
+          $ref: "#/components/schemas/Expression"
     PipeExpression:
       description: Call expression with pipe argument
       type: object


### PR DESCRIPTION
Add `ParenExpression` to swagger definition. 

The `ParenExpression ` was introduce in https://github.com/influxdata/flux/pull/1848.

- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)