### PR TITLE
feat(ui): lazy load monaco in runtime

### DIFF
--- a/ui/global.d.ts
+++ b/ui/global.d.ts
@@ -2,4 +2,3 @@
 // got some globals here that only exist during compilation
 //
 
-declare var ENABLE_MONACO: string

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -5,6 +5,7 @@ const OSS_FLAGS = {
   alerting: false,
   eventMarkers: false,
   deleteWithPredicate: false,
+  monacoEditor: false,
   downloadCellCSV: false,
 }
 
@@ -12,6 +13,7 @@ const CLOUD_FLAGS = {
   alerting: true,
   eventMarkers: false,
   deleteWithPredicate: false,
+  monacoEditor: false,
   cloudBilling: CLOUD_BILLING_VISIBLE, // should be visible in dev and acceptance, but not in cloud
   downloadCellCSV: false,
 }
@@ -44,6 +46,52 @@ export const FeatureFlag: FunctionComponent<{name: string}> = ({
   return children as any
 }
 
+export const NegativeFeatureFlag: FunctionComponent<{name: string}> = ({
+  name,
+  children,
+}) => {
+  if (isFlagEnabled(name)) {
+    return null
+  }
+
+  return children as any
+}
+
+const list = () => {
+  console.log(
+    'Currently Available Feature Flags'
+  )
+  if (CLOUD) {
+    console.table(CLOUD_FLAGS)
+  } else {
+    console.table(OSS_FLAGS)
+  }
+}
+
+const reset = () => {
+  const featureFlags = JSON.parse(window.localStorage.featureFlags || '{}')
+
+  if (CLOUD) {
+    Object.keys(featureFlags).forEach((k) => {
+      if (!CLOUD_FLAGS.hasOwnProperty(k)) {
+        delete featureFlags[k]
+      } else {
+        featureFlags[k] = CLOUD_FLAGS[k]
+      }
+    })
+  } else {
+    Object.keys(featureFlags).forEach((k) => {
+      if (!CLOUD_FLAGS.hasOwnProperty(k)) {
+        delete featureFlags[k]
+      } else {
+        featureFlags[k] = CLOUD_FLAGS[k]
+      }
+    })
+  }
+
+  window.localStorage.featureFlags = JSON.stringify(featureFlags)
+}
+
 export const toggleLocalStorageFlag = (flagName: string) => {
   const featureFlags = JSON.parse(window.localStorage.featureFlags || '{}')
 
@@ -57,4 +105,4 @@ export const toggleLocalStorageFlag = (flagName: string) => {
 // Expose utility in dev tools console for convenience
 const w: any = window
 
-w.influx = {toggleFeature: toggleLocalStorageFlag}
+w.influx = {toggleFeature: toggleLocalStorageFlag, list, reset}

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -57,22 +57,22 @@ export const NegativeFeatureFlag: FunctionComponent<{name: string}> = ({
   return children as any
 }
 
+/* eslint-disable no-console */
 const list = () => {
-  console.log(
-    'Currently Available Feature Flags'
-  )
+  console.log('Currently Available Feature Flags')
   if (CLOUD) {
     console.table(CLOUD_FLAGS)
   } else {
     console.table(OSS_FLAGS)
   }
 }
+/* eslint-enable no-console */
 
 const reset = () => {
   const featureFlags = JSON.parse(window.localStorage.featureFlags || '{}')
 
   if (CLOUD) {
-    Object.keys(featureFlags).forEach((k) => {
+    Object.keys(featureFlags).forEach(k => {
       if (!CLOUD_FLAGS.hasOwnProperty(k)) {
         delete featureFlags[k]
       } else {
@@ -80,7 +80,7 @@ const reset = () => {
       }
     })
   } else {
-    Object.keys(featureFlags).forEach((k) => {
+    Object.keys(featureFlags).forEach(k => {
       if (!CLOUD_FLAGS.hasOwnProperty(k)) {
         delete featureFlags[k]
       } else {

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.scss
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.scss
@@ -25,3 +25,20 @@
   width: 100%;
   height: 100%;
 }
+
+.time-machine-editor--loading {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  background: #292933;
+
+  &:after {
+    content: '';
+    position: absolute;
+    background: #202028;
+    top: 8px;
+    bottom: 8px;
+    left: 24px;
+    right: 8px;
+  }
+}

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -5,15 +5,14 @@ import {Position} from 'codemirror'
 
 // Components
 const FluxEditor = React.lazy(() => import('src/shared/components/FluxEditor'))
-const FluxMonacoEditor = React.lazy(() => import('src/shared/components/FluxMonacoEditor'))
+const FluxMonacoEditor = React.lazy(() =>
+  import('src/shared/components/FluxMonacoEditor')
+)
 import Threesizer from 'src/shared/components/threesizer/Threesizer'
 import FluxFunctionsToolbar from 'src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar'
 import VariableToolbar from 'src/timeMachine/components/variableToolbar/VariableToolbar'
 import ToolbarTab from 'src/timeMachine/components/ToolbarTab'
-import {
-  FeatureFlag,
-  NegativeFeatureFlag
-} from 'src/shared/utils/featureFlag'
+import {FeatureFlag, NegativeFeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Actions
 import {setActiveQueryText} from 'src/timeMachine/actions'
@@ -45,9 +44,7 @@ interface State {
 
 type Props = StateProps & DispatchProps
 
-const spinner = (
-  <div className="time-machine-editor--loading" />
-)
+const spinner = <div className="time-machine-editor--loading" />
 
 class TimeMachineFluxEditor extends PureComponent<Props, State> {
   private cursorPosition: Position = {line: 0, ch: 0}
@@ -66,7 +63,7 @@ class TimeMachineFluxEditor extends PureComponent<Props, State> {
         render: () => {
           return (
             <>
-              <Suspense fallback={spinner} >
+              <Suspense fallback={spinner}>
                 <FeatureFlag name="monacoEditor">
                   <FluxMonacoEditor
                     script={activeQueryText}

--- a/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
+++ b/ui/src/timeMachine/components/TimeMachineFluxEditor.tsx
@@ -12,7 +12,7 @@ import Threesizer from 'src/shared/components/threesizer/Threesizer'
 import FluxFunctionsToolbar from 'src/timeMachine/components/fluxFunctionsToolbar/FluxFunctionsToolbar'
 import VariableToolbar from 'src/timeMachine/components/variableToolbar/VariableToolbar'
 import ToolbarTab from 'src/timeMachine/components/ToolbarTab'
-import {FeatureFlag, NegativeFeatureFlag} from 'src/shared/utils/featureFlag'
+import {FeatureFlag} from 'src/shared/utils/featureFlag'
 
 // Actions
 import {setActiveQueryText} from 'src/timeMachine/actions'
@@ -72,7 +72,7 @@ class TimeMachineFluxEditor extends PureComponent<Props, State> {
                     onCursorChange={this.handleCursorPosition}
                   />
                 </FeatureFlag>
-                <NegativeFeatureFlag name="monacoEditor">
+                <FeatureFlag name="monacoEditor" equals={false}>
                   <FluxEditor
                     script={activeQueryText}
                     status={{type: '', text: ''}}
@@ -81,7 +81,7 @@ class TimeMachineFluxEditor extends PureComponent<Props, State> {
                     suggestions={[]}
                     onCursorChange={this.handleCursorPosition}
                   />
-                </NegativeFeatureFlag>
+                </FeatureFlag>
               </Suspense>
             </>
           )

--- a/ui/webpack.common.ts
+++ b/ui/webpack.common.ts
@@ -109,9 +109,6 @@ module.exports = {
     }),
     new ForkTsCheckerWebpackPlugin(),
     new webpack.ProgressPlugin(),
-    new webpack.DefinePlugin({
-      ENABLE_MONACO: JSON.stringify(false)
-    }),
     new webpack.EnvironmentPlugin({...process.env, GIT_SHA, API_PREFIX: API_BASE_PATH, STATIC_PREFIX: BASE_PATH}),
   ],
   stats: {


### PR DESCRIPTION
Closes #15955

This allows the user to switch to using monaco through the feature flag mechanism we use for testing. As the monaco codebase is fairly large and its impact on performance hasn't been charted, I made the feature flag lazy load the libraries on switch to prevent our customers from seeing an impact in production.