### PR TITLE
fix(http): add a discriminator for a Threshold schema, add links into CheckBase schema

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9366,6 +9366,27 @@ components:
           type: string
         labels:
           $ref: "#/components/schemas/Labels"
+        links:
+          type: object
+          readOnly: true
+          example:
+            self: "/api/v2/checks/1"
+            labels: "/api/v2/checks/1/labels"
+            members: "/api/v2/checks/1/members"
+            owners: "/api/v2/checks/1/owners"
+          properties:
+            self:
+              description: URL for this check
+              $ref: "#/components/schemas/Link"
+            labels:
+              description: URL to retrieve labels for this check
+              $ref: "#/components/schemas/Link"
+            members:
+              description: URL to retrieve members for this check
+              $ref: "#/components/schemas/Link"
+            owners:
+              description: URL to retrieve owners for this check
+              $ref: "#/components/schemas/Link"
       required: [name, type, orgID, query]
     ThresholdCheck:
       allOf:
@@ -9384,6 +9405,12 @@ components:
         - $ref: "#/components/schemas/GreaterThreshold"
         - $ref: "#/components/schemas/LesserThreshold"
         - $ref: "#/components/schemas/RangeThreshold"
+      discriminator:
+        propertyName: type
+        mapping:
+          greater: "#/components/schemas/GreaterThreshold"
+          lesser:  "#/components/schemas/LesserThreshold"
+          range: "#/components/schemas/RangeThreshold"
     DeadmanCheck:
       allOf:
         - $ref: "#/components/schemas/CheckBase"


### PR DESCRIPTION
1. Added a `discriminator` for a `Threshold` schema
1. Added `links` into `CheckBase` schema

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)