### PR TITLE
fix(ui): don't show members information in cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [15777](https://github.com/influxdata/influxdb/pull/15777): Fix long startup when running 'influx help'
 1. [15713](https://github.com/influxdata/influxdb/pull/15713): Mock missing Flux dependencies when creating tasks
 1. [15731](https://github.com/influxdata/influxdb/pull/15731): Ensure array cursor iterator stats accumulate all cursor stats
+1. [15866](https://github.com/influxdata/influxdb/pull/15866): Do not show Members section in Cloud environments
 
 ### UI Improvements
 1. [15809](https://github.com/influxdata/influxdb/pull/15809): Redesign cards and animations on getting started page

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -7,6 +7,7 @@ import {Provider} from 'react-redux'
 import {Router, Route, useRouterHistory, IndexRoute} from 'react-router'
 import {createHistory, History} from 'history'
 
+import {CLOUD} from 'src/shared/constants'
 import configureStore from 'src/store/configureStore'
 import {loadLocalStorage} from 'src/localStorage'
 
@@ -349,10 +350,20 @@ class Root extends PureComponent {
                             </Route>
                           </Route>
                           <Route path="settings">
-                            <IndexRoute component={MembersIndex} />
-                            <Route path="members" component={MembersIndex}>
-                              <Route path="new" component={AddMembersOverlay} />
-                            </Route>
+                            {CLOUD ? (
+                              <IndexRoute component={VariablesIndex} />
+                            ) : (
+                              <>
+                                <IndexRoute component={MembersIndex} />
+                                <Route path="members" component={MembersIndex}>
+                                  <Route
+                                    path="new"
+                                    component={AddMembersOverlay}
+                                  />
+                                </Route>
+                              </>
+                            )}
+
                             <Route path="templates" component={TemplatesIndex}>
                               <Route
                                 path="import"

--- a/ui/src/pageLayout/containers/Nav.tsx
+++ b/ui/src/pageLayout/containers/Nav.tsx
@@ -76,7 +76,7 @@ class SideNav extends PureComponent<Props, State> {
     const tokensLink = `${orgPrefix}/load-data/tokens`
     const clientLibrariesLink = `${orgPrefix}/load-data/client-libraries`
     // Settings
-    const settingsLink = `${orgPrefix}/settings/members`
+    const settingsLink = `${orgPrefix}/settings`
     const membersLink = `${orgPrefix}/settings/members`
     const variablesLink = `${orgPrefix}/settings/variables`
     const templatesLink = `${orgPrefix}/settings/templates`
@@ -253,15 +253,17 @@ class SideNav extends PureComponent<Props, State> {
           )}
           active={getNavItemActivation(['settings'], location.pathname)}
         >
-          <NavMenu.SubItem
-            titleLink={className => (
-              <Link to={membersLink} className={className}>
-                Members
-              </Link>
-            )}
-            active={getNavItemActivation(['members'], location.pathname)}
-            key="members"
-          />
+          <CloudExclude>
+            <NavMenu.SubItem
+              titleLink={className => (
+                <Link to={membersLink} className={className}>
+                  Members
+                </Link>
+              )}
+              active={getNavItemActivation(['members'], location.pathname)}
+              key="members"
+            />
+          </CloudExclude>
           <NavMenu.SubItem
             titleLink={className => (
               <Link to={variablesLink} className={className}>

--- a/ui/src/settings/components/SettingsNavigation.tsx
+++ b/ui/src/settings/components/SettingsNavigation.tsx
@@ -36,7 +36,7 @@ class SettingsNavigation extends PureComponent<Props> {
       {
         text: 'Members',
         id: 'members',
-        cloudExclude: false,
+        cloudExclude: true,
       },
       {
         text: 'Variables',


### PR DESCRIPTION
Closes influxdata/idpe#5244

Hide Members tabs and navigation options in Cloud environments.

#### Testing instructions
While logged in, change [this line](https://github.com/influxdata/influxdb/blob/master/ui/src/shared/constants/index.ts#L56) to `true`. It should change your environment to cloud and change the navigation.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
