### PR TITLE
fix(ui/checks): checks render once they've been created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 1. [15510](https://github.com/influxdata/influxdb/pull/15510): UI/Telegraf sort functionality fixed
 1. [15549](https://github.com/influxdata/influxdb/pull/15549): UI/Task edit functionality fixed
 1. [15559](https://github.com/influxdata/influxdb/pull/15559): Exiting a configuration of a dashboard cell now properly renders the cell content
+1. [15556](https://github.com/influxdata/influxdb/pull/15556): Creating a check now displays on the checklist
 
 ## v2.0.0-alpha.18 [2019-09-26]
 

--- a/ui/cypress/e2e/checks.test.ts
+++ b/ui/cypress/e2e/checks.test.ts
@@ -56,4 +56,40 @@ describe('Checks', () => {
       })
     })
   })
+
+  describe('Check should be viewable once created', () => {
+    beforeEach(() => {
+      // creates a check before each iteration
+      // TODO: refactor into a request
+      cy.getByTestID('create-check').click()
+      cy.getByTestID('create-threshold-check').click()
+      cy.getByTestID(`selector-list ${measurement}`).click()
+      cy.getByTestID('save-cell--button').should('be.disabled')
+      cy.getByTestID(`selector-list ${field}`).click()
+      cy.getByTestID('save-cell--button').should('be.disabled')
+      cy.getByTestID('checkeo--header alerting-tab').click()
+      cy.getByTestID('add-threshold-condition-WARN').click()
+      cy.getByTestID('save-cell--button').click()
+      cy.getByTestID('check-card').should('have.length', 1)
+    })
+
+    it('should allow created checks to be selected and routed to the edit page', () => {
+      cy.getByTestID('check-card--name').should('have.length', 1)
+      cy.getByTestID('check-card--name').click()
+      cy.get('@org').then(({id}: Organization) => {
+        cy.fixture('routes').then(({orgs, alerting, checks}) => {
+          cy.url().then(url => {
+            Cypress.minimatch(
+              url,
+              `
+                ${
+                  Cypress.config().baseUrl
+                }${orgs}/${id}${alerting}${checks}/*/edit
+              `
+            )
+          })
+        })
+      })
+    })
+  })
 })

--- a/ui/src/alerting/actions/checks.ts
+++ b/ui/src/alerting/actions/checks.ts
@@ -1,6 +1,7 @@
 // Libraries
 import {Dispatch} from 'react'
 import {push} from 'react-router-redux'
+import {get} from 'lodash'
 
 // Constants
 import * as copy from 'src/shared/copy/notifications'
@@ -151,11 +152,12 @@ export const saveCheckFromTimeMachine = () => async (
     alerting: {check},
   } = getActiveTimeMachine(state)
 
+  const labels = get(check, 'labels', []) as Label[]
   const checkWithOrg = {
     ...check,
     query: draftQueries[0],
     orgID,
-    labels: check.labels.map(l => l.id),
+    labels: labels.map(l => l.id),
   } as PostCheck
 
   const resp = check.id
@@ -253,10 +255,11 @@ export const cloneCheck = (check: Check) => async (
     const allCheckNames = list.map(c => c.name)
 
     const clonedName = incrementCloneName(allCheckNames, check.name)
+    const labels = get(check, 'labels', []) as Label[]
     const data = {
       ...check,
       name: clonedName,
-      labels: check.labels.map(l => l.id),
+      labels: labels.map(l => l.id),
     } as PostCheck
     const resp = await api.postCheck({data})
 


### PR DESCRIPTION
Closes #15554 

### Problem

Newly created checks without labels were not rendering on the checks list.

Steps for reproduction can be found on #15554 

### Solution

Ensure that check labels exist before mapping the values. Added testing to ensure that the checks list page should render a check once it has been created

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)