### PR TITLE
refactor(dependencies): use new dependency injection framework

### DIFF
--- a/cmd/influx/repl.go
+++ b/cmd/influx/repl.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/repl"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/http"
@@ -106,5 +106,5 @@ func getFluxREPL(addr, token string, orgID platform.ID) (*repl.REPL, error) {
 	}
 	// background context is OK here, and DefaultDependencies are noop deps.  Also safe since we send all queries to the
 	// server side.
-	return repl.New(context.Background(), dependencies.NewDefaults(), q), nil
+	return repl.New(context.Background(), flux.NewDefaultDependencies(), q), nil
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/flux"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/authorizer"
 	"github.com/influxdata/influxdb/bolt"
@@ -532,7 +533,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 			m.logger.Error("Failed to get query controller dependencies", zap.Error(err))
 			return err
 		}
-		cc.ExecutorDependencies = deps
+		cc.ExecutorDependencies = []flux.Dependency{deps}
 
 		c, err := control.New(cc)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/hashicorp/go-msgpack v0.0.0-20150518234257-fa3f63826f7c // indirect
 	github.com/hashicorp/raft v1.0.0 // indirect
 	github.com/hashicorp/vault/api v1.0.2
-	github.com/influxdata/flux v0.47.0
+	github.com/influxdata/flux v0.47.1-0.20190917165150-71861fd0953f
 	github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368
 	github.com/jessevdk/go-flags v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/changelog v1.0.0 h1:RstJD6H48zLQj0GdE6E6k/6RPwtUjkyzIe/T1E/xuWU=
 github.com/influxdata/changelog v1.0.0/go.mod h1:uzpGWE/qehT8L426YuXwpMQub+a63vIINhIeEI9mnSM=
-github.com/influxdata/flux v0.47.0 h1:DR6ji+5IomoDNGO95MaP9Qkiicg3qXM5m6M75bYrrJI=
-github.com/influxdata/flux v0.47.0/go.mod h1:ytbedJDFqhVs0HmoV/cMoS4AR2O8PGLY84cN8+X7kBQ=
+github.com/influxdata/flux v0.47.1-0.20190917165150-71861fd0953f h1:mHdP0GqqEWq8q/pY2wLTbvEybO5XDTZNGF5vLQnELjo=
+github.com/influxdata/flux v0.47.1-0.20190917165150-71861fd0953f/go.mod h1:ytbedJDFqhVs0HmoV/cMoS4AR2O8PGLY84cN8+X7kBQ=
 github.com/influxdata/goreleaser v0.97.0-influx h1:jT5OrcW7WfS0e2QxfwmTBjhLvpIC9CDLRhNgZJyhj8s=
 github.com/influxdata/goreleaser v0.97.0-influx/go.mod h1:MnjA0e0Uq6ISqjG1WxxMAl+3VS1QYjILSWVnMYDxasE=
 github.com/influxdata/influxql v0.0.0-20180925231337-1cbfca8e56b6 h1:CFx+pP90q/qg3spoiZjf8donE4WpAdjeJfPOcoNqkWo=

--- a/query/bridges.go
+++ b/query/bridges.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/csv"
-	"github.com/influxdata/flux/dependencies"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/check"
 	"github.com/influxdata/influxdb/kit/tracing"
