### PR TITLE
refactor(ui): convert confirmation overlay to confirmation button

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -33,6 +33,50 @@ describe('DataExplorer', () => {
       })
     })
   })
+  
+  describe('editing mode switching', () => {
+    it('can switch to script editor mode', () => {
+      const toggle = cy.getByTestID('switch-to-script-editor')
+  
+      toggle.click()
+  
+      const fluxEditor = cy.getByTestID('flux-editor')
+  
+      fluxEditor.should('have.length', 1)
+    })
+
+    it('can revert back to query builder mode (without confirmation)', () => {
+      cy.getByTestID('switch-to-script-editor').click()
+
+      const toggle = cy.getByTestID('switch-to-query-builder')
+  
+      toggle.click()
+  
+      const builder = cy.getByTestID('query-builder')
+  
+      builder.should('have.length', 1)
+    })
+  
+    it('can revert back to query builder mode (with confirmation)', () => {
+      cy.getByTestID('switch-to-script-editor').click()
+
+      cy.getByTestID('flux-editor').within(() => {
+        cy.get('textarea').type('yoyoyoyoyo', {force: true})
+      })
+  
+      const toggle = cy.getByTestID('switch-query-builder-confirm--button')
+  
+      toggle.click()
+  
+      cy.getByTestID('switch-query-builder-confirm--popover--contents').within(() => {
+        cy.getByTestID('button').click()
+      })
+  
+      const builder = cy.getByTestID('query-builder')
+  
+      builder.should('have.length', 1)
+    })
+  })
 
   describe('raw script editing', () => {
     beforeEach(() => {

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -9,6 +9,7 @@ import {
   STRINGS_TITLE,
   STRINGS_TRIM,
 } from '../../src/shared/constants/fluxFunctions'
+import {CheckType} from '@influxdata/influx'
 
 interface HTMLElementCM extends HTMLElement {
   CodeMirror: {
@@ -35,38 +36,32 @@ describe('DataExplorer', () => {
   })
 
   describe('editing mode switching', () => {
-    it('can switch to script editor mode', () => {
-      const toggle = cy.getByTestID('switch-to-script-editor')
+    const measurement = 'my_meas'
+    const field = 'my_field'
 
-      toggle.click()
-
-      const fluxEditor = cy.getByTestID('flux-editor')
-
-      fluxEditor.should('have.length', 1)
+    beforeEach(() => {
+      cy.writeData([`${measurement} ${field}=0`, `${measurement} ${field}=1`])
     })
 
-    it('can revert back to query builder mode (without confirmation)', () => {
+    it('can switch to and from script editor mode', () => {
+      cy.getByTestID('selector-list my_meas').click()
+      cy.getByTestID('selector-list my_field').click()
+
       cy.getByTestID('switch-to-script-editor').click()
+      cy.getByTestID('flux-editor').should('exist')
 
-      const toggle = cy.getByTestID('switch-to-query-builder')
+      // revert back to query builder mode (without confirmation)
+      cy.getByTestID('switch-to-query-builder').click()
+      cy.getByTestID('query-builder').should('exist')
 
-      toggle.click()
-
-      const builder = cy.getByTestID('query-builder')
-
-      builder.should('have.length', 1)
-    })
-
-    it('can revert back to query builder mode (with confirmation)', () => {
+      // can revert back to query builder mode (with confirmation)
       cy.getByTestID('switch-to-script-editor').click()
-
+      cy.getByTestID('flux-editor').should('exist')
       cy.getByTestID('flux-editor').within(() => {
         cy.get('textarea').type('yoyoyoyoyo', {force: true})
       })
 
-      const toggle = cy.getByTestID('switch-query-builder-confirm--button')
-
-      toggle.click()
+      cy.getByTestID('switch-query-builder-confirm--button').click()
 
       cy.getByTestID('switch-query-builder-confirm--popover--contents').within(
         () => {
@@ -74,9 +69,7 @@ describe('DataExplorer', () => {
         }
       )
 
-      const builder = cy.getByTestID('query-builder')
-
-      builder.should('have.length', 1)
+      cy.getByTestID('query-builder').should('exist')
     })
   })
 

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -33,15 +33,15 @@ describe('DataExplorer', () => {
       })
     })
   })
-  
+
   describe('editing mode switching', () => {
     it('can switch to script editor mode', () => {
       const toggle = cy.getByTestID('switch-to-script-editor')
-  
+
       toggle.click()
-  
+
       const fluxEditor = cy.getByTestID('flux-editor')
-  
+
       fluxEditor.should('have.length', 1)
     })
 
@@ -49,31 +49,33 @@ describe('DataExplorer', () => {
       cy.getByTestID('switch-to-script-editor').click()
 
       const toggle = cy.getByTestID('switch-to-query-builder')
-  
+
       toggle.click()
-  
+
       const builder = cy.getByTestID('query-builder')
-  
+
       builder.should('have.length', 1)
     })
-  
+
     it('can revert back to query builder mode (with confirmation)', () => {
       cy.getByTestID('switch-to-script-editor').click()
 
       cy.getByTestID('flux-editor').within(() => {
         cy.get('textarea').type('yoyoyoyoyo', {force: true})
       })
-  
+
       const toggle = cy.getByTestID('switch-query-builder-confirm--button')
-  
+
       toggle.click()
-  
-      cy.getByTestID('switch-query-builder-confirm--popover--contents').within(() => {
-        cy.getByTestID('button').click()
-      })
-  
+
+      cy.getByTestID('switch-query-builder-confirm--popover--contents').within(
+        () => {
+          cy.getByTestID('button').click()
+        }
+      )
+
       const builder = cy.getByTestID('query-builder')
-  
+
       builder.should('have.length', 1)
     })
   })

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -9,7 +9,6 @@ import {
   STRINGS_TITLE,
   STRINGS_TRIM,
 } from '../../src/shared/constants/fluxFunctions'
-import {CheckType} from '@influxdata/influx'
 
 interface HTMLElementCM extends HTMLElement {
   CodeMirror: {

--- a/ui/src/timeMachine/components/QueriesSwitcher.scss
+++ b/ui/src/timeMachine/components/QueriesSwitcher.scss
@@ -3,9 +3,8 @@
    -----------------------------------------------------------------------------
 */
 
-.queries-switcher--warning {
-  font-size: 15px;
-  font-weight: 500;
-  color: $g13-mist;
-  margin: 0;
+// This is kinda hacky but works for now. Ideally there  weould an additional
+// className prop on ConfirmationButton that passes through to the popover
+span[data-testid="switch-query-builder-confirm--confirmation-label"] {
+  white-space: normal;
 }

--- a/ui/src/timeMachine/components/QueriesSwitcher.tsx
+++ b/ui/src/timeMachine/components/QueriesSwitcher.tsx
@@ -39,8 +39,28 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props> {
     const {onEditAsFlux, onEditWithBuilder} = this.props
     const {editMode, text, builderConfig} = this.props.activeQuery
 
+    let button = (
+      <Button
+        text="Script Editor"
+        titleText="Switch to Script Editor"
+        onClick={onEditAsFlux}
+        testID="switch-to-script-editor"
+      />
+    )
+    
+    if (editMode !== 'builder') {
+      button = (
+        <Button
+        text="Query Builder"
+        titleText="Switch to Query Builder"
+        onClick={onEditWithBuilder}
+        testID="switch-to-query-builder"
+        />
+      )
+    }
+
     if (editMode !== 'builder' && hasQueryBeenEdited(text, builderConfig)) {
-      return (
+      button = (
         <ConfirmationButton
           popoverColor={ComponentColor.Danger}
           popoverType={PopoverType.Outline}
@@ -55,25 +75,7 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props> {
       )
     }
 
-    if (editMode !== 'builder') {
-      return (
-        <Button
-          text="Query Builder"
-          titleText="Switch to Query Builder"
-          onClick={onEditWithBuilder}
-          testID="switch-to-query-builder"
-        />
-      )
-    }
-
-    return (
-      <Button
-        text="Script Editor"
-        titleText="Switch to Script Editor"
-        onClick={onEditAsFlux}
-        testID="switch-to-script-editor"
-      />
-    )
+    return button
   }
 }
 

--- a/ui/src/timeMachine/components/QueriesSwitcher.tsx
+++ b/ui/src/timeMachine/components/QueriesSwitcher.tsx
@@ -18,7 +18,10 @@ import {
 
 // Utils
 import {getActiveQuery} from 'src/timeMachine/selectors'
-import {hasQueryBeenEdited} from 'src/timeMachine/utils/queryBuilder'
+import {
+  confirmationState,
+  ConfirmationState,
+} from 'src/timeMachine/utils/queryBuilder'
 
 // Types
 import {AppState, DashboardQuery} from 'src/types'
@@ -38,6 +41,7 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props> {
   public render() {
     const {onEditAsFlux, onEditWithBuilder} = this.props
     const {editMode, text, builderConfig} = this.props.activeQuery
+    const scriptMode = editMode !== 'builder'
 
     let button = (
       <Button
@@ -47,19 +51,22 @@ class TimeMachineQueriesSwitcher extends PureComponent<Props> {
         testID="switch-to-script-editor"
       />
     )
-    
-    if (editMode !== 'builder') {
+
+    if (scriptMode) {
       button = (
         <Button
-        text="Query Builder"
-        titleText="Switch to Query Builder"
-        onClick={onEditWithBuilder}
-        testID="switch-to-query-builder"
+          text="Query Builder"
+          titleText="Switch to Query Builder"
+          onClick={onEditWithBuilder}
+          testID="switch-to-query-builder"
         />
       )
     }
 
-    if (editMode !== 'builder' && hasQueryBeenEdited(text, builderConfig)) {
+    if (
+      scriptMode &&
+      confirmationState(text, builderConfig) === ConfirmationState.Required
+    ) {
       button = (
         <ConfirmationButton
           popoverColor={ComponentColor.Danger}

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -12,9 +12,11 @@ import {BuilderTagsType} from '@influxdata/influx'
 
 export function isConfigValid(builderConfig: BuilderConfig): boolean {
   const {buckets, tags} = builderConfig
+
   const isConfigValid =
     buckets.length >= 1 &&
     tags.length >= 1 &&
+    tags[0].key !== undefined &&
     tags.some(({key, values}) => key && values.length > 0)
 
   return isConfigValid

--- a/ui/src/timeMachine/utils/queryBuilder.ts
+++ b/ui/src/timeMachine/utils/queryBuilder.ts
@@ -146,7 +146,11 @@ export function hasQueryBeenEdited(
   query: string,
   builderConfig: BuilderConfig
 ): boolean {
-  const emptyQueryChanged = !isConfigValid(builderConfig) && !isEmpty(query)
+  if (isEmpty(query)) {
+    return true
+  }
+
+  const emptyQueryChanged = !isConfigValid(builderConfig)
   const existingQueryChanged = query !== buildQuery(builderConfig)
 
   return emptyQueryChanged || existingQueryChanged


### PR DESCRIPTION
Closes #15488 

Replace the overlay confirmation interaction with a `ConfirmationButton`

![queries-switcher-confirmation](https://user-images.githubusercontent.com/2433762/67056224-fccb0100-f0ff-11e9-92cc-aa547ea745a9.gif)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
