### PR TITLE
refactor(tasks): use Go time objects for timestamps on task Runs

### DIFF
--- a/authorizer/task_test.go
+++ b/authorizer/task_test.go
@@ -3,6 +3,7 @@ package authorizer_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/authorizer"
@@ -68,9 +69,9 @@ from(bucket:"holder") |> range(start:-5m) |> to(bucket:"holder", org:"thing")`,
 		ID:           runID,
 		TaskID:       taskID,
 		Status:       "completed",
-		ScheduledFor: "a while ago",
-		StartedAt:    "not so long ago",
-		FinishedAt:   "more recently",
+		ScheduledFor: time.Now().UTC(),
+		StartedAt:    time.Now().UTC().Add(time.Second * 3),
+		FinishedAt:   time.Now().UTC().Add(time.Second * 10),
 		Log:          []influxdb.Log{log},
 	}
 

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/influxdata/flux/repl"
 	platform "github.com/influxdata/influxdb"
@@ -528,15 +529,21 @@ func taskRunFindF(cmd *cobra.Command, args []string) error {
 		"FinishedAt",
 		"RequestedAt",
 	)
+
 	for _, r := range runs {
+		scheduledFor := r.ScheduledFor.Format(time.RFC3339)
+		startedAt := r.StartedAt.Format(time.RFC3339Nano)
+		finishedAt := r.FinishedAt.Format(time.RFC3339Nano)
+		requestedAt := r.RequestedAt.Format(time.RFC3339Nano)
+
 		w.Write(map[string]interface{}{
 			"ID":           r.ID,
 			"TaskID":       r.TaskID,
 			"Status":       r.Status,
-			"ScheduledFor": r.ScheduledFor,
-			"StartedAt":    r.StartedAt,
-			"FinishedAt":   r.FinishedAt,
-			"RequestedAt":  r.RequestedAt,
+			"ScheduledFor": scheduledFor,
+			"StartedAt":    startedAt,
+			"FinishedAt":   finishedAt,
+			"RequestedAt":  requestedAt,
 		})
 	}
 	w.Flush()

--- a/http/task_service_test.go
+++ b/http/task_service_test.go
@@ -610,14 +610,18 @@ func TestTaskHandler_handleGetRun(t *testing.T) {
 			fields: fields{
 				taskService: &mock.TaskService{
 					FindRunByIDFn: func(ctx context.Context, taskID platform.ID, runID platform.ID) (*platform.Run, error) {
+						scheduledFor, _ := time.Parse(time.RFC3339, "2018-12-01T17:00:13Z")
+						startedAt, _ := time.Parse(time.RFC3339Nano, "2018-12-01T17:00:03.155645Z")
+						finishedAt, _ := time.Parse(time.RFC3339Nano, "2018-12-01T17:00:13.155645Z")
+						requestedAt, _ := time.Parse(time.RFC3339, "2018-12-01T17:00:13Z")
 						run := platform.Run{
 							ID:           runID,
 							TaskID:       taskID,
 							Status:       "success",
-							ScheduledFor: "2018-12-01T17:00:13Z",
-							StartedAt:    "2018-12-01T17:00:03.155645Z",
-							FinishedAt:   "2018-12-01T17:00:13.155645Z",
-							RequestedAt:  "2018-12-01T17:00:13Z",
+							ScheduledFor: scheduledFor,
+							StartedAt:    startedAt,
+							FinishedAt:   finishedAt,
+							RequestedAt:  requestedAt,
 						}
 						return &run, nil
 					},
@@ -719,15 +723,19 @@ func TestTaskHandler_handleGetRuns(t *testing.T) {
 			fields: fields{
 				taskService: &mock.TaskService{
 					FindRunsFn: func(ctx context.Context, f platform.RunFilter) ([]*platform.Run, int, error) {
+						scheduledFor, _ := time.Parse(time.RFC3339, "2018-12-01T17:00:13Z")
+						startedAt, _ := time.Parse(time.RFC3339Nano, "2018-12-01T17:00:03.155645Z")
+						finishedAt, _ := time.Parse(time.RFC3339Nano, "2018-12-01T17:00:13.155645Z")
+						requestedAt, _ := time.Parse(time.RFC3339, "2018-12-01T17:00:13Z")
 						runs := []*platform.Run{
 							{
 								ID:           platform.ID(2),
 								TaskID:       f.Task,
 								Status:       "success",
-								ScheduledFor: "2018-12-01T17:00:13Z",
-								StartedAt:    "2018-12-01T17:00:03.155645Z",
-								FinishedAt:   "2018-12-01T17:00:13.155645Z",
-								RequestedAt:  "2018-12-01T17:00:13Z",
+								ScheduledFor: scheduledFor,
+								StartedAt:    startedAt,
+								FinishedAt:   finishedAt,
+								RequestedAt:  requestedAt,
 							},
 						}
 						return runs, len(runs), nil

--- a/task.go
+++ b/task.go
@@ -83,29 +83,14 @@ func (t *Task) OffsetDuration() (time.Duration, error) {
 
 // Run is a record createId when a run of a task is scheduled.
 type Run struct {
-	ID           ID     `json:"id,omitempty"`
-	TaskID       ID     `json:"taskID"`
-	Status       string `json:"status"`
-	ScheduledFor string `json:"scheduledFor"`          // ScheduledFor is the time the task is scheduled to run at
-	StartedAt    string `json:"startedAt,omitempty"`   // StartedAt is the time the executor begins running the task
-	FinishedAt   string `json:"finishedAt,omitempty"`  // FinishedAt is the time the executor finishes running the task
-	RequestedAt  string `json:"requestedAt,omitempty"` // RequestedAt is the time the coordinator told the scheduler to schedule the task
-	Log          []Log  `json:"log,omitempty"`
-}
-
-// ScheduledForTime gives the time.Time that the run is scheduled for.
-func (r *Run) ScheduledForTime() (time.Time, error) {
-	return time.Parse(time.RFC3339, r.ScheduledFor)
-}
-
-// StartedAtTime gives the time.Time that the run was started.
-func (r *Run) StartedAtTime() (time.Time, error) {
-	return time.Parse(time.RFC3339Nano, r.StartedAt)
-}
-
-// RequestedAtTime gives the time.Time that the run was requested.
-func (r *Run) RequestedAtTime() (time.Time, error) {
-	return time.Parse(time.RFC3339, r.RequestedAt)
+	ID           ID        `json:"id,omitempty"`
+	TaskID       ID        `json:"taskID"`
+	Status       string    `json:"status"`
+	ScheduledFor time.Time `json:"scheduledFor"`          // ScheduledFor is the time the task is scheduled to run at
+	StartedAt    time.Time `json:"startedAt,omitempty"`   // StartedAt is the time the executor begins running the task
+	FinishedAt   time.Time `json:"finishedAt,omitempty"`  // FinishedAt is the time the executor finishes running the task
+	RequestedAt  time.Time `json:"requestedAt,omitempty"` // RequestedAt is the time the coordinator told the scheduler to schedule the task
+	Log          []Log     `json:"log,omitempty"`
 }
 
 // Log represents a link to a log resource

--- a/task/backend/analytical_storage_test.go
+++ b/task/backend/analytical_storage_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/influxdb"
@@ -82,7 +83,7 @@ func TestDeduplicateRuns(t *testing.T) {
 	}
 	mockTCS := &mock.TaskControlService{
 		FinishRunFn: func(ctx context.Context, taskID, runID influxdb.ID) (*influxdb.Run, error) {
-			return &influxdb.Run{ID: 2, TaskID: 1, Status: "success", ScheduledFor: "1", StartedAt: "2", FinishedAt: "3"}, nil
+			return &influxdb.Run{ID: 2, TaskID: 1, Status: "success", ScheduledFor: time.Now(), StartedAt: time.Now().Add(1), FinishedAt: time.Now().Add(2)}, nil
 		},
 	}
 

--- a/task/backend/coordinator/task_coordinator_test.go
+++ b/task/backend/coordinator/task_coordinator_test.go
@@ -16,12 +16,10 @@ func Test_Coordinator_Executor_Methods(t *testing.T) {
 		one     = influxdb.ID(1)
 		taskOne = &influxdb.Task{ID: one}
 
-		timeString = time.Now().Format(time.RFC3339)
-
 		runOne = &influxdb.Run{
 			ID:           one,
 			TaskID:       one,
-			ScheduledFor: timeString,
+			ScheduledFor: time.Now(),
 		}
 
 		allowUnexported = cmp.AllowUnexported(executorE{}, schedulerC{})
@@ -122,12 +120,10 @@ func Test_Coordinator_Scheduler_Methods(t *testing.T) {
 		schedulableTaskTwo   = SchedulableTask{taskTwo}
 		schedulableTaskThree = SchedulableTask{taskThreeNew}
 
-		timeString = time.Now().Format(time.RFC3339)
-
 		runOne = &influxdb.Run{
 			ID:           one,
 			TaskID:       one,
-			ScheduledFor: timeString,
+			ScheduledFor: time.Now().UTC(),
 		}
 
 		allowUnexported = cmp.AllowUnexported(executorE{}, schedulerC{})

--- a/task/backend/executor/limits.go
+++ b/task/backend/executor/limits.go
@@ -28,14 +28,10 @@ func ConcurrencyLimit(exec *TaskExecutor) LimitFunc {
 		// sort by scheduledFor time because we want to make sure older scheduled for times
 		// are higher priority
 		sort.SliceStable(runs, func(i, j int) bool {
-			runi, err := runs[i].ScheduledForTime()
-			if err != nil {
-				return false
-			}
-			runj, err := runs[j].ScheduledForTime()
-			if err != nil {
-				return false
-			}
+			runi := runs[i].ScheduledFor
+
+			runj := runs[j].ScheduledFor
+
 			return runi.Before(runj)
 		})
 

--- a/task/backend/executor/limits_test.go
+++ b/task/backend/executor/limits_test.go
@@ -31,7 +31,7 @@ func TestTaskConcurrency(t *testing.T) {
 
 	r4 := &influxdb.Run{
 		ID:           3,
-		ScheduledFor: time.Now().Format(time.RFC3339),
+		ScheduledFor: time.Now(),
 	}
 
 	clFunc := ConcurrencyLimit(te)

--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -324,8 +324,7 @@ func (w *worker) finish(p *promise, rs backend.RunStatus, err error) {
 	w.te.tcs.UpdateRunState(ctx, p.task.ID, p.run.ID, time.Now(), rs)
 
 	// add to metrics
-	s, _ := p.run.StartedAtTime()
-	rd := time.Since(s)
+	rd := time.Since(p.run.StartedAt)
 	w.te.metrics.FinishRun(p.task, rs, rd)
 
 	// log error
@@ -365,11 +364,7 @@ func (w *worker) executeQuery(p *promise) {
 		return
 	}
 
-	sf, err := p.run.ScheduledForTime()
-	if err != nil {
-		w.finish(p, backend.RunFail, influxdb.ErrTaskTimeParse(err))
-		return
-	}
+	sf := p.run.ScheduledFor
 
 	req := &query.Request{
 		Authorization:  p.auth,

--- a/task/backend/middleware/middleware_test.go
+++ b/task/backend/middleware/middleware_test.go
@@ -104,7 +104,7 @@ func inmemTaskService() platform.TaskService {
 				return nil, platform.ErrTaskNotFound
 			}
 
-			return &platform.Run{ID: id, TaskID: t.ID, ScheduledFor: time.Unix(scheduledFor, 0).Format(time.RFC3339)}, nil
+			return &platform.Run{ID: id, TaskID: t.ID, ScheduledFor: time.Unix(scheduledFor, 0)}, nil
 		},
 	}
 	return ts

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -532,11 +532,7 @@ func (ts *taskScheduler) WorkCurrentlyRunning(runs []*platform.Run) error {
 
 	for _, cr := range runs {
 		for _, r := range ts.runners {
-			t, err := time.Parse(time.RFC3339, cr.ScheduledFor)
-			if err != nil {
-				return err
-			}
-			qr := QueuedRun{TaskID: ts.task.ID, RunID: platform.ID(cr.ID), DueAt: time.Now().UTC().Unix(), Now: t.Unix()}
+			qr := QueuedRun{TaskID: ts.task.ID, RunID: platform.ID(cr.ID), DueAt: time.Now().UTC().Unix(), Now: cr.ScheduledFor.Unix()}
 			if r.RestartRun(qr) {
 				foundWorker = true
 				break

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -409,22 +409,25 @@ func TestScheduler_Queue(t *testing.T) {
 		LatestCompleted: "1970-01-01T00:50:00Z",
 		Flux:            `option task = {name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
+	t1, _ := time.Parse(time.RFC3339, "1970-01-01T00:02:00Z")
+	t2, _ := time.Parse(time.RFC3339, "1970-01-01T00:03:00Z")
+	t3, _ := time.Parse(time.RFC3339, "1970-01-01T00:04:00Z")
 
 	tcs.SetTask(task)
 	tcs.SetManualRuns([]*platform.Run{
 		&platform.Run{
 			ID:           platform.ID(10),
 			TaskID:       task.ID,
-			ScheduledFor: "1970-01-01T00:02:00Z",
+			ScheduledFor: t1,
 		},
 		&platform.Run{
 			ID:           platform.ID(11),
 			TaskID:       task.ID,
-			ScheduledFor: "1970-01-01T00:03:00Z",
+			ScheduledFor: t2,
 		}, &platform.Run{
 			ID:           platform.ID(12),
 			TaskID:       task.ID,
-			ScheduledFor: "1970-01-01T00:04:00Z",
+			ScheduledFor: t3,
 		},
 	})
 	if err := o.ClaimTask(context.Background(), task); err != nil {

--- a/task_test.go
+++ b/task_test.go
@@ -3,7 +3,6 @@ package influxdb_test
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	platform "github.com/influxdata/influxdb"
@@ -138,27 +137,4 @@ from(bucket: "x")
 		}
 	})
 
-}
-
-func TestRun(t *testing.T) {
-	t.Run("ScheduledForTime", func(t *testing.T) {
-		now := time.Now().Truncate(time.Second)
-		r := platform.Run{
-			ScheduledFor: now.Format(time.RFC3339),
-		}
-		schedFor, err := r.ScheduledForTime()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !now.Equal(schedFor) {
-			t.Fatalf("expected scheduled for to match now time: exp: %s, got: %s", now.String(), schedFor.String())
-		}
-		r = platform.Run{
-			ScheduledFor: "ugly time",
-		}
-		schedFor, err = r.ScheduledForTime()
-		if err == nil {
-			t.Fatal("failed to error with a bad time")
-		}
-	})
 }


### PR DESCRIPTION
Closes #14523

This PR converts the the type of the `StartedAt`, `ScheduledFor`, `FinishedAt`, and `RequestedAt` properties of the Task Run struct from strings to Go time.Time objects. This will reduce the complexity of having to parse/format these timestamps throughout the internal task systems. 

These properties will still be stored in the database as strings, for backwards compatibility.

- [x] Rebased/mergeable
- [x] Tests pass
