### PR TITLE
fix(storage): fixes panic when building predicates

### DIFF
--- a/tsdb/tsm1/predicate.go
+++ b/tsdb/tsm1/predicate.go
@@ -75,7 +75,15 @@ func NewProtobufPredicate(pred *datatypes.Predicate) (Predicate, error) {
 		if node.GetNodeType() == datatypes.NodeTypeTagRef {
 			switch value := node.GetValue().(type) {
 			case *datatypes.Node_TagRefValue:
-				locs[value.TagRefValue] = len(locs)
+				// Only add to the matcher locations the first time we encounter
+				// the tag key reference. This prevents problems with redundant
+				// predicates like:
+				//
+				//   foo = a AND foo = b
+				//   foo = c AND foo = d
+				if _, ok := locs[value.TagRefValue]; !ok {
+					locs[value.TagRefValue] = len(locs)
+				}
 			}
 		}
 	})

--- a/tsdb/tsm1/predicate_test.go
+++ b/tsdb/tsm1/predicate_test.go
@@ -86,6 +86,16 @@ func TestPredicate_Matches(t *testing.T) {
 		},
 
 		{
+			Name: "Logical And Matching Reduce (Simplify)",
+			Predicate: predicate(
+				andNode(
+					comparisonNode(datatypes.ComparisonEqual, tagNode("foo"), stringNode("bar")),
+					comparisonNode(datatypes.ComparisonNotEqual, tagNode("foo"), stringNode("bif")))),
+			Key:     "bucketorg,baz=bif,foo=bar,tag3=val3",
+			Matches: true,
+		},
+
+		{
 			Name: "Regex Matching",
 			Predicate: predicate(
 				comparisonNode(datatypes.ComparisonRegex, tagNode("tag3"), regexNode("...3"))),


### PR DESCRIPTION
Fixes #15916.

If a predicate was passed in with multiple key/value matches for the
same tag key, then the value index would be incorrect. This ensures that
each tag key can only be added to the location map once.
