### PR TITLE
feat(pkger): exports scatter and heatmap charts

### DIFF
--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -76,6 +76,22 @@ func convertCellView(cv cellView) chart {
 	case influxdb.GaugeViewProperties:
 		setCommon(chartKindGauge, p.ViewColors, p.DecimalPlaces, p.Queries)
 		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, p.Prefix, p.Suffix)
+	case influxdb.HeatmapViewProperties:
+		ch.Kind = chartKindHeatMap
+		ch.Queries = convertQueries(p.Queries)
+		ch.Colors = stringsToColors(p.ViewColors)
+		ch.XCol = p.XColumn
+		ch.YCol = p.YColumn
+		ch.Axes = []axis{
+			{Label: p.XAxisLabel, Prefix: p.XPrefix, Suffix: p.XSuffix, Name: "x", Domain: p.XDomain},
+			{Label: p.YAxisLabel, Prefix: p.YPrefix, Suffix: p.YSuffix, Name: "y", Domain: p.YDomain},
+		}
+		ch.Note = p.Note
+		ch.NoteOnEmpty = p.ShowNoteWhenEmpty
+		ch.BinSize = int(p.BinSize)
+	case influxdb.MarkdownViewProperties:
+		ch.Kind = chartKindMarkdown
+		ch.Note = p.Note
 	case influxdb.LinePlusSingleStatProperties:
 		setCommon(chartKindSingleStatPlusLine, p.ViewColors, p.DecimalPlaces, p.Queries)
 		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, p.Prefix, p.Suffix)
@@ -87,9 +103,18 @@ func convertCellView(cv cellView) chart {
 	case influxdb.SingleStatViewProperties:
 		setCommon(chartKindSingleStat, p.ViewColors, p.DecimalPlaces, p.Queries)
 		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, p.Prefix, p.Suffix)
-	case influxdb.MarkdownViewProperties:
-		ch.Kind = chartKindMarkdown
+	case influxdb.ScatterViewProperties:
+		ch.Kind = chartKindScatter
+		ch.Queries = convertQueries(p.Queries)
+		ch.Colors = stringsToColors(p.ViewColors)
+		ch.XCol = p.XColumn
+		ch.YCol = p.YColumn
+		ch.Axes = []axis{
+			{Label: p.XAxisLabel, Prefix: p.XPrefix, Suffix: p.XSuffix, Name: "x", Domain: p.XDomain},
+			{Label: p.YAxisLabel, Prefix: p.YPrefix, Suffix: p.YSuffix, Name: "y", Domain: p.YDomain},
+		}
 		ch.Note = p.Note
+		ch.NoteOnEmpty = p.ShowNoteWhenEmpty
 	case influxdb.XYViewProperties:
 		setCommon(chartKindXY, p.ViewColors, influxdb.DecimalPlaces{}, p.Queries)
 		setNoteFixes(p.Note, p.ShowNoteWhenEmpty, "", "")
