### PR TITLE
fix(jwt): jwt id's can't be invalid when marshaling

### DIFF
--- a/jsonweb/token.go
+++ b/jsonweb/token.go
@@ -112,7 +112,7 @@ func (t *Token) Allowed(p influxdb.Permission) bool {
 func (t *Token) Identifier() influxdb.ID {
 	id, err := influxdb.IDFromString(t.Id)
 	if err != nil || id == nil {
-		return influxdb.ID(0)
+		return influxdb.ID(1)
 	}
 
 	return *id


### PR DESCRIPTION
When converting a jwt token to a influxdb.Auth the id must be present for json marshal to work. A workaround is in place but the workaround created an invalid id.