### PR TITLE
feat(pkger): add support for variable resource to pkger

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -839,9 +839,14 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 
 	var pkgSVC pkger.SVC
 	{
-		pkgLogger := m.logger.With(zap.String("service", "pkger"))
 		b := m.apibackend
-		pkgSVC = pkger.NewService(pkgLogger, b.BucketService, b.LabelService, b.DashboardService)
+		pkgSVC = pkger.NewService(
+			pkger.WithLogger(m.logger.With(zap.String("service", "pkger"))),
+			pkger.WithBucketSVC(b.BucketService),
+			pkger.WithDashboardSVC(b.DashboardService),
+			pkger.WithLabelSVC(b.LabelService),
+			pkger.WithVariableSVC(b.VariableService),
+		)
 	}
 
 	var pkgHTTPServer *http.HandlerPkg

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7186,6 +7186,17 @@ components:
                     type: string
                   labelID:
                     type: string
+            variables:
+              type: array
+              items:
+                allOf:
+                  - $ref: "#/components/schemas/Variable"
+                  - type: object
+                    properties:
+                      labelAssociations:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Label"
         diff:
           type: object
           properties:
@@ -7253,6 +7264,23 @@ components:
                     type: string
                   labelName:
                     type: string
+            variables:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  oldDescription:
+                    type: string
+                  newDescription:
+                    type: string
+                  oldArgs:
+                    $ref: "#/components/schemas/VariableProperties"
+                  newArgs:
+                    $ref: "#/components/schemas/VariableProperties"
     PkgChart:
       type: object
       properties:
@@ -8461,11 +8489,7 @@ components:
         labels:
           $ref: "#/components/schemas/Labels"
         arguments:
-          type: object
-          oneOf:
-            - $ref: "#/components/schemas/QueryVariableProperties"
-            - $ref: "#/components/schemas/ConstantVariableProperties"
-            - $ref: "#/components/schemas/MapVariableProperties"
+          $ref: "#/components/schemas/VariableProperties"
         createdAt:
           type: string
           format: date-time
@@ -8511,6 +8535,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Variable"
+    VariableProperties:
+      type: object
+      oneOf:
+        - $ref: "#/components/schemas/QueryVariableProperties"
+        - $ref: "#/components/schemas/ConstantVariableProperties"
+        - $ref: "#/components/schemas/MapVariableProperties"
     ViewProperties:
       oneOf:
         - $ref: "#/components/schemas/LinePlusSingleStatProperties"

