### PR TITLE
feat(tasks): expose lastRunStatus and lastRunError in task API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [15313](https://github.com/influxdata/influxdb/pull/15313): Add shortcut for toggling comments in script editor
+1. [15650](https://github.com/influxdata/influxdb/pull/15650): Expose last run status and last run error in task API
 
 ### UI Improvements
 1. [15503](https://github.com/influxdata/influxdb/pull/15503): Redesign page headers to be more space efficient

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7155,6 +7155,16 @@ components:
           type: string
           format: date-time
           readOnly: true
+        lastRunStatus:
+          readOnly: true
+          type: string
+          enum:
+            - failed
+            - success
+            - canceled
+        lastRunError:
+          readOnly: true
+          type: string
         createdAt:
           type: string
           format: date-time

--- a/task.go
+++ b/task.go
@@ -44,6 +44,8 @@ type Task struct {
 	Cron            string                 `json:"cron,omitempty"`
 	Offset          string                 `json:"offset,omitempty"`
 	LatestCompleted string                 `json:"latestCompleted,omitempty"`
+	LastRunStatus   string                 `json:"lastRunStatus,omitempty"`
+	LastRunError    string                 `json:"lastRunError,omitempty"`
 	CreatedAt       string                 `json:"createdAt,omitempty"`
 	UpdatedAt       string                 `json:"updatedAt,omitempty"`
 	Metadata        map[string]interface{} `json:"metadata,omitempty"`
@@ -230,6 +232,8 @@ type TaskUpdate struct {
 
 	// LatestCompleted us to set latest completed on startup to skip task catchup
 	LatestCompleted *string                `json:"-"`
+	LastRunStatus   *string                `json:"-"`
+	LastRunError    *string                `json:"-"`
 	Metadata        map[string]interface{} `json:"-"` // not to be set through a web request but rather used by a http service using tasks backend.
 
 	// Options gets unmarshalled from json as if it was flat, with the same level as Flux and Status.


### PR DESCRIPTION
Closes #15153 

This PR exposes `lastRunStatus` and `lastRunError` in the task API object and records corresponding fields on the backend task model. If `lastRunStatus` is `"failed"`, `lastRunError` is recorded as the last message in the task run log. Otherwise, `lastRunError` is cleared. Both new fields are excluded from the response if empty.

The [task update logic](https://github.com/influxdata/influxdb/pull/15650/files#diff-305c59262c657f72f86a5054a59d462eR745) is augmented to allow the status and error to be updated, and the [task run finish logic](https://github.com/influxdata/influxdb/pull/15650/files#diff-305c59262c657f72f86a5054a59d462eR1580) takes advantage of this new capability. [Tests](https://github.com/influxdata/influxdb/pull/15650/files#diff-bf1d0d8dc888d493a547519debfe320d) are included.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
