### PR TITLE
fix(http): honor insecure-skip-very even if custom tls config is specified

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -110,6 +110,8 @@ func NewHTTPClient(conf HTTPConfig) (Client, error) {
 	}
 	if conf.TLSConfig != nil {
 		tr.TLSClientConfig = conf.TLSConfig
+		// Make sure to preserve the InsecureSkipVerify setting from the config.
+		tr.TLSClientConfig.InsecureSkipVerify = conf.InsecureSkipVerify
 	}
 	return &client{
 		url:       *u,


### PR DESCRIPTION
This is a cherry pick of https://github.com/influxdata/influxdb/pull/15385 onto the 1.7 branch