### PR TITLE
Fix/tasks edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 1. [15452](https://github.com/influxdata/influxdb/pull/15452): Log error as info message on unauthorized API call attempts
 1. [15504](https://github.com/influxdata/influxdb/pull/15504): Ensure members&owners eps 404 when /org resource does not exist
 1. [15510](https://github.com/influxdata/influxdb/pull/15510): UI/Telegraf sort functionality fixed
+1. [15549](https://github.com/influxdata/influxdb/pull/15549): UI/Task edit functionality fixed
 
 ## v2.0.0-alpha.18 [2019-09-26]
 

--- a/ui/cypress/index.d.ts
+++ b/ui/cypress/index.d.ts
@@ -9,6 +9,7 @@ import {
   flush,
   getByTestID,
   getByInputName,
+  getByInputValue,
   getByTitle,
   createTask,
   createVariable,
@@ -42,6 +43,7 @@ declare global {
       flush: typeof flush
       getByTestID: typeof getByTestID
       getByInputName: typeof getByInputName
+      getByInputValue: typeof getByInputValue
       getByTitle: typeof getByTitle
       getByTestIDSubStr: typeof getByTestIDSubStr
       createAndAddLabel: typeof createAndAddLabel

--- a/ui/cypress/support/commands.ts
+++ b/ui/cypress/support/commands.ts
@@ -361,6 +361,10 @@ export const getByInputName = (name: string): Cypress.Chainable => {
   return cy.get(`input[name=${name}]`)
 }
 
+export const getByInputValue = (value: string): Cypress.Chainable => {
+  return cy.get(`input[value='${value}']`)
+}
+
 export const getByTitle = (name: string): Cypress.Chainable => {
   return cy.get(`[title="${name}"]`)
 }
@@ -398,6 +402,7 @@ Cypress.Commands.add('fluxEqual', fluxEqual)
 // getters
 Cypress.Commands.add('getByTestID', getByTestID)
 Cypress.Commands.add('getByInputName', getByInputName)
+Cypress.Commands.add('getByInputValue', getByInputValue)
 Cypress.Commands.add('getByTitle', getByTitle)
 Cypress.Commands.add('getByTestIDSubStr', getByTestIDSubStr)
 

--- a/ui/src/tasks/actions/index.ts
+++ b/ui/src/tasks/actions/index.ts
@@ -352,6 +352,20 @@ export const selectTaskByID = (id: string) => async (
   }
 }
 
+export const setAllTaskOptionsByID = (id: string) => async (
+  dispatch
+): Promise<void> => {
+  try {
+    const task = await client.tasks.get(id)
+    dispatch(setAllTaskOptions(task))
+  } catch (e) {
+    console.error(e)
+    dispatch(goToTasks())
+    const message = getErrorMessage(e)
+    dispatch(notify(taskNotFound(message)))
+  }
+}
+
 export const selectTask = (task: Task) => (
   dispatch,
   getState: GetStateFunc

--- a/ui/src/tasks/actions/index.ts
+++ b/ui/src/tasks/actions/index.ts
@@ -352,11 +352,11 @@ export const selectTaskByID = (id: string) => async (
   }
 }
 
-export const setAllTaskOptionsByID = (id: string) => async (
+export const setAllTaskOptionsByID = (taskID: string) => async (
   dispatch
 ): Promise<void> => {
   try {
-    const task = await client.tasks.get(id)
+    const task = await client.tasks.get(taskID)
     dispatch(setAllTaskOptions(task))
   } catch (e) {
     console.error(e)

--- a/ui/src/tasks/components/TaskForm.tsx
+++ b/ui/src/tasks/components/TaskForm.tsx
@@ -97,6 +97,7 @@ export default class TaskForm extends PureComponent<Props, State> {
                       value={TaskSchedule.interval}
                       titleText="Run task at regular intervals"
                       onClick={this.handleChangeScheduleType}
+                      testID="task-card-every-btn"
                     >
                       Every
                     </Radio.Button>
@@ -106,6 +107,7 @@ export default class TaskForm extends PureComponent<Props, State> {
                       value={TaskSchedule.cron}
                       titleText="Use cron syntax for more control over scheduling"
                       onClick={this.handleChangeScheduleType}
+                      testID="task-card-cron-btn"
                     >
                       Cron
                     </Radio.Button>

--- a/ui/src/tasks/components/TaskScheduleFormField.tsx
+++ b/ui/src/tasks/components/TaskScheduleFormField.tsx
@@ -47,6 +47,7 @@ export default class TaskScheduleFormFields extends PureComponent<Props> {
               value={offset}
               placeholder="20m"
               onChange={onChangeInput}
+              testID="task-form-offset-input"
             />
           </Form.Element>
         </Grid.Column>

--- a/ui/src/tasks/components/__snapshots__/TaskForm.test.tsx.snap
+++ b/ui/src/tasks/components/__snapshots__/TaskForm.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`TaskForm rendering renders 1`] = `
                 active={false}
                 id="every"
                 onClick={[Function]}
+                testID="task-card-every-btn"
                 titleText="Run task at regular intervals"
                 value="interval"
               >
@@ -44,6 +45,7 @@ exports[`TaskForm rendering renders 1`] = `
                 active={false}
                 id="cron"
                 onClick={[Function]}
+                testID="task-card-cron-btn"
                 titleText="Use cron syntax for more control over scheduling"
                 value="cron"
               >

--- a/ui/src/tasks/containers/TaskEditPage.tsx
+++ b/ui/src/tasks/containers/TaskEditPage.tsx
@@ -18,7 +18,7 @@ import {
   cancel,
   setTaskOption,
   clearTask,
-  setAllTaskOptions,
+  setAllTaskOptionsByID,
 } from 'src/tasks/actions'
 
 // Utils
@@ -50,7 +50,7 @@ interface DispatchProps {
   cancel: typeof cancel
   selectTaskByID: typeof selectTaskByID
   clearTask: typeof clearTask
-  setAllTaskOptions: typeof setAllTaskOptions
+  setAllTaskOptionsByID: typeof setAllTaskOptionsByID
 }
 
 type Props = OwnProps & StateProps & DispatchProps
@@ -65,10 +65,7 @@ class TaskEditPage extends PureComponent<Props> {
       params: {id},
     } = this.props
     this.props.selectTaskByID(id)
-
-    const {currentTask} = this.props
-
-    this.props.setAllTaskOptions(currentTask)
+    this.props.setAllTaskOptionsByID(id)
   }
 
   public componentWillUnmount() {
@@ -158,7 +155,7 @@ const mdtp: DispatchProps = {
   updateScript,
   cancel,
   selectTaskByID,
-  setAllTaskOptions,
+  setAllTaskOptionsByID,
   clearTask,
 }
 

--- a/ui/src/tasks/reducers/index.ts
+++ b/ui/src/tasks/reducers/index.ts
@@ -90,22 +90,6 @@ export default (
       }
     case 'SET_TASK_OPTION':
       const {key, value} = action.payload
-
-      if (key === 'taskScheduleType') {
-        if (value === TaskSchedule.cron) {
-          return {
-            ...state,
-            taskOptions: {...state.taskOptions, interval: '', [key]: value},
-          }
-        }
-        if (value === TaskSchedule.interval) {
-          return {
-            ...state,
-            taskOptions: {...state.taskOptions, cron: '', [key]: value},
-          }
-        }
-      }
-
       return {
         ...state,
         taskOptions: {...state.taskOptions, [key]: value},

--- a/ui/src/tasks/reducers/tasks.test.ts
+++ b/ui/src/tasks/reducers/tasks.test.ts
@@ -5,7 +5,8 @@ import tasksReducer, {
 import {setTaskOption} from 'src/tasks/actions'
 import {TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
 
-describe('tasksReducer', () => {
+// skipping this test since the cron and interval values should not be reset when toggling between schedule tasks
+describe.skip('tasksReducer', () => {
   describe('setTaskOption', () => {
     it('clears the cron property from the task options when interval is selected', () => {
       const initialState = defaultState

--- a/ui/src/tasks/reducers/tasks.test.ts
+++ b/ui/src/tasks/reducers/tasks.test.ts
@@ -11,7 +11,7 @@ describe('tasksReducer', () => {
     it('should not clear the cron property from the task options when interval is selected', () => {
       const initialState = defaultState
       const cron = '0 2 * * *'
-      initialState.taskOptions = {...defaultTaskOptions, cron }
+      initialState.taskOptions = {...defaultTaskOptions, cron}
 
       const actual = tasksReducer(
         initialState,
@@ -33,7 +33,7 @@ describe('tasksReducer', () => {
     it('should not clear the interval property from the task options when cron is selected', () => {
       const initialState = defaultState
       const interval = '24h'
-      initialState.taskOptions = {...defaultTaskOptions, interval } // todo(docmerlin): allow for time units larger than 1d, right now h is the longest unit our s
+      initialState.taskOptions = {...defaultTaskOptions, interval} // todo(docmerlin): allow for time units larger than 1d, right now h is the longest unit our s
 
       const actual = tasksReducer(
         initialState,

--- a/ui/src/tasks/reducers/tasks.test.ts
+++ b/ui/src/tasks/reducers/tasks.test.ts
@@ -5,7 +5,6 @@ import tasksReducer, {
 import {setTaskOption} from 'src/tasks/actions'
 import {TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
 
-// skipping this test since the cron and interval values should not be reset when toggling between schedule tasks
 describe('tasksReducer', () => {
   describe('setTaskOption', () => {
     it('should not clear the cron property from the task options when interval is selected', () => {

--- a/ui/src/tasks/reducers/tasks.test.ts
+++ b/ui/src/tasks/reducers/tasks.test.ts
@@ -6,11 +6,12 @@ import {setTaskOption} from 'src/tasks/actions'
 import {TaskSchedule} from 'src/utils/taskOptionsToFluxScript'
 
 // skipping this test since the cron and interval values should not be reset when toggling between schedule tasks
-describe.skip('tasksReducer', () => {
+describe('tasksReducer', () => {
   describe('setTaskOption', () => {
-    it('clears the cron property from the task options when interval is selected', () => {
+    it('should not clear the cron property from the task options when interval is selected', () => {
       const initialState = defaultState
-      initialState.taskOptions = {...defaultTaskOptions, cron: '0 2 * * *'}
+      const cron = '0 2 * * *'
+      initialState.taskOptions = {...defaultTaskOptions, cron }
 
       const actual = tasksReducer(
         initialState,
@@ -22,16 +23,17 @@ describe.skip('tasksReducer', () => {
         taskOptions: {
           ...defaultTaskOptions,
           taskScheduleType: TaskSchedule.interval,
-          cron: '',
+          cron,
         },
       }
 
       expect(actual).toEqual(expected)
     })
 
-    it('clears the interval property from the task options when cron is selected', () => {
+    it('should not clear the interval property from the task options when cron is selected', () => {
       const initialState = defaultState
-      initialState.taskOptions = {...defaultTaskOptions, interval: '24h'} // todo(docmerlin): allow for time units larger than 1d, right now h is the longest unit our s
+      const interval = '24h'
+      initialState.taskOptions = {...defaultTaskOptions, interval } // todo(docmerlin): allow for time units larger than 1d, right now h is the longest unit our s
 
       const actual = tasksReducer(
         initialState,
@@ -43,7 +45,7 @@ describe.skip('tasksReducer', () => {
         taskOptions: {
           ...defaultTaskOptions,
           taskScheduleType: TaskSchedule.cron,
-          interval: '',
+          interval,
         },
       }
 


### PR DESCRIPTION
Closes #15534 

### Problem

The page would crash whenever an existing task was selected to edit. In addition, data on the task form would not populate or persist whenever a task was selected to edit / was toggled between task

### Solution

The app was originally failing because of a race condition where the `currentTask` that was needed to call the `setAllTaskOptions` was only being populate after the componentDidMount function `selectTaskByID` was triggered. Since they were both being triggered in the CDM lifecycle, the `setAllTaskOptions` would never actually populate the data. To solve this, I created a new `setAllTaskOptionsByID` to get the task data based on the `id`. 

In doing so, this fixed our issue of data persistence in the `TaskForm`. To resolve the issue of data persistence when toggling between `schedule tasks` simply required a modification to the following reducer:

https://github.com/influxdata/influxdb/blob/master/ui/src/tasks/reducers/index.ts#L94

It seems like the original intent of this conditional was to prevent data persistence from mucking up the task (i.e. storing interval data and cron data may have set the data for both), but these fears seem unfounded since the data is set correctly without any unintended consequences.

![tasks_test](https://user-images.githubusercontent.com/19984220/67415344-bbac7400-f579-11e9-90f8-90be63a6dd29.gif)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
