### PR TITLE
fix(storage): remove level=0 from TSM disk bytes metrics.

### DIFF
--- a/storage/engine_test.go
+++ b/storage/engine_test.go
@@ -384,7 +384,7 @@ func TestEngine_InitializeMetrics(t *testing.T) {
 	files := promtest.MustFindMetric(t, mfs, "storage_tsm_files_total", prometheus.Labels{
 		"node_id":   fmt.Sprint(engine.nodeID),
 		"engine_id": fmt.Sprint(engine.engineID),
-		"level":     "0",
+		"level":     "1",
 	})
 	if m, got, exp := files, files.GetGauge().GetValue(), 0.0; got != exp {
 		t.Errorf("[%s] got %v, expected %v", m, got, exp)
@@ -393,7 +393,7 @@ func TestEngine_InitializeMetrics(t *testing.T) {
 	bytes := promtest.MustFindMetric(t, mfs, "storage_tsm_files_disk_bytes", prometheus.Labels{
 		"node_id":   fmt.Sprint(engine.nodeID),
 		"engine_id": fmt.Sprint(engine.engineID),
-		"level":     "0",
+		"level":     "1",
 	})
 	if m, got, exp := bytes, bytes.GetGauge().GetValue(), 0.0; got != exp {
 		t.Errorf("[%s] got %v, expected %v", m, got, exp)

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -625,6 +625,8 @@ func pollForRunStatus(t *testing.T, r *runListener, taskID platform.ID, expCount
 }
 
 func TestScheduler_RunStatus(t *testing.T) {
+	t.Skip("https://github.com/influxdata/influxdb/issues/15273")
+
 	t.Parallel()
 
 	tcs := mock.NewTaskControlService()

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -376,6 +376,14 @@ func (t *fileTracker) ClearFileCounts() {
 	}
 }
 
+func (t *fileTracker) ClearDiskSizes() {
+	labels := t.Labels()
+	for i := uint64(0); i <= 4; i++ {
+		labels["level"] = formatLevel(i)
+		t.metrics.DiskSize.With(labels).Set(float64(0))
+	}
+}
+
 func formatLevel(level uint64) string {
 	if level >= 4 {
 		return "4+"
@@ -676,9 +684,9 @@ func (f *FileStore) Open(ctx context.Context) error {
 	}
 
 	var lm int64
-	counts := make(map[int]uint64, 5)
-	sizes := make(map[int]uint64, 5)
-	for i := 0; i <= 5; i++ {
+	counts := make(map[int]uint64, 4)
+	sizes := make(map[int]uint64, 4)
+	for i := 1; i <= 4; i++ {
 		counts[i] = 0
 		sizes[i] = 0
 	}
@@ -1015,10 +1023,11 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 	f.files = active
 	sort.Sort(tsmReaders(f.files))
 	f.tracker.ClearFileCounts()
+	f.tracker.ClearDiskSizes()
 
 	// Recalculate the disk size stat
-	sizes := make(map[int]uint64, 5)
-	counts := make(map[int]uint64, 5)
+	sizes := make(map[int]uint64, 4)
+	counts := make(map[int]uint64, 4)
 	for _, file := range f.files {
 		size := uint64(file.Size())
 		for _, ts := range file.TombstoneFiles() {

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -370,7 +370,7 @@ func (t *fileTracker) SetFileCount(files map[int]uint64) {
 
 func (t *fileTracker) ClearFileCounts() {
 	labels := t.Labels()
-	for i := uint64(0); i <= 4; i++ {
+	for i := uint64(1); i <= 4; i++ {
 		labels["level"] = formatLevel(i)
 		t.metrics.Files.With(labels).Set(float64(0))
 	}
@@ -378,7 +378,7 @@ func (t *fileTracker) ClearFileCounts() {
 
 func (t *fileTracker) ClearDiskSizes() {
 	labels := t.Labels()
-	for i := uint64(0); i <= 4; i++ {
+	for i := uint64(1); i <= 4; i++ {
 		labels["level"] = formatLevel(i)
 		t.metrics.DiskSize.With(labels).Set(float64(0))
 	}


### PR DESCRIPTION
This commit removes the level=0 label from TSM Disk Usage metrics, since TSM level starts always (from 1 up to 4+).
    ex:

 before fix  :

```
            storage_tsm_files_disk_bytes{engine_id="0",level="0",node_id="0"} 0
            storage_tsm_files_disk_bytes{engine_id="0",level="1",node_id="0"} 3.3855125e+07
            storage_tsm_files_disk_bytes{engine_id="0",level="2",node_id="0"} 2.3737882e+07
            storage_tsm_files_disk_bytes{engine_id="0",level="3",node_id="0"} 1.86620984e+08
```

After fix :

```
            storage_tsm_files_disk_bytes{engine_id="0",level="1",node_id="0"} 3.3855125e+07
            storage_tsm_files_disk_bytes{engine_id="0",level="2",node_id="0"} 2.3737882e+07
            storage_tsm_files_disk_bytes{engine_id="0",level="3",node_id="0"} 1.86620984e+08
``` 
