### PR TITLE
feat(verify-seriesfile): add ability to verify by org/bucket

### DIFF
--- a/cmd/influxd/inspect/verify_series.go
+++ b/cmd/influxd/inspect/verify_series.go
@@ -1,6 +1,7 @@
 package inspect
 
 import (
+	"encoding/hex"
 	"os"
 	"runtime"
 
@@ -33,16 +34,17 @@ func NewVerifySeriesFileCommand() *cobra.Command {
 	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags._recover, "recover", "r", true, "recover panics")
 	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags.continueError, "continue-on-error", "", false, "continue on error")
 	verifySeriesCommand.Flags().IntVarP(&VerifySeriesFlags.concurrent, "c", "c", runtime.GOMAXPROCS(0), "How many concurrent workers to run.")
-
+	verifySeriesCommand.Flags().StringVar(&VerifySeriesFlags.measurementPrefixHex, "measurement-prefix", "", "filter measurements by provided base-16 prefix")
 	return verifySeriesCommand
 }
 
 var VerifySeriesFlags = struct {
-	seriesFile    string
-	verbose       bool
-	continueError bool
-	_recover      bool
-	concurrent    int
+	seriesFile           string
+	verbose              bool
+	continueError        bool
+	_recover             bool
+	concurrent           int
+	measurementPrefixHex string
 }{}
 
 // verifySeriesRun executes the command.
@@ -64,6 +66,13 @@ func verifySeriesRun(cmd *cobra.Command, args []string) error {
 	v.ContinueOnError = VerifySeriesFlags.continueError
 	v.SeriesFilePath = VerifySeriesFlags.seriesFile
 
+	if VerifySeriesFlags.measurementPrefixHex != "" {
+		namePrefix, err := hex.DecodeString(VerifySeriesFlags.measurementPrefixHex)
+		if err != nil {
+			return err
+		}
+		v.MeasurementPrefix = namePrefix
+	}
 	_, err = v.VerifySeriesFile()
 	return err
 }

--- a/cmd/influxd/inspect/verify_series.go
+++ b/cmd/influxd/inspect/verify_series.go
@@ -28,20 +28,21 @@ func NewVerifySeriesFileCommand() *cobra.Command {
 		RunE: verifySeriesRun,
 	}
 
-	verifySeriesCommand.Flags().StringVar(&VerifySeriesFlags.seriesFile, "series-file", os.Getenv("HOME")+"/.influxdbv2/engine/_series",
-		"Path to a series file. This defaults to "+os.Getenv("HOME")+"/.influxdbv2/engine/_series")
-	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags.verbose, "v", "v", false,
-		"Verbose output.")
-	verifySeriesCommand.Flags().IntVarP(&VerifySeriesFlags.concurrent, "c", "c", runtime.GOMAXPROCS(0),
-		"How many concurrent workers to run.")
+	verifySeriesCommand.Flags().StringVar(&VerifySeriesFlags.seriesFile, "series-file", os.Getenv("HOME")+"/.influxdbv2/engine/_series", "Path to a series file. This defaults to "+os.Getenv("HOME")+"/.influxdbv2/engine/_series")
+	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags.verbose, "v", "v", false, "Verbose output.")
+	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags._recover, "recover", "r", true, "recover panics")
+	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags.continueError, "continue-on-error", "", false, "continue on error")
+	verifySeriesCommand.Flags().IntVarP(&VerifySeriesFlags.concurrent, "c", "c", runtime.GOMAXPROCS(0), "How many concurrent workers to run.")
 
 	return verifySeriesCommand
 }
 
 var VerifySeriesFlags = struct {
-	seriesFile string
-	verbose    bool
-	concurrent int
+	seriesFile    string
+	verbose       bool
+	continueError bool
+	_recover      bool
+	concurrent    int
 }{}
 
 // verifySeriesRun executes the command.
@@ -58,12 +59,11 @@ func verifySeriesRun(cmd *cobra.Command, args []string) error {
 
 	v := tsdb.NewVerify()
 	v.Logger = logger
+	v.Recover = VerifySeriesFlags._recover
 	v.Concurrent = VerifySeriesFlags.concurrent
+	v.ContinueOnError = VerifySeriesFlags.continueError
+	v.SeriesFilePath = VerifySeriesFlags.seriesFile
 
-	if VerifySeriesFlags.seriesFile != "" {
-		_, err := v.VerifySeriesFile(VerifySeriesFlags.seriesFile)
-		return err
-	}
-
-	return nil
+	_, err = v.VerifySeriesFile()
+	return err
 }

