### PR TITLE
refactor(ui): global overlays

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -184,6 +184,7 @@
     "papaparse": "^4.6.3",
     "prop-types": "^15.6.1",
     "qs": "^6.5.2",
+    "query-string": "^6.8.3",
     "react": "^16.8.2",
     "react-codemirror2": "^4.2.1",
     "react-copy-to-clipboard": "^5.0.1",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,6 +9,7 @@ import Nav from 'src/pageLayout'
 import TooltipPortal from 'src/portals/TooltipPortal'
 import NotesPortal from 'src/portals/NotesPortal'
 import Notifications from 'src/shared/components/notifications/Notifications'
+import OverlayRouter from 'src/overlays/containers/OverlayRouter'
 
 // Types
 import {AppState} from 'src/types'
@@ -28,6 +29,7 @@ const App: SFC<Props> = ({children, inPresentationMode}) => (
     <RightClickLayer />
     <TooltipPortal />
     <NotesPortal />
+    <OverlayRouter />
     <Nav />
     {children}
   </AppWrapper>

--- a/ui/src/alerting/components/CheckCard.tsx
+++ b/ui/src/alerting/components/CheckCard.tsx
@@ -7,6 +7,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 import {SlideToggle, ComponentSize, ResourceCard} from '@influxdata/clockface'
 import CheckCardContext from 'src/alerting/components/CheckCardContext'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Constants
 import {DEFAULT_CHECK_NAME} from 'src/alerting/constants'
@@ -101,10 +102,6 @@ const CheckCard: FunctionComponent<Props> = ({
     }
   }
 
-  const onCheckClick = () => {
-    router.push(`/orgs/${orgID}/alerting/checks/${check.id}/edit`)
-  }
-
   const onView = () => {
     const historyType: AlertHistoryType = 'statuses'
 
@@ -133,15 +130,19 @@ const CheckCard: FunctionComponent<Props> = ({
       key={`check-id--${check.id}`}
       testID="check-card"
       name={
-        <ResourceCard.EditableName
-          onUpdate={onUpdateName}
-          onClick={onCheckClick}
-          name={check.name}
-          noNameString={DEFAULT_CHECK_NAME}
-          testID="check-card--name"
-          buttonTestID="check-card--name-button"
-          inputTestID="check-card--input"
-        />
+        <OverlayLink overlayID="edit-check" resourceID={check.id}>
+          {onClick => (
+            <ResourceCard.EditableName
+              onUpdate={onUpdateName}
+              onClick={onClick}
+              name={check.name}
+              noNameString={DEFAULT_CHECK_NAME}
+              testID="check-card--name"
+              buttonTestID="check-card--name-button"
+              inputTestID="check-card--input"
+            />
+          )}
+        </OverlayLink>
       }
       toggle={
         <SlideToggle

--- a/ui/src/alerting/components/CheckCards.tsx
+++ b/ui/src/alerting/components/CheckCards.tsx
@@ -14,6 +14,7 @@ import {
   ComponentColor,
   ButtonShape,
 } from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Types
 import {Check} from 'src/types'
@@ -23,16 +24,12 @@ interface Props {
   checks: Check[]
   searchTerm: string
   showFirstTimeWidget: boolean
-  onCreateThreshold: () => void
-  onCreateDeadman: () => void
 }
 
 const CheckCards: FunctionComponent<Props> = ({
   checks,
   searchTerm,
   showFirstTimeWidget,
-  onCreateThreshold,
-  onCreateDeadman,
 }) => {
   const cards = cs => cs.map(c => <CheckCard key={c.id} check={c} />)
   const body = filtered => (
@@ -40,8 +37,6 @@ const CheckCards: FunctionComponent<Props> = ({
       emptyState={
         <EmptyChecksList
           showFirstTimeWidget={showFirstTimeWidget}
-          onCreateThreshold={onCreateThreshold}
-          onCreateDeadman={onCreateDeadman}
           searchTerm={searchTerm}
         />
       }
@@ -68,15 +63,11 @@ const CheckCards: FunctionComponent<Props> = ({
 
 interface EmptyProps {
   showFirstTimeWidget: boolean
-  onCreateThreshold: () => void
-  onCreateDeadman: () => void
   searchTerm: string
 }
 
 const EmptyChecksList: FunctionComponent<EmptyProps> = ({
   showFirstTimeWidget,
-  onCreateThreshold,
-  onCreateDeadman,
   searchTerm,
 }) => {
   if (searchTerm) {
@@ -100,23 +91,31 @@ const EmptyChecksList: FunctionComponent<EmptyProps> = ({
         <Panel.Body>
           <h1>Get started monitoring by creating a check</h1>
           <h5>When a value crosses a specific threshold:</h5>
-          <Button
-            size={ComponentSize.Medium}
-            color={ComponentColor.Primary}
-            onClick={onCreateThreshold}
-            text="Threshold Check"
-            icon={IconFont.Plus}
-            shape={ButtonShape.StretchToFit}
-          />
+          <OverlayLink overlayID="create-threshold-check">
+            {onClick => (
+              <Button
+                size={ComponentSize.Medium}
+                color={ComponentColor.Primary}
+                onClick={onClick}
+                text="Threshold Check"
+                icon={IconFont.Plus}
+                shape={ButtonShape.StretchToFit}
+              />
+            )}
+          </OverlayLink>
           <h5>If a service stops sending metrics:</h5>
-          <Button
-            size={ComponentSize.Medium}
-            color={ComponentColor.Primary}
-            onClick={onCreateDeadman}
-            text="Deadman Check"
-            icon={IconFont.Plus}
-            shape={ButtonShape.StretchToFit}
-          />
+          <OverlayLink overlayID="create-deadman-check">
+            {onClick => (
+              <Button
+                size={ComponentSize.Medium}
+                color={ComponentColor.Primary}
+                onClick={onClick}
+                text="Deadman Check"
+                icon={IconFont.Plus}
+                shape={ButtonShape.StretchToFit}
+              />
+            )}
+          </OverlayLink>
         </Panel.Body>
       </Panel>
     )

--- a/ui/src/alerting/components/ChecksColumn.tsx
+++ b/ui/src/alerting/components/ChecksColumn.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Selectors
@@ -20,23 +19,11 @@ interface StateProps {
   endpoints: AppState['endpoints']['list']
 }
 
-type Props = StateProps & WithRouterProps
-
-const ChecksColumn: FunctionComponent<Props> = ({
+const ChecksColumn: FunctionComponent<StateProps> = ({
   checks,
-  router,
-  params: {orgID},
   rules,
   endpoints,
 }) => {
-  const handleCreateThreshold = () => {
-    router.push(`/orgs/${orgID}/alerting/checks/new-threshold`)
-  }
-
-  const handleCreateDeadman = () => {
-    router.push(`/orgs/${orgID}/alerting/checks/new-deadman`)
-  }
-
   const tooltipContents = (
     <>
       A <strong>Check</strong> is a periodic query that the system
@@ -58,12 +45,7 @@ const ChecksColumn: FunctionComponent<Props> = ({
   const noAlertingResourcesExist =
     !checks.length && !rules.length && !endpoints.length
 
-  const createButton = (
-    <CreateCheckDropdown
-      onCreateThreshold={handleCreateThreshold}
-      onCreateDeadman={handleCreateDeadman}
-    />
-  )
+  const createButton = <CreateCheckDropdown />
 
   return (
     <AlertsColumn
@@ -75,8 +57,6 @@ const ChecksColumn: FunctionComponent<Props> = ({
         <CheckCards
           checks={checks}
           searchTerm={searchTerm}
-          onCreateThreshold={handleCreateThreshold}
-          onCreateDeadman={handleCreateDeadman}
           showFirstTimeWidget={noAlertingResourcesExist}
         />
       )}
@@ -103,4 +83,4 @@ const mstp = (state: AppState) => {
 export default connect<StateProps, {}, {}>(
   mstp,
   null
-)(withRouter(ChecksColumn))
+)(ChecksColumn)

--- a/ui/src/alerting/components/CreateCheckDropdown.tsx
+++ b/ui/src/alerting/components/CreateCheckDropdown.tsx
@@ -3,29 +3,11 @@ import React, {FunctionComponent, MouseEvent} from 'react'
 
 // Components
 import {Dropdown, ComponentColor, IconFont} from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
-// Types
-import {CheckType} from 'src/types'
+interface Props {}
 
-interface Props {
-  onCreateThreshold: () => void
-  onCreateDeadman: () => void
-}
-
-const CreateCheckDropdown: FunctionComponent<Props> = ({
-  onCreateThreshold,
-  onCreateDeadman,
-}) => {
-  const handleItemClick = (type: CheckType): void => {
-    if (type === 'threshold') {
-      onCreateThreshold()
-    }
-
-    if (type === 'deadman') {
-      onCreateDeadman()
-    }
-  }
-
+const CreateCheckDropdown: FunctionComponent<Props> = () => {
   const DropdownButton = (
     active: boolean,
     onClick: (e: MouseEvent<HTMLButtonElement>) => void
@@ -43,20 +25,28 @@ const CreateCheckDropdown: FunctionComponent<Props> = ({
 
   const DropdownMenu = (onCollapse: () => void) => (
     <Dropdown.Menu onCollapse={onCollapse}>
-      <Dropdown.Item
-        value="threshold"
-        onClick={handleItemClick}
-        testID="create-threshold-check"
-      >
-        Threshold Check
-      </Dropdown.Item>
-      <Dropdown.Item
-        value="deadman"
-        onClick={handleItemClick}
-        testID="create-deadman-check"
-      >
-        Deadman Check
-      </Dropdown.Item>
+      <OverlayLink overlayID="create-threshold-check">
+        {onClick => (
+          <Dropdown.Item
+            value="threshold"
+            onClick={onClick}
+            testID="create-threshold-check"
+          >
+            Threshold Check
+          </Dropdown.Item>
+        )}
+      </OverlayLink>
+      <OverlayLink overlayID="create-deadman-check">
+        {onClick => (
+          <Dropdown.Item
+            value="deadman"
+            onClick={onClick}
+            testID="create-deadman-check"
+          >
+            Deadman Check
+          </Dropdown.Item>
+        )}
+      </OverlayLink>
     </Dropdown.Menu>
   )
 

--- a/ui/src/alerting/components/EditCheckEO.tsx
+++ b/ui/src/alerting/components/EditCheckEO.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -50,7 +49,12 @@ interface StateProps {
   activeTimeMachineID: TimeMachineID
 }
 
-type Props = WithRouterProps & DispatchProps & StateProps
+interface OwnProps {
+  onDismiss: () => void
+  checkID: string
+}
+
+type Props = OwnProps & DispatchProps & StateProps
 
 const EditCheckEditorOverlay: FunctionComponent<Props> = ({
   onUpdateCheck,
@@ -58,11 +62,11 @@ const EditCheckEditorOverlay: FunctionComponent<Props> = ({
   onGetCheckForTimeMachine,
   onUpdateTimeMachineCheck,
   onSetTimeMachineCheck,
-  onNotify,
   activeTimeMachineID,
   checkStatus,
-  router,
-  params: {checkID, orgID},
+  onDismiss,
+  onNotify,
+  checkID,
   query,
   check,
   view,
@@ -80,7 +84,7 @@ const EditCheckEditorOverlay: FunctionComponent<Props> = ({
   }
 
   const handleClose = () => {
-    router.push(`/orgs/${orgID}/alerting`)
+    onDismiss()
     onSetTimeMachineCheck(RemoteDataState.NotStarted, null)
   }
 
@@ -159,4 +163,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, {}>(
   mstp,
   mdtp
-)(withRouter(EditCheckEditorOverlay))
+)(EditCheckEditorOverlay)

--- a/ui/src/alerting/components/EndpointsColumn.tsx
+++ b/ui/src/alerting/components/EndpointsColumn.tsx
@@ -1,26 +1,21 @@
 // Libraries
 import React, {FC} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Button, IconFont, ComponentColor} from '@influxdata/clockface'
 import EndpointCards from 'src/alerting/components/endpoints/EndpointCards'
 import AlertsColumn from 'src/alerting/components/AlertsColumn'
+import OverlayLink from 'src/overlays/components/OverlayLink'
+
+// Types
 import {AppState} from 'src/types'
 
 interface StateProps {
   endpoints: AppState['endpoints']['list']
 }
-type OwnProps = {}
-type Props = OwnProps & WithRouterProps & StateProps
 
-const EndpointsColumn: FC<Props> = ({router, params, endpoints}) => {
-  const handleOpenOverlay = () => {
-    const newRuleRoute = `/orgs/${params.orgID}/alerting/endpoints/new`
-    router.push(newRuleRoute)
-  }
-
+const EndpointsColumn: FC<StateProps> = ({endpoints}) => {
   const tooltipContents = (
     <>
       A <strong>Notification Endpoint</strong> stores the information to connect
@@ -40,13 +35,17 @@ const EndpointsColumn: FC<Props> = ({router, params, endpoints}) => {
   )
 
   const createButton = (
-    <Button
-      color={ComponentColor.Secondary}
-      text="Create"
-      onClick={handleOpenOverlay}
-      testID="create-endpoint"
-      icon={IconFont.Plus}
-    />
+    <OverlayLink overlayID="create-endpoint">
+      {onClick => (
+        <Button
+          color={ComponentColor.Secondary}
+          text="Create"
+          onClick={onClick}
+          testID="create-endpoint"
+          icon={IconFont.Plus}
+        />
+      )}
+    </OverlayLink>
   )
 
   return (
@@ -66,4 +65,4 @@ const mstp = ({endpoints}: AppState) => {
   return {endpoints: endpoints.list}
 }
 
-export default connect<StateProps>(mstp)(withRouter<OwnProps>(EndpointsColumn))
+export default connect<StateProps>(mstp)(EndpointsColumn)

--- a/ui/src/alerting/components/NewDeadmanCheckEO.tsx
+++ b/ui/src/alerting/components/NewDeadmanCheckEO.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Overlay, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
@@ -39,18 +38,21 @@ interface StateProps {
   checkStatus: RemoteDataState
 }
 
-type Props = DispatchProps & StateProps & WithRouterProps
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps & DispatchProps & StateProps
 
 const NewCheckOverlay: FunctionComponent<Props> = ({
   onSetActiveTimeMachine,
   updateTimeMachineCheck,
   setTimeMachineCheck,
   saveCheckFromTimeMachine,
-  params,
-  router,
   checkStatus,
   check,
   notify,
+  onDismiss,
 }) => {
   useEffect(() => {
     const view = createView<CheckViewProperties>('deadman')
@@ -69,7 +71,7 @@ const NewCheckOverlay: FunctionComponent<Props> = ({
 
   const handleClose = () => {
     setTimeMachineCheck(RemoteDataState.NotStarted, null)
-    router.push(`/orgs/${params.orgID}/alerting`)
+    onDismiss()
   }
 
   const handleSave = async () => {
@@ -127,4 +129,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, {}>(
   mstp,
   mdtp
-)(withRouter(NewCheckOverlay))
+)(NewCheckOverlay)

--- a/ui/src/alerting/components/NewThresholdCheckEO.tsx
+++ b/ui/src/alerting/components/NewThresholdCheckEO.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FunctionComponent, useEffect} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Overlay, SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
@@ -39,18 +38,21 @@ interface StateProps {
   checkStatus: RemoteDataState
 }
 
-type Props = DispatchProps & StateProps & WithRouterProps
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps & DispatchProps & StateProps
 
 const NewCheckOverlay: FunctionComponent<Props> = ({
   onSetActiveTimeMachine,
   updateTimeMachineCheck,
   setTimeMachineCheck,
   saveCheckFromTimeMachine,
-  params,
-  router,
   checkStatus,
   check,
   notify,
+  onDismiss,
 }) => {
   useEffect(() => {
     const view = createView<CheckViewProperties>('threshold')
@@ -69,7 +71,7 @@ const NewCheckOverlay: FunctionComponent<Props> = ({
 
   const handleClose = () => {
     setTimeMachineCheck(RemoteDataState.NotStarted, null)
-    router.push(`/orgs/${params.orgID}/alerting`)
+    onDismiss()
   }
 
   const handleSave = async () => {
@@ -127,4 +129,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, {}>(
   mstp,
   mdtp
-)(withRouter(NewCheckOverlay))
+)(NewCheckOverlay)

--- a/ui/src/alerting/components/endpoints/EditEndpointOverlay.tsx
+++ b/ui/src/alerting/components/endpoints/EditEndpointOverlay.tsx
@@ -83,4 +83,4 @@ const mstp = ({endpoints}: AppState, {endpointID}: Props): StateProps => {
 export default connect<StateProps, DispatchProps>(
   mstp,
   mdtp
-)(withRouter<Props>(EditEndpointOverlay))
+)(withRouter<OwnProps>(EditEndpointOverlay))

--- a/ui/src/alerting/components/endpoints/EditEndpointOverlay.tsx
+++ b/ui/src/alerting/components/endpoints/EditEndpointOverlay.tsx
@@ -22,7 +22,12 @@ interface StateProps {
   endpoint: NotificationEndpoint
 }
 
-type Props = WithRouterProps & DispatchProps & StateProps
+interface OwnProps {
+  onDismiss: () => void
+  endpointID: string
+}
+
+type Props = OwnProps & WithRouterProps & DispatchProps & StateProps
 
 const EditEndpointOverlay: FC<Props> = ({
   params,
@@ -65,8 +70,8 @@ const mdtp = {
   onUpdateEndpoint: updateEndpoint,
 }
 
-const mstp = ({endpoints}: AppState, {params}: Props): StateProps => {
-  const endpoint = endpoints.list.find(ep => ep.id === params.endpointID)
+const mstp = ({endpoints}: AppState, {endpointID}: Props): StateProps => {
+  const endpoint = endpoints.list.find(ep => ep.id === endpointID)
 
   if (!endpoint) {
     throw new Error('Unknown endpoint provided to <EditEndpointOverlay/>')

--- a/ui/src/alerting/components/endpoints/EndpointCard.tsx
+++ b/ui/src/alerting/components/endpoints/EndpointCard.tsx
@@ -20,6 +20,7 @@ import {
 import {SlideToggle, ComponentSize, ResourceCard} from '@influxdata/clockface'
 import EndpointCardMenu from 'src/alerting/components/endpoints/EndpointCardMenu'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Constants
 import {
@@ -83,21 +84,22 @@ const EndpointCard: FC<Props> = ({
   const handleUpdateName = (name: string) => {
     onUpdateEndpointProperties(id, {name})
   }
-  const handleClick = () => {
-    router.push(`orgs/${orgID}/alerting/endpoints/${endpoint.id}/edit`)
-  }
 
   const nameComponent = (
-    <ResourceCard.EditableName
-      key={id}
-      name={name}
-      onClick={handleClick}
-      onUpdate={handleUpdateName}
-      testID={`endpoint-card--name ${name}`}
-      inputTestID="endpoint-card--input"
-      buttonTestID="endpoint-card--name-button"
-      noNameString="Name this notification endpoint"
-    />
+    <OverlayLink overlayID="edit-endpoint" resourceID={endpoint.id}>
+      {onClick => (
+        <ResourceCard.EditableName
+          key={id}
+          name={name}
+          onClick={onClick}
+          onUpdate={handleUpdateName}
+          testID={`endpoint-card--name ${name}`}
+          inputTestID="endpoint-card--input"
+          buttonTestID="endpoint-card--name-button"
+          noNameString="Name this notification endpoint"
+        />
+      )}
+    </OverlayLink>
   )
 
   const handleToggle = () => {

--- a/ui/src/alerting/components/endpoints/NewEndpointOverlay.tsx
+++ b/ui/src/alerting/components/endpoints/NewEndpointOverlay.tsx
@@ -19,18 +19,19 @@ interface DispatchProps {
   onCreateEndpoint: typeof createEndpoint
 }
 
-type Props = WithRouterProps & DispatchProps
+interface OwnProps {
+  onDismiss: () => void
+}
 
-const NewRuleOverlay: FC<Props> = ({params, router, onCreateEndpoint}) => {
+type Props = OwnProps & WithRouterProps & DispatchProps
+
+const NewRuleOverlay: FC<Props> = ({params, onCreateEndpoint, onDismiss}) => {
   const {orgID} = params
-  const handleDismiss = () => {
-    router.push(`/orgs/${params.orgID}/alerting`)
-  }
 
   const handleCreateEndpoint = async (endpoint: NotificationEndpoint) => {
     await onCreateEndpoint(endpoint)
 
-    handleDismiss()
+    onDismiss()
   }
 
   const initialState = useMemo(() => ({...NEW_ENDPOINT_DRAFT, orgID}), [orgID])
@@ -41,11 +42,11 @@ const NewRuleOverlay: FC<Props> = ({params, router, onCreateEndpoint}) => {
         <Overlay.Container maxWidth={666}>
           <Overlay.Header
             title="Create a Notification Endpoint"
-            onDismiss={handleDismiss}
+            onDismiss={onDismiss}
           />
           <EndpointOverlayContents
             onSave={handleCreateEndpoint}
-            onCancel={handleDismiss}
+            onCancel={onDismiss}
             saveButtonText="Create Notification Endpoint"
           />
         </Overlay.Container>
@@ -61,4 +62,4 @@ const mdtp = {
 export default connect<null, DispatchProps>(
   null,
   mdtp
-)(withRouter<Props>(NewRuleOverlay))
+)(withRouter<OwnProps>(NewRuleOverlay))

--- a/ui/src/alerting/components/notifications/EditRuleOverlay.tsx
+++ b/ui/src/alerting/components/notifications/EditRuleOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {FC} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -24,26 +23,22 @@ interface DispatchProps {
   onUpdateRule: (rule: NotificationRuleDraft) => Promise<void>
 }
 
-type Props = WithRouterProps & StateProps & DispatchProps
+interface OwnProps {
+  onDismiss: () => void
+  ruleID: string
+}
 
-const EditRuleOverlay: FC<Props> = ({
-  params: {orgID},
-  router,
-  stateRule,
-  onUpdateRule,
-}) => {
+type Props = OwnProps & StateProps & DispatchProps
+
+const EditRuleOverlay: FC<Props> = ({stateRule, onUpdateRule, onDismiss}) => {
   if (!stateRule) {
     return null
-  }
-
-  const handleDismiss = () => {
-    router.push(`/orgs/${orgID}/alerting`)
   }
 
   const handleUpdateRule = async (rule: NotificationRuleDraft) => {
     await onUpdateRule(rule)
 
-    handleDismiss()
+    onDismiss()
   }
 
   return (
@@ -52,7 +47,7 @@ const EditRuleOverlay: FC<Props> = ({
         <Overlay.Container maxWidth={800}>
           <Overlay.Header
             title="Edit this Notification Rule"
-            onDismiss={handleDismiss}
+            onDismiss={onDismiss}
           />
           <Overlay.Body>
             <RuleOverlayContents
@@ -66,8 +61,8 @@ const EditRuleOverlay: FC<Props> = ({
   )
 }
 
-const mstp = ({rules}: AppState, {params}: Props): StateProps => {
-  const stateRule = rules.list.find(r => r.id === params.ruleID)
+const mstp = ({rules}: AppState, {ruleID}: OwnProps): StateProps => {
+  const stateRule = rules.list.find(r => r.id === ruleID)
 
   return {
     stateRule,
@@ -81,4 +76,4 @@ const mdtp = {
 export default connect<StateProps, DispatchProps>(
   mstp,
   mdtp
-)(withRouter<Props>(EditRuleOverlay))
+)(EditRuleOverlay)

--- a/ui/src/alerting/components/notifications/NewRuleOverlay.tsx
+++ b/ui/src/alerting/components/notifications/NewRuleOverlay.tsx
@@ -21,17 +21,21 @@ interface DispatchProps {
   onCreateRule: (rule: Partial<NotificationRuleDraft>) => Promise<void>
 }
 
-type Props = WithRouterProps & DispatchProps
+interface OwnProps {
+  onDismiss: () => void
+}
 
-const NewRuleOverlay: FC<Props> = ({params: {orgID}, router, onCreateRule}) => {
-  const handleDismiss = () => {
-    router.push(`/orgs/${orgID}/alerting`)
-  }
+type Props = OwnProps & WithRouterProps & DispatchProps
 
+const NewRuleOverlay: FC<Props> = ({
+  params: {orgID},
+  onCreateRule,
+  onDismiss,
+}) => {
   const handleCreateRule = async (rule: NotificationRuleDraft) => {
     await onCreateRule(rule)
 
-    handleDismiss()
+    onDismiss()
   }
 
   const initialState = useMemo(() => initRuleDraft(orgID), [orgID])
@@ -42,7 +46,7 @@ const NewRuleOverlay: FC<Props> = ({params: {orgID}, router, onCreateRule}) => {
         <Overlay.Container maxWidth={800}>
           <Overlay.Header
             title="Create a Notification Rule"
-            onDismiss={handleDismiss}
+            onDismiss={onDismiss}
           />
           <Overlay.Body>
             <RuleOverlayContents
@@ -63,4 +67,4 @@ const mdtp = {
 export default connect<{}, DispatchProps>(
   null,
   mdtp
-)(withRouter<Props>(NewRuleOverlay))
+)(withRouter<OwnProps>(NewRuleOverlay))

--- a/ui/src/alerting/components/notifications/RuleCard.tsx
+++ b/ui/src/alerting/components/notifications/RuleCard.tsx
@@ -7,6 +7,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 import {SlideToggle, ComponentSize, ResourceCard} from '@influxdata/clockface'
 import NotificationRuleCardContext from 'src/alerting/components/notifications/RuleCardContext'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Constants
 import {DEFAULT_NOTIFICATION_RULE_NAME} from 'src/alerting/constants'
@@ -90,10 +91,6 @@ const RuleCard: FC<Props> = ({
     onUpdateRuleProperties(rule.id, {status})
   }
 
-  const onRuleClick = () => {
-    router.push(`/orgs/${orgID}/alerting/rules/${rule.id}/edit`)
-  }
-
   const onView = () => {
     const historyType: AlertHistoryType = 'notifications'
 
@@ -122,15 +119,19 @@ const RuleCard: FC<Props> = ({
       key={`rule-id--${rule.id}`}
       testID="rule-card"
       name={
-        <ResourceCard.EditableName
-          onUpdate={onUpdateName}
-          onClick={onRuleClick}
-          name={rule.name}
-          noNameString={DEFAULT_NOTIFICATION_RULE_NAME}
-          testID="rule-card--name"
-          buttonTestID="rule-card--name-button"
-          inputTestID="rule-card--input"
-        />
+        <OverlayLink overlayID="edit-notification-rule" resourceID={rule.id}>
+          {onClick => (
+            <ResourceCard.EditableName
+              onUpdate={onUpdateName}
+              onClick={onClick}
+              name={rule.name}
+              noNameString={DEFAULT_NOTIFICATION_RULE_NAME}
+              testID="rule-card--name"
+              buttonTestID="rule-card--name-button"
+              inputTestID="rule-card--input"
+            />
+          )}
+        </OverlayLink>
       }
       toggle={
         <SlideToggle

--- a/ui/src/alerting/components/notifications/RulesColumn.tsx
+++ b/ui/src/alerting/components/notifications/RulesColumn.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Types
 import {NotificationRuleDraft, AppState} from 'src/types'
@@ -15,25 +14,19 @@ import {
 } from '@influxdata/clockface'
 import NotificationRuleCards from 'src/alerting/components/notifications/RuleCards'
 import AlertsColumn from 'src/alerting/components/AlertsColumn'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 interface StateProps {
   rules: NotificationRuleDraft[]
   endpoints: AppState['endpoints']['list']
 }
 
-type Props = StateProps & WithRouterProps
+type Props = StateProps
 
 const NotificationRulesColumn: FunctionComponent<Props> = ({
   rules,
-  router,
-  params,
   endpoints,
 }) => {
-  const handleOpenOverlay = () => {
-    const newRuleRoute = `/orgs/${params.orgID}/alerting/rules/new`
-    router.push(newRuleRoute)
-  }
-
   const tooltipContents = (
     <>
       A <strong>Notification Rule</strong> will query statuses
@@ -63,15 +56,19 @@ const NotificationRulesColumn: FunctionComponent<Props> = ({
     : 'You need at least 1 Notifcation Endpoint to create a Notification Rule'
 
   const createButton = (
-    <Button
-      color={ComponentColor.Secondary}
-      text="Create"
-      onClick={handleOpenOverlay}
-      testID="create-rule"
-      icon={IconFont.Plus}
-      status={buttonStatus}
-      titleText={buttonTitleText}
-    />
+    <OverlayLink overlayID="create-notification-rule">
+      {onClick => (
+        <Button
+          color={ComponentColor.Secondary}
+          text="Create"
+          onClick={onClick}
+          testID="create-rule"
+          icon={IconFont.Plus}
+          status={buttonStatus}
+          titleText={buttonTitleText}
+        />
+      )}
+    </OverlayLink>
   )
 
   return (
@@ -99,4 +96,4 @@ const mstp = (state: AppState) => {
 export default connect<StateProps, {}, {}>(
   mstp,
   null
-)(withRouter(NotificationRulesColumn))
+)(NotificationRulesColumn)

--- a/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -42,7 +42,7 @@ interface OwnProps {
   onDismiss: () => void
 }
 
-type Props = OwnProps& WithRouterProps & DispatchProps
+type Props = OwnProps & WithRouterProps & DispatchProps
 
 @ErrorHandling
 class AllAccessTokenOverlay extends PureComponent<Props, State> {

--- a/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
+++ b/ui/src/authorizations/components/AllAccessTokenOverlay.tsx
@@ -38,13 +38,18 @@ interface State {
   description: string
 }
 
-type Props = WithRouterProps & DispatchProps
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps& WithRouterProps & DispatchProps
 
 @ErrorHandling
 class AllAccessTokenOverlay extends PureComponent<Props, State> {
   public state = {description: ''}
 
   render() {
+    const {onDismiss} = this.props
     const {description} = this.state
 
     return (
@@ -52,7 +57,7 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
         <Overlay.Container maxWidth={500}>
           <Overlay.Header
             title="Generate All Access Token"
-            onDismiss={this.handleDismiss}
+            onDismiss={onDismiss}
           />
           <Overlay.Body>
             <Form onSubmit={this.handleSave}>
@@ -80,7 +85,7 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
                   <Button
                     text="Cancel"
                     icon={IconFont.Remove}
-                    onClick={this.handleDismiss}
+                    onClick={onDismiss}
                   />
 
                   <Button
@@ -102,6 +107,7 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
     const {
       params: {orgID},
       onCreateAuthorization,
+      onDismiss,
     } = this.props
 
     const token: Authorization = {
@@ -112,22 +118,13 @@ class AllAccessTokenOverlay extends PureComponent<Props, State> {
 
     await onCreateAuthorization(token)
 
-    this.handleDismiss()
+    onDismiss()
   }
 
   private handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const {value} = e.target
 
     this.setState({description: value})
-  }
-
-  private handleDismiss = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/load-data/tokens`)
   }
 }
 

--- a/ui/src/authorizations/components/BucketsTokenOverlay.tsx
+++ b/ui/src/authorizations/components/BucketsTokenOverlay.tsx
@@ -55,7 +55,11 @@ interface State {
   activeTabWrite: BucketTab
 }
 
-type Props = WithRouterProps & DispatchProps & StateProps
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps & WithRouterProps & DispatchProps & StateProps
 
 @ErrorHandling
 class BucketsTokenOverlay extends PureComponent<Props, State> {
@@ -75,13 +79,14 @@ class BucketsTokenOverlay extends PureComponent<Props, State> {
       activeTabRead,
       activeTabWrite,
     } = this.state
+    const {onDismiss} = this.props
 
     return (
       <Overlay visible={true}>
         <Overlay.Container maxWidth={700}>
           <Overlay.Header
             title="Generate Read/Write Token"
-            onDismiss={this.handleDismiss}
+            onDismiss={onDismiss}
           />
           <Overlay.Body>
             <Form onSubmit={this.handleSave}>
@@ -138,7 +143,7 @@ class BucketsTokenOverlay extends PureComponent<Props, State> {
                   <Button
                     text="Cancel"
                     icon={IconFont.Remove}
-                    onClick={this.handleDismiss}
+                    onClick={onDismiss}
                     testID="button--cancel"
                   />
 
@@ -200,6 +205,7 @@ class BucketsTokenOverlay extends PureComponent<Props, State> {
     const {
       params: {orgID},
       onCreateAuthorization,
+      onDismiss,
     } = this.props
     const {activeTabRead, activeTabWrite} = this.state
 
@@ -225,7 +231,7 @@ class BucketsTokenOverlay extends PureComponent<Props, State> {
 
     await onCreateAuthorization(token)
 
-    this.handleDismiss()
+    onDismiss()
   }
 
   private get writeBucketPermissions(): Permission[] {
@@ -275,15 +281,6 @@ class BucketsTokenOverlay extends PureComponent<Props, State> {
 
     this.setState({description: value})
   }
-
-  private handleDismiss = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/load-data/tokens`)
-  }
 }
 
 const mstp = ({buckets: {list}}: AppState): StateProps => {
@@ -297,4 +294,4 @@ const mdtp: DispatchProps = {
 export default connect<{}, DispatchProps, {}>(
   mstp,
   mdtp
-)(withRouter(BucketsTokenOverlay))
+)(withRouter<OwnProps>(BucketsTokenOverlay))

--- a/ui/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/ui/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -12,7 +12,10 @@ import {IconFont, ComponentColor} from '@influxdata/clockface'
 type Props = {}
 
 const GenerateTokenDropdown: FunctionComponent<Props> = () => {
-  const button = (active: boolean, onClick: (e?: MouseEvent<HTMLButtonElement>) => void) => (
+  const button = (
+    active: boolean,
+    onClick: (e?: MouseEvent<HTMLButtonElement>) => void
+  ) => (
     <Dropdown.Button
       active={active}
       onClick={onClick}
@@ -47,7 +50,7 @@ const GenerateTokenDropdown: FunctionComponent<Props> = () => {
             onClick={onClick}
           >
             All Access Token
-        </Dropdown.Item>
+          </Dropdown.Item>
         )}
       </OverlayLink>
     </Dropdown.Menu>

--- a/ui/src/authorizations/components/GenerateTokenDropdown.tsx
+++ b/ui/src/authorizations/components/GenerateTokenDropdown.tsx
@@ -1,82 +1,66 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import _ from 'lodash'
 
 // Components
 import {Dropdown} from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Types
 import {IconFont, ComponentColor} from '@influxdata/clockface'
 
-interface OwnProps {
-  onSelectAllAccess: () => void
-  onSelectReadWrite: () => void
-}
+type Props = {}
 
-type Props = OwnProps
+const GenerateTokenDropdown: FunctionComponent<Props> = () => {
+  const button = (active: boolean, onClick: (e?: MouseEvent<HTMLButtonElement>) => void) => (
+    <Dropdown.Button
+      active={active}
+      onClick={onClick}
+      icon={IconFont.Plus}
+      color={ComponentColor.Primary}
+      testID="dropdown-button--gen-token"
+    >
+      Generate
+    </Dropdown.Button>
+  )
 
-export default class GenerateTokenDropdown extends PureComponent<Props> {
-  public render() {
-    return (
-      <Dropdown
-        testID="dropdown--gen-token"
-        widthPixels={160}
-        button={(active, onClick) => (
-          <Dropdown.Button
-            active={active}
+  const menu = (onCollapse: () => void) => (
+    <Dropdown.Menu onCollapse={onCollapse}>
+      <OverlayLink overlayID="generate-read-write-token">
+        {onClick => (
+          <Dropdown.Item
+            testID="dropdown-item generate-token--read-write"
+            id="Read/Write Token"
+            value="Read/Write Token"
             onClick={onClick}
-            icon={IconFont.Plus}
-            color={ComponentColor.Primary}
-            testID="dropdown-button--gen-token"
           >
-            Generate
-          </Dropdown.Button>
+            Read/Write Token
+          </Dropdown.Item>
         )}
-        menu={onCollapse => (
-          <Dropdown.Menu onCollapse={onCollapse}>
-            {this.optionItems}
-          </Dropdown.Menu>
+      </OverlayLink>
+      <OverlayLink overlayID="generate-all-access-token">
+        {onClick => (
+          <Dropdown.Item
+            testID="dropdown-item generate-token--all-access"
+            id="All Access Token"
+            value="All Access Token"
+            onClick={onClick}
+          >
+            All Access Token
+        </Dropdown.Item>
         )}
-      />
-    )
-  }
+      </OverlayLink>
+    </Dropdown.Menu>
+  )
 
-  private get optionItems(): JSX.Element[] {
-    return [
-      <Dropdown.Item
-        testID="dropdown-item generate-token--read-write"
-        id={this.bucketReadWriteOption}
-        key={this.bucketReadWriteOption}
-        value={this.bucketReadWriteOption}
-        onClick={this.handleSelect}
-      >
-        {this.bucketReadWriteOption}
-      </Dropdown.Item>,
-      <Dropdown.Item
-        testID="dropdown-item generate-token--all-access"
-        id={this.allAccessOption}
-        key={this.allAccessOption}
-        value={this.allAccessOption}
-        onClick={this.handleSelect}
-      >
-        {this.allAccessOption}
-      </Dropdown.Item>,
-    ]
-  }
-
-  private get bucketReadWriteOption(): string {
-    return 'Read/Write Token'
-  }
-
-  private get allAccessOption(): string {
-    return 'All Access Token'
-  }
-
-  private handleSelect = (selection: string): void => {
-    if (selection === this.allAccessOption) {
-      this.props.onSelectAllAccess()
-    } else if (selection === this.bucketReadWriteOption) {
-      this.props.onSelectReadWrite()
-    }
-  }
+  return (
+    <Dropdown
+      testID="dropdown--gen-token"
+      widthPixels={160}
+      button={button}
+      menu={menu}
+    />
+  )
 }
+
+export default GenerateTokenDropdown

--- a/ui/src/authorizations/components/TokensTab.tsx
+++ b/ui/src/authorizations/components/TokensTab.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Sort} from '@influxdata/clockface'
@@ -33,7 +32,7 @@ interface StateProps {
 
 type SortKey = keyof Authorization
 
-type Props = StateProps & WithRouterProps
+type Props = StateProps
 
 class TokensTab extends PureComponent<Props, State> {
   constructor(props) {
@@ -59,10 +58,7 @@ class TokensTab extends PureComponent<Props, State> {
             onSearch={this.handleChangeSearchTerm}
             testID="input-field--filter"
           />
-          <GenerateTokenDropdown
-            onSelectAllAccess={this.handleGenerateAllAccess}
-            onSelectReadWrite={this.handleGenerateReadWrite}
-          />
+          <GenerateTokenDropdown />
         </TabbedPageHeader>
         <FilterList<Authorization>
           list={tokens}
@@ -96,24 +92,6 @@ class TokensTab extends PureComponent<Props, State> {
   private get searchKeys(): AuthSearchKeys[] {
     return [AuthSearchKeys.Status, AuthSearchKeys.Description]
   }
-
-  private handleGenerateAllAccess = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/load-data/tokens/generate/all-access`)
-  }
-
-  private handleGenerateReadWrite = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/load-data/tokens/generate/buckets`)
-  }
 }
 
 const mstp = ({tokens}: AppState) => ({tokens: tokens.list})
@@ -121,4 +99,4 @@ const mstp = ({tokens}: AppState) => ({tokens: tokens.list})
 export default connect<StateProps, {}, {}>(
   mstp,
   null
-)(withRouter(TokensTab))
+)(TokensTab)

--- a/ui/src/buckets/components/BucketAddDataButton.tsx
+++ b/ui/src/buckets/components/BucketAddDataButton.tsx
@@ -12,16 +12,16 @@ import {
   PopoverType,
   PopoverPosition,
 } from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 interface Props {
   onAddCollector: () => void
-  onAddLineProtocol: () => void
-  onAddScraper: () => void
+  bucketID: string
 }
 
 export default class BucketAddDataButton extends PureComponent<Props> {
   public render() {
-    const {onAddCollector, onAddLineProtocol, onAddScraper} = this.props
+    const {onAddCollector, bucketID} = this.props
 
     return (
       <Popover
@@ -39,26 +39,34 @@ export default class BucketAddDataButton extends PureComponent<Props> {
                 Configure a Telegraf agent to push data into your bucket.
               </div>
             </div>
-            <div
-              className="bucket-add-data--option"
-              onClick={onAddLineProtocol}
-            >
-              <div className="bucket-add-data--option-header">
-                Line Protocol
-              </div>
-              <div className="bucket-add-data--option-desc">
-                Quickly load an existing line protocol file.
-              </div>
-            </div>
+            <OverlayLink overlayID="write-data-with-line-protocol">
+              {onClick => (
+                <div className="bucket-add-data--option" onClick={onClick}>
+                  <div className="bucket-add-data--option-header">
+                    Line Protocol
+                  </div>
+                  <div className="bucket-add-data--option-desc">
+                    Quickly load an existing line protocol file.
+                  </div>
+                </div>
+              )}
+            </OverlayLink>
             <CloudExclude>
-              <div className="bucket-add-data--option" onClick={onAddScraper}>
-                <div className="bucket-add-data--option-header">
-                  Scrape Metrics
-                </div>
-                <div className="bucket-add-data--option-desc">
-                  Add a scrape target to pull data into your bucket.
-                </div>
-              </div>
+              <OverlayLink
+                overlayID="add-scraper-to-bucket"
+                resourceID={bucketID}
+              >
+                {onClick => (
+                  <div className="bucket-add-data--option" onClick={onClick}>
+                    <div className="bucket-add-data--option-header">
+                      Scrape Metrics
+                    </div>
+                    <div className="bucket-add-data--option-desc">
+                      Add a scrape target to pull data into your bucket.
+                    </div>
+                  </div>
+                )}
+              </OverlayLink>
             </CloudExclude>
           </div>
         )}

--- a/ui/src/buckets/components/BucketCard.tsx
+++ b/ui/src/buckets/components/BucketCard.tsx
@@ -14,6 +14,7 @@ import {
 import BucketContextMenu from 'src/buckets/components/BucketContextMenu'
 import BucketAddDataButton from 'src/buckets/components/BucketAddDataButton'
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Constants
 import {isSystemBucket} from 'src/buckets/constants/index'
@@ -29,7 +30,6 @@ export interface PrettyBucket extends Bucket {
 interface Props {
   bucket: PrettyBucket
   onEditBucket: (b: PrettyBucket) => void
-  onDeleteData: (b: PrettyBucket) => void
   onDeleteBucket: (b: PrettyBucket) => void
   onAddData: (b: PrettyBucket, d: DataLoaderType, l: string) => void
   onUpdateBucket: (b: PrettyBucket) => void
@@ -62,11 +62,15 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
     const {bucket} = this.props
     if (bucket.type === 'user') {
       return (
-        <ResourceCard.Name
-          testID={`bucket--card ${bucket.name}`}
-          onClick={this.handleNameClick}
-          name={bucket.name}
-        />
+        <OverlayLink overlayID="edit-bucket" resourceID={bucket.id}>
+          {onClick => (
+            <ResourceCard.Name
+              testID={`bucket--card ${bucket.name}`}
+              onClick={onClick}
+              name={bucket.name}
+            />
+          )}
+        </OverlayLink>
       )
     }
 
@@ -109,49 +113,30 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
             onAddLineProtocol={this.handleAddLineProtocol}
             onAddScraper={this.handleAddScraper}
           />
-          <Button
-            text="Rename"
-            testID="bucket-rename"
-            size={ComponentSize.ExtraSmall}
-            onClick={this.handleRenameBucket}
-          />
+          <OverlayLink overlayID="rename-bucket" resourceID={bucket.id}>
+            {onClick => (
+              <Button
+                text="Rename"
+                testID="bucket-rename"
+                size={ComponentSize.ExtraSmall}
+                onClick={onClick}
+              />
+            )}
+          </OverlayLink>
           <FeatureFlag name="deleteWithPredicate">
+            <OverlayLink overlayID="delete-data" resourceID={bucket.id}>
+              {onClick => (
             <Button
               text="Delete Data By Filter"
               testID="bucket-delete-task"
               size={ComponentSize.ExtraSmall}
-              onClick={this.handleDeleteData}
-            />
+                  onClick={onClick}
+            />)}
+            </OverlayLink>
           </FeatureFlag>
         </FlexBox>
       )
     }
-  }
-
-  private handleDeleteData = () => {
-    const {onDeleteData, bucket} = this.props
-
-    onDeleteData(bucket)
-  }
-
-  private handleRenameBucket = () => {
-    const {
-      params: {orgID},
-      bucket: {id},
-      router,
-    } = this.props
-
-    router.push(`/orgs/${orgID}/load-data/buckets/${id}/rename`)
-  }
-
-  private handleNameClick = (): void => {
-    const {
-      params: {orgID},
-      bucket: {id},
-      router,
-    } = this.props
-
-    router.push(`/orgs/${orgID}/load-data/buckets/${id}/edit`)
   }
 
   private handleAddCollector = (): void => {

--- a/ui/src/buckets/components/BucketCard.tsx
+++ b/ui/src/buckets/components/BucketCard.tsx
@@ -110,8 +110,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
         >
           <BucketAddDataButton
             onAddCollector={this.handleAddCollector}
-            onAddLineProtocol={this.handleAddLineProtocol}
-            onAddScraper={this.handleAddScraper}
+            bucketID={bucket.id}
           />
           <OverlayLink overlayID="rename-bucket" resourceID={bucket.id}>
             {onClick => (
@@ -148,26 +147,6 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
 
     const link = `/orgs/${orgID}/load-data/buckets/${id}/telegrafs/new`
     this.props.onAddData(this.props.bucket, DataLoaderType.Streaming, link)
-  }
-
-  private handleAddLineProtocol = (): void => {
-    const {
-      params: {orgID},
-      bucket: {id},
-    } = this.props
-
-    const link = `/orgs/${orgID}/load-data/buckets/${id}/line-protocols/new`
-    this.props.onAddData(this.props.bucket, DataLoaderType.LineProtocol, link)
-  }
-
-  private handleAddScraper = (): void => {
-    const {
-      params: {orgID},
-      bucket: {id},
-    } = this.props
-
-    const link = `/orgs/${orgID}/load-data/buckets/${id}/scrapers/new`
-    this.props.onAddData(this.props.bucket, DataLoaderType.Scraping, link)
   }
 }
 

--- a/ui/src/buckets/components/BucketCard.tsx
+++ b/ui/src/buckets/components/BucketCard.tsx
@@ -126,12 +126,13 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
           <FeatureFlag name="deleteWithPredicate">
             <OverlayLink overlayID="delete-data" resourceID={bucket.id}>
               {onClick => (
-            <Button
-              text="Delete Data By Filter"
-              testID="bucket-delete-task"
-              size={ComponentSize.ExtraSmall}
+                <Button
+                  text="Delete Data By Filter"
+                  testID="bucket-delete-task"
+                  size={ComponentSize.ExtraSmall}
                   onClick={onClick}
-            />)}
+                />
+              )}
             </OverlayLink>
           </FeatureFlag>
         </FlexBox>

--- a/ui/src/buckets/components/BucketList.tsx
+++ b/ui/src/buckets/components/BucketList.tsx
@@ -125,7 +125,6 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
         bucket={bucket}
         onEditBucket={this.handleStartEdit}
         onDeleteBucket={onDeleteBucket}
-        onDeleteData={this.handleStartDeleteData}
         onAddData={this.handleStartAddData}
         onUpdateBucket={this.handleUpdateBucket}
         onFilterChange={onFilterChange}
@@ -137,14 +136,6 @@ class BucketList extends PureComponent<Props & WithRouterProps, State> {
     const {orgID} = this.props.params
 
     this.props.router.push(`/orgs/${orgID}/load-data/buckets/${bucket.id}/edit`)
-  }
-
-  private handleStartDeleteData = (bucket: PrettyBucket) => {
-    const {orgID} = this.props.params
-
-    this.props.router.push(
-      `/orgs/${orgID}/load-data/buckets/${bucket.id}/delete-data`
-    )
   }
 
   private handleStartAddData = (

--- a/ui/src/buckets/components/BucketOverlayForm.tsx
+++ b/ui/src/buckets/components/BucketOverlayForm.tsx
@@ -28,6 +28,7 @@ interface Props {
   onChangeInput: (e: ChangeEvent<HTMLInputElement>) => void
   disableRenaming: boolean
   buttonText: string
+  disableSubmitButton?: boolean
 }
 
 export default class BucketOverlayForm extends PureComponent<Props> {
@@ -136,10 +137,10 @@ export default class BucketOverlayForm extends PureComponent<Props> {
   }
 
   private get submitButtonStatus(): ComponentStatus {
-    const {name} = this.props
+    const {name, disableSubmitButton} = this.props
     const nameHasErrors = this.handleNameValidation(name)
 
-    if (nameHasErrors || this.retentionIsTooShort) {
+    if (nameHasErrors || this.retentionIsTooShort || disableSubmitButton) {
       return ComponentStatus.Disabled
     }
 

--- a/ui/src/buckets/components/BucketsTab.tsx
+++ b/ui/src/buckets/components/BucketsTab.tsx
@@ -5,11 +5,7 @@ import {connect} from 'react-redux'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {
-  ComponentSize,
-  Sort,
-  EmptyState,
-} from '@influxdata/clockface'
+import {ComponentSize, Sort, EmptyState} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import SettingsTabbedPageHeader from 'src/settings/components/SettingsTabbedPageHeader'
 import FilterList from 'src/shared/components/Filter'
@@ -74,12 +70,7 @@ class BucketsTab extends PureComponent<Props, State> {
 
   public render() {
     const {buckets, limitStatus} = this.props
-    const {
-      searchTerm,
-      sortKey,
-      sortDirection,
-      sortType,
-    } = this.state
+    const {searchTerm, sortKey, sortDirection, sortType} = this.state
 
     return (
       <>

--- a/ui/src/buckets/components/CreateBucketButton.tsx
+++ b/ui/src/buckets/components/CreateBucketButton.tsx
@@ -1,0 +1,65 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+
+// Components
+import {
+  IconFont,
+  ComponentSize,
+  ComponentColor,
+  Button,
+  ComponentStatus,
+} from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
+
+// Actions
+import {LimitStatus} from 'src/cloud/actions/limits'
+
+// Utils
+import {extractBucketLimits} from 'src/cloud/utils/limits'
+
+// Types
+import {AppState} from 'src/types'
+
+interface OwnProps {
+  color?: ComponentColor
+  size?: ComponentSize
+}
+
+interface StateProps {
+  limitStatus: LimitStatus
+}
+
+type Props = OwnProps & StateProps
+
+const CreateBucketButton: FunctionComponent<Props> = ({color = ComponentColor.Primary, size = ComponentSize.Small, limitStatus}) => {
+  const disabled = limitStatus === LimitStatus.EXCEEDED
+
+  const titleText = disabled ? 'This account has the maximum number of buckets allowed' : 'Create a bucket'
+  const status = disabled ? ComponentStatus.Disabled : ComponentStatus.Default
+
+  return (
+    <OverlayLink overlayID="create-bucket">
+      {onClick => (
+        <Button
+          text="Create Bucket"
+          icon={IconFont.Plus}
+          size={size}
+          color={color}
+          onClick={onClick}
+          testID="Create Bucket"
+          status={status}
+          titleText={titleText}
+        />
+      )}
+    </OverlayLink>
+  )
+}
+
+const mstp = ({cloud: {limits}}: AppState): StateProps => ({
+  limitStatus: extractBucketLimits(limits),
+})
+
+export default connect<StateProps, {}, {}>(
+  mstp
+)(CreateBucketButton)

--- a/ui/src/buckets/components/CreateBucketButton.tsx
+++ b/ui/src/buckets/components/CreateBucketButton.tsx
@@ -32,10 +32,16 @@ interface StateProps {
 
 type Props = OwnProps & StateProps
 
-const CreateBucketButton: FunctionComponent<Props> = ({color = ComponentColor.Primary, size = ComponentSize.Small, limitStatus}) => {
+const CreateBucketButton: FunctionComponent<Props> = ({
+  color = ComponentColor.Primary,
+  size = ComponentSize.Small,
+  limitStatus,
+}) => {
   const disabled = limitStatus === LimitStatus.EXCEEDED
 
-  const titleText = disabled ? 'This account has the maximum number of buckets allowed' : 'Create a bucket'
+  const titleText = disabled
+    ? 'This account has the maximum number of buckets allowed'
+    : 'Create a bucket'
   const status = disabled ? ComponentStatus.Disabled : ComponentStatus.Default
 
   return (
@@ -60,6 +66,4 @@ const mstp = ({cloud: {limits}}: AppState): StateProps => ({
   limitStatus: extractBucketLimits(limits),
 })
 
-export default connect<StateProps, {}, {}>(
-  mstp
-)(CreateBucketButton)
+export default connect<StateProps, {}, {}>(mstp)(CreateBucketButton)

--- a/ui/src/buckets/components/CreateBucketOverlay.tsx
+++ b/ui/src/buckets/components/CreateBucketOverlay.tsx
@@ -65,10 +65,7 @@ class CreateBucketOverlay extends PureComponent<Props, State> {
     return (
       <Overlay visible={true}>
         <Overlay.Container maxWidth={400}>
-          <Overlay.Header
-            title="Create Bucket"
-            onDismiss={onDismiss}
-          />
+          <Overlay.Header title="Create Bucket" onDismiss={onDismiss} />
           <Overlay.Body>
             <BucketOverlayForm
               name={bucket.name}
@@ -126,7 +123,7 @@ class CreateBucketOverlay extends PureComponent<Props, State> {
       })
     }
   }
-  
+
   private handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
     e.preventDefault()
     const {org} = this.props
@@ -158,9 +155,7 @@ class CreateBucketOverlay extends PureComponent<Props, State> {
 }
 
 const mstp = ({orgs: {org}, cloud: {limits}}: AppState): StateProps => ({
-  isRetentionLimitEnforced: !!extractBucketMaxRetentionSeconds(
-    limits
-  ),
+  isRetentionLimitEnforced: !!extractBucketMaxRetentionSeconds(limits),
   org,
   limitStatus: extractBucketLimits(limits),
 })
@@ -169,4 +164,7 @@ const mdtp = {
   createBucket,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(mstp, mdtp)(CreateBucketOverlay)
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mstp,
+  mdtp
+)(CreateBucketOverlay)

--- a/ui/src/buckets/components/RenameBucketForm.tsx
+++ b/ui/src/buckets/components/RenameBucketForm.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -36,14 +35,18 @@ interface DispatchProps {
   onRenameBucket: typeof renameBucket
 }
 
-type OwnProps = {}
+type OwnProps = {
+  onDismiss: () => void
+  bucketID: string
+}
 
-type Props = StateProps & DispatchProps & WithRouterProps & OwnProps
+type Props = StateProps & DispatchProps & OwnProps
 
 class RenameBucketForm extends PureComponent<Props, State> {
   public state = {bucket: this.props.startBucket}
 
   public render() {
+    const {onDismiss} = this.props
     const {bucket} = this.state
 
     return (
@@ -75,7 +78,7 @@ class RenameBucketForm extends PureComponent<Props, State> {
                 >
                   <Button
                     text="Cancel"
-                    onClick={this.handleClose}
+                    onClick={onDismiss}
                     type={ButtonType.Button}
                   />
                   <Button
@@ -117,11 +120,11 @@ class RenameBucketForm extends PureComponent<Props, State> {
   }
 
   private handleSubmit = (): void => {
-    const {startBucket, onRenameBucket} = this.props
+    const {startBucket, onRenameBucket, onDismiss} = this.props
     const {bucket} = this.state
 
     onRenameBucket(startBucket.name, bucket)
-    this.handleClose()
+    onDismiss()
   }
 
   private handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
@@ -130,21 +133,10 @@ class RenameBucketForm extends PureComponent<Props, State> {
 
     this.setState({bucket})
   }
-
-  private handleClose = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/load-data/buckets`)
-  }
 }
 
 const mstp = (state: AppState, props: Props): StateProps => {
-  const {
-    params: {bucketID},
-  } = props
+  const {bucketID} = props
 
   const startBucket = state.buckets.list.find(b => b.id === bucketID)
   const buckets = state.buckets.list.filter(b => b.id !== bucketID)
@@ -160,9 +152,7 @@ const mdtp: DispatchProps = {
 }
 
 // state mapping requires router
-export default withRouter<OwnProps>(
-  connect<StateProps, DispatchProps, OwnProps>(
+export default connect<StateProps, DispatchProps, OwnProps>(
     mstp,
     mdtp
   )(RenameBucketForm)
-)

--- a/ui/src/buckets/components/RenameBucketForm.tsx
+++ b/ui/src/buckets/components/RenameBucketForm.tsx
@@ -153,6 +153,6 @@ const mdtp: DispatchProps = {
 
 // state mapping requires router
 export default connect<StateProps, DispatchProps, OwnProps>(
-    mstp,
-    mdtp
-  )(RenameBucketForm)
+  mstp,
+  mdtp
+)(RenameBucketForm)

--- a/ui/src/buckets/components/RenameBucketOverlay.tsx
+++ b/ui/src/buckets/components/RenameBucketOverlay.tsx
@@ -1,7 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
-
 import _ from 'lodash'
 
 // Components
@@ -11,18 +9,25 @@ import RenameBucketForm from 'src/buckets/components/RenameBucketForm'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+interface Props {
+  onDismiss: () => void
+  bucketID: string
+}
+
 @ErrorHandling
-class RenameBucketOverlay extends PureComponent<WithRouterProps> {
+class RenameBucketOverlay extends PureComponent<Props> {
   public render() {
+    const {onDismiss, bucketID} = this.props
+
     return (
       <DangerConfirmationOverlay
         title="Rename Bucket"
         message={this.message}
         effectedItems={this.effectedItems}
-        onClose={this.handleClose}
+        onClose={onDismiss}
         confirmButtonText="I understand, let's rename my Bucket"
       >
-        <RenameBucketForm />
+        <RenameBucketForm bucketID={bucketID} onDismiss={onDismiss} />
       </DangerConfirmationOverlay>
     )
   }
@@ -40,15 +45,6 @@ class RenameBucketOverlay extends PureComponent<WithRouterProps> {
       'Templates',
     ]
   }
-
-  private handleClose = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/load-data/buckets`)
-  }
 }
 
-export default withRouter(RenameBucketOverlay)
+export default RenameBucketOverlay

--- a/ui/src/buckets/components/UpdateBucketOverlay.tsx
+++ b/ui/src/buckets/components/UpdateBucketOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -29,7 +28,12 @@ interface DispatchProps {
   onUpdateBucket: typeof updateBucket
 }
 
-type Props = StateProps & DispatchProps & WithRouterProps
+interface OwnProps {
+  onDismiss: () => void
+  bucketID: string
+}
+
+type Props = OwnProps & StateProps & DispatchProps
 
 class UpdateBucketOverlay extends PureComponent<Props, State> {
   constructor(props) {
@@ -44,18 +48,19 @@ class UpdateBucketOverlay extends PureComponent<Props, State> {
   }
 
   public render() {
+    const {onDismiss} = this.props
     const {bucket, ruleType} = this.state
 
     return (
       <Overlay visible={true}>
         <Overlay.Container maxWidth={500}>
-          <Overlay.Header title="Edit Bucket" onDismiss={this.handleClose} />
+          <Overlay.Header title="Edit Bucket" onDismiss={onDismiss} />
           <Overlay.Body>
             <BucketOverlayForm
               name={bucket.name}
               buttonText="Save Changes"
               ruleType={ruleType}
-              onCloseModal={this.handleClose}
+              onCloseModal={onDismiss}
               onSubmit={this.handleSubmit}
               disableRenaming={true}
               onChangeInput={this.handleChangeInput}
@@ -104,17 +109,17 @@ class UpdateBucketOverlay extends PureComponent<Props, State> {
 
   private handleSubmit = (e): void => {
     e.preventDefault()
-    const {onUpdateBucket} = this.props
+    const {onUpdateBucket, onDismiss} = this.props
     const {ruleType, bucket} = this.state
 
     if (ruleType === null) {
       onUpdateBucket({...bucket, retentionRules: []})
-      this.handleClose()
+      onDismiss()
       return
     }
 
     onUpdateBucket(bucket)
-    this.handleClose()
+    onDismiss()
   }
 
   private handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
@@ -124,17 +129,10 @@ class UpdateBucketOverlay extends PureComponent<Props, State> {
 
     this.setState({bucket})
   }
-
-  private handleClose = () => {
-    const {orgID} = this.props.params
-    this.props.router.push(`/orgs/${orgID}/load-data/buckets`)
-  }
 }
 
 const mstp = ({buckets}: AppState, props: Props): StateProps => {
-  const {
-    params: {bucketID},
-  } = props
+  const {bucketID} = props
 
   const bucket = buckets.list.find(b => b.id === bucketID)
 
@@ -150,4 +148,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, {}>(
   mstp,
   mdtp
-)(withRouter(UpdateBucketOverlay))
+)(UpdateBucketOverlay)

--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -7,11 +7,15 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 // Constants
 import {clientCSharpLibrary} from 'src/clientLibraries/constants'
 
-const ClientCSharpOverlay: FunctionComponent<{}> = () => {
+interface Props {
+  onDismiss: () => void
+}
+
+const ClientCSharpOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientCSharpLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`}>
+    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -15,7 +15,10 @@ const ClientCSharpOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientCSharpLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
+    <ClientLibraryOverlay
+      title={`${name} Client Library`}
+      onDismiss={onDismiss}
+    >
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientGoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientGoOverlay.tsx
@@ -15,7 +15,10 @@ const ClientGoOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientGoLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
+    <ClientLibraryOverlay
+      title={`${name} Client Library`}
+      onDismiss={onDismiss}
+    >
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientGoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientGoOverlay.tsx
@@ -7,11 +7,15 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 // Constants
 import {clientGoLibrary} from 'src/clientLibraries/constants'
 
-const ClientGoOverlay: FunctionComponent<{}> = () => {
+interface Props {
+  onDismiss: () => void
+}
+
+const ClientGoOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientGoLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`}>
+    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientJSOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJSOverlay.tsx
@@ -7,11 +7,15 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 // Constants
 import {clientJSLibrary} from 'src/clientLibraries/constants'
 
-const ClientJSOverlay: FunctionComponent<{}> = () => {
+interface Props {
+  onDismiss: () => void
+}
+
+const ClientJSOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientJSLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`}>
+    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientJSOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJSOverlay.tsx
@@ -15,7 +15,10 @@ const ClientJSOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientJSLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
+    <ClientLibraryOverlay
+      title={`${name} Client Library`}
+      onDismiss={onDismiss}
+    >
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -7,11 +7,15 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 // Constants
 import {clientJavaLibrary} from 'src/clientLibraries/constants'
 
-const ClientJavaOverlay: FunctionComponent<{}> = () => {
+interface Props {
+  onDismiss: () => void
+}
+
+const ClientJavaOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientJavaLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`}>
+    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -15,7 +15,10 @@ const ClientJavaOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientJavaLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
+    <ClientLibraryOverlay
+      title={`${name} Client Library`}
+      onDismiss={onDismiss}
+    >
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientLibraries.tsx
+++ b/ui/src/clientLibraries/components/ClientLibraries.tsx
@@ -1,22 +1,18 @@
 // Libraries
 import _ from 'lodash'
 import React, {FunctionComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Grid, SelectableCard} from '@influxdata/clockface'
 import {ResponsiveGridSizer} from 'src/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Mocks
 import {clientLibraries} from 'src/clientLibraries/constants'
 
-interface OwnProps {
-  orgID: string
-}
+interface Props {}
 
-type Props = OwnProps & WithRouterProps
-
-const ClientLibraries: FunctionComponent<Props> = ({orgID, router}) => {
+const ClientLibraries: FunctionComponent<Props> = () => {
   const clientLibrariesCount = clientLibraries.length
 
   return (
@@ -25,23 +21,21 @@ const ClientLibraries: FunctionComponent<Props> = ({orgID, router}) => {
         <Grid.Column>
           <ResponsiveGridSizer columns={clientLibrariesCount}>
             {clientLibraries.map(cl => {
-              const handleClick = (): void => {
-                router.push(
-                  `/orgs/${orgID}/load-data/client-libraries/${cl.id}`
-                )
-              }
-
               return (
-                <SelectableCard
-                  key={cl.id}
-                  id={cl.id}
-                  formName="client-libraries-cards"
-                  label={cl.name}
-                  testID={`client-libraries-cards--${cl.id}`}
-                  selected={false}
-                  onClick={handleClick}
-                  image={<img src={cl.logoUrl} />}
-                />
+                <OverlayLink overlayID={`${cl.id}-client`}>
+                  {onClick => (
+                    <SelectableCard
+                      key={cl.id}
+                      id={cl.id}
+                      formName="client-libraries-cards"
+                      label={cl.name}
+                      testID={`client-libraries-cards--${cl.id}`}
+                      selected={false}
+                      onClick={onClick}
+                      image={<img src={cl.logoUrl} />}
+                    />
+                  )}
+                </OverlayLink>
               )
             })}
           </ResponsiveGridSizer>
@@ -51,4 +45,4 @@ const ClientLibraries: FunctionComponent<Props> = ({orgID, router}) => {
   )
 }
 
-export default withRouter<OwnProps>(ClientLibraries)
+export default ClientLibraries

--- a/ui/src/clientLibraries/components/ClientLibraries.tsx
+++ b/ui/src/clientLibraries/components/ClientLibraries.tsx
@@ -22,10 +22,9 @@ const ClientLibraries: FunctionComponent<Props> = () => {
           <ResponsiveGridSizer columns={clientLibrariesCount}>
             {clientLibraries.map(cl => {
               return (
-                <OverlayLink overlayID={`${cl.id}-client`}>
+                <OverlayLink key={cl.id} overlayID={`${cl.id}-client`}>
                   {onClick => (
                     <SelectableCard
-                      key={cl.id}
                       id={cl.id}
                       formName="client-libraries-cards"
                       label={cl.name}

--- a/ui/src/clientLibraries/components/ClientLibraryOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientLibraryOverlay.tsx
@@ -1,34 +1,19 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Overlay} from '@influxdata/clockface'
 
-// Types
-import {AppState, Organization} from 'src/types'
-
-interface OwnProps {
+interface Props {
   title: string
+  onDismiss: () => void
 }
-
-interface StateProps {
-  org: Organization
-}
-
-type Props = OwnProps & StateProps & WithRouterProps
 
 const ClientLibraryOverlay: FunctionComponent<Props> = ({
   title,
   children,
-  router,
-  org,
+  onDismiss,
 }) => {
-  const onDismiss = () => {
-    router.push(`/orgs/${org.id}/load-data/client-libraries`)
-  }
-
   return (
     <Overlay visible={true}>
       <Overlay.Container maxWidth={980}>
@@ -41,10 +26,4 @@ const ClientLibraryOverlay: FunctionComponent<Props> = ({
   )
 }
 
-const mstp = ({orgs: {org}}: AppState): StateProps => ({
-  org,
-})
-
-export default connect<StateProps>(mstp)(
-  withRouter<OwnProps>(ClientLibraryOverlay)
-)
+export default ClientLibraryOverlay

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -7,11 +7,15 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 // Constants
 import {clientPythonLibrary} from 'src/clientLibraries/constants'
 
-const ClientPythonOverlay: FunctionComponent<{}> = () => {
+interface Props {
+  onDismiss: () => void
+}
+
+const ClientPythonOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientPythonLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`}>
+    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -15,7 +15,10 @@ const ClientPythonOverlay: FunctionComponent<Props> = ({onDismiss}) => {
   const {name, url} = clientPythonLibrary
 
   return (
-    <ClientLibraryOverlay title={`${name} Client Library`} onDismiss={onDismiss}>
+    <ClientLibraryOverlay
+      title={`${name} Client Library`}
+      onDismiss={onDismiss}
+    >
       <p>
         For more detailed and up to date information check out the{' '}
         <a href={url} target="_blank">

--- a/ui/src/clientLibraries/containers/ClientLibrariesPage.tsx
+++ b/ui/src/clientLibraries/containers/ClientLibrariesPage.tsx
@@ -29,7 +29,7 @@ class ClientLibrariesPage extends PureComponent<StateProps> {
         <Page titleTag={pageTitleSuffixer(['Client Libraries', 'Load Data'])}>
           <LoadDataHeader />
           <LoadDataTabbedPage activeTab="client-libraries" orgID={org.id}>
-            <ClientLibraries orgID={org.id} />
+            <ClientLibraries />
           </LoadDataTabbedPage>
         </Page>
         {children}

--- a/ui/src/dashboards/components/Dashboard.tsx
+++ b/ui/src/dashboards/components/Dashboard.tsx
@@ -22,7 +22,6 @@ interface Props {
   onPositionChange: (cells: Cell[]) => void
   onEditView: (cellID: string) => void
   onAddCell: () => void
-  onEditNote: (id: string) => void
 }
 
 @ErrorHandling
@@ -37,7 +36,6 @@ class DashboardComponent extends PureComponent<Props> {
       onEditView,
       onPositionChange,
       onAddCell,
-      onEditNote,
     } = this.props
 
     return (
@@ -51,7 +49,6 @@ class DashboardComponent extends PureComponent<Props> {
             onDeleteCell={onDeleteCell}
             onPositionChange={onPositionChange}
             onEditView={onEditView}
-            onEditNote={onEditNote}
           />
         ) : (
           <DashboardEmpty onAddCell={onAddCell} />

--- a/ui/src/dashboards/components/DashboardExportOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardExportOverlay.tsx
@@ -32,10 +32,7 @@ type Props = OwnProps & StateProps & DispatchProps
 
 class DashboardExportOverlay extends PureComponent<Props> {
   public async componentDidMount() {
-    const {
-      dashboardID,
-      convertToTemplate,
-    } = this.props
+    const {dashboardID, convertToTemplate} = this.props
 
     convertToTemplate(dashboardID)
   }

--- a/ui/src/dashboards/components/DashboardExportOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardExportOverlay.tsx
@@ -1,6 +1,5 @@
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import ExportOverlay from 'src/shared/components/ExportOverlay'
@@ -15,7 +14,8 @@ import {AppState} from 'src/types'
 import {RemoteDataState} from 'src/types'
 
 interface OwnProps {
-  params: {dashboardID: string}
+  dashboardID: string
+  onDismiss: () => void
 }
 
 interface DispatchProps {
@@ -28,12 +28,12 @@ interface StateProps {
   status: RemoteDataState
 }
 
-type Props = OwnProps & StateProps & DispatchProps & WithRouterProps
+type Props = OwnProps & StateProps & DispatchProps
 
 class DashboardExportOverlay extends PureComponent<Props> {
   public async componentDidMount() {
     const {
-      params: {dashboardID},
+      dashboardID,
       convertToTemplate,
     } = this.props
 
@@ -54,9 +54,9 @@ class DashboardExportOverlay extends PureComponent<Props> {
   }
 
   private onDismiss = () => {
-    const {router, clearExportTemplate} = this.props
+    const {onDismiss, clearExportTemplate} = this.props
 
-    router.goBack()
+    onDismiss()
     clearExportTemplate()
   }
 }
@@ -74,4 +74,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
-)(withRouter<Props>(DashboardExportOverlay))
+)(DashboardExportOverlay)

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -17,6 +17,7 @@ import {
   ComponentColor,
   Page,
 } from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Constants
 import {
@@ -45,7 +46,6 @@ interface Props {
   onRenameDashboard: (name: string) => Promise<void>
   toggleVariablesControlBar: () => void
   isShowingVariablesControlBar: boolean
-  onAddNote: () => void
   zoomedTimeRange: QueriesModels.TimeRange
 }
 
@@ -93,11 +93,15 @@ export default class DashboardHeader extends Component<Props> {
             text="Add Cell"
             titleText="Add cell to dashboard"
           />
-          <Button
-            icon={IconFont.TextBlock}
-            text="Add Note"
-            onClick={this.handleAddNote}
-          />
+          <OverlayLink overlayID="create-note">
+            {onClick => (
+              <Button
+                icon={IconFont.TextBlock}
+                text="Add Note"
+                onClick={onClick}
+              />
+            )}
+          </OverlayLink>
           <TimeZoneDropdown />
           <AutoRefreshDropdown
             onChoose={handleChooseAutoRefresh}
@@ -130,10 +134,6 @@ export default class DashboardHeader extends Component<Props> {
         </Page.Header.Right>
       </Page.Header>
     )
-  }
-
-  private handleAddNote = () => {
-    this.props.onAddNote()
   }
 
   private handleClickPresentationButton = (): void => {

--- a/ui/src/dashboards/components/DashboardImportOverlay.tsx
+++ b/ui/src/dashboards/components/DashboardImportOverlay.tsx
@@ -16,18 +16,20 @@ interface DispatchProps {
   populateDashboards: typeof getDashboardsAsync
 }
 
-interface OwnProps extends WithRouterProps {
-  params: {orgID: string}
+interface OwnProps {
+  onDismiss: () => void
 }
 
-type Props = OwnProps & DispatchProps
+type Props = OwnProps & DispatchProps & WithRouterProps
 
 class DashboardImportOverlay extends PureComponent<Props> {
   public render() {
+    const {onDismiss} = this.props
+
     return (
       <ImportOverlay
         isVisible={true}
-        onDismissOverlay={this.onDismiss}
+        onDismissOverlay={onDismiss}
         resourceName="Dashboard"
         onSubmit={this.handleImportDashboard}
       />
@@ -37,23 +39,19 @@ class DashboardImportOverlay extends PureComponent<Props> {
   private handleImportDashboard = async (
     uploadContent: string
   ): Promise<void> => {
+    const {onDismiss} = this.props
     const {createDashboardFromTemplate, populateDashboards} = this.props
     const template = JSON.parse(uploadContent)
 
     if (_.isEmpty(template)) {
-      this.onDismiss()
+      onDismiss()
     }
 
     await createDashboardFromTemplate(template)
 
     await populateDashboards()
 
-    this.onDismiss()
-  }
-
-  private onDismiss = (): void => {
-    const {router} = this.props
-    router.goBack()
+    onDismiss()
   }
 }
 
@@ -65,4 +63,4 @@ const mdtp: DispatchProps = {
 export default connect<{}, DispatchProps, OwnProps>(
   null,
   mdtp
-)(withRouter(DashboardImportOverlay))
+)(withRouter<OwnProps>(DashboardImportOverlay))

--- a/ui/src/dashboards/components/DashboardPage.tsx
+++ b/ui/src/dashboards/components/DashboardPage.tsx
@@ -166,7 +166,6 @@ class DashboardPage extends Component<Props> {
               timeRange={timeRange}
               autoRefresh={autoRefresh}
               onAddCell={this.handleAddCell}
-              onAddNote={this.showNoteOverlay}
               onManualRefresh={onManualRefresh}
               zoomedTimeRange={zoomedTimeRange}
               onRenameDashboard={this.handleRenameDashboard}
@@ -196,7 +195,6 @@ class DashboardPage extends Component<Props> {
                 onDeleteCell={this.handleDeleteDashboardCell}
                 onEditView={this.handleEditView}
                 onAddCell={this.handleAddCell}
-                onEditNote={this.showNoteOverlay}
               />
             )}
             {children}
@@ -257,14 +255,6 @@ class DashboardPage extends Component<Props> {
   private handleAddCell = async (): Promise<void> => {
     const {router, location} = this.props
     router.push(`${location.pathname}/cells/new`)
-  }
-
-  private showNoteOverlay = async (id?: string): Promise<void> => {
-    if (id) {
-      this.props.router.push(`${this.props.location.pathname}/notes/${id}/edit`)
-    } else {
-      this.props.router.push(`${this.props.location.pathname}/notes/new`)
-    }
   }
 
   private handleEditView = (cellID: string): void => {

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -187,13 +187,14 @@ class DashboardCard extends PureComponent<Props> {
   }
 
   private handleExport = () => {
-    const {
-      location,
-      router,
-      dashboard,
-    } = this.props
+    const {location, router, dashboard} = this.props
 
-    const handleExport = displayOverlay(location.pathname, router, 'export-dashboard', dashboard.id)
+    const handleExport = displayOverlay(
+      location.pathname,
+      router,
+      'export-dashboard',
+      dashboard.id
+    )
 
     handleExport()
   }

--- a/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardCard.tsx
@@ -27,6 +27,7 @@ import {resetViews} from 'src/dashboards/actions/views'
 
 // Utilities
 import {relativeTimestampFormatter} from 'src/shared/utils/relativeTimestampFormatter'
+import {displayOverlay} from 'src/overlays/components/OverlayLink'
 
 interface PassedProps {
   dashboard: Dashboard
@@ -187,12 +188,14 @@ class DashboardCard extends PureComponent<Props> {
 
   private handleExport = () => {
     const {
+      location,
       router,
       dashboard,
-      params: {orgID},
     } = this.props
 
-    router.push(`/orgs/${orgID}/dashboards/${dashboard.id}/export`)
+    const handleExport = displayOverlay(location.pathname, router, 'export-dashboard', dashboard.id)
+
+    handleExport()
   }
 }
 

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {InjectedRouter} from 'react-router'
+import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Decorators
@@ -15,6 +15,7 @@ import PageTitleWithOrg from 'src/shared/components/PageTitleWithOrg'
 import GetAssetLimits from 'src/cloud/components/GetAssetLimits'
 import GetResources, {ResourceType} from 'src/shared/components/GetResources'
 import AssetLimitAlert from 'src/cloud/components/AssetLimitAlert'
+import {displayOverlay} from 'src/overlays/components/OverlayLink'
 
 // Utils
 import {pageTitleSuffixer} from 'src/shared/utils/pageTitles'
@@ -44,12 +45,7 @@ interface StateProps {
   limitStatus: LimitStatus
 }
 
-interface OwnProps {
-  router: InjectedRouter
-  params: {orgID: string}
-}
-
-type Props = DispatchProps & StateProps & OwnProps
+type Props = DispatchProps & StateProps & WithRouterProps
 
 interface State {
   searchTerm: string
@@ -72,8 +68,14 @@ class DashboardIndex extends PureComponent<Props, State> {
       handleUpdateDashboard,
       handleDeleteDashboard,
       limitStatus,
+      location,
+      router,
     } = this.props
     const {searchTerm} = this.state
+
+    const handleSummonImportOverlay = displayOverlay(location.pathname, router, 'import-dashboard')
+    const handleSummonCreateFromTemplateOverlay = displayOverlay(location.pathname, router, 'create-dashboard-from-template')
+
     return (
       <>
         <Page titleTag={pageTitleSuffixer(['Dashboards'])}>
@@ -84,8 +86,8 @@ class DashboardIndex extends PureComponent<Props, State> {
             <Page.Header.Right>
               <AddResourceDropdown
                 onSelectNew={createDashboard}
-                onSelectImport={this.summonImportOverlay}
-                onSelectTemplate={this.summonImportFromTemplateOverlay}
+                onSelectImport={handleSummonImportOverlay}
+                onSelectTemplate={handleSummonCreateFromTemplateOverlay}
                 resourceName="Dashboard"
                 canImportFromTemplate={true}
                 status={this.addResourceStatus}
@@ -114,7 +116,8 @@ class DashboardIndex extends PureComponent<Props, State> {
                     onUpdateDashboard={handleUpdateDashboard}
                     searchTerm={searchTerm}
                     onFilterChange={this.handleFilterDashboards}
-                    onImportDashboard={this.summonImportOverlay}
+                    onImportDashboard={handleSummonImportOverlay}
+                    onCreateDashboardFromTemplate={handleSummonCreateFromTemplateOverlay}
                   />
                 </GetAssetLimits>
               </GetResources>
@@ -128,22 +131,6 @@ class DashboardIndex extends PureComponent<Props, State> {
 
   private handleFilterDashboards = (searchTerm: string): void => {
     this.setState({searchTerm})
-  }
-
-  private summonImportOverlay = (): void => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-    router.push(`/orgs/${orgID}/dashboards/import`)
-  }
-
-  private summonImportFromTemplateOverlay = (): void => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-    router.push(`/orgs/${orgID}/dashboards/import/template`)
   }
 
   private get addResourceStatus(): ComponentStatus {
@@ -172,7 +159,7 @@ const mdtp: DispatchProps = {
   cloneDashboard: cloneDashboardAction,
 }
 
-export default connect<StateProps, DispatchProps, OwnProps>(
+export default connect<StateProps, DispatchProps, {}>(
   mstp,
   mdtp
-)(DashboardIndex)
+)(withRouter(DashboardIndex))

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndex.tsx
@@ -73,8 +73,16 @@ class DashboardIndex extends PureComponent<Props, State> {
     } = this.props
     const {searchTerm} = this.state
 
-    const handleSummonImportOverlay = displayOverlay(location.pathname, router, 'import-dashboard')
-    const handleSummonCreateFromTemplateOverlay = displayOverlay(location.pathname, router, 'create-dashboard-from-template')
+    const handleSummonImportOverlay = displayOverlay(
+      location.pathname,
+      router,
+      'import-dashboard'
+    )
+    const handleSummonCreateFromTemplateOverlay = displayOverlay(
+      location.pathname,
+      router,
+      'create-dashboard-from-template'
+    )
 
     return (
       <>
@@ -117,7 +125,9 @@ class DashboardIndex extends PureComponent<Props, State> {
                     searchTerm={searchTerm}
                     onFilterChange={this.handleFilterDashboards}
                     onImportDashboard={handleSummonImportOverlay}
-                    onCreateDashboardFromTemplate={handleSummonCreateFromTemplateOverlay}
+                    onCreateDashboardFromTemplate={
+                      handleSummonCreateFromTemplateOverlay
+                    }
                   />
                 </GetAssetLimits>
               </GetResources>

--- a/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
+++ b/ui/src/dashboards/components/dashboard_index/DashboardsIndexContents.tsx
@@ -26,6 +26,7 @@ interface OwnProps {
   searchTerm: string
   filterComponent?: JSX.Element
   onImportDashboard: () => void
+  onCreateDashboardFromTemplate: () => void
 }
 
 interface DispatchProps {
@@ -61,6 +62,7 @@ class DashboardsIndexContents extends Component<Props> {
       filterComponent,
       onFilterChange,
       onImportDashboard,
+      onCreateDashboardFromTemplate,
     } = this.props
 
     return (
@@ -81,6 +83,7 @@ class DashboardsIndexContents extends Component<Props> {
             onUpdateDashboard={onUpdateDashboard}
             onFilterChange={onFilterChange}
             onImportDashboard={onImportDashboard}
+            onCreateDashboardFromTemplate={onCreateDashboardFromTemplate}
           />
         )}
       </FilterList>

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -104,7 +104,7 @@ class DashboardsTable extends PureComponent<Props, State> {
     }
 
     this.setState({sortKey, sortDirection: nextSort, sortType})
-  }
+  } 
 
   private get emptyState(): JSX.Element {
     const {onCreateDashboard, searchTerm, onImportDashboard, onCreateDashboardFromTemplate} = this.props

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -23,6 +23,7 @@ interface OwnProps {
   filterComponent?: JSX.Element
   onImportDashboard: () => void
   dashboards: Dashboard[]
+  onCreateDashboardFromTemplate: () => void
 }
 
 interface State {
@@ -105,16 +106,8 @@ class DashboardsTable extends PureComponent<Props, State> {
     this.setState({sortKey, sortDirection: nextSort, sortType})
   }
 
-  private summonImportFromTemplateOverlay = (): void => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-    router.push(`/orgs/${orgID}/dashboards/import/template`)
-  }
-
   private get emptyState(): JSX.Element {
-    const {onCreateDashboard, searchTerm, onImportDashboard} = this.props
+    const {onCreateDashboard, searchTerm, onImportDashboard, onCreateDashboardFromTemplate} = this.props
 
     if (searchTerm) {
       return (
@@ -133,7 +126,7 @@ class DashboardsTable extends PureComponent<Props, State> {
         <AddResourceDropdown
           onSelectNew={onCreateDashboard}
           onSelectImport={onImportDashboard}
-          onSelectTemplate={this.summonImportFromTemplateOverlay}
+          onSelectTemplate={onCreateDashboardFromTemplate}
           resourceName="Dashboard"
           canImportFromTemplate={true}
         />

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -104,10 +104,15 @@ class DashboardsTable extends PureComponent<Props, State> {
     }
 
     this.setState({sortKey, sortDirection: nextSort, sortType})
-  } 
+  }
 
   private get emptyState(): JSX.Element {
-    const {onCreateDashboard, searchTerm, onImportDashboard, onCreateDashboardFromTemplate} = this.props
+    const {
+      onCreateDashboard,
+      searchTerm,
+      onImportDashboard,
+      onCreateDashboardFromTemplate,
+    } = this.props
 
     if (searchTerm) {
       return (

--- a/ui/src/dataExplorer/components/DeleteDataButton.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataButton.tsx
@@ -18,7 +18,6 @@ const DeleteDataButton: FunctionComponent<{}> = () => {
           />
         )}
       </OverlayLink>
-      
     </FeatureFlag>
   )
 }

--- a/ui/src/dataExplorer/components/DeleteDataButton.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataButton.tsx
@@ -1,26 +1,26 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Button} from '@influxdata/clockface'
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
-const DeleteDataButton: FunctionComponent<WithRouterProps> = ({
-  location: {pathname},
-  router,
-}) => {
-  const onClick = () => router.push(`${pathname}/delete-data`)
-
+const DeleteDataButton: FunctionComponent<{}> = () => {
   return (
     <FeatureFlag name="deleteWithPredicate">
-      <Button
-        text="Delete Data"
-        onClick={onClick}
-        titleText="Filter and mark data for deletion"
-      />
+      <OverlayLink overlayID="delete-data">
+        {onClick => (
+          <Button
+            text="Delete Data"
+            onClick={onClick}
+            titleText="Filter and mark data for deletion"
+          />
+        )}
+      </OverlayLink>
+      
     </FeatureFlag>
   )
 }
 
-export default withRouter<{}>(DeleteDataButton)
+export default DeleteDataButton

--- a/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
@@ -33,18 +33,20 @@ interface StateProps {
   selectedTimeRange?: [number, number]
 }
 
-const DeleteDataOverlay: FunctionComponent<StateProps & WithRouterProps> = ({
+interface OwnProps {
+  onDismiss: () => void
+}
+
+const DeleteDataOverlay: FunctionComponent<OwnProps & StateProps & WithRouterProps> = ({
   selectedBucketName,
   selectedTimeRange,
-  router,
   params: {orgID},
+  onDismiss,
 }) => {
-  const handleDismiss = () => router.push(`/orgs/${orgID}/data-explorer`)
-
   return (
     <Overlay visible={true}>
       <Overlay.Container maxWidth={600}>
-        <Overlay.Header title="Delete Data" onDismiss={handleDismiss} />
+        <Overlay.Header title="Delete Data" onDismiss={onDismiss} />
         <Overlay.Body>
           <GetResources resource={ResourceType.Buckets}>
             <DeleteDataForm
@@ -70,5 +72,5 @@ const mstp = (state: AppState): StateProps => {
 }
 
 export default connect<StateProps>(mstp)(
-  withRouter<StateProps>(DeleteDataOverlay)
+  withRouter<OwnProps>(DeleteDataOverlay)
 )

--- a/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
@@ -37,12 +37,9 @@ interface OwnProps {
   onDismiss: () => void
 }
 
-const DeleteDataOverlay: FunctionComponent<OwnProps & StateProps & WithRouterProps> = ({
-  selectedBucketName,
-  selectedTimeRange,
-  params: {orgID},
-  onDismiss,
-}) => {
+const DeleteDataOverlay: FunctionComponent<
+  OwnProps & StateProps & WithRouterProps
+> = ({selectedBucketName, selectedTimeRange, params: {orgID}, onDismiss}) => {
   return (
     <Overlay visible={true}>
       <Overlay.Container maxWidth={600}>

--- a/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
@@ -34,6 +34,7 @@ interface StateProps {
 }
 
 interface OwnProps {
+  bucketID?: string
   onDismiss: () => void
 }
 
@@ -58,9 +59,11 @@ const DeleteDataOverlay: FunctionComponent<
   )
 }
 
-const mstp = (state: AppState): StateProps => {
+const mstp = (state: AppState, {bucketID}: OwnProps): StateProps => {
   const activeQuery = getActiveQuery(state)
-  const selectedBucketName = get(activeQuery, 'builderConfig.buckets.0')
+  const selectedBucket = state.buckets.list.find(b => b.id === bucketID)
+
+  const selectedBucketName = get(selectedBucket, 'name') || get(activeQuery, 'builderConfig.buckets.0')
 
   const {timeRange} = getActiveTimeMachine(state)
   const selectedTimeRange = resolveTimeRange(timeRange)

--- a/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
+++ b/ui/src/dataExplorer/components/DeleteDataOverlay.tsx
@@ -63,7 +63,8 @@ const mstp = (state: AppState, {bucketID}: OwnProps): StateProps => {
   const activeQuery = getActiveQuery(state)
   const selectedBucket = state.buckets.list.find(b => b.id === bucketID)
 
-  const selectedBucketName = get(selectedBucket, 'name') || get(activeQuery, 'builderConfig.buckets.0')
+  const selectedBucketName =
+    get(selectedBucket, 'name') || get(activeQuery, 'builderConfig.buckets.0')
 
   const {timeRange} = getActiveTimeMachine(state)
   const selectedTimeRange = resolveTimeRange(timeRange)

--- a/ui/src/dataExplorer/components/SaveAsButton.tsx
+++ b/ui/src/dataExplorer/components/SaveAsButton.tsx
@@ -1,32 +1,24 @@
 // Libraries
-import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
+import React, {FunctionComponent} from 'react'
 
 // Components
 import {IconFont, Button, ComponentColor} from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
-class SaveAsButton extends PureComponent<WithRouterProps, {}> {
-  public render() {
-    return (
-      <>
+const SaveAsButton: FunctionComponent<{}> = () => {
+  return (
+    <OverlayLink overlayID="save-as">
+      {onClick => (
         <Button
           icon={IconFont.Export}
           text="Save As"
-          onClick={this.handleShowOverlay}
+          onClick={onClick}
           color={ComponentColor.Primary}
           titleText="Save your query as a Dashboard Cell or a Task"
         />
-      </>
-    )
-  }
-
-  private handleShowOverlay = () => {
-    const {
-      location: {pathname},
-    } = this.props
-
-    this.props.router.push(`${pathname}/save`)
-  }
+      )}
+    </OverlayLink>
+  )
 }
 
-export default withRouter<{}, {}>(SaveAsButton)
+export default SaveAsButton

--- a/ui/src/dataExplorer/components/SaveAsOverlay.tsx
+++ b/ui/src/dataExplorer/components/SaveAsOverlay.tsx
@@ -17,18 +17,25 @@ interface State {
   saveAsOption: SaveAsOption
 }
 
-class SaveAsOverlay extends PureComponent<WithRouterProps, State> {
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps & WithRouterProps
+
+class SaveAsOverlay extends PureComponent<Props, State> {
   public state: State = {
     saveAsOption: SaveAsOption.Dashboard,
   }
 
   render() {
     const {saveAsOption} = this.state
+    const {onDismiss} = this.props
 
     return (
       <Overlay visible={true}>
         <Overlay.Container maxWidth={600}>
-          <Overlay.Header title="Save As" onDismiss={this.handleHideOverlay} />
+          <Overlay.Header title="Save As" onDismiss={onDismiss} />
           <Overlay.Body>
             <div className="save-as--options">
               <Radio>
@@ -73,18 +80,15 @@ class SaveAsOverlay extends PureComponent<WithRouterProps, State> {
 
   private get saveAsForm(): JSX.Element {
     const {saveAsOption} = this.state
+    const {onDismiss} = this.props
 
     if (saveAsOption === SaveAsOption.Dashboard) {
-      return <SaveAsCellForm dismiss={this.handleHideOverlay} />
+      return <SaveAsCellForm dismiss={onDismiss} />
     } else if (saveAsOption === SaveAsOption.Task) {
-      return <SaveAsTaskForm dismiss={this.handleHideOverlay} />
+      return <SaveAsTaskForm dismiss={onDismiss} />
     } else if (saveAsOption === SaveAsOption.Variable) {
-      return <SaveAsVariable onHideOverlay={this.handleHideOverlay} />
+      return <SaveAsVariable onHideOverlay={onDismiss} />
     }
-  }
-
-  private handleHideOverlay = () => {
-    this.props.router.goBack()
   }
 
   private handleSetSaveAsOption = (saveAsOption: SaveAsOption) => {
@@ -92,4 +96,4 @@ class SaveAsOverlay extends PureComponent<WithRouterProps, State> {
   }
 }
 
-export default withRouter<{}, {}>(SaveAsOverlay)
+export default withRouter<OwnProps, {}>(SaveAsOverlay)

--- a/ui/src/dataExplorer/components/__snapshots__/SaveAsButton.test.tsx.snap
+++ b/ui/src/dataExplorer/components/__snapshots__/SaveAsButton.test.tsx.snap
@@ -1,3 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SaveAsButton rendering renders 1`] = `<SaveAsButton />`;
+exports[`SaveAsButton rendering renders 1`] = `
+<withRouter(OverlayLink)
+  overlayID="save-as"
+>
+  <Component />
+</withRouter(OverlayLink)>
+`;

--- a/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard.tsx
@@ -36,6 +36,7 @@ export interface LineProtocolStepProps {
 interface OwnProps {
   onCompleteSetup: () => void
   startingStep?: number
+  onDismiss: () => void
 }
 
 interface DispatchProps {
@@ -97,11 +98,11 @@ class LineProtocolWizard extends PureComponent<Props & WithRouterProps> {
   }
 
   private handleDismiss = () => {
-    const {router, onClearDataLoaders, onClearSteps} = this.props
+    const {onDismiss, onClearDataLoaders, onClearSteps} = this.props
 
     onClearDataLoaders()
     onClearSteps()
-    router.goBack()
+    onDismiss()
   }
 
   private get stepProps(): LineProtocolStepProps {

--- a/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard.tsx
+++ b/ui/src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard.tsx
@@ -34,7 +34,6 @@ export interface LineProtocolStepProps {
 }
 
 interface OwnProps {
-  onCompleteSetup: () => void
   startingStep?: number
   onDismiss: () => void
 }

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -26,7 +26,6 @@ import TaskRunsPage from 'src/tasks/components/TaskRunsPage'
 import TaskEditPage from 'src/tasks/containers/TaskEditPage'
 import DashboardPage from 'src/dashboards/components/DashboardPage'
 import DashboardsIndex from 'src/dashboards/components/dashboard_index/DashboardsIndex'
-import CreateVariableOverlay from 'src/variables/components/CreateVariableOverlay'
 import DataExplorerPage from 'src/dataExplorer/components/DataExplorerPage'
 import {MePage} from 'src/me'
 import NotFound from 'src/shared/components/NotFound'
@@ -45,8 +44,6 @@ import TelegrafsPage from 'src/telegrafs/containers/TelegrafsPage'
 import ClientLibrariesPage from 'src/clientLibraries/containers/ClientLibrariesPage'
 import VariablesIndex from 'src/variables/containers/VariablesIndex'
 import ScrapersIndex from 'src/scrapers/containers/ScrapersIndex'
-import VariableImportOverlay from 'src/variables/components/VariableImportOverlay'
-import VariableExportOverlay from 'src/variables/components/VariableExportOverlay'
 import SetOrg from 'src/shared/containers/SetOrg'
 import RouteToOrg from 'src/shared/containers/RouteToOrg'
 import CreateScraperOverlay from 'src/scrapers/components/CreateScraperOverlay'
@@ -58,8 +55,6 @@ import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/Li
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
-import RenameVariableOverlay from 'src/variables/components/RenameVariableOverlay'
-import UpdateVariableOverlay from 'src/variables/components/UpdateVariableOverlay'
 import TaskImportFromTemplateOverlay from './tasks/components/TaskImportFromTemplateOverlay'
 import AlertingIndex from 'src/alerting/components/AlertingIndex'
 import AlertHistoryIndex from 'src/alerting/components/AlertHistoryIndex'
@@ -225,28 +220,10 @@ class Root extends PureComponent {
                               path="templates"
                               component={TemplatesIndex}
                             />
-                            <Route path="variables" component={VariablesIndex}>
-                              <Route
-                                path="import"
-                                component={VariableImportOverlay}
-                              />
-                              <Route
-                                path=":id/export"
-                                component={VariableExportOverlay}
-                              />
-                              <Route
-                                path="new"
-                                component={CreateVariableOverlay}
-                              />
-                              <Route
-                                path=":id/rename"
-                                component={RenameVariableOverlay}
-                              />
-                              <Route
-                                path=":id/edit"
-                                component={UpdateVariableOverlay}
-                              />
-                            </Route>
+                            <Route
+                              path="variables"
+                              component={VariablesIndex}
+                            />
                             <Route path="labels" component={LabelsIndex} />
                             <Route path="profile" component={OrgProfilePage} />
                           </Route>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -32,8 +32,6 @@ import NotFound from 'src/shared/components/NotFound'
 import GetLinks from 'src/shared/containers/GetLinks'
 import GetMe from 'src/shared/containers/GetMe'
 import UnauthenticatedApp from 'src/shared/containers/UnauthenticatedApp'
-import TaskExportOverlay from 'src/tasks/components/TaskExportOverlay'
-import TaskImportOverlay from 'src/tasks/components/TaskImportOverlay'
 import EditVEO from 'src/dashboards/components/EditVEO'
 import NewVEO from 'src/dashboards/components/NewVEO'
 import NoteEditorOverlay from 'src/dashboards/components/NoteEditorOverlay'
@@ -55,7 +53,6 @@ import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/Li
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
-import TaskImportFromTemplateOverlay from './tasks/components/TaskImportFromTemplateOverlay'
 import AlertingIndex from 'src/alerting/components/AlertingIndex'
 import AlertHistoryIndex from 'src/alerting/components/AlertHistoryIndex'
 
@@ -125,20 +122,7 @@ class Root extends PureComponent {
                       <Route path="orgs" component={App}>
                         <Route path=":orgID" component={SetOrg}>
                           <IndexRoute component={MePage} />
-                          <Route path="tasks" component={TasksPage}>
-                            <Route
-                              path=":id/export"
-                              component={TaskExportOverlay}
-                            />
-                            <Route
-                              path="import"
-                              component={TaskImportOverlay}
-                            />
-                            <Route
-                              path="import/template"
-                              component={TaskImportFromTemplateOverlay}
-                            />
-                          </Route>
+                          <Route path="tasks" component={TasksPage} />
                           <Route
                             path="tasks/:id/runs"
                             component={TaskRunsPage}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -27,8 +27,6 @@ import TaskEditPage from 'src/tasks/containers/TaskEditPage'
 import DashboardPage from 'src/dashboards/components/DashboardPage'
 import DashboardsIndex from 'src/dashboards/components/dashboard_index/DashboardsIndex'
 import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
-import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
-import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
 import CreateVariableOverlay from 'src/variables/components/CreateVariableOverlay'
 import DataExplorerPage from 'src/dataExplorer/components/DataExplorerPage'
 import {MePage} from 'src/me'
@@ -175,14 +173,6 @@ class Root extends PureComponent {
                             component={DataExplorerPage}
                           />
                           <Route path="dashboards" component={DashboardsIndex}>
-                            <Route
-                              path="import"
-                              component={DashboardImportOverlay}
-                            />
-                            <Route
-                              path="import/template"
-                              component={CreateFromTemplateOverlay}
-                            />
                             <Route
                               path=":dashboardID/export"
                               component={DashboardExportOverlay}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -46,11 +46,6 @@ import BucketsIndex from 'src/buckets/containers/BucketsIndex'
 import TemplatesIndex from 'src/templates/containers/TemplatesIndex'
 import TelegrafsPage from 'src/telegrafs/containers/TelegrafsPage'
 import ClientLibrariesPage from 'src/clientLibraries/containers/ClientLibrariesPage'
-import ClientCSharpOverlay from 'src/clientLibraries/components/ClientCSharpOverlay'
-import ClientGoOverlay from 'src/clientLibraries/components/ClientGoOverlay'
-import ClientJavaOverlay from 'src/clientLibraries/components/ClientJavaOverlay'
-import ClientJSOverlay from 'src/clientLibraries/components/ClientJSOverlay'
-import ClientPythonOverlay from 'src/clientLibraries/components/ClientPythonOverlay'
 import TemplateImportOverlay from 'src/templates/components/TemplateImportOverlay'
 import TemplateExportOverlay from 'src/templates/components/TemplateExportOverlay'
 import VariablesIndex from 'src/variables/containers/VariablesIndex'
@@ -262,25 +257,7 @@ class Root extends PureComponent {
                               <Route
                                 path="client-libraries"
                                 component={ClientLibrariesPage}
-                              >
-                                <Route
-                                  path="csharp"
-                                  component={ClientCSharpOverlay}
-                                />
-                                <Route path="go" component={ClientGoOverlay} />
-                                <Route
-                                  path="java"
-                                  component={ClientJavaOverlay}
-                                />
-                                <Route
-                                  path="javascript-node"
-                                  component={ClientJSOverlay}
-                                />
-                                <Route
-                                  path="python"
-                                  component={ClientPythonOverlay}
-                                />
-                              </Route>
+                              />
                             </FeatureFlag>
                           </Route>
                           <Route path="settings">

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -71,9 +71,6 @@ import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateVi
 import AlertingIndex from 'src/alerting/components/AlertingIndex'
 import AlertHistoryIndex from 'src/alerting/components/AlertHistoryIndex'
 import BucketsDeleteDataOverlay from 'src/shared/components/DeleteDataOverlay'
-import NewThresholdCheckEO from 'src/alerting/components/NewThresholdCheckEO'
-import NewDeadmanCheckEO from 'src/alerting/components/NewDeadmanCheckEO'
-import EditCheckEO from 'src/alerting/components/EditCheckEO'
 
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
@@ -288,20 +285,7 @@ class Root extends PureComponent {
                             <Route path="labels" component={LabelsIndex} />
                             <Route path="profile" component={OrgProfilePage} />
                           </Route>
-                          <Route path="alerting" component={AlertingIndex}>
-                            <Route
-                              path="checks/new-threshold"
-                              component={NewThresholdCheckEO}
-                            />
-                            <Route
-                              path="checks/new-deadman"
-                              component={NewDeadmanCheckEO}
-                            />
-                            <Route
-                              path="checks/:checkID/edit"
-                              component={EditCheckEO}
-                            />
-                          </Route>
+                          <Route path="alerting" component={AlertingIndex} />
                           <Route
                             path="alert-history"
                             component={AlertHistoryIndex}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -62,15 +62,12 @@ import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/Li
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
-import UpdateBucketOverlay from 'src/buckets/components/UpdateBucketOverlay'
-import RenameBucketOverlay from 'src/buckets/components/RenameBucketOverlay'
 import RenameVariableOverlay from 'src/variables/components/RenameVariableOverlay'
 import UpdateVariableOverlay from 'src/variables/components/UpdateVariableOverlay'
 import TaskImportFromTemplateOverlay from './tasks/components/TaskImportFromTemplateOverlay'
 import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateViewOverlay'
 import AlertingIndex from 'src/alerting/components/AlertingIndex'
 import AlertHistoryIndex from 'src/alerting/components/AlertHistoryIndex'
-import BucketsDeleteDataOverlay from 'src/shared/components/DeleteDataOverlay'
 
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
@@ -200,18 +197,6 @@ class Root extends PureComponent {
                                 <Route
                                   path="scrapers/new"
                                   component={CreateScraperOverlay}
-                                />
-                                <Route
-                                  path="edit"
-                                  component={UpdateBucketOverlay}
-                                />
-                                <Route
-                                  path="delete-data"
-                                  component={BucketsDeleteDataOverlay}
-                                />
-                                <Route
-                                  path="rename"
-                                  component={RenameBucketOverlay}
                                 />
                               </Route>
                             </Route>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -44,12 +44,10 @@ import VariablesIndex from 'src/variables/containers/VariablesIndex'
 import ScrapersIndex from 'src/scrapers/containers/ScrapersIndex'
 import SetOrg from 'src/shared/containers/SetOrg'
 import RouteToOrg from 'src/shared/containers/RouteToOrg'
-import CreateScraperOverlay from 'src/scrapers/components/CreateScraperOverlay'
 import TokensIndex from 'src/authorizations/containers/TokensIndex'
 import MembersIndex from 'src/members/containers/MembersIndex'
 import LabelsIndex from 'src/labels/containers/LabelsIndex'
 import TelegrafConfigOverlay from 'src/telegrafs/components/TelegrafConfigOverlay'
-import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard'
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
@@ -160,16 +158,8 @@ class Root extends PureComponent {
                             <Route path="buckets" component={BucketsIndex}>
                               <Route path=":bucketID">
                                 <Route
-                                  path="line-protocols/new"
-                                  component={LineProtocolWizard}
-                                />
-                                <Route
                                   path="telegrafs/new"
                                   component={CollectorsWizard}
-                                />
-                                <Route
-                                  path="scrapers/new"
-                                  component={CreateScraperOverlay}
                                 />
                               </Route>
                             </Route>
@@ -184,12 +174,7 @@ class Root extends PureComponent {
                               />
                               <Route path="new" component={CollectorsWizard} />
                             </Route>
-                            <Route path="scrapers" component={ScrapersIndex}>
-                              <Route
-                                path="new"
-                                component={CreateScraperOverlay}
-                              />
-                            </Route>
+                            <Route path="scrapers" component={ScrapersIndex} />
                             <FeatureFlag name="clientLibrariesPage">
                               <Route
                                 path="client-libraries"

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -62,7 +62,6 @@ import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/Li
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
 import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
-import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 import UpdateBucketOverlay from 'src/buckets/components/UpdateBucketOverlay'
 import RenameBucketOverlay from 'src/buckets/components/RenameBucketOverlay'
 import RenameVariableOverlay from 'src/variables/components/RenameVariableOverlay'
@@ -291,12 +290,7 @@ class Root extends PureComponent {
                               />
                             </Route>
                             <Route path="labels" component={LabelsIndex} />
-                            <Route path="profile" component={OrgProfilePage}>
-                              <Route
-                                path="rename"
-                                component={RenameOrgOverlay}
-                              />
-                            </Route>
+                            <Route path="profile" component={OrgProfilePage} />
                           </Route>
                           <Route path="alerting" component={AlertingIndex}>
                             <Route

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -76,7 +76,6 @@ import NewDeadmanCheckEO from 'src/alerting/components/NewDeadmanCheckEO'
 import EditCheckEO from 'src/alerting/components/EditCheckEO'
 import NewRuleOverlay from 'src/alerting/components/notifications/NewRuleOverlay'
 import EditRuleOverlay from 'src/alerting/components/notifications/EditRuleOverlay'
-import NewEndpointOverlay from 'src/alerting/components/endpoints/NewEndpointOverlay'
 import EditEndpointOverlay from 'src/alerting/components/endpoints/EditEndpointOverlay'
 
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
@@ -312,10 +311,6 @@ class Root extends PureComponent {
                             <Route
                               path="rules/:ruleID/edit"
                               component={EditRuleOverlay}
-                            />
-                            <Route
-                              path="endpoints/new"
-                              component={NewEndpointOverlay}
                             />
                             <Route
                               path="endpoints/:endpointID/edit"

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -43,8 +43,6 @@ import BucketsIndex from 'src/buckets/containers/BucketsIndex'
 import TemplatesIndex from 'src/templates/containers/TemplatesIndex'
 import TelegrafsPage from 'src/telegrafs/containers/TelegrafsPage'
 import ClientLibrariesPage from 'src/clientLibraries/containers/ClientLibrariesPage'
-import TemplateImportOverlay from 'src/templates/components/TemplateImportOverlay'
-import TemplateExportOverlay from 'src/templates/components/TemplateExportOverlay'
 import VariablesIndex from 'src/variables/containers/VariablesIndex'
 import ScrapersIndex from 'src/scrapers/containers/ScrapersIndex'
 import VariableImportOverlay from 'src/variables/components/VariableImportOverlay'
@@ -55,7 +53,6 @@ import CreateScraperOverlay from 'src/scrapers/components/CreateScraperOverlay'
 import TokensIndex from 'src/authorizations/containers/TokensIndex'
 import MembersIndex from 'src/members/containers/MembersIndex'
 import LabelsIndex from 'src/labels/containers/LabelsIndex'
-import TemplateViewOverlay from 'src/templates/components/TemplateViewOverlay'
 import TelegrafConfigOverlay from 'src/telegrafs/components/TelegrafConfigOverlay'
 import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard'
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
@@ -64,7 +61,6 @@ import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
 import RenameVariableOverlay from 'src/variables/components/RenameVariableOverlay'
 import UpdateVariableOverlay from 'src/variables/components/UpdateVariableOverlay'
 import TaskImportFromTemplateOverlay from './tasks/components/TaskImportFromTemplateOverlay'
-import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateViewOverlay'
 import AlertingIndex from 'src/alerting/components/AlertingIndex'
 import AlertHistoryIndex from 'src/alerting/components/AlertHistoryIndex'
 
@@ -225,24 +221,10 @@ class Root extends PureComponent {
                           <Route path="settings">
                             <IndexRoute component={MembersIndex} />
                             <Route path="members" component={MembersIndex} />
-                            <Route path="templates" component={TemplatesIndex}>
-                              <Route
-                                path="import"
-                                component={TemplateImportOverlay}
-                              />
-                              <Route
-                                path=":id/export"
-                                component={TemplateExportOverlay}
-                              />
-                              <Route
-                                path=":id/view"
-                                component={TemplateViewOverlay}
-                              />
-                              <Route
-                                path=":id/static/view"
-                                component={StaticTemplateViewOverlay}
-                              />
-                            </Route>
+                            <Route
+                              path="templates"
+                              component={TemplatesIndex}
+                            />
                             <Route path="variables" component={VariablesIndex}>
                               <Route
                                 path="import"

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -82,7 +82,6 @@ import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateVi
 import AlertingIndex from 'src/alerting/components/AlertingIndex'
 import AlertHistoryIndex from 'src/alerting/components/AlertHistoryIndex'
 import BucketsDeleteDataOverlay from 'src/shared/components/DeleteDataOverlay'
-import DEDeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
 import NewThresholdCheckEO from 'src/alerting/components/NewThresholdCheckEO'
 import NewDeadmanCheckEO from 'src/alerting/components/NewDeadmanCheckEO'
 import EditCheckEO from 'src/alerting/components/EditCheckEO'
@@ -183,10 +182,6 @@ class Root extends PureComponent {
                             component={DataExplorerPage}
                           >
                             <Route path="save" component={SaveAsOverlay} />
-                            <Route
-                              path="delete-data"
-                              component={DEDeleteDataOverlay}
-                            />
                           </Route>
                           <Route path="dashboards" component={DashboardsIndex}>
                             <Route

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -26,7 +26,6 @@ import TaskRunsPage from 'src/tasks/components/TaskRunsPage'
 import TaskEditPage from 'src/tasks/containers/TaskEditPage'
 import DashboardPage from 'src/dashboards/components/DashboardPage'
 import DashboardsIndex from 'src/dashboards/components/dashboard_index/DashboardsIndex'
-import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 import CreateVariableOverlay from 'src/variables/components/CreateVariableOverlay'
 import DataExplorerPage from 'src/dataExplorer/components/DataExplorerPage'
 import {MePage} from 'src/me'
@@ -172,12 +171,7 @@ class Root extends PureComponent {
                             path="data-explorer"
                             component={DataExplorerPage}
                           />
-                          <Route path="dashboards" component={DashboardsIndex}>
-                            <Route
-                              path=":dashboardID/export"
-                              component={DashboardExportOverlay}
-                            />
-                          </Route>
+                          <Route path="dashboards" component={DashboardsIndex}/>
                           <Route
                             path="dashboards/:dashboardID"
                             component={DashboardPage}

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -69,7 +69,6 @@ import TelegrafConfigOverlay from 'src/telegrafs/components/TelegrafConfigOverla
 import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard'
 import CollectorsWizard from 'src/dataLoaders/components/collectorsWizard/CollectorsWizard'
 import TelegrafInstructionsOverlay from 'src/telegrafs/components/TelegrafInstructionsOverlay'
-import AddMembersOverlay from 'src/members/components/AddMembersOverlay'
 import OrgProfilePage from 'src/organizations/containers/OrgProfilePage'
 import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 import UpdateBucketOverlay from 'src/buckets/components/UpdateBucketOverlay'
@@ -286,9 +285,7 @@ class Root extends PureComponent {
                           </Route>
                           <Route path="settings">
                             <IndexRoute component={MembersIndex} />
-                            <Route path="members" component={MembersIndex}>
-                              <Route path="new" component={AddMembersOverlay} />
-                            </Route>
+                            <Route path="members" component={MembersIndex} />
                             <Route path="templates" component={TemplatesIndex}>
                               <Route
                                 path="import"

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -51,7 +51,6 @@ import VariableImportOverlay from 'src/variables/components/VariableImportOverla
 import VariableExportOverlay from 'src/variables/components/VariableExportOverlay'
 import SetOrg from 'src/shared/containers/SetOrg'
 import RouteToOrg from 'src/shared/containers/RouteToOrg'
-import CreateOrgOverlay from 'src/organizations/components/CreateOrgOverlay'
 import CreateScraperOverlay from 'src/scrapers/components/CreateScraperOverlay'
 import TokensIndex from 'src/authorizations/containers/TokensIndex'
 import MembersIndex from 'src/members/containers/MembersIndex'
@@ -133,7 +132,6 @@ class Root extends PureComponent {
                     <Route path="/">
                       <IndexRoute component={RouteToOrg} />
                       <Route path="orgs" component={App}>
-                        <Route path="new" component={CreateOrgOverlay} />
                         <Route path=":orgID" component={SetOrg}>
                           <IndexRoute component={MePage} />
                           <Route path="tasks" component={TasksPage}>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -31,7 +31,6 @@ import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOve
 import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
 import CreateVariableOverlay from 'src/variables/components/CreateVariableOverlay'
 import DataExplorerPage from 'src/dataExplorer/components/DataExplorerPage'
-import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
 import {MePage} from 'src/me'
 import NotFound from 'src/shared/components/NotFound'
 import GetLinks from 'src/shared/containers/GetLinks'
@@ -180,9 +179,7 @@ class Root extends PureComponent {
                           <Route
                             path="data-explorer"
                             component={DataExplorerPage}
-                          >
-                            <Route path="save" component={SaveAsOverlay} />
-                          </Route>
+                          />
                           <Route path="dashboards" component={DashboardsIndex}>
                             <Route
                               path="import"

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -74,9 +74,6 @@ import BucketsDeleteDataOverlay from 'src/shared/components/DeleteDataOverlay'
 import NewThresholdCheckEO from 'src/alerting/components/NewThresholdCheckEO'
 import NewDeadmanCheckEO from 'src/alerting/components/NewDeadmanCheckEO'
 import EditCheckEO from 'src/alerting/components/EditCheckEO'
-import NewRuleOverlay from 'src/alerting/components/notifications/NewRuleOverlay'
-import EditRuleOverlay from 'src/alerting/components/notifications/EditRuleOverlay'
-import EditEndpointOverlay from 'src/alerting/components/endpoints/EditEndpointOverlay'
 
 import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
@@ -303,18 +300,6 @@ class Root extends PureComponent {
                             <Route
                               path="checks/:checkID/edit"
                               component={EditCheckEO}
-                            />
-                            <Route
-                              path="rules/new"
-                              component={NewRuleOverlay}
-                            />
-                            <Route
-                              path="rules/:ruleID/edit"
-                              component={EditRuleOverlay}
-                            />
-                            <Route
-                              path="endpoints/:endpointID/edit"
-                              component={EditEndpointOverlay}
                             />
                           </Route>
                           <Route

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -34,7 +34,6 @@ import GetMe from 'src/shared/containers/GetMe'
 import UnauthenticatedApp from 'src/shared/containers/UnauthenticatedApp'
 import EditVEO from 'src/dashboards/components/EditVEO'
 import NewVEO from 'src/dashboards/components/NewVEO'
-import NoteEditorOverlay from 'src/dashboards/components/NoteEditorOverlay'
 import OnboardingWizardPage from 'src/onboarding/containers/OnboardingWizardPage'
 import BucketsIndex from 'src/buckets/containers/BucketsIndex'
 import TemplatesIndex from 'src/templates/containers/TemplatesIndex'
@@ -142,13 +141,6 @@ class Root extends PureComponent {
                             <Route path="cells">
                               <Route path="new" component={NewVEO} />
                               <Route path=":cellID/edit" component={EditVEO} />
-                            </Route>
-                            <Route path="notes">
-                              <Route path="new" component={NoteEditorOverlay} />
-                              <Route
-                                path=":cellID/edit"
-                                component={NoteEditorOverlay}
-                              />
                             </Route>
                           </Route>
                           <Route path="me" component={MePage} />

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -77,8 +77,6 @@ import UpdateBucketOverlay from 'src/buckets/components/UpdateBucketOverlay'
 import RenameBucketOverlay from 'src/buckets/components/RenameBucketOverlay'
 import RenameVariableOverlay from 'src/variables/components/RenameVariableOverlay'
 import UpdateVariableOverlay from 'src/variables/components/UpdateVariableOverlay'
-import AllAccessTokenOverlay from 'src/authorizations/components/AllAccessTokenOverlay'
-import BucketsTokenOverlay from 'src/authorizations/components/BucketsTokenOverlay'
 import TaskImportFromTemplateOverlay from './tasks/components/TaskImportFromTemplateOverlay'
 import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateViewOverlay'
 import AlertingIndex from 'src/alerting/components/AlertingIndex'
@@ -223,18 +221,7 @@ class Root extends PureComponent {
                           <Route path="me" component={MePage} />
                           <Route path="load-data">
                             <IndexRoute component={BucketsIndex} />
-                            <Route path="tokens" component={TokensIndex}>
-                              <Route path="generate">
-                                <Route
-                                  path="all-access"
-                                  component={AllAccessTokenOverlay}
-                                />
-                                <Route
-                                  path="buckets"
-                                  component={BucketsTokenOverlay}
-                                />
-                              </Route>
-                            </Route>
+                            <Route path="tokens" component={TokensIndex} />
                             <Route path="buckets" component={BucketsIndex}>
                               <Route path=":bucketID">
                                 <Route

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -171,7 +171,10 @@ class Root extends PureComponent {
                             path="data-explorer"
                             component={DataExplorerPage}
                           />
-                          <Route path="dashboards" component={DashboardsIndex}/>
+                          <Route
+                            path="dashboards"
+                            component={DashboardsIndex}
+                          />
                           <Route
                             path="dashboards/:dashboardID"
                             component={DashboardPage}

--- a/ui/src/members/components/AddMembersOverlay.tsx
+++ b/ui/src/members/components/AddMembersOverlay.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import AddMembersForm from 'src/members/components/AddMembersForm'
@@ -27,13 +26,17 @@ interface DispatchProps {
   addMember: typeof addNewMember
 }
 
+interface OwnProps {
+  onDismiss: () => void
+}
+
 interface State {
   selectedUserIDs: string[]
   searchTerm: string
   selectedMembers: UsersMap
 }
 
-type Props = StateProps & DispatchProps & WithRouterProps
+type Props = OwnProps & StateProps & DispatchProps
 
 class AddMembersOverlay extends PureComponent<Props, State> {
   public state: State = {
@@ -47,14 +50,14 @@ class AddMembersOverlay extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {status} = this.props
+    const {status, onDismiss} = this.props
     const {selectedUserIDs, searchTerm, selectedMembers} = this.state
 
     return (
       <GetResources resource={ResourceType.Users}>
         <Overlay visible={true}>
           <Overlay.Container maxWidth={720}>
-            <Overlay.Header title="Add Member" onDismiss={this.handleDismiss} />
+            <Overlay.Header title="Add Member" onDismiss={onDismiss} />
             <Overlay.Body>
               <SpinnerContainer
                 loading={status}
@@ -67,7 +70,7 @@ class AddMembersOverlay extends PureComponent<Props, State> {
                 >
                   {ts => (
                     <AddMembersForm
-                      onCloseModal={this.handleDismiss}
+                      onCloseModal={onDismiss}
                       users={ts}
                       onSelect={this.handleSelectUserID}
                       selectedUserIDs={selectedUserIDs}
@@ -119,24 +122,15 @@ class AddMembersOverlay extends PureComponent<Props, State> {
     })
   }
 
-  private handleDismiss = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/members`)
-  }
-
   private handleSave = () => {
-    const {addMember} = this.props
+    const {addMember, onDismiss} = this.props
     const {selectedMembers} = this.state
 
     Object.keys(selectedMembers).map(id => {
       addMember({id: id, name: selectedMembers[id].name})
     })
 
-    this.handleDismiss()
+    onDismiss()
   }
 }
 
@@ -152,4 +146,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps>(
   mstp,
   mdtp
-)(withRouter<Props>(AddMembersOverlay))
+)(AddMembersOverlay)

--- a/ui/src/members/components/Members.tsx
+++ b/ui/src/members/components/Members.tsx
@@ -2,7 +2,6 @@
 import React, {PureComponent} from 'react'
 import _ from 'lodash'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import SettingsTabbedPageHeader from 'src/settings/components/SettingsTabbedPageHeader'
@@ -10,6 +9,7 @@ import {Button, EmptyState, Sort} from '@influxdata/clockface'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import MemberList from 'src/members/components/MemberList'
 import FilterList from 'src/shared/components/Filter'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Actions
 import {deleteMember} from 'src/members/actions'
@@ -38,7 +38,7 @@ interface State {
 
 type SortKey = keyof Member
 
-class Members extends PureComponent<Props & WithRouterProps, State> {
+class Members extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
@@ -59,12 +59,16 @@ class Members extends PureComponent<Props & WithRouterProps, State> {
             searchTerm={searchTerm}
             onSearch={this.handleFilterChange}
           />
-          <Button
-            text="Add Member"
-            icon={IconFont.Plus}
-            color={ComponentColor.Primary}
-            onClick={this.handleOpenOverlay}
-          />
+          <OverlayLink overlayID="add-members">
+            {onClick => (
+              <Button
+                text="Add Member"
+                icon={IconFont.Plus}
+                color={ComponentColor.Primary}
+                onClick={onClick}
+              />
+            )}
+          </OverlayLink>
         </SettingsTabbedPageHeader>
         <FilterList<Member>
           list={this.props.members}
@@ -95,15 +99,6 @@ class Members extends PureComponent<Props & WithRouterProps, State> {
   private removeMember = (member: Member) => {
     const {onRemoveMember} = this.props
     onRemoveMember(member)
-  }
-
-  private handleOpenOverlay = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/members/new`)
   }
 
   private handleFilterChange = (searchTerm: string): void => {
@@ -143,4 +138,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, {}>(
   mstp,
   mdtp
-)(withRouter<Props>(Members))
+)(Members)

--- a/ui/src/organizations/components/CreateOrgOverlay.tsx
+++ b/ui/src/organizations/components/CreateOrgOverlay.tsx
@@ -65,10 +65,7 @@ class CreateOrgOverlay extends PureComponent<Props, State> {
     return (
       <Overlay visible={true}>
         <Overlay.Container maxWidth={500}>
-          <Overlay.Header
-            title="Create Organization"
-            onDismiss={onDismiss}
-          />
+          <Overlay.Header title="Create Organization" onDismiss={onDismiss} />
           <Form onSubmit={this.handleCreateOrg}>
             <Overlay.Body>
               <Form.Element

--- a/ui/src/organizations/components/CreateOrgOverlay.tsx
+++ b/ui/src/organizations/components/CreateOrgOverlay.tsx
@@ -19,7 +19,9 @@ import {
 // Actions
 import {createOrgWithBucket} from 'src/organizations/actions/orgs'
 
-interface OwnProps {}
+interface OwnProps {
+  onDismiss: () => void
+}
 
 interface DispatchProps {
   createOrgWithBucket: typeof createOrgWithBucket
@@ -58,13 +60,14 @@ class CreateOrgOverlay extends PureComponent<Props, State> {
       bucketNameInputStatus,
       bucketErrorMessage,
     } = this.state
+    const {onDismiss} = this.props
 
     return (
       <Overlay visible={true}>
         <Overlay.Container maxWidth={500}>
           <Overlay.Header
             title="Create Organization"
-            onDismiss={this.closeModal}
+            onDismiss={onDismiss}
           />
           <Form onSubmit={this.handleCreateOrg}>
             <Overlay.Body>
@@ -98,7 +101,7 @@ class CreateOrgOverlay extends PureComponent<Props, State> {
               </Form.Element>
             </Overlay.Body>
             <Overlay.Footer>
-              <Button text="Cancel" onClick={this.closeModal} />
+              <Button text="Cancel" onClick={onDismiss} />
               <Button
                 text="Create"
                 type={ButtonType.Submit}
@@ -125,13 +128,10 @@ class CreateOrgOverlay extends PureComponent<Props, State> {
 
   private handleCreateOrg = async () => {
     const {org, bucket} = this.state
-    const {createOrgWithBucket} = this.props
+    const {createOrgWithBucket, onDismiss} = this.props
 
     await createOrgWithBucket(org, bucket as any)
-  }
-
-  private closeModal = () => {
-    this.props.router.goBack()
+    onDismiss()
   }
 
   private handleChangeOrgInput = (e: ChangeEvent<HTMLInputElement>) => {

--- a/ui/src/organizations/components/OrgProfileTab.tsx
+++ b/ui/src/organizations/components/OrgProfileTab.tsx
@@ -29,39 +29,35 @@ class OrgProfileTab extends PureComponent<Props> {
           <Panel.Title>Organization Profile</Panel.Title>
         </Panel.Header>
         <Panel.Body>
-            <Panel
-              gradient={Gradients.DocScott}
-              size={ComponentSize.ExtraSmall}
-            >
-              <Panel.Header>
-                <Panel.Title>Danger Zone!</Panel.Title>
-              </Panel.Header>
-              <Panel.Body>
-                <FlexBox
-                  stretchToFitWidth={true}
-                  alignItems={AlignItems.Center}
-                  direction={FlexDirection.Row}
-                  justifyContent={JustifyContent.SpaceBetween}
-                >
-                  <div>
-                    <h5 style={{marginBottom: '0'}}>Rename Organization</h5>
-                    <p style={{marginTop: '2px'}}>
-                      This action can have wide-reaching unintended
-                      consequences.
-                    </p>
-                  </div>
-                  <OverlayLink overlayID="rename-organization">
-                    {onClick => (
-                      <Button
-                        text="Rename"
-                        icon={IconFont.Pencil}
-                        onClick={onClick}
-                      />
-                    )}
-                  </OverlayLink>
-                </FlexBox>
-              </Panel.Body>
-            </Panel>
+          <Panel gradient={Gradients.DocScott} size={ComponentSize.ExtraSmall}>
+            <Panel.Header>
+              <Panel.Title>Danger Zone!</Panel.Title>
+            </Panel.Header>
+            <Panel.Body>
+              <FlexBox
+                stretchToFitWidth={true}
+                alignItems={AlignItems.Center}
+                direction={FlexDirection.Row}
+                justifyContent={JustifyContent.SpaceBetween}
+              >
+                <div>
+                  <h5 style={{marginBottom: '0'}}>Rename Organization</h5>
+                  <p style={{marginTop: '2px'}}>
+                    This action can have wide-reaching unintended consequences.
+                  </p>
+                </div>
+                <OverlayLink overlayID="rename-organization">
+                  {onClick => (
+                    <Button
+                      text="Rename"
+                      icon={IconFont.Pencil}
+                      onClick={onClick}
+                    />
+                  )}
+                </OverlayLink>
+              </FlexBox>
+            </Panel.Body>
+          </Panel>
         </Panel.Body>
       </Panel>
     )

--- a/ui/src/organizations/components/OrgProfileTab.tsx
+++ b/ui/src/organizations/components/OrgProfileTab.tsx
@@ -1,12 +1,9 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {WithRouterProps, withRouter} from 'react-router'
-
 import _ from 'lodash'
 
 // Components
 import {
-  Form,
   Button,
   ComponentSize,
   Panel,
@@ -19,11 +16,9 @@ import {
   JustifyContent,
 } from '@influxdata/clockface'
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
-// Types
-import {ButtonType} from 'src/clockface'
-
-type Props = WithRouterProps
+type Props = {}
 
 @ErrorHandling
 class OrgProfileTab extends PureComponent<Props> {
@@ -34,7 +29,6 @@ class OrgProfileTab extends PureComponent<Props> {
           <Panel.Title>Organization Profile</Panel.Title>
         </Panel.Header>
         <Panel.Body>
-          <Form onSubmit={this.handleShowEditOverlay}>
             <Panel
               gradient={Gradients.DocScott}
               size={ComponentSize.ExtraSmall}
@@ -56,28 +50,22 @@ class OrgProfileTab extends PureComponent<Props> {
                       consequences.
                     </p>
                   </div>
-                  <Button
-                    text="Rename"
-                    icon={IconFont.Pencil}
-                    type={ButtonType.Submit}
-                  />
+                  <OverlayLink overlayID="rename-organization">
+                    {onClick => (
+                      <Button
+                        text="Rename"
+                        icon={IconFont.Pencil}
+                        onClick={onClick}
+                      />
+                    )}
+                  </OverlayLink>
                 </FlexBox>
               </Panel.Body>
             </Panel>
-          </Form>
         </Panel.Body>
       </Panel>
     )
   }
-
-  private handleShowEditOverlay = () => {
-    const {
-      params: {orgID},
-      router,
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/profile/rename`)
-  }
 }
 
-export default withRouter<{}>(OrgProfileTab)
+export default OrgProfileTab

--- a/ui/src/organizations/components/RenameOrgForm.tsx
+++ b/ui/src/organizations/components/RenameOrgForm.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
 import {connect} from 'react-redux'
-import {WithRouterProps, withRouter} from 'react-router'
 
 import _ from 'lodash'
 
@@ -36,7 +35,11 @@ interface DispatchProps {
   onRenameOrg: typeof renameOrg
 }
 
-type Props = StateProps & DispatchProps & WithRouterProps
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps & StateProps & DispatchProps
 
 interface State {
   org: Organization
@@ -52,6 +55,7 @@ class RenameOrgForm extends PureComponent<Props, State> {
   }
 
   public render() {
+    const {onDismiss} = this.props
     const {org} = this.state
 
     return (
@@ -85,7 +89,7 @@ class RenameOrgForm extends PureComponent<Props, State> {
                   <Button
                     text="Cancel"
                     icon={IconFont.Remove}
-                    onClick={this.handleGoBack}
+                    onClick={onDismiss}
                   />
                   <Button
                     text="Change Organization Name"
@@ -116,10 +120,6 @@ class RenameOrgForm extends PureComponent<Props, State> {
     return validationStatus
   }
 
-  private handleGoBack = () => {
-    this.props.router.push(`/orgs/${this.props.startOrg.id}/settings/profile`)
-  }
-
   private handleValidation = (orgName: string): string | null => {
     if (!orgName) {
       return 'Name is required'
@@ -142,12 +142,12 @@ class RenameOrgForm extends PureComponent<Props, State> {
   }
 
   private handleRenameOrg = async () => {
-    const {onRenameOrg, startOrg} = this.props
+    const {onRenameOrg, startOrg, onDismiss} = this.props
     const {org} = this.state
 
     await onRenameOrg(startOrg.name, org)
 
-    this.handleGoBack()
+    onDismiss()
   }
 }
 
@@ -168,4 +168,4 @@ const mdtp = {
 export default connect<StateProps, DispatchProps>(
   mstp,
   mdtp
-)(withRouter<{}>(RenameOrgForm))
+)(RenameOrgForm)

--- a/ui/src/organizations/components/RenameOrgOverlay.tsx
+++ b/ui/src/organizations/components/RenameOrgOverlay.tsx
@@ -1,7 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
-
 import _ from 'lodash'
 
 // Components
@@ -11,18 +9,24 @@ import RenameOrgForm from 'src/organizations/components/RenameOrgForm'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+interface Props {
+  onDismiss: () => void
+}
+
 @ErrorHandling
-class RenameOrgOverlay extends PureComponent<WithRouterProps> {
+class RenameOrgOverlay extends PureComponent<Props> {
   public render() {
+    const {onDismiss} = this.props
+  
     return (
       <DangerConfirmationOverlay
         title="Rename Organization"
         message={this.message}
         effectedItems={this.effectedItems}
-        onClose={this.handleClose}
+        onClose={onDismiss}
         confirmButtonText="I understand, let's rename my Organization"
       >
-        <RenameOrgForm />
+        <RenameOrgForm onDismiss={onDismiss} />
       </DangerConfirmationOverlay>
     )
   }
@@ -40,15 +44,6 @@ class RenameOrgOverlay extends PureComponent<WithRouterProps> {
       'Client Libraries',
     ]
   }
-
-  private handleClose = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/profile`)
-  }
 }
 
-export default withRouter(RenameOrgOverlay)
+export default RenameOrgOverlay

--- a/ui/src/organizations/components/RenameOrgOverlay.tsx
+++ b/ui/src/organizations/components/RenameOrgOverlay.tsx
@@ -17,7 +17,7 @@ interface Props {
 class RenameOrgOverlay extends PureComponent<Props> {
   public render() {
     const {onDismiss} = this.props
-  
+
     return (
       <DangerConfirmationOverlay
         title="Rename Organization"

--- a/ui/src/overlays/components/OverlayLink.tsx
+++ b/ui/src/overlays/components/OverlayLink.tsx
@@ -1,6 +1,7 @@
 // Libraries
 import {FunctionComponent} from 'react'
 import {withRouter, WithRouterProps, InjectedRouter} from 'react-router'
+// import queryString from 'query-string'
 
 type HandleOpenOverlay = () => void
 
@@ -15,9 +16,16 @@ type Props = OwnProps & WithRouterProps
 const generateOverlayURL = (
   pathname: string,
   overlayID: string,
-  resourceID?: string
+  resourceID?: string,
+  search?: string, 
 ): string => {
-  let url = `${pathname}?overlay=${overlayID}`
+  let url = `${pathname}`
+
+  if (search) {
+    url = `${url}${search}&overlay=${overlayID}`
+  } else {
+    url = `${url}?overlay=${overlayID}`
+  }
 
   if (resourceID) {
     url = `${url}&resource=${resourceID}`
@@ -36,7 +44,8 @@ const OverlayLink: FunctionComponent<Props> = ({
   const overlayURL = generateOverlayURL(
     location.pathname,
     overlayID,
-    resourceID
+    resourceID,
+    location.search,
   )
 
   const handleClick = (): void => {

--- a/ui/src/overlays/components/OverlayLink.tsx
+++ b/ui/src/overlays/components/OverlayLink.tsx
@@ -1,0 +1,24 @@
+// Libraries
+import {FunctionComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+
+type HandleOpenOverlay = () => void
+
+interface OwnProps {
+  children: (onClick: HandleOpenOverlay) => JSX.Element
+  overlayID: string
+}
+
+type Props = OwnProps & WithRouterProps
+
+const OverlayLink: FunctionComponent<Props> = ({children, location, router, overlayID}) => {
+  const overlayURL = `${location.pathname}?overlay=${overlayID}`
+  
+  const handleClick = (): void => {
+    router.push(overlayURL)
+  }
+
+  return children(handleClick)
+}
+
+export default withRouter(OverlayLink)

--- a/ui/src/overlays/components/OverlayLink.tsx
+++ b/ui/src/overlays/components/OverlayLink.tsx
@@ -7,16 +7,23 @@ type HandleOpenOverlay = () => void
 interface OwnProps {
   children: (onClick: HandleOpenOverlay) => JSX.Element
   overlayID: string
+  resourceID?: string
 }
 
 type Props = OwnProps & WithRouterProps
 
-const generateOverlayURL = (pathname: string, overlayID: string): string => {
-  return `${pathname}?overlay=${overlayID}`
+const generateOverlayURL = (pathname: string, overlayID: string, resourceID?: string): string => {
+  let url = `${pathname}?overlay=${overlayID}`
+
+  if (resourceID) {
+    url = `${url}&resource=${resourceID}`
+  }
+
+  return url
 }
 
-const OverlayLink: FunctionComponent<Props> = ({children, location, router, overlayID}) => {
-  const overlayURL = generateOverlayURL(location.pathname, overlayID)
+const OverlayLink: FunctionComponent<Props> = ({children, location, router, overlayID, resourceID}) => {
+  const overlayURL = generateOverlayURL(location.pathname, overlayID, resourceID)
   
   const handleClick = (): void => {
     router.push(overlayURL)
@@ -27,8 +34,8 @@ const OverlayLink: FunctionComponent<Props> = ({children, location, router, over
 
 export default withRouter(OverlayLink)
 
-export const displayOverlay = (pathname: string, router: InjectedRouter, overlayID: string): HandleOpenOverlay => {
-  const overlayURL = generateOverlayURL(pathname, overlayID)
+export const displayOverlay = (pathname: string, router: InjectedRouter, overlayID: string, resourceID?: string): HandleOpenOverlay => {
+  const overlayURL = generateOverlayURL(pathname, overlayID, resourceID)
   const displayOverlay = (): void => {
     router.push(overlayURL)
   }

--- a/ui/src/overlays/components/OverlayLink.tsx
+++ b/ui/src/overlays/components/OverlayLink.tsx
@@ -12,7 +12,11 @@ interface OwnProps {
 
 type Props = OwnProps & WithRouterProps
 
-const generateOverlayURL = (pathname: string, overlayID: string, resourceID?: string): string => {
+const generateOverlayURL = (
+  pathname: string,
+  overlayID: string,
+  resourceID?: string
+): string => {
   let url = `${pathname}?overlay=${overlayID}`
 
   if (resourceID) {
@@ -22,9 +26,19 @@ const generateOverlayURL = (pathname: string, overlayID: string, resourceID?: st
   return url
 }
 
-const OverlayLink: FunctionComponent<Props> = ({children, location, router, overlayID, resourceID}) => {
-  const overlayURL = generateOverlayURL(location.pathname, overlayID, resourceID)
-  
+const OverlayLink: FunctionComponent<Props> = ({
+  children,
+  location,
+  router,
+  overlayID,
+  resourceID,
+}) => {
+  const overlayURL = generateOverlayURL(
+    location.pathname,
+    overlayID,
+    resourceID
+  )
+
   const handleClick = (): void => {
     router.push(overlayURL)
   }
@@ -34,7 +48,12 @@ const OverlayLink: FunctionComponent<Props> = ({children, location, router, over
 
 export default withRouter(OverlayLink)
 
-export const displayOverlay = (pathname: string, router: InjectedRouter, overlayID: string, resourceID?: string): HandleOpenOverlay => {
+export const displayOverlay = (
+  pathname: string,
+  router: InjectedRouter,
+  overlayID: string,
+  resourceID?: string
+): HandleOpenOverlay => {
   const overlayURL = generateOverlayURL(pathname, overlayID, resourceID)
   const displayOverlay = (): void => {
     router.push(overlayURL)

--- a/ui/src/overlays/components/OverlayLink.tsx
+++ b/ui/src/overlays/components/OverlayLink.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import {FunctionComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
+import {withRouter, WithRouterProps, InjectedRouter} from 'react-router'
 
 type HandleOpenOverlay = () => void
 
@@ -11,8 +11,12 @@ interface OwnProps {
 
 type Props = OwnProps & WithRouterProps
 
+const generateOverlayURL = (pathname: string, overlayID: string): string => {
+  return `${pathname}?overlay=${overlayID}`
+}
+
 const OverlayLink: FunctionComponent<Props> = ({children, location, router, overlayID}) => {
-  const overlayURL = `${location.pathname}?overlay=${overlayID}`
+  const overlayURL = generateOverlayURL(location.pathname, overlayID)
   
   const handleClick = (): void => {
     router.push(overlayURL)
@@ -22,3 +26,12 @@ const OverlayLink: FunctionComponent<Props> = ({children, location, router, over
 }
 
 export default withRouter(OverlayLink)
+
+export const displayOverlay = (pathname: string, router: InjectedRouter, overlayID: string): HandleOpenOverlay => {
+  const overlayURL = generateOverlayURL(pathname, overlayID)
+  const displayOverlay = (): void => {
+    router.push(overlayURL)
+  }
+
+  return displayOverlay
+}

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -33,6 +33,11 @@ import TemplateImportOverlay from 'src/templates/components/TemplateImportOverla
 import TemplateExportOverlay from 'src/templates/components/TemplateExportOverlay'
 import TemplateViewOverlay from 'src/templates/components/TemplateViewOverlay'
 import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateViewOverlay'
+import CreateVariableOverlay from 'src/variables/components/CreateVariableOverlay'
+import VariableImportOverlay from 'src/variables/components/VariableImportOverlay'
+import VariableExportOverlay from 'src/variables/components/VariableExportOverlay'
+import RenameVariableOverlay from 'src/variables/components/RenameVariableOverlay'
+import UpdateVariableOverlay from 'src/variables/components/UpdateVariableOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -196,6 +201,36 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
         <StaticTemplateViewOverlay
           onDismiss={handleDismissOverlay}
           templateID={resourceID}
+        />
+      )
+      break
+    case 'create-variable':
+      activeOverlay = <CreateVariableOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'import-variable':
+      activeOverlay = <VariableImportOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'export-variable':
+      activeOverlay = (
+        <VariableExportOverlay
+          onDismiss={handleDismissOverlay}
+          variableID={resourceID}
+        />
+      )
+      break
+    case 'edit-variable':
+      activeOverlay = (
+        <UpdateVariableOverlay
+          onDismiss={handleDismissOverlay}
+          variableID={resourceID}
+        />
+      )
+      break
+    case 'rename-variable':
+      activeOverlay = (
+        <RenameVariableOverlay
+          onDismiss={handleDismissOverlay}
+          variableID={resourceID}
         />
       )
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -55,7 +55,7 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
     case 'generate-read-write-token':
       activeOverlay = <BucketsTokenOverlay onDismiss={handleDismissOverlay} />
       break
-    case 'new-endpoint':
+    case 'create-endpoint':
       activeOverlay = <NewEndpointOverlay onDismiss={handleDismissOverlay} />
       break
     case 'delete-data':

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -20,6 +20,7 @@ import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOve
 import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
 import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
+import EditEndpointOverlay from 'src/alerting/components/endpoints/EditEndpointOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -57,6 +58,14 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
       break
     case 'create-endpoint':
       activeOverlay = <NewEndpointOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'edit-endpoint':
+      activeOverlay = (
+        <EditEndpointOverlay
+          onDismiss={handleDismissOverlay}
+          endpointID={resourceID}
+        />
+      )
       break
     case 'delete-data':
       activeOverlay = <DeleteDataOverlay onDismiss={handleDismissOverlay} />

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -41,6 +41,8 @@ import UpdateVariableOverlay from 'src/variables/components/UpdateVariableOverla
 import TaskExportOverlay from 'src/tasks/components/TaskExportOverlay'
 import TaskImportOverlay from 'src/tasks/components/TaskImportOverlay'
 import TaskImportFromTemplateOverlay from 'src/tasks/components/TaskImportFromTemplateOverlay'
+import CreateScraperOverlay from 'src/scrapers/components/CreateScraperOverlay'
+import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -72,6 +74,20 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   let activeOverlay = <></>
 
   switch (overlayID) {
+    case 'write-data-with-line-protocol':
+      activeOverlay = <LineProtocolWizard onDismiss={handleDismissOverlay} />
+      break
+    case 'create-scraper':
+      activeOverlay = <CreateScraperOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'add-scraper-to-bucket':
+      activeOverlay = (
+        <CreateScraperOverlay
+          onDismiss={handleDismissOverlay}
+          bucketID={resourceID}
+        />
+      )
+      break
     case 'generate-all-access-token':
       activeOverlay = <AllAccessTokenOverlay onDismiss={handleDismissOverlay} />
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -18,11 +18,11 @@ import ClientPythonOverlay from 'src/clientLibraries/components/ClientPythonOver
 import CreateBucketOverlay from 'src/buckets/components/CreateBucketOverlay'
 import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
 import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
+import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) => {
-  const {overlay} = queryString.parse(location.search)
+  const {overlay, resource} = queryString.parse(location.search)
 
-  
   const handleDismissOverlay = (): void => {
     const newPath = `${location.pathname}`
     router.push(newPath)
@@ -72,6 +72,9 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
       break
     case 'create-dashboard-from-template':
       activeOverlay = <CreateFromTemplateOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'export-dashboard':
+      activeOverlay = <DashboardExportOverlay onDismiss={handleDismissOverlay} dashboardID={resource} />
       break
     default:
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -38,6 +38,9 @@ import VariableImportOverlay from 'src/variables/components/VariableImportOverla
 import VariableExportOverlay from 'src/variables/components/VariableExportOverlay'
 import RenameVariableOverlay from 'src/variables/components/RenameVariableOverlay'
 import UpdateVariableOverlay from 'src/variables/components/UpdateVariableOverlay'
+import TaskExportOverlay from 'src/tasks/components/TaskExportOverlay'
+import TaskImportOverlay from 'src/tasks/components/TaskImportOverlay'
+import TaskImportFromTemplateOverlay from 'src/tasks/components/TaskImportFromTemplateOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -168,6 +171,22 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
         <DashboardExportOverlay
           onDismiss={handleDismissOverlay}
           dashboardID={resourceID}
+        />
+      )
+      break
+    case 'import-task':
+      activeOverlay = <TaskImportOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'create-task-from-template':
+      activeOverlay = (
+        <TaskImportFromTemplateOverlay onDismiss={handleDismissOverlay} />
+      )
+      break
+    case 'export-task':
+      activeOverlay = (
+        <TaskExportOverlay
+          onDismiss={handleDismissOverlay}
+          taskID={resourceID}
         />
       )
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -16,6 +16,8 @@ import ClientJavaOverlay from 'src/clientLibraries/components/ClientJavaOverlay'
 import ClientJSOverlay from 'src/clientLibraries/components/ClientJSOverlay'
 import ClientPythonOverlay from 'src/clientLibraries/components/ClientPythonOverlay'
 import CreateBucketOverlay from 'src/buckets/components/CreateBucketOverlay'
+import UpdateBucketOverlay from 'src/buckets/components/UpdateBucketOverlay'
+import RenameBucketOverlay from 'src/buckets/components/RenameBucketOverlay'
 import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
 import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
 import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
@@ -94,7 +96,12 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
       )
       break
     case 'delete-data':
-      activeOverlay = <DeleteDataOverlay onDismiss={handleDismissOverlay} />
+      activeOverlay = (
+        <DeleteDataOverlay
+          onDismiss={handleDismissOverlay}
+          bucketID={resourceID}
+        />
+      )
       break
     case 'save-as':
       activeOverlay = <SaveAsOverlay onDismiss={handleDismissOverlay} />
@@ -119,6 +126,22 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
       break
     case 'create-bucket':
       activeOverlay = <CreateBucketOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'edit-bucket':
+      activeOverlay = (
+        <UpdateBucketOverlay
+          onDismiss={handleDismissOverlay}
+          bucketID={resourceID}
+        />
+      )
+      break
+    case 'rename-bucket':
+      activeOverlay = (
+        <RenameBucketOverlay
+          onDismiss={handleDismissOverlay}
+          bucketID={resourceID}
+        />
+      )
       break
     case 'import-dashboard':
       activeOverlay = (

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -21,6 +21,8 @@ import CreateFromTemplateOverlay from 'src/templates/components/createFromTempla
 import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 import EditEndpointOverlay from 'src/alerting/components/endpoints/EditEndpointOverlay'
+import NewRuleOverlay from 'src/alerting/components/notifications/NewRuleOverlay'
+import EditRuleOverlay from 'src/alerting/components/notifications/EditRuleOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -30,6 +32,7 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   let overlayID = ''
   let resourceID = ''
 
+  // Coerce type into string
   if (Array.isArray(overlay)) {
     overlayID = overlay[0]
   } else {
@@ -42,6 +45,7 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
     resourceID = `${resource}`
   }
 
+  // TODO: make this less destructive
   const handleDismissOverlay = (): void => {
     const newPath = `${location.pathname}`
     router.push(newPath)
@@ -65,6 +69,14 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
           onDismiss={handleDismissOverlay}
           endpointID={resourceID}
         />
+      )
+      break
+    case 'create-notification-rule':
+      activeOverlay = <NewRuleOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'edit-notification-rule':
+      activeOverlay = (
+        <EditRuleOverlay onDismiss={handleDismissOverlay} ruleID={resourceID} />
       )
       break
     case 'delete-data':

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -15,6 +15,7 @@ import ClientGoOverlay from 'src/clientLibraries/components/ClientGoOverlay'
 import ClientJavaOverlay from 'src/clientLibraries/components/ClientJavaOverlay'
 import ClientJSOverlay from 'src/clientLibraries/components/ClientJSOverlay'
 import ClientPythonOverlay from 'src/clientLibraries/components/ClientPythonOverlay'
+import CreateBucketOverlay from 'src/buckets/components/CreateBucketOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) => {
   const {overlay} = queryString.parse(location.search)
@@ -60,6 +61,9 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
       break
     case 'python-client':
       activeOverlay = <ClientPythonOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'create-bucket':
+      activeOverlay = <CreateBucketOverlay onDismiss={handleDismissOverlay} />
       break
     default:
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -8,6 +8,7 @@ import AllAccessTokenOverlay from 'src/authorizations/components/AllAccessTokenO
 import BucketsTokenOverlay from 'src/authorizations/components/BucketsTokenOverlay'
 import NewEndpointOverlay from 'src/alerting/components/endpoints/NewEndpointOverlay'
 import DeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
+import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) => {
   const {overlay} = queryString.parse(location.search)
@@ -32,6 +33,9 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
       break
     case 'delete-data':
       activeOverlay = <DeleteDataOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'save-as':
+      activeOverlay = <SaveAsOverlay onDismiss={handleDismissOverlay} />
       break
     default:
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -20,7 +20,10 @@ import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOve
 import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
 import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
 
-const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) => {
+const OverlayRouter: FunctionComponent<WithRouterProps> = ({
+  location,
+  router,
+}) => {
   const {overlay, resource} = queryString.parse(location.search)
 
   const handleDismissOverlay = (): void => {
@@ -68,13 +71,22 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
       activeOverlay = <CreateBucketOverlay onDismiss={handleDismissOverlay} />
       break
     case 'import-dashboard':
-      activeOverlay = <DashboardImportOverlay onDismiss={handleDismissOverlay} />
+      activeOverlay = (
+        <DashboardImportOverlay onDismiss={handleDismissOverlay} />
+      )
       break
     case 'create-dashboard-from-template':
-      activeOverlay = <CreateFromTemplateOverlay onDismiss={handleDismissOverlay} />
+      activeOverlay = (
+        <CreateFromTemplateOverlay onDismiss={handleDismissOverlay} />
+      )
       break
     case 'export-dashboard':
-      activeOverlay = <DashboardExportOverlay onDismiss={handleDismissOverlay} dashboardID={resource} />
+      activeOverlay = (
+        <DashboardExportOverlay
+          onDismiss={handleDismissOverlay}
+          dashboardID={resource}
+        />
+      )
       break
     default:
       break
@@ -82,7 +94,5 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
 
   return activeOverlay
 }
-
-
 
 export default withRouter(OverlayRouter)

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -1,0 +1,41 @@
+// Libraries
+import React, {FunctionComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
+import queryString from 'query-string'
+
+// Components
+import AllAccessTokenOverlay from 'src/authorizations/components/AllAccessTokenOverlay'
+import NewEndpointOverlay from 'src/alerting/components/endpoints/NewEndpointOverlay'
+import DeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
+
+const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) => {
+  const {overlay} = queryString.parse(location.search)
+
+  
+  const handleDismissOverlay = (): void => {
+    const newPath = `${location.pathname}`
+    router.push(newPath)
+  }
+
+  let activeOverlay = <></>
+
+  switch (overlay) {
+    case 'all-access-token':
+      activeOverlay = <AllAccessTokenOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'new-endpoint':
+      activeOverlay = <NewEndpointOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'delete-data':
+      activeOverlay = <DeleteDataOverlay onDismiss={handleDismissOverlay} />
+      break
+    default:
+      break
+  }
+
+  return activeOverlay
+}
+
+
+
+export default withRouter(OverlayRouter)

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -9,6 +9,7 @@ import BucketsTokenOverlay from 'src/authorizations/components/BucketsTokenOverl
 import NewEndpointOverlay from 'src/alerting/components/endpoints/NewEndpointOverlay'
 import DeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
 import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
+import AddMembersOverlay from 'src/members/components/AddMembersOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) => {
   const {overlay} = queryString.parse(location.search)
@@ -36,6 +37,9 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
       break
     case 'save-as':
       activeOverlay = <SaveAsOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'add-members':
+      activeOverlay = <AddMembersOverlay onDismiss={handleDismissOverlay} />
       break
     default:
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -40,8 +40,6 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
     resourceID = `${resource}`
   }
 
-  console.log(queryString.parse(location.search))
-
   const handleDismissOverlay = (): void => {
     const newPath = `${location.pathname}`
     router.push(newPath)

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -29,6 +29,10 @@ import NewThresholdCheckEO from 'src/alerting/components/NewThresholdCheckEO'
 import NewDeadmanCheckEO from 'src/alerting/components/NewDeadmanCheckEO'
 import EditCheckEO from 'src/alerting/components/EditCheckEO'
 import CreateOrgOverlay from 'src/organizations/components/CreateOrgOverlay'
+import TemplateImportOverlay from 'src/templates/components/TemplateImportOverlay'
+import TemplateExportOverlay from 'src/templates/components/TemplateExportOverlay'
+import TemplateViewOverlay from 'src/templates/components/TemplateViewOverlay'
+import StaticTemplateViewOverlay from 'src/templates/components/StaticTemplateViewOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -167,6 +171,33 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
       break
     case 'create-organization':
       activeOverlay = <CreateOrgOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'import-template':
+      activeOverlay = <TemplateImportOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'export-template':
+      activeOverlay = (
+        <TemplateExportOverlay
+          onDismiss={handleDismissOverlay}
+          templateID={resourceID}
+        />
+      )
+      break
+    case 'view-user-template':
+      activeOverlay = (
+        <TemplateViewOverlay
+          onDismiss={handleDismissOverlay}
+          templateID={resourceID}
+        />
+      )
+      break
+    case 'view-static-template':
+      activeOverlay = (
+        <StaticTemplateViewOverlay
+          onDismiss={handleDismissOverlay}
+          templateID={resourceID}
+        />
+      )
       break
     default:
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -23,6 +23,9 @@ import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 import EditEndpointOverlay from 'src/alerting/components/endpoints/EditEndpointOverlay'
 import NewRuleOverlay from 'src/alerting/components/notifications/NewRuleOverlay'
 import EditRuleOverlay from 'src/alerting/components/notifications/EditRuleOverlay'
+import NewThresholdCheckEO from 'src/alerting/components/NewThresholdCheckEO'
+import NewDeadmanCheckEO from 'src/alerting/components/NewDeadmanCheckEO'
+import EditCheckEO from 'src/alerting/components/EditCheckEO'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -59,6 +62,17 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
       break
     case 'generate-read-write-token':
       activeOverlay = <BucketsTokenOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'create-threshold-check':
+      activeOverlay = <NewThresholdCheckEO onDismiss={handleDismissOverlay} />
+      break
+    case 'create-deadman-check':
+      activeOverlay = <NewDeadmanCheckEO onDismiss={handleDismissOverlay} />
+      break
+    case 'edit-check':
+      activeOverlay = (
+        <EditCheckEO onDismiss={handleDismissOverlay} checkID={resourceID} />
+      )
       break
     case 'create-endpoint':
       activeOverlay = <NewEndpointOverlay onDismiss={handleDismissOverlay} />

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -43,6 +43,7 @@ import TaskImportOverlay from 'src/tasks/components/TaskImportOverlay'
 import TaskImportFromTemplateOverlay from 'src/tasks/components/TaskImportFromTemplateOverlay'
 import CreateScraperOverlay from 'src/scrapers/components/CreateScraperOverlay'
 import LineProtocolWizard from 'src/dataLoaders/components/lineProtocolWizard/LineProtocolWizard'
+import NoteEditorOverlay from 'src/dashboards/components/NoteEditorOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -74,6 +75,17 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   let activeOverlay = <></>
 
   switch (overlayID) {
+    case 'create-note':
+      activeOverlay = <NoteEditorOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'edit-note':
+      activeOverlay = (
+        <NoteEditorOverlay
+          onDismiss={handleDismissOverlay}
+          cellID={resourceID}
+        />
+      )
+      break
     case 'write-data-with-line-protocol':
       activeOverlay = <LineProtocolWizard onDismiss={handleDismissOverlay} />
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -10,6 +10,11 @@ import NewEndpointOverlay from 'src/alerting/components/endpoints/NewEndpointOve
 import DeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
 import SaveAsOverlay from 'src/dataExplorer/components/SaveAsOverlay'
 import AddMembersOverlay from 'src/members/components/AddMembersOverlay'
+import ClientCSharpOverlay from 'src/clientLibraries/components/ClientCSharpOverlay'
+import ClientGoOverlay from 'src/clientLibraries/components/ClientGoOverlay'
+import ClientJavaOverlay from 'src/clientLibraries/components/ClientJavaOverlay'
+import ClientJSOverlay from 'src/clientLibraries/components/ClientJSOverlay'
+import ClientPythonOverlay from 'src/clientLibraries/components/ClientPythonOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) => {
   const {overlay} = queryString.parse(location.search)
@@ -40,6 +45,21 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
       break
     case 'add-members':
       activeOverlay = <AddMembersOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'csharp-client':
+      activeOverlay = <ClientCSharpOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'go-client':
+      activeOverlay = <ClientGoOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'java-client':
+      activeOverlay = <ClientJavaOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'javascript-node-client':
+      activeOverlay = <ClientJSOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'python-client':
+      activeOverlay = <ClientPythonOverlay onDismiss={handleDismissOverlay} />
       break
     default:
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -25,6 +25,22 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   router,
 }) => {
   const {overlay, resource} = queryString.parse(location.search)
+  let overlayID = ''
+  let resourceID = ''
+
+  if (Array.isArray(overlay)) {
+    overlayID = overlay[0]
+  } else {
+    overlayID = `${overlay}`
+  }
+
+  if (Array.isArray(resource)) {
+    resourceID = resource[0]
+  } else {
+    resourceID = `${resource}`
+  }
+
+  console.log(queryString.parse(location.search))
 
   const handleDismissOverlay = (): void => {
     const newPath = `${location.pathname}`
@@ -33,7 +49,7 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
 
   let activeOverlay = <></>
 
-  switch (overlay) {
+  switch (overlayID) {
     case 'generate-all-access-token':
       activeOverlay = <AllAccessTokenOverlay onDismiss={handleDismissOverlay} />
       break
@@ -84,7 +100,7 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
       activeOverlay = (
         <DashboardExportOverlay
           onDismiss={handleDismissOverlay}
-          dashboardID={resource}
+          dashboardID={resourceID}
         />
       )
       break
@@ -95,4 +111,4 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   return activeOverlay
 }
 
-export default withRouter(OverlayRouter)
+export default withRouter<{}>(OverlayRouter)

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -16,6 +16,8 @@ import ClientJavaOverlay from 'src/clientLibraries/components/ClientJavaOverlay'
 import ClientJSOverlay from 'src/clientLibraries/components/ClientJSOverlay'
 import ClientPythonOverlay from 'src/clientLibraries/components/ClientPythonOverlay'
 import CreateBucketOverlay from 'src/buckets/components/CreateBucketOverlay'
+import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
+import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) => {
   const {overlay} = queryString.parse(location.search)
@@ -64,6 +66,12 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
       break
     case 'create-bucket':
       activeOverlay = <CreateBucketOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'import-dashboard':
+      activeOverlay = <DashboardImportOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'create-dashboard-from-template':
+      activeOverlay = <CreateFromTemplateOverlay onDismiss={handleDismissOverlay} />
       break
     default:
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -2,6 +2,7 @@
 import React, {FunctionComponent} from 'react'
 import {withRouter, WithRouterProps} from 'react-router'
 import queryString from 'query-string'
+import {keys, pick} from 'lodash'
 
 // Components
 import AllAccessTokenOverlay from 'src/authorizations/components/AllAccessTokenOverlay'
@@ -49,7 +50,8 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
   router,
 }) => {
-  const {overlay, resource} = queryString.parse(location.search)
+  const queryParams = queryString.parse(location.search)
+  const {overlay, resource} = queryParams
   let overlayID = ''
   let resourceID = ''
 
@@ -68,8 +70,15 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
 
   // TODO: make this less destructive
   const handleDismissOverlay = (): void => {
-    const newPath = `${location.pathname}`
-    router.push(newPath)
+    const paramKeysWithoutOverlays = keys(queryParams).filter(pk => pk !== 'overlay' && pk !== 'resource')
+    let dismissPath = `${location.pathname}`
+    
+    if (paramKeysWithoutOverlays.length) {
+      const cleanedParams = pick(queryParams, paramKeysWithoutOverlays)
+      dismissPath = `${dismissPath}?${queryString.stringify(cleanedParams)}`
+    }
+
+    router.push(dismissPath)
   }
 
   let activeOverlay = <></>

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -19,6 +19,7 @@ import CreateBucketOverlay from 'src/buckets/components/CreateBucketOverlay'
 import DashboardImportOverlay from 'src/dashboards/components/DashboardImportOverlay'
 import CreateFromTemplateOverlay from 'src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay'
 import DashboardExportOverlay from 'src/dashboards/components/DashboardExportOverlay'
+import RenameOrgOverlay from 'src/organizations/components/RenameOrgOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -101,6 +102,9 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
           dashboardID={resourceID}
         />
       )
+      break
+    case 'rename-organization':
+      activeOverlay = <RenameOrgOverlay onDismiss={handleDismissOverlay} />
       break
     default:
       break

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -5,6 +5,7 @@ import queryString from 'query-string'
 
 // Components
 import AllAccessTokenOverlay from 'src/authorizations/components/AllAccessTokenOverlay'
+import BucketsTokenOverlay from 'src/authorizations/components/BucketsTokenOverlay'
 import NewEndpointOverlay from 'src/alerting/components/endpoints/NewEndpointOverlay'
 import DeleteDataOverlay from 'src/dataExplorer/components/DeleteDataOverlay'
 
@@ -20,8 +21,11 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({location, router}) =
   let activeOverlay = <></>
 
   switch (overlay) {
-    case 'all-access-token':
+    case 'generate-all-access-token':
       activeOverlay = <AllAccessTokenOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'generate-read-write-token':
+      activeOverlay = <BucketsTokenOverlay onDismiss={handleDismissOverlay} />
       break
     case 'new-endpoint':
       activeOverlay = <NewEndpointOverlay onDismiss={handleDismissOverlay} />

--- a/ui/src/overlays/containers/OverlayRouter.tsx
+++ b/ui/src/overlays/containers/OverlayRouter.tsx
@@ -28,6 +28,7 @@ import EditRuleOverlay from 'src/alerting/components/notifications/EditRuleOverl
 import NewThresholdCheckEO from 'src/alerting/components/NewThresholdCheckEO'
 import NewDeadmanCheckEO from 'src/alerting/components/NewDeadmanCheckEO'
 import EditCheckEO from 'src/alerting/components/EditCheckEO'
+import CreateOrgOverlay from 'src/organizations/components/CreateOrgOverlay'
 
 const OverlayRouter: FunctionComponent<WithRouterProps> = ({
   location,
@@ -163,6 +164,9 @@ const OverlayRouter: FunctionComponent<WithRouterProps> = ({
       break
     case 'rename-organization':
       activeOverlay = <RenameOrgOverlay onDismiss={handleDismissOverlay} />
+      break
+    case 'create-organization':
+      activeOverlay = <CreateOrgOverlay onDismiss={handleDismissOverlay} />
       break
     default:
       break

--- a/ui/src/pageLayout/components/AccountNavSubItem.tsx
+++ b/ui/src/pageLayout/components/AccountNavSubItem.tsx
@@ -49,10 +49,10 @@ class AccountNavSubItem extends PureComponent<Props> {
             titleLink={className => (
               <OverlayLink overlayID="create-organization">
                 {onClick => (
-                    <div onClick={onClick} className={className}>
-                      Create Organization
-                    </div>
-                  )}
+                  <div onClick={onClick} className={className}>
+                    Create Organization
+                  </div>
+                )}
               </OverlayLink>
             )}
             active={false}

--- a/ui/src/pageLayout/components/AccountNavSubItem.tsx
+++ b/ui/src/pageLayout/components/AccountNavSubItem.tsx
@@ -6,6 +6,7 @@ import {Link} from 'react-router'
 import {NavMenu} from '@influxdata/clockface'
 import SortingHat from 'src/shared/components/sorting_hat/SortingHat'
 import CloudExclude from 'src/shared/components/cloud/CloudExclude'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Types
 import {Organization} from 'src/types'
@@ -46,9 +47,13 @@ class AccountNavSubItem extends PureComponent<Props> {
 
           <NavMenu.SubItem
             titleLink={className => (
-              <Link to="/orgs/new" className={className}>
-                Create Organization
-              </Link>
+              <OverlayLink overlayID="create-organization">
+                {onClick => (
+                    <div onClick={onClick} className={className}>
+                      Create Organization
+                    </div>
+                  )}
+              </OverlayLink>
             )}
             active={false}
           />

--- a/ui/src/shared/components/cells/Cell.tsx
+++ b/ui/src/shared/components/cells/Cell.tsx
@@ -37,7 +37,6 @@ interface OwnProps {
   onDeleteCell: (cell: Cell) => void
   onCloneCell: (cell: Cell) => void
   onEditCell: () => void
-  onEditNote: (id: string) => void
 }
 
 interface State {
@@ -49,14 +48,7 @@ type Props = StateProps & OwnProps
 @ErrorHandling
 class CellComponent extends Component<Props, State> {
   public render() {
-    const {
-      onEditCell,
-      onEditNote,
-      onDeleteCell,
-      onCloneCell,
-      cell,
-      view,
-    } = this.props
+    const {onEditCell, onDeleteCell, onCloneCell, cell, view} = this.props
 
     return (
       <>
@@ -68,7 +60,6 @@ class CellComponent extends Component<Props, State> {
             onDeleteCell={onDeleteCell}
             onCloneCell={onCloneCell}
             onEditCell={onEditCell}
-            onEditNote={onEditNote}
             onCSVDownload={this.handleCSVDownload}
           />
         )}

--- a/ui/src/shared/components/cells/CellContext.tsx
+++ b/ui/src/shared/components/cells/CellContext.tsx
@@ -5,6 +5,7 @@ import {get} from 'lodash'
 // Components
 import {Context} from 'src/clockface'
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Types
 import {IconFont, ComponentColor} from '@influxdata/clockface'
@@ -17,7 +18,6 @@ interface Props {
   onCloneCell: (cell: Cell) => void
   onCSVDownload: () => void
   onEditCell: () => void
-  onEditNote: (id: string) => void
 }
 
 @ErrorHandling
@@ -45,18 +45,25 @@ export default class CellContext extends PureComponent<Props> {
     const {view, onEditCell, onCSVDownload} = this.props
 
     if (view.properties.type === 'markdown') {
-      return <Context.Item label="Edit Note" action={this.handleEditNote} />
+      return (
+        <OverlayLink overlayID="edit-note" resourceID={view.id}>
+          {onClick => <Context.Item label="Edit Note" action={onClick} />}
+        </OverlayLink>
+      )
     }
 
     const hasNote = !!get(view, 'properties.note')
 
     return [
       <Context.Item key="configure" label="Configure" action={onEditCell} />,
-      <Context.Item
-        key="note"
-        label={hasNote ? 'Edit Note' : 'Add Note'}
-        action={this.handleEditNote}
-      />,
+      <OverlayLink key="note" overlayID="edit-note" resourceID={view.id}>
+        {onClick => (
+          <Context.Item
+            label={hasNote ? 'Edit Note' : 'Add Note'}
+            action={onClick}
+          />
+        )}
+      </OverlayLink>,
       <Context.Item
         key="download"
         label="Download CSV"
@@ -64,14 +71,5 @@ export default class CellContext extends PureComponent<Props> {
         disabled={true}
       />,
     ]
-  }
-
-  private handleEditNote = () => {
-    const {
-      view: {id},
-      onEditNote,
-    } = this.props
-
-    onEditNote(id)
   }
 }

--- a/ui/src/shared/components/cells/Cells.tsx
+++ b/ui/src/shared/components/cells/Cells.tsx
@@ -28,7 +28,6 @@ interface Props {
   onDeleteCell?: (cell: Cell) => void
   onPositionChange?: (cells: Cell[]) => void
   onEditView: (cellID: string) => void
-  onEditNote: (id: string) => void
 }
 
 @ErrorHandling
@@ -40,7 +39,6 @@ class Cells extends Component<Props & WithRouterProps> {
       onCloneCell,
       timeRange,
       manualRefresh,
-      onEditNote,
     } = this.props
 
     return (
@@ -65,7 +63,6 @@ class Cells extends Component<Props & WithRouterProps> {
               onCloneCell={onCloneCell}
               onDeleteCell={onDeleteCell}
               onEditCell={this.handleEditCell(cell)}
-              onEditNote={onEditNote}
             />
             {this.cellBorder}
           </div>

--- a/ui/src/tasks/components/EmptyTasksList.tsx
+++ b/ui/src/tasks/components/EmptyTasksList.tsx
@@ -1,30 +1,37 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {EmptyState} from '@influxdata/clockface'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
+import {displayOverlay} from 'src/overlays/components/OverlayLink'
 
 // Types
 import {ComponentSize} from '@influxdata/clockface'
 
-interface Props {
+interface OwnProps {
   searchTerm: string
   onCreate: () => void
   totalCount: number
-  onImportTask: () => void
-  onImportFromTemplate: () => void
 }
 
-export default class EmptyTasksLists extends PureComponent<Props> {
+type Props = OwnProps & WithRouterProps
+
+class EmptyTasksList extends PureComponent<Props> {
   public render() {
-    const {
-      searchTerm,
-      onCreate,
-      totalCount,
-      onImportTask,
-      onImportFromTemplate,
-    } = this.props
+    const {searchTerm, onCreate, totalCount, router, location} = this.props
+
+    const handleOpenImportOverlay = displayOverlay(
+      location.pathname,
+      router,
+      'import-task'
+    )
+    const handleOpenCreateFromTemplateOverlay = displayOverlay(
+      location.pathname,
+      router,
+      'create-task-from-template'
+    )
 
     if (totalCount && searchTerm === '') {
       return (
@@ -46,8 +53,8 @@ export default class EmptyTasksLists extends PureComponent<Props> {
           <AddResourceDropdown
             canImportFromTemplate={true}
             onSelectNew={onCreate}
-            onSelectImport={onImportTask}
-            onSelectTemplate={onImportFromTemplate}
+            onSelectImport={handleOpenImportOverlay}
+            onSelectTemplate={handleOpenCreateFromTemplateOverlay}
             resourceName="Task"
           />
         </EmptyState>
@@ -61,3 +68,5 @@ export default class EmptyTasksLists extends PureComponent<Props> {
     )
   }
 }
+
+export default withRouter<OwnProps>(EmptyTasksList)

--- a/ui/src/tasks/components/TaskCard.tsx
+++ b/ui/src/tasks/components/TaskCard.tsx
@@ -7,6 +7,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 import {SlideToggle, ComponentSize, ResourceCard} from '@influxdata/clockface'
 import {Context} from 'src/clockface'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Actions
 import {addTaskLabelsAsync, removeTaskLabelsAsync} from 'src/tasks/actions'
@@ -90,7 +91,9 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
     return (
       <Context>
         <Context.Menu icon={IconFont.CogThick}>
-          <Context.Item label="Export" action={this.handleExport} />
+          <OverlayLink overlayID="export-task" resourceID={task.id}>
+            {onClick => <Context.Item label="Export" action={onClick} />}
+          </OverlayLink>
           <Context.Item label="View Task Runs" action={this.handleViewRuns} />
           <Context.Item label="Run Task" action={onRunTask} value={task.id} />
         </Context.Menu>
@@ -134,15 +137,6 @@ export class TaskCard extends PureComponent<Props & WithRouterProps> {
   private handleRenameTask = async (name: string) => {
     const {onUpdate, task} = this.props
     await onUpdate({...task, name})
-  }
-
-  private handleExport = () => {
-    const {
-      router,
-      task,
-      location: {pathname},
-    } = this.props
-    router.push(`${pathname}/${task.id}/export`)
   }
 
   private get labels(): JSX.Element {

--- a/ui/src/tasks/components/TaskExportOverlay.tsx
+++ b/ui/src/tasks/components/TaskExportOverlay.tsx
@@ -1,5 +1,4 @@
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -15,7 +14,8 @@ import {DocumentCreate} from '@influxdata/influx'
 import {RemoteDataState} from 'src/types'
 
 interface OwnProps {
-  params: {id: string}
+  taskID: string
+  onDismiss: () => void
 }
 
 interface DispatchProps {
@@ -28,16 +28,13 @@ interface StateProps {
   status: RemoteDataState
 }
 
-type Props = OwnProps & StateProps & DispatchProps & WithRouterProps
+type Props = OwnProps & StateProps & DispatchProps
 
 class TaskExportOverlay extends PureComponent<Props> {
   public async componentDidMount() {
-    const {
-      params: {id},
-      convertToTemplate,
-    } = this.props
+    const {taskID, convertToTemplate} = this.props
 
-    convertToTemplate(id)
+    convertToTemplate(taskID)
   }
 
   public render() {
@@ -54,9 +51,9 @@ class TaskExportOverlay extends PureComponent<Props> {
   }
 
   private onDismiss = () => {
-    const {router, clearExportTemplate} = this.props
+    const {onDismiss, clearExportTemplate} = this.props
 
-    router.goBack()
+    onDismiss()
     clearExportTemplate()
   }
 }
@@ -74,4 +71,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
-)(withRouter<Props>(TaskExportOverlay))
+)(TaskExportOverlay)

--- a/ui/src/tasks/components/TaskImportFromTemplateOverlay.tsx
+++ b/ui/src/tasks/components/TaskImportFromTemplateOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 import _ from 'lodash'
 
@@ -38,17 +37,18 @@ interface DispatchProps {
   createTaskFromTemplate: typeof createTaskFromTemplateAction
 }
 
+interface OwnProps {
+  onDismiss: () => void
+}
+
 interface State {
   selectedTemplateSummary: TemplateSummary
   selectedTemplate: Template
 }
 
-type Props = DispatchProps & StateProps
+type Props = OwnProps & DispatchProps & StateProps
 
-class TaskImportFromTemplateOverlay extends PureComponent<
-  Props & WithRouterProps,
-  State
-> {
+class TaskImportFromTemplateOverlay extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
@@ -58,33 +58,33 @@ class TaskImportFromTemplateOverlay extends PureComponent<
   }
 
   render() {
+    const {onDismiss} = this.props
+
     return (
-      <GetResources resource={ResourceType.Templates}>
-        <Overlay visible={true}>
-          <Overlay.Container maxWidth={900}>
-            <Overlay.Header
-              title="Create Task from a Template"
-              onDismiss={this.onDismiss}
+      <Overlay visible={true}>
+        <Overlay.Container maxWidth={900}>
+          <Overlay.Header
+            title="Create Task from a Template"
+            onDismiss={onDismiss}
+          />
+          <Overlay.Body>
+            <GetResources resource={ResourceType.Templates}>
+              {this.overlayBody}
+            </GetResources>
+          </Overlay.Body>
+          <Overlay.Footer>
+            <Button text="Cancel" onClick={onDismiss} key="cancel-button" />
+            <Button
+              text="Create Task"
+              onClick={this.onSubmit}
+              key="submit-button"
+              testID="create-task-button"
+              color={ComponentColor.Success}
+              status={this.submitStatus}
             />
-            <Overlay.Body>{this.overlayBody}</Overlay.Body>
-            <Overlay.Footer>
-              <Button
-                text="Cancel"
-                onClick={this.onDismiss}
-                key="cancel-button"
-              />
-              <Button
-                text="Create Task"
-                onClick={this.onSubmit}
-                key="submit-button"
-                testID="create-task-button"
-                color={ComponentColor.Success}
-                status={this.submitStatus}
-              />
-            </Overlay.Footer>
-          </Overlay.Container>
-        </Overlay>
-      </GetResources>
+          </Overlay.Footer>
+        </Overlay.Container>
+      </Overlay>
     )
   }
 
@@ -123,17 +123,12 @@ class TaskImportFromTemplateOverlay extends PureComponent<
     })
   }
 
-  private onDismiss = () => {
-    const {router} = this.props
-    router.goBack()
-  }
-
   private onSubmit = async (): Promise<void> => {
-    const {createTaskFromTemplate} = this.props
+    const {createTaskFromTemplate, onDismiss} = this.props
     const taskTemplate = this.state.selectedTemplate as TaskTemplate
 
     await createTaskFromTemplate(taskTemplate)
-    this.onDismiss()
+    onDismiss()
   }
 }
 
@@ -156,7 +151,7 @@ const mdtp: DispatchProps = {
   createTaskFromTemplate: createTaskFromTemplateAction,
 }
 
-export default connect<StateProps>(
+export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
-)(withRouter(TaskImportFromTemplateOverlay))
+)(TaskImportFromTemplateOverlay)

--- a/ui/src/tasks/components/TaskImportOverlay.tsx
+++ b/ui/src/tasks/components/TaskImportOverlay.tsx
@@ -1,5 +1,4 @@
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -12,33 +11,33 @@ interface DispatchProps {
   createTaskFromTemplate: typeof createTaskFromTemplateAction
 }
 
-type Props = DispatchProps & WithRouterProps
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps & DispatchProps
 
 class TaskImportOverlay extends PureComponent<Props> {
   public render() {
+    const {onDismiss} = this.props
+
     return (
       <ImportOverlay
-        onDismissOverlay={this.onDismiss}
+        onDismissOverlay={onDismiss}
         resourceName="Task"
         onSubmit={this.handleImportTask}
       />
     )
   }
 
-  private onDismiss = () => {
-    const {router} = this.props
-
-    router.goBack()
-  }
-
   private handleImportTask = async (importString: string): Promise<void> => {
-    const {createTaskFromTemplate} = this.props
+    const {createTaskFromTemplate, onDismiss} = this.props
 
     const template = JSON.parse(importString)
 
     await createTaskFromTemplate(template)
 
-    this.onDismiss()
+    onDismiss()
   }
 }
 
@@ -46,7 +45,7 @@ const mdtp: DispatchProps = {
   createTaskFromTemplate: createTaskFromTemplateAction,
 }
 
-export default connect<{}, DispatchProps, Props>(
+export default connect<{}, DispatchProps, OwnProps>(
   null,
   mdtp
-)(withRouter(TaskImportOverlay))
+)(TaskImportOverlay)

--- a/ui/src/tasks/components/TasksHeader.tsx
+++ b/ui/src/tasks/components/TasksHeader.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {
@@ -10,28 +11,40 @@ import {
 } from '@influxdata/clockface'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 import PageTitleWithOrg from 'src/shared/components/PageTitleWithOrg'
+import {displayOverlay} from 'src/overlays/components/OverlayLink'
 
 // Types
 import {LimitStatus} from 'src/cloud/actions/limits'
 
-interface Props {
+interface OwnProps {
   onCreateTask: () => void
   setShowInactive: () => void
   showInactive: boolean
-  onImportTask: () => void
   limitStatus: LimitStatus
-  onImportFromTemplate: () => void
 }
 
-export default class TasksHeader extends PureComponent<Props> {
+type Props = OwnProps & WithRouterProps
+
+class TasksHeader extends PureComponent<Props> {
   public render() {
     const {
       onCreateTask,
       setShowInactive,
       showInactive,
-      onImportTask,
-      onImportFromTemplate,
+      router,
+      location,
     } = this.props
+
+    const handleOpenImportOverlay = displayOverlay(
+      location.pathname,
+      router,
+      'import-task'
+    )
+    const handleOpenCreateFromTemplateOverlay = displayOverlay(
+      location.pathname,
+      router,
+      'create-task-from-template'
+    )
 
     return (
       <Page.Header fullWidth={false}>
@@ -48,8 +61,8 @@ export default class TasksHeader extends PureComponent<Props> {
           <AddResourceDropdown
             canImportFromTemplate={true}
             onSelectNew={onCreateTask}
-            onSelectImport={onImportTask}
-            onSelectTemplate={onImportFromTemplate}
+            onSelectImport={handleOpenImportOverlay}
+            onSelectTemplate={handleOpenCreateFromTemplateOverlay}
             resourceName="Task"
             status={this.addResourceStatus}
           />
@@ -66,3 +79,5 @@ export default class TasksHeader extends PureComponent<Props> {
     return ComponentStatus.Default
   }
 }
+
+export default withRouter<OwnProps>(TasksHeader)

--- a/ui/src/tasks/components/TasksList.tsx
+++ b/ui/src/tasks/components/TasksList.tsx
@@ -38,13 +38,11 @@ interface Props {
   onRunTask: typeof runTask
   onUpdate: (task: Task) => void
   filterComponent?: JSX.Element
-  onImportTask: () => void
   sortKey: string
   sortDirection: Sort
   sortType: SortTypes
   onClickColumn: (nextSort: Sort, sortKey: SortKey) => void
   checkTaskLimits: typeof checkTaskLimitsAction
-  onImportFromTemplate: () => void
 }
 
 type SortKey = keyof Task
@@ -77,11 +75,9 @@ export default class TasksList extends PureComponent<Props, State> {
       onCreate,
       totalCount,
       filterComponent,
-      onImportTask,
       sortKey,
       sortDirection,
       onClickColumn,
-      onImportFromTemplate,
     } = this.props
 
     const headerKeys: SortKey[] = ['name', 'status', 'every', 'latestCompleted']
@@ -121,8 +117,6 @@ export default class TasksList extends PureComponent<Props, State> {
                 searchTerm={searchTerm}
                 onCreate={onCreate}
                 totalCount={totalCount}
-                onImportTask={onImportTask}
-                onImportFromTemplate={onImportFromTemplate}
               />
             }
           >

--- a/ui/src/tasks/components/__snapshots__/TasksList.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TasksList.test.tsx.snap
@@ -35,9 +35,8 @@ exports[`TasksList rendering renders 1`] = `
     </ResourceListHeader>
     <ResourceListBody
       emptyState={
-        <EmptyTasksLists
+        <withRouter(EmptyTasksList)
           onCreate={[Function]}
-          onImportTask={[Function]}
           searchTerm=""
         />
       }

--- a/ui/src/tasks/containers/TasksPage.tsx
+++ b/ui/src/tasks/containers/TasksPage.tsx
@@ -125,8 +125,6 @@ class TasksPage extends PureComponent<Props, State> {
             onCreateTask={this.handleCreateTask}
             setShowInactive={setShowInactive}
             showInactive={showInactive}
-            onImportTask={this.summonImportOverlay}
-            onImportFromTemplate={this.summonImportFromTemplateOverlay}
             limitStatus={limitStatus}
           />
           <Page.Contents fullWidth={false} scrollable={true}>
@@ -158,10 +156,6 @@ class TasksPage extends PureComponent<Props, State> {
                         onFilterChange={setSearchTerm}
                         filterComponent={this.search}
                         onUpdate={updateTaskName}
-                        onImportTask={this.summonImportOverlay}
-                        onImportFromTemplate={
-                          this.summonImportFromTemplateOverlay
-                        }
                         sortKey={sortKey}
                         sortDirection={sortDirection}
                         sortType={sortType}
@@ -211,24 +205,6 @@ class TasksPage extends PureComponent<Props, State> {
     } = this.props
 
     router.push(`/orgs/${orgID}/tasks/new`)
-  }
-
-  private summonImportFromTemplateOverlay = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/tasks/import/template`)
-  }
-
-  private summonImportOverlay = (): void => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/tasks/import`)
   }
 
   private get search(): JSX.Element {

--- a/ui/src/templates/components/EmptyTemplatesList.tsx
+++ b/ui/src/templates/components/EmptyTemplatesList.tsx
@@ -8,19 +8,16 @@ import {
   ComponentColor,
   Button,
 } from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Types
 import {ComponentSize} from '@influxdata/clockface'
 
 interface Props {
   searchTerm: string
-  onImport: () => void
 }
 
-const EmptyTemplatesList: FunctionComponent<Props> = ({
-  searchTerm,
-  onImport,
-}) => {
+const EmptyTemplatesList: FunctionComponent<Props> = ({searchTerm}) => {
   if (searchTerm === '') {
     return (
       <EmptyState size={ComponentSize.Large}>
@@ -28,12 +25,16 @@ const EmptyTemplatesList: FunctionComponent<Props> = ({
           text={"Looks like you don't have any Templates, why not create one?"}
           highlightWords={['Templates']}
         />
-        <Button
-          text="Import Template"
-          icon={IconFont.Plus}
-          color={ComponentColor.Primary}
-          onClick={onImport}
-        />
+        <OverlayLink overlayID="import-template">
+          {onClick => (
+            <Button
+              text="Import Template"
+              icon={IconFont.Plus}
+              color={ComponentColor.Primary}
+              onClick={onClick}
+            />
+          )}
+        </OverlayLink>
       </EmptyState>
     )
   }

--- a/ui/src/templates/components/StaticTemplateCard.tsx
+++ b/ui/src/templates/components/StaticTemplateCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent} from 'react'
 import _ from 'lodash'
 import {connect} from 'react-redux'
 import {withRouter, WithRouterProps} from 'react-router'
@@ -13,6 +13,7 @@ import {
 
 // Components
 import {ResourceCard} from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Actions
 import {createResourceFromStaticTemplate} from 'src/templates/actions'
@@ -47,17 +48,23 @@ class StaticTemplateCard extends PureComponent<Props & WithRouterProps> {
   public render() {
     const {template} = this.props
 
+    const templateID = template.meta.name.replace(/\s/gi, '-').toLowerCase()
+
     return (
       <ResourceCard
         testID="template-card"
         contextMenu={this.contextMenu}
         description={this.description}
         name={
-          <ResourceCard.Name
-            onClick={this.handleNameClick}
-            name={template.meta.name}
-            testID="template-card--name"
-          />
+          <OverlayLink overlayID="view-static-template" resourceID={templateID}>
+            {onClick => (
+              <ResourceCard.Name
+                onClick={onClick}
+                name={template.meta.name}
+                testID="template-card--name"
+              />
+            )}
+          </OverlayLink>
         }
         metaData={[this.templateType]}
       />
@@ -104,17 +111,6 @@ class StaticTemplateCard extends PureComponent<Props & WithRouterProps> {
     const {onCreateFromTemplate, name} = this.props
 
     onCreateFromTemplate(name)
-  }
-
-  private handleNameClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-    this.handleViewTemplate()
-  }
-
-  private handleViewTemplate = () => {
-    const {router, org, name} = this.props
-
-    router.push(`/orgs/${org.id}/settings/templates/${name}/static/view`)
   }
 }
 

--- a/ui/src/templates/components/StaticTemplateViewOverlay.tsx
+++ b/ui/src/templates/components/StaticTemplateViewOverlay.tsx
@@ -1,6 +1,5 @@
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
-import _ from 'lodash'
+import {get} from 'lodash'
 
 // Components
 import ViewOverlay from 'src/shared/components/ViewOverlay'
@@ -12,42 +11,39 @@ import {RemoteDataState} from '@influxdata/clockface'
 import {staticTemplates} from 'src/templates/constants/defaultTemplates'
 import {DashboardTemplate} from 'src/types'
 
-interface OwnProps {
-  params: {id: string}
+interface Props {
+  templateID: string
+  onDismiss: () => void
 }
-
-type Props = OwnProps & WithRouterProps
 
 @ErrorHandling
 class TemplateExportOverlay extends PureComponent<Props> {
   public render() {
+    const {onDismiss} = this.props
+
     return (
       <ViewOverlay
         resource={this.template}
         overlayHeading={this.overlayTitle}
-        onDismissOverlay={this.onDismiss}
+        onDismissOverlay={onDismiss}
         status={RemoteDataState.Done}
       />
     )
   }
 
   private get template(): DashboardTemplate {
-    const {
-      params: {id},
-    } = this.props
+    const {templateID} = this.props
 
-    return staticTemplates[id]
+    return staticTemplates[templateID]
   }
 
-  private get overlayTitle() {
-    return this.template.meta.name
-  }
+  private get overlayTitle(): string {
+    const {templateID} = this.props
 
-  private onDismiss = () => {
-    const {router} = this.props
+    const template: DashboardTemplate = staticTemplates[templateID]
 
-    router.goBack()
+    return get(template, 'meta.name', 'View')
   }
 }
 
-export default withRouter<Props>(TemplateExportOverlay)
+export default TemplateExportOverlay

--- a/ui/src/templates/components/StaticTemplatesList.tsx
+++ b/ui/src/templates/components/StaticTemplatesList.tsx
@@ -22,7 +22,6 @@ interface Props {
   templates: {name: string; template: TemplateSummary}[]
   searchTerm: string
   onFilterChange: (searchTerm: string) => void
-  onImport: () => void
   sortKey: string
   sortDirection: Sort
   sortType: SortTypes
@@ -35,13 +34,7 @@ export default class StaticTemplatesList extends PureComponent<Props> {
   )
 
   public render() {
-    const {
-      searchTerm,
-      onImport,
-      sortKey,
-      sortDirection,
-      onClickColumn,
-    } = this.props
+    const {searchTerm, sortKey, sortDirection, onClickColumn} = this.props
 
     const headerKeys: SortKey[] = ['meta.name']
 
@@ -56,9 +49,7 @@ export default class StaticTemplatesList extends PureComponent<Props> {
           />
         </ResourceList.Header>
         <ResourceList.Body
-          emptyState={
-            <EmptyTemplatesList searchTerm={searchTerm} onImport={onImport} />
-          }
+          emptyState={<EmptyTemplatesList searchTerm={searchTerm} />}
         >
           {this.rows}
         </ResourceList.Body>

--- a/ui/src/templates/components/TemplateCard.tsx
+++ b/ui/src/templates/components/TemplateCard.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 import _ from 'lodash'
 import {withRouter, WithRouterProps} from 'react-router'
@@ -15,6 +15,7 @@ import {
 import {Context} from 'src/clockface'
 import {ResourceCard, IconFont} from '@influxdata/clockface'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Actions
 import {
@@ -69,15 +70,19 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
         testID="template-card"
         contextMenu={this.contextMenu}
         name={
-          <ResourceCard.EditableName
-            onClick={this.handleNameClick}
-            onUpdate={this.handleUpdateTemplateName}
-            name={template.meta.name}
-            noNameString={DEFAULT_TEMPLATE_NAME}
-            testID="template-card--name"
-            buttonTestID="template-card--name-button"
-            inputTestID="template-card--input"
-          />
+          <OverlayLink overlayID="view-user-template" resourceID={template.id}>
+            {onClick => (
+              <ResourceCard.EditableName
+                onClick={onClick}
+                onUpdate={this.handleUpdateTemplateName}
+                name={template.meta.name}
+                noNameString={DEFAULT_TEMPLATE_NAME}
+                testID="template-card--name"
+                buttonTestID="template-card--name-button"
+                inputTestID="template-card--input"
+              />
+            )}
+          </OverlayLink>
         }
         description={this.description}
         labels={
@@ -190,17 +195,6 @@ class TemplateCard extends PureComponent<Props & WithRouterProps> {
       onClone,
     } = this.props
     onClone(id)
-  }
-
-  private handleNameClick = (e: MouseEvent): void => {
-    e.preventDefault()
-
-    this.handleViewTemplate()
-  }
-
-  private handleViewTemplate = () => {
-    const {router, template, org} = this.props
-    router.push(`/orgs/${org.id}/settings/templates/${template.id}/view`)
   }
 
   private handleAddLabel = (label: ILabel): void => {

--- a/ui/src/templates/components/TemplateExportOverlay.tsx
+++ b/ui/src/templates/components/TemplateExportOverlay.tsx
@@ -1,6 +1,5 @@
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import ExportOverlay from 'src/shared/components/ExportOverlay'
@@ -17,7 +16,8 @@ import {AppState} from 'src/types'
 import {RemoteDataState} from 'src/types'
 
 interface OwnProps {
-  params: {id: string}
+  templateID: string
+  onDismiss: () => void
 }
 
 interface DispatchProps {
@@ -30,15 +30,12 @@ interface StateProps {
   status: RemoteDataState
 }
 
-type Props = OwnProps & StateProps & DispatchProps & WithRouterProps
+type Props = OwnProps & StateProps & DispatchProps
 
 class TemplateExportOverlay extends PureComponent<Props> {
   public componentDidMount() {
-    const {
-      params: {id},
-      convertToTemplate,
-    } = this.props
-    convertToTemplate(id)
+    const {templateID, convertToTemplate} = this.props
+    convertToTemplate(templateID)
   }
 
   public render() {
@@ -55,9 +52,9 @@ class TemplateExportOverlay extends PureComponent<Props> {
   }
 
   private onDismiss = () => {
-    const {router, clearExportTemplate} = this.props
+    const {onDismiss, clearExportTemplate} = this.props
 
-    router.goBack()
+    onDismiss()
     clearExportTemplate()
   }
 }
@@ -75,4 +72,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
-)(withRouter<Props>(TemplateExportOverlay))
+)(TemplateExportOverlay)

--- a/ui/src/templates/components/TemplateImportOverlay.tsx
+++ b/ui/src/templates/components/TemplateImportOverlay.tsx
@@ -1,5 +1,4 @@
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -25,49 +24,42 @@ interface StateProps {
   org: Organization
 }
 
-interface OwnProps extends WithRouterProps {
-  params: {orgID: string}
+interface OwnProps {
+  onDismiss: () => void
 }
 
-type Props = DispatchProps & OwnProps & StateProps
+type Props = OwnProps & DispatchProps & StateProps
 
 class TemplateImportOverlay extends PureComponent<Props> {
   public render() {
+    const {onDismiss} = this.props
     return (
       <ImportOverlay
-        onDismissOverlay={this.onDismiss}
+        onDismissOverlay={onDismiss}
         resourceName="Template"
         onSubmit={this.handleImportTemplate}
       />
     )
   }
 
-  private onDismiss = () => {
-    const {router} = this.props
-
-    router.goBack()
-  }
-
   private handleImportTemplate = async (
     importString: string
   ): Promise<void> => {
-    const {createTemplate, getTemplates} = this.props
+    const {createTemplate, getTemplates, onDismiss} = this.props
 
     const template = JSON.parse(importString)
     await createTemplate(template)
 
     getTemplates()
 
-    this.onDismiss()
+    onDismiss()
   }
 }
 
-const mstp = (state: AppState, props: Props): StateProps => {
+const mstp = (state: AppState): StateProps => {
   const {
-    orgs: {items},
+    orgs: {org},
   } = state
-
-  const org = items.find(o => o.id === props.params.orgID)
 
   return {org}
 }
@@ -78,7 +70,7 @@ const mdtp: DispatchProps = {
   getTemplates: getTemplatesAction,
 }
 
-export default connect<StateProps, DispatchProps, Props>(
+export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
-)(withRouter(TemplateImportOverlay))
+)(TemplateImportOverlay)

--- a/ui/src/templates/components/TemplateViewOverlay.tsx
+++ b/ui/src/templates/components/TemplateViewOverlay.tsx
@@ -1,6 +1,5 @@
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 import _ from 'lodash'
 
 // Components
@@ -19,7 +18,8 @@ import {AppState} from 'src/types'
 import {RemoteDataState} from 'src/types'
 
 interface OwnProps {
-  params: {id: string}
+  templateID: string
+  onDismiss: () => void
 }
 
 interface DispatchProps {
@@ -32,16 +32,13 @@ interface StateProps {
   status: RemoteDataState
 }
 
-type Props = OwnProps & StateProps & DispatchProps & WithRouterProps
+type Props = OwnProps & StateProps & DispatchProps
 
 @ErrorHandling
 class TemplateExportOverlay extends PureComponent<Props> {
   public componentDidMount() {
-    const {
-      params: {id},
-      convertToTemplate,
-    } = this.props
-    convertToTemplate(id)
+    const {templateID, convertToTemplate} = this.props
+    convertToTemplate(templateID)
   }
 
   public render() {
@@ -60,15 +57,15 @@ class TemplateExportOverlay extends PureComponent<Props> {
   private get overlayTitle() {
     const {exportTemplate} = this.props
     if (exportTemplate) {
-      return exportTemplate.meta.name
+      return exportTemplate.meta.name || 'Untitled Template'
     }
-    return ''
+    return 'Untitled Template'
   }
 
   private onDismiss = () => {
-    const {router, clearExportTemplate} = this.props
+    const {onDismiss, clearExportTemplate} = this.props
 
-    router.goBack()
+    onDismiss()
     clearExportTemplate()
   }
 }
@@ -86,4 +83,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
-)(withRouter<Props>(TemplateExportOverlay))
+)(TemplateExportOverlay)

--- a/ui/src/templates/components/TemplatesList.tsx
+++ b/ui/src/templates/components/TemplatesList.tsx
@@ -22,7 +22,6 @@ interface Props {
   templates: TemplateSummary[]
   searchTerm: string
   onFilterChange: (searchTerm: string) => void
-  onImport: () => void
   sortKey: string
   sortDirection: Sort
   sortType: SortTypes
@@ -35,13 +34,7 @@ export default class TemplatesList extends PureComponent<Props> {
   )
 
   public render() {
-    const {
-      searchTerm,
-      onImport,
-      sortKey,
-      sortDirection,
-      onClickColumn,
-    } = this.props
+    const {searchTerm, sortKey, sortDirection, onClickColumn} = this.props
 
     const headerKeys: SortKey[] = ['meta.name']
 
@@ -57,9 +50,7 @@ export default class TemplatesList extends PureComponent<Props> {
             />
           </ResourceList.Header>
           <ResourceList.Body
-            emptyState={
-              <EmptyTemplatesList searchTerm={searchTerm} onImport={onImport} />
-            }
+            emptyState={<EmptyTemplatesList searchTerm={searchTerm} />}
           >
             {this.rows}
           </ResourceList.Body>

--- a/ui/src/templates/components/TemplatesPage.tsx
+++ b/ui/src/templates/components/TemplatesPage.tsx
@@ -11,6 +11,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import SearchWidget from 'src/shared/components/search_widget/SearchWidget'
 import GetResources, {ResourceType} from 'src/shared/components/GetResources'
 import SettingsTabbedPageHeader from 'src/settings/components/SettingsTabbedPageHeader'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Types
 import {TemplateSummary, AppState} from 'src/types'
@@ -38,15 +39,9 @@ const staticTemplates: StaticTemplate[] = _.map(statics, (template, name) => ({
   template,
 }))
 
-interface OwnProps {
-  onImport: () => void
-}
-
 interface StateProps {
   templates: TemplateSummary[]
 }
-
-type Props = OwnProps & StateProps
 
 interface State {
   searchTerm: string
@@ -59,7 +54,7 @@ interface State {
 type SortKey = 'meta.name'
 
 @ErrorHandling
-class TemplatesPage extends PureComponent<Props, State> {
+class TemplatesPage extends PureComponent<StateProps, State> {
   constructor(props) {
     super(props)
 
@@ -73,7 +68,6 @@ class TemplatesPage extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {onImport} = this.props
     const {activeTab} = this.state
 
     return (
@@ -102,12 +96,16 @@ class TemplatesPage extends PureComponent<Props, State> {
               </Radio.Button>
             </Radio>
           </FlexBox>
-          <Button
-            text="Import Template"
-            icon={IconFont.Plus}
-            color={ComponentColor.Primary}
-            onClick={onImport}
-          />
+          <OverlayLink overlayID="import-template">
+            {onClick => (
+              <Button
+                text="Import Template"
+                icon={IconFont.Plus}
+                color={ComponentColor.Primary}
+                onClick={onClick}
+              />
+            )}
+          </OverlayLink>
         </SettingsTabbedPageHeader>
         {this.templatesList}
       </>
@@ -124,7 +122,7 @@ class TemplatesPage extends PureComponent<Props, State> {
   }
 
   private get templatesList(): JSX.Element {
-    const {templates, onImport} = this.props
+    const {templates} = this.props
     const {searchTerm, sortKey, sortDirection, sortType, activeTab} = this.state
 
     if (activeTab === 'static-templates') {
@@ -140,7 +138,6 @@ class TemplatesPage extends PureComponent<Props, State> {
                 searchTerm={searchTerm}
                 templates={ts}
                 onFilterChange={this.setSearchTerm}
-                onImport={onImport}
                 sortKey={sortKey}
                 sortDirection={sortDirection}
                 sortType={sortType}
@@ -166,7 +163,6 @@ class TemplatesPage extends PureComponent<Props, State> {
                   searchTerm={searchTerm}
                   templates={ts}
                   onFilterChange={this.setSearchTerm}
-                  onImport={onImport}
                   sortKey={sortKey}
                   sortDirection={sortDirection}
                   sortType={sortType}

--- a/ui/src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay.tsx
+++ b/ui/src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay.tsx
@@ -79,11 +79,7 @@ class DashboardImportFromTemplateOverlay extends PureComponent<Props, State> {
             <Overlay.Body>{this.overlayBody}</Overlay.Body>
           </GetResources>
           <Overlay.Footer>
-            <Button
-              text="Cancel"
-              onClick={onDismiss}
-              key="cancel-button"
-            />
+            <Button text="Cancel" onClick={onDismiss} key="cancel-button" />
             <Button
               text="Create Dashboard"
               onClick={this.onSubmit}

--- a/ui/src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay.tsx
+++ b/ui/src/templates/components/createFromTemplateOverlay/CreateFromTemplateOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 import _ from 'lodash'
 
@@ -42,6 +41,10 @@ interface DispatchProps {
   createDashboardFromTemplate: typeof createDashboardFromTemplateAction
 }
 
+interface OwnProps {
+  onDismiss: () => void
+}
+
 interface State {
   selectedTemplateSummary: TemplateSummary
   selectedTemplate: Template
@@ -49,12 +52,9 @@ interface State {
   cells: string[]
 }
 
-type Props = DispatchProps & StateProps
+type Props = OwnProps & DispatchProps & StateProps
 
-class DashboardImportFromTemplateOverlay extends PureComponent<
-  Props & WithRouterProps,
-  State
-> {
+class DashboardImportFromTemplateOverlay extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
@@ -66,33 +66,35 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
   }
 
   render() {
+    const {onDismiss} = this.props
+
     return (
-      <GetResources resource={ResourceType.Templates}>
-        <Overlay visible={true}>
-          <Overlay.Container maxWidth={900}>
-            <Overlay.Header
-              title="Create Dashboard from a Template"
-              onDismiss={this.onDismiss}
-            />
+      <Overlay visible={true}>
+        <Overlay.Container maxWidth={900}>
+          <Overlay.Header
+            title="Create Dashboard from a Template"
+            onDismiss={onDismiss}
+          />
+          <GetResources resource={ResourceType.Templates}>
             <Overlay.Body>{this.overlayBody}</Overlay.Body>
-            <Overlay.Footer>
-              <Button
-                text="Cancel"
-                onClick={this.onDismiss}
-                key="cancel-button"
-              />
-              <Button
-                text="Create Dashboard"
-                onClick={this.onSubmit}
-                key="submit-button"
-                testID="create-dashboard-button"
-                color={ComponentColor.Success}
-                status={this.submitStatus}
-              />
-            </Overlay.Footer>
-          </Overlay.Container>
-        </Overlay>
-      </GetResources>
+          </GetResources>
+          <Overlay.Footer>
+            <Button
+              text="Cancel"
+              onClick={onDismiss}
+              key="cancel-button"
+            />
+            <Button
+              text="Create Dashboard"
+              onClick={this.onSubmit}
+              key="submit-button"
+              testID="create-dashboard-button"
+              color={ComponentColor.Success}
+              status={this.submitStatus}
+            />
+          </Overlay.Footer>
+        </Overlay.Container>
+      </Overlay>
     )
   }
 
@@ -171,17 +173,12 @@ class DashboardImportFromTemplateOverlay extends PureComponent<
     })
   }
 
-  private onDismiss = () => {
-    const {router} = this.props
-    router.goBack()
-  }
-
   private onSubmit = async (): Promise<void> => {
-    const {createDashboardFromTemplate} = this.props
+    const {createDashboardFromTemplate, onDismiss} = this.props
     const dashboardTemplate = this.state.selectedTemplate as DashboardTemplate
 
     await createDashboardFromTemplate(dashboardTemplate)
-    this.onDismiss()
+    onDismiss()
   }
 }
 
@@ -204,7 +201,7 @@ const mdtp: DispatchProps = {
   createDashboardFromTemplate: createDashboardFromTemplateAction,
 }
 
-export default connect<StateProps>(
+export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
-)(withRouter(DashboardImportFromTemplateOverlay))
+)(DashboardImportFromTemplateOverlay)

--- a/ui/src/templates/constants/defaultTemplates.ts
+++ b/ui/src/templates/constants/defaultTemplates.ts
@@ -17,16 +17,16 @@ export const ossMetricsTemplate = (): DashboardTemplate => {
 }
 
 export const staticTemplates: {[k: string]: DashboardTemplate} = {
-  Apache: apache,
-  Docker: docker,
-  'getting-started': gettingStarted,
-  Github: github,
-  JMeter: jmeter,
-  Kubernetes: kubernetes,
-  Nginx: nginx,
-  'oss-metrics': ossMetrics,
-  Redis: redis,
-  System: system,
+  'apache-data': apache,
+  docker: docker,
+  'getting-started-with-flux': gettingStarted,
+  'github-data': github,
+  jmeter: jmeter,
+  kubernetes: kubernetes,
+  nginx: nginx,
+  'influxdb-2.0-oss-metrics': ossMetrics,
+  redis: redis,
+  system: system,
 }
 
 export const influxdbTemplateList: DashboardTemplate[] = [

--- a/ui/src/templates/containers/TemplatesIndex.tsx
+++ b/ui/src/templates/containers/TemplatesIndex.tsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -20,10 +19,8 @@ interface StateProps {
   org: Organization
 }
 
-type Props = WithRouterProps & StateProps
-
 @ErrorHandling
-class TemplatesIndex extends Component<Props> {
+class TemplatesIndex extends Component<StateProps> {
   public render() {
     const {org, children} = this.props
     return (
@@ -32,18 +29,13 @@ class TemplatesIndex extends Component<Props> {
           <SettingsHeader />
           <SettingsTabbedPage activeTab="templates" orgID={org.id}>
             <GetResources resource={ResourceType.Templates}>
-              <TemplatesPage onImport={this.handleImport} />
+              <TemplatesPage />
             </GetResources>
           </SettingsTabbedPage>
         </Page>
         {children}
       </>
     )
-  }
-
-  private handleImport = () => {
-    const {router, org} = this.props
-    router.push(`/orgs/${org.id}/settings/templates/import`)
   }
 }
 
@@ -60,4 +52,4 @@ const mstp = (state: AppState): StateProps => {
 export default connect<StateProps, {}, {}>(
   mstp,
   null
-)(withRouter<{}>(TemplatesIndex))
+)(TemplatesIndex)

--- a/ui/src/variables/components/CreateVariableOverlay.tsx
+++ b/ui/src/variables/components/CreateVariableOverlay.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Utils
 import {extractVariablesList} from 'src/variables/selectors'
@@ -26,40 +25,32 @@ interface StateProps {
   variables: Variable[]
 }
 
-type Props = DispatchProps & WithRouterProps & StateProps
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps & DispatchProps & StateProps
 
 class CreateVariableOverlay extends PureComponent<Props> {
   public render() {
-    const {onCreateVariable, variables} = this.props
+    const {onCreateVariable, variables, onDismiss} = this.props
 
     return (
       <GetResources resource={ResourceType.Variables}>
         <Overlay visible={true}>
           <Overlay.Container maxWidth={1000}>
-            <Overlay.Header
-              title="Create Variable"
-              onDismiss={this.handleHideOverlay}
-            />
+            <Overlay.Header title="Create Variable" onDismiss={onDismiss} />
             <Overlay.Body>
               <VariableForm
                 variables={variables}
                 onCreateVariable={onCreateVariable}
-                onHideOverlay={this.handleHideOverlay}
+                onHideOverlay={onDismiss}
               />
             </Overlay.Body>
           </Overlay.Container>
         </Overlay>
       </GetResources>
     )
-  }
-
-  private handleHideOverlay = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/variables`)
   }
 }
 
@@ -76,4 +67,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps>(
   mstp,
   mdtp
-)(withRouter<{}>(CreateVariableOverlay))
+)(CreateVariableOverlay)

--- a/ui/src/variables/components/RenameVariableForm.tsx
+++ b/ui/src/variables/components/RenameVariableForm.tsx
@@ -2,7 +2,6 @@
 import React, {PureComponent, ChangeEvent, FormEvent} from 'react'
 import _ from 'lodash'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {Form, Input, Button, Grid, Columns} from '@influxdata/clockface'
@@ -24,7 +23,8 @@ import {
 } from '@influxdata/clockface'
 
 interface OwnProps {
-  onClose: () => void
+  onDismiss: () => void
+  variableID: string
 }
 
 interface State {
@@ -41,7 +41,7 @@ interface DispatchProps {
   onUpdateVariable: typeof updateVariable
 }
 
-type Props = StateProps & OwnProps & DispatchProps & WithRouterProps
+type Props = StateProps & OwnProps & DispatchProps
 
 class RenameVariableOverlayForm extends PureComponent<Props, State> {
   public state: State = {
@@ -50,14 +50,14 @@ class RenameVariableOverlayForm extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {onClose} = this.props
+    const {onDismiss} = this.props
     const {workingVariable, isNameValid} = this.state
 
     return (
       <Form onSubmit={this.handleSubmit}>
         <Grid>
           <Grid.Row>
-            <Grid.Column widthXS={Columns.Six}>
+            <Grid.Column widthXS={Columns.Twelve}>
               <div className="overlay-flux-editor--spacing">
                 <Form.ValidationElement
                   label="Name"
@@ -85,7 +85,7 @@ class RenameVariableOverlayForm extends PureComponent<Props, State> {
                 <Button
                   text="Cancel"
                   color={ComponentColor.Danger}
-                  onClick={onClose}
+                  onClick={onDismiss}
                 />
                 <Button
                   text="Submit"
@@ -111,7 +111,7 @@ class RenameVariableOverlayForm extends PureComponent<Props, State> {
     e.preventDefault()
 
     this.props.onUpdateVariable(workingVariable.id, workingVariable)
-    this.props.onClose()
+    this.props.onDismiss()
   }
 
   private handleNameValidation = (name: string) => {
@@ -134,9 +134,9 @@ class RenameVariableOverlayForm extends PureComponent<Props, State> {
   }
 }
 
-const mstp = (state: AppState, {params: {id}}: Props): StateProps => {
+const mstp = (state: AppState, {variableID}: OwnProps): StateProps => {
   const variables = extractVariablesList(state)
-  const startVariable = variables.find(v => v.id === id)
+  const startVariable = variables.find(v => v.id === variableID)
 
   return {variables, startVariable}
 }
@@ -145,9 +145,7 @@ const mdtp: DispatchProps = {
   onUpdateVariable: updateVariable,
 }
 
-export default withRouter<OwnProps>(
-  connect<StateProps, DispatchProps, OwnProps>(
-    mstp,
-    mdtp
-  )(RenameVariableOverlayForm)
-)
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mstp,
+  mdtp
+)(RenameVariableOverlayForm)

--- a/ui/src/variables/components/RenameVariableOverlay.tsx
+++ b/ui/src/variables/components/RenameVariableOverlay.tsx
@@ -1,6 +1,5 @@
 // Libraries
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 
 import _ from 'lodash'
 
@@ -11,18 +10,25 @@ import RenameVariableForm from 'src/variables/components/RenameVariableForm'
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+interface Props {
+  variableID: string
+  onDismiss: () => void
+}
+
 @ErrorHandling
-class RenameVariableOverlay extends PureComponent<WithRouterProps> {
+class RenameVariableOverlay extends PureComponent<Props> {
   public render() {
+    const {onDismiss, variableID} = this.props
+
     return (
       <DangerConfirmationOverlay
         title="Rename Variable"
         message={this.message}
         effectedItems={this.effectedItems}
-        onClose={this.handleClose}
+        onClose={onDismiss}
         confirmButtonText="I understand, let's rename my Variable"
       >
-        <RenameVariableForm onClose={this.handleClose} />
+        <RenameVariableForm onDismiss={onDismiss} variableID={variableID} />
       </DangerConfirmationOverlay>
     )
   }
@@ -34,15 +40,6 @@ class RenameVariableOverlay extends PureComponent<WithRouterProps> {
   private get effectedItems(): string[] {
     return ['Queries', 'Dashboards', 'Telegraf Configurations', 'Templates']
   }
-
-  private handleClose = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/variables`)
-  }
 }
 
-export default withRouter(RenameVariableOverlay)
+export default RenameVariableOverlay

--- a/ui/src/variables/components/UpdateVariableOverlay.tsx
+++ b/ui/src/variables/components/UpdateVariableOverlay.tsx
@@ -2,7 +2,6 @@
 import React, {PureComponent, FormEvent} from 'react'
 import _ from 'lodash'
 import {connect} from 'react-redux'
-import {withRouter, WithRouterProps} from 'react-router'
 
 // Components
 import {
@@ -49,7 +48,12 @@ interface DispatchProps {
   onUpdateVariable: typeof updateVariable
 }
 
-type Props = StateProps & DispatchProps & WithRouterProps
+interface OwnProps {
+  variableID: string
+  onDismiss: () => void
+}
+
+type Props = OwnProps & StateProps & DispatchProps
 
 class UpdateVariableOverlay extends PureComponent<Props, State> {
   public state: State = {
@@ -59,12 +63,13 @@ class UpdateVariableOverlay extends PureComponent<Props, State> {
   }
 
   public render() {
+    const {onDismiss} = this.props
     const {workingVariable, hasValidArgs} = this.state
 
     return (
       <Overlay visible={true}>
         <Overlay.Container maxWidth={1000}>
-          <Overlay.Header title="Edit Variable" onDismiss={this.handleClose} />
+          <Overlay.Header title="Edit Variable" onDismiss={onDismiss} />
           <Overlay.Body>
             <Form onSubmit={this.handleSubmit}>
               <Grid>
@@ -130,7 +135,7 @@ class UpdateVariableOverlay extends PureComponent<Props, State> {
                       <Button
                         text="Cancel"
                         color={ComponentColor.Danger}
-                        onClick={this.handleClose}
+                        onClick={onDismiss}
                       />
                       <Button
                         text="Submit"
@@ -240,24 +245,16 @@ class UpdateVariableOverlay extends PureComponent<Props, State> {
   private handleSubmit = (e: FormEvent): void => {
     e.preventDefault()
     const {workingVariable} = this.state
+    const {onDismiss} = this.props
 
     this.props.onUpdateVariable(workingVariable.id, workingVariable)
-    this.handleClose()
-  }
-
-  private handleClose = () => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/variables`)
+    onDismiss()
   }
 }
 
-const mstp = (state: AppState, {params: {id}}: Props): StateProps => {
+const mstp = (state: AppState, {variableID}: OwnProps): StateProps => {
   const variables = extractVariablesList(state)
-  const startVariable = variables.find(v => v.id === id)
+  const startVariable = variables.find(v => v.id === variableID)
 
   return {variables, startVariable}
 }
@@ -266,9 +263,7 @@ const mdtp: DispatchProps = {
   onUpdateVariable: updateVariable,
 }
 
-export default withRouter(
-  connect<StateProps, DispatchProps>(
-    mstp,
-    mdtp
-  )(UpdateVariableOverlay)
-)
+export default connect<StateProps, DispatchProps, OwnProps>(
+  mstp,
+  mdtp
+)(UpdateVariableOverlay)

--- a/ui/src/variables/components/VariableCard.tsx
+++ b/ui/src/variables/components/VariableCard.tsx
@@ -7,6 +7,7 @@ import {withRouter, WithRouterProps} from 'react-router'
 import {ResourceCard} from '@influxdata/clockface'
 import InlineLabels from 'src/shared/components/inlineLabels/InlineLabels'
 import VariableContextMenu from 'src/variables/components/VariableContextMenu'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Types
 import {IVariable as Variable, ILabel} from '@influxdata/influx'
@@ -25,8 +26,6 @@ import {createLabel as createLabelAsync} from 'src/labels/actions'
 interface OwnProps {
   variable: Variable
   onDeleteVariable: (variable: Variable) => void
-  onUpdateVariableName: (variable: Partial<Variable>) => void
-  onEditVariable: (variable: Variable) => void
   onFilterChange: (searchTerm: string) => void
 }
 
@@ -53,30 +52,19 @@ class VariableCard extends PureComponent<Props & WithRouterProps> {
         contextMenu={
           <VariableContextMenu
             variable={variable}
-            onExport={this.handleExport}
-            onRename={this.handleRenameVariable}
             onDelete={onDeleteVariable}
           />
         }
         name={
-          <ResourceCard.Name
-            onClick={this.handleNameClick}
-            name={variable.name}
-          />
+          <OverlayLink overlayID="edit-variable" resourceID={variable.id}>
+            {onClick => (
+              <ResourceCard.Name onClick={onClick} name={variable.name} />
+            )}
+          </OverlayLink>
         }
         metaData={[<>Type: {variable.arguments.type}</>]}
       />
     )
-  }
-
-  private handleNameClick = (): void => {
-    const {
-      variable,
-      params: {orgID},
-      router,
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/variables/${variable.id}/edit`)
   }
 
   private get labels(): JSX.Element {
@@ -114,25 +102,6 @@ class VariableCard extends PureComponent<Props & WithRouterProps> {
     } catch (err) {
       throw err
     }
-  }
-
-  private handleExport = () => {
-    const {
-      router,
-      variable,
-      params: {orgID},
-    } = this.props
-    router.push(`/orgs/${orgID}/settings/variables/${variable.id}/export`)
-  }
-
-  private handleRenameVariable = async () => {
-    const {
-      router,
-      variable,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/variables/${variable.id}/rename`)
   }
 }
 

--- a/ui/src/variables/components/VariableContextMenu.tsx
+++ b/ui/src/variables/components/VariableContextMenu.tsx
@@ -4,26 +4,29 @@ import React, {PureComponent} from 'react'
 // Components
 import {Context} from 'src/clockface'
 import {IconFont, ComponentColor} from '@influxdata/clockface'
+import OverlayLink from 'src/overlays/components/OverlayLink'
 
 // Types
 import {Variable} from '@influxdata/influx'
 
 interface Props {
   variable: Variable
-  onExport: () => void
-  onRename: () => void
   onDelete: (variable: Variable) => void
 }
 
 export default class VariableContextMenu extends PureComponent<Props> {
   public render() {
-    const {variable, onExport, onRename, onDelete} = this.props
+    const {variable, onDelete} = this.props
 
     return (
       <Context>
         <Context.Menu icon={IconFont.CogThick}>
-          <Context.Item label="Export" action={onExport} />
-          <Context.Item label="Rename" action={onRename} />
+          <OverlayLink overlayID="export-variable" resourceID={variable.id}>
+            {onClick => <Context.Item label="Export" action={onClick} />}
+          </OverlayLink>
+          <OverlayLink overlayID="rename-variable" resourceID={variable.id}>
+            {onClick => <Context.Item label="Rename" action={onClick} />}
+          </OverlayLink>
         </Context.Menu>
         <Context.Menu
           icon={IconFont.Trash}

--- a/ui/src/variables/components/VariableExportOverlay.tsx
+++ b/ui/src/variables/components/VariableExportOverlay.tsx
@@ -1,5 +1,4 @@
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -15,7 +14,8 @@ import {DocumentCreate} from '@influxdata/influx'
 import {RemoteDataState} from 'src/types'
 
 interface OwnProps {
-  params: {id: string}
+  variableID: string
+  onDismiss: () => void
 }
 
 interface DispatchProps {
@@ -28,16 +28,13 @@ interface StateProps {
   status: RemoteDataState
 }
 
-type Props = OwnProps & StateProps & DispatchProps & WithRouterProps
+type Props = OwnProps & StateProps & DispatchProps
 
 class VariableExportOverlay extends PureComponent<Props> {
   public async componentDidMount() {
-    const {
-      params: {id},
-      convertToTemplate,
-    } = this.props
+    const {variableID, convertToTemplate} = this.props
 
-    convertToTemplate(id)
+    convertToTemplate(variableID)
   }
 
   public render() {
@@ -54,9 +51,9 @@ class VariableExportOverlay extends PureComponent<Props> {
   }
 
   private onDismiss = () => {
-    const {router, clearExportTemplate} = this.props
+    const {clearExportTemplate, onDismiss} = this.props
 
-    router.goBack()
+    onDismiss()
     clearExportTemplate()
   }
 }
@@ -74,4 +71,4 @@ const mdtp: DispatchProps = {
 export default connect<StateProps, DispatchProps, OwnProps>(
   mstp,
   mdtp
-)(withRouter<Props>(VariableExportOverlay))
+)(VariableExportOverlay)

--- a/ui/src/variables/components/VariableImportOverlay.tsx
+++ b/ui/src/variables/components/VariableImportOverlay.tsx
@@ -1,5 +1,4 @@
 import React, {PureComponent} from 'react'
-import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
 // Components
@@ -16,35 +15,34 @@ interface DispatchProps {
   getVariables: typeof getVariablesAction
 }
 
-type Props = DispatchProps & WithRouterProps
+interface OwnProps {
+  onDismiss: () => void
+}
+
+type Props = OwnProps & DispatchProps
 
 class VariableImportOverlay extends PureComponent<Props> {
   public render() {
+    const {onDismiss} = this.props
     return (
       <ImportOverlay
-        onDismissOverlay={this.onDismiss}
+        onDismissOverlay={onDismiss}
         resourceName="Variable"
         onSubmit={this.handleImportVariable}
       />
     )
   }
 
-  private onDismiss = () => {
-    const {router} = this.props
-
-    router.goBack()
-  }
-
   private handleImportVariable = async (
     uploadContent: string
   ): Promise<void> => {
-    const {createVariableFromTemplate, getVariables} = this.props
+    const {createVariableFromTemplate, getVariables, onDismiss} = this.props
 
     const template = JSON.parse(uploadContent)
     await createVariableFromTemplate(template)
     getVariables()
 
-    this.onDismiss()
+    onDismiss()
   }
 }
 
@@ -53,7 +51,7 @@ const mdtp: DispatchProps = {
   getVariables: getVariablesAction,
 }
 
-export default connect<{}, DispatchProps, Props>(
+export default connect<{}, DispatchProps, OwnProps>(
   null,
   mdtp
-)(withRouter(VariableImportOverlay))
+)(VariableImportOverlay)

--- a/ui/src/variables/components/VariableList.tsx
+++ b/ui/src/variables/components/VariableList.tsx
@@ -8,7 +8,6 @@ import VariableCard from 'src/variables/components/VariableCard'
 
 // Types
 import {IVariable as Variable} from '@influxdata/influx'
-import {OverlayState} from 'src/types'
 import {SortTypes} from 'src/shared/utils/sort'
 import {Sort} from '@influxdata/clockface'
 
@@ -21,7 +20,6 @@ interface Props {
   variables: Variable[]
   emptyState: JSX.Element
   onDeleteVariable: (variable: Variable) => void
-  onUpdateVariable: (variable: Variable) => void
   onFilterChange: (searchTerm: string) => void
   sortKey: string
   sortDirection: Sort
@@ -30,8 +28,6 @@ interface Props {
 }
 
 interface State {
-  variableID: string
-  variableOverlayState: OverlayState
   sortedVariables: Variable[]
 }
 
@@ -44,8 +40,6 @@ export default class VariableList extends PureComponent<Props, State> {
     super(props)
 
     this.state = {
-      variableID: null,
-      variableOverlayState: OverlayState.Closed,
       sortedVariables: this.props.variables,
     }
   }
@@ -89,7 +83,6 @@ export default class VariableList extends PureComponent<Props, State> {
       sortDirection,
       sortType,
       onDeleteVariable,
-      onUpdateVariable,
       onFilterChange,
     } = this.props
     const sortedVariables = this.memGetSortedResources(
@@ -104,17 +97,8 @@ export default class VariableList extends PureComponent<Props, State> {
         key={variable.id || `variable-${index}`}
         variable={variable}
         onDeleteVariable={onDeleteVariable}
-        onUpdateVariableName={onUpdateVariable}
-        onEditVariable={this.handleStartEdit}
         onFilterChange={onFilterChange}
       />
     ))
-  }
-
-  private handleStartEdit = (variable: Variable) => {
-    this.setState({
-      variableID: variable.id,
-      variableOverlayState: OverlayState.Open,
-    })
   }
 }

--- a/ui/src/variables/components/VariablesTab.tsx
+++ b/ui/src/variables/components/VariablesTab.tsx
@@ -17,6 +17,7 @@ import FilterList from 'src/shared/components/Filter'
 import AddResourceDropdown from 'src/shared/components/AddResourceDropdown'
 import GetResources, {ResourceType} from 'src/shared/components/GetResources'
 import {Sort} from '@influxdata/clockface'
+import {displayOverlay} from 'src/overlays/components/OverlayLink'
 
 // Types
 import {OverlayState} from 'src/types'
@@ -84,7 +85,6 @@ class VariablesTab extends PureComponent<Props, State> {
                 variables={variables}
                 emptyState={this.emptyState}
                 onDeleteVariable={this.handleDeleteVariable}
-                onUpdateVariable={this.handleUpdateVariable}
                 onFilterChange={this.handleFilterUpdate}
                 sortKey={sortKey}
                 sortDirection={sortDirection}
@@ -96,6 +96,22 @@ class VariablesTab extends PureComponent<Props, State> {
         </GetResources>
       </>
     )
+  }
+
+  private handleOpenCreateOverlay = () => {
+    const {router, location} = this.props
+
+    const open = displayOverlay(location.pathname, router, 'create-variable')
+
+    open()
+  }
+
+  private handleOpenImportOverlay = () => {
+    const {router, location} = this.props
+
+    const open = displayOverlay(location.pathname, router, 'import-variable')
+
+    open()
   }
 
   private handleClickColumn = (nextSort: Sort, sortKey: SortKey) => {
@@ -135,30 +151,6 @@ class VariablesTab extends PureComponent<Props, State> {
 
   private handleFilterUpdate = (searchTerm: string) => {
     this.setState({searchTerm})
-  }
-
-  private handleOpenImportOverlay = (): void => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/variables/import`)
-  }
-
-  private handleOpenCreateOverlay = (): void => {
-    const {
-      router,
-      params: {orgID},
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/variables/new`)
-  }
-
-  private handleUpdateVariable = (variable: Partial<Variable>): void => {
-    const {onUpdateVariable} = this.props
-
-    onUpdateVariable(variable.id, variable)
   }
 
   private handleDeleteVariable = (variable: Variable): void => {

--- a/ui/src/variables/components/__snapshots__/Variables.test.tsx.snap
+++ b/ui/src/variables/components/__snapshots__/Variables.test.tsx.snap
@@ -28,7 +28,6 @@ exports[`VariableList rendering renders 1`] = `
       <Connect(withRouter(VariableCard))
         key="variable-0"
         onDeleteVariable={[MockFunction]}
-        onEditVariable={[Function]}
         variable={
           Object {
             "arguments": Object {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9666,6 +9666,15 @@ query-string@^4.1.0, query-string@^4.2.2:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.8.3:
+  version "6.8.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.3.tgz#fd9fb7ffb068b79062b43383685611ee47777d4b"
+  integrity sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -11100,6 +11109,11 @@ spdy@^4.0.0:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -11240,6 +11254,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**Goals:**
- Enable more experimentation of UX flows by allowing increased flexibility in accessing overlays
- Hypothesis: Allowing access to overlays from anywhere will make the UI easier to use because the user doesn't need to keep track of the access path for each overlay

**Problem:**
- Overlays must be tied to a specific route
- Accessing an overlay from multiple places means defining a specific route for each one
- Making an overlay accessible from any page is clunky
- Some overlays require props from their parent
- Not all overlays are accessible via the router

**Solution:**
- Place a component within `App.tsx` that listens for query params in the URL and displays overlays based on that
  - example: `8080/orgs/0349f0efc0d46000/data-explorer?overlay=create-bucket`
  - This means any overlay can be opened from any page
- Create a component and utility for opening overlays
- Refactor overlay components so they don't inherit any props from their parent

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
