### PR TITLE
fix(ui/telegraf): filter functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [15306](https://github.com/influxdata/influxdb/pull/15306): Added missing string values for CacheStatus type
 1. [15348](https://github.com/influxdata/influxdb/pull/15348): Disable saving for threshold check if no threshold selected
 1. [15354](https://github.com/influxdata/influxdb/pull/15354): Query variable selector shows variable keys, not values
+1. [15246](https://github.com/influxdata/influxdb/pull/15427): UI/Telegraf filter functionality shows results based on input name
 
 ## v2.0.0-alpha.18 [2019-09-26]
 

--- a/ui/cypress/e2e/collectors.test.ts
+++ b/ui/cypress/e2e/collectors.test.ts
@@ -124,6 +124,8 @@ describe('Collectors', () => {
     })
 
     it('can filter telegraf configs correctly', () => {
+      // fixes issue #15246:
+      // https://github.com/influxdata/influxdb/issues/15246
       const firstTelegraf = 'test1'
       const secondTelegraf = 'test2'
       const thirdTelegraf = 'unicorn'

--- a/ui/cypress/e2e/collectors.test.ts
+++ b/ui/cypress/e2e/collectors.test.ts
@@ -135,8 +135,7 @@ describe('Collectors', () => {
         cy.createTelegraf(thirdTelegraf, description, id)
       })
 
-      cy.getByTestID('search-widget')
-        .type(firstTelegraf)
+      cy.getByTestID('search-widget').type(firstTelegraf)
 
       cy.getByTestID('resource-card').should('have.length', 1)
       cy.getByTestID('resource-card').should('contain', firstTelegraf)

--- a/ui/cypress/e2e/collectors.test.ts
+++ b/ui/cypress/e2e/collectors.test.ts
@@ -61,7 +61,7 @@ describe('Collectors', () => {
       const telegrafConfigName = 'New Config'
       const description = 'Config Description'
 
-      cy.get<Organization>('@org').then(({id}) => {
+      cy.get('@org').then(({id}: Organization) => {
         cy.createTelegraf(telegrafConfigName, description, id)
       })
 
@@ -84,7 +84,7 @@ describe('Collectors', () => {
       const telegrafConfigName = 'New Config'
       const description = 'Config Description'
 
-      cy.get<Organization>('@org').then(({id}) => {
+      cy.get('@org').then(({id}: Organization) => {
         cy.createTelegraf(telegrafConfigName, description, id)
         cy.createTelegraf(telegrafConfigName, description, id)
       })
@@ -106,7 +106,7 @@ describe('Collectors', () => {
       const telegrafConfigName = 'New Config'
       const description = 'Config Description'
 
-      cy.get<Organization>('@org').then(({id}) => {
+      cy.get('@org').then(({id}: Organization) => {
         cy.createTelegraf(telegrafConfigName, description, id)
       })
 
@@ -121,6 +121,55 @@ describe('Collectors', () => {
         .click()
 
       cy.getByTestID('setup-instructions').should('not.exist')
+    })
+
+    it('can filter telegraf configs correctly', () => {
+      const firstTelegraf = 'test1'
+      const secondTelegraf = 'test2'
+      const thirdTelegraf = 'unicorn'
+      const description = 'Config Description'
+
+      cy.get('@org').then(({id}: Organization) => {
+        cy.createTelegraf(firstTelegraf, description, id)
+        cy.createTelegraf(secondTelegraf, description, id)
+        cy.createTelegraf(thirdTelegraf, description, id)
+      })
+
+      cy.getByTestID('search-widget')
+        .type(firstTelegraf)
+
+      cy.getByTestID('resource-card').should('have.length', 1)
+      cy.getByTestID('resource-card').should('contain', firstTelegraf)
+
+      cy.getByTestID('search-widget')
+        .clear()
+        .type(secondTelegraf)
+
+      cy.getByTestID('resource-card').should('have.length', 1)
+      cy.getByTestID('resource-card').should('contain', secondTelegraf)
+
+      cy.getByTestID('search-widget')
+        .clear()
+        .type(thirdTelegraf)
+
+      cy.getByTestID('resource-card').should('have.length', 1)
+      cy.getByTestID('resource-card').should('contain', thirdTelegraf)
+
+      cy.getByTestID('search-widget')
+        .clear()
+        .type('should have no results')
+
+      cy.getByTestID('resource-card').should('have.length', 0)
+      cy.getByTestID('empty-state').should('exist')
+
+      cy.getByTestID('search-widget')
+        .clear()
+        .type('test')
+
+      cy.getByTestID('resource-card').should('have.length', 2)
+      cy.getByTestID('resource-card').should('contain', firstTelegraf)
+      cy.getByTestID('resource-card').should('contain', secondTelegraf)
+      cy.getByTestID('resource-card').should('not.contain', thirdTelegraf)
     })
   })
 })

--- a/ui/src/telegrafs/components/Collectors.tsx
+++ b/ui/src/telegrafs/components/Collectors.tsx
@@ -115,7 +115,7 @@ class Collectors extends PureComponent<Props, State> {
               <GetResources resource={ResourceType.Labels}>
                 <FilterList<Telegraf>
                   searchTerm={searchTerm}
-                  searchKeys={['plugins.0.config.bucket', 'labels[].name']}
+                  searchKeys={['plugins.0.config.bucket', 'name']}
                   list={collectors}
                 >
                   {cs => (


### PR DESCRIPTION
Closes #15246 

This PR fixes the search funcitonality in the ui/telegraf input field.

### Problem

The problem originated by an invalid prop filter, where the frontend was expecting results to be filtered based on a label array property, rather than a string.

### 
Solution

Updated the frontend filter functionality to search for the filter parameter based on the correct property - `telegrafconfig.name`

![Kapture 2019-10-15 at 14 24 59](https://user-images.githubusercontent.com/19984220/66871060-b2a71b80-ef57-11e9-9d7a-23acb69d8983.gif)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
