### PR TITLE
feat(tests): added tests to validate bug unreproducible

### DIFF
--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -257,6 +257,113 @@ from(bucket: "${name}")
       cy.contains('Save').click()
     })
   })
+
+  describe('renders the correct name when toggling between tasks', () => {
+    // addresses an issue that was reported when clicking tasks
+    // this issue could not be reproduced manually | testing:
+    // https://github.com/influxdata/influxdb/issues/15552
+    const firstTask = 'First_Task'
+    const secondTask = 'Second_Task'
+    const taskName = 'First_Task'
+    const interval = '12h'
+    const offset = '30m'
+    const flux = name => `import "influxdata/influxdb/v1"
+    v1.tagValues(bucket: "${name}", tag: "_field")
+    from(bucket: "${name}")
+      |> range(start: -2m)`
+    beforeEach(() => {
+      createFirstTask(
+        firstTask,
+        ({name}) => {
+          return flux(name)
+        },
+        interval,
+        offset
+      )
+      cy.contains('Save').click()
+      cy.getByTestID('task-card')
+        .should('have.length', 1)
+        .and('contain', firstTask)
+
+      cy.getByTestID('add-resource-dropdown--button').click()
+      cy.getByTestID('add-resource-dropdown--new').click()
+      cy.getByInputName('name').type(secondTask)
+      cy.getByTestID('task-form-schedule-input').type(interval)
+      cy.getByTestID('task-form-offset-input').type(offset)
+      cy.get<Bucket>('@bucket').then(bucket => {
+        cy.getByTestID('flux-editor').within(() => {
+          cy.get('textarea').type(flux(bucket), {force: true})
+        })
+      })
+      cy.contains('Save').click()
+      cy.getByTestID('task-card')
+        .should('have.length', 2)
+        .and('contain', firstTask)
+        .and('contain', secondTask)
+      cy.getByTestID('task-card--name')
+        .contains(firstTask)
+        .click()
+    })
+
+    it('when navigating using the navbar', () => {
+      // verify that the previously input data exists
+      cy.getByInputValue(firstTask)
+      // navigate home
+      cy.get('div.cf-nav--item.active').click()
+      // click on the second task
+      cy.getByTestID('task-card--name')
+        .contains(secondTask)
+        .click()
+      // verify that it is the correct data
+      cy.getByInputValue(secondTask)
+      cy.get('div.cf-nav--item.active').click()
+      // navigate back to the first one to verify that the name is correct
+      cy.getByTestID('task-card--name')
+        .contains(firstTask)
+        .click()
+      cy.getByInputValue(firstTask)
+    })
+
+    it('when navigating using the cancel button', () => {
+      // verify that the previously input data exists
+      cy.getByInputValue(firstTask)
+      // navigate home
+      cy.getByTestID('task-cancel-btn').click()
+      // click on the second task
+      cy.getByTestID('task-card--name')
+        .contains(secondTask)
+        .click()
+      // verify that it is the correct data
+      cy.getByInputValue(secondTask)
+      cy.getByTestID('task-cancel-btn').click()
+      // navigate back to the first task again
+      cy.getByTestID('task-card--name')
+        .contains(firstTask)
+        .click()
+      cy.getByInputValue(firstTask)
+      cy.getByTestID('task-cancel-btn').click()
+    })
+
+    it('when navigating using the save button', () => {
+      // verify that the previously input data exists
+      cy.getByInputValue(firstTask)
+      // navigate home
+      cy.getByTestID('task-save-btn').click()
+      // click on the second task
+      cy.getByTestID('task-card--name')
+        .contains(secondTask)
+        .click()
+      // verify that it is the correct data
+      cy.getByInputValue(secondTask)
+      cy.getByTestID('task-save-btn').click()
+      // navigate back to the first task again
+      cy.getByTestID('task-card--name')
+        .contains(firstTask)
+        .click()
+      cy.getByInputValue(firstTask)
+      cy.getByTestID('task-save-btn').click()
+    })
+  })
 })
 
 function createFirstTask(

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -264,7 +264,6 @@ from(bucket: "${name}")
     // https://github.com/influxdata/influxdb/issues/15552
     const firstTask = 'First_Task'
     const secondTask = 'Second_Task'
-    const taskName = 'First_Task'
     const interval = '12h'
     const offset = '30m'
     const flux = name => `import "influxdata/influxdb/v1"

--- a/ui/src/tasks/components/TaskHeader.tsx
+++ b/ui/src/tasks/components/TaskHeader.tsx
@@ -31,6 +31,7 @@ export default class TaskHeader extends PureComponent<Props> {
             color={ComponentColor.Default}
             text="Cancel"
             onClick={this.props.onCancel}
+            testID="task-cancel-btn"
           />
           <Button
             color={ComponentColor.Success}
@@ -41,6 +42,7 @@ export default class TaskHeader extends PureComponent<Props> {
                 : ComponentStatus.Disabled
             }
             onClick={this.props.onSave}
+            testID="task-save-btn"
           />
         </Page.HeaderRight>
       </Page.Header>


### PR DESCRIPTION
Closes #15552 

### Problem

Task names don't populate the form correctly when toggling between tasks

### Solution

Since this bug could not be reproduced, I added tests to ensure that the correct names are displaying when toggling between tasks using the navbar, the cancel button, and the save button

For more info, please see:

![cannot_reproduce](https://user-images.githubusercontent.com/19984220/67947674-6851ab80-fba1-11e9-9903-39fd9d9d2901.gif)



