### PR TITLE
fix(predicate/parser): updated case statement for NotEqual on deleteWithPredicate API

### DIFF
--- a/predicate/parser.go
+++ b/predicate/parser.go
@@ -77,13 +77,7 @@ func (p *parser) parseLogicalNode() (Node, error) {
 	for {
 		tok, pos, _ := p.scanIgnoreWhitespace()
 		switch tok {
-		case influxql.NUMBER:
-			fallthrough
-		case influxql.INTEGER:
-			fallthrough
-		case influxql.NAME:
-			fallthrough
-		case influxql.IDENT:
+		case influxql.NUMBER, influxql.INTEGER, influxql.NAME, influxql.IDENT:
 			p.unscan()
 			tr, err := p.parseTagRuleNode()
 			if err != nil {
@@ -181,7 +175,8 @@ func (p *parser) parseTagRuleNode() (TagRuleNode, error) {
 		n.Operator = influxdb.Equal
 		goto scanRegularTagValue
 	case influxql.NEQ:
-		fallthrough
+		n.Operator = influxdb.NotEqual
+		goto scanRegularTagValue
 	case influxql.EQREGEX:
 		fallthrough
 	case influxql.NEQREGEX:

--- a/predicate/parser_test.go
+++ b/predicate/parser_test.go
@@ -117,11 +117,8 @@ func TestParseTagRule(t *testing.T) {
 			node: TagRuleNode{Tag: influxdb.Tag{Key: "abc", Value: "-1221"}},
 		},
 		{
-			str: ` abc != "opq"`,
-			err: &influxdb.Error{
-				Code: influxdb.EInvalid,
-				Msg:  `operator: "!=" at position: 5 is not supported yet`,
-			},
+			str:  ` abc != "opq"`,
+			node: TagRuleNode{Tag: influxdb.Tag{Key: "abc", Value: "opq"}, Operator: influxdb.NotEqual},
 		},
 		{
 			str:  `abc=123`,

--- a/ui/src/buckets/selectors/index.test.ts
+++ b/ui/src/buckets/selectors/index.test.ts
@@ -13,7 +13,9 @@ describe('Bucket Selector', () => {
     expect(isSystemBucket(`naming_${SYSTEM}`)).toEqual(false)
     expect(isSystemBucket('SYSTEM')).toEqual(false)
   })
-  it('should sort the bucket names alphabetically', () => {
+  // skipping this test for now as it's flakey. Issue has been raise:
+  // https://github.com/influxdata/influxdb/issues/15798
+  it.skip('should sort the bucket names alphabetically', () => {
     const buckets: Bucket[] = [
       {
         id: '7902bd683453c00c',


### PR DESCRIPTION
Closes #15643 

### Problem

predicate/parser NotEqual case would `fallthrough` to the default error whenever requests with a `!=` were being made

### Solution

Updated the predicate/parsers `parseTagRuleNode` NEQ case to handle queries where the equality filter is NotEqual
