### PR TITLE
chore: enable CLAsee checker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  cla-checker:
+    runs-on: ubuntu-latest
+    name: "Check CLA"
+    steps:
+      - name: "Lookup PR Author"
+        uses: influxdata/clasee@v1
+        with:
+          spreadsheet: "1jnRZYSw83oa6hcEBb1lxK6nNvXrWnOzPT8Bz9iR4Q8s"
+          range: "Form Responses!E:E"
+        env:
+          CLASEE_SECRET: ${{ secrets.CLASEE_SECRET }}

--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ Table: keys: [_start, _stop, _field, _measurement]
 
 We recently announced Flux, the MIT-licensed data scripting language (previously named IFQL). The source for Flux is [available on GitHub](https://github.com/influxdata/flux). Learn more about Flux from [CTO Paul Dix's presentation](https://speakerdeck.com/pauldix/flux-number-fluxlang-a-new-time-series-data-scripting-language).
 
+## Contributors
+
+### Contributor License Agreement
+
+All contributors to influxdb are required to sign our Individual Contributor License Agreement which can be found [here](https://influxdata.com/community/cla/). This is also explained in our pull request template.
+
+This is part of the legal framework of the open-source ecosystem that adds some red tape, but protects both the contributor and the company / foundation behind the project. It also gives us the option to relicense the code with a more permissive license in the future.
+
+When a contributor opens a new pull request to influxdb a github action is triggered which looks up the user in our contributor list.
+The configuration for this workflow can be found in the [main workflow](./.github/workflows/main.yml). The public github action itself (clasee) can be found [here](https://github.com/influxdata/clasee).
+
 ## CI and Static Analysis
 
 ### CI


### PR DESCRIPTION
This enabled the clasee github action which checks the influxdata CLA on PR open.

If the contributor has not yet signed the CLA it fails the PR build.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
