### PR TITLE
refactor(ui): split check creation flow

### DIFF
--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -18,17 +18,17 @@ describe('Checks', () => {
     })
   })
 
-  it('can validate a check', () => {
+  it('can validate a threshold check', () => {
     cy.getByTestID('create-check').click()
+
+    cy.getByTestID('create-threshold-check').click()
 
     cy.getByTestID(`selector-list ${measurement}`).click()
 
     cy.getByTestID('save-cell--button').should('be.disabled')
-    cy.getByTestID('checkeo--header alerting-tab').should('be.disabled')
 
     cy.getByTestID(`selector-list ${field}`).click()
 
     cy.getByTestID('save-cell--button').should('be.enabled')
-    cy.getByTestID('checkeo--header alerting-tab').should('be.enabled')
   })
 })

--- a/ui/src/alerting/components/AlertingIndex.scss
+++ b/ui/src/alerting/components/AlertingIndex.scss
@@ -45,12 +45,17 @@
   h5 {
     line-height: 1.5em;
     font-weight: 500;
-    margin-bottom: 1.5em;
+    margin-bottom: 1em;
 
     strong {
       font-weight: 900;
       color: $g20-white;
     }
+  }
+
+  .cf-button {
+    margin-top: $ix-marg-c;
+    margin-right: $ix-marg-b;
   }
 }
 

--- a/ui/src/alerting/components/AlertingIndex.scss
+++ b/ui/src/alerting/components/AlertingIndex.scss
@@ -45,7 +45,7 @@
   h5 {
     line-height: 1.5em;
     font-weight: 500;
-    margin-bottom: 1em;
+    margin-bottom: 0.25em;
 
     strong {
       font-weight: 900;
@@ -54,7 +54,7 @@
   }
 
   .cf-button {
-    margin-top: $ix-marg-c;
+    margin-bottom: $ix-marg-c;
     margin-right: $ix-marg-b;
   }
 }

