### PR TITLE
refactor(tasks): use go time in task struct

### DIFF
--- a/crud_log.go
+++ b/crud_log.go
@@ -1,8 +1,6 @@
 package influxdb
 
 import (
-	"encoding/json"
-	"errors"
 	"time"
 )
 
@@ -40,36 +38,4 @@ type RealTimeGenerator struct{}
 // Now returns the current time.
 func (g RealTimeGenerator) Now() time.Time {
 	return time.Now()
-}
-
-// Duration is based on time.Duration to embed in any struct.
-type Duration struct {
-	time.Duration
-}
-
-// MarshalJSON implements json.Marshaler interface.
-func (d Duration) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.String())
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface.
-func (d *Duration) UnmarshalJSON(b []byte) error {
-	var v interface{}
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	switch value := v.(type) {
-	case float64:
-		d.Duration = time.Duration(value)
-		return nil
-	case string:
-		var err error
-		d.Duration, err = time.ParseDuration(value)
-		if err != nil {
-			return err
-		}
-		return nil
-	default:
-		return errors.New("invalid duration")
-	}
 }

--- a/duration.go
+++ b/duration.go
@@ -1,0 +1,39 @@
+package influxdb
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Duration is based on time.Duration to embed in any struct.
+type Duration struct {
+	time.Duration
+}
+
+// MarshalJSON implements json.Marshaler interface.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		d.Duration = time.Duration(value)
+		return nil
+	case string:
+		var err error
+		d.Duration, err = time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}

