### PR TITLE
feat: add status changes back to rules

### DIFF
--- a/ui/src/alerting/components/notifications/StatusLevels.tsx
+++ b/ui/src/alerting/components/notifications/StatusLevels.tsx
@@ -9,7 +9,7 @@ import {
   ComponentSize,
 } from '@influxdata/clockface'
 import RuleLevelsDropdown from 'src/alerting/components/notifications/RuleLevelsDropdown'
-// import StatusChangeDropdown from 'src/alerting/components/notifications/StatusChangeDropdown'
+import StatusChangeDropdown from 'src/alerting/components/notifications/StatusChangeDropdown'
 import {LevelType} from 'src/alerting/components/notifications/RuleOverlay.reducer'
 
 // Utils
@@ -35,15 +35,13 @@ const StatusLevels: FC<Props> = ({status}) => {
     })
   }
 
-  // TODO: remove these comments when status change actually works
   return (
     <FlexBox direction={FlexDirection.Row} margin={ComponentSize.Small}>
       <TextBlock text="When status" />
       <FlexBox.Child grow={0} basis={140}>
-        <TextBlock text="is equal to" />
-        {/*<StatusChangeDropdown status={status} />*/}
+        <StatusChangeDropdown status={status} />
       </FlexBox.Child>
-      {/*{!!previousLevel && (
+      {!!previousLevel && (
         <FlexBox.Child grow={0} basis={140}>
           <RuleLevelsDropdown
             type="previousLevel"
@@ -52,8 +50,8 @@ const StatusLevels: FC<Props> = ({status}) => {
             onClickLevel={onClickLevel}
           />
         </FlexBox.Child>
-      )*/}
-      {/* !!previousLevel && <TextBlock text="to" /> */}
+      )}
+      {!!previousLevel && <TextBlock text="to" />}
       <FlexBox.Child grow={0} basis={140}>
         <RuleLevelsDropdown
           type="currentLevel"

--- a/ui/src/alerting/components/notifications/utils/index.ts
+++ b/ui/src/alerting/components/notifications/utils/index.ts
@@ -105,13 +105,11 @@ export const draftRuleToPostRule = (
   draftRule: NotificationRuleDraft
 ): PostNotificationRule => {
   return {
-    id: '',
     ...draftRule,
     statusRules: draftRule.statusRules.map(r => r.value),
     tagRules: draftRule.tagRules
       .map(r => r.value)
       .filter(tr => tr.key && tr.value),
-    labels: draftRule.labels.map(l => l.id),
   } as PostNotificationRule
 }
 


### PR DESCRIPTION
Closes #15155 

This adds back the ability for a notification to fire if a status changes from `OK` to `CRIT` etc.  

### Notes
Would love to add tests but rule creation is waiting for https://github.com/influxdata/influxdb/issues/14799 until we can start adding some e2e's. 
