### PR TITLE
fix(ui): Delay threshold re-rendering until mouse up when dragging markers

### DIFF
--- a/ui/src/shared/components/GreaterThresholdMarker.tsx
+++ b/ui/src/shared/components/GreaterThresholdMarker.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import {Scale} from '@influxdata/giraffe'
 
 // Components
@@ -18,6 +18,7 @@ interface Props {
   yDomain: number[]
   threshold: GreaterThreshold
   onChangePos: (e: DragEvent) => void
+  onMouseUp: (e: MouseEvent<HTMLDivElement>) => void
 }
 
 const GreaterThresholdMarker: FunctionComponent<Props> = ({
@@ -25,13 +26,19 @@ const GreaterThresholdMarker: FunctionComponent<Props> = ({
   yScale,
   threshold: {level, value},
   onChangePos,
+  onMouseUp,
 }) => {
   const y = yScale(clamp(value, yDomain))
 
   return (
     <>
       {isInDomain(value, yDomain) && (
-        <ThresholdMarker level={level} y={y} onDrag={onChangePos} />
+        <ThresholdMarker
+          level={level}
+          y={y}
+          onDrag={onChangePos}
+          onMouseUp={onMouseUp}
+        />
       )}
       {value <= yDomain[1] && (
         <ThresholdMarkerArea

--- a/ui/src/shared/components/LessThresholdMarker.tsx
+++ b/ui/src/shared/components/LessThresholdMarker.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import {Scale} from '@influxdata/giraffe'
 
 // Components
@@ -18,6 +18,7 @@ interface Props {
   yDomain: number[]
   threshold: LesserThreshold
   onChangePos: (e: DragEvent) => void
+  onMouseUp: (e: MouseEvent<HTMLDivElement>) => void
 }
 
 const LessThresholdMarker: FunctionComponent<Props> = ({
@@ -25,13 +26,19 @@ const LessThresholdMarker: FunctionComponent<Props> = ({
   yDomain,
   threshold: {level, value},
   onChangePos,
+  onMouseUp,
 }) => {
   const y = yScale(clamp(value, yDomain))
 
   return (
     <>
       {isInDomain(value, yDomain) && (
-        <ThresholdMarker level={level} y={y} onDrag={onChangePos} />
+        <ThresholdMarker
+          level={level}
+          y={y}
+          onDrag={onChangePos}
+          onMouseUp={onMouseUp}
+        />
       )}
       {value >= yDomain[0] && (
         <ThresholdMarkerArea

--- a/ui/src/shared/components/RangeThresholdMarkers.tsx
+++ b/ui/src/shared/components/RangeThresholdMarkers.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import {Scale} from '@influxdata/giraffe'
 
 // Components
@@ -19,6 +19,7 @@ interface Props {
   threshold: RangeThreshold
   onChangeMaxPos: (e: DragEvent) => void
   onChangeMinPos: (e: DragEvent) => void
+  onMouseUp: (e: MouseEvent<HTMLDivElement>) => void
 }
 
 const RangeThresholdMarkers: FunctionComponent<Props> = ({
@@ -27,6 +28,7 @@ const RangeThresholdMarkers: FunctionComponent<Props> = ({
   threshold: {level, within, min, max},
   onChangeMinPos,
   onChangeMaxPos,
+  onMouseUp,
 }) => {
   const minY = yScale(clamp(min, yDomain))
   const maxY = yScale(clamp(max, yDomain))
@@ -34,10 +36,20 @@ const RangeThresholdMarkers: FunctionComponent<Props> = ({
   return (
     <>
       {isInDomain(min, yDomain) && (
-        <ThresholdMarker level={level} y={minY} onDrag={onChangeMinPos} />
+        <ThresholdMarker
+          level={level}
+          y={minY}
+          onDrag={onChangeMinPos}
+          onMouseUp={onMouseUp}
+        />
       )}
       {isInDomain(max, yDomain) && (
-        <ThresholdMarker level={level} y={maxY} onDrag={onChangeMaxPos} />
+        <ThresholdMarker
+          level={level}
+          y={maxY}
+          onDrag={onChangeMaxPos}
+          onMouseUp={onMouseUp}
+        />
       )}
       {within ? (
         <ThresholdMarkerArea level={level} top={maxY} height={minY - maxY} />

--- a/ui/src/shared/components/ThresholdMarker.tsx
+++ b/ui/src/shared/components/ThresholdMarker.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 
 // Utils
 import {useDragBehavior, DragEvent} from 'src/shared/utils/useDragBehavior'
@@ -11,9 +11,15 @@ interface Props {
   level: CheckStatusLevel
   y: number
   onDrag: (e: DragEvent) => void
+  onMouseUp: (e: MouseEvent<HTMLDivElement>) => void
 }
 
-const ThresholdMarker: FunctionComponent<Props> = ({level, y, onDrag}) => {
+const ThresholdMarker: FunctionComponent<Props> = ({
+  level,
+  y,
+  onDrag,
+  onMouseUp,
+}) => {
   const dragTargetProps = useDragBehavior(onDrag)
   const levelClass = `threshold-marker--${level.toLowerCase()}`
   const style = {top: `${y}px`}
@@ -25,6 +31,7 @@ const ThresholdMarker: FunctionComponent<Props> = ({level, y, onDrag}) => {
         className={`threshold-marker--handle ${levelClass}`}
         style={style}
         {...dragTargetProps}
+        onMouseUp={onMouseUp}
       />
     </>
   )


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15832

Single marker dragging fix:

![single_marker_dragging](https://user-images.githubusercontent.com/10736577/69178324-38216c80-0abe-11ea-8ded-c181f6c444af.gif)


Double marker dragging fix:

![double_marker_dragging](https://user-images.githubusercontent.com/10736577/69178345-41123e00-0abe-11ea-861e-bc63157b2bac.gif)

