### PR TITLE
feat(tasks): add ability to filter by active tasks

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -4342,6 +4342,14 @@ paths:
             type: string
           description: Filter tasks to a specific organization ID.
         - in: query
+          name: status
+          schema:
+            type: string
+            enum:
+              - active
+              - inactive
+          description: Filter tasks by a status--"inactive" or "active".
+        - in: query
           name: limit
           schema:
             type: integer

--- a/http/task_service.go
+++ b/http/task_service.go
@@ -511,6 +511,12 @@ func decodeGetTasksRequest(ctx context.Context, r *http.Request, orgs influxdb.O
 		req.filter.Limit = influxdb.TaskDefaultPageSize
 	}
 
+	if status := qp.Get("status"); status == "active" {
+		req.filter.Status = &status
+	} else if status := qp.Get("status"); status == "inactive" {
+		req.filter.Status = &status
+	}
+
 	// the task api can only create or lookup system tasks.
 	req.filter.Type = &influxdb.TaskSystemType
 
@@ -1472,6 +1478,10 @@ func (t TaskService) FindTasks(ctx context.Context, filter influxdb.TaskFilter) 
 	}
 	if filter.Limit != 0 {
 		val.Add("limit", strconv.Itoa(filter.Limit))
+	}
+
+	if filter.Status != nil {
+		val.Add("status", *filter.Status)
 	}
 
 	if filter.Type != nil {

--- a/kv/task.go
+++ b/kv/task.go
@@ -310,6 +310,8 @@ func (s *Service) findTasksByUser(ctx context.Context, tx Tx, filter influxdb.Ta
 		return nil, 0, err
 	}
 
+	matchFn := newTaskMatchFn(filter, org)
+
 	for _, m := range maps {
 		task, err := s.findTaskByIDWithAuth(ctx, tx, m.ResourceID)
 		if err != nil && err != influxdb.ErrTaskNotFound {
@@ -319,17 +321,14 @@ func (s *Service) findTasksByUser(ctx context.Context, tx Tx, filter influxdb.Ta
 			continue
 		}
 
-		if org != nil && task.OrganizationID != org.ID {
-			continue
-		}
-
-		if taskFilterMatch(filter.Type, task.Type) {
+		if matchFn == nil || matchFn(task) {
 			ts = append(ts, task)
+
+			if len(ts) >= filter.Limit {
+				break
+			}
 		}
 
-		if len(ts) >= filter.Limit {
-			break
-		}
 	}
 
 	return ts, len(ts), nil
@@ -366,6 +365,8 @@ func (s *Service) findTasksByOrg(ctx context.Context, tx Tx, filter influxdb.Tas
 	if err != nil {
 		return nil, 0, influxdb.ErrUnexpectedTaskBucketErr(err)
 	}
+
+	var k, v []byte
 	// we can filter by orgID
 	if filter.After != nil {
 		key, err := taskOrgKey(org.ID, *filter.After)
@@ -375,45 +376,20 @@ func (s *Service) findTasksByOrg(ctx context.Context, tx Tx, filter influxdb.Tas
 		// ignore the key:val returned in this seek because we are starting "after"
 		// this key
 		c.Seek(key)
+		k, v = c.Next()
 	} else {
-		// if we dont have an after we just move the cursor to the first instance of the
-		// orgID
+		// if we dont have an after we just move the cursor to the first instance of the orgID
 		key, err := org.ID.Encode()
 		if err != nil {
 			return nil, 0, influxdb.ErrInvalidTaskID
 		}
-		k, v := c.Seek(key)
-		if k != nil {
-			id, err := influxdb.IDFromString(string(v))
-			if err != nil {
-				return nil, 0, influxdb.ErrInvalidTaskID
-			}
 
-			t, err := s.findTaskByIDWithAuth(ctx, tx, *id)
-			if err != nil && err != influxdb.ErrTaskNotFound {
-				// we might have some crufty index's
-				return nil, 0, err
-			}
-
-			if t != nil {
-				if taskFilterMatch(filter.Type, t.Type) {
-					ts = append(ts, t)
-				}
-			}
-		}
+		k, v = c.Seek(key)
 	}
 
-	// if someone has a limit of 1
-	if len(ts) >= filter.Limit {
-		return ts, len(ts), nil
-	}
+	matchFn := newTaskMatchFn(filter, nil)
 
-	for {
-		k, v := c.Next()
-		if k == nil {
-			break
-		}
-
+	for k != nil {
 		id, err := influxdb.IDFromString(string(v))
 		if err != nil {
 			return nil, 0, influxdb.ErrInvalidTaskID
@@ -433,21 +409,15 @@ func (s *Service) findTasksByOrg(ctx context.Context, tx Tx, filter influxdb.Tas
 			break
 		}
 
-		if !taskFilterMatch(filter.Type, t.Type) {
-			continue
+		if matchFn == nil || matchFn(t) {
+			ts = append(ts, t)
+			// Check if we are over running the limit
+			if len(ts) >= filter.Limit {
+				break
+			}
 		}
 
-		// insert the new task into the list
-		ts = append(ts, t)
-
-		// Check if we are over running the limit
-		if len(ts) >= filter.Limit {
-			break
-		}
-	}
-
-	if filter.Name != nil {
-		ts = filterByName(ts, *filter.Name)
+		k, v = c.Next()
 	}
 
 	return ts, len(ts), err
@@ -486,6 +456,14 @@ func newTaskMatchFn(f influxdb.TaskFilter, org *influxdb.Organization) func(t *i
 		fn = func(t *influxdb.Task) bool {
 			res := prevFn == nil || prevFn(t)
 			return res && (expected == t.Name)
+		}
+	}
+
+	if f.Status != nil {
+		prevFn := fn
+		fn = func(t *influxdb.Task) bool {
+			res := prevFn == nil || prevFn(t)
+			return res && (t.Status == *f.Status)
 		}
 	}
 
@@ -545,18 +523,6 @@ func (s *Service) findAllTasks(ctx context.Context, tx Tx, filter influxdb.TaskF
 	}
 
 	return ts, len(ts), err
-}
-
-func filterByName(ts []*influxdb.Task, taskName string) []*influxdb.Task {
-	filtered := []*influxdb.Task{}
-
-	for _, task := range ts {
-		if task.Name == taskName {
-			filtered = append(filtered, task)
-		}
-	}
-
-	return filtered
 }
 
 // CreateTask creates a new task.
@@ -1923,20 +1889,4 @@ func taskRunKey(taskID, runID influxdb.ID) ([]byte, error) {
 	}
 
 	return []byte(string(encodedID) + "/" + string(encodedRunID)), nil
-}
-
-func taskFilterMatch(filter *string, ttype string) bool {
-	// if they want a system task the record may be system or an empty string
-	if filter != nil {
-		// if the task is either "system" or "" it qaulifies as a system task
-		if *filter == influxdb.TaskSystemType && (ttype == influxdb.TaskSystemType || ttype == "") {
-			return true
-		}
-
-		// otherwise check task type against the filter
-		if *filter != ttype {
-			return false
-		}
-	}
-	return true
 }

--- a/kv/task_test.go
+++ b/kv/task_test.go
@@ -11,6 +11,7 @@ import (
 	icontext "github.com/influxdata/influxdb/context"
 	"github.com/influxdata/influxdb/kv"
 	_ "github.com/influxdata/influxdb/query/builtin"
+	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/servicetest"
 )
 
@@ -223,6 +224,7 @@ func TestRetrieveTaskWithBadAuth(t *testing.T) {
 		Flux:           `option task = {name: "a task",every: 1h} from(bucket:"test") |> range(start:-1h)`,
 		OrganizationID: o.ID,
 		OwnerID:        u.ID,
+		Status:         string(backend.TaskActive),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -271,5 +273,15 @@ func TestRetrieveTaskWithBadAuth(t *testing.T) {
 	}
 	if len(tasks) != 1 {
 		t.Fatal("failed to return task")
+	}
+
+	// test status filter
+	active := string(backend.TaskActive)
+	tasksWithActiveFilter, _, err := service.FindTasks(ctx, influxdb.TaskFilter{Status: &active})
+	if err != nil {
+		t.Fatal("could not find tasks")
+	}
+	if len(tasksWithActiveFilter) != 1 {
+		t.Fatal("failed to find active task with filter")
 	}
 }

--- a/task.go
+++ b/task.go
@@ -414,6 +414,7 @@ type TaskFilter struct {
 	Organization   string
 	User           *ID
 	Limit          int
+	Status         *string
 }
 
 // QueryParams Converts TaskFilter fields to url query params.

--- a/task/servicetest/servicetest.go
+++ b/task/servicetest/servicetest.go
@@ -192,6 +192,16 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		return nil, fmt.Errorf("failed to find task by id %s", id)
 	}
 
+	findTasksByStatus := func(tasks []*influxdb.Task, status string) []*influxdb.Task {
+		var foundTasks = []*influxdb.Task{}
+		for _, t := range tasks {
+			if t.Status == status {
+				foundTasks = append(foundTasks, t)
+			}
+		}
+		return foundTasks
+	}
+
 	// TODO: replace with ErrMissingOwner test
 	// // should not be able to create a task without a token
 	// noToken := influxdb.TaskCreate{
@@ -227,6 +237,16 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		t.Fatal(err)
 	}
 	found["FindTasks with Organization filter"] = f
+
+	fs, _, err = sys.TaskService.FindTasks(sys.Ctx, influxdb.TaskFilter{Organization: cr.Org})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err = findTask(fs, tsk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found["FindTasks with Organization name filter"] = f
 
 	fs, _, err = sys.TaskService.FindTasks(sys.Ctx, influxdb.TaskFilter{User: &cr.UserID})
 	if err != nil {
@@ -266,6 +286,7 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		OrganizationID: cr.OrgID,
 		Flux:           fmt.Sprintf(scriptFmt, 1),
 		OwnerID:        cr.UserID,
+		Status:         string(backend.TaskInactive),
 	}
 
 	if _, err := sys.TaskService.CreateTask(authorizedCtx, tc2); err != nil {
@@ -297,6 +318,29 @@ func testTaskCRUD(t *testing.T, sys *System) {
 		if first.ID == task.ID {
 			t.Fatalf("after task included in task list")
 		}
+	}
+
+	// Check task status filter
+	active := string(backend.TaskActive)
+	fs, _, err = sys.TaskService.FindTasks(sys.Ctx, influxdb.TaskFilter{Status: &active})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	activeTasks := findTasksByStatus(fs, string(backend.TaskActive))
+	if len(fs) != len(activeTasks) {
+		t.Fatalf("expected to find %d active tasks, found: %d", len(activeTasks), len(fs))
+	}
+
+	inactive := string(backend.TaskInactive)
+	fs, _, err = sys.TaskService.FindTasks(sys.Ctx, influxdb.TaskFilter{Status: &inactive})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inactiveTasks := findTasksByStatus(fs, string(backend.TaskInactive))
+	if len(fs) != len(inactiveTasks) {
+		t.Fatalf("expected to find %d inactive tasks, found: %d", len(inactiveTasks), len(fs))
 	}
 
 	// Update task: script only.


### PR DESCRIPTION
This PR adds an "Active" filter to the `TaskFilter` struct to enable filtering by Task Status. The "Active" is a pointer to a bool, so it may be true, false, or nil when it is not set explicitly.

This PR also refactors the `findTasksByOrg` function to be more DRY, as well as consolidating multiple filter functions in kv/task.go with duplicated functionality.

- [x] Rebased/mergeable
- [x] Tests pass
- [x] swagger.yml updated
