### PR TITLE
feat(storage): allow compaction limiter to be injected into engine

### DIFF
--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -231,6 +231,12 @@ func NewEngine(path string, idx *tsi1.Index, config Config, options ...EngineOpt
 	return e
 }
 
+// WithCompactionLimiter sets the compaction limiter, which is used to limit the
+// number of concurrent compactions.
+func (e *Engine) WithCompactionLimiter(limiter limiter.Fixed) {
+	e.compactionLimiter = limiter
+}
+
 func (e *Engine) WithFormatFileNameFunc(formatFileNameFunc FormatFileNameFunc) {
 	e.Compactor.WithFormatFileNameFunc(formatFileNameFunc)
 	e.formatFileName = formatFileNameFunc


### PR DESCRIPTION
This PR enables us to inject a limiter into a storage engine to control the concurrent number of compactions that can execute.

The use-case for this is when running multiple storage engines and wanting to limit concurrent compactions across them.