### PR TITLE
fix(influx): bad shorthand var for pkg command

### DIFF
--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -46,7 +46,7 @@ func pkgApplyCmd() *cobra.Command {
 	cmd.MarkFlagRequired("org-id")
 
 	hasColor := cmd.Flags().BoolP("color", "c", true, "Enable color in output, defaults true")
-	hasTableBorders := cmd.Flags().BoolP("table-borders", "tb", true, "Enable table borders, defaults true")
+	hasTableBorders := cmd.Flags().Bool("table-borders", true, "Enable table borders, defaults true")
 
 	cmd.RunE = pkgApplyRunEFn(orgID, path, hasColor, hasTableBorders)
 


### PR DESCRIPTION
drops unneccessary shorthand for table borders that was causing panic (should be 1 char, but had 2). In hindsight, a shorthand here doesn't do us much good 🤷‍♂ 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass