### PR TITLE
feat(kv): Cursor API accepts hints for improving performance

### DIFF
--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -198,7 +198,7 @@ func (b *Bucket) Delete(key []byte) error {
 
 // Cursor retrieves a cursor for iterating through the entries
 // in the key value store.
-func (b *Bucket) Cursor() (kv.Cursor, error) {
+func (b *Bucket) Cursor(opts ...kv.CursorHint) (kv.Cursor, error) {
 	return &Cursor{
 		cursor: b.bucket.Cursor(),
 	}, nil

--- a/inmem/kv.go
+++ b/inmem/kv.go
@@ -199,9 +199,9 @@ func (b *Bucket) Delete(key []byte) error {
 }
 
 // Cursor creates a static cursor from all entries in the database.
-func (b *Bucket) Cursor() (kv.Cursor, error) {
+func (b *Bucket) Cursor(opts ...kv.CursorHint) (kv.Cursor, error) {
 	// TODO we should do this by using the Ascend/Descend methods that
-	// the btree provides.
+	//  the btree provides.
 	pairs, err := b.getAll()
 	if err != nil {
 		return nil, err

--- a/kv/store.go
+++ b/kv/store.go
@@ -38,14 +38,41 @@ type Tx interface {
 	WithContext(ctx context.Context)
 }
 
+type CursorHints struct {
+	KeyPrefix *string
+	KeyStart  *string
+}
+
+// CursorHint configures CursorHints
+type CursorHint func(*CursorHints)
+
+// WithCursorHintPrefix is a hint to the store
+// that the caller is only interested keys with the
+// specified prefix.
+func WithCursorHintPrefix(prefix string) CursorHint {
+	return func(o *CursorHints) {
+		o.KeyPrefix = &prefix
+	}
+}
+
+// WithCursorHintKeyStart is a hint to the store
+// that the caller is interested in reading keys from
+// start.
+func WithCursorHintKeyStart(start string) CursorHint {
+	return func(o *CursorHints) {
+		o.KeyStart = &start
+	}
+}
+
 // Bucket is the abstraction used to perform get/put/delete/get-many operations
 // in a key value store.
 type Bucket interface {
 	// TODO context?
 	// Get returns a key within this bucket. Errors if key does not exist.
 	Get(key []byte) ([]byte, error)
-	// Cursor returns a cursor at the beginning of this bucket.
-	Cursor() (Cursor, error)
+	// Cursor returns a cursor at the beginning of this bucket optionally
+	// using the provided hints to improve performance.
+	Cursor(hints ...CursorHint) (Cursor, error)
 	// Put should error if the transaction it was called in is not writable.
 	Put(key, value []byte) error
 	// Delete should error if the transaction it was called in is not writable.

--- a/kv/task_private_test.go
+++ b/kv/task_private_test.go
@@ -1,0 +1,214 @@
+package kv
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb"
+)
+
+func Test_newTaskMatchFN(t *testing.T) {
+	ct := func(typ string, name string) *influxdb.Task {
+		return &influxdb.Task{
+			Type:           typ,
+			OrganizationID: 1,
+			Name:           name,
+		}
+	}
+
+	const (
+		NoOrg = influxdb.ID(0)
+		NoTyp = "-"
+		NoNam = "-"
+	)
+
+	newMatch := func(orgID influxdb.ID, typ string, name string) taskMatchFn {
+		var (
+			org *influxdb.Organization
+			fil influxdb.TaskFilter
+		)
+
+		if orgID != NoOrg {
+			org = &influxdb.Organization{ID: orgID}
+		}
+
+		if typ != NoTyp {
+			fil.Type = &typ
+		}
+
+		if name != NoNam {
+			fil.Name = &name
+		}
+
+		return newTaskMatchFn(fil, org)
+	}
+
+	type test struct {
+		name string
+		task *influxdb.Task
+		fn   taskMatchFn
+		exp  bool
+	}
+
+	tests := []struct {
+		name  string
+		tests []test
+	}{
+		{
+			"match org",
+			[]test{
+				{
+					name: "equal",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(1, NoTyp, NoNam),
+					exp:  true,
+				},
+				{
+					name: "not org",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(2, NoTyp, NoNam),
+					exp:  false,
+				},
+			},
+		},
+		{
+			"match type",
+			[]test{
+				{
+					name: "empty with system type",
+					task: ct("", "Foo"),
+					fn:   newMatch(NoOrg, influxdb.TaskSystemType, NoNam),
+					exp:  true,
+				},
+				{
+					name: "system with system type",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(NoOrg, influxdb.TaskSystemType, NoNam),
+					exp:  true,
+				},
+				{
+					name: "equal",
+					task: ct("other type", "Foo"),
+					fn:   newMatch(NoOrg, "other type", NoNam),
+					exp:  true,
+				},
+				{
+					name: "not type",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(NoOrg, "other type", NoNam),
+					exp:  false,
+				},
+			},
+		},
+		{
+			"match name",
+			[]test{
+				{
+					name: "equal",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(NoOrg, NoTyp, "Foo"),
+					exp:  true,
+				},
+				{
+					name: "not name",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(NoOrg, NoTyp, "Bar"),
+					exp:  false,
+				},
+			},
+		},
+		{
+			"match org type",
+			[]test{
+				{
+					name: "equal",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(1, influxdb.TaskSystemType, NoNam),
+					exp:  true,
+				},
+				{
+					name: "not type",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(1, "wrong type", NoNam),
+					exp:  false,
+				},
+				{
+					name: "not org",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(2, influxdb.TaskSystemType, NoNam),
+					exp:  false,
+				},
+				{
+					name: "not org and type",
+					task: ct("check", "Foo"),
+					fn:   newMatch(2, influxdb.TaskSystemType, NoNam),
+					exp:  false,
+				},
+			},
+		},
+		{
+			"match org name",
+			[]test{
+				{
+					name: "equal",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(1, NoTyp, "Foo"),
+					exp:  true,
+				},
+				{
+					name: "not org",
+					task: ct(influxdb.TaskSystemType, "Foo"),
+					fn:   newMatch(2, NoTyp, "Foo"),
+					exp:  false,
+				},
+			},
+		},
+		{
+			"match org name type",
+			[]test{
+				{
+					name: "equal",
+					task: ct("check", "Foo"),
+					fn:   newMatch(1, "check", "Foo"),
+					exp:  true,
+				},
+				{
+					name: "not org",
+					task: ct("check", "Foo"),
+					fn:   newMatch(2, "check", "Foo"),
+					exp:  false,
+				},
+				{
+					name: "not name",
+					task: ct("check", "Foo"),
+					fn:   newMatch(1, "check", "Bar"),
+					exp:  false,
+				},
+				{
+					name: "not type",
+					task: ct("check", "Foo"),
+					fn:   newMatch(1, "other", "Foo"),
+					exp:  false,
+				},
+			},
+		},
+	}
+	for _, group := range tests {
+		t.Run(group.name, func(t *testing.T) {
+			for _, test := range group.tests {
+				t.Run(test.name, func(t *testing.T) {
+					if got, exp := test.fn(test.task), test.exp; got != exp {
+						t.Errorf("unxpected match result: -got/+exp\n%v", cmp.Diff(got, exp))
+					}
+				})
+			}
+		})
+	}
+
+	t.Run("match returns nil for no filter", func(t *testing.T) {
+		fn := newTaskMatchFn(influxdb.TaskFilter{}, nil)
+		if fn != nil {
+			t.Error("expected nil")
+		}
+	})
+}

--- a/mock/kv.go
+++ b/mock/kv.go
@@ -66,7 +66,7 @@ func (b *Bucket) Get(key []byte) ([]byte, error) {
 }
 
 // Cursor returns a cursor at the beginning of this bucket.
-func (b *Bucket) Cursor() (kv.Cursor, error) {
+func (b *Bucket) Cursor(opts ...kv.CursorHint) (kv.Cursor, error) {
 	return b.CursorFn()
 }
 


### PR DESCRIPTION
Implementations of the `kv.Bucket#Cursor` API may use the hints to instruct the access or read behavior to the underlying key/value store.

The `findAllTasks` function was also fixed to ensure that paging works as expected when using a name filter. Tests were added to verify this behavior.

Redundant error checks were also removed.
