### PR TITLE
feat(ui): Add matching rules card to alert builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Features
 
 1. [16234](https://github.com/influxdata/influxdb/pull/16234): Add support for notification endpoints to influx templates/pkgs.
-1. [16242](https://github.com/influxdata/influxdb/pull/16242): Drop id prefix for secret key requirement for notification endpoints
+1. [16242](https://github.com/influxdata/influxdb/pull/16242): Drop id prefix for secret key requirement for notification
+   endpoints
 1. [16259](https://github.com/influxdata/influxdb/pull/16259): Add support for check resource to pkger parser
 1. [16262](https://github.com/influxdata/influxdb/pull/16262): Add support for check resource pkger dry run functionality
 1. [16275](https://github.com/influxdata/influxdb/pull/16275): Add support for check resource pkger apply functionality
@@ -25,6 +26,7 @@
 1. [16336](https://github.com/influxdata/influxdb/pull/16336): Manual Overrides for Readiness Endpoint
 1. [16347](https://github.com/influxdata/influxdb/pull/16347): Drop legacy inmem service implementation in favor of kv service with inmem dependency
 1. [16348](https://github.com/influxdata/influxdb/pull/16348): Drop legacy bolt service implementation in favor of kv service with bolt dependency
+1. [16014](https://github.com/influxdata/influxdb/pull/16014): While creating check, also display notification rules that would match check based on tag rules
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ### Features
 
 1. [16234](https://github.com/influxdata/influxdb/pull/16234): Add support for notification endpoints to influx templates/pkgs.
-1. [16242](https://github.com/influxdata/influxdb/pull/16242): Drop id prefix for secret key requirement for notification
-   endpoints
+1. [16242](https://github.com/influxdata/influxdb/pull/16242): Drop id prefix for secret key requirement for notification endpoints
 1. [16259](https://github.com/influxdata/influxdb/pull/16259): Add support for check resource to pkger parser
 1. [16262](https://github.com/influxdata/influxdb/pull/16262): Add support for check resource pkger dry run functionality
 1. [16275](https://github.com/influxdata/influxdb/pull/16275): Add support for check resource pkger apply functionality

--- a/ui/cypress/e2e/explorer.test.ts
+++ b/ui/cypress/e2e/explorer.test.ts
@@ -546,8 +546,11 @@ describe('DataExplorer', () => {
         cy.getByTestID('switch-to-script-editor').click()
 
         cy.getByTestID('time-machine--bottom').within(() => {
-          cy.get('textarea').type('from(', {force: true})
-          cy.getByTestID('time-machine-submit-button').click()
+          cy.get('textarea')
+            .type('from(', {force: true})
+            .then(() => {
+              cy.getByTestID('time-machine-submit-button').click()
+            })
         })
 
         cy.getByTestID('empty-graph--error').should('exist')

--- a/ui/src/alerting/components/builder/AlertBuilder.tsx
+++ b/ui/src/alerting/components/builder/AlertBuilder.tsx
@@ -6,6 +6,7 @@ import FancyScrollbar from 'src/shared/components/fancy_scrollbar/FancyScrollbar
 import CheckMetaCard from 'src/alerting/components/builder/CheckMetaCard'
 import CheckMessageCard from 'src/alerting/components/builder/CheckMessageCard'
 import CheckConditionsCard from 'src/alerting/components/builder/CheckConditionsCard'
+import CheckMatchingRulesCard from 'src/alerting/components/builder/CheckMatchingRulesCard'
 
 const AlertBuilder: FC = () => {
   return (
@@ -16,6 +17,7 @@ const AlertBuilder: FC = () => {
             <CheckMetaCard />
             <CheckMessageCard />
             <CheckConditionsCard />
+            <CheckMatchingRulesCard />
           </div>
         </FancyScrollbar>
       </div>

--- a/ui/src/alerting/components/builder/AlertBuilder.tsx
+++ b/ui/src/alerting/components/builder/AlertBuilder.tsx
@@ -7,6 +7,7 @@ import CheckMetaCard from 'src/alerting/components/builder/CheckMetaCard'
 import CheckMessageCard from 'src/alerting/components/builder/CheckMessageCard'
 import CheckConditionsCard from 'src/alerting/components/builder/CheckConditionsCard'
 import CheckMatchingRulesCard from 'src/alerting/components/builder/CheckMatchingRulesCard'
+import {isFlagEnabled} from 'src/shared/utils/featureFlag'
 
 const AlertBuilder: FC = () => {
   return (
@@ -17,7 +18,9 @@ const AlertBuilder: FC = () => {
             <CheckMetaCard />
             <CheckMessageCard />
             <CheckConditionsCard />
-            <CheckMatchingRulesCard />
+            {isFlagEnabled('matchingNotificationRules') && (
+              <CheckMatchingRulesCard />
+            )}
           </div>
         </FancyScrollbar>
       </div>

--- a/ui/src/alerting/components/builder/CheckMatchingRulesCard.tsx
+++ b/ui/src/alerting/components/builder/CheckMatchingRulesCard.tsx
@@ -15,7 +15,7 @@ import {
 } from '@influxdata/clockface'
 
 // API
-import {getNotificationRules} from 'src/client'
+import {getNotificationRules as apiGetNotificationRules} from 'src/client'
 
 //Types
 import {NotificationRule, AppState, CheckTagSet} from 'src/types'
@@ -61,7 +61,7 @@ const CheckMatchingRulesCard: FunctionComponent<StateProps> = ({
       `${t[0].trim()}:${t[1].trim()}`,
     ])
 
-    const resp = await getNotificationRules({
+    const resp = await apiGetNotificationRules({
       query: [['orgID', orgID], ...tagsList] as any,
     })
 

--- a/ui/src/alerting/components/builder/CheckMatchingRulesCard.tsx
+++ b/ui/src/alerting/components/builder/CheckMatchingRulesCard.tsx
@@ -4,7 +4,13 @@ import {connect} from 'react-redux'
 
 // Components
 import MatchingRuleCard from 'src/alerting/components/builder/MatchingRuleCard'
-import {SpinnerContainer, TechnoSpinner} from '@influxdata/clockface'
+import {
+  SpinnerContainer,
+  TechnoSpinner,
+  FlexBox,
+  FlexDirection,
+  AlignItems,
+} from '@influxdata/clockface'
 
 // API
 import * as api from 'src/client'
@@ -12,6 +18,7 @@ import * as api from 'src/client'
 //Types
 import {NotificationRule, AppState, CheckTagSet} from 'src/types'
 import {EmptyState, ComponentSize, RemoteDataState} from '@influxdata/clockface'
+import BuilderCard from 'src/timeMachine/components/builderCard/BuilderCard'
 
 interface StateProps {
   tags: CheckTagSet[]
@@ -23,7 +30,9 @@ const CheckMatchingRulesCard: FunctionComponent<StateProps> = ({
   tags,
 }) => {
   const getMatchingRules = async (): Promise<NotificationRule[]> => {
-    const tagsList = tags.map(t => ['tag', `${t.key}:${t.value}`])
+    const tagsList = tags
+      .filter(t => t.key && t.value)
+      .map(t => ['tag', `${t.key}:${t.value}`])
 
     // todo also: get tags from query results
 
@@ -33,6 +42,7 @@ const CheckMatchingRulesCard: FunctionComponent<StateProps> = ({
 
     if (resp.status !== 200) {
       setMatchingRules({matchingRules: [], status: RemoteDataState.Error})
+      //TODO:notify?
       return
     }
 
@@ -55,40 +65,57 @@ const CheckMatchingRulesCard: FunctionComponent<StateProps> = ({
     getMatchingRules()
   }, [tags])
 
-  const emptyState = (
-    <EmptyState
-      size={ComponentSize.Small}
-      className="alert-builder--card__empty"
-    >
-      <EmptyState.Text>
-        Notification Rules configured to act on tag sets matching this Alert
-        Check will automatically show up here
-      </EmptyState.Text>
-      <EmptyState.Text>
-        Looks like no notification rules match the tag set defined in this Alert
-        Check
-      </EmptyState.Text>
-    </EmptyState>
-  )
+  let contents: JSX.Element
 
   if (
     status === RemoteDataState.NotStarted ||
     status === RemoteDataState.Loading
   ) {
-    return (
+    contents = (
       <SpinnerContainer spinnerComponent={<TechnoSpinner />} loading={status} />
+    )
+  } else if (matchingRules.length === 0) {
+    contents = (
+      <EmptyState
+        size={ComponentSize.Small}
+        className="alert-builder--card__empty"
+      >
+        <EmptyState.Text>
+          Notification Rules configured to act on tag sets matching this Alert
+          Check will show up here
+        </EmptyState.Text>
+        <EmptyState.Text>
+          Looks like no notification rules match the tag set defined in this
+          Alert Check
+        </EmptyState.Text>
+      </EmptyState>
+    )
+  } else {
+    contents = (
+      <>
+        {matchingRules.map(r => (
+          <MatchingRuleCard key={r.id} rule={r} />
+        ))}
+      </>
     )
   }
 
-  if (matchingRules.length === 0) {
-    return emptyState
-  }
   return (
-    <>
-      {matchingRules.map(r => (
-        <MatchingRuleCard key={r.id} rule={r} />
-      ))}
-    </>
+    <BuilderCard
+      testID="builder-conditions"
+      className="alert-builder--card alert-builder--conditions-card"
+    >
+      <BuilderCard.Header title="Matching Notification Rules" />
+      <BuilderCard.Body addPadding={true} autoHideScrollbars={true}>
+        <FlexBox
+          direction={FlexDirection.Column}
+          alignItems={AlignItems.Stretch}
+          margin={ComponentSize.Medium}
+        >
+          {contents}
+        </FlexBox>
+      </BuilderCard.Body>
+    </BuilderCard>
   )
 }
 

--- a/ui/src/shared/utils/featureFlag.ts
+++ b/ui/src/shared/utils/featureFlag.ts
@@ -2,17 +2,16 @@ import {FunctionComponent} from 'react'
 import {CLOUD, CLOUD_BILLING_VISIBLE} from 'src/shared/constants'
 
 export const OSS_FLAGS = {
-  alerting: false,
   deleteWithPredicate: false,
   monacoEditor: false,
   downloadCellCSV: false,
   telegrafEditor: false,
   queryBuilderGrouping: false,
   customCheckQuery: false,
+  matchingNotificationRules: false,
 }
 
 export const CLOUD_FLAGS = {
-  alerting: true,
   deleteWithPredicate: false,
   monacoEditor: false,
   cloudBilling: CLOUD_BILLING_VISIBLE, // should be visible in dev and acceptance, but not in cloud
@@ -20,6 +19,7 @@ export const CLOUD_FLAGS = {
   telegrafEditor: false,
   queryBuilderGrouping: false,
   customCheckQuery: false,
+  matchingNotificationRules: false,
 }
 
 export const isFlagEnabled = (flagName: string, equals?: string | boolean) => {


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/15806

Adds 'matching rules' card to check creation page, which displays any notification rules that "would match" the tags that are on statuses generated by the check. The back end work is in https://github.com/influxdata/influxdb/pull/16328.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] http/swagger.yml updated (if modified Go structs or API)
- [ ] Documentation updated or issue created (provide link to issue/pr)
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
