### PR TITLE
fix(tasks): thread auth on context when calling FinishRun

### DIFF
--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -350,7 +350,8 @@ func (w *worker) finish(p *promise, rs backend.RunStatus, err error) {
 	} else {
 		w.te.logger.Debug("Completed successfully", zap.String("taskID", p.task.ID.String()))
 	}
-	w.te.tcs.FinishRun(p.ctx, p.task.ID, p.run.ID)
+
+	w.te.tcs.FinishRun(icontext.SetAuthorizer(p.ctx, p.auth), p.task.ID, p.run.ID)
 
 }
 


### PR DESCRIPTION
Ensure new scheduler threads auth on context when calling FinishRun.

FinishRun will result in a call to the API to write a point which contains the run. This ensures the executor passes the authentication is has down through the context.Context.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
