### PR TITLE
fix(ui): allow users to go to the token page

### DIFF
--- a/ui/src/overlays/components/RouteOverlay.tsx
+++ b/ui/src/overlays/components/RouteOverlay.tsx
@@ -5,7 +5,7 @@ import {connect} from 'react-redux'
 import {OverlayID} from 'src/overlays/reducers/overlays'
 
 // Actions
-import {showOverlay} from 'src/overlays/actions/overlays'
+import {showOverlay, dismissOverlay} from 'src/overlays/actions/overlays'
 
 // NOTE: i dont know what is wrong with the type definition of react-router
 // but it doesn't include params on an injected router upon route resolution
@@ -22,11 +22,16 @@ interface OwnProps {
 
 interface DispatchProps {
   onShowOverlay: typeof showOverlay
+  onDismissOverlay: typeof showOverlay
 }
 
 type OverlayHandlerProps = OwnProps & DispatchProps & WithRouterProps
 
 class OverlayHandler extends Component<OverlayHandlerProps> {
+  public componentWillUnmount() {
+    this.props.onDismissOverlay()
+  }
+
   public render() {
     const closer = () => {
       this.props.onClose(this.props.router as RealInjectedRouter)
@@ -39,6 +44,7 @@ class OverlayHandler extends Component<OverlayHandlerProps> {
 
 const mdtp: DispatchProps = {
   onShowOverlay: showOverlay,
+  onDismissOverlay: dismissOverlay,
 }
 
 export default connect<{}, DispatchProps, OwnProps>(

--- a/ui/src/overlays/components/RouteOverlay.tsx
+++ b/ui/src/overlays/components/RouteOverlay.tsx
@@ -22,7 +22,7 @@ interface OwnProps {
 
 interface DispatchProps {
   onShowOverlay: typeof showOverlay
-  onDismissOverlay: typeof showOverlay
+  onDismissOverlay: typeof dismissOverlay
 }
 
 type OverlayHandlerProps = OwnProps & DispatchProps & WithRouterProps

--- a/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -104,12 +104,7 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
         <Overlay.Body>
           <p style={{marginTop: '-18px'}}>
             The $INFLUX_TOKEN can be generated on the
-            <Link
-              to={`/orgs/${orgID}/load-data/tokens`}
-              onClick={this.handleDismiss}
-            >
-              &nbsp;Tokens tab
-            </Link>
+            <Link to={`/orgs/${orgID}/load-data/tokens`}>&nbsp;Tokens tab</Link>
             .
           </p>
           {bucket_dd}

--- a/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
+++ b/ui/src/telegrafs/components/TelegrafOutputOverlay.tsx
@@ -104,7 +104,12 @@ class TelegrafOutputOverlay extends PureComponent<Props> {
         <Overlay.Body>
           <p style={{marginTop: '-18px'}}>
             The $INFLUX_TOKEN can be generated on the
-            <Link to={`/orgs/${orgID}/load-data/tokens`}>&nbsp;Tokens tab</Link>
+            <Link
+              to={`/orgs/${orgID}/load-data/tokens`}
+              onClick={this.handleDismiss}
+            >
+              &nbsp;Tokens tab
+            </Link>
             .
           </p>
           {bucket_dd}


### PR DESCRIPTION
there was an issue in which the overlay controller wasn't notified of the route change for route based overlays in the app. this showed up when a user is on the telegraf output overlay and tried clicking the link to the token page. The route would change, but the modal would remain open. The solution is to just connect route overlays fully to a route.