### PR TITLE
chore(ui): relocate testing configuration

### DIFF
--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -1,0 +1,45 @@
+module.exports = {
+  setupFilesAfterEnv: [
+    './jestSetup.ts'
+  ],
+  displayName: 'test',
+  testURL: 'http://localhost',
+  testPathIgnorePatterns: [
+    'build',
+    '<rootDir>/node_modules/(?!(jest-test))',
+    'cypress'
+  ],
+  setupFiles: [
+    '<rootDir>/testSetup.ts'
+  ],
+  modulePaths: [
+    '<rootDir>',
+    '<rootDir>/node_modules'
+  ],
+  moduleDirectories: [
+    'src'
+  ],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  },
+  testRegex: '(/__tests__/.*|(\\.|/)(test))\\.(ts?|tsx?)$',
+  moduleFileExtensions: [
+    'ts',
+    'tsx',
+    'js',
+    'jsx',
+    'json',
+    'node'
+  ],
+  snapshotSerializers: [
+    'enzyme-to-json/serializer'
+  ],
+  moduleNameMapper: {
+    '\\.(css|scss)$': 'identity-obj-proxy'
+  },
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.test.json'
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,14 +16,16 @@
     "src": "./src"
   },
   "scripts": {
-    "start": "yarn install && yarn generate && cross-env TS_NODE_PROJECT=\"webpack.tsconfig.json\" && yarn run build:vendor && webpack-dev-server --config ./webpack.dev.ts",
+    "start": "yarn install && yarn generate && cross-env TS_NODE_PROJECT=\"webpack.tsconfig.json\" && yarn run build:vendor && yarn run start:dev",
+    "start:docker": "yarn generate && yarn build:vendor && yarn run start:dev",
+    "start:dev": "webpack-dev-server --config ./webpack.dev.ts",
     "build": "yarn install --silent && yarn generate && webpack --config webpack.prod.ts",
     "build:vendor": "webpack --config webpack.vendor.ts",
     "clean": "rm -rf ./build && rm -rf ./.cache && rm -rf node_modules && rm -rf cypress/screenshots && rm -rf cypress/videos && rm -f junit-results/* ",
     "test": "jest --maxWorkers=2",
     "test:watch": "jest --watch --verbose false",
     "test:update": "jest --updateSnapshot",
-    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand --watch --verbose false",
+    "test:debug": "node --inspect-brk $(npm bin)/jest --runInBand --watch --verbose false",
     "test:junit": "CYPRESS_baseUrl=http://localhost:9999 cypress run --browser chrome --reporter junit --reporter-options 'mochaFile=junit-results/test-output-[hash].xml'",
     "test:ju:report": "junit-viewer --results=junit-results --save-file=cypress/site/junit-report.html",
     "test:ju:clean": "rm junit-results/*.xml",
@@ -36,46 +38,6 @@
     "cy": "CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "CYPRESS_baseUrl=http://localhost:8080 cypress open",
     "generate": "oats ../http/swagger.yml > src/client/index.ts"
-  },
-  "jest": {
-    "setupFilesAfterEnv": [
-      "./jestSetup.ts"
-    ],
-    "displayName": "test",
-    "testURL": "http://localhost",
-    "testPathIgnorePatterns": [
-      "build",
-      "<rootDir>/node_modules/(?!(jest-test))",
-      "cypress"
-    ],
-    "setupFiles": [
-      "<rootDir>/testSetup.ts"
-    ],
-    "modulePaths": [
-      "<rootDir>",
-      "<rootDir>/node_modules"
-    ],
-    "moduleDirectories": [
-      "src"
-    ],
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test))\\.(ts?|tsx?)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ],
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ],
-    "moduleNameMapper": {
-      "\\.(css|scss)$": "identity-obj-proxy"
-    }
   },
   "author": "",
   "devDependencies": {

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -31,6 +31,9 @@
     "build",
     "node_modules",
     "cypress",
-    "webpack.tsconfig.json"
+    "webpack.tsconfig.json",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/mocks.ts"
   ]
 }

--- a/ui/tsconfig.test.json
+++ b/ui/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "assets",
+    "build",
+    "node_modules",
+    "cypress",
+    "webpack.tsconfig.json"
+  ]
+}


### PR DESCRIPTION
while exploring containerization of the frontend, i decided to remove the
existing environment configuration from package.json and push it into
external files in an attempt to improve the caching strategies available
for local development. the CI pipeline should be watching the lock file,
but changes to the testing environment locally shouldn't cause a rebuild
of node_modules.