### PR TITLE
fix(tasks): replace deactivation of unrecoverable errors with metric

### DIFF
--- a/task/backend/check_task_error.go
+++ b/task/backend/check_task_error.go
@@ -22,5 +22,10 @@ func IsUnrecoverable(err error) bool {
 		return true
 	}
 
+	// Flux script uses an API that attempts to read the filesystem
+	if strings.Contains(errString, "filesystem service uninitialized") {
+		return true
+	}
+
 	return false
 }

--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -335,11 +335,15 @@ func (w *worker) finish(p *promise, rs backend.RunStatus, err error) {
 		w.te.metrics.LogError(p.task.Type, err)
 
 		if backend.IsUnrecoverable(err) {
+			// TODO (al): once user notification system is put in place, this code should be uncommented
 			// if we get an error that requires user intervention to fix, deactivate the task and alert the user
-			inactive := string(backend.TaskInactive)
-			w.te.ts.UpdateTask(p.ctx, p.task.ID, influxdb.TaskUpdate{Status: &inactive})
+			// inactive := string(backend.TaskInactive)
+			// w.te.ts.UpdateTask(p.ctx, p.task.ID, influxdb.TaskUpdate{Status: &inactive})
+
 			// and add to run logs
-			w.te.tcs.AddRunLog(p.ctx, p.task.ID, p.run.ID, time.Now(), fmt.Sprintf("Task deactivated after encountering unrecoverable error: %v", err.Error()))
+			w.te.tcs.AddRunLog(p.ctx, p.task.ID, p.run.ID, time.Now(), fmt.Sprintf("Task encountered unrecoverable error, requires admin action: %v", err.Error()))
+			// add to metrics
+			w.te.metrics.LogUnrecoverableError(p.task.ID, err)
 		}
 
 		p.err = err

--- a/task/backend/executor/task_executor_test.go
+++ b/task/backend/executor/task_executor_test.go
@@ -421,6 +421,10 @@ func testErrorHandling(t *testing.T) {
 	t.Parallel()
 	tes := taskExecutorSystem(t)
 
+	metrics := tes.metrics
+	reg := prom.NewRegistry()
+	reg.MustRegister(metrics.PrometheusCollectors()...)
+
 	script := fmt.Sprintf(fmtTestScript, t.Name())
 	ctx := icontext.SetAuthorizer(context.Background(), tes.tc.Auth)
 	task, err := tes.i.CreateTask(ctx, influxdb.TaskCreate{OrganizationID: tes.tc.OrgID, OwnerID: tes.tc.Auth.GetUserID(), Flux: script, Status: "active"})
@@ -428,7 +432,7 @@ func testErrorHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// encountering a bucket not found error should deactivate the task
+	// encountering a bucket not found error should log an unrecoverable error in the metrics
 	forcedErr := errors.New("could not find bucket")
 	tes.svc.FailNextQuery(forcedErr)
 
@@ -439,12 +443,23 @@ func testErrorHandling(t *testing.T) {
 
 	<-promise.Done()
 
-	inactive, err := tes.i.FindTaskByID(context.Background(), task.ID)
-	if err != nil {
-		t.Fatal(err)
+	mg := promtest.MustGather(t, reg)
+
+	m := promtest.MustFindMetric(t, mg, "task_executor_unrecoverable_counter", map[string]string{"taskID": task.ID.String(), "errorType": "internal error"})
+	if got := *m.Counter.Value; got != 1 {
+		t.Fatalf("expected 1 unrecoverable error, got %v", got)
 	}
 
-	if inactive.Status != "inactive" {
-		t.Fatal("expected task to be deactivated after permanent error")
-	}
+	// TODO (al): once user notification system is put in place, this code should be uncommented
+	// encountering a bucket not found error should deactivate the task
+	/*
+		inactive, err := tes.i.FindTaskByID(context.Background(), task.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if inactive.Status != "inactive" {
+			t.Fatal("expected task to be deactivated after permanent error")
+		}
+	*/
 }


### PR DESCRIPTION
This PR comments out the deactivation logic for unrecoverable errors, to be restored when a user notification system is put in place to alert users when they have a task that is going to be deactivated.

This PR also adds a new metric for the new executor called "Unrecoverable Counter" which will allow engineers to see in one place all of the errors for which we would like to deactivate the offending tasks.

The error message "filesystem service uninitialized" is also added to the list of unrecoverable errors.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass

