### PR TITLE
fix(VEO): only execute queries if cellID or dashboardID change

### DIFF
--- a/ui/src/dashboards/components/EditVEO.tsx
+++ b/ui/src/dashboards/components/EditVEO.tsx
@@ -47,11 +47,8 @@ const EditViewVEO: FunctionComponent<Props> = ({
 }) => {
   useEffect(() => {
     getViewForTimeMachine(dashboardID, cellID, 'veo')
-  }, [cellID, dashboardID])
-
-  useEffect(() => {
     onExecuteQueries()
-  }, [view])
+  }, [cellID, dashboardID])
 
   const handleClose = () => {
     router.push(`/orgs/${orgID}/dashboards/${dashboardID}`)


### PR DESCRIPTION
Closes #15233 

### The Problem
As the user types a new y axis label the a new view is created and triggers the `useEffect` hook.

### The Solution
Only execute queries if a cellID or dashboardID changes.  Could probably only do this on the mounting of the component but 🤷‍♂ .