@@ -124,6 +149,10 @@ func convertChartToResource(ch chart) Resource {
 
 	if ch.Legend.Type != "" {
 		r[fieldChartLegend] = ch.Legend
+	}
+
+	if ch.BinSize != 0 {
+		r[fieldChartBinSize] = ch.BinSize
 	}
 
 	ignoreFalseBools := map[string]bool{
@@ -280,4 +309,12 @@ func variableToResource(v influxdb.Variable, name string) Resource {
 	}
 
 	return r
+}
+
+func stringsToColors(clrs []string) colors {
+	newColors := make(colors, 0)
+	for _, x := range clrs {
+		newColors = append(newColors, &color{Hex: x})
+	}
+	return newColors
 }

--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -746,6 +746,21 @@ func parseChart(r Resource) (chart, []ValidationErr) {
 		c.Axes = presAxes
 	} else {
 		for _, ra := range r.slcResource(fieldChartAxes) {
+			domain := []float64{}
+
+			if _, ok := ra[fieldChartDomain]; ok {
+				for _, str := range ra.slcStr(fieldChartDomain) {
+					val, err := strconv.ParseFloat(str, 64)
+					if err != nil {
+						failures = append(failures, ValidationErr{
+							Field: "axes",
+							Msg:   err.Error(),
+						})
+					}
+					domain = append(domain, val)
+				}
+			}
+
 			c.Axes = append(c.Axes, axis{
 				Base:   ra.stringShort(fieldAxisBase),
 				Label:  ra.stringShort(fieldAxisLabel),
@@ -753,6 +768,7 @@ func parseChart(r Resource) (chart, []ValidationErr) {
 				Prefix: ra.stringShort(fieldPrefix),
 				Scale:  ra.stringShort(fieldAxisScale),
 				Suffix: ra.stringShort(fieldSuffix),
+				Domain: domain,
 			})
 		}
 	}

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -693,7 +693,7 @@ spec:
 
 				actual := sum.Dashboards[0]
 				assert.Equal(t, "dashboard w/ single heatmap chart", actual.Name)
-				assert.Equal(t, "a dashboard w/ heatmap scatter chart", actual.Description)
+				assert.Equal(t, "a dashboard w/ heatmap chart", actual.Description)
 
 				require.Len(t, actual.Charts, 1)
 				actualChart := actual.Charts[0]
@@ -708,6 +708,9 @@ spec:
 				assert.Equal(t, "heatmap note", props.Note)
 				assert.Equal(t, int32(10), props.BinSize)
 				assert.True(t, props.ShowNoteWhenEmpty)
+
+				assert.Equal(t, []float64{0, 10}, props.XDomain)
+				assert.Equal(t, []float64{0, 100}, props.YDomain)
 
 				require.Len(t, props.Queries, 1)
 				q := props.Queries[0]
@@ -741,7 +744,7 @@ spec:
 		{
 			"kind": "Dashboard",
 			"name": "dashboard w/ single heatmap chart",
-			"description": "a dashboard w/ heatmap scatter chart",
+			"description": "a dashboard w/ heatmap chart",
 			"charts": [
 			{
 				"kind": "heatmap",
@@ -813,7 +816,7 @@ spec:
 		{
 			"kind": "Dashboard",
 			"name": "dashboard w/ single heatmap chart",
-			"description": "a dashboard w/ heatmap scatter chart",
+			"description": "a dashboard w/ heatmap chart",
 			"charts": [
 			{
 				"kind": "heatmap",
@@ -870,7 +873,7 @@ spec:
 		{
 			"kind": "Dashboard",
 			"name": "dashboard w/ single heatmap chart",
-			"description": "a dashboard w/ heatmap scatter chart",
+			"description": "a dashboard w/ heatmap chart",
 			"charts": [
 			{
 				"kind": "heatmap",
@@ -1009,6 +1012,8 @@ spec:
 				assert.Equal(t, expectedQuery, q.Text)
 				assert.Equal(t, "advanced", q.EditMode)
 
+				assert.Equal(t, []float64{0, 10}, props.XDomain)
+				assert.Equal(t, []float64{0, 100}, props.YDomain)
 				assert.Equal(t, "x_label", props.XAxisLabel)
 				assert.Equal(t, "y_label", props.YAxisLabel)
 				assert.Equal(t, "x_prefix", props.XPrefix)

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -784,6 +784,78 @@ func TestService(t *testing.T) {
 					expectedView influxdb.View
 				}{
 					{
+						name:    "gauge",
+						newName: "new name",
+						expectedView: influxdb.View{
+							ViewContents: influxdb.ViewContents{
+								Name: "view name",
+							},
+							Properties: influxdb.GaugeViewProperties{
+								Type:              influxdb.ViewPropertyTypeGauge,
+								DecimalPlaces:     influxdb.DecimalPlaces{IsEnforced: true, Digits: 1},
+								Note:              "a note",
+								Prefix:            "pre",
+								Suffix:            "suf",
+								Queries:           []influxdb.DashboardQuery{newQuery()},
+								ShowNoteWhenEmpty: true,
+								ViewColors:        newColors("min", "max", "threshold"),
+							},
+						},
+					},
+					{
+						name:    "heatmap",
+						newName: "new name",
+						expectedView: influxdb.View{
+							ViewContents: influxdb.ViewContents{
+								Name: "view name",
+							},
+							Properties: influxdb.HeatmapViewProperties{
+								Type:              influxdb.ViewPropertyTypeHeatMap,
+								Note:              "a note",
+								Queries:           []influxdb.DashboardQuery{newQuery()},
+								ShowNoteWhenEmpty: true,
+								ViewColors:        []string{"#8F8AF4", "#8F8AF4", "#8F8AF4"},
+								XColumn:           "x",
+								YColumn:           "y",
+								XDomain:           []float64{0, 10},
+								YDomain:           []float64{0, 100},
+								XAxisLabel:        "x_label",
+								XPrefix:           "x_prefix",
+								XSuffix:           "x_suffix",
+								YAxisLabel:        "y_label",
+								YPrefix:           "y_prefix",
+								YSuffix:           "y_suffix",
+								BinSize:           10,
+							},
+						},
+					},
+					{
+						name:    "scatter",
+						newName: "new name",
+						expectedView: influxdb.View{
+							ViewContents: influxdb.ViewContents{
+								Name: "view name",
+							},
+							Properties: influxdb.ScatterViewProperties{
+								Type:              influxdb.ViewPropertyTypeScatter,
+								Note:              "a note",
+								Queries:           []influxdb.DashboardQuery{newQuery()},
+								ShowNoteWhenEmpty: true,
+								ViewColors:        []string{"#8F8AF4", "#8F8AF4", "#8F8AF4"},
+								XColumn:           "x",
+								YColumn:           "y",
+								XDomain:           []float64{0, 10},
+								YDomain:           []float64{0, 100},
+								XAxisLabel:        "x_label",
+								XPrefix:           "x_prefix",
+								XSuffix:           "x_suffix",
+								YAxisLabel:        "y_label",
+								YPrefix:           "y_prefix",
+								YSuffix:           "y_suffix",
+							},
+						},
+					},
+					{
 						name: "without new name single stat",
 						expectedView: influxdb.View{
 							ViewContents: influxdb.ViewContents{
@@ -821,24 +893,6 @@ func TestService(t *testing.T) {
 						},
 					},
 					{
-						name:    "guage",
-						newName: "new name",
-						expectedView: influxdb.View{
-							ViewContents: influxdb.ViewContents{
-								Name: "view name",
-							},
-							Properties: influxdb.GaugeViewProperties{
-								Type:              influxdb.ViewPropertyTypeGauge,
-								DecimalPlaces:     influxdb.DecimalPlaces{IsEnforced: true, Digits: 1},
-								Note:              "a note",
-								Prefix:            "pre",
-								Suffix:            "suf",
-								Queries:           []influxdb.DashboardQuery{newQuery()},
-								ShowNoteWhenEmpty: true,
-								ViewColors:        newColors("min", "max", "threshold"),
-							},
-						},
-					}, {
 						name:    "single stat plus line",
 						newName: "new name",
 						expectedView: influxdb.View{

--- a/pkger/testdata/dashboard_heatmap.json
+++ b/pkger/testdata/dashboard_heatmap.json
@@ -11,7 +11,7 @@
         {
           "kind": "Dashboard",
           "name": "dashboard w/ single heatmap chart",
-          "description": "a dashboard w/ heatmap scatter chart",
+          "description": "a dashboard w/ heatmap chart",
           "charts": [
             {
               "kind": "heatmap",
@@ -35,13 +35,15 @@
                   "name": "x",
                   "label": "x_label",
                   "prefix": "x_prefix",
-                  "suffix": "x_suffix"
+                  "suffix": "x_suffix",
+                  "domain": [0, 10]
                 },
                 {
                   "name": "y",
                   "label": "y_label",
                   "prefix": "y_prefix",
-                  "suffix": "y_suffix"
+                  "suffix": "y_suffix",
+                  "domain": [0, 100]
                 }
               ],
               "colors": [

--- a/pkger/testdata/dashboard_heatmap.yml
+++ b/pkger/testdata/dashboard_heatmap.yml
@@ -8,7 +8,7 @@ spec:
   resources:
     - kind: Dashboard
       name: dashboard w/ single heatmap chart
-      description: a dashboard w/ heatmap scatter chart
+      description: a dashboard w/ heatmap chart
       charts:
         - kind:   heatmap
           name:   heatmap
@@ -42,7 +42,13 @@ spec:
               label: x_label
               prefix: x_prefix
               suffix: x_suffix
+              domain:
+                - 0
+                - 10
             - name: y
               label: y_label
               prefix: y_prefix
               suffix: y_suffix
+              domain:
+                - 0
+                - 100

--- a/pkger/testdata/dashboard_scatter.json
+++ b/pkger/testdata/dashboard_scatter.json
@@ -34,13 +34,15 @@
                   "name": "x",
                   "label": "x_label",
                   "prefix": "x_prefix",
-                  "suffix": "x_suffix"
+                  "suffix": "x_suffix",
+                  "domain": [0, 10]
                 },
                 {
                   "name": "y",
                   "label": "y_label",
                   "prefix": "y_prefix",
-                  "suffix": "y_suffix"
+                  "suffix": "y_suffix",
+                  "domain": [0, 100]
                 }
               ],
               "colors": [

--- a/pkger/testdata/dashboard_scatter.yml
+++ b/pkger/testdata/dashboard_scatter.yml
@@ -34,7 +34,13 @@ spec:
               label: x_label
               prefix: x_prefix
               suffix: x_suffix
+              domain:
+                - 0
+                - 10
             - name: "y"
               label: y_label
               prefix: y_prefix
               suffix: y_suffix
+              domain:
+                - 0
+                - 100


### PR DESCRIPTION
Closes #

Describe your proposed changes here.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->
- Adds an export for the scatter and heatmap charts
- Also adds 2 additional pkger fields for the heatmap, and scatter charts (`xDomain`, `yDomain`). At first, didn't realized these existed, but you can create these fields when in the chronograf UI. Decided to add these to make sure we're backwards compatible.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass