### PR TITLE
chore(ui): adding a coverage reporter to see how we are doing

### DIFF
--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -41,5 +41,15 @@ module.exports = {
     'ts-jest': {
       tsConfig: 'tsconfig.test.json'
     }
-  }
+  },
+  collectCoverage: true,
+  collectCoverageFrom: [
+    './src/**/*.{js,jsx,ts,tsx}',
+    '!./src/**/*.test.{js,jsx,ts,tsx}'
+  ],
+  coverageDirectory: './coverage',
+  coverageReporters: [
+    'html',
+    'cobertura'
+  ]
 }


### PR DESCRIPTION
We need to chart how our testing push is doing, so lets expose it! This has an HTML reporter for consumption by people looking for testing blindspots, and a Cobertura reporter for showing the aggregate nicely in jenkins / CI tools.