### PR TITLE
fix(influxdb): Always return user status

### DIFF
--- a/bolt/user.go
+++ b/bolt/user.go
@@ -324,6 +324,10 @@ func (c *Client) updateUser(ctx context.Context, tx *bolt.Tx, id platform.ID, up
 		u.Name = *upd.Name
 	}
 
+	if upd.Status != nil {
+		u.Status = *upd.Status
+	}
+
 	if err := c.appendUserEventToLog(ctx, tx, u.ID, userUpdatedEvent); err != nil {
 		return nil, &platform.Error{
 			Err: err,

--- a/http/bucket_test.go
+++ b/http/bucket_test.go
@@ -917,8 +917,9 @@ func TestService_handlePostBucketMember(t *testing.T) {
 				UserService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id platform.ID) (*platform.User, error) {
 						return &platform.User{
-							ID:   id,
-							Name: "name",
+							ID:     id,
+							Name:   "name",
+							Status: platform.Active,
 						}, nil
 					},
 				},
@@ -940,7 +941,8 @@ func TestService_handlePostBucketMember(t *testing.T) {
   },
   "role": "member",
   "id": "6f626f7274697320",
-  "name": "name"
+	"name": "name",
+	"status": "active"
 }
 `,
 			},
@@ -1009,8 +1011,9 @@ func TestService_handlePostBucketOwner(t *testing.T) {
 				UserService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id platform.ID) (*platform.User, error) {
 						return &platform.User{
-							ID:   id,
-							Name: "name",
+							ID:     id,
+							Name:   "name",
+							Status: platform.Active,
 						}, nil
 					},
 				},
@@ -1032,7 +1035,8 @@ func TestService_handlePostBucketOwner(t *testing.T) {
   },
   "role": "owner",
   "id": "6f626f7274697320",
-  "name": "name"
+	"name": "name",
+	"status": "active"
 }
 `,
 			},

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -1260,8 +1260,9 @@ func TestService_handlePostCheckMember(t *testing.T) {
 				UserService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
 						return &influxdb.User{
-							ID:   id,
-							Name: "name",
+							ID:     id,
+							Name:   "name",
+							Status: influxdb.Active,
 						}, nil
 					},
 				},
@@ -1283,7 +1284,8 @@ func TestService_handlePostCheckMember(t *testing.T) {
   },
   "role": "member",
   "id": "6f626f7274697320",
-  "name": "name"
+	"name": "name",
+	"status": "active"
 }
 `,
 			},
@@ -1357,8 +1359,9 @@ func TestService_handlePostCheckOwner(t *testing.T) {
 				UserService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
 						return &influxdb.User{
-							ID:   id,
-							Name: "name",
+							ID:     id,
+							Name:   "name",
+							Status: influxdb.Active,
 						}, nil
 					},
 				},
@@ -1380,7 +1383,8 @@ func TestService_handlePostCheckOwner(t *testing.T) {
   },
   "role": "owner",
   "id": "6f626f7274697320",
-  "name": "name"
+	"name": "name",
+	"status": "active"
 }
 `,
 			},

--- a/http/notification_endpoint_test.go
+++ b/http/notification_endpoint_test.go
@@ -1011,8 +1011,9 @@ func TestService_handlePostNotificationEndpointMember(t *testing.T) {
 				UserService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
 						return &influxdb.User{
-							ID:   id,
-							Name: "name",
+							ID:     id,
+							Name:   "name",
+							Status: influxdb.Active,
 						}, nil
 					},
 				},
@@ -1034,7 +1035,8 @@ func TestService_handlePostNotificationEndpointMember(t *testing.T) {
   },
   "role": "member",
   "id": "6f626f7274697320",
-  "name": "name"
+	"name": "name",
+	"status": "active"
 }
 `,
 			},
@@ -1104,8 +1106,9 @@ func TestService_handlePostNotificationEndpointOwner(t *testing.T) {
 				UserService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id influxdb.ID) (*influxdb.User, error) {
 						return &influxdb.User{
-							ID:   id,
-							Name: "name",
+							ID:     id,
+							Name:   "name",
+							Status: influxdb.Active,
 						}, nil
 					},
 				},
@@ -1127,7 +1130,8 @@ func TestService_handlePostNotificationEndpointOwner(t *testing.T) {
   },
   "role": "owner",
   "id": "6f626f7274697320",
-  "name": "name"
+	"name": "name",
+	"status": "active"
 }
 `,
 			},

