### PR TITLE
feat(pkger): update pkg application to skip resources that impose no changes

### DIFF
--- a/pkger/models.go
+++ b/pkger/models.go
@@ -244,6 +244,13 @@ func (b *bucket) summarize() SummaryBucket {
 	}
 }
 
+func (b *bucket) shouldApply() bool {
+	return b.existing == nil ||
+		b.Description != b.existing.Description ||
+		b.Name != b.existing.Name ||
+		b.RetentionPeriod != b.existing.RetentionPeriod
+}
+
 type labelMapKey struct {
 	resType influxdb.ResourceType
 	name    string
@@ -283,6 +290,13 @@ type label struct {
 	// exists in the platform. If a resource already exists(exists=true)
 	// then the ID should be populated.
 	existing *influxdb.Label
+}
+
+func (l *label) shouldApply() bool {
+	return l.existing == nil ||
+		l.Description != l.existing.Properties["description"] ||
+		l.Name != l.existing.Name ||
+		l.Color != l.existing.Properties["color"]
 }
 
 func (l *label) ID() influxdb.ID {

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -313,6 +313,9 @@ func (s *Service) applyBuckets(buckets []*bucket) applier {
 		var errs applyErrs
 		for i, b := range buckets {
 			buckets[i].OrgID = orgID
+			if !b.shouldApply() {
+				continue
+			}
 			influxBucket, err := s.applyBucket(ctx, b)
 			if err != nil {
 				errs = append(errs, applyErrBody{
@@ -501,6 +504,9 @@ func (s *Service) applyLabels(labels []*label) applier {
 		var errs applyErrs
 		for i, l := range labels {
 			labels[i].OrgID = orgID
+			if !l.shouldApply() {
+				continue
+			}
 			influxLabel, err := s.applyLabel(ctx, l)
 			if err != nil {
 				errs = append(errs, applyErrBody{


### PR DESCRIPTION
little cleanup for pkger. this makes any bucket/label resource skipped if it imposes no updates to an existing resource. if it is new, still runs. It is going to change existing state on a resource, it runs. If it is identical in every field the pkger exposes, then we skip it.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
