### PR TITLE
chore(pkger): refactor diff into common types for easier access

### DIFF
--- a/http/swagger.yml
+++ b/http/swagger.yml
@@ -6928,6 +6928,7 @@ components:
           format: date-time
           readOnly: true
         retentionRules:
+          $ref: "#/components/schemas/RetentionRules"
           type: array
           description: Rules to expire or retain data.  No rules means data never expires.
           items:
@@ -6957,6 +6958,23 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Bucket"
+    RetentionRules:
+      type: array
+      description: Rules to expire or retain data.  No rules means data never expires.
+      items:
+        type: object
+        properties:
+          type:
+            type: string
+            default: expire
+            enum:
+              - expire
+          everySeconds:
+            type: integer
+            description: Duration in seconds for how long data will be kept in the database.
+            example: 86400
+            minimum: 1
+        required: [type, everySeconds]
     Link:
       type: string
       format: uri
@@ -7224,14 +7242,20 @@ components:
                     type: string
                   name:
                     type: string
-                  oldDescription:
-                    type: string
-                  newDescription:
-                    type: string
-                  oldRP:
-                    type: string
-                  newRP:
-                    type: string
+                  new:
+                    type: object
+                    properties:
+                      description:
+                        type: string
+                      retentionRules:
+                        $ref: "#/components/schemas/RetentionRules"
+                  old:
+                    type: object
+                    properties:
+                      description:
+                        type: string
+                      retentionRules:
+                        $ref: "#/components/schemas/RetentionRules"
             dashboards:
               type: array
               items:
@@ -7254,14 +7278,20 @@ components:
                     type: string
                   name:
                     type: string
-                  oldDescription:
-                    type: string
-                  newDescription:
-                    type: string
-                  oldColor:
-                    type: string
-                  newColor:
-                    type: string
+                  new:
+                    type: object
+                    properties:
+                      color:
+                        type: string
+                      description:
+                        type: string
+                  old:
+                    type: object
+                    properties:
+                      color:
+                        type: string
+                      description:
+                        type: string
             labelMappings:
               type: array
               items:
@@ -7288,14 +7318,20 @@ components:
                     type: string
                   name:
                     type: string
-                  oldDescription:
-                    type: string
-                  newDescription:
-                    type: string
-                  oldArgs:
-                    $ref: "#/components/schemas/VariableProperties"
-                  newArgs:
-                    $ref: "#/components/schemas/VariableProperties"
+                  new:
+                    type: object
+                    properties:
+                      description:
+                        type: string
+                      args:
+                        $ref: "#/components/schemas/VariableProperties"
+                  old:
+                    type: object
+                    properties:
+                      description:
+                        type: string
+                      args:
+                        $ref: "#/components/schemas/VariableProperties"
         errors:
           type: array
           items:

--- a/pkger/service.go
+++ b/pkger/service.go
@@ -502,9 +502,9 @@ func (s *Service) dryRunBuckets(ctx context.Context, orgID influxdb.ID, pkg *Pkg
 		//  err isn't a not found (some other error)
 		case nil:
 			b.existing = existingBkt
-			mExistingBkts[b.Name] = newDiffBucket(b, *existingBkt)
+			mExistingBkts[b.Name] = newDiffBucket(b, existingBkt)
 		default:
-			mExistingBkts[b.Name] = newDiffBucket(b, influxdb.Bucket{})
+			mExistingBkts[b.Name] = newDiffBucket(b, nil)
 		}
 	}
 
@@ -547,9 +547,9 @@ func (s *Service) dryRunLabels(ctx context.Context, orgID influxdb.ID, pkg *Pkg)
 		case err == nil && len(existingLabels) > 0:
 			existingLabel := existingLabels[0]
 			pkgLabel.existing = existingLabel
-			mExistingLabels[pkgLabel.Name] = newDiffLabel(pkgLabel, *existingLabel)
+			mExistingLabels[pkgLabel.Name] = newDiffLabel(pkgLabel, existingLabel)
 		default:
-			mExistingLabels[pkgLabel.Name] = newDiffLabel(pkgLabel, influxdb.Label{})
+			mExistingLabels[pkgLabel.Name] = newDiffLabel(pkgLabel, nil)
 		}
 	}
 
@@ -585,14 +585,14 @@ VarLoop:
 					continue
 				}
 				pkgVar.existing = existingVar
-				mExistingLabels[pkgVar.Name] = newDiffVariable(pkgVar, *existingVar)
+				mExistingLabels[pkgVar.Name] = newDiffVariable(pkgVar, existingVar)
 				continue VarLoop
 			}
 			// fallthrough here for when the variable is not found, it'll fall to the
 			// default case and add it as new.
 			fallthrough
 		default:
