### PR TITLE
fix(pkgr/parser): added failure definition to prevent build failure

### DIFF
--- a/pkger/parser.go
+++ b/pkger/parser.go
@@ -668,6 +668,7 @@ func parseChart(r Resource) (chart, []ValidationErr) {
 			Msg:   err.Error(),
 		}}
 	}
+	var failures []ValidationErr
 
 	c := chart{
 		Kind:        ck,


### PR DESCRIPTION
Updated pkgr/parser to define failures to prevent runtime go run build failure