### PR TITLE
fix(ui/timerangedropdown): refactored the daterangepicker implementation from modal to popover

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -34,6 +34,128 @@ describe('DataExplorer', () => {
     })
   })
 
+  describe('select time range to query', () => {
+    it('can select different time ranges', () => {
+      // find initial value
+      cy.get('.cf-dropdown--selected')
+        .contains('Past 1')
+        .should('have.length', 1)
+      cy.getByTestID('timerange-popover--dialog').should('have.length', 0)
+      cy.getByTestID('timerange-dropdown').click()
+
+      cy.getByTestID('dropdown-item-past15m').click()
+      cy.get('.cf-dropdown--selected')
+        .contains('Past 15m')
+        .should('have.length', 1)
+
+      cy.getByTestID('timerange-dropdown').click()
+
+      cy.getByTestID('timerange-popover--dialog').should('have.length', 0)
+
+      cy.getByTestID('dropdown-item-customtimerange').click()
+      cy.getByTestID('timerange-popover--dialog').should('have.length', 1)
+    })
+
+    describe('should allow for custom time range selection', () => {
+      beforeEach(() => {
+        cy.getByTestID('timerange-dropdown').click()
+        cy.getByTestID('dropdown-item-customtimerange').click()
+        cy.getByTestID('timerange-popover--dialog').should('have.length', 1)
+      })
+      it.skip('should error when submitting stop dates that are before start dates', () => {
+        // TODO: complete with issue #15632
+        // https://github.com/influxdata/influxdb/issues/15632
+        cy.get('input[title="Start"]')
+          .should('have.length', 1)
+          .clear()
+          .type('2019-10-31')
+
+        cy.get('input[title="Stop"]')
+          .should('have.length', 1)
+          .clear()
+          .type('2019-10-29')
+
+        // click button and see if time range has been selected
+        cy.get('.cf-button--label')
+          .contains('Apply Time Range')
+          .should('have.length', 1)
+          .click()
+
+        // TODO: complete test once functionality is fleshed out
+
+        // cy.get('.cf-dropdown--selected')
+        //   .contains('2019-10-01 00:00 - 2019-10-31 00:00')
+        //   .should('have.length', 1)
+      })
+
+      it.skip('should error when invalid dates are input', () => {
+        // TODO: complete with issue #15632
+        // https://github.com/influxdata/influxdb/issues/15632
+        // default inputs should be valid
+        cy.getByTestID('input-error').should('have.length', 0)
+
+        // type incomplete input
+        cy.get('input[title="Start"]')
+          .should('have.length', 1)
+          .clear()
+          .type('2019-10')
+
+        // invalid date errors
+        cy.getByTestID('input-error').should('have.length', 1)
+
+        // modifies the input to be valid
+        cy.get('input[title="Start"]').type('-01')
+
+        // warnings should not appear
+        cy.getByTestID('input-error').should('have.length', 0)
+
+        // type invalid stop date
+        cy.get('input[title="Stop"]')
+          .should('have.length', 1)
+          .clear()
+          .type('2019-10-')
+
+        // invalid date errors
+        cy.getByTestID('input-error').should('have.length', 1)
+
+        // try submitting invalid date
+        cy.get('.cf-button--label')
+          .contains('Apply Time Range')
+          .should('have.length', 1)
+          .click()
+
+        // TODO: complete test once functionality is fleshed out
+
+        // cy.get('.cf-dropdown--selected')
+        //   .contains('2019-10-01 00:00 - 2019-10-31 00:00')
+        //   .should('have.length', 1)
+      })
+
+      it('can set a custom time range', () => {
+        // set the start and stop dates
+        cy.get('input[title="Start"]')
+          .should('have.length', 1)
+          .clear()
+          .type('2019-10-01')
+
+        cy.get('input[title="Stop"]')
+          .should('have.length', 1)
+          .clear()
+          .type('2019-10-31')
+
+        // click button and see if time range has been selected
+        cy.get('.cf-button--label')
+          .contains('Apply Time Range')
+          .should('have.length', 1)
+          .click()
+
+        cy.get('.cf-dropdown--selected')
+          .contains('2019-10-01 00:00 - 2019-10-31 00:00')
+          .should('have.length', 1)
+      })
+    })
+  })
+
   describe('editing mode switching', () => {
     const measurement = 'my_meas'
     const field = 'my_field'

--- a/ui/src/shared/components/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/TimeRangeDropdown.tsx
@@ -4,7 +4,13 @@ import {get} from 'lodash'
 import moment from 'moment'
 
 // Components
-import {Dropdown} from '@influxdata/clockface'
+import {
+  Dropdown,
+  Popover,
+  PopoverPosition,
+  PopoverInteraction,
+  PopoverType,
+} from '@influxdata/clockface'
 import DateRangePicker from 'src/shared/components/dateRangePicker/DateRangePicker'
 
 // Constants
@@ -40,6 +46,7 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
   }
 
   private dropdownRef = createRef<HTMLDivElement>()
+  private triggerRef = createRef<HTMLSpanElement>()
 
   constructor(props: Props) {
     super(props)
@@ -53,12 +60,26 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
 
     return (
       <>
+        <Popover
+          type={PopoverType.Outline}
+          position={PopoverPosition.ToTheLeft}
+          triggerRef={this.triggerRef}
+          showEvent={PopoverInteraction.Hover}
+          hideEvent={PopoverInteraction.Hover}
+          distanceFromTrigger={8}
+          contents={() => (
+            <div>
+              Hello World
+            </div>
+          )}
+        />
+        {console.log('this over here: ', this)}
         {this.isDatePickerVisible && (
           <DateRangePicker
             timeRange={timeRange}
             onSetTimeRange={this.handleApplyTimeRange}
             onClose={this.handleHideDatePicker}
-            position={centerPicker ? null : this.state.dropdownPosition}
+            position={this.state.dropdownPosition}
           />
         )}
         <div ref={this.dropdownRef}>
@@ -71,13 +92,31 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
             )}
             menu={onCollapse => (
               <Dropdown.Menu
-                onCollapse={onCollapse}
+                // onCollapse={onCollapse}
                 style={{width: `${this.dropdownWidth + 50}px`}}
               >
                 {TIME_RANGES.map(({label}) => {
                   if (label === TIME_RANGE_LABEL) {
                     return (
                       <Dropdown.Divider key={label} text={label} id={label} />
+                    )
+                  }
+                  if (label === CUSTOM_TIME_RANGE_LABEL) {
+                    console.log('this: ', this)
+                    return (
+                      <span
+                        ref={this.triggerRef}
+                        key={label}
+                      >
+                        <Dropdown.Item
+                          value={label}
+                          id={label}
+                          onClick={this.handleChange}
+                          selected={label === timeRange.label}
+                        >
+                          {label}
+                        </Dropdown.Item>
+                      </span>
                     )
                   }
                   return (
@@ -197,7 +236,15 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
     if (label === CUSTOM_TIME_RANGE_LABEL) {
       const {top, left} = this.dropdownRef.current.getBoundingClientRect()
       const right = window.innerWidth - left
-      this.setState({isDatePickerOpen: true, dropdownPosition: {top, right}})
+      this.setState({
+        isDatePickerOpen: true,
+        dropdownPosition: {
+          top,
+          right,
+          transform: 'translate(-50%, -50%)',
+          position: 'fixed',
+        }
+      })
       return
     }
 

--- a/ui/src/shared/components/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/TimeRangeDropdown.tsx
@@ -206,7 +206,7 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
     if (label === CUSTOM_TIME_RANGE_LABEL) {
       this.setState({
         isDatePickerOpen: true,
-        dropdownPosition: {position: 'relative'}
+        dropdownPosition: {position: 'relative'},
       })
       return
     }

--- a/ui/src/shared/components/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/TimeRangeDropdown.tsx
@@ -32,21 +32,15 @@ export enum RangeType {
 interface Props {
   timeRange: TimeRange
   onSetTimeRange: (timeRange: TimeRange, rangeType?: RangeType) => void
-  centerPicker: boolean
 }
 
 interface State {
   isDatePickerOpen: boolean
-  dropdownPosition: {top: number; right: number}
+  dropdownPosition: {position: string}
 }
 
 class TimeRangeDropdown extends PureComponent<Props, State> {
-  public static defaultProps = {
-    centerPicker: false,
-  }
-
   private dropdownRef = createRef<HTMLDivElement>()
-  private triggerRef = createRef<HTMLSpanElement>()
 
   constructor(props: Props) {
     super(props)
@@ -56,32 +50,26 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
 
   public render() {
     const timeRange = this.timeRange
-    const {centerPicker} = this.props
-
     return (
       <>
         <Popover
           type={PopoverType.Outline}
           position={PopoverPosition.ToTheLeft}
-          triggerRef={this.triggerRef}
-          showEvent={PopoverInteraction.Hover}
-          hideEvent={PopoverInteraction.Hover}
+          triggerRef={this.dropdownRef}
+          visible={this.isDatePickerVisible}
+          showEvent={PopoverInteraction.None}
+          hideEvent={PopoverInteraction.None}
           distanceFromTrigger={8}
+          enableDefaultStyles={false}
           contents={() => (
-            <div>
-              Hello World
-            </div>
+            <DateRangePicker
+              timeRange={timeRange}
+              onSetTimeRange={this.handleApplyTimeRange}
+              onClose={this.handleHideDatePicker}
+              position={this.state.dropdownPosition}
+            />
           )}
         />
-        {console.log('this over here: ', this)}
-        {this.isDatePickerVisible && (
-          <DateRangePicker
-            timeRange={timeRange}
-            onSetTimeRange={this.handleApplyTimeRange}
-            onClose={this.handleHideDatePicker}
-            position={this.state.dropdownPosition}
-          />
-        )}
         <div ref={this.dropdownRef}>
           <Dropdown
             style={{width: `${this.dropdownWidth}px`}}
@@ -92,31 +80,13 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
             )}
             menu={onCollapse => (
               <Dropdown.Menu
-                // onCollapse={onCollapse}
+                onCollapse={onCollapse}
                 style={{width: `${this.dropdownWidth + 50}px`}}
               >
                 {TIME_RANGES.map(({label}) => {
                   if (label === TIME_RANGE_LABEL) {
                     return (
                       <Dropdown.Divider key={label} text={label} id={label} />
-                    )
-                  }
-                  if (label === CUSTOM_TIME_RANGE_LABEL) {
-                    console.log('this: ', this)
-                    return (
-                      <span
-                        ref={this.triggerRef}
-                        key={label}
-                      >
-                        <Dropdown.Item
-                          value={label}
-                          id={label}
-                          onClick={this.handleChange}
-                          selected={label === timeRange.label}
-                        >
-                          {label}
-                        </Dropdown.Item>
-                      </span>
                     )
                   }
                   return (
@@ -234,16 +204,9 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
     const timeRange = TIME_RANGES.find(t => t.label === label)
 
     if (label === CUSTOM_TIME_RANGE_LABEL) {
-      const {top, left} = this.dropdownRef.current.getBoundingClientRect()
-      const right = window.innerWidth - left
       this.setState({
         isDatePickerOpen: true,
-        dropdownPosition: {
-          top,
-          right,
-          transform: 'translate(-50%, -50%)',
-          position: 'fixed',
-        }
+        dropdownPosition: {position: 'relative'}
       })
       return
     }

--- a/ui/src/shared/components/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/TimeRangeDropdown.tsx
@@ -60,6 +60,7 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
           showEvent={PopoverInteraction.None}
           hideEvent={PopoverInteraction.None}
           distanceFromTrigger={8}
+          testID="timerange-popover"
           enableDefaultStyles={false}
           contents={() => (
             <DateRangePicker
@@ -73,6 +74,7 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
         <div ref={this.dropdownRef}>
           <Dropdown
             style={{width: `${this.dropdownWidth}px`}}
+            testID="timerange-dropdown"
             button={(active, onClick) => (
               <Dropdown.Button active={active} onClick={onClick}>
                 {this.formattedCustomTimeRange}
@@ -89,11 +91,13 @@ class TimeRangeDropdown extends PureComponent<Props, State> {
                       <Dropdown.Divider key={label} text={label} id={label} />
                     )
                   }
+                  const testID = label.toLowerCase().replace(/\s/g, '')
                   return (
                     <Dropdown.Item
                       key={label}
                       value={label}
                       id={label}
+                      testID={`dropdown-item-${testID}`}
                       selected={label === timeRange.label}
                       onClick={this.handleChange}
                     >

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
@@ -13,7 +13,7 @@ interface Props {
   timeRange: TimeRange
   onSetTimeRange: (timeRange: TimeRange) => void
   onClose: () => void
-  position?: {top?: number; right?: number; bottom?: number; left?: number}
+  position?: {top?: number; right?: number; bottom?: number; left?: number; position?: string}
 }
 
 interface State {
@@ -86,7 +86,6 @@ class DateRangePicker extends PureComponent<Props, State> {
         } else {
           obj[k] = `${v}px`
         }
-        console.log('obj: ', obj)
         return obj;
       },
       {}

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
@@ -79,7 +79,16 @@ class DateRangePicker extends PureComponent<Props, State> {
     }
 
     const style = Object.entries(position).reduce(
-      (acc, [k, v]) => ({...acc, [k]: `${v}px`}),
+      (acc, [k, v]) => {
+        const obj = { ...acc }
+        if (isNaN(+v)) {
+          obj[k] = v
+        } else {
+          obj[k] = `${v}px`
+        }
+        console.log('obj: ', obj)
+        return obj;
+      },
       {}
     )
 

--- a/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
+++ b/ui/src/shared/components/dateRangePicker/DateRangePicker.tsx
@@ -13,7 +13,13 @@ interface Props {
   timeRange: TimeRange
   onSetTimeRange: (timeRange: TimeRange) => void
   onClose: () => void
-  position?: {top?: number; right?: number; bottom?: number; left?: number; position?: string}
+  position?: {
+    top?: number
+    right?: number
+    bottom?: number
+    left?: number
+    position?: string
+  }
 }
 
 interface State {
@@ -78,18 +84,15 @@ class DateRangePicker extends PureComponent<Props, State> {
       }
     }
 
-    const style = Object.entries(position).reduce(
-      (acc, [k, v]) => {
-        const obj = { ...acc }
-        if (isNaN(+v)) {
-          obj[k] = v
-        } else {
-          obj[k] = `${v}px`
-        }
-        return obj;
-      },
-      {}
-    )
+    const style = Object.entries(position).reduce((acc, [k, v]) => {
+      const obj = {...acc}
+      if (isNaN(+v)) {
+        obj[k] = v
+      } else {
+        obj[k] = `${v}px`
+      }
+      return obj
+    }, {})
 
     return style
   }

--- a/ui/src/timeMachine/components/Queries.tsx
+++ b/ui/src/timeMachine/components/Queries.tsx
@@ -81,7 +81,6 @@ class TimeMachineQueries extends PureComponent<Props> {
                   <TimeRangeDropdown
                     timeRange={timeRange}
                     onSetTimeRange={this.handleSetTimeRange}
-                    centerPicker={true}
                   />
                   <TimeMachineQueriesSwitcher />
                 </>


### PR DESCRIPTION
Closes #15420 

### Problem

The current Data Explorer DateRangePicker was set in a modal that would render to a fixed location on the screen (middle)

### Solution

Refactored the way the component was being rendered so that it was relative to the dropdown and within a popover

![datetimepopover](https://user-images.githubusercontent.com/19984220/67714278-d0777600-f984-11e9-9a48-7b6a964624ab.gif)
