### PR TITLE
feat(task): add limit function for task concurrency

### DIFF
--- a/task/backend/executor/limits.go
+++ b/task/backend/executor/limits.go
@@ -1,0 +1,56 @@
+package executor
+
+import (
+	"context"
+	"sort"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/task/options"
+)
+
+// ConcurrencyLimit creates a concurrency limit func that uses the executor to determine
+// if they
+func ConcurrencyLimit(exec *TaskExecutor) LimitFunc {
+	return func(t *influxdb.Task, r *influxdb.Run) error {
+		o, err := options.FromScript(t.Flux)
+		if err != nil {
+			return err
+		}
+		if o.Concurrency == nil {
+			return nil
+		}
+
+		runs, err := exec.tcs.CurrentlyRunning(context.Background(), t.ID)
+		if err != nil {
+			return err
+		}
+
+		// sort by scheduledFor time because we want to make sure older scheduled for times
+		// are higher priority
+		sort.SliceStable(runs, func(i, j int) bool {
+			runi, err := runs[i].ScheduledForTime()
+			if err != nil {
+				return false
+			}
+			runj, err := runs[j].ScheduledForTime()
+			if err != nil {
+				return false
+			}
+			return runi.Before(runj)
+		})
+
+		if len(runs) > int(*o.Concurrency) {
+			for i, run := range runs {
+				if run.ID == r.ID {
+					if i >= int(*o.Concurrency) {
+						return influxdb.ErrTaskConcurrencyLimitReached(i - int(*o.Concurrency))
+					}
+					return nil // no need to keep looping.
+				}
+			}
+			// this run isn't currently running. but we have more run's then the concurrency allows
+			return influxdb.ErrTaskConcurrencyLimitReached(len(runs) - int(*o.Concurrency))
+		}
+		return nil
+	}
+}

--- a/task/backend/executor/limits.go
+++ b/task/backend/executor/limits.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ConcurrencyLimit creates a concurrency limit func that uses the executor to determine
-// if they
+// if the task has exceeded the concurrency limit.
 func ConcurrencyLimit(exec *TaskExecutor) LimitFunc {
 	return func(t *influxdb.Task, r *influxdb.Run) error {
 		o, err := options.FromScript(t.Flux)

--- a/task/backend/executor/limits_test.go
+++ b/task/backend/executor/limits_test.go
@@ -1,0 +1,57 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb"
+)
+
+var (
+	taskWith1Concurrency  = &influxdb.Task{ID: 1, Flux: `option task = {concurrency: 1, name:"x", every:1m} from(bucket:"b-src") |> range(start:-1m) |> to(bucket:"b-dst", org:"o")`}
+	taskWith10Concurrency = &influxdb.Task{ID: 1, Flux: `option task = {concurrency: 10, name:"x", every:1m} from(bucket:"b-src") |> range(start:-1m) |> to(bucket:"b-dst", org:"o")`}
+)
+
+func TestTaskConcurrency(t *testing.T) {
+	tes := taskExecutorSystem(t)
+	te := tes.ex
+	r1, err := te.tcs.CreateRun(context.Background(), taskWith1Concurrency.ID, time.Now().Add(-4*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := te.tcs.CreateRun(context.Background(), taskWith1Concurrency.ID, time.Now().Add(-3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r3, err := te.tcs.CreateRun(context.Background(), taskWith1Concurrency.ID, time.Now().Add(-2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r4 := &influxdb.Run{
+		ID:           3,
+		ScheduledFor: time.Now().Format(time.RFC3339),
+	}
+
+	clFunc := ConcurrencyLimit(te)
+	if err := clFunc(taskWith1Concurrency, r1); err != nil {
+		t.Fatal(err)
+	}
+	if err := clFunc(taskWith1Concurrency, r2); err == nil {
+		t.Fatal("failed to error when exceeding limit by 1")
+	}
+	if err := clFunc(taskWith1Concurrency, r3); err == nil {
+		t.Fatal("failed to error when exceeding limit by 2")
+	}
+	if err := clFunc(taskWith1Concurrency, r4); err == nil {
+		t.Fatal("failed to error when exceeding limit before saving run")
+	}
+
+	if err := clFunc(taskWith10Concurrency, r4); err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO(lh): add testing around infinite concurrency once the task options
+	// are not setting a default concurrency to 1.
+}

--- a/task/backend/executor/task_executor_test.go
+++ b/task/backend/executor/task_executor_test.go
@@ -264,7 +264,7 @@ func testLimitFunc(t *testing.T) {
 	tes.svc.FailNextQuery(forcedErr)
 
 	count := 0
-	tes.ex.SetLimitFunc(func(*influxdb.Run) error {
+	tes.ex.SetLimitFunc(func(*influxdb.Task, *influxdb.Run) error {
 		count++
 		if count < 2 {
 			return errors.New("not there yet")

--- a/task_errors.go
+++ b/task_errors.go
@@ -193,3 +193,11 @@ func ErrRunExecutionError(err error) *Error {
 		Err:  err,
 	}
 }
+
+func ErrTaskConcurrencyLimitReached(runsInFront int) *Error {
+	return &Error{
+		Code: ETooManyRequests,
+		Msg:  fmt.Sprintf("could not execute task, concurrency limit reached, runs in front: %d", runsInFront),
+		Op:   "taskExecutor",
+	}
+}


### PR DESCRIPTION
The new task executor handles limit's differently then the old executor
instead of front loading limits by creating a runner for every task that might run
the new executor has a large worker pool and queue. This allow's us to have a unlimited
concurrency per task and helps us avoid a back log of task's execution based on a
arbitrary execution limit. This add's the ability to add an optional task execution limit
so a user can still have the advantages of limiting concurrency.
