### PR TITLE
feat(influx): add pkg summary and validate cmds

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -48,7 +48,7 @@ func influxCmd() *cobra.Command {
 		deleteCmd,
 		organizationCmd,
 		pingCmd,
-		pkgCmd(newPkgerSVC),
+		cmdPkg(newPkgerSVC),
 		queryCmd,
 		replCmd,
 		setupCmd,

--- a/cmd/influx/pkg.go
+++ b/cmd/influx/pkg.go
@@ -76,6 +76,7 @@ func (b *cmdPkgBuilder) cmdPkg() *cobra.Command {
 	cmd.AddCommand(
 		b.cmdPkgNew(),
 		b.cmdPkgExport(),
+		b.cmdPkgSummary(),
 		b.cmdPkgValidate(),
 	)
 	return cmd
@@ -307,14 +308,35 @@ func (b *cmdPkgBuilder) pkgExportAllRunEFn() func(*cobra.Command, []string) erro
 	}
 }
 
+func (b *cmdPkgBuilder) cmdPkgSummary() *cobra.Command {
+	cmd := b.newCmd("summary")
+	cmd.Short = "Summarize the provided package"
+
+	cmd.Flags().StringVarP(&b.file, "file", "f", "", "input file for pkg; if none provided will use TTY input")
+	cmd.Flags().BoolVarP(&b.hasColor, "color", "c", true, "Enable color in output, defaults true")
+	cmd.Flags().BoolVar(&b.hasTableBorders, "table-borders", true, "Enable table borders, defaults true")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		pkg, _, err := b.readPkgStdInOrFile(b.file)
+		if err != nil {
+			return err
+		}
+
+		b.printPkgSummary(pkg.Summary())
+		return nil
+	}
+
+	return cmd
+}
+
 func (b *cmdPkgBuilder) cmdPkgValidate() *cobra.Command {
 	cmd := b.newCmd("validate")
 	cmd.Short = "Validate the provided package"
 
-	inPath := cmd.Flags().StringP("file", "f", "", "input file for pkg; if none provided will use TTY input")
+	cmd.Flags().StringVarP(&b.file, "file", "f", "", "input file for pkg; if none provided will use TTY input")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		pkg, _, err := b.readPkgStdInOrFile(*inPath)
+		pkg, _, err := b.readPkgStdInOrFile(b.file)
 		if err != nil {
 			return err
 		}

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -87,7 +87,7 @@ func Test_Pkg(t *testing.T) {
 		}
 
 		cmdFn := func() *cobra.Command {
-			return pkgNewCmd(fakeSVCFn(pkger.NewService()))
+			return cmdPkgNew(fakeSVCFn(pkger.NewService()))
 		}
 
 		for _, tt := range tests {
@@ -151,7 +151,7 @@ func Test_Pkg(t *testing.T) {
 					return &pkg, nil
 				},
 			}
-			return pkgExportAllCmd(fakeSVCFn(pkgSVC))
+			return cmdPkgExportAll(fakeSVCFn(pkgSVC))
 		}
 		for _, tt := range tests {
 			testPkgWrites(t, cmdFn, tt.pkgFileArgs, func(t *testing.T, pkg *pkger.Pkg) {
@@ -303,7 +303,7 @@ func Test_Pkg(t *testing.T) {
 					return &pkg, nil
 				},
 			}
-			return pkgExportCmd(fakeSVCFn(pkgSVC))
+			return cmdPkgExport(fakeSVCFn(pkgSVC))
 		}
 		for _, tt := range tests {
 			tt.flags = append(tt.flags,

--- a/cmd/influx/pkg_test.go
+++ b/cmd/influx/pkg_test.go
@@ -347,6 +347,30 @@ func Test_Pkg(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("validate", func(t *testing.T) {
+		t.Run("pkg is valid returns no error", func(t *testing.T) {
+			cmd := newCmdPkgBuilder(fakeSVCFn(new(fakePkgSVC))).cmdPkgValidate()
+			require.NoError(t, cmd.Flags().Set("file", "../../pkger/testdata/bucket.yml"))
+			require.NoError(t, cmd.Execute())
+		})
+
+		t.Run("pkg is invalid returns error", func(t *testing.T) {
+			// pkgYml is invalid because it is missing a name
+			const pkgYml = `apiVersion: 0.1.0
+kind: Package
+meta:
+  pkgName:      pkg_name
+  pkgVersion:   1
+spec:
+  resources:
+    - kind: Bucket`
+
+			b := newCmdPkgBuilder(fakeSVCFn(new(fakePkgSVC)), in(strings.NewReader(pkgYml)), out(ioutil.Discard))
+			cmd := b.cmdPkgValidate()
+			require.Error(t, cmd.Execute())
+		})
+	})
 }
 
 type flagArg struct{ name, val string }


### PR DESCRIPTION
adds ability to validate and summarize a package form `influx` cli. I was refactoring the cli for pkg up a bit here to tighten things up. 

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass