### PR TITLE
fix(cli): add organization back to bucket response

### DIFF
--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -90,14 +90,13 @@ func bucketCreateF(cmd *cobra.Command, args []string) error {
 		"ID",
 		"Name",
 		"Retention",
-		"Org",
 		"OrganizationID",
 	)
 	w.Write(map[string]interface{}{
-		"ID":        b.ID.String(),
-		"Name":      b.Name,
-		"Retention": b.RetentionPeriod,
-		"OrgID":     b.OrgID.String(),
+		"ID":             b.ID.String(),
+		"Name":           b.Name,
+		"Retention":      b.RetentionPeriod,
+		"OrganizationID": b.OrgID.String(),
 	})
 	w.Flush()
 
@@ -174,15 +173,14 @@ func bucketFindF(cmd *cobra.Command, args []string) error {
 		"ID",
 		"Name",
 		"Retention",
-		"Org",
 		"OrganizationID",
 	)
 	for _, b := range buckets {
 		w.Write(map[string]interface{}{
-			"ID":        b.ID.String(),
-			"Name":      b.Name,
-			"Retention": b.RetentionPeriod,
-			"OrgID":     b.OrgID.String(),
+			"ID":             b.ID.String(),
+			"Name":           b.Name,
+			"Retention":      b.RetentionPeriod,
+			"OrganizationID": b.OrgID.String(),
 		})
 	}
 	w.Flush()
@@ -243,14 +241,13 @@ func bucketUpdateF(cmd *cobra.Command, args []string) error {
 		"ID",
 		"Name",
 		"Retention",
-		"Organization",
 		"OrganizationID",
 	)
 	w.Write(map[string]interface{}{
-		"ID":        b.ID.String(),
-		"Name":      b.Name,
-		"Retention": b.RetentionPeriod,
-		"OrgID":     b.OrgID.String(),
+		"ID":             b.ID.String(),
+		"Name":           b.Name,
+		"Retention":      b.RetentionPeriod,
+		"OrganizationID": b.OrgID.String(),
 	})
 	w.Flush()
 
@@ -290,16 +287,15 @@ func bucketDeleteF(cmd *cobra.Command, args []string) error {
 		"ID",
 		"Name",
 		"Retention",
-		"Organization",
 		"OrganizationID",
 		"Deleted",
 	)
 	w.Write(map[string]interface{}{
-		"ID":        b.ID.String(),
-		"Name":      b.Name,
-		"Retention": b.RetentionPeriod,
-		"OrgID":     b.OrgID.String(),
-		"Deleted":   true,
+		"ID":             b.ID.String(),
+		"Name":           b.Name,
+		"Retention":      b.RetentionPeriod,
+		"OrganizationID": b.OrgID.String(),
+		"Deleted":        true,
 	})
 	w.Flush()
 


### PR DESCRIPTION
ref #15828 

This fixes a mismatch between tabwriter keys introduced by 9d44ac3635b2800c1dd8e90ac23729e1d298eb0a.

It's probably worth considering adding org names back in the response. Expecting users to work with orgIDs for everything feels like bad UX when it's really an internal implementation detail.