### PR TITLE
feat(httpd): Add option to authenticate debug/pprof and ping endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ v1.8.0 [unreleased]
 ### Features
 
 -	[#14315](https://github.com/influxdata/influxdb/pull/14315): Update to go 1.12.7
+-	[#15222](https://github.com/influxdata/influxdb/pull/15222): Add options to authenticate pprof and ping endpoints.
 
 ### Bugfixes
 

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -288,9 +288,18 @@
   # troubleshooting and monitoring.
   # pprof-enabled = true
 
+  # Enables authentication on pprof endpoints. Users will need admin permissions
+  # to access the pprof endpoints when this setting is enabled. This setting has
+  # no effect if either auth-enabled or pprof-enabled are set to false.
+  # pprof-auth-enabled = false
+
   # Enables a pprof endpoint that binds to localhost:6060 immediately on startup.
   # This is only needed to debug startup issues.
   # debug-pprof-enabled = false
+
+  # Enables authentication on the /ping, /metrics, and deprecated /status
+  # endpoints. This setting has no effect if auth-enabled is set to false.
+  # ping-auth-enabled = false
 
   # Determines whether HTTPS is enabled.
   # https-enabled = false

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -41,7 +41,9 @@ type Config struct {
 	FluxEnabled             bool           `toml:"flux-enabled"`
 	FluxLogEnabled          bool           `toml:"flux-log-enabled"`
 	PprofEnabled            bool           `toml:"pprof-enabled"`
+	PprofAuthEnabled        bool           `toml:"pprof-auth-enabled"`
 	DebugPprofEnabled       bool           `toml:"debug-pprof-enabled"`
+	PingAuthEnabled         bool           `toml:"ping-auth-enabled"`
 	HTTPSEnabled            bool           `toml:"https-enabled"`
 	HTTPSCertificate        string         `toml:"https-certificate"`
 	HTTPSPrivateKey         string         `toml:"https-private-key"`
@@ -71,7 +73,9 @@ func NewConfig() Config {
 		BindAddress:           DefaultBindAddress,
 		LogEnabled:            true,
 		PprofEnabled:          true,
+		PprofAuthEnabled:      false,
 		DebugPprofEnabled:     false,
+		PingAuthEnabled:       false,
 		HTTPSEnabled:          false,
 		HTTPSCertificate:      "/etc/ssl/influxdb.pem",
 		MaxRowLimit:           0,

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -594,6 +594,158 @@ func TestHandler_Query_CloseNotify(t *testing.T) {
 	}
 }
 
+// Ensure the handler returns an appropriate 401 status when authentication
+// fails on ping endpoints.
+func TestHandler_Ping_ErrAuthorize(t *testing.T) {
+	h := NewHandlerWithConfig(NewHandlerConfig(WithAuthentication(), WithPingAuthEnabled()))
+	h.MetaClient.AdminUserExistsFn = func() bool { return true }
+	h.MetaClient.DatabaseFn = func(name string) *meta.DatabaseInfo {
+		return &meta.DatabaseInfo{}
+	}
+	h.MetaClient.AuthenticateFn = func(u, p string) (meta.User, error) {
+		users := []meta.UserInfo{
+			{
+				Name:  "admin",
+				Hash:  "admin",
+				Admin: true,
+			},
+			{
+				Name: "user1",
+				Hash: "abcd",
+				Privileges: map[string]influxql.Privilege{
+					"db0": influxql.ReadPrivilege,
+				},
+			},
+		}
+
+		for _, user := range users {
+			if u == user.Name {
+				if p == user.Hash {
+					return &user, nil
+				}
+				return nil, meta.ErrAuthenticate
+			}
+		}
+		return nil, meta.ErrUserNotFound
+	}
+
+	for i, tt := range []struct {
+		user     string
+		password string
+		query    string
+		code     int
+	}{
+		{
+			query: "/ping",
+			code:  http.StatusUnauthorized,
+		},
+		{
+			user:     "user1",
+			password: "abcd",
+			query:    "/ping",
+			code:     http.StatusNoContent,
+		},
+		{
+			user:     "user2",
+			password: "abcd",
+			query:    "/ping",
+			code:     http.StatusUnauthorized,
+		},
+	} {
+		w := httptest.NewRecorder()
+		r := MustNewJSONRequest("GET", tt.query, nil)
+		params := r.URL.Query()
+		if tt.user != "" {
+			params.Set("u", tt.user)
+		}
+		if tt.password != "" {
+			params.Set("p", tt.password)
+		}
+		r.URL.RawQuery = params.Encode()
+
+		h.ServeHTTP(w, r)
+		if w.Code != tt.code {
+			t.Errorf("%d. unexpected status: got=%d exp=%d\noutput: %s", i, w.Code, tt.code, w.Body.String())
+		}
+	}
+}
+
+// Ensure the handler returns an appropriate 403 status when authentication or
+// authorization fails on debug endpoints.
+func TestHandler_Debug_ErrAuthorize(t *testing.T) {
+	h := NewHandlerWithConfig(NewHandlerConfig(WithAuthentication(), WithPprofAuthEnabled()))
+	h.MetaClient.AdminUserExistsFn = func() bool { return true }
+	h.MetaClient.DatabaseFn = func(name string) *meta.DatabaseInfo {
+		return &meta.DatabaseInfo{}
+	}
+	h.MetaClient.AuthenticateFn = func(u, p string) (meta.User, error) {
+		users := []meta.UserInfo{
+			{
+				Name:  "admin",
+				Hash:  "admin",
+				Admin: true,
+			},
+			{
+				Name: "user1",
+				Hash: "abcd",
+				Privileges: map[string]influxql.Privilege{
+					"db0": influxql.ReadPrivilege,
+				},
+			},
+		}
+
+		for _, user := range users {
+			if u == user.Name {
+				if p == user.Hash {
+					return &user, nil
+				}
+				return nil, meta.ErrAuthenticate
+			}
+		}
+		return nil, meta.ErrUserNotFound
+	}
+
+	for i, tt := range []struct {
+		user     string
+		password string
+		query    string
+		code     int
+	}{
+		{
+			query: "/debug/vars",
+			code:  http.StatusUnauthorized,
+		},
+		{
+			user:     "user1",
+			password: "abcd",
+			query:    "/debug/vars",
+			code:     http.StatusForbidden,
+		},
+		{
+			user:     "user2",
+			password: "abcd",
+			query:    "/debug/vars",
+			code:     http.StatusUnauthorized,
+		},
+	} {
+		w := httptest.NewRecorder()
+		r := MustNewJSONRequest("GET", tt.query, nil)
+		params := r.URL.Query()
+		if tt.user != "" {
+			params.Set("u", tt.user)
+		}
+		if tt.password != "" {
+			params.Set("p", tt.password)
+		}
+		r.URL.RawQuery = params.Encode()
+
+		h.ServeHTTP(w, r)
+		if w.Code != tt.code {
+			t.Errorf("%d. unexpected status: got=%d exp=%d\noutput: %s", i, w.Code, tt.code, w.Body.String())
+		}
+	}
+}
+
 // Ensure the prometheus remote write works with valid values.
 func TestHandler_PromWrite(t *testing.T) {
 	req := &remote.WriteRequest{
@@ -1308,7 +1460,6 @@ func TestHandler_Flux_Auth(t *testing.T) {
 }
 
 // Ensure the handler handles ping requests correctly.
-// TODO: This should be expanded to verify the MetaClient check in servePing is working correctly
 func TestHandler_Ping(t *testing.T) {
 	h := NewHandler(false)
 	w := httptest.NewRecorder()
@@ -1685,6 +1836,19 @@ func WithAuthentication() configOption {
 	return func(c *httpd.Config) {
 		c.AuthEnabled = true
 		c.SharedSecret = "super secret key"
+	}
+}
+
+func WithPprofAuthEnabled() configOption {
+	return func(c *httpd.Config) {
+		c.PprofEnabled = true
+		c.PprofAuthEnabled = true
+	}
+}
+
+func WithPingAuthEnabled() configOption {
+	return func(c *httpd.Config) {
+		c.PingAuthEnabled = true
 	}
 }
 


### PR DESCRIPTION
Adds `pprof-auth-enabled` and `ping-auth-enabled` configuration options which can enable authentication on all `/debug` and `/ping` endpoints. This also covers the prometheus `/metrics` and deprecated `/status` endpoints.

With these additions, all InfluxDB endpoints will require authentication with the following configuration:

```
[http]
  auth-enabled = true
  pprof-auth-enabled = true
  ping-auth-enabled = true
```

Note that `go tool pprof` does not support authentication so it will not work when `pprof-auth-enabled` is enabled.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
