### PR TITLE
fix(ui): allow hmr feature with proxied ingress controllers

### DIFF
--- a/ui/webpack.dev.ts
+++ b/ui/webpack.dev.ts
@@ -21,14 +21,10 @@ module.exports = merge(common, {
       '/api/v2': 'http://localhost:9999',
       '/debug/flush': 'http://localhost:9999',
     },
-    watchOptions: {
-      aggregateTimeout: 300,
-      poll: 1000
-    },
     disableHostCheck: true,
     host: '0.0.0.0',
     port: PORT,
-    public: PUBLIC
+    public: PUBLIC,
   },
   module: {
     rules: [

--- a/ui/webpack.dev.ts
+++ b/ui/webpack.dev.ts
@@ -5,6 +5,7 @@ const webpack = require('webpack')
 const common = require('./webpack.common.ts')
 const path = require('path')
 const PORT = parseInt(process.env.PORT, 10) || 8080
+const PUBLIC = process.env.PUBLIC || undefined
 
 module.exports = merge(common, {
   mode: 'development',
@@ -20,8 +21,14 @@ module.exports = merge(common, {
       '/api/v2': 'http://localhost:9999',
       '/debug/flush': 'http://localhost:9999',
     },
+    watchOptions: {
+      aggregateTimeout: 300,
+      poll: 1000
+    },
+    disableHostCheck: true,
     host: '0.0.0.0',
     port: PORT,
+    public: PUBLIC
   },
   module: {
     rules: [


### PR DESCRIPTION
This allows you to pass a root url into the dev server, for when all else fails and you need to hard code some paths. currently, this is used by the hot module replacement mechanism within webpack development server to define the base path of the websocket server from a client's perspective. now we can hide a dev server, running at `http://localhost:9999`, behind the url `https://secure.local:8000`, and HMR should still work. Check the changes in monitor-ci for configuring the ingress controller to pass the correct headers.