### PR TITLE
fix(ui/alertbuilder): updated scss file to accurately set textarea height

### DIFF
--- a/ui/src/alerting/components/builder/AlertBuilder.scss
+++ b/ui/src/alerting/components/builder/AlertBuilder.scss
@@ -41,6 +41,12 @@
   justify-content: center;
 }
 
+.alert-builder--message-template {
+  textarea {
+    height: 120px;
+  }
+}
+
 .alert-builder--message-template.cf-text-area--container.cf-input-md {
   height: auto;
 
@@ -66,7 +72,6 @@
     user-select: text;
   }
 }
-
 
 .alert-builder--check-type-selector {
   margin-bottom: $ix-marg-c;


### PR DESCRIPTION
Closes #15831

### Problem

CSS textarea wasn't being set correctly

### Solution

Updated the scss file to correctly set the textarea