### PR TITLE
feat: opentracing in query execution runtime

### DIFF
--- a/cmd/influxd/main.go
+++ b/cmd/influxd/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/influxdata/flux"
 	"github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/cmd/influxd/generate"
 	"github.com/influxdata/influxdb/cmd/influxd/inspect"
@@ -45,6 +46,11 @@ func init() {
 	rootCmd.AddCommand(launcher.NewCommand())
 	rootCmd.AddCommand(generate.Command)
 	rootCmd.AddCommand(inspect.NewCommand())
+
+	// TODO: this should be removed in the future: https://github.com/influxdata/influxdb/issues/16220
+	if os.Getenv("QUERY_TRACING") == "1" {
+		flux.EnableExperimentalTracing()
+	}
 }
 
 // find determines the default behavior when running influxd.


### PR DESCRIPTION
This pull request has another part in flux as https://github.com/influxdata/flux/pull/1992

We already have opentracing in influxdb but on a more coarse level. This pull request added more granular opentracing [spans](https://opentracing.io/docs/overview/spans/#what-is-a-span) into the query execution engine. Now, with opentracing enabled, you will be able to see the sources/transformations involved in queries and see how many of them / how much time do they take.

You can visualize the spans by using Jaeger. The following command starts a Jaeger instance using Docker:
```bash
docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
  -p 5775:5775/udp \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 14268:14268 \
  -p 9411:9411 \
  jaegertracing/all-in-one:latest
```
With that, run influxd using the following command:
```bash
JAEGER_SERVICE_NAME=influxd JAEGER_SAMPLER_PARAM=1.0 go run ./cmd/influxd --tracing-type jaeger --assets-path ui/build
```
Please note that for testing purposes, we configure it to report every instance by setting the environment variable “JAEGER_SAMPLER_PARAM=1.0”. By default, it will use a probabilistic sampler set to report every 1000th trace instance.

After you started influx OSS, you can run any query in the data explorer and query the captured spans using Jaeger by visiting http://localhost:16686.

Every source/transformation will create a span. In some extreme cases when the data has a tremendous amount of groups, any simple query could potentially generate a lot of spans. You can see it live by trying to run a simple query against the data our internal data generator generated:
```
import "internal/gen"
gen.tables(n: 1000, tags: [{name: "tag1", cardinality: 20}, {name: "tag2", cardinality: 100}])
    |> range(start: -1h)
    |> limit(n: 100)
    |> sort(columns: ["_stop"])
```
This query on my machine generated 6022 spans while only 32 spans were be generated before this change. However, no significant statistical difference is observed in terms of query execution time.
Five time measurements were taken before and after this opentracing change is introduced:

| Commit | 1 | 2 | 3 | 4 | 5 |
| --- | --- | --- | --- | --- | --- |
| master| 2.39s | 2.5s | 2.34s | 2.27s | 2.21s | 2.25s |
| current | 2.32s | 2.27s | 2.28s | 2.44s | 2.30s |

Recall that we got this result configuring the system to report every instance by setting the environment variable “JAEGER_SAMPLER_PARAM=1.0” in the test environment, I would be even less concerned about the performance impact because we can set this sampling rate to be significantly smaller in a production environment while the collected dats is still helpful for diagnosing performance issues.