### PR TITLE
feat: enable 32-bit support for influxd

### DIFF
--- a/inmem/kv_test.go
+++ b/inmem/kv_test.go
@@ -174,7 +174,7 @@ func BenchmarkKVStore_Bucket_Cursor(b *testing.B) {
 
 const sourceFile = "kvdata/keys.txt"
 
-func fillBucket(t testing.TB, s *inmem.KVStore, bucket string, lines int) {
+func fillBucket(t testing.TB, s *inmem.KVStore, bucket string, lines int64) {
 	t.Helper()
 	err := s.Update(context.Background(), func(tx kv.Tx) error {
 		b, err := tx.Bucket([]byte(bucket))
@@ -189,7 +189,7 @@ func fillBucket(t testing.TB, s *inmem.KVStore, bucket string, lines int) {
 		defer f.Close()
 
 		if lines == 0 {
-			lines = math.MaxInt64
+			lines = int64(math.MaxInt64)
 		}
 
 		scan := bufio.NewScanner(bufio.NewReader(f))

--- a/storage/retention_test.go
+++ b/storage/retention_test.go
@@ -217,7 +217,7 @@ func TestRetentionService(t *testing.T) {
 	gotMatched := map[string]struct{}{}
 	engine.DeleteBucketRangeFn = func(ctx context.Context, orgID, bucketID influxdb.ID, from, to int64) error {
 		if from != math.MinInt64 {
-			t.Fatalf("got from %d, expected %d", from, math.MinInt64)
+			t.Fatalf("got from %d, expected %d", from, int64(math.MinInt64))
 		}
 		wantTo := now.Add(-3 * time.Hour).UnixNano()
 		if to != wantTo {

--- a/task/backend/scheduler.go
+++ b/task/backend/scheduler.go
@@ -187,11 +187,12 @@ func NewScheduler(taskControlService TaskControlService, executor Executor, now 
 }
 
 type TickScheduler struct {
+	now int64 // Accessed via atomic; ensure 8b word 8b aligned.
+
 	taskControlService TaskControlService
 	executor           Executor
 
 	maxConcurrency int
-	now            int64
 	logger         *zap.Logger
 
 	metrics *schedulerMetrics

--- a/tsdb/tsm1/cache_entry.go
+++ b/tsdb/tsm1/cache_entry.go
@@ -10,12 +10,12 @@ import (
 
 // entry is a set of values and some metadata.
 type entry struct {
+	// Tracks the number of values in the entry. Must always be accessed via
+	// atomic; must be 8b aligned.
+	n int64
+
 	mu     sync.RWMutex
 	values Values // All stored values.
-
-	// Tracks the number of values in the entry. Must always be accessed via
-	// atomic.
-	n int64
 
 	// The type of values stored. Read only so doesn't need to be protected by mu.
 	vtype byte

--- a/tsdb/tsm1/tombstone.go
+++ b/tsdb/tsm1/tombstone.go
@@ -456,7 +456,7 @@ func (t *Tombstoner) readTombstoneV4(f *os.File, fn func(t Tombstone) error) err
 		}
 	}
 
-	const kmask = 0xff000000 // Mask for non key-length bits
+	const kmask = int64(0xff000000) // Mask for non key-length bits
 
 	br := bufio.NewReaderSize(f, 64*1024)
 	gr, err := gzip.NewReader(br)
@@ -484,14 +484,14 @@ func (t *Tombstoner) readTombstoneV4(f *os.File, fn func(t Tombstone) error) err
 					return err
 				}
 
-				keyLen := int(binary.BigEndian.Uint32(buf[:4]))
+				keyLen := int64(binary.BigEndian.Uint32(buf[:4]))
 				prefix := keyLen>>31&1 == 1 // Prefix is set according to whether the highest bit is set.
 				hasPred := keyLen>>30&1 == 1
 
 				// Remove 8 MSB to get correct length.
 				keyLen &^= kmask
 
-				if len(keyBuf) < keyLen {
+				if int64(len(keyBuf)) < keyLen {
 					keyBuf = make([]byte, keyLen)
 				}
 				// cap slice protects against invalid usages of append in callback


### PR DESCRIPTION
This PR ensures that `influxd` can be built on a 32-bit architecture. 

In order to keep 32-bit supported we will need to add a dedicated CI pipeline.