### PR TITLE
fix(ui): update wording and remove name editing in checks page

### DIFF
--- a/ui/src/alerting/components/CheckAlertingButton.tsx
+++ b/ui/src/alerting/components/CheckAlertingButton.tsx
@@ -36,7 +36,7 @@ const CheckAlertingButton: FunctionComponent<Props> = ({
         active={activeTab === 'queries'}
         onClick={handleClick('queries')}
       >
-        1. Query
+        1. Define Query
       </Radio.Button>
 
       <Radio.Button
@@ -48,7 +48,7 @@ const CheckAlertingButton: FunctionComponent<Props> = ({
         active={activeTab === 'alerting'}
         onClick={handleClick('alerting')}
       >
-        2. Check
+        2. Configure Check
       </Radio.Button>
     </Radio>
   )

--- a/ui/src/alerting/components/builder/CheckMetaCard.tsx
+++ b/ui/src/alerting/components/builder/CheckMetaCard.tsx
@@ -4,7 +4,6 @@ import {connect} from 'react-redux'
 
 // Components
 import {Form, ComponentSize, ComponentColor, Grid} from '@influxdata/clockface'
-import {Input} from '@influxdata/clockface'
 import DashedButton from 'src/shared/components/dashed_button/DashedButton'
 import CheckTagRow from 'src/alerting/components/builder/CheckTagRow'
 import DurationSelector from 'src/shared/components/DurationSelector'
@@ -37,12 +36,6 @@ const CheckMetaCard: FC<Props> = ({
   onUpdateTimeMachineCheck,
   onSelectCheckEvery,
 }) => {
-  const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    onUpdateTimeMachineCheck({[e.target.name]: e.target.value})
-  }
-
   const addTagsRow = () => {
     const tags = check.tags || []
     onUpdateTimeMachineCheck({tags: [...tags, {key: '', value: ''}]})
@@ -67,16 +60,6 @@ const CheckMetaCard: FC<Props> = ({
     >
       <BuilderCard.Header title="Properties" />
       <BuilderCard.Body addPadding={true} autoHideScrollbars={true}>
-        <Form.Element label="Name">
-          <Input
-            autoFocus={true}
-            name="name"
-            onChange={handleChange}
-            placeholder="Name this check"
-            size={ComponentSize.Small}
-            value={check.name}
-          />
-        </Form.Element>
         <Grid>
           <Grid.Row>
             <Grid.Column widthSM={6}>


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15108

Changes:
1. Define Query
2. Configure Check

Name editing removed in the card (bottom left).

Looks like this:
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/10736577/68726014-0b78cc80-0575-11ea-8890-534754ec9c35.png">



