### PR TITLE
Updated Flux functions list for flux 0.51.0

### DIFF
--- a/ui/src/shared/constants/fluxFunctions.ts
+++ b/ui/src/shared/constants/fluxFunctions.ts
@@ -3046,6 +3046,23 @@ export const FLUX_FUNCTIONS: FluxToolbarFunction[] = [
       'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/transformations/pivot/',
   },
   {
+    name: 'prometheus.histogramQuantile',
+    args: [
+      {
+        name: 'quantile',
+        desc: 'A value between 0.0 and 1.0 indicating the desired quantile.',
+        type: 'Float',
+      },
+    ],
+    package: 'experimental/prometheus',
+    desc:
+      'Calculates quantiles on a set of values assuming the histogram data is scraped or read from a Prometheus data source.',
+    example: 'prometheus.histogramQuantile(quantile: 0.99)',
+    category: 'Transformations',
+    link:
+      'https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/experimental/prometheus/histogramquantile/',
+  },
+  {
     name: 'prometheus.scrape',
     args: [
       {


### PR DESCRIPTION
Depends on #15616 

Added `prometheus.histogramQuatile()` to `fluxFunctions.ts`.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
