### PR TITLE
fix(DWP-date): date selector refactored to popover and fixed reducer error

### DIFF
--- a/ui/src/shared/actions/predicates.ts
+++ b/ui/src/shared/actions/predicates.ts
@@ -45,12 +45,12 @@ export const setBucketName = (bucketName: string): SetBucketName => ({
 })
 
 interface SetTimeRange {
-  type: 'SET_TIME_RANGE'
+  type: 'SET_DELETE_TIME_RANGE'
   timeRange: [number, number]
 }
 
 export const setTimeRange = (timeRange: [number, number]): SetTimeRange => ({
-  type: 'SET_TIME_RANGE',
+  type: 'SET_DELETE_TIME_RANGE',
   timeRange,
 })
 

--- a/ui/src/shared/components/DeleteDataForm/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/DeleteDataForm/TimeRangeDropdown.tsx
@@ -1,7 +1,13 @@
 // Libraries
-import React, {useRef, useState, FunctionComponent} from 'react'
+import React, {useRef, useState, FC} from 'react'
 import moment from 'moment'
-import {Dropdown} from '@influxdata/clockface'
+import {
+  Dropdown,
+  Popover,
+  PopoverPosition,
+  PopoverInteraction,
+  PopoverType,
+} from '@influxdata/clockface'
 
 // Components
 import DateRangePicker from 'src/shared/components/dateRangePicker/DateRangePicker'
@@ -11,39 +17,44 @@ interface Props {
   onSetTimeRange: (timeRange: [number, number]) => any
 }
 
-const TimeRangeDropdown: FunctionComponent<Props> = ({
+const TimeRangeDropdown: FC<Props> = ({
   timeRange,
   onSetTimeRange,
 }) => {
   const [pickerActive, setPickerActive] = useState(false)
   const buttonRef = useRef<HTMLDivElement>(null)
 
-  let datePickerPosition = null
-
-  if (buttonRef.current) {
-    const {right, top} = buttonRef.current.getBoundingClientRect()
-
-    datePickerPosition = {top: top, right: window.innerWidth - right}
-  }
-
   const lower = moment(timeRange[0]).format('YYYY-MM-DD HH:mm:ss')
   const upper = moment(timeRange[1]).format('YYYY-MM-DD HH:mm:ss')
 
+  const handleApplyTimeRange = (lower, upper) => {
+    onSetTimeRange([Date.parse(lower), Date.parse(upper)])
+    setPickerActive(false)
+  }
   return (
     <div ref={buttonRef}>
       <Dropdown.Button onClick={() => setPickerActive(!pickerActive)}>
         {lower} - {upper}
       </Dropdown.Button>
-      {pickerActive && (
-        <DateRangePicker
-          timeRange={{lower, upper}}
-          onSetTimeRange={({lower, upper}) =>
-            onSetTimeRange([Date.parse(lower), Date.parse(upper)])
-          }
-          position={datePickerPosition}
-          onClose={() => setPickerActive(false)}
-        />
-      )}
+      <Popover
+        type={PopoverType.Outline}
+        position={PopoverPosition.ToTheBottom}
+        triggerRef={buttonRef}
+        visible={pickerActive}
+        showEvent={PopoverInteraction.None}
+        hideEvent={PopoverInteraction.None}
+        distanceFromTrigger={8}
+        testID="timerange-popover"
+        enableDefaultStyles={false}
+        contents={() => (
+          <DateRangePicker
+            timeRange={{lower, upper}}
+            onSetTimeRange={({lower, upper}) => handleApplyTimeRange(lower, upper)}
+            onClose={() => setPickerActive(false)}
+            position={{position: 'relative'}}
+          />
+        )}
+      />
     </div>
   )
 }

--- a/ui/src/shared/components/DeleteDataForm/TimeRangeDropdown.tsx
+++ b/ui/src/shared/components/DeleteDataForm/TimeRangeDropdown.tsx
@@ -17,10 +17,7 @@ interface Props {
   onSetTimeRange: (timeRange: [number, number]) => any
 }
 
-const TimeRangeDropdown: FC<Props> = ({
-  timeRange,
-  onSetTimeRange,
-}) => {
+const TimeRangeDropdown: FC<Props> = ({timeRange, onSetTimeRange}) => {
   const [pickerActive, setPickerActive] = useState(false)
   const buttonRef = useRef<HTMLDivElement>(null)
 
@@ -38,7 +35,7 @@ const TimeRangeDropdown: FC<Props> = ({
       </Dropdown.Button>
       <Popover
         type={PopoverType.Outline}
-        position={PopoverPosition.ToTheBottom}
+        position={PopoverPosition.Below}
         triggerRef={buttonRef}
         visible={pickerActive}
         showEvent={PopoverInteraction.None}
@@ -49,7 +46,9 @@ const TimeRangeDropdown: FC<Props> = ({
         contents={() => (
           <DateRangePicker
             timeRange={{lower, upper}}
-            onSetTimeRange={({lower, upper}) => handleApplyTimeRange(lower, upper)}
+            onSetTimeRange={({lower, upper}) =>
+              handleApplyTimeRange(lower, upper)
+            }
             onClose={() => setPickerActive(false)}
             position={{position: 'relative'}}
           />

--- a/ui/src/shared/reducers/predicates.ts
+++ b/ui/src/shared/reducers/predicates.ts
@@ -29,7 +29,7 @@ export const predicatesReducer = (
     case 'SET_BUCKET_NAME':
       return {...state, bucketName: action.bucketName}
 
-    case 'SET_TIME_RANGE':
+    case 'SET_DELETE_TIME_RANGE':
       return {...state, timeRange: action.timeRange}
 
     case 'SET_FILTER':


### PR DESCRIPTION
Closes #15716

### Problem

1. Selecting a timerange would trigger an error due to duplication action naming
2. Timerange wasn't in a popover
3. Selecting a timerange wouldn't close the picker once it had been applied

### Solution

1. Renamed the action that was setting the timerange to avoid triggering two different actions with the same name
2. Refactored the timerange to be in a popover
3. Created a helper function to close the popover when a timerange had been applied

![DWP-timerange](https://user-images.githubusercontent.com/19984220/68239345-aa268b80-ffbf-11e9-8bad-284929fe0ed9.gif)

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