--- a/http/user_resource_mapping_test.go
+++ b/http/user_resource_mapping_test.go
@@ -43,7 +43,7 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 			fields: fields{
 				userService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id platform.ID) (*platform.User, error) {
-						return &platform.User{ID: id, Name: fmt.Sprintf("user%s", id)}, nil
+						return &platform.User{ID: id, Name: fmt.Sprintf("user%s", id), Status: platform.Active}, nil
 					},
 				},
 				userResourceMappingService: &mock.UserResourceMappingService{
@@ -86,7 +86,8 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
       },
       "id": "0000000000000001",
       "name": "user0000000000000001",
-      "role": "member"
+			"role": "member",
+			"status": "active"
     },
     {
       "links": {
@@ -95,7 +96,8 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
       },
       "id": "0000000000000002",
       "name": "user0000000000000002",
-      "role": "member"
+      "role": "member",
+			"status": "active"
     }
   ]
 }`,
@@ -107,7 +109,7 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
 			fields: fields{
 				userService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id platform.ID) (*platform.User, error) {
-						return &platform.User{ID: id, Name: fmt.Sprintf("user%s", id)}, nil
+						return &platform.User{ID: id, Name: fmt.Sprintf("user%s", id), Status: platform.Active}, nil
 					},
 				},
 				userResourceMappingService: &mock.UserResourceMappingService{
@@ -150,7 +152,8 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
       },
       "id": "0000000000000001",
       "name": "user0000000000000001",
-      "role": "owner"
+      "role": "owner",
+			"status": "active"
     },
     {
       "links": {
@@ -159,7 +162,8 @@ func TestUserResourceMappingService_GetMembersHandler(t *testing.T) {
       },
       "id": "0000000000000002",
       "name": "user0000000000000002",
-      "role": "owner"
+			"role": "owner",
+			"status": "active"
     }
   ]
 }`,
@@ -247,7 +251,7 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 			fields: fields{
 				userService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id platform.ID) (*platform.User, error) {
-						return &platform.User{ID: id, Name: fmt.Sprintf("user%s", id)}, nil
+						return &platform.User{ID: id, Name: fmt.Sprintf("user%s", id), Status: platform.Active}, nil
 					},
 				},
 				userResourceMappingService: &mock.UserResourceMappingService{
@@ -259,8 +263,9 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 			args: args{
 				resourceID: "0000000000000099",
 				user: platform.User{
-					ID:   1,
-					Name: "user0000000000000001",
+					ID:     1,
+					Name:   "user0000000000000001",
+					Status: platform.Active,
 				},
 				userType: platform.Member,
 			},
@@ -275,7 +280,8 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 	},
 	"id": "0000000000000001",
 	"name": "user0000000000000001",
