### PR TITLE
fix(storage): simple8b passes checkptr

### DIFF
--- a/pkg/encoding/simple8b/encoding.go
+++ b/pkg/encoding/simple8b/encoding.go
@@ -468,6 +468,8 @@ func Decode(dst *[240]uint64, v uint64) (n int, err error) {
 
 // Decode writes the uncompressed values from src to dst.  It returns the number
 // of values written or an error.
+//go:nocheckptr
+// nocheckptr while the underlying struct layout doesn't change
 func DecodeAll(dst, src []uint64) (value int, err error) {
 	j := 0
 	for _, v := range src {
@@ -480,6 +482,8 @@ func DecodeAll(dst, src []uint64) (value int, err error) {
 
 // DecodeBytesBigEndian writes the compressed, big-endian values from src to dst.  It returns the number
 // of values written or an error.
+//go:nocheckptr
+// nocheckptr while the underlying struct layout doesn't change
 func DecodeBytesBigEndian(dst []uint64, src []byte) (value int, err error) {
 	if len(src)&7 != 0 {
 		return 0, errors.New("src length is not multiple of 8")

--- a/pkg/encoding/simple8b/encoding.go
+++ b/pkg/encoding/simple8b/encoding.go
@@ -541,6 +541,7 @@ func pack120(src []uint64) uint64 {
 
 // pack60 packs 60 values from in using 1 bit each
 func pack60(src []uint64) uint64 {
+	_ = src[59] // eliminate multiple bounds checks
 	return 2<<60 |
 		src[0] |
 		src[1]<<1 |
@@ -607,6 +608,7 @@ func pack60(src []uint64) uint64 {
 
 // pack30 packs 30 values from in using 2 bits each
 func pack30(src []uint64) uint64 {
+	_ = src[29] // eliminate multiple bounds checks
 	return 3<<60 |
 		src[0] |
 		src[1]<<2 |
@@ -642,6 +644,7 @@ func pack30(src []uint64) uint64 {
 
 // pack20 packs 20 values from in using 3 bits each
 func pack20(src []uint64) uint64 {
+	_ = src[19] // eliminate multiple bounds checks
 	return 4<<60 |
 		src[0] |
 		src[1]<<3 |
@@ -667,6 +670,7 @@ func pack20(src []uint64) uint64 {
 
 // pack15 packs 15 values from in using 3 bits each
 func pack15(src []uint64) uint64 {
+	_ = src[14] // eliminate multiple bounds checks
 	return 5<<60 |
 		src[0] |
 		src[1]<<4 |
@@ -687,6 +691,7 @@ func pack15(src []uint64) uint64 {
 
 // pack12 packs 12 values from in using 5 bits each
 func pack12(src []uint64) uint64 {
+	_ = src[11] // eliminate multiple bounds checks
 	return 6<<60 |
 		src[0] |
 		src[1]<<5 |
@@ -704,6 +709,7 @@ func pack12(src []uint64) uint64 {
 
 // pack10 packs 10 values from in using 6 bits each
 func pack10(src []uint64) uint64 {
+	_ = src[9] // eliminate multiple bounds checks
 	return 7<<60 |
 		src[0] |
 		src[1]<<6 |
@@ -719,6 +725,7 @@ func pack10(src []uint64) uint64 {
 
 // pack8 packs 8 values from in using 7 bits each
 func pack8(src []uint64) uint64 {
+	_ = src[7] // eliminate multiple bounds checks
 	return 8<<60 |
 		src[0] |
 		src[1]<<7 |
@@ -732,6 +739,7 @@ func pack8(src []uint64) uint64 {
 
 // pack7 packs 7 values from in using 8 bits each
 func pack7(src []uint64) uint64 {
+	_ = src[6] // eliminate multiple bounds checks
 	return 9<<60 |
 		src[0] |
 		src[1]<<8 |
@@ -744,6 +752,7 @@ func pack7(src []uint64) uint64 {
 
 // pack6 packs 6 values from in using 10 bits each
 func pack6(src []uint64) uint64 {
+	_ = src[5] // eliminate multiple bounds checks
 	return 10<<60 |
 		src[0] |
 		src[1]<<10 |
@@ -755,6 +764,7 @@ func pack6(src []uint64) uint64 {
 
 // pack5 packs 5 values from in using 12 bits each
 func pack5(src []uint64) uint64 {
+	_ = src[4] // eliminate multiple bounds checks
 	return 11<<60 |
 		src[0] |
 		src[1]<<12 |
@@ -765,6 +775,7 @@ func pack5(src []uint64) uint64 {
 
 // pack4 packs 4 values from in using 15 bits each
 func pack4(src []uint64) uint64 {
+	_ = src[3] // eliminate multiple bounds checks
 	return 12<<60 |
 		src[0] |
 		src[1]<<15 |
@@ -774,6 +785,7 @@ func pack4(src []uint64) uint64 {
 
 // pack3 packs 3 values from in using 20 bits each
 func pack3(src []uint64) uint64 {
+	_ = src[2] // eliminate multiple bounds checks
 	return 13<<60 |
 		src[0] |
 		src[1]<<20 |
@@ -782,6 +794,7 @@ func pack3(src []uint64) uint64 {
 
 // pack2 packs 2 values from in using 30 bits each
 func pack2(src []uint64) uint64 {
+	_ = src[1] // eliminate multiple bounds checks
 	return 14<<60 |
 		src[0] |
 		src[1]<<30

--- a/pkg/encoding/simple8b/encoding.go
+++ b/pkg/encoding/simple8b/encoding.go
@@ -520,8 +520,8 @@ func canPack(src []uint64, n, bits int) bool {
 
 	max := uint64((1 << uint64(bits)) - 1)
 
-	for i := 0; i < end; i++ {
-		if src[i] > max {
+	for _, s := range src[:n] {
+		if s > max {
 			return false
 		}
 	}
@@ -541,8 +541,8 @@ func pack120(src []uint64) uint64 {
 
 // pack60 packs 60 values from in using 1 bit each
 func pack60(src []uint64) uint64 {
-	_ = src[59] // eliminate multiple bounds checks
-	return 2<<60 |
+	return src[59]<<59 | // eliminate multiple bounds checks
+		2<<60 |
 		src[0] |
 		src[1]<<1 |
 		src[2]<<2 |
@@ -601,15 +601,13 @@ func pack60(src []uint64) uint64 {
 		src[55]<<55 |
 		src[56]<<56 |
 		src[57]<<57 |
-		src[58]<<58 |
-		src[59]<<59
-
+		src[58]<<58
 }
 
 // pack30 packs 30 values from in using 2 bits each
 func pack30(src []uint64) uint64 {
-	_ = src[29] // eliminate multiple bounds checks
-	return 3<<60 |
+	return src[29]<<58 | // eliminate multiple bounds checks
+		3<<60 |
 		src[0] |
 		src[1]<<2 |
 		src[2]<<4 |
@@ -638,14 +636,13 @@ func pack30(src []uint64) uint64 {
 		src[25]<<50 |
 		src[26]<<52 |
 		src[27]<<54 |
-		src[28]<<56 |
-		src[29]<<58
+		src[28]<<56
 }
 
 // pack20 packs 20 values from in using 3 bits each
 func pack20(src []uint64) uint64 {
-	_ = src[19] // eliminate multiple bounds checks
-	return 4<<60 |
+	return src[19]<<57 | // eliminate multiple bounds checks
+		4<<60 |
 		src[0] |
 		src[1]<<3 |
 		src[2]<<6 |
@@ -664,14 +661,13 @@ func pack20(src []uint64) uint64 {
 		src[15]<<45 |
 		src[16]<<48 |
 		src[17]<<51 |
-		src[18]<<54 |
-		src[19]<<57
+		src[18]<<54
 }
 
 // pack15 packs 15 values from in using 3 bits each
 func pack15(src []uint64) uint64 {
-	_ = src[14] // eliminate multiple bounds checks
-	return 5<<60 |
+	return src[14]<<56 | // eliminate multiple bounds checks
+		5<<60 |
 		src[0] |
 		src[1]<<4 |
 		src[2]<<8 |
@@ -685,14 +681,13 @@ func pack15(src []uint64) uint64 {
 		src[10]<<40 |
 		src[11]<<44 |
 		src[12]<<48 |
-		src[13]<<52 |
-		src[14]<<56
+		src[13]<<52
 }
 
 // pack12 packs 12 values from in using 5 bits each
 func pack12(src []uint64) uint64 {
-	_ = src[11] // eliminate multiple bounds checks
-	return 6<<60 |
+	return src[11]<<55 | // eliminate multiple bounds checks
+		6<<60 |
 		src[0] |
 		src[1]<<5 |
 		src[2]<<10 |
@@ -703,14 +698,13 @@ func pack12(src []uint64) uint64 {
 		src[7]<<35 |
 		src[8]<<40 |
 		src[9]<<45 |
-		src[10]<<50 |
-		src[11]<<55
+		src[10]<<50
 }
 
 // pack10 packs 10 values from in using 6 bits each
 func pack10(src []uint64) uint64 {
-	_ = src[9] // eliminate multiple bounds checks
-	return 7<<60 |
+	return src[9]<<54 |
+		7<<60 |
 		src[0] |
 		src[1]<<6 |
 		src[2]<<12 |
@@ -719,85 +713,77 @@ func pack10(src []uint64) uint64 {
 		src[5]<<30 |
 		src[6]<<36 |
 		src[7]<<42 |
-		src[8]<<48 |
-		src[9]<<54
+		src[8]<<48
 }
 
 // pack8 packs 8 values from in using 7 bits each
 func pack8(src []uint64) uint64 {
-	_ = src[7] // eliminate multiple bounds checks
-	return 8<<60 |
+	return src[7]<<49 |
+		8<<60 |
 		src[0] |
 		src[1]<<7 |
 		src[2]<<14 |
 		src[3]<<21 |
 		src[4]<<28 |
 		src[5]<<35 |
-		src[6]<<42 |
-		src[7]<<49
+		src[6]<<42
 }
 
 // pack7 packs 7 values from in using 8 bits each
 func pack7(src []uint64) uint64 {
-	_ = src[6] // eliminate multiple bounds checks
-	return 9<<60 |
+	return src[6]<<48 | // eliminate multiple bounds checks
+		9<<60 |
 		src[0] |
 		src[1]<<8 |
 		src[2]<<16 |
 		src[3]<<24 |
 		src[4]<<32 |
-		src[5]<<40 |
-		src[6]<<48
+		src[5]<<40
 }
 
 // pack6 packs 6 values from in using 10 bits each
 func pack6(src []uint64) uint64 {
-	_ = src[5] // eliminate multiple bounds checks
-	return 10<<60 |
+	return src[5]<<50 | // eliminate multiple bounds checks
+		10<<60 |
 		src[0] |
 		src[1]<<10 |
 		src[2]<<20 |
 		src[3]<<30 |
-		src[4]<<40 |
-		src[5]<<50
+		src[4]<<40
 }
 
 // pack5 packs 5 values from in using 12 bits each
 func pack5(src []uint64) uint64 {
-	_ = src[4] // eliminate multiple bounds checks
-	return 11<<60 |
+	return src[4]<<48 | // eliminate multiple bounds checks
+		11<<60 |
 		src[0] |
 		src[1]<<12 |
 		src[2]<<24 |
-		src[3]<<36 |
-		src[4]<<48
+		src[3]<<36
 }
 
 // pack4 packs 4 values from in using 15 bits each
 func pack4(src []uint64) uint64 {
-	_ = src[3] // eliminate multiple bounds checks
-	return 12<<60 |
+	return src[3]<<45 | // eliminate multiple bounds checks
+		12<<60 |
 		src[0] |
 		src[1]<<15 |
-		src[2]<<30 |
-		src[3]<<45
+		src[2]<<30
 }
 
 // pack3 packs 3 values from in using 20 bits each
 func pack3(src []uint64) uint64 {
-	_ = src[2] // eliminate multiple bounds checks
-	return 13<<60 |
+	return src[2]<<40 | // eliminate multiple bounds checks
+		13<<60 |
 		src[0] |
-		src[1]<<20 |
-		src[2]<<40
+		src[1]<<20
 }
 
 // pack2 packs 2 values from in using 30 bits each
 func pack2(src []uint64) uint64 {
-	_ = src[1] // eliminate multiple bounds checks
-	return 14<<60 |
-		src[0] |
-		src[1]<<30
+	return src[1]<<30 | // eliminate multiple bounds checks
+		14<<60 |
+		src[0]
 }
 
 // pack1 packs 1 values from in using 60 bits each

--- a/pkg/encoding/simple8b/encoding.go
+++ b/pkg/encoding/simple8b/encoding.go
@@ -507,11 +507,6 @@ func canPack(src []uint64, n, bits int) bool {
 		return false
 	}
 
-	end := len(src)
-	if n < end {
-		end = n
-	}
-
 	// Selector 0,1 are special and use 0 bits to encode runs of 1's
 	if bits == 0 {
 		for _, v := range src {
@@ -545,8 +540,8 @@ func pack120(src []uint64) uint64 {
 
 // pack60 packs 60 values from in using 1 bit each
 func pack60(src []uint64) uint64 {
-	return src[59]<<59 | // eliminate multiple bounds checks
-		2<<60 |
+	_ = src[59] // eliminate multiple bounds checks
+	return 2<<60 |
 		src[0] |
 		src[1]<<1 |
 		src[2]<<2 |
@@ -605,13 +600,15 @@ func pack60(src []uint64) uint64 {
 		src[55]<<55 |
 		src[56]<<56 |
 		src[57]<<57 |
-		src[58]<<58
+		src[58]<<58 |
+		src[59]<<59
+
 }
 
 // pack30 packs 30 values from in using 2 bits each
 func pack30(src []uint64) uint64 {
-	return src[29]<<58 | // eliminate multiple bounds checks
-		3<<60 |
+	_ = src[29] // eliminate multiple bounds checks
+	return 3<<60 |
 		src[0] |
 		src[1]<<2 |
 		src[2]<<4 |
@@ -640,13 +637,14 @@ func pack30(src []uint64) uint64 {
 		src[25]<<50 |
 		src[26]<<52 |
 		src[27]<<54 |
-		src[28]<<56
+		src[28]<<56 |
+		src[29]<<58
 }
 
 // pack20 packs 20 values from in using 3 bits each
 func pack20(src []uint64) uint64 {
-	return src[19]<<57 | // eliminate multiple bounds checks
-		4<<60 |
+	_ = src[19] // eliminate multiple bounds checks
+	return 4<<60 |
 		src[0] |
 		src[1]<<3 |
 		src[2]<<6 |
@@ -665,13 +663,14 @@ func pack20(src []uint64) uint64 {
 		src[15]<<45 |
 		src[16]<<48 |
 		src[17]<<51 |
-		src[18]<<54
+		src[18]<<54 |
+		src[19]<<57
 }
 
 // pack15 packs 15 values from in using 3 bits each
 func pack15(src []uint64) uint64 {
-	return src[14]<<56 | // eliminate multiple bounds checks
-		5<<60 |
+	_ = src[14] // eliminate multiple bounds checks
+	return 5<<60 |
 		src[0] |
 		src[1]<<4 |
 		src[2]<<8 |
@@ -685,13 +684,14 @@ func pack15(src []uint64) uint64 {
 		src[10]<<40 |
 		src[11]<<44 |
 		src[12]<<48 |
-		src[13]<<52
+		src[13]<<52 |
+		src[14]<<56
 }
 
 // pack12 packs 12 values from in using 5 bits each
 func pack12(src []uint64) uint64 {
-	return src[11]<<55 | // eliminate multiple bounds checks
-		6<<60 |
+	_ = src[11] // eliminate multiple bounds checks
+	return 6<<60 |
 		src[0] |
 		src[1]<<5 |
 		src[2]<<10 |
@@ -702,13 +702,14 @@ func pack12(src []uint64) uint64 {
 		src[7]<<35 |
 		src[8]<<40 |
 		src[9]<<45 |
-		src[10]<<50
+		src[10]<<50 |
+		src[11]<<55
 }
 
 // pack10 packs 10 values from in using 6 bits each
 func pack10(src []uint64) uint64 {
-	return src[9]<<54 |
-		7<<60 |
+	_ = src[9] // eliminate multiple bounds checks
+	return 7<<60 |
 		src[0] |
 		src[1]<<6 |
 		src[2]<<12 |
@@ -717,77 +718,85 @@ func pack10(src []uint64) uint64 {
 		src[5]<<30 |
 		src[6]<<36 |
 		src[7]<<42 |
-		src[8]<<48
+		src[8]<<48 |
+		src[9]<<54
 }
 
 // pack8 packs 8 values from in using 7 bits each
 func pack8(src []uint64) uint64 {
-	return src[7]<<49 |
-		8<<60 |
+	_ = src[7] // eliminate multiple bounds checks
+	return 8<<60 |
 		src[0] |
 		src[1]<<7 |
 		src[2]<<14 |
 		src[3]<<21 |
 		src[4]<<28 |
 		src[5]<<35 |
-		src[6]<<42
+		src[6]<<42 |
+		src[7]<<49
 }
 
 // pack7 packs 7 values from in using 8 bits each
 func pack7(src []uint64) uint64 {
-	return src[6]<<48 | // eliminate multiple bounds checks
-		9<<60 |
+	_ = src[6] // eliminate multiple bounds checks
+	return 9<<60 |
 		src[0] |
 		src[1]<<8 |
 		src[2]<<16 |
 		src[3]<<24 |
 		src[4]<<32 |
-		src[5]<<40
+		src[5]<<40 |
+		src[6]<<48
 }
 
 // pack6 packs 6 values from in using 10 bits each
 func pack6(src []uint64) uint64 {
-	return src[5]<<50 | // eliminate multiple bounds checks
-		10<<60 |
+	_ = src[5] // eliminate multiple bounds checks
+	return 10<<60 |
 		src[0] |
 		src[1]<<10 |
 		src[2]<<20 |
 		src[3]<<30 |
-		src[4]<<40
+		src[4]<<40 |
+		src[5]<<50
 }
 
 // pack5 packs 5 values from in using 12 bits each
 func pack5(src []uint64) uint64 {
-	return src[4]<<48 | // eliminate multiple bounds checks
-		11<<60 |
+	_ = src[4] // eliminate multiple bounds checks
+	return 11<<60 |
 		src[0] |
 		src[1]<<12 |
 		src[2]<<24 |
-		src[3]<<36
+		src[3]<<36 |
+		src[4]<<48
 }
 
 // pack4 packs 4 values from in using 15 bits each
 func pack4(src []uint64) uint64 {
-	return src[3]<<45 | // eliminate multiple bounds checks
-		12<<60 |
+	_ = src[3] // eliminate multiple bounds checks
+	return 12<<60 |
 		src[0] |
 		src[1]<<15 |
-		src[2]<<30
+		src[2]<<30 |
+		src[3]<<45
 }
 
 // pack3 packs 3 values from in using 20 bits each
 func pack3(src []uint64) uint64 {
-	return src[2]<<40 | // eliminate multiple bounds checks
-		13<<60 |
+	_ = src[2] // eliminate multiple bounds checks
+	return 13<<60 |
 		src[0] |
-		src[1]<<20
+		src[1]<<20 |
+		src[2]<<40
 }
 
 // pack2 packs 2 values from in using 30 bits each
 func pack2(src []uint64) uint64 {
-	return src[1]<<30 | // eliminate multiple bounds checks
-		14<<60 |
-		src[0]
+	_ = src[1] // eliminate multiple bounds checks
+	return 14<<60 |
+		src[0] |
+		src[1]<<30
 }
 
 // pack1 packs 1 values from in using 60 bits each


### PR DESCRIPTION
Using `unsafe.Pointer` to convert a slice to array pointer fails `checkptr`. This adds slice versions of array functions used by batch decoding.

Fixes #15509