### PR TITLE
chore(ui): add giraffe and clockface sourcemaps to honeybadger config

### DIFF
--- a/ui/scripts/upload_sourcemap.sh
+++ b/ui/scripts/upload_sourcemap.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 
-FILE=`ls build/*.js.map | tail -n 1 | tr -d "\n"`
-MIN_FILE=`ls build/*.js | tail -n 1 | tr -d "\n"`
+INFLUX_MINIFIED_FILE=`ls build/*.js | tail -n 1 | tr -d "\n"`
+INFLUX_SOURCEMAP=`ls build/*.js.map | tail -n 1 | tr -d "\n"`
+
+CLOCKFACE_SOURCEMAP=node_modules/@influxdata/clockface/dist/index.js.map
+GIRAFFE_SOURCEMAP=node_modules/@influxdata/giraffe/dist/index.js.map
+
 GIT_SHA=$(git rev-parse HEAD)
 
 curl https://api.honeybadger.io/v1/source_maps \
   -F api_key=$HONEYBADGER_KEY \
   -F revision=$GIT_SHA \
   -F minified_url="*" \
-  -F source_map=@$FILE \
-  -F minified_file=@$MIN_FILE
+  -F minified_file=@$INFLUX_MINIFIED_FILE \
+  -F source_map=@$INFLUX_SOURCEMAP \
+  -F *=@$CLOCKFACE_SOURCEMAP \
+  -F *=@$GIRAFFE_SOURCEMAP


### PR DESCRIPTION
Closes #15402

[Honeybadger's Docs](https://app.honeybadger.io/projects/61122/sourcemaps#uploading-your-files) mention linking `<additional source files>` that are referenced from this sourcemap.

I ran this script locally at `10/16/2019 21:20:39 UTC` using the correct values, and [it seems to have worked correctly](https://app.honeybadger.io/projects/61122/source_map_uploads)

This PR hooks that up so that it's called on deploy.

**Note:** I never actually confirmed that this mapped errors correctly. More than happy to wait on deploying this until that confirmation.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
