### PR TITLE
fix(ui): Allow easier manipulation of custom bin sizes in Histograms

### DIFF
--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -34,6 +34,57 @@ describe('DataExplorer', () => {
     })
   })
 
+  describe('numeric input using custom bin sizes in Histograms', () => {
+    beforeEach(() => {
+      cy.getByTestID('page-header--right').within(() => {
+        cy.getByTestID('dropdown')
+          .click()
+          .then(() => {
+            cy.get('#histogram')
+              .click()
+              .then(() => {
+                cy.getByTestID('cog-cell--button').click()
+              })
+          })
+      })
+    })
+    it('should keep the user on the Custom field and in error status after all input has been deleted even if non-numeric input is typed', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('auto-input').within(() => {
+          cy.getByTestID('input-field')
+            .click()
+            .type('{backspace}{backspace}')
+            .then(() => {
+              cy.getByTestID('auto-input--custom').should(
+                'have.class',
+                'active'
+              )
+              cy.getByTestID('input-field--error').should('have.length', 1)
+            })
+            .then(() => {
+              cy.getByTestID('input-field')
+                .type('adfuiopbvmc')
+                .then(() => {
+                  cy.getByTestID('input-field--error').should('have.length', 1)
+                })
+            })
+        })
+      })
+    })
+    it('should not have the input field in error status when input becomes valid', () => {
+      cy.get('.view-options').within(() => {
+        cy.getByTestID('auto-input').within(() => {
+          cy.getByTestID('input-field')
+            .click()
+            .type('{backspace}{backspace}3')
+            .then(() => {
+              cy.getByTestID('input-field--error').should('have.length', 0)
+            })
+        })
+      })
+    })
+  })
+
   describe('numeric input validation when changing bin sizes in Heat Maps', () => {
     beforeEach(() => {
       cy.getByTestID('page-header--right').within(() => {

--- a/ui/src/timeMachine/components/view_options/BinCountInput.tsx
+++ b/ui/src/timeMachine/components/view_options/BinCountInput.tsx
@@ -4,6 +4,9 @@ import React, {FunctionComponent, ChangeEvent} from 'react'
 // Components
 import {AutoInput, AutoInputMode, Input, InputType} from '@influxdata/clockface'
 
+// Utils
+import {convertUserInputToNumOrNaN} from 'src/shared/utils/convertUserInput'
+
 // Actions
 import {setBinCount} from 'src/timeMachine/actions'
 
@@ -14,7 +17,7 @@ interface Props {
 
 const BinCountInput: FunctionComponent<Props> = ({binCount, onSetBinCount}) => {
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    const binCount = Number(e.target.value) || null
+    const binCount = convertUserInputToNumOrNaN(e)
 
     onSetBinCount(binCount)
   }
@@ -29,7 +32,9 @@ const BinCountInput: FunctionComponent<Props> = ({binCount, onSetBinCount}) => {
 
   return (
     <AutoInput
-      mode={binCount ? AutoInputMode.Custom : AutoInputMode.Auto}
+      mode={
+        typeof binCount === 'number' ? AutoInputMode.Custom : AutoInputMode.Auto
+      }
       onChangeMode={handleChangeMode}
       inputComponent={
         <Input


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15841

In Histograms, let the user delete all input in Custom bin sizes to input new numbers, and make Auto bin size mode less aggressive.
