### PR TITLE
feat(task): add type to some specific metrics in new execution.

### DIFF
--- a/task/backend/executor/executor_metrics.go
+++ b/task/backend/executor/executor_metrics.go
@@ -35,7 +35,7 @@ func NewExecutorMetrics(te *TaskExecutor) *ExecutorMetrics {
 			Subsystem: subsystem,
 			Name:      "total_runs_complete",
 			Help:      "Total number of runs completed across all tasks, split out by success or failure.",
-		}, []string{"status"}),
+		}, []string{"task_type", "status"}),
 
 		activeRuns: NewRunCollector(te),
 
@@ -45,7 +45,7 @@ func NewExecutorMetrics(te *TaskExecutor) *ExecutorMetrics {
 			Name:       "run_queue_delta",
 			Help:       "The duration in seconds between a run being due to start and actually starting.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-		}, []string{"taskID"}),
+		}, []string{"task_type", "taskID"}),
 
 		runDuration: prometheus.NewSummaryVec(prometheus.SummaryOpts{
 			Namespace:  namespace,
@@ -53,14 +53,14 @@ func NewExecutorMetrics(te *TaskExecutor) *ExecutorMetrics {
 			Name:       "run_duration",
 			Help:       "The duration in seconds between a run starting and finishing.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-		}, []string{"taskID"}),
+		}, []string{"task_type", "taskID"}),
 
 		errorsCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "errors_counter",
 			Help:      "The number of errors thrown by the executor with the type of error (ex. Invalid, Internal, etc.)",
-		}, []string{"errorType"}),
+		}, []string{"task_type", "errorType"}),
 
 		manualRunsCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
@@ -117,22 +117,22 @@ func (em *ExecutorMetrics) PrometheusCollectors() []prometheus.Collector {
 }
 
 // StartRun store the delta time between when a run is due to start and actually starting.
-func (em *ExecutorMetrics) StartRun(taskID influxdb.ID, queueDelta time.Duration) {
-	em.queueDelta.WithLabelValues("all").Observe(queueDelta.Seconds())
-	em.queueDelta.WithLabelValues(taskID.String()).Observe(queueDelta.Seconds())
+func (em *ExecutorMetrics) StartRun(task *influxdb.Task, queueDelta time.Duration) {
+	em.queueDelta.WithLabelValues(task.Type, "all").Observe(queueDelta.Seconds())
+	em.queueDelta.WithLabelValues("", task.ID.String()).Observe(queueDelta.Seconds())
 }
 
 // FinishRun adjusts the metrics to indicate a run is no longer in progress for the given task ID.
-func (em *ExecutorMetrics) FinishRun(taskID influxdb.ID, status backend.RunStatus, runDuration time.Duration) {
-	em.totalRunsComplete.WithLabelValues(status.String()).Inc()
+func (em *ExecutorMetrics) FinishRun(task *influxdb.Task, status backend.RunStatus, runDuration time.Duration) {
+	em.totalRunsComplete.WithLabelValues(task.Type, status.String()).Inc()
 
-	em.runDuration.WithLabelValues("all").Observe(runDuration.Seconds())
-	em.runDuration.WithLabelValues(taskID.String()).Observe(runDuration.Seconds())
+	em.runDuration.WithLabelValues(task.Type, "all").Observe(runDuration.Seconds())
+	em.runDuration.WithLabelValues("", task.ID.String()).Observe(runDuration.Seconds())
 }
 
 // LogError increments the count of errors.
-func (em *ExecutorMetrics) LogError(err *influxdb.Error) {
-	em.errorsCounter.WithLabelValues(err.Code)
+func (em *ExecutorMetrics) LogError(taskType string, err *influxdb.Error) {
+	em.errorsCounter.WithLabelValues(taskType, err.Code).Inc()
 }
 
 // Describe returns all descriptions associated with the run collector.

--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -310,7 +310,7 @@ func (w *worker) start(p *promise) {
 	w.te.tcs.UpdateRunState(ctx, p.task.ID, p.run.ID, time.Now(), backend.RunStarted)
 
 	// add to metrics
-	w.te.metrics.StartRun(p.task.ID, time.Since(p.createdAt))
+	w.te.metrics.StartRun(p.task, time.Since(p.createdAt))
 }
 
 func (w *worker) finish(p *promise, rs backend.RunStatus, err *influxdb.Error) {
@@ -326,12 +326,12 @@ func (w *worker) finish(p *promise, rs backend.RunStatus, err *influxdb.Error) {
 	// add to metrics
 	s, _ := p.run.StartedAtTime()
 	rd := time.Since(s)
-	w.te.metrics.FinishRun(p.task.ID, rs, rd)
+	w.te.metrics.FinishRun(p.task, rs, rd)
 
 	// log error
 	if err.Err != nil {
 		w.te.logger.Debug("execution failed", zap.Error(err), zap.String("taskID", p.task.ID.String()))
-		w.te.metrics.LogError(err)
+		w.te.metrics.LogError(p.task.Type, err)
 		p.err = err
 	} else {
 		w.te.logger.Debug("Completed successfully", zap.String("taskID", p.task.ID.String()))

--- a/task/backend/executor/task_executor_test.go
+++ b/task/backend/executor/task_executor_test.go
@@ -336,7 +336,7 @@ func testMetrics(t *testing.T) {
 
 	mg = promtest.MustGather(t, reg)
 
-	m = promtest.MustFindMetric(t, mg, "task_executor_total_runs_complete", map[string]string{"status": "success"})
+	m = promtest.MustFindMetric(t, mg, "task_executor_total_runs_complete", map[string]string{"task_type": "", "status": "success"})
 	if got := *m.Counter.Value; got != 1 {
 		t.Fatalf("expected 1 active runs, got %v", got)
 	}


### PR DESCRIPTION
We would like to be able to see some task metrics with tag's about what type of task they are. Right now the check's and notifications are different types of tasks and seeing stat's broken down in new way's will be helpful