### PR TITLE
feat(pkger): add export functonality to pkger for existing buckets/label/dash/vars

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -299,6 +299,21 @@ type ViewContents struct {
 	Name string `json:"name"`
 }
 
+// Values for all supported view property types.
+const (
+	ViewPropertyTypeCheck              = "check"
+	ViewPropertyTypeGauge              = "gauge"
+	ViewPropertyTypeHeatMap            = "heatmap"
+	ViewPropertyTypeHistogram          = "histogram"
+	ViewPropertyTypeLogViewer          = "log-viewer"
+	ViewPropertyTypeMarkdown           = "markdown"
+	ViewPropertyTypeScatter            = "scatter"
+	ViewPropertyTypeSingleStat         = "single-stat"
+	ViewPropertyTypeSingleStatPlusLine = "line-plus-single-stat"
+	ViewPropertyTypeTable              = "table"
+	ViewPropertyTypeXY                 = "xy"
+)
+
 // ViewProperties is used to mark other structures as conforming to a View.
 type ViewProperties interface {
 	viewProperties()
@@ -340,67 +355,67 @@ func UnmarshalViewPropertiesJSON(b []byte) (ViewProperties, error) {
 	switch t.Shape {
 	case "chronograf-v2":
 		switch t.Type {
-		case "check":
+		case ViewPropertyTypeCheck:
 			var cv CheckViewProperties
 			if err := json.Unmarshal(v.B, &cv); err != nil {
 				return nil, err
 			}
 			vis = cv
-		case "xy":
+		case ViewPropertyTypeXY:
 			var xyv XYViewProperties
 			if err := json.Unmarshal(v.B, &xyv); err != nil {
 				return nil, err
 			}
 			vis = xyv
-		case "single-stat":
+		case ViewPropertyTypeSingleStat:
 			var ssv SingleStatViewProperties
 			if err := json.Unmarshal(v.B, &ssv); err != nil {
 				return nil, err
 			}
 			vis = ssv
-		case "gauge":
+		case ViewPropertyTypeGauge:
 			var gv GaugeViewProperties
 			if err := json.Unmarshal(v.B, &gv); err != nil {
 				return nil, err
 			}
 			vis = gv
-		case "table":
+		case ViewPropertyTypeTable:
 			var tv TableViewProperties
 			if err := json.Unmarshal(v.B, &tv); err != nil {
 				return nil, err
 			}
 			vis = tv
-		case "markdown":
+		case ViewPropertyTypeMarkdown:
 			var mv MarkdownViewProperties
 			if err := json.Unmarshal(v.B, &mv); err != nil {
 				return nil, err
 			}
 			vis = mv
-		case "log-viewer": // happens in log viewer stays in log viewer.
+		case ViewPropertyTypeLogViewer: // happens in log viewer stays in log viewer.
 			var lv LogViewProperties
 			if err := json.Unmarshal(v.B, &lv); err != nil {
 				return nil, err
 			}
 			vis = lv
-		case "line-plus-single-stat":
+		case ViewPropertyTypeSingleStatPlusLine:
 			var lv LinePlusSingleStatProperties
 			if err := json.Unmarshal(v.B, &lv); err != nil {
 				return nil, err
 			}
 			vis = lv
-		case "histogram":
+		case ViewPropertyTypeHistogram:
 			var hv HistogramViewProperties
 			if err := json.Unmarshal(v.B, &hv); err != nil {
 				return nil, err
 			}
 			vis = hv
-		case "heatmap":
+		case ViewPropertyTypeHeatMap:
 			var hv HeatmapViewProperties
 			if err := json.Unmarshal(v.B, &hv); err != nil {
 				return nil, err
 			}
 			vis = hv
-		case "scatter":
+		case ViewPropertyTypeScatter:
 			var sv ScatterViewProperties
 			if err := json.Unmarshal(v.B, &sv); err != nil {
 				return nil, err

--- a/http/pkger_http_server.go
+++ b/http/pkger_http_server.go
@@ -54,11 +54,13 @@ type ReqCreatePkg struct {
 	PkgName        string `json:"pkgName"`
 	PkgDescription string `json:"pkgDescription"`
 	PkgVersion     string `json:"pkgVersion"`
+
+	Resources []pkger.ResourceToClone `json:"resources"`
 }
 
 // RespCreatePkg is a response body for the create pkg endpoint.
 type RespCreatePkg struct {
-	Package *pkger.Pkg `json:"package"`
+	*pkger.Pkg
 }
 
 func (s *HandlerPkg) createPkg(w http.ResponseWriter, r *http.Request) {
@@ -75,6 +77,7 @@ func (s *HandlerPkg) createPkg(w http.ResponseWriter, r *http.Request) {
 			Name:        reqBody.PkgName,
 			Version:     reqBody.PkgVersion,
 		}),
+		pkger.WithResourceClones(reqBody.Resources...),
 	)
 	if err != nil {
 		s.HandleHTTPError(r.Context(), err, w)
@@ -82,7 +85,7 @@ func (s *HandlerPkg) createPkg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.encResp(r.Context(), w, http.StatusOK, RespCreatePkg{
-		Package: newPkg,
+		Pkg: newPkg,
 	})
 }
 

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7104,6 +7104,21 @@ components:
           type: string
         pkgVersion:
           type: string
+        resources:
+          type: object
+          properties:
+            id:
+              type: string
+            kind:
+              type: string
+              enum:
+                - bucket
+                - dashboard
+                - label
+                - variable
+            name:
+              type: string
+          required: [id, kind]
     Pkg:
       type: object
       properties:

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -1,0 +1,280 @@
+package pkger
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/influxdata/influxdb"
+)
+
+// ResourceToClone is a resource that will be cloned.
+type ResourceToClone struct {
+	Kind Kind        `json:"kind"`
+	ID   influxdb.ID `json:"id"`
+	Name string      `json:"name"`
+}
+
+// OK validates a resource clone is viable.
+func (r ResourceToClone) OK() error {
+	if err := r.Kind.OK(); err != nil {
+		return err
+	}
+	if r.ID == influxdb.ID(0) {
+		return errors.New("must provide an ID")
+	}
+	return nil
+}
+
+func bucketToResource(bkt influxdb.Bucket, name string) Resource {
+	if name == "" {
+		name = bkt.Name
+	}
+	return Resource{
+		fieldKind:                  KindBucket.String(),
+		fieldName:                  name,
+		fieldDescription:           bkt.Description,
+		fieldBucketRetentionPeriod: bkt.RetentionPeriod.String(),
+	}
+}
+
+type cellView struct {
+	c influxdb.Cell
+	v influxdb.View
+}
+
+func convertCellView(cv cellView) chart {
+	ch := chart{
+		Name:   cv.v.Name,
+		Height: int(cv.c.H),
+		Width:  int(cv.c.W),
+		XPos:   int(cv.c.X),
+		YPos:   int(cv.c.Y),
+	}
+
+	setCommon := func(k chartKind, iColors []influxdb.ViewColor, dec influxdb.DecimalPlaces, iQueries []influxdb.DashboardQuery) {
+		ch.Kind = k
+		ch.Colors = convertColors(iColors)
+		ch.DecimalPlaces = int(dec.Digits)
+		ch.EnforceDecimals = dec.IsEnforced
+		ch.Queries = convertQueries(iQueries)
+	}
+
+	setNoteFixes := func(note string, noteOnEmpty bool, prefix, suffix string) {
+		ch.Note = note
+		ch.NoteOnEmpty = noteOnEmpty
+		ch.Prefix = prefix
+		ch.Suffix = suffix
+	}
+
+	setLegend := func(l influxdb.Legend) {
+		ch.Legend.Orientation = l.Orientation
+		ch.Legend.Type = l.Type
+	}
+
+	props := cv.v.Properties
+	switch p := props.(type) {
+	case influxdb.GaugeViewProperties:
+		setCommon(chartKindGauge, p.ViewColors, p.DecimalPlaces, p.Queries)
+		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, p.Prefix, p.Suffix)
+	case influxdb.LinePlusSingleStatProperties:
+		setCommon(chartKindSingleStatPlusLine, p.ViewColors, p.DecimalPlaces, p.Queries)
+		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, p.Prefix, p.Suffix)
+		setLegend(p.Legend)
+		ch.Axes = convertAxes(p.Axes)
+		ch.Shade = p.ShadeBelow
+		ch.XCol = p.XColumn
+		ch.YCol = p.YColumn
+	case influxdb.SingleStatViewProperties:
+		setCommon(chartKindSingleStat, p.ViewColors, p.DecimalPlaces, p.Queries)
+		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, p.Prefix, p.Suffix)
+	case influxdb.XYViewProperties:
+		setCommon(chartKindXY, p.ViewColors, influxdb.DecimalPlaces{}, p.Queries)
+		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, "", "")
+		setLegend(p.Legend)
+		ch.Axes = convertAxes(p.Axes)
+		ch.Geom = p.Geom
+		ch.Shade = p.ShadeBelow
+		ch.XCol = p.XColumn
+		ch.YCol = p.YColumn
+	}
+
+	return ch
+}
+
+func convertChartToResource(ch chart) Resource {
+	r := Resource{
+		fieldKind:         string(ch.Kind),
+		fieldName:         ch.Name,
+		fieldChartQueries: ch.Queries,
+		fieldChartHeight:  ch.Height,
+		fieldChartWidth:   ch.Width,
+	}
+	if len(ch.Colors) > 0 {
+		r[fieldChartColors] = ch.Colors
+	}
+	if len(ch.Axes) > 0 {
+		r[fieldChartAxes] = ch.Axes
+	}
+	if ch.EnforceDecimals {
+		r[fieldChartDecimalPlaces] = ch.DecimalPlaces
+	}
+
+	if ch.Legend.Type != "" {
+		r[fieldChartLegend] = ch.Legend
+	}
+
+	ignoreFalseBools := map[string]bool{
+		fieldChartNoteOnEmpty: ch.NoteOnEmpty,
+		fieldChartShade:       ch.Shade,
+	}
+	for k, v := range ignoreFalseBools {
+		if v {
+			r[k] = v
+		}
+	}
+
+	ignoreEmptyStrPairs := map[string]string{
+		fieldChartNote: ch.Note,
+		fieldPrefix:    ch.Prefix,
+		fieldSuffix:    ch.Suffix,
+		fieldChartGeom: ch.Geom,
+		fieldChartXCol: ch.XCol,
+		fieldChartYCol: ch.YCol,
+	}
+	for k, v := range ignoreEmptyStrPairs {
+		if v != "" {
+			r[k] = v
+		}
+	}
+
+	ignoreEmptyIntPairs := map[string]int{
+		fieldChartXPos: ch.XPos,
+		fieldChartYPos: ch.YPos,
+	}
+	for k, v := range ignoreEmptyIntPairs {
+		if v != 0 {
+			r[k] = v
+		}
+	}
+
+	return r
+}
+
+func convertAxes(iAxes map[string]influxdb.Axis) axes {
+	out := make(axes, 0, len(iAxes))
+	for name, a := range iAxes {
+		out = append(out, axis{
+			Base:   a.Base,
+			Label:  a.Label,
+			Name:   name,
+			Prefix: a.Prefix,
+			Scale:  a.Scale,
+			Suffix: a.Suffix,
+		})
+	}
+	return out
+}
+
+func convertColors(iColors []influxdb.ViewColor) colors {
+	out := make(colors, 0, len(iColors))
+	for _, ic := range iColors {
+		out = append(out, &color{
+			Name:  ic.Name,
+			Type:  ic.Type,
+			Hex:   ic.Hex,
+			Value: flt64Ptr(ic.Value),
+		})
+	}
+	return out
+}
+
+func convertQueries(iQueries []influxdb.DashboardQuery) queries {
+	out := make(queries, 0, len(iQueries))
+	for _, iq := range iQueries {
+		out = append(out, query{Query: iq.Text})
+	}
+	return out
+}
+
+func dashboardToResource(dash influxdb.Dashboard, cellViews []cellView, name string) Resource {
+	if name == "" {
+		name = dash.Name
+	}
+
+	sort.Slice(cellViews, func(i, j int) bool {
+		ic, jc := cellViews[i].c, cellViews[j].c
+		if ic.X == jc.X {
+			return ic.Y < jc.Y
+		}
+		return ic.X < jc.X
+	})
+
+	charts := make([]Resource, 0, len(cellViews))
+	for _, cv := range cellViews {
+		if cv.c.ID == influxdb.ID(0) {
+			continue
+		}
+		ch := convertCellView(cv)
+		if !ch.Kind.ok() {
+			continue
+		}
+		charts = append(charts, convertChartToResource(ch))
+	}
+
+	return Resource{
+		fieldKind:        KindDashboard.String(),
+		fieldName:        name,
+		fieldDescription: dash.Description,
+		fieldDashCharts:  charts,
+	}
+}
+
+func labelToResource(l influxdb.Label, name string) Resource {
+	if name == "" {
+		name = l.Name
+	}
+	return Resource{
+		fieldKind:        KindLabel.String(),
+		fieldName:        name,
+		fieldLabelColor:  l.Properties["color"],
+		fieldDescription: l.Properties["description"],
+	}
+}
+
+func variableToResource(v influxdb.Variable, name string) Resource {
+	if name == "" {
+		name = v.Name
+	}
+
+	r := Resource{
+		fieldKind:        KindVariable.String(),
+		fieldName:        name,
+		fieldDescription: v.Description,
+	}
+	args := v.Arguments
+	if args == nil {
+		return r
+	}
+	r[fieldType] = args.Type
+
+	switch args.Type {
+	case fieldArgTypeConstant:
+		vals, ok := args.Values.(influxdb.VariableConstantValues)
+		if ok {
+			r[fieldValues] = []string(vals)
+		}
+	case fieldArgTypeMap:
+		vals, ok := args.Values.(influxdb.VariableMapValues)
+		if ok {
+			r[fieldValues] = map[string]string(vals)
+		}
+	case fieldArgTypeQuery:
+		vals, ok := args.Values.(influxdb.VariableQueryValues)
+		if ok {
+			r[fieldVarLanguage] = vals.Language
+			r[fieldQuery] = vals.Query
+		}
+	}
+
+	return r
+}

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -277,15 +277,15 @@ func (p *Pkg) labelMappings() []SummaryLabelMapping {
 
 func (p *Pkg) validMetadata() error {
 	var failures []*failure
-	if p.APIVersion != "0.1.0" {
+	if p.APIVersion != APIVersion {
 		failures = append(failures, &failure{
 			Field: "apiVersion",
-			Msg:   "must be version 0.1.0",
+			Msg:   "must be version " + APIVersion,
 		})
 	}
 
-	mKind := kind(strings.TrimSpace(strings.ToLower(p.Kind)))
-	if mKind != kindPackage {
+	mKind := Kind(strings.TrimSpace(strings.ToLower(p.Kind)))
+	if mKind != KindPackage {
 		failures = append(failures, &failure{
 			Field: "kind",
 			Msg:   `must be of kind "Package"`,
@@ -294,14 +294,14 @@ func (p *Pkg) validMetadata() error {
 
 	if p.Metadata.Version == "" {
 		failures = append(failures, &failure{
-			Field: "pkgVersion",
+			Field: "meta.pkgVersion",
 			Msg:   "version is required",
 		})
 	}
 
 	if p.Metadata.Name == "" {
 		failures = append(failures, &failure{
-			Field: "pkgName",
+			Field: "meta.pkgName",
 			Msg:   "must be at least 1 char",
 		})
 	}
@@ -311,7 +311,7 @@ func (p *Pkg) validMetadata() error {
 	}
 
 	res := errResource{
-		Kind: kindPackage.String(),
+		Kind: KindPackage.String(),
 		Idx:  -1,
 	}
 	for _, f := range failures {
@@ -366,7 +366,7 @@ func (p *Pkg) graphResources() error {
 
 func (p *Pkg) graphBuckets() error {
 	p.mBuckets = make(map[string]*bucket)
-	return p.eachResource(kindBucket, func(r Resource) []failure {
+	return p.eachResource(KindBucket, func(r Resource) []failure {
 		if r.Name() == "" {
 			return []failure{{
 				Field: "name",
@@ -383,8 +383,8 @@ func (p *Pkg) graphBuckets() error {
 
 		bkt := &bucket{
 			Name:            r.Name(),
-			Description:     r.stringShort("description"),
-			RetentionPeriod: r.duration("retention_period"),
+			Description:     r.stringShort(fieldDescription),
+			RetentionPeriod: r.duration(fieldBucketRetentionPeriod),
 		}
 
 		failures := p.parseNestedLabels(r, func(l *label) error {
@@ -407,7 +407,7 @@ func (p *Pkg) graphBuckets() error {
 
 func (p *Pkg) graphLabels() error {
 	p.mLabels = make(map[string]*label)
-	return p.eachResource(kindLabel, func(r Resource) []failure {
+	return p.eachResource(KindLabel, func(r Resource) []failure {
 		if r.Name() == "" {
 			return []failure{{
 				Field: "name",
@@ -423,8 +423,8 @@ func (p *Pkg) graphLabels() error {
 		}
 		p.mLabels[r.Name()] = &label{
 			Name:        r.Name(),
-			Color:       r.stringShort("color"),
-			Description: r.stringShort("description"),
+			Color:       r.stringShort(fieldLabelColor),
+			Description: r.stringShort(fieldDescription),
 		}
 
 		return nil
@@ -433,7 +433,7 @@ func (p *Pkg) graphLabels() error {
 
 func (p *Pkg) graphDashboards() error {
 	p.mDashboards = make(map[string]*dashboard)
-	return p.eachResource(kindDashboard, func(r Resource) []failure {
+	return p.eachResource(KindDashboard, func(r Resource) []failure {
 		if r.Name() == "" {
 			return []failure{{
 				Field: "name",
@@ -450,7 +450,7 @@ func (p *Pkg) graphDashboards() error {
 
 		dash := &dashboard{
 			Name:        r.Name(),
-			Description: r.stringShort("description"),
+			Description: r.stringShort(fieldDescription),
 		}
 
 		failures := p.parseNestedLabels(r, func(l *label) error {
@@ -462,7 +462,7 @@ func (p *Pkg) graphDashboards() error {
 			return dash.labels[i].Name < dash.labels[j].Name
 		})
 
-		for i, cr := range r.slcResource("charts") {
+		for i, cr := range r.slcResource(fieldDashCharts) {
 			ch, fails := parseChart(cr)
 			if fails != nil {
 				for _, f := range fails {
@@ -488,7 +488,7 @@ func (p *Pkg) graphDashboards() error {
 
 func (p *Pkg) graphVariables() error {
 	p.mVariables = make(map[string]*variable)
-	return p.eachResource(kindVariable, func(r Resource) []failure {
+	return p.eachResource(KindVariable, func(r Resource) []failure {
 		if r.Name() == "" {
 			return []failure{{
 				Field: "name",
@@ -505,12 +505,12 @@ func (p *Pkg) graphVariables() error {
 
 		newVar := &variable{
 			Name:        r.Name(),
-			Description: r.stringShort("description"),
-			Type:        strings.ToLower(r.stringShort("type")),
-			Query:       strings.TrimSpace(r.stringShort("query")),
-			Language:    strings.ToLower(strings.TrimSpace(r.stringShort("language"))),
-			ConstValues: r.slcStr("values"),
-			MapValues:   r.mapStrStr("values"),
+			Description: r.stringShort(fieldDescription),
+			Type:        strings.ToLower(r.stringShort(fieldType)),
+			Query:       strings.TrimSpace(r.stringShort(fieldQuery)),
+			Language:    strings.ToLower(strings.TrimSpace(r.stringShort(fieldLegendLanguage))),
+			ConstValues: r.slcStr(fieldValues),
+			MapValues:   r.mapStrStr(fieldValues),
 		}
 
 		failures := p.parseNestedLabels(r, func(l *label) error {
@@ -536,7 +536,7 @@ func (p *Pkg) graphVariables() error {
 	})
 }
 
-func (p *Pkg) eachResource(resourceKind kind, fn func(r Resource) []failure) error {
+func (p *Pkg) eachResource(resourceKind Kind, fn func(r Resource) []failure) error {
 	var parseErr ParseErr
 	for i, r := range p.Spec.Resources {
 		k, err := r.kind()
@@ -556,7 +556,7 @@ func (p *Pkg) eachResource(resourceKind kind, fn func(r Resource) []failure) err
 			})
 			continue
 		}
-		if k != resourceKind {
+		if !k.is(resourceKind) {
 			continue
 		}
 
@@ -593,7 +593,7 @@ func (p *Pkg) parseNestedLabels(r Resource, fn func(lb *label) error) []failure 
 	nestedLabels := make(map[string]*label)
 
 	var failures []failure
-	for i, nr := range r.nestedAssociations() {
+	for i, nr := range r.slcResource(fieldAssociations) {
 		fail := p.parseNestedLabel(i, nr, func(l *label) error {
 			if _, ok := nestedLabels[l.Name]; ok {
 				return fmt.Errorf("duplicate nested label: %q", l.Name)
@@ -620,7 +620,7 @@ func (p *Pkg) parseNestedLabel(idx int, nr Resource, fn func(lb *label) error) *
 			assIndex:        idx,
 		}
 	}
-	if k != kindLabel {
+	if !k.is(KindLabel) {
 		return nil
 	}
 
@@ -657,56 +657,73 @@ func parseChart(r Resource) (chart, []failure) {
 	c := chart{
 		Kind:        ck,
 		Name:        r.Name(),
-		Prefix:      r.stringShort("prefix"),
-		Suffix:      r.stringShort("suffix"),
-		Note:        r.stringShort("note"),
-		NoteOnEmpty: r.boolShort("noteOnEmpty"),
-		Shade:       r.boolShort("shade"),
-		XCol:        r.stringShort("xCol"),
-		YCol:        r.stringShort("yCol"),
-		XPos:        r.intShort("xPos"),
-		YPos:        r.intShort("yPos"),
-		Height:      r.intShort("height"),
-		Width:       r.intShort("width"),
-		Geom:        r.stringShort("geom"),
+		Prefix:      r.stringShort(fieldPrefix),
+		Suffix:      r.stringShort(fieldSuffix),
+		Note:        r.stringShort(fieldChartNote),
+		NoteOnEmpty: r.boolShort(fieldChartNoteOnEmpty),
+		Shade:       r.boolShort(fieldChartShade),
+		XCol:        r.stringShort(fieldChartXCol),
+		YCol:        r.stringShort(fieldChartYCol),
+		XPos:        r.intShort(fieldChartXPos),
+		YPos:        r.intShort(fieldChartYPos),
+		Height:      r.intShort(fieldChartHeight),
+		Width:       r.intShort(fieldChartWidth),
+		Geom:        r.stringShort(fieldChartGeom),
 	}
 
-	if leg, ok := ifaceToResource(r["legend"]); ok {
-		c.Legend.Type = leg.stringShort("type")
-		c.Legend.Orientation = leg.stringShort("orientation")
+	if presLeg, ok := r[fieldChartLegend].(legend); ok {
+		c.Legend = presLeg
+	} else {
+		if leg, ok := ifaceToResource(r[fieldChartLegend]); ok {
+			c.Legend.Type = leg.stringShort(fieldType)
+			c.Legend.Orientation = leg.stringShort(fieldLegendOrientation)
+		}
 	}
 
-	if dp, ok := r.int("decimalPlaces"); ok {
+	if dp, ok := r.int(fieldChartDecimalPlaces); ok {
 		c.EnforceDecimals = true
 		c.DecimalPlaces = dp
 	}
 
 	var failures []failure
-	for _, rq := range r.slcResource("queries") {
-		c.Queries = append(c.Queries, query{
-			Query: strings.TrimSpace(rq.stringShort("query")),
-		})
+	if presentQueries, ok := r[fieldChartQueries].(queries); ok {
+		c.Queries = presentQueries
+	} else {
+		for _, rq := range r.slcResource(fieldChartQueries) {
+			c.Queries = append(c.Queries, query{
+				Query: strings.TrimSpace(rq.stringShort(fieldQuery)),
+			})
+		}
 	}
 
-	for _, rc := range r.slcResource("colors") {
-		c.Colors = append(c.Colors, &color{
-			id:    influxdb.ID(int(time.Now().UnixNano())).String(),
-			Name:  rc.Name(),
-			Type:  rc.stringShort("type"),
-			Hex:   rc.stringShort("hex"),
-			Value: rc.float64Short("value"),
-		})
+	if presentColors, ok := r[fieldChartColors].(colors); ok {
+		c.Colors = presentColors
+	} else {
+		for _, rc := range r.slcResource(fieldChartColors) {
+			c.Colors = append(c.Colors, &color{
+				// TODO: think we can just axe the stub here
+				id:    influxdb.ID(int(time.Now().UnixNano())).String(),
+				Name:  rc.Name(),
+				Type:  rc.stringShort(fieldType),
+				Hex:   rc.stringShort(fieldColorHex),
+				Value: flt64Ptr(rc.float64Short(fieldValue)),
+			})
+		}
 	}
 
-	for _, ra := range r.slcResource("axes") {
-		c.Axes = append(c.Axes, axis{
-			Base:   ra.stringShort("base"),
-			Label:  ra.stringShort("label"),
-			Name:   ra.Name(),
-			Prefix: ra.stringShort("prefix"),
-			Scale:  ra.stringShort("scale"),
-			Suffix: ra.stringShort("suffix"),
-		})
+	if presAxes, ok := r[fieldChartAxes].(axes); ok {
+		c.Axes = presAxes
+	} else {
+		for _, ra := range r.slcResource(fieldChartAxes) {
+			c.Axes = append(c.Axes, axis{
+				Base:   ra.stringShort(fieldAxisBase),
+				Label:  ra.stringShort(fieldAxisLabel),
+				Name:   ra.Name(),
+				Prefix: ra.stringShort(fieldPrefix),
+				Scale:  ra.stringShort(fieldAxisScale),
+				Suffix: ra.stringShort(fieldSuffix),
+			})
+		}
 	}
 
 	if fails := c.validProperties(); len(fails) > 0 {
@@ -724,25 +741,23 @@ func parseChart(r Resource) (chart, []failure) {
 // available kinds that are supported.
 type Resource map[string]interface{}
 
+// Name returns the name of the resource.
 func (r Resource) Name() string {
-	return strings.TrimSpace(r.stringShort("name"))
+	return strings.TrimSpace(r.stringShort(fieldName))
 }
 
-func (r Resource) kind() (kind, error) {
-	resKind, ok := r.string("kind")
+func (r Resource) kind() (Kind, error) {
+	resKind, ok := r.string(fieldKind)
 	if !ok {
-		return kindUnknown, errors.New("no kind provided")
+		return KindUnknown, errors.New("no kind provided")
 	}
 
-	newKind := kind(strings.TrimSpace(strings.ToLower(resKind)))
-	if newKind == kindUnknown {
-		return kindUnknown, errors.New("invalid kind")
-	}
-	if !kinds[newKind] {
-		return newKind, errors.New("unsupported kind provided")
+	k := newKind(resKind)
+	if err := k.OK(); err != nil {
+		return k, err
 	}
 
-	return newKind, nil
+	return k, nil
 }
 
 func (r Resource) chartKind() (chartKind, error) {
@@ -752,29 +767,6 @@ func (r Resource) chartKind() (chartKind, error) {
 		return chartKindUnknown, errors.New("invalid chart kind provided: " + string(chartKind))
 	}
 	return chartKind, nil
-}
-
-func (r Resource) nestedAssociations() []Resource {
-	v, ok := r["associations"]
-	if !ok {
-		return nil
-	}
-
-	ifaces, ok := v.([]interface{})
-	if !ok {
-		return nil
-	}
-
-	var resources []Resource
-	for _, iface := range ifaces {
-		newRes, ok := ifaceToResource(iface)
-		if !ok {
-			continue
-		}
-		resources = append(resources, newRes)
-	}
-
-	return resources
 }
 
 func (r Resource) bool(key string) (bool, bool) {
@@ -843,6 +835,10 @@ func (r Resource) slcResource(key string) []Resource {
 		return nil
 	}
 
+	if resources, ok := v.([]Resource); ok {
+		return resources
+	}
+
 	iFaceSlc, ok := v.([]interface{})
 	if !ok {
 		return nil
@@ -866,6 +862,10 @@ func (r Resource) slcStr(key string) []string {
 		return nil
 	}
 
+	if strSlc, ok := v.([]string); ok {
+		return strSlc
+	}
+
 	iFaceSlc, ok := v.([]interface{})
 	if !ok {
 		return nil
@@ -884,7 +884,16 @@ func (r Resource) slcStr(key string) []string {
 }
 
 func (r Resource) mapStrStr(key string) map[string]string {
-	res, ok := ifaceToResource(r[key])
+	v, ok := r[key]
+	if !ok {
+		return nil
+	}
+
+	if m, ok := v.(map[string]string); ok {
+		return m
+	}
+
+	res, ok := ifaceToResource(v)
 	if !ok {
 		return nil
 	}
@@ -905,8 +914,7 @@ func ifaceToResource(i interface{}) (Resource, bool) {
 		return nil, false
 	}
 
-	res, ok := i.(Resource)
-	if ok {
+	if res, ok := i.(Resource); ok {
 		return res, true
 	}
 

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -74,7 +74,7 @@ spec:
       name: buck_1
       retention_period: 1h
 `,
-					valFields: []string{"pkgName"},
+					valFields: []string{"meta.pkgName"},
 				},
 				{
 					name: "missing pkgVersion",
@@ -88,7 +88,7 @@ spec:
       name: buck_1
       retention_period: 1h
 `,
-					valFields: []string{"pkgVersion"},
+					valFields: []string{"meta.pkgVersion"},
 				},
 				{
 					name: "missing multiple",
@@ -98,12 +98,12 @@ spec:
       name: buck_1
       retention_period: 1h
 `,
-					valFields: []string{"apiVersion", "kind", "pkgVersion", "pkgName"},
+					valFields: []string{"apiVersion", "kind", "meta.pkgVersion", "meta.pkgName"},
 				},
 			}
 
 			for _, tt := range tests {
-				testPkgErrors(t, kindPackage, tt)
+				testPkgErrors(t, KindPackage, tt)
 			}
 		})
 	})
@@ -203,7 +203,7 @@ spec:
 			}
 
 			for _, tt := range tests {
-				testPkgErrors(t, kindBucket, tt)
+				testPkgErrors(t, KindBucket, tt)
 			}
 		})
 	})
@@ -281,7 +281,7 @@ spec:
 			}
 
 			for _, tt := range tests {
-				testPkgErrors(t, kindLabel, tt)
+				testPkgErrors(t, KindLabel, tt)
 			}
 		})
 	})
@@ -435,7 +435,7 @@ spec:
 			}
 
 			for _, tt := range tests {
-				testPkgErrors(t, kindBucket, tt)
+				testPkgErrors(t, KindBucket, tt)
 			}
 		})
 	})
@@ -512,33 +512,6 @@ spec:
           colors:
             - name: laser
               type: text
-`,
-					},
-					{
-						name:           "no colors provided",
-						validationErrs: 2,
-						valFields:      []string{"charts[0].colors", "charts[0].colors"},
-						pkgStr: `apiVersion: 0.1.0
-kind: Package
-meta:
-  pkgName:      pkg_name
-  pkgVersion:   1
-  description:  pack description
-spec:
-  resources:
-    - kind: Dashboard
-      name: dash_1
-      description: desc1
-      charts:
-        - kind:   Single_Stat
-          name:   single stat
-          suffix: days
-          width:  6
-          height: 3
-          shade: true
-          queries:
-            - query: >
-                from(bucket: v.bucket) |> range(start: v.timeRangeStart) |> filter(fn: (r) => r._measurement == "system") |> filter(fn: (r) => r._field == "uptime") |> last() |> map(fn: (r) => ({r with _value: r._value / 86400})) |> yield(name: "last")
 `,
 					},
 					{
@@ -662,7 +635,7 @@ spec:
 				}
 
 				for _, tt := range tests {
-					testPkgErrors(t, kindDashboard, tt)
+					testPkgErrors(t, KindDashboard, tt)
 				}
 			})
 		})
@@ -757,40 +730,6 @@ spec:
             - name: android
               type: scale
               hex: "#F4CF31"
-          axes:
-            - name : "x"
-              label: x_label
-              base: 10
-              scale: linear
-            - name: "y"
-              label: y_label
-              base: 10
-              scale: linear
-`,
-					},
-					{
-						name:           "no colors provided",
-						validationErrs: 3,
-						valFields:      []string{"charts[0].colors", "charts[0].colors", "charts[0].colors"},
-						pkgStr: `apiVersion: 0.1.0
-kind: Package
-meta:
-  pkgName:      pkg_name
-  pkgVersion:   1
-  description:  pack description
-spec:
-  resources:
-    - kind: Dashboard
-      name: dash_1
-      description: desc1
-      charts:
-        - kind:   Single_Stat_Plus_Line
-          name:   single stat plus line
-          width:  6
-          height: 3
-          queries:
-            - query: >
-                from(bucket: v.bucket) |> range(start: v.timeRangeStart) |> filter(fn: (r) => r._measurement == "system") |> filter(fn: (r) => r._field == "uptime") |> last() |> map(fn: (r) => ({r with _value: r._value / 86400})) |> yield(name: "last")
           axes:
             - name : "x"
               label: x_label
@@ -1068,7 +1007,7 @@ spec:
 				}
 
 				for _, tt := range tests {
-					testPkgErrors(t, kindDashboard, tt)
+					testPkgErrors(t, KindDashboard, tt)
 				}
 			})
 		})
@@ -1268,7 +1207,7 @@ spec:
 				}
 
 				for _, tt := range tests {
-					testPkgErrors(t, kindDashboard, tt)
+					testPkgErrors(t, KindDashboard, tt)
 				}
 			})
 		})
@@ -1512,7 +1451,7 @@ spec:
 				}
 
 				for _, tt := range tests {
-					testPkgErrors(t, kindDashboard, tt)
+					testPkgErrors(t, KindDashboard, tt)
 				}
 			})
 		})
@@ -1634,7 +1573,7 @@ spec:
 			}
 
 			for _, tt := range tests {
-				testPkgErrors(t, kindDashboard, tt)
+				testPkgErrors(t, KindDashboard, tt)
 			}
 		})
 	})
@@ -1829,7 +1768,7 @@ spec:
 			}
 
 			for _, tt := range tests {
-				testPkgErrors(t, kindVariable, tt)
+				testPkgErrors(t, KindVariable, tt)
 			}
 		})
 	})
@@ -1889,7 +1828,7 @@ type testPkgResourceError struct {
 
 // defaults to yaml encoding if encoding not provided
 // defaults num resources to 1 if resource errs not provided.
-func testPkgErrors(t *testing.T, k kind, tt testPkgResourceError) {
+func testPkgErrors(t *testing.T, k Kind, tt testPkgResourceError) {
 	t.Helper()
 	encoding := EncodingYAML
 	if tt.encoding != EncodingUnknown {

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 	"strings"
 	"time"
@@ -99,36 +100,117 @@ func NewService(opts ...ServiceSetterFn) *Service {
 }
 
 // CreatePkgSetFn is a functional input for setting the pkg fields.
-type CreatePkgSetFn func(ctx context.Context, pkg *Pkg) error
+type CreatePkgSetFn func(opt *createOpt) error
+
+type createOpt struct {
+	metadata  Metadata
+	resources []ResourceToClone
+}
 
 // WithMetadata sets the metadata on the pkg in a CreatePkg call.
 func WithMetadata(meta Metadata) CreatePkgSetFn {
-	return func(ctx context.Context, pkg *Pkg) error {
-		pkg.Metadata = meta
+	return func(opt *createOpt) error {
+		opt.metadata = meta
+		return nil
+	}
+}
+
+// WithResourceClones allows the create method to clone existing resources.
+func WithResourceClones(resources ...ResourceToClone) CreatePkgSetFn {
+	return func(opt *createOpt) error {
+		for _, r := range resources {
+			if err := r.OK(); err != nil {
+				return err
+			}
+		}
+		opt.resources = append(opt.resources, resources...)
 		return nil
 	}
 }
 
 // CreatePkg will produce a pkg from the parameters provided.
 func (s *Service) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pkg, error) {
-	pkg := &Pkg{
-		APIVersion: APIVersion,
-		Kind:       kindPackage.String(),
-		Spec: struct {
-			Resources []Resource `yaml:"resources" json:"resources"`
-		}{
-			Resources: []Resource{},
-		},
-	}
-
+	opt := new(createOpt)
 	for _, setter := range setters {
-		err := setter(ctx, pkg)
-		if err != nil {
+		if err := setter(opt); err != nil {
 			return nil, err
 		}
 	}
 
+	pkg := &Pkg{
+		APIVersion: APIVersion,
+		Kind:       KindPackage.String(),
+		Metadata:   opt.metadata,
+		Spec: struct {
+			Resources []Resource `yaml:"resources" json:"resources"`
+		}{
+			Resources: make([]Resource, 0, len(opt.resources)),
+		},
+	}
+	if pkg.Metadata.Name == "" {
+		// sudo randomness, this is not an attempt at making charts unique
+		// that is a problem for the consumer.
+		pkg.Metadata.Name = fmt.Sprintf("new_%7d", rand.Int())
+	}
+	if pkg.Metadata.Version == "" {
+		pkg.Metadata.Version = "v1"
+	}
+
+	for _, r := range opt.resources {
+		newResource, err := s.resourceCloneToResource(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		pkg.Spec.Resources = append(pkg.Spec.Resources, newResource)
+	}
+
+	if err := pkg.Validate(); err != nil {
+		return nil, err
+	}
+
 	return pkg, nil
+}
+
+func (s *Service) resourceCloneToResource(ctx context.Context, r ResourceToClone) (Resource, error) {
+	switch {
+	case r.Kind.is(KindBucket):
+		bkt, err := s.bucketSVC.FindBucketByID(ctx, r.ID)
+		if err != nil {
+			return nil, err
+		}
+		return bucketToResource(*bkt, r.Name), nil
+	case r.Kind.is(KindDashboard):
+		dash, err := s.dashSVC.FindDashboardByID(ctx, r.ID)
+		if err != nil {
+			return nil, err
+		}
+		var cellViews []cellView
+		for _, cell := range dash.Cells {
+			v, err := s.dashSVC.GetDashboardCellView(ctx, r.ID, cell.ID)
+			if err != nil {
+				return nil, err
+			}
+			cellViews = append(cellViews, cellView{
+				c: *cell,
+				v: *v,
+			})
+		}
+		return dashboardToResource(*dash, cellViews, r.Name), nil
+	case r.Kind.is(KindLabel):
+		l, err := s.labelSVC.FindLabelByID(ctx, r.ID)
+		if err != nil {
+			return nil, err
+		}
+		return labelToResource(*l, r.Name), nil
+	case r.Kind.is(KindVariable):
+		v, err := s.varSVC.FindVariableByID(ctx, r.ID)
+		if err != nil {
+			return nil, err
+		}
+		return variableToResource(*v, r.Name), nil
+	default:
+		return nil, errors.New("unsupported kind provided: " + string(r.Kind))
+	}
 }
 
 // DryRun provides a dry run of the pkg application. The pkg will be marked verified
@@ -657,6 +739,8 @@ func convertChartsToCells(ch []chart) ([]*influxdb.Cell, map[*influxdb.Cell]int)
 	for i, c := range ch {
 		icell := &influxdb.Cell{
 			CellProperty: influxdb.CellProperty{
+				X: int32(c.XPos),
+				Y: int32(c.YPos),
 				H: int32(c.Height),
 				W: int32(c.Width),
 			},


### PR DESCRIPTION
This is the start of exporting existing resources in the form of a package. 

no associations included at this time. It will only include the resources that are described in the API call. The next body of work will add all associations with labels to every entity that is mapped.

note about this work. I ended up coupling the dec/enc fields via constants. I am using some types directly as json/yaml for the encoding, but most are using the Resource type. This buys us more extensible encoding/decoding support. We can add jsonnet/toml/yada yada with a small LoC change. Adding specific Decode/Encode to each type could make this work with less LoCs, but there are quite a few gotchas in those. Not to mention you'll have to create new methods for a new enc/dec if they don't' follow the std lib's dec/enc approach. That'd be rough as well.  I'm not crazy about the Resource use, but I also don't hate it, and I like that adding JSON support is only 3 lines of code as opposed to dupliating Enc/Dec methods everywhere. Those custom types are necessary because of how polymorphic this design is.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
