### PR TITLE
fix(http): add discriminator for Check schema

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9351,6 +9351,11 @@ components:
       oneOf:
         - $ref: "#/components/schemas/DeadmanCheck"
         - $ref: "#/components/schemas/ThresholdCheck"
+      discriminator:
+        propertyName: type
+        mapping:
+          deadman:  "#/components/schemas/DeadmanCheck"
+          threshold: "#/components/schemas/ThresholdCheck"
     Checks:
       properties:
         checks:


### PR DESCRIPTION
Added discriminator for `Check` into swagger definition.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)