### PR TITLE
fix(getResourcesStatus): added checks for status prop in getResourceStatus

### DIFF
--- a/ui/src/shared/selectors/getResourcesStatus.ts
+++ b/ui/src/shared/selectors/getResourcesStatus.ts
@@ -6,27 +6,24 @@ export const getResourcesStatus = (
   state: AppState,
   {resources}: Props
 ): RemoteDataState => {
-  const resourceExists = (state, resource): boolean =>
-    state[resource] && state[resource].status
-
   const done = resources.every(resource => {
-    if (resourceExists(state, resource)) {
+    if (state[resource] && state[resource].status) {
       return state[resource].status === 'Done'
     }
     return false
   })
 
   const loading = resources.some(resource => {
-    if (resourceExists(state, resource)) {
+    if (state[resource] && state[resource].status) {
       return state[resource].status === 'Loading'
     }
   })
 
   const error = resources.some(resource => {
-    if (resourceExists(state, resource)) {
+    if (state[resource] && state[resource].status) {
       return state[resource].status === 'Error'
     }
-    if (resourceExists(state, resource) === false) {
+    if (state[resource] && state[resource].status === false) {
       // if the resource doesn't exist in the state return an error
       return true
     }

--- a/ui/src/shared/selectors/getResourcesStatus.ts
+++ b/ui/src/shared/selectors/getResourcesStatus.ts
@@ -9,20 +9,20 @@ export const getResourcesStatus = (
   const resourceExists = (state, resource): boolean =>
     state[resource] && state[resource].status
 
-  const done = resources.every((resource) => {
+  const done = resources.every(resource => {
     if (resourceExists(state, resource)) {
       return state[resource].status === 'Done'
     }
     return false
   })
 
-  const loading = resources.some((resource) => {
+  const loading = resources.some(resource => {
     if (resourceExists(state, resource)) {
       return state[resource].status === 'Loading'
     }
   })
 
-  const error = resources.some((resource) => {
+  const error = resources.some(resource => {
     if (resourceExists(state, resource)) {
       return state[resource].status === 'Error'
     }

--- a/ui/src/shared/selectors/getResourcesStatus.ts
+++ b/ui/src/shared/selectors/getResourcesStatus.ts
@@ -6,16 +6,30 @@ export const getResourcesStatus = (
   state: AppState,
   {resources}: Props
 ): RemoteDataState => {
-  const done = resources.every(resource => {
-    return state[resource].status === 'Done'
+  const resourceExists = (state, resource): boolean =>
+    state[resource] && state[resource].status
+
+  const done = resources.every((resource) => {
+    if (resourceExists(state, resource)) {
+      return state[resource].status === 'Done'
+    }
+    return false
   })
 
-  const loading = resources.some(resource => {
-    return state[resource].status === 'Loading'
+  const loading = resources.some((resource) => {
+    if (resourceExists(state, resource)) {
+      return state[resource].status === 'Loading'
+    }
   })
 
-  const error = resources.some(resource => {
-    return state[resource].status === 'Error'
+  const error = resources.some((resource) => {
+    if (resourceExists(state, resource)) {
+      return state[resource].status === 'Error'
+    }
+    if (resourceExists(state, resource) === false) {
+      // if the resource doesn't exist in the state return an error
+      return true
+    }
   })
 
   let status = RemoteDataState.NotStarted


### PR DESCRIPTION
Closes #15865

### Problem

getResourceStatus threw an error: `Cannot read property 'status' of undefined`

### Solution

Added helper function before checking to see whether the resource is defined in the state before checking the status. Also added in a default error for when the resource is undefined on the state