-	"role": "member"
+	"role": "member",
+	"status": "active"
 }`,
 			},
 		},
@@ -285,7 +291,7 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 			fields: fields{
 				userService: &mock.UserService{
 					FindUserByIDFn: func(ctx context.Context, id platform.ID) (*platform.User, error) {
-						return &platform.User{ID: id, Name: fmt.Sprintf("user%s", id)}, nil
+						return &platform.User{ID: id, Name: fmt.Sprintf("user%s", id), Status: platform.Active}, nil
 					},
 				},
 				userResourceMappingService: &mock.UserResourceMappingService{
@@ -297,8 +303,9 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 			args: args{
 				resourceID: "0000000000000099",
 				user: platform.User{
-					ID:   2,
-					Name: "user0000000000000002",
+					ID:     2,
+					Name:   "user0000000000000002",
+					Status: platform.Active,
 				},
 				userType: platform.Owner,
 			},
@@ -313,7 +320,8 @@ func TestUserResourceMappingService_PostMembersHandler(t *testing.T) {
 	},
 	"id": "0000000000000002",
 	"name": "user0000000000000002",
-	"role": "owner"
+	"role": "owner",
+	"status": "active"
 }`,
 			},
 		},

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -149,6 +149,10 @@ func (h *UserHandler) handlePostUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.User.Status == "" {
+		req.User.Status = influxdb.Active
+	}
+
 	if err := h.UserService.CreateUser(ctx, req.User); err != nil {
 		h.HandleHTTPError(ctx, err, w)
 		return

--- a/inmem/user_service.go
+++ b/inmem/user_service.go
@@ -181,6 +181,10 @@ func (s *Service) UpdateUser(ctx context.Context, id platform.ID, upd platform.U
 		o.Name = *upd.Name
 	}
 
+	if upd.Status != nil {
+		o.Status = *upd.Status
+	}
+
 	s.userKV.Store(o.ID.String(), o)
 
 	return o, nil

--- a/testing/user_service.go
+++ b/testing/user_service.go
@@ -104,14 +104,16 @@ func CreateUser(
 			},
 			args: args{
 				user: &platform.User{
-					Name: "name1",
+					Name:   "name1",
+					Status: platform.Active,
 				},
 			},
 			wants: wants{
 				users: []*platform.User{
 					{
-						Name: "name1",
-						ID:   MustIDBase16(userOneID),
+						Name:   "name1",
+						ID:     MustIDBase16(userOneID),
+						Status: platform.Active,
 					},
 				},
 			},
@@ -122,25 +124,29 @@ func CreateUser(
 				IDGenerator: mock.NewIDGenerator(userTwoID, t),
 				Users: []*platform.User{
 					{
-						ID:   MustIDBase16(userOneID),
-						Name: "user1",
+						ID:     MustIDBase16(userOneID),
+						Name:   "user1",
+						Status: platform.Active,
 					},
 				},
 			},
 			args: args{
 				user: &platform.User{
-					Name: "user2",
+					Name:   "user2",
+					Status: platform.Active,
 				},
 			},
 			wants: wants{
 				users: []*platform.User{
 					{
-						ID:   MustIDBase16(userOneID),
-						Name: "user1",
+						ID:     MustIDBase16(userOneID),
+						Name:   "user1",
+						Status: platform.Active,
 					},
 					{
-						ID:   MustIDBase16(userTwoID),
-						Name: "user2",
+						ID:     MustIDBase16(userTwoID),
+						Name:   "user2",
+						Status: platform.Active,
 					},
 				},
 			},
@@ -772,8 +778,9 @@ func UpdateUser(
 	t *testing.T,
 ) {
 	type args struct {
-		name string
-		id   platform.ID
+		name   string
+		id     platform.ID
+		status string
 	}
 	type wants struct {
 		err  error
@@ -808,6 +815,34 @@ func UpdateUser(
 				user: &platform.User{
 					ID:   MustIDBase16(userOneID),
 					Name: "changed",
+				},
+			},
+		},
+		{
+			name: "update status",
+			fields: UserFields{
+				Users: []*platform.User{
+					{
+						ID:     MustIDBase16(userOneID),
+						Name:   "user1",
+						Status: platform.Active,
+					},
+					{
+						ID:     MustIDBase16(userTwoID),
+						Name:   "user2",
+						Status: platform.Active,
+					},
+				},
+			},
+			args: args{
+				id:     MustIDBase16(userOneID),
+				status: "inactive",
+			},
+			wants: wants{
+				user: &platform.User{
+					ID:     MustIDBase16(userOneID),
+					Name:   "user1",
+					Status: "inactive",
 				},
 			},
 		},
@@ -848,6 +883,15 @@ func UpdateUser(
 			upd := platform.UserUpdate{}
 			if tt.args.name != "" {
 				upd.Name = &tt.args.name
+			}
+
+			switch tt.args.status {
+			case "inactive":
+				status := platform.Inactive
+				upd.Status = &status
+			case "active":
+				status := platform.Inactive
+				upd.Status = &status
 			}
 
 			user, err := s.UpdateUser(ctx, tt.args.id, upd)

--- a/user.go
+++ b/user.go
@@ -21,7 +21,7 @@ type User struct {
 	ID      ID     `json:"id,omitempty"`
 	Name    string `json:"name"`
 	OAuthID string `json:"oauthID,omitempty"`
-	Status  Status `json:"status,omitempty"`
+	Status  Status `json:"status"`
 }
 
 // Valid validates user


### PR DESCRIPTION
Don't omit status on user responses

- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
