### PR TITLE
feat: add support for setting password and org for a new user in the cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## v2.0.0-alpha.20 [unreleased]
 
-### Feaures
+### Features
 
 1. [15805](https://github.com/influxdata/influxdb/pull/15924) Add tls insecure skip verify to influx CLI.
+2. [15981](https://github.com/influxdata/influxdb/pull/15981) Extend influx cli user create to allow for organization ID and user passwords to be set on user.
 
 ### Bug Fixes
 

--- a/authorizer/password.go
+++ b/authorizer/password.go
@@ -1,0 +1,38 @@
+package authorizer
+
+import (
+	"context"
+
+	"github.com/influxdata/influxdb"
+)
+
+// PasswordService is a new authorization middleware for a password service.
+type PasswordService struct {
+	next influxdb.PasswordsService
+}
+
+// NewPasswordService wraps an existing password service with auth middlware.
+func NewPasswordService(svc influxdb.PasswordsService) *PasswordService {
+	return &PasswordService{next: svc}
+}
+
+// SetPassword overrides the password of a known user.
+func (s *PasswordService) SetPassword(ctx context.Context, userID influxdb.ID, password string) error {
+	if err := authorizeWriteUser(ctx, userID); err != nil {
+		return err
+	}
+
+	return s.next.SetPassword(ctx, userID, password)
+}
+
+// ComparePassword checks if the password matches the password recorded.
+// Passwords that do not match return errors.
+func (s *PasswordService) ComparePassword(ctx context.Context, userID influxdb.ID, password string) error {
+	panic("not implemented")
+}
+
+// CompareAndSetPassword checks the password and if they match
+// updates to the new password.
+func (s *PasswordService) CompareAndSetPassword(ctx context.Context, userID influxdb.ID, old string, new string) error {
+	panic("not implemented")
+}

--- a/authorizer/password_test.go
+++ b/authorizer/password_test.go
@@ -1,0 +1,105 @@
+package authorizer_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/authorizer"
+	icontext "github.com/influxdata/influxdb/context"
+	"github.com/influxdata/influxdb/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPasswordService(t *testing.T) {
+	t.Run("SetPassword", func(t *testing.T) {
+		t.Run("user with permissions should proceed", func(t *testing.T) {
+			userID := influxdb.ID(1)
+
+			permission := influxdb.Permission{
+				Action: influxdb.WriteAction,
+				Resource: influxdb.Resource{
+					Type: influxdb.UsersResourceType,
+					ID:   &userID,
+				},
+			}
+
+			fakeSVC := mock.NewPasswordsService()
+			fakeSVC.SetPasswordFn = func(_ context.Context, _ influxdb.ID, _ string) error {
+				return nil
+			}
+			s := authorizer.NewPasswordService(fakeSVC)
+
+			ctx := icontext.SetAuthorizer(context.Background(), &Authorizer{
+				Permissions: []influxdb.Permission{permission},
+			})
+
+			err := s.SetPassword(ctx, 1, "password")
+			require.NoError(t, err)
+		})
+
+		t.Run("user without permissions should proceed", func(t *testing.T) {
+			goodUserID := influxdb.ID(1)
+			badUserID := influxdb.ID(3)
+
+			tests := []struct {
+				name          string
+				badPermission influxdb.Permission
+			}{
+				{
+					name: "has no access",
+				},
+				{
+					name: "has read only access on correct resource",
+					badPermission: influxdb.Permission{
+						Action: influxdb.ReadAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.UsersResourceType,
+							ID:   &goodUserID,
+						},
+					},
+				},
+				{
+					name: "has write access on incorrect resource",
+					badPermission: influxdb.Permission{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.OrgsResourceType,
+							ID:   &goodUserID,
+						},
+					},
+				},
+				{
+					name: "user accessing user that is not self",
+					badPermission: influxdb.Permission{
+						Action: influxdb.WriteAction,
+						Resource: influxdb.Resource{
+							Type: influxdb.UsersResourceType,
+							ID:   &badUserID,
+						},
+					},
+				},
+			}
+
+			for _, tt := range tests {
+				fn := func(t *testing.T) {
+					fakeSVC := &mock.PasswordsService{
+						SetPasswordFn: func(_ context.Context, _ influxdb.ID, _ string) error {
+							return nil
+						},
+					}
+					s := authorizer.NewPasswordService(fakeSVC)
+
+					ctx := icontext.SetAuthorizer(context.Background(), &Authorizer{
+						Permissions: []influxdb.Permission{tt.badPermission},
+					})
+
+					err := s.SetPassword(ctx, goodUserID, "password")
+					require.Error(t, err)
+				}
+
+				t.Run(tt.name, fn)
+			}
+		})
+	})
+}