--- a/pkger/models_test.go
+++ b/pkger/models_test.go
@@ -94,12 +94,14 @@ func TestPkg(t *testing.T) {
 				Name:        "name2",
 				Description: "desc2",
 				Color:       "blurple",
-				mappings: map[assocMapKey]assocMapVal{
-					assocMapKey{
-						resType: influxdb.BucketsResourceType,
-						name:    bucket1.Name,
-					}: {
-						v: bucket1,
+				associationMapping: associationMapping{
+					mappings: map[assocMapKey]assocMapVal{
+						assocMapKey{
+							resType: influxdb.BucketsResourceType,
+							name:    bucket1.Name,
+						}: {
+							v: bucket1,
+						},
 					},
 				},
 			}

--- a/pkger/models_test.go
+++ b/pkger/models_test.go
@@ -94,8 +94,8 @@ func TestPkg(t *testing.T) {
 				Name:        "name2",
 				Description: "desc2",
 				Color:       "blurple",
-				mappings: map[labelMapKey]labelMapVal{
-					labelMapKey{
+				mappings: map[assocMapKey]assocMapVal{
+					assocMapKey{
 						resType: influxdb.BucketsResourceType,
 						name:    bucket1.Name,
 					}: {

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -513,6 +513,15 @@ func (p *Pkg) graphVariables() error {
 			MapValues:   r.mapStrStr("values"),
 		}
 
+		failures := p.parseNestedLabels(r, func(l *label) error {
+			newVar.labels = append(newVar.labels, l)
+			p.mLabels[l.Name].setVariableMapping(newVar, false)
+			return nil
+		})
+		sort.Slice(newVar.labels, func(i, j int) bool {
+			return newVar.labels[i].Name < newVar.labels[j].Name
+		})
+
 		p.mVariables[r.Name()] = newVar
 
 		// here we set the var on the var map and return fails
@@ -523,7 +532,7 @@ func (p *Pkg) graphVariables() error {
 		// invalid. So the mapping is correct. So we keep this
 		// to validate that mapping is correct, and return fails
 		// to indicate fails from the var.
-		return newVar.valid()
+		return append(failures, newVar.valid()...)
 	})
 }
 

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -22,6 +22,53 @@ type SVC interface {
 	Apply(ctx context.Context, orgID influxdb.ID, pkg *Pkg) (Summary, error)
 }
 
+type serviceOpt struct {
+	logger *zap.Logger
+
+	labelSVC  influxdb.LabelService
+	bucketSVC influxdb.BucketService
+	dashSVC   influxdb.DashboardService
+	varSVC    influxdb.VariableService
+}
+
+// ServiceSetterFn is a means of setting dependencies on the Service type.
+type ServiceSetterFn func(opt *serviceOpt)
+
+// WithLogger sets the service logger.
+func WithLogger(logger *zap.Logger) ServiceSetterFn {
+	return func(opt *serviceOpt) {
+		opt.logger = logger
+	}
+}
+
+// WithBucketSVC sets the bucket service.
+func WithBucketSVC(bktSVC influxdb.BucketService) ServiceSetterFn {
+	return func(opt *serviceOpt) {
+		opt.bucketSVC = bktSVC
+	}
+}
+
+// WithDashboardSVC sets the dashboard service.
+func WithDashboardSVC(dashSVC influxdb.DashboardService) ServiceSetterFn {
+	return func(opt *serviceOpt) {
+		opt.dashSVC = dashSVC
+	}
+}
+
+// WithLabelSVC sets the label service.
+func WithLabelSVC(labelSVC influxdb.LabelService) ServiceSetterFn {
+	return func(opt *serviceOpt) {
+		opt.labelSVC = labelSVC
+	}
+}
+
+// WithVariableSVC sets the variable service.
+func WithVariableSVC(varSVC influxdb.VariableService) ServiceSetterFn {
+	return func(opt *serviceOpt) {
+		opt.varSVC = varSVC
+	}
+}
+
 // Service provides the pkger business logic including all the dependencies to make
 // this resource sausage.
 type Service struct {
@@ -30,21 +77,25 @@ type Service struct {
 	labelSVC  influxdb.LabelService
 	bucketSVC influxdb.BucketService
 	dashSVC   influxdb.DashboardService
+	varSVC    influxdb.VariableService
 }
 
 // NewService is a constructor for a pkger Service.
-func NewService(l *zap.Logger, bucketSVC influxdb.BucketService, labelSVC influxdb.LabelService, dashSVC influxdb.DashboardService) *Service {
-	svc := Service{
-		logger:    zap.NewNop(),
-		bucketSVC: bucketSVC,
-		labelSVC:  labelSVC,
-		dashSVC:   dashSVC,
+func NewService(opts ...ServiceSetterFn) *Service {
+	opt := &serviceOpt{
+		logger: zap.NewNop(),
+	}
+	for _, o := range opts {
+		o(opt)
 	}
 
-	if l != nil {
-		svc.logger = l
+	return &Service{
+		logger:    opt.logger,
+		bucketSVC: opt.bucketSVC,
+		labelSVC:  opt.labelSVC,
+		dashSVC:   opt.dashSVC,
+		varSVC:    opt.varSVC,
 	}
-	return &svc
 }
 
 // CreatePkgSetFn is a functional input for setting the pkg fields.
@@ -105,6 +156,11 @@ func (s *Service) DryRun(ctx context.Context, orgID influxdb.ID, pkg *Pkg) (Summ
 		return Summary{}, Diff{}, err
 	}
 
+	diffVars, err := s.dryRunVariables(ctx, orgID, pkg)
+	if err != nil {
+		return Summary{}, Diff{}, err
+	}
+
 	diffLabelMappings, err := s.dryRunLabelMappings(ctx, pkg)
 	if err != nil {
 		return Summary{}, Diff{}, err
@@ -120,6 +176,7 @@ func (s *Service) DryRun(ctx context.Context, orgID influxdb.ID, pkg *Pkg) (Summ
 		Dashboards:    diffDashes,
 		Labels:        diffLabels,
 		LabelMappings: diffLabelMappings,
+		Variables:     diffVars,
 	}
 	return pkg.Summary(), diff, nil
 }
@@ -169,9 +226,9 @@ func (s *Service) dryRunLabels(ctx context.Context, orgID influxdb.ID, pkg *Pkg)
 	mExistingLabels := make(map[string]DiffLabel)
 	labels := pkg.labels()
 	for i := range labels {
-		l := labels[i]
+		pkgLabel := labels[i]
 		existingLabels, err := s.labelSVC.FindLabels(ctx, influxdb.LabelFilter{
-			Name:  l.Name,
+			Name:  pkgLabel.Name,
 			OrgID: &orgID,
 		}, influxdb.FindOptions{Limit: 1})
 		switch {
@@ -179,14 +236,57 @@ func (s *Service) dryRunLabels(ctx context.Context, orgID influxdb.ID, pkg *Pkg)
 		//  err isn't a not found (some other error)
 		case err == nil && len(existingLabels) > 0:
 			existingLabel := existingLabels[0]
-			l.existing = existingLabel
-			mExistingLabels[l.Name] = newDiffLabel(l, *existingLabel)
+			pkgLabel.existing = existingLabel
+			mExistingLabels[pkgLabel.Name] = newDiffLabel(pkgLabel, *existingLabel)
 		default:
-			mExistingLabels[l.Name] = newDiffLabel(l, influxdb.Label{})
+			mExistingLabels[pkgLabel.Name] = newDiffLabel(pkgLabel, influxdb.Label{})
 		}
 	}
 
 	diffs := make([]DiffLabel, 0, len(mExistingLabels))
+	for _, diff := range mExistingLabels {
+		diffs = append(diffs, diff)
+	}
+	sort.Slice(diffs, func(i, j int) bool {
+		return diffs[i].Name < diffs[j].Name
+	})
+
+	return diffs, nil
+}
+
+func (s *Service) dryRunVariables(ctx context.Context, orgID influxdb.ID, pkg *Pkg) ([]DiffVariable, error) {
+	mExistingLabels := make(map[string]DiffVariable)
+	variables := pkg.variables()
+
+VarLoop:
+	for i := range variables {
+		pkgVar := variables[i]
+		existingLabels, err := s.varSVC.FindVariables(ctx, influxdb.VariableFilter{
+			OrganizationID: &orgID,
+			// TODO: would be ideal to extend find variables to allow for a name matcher
+			//  since names are unique for vars within an org, meanwhile, make large limit
+			// 	returned vars, should be more than enough for the time being.
+		}, influxdb.FindOptions{Limit: 10000})
+		switch {
+		case err == nil && len(existingLabels) > 0:
+			for i := range existingLabels {
+				existingVar := existingLabels[i]
+				if existingVar.Name != pkgVar.Name {
+					continue
+				}
+				pkgVar.existing = existingVar
+				mExistingLabels[pkgVar.Name] = newDiffVariable(pkgVar, *existingVar)
+				continue VarLoop
+			}
+			// fallthrough here for when the variable is not found, it'll fall to the
+			// default case and add it as new.
+			fallthrough
+		default:
+			mExistingLabels[pkgVar.Name] = newDiffVariable(pkgVar, influxdb.Variable{})
+		}
+	}
+
+	diffs := make([]DiffVariable, 0, len(mExistingLabels))
 	for _, diff := range mExistingLabels {
 		diffs = append(diffs, diff)
 	}
@@ -243,6 +343,23 @@ func (s *Service) dryRunLabelMappings(ctx context.Context, pkg *Pkg) ([]DiffLabe
 		}
 	}
 
+	for _, v := range pkg.variables() {
+		err := s.dryRunResourceLabelMapping(ctx, v, v.labels, func(labelID influxdb.ID, labelName string, isNew bool) {
+			pkg.mLabels[labelName].setVariableMapping(v, !isNew)
+			diffs = append(diffs, DiffLabelMapping{
+				IsNew:     isNew,
+				ResType:   v.ResourceType(),
+				ResID:     SafeID(v.ID()),
+				ResName:   v.Name,
+				LabelID:   SafeID(labelID),
+				LabelName: labelName,
+			})
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// sort by res type ASC, then res name ASC, then label name ASC
 	sort.Slice(diffs, func(i, j int) bool {
 		n, m := diffs[i], diffs[j]
@@ -271,6 +388,7 @@ func (s *Service) dryRunResourceLabelMapping(ctx context.Context, la labelAssoci
 		}
 		return nil
 	}
+
 	// loop through and hit api for all labels associated with a bkt
 	// lookup labels in pkg, add it to the label mapping, if exists in
 	// the results from API, mark it exists
@@ -338,6 +456,7 @@ func (s *Service) Apply(ctx context.Context, orgID influxdb.ID, pkg *Pkg) (sum S
 		{
 			// primary resources
 			s.applyLabels(pkg.labels()),
+			s.applyVariables(pkg.variables()),
 			s.applyBuckets(pkg.buckets()),
 			s.applyDashboards(pkg.dashboards()),
 		},
@@ -589,7 +708,17 @@ func (s *Service) applyLabels(labels []*label) applier {
 func (s *Service) rollbackLabels(labels []*label) error {
 	var errs []string
 	for _, l := range labels {
-		err := s.labelSVC.DeleteLabel(context.Background(), l.ID())
+		if l.existing == nil {
+			err := s.labelSVC.DeleteLabel(context.Background(), l.ID())
+			if err != nil {
+				errs = append(errs, l.ID().String())
+			}
+			continue
+		}
+
+		_, err := s.labelSVC.UpdateLabel(context.Background(), l.ID(), influxdb.LabelUpdate{
+			Properties: l.existing.Properties,
+		})
 		if err != nil {
 			errs = append(errs, l.ID().String())
 		}
@@ -624,6 +753,97 @@ func (s *Service) applyLabel(ctx context.Context, l *label) (influxdb.Label, err
 	}
 
 	return influxLabel, nil
+}
+
+func (s *Service) applyVariables(vars []*variable) applier {
+	const resource = "variable"
+
+	rollBackVars := make([]*variable, 0, len(vars))
+	createFn := func(ctx context.Context, orgID influxdb.ID) error {
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+		defer cancel()
+
+		var errs applyErrs
+		for i, v := range vars {
+			vars[i].OrgID = orgID
+			if !v.shouldApply() {
+				continue
+			}
+			influxVar, err := s.applyVariable(ctx, v)
+			if err != nil {
+				errs = append(errs, applyErrBody{
+					name: v.Name,
+					msg:  err.Error(),
+				})
+				continue
+			}
+			vars[i].id = influxVar.ID
+			rollBackVars = append(rollBackVars, vars[i])
+		}
+
+		return errs.toError(resource, "failed to create variable")
+	}
+
+	return applier{
+		creater: createFn,
+		rollbacker: rollbacker{
+			resource: resource,
+			fn:       func() error { return s.rollbackVariables(rollBackVars) },
+		},
+	}
+}
+
+func (s *Service) rollbackVariables(variables []*variable) error {
+	var errs []string
+	for _, v := range variables {
+		if v.existing == nil {
+			err := s.varSVC.DeleteVariable(context.Background(), v.ID())
+			if err != nil {
+				errs = append(errs, v.ID().String())
+			}
+			continue
+		}
+
+		_, err := s.varSVC.UpdateVariable(context.Background(), v.ID(), &influxdb.VariableUpdate{
+			Description: v.existing.Description,
+			Arguments:   v.existing.Arguments,
+		})
+		if err != nil {
+			errs = append(errs, v.ID().String())
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf(`variable_ids=[%s] err="unable to delete variable"`, strings.Join(errs, ", "))
+	}
+
+	return nil
+}
+
+func (s *Service) applyVariable(ctx context.Context, v *variable) (influxdb.Variable, error) {
+	if v.existing != nil {
+		updatedVar, err := s.varSVC.UpdateVariable(ctx, v.ID(), &influxdb.VariableUpdate{
+			Description: v.Description,
+			Arguments:   v.influxVarArgs(),
+		})
+		if err != nil {
+			return influxdb.Variable{}, err
+		}
+		return *updatedVar, nil
+	}
+
+	influxVar := influxdb.Variable{
+		OrganizationID: v.OrgID,
+		Name:           v.Name,
+		Description:    v.Description,
+		Arguments:      v.influxVarArgs(),
+	}
+	err := s.varSVC.CreateVariable(ctx, &influxVar)
+	if err != nil {
+		return influxdb.Variable{}, err
+	}
+
+	return influxVar, nil
 }
 
 func (s *Service) applyLabelMappings(pkg *Pkg) applier {

--- a/pkger/testdata/variables.json
+++ b/pkger/testdata/variables.json
@@ -1,0 +1,45 @@
+{
+  "apiVersion": "0.1.0",
+  "kind": "Package",
+  "meta": {
+    "pkgName": "pkg_name",
+    "pkgVersion": "1",
+    "description": "pack description"
+  },
+  "spec": {
+    "resources": [
+      {
+        "kind": "Variable",
+        "name": "var_query_1",
+        "description": "var_query_1 desc",
+        "type": "query",
+        "query": "buckets()  |> filter(fn: (r) => r.name !~ /^_/)  |> rename(columns: {name: \"_value\"})  |> keep(columns: [\"_value\"])",
+        "language": "flux"
+      },
+      {
+        "kind": "Variable",
+        "name": "var_query_2",
+        "description": "var_query_2 desc",
+        "type": "query",
+        "query": "an influxql query of sorts",
+        "language": "influxql"
+      },
+      {
+        "kind": "Variable",
+        "name": "var_const",
+        "description": "var_const desc",
+        "type": "constant",
+        "values": ["first val"]
+      },
+      {
+        "kind": "Variable",
+        "name": "var_map",
+        "description": "var_map desc",
+        "type": "map",
+        "values": {
+          "k1": "v1"
+        }
+      }
+    ]
+  }
+}

--- a/pkger/testdata/variables.yml
+++ b/pkger/testdata/variables.yml
@@ -1,0 +1,33 @@
+apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: Variable
+      name: var_query_1
+      description: var_query_1 desc
+      type: query
+      language: flux
+      query: |
+        buckets()  |> filter(fn: (r) => r.name !~ /^_/)  |> rename(columns: {name: "_value"})  |> keep(columns: ["_value"])
+    - kind: Variable
+      name: var_query_2
+      description: var_query_2 desc
+      type: query
+      query: an influxql query of sorts
+      language: influxql
+    - kind: Variable
+      name: var_const
+      description: var_const desc
+      type: constant
+      values:
+        - first val
+    - kind: Variable
+      name: var_map
+      description: var_map desc
+      type: map
+      values:
+        k1: v1

--- a/pkger/testdata/variables_associates_label.yml
+++ b/pkger/testdata/variables_associates_label.yml
@@ -1,0 +1,18 @@
+apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+  description:  pack description
+spec:
+  resources:
+    - kind: Label
+      name: label_1
+    - kind: Variable
+      name: var_1
+      type: constant
+      values:
+        - first val
+      associations:
+        - kind: Label
+          name: label_1

--- a/variable.go
+++ b/variable.go
@@ -123,7 +123,7 @@ func (m *Variable) Valid() error {
 		"query":    true,
 	}
 
-	if _, prs := validTypes[m.Arguments.Type]; !prs {
+	if !validTypes[m.Arguments.Type] {
 		return fmt.Errorf("invalid arguments type")
 	}
 


### PR DESCRIPTION
Only issue here is the #15758 issue is waiting on some feedback for a name for hte service endpoints. This is ready to go once that gets going. PR is compared against teh http server branch, which is up to date as of writing this. Once merged, will jigger this to pint at master.

PR isn't as big as the LOCs indicate. Found a nice abstraction for a testrunner on the parser side, ended up moving some bits around there to take advantage. Thanks for your patience 😬 

Dry run:

<img width="931" alt="image" src="https://user-images.githubusercontent.com/17263167/68369319-d987e600-00ee-11ea-9b1f-01152a5ecc16.png">

Application Summary:

<img width="933" alt="image" src="https://user-images.githubusercontent.com/17263167/68369332-e9072f00-00ee-11ea-9765-89e9dfb60db1.png">


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass