### PR TITLE
fix(query/stdlib): fix rewritten pushable expressions when a logical expression is present

### DIFF
--- a/query/stdlib/influxdata/influxdb/rules.go
+++ b/query/stdlib/influxdata/influxdb/rules.go
@@ -437,6 +437,15 @@ func rewritePushableExpr(e semantic.Expression) (semantic.Expression, bool) {
 			e.Left, e.Right = left, right
 			return e, true
 		}
+
+	case *semantic.LogicalExpression:
+		left, lok := rewritePushableExpr(e.Left)
+		right, rok := rewritePushableExpr(e.Right)
+		if lok || rok {
+			e = e.Copy().(*semantic.LogicalExpression)
+			e.Left, e.Right = left, right
+			return e, true
+		}
 	}
 	return e, false
 }


### PR DESCRIPTION
When `exists` was used in conjunction with any other pushed down
expression, the `exists` was not rewritten properly because the rewrite
did not descend into logical expressions.

This is now fixed so those expressions will be rewritten correctly. This
affected the following form:

    filter(fn: (r) => r._measurement == "cpu" and exists r.host)

It did not affect the following:

    filter(fn: (r) => r._measurement == "cpu")
    |> filter(fn: (r) => exists r.host)