### PR TITLE
fix(jwt): panic on call to token.Identifier()

### DIFF
--- a/jsonweb/token.go
+++ b/jsonweb/token.go
@@ -110,7 +110,11 @@ func (t *Token) Allowed(p influxdb.Permission) bool {
 // Identifier returns the identifier for this Token
 // as found in the standard claims
 func (t *Token) Identifier() influxdb.ID {
-	id, _ := influxdb.IDFromString(t.Id)
+	id, err := influxdb.IDFromString(t.Id)
+	if err != nil || id == nil {
+		return influxdb.ID(0)
+	}
+
 	return *id
 }
 

--- a/jsonweb/token_test.go
+++ b/jsonweb/token_test.go
@@ -80,6 +80,12 @@ func Test_TokenParser(t *testing.T) {
 			if diff := cmp.Diff(test.token, token); diff != "" {
 				t.Errorf("unexpected token:\n%s", diff)
 			}
+
+			// if err is nil then token should be present
+			if err == nil {
+				// ensure this does not panic
+				token.Identifier()
+			}
 		})
 	}
 }


### PR DESCRIPTION
When a token is parsed without an ID it should not lead to a panic.

This fixes the scenario when a token has no ID. Instead of panicing it just returns an invalid influx ID. (0).

- [x] [CHANGELOG.md](https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md) updated with a link to the PR (not the Issue)
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)
- [x] Documentation updated or issue created (provide link to issue/pr)
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)
