### PR TITLE
fix(notification/rule): fixed http NotificationRule

### DIFF
--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -129,7 +129,7 @@ func NewNotificationRuleHandler(b *NotificationRuleBackend) *NotificationRuleHan
 		LabelService:     b.LabelService,
 		ResourceType:     influxdb.TelegrafsResourceType,
 	}
-	h.HandlerFunc("GET", notificationRulesIDLabelsIDPath, newGetLabelsHandler(labelBackend))
+	h.HandlerFunc("GET", notificationRulesIDLabelsPath, newGetLabelsHandler(labelBackend))
 	h.HandlerFunc("POST", notificationRulesIDLabelsPath, newPostLabelHandler(labelBackend))
 	h.HandlerFunc("DELETE", notificationRulesIDLabelsIDPath, newDeleteLabelHandler(labelBackend))
 

--- a/kv/notification_rule.go
+++ b/kv/notification_rule.go
@@ -335,7 +335,7 @@ func (s *Service) findNotificationRuleByID(ctx context.Context, tx Tx, id influx
 // Additional options provide pagination & sorting.
 func (s *Service) FindNotificationRules(ctx context.Context, filter influxdb.NotificationRuleFilter, opt ...influxdb.FindOptions) (nrs []influxdb.NotificationRule, n int, err error) {
 	err = s.kv.View(ctx, func(tx Tx) error {
-		nrs, n, err = s.findNotificationRules(ctx, tx, filter)
+		nrs, n, err = s.findNotificationRules(ctx, tx, filter, opt...)
 		return err
 	})
 	return nrs, n, err

--- a/testing/notification_rule.go
+++ b/testing/notification_rule.go
@@ -608,6 +608,7 @@ func FindNotificationRules(
 ) {
 	type args struct {
 		filter influxdb.NotificationRuleFilter
+		opts   influxdb.FindOptions
 	}
 
 	type wants struct {
@@ -1339,6 +1340,207 @@ func FindNotificationRules(
 			},
 		},
 		{
+			name: "find options limit",
+			fields: NotificationRuleFields{
+				Orgs: []*influxdb.Organization{
+					{
+						ID:   MustIDBase16(oneID),
+						Name: "org1",
+					},
+					{
+						ID:   MustIDBase16(fourID),
+						Name: "org4",
+					},
+				},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: influxdb.NotificationRuleResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: influxdb.NotificationRuleResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+					},
+					{
+						ResourceID:   MustIDBase16(fourID),
+						ResourceType: influxdb.NotificationRuleResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+				},
+				NotificationRules: []influxdb.NotificationRule{
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(oneID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr1",
+						},
+						Channel:         "ch1",
+						MessageTemplate: "msg1",
+					},
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(twoID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr2",
+						},
+						MessageTemplate: "body2",
+					},
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(fourID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr3",
+						},
+						MessageTemplate: "msg",
+					},
+				},
+			},
+			args: args{
+				filter: influxdb.NotificationRuleFilter{
+					OrgID: idPtr(MustIDBase16(oneID)),
+				},
+				opts: influxdb.FindOptions{
+					Limit: 2,
+				},
+			},
+			wants: wants{
+				notificationRules: []influxdb.NotificationRule{
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(oneID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr1",
+						},
+						Channel:         "ch1",
+						MessageTemplate: "msg1",
+					},
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(twoID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr2",
+						},
+						MessageTemplate: "body2",
+					},
+				},
+			},
+		},
+		{
+			name: "find options offset",
+			fields: NotificationRuleFields{
+				Orgs: []*influxdb.Organization{
+					{
+						ID:   MustIDBase16(oneID),
+						Name: "org1",
+					},
+					{
+						ID:   MustIDBase16(fourID),
+						Name: "org4",
+					},
+				},
+				UserResourceMappings: []*influxdb.UserResourceMapping{
+					{
+						ResourceID:   MustIDBase16(oneID),
+						ResourceType: influxdb.NotificationRuleResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+					{
+						ResourceID:   MustIDBase16(twoID),
+						ResourceType: influxdb.NotificationRuleResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Member,
+					},
+					{
+						ResourceID:   MustIDBase16(fourID),
+						ResourceType: influxdb.NotificationRuleResourceType,
+						UserID:       MustIDBase16(sixID),
+						UserType:     influxdb.Owner,
+					},
+				},
+				NotificationRules: []influxdb.NotificationRule{
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(oneID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr1",
+						},
+						Channel:         "ch1",
+						MessageTemplate: "msg1",
+					},
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(twoID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr2",
+						},
+						MessageTemplate: "body2",
+					},
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(fourID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr3",
+						},
+						MessageTemplate: "msg",
+					},
+				},
+			},
+			args: args{
+				filter: influxdb.NotificationRuleFilter{
+					OrgID: idPtr(MustIDBase16(oneID)),
+				},
+				opts: influxdb.FindOptions{
+					Offset: 1,
+				},
+			},
+			wants: wants{
+				notificationRules: []influxdb.NotificationRule{
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(twoID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr2",
+						},
+						MessageTemplate: "body2",
+					},
+					&rule.Slack{
+						Base: rule.Base{
+							ID:         MustIDBase16(fourID),
+							OrgID:      MustIDBase16(oneID),
+							EndpointID: 1,
+							OwnerID:    MustIDBase16(sixID),
+							Name:       "nr3",
+						},
+						MessageTemplate: "msg",
+					},
+				},
+			},
+		},
+		{
 			name: "find nothing",
 			fields: NotificationRuleFields{
 				Orgs: []*influxdb.Organization{
@@ -1423,7 +1625,7 @@ func FindNotificationRules(
 			defer done()
 			ctx := context.Background()
 
-			nrs, n, err := s.FindNotificationRules(ctx, tt.args.filter)
+			nrs, n, err := s.FindNotificationRules(ctx, tt.args.filter, tt.args.opts)
 			ErrorsEqual(t, err, tt.wants.err)
 			if n != len(tt.wants.notificationRules) {
 				t.Fatalf("notification rules length is different got %d, want %d", n, len(tt.wants.notificationRules))


### PR DESCRIPTION
1. Fixed handler path for a list of all labels for a notification rule
1. Fixed filtering `NotificationRules` by `limit` and `offset`

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
