### PR TITLE
feat: add support for insecure skip verify on cli http clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v2.0.0-alpha.20 [unreleased]
 
+### Feaures
+
+1. [15805](https://github.com/influxdata/influxdb/pull/15924) Add tls insecure skip verify to influx CLI.
+
 ### Bug Fixes
 
 1. [15777](https://github.com/influxdata/influxdb/pull/15777): Fix long startup when running 'influx help'

--- a/cmd/influx/authorization.go
+++ b/cmd/influx/authorization.go
@@ -293,7 +293,7 @@ func authorizationCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	if userName := authorizationCreateFlags.user; userName != "" {
-		userSvc, err := newUserService(flags)
+		userSvc, err := newUserService()
 		if err != nil {
 			return err
 		}
@@ -374,8 +374,9 @@ func newAuthorizationService(f Flags) (platform.AuthorizationService, error) {
 		return newLocalKVService()
 	}
 	return &http.AuthorizationService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}, nil
 }
 

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -52,8 +52,9 @@ func newBucketService(f Flags) (platform.BucketService, error) {
 		return newLocalKVService()
 	}
 	return &http.BucketService{
-		Addr:  f.host,
-		Token: f.token,
+		Addr:               f.host,
+		Token:              f.token,
+		InsecureSkipVerify: f.skipVerify,
 	}, nil
 }
 

--- a/cmd/influx/delete.go
+++ b/cmd/influx/delete.go
@@ -66,8 +66,9 @@ func fluxDeleteF(cmd *cobra.Command, args []string) error {
 	}
 
 	s := &http.DeleteService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	ctx = signals.WithStandardSignals(ctx)

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -64,6 +64,8 @@ func init() {
 
 	influxCmd.PersistentFlags().BoolVar(&flags.local, "local", false, "Run commands locally against the filesystem")
 
+	influxCmd.PersistentFlags().BoolVar(&flags.skipVerify, "skip-verify", false, "SkipVerify controls whether a client verifies the server's certificate chain and host name.")
+
 	// Override help on all the commands tree
 	walk(influxCmd, func(c *cobra.Command) {
 		c.Flags().BoolP("help", "h", false, fmt.Sprintf("Help for the %s command ", c.Name()))
@@ -78,9 +80,10 @@ func main() {
 
 // Flags contains all the CLI flag values for influx.
 type Flags struct {
-	token string
-	host  string
-	local bool
+	token      string
+	host       string
+	local      bool
+	skipVerify bool
 }
 
 var flags Flags
@@ -114,7 +117,8 @@ func writeTokenToPath(tok, path, dir string) error {
 
 func checkSetup(host string) error {
 	s := &http.SetupService{
-		Addr: flags.host,
+		Addr:               flags.host,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	isOnboarding, err := s.IsOnboarding(context.Background())

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -48,8 +48,9 @@ func newOrganizationService(f Flags) (platform.OrganizationService, error) {
 		return newLocalKVService()
 	}
 	return &http.OrganizationService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}, nil
 }
 
@@ -308,7 +309,7 @@ func organizationMembersListF(cmd *cobra.Command, args []string) error {
 		ResourceType: platform.OrgsResourceType,
 		ResourceID:   organization.ID,
 		UserType:     platform.Member,
-	}, flags)
+	})
 }
 
 func init() {
@@ -379,7 +380,7 @@ func organizationMembersAddF(cmd *cobra.Command, args []string) error {
 		MappingType:  platform.UserMappingType,
 		UserID:       memberID,
 		UserType:     platform.Member,
-	}, flags)
+	})
 }
 
 func init() {
@@ -446,7 +447,7 @@ func organizationMembersRemoveF(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to decode member id %s: %v", organizationMembersRemoveFlags.memberID, err)
 	}
 
-	return membersRemoveF(ctx, organization.ID, memberID, flags)
+	return membersRemoveF(ctx, organization.ID, memberID)
 }
 
 func init() {

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -125,8 +125,9 @@ func newDashboardService(f Flags) (influxdb.DashboardService, error) {
 		return newLocalKVService()
 	}
 	return &http.DashboardService{
-		Addr:  f.host,
-		Token: f.token,
+		Addr:               f.host,
+		Token:              f.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}, nil
 }
 
