### PR TITLE
fix(DWP): reset redux state when DWP resolves or rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [15731](https://github.com/influxdata/influxdb/pull/15731): Ensure array cursor iterator stats accumulate all cursor stats
+1. [15766](https://github.com/influxdata/influxdb/pull/15766): Reset delete with predicate state after submission
 
 ## v2.0.0-alpha.19 [2019-10-30]
 

--- a/ui/src/shared/actions/predicates.ts
+++ b/ui/src/shared/actions/predicates.ts
@@ -23,6 +23,7 @@ export type Action =
   | SetFilter
   | DeleteFilter
   | SetDeletionStatus
+  | SetPredicateToDefault
 
 interface SetIsSerious {
   type: 'SET_IS_SERIOUS'
@@ -88,6 +89,14 @@ export const setDeletionStatus = (
   deletionStatus: status,
 })
 
+interface SetPredicateToDefault {
+  type: 'SET_PREDICATE_DEFAULT'
+}
+
+export const resetPredicateState = (): SetPredicateToDefault => ({
+  type: 'SET_PREDICATE_DEFAULT',
+})
+
 export const deleteWithPredicate = params => async (
   dispatch: Dispatch<Action>
 ) => {
@@ -97,10 +106,12 @@ export const deleteWithPredicate = params => async (
       throw new Error(resp.data.message)
     }
 
-    dispatch(notify(predicateDeleteSucceeded()))
     dispatch(setDeletionStatus(RemoteDataState.Done))
+    dispatch(notify(predicateDeleteSucceeded()))
+    dispatch(resetPredicateState())
   } catch {
     dispatch(notify(predicateDeleteFailed()))
     dispatch(setDeletionStatus(RemoteDataState.Error))
+    dispatch(resetPredicateState())
   }
 }

--- a/ui/src/shared/reducers/predicates.test.ts
+++ b/ui/src/shared/reducers/predicates.test.ts
@@ -1,3 +1,6 @@
+// Libraries
+import moment from 'moment'
+
 // Reducer
 import {
   HOUR_MS,
@@ -11,11 +14,12 @@ import {Filter} from 'src/types'
 
 // Actions
 import {
+  deleteFilter,
+  resetPredicateState,
   setBucketName,
   setFilter,
   setIsSerious,
   setTimeRange,
-  deleteFilter,
 } from 'src/shared/actions/predicates'
 
 describe('Shared.Reducers.notifications', () => {
@@ -49,5 +53,13 @@ describe('Shared.Reducers.notifications', () => {
     expect(result.filters).toEqual([filter])
     result = predicatesReducer(initialState, deleteFilter(0))
     expect(initialState.filters).toEqual([])
+  })
+  it('should reset the state after a filter DWP has been successfully submitted', () => {
+    const state = Object.assign({}, initialState)
+    const filter: Filter = {key: 'mean', equality: '=', value: '100'}
+    initialState.isSerious = predicatesReducer(initialState, setIsSerious(true)).isSerious
+    initialState.filters = predicatesReducer(initialState, setFilter(filter, 0)).filters
+    const result = predicatesReducer(initialState, resetPredicateState())
+    expect(result).toEqual(state)
   })
 })

--- a/ui/src/shared/reducers/predicates.test.ts
+++ b/ui/src/shared/reducers/predicates.test.ts
@@ -57,8 +57,14 @@ describe('Shared.Reducers.notifications', () => {
   it('should reset the state after a filter DWP has been successfully submitted', () => {
     const state = Object.assign({}, initialState)
     const filter: Filter = {key: 'mean', equality: '=', value: '100'}
-    initialState.isSerious = predicatesReducer(initialState, setIsSerious(true)).isSerious
-    initialState.filters = predicatesReducer(initialState, setFilter(filter, 0)).filters
+    initialState.isSerious = predicatesReducer(
+      initialState,
+      setIsSerious(true)
+    ).isSerious
+    initialState.filters = predicatesReducer(
+      initialState,
+      setFilter(filter, 0)
+    ).filters
     const result = predicatesReducer(initialState, resetPredicateState())
     expect(result).toEqual(state)
   })

--- a/ui/src/shared/reducers/predicates.test.ts
+++ b/ui/src/shared/reducers/predicates.test.ts
@@ -1,6 +1,3 @@
-// Libraries
-import moment from 'moment'
-
 // Reducer
 import {
   HOUR_MS,

--- a/ui/src/shared/reducers/predicates.ts
+++ b/ui/src/shared/reducers/predicates.ts
@@ -53,6 +53,15 @@ export const predicatesReducer = (
     case 'SET_DELETION_STATUS':
       return {...state, deletionStatus: action.deletionStatus}
 
+    case 'SET_PREDICATE_DEFAULT':
+      return {
+        bucketName: '',
+        timeRange: [recently - HOUR_MS, recently],
+        filters: [],
+        isSerious: false,
+        deletionStatus: RemoteDataState.NotStarted,
+      }
+
     default:
       return state
   }


### PR DESCRIPTION
Closes #15717 

### Problem

State wouldn't reset after a un/successful delete with predicate submission

### Solution

Created a new action and case to dispatch after the API call resolve / rejects

![DWP-reset](https://user-images.githubusercontent.com/19984220/68227706-092cd600-ffa9-11e9-9b1d-d5839ce613d1.gif)


- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)