### PR TITLE
fix(tsdb): error instead of panic'ing on corrupted series file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [15713](https://github.com/influxdata/influxdb/pull/15713): Mock missing Flux dependencies when creating tasks
 1. [15731](https://github.com/influxdata/influxdb/pull/15731): Ensure array cursor iterator stats accumulate all cursor stats
 1. [15866](https://github.com/influxdata/influxdb/pull/15866): Do not show Members section in Cloud environments
+1. [15900](https://github.com/influxdata/influxdb/pull/15900): Error instead of crashing on corrupted series file
 
 ### UI Improvements
 1. [15809](https://github.com/influxdata/influxdb/pull/15809): Redesign cards and animations on getting started page


### PR DESCRIPTION
We repeatedly see InfluxDB crashing on startup due to a corrupted data directory with a stack trace which looks _rougly_ like this:

```
panic: runtime error: slice bounds out of 

range goroutine 3617 [running]:
github.com/influxdata/influxdb/tsdb.ReadSeriesKey(0x7fde4cc02f45, 0x91b00bb, 0x91b00bb, 0x7fde4c330006, 0xc00037bf40, 0x7fde4c33d709, 0xd9, 0x9a758f7, 0xaaeea615dd120b4e)    
/go/src/github.com/influxdata/influxdb/tsdb/series_file.go:335 +0xa9
github.com/influxdata/influxdb/tsdb.ReadSeriesKeyFromSegments(0xc00238c580, 0x7, 0x8, 0x606e4ff45, 0x7fde4c33d709, 0xd9, 0x9a758f7)    
/go/src/github.com/influxdata/influxdb/tsdb/series_segment.go:292 +0x9c
github.com/influxdata/influxdb/tsdb.(*SeriesIndex).FindIDBySeriesKey(0xc00020d900, 0xc00238c580, 0x7, 0x8, 0xc0f34fd1f5, 0xdc, 0xcf236, 0xce99f)    
/go/src/github.com/influxdata/influxdb/tsdb/series_index.go:204 +0x1c5github.com/influxdata/influxdb/tsdb.(*SeriesPartition).CreateSeriesListIfNotExists(0xc000788580, 0xc0ebf9e000, 0x2710, 0x2710, 0xc0ebfda000, 0x2710, 0x2710, 0xc0ebfee000, 0x2710, 0x2710, ...)   
 /go/src/github.com/influxdata/influxdb/tsdb/series_partition.go:189 +0x109github.com/influxdata/influxdb/tsdb.(*SeriesFile).CreateSeriesListIfNotExists.func1(0x8, 0x151bb18)    
/go/src/github.com/influxdata/influxdb/tsdb/series_file.go:151 +0x7fgithub.com/influxdata/influxdb/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1(0xc02f0da0f0, 0xc0ed2c15c0)    
/go/src/github.com/influxdata/influxdb/vendor/golang.org/x/sync/errgroup/errgroup.go:58 +0x57created by github.com/influxdata/influxdb/vendor/golang.org/x/sync/errgroup.(*Group).Go    
/go/src/github.com/influxdata/influxdb/vendor/golang.org/x/sync/errgroup/errgroup.go:55 +0x66
```

We fix this with some educated guesses and deleting series files until we catch the bad one. Obviously, we should find & resolve the root cause of why this is happening to us, but in the meantime, this PR will at least improve the behaviour to not crash the process due to a panic but rather return an error which happens to state which file/partition is corrupted.

I have 'assumed' at the 'kit/errors' package is what we want to use going forward. Please let me know if that is not correct.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
