### PR TITLE
fix: influxd restore and influx import feedback bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.8.0 [unreleased]
 
 -	[#10503](https://github.com/influxdata/influxdb/pull/10503): Delete rebuilds series index when series to be deleted are only found in cache.
 -	[#10504](https://github.com/influxdata/influxdb/issue/10504): Delete rebuilds series index when series to be deleted are outside timerange.
+-   [#15620](https://github.com/influxdata/influxdb/pull/15620): Influxd restore and influx import feedback bugfix.
 
 v1.7.0 [unreleased]
 -------------------

--- a/cmd/influxd/restore/restore.go
+++ b/cmd/influxd/restore/restore.go
@@ -560,7 +560,7 @@ func (cmd *Command) unpackTar(tarFile string) error {
 		return fmt.Errorf("backup tarfile name incorrect format")
 	}
 
-	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.Trim(pathParts[2], "0"))
+	shardPath := filepath.Join(cmd.datadir, pathParts[0], pathParts[1], strings.TrimPrefix(pathParts[2], "0"))
 	os.MkdirAll(shardPath, 0755)
 
 	return tarstream.Restore(f, shardPath)

--- a/importer/v8/importer.go
+++ b/importer/v8/importer.go
@@ -15,6 +15,7 @@ import (
 )
 
 const batchSize = 5000
+const reportSize = 100000
 
 // Config is the config used to initialize a Importer importer
 type Config struct {
@@ -40,6 +41,7 @@ type Importer struct {
 	batch                 []string
 	totalInserts          int
 	failedInserts         int
+	reports               int
 	totalCommands         int
 	throttlePointsWritten int
 	startTime             time.Time
@@ -266,9 +268,10 @@ func (i *Importer) batchWrite() {
 	i.batch = i.batch[:0]
 	// Give some status feedback every 100000 lines processed
 	processed := i.totalInserts + i.failedInserts
-	if processed%100000 == 0 {
+	if processed/reportSize > i.reports {
 		since := time.Since(i.startTime)
 		pps := float64(processed) / since.Seconds()
 		i.stdoutLogger.Printf("Processed %d lines.  Time elapsed: %s.  Points per second (PPS): %d", processed, since.String(), int64(pps))
+		i.reports += 1
 	}
 }

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -890,6 +890,12 @@ func (data *Data) importOneDB(other Data, backupDBName, restoreDBName, backupRPN
 		}
 	}
 
+	// import all CQs
+	dbImport.ContinuousQueries = []ContinuousQueryInfo{}
+	for _, cqPtr := range dbPtr.ContinuousQueries {
+		dbImport.ContinuousQueries = append(dbImport.ContinuousQueries, cqPtr.clone())
+	}
+
 	return restoreDBName, nil
 }
 


### PR DESCRIPTION
I find the bug and some can be better when I use influxd restore and influx import tool.
- influxd restore: Any shard that ends with "0" will restore to wrong shard.
- influxd restore: Continuous queries have not restored.
- influxd import: When import multi databases or rps, the feedback have not given.

Describe your proposed changes here.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] Tests pass
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
