### PR TITLE
fix(ui): Update numeric Input components to pass NaN where appropriat…

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -34,6 +34,150 @@ describe('DataExplorer', () => {
     })
   })
 
+  describe('numeric input validation when changing bin sizes in Heat Maps', () => {
+    beforeEach(() => {
+      cy.getByTestID('page-header--right').within(() => {
+        cy.getByTestID('dropdown')
+          .click()
+          .then(() => {
+            cy.get('#heatmap')
+              .click()
+              .then(() => {
+                cy.getByTestID('cog-cell--button').click()
+              })
+          })
+      })
+    })
+    it('should put input field in error status when "10" gets one character deleted and becomes "1"', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('grid--column').within(() => {
+          cy.getByTestID('input-field')
+            .first()
+            .click()
+            .type('{backspace}')
+            .getByTestID('input-field--error')
+            .should('have.length', 1)
+        })
+      })
+    })
+    it('should put input field in error status when "10" gets all characters deleted and becomes empty', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('grid--column').within(() => {
+          cy.getByTestID('input-field')
+            .first()
+            .click()
+            .type('{backspace}{backspace}')
+            .getByTestID('input-field--error')
+            .should('have.length', 1)
+        })
+      })
+    })
+    it('should keep input field in error status when "10" becomes "4"', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('grid--column').within(() => {
+          cy.getByTestID('input-field')
+            .first()
+            .click()
+            .type('{backspace}{backspace}4')
+            .getByTestID('input-field--error')
+            .should('have.length', 1)
+        })
+      })
+    })
+    it('should keep input field in error status when non-numeric characters are typed', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('grid--column').within(() => {
+          cy.getByTestID('input-field')
+            .first()
+            .click()
+            .type('{backspace}{backspace}abcdefg')
+            .getByTestID('input-field--error')
+            .should('have.length', 1)
+        })
+      })
+    })
+    it('should not have input field in error status when "10" becomes valid input such as "5"', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('grid--column').within(() => {
+          cy.getByTestID('input-field')
+            .first()
+            .click()
+            .type('{backspace}{backspace}5')
+            .getByTestID('input-field--error')
+            .should('have.length', 0)
+        })
+      })
+    })
+  })
+
+  describe('numeric input validation when changing number of decimal places in Single Stat', () => {
+    beforeEach(() => {
+      cy.getByTestID('page-header--right').within(() => {
+        cy.getByTestID('dropdown')
+          .click()
+          .then(() => {
+            cy.get('#single-stat')
+              .click()
+              .then(() => {
+                cy.getByTestID('cog-cell--button').click()
+              })
+          })
+      })
+    })
+    it('should allow "2" to be deleted to temporarily become a text input field in error status', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('auto-input--input').within(() => {
+          cy.getByTestID('input-field')
+            .click()
+            .type('{backspace}')
+            .invoke('attr', 'type')
+            .should('equal', 'text')
+            .getByTestID('input-field--error')
+            .should('have.length', 1)
+        })
+      })
+    })
+    it('should allow "2" to be deleted to become a blank input field in error status', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('auto-input--input').within(() => {
+          cy.getByTestID('input-field')
+            .click()
+            .type('{backspace}')
+            .invoke('val')
+            .should('equal', '')
+            .getByTestID('input-field--error')
+            .should('have.length', 1)
+        })
+      })
+    })
+    it('should allow "2" to be deleted to temporarily become a text input field but does NOT allow text input and remains in error status', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('auto-input--input').within(() => {
+          cy.getByTestID('input-field')
+            .click()
+            .type('{backspace}abcdefg')
+            .invoke('val')
+            .should('equal', '')
+            .getByTestID('input-field--error')
+            .should('have.length', 1)
+        })
+      })
+    })
+    it('should allow "2" to be deleted and then allow numeric input to get out of error status', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('auto-input--input').within(() => {
+          cy.getByTestID('input-field')
+            .click()
+            .type('{backspace}3')
+            .invoke('val')
+            .should('equal', '3')
+            .getByTestID('input-field--error')
+            .should('have.length', 0)
+        })
+      })
+    })
+  })
+
   describe('select time range to query', () => {
     it('can select different time ranges', () => {
       // find initial value

--- a/ui/cypress/e2e/notificationRules.test.ts
+++ b/ui/cypress/e2e/notificationRules.test.ts
@@ -47,6 +47,234 @@ describe('NotificationRules', () => {
     })
   })
 
+  describe('numeric input validation in Theshold Checks', () => {
+    beforeEach(() => {
+      cy.getByTestID('page-contents').within(() => {
+        cy.getByTestID('dropdown')
+          .click()
+          .then(() => {
+            cy.getByTestID('create-threshold-check').click()
+          })
+      })
+    })
+    describe('when threshold is above', () => {
+      it('should allow "20" to be deleted to temporarily become a text input field in error status', () => {
+        cy.getByTestID('checkeo--header alerting-tab')
+          .click()
+          .then(() => {
+            cy.getByTestID('add-threshold-condition-CRIT')
+              .click()
+              .then(() => {
+                cy.getByTestID('builder-conditions').within(() => {
+                  cy.getByTestID('panel').within(() => {
+                    cy.getByTestID('input-field')
+                      .click()
+                      .type('{backspace}{backspace}')
+                      .invoke('attr', 'type')
+                      .should('equal', 'text')
+                      .getByTestID('input-field--error')
+                      .should('have.length', 1)
+                  })
+                })
+              })
+          })
+      })
+      it('should allow "20" to be deleted to become a blank input field in error status', () => {
+        cy.getByTestID('checkeo--header alerting-tab')
+          .click()
+          .then(() => {
+            cy.getByTestID('add-threshold-condition-CRIT')
+              .click()
+              .then(() => {
+                cy.getByTestID('builder-conditions').within(() => {
+                  cy.getByTestID('panel').within(() => {
+                    cy.getByTestID('input-field')
+                      .click()
+                      .type('{backspace}{backspace}')
+                      .invoke('val')
+                      .should('equal', '')
+                      .getByTestID('input-field--error')
+                      .should('have.length', 1)
+                  })
+                })
+              })
+          })
+      })
+      it('should allow "20" to be deleted to temporarily become a text input field but does NOT allow text input and remains in error status', () => {
+        cy.getByTestID('checkeo--header alerting-tab')
+          .click()
+          .then(() => {
+            cy.getByTestID('add-threshold-condition-CRIT')
+              .click()
+              .then(() => {
+                cy.getByTestID('builder-conditions').within(() => {
+                  cy.getByTestID('panel').within(() => {
+                    cy.getByTestID('input-field')
+                      .click()
+                      .type('{backspace}{backspace}somerange')
+                      .invoke('val')
+                      .should('equal', '')
+                      .getByTestID('input-field--error')
+                      .should('have.length', 1)
+                  })
+                })
+              })
+          })
+      })
+      it('should allow "20" to be deleted and then allow numeric input to get out of error status', () => {
+        cy.getByTestID('checkeo--header alerting-tab')
+          .click()
+          .then(() => {
+            cy.getByTestID('add-threshold-condition-CRIT')
+              .click()
+              .then(() => {
+                cy.getByTestID('builder-conditions').within(() => {
+                  cy.getByTestID('panel').within(() => {
+                    cy.getByTestID('input-field')
+                      .click()
+                      .type('{backspace}{backspace}9')
+                      .invoke('val')
+                      .should('equal', '9')
+                      .getByTestID('input-field--error')
+                      .should('have.length', 0)
+                  })
+                })
+              })
+          })
+      })
+    })
+    describe('when threshold is inside range', () => {
+      it('should allow "20" to be deleted to temporarily become a text input field in error status', () => {
+        cy.getByTestID('checkeo--header alerting-tab')
+          .click()
+          .then(() => {
+            cy.getByTestID('add-threshold-condition-CRIT')
+              .click()
+              .then(() => {
+                cy.getByTestID('builder-conditions').within(() => {
+                  cy.getByTestID('panel').within(() => {
+                    cy.getByTestID('dropdown--button')
+                      .click()
+                      .then(() => {
+                        cy.get(
+                          '.cf-dropdown-item--children:contains("is inside range")'
+                        )
+                          .click()
+                          .then(() => {
+                            cy.getByTestID('input-field')
+                              .first()
+                              .click()
+                              .type('{backspace}{backspace}')
+                              .invoke('attr', 'type')
+                              .should('equal', 'text')
+                              .getByTestID('input-field--error')
+                              .should('have.length', 1)
+                          })
+                      })
+                  })
+                })
+              })
+          })
+      })
+      it('should allow "20" to be deleted to become a blank input field in error status', () => {
+        cy.getByTestID('checkeo--header alerting-tab')
+          .click()
+          .then(() => {
+            cy.getByTestID('add-threshold-condition-CRIT')
+              .click()
+              .then(() => {
+                cy.getByTestID('builder-conditions').within(() => {
+                  cy.getByTestID('panel').within(() => {
+                    cy.getByTestID('dropdown--button')
+                      .click()
+                      .then(() => {
+                        cy.get(
+                          '.cf-dropdown-item--children:contains("is inside range")'
+                        )
+                          .click()
+                          .then(() => {
+                            cy.getByTestID('input-field')
+                              .first()
+                              .click()
+                              .type('{backspace}{backspace}')
+                              .invoke('val')
+                              .should('equal', '')
+                              .getByTestID('input-field--error')
+                              .should('have.length', 1)
+                          })
+                      })
+                  })
+                })
+              })
+          })
+      })
+      it('should allow "20" to be deleted to temporarily become a text input field but does NOT allow text input and remains in error status', () => {
+        cy.getByTestID('checkeo--header alerting-tab')
+          .click()
+          .then(() => {
+            cy.getByTestID('add-threshold-condition-CRIT')
+              .click()
+              .then(() => {
+                cy.getByTestID('builder-conditions').within(() => {
+                  cy.getByTestID('panel').within(() => {
+                    cy.getByTestID('dropdown--button')
+                      .click()
+                      .then(() => {
+                        cy.get(
+                          '.cf-dropdown-item--children:contains("is inside range")'
+                        )
+                          .click()
+                          .then(() => {
+                            cy.getByTestID('input-field')
+                              .first()
+                              .click()
+                              .type('{backspace}{backspace}hhhhhhhhhhhh')
+                              .invoke('val')
+                              .should('equal', '')
+                              .getByTestID('input-field--error')
+                              .should('have.length', 1)
+                          })
+                      })
+                  })
+                })
+              })
+          })
+      })
+      it('should allow "20" to be deleted and then allow numeric input to get out of error status', () => {
+        cy.getByTestID('checkeo--header alerting-tab')
+          .click()
+          .then(() => {
+            cy.getByTestID('add-threshold-condition-CRIT')
+              .click()
+              .then(() => {
+                cy.getByTestID('builder-conditions').within(() => {
+                  cy.getByTestID('panel').within(() => {
+                    cy.getByTestID('dropdown--button')
+                      .click()
+                      .then(() => {
+                        cy.get(
+                          '.cf-dropdown-item--children:contains("is inside range")'
+                        )
+                          .click()
+                          .then(() => {
+                            cy.getByTestID('input-field')
+                              .first()
+                              .click()
+                              .type('{backspace}{backspace}7')
+                              .invoke('val')
+                              .should('equal', '7')
+                              .getByTestID('input-field--error')
+                              .should('have.length', 0)
+                          })
+                      })
+                  })
+                })
+              })
+          })
+      })
+    })
+  })
+
   // TODO(desa): this needs to be skipped until https://github.com/influxdata/influxdb/issues/14799
   it.skip('can create a notification rule', () => {
     const ruleName = 'my-new-rule'

--- a/ui/package.json
+++ b/ui/package.json
@@ -125,7 +125,7 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@influxdata/clockface": "1.0.4",
+    "@influxdata/clockface": "1.0.5",
     "@influxdata/flux-parser": "^0.3.0",
     "@influxdata/giraffe": "0.16.4",
     "@influxdata/influx": "0.5.5",

--- a/ui/src/alerting/components/builder/ThresholdRangeInput.tsx
+++ b/ui/src/alerting/components/builder/ThresholdRangeInput.tsx
@@ -5,6 +5,9 @@ import React, {FC} from 'react'
 import {FlexBox, TextBlock, Input, InputType} from '@influxdata/clockface'
 import {RangeThreshold} from 'src/types'
 
+// Utils
+import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+
 // Types
 interface Props {
   threshold: RangeThreshold
@@ -13,12 +16,13 @@ interface Props {
 
 const ThresholdRangeStatement: FC<Props> = ({threshold, changeRange}) => {
   const onChangeMin = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const min = Number(e.target.value)
+    const min = convertUserInputToNumOrNaN(e)
+
     changeRange(min, threshold.max)
   }
 
   const onChangeMax = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const max = Number(e.target.value)
+    const max = convertUserInputToNumOrNaN(e)
     changeRange(threshold.min, max)
   }
 

--- a/ui/src/alerting/components/builder/ThresholdValueInput.tsx
+++ b/ui/src/alerting/components/builder/ThresholdValueInput.tsx
@@ -5,6 +5,9 @@ import React, {FC} from 'react'
 import {FlexBox, Input, InputType} from '@influxdata/clockface'
 import {GreaterThreshold, LesserThreshold} from 'src/types'
 
+// Utils
+import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+
 // Types
 interface Props {
   threshold: GreaterThreshold | LesserThreshold
@@ -13,7 +16,7 @@ interface Props {
 
 const ThresholdValueStatement: FC<Props> = ({threshold, changeValue}) => {
   const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-    changeValue(Number(e.target.value))
+    changeValue(convertUserInputToNumOrNaN(e))
   }
   return (
     <FlexBox.Child testID="component-spacer--flex-child">

--- a/ui/src/shared/utils/convertUserInput.test.ts
+++ b/ui/src/shared/utils/convertUserInput.test.ts
@@ -1,0 +1,69 @@
+import React from 'react'
+import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+
+describe('convertUserInputToNumOrNaN', () => {
+  let value
+  let result
+
+  it('should convert a number string to a number', () => {
+    value = 123
+    const event = {
+      target: {
+        value: `${value}`,
+      },
+    } as React.ChangeEvent<HTMLInputElement>
+    expect(convertUserInputToNumOrNaN(event)).toEqual(value)
+  })
+
+  it('should convert a non-numeric, non-empty string to NaN', () => {
+    const event = {
+      target: {
+        value: 'a number',
+      },
+    } as React.ChangeEvent<HTMLInputElement>
+
+    result = convertUserInputToNumOrNaN(event)
+    expect(Number.isNaN(result)).toEqual(true)
+  })
+
+  it('should convert an empty string to NaN', () => {
+    const event = {
+      target: {
+        value: '',
+      },
+    } as React.ChangeEvent<HTMLInputElement>
+
+    result = convertUserInputToNumOrNaN(event)
+    expect(Number.isNaN(result)).toEqual(true)
+  })
+
+  it('should convert undefined to NaN', () => {
+    const event = {
+      target: {
+        value: undefined,
+      },
+    } as React.ChangeEvent<HTMLInputElement>
+    result = convertUserInputToNumOrNaN(event)
+    expect(Number.isNaN(result)).toEqual(true)
+  })
+
+  it('should convert false to 0', () => {
+    value = false
+    const event = {
+      target: {
+        value,
+      },
+    } as React.ChangeEvent<HTMLInputElement>
+    expect(convertUserInputToNumOrNaN(event)).toEqual(0)
+  })
+
+  it('should convert null to 0', () => {
+    value = null
+    const event = {
+      target: {
+        value,
+      },
+    } as React.ChangeEvent<HTMLInputElement>
+    expect(convertUserInputToNumOrNaN(event)).toEqual(0)
+  })
+})

--- a/ui/src/shared/utils/convertUserInput.ts
+++ b/ui/src/shared/utils/convertUserInput.ts
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export const convertUserInputToNumOrNaN = (
+  e: React.ChangeEvent<HTMLInputElement>
+) => (e.target.value === '' ? NaN : Number(e.target.value))

--- a/ui/src/timeMachine/components/view_options/DecimalPlaces.tsx
+++ b/ui/src/timeMachine/components/view_options/DecimalPlaces.tsx
@@ -1,6 +1,9 @@
 // Libraries
 import React, {PureComponent, ChangeEvent} from 'react'
 
+// Utils
+import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+
 // Components
 import {
   Form,
@@ -26,6 +29,7 @@ interface Props extends DecimalPlaces {
 
 interface State {
   mode: AutoInputMode
+  value: number
 }
 
 @ErrorHandling
@@ -35,6 +39,7 @@ class DecimalPlacesOption extends PureComponent<Props, State> {
 
     this.state = {
       mode: this.props.digits ? AutoInputMode.Custom : AutoInputMode.Auto,
+      value: this.props.digits,
     }
   }
 
@@ -52,7 +57,7 @@ class DecimalPlacesOption extends PureComponent<Props, State> {
                 name="decimal-places"
                 placeholder="Enter a number"
                 onChange={this.handleSetValue}
-                value={this.value}
+                value={this.state.value}
                 min={MIN_DECIMAL_PLACES}
                 max={MAX_DECIMAL_PLACES}
                 type={InputType.Number}
@@ -65,28 +70,22 @@ class DecimalPlacesOption extends PureComponent<Props, State> {
   }
 
   public handleSetValue = (e: ChangeEvent<HTMLInputElement>): void => {
-    const value = Number(e.target.value) || 0
+    const value = convertUserInputToNumOrNaN(e)
     const {digits, onDecimalPlacesChange} = this.props
 
-    if (value === null) {
-      onDecimalPlacesChange({digits, isEnforced: false})
+    if (value === value && value >= MIN_DECIMAL_PLACES) {
+      onDecimalPlacesChange({
+        digits: Math.min(value, MAX_DECIMAL_PLACES),
+        isEnforced: true,
+      })
     } else {
-      onDecimalPlacesChange({digits: value, isEnforced: true})
+      onDecimalPlacesChange({digits, isEnforced: false})
     }
+    this.setState({value})
   }
 
   private handleChangeMode = (mode: AutoInputMode): void => {
     this.setState({mode})
-  }
-
-  private get value(): number {
-    const {isEnforced, digits} = this.props
-
-    if (!isEnforced) {
-      return
-    }
-
-    return digits
   }
 }
 

--- a/ui/src/timeMachine/components/view_options/HeatmapOptions.tsx
+++ b/ui/src/timeMachine/components/view_options/HeatmapOptions.tsx
@@ -1,8 +1,18 @@
 // Libraries
-import React, {FunctionComponent, ChangeEvent} from 'react'
+import React, {FunctionComponent, ChangeEvent, useState} from 'react'
 import {connect} from 'react-redux'
 import {VIRIDIS, MAGMA, INFERNO, PLASMA} from '@influxdata/giraffe'
-import {Form, Grid, Input, Columns, InputType} from '@influxdata/clockface'
+import {
+  Form,
+  Grid,
+  Input,
+  Columns,
+  InputType,
+  ComponentStatus,
+} from '@influxdata/clockface'
+
+// Utils
+import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
 
 // Components
 import AutoDomainInput from 'src/shared/components/AutoDomainInput'
@@ -75,13 +85,19 @@ interface OwnProps {
 type Props = StateProps & DispatchProps & OwnProps
 
 const HeatmapOptions: FunctionComponent<Props> = props => {
+  const [binInputStatus, setBinInputStatus] = useState(ComponentStatus.Default)
+  const [binInput, setBinInput] = useState(props.binSize)
+
   const onSetBinSize = (e: ChangeEvent<HTMLInputElement>) => {
-    const val = +e.target.value
+    const val = convertUserInputToNumOrNaN(e)
+    setBinInput(val)
 
     if (isNaN(val) || val < 5) {
+      setBinInputStatus(ComponentStatus.Error)
       return
     }
 
+    setBinInputStatus(ComponentStatus.Default)
     props.onSetBinSize(val)
   }
 
@@ -112,7 +128,8 @@ const HeatmapOptions: FunctionComponent<Props> = props => {
       </Form.Element>
       <Form.Element label="Bin Size">
         <Input
-          value={props.binSize}
+          status={binInputStatus}
+          value={binInput}
           type={InputType.Number}
           onChange={onSetBinSize}
         />

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1004,10 +1004,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@influxdata/clockface@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-1.0.4.tgz#ec454ba11c9006a5248d716853d8d27dcc4789e8"
-  integrity sha512-V0RVLVlKenVSHrTaAfijqcipbSMyQ+7AYsx82Q889K+SDdjnu8W8wpWJIERjJFzJiAWBCjfJoY//r2PfmUB/Cw==
+"@influxdata/clockface@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@influxdata/clockface/-/clockface-1.0.5.tgz#966d95aa98738e328f884f14bff09a4e66cde55e"
+  integrity sha512-x+YL1XiS0JiAw/iTHKolnjMnj66M+lDlG9ErxZgf94TPSWzRdrF0ZUIjg2mCQ8v8OZFo35Ytk0+rkKeeXpxqrQ==
 
 "@influxdata/flux-parser@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15024

Updates numeric Inputs to deliberately pass NaN when user input is completely deleted, as clockface will handle this appropriately, see https://github.com/influxdata/clockface/pull/373

Fixes edge cases with bin sizes in Heat Maps and decimal places in Single Stat.
