### PR TITLE
fix(http): remove a HTTPNotificationRuleBase.url from required properties

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9651,7 +9651,7 @@ components:
           type: string
     HTTPNotificationRuleBase:
       type: object
-      required: [type, url]
+      required: [type]
       properties:
         type:
           type: string


### PR DESCRIPTION
The `url` property of `HTTPNotificationRuleBase` should not be required:

https://github.com/influxdata/influxdb/blob/dbcdc8dc59a28b819ee50385756a59a284012fdf/notification/rule/http.go#L179


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
