### PR TITLE
fix(api): change task ID runs success status from 200 to 201

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [15549](https://github.com/influxdata/influxdb/pull/15549): UI/Task edit functionality fixed
 1. [15559](https://github.com/influxdata/influxdb/pull/15559): Exiting a configuration of a dashboard cell now properly renders the cell content
 1. [15556](https://github.com/influxdata/influxdb/pull/15556): Creating a check now displays on the checklist
+1. [15592](https://github.com/influxdata/influxdb/pull/15592): Changed task runs success status code from 200 to 201 to match Swagger documentation.
 
 ## v2.0.0-alpha.18 [2019-09-26]
 

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -954,7 +954,7 @@ func (h *TaskHandler) handleForceRun(w http.ResponseWriter, r *http.Request) {
 		h.HandleHTTPError(ctx, err, w)
 		return
 	}
-	if err := encodeResponse(ctx, w, http.StatusOK, newRunResponse(*run)); err != nil {
+	if err := encodeResponse(ctx, w, http.StatusCreated, newRunResponse(*run)); err != nil {
 		logEncodingError(h.logger, r, err)
 		return
 	}


### PR DESCRIPTION
Closes #15177 

Changes success status code for task runs endpoint (`/api/v2/tasks/:id/runs`) from 200 to 201.

Note that the `swagger.yml` file already documented a 201 status for this endpoint, so this PR rectifies that discrepancy. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
