### PR TITLE
feat: add full compaction semaphore abstraction

### DIFF
--- a/semaphore.go
+++ b/semaphore.go
@@ -1,0 +1,58 @@
+package influxdb
+
+import (
+	"context"
+	"time"
+)
+
+// DefaultLeaseTTL is used when a specific lease TTL is not requested.
+const DefaultLeaseTTL = time.Minute
+
+// A Semaphore provides an API for requesting ownership of an expirable semaphore.
+//
+// Acquired semaphores have an expiration period. If they're not released or extended
+// during this period then they will expire and ownership of the semaphore will
+// be lost.
+type Semaphore interface {
+	// TODO(edd): add Acquire and AcquireTTL when needed. These should block.
+
+	// TryAcquire attempts to acquire ownership of the semaphore. TryAcquire
+	// must not block. Failure to get ownership of the semaphore should be
+	// signalled to the caller via the return of a nil Lease.
+	TryAcquire(context.Context) (Lease, error)
+
+	// TryAcquireTTL is similar to TryAcquire, but a specific TTL is provided.
+	TryAcquireTTL(ctx context.Context, ttl time.Duration) (Lease, error)
+}
+
+// A Lease represents ownership over a semaphore. It gives the owner the ability
+// to extend ownership over the semaphore or release ownership of the semaphore.
+type Lease interface {
+	// TTL returns the duration of time remaining before the lease expires.
+	TTL(context.Context) (time.Duration, error)
+
+	// Release terminates ownership of the semaphore by revoking the lease.
+	Release(context.Context) error
+
+	// KeepAlive extends the lease back to the original TTL.
+	KeepAlive(context.Context) error
+}
+
+// NopSemaphore is a Semaphore that always hands out leases.
+var NopSemaphore Semaphore = nopSemaphore{}
+
+type nopSemaphore struct{}
+
+func (nopSemaphore) TryAcquire(context.Context) (Lease, error) {
+	return nopLease{}, nil
+}
+
+func (nopSemaphore) TryAcquireTTL(ctx context.Context, ttl time.Duration) (Lease, error) {
+	return nopLease{}, nil
+}
+
+type nopLease struct{}
+
+func (nopLease) TTL(context.Context) (time.Duration, error) { return DefaultLeaseTTL, nil }
+func (nopLease) Release(context.Context) error              { return nil }
+func (nopLease) KeepAlive(context.Context) error            { return nil }

--- a/storage/engine.go
+++ b/storage/engine.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/influxdata/influxdb"
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/kit/tracing"
 	"github.com/influxdata/influxdb/logger"
@@ -138,6 +139,14 @@ func WithCompactionPlanner(planner tsm1.CompactionPlanner) Option {
 func WithCompactionLimiter(limiter limiter.Fixed) Option {
 	return func(e *Engine) {
 		e.engine.WithCompactionLimiter(limiter)
+	}
+}
+
+// WithCompactionSemaphore sets the semaphore used to coordinate full compactions
+// across multiple storage engines.
+func WithCompactionSemaphore(s influxdb.Semaphore) Option {
+	return func(e *Engine) {
+		e.engine.SetSemaphore(s)
 	}
 }
 


### PR DESCRIPTION
This feature adds the concept of a semaphore to the `tsm1.Engine`, which can be used to limit full compactions. By default this feature is disabled; the full compaction behaviour does
not change. 

When this feature is enabled, compactions can be limited across multiple storage engines running in multiple processes through an implementation of an `influxdb.Semaphore`.

Currently the `Semaphore` interface defines non-blocking acquisition methods as that's what's used in the `tsm1.Engine`. We could extend the interface in the future to add blocking methods.