@@ -135,8 +136,9 @@ func newLabelService(f Flags) (influxdb.LabelService, error) {
 		return newLocalKVService()
 	}
 	return &http.LabelService{
-		Addr:  f.host,
-		Token: f.token,
+		Addr:               f.host,
+		Token:              f.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}, nil
 }
 
@@ -145,8 +147,9 @@ func newVariableService(f Flags) (influxdb.VariableService, error) {
 		return newLocalKVService()
 	}
 	return &http.VariableService{
-		Addr:  f.host,
-		Token: f.token,
+		Addr:               f.host,
+		Token:              f.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}, nil
 }
 

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -80,7 +80,7 @@ func fluxQueryF(cmd *cobra.Command, args []string) error {
 
 	flux.FinalizeBuiltIns()
 
-	r, err := getFluxREPL(flags.host, flags.token, orgID)
+	r, err := getFluxREPL(flags.host, flags.token, flags.skipVerify, orgID)
 	if err != nil {
 		return fmt.Errorf("failed to get the flux REPL: %v", err)
 	}

--- a/cmd/influx/repl.go
+++ b/cmd/influx/repl.go
@@ -73,7 +73,7 @@ func replF(cmd *cobra.Command, args []string) error {
 
 	flux.FinalizeBuiltIns()
 
-	r, err := getFluxREPL(flags.host, flags.token, orgID)
+	r, err := getFluxREPL(flags.host, flags.token, flags.skipVerify, orgID)
 	if err != nil {
 		return err
 	}
@@ -84,8 +84,9 @@ func replF(cmd *cobra.Command, args []string) error {
 
 func findOrgID(ctx context.Context, org string) (platform.ID, error) {
 	svc := &http.OrganizationService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	o, err := svc.FindOrganization(ctx, platform.OrganizationFilter{
@@ -98,10 +99,11 @@ func findOrgID(ctx context.Context, org string) (platform.ID, error) {
 	return o.ID, nil
 }
 
-func getFluxREPL(addr, token string, orgID platform.ID) (*repl.REPL, error) {
+func getFluxREPL(addr, token string, skipVerify bool, orgID platform.ID) (*repl.REPL, error) {
 	qs := &http.FluxQueryService{
-		Addr:  addr,
-		Token: token,
+		Addr:               addr,
+		Token:              token,
+		InsecureSkipVerify: skipVerify,
 	}
 	q := &query.REPLQuerier{
 		OrganizationID: orgID,

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -51,7 +51,8 @@ func setupF(cmd *cobra.Command, args []string) error {
 
 	// check if setup is allowed
 	s := &http.SetupService{
-		Addr: flags.host,
+		Addr:               flags.host,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	allowed, err := s.IsOnboarding(context.Background())

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -83,8 +83,9 @@ func taskCreateF(cmd *cobra.Command, args []string) error {
 	}
 
 	s := &http.TaskService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	flux, err := repl.LoadQuery(args[0])
@@ -163,8 +164,9 @@ func init() {
 
 func taskFindF(cmd *cobra.Command, args []string) error {
 	s := &http.TaskService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	filter := platform.TaskFilter{}
@@ -265,8 +267,9 @@ func init() {
 
 func taskUpdateF(cmd *cobra.Command, args []string) error {
 	s := &http.TaskService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	var id platform.ID
@@ -339,8 +342,9 @@ func init() {
 
 func taskDeleteF(cmd *cobra.Command, args []string) error {
 	s := &http.TaskService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	var id platform.ID
@@ -408,8 +412,9 @@ func init() {
 
 func taskLogFindF(cmd *cobra.Command, args []string) error {
 	s := &http.TaskService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	var filter platform.LogFilter
@@ -482,8 +487,9 @@ func init() {
 
 func taskRunFindF(cmd *cobra.Command, args []string) error {
 	s := &http.TaskService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	filter := platform.RunFilter{
@@ -570,8 +576,9 @@ func init() {
 
 func runRetryF(cmd *cobra.Command, args []string) error {
 	s := &http.TaskService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	var taskID, runID platform.ID

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -40,28 +40,30 @@ func init() {
 	userCmd.AddCommand(userUpdateCmd)
 }
 
-func newUserService(f Flags) (platform.UserService, error) {
+func newUserService() (platform.UserService, error) {
 	if flags.local {
 		return newLocalKVService()
 	}
 	return &http.UserService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}, nil
 }
 
-func newUserResourceMappingService(f Flags) (platform.UserResourceMappingService, error) {
+func newUserResourceMappingService() (platform.UserResourceMappingService, error) {
 	if flags.local {
 		return newLocalKVService()
 	}
 	return &http.UserResourceMappingService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}, nil
 }
 
 func userUpdateF(cmd *cobra.Command, args []string) error {
-	s, err := newUserService(flags)
+	s, err := newUserService()
 	if err != nil {
 		return err
 	}
@@ -116,7 +118,7 @@ func init() {
 }
 
 func userCreateF(cmd *cobra.Command, args []string) error {
-	s, err := newUserService(flags)
+	s, err := newUserService()
 	if err != nil {
 		return err
 	}
@@ -165,7 +167,7 @@ func init() {
 }
 
 func userFindF(cmd *cobra.Command, args []string) error {
-	s, err := newUserService(flags)
+	s, err := newUserService()
 	if err != nil {
 		return err
 	}
@@ -224,7 +226,7 @@ func init() {
 }
 
 func userDeleteF(cmd *cobra.Command, args []string) error {
-	s, err := newUserService(flags)
+	s, err := newUserService()
 	if err != nil {
 		return err
 	}

--- a/cmd/influx/user_resource_mapping.go
+++ b/cmd/influx/user_resource_mapping.go
@@ -9,8 +9,8 @@ import (
 	"github.com/influxdata/influxdb/cmd/influx/internal"
 )
 
-func membersListF(ctx context.Context, filter influxdb.UserResourceMappingFilter, flgs Flags) error {
-	mappingSvc, err := newUserResourceMappingService(flgs)
+func membersListF(ctx context.Context, filter influxdb.UserResourceMappingFilter) error {
+	mappingSvc, err := newUserResourceMappingService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize members service client: %v", err)
 	}
@@ -18,7 +18,7 @@ func membersListF(ctx context.Context, filter influxdb.UserResourceMappingFilter
 	if err != nil {
 		return fmt.Errorf("failed to find members: %v", err)
 	}
-	userSVC, err := newUserService(flgs)
+	userSVC, err := newUserService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize users service client: %v", err)
 	}
@@ -77,8 +77,8 @@ func membersListF(ctx context.Context, filter influxdb.UserResourceMappingFilter
 	return nil
 }
 
-func membersAddF(ctx context.Context, urm influxdb.UserResourceMapping, flgs Flags) error {
-	mappingSvc, err := newUserResourceMappingService(flgs)
+func membersAddF(ctx context.Context, urm influxdb.UserResourceMapping) error {
+	mappingSvc, err := newUserResourceMappingService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize members service client: %v", err)
 	}
@@ -90,8 +90,8 @@ func membersAddF(ctx context.Context, urm influxdb.UserResourceMapping, flgs Fla
 	return nil
 }
 
-func membersRemoveF(ctx context.Context, resourceID, userID influxdb.ID, flgs Flags) error {
-	mappingSvc, err := newUserResourceMappingService(flgs)
+func membersRemoveF(ctx context.Context, resourceID, userID influxdb.ID) error {
+	mappingSvc, err := newUserResourceMappingService()
 	if err != nil {
 		return fmt.Errorf("failed to initialize members service client: %v", err)
 	}

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -84,8 +84,9 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 	}
 
 	bs := &http.BucketService{
-		Addr:  flags.host,
-		Token: flags.token,
+		Addr:               flags.host,
+		Token:              flags.token,
+		InsecureSkipVerify: flags.skipVerify,
 	}
 
 	var err error
@@ -144,9 +145,10 @@ func fluxWriteF(cmd *cobra.Command, args []string) error {
 
 	s := write.Batcher{
 		Service: &http.WriteService{
-			Addr:      flags.host,
-			Token:     flags.token,
-			Precision: writeFlags.Precision,
+			Addr:               flags.host,
+			Token:              flags.token,
+			Precision:          writeFlags.Precision,
+			InsecureSkipVerify: flags.skipVerify,
 		},
 	}
 


### PR DESCRIPTION
Closes #15805 

Adds support for insecure skip verify flag in `influx` cli.

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass