### PR TITLE
chore(ui): remove react tooltip

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -164,7 +164,6 @@
     "react-router": "^3.0.2",
     "react-router-redux": "^4.0.8",
     "react-scrollbars-custom": "^4.0.0-alpha.8",
-    "react-tooltip": "^3.2.1",
     "react-virtualized": "^9.18.5",
     "redux": "^4.0.0",
     "redux-auth-wrapper": "^1.0.0",


### PR DESCRIPTION
Closes #15421

all references are removed from this library. if tests pass, it should be fine to delete, cause that's why we have tests.