### PR TITLE
feat(ui): Add documentation for Java, C# and Python client

### DIFF
--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -1,14 +1,12 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
-
 // Constants
 import {clientCSharpLibrary} from 'src/clientLibraries/constants'
 
 const ClientCSharpOverlay: FunctionComponent<{}> = () => {
-  const {name, url} = clientCSharpLibrary
+  const {name, url} = clientCSharpLibrary;
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -18,8 +16,98 @@ const ClientCSharpOverlay: FunctionComponent<{}> = () => {
           GitHub Repository
         </a>
       </p>
+      <br/>
+      <h5>Installing package</h5>
+      <p><b>Package Manager</b></p>
+      <pre>
+        <code>
+          Install-Package InfluxDB.Client
+        </code>
+      </pre>
+      <p><b>.NET CLI</b></p>
+      <pre>
+        <code>
+          dotnet add package InfluxDB.Client
+        </code>
+      </pre>
+      <p><b>Package Reference</b></p>
+      <pre>
+        <code>
+          &lt;PackageReference Include="InfluxDB.Client"/&gt;
+        </code>
+      </pre>
+      <h5>Initializing the Client</h5>
+      <pre>
+        <code>
+          using InfluxDB.Client;<br/><br/>
+          namespace Examples<br/>
+          &#123;<br/>
+          &nbsp;&nbsp;public class Examples<br/>
+          &nbsp;&nbsp;&#123;<br/>
+          &nbsp;&nbsp;&nbsp;&nbsp;public static void Main(string[] args)<br/>
+          &nbsp;&nbsp;&nbsp;&nbsp;&#123;<br/>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;var client = InfluxDBClientFactory.Create("basepath", "token".ToCharArray());<br/>
+          &nbsp;&nbsp;&nbsp;&nbsp;&#125;<br/>
+          &nbsp;&nbsp;&#125;<br/>
+          &#125;<br/>
+        </code>
+      </pre>
+      <h5>Using the client to execute a query</h5>
+      <pre>
+        <code>
+          const string query = "from(bucket: \"my_bucket\") |> range(start: -1h)";<br/><br/>
+          var tables = await client.GetQueryApi().QueryAsync(query, "someorgid");
+        </code>
+      </pre>
+      <h5>Writing Data</h5>
+      <p>Data could be written using InfluxDB Line Protocol, Data Point or POCO</p>
+      <p><b>InfluxDB Line Protocol</b></p>
+      <pre>
+        <code>
+          const string data = "mem,host=host1 used_percent=23.43234543 1556896326";<br/><br/>
+          using (var writeApi = client.GetWriteApi())<br/>
+          &#123;<br/>
+          &nbsp;&nbsp;writeApi.WriteRecord("bucketID", "orgID", WritePrecision.Ns, data);<br/>
+          &#125;<br/>
+        </code>
+      </pre>
+      <p><b>Data Point</b></p>
+      <pre>
+        <code>
+          var point = PointData<br/>
+          &nbsp;&nbsp;.Measurement("mem")<br/>
+          &nbsp;&nbsp;.Tag("host", "host1")<br/>
+          &nbsp;&nbsp;.Field("used_percent", 23.43234543)<br/>
+          &nbsp;&nbsp;.Timestamp(1556896326L, WritePrecision.Ns);<br/><br/>
+          using (var writeApi = client.GetWriteApi())<br/>
+          &#123;<br/>
+          &nbsp;&nbsp;writeApi.WritePoint("bucketID", "orgID", point);<br/>
+          &#125;<br/>
+        </code>
+      </pre>
+      <p><b>POCO</b></p>
+      <pre>
+        <code>
+          var mem = new Mem &#123;Host = "host1", UsedPercent = 23.43234543, Time = DateTime.UtcNow&#125;;<br/><br/>
+          using (var writeApi = client.GetWriteApi())<br/>
+          &#123;<br/>
+          &nbsp;&nbsp;writeApi.WriteMeasurement("bucketID", "orgID", WritePrecision.Ns, mem);<br/>
+          &#125;<br/>
+        </code>
+      </pre>
+      <pre>
+        <code>
+          [Measurement("mem")]<br/>
+          private class Mem<br/>
+          &#123;<br/>
+          &nbsp;&nbsp;[Column("host", IsTag = true)] public string Host &#123; get; set; &#125;<br/>
+          &nbsp;&nbsp;[Column("used_percent")] public double? UsedPercent &#123; get; set; &#125;<br/>
+          &nbsp;&nbsp;[Column(IsTimestamp = true)] public DateTime Time &#123; get; set; &#125;<br/>
+          &#125;
+        </code>
+      </pre>
     </ClientLibraryOverlay>
   )
-}
+};
 
 export default ClientCSharpOverlay

