### PR TITLE
feat(pkger): extend apply HTTP API to return parse err with 422 resp

### DIFF
--- a/http/pkger_http_server.go
+++ b/http/pkger_http_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi"
@@ -32,12 +33,13 @@ func NewHandlerPkg(errHandler influxdb.HTTPErrorHandler, svc pkger.SVC) *Handler
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
 	r.Use(traceMW)
-	r.Use(middleware.SetHeader("Content-Type", "application/json; charset=utf-8"))
 	r.Use(middleware.Recoverer)
 
 	{
-		r.Post("/", svr.createPkg)
-		r.Post("/apply", svr.applyPkg)
+		r.With(middleware.AllowContentType("text/yml", "application/x-yaml", "application/json")).
+			Post("/", svr.createPkg)
+		r.With(middleware.SetHeader("Content-Type", "application/json; charset=utf-8")).
+			Post("/apply", svr.applyPkg)
 	}
 
 	svr.Router = r
@@ -49,24 +51,27 @@ func (s *HandlerPkg) Prefix() string {
 	return "/api/v2/packages"
 }
 
-// ReqCreatePkg is a request body for the create pkg endpoint.
-type ReqCreatePkg struct {
-	PkgName        string `json:"pkgName"`
-	PkgDescription string `json:"pkgDescription"`
-	PkgVersion     string `json:"pkgVersion"`
+type (
+	// ReqCreatePkg is a request body for the create pkg endpoint.
+	ReqCreatePkg struct {
+		PkgName        string `json:"pkgName"`
+		PkgDescription string `json:"pkgDescription"`
+		PkgVersion     string `json:"pkgVersion"`
 
-	Resources []pkger.ResourceToClone `json:"resources"`
-}
+		Resources []pkger.ResourceToClone `json:"resources"`
+	}
 
-// RespCreatePkg is a response body for the create pkg endpoint.
-type RespCreatePkg struct {
-	*pkger.Pkg
-}
+	// RespCreatePkg is a response body for the create pkg endpoint.
+	RespCreatePkg struct {
+		*pkger.Pkg
+	}
+)
 
 func (s *HandlerPkg) createPkg(w http.ResponseWriter, r *http.Request) {
 	var reqBody ReqCreatePkg
-	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-		s.HandleHTTPError(r.Context(), newDecodeErr("json", err), w)
+	encoding, err := decodeWithEncoding(r, &reqBody)
+	if err != nil {
+		s.HandleHTTPError(r.Context(), newDecodeErr(encoding.String(), err), w)
 		return
 	}
 	defer r.Body.Close()
@@ -84,28 +89,50 @@ func (s *HandlerPkg) createPkg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.encResp(r.Context(), w, http.StatusOK, RespCreatePkg{
+	var enc encoder
+	switch encoding {
+	case pkger.EncodingYAML:
+		enc = yaml.NewEncoder(w)
+		w.Header().Set("Content-Type", "application/x-yaml")
+	default:
+		enc = newJSONEnc(w)
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	}
+	s.encResp(r.Context(), w, enc, http.StatusOK, RespCreatePkg{
 		Pkg: newPkg,
 	})
 }
 
-// ReqApplyPkg is the request body for a json or yaml body for the apply pkg endpoint.
-type ReqApplyPkg struct {
-	DryRun bool       `yaml:"dryRun" json:"dryRun"`
-	OrgID  string     `yaml:"orgID" json:"orgID"`
-	Pkg    *pkger.Pkg `yaml:"package" json:"package"`
-}
+type (
+	// ReqApplyPkg is the request body for a json or yaml body for the apply pkg endpoint.
+	ReqApplyPkg struct {
+		DryRun bool       `json:"dryRun" yaml:"dryRun"`
+		OrgID  string     `json:"orgID" yaml:"orgID"`
+		Pkg    *pkger.Pkg `json:"package" yaml:"package"`
+	}
 
-// RespApplyPkg is the response body for the apply pkg endpoint.
-type RespApplyPkg struct {
-	Diff    pkger.Diff    `yaml:"diff" json:"diff"`
-	Summary pkger.Summary `yaml:"summary" json:"summary"`
-}
+	// RespApplyPkg is the response body for the apply pkg endpoint.
+	RespApplyPkg struct {
+		Diff    pkger.Diff    `json:"diff" yaml:"diff"`
+		Summary pkger.Summary `json:"summary" yaml:"summary"`
+
+		Errors []PkgValidationErr `json:"errors,omitempty" yaml:"errors,omitempty"`
+	}
+
+	// PkgValidationErr is a single
+	PkgValidationErr struct {
+		Kind    string   `json:"kind" yaml:"kind"`
+		Fields  []string `json:"fields" yaml:"fields"`
+		Indexes []*int   `json:"idxs" yaml:"idxs"`
+		Reason  string   `json:"reason" yaml:"reason"`
+	}
+)
 
 func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
-	reqBody, err := decodeApplyReq(r)
+	var reqBody ReqApplyPkg
+	encoding, err := decodeWithEncoding(r, &reqBody)
 	if err != nil {
-		s.HandleHTTPError(r.Context(), err, w)
+		s.HandleHTTPError(r.Context(), newDecodeErr(encoding.String(), err), w)
 		return
 	}
 
@@ -120,6 +147,14 @@ func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
 
 	parsedPkg := reqBody.Pkg
 	sum, diff, err := s.svc.DryRun(r.Context(), *orgID, parsedPkg)
+	if pkger.IsParseErr(err) {
+		s.encJSONResp(r.Context(), w, http.StatusUnprocessableEntity, RespApplyPkg{
+			Diff:    diff,
+			Summary: sum,
+			Errors:  convertParseErr(err),
+		})
+		return
+	}
 	if err != nil {
 		s.HandleHTTPError(r.Context(), err, w)
 		return
@@ -127,7 +162,7 @@ func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
 
 	// if only a dry run, then we exit before anything destructive
 	if reqBody.DryRun {
-		s.encResp(r.Context(), w, http.StatusOK, RespApplyPkg{
+		s.encJSONResp(r.Context(), w, http.StatusOK, RespApplyPkg{
 			Diff:    diff,
 			Summary: sum,
 		})
@@ -135,50 +170,94 @@ func (s *HandlerPkg) applyPkg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sum, err = s.svc.Apply(r.Context(), *orgID, parsedPkg)
-	if err != nil {
+	if err != nil && !pkger.IsParseErr(err) {
 		s.HandleHTTPError(r.Context(), err, w)
 		return
 	}
 
-	s.encResp(r.Context(), w, http.StatusCreated, RespApplyPkg{
+	s.encJSONResp(r.Context(), w, http.StatusCreated, RespApplyPkg{
 		Diff:    diff,
 		Summary: sum,
 	})
 }
 
-func decodeApplyReq(r *http.Request) (ReqApplyPkg, error) {
-	var (
-		reqBody  ReqApplyPkg
-		encoding pkger.Encoding
-		err      error
-	)
+type encoder interface {
+	Encode(interface{}) error
+}
 
+func decodeWithEncoding(r *http.Request, v interface{}) (pkger.Encoding, error) {
+	var (
+		encoding pkger.Encoding
+		dec      interface{ Decode(interface{}) error }
+	)
 	switch contentType := r.Header.Get("Content-Type"); contentType {
 	case "text/yml", "application/x-yaml":
 		encoding = pkger.EncodingYAML
-		err = yaml.NewDecoder(r.Body).Decode(&reqBody)
+		dec = yaml.NewDecoder(r.Body)
 	default:
 		encoding = pkger.EncodingJSON
-		err = json.NewDecoder(r.Body).Decode(&reqBody)
-	}
-	if err != nil {
-		return ReqApplyPkg{}, newDecodeErr(encoding.String(), err)
+		dec = json.NewDecoder(r.Body)
 	}
 
-	return reqBody, nil
+	return encoding, dec.Decode(v)
 }
 
-func (s *HandlerPkg) encResp(ctx context.Context, w http.ResponseWriter, code int, res interface{}) {
-	w.WriteHeader(code)
+func newJSONEnc(w io.Writer) encoder {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "\t")
+	return enc
+}
+
+func (s *HandlerPkg) encResp(ctx context.Context, w http.ResponseWriter, enc encoder, code int, res interface{}) {
+	w.WriteHeader(code)
 	if err := enc.Encode(res); err != nil {
 		s.HandleHTTPError(ctx, &influxdb.Error{
-			Msg:  fmt.Sprintf("unable to marshal json; Err: %v", err),
+			Msg:  fmt.Sprintf("unable to marshal; Err: %v", err),
 			Code: influxdb.EInternal,
 			Err:  err,
 		}, w)
 	}
+}
+
+func (s *HandlerPkg) encJSONResp(ctx context.Context, w http.ResponseWriter, code int, res interface{}) {
+	s.encResp(ctx, w, newJSONEnc(w), code, res)
+}
+
+func convertParseErr(err error) []PkgValidationErr {
+	pErr, ok := err.(*pkger.ParseErr)
+	if !ok {
+		return nil
+	}
+
+	var errs []PkgValidationErr
+	for _, r := range pErr.Resources {
+		rootErr := PkgValidationErr{
+			Kind:    r.Kind,
+			Fields:  []string{"resources"},
+			Indexes: []*int{&r.Idx},
+		}
+
+		for _, v := range append(r.ValidationErrs, r.AssociationErrs...) {
+			errs = append(errs, traverseErrs(rootErr, v)...)
+		}
+	}
+
+	return errs
+}
+
+func traverseErrs(root PkgValidationErr, vErr pkger.ValidationErr) []PkgValidationErr {
+	root.Fields = append(root.Fields, vErr.Field)
+	root.Indexes = append(root.Indexes, vErr.Index)
+	if len(vErr.Nested) == 0 {
+		root.Reason = vErr.Msg
+		return []PkgValidationErr{root}
+	}
+
+	var errs []PkgValidationErr
+	for _, n := range vErr.Nested {
+		errs = append(errs, traverseErrs(root, n)...)
+	}
+	return errs
 }
 
 func newDecodeErr(encoding string, err error) *influxdb.Error {

--- a/http/pkger_http_server_test.go
+++ b/http/pkger_http_server_test.go
@@ -222,6 +222,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 
 				assert.Len(t, resp.Summary.Buckets, 1)
 				assert.Len(t, resp.Diff.Buckets, 1)
+				assert.Nil(t, resp.Errors)
 			})
 	})
 }

--- a/http/pkger_parse_err_test.go
+++ b/http/pkger_parse_err_test.go
@@ -1,0 +1,74 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/influxdata/influxdb/pkger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_PkgValidationErr(t *testing.T) {
+	iPtr := func(i int) *int {
+		return &i
+	}
+
+	compIntSlcs := func(t *testing.T, expected []int, actuals []*int) {
+		t.Helper()
+
+		if len(expected) >= len(actuals) {
+			require.FailNow(t, "expected array is larger than actuals")
+		}
+
+		for i, actual := range actuals {
+			if i == len(expected) {
+				assert.Nil(t, actual)
+				continue
+			}
+			assert.Equal(t, expected[i], *actual)
+		}
+	}
+
+	pErr := &pkger.ParseErr{
+		Resources: []pkger.ResourceErr{
+			{
+				Kind: pkger.KindDashboard.String(),
+				Idx:  0,
+				ValidationErrs: []pkger.ValidationErr{
+					{
+						Field: "charts",
+						Index: iPtr(1),
+						Nested: []pkger.ValidationErr{
+							{
+								Field: "colors",
+								Index: iPtr(0),
+								Nested: []pkger.ValidationErr{
+									{
+										Field: "hex",
+										Msg:   "hex value required",
+									},
+								},
+							},
+							{
+								Field: "kind",
+								Msg:   "chart kind must be provided",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := convertParseErr(pErr)
+	require.Len(t, errs, 2)
+	assert.Equal(t, pkger.KindDashboard.String(), errs[0].Kind)
+	assert.Equal(t, []string{"resources", "charts", "colors", "hex"}, errs[0].Fields)
+	compIntSlcs(t, []int{0, 1, 0}, errs[0].Indexes)
+	assert.Equal(t, "hex value required", errs[0].Reason)
+
+	assert.Equal(t, pkger.KindDashboard.String(), errs[1].Kind)
+	assert.Equal(t, []string{"resources", "charts", "kind"}, errs[1].Fields)
+	compIntSlcs(t, []int{0, 1}, errs[1].Indexes)
+	assert.Equal(t, "chart kind must be provided", errs[1].Reason)
+}

--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -7296,6 +7296,23 @@ components:
                     $ref: "#/components/schemas/VariableProperties"
                   newArgs:
                     $ref: "#/components/schemas/VariableProperties"
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              kind:
+                type: string
+              reason:
+                type: string
+              fields:
+                type: array
+                items:
+                  type: string
+              indexes:
+                type: array
+                items:
+                  type: integer
     PkgChart:
       type: object
       properties:

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -2720,9 +2720,9 @@ func testPkgErrors(t *testing.T, k Kind, tt testPkgResourceError) {
 		_, err := Parse(encoding, FromString(tt.pkgStr))
 		require.Error(t, err)
 
-		pErr, ok := IsParseErr(err)
-		require.True(t, ok, err)
+		require.True(t, IsParseErr(err), err)
 
+		pErr := err.(*ParseErr)
 		require.Len(t, pErr.Resources, resErrs)
 
 		resErr := pErr.Resources[0]


### PR DESCRIPTION
this change is to provide a more robust response when encountering a validation error during the application of a package. The errors returned enables the API consumer to the errors and have pin point accuracy of where in their package things went amuck, regardless of it being JSON/YML/gzipped/etc. 

<details>
<summary>example of updated API response for validation errors, a 422 is returned with the following body</summary>

```json
{
   "diff": ... same,
   "summary": ... same,
   "errors": [
		{
			"kind": "dashboard",
			"fields": [
				"resources",
				"charts",
				"kind"
			],
			"idxs": [
				3,
				10,
				null
			],
			"reason": "invalid chart kind provided: "
		},
		{
			"kind": "dashboard",
			"fields": [
				"resources",
				"charts",
				"height"
			],
			"idxs": [
				3,
				11,
				null
			],
			"reason": "must be greater than 0"
		},
		{
			"kind": "dashboard",
			"fields": [
				"resources",
				"charts",
				"queries",
				"query"
			],
			"idxs": [
				3,
				11,
				0,
				null
			],
			"reason": "a query must be provided"
		},
		{
			"kind": "dashboard",
			"fields": [
				"resources",
				"charts",
				"geom"
			],
			"idxs": [
				3,
				11,
				null
			],
			"reason": "type not found: \"\""
		},
		{
			"kind": "dashboard",
			"fields": [
				"resources",
				"charts",
				"axes"
			],
			"idxs": [
				3,
				11,
				null
			],
			"reason": "axis not found: \"x\""
		},
		{
			"kind": "bucket",
			"fields": [
				"resources",
				"associations"
			],
			"idxs": [
				3,
				0
			],
			"reason": "label \"label_11\" does not exist in pkg"
		}
	]
}
```

</details>


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
