### PR TITLE
feat(pkger): move bucket pkger model to reflect http APIs retention rules

### DIFF
--- a/pkger/clone_resource.go
+++ b/pkger/clone_resource.go
@@ -63,7 +63,7 @@ func bucketToResource(bkt influxdb.Bucket, name string) Resource {
 		r[fieldDescription] = bkt.Description
 	}
 	if bkt.RetentionPeriod != 0 {
-		r[fieldBucketRetentionPeriod] = bkt.RetentionPeriod.String()
+		r[fieldBucketRetentionRules] = retentionRules{newRetentionRule(bkt.RetentionPeriod)}
 	}
 	return r
 }
@@ -351,7 +351,7 @@ func variableToResource(v influxdb.Variable, name string) Resource {
 	case fieldArgTypeQuery:
 		vals, ok := args.Values.(influxdb.VariableQueryValues)
 		if ok {
-			r[fieldVarLanguage] = vals.Language
+			r[fieldLanguage] = vals.Language
 			r[fieldQuery] = vals.Query
 		}
 	}

--- a/pkger/models_test.go
+++ b/pkger/models_test.go
@@ -16,18 +16,18 @@ func TestPkg(t *testing.T) {
 			pkg := Pkg{
 				mBuckets: map[string]*bucket{
 					"buck_2": {
-						id:              influxdb.ID(2),
-						OrgID:           influxdb.ID(100),
-						Description:     "desc2",
-						Name:            "name2",
-						RetentionPeriod: 2 * time.Hour,
+						id:             influxdb.ID(2),
+						OrgID:          influxdb.ID(100),
+						Description:    "desc2",
+						Name:           "name2",
+						RetentionRules: retentionRules{newRetentionRule(2 * time.Hour)},
 					},
 					"buck_1": {
-						id:              influxdb.ID(1),
-						OrgID:           influxdb.ID(100),
-						Name:            "name1",
-						Description:     "desc1",
-						RetentionPeriod: time.Hour,
+						id:             influxdb.ID(1),
+						OrgID:          influxdb.ID(100),
+						Name:           "name1",
+						Description:    "desc1",
+						RetentionRules: retentionRules{newRetentionRule(time.Hour)},
 					},
 				},
 			}

--- a/pkger/parser_test.go
+++ b/pkger/parser_test.go
@@ -117,9 +117,9 @@ spec:
 
 				actual := buckets[0]
 				expectedBucket := bucket{
-					Name:            "rucket_11",
-					Description:     "bucket 1 description",
-					RetentionPeriod: time.Hour,
+					Name:           "rucket_11",
+					Description:    "bucket 1 description",
+					RetentionRules: retentionRules{newRetentionRule(time.Hour)},
 				}
 				assert.Equal(t, expectedBucket, *actual)
 			})

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -829,9 +829,10 @@ func (s *Service) rollbackBuckets(buckets []*bucket) error {
 			continue
 		}
 
+		rp := b.RetentionRules.RP()
 		_, err := s.bucketSVC.UpdateBucket(context.Background(), b.ID(), influxdb.BucketUpdate{
 			Description:     &b.Description,
-			RetentionPeriod: &b.RetentionPeriod,
+			RetentionPeriod: &rp,
 		})
 		if err != nil {
 			errs = append(errs, b.ID().String())
@@ -847,10 +848,11 @@ func (s *Service) rollbackBuckets(buckets []*bucket) error {
 }
 
 func (s *Service) applyBucket(ctx context.Context, b *bucket) (influxdb.Bucket, error) {
+	rp := b.RetentionRules.RP()
 	if b.existing != nil {
 		influxBucket, err := s.bucketSVC.UpdateBucket(ctx, b.ID(), influxdb.BucketUpdate{
 			Description:     &b.Description,
-			RetentionPeriod: &b.RetentionPeriod,
+			RetentionPeriod: &rp,
 		})
 		if err != nil {
 			return influxdb.Bucket{}, err
@@ -862,7 +864,7 @@ func (s *Service) applyBucket(ctx context.Context, b *bucket) (influxdb.Bucket, 
 		OrgID:           b.OrgID,
 		Description:     b.Description,
 		Name:            b.Name,
-		RetentionPeriod: b.RetentionPeriod,
+		RetentionPeriod: rp,
 	}
 	err := s.bucketSVC.CreateBucket(ctx, &influxBucket)
 	if err != nil {

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -234,7 +234,7 @@ func TestService(t *testing.T) {
 						OrgID:           orgID,
 						Name:            pkgBkt.Name,
 						Description:     pkgBkt.Description,
-						RetentionPeriod: pkgBkt.RetentionPeriod,
+						RetentionPeriod: pkgBkt.RetentionRules.RP(),
 					}
 
 					fakeBktSVC := mock.NewBucketService()

--- a/pkger/testdata/bucket.json
+++ b/pkger/testdata/bucket.json
@@ -11,6 +11,12 @@
       {
         "kind": "Bucket",
         "name": "rucket_11",
+        "retentionRules": [
+          {
+            "type": "expire",
+            "everySeconds": 3600
+          }
+        ],
         "retention_period": "1h",
         "description": "bucket 1 description"
       }

--- a/pkger/testdata/bucket.yml
+++ b/pkger/testdata/bucket.yml
@@ -8,5 +8,7 @@ spec:
   resources:
     - kind: Bucket
       name: rucket_11
-      retention_period: 1h
       description: bucket 1 description
+      retentionRules:
+        - type: expire
+          everySeconds: 3600


### PR DESCRIPTION
Closes #15987 

after discussion with @goller, we'd like pkger to reflect teh same API as the http bucket api for rentention rules in place of retention period.

- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [ ] Tests pass