--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -6,7 +6,7 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 import {clientCSharpLibrary} from 'src/clientLibraries/constants'
 
 const ClientCSharpOverlay: FunctionComponent<{}> = () => {
-  const {name, url} = clientCSharpLibrary;
+  const {name, url} = clientCSharpLibrary
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -16,98 +16,158 @@ const ClientCSharpOverlay: FunctionComponent<{}> = () => {
           GitHub Repository
         </a>
       </p>
-      <br/>
+      <br />
       <h5>Installing package</h5>
-      <p><b>Package Manager</b></p>
+      <p>
+        <b>Package Manager</b>
+      </p>
       <pre>
-        <code>
-          Install-Package InfluxDB.Client
-        </code>
+        <code>Install-Package InfluxDB.Client</code>
       </pre>
-      <p><b>.NET CLI</b></p>
+      <p>
+        <b>.NET CLI</b>
+      </p>
       <pre>
-        <code>
-          dotnet add package InfluxDB.Client
-        </code>
+        <code>dotnet add package InfluxDB.Client</code>
       </pre>
-      <p><b>Package Reference</b></p>
+      <p>
+        <b>Package Reference</b>
+      </p>
       <pre>
-        <code>
-          &lt;PackageReference Include="InfluxDB.Client"/&gt;
-        </code>
+        <code>&lt;PackageReference Include="InfluxDB.Client"/&gt;</code>
       </pre>
       <h5>Initializing the Client</h5>
       <pre>
         <code>
-          using InfluxDB.Client;<br/><br/>
-          namespace Examples<br/>
-          &#123;<br/>
-          &nbsp;&nbsp;public class Examples<br/>
-          &nbsp;&nbsp;&#123;<br/>
-          &nbsp;&nbsp;&nbsp;&nbsp;public static void Main(string[] args)<br/>
-          &nbsp;&nbsp;&nbsp;&nbsp;&#123;<br/>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;var client = InfluxDBClientFactory.Create("basepath", "token".ToCharArray());<br/>
-          &nbsp;&nbsp;&nbsp;&nbsp;&#125;<br/>
-          &nbsp;&nbsp;&#125;<br/>
-          &#125;<br/>
+          using InfluxDB.Client;
+          <br />
+          <br />
+          namespace Examples
+          <br />
+          &#123;
+          <br />
+          &nbsp;&nbsp;public class Examples
+          <br />
+          &nbsp;&nbsp;&#123;
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;public static void Main(string[] args)
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&#123;
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;var client =
+          InfluxDBClientFactory.Create("basepath", "token".ToCharArray());
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&#125;
+          <br />
+          &nbsp;&nbsp;&#125;
+          <br />
+          &#125;
+          <br />
         </code>
       </pre>
       <h5>Using the client to execute a query</h5>
       <pre>
         <code>
-          const string query = "from(bucket: \"my_bucket\") |> range(start: -1h)";<br/><br/>
-          var tables = await client.GetQueryApi().QueryAsync(query, "someorgid");
+          const string query = "from(bucket: \"my_bucket\") |> range(start:
+          -1h)";
+          <br />
+          <br />
+          var tables = await client.GetQueryApi().QueryAsync(query,
+          "someorgid");
         </code>
       </pre>
       <h5>Writing Data</h5>
-      <p>Data could be written using InfluxDB Line Protocol, Data Point or POCO</p>
-      <p><b>InfluxDB Line Protocol</b></p>
+      <p>
+        Data could be written using InfluxDB Line Protocol, Data Point or POCO
+      </p>
+      <p>
+        <b>InfluxDB Line Protocol</b>
+      </p>
       <pre>
         <code>
-          const string data = "mem,host=host1 used_percent=23.43234543 1556896326";<br/><br/>
-          using (var writeApi = client.GetWriteApi())<br/>
-          &#123;<br/>
-          &nbsp;&nbsp;writeApi.WriteRecord("bucketID", "orgID", WritePrecision.Ns, data);<br/>
-          &#125;<br/>
+          const string data = "mem,host=host1 used_percent=23.43234543
+          1556896326";
+          <br />
+          <br />
+          using (var writeApi = client.GetWriteApi())
+          <br />
+          &#123;
+          <br />
+          &nbsp;&nbsp;writeApi.WriteRecord("bucketID", "orgID",
+          WritePrecision.Ns, data);
+          <br />
+          &#125;
+          <br />
         </code>
       </pre>
-      <p><b>Data Point</b></p>
+      <p>
+        <b>Data Point</b>
+      </p>
       <pre>
         <code>
-          var point = PointData<br/>
-          &nbsp;&nbsp;.Measurement("mem")<br/>
-          &nbsp;&nbsp;.Tag("host", "host1")<br/>
-          &nbsp;&nbsp;.Field("used_percent", 23.43234543)<br/>
-          &nbsp;&nbsp;.Timestamp(1556896326L, WritePrecision.Ns);<br/><br/>
-          using (var writeApi = client.GetWriteApi())<br/>
-          &#123;<br/>
-          &nbsp;&nbsp;writeApi.WritePoint("bucketID", "orgID", point);<br/>
-          &#125;<br/>
+          var point = PointData
+          <br />
+          &nbsp;&nbsp;.Measurement("mem")
+          <br />
+          &nbsp;&nbsp;.Tag("host", "host1")
+          <br />
+          &nbsp;&nbsp;.Field("used_percent", 23.43234543)
+          <br />
+          &nbsp;&nbsp;.Timestamp(1556896326L, WritePrecision.Ns);
+          <br />
+          <br />
+          using (var writeApi = client.GetWriteApi())
+          <br />
+          &#123;
+          <br />
+          &nbsp;&nbsp;writeApi.WritePoint("bucketID", "orgID", point);
+          <br />
+          &#125;
+          <br />
         </code>
       </pre>
-      <p><b>POCO</b></p>
+      <p>
+        <b>POCO</b>
+      </p>
       <pre>
         <code>
-          var mem = new Mem &#123;Host = "host1", UsedPercent = 23.43234543, Time = DateTime.UtcNow&#125;;<br/><br/>
-          using (var writeApi = client.GetWriteApi())<br/>
-          &#123;<br/>
-          &nbsp;&nbsp;writeApi.WriteMeasurement("bucketID", "orgID", WritePrecision.Ns, mem);<br/>
-          &#125;<br/>
+          var mem = new Mem &#123;Host = "host1", UsedPercent = 23.43234543,
+          Time = DateTime.UtcNow&#125;;
+          <br />
+          <br />
+          using (var writeApi = client.GetWriteApi())
+          <br />
+          &#123;
+          <br />
+          &nbsp;&nbsp;writeApi.WriteMeasurement("bucketID", "orgID",
+          WritePrecision.Ns, mem);
+          <br />
+          &#125;
+          <br />
         </code>
       </pre>
       <pre>
         <code>
-          [Measurement("mem")]<br/>
-          private class Mem<br/>
-          &#123;<br/>
-          &nbsp;&nbsp;[Column("host", IsTag = true)] public string Host &#123; get; set; &#125;<br/>
-          &nbsp;&nbsp;[Column("used_percent")] public double? UsedPercent &#123; get; set; &#125;<br/>
-          &nbsp;&nbsp;[Column(IsTimestamp = true)] public DateTime Time &#123; get; set; &#125;<br/>
+          [Measurement("mem")]
+          <br />
+          private class Mem
+          <br />
+          &#123;
+          <br />
+          &nbsp;&nbsp;[Column("host", IsTag = true)] public string Host &#123;
+          get; set; &#125;
+          <br />
+          &nbsp;&nbsp;[Column("used_percent")] public double? UsedPercent &#123;
+          get; set; &#125;
+          <br />
+          &nbsp;&nbsp;[Column(IsTimestamp = true)] public DateTime Time &#123;
+          get; set; &#125;
+          <br />
           &#125;
         </code>
       </pre>
     </ClientLibraryOverlay>
   )
