### PR TITLE
build(webpack): remove eslint from ForkTsChecker plugin

### DIFF
--- a/ui/cypress/e2e/labels.test.ts
+++ b/ui/cypress/e2e/labels.test.ts
@@ -260,30 +260,43 @@ describe('labels', () => {
       .should('contain', hex2BgColor(newLabelColor))
   })
 
-  it.only('can delete a label', () => {
+  describe('label destruction', () => {
     const labelName = 'Modus (目录)'
     const labelDescription =
       '(\u03945) Per modum intelligo substantiae affectiones sive id quod in alio est, per quod etiam concipitur.'
     const labelColor = '#88AACC'
 
-    // Create labels
-    cy.get('@org').then(({id}: Organization) => {
-      cy.createLabel(labelName, id, {
-        description: labelDescription,
-        color: labelColor,
+    beforeEach(() => {
+      // Create labels
+      cy.get('@org').then(({id}: Organization) => {
+        cy.createLabel(labelName, id, {
+          description: labelDescription,
+          color: labelColor,
+        })
+        cy.createLabel(labelName, id, {
+          description: labelDescription,
+          color: '#CCAA88',
+        })
       })
     })
 
-    cy.getByTestID('label-card').should('have.length', 1)
+    it('can delete a label', () => {
+      cy.server()
+      cy.route('DELETE', 'api/v2/labels/*').as('deleteLabels')
 
-    cy.getByTestID('context-delete-menu')
-      .eq(0)
-      .click({force: true})
-    cy.getByTestID('context-delete-label')
-      .eq(0)
-      .click({force: true})
+      cy.getByTestID('label-card').should('have.length', 2)
 
-    cy.getByTestID('empty-state').should('exist', 1)
+      cy.getByTestID('context-delete-menu')
+        .eq(0)
+        .click({force: true})
+      cy.getByTestID('context-delete-label')
+        .eq(0)
+        .click({force: true})
+
+      cy.wait('@deleteLabels')
+
+      cy.getByTestID('label-card').should('have.length', 1)
+    })
   })
 
   it('can sort labels by name', () => {

--- a/ui/webpack.dev.ts
+++ b/ui/webpack.dev.ts
@@ -43,8 +43,6 @@ module.exports = merge(common, {
       context: path.join(__dirname, 'build'),
       manifest: require('./build/vendor-manifest.json'),
     }),
-    new ForkTsCheckerWebpackPlugin({
-      eslint: true,
-    }),
+    new ForkTsCheckerWebpackPlugin(),
   ],
 })


### PR DESCRIPTION
Currently the parsing for this is so slow as to make it useless.  Will re-enable when parsing speed is improved. 