-			mExistingLabels[pkgVar.Name] = newDiffVariable(pkgVar, influxdb.Variable{})
+			mExistingLabels[pkgVar.Name] = newDiffVariable(pkgVar, nil)
 		}
 	}
 

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -36,12 +36,16 @@ func TestService(t *testing.T) {
 					require.Len(t, diff.Buckets, 1)
 
 					expected := DiffBucket{
-						ID:           SafeID(1),
-						Name:         "rucket_11",
-						OldDesc:      "old desc",
-						NewDesc:      "bucket 1 description",
-						OldRetention: 30 * time.Hour,
-						NewRetention: time.Hour,
+						ID:   SafeID(1),
+						Name: "rucket_11",
+						Old: &DiffBucketValues{
+							Description:    "old desc",
+							RetentionRules: retentionRules{newRetentionRule(30 * time.Hour)},
+						},
+						New: DiffBucketValues{
+							Description:    "bucket 1 description",
+							RetentionRules: retentionRules{newRetentionRule(time.Hour)},
+						},
 					}
 					assert.Equal(t, expected, diff.Buckets[0])
 				})
@@ -61,11 +65,14 @@ func TestService(t *testing.T) {
 					require.Len(t, diff.Buckets, 1)
 
 					expected := DiffBucket{
-						Name:         "rucket_11",
-						NewDesc:      "bucket 1 description",
-						NewRetention: time.Hour,
+						Name: "rucket_11",
+						New: DiffBucketValues{
+							Description:    "bucket 1 description",
+							RetentionRules: retentionRules{newRetentionRule(time.Hour)},
+						},
 					}
 					assert.Equal(t, expected, diff.Buckets[0])
+					t.Log(diff.Buckets[0].Old)
 				})
 			})
 		})
@@ -94,18 +101,22 @@ func TestService(t *testing.T) {
 					require.Len(t, diff.Labels, 2)
 
 					expected := DiffLabel{
-						ID:       SafeID(1),
-						Name:     "label_1",
-						OldColor: "old color",
-						NewColor: "#FFFFFF",
-						OldDesc:  "old description",
-						NewDesc:  "label 1 description",
+						ID:   SafeID(1),
+						Name: "label_1",
+						Old: &DiffLabelValues{
+							Color:       "old color",
+							Description: "old description",
+						},
+						New: DiffLabelValues{
+							Color:       "#FFFFFF",
+							Description: "label 1 description",
+						},
 					}
 					assert.Equal(t, expected, diff.Labels[0])
 
 					expected.Name = "label_2"
-					expected.NewColor = "#000000"
-					expected.NewDesc = "label 2 description"
+					expected.New.Color = "#000000"
+					expected.New.Description = "label 2 description"
 					assert.Equal(t, expected, diff.Labels[1])
 				})
 			})
@@ -124,15 +135,17 @@ func TestService(t *testing.T) {
 					require.Len(t, diff.Labels, 2)
 
 					expected := DiffLabel{
-						Name:     "label_1",
-						NewColor: "#FFFFFF",
-						NewDesc:  "label 1 description",
+						Name: "label_1",
+						New: DiffLabelValues{
+							Color:       "#FFFFFF",
+							Description: "label 1 description",
+						},
 					}
 					assert.Equal(t, expected, diff.Labels[0])
 
 					expected.Name = "label_2"
-					expected.NewColor = "#000000"
-					expected.NewDesc = "label 2 description"
+					expected.New.Color = "#000000"
+					expected.New.Description = "label 2 description"
 					assert.Equal(t, expected, diff.Labels[1])
 				})
 			})
@@ -162,25 +175,30 @@ func TestService(t *testing.T) {
 				require.Len(t, diff.Variables, 4)
 
 				expected := DiffVariable{
-					ID:      SafeID(1),
-					Name:    "var_const",
-					OldDesc: "old desc",
-					NewDesc: "var_const desc",
-					NewArgs: &influxdb.VariableArguments{
-						Type:   "constant",
-						Values: influxdb.VariableConstantValues{"first val"},
+					ID:   SafeID(1),
+					Name: "var_const",
+					Old: &DiffVariableValues{
+						Description: "old desc",
+					},
+					New: DiffVariableValues{
+						Description: "var_const desc",
+						Args: &influxdb.VariableArguments{
+							Type:   "constant",
+							Values: influxdb.VariableConstantValues{"first val"},
+						},
 					},
 				}
 				assert.Equal(t, expected, diff.Variables[0])
 
 				expected = DiffVariable{
 					// no ID here since this one would be new
-					Name:    "var_map",
-					OldDesc: "",
-					NewDesc: "var_map desc",
-					NewArgs: &influxdb.VariableArguments{
-						Type:   "map",
-						Values: influxdb.VariableMapValues{"k1": "v1"},
+					Name: "var_map",
+					New: DiffVariableValues{
+						Description: "var_map desc",
+						Args: &influxdb.VariableArguments{
+							Type:   "map",
+							Values: influxdb.VariableMapValues{"k1": "v1"},
+						},
 					},
 				}
 				assert.Equal(t, expected, diff.Variables[1])


### PR DESCRIPTION
This is a small refactor of the pkger.Diff type. After discussion with @goller, looking to increase connascence across old and new types, and this brings a step close to that.


- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass
- [x] http/swagger.yml updated (if modified Go structs or API)