-};
+}
 
 export default ClientCSharpOverlay

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -1,14 +1,12 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
-
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
-
 // Constants
 import {clientJavaLibrary} from 'src/clientLibraries/constants'
 
 const ClientJavaOverlay: FunctionComponent<{}> = () => {
-  const {name, url} = clientJavaLibrary
+  const {name, url} = clientJavaLibrary;
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -18,8 +16,97 @@ const ClientJavaOverlay: FunctionComponent<{}> = () => {
           GitHub Repository
         </a>
       </p>
+      <br/>
+      <h5>Adding dependency</h5>
+      <p><b>Build with Maven</b></p>
+      <pre>
+        <code>
+          &lt;dependency&gt;<br/>
+          &nbsp;&nbsp;&lt;groupId&gt;com.influxdb&lt;/groupId&gt;<br/>
+          &nbsp;&nbsp;&lt;artifactId&gt;influxdb-client-java&lt;/artifactId&gt;<br/>
+          &nbsp;&nbsp;&lt;version&gt;1.1.0&lt;/version&gt;<br/>
+          &lt;/dependency&gt;
+        </code>
+      </pre>
+      <p><b>Build with Gradle</b></p>
+      <pre>
+        <code>
+          dependencies &#123;<br/>
+          &nbsp;&nbsp;compile "com.influxdb:influxdb-client-java:1.1.0"<br/>
+          &#125;
+        </code>
+      </pre>
+      <h5>Initializing the Client</h5>
+      <pre>
+        <code>
+          package example;<br/><br/>
+          import com.influxdb.client.InfluxDBClient;<br/>
+          import com.influxdb.client.InfluxDBClientFactory;<br/><br/>
+          public class InfluxDB2Example &#123;<br/><br/>
+          &nbsp;&nbsp;public static void main(final String[] args) &#123;<br/><br/>
+          &nbsp;&nbsp;&nbsp;&nbsp;InfluxDBClient client = InfluxDBClientFactory.create("basepath", "token".toCharArray());<br/><br/>
+          &nbsp;&nbsp;&#125;<br/>
+          &#125;
+        </code>
+      </pre>
+      <h5>Using the client to execute a query</h5>
+      <pre>
+        <code>
+          String query = "from(bucket: \"my_bucket\") |> range(start: -1h)";<br/><br/>
+          List&lt;FluxTable&gt; tables = client.getQueryApi().query(query, "someorgid");
+        </code>
+      </pre>
+      <h5>Writing Data</h5>
+      <p>Data could be written using InfluxDB Line Protocol, Data Point or POJO</p>
+      <p><b>InfluxDB Line Protocol</b></p>
+      <pre>
+        <code>
+          String data = "mem,host=host1 used_percent=23.43234543 1556896326";<br/><br/>
+          try (WriteApi writeApi = client.getWriteApi()) &#123;<br/>
+          &nbsp;&nbsp;writeApi.writeRecord("bucketID", "orgID", WritePrecision.NS, data);<br/>
+          &#125;
+        </code>
+      </pre>
+      <p><b>Data Point</b></p>
+      <pre>
+        <code>
+          Point point = Point<br/>
+          &nbsp;&nbsp;.measurement("mem")<br/>
+          &nbsp;&nbsp;.addTag("host", "host1")<br/>
+          &nbsp;&nbsp;.addField("used_percent", 23.43234543)<br/>
+          &nbsp;&nbsp;.time(1556896326L, WritePrecision.NS);<br/><br/>
+          try (WriteApi writeApi = client.getWriteApi()) &#123;<br/>
+          &nbsp;&nbsp;writeApi.writePoint("bucketID", "orgID", point);<br/>
+          &#125;
+        </code>
+      </pre>
+      <p><b>POJO</b></p>
+      <pre>
+        <code>
+          Mem mem = new Mem();<br/>
+          mem.host = "host1";<br/>
+          mem.used_percent = 23.43234543;<br/>
+          mem.time = Instant.now();<br/><br/>
+          try (WriteApi writeApi = client.getWriteApi()) &#123;<br/>
+          &nbsp;&nbsp;writeApi.writeMeasurement("bucketID", "orgID", WritePrecision.NS, mem);<br/>
+          &#125;
+        </code>
+      </pre>
+      <pre>
+        <code>
+          @Measurement(name = "mem")<br/>
+          public class Mem &#123;<br/>
+          &nbsp;&nbsp;@Column(tag = true)<br/>
+          &nbsp;&nbsp;String host;<br/><br/>
+          &nbsp;&nbsp;@Column<br/>
+          &nbsp;&nbsp;Double used_percent;<br/><br/>
+          &nbsp;&nbsp;@Column(timestamp = true)<br/>
+          &nbsp;&nbsp;Instant time;<br/>
+          &#125;
+        </code>
+      </pre>
     </ClientLibraryOverlay>
   )
-}
+};
 
 export default ClientJavaOverlay

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -6,7 +6,7 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 import {clientJavaLibrary} from 'src/clientLibraries/constants'
 
 const ClientJavaOverlay: FunctionComponent<{}> = () => {
-  const {name, url} = clientJavaLibrary;
+  const {name, url} = clientJavaLibrary
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -16,97 +16,162 @@ const ClientJavaOverlay: FunctionComponent<{}> = () => {
           GitHub Repository
         </a>
       </p>
-      <br/>
+      <br />
       <h5>Adding dependency</h5>
-      <p><b>Build with Maven</b></p>
+      <p>
+        <b>Build with Maven</b>
+      </p>
       <pre>
         <code>
-          &lt;dependency&gt;<br/>
-          &nbsp;&nbsp;&lt;groupId&gt;com.influxdb&lt;/groupId&gt;<br/>
-          &nbsp;&nbsp;&lt;artifactId&gt;influxdb-client-java&lt;/artifactId&gt;<br/>
-          &nbsp;&nbsp;&lt;version&gt;1.1.0&lt;/version&gt;<br/>
+          &lt;dependency&gt;
+          <br />
+          &nbsp;&nbsp;&lt;groupId&gt;com.influxdb&lt;/groupId&gt;
+          <br />
+          &nbsp;&nbsp;&lt;artifactId&gt;influxdb-client-java&lt;/artifactId&gt;
+          <br />
+          &nbsp;&nbsp;&lt;version&gt;1.1.0&lt;/version&gt;
+          <br />
           &lt;/dependency&gt;
         </code>
       </pre>
-      <p><b>Build with Gradle</b></p>
+      <p>
+        <b>Build with Gradle</b>
+      </p>
       <pre>
         <code>
-          dependencies &#123;<br/>
-          &nbsp;&nbsp;compile "com.influxdb:influxdb-client-java:1.1.0"<br/>
+          dependencies &#123;
+          <br />
+          &nbsp;&nbsp;compile "com.influxdb:influxdb-client-java:1.1.0"
+          <br />
           &#125;
         </code>
       </pre>
       <h5>Initializing the Client</h5>
       <pre>
         <code>
-          package example;<br/><br/>
-          import com.influxdb.client.InfluxDBClient;<br/>
-          import com.influxdb.client.InfluxDBClientFactory;<br/><br/>
-          public class InfluxDB2Example &#123;<br/><br/>
-          &nbsp;&nbsp;public static void main(final String[] args) &#123;<br/><br/>
-          &nbsp;&nbsp;&nbsp;&nbsp;InfluxDBClient client = InfluxDBClientFactory.create("basepath", "token".toCharArray());<br/><br/>
-          &nbsp;&nbsp;&#125;<br/>
+          package example;
+          <br />
+          <br />
+          import com.influxdb.client.InfluxDBClient;
+          <br />
+          import com.influxdb.client.InfluxDBClientFactory;
+          <br />
+          <br />
+          public class InfluxDB2Example &#123;
+          <br />
+          <br />
+          &nbsp;&nbsp;public static void main(final String[] args) &#123;
+          <br />
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;InfluxDBClient client =
+          InfluxDBClientFactory.create("basepath", "token".toCharArray());
+          <br />
+          <br />
+          &nbsp;&nbsp;&#125;
+          <br />
           &#125;
         </code>
       </pre>
       <h5>Using the client to execute a query</h5>
       <pre>
         <code>
-          String query = "from(bucket: \"my_bucket\") |> range(start: -1h)";<br/><br/>
-          List&lt;FluxTable&gt; tables = client.getQueryApi().query(query, "someorgid");
+          String query = "from(bucket: \"my_bucket\") |> range(start: -1h)";
+          <br />
+          <br />
+          List&lt;FluxTable&gt; tables = client.getQueryApi().query(query,
+          "someorgid");
         </code>
       </pre>
       <h5>Writing Data</h5>
-      <p>Data could be written using InfluxDB Line Protocol, Data Point or POJO</p>
-      <p><b>InfluxDB Line Protocol</b></p>
+      <p>
+        Data could be written using InfluxDB Line Protocol, Data Point or POJO
+      </p>
+      <p>
+        <b>InfluxDB Line Protocol</b>
+      </p>
       <pre>
         <code>
-          String data = "mem,host=host1 used_percent=23.43234543 1556896326";<br/><br/>
-          try (WriteApi writeApi = client.getWriteApi()) &#123;<br/>
-          &nbsp;&nbsp;writeApi.writeRecord("bucketID", "orgID", WritePrecision.NS, data);<br/>
+          String data = "mem,host=host1 used_percent=23.43234543 1556896326";
+          <br />
+          <br />
+          try (WriteApi writeApi = client.getWriteApi()) &#123;
+          <br />
+          &nbsp;&nbsp;writeApi.writeRecord("bucketID", "orgID",
+          WritePrecision.NS, data);
+          <br />
           &#125;
         </code>
       </pre>
-      <p><b>Data Point</b></p>
+      <p>
+        <b>Data Point</b>
+      </p>
       <pre>
         <code>
-          Point point = Point<br/>
-          &nbsp;&nbsp;.measurement("mem")<br/>
-          &nbsp;&nbsp;.addTag("host", "host1")<br/>
-          &nbsp;&nbsp;.addField("used_percent", 23.43234543)<br/>
-          &nbsp;&nbsp;.time(1556896326L, WritePrecision.NS);<br/><br/>
-          try (WriteApi writeApi = client.getWriteApi()) &#123;<br/>
-          &nbsp;&nbsp;writeApi.writePoint("bucketID", "orgID", point);<br/>
+          Point point = Point
+          <br />
+          &nbsp;&nbsp;.measurement("mem")
+          <br />
+          &nbsp;&nbsp;.addTag("host", "host1")
+          <br />
+          &nbsp;&nbsp;.addField("used_percent", 23.43234543)
+          <br />
+          &nbsp;&nbsp;.time(1556896326L, WritePrecision.NS);
+          <br />
+          <br />
+          try (WriteApi writeApi = client.getWriteApi()) &#123;
+          <br />
+          &nbsp;&nbsp;writeApi.writePoint("bucketID", "orgID", point);
+          <br />
           &#125;
         </code>
       </pre>
-      <p><b>POJO</b></p>
+      <p>
+        <b>POJO</b>
+      </p>
       <pre>
         <code>
-          Mem mem = new Mem();<br/>
-          mem.host = "host1";<br/>
-          mem.used_percent = 23.43234543;<br/>
-          mem.time = Instant.now();<br/><br/>
-          try (WriteApi writeApi = client.getWriteApi()) &#123;<br/>
-          &nbsp;&nbsp;writeApi.writeMeasurement("bucketID", "orgID", WritePrecision.NS, mem);<br/>
+          Mem mem = new Mem();
+          <br />
+          mem.host = "host1";
+          <br />
+          mem.used_percent = 23.43234543;
+          <br />
+          mem.time = Instant.now();
+          <br />
+          <br />
+          try (WriteApi writeApi = client.getWriteApi()) &#123;
+          <br />
+          &nbsp;&nbsp;writeApi.writeMeasurement("bucketID", "orgID",
+          WritePrecision.NS, mem);
+          <br />
           &#125;
         </code>
       </pre>
       <pre>
         <code>
-          @Measurement(name = "mem")<br/>
-          public class Mem &#123;<br/>
-          &nbsp;&nbsp;@Column(tag = true)<br/>
-          &nbsp;&nbsp;String host;<br/><br/>
-          &nbsp;&nbsp;@Column<br/>
-          &nbsp;&nbsp;Double used_percent;<br/><br/>
-          &nbsp;&nbsp;@Column(timestamp = true)<br/>
-          &nbsp;&nbsp;Instant time;<br/>
+          @Measurement(name = "mem")
+          <br />
+          public class Mem &#123;
+          <br />
+          &nbsp;&nbsp;@Column(tag = true)
+          <br />
+          &nbsp;&nbsp;String host;
+          <br />
+          <br />
+          &nbsp;&nbsp;@Column
+          <br />
+          &nbsp;&nbsp;Double used_percent;
+          <br />
+          <br />
+          &nbsp;&nbsp;@Column(timestamp = true)
+          <br />
+          &nbsp;&nbsp;Instant time;
+          <br />
           &#125;
         </code>
       </pre>
     </ClientLibraryOverlay>
   )
-};
+}
 
 export default ClientJavaOverlay

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -8,7 +8,7 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 import {clientPythonLibrary} from 'src/clientLibraries/constants'
 
 const ClientPythonOverlay: FunctionComponent<{}> = () => {
-  const {name, url} = clientPythonLibrary;
+  const {name, url} = clientPythonLibrary
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -18,56 +18,76 @@ const ClientPythonOverlay: FunctionComponent<{}> = () => {
           GitHub Repository
         </a>
       </p>
-      <br/>
+      <br />
       <h5>Installing Package</h5>
       <pre>
-        <code>
-          pip install influxdb-client
-        </code>
+        <code>pip install influxdb-client</code>
       </pre>
       <h5>Initializing the Client</h5>
       <pre>
         <code>
-        import influxdb_client<br/>
-        from influxdb_client import InfluxDBClient<br/><br/>
-
-        client = InfluxDBClient(url="basepath", token="token")<br/>
+          import influxdb_client
+          <br />
+          from influxdb_client import InfluxDBClient
+          <br />
+          <br />
+          client = InfluxDBClient(url="basepath", token="token")
+          <br />
         </code>
       </pre>
       <h5>Using the client to execute a query</h5>
       <pre>
         <code>
-          query = 'from(bucket: "my_bucket") |> range(start: -1h)'<br/><br/>
+          query = 'from(bucket: "my_bucket") |> range(start: -1h)'
+          <br />
+          <br />
           tables = client.query_api().query(query, org="someorgid")
         </code>
       </pre>
       <h5>Writing Data</h5>
-      <p>Data could be written using InfluxDB Line Protocol,Data Point or Sequence</p>
-      <p><b>InfluxDB Line Protocol</b></p>
+      <p>
+        Data could be written using InfluxDB Line Protocol,Data Point or
+        Sequence
+      </p>
+      <p>
+        <b>InfluxDB Line Protocol</b>
+      </p>
       <pre>
         <code>
-          data = "mem,host=host1 used_percent=23.43234543 1556896326"<br/><br/>
+          data = "mem,host=host1 used_percent=23.43234543 1556896326"
+          <br />
+          <br />
           write_client.write("bucketID", "orgID", data)
         </code>
       </pre>
-      <p><b>Data Point</b></p>
+      <p>
+        <b>Data Point</b>
+      </p>
       <pre>
         <code>
-          point = Point("mem").tag("host", "host1").field("used_percent", 23.43234543).time(1556896326,  WritePrecision.NS)<br/><br/>
+          point = Point("mem").tag("host", "host1").field("used_percent",
+          23.43234543).time(1556896326, WritePrecision.NS)
+          <br />
+          <br />
           write_client.write("bucketID", "orgID", point)
         </code>
       </pre>
-      <p><b>Sequence</b></p>
+      <p>
+        <b>Sequence</b>
+      </p>
       <pre>
         <code>
-          sequence = ["mem,host=host1 used_percent=23.43234543 1556896326",<br/>
-          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"mem,host=host1 available_percent=15.856523 1556896326"]<br/><br/>
-
+          sequence = ["mem,host=host1 used_percent=23.43234543 1556896326",
+          <br />
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"mem,host=host1
+          available_percent=15.856523 1556896326"]
+          <br />
+          <br />
           write_client.write("bucketID", "orgID", sequence)
         </code>
       </pre>
     </ClientLibraryOverlay>
   )
-};
+}
 
 export default ClientPythonOverlay

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -8,7 +8,7 @@ import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOv
 import {clientPythonLibrary} from 'src/clientLibraries/constants'
 
 const ClientPythonOverlay: FunctionComponent<{}> = () => {
-  const {name, url} = clientPythonLibrary
+  const {name, url} = clientPythonLibrary;
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -18,8 +18,56 @@ const ClientPythonOverlay: FunctionComponent<{}> = () => {
           GitHub Repository
         </a>
       </p>
+      <br/>
+      <h5>Installing Package</h5>
+      <pre>
+        <code>
+          pip install influxdb-client
+        </code>
+      </pre>
+      <h5>Initializing the Client</h5>
+      <pre>
+        <code>
+        import influxdb_client<br/>
+        from influxdb_client import InfluxDBClient<br/><br/>
+
+        client = InfluxDBClient(url="basepath", token="token")<br/>
+        </code>
+      </pre>
+      <h5>Using the client to execute a query</h5>
+      <pre>
+        <code>
+          query = 'from(bucket: "my_bucket") |> range(start: -1h)'<br/><br/>
+          tables = client.query_api().query(query, org="someorgid")
+        </code>
+      </pre>
+      <h5>Writing Data</h5>
+      <p>Data could be written using InfluxDB Line Protocol,Data Point or Sequence</p>
+      <p><b>InfluxDB Line Protocol</b></p>
+      <pre>
+        <code>
+          data = "mem,host=host1 used_percent=23.43234543 1556896326"<br/><br/>
+          write_client.write("bucketID", "orgID", data)
+        </code>
+      </pre>
+      <p><b>Data Point</b></p>
+      <pre>
+        <code>
+          point = Point("mem").tag("host", "host1").field("used_percent", 23.43234543).time(1556896326,  WritePrecision.NS)<br/><br/>
+          write_client.write("bucketID", "orgID", point)
+        </code>
+      </pre>
+      <p><b>Sequence</b></p>
+      <pre>
+        <code>
+          sequence = ["mem,host=host1 used_percent=23.43234543 1556896326",<br/>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"mem,host=host1 available_percent=15.856523 1556896326"]<br/><br/>
+
+          write_client.write("bucketID", "orgID", sequence)
+        </code>
+      </pre>
     </ClientLibraryOverlay>
   )
-}
+};
 
 export default ClientPythonOverlay


### PR DESCRIPTION
Part of #15159 

Adding documentation for `Java`, `C#` and `Python` client:

### C#

![image](https://user-images.githubusercontent.com/455137/66564243-d6d1b980-eb5f-11e9-984a-1a474afa23ec.png)

### Python

![image](https://user-images.githubusercontent.com/455137/66564356-18fafb00-eb60-11e9-80b7-a012e185e994.png)

### Java

![image](https://user-images.githubusercontent.com/455137/66564304-fb2d9600-eb5f-11e9-8e67-ed713d38e203.png)

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
