### PR TITLE
fix(storage): array cursor iterator should return stats of all observed cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.0-alpha.20 [unreleased]
+
+### Bug Fixes
+
+1. [15731](https://github.com/influxdata/influxdb/pull/15731): Ensure array cursor iterator stats accumulate all cursor stats
+
 ## v2.0.0-alpha.19 [2019-10-30]
 
 ### Features

--- a/tsdb/tsm1/array_cursor_iterator.go
+++ b/tsdb/tsm1/array_cursor_iterator.go
@@ -12,10 +12,8 @@ import (
 )
 
 type arrayCursorIterator struct {
-	e     *Engine
-	key   []byte
-	id    tsdb.SeriesIDTyped
-	isAsc bool
+	e   *Engine
+	key []byte
 
 	asc struct {
 		Float    *floatArrayAscendingCursor
@@ -36,9 +34,8 @@ type arrayCursorIterator struct {
 
 func (q *arrayCursorIterator) Next(ctx context.Context, r *tsdb.CursorRequest) (tsdb.Cursor, error) {
 	q.key = tsdb.AppendSeriesKey(q.key[:0], r.Name, r.Tags)
-	q.isAsc = r.Ascending
-	q.id = q.e.sfile.SeriesIDTypedBySeriesKey(q.key)
-	if q.id.IsZero() {
+	id := q.e.sfile.SeriesIDTypedBySeriesKey(q.key)
+	if id.IsZero() {
 		return nil, nil
 	}
 
@@ -54,7 +51,7 @@ func (q *arrayCursorIterator) Next(ctx context.Context, r *tsdb.CursorRequest) (
 	opt.EndTime = r.EndTime
 
 	// Return appropriate cursor based on type.
-	switch typ := q.id.Type(); typ {
+	switch typ := id.Type(); typ {
 	case models.Float:
 		return q.buildFloatArrayCursor(ctx, r.Name, r.Tags, r.Field, opt), nil
 	case models.Integer:
@@ -78,67 +75,37 @@ func (q *arrayCursorIterator) seriesFieldKeyBytes(name []byte, tags models.Tags,
 }
 
 // Stats returns the cumulative stats for all cursors.
-func (q *arrayCursorIterator) Stats() (stats cursors.CursorStats) {
-	// Return appropriate cursor based on type.
-	switch typ := q.id.Type(); typ {
-	case models.Float:
-		if q.isAsc {
-			if cur := q.asc.Float; cur != nil {
-				stats.Add(cur.Stats())
-			}
-			return
-		}
-
-		if cur := q.desc.Float; cur != nil {
-			stats.Add(cur.Stats())
-		}
-	case models.Integer:
-		if q.isAsc {
-			if cur := q.asc.Integer; cur != nil {
-				stats.Add(cur.Stats())
-			}
-			return
-		}
-
-		if cur := q.desc.Integer; cur != nil {
-			stats.Add(cur.Stats())
-		}
-	case models.Unsigned:
-		if q.isAsc {
-			if cur := q.asc.Unsigned; cur != nil {
-				stats.Add(cur.Stats())
-			}
-			return
-		}
-
-		if cur := q.desc.Unsigned; cur != nil {
-			stats.Add(cur.Stats())
-		}
-	case models.String:
-		if q.isAsc {
-			if cur := q.asc.String; cur != nil {
-				stats.Add(cur.Stats())
-			}
-			return
-		}
-
-		if cur := q.desc.String; cur != nil {
-			stats.Add(cur.Stats())
-		}
-	case models.Boolean:
-		if q.isAsc {
-			if cur := q.asc.Boolean; cur != nil {
-				stats.Add(cur.Stats())
-			}
-			return
-		}
-
-		if cur := q.desc.Boolean; cur != nil {
-			stats.Add(cur.Stats())
-		}
-	default:
-		panic(fmt.Sprintf("unreachable: %v", typ))
+func (q *arrayCursorIterator) Stats() cursors.CursorStats {
+	var stats cursors.CursorStats
+	if cur := q.asc.Float; cur != nil {
+		stats.Add(cur.Stats())
 	}
-
-	return
+	if cur := q.asc.Integer; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	if cur := q.asc.Unsigned; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	if cur := q.asc.Boolean; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	if cur := q.asc.String; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	if cur := q.desc.Float; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	if cur := q.desc.Integer; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	if cur := q.desc.Unsigned; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	if cur := q.desc.Boolean; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	if cur := q.desc.String; cur != nil {
+		stats.Add(cur.Stats())
+	}
+	return stats
 }

--- a/tsdb/tsm1/engine_cursor_test.go
+++ b/tsdb/tsm1/engine_cursor_test.go
@@ -1,0 +1,122 @@
+package tsm1_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxdb/tsdb/cursors"
+)
+
+func TestEngine_CursorIterator_Stats(t *testing.T) {
+	e := MustOpenEngine()
+	defer e.Close()
+
+	points := []models.Point{
+		models.MustNewPoint("cpu",
+			models.Tags{
+				{Key: []byte("a"), Value: []byte("b")},
+			},
+			models.Fields{"value": 4.6},
+			time.Now().UTC(),
+		),
+		models.MustNewPoint("cpu",
+			models.Tags{
+				{Key: []byte("a"), Value: []byte("b")},
+			},
+			models.Fields{"value": 3.2},
+			time.Now().UTC(),
+		),
+		models.MustNewPoint("mem",
+			models.Tags{
+				{Key: []byte("b"), Value: []byte("c")},
+			},
+			models.Fields{"value": int64(3)},
+			time.Now().UTC(),
+		),
+	}
+
+	// Write into the index.
+	collection := tsdb.NewSeriesCollection(points)
+	if err := e.index.CreateSeriesListIfNotExists(collection); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := e.WritePoints(points); err != nil {
+		t.Fatal(err)
+	}
+
+	e.MustWriteSnapshot()
+
+	ctx := context.Background()
+	cursorIterator, err := e.CreateCursorIterator(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cur, err := cursorIterator.Next(ctx, &tsdb.CursorRequest{
+		Name:      []byte("cpu"),
+		Tags:      []models.Tag{{Key: []byte("a"), Value: []byte("b")}},
+		Field:     "value",
+		EndTime:   time.Now().UTC().UnixNano(),
+		Ascending: true,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cur == nil {
+		t.Fatal("expected cursor to be present")
+	}
+
+	fc, ok := cur.(cursors.FloatArrayCursor)
+	if !ok {
+		t.Fatalf("unexpected cursor type: expected FloatArrayCursor, got %#v", cur)
+	}
+
+	// drain the cursor
+	for a := fc.Next(); a.Len() > 0; a = fc.Next() {
+	}
+
+	// iterator should report float stats
+	if got, exp := cursorIterator.Stats(), (cursors.CursorStats{ScannedValues: 2, ScannedBytes: 16}); exp != got {
+		t.Fatalf("expected %v, got %v", exp, got)
+	}
+
+	cur.Close()
+
+	cur, err = cursorIterator.Next(ctx, &tsdb.CursorRequest{
+		Name:      []byte("mem"),
+		Tags:      []models.Tag{{Key: []byte("b"), Value: []byte("c")}},
+		Field:     "value",
+		EndTime:   time.Now().UTC().UnixNano(),
+		Ascending: true,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cur == nil {
+		t.Fatal("expected cursor to be present")
+	}
+
+	defer cur.Close()
+
+	ic, ok := cur.(cursors.IntegerArrayCursor)
+	if !ok {
+		t.Fatalf("unexpected cursor type: expected FloatArrayCursor, got %#v", cur)
+	}
+
+	// drain the cursor
+	for a := ic.Next(); a.Len() > 0; a = ic.Next() {
+	}
+
+	// iterator should report integer array stats
+	if got, exp := cursorIterator.Stats(), (cursors.CursorStats{ScannedValues: 1, ScannedBytes: 8}); exp != got {
+		t.Fatalf("expected %v, got %v", exp, got)
+	}
+}

--- a/tsdb/tsm1/engine_cursor_test.go
+++ b/tsdb/tsm1/engine_cursor_test.go
@@ -81,11 +81,6 @@ func TestEngine_CursorIterator_Stats(t *testing.T) {
 	for a := fc.Next(); a.Len() > 0; a = fc.Next() {
 	}
 
-	// iterator should report float stats
-	if got, exp := cursorIterator.Stats(), (cursors.CursorStats{ScannedValues: 2, ScannedBytes: 16}); exp != got {
-		t.Fatalf("expected %v, got %v", exp, got)
-	}
-
 	cur.Close()
 
 	cur, err = cursorIterator.Next(ctx, &tsdb.CursorRequest{
@@ -116,7 +111,7 @@ func TestEngine_CursorIterator_Stats(t *testing.T) {
 	}
 
 	// iterator should report integer array stats
-	if got, exp := cursorIterator.Stats(), (cursors.CursorStats{ScannedValues: 1, ScannedBytes: 8}); exp != got {
+	if got, exp := cursorIterator.Stats(), (cursors.CursorStats{ScannedValues: 3, ScannedBytes: 24}); exp != got {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15732

1. Adds a failing test which demonstrates the incorrect reporting of stats from the `arrayCursorIterator.Stats()` method.
2. Updates `arrayCursorIterator.Stats()` to accumulate all the cursor field stats values into a single response.

@stuartcarnie showed me that the `builldXArrayCursor` methods actually retain previously read stats and accumlate them on calls to `reset` which is how all read stats are accumulated in the end.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
