### PR TITLE
fix(kv): don't stub system buckets when searching by name

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -153,8 +153,3 @@ func (f BucketFilter) String() string {
 	}
 	return "[" + strings.Join(parts, ", ") + "]"
 }
-
-// FindSystemBucket finds the system bucket with a given name
-func FindSystemBucket(ctx context.Context, bs BucketService, orgID ID, name string) (*Bucket, error) {
-	return bs.FindBucketByName(ctx, orgID, name)
-}

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -345,6 +345,14 @@ func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter,
 		return nil
 	})
 
+	// Don't append system buckets if Name is set.
+	// This has a side effect that users with no system buckets won't get mock
+	// system buckets, but this has limited utility and affects a negligibly small number
+	// of people. This can be removed once mock system bucket code is removed.
+	if filter.Name != nil {
+		return bs, len(bs), nil
+	}
+
 	needsSystemBuckets := true
 	for _, b := range bs {
 		if b.Type == influxdb.BucketTypeSystem {

--- a/kv/bucket.go
+++ b/kv/bucket.go
@@ -345,10 +345,10 @@ func (s *Service) FindBuckets(ctx context.Context, filter influxdb.BucketFilter,
 		return nil
 	})
 
-	// Don't append system buckets if Name is set.
-	// This has a side effect that users with no system buckets won't get mock
-	// system buckets, but this has limited utility and affects a negligibly small number
-	// of people. This can be removed once mock system bucket code is removed.
+	// Don't append system buckets if Name is set. Users who don't have real
+	// system buckets won't get mocked buckets if they query for a bucket by name
+	// without the orgID, but this is a vanishing small number of users and has
+	// limited utility anyways. Can be removed once mock system code is ripped out.
 	if filter.Name != nil {
 		return bs, len(bs), nil
 	}

--- a/task/backend/analytical_storage.go
+++ b/task/backend/analytical_storage.go
@@ -75,7 +75,7 @@ func (as *AnalyticalStorage) FinishRun(ctx context.Context, taskID, runID influx
 			return run, err
 		}
 
-		sb, err := influxdb.FindSystemBucket(ctx, as.BucketService, task.OrganizationID, influxdb.TasksSystemBucketName)
+		sb, err := as.BucketService.FindBucketByName(ctx, task.OrganizationID, influxdb.TasksSystemBucketName)
 		if err != nil {
 			return run, err
 		}
@@ -142,7 +142,7 @@ func (as *AnalyticalStorage) FindRuns(ctx context.Context, filter influxdb.RunFi
 		return runs, n, err
 	}
 
-	sb, err := influxdb.FindSystemBucket(ctx, as.BucketService, task.OrganizationID, influxdb.TasksSystemBucketName)
+	sb, err := as.BucketService.FindBucketByName(ctx, task.OrganizationID, influxdb.TasksSystemBucketName)
 	if err != nil {
 		return runs, n, err
 	}
@@ -246,7 +246,7 @@ func (as *AnalyticalStorage) FindRunByID(ctx context.Context, taskID, runID infl
 		return run, err
 	}
 
-	sb, err := influxdb.FindSystemBucket(ctx, as.BucketService, task.OrganizationID, influxdb.TasksSystemBucketName)
+	sb, err := as.BucketService.FindBucketByName(ctx, task.OrganizationID, influxdb.TasksSystemBucketName)
 	if err != nil {
 		return run, err
 	}


### PR DESCRIPTION
Fixes #14900

* Removed an unused function as cleanup.
* Users without true system buckets won't have fake buckets returned if they don't specify their org in the request, but this shouldn't break tasks. It wasn't working correctly previously, and considering the small number of people this impacts in a meaningless way, I'm not sure it's worth doing "correctly" for code we'll rip out soon.
