### PR TITLE
fix(vault): rename flags to match env vars and add missing token flag

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -196,7 +196,7 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 		},
 		{
 			DestP: &vaultConfig.Address,
-			Flag:  "vault-address",
+			Flag:  "vault-addr",
 			Desc:  "address of the Vault server expressed as a URL and port, for example: https://127.0.0.1:8200/.",
 		},
 		{
@@ -206,17 +206,17 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 		},
 		{
 			DestP: &vaultConfig.MaxRetries,
-			Flag:  "vault-client-max-retries",
+			Flag:  "vault-max-retries",
 			Desc:  "maximum number of retries when a 5xx error code is encountered. The default is 2, for three total attempts. Set this to 0 or less to disable retrying.",
 		},
 		{
 			DestP: &vaultConfig.CACert,
-			Flag:  "vault-ca-cert",
+			Flag:  "vault-cacert",
 			Desc:  "path to a PEM-encoded CA certificate file on the local disk. This file is used to verify the Vault server's SSL certificate. This environment variable takes precedence over VAULT_CAPATH.",
 		},
 		{
 			DestP: &vaultConfig.CAPath,
-			Flag:  "vault-ca-path",
+			Flag:  "vault-capath",
 			Desc:  "path to a directory of PEM-encoded CA certificate files on the local disk. These certificates are used to verify the Vault server's SSL certificate.",
 		},
 		{
@@ -238,6 +238,11 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 			DestP: &vaultConfig.TLSServerName,
 			Flag:  "vault-tls-server-name",
 			Desc:  "name to use as the SNI host when connecting via TLS.",
+		},
+		{
+			DestP: &vaultConfig.Token,
+			Flag:  "vault-token",
+			Desc:  "vault authentication token",
 		},
 		{
 			DestP:   &l.httpTlsCert,

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -25,6 +25,7 @@ type Config struct {
 	AgentAddress  string
 	ClientTimeout time.Duration
 	MaxRetries    int
+	Token         string
 	TLSConfig
 }
 
@@ -112,6 +113,10 @@ func NewSecretService(cfgOpts ...ConfigOptFn) (*SecretService, error) {
 	c, err := api.NewClient(cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	if explicitConfig.Token != "" {
+		c.SetToken(explicitConfig.Token)
 	}
 
 	return &SecretService{


### PR DESCRIPTION
the flags have to match the flags with the exception of beign lower case and
all `_` be changed to `-` in the flag. This is a result of using the cobra
flag to env var mapping with the `-` replaced to `_`.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
