### PR TITLE
fix(templates): add jmeter template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [15151](https://github.com/influxdata/influxdb/pull/15151): Add jsonweb package for future JWT support
+1. [15168](https://github.com/influxdata/influxdb/pull/15168): Added the JMeter Template dashboard
 
 ### UI Improvements
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -162,7 +162,7 @@
     "@influxdata/flux-parser": "^0.3.0",
     "@influxdata/giraffe": "0.16.3",
     "@influxdata/influx": "0.5.5",
-    "@influxdata/influxdb-templates": "0.8.0",
+    "@influxdata/influxdb-templates": "0.9.0",
     "@influxdata/react-custom-scrollbars": "4.3.8",
     "abortcontroller-polyfill": "^1.3.0",
     "axios": "^0.19.0",

--- a/ui/src/templates/constants/defaultTemplates.ts
+++ b/ui/src/templates/constants/defaultTemplates.ts
@@ -3,6 +3,7 @@ import {
   docker,
   gettingStarted,
   github,
+  jmeter,
   kubernetes,
   nginx,
   ossMetrics,
@@ -20,6 +21,7 @@ export const staticTemplates: {[k: string]: DashboardTemplate} = {
   Docker: docker,
   'getting-started': gettingStarted,
   Github: github,
+  JMeter: jmeter,
   Kubernetes: kubernetes,
   Nginx: nginx,
   'oss-metrics': ossMetrics,
@@ -32,6 +34,7 @@ export const influxdbTemplateList: DashboardTemplate[] = [
   docker,
   gettingStarted,
   github,
+  jmeter
   kubernetes,
   nginx,
   ossMetrics,

--- a/ui/src/templates/constants/defaultTemplates.ts
+++ b/ui/src/templates/constants/defaultTemplates.ts
@@ -34,7 +34,7 @@ export const influxdbTemplateList: DashboardTemplate[] = [
   docker,
   gettingStarted,
   github,
-  jmeter
+  jmeter,
   kubernetes,
   nginx,
   ossMetrics,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1102,10 +1102,10 @@
   dependencies:
     axios "^0.19.0"
 
-"@influxdata/influxdb-templates@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/influxdb-templates/-/influxdb-templates-0.8.0.tgz#16e5f8c157b8c02bb6e5fa657a805b85d97b920b"
-  integrity sha512-e+tx021ZWR/cYb6Q+IpH8zFAyF/HeNEp/3Auu1K3OOaMU6nxJ8AnG4tpAlWbjGoSa/lqUYbZKv65w7nWxboH5Q==
+"@influxdata/influxdb-templates@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/influxdb-templates/-/influxdb-templates-0.9.0.tgz#d4b1f727c8949147d2ade63f5754425a0d1a0e9d"
+  integrity sha512-R/QhYJz+nNPGT8LkWHXKOLYYUROavDPfIFoGP7sIrxhStjm+hb0TzHYeQ75HLPQqKh54zCB8cv/TINwRgijYBw==
 
 "@influxdata/oats@0.4.0":
   version "0.4.0"


### PR DESCRIPTION
don't merge until https://github.com/influxdata/influxdb-templates/pull/24 is closed and a new version of the templates package is cut.

Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