--- a/bolt/onboarding.go
+++ b/bolt/onboarding.go
@@ -90,7 +90,7 @@ func (c *Client) Generate(ctx context.Context, req *platform.OnboardingRequest) 
 		return nil, err
 	}
 
-	if err = c.SetPassword(ctx, u.Name, req.Password); err != nil {
+	if err = c.SetPassword(ctx, u.ID, req.Password); err != nil {
 		return nil, err
 	}
 

--- a/bolt/passwords_test.go
+++ b/bolt/passwords_test.go
@@ -22,7 +22,7 @@ func initPasswordsService(f platformtesting.PasswordFields, t *testing.T) (platf
 	}
 
 	for i := range f.Passwords {
-		if err := c.SetPassword(ctx, f.Users[i].Name, f.Passwords[i]); err != nil {
+		if err := c.SetPassword(ctx, f.Users[i].ID, f.Passwords[i]); err != nil {
 			t.Fatalf("error setting passsword user, %s %s: %v", f.Users[i].Name, f.Passwords[i], err)
 		}
 	}

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -156,6 +156,7 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 
 	userBackend := NewUserBackend(b)
 	userBackend.UserService = authorizer.NewUserService(b.UserService)
+	userBackend.PasswordsService = authorizer.NewPasswordService(b.PasswordsService)
 	h.UserHandler = NewUserHandler(userBackend)
 
 	dashboardBackend := NewDashboardBackend(b)

--- a/http/api_handler.go
+++ b/http/api_handler.go
@@ -143,7 +143,7 @@ func NewAPIHandler(b *APIBackend, opts ...APIHandlerOptFn) *APIHandler {
 	documentBackend := NewDocumentBackend(b)
 	h.DocumentHandler = NewDocumentHandler(documentBackend)
 
-	sessionBackend := NewSessionBackend(b)
+	sessionBackend := newSessionBackend(b)
 	h.SessionHandler = NewSessionHandler(sessionBackend)
 
 	bucketBackend := NewBucketBackend(b)

--- a/http/authentication_middleware.go
+++ b/http/authentication_middleware.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -89,21 +90,17 @@ func (h *AuthenticationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	var auth platform.Authorizer
-
 	switch scheme {
 	case tokenAuthScheme:
 		auth, err = h.extractAuthorization(ctx, r)
-		if err != nil {
-			h.unauthorized(ctx, w, err)
-			return
-		}
 	case sessionAuthScheme:
 		auth, err = h.extractSession(ctx, r)
-		if err != nil {
-			h.unauthorized(ctx, w, err)
-			return
-		}
 	default:
+		// TODO: this error will be nil if it gets here, this should be remedied with some
+		//  sentinel error I'm thinking
+		err = errors.New("invalid auth scheme")
+	}
+	if err != nil {
 		h.unauthorized(ctx, w, err)
 		return
 	}

--- a/http/session_test.go
+++ b/http/session_test.go
@@ -16,11 +16,16 @@ import (
 
 // NewMockSessionBackend returns a SessionBackend with mock services.
 func NewMockSessionBackend() *platformhttp.SessionBackend {
+	userSVC := mock.NewUserService()
+	userSVC.FindUserFn = func(_ context.Context, f platform.UserFilter) (*platform.User, error) {
+		return &platform.User{ID: 1}, nil
+	}
 	return &platformhttp.SessionBackend{
-		Logger: zap.NewNop().With(zap.String("handler", "session")),
+		Logger: zap.NewNop(),
 
 		SessionService:   mock.NewSessionService(),
-		PasswordsService: mock.NewPasswordsService("", ""),
+		PasswordsService: mock.NewPasswordsService(),
+		UserService:      userSVC,
 	}
 }
 
@@ -59,7 +64,7 @@ func TestSessionHandler_handleSignin(t *testing.T) {
 					},
 				},
 				PasswordsService: &mock.PasswordsService{
-					ComparePasswordFn: func(context.Context, string, string) error {
+					ComparePasswordFn: func(context.Context, platform.ID, string) error {
 						return nil
 					},
 				},

--- a/http/user_service.go
+++ b/http/user_service.go
@@ -72,6 +72,10 @@ func NewUserHandler(b *UserBackend) *UserHandler {
 	h.HandlerFunc("GET", usersLogPath, h.handleGetUserLog)
 	h.HandlerFunc("PATCH", usersIDPath, h.handlePatchUser)
 	h.HandlerFunc("DELETE", usersIDPath, h.handleDeleteUser)
+	// the POST doesn't need to be nested under users in this scheme
+	// seems worthwhile to make this a root resource in our HTTP API
+	// removes coupling with userid.
+	h.HandlerFunc("POST", usersPasswordPath, h.handlePostUserPassword)
 	h.HandlerFunc("PUT", usersPasswordPath, h.handlePutUserPassword)
 
 	h.HandlerFunc("GET", mePath, h.handleGetMe)
@@ -80,14 +84,56 @@ func NewUserHandler(b *UserBackend) *UserHandler {
 	return h
 }
 
-func (h *UserHandler) putPassword(ctx context.Context, w http.ResponseWriter, r *http.Request) (username string, err error) {
+type passwordSetRequest struct {
+	Password string `json:"password"`
+}
 
-	req, err := decodePasswordResetRequest(ctx, r)
+// handlePutPassword is the HTTP handler for the PUT /api/v2/users/:id/password
+func (h *UserHandler) handlePostUserPassword(w http.ResponseWriter, r *http.Request) {
+	var body passwordSetRequest
+	err := json.NewDecoder(r.Body).Decode(&body)
+	if err != nil {
+		h.HandleHTTPError(r.Context(), &influxdb.Error{
+			Code: influxdb.EInvalid,
+			Err:  err,
+		}, w)
+		return
+	}
+
+	params := httprouter.ParamsFromContext(r.Context())
+	userID, err := influxdb.IDFromString(params.ByName("id"))
+	if err != nil {
+		h.HandleHTTPError(r.Context(), &influxdb.Error{
+			Msg: "invalid user ID provided in route",
+		}, w)
+		return
+	}
+
+	err = h.PasswordsService.SetPassword(r.Context(), *userID, body.Password)
+	if err != nil {
+		h.HandleHTTPError(r.Context(), err, w)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *UserHandler) putPassword(ctx context.Context, w http.ResponseWriter, r *http.Request) (username string, err error) {
+	req, err := decodePasswordResetRequest(r)
 	if err != nil {
 		return "", err
 	}
 
-	err = h.PasswordsService.CompareAndSetPassword(ctx, req.Username, req.PasswordOld, req.PasswordNew)
+	params := httprouter.ParamsFromContext(r.Context())
+	userID, err := influxdb.IDFromString(params.ByName("id"))
+	if err != nil {
+		h.HandleHTTPError(r.Context(), &influxdb.Error{
+			Msg: "invalid user ID provided in route",
+		}, w)
+		return
+	}
+
+	err = h.PasswordsService.CompareAndSetPassword(ctx, *userID, req.PasswordOld, req.PasswordNew)
 	if err != nil {
 		return "", err
 	}
@@ -116,7 +162,7 @@ type passwordResetRequestBody struct {
 	Password string `json:"password"`
 }
 
-func decodePasswordResetRequest(ctx context.Context, r *http.Request) (*passwordResetRequest, error) {
+func decodePasswordResetRequest(r *http.Request) (*passwordResetRequest, error) {
 	u, o, ok := r.BasicAuth()
 	if !ok {
 		return nil, fmt.Errorf("invalid basic auth")
@@ -751,4 +797,58 @@ func newUserLogResponse(id influxdb.ID, es []*influxdb.OperationLogEntry) *opera
 		},
 		Logs: logs,
 	}
+}
+
+// PasswordService is an http client to speak to the password service.
+type PasswordService struct {
+	Addr               string
+	Token              string
+	InsecureSkipVerify bool
+}
+
+var _ influxdb.PasswordsService = (*PasswordService)(nil)
+
+// SetPassword sets the user's password.
+func (s *PasswordService) SetPassword(ctx context.Context, userID influxdb.ID, password string) error {
+	u, err := NewURL(s.Addr, path.Join("/api/v2/users", userID.String(), "password"))
+	if err != nil {
+		return err
+	}
+
+	newPass := passwordSetRequest{
+		Password: password,
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(newPass); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, u.String(), &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	SetToken(s.Token, req)
+
+	hc := NewClient(u.Scheme, s.InsecureSkipVerify)
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return CheckError(resp)
+}
+
+// ComparePassword compares the user new password with existing. Note: is not implemented.
+func (s *PasswordService) ComparePassword(ctx context.Context, userID influxdb.ID, password string) error {
+	panic("not implemented")
+}
+
+// CompareAndSetPassword compares the old and new password and submits the new password if possoble.
+// Note: is not implemented.
+func (s *PasswordService) CompareAndSetPassword(ctx context.Context, userID influxdb.ID, old string, new string) error {
+	panic("not implemented")
 }

--- a/http/user_test.go
+++ b/http/user_test.go
@@ -18,7 +18,7 @@ func NewMockUserBackend() *UserBackend {
 		Logger:                  zap.NewNop().With(zap.String("handler", "user")),
 		UserService:             mock.NewUserService(),
 		UserOperationLogService: mock.NewUserOperationLogService(),
-		PasswordsService:        mock.NewPasswordsService("", ""),
+		PasswordsService:        mock.NewPasswordsService(),
 	}
 }
 

--- a/http/user_test.go
+++ b/http/user_test.go
@@ -1,9 +1,18 @@
 package http
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
 	"net/http/httptest"
+	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/influxdb/pkg/testttp"
 
 	platform "github.com/influxdata/influxdb"
 	"github.com/influxdata/influxdb/inmem"
@@ -15,10 +24,11 @@ import (
 // NewMockUserBackend returns a UserBackend with mock services.
 func NewMockUserBackend() *UserBackend {
 	return &UserBackend{
-		Logger:                  zap.NewNop().With(zap.String("handler", "user")),
+		Logger:                  zap.NewNop(),
 		UserService:             mock.NewUserService(),
 		UserOperationLogService: mock.NewUserOperationLogService(),
 		PasswordsService:        mock.NewPasswordsService(),
+		HTTPErrorHandler:        ErrorHandler(0),
 	}
 }
 
@@ -52,4 +62,38 @@ func initUserService(f platformtesting.UserFields, t *testing.T) (platform.UserS
 func TestUserService(t *testing.T) {
 	t.Parallel()
 	platformtesting.UserService(initUserService, t)
+}
+
+func TestUserHandler_SettingPassword(t *testing.T) {
+	be := NewMockUserBackend()
+	fakePassSVC := mock.NewPasswordsService()
+
+	userID := platform.ID(1)
+	fakePassSVC.SetPasswordFn = func(_ context.Context, id platform.ID, newPass string) error {
+		if id != userID {
+			return errors.New("unexpected id: " + id.String())
+		}
+		if newPass == "" {
+			return errors.New("no password provided")
+		}
+		return nil
+	}
+	be.PasswordsService = fakePassSVC
+
+	h := NewUserHandler(be)
+
+	body := newReqBody(t, passwordSetRequest{Password: "newpassword"})
+	addr := path.Join("/api/v2/users", userID.String(), "/password")
+
+	testttp.Post(addr, body).Do(h).ExpectStatus(t, http.StatusNoContent)
+}
+
+func newReqBody(t *testing.T, v interface{}) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(v); err != nil {
+		require.FailNow(t, "unexpected json encoding error", err)
+	}
+	return &buf
 }

--- a/inmem/onboarding.go
+++ b/inmem/onboarding.go
@@ -73,7 +73,7 @@ func (s *Service) Generate(ctx context.Context, req *platform.OnboardingRequest)
 		return nil, err
 	}
 
-	if err = s.SetPassword(ctx, u.Name, req.Password); err != nil {
+	if err = s.SetPassword(ctx, u.ID, req.Password); err != nil {
 		return nil, err
 	}
 

--- a/inmem/passwords.go
+++ b/inmem/passwords.go
@@ -18,6 +18,13 @@ var (
 		Msg:  "your username or password is incorrect",
 	}
 
+	// EIncorrectUser is returned when any user is failed to be found which indicates
+	// the userID provided is for a user that does not exist.
+	EIncorrectUser = &platform.Error{
+		Code: platform.EForbidden,
+		Msg:  "your userID is incorrect",
+	}
+
 	// EShortPassword is used when a password is less than the minimum
 	// acceptable password length.
 	EShortPassword = &platform.Error{
@@ -32,14 +39,14 @@ var _ platform.PasswordsService = (*Service)(nil)
 const HashCost = bcrypt.DefaultCost
 
 // SetPassword stores the password hash associated with a user.
-func (s *Service) SetPassword(ctx context.Context, name string, password string) error {
+func (s *Service) SetPassword(ctx context.Context, userID platform.ID, password string) error {
 	if len(password) < MinPasswordLength {
 		return EShortPassword
 	}
 
-	u, err := s.FindUser(ctx, platform.UserFilter{Name: &name})
+	u, err := s.FindUserByID(ctx, userID)
 	if err != nil {
-		return EIncorrectPassword
+		return EIncorrectUser
 	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), HashCost)
 	if err != nil {
@@ -52,10 +59,10 @@ func (s *Service) SetPassword(ctx context.Context, name string, password string)
 }
 
 // ComparePassword compares a provided password with the stored password hash.
-func (s *Service) ComparePassword(ctx context.Context, name string, password string) error {
-	u, err := s.FindUser(ctx, platform.UserFilter{Name: &name})
+func (s *Service) ComparePassword(ctx context.Context, userID platform.ID, password string) error {
+	u, err := s.FindUserByID(ctx, userID)
 	if err != nil {
-		return EIncorrectPassword
+		return EIncorrectUser
 	}
 	hash, ok := s.basicAuthKV.Load(u.ID.String())
 	if !ok {
@@ -69,9 +76,9 @@ func (s *Service) ComparePassword(ctx context.Context, name string, password str
 }
 
 // CompareAndSetPassword replaces the old password with the new password if thee old password is correct.
-func (s *Service) CompareAndSetPassword(ctx context.Context, name string, old string, new string) error {
-	if err := s.ComparePassword(ctx, name, old); err != nil {
+func (s *Service) CompareAndSetPassword(ctx context.Context, userID platform.ID, old string, new string) error {
+	if err := s.ComparePassword(ctx, userID, old); err != nil {
 		return err
 	}
-	return s.SetPassword(ctx, name, new)
+	return s.SetPassword(ctx, userID, new)
 }

--- a/inmem/passwords_test.go
+++ b/inmem/passwords_test.go
@@ -19,7 +19,7 @@ func initPasswordsService(f platformtesting.PasswordFields, t *testing.T) (platf
 	}
 
 	for i := range f.Passwords {
-		if err := s.SetPassword(ctx, f.Users[i].Name, f.Passwords[i]); err != nil {
+		if err := s.SetPassword(ctx, f.Users[i].ID, f.Passwords[i]); err != nil {
 			t.Fatalf("error setting passsword user, %s %s: %v", f.Users[i].Name, f.Passwords[i], err)
 		}
 	}

--- a/kv/onboarding.go
+++ b/kv/onboarding.go
@@ -133,7 +133,7 @@ func (s *Service) Generate(ctx context.Context, req *influxdb.OnboardingRequest)
 			return err
 		}
 
-		if err := s.setPassword(ctx, tx, u.Name, req.Password); err != nil {
+		if err := s.setPassword(ctx, tx, u.ID, req.Password); err != nil {
 			return err
 		}
 

--- a/kv/passwords_test.go
+++ b/kv/passwords_test.go
@@ -2,6 +2,7 @@ package kv_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -62,7 +63,7 @@ func initPasswordsService(s kv.Store, f influxdbtesting.PasswordFields, t *testi
 	}
 
 	for i := range f.Passwords {
-		if err := svc.SetPassword(ctx, f.Users[i].Name, f.Passwords[i]); err != nil {
+		if err := svc.SetPassword(ctx, f.Users[i].ID, f.Passwords[i]); err != nil {
 			t.Fatalf("error setting passsword user, %s %s: %v", f.Users[i].Name, f.Passwords[i], err)
 		}
 	}
@@ -95,7 +96,7 @@ func TestService_SetPassword(t *testing.T) {
 		Hash kv.Crypt
 	}
 	type args struct {
-		name     string
+		id       influxdb.ID
 		password string
 	}
 	type wants struct {
@@ -117,7 +118,7 @@ func TestService_SetPassword(t *testing.T) {
 							BucketFn: func(b []byte) (kv.Bucket, error) {
 								return &mock.Bucket{
 									GetFn: func(key []byte) ([]byte, error) {
-										return nil, nil
+										return nil, errors.New("its broked")
 									},
 								}, nil
 							},
@@ -127,11 +128,11 @@ func TestService_SetPassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       1,
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("your username or password is incorrect"),
+				err: fmt.Errorf("your userID is incorrect"),
 			},
 		},
 		{
@@ -143,10 +144,10 @@ func TestService_SetPassword(t *testing.T) {
 							BucketFn: func(b []byte) (kv.Bucket, error) {
 								return &mock.Bucket{
 									GetFn: func(key []byte) ([]byte, error) {
-										if string(key) == "user1" {
-											return []byte("0000000000000001"), nil
-										}
 										return nil, kv.ErrKeyNotFound
+									},
+									PutFn: func(key, val []byte) error {
+										return nil
 									},
 								}, nil
 							},
@@ -156,11 +157,11 @@ func TestService_SetPassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       1,
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("your username or password is incorrect"),
+				err: fmt.Errorf("your userID is incorrect"),
 			},
 		},
 		{
@@ -172,13 +173,13 @@ func TestService_SetPassword(t *testing.T) {
 							BucketFn: func(b []byte) (kv.Bucket, error) {
 								return &mock.Bucket{
 									GetFn: func(key []byte) ([]byte, error) {
-										if string(key) == "user1" {
-											return []byte("0000000000000001"), nil
-										}
 										if string(key) == "0000000000000001" {
 											return []byte(`{"name": "user1"}`), nil
 										}
 										return nil, kv.ErrKeyNotFound
+									},
+									PutFn: func(key, val []byte) error {
+										return nil
 									},
 								}, nil
 							},
@@ -188,11 +189,11 @@ func TestService_SetPassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       0,
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("User ID for user1 has been corrupted; Err: invalid ID"),
+				err: fmt.Errorf("User ID  has been corrupted; Err: invalid ID"),
 			},
 		},
 		{
@@ -207,13 +208,13 @@ func TestService_SetPassword(t *testing.T) {
 								}
 								return &mock.Bucket{
 									GetFn: func(key []byte) ([]byte, error) {
-										if string(key) == "user1" {
-											return []byte("0000000000000001"), nil
-										}
 										if string(key) == "0000000000000001" {
 											return []byte(`{"id": "0000000000000001", "name": "user1"}`), nil
 										}
 										return nil, kv.ErrKeyNotFound
+									},
+									PutFn: func(key, val []byte) error {
+										return nil
 									},
 								}, nil
 							},
@@ -223,7 +224,7 @@ func TestService_SetPassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       1,
 				password: "howdydoody",
 			},
 			wants: wants{
@@ -245,13 +246,13 @@ func TestService_SetPassword(t *testing.T) {
 								}
 								return &mock.Bucket{
 									GetFn: func(key []byte) ([]byte, error) {
-										if string(key) == "user1" {
-											return []byte("0000000000000001"), nil
-										}
 										if string(key) == "0000000000000001" {
 											return []byte(`{"id": "0000000000000001", "name": "user1"}`), nil
 										}
 										return nil, kv.ErrKeyNotFound
+									},
+									PutFn: func(key, val []byte) error {
+										return nil
 									},
 								}, nil
 							},
@@ -261,7 +262,7 @@ func TestService_SetPassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       1,
 				password: "howdydoody",
 			},
 			wants: wants{
@@ -284,13 +285,13 @@ func TestService_SetPassword(t *testing.T) {
 								}
 								return &mock.Bucket{
 									GetFn: func(key []byte) ([]byte, error) {
-										if string(key) == "user1" {
-											return []byte("0000000000000001"), nil
-										}
 										if string(key) == "0000000000000001" {
 											return []byte(`{"id": "0000000000000001", "name": "user1"}`), nil
 										}
 										return nil, kv.ErrKeyNotFound
+									},
+									PutFn: func(key, val []byte) error {
+										return nil
 									},
 								}, nil
 							},
@@ -300,7 +301,7 @@ func TestService_SetPassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       1,
 				password: "howdydoody",
 			},
 			wants: wants{
@@ -315,7 +316,7 @@ func TestService_SetPassword(t *testing.T) {
 			}
 			s.WithStore(tt.fields.kv)
 
-			err := s.SetPassword(context.Background(), tt.args.name, tt.args.password)
+			err := s.SetPassword(context.Background(), tt.args.id, tt.args.password)
 			if (err != nil && tt.wants.err == nil) || (err == nil && tt.wants.err != nil) {
 				t.Fatalf("Service.SetPassword() error = %v, want %v", err, tt.wants.err)
 				return
@@ -336,7 +337,7 @@ func TestService_ComparePassword(t *testing.T) {
 		Hash kv.Crypt
 	}
 	type args struct {
-		name     string
+		id       influxdb.ID
 		password string
 	}
 	type wants struct {
@@ -367,11 +368,11 @@ func TestService_ComparePassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       1,
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("your username or password is incorrect"),
+				err: fmt.Errorf("your userID is incorrect"),
 			},
 		},
 		{
@@ -399,11 +400,11 @@ func TestService_ComparePassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       0,
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("User ID for user1 has been corrupted; Err: invalid ID"),
+				err: fmt.Errorf("User ID  has been corrupted; Err: invalid ID"),
 			},
 		},
 		{
@@ -434,7 +435,7 @@ func TestService_ComparePassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       1,
 				password: "howdydoody",
 			},
 			wants: wants{
@@ -476,7 +477,7 @@ func TestService_ComparePassword(t *testing.T) {
 				},
 			},
 			args: args{
-				name:     "user1",
+				id:       1,
 				password: "howdydoody",
 			},
 			wants: wants{
@@ -490,7 +491,7 @@ func TestService_ComparePassword(t *testing.T) {
 				Hash: tt.fields.Hash,
 			}
 			s.WithStore(tt.fields.kv)
-			err := s.ComparePassword(context.Background(), tt.args.name, tt.args.password)
+			err := s.ComparePassword(context.Background(), tt.args.id, tt.args.password)
 
 			if (err != nil && tt.wants.err == nil) || (err == nil && tt.wants.err != nil) {
 				t.Fatalf("Service.ComparePassword() error = %v, want %v", err, tt.wants.err)

--- a/mock/passwords.go
+++ b/mock/passwords.go
@@ -3,37 +3,39 @@ package mock
 import (
 	"context"
 	"fmt"
+
+	"github.com/influxdata/influxdb"
 )
 
 // PasswordsService is a mock implementation of a retention.PasswordsService, which
 // also makes it a suitable mock to use wherever an platform.PasswordsService is required.
 type PasswordsService struct {
-	SetPasswordFn           func(context.Context, string, string) error
-	ComparePasswordFn       func(context.Context, string, string) error
-	CompareAndSetPasswordFn func(context.Context, string, string, string) error
+	SetPasswordFn           func(context.Context, influxdb.ID, string) error
+	ComparePasswordFn       func(context.Context, influxdb.ID, string) error
+	CompareAndSetPasswordFn func(context.Context, influxdb.ID, string, string) error
 }
 
 // NewPasswordsService returns a mock PasswordsService where its methods will return
 // zero values.
-func NewPasswordsService(user, password string) *PasswordsService {
+func NewPasswordsService() *PasswordsService {
 	return &PasswordsService{
-		SetPasswordFn:           func(context.Context, string, string) error { return fmt.Errorf("mock error") },
-		ComparePasswordFn:       func(context.Context, string, string) error { return fmt.Errorf("mock error") },
-		CompareAndSetPasswordFn: func(context.Context, string, string, string) error { return fmt.Errorf("mock error") },
+		SetPasswordFn:           func(context.Context, influxdb.ID, string) error { return fmt.Errorf("mock error") },
+		ComparePasswordFn:       func(context.Context, influxdb.ID, string) error { return fmt.Errorf("mock error") },
+		CompareAndSetPasswordFn: func(context.Context, influxdb.ID, string, string) error { return fmt.Errorf("mock error") },
 	}
 }
 
 // SetPassword sets the users current password to be the provided password.
-func (s *PasswordsService) SetPassword(ctx context.Context, name string, password string) error {
-	return s.SetPasswordFn(ctx, name, password)
+func (s *PasswordsService) SetPassword(ctx context.Context, userID influxdb.ID, password string) error {
+	return s.SetPasswordFn(ctx, userID, password)
 }
 
 // ComparePassword password compares the provided password.
-func (s *PasswordsService) ComparePassword(ctx context.Context, name string, password string) error {
-	return s.ComparePasswordFn(ctx, name, password)
+func (s *PasswordsService) ComparePassword(ctx context.Context, userID influxdb.ID, password string) error {
+	return s.ComparePasswordFn(ctx, userID, password)
 }
 
 // CompareAndSetPassword compares the provided password and sets it to the new password.
-func (s *PasswordsService) CompareAndSetPassword(ctx context.Context, name string, old string, new string) error {
-	return s.CompareAndSetPasswordFn(ctx, name, old, new)
+func (s *PasswordsService) CompareAndSetPassword(ctx context.Context, userID influxdb.ID, old string, new string) error {
+	return s.CompareAndSetPasswordFn(ctx, userID, old, new)
 }

--- a/passwords.go
+++ b/passwords.go
@@ -5,11 +5,11 @@ import "context"
 // PasswordsService is the service for managing basic auth passwords.
 type PasswordsService interface {
 	// SetPassword overrides the password of a known user.
-	SetPassword(ctx context.Context, name string, password string) error
+	SetPassword(ctx context.Context, userID ID, password string) error
 	// ComparePassword checks if the password matches the password recorded.
 	// Passwords that do not match return errors.
-	ComparePassword(ctx context.Context, name string, password string) error
+	ComparePassword(ctx context.Context, userID ID, password string) error
 	// CompareAndSetPassword checks the password and if they match
 	// updates to the new password.
-	CompareAndSetPassword(ctx context.Context, name string, old string, new string) error
+	CompareAndSetPassword(ctx context.Context, userID ID, old, new string) error
 }

--- a/testing/onboarding.go
+++ b/testing/onboarding.go
@@ -210,7 +210,7 @@ func Generate(
 				t.Errorf("onboarding results are different -got/+want\ndiff %s", diff)
 			}
 			if results != nil {
-				if err = s.ComparePassword(ctx, results.User.Name, tt.wants.password); err != nil {
+				if err = s.ComparePassword(ctx, results.User.ID, tt.wants.password); err != nil {
 					t.Errorf("onboarding set password is wrong")
 				}
 			}

--- a/testing/passwords.go
+++ b/testing/passwords.go
@@ -49,7 +49,7 @@ func SetPassword(
 	init func(PasswordFields, *testing.T) (influxdb.PasswordsService, func()),
 	t *testing.T) {
 	type args struct {
-		user     string
+		user     influxdb.ID
 		password string
 	}
 	type wants struct {
@@ -72,7 +72,7 @@ func SetPassword(
 				},
 			},
 			args: args{
-				user:     "user1",
+				user:     MustIDBase16(oneID),
 				password: "howdydoody",
 			},
 			wants: wants{},
@@ -88,7 +88,7 @@ func SetPassword(
 				},
 			},
 			args: args{
-				user:     "user1",
+				user:     MustIDBase16(oneID),
 				password: "short",
 			},
 			wants: wants{
@@ -106,11 +106,11 @@ func SetPassword(
 				},
 			},
 			args: args{
-				user:     "invalid",
+				user:     33,
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("your username or password is incorrect"),
+				err: fmt.Errorf("your userID is incorrect"),
 			},
 		},
 	}
@@ -132,7 +132,6 @@ func SetPassword(
 				if want, got := tt.wants.err.Error(), err.Error(); want != got {
 					t.Fatalf("expected SetPassword error %v got %v", want, got)
 				}
-				return
 			}
 		})
 	}
@@ -143,7 +142,7 @@ func ComparePassword(
 	init func(PasswordFields, *testing.T) (influxdb.PasswordsService, func()),
 	t *testing.T) {
 	type args struct {
-		user     string
+		user     influxdb.ID
 		password string
 	}
 	type wants struct {
@@ -167,7 +166,7 @@ func ComparePassword(
 				Passwords: []string{"howdydoody"},
 			},
 			args: args{
-				user:     "user1",
+				user:     MustIDBase16(oneID),
 				password: "howdydoody",
 			},
 			wants: wants{},
@@ -184,7 +183,7 @@ func ComparePassword(
 				Passwords: []string{"howdydoody"},
 			},
 			args: args{
-				user:     "user1",
+				user:     MustIDBase16(oneID),
 				password: "wrongpassword",
 			},
 			wants: wants{
@@ -203,11 +202,11 @@ func ComparePassword(
 				Passwords: []string{"howdydoody"},
 			},
 			args: args{
-				user:     "invalid",
+				user:     1,
 				password: "howdydoody",
 			},
 			wants: wants{
-				err: fmt.Errorf("your username or password is incorrect"),
+				err: fmt.Errorf("your userID is incorrect"),
 			},
 		},
 		{
@@ -221,7 +220,7 @@ func ComparePassword(
 				},
 			},
 			args: args{
-				user:     "user1",
+				user:     MustIDBase16(oneID),
 				password: "howdydoody",
 			},
 			wants: wants{
@@ -259,7 +258,7 @@ func CompareAndSetPassword(
 	init func(PasswordFields, *testing.T) (influxdb.PasswordsService, func()),
 	t *testing.T) {
 	type args struct {
-		user string
+		user influxdb.ID
 		old  string
 		new  string
 	}
@@ -284,7 +283,7 @@ func CompareAndSetPassword(
 				Passwords: []string{"howdydoody"},
 			},
 			args: args{
-				user: "user1",
+				user: MustIDBase16(oneID),
 				old:  "howdydoody",
 				new:  "howdydoody",
 			},
@@ -302,7 +301,7 @@ func CompareAndSetPassword(
 				Passwords: []string{"howdydoody"},
 			},
 			args: args{
-				user: "user1",
+				user: MustIDBase16(oneID),
 				old:  "invalid",
 				new:  "not used",
 			},
@@ -322,7 +321,7 @@ func CompareAndSetPassword(
 				Passwords: []string{"howdydoody"},
 			},
 			args: args{
-				user: "user1",
+				user: MustIDBase16(oneID),
 				old:  "howdydoody",
 				new:  "short",
 			},


### PR DESCRIPTION
one thing to note here is that new endpoint was created. there was no
endpoint for setting an initial password that worked. The existing endpoint
was a bit messy and coupled across multiple routes. Having multiple auth
schemes proved incredibly taxing to write against.

update: this came up in discussion in another topic with @goller and from that conversation decided to fixup the password service interface here. To provide the user id instead of name as the first arg to each set/compare func in the PasswordService.

closes: https://github.com/influxdata/influxdb/issues/15977

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass