### PR TITLE
fix(ui/boxtooltip): Preventing constant toggle b/w onMouseOver and onMouseOut on EventMarker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@
 1. [15549](https://github.com/influxdata/influxdb/pull/15549): UI/Task edit functionality fixed
 1. [15559](https://github.com/influxdata/influxdb/pull/15559): Exiting a configuration of a dashboard cell now properly renders the cell content
 1. [15556](https://github.com/influxdata/influxdb/pull/15556): Creating a check now displays on the checklist
-1. [15581](https://github.com/influxdata/influxdb/pull/15581): Hovering over an Event Marker in the `alerting/checks` chart no longer jitters between on/off in certain situations
 
 ## v2.0.0-alpha.18 [2019-09-26]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [15549](https://github.com/influxdata/influxdb/pull/15549): UI/Task edit functionality fixed
 1. [15559](https://github.com/influxdata/influxdb/pull/15559): Exiting a configuration of a dashboard cell now properly renders the cell content
 1. [15556](https://github.com/influxdata/influxdb/pull/15556): Creating a check now displays on the checklist
+1. [15581](https://github.com/influxdata/influxdb/pull/15581): Hovering over an Event Marker in the `alerting/checks` chart no longer jitters between on/off in certain situations
 
 ## v2.0.0-alpha.18 [2019-09-26]
 

--- a/ui/src/shared/components/BoxTooltip.tsx
+++ b/ui/src/shared/components/BoxTooltip.tsx
@@ -32,8 +32,10 @@ const BoxTooltip: FunctionComponent<Props> = ({
     }
 
     const rect = el.getBoundingClientRect()
-
     let left = Math.floor(triggerRect.left - rect.width) - 2
+    // Hacky for #15518 (https://github.com/influxdata/influxdb/issues/15518)
+    // Long term solution would be to have getBoundingClientRect output
+    // to the left / ride side of the div based on boxtooltip location
     let caretClassName = 'left'
 
     // If the width of the tooltip causes it to overflow left

--- a/ui/src/shared/components/BoxTooltip.tsx
+++ b/ui/src/shared/components/BoxTooltip.tsx
@@ -33,7 +33,7 @@ const BoxTooltip: FunctionComponent<Props> = ({
 
     const rect = el.getBoundingClientRect()
 
-    let left = ~~(triggerRect.left - rect.width) - 2
+    let left = Math.floor(triggerRect.left - rect.width) - 2
     let caretClassName = 'left'
 
     // If the width of the tooltip causes it to overflow left

--- a/ui/src/shared/components/BoxTooltip.tsx
+++ b/ui/src/shared/components/BoxTooltip.tsx
@@ -33,7 +33,7 @@ const BoxTooltip: FunctionComponent<Props> = ({
 
     const rect = el.getBoundingClientRect()
 
-    let left = triggerRect.left - rect.width
+    let left = ~~(triggerRect.left - rect.width) - 2
     let caretClassName = 'left'
 
     // If the width of the tooltip causes it to overflow left


### PR DESCRIPTION
Closes #15518 

### Problem

Sometimes hovering over the EventMarker in the alerting checks box would trigger the `BoxTooltip` to periodically render to the right of the mouse rather than the left. Since the div that was being rendered would render over the previous div, the previous div's `onMouseOut` event would be triggered, thereby closing the div that had just been rendered. Once the `div` for the `BoxTooltip` was gone, the mouse was left in the same position, triggering the `onMouseOver` event. This cycle would continue until the mouse was moved.

### Solution

Once the problem was clear, I tried to fix the underlying issue (that the `BoxTooltip` was rendering in the incorrect area). Unfortunately, after quite a few attempts, I was unable to correctly render the `BoxTooltip` consistently enough based on the pointer's coordinates. An easy workaround that I implemented was simply to have the `BoxTooltip` render a couple pixels to the left of where it would have rendered, thereby preventing the jittery cycle and resolving the bug 

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)