### PR TITLE
Update flux version to v0.50.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,25 @@
 
 
 [[projects]]
+  digest = "1:d34e87d0b266bdfed3a3fc12e7cadf3c952abd1f6a68063ab0109a81e13ba105"
+  name = "cloud.google.com/go"
+  packages = [
+    ".",
+    "bigtable",
+    "bigtable/internal/option",
+    "compute/metadata",
+    "iam",
+    "internal/optional",
+    "internal/trace",
+    "internal/version",
+    "longrunning",
+    "longrunning/autogen",
+  ]
+  pruneopts = "UT"
+  revision = "cfe8f6d1fe6976d03af790d7a8b9bf6aa73287bd"
+  version = "v0.47.0"
+
+[[projects]]
   digest = "1:188f74d743ff5e941788eceec4546703f31cde64d7da744137ad361c875c8609"
   name = "collectd.org"
   packages = [
@@ -49,19 +68,21 @@
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
-  digest = "1:8351fe2c28d2476ebfb708202bbf746246264d23c492c9bbb4bb3f579ad04477"
+  digest = "1:ad32f3393e411bb3106c0889cc04bbf93c15ab9d46bde5b8c57f991af5cd8b1f"
   name = "github.com/apache/arrow"
   packages = [
     "go/arrow",
     "go/arrow/array",
-    "go/arrow/internal/bitutil",
+    "go/arrow/bitutil",
+    "go/arrow/decimal128",
+    "go/arrow/float16",
     "go/arrow/internal/cpu",
     "go/arrow/internal/debug",
     "go/arrow/math",
     "go/arrow/memory",
   ]
   pruneopts = "UT"
-  revision = "338c62a2a20574072fde5c478fcd42bf27a2d4b6"
+  revision = "af6fa24be0dbbc021e0844c63d1c0b89fb23a95c"
 
 [[projects]]
   branch = "master"
@@ -73,6 +94,52 @@
   ]
   pruneopts = "UT"
   revision = "941dea75d3ebfbdd905a5d8b7b232965c5e5c684"
+
+[[projects]]
+  digest = "1:a6c4a954500ceea17deffb8eb89778fcdaa8bbf42c56b613056c5ae1527d3400"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
+    "internal/sdkio",
+    "internal/sdkmath",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/json/jsonutil",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/sts",
+    "service/sts/stsiface",
+  ]
+  pruneopts = "UT"
+  revision = "4b77f7c2f7303e8c757947ae8aff6a33dce7b8d1"
+  version = "v1.25.16"
 
 [[projects]]
   branch = "master"
@@ -163,6 +230,17 @@
   revision = "3522498ce2c8ea06df73e55df58edfbfb33cfdd6"
 
 [[projects]]
+  digest = "1:bb89a2542933056fcebc2950bb15ec636e623cc43c96597288aa2009f15b0ce1"
+  name = "github.com/eclipse/paho.mqtt.golang"
+  packages = [
+    ".",
+    "packets",
+  ]
+  pruneopts = "UT"
+  revision = "adca289fdcf8c883800aafa545bc263452290bae"
+  version = "v1.2.0"
+
+[[projects]]
   digest = "1:938a2672d6ebbb7f7bc63eee3e4b9464c16ffcf77ec8913d3edbf32b4e3984dd"
   name = "github.com/fatih/color"
   packages = ["."]
@@ -201,14 +279,30 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
+  branch = "master"
+  digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = "UT"
+  revision = "404acd9df4cc9859d64fb9eed42e5c026187287a"
+
+[[projects]]
+  digest = "1:d367a929240dc4e604bc92a004bfffc27d0cc7add0a08cb5417fea1a5398e542"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
+    "protoc-gen-go",
+    "protoc-gen-go/descriptor",
+    "protoc-gen-go/generator",
+    "protoc-gen-go/generator/internal/remap",
+    "protoc-gen-go/grpc",
+    "protoc-gen-go/plugin",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
+    "ptypes/empty",
     "ptypes/timestamp",
+    "ptypes/wrappers",
   ]
   pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
@@ -252,6 +346,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:766102087520f9d54f2acc72bd6637045900ac735b4a419b128d216f0c5c4876"
+  name = "github.com/googleapis/gax-go"
+  packages = ["v2"]
+  pruneopts = "UT"
+  revision = "bd5b16380fd03dc758d11cef74ba2e3bc8b0e8c2"
+  version = "v2.0.5"
+
+[[projects]]
   digest = "1:1df974d36df3c0e8babb751568bbd050954180ed40fc3e3f304222e2d9c7c932"
   name = "github.com/goreleaser/archive"
   packages = [
@@ -264,7 +366,7 @@
   version = "v1.1.3"
 
 [[projects]]
-  digest = "1:a1e6199307074510caebf310d3264fd52acfb7536fd858e86c914f49588dee1d"
+  digest = "1:26092d01829094cf1d7ef5a2621ae6e6a26090661d6f43e885eb35a901e37104"
   name = "github.com/goreleaser/goreleaser"
   packages = [
     ".",
@@ -278,7 +380,9 @@
     "internal/deprecate",
     "internal/filenametemplate",
     "internal/git",
+    "internal/http",
     "internal/linux",
+    "internal/nametemplate",
     "pipeline",
     "pipeline/archive",
     "pipeline/artifactory",
@@ -296,18 +400,20 @@
     "pipeline/git",
     "pipeline/nfpm",
     "pipeline/project",
+    "pipeline/put",
     "pipeline/release",
+    "pipeline/s3",
     "pipeline/scoop",
     "pipeline/sign",
     "pipeline/snapcraft",
     "pipeline/snapshot",
   ]
   pruneopts = "UT"
-  revision = "ad118b0f7c64c46265a3a05737c3e0d4d6d1c2be"
-  version = "v0.72.0"
+  revision = "8f675d8d9134457e6713df1ec2b63e86a0849080"
+  version = "v0.79.2"
 
 [[projects]]
-  digest = "1:668fc13808c0d4d850ae04cc58709c9c8025e81d08866d4fb0656cc12aeebfbc"
+  digest = "1:93922bf41c9d8fc6e5020cfd1e3d7259905b9b4d2d5effdc1a90d1da30428596"
   name = "github.com/goreleaser/nfpm"
   packages = [
     ".",
@@ -316,8 +422,8 @@
     "rpm",
   ]
   pruneopts = "UT"
-  revision = "8faa8e2e621115b3b560688a72d9c37bff4acb9f"
-  version = "v0.8.2"
+  revision = "11452f4e2a77580f157cc3df3f4e33b30a088062"
+  version = "v0.9.7"
 
 [[projects]]
   digest = "1:8eb1de8112c9924d59bf1d3e5c26f5eaa2bfc2a5fcbb92dc1c2e4546d695f277"
@@ -328,7 +434,15 @@
   version = "v0.3.6"
 
 [[projects]]
-  digest = "1:4ba702fa43214aa9a7289b675d12ca090bf460dbc6423162d367c7c22500f63a"
+  branch = "dep"
+  digest = "1:da8d5c481a1be9acb0e4ff42e03b125e875985456abd5bc25dcf2c0d624a3d9e"
+  name = "github.com/influxdata/changelog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d2664f8a12e3964090409ac8456763c798055df0"
+
+[[projects]]
+  digest = "1:8d9d8099283966ebbb234511d5c3461e040e345effa57e5daea7733ad2eef386"
   name = "github.com/influxdata/flux"
   packages = [
     ".",
@@ -337,9 +451,17 @@
     "codes",
     "compiler",
     "csv",
+    "dependencies/dependenciestest",
+    "dependencies/filesystem",
+    "dependencies/secret",
+    "dependencies/url",
     "execute",
+    "execute/executetest",
     "influxql",
     "internal/errors",
+    "internal/gen",
+    "internal/moving_average",
+    "internal/mutable",
     "internal/parser",
     "internal/pkg/syncutil",
     "internal/scanner",
@@ -359,30 +481,46 @@
     "semantic/semantictest",
     "stdlib",
     "stdlib/csv",
+    "stdlib/date",
+    "stdlib/experimental",
+    "stdlib/experimental/bigtable",
+    "stdlib/experimental/mqtt",
+    "stdlib/experimental/prometheus",
     "stdlib/generate",
     "stdlib/http",
     "stdlib/influxdata/influxdb",
+    "stdlib/influxdata/influxdb/monitor",
+    "stdlib/influxdata/influxdb/secrets",
     "stdlib/influxdata/influxdb/v1",
-    "stdlib/influxdata/influxdb/v1/fluxtests",
+    "stdlib/internal/gen",
+    "stdlib/internal/promql",
+    "stdlib/json",
     "stdlib/kafka",
     "stdlib/math",
-    "stdlib/pandas_tests/testdata",
+    "stdlib/pagerduty",
+    "stdlib/planner",
     "stdlib/regexp",
+    "stdlib/runtime",
+    "stdlib/slack",
     "stdlib/socket",
     "stdlib/sql",
     "stdlib/strings",
-    "stdlib/strings/testdata",
     "stdlib/system",
     "stdlib/testing",
     "stdlib/testing/chronograf",
-    "stdlib/testing/testdata",
+    "stdlib/testing/kapacitor",
+    "stdlib/testing/pandas",
+    "stdlib/testing/promql",
+    "stdlib/testing/usage",
     "stdlib/universe",
+    "stdlib/universe/holt_winters",
     "values",
     "values/objects",
+    "values/valuestest",
   ]
   pruneopts = "UT"
-  revision = "b25312b5fc12e5709f8d31e9ad9dca75a8acf56b"
-  version = "v0.36.2"
+  revision = "3e810ff48d3c670ab9b09fe7cfab3778efb9cb60"
+  version = "v0.50.2"
 
 [[projects]]
   digest = "1:a56e8bb5d96771d927b51963554589937d280877671482b45529e14c3e45f39b"
@@ -426,6 +564,33 @@
   packages = ["v1"]
   pruneopts = "UT"
   revision = "6d3895376368aa52a3a81d2a16e90f0f52371967"
+
+[[projects]]
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2b33e84"
+
+[[projects]]
+  digest = "1:076c531484852c227471112d49465873aaad47e5ad6e1aec3a5b092a436117ef"
+  name = "github.com/jstemmer/go-junit-report"
+  packages = [
+    ".",
+    "formatter",
+    "parser",
+  ]
+  pruneopts = "UT"
+  revision = "cc1f095d5cc5eca2844f5c5ea7bb37f6b9bf6cac"
+  version = "v0.9.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:9caa5da349b4f7e8b0c9bfeb784ba90fe63b5520f763fc5835a4c6aec25e0708"
+  name = "github.com/jsternberg/markdownfmt"
+  packages = ["markdown"]
+  pruneopts = "UT"
+  revision = "c2a5702991e37f837f84104a79fa48fd215d0458"
 
 [[projects]]
   digest = "1:78867fbb25230fd7dacdc62eab84f78593d74adee03ce974038cfd8299615167"
@@ -691,6 +856,22 @@
   version = "v0.2.2"
 
 [[projects]]
+  branch = "master"
+  digest = "1:059f0b8049ca1133b0f441ef9c998151e0b9a144cee1d7a844cfd7913476df71"
+  name = "github.com/shurcooL/go"
+  packages = ["indentwriter"]
+  pruneopts = "UT"
+  revision = "7189cc372560f641a5c041d2b199d9b0a41293c4"
+
+[[projects]]
+  digest = "1:9421f6e9e28ef86933e824b5caff441366f2b69bb281085b9dca40e1f27a1602"
+  name = "github.com/shurcooL/sanitized_anchor_name"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7bfe4c7ecddb3666a94b053b422cdd8f5aaa3615"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
   name = "github.com/spf13/cast"
   packages = ["."]
@@ -723,6 +904,32 @@
   revision = "d6fb6747feb6e7cfdc44682a024bddf87ef07ec2"
 
 [[projects]]
+  digest = "1:07ca513e3b295b9aeb1f0f6fbefb8102139a2764ce0f28d02040c0eb2dc276dd"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "plugin/ocgrpc",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+    "trace/tracestate",
+  ]
+  pruneopts = "UT"
+  revision = "59d1ce35d30f3c25ba762169da2a37eab6ffa041"
+  version = "v0.22.1"
+
+[[projects]]
   digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"
   name = "go.uber.org/atomic"
   packages = ["."]
@@ -739,7 +946,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:6547e315913965ebfc497191bee6b85d8b168f8d98150a77a6be526dc905973a"
+  digest = "1:e5ce08cf673db51eb256b85abf819826280237fd168362c46a7acf4ec6b9079e"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -747,7 +954,9 @@
     "internal/bufferpool",
     "internal/color",
     "internal/exit",
+    "internal/ztest",
     "zapcore",
+    "zaptest",
     "zaptest/observer",
   ]
   pruneopts = "UT"
@@ -768,7 +977,29 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3678c5905f4223908ae7f0e09d7be17393a38ace3daaa5ece320e55b9b42314a"
+  digest = "1:b1444bc98b5838c3116ed23e231fee4fa8509f975abd96e5d9e67e572dd01604"
+  name = "golang.org/x/exp"
+  packages = [
+    "apidiff",
+    "cmd/apidiff",
+  ]
+  pruneopts = "UT"
+  revision = "69215a2ee97e88b0d79235b7aae60dc2bfa3d034"
+
+[[projects]]
+  branch = "master"
+  digest = "1:21d7bad9b7da270fd2d50aba8971a041bd691165c95096a2a4c68db823cbc86a"
+  name = "golang.org/x/lint"
+  packages = [
+    ".",
+    "golint",
+  ]
+  pruneopts = "UT"
+  revision = "16217165b5de779cb6a5e4fc81fa9c1166fda457"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c2b57e5f2fc07090736110f3e6a09a034fc8c38dc94e796346efc461c65ff1bb"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -777,19 +1008,25 @@
     "http2",
     "http2/hpack",
     "idna",
+    "internal/socks",
     "internal/timeseries",
+    "proxy",
     "trace",
+    "websocket",
   ]
   pruneopts = "UT"
   revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
 
 [[projects]]
   branch = "master"
-  digest = "1:28b360454e161aae382c007449bcb1296087b5b52b4f37623bba0f9f9d7207f4"
+  digest = "1:39273b3e6c96fed52bd8f7793fc463c40b1a27a7caa51302b81d45306b9646b4"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
+    "google",
     "internal",
+    "jws",
+    "jwt",
   ]
   pruneopts = "UT"
   revision = "c57b0facaced709681d9f90397429b9430a74754"
@@ -852,29 +1089,74 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ef14d82562109d84ffea95e11945c59bb5547e0ef8e4933fac5e3ac6be3a662e"
+  digest = "1:931aa0b139954c9a6a7ba33b5fbecf603367fcc34e361b5ff1ac924a9e349cdd"
   name = "golang.org/x/tools"
   packages = [
+    "cmd/goimports",
     "go/ast/astutil",
     "go/buildutil",
+    "go/gcexportdata",
     "go/internal/cgo",
+    "go/internal/gcimporter",
     "go/loader",
+    "go/packages",
     "go/types/typeutil",
+    "imports",
+    "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/semver",
   ]
   pruneopts = "UT"
   revision = "45ff765b4815d34d8b80220fd05c79063b185ce1"
 
 [[projects]]
-  digest = "1:4b8f3d164fcba1aed1e5ec63edb518b7d436b001f01e06c7f9c2335498b4c5a3"
+  digest = "1:ec4585a778175a5f5edb48fccc4d72878089bbedc42a10b24125c8662e1a705c"
+  name = "gonum.org/v1/gonum"
+  packages = [
+    "floats",
+    "internal/asm/f64",
+  ]
+  pruneopts = "UT"
+  revision = "b72f7aa23a47a7d95df7d3d5248af26c33327925"
+  version = "v0.6.0"
+
+[[projects]]
+  digest = "1:7bfa0df4a2c105f94ed3f54934339bee4e7a5324e8ca7f0d36d09b9f480c835c"
+  name = "google.golang.org/api"
+  packages = [
+    "cloudresourcemanager/v1",
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "googleapi/transport",
+    "internal",
+    "iterator",
+    "option",
+    "transport",
+    "transport/grpc",
+    "transport/http",
+    "transport/http/internal/propagation",
+  ]
+  pruneopts = "UT"
+  revision = "721295fe20d585ce7e948146f82188429d14da33"
+  version = "v0.5.0"
+
+[[projects]]
+  digest = "1:d2cfb607095cee410f25a3c04eed77f76c4721d1bb0cbc894f5d8624b33394c8"
   name = "google.golang.org/appengine"
   packages = [
+    ".",
     "cloudsql",
     "internal",
+    "internal/app_identity",
     "internal/base",
     "internal/datastore",
     "internal/log",
+    "internal/modules",
     "internal/remote_api",
+    "internal/socket",
     "internal/urlfetch",
+    "socket",
     "urlfetch",
   ]
   pruneopts = "UT"
@@ -883,14 +1165,23 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:601e63e7d4577f907118bec825902505291918859d223bce015539e79f1160e3"
+  digest = "1:2e135b48501fca74c106a1662d12c407dbdb3e24c4bfd925f91732957d946e3b"
   name = "google.golang.org/genproto"
-  packages = ["googleapis/rpc/status"]
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/bigtable/admin/v2",
+    "googleapis/bigtable/v2",
+    "googleapis/iam/v1",
+    "googleapis/longrunning",
+    "googleapis/rpc/code",
+    "googleapis/rpc/status",
+    "protobuf/field_mask",
+  ]
   pruneopts = "UT"
   revision = "fedd2861243fd1a8152376292b921b394c7bef7e"
 
 [[projects]]
-  digest = "1:2dab32a43451e320e49608ff4542fdfc653c95dcc35d0065ec9c6c3dd540ed74"
+  digest = "1:686525281321f81747cfb0bba0bc384511bbdc5cdc92a6aa1afe5f1808f82c36"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -900,6 +1191,7 @@
     "codes",
     "connectivity",
     "credentials",
+    "credentials/oauth",
     "encoding",
     "encoding/proto",
     "grpclog",
@@ -922,6 +1214,14 @@
   pruneopts = "UT"
   revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
   version = "v1.13.0"
+
+[[projects]]
+  digest = "1:2ee0f15eb0fb04f918db7c2dcf39745f40d69f798ef171610a730e8a56aaa4fd"
+  name = "gopkg.in/russross/blackfriday.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d3b5b032dc8e8927d31a5071b56e14c89f045135"
+  version = "v2.0.1"
 
 [[projects]]
   branch = "v2"
@@ -976,8 +1276,11 @@
     "github.com/influxdata/flux",
     "github.com/influxdata/flux/arrow",
     "github.com/influxdata/flux/ast",
+    "github.com/influxdata/flux/codes",
     "github.com/influxdata/flux/csv",
     "github.com/influxdata/flux/execute",
+    "github.com/influxdata/flux/execute/executetest",
+    "github.com/influxdata/flux/interpreter",
     "github.com/influxdata/flux/lang",
     "github.com/influxdata/flux/memory",
     "github.com/influxdata/flux/mock",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,11 +72,11 @@
 
 [[constraint]]
   name = "github.com/influxdata/flux"
-  version = "~ 0.36.2"
+  version = "~ 0.50.0"
 
 [[constraint]]
   name = "github.com/apache/arrow"
-  revision = "338c62a2a20574072fde5c478fcd42bf27a2d4b6"
+  revision = "af6fa24be0dbbc021e0844c63d1c0b89fb23a95c"
 
 [[constraint]]
   name = "github.com/influxdata/influxql"

--- a/cmd/influx/cli/flux.go
+++ b/cmd/influx/cli/flux.go
@@ -22,7 +22,7 @@ type replQuerier struct {
 	client fluxClient
 }
 
