### PR TITLE
feat(ui): add 403 signout handler to new api requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ ui/src/api/.openapi-generator/VERSION
 ui/src/api/git_push.sh
 
 # UI generated typescript types
-ui/src/client/index.ts
+ui/src/client/generatedRoutes.ts
 
 http/swagger_gen.go
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Features
 1. [15313](https://github.com/influxdata/influxdb/pull/15313): Add shortcut for toggling comments in script editor
 
+### UI Improvements
+1. [15426](https://github.com/influxdata/influxdb/pull/15426): Add 403 handler that redirects back to the sign-in page on oats-generated routes.
+
 ### Bug Fixes
 1. [15295](https://github.com/influxdata/influxdb/pull/15295): Ensures users are created with an active status
 1. [15306](https://github.com/influxdata/influxdb/pull/15306): Added missing string values for CacheStatus type

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,14 +37,14 @@
     "tsc:cypress": "tsc -p ./cypress/tsconfig.json --noEmit --pretty --skipLibCheck",
     "cy": "CYPRESS_baseUrl=http://localhost:9999 cypress open",
     "cy:dev": "CYPRESS_baseUrl=http://localhost:8080 cypress open",
-    "generate": "oats ../http/swagger.yml > src/client/index.ts"
+    "generate": "oats ../http/swagger.yml > src/client/generatedRoutes.ts"
   },
   "author": "",
   "devDependencies": {
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@cypress/webpack-preprocessor": "^4.0.3",
-    "@influxdata/oats": "0.4.0",
+    "@influxdata/oats": "0.5.0",
     "@types/chroma-js": "^1.3.4",
     "@types/codemirror": "^0.0.56",
     "@types/d3-color": "^1.2.1",

--- a/ui/src/client/index.ts
+++ b/ui/src/client/index.ts
@@ -1,0 +1,12 @@
+import {setResponseHandler, postSignout} from './generatedRoutes'
+
+setResponseHandler((status, headers, data) => {
+  if (status === 403) {
+    postSignout({})
+    window.location.href = '/signin'
+  }
+
+  return {status, headers, data}
+})
+
+export * from './generatedRoutes'

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1107,10 +1107,10 @@
   resolved "https://registry.yarnpkg.com/@influxdata/influxdb-templates/-/influxdb-templates-0.9.0.tgz#d4b1f727c8949147d2ade63f5754425a0d1a0e9d"
   integrity sha512-R/QhYJz+nNPGT8LkWHXKOLYYUROavDPfIFoGP7sIrxhStjm+hb0TzHYeQ75HLPQqKh54zCB8cv/TINwRgijYBw==
 
-"@influxdata/oats@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@influxdata/oats/-/oats-0.4.0.tgz#709b288232473140802fd1a3871f9b0f7ae49fc2"
-  integrity sha512-VgzO2jU0UguGFmdBEuqMM7jQS9soW0pqj251LmLKQhlFbuL9AKCAIOO6rf6OFqC3sCloduxwgZRc+Y9EprQhmQ==
+"@influxdata/oats@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@influxdata/oats/-/oats-0.5.0.tgz#0fdd308524fa407303ffa6a3d60fe959777dcfcb"
+  integrity sha512-oBlSB5ROM6JMqsVBDLlJzkBiMvAom+b4dszH83LPdM9H+pUtj2SeUoMpQhj9/4ioCnUVZx8HFN58/a/pkmADAQ==
   dependencies:
     commander "^2.20.0"
     humps "^2.0.1"


### PR DESCRIPTION
Closes #15312

- Adds a custom response handler for the new api routes created by oats that immediately logs the user out and returns them to `/signin` when a 403 is returned from the API
  - upgrades to oats 0.5.0

![out](https://user-images.githubusercontent.com/146112/66875851-9d84b980-ef64-11e9-8e4c-0a79c78d6551.gif)


### Testing Instructions
* If you'd like to see which routes use the new api and go through this handler, you can add a log statement [here](https://github.com/influxdata/influxdb/blob/bs_bugfix_403_logout/ui/src/client/index.ts#L4)
* To force 403s from the API (only works on the api calls that use `client/index`):
  * change [authentication_middleware.go](https://github.com/influxdata/influxdb/blob/bs_bugfix_403_logout/http/authentication_middleware.go#L110) to something [like this](https://gist.github.com/hoorayimhelping/c138a0f393b3face916637b3db29ffe2) (change the id to match yours, which can be found in the url on home page after you log in to the app)
  * re-build and run: `go run ./cmd/influxd --assets-path=ui/build`
  * on the sidebar, click settings -> members (log back in, if necessary)
  * you should be sent back to the `/signin` screen with whatever message you logged in 403 handler.
* To ensure `/me` works (this is a little tricky):
  * start the app normally
  * sign in
  * change [authentication_middleware.go](https://github.com/influxdata/influxdb/blob/bs_bugfix_403_logout/http/authentication_middleware.go#L110) to [check for `/api/v2/me`](https://gist.github.com/hoorayimhelping/09d7d337316411696fd8f970dcd606a3)
   * re-build and run **without reloading and signing back in**: `go run ./cmd/influxd --assets-path=ui/build`
  * wait
  * see the user get logged out
    * if you added a log message in the handler above, you'll see that it doesn't get called. *403s from `/me` already get kicked back to the `/signin` screen.*

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass