### PR TITLE
fix(http/links): Added query links to checks and notificationRules response, updated swagger.yml

### DIFF
--- a/http/check_service.go
+++ b/http/check_service.go
@@ -133,6 +133,7 @@ type checkLinks struct {
 	Labels  string `json:"labels"`
 	Members string `json:"members"`
 	Owners  string `json:"owners"`
+	Query   string `json:"query"`
 }
 
 type checkResponse struct {
@@ -195,6 +196,7 @@ func (h *CheckHandler) newCheckResponse(ctx context.Context, chk influxdb.Check,
 			Labels:  fmt.Sprintf("/api/v2/checks/%s/labels", chk.GetID()),
 			Members: fmt.Sprintf("/api/v2/checks/%s/members", chk.GetID()),
 			Owners:  fmt.Sprintf("/api/v2/checks/%s/owners", chk.GetID()),
+			Query:   fmt.Sprintf("/api/v2/checks/%s/query", chk.GetID()),
 		},
 		Labels: []influxdb.Label{},
 	}

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -131,6 +131,7 @@ func TestService_handleGetChecks(t *testing.T) {
       "links": {
         "self": "/api/v2/checks/0b501e7e557ab1ed",
         "labels": "/api/v2/checks/0b501e7e557ab1ed/labels",
+        "query": "/api/v2/checks/0b501e7e557ab1ed/query",
         "owners": "/api/v2/checks/0b501e7e557ab1ed/owners",
         "members": "/api/v2/checks/0b501e7e557ab1ed/members"
       },
@@ -173,7 +174,8 @@ func TestService_handleGetChecks(t *testing.T) {
         "self": "/api/v2/checks/c0175f0077a77005",
         "labels": "/api/v2/checks/c0175f0077a77005/labels",
         "members": "/api/v2/checks/c0175f0077a77005/members",
-        "owners": "/api/v2/checks/c0175f0077a77005/owners"
+        "owners": "/api/v2/checks/c0175f0077a77005/owners",
+        "query": "/api/v2/checks/c0175f0077a77005/query"
       },
 			"createdAt": "0001-01-01T00:00:00Z",
 			"updatedAt": "0001-01-01T00:00:00Z",
@@ -513,7 +515,8 @@ func TestService_handleGetCheck(t *testing.T) {
 		    "self": "/api/v2/checks/020f755c3c082000",
 		    "labels": "/api/v2/checks/020f755c3c082000/labels",
 		    "members": "/api/v2/checks/020f755c3c082000/members",
-		    "owners": "/api/v2/checks/020f755c3c082000/owners"
+		    "owners": "/api/v2/checks/020f755c3c082000/owners",
+		    "query": "/api/v2/checks/020f755c3c082000/query"
 		  },
 		  "labels": [],
 		  "level": "CRIT",
@@ -684,7 +687,8 @@ func TestService_handlePostCheck(t *testing.T) {
     "self": "/api/v2/checks/020f755c3c082000",
     "labels": "/api/v2/checks/020f755c3c082000/labels",
     "members": "/api/v2/checks/020f755c3c082000/members",
-    "owners": "/api/v2/checks/020f755c3c082000/owners"
+    "owners": "/api/v2/checks/020f755c3c082000/owners",
+    "query": "/api/v2/checks/020f755c3c082000/query"
   },
   "reportZero": true,
   "statusMessageTemplate": "msg1",
@@ -942,7 +946,8 @@ func TestService_handlePatchCheck(t *testing.T) {
 		    "self": "/api/v2/checks/020f755c3c082000",
 		    "labels": "/api/v2/checks/020f755c3c082000/labels",
 		    "members": "/api/v2/checks/020f755c3c082000/members",
-		    "owners": "/api/v2/checks/020f755c3c082000/owners"
+		    "owners": "/api/v2/checks/020f755c3c082000/owners",
+		    "query": "/api/v2/checks/020f755c3c082000/query"
 		  },
 		  "createdAt": "0001-01-01T00:00:00Z",
 		  "updatedAt": "0001-01-01T00:00:00Z",
@@ -1121,7 +1126,8 @@ func TestService_handleUpdateCheck(t *testing.T) {
 		    "self": "/api/v2/checks/020f755c3c082000",
 		    "labels": "/api/v2/checks/020f755c3c082000/labels",
 		    "members": "/api/v2/checks/020f755c3c082000/members",
-		    "owners": "/api/v2/checks/020f755c3c082000/owners"
+		    "owners": "/api/v2/checks/020f755c3c082000/owners",
+		    "query": "/api/v2/checks/020f755c3c082000/query"
 		  },
 		  "createdAt": "0001-01-01T00:00:00Z",
 		  "updatedAt": "0001-01-01T00:00:00Z",

--- a/http/notification_rule.go
+++ b/http/notification_rule.go
@@ -141,6 +141,7 @@ type notificationRuleLinks struct {
 	Labels  string `json:"labels"`
 	Members string `json:"members"`
 	Owners  string `json:"owners"`
+	Query   string `json:"query"`
 }
 
 type notificationRuleResponse struct {
@@ -192,6 +193,7 @@ func (h *NotificationRuleHandler) newNotificationRuleResponse(ctx context.Contex
 			Labels:  fmt.Sprintf("/api/v2/notificationRules/%s/labels", nr.GetID()),
 			Members: fmt.Sprintf("/api/v2/notificationRules/%s/members", nr.GetID()),
 			Owners:  fmt.Sprintf("/api/v2/notificationRules/%s/owners", nr.GetID()),
+			Query:   fmt.Sprintf("/api/v2/notificationRules/%s/query", nr.GetID()),
 		},
 		Labels: []influxdb.Label{},
 		Status: t.Status,

--- a/http/notification_rule_test.go
+++ b/http/notification_rule_test.go
@@ -115,6 +115,7 @@ func Test_newNotificationRuleResponses(t *testing.T) {
         "labels": "/api/v2/notificationRules/0000000000000001/labels",
         "members": "/api/v2/notificationRules/0000000000000001/members",
         "owners": "/api/v2/notificationRules/0000000000000001/owners",
+        "query": "/api/v2/notificationRules/0000000000000001/query",
         "self": "/api/v2/notificationRules/0000000000000001"
       },
       "messageTemplate": "message 1{var1}",
@@ -160,6 +161,7 @@ func Test_newNotificationRuleResponses(t *testing.T) {
         "labels": "/api/v2/notificationRules/000000000000000b/labels",
         "members": "/api/v2/notificationRules/000000000000000b/members",
         "owners": "/api/v2/notificationRules/000000000000000b/owners",
+        "query": "/api/v2/notificationRules/000000000000000b/query",
         "self": "/api/v2/notificationRules/000000000000000b"
       },
       "messageTemplate": "body 2{var2}",
@@ -253,6 +255,7 @@ func Test_newNotificationRuleResponse(t *testing.T) {
    "labels": "/api/v2/notificationRules/0000000000000001/labels",
    "members": "/api/v2/notificationRules/0000000000000001/members",
    "owners": "/api/v2/notificationRules/0000000000000001/owners",
+   "query": "/api/v2/notificationRules/0000000000000001/query",
    "self": "/api/v2/notificationRules/0000000000000001"
  },
  "messageTemplate": "message 1{var1}",

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -9821,6 +9821,7 @@ components:
             labels: "/api/v2/checks/1/labels"
             members: "/api/v2/checks/1/members"
             owners: "/api/v2/checks/1/owners"
+            query: "/api/v2/checks/1/query"
           properties:
             self:
               description: URL for this check
@@ -10062,6 +10063,7 @@ components:
             labels: "/api/v2/notificationRules/1/labels"
             members: "/api/v2/notificationRules/1/members"
             owners: "/api/v2/notificationRules/1/owners"
+            query: "/api/v2/notificationRules/1/query"
           properties:
             self:
               description: URL for this endpoint.


### PR DESCRIPTION
Closes #15553 

### Problem

API response for `checks` and `notificationRules` was not returning a reference to the query in the response: `/api/v2/notificationRules/ID/query`

### Solution

Updated `check_service` & `notification_rule` to return a reference to the `/query`  in the response links. Updated tests and swagger.yml to reflect these changes
