### PR TITLE
fix(ui): ignore false change events in VariableForm

### DIFF
--- a/ui/src/dataExplorer/components/SaveAsVariable.tsx
+++ b/ui/src/dataExplorer/components/SaveAsVariable.tsx
@@ -7,11 +7,26 @@ import {connect} from 'react-redux'
 import VariableForm from 'src/variables/components/VariableForm'
 
 // Utils
-import {createVariable} from 'src/variables/actions'
-import {extractVariablesList} from 'src/variables/selectors'
+import {
+  createVariable,
+  updateName,
+  updateType,
+  updateQuery,
+  updateMap,
+  updateConstant,
+  clearEditor,
+} from 'src/variables/actions'
+import {
+  extractVariablesList,
+  extractVariableEditorName,
+  extractVariableEditorType,
+  extractVariableEditorQuery,
+  extractVariableEditorMap,
+  extractVariableEditorConstant,
+} from 'src/variables/selectors'
 
 // Types
-import {AppState} from 'src/types'
+import {AppState, VariableArguments, VariableArgumentType} from 'src/types'
 import {getActiveQuery} from 'src/timeMachine/selectors'
 import {IVariable as Variable} from '@influxdata/influx'
 
@@ -21,11 +36,22 @@ interface OwnProps {
 
 interface DispatchProps {
   onCreateVariable: typeof createVariable
+  onNameUpdate: typeof updateName
+  onTypeUpdate: typeof updateType
+  onQueryUpdate: typeof updateQuery
+  onMapUpdate: typeof updateMap
+  onConstantUpdate: typeof updateConstant
+  onEditorClose: typeof clearEditor
 }
 
 interface StateProps {
   initialScript?: string
   variables: Variable[]
+  name: string
+  variableType: VariableArgumentType
+  query: VariableArguments
+  map: VariableArguments
+  constant: VariableArguments
 }
 
 type Props = StateProps & DispatchProps & OwnProps
@@ -33,35 +59,77 @@ type Props = StateProps & DispatchProps & OwnProps
 class SaveAsVariable extends PureComponent<Props & WithRouterProps> {
   render() {
     const {
-      onHideOverlay,
       onCreateVariable,
+      onNameUpdate,
+      onTypeUpdate,
+      onQueryUpdate,
+      onMapUpdate,
+      onConstantUpdate,
+      name,
       initialScript,
       variables,
+      variableType,
+      query,
+      map,
+      constant,
     } = this.props
 
     return (
       <VariableForm
-        onHideOverlay={onHideOverlay}
-        onCreateVariable={onCreateVariable}
-        initialScript={initialScript}
+        name={name}
+        variableType={variableType}
+        query={query}
+        map={map}
+        constant={constant}
         variables={variables}
+        initialScript={initialScript}
+        onHideOverlay={this.handleHideOverlay}
+        onCreateVariable={onCreateVariable}
+        onNameUpdate={onNameUpdate}
+        onTypeUpdate={onTypeUpdate}
+        onQueryUpdate={onQueryUpdate}
+        onMapUpdate={onMapUpdate}
+        onConstantUpdate={onConstantUpdate}
       />
     )
+  }
+
+  private handleHideOverlay = () => {
+    const {onEditorClose, onHideOverlay} = this.props
+
+    onEditorClose()
+    onHideOverlay()
   }
 }
 
 const mstp = (state: AppState): StateProps => {
-  const activeQuery = getActiveQuery(state)
-  const variables = extractVariablesList(state)
+  const activeQuery = getActiveQuery(state),
+    variables = extractVariablesList(state),
+    name = extractVariableEditorName(state),
+    variableType = extractVariableEditorType(state),
+    query = extractVariableEditorQuery(state),
+    map = extractVariableEditorMap(state),
+    constant = extractVariableEditorConstant(state)
 
   return {
     initialScript: activeQuery.text,
     variables,
+    name,
+    variableType,
+    query,
+    map,
+    constant,
   }
 }
 
 const mdtp = {
   onCreateVariable: createVariable,
+  onNameUpdate: updateName,
+  onTypeUpdate: updateType,
+  onQueryUpdate: updateQuery,
+  onMapUpdate: updateMap,
+  onConstantUpdate: updateConstant,
+  onEditorClose: clearEditor,
 }
 
 export default connect<StateProps, DispatchProps, OwnProps>(

--- a/ui/src/dataExplorer/components/SaveAsVariable.tsx
+++ b/ui/src/dataExplorer/components/SaveAsVariable.tsx
@@ -41,7 +41,7 @@ const mstp = (state: AppState): StateProps => {
   }
 }
 
-export default connect<StateProps, void, OwnProps>(
+export default connect<StateProps, {}, OwnProps>(
   mstp,
-  () => {}
+  null
 )(withRouter<Props>(SaveAsVariable))

--- a/ui/src/dataExplorer/components/SaveAsVariable.tsx
+++ b/ui/src/dataExplorer/components/SaveAsVariable.tsx
@@ -4,135 +4,44 @@ import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
-import VariableForm from 'src/variables/components/VariableForm'
-
-// Utils
-import {
-  createVariable,
-  updateName,
-  updateType,
-  updateQuery,
-  updateMap,
-  updateConstant,
-  clearEditor,
-} from 'src/variables/actions'
-import {
-  extractVariablesList,
-  extractVariableEditorName,
-  extractVariableEditorType,
-  extractVariableEditorQuery,
-  extractVariableEditorMap,
-  extractVariableEditorConstant,
-} from 'src/variables/selectors'
+import VariableFormContext from 'src/variables/components/VariableFormContext'
 
 // Types
-import {AppState, VariableArguments, VariableArgumentType} from 'src/types'
+import {AppState} from 'src/types'
 import {getActiveQuery} from 'src/timeMachine/selectors'
-import {IVariable as Variable} from '@influxdata/influx'
 
 interface OwnProps {
   onHideOverlay: () => void
 }
 
-interface DispatchProps {
-  onCreateVariable: typeof createVariable
-  onNameUpdate: typeof updateName
-  onTypeUpdate: typeof updateType
-  onQueryUpdate: typeof updateQuery
-  onMapUpdate: typeof updateMap
-  onConstantUpdate: typeof updateConstant
-  onEditorClose: typeof clearEditor
-}
-
 interface StateProps {
   initialScript?: string
-  variables: Variable[]
-  name: string
-  variableType: VariableArgumentType
-  query: VariableArguments
-  map: VariableArguments
-  constant: VariableArguments
 }
 
-type Props = StateProps & DispatchProps & OwnProps
+type Props = StateProps & OwnProps
 
 class SaveAsVariable extends PureComponent<Props & WithRouterProps> {
   render() {
-    const {
-      onCreateVariable,
-      onNameUpdate,
-      onTypeUpdate,
-      onQueryUpdate,
-      onMapUpdate,
-      onConstantUpdate,
-      name,
-      initialScript,
-      variables,
-      variableType,
-      query,
-      map,
-      constant,
-    } = this.props
+    const {initialScript, onHideOverlay} = this.props
 
     return (
-      <VariableForm
-        name={name}
-        variableType={variableType}
-        query={query}
-        map={map}
-        constant={constant}
-        variables={variables}
+      <VariableFormContext
         initialScript={initialScript}
-        onHideOverlay={this.handleHideOverlay}
-        onCreateVariable={onCreateVariable}
-        onNameUpdate={onNameUpdate}
-        onTypeUpdate={onTypeUpdate}
-        onQueryUpdate={onQueryUpdate}
-        onMapUpdate={onMapUpdate}
-        onConstantUpdate={onConstantUpdate}
+        onHideOverlay={onHideOverlay}
       />
     )
-  }
-
-  private handleHideOverlay = () => {
-    const {onEditorClose, onHideOverlay} = this.props
-
-    onEditorClose()
-    onHideOverlay()
   }
 }
 
 const mstp = (state: AppState): StateProps => {
-  const activeQuery = getActiveQuery(state),
-    variables = extractVariablesList(state),
-    name = extractVariableEditorName(state),
-    variableType = extractVariableEditorType(state),
-    query = extractVariableEditorQuery(state),
-    map = extractVariableEditorMap(state),
-    constant = extractVariableEditorConstant(state)
+  const activeQuery = getActiveQuery(state)
 
   return {
     initialScript: activeQuery.text,
-    variables,
-    name,
-    variableType,
-    query,
-    map,
-    constant,
   }
 }
 
-const mdtp = {
-  onCreateVariable: createVariable,
-  onNameUpdate: updateName,
-  onTypeUpdate: updateType,
-  onQueryUpdate: updateQuery,
-  onMapUpdate: updateMap,
-  onConstantUpdate: updateConstant,
-  onEditorClose: clearEditor,
-}
-
-export default connect<StateProps, DispatchProps, OwnProps>(
+export default connect<StateProps, void, OwnProps>(
   mstp,
-  mdtp
+  () => {}
 )(withRouter<Props>(SaveAsVariable))

--- a/ui/src/store/configureStore.ts
+++ b/ui/src/store/configureStore.ts
@@ -20,7 +20,7 @@ import orgsReducer from 'src/organizations/reducers/orgs'
 import onboardingReducer from 'src/onboarding/reducers'
 import noteEditorReducer from 'src/dashboards/reducers/notes'
 import dataLoadingReducer from 'src/dataLoaders/reducers'
-import {variablesReducer} from 'src/variables/reducers'
+import {variablesReducer, variableEditorReducer} from 'src/variables/reducers'
 import {labelsReducer} from 'src/labels/reducers'
 import {bucketsReducer} from 'src/buckets/reducers'
 import {telegrafsReducer} from 'src/telegrafs/reducers'
@@ -56,6 +56,7 @@ export const rootReducer = combineReducers<ReducerState>({
   noteEditor: noteEditorReducer,
   dataLoading: dataLoadingReducer,
   variables: variablesReducer,
+  variableEditor: variableEditorReducer,
   labels: labelsReducer,
   buckets: bucketsReducer,
   telegrafs: telegrafsReducer,

--- a/ui/src/types/arguments.ts
+++ b/ui/src/types/arguments.ts
@@ -1,21 +1,22 @@
-export interface MapArguments {
+interface Argument<T> {
+  type: VariableArgumentType
+  values: T
+}
+
+export interface MapArguments extends Argument<KeyValueMap> {
   type: 'map'
-  values: KeyValueMap
+}
+
+export interface QueryArguments extends Argument<QueryValue> {
+  type: 'query'
+}
+
+export interface CSVArguments extends Argument<string[]> {
+  type: 'constant'
 }
 
 export type KeyValueMap = {[key: string]: string}
-
-export interface QueryArguments {
-  type: 'query'
-  values: {
-    language: 'flux'
-    query: string
-  }
-}
-
-export interface CSVArguments {
-  type: 'constant'
-  values: string[]
-}
+export type QueryValue = {language: 'flux'; query: string}
 
 export type VariableArguments = QueryArguments | MapArguments | CSVArguments
+export type VariableArgumentType = 'query' | 'map' | 'constant'

--- a/ui/src/types/stores.ts
+++ b/ui/src/types/stores.ts
@@ -9,7 +9,7 @@ import {MeState} from 'src/shared/reducers/me'
 import {NoteEditorState} from 'src/dashboards/reducers/notes'
 import {DataLoadingState} from 'src/dataLoaders/reducers'
 import {OnboardingState} from 'src/onboarding/reducers'
-import {VariablesState} from 'src/variables/reducers'
+import {VariablesState, VariableEditorState} from 'src/variables/reducers'
 import {LabelsState} from 'src/labels/reducers'
 import {BucketsState} from 'src/buckets/reducers'
 import {TelegrafsState} from 'src/telegrafs/reducers'
@@ -50,6 +50,7 @@ export interface AppState {
   noteEditor: NoteEditorState
   dataLoading: DataLoadingState
   variables: VariablesState
+  variableEditor: VariableEditorState
   tokens: AuthorizationsState
   templates: TemplatesState
   scrapers: ScrapersState

--- a/ui/src/variables/actions/index.ts
+++ b/ui/src/variables/actions/index.ts
@@ -31,13 +31,79 @@ import * as copy from 'src/shared/copy/notifications'
 // Types
 import {Dispatch} from 'redux-thunk'
 import {RemoteDataState, VariableTemplate} from 'src/types'
-import {GetState} from 'src/types'
+import {GetState, VariableArguments, VariableArgumentType} from 'src/types'
 import {IVariable as Variable, ILabel as Label} from '@influxdata/influx'
 import {VariableValuesByID} from 'src/variables/types'
 import {
   addVariableLabelFailed,
   removeVariableLabelFailed,
 } from 'src/shared/copy/notifications'
+
+export type EditorAction =
+  | ClearEditor
+  | SetName
+  | SelectType
+  | SetQuery
+  | SetMap
+  | SetConstant
+
+interface ClearEditor {
+  type: 'CLEAR_VARIABLE_EDITOR'
+}
+
+export const clearEditor = (): ClearEditor => ({
+  type: 'CLEAR_VARIABLE_EDITOR',
+})
+
+interface SelectType {
+  type: 'CHANGE_VARIABLE_EDITOR_TYPE'
+  payload: VariableArgumentType
+}
+
+export const updateType = (type: VariableArgumentType): SelectType => ({
+  type: 'CHANGE_VARIABLE_EDITOR_TYPE',
+  payload: type,
+})
+
+interface SetName {
+  type: 'UPDATE_VARIABLE_EDITOR_NAME'
+  payload: string
+}
+
+export const updateName = (name: string): SetName => ({
+  type: 'UPDATE_VARIABLE_EDITOR_NAME',
+  payload: name,
+})
+
+interface SetQuery {
+  type: 'UPDATE_VARIABLE_EDITOR_QUERY'
+  payload: VariableArguments
+}
+
+export const updateQuery = (arg: VariableArguments): SetQuery => ({
+  type: 'UPDATE_VARIABLE_EDITOR_QUERY',
+  payload: arg,
+})
+
+interface SetMap {
+  type: 'UPDATE_VARIABLE_EDITOR_MAP'
+  payload: VariableArguments
+}
+
+export const updateMap = (arg: VariableArguments): SetMap => ({
+  type: 'UPDATE_VARIABLE_EDITOR_MAP',
+  payload: arg,
+})
+
+interface SetConstant {
+  type: 'UPDATE_VARIABLE_EDITOR_CONSTANT'
+  payload: VariableArguments
+}
+
+export const updateConstant = (arg: VariableArguments): SetConstant => ({
+  type: 'UPDATE_VARIABLE_EDITOR_CONSTANT',
+  payload: arg,
+})
 
 export type Action =
   | SetVariables

--- a/ui/src/variables/actions/index.ts
+++ b/ui/src/variables/actions/index.ts
@@ -46,170 +46,93 @@ import {
 } from 'src/shared/copy/notifications'
 
 export type EditorAction =
-  | ClearEditor
-  | SetName
-  | SelectType
-  | SetQuery
-  | SetMap
-  | SetConstant
+  | ReturnType<typeof clearEditor>
+  | ReturnType<typeof updateType>
+  | ReturnType<typeof updateName>
+  | ReturnType<typeof updateQuery>
+  | ReturnType<typeof updateMap>
+  | ReturnType<typeof updateConstant>
 
-interface ClearEditor {
-  type: 'CLEAR_VARIABLE_EDITOR'
-}
-
-export const clearEditor = (): ClearEditor => ({
-  type: 'CLEAR_VARIABLE_EDITOR',
+export const clearEditor = () => ({
+  type: 'CLEAR_VARIABLE_EDITOR' as 'CLEAR_VARIABLE_EDITOR',
 })
 
-interface SelectType {
-  type: 'CHANGE_VARIABLE_EDITOR_TYPE'
-  payload: VariableArgumentType
-}
-
-export const updateType = (type: VariableArgumentType): SelectType => ({
-  type: 'CHANGE_VARIABLE_EDITOR_TYPE',
+export const updateType = (type: VariableArgumentType) => ({
+  type: 'CHANGE_VARIABLE_EDITOR_TYPE' as 'CHANGE_VARIABLE_EDITOR_TYPE',
   payload: type,
 })
 
-interface SetName {
-  type: 'UPDATE_VARIABLE_EDITOR_NAME'
-  payload: string
-}
-
-export const updateName = (name: string): SetName => ({
-  type: 'UPDATE_VARIABLE_EDITOR_NAME',
+export const updateName = (name: string) => ({
+  type: 'UPDATE_VARIABLE_EDITOR_NAME' as 'UPDATE_VARIABLE_EDITOR_NAME',
   payload: name,
 })
 
-interface SetQuery {
-  type: 'UPDATE_VARIABLE_EDITOR_QUERY'
-  payload: QueryArguments
-}
-
-export const updateQuery = (arg: QueryArguments): SetQuery => ({
-  type: 'UPDATE_VARIABLE_EDITOR_QUERY',
+export const updateQuery = (arg: QueryArguments) => ({
+  type: 'UPDATE_VARIABLE_EDITOR_QUERY' as 'UPDATE_VARIABLE_EDITOR_QUERY',
   payload: arg,
 })
 
-interface SetMap {
-  type: 'UPDATE_VARIABLE_EDITOR_MAP'
-  payload: MapArguments
-}
-
-export const updateMap = (arg: MapArguments): SetMap => ({
-  type: 'UPDATE_VARIABLE_EDITOR_MAP',
+export const updateMap = (arg: MapArguments) => ({
+  type: 'UPDATE_VARIABLE_EDITOR_MAP' as 'UPDATE_VARIABLE_EDITOR_MAP',
   payload: arg,
 })
 
-interface SetConstant {
-  type: 'UPDATE_VARIABLE_EDITOR_CONSTANT'
-  payload: CSVArguments
-}
-
-export const updateConstant = (arg: CSVArguments): SetConstant => ({
-  type: 'UPDATE_VARIABLE_EDITOR_CONSTANT',
+export const updateConstant = (arg: CSVArguments) => ({
+  type: 'UPDATE_VARIABLE_EDITOR_CONSTANT' as 'UPDATE_VARIABLE_EDITOR_CONSTANT',
   payload: arg,
 })
 
 export type Action =
-  | SetVariables
-  | SetVariable
-  | RemoveVariable
-  | MoveVariable
-  | SetValues
-  | SelectValue
+  | ReturnType<typeof setVariables>
+  | ReturnType<typeof setVariable>
+  | ReturnType<typeof removeVariable>
+  | ReturnType<typeof moveVariable>
+  | ReturnType<typeof setValues>
+  | ReturnType<typeof selectValue>
 
-interface SetVariables {
-  type: 'SET_VARIABLES'
-  payload: {
-    status: RemoteDataState
-    variables?: Variable[]
-  }
-}
-
-const setVariables = (
-  status: RemoteDataState,
-  variables?: Variable[]
-): SetVariables => ({
-  type: 'SET_VARIABLES',
+const setVariables = (status: RemoteDataState, variables?: Variable[]) => ({
+  type: 'SET_VARIABLES' as 'SET_VARIABLES',
   payload: {status, variables},
 })
-
-interface SetVariable {
-  type: 'SET_VARIABLE'
-  payload: {
-    id: string
-    status: RemoteDataState
-    variable?: Variable
-  }
-}
 
 const setVariable = (
   id: string,
   status: RemoteDataState,
   variable?: Variable
-): SetVariable => ({
-  type: 'SET_VARIABLE',
+) => ({
+  type: 'SET_VARIABLE' as 'SET_VARIABLE',
   payload: {id, status, variable},
 })
 
-interface RemoveVariable {
-  type: 'REMOVE_VARIABLE'
-  payload: {id: string}
-}
-
-const removeVariable = (id: string): RemoveVariable => ({
-  type: 'REMOVE_VARIABLE',
+const removeVariable = (id: string) => ({
+  type: 'REMOVE_VARIABLE' as 'REMOVE_VARIABLE',
   payload: {id},
 })
-
-interface MoveVariable {
-  type: 'MOVE_VARIABLE'
-  payload: {originalIndex: number; newIndex: number; contextID: string}
-}
 
 export const moveVariable = (
   originalIndex: number,
   newIndex: number,
   contextID: string
-): MoveVariable => ({
-  type: 'MOVE_VARIABLE',
+) => ({
+  type: 'MOVE_VARIABLE' as 'MOVE_VARIABLE',
   payload: {originalIndex, newIndex, contextID},
 })
-
-interface SetValues {
-  type: 'SET_VARIABLE_VALUES'
-  payload: {
-    contextID: string
-    status: RemoteDataState
-    values?: VariableValuesByID
-  }
-}
 
 const setValues = (
   contextID: string,
   status: RemoteDataState,
   values?: VariableValuesByID
-): SetValues => ({
-  type: 'SET_VARIABLE_VALUES',
+) => ({
+  type: 'SET_VARIABLE_VALUES' as 'SET_VARIABLE_VALUES',
   payload: {contextID, status, values},
 })
-
-interface SelectValue {
-  type: 'SELECT_VARIABLE_VALUE'
-  payload: {
-    contextID: string
-    variableID: string
-    selectedValue: string
-  }
-}
 
 export const selectValue = (
   contextID: string,
   variableID: string,
   selectedValue: string
-): SelectValue => ({
-  type: 'SELECT_VARIABLE_VALUE',
+) => ({
+  type: 'SELECT_VARIABLE_VALUE' as 'SELECT_VARIABLE_VALUE',
   payload: {contextID, variableID, selectedValue},
 })
 

--- a/ui/src/variables/components/CreateVariableOverlay.tsx
+++ b/ui/src/variables/components/CreateVariableOverlay.tsx
@@ -4,10 +4,25 @@ import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
 
 // Utils
-import {extractVariablesList} from 'src/variables/selectors'
+import {
+  extractVariablesList,
+  extractVariableEditorName,
+  extractVariableEditorType,
+  extractVariableEditorQuery,
+  extractVariableEditorMap,
+  extractVariableEditorConstant,
+} from 'src/variables/selectors'
 
 // Actions
-import {createVariable} from 'src/variables/actions'
+import {
+  createVariable,
+  updateName,
+  updateType,
+  updateQuery,
+  updateMap,
+  updateConstant,
+  clearEditor,
+} from 'src/variables/actions'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
@@ -15,22 +30,46 @@ import VariableForm from 'src/variables/components/VariableForm'
 import GetResources, {ResourceType} from 'src/shared/components/GetResources'
 
 // Types
-import {AppState} from 'src/types'
+import {AppState, VariableArguments, VariableArgumentType} from 'src/types'
 import {IVariable as Variable} from '@influxdata/influx'
 
 interface DispatchProps {
   onCreateVariable: typeof createVariable
+  onNameUpdate: typeof updateName
+  onTypeUpdate: typeof updateType
+  onQueryUpdate: typeof updateQuery
+  onMapUpdate: typeof updateMap
+  onConstantUpdate: typeof updateConstant
+  onEditorClose: typeof clearEditor
 }
 
 interface StateProps {
   variables: Variable[]
+  name: string
+  variableType: VariableArgumentType
+  query: VariableArguments
+  map: VariableArguments
+  constant: VariableArguments
 }
 
 type Props = DispatchProps & WithRouterProps & StateProps
 
 class CreateVariableOverlay extends PureComponent<Props> {
   public render() {
-    const {onCreateVariable, variables} = this.props
+    const {
+      onCreateVariable,
+      variables,
+      name,
+      onNameUpdate,
+      onTypeUpdate,
+      onQueryUpdate,
+      onMapUpdate,
+      onConstantUpdate,
+      variableType,
+      query,
+      map,
+      constant,
+    } = this.props
 
     return (
       <GetResources resource={ResourceType.Variables}>
@@ -42,8 +81,18 @@ class CreateVariableOverlay extends PureComponent<Props> {
             />
             <Overlay.Body>
               <VariableForm
+                name={name}
+                variableType={variableType}
+                query={query}
+                map={map}
+                constant={constant}
                 variables={variables}
                 onCreateVariable={onCreateVariable}
+                onNameUpdate={onNameUpdate}
+                onTypeUpdate={onTypeUpdate}
+                onQueryUpdate={onQueryUpdate}
+                onMapUpdate={onMapUpdate}
+                onConstantUpdate={onConstantUpdate}
                 onHideOverlay={this.handleHideOverlay}
               />
             </Overlay.Body>
@@ -57,20 +106,40 @@ class CreateVariableOverlay extends PureComponent<Props> {
     const {
       router,
       params: {orgID},
+      onEditorClose,
     } = this.props
 
+    onEditorClose()
     router.push(`/orgs/${orgID}/settings/variables`)
   }
 }
 
 const mstp = (state: AppState): StateProps => {
-  const variables = extractVariablesList(state)
+  const variables = extractVariablesList(state),
+    name = extractVariableEditorName(state),
+    variableType = extractVariableEditorType(state),
+    query = extractVariableEditorQuery(state),
+    map = extractVariableEditorMap(state),
+    constant = extractVariableEditorConstant(state)
 
-  return {variables}
+  return {
+    variables,
+    name,
+    variableType,
+    query,
+    map,
+    constant,
+  }
 }
 
 const mdtp: DispatchProps = {
   onCreateVariable: createVariable,
+  onNameUpdate: updateName,
+  onTypeUpdate: updateType,
+  onQueryUpdate: updateQuery,
+  onMapUpdate: updateMap,
+  onConstantUpdate: updateConstant,
+  onEditorClose: clearEditor,
 }
 
 export default connect<StateProps, DispatchProps>(

--- a/ui/src/variables/components/CreateVariableOverlay.tsx
+++ b/ui/src/variables/components/CreateVariableOverlay.tsx
@@ -1,76 +1,16 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
-
-// Utils
-import {
-  extractVariablesList,
-  extractVariableEditorName,
-  extractVariableEditorType,
-  extractVariableEditorQuery,
-  extractVariableEditorMap,
-  extractVariableEditorConstant,
-} from 'src/variables/selectors'
-
-// Actions
-import {
-  createVariable,
-  updateName,
-  updateType,
-  updateQuery,
-  updateMap,
-  updateConstant,
-  clearEditor,
-} from 'src/variables/actions'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
-import VariableForm from 'src/variables/components/VariableForm'
+import VariableFormContext from 'src/variables/components/VariableFormContext'
 import GetResources, {ResourceType} from 'src/shared/components/GetResources'
 
-// Types
-import {AppState, VariableArguments, VariableArgumentType} from 'src/types'
-import {IVariable as Variable} from '@influxdata/influx'
-
-interface DispatchProps {
-  onCreateVariable: typeof createVariable
-  onNameUpdate: typeof updateName
-  onTypeUpdate: typeof updateType
-  onQueryUpdate: typeof updateQuery
-  onMapUpdate: typeof updateMap
-  onConstantUpdate: typeof updateConstant
-  onEditorClose: typeof clearEditor
-}
-
-interface StateProps {
-  variables: Variable[]
-  name: string
-  variableType: VariableArgumentType
-  query: VariableArguments
-  map: VariableArguments
-  constant: VariableArguments
-}
-
-type Props = DispatchProps & WithRouterProps & StateProps
+type Props = WithRouterProps
 
 class CreateVariableOverlay extends PureComponent<Props> {
   public render() {
-    const {
-      onCreateVariable,
-      variables,
-      name,
-      onNameUpdate,
-      onTypeUpdate,
-      onQueryUpdate,
-      onMapUpdate,
-      onConstantUpdate,
-      variableType,
-      query,
-      map,
-      constant,
-    } = this.props
-
     return (
       <GetResources resource={ResourceType.Variables}>
         <Overlay visible={true}>
@@ -80,19 +20,7 @@ class CreateVariableOverlay extends PureComponent<Props> {
               onDismiss={this.handleHideOverlay}
             />
             <Overlay.Body>
-              <VariableForm
-                name={name}
-                variableType={variableType}
-                query={query}
-                map={map}
-                constant={constant}
-                variables={variables}
-                onCreateVariable={onCreateVariable}
-                onNameUpdate={onNameUpdate}
-                onTypeUpdate={onTypeUpdate}
-                onQueryUpdate={onQueryUpdate}
-                onMapUpdate={onMapUpdate}
-                onConstantUpdate={onConstantUpdate}
+              <VariableFormContext
                 onHideOverlay={this.handleHideOverlay}
               />
             </Overlay.Body>
@@ -106,43 +34,11 @@ class CreateVariableOverlay extends PureComponent<Props> {
     const {
       router,
       params: {orgID},
-      onEditorClose,
     } = this.props
 
-    onEditorClose()
     router.push(`/orgs/${orgID}/settings/variables`)
   }
 }
 
-const mstp = (state: AppState): StateProps => {
-  const variables = extractVariablesList(state),
-    name = extractVariableEditorName(state),
-    variableType = extractVariableEditorType(state),
-    query = extractVariableEditorQuery(state),
-    map = extractVariableEditorMap(state),
-    constant = extractVariableEditorConstant(state)
-
-  return {
-    variables,
-    name,
-    variableType,
-    query,
-    map,
-    constant,
-  }
-}
-
-const mdtp: DispatchProps = {
-  onCreateVariable: createVariable,
-  onNameUpdate: updateName,
-  onTypeUpdate: updateType,
-  onQueryUpdate: updateQuery,
-  onMapUpdate: updateMap,
-  onConstantUpdate: updateConstant,
-  onEditorClose: clearEditor,
-}
-
-export default connect<StateProps, DispatchProps>(
-  mstp,
-  mdtp
-)(withRouter<{}>(CreateVariableOverlay))
+export { CreateVariableOverlay }
+export default withRouter<{}>(CreateVariableOverlay)

--- a/ui/src/variables/components/CreateVariableOverlay.tsx
+++ b/ui/src/variables/components/CreateVariableOverlay.tsx
@@ -20,9 +20,7 @@ class CreateVariableOverlay extends PureComponent<Props> {
               onDismiss={this.handleHideOverlay}
             />
             <Overlay.Body>
-              <VariableFormContext
-                onHideOverlay={this.handleHideOverlay}
-              />
+              <VariableFormContext onHideOverlay={this.handleHideOverlay} />
             </Overlay.Body>
           </Overlay.Container>
         </Overlay>
@@ -40,5 +38,5 @@ class CreateVariableOverlay extends PureComponent<Props> {
   }
 }
 
-export { CreateVariableOverlay }
+export {CreateVariableOverlay}
 export default withRouter<{}>(CreateVariableOverlay)

--- a/ui/src/variables/components/UpdateVariableOverlay.tsx
+++ b/ui/src/variables/components/UpdateVariableOverlay.tsx
@@ -117,6 +117,7 @@ class UpdateVariableOverlay extends PureComponent<Props, State> {
                 <Grid.Row>
                   <Grid.Column>
                     <VariableArgumentsEditor
+                      variableType={workingVariable.arguments.type}
                       onChange={this.handleChangeArgs}
                       onSelectMapDefault={this.handleSelectMapDefault}
                       selected={workingVariable.selected}

--- a/ui/src/variables/components/VariableArgumentsEditor.tsx
+++ b/ui/src/variables/components/VariableArgumentsEditor.tsx
@@ -13,6 +13,7 @@ import {
   KeyValueMap,
   QueryArguments,
   VariableArguments,
+  VariableArgumentType,
   CSVArguments,
 } from 'src/types'
 
@@ -21,20 +22,21 @@ interface Props {
   onChange: (update: {args: VariableArguments; isValid: boolean}) => void
   onSelectMapDefault: (selectedKey: string) => void
   selected: string[]
+  variableType: VariableArgumentType
 }
 
 class VariableArgumentsEditor extends PureComponent<Props> {
   render() {
-    const {args, onSelectMapDefault, selected} = this.props
+    const {args, onSelectMapDefault, selected, variableType} = this.props
 
-    switch (args.type) {
+    switch (variableType) {
       case 'query':
         return (
           <Form.Element label="Script">
             <Grid.Column>
               <div className="overlay-flux-editor">
                 <FluxEditor
-                  script={args.values.query}
+                  script={(args as QueryArguments).values.query}
                   onChangeScript={this.handleChangeQuery}
                   visibility="visible"
                   suggestions={[]}
@@ -47,7 +49,7 @@ class VariableArgumentsEditor extends PureComponent<Props> {
         return (
           <MapVariableBuilder
             onChange={this.handleChangeMap}
-            values={args.values}
+            values={(args as MapArguments).values}
             onSelectDefault={onSelectMapDefault}
             selected={selected}
           />
@@ -56,7 +58,7 @@ class VariableArgumentsEditor extends PureComponent<Props> {
         return (
           <CSVVariableBuilder
             onChange={this.handleChangeCSV}
-            values={args.values}
+            values={(args as CSVArguments).values}
             onSelectDefault={onSelectMapDefault}
             selected={selected}
           />

--- a/ui/src/variables/components/VariableForm.test.tsx
+++ b/ui/src/variables/components/VariableForm.test.tsx
@@ -50,9 +50,8 @@ const setup = (override?) => {
   return {wrapper, actions}
 }
 
-    jest.mock(
-      'src/shared/components/FluxEditor'
-    )
+jest.mock('src/shared/components/FluxEditor')
+
 describe('Variables.Components.VariableForm', () => {
   describe('rendering', () => {
     it('renders', () => {

--- a/ui/src/variables/components/VariableForm.test.tsx
+++ b/ui/src/variables/components/VariableForm.test.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React from 'react'
-import {shallow} from 'enzyme'
+import {render, fireEvent} from 'react-testing-library'
 
 // Components
 import VariableForm from 'src/variables/components/VariableForm'
@@ -45,38 +45,53 @@ const setup = (override?) => {
     ...override,
   }
 
-  const wrapper = shallow<VariableForm>(<VariableForm {...props} />)
+  const wrapper = render(<VariableForm {...props} />)
 
   return {wrapper, actions}
 }
 
-describe('VariableForm', () => {
+    jest.mock(
+      'src/shared/components/FluxEditor'
+    )
+describe('Variables.Components.VariableForm', () => {
   describe('rendering', () => {
     it('renders', () => {
       const {wrapper} = setup()
-      expect(wrapper.exists()).toBe(true)
-      expect(wrapper).toMatchSnapshot()
+      const {getByTestId} = wrapper
+      const root = getByTestId('variable-form--root')
+
+      expect(root).toMatchSnapshot()
     })
   })
 
   describe('type selector', () => {
-    it('should not tell the the parrent if the type was not changed', () => {
+    it('should not tell the the parent if the type was not changed', () => {
       const {wrapper, actions} = setup()
+      const {getByTestId} = wrapper
 
-      const defaultType = 'query'
+      const button = getByTestId('variable-form--dropdown-button')
 
-      // this way of accessing the instance function
-      // bypasses typescript's private function check
-      wrapper.instance()['handleChangeType'](defaultType)
+      fireEvent.click(button)
+
+      const item = getByTestId('variable-form--dropdown-query')
+
+      fireEvent.click(item)
+
       expect(actions.type.mock.calls.length).toBe(0)
     })
 
-    it('should update tell the the parrent if type was changed', () => {
+    it('should tell the parent if type was changed', () => {
       const {wrapper, actions} = setup()
+      const {getByTestId} = wrapper
 
-      // this way of accessing the instance function
-      // bypasses typescript's private function check
-      wrapper.instance()['handleChangeType']('map')
+      const button = getByTestId('variable-form--dropdown-button')
+
+      fireEvent.click(button)
+
+      const item = getByTestId('variable-form--dropdown-map')
+
+      fireEvent.click(item)
+
       expect(actions.type.mock.calls.length).toBe(1)
       expect(actions.type.mock.calls[0][0]).toBe('map')
     })

--- a/ui/src/variables/components/VariableForm.test.tsx
+++ b/ui/src/variables/components/VariableForm.test.tsx
@@ -9,17 +9,45 @@ import VariableForm from 'src/variables/components/VariableForm'
 import {variables} from 'mocks/dummyData'
 
 const setup = (override?) => {
+  const actions = {
+    name: jest.fn(),
+    type: jest.fn(),
+    query: jest.fn(),
+    map: jest.fn(),
+    constant: jest.fn(),
+  }
   const props = {
     variables,
+    variableType: 'query',
+    query: {
+      type: 'query',
+      values: {
+        query: '',
+        language: 'flux',
+      },
+    },
+    map: {
+      type: 'map',
+      values: {},
+    },
+    constant: {
+      type: 'constant',
+      values: [],
+    },
     initialScript: 'Hello There!',
     onCreateVariable: jest.fn(),
     onHideOverlay: jest.fn(),
+    onNameUpdate: name => actions.name(name),
+    onTypeUpdate: type => actions.type(type),
+    onQueryUpdate: arg => actions.query(arg),
+    onMapUpdate: arg => actions.map(arg),
+    onConstantUpdate: arg => actions.constant(arg),
     ...override,
   }
 
   const wrapper = shallow<VariableForm>(<VariableForm {...props} />)
 
-  return {wrapper}
+  return {wrapper, actions}
 }
 
 describe('VariableForm', () => {
@@ -33,9 +61,9 @@ describe('VariableForm', () => {
 
   describe('type selector', () => {
     it('should not update state if the type was not changed', () => {
-      const {wrapper} = setup()
+      const {wrapper, actions} = setup()
 
-      const defaultType = wrapper.state().args.type
+      const defaultType = 'query'
       const stateStub = jest.fn()
 
       wrapper.instance().setState = stateStub
@@ -44,10 +72,11 @@ describe('VariableForm', () => {
       // bypasses typescript's private function check
       wrapper.instance()['handleChangeType'](defaultType)
       expect(stateStub.mock.calls.length).toBe(0)
+      expect(actions.type.mock.calls.length).toBe(0)
     })
 
     it('should update state if the type was changed', () => {
-      const {wrapper} = setup()
+      const {wrapper, actions} = setup()
 
       const stateStub = jest.fn()
 
@@ -57,6 +86,8 @@ describe('VariableForm', () => {
       // bypasses typescript's private function check
       wrapper.instance()['handleChangeType']('map')
       expect(stateStub.mock.calls.length).toBe(1)
+      expect(actions.type.mock.calls.length).toBe(1)
+      expect(actions.type.mock.calls[0][0]).toBe('map')
     })
   })
 })

--- a/ui/src/variables/components/VariableForm.test.tsx
+++ b/ui/src/variables/components/VariableForm.test.tsx
@@ -60,32 +60,23 @@ describe('VariableForm', () => {
   })
 
   describe('type selector', () => {
-    it('should not update state if the type was not changed', () => {
+    it('should not tell the the parrent if the type was not changed', () => {
       const {wrapper, actions} = setup()
 
       const defaultType = 'query'
-      const stateStub = jest.fn()
-
-      wrapper.instance().setState = stateStub
 
       // this way of accessing the instance function
       // bypasses typescript's private function check
       wrapper.instance()['handleChangeType'](defaultType)
-      expect(stateStub.mock.calls.length).toBe(0)
       expect(actions.type.mock.calls.length).toBe(0)
     })
 
-    it('should update state if the type was changed', () => {
+    it('should update tell the the parrent if type was changed', () => {
       const {wrapper, actions} = setup()
-
-      const stateStub = jest.fn()
-
-      wrapper.instance().setState = stateStub
 
       // this way of accessing the instance function
       // bypasses typescript's private function check
       wrapper.instance()['handleChangeType']('map')
-      expect(stateStub.mock.calls.length).toBe(1)
       expect(actions.type.mock.calls.length).toBe(1)
       expect(actions.type.mock.calls[0][0]).toBe('map')
     })

--- a/ui/src/variables/components/VariableForm.test.tsx
+++ b/ui/src/variables/components/VariableForm.test.tsx
@@ -40,6 +40,8 @@ describe('VariableForm', () => {
 
       wrapper.instance().setState = stateStub
 
+      // this way of accessing the instance function
+      // bypasses typescript's private function check
       wrapper.instance()['handleChangeType'](defaultType)
       expect(stateStub.mock.calls.length).toBe(0)
     })
@@ -51,6 +53,8 @@ describe('VariableForm', () => {
 
       wrapper.instance().setState = stateStub
 
+      // this way of accessing the instance function
+      // bypasses typescript's private function check
       wrapper.instance()['handleChangeType']('map')
       expect(stateStub.mock.calls.length).toBe(1)
     })

--- a/ui/src/variables/components/VariableForm.test.tsx
+++ b/ui/src/variables/components/VariableForm.test.tsx
@@ -1,0 +1,58 @@
+// Libraries
+import React from 'react'
+import {shallow} from 'enzyme'
+
+// Components
+import VariableForm from 'src/variables/components/VariableForm'
+
+// Constants
+import {variables} from 'mocks/dummyData'
+
+const setup = (override?) => {
+  const props = {
+    variables,
+    initialScript: 'Hello There!',
+    onCreateVariable: jest.fn(),
+    onHideOverlay: jest.fn(),
+    ...override,
+  }
+
+  const wrapper = shallow<VariableForm>(<VariableForm {...props} />)
+
+  return {wrapper}
+}
+
+describe('VariableForm', () => {
+  describe('rendering', () => {
+    it('renders', () => {
+      const {wrapper} = setup()
+      expect(wrapper.exists()).toBe(true)
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('type selector', () => {
+    it('should not update state if the type was not changed', () => {
+      const {wrapper} = setup()
+
+      const defaultType = wrapper.state().args.type
+      const stateStub = jest.fn()
+
+      wrapper.instance().setState = stateStub
+
+      wrapper.instance()['handleChangeType'](defaultType)
+      expect(stateStub.mock.calls.length).toBe(0)
+    })
+
+    it('should update state if the type was changed', () => {
+      const {wrapper} = setup()
+
+      const stateStub = jest.fn()
+
+      wrapper.instance().setState = stateStub
+
+      wrapper.instance()['handleChangeType']('map')
+      expect(stateStub.mock.calls.length).toBe(1)
+    })
+  })
+})

--- a/ui/src/variables/components/VariableForm.tsx
+++ b/ui/src/variables/components/VariableForm.tsx
@@ -199,7 +199,7 @@ export default class VariableForm extends PureComponent<Props, State> {
     const defaults = {selected: null, hasValidArgs: false, isNameValid}
 
     if (this.state.args.type === selectedType) {
-        return;
+        return
     }
 
     switch (selectedType) {

--- a/ui/src/variables/components/VariableForm.tsx
+++ b/ui/src/variables/components/VariableForm.tsx
@@ -56,7 +56,8 @@ export default class VariableForm extends PureComponent<Props, State> {
     const {selected} = this.state
 
     return (
-      <Form onSubmit={this.handleSubmit}>
+      <Form onSubmit={this.handleSubmit}
+        testID="variable-form--root">
         <Grid>
           <Grid.Row>
             <Grid.Column widthXS={Columns.Six}>
@@ -84,7 +85,10 @@ export default class VariableForm extends PureComponent<Props, State> {
               <Form.Element label="Type" required={true}>
                 <Dropdown
                   button={(active, onClick) => (
-                    <Dropdown.Button active={active} onClick={onClick}>
+                    <Dropdown.Button
+                      active={active}
+                      onClick={onClick}
+                      testID={'variable-form--dropdown-button'}>
                       {this.typeDropdownLabel}
                     </Dropdown.Button>
                   )}
@@ -94,6 +98,7 @@ export default class VariableForm extends PureComponent<Props, State> {
                         <Dropdown.Item
                           key={v.type}
                           id={v.type}
+                          testID={`variable-form--dropdown-${v.type}`}
                           value={v.type}
                           onClick={this.handleChangeType}
                           selected={v.type === variableType}

--- a/ui/src/variables/components/VariableForm.tsx
+++ b/ui/src/variables/components/VariableForm.tsx
@@ -199,7 +199,7 @@ export default class VariableForm extends PureComponent<Props, State> {
     const defaults = {selected: null, hasValidArgs: false, isNameValid}
 
     if (this.state.args.type === selectedType) {
-        return
+      return
     }
 
     switch (selectedType) {

--- a/ui/src/variables/components/VariableForm.tsx
+++ b/ui/src/variables/components/VariableForm.tsx
@@ -19,7 +19,7 @@ import {validateVariableName} from 'src/variables/utils/validation'
 import {variableItemTypes} from 'src/variables/constants'
 
 // Types
-import {IVariable as Variable} from '@influxdata/influx'
+import {Props} from 'src/variables/components/VariableFormContext'
 import {
   ButtonType,
   ComponentColor,
@@ -32,25 +32,6 @@ import {
   MapArguments,
   CSVArguments,
 } from 'src/types'
-
-interface Props {
-  name: string
-  variableType: VariableArgumentType
-  query: VariableArguments | null
-  map: VariableArguments | null
-  constant: VariableArguments | null
-  onNameUpdate: (string) => void
-  onTypeUpdate: (VariableArgumentType) => void
-  onQueryUpdate: (VariableArguments) => void
-  onMapUpdate: (VariableArguments) => void
-  onConstantUpdate: (VariableArguments) => void
-  onCreateVariable: (
-    variable: Pick<Variable, 'name' | 'arguments' | 'selected'>
-  ) => void
-  onHideOverlay?: () => void
-  initialScript?: string
-  variables: Variable[]
-}
 
 interface State {
   isNameValid: boolean

--- a/ui/src/variables/components/VariableForm.tsx
+++ b/ui/src/variables/components/VariableForm.tsx
@@ -198,6 +198,10 @@ export default class VariableForm extends PureComponent<Props, State> {
     const {isNameValid} = this.state
     const defaults = {selected: null, hasValidArgs: false, isNameValid}
 
+    if (this.state.args.type === selectedType) {
+        return;
+    }
+
     switch (selectedType) {
       case 'query':
         return this.setState({

--- a/ui/src/variables/components/VariableForm.tsx
+++ b/ui/src/variables/components/VariableForm.tsx
@@ -50,8 +50,7 @@ export default class VariableForm extends PureComponent<Props, State> {
     const {selected} = this.state
 
     return (
-      <Form onSubmit={this.handleSubmit}
-        testID="variable-form--root">
+      <Form onSubmit={this.handleSubmit} testID="variable-form--root">
         <Grid>
           <Grid.Row>
             <Grid.Column widthXS={Columns.Six}>
@@ -82,7 +81,8 @@ export default class VariableForm extends PureComponent<Props, State> {
                     <Dropdown.Button
                       active={active}
                       onClick={onClick}
-                      testID={'variable-form--dropdown-button'}>
+                      testID="variable-form--dropdown-button"
+                    >
                       {this.typeDropdownLabel}
                     </Dropdown.Button>
                   )}

--- a/ui/src/variables/components/VariableFormContext.test.tsx
+++ b/ui/src/variables/components/VariableFormContext.test.tsx
@@ -1,0 +1,45 @@
+// Libraries
+import React from 'react'
+import {shallow} from 'enzyme'
+
+// Components
+import {VariableFormContext} from 'src/variables/components/VariableFormContext'
+
+const setup = (override?) => {
+  const actions = {
+    name: jest.fn(),
+    type: jest.fn(),
+    query: jest.fn(),
+    map: jest.fn(),
+    constant: jest.fn(),
+    clear: jest.fn(),
+  }
+  const props = {
+    initialScript: 'Hello There!',
+    onCreateVariable: jest.fn(),
+    onHideOverlay: jest.fn(),
+    onNameUpdate: name => actions.name(name),
+    onTypeUpdate: type => actions.type(type),
+    onQueryUpdate: arg => actions.query(arg),
+    onMapUpdate: arg => actions.map(arg),
+    onConstantUpdate: arg => actions.constant(arg),
+    onEditorClose: () => actions.clear(),
+    ...override,
+  }
+
+  const wrapper = shallow<VariableFormContext>(
+    <VariableFormContext {...props} />
+  )
+
+  return {wrapper, actions}
+}
+
+describe('VariableFormContext', () => {
+  it('should tell the store to clear on close', () => {
+    const {wrapper, actions} = setup()
+
+    wrapper.instance()['handlelHideOverlay']()
+
+    expect(actions.clear.mock.calls.length).toBe(1)
+  })
+})

--- a/ui/src/variables/components/VariableFormContext.test.tsx
+++ b/ui/src/variables/components/VariableFormContext.test.tsx
@@ -38,7 +38,7 @@ describe('VariableFormContext', () => {
   it('should tell the store to clear on close', () => {
     const {wrapper, actions} = setup()
 
-    wrapper.instance()['handlelHideOverlay']()
+    wrapper.instance()['handleHideOverlay']()
 
     expect(actions.clear.mock.calls.length).toBe(1)
   })

--- a/ui/src/variables/components/VariableFormContext.tsx
+++ b/ui/src/variables/components/VariableFormContext.tsx
@@ -28,11 +28,7 @@ import VariableForm from 'src/variables/components/VariableForm'
 
 // Types
 import {IVariable as Variable} from '@influxdata/influx'
-import {
-  AppState,
-  VariableArguments,
-  VariableArgumentType,
-} from 'src/types'
+import {AppState, VariableArguments, VariableArgumentType} from 'src/types'
 
 interface ComponentProps {
   onHideOverlay?: () => void
@@ -64,18 +60,18 @@ type Props = ComponentProps & DispatchProps & StateProps
 
 class VariableFormContext extends PureComponent<Props> {
   render() {
-    const {onHideOverlay, onEditorClose} = this.props
-    const hideOverlay = () => {
-      onEditorClose()
-      onHideOverlay()
-    }
     const props = {
-      onHideOverlay: hideOverlay,
-      ...this.props
+      onHideOverlay: this.handleHideOverlay,
+      ...this.props,
     }
-    return (
-      <VariableForm {...props}/>
-    )
+    return <VariableForm {...props} />
+  }
+
+  private handleHideOverlay() {
+    const {onHideOverlay, onEditorClose} = this.props
+
+    onEditorClose()
+    onHideOverlay()
   }
 }
 

--- a/ui/src/variables/components/VariableFormContext.tsx
+++ b/ui/src/variables/components/VariableFormContext.tsx
@@ -1,0 +1,115 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+
+// Utils
+import {
+  extractVariablesList,
+  extractVariableEditorName,
+  extractVariableEditorType,
+  extractVariableEditorQuery,
+  extractVariableEditorMap,
+  extractVariableEditorConstant,
+} from 'src/variables/selectors'
+
+// Actions
+import {
+  updateName,
+  updateType,
+  updateQuery,
+  updateMap,
+  updateConstant,
+  clearEditor,
+  createVariable,
+} from 'src/variables/actions'
+
+// Component
+import VariableForm from 'src/variables/components/VariableForm'
+
+// Types
+import {IVariable as Variable} from '@influxdata/influx'
+import {
+  AppState,
+  VariableArguments,
+  VariableArgumentType,
+} from 'src/types'
+
+interface ComponentProps {
+  onHideOverlay?: () => void
+  initialScript?: string
+}
+
+interface DispatchProps {
+  onCreateVariable: (
+    variable: Pick<Variable, 'name' | 'arguments' | 'selected'>
+  ) => void
+  onNameUpdate: typeof updateName
+  onTypeUpdate: typeof updateType
+  onQueryUpdate: typeof updateQuery
+  onMapUpdate: typeof updateMap
+  onConstantUpdate: typeof updateConstant
+  onEditorClose: typeof clearEditor
+}
+
+interface StateProps {
+  variables: Variable[]
+  name: string
+  variableType: VariableArgumentType
+  query: VariableArguments
+  map: VariableArguments
+  constant: VariableArguments
+}
+
+type Props = ComponentProps & DispatchProps & StateProps
+
+class VariableFormContext extends PureComponent<Props> {
+  render() {
+    const {onHideOverlay, onEditorClose} = this.props
+    const hideOverlay = () => {
+      onEditorClose()
+      onHideOverlay()
+    }
+    const props = {
+      onHideOverlay: hideOverlay,
+      ...this.props
+    }
+    return (
+      <VariableForm {...props}/>
+    )
+  }
+}
+
+const mstp = (state: AppState): StateProps => {
+  const variables = extractVariablesList(state),
+    name = extractVariableEditorName(state),
+    variableType = extractVariableEditorType(state),
+    query = extractVariableEditorQuery(state),
+    map = extractVariableEditorMap(state),
+    constant = extractVariableEditorConstant(state)
+
+  return {
+    variables,
+    name,
+    variableType,
+    query,
+    map,
+    constant,
+  }
+}
+
+const mdtp: DispatchProps = {
+  onNameUpdate: updateName,
+  onTypeUpdate: updateType,
+  onQueryUpdate: updateQuery,
+  onMapUpdate: updateMap,
+  onConstantUpdate: updateConstant,
+  onEditorClose: clearEditor,
+  onCreateVariable: createVariable,
+}
+
+export {Props}
+export {VariableFormContext}
+export default connect<StateProps, DispatchProps>(
+  mstp,
+  mdtp
+)(VariableFormContext)

--- a/ui/src/variables/components/__snapshots__/VariableForm.test.tsx.snap
+++ b/ui/src/variables/components/__snapshots__/VariableForm.test.tsx.snap
@@ -1,0 +1,112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VariableForm rendering renders 1`] = `
+<Form
+  onSubmit={[Function]}
+  preventDefault={true}
+  testID="form-container"
+>
+  <Grid
+    testID="grid"
+  >
+    <GridRow
+      testID="grid--row"
+    >
+      <GridColumn
+        testID="grid--column"
+        widthXS={6}
+      >
+        <div
+          className="overlay-flux-editor--spacing"
+        >
+          <FormValidationElement
+            label="Name"
+            required={true}
+            testID="form--validation-element"
+            validationFunc={[Function]}
+            value=""
+          >
+            <Component />
+          </FormValidationElement>
+        </div>
+      </GridColumn>
+      <GridColumn
+        testID="grid--column"
+        widthXS={6}
+      >
+        <FormElement
+          label="Type"
+          required={true}
+          testID="form--element"
+        >
+          <Dropdown
+            button={[Function]}
+            dropUp={false}
+            menu={[Function]}
+            testID="dropdown"
+          />
+        </FormElement>
+      </GridColumn>
+    </GridRow>
+    <GridRow
+      testID="grid--row"
+    >
+      <GridColumn
+        testID="grid--column"
+        widthXS={12}
+      >
+        <VariableArgumentsEditor
+          args={
+            Object {
+              "type": "query",
+              "values": Object {
+                "language": "flux",
+                "query": "Hello There!",
+              },
+            }
+          }
+          onChange={[Function]}
+          onSelectMapDefault={[Function]}
+          selected={null}
+        />
+      </GridColumn>
+    </GridRow>
+    <GridRow
+      testID="grid--row"
+    >
+      <GridColumn
+        testID="grid--column"
+        widthXS={12}
+      >
+        <FormFooter
+          testID="form--footer"
+        >
+          <Button
+            active={false}
+            color="danger"
+            onClick={[MockFunction]}
+            placeIconAfterText={false}
+            shape="none"
+            size="sm"
+            status="default"
+            testID="button"
+            text="Cancel"
+            type="button"
+          />
+          <Button
+            active={false}
+            color="primary"
+            placeIconAfterText={false}
+            shape="none"
+            size="sm"
+            status="disabled"
+            testID="button"
+            text="Create"
+            type="submit"
+          />
+        </FormFooter>
+      </GridColumn>
+    </GridRow>
+  </Grid>
+</Form>
+`;

--- a/ui/src/variables/components/__snapshots__/VariableForm.test.tsx.snap
+++ b/ui/src/variables/components/__snapshots__/VariableForm.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`VariableForm rendering renders 1`] = `
             required={true}
             testID="form--validation-element"
             validationFunc={[Function]}
-            value=""
           >
             <Component />
           </FormValidationElement>
@@ -68,6 +67,7 @@ exports[`VariableForm rendering renders 1`] = `
           onChange={[Function]}
           onSelectMapDefault={[Function]}
           selected={null}
+          variableType="query"
         />
       </GridColumn>
     </GridRow>

--- a/ui/src/variables/components/__snapshots__/VariableForm.test.tsx.snap
+++ b/ui/src/variables/components/__snapshots__/VariableForm.test.tsx.snap
@@ -1,112 +1,186 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`VariableForm rendering renders 1`] = `
-<Form
-  onSubmit={[Function]}
-  preventDefault={true}
-  testID="form-container"
+exports[`Variables.Components.VariableForm rendering renders 1`] = `
+<form
+  class="cf-form--wrapper"
+  data-testid="variable-form--root"
 >
-  <Grid
-    testID="grid"
+  <div
+    class="cf-grid--container"
+    data-testid="grid"
   >
-    <GridRow
-      testID="grid--row"
+    <div
+      class="cf-grid--row"
+      data-testid="grid--row"
     >
-      <GridColumn
-        testID="grid--column"
-        widthXS={6}
+      <div
+        class="cf-grid--column cf-col-xs-6"
+        data-testid="grid--column"
       >
         <div
-          className="overlay-flux-editor--spacing"
+          class="overlay-flux-editor--spacing"
         >
-          <FormValidationElement
-            label="Name"
-            required={true}
-            testID="form--validation-element"
-            validationFunc={[Function]}
+          <div
+            class="cf-form--element"
+            data-testid="form--validation-element"
           >
-            <Component />
-          </FormValidationElement>
+            <label
+              class="cf-form--label"
+              data-testid="form--label"
+            >
+              <span>
+                Name
+                <span
+                  class="cf-form--label-required"
+                >
+                  *
+                </span>
+              </span>
+            </label>
+            <div
+              class="cf-input cf-input-sm"
+              style="width: 100%;"
+            >
+              <input
+                autocomplete="off"
+                class="cf-input-field"
+                data-testid="input-field"
+                name="name"
+                placeholder="Give your variable a name"
+                spellcheck="false"
+                title=""
+                type="text"
+                value=""
+              />
+              <div
+                class="cf-input-shadow"
+              />
+            </div>
+          </div>
         </div>
-      </GridColumn>
-      <GridColumn
-        testID="grid--column"
-        widthXS={6}
+      </div>
+      <div
+        class="cf-grid--column cf-col-xs-6"
+        data-testid="grid--column"
       >
-        <FormElement
-          label="Type"
-          required={true}
-          testID="form--element"
+        <div
+          class="cf-form--element"
+          data-testid="form--element"
         >
-          <Dropdown
-            button={[Function]}
-            dropUp={false}
-            menu={[Function]}
-            testID="dropdown"
-          />
-        </FormElement>
-      </GridColumn>
-    </GridRow>
-    <GridRow
-      testID="grid--row"
+          <label
+            class="cf-form--label"
+            data-testid="form--label"
+          >
+            <span>
+              Type
+              <span
+                class="cf-form--label-required"
+              >
+                *
+              </span>
+            </span>
+          </label>
+          <div
+            class="cf-dropdown cf-dropdown__down"
+            data-testid="dropdown"
+            style="width: 100%;"
+          >
+            <button
+              class="cf-button cf-button-sm cf-button-default cf-button-stretch cf-dropdown--button"
+              data-testid="variable-form--dropdown-button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="cf-dropdown--selected"
+              >
+                Query
+              </span>
+              <span
+                class="cf-icon caret-down cf-dropdown--caret"
+                data-testid="icon"
+              />
+            </button>
+            <div
+              class="cf-dropdown--menu-container"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="cf-grid--row"
+      data-testid="grid--row"
     >
-      <GridColumn
-        testID="grid--column"
-        widthXS={12}
+      <div
+        class="cf-grid--column cf-col-xs-12"
+        data-testid="grid--column"
       >
-        <VariableArgumentsEditor
-          args={
-            Object {
-              "type": "query",
-              "values": Object {
-                "language": "flux",
-                "query": "Hello There!",
-              },
-            }
-          }
-          onChange={[Function]}
-          onSelectMapDefault={[Function]}
-          selected={null}
-          variableType="query"
-        />
-      </GridColumn>
-    </GridRow>
-    <GridRow
-      testID="grid--row"
-    >
-      <GridColumn
-        testID="grid--column"
-        widthXS={12}
-      >
-        <FormFooter
-          testID="form--footer"
+        <div
+          class="cf-form--element"
+          data-testid="form--element"
         >
-          <Button
-            active={false}
-            color="danger"
-            onClick={[MockFunction]}
-            placeIconAfterText={false}
-            shape="none"
-            size="sm"
-            status="default"
-            testID="button"
-            text="Cancel"
+          <label
+            class="cf-form--label"
+            data-testid="form--label"
+          >
+            <span>
+              Script
+            </span>
+          </label>
+          <div
+            class="cf-grid--column cf-col-xs-12"
+            data-testid="grid--column"
+          >
+            <div
+              class="overlay-flux-editor"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="cf-grid--row"
+      data-testid="grid--row"
+    >
+      <div
+        class="cf-grid--column cf-col-xs-12"
+        data-testid="grid--column"
+      >
+        <div
+          class="cf-form--element cf-form--footer"
+          data-testid="form--footer"
+        >
+          <button
+            class="cf-button cf-button-sm cf-button-danger"
+            data-testid="button"
+            tabindex="0"
+            title="Cancel"
             type="button"
-          />
-          <Button
-            active={false}
-            color="primary"
-            placeIconAfterText={false}
-            shape="none"
-            size="sm"
-            status="disabled"
-            testID="button"
-            text="Create"
+          >
+            <span
+              class="cf-button--label"
+            >
+              Cancel
+            </span>
+          </button>
+          <button
+            class="cf-button cf-button-sm cf-button-primary cf-button--disabled"
+            data-testid="button"
+            disabled=""
+            tabindex="0"
+            title="Create"
             type="submit"
-          />
-        </FormFooter>
-      </GridColumn>
-    </GridRow>
-  </Grid>
-</Form>
+          >
+            <span
+              class="cf-button--label"
+            >
+              Create
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
 `;

--- a/ui/src/variables/reducers/index.ts
+++ b/ui/src/variables/reducers/index.ts
@@ -17,7 +17,6 @@ import {IVariable as Variable} from '@influxdata/influx'
 export const initialEditorState = (): VariableEditorState => ({
   name: '',
   selected: 'query',
-
   argsQuery: null,
   argsMap: null,
   argsConstant: null,

--- a/ui/src/variables/reducers/index.ts
+++ b/ui/src/variables/reducers/index.ts
@@ -3,10 +3,65 @@ import {produce} from 'immer'
 import {get} from 'lodash'
 
 // Types
-import {RemoteDataState} from 'src/types'
+import {
+  RemoteDataState,
+  VariableArguments,
+  VariableArgumentType,
+} from 'src/types'
 import {VariableValuesByID} from 'src/variables/types'
-import {Action} from 'src/variables/actions'
+import {Action, EditorAction} from 'src/variables/actions'
 import {IVariable as Variable} from '@influxdata/influx'
+
+export const initialEditorState = (): VariableEditorState => ({
+  name: '',
+  selected: 'query',
+
+  argsQuery: null,
+  argsMap: null,
+  argsConstant: null,
+})
+
+export interface VariableEditorState {
+  name: string
+  selected: VariableArgumentType
+  argsQuery: VariableArguments
+  argsMap: VariableArguments
+  argsConstant: VariableArguments
+}
+
+export const variableEditorReducer = (
+  state: VariableEditorState = initialEditorState(),
+  action: EditorAction
+): VariableEditorState =>
+  produce(state, draftState => {
+    switch (action.type) {
+      case 'CLEAR_VARIABLE_EDITOR': {
+        return initialEditorState()
+      }
+      case 'CHANGE_VARIABLE_EDITOR_TYPE': {
+        draftState.selected = action.payload
+        return
+      }
+      case 'UPDATE_VARIABLE_EDITOR_NAME': {
+        draftState.name = action.payload
+        return
+      }
+      case 'UPDATE_VARIABLE_EDITOR_QUERY': {
+        draftState.argsQuery = action.payload
+        return
+      }
+      case 'UPDATE_VARIABLE_EDITOR_MAP': {
+        draftState.argsMap = action.payload
+        return
+      }
+      case 'UPDATE_VARIABLE_EDITOR_CONSTANT': {
+        draftState.argsConstant = action.payload
+        return
+      }
+      default:
+        return
+    }
+  })
 
 export const initialState = (): VariablesState => ({
   status: RemoteDataState.NotStarted,

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -6,7 +6,12 @@ import {get} from 'lodash'
 import {getVarAssignment} from 'src/variables/utils/getVarAssignment'
 
 // Types
-import {RemoteDataState, MapArguments, QueryArguments, CSVArguments} from 'src/types'
+import {
+  RemoteDataState,
+  MapArguments,
+  QueryArguments,
+  CSVArguments,
+} from 'src/types'
 import {VariableAssignment} from 'src/types/ast'
 import {AppState, VariableArguments, VariableArgumentType} from 'src/types'
 import {

--- a/ui/src/variables/selectors/index.tsx
+++ b/ui/src/variables/selectors/index.tsx
@@ -8,7 +8,7 @@ import {getVarAssignment} from 'src/variables/utils/getVarAssignment'
 // Types
 import {RemoteDataState} from 'src/types'
 import {VariableAssignment} from 'src/types/ast'
-import {AppState, VariableArguments} from 'src/types'
+import {AppState, VariableArguments, VariableArgumentType} from 'src/types'
 import {
   VariableValues,
   VariableValuesByID,
@@ -29,6 +29,52 @@ const extractVariablesListMemoized = memoizeOne(
 
 export const extractVariablesList = (state: AppState): Variable[] => {
   return extractVariablesListMemoized(state.variables.variables)
+}
+
+export const extractVariableEditorName = (state: AppState): string => {
+  return state.variableEditor.name
+}
+
+export const extractVariableEditorType = (
+  state: AppState
+): VariableArgumentType => {
+  return state.variableEditor.selected
+}
+
+export const extractVariableEditorQuery = (
+  state: AppState
+): VariableArguments => {
+  return (
+    state.variableEditor.argsQuery || {
+      type: 'query',
+      values: {
+        query: '',
+        language: 'flux',
+      },
+    }
+  )
+}
+
+export const extractVariableEditorMap = (
+  state: AppState
+): VariableArguments => {
+  return (
+    state.variableEditor.argsMap || {
+      type: 'map',
+      values: {},
+    }
+  )
+}
+
+export const extractVariableEditorConstant = (
+  state: AppState
+): VariableArguments => {
+  return (
+    state.variableEditor.argsConstant || {
+      type: 'constant',
+      values: [],
+    }
+  )
 }
 
 const getVariablesForDashboardMemoized = memoizeOne(


### PR DESCRIPTION
Closes #15059

If a user re-selects the same variable type when adding a variable, no action takes place