### PR TITLE
fix(flakey-test): refactored getSortedBucketNames for more consistency and predictability. Finished DWP API functionality

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6314,7 +6314,7 @@ components:
           type: string
         predicate:
           description: sql where like delete statement
-          example: tag1="value1" and (tag2="value2" and tag3="value3")
+          example: tag1="value1" and (tag2="value2" and tag3!="value3")
           type: string
     Node:
       oneOf:

--- a/predicate/predicate_test.go
+++ b/predicate/predicate_test.go
@@ -21,7 +21,7 @@ func TestDataTypeConversion(t *testing.T) {
 			name: "empty node",
 		},
 		{
-			name: "tag rule",
+			name: "equal tag rule",
 			node: &TagRuleNode{
 				Operator: influxdb.Equal,
 				Tag: influxdb.Tag{
@@ -47,7 +47,33 @@ func TestDataTypeConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "measurement tag rule",
+			name: "not equal tag rule",
+			node: &TagRuleNode{
+				Operator: influxdb.NotEqual,
+				Tag: influxdb.Tag{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			dataType: &datatypes.Node{
+				NodeType: datatypes.NodeTypeComparisonExpression,
+				Value:    &datatypes.Node_Comparison_{Comparison: datatypes.ComparisonNotEqual},
+				Children: []*datatypes.Node{
+					{
+						NodeType: datatypes.NodeTypeTagRef,
+						Value:    &datatypes.Node_TagRefValue{TagRefValue: "k1"},
+					},
+					{
+						NodeType: datatypes.NodeTypeLiteral,
+						Value: &datatypes.Node_StringValue{
+							StringValue: "v1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "measurement equal tag rule",
 			node: &TagRuleNode{
 				Operator: influxdb.Equal,
 				Tag: influxdb.Tag{
@@ -73,7 +99,33 @@ func TestDataTypeConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "field tag rule",
+			name: "measurement not equal tag rule",
+			node: &TagRuleNode{
+				Operator: influxdb.NotEqual,
+				Tag: influxdb.Tag{
+					Key:   "_measurement",
+					Value: "cpu",
+				},
+			},
+			dataType: &datatypes.Node{
+				NodeType: datatypes.NodeTypeComparisonExpression,
+				Value:    &datatypes.Node_Comparison_{Comparison: datatypes.ComparisonNotEqual},
+				Children: []*datatypes.Node{
+					{
+						NodeType: datatypes.NodeTypeTagRef,
+						Value:    &datatypes.Node_TagRefValue{TagRefValue: models.MeasurementTagKey},
+					},
+					{
+						NodeType: datatypes.NodeTypeLiteral,
+						Value: &datatypes.Node_StringValue{
+							StringValue: "cpu",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "equal field tag rule",
 			node: &TagRuleNode{
 				Operator: influxdb.Equal,
 				Tag: influxdb.Tag{
@@ -84,6 +136,32 @@ func TestDataTypeConversion(t *testing.T) {
 			dataType: &datatypes.Node{
 				NodeType: datatypes.NodeTypeComparisonExpression,
 				Value:    &datatypes.Node_Comparison_{Comparison: datatypes.ComparisonEqual},
+				Children: []*datatypes.Node{
+					{
+						NodeType: datatypes.NodeTypeTagRef,
+						Value:    &datatypes.Node_TagRefValue{TagRefValue: models.FieldKeyTagKey},
+					},
+					{
+						NodeType: datatypes.NodeTypeLiteral,
+						Value: &datatypes.Node_StringValue{
+							StringValue: "cpu",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "not equal field tag rule",
+			node: &TagRuleNode{
+				Operator: influxdb.NotEqual,
+				Tag: influxdb.Tag{
+					Key:   "_field",
+					Value: "cpu",
+				},
+			},
+			dataType: &datatypes.Node{
+				NodeType: datatypes.NodeTypeComparisonExpression,
+				Value:    &datatypes.Node_Comparison_{Comparison: datatypes.ComparisonNotEqual},
 				Children: []*datatypes.Node{
 					{
 						NodeType: datatypes.NodeTypeTagRef,

--- a/predicate/tag_rule.go
+++ b/predicate/tag_rule.go
@@ -44,7 +44,7 @@ func NodeComparison(op influxdb.Operator) (datatypes.Node_Comparison, error) {
 	case influxdb.Equal:
 		return datatypes.ComparisonEqual, nil
 	case influxdb.NotEqual:
-		fallthrough
+		return datatypes.ComparisonNotEqual, nil
 	case influxdb.RegexEqual:
 		fallthrough
 	case influxdb.NotRegexEqual:

--- a/ui/src/buckets/selectors/index.test.ts
+++ b/ui/src/buckets/selectors/index.test.ts
@@ -13,9 +13,7 @@ describe('Bucket Selector', () => {
     expect(isSystemBucket(`naming_${SYSTEM}`)).toEqual(false)
     expect(isSystemBucket('SYSTEM')).toEqual(false)
   })
-  // skipping this test for now as it's flakey. Issue has been raise:
-  // https://github.com/influxdata/influxdb/issues/15798
-  it.skip('should sort the bucket names alphabetically', () => {
+  it('should sort the bucket names alphabetically', () => {
     const buckets: Bucket[] = [
       {
         id: '7902bd683453c00c',

--- a/ui/src/buckets/selectors/index.ts
+++ b/ui/src/buckets/selectors/index.ts
@@ -5,28 +5,36 @@ export const SYSTEM = 'system'
 
 export const isSystemBucket = (type: string): boolean => type === SYSTEM
 
-export const getSortedBucketNames = (buckets: Bucket[]) =>
-  buckets
-    .sort((a, b) => {
-      const firstBucket = `${a.name}`.toLowerCase()
-      const secondBucket = `${b.name}`.toLowerCase()
-      if (firstBucket === secondBucket) {
-        return 0
-      }
-      if (isSystemBucket(a.type)) {
-        // ensures that the default system types are the last buckets
-        return 1
-      }
-      if (isSystemBucket(b.type)) {
-        // ensures that the default system types are the last buckets
-        return -1
-      }
-      if (firstBucket < secondBucket) {
-        return -1
-      }
-      if (firstBucket > secondBucket) {
-        return 1
-      }
-      return 0
-    })
-    .map(bucket => bucket.name)
+const sortFunc = (a: Bucket, b: Bucket) => {
+  const firstBucket = `${a.name}`.toLowerCase()
+  const secondBucket = `${b.name}`.toLowerCase()
+  if (firstBucket === secondBucket) {
+    return 0
+  }
+  if (firstBucket < secondBucket) {
+    return -1
+  }
+  if (firstBucket > secondBucket) {
+    return 1
+  }
+  return 0
+}
+
+export const getSortedBucketNames = (buckets: Bucket[]) => {
+  const systemBuckets = []
+  const otherBuckets = []
+  buckets.forEach(bucket => {
+    // separate system buckets from the rest
+    if (isSystemBucket(bucket.type)) {
+      systemBuckets.push(bucket)
+    } else {
+      otherBuckets.push(bucket)
+    }
+  })
+  // alphabetize system buckets
+  systemBuckets.sort(sortFunc)
+  // alphabetize other buckets
+  otherBuckets.sort(sortFunc)
+  // concat the system buckets to the end of the other buckets and map results
+  return otherBuckets.concat(systemBuckets).map(bucket => bucket.name)
+}

--- a/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
+++ b/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
@@ -46,20 +46,17 @@ const FilterRow: FC<Props> = ({
       >
         <Input onChange={onChangeKey} value={key} testID="key-input" />
       </Form.Element>
-      <div className="delete-data-filter--equals">==</div>
-      <FeatureFlag name="deleteWithPredicateEquality">
-        <Form.Element
-          label="Equality Filter"
-          required={true}
-          errorMessage={equalityErrorMessage}
-        >
-          <SelectDropdown
-            options={['=', '!=']}
-            selectedOption={equality}
-            onSelect={onChangeEquality}
-          />
-        </Form.Element>
-      </FeatureFlag>
+      <Form.Element
+        label="Equality Filter"
+        required={true}
+        errorMessage={equalityErrorMessage}
+      >
+        <SelectDropdown
+          options={['=', '!=']}
+          selectedOption={equality}
+          onSelect={onChangeEquality}
+        />
+      </Form.Element>
       <Form.Element
         label="Tag Value"
         required={true}

--- a/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
+++ b/ui/src/shared/components/DeleteDataForm/FilterRow.tsx
@@ -8,7 +8,6 @@ import {
   Input,
   SelectDropdown,
 } from '@influxdata/clockface'
-import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Types
 import {Filter} from 'src/types'

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -5,7 +5,6 @@ const OSS_FLAGS = {
   alerting: false,
   eventMarkers: false,
   deleteWithPredicate: false,
-  deleteWithPredicateEquality: false,
   downloadCellCSV: false,
 }
 
@@ -13,7 +12,6 @@ const CLOUD_FLAGS = {
   alerting: true,
   eventMarkers: false,
   deleteWithPredicate: false,
-  deleteWithPredicateEquality: false,
   cloudBilling: CLOUD_BILLING_VISIBLE, // should be visible in dev and acceptance, but not in cloud
   downloadCellCSV: false,
 }


### PR DESCRIPTION
Closes #15798 

### Problem

This PR deals with two separate problems:

1. The issue noted above was the result of inconsistent behavior in the test.
2. The API still couldn't handle `!=` deleteWithPredicate conditions

### Solution

1. Refactored the `getSortedBucketNames` to break the data into two separate arrays that are sorted, concatenated and mapped.
2. Connected the `datatypes.ComparisonNotEqual` to the `influxdb.NotEqual` case in `predicate/tag_rule`