### PR TITLE
2939/add logging to gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vendor
 .vs
 .tern-project
 .DS_Store
+.idea
 
 # binary databases
 influxd.bolt

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -711,6 +711,9 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 
 	h := http.NewHandlerFromRegistry("platform", m.reg)
 	h.Handler = platformHandler
+	if logconf.Level == zap.DebugLevel {
+		h.Handler = http.HTTPLoggingMW(httpLogger)(h.Handler)
+	}
 	h.Logger = httpLogger
 
 	m.httpServer.Handler = h

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -1,10 +1,10 @@
 package http
 
 import (
-	http "net/http"
+	"net/http"
 	"strings"
 
-	influxdb "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/authorizer"
 	"github.com/influxdata/influxdb/chronograf/server"
 	"github.com/influxdata/influxdb/http/metric"

--- a/http/platform_handler.go
+++ b/http/platform_handler.go
@@ -1,10 +1,15 @@
 package http
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 )
 
 // PlatformHandler is a collection of all the service handlers.
@@ -19,6 +24,68 @@ func setCORSResponseHeaders(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
 		w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization")
+	}
+}
+
+type bodyEchoer struct {
+	rc    io.ReadCloser
+	teedR io.Reader
+}
+
+func (b *bodyEchoer) Read(p []byte) (int, error) {
+	return b.teedR.Read(p)
+}
+
+func (b *bodyEchoer) Close() error {
+	return b.rc.Close()
+}
+
+func HTTPLoggingMW(logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			srw := &statusResponseWriter{
+				ResponseWriter: w,
+			}
+
+			var buf bytes.Buffer
+			r.Body = &bodyEchoer{
+				rc:    r.Body,
+				teedR: io.TeeReader(r.Body, &buf),
+			}
+
+			defer func(start time.Time) {
+				errField := zap.Skip()
+				if errStr := w.Header().Get(PlatformErrorCodeHeader); errStr != "" {
+					errField = zap.Error(errors.New(errStr))
+				}
+
+				errReferenceField := zap.Skip()
+				if errReference := w.Header().Get(PlatformErrorCodeHeader); errReference != "" {
+					errReferenceField = zap.String("error_code", PlatformErrorCodeHeader)
+				}
+
+				logger.Debug(
+					"Request",
+					zap.String("method", r.Method),
+					zap.String("host", r.Host),
+					zap.String("path", r.URL.Path),
+					zap.String("query", r.URL.Query().Encode()),
+					zap.String("proto", r.Proto),
+					zap.Int("status_code", srw.code()),
+					zap.Int("response_size", srw.responseBytes),
+					zap.Int64("content_length", r.ContentLength),
+					zap.String("referrer", r.Referer()),
+					zap.String("remote", r.RemoteAddr),
+					zap.String("user_agent", r.UserAgent()),
+					zap.ByteString("body", buf.Bytes()),
+					zap.Duration("took", time.Since(start)),
+					errField,
+					errReferenceField,
+				)
+			}(time.Now())
+			next.ServeHTTP(srw, r)
+		}
+		return http.HandlerFunc(fn)
 	}
 }
 


### PR DESCRIPTION
add some debug logging to the `http` gateway service. Will log all req/resp life cycle without sharing any PPI/secrets.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [X] Rebased/mergeable
- [ ] Tests pass
