### PR TITLE
feat(backup): backup data and metadata

### DIFF
--- a/authorizer/authorize.go
+++ b/authorizer/authorize.go
@@ -11,15 +11,23 @@ import (
 // IsAllowed checks to see if an action is authorized by retrieving the authorizer
 // off of context and authorizing the action appropriately.
 func IsAllowed(ctx context.Context, p influxdb.Permission) error {
+	return IsAllowedAll(ctx, []influxdb.Permission{p})
+}
+
+// IsAllowedAll checks to see if an action is authorized by ALL permissions.
+// Also see IsAllowed.
+func IsAllowedAll(ctx context.Context, permissions []influxdb.Permission) error {
 	a, err := influxdbcontext.GetAuthorizer(ctx)
 	if err != nil {
 		return err
 	}
 
-	if !a.Allowed(p) {
-		return &influxdb.Error{
-			Code: influxdb.EUnauthorized,
-			Msg:  fmt.Sprintf("%s is unauthorized", p),
+	for _, p := range permissions {
+		if !a.Allowed(p) {
+			return &influxdb.Error{
+				Code: influxdb.EUnauthorized,
+				Msg:  fmt.Sprintf("%s is unauthorized", p),
+			}
 		}
 	}
 

--- a/authorizer/backup.go
+++ b/authorizer/backup.go
@@ -1,0 +1,48 @@
+package authorizer
+
+import (
+	"context"
+	"io"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/tracing"
+)
+
+var _ influxdb.BackupService = (*BackupService)(nil)
+
+// BackupService wraps a influxdb.BackupService and authorizes actions
+// against it appropriately.
+type BackupService struct {
+	s influxdb.BackupService
+}
+
+// NewBackupService constructs an instance of an authorizing backup service.
+func NewBackupService(s influxdb.BackupService) *BackupService {
+	return &BackupService{
+		s: s,
+	}
+}
+
+func (b BackupService) CreateBackup(ctx context.Context) (int, []string, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if err := IsAllowedAll(ctx, influxdb.ReadAllPermissions()); err != nil {
+		return 0, nil, err
+	}
+	return b.s.CreateBackup(ctx)
+}
+
+func (b BackupService) FetchBackupFile(ctx context.Context, backupID int, backupFile string, w io.Writer) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	if err := IsAllowedAll(ctx, influxdb.ReadAllPermissions()); err != nil {
+		return nil
+	}
+	return b.s.FetchBackupFile(ctx, backupID, backupFile, w)
+}
+
+func (b BackupService) InternalBackupPath(backupID int) string {
+	return b.s.InternalBackupPath(backupID)
+}

--- a/authz.go
+++ b/authz.go
@@ -335,6 +335,16 @@ func OperPermissions() []Permission {
 	return ps
 }
 
+// ReadAllPermissions represents permission to read all data and metadata.
+// Like OperPermissions, but allows read-only users.
+func ReadAllPermissions() []Permission {
+	ps := make([]Permission, len(AllResourceTypes))
+	for i, t := range AllResourceTypes {
+		ps[i] = Permission{Action: ReadAction, Resource: Resource{Type: t}}
+	}
+	return ps
+}
+
 // OwnerPermissions are the default permissions for those who own a resource.
 func OwnerPermissions(orgID ID) []Permission {
 	ps := []Permission{}

--- a/backup.go
+++ b/backup.go
@@ -1,0 +1,23 @@
+package influxdb
+
+import (
+	"context"
+	"io"
+)
+
+// BackupService represents the data backup functions of InfluxDB.
+type BackupService interface {
+	// CreateBackup creates a local copy (hard links) of the TSM data for all orgs and buckets.
+	// The return values are used to download each backup file.
+	CreateBackup(context.Context) (backupID int, backupFiles []string, err error)
+	// FetchBackupFile downloads one backup file, data or metadata.
+	FetchBackupFile(ctx context.Context, backupID int, backupFile string, w io.Writer) error
+	// InternalBackupPath is a utility to determine the on-disk location of a backup fileset.
+	InternalBackupPath(backupID int) string
+}
+
+// KVBackupService represents the meta data backup functions of InfluxDB.
+type KVBackupService interface {
+	// Backup creates a live backup copy of the metadata database.
+	Backup(ctx context.Context, w io.Writer) error
+}

--- a/bolt/bbolt.go
+++ b/bolt/bbolt.go
@@ -14,8 +14,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// OpPrefix is the prefix for bolt ops
-const OpPrefix = "bolt/"
+const (
+	// OpPrefix is the prefix for bolt ops
+	OpPrefix = "bolt/"
+
+	DefaultFilename = "influxd.bolt"
+)
 
 func getOp(op string) string {
 	return OpPrefix + op

--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -3,6 +3,7 @@ package bolt
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -117,6 +118,17 @@ func (s *KVStore) Update(ctx context.Context, fn func(tx kv.Tx) error) error {
 			tx:  tx,
 			ctx: ctx,
 		})
+	})
+}
+
+// Backup copies all K:Vs to a writer, in BoltDB format.
+func (s *KVStore) Backup(ctx context.Context, w io.Writer) error {
+	span, _ := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	return s.db.View(func(tx *bolt.Tx) error {
+		_, err := tx.WriteTo(w)
+		return err
 	})
 }
 

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/bolt"
+	"github.com/influxdata/influxdb/http"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/multierr"
+)
+
+var backupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Backup the data in InfluxDB",
+	Long: fmt.Sprintf(
+		`Backs up data and meta data for the running InfluxDB instance.
+Downloaded files are written to the directory indicated by --path.
+The target directory, and any parent directories, are created automatically.
+Data file have extension .tsm; meta data is written to %s in the same directory.`,
+		bolt.DefaultFilename),
+	RunE: backupF,
+}
+
+var backupFlags struct {
+	Path string
+}
+
+func init() {
+	backupCmd.PersistentFlags().StringVarP(&backupFlags.Path, "path", "p", "", "directory path to write backup files to")
+	err := viper.BindEnv("PATH")
+	if err != nil {
+		panic(err)
+	}
+	if h := viper.GetString("PATH"); h != "" {
+		backupFlags.Path = h
+	}
+}
+
+func newBackupService(flags Flags) (influxdb.BackupService, error) {
+	return &http.BackupService{
+		Addr:  flags.host,
+		Token: flags.token,
+	}, nil
+}
+
+func backupF(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	if flags.local {
+		return fmt.Errorf("local flag not supported for backup command")
+	}
+
+	if backupFlags.Path == "" {
+		return fmt.Errorf("must specify path")
+	}
+
+	err := os.MkdirAll(backupFlags.Path, 0770)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	backupService, err := newBackupService(flags)
+	if err != nil {
+		return err
+	}
+
+	id, backupFilenames, err := backupService.CreateBackup(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Backup ID %d contains %d files\n", id, len(backupFilenames))
+
+	for _, backupFilename := range backupFilenames {
+		dest := filepath.Join(backupFlags.Path, backupFilename)
+		w, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
+		if err != nil {
+			return err
+		}
+		err = backupService.FetchBackupFile(ctx, id, backupFilename, w)
+		if err != nil {
+			return multierr.Append(err, w.Close())
+		}
+		if err = w.Close(); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("Backup complete")
+
+	return nil
+}

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -85,6 +85,7 @@ func influxCmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		authCmd(),
+		backupCmd,
 		bucketCmd,
 		deleteCmd,
 		organizationCmd(),

--- a/cmd/influxd/launcher/engine.go
+++ b/cmd/influxd/launcher/engine.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"os"
 	"sync"
@@ -29,6 +30,7 @@ type Engine interface {
 	storage.PointsWriter
 	storage.BucketDeleter
 	prom.PrometheusCollector
+	influxdb.BackupService
 
 	SeriesCardinality() int64
 
@@ -164,4 +166,16 @@ func (t *TemporaryEngine) Flush(ctx context.Context) {
 	if err := t.Open(ctx); err != nil {
 		t.log.Fatal("unable to open engine", zap.Error(err))
 	}
+}
+
+func (t *TemporaryEngine) CreateBackup(ctx context.Context) (int, []string, error) {
+	return t.engine.CreateBackup(ctx)
+}
+
+func (t *TemporaryEngine) FetchBackupFile(ctx context.Context, backupID int, backupFile string, w io.Writer) error {
+	return t.engine.FetchBackupFile(ctx, backupID, backupFile, w)
+}
+
+func (t *TemporaryEngine) InternalBackupPath(backupID int) string {
+	return t.engine.InternalBackupPath(backupID)
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -146,7 +146,7 @@ func buildLauncherCommand(l *Launcher, cmd *cobra.Command) {
 		{
 			DestP:   &l.boltPath,
 			Flag:    "bolt-path",
-			Default: filepath.Join(dir, "influxd.bolt"),
+			Default: filepath.Join(dir, bolt.DefaultFilename),
 			Desc:    "path to boltdb database",
 		},
 		{
@@ -590,6 +590,7 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 	var (
 		deleteService platform.DeleteService = m.engine
 		pointsWriter  storage.PointsWriter   = m.engine
+		backupService platform.BackupService = m.engine
 	)
 
 	// TODO(cwolff): Figure out a good default per-query memory limit:
@@ -796,6 +797,8 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		NewQueryService:      source.NewQueryService,
 		PointsWriter:         pointsWriter,
 		DeleteService:        deleteService,
+		BackupService:        backupService,
+		KVBackupService:      m.kvService,
 		AuthorizationService: authSvc,
 		// Wrap the BucketService in a storage backed one that will ensure deleted buckets are removed from the storage engine.
 		BucketService:                   storage.NewBucketService(bucketSvc, m.engine),

--- a/cmd/influxd/launcher/launcher_helpers.go
+++ b/cmd/influxd/launcher/launcher_helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/lang"
 	platform "github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/bolt"
 	influxdbcontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/http"
 	"github.com/influxdata/influxdb/kv"
@@ -79,7 +80,7 @@ func RunTestLauncherOrFail(tb testing.TB, ctx context.Context, args ...string) *
 
 // Run executes the program with additional arguments to set paths and ports.
 func (tl *TestLauncher) Run(ctx context.Context, args ...string) error {
-	args = append(args, "--bolt-path", filepath.Join(tl.Path, "influxd.bolt"))
+	args = append(args, "--bolt-path", filepath.Join(tl.Path, bolt.DefaultFilename))
 	args = append(args, "--engine-path", filepath.Join(tl.Path, "engine"))
 	args = append(args, "--http-bind-address", "127.0.0.1:0")
 	args = append(args, "--log-level", "debug")

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -36,6 +36,8 @@ type APIBackend struct {
 
 	PointsWriter                    storage.PointsWriter
 	DeleteService                   influxdb.DeleteService
+	BackupService                   influxdb.BackupService
+	KVBackupService                 influxdb.KVBackupService
 	AuthorizationService            influxdb.AuthorizationService
 	BucketService                   influxdb.BucketService
 	SessionService                  influxdb.SessionService
@@ -197,6 +199,10 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 	variableBackend.VariableService = authorizer.NewVariableService(b.VariableService)
 	h.Mount(prefixVariables, NewVariableHandler(b.Logger, variableBackend))
 
+	backupBackend := NewBackupBackend(b)
+	backupBackend.BackupService = authorizer.NewBackupService(backupBackend.BackupService)
+	h.Mount(prefixBackup, NewBackupHandler(backupBackend))
+
 	writeBackend := NewWriteBackend(b.Logger.With(zap.String("handler", "write")), b)
 	h.Mount(prefixWrite, NewWriteHandler(b.Logger, writeBackend))
 
@@ -210,6 +216,7 @@ var apiLinks = map[string]interface{}{
 	// when adding new links, please take care to keep this list alphabetical
 	// as this makes it easier to verify values against the swagger document.
 	"authorizations": "/api/v2/authorizations",
+	"backup":         "/api/v2/backup",
 	"buckets":        "/api/v2/buckets",
 	"dashboards":     "/api/v2/dashboards",
 	"external": map[string]string{

--- a/http/backup_service.go
+++ b/http/backup_service.go
@@ -1,0 +1,226 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/influxdata/httprouter"
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/bolt"
+	"github.com/influxdata/influxdb/kit/tracing"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+// BackupBackend is all services and associated parameters required to construct the BackupHandler.
+type BackupBackend struct {
+	Logger *zap.Logger
+	influxdb.HTTPErrorHandler
+
+	BackupService   influxdb.BackupService
+	KVBackupService influxdb.KVBackupService
+}
+
+// NewBackupBackend returns a new instance of BackupBackend.
+func NewBackupBackend(b *APIBackend) *BackupBackend {
+	return &BackupBackend{
+		Logger: b.Logger.With(zap.String("handler", "backup")),
+
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		BackupService:    b.BackupService,
+		KVBackupService:  b.KVBackupService,
+	}
+}
+
+type BackupHandler struct {
+	*httprouter.Router
+	influxdb.HTTPErrorHandler
+	Logger *zap.Logger
+
+	BackupService   influxdb.BackupService
+	KVBackupService influxdb.KVBackupService
+}
+
+const (
+	prefixBackup        = "/api/v2/backup"
+	backupIDParamName   = "backup_id"
+	backupFileParamName = "backup_file"
+	backupFilePath      = prefixBackup + "/:" + backupIDParamName + "/file/:" + backupFileParamName
+
+	httpClientTimeout = time.Hour
+)
+
+func composeBackupFilePath(backupID int, backupFile string) string {
+	return path.Join(prefixBackup, fmt.Sprint(backupID), "file", fmt.Sprint(backupFile))
+}
+
+// NewBackupHandler creates a new handler at /api/v2/backup to receive backup requests.
+func NewBackupHandler(b *BackupBackend) *BackupHandler {
+	h := &BackupHandler{
+		HTTPErrorHandler: b.HTTPErrorHandler,
+		Router:           NewRouter(b.HTTPErrorHandler),
+		Logger:           b.Logger,
+		BackupService:    b.BackupService,
+		KVBackupService:  b.KVBackupService,
+	}
+
+	h.HandlerFunc(http.MethodPost, prefixBackup, h.handleCreate)
+	h.HandlerFunc(http.MethodGet, backupFilePath, h.handleFetchFile)
+
+	return h
+}
+
+type backup struct {
+	ID    int      `json:"id,omitempty"`
+	Files []string `json:"files,omitempty"`
+}
+
+func (h *BackupHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "BackupHandler.handleCreate")
+	defer span.Finish()
+
+	ctx := r.Context()
+
+	id, files, err := h.BackupService.CreateBackup(ctx)
+	if err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+
+	internalBackupPath := h.BackupService.InternalBackupPath(id)
+	metaFilename := filepath.Join(internalBackupPath, bolt.DefaultFilename)
+	metaFile, err := os.OpenFile(metaFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0660)
+	if err != nil {
+		err = multierr.Append(err, os.RemoveAll(internalBackupPath))
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+
+	if err = h.KVBackupService.Backup(ctx, metaFile); err != nil {
+		err = multierr.Append(err, os.RemoveAll(internalBackupPath))
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+	files = append(files, bolt.DefaultFilename)
+
+	b := backup{
+		ID:    id,
+		Files: files,
+	}
+	if err = json.NewEncoder(w).Encode(&b); err != nil {
+		err = multierr.Append(err, os.RemoveAll(internalBackupPath))
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+}
+
+func (h *BackupHandler) handleFetchFile(w http.ResponseWriter, r *http.Request) {
+	span, r := tracing.ExtractFromHTTPRequest(r, "BackupHandler.handleFetchFile")
+	defer span.Finish()
+
+	ctx := r.Context()
+
+	params := httprouter.ParamsFromContext(ctx)
+	backupID, err := strconv.Atoi(params.ByName("backup_id"))
+	if err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+	backupFile := params.ByName("backup_file")
+
+	if err = h.BackupService.FetchBackupFile(ctx, backupID, backupFile, w); err != nil {
+		h.HandleHTTPError(ctx, err, w)
+		return
+	}
+}
+
+// BackupService is the client implementation of influxdb.BackupService.
+type BackupService struct {
+	Addr               string
+	Token              string
+	InsecureSkipVerify bool
+}
+
+func (s *BackupService) CreateBackup(ctx context.Context) (int, []string, error) {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	u, err := NewURL(s.Addr, prefixBackup)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	SetToken(s.Token, req)
+	req = req.WithContext(ctx)
+
+	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
+	hc.Timeout = httpClientTimeout
+	resp, err := hc.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := CheckError(resp); err != nil {
+		return 0, nil, err
+	}
+
+	var b backup
+	if err = json.NewDecoder(resp.Body).Decode(&b); err != nil {
+		return 0, nil, err
+	}
+
+	return b.ID, b.Files, nil
+}
+
+func (s *BackupService) FetchBackupFile(ctx context.Context, backupID int, backupFile string, w io.Writer) error {
+	span, ctx := tracing.StartSpanFromContext(ctx)
+	defer span.Finish()
+
+	u, err := NewURL(s.Addr, composeBackupFilePath(backupID, backupFile))
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	SetToken(s.Token, req)
+	req = req.WithContext(ctx)
+
+	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
+	hc.Timeout = httpClientTimeout
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err := CheckError(resp); err != nil {
+		return err
+	}
+
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *BackupService) InternalBackupPath(backupID int) string {
+	panic("internal method not implemented here")
+}

--- a/http/client.go
+++ b/http/client.go
@@ -40,6 +40,7 @@ type Service struct {
 	InsecureSkipVerify bool
 
 	*AuthorizationService
+	*BackupService
 	*BucketService
 	*DashboardService
 	*OrganizationService
@@ -62,6 +63,10 @@ func NewService(addr, token string) (*Service, error) {
 		AuthorizationService: &AuthorizationService{
 			Addr:  addr,
 			Token: token,
+		},
+		BackupService: &BackupService{
+			Addr:addr,
+			Token:token,
 		},
 		BucketService:       &BucketService{Client: httpClient},
 		DashboardService:    &DashboardService{Client: httpClient},

--- a/http/client.go
+++ b/http/client.go
@@ -65,8 +65,8 @@ func NewService(addr, token string) (*Service, error) {
 			Token: token,
 		},
 		BackupService: &BackupService{
-			Addr:addr,
-			Token:token,
+			Addr:  addr,
+			Token: token,
 		},
 		BucketService:       &BucketService{Client: httpClient},
 		DashboardService:    &DashboardService{Client: httpClient},

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/google/btree"
@@ -47,6 +48,10 @@ func (s *KVStore) Update(ctx context.Context, fn func(kv.Tx) error) error {
 		writable: true,
 		ctx:      ctx,
 	})
+}
+
+func (s *KVStore) Backup(ctx context.Context, w io.Writer) error {
+	panic("not implemented")
 }
 
 // Flush removes all data from the buckets.  Used for testing.

--- a/kv/backup.go
+++ b/kv/backup.go
@@ -1,0 +1,10 @@
+package kv
+
+import (
+	"context"
+	"io"
+)
+
+func (s *Service) Backup(ctx context.Context, w io.Writer) error {
+	return s.kv.Backup(ctx, w)
+}

--- a/kv/service_test.go
+++ b/kv/service_test.go
@@ -2,6 +2,7 @@ package kv_test
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -18,6 +19,10 @@ func (s mockStore) View(context.Context, func(kv.Tx) error) error {
 }
 
 func (s mockStore) Update(context.Context, func(kv.Tx) error) error {
+	return nil
+}
+
+func (s mockStore) Backup(ctx context.Context, w io.Writer) error {
 	return nil
 }
 

--- a/kv/store.go
+++ b/kv/store.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"errors"
+	"io"
 )
 
 var (
@@ -26,6 +27,8 @@ type Store interface {
 	View(context.Context, func(Tx) error) error
 	// Update opens up a transaction that will mutate data.
 	Update(context.Context, func(Tx) error) error
+	// Backup copies all K:Vs to a writer, file format determined by implementation.
+	Backup(ctx context.Context, w io.Writer) error
 }
 
 // Tx is a transaction in the store.

--- a/mock/kv.go
+++ b/mock/kv.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"io"
 
 	"github.com/influxdata/influxdb/kv"
 )
@@ -12,6 +13,7 @@ var _ (kv.Store) = (*Store)(nil)
 type Store struct {
 	ViewFn   func(func(kv.Tx) error) error
 	UpdateFn func(func(kv.Tx) error) error
+	BackupFn func(ctx context.Context, w io.Writer) error
 }
 
 // View opens up a transaction that will not write to any data. Implementing interfaces
@@ -23,6 +25,10 @@ func (s *Store) View(ctx context.Context, fn func(kv.Tx) error) error {
 // Update opens up a transaction that will mutate data.
 func (s *Store) Update(ctx context.Context, fn func(kv.Tx) error) error {
 	return s.UpdateFn(fn)
+}
+
+func (s *Store) Backup(ctx context.Context, w io.Writer) error {
+	return s.BackupFn(ctx, w)
 }
 
 var _ (kv.Tx) = (*Tx)(nil)

--- a/tsdb/tsm1/engine.go
+++ b/tsdb/tsm1/engine.go
@@ -799,8 +799,9 @@ func (e *Engine) WriteSnapshot(ctx context.Context, status CacheStatus) error {
 	if err != nil && err != errCompactionsDisabled {
 		e.logger.Info("Error writing snapshot", zap.Error(err))
 	}
-	e.compactionTracker.SnapshotAttempted(err == nil || err == errCompactionsDisabled ||
-		err == ErrSnapshotInProgress, status, time.Since(start))
+	e.compactionTracker.SnapshotAttempted(
+		err == nil || err == errCompactionsDisabled || err == ErrSnapshotInProgress,
+		status, time.Since(start))
 
 	if err != nil {
 		return err
@@ -932,6 +933,7 @@ const (
 	CacheStatusColdNoWrites                      // The cache has not been written to for long enough that it should be snapshotted.
 	CacheStatusRetention                         // The cache was snapshotted before running retention.
 	CacheStatusFullCompaction                    // The cache was snapshotted as part of a full compaction.
+	CacheStatusBackup                            // The cache was snapshotted before running backup.
 )
 
 // ShouldCompactCache returns a status indicating if the Cache should be

--- a/tsdb/tsm1/file_store.go
+++ b/tsdb/tsm1/file_store.go
@@ -1208,7 +1208,7 @@ func (f *FileStore) locations(key []byte, t int64, ascending bool) []*location {
 
 // CreateSnapshot creates hardlinks for all tsm and tombstone files
 // in the path provided.
-func (f *FileStore) CreateSnapshot(ctx context.Context) (string, error) {
+func (f *FileStore) CreateSnapshot(ctx context.Context) (backupID int, backupDirFullPath string, err error) {
 	span, _ := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
@@ -1228,30 +1228,35 @@ func (f *FileStore) CreateSnapshot(ctx context.Context) (string, error) {
 	// increment and keep track of the current temp dir for when we drop the lock.
 	// this ensures we are the only writer to the directory.
 	f.currentTempDirID += 1
-	tmpPath := fmt.Sprintf("%d.%s", f.currentTempDirID, TmpTSMFileExtension)
-	tmpPath = filepath.Join(f.dir, tmpPath)
+	backupID = f.currentTempDirID
 	f.mu.Unlock()
+
+	backupDirFullPath = f.InternalBackupPath(backupID)
 
 	// create the tmp directory and add the hard links. there is no longer any shared
 	// mutable state.
-	err := os.Mkdir(tmpPath, 0777)
+	err = os.Mkdir(backupDirFullPath, 0777)
 	if err != nil {
-		return "", err
+		return 0, "", err
 	}
 	for _, tsmf := range files {
-		newpath := filepath.Join(tmpPath, filepath.Base(tsmf.Path()))
+		newpath := filepath.Join(backupDirFullPath, filepath.Base(tsmf.Path()))
 		if err := os.Link(tsmf.Path(), newpath); err != nil {
-			return "", fmt.Errorf("error creating tsm hard link: %q", err)
+			return 0, "", fmt.Errorf("error creating tsm hard link: %q", err)
 		}
 		for _, tf := range tsmf.TombstoneFiles() {
-			newpath := filepath.Join(tmpPath, filepath.Base(tf.Path))
+			newpath := filepath.Join(backupDirFullPath, filepath.Base(tf.Path))
 			if err := os.Link(tf.Path, newpath); err != nil {
-				return "", fmt.Errorf("error creating tombstone hard link: %q", err)
+				return 0, "", fmt.Errorf("error creating tombstone hard link: %q", err)
 			}
 		}
 	}
 
-	return tmpPath, nil
+	return backupID, backupDirFullPath, nil
+}
+
+func (f *FileStore) InternalBackupPath(backupID int) string {
+	return filepath.Join(f.dir, fmt.Sprintf("%d.%s", backupID, TmpTSMFileExtension))
 }
 
 // MeasurementStats returns the sum of all measurement stats within the store.

--- a/tsdb/tsm1/file_store_test.go
+++ b/tsdb/tsm1/file_store_test.go
@@ -2724,7 +2724,7 @@ func TestFileStore_CreateSnapshot(t *testing.T) {
 		t.Fatalf("unexpected error delete range: %v", err)
 	}
 
-	s, e := fs.CreateSnapshot(context.Background())
+	_, s, e := fs.CreateSnapshot(context.Background())
 	if e != nil {
 		t.Fatal(e)
 	}


### PR DESCRIPTION
Fixes #15603 
Fixes #15604 
Currently blocked on #15961

This command backs up data and metadata:
```
$ influx backup --path backup_dir
```
