### PR TITLE
test: add selenium acceptance tests to nightly build - Bonitoo/selenium nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,11 +108,11 @@ jobs:
            npm run report:html
            npm run report:junit
            mkdir -p ~/test-results/cucumber
-           mkdir -p ~/artefacts/html
-           cp ~/project/selenium-accept-infl2/report/cucumber_report.html ~/artefacts/html/cucumber_report.html
+           mkdir -p ~/artifacts/html
+           cp ~/project/selenium-accept-infl2/report/cucumber_report.html ~/artifacts/html/cucumber_report.html
            cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/test-results/cucumber/report.xml
-           cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/artefacts/report.xml
-           cp -r ~/project/selenium-accept-infl2/screenshots ~/artefacts
+           cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/artifacts/report.xml
+           cp -r ~/project/selenium-accept-infl2/screenshots ~/artifacts
            ls -al
            exit $TEST_RESULT
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,9 +294,6 @@ workflows:
   e2e:
     jobs:
       - e2e
-  selenium:
-    jobs:
-      - selenium_accept
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,45 @@ jobs:
       - store_artifacts:
           path: ui/cypress/screenshots
           destination: screenshots
+  selenium_accept:
+    docker:
+      - image: circleci/node:13.0.1-stretch-browsers
+      - image: quay.io/influxdb/influx:nightly
+        command: [ --e2e-testing=true ]
+    steps:
+      - checkout
+      - run:
+         name: Environment check
+         command: |
+           git --version
+           node --version && npm --version
+           docker --version
+           google-chrome --version && which google-chrome && chromedriver --version && which chromedriver
+      - run:
+         name: Checkout Tests
+         command: git clone --single-branch --branch 2.0-Alpha https://github.com/bonitoo-io/selenium-accept-infl2.git
+      - run:
+         name: Selenium tests
+         command: |
+           set +e
+           cd selenium-accept-infl2
+           npm install
+           npm test; TEST_RESULT=$?
+           sleep 30
+           npm run report:html
+           npm run report:junit
+           mkdir -p ~/test-results/cucumber
+           mkdir -p ~/artefacts/html
+           cp ~/project/selenium-accept-infl2/report/cucumber_report.html ~/artefacts/html/cucumber_report.html
+           cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/test-results/cucumber/report.xml
+           cp ~/project/selenium-accept-infl2/report/cucumber_junit.xml ~/artefacts/report.xml
+           cp -r ~/project/selenium-accept-infl2/screenshots ~/artefacts
+           ls -al
+           exit $TEST_RESULT
+      - store_test_results:
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/artefacts
   jstest:
     docker:
       - image: circleci/golang:1.12-node-browsers
@@ -255,6 +294,9 @@ workflows:
   e2e:
     jobs:
       - e2e
+  selenium:
+    jobs:
+      - selenium_accept
   nightly:
     triggers:
       - schedule:
@@ -276,7 +318,9 @@ workflows:
       - litmus_nightly:
           requires:
             - deploy-nightly
-
+      - selenium_accept:
+          requires:
+            - deploy-nightly
   release:
     jobs:
       - gotest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
-          path: ~/artefacts
+          path: ~/artifacts
   jstest:
     docker:
       - image: circleci/golang:1.12-node-browsers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ jobs:
            node --version && npm --version
            docker --version
            google-chrome --version && which google-chrome && chromedriver --version && which chromedriver
+           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9999)" != "200" ]]; do sleep 5; done' || false
       - run:
          name: Checkout Tests
          command: git clone --single-branch --branch 2.0-Alpha https://github.com/bonitoo-io/selenium-accept-infl2.git
@@ -104,7 +105,6 @@ jobs:
            cd selenium-accept-infl2
            npm install
            npm test; TEST_RESULT=$?
-           sleep 30
            npm run report:html
            npm run report:junit
            mkdir -p ~/test-results/cucumber


### PR DESCRIPTION
Closes #

Adds a selenium_accept job to circleci and adds it to the nightly workflow.  

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