--- a/cmd/influxd/inspect/verify_series.go
+++ b/cmd/influxd/inspect/verify_series.go
@@ -17,23 +17,35 @@ func NewVerifySeriesFileCommand() *cobra.Command {
 	verifySeriesCommand := &cobra.Command{
 		Use:   "verify-seriesfile",
 		Short: "Verifies the integrity of Series files",
-		Long: `Verifies the integrity of Series files.
-		Usage: influx_inspect verify-seriesfile [flags]
-			--series-file <path>
-					Path to a series file. This defaults to ` + os.Getenv("HOME") + `/.influxdbv2/engine/_series.
-			--v
-					Enable verbose logging.
-			--c
-					How many concurrent workers to run.
-					Defaults to "` + string(runtime.GOMAXPROCS(0)) + `" on this machine.`,
+		Long: `This command verifies the integrity and correctness of the Series
+File segments and index.
+
+It is possible to verify only data belonging to a single bucket or org using the 
+--measurement-prefix flag.
+
+Example for a single bucket: --measurement-prefix="0231f2dbca673232000000000000000a"
+
+Example for all buckets in an org: --measurement-prefix="0231f2dbca673232"
+
+Partitions are verified concurrently (unless -c = 1). The tool proceeds as follows:
+
+  - Each segment in the partition is initialised in order.
+  - All entries within the segment are read.
+  - The series ID of each entry is checked to ensure it is monotonically increasing.
+  - Upon reading an insertion entry the tool verifies there was not a previous deletion of the ID.
+  - Each series key is parsed within an insertion entry.
+  - Upon reading a deletion entry the tool verifies it was previously inserted.
+  - The tool checks for invalid entries.
+  - Once all segments in a partition are verified, the index for the partition is verified.
+  - For each entry from the segment the tool verifies it exists correctly in the index.`,
 		RunE: verifySeriesRun,
 	}
 
 	verifySeriesCommand.Flags().StringVar(&VerifySeriesFlags.seriesFile, "series-file", os.Getenv("HOME")+"/.influxdbv2/engine/_series", "Path to a series file. This defaults to "+os.Getenv("HOME")+"/.influxdbv2/engine/_series")
-	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags.verbose, "v", "v", false, "Verbose output.")
-	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags._recover, "recover", "r", true, "recover panics")
-	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags.continueError, "continue-on-error", "", false, "continue on error")
-	verifySeriesCommand.Flags().IntVarP(&VerifySeriesFlags.concurrent, "c", "c", runtime.GOMAXPROCS(0), "How many concurrent workers to run.")
+	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags.verbose, "v", "v", false, "verbose output")
+	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags._recover, "recover", "r", true, "recover from a panic")
+	verifySeriesCommand.Flags().BoolVarP(&VerifySeriesFlags.continueError, "continue-on-error", "", false, "continue verification after encountering an error")
+	verifySeriesCommand.Flags().IntVarP(&VerifySeriesFlags.concurrent, "c", "c", runtime.GOMAXPROCS(0), "number of concurrent workers to use")
 	verifySeriesCommand.Flags().StringVar(&VerifySeriesFlags.measurementPrefixHex, "measurement-prefix", "", "filter measurements by provided base-16 prefix")
 	return verifySeriesCommand
 }

--- a/tsdb/series_verify.go
+++ b/tsdb/series_verify.go
@@ -118,6 +118,7 @@ func (v Verify) VerifySeriesFile() (valid bool, err error) {
 		}
 	}()
 
+	valid = true
 	for i := 0; i < m; i++ {
 		select {
 		default:


### PR DESCRIPTION
This PR does the following:

 - Fixes a bug with the tool wherein it would not verify 2.x Series File data (it was not removing the type information from the series ids before verifying them.
 - Adds options to let the operator completely verify a series file even if an error is encountered (`--continue-on-error`).
 - Adds an option to expose a stacktrace for an encountered panic (`--recover=false`).
 - Adds the ability to run series file verification only on series data scoped to either an organisation or a bucket.