### PR TITLE
fix(http): Return an empty array if organization has no secret keys

### DIFF
--- a/bolt/secret.go
+++ b/bolt/secret.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 
 	bolt "github.com/coreos/bbolt"
 	influxdb "github.com/influxdata/influxdb"
@@ -103,7 +102,10 @@ func (c *Client) getSecretKeys(ctx context.Context, tx *bolt.Tx, orgID influxdb.
 	}
 
 	if id != orgID {
-		return nil, fmt.Errorf("organization has no secret keys")
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "organization has no secret keys",
+		}
 	}
 
 	keys := []string{key}

--- a/bolt/secret.go
+++ b/bolt/secret.go
@@ -102,7 +102,7 @@ func (c *Client) getSecretKeys(ctx context.Context, tx *bolt.Tx, orgID influxdb.
 	}
 
 	if id != orgID {
-		return nil, &influxdb.Error{
+		return []string{}, &influxdb.Error{
 			Code: influxdb.ENotFound,
 			Msg:  "organization has no secret keys",
 		}

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -444,9 +444,6 @@ func (h *OrgHandler) handleGetSecrets(w http.ResponseWriter, r *http.Request) {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
-	if ks == nil {
-		ks = []string{}
-	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newSecretsResponse(req.orgID, ks)); err != nil {
 		logEncodingError(h.Logger, r, err)

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -440,9 +440,12 @@ func (h *OrgHandler) handleGetSecrets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ks, err := h.SecretService.GetSecretKeys(ctx, req.orgID)
-	if err != nil {
+	if err != nil && influxdb.ErrorCode(err) != influxdb.ENotFound {
 		h.HandleHTTPError(ctx, err, w)
 		return
+	}
+	if ks == nil {
+		ks = []string{}
 	}
 
 	if err := encodeResponse(ctx, w, http.StatusOK, newSecretsResponse(req.orgID, ks)); err != nil {

--- a/http/org_test.go
+++ b/http/org_test.go
@@ -147,6 +147,36 @@ func TestSecretService_handleGetSecrets(t *testing.T) {
 `,
 			},
 		},
+		{
+			name: "get secrets when organization has no secret keys",
+			fields: fields{
+				&mock.SecretService{
+					GetSecretKeysFn: func(ctx context.Context, orgID platform.ID) ([]string, error) {
+						return nil, &platform.Error{
+							Code: platform.ENotFound,
+							Msg:  "organization has no secret keys",
+						}
+
+					},
+				},
+			},
+			args: args{
+				orgID: 1,
+			},
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json; charset=utf-8",
+				body: `
+{
+  "links": {
+    "org": "/api/v2/orgs/0000000000000001",
+    "self": "/api/v2/orgs/0000000000000001/secrets"
+  },
+  "secrets": []
+}
+`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/http/org_test.go
+++ b/http/org_test.go
@@ -152,7 +152,7 @@ func TestSecretService_handleGetSecrets(t *testing.T) {
 			fields: fields{
 				&mock.SecretService{
 					GetSecretKeysFn: func(ctx context.Context, orgID platform.ID) ([]string, error) {
-						return nil, &platform.Error{
+						return []string{}, &platform.Error{
 							Code: platform.ENotFound,
 							Msg:  "organization has no secret keys",
 						}

--- a/kv/secret.go
+++ b/kv/secret.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"fmt"
 
 	"github.com/influxdata/influxdb"
 )
@@ -120,7 +119,10 @@ func (s *Service) getSecretKeys(ctx context.Context, tx Tx, orgID influxdb.ID) (
 	}
 
 	if id != orgID {
-		return nil, fmt.Errorf("organization has no secret keys")
+		return nil, &influxdb.Error{
+			Code: influxdb.ENotFound,
+			Msg:  "organization has no secret keys",
+		}
 	}
 
 	keys := []string{key}

--- a/kv/secret.go
+++ b/kv/secret.go
@@ -119,7 +119,7 @@ func (s *Service) getSecretKeys(ctx context.Context, tx Tx, orgID influxdb.ID) (
 	}
 
 	if id != orgID {
-		return nil, &influxdb.Error{
+		return []string{}, &influxdb.Error{
 			Code: influxdb.ENotFound,
 			Msg:  "organization has no secret keys",
 		}


### PR DESCRIPTION
Closes #15362

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
