### PR TITLE
fix(flux): use flux.EvalOptions over problematic flux.EvalAST

### DIFF
--- a/task/options/options.go
+++ b/task/options/options.go
@@ -225,7 +225,7 @@ func FromScript(script string) (Options, error) {
 	durTypes := grabTaskOptionAST(fluxAST, optEvery, optOffset)
 	// TODO(desa): should be dependencies.NewEmpty(), but for now we'll hack things together
 	ctx := newDeps().Inject(context.Background())
-	_, scope, err := flux.EvalAST(ctx, fluxAST)
+	_, scope, err := flux.EvalOptions(ctx, fluxAST)
 	if err != nil {
 		return opt, err
 	}

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -25,7 +25,8 @@ describe('Tasks', () => {
     })
   })
 
-  it('cannot create a task with an invalid to() function', () => {
+  it.skip('cannot create a task with an invalid to() function', () => {
+    // skipped pending https://github.com/influxdata/flux/issues/2085
     const taskName = 'Bad Task'
 
     createFirstTask(taskName, ({name}) => {


### PR DESCRIPTION
Closes #15583 

Use `EvalOptions` instead of `EvalAST` to avoid missing dependencies in the rest of the AST when we only need the options.

This change removes most of the flux script pre-checking we do on task creation. As a result, a UI test is skipped until more robust static pre-checking is available after the Flux team's Algorithm W work is completed. Relevant [Flux issue](https://github.com/influxdata/flux/issues/2085).

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
