### PR TITLE
feat(pkger): add ability to export resources to pkg in cli

### DIFF
--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -105,10 +105,11 @@ func bucketCreateF(cmd *cobra.Command, args []string) error {
 
 // BucketFindFlags define the Find Command
 type BucketFindFlags struct {
-	name  string
-	id    string
-	org   string
-	orgID string
+	name    string
+	id      string
+	org     string
+	orgID   string
+	headers bool
 }
 
 var bucketFindFlags BucketFindFlags
@@ -124,6 +125,7 @@ func init() {
 	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.id, "id", "i", "", "The bucket ID")
 	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.orgID, "org-id", "", "", "The bucket organization ID")
 	bucketFindCmd.Flags().StringVarP(&bucketFindFlags.org, "org", "o", "", "The bucket organization name")
+	bucketFindCmd.Flags().BoolVar(&bucketFindFlags.headers, "headers", true, "To print the table headers; defaults true")
 
 	bucketCmd.AddCommand(bucketFindCmd)
 }
@@ -169,6 +171,7 @@ func bucketFindF(cmd *cobra.Command, args []string) error {
 	}
 
 	w := internal.NewTabWriter(os.Stdout)
+	w.HideHeaders(!bucketFindFlags.headers)
 	w.WriteHeaders(
 		"ID",
 		"Name",

--- a/cmd/influx/internal/tabwriter.go
+++ b/cmd/influx/internal/tabwriter.go
@@ -10,8 +10,9 @@ import (
 )
 
 type tabWriter struct {
-	writer  *tabwriter.Writer
-	headers []string
+	writer      *tabwriter.Writer
+	headers     []string
+	hideHeaders bool
 }
 
 func NewTabWriter(w io.Writer) *tabWriter {
@@ -20,9 +21,15 @@ func NewTabWriter(w io.Writer) *tabWriter {
 	}
 }
 
+func (w *tabWriter) HideHeaders(b bool) {
+	w.hideHeaders = b
+}
+
 func (w *tabWriter) WriteHeaders(h ...string) {
 	w.headers = h
-	fmt.Fprintln(w.writer, strings.Join(h, "\t"))
+	if !w.hideHeaders {
+		fmt.Fprintln(w.writer, strings.Join(h, "\t"))
+	}
 }
 
 func (w *tabWriter) Write(m map[string]interface{}) {

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -19,6 +19,11 @@ import (
 
 const maxTCPConnections = 128
 
+type httpClientOpts struct {
+	token, addr string
+	skipVerify  bool
+}
+
 func main() {
 	influxCmd := influxCmd()
 	if err := influxCmd.Execute(); err != nil {

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/influxdata/influxdb"
+	"github.com/influxdata/influxdb/kit/errors"
 	"github.com/influxdata/influxdb/pkger"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,22 +26,30 @@ func Test_Pkg(t *testing.T) {
 		}
 	}
 
+	hasNotZeroDefault := func(t *testing.T, expected, actual string) {
+		t.Helper()
+		if expected == "" {
+			assert.NotZero(t, actual)
+			return
+		}
+		assert.Equal(t, expected, actual)
+	}
+
 	t.Run("new", func(t *testing.T) {
 		tests := []struct {
-			name         string
-			encoding     pkger.Encoding
-			filename     string
-			flags        []struct{ name, val string }
 			expectedMeta pkger.Metadata
+			args         pkgFileArgs
 		}{
 			{
-				name:     "yaml out",
-				encoding: pkger.EncodingYAML,
-				filename: "pkg_0.yml",
-				flags: []struct{ name, val string }{
-					{name: "name", val: "new name"},
-					{name: "description", val: "new desc"},
-					{name: "version", val: "new version"},
+				args: pkgFileArgs{
+					name:     "yaml out",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+					},
 				},
 				expectedMeta: pkger.Metadata{
 					Name:        "new name",
@@ -42,13 +58,15 @@ func Test_Pkg(t *testing.T) {
 				},
 			},
 			{
-				name:     "json out",
-				encoding: pkger.EncodingJSON,
-				filename: "pkg_1.json",
-				flags: []struct{ name, val string }{
-					{name: "name", val: "new name"},
-					{name: "description", val: "new desc"},
-					{name: "version", val: "new version"},
+				args: pkgFileArgs{
+					name:     "json out",
+					encoding: pkger.EncodingJSON,
+					filename: "pkg_1.json",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+					},
 				},
 				expectedMeta: pkger.Metadata{
 					Name:        "new name",
@@ -57,50 +75,369 @@ func Test_Pkg(t *testing.T) {
 				},
 			},
 			{
-				name:     "quiet mode",
-				encoding: pkger.EncodingJSON,
-				filename: "pkg_1.json",
-				flags: []struct{ name, val string }{
-					{name: "quiet", val: "true"},
+				args: pkgFileArgs{
+					name:     "quiet mode",
+					encoding: pkger.EncodingJSON,
+					filename: "pkg_1.json",
+					flags: []flagArg{
+						{name: "quiet", val: "true"},
+					},
 				},
 			},
+		}
+
+		cmdFn := func() *cobra.Command {
+			return pkgNewCmd(fakeSVCFn(pkger.NewService()))
 		}
 
 		for _, tt := range tests {
-			fn := func(t *testing.T) {
-				tempDir := newTempDir(t)
-				defer os.RemoveAll(tempDir)
-
-				pathToFile := filepath.Join(tempDir, tt.filename)
-
-				cmd := pkgCreateCmd(fakeSVCFn(pkger.NewService()))
-				require.NoError(t, cmd.Flags().Set("out", pathToFile))
-				for _, f := range tt.flags {
-					require.NoError(t, cmd.Flags().Set(f.name, f.val))
-				}
-				require.NoError(t, cmd.Execute())
-
-				pkg, err := pkger.Parse(tt.encoding, pkger.FromFile(pathToFile), pkger.ValidWithoutResources())
-				require.NoError(t, err)
-
-				assert.Equal(t, pkger.KindPackage.String(), pkg.Kind)
+			testPkgWrites(t, cmdFn, tt.args, func(t *testing.T, pkg *pkger.Pkg) {
 				assert.Equal(t, tt.expectedMeta.Description, pkg.Metadata.Description)
-
-				hasNotZeroDefault := func(t *testing.T, expected, actual string) {
-					t.Helper()
-					if expected == "" {
-						assert.NotZero(t, actual)
-						return
-					}
-					assert.Equal(t, expected, actual)
-				}
 				hasNotZeroDefault(t, tt.expectedMeta.Name, pkg.Metadata.Name)
 				hasNotZeroDefault(t, tt.expectedMeta.Version, pkg.Metadata.Version)
-			}
-
-			t.Run(tt.name, fn)
+			})
 		}
 	})
+
+	t.Run("export all", func(t *testing.T) {
+		expectedOrgID := influxdb.ID(9000)
+
+		tests := []struct {
+			pkgFileArgs
+			expectedMeta pkger.Metadata
+		}{
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "yaml out",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+						{name: "org-id", val: expectedOrgID.String()},
+					},
+				},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
+		}
+
+		cmdFn := func() *cobra.Command {
+			pkgSVC := &fakePkgSVC{
+				createFn: func(_ context.Context, opts ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
+					opt := pkger.CreateOpt{}
+					for _, o := range opts {
+						if err := o(&opt); err != nil {
+							return nil, err
+						}
+					}
+					if !opt.OrgIDs[expectedOrgID] {
+						return nil, errors.New("did not provide expected orgID")
+					}
+
+					pkg := pkger.Pkg{
+						APIVersion: pkger.APIVersion,
+						Kind:       pkger.KindPackage,
+						Metadata:   opt.Metadata,
+					}
+					pkg.Spec.Resources = append(pkg.Spec.Resources, pkger.Resource{
+						"name": "bucket1",
+						"kind": pkger.KindBucket.String(),
+					})
+					return &pkg, nil
+				},
+			}
+			return pkgExportAllCmd(fakeSVCFn(pkgSVC))
+		}
+		for _, tt := range tests {
+			testPkgWrites(t, cmdFn, tt.pkgFileArgs, func(t *testing.T, pkg *pkger.Pkg) {
+				assert.Equal(t, tt.expectedMeta.Description, pkg.Metadata.Description)
+				hasNotZeroDefault(t, tt.expectedMeta.Name, pkg.Metadata.Name)
+				hasNotZeroDefault(t, tt.expectedMeta.Version, pkg.Metadata.Version)
+
+				sum := pkg.Summary()
+
+				require.Len(t, sum.Buckets, 1)
+				assert.Equal(t, "bucket1", sum.Buckets[0].Name)
+			})
+		}
+	})
+
+	t.Run("export resources", func(t *testing.T) {
+		tests := []struct {
+			name string
+			pkgFileArgs
+			bucketIDs    []influxdb.ID
+			dashIDs      []influxdb.ID
+			labelIDs     []influxdb.ID
+			varIDs       []influxdb.ID
+			expectedMeta pkger.Metadata
+		}{
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "buckets",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+						{name: "version", val: "new version"},
+					},
+				},
+				bucketIDs: []influxdb.ID{1, 2},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "dashboards",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+						{name: "version", val: "new version"},
+					},
+				},
+				dashIDs: []influxdb.ID{1, 2},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "labels",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+						{name: "version", val: "new version"},
+					},
+				},
+				labelIDs: []influxdb.ID{1, 2},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "variables",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+						{name: "version", val: "new version"},
+					},
+				},
+				varIDs: []influxdb.ID{1, 2},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
+			{
+				pkgFileArgs: pkgFileArgs{
+					name:     "mixed",
+					encoding: pkger.EncodingYAML,
+					filename: "pkg_0.yml",
+					flags: []flagArg{
+						{name: "name", val: "new name"},
+						{name: "description", val: "new desc"},
+						{name: "version", val: "new version"},
+						{name: "version", val: "new version"},
+					},
+				},
+				bucketIDs: []influxdb.ID{1, 2},
+				dashIDs:   []influxdb.ID{3, 4},
+				labelIDs:  []influxdb.ID{5, 6},
+				varIDs:    []influxdb.ID{7, 8},
+				expectedMeta: pkger.Metadata{
+					Name:        "new name",
+					Description: "new desc",
+					Version:     "new version",
+				},
+			},
+		}
+
+		cmdFn := func() *cobra.Command {
+			pkgSVC := &fakePkgSVC{
+				createFn: func(_ context.Context, opts ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
+					opt := pkger.CreateOpt{}
+					for _, o := range opts {
+						if err := o(&opt); err != nil {
+							return nil, err
+						}
+					}
+
+					pkg := pkger.Pkg{
+						APIVersion: pkger.APIVersion,
+						Kind:       pkger.KindPackage,
+						Metadata:   opt.Metadata,
+					}
+					for _, rc := range opt.Resources {
+						name := rc.Kind.String() + strconv.Itoa(int(rc.ID))
+						pkg.Spec.Resources = append(pkg.Spec.Resources, pkger.Resource{
+							"kind": rc.Kind,
+							"name": name,
+						})
+					}
+
+					return &pkg, nil
+				},
+			}
+			return pkgExportCmd(fakeSVCFn(pkgSVC))
+		}
+		for _, tt := range tests {
+			tt.flags = append(tt.flags,
+				flagArg{"buckets", idsStr(tt.bucketIDs...)},
+				flagArg{"dashboards", idsStr(tt.dashIDs...)},
+				flagArg{"labels", idsStr(tt.labelIDs...)},
+				flagArg{"variables", idsStr(tt.varIDs...)},
+			)
+
+			testPkgWrites(t, cmdFn, tt.pkgFileArgs, func(t *testing.T, pkg *pkger.Pkg) {
+				assert.Equal(t, tt.expectedMeta.Description, pkg.Metadata.Description)
+				hasNotZeroDefault(t, tt.expectedMeta.Name, pkg.Metadata.Name)
+				hasNotZeroDefault(t, tt.expectedMeta.Version, pkg.Metadata.Version)
+
+				sum := pkg.Summary()
+
+				require.Len(t, sum.Buckets, len(tt.bucketIDs))
+				for i, id := range tt.bucketIDs {
+					actual := sum.Buckets[i]
+					assert.Equal(t, "bucket"+strconv.Itoa(int(id)), actual.Name)
+				}
+				require.Len(t, sum.Dashboards, len(tt.dashIDs))
+				for i, id := range tt.dashIDs {
+					actual := sum.Dashboards[i]
+					assert.Equal(t, "dashboard"+strconv.Itoa(int(id)), actual.Name)
+				}
+				require.Len(t, sum.Labels, len(tt.labelIDs))
+				for i, id := range tt.labelIDs {
+					actual := sum.Labels[i]
+					assert.Equal(t, "label"+strconv.Itoa(int(id)), actual.Name)
+				}
+				require.Len(t, sum.Variables, len(tt.varIDs))
+				for i, id := range tt.varIDs {
+					actual := sum.Variables[i]
+					assert.Equal(t, "variable"+strconv.Itoa(int(id)), actual.Name)
+				}
+			})
+		}
+	})
+}
+
+type flagArg struct{ name, val string }
+
+type pkgFileArgs struct {
+	name     string
+	filename string
+	encoding pkger.Encoding
+	flags    []flagArg
+}
+
+func testPkgWrites(t *testing.T, newCmdFn func() *cobra.Command, args pkgFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) {
+	wrappedCmdFn := func() *cobra.Command {
+		cmd := newCmdFn()
+		cmd.SetArgs([]string{})
+		return cmd
+	}
+
+	t.Run(path.Join(args.name, "file"), testPkgWritesFile(wrappedCmdFn, args, assertFn))
+	t.Run(path.Join(args.name, "buffer"), testPkgWritesToBuffer(wrappedCmdFn, args, assertFn))
+}
+
+func testPkgWritesFile(newCmdFn func() *cobra.Command, args pkgFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		tempDir := newTempDir(t)
+		defer os.RemoveAll(tempDir)
+
+		pathToFile := filepath.Join(tempDir, args.filename)
+
+		cmd := newCmdFn()
+		require.NoError(t, cmd.Flags().Set("file", pathToFile))
+		for _, f := range args.flags {
+			require.NoError(t, cmd.Flags().Set(f.name, f.val))
+		}
+
+		require.NoError(t, cmd.Execute())
+
+		pkg, err := pkger.Parse(args.encoding, pkger.FromFile(pathToFile), pkger.ValidWithoutResources())
+		require.NoError(t, err)
+
+		require.Equal(t, pkger.KindPackage, pkg.Kind)
+
+		assertFn(t, pkg)
+	}
+}
+
+func testPkgWritesToBuffer(newCmdFn func() *cobra.Command, args pkgFileArgs, assertFn func(t *testing.T, pkg *pkger.Pkg)) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Helper()
+
+		var buf bytes.Buffer
+		cmd := newCmdFn()
+		cmd.SetOutput(&buf)
+		for _, f := range args.flags {
+			require.NoError(t, cmd.Flags().Set(f.name, f.val))
+		}
+
+		require.NoError(t, cmd.Execute())
+
+		pkg, err := pkger.Parse(pkger.EncodingYAML, pkger.FromReader(&buf), pkger.ValidWithoutResources())
+		require.NoError(t, err)
+
+		require.Equal(t, pkger.KindPackage, pkg.Kind)
+
+		assertFn(t, pkg)
+	}
+}
+
+type fakePkgSVC struct {
+	createFn func(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error)
+	dryRunFn func(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error)
+	applyFn  func(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error)
+}
+
+func (f *fakePkgSVC) CreatePkg(ctx context.Context, setters ...pkger.CreatePkgSetFn) (*pkger.Pkg, error) {
+	if f.createFn != nil {
+		return f.createFn(ctx, setters...)
+	}
+	panic("not implemented")
+}
+
+func (f *fakePkgSVC) DryRun(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, pkger.Diff, error) {
+	if f.dryRunFn != nil {
+		return f.dryRunFn(ctx, orgID, pkg)
+	}
+	panic("not implemented")
+}
+
+func (f *fakePkgSVC) Apply(ctx context.Context, orgID influxdb.ID, pkg *pkger.Pkg) (pkger.Summary, error) {
+	if f.applyFn != nil {
+		return f.applyFn(ctx, orgID, pkg)
+	}
+	panic("not implemented")
 }
 
 func newTempDir(t *testing.T) string {
@@ -109,4 +446,12 @@ func newTempDir(t *testing.T) string {
 	tempDir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
 	return tempDir
+}
+
+func idsStr(ids ...influxdb.ID) string {
+	var idStrs []string
+	for _, id := range ids {
+		idStrs = append(idStrs, id.String())
+	}
+	return strings.Join(idStrs, ",")
 }

--- a/http/pkger_http_server_test.go
+++ b/http/pkger_http_server_test.go
@@ -56,7 +56,7 @@ func TestPkgerHTTPServer(t *testing.T) {
 					pkg := resp.Pkg
 					require.NoError(t, pkg.Validate())
 					assert.Equal(t, pkger.APIVersion, pkg.APIVersion)
-					assert.Equal(t, "package", pkg.Kind)
+					assert.Equal(t, pkger.KindPackage, pkg.Kind)
 
 					meta := pkg.Metadata
 					assert.Equal(t, "name1", meta.Name)

--- a/pkger/models.go
+++ b/pkger/models.go
@@ -30,7 +30,8 @@ var kinds = map[Kind]bool{
 // Kind is a resource kind.
 type Kind string
 
-func newKind(s string) Kind {
+// NewKind returns the kind parsed from the provided string.
+func NewKind(s string) Kind {
 	return Kind(strings.TrimSpace(strings.ToLower(s)))
 }
 

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -3050,7 +3050,7 @@ func nextField(t *testing.T, field string) (string, int) {
 
 type baseAsserts struct {
 	version     string
-	kind        string
+	kind        Kind
 	description string
 	metaName    string
 	metaVersion string
@@ -3063,7 +3063,7 @@ func validParsedPkg(t *testing.T, path string, encoding Encoding, expected baseA
 	require.NoError(t, err)
 
 	require.Equal(t, expected.version, pkg.APIVersion)
-	require.Equal(t, expected.kind, pkg.Kind)
+	require.True(t, pkg.Kind.is(expected.kind))
 	require.Equal(t, expected.description, pkg.Metadata.Description)
 	require.Equal(t, expected.metaName, pkg.Metadata.Name)
 	require.Equal(t, expected.metaVersion, pkg.Metadata.Version)
@@ -3108,7 +3108,7 @@ func testfileRunner(t *testing.T, path string, testFn func(t *testing.T, pkg *Pk
 
 			pkg := validParsedPkg(t, path+tt.extension, tt.encoding, baseAsserts{
 				version:     "0.1.0",
-				kind:        "Package",
+				kind:        KindPackage,
 				description: "pack description",
 				metaName:    "pkg_name",
 				metaVersion: "1",


### PR DESCRIPTION
big chunk of the work for: #15921 

couple other odds and ends that got extended here, having abiliy to turn off headers for the `influx bucket find` call (no need to `grep -v` first line), and the ability to take TTY inputs for the `influx pkg` cmd. This enables inputs like `<<EOF` document inputs, which is handy for scripting.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
