### PR TITLE
fix(tasks): construct permissions for finish run to write to system buckets

### DIFF
--- a/task/backend/executor/task_executor.go
+++ b/task/backend/executor/task_executor.go
@@ -352,7 +352,7 @@ func (w *worker) finish(p *promise, rs backend.RunStatus, err error) {
 		w.te.logger.Debug("Completed successfully", zap.String("taskID", p.task.ID.String()))
 	}
 
-	if _, err := w.te.tcs.FinishRun(icontext.SetAuthorizer(p.ctx, p.auth), p.task.ID, p.run.ID); err != nil {
+	if _, err := w.te.tcs.FinishRun(p.ctx, p.task.ID, p.run.ID); err != nil {
 		w.te.logger.Error("Failed to finish run", zap.String("taskID", p.task.ID.String()), zap.String("runID", p.run.ID.String()), zap.Error(err))
 	}
 }

--- a/task/backend/executor/task_executor_test.go
+++ b/task/backend/executor/task_executor_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/influxdata/influxdb/kit/prom/promtest"
 	"github.com/influxdata/influxdb/kv"
 	"github.com/influxdata/influxdb/query"
-	"github.com/influxdata/influxdb/task/backend"
 	"github.com/influxdata/influxdb/task/backend/scheduler"
 	"go.uber.org/zap/zaptest"
 )
@@ -38,7 +37,7 @@ func taskExecutorSystem(t *testing.T) tes {
 
 	i := kv.NewService(inmem.NewKVStore())
 
-	ex, metrics := NewExecutor(zaptest.NewLogger(t), qs, i, i, taskControlService{i})
+	ex, metrics := NewExecutor(zaptest.NewLogger(t), qs, i, i, i)
 	return tes{
 		svc:     aqs,
 		ex:      ex,
@@ -473,18 +472,4 @@ func testErrorHandling(t *testing.T) {
 			t.Fatal("expected task to be deactivated after permanent error")
 		}
 	*/
-}
-
-type taskControlService struct {
-	backend.TaskControlService
-}
-
-func (t taskControlService) FinishRun(ctx context.Context, taskID influxdb.ID, runID influxdb.ID) (*influxdb.Run, error) {
-	// ensure auth set on context
-	_, err := icontext.GetAuthorizer(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	return t.TaskControlService.FinishRun(ctx, taskID, runID)
 }

--- a/task/backend/support_test.go
+++ b/task/backend/support_test.go
@@ -1,0 +1,49 @@
+package backend_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/influxdata/influxdb"
+	icontext "github.com/influxdata/influxdb/context"
+)
+
+type runRecorder struct {
+	isLegacyOrg func(influxdb.ID) bool
+	call        recordCall
+}
+
+type recordCall struct {
+	orgID    influxdb.ID
+	org      string
+	bucketID influxdb.ID
+	bucket   string
+	run      *influxdb.Run
+}
+
+func (r *runRecorder) Record(ctx context.Context, orgID influxdb.ID, org string, bucketID influxdb.ID, bucket string, run *influxdb.Run) error {
+	auth, err := icontext.GetAuthorizer(ctx)
+	if err != nil {
+		return err
+	}
+
+	var expOrg *influxdb.ID
+	if !r.isLegacyOrg(orgID) {
+		expOrg = &orgID
+	}
+
+	if !auth.Allowed(influxdb.Permission{
+		Action: influxdb.WriteAction,
+		Resource: influxdb.Resource{
+			Type:  influxdb.BucketsResourceType,
+			ID:    &bucketID,
+			OrgID: expOrg,
+		},
+	}) {
+		return errors.New("permission not allowed")
+	}
+
+	r.call = recordCall{orgID, org, bucketID, bucket, run}
+
+	return nil
+}


### PR DESCRIPTION
This changes the way authentication for the `_tasks` system bucket is crafted within the analytical store.
Prior to this I threaded the author of the tasks authentication onto the FinishRun call. This meant the user needed the permission to write to the system tasks bucket. However, upon reflection the actor here is the system itself attempting to record something. It is archiving a run from short-term to long-term storage. Not the user.
I believe it is therefor safe for the analytical store to craft this permission itself. The downstream storage at the end of the run recorder still has to verify the authenticity of the authorization.

This closes an issue we are experiencing with backwards compatibility with legacy system bucket recording of runs.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
