### PR TITLE
fix(query): correctly compute row number when echoing to() output

### DIFF
--- a/query/stdlib/influxdata/influxdb/to.go
+++ b/query/stdlib/influxdata/influxdb/to.go
@@ -570,6 +570,7 @@ func writeTable(ctx context.Context, t *ToTransformation, tbl flux.Table) (err e
 
 	measurementStats := make(map[string]Stats)
 	measurementName := ""
+	rowNum := 0
 	return tbl.Do(func(er flux.ColReader) error {
 		var pointTime time.Time
 		var points models.Points
@@ -678,9 +679,10 @@ func writeTable(ctx context.Context, t *ToTransformation, tbl flux.Table) (err e
 				points = append(points, pt)
 			}
 
-			if err := execute.AppendRecord(i, er, builder); err != nil {
+			if err := execute.AppendRecord(rowNum, er, builder); err != nil {
 				return err
 			}
+			rowNum++
 		}
 
 		return t.buf.WritePoints(ctx, points)


### PR DESCRIPTION
This fix is the same as the one here:
https://github.com/influxdata/idpe/pull/4759/files#diff-458ae59fbf7d45cbf871044ade08f7fdR294