### PR TITLE
refactor(ui): redesign org profile tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v2.0.0-alpha.20 [unreleased]
 
-### Feaures
+### Features
 
 1. [15805](https://github.com/influxdata/influxdb/pull/15924) Add tls insecure skip verify to influx CLI.
 
@@ -13,6 +13,7 @@
 
 ### UI Improvements
 1. [15809](https://github.com/influxdata/influxdb/pull/15809): Redesign cards and animations on getting started page
+1. [15965](https://github.com/influxdata/influxdb/pull/15965): Display organization name and ID within the "Org Profile" settings tab
 
 ## v2.0.0-alpha.19 [2019-10-30]
 

--- a/ui/src/organizations/components/OrgProfileTab.tsx
+++ b/ui/src/organizations/components/OrgProfileTab.tsx
@@ -1,84 +1,102 @@
 // Libraries
-import React, {PureComponent} from 'react'
+import React, {FunctionComponent} from 'react'
 import {WithRouterProps, withRouter} from 'react-router'
-
 import _ from 'lodash'
 
 // Components
 import {
   Form,
   Button,
+  Alert,
   ComponentSize,
   Panel,
   IconFont,
   FlexBox,
   AlignItems,
   FlexDirection,
-  Gradients,
   InfluxColors,
   JustifyContent,
+  Table,
+  BorderType,
+  ComponentColor,
+  ButtonType,
 } from '@influxdata/clockface'
-import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {ButtonType} from 'src/clockface'
-
-type Props = WithRouterProps
-
-@ErrorHandling
-class OrgProfileTab extends PureComponent<Props> {
-  public render() {
-    return (
-      <Panel backgroundColor={InfluxColors.Onyx}>
-        <Panel.Header size={ComponentSize.Small}>
-          <Panel.Title size={ComponentSize.Small}>
-            Organization Profile
-          </Panel.Title>
-        </Panel.Header>
-        <Panel.Body size={ComponentSize.Small}>
-          <Form onSubmit={this.handleShowEditOverlay}>
-            <Panel gradient={Gradients.DocScott}>
-              <Panel.Header size={ComponentSize.ExtraSmall}>
-                <Panel.Title size={ComponentSize.ExtraSmall}>
-                  Danger Zone!
-                </Panel.Title>
-              </Panel.Header>
-              <Panel.Body size={ComponentSize.ExtraSmall}>
-                <FlexBox
-                  stretchToFitWidth={true}
-                  alignItems={AlignItems.Center}
-                  direction={FlexDirection.Row}
-                  justifyContent={JustifyContent.SpaceBetween}
-                >
-                  <div>
-                    <h5 style={{marginBottom: '0'}}>Rename Organization</h5>
-                    <p style={{marginTop: '2px'}}>
-                      This action can have wide-reaching unintended
-                      consequences.
-                    </p>
-                  </div>
-                  <Button
-                    text="Rename"
-                    icon={IconFont.Pencil}
-                    type={ButtonType.Submit}
-                  />
-                </FlexBox>
-              </Panel.Body>
-            </Panel>
-          </Form>
-        </Panel.Body>
-      </Panel>
-    )
-  }
-
-  private handleShowEditOverlay = () => {
-    const {
-      params: {orgID},
-      router,
-    } = this.props
-
-    router.push(`/orgs/${orgID}/settings/profile/rename`)
-  }
+interface OwnProps {
+  orgID: string
+  orgName: string
 }
 
-export default withRouter<{}>(OrgProfileTab)
+type Props = WithRouterProps & OwnProps
+
+const OrgProfileTab: FunctionComponent<Props> = ({orgID, orgName, router}) => {
+  const handleShowEditOverlay = () => {
+    router.push(`/orgs/${orgID}/settings/profile/rename`)
+  }
+
+  return (
+    <Panel backgroundColor={InfluxColors.Onyx}>
+      <Panel.Header size={ComponentSize.Small}>
+        <Panel.Title size={ComponentSize.Small}>
+          About this Organization
+        </Panel.Title>
+      </Panel.Header>
+      <Panel.Body size={ComponentSize.Small}>
+        <Table
+          borders={BorderType.All}
+          style={{marginBottom: '18px', width: '100%'}}
+        >
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell
+                style={{width: '60px', borderColor: InfluxColors.Smoke}}
+              >
+                <strong>Name</strong>
+              </Table.Cell>
+              <Table.Cell style={{borderColor: InfluxColors.Smoke}}>
+                {orgName}
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell
+                style={{width: '60px', borderColor: InfluxColors.Smoke}}
+              >
+                <strong>ID</strong>
+              </Table.Cell>
+              <Table.Cell style={{borderColor: InfluxColors.Smoke}}>
+                {orgID}
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+        <Form onSubmit={handleShowEditOverlay}>
+          <Alert color={ComponentColor.Danger} icon={IconFont.AlertTriangle}>
+            <FlexBox
+              stretchToFitWidth={true}
+              alignItems={AlignItems.Center}
+              direction={FlexDirection.Row}
+              justifyContent={JustifyContent.SpaceBetween}
+              style={{padding: '6px'}}
+            >
+              <div>
+                <h4 style={{marginBottom: '0'}}>Danger Zone!</h4>
+                <p style={{marginTop: '2px'}}>
+                  This action can have wide-reaching unintended consequences.
+                </p>
+              </div>
+              <Button
+                color={ComponentColor.Danger}
+                text="Rename Organization"
+                icon={IconFont.Pencil}
+                type={ButtonType.Submit}
+              />
+            </FlexBox>
+          </Alert>
+        </Form>
+      </Panel.Body>
+    </Panel>
+  )
+}
+
+export default withRouter<OwnProps>(OrgProfileTab)

--- a/ui/src/organizations/containers/OrgProfilePage.tsx
+++ b/ui/src/organizations/containers/OrgProfilePage.tsx
@@ -32,7 +32,7 @@ class OrgProfilePage extends Component<StateProps> {
             <Grid>
               <Grid.Row>
                 <Grid.Column widthXS={Columns.Twelve} widthSM={Columns.Six}>
-                  <OrgProfileTab />
+                  <OrgProfileTab orgID={org.id} orgName={org.name} />
                 </Grid.Column>
               </Grid.Row>
             </Grid>


### PR DESCRIPTION
Closes #15964 

Display organization name and id in the "Org Profile" settings tab

![Screen Shot 2019-11-18 at 2 32 15 PM](https://user-images.githubusercontent.com/2433762/69100000-07cfc480-0a11-11ea-86f3-dedc6808a274.png)

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