@@ -128,7 +127,7 @@ type REPLQuerier struct {
 
 // Query will pack a query to be sent to a remote server for execution.  deps may be safely ignored since
 // they will be correctly initialized on the server side.
-func (q *REPLQuerier) Query(ctx context.Context, deps dependencies.Interface, compiler flux.Compiler) (flux.ResultIterator, error) {
+func (q *REPLQuerier) Query(ctx context.Context, deps flux.Dependencies, compiler flux.Compiler) (flux.ResultIterator, error) {
 	req := &Request{
 		Authorization:  q.Authorization,
 		OrganizationID: q.OrganizationID,

--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
-	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
@@ -21,7 +20,9 @@ import (
 	"github.com/influxdata/flux/plan/plantest"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/influxdb/query"
+	_ "github.com/influxdata/influxdb/query/builtin"
 	"github.com/influxdata/influxdb/query/control"
+	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"go.uber.org/zap/zaptest"
@@ -45,7 +46,7 @@ var (
 		ConcurrencyQuota:         1,
 		MemoryBytesQuotaPerQuery: 1024,
 		QueueSize:                1,
-		ExecutorDependencies:     executetest.NewTestExecuteDependencies(),
+		ExecutorDependencies:     influxdb.Dependencies{FluxDeps: executetest.NewTestExecuteDependencies()},
 	}
 )
 

--- a/query/control/controller_test.go
+++ b/query/control/controller_test.go
@@ -46,7 +46,11 @@ var (
 		ConcurrencyQuota:         1,
 		MemoryBytesQuotaPerQuery: 1024,
 		QueueSize:                1,
-		ExecutorDependencies:     influxdb.Dependencies{FluxDeps: executetest.NewTestExecuteDependencies()},
+		ExecutorDependencies: []flux.Dependency{
+			influxdb.Dependencies{
+				FluxDeps: executetest.NewTestExecuteDependencies(),
+			},
+		},
 	}
 )
 

--- a/query/stdlib/influxdata/influxdb/buckets.go
+++ b/query/stdlib/influxdata/influxdb/buckets.go
@@ -2,7 +2,6 @@ package influxdb
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/influxdata/flux"
@@ -110,7 +109,7 @@ func createBucketsSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
 
 	// the dependencies used for FromKind are adequate for what we need here
 	// so there's no need to inject custom dependencies for buckets()
-	deps := a.Dependencies()[influxdb.BucketsKind].(BucketDependencies)
+	deps := GetStorageDependencies(a.Context()).BucketDeps
 	req := query.RequestFromContext(a.Context())
 	if req == nil {
 		return nil, &flux.Error{
@@ -129,11 +128,3 @@ type AllBucketLookup interface {
 	FindAllBuckets(ctx context.Context, orgID platform.ID) ([]*platform.Bucket, int)
 }
 type BucketDependencies AllBucketLookup
-
-func InjectBucketDependencies(depsMap execute.Dependencies, deps BucketDependencies) error {
-	if deps == nil {
-		return errors.New("missing all bucket lookup dependency")
-	}
-	depsMap[influxdb.BucketsKind] = deps
-	return nil
-}

--- a/query/stdlib/influxdata/influxdb/dependencies.go
+++ b/query/stdlib/influxdata/influxdb/dependencies.go
@@ -1,0 +1,100 @@
+package influxdb
+
+import (
+	"context"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/prom"
+	"github.com/influxdata/influxdb/query"
+	"github.com/influxdata/influxdb/storage"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type key int
+
+const dependenciesKey key = iota
+
+type StorageDependencies struct {
+	FromDeps   FromDependencies
+	BucketDeps BucketDependencies
+	ToDeps     ToDependencies
+}
+
+func (d StorageDependencies) Inject(ctx context.Context) context.Context {
+	return context.WithValue(ctx, dependenciesKey, d)
+}
+
+func GetStorageDependencies(ctx context.Context) StorageDependencies {
+	return ctx.Value(dependenciesKey).(StorageDependencies)
+}
+
+// PrometheusCollectors satisfies the prom.PrometheusCollector interface.
+func (d StorageDependencies) PrometheusCollectors() []prometheus.Collector {
+	depS := []interface{}{
+		d.FromDeps,
+		d.BucketDeps,
+		d.ToDeps,
+	}
+	collectors := make([]prometheus.Collector, 0, len(depS))
+	for _, v := range depS {
+		if pc, ok := v.(prom.PrometheusCollector); ok {
+			collectors = append(collectors, pc.PrometheusCollectors()...)
+		}
+	}
+	return collectors
+}
+
+type Dependencies struct {
+	StorageDeps StorageDependencies
+	FluxDeps    flux.Dependencies
+}
+
+func (d Dependencies) Inject(ctx context.Context) context.Context {
+	ctx = d.FluxDeps.Inject(ctx)
+	return d.StorageDeps.Inject(ctx)
+}
+
+// PrometheusCollectors satisfies the prom.PrometheusCollector interface.
+func (d Dependencies) PrometheusCollectors() []prometheus.Collector {
+	collectors := d.StorageDeps.PrometheusCollectors()
+	if pc, ok := d.FluxDeps.(prom.PrometheusCollector); ok {
+		collectors = append(collectors, pc.PrometheusCollectors()...)
+	}
+	return collectors
+}
+
+func NewDependencies(
+	reader Reader,
+	writer storage.PointsWriter,
+	bucketSvc influxdb.BucketService,
+	orgSvc influxdb.OrganizationService,
+	ss influxdb.SecretService,
+	metricLabelKeys []string,
+) (Dependencies, error) {
+	fdeps := flux.NewDefaultDependencies()
+	fdeps.Deps.SecretService = query.FromSecretService(ss)
+	deps := Dependencies{FluxDeps: fdeps}
+	bucketLookupSvc := query.FromBucketService(bucketSvc)
+	orgLookupSvc := query.FromOrganizationService(orgSvc)
+	metrics := NewMetrics(metricLabelKeys)
+	deps.StorageDeps.FromDeps = FromDependencies{
+		Reader:             reader,
+		BucketLookup:       bucketLookupSvc,
+		OrganizationLookup: orgLookupSvc,
+		Metrics:            metrics,
+	}
+	if err := deps.StorageDeps.FromDeps.Validate(); err != nil {
+		return Dependencies{}, err
+	}
+	deps.StorageDeps.BucketDeps = bucketLookupSvc
+	deps.StorageDeps.ToDeps = ToDependencies{
+		BucketLookup:       bucketLookupSvc,
+		OrganizationLookup: orgLookupSvc,
+		PointsWriter:       writer,
+	}
+	if err := deps.StorageDeps.ToDeps.Validate(); err != nil {
+		return Dependencies{}, err
+	}
+	return deps, nil
+}

--- a/query/stdlib/influxdata/influxdb/from.go
+++ b/query/stdlib/influxdata/influxdb/from.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
@@ -152,12 +151,4 @@ func (s *FromProcedureSpec) PostPhysicalValidate(id plan.NodeID) error {
 		Code: codes.Invalid,
 		Msg:  fmt.Sprintf("cannot submit unbounded read to %q; try bounding 'from' with a call to 'range'", bucket),
 	}
-}
-
-func InjectFromDependencies(depsMap execute.Dependencies, deps Dependencies) error {
-	if err := deps.Validate(); err != nil {
-		return err
-	}
-	depsMap[FromKind] = deps
-	return nil
 }

--- a/query/stdlib/influxdata/influxdb/metrics.go
+++ b/query/stdlib/influxdata/influxdb/metrics.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/influxdata/flux/execute"
 	platform "github.com/influxdata/influxdb"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -81,8 +80,4 @@ func (m *metrics) recordMetrics(labelValues []string, start time.Time) {
 		return
 	}
 	m.requestDur.WithLabelValues(labelValues...).Observe(time.Since(start).Seconds())
-}
-
-func getMetricsFromDependencies(depsMap execute.Dependencies) *metrics {
-	return depsMap[FromKind].(Dependencies).Metrics
 }

--- a/query/stdlib/influxdata/influxdb/source.go
+++ b/query/stdlib/influxdata/influxdb/source.go
@@ -123,7 +123,7 @@ func ReadFilterSource(id execute.DatasetID, r Reader, readSpec ReadFilterSpec, a
 	src.reader = r
 	src.readSpec = readSpec
 
-	src.m = getMetricsFromDependencies(a.Dependencies())
+	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
 	src.orgID = readSpec.OrganizationID
 	src.op = "readFilter"
 
@@ -158,7 +158,7 @@ func createReadFilterSource(s plan.ProcedureSpec, id execute.DatasetID, a execut
 		}
 	}
 
-	deps := a.Dependencies()[FromKind].(Dependencies)
+	deps := GetStorageDependencies(a.Context()).FromDeps
 
 	req := query.RequestFromContext(a.Context())
 	if req == nil {
@@ -206,7 +206,7 @@ func ReadGroupSource(id execute.DatasetID, r Reader, readSpec ReadGroupSpec, a e
 	src.reader = r
 	src.readSpec = readSpec
 
-	src.m = getMetricsFromDependencies(a.Dependencies())
+	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
 	src.orgID = readSpec.OrganizationID
 	src.op = "readGroup"
 
@@ -238,7 +238,7 @@ func createReadGroupSource(s plan.ProcedureSpec, id execute.DatasetID, a execute
 		return nil, errors.New("nil bounds passed to from")
 	}
 
-	deps := a.Dependencies()[FromKind].(Dependencies)
+	deps := GetStorageDependencies(a.Context()).FromDeps
 
 	req := query.RequestFromContext(a.Context())
 	if req == nil {
@@ -278,7 +278,7 @@ func createReadTagKeysSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, 
 	defer span.Finish()
 
 	spec := prSpec.(*ReadTagKeysPhysSpec)
-	deps := a.Dependencies()[FromKind].(Dependencies)
+	deps := GetStorageDependencies(a.Context()).FromDeps
 	req := query.RequestFromContext(a.Context())
 	if req == nil {
 		return nil, errors.New("missing request on context")
@@ -326,7 +326,7 @@ func ReadTagKeysSource(id execute.DatasetID, r Reader, readSpec ReadTagKeysSpec,
 	src.id = id
 	src.alloc = a.Allocator()
 
-	src.m = getMetricsFromDependencies(a.Dependencies())
+	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
 	src.orgID = readSpec.OrganizationID
 	src.op = "readTagKeys"
 
@@ -347,7 +347,7 @@ func createReadTagValuesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID
 	defer span.Finish()
 
 	spec := prSpec.(*ReadTagValuesPhysSpec)
-	deps := a.Dependencies()[FromKind].(Dependencies)
+	deps := GetStorageDependencies(a.Context()).FromDeps
 	req := query.RequestFromContext(a.Context())
 	if req == nil {
 		return nil, errors.New("missing request on context")
@@ -396,7 +396,7 @@ func ReadTagValuesSource(id execute.DatasetID, r Reader, readSpec ReadTagValuesS
 	src.id = id
 	src.alloc = a.Allocator()
 
-	src.m = getMetricsFromDependencies(a.Dependencies())
+	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
 	src.orgID = readSpec.OrganizationID
 	src.op = "readTagValues"
 

--- a/query/stdlib/influxdata/influxdb/v1/databases.go
+++ b/query/stdlib/influxdata/influxdb/v1/databases.go
@@ -181,10 +181,7 @@ func createDatabasesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a 
 	if !ok {
 		return nil, fmt.Errorf("invalid spec type %T", prSpec)
 	}
-
-	// the dependencies used for FromKind are adequate for what we need here
-	// so there's no need to inject custom dependencies for databases()
-	deps := a.Dependencies()[DatabasesKind].(DatabasesDependencies)
+	deps := GetDatabasesDependencies(a.Context())
 	req := query.RequestFromContext(a.Context())
 	if req == nil {
 		return nil, errors.New("missing request on context")
@@ -196,20 +193,29 @@ func createDatabasesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a 
 	return execute.CreateSourceFromDecoder(bd, dsid, a)
 }
 
+type key int
+
+const dependenciesKey key = iota
+
 type DatabasesDependencies struct {
 	DBRP         platform.DBRPMappingService
 	BucketLookup platform.BucketService
 }
 
-func InjectDatabasesDependencies(depsMap execute.Dependencies, deps DatabasesDependencies) error {
-	if deps.DBRP == nil {
+func (d DatabasesDependencies) Inject(ctx context.Context) context.Context {
+	return context.WithValue(ctx, dependenciesKey, d)
+}
+
+func GetDatabasesDependencies(ctx context.Context) DatabasesDependencies {
+	return ctx.Value(dependenciesKey).(DatabasesDependencies)
+}
+
+func (d DatabasesDependencies) Validate() error {
+	if d.DBRP == nil {
 		return errors.New("missing all databases lookup dependency")
 	}
-
-	if deps.BucketLookup == nil {
+	if d.BucketLookup == nil {
 		return errors.New("missing buckets lookup dependency")
 	}
-
-	depsMap[DatabasesKind] = deps
 	return nil
 }

--- a/storage/readservice/service.go
+++ b/storage/readservice/service.go
@@ -1,13 +1,8 @@
 package readservice
 
 import (
-	"github.com/influxdata/flux/dependencies"
-	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/query/control"
-	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
-	"github.com/influxdata/influxdb/storage"
-	"github.com/influxdata/influxdb/storage/reads"
 )
 
 // NewProxyQueryService returns a proxy query service based on the given queryController
@@ -16,40 +11,4 @@ func NewProxyQueryService(queryController *control.Controller) query.ProxyQueryS
 	return query.ProxyQueryServiceAsyncBridge{
 		AsyncQueryService: queryController,
 	}
-}
-
-// AddControllerConfigDependencies sets up the dependencies on cc
-// such that "from" and "to" flux functions will work correctly.
-func AddControllerConfigDependencies(
-	cc *control.Config,
-	engine *storage.Engine,
-	bucketSvc platform.BucketService,
-	orgSvc platform.OrganizationService,
-	ss platform.SecretService,
-) error {
-	deps := dependencies.NewDefaults()
-	deps.Deps.SecretService = query.FromSecretService(ss)
-	cc.ExecutorDependencies[dependencies.InterpreterDepsKey] = deps
-
-	bucketLookupSvc := query.FromBucketService(bucketSvc)
-	orgLookupSvc := query.FromOrganizationService(orgSvc)
-	metrics := influxdb.NewMetrics(cc.MetricLabelKeys)
-	if err := influxdb.InjectFromDependencies(cc.ExecutorDependencies, influxdb.Dependencies{
-		Reader:             reads.NewReader(newStore(engine)),
-		BucketLookup:       bucketLookupSvc,
-		OrganizationLookup: orgLookupSvc,
-		Metrics:            metrics,
-	}); err != nil {
-		return err
-	}
-
-	if err := influxdb.InjectBucketDependencies(cc.ExecutorDependencies, bucketLookupSvc); err != nil {
-		return err
-	}
-
-	return influxdb.InjectToDependencies(cc.ExecutorDependencies, influxdb.ToDependencies{
-		BucketLookup:       bucketLookupSvc,
-		OrganizationLookup: orgLookupSvc,
-		PointsWriter:       engine,
-	})
 }

--- a/storage/readservice/store.go
+++ b/storage/readservice/store.go
@@ -20,7 +20,7 @@ type store struct {
 	engine *storage.Engine
 }
 
-func newStore(engine *storage.Engine) *store {
+func NewStore(engine *storage.Engine) reads.Store {
 	return &store{engine: engine}
 }
 

--- a/storage/wal/verifier_test.go
+++ b/storage/wal/verifier_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Test struct {
-	dir string
+	dir          string
 	corruptFiles []string
 }
 
@@ -45,7 +45,7 @@ func TestVerifyWALL_CleanFile(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	expectedEntries :=  numTestEntries
+	expectedEntries := numTestEntries
 	if summary.EntryCount != expectedEntries {
 		t.Fatalf("Error: expected %d entries, checked %d entries", expectedEntries, summary.EntryCount)
 	}
@@ -65,7 +65,7 @@ func CreateTest(t *testing.T, createFiles func() (string, []string, error)) *Tes
 	}
 
 	return &Test{
-		dir: dir,
+		dir:          dir,
 		corruptFiles: corruptFiles,
 	}
 }
@@ -96,7 +96,7 @@ func TestVerifyWALL_CorruptFile(t *testing.T) {
 
 	want := test.corruptFiles
 	got := summary.CorruptFiles
-	lessFunc := func(a, b string) bool {return a < b}
+	lessFunc := func(a, b string) bool { return a < b }
 
 	if !cmp.Equal(summary.CorruptFiles, want, cmpopts.SortSlices(lessFunc)) {
 		t.Fatalf("Error: unexpected list of corrupt files %v", cmp.Diff(got, want))

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/influxdata/flux"
 	"github.com/influxdata/influxdb"
 	icontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/inmem"
@@ -20,7 +21,6 @@ import (
 	"github.com/influxdata/influxdb/storage/readservice"
 	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/servicetest"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -165,7 +165,7 @@ func newAnalyticalBackend(t *testing.T, orgSvc influxdb.OrganizationService, buc
 		t.Fatal(err)
 	}
 	cc := control.Config{
-		ExecutorDependencies:     deps,
+		ExecutorDependencies:     []flux.Dependency{deps},
 		ConcurrencyQuota:         concurrencyQuota,
 		MemoryBytesQuotaPerQuery: int64(memoryBytesQuotaPerQuery),
 		QueueSize:                queueSize,

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -9,12 +9,11 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/influxdb/pkg/pointer"
-	cron "gopkg.in/robfig/cron.v2"
+	"gopkg.in/robfig/cron.v2"
 )
 
 const maxConcurrency = 100
@@ -200,12 +199,11 @@ func (s constantSecretService) LoadSecret(ctx context.Context, k string) (string
 	return "", nil
 }
 
-func newDeps() dependencies.Dependencies {
-	deps := dependencies.NewDefaults()
+func newDeps() flux.Dependencies {
+	deps := flux.NewDefaultDependencies()
 	deps.Deps.HTTPClient = nil
 	deps.Deps.URLValidator = nil
 	deps.Deps.SecretService = constantSecretService{}
-
 	return deps
 }
 
@@ -219,8 +217,8 @@ func FromScript(script string) (Options, error) {
 	}
 	durTypes := grabTaskOptionAST(fluxAST, optEvery, optOffset)
 	// TODO(desa): should be dependencies.NewEmpty(), but for now we'll hack things together
-	ctx, deps := context.Background(), newDeps()
-	_, scope, err := flux.EvalAST(ctx, deps, fluxAST)
+	ctx := newDeps().Inject(context.Background())
+	_, scope, err := flux.EvalAST(ctx, fluxAST)
 	if err != nil {
 		return opt, err
 	}

--- a/tsdb/tsm1/metrics_test.go
+++ b/tsdb/tsm1/metrics_test.go
@@ -25,7 +25,7 @@ func TestMetrics_Filestore(t *testing.T) {
 	t2.AddBytes(200, 0)
 	t2.SetFileCount(map[int]uint64{0: 4, 4: 3, 5: 1})
 
-	t3.SetBytes(map[int]uint64{0: 300, 1: 500, 4:100, 5: 100})
+	t3.SetBytes(map[int]uint64{0: 300, 1: 500, 4: 100, 5: 100})
 
 	// Test that all the correct metrics are present.
 	mfs, err := reg.Gather()


### PR DESCRIPTION
Connected to https://github.com/influxdata/flux/issues/1795.

This is the counterpart of https://github.com/influxdata/flux/pull/1879.

I moved dependency management from `readservice` to `stdlib/influxdata/influxdb` because of circular dependencies and because that seems its natural place.

Added a Launcher test to check that dynamic queries work.