### PR TITLE
fix(ui): Show empty dashboards state

### DIFF
--- a/ui/cypress/e2e/dashboardsIndex.test.ts
+++ b/ui/cypress/e2e/dashboardsIndex.test.ts
@@ -19,6 +19,23 @@ describe('Dashboards', () => {
     })
   })
 
+  it('empty state should have a header with text and a button to create a dashboard', () => {
+    cy.getByTestID('page-contents').within(() => {
+      cy.getByTestID('empty-dashboards-list').within(() => {
+        cy.getByTestID('empty-state--text').should($t => {
+          expect($t).to.have.length(1)
+          expect($t).to.contain(
+            "Looks like you don't have any Dashboards, why not create one?"
+          )
+        })
+        cy.getByTestID('add-resource-dropdown--button').should($b => {
+          expect($b).to.have.length(1)
+          expect($b).to.contain('Create Dashboard')
+        })
+      })
+    })
+  })
+
   it('can create a dashboard from empty state', () => {
     cy.getByTestID('empty-dashboards-list').within(() => {
       cy.getByTestID('add-resource-dropdown--button').click()

--- a/ui/src/dashboards/components/dashboard_index/Table.tsx
+++ b/ui/src/dashboards/components/dashboard_index/Table.tsx
@@ -72,9 +72,9 @@ class DashboardsTable extends PureComponent<Props, State> {
         </ResourceList.Header>
         <ResourceList.Body
           emptyState={this.emptyState}
-          className="dashboards-card-grid"
+          className={dashboards.length ? 'dashboards-card-grid' : ''}
         >
-          {!!dashboards.length && (
+          {dashboards.length ? (
             <DashboardCards
               dashboards={dashboards}
               sortKey={sortKey}
@@ -85,7 +85,7 @@ class DashboardsTable extends PureComponent<Props, State> {
               onUpdateDashboard={onUpdateDashboard}
               onFilterChange={onFilterChange}
             />
-          )}
+          ) : null}
         </ResourceList.Body>
       </ResourceList>
     )
@@ -129,7 +129,7 @@ class DashboardsTable extends PureComponent<Props, State> {
     return (
       <EmptyState size={ComponentSize.Large} testID="empty-dashboards-list">
         <EmptyState.Text>
-          Looks like you don’t have any <b>Dashboards</b>, why not create one?
+          Looks like you don't have any <b>Dashboards</b>, why not create one?
         </EmptyState.Text>
         <AddResourceDropdown
           onSelectNew={onCreateDashboard}


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15656

When dashboards length is 0, props.children evaluates to null rather than false, so that clockface will render the default state.

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/10736577/68701400-8b824080-053b-11ea-85b4-a1a0e3e110df.png">

