### PR TITLE
chore: ignore 2.0 build artefacts via gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,8 @@ man/*.1.gz
 # vendored files
 /vendor
 /gen
+
+# 2.0 build artefacts
+/chronograf
+/http
+/ui


### PR DESCRIPTION
If you move between `master` and `1.8` you can end up with a bunch of stuff in your working directory that git wants to stage. However these build artefacts are not relevant to 1.8.

This PR adds them to the `.gitignore` file.