-func (q *replQuerier) Query(ctx context.Context, compiler flux.Compiler) (flux.ResultIterator, error) {
+func (q *replQuerier) Query(ctx context.Context, deps flux.Dependencies, compiler flux.Compiler) (flux.ResultIterator, error) {
 	req := &client.ProxyRequest{
 		Compiler: compiler,
 		Dialect:  csv.DefaultDialect(),
@@ -37,5 +37,5 @@ func getFluxREPL(host string, port int, ssl bool, username, password string) (*r
 	}
 	c.Username = username
 	c.Password = password
-	return repl.New(&replQuerier{client: c}), nil
+	return repl.New(context.Background(), flux.NewDefaultDependencies(), &replQuerier{client: c}), nil
 }

--- a/flux/control/controller.go
+++ b/flux/control/controller.go
@@ -4,13 +4,11 @@ import (
 	"context"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/influxdb/coordinator"
 	_ "github.com/influxdata/influxdb/flux/builtin"
 	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
-	v1 "github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -19,53 +17,33 @@ type MetaClient = coordinator.MetaClient
 type Authorizer = influxdb.Authorizer
 
 func NewController(mc MetaClient, reader influxdb.Reader, auth Authorizer, authEnabled bool, logger *zap.Logger) *Controller {
-
-	executorDependencies := make(execute.Dependencies)
-
-	if err := influxdb.InjectFromDependencies(executorDependencies, influxdb.Dependencies{
-		Reader:      reader,
-		MetaClient:  mc,
-		Authorizer:  auth,
-		AuthEnabled: authEnabled,
-	}); err != nil {
-		panic(err)
-	}
-
-	if err := v1.InjectDatabaseDependencies(executorDependencies, v1.DatabaseDependencies{
-		MetaClient:  mc,
-		Authorizer:  auth,
-		AuthEnabled: authEnabled,
-	}); err != nil {
-		panic(err)
-	}
-
-	if err := influxdb.InjectBucketDependencies(executorDependencies, influxdb.BucketDependencies{
-		MetaClient:  mc,
-		Authorizer:  auth,
-		AuthEnabled: authEnabled,
-	}); err != nil {
+	storageDeps, err := influxdb.NewDependencies(mc, reader, auth, authEnabled)
+	if err != nil {
 		panic(err)
 	}
 
 	return &Controller{
-		deps:   executorDependencies,
+		deps:   []flux.Dependency{storageDeps},
 		logger: logger,
 	}
 }
 
 type Controller struct {
-	deps   execute.Dependencies
+	deps   []flux.Dependency
 	logger *zap.Logger
 }
 
 func (c *Controller) Query(ctx context.Context, compiler flux.Compiler) (flux.Query, error) {
+	for _, dep := range c.deps {
+		ctx = dep.Inject(ctx)
+	}
+
 	p, err := compiler.Compile(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if p, ok := p.(lang.DependenciesAwareProgram); ok {
-		p.SetExecutorDependencies(c.deps)
+	if p, ok := p.(lang.LoggingProgram); ok {
 		p.SetLogger(c.logger)
 	}
 

--- a/flux/stdlib/influxdata/influxdb/dependencies.go
+++ b/flux/stdlib/influxdata/influxdb/dependencies.go
@@ -1,0 +1,70 @@
+package influxdb
+
+import (
+	"context"
+	"errors"
+
+	"github.com/influxdata/flux"
+)
+
+type key int
+
+const dependenciesKey key = iota
+
+type StorageDependencies struct {
+	Reader      Reader
+	MetaClient  MetaClient
+	Authorizer  Authorizer
+	AuthEnabled bool
+}
+
+func (d StorageDependencies) Inject(ctx context.Context) context.Context {
+	return context.WithValue(ctx, dependenciesKey, d)
+}
+
+func (d StorageDependencies) Validate() error {
+	if d.Reader == nil {
+		return errors.New("missing reader dependency")
+	}
+	if d.MetaClient == nil {
+		return errors.New("missing meta client dependency")
+	}
+	if d.AuthEnabled && d.Authorizer == nil {
+		return errors.New("missing authorizer dependency")
+	}
+	return nil
+}
+
+func GetStorageDependencies(ctx context.Context) StorageDependencies {
+	return ctx.Value(dependenciesKey).(StorageDependencies)
+}
+
+type Dependencies struct {
+	StorageDeps StorageDependencies
+	FluxDeps    flux.Dependencies
+}
+
+func (d Dependencies) Inject(ctx context.Context) context.Context {
+	ctx = d.FluxDeps.Inject(ctx)
+	return d.StorageDeps.Inject(ctx)
+}
+
+func NewDependencies(
+	mc MetaClient,
+	reader Reader,
+	auth Authorizer,
+	authEnabled bool,
+) (Dependencies, error) {
+	fdeps := flux.NewDefaultDependencies()
+	deps := Dependencies{FluxDeps: fdeps}
+	deps.StorageDeps = StorageDependencies{
+		Reader:      reader,
+		MetaClient:  mc,
+		Authorizer:  auth,
+		AuthEnabled: authEnabled,
+	}
+	if err := deps.StorageDeps.Validate(); err != nil {
+		return Dependencies{}, err
+	}
+	return deps, nil
+}

--- a/flux/stdlib/influxdata/influxdb/from.go
+++ b/flux/stdlib/influxdata/influxdb/from.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
-	"github.com/pkg/errors"
 )
 
 const FromKind = "influxDBFrom"
@@ -49,10 +48,16 @@ func createFromOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	}
 
 	if spec.Bucket == "" && spec.BucketID == "" {
-		return nil, errors.New("must specify one of bucket or bucketID")
+		return nil, &flux.Error{
+			Code: codes.Invalid,
+			Msg:  "must specify one of bucket or bucketID",
+		}
 	}
 	if spec.Bucket != "" && spec.BucketID != "" {
-		return nil, errors.New("must specify only one of bucket or bucketID")
+		return nil, &flux.Error{
+			Code: codes.Invalid,
+			Msg:  "must specify only one of bucket or bucketID",
+		}
 	}
 	return spec, nil
 }
@@ -73,7 +78,10 @@ type FromProcedureSpec struct {
 func newFromProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*FromOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, &flux.Error{
+			Code: codes.Internal,
+			Msg:  fmt.Sprintf("invalid spec type %T", qs),
+		}
 	}
 
 	return &FromProcedureSpec{
@@ -113,13 +121,8 @@ func (s *FromProcedureSpec) PostPhysicalValidate(id plan.NodeID) error {
 	} else {
 		bucket = s.BucketID
 	}
-	return fmt.Errorf("cannot submit unbounded read to %q; try bounding 'from' with a call to 'range'", bucket)
-}
-
-func InjectFromDependencies(depsMap execute.Dependencies, deps Dependencies) error {
-	if err := deps.Validate(); err != nil {
-		return err
+	return &flux.Error{
+		Code: codes.Invalid,
+		Msg:  fmt.Sprintf("cannot submit unbounded read to %q; try bounding 'from' with a call to 'range'", bucket),
 	}
-	depsMap[FromKind] = deps
-	return nil
 }

--- a/flux/stdlib/influxdata/influxdb/from_test.go
+++ b/flux/stdlib/influxdata/influxdb/from_test.go
@@ -1,0 +1,1 @@
+package influxdb_test

--- a/flux/stdlib/influxdata/influxdb/metrics.go
+++ b/flux/stdlib/influxdata/influxdb/metrics.go
@@ -1,0 +1,3 @@
+package influxdb
+
+// Storage metrics are not implemented in the 1.x flux engine.

--- a/flux/stdlib/influxdata/influxdb/operators.go
+++ b/flux/stdlib/influxdata/influxdb/operators.go
@@ -81,7 +81,7 @@ func (s *ReadRangePhysSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
-func (s *ReadRangePhysSpec) LookupDatabase(ctx context.Context, deps Dependencies, a execute.Administration) (string, string, error) {
+func (s *ReadRangePhysSpec) LookupDatabase(ctx context.Context, deps StorageDependencies, a execute.Administration) (string, string, error) {
 	if len(s.BucketID) != 0 {
 		return "", "", errors.New("cannot refer to buckets by their id in 1.x")
 	}

--- a/flux/stdlib/influxdata/influxdb/source_test.go
+++ b/flux/stdlib/influxdata/influxdb/source_test.go
@@ -1,0 +1,1 @@
+package influxdb_test

--- a/flux/stdlib/influxdata/influxdb/storage.go
+++ b/flux/stdlib/influxdata/influxdb/storage.go
@@ -18,14 +18,14 @@ type Authorizer interface {
 	AuthorizeDatabase(u meta.User, priv influxql.Privilege, database string) error
 }
 
-type Dependencies struct {
+type FromDependencies struct {
 	Reader      Reader
 	MetaClient  MetaClient
 	Authorizer  Authorizer
 	AuthEnabled bool
 }
 
-func (d Dependencies) Validate() error {
+func (d FromDependencies) Validate() error {
 	if d.Reader == nil {
 		return errors.New("missing reader dependency")
 	}
@@ -33,7 +33,7 @@ func (d Dependencies) Validate() error {
 		return errors.New("missing meta client dependency")
 	}
 	if d.AuthEnabled && d.Authorizer == nil {
-		return errors.New("validate Dependencies: missing Authorizer")
+		return errors.New("missing authorizer dependency")
 	}
 	return nil
 }

--- a/flux/stdlib/influxdata/influxdb/v1/databases.go
+++ b/flux/stdlib/influxdata/influxdb/v1/databases.go
@@ -9,9 +9,8 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
-	v1 "github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
 	"github.com/influxdata/flux/values"
-	"github.com/influxdata/influxdb/coordinator"
 	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxql"
@@ -68,23 +67,22 @@ func init() {
 }
 
 type DatabasesDecoder struct {
-	deps      *DatabaseDependencies
+	deps      *influxdb.StorageDependencies
 	databases []meta.DatabaseInfo
 	user      meta.User
 	alloc     *memory.Allocator
-	ctx       context.Context
 }
 
-func (bd *DatabasesDecoder) Connect() error {
+func (bd *DatabasesDecoder) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (bd *DatabasesDecoder) Fetch() (bool, error) {
+func (bd *DatabasesDecoder) Fetch(ctx context.Context) (bool, error) {
 	bd.databases = bd.deps.MetaClient.Databases()
 	return false, nil
 }
 
-func (bd *DatabasesDecoder) Decode() (flux.Table, error) {
+func (bd *DatabasesDecoder) Decode(ctx context.Context) (flux.Table, error) {
 	kb := execute.NewGroupKeyBuilder(nil)
 	kb.AddKeyValue("organizationID", values.NewString(""))
 	gk, err := kb.Build()
@@ -93,7 +91,6 @@ func (bd *DatabasesDecoder) Decode() (flux.Table, error) {
 	}
 
 	b := execute.NewColListTableBuilder(gk, bd.alloc)
-
 	if _, err := b.AddCol(flux.ColMeta{
 		Label: "organizationID",
 		Type:  flux.TString,
@@ -168,8 +165,7 @@ func createDatabasesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a 
 	if !ok {
 		return nil, fmt.Errorf("invalid spec type %T", prSpec)
 	}
-
-	deps := a.Dependencies()[DatabasesKind].(DatabaseDependencies)
+	deps := influxdb.GetStorageDependencies(a.Context())
 	var user meta.User
 	if deps.AuthEnabled {
 		user = meta.UserFromContext(a.Context())
@@ -177,23 +173,6 @@ func createDatabasesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a 
 			return nil, errors.New("createDatabasesSource: no user")
 		}
 	}
-	bd := &DatabasesDecoder{deps: &deps, alloc: a.Allocator(), ctx: a.Context(), user: user}
+	bd := &DatabasesDecoder{deps: &deps, alloc: a.Allocator(), user: user}
 	return execute.CreateSourceFromDecoder(bd, dsid, a)
-}
-
-type DatabaseDependencies struct {
-	MetaClient  coordinator.MetaClient
-	Authorizer  influxdb.Authorizer
-	AuthEnabled bool
-}
-
-func InjectDatabaseDependencies(depsMap execute.Dependencies, deps DatabaseDependencies) error {
-	if deps.MetaClient == nil {
-		return errors.New("missing meta client dependency")
-	}
-	if deps.AuthEnabled && deps.Authorizer == nil {
-		return errors.New("missing authorizer with auth enabled")
-	}
-	depsMap[DatabasesKind] = deps
-	return nil
 }

--- a/mock/storage_reads.go
+++ b/mock/storage_reads.go
@@ -1,7 +1,11 @@
 package mock
 
 import (
+	"context"
+
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/services/storage"
 	"github.com/influxdata/influxdb/storage/reads"
 	"github.com/influxdata/influxdb/storage/reads/datatypes"
 	"github.com/influxdata/influxdb/tsdb/cursors"
@@ -98,6 +102,38 @@ func (rs *GroupResultSet) Err() error {
 	return rs.ErrFunc()
 }
 
+type FloatArrayCursor struct {
+	CloseFunc func()
+	Errfunc   func() error
+	StatsFunc func() cursors.CursorStats
+	NextFunc  func() *cursors.FloatArray
+}
+
+func NewFloatArrayCursor() *FloatArrayCursor {
+	return &FloatArrayCursor{
+		CloseFunc: func() {},
+		Errfunc:   func() error { return nil },
+		StatsFunc: func() cursors.CursorStats { return cursors.CursorStats{} },
+		NextFunc:  func() *cursors.FloatArray { return &cursors.FloatArray{} },
+	}
+}
+
+func (c *FloatArrayCursor) Close() {
+	c.CloseFunc()
+}
+
+func (c *FloatArrayCursor) Err() error {
+	return c.Errfunc()
+}
+
+func (c *FloatArrayCursor) Stats() cursors.CursorStats {
+	return c.StatsFunc()
+}
+
+func (c *FloatArrayCursor) Next() *cursors.FloatArray {
+	return c.NextFunc()
+}
+
 type IntegerArrayCursor struct {
 	CloseFunc func()
 	Errfunc   func() error
@@ -184,4 +220,35 @@ func (c *GroupCursor) Err() error {
 
 func (c *GroupCursor) Stats() cursors.CursorStats {
 	return c.StatsFunc()
+}
+
+type StoreReader struct {
+	ReadFilterFunc func(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error)
+	ReadGroupFunc  func(ctx context.Context, req *datatypes.ReadGroupRequest) (reads.GroupResultSet, error)
+	TagKeysFunc    func(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error)
+	TagValuesFunc  func(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error)
+}
+
+func NewStoreReader() *StoreReader {
+	return &StoreReader{}
+}
+
+func (s *StoreReader) ReadFilter(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error) {
+	return s.ReadFilterFunc(ctx, req)
+}
+
+func (s *StoreReader) ReadGroup(ctx context.Context, req *datatypes.ReadGroupRequest) (reads.GroupResultSet, error) {
+	return s.ReadGroupFunc(ctx, req)
+}
+
+func (s *StoreReader) TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error) {
+	return s.TagKeysFunc(ctx, req)
+}
+
+func (s *StoreReader) TagValues(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error) {
+	return s.TagValuesFunc(ctx, req)
+}
+
+func (*StoreReader) GetSource(db, rp string) proto.Message {
+	return &storage.ReadSource{Database: db, RetentionPolicy: rp}
 }

--- a/patches/flux.patch
+++ b/patches/flux.patch
@@ -1,27 +1,27 @@
-diff -ur a/flux/stdlib/influxdata/influxdb/buckets.go b/flux/stdlib/influxdata/influxdb/buckets.go
---- a/flux/stdlib/influxdata/influxdb/buckets.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/flux/stdlib/influxdata/influxdb/buckets.go	2019-06-25 10:03:53.000000000 -0500
-@@ -1,6 +1,7 @@
- package influxdb
+diff --git b/flux/stdlib/influxdata/influxdb/buckets.go a/flux/stdlib/influxdata/influxdb/buckets.go
+index 4fd36f948..9ecbe4923 100644
+--- b/flux/stdlib/influxdata/influxdb/buckets.go
++++ a/flux/stdlib/influxdata/influxdb/buckets.go
+@@ -2,6 +2,7 @@ package influxdb
  
  import (
+ 	"context"
 +	"errors"
  	"fmt"
  
  	"github.com/influxdata/flux"
-@@ -9,9 +10,8 @@
+@@ -11,8 +12,8 @@ import (
  	"github.com/influxdata/flux/plan"
  	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
  	"github.com/influxdata/flux/values"
 -	platform "github.com/influxdata/influxdb"
 -	"github.com/influxdata/influxdb/query"
--	"github.com/pkg/errors"
 +	"github.com/influxdata/influxdb/services/meta"
 +	"github.com/influxdata/influxql"
  )
  
  func init() {
-@@ -19,10 +19,9 @@
+@@ -20,10 +21,9 @@ func init() {
  }
  
  type BucketsDecoder struct {
@@ -29,32 +29,35 @@ diff -ur a/flux/stdlib/influxdata/influxdb/buckets.go b/flux/stdlib/influxdata/i
 -	deps    BucketDependencies
 -	buckets []*platform.Bucket
 -	alloc   *memory.Allocator
-+	deps  BucketDependencies
++	deps  StorageDependencies
 +	alloc *memory.Allocator
 +	user  meta.User
  }
  
- func (bd *BucketsDecoder) Connect() error {
-@@ -30,17 +29,12 @@
+ func (bd *BucketsDecoder) Connect(ctx context.Context) error {
+@@ -31,20 +31,12 @@ func (bd *BucketsDecoder) Connect(ctx context.Context) error {
  }
  
- func (bd *BucketsDecoder) Fetch() (bool, error) {
--	b, count := bd.deps.FindAllBuckets(bd.orgID)
+ func (bd *BucketsDecoder) Fetch(ctx context.Context) (bool, error) {
+-	b, count := bd.deps.FindAllBuckets(ctx, bd.orgID)
 -	if count <= 0 {
--		return false, fmt.Errorf("no buckets found in organization %v", bd.orgID)
+-		return false, &flux.Error{
+-			Code: codes.NotFound,
+-			Msg:  fmt.Sprintf("no buckets found in organization %v", bd.orgID),
+-		}
 -	}
 -	bd.buckets = b
  	return false, nil
  }
  
- func (bd *BucketsDecoder) Decode() (flux.Table, error) {
+ func (bd *BucketsDecoder) Decode(ctx context.Context) (flux.Table, error) {
  	kb := execute.NewGroupKeyBuilder(nil)
 -	kb.AddKeyValue("organizationID", values.NewString(bd.buckets[0].OrgID.String()))
 +	kb.AddKeyValue("organizationID", values.NewString(""))
  	gk, err := kb.Build()
  	if err != nil {
  		return nil, err
-@@ -48,43 +42,54 @@
+@@ -52,43 +44,50 @@ func (bd *BucketsDecoder) Decode(ctx context.Context) (flux.Table, error) {
  
  	b := execute.NewColListTableBuilder(gk, bd.alloc)
  
@@ -74,10 +77,6 @@ diff -ur a/flux/stdlib/influxdata/influxdb/buckets.go b/flux/stdlib/influxdata/i
 -		return nil, err
 -	}
 -	if _, err := b.AddCol(flux.ColMeta{
-+	})
-+	_, _ = b.AddCol(flux.ColMeta{
-+		Label: "organization",
-+		Type:  flux.TString,
 +	})
 +	_, _ = b.AddCol(flux.ColMeta{
  		Label: "organizationID",
@@ -100,15 +99,8 @@ diff -ur a/flux/stdlib/influxdata/influxdb/buckets.go b/flux/stdlib/influxdata/i
  		Type:  flux.TInt,
 -	}); err != nil {
 -		return nil, err
--	}
 +	})
- 
--	for _, bucket := range bd.buckets {
--		_ = b.AppendString(0, bucket.Name)
--		_ = b.AppendString(1, bucket.ID.String())
--		_ = b.AppendString(2, bucket.OrgID.String())
--		_ = b.AppendString(3, bucket.RetentionPolicyName)
--		_ = b.AppendInt(4, bucket.RetentionPeriod.Nanoseconds())
++
 +	var hasAccess func(db string) bool
 +	if bd.user == nil {
 +		hasAccess = func(db string) bool {
@@ -119,8 +111,14 @@ diff -ur a/flux/stdlib/influxdata/influxdb/buckets.go b/flux/stdlib/influxdata/i
 +			return bd.deps.Authorizer.AuthorizeDatabase(bd.user, influxql.ReadPrivilege, db) == nil ||
 +				bd.deps.Authorizer.AuthorizeDatabase(bd.user, influxql.WritePrivilege, db) == nil
 +		}
-+	}
-+
+ 	}
+ 
+-	for _, bucket := range bd.buckets {
+-		_ = b.AppendString(0, bucket.Name)
+-		_ = b.AppendString(1, bucket.ID.String())
+-		_ = b.AppendString(2, bucket.OrgID.String())
+-		_ = b.AppendString(3, bucket.RetentionPolicyName)
+-		_ = b.AppendInt(4, bucket.RetentionPeriod.Nanoseconds())
 +	for _, db := range bd.deps.MetaClient.Databases() {
 +		if hasAccess(db.Name) {
 +			for _, rp := range db.RetentionPolicies {
@@ -135,20 +133,24 @@ diff -ur a/flux/stdlib/influxdata/influxdb/buckets.go b/flux/stdlib/influxdata/i
  	}
  
  	return b.Table()
-@@ -103,25 +108,45 @@
+@@ -109,22 +108,22 @@ func createBucketsSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
+ 
  	// the dependencies used for FromKind are adequate for what we need here
  	// so there's no need to inject custom dependencies for buckets()
- 	deps := a.Dependencies()[influxdb.BucketsKind].(BucketDependencies)
+-	deps := GetStorageDependencies(a.Context()).BucketDeps
 -	req := query.RequestFromContext(a.Context())
 -	if req == nil {
--		return nil, errors.New("missing request on context")
+-		return nil, &flux.Error{
+-			Code: codes.Internal,
+-			Msg:  "missing request on context",
++	deps := GetStorageDependencies(a.Context())
 +
 +	var user meta.User
 +	if deps.AuthEnabled {
 +		user = meta.UserFromContext(a.Context())
 +		if user == nil {
 +			return nil, errors.New("createBucketsSource: no user")
-+		}
+ 		}
  	}
 -	orgID := req.OrganizationID
  
@@ -156,53 +158,153 @@ diff -ur a/flux/stdlib/influxdata/influxdb/buckets.go b/flux/stdlib/influxdata/i
 +	bd := &BucketsDecoder{deps: deps, alloc: a.Allocator(), user: user}
  
  	return execute.CreateSourceFromDecoder(bd, dsid, a)
-+
-+}
-+
+ }
+ 
+-type AllBucketLookup interface {
+-	FindAllBuckets(ctx context.Context, orgID platform.ID) ([]*platform.Bucket, int)
 +type MetaClient interface {
 +	Databases() []meta.DatabaseInfo
 +	Database(name string) *meta.DatabaseInfo
  }
+-type BucketDependencies AllBucketLookup
+diff --git b/flux/stdlib/influxdata/influxdb/dependencies.go a/flux/stdlib/influxdata/influxdb/dependencies.go
+index 3303c2758..ad9a36ab6 100644
+--- b/flux/stdlib/influxdata/influxdb/dependencies.go
++++ a/flux/stdlib/influxdata/influxdb/dependencies.go
+@@ -2,13 +2,9 @@ package influxdb
  
--type AllBucketLookup interface {
--	FindAllBuckets(orgID platform.ID) ([]*platform.Bucket, int)
-+type BucketDependencies struct {
+ import (
+ 	"context"
++	"errors"
+ 
+ 	"github.com/influxdata/flux"
+-	"github.com/influxdata/influxdb"
+-	"github.com/influxdata/influxdb/kit/prom"
+-	"github.com/influxdata/influxdb/query"
+-	"github.com/influxdata/influxdb/storage"
+-	"github.com/prometheus/client_golang/prometheus"
+ )
+ 
+ type key int
+@@ -16,33 +12,31 @@ type key int
+ const dependenciesKey key = iota
+ 
+ type StorageDependencies struct {
+-	FromDeps   FromDependencies
+-	BucketDeps BucketDependencies
+-	ToDeps     ToDependencies
++	Reader      Reader
 +	MetaClient  MetaClient
 +	Authorizer  Authorizer
 +	AuthEnabled bool
-+}
-+
-+func (d BucketDependencies) Validate() error {
+ }
+ 
+ func (d StorageDependencies) Inject(ctx context.Context) context.Context {
+ 	return context.WithValue(ctx, dependenciesKey, d)
+ }
+ 
+-func GetStorageDependencies(ctx context.Context) StorageDependencies {
+-	return ctx.Value(dependenciesKey).(StorageDependencies)
+-}
+-
+-// PrometheusCollectors satisfies the prom.PrometheusCollector interface.
+-func (d StorageDependencies) PrometheusCollectors() []prometheus.Collector {
+-	depS := []interface{}{
+-		d.FromDeps,
+-		d.BucketDeps,
+-		d.ToDeps,
++func (d StorageDependencies) Validate() error {
++	if d.Reader == nil {
++		return errors.New("missing reader dependency")
+ 	}
+-	collectors := make([]prometheus.Collector, 0, len(depS))
+-	for _, v := range depS {
+-		if pc, ok := v.(prom.PrometheusCollector); ok {
+-			collectors = append(collectors, pc.PrometheusCollectors()...)
+-		}
 +	if d.MetaClient == nil {
-+		return errors.New("validate BucketDependencies: missing MetaClient")
-+	}
++		return errors.New("missing meta client dependency")
+ 	}
+-	return collectors
 +	if d.AuthEnabled && d.Authorizer == nil {
-+		return errors.New("validate BucketDependencies: missing Authorizer")
++		return errors.New("missing authorizer dependency")
 +	}
 +	return nil
++}
++
++func GetStorageDependencies(ctx context.Context) StorageDependencies {
++	return ctx.Value(dependenciesKey).(StorageDependencies)
  }
--type BucketDependencies AllBucketLookup
  
- func InjectBucketDependencies(depsMap execute.Dependencies, deps BucketDependencies) error {
--	if deps == nil {
--		return errors.New("missing all bucket lookup dependency")
-+	if err := deps.Validate(); err != nil {
-+		return err
+ type Dependencies struct {
+@@ -55,45 +49,21 @@ func (d Dependencies) Inject(ctx context.Context) context.Context {
+ 	return d.StorageDeps.Inject(ctx)
+ }
+ 
+-// PrometheusCollectors satisfies the prom.PrometheusCollector interface.
+-func (d Dependencies) PrometheusCollectors() []prometheus.Collector {
+-	collectors := d.StorageDeps.PrometheusCollectors()
+-	if pc, ok := d.FluxDeps.(prom.PrometheusCollector); ok {
+-		collectors = append(collectors, pc.PrometheusCollectors()...)
+-	}
+-	return collectors
+-}
+-
+ func NewDependencies(
++	mc MetaClient,
+ 	reader Reader,
+-	writer storage.PointsWriter,
+-	bucketSvc influxdb.BucketService,
+-	orgSvc influxdb.OrganizationService,
+-	ss influxdb.SecretService,
+-	metricLabelKeys []string,
++	auth Authorizer,
++	authEnabled bool,
+ ) (Dependencies, error) {
+ 	fdeps := flux.NewDefaultDependencies()
+-	fdeps.Deps.SecretService = query.FromSecretService(ss)
+ 	deps := Dependencies{FluxDeps: fdeps}
+-	bucketLookupSvc := query.FromBucketService(bucketSvc)
+-	orgLookupSvc := query.FromOrganizationService(orgSvc)
+-	metrics := NewMetrics(metricLabelKeys)
+-	deps.StorageDeps.FromDeps = FromDependencies{
+-		Reader:             reader,
+-		BucketLookup:       bucketLookupSvc,
+-		OrganizationLookup: orgLookupSvc,
+-		Metrics:            metrics,
+-	}
+-	if err := deps.StorageDeps.FromDeps.Validate(); err != nil {
+-		return Dependencies{}, err
+-	}
+-	deps.StorageDeps.BucketDeps = bucketLookupSvc
+-	deps.StorageDeps.ToDeps = ToDependencies{
+-		BucketLookup:       bucketLookupSvc,
+-		OrganizationLookup: orgLookupSvc,
+-		PointsWriter:       writer,
++	deps.StorageDeps = StorageDependencies{
++		Reader:      reader,
++		MetaClient:  mc,
++		Authorizer:  auth,
++		AuthEnabled: authEnabled,
  	}
- 	depsMap[influxdb.BucketsKind] = deps
- 	return nil
-diff -ur a/flux/stdlib/influxdata/influxdb/from.go b/flux/stdlib/influxdata/influxdb/from.go
---- a/flux/stdlib/influxdata/influxdb/from.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/flux/stdlib/influxdata/influxdb/from.go	2019-06-25 13:49:49.000000000 -0500
-@@ -8,7 +8,6 @@
+-	if err := deps.StorageDeps.ToDeps.Validate(); err != nil {
++	if err := deps.StorageDeps.Validate(); err != nil {
+ 		return Dependencies{}, err
+ 	}
+ 	return deps, nil
+diff --git b/flux/stdlib/influxdata/influxdb/from.go a/flux/stdlib/influxdata/influxdb/from.go
+index cdd6789c1..6662f54fd 100644
+--- b/flux/stdlib/influxdata/influxdb/from.go
++++ a/flux/stdlib/influxdata/influxdb/from.go
+@@ -8,7 +8,6 @@ import (
  	"github.com/influxdata/flux/plan"
  	"github.com/influxdata/flux/semantic"
  	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 -	platform "github.com/influxdata/influxdb"
- 	"github.com/pkg/errors"
  )
  
-@@ -66,31 +65,6 @@
+ const FromKind = "influxDBFrom"
+@@ -71,31 +70,6 @@ func (s *FromOpSpec) Kind() flux.OperationKind {
  	return FromKind
  }
  
@@ -234,17 +336,306 @@ diff -ur a/flux/stdlib/influxdata/influxdb/from.go b/flux/stdlib/influxdata/infl
  type FromProcedureSpec struct {
  	Bucket   string
  	BucketID string
-diff -ur a/flux/stdlib/influxdata/influxdb/operators.go b/flux/stdlib/influxdata/influxdb/operators.go
---- a/flux/stdlib/influxdata/influxdb/operators.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/flux/stdlib/influxdata/influxdb/operators.go	2019-06-25 13:49:49.000000000 -0500
-@@ -3,13 +3,15 @@
+diff --git b/flux/stdlib/influxdata/influxdb/from_test.go a/flux/stdlib/influxdata/influxdb/from_test.go
+index dac3b13ee..daba8c936 100644
+--- b/flux/stdlib/influxdata/influxdb/from_test.go
++++ a/flux/stdlib/influxdata/influxdb/from_test.go
+@@ -1,192 +1 @@
+ package influxdb_test
+-
+-import (
+-	"fmt"
+-	"testing"
+-	"time"
+-
+-	"github.com/influxdata/flux"
+-	"github.com/influxdata/flux/execute"
+-	"github.com/influxdata/flux/plan"
+-	"github.com/influxdata/flux/plan/plantest"
+-	"github.com/influxdata/flux/querytest"
+-	"github.com/influxdata/flux/stdlib/universe"
+-	platform "github.com/influxdata/influxdb"
+-	pquerytest "github.com/influxdata/influxdb/query/querytest"
+-	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
+-)
+-
+-func TestFrom_NewQuery(t *testing.T) {
+-	t.Skip()
+-	tests := []querytest.NewQueryTestCase{
+-		{
+-			Name:    "from no args",
+-			Raw:     `from()`,
+-			WantErr: true,
+-		},
+-		{
+-			Name:    "from conflicting args",
+-			Raw:     `from(bucket:"d", bucket:"b")`,
+-			WantErr: true,
+-		},
+-		{
+-			Name:    "from repeat arg",
+-			Raw:     `from(bucket:"telegraf", bucket:"oops")`,
+-			WantErr: true,
+-		},
+-		{
+-			Name:    "from",
+-			Raw:     `from(bucket:"telegraf", chicken:"what is this?")`,
+-			WantErr: true,
+-		},
+-		{
+-			Name:    "from bucket invalid ID",
+-			Raw:     `from(bucketID:"invalid")`,
+-			WantErr: true,
+-		},
+-		{
+-			Name: "from bucket ID",
+-			Raw:  `from(bucketID:"aaaabbbbccccdddd")`,
+-			Want: &flux.Spec{
+-				Operations: []*flux.Operation{
+-					{
+-						ID: "from0",
+-						Spec: &influxdb.FromOpSpec{
+-							BucketID: "aaaabbbbccccdddd",
+-						},
+-					},
+-				},
+-			},
+-		},
+-		{
+-			Name: "from with database",
+-			Raw:  `from(bucket:"mybucket") |> range(start:-4h, stop:-2h) |> sum()`,
+-			Want: &flux.Spec{
+-				Operations: []*flux.Operation{
+-					{
+-						ID: "from0",
+-						Spec: &influxdb.FromOpSpec{
+-							Bucket: "mybucket",
+-						},
+-					},
+-					{
+-						ID: "range1",
+-						Spec: &universe.RangeOpSpec{
+-							Start: flux.Time{
+-								Relative:   -4 * time.Hour,
+-								IsRelative: true,
+-							},
+-							Stop: flux.Time{
+-								Relative:   -2 * time.Hour,
+-								IsRelative: true,
+-							},
+-							TimeColumn:  "_time",
+-							StartColumn: "_start",
+-							StopColumn:  "_stop",
+-						},
+-					},
+-					{
+-						ID: "sum2",
+-						Spec: &universe.SumOpSpec{
+-							AggregateConfig: execute.DefaultAggregateConfig,
+-						},
+-					},
+-				},
+-				Edges: []flux.Edge{
+-					{Parent: "from0", Child: "range1"},
+-					{Parent: "range1", Child: "sum2"},
+-				},
+-			},
+-		},
+-	}
+-	for _, tc := range tests {
+-		tc := tc
+-		t.Run(tc.Name, func(t *testing.T) {
+-			t.Parallel()
+-			querytest.NewQueryTestHelper(t, tc)
+-		})
+-	}
+-}
+-
+-func TestFromOperation_Marshaling(t *testing.T) {
+-	t.Skip()
+-	data := []byte(`{"id":"from","kind":"from","spec":{"bucket":"mybucket"}}`)
+-	op := &flux.Operation{
+-		ID: "from",
+-		Spec: &influxdb.FromOpSpec{
+-			Bucket: "mybucket",
+-		},
+-	}
+-	querytest.OperationMarshalingTestHelper(t, data, op)
+-}
+-
+-func TestFromOpSpec_BucketsAccessed(t *testing.T) {
+-	bucketName := "my_bucket"
+-	bucketIDString := "aaaabbbbccccdddd"
+-	bucketID, err := platform.IDFromString(bucketIDString)
+-	if err != nil {
+-		t.Fatal(err)
+-	}
+-	invalidID := platform.InvalidID()
+-	tests := []pquerytest.BucketsAccessedTestCase{
+-		{
+-			Name:             "From with bucket",
+-			Raw:              fmt.Sprintf(`from(bucket:"%s")`, bucketName),
+-			WantReadBuckets:  &[]platform.BucketFilter{{Name: &bucketName}},
+-			WantWriteBuckets: &[]platform.BucketFilter{},
+-		},
+-		{
+-			Name:             "From with bucketID",
+-			Raw:              fmt.Sprintf(`from(bucketID:"%s")`, bucketID),
+-			WantReadBuckets:  &[]platform.BucketFilter{{ID: bucketID}},
+-			WantWriteBuckets: &[]platform.BucketFilter{},
+-		},
+-		{
+-			Name:             "From invalid bucketID",
+-			Raw:              `from(bucketID:"invalid")`,
+-			WantReadBuckets:  &[]platform.BucketFilter{{ID: &invalidID}},
+-			WantWriteBuckets: &[]platform.BucketFilter{},
+-		},
+-	}
+-	for _, tc := range tests {
+-		tc := tc
+-		t.Run(tc.Name, func(t *testing.T) {
+-			t.Parallel()
+-			pquerytest.BucketsAccessedTestHelper(t, tc)
+-		})
+-	}
+-}
+-
+-func TestFromValidation(t *testing.T) {
+-	spec := plantest.PlanSpec{
+-		// from |> group (cannot query an infinite time range)
+-		Nodes: []plan.Node{
+-			plan.CreateLogicalNode("from", &influxdb.FromProcedureSpec{
+-				Bucket: "my-bucket",
+-			}),
+-			plan.CreatePhysicalNode("group", &universe.GroupProcedureSpec{
+-				GroupMode: flux.GroupModeBy,
+-				GroupKeys: []string{"_measurement", "_field"},
+-			}),
+-		},
+-		Edges: [][2]int{
+-			{0, 1},
+-		},
+-	}
+-
+-	ps := plantest.CreatePlanSpec(&spec)
+-	pp := plan.NewPhysicalPlanner(plan.OnlyPhysicalRules(
+-		influxdb.PushDownRangeRule{},
+-		influxdb.PushDownFilterRule{},
+-		influxdb.PushDownGroupRule{},
+-	))
+-	_, err := pp.Plan(ps)
+-	if err == nil {
+-		t.Error("Expected query with no call to range to fail physical planning")
+-	}
+-	want := `cannot submit unbounded read to "my-bucket"; try bounding 'from' with a call to 'range'`
+-	got := err.Error()
+-	if want != got {
+-		t.Errorf("unexpected error; -want/+got\n- %s\n+ %s", want, got)
+-	}
+-}
+diff --git b/flux/stdlib/influxdata/influxdb/metrics.go a/flux/stdlib/influxdata/influxdb/metrics.go
+index 82577e3a5..dd3cee868 100644
+--- b/flux/stdlib/influxdata/influxdb/metrics.go
++++ a/flux/stdlib/influxdata/influxdb/metrics.go
+@@ -1,83 +1,3 @@
+ package influxdb
+ 
+-import (
+-	"context"
+-	"fmt"
+-	"time"
+-
+-	platform "github.com/influxdata/influxdb"
+-	"github.com/prometheus/client_golang/prometheus"
+-)
+-
+-const (
+-	orgLabel = "org"
+-	opLabel  = "op"
+-)
+-
+-type metrics struct {
+-	ctxLabelKeys []string
+-	requestDur   *prometheus.HistogramVec
+-}
+-
+-// NewMetrics produces a new metrics objects for an influxdb source.
+-// Currently it just collects the duration of read requests into a histogram.
+-// ctxLabelKeys is a list of labels to add to the produced metrics.
+-// The value for a given key will be read off the context.
+-// The context value must be a string or an implementation of the Stringer interface.
+-// In addition, produced metrics will be labeled with the orgID and type of operation requested.
+-func NewMetrics(ctxLabelKeys []string) *metrics {
+-	labelKeys := make([]string, len(ctxLabelKeys)+2)
+-	copy(labelKeys, ctxLabelKeys)
+-	labelKeys[len(labelKeys)-2] = orgLabel
+-	labelKeys[len(labelKeys)-1] = opLabel
+-
+-	m := new(metrics)
+-	m.requestDur = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+-		Namespace: "query",
+-		Subsystem: "influxdb_source",
+-		Name:      "read_request_duration_seconds",
+-		Help:      "Histogram of times spent in read requests",
+-		Buckets:   prometheus.ExponentialBuckets(1e-3, 5, 7),
+-	}, labelKeys)
+-	m.ctxLabelKeys = ctxLabelKeys
+-	return m
+-}
+-
+-// PrometheusCollectors satisfies the PrometheusCollector interface.
+-func (m *metrics) PrometheusCollectors() []prometheus.Collector {
+-	if m == nil {
+-		// if metrics happens to be nil here (such as for a test), then let's not panic.
+-		return nil
+-	}
+-	return []prometheus.Collector{
+-		m.requestDur,
+-	}
+-}
+-
+-func (m *metrics) getLabelValues(ctx context.Context, orgID platform.ID, op string) []string {
+-	if m == nil {
+-		return nil
+-	}
+-	labelValues := make([]string, len(m.ctxLabelKeys)+2)
+-	for i, k := range m.ctxLabelKeys {
+-		value := ctx.Value(k)
+-		var str string
+-		switch v := value.(type) {
+-		case string:
+-			str = v
+-		case fmt.Stringer:
+-			str = v.String()
+-		}
+-		labelValues[i] = str
+-	}
+-	labelValues[len(labelValues)-2] = orgID.String()
+-	labelValues[len(labelValues)-1] = op
+-	return labelValues
+-}
+-
+-func (m *metrics) recordMetrics(labelValues []string, start time.Time) {
+-	if m == nil {
+-		return
+-	}
+-	m.requestDur.WithLabelValues(labelValues...).Observe(time.Since(start).Seconds())
+-}
++// Storage metrics are not implemented in the 1.x flux engine.
+diff --git b/flux/stdlib/influxdata/influxdb/operators.go a/flux/stdlib/influxdata/influxdb/operators.go
+index 4203b074b..b0db49591 100644
+--- b/flux/stdlib/influxdata/influxdb/operators.go
++++ a/flux/stdlib/influxdata/influxdb/operators.go
+@@ -2,14 +2,16 @@ package influxdb
+ 
  import (
  	"context"
- 	"errors"
 -	"fmt"
++	"errors"
 +	"strings"
  
  	"github.com/influxdata/flux"
+-	"github.com/influxdata/flux/codes"
 +	"github.com/influxdata/flux/execute"
  	"github.com/influxdata/flux/plan"
  	"github.com/influxdata/flux/semantic"
@@ -255,7 +646,7 @@ diff -ur a/flux/stdlib/influxdata/influxdb/operators.go b/flux/stdlib/influxdata
  )
  
  const (
-@@ -79,24 +81,43 @@
+@@ -79,34 +81,43 @@ func (s *ReadRangePhysSpec) Copy() plan.ProcedureSpec {
  	return ns
  }
  
@@ -265,8 +656,21 @@ diff -ur a/flux/stdlib/influxdata/influxdb/operators.go b/flux/stdlib/influxdata
 -	case s.Bucket != "":
 -		b, ok := buckets.Lookup(ctx, orgID, s.Bucket)
 -		if !ok {
--			return 0, fmt.Errorf("could not find bucket %q", s.Bucket)
-+func (s *ReadRangePhysSpec) LookupDatabase(ctx context.Context, deps Dependencies, a execute.Administration) (string, string, error) {
+-			return 0, &flux.Error{
+-				Code: codes.NotFound,
+-				Msg:  fmt.Sprintf("could not find bucket %q", s.Bucket),
+-			}
+-		}
+-		return b, nil
+-	case len(s.BucketID) != 0:
+-		var b influxdb.ID
+-		if err := b.DecodeFromString(s.BucketID); err != nil {
+-			return 0, &flux.Error{
+-				Code: codes.Invalid,
+-				Msg:  "invalid bucket id",
+-				Err:  err,
+-			}
++func (s *ReadRangePhysSpec) LookupDatabase(ctx context.Context, deps StorageDependencies, a execute.Administration) (string, string, error) {
 +	if len(s.BucketID) != 0 {
 +		return "", "", errors.New("cannot refer to buckets by their id in 1.x")
 +	}
@@ -291,16 +695,13 @@ diff -ur a/flux/stdlib/influxdata/influxdb/operators.go b/flux/stdlib/influxdata
 +			return "", "", errors.New("createFromSource: no user")
  		}
 -		return b, nil
--	case len(s.BucketID) != 0:
--		var b influxdb.ID
--		if err := b.DecodeFromString(s.BucketID); err != nil {
--			return 0, err
+-	default:
+-		return 0, &flux.Error{
+-			Code: codes.Invalid,
+-			Msg:  "no bucket name or id have been specified",
 +		if err := deps.Authorizer.AuthorizeDatabase(user, influxql.ReadPrivilege, db); err != nil {
 +			return "", "", err
  		}
--		return b, nil
--	default:
--		return 0, errors.New("no bucket name or id have been specified")
  	}
 +
 +	if rp == "" {
@@ -314,10 +715,11 @@ diff -ur a/flux/stdlib/influxdata/influxdb/operators.go b/flux/stdlib/influxdata
  }
  
  // TimeBounds implements plan.BoundsAwareProcedureSpec.
-diff -ur a/flux/stdlib/influxdata/influxdb/rules.go b/flux/stdlib/influxdata/influxdb/rules.go
---- a/flux/stdlib/influxdata/influxdb/rules.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/flux/stdlib/influxdata/influxdb/rules.go	2019-06-25 13:49:50.000000000 -0500
-@@ -190,6 +190,12 @@
+diff --git b/flux/stdlib/influxdata/influxdb/rules.go a/flux/stdlib/influxdata/influxdb/rules.go
+index 9e9e66283..4b6425ac9 100644
+--- b/flux/stdlib/influxdata/influxdb/rules.go
++++ a/flux/stdlib/influxdata/influxdb/rules.go
+@@ -192,6 +192,12 @@ func (rule PushDownReadTagKeysRule) Rewrite(pn plan.Node) (plan.Node, bool, erro
  	// constructing our own replacement. We do not care about it
  	// at the moment though which is why it is not in the pattern.
  
@@ -330,7 +732,7 @@ diff -ur a/flux/stdlib/influxdata/influxdb/rules.go b/flux/stdlib/influxdata/inf
  	// The schema mutator needs to correspond to a keep call
  	// on the column specified by the keys procedure.
  	if len(keepSpec.Mutations) != 1 {
-@@ -219,6 +225,20 @@
+@@ -221,6 +227,20 @@ func (rule PushDownReadTagKeysRule) Rewrite(pn plan.Node) (plan.Node, bool, erro
  	}), true, nil
  }
  
@@ -351,7 +753,7 @@ diff -ur a/flux/stdlib/influxdata/influxdb/rules.go b/flux/stdlib/influxdata/inf
  // PushDownReadTagValuesRule matches 'ReadRange |> keep(columns: [tag]) |> group() |> distinct(column: tag)'.
  // The 'from()' must have already been merged with 'range' and, optionally,
  // may have been merged with 'filter'.
-@@ -296,6 +316,9 @@
+@@ -298,6 +318,9 @@ var invalidTagKeysForTagValues = []string{
  	execute.DefaultValueColLabel,
  	execute.DefaultStartColLabel,
  	execute.DefaultStopColLabel,
@@ -361,10 +763,11 @@ diff -ur a/flux/stdlib/influxdata/influxdb/rules.go b/flux/stdlib/influxdata/inf
  }
  
  // isValidTagKeyForTagValues returns true if the given key can
-diff -ur a/flux/stdlib/influxdata/influxdb/rules_test.go b/flux/stdlib/influxdata/influxdb/rules_test.go
---- a/flux/stdlib/influxdata/influxdb/rules_test.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/flux/stdlib/influxdata/influxdb/rules_test.go	2019-06-25 13:49:49.000000000 -0500
-@@ -11,7 +11,7 @@
+diff --git b/flux/stdlib/influxdata/influxdb/rules_test.go a/flux/stdlib/influxdata/influxdb/rules_test.go
+index 12514b8d8..676deda55 100644
+--- b/flux/stdlib/influxdata/influxdb/rules_test.go
++++ a/flux/stdlib/influxdata/influxdb/rules_test.go
+@@ -12,7 +12,7 @@ import (
  	"github.com/influxdata/flux/plan/plantest"
  	"github.com/influxdata/flux/semantic"
  	"github.com/influxdata/flux/stdlib/universe"
@@ -373,19 +776,58 @@ diff -ur a/flux/stdlib/influxdata/influxdb/rules_test.go b/flux/stdlib/influxdat
  )
  
  func fluxTime(t int64) flux.Time {
-diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/influxdb/source.go
---- a/flux/stdlib/influxdata/influxdb/source.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/flux/stdlib/influxdata/influxdb/source.go	2019-06-25 13:49:49.000000000 -0500
-@@ -9,8 +9,6 @@
+diff --git b/flux/stdlib/influxdata/influxdb/source.go a/flux/stdlib/influxdata/influxdb/source.go
+index 1cff76b5b..3e0d5b654 100644
+--- b/flux/stdlib/influxdata/influxdb/source.go
++++ a/flux/stdlib/influxdata/influxdb/source.go
+@@ -3,7 +3,6 @@ package influxdb
+ import (
+ 	"context"
+ 	"errors"
+-	"time"
+ 
+ 	"github.com/influxdata/flux"
+ 	"github.com/influxdata/flux/codes"
+@@ -11,9 +10,6 @@ import (
  	"github.com/influxdata/flux/memory"
  	"github.com/influxdata/flux/plan"
  	"github.com/influxdata/flux/semantic"
+-	platform "github.com/influxdata/influxdb"
 -	"github.com/influxdata/influxdb/kit/tracing"
 -	"github.com/influxdata/influxdb/query"
  	"github.com/influxdata/influxdb/tsdb/cursors"
  )
  
-@@ -131,8 +129,7 @@
+@@ -36,17 +32,10 @@ type Source struct {
+ 	stats cursors.CursorStats
+ 
+ 	runner runner
+-
+-	m     *metrics
+-	orgID platform.ID
+-	op    string
+ }
+ 
+ func (s *Source) Run(ctx context.Context) {
+-	labelValues := s.m.getLabelValues(ctx, s.orgID, s.op)
+-	start := time.Now()
+ 	err := s.runner.run(ctx)
+-	s.m.recordMetrics(labelValues, start)
+ 	for _, t := range s.ts {
+ 		t.Finish(s.id, err)
+ 	}
+@@ -123,10 +112,6 @@ func ReadFilterSource(id execute.DatasetID, r Reader, readSpec ReadFilterSpec, a
+ 	src.reader = r
+ 	src.readSpec = readSpec
+ 
+-	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
+-	src.orgID = readSpec.OrganizationID
+-	src.op = "readFilter"
+-
+ 	src.runner = src
+ 	return src
+ }
+@@ -145,8 +130,7 @@ func (s *readFilterSource) run(ctx context.Context) error {
  }
  
  func createReadFilterSource(s plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
@@ -395,22 +837,28 @@ diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/in
  
  	spec := s.(*ReadRangePhysSpec)
  
-@@ -143,13 +140,7 @@
+@@ -158,18 +142,9 @@ func createReadFilterSource(s plan.ProcedureSpec, id execute.DatasetID, a execut
+ 		}
+ 	}
  
- 	deps := a.Dependencies()[FromKind].(Dependencies)
- 
+-	deps := GetStorageDependencies(a.Context()).FromDeps
+-
 -	req := query.RequestFromContext(a.Context())
 -	if req == nil {
--		return nil, errors.New("missing request on context")
+-		return nil, &flux.Error{
+-			Code: codes.Internal,
+-			Msg:  "missing request on context",
+-		}
 -	}
--
++	deps := GetStorageDependencies(a.Context())
+ 
 -	orgID := req.OrganizationID
 -	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
 +	db, rp, err := spec.LookupDatabase(ctx, deps, a)
  	if err != nil {
  		return nil, err
  	}
-@@ -162,10 +153,10 @@
+@@ -182,10 +157,10 @@ func createReadFilterSource(s plan.ProcedureSpec, id execute.DatasetID, a execut
  		id,
  		deps.Reader,
  		ReadFilterSpec{
@@ -423,9 +871,20 @@ diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/in
 +			Bounds:          *bounds,
 +			Predicate:       filter,
  		},
- 		a.Allocator(),
+ 		a,
  	), nil
-@@ -204,8 +195,7 @@
+@@ -206,10 +181,6 @@ func ReadGroupSource(id execute.DatasetID, r Reader, readSpec ReadGroupSpec, a e
+ 	src.reader = r
+ 	src.readSpec = readSpec
+ 
+-	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
+-	src.orgID = readSpec.OrganizationID
+-	src.op = "readGroup"
+-
+ 	src.runner = src
+ 	return src
+ }
+@@ -228,8 +199,7 @@ func (s *readGroupSource) run(ctx context.Context) error {
  }
  
  func createReadGroupSource(s plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
@@ -435,22 +894,25 @@ diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/in
  
  	spec := s.(*ReadGroupPhysSpec)
  
-@@ -216,13 +206,7 @@
+@@ -238,15 +208,9 @@ func createReadGroupSource(s plan.ProcedureSpec, id execute.DatasetID, a execute
+ 		return nil, errors.New("nil bounds passed to from")
+ 	}
  
- 	deps := a.Dependencies()[FromKind].(Dependencies)
- 
+-	deps := GetStorageDependencies(a.Context()).FromDeps
+-
 -	req := query.RequestFromContext(a.Context())
 -	if req == nil {
 -		return nil, errors.New("missing request on context")
 -	}
--
++	deps := GetStorageDependencies(a.Context())
+ 
 -	orgID := req.OrganizationID
 -	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
 +	db, rp, err := spec.LookupDatabase(ctx, deps, a)
  	if err != nil {
  		return nil, err
  	}
-@@ -236,10 +220,10 @@
+@@ -260,10 +224,10 @@ func createReadGroupSource(s plan.ProcedureSpec, id execute.DatasetID, a execute
  		deps.Reader,
  		ReadGroupSpec{
  			ReadFilterSpec: ReadFilterSpec{
@@ -465,7 +927,7 @@ diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/in
  			},
  			GroupMode:       ToGroupMode(spec.GroupMode),
  			GroupKeys:       spec.GroupKeys,
-@@ -250,18 +234,12 @@
+@@ -274,18 +238,12 @@ func createReadGroupSource(s plan.ProcedureSpec, id execute.DatasetID, a execute
  }
  
  func createReadTagKeysSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
@@ -474,19 +936,20 @@ diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/in
 +	ctx := a.Context()
  
  	spec := prSpec.(*ReadTagKeysPhysSpec)
- 	deps := a.Dependencies()[FromKind].(Dependencies)
+-	deps := GetStorageDependencies(a.Context()).FromDeps
 -	req := query.RequestFromContext(a.Context())
 -	if req == nil {
 -		return nil, errors.New("missing request on context")
 -	}
 -	orgID := req.OrganizationID
++	deps := GetStorageDependencies(a.Context())
  
 -	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
 +	db, rp, err := spec.LookupDatabase(ctx, deps, a)
  	if err != nil {
  		return nil, err
  	}
-@@ -277,10 +255,10 @@
+@@ -301,10 +259,10 @@ func createReadTagKeysSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID,
  		deps.Reader,
  		ReadTagKeysSpec{
  			ReadFilterSpec: ReadFilterSpec{
@@ -500,8 +963,19 @@ diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/in
 +				Predicate:       filter,
  			},
  		},
- 		a.Allocator(),
-@@ -314,18 +292,12 @@
+ 		a,
+@@ -326,10 +284,6 @@ func ReadTagKeysSource(id execute.DatasetID, r Reader, readSpec ReadTagKeysSpec,
+ 	src.id = id
+ 	src.alloc = a.Allocator()
+ 
+-	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
+-	src.orgID = readSpec.OrganizationID
+-	src.op = "readTagKeys"
+-
+ 	src.runner = src
+ 	return src
+ }
+@@ -343,18 +297,12 @@ func (s *readTagKeysSource) run(ctx context.Context) error {
  }
  
  func createReadTagValuesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
@@ -510,19 +984,20 @@ diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/in
 +	ctx := a.Context()
  
  	spec := prSpec.(*ReadTagValuesPhysSpec)
- 	deps := a.Dependencies()[FromKind].(Dependencies)
+-	deps := GetStorageDependencies(a.Context()).FromDeps
 -	req := query.RequestFromContext(a.Context())
 -	if req == nil {
 -		return nil, errors.New("missing request on context")
 -	}
 -	orgID := req.OrganizationID
++	deps := GetStorageDependencies(a.Context())
  
 -	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
 +	db, rp, err := spec.LookupDatabase(ctx, deps, a)
  	if err != nil {
  		return nil, err
  	}
-@@ -341,10 +313,10 @@
+@@ -370,10 +318,10 @@ func createReadTagValuesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID
  		deps.Reader,
  		ReadTagValuesSpec{
  			ReadFilterSpec: ReadFilterSpec{
@@ -537,18 +1012,168 @@ diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/in
  			},
  			TagKey: spec.TagKey,
  		},
-diff -ur a/flux/stdlib/influxdata/influxdb/storage.go b/flux/stdlib/influxdata/influxdb/storage.go
---- a/flux/stdlib/influxdata/influxdb/storage.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/flux/stdlib/influxdata/influxdb/storage.go	2019-06-25 13:49:49.000000000 -0500
-@@ -8,61 +8,36 @@
+@@ -396,10 +344,6 @@ func ReadTagValuesSource(id execute.DatasetID, r Reader, readSpec ReadTagValuesS
+ 	src.id = id
+ 	src.alloc = a.Allocator()
+ 
+-	src.m = GetStorageDependencies(a.Context()).FromDeps.Metrics
+-	src.orgID = readSpec.OrganizationID
+-	src.op = "readTagValues"
+-
+ 	src.runner = src
+ 	return src
+ }
+diff --git b/flux/stdlib/influxdata/influxdb/source_test.go a/flux/stdlib/influxdata/influxdb/source_test.go
+index 1cdda0f93..daba8c936 100644
+--- b/flux/stdlib/influxdata/influxdb/source_test.go
++++ a/flux/stdlib/influxdata/influxdb/source_test.go
+@@ -1,131 +1 @@
+ package influxdb_test
+-
+-import (
+-	"context"
+-	"testing"
+-	"time"
+-
+-	"github.com/influxdata/flux"
+-	"github.com/influxdata/flux/dependencies/dependenciestest"
+-	"github.com/influxdata/flux/execute"
+-	"github.com/influxdata/flux/memory"
+-	platform "github.com/influxdata/influxdb"
+-	"github.com/influxdata/influxdb/kit/prom/promtest"
+-	"github.com/influxdata/influxdb/mock"
+-	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
+-	"github.com/influxdata/influxdb/tsdb/cursors"
+-	"github.com/influxdata/influxdb/uuid"
+-	"github.com/prometheus/client_golang/prometheus"
+-)
+-
+-type mockTableIterator struct {
+-}
+-
+-func (mockTableIterator) Do(f func(flux.Table) error) error {
+-	return nil
+-}
+-
+-func (mockTableIterator) Statistics() cursors.CursorStats {
+-	return cursors.CursorStats{}
+-}
+-
+-type mockReader struct {
+-}
+-
+-func (mockReader) ReadFilter(ctx context.Context, spec influxdb.ReadFilterSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+-	return &mockTableIterator{}, nil
+-}
+-
+-func (mockReader) ReadGroup(ctx context.Context, spec influxdb.ReadGroupSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+-	return &mockTableIterator{}, nil
+-}
+-
+-func (mockReader) ReadTagKeys(ctx context.Context, spec influxdb.ReadTagKeysSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+-	return &mockTableIterator{}, nil
+-}
+-
+-func (mockReader) ReadTagValues(ctx context.Context, spec influxdb.ReadTagValuesSpec, alloc *memory.Allocator) (influxdb.TableIterator, error) {
+-	return &mockTableIterator{}, nil
+-}
+-
+-func (mockReader) Close() {
+-}
+-
+-type mockAdministration struct {
+-	Ctx context.Context
+-}
+-
+-func (a mockAdministration) Context() context.Context {
+-	return a.Ctx
+-}
+-
+-func (mockAdministration) ResolveTime(qt flux.Time) execute.Time {
+-	return 0
+-}
+-
+-func (mockAdministration) StreamContext() execute.StreamContext {
+-	return nil
+-}
+-
+-func (mockAdministration) Allocator() *memory.Allocator {
+-	return &memory.Allocator{}
+-}
+-
+-func (mockAdministration) Parents() []execute.DatasetID {
+-	return nil
+-}
+-
+-const (
+-	labelKey   = "key1"
+-	labelValue = "value1"
+-)
+-
+-// TestMetrics ensures that the metrics collected by an influxdb source are recorded.
+-func TestMetrics(t *testing.T) {
+-	reg := prometheus.NewRegistry()
+-
+-	orgID, err := platform.IDFromString("deadbeefbeefdead")
+-	if err != nil {
+-		t.Fatal(err)
+-	}
+-
+-	deps := influxdb.Dependencies{
+-		FluxDeps: dependenciestest.Default(),
+-		StorageDeps: influxdb.StorageDependencies{
+-			FromDeps: influxdb.FromDependencies{
+-				Reader:             &mockReader{},
+-				BucketLookup:       mock.BucketLookup{},
+-				OrganizationLookup: mock.OrganizationLookup{},
+-				Metrics:            influxdb.NewMetrics([]string{labelKey}),
+-			},
+-		},
+-	}
+-	reg.MustRegister(deps.PrometheusCollectors()...)
+-
+-	// This key/value pair added to the context will appear as a label in the prometheus histogram.
+-	ctx := context.WithValue(context.Background(), labelKey, labelValue) //lint:ignore SA1029 this is a temporary ignore until we have time to create an appropriate type
+-	// Injecting deps
+-	ctx = deps.Inject(ctx)
+-	a := &mockAdministration{Ctx: ctx}
+-	rfs := influxdb.ReadFilterSource(
+-		execute.DatasetID(uuid.FromTime(time.Now())),
+-		&mockReader{},
+-		influxdb.ReadFilterSpec{
+-			OrganizationID: *orgID,
+-		},
+-		a,
+-	)
+-	rfs.Run(ctx)
+-
+-	// Verify that we sampled the execution of the source by checking the prom registry.
+-	mfs := promtest.MustGather(t, reg)
+-	expectedLabels := map[string]string{
+-		"org":  "deadbeefbeefdead",
+-		"key1": "value1",
+-		"op":   "readFilter",
+-	}
+-	m := promtest.MustFindMetric(t, mfs, "query_influxdb_source_read_request_duration_seconds", expectedLabels)
+-	if want, got := uint64(1), *(m.Histogram.SampleCount); want != got {
+-		t.Fatalf("expected sample count of %v, got %v", want, got)
+-	}
+-}
+diff --git b/flux/stdlib/influxdata/influxdb/storage.go a/flux/stdlib/influxdata/influxdb/storage.go
+index 4f574fb20..727894907 100644
+--- b/flux/stdlib/influxdata/influxdb/storage.go
++++ a/flux/stdlib/influxdata/influxdb/storage.go
+@@ -8,75 +8,33 @@ import (
  	"github.com/influxdata/flux/execute"
  	"github.com/influxdata/flux/memory"
  	"github.com/influxdata/flux/semantic"
 -	platform "github.com/influxdata/influxdb"
+-	"github.com/influxdata/influxdb/kit/prom"
 +	"github.com/influxdata/influxdb/services/meta"
  	"github.com/influxdata/influxdb/tsdb/cursors"
 +	"github.com/influxdata/influxql"
  	"github.com/pkg/errors"
+-	"github.com/prometheus/client_golang/prometheus"
  )
  
 -type HostLookup interface {
@@ -558,41 +1183,56 @@ diff -ur a/flux/stdlib/influxdata/influxdb/storage.go b/flux/stdlib/influxdata/i
 -
 -type BucketLookup interface {
 -	Lookup(ctx context.Context, orgID platform.ID, name string) (platform.ID, bool)
+-	LookupName(ctx context.Context, orgID platform.ID, id platform.ID) string
 -}
 -
 -type OrganizationLookup interface {
 -	Lookup(ctx context.Context, name string) (platform.ID, bool)
+-	LookupName(ctx context.Context, id platform.ID) string
 +type Authorizer interface {
 +	AuthorizeDatabase(u meta.User, priv influxql.Privilege, database string) error
  }
  
- type Dependencies struct {
+ type FromDependencies struct {
 -	Reader             Reader
 -	BucketLookup       BucketLookup
 -	OrganizationLookup OrganizationLookup
+-	Metrics            *metrics
 +	Reader      Reader
 +	MetaClient  MetaClient
 +	Authorizer  Authorizer
 +	AuthEnabled bool
  }
  
- func (d Dependencies) Validate() error {
+ func (d FromDependencies) Validate() error {
  	if d.Reader == nil {
  		return errors.New("missing reader dependency")
  	}
 -	if d.BucketLookup == nil {
 -		return errors.New("missing bucket lookup dependency")
+-	}
+-	if d.OrganizationLookup == nil {
+-		return errors.New("missing organization lookup dependency")
+-	}
+-	return nil
+-}
+-
+-// PrometheusCollectors satisfies the PrometheusCollector interface.
+-func (d FromDependencies) PrometheusCollectors() []prometheus.Collector {
+-	collectors := make([]prometheus.Collector, 0)
+-	if pc, ok := d.Reader.(prom.PrometheusCollector); ok {
+-		collectors = append(collectors, pc.PrometheusCollectors()...)
 +	if d.MetaClient == nil {
 +		return errors.New("missing meta client dependency")
  	}
--	if d.OrganizationLookup == nil {
--		return errors.New("missing organization lookup dependency")
+-	if d.Metrics != nil {
+-		collectors = append(collectors, d.Metrics.PrometheusCollectors()...)
 +	if d.AuthEnabled && d.Authorizer == nil {
-+		return errors.New("validate Dependencies: missing Authorizer")
++		return errors.New("missing authorizer dependency")
  	}
- 	return nil
- }
- 
+-	return collectors
+-}
+-
 -type StaticLookup struct {
 -	hosts []string
 -}
@@ -608,13 +1248,10 @@ diff -ur a/flux/stdlib/influxdata/influxdb/storage.go b/flux/stdlib/influxdata/i
 -}
 -func (l StaticLookup) Watch() <-chan struct{} {
 -	// A nil channel always blocks, since hosts never change this is appropriate.
--	return nil
--}
--
- type GroupMode int
+ 	return nil
+ }
  
- const (
-@@ -85,8 +60,8 @@
+@@ -102,8 +60,8 @@ func ToGroupMode(fluxMode flux.GroupMode) GroupMode {
  }
  
  type ReadFilterSpec struct {
@@ -625,51 +1262,51 @@ diff -ur a/flux/stdlib/influxdata/influxdb/storage.go b/flux/stdlib/influxdata/i
  
  	Bounds execute.Bounds
  
-diff -ur a/flux/stdlib/influxdata/influxdb/v1/databases.go b/flux/stdlib/influxdata/influxdb/v1/databases.go
---- a/flux/stdlib/influxdata/influxdb/v1/databases.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/flux/stdlib/influxdata/influxdb/v1/databases.go	2019-06-25 10:03:53.000000000 -0500
-@@ -2,17 +2,19 @@
+diff --git b/flux/stdlib/influxdata/influxdb/v1/databases.go a/flux/stdlib/influxdata/influxdb/v1/databases.go
+index 6a6c59a76..1779f411c 100644
+--- b/flux/stdlib/influxdata/influxdb/v1/databases.go
++++ a/flux/stdlib/influxdata/influxdb/v1/databases.go
+@@ -2,8 +2,8 @@ package v1
  
  import (
  	"context"
 +	"errors"
  	"fmt"
+-	"time"
  
  	"github.com/influxdata/flux"
  	"github.com/influxdata/flux/execute"
- 	"github.com/influxdata/flux/memory"
+@@ -11,9 +11,9 @@ import (
  	"github.com/influxdata/flux/plan"
--	"github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
-+	v1 "github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
+ 	"github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
  	"github.com/influxdata/flux/values"
 -	platform "github.com/influxdata/influxdb"
 -	"github.com/influxdata/influxdb/query"
 -	"github.com/pkg/errors"
-+	"github.com/influxdata/influxdb/coordinator"
 +	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
 +	"github.com/influxdata/influxdb/services/meta"
 +	"github.com/influxdata/influxql"
  )
  
  const DatabasesKind = v1.DatabasesKind
-@@ -66,9 +68,9 @@
+@@ -67,9 +67,9 @@ func init() {
  }
  
  type DatabasesDecoder struct {
 -	orgID     platform.ID
 -	deps      *DatabasesDependencies
 -	databases []*platform.DBRPMapping
-+	deps      *DatabaseDependencies
++	deps      *influxdb.StorageDependencies
 +	databases []meta.DatabaseInfo
 +	user      meta.User
  	alloc     *memory.Allocator
- 	ctx       context.Context
- }
-@@ -78,20 +80,13 @@
  }
  
- func (bd *DatabasesDecoder) Fetch() (bool, error) {
--	b, _, err := bd.deps.DBRP.FindMany(bd.ctx, platform.DBRPMappingFilter{})
+@@ -78,45 +78,13 @@ func (bd *DatabasesDecoder) Connect(ctx context.Context) error {
+ }
+ 
+ func (bd *DatabasesDecoder) Fetch(ctx context.Context) (bool, error) {
+-	b, _, err := bd.deps.DBRP.FindMany(ctx, platform.DBRPMappingFilter{})
 -	if err != nil {
 -		return false, err
 -	}
@@ -678,20 +1315,52 @@ diff -ur a/flux/stdlib/influxdata/influxdb/v1/databases.go b/flux/stdlib/influxd
  	return false, nil
  }
  
- func (bd *DatabasesDecoder) Decode() (flux.Table, error) {
- 	kb := execute.NewGroupKeyBuilder(nil)
--	if len(bd.databases) == 0 {
--		return nil, errors.New("no 1.x databases found")
+ func (bd *DatabasesDecoder) Decode(ctx context.Context) (flux.Table, error) {
+-	type databaseInfo struct {
+-		*platform.DBRPMapping
+-		RetentionPeriod time.Duration
 -	}
--	kb.AddKeyValue("organizationID", values.NewString(bd.databases[0].OrganizationID.String()))
+-
+-	databases := make([]databaseInfo, 0, len(bd.databases))
+-	for _, db := range bd.databases {
+-		bucket, err := bd.deps.BucketLookup.FindBucketByID(ctx, db.BucketID)
+-		if err != nil {
+-			code := platform.ErrorCode(err)
+-			if code == platform.EUnauthorized || code == platform.EForbidden {
+-				continue
+-			}
+-			return nil, err
+-		}
+-		databases = append(databases, databaseInfo{
+-			DBRPMapping:     db,
+-			RetentionPeriod: bucket.RetentionPeriod,
+-		})
+-	}
+-
+-	if len(databases) == 0 {
+-		return nil, &platform.Error{
+-			Code: platform.ENotFound,
+-			Msg:  "no 1.x databases found",
+-		}
+-	}
+-
+ 	kb := execute.NewGroupKeyBuilder(nil)
+-	kb.AddKeyValue("organizationID", values.NewString(databases[0].OrganizationID.String()))
 +	kb.AddKeyValue("organizationID", values.NewString(""))
  	gk, err := kb.Build()
  	if err != nil {
  		return nil, err
-@@ -136,16 +131,28 @@
+@@ -160,13 +128,29 @@ func (bd *DatabasesDecoder) Decode(ctx context.Context) (flux.Table, error) {
  		return nil, err
  	}
  
+-	for _, db := range databases {
+-		_ = b.AppendString(0, db.OrganizationID.String())
+-		_ = b.AppendString(1, db.Database)
+-		_ = b.AppendString(2, db.RetentionPolicy)
+-		_ = b.AppendInt(3, db.RetentionPeriod.Nanoseconds())
+-		_ = b.AppendBool(4, db.Default)
+-		_ = b.AppendString(5, db.BucketID.String())
 +	var hasAccess func(db string) bool
 +	if bd.user == nil {
 +		hasAccess = func(db string) bool {
@@ -704,16 +1373,7 @@ diff -ur a/flux/stdlib/influxdata/influxdb/v1/databases.go b/flux/stdlib/influxd
 +		}
 +	}
 +
- 	for _, db := range bd.databases {
--		if bucket, err := bd.deps.BucketLookup.FindBucketByID(bd.ctx, db.BucketID); err != nil {
--			return nil, err
--		} else {
--			_ = b.AppendString(0, db.OrganizationID.String())
--			_ = b.AppendString(1, db.Database)
--			_ = b.AppendString(2, db.RetentionPolicy)
--			_ = b.AppendInt(3, bucket.RetentionPeriod.Nanoseconds())
--			_ = b.AppendBool(4, db.Default)
--			_ = b.AppendString(5, db.BucketID.String())
++	for _, db := range bd.databases {
 +		if hasAccess(db.Name) {
 +			for _, rp := range db.RetentionPolicies {
 +				_ = b.AppendString(0, "")
@@ -723,20 +1383,19 @@ diff -ur a/flux/stdlib/influxdata/influxdb/v1/databases.go b/flux/stdlib/influxd
 +				_ = b.AppendBool(4, db.DefaultRetentionPolicy == rp.Name)
 +				_ = b.AppendString(5, "")
 +			}
- 		}
++		}
  	}
  
-@@ -162,34 +169,31 @@
+ 	return b.Table()
+@@ -181,41 +165,14 @@ func createDatabasesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a
+ 	if !ok {
  		return nil, fmt.Errorf("invalid spec type %T", prSpec)
  	}
- 
--	// the dependencies used for FromKind are adequate for what we need here
--	// so there's no need to inject custom dependencies for databases()
--	deps := a.Dependencies()[DatabasesKind].(DatabasesDependencies)
+-	deps := GetDatabasesDependencies(a.Context())
 -	req := query.RequestFromContext(a.Context())
 -	if req == nil {
 -		return nil, errors.New("missing request on context")
-+	deps := a.Dependencies()[DatabasesKind].(DatabaseDependencies)
++	deps := influxdb.GetStorageDependencies(a.Context())
 +	var user meta.User
 +	if deps.AuthEnabled {
 +		user = meta.UserFromContext(a.Context())
@@ -746,42 +1405,953 @@ diff -ur a/flux/stdlib/influxdata/influxdb/v1/databases.go b/flux/stdlib/influxd
  	}
 -	orgID := req.OrganizationID
 -
--	bd := &DatabasesDecoder{orgID: orgID, deps: &deps, alloc: a.Allocator(), ctx: a.Context()}
+-	bd := &DatabasesDecoder{orgID: orgID, deps: &deps, alloc: a.Allocator()}
 -
-+	bd := &DatabasesDecoder{deps: &deps, alloc: a.Allocator(), ctx: a.Context(), user: user}
++	bd := &DatabasesDecoder{deps: &deps, alloc: a.Allocator(), user: user}
  	return execute.CreateSourceFromDecoder(bd, dsid, a)
  }
- 
+-
+-type key int
+-
+-const dependenciesKey key = iota
+-
 -type DatabasesDependencies struct {
 -	DBRP         platform.DBRPMappingService
 -	BucketLookup platform.BucketService
-+type DatabaseDependencies struct {
-+	MetaClient  coordinator.MetaClient
-+	Authorizer  influxdb.Authorizer
-+	AuthEnabled bool
- }
- 
--func InjectDatabasesDependencies(depsMap execute.Dependencies, deps DatabasesDependencies) error {
--	if deps.DBRP == nil {
+-}
+-
+-func (d DatabasesDependencies) Inject(ctx context.Context) context.Context {
+-	return context.WithValue(ctx, dependenciesKey, d)
+-}
+-
+-func GetDatabasesDependencies(ctx context.Context) DatabasesDependencies {
+-	return ctx.Value(dependenciesKey).(DatabasesDependencies)
+-}
+-
+-func (d DatabasesDependencies) Validate() error {
+-	if d.DBRP == nil {
 -		return errors.New("missing all databases lookup dependency")
-+func InjectDatabaseDependencies(depsMap execute.Dependencies, deps DatabaseDependencies) error {
-+	if deps.MetaClient == nil {
-+		return errors.New("missing meta client dependency")
- 	}
--
--	if deps.BucketLookup == nil {
+-	}
+-	if d.BucketLookup == nil {
 -		return errors.New("missing buckets lookup dependency")
-+	if deps.AuthEnabled && deps.Authorizer == nil {
-+		return errors.New("missing authorizer with auth enabled")
- 	}
--
- 	depsMap[DatabasesKind] = deps
- 	return nil
- }
-diff -ur a/storage/reads/group_resultset.go b/storage/reads/group_resultset.go
---- a/storage/reads/group_resultset.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/storage/reads/group_resultset.go	2019-06-25 13:49:49.000000000 -0500
-@@ -7,7 +7,6 @@
+-	}
+-	return nil
+-}
+diff --git b/patches/flux.patch a/patches/flux.patch
+index a35a722a5..743b1ddd2 100644
+--- b/patches/flux.patch
++++ a/patches/flux.patch
+@@ -0,0 +1,905 @@
++diff -ur a/flux/stdlib/influxdata/influxdb/buckets.go b/flux/stdlib/influxdata/influxdb/buckets.go
++--- a/flux/stdlib/influxdata/influxdb/buckets.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/flux/stdlib/influxdata/influxdb/buckets.go	2019-06-25 10:03:53.000000000 -0500
++@@ -1,6 +1,7 @@
++ package influxdb
++ 
++ import (
+++	"errors"
++ 	"fmt"
++ 
++ 	"github.com/influxdata/flux"
++@@ -9,9 +10,8 @@
++ 	"github.com/influxdata/flux/plan"
++ 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
++ 	"github.com/influxdata/flux/values"
++-	platform "github.com/influxdata/influxdb"
++-	"github.com/influxdata/influxdb/query"
++-	"github.com/pkg/errors"
+++	"github.com/influxdata/influxdb/services/meta"
+++	"github.com/influxdata/influxql"
++ )
++ 
++ func init() {
++@@ -19,10 +19,9 @@
++ }
++ 
++ type BucketsDecoder struct {
++-	orgID   platform.ID
++-	deps    BucketDependencies
++-	buckets []*platform.Bucket
++-	alloc   *memory.Allocator
+++	deps  BucketDependencies
+++	alloc *memory.Allocator
+++	user  meta.User
++ }
++ 
++ func (bd *BucketsDecoder) Connect() error {
++@@ -30,17 +29,12 @@
++ }
++ 
++ func (bd *BucketsDecoder) Fetch() (bool, error) {
++-	b, count := bd.deps.FindAllBuckets(bd.orgID)
++-	if count <= 0 {
++-		return false, fmt.Errorf("no buckets found in organization %v", bd.orgID)
++-	}
++-	bd.buckets = b
++ 	return false, nil
++ }
++ 
++ func (bd *BucketsDecoder) Decode() (flux.Table, error) {
++ 	kb := execute.NewGroupKeyBuilder(nil)
++-	kb.AddKeyValue("organizationID", values.NewString(bd.buckets[0].OrgID.String()))
+++	kb.AddKeyValue("organizationID", values.NewString(""))
++ 	gk, err := kb.Build()
++ 	if err != nil {
++ 		return nil, err
++@@ -48,43 +42,54 @@
++ 
++ 	b := execute.NewColListTableBuilder(gk, bd.alloc)
++ 
++-	if _, err := b.AddCol(flux.ColMeta{
+++	_, _ = b.AddCol(flux.ColMeta{
++ 		Label: "name",
++ 		Type:  flux.TString,
++-	}); err != nil {
++-		return nil, err
++-	}
++-	if _, err := b.AddCol(flux.ColMeta{
+++	})
+++	_, _ = b.AddCol(flux.ColMeta{
++ 		Label: "id",
++ 		Type:  flux.TString,
++-	}); err != nil {
++-		return nil, err
++-	}
++-	if _, err := b.AddCol(flux.ColMeta{
+++	})
+++	_, _ = b.AddCol(flux.ColMeta{
+++		Label: "organization",
+++		Type:  flux.TString,
+++	})
+++	_, _ = b.AddCol(flux.ColMeta{
++ 		Label: "organizationID",
++ 		Type:  flux.TString,
++-	}); err != nil {
++-		return nil, err
++-	}
++-	if _, err := b.AddCol(flux.ColMeta{
+++	})
+++	_, _ = b.AddCol(flux.ColMeta{
++ 		Label: "retentionPolicy",
++ 		Type:  flux.TString,
++-	}); err != nil {
++-		return nil, err
++-	}
++-	if _, err := b.AddCol(flux.ColMeta{
+++	})
+++	_, _ = b.AddCol(flux.ColMeta{
++ 		Label: "retentionPeriod",
++ 		Type:  flux.TInt,
++-	}); err != nil {
++-		return nil, err
++-	}
+++	})
++ 
++-	for _, bucket := range bd.buckets {
++-		_ = b.AppendString(0, bucket.Name)
++-		_ = b.AppendString(1, bucket.ID.String())
++-		_ = b.AppendString(2, bucket.OrgID.String())
++-		_ = b.AppendString(3, bucket.RetentionPolicyName)
++-		_ = b.AppendInt(4, bucket.RetentionPeriod.Nanoseconds())
+++	var hasAccess func(db string) bool
+++	if bd.user == nil {
+++		hasAccess = func(db string) bool {
+++			return true
+++		}
+++	} else {
+++		hasAccess = func(db string) bool {
+++			return bd.deps.Authorizer.AuthorizeDatabase(bd.user, influxql.ReadPrivilege, db) == nil ||
+++				bd.deps.Authorizer.AuthorizeDatabase(bd.user, influxql.WritePrivilege, db) == nil
+++		}
+++	}
+++
+++	for _, db := range bd.deps.MetaClient.Databases() {
+++		if hasAccess(db.Name) {
+++			for _, rp := range db.RetentionPolicies {
+++				_ = b.AppendString(0, db.Name+"/"+rp.Name)
+++				_ = b.AppendString(1, "")
+++				_ = b.AppendString(2, "influxdb")
+++				_ = b.AppendString(3, "")
+++				_ = b.AppendString(4, rp.Name)
+++				_ = b.AppendInt(5, rp.Duration.Nanoseconds())
+++			}
+++		}
++ 	}
++ 
++ 	return b.Table()
++@@ -103,25 +108,45 @@
++ 	// the dependencies used for FromKind are adequate for what we need here
++ 	// so there's no need to inject custom dependencies for buckets()
++ 	deps := a.Dependencies()[influxdb.BucketsKind].(BucketDependencies)
++-	req := query.RequestFromContext(a.Context())
++-	if req == nil {
++-		return nil, errors.New("missing request on context")
+++
+++	var user meta.User
+++	if deps.AuthEnabled {
+++		user = meta.UserFromContext(a.Context())
+++		if user == nil {
+++			return nil, errors.New("createBucketsSource: no user")
+++		}
++ 	}
++-	orgID := req.OrganizationID
++ 
++-	bd := &BucketsDecoder{orgID: orgID, deps: deps, alloc: a.Allocator()}
+++	bd := &BucketsDecoder{deps: deps, alloc: a.Allocator(), user: user}
++ 
++ 	return execute.CreateSourceFromDecoder(bd, dsid, a)
+++
+++}
+++
+++type MetaClient interface {
+++	Databases() []meta.DatabaseInfo
+++	Database(name string) *meta.DatabaseInfo
++ }
++ 
++-type AllBucketLookup interface {
++-	FindAllBuckets(orgID platform.ID) ([]*platform.Bucket, int)
+++type BucketDependencies struct {
+++	MetaClient  MetaClient
+++	Authorizer  Authorizer
+++	AuthEnabled bool
+++}
+++
+++func (d BucketDependencies) Validate() error {
+++	if d.MetaClient == nil {
+++		return errors.New("validate BucketDependencies: missing MetaClient")
+++	}
+++	if d.AuthEnabled && d.Authorizer == nil {
+++		return errors.New("validate BucketDependencies: missing Authorizer")
+++	}
+++	return nil
++ }
++-type BucketDependencies AllBucketLookup
++ 
++ func InjectBucketDependencies(depsMap execute.Dependencies, deps BucketDependencies) error {
++-	if deps == nil {
++-		return errors.New("missing all bucket lookup dependency")
+++	if err := deps.Validate(); err != nil {
+++		return err
++ 	}
++ 	depsMap[influxdb.BucketsKind] = deps
++ 	return nil
++diff -ur a/flux/stdlib/influxdata/influxdb/from.go b/flux/stdlib/influxdata/influxdb/from.go
++--- a/flux/stdlib/influxdata/influxdb/from.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/flux/stdlib/influxdata/influxdb/from.go	2019-06-25 13:49:49.000000000 -0500
++@@ -8,7 +8,6 @@
++ 	"github.com/influxdata/flux/plan"
++ 	"github.com/influxdata/flux/semantic"
++ 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
++-	platform "github.com/influxdata/influxdb"
++ 	"github.com/pkg/errors"
++ )
++ 
++@@ -66,31 +65,6 @@
++ 	return FromKind
++ }
++ 
++-// BucketsAccessed makes FromOpSpec a query.BucketAwareOperationSpec
++-func (s *FromOpSpec) BucketsAccessed(orgID *platform.ID) (readBuckets, writeBuckets []platform.BucketFilter) {
++-	bf := platform.BucketFilter{}
++-	if s.Bucket != "" {
++-		bf.Name = &s.Bucket
++-	}
++-	if orgID != nil {
++-		bf.OrganizationID = orgID
++-	}
++-
++-	if len(s.BucketID) > 0 {
++-		if id, err := platform.IDFromString(s.BucketID); err != nil {
++-			invalidID := platform.InvalidID()
++-			bf.ID = &invalidID
++-		} else {
++-			bf.ID = id
++-		}
++-	}
++-
++-	if bf.ID != nil || bf.Name != nil {
++-		readBuckets = append(readBuckets, bf)
++-	}
++-	return readBuckets, writeBuckets
++-}
++-
++ type FromProcedureSpec struct {
++ 	Bucket   string
++ 	BucketID string
++diff -ur a/flux/stdlib/influxdata/influxdb/operators.go b/flux/stdlib/influxdata/influxdb/operators.go
++--- a/flux/stdlib/influxdata/influxdb/operators.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/flux/stdlib/influxdata/influxdb/operators.go	2019-06-25 13:49:49.000000000 -0500
++@@ -3,13 +3,15 @@
++ import (
++ 	"context"
++ 	"errors"
++-	"fmt"
+++	"strings"
++ 
++ 	"github.com/influxdata/flux"
+++	"github.com/influxdata/flux/execute"
++ 	"github.com/influxdata/flux/plan"
++ 	"github.com/influxdata/flux/semantic"
++ 	"github.com/influxdata/flux/values"
++-	"github.com/influxdata/influxdb"
+++	"github.com/influxdata/influxdb/services/meta"
+++	"github.com/influxdata/influxql"
++ )
++ 
++ const (
++@@ -79,24 +81,43 @@
++ 	return ns
++ }
++ 
++-func (s *ReadRangePhysSpec) LookupBucketID(ctx context.Context, orgID influxdb.ID, buckets BucketLookup) (influxdb.ID, error) {
++-	// Determine bucketID
++-	switch {
++-	case s.Bucket != "":
++-		b, ok := buckets.Lookup(ctx, orgID, s.Bucket)
++-		if !ok {
++-			return 0, fmt.Errorf("could not find bucket %q", s.Bucket)
+++func (s *ReadRangePhysSpec) LookupDatabase(ctx context.Context, deps Dependencies, a execute.Administration) (string, string, error) {
+++	if len(s.BucketID) != 0 {
+++		return "", "", errors.New("cannot refer to buckets by their id in 1.x")
+++	}
+++
+++	var db, rp string
+++	if i := strings.IndexByte(s.Bucket, '/'); i == -1 {
+++		db = s.Bucket
+++	} else {
+++		rp = s.Bucket[i+1:]
+++		db = s.Bucket[:i]
+++	}
+++
+++	// validate and resolve db/rp
+++	di := deps.MetaClient.Database(db)
+++	if di == nil {
+++		return "", "", errors.New("no database")
+++	}
+++
+++	if deps.AuthEnabled {
+++		user := meta.UserFromContext(a.Context())
+++		if user == nil {
+++			return "", "", errors.New("createFromSource: no user")
++ 		}
++-		return b, nil
++-	case len(s.BucketID) != 0:
++-		var b influxdb.ID
++-		if err := b.DecodeFromString(s.BucketID); err != nil {
++-			return 0, err
+++		if err := deps.Authorizer.AuthorizeDatabase(user, influxql.ReadPrivilege, db); err != nil {
+++			return "", "", err
++ 		}
++-		return b, nil
++-	default:
++-		return 0, errors.New("no bucket name or id have been specified")
++ 	}
+++
+++	if rp == "" {
+++		rp = di.DefaultRetentionPolicy
+++	}
+++
+++	if rpi := di.RetentionPolicy(rp); rpi == nil {
+++		return "", "", errors.New("invalid retention policy")
+++	}
+++	return db, rp, nil
++ }
++ 
++ // TimeBounds implements plan.BoundsAwareProcedureSpec.
++diff -ur a/flux/stdlib/influxdata/influxdb/rules.go b/flux/stdlib/influxdata/influxdb/rules.go
++--- a/flux/stdlib/influxdata/influxdb/rules.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/flux/stdlib/influxdata/influxdb/rules.go	2019-06-25 13:49:50.000000000 -0500
++@@ -190,6 +190,12 @@
++ 	// constructing our own replacement. We do not care about it
++ 	// at the moment though which is why it is not in the pattern.
++ 
+++	// The tag keys mechanism doesn't know about fields so we cannot
+++	// push down _field comparisons in 1.x.
+++	if hasFieldExpr(fromSpec.Filter) {
+++		return pn, false, nil
+++	}
+++
++ 	// The schema mutator needs to correspond to a keep call
++ 	// on the column specified by the keys procedure.
++ 	if len(keepSpec.Mutations) != 1 {
++@@ -219,6 +225,20 @@
++ 	}), true, nil
++ }
++ 
+++func hasFieldExpr(expr semantic.Expression) bool {
+++	hasField := false
+++	v := semantic.CreateVisitor(func(node semantic.Node) {
+++		switch n := node.(type) {
+++		case *semantic.MemberExpression:
+++			if n.Property == "_field" {
+++				hasField = true
+++			}
+++		}
+++	})
+++	semantic.Walk(v, expr)
+++	return hasField
+++}
+++
++ // PushDownReadTagValuesRule matches 'ReadRange |> keep(columns: [tag]) |> group() |> distinct(column: tag)'.
++ // The 'from()' must have already been merged with 'range' and, optionally,
++ // may have been merged with 'filter'.
++@@ -296,6 +316,9 @@
++ 	execute.DefaultValueColLabel,
++ 	execute.DefaultStartColLabel,
++ 	execute.DefaultStopColLabel,
+++	// TODO(jsternberg): There just doesn't seem to be a good way to do this
+++	// in the 1.x line of the release.
+++	"_field",
++ }
++ 
++ // isValidTagKeyForTagValues returns true if the given key can
++diff -ur a/flux/stdlib/influxdata/influxdb/rules_test.go b/flux/stdlib/influxdata/influxdb/rules_test.go
++--- a/flux/stdlib/influxdata/influxdb/rules_test.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/flux/stdlib/influxdata/influxdb/rules_test.go	2019-06-25 13:49:49.000000000 -0500
++@@ -11,7 +11,7 @@
++ 	"github.com/influxdata/flux/plan/plantest"
++ 	"github.com/influxdata/flux/semantic"
++ 	"github.com/influxdata/flux/stdlib/universe"
++-	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
+++	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
++ )
++ 
++ func fluxTime(t int64) flux.Time {
++diff -ur a/flux/stdlib/influxdata/influxdb/source.go b/flux/stdlib/influxdata/influxdb/source.go
++--- a/flux/stdlib/influxdata/influxdb/source.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/flux/stdlib/influxdata/influxdb/source.go	2019-06-25 13:49:49.000000000 -0500
++@@ -9,8 +9,6 @@
++ 	"github.com/influxdata/flux/memory"
++ 	"github.com/influxdata/flux/plan"
++ 	"github.com/influxdata/flux/semantic"
++-	"github.com/influxdata/influxdb/kit/tracing"
++-	"github.com/influxdata/influxdb/query"
++ 	"github.com/influxdata/influxdb/tsdb/cursors"
++ )
++ 
++@@ -131,8 +129,7 @@
++ }
++ 
++ func createReadFilterSource(s plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
++-	span, ctx := tracing.StartSpanFromContext(a.Context())
++-	defer span.Finish()
+++	ctx := a.Context()
++ 
++ 	spec := s.(*ReadRangePhysSpec)
++ 
++@@ -143,13 +140,7 @@
++ 
++ 	deps := a.Dependencies()[FromKind].(Dependencies)
++ 
++-	req := query.RequestFromContext(a.Context())
++-	if req == nil {
++-		return nil, errors.New("missing request on context")
++-	}
++-
++-	orgID := req.OrganizationID
++-	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
+++	db, rp, err := spec.LookupDatabase(ctx, deps, a)
++ 	if err != nil {
++ 		return nil, err
++ 	}
++@@ -162,10 +153,10 @@
++ 		id,
++ 		deps.Reader,
++ 		ReadFilterSpec{
++-			OrganizationID: orgID,
++-			BucketID:       bucketID,
++-			Bounds:         *bounds,
++-			Predicate:      filter,
+++			Database:        db,
+++			RetentionPolicy: rp,
+++			Bounds:          *bounds,
+++			Predicate:       filter,
++ 		},
++ 		a.Allocator(),
++ 	), nil
++@@ -204,8 +195,7 @@
++ }
++ 
++ func createReadGroupSource(s plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
++-	span, ctx := tracing.StartSpanFromContext(a.Context())
++-	defer span.Finish()
+++	ctx := a.Context()
++ 
++ 	spec := s.(*ReadGroupPhysSpec)
++ 
++@@ -216,13 +206,7 @@
++ 
++ 	deps := a.Dependencies()[FromKind].(Dependencies)
++ 
++-	req := query.RequestFromContext(a.Context())
++-	if req == nil {
++-		return nil, errors.New("missing request on context")
++-	}
++-
++-	orgID := req.OrganizationID
++-	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
+++	db, rp, err := spec.LookupDatabase(ctx, deps, a)
++ 	if err != nil {
++ 		return nil, err
++ 	}
++@@ -236,10 +220,10 @@
++ 		deps.Reader,
++ 		ReadGroupSpec{
++ 			ReadFilterSpec: ReadFilterSpec{
++-				OrganizationID: orgID,
++-				BucketID:       bucketID,
++-				Bounds:         *bounds,
++-				Predicate:      filter,
+++				Database:        db,
+++				RetentionPolicy: rp,
+++				Bounds:          *bounds,
+++				Predicate:       filter,
++ 			},
++ 			GroupMode:       ToGroupMode(spec.GroupMode),
++ 			GroupKeys:       spec.GroupKeys,
++@@ -250,18 +234,12 @@
++ }
++ 
++ func createReadTagKeysSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
++-	span, ctx := tracing.StartSpanFromContext(a.Context())
++-	defer span.Finish()
+++	ctx := a.Context()
++ 
++ 	spec := prSpec.(*ReadTagKeysPhysSpec)
++ 	deps := a.Dependencies()[FromKind].(Dependencies)
++-	req := query.RequestFromContext(a.Context())
++-	if req == nil {
++-		return nil, errors.New("missing request on context")
++-	}
++-	orgID := req.OrganizationID
++ 
++-	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
+++	db, rp, err := spec.LookupDatabase(ctx, deps, a)
++ 	if err != nil {
++ 		return nil, err
++ 	}
++@@ -277,10 +255,10 @@
++ 		deps.Reader,
++ 		ReadTagKeysSpec{
++ 			ReadFilterSpec: ReadFilterSpec{
++-				OrganizationID: orgID,
++-				BucketID:       bucketID,
++-				Bounds:         *bounds,
++-				Predicate:      filter,
+++				Database:        db,
+++				RetentionPolicy: rp,
+++				Bounds:          *bounds,
+++				Predicate:       filter,
++ 			},
++ 		},
++ 		a.Allocator(),
++@@ -314,18 +292,12 @@
++ }
++ 
++ func createReadTagValuesSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
++-	span, ctx := tracing.StartSpanFromContext(a.Context())
++-	defer span.Finish()
+++	ctx := a.Context()
++ 
++ 	spec := prSpec.(*ReadTagValuesPhysSpec)
++ 	deps := a.Dependencies()[FromKind].(Dependencies)
++-	req := query.RequestFromContext(a.Context())
++-	if req == nil {
++-		return nil, errors.New("missing request on context")
++-	}
++-	orgID := req.OrganizationID
++ 
++-	bucketID, err := spec.LookupBucketID(ctx, orgID, deps.BucketLookup)
+++	db, rp, err := spec.LookupDatabase(ctx, deps, a)
++ 	if err != nil {
++ 		return nil, err
++ 	}
++@@ -341,10 +313,10 @@
++ 		deps.Reader,
++ 		ReadTagValuesSpec{
++ 			ReadFilterSpec: ReadFilterSpec{
++-				OrganizationID: orgID,
++-				BucketID:       bucketID,
++-				Bounds:         *bounds,
++-				Predicate:      filter,
+++				Database:        db,
+++				RetentionPolicy: rp,
+++				Bounds:          *bounds,
+++				Predicate:       filter,
++ 			},
++ 			TagKey: spec.TagKey,
++ 		},
++diff -ur a/flux/stdlib/influxdata/influxdb/storage.go b/flux/stdlib/influxdata/influxdb/storage.go
++--- a/flux/stdlib/influxdata/influxdb/storage.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/flux/stdlib/influxdata/influxdb/storage.go	2019-06-25 13:49:49.000000000 -0500
++@@ -8,61 +8,36 @@
++ 	"github.com/influxdata/flux/execute"
++ 	"github.com/influxdata/flux/memory"
++ 	"github.com/influxdata/flux/semantic"
++-	platform "github.com/influxdata/influxdb"
+++	"github.com/influxdata/influxdb/services/meta"
++ 	"github.com/influxdata/influxdb/tsdb/cursors"
+++	"github.com/influxdata/influxql"
++ 	"github.com/pkg/errors"
++ )
++ 
++-type HostLookup interface {
++-	Hosts() []string
++-	Watch() <-chan struct{}
++-}
++-
++-type BucketLookup interface {
++-	Lookup(ctx context.Context, orgID platform.ID, name string) (platform.ID, bool)
++-}
++-
++-type OrganizationLookup interface {
++-	Lookup(ctx context.Context, name string) (platform.ID, bool)
+++type Authorizer interface {
+++	AuthorizeDatabase(u meta.User, priv influxql.Privilege, database string) error
++ }
++ 
++ type Dependencies struct {
++-	Reader             Reader
++-	BucketLookup       BucketLookup
++-	OrganizationLookup OrganizationLookup
+++	Reader      Reader
+++	MetaClient  MetaClient
+++	Authorizer  Authorizer
+++	AuthEnabled bool
++ }
++ 
++ func (d Dependencies) Validate() error {
++ 	if d.Reader == nil {
++ 		return errors.New("missing reader dependency")
++ 	}
++-	if d.BucketLookup == nil {
++-		return errors.New("missing bucket lookup dependency")
+++	if d.MetaClient == nil {
+++		return errors.New("missing meta client dependency")
++ 	}
++-	if d.OrganizationLookup == nil {
++-		return errors.New("missing organization lookup dependency")
+++	if d.AuthEnabled && d.Authorizer == nil {
+++		return errors.New("validate Dependencies: missing Authorizer")
++ 	}
++ 	return nil
++ }
++ 
++-type StaticLookup struct {
++-	hosts []string
++-}
++-
++-func NewStaticLookup(hosts []string) StaticLookup {
++-	return StaticLookup{
++-		hosts: hosts,
++-	}
++-}
++-
++-func (l StaticLookup) Hosts() []string {
++-	return l.hosts
++-}
++-func (l StaticLookup) Watch() <-chan struct{} {
++-	// A nil channel always blocks, since hosts never change this is appropriate.
++-	return nil
++-}
++-
++ type GroupMode int
++ 
++ const (
++@@ -85,8 +60,8 @@
++ }
++ 
++ type ReadFilterSpec struct {
++-	OrganizationID platform.ID
++-	BucketID       platform.ID
+++	Database        string
+++	RetentionPolicy string
++ 
++ 	Bounds execute.Bounds
++ 
++diff -ur a/flux/stdlib/influxdata/influxdb/v1/databases.go b/flux/stdlib/influxdata/influxdb/v1/databases.go
++--- a/flux/stdlib/influxdata/influxdb/v1/databases.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/flux/stdlib/influxdata/influxdb/v1/databases.go	2019-06-25 10:03:53.000000000 -0500
++@@ -2,17 +2,19 @@
++ 
++ import (
++ 	"context"
+++	"errors"
++ 	"fmt"
++ 
++ 	"github.com/influxdata/flux"
++ 	"github.com/influxdata/flux/execute"
++ 	"github.com/influxdata/flux/memory"
++ 	"github.com/influxdata/flux/plan"
++-	"github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
+++	v1 "github.com/influxdata/flux/stdlib/influxdata/influxdb/v1"
++ 	"github.com/influxdata/flux/values"
++-	platform "github.com/influxdata/influxdb"
++-	"github.com/influxdata/influxdb/query"
++-	"github.com/pkg/errors"
+++	"github.com/influxdata/influxdb/coordinator"
+++	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
+++	"github.com/influxdata/influxdb/services/meta"
+++	"github.com/influxdata/influxql"
++ )
++ 
++ const DatabasesKind = v1.DatabasesKind
++@@ -66,9 +68,9 @@
++ }
++ 
++ type DatabasesDecoder struct {
++-	orgID     platform.ID
++-	deps      *DatabasesDependencies
++-	databases []*platform.DBRPMapping
+++	deps      *DatabaseDependencies
+++	databases []meta.DatabaseInfo
+++	user      meta.User
++ 	alloc     *memory.Allocator
++ 	ctx       context.Context
++ }
++@@ -78,20 +80,13 @@
++ }
++ 
++ func (bd *DatabasesDecoder) Fetch() (bool, error) {
++-	b, _, err := bd.deps.DBRP.FindMany(bd.ctx, platform.DBRPMappingFilter{})
++-	if err != nil {
++-		return false, err
++-	}
++-	bd.databases = b
+++	bd.databases = bd.deps.MetaClient.Databases()
++ 	return false, nil
++ }
++ 
++ func (bd *DatabasesDecoder) Decode() (flux.Table, error) {
++ 	kb := execute.NewGroupKeyBuilder(nil)
++-	if len(bd.databases) == 0 {
++-		return nil, errors.New("no 1.x databases found")
++-	}
++-	kb.AddKeyValue("organizationID", values.NewString(bd.databases[0].OrganizationID.String()))
+++	kb.AddKeyValue("organizationID", values.NewString(""))
++ 	gk, err := kb.Build()
++ 	if err != nil {
++ 		return nil, err
++@@ -136,16 +131,28 @@
++ 		return nil, err
++ 	}
++ 
+++	var hasAccess func(db string) bool
+++	if bd.user == nil {
+++		hasAccess = func(db string) bool {
+++			return true
+++		}
+++	} else {
+++		hasAccess = func(db string) bool {
+++			return bd.deps.Authorizer.AuthorizeDatabase(bd.user, influxql.ReadPrivilege, db) == nil ||
+++				bd.deps.Authorizer.AuthorizeDatabase(bd.user, influxql.WritePrivilege, db) == nil
+++		}
+++	}
+++
++ 	for _, db := range bd.databases {
++-		if bucket, err := bd.deps.BucketLookup.FindBucketByID(bd.ctx, db.BucketID); err != nil {
++-			return nil, err
++-		} else {
++-			_ = b.AppendString(0, db.OrganizationID.String())
++-			_ = b.AppendString(1, db.Database)
++-			_ = b.AppendString(2, db.RetentionPolicy)
++-			_ = b.AppendInt(3, bucket.RetentionPeriod.Nanoseconds())
++-			_ = b.AppendBool(4, db.Default)
++-			_ = b.AppendString(5, db.BucketID.String())
+++		if hasAccess(db.Name) {
+++			for _, rp := range db.RetentionPolicies {
+++				_ = b.AppendString(0, "")
+++				_ = b.AppendString(1, db.Name)
+++				_ = b.AppendString(2, rp.Name)
+++				_ = b.AppendInt(3, rp.Duration.Nanoseconds())
+++				_ = b.AppendBool(4, db.DefaultRetentionPolicy == rp.Name)
+++				_ = b.AppendString(5, "")
+++			}
++ 		}
++ 	}
++ 
++@@ -162,34 +169,31 @@
++ 		return nil, fmt.Errorf("invalid spec type %T", prSpec)
++ 	}
++ 
++-	// the dependencies used for FromKind are adequate for what we need here
++-	// so there's no need to inject custom dependencies for databases()
++-	deps := a.Dependencies()[DatabasesKind].(DatabasesDependencies)
++-	req := query.RequestFromContext(a.Context())
++-	if req == nil {
++-		return nil, errors.New("missing request on context")
+++	deps := a.Dependencies()[DatabasesKind].(DatabaseDependencies)
+++	var user meta.User
+++	if deps.AuthEnabled {
+++		user = meta.UserFromContext(a.Context())
+++		if user == nil {
+++			return nil, errors.New("createDatabasesSource: no user")
+++		}
++ 	}
++-	orgID := req.OrganizationID
++-
++-	bd := &DatabasesDecoder{orgID: orgID, deps: &deps, alloc: a.Allocator(), ctx: a.Context()}
++-
+++	bd := &DatabasesDecoder{deps: &deps, alloc: a.Allocator(), ctx: a.Context(), user: user}
++ 	return execute.CreateSourceFromDecoder(bd, dsid, a)
++ }
++ 
++-type DatabasesDependencies struct {
++-	DBRP         platform.DBRPMappingService
++-	BucketLookup platform.BucketService
+++type DatabaseDependencies struct {
+++	MetaClient  coordinator.MetaClient
+++	Authorizer  influxdb.Authorizer
+++	AuthEnabled bool
++ }
++ 
++-func InjectDatabasesDependencies(depsMap execute.Dependencies, deps DatabasesDependencies) error {
++-	if deps.DBRP == nil {
++-		return errors.New("missing all databases lookup dependency")
+++func InjectDatabaseDependencies(depsMap execute.Dependencies, deps DatabaseDependencies) error {
+++	if deps.MetaClient == nil {
+++		return errors.New("missing meta client dependency")
++ 	}
++-
++-	if deps.BucketLookup == nil {
++-		return errors.New("missing buckets lookup dependency")
+++	if deps.AuthEnabled && deps.Authorizer == nil {
+++		return errors.New("missing authorizer with auth enabled")
++ 	}
++-
++ 	depsMap[DatabasesKind] = deps
++ 	return nil
++ }
++diff -ur a/storage/reads/group_resultset.go b/storage/reads/group_resultset.go
++--- a/storage/reads/group_resultset.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/storage/reads/group_resultset.go	2019-06-25 13:49:49.000000000 -0500
++@@ -7,7 +7,6 @@
++ 	"math"
++ 	"sort"
++ 
++-	"github.com/influxdata/influxdb/kit/tracing"
++ 	"github.com/influxdata/influxdb/models"
++ 	"github.com/influxdata/influxdb/storage/reads/datatypes"
++ 	"github.com/influxdata/influxdb/tsdb/cursors"
++@@ -112,16 +111,7 @@
++ }
++ 
++ func (g *groupResultSet) sort() (int, error) {
++-	span, _ := tracing.StartSpanFromContext(g.ctx)
++-	defer span.Finish()
++-	span.LogKV("group_type", g.req.Group.String())
++-
++ 	n, err := g.sortFn(g)
++-
++-	if err != nil {
++-		span.LogKV("rows", n)
++-	}
++-
++ 	return n, err
++ }
++ 
++diff -ur a/storage/reads/group_resultset_test.go b/storage/reads/group_resultset_test.go
++--- a/storage/reads/group_resultset_test.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/storage/reads/group_resultset_test.go	2019-06-25 13:49:49.000000000 -0500
++@@ -394,7 +394,7 @@
++ 		vals[i] = gen.NewCounterByteSequenceCount(card[i])
++ 	}
++ 
++-	tags := gen.NewTagsValuesSequenceValues("m0", "f0", "tag", vals)
+++	tags := gen.NewTagsValuesSequenceValues("tag", vals)
++ 	rows := make([]reads.SeriesRow, tags.Count())
++ 	for i := range rows {
++ 		tags.Next()
++diff -ur a/storage/reads/reader.go b/storage/reads/reader.go
++--- a/storage/reads/reader.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/storage/reads/reader.go	2019-06-25 13:49:49.000000000 -0500
++@@ -10,8 +10,8 @@
++ 	"github.com/influxdata/flux/execute"
++ 	"github.com/influxdata/flux/memory"
++ 	"github.com/influxdata/flux/values"
+++	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
++ 	"github.com/influxdata/influxdb/models"
++-	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
++ 	"github.com/influxdata/influxdb/storage/reads/datatypes"
++ 	"github.com/influxdata/influxdb/tsdb/cursors"
++ )
++@@ -103,8 +103,8 @@
++ 
++ func (fi *filterIterator) Do(f func(flux.Table) error) error {
++ 	src := fi.s.GetSource(
++-		uint64(fi.spec.OrganizationID),
++-		uint64(fi.spec.BucketID),
+++		fi.spec.Database,
+++		fi.spec.RetentionPolicy,
++ 	)
++ 
++ 	// Setup read request
++@@ -225,8 +225,8 @@
++ 
++ func (gi *groupIterator) Do(f func(flux.Table) error) error {
++ 	src := gi.s.GetSource(
++-		uint64(gi.spec.OrganizationID),
++-		uint64(gi.spec.BucketID),
+++		gi.spec.Database,
+++		gi.spec.RetentionPolicy,
++ 	)
++ 
++ 	// Setup read request
++@@ -504,8 +504,8 @@
++ 
++ func (ti *tagKeysIterator) Do(f func(flux.Table) error) error {
++ 	src := ti.s.GetSource(
++-		uint64(ti.readSpec.OrganizationID),
++-		uint64(ti.readSpec.BucketID),
+++		ti.readSpec.Database,
+++		ti.readSpec.RetentionPolicy,
++ 	)
++ 
++ 	var req datatypes.TagKeysRequest
++@@ -586,8 +586,8 @@
++ 
++ func (ti *tagValuesIterator) Do(f func(flux.Table) error) error {
++ 	src := ti.s.GetSource(
++-		uint64(ti.readSpec.OrganizationID),
++-		uint64(ti.readSpec.BucketID),
+++		ti.readSpec.Database,
+++		ti.readSpec.RetentionPolicy,
++ 	)
++ 
++ 	var req datatypes.TagValuesRequest
++diff -ur a/storage/reads/store.go b/storage/reads/store.go
++--- a/storage/reads/store.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/storage/reads/store.go	2019-06-25 13:49:49.000000000 -0500
++@@ -80,5 +80,5 @@
++ 	TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error)
++ 	TagValues(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error)
++ 
++-	GetSource(orgID, bucketID uint64) proto.Message
+++	GetSource(db, rp string) proto.Message
++ }
++diff -ur a/storage/reads/table.go b/storage/reads/table.go
++--- a/storage/reads/table.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/storage/reads/table.go	2019-06-25 13:49:49.000000000 -0500
++@@ -1,7 +1,5 @@
++ package reads
++ 
++-//go:generate env GO111MODULE=on go run github.com/benbjohnson/tmpl -data=@types.tmpldata table.gen.go.tmpl
++-
++ import (
++ 	"sync/atomic"
++ 
++diff -ur a/tsdb/cursors/gen.go b/tsdb/cursors/gen.go
++--- a/tsdb/cursors/gen.go	2019-06-20 14:35:12.000000000 -0500
+++++ b/tsdb/cursors/gen.go	2019-06-25 14:00:51.000000000 -0500
++@@ -1,3 +1 @@
++ package cursors
++-
++-//go:generate env GO111MODULE=on go run github.com/benbjohnson/tmpl -data=@arrayvalues.gen.go.tmpldata arrayvalues.gen.go.tmpl
+diff --git b/storage/reads/group_resultset.go a/storage/reads/group_resultset.go
+index c7ed990bb..5d6ca33a4 100644
+--- b/storage/reads/group_resultset.go
++++ a/storage/reads/group_resultset.go
+@@ -7,7 +7,6 @@ import (
  	"math"
  	"sort"
  
@@ -789,7 +2359,7 @@ diff -ur a/storage/reads/group_resultset.go b/storage/reads/group_resultset.go
  	"github.com/influxdata/influxdb/models"
  	"github.com/influxdata/influxdb/storage/reads/datatypes"
  	"github.com/influxdata/influxdb/tsdb/cursors"
-@@ -112,16 +111,7 @@
+@@ -112,16 +111,7 @@ func (g *groupResultSet) Next() GroupCursor {
  }
  
  func (g *groupResultSet) sort() (int, error) {
@@ -806,10 +2376,11 @@ diff -ur a/storage/reads/group_resultset.go b/storage/reads/group_resultset.go
  	return n, err
  }
  
-diff -ur a/storage/reads/group_resultset_test.go b/storage/reads/group_resultset_test.go
---- a/storage/reads/group_resultset_test.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/storage/reads/group_resultset_test.go	2019-06-25 13:49:49.000000000 -0500
-@@ -394,7 +394,7 @@
+diff --git b/storage/reads/group_resultset_test.go a/storage/reads/group_resultset_test.go
+index ee13d1616..eb1fc91fc 100644
+--- b/storage/reads/group_resultset_test.go
++++ a/storage/reads/group_resultset_test.go
+@@ -394,7 +394,7 @@ func BenchmarkNewGroupResultSet_GroupBy(b *testing.B) {
  		vals[i] = gen.NewCounterByteSequenceCount(card[i])
  	}
  
@@ -818,10 +2389,185 @@ diff -ur a/storage/reads/group_resultset_test.go b/storage/reads/group_resultset
  	rows := make([]reads.SeriesRow, tags.Count())
  	for i := range rows {
  		tags.Next()
-diff -ur a/storage/reads/reader.go b/storage/reads/reader.go
---- a/storage/reads/reader.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/storage/reads/reader.go	2019-06-25 13:49:49.000000000 -0500
-@@ -10,8 +10,8 @@
+diff --git b/storage/reads/helpers_test.go a/storage/reads/helpers_test.go
+index d688ae365..ff8698b89 100644
+--- b/storage/reads/helpers_test.go
++++ a/storage/reads/helpers_test.go
+@@ -1,169 +1 @@
+ package reads_test
+-
+-import (
+-	"context"
+-
+-	"github.com/influxdata/influxdb/models"
+-	"github.com/influxdata/influxdb/pkg/data/gen"
+-	"github.com/influxdata/influxdb/storage/reads"
+-	"github.com/influxdata/influxdb/tsdb"
+-	"github.com/influxdata/influxdb/tsdb/cursors"
+-)
+-
+-type seriesGeneratorCursorIterator struct {
+-	g   gen.SeriesGenerator
+-	f   floatTimeValuesGeneratorCursor
+-	i   integerTimeValuesGeneratorCursor
+-	u   unsignedTimeValuesGeneratorCursor
+-	s   stringTimeValuesGeneratorCursor
+-	b   booleanTimeValuesGeneratorCursor
+-	cur cursors.Cursor
+-}
+-
+-func (ci *seriesGeneratorCursorIterator) Next(ctx context.Context, r *cursors.CursorRequest) (cursors.Cursor, error) {
+-	switch ci.g.FieldType() {
+-	case models.Float:
+-		ci.f.tv = ci.g.TimeValuesGenerator()
+-		ci.cur = &ci.f
+-	case models.Integer:
+-		ci.i.tv = ci.g.TimeValuesGenerator()
+-		ci.cur = &ci.i
+-	case models.Unsigned:
+-		ci.u.tv = ci.g.TimeValuesGenerator()
+-		ci.cur = &ci.u
+-	case models.String:
+-		ci.s.tv = ci.g.TimeValuesGenerator()
+-		ci.cur = &ci.s
+-	case models.Boolean:
+-		ci.b.tv = ci.g.TimeValuesGenerator()
+-		ci.cur = &ci.b
+-	default:
+-		panic("unreachable")
+-	}
+-
+-	return ci.cur, nil
+-}
+-
+-func (ci *seriesGeneratorCursorIterator) Stats() cursors.CursorStats {
+-	return ci.cur.Stats()
+-}
+-
+-type seriesGeneratorSeriesCursor struct {
+-	ci seriesGeneratorCursorIterator
+-	r  reads.SeriesRow
+-}
+-
+-func newSeriesGeneratorSeriesCursor(g gen.SeriesGenerator) *seriesGeneratorSeriesCursor {
+-	s := &seriesGeneratorSeriesCursor{}
+-	s.ci.g = g
+-	s.r.Query = tsdb.CursorIterators{&s.ci}
+-	return s
+-}
+-
+-func (s *seriesGeneratorSeriesCursor) Close()     {}
+-func (s *seriesGeneratorSeriesCursor) Err() error { return nil }
+-
+-func (s *seriesGeneratorSeriesCursor) Next() *reads.SeriesRow {
+-	if s.ci.g.Next() {
+-		s.r.SeriesTags = s.ci.g.Tags()
+-		s.r.Tags = s.ci.g.Tags()
+-		return &s.r
+-	}
+-	return nil
+-}
+-
+-type timeValuesGeneratorCursor struct {
+-	tv    gen.TimeValuesSequence
+-	stats cursors.CursorStats
+-}
+-
+-func (t timeValuesGeneratorCursor) Close()                     {}
+-func (t timeValuesGeneratorCursor) Err() error                 { return nil }
+-func (t timeValuesGeneratorCursor) Stats() cursors.CursorStats { return t.stats }
+-
+-type floatTimeValuesGeneratorCursor struct {
+-	timeValuesGeneratorCursor
+-	a tsdb.FloatArray
+-}
+-
+-func (c *floatTimeValuesGeneratorCursor) Next() *cursors.FloatArray {
+-	if c.tv.Next() {
+-		c.tv.Values().(gen.FloatValues).Copy(&c.a)
+-	} else {
+-		c.a.Timestamps = c.a.Timestamps[:0]
+-		c.a.Values = c.a.Values[:0]
+-	}
+-	c.stats.ScannedBytes += len(c.a.Values) * 8
+-	c.stats.ScannedValues += c.a.Len()
+-	return &c.a
+-}
+-
+-type integerTimeValuesGeneratorCursor struct {
+-	timeValuesGeneratorCursor
+-	a tsdb.IntegerArray
+-}
+-
+-func (c *integerTimeValuesGeneratorCursor) Next() *cursors.IntegerArray {
+-	if c.tv.Next() {
+-		c.tv.Values().(gen.IntegerValues).Copy(&c.a)
+-	} else {
+-		c.a.Timestamps = c.a.Timestamps[:0]
+-		c.a.Values = c.a.Values[:0]
+-	}
+-	c.stats.ScannedBytes += len(c.a.Values) * 8
+-	c.stats.ScannedValues += c.a.Len()
+-	return &c.a
+-}
+-
+-type unsignedTimeValuesGeneratorCursor struct {
+-	timeValuesGeneratorCursor
+-	a tsdb.UnsignedArray
+-}
+-
+-func (c *unsignedTimeValuesGeneratorCursor) Next() *cursors.UnsignedArray {
+-	if c.tv.Next() {
+-		c.tv.Values().(gen.UnsignedValues).Copy(&c.a)
+-	} else {
+-		c.a.Timestamps = c.a.Timestamps[:0]
+-		c.a.Values = c.a.Values[:0]
+-	}
+-	c.stats.ScannedBytes += len(c.a.Values) * 8
+-	c.stats.ScannedValues += c.a.Len()
+-	return &c.a
+-}
+-
+-type stringTimeValuesGeneratorCursor struct {
+-	timeValuesGeneratorCursor
+-	a tsdb.StringArray
+-}
+-
+-func (c *stringTimeValuesGeneratorCursor) Next() *cursors.StringArray {
+-	if c.tv.Next() {
+-		c.tv.Values().(gen.StringValues).Copy(&c.a)
+-	} else {
+-		c.a.Timestamps = c.a.Timestamps[:0]
+-		c.a.Values = c.a.Values[:0]
+-	}
+-	for _, v := range c.a.Values {
+-		c.stats.ScannedBytes += len(v)
+-	}
+-	c.stats.ScannedValues += c.a.Len()
+-	return &c.a
+-}
+-
+-type booleanTimeValuesGeneratorCursor struct {
+-	timeValuesGeneratorCursor
+-	a tsdb.BooleanArray
+-}
+-
+-func (c *booleanTimeValuesGeneratorCursor) Next() *cursors.BooleanArray {
+-	if c.tv.Next() {
+-		c.tv.Values().(gen.BooleanValues).Copy(&c.a)
+-	} else {
+-		c.a.Timestamps = c.a.Timestamps[:0]
+-		c.a.Values = c.a.Values[:0]
+-	}
+-	c.stats.ScannedBytes += len(c.a.Values)
+-	c.stats.ScannedValues += c.a.Len()
+-	return &c.a
+-}
+diff --git b/storage/reads/reader.go a/storage/reads/reader.go
+index f9765dbe1..38acd4157 100644
+--- b/storage/reads/reader.go
++++ a/storage/reads/reader.go
+@@ -10,8 +10,8 @@ import (
  	"github.com/influxdata/flux/execute"
  	"github.com/influxdata/flux/memory"
  	"github.com/influxdata/flux/values"
@@ -831,7 +2577,7 @@ diff -ur a/storage/reads/reader.go b/storage/reads/reader.go
  	"github.com/influxdata/influxdb/storage/reads/datatypes"
  	"github.com/influxdata/influxdb/tsdb/cursors"
  )
-@@ -103,8 +103,8 @@
+@@ -103,8 +103,8 @@ func (fi *filterIterator) Statistics() cursors.CursorStats { return fi.stats }
  
  func (fi *filterIterator) Do(f func(flux.Table) error) error {
  	src := fi.s.GetSource(
@@ -842,7 +2588,7 @@ diff -ur a/storage/reads/reader.go b/storage/reads/reader.go
  	)
  
  	// Setup read request
-@@ -225,8 +225,8 @@
+@@ -225,8 +225,8 @@ func (gi *groupIterator) Statistics() cursors.CursorStats { return gi.stats }
  
  func (gi *groupIterator) Do(f func(flux.Table) error) error {
  	src := gi.s.GetSource(
@@ -853,7 +2599,7 @@ diff -ur a/storage/reads/reader.go b/storage/reads/reader.go
  	)
  
  	// Setup read request
-@@ -504,8 +504,8 @@
+@@ -504,8 +504,8 @@ type tagKeysIterator struct {
  
  func (ti *tagKeysIterator) Do(f func(flux.Table) error) error {
  	src := ti.s.GetSource(
@@ -864,7 +2610,7 @@ diff -ur a/storage/reads/reader.go b/storage/reads/reader.go
  	)
  
  	var req datatypes.TagKeysRequest
-@@ -586,8 +586,8 @@
+@@ -586,8 +586,8 @@ type tagValuesIterator struct {
  
  func (ti *tagValuesIterator) Do(f func(flux.Table) error) error {
  	src := ti.s.GetSource(
@@ -875,30 +2621,477 @@ diff -ur a/storage/reads/reader.go b/storage/reads/reader.go
  	)
  
  	var req datatypes.TagValuesRequest
-diff -ur a/storage/reads/store.go b/storage/reads/store.go
---- a/storage/reads/store.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/storage/reads/store.go	2019-06-25 13:49:49.000000000 -0500
-@@ -80,5 +80,5 @@
+diff --git b/storage/reads/reader_test.go a/storage/reads/reader_test.go
+index 4d660b3ff..8cc72783a 100644
+--- b/storage/reads/reader_test.go
++++ a/storage/reads/reader_test.go
+@@ -9,8 +9,8 @@ import (
+ 	"github.com/influxdata/flux/execute"
+ 	"github.com/influxdata/flux/execute/executetest"
+ 	"github.com/influxdata/flux/memory"
++	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
+ 	"github.com/influxdata/influxdb/mock"
+-	"github.com/influxdata/influxdb/query/stdlib/influxdata/influxdb"
+ 	"github.com/influxdata/influxdb/storage/reads"
+ 	"github.com/influxdata/influxdb/storage/reads/datatypes"
+ 	"github.com/influxdata/influxdb/tsdb/cursors"
+diff --git b/storage/reads/response_writer_test.go a/storage/reads/response_writer_test.go
+index 0916c822b..0abaf7544 100644
+--- b/storage/reads/response_writer_test.go
++++ a/storage/reads/response_writer_test.go
+@@ -1,21 +1,12 @@
+ package reads_test
+ 
+ import (
+-	"context"
+-	"errors"
+ 	"fmt"
+ 	"reflect"
+-	"strings"
+ 	"testing"
+-	"time"
+ 
+-	"github.com/influxdata/influxdb"
+ 	"github.com/influxdata/influxdb/mock"
+-	"github.com/influxdata/influxdb/pkg/data/gen"
+-	"github.com/influxdata/influxdb/pkg/testing/assert"
+ 	"github.com/influxdata/influxdb/storage/reads"
+-	"github.com/influxdata/influxdb/storage/reads/datatypes"
+-	"github.com/influxdata/influxdb/tsdb"
+ 	"github.com/influxdata/influxdb/tsdb/cursors"
+ 	"google.golang.org/grpc/metadata"
+ )
+@@ -132,403 +123,3 @@ func TestResponseWriter_WriteGroupResultSet_Stats(t *testing.T) {
+ 		t.Errorf("expected scanned-bytes '%v' but got '%v'", []string{fmt.Sprint(scannedBytes)}, gotTrailer.Get("scanned-bytes"))
+ 	}
+ }
+-
+-var (
+-	org         = influxdb.ID(0xff00ff00)
+-	bucket      = influxdb.ID(0xcc00cc00)
+-	orgBucketID = tsdb.EncodeName(org, bucket)
+-)
+-
+-func makeTypedSeries(m, prefix, field string, val interface{}, valueCount int, counts ...int) gen.SeriesGenerator {
+-	spec := gen.TimeSequenceSpec{Count: valueCount, Start: time.Unix(0, 0), Delta: time.Second}
+-	ts := gen.NewTimestampSequenceFromSpec(spec)
+-	var vg gen.TimeValuesSequence
+-	switch val := val.(type) {
+-	case float64:
+-		vg = gen.NewTimeFloatValuesSequence(spec.Count, ts, gen.NewFloatConstantValuesSequence(val))
+-	case int64:
+-		vg = gen.NewTimeIntegerValuesSequence(spec.Count, ts, gen.NewIntegerConstantValuesSequence(val))
+-	case int:
+-		vg = gen.NewTimeIntegerValuesSequence(spec.Count, ts, gen.NewIntegerConstantValuesSequence(int64(val)))
+-	case uint64:
+-		vg = gen.NewTimeUnsignedValuesSequence(spec.Count, ts, gen.NewUnsignedConstantValuesSequence(val))
+-	case string:
+-		vg = gen.NewTimeStringValuesSequence(spec.Count, ts, gen.NewStringConstantValuesSequence(val))
+-	case bool:
+-		vg = gen.NewTimeBooleanValuesSequence(spec.Count, ts, gen.NewBooleanConstantValuesSequence(val))
+-	default:
+-		panic(fmt.Sprintf("unexpected type %T", val))
+-	}
+-
+-	return gen.NewSeriesGenerator(orgBucketID, []byte(field), vg, gen.NewTagsValuesSequenceCounts(m, field, prefix, counts))
+-}
+-
+-type sendSummary struct {
+-	groupCount    int
+-	seriesCount   int
+-	floatCount    int
+-	integerCount  int
+-	unsignedCount int
+-	stringCount   int
+-	booleanCount  int
+-}
+-
+-func (ss *sendSummary) makeSendFunc() func(*datatypes.ReadResponse) error {
+-	return func(r *datatypes.ReadResponse) error {
+-		for i := range r.Frames {
+-			d := r.Frames[i].Data
+-			switch p := d.(type) {
+-			case *datatypes.ReadResponse_Frame_FloatPoints:
+-				ss.floatCount += len(p.FloatPoints.Values)
+-			case *datatypes.ReadResponse_Frame_IntegerPoints:
+-				ss.integerCount += len(p.IntegerPoints.Values)
+-			case *datatypes.ReadResponse_Frame_UnsignedPoints:
+-				ss.unsignedCount += len(p.UnsignedPoints.Values)
+-			case *datatypes.ReadResponse_Frame_StringPoints:
+-				ss.stringCount += len(p.StringPoints.Values)
+-			case *datatypes.ReadResponse_Frame_BooleanPoints:
+-				ss.booleanCount += len(p.BooleanPoints.Values)
+-			case *datatypes.ReadResponse_Frame_Series:
+-				ss.seriesCount++
+-			case *datatypes.ReadResponse_Frame_Group:
+-				ss.groupCount++
+-			default:
+-				panic("unexpected")
+-			}
+-		}
+-		return nil
+-	}
+-}
+-
+-func TestResponseWriter_WriteResultSet(t *testing.T) {
+-	t.Run("normal", func(t *testing.T) {
+-		t.Run("all types one series each", func(t *testing.T) {
+-			exp := sendSummary{
+-				seriesCount:   5,
+-				floatCount:    500,
+-				integerCount:  400,
+-				unsignedCount: 300,
+-				stringCount:   200,
+-				booleanCount:  100,
+-			}
+-			var ss sendSummary
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = ss.makeSendFunc()
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			var gens []gen.SeriesGenerator
+-
+-			gens = append(gens, makeTypedSeries("m0", "t", "ff", 3.3, exp.floatCount, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "if", 100, exp.integerCount, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "uf", uint64(25), exp.unsignedCount, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "sf", "foo", exp.stringCount, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "bf", false, exp.booleanCount, 1))
+-
+-			cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+-			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+-			err := w.WriteResultSet(rs)
+-			if err != nil {
+-				t.Fatalf("unexpected err: %v", err)
+-			}
+-			w.Flush()
+-
+-			assert.Equal(t, ss, exp)
+-		})
+-		t.Run("multi-series floats", func(t *testing.T) {
+-			exp := sendSummary{
+-				seriesCount: 5,
+-				floatCount:  8600,
+-			}
+-			var ss sendSummary
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = ss.makeSendFunc()
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			var gens []gen.SeriesGenerator
+-			gens = append(gens, makeTypedSeries("m0", "t", "f0", 3.3, 2000, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "f1", 5.3, 1500, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "f2", 5.3, 2500, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "f3", -2.2, 900, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "f4", -9.2, 1700, 1))
+-
+-			cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+-			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+-			err := w.WriteResultSet(rs)
+-			if err != nil {
+-				t.Fatalf("unexpected err: %v", err)
+-			}
+-			w.Flush()
+-
+-			assert.Equal(t, ss, exp)
+-		})
+-
+-		t.Run("multi-series strings", func(t *testing.T) {
+-			exp := sendSummary{
+-				seriesCount: 4,
+-				stringCount: 6900,
+-			}
+-			var ss sendSummary
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = ss.makeSendFunc()
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			var gens []gen.SeriesGenerator
+-			gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 100), 2000, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 200), 1500, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "s2", strings.Repeat("ccc", 300), 2500, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "s3", strings.Repeat("ddd", 200), 900, 1))
+-
+-			cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+-			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+-			err := w.WriteResultSet(rs)
+-			if err != nil {
+-				t.Fatalf("unexpected err: %v", err)
+-			}
+-			w.Flush()
+-
+-			assert.Equal(t, ss, exp)
+-		})
+-
+-		t.Run("writer doesn't send series with no values", func(t *testing.T) {
+-			exp := sendSummary{
+-				seriesCount: 2,
+-				stringCount: 3700,
+-			}
+-			var ss sendSummary
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = ss.makeSendFunc()
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			var gens []gen.SeriesGenerator
+-			gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 100), 2000, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 200), 0, 1))
+-			gens = append(gens, makeTypedSeries("m0", "t", "s2", strings.Repeat("ccc", 100), 1700, 1))
+-			cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+-
+-			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+-			err := w.WriteResultSet(rs)
+-			if err != nil {
+-				t.Fatalf("unexpected err: %v", err)
+-			}
+-			w.Flush()
+-
+-			assert.Equal(t, ss, exp)
+-		})
+-	})
+-
+-	t.Run("error conditions", func(t *testing.T) {
+-		t.Run("writer returns stream error", func(t *testing.T) {
+-			exp := errors.New("no write")
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = func(r *datatypes.ReadResponse) error { return exp }
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			cur := newSeriesGeneratorSeriesCursor(makeTypedSeries("m0", "t", "f0", strings.Repeat("0", 1000), 2000, 1))
+-			rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+-			_ = w.WriteResultSet(rs)
+-			assert.Equal(t, w.Err(), exp)
+-		})
+-	})
+-
+-	t.Run("issues", func(t *testing.T) {
+-		t.Run("short write", func(t *testing.T) {
+-			t.Run("single string series", func(t *testing.T) {
+-				exp := sendSummary{seriesCount: 1, stringCount: 1020}
+-				var ss sendSummary
+-
+-				stream := mock.NewResponseStream()
+-				stream.SendFunc = ss.makeSendFunc()
+-				w := reads.NewResponseWriter(stream, 0)
+-
+-				cur := newSeriesGeneratorSeriesCursor(makeTypedSeries("m0", "t", "f0", strings.Repeat("0", 1000), exp.stringCount, 1))
+-				rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+-				err := w.WriteResultSet(rs)
+-				if err != nil {
+-					t.Fatalf("unexpected err: %v", err)
+-				}
+-				w.Flush()
+-
+-				assert.Equal(t, ss, exp)
+-			})
+-
+-			t.Run("single float series", func(t *testing.T) {
+-				exp := sendSummary{seriesCount: 1, floatCount: 50500}
+-				var ss sendSummary
+-
+-				stream := mock.NewResponseStream()
+-				stream.SendFunc = ss.makeSendFunc()
+-				w := reads.NewResponseWriter(stream, 0)
+-
+-				cur := newSeriesGeneratorSeriesCursor(makeTypedSeries("m0", "t", "f0", 5.5, exp.floatCount, 1))
+-				rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+-				err := w.WriteResultSet(rs)
+-				if err != nil {
+-					t.Fatalf("unexpected err: %v", err)
+-				}
+-				w.Flush()
+-
+-				assert.Equal(t, ss, exp)
+-			})
+-
+-			t.Run("multi series", func(t *testing.T) {
+-				exp := sendSummary{seriesCount: 2, stringCount: 3700}
+-				var ss sendSummary
+-
+-				stream := mock.NewResponseStream()
+-				stream.SendFunc = ss.makeSendFunc()
+-				w := reads.NewResponseWriter(stream, 0)
+-
+-				var gens []gen.SeriesGenerator
+-				gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 1000), 2200, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 1000), 1500, 1))
+-
+-				cur := newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens))
+-				rs := reads.NewFilteredResultSet(context.Background(), &datatypes.ReadFilterRequest{}, cur)
+-				err := w.WriteResultSet(rs)
+-				if err != nil {
+-					t.Fatalf("unexpected err: %v", err)
+-				}
+-				w.Flush()
+-
+-				assert.Equal(t, ss, exp)
+-			})
+-		})
+-	})
+-}
+-
+-func TestResponseWriter_WriteGroupResultSet(t *testing.T) {
+-	t.Run("normal", func(t *testing.T) {
+-		t.Run("all types one series each", func(t *testing.T) {
+-			exp := sendSummary{
+-				groupCount:    1,
+-				seriesCount:   5,
+-				floatCount:    500,
+-				integerCount:  400,
+-				unsignedCount: 300,
+-				stringCount:   200,
+-				booleanCount:  100,
+-			}
+-			var ss sendSummary
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = ss.makeSendFunc()
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			newCursor := func() (cursor reads.SeriesCursor, e error) {
+-				var gens []gen.SeriesGenerator
+-				gens = append(gens, makeTypedSeries("m0", "t", "ff", 3.3, exp.floatCount, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "if", 100, exp.integerCount, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "uf", uint64(25), exp.unsignedCount, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "sf", "foo", exp.stringCount, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "bf", false, exp.booleanCount, 1))
+-				return newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens)), nil
+-			}
+-
+-			rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupNone}, newCursor)
+-			err := w.WriteGroupResultSet(rs)
+-			if err != nil {
+-				t.Fatalf("unexpected err: %v", err)
+-			}
+-			w.Flush()
+-
+-			assert.Equal(t, ss, exp)
+-		})
+-		t.Run("multi-series floats", func(t *testing.T) {
+-			exp := sendSummary{
+-				groupCount:  1,
+-				seriesCount: 5,
+-				floatCount:  8600,
+-			}
+-			var ss sendSummary
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = ss.makeSendFunc()
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			newCursor := func() (cursor reads.SeriesCursor, e error) {
+-				var gens []gen.SeriesGenerator
+-				gens = append(gens, makeTypedSeries("m0", "t", "f0", 3.3, 2000, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "f1", 5.3, 1500, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "f2", 5.3, 2500, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "f3", -2.2, 900, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "f4", -9.2, 1700, 1))
+-				return newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens)), nil
+-			}
+-
+-			rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupNone}, newCursor)
+-			err := w.WriteGroupResultSet(rs)
+-			if err != nil {
+-				t.Fatalf("unexpected err: %v", err)
+-			}
+-			w.Flush()
+-
+-			assert.Equal(t, ss, exp)
+-		})
+-
+-		t.Run("multi-series strings", func(t *testing.T) {
+-			exp := sendSummary{
+-				groupCount:  1,
+-				seriesCount: 4,
+-				stringCount: 6900,
+-			}
+-			var ss sendSummary
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = ss.makeSendFunc()
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			newCursor := func() (cursor reads.SeriesCursor, e error) {
+-				var gens []gen.SeriesGenerator
+-				gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 100), 2000, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 200), 1500, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "s2", strings.Repeat("ccc", 300), 2500, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "s3", strings.Repeat("ddd", 200), 900, 1))
+-				return newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens)), nil
+-			}
+-
+-			rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupNone}, newCursor)
+-			err := w.WriteGroupResultSet(rs)
+-			if err != nil {
+-				t.Fatalf("unexpected err: %v", err)
+-			}
+-			w.Flush()
+-
+-			assert.Equal(t, ss, exp)
+-		})
+-
+-		t.Run("writer doesn't send series with no values", func(t *testing.T) {
+-			exp := sendSummary{
+-				groupCount:  1,
+-				seriesCount: 2,
+-				stringCount: 3700,
+-			}
+-			var ss sendSummary
+-
+-			stream := mock.NewResponseStream()
+-			stream.SendFunc = ss.makeSendFunc()
+-			w := reads.NewResponseWriter(stream, 0)
+-
+-			newCursor := func() (cursor reads.SeriesCursor, e error) {
+-				var gens []gen.SeriesGenerator
+-				gens = append(gens, makeTypedSeries("m0", "t", "s0", strings.Repeat("aaa", 100), 2000, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "s1", strings.Repeat("bbb", 200), 0, 1))
+-				gens = append(gens, makeTypedSeries("m0", "t", "s2", strings.Repeat("ccc", 100), 1700, 1))
+-				return newSeriesGeneratorSeriesCursor(gen.NewMergedSeriesGenerator(gens)), nil
+-			}
+-
+-			rs := reads.NewGroupResultSet(context.Background(), &datatypes.ReadGroupRequest{Group: datatypes.GroupNone}, newCursor)
+-			err := w.WriteGroupResultSet(rs)
+-			if err != nil {
+-				t.Fatalf("unexpected err: %v", err)
+-			}
+-			w.Flush()
+-
+-			assert.Equal(t, ss, exp)
+-		})
+-	})
+-}
+diff --git b/storage/reads/store.go a/storage/reads/store.go
+index 8918794b3..655d12d21 100644
+--- b/storage/reads/store.go
++++ a/storage/reads/store.go
+@@ -80,5 +80,5 @@ type Store interface {
  	TagKeys(ctx context.Context, req *datatypes.TagKeysRequest) (cursors.StringIterator, error)
  	TagValues(ctx context.Context, req *datatypes.TagValuesRequest) (cursors.StringIterator, error)
  
 -	GetSource(orgID, bucketID uint64) proto.Message
 +	GetSource(db, rp string) proto.Message
  }
-diff -ur a/storage/reads/table.go b/storage/reads/table.go
---- a/storage/reads/table.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/storage/reads/table.go	2019-06-25 13:49:49.000000000 -0500
+diff --git b/storage/reads/table.go a/storage/reads/table.go
+index 32784a538..3aa7485e2 100644
+--- b/storage/reads/table.go
++++ a/storage/reads/table.go
 @@ -1,7 +1,5 @@
  package reads
  
 -//go:generate env GO111MODULE=on go run github.com/benbjohnson/tmpl -data=@types.tmpldata table.gen.go.tmpl
 -
  import (
+ 	"errors"
  	"sync/atomic"
- 
-diff -ur a/tsdb/cursors/gen.go b/tsdb/cursors/gen.go
---- a/tsdb/cursors/gen.go	2019-06-20 14:35:12.000000000 -0500
-+++ b/tsdb/cursors/gen.go	2019-06-25 14:00:51.000000000 -0500
+diff --git b/tsdb/cursors/gen.go a/tsdb/cursors/gen.go
+index 63316e5c0..ee7a8876a 100644
+--- b/tsdb/cursors/gen.go
++++ a/tsdb/cursors/gen.go
 @@ -1,3 +1 @@
  package cursors
 -

--- a/storage/reads/datatypes/storage_common.pb.go
+++ b/storage/reads/datatypes/storage_common.pb.go
@@ -989,7 +989,7 @@ var xxx_messageInfo_CapabilitiesResponse proto.InternalMessageInfo
 type TimestampRange struct {
 	// Start defines the inclusive lower bound.
 	Start int64 `protobuf:"varint,1,opt,name=start,proto3" json:"start,omitempty"`
-	// End defines the inclusive upper bound.
+	// End defines the exclusive upper bound.
 	End int64 `protobuf:"varint,2,opt,name=end,proto3" json:"end,omitempty"`
 }
 

--- a/storage/reads/datatypes/storage_common.proto
+++ b/storage/reads/datatypes/storage_common.proto
@@ -173,7 +173,7 @@ message TimestampRange {
   // Start defines the inclusive lower bound.
   int64 start = 1;
 
-  // End defines the inclusive upper bound.
+  // End defines the exclusive upper bound.
   int64 end = 2;
 }
 

--- a/storage/reads/helpers_test.go
+++ b/storage/reads/helpers_test.go
@@ -1,0 +1,1 @@
+package reads_test

--- a/storage/reads/reader.go
+++ b/storage/reads/reader.go
@@ -137,7 +137,7 @@ func (fi *filterIterator) Do(f func(flux.Table) error) error {
 		return nil
 	}
 
-	return fi.handleRead(f, rs)
+	return fi.handleRead(filterDuplicateTables(f), rs)
 }
 
 func (fi *filterIterator) handleRead(f func(flux.Table) error, rs ResultSet) error {
@@ -267,7 +267,7 @@ func (gi *groupIterator) Do(f func(flux.Table) error) error {
 	if rs == nil {
 		return nil
 	}
-	return gi.handleRead(f, rs)
+	return gi.handleRead(filterDuplicateTables(f), rs)
 }
 
 func (gi *groupIterator) handleRead(f func(flux.Table) error, rs GroupResultSet) error {
@@ -415,8 +415,8 @@ func determineTableColsForSeries(tags models.Tags, typ flux.ColType) ([]flux.Col
 }
 
 func defaultGroupKeyForSeries(tags models.Tags, bnds execute.Bounds) flux.GroupKey {
-	cols := make([]flux.ColMeta, 2, len(tags))
-	vs := make([]values.Value, 2, len(tags))
+	cols := make([]flux.ColMeta, 2, len(tags)+2)
+	vs := make([]values.Value, 2, len(tags)+2)
 	cols[0] = flux.ColMeta{
 		Label: execute.DefaultStartColLabel,
 		Type:  flux.TTime,
@@ -647,4 +647,28 @@ func (ti *tagValuesIterator) handleRead(f func(flux.Table) error, rs cursors.Str
 
 func (ti *tagValuesIterator) Statistics() cursors.CursorStats {
 	return cursors.CursorStats{}
+}
+
+type duplicateFilter struct {
+	f    func(tbl flux.Table) error
+	seen *execute.GroupLookup
+}
+
+func filterDuplicateTables(f func(tbl flux.Table) error) func(tbl flux.Table) error {
+	filter := &duplicateFilter{
+		f:    f,
+		seen: execute.NewGroupLookup(),
+	}
+	return filter.Process
+}
+
+func (df *duplicateFilter) Process(tbl flux.Table) error {
+	// Identify duplicate keys within the cursor.
+	if _, ok := df.seen.Lookup(tbl.Key()); ok {
+		// Discard this table.
+		tbl.Done()
+		return nil
+	}
+	df.seen.Set(tbl.Key(), true)
+	return df.f(tbl)
 }

--- a/storage/reads/reader_test.go
+++ b/storage/reads/reader_test.go
@@ -1,0 +1,124 @@
+package reads_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/influxdb/flux/stdlib/influxdata/influxdb"
+	"github.com/influxdata/influxdb/mock"
+	"github.com/influxdata/influxdb/storage/reads"
+	"github.com/influxdata/influxdb/storage/reads/datatypes"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+)
+
+func TestDuplicateKeys_ReadFilter(t *testing.T) {
+	closed := 0
+
+	s := mock.NewStoreReader()
+	s.ReadFilterFunc = func(ctx context.Context, req *datatypes.ReadFilterRequest) (reads.ResultSet, error) {
+		inputs := make([]cursors.Cursor, 2)
+		inputs[0] = func() cursors.Cursor {
+			called := false
+			cur := mock.NewFloatArrayCursor()
+			cur.NextFunc = func() *cursors.FloatArray {
+				if called {
+					return &cursors.FloatArray{}
+				}
+				called = true
+				return &cursors.FloatArray{
+					Timestamps: []int64{0},
+					Values:     []float64{1.0},
+				}
+			}
+			cur.CloseFunc = func() {
+				closed++
+			}
+			return cur
+		}()
+		inputs[1] = func() cursors.Cursor {
+			called := false
+			cur := mock.NewIntegerArrayCursor()
+			cur.NextFunc = func() *cursors.IntegerArray {
+				if called {
+					return &cursors.IntegerArray{}
+				}
+				called = true
+				return &cursors.IntegerArray{
+					Timestamps: []int64{10},
+					Values:     []int64{1},
+				}
+			}
+			cur.CloseFunc = func() {
+				closed++
+			}
+			return cur
+		}()
+
+		idx := -1
+		rs := mock.NewResultSet()
+		rs.NextFunc = func() bool {
+			idx++
+			return idx < len(inputs)
+		}
+		rs.CursorFunc = func() cursors.Cursor {
+			return inputs[idx]
+		}
+		rs.CloseFunc = func() {
+			idx = len(inputs)
+		}
+		return rs, nil
+	}
+
+	r := reads.NewReader(s)
+	ti, err := r.ReadFilter(context.Background(), influxdb.ReadFilterSpec{
+		Bounds: execute.Bounds{
+			Start: execute.Time(0),
+			Stop:  execute.Time(30),
+		},
+	}, &memory.Allocator{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var got []*executetest.Table
+	if err := ti.Do(func(tbl flux.Table) error {
+		t, err := executetest.ConvertTable(tbl)
+		if err != nil {
+			return err
+		}
+		got = append(got, t)
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	want := []*executetest.Table{
+		{
+			ColMeta: []flux.ColMeta{
+				{Label: "_start", Type: flux.TTime},
+				{Label: "_stop", Type: flux.TTime},
+				{Label: "_time", Type: flux.TTime},
+				{Label: "_value", Type: flux.TFloat},
+			},
+			KeyCols: []string{"_start", "_stop"},
+			Data: [][]interface{}{
+				{execute.Time(0), execute.Time(30), execute.Time(0), 1.0},
+			},
+		},
+	}
+	for _, tbl := range want {
+		tbl.Normalize()
+	}
+	if !cmp.Equal(want, got) {
+		t.Fatalf("unexpected output:\n%s", cmp.Diff(want, got))
+	}
+
+	if want, got := closed, 2; want != got {
+		t.Fatalf("unexpected count of closed cursors -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}

--- a/storage/reads/response_writer.go
+++ b/storage/reads/response_writer.go
@@ -31,7 +31,9 @@ type ResponseWriter struct {
 	// current series
 	sf *datatypes.ReadResponse_SeriesFrame
 	ss int // pointer to current series frame; used to skip writing if no points
-	sz int // estimated size in bytes for pending write
+	// sz is an estimated size in bytes for pending writes to flush periodically
+	// when the size exceeds writeSize.
+	sz int
 
 	vc int // total value count
 

--- a/storage/reads/stream_reader.go
+++ b/storage/reads/stream_reader.go
@@ -111,6 +111,12 @@ func (r *ResultSetStreamReader) Stats() cursors.CursorStats {
 	return r.fr.stats.Stats()
 }
 
+// Peek reads the next frame on the underlying stream-reader
+// if there is one
+func (r *ResultSetStreamReader) Peek() {
+	r.fr.peekFrame()
+}
+
 func (r *ResultSetStreamReader) Next() bool {
 	if r.fr.state == stateReadSeries {
 		return r.readSeriesFrame()
@@ -176,6 +182,12 @@ func NewGroupResultSetStreamReader(stream StreamReader) *GroupResultSetStreamRea
 }
 
 func (r *GroupResultSetStreamReader) Err() error { return r.fr.err }
+
+// Peek reads the next frame on the underlying stream-reader
+// if there is one
+func (r *GroupResultSetStreamReader) Peek() {
+	r.fr.peekFrame()
+}
 
 func (r *GroupResultSetStreamReader) Next() GroupCursor {
 	if r.fr.state == stateReadGroup {

--- a/storage/reads/stream_reader_test.go
+++ b/storage/reads/stream_reader_test.go
@@ -308,6 +308,10 @@ series: _m=cpu,tag0=val1
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs := reads.NewResultSetStreamReader(tt.stream)
+
+			// ensure a peek doesn't effect the end result
+			rs.Peek()
+
 			sb := new(strings.Builder)
 			ResultSetToString(sb, rs)
 
@@ -582,6 +586,10 @@ group:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rs := reads.NewGroupResultSetStreamReader(tt.stream)
+
+			// ensure a peek doesn't effect the end result
+			rs.Peek()
+
 			sb := new(strings.Builder)
 			GroupResultSetToString(sb, rs)
 

--- a/storage/reads/table.go
+++ b/storage/reads/table.go
@@ -1,6 +1,7 @@
 package reads
 
 import (
+	"errors"
 	"sync/atomic"
 
 	"github.com/apache/arrow/go/arrow/array"
@@ -27,8 +28,8 @@ type table struct {
 
 	err error
 
-	cancelled int32
-	alloc     *memory.Allocator
+	cancelled, used int32
+	alloc           *memory.Allocator
 }
 
 func newTable(
@@ -53,7 +54,7 @@ func newTable(
 func (t *table) Key() flux.GroupKey   { return t.key }
 func (t *table) Cols() []flux.ColMeta { return t.cols }
 func (t *table) Err() error           { return t.err }
-func (t *table) Empty() bool          { return false }
+func (t *table) Empty() bool          { return t.colBufs == nil || t.colBufs.l == 0 }
 
 func (t *table) Cancel() {
 	atomic.StoreInt32(&t.cancelled, 1)
@@ -63,25 +64,59 @@ func (t *table) isCancelled() bool {
 	return atomic.LoadInt32(&t.cancelled) != 0
 }
 
-// getBuffer will retrieve a suitable buffer for the
-// table implementations to use. If the existing buffer
-// is not used anymore, then it may be reused.
-func (t *table) getBuffer(l int) *colReader {
-	if t.colBufs != nil && atomic.LoadInt64(&t.colBufs.refCount) == 0 {
-		t.colBufs.refCount = 1
-		t.colBufs.l = l
-		return t.colBufs
+func (t *table) do(f func(flux.ColReader) error, advance func() bool) error {
+	// Mark this table as having been used. If this doesn't
+	// succeed, then this has already been invoked somewhere else.
+	if !atomic.CompareAndSwapInt32(&t.used, 0, 1) {
+		return errors.New("table already used")
+	}
+	defer t.closeDone()
+
+	if !t.Empty() {
+		t.err = f(t.colBufs)
+		t.colBufs.Release()
+
+		for !t.isCancelled() && t.err == nil && advance() {
+			t.err = f(t.colBufs)
+			t.colBufs.Release()
+		}
+		t.colBufs = nil
 	}
 
-	// The current buffer is still being used so we should
-	// generate a new one.
-	t.colBufs = &colReader{
-		refCount: 1,
-		key:      t.key,
-		colMeta:  t.cols,
-		cols:     make([]array.Interface, len(t.cols)),
-		l:        l,
+	return t.err
+}
+
+func (t *table) Done() {
+	// Mark the table as having been used. If this has already
+	// been done, then nothing needs to be done.
+	if atomic.CompareAndSwapInt32(&t.used, 0, 1) {
+		defer t.closeDone()
 	}
+
+	if t.colBufs != nil {
+		t.colBufs.Release()
+		t.colBufs = nil
+	}
+}
+
+// allocateBuffer will allocate a suitable buffer for the
+// table implementations to use. If the existing buffer
+// is not used anymore, then it may be reused.
+//
+// The allocated buffer can be accessed at colBufs or
+// through the returned colReader.
+func (t *table) allocateBuffer(l int) *colReader {
+	if t.colBufs == nil || atomic.LoadInt64(&t.colBufs.refCount) > 0 {
+		// The current buffer is still being used so we should
+		// generate a new one.
+		t.colBufs = &colReader{
+			key:     t.key,
+			colMeta: t.cols,
+			cols:    make([]array.Interface, len(t.cols)),
+		}
+	}
+	t.colBufs.refCount = 1
+	t.colBufs.l = l
 	return t.colBufs
 }
 

--- a/tsdb/cursors/arrayvalues.gen.go
+++ b/tsdb/cursors/arrayvalues.gen.go
@@ -26,10 +26,6 @@ func (a *FloatArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
 }
 
-func (a *FloatArray) Size() int {
-	panic("not implemented")
-}
-
 func (a *FloatArray) Len() int {
 	return len(a.Timestamps)
 }
@@ -225,10 +221,6 @@ func (a *IntegerArray) MinTime() int64 {
 
 func (a *IntegerArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
-}
-
-func (a *IntegerArray) Size() int {
-	panic("not implemented")
 }
 
 func (a *IntegerArray) Len() int {
@@ -428,10 +420,6 @@ func (a *UnsignedArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
 }
 
-func (a *UnsignedArray) Size() int {
-	panic("not implemented")
-}
-
 func (a *UnsignedArray) Len() int {
 	return len(a.Timestamps)
 }
@@ -627,10 +615,6 @@ func (a *StringArray) MinTime() int64 {
 
 func (a *StringArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
-}
-
-func (a *StringArray) Size() int {
-	panic("not implemented")
 }
 
 func (a *StringArray) Len() int {
@@ -830,10 +814,6 @@ func (a *BooleanArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
 }
 
-func (a *BooleanArray) Size() int {
-	panic("not implemented")
-}
-
 func (a *BooleanArray) Len() int {
 	return len(a.Timestamps)
 }
@@ -1027,10 +1007,6 @@ func (a *TimestampArray) MinTime() int64 {
 
 func (a *TimestampArray) MaxTime() int64 {
 	return a.Timestamps[len(a.Timestamps)-1]
-}
-
-func (a *TimestampArray) Size() int {
-	panic("not implemented")
 }
 
 func (a *TimestampArray) Len() int {

--- a/tsdb/cursors/arrayvalues.go
+++ b/tsdb/cursors/arrayvalues.go
@@ -1,0 +1,29 @@
+package cursors
+
+func (a *FloatArray) Size() int {
+	// size of timestamps + values
+	return len(a.Timestamps)*8 + len(a.Values)*8
+}
+
+func (a *IntegerArray) Size() int {
+	// size of timestamps + values
+	return len(a.Timestamps)*8 + len(a.Values)*8
+}
+
+func (a *UnsignedArray) Size() int {
+	// size of timestamps + values
+	return len(a.Timestamps)*8 + len(a.Values)*8
+}
+
+func (a *StringArray) Size() int {
+	sz := len(a.Timestamps) * 8
+	for _, s := range a.Values {
+		sz += len(s)
+	}
+	return sz
+}
+
+func (a *BooleanArray) Size() int {
+	// size of timestamps + values
+	return len(a.Timestamps)*8 + len(a.Values)
+}


### PR DESCRIPTION
This upgrades the flux version to v0.50.2.

The secret service, which is used for alerts, is not included. The
`to()` function is also still not included.