### PR TITLE
chore(influx): refactor orgnization cmd

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -91,7 +91,7 @@ func influxCmd() *cobra.Command {
 		authCmd(),
 		bucketCmd,
 		deleteCmd,
-		organizationCmd,
+		organizationCmd(),
 		pingCmd,
 		cmdPkg(newPkgerSVC),
 		queryCmd,

--- a/cmd/influx/organization.go
+++ b/cmd/influx/organization.go
@@ -11,12 +11,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Organization Command
-var organizationCmd = &cobra.Command{
-	Use:     "org",
-	Aliases: []string{"organization"},
-	Short:   "Organization management commands",
-	Run:     organizationF,
+func organizationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "org",
+		Aliases: []string{"organization"},
+		Short:   "Organization management commands",
+		Run:     organizationF,
+	}
+
+	cmd.AddCommand(
+		orgCreateCmd(),
+		orgDeleteCmd(),
+		orgFindCmd(),
+		orgMembersCmd(),
+		orgUpdateCmd(),
+	)
+
+	return cmd
 }
 
 func organizationF(cmd *cobra.Command, args []string) {
@@ -30,17 +41,17 @@ type OrganizationCreateFlags struct {
 
 var organizationCreateFlags OrganizationCreateFlags
 
-func init() {
-	organizationCreateCmd := &cobra.Command{
+func orgCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create organization",
 		RunE:  wrapCheckSetup(organizationCreateF),
 	}
 
-	organizationCreateCmd.Flags().StringVarP(&organizationCreateFlags.name, "name", "n", "", "The name of organization that will be created")
-	organizationCreateCmd.MarkFlagRequired("name")
+	cmd.Flags().StringVarP(&organizationCreateFlags.name, "name", "n", "", "The name of organization that will be created")
+	cmd.MarkFlagRequired("name")
 
-	organizationCmd.AddCommand(organizationCreateCmd)
+	return cmd
 }
 
 func newOrganizationService(f Flags) (platform.OrganizationService, error) {
@@ -90,17 +101,17 @@ type OrganizationFindFlags struct {
 
 var organizationFindFlags OrganizationFindFlags
 
-func init() {
-	organizationFindCmd := &cobra.Command{
+func orgFindCmd() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "find",
 		Short: "Find organizations",
 		RunE:  wrapCheckSetup(organizationFindF),
 	}
 
-	organizationFindCmd.Flags().StringVarP(&organizationFindFlags.name, "name", "n", "", "The organization name")
-	organizationFindCmd.Flags().StringVarP(&organizationFindFlags.id, "id", "i", "", "The organization ID")
+	cmd.Flags().StringVarP(&organizationFindFlags.name, "name", "n", "", "The organization name")
+	cmd.Flags().StringVarP(&organizationFindFlags.id, "id", "i", "", "The organization ID")
 
-	organizationCmd.AddCommand(organizationFindCmd)
+	return cmd
 }
 
 func organizationFindF(cmd *cobra.Command, args []string) error {
@@ -151,18 +162,18 @@ type OrganizationUpdateFlags struct {
 
 var organizationUpdateFlags OrganizationUpdateFlags
 
-func init() {
-	organizationUpdateCmd := &cobra.Command{
+func orgUpdateCmd() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update organization",
 		RunE:  wrapCheckSetup(organizationUpdateF),
 	}
 
-	organizationUpdateCmd.Flags().StringVarP(&organizationUpdateFlags.id, "id", "i", "", "The organization ID (required)")
-	organizationUpdateCmd.Flags().StringVarP(&organizationUpdateFlags.name, "name", "n", "", "The organization name")
-	organizationUpdateCmd.MarkFlagRequired("id")
+	cmd.Flags().StringVarP(&organizationUpdateFlags.id, "id", "i", "", "The organization ID (required)")
+	cmd.Flags().StringVarP(&organizationUpdateFlags.name, "name", "n", "", "The organization name")
+	cmd.MarkFlagRequired("id")
 
-	organizationCmd.AddCommand(organizationUpdateCmd)
+	return cmd
 }
 
 func organizationUpdateF(cmd *cobra.Command, args []string) error {
@@ -244,28 +255,33 @@ func organizationDeleteF(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func init() {
-	organizationDeleteCmd := &cobra.Command{
+func orgDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete organization",
 		RunE:  wrapCheckSetup(organizationDeleteF),
 	}
 
-	organizationDeleteCmd.Flags().StringVarP(&organizationDeleteFlags.id, "id", "i", "", "The organization ID (required)")
-	organizationDeleteCmd.MarkFlagRequired("id")
+	cmd.Flags().StringVarP(&organizationDeleteFlags.id, "id", "i", "", "The organization ID (required)")
+	cmd.MarkFlagRequired("id")
 
-	organizationCmd.AddCommand(organizationDeleteCmd)
+	return cmd
 }
 
-// Member management
-var organizationMembersCmd = &cobra.Command{
-	Use:   "members",
-	Short: "Organization membership commands",
-	Run:   organizationF,
-}
+func orgMembersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "members",
+		Short: "Organization membership commands",
+		Run:   organizationF,
+	}
 
-func init() {
-	organizationCmd.AddCommand(organizationMembersCmd)
+	cmd.AddCommand(
+		orgMembersAddCmd(),
+		orgMembersListCmd(),
+		orgMembersRemoveCmd(),
+	)
+
+	return cmd
 }
 
 // List Members
@@ -312,17 +328,17 @@ func organizationMembersListF(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func init() {
-	organizationMembersListCmd := &cobra.Command{
+func orgMembersListCmd() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List organization members",
 		RunE:  wrapCheckSetup(organizationMembersListF),
 	}
 
-	organizationMembersListCmd.Flags().StringVarP(&organizationMembersListFlags.id, "id", "i", "", "The organization ID")
-	organizationMembersListCmd.Flags().StringVarP(&organizationMembersListFlags.name, "name", "n", "", "The organization name")
+	cmd.Flags().StringVarP(&organizationMembersListFlags.id, "id", "i", "", "The organization ID")
+	cmd.Flags().StringVarP(&organizationMembersListFlags.name, "name", "n", "", "The organization name")
 
-	organizationMembersCmd.AddCommand(organizationMembersListCmd)
+	return cmd
 }
 
 // OrganizationMembersAddFlags includes flags to add a member
@@ -383,19 +399,19 @@ func organizationMembersAddF(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func init() {
-	organizationMembersAddCmd := &cobra.Command{
+func orgMembersAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add organization member",
 		RunE:  wrapCheckSetup(organizationMembersAddF),
 	}
 
-	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.id, "id", "i", "", "The organization ID")
-	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.name, "name", "n", "", "The organization name")
-	organizationMembersAddCmd.Flags().StringVarP(&organizationMembersAddFlags.memberID, "member", "o", "", "The member ID")
-	organizationMembersAddCmd.MarkFlagRequired("member")
+	cmd.Flags().StringVarP(&organizationMembersAddFlags.id, "id", "i", "", "The organization ID")
+	cmd.Flags().StringVarP(&organizationMembersAddFlags.name, "name", "n", "", "The organization name")
+	cmd.Flags().StringVarP(&organizationMembersAddFlags.memberID, "member", "o", "", "The member ID")
+	cmd.MarkFlagRequired("member")
 
-	organizationMembersCmd.AddCommand(organizationMembersAddCmd)
+	return cmd
 }
 
 // OrganizationMembersRemoveFlags includes flags to remove a Member
@@ -450,17 +466,17 @@ func organizationMembersRemoveF(cmd *cobra.Command, args []string) error {
 	return membersRemoveF(ctx, organization.ID, memberID)
 }
 
-func init() {
-	organizationMembersRemoveCmd := &cobra.Command{
+func orgMembersRemoveCmd() *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove organization member",
 		RunE:  wrapCheckSetup(organizationMembersRemoveF),
 	}
 
-	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.id, "id", "i", "", "The organization ID")
-	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.name, "name", "n", "", "The organization name")
-	organizationMembersRemoveCmd.Flags().StringVarP(&organizationMembersRemoveFlags.memberID, "member", "o", "", "The member ID")
-	organizationMembersRemoveCmd.MarkFlagRequired("member")
+	cmd.Flags().StringVarP(&organizationMembersRemoveFlags.id, "id", "i", "", "The organization ID")
+	cmd.Flags().StringVarP(&organizationMembersRemoveFlags.name, "name", "n", "", "The organization name")
+	cmd.Flags().StringVarP(&organizationMembersRemoveFlags.memberID, "member", "o", "", "The member ID")
+	cmd.MarkFlagRequired("member")
 
-	organizationMembersCmd.AddCommand(organizationMembersRemoveCmd)
+	return cmd
 }


### PR DESCRIPTION
cleans up the extraneous `init()` calls. part of a larger effort to minimize startup times.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass

depends on: #15938 