### PR TITLE
refactor(ui): redesign all page headers to make use of PageSubTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [15313](https://github.com/influxdata/influxdb/pull/15313): Add shortcut for toggling comments in script editor
 
 ### UI Improvements
+1. [15503](https://github.com/influxdata/influxdb/pull/15503): Redesign page headers to be more space efficient
 1. [15426](https://github.com/influxdata/influxdb/pull/15426): Add 403 handler that redirects back to the sign-in page on oats-generated routes.
 
 ### Bug Fixes

--- a/ui/src/me/components/UserPageHeader.tsx
+++ b/ui/src/me/components/UserPageHeader.tsx
@@ -2,7 +2,13 @@
 import React, {PureComponent} from 'react'
 
 // Components
-import {Page} from '@influxdata/clockface'
+import {
+  Page,
+  FlexBox,
+  FlexDirection,
+  AlignItems,
+  ComponentSize,
+} from '@influxdata/clockface'
 
 // Constants
 import {generateRandomGreeting} from 'src/me/constants'
@@ -16,7 +22,15 @@ export default class UserPageHeader extends PureComponent<Props> {
   public render() {
     return (
       <Page.Header fullWidth={false}>
-        <Page.HeaderLeft>{this.title}</Page.HeaderLeft>
+        <Page.HeaderLeft>
+          <FlexBox
+            direction={FlexDirection.Column}
+            alignItems={AlignItems.FlexStart}
+            margin={ComponentSize.Small}
+          >
+            {this.title}
+          </FlexBox>
+        </Page.HeaderLeft>
         <Page.HeaderRight />
       </Page.Header>
     )
@@ -37,6 +51,11 @@ export default class UserPageHeader extends PureComponent<Props> {
 
     const altText = `That's how you say hello in ${language}`
 
-    return <Page.Title title={title} altText={altText} />
+    return (
+      <>
+        <Page.Title title={title} />
+        <Page.SubTitle title={altText} />
+      </>
+    )
   }
 }

--- a/ui/src/pageLayout/components/RenamablePageTitle.scss
+++ b/ui/src/pageLayout/components/RenamablePageTitle.scss
@@ -6,15 +6,14 @@
 $rename-dash-title-padding: 4px;
 
 .renamable-page-title {
-  height: $form-sm-height;
   width: 100%;
   min-width: 29vw;
   max-width: 42vw;
   display: flex;
+  margin-bottom: 4px !important;
 }
 
 .renamable-page-title--title,
-.renamable-page-title--input-prefix,
 .cf-input.renamable-page-title--input > input {
   font-size: $page-title-size;
   font-weight: $page-title-weight;
@@ -26,12 +25,11 @@ $rename-dash-title-padding: 4px;
 .renamable-page-title--input {
   position: relative;
   width: calc(100% + #{$rename-dash-title-padding}) !important;
-  left: -$rename-dash-title-padding;
+  left: -($rename-dash-title-padding + $ix-border);
 }
 
 .renamable-page-title--title {
   border-radius: $radius;
-  position: relative;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/ui/src/pageLayout/components/RenamablePageTitle.tsx
+++ b/ui/src/pageLayout/components/RenamablePageTitle.tsx
@@ -8,7 +8,15 @@ import React, {
 import classnames from 'classnames'
 
 // Components
-import {Input, PageTitle, Icon, IconFont} from '@influxdata/clockface'
+import {
+  Input,
+  Icon,
+  IconFont,
+  Page,
+  FlexBox,
+  FlexDirection,
+  AlignItems,
+} from '@influxdata/clockface'
 import {ClickOutside} from 'src/shared/components/ClickOutside'
 
 // Decorators
@@ -47,34 +55,37 @@ class RenamablePageTitle extends PureComponent<Props, State> {
     const {name, placeholder} = this.props
     const {isEditing} = this.state
 
+    let title = (
+      <div className={this.titleClassName} onClick={this.handleStartEditing}>
+        <Page.Title title={name || placeholder} />
+        <Icon glyph={IconFont.Pencil} />
+      </div>
+    )
+
     if (isEditing) {
-      return (
-        <div className="renamable-page-title">
-          {this.prefix}
-          <ClickOutside onClickOutside={this.handleStopEditing}>
-            {this.input}
-          </ClickOutside>
-        </div>
+      title = (
+        <ClickOutside onClickOutside={this.handleStopEditing}>
+          {this.input}
+        </ClickOutside>
       )
     }
 
     return (
-      <div className="renamable-page-title">
+      <FlexBox
+        direction={FlexDirection.Column}
+        alignItems={AlignItems.FlexStart}
+        className="renamable-page-title"
+      >
+        {title}
         {this.prefix}
-        <div className={this.titleClassName} onClick={this.handleStartEditing}>
-          <PageTitle title={name || placeholder} />
-          <Icon glyph={IconFont.Pencil} />
-        </div>
-      </div>
+      </FlexBox>
     )
   }
 
   private get prefix(): JSX.Element {
     const {prefix} = this.props
     if (prefix) {
-      return (
-        <div className="renamable-page-title--input-prefix">{`${prefix} /`}</div>
-      )
+      return <Page.SubTitle title={prefix} />
     }
   }
 

--- a/ui/src/shared/components/PageTitleWithOrg.tsx
+++ b/ui/src/shared/components/PageTitleWithOrg.tsx
@@ -3,7 +3,13 @@ import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 
 // Components
-import {Page} from '@influxdata/clockface'
+import {
+  Page,
+  FlexBox,
+  FlexDirection,
+  AlignItems,
+  ComponentSize,
+} from '@influxdata/clockface'
 
 // Types
 import {AppState} from 'src/types'
@@ -27,7 +33,16 @@ class PageTitleWithOrg extends PureComponent<Props> {
   render() {
     const {orgName, title, altText} = this.props
 
-    return <Page.Title title={`${orgName} / ${title}`} altText={altText} />
+    return (
+      <FlexBox
+        direction={FlexDirection.Column}
+        alignItems={AlignItems.FlexStart}
+        margin={ComponentSize.Small}
+      >
+        <Page.Title title={title} altText={altText} />
+        <Page.SubTitle title={orgName} />
+      </FlexBox>
+    )
   }
 }
 


### PR DESCRIPTION
Closes #15494 

![Screen Shot 2019-10-18 at 10 26 46 AM](https://user-images.githubusercontent.com/2433762/67114934-e40b2b80-f191-11e9-927e-411253380f41.png)
![Screen Shot 2019-10-18 at 10 26 55 AM](https://user-images.githubusercontent.com/2433762/67114939-e7061c00-f191-11e9-802d-b1821c20d716.png)

This PR aims to make the page headers more compact by splitting the text into 2 lines. On most pages the subtitle is the current org name, and on the home page there's an explainer line for the random language greeting.

This should help with real estate issues on dashboard headers (long org names + long dashboard names exacerbate the issue)

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