--- a/ui/src/alerting/components/AlertingIndex.scss
+++ b/ui/src/alerting/components/AlertingIndex.scss
@@ -65,6 +65,7 @@
 */
 
 .query-checklist--popover {
+  width: 300px;
   padding: 16px;
   user-select: none;
 

--- a/ui/src/alerting/components/CheckAlertingButton.tsx
+++ b/ui/src/alerting/components/CheckAlertingButton.tsx
@@ -2,20 +2,7 @@
 import React, {FunctionComponent} from 'react'
 
 // Components
-import {
-  Radio,
-  Popover,
-  PopoverInteraction,
-  PopoverPosition,
-  ComponentColor,
-  PopoverType,
-  ButtonShape,
-  Icon,
-  IconFont,
-} from '@influxdata/clockface'
-
-// Utils
-import {isDraftQueryAlertable} from 'src/timeMachine/utils/queryBuilder'
+import {Radio, ButtonShape, Icon, IconFont} from '@influxdata/clockface'
 
 // Actions
 import {setActiveTab} from 'src/timeMachine/actions'
@@ -31,7 +18,6 @@ interface Props {
 
 const CheckAlertingButton: FunctionComponent<Props> = ({
   setActiveTab,
-  draftQueries,
   activeTab,
 }) => {
   const handleClick = (nextTab: TimeMachineTab) => () => {
@@ -40,68 +26,31 @@ const CheckAlertingButton: FunctionComponent<Props> = ({
     }
   }
 
-  const {
-    oneQuery,
-    builderMode,
-    singleAggregateFunc,
-    singleField,
-  } = isDraftQueryAlertable(draftQueries)
-
-  const isQueryAlertable =
-    oneQuery && builderMode && singleAggregateFunc && singleField
-
   return (
-    <Popover
-      style={{width: '100%'}}
-      visible={!isQueryAlertable}
-      position={PopoverPosition.ToTheRight}
-      showEvent={PopoverInteraction.None}
-      hideEvent={PopoverInteraction.None}
-      color={ComponentColor.Secondary}
-      type={PopoverType.Outline}
-      contents={onHide => (
-        <div className="query-checklist--popover">
-          <p>To create a check, your query must include:</p>
-          <ul className="query-checklist--list">
-            <QueryChecklistItem text="One field" selected={singleField} />
-            <QueryChecklistItem
-              text="One aggregate function"
-              selected={singleAggregateFunc}
-            />
-          </ul>
-          <Popover.DismissButton
-            onClick={onHide}
-            color={ComponentColor.Secondary}
-          />
-        </div>
-      )}
-    >
-      <Radio shape={ButtonShape.StretchToFit}>
-        <Radio.Button
-          key="queries"
-          id="queries"
-          titleText="queries"
-          value="queries"
-          active={activeTab === 'queries'}
-          onClick={handleClick('queries')}
-        >
-          1. Query
-        </Radio.Button>
+    <Radio shape={ButtonShape.StretchToFit}>
+      <Radio.Button
+        key="queries"
+        id="queries"
+        titleText="queries"
+        value="queries"
+        active={activeTab === 'queries'}
+        onClick={handleClick('queries')}
+      >
+        1. Query
+      </Radio.Button>
 
-        <Radio.Button
-          key="alerting"
-          id="alerting"
-          testID="checkeo--header alerting-tab"
-          titleText="alerting"
-          value="alerting"
-          active={activeTab === 'alerting'}
-          onClick={handleClick('alerting')}
-          disabled={!isQueryAlertable}
-        >
-          2. Check
-        </Radio.Button>
-      </Radio>
-    </Popover>
+      <Radio.Button
+        key="alerting"
+        id="alerting"
+        testID="checkeo--header alerting-tab"
+        titleText="alerting"
+        value="alerting"
+        active={activeTab === 'alerting'}
+        onClick={handleClick('alerting')}
+      >
+        2. Check
+      </Radio.Button>
+    </Radio>
   )
 }
 

--- a/ui/src/alerting/components/CheckAlertingButton.tsx
+++ b/ui/src/alerting/components/CheckAlertingButton.tsx
@@ -2,7 +2,7 @@
 import React, {FunctionComponent} from 'react'
 
 // Components
-import {Radio, ButtonShape, Icon, IconFont} from '@influxdata/clockface'
+import {Radio, ButtonShape} from '@influxdata/clockface'
 
 // Actions
 import {setActiveTab} from 'src/timeMachine/actions'
@@ -55,25 +55,3 @@ const CheckAlertingButton: FunctionComponent<Props> = ({
 }
 
 export default CheckAlertingButton
-
-interface ChecklistItemProps {
-  selected: boolean
-  text: string
-}
-
-const QueryChecklistItem: FunctionComponent<ChecklistItemProps> = ({
-  selected,
-  text,
-}) => {
-  const className = selected
-    ? 'query-checklist--item valid'
-    : 'query-checklist--item error'
-  const icon = selected ? IconFont.Checkmark : IconFont.Remove
-
-  return (
-    <li className={className}>
-      <Icon glyph={icon} />
-      {text}
-    </li>
-  )
-}

--- a/ui/src/alerting/components/CheckCards.tsx
+++ b/ui/src/alerting/components/CheckCards.tsx
@@ -22,14 +22,16 @@ interface Props {
   checks: Check[]
   searchTerm: string
   showFirstTimeWidget: boolean
-  onCreateCheck: () => void
+  onCreateThreshold: () => void
+  onCreateDeadman: () => void
 }
 
 const CheckCards: FunctionComponent<Props> = ({
   checks,
   searchTerm,
   showFirstTimeWidget,
-  onCreateCheck,
+  onCreateThreshold,
+  onCreateDeadman,
 }) => {
   const cards = cs => cs.map(c => <CheckCard key={c.id} check={c} />)
   const body = filtered => (
@@ -37,7 +39,8 @@ const CheckCards: FunctionComponent<Props> = ({
       emptyState={
         <EmptyChecksList
           showFirstTimeWidget={showFirstTimeWidget}
-          onCreateCheck={onCreateCheck}
+          onCreateThreshold={onCreateThreshold}
+          onCreateDeadman={onCreateDeadman}
           searchTerm={searchTerm}
         />
       }
@@ -64,13 +67,15 @@ const CheckCards: FunctionComponent<Props> = ({
 
 interface EmptyProps {
   showFirstTimeWidget: boolean
-  onCreateCheck: () => void
+  onCreateThreshold: () => void
+  onCreateDeadman: () => void
   searchTerm: string
 }
 
 const EmptyChecksList: FunctionComponent<EmptyProps> = ({
   showFirstTimeWidget,
-  onCreateCheck,
+  onCreateThreshold,
+  onCreateDeadman,
   searchTerm,
 }) => {
   if (searchTerm) {
@@ -105,14 +110,14 @@ const EmptyChecksList: FunctionComponent<EmptyProps> = ({
           <Button
             size={ComponentSize.Medium}
             color={ComponentColor.Primary}
-            onClick={onCreateCheck}
+            onClick={onCreateThreshold}
             text="Threshold Check"
             icon={IconFont.Plus}
           />
           <Button
             size={ComponentSize.Medium}
             color={ComponentColor.Primary}
-            onClick={onCreateCheck}
+            onClick={onCreateDeadman}
             text="Deadman Check"
             icon={IconFont.Plus}
           />

--- a/ui/src/alerting/components/CheckCards.tsx
+++ b/ui/src/alerting/components/CheckCards.tsx
@@ -106,7 +106,14 @@ const EmptyChecksList: FunctionComponent<EmptyProps> = ({
             size={ComponentSize.Medium}
             color={ComponentColor.Primary}
             onClick={onCreateCheck}
-            text="Create a Check"
+            text="Threshold Check"
+            icon={IconFont.Plus}
+          />
+          <Button
+            size={ComponentSize.Medium}
+            color={ComponentColor.Primary}
+            onClick={onCreateCheck}
+            text="Deadman Check"
             icon={IconFont.Plus}
           />
         </Panel.Body>

--- a/ui/src/alerting/components/CheckCards.tsx
+++ b/ui/src/alerting/components/CheckCards.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   IconFont,
   ComponentColor,
+  ButtonShape,
 } from '@influxdata/clockface'
 
 // Types
@@ -97,29 +98,24 @@ const EmptyChecksList: FunctionComponent<EmptyProps> = ({
         className="alerting-first-time"
       >
         <Panel.Body>
-          <h1>
-            Looks like it's your
-            <br />
-            first time here
-          </h1>
-          <h5>
-            Welcome to our new Monitoring & Alerting feature!
-            <br />
-            To get started try creating a Check:
-          </h5>
+          <h1>Get started monitoring by creating a check</h1>
+          <h5>When a value crosses a specific threshold:</h5>
           <Button
             size={ComponentSize.Medium}
             color={ComponentColor.Primary}
             onClick={onCreateThreshold}
             text="Threshold Check"
             icon={IconFont.Plus}
+            shape={ButtonShape.StretchToFit}
           />
+          <h5>If a service stops sending metrics:</h5>
           <Button
             size={ComponentSize.Medium}
             color={ComponentColor.Primary}
             onClick={onCreateDeadman}
             text="Deadman Check"
             icon={IconFont.Plus}
+            shape={ButtonShape.StretchToFit}
           />
         </Panel.Body>
       </Panel>

--- a/ui/src/alerting/components/CheckEOSaveButton.tsx
+++ b/ui/src/alerting/components/CheckEOSaveButton.tsx
@@ -1,0 +1,93 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+
+// Components
+import {
+  SquareButton,
+  ComponentColor,
+  ComponentSize,
+  ComponentStatus,
+  Icon,
+  IconFont,
+  Popover,
+  PopoverInteraction,
+  PopoverPosition,
+  PopoverType,
+} from '@influxdata/clockface'
+
+interface Props {
+  onSave: () => Promise<void>
+  status: ComponentStatus
+  className: string
+  checkType: string
+  singleField: boolean
+  singleAggregateFunc: boolean
+}
+
+const CheckEOSaveButton: FunctionComponent<Props> = ({
+  onSave,
+  status,
+  className,
+  checkType,
+  singleField,
+  singleAggregateFunc,
+}) => {
+  return (
+    <Popover
+      visible={status !== ComponentStatus.Default}
+      position={PopoverPosition.Below}
+      showEvent={PopoverInteraction.None}
+      hideEvent={PopoverInteraction.None}
+      color={ComponentColor.Secondary}
+      type={PopoverType.Outline}
+      contents={() => (
+        <div className="query-checklist--popover">
+          <p>{`To create a ${checkType} check, your query must include:`}</p>
+          <ul className="query-checklist--list">
+            <QueryChecklistItem text="One field" selected={singleField} />
+            {checkType === 'threshold' && (
+              <QueryChecklistItem
+                text="One aggregate function"
+                selected={singleAggregateFunc}
+              />
+            )}
+          </ul>
+        </div>
+      )}
+    >
+      <SquareButton
+        className={className}
+        icon={IconFont.Checkmark}
+        color={ComponentColor.Success}
+        size={ComponentSize.Small}
+        status={status}
+        onClick={onSave}
+        testID="save-cell--button"
+      />
+    </Popover>
+  )
+}
+
+export default CheckEOSaveButton
+
+interface ChecklistItemProps {
+  selected: boolean
+  text: string
+}
+
+const QueryChecklistItem: FunctionComponent<ChecklistItemProps> = ({
+  selected,
+  text,
+}) => {
+  const className = selected
+    ? 'query-checklist--item valid'
+    : 'query-checklist--item error'
+  const icon = selected ? IconFont.Checkmark : IconFont.Remove
+
+  return (
+    <li className={className}>
+      <Icon glyph={icon} />
+      {text}
+    </li>
+  )
+}

--- a/ui/src/alerting/components/ChecksColumn.tsx
+++ b/ui/src/alerting/components/ChecksColumn.tsx
@@ -29,8 +29,12 @@ const ChecksColumn: FunctionComponent<Props> = ({
   rules,
   endpoints,
 }) => {
-  const handleCreateCheck = () => {
-    router.push(`/orgs/${orgID}/alerting/checks/new`)
+  const handleCreateThreshold = () => {
+    router.push(`/orgs/${orgID}/alerting/checks/new-threshold`)
+  }
+
+  const handleCreateDeadman = () => {
+    router.push(`/orgs/${orgID}/alerting/checks/new-deadman`)
   }
 
   const tooltipContents = (
@@ -56,8 +60,8 @@ const ChecksColumn: FunctionComponent<Props> = ({
 
   const createButton = (
     <CreateCheckDropdown
-      onCreateThreshold={handleCreateCheck}
-      onCreateDeadman={handleCreateCheck}
+      onCreateThreshold={handleCreateThreshold}
+      onCreateDeadman={handleCreateDeadman}
     />
   )
 
@@ -71,7 +75,8 @@ const ChecksColumn: FunctionComponent<Props> = ({
         <CheckCards
           checks={checks}
           searchTerm={searchTerm}
-          onCreateCheck={handleCreateCheck}
+          onCreateThreshold={handleCreateThreshold}
+          onCreateDeadman={handleCreateDeadman}
           showFirstTimeWidget={noAlertingResourcesExist}
         />
       )}

--- a/ui/src/alerting/components/ChecksColumn.tsx
+++ b/ui/src/alerting/components/ChecksColumn.tsx
@@ -9,7 +9,7 @@ import {viewableLabels} from 'src/labels/selectors'
 // Components
 import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
 import CheckCards from 'src/alerting/components/CheckCards'
-import AlertsColumnHeader from 'src/alerting/components/AlertsColumn'
+import AlertsColumn from 'src/alerting/components/AlertsColumn'
 
 // Types
 import {Check, NotificationRuleDraft, AppState} from 'src/types'
@@ -29,7 +29,7 @@ const ChecksColumn: FunctionComponent<Props> = ({
   rules,
   endpoints,
 }) => {
-  const handleClick = () => {
+  const handleCreateCheck = () => {
     router.push(`/orgs/${orgID}/alerting/checks/new`)
   }
 
@@ -65,7 +65,7 @@ const ChecksColumn: FunctionComponent<Props> = ({
   )
 
   return (
-    <AlertsColumnHeader
+    <AlertsColumn
       title="Checks"
       createButton={createButton}
       questionMarkTooltipContents={tooltipContents}
@@ -74,11 +74,11 @@ const ChecksColumn: FunctionComponent<Props> = ({
         <CheckCards
           checks={checks}
           searchTerm={searchTerm}
-          onCreateCheck={handleClick}
+          onCreateCheck={handleCreateCheck}
           showFirstTimeWidget={noAlertingResourcesExist}
         />
       )}
-    </AlertsColumnHeader>
+    </AlertsColumn>
   )
 }
 

--- a/ui/src/alerting/components/ChecksColumn.tsx
+++ b/ui/src/alerting/components/ChecksColumn.tsx
@@ -7,9 +7,9 @@ import {connect} from 'react-redux'
 import {viewableLabels} from 'src/labels/selectors'
 
 // Components
-import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
 import CheckCards from 'src/alerting/components/CheckCards'
 import AlertsColumn from 'src/alerting/components/AlertsColumn'
+import CreateCheckDropdown from 'src/alerting/components/CreateCheckDropdown'
 
 // Types
 import {Check, NotificationRuleDraft, AppState} from 'src/types'
@@ -55,12 +55,9 @@ const ChecksColumn: FunctionComponent<Props> = ({
     !checks.length && !rules.length && !endpoints.length
 
   const createButton = (
-    <Button
-      color={ComponentColor.Primary}
-      text="Create"
-      onClick={handleClick}
-      testID="create-check"
-      icon={IconFont.Plus}
+    <CreateCheckDropdown
+      onCreateThreshold={handleCreateCheck}
+      onCreateDeadman={handleCreateCheck}
     />
   )
 

--- a/ui/src/alerting/components/CreateCheckDropdown.tsx
+++ b/ui/src/alerting/components/CreateCheckDropdown.tsx
@@ -37,6 +37,7 @@ const CreateCheckDropdown: FunctionComponent<Props> = ({
       color={ComponentColor.Primary}
       active={active}
       onClick={onClick}
+      testID="create-check"
     >
       Create
     </Dropdown.Button>
@@ -44,10 +45,18 @@ const CreateCheckDropdown: FunctionComponent<Props> = ({
 
   const DropdownMenu = (onCollapse: () => void) => (
     <Dropdown.Menu onCollapse={onCollapse}>
-      <Dropdown.Item value={CheckType.Threshold} onClick={handleItemClick}>
+      <Dropdown.Item
+        value={CheckType.Threshold}
+        onClick={handleItemClick}
+        testID="create-threshold-check"
+      >
         Threshold Check
       </Dropdown.Item>
-      <Dropdown.Item value={CheckType.Deadman} onClick={handleItemClick}>
+      <Dropdown.Item
+        value={CheckType.Deadman}
+        onClick={handleItemClick}
+        testID="create-deadman-check"
+      >
         Deadman Check
       </Dropdown.Item>
     </Dropdown.Menu>

--- a/ui/src/alerting/components/CreateCheckDropdown.tsx
+++ b/ui/src/alerting/components/CreateCheckDropdown.tsx
@@ -4,14 +4,12 @@ import React, {FunctionComponent, MouseEvent} from 'react'
 // Components
 import {Dropdown, ComponentColor, IconFont} from '@influxdata/clockface'
 
+// Types
+import {CheckType} from 'src/types'
+
 interface Props {
   onCreateThreshold: () => void
   onCreateDeadman: () => void
-}
-
-enum CheckType {
-  Deadman = 'deadman',
-  Threshold = 'threshold',
 }
 
 const CreateCheckDropdown: FunctionComponent<Props> = ({
@@ -19,11 +17,11 @@ const CreateCheckDropdown: FunctionComponent<Props> = ({
   onCreateDeadman,
 }) => {
   const handleItemClick = (type: CheckType): void => {
-    if (type === CheckType.Threshold) {
+    if (type === 'threshold') {
       onCreateThreshold()
     }
 
-    if (type === CheckType.Deadman) {
+    if (type === 'deadman') {
       onCreateDeadman()
     }
   }
@@ -46,14 +44,14 @@ const CreateCheckDropdown: FunctionComponent<Props> = ({
   const DropdownMenu = (onCollapse: () => void) => (
     <Dropdown.Menu onCollapse={onCollapse}>
       <Dropdown.Item
-        value={CheckType.Threshold}
+        value="threshold"
         onClick={handleItemClick}
         testID="create-threshold-check"
       >
         Threshold Check
       </Dropdown.Item>
       <Dropdown.Item
-        value={CheckType.Deadman}
+        value="deadman"
         onClick={handleItemClick}
         testID="create-deadman-check"
       >

--- a/ui/src/alerting/components/CreateCheckDropdown.tsx
+++ b/ui/src/alerting/components/CreateCheckDropdown.tsx
@@ -1,0 +1,61 @@
+// Libraries
+import React, {FunctionComponent, MouseEvent} from 'react'
+
+// Components
+import {Dropdown, ComponentColor, IconFont} from '@influxdata/clockface'
+
+interface Props {
+  onCreateThreshold: () => void
+  onCreateDeadman: () => void
+}
+
+enum CheckType {
+  Deadman = 'deadman',
+  Threshold = 'threshold',
+}
+
+const CreateCheckDropdown: FunctionComponent<Props> = ({
+  onCreateThreshold,
+  onCreateDeadman,
+}) => {
+  const handleItemClick = (type: CheckType): void => {
+    if (type === CheckType.Threshold) {
+      onCreateThreshold()
+    }
+
+    if (type === CheckType.Deadman) {
+      onCreateDeadman()
+    }
+  }
+
+  const DropdownButton = (
+    active: boolean,
+    onClick: (e: MouseEvent<HTMLButtonElement>) => void
+  ) => (
+    <Dropdown.Button
+      icon={IconFont.Plus}
+      color={ComponentColor.Primary}
+      active={active}
+      onClick={onClick}
+    >
+      Create
+    </Dropdown.Button>
+  )
+
+  const DropdownMenu = (onCollapse: () => void) => (
+    <Dropdown.Menu onCollapse={onCollapse}>
+      <Dropdown.Item value={CheckType.Threshold} onClick={handleItemClick}>
+        Threshold Check
+      </Dropdown.Item>
+      <Dropdown.Item value={CheckType.Deadman} onClick={handleItemClick}>
+        Deadman Check
+      </Dropdown.Item>
+    </Dropdown.Menu>
+  )
+
+  return (
+    <Dropdown button={DropdownButton} menu={DropdownMenu} widthPixels={124} />
+  )
+}
+
+export default CreateCheckDropdown

--- a/ui/src/alerting/components/NewCheckEO.tsx
+++ b/ui/src/alerting/components/NewCheckEO.tsx
@@ -24,7 +24,10 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Types
 import {Check, AppState, RemoteDataState, CheckViewProperties} from 'src/types'
-import {DEFAULT_THRESHOLD_CHECK} from 'src/alerting/constants'
+import {
+  DEFAULT_THRESHOLD_CHECK,
+  DEFAULT_DEADMAN_CHECK,
+} from 'src/alerting/constants'
 
 interface DispatchProps {
   setTimeMachineCheck: typeof setTimeMachineCheck
@@ -51,14 +54,30 @@ const NewCheckOverlay: FunctionComponent<Props> = ({
   checkStatus,
   check,
   notify,
+  location,
 }) => {
+  const useCorrectDefaultCheck = () => {
+    const newCheckType = location.pathname
+      .split('/')
+      .reverse()[0]
+      .replace('new-', '')
+
+    if (newCheckType === 'threshold') {
+      return DEFAULT_THRESHOLD_CHECK
+    }
+
+    if (newCheckType === 'deadman') {
+      return DEFAULT_DEADMAN_CHECK
+    }
+  }
+
   useEffect(() => {
     const view = createView<CheckViewProperties>('check')
     onSetActiveTimeMachine('alerting', {
       view,
       alerting: {
         checkStatus: RemoteDataState.Done,
-        check: DEFAULT_THRESHOLD_CHECK,
+        check: useCorrectDefaultCheck(),
       },
     })
   }, [])

--- a/ui/src/alerting/components/NewDeadmanCheckEO.tsx
+++ b/ui/src/alerting/components/NewDeadmanCheckEO.tsx
@@ -24,10 +24,7 @@ import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Types
 import {Check, AppState, RemoteDataState, CheckViewProperties} from 'src/types'
-import {
-  DEFAULT_THRESHOLD_CHECK,
-  DEFAULT_DEADMAN_CHECK,
-} from 'src/alerting/constants'
+import {DEFAULT_DEADMAN_CHECK} from 'src/alerting/constants'
 
 interface DispatchProps {
   setTimeMachineCheck: typeof setTimeMachineCheck
@@ -54,30 +51,14 @@ const NewCheckOverlay: FunctionComponent<Props> = ({
   checkStatus,
   check,
   notify,
-  location,
 }) => {
-  const useCorrectDefaultCheck = () => {
-    const newCheckType = location.pathname
-      .split('/')
-      .reverse()[0]
-      .replace('new-', '')
-
-    if (newCheckType === 'threshold') {
-      return DEFAULT_THRESHOLD_CHECK
-    }
-
-    if (newCheckType === 'deadman') {
-      return DEFAULT_DEADMAN_CHECK
-    }
-  }
-
   useEffect(() => {
-    const view = createView<CheckViewProperties>('check')
+    const view = createView<CheckViewProperties>('deadmanCheck')
     onSetActiveTimeMachine('alerting', {
       view,
       alerting: {
         checkStatus: RemoteDataState.Done,
-        check: useCorrectDefaultCheck(),
+        check: DEFAULT_DEADMAN_CHECK,
       },
     })
   }, [])

--- a/ui/src/alerting/components/NewThresholdCheckEO.tsx
+++ b/ui/src/alerting/components/NewThresholdCheckEO.tsx
@@ -1,0 +1,130 @@
+// Libraries
+import React, {FunctionComponent, useEffect} from 'react'
+import {connect} from 'react-redux'
+import {withRouter, WithRouterProps} from 'react-router'
+
+// Components
+import {Overlay, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
+import CheckEOHeader from 'src/alerting/components/CheckEOHeader'
+import TimeMachine from 'src/timeMachine/components/TimeMachine'
+
+// Actions
+import {saveCheckFromTimeMachine} from 'src/alerting/actions/checks'
+import {
+  setActiveTimeMachine,
+  updateTimeMachineCheck,
+  setTimeMachineCheck,
+} from 'src/timeMachine/actions'
+import {createCheckFailed} from 'src/shared/copy/notifications'
+import {notify} from 'src/shared/actions/notifications'
+
+// Utils
+import {createView} from 'src/shared/utils/view'
+import {getActiveTimeMachine} from 'src/timeMachine/selectors'
+
+// Types
+import {Check, AppState, RemoteDataState, CheckViewProperties} from 'src/types'
+import {DEFAULT_THRESHOLD_CHECK} from 'src/alerting/constants'
+
+interface DispatchProps {
+  setTimeMachineCheck: typeof setTimeMachineCheck
+  updateTimeMachineCheck: typeof updateTimeMachineCheck
+  onSetActiveTimeMachine: typeof setActiveTimeMachine
+  saveCheckFromTimeMachine: typeof saveCheckFromTimeMachine
+  notify: typeof notify
+}
+
+interface StateProps {
+  check: Partial<Check>
+  checkStatus: RemoteDataState
+}
+
+type Props = DispatchProps & StateProps & WithRouterProps
+
+const NewCheckOverlay: FunctionComponent<Props> = ({
+  onSetActiveTimeMachine,
+  updateTimeMachineCheck,
+  setTimeMachineCheck,
+  saveCheckFromTimeMachine,
+  params,
+  router,
+  checkStatus,
+  check,
+  notify,
+}) => {
+  useEffect(() => {
+    const view = createView<CheckViewProperties>('thresholdCheck')
+    onSetActiveTimeMachine('alerting', {
+      view,
+      alerting: {
+        checkStatus: RemoteDataState.Done,
+        check: DEFAULT_THRESHOLD_CHECK,
+      },
+    })
+  }, [])
+
+  const handleUpdateName = (name: string) => {
+    updateTimeMachineCheck({name})
+  }
+
+  const handleClose = () => {
+    setTimeMachineCheck(RemoteDataState.NotStarted, null)
+    router.push(`/orgs/${params.orgID}/alerting`)
+  }
+
+  const handleSave = async () => {
+    // todo: when check has own view
+    // save view as view
+    // put view.id on check.viewID
+    try {
+      await saveCheckFromTimeMachine()
+      handleClose()
+    } catch (e) {
+      console.error(e)
+      notify(createCheckFailed(e.message))
+    }
+  }
+
+  return (
+    <Overlay visible={true} className="veo-overlay">
+      <div className="veo">
+        <SpinnerContainer
+          spinnerComponent={<TechnoSpinner />}
+          loading={checkStatus || RemoteDataState.Loading}
+        >
+          <CheckEOHeader
+            key={check && check.name}
+            name={check && check.name}
+            onSetName={handleUpdateName}
+            onCancel={handleClose}
+            onSave={handleSave}
+          />
+          <div className="veo-contents">
+            <TimeMachine />
+          </div>
+        </SpinnerContainer>
+      </div>
+    </Overlay>
+  )
+}
+
+const mstp = (state: AppState): StateProps => {
+  const {
+    alerting: {check, checkStatus},
+  } = getActiveTimeMachine(state)
+
+  return {check, checkStatus}
+}
+
+const mdtp: DispatchProps = {
+  setTimeMachineCheck: setTimeMachineCheck,
+  updateTimeMachineCheck: updateTimeMachineCheck,
+  onSetActiveTimeMachine: setActiveTimeMachine,
+  saveCheckFromTimeMachine: saveCheckFromTimeMachine,
+  notify: notify,
+}
+
+export default connect<StateProps, DispatchProps, {}>(
+  mstp,
+  mdtp
+)(withRouter(NewCheckOverlay))

--- a/ui/src/alerting/components/builder/CheckConditionsCard.tsx
+++ b/ui/src/alerting/components/builder/CheckConditionsCard.tsx
@@ -8,15 +8,12 @@ import {
   FlexDirection,
   AlignItems,
   ComponentSize,
-  Radio,
-  JustifyContent,
 } from '@influxdata/clockface'
 import ThresholdConditions from 'src/alerting/components/builder/ThresholdConditions'
 import DeadmanConditions from 'src/alerting/components/builder/DeadmanConditions'
 import BuilderCard from 'src/timeMachine/components/builderCard/BuilderCard'
 
 // Actions & Selectors
-import {changeCheckType} from 'src/timeMachine/actions'
 import {getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Types
@@ -26,60 +23,35 @@ interface StateProps {
   check: Partial<Check>
 }
 
-interface DispatchProps {
-  changeCheckType: typeof changeCheckType
-}
+type Props = StateProps
 
-type Props = DispatchProps & StateProps
+const CheckConditionsCard: FC<Props> = ({check}) => {
+  let cardTitle: string
+  let conditionsComponent: JSX.Element
 
-const CheckConditionsCard: FC<Props> = ({check, changeCheckType}) => {
+  if (check.type === 'deadman') {
+    cardTitle = 'Deadman'
+    conditionsComponent = <DeadmanConditions check={check} />
+  }
+
+  if (check.type === 'threshold') {
+    cardTitle = 'Thresholds'
+    conditionsComponent = <ThresholdConditions check={check} />
+  }
+
   return (
     <BuilderCard
       testID="builder-conditions"
       className="alert-builder--card alert-builder--conditions-card"
     >
-      <BuilderCard.Header title="Conditions" />
+      <BuilderCard.Header title={cardTitle} />
       <BuilderCard.Body addPadding={true} autoHideScrollbars={true}>
-        <FlexBox
-          direction={FlexDirection.Row}
-          alignItems={AlignItems.Center}
-          stretchToFitWidth={true}
-          justifyContent={JustifyContent.Center}
-          className="alert-builder--check-type-selector"
-        >
-          <Radio>
-            <Radio.Button
-              key="threshold"
-              id="threshold"
-              titleText="threshold"
-              value="threshold"
-              active={check.type === 'threshold'}
-              onClick={changeCheckType}
-            >
-              Threshold
-            </Radio.Button>
-            <Radio.Button
-              key="deadman"
-              id="deadman"
-              titleText="deadman"
-              value="deadman"
-              active={check.type === 'deadman'}
-              onClick={changeCheckType}
-            >
-              Deadman
-            </Radio.Button>
-          </Radio>
-        </FlexBox>
         <FlexBox
           direction={FlexDirection.Column}
           alignItems={AlignItems.Stretch}
           margin={ComponentSize.Medium}
         >
-          {check.type === 'deadman' ? (
-            <DeadmanConditions check={check} />
-          ) : (
-            <ThresholdConditions check={check} />
-          )}
+          {conditionsComponent}
         </FlexBox>
       </BuilderCard.Body>
     </BuilderCard>
@@ -94,11 +66,7 @@ const mstp = (state: AppState): StateProps => {
   return {check}
 }
 
-const mdtp: DispatchProps = {
-  changeCheckType: changeCheckType,
-}
-
-export default connect<StateProps, DispatchProps, {}>(
+export default connect<StateProps, {}, {}>(
   mstp,
-  mdtp
+  null
 )(CheckConditionsCard)

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -80,7 +80,8 @@ import AlertingIndex from 'src/alerting/components/AlertingIndex'
 import AlertHistoryIndex from 'src/alerting/components/AlertHistoryIndex'
 import BucketsDeleteDataOverlay from 'src/shared/components/DeleteDataOverlay'
 import DEDeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
-import NewCheckEO from 'src/alerting/components/NewCheckEO'
+import NewThresholdCheckEO from 'src/alerting/components/NewThresholdCheckEO'
+import NewDeadmanCheckEO from 'src/alerting/components/NewDeadmanCheckEO'
 import EditCheckEO from 'src/alerting/components/EditCheckEO'
 import NewRuleOverlay from 'src/alerting/components/notifications/NewRuleOverlay'
 import EditRuleOverlay from 'src/alerting/components/notifications/EditRuleOverlay'
@@ -338,11 +339,11 @@ class Root extends PureComponent {
                             <Route path="alerting" component={AlertingIndex}>
                               <Route
                                 path="checks/new-threshold"
-                                component={NewCheckEO}
+                                component={NewThresholdCheckEO}
                               />
                               <Route
                                 path="checks/new-deadman"
-                                component={NewCheckEO}
+                                component={NewDeadmanCheckEO}
                               />
                               <Route
                                 path="checks/:checkID/edit"

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -336,7 +336,14 @@ class Root extends PureComponent {
                           </Route>
                           <FeatureFlag name="alerting">
                             <Route path="alerting" component={AlertingIndex}>
-                              <Route path="checks/new" component={NewCheckEO} />
+                              <Route
+                                path="checks/new-threshold"
+                                component={NewCheckEO}
+                              />
+                              <Route
+                                path="checks/new-deadman"
+                                component={NewCheckEO}
+                              />
                               <Route
                                 path="checks/:checkID/edit"
                                 component={EditCheckEO}

--- a/ui/src/shared/utils/view.ts
+++ b/ui/src/shared/utils/view.ts
@@ -246,7 +246,7 @@ const NEW_VIEW_CREATORS = {
       ySuffix: '',
     },
   }),
-  check: (): NewView<CheckViewProperties> => ({
+  thresholdCheck: (): NewView<CheckViewProperties> => ({
     name: 'check',
     properties: {
       type: 'check',
@@ -268,10 +268,33 @@ const NEW_VIEW_CREATORS = {
       colors: NINETEEN_EIGHTY_FOUR,
     },
   }),
+  deadmanCheck: (): NewView<CheckViewProperties> => ({
+    name: 'check',
+    properties: {
+      type: 'check',
+      shape: 'chronograf-v2',
+      checkID: '',
+      queries: [
+        {
+          name: '',
+          text: '',
+          editMode: 'builder',
+          builderConfig: {
+            buckets: [],
+            tags: [{key: '_measurement', values: []}],
+            functions: [],
+          },
+        },
+      ],
+      colors: NINETEEN_EIGHTY_FOUR,
+    },
+  }),
 }
 
+type weeeee = ViewType | 'deadmanCheck' | 'thresholdCheck'
+
 export function createView<T extends ViewProperties = ViewProperties>(
-  viewType: ViewType = 'xy'
+  viewType: weeeee = 'xy'
 ): NewView<T> {
   const creator = NEW_VIEW_CREATORS[viewType]
 

--- a/ui/src/timeMachine/components/QueryBuilder.tsx
+++ b/ui/src/timeMachine/components/QueryBuilder.tsx
@@ -18,12 +18,13 @@ import {loadBuckets, addTagSelector} from 'src/timeMachine/actions/queryBuilder'
 import {getActiveQuery, getActiveTimeMachine} from 'src/timeMachine/selectors'
 
 // Types
-import {AppState} from 'src/types'
+import {Check, AppState} from 'src/types'
 import {RemoteDataState} from 'src/types'
 
 interface StateProps {
   tagFiltersLength: number
   moreTags: boolean
+  check: Partial<Check>
 }
 
 interface DispatchProps {
@@ -58,10 +59,20 @@ class TimeMachineQueryBuilder extends PureComponent<Props, State> {
               {this.addButton}
             </div>
           </FancyScrollbar>
-          <FunctionSelector />
+          {this.functionSelector}
         </div>
       </div>
     )
+  }
+
+  private get functionSelector(): JSX.Element {
+    const {check} = this.props
+
+    if (check.type === 'deadman') {
+      return
+    }
+
+    return <FunctionSelector />
   }
 
   private get addButton(): JSX.Element {
@@ -77,13 +88,17 @@ class TimeMachineQueryBuilder extends PureComponent<Props, State> {
 
 const mstp = (state: AppState): StateProps => {
   const tagFiltersLength = getActiveQuery(state).builderConfig.tags.length
-  const tags = getActiveTimeMachine(state).queryBuilder.tags
+  const {
+    queryBuilder: {tags},
+    alerting: {check},
+  } = getActiveTimeMachine(state)
 
   const {keys, keysStatus} = tags[tags.length - 1]
 
   return {
     tagFiltersLength,
     moreTags: !(keys.length === 0 && keysStatus === RemoteDataState.Done),
+    check,
   }
 }
 

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -47,7 +47,8 @@ export const isDraftQueryAlertable = (
 }
 
 export const isCheckSaveable = (
-  draftQueries: DashboardDraftQuery[]
+  draftQueries: DashboardDraftQuery[],
+  checkType: string
 ): boolean => {
   const {
     oneQuery,
@@ -55,6 +56,11 @@ export const isCheckSaveable = (
     singleAggregateFunc,
     singleField,
   } = isDraftQueryAlertable(draftQueries)
+
+  if (checkType === 'deadman') {
+    return oneQuery && builderMode && singleField
+  }
+
   return oneQuery && builderMode && singleAggregateFunc && singleField
 }
 


### PR DESCRIPTION
Closes #15162 
Closes #15163 
Closes #15164 
Closes #15165 

![Screen Shot 2019-09-16 at 5 11 12 PM](https://user-images.githubusercontent.com/2433762/65001598-0238ef80-d8a5-11e9-9d14-0f8ed58a6ac9.png)
Have the user select the type of check they are making before opening the check editor

![Screen Shot 2019-09-16 at 4 23 09 PM](https://user-images.githubusercontent.com/2433762/65000024-e599b900-d89e-11e9-9a16-ea91739e924d.png)
![Screen Shot 2019-09-16 at 4 23 16 PM](https://user-images.githubusercontent.com/2433762/65000026-e7637c80-d89e-11e9-95f3-38c9bc92f810.png)
Move validation popover to save button instead of radio buttons

![Screen Shot 2019-09-16 at 4 23 24 PM](https://user-images.githubusercontent.com/2433762/65000038-f3e7d500-d89e-11e9-8bec-917ea955b783.png)
Don't show function selector if check is deadman

![Screen Shot 2019-09-16 at 4 23 52 PM](https://user-images.githubusercontent.com/2433762/65000047-ff3b0080-d89e-11e9-953a-1b1acf86d6ad.png)
Remove check type toggle from conditions card

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
