### PR TITLE
fix: enable uint64 support

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -18,6 +18,16 @@ import (
 	"github.com/influxdata/influxdb/pkg/escape"
 )
 
+// FIXME(edd): this temporarily enables uint64 support. It should be enabled by
+// default in 2.0. Therefore we need to pay down all the technical debt of cleaning
+// up all the conditionals within this package.
+//
+// This issue tracks the cleanup work:
+// https://github.com/influxdata/influxdb/issues/15711
+func init() {
+	EnableUintSupport()
+}
+
 // Values used to store the field key and measurement name as special internal tags.
 const (
 	FieldKeyTagKey    = "\xff"

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -16,11 +16,6 @@ import (
 	"github.com/influxdata/influxdb/models"
 )
 
-func init() {
-	// Force uint support to be enabled for testing.
-	models.EnableUintSupport()
-}
-
 var (
 	tags   = models.NewTags(map[string]string{"foo": "bar", "apple": "orange", "host": "serverA", "region": "uswest"})
 	fields = models.Fields{


### PR DESCRIPTION
This PR enables `uint64` support in InfluxDB. This means that you can write unsigned integers into the database. To differentiate between unsigned integer values and signed integer values, use the `u` suffix. 

Example:

```
influx write -o edd -b edd  "cpu,region=west balance=-232i,space=23432u
```

Where `balance` is a regular signed integer, and `space` is an unsigned integer.

Within the TSM storage engine both signed and unsigned integers are compressed in the same way. You cannot mix signed and unsigned integers within the same series, e.g., you **cannot** do this:

```
influx write -o edd -b edd  "cpu,region=west space=23432u
influx write -o edd -b edd  "cpu,region=west space=100i
```

The approach here is temporary. We should make this change permanent by removing all the code that allows `uint64` to be disabled. https://github.com/influxdata/influxdb/issues/15711 tracks that work