### PR TITLE
fix: Place resource fetch logic in overlay

### DIFF
--- a/ui/cypress/e2e/buckets.test.ts
+++ b/ui/cypress/e2e/buckets.test.ts
@@ -17,7 +17,7 @@ describe('Buckets', () => {
     })
   })
 
-  describe('from the org view', () => {
+  describe('from the buckets index page', () => {
     it('can create a bucket', () => {
       const newBucket = '🅱️ucket'
       cy.getByTestID(`bucket--card ${newBucket}`).should('not.exist')
@@ -66,6 +66,36 @@ describe('Buckets', () => {
       cy.getByTestID(`context-delete-bucket ${bucket1}`).click()
 
       cy.getByTestID(`bucket--card--name ${bucket1}`).should('not.exist')
+    })
+  })
+
+  describe('Routing directly to the edit overlay', () => {
+    it('reroutes to buckets view if bucket does not exist', () => {
+      cy.get<Organization>('@org').then(({id}: Organization) => {
+        cy.fixture('routes').then(({orgs}) => {
+          const idThatDoesntExist = '261234d1a7f932e4'
+          cy.visit(`${orgs}/${id}/load-data/buckets/${idThatDoesntExist}/edit`)
+          cy.location('pathname').should(
+            'be',
+            `${orgs}/${id}/load-data/buckets/`
+          )
+        })
+      })
+    })
+
+    it('displays overlay if bucket does exist', () => {
+      cy.get<Organization>('@org').then(({id: orgID}: Organization) => {
+        cy.fixture('routes').then(({orgs}) => {
+          cy.get<Bucket>('@bucket').then(({id: bucketID}: Bucket) => {
+            cy.visit(`${orgs}/${orgID}/load-data/buckets/${bucketID}/edit`)
+            cy.location('pathname').should(
+              'be',
+              `${orgs}/${orgID}/load-data/buckets/${bucketID}/edit`
+            )
+          })
+          cy.getByTestID(`overlay`).should('exist')
+        })
+      })
     })
   })
 })

--- a/ui/cypress/e2e/buckets.test.ts
+++ b/ui/cypress/e2e/buckets.test.ts
@@ -20,7 +20,7 @@ describe('Buckets', () => {
   describe('from the org view', () => {
     it('can create a bucket', () => {
       const newBucket = '🅱️ucket'
-      cy.getByTestID('bucket--card').should('have.length', 1)
+      cy.getByTestID(`bucket--card ${newBucket}`).should('not.exist')
 
       cy.getByTestID('Create Bucket').click()
       cy.getByTestID('overlay--container').within(() => {
@@ -30,14 +30,13 @@ describe('Buckets', () => {
           .click()
       })
 
-      cy.getByTestID('bucket--card')
-        .should('have.length', 2)
-        .and('contain', newBucket)
+      cy.getByTestID(`bucket--card ${newBucket}`).should('exist')
     })
 
-    it.only("can update a bucket's retention rules", () => {
+    it("can update a bucket's retention rules", () => {
       cy.get<Bucket>('@bucket').then(({name}: Bucket) => {
-        cy.getByTestID(`bucket--card ${name}`).click()
+        cy.getByTestID(`bucket--card--name ${name}`).click()
+        cy.getByTestID(`bucket--card ${name}`).should('not.contain', '7 days')
       })
 
       cy.getByTestID('retention-intervals--button').click()
@@ -48,33 +47,25 @@ describe('Buckets', () => {
         cy.contains('Save').click()
       })
 
-      cy.getByTestID('bucket--card').should('contain', '7 days')
-
       cy.get<Bucket>('@bucket').then(({name}: Bucket) => {
-        cy.getByTestID(`bucket--card ${name}`).click()
+        cy.getByTestID(`bucket--card ${name}`).should('contain', '7 days')
       })
-
-      cy.getByTestID('retention-never--button').click()
-      cy.getByTestID('overlay--container').within(() => {
-        cy.contains('Save').click()
-      })
-
-      cy.getByTestID('overlay--container').should('not.be.visible')
     })
 
-    it.skip('can delete a bucket', () => {
+    it('can delete a bucket', () => {
+      const bucket1 = 'newbucket1'
+      const bucket2 = 'newbucket2'
       cy.get<Organization>('@org').then(({id, name}: Organization) => {
-        cy.createBucket(id, name, 'newbucket1')
-        cy.createBucket(id, name, 'newbucket2')
+        cy.createBucket(id, name, bucket1)
+        cy.createBucket(id, name, bucket2)
       })
 
-      cy.getByTestID('bucket--card').should('have.length', 3)
+      cy.getByTestID(`bucket--card--name ${bucket1}`).should('exist')
 
-      cy.getByTestID('confirmation-button')
-        .last()
-        .click({force: true})
+      cy.getByTestID(`context-delete-menu ${bucket1}`).click()
+      cy.getByTestID(`context-delete-bucket ${bucket1}`).click()
 
-      cy.getByTestID('bucket--card').should('have.length', 2)
+      cy.getByTestID(`bucket--card--name ${bucket1}`).should('not.exist')
     })
   })
 })

--- a/ui/src/buckets/components/BucketCard.tsx
+++ b/ui/src/buckets/components/BucketCard.tsx
@@ -41,7 +41,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
     const {bucket, onDeleteBucket} = this.props
     return (
       <ResourceCard
-        testID="bucket--card"
+        testID={`bucket--card ${bucket.name}`}
         contextMenu={
           !isSystemBucket(bucket.name) && (
             <BucketContextMenu
@@ -63,7 +63,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
     if (bucket.type === 'user') {
       return (
         <ResourceCard.Name
-          testID={`bucket--card ${bucket.name}`}
+          testID={`bucket--card--name ${bucket.name}`}
           onClick={this.handleNameClick}
           name={bucket.name}
         />
@@ -72,7 +72,7 @@ class BucketRow extends PureComponent<Props & WithRouterProps> {
 
     return (
       <ResourceCard.Name
-        testID={`bucket--card ${bucket.name}`}
+        testID={`bucket--card--name ${bucket.name}`}
         name={bucket.name}
       />
     )

--- a/ui/src/buckets/components/BucketContextMenu.tsx
+++ b/ui/src/buckets/components/BucketContextMenu.tsx
@@ -47,13 +47,13 @@ export default class BucketContextMenu extends PureComponent<Props> {
           color={ComponentColor.Danger}
           shape={ButtonShape.Default}
           text="Delete Bucket"
-          testID="context-delete-menu"
+          testID={`context-delete-menu ${bucket.name}`}
         >
           <Context.Item
             label="Confirm"
             action={onDeleteBucket}
             value={bucket}
-            testID="context-delete-task"
+            testID={`context-delete-bucket ${bucket.name}`}
           />
         </Context.Menu>
       )

--- a/ui/src/buckets/components/UpdateBucketOverlay.tsx
+++ b/ui/src/buckets/components/UpdateBucketOverlay.tsx
@@ -1,153 +1,159 @@
 // Libraries
-import React, {PureComponent, ChangeEvent} from 'react'
+import React, {
+  FunctionComponent,
+  useEffect,
+  useState,
+  ChangeEvent,
+  FormEvent,
+} from 'react'
 import {withRouter, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
+import {get} from 'lodash'
 
 // Components
-import {Overlay} from '@influxdata/clockface'
+import {
+  Overlay,
+  RemoteDataState,
+  SpinnerContainer,
+  TechnoSpinner,
+} from '@influxdata/clockface'
 import BucketOverlayForm from 'src/buckets/components/BucketOverlayForm'
 
 // Actions
 import {updateBucket} from 'src/buckets/actions'
+import {notify} from 'src/shared/actions/notifications'
+
+// APIs
+import * as api from 'src/client'
 
 // Constants
 import {DEFAULT_SECONDS} from 'src/buckets/components/Retention'
+import {getBucketFailed} from 'src/shared/copy/notifications'
 
-// Types
-import {AppState, Bucket} from 'src/types'
-
-interface State {
-  bucket: Bucket
-  ruleType: 'expire'
-}
-
-interface StateProps {
-  bucket: Bucket
-}
+//Types
+import {Bucket} from 'src/types'
 
 interface DispatchProps {
   onUpdateBucket: typeof updateBucket
+  onNotify: typeof notify
 }
 
-type Props = StateProps & DispatchProps & WithRouterProps
+type Props = DispatchProps & WithRouterProps
 
-class UpdateBucketOverlay extends PureComponent<Props, State> {
-  constructor(props) {
-    super(props)
+const UpdateBucketOverlay: FunctionComponent<Props> = ({
+  onUpdateBucket,
+  onNotify,
+  params: {bucketID, orgID},
+  router,
+}) => {
+  const [bucketDraft, setBucketDraft] = useState<Bucket>(null)
 
-    const {bucket} = this.props
+  const [loadingStatus, setLoadingStatus] = useState(RemoteDataState.Loading)
 
-    this.state = {
-      ruleType: this.ruleType(bucket),
-      bucket,
+  const [retentionSelection, setRetentionSelection] = useState(DEFAULT_SECONDS)
+
+  useEffect(() => {
+    const fetchBucket = async () => {
+      const resp = await api.getBucket({bucketID})
+
+      if (resp.status !== 200) {
+        onNotify(getBucketFailed(bucketID, resp.data.message))
+        handleClose()
+        return
+      }
+      setBucketDraft(resp.data)
+
+      const rules = get(resp.data, 'retentionRules', [])
+      const rule = rules.find(r => r.type === 'expire')
+      if (rule) {
+        setRetentionSelection(rule.everySeconds)
+      }
+
+      setLoadingStatus(RemoteDataState.Done)
+    }
+    fetchBucket()
+  }, [bucketID])
+
+  const handleChangeRetentionRule = (everySeconds: number): void => {
+    setBucketDraft({
+      ...bucketDraft,
+      retentionRules: [{type: 'expire' as 'expire', everySeconds}],
+    })
+    setRetentionSelection(everySeconds)
+  }
+
+  const handleChangeRuleType = (ruleType: 'expire' | null) => {
+    if (ruleType) {
+      setBucketDraft({
+        ...bucketDraft,
+        retentionRules: [
+          {type: 'expire' as 'expire', everySeconds: retentionSelection},
+        ],
+      })
+    } else {
+      setBucketDraft({
+        ...bucketDraft,
+        retentionRules: [],
+      })
     }
   }
 
-  public render() {
-    const {bucket, ruleType} = this.state
+  const handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault()
+    onUpdateBucket(bucketDraft)
+    handleClose()
+  }
 
-    return (
-      <Overlay visible={true}>
-        <Overlay.Container maxWidth={500}>
-          <Overlay.Header title="Edit Bucket" onDismiss={this.handleClose} />
+  const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const key = e.target.name
+    const value = e.target.value
+    setBucketDraft({...bucketDraft, [key]: value})
+  }
+
+  const handleClose = () => {
+    router.push(`/orgs/${orgID}/load-data/buckets`)
+  }
+
+  const rules = get(bucketDraft, 'retentionRules', [])
+  const rule = rules.find(r => r.type === 'expire')
+
+  const retentionSeconds = rule ? rule.everySeconds : retentionSelection
+  const ruleType = rule ? ('expire' as 'expire') : null
+
+  return (
+    <Overlay visible={true}>
+      <Overlay.Container maxWidth={500}>
+        <Overlay.Header title="Edit Bucket" onDismiss={handleClose} />
+        <SpinnerContainer
+          spinnerComponent={<TechnoSpinner />}
+          loading={loadingStatus}
+        >
           <Overlay.Body>
             <BucketOverlayForm
-              name={bucket.name}
+              name={bucketDraft ? bucketDraft.name : ''}
               buttonText="Save Changes"
               ruleType={ruleType}
-              onCloseModal={this.handleClose}
-              onSubmit={this.handleSubmit}
+              onCloseModal={handleClose}
+              onSubmit={handleSubmit}
               disableRenaming={true}
-              onChangeInput={this.handleChangeInput}
-              retentionSeconds={this.retentionSeconds}
-              onChangeRuleType={this.handleChangeRuleType}
-              onChangeRetentionRule={this.handleChangeRetentionRule}
+              onChangeInput={handleChangeInput}
+              retentionSeconds={retentionSeconds}
+              onChangeRuleType={handleChangeRuleType}
+              onChangeRetentionRule={handleChangeRetentionRule}
             />
           </Overlay.Body>
-        </Overlay.Container>
-      </Overlay>
-    )
-  }
-
-  private get retentionSeconds(): number {
-    const rule = this.state.bucket.retentionRules.find(r => r.type === 'expire')
-
-    if (!rule) {
-      return DEFAULT_SECONDS
-    }
-
-    return rule.everySeconds
-  }
-
-  private ruleType = (bucket: Bucket): 'expire' => {
-    const rule = bucket.retentionRules.find(r => r.type === 'expire')
-
-    if (!rule) {
-      return null
-    }
-
-    return 'expire'
-  }
-
-  private handleChangeRetentionRule = (everySeconds: number): void => {
-    const bucket = {
-      ...this.state.bucket,
-      retentionRules: [{type: 'expire' as 'expire', everySeconds}],
-    }
-
-    this.setState({bucket})
-  }
-
-  private handleChangeRuleType = (ruleType: 'expire') => {
-    this.setState({ruleType})
-  }
-
-  private handleSubmit = (e): void => {
-    e.preventDefault()
-    const {onUpdateBucket} = this.props
-    const {ruleType, bucket} = this.state
-
-    if (ruleType === null) {
-      onUpdateBucket({...bucket, retentionRules: []})
-      this.handleClose()
-      return
-    }
-
-    onUpdateBucket(bucket)
-    this.handleClose()
-  }
-
-  private handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-    const key = e.target.name
-    const bucket = {...this.state.bucket, [key]: value}
-
-    this.setState({bucket})
-  }
-
-  private handleClose = () => {
-    const {orgID} = this.props.params
-    this.props.router.push(`/orgs/${orgID}/load-data/buckets`)
-  }
-}
-
-const mstp = ({buckets}: AppState, props: Props): StateProps => {
-  const {
-    params: {bucketID},
-  } = props
-
-  const bucket = buckets.list.find(b => b.id === bucketID)
-
-  return {
-    bucket,
-  }
+        </SpinnerContainer>
+      </Overlay.Container>
+    </Overlay>
+  )
 }
 
 const mdtp: DispatchProps = {
   onUpdateBucket: updateBucket,
+  onNotify: notify,
 }
 
-export default connect<StateProps, DispatchProps, {}>(
-  mstp,
+export default connect<{}, DispatchProps, {}>(
+  null,
   mdtp
 )(withRouter(UpdateBucketOverlay))

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -419,6 +419,14 @@ export const getBucketsFailed = (): Notification => ({
   message: 'Failed to fetch buckets',
 })
 
+export const getBucketFailed = (
+  bucketID: string,
+  error: string
+): Notification => ({
+  ...defaultErrorNotification,
+  message: `Failed to fetch bucket with id ${bucketID}: ${error}`,
+})
+
 // Limits
 export const readWriteCardinalityLimitReached = (
   message: string


### PR DESCRIPTION
Closes # [4893](https://github.com/influxdata/idpe/issues/4893)

Resource fetching for overlays is a problem that exists in many places in the UI. 
Currently a lot of our overlays do not fetch the resources they need, instead they rely on parent components to fetch resources and place in to redux state. They also do not warn user if the resource they need can not be found in redux state. 
I'm suggesting this PR as a general pattern for data fetching and errors in overlays. 
Would love to hear concerns / feedback

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
