### PR TITLE
feat(ui): autofilling the organization in the client examples

### DIFF
--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -18,7 +18,7 @@ interface StateProps {
 
 type Props = StateProps
 
-const ClientCSharpOverlay: FunctionComponent<Props> = (props) => {
+const ClientCSharpOverlay: FunctionComponent<Props> = props => {
   const {
     name,
     url,
@@ -32,9 +32,7 @@ const ClientCSharpOverlay: FunctionComponent<Props> = (props) => {
     writingDataPocoCodeSnippet,
     pocoClassCodeSnippet,
   } = clientCSharpLibrary
-  const {
-    org
-  } = props
+  const {org} = props
   const server = window.location.origin
 
   return (
@@ -70,7 +68,7 @@ const ClientCSharpOverlay: FunctionComponent<Props> = (props) => {
           token: 'token',
         }}
         values={{
-          server
+          server,
         }}
       />
       <h5>Write Data</h5>
@@ -83,7 +81,7 @@ const ClientCSharpOverlay: FunctionComponent<Props> = (props) => {
           bucket: 'bucketID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <p>Option 2: Use a Data Point to write data</p>
@@ -95,7 +93,7 @@ const ClientCSharpOverlay: FunctionComponent<Props> = (props) => {
           bucket: 'bucketID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <p>Option 3: Use POCO and corresponding Class to write data</p>
@@ -107,7 +105,7 @@ const ClientCSharpOverlay: FunctionComponent<Props> = (props) => {
           bucket: 'bucketID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <TemplatedCodeSnippet template={pocoClassCodeSnippet} label="C# Code" />
@@ -120,7 +118,7 @@ const ClientCSharpOverlay: FunctionComponent<Props> = (props) => {
           bucket: 'bucketID',
         }}
         values={{
-          org
+          org,
         }}
       />
     </ClientLibraryOverlay>
@@ -138,5 +136,5 @@ const mstp = (state: AppState): StateProps => {
 export {ClientCSharpOverlay}
 export default connect<StateProps, {}, Props>(
   mstp,
-  null,
+  null
 )(ClientCSharpOverlay)

--- a/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientCSharpOverlay.tsx
@@ -1,12 +1,24 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
 import TemplatedCodeSnippet from 'src/shared/components/TemplatedCodeSnippet'
+
 // Constants
 import {clientCSharpLibrary} from 'src/clientLibraries/constants'
 
-const ClientCSharpOverlay: FunctionComponent<{}> = () => {
+// Types
+import {AppState} from 'src/types'
+
+interface StateProps {
+  org: string
+}
+
+type Props = StateProps
+
+const ClientCSharpOverlay: FunctionComponent<Props> = (props) => {
   const {
     name,
     url,
@@ -20,6 +32,11 @@ const ClientCSharpOverlay: FunctionComponent<{}> = () => {
     writingDataPocoCodeSnippet,
     pocoClassCodeSnippet,
   } = clientCSharpLibrary
+  const {
+    org
+  } = props
+  const server = window.location.origin
+
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
       <p>
@@ -52,6 +69,9 @@ const ClientCSharpOverlay: FunctionComponent<{}> = () => {
           server: 'basepath',
           token: 'token',
         }}
+        values={{
+          server
+        }}
       />
       <h5>Write Data</h5>
       <p>Option 1: Use InfluxDB Line Protocol to write data</p>
@@ -62,6 +82,9 @@ const ClientCSharpOverlay: FunctionComponent<{}> = () => {
           org: 'orgID',
           bucket: 'bucketID',
         }}
+        values={{
+          org
+        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
@@ -71,6 +94,9 @@ const ClientCSharpOverlay: FunctionComponent<{}> = () => {
           org: 'orgID',
           bucket: 'bucketID',
         }}
+        values={{
+          org
+        }}
       />
       <p>Option 3: Use POCO and corresponding Class to write data</p>
       <TemplatedCodeSnippet
@@ -79,6 +105,9 @@ const ClientCSharpOverlay: FunctionComponent<{}> = () => {
         defaults={{
           org: 'orgID',
           bucket: 'bucketID',
+        }}
+        values={{
+          org
         }}
       />
       <TemplatedCodeSnippet template={pocoClassCodeSnippet} label="C# Code" />
@@ -90,9 +119,24 @@ const ClientCSharpOverlay: FunctionComponent<{}> = () => {
           org: 'orgID',
           bucket: 'bucketID',
         }}
+        values={{
+          org
+        }}
       />
     </ClientLibraryOverlay>
   )
 }
 
-export default ClientCSharpOverlay
+const mstp = (state: AppState): StateProps => {
+  const org = state.orgs.org.id
+
+  return {
+    org,
+  }
+}
+
+export {ClientCSharpOverlay}
+export default connect<StateProps, {}, Props>(
+  mstp,
+  null,
+)(ClientCSharpOverlay)

--- a/ui/src/clientLibraries/components/ClientGoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientGoOverlay.tsx
@@ -18,16 +18,14 @@ interface StateProps {
 
 type Props = StateProps
 
-const ClientGoOverlay: FunctionComponent<Props> = (props) => {
+const ClientGoOverlay: FunctionComponent<Props> = props => {
   const {
     name,
     url,
     initializeClientCodeSnippet,
     writeDataCodeSnippet,
   } = clientGoLibrary
-  const {
-    org
-  } = props
+  const {org} = props
   const server = window.location.origin
 
   return (
@@ -47,7 +45,7 @@ const ClientGoOverlay: FunctionComponent<Props> = (props) => {
           server: 'myHTTPInfluxAddress',
         }}
         values={{
-          server
+          server,
         }}
       />
       <h5>Write Data</h5>
@@ -59,7 +57,7 @@ const ClientGoOverlay: FunctionComponent<Props> = (props) => {
           org: 'my-very-awesome-org',
         }}
         values={{
-          org
+          org,
         }}
       />
     </ClientLibraryOverlay>
@@ -77,5 +75,5 @@ const mstp = (state: AppState): StateProps => {
 export {ClientGoOverlay}
 export default connect<StateProps, {}, Props>(
   mstp,
-  null,
+  null
 )(ClientGoOverlay)

--- a/ui/src/clientLibraries/components/ClientGoOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientGoOverlay.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -8,13 +9,27 @@ import TemplatedCodeSnippet from 'src/shared/components/TemplatedCodeSnippet'
 // Constants
 import {clientGoLibrary} from 'src/clientLibraries/constants'
 
-const ClientGoOverlay: FunctionComponent<{}> = () => {
+// Types
+import {AppState} from 'src/types'
+
+interface StateProps {
+  org: string
+}
+
+type Props = StateProps
+
+const ClientGoOverlay: FunctionComponent<Props> = (props) => {
   const {
     name,
     url,
     initializeClientCodeSnippet,
     writeDataCodeSnippet,
   } = clientGoLibrary
+  const {
+    org
+  } = props
+  const server = window.location.origin
+
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
       <p>
@@ -31,6 +46,9 @@ const ClientGoOverlay: FunctionComponent<{}> = () => {
           token: 'myToken',
           server: 'myHTTPInfluxAddress',
         }}
+        values={{
+          server
+        }}
       />
       <h5>Write Data</h5>
       <TemplatedCodeSnippet
@@ -40,9 +58,24 @@ const ClientGoOverlay: FunctionComponent<{}> = () => {
           bucket: 'my-awesome-bucket',
           org: 'my-very-awesome-org',
         }}
+        values={{
+          org
+        }}
       />
     </ClientLibraryOverlay>
   )
 }
 
-export default ClientGoOverlay
+const mstp = (state: AppState): StateProps => {
+  const org = state.orgs.org.id
+
+  return {
+    org,
+  }
+}
+
+export {ClientGoOverlay}
+export default connect<StateProps, {}, Props>(
+  mstp,
+  null,
+)(ClientGoOverlay)

--- a/ui/src/clientLibraries/components/ClientJSOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJSOverlay.tsx
@@ -18,7 +18,7 @@ interface StateProps {
 
 type Props = StateProps
 
-const ClientJSOverlay: FunctionComponent<Props> = (props) => {
+const ClientJSOverlay: FunctionComponent<Props> = props => {
   const {
     name,
     url,
@@ -26,9 +26,7 @@ const ClientJSOverlay: FunctionComponent<Props> = (props) => {
     executeQueryCodeSnippet,
     writingDataLineProtocolCodeSnippet,
   } = clientJSLibrary
-  const {
-    org
-  } = props
+  const {org} = props
   const server = window.location.origin
 
   return (
@@ -49,7 +47,7 @@ const ClientJSOverlay: FunctionComponent<Props> = (props) => {
           token: 'token',
         }}
         values={{
-          server
+          server,
         }}
       />
       <h5>Write Data</h5>
@@ -61,7 +59,7 @@ const ClientJSOverlay: FunctionComponent<Props> = (props) => {
           bucket: 'bucketID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <h5>Execute a Flux query</h5>
@@ -72,7 +70,7 @@ const ClientJSOverlay: FunctionComponent<Props> = (props) => {
           org: 'orgID',
         }}
         values={{
-          org
+          org,
         }}
       />
     </ClientLibraryOverlay>
@@ -90,5 +88,5 @@ const mstp = (state: AppState): StateProps => {
 export {ClientJSOverlay}
 export default connect<StateProps, {}, Props>(
   mstp,
-  null,
+  null
 )(ClientJSOverlay)

--- a/ui/src/clientLibraries/components/ClientJSOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJSOverlay.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -8,7 +9,16 @@ import TemplatedCodeSnippet from 'src/shared/components/TemplatedCodeSnippet'
 // Constants
 import {clientJSLibrary} from 'src/clientLibraries/constants'
 
-const ClientJSOverlay: FunctionComponent<{}> = () => {
+// Types
+import {AppState} from 'src/types'
+
+interface StateProps {
+  org: string
+}
+
+type Props = StateProps
+
+const ClientJSOverlay: FunctionComponent<Props> = (props) => {
   const {
     name,
     url,
@@ -16,6 +26,10 @@ const ClientJSOverlay: FunctionComponent<{}> = () => {
     executeQueryCodeSnippet,
     writingDataLineProtocolCodeSnippet,
   } = clientJSLibrary
+  const {
+    org
+  } = props
+  const server = window.location.origin
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -34,6 +48,9 @@ const ClientJSOverlay: FunctionComponent<{}> = () => {
           server: 'server',
           token: 'token',
         }}
+        values={{
+          server
+        }}
       />
       <h5>Write Data</h5>
       <TemplatedCodeSnippet
@@ -43,6 +60,9 @@ const ClientJSOverlay: FunctionComponent<{}> = () => {
           org: 'orgID',
           bucket: 'bucketID',
         }}
+        values={{
+          org
+        }}
       />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
@@ -51,9 +71,24 @@ const ClientJSOverlay: FunctionComponent<{}> = () => {
         defaults={{
           org: 'orgID',
         }}
+        values={{
+          org
+        }}
       />
     </ClientLibraryOverlay>
   )
 }
 
-export default ClientJSOverlay
+const mstp = (state: AppState): StateProps => {
+  const org = state.orgs.org.id
+
+  return {
+    org,
+  }
+}
+
+export {ClientJSOverlay}
+export default connect<StateProps, {}, Props>(
+  mstp,
+  null,
+)(ClientJSOverlay)

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -1,12 +1,24 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
+
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
 import TemplatedCodeSnippet from 'src/shared/components/TemplatedCodeSnippet'
+
 // Constants
 import {clientJavaLibrary} from 'src/clientLibraries/constants'
 
-const ClientJavaOverlay: FunctionComponent<{}> = () => {
+// Types
+import {AppState} from 'src/types'
+
+interface StateProps {
+  org: string
+}
+
+type Props = StateProps
+
+const ClientJavaOverlay: FunctionComponent<Props> = (props) => {
   const {
     name,
     url,
@@ -19,6 +31,10 @@ const ClientJavaOverlay: FunctionComponent<{}> = () => {
     writingDataPojoCodeSnippet,
     pojoClassCodeSnippet,
   } = clientJavaLibrary
+  const {
+    org
+  } = props
+  const server = window.location.origin
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -44,6 +60,9 @@ const ClientJavaOverlay: FunctionComponent<{}> = () => {
           server: 'serverUrl',
           token: 'token',
         }}
+        values={{
+          server
+        }}
       />
       <h5>Write Data</h5>
       <p>Option 1: Use InfluxDB Line Protocol to write data</p>
@@ -54,6 +73,9 @@ const ClientJavaOverlay: FunctionComponent<{}> = () => {
           bucket: 'bucketID',
           org: 'orgID',
         }}
+        values={{
+          org
+        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
@@ -63,6 +85,9 @@ const ClientJavaOverlay: FunctionComponent<{}> = () => {
           bucket: 'bucketID',
           org: 'orgID',
         }}
+        values={{
+          org
+        }}
       />
       <p>Option 3: Use POJO and corresponding class to write data</p>
       <TemplatedCodeSnippet
@@ -71,6 +96,9 @@ const ClientJavaOverlay: FunctionComponent<{}> = () => {
         defaults={{
           bucket: 'bucketID',
           org: 'orgID',
+        }}
+        values={{
+          org
         }}
       />
       <TemplatedCodeSnippet template={pojoClassCodeSnippet} label="Java Code" />
@@ -82,9 +110,24 @@ const ClientJavaOverlay: FunctionComponent<{}> = () => {
           bucket: 'my_bucket',
           org: 'myorgid',
         }}
+        values={{
+          org
+        }}
       />
     </ClientLibraryOverlay>
   )
 }
 
-export default ClientJavaOverlay
+const mstp = (state: AppState): StateProps => {
+  const org = state.orgs.org.id
+
+  return {
+    org,
+  }
+}
+
+export {ClientJavaOverlay}
+export default connect<StateProps, {}, Props>(
+  mstp,
+  null,
+)(ClientJavaOverlay)

--- a/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientJavaOverlay.tsx
@@ -18,7 +18,7 @@ interface StateProps {
 
 type Props = StateProps
 
-const ClientJavaOverlay: FunctionComponent<Props> = (props) => {
+const ClientJavaOverlay: FunctionComponent<Props> = props => {
   const {
     name,
     url,
@@ -31,9 +31,7 @@ const ClientJavaOverlay: FunctionComponent<Props> = (props) => {
     writingDataPojoCodeSnippet,
     pojoClassCodeSnippet,
   } = clientJavaLibrary
-  const {
-    org
-  } = props
+  const {org} = props
   const server = window.location.origin
 
   return (
@@ -61,7 +59,7 @@ const ClientJavaOverlay: FunctionComponent<Props> = (props) => {
           token: 'token',
         }}
         values={{
-          server
+          server,
         }}
       />
       <h5>Write Data</h5>
@@ -74,7 +72,7 @@ const ClientJavaOverlay: FunctionComponent<Props> = (props) => {
           org: 'orgID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <p>Option 2: Use a Data Point to write data</p>
@@ -86,7 +84,7 @@ const ClientJavaOverlay: FunctionComponent<Props> = (props) => {
           org: 'orgID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <p>Option 3: Use POJO and corresponding class to write data</p>
@@ -98,7 +96,7 @@ const ClientJavaOverlay: FunctionComponent<Props> = (props) => {
           org: 'orgID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <TemplatedCodeSnippet template={pojoClassCodeSnippet} label="Java Code" />
@@ -111,7 +109,7 @@ const ClientJavaOverlay: FunctionComponent<Props> = (props) => {
           org: 'myorgid',
         }}
         values={{
-          org
+          org,
         }}
       />
     </ClientLibraryOverlay>
@@ -129,5 +127,5 @@ const mstp = (state: AppState): StateProps => {
 export {ClientJavaOverlay}
 export default connect<StateProps, {}, Props>(
   mstp,
-  null,
+  null
 )(ClientJavaOverlay)

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -18,7 +18,7 @@ interface StateProps {
 
 type Props = StateProps
 
-const ClientPythonOverlay: FunctionComponent<Props> = (props) => {
+const ClientPythonOverlay: FunctionComponent<Props> = props => {
   const {
     name,
     url,
@@ -29,9 +29,7 @@ const ClientPythonOverlay: FunctionComponent<Props> = (props) => {
     writingDataPointCodeSnippet,
     writingDataBatchCodeSnippet,
   } = clientPythonLibrary
-  const {
-    org
-  } = props
+  const {org} = props
   const server = window.location.origin
 
   return (
@@ -56,7 +54,7 @@ const ClientPythonOverlay: FunctionComponent<Props> = (props) => {
           token: 'token',
         }}
         values={{
-          server
+          server,
         }}
       />
       <h5>Write Data</h5>
@@ -69,7 +67,7 @@ const ClientPythonOverlay: FunctionComponent<Props> = (props) => {
           org: 'orgID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <p>Option 2: Use a Data Point to write data</p>
@@ -81,7 +79,7 @@ const ClientPythonOverlay: FunctionComponent<Props> = (props) => {
           org: 'orgID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <p>Option 3: Use a Batch Sequence to write data</p>
@@ -93,7 +91,7 @@ const ClientPythonOverlay: FunctionComponent<Props> = (props) => {
           org: 'orgID',
         }}
         values={{
-          org
+          org,
         }}
       />
       <h5>Execute a Flux query</h5>
@@ -105,7 +103,7 @@ const ClientPythonOverlay: FunctionComponent<Props> = (props) => {
           org: 'orgID',
         }}
         values={{
-          org
+          org,
         }}
       />
     </ClientLibraryOverlay>
@@ -123,5 +121,5 @@ const mstp = (state: AppState): StateProps => {
 export {ClientPythonOverlay}
 export default connect<StateProps, {}, Props>(
   mstp,
-  null,
+  null
 )(ClientPythonOverlay)

--- a/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
+++ b/ui/src/clientLibraries/components/ClientPythonOverlay.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {FunctionComponent} from 'react'
+import {connect} from 'react-redux'
 
 // Components
 import ClientLibraryOverlay from 'src/clientLibraries/components/ClientLibraryOverlay'
@@ -8,7 +9,16 @@ import TemplatedCodeSnippet from 'src/shared/components/TemplatedCodeSnippet'
 // Constants
 import {clientPythonLibrary} from 'src/clientLibraries/constants'
 
-const ClientPythonOverlay: FunctionComponent<{}> = () => {
+// Types
+import {AppState} from 'src/types'
+
+interface StateProps {
+  org: string
+}
+
+type Props = StateProps
+
+const ClientPythonOverlay: FunctionComponent<Props> = (props) => {
   const {
     name,
     url,
@@ -19,6 +29,10 @@ const ClientPythonOverlay: FunctionComponent<{}> = () => {
     writingDataPointCodeSnippet,
     writingDataBatchCodeSnippet,
   } = clientPythonLibrary
+  const {
+    org
+  } = props
+  const server = window.location.origin
 
   return (
     <ClientLibraryOverlay title={`${name} Client Library`}>
@@ -41,6 +55,9 @@ const ClientPythonOverlay: FunctionComponent<{}> = () => {
           server: 'serverUrl',
           token: 'token',
         }}
+        values={{
+          server
+        }}
       />
       <h5>Write Data</h5>
       <p>Option 1: Use InfluxDB Line Protocol to write data</p>
@@ -51,6 +68,9 @@ const ClientPythonOverlay: FunctionComponent<{}> = () => {
           bucket: 'bucketID',
           org: 'orgID',
         }}
+        values={{
+          org
+        }}
       />
       <p>Option 2: Use a Data Point to write data</p>
       <TemplatedCodeSnippet
@@ -59,6 +79,9 @@ const ClientPythonOverlay: FunctionComponent<{}> = () => {
         defaults={{
           bucket: 'bucketID',
           org: 'orgID',
+        }}
+        values={{
+          org
         }}
       />
       <p>Option 3: Use a Batch Sequence to write data</p>
@@ -69,6 +92,9 @@ const ClientPythonOverlay: FunctionComponent<{}> = () => {
           bucket: 'bucketID',
           org: 'orgID',
         }}
+        values={{
+          org
+        }}
       />
       <h5>Execute a Flux query</h5>
       <TemplatedCodeSnippet
@@ -78,9 +104,24 @@ const ClientPythonOverlay: FunctionComponent<{}> = () => {
           bucket: 'my_bucket',
           org: 'orgID',
         }}
+        values={{
+          org
+        }}
       />
     </ClientLibraryOverlay>
   )
 }
 
-export default ClientPythonOverlay
+const mstp = (state: AppState): StateProps => {
+  const org = state.orgs.org.id
+
+  return {
+    org,
+  }
+}
+
+export {ClientPythonOverlay}
+export default connect<StateProps, {}, Props>(
+  mstp,
+  null,
+)(ClientPythonOverlay)


### PR DESCRIPTION
This PR is a follow up task to a feature that was released last week. It autofills the server location and organization id into the example text so that a user may more readily copy pasta their way to success :tm:
It would be nice to know where to put a bucket and token selection mechanism to finish out the last few tidbits of info in this page.