### PR TITLE
Revert "fix(flux): use flux.EvalOptions over problematic flux.EvalAST"

### DIFF
--- a/task/options/options.go
+++ b/task/options/options.go
@@ -225,7 +225,7 @@ func FromScript(script string) (Options, error) {
 	durTypes := grabTaskOptionAST(fluxAST, optEvery, optOffset)
 	// TODO(desa): should be dependencies.NewEmpty(), but for now we'll hack things together
 	ctx := newDeps().Inject(context.Background())
-	_, scope, err := flux.EvalOptions(ctx, fluxAST)
+	_, scope, err := flux.EvalAST(ctx, fluxAST)
 	if err != nil {
 		return opt, err
 	}

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -25,8 +25,7 @@ describe('Tasks', () => {
     })
   })
 
-  it.skip('cannot create a task with an invalid to() function', () => {
-    // skipped pending https://github.com/influxdata/flux/issues/2085
+  it('cannot create a task with an invalid to() function', () => {
     const taskName = 'Bad Task'
 
     createFirstTask(taskName, ({name}) => {


### PR DESCRIPTION
Reverts influxdata/influxdb#15665

Fixes #15688 

Due the task validation regression introduced by this PR, we've opted to revert it for the time being.