### PR TITLE
fix(tasks): fake flux deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [15777](https://github.com/influxdata/influxdb/pull/15777): Fix long startup when running 'influx help'
+1. [15713](https://github.com/influxdata/influxdb/pull/15713): Mock missing Flux dependencies when creating tasks
 1. [15731](https://github.com/influxdata/influxdb/pull/15731): Ensure array cursor iterator stats accumulate all cursor stats
 
 ## v2.0.0-alpha.19 [2019-10-30]
@@ -13,6 +14,7 @@
 1. [15650](https://github.com/influxdata/influxdb/pull/15650): Expose last run status and last run error in task API
 
 ### UI Improvements
+
 1. [15503](https://github.com/influxdata/influxdb/pull/15503): Redesign page headers to be more space efficient
 1. [15426](https://github.com/influxdata/influxdb/pull/15426): Add 403 handler that redirects back to the sign-in page on oats-generated routes.
 1. [15710](https://github.com/influxdata/influxdb/pull/15710): Add button to nginx and redis configuration sections to make interaction more clear

--- a/task/options/flux_deps.go
+++ b/task/options/flux_deps.go
@@ -1,0 +1,62 @@
+package options
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/influxdata/flux/dependencies/filesystem"
+	fluxhttp "github.com/influxdata/flux/dependencies/http"
+	"github.com/influxdata/flux/dependencies/secret"
+	fluxurl "github.com/influxdata/flux/dependencies/url"
+)
+
+var (
+	_ fluxhttp.Client    = httpClient{}
+	_ filesystem.Service = fileSystem{}
+	_ secret.Service     = secretService{}
+	_ fluxurl.Validator  = urlValidator{}
+)
+
+type httpClient struct{}
+
+func (httpClient) Do(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		Body: ioutil.NopCloser(&bytes.Reader{}),
+	}, nil
+}
+
+type secretService struct{}
+
+func (secretService) LoadSecret(ctx context.Context, k string) (string, error) { return "", nil }
+
+type urlValidator struct{}
+
+func (urlValidator) Validate(*url.URL) error { return nil }
+
+type fileSystem struct{}
+
+func (fileSystem) Open(_ string) (filesystem.File, error)   { return file{}, nil }
+func (fileSystem) Create(_ string) (filesystem.File, error) { return file{}, nil }
+func (fileSystem) Stat(_ string) (os.FileInfo, error)       { return nil, nil }
+
+type file struct{}
+
+func (file) Read(_ []byte) (int, error)         { return 0, nil }
+func (file) Write(_ []byte) (int, error)        { return 0, nil }
+func (file) Close() error                       { return nil }
+func (file) Seek(_ int64, _ int) (int64, error) { return 0, nil }
+func (file) Stat() (os.FileInfo, error)         { return info{}, nil }
+
+type info struct{}
+
+func (info) Name() string       { return "" }
+func (info) Size() int64        { return 0 }
+func (info) Mode() os.FileMode  { return 0 }
+func (info) ModTime() time.Time { return time.Now() }
+func (info) IsDir() bool        { return false }
+func (info) Sys() interface{}   { return nil }

--- a/task/options/options.go
+++ b/task/options/options.go
@@ -200,17 +200,12 @@ func grabTaskOptionAST(p *ast.Package, keys ...string) map[string]ast.Expression
 	return res
 }
 
-type constantSecretService struct{}
-
-func (s constantSecretService) LoadSecret(ctx context.Context, k string) (string, error) {
-	return "", nil
-}
-
 func newDeps() flux.Dependencies {
 	deps := flux.NewDefaultDependencies()
-	deps.Deps.HTTPClient = nil
-	deps.Deps.URLValidator = nil
-	deps.Deps.SecretService = constantSecretService{}
+	deps.Deps.HTTPClient = httpClient{}
+	deps.Deps.URLValidator = urlValidator{}
+	deps.Deps.SecretService = secretService{}
+	deps.Deps.FilesystemService = fileSystem{}
 	return deps
 }
 

--- a/ui/cypress/e2e/tasks.test.ts
+++ b/ui/cypress/e2e/tasks.test.ts
@@ -60,6 +60,23 @@ from(bucket: "${name}")
       .and('contain', taskName)
   })
 
+  it('can create a task using http.post', () => {
+    const taskName = 'Task'
+    createFirstTask(taskName, () => {
+      return `import "http"
+http.post(
+  url: "https://foo.bar/baz",
+  data: bytes(v: "body")
+)`
+    })
+
+    cy.contains('Save').click()
+
+    cy.getByTestID('task-card')
+      .should('have.length', 1)
+      .and('contain', taskName)
+  })
+
   describe('When tasks already exist', () => {
     beforeEach(() => {
       cy.get('@org').then(({id}: Organization) => {


### PR DESCRIPTION
Closes #15583 

Wire fake flux dependencies to allow use of `http.post`, etc. in tasks. 

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
