### PR TITLE
fix(cmd/influx): remove dup usage

### DIFF
--- a/cmd/influx/delete.go
+++ b/cmd/influx/delete.go
@@ -54,17 +54,14 @@ func fluxDeleteF(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	if deleteFlags.Org == "" && deleteFlags.OrgID == "" {
-		cmd.Usage()
 		return fmt.Errorf("please specify one of org or org-id")
 	}
 
 	if deleteFlags.Bucket == "" && deleteFlags.BucketID == "" {
-		cmd.Usage()
 		return fmt.Errorf("please specify one of bucket or bucket-id")
 	}
 
 	if deleteFlags.Start == "" || deleteFlags.Stop == "" {
-		cmd.Usage()
 		return fmt.Errorf("both start and stop are required")
 	}
 


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15676

Remove the duplicate usage, when issue wrong influx delete command.
Manually tested 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
