### PR TITLE
fix(kv): allow system buckets to be created

### DIFF
--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -528,9 +528,6 @@ func (s *Service) putBucket(ctx context.Context, tx Tx, b *influxdb.Bucket) erro
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
-	// TODO(jade): remove this after we support storing system buckets
-	b.Type = influxdb.BucketTypeUser
-
 	v, err := json.Marshal(b)
 	if err != nil {
 		return &influxdb.Error{


### PR DESCRIPTION
This code is no longer necessary, as we now enforce this behavior for http-originating bucket creations here: https://github.com/influxdata/influxdb/blob/master/http/bucket_service.go#L377

Without this change, all system buckets that are created or updated will have the incorrect type.