### PR TITLE
feat(pkger): add authentication to service dependencies for pkger

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -842,10 +842,10 @@ func (m *Launcher) run(ctx context.Context) (err error) {
 		b := m.apibackend
 		pkgSVC = pkger.NewService(
 			pkger.WithLogger(m.logger.With(zap.String("service", "pkger"))),
-			pkger.WithBucketSVC(b.BucketService),
-			pkger.WithDashboardSVC(b.DashboardService),
-			pkger.WithLabelSVC(b.LabelService),
-			pkger.WithVariableSVC(b.VariableService),
+			pkger.WithBucketSVC(authorizer.NewBucketService(b.BucketService)),
+			pkger.WithDashboardSVC(authorizer.NewDashboardService(b.DashboardService)),
+			pkger.WithLabelSVC(authorizer.NewLabelService(b.LabelService)),
+			pkger.WithVariableSVC(authorizer.NewVariableService(b.VariableService)),
 		)
 	}
 


### PR DESCRIPTION
turns out all we need to do is auth the service deps themselves.... there is no perm for pkg stuffs yet, when that gets donezo, we can add an authorizer for pkger.SVC no prob.

closes: #15897


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass