### PR TITLE
fix(ui): allow telegraf output without buckets

### DIFF
--- a/ui/src/shared/components/CodeSnippet.tsx
+++ b/ui/src/shared/components/CodeSnippet.tsx
@@ -23,7 +23,7 @@ class CodeSnippet extends PureComponent<Props> {
 
   public render() {
     const {copyText, label} = this.props
-    let testID = this.props.testID || 'code-snippet'
+    const testID = this.props.testID || 'code-snippet'
 
     return (
       <div className="code-snippet" data-testid={testID}>

--- a/ui/src/shared/components/CodeSnippet.tsx
+++ b/ui/src/shared/components/CodeSnippet.tsx
@@ -26,8 +26,7 @@ class CodeSnippet extends PureComponent<Props> {
     let testID = this.props.testID || 'code-snippet'
 
     return (
-      <div className="code-snippet"
-        data-testid={ testID }>
+      <div className="code-snippet" data-testid={testID}>
         <FancyScrollbar
           autoHide={false}
           autoHeight={true}

--- a/ui/src/shared/components/CodeSnippet.tsx
+++ b/ui/src/shared/components/CodeSnippet.tsx
@@ -11,6 +11,7 @@ import CopyButton from 'src/shared/components/CopyButton'
 
 export interface Props {
   copyText: string
+  testID?: string
   label: string
 }
 
@@ -22,8 +23,11 @@ class CodeSnippet extends PureComponent<Props> {
 
   public render() {
     const {copyText, label} = this.props
+    let testID = this.props.testID || 'code-snippet'
+
     return (
-      <div className="code-snippet">
+      <div className="code-snippet"
+        data-testid={ testID }>
         <FancyScrollbar
           autoHide={false}
           autoHeight={true}

--- a/ui/src/shared/components/TemplatedCodeSnippet.tsx
+++ b/ui/src/shared/components/TemplatedCodeSnippet.tsx
@@ -13,6 +13,7 @@ interface StringMap {
 export interface Props {
   template: string
   label: string
+  testID?: string
   values?: StringMap
   defaults?: StringMap
 }
@@ -42,9 +43,10 @@ class TemplatedCodeSnippet extends PureComponent<Props> {
   }
 
   render() {
-    const {label} = this.props
+    const {label, testID} = this.props
     const props = {
       label,
+      testID,
       copyText: this.transform(),
     }
 

--- a/ui/src/telegrafs/components/TelegrafOutputOverlay.test.tsx
+++ b/ui/src/telegrafs/components/TelegrafOutputOverlay.test.tsx
@@ -1,0 +1,29 @@
+// Libraries
+import React from 'react'
+import {render} from 'react-testing-library'
+
+
+describe('Telegrafs.Components.TelegrafOutputOverlay', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('should render when there are no buckets', () => {
+    const props = {
+      org: 'neateo',
+      orgID: '1234',
+      server: 'localhost',
+      buckets: [],
+      onClose: () => {},
+    }
+    // NOTE: stubbing is required here as the CopyButton component
+    // requires a redux store (alex)
+    jest.mock('src/shared/components/CopyButton', () => () => null)
+    const { TelegrafOutputOverlay } = require('src/telegrafs/components/TelegrafOutputOverlay')
+    const {getByTestId} = render(<TelegrafOutputOverlay {...props}/>)
+
+    const root = getByTestId('telegraf-output-overlay--code-snippet')
+
+    expect(root).toBeTruthy()
+  })
+})

--- a/ui/src/telegrafs/components/TelegrafOutputOverlay.test.tsx
+++ b/ui/src/telegrafs/components/TelegrafOutputOverlay.test.tsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import {render} from 'react-testing-library'
 
-
 describe('Telegrafs.Components.TelegrafOutputOverlay', () => {
   beforeEach(() => {
     jest.resetModules()
@@ -19,8 +18,10 @@ describe('Telegrafs.Components.TelegrafOutputOverlay', () => {
     // NOTE: stubbing is required here as the CopyButton component
     // requires a redux store (alex)
     jest.mock('src/shared/components/CopyButton', () => () => null)
-    const { TelegrafOutputOverlay } = require('src/telegrafs/components/TelegrafOutputOverlay')
-    const {getByTestId} = render(<TelegrafOutputOverlay {...props}/>)
+    const {
+      TelegrafOutputOverlay,
+    } = require('src/telegrafs/components/TelegrafOutputOverlay')
+    const {getByTestId} = render(<TelegrafOutputOverlay {...props} />)
 
     const root = getByTestId('telegraf-output-overlay--code-snippet')
 

--- a/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -85,7 +85,6 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
     let bucket = null
 
     if (_buckets.length) {
-      console.log(_buckets.length, selectedBucket)
       bucket = selectedBucket ? selectedBucket : _buckets[0]
       bucket_dd = (
         <BucketDropdown

--- a/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -81,10 +81,12 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
         return _a > _b ? 1 : _a < _b ? -1 : 0
       })
     const {selectedBucket} = this.state
-    const bucket = selectedBucket ? selectedBucket : _buckets[0]
     let bucket_dd = null
+    let bucket = null
 
-    if (buckets.length) {
+    if (_buckets.length) {
+      console.log(_buckets.length, selectedBucket)
+      bucket = selectedBucket ? selectedBucket : _buckets[0]
       bucket_dd = (
         <BucketDropdown
           selectedBucketID={bucket.id}
@@ -111,6 +113,7 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
             <TemplatedCodeSnippet
               template={TELEGRAF_OUTPUT}
               label="telegraf.conf"
+              testID="telegraf-output-overlay--code-snippet"
               values={{
                 server,
                 org,


### PR DESCRIPTION
Closes #15962 

Removes the assumption that users would need a bucket to get a telegraf output config, and adds a test for that condition!