### PR TITLE
fix(DWP-not): added new featureflag for DWP inequality filter

### DIFF
--- a/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
+++ b/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
@@ -47,7 +47,7 @@ const FilterRow: FC<Props> = ({
         <Input onChange={onChangeKey} value={key} testID="key-input" />
       </Form.Element>
       <div className="delete-data-filter--equals">==</div>
-      <FeatureFlag name="deleteWithPredicate">
+      <FeatureFlag name="deleteWithPredicateEquality">
         <Form.Element
           label="Equality Filter"
           required={true}

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -5,12 +5,14 @@ const OSS_FLAGS = {
   alerting: false,
   eventMarkers: false,
   deleteWithPredicate: false,
+  deleteWithPredicateEquality: false,
 }
 
 const CLOUD_FLAGS = {
   alerting: true,
   eventMarkers: false,
   deleteWithPredicate: false,
+  deleteWithPredicateEquality: false,
   cloudBilling: CLOUD_BILLING_VISIBLE, // should be visible in dev and acceptance, but not in cloud
 }
 


### PR DESCRIPTION
Closes #15715

### Problem

Enabling the `deleteWithPredicate` feature flag was causing both equality filters to be displayed in the app

### Solution

Renaming the `inequality` feature flag and setting the new flags in the `featureFlag` utility file so that it remains a separate piece of functionality