### PR TITLE
feat(pkger): add support for exporting resource associations

### DIFF
--- a/http/pkger_http_server.go
+++ b/http/pkger_http_server.go
@@ -72,12 +72,12 @@ func (s *HandlerPkg) createPkg(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	newPkg, err := s.svc.CreatePkg(r.Context(),
-		pkger.WithMetadata(pkger.Metadata{
+		pkger.CreateWithMetadata(pkger.Metadata{
 			Description: reqBody.PkgDescription,
 			Name:        reqBody.PkgName,
 			Version:     reqBody.PkgVersion,
 		}),
-		pkger.WithResourceClones(reqBody.Resources...),
+		pkger.CreateWithExistingResources(reqBody.Resources...),
 	)
 	if err != nil {
 		s.HandleHTTPError(r.Context(), err, w)

--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -30,7 +30,7 @@ func bucketToResource(bkt influxdb.Bucket, name string) Resource {
 		name = bkt.Name
 	}
 	return Resource{
-		fieldKind:                  KindBucket.String(),
+		fieldKind:                  KindBucket.title(),
 		fieldName:                  name,
 		fieldDescription:           bkt.Description,
 		fieldBucketRetentionPeriod: bkt.RetentionPeriod.String(),
@@ -103,7 +103,7 @@ func convertCellView(cv cellView) chart {
 
 func convertChartToResource(ch chart) Resource {
 	r := Resource{
-		fieldKind:         string(ch.Kind),
+		fieldKind:         ch.Kind.title(),
 		fieldName:         ch.Name,
 		fieldChartQueries: ch.Queries,
 		fieldChartHeight:  ch.Height,
@@ -222,7 +222,7 @@ func dashboardToResource(dash influxdb.Dashboard, cellViews []cellView, name str
 	}
 
 	return Resource{
-		fieldKind:        KindDashboard.String(),
+		fieldKind:        KindDashboard.title(),
 		fieldName:        name,
 		fieldDescription: dash.Description,
 		fieldDashCharts:  charts,
@@ -234,7 +234,7 @@ func labelToResource(l influxdb.Label, name string) Resource {
 		name = l.Name
 	}
 	return Resource{
-		fieldKind:        KindLabel.String(),
+		fieldKind:        KindLabel.title(),
 		fieldName:        name,
 		fieldLabelColor:  l.Properties["color"],
 		fieldDescription: l.Properties["description"],
@@ -247,7 +247,7 @@ func variableToResource(v influxdb.Variable, name string) Resource {
 	}
 
 	r := Resource{
-		fieldKind:        KindVariable.String(),
+		fieldKind:        KindVariable.title(),
 		fieldName:        name,
 		fieldDescription: v.Description,
 	}

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -57,6 +57,10 @@ func (k Kind) OK() error {
 	return nil
 }
 
+func (k Kind) title() string {
+	return strings.Title(k.String())
+}
+
 func (k Kind) is(comp Kind) bool {
 	normed := Kind(strings.TrimSpace(strings.ToLower(string(k))))
 	return normed == comp
@@ -266,6 +270,11 @@ func (c chartKind) ok() bool {
 	default:
 		return false
 	}
+}
+
+func (c chartKind) title() string {
+	spacedKind := strings.ReplaceAll(string(c), "_", " ")
+	return strings.ReplaceAll(strings.Title(spacedKind), " ", "_")
 }
 
 // SummaryChart provides a summary of a pkg dashboard's chart.

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -107,21 +107,22 @@ type createOpt struct {
 	resources []ResourceToClone
 }
 
-// WithMetadata sets the metadata on the pkg in a CreatePkg call.
-func WithMetadata(meta Metadata) CreatePkgSetFn {
+// CreateWithMetadata sets the metadata on the pkg in a CreatePkg call.
+func CreateWithMetadata(meta Metadata) CreatePkgSetFn {
 	return func(opt *createOpt) error {
 		opt.metadata = meta
 		return nil
 	}
 }
 
-// WithResourceClones allows the create method to clone existing resources.
-func WithResourceClones(resources ...ResourceToClone) CreatePkgSetFn {
+// CreateWithExistingResources allows the create method to clone existing resources.
+func CreateWithExistingResources(resources ...ResourceToClone) CreatePkgSetFn {
 	return func(opt *createOpt) error {
 		for _, r := range resources {
 			if err := r.OK(); err != nil {
 				return err
 			}
+			r.Kind = newKind(string(r.Kind))
 		}
 		opt.resources = append(opt.resources, resources...)
 		return nil
@@ -156,29 +157,49 @@ func (s *Service) CreatePkg(ctx context.Context, setters ...CreatePkgSetFn) (*Pk
 		pkg.Metadata.Version = "v1"
 	}
 
+	cloneAssFn := s.resourceCloneAssociationsGen()
 	for _, r := range opt.resources {
-		newResource, err := s.resourceCloneToResource(ctx, r)
+		newResources, err := s.resourceCloneToResource(ctx, r, cloneAssFn)
 		if err != nil {
 			return nil, err
 		}
-		pkg.Spec.Resources = append(pkg.Spec.Resources, newResource)
+		pkg.Spec.Resources = append(pkg.Spec.Resources, newResources...)
 	}
 
-	if err := pkg.Validate(); err != nil {
+	if err := pkg.Validate(ValidWithoutResources()); err != nil {
 		return nil, err
 	}
+
+	var kindPriorities = map[Kind]int{
+		KindLabel:     1,
+		KindBucket:    2,
+		KindVariable:  3,
+		KindDashboard: 4,
+	}
+
+	sort.Slice(pkg.Spec.Resources, func(i, j int) bool {
+		iName, jName := pkg.Spec.Resources[i].Name(), pkg.Spec.Resources[j].Name()
+		iKind, _ := pkg.Spec.Resources[i].kind()
+		jKind, _ := pkg.Spec.Resources[j].kind()
+
+		if iKind.is(jKind) {
+			return iName < jName
+		}
+		return kindPriorities[iKind] < kindPriorities[jKind]
+	})
 
 	return pkg, nil
 }
 
-func (s *Service) resourceCloneToResource(ctx context.Context, r ResourceToClone) (Resource, error) {
+func (s *Service) resourceCloneToResource(ctx context.Context, r ResourceToClone, cFn cloneAssociationsFn) ([]Resource, error) {
+	var newResource Resource
 	switch {
 	case r.Kind.is(KindBucket):
 		bkt, err := s.bucketSVC.FindBucketByID(ctx, r.ID)
 		if err != nil {
 			return nil, err
 		}
-		return bucketToResource(*bkt, r.Name), nil
+		newResource = bucketToResource(*bkt, r.Name)
 	case r.Kind.is(KindDashboard):
 		dash, err := s.dashSVC.FindDashboardByID(ctx, r.ID)
 		if err != nil {
@@ -190,26 +211,87 @@ func (s *Service) resourceCloneToResource(ctx context.Context, r ResourceToClone
 			if err != nil {
 				return nil, err
 			}
-			cellViews = append(cellViews, cellView{
-				c: *cell,
-				v: *v,
-			})
+			cellViews = append(cellViews, cellView{c: *cell, v: *v})
 		}
-		return dashboardToResource(*dash, cellViews, r.Name), nil
+		newResource = dashboardToResource(*dash, cellViews, r.Name)
 	case r.Kind.is(KindLabel):
 		l, err := s.labelSVC.FindLabelByID(ctx, r.ID)
 		if err != nil {
 			return nil, err
 		}
-		return labelToResource(*l, r.Name), nil
+		newResource = labelToResource(*l, r.Name)
 	case r.Kind.is(KindVariable):
 		v, err := s.varSVC.FindVariableByID(ctx, r.ID)
 		if err != nil {
 			return nil, err
 		}
-		return variableToResource(*v, r.Name), nil
+		newResource = variableToResource(*v, r.Name)
 	default:
 		return nil, errors.New("unsupported kind provided: " + string(r.Kind))
+	}
+
+	ass, err := cFn(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	if len(ass.associations) > 0 {
+		newResource[fieldAssociations] = ass.associations
+	}
+
+	return append([]Resource{newResource}, ass.newLableResources...), nil
+}
+
+type (
+	associations struct {
+		associations      []Resource
+		newLableResources []Resource
+	}
+
+	cloneAssociationsFn func(context.Context, ResourceToClone) (associations, error)
+)
+
+func (s *Service) resourceCloneAssociationsGen() cloneAssociationsFn {
+	type key struct {
+		id   influxdb.ID
+		name string
+	}
+	// memoize the labels so we dont' create duplicates
+	m := make(map[key]bool)
+	return func(ctx context.Context, r ResourceToClone) (associations, error) {
+		var iResType influxdb.ResourceType
+		switch {
+		case r.Kind.is(KindBucket):
+			iResType = influxdb.BucketsResourceType
+		case r.Kind.is(KindDashboard):
+			iResType = influxdb.DashboardsResourceType
+		case r.Kind.is(KindVariable):
+			iResType = influxdb.VariablesResourceType
+		default:
+			return associations{}, nil
+		}
+
+		labels, err := s.labelSVC.FindResourceLabels(ctx, influxdb.LabelMappingFilter{
+			ResourceID:   r.ID,
+			ResourceType: iResType,
+		})
+		if err != nil {
+			return associations{}, err
+		}
+
+		var ass associations
+		for _, l := range labels {
+			ass.associations = append(ass.associations, Resource{
+				fieldKind: KindLabel.String(),
+				fieldName: l.Name,
+			})
+			k := key{id: l.ID, name: l.Name}
+			if m[k] {
+				continue
+			}
+			m[k] = true
+			ass.newLableResources = append(ass.newLableResources, labelToResource(*l, ""))
+		}
+		return ass, nil
 	}
 }
 
@@ -393,7 +475,9 @@ func (s *Service) dryRunLabelMappings(ctx context.Context, pkg *Pkg) ([]DiffLabe
 	var diffs []DiffLabelMapping
 	for _, b := range pkg.buckets() {
 		err := s.dryRunResourceLabelMapping(ctx, b, b.labels, func(labelID influxdb.ID, labelName string, isNew bool) {
-			pkg.mLabels[labelName].setBucketMapping(b, !isNew)
+			if l, ok := pkg.mLabels[labelName]; ok {
+				l.setBucketMapping(b, !isNew)
+			}
 			diffs = append(diffs, DiffLabelMapping{
 				IsNew:     isNew,
 				ResType:   b.ResourceType(),


### PR DESCRIPTION
this PR adds associations for resources that are being exported and adds those to the new package that is created. 

Closes #15764 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
