### PR TITLE
test(ui): rejigger the collector tests to be less flaky

### DIFF
--- a/ui/cypress/e2e/collectors.test.ts
+++ b/ui/cypress/e2e/collectors.test.ts
@@ -214,19 +214,19 @@ describe('Collectors', () => {
           .then(() => {
             bucketz.sort()
             cy.getByTestID('bucket-name')
-            .should('have.length', 3)
-            .each((val, index) => {
-              const text = val.text()
-              expect(text).to.include(bucketz[index])
-            })
-            .then(() => {
-              cy.getByTestID('bucket-sorter').click()
-              bucketz.reverse()
-              cy.getByTestID('bucket-name').each((val, index) => {
+              .should('have.length', 3)
+              .each((val, index) => {
                 const text = val.text()
                 expect(text).to.include(bucketz[index])
               })
-            })
+              .then(() => {
+                cy.getByTestID('bucket-sorter').click()
+                bucketz.reverse()
+                cy.getByTestID('bucket-name').each((val, index) => {
+                  const text = val.text()
+                  expect(text).to.include(bucketz[index])
+                })
+              })
           })
 
         // sort by name test here

--- a/ui/cypress/e2e/collectors.test.ts
+++ b/ui/cypress/e2e/collectors.test.ts
@@ -21,30 +21,41 @@ describe('Collectors', () => {
       const newConfig = 'New Config'
       const configDescription = 'This is a new config testing'
 
-      cy.getByTestID('table-row').should('have.length', 0)
-
-      cy.contains('Create Configuration').click()
-      cy.getByTestID('overlay--container').within(() => {
-        cy.getByTestID('telegraf-plugins--System').click()
-        cy.getByTestID('next').click()
-        cy.getByInputName('name')
-          .clear()
-          .type(newConfig)
-        cy.getByInputName('description')
-          .clear()
-          .type(configDescription)
-        cy.get('.cf-button')
-          .contains('Create and Verify')
-          .click()
-        cy.getByTestID('streaming').within(() => {
-          cy.get('.cf-button')
-            .contains('Listen for Data')
+      cy.getByTestID('table-row')
+        .should('have.length', 0)
+        .then(() => {
+          cy.contains('Create Configuration')
             .click()
+            .then(() => {
+              cy.getByTestID('overlay--container').within(() => {
+                cy.getByTestID('telegraf-plugins--System')
+                  .click()
+                  .then(() => {
+                    cy.getByTestID('next')
+                      .click()
+                      .then(() => {
+                        cy.getByInputName('name')
+                          .clear()
+                          .type(newConfig)
+                        cy.getByInputName('description')
+                          .clear()
+                          .type(configDescription)
+                        cy.get('.cf-button')
+                          .contains('Create and Verify')
+                          .click()
+                        cy.getByTestID('streaming').within(() => {
+                          cy.get('.cf-button')
+                            .contains('Listen for Data')
+                            .click()
+                        })
+                        cy.get('.cf-button')
+                          .contains('Finish')
+                          .click()
+                      })
+                  })
+              })
+            })
         })
-        cy.get('.cf-button')
-          .contains('Finish')
-          .click()
-      })
 
       cy.fixture('user').then(({bucket}) => {
         cy.getByTestID('resource-card')
@@ -52,33 +63,6 @@ describe('Collectors', () => {
           .and('contain', newConfig)
           .and('contain', bucket)
       })
-    })
-
-    it('can update configuration name', () => {
-      const newConfigName = 'This is new name'
-
-      const telegrafConfigName = 'New Config'
-      const description = 'Config Description'
-
-      cy.get('@org').then(({id}: Organization) => {
-        cy.fixture('user').then(({bucket}) => {
-          cy.createTelegraf(telegrafConfigName, description, id, bucket)
-        })
-      })
-
-      cy.getByTestID('collector-card--name')
-        .first()
-        .trigger('mouseover')
-
-      cy.getByTestID('collector-card--name-button')
-        .first()
-        .click()
-
-      cy.getByTestID('collector-card--input')
-        .type(newConfigName)
-        .type('{enter}')
-
-      cy.getByTestID('collector-card--name').should('contain', newConfigName)
     })
 
     describe('when a config already exists', () => {
@@ -94,18 +78,42 @@ describe('Collectors', () => {
         cy.reload()
       })
 
-      it('can delete a telegraf config', () => {
+      it('can update configuration name and delete a configuration', () => {
+        const newConfigName = 'This is new name'
+
+        cy.getByTestID('collector-card--name')
+          .first()
+          .trigger('mouseover')
+          .then(() => {
+            cy.getByTestID('collector-card--name-button')
+              .first()
+              .click()
+              .then(() => {
+                cy.getByTestID('collector-card--input')
+                  .type(newConfigName)
+                  .type('{enter}')
+                  .then(() => {
+                    cy.getByTestID('collector-card--name').should(
+                      'contain',
+                      newConfigName
+                    )
+                  })
+              })
+          })
+
         cy.getByTestID('resource-card').should('have.length', 1)
 
         cy.getByTestID('context-menu')
           .last()
-          .click({force: true})
-
-        cy.getByTestID('context-menu-item')
-          .last()
-          .click({force: true})
-
-        cy.getByTestID('empty-state').should('exist')
+          .click()
+          .then(() => {
+            cy.getByTestID('context-menu-item')
+              .last()
+              .click()
+              .then(() => {
+                cy.getByTestID('empty-state').should('exist')
+              })
+          })
       })
 
       it('can view setup instructions for a config', () => {
@@ -138,67 +146,91 @@ describe('Collectors', () => {
         cy.reload()
       })
       // filter by name
-      it('can filter telegraf configs correctly', () => {
-        // fixes issue #15246:
-        // https://github.com/influxdata/influxdb/issues/15246
-
-        cy.getByTestID('search-widget').type(firstTelegraf)
-
-        cy.getByTestID('resource-card').should('have.length', 1)
-        cy.getByTestID('resource-card').should('contain', firstTelegraf)
-
+      it('can filter telegraf configs and sort by bucket and name', () => {
+        // fixes https://github.com/influxdata/influxdb/issues/15246
         cy.getByTestID('search-widget')
-          .clear()
-          .type(secondTelegraf)
-
-        cy.getByTestID('resource-card').should('have.length', 1)
-        cy.getByTestID('resource-card').should('contain', secondTelegraf)
-
-        cy.getByTestID('search-widget')
-          .clear()
-          .type(thirdTelegraf)
-
-        cy.getByTestID('resource-card').should('have.length', 1)
-        cy.getByTestID('resource-card').should('contain', thirdTelegraf)
-
-        cy.getByTestID('search-widget')
-          .clear()
-          .type('should have no results')
-
-        cy.getByTestID('resource-card').should('have.length', 0)
-        cy.getByTestID('empty-state').should('exist')
-
-        cy.getByTestID('search-widget')
-          .clear()
-          .type('a')
-
-        cy.getByTestID('resource-card').should('have.length', 2)
-        cy.getByTestID('resource-card').should('contain', firstTelegraf)
-        cy.getByTestID('resource-card').should('contain', secondTelegraf)
-        cy.getByTestID('resource-card').should('not.contain', thirdTelegraf)
-      })
-      // sort by buckets test here
-      it('can sort telegraf configs by bucket', () => {
-        cy.getByTestID('bucket-name').should('have.length', 3)
-        cy.getByTestID('bucket-sorter').click()
-
-        bucketz.sort()
-        cy.getByTestID('bucket-name')
-          .each((val, index) => {
-            const text = val.text()
-            expect(text).to.include(bucketz[index])
-          })
+          .type(firstTelegraf)
           .then(() => {
-            cy.getByTestID('bucket-sorter').click()
-            bucketz.reverse()
-            cy.getByTestID('bucket-name').each((val, index) => {
+            cy.getByTestID('resource-card').should('have.length', 1)
+            cy.getByTestID('resource-card').should('contain', firstTelegraf)
+
+            cy.getByTestID('search-widget')
+              .clear()
+              .type(secondTelegraf)
+              .then(() => {
+                cy.getByTestID('resource-card').should('have.length', 1)
+                cy.getByTestID('resource-card').should(
+                  'contain',
+                  secondTelegraf
+                )
+
+                cy.getByTestID('search-widget')
+                  .clear()
+                  .type(thirdTelegraf)
+                  .then(() => {
+                    cy.getByTestID('resource-card').should('have.length', 1)
+                    cy.getByTestID('resource-card').should(
+                      'contain',
+                      thirdTelegraf
+                    )
+
+                    cy.getByTestID('search-widget')
+                      .clear()
+                      .type('should have no results')
+                      .then(() => {
+                        cy.getByTestID('resource-card').should('have.length', 0)
+                        cy.getByTestID('empty-state').should('exist')
+
+                        cy.getByTestID('search-widget')
+                          .clear()
+                          .type('a')
+                          .then(() => {
+                            cy.getByTestID('resource-card').should(
+                              'have.length',
+                              2
+                            )
+                            cy.getByTestID('resource-card').should(
+                              'contain',
+                              firstTelegraf
+                            )
+                            cy.getByTestID('resource-card').should(
+                              'contain',
+                              secondTelegraf
+                            )
+                            cy.getByTestID('resource-card').should(
+                              'not.contain',
+                              thirdTelegraf
+                            )
+                          })
+                      })
+                  })
+              })
+          })
+
+        // sort by buckets test here
+        cy.reload() // clear out filtering state from the previous test
+        cy.getByTestID('bucket-sorter')
+          .click()
+          .then(() => {
+            bucketz.sort()
+            cy.getByTestID('bucket-name')
+            .should('have.length', 3)
+            .each((val, index) => {
               const text = val.text()
               expect(text).to.include(bucketz[index])
             })
+            .then(() => {
+              cy.getByTestID('bucket-sorter').click()
+              bucketz.reverse()
+              cy.getByTestID('bucket-name').each((val, index) => {
+                const text = val.text()
+                expect(text).to.include(bucketz[index])
+              })
+            })
           })
-      })
-      // sort by name test here
-      it('can sort telegraf configs by name', () => {
+
+        // sort by name test here
+        cy.reload() // clear out sorting state from previous test
         cy.getByTestID('collector-card--name').should('have.length', 3)
 
         // test to see if telegrafs are initially sorted by name
@@ -209,13 +241,14 @@ describe('Collectors', () => {
             expect(val.text()).to.include(telegrafs[index])
           })
           .then(() => {
-            cy.getByTestID('name-sorter').click()
             telegrafs.reverse()
-          })
-          .then(() => {
-            cy.getByTestID('collector-card--name').each((val, index) => {
-              expect(val.text()).to.include(telegrafs[index])
-            })
+            cy.getByTestID('name-sorter')
+              .click()
+              .then(() => {
+                cy.getByTestID('collector-card--name').each((val, index) => {
+                  expect(val.text()).to.include(telegrafs[index])
+                })
+              })
           })
       })
     })

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -67,34 +67,43 @@ from(bucket: "${name}")
           cy.createTask(token, id)
         })
       })
+      cy.reload()
     })
 
     it('can edit a task', () => {
       // Disabling the test
-      cy.getByTestID('task-card--slide-toggle').should('have.class', 'active')
-
-      cy.getByTestID('task-card--slide-toggle').click()
-
-      cy.getByTestID('task-card--slide-toggle').should(
-        'not.have.class',
-        'active'
-      )
+      cy.getByTestID('task-card--slide-toggle')
+        .should('have.class', 'active')
+        .then(() => {
+          cy.getByTestID('task-card--slide-toggle')
+            .click()
+            .then(() => {
+              cy.getByTestID('task-card--slide-toggle').should(
+                'not.have.class',
+                'active'
+              )
+            })
+        })
 
       // Editing a name
       const newName = 'Task'
 
-      cy.getByTestID('task-card').within(() => {
-        cy.getByTestID('task-card--name').trigger('mouseover')
+      cy.getByTestID('task-card').then(() => {
+        cy.getByTestID('task-card--name')
+          .trigger('mouseover')
+          .then(() => {
+            cy.getByTestID('task-card--name-button')
+              .click()
+              .then(() => {
+                cy.getByTestID('task-card--input')
+                  .type(newName)
+                  .type('{enter}')
+              })
 
-        cy.getByTestID('task-card--name-button').click()
-
-        cy.get('.cf-input-field')
-          .type(newName)
-          .type('{enter}')
+            cy.getByTestID('notification-success').should('exist')
+            cy.contains(newName).should('exist')
+          })
       })
-
-      cy.getByTestID('notification-success').should('exist')
-      cy.getByTestID('task-card').should('contain', newName)
     })
 
     it('can delete a task', () => {


### PR DESCRIPTION
Makes collector e2e test lest flaky

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
