### PR TITLE
fix: /owners /members endpoints to 404 when resources don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [15306](https://github.com/influxdata/influxdb/pull/15306): Added missing string values for CacheStatus type
 1. [15348](https://github.com/influxdata/influxdb/pull/15348): Disable saving for threshold check if no threshold selected
 1. [15354](https://github.com/influxdata/influxdb/pull/15354): Query variable selector shows variable keys, not values
+1. [15408] (https://github.com/influxdata/influxdb/pull/15408): Owners and Members endpoints to 404 when resources don't exist
 
 ## v2.0.0-alpha.18 [2019-09-26]
 

--- a/http/check_service.go
+++ b/http/check_service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/influxdata/influxdb"

--- a/http/label_service.go
+++ b/http/label_service.go
@@ -330,11 +330,15 @@ type LabelBackend struct {
 	influxdb.HTTPErrorHandler
 	LabelService influxdb.LabelService
 	ResourceType influxdb.ResourceType
+	Precheck     func(w http.ResponseWriter, r *http.Request) interface{}
 }
 
 // newGetLabelsHandler returns a handler func for a GET to /labels endpoints
 func newGetLabelsHandler(b *LabelBackend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if b.Precheck(w, r) == nil {
+			return
+		}
 		ctx := r.Context()
 
 		req, err := decodeGetLabelMappingsRequest(ctx, r, b.ResourceType)
@@ -385,6 +389,9 @@ func decodeGetLabelMappingsRequest(ctx context.Context, r *http.Request, rt infl
 // newPostLabelHandler returns a handler func for a POST to /labels endpoints
 func newPostLabelHandler(b *LabelBackend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if b.Precheck(w, r) == nil {
+			return
+		}
 		ctx := r.Context()
 
 		req, err := decodePostLabelMappingRequest(ctx, r, b.ResourceType)
@@ -460,6 +467,9 @@ func decodePostLabelMappingRequest(ctx context.Context, r *http.Request, rt infl
 // newDeleteLabelHandler returns a handler func for a DELETE to /labels endpoints
 func newDeleteLabelHandler(b *LabelBackend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if b.Precheck(w, r) == nil {
+			return
+		}
 		ctx := r.Context()
 
 		req, err := decodeDeleteLabelMappingRequest(ctx, r)

--- a/http/middleware.go
+++ b/http/middleware.go
@@ -153,7 +153,7 @@ func (b *bodyEchoer) Close() error {
 	return b.rc.Close()
 }
 
-func getMembersMiddleware(next http.HandlerFunc, backend MemberBackend) http.HandlerFunc {
+func getMembersPrecheckMiddleware(next http.HandlerFunc, backend MemberBackend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		req, err := decodeGetMembersRequest(ctx, r)
@@ -168,13 +168,13 @@ func getMembersMiddleware(next http.HandlerFunc, backend MemberBackend) http.Han
 			UserType:     backend.UserType,
 		}
 
-		mappings, _, err := backend.UserResourceMappingService.FindUserResourceMappings(ctx, filter)
+		_, count, err := backend.UserResourceMappingService.FindUserResourceMappings(ctx, filter)
 		if err != nil {
 			backend.HandleHTTPError(ctx, err, w)
 			return
 		}
 
-		if len(mappings) == 0 {
+		if count == 0 {
 			backend.Logger.Debug("No members/owners retrieved")
 			err := &influxdb.Error{
 				Code: influxdb.ENotFound,

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -104,7 +104,7 @@ func NewOrgHandler(b *OrgBackend) *OrgHandler {
 		UserService:                b.UserService,
 	}
 	h.HandlerFunc("POST", organizationsIDMembersPath, newPostMemberHandler(memberBackend))
-	h.HandlerFunc("GET", organizationsIDMembersPath, newGetMembersHandler(memberBackend))
+	h.HandlerFunc("GET", organizationsIDMembersPath, getMembersMiddleware(newGetMembersHandler(memberBackend), memberBackend))
 	h.HandlerFunc("DELETE", organizationsIDMembersIDPath, newDeleteMemberHandler(memberBackend))
 
 	ownerBackend := MemberBackend{
@@ -116,7 +116,7 @@ func NewOrgHandler(b *OrgBackend) *OrgHandler {
 		UserService:                b.UserService,
 	}
 	h.HandlerFunc("POST", organizationsIDOwnersPath, newPostMemberHandler(ownerBackend))
-	h.HandlerFunc("GET", organizationsIDOwnersPath, newGetMembersHandler(ownerBackend))
+	h.HandlerFunc("GET", organizationsIDOwnersPath, getMembersMiddleware(newGetMembersHandler(ownerBackend), memberBackend))
 	h.HandlerFunc("DELETE", organizationsIDOwnersIDPath, newDeleteMemberHandler(ownerBackend))
 
 	h.HandlerFunc("GET", organizationsIDSecretsPath, h.handleGetSecrets)

--- a/http/org_service.go
+++ b/http/org_service.go
@@ -104,7 +104,7 @@ func NewOrgHandler(b *OrgBackend) *OrgHandler {
 		UserService:                b.UserService,
 	}
 	h.HandlerFunc("POST", organizationsIDMembersPath, newPostMemberHandler(memberBackend))
-	h.HandlerFunc("GET", organizationsIDMembersPath, getMembersMiddleware(newGetMembersHandler(memberBackend), memberBackend))
+	h.HandlerFunc("GET", organizationsIDMembersPath, getMembersPrecheckMiddleware(newGetMembersHandler(memberBackend), memberBackend))
 	h.HandlerFunc("DELETE", organizationsIDMembersIDPath, newDeleteMemberHandler(memberBackend))
 
 	ownerBackend := MemberBackend{
@@ -116,7 +116,7 @@ func NewOrgHandler(b *OrgBackend) *OrgHandler {
 		UserService:                b.UserService,
 	}
 	h.HandlerFunc("POST", organizationsIDOwnersPath, newPostMemberHandler(ownerBackend))
-	h.HandlerFunc("GET", organizationsIDOwnersPath, getMembersMiddleware(newGetMembersHandler(ownerBackend), memberBackend))
+	h.HandlerFunc("GET", organizationsIDOwnersPath, getMembersPrecheckMiddleware(newGetMembersHandler(ownerBackend), ownerBackend))
 	h.HandlerFunc("DELETE", organizationsIDOwnersIDPath, newDeleteMemberHandler(ownerBackend))
 
 	h.HandlerFunc("GET", organizationsIDSecretsPath, h.handleGetSecrets)

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -3975,6 +3975,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResourceMembers"
+        '404':
+          description: Organization members not found
+          content:
+            application/json:
+            schema:
+              $ref: "#/components/schemas/Error"
         default:
           description: Unexpected error
           content:
@@ -4067,6 +4073,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ResourceOwners"
+        '404':
+          description: Organization owners not found
+          content:
+            application/json:
+            schema:
+              $ref: "#/components/schemas/Error"
         default:
           description: Unexpected error
           content:

--- a/http/user_resource_mapping_service.go
+++ b/http/user_resource_mapping_service.go
@@ -163,7 +163,6 @@ func newGetMembersHandler(b MemberBackend) http.HandlerFunc {
 		}
 
 		users := make([]*influxdb.User, 0, len(mappings))
-
 		for _, m := range mappings {
 			if m.MappingType == influxdb.OrgMappingType {
 				continue

--- a/http/user_resource_mapping_service.go
+++ b/http/user_resource_mapping_service.go
@@ -58,6 +58,7 @@ type MemberBackend struct {
 	influxdb.HTTPErrorHandler
 	Logger *zap.Logger
 
+	Precheck     func(w http.ResponseWriter, r *http.Request) interface{}
 	ResourceType influxdb.ResourceType
 	UserType     influxdb.UserType
 
@@ -68,6 +69,9 @@ type MemberBackend struct {
 // newPostMemberHandler returns a handler func for a POST to /members or /owners endpoints
 func newPostMemberHandler(b MemberBackend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if b.Precheck(w, r) == nil {
+			return
+		}
 		ctx := r.Context()
 		req, err := decodePostMemberRequest(ctx, r)
 		if err != nil {
@@ -142,6 +146,10 @@ func decodePostMemberRequest(ctx context.Context, r *http.Request) (*postMemberR
 // newGetMembersHandler returns a handler func for a GET to /members or /owners endpoints
 func newGetMembersHandler(b MemberBackend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if b.Precheck(w, r) == nil {
+			return
+		}
+
 		ctx := r.Context()
 		req, err := decodeGetMembersRequest(ctx, r)
 		if err != nil {
@@ -214,6 +222,9 @@ func decodeGetMembersRequest(ctx context.Context, r *http.Request) (*getMembersR
 // newDeleteMemberHandler returns a handler func for a DELETE to /members or /owners endpoints
 func newDeleteMemberHandler(b MemberBackend) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if b.Precheck(w, r) == nil {
+			return
+		}
 		ctx := r.Context()
 		req, err := decodeDeleteMemberRequest(ctx, r)
 		if err != nil {

--- a/http/user_resource_mapping_service.go
+++ b/http/user_resource_mapping_service.go
@@ -163,6 +163,7 @@ func newGetMembersHandler(b MemberBackend) http.HandlerFunc {
 		}
 
 		users := make([]*influxdb.User, 0, len(mappings))
+
 		for _, m := range mappings {
 			if m.MappingType == influxdb.OrgMappingType {
 				continue


### PR DESCRIPTION
Closes #
https://github.com/influxdata/influxdb/issues/15243

members and owners endpoints typically return an empty array in the response body, when in that case I think we want to 404.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