--- a/kv/task_test.go
+++ b/kv/task_test.go
@@ -159,7 +159,7 @@ func TestNextRunDue(t *testing.T) {
 
 		// +20 to account for the 20 second offset in the flux script
 		oldNextDue := run.Created.Now
-		if task.Offset != "" {
+		if task.Offset != 0 {
 			oldNextDue += 20
 		}
 		if oldNextDue != nd {

--- a/task.go
+++ b/task.go
@@ -42,13 +42,13 @@ type Task struct {
 	Flux            string                 `json:"flux"`
 	Every           string                 `json:"every,omitempty"`
 	Cron            string                 `json:"cron,omitempty"`
-	Offset          string                 `json:"offset,omitempty"`
-	LatestCompleted string                 `json:"latestCompleted,omitempty"`
+	Offset          time.Duration          `json:"offset,omitempty"`
+	LatestCompleted time.Time              `json:"latestCompleted,omitempty"`
 	LatestScheduled time.Time              `json:"latestScheduled,omitempty"`
 	LastRunStatus   string                 `json:"lastRunStatus,omitempty"`
 	LastRunError    string                 `json:"lastRunError,omitempty"`
-	CreatedAt       string                 `json:"createdAt,omitempty"`
-	UpdatedAt       string                 `json:"updatedAt,omitempty"`
+	CreatedAt       time.Time              `json:"createdAt,omitempty"`
+	UpdatedAt       time.Time              `json:"updatedAt,omitempty"`
 	Metadata        map[string]interface{} `json:"metadata,omitempty"`
 }
 
@@ -65,23 +65,6 @@ func (t *Task) EffectiveCron() string {
 		return "@every " + t.Every
 	}
 	return ""
-}
-
-// LatestCompletedTime gives the time.Time that the task was last queued to be run in RFC3339 format.
-func (t *Task) LatestCompletedTime() (time.Time, error) {
-	tm := t.LatestCompleted
-	if tm == "" {
-		tm = t.CreatedAt
-	}
-	return time.Parse(time.RFC3339, tm)
-}
-
-// OffsetDuration gives the time.Duration of the Task's Offset property, which represents a delay before execution
-func (t *Task) OffsetDuration() (time.Duration, error) {
-	if t.Offset == "" {
-		return time.Duration(0), nil
-	}
-	return time.ParseDuration(t.Offset)
 }
 
 // Run is a record createId when a run of a task is scheduled.
@@ -177,7 +160,7 @@ type TaskUpdate struct {
 	Description *string `json:"description,omitempty"`
 
 	// LatestCompleted us to set latest completed on startup to skip task catchup
-	LatestCompleted *string                `json:"-"`
+	LatestCompleted *time.Time             `json:"-"`
 	LatestScheduled *time.Time             `json:"-"`
 	LastRunStatus   *string                `json:"-"`
 	LastRunError    *string                `json:"-"`

--- a/task/backend/coordinator.go
+++ b/task/backend/coordinator.go
@@ -33,7 +33,7 @@ func NotifyCoordinatorOfExisting(ctx context.Context, ts TaskService, coord Coor
 		return err
 	}
 
-	latestCompleted := now().Format(time.RFC3339)
+	latestCompleted := now()
 	for len(tasks) > 0 {
 		for _, task := range tasks {
 			if task.Status != string(TaskActive) {
@@ -74,7 +74,7 @@ func TaskNotifyCoordinatorOfExisting(ctx context.Context, ts TaskService, tcs Ta
 		return err
 	}
 
-	latestCompleted := now().Format(time.RFC3339)
+	latestCompleted := now()
 	for len(tasks) > 0 {
 		for _, task := range tasks {
 			if task.Status != string(TaskActive) {

--- a/task/backend/coordinator/task_coordinator.go
+++ b/task/backend/coordinator/task_coordinator.go
@@ -53,8 +53,7 @@ func (t SchedulableTask) Schedule() scheduler.Schedule {
 
 // Offset returns a time.Duration for the Task's offset property
 func (t SchedulableTask) Offset() time.Duration {
-	offset, _ := t.OffsetDuration()
-	return offset
+	return t.Task.Offset
 }
 
 // LastScheduled parses the task's LatestCompleted value as a Time object
@@ -62,13 +61,11 @@ func (t SchedulableTask) LastScheduled() time.Time {
 	if !t.LatestScheduled.IsZero() {
 		return t.LatestScheduled
 	}
-	if t.LatestCompleted != "" {
-		latestCompleted, _ := t.LatestCompletedTime()
-		return latestCompleted
+	if !t.LatestCompleted.IsZero() {
+		return t.LatestCompleted
 	}
 
-	createdAt, _ := time.Parse(time.RFC3339, t.CreatedAt)
-	return createdAt
+	return t.CreatedAt
 }
 
 func WithLimitOpt(i int) CoordinatorOption {
@@ -79,13 +76,7 @@ func WithLimitOpt(i int) CoordinatorOption {
 
 // NewSchedulableTask transforms an influxdb task to a schedulable task type
 func NewSchedulableTask(task *influxdb.Task) (SchedulableTask, error) {
-	if offset, err := task.OffsetDuration(); offset != time.Duration(0) && err != nil {
-		return SchedulableTask{}, errors.New("could not create schedulable task: offset duration could not be parsed")
-	}
 
-	if _, err := task.LatestCompletedTime(); err != nil {
-		return SchedulableTask{}, errors.New("could not create schedulable task: latest completed time could not be parsed")
-	}
 	if task.Cron == "" && task.Every == "" {
 		return SchedulableTask{}, errors.New("invalid cron or every")
 	}

--- a/task/backend/coordinator/task_coordinator_test.go
+++ b/task/backend/coordinator/task_coordinator_test.go
@@ -100,7 +100,7 @@ func Test_Coordinator_Scheduler_Methods(t *testing.T) {
 		one   = influxdb.ID(1)
 		two   = influxdb.ID(2)
 		three = influxdb.ID(3)
-		now   = time.Now().Format(time.RFC3339Nano)
+		now   = time.Now().UTC()
 
 		taskOne           = &influxdb.Task{ID: one, CreatedAt: now, Cron: "* * * * *"}
 		taskTwo           = &influxdb.Task{ID: two, Status: "active", CreatedAt: now, Cron: "* * * * *"}

--- a/task/backend/coordinator_test.go
+++ b/task/backend/coordinator_test.go
@@ -16,8 +16,7 @@ var (
 	three = influxdb.ID(3)
 	four  = influxdb.ID(4)
 
-	aTime      = time.Now()
-	aTimeStamp = aTime.Format(time.RFC3339)
+	aTime = time.Now().UTC()
 
 	taskOne   = &influxdb.Task{ID: one}
 	taskTwo   = &influxdb.Task{ID: two, Status: "active"}
@@ -56,7 +55,7 @@ func Test_NotifyCoordinatorOfCreated(t *testing.T) {
 	}
 
 	if diff := cmp.Diff([]update{
-		{two, influxdb.TaskUpdate{LatestCompleted: &aTimeStamp}},
+		{two, influxdb.TaskUpdate{LatestCompleted: &aTime}},
 	}, tasks.updates); diff != "" {
 		t.Errorf("unexpected updates to task service %v", diff)
 	}

--- a/task/backend/middleware/check_middleware.go
+++ b/task/backend/middleware/check_middleware.go
@@ -81,7 +81,7 @@ func (cs *CoordinatingCheckService) UpdateCheck(ctx context.Context, id influxdb
 	// if the update is to activate and the previous task was inactive we should add a "latest completed" update
 	// this allows us to see not run the task for inactive time
 	if fromTask.Status == string(backend.TaskInactive) && toTask.Status == string(backend.TaskActive) {
-		toTask.LatestCompleted = cs.Now().Format(time.RFC3339)
+		toTask.LatestCompleted = cs.Now()
 	}
 
 	return to, cs.coordinator.TaskUpdated(ctx, fromTask, toTask)
@@ -112,7 +112,7 @@ func (cs *CoordinatingCheckService) PatchCheck(ctx context.Context, id influxdb.
 	// if the update is to activate and the previous task was inactive we should add a "latest completed" update
 	// this allows us to see not run the task for inactive time
 	if fromTask.Status == string(backend.TaskInactive) && toTask.Status == string(backend.TaskActive) {
-		toTask.LatestCompleted = cs.Now().Format(time.RFC3339)
+		toTask.LatestCompleted = cs.Now()
 	}
 
 	return to, cs.coordinator.TaskUpdated(ctx, fromTask, toTask)

--- a/task/backend/middleware/check_middleware_test.go
+++ b/task/backend/middleware/check_middleware_test.go
@@ -216,7 +216,7 @@ func TestCheckUpdateFromInactive(t *testing.T) {
 		if task.ID != thecheck.GetTaskID() {
 			t.Fatalf("task sent to coordinator doesn't match expected")
 		}
-		if task.LatestCompleted != latest.Format(time.RFC3339) {
+		if task.LatestCompleted != latest {
 			t.Fatalf("update returned incorrect LatestCompleted, expected %s got %s, or ", latest.Format(time.RFC3339), task.LatestCompleted)
 		}
 	default:
@@ -233,7 +233,7 @@ func TestCheckUpdateFromInactive(t *testing.T) {
 		if task.ID != thecheck.GetTaskID() {
 			t.Fatalf("task sent to coordinator doesn't match expected")
 		}
-		if task.LatestCompleted != latest.Format(time.RFC3339) {
+		if task.LatestCompleted != latest {
 			t.Fatalf("update returned incorrect LatestCompleted, expected %s got %s, or ", latest.Format(time.RFC3339), task.LatestCompleted)
 		}
 	default:

--- a/task/backend/middleware/middleware.go
+++ b/task/backend/middleware/middleware.go
@@ -76,7 +76,7 @@ func (s *CoordinatingTaskService) UpdateTask(ctx context.Context, id influxdb.ID
 	if upd.Status != nil && *upd.Status == string(backend.TaskActive) {
 		// confirm that it was inactive and this is an attempt to activate
 		if from.Status == string(backend.TaskInactive) {
-			lc := s.now().Format(time.RFC3339)
+			lc := s.now()
 			upd.LatestCompleted = &lc
 		}
 	}

--- a/task/backend/middleware/middleware_test.go
+++ b/task/backend/middleware/middleware_test.go
@@ -257,7 +257,7 @@ func TestCoordinatingTaskService_ClaimTaskUpdatesLatestCompleted(t *testing.T) {
 
 	select {
 	case claimedTask := <-cchan:
-		if claimedTask.LatestCompleted != latest.UTC().Format(time.RFC3339) {
+		if claimedTask.LatestCompleted != latest.UTC() {
 			t.Fatal("failed up update latest completed in claimed task")
 		}
 	case <-time.After(time.Second):

--- a/task/backend/middleware/notification_middleware.go
+++ b/task/backend/middleware/notification_middleware.go
@@ -80,7 +80,7 @@ func (ns *CoordinatingNotificationRuleStore) UpdateNotificationRule(ctx context.
 	// if the update is to activate and the previous task was inactive we should add a "latest completed" update
 	// this allows us to see not run the task for inactive time
 	if fromTask.Status == string(backend.TaskInactive) && toTask.Status == string(backend.TaskActive) {
-		toTask.LatestCompleted = ns.Now().Format(time.RFC3339)
+		toTask.LatestCompleted = ns.Now()
 	}
 
 	return to, ns.coordinator.TaskUpdated(ctx, fromTask, toTask)
@@ -111,7 +111,7 @@ func (ns *CoordinatingNotificationRuleStore) PatchNotificationRule(ctx context.C
 	// if the update is to activate and the previous task was inactive we should add a "latest completed" update
 	// this allows us to see not run the task for inactive time
 	if fromTask.Status == string(backend.TaskInactive) && toTask.Status == string(backend.TaskActive) {
-		toTask.LatestCompleted = ns.Now().Format(time.RFC3339)
+		toTask.LatestCompleted = ns.Now()
 	}
 
 	return to, ns.coordinator.TaskUpdated(ctx, fromTask, toTask)

--- a/task/backend/middleware/notification_middleware_test.go
+++ b/task/backend/middleware/notification_middleware_test.go
@@ -107,7 +107,7 @@ func TestNotificationRuleUpdateFromInactive(t *testing.T) {
 		if task.ID != therule.GetTaskID() {
 			t.Fatalf("task sent to coordinator doesn't match expected")
 		}
-		if task.LatestCompleted != latest.Format(time.RFC3339) {
+		if task.LatestCompleted != latest {
 			t.Fatalf("update returned incorrect LatestCompleted, expected %s got %s, or ", latest.Format(time.RFC3339), task.LatestCompleted)
 		}
 	default:
@@ -124,7 +124,7 @@ func TestNotificationRuleUpdateFromInactive(t *testing.T) {
 		if task.ID != therule.GetTaskID() {
 			t.Fatalf("task sent to coordinator doesn't match expected")
 		}
-		if task.LatestCompleted != latest.Format(time.RFC3339) {
+		if task.LatestCompleted != latest {
 			t.Fatalf("update returned incorrect LatestCompleted, expected %s got %s, or ", latest.Format(time.RFC3339), task.LatestCompleted)
 		}
 	default:

--- a/task/backend/schedulable_task_service_test.go
+++ b/task/backend/schedulable_task_service_test.go
@@ -10,13 +10,12 @@ import (
 )
 
 var (
-	mockTaskID     = influxdb.ID(1)
-	mockTimeNow    = time.Now()
-	mockTimeNowStr = time.Now().Format(time.RFC3339Nano)
+	mockTaskID  = influxdb.ID(1)
+	mockTimeNow = time.Now()
 )
 
 func (m MockTaskService) UpdateTask(_ context.Context, id influxdb.ID, _ influxdb.TaskUpdate) (*influxdb.Task, error) {
-	return &influxdb.Task{ID: id, UpdatedAt: mockTimeNowStr}, nil
+	return &influxdb.Task{ID: id, UpdatedAt: mockTimeNow}, nil
 }
 
 type MockTaskService struct{}

--- a/task/backend/scheduler_test.go
+++ b/task/backend/scheduler_test.go
@@ -34,11 +34,13 @@ func TestScheduler_Cancelation(t *testing.T) {
 	defer o.Stop()
 
 	const orgID = 2
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:04Z")
+
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		OrganizationID:  orgID,
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:04Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 	tcs.SetTask(task)
@@ -78,10 +80,11 @@ func TestScheduler_StartScriptOnClaim(t *testing.T) {
 	o.Start(context.Background())
 	defer o.Stop()
 
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:03Z")
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Cron:            "* * * * *",
-		LatestCompleted: "1970-01-01T00:00:03Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -99,7 +102,7 @@ func TestScheduler_StartScriptOnClaim(t *testing.T) {
 	task = &platform.Task{
 		ID:              platform.ID(2),
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:03Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {concurrency: 99, name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -145,11 +148,12 @@ func TestScheduler_DontRunInactiveTasks(t *testing.T) {
 	o := backend.NewScheduler(tcs, e, 5)
 	o.Start(context.Background())
 	defer o.Stop()
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:05Z")
 
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:05Z",
+		LatestCompleted: latestCompleted,
 		Status:          "inactive",
 		Flux:            `option task = {concurrency: 2, name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
@@ -177,11 +181,12 @@ func TestScheduler_CreateNextRunOnTick(t *testing.T) {
 	o := backend.NewScheduler(tcs, e, 5)
 	o.Start(context.Background())
 	defer o.Stop()
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:05Z")
 
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:05Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {concurrency: 2, name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -252,12 +257,13 @@ func TestScheduler_LogStatisticsOnSuccess(t *testing.T) {
 
 	const taskID = 0x12345
 	const orgID = 0x54321
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:05Z")
 
 	task := &platform.Task{
 		ID:              taskID,
 		OrganizationID:  orgID,
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:05Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -315,11 +321,12 @@ func TestScheduler_Release(t *testing.T) {
 	o := backend.NewScheduler(tcs, e, 5)
 	o.Start(context.Background())
 	defer o.Stop()
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:05Z")
 
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:05Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {concurrency: 99, name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -351,11 +358,12 @@ func TestScheduler_UpdateTask(t *testing.T) {
 	s := backend.NewScheduler(tcs, e, 3059, backend.WithLogger(zaptest.NewLogger(t)))
 	s.Start(context.Background())
 	defer s.Stop()
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:50:00Z")
 
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Cron:            "* * * * *",
-		LatestCompleted: "1970-01-01T00:50:00Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -402,11 +410,12 @@ func TestScheduler_Queue(t *testing.T) {
 	o := backend.NewScheduler(tcs, e, 3059, backend.WithLogger(zaptest.NewLogger(t)))
 	o.Start(context.Background())
 	defer o.Stop()
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:50:00Z")
 
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Cron:            "* * * * *",
-		LatestCompleted: "1970-01-01T00:50:00Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 	t1, _ := time.Parse(time.RFC3339, "1970-01-01T00:02:00Z")
@@ -639,13 +648,14 @@ func TestScheduler_RunStatus(t *testing.T) {
 	s := backend.NewScheduler(rl, e, 5, backend.WithLogger(zaptest.NewLogger(t)))
 	s.Start(context.Background())
 	defer s.Stop()
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:05Z")
 
 	// Claim a task that starts later.
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		OrganizationID:  platform.ID(2),
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:05Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {concurrency: 99, name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -739,12 +749,13 @@ func TestScheduler_RunFailureCleanup(t *testing.T) {
 	s := backend.NewScheduler(ll, e, 5, backend.WithLogger(zaptest.NewLogger(t)))
 	s.Start(context.Background())
 	defer s.Stop()
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:05Z")
 
 	// Task with concurrency 1 should continue after one run fails.
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:05Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -829,10 +840,11 @@ func TestScheduler_Metrics(t *testing.T) {
 	reg.MustRegister(s.PrometheusCollectors()...)
 
 	// Claim a task that starts later.
+	latestCompleted, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:05Z")
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Every:           "1s",
-		LatestCompleted: "1970-01-01T00:00:05Z",
+		LatestCompleted: latestCompleted,
 		Flux:            `option task = {concurrency: 99, name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
 	}
 
@@ -1008,12 +1020,12 @@ func TestScheduler_WithTicker(t *testing.T) {
 
 	o.Start(ctx)
 	defer o.Stop()
-	createdAt := time.Now()
+	createdAt := time.Now().UTC()
 	task := &platform.Task{
 		ID:              platform.ID(1),
 		Every:           "1s",
 		Flux:            `option task = {concurrency: 5, name:"x", every:1m} from(bucket:"a") |> to(bucket:"b", org: "o")`,
-		LatestCompleted: createdAt.Format(time.RFC3339Nano),
+		LatestCompleted: createdAt,
 	}
 
 	tcs.SetTask(task)

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -249,7 +249,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		OwnerID:         tsk.OwnerID,
 		Name:            "task #0",
 		Cron:            "* * * * *",
-		Offset:          "5s",
+		Offset:          5 * time.Second,
 		Status:          string(backend.DefaultTaskStatus),
 		Flux:            fmt.Sprintf(scriptFmt, 0),
 		Type:            influxdb.TaskSystemType,
@@ -563,7 +563,8 @@ from(bucket: "b")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if fNoOffset.Offset != "" {
+		var zero time.Duration
+		if fNoOffset.Offset != zero {
 			t.Fatal("removing offset failed")
 		}
 	})
@@ -599,19 +600,13 @@ func testUpdate(t *testing.T, sys *System) {
 	after := time.Now()
 	latestCA := after.Add(time.Second)
 
-	ca, err := time.Parse(time.RFC3339, st.CreatedAt)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ca := st.CreatedAt
 
 	if earliestCA.After(ca) || latestCA.Before(ca) {
 		t.Fatalf("createdAt not accurate, expected %s to be between %s and %s", ca, earliestCA, latestCA)
 	}
 
-	ti, err := time.Parse(time.RFC3339, st.LatestCompleted)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ti := st.LatestCompleted
 
 	if now.Sub(ti) > 10*time.Second {
 		t.Fatalf("latest completed not accurate, expected: ~%s, got %s", now, ti)
@@ -641,7 +636,7 @@ func testUpdate(t *testing.T, sys *System) {
 		t.Fatal(err)
 	}
 
-	if st2.LatestCompleted <= st.LatestCompleted {
+	if st2.LatestCompleted.Before(st.LatestCompleted) {
 		t.Fatalf("executed task has not updated latest complete: expected %s > %s", st2.LatestCompleted, st.LatestCompleted)
 	}
 
@@ -683,7 +678,7 @@ func testUpdate(t *testing.T, sys *System) {
 		t.Fatal(err)
 	}
 
-	if st3.LatestCompleted <= st2.LatestCompleted {
+	if st3.LatestCompleted.Before(st2.LatestCompleted) {
 		t.Fatalf("executed task has not updated latest complete: expected %s > %s", st3.LatestCompleted, st2.LatestCompleted)
 	}
 
@@ -706,10 +701,7 @@ func testUpdate(t *testing.T, sys *System) {
 	earliestUA := now.Add(-time.Second)
 	latestUA := after.Add(time.Second)
 
-	ua, err := time.Parse(time.RFC3339, task.UpdatedAt)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ua := task.UpdatedAt
 
 	if earliestUA.After(ua) || latestUA.Before(ua) {
 		t.Fatalf("updatedAt not accurate, expected %s to be between %s and %s", ua, earliestUA, latestUA)
@@ -720,10 +712,7 @@ func testUpdate(t *testing.T, sys *System) {
 		t.Fatal(err)
 	}
 
-	ua, err = time.Parse(time.RFC3339, st.UpdatedAt)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ua = st.UpdatedAt
 
 	if earliestUA.After(ua) || latestUA.Before(ua) {
 		t.Fatalf("updatedAt not accurate after pulling new task, expected %s to be between %s and %s", ua, earliestUA, latestUA)


### PR DESCRIPTION
Closes #14522

This PR updates the internal Task struct to use Go time.Time and time.Duration objects for time values instead of timestamp strings.

Continuation of refactoring work started in https://github.com/influxdata/influxdb/pull/15406

- [x] Rebased/mergeable
- [x